### PR TITLE
fix(hooks): port the guard-main-checkout-bash.sh fix family from objectstack PR #11278

### DIFF
--- a/.claude/hooks/guard-main-checkout-bash.selftest.sh
+++ b/.claude/hooks/guard-main-checkout-bash.selftest.sh
@@ -169,6 +169,30 @@ expect allow 'grep -rn "he said \"sed -i\" once" .claude/'
 expect block 'node -e "console.log(\"hi\")" > pkg/out.json'
 expect block 'sed -i "s/\"a\"/\"b\"/" pkg/x.ts'
 
+echo "== an UNQUOTED \\\" opens no quote, so the write behind it is still seen (objectstack#11131) =="
+CWD="$MAIN"
+# The measured hole: segmentation read the escaped `"` as OPENING a quoted region that never
+# closed. Every separator behind it went inert, the command collapsed into one `echo`
+# segment, and the real in-place write was just another argument. tokenize() always had the
+# backslash branch; this is the pass agreement.
+expect block 'echo \" ; sed -i s/a/b/ pkg/x.ts'
+expect block 'echo \" ; rm -rf pkg/x.ts'
+expect block 'printf \" ; tee pkg/a.ts'
+expect block "$(printf 'echo \\"\nsed -i s/a/b/ pkg/x.ts\n')"
+# Precision twins: the escape must not manufacture a target where nothing is written, and
+# the same command aimed at a linked worktree stays allowed.
+expect allow 'echo \" ; echo hello'
+expect allow 'echo \" ; cat README.md'
+expect allow 'echo a\ b'
+expect allow 'echo \\ ; grep -n worktree README.md'
+# NOT a discriminating case for this fix, kept as a plain regression pin: a `>` target is
+# collected wherever it appears, so this blocked even while the passes disagreed. What the
+# disagreement lost was the COMMAND-NAME writers (sed -i / rm / tee) — once the command
+# collapsed into one segment the head word became `echo` and they were mere arguments.
+expect block 'echo \" && echo x > pkg/x.ts'
+CWD="$WT"
+expect allow 'echo \" ; sed -i s/a/b/ pkg/x.ts'
+
 echo "== a shell COMMENT is text, not a command (objectstack#10570) =="
 CWD="$MAIN"
 # The measured false blocks: prose in a comment put a real `>` in operator position and the
@@ -197,6 +221,32 @@ expect block 'echo ${#TOK[@]} > pkg/x.ts'
 expect block 'echo ${x#a} > pkg/x.ts'
 # an escaped `\#` outside quotes is a literal, not a comment opener
 expect allow 'echo \# not a comment'
+
+echo "== a heredoc introducer NAMED in a comment introduces nothing (objectstack#11133) =="
+CWD="$MAIN"
+# The measured hole: `<<EOF` inside prose registered as a real introducer. `EOF` never
+# appeared on a line of its own, so the pending heredoc was never satisfied and every
+# remaining line — including the real write — was dropped before analysis.
+expect block "$(printf '# use cat > /tmp/n <<EOF for notes\nsed -i s/a/b/ pkg/x.ts\n')"
+expect block "$(printf '# see the <<EOF trick\necho x >> pkg/x.ts\n')"
+expect block "$(printf 'git status   # cat <<MARKER writes notes\nrm -rf pkg/x.ts\n')"
+expect block "$(printf '# heredocs: <<-EOF and <<"Q" both introduce\ntouch pkg/new.ts\n')"
+# Real heredocs are untouched: a body is still prose, and the introducing line's own
+# redirect is still a write.
+expect allow "$(printf "cat > /tmp/notes.md <<'EOF'\nsed -i 's/a/b/' %s/pkg/x.ts\nEOF\n" "$MAIN")"
+expect block "$(printf 'cat > %s/notes.md <<EOF\nhello\nEOF\n' "$MAIN")"
+# An inline comment AFTER a real introducer must not cancel it — the body is still stripped,
+# and the negative twin shows a real write after the terminator is still caught.
+expect allow "$(printf 'cat > /tmp/n.md <<EOF   # notes\nsed -i s/a/b/ pkg/x.ts\nEOF\n')"
+expect block "$(printf 'cat > /tmp/n.md <<EOF   # notes\nhello\nEOF\nsed -i s/a/b/ pkg/x.ts\n')"
+# A QUOTED `#` on the introducing line is not a comment: truncating there would lose the
+# real introducer and expose the body as commands. This is the load-bearing precision case.
+expect allow "$(printf "grep '#' README.md <<EOF\nsed -i 's/a/b/' pkg/x.ts\nEOF\n")"
+# Ordering pin: an unbalanced apostrophe inside a heredoc BODY must not desynchronise the
+# comment rule for the lines that follow. Body lines never reach the comment scan, so the
+# real write after the terminator is still analysed.
+expect block "$(printf "cat > /tmp/n.md <<'EOF'\n# it's a note, don't strip me\nEOF\nsed -i s/a/b/ pkg/x.ts\n")"
+expect allow "$(printf "cat > /tmp/n.md <<'EOF'\n# it's a note, don't strip me\nEOF\ngit status\n")"
 
 echo "== shapes this guard deliberately does NOT claim (documented fail-open) =="
 CWD="$MAIN"

--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -41,7 +41,7 @@
 # for anyone who means to write there, and the target of this guard is the reflexive
 # `sed -i` an agent reaches for mid-task, not a determined evader.
 #
-# Writing ABOUT the ban must never trip the ban (objectstack#4890's lesson). Three layers:
+# Writing ABOUT the ban must never trip the ban (objectstack#4890's lesson). Four layers:
 #   1. quote-aware segmentation + tokenisation — a `>` or a `sed -i` inside '…' or "…" is
 #      literal text, so `grep -n "sed -i" .claude/` and `echo "never sed -i in main"` pass;
 #   2. heredoc bodies are stripped before analysis — the LINES of a `cat > /tmp/notes <<EOF`
@@ -54,6 +54,11 @@
 #      in that tail put a REAL ASCII `>` in operator position, so the guard named the
 #      following JS fragment as a write "target" and blocked a pure-read command (objectstack#10247).
 #      Single quotes take no escapes: inside '…' a backslash is literal, as in a real shell.
+#      OUTSIDE quotes the same escape holds and both passes must agree that it does: a `\"`
+#      there opens no quoted region at all. Only tokenise() knew that, so segmentation read
+#      the `"` as opening a region that never closed, went inert for every separator behind
+#      it, and let a real `sed -i` through as a mere argument — the fail-OPEN mirror of the
+#      false block above (objectstack#11131). The two passes now share the rule in both directions.
 #   4. shell COMMENTS are text, not commands — both quote-aware passes stop at an unquoted
 #      `#` that starts a WORD and resume at the next newline (objectstack#10570). A comment cannot
 #      write anything, so reading one as a command is a false BLOCK: prose arrows (`->`,
@@ -113,6 +118,47 @@ fi
 # on newlines, so without this pass a documented example inside the body ("sed -i … main
 # checkout") would be analysed as if the agent had run it. Drop body lines (and their
 # terminator); the introducing line — which is where the real redirection lives — stays.
+#
+# A `<<WORD` that is merely NAMED inside a COMMENT introduces nothing — bash removes the
+# comment before it ever looks for a heredoc. Reading one as a real introducer was fail-OPEN
+# and badly so: the delimiter never appeared on a line of its own, so the pending heredoc
+# was never satisfied and EVERY remaining line — including real commands — was dropped
+# before either quote-aware pass could see it (objectstack#11133).
+#
+# Only the DELIMITER SCAN consults the comment rule; the line itself is passed through
+# untouched, because both quote-aware passes already own that rule (objectstack#10570) and a second
+# implementation of it here is exactly how the two would drift.
+#
+# This is why the fix is a narrow scan-side truncation rather than a comment-stripping pass
+# run BEFORE this one: a heredoc BODY may contain an unbalanced apostrophe, and a quote-aware
+# comment scanner run over the raw text would desynchronise on it for every following line.
+# Body lines never reach this scan — they are consumed by the `pending` branch below and
+# `continue` before it — so that hazard is structurally out of reach here.
+#
+# Word-start rule, identical to split_segments()/tokenize(): a `#` opens a comment only where
+# a WORD could start — at line start, after a blank, or after one of `; | & ( ) > <`.
+strip_line_comment() {
+  local s="$1" n=${#1} i ch q="" word=0
+  for ((i = 0; i < n; i++)); do
+    ch="${s:i:1}"
+    if [ -n "$q" ]; then
+      if [ "$q" = '"' ] && [ "$ch" = '\' ] && [ $((i + 1)) -lt "$n" ]; then i=$((i + 1)); continue; fi
+      [ "$ch" = "$q" ] && q=""
+      continue
+    fi
+    case "$ch" in
+      '#')
+        if [ "$word" = 0 ]; then printf '%s' "${s:0:i}" ; return ; fi
+        ;;                                        # foo#bar, ${x#y}, url/#frag
+      '\') i=$((i + 1)) ; word=1 ;;
+      "'" | '"') q="$ch" ; word=1 ;;
+      ';' | '|' | '&' | '(' | ')' | ' ' | $'\t' | '>' | '<') word=0 ;;
+      *) word=1 ;;
+    esac
+  done
+  printf '%s' "$s"
+}
+
 strip_heredocs() {
   local s="$1" out="" line scan d t
   local -a pending=()
@@ -125,8 +171,10 @@ strip_heredocs() {
       continue
     fi
     out+="$line"$'\n'
+    # A `<<WORD` behind an unquoted word-start `#` is prose, not an introducer (objectstack#11133).
+    scan="$(strip_line_comment "$line")"
     # `<<<` is a herestring, not a heredoc — mask it before hunting for delimiters.
-    scan="${line//<<</__OS_HERESTRING__}"
+    scan="${scan//<<</__OS_HERESTRING__}"
     case "$scan" in
       *'<<'*)
         while IFS= read -r d; do
@@ -176,6 +224,18 @@ split_segments() {
           continue
         fi
         seg+="$ch"                                   # foo#bar, ${x#y}, url/#frag
+        ;;
+      '\')
+        # Outside quotes a backslash escapes the NEXT character, so an escaped `\"` does NOT
+        # open a quoted region. tokenize() has always had this branch; this pass did not, and
+        # the disagreement was a fail-OPEN hole: the `"` after the backslash opened a quote
+        # here that never closed, every later separator went inert, the whole command
+        # collapsed into one `echo` segment, and a real `sed -i` behind it was just another
+        # argument (objectstack#11131). Both characters are kept verbatim — this pass only SPLITS, and
+        # tokenize() re-reads the escape when it strips quoting.
+        seg+="$ch"
+        if [ $((i + 1)) -lt "$n" ]; then i=$((i + 1)) ; seg+="${s:i:1}" ; fi
+        word=1
         ;;
       "'" | '"') q="$ch" ; seg+="$ch" ; word=1 ;;
       ';' | '|' | '&' | '(' | ')' | $'\n') segments+=("$seg") ; seg="" ; word=0 ;;


### PR DESCRIPTION
Fixes #5789

Verbatim cross-repo port of the three commits on objectstack PR objectstack-ai/objectstack#11278 (family objectstack#11131 + objectstack#11133 + objectstack#11234) into this repo's copy of `.claude/hooks/guard-main-checkout-bash.sh`, plus the selftest additions.

> Note on this body: GitHub's body sanitizer eats less-than fragments, so every heredoc introducer below is written as **"two-less-than"** in words rather than literally. An earlier revision of this body spelled them out literally and lost two whole sections to the sanitizer.

## ⛔ Governed surface — draft PR, human merge only

`.claude/**` is a governed surface in this repo. This PR is deliberately a **draft** and must stay one: it is not to be marked ready, not to be put on auto-merge, and not to be merged by an agent. **A human merges this one.**

## What landed

1. **`split_segments()` gains the backslash branch `tokenize()` already had.** Outside quotes a backslash escapes the next character, so an escaped backslash-doublequote opens no quoted region at all. Only `tokenize()` knew that; segmentation read the double quote as opening a region that never closed, went inert for every separator behind it, collapsed the whole command into one `echo` segment, and let a real `sed -i` through as a mere argument.
2. **`strip_heredocs()`'s delimiter scan learns the comment rule, via a new `strip_line_comment()` helper.** A two-less-than introducer merely NAMED in a comment introduces nothing in bash, but the scan registered it as real; the delimiter then never appeared on a line of its own, so the pending heredoc was never satisfied and every remaining line — including real commands — was dropped before either quote-aware pass could see it.
3. **Header enumeration count `Three layers:` → `Four layers:`.** objectui#5459's port carried the miscount **deliberately**, to stay byte-identical with an upstream that was itself wrong. Upstream has now corrected it, so correcting it here **restores** parity rather than breaking it — this is not intentional local divergence being overwritten.

Selftest matrix: **100 → 121 cases**.

## Evidence

### 1. Selftest, before and after

| revision | `bash .claude/hooks/guard-main-checkout-bash.selftest.sh` |
| --- | --- |
| before (`ad0f5f11f`) | `100 passed, 0 failed` |
| after (`c42985576`) | `121 passed, 0 failed` |

### 2. The two measured probes flip ALLOWED to blocked

Run against this repo's hook with the selftest's own fixture shape (payload `cwd` = the shared primary checkout).

| probe | before | after |
| --- | --- | --- |
| objectstack#11131 — `echo` backslash-doublequote, then `;`, then `sed -i s/a/b/ pkg/x.ts` | **ALLOWED** | **blocked** |
| objectstack#11133 — a comment line reading `# use cat` redirect `/tmp/n` two-less-than `EOF for notes`, then a newline, then `sed -i s/a/b/ pkg/x.ts` | **ALLOWED** | **blocked** |

Both were genuine fail-opens in this copy before the port: a real in-place write of a file in the shared checkout, waved through. The exact byte-for-byte probe commands are the new selftest cases themselves — see the `objectstack#11131` and `objectstack#11133` sections added to `guard-main-checkout-bash.selftest.sh` in this diff.

### 3. The objectstack#10247 mirror twins stay ALLOWED — no over-blocking

A guard that blocks more than intended is a defect, not extra safety. Verified unchanged:

| command | before | after |
| --- | --- | --- |
| a pure-read `node -e` whose string literal carries U+2192 and whose body has a `st=` arrow-fn | ALLOWED | ALLOWED |
| `node -e` with an escaped-doublequote string literal, no redirect | ALLOWED | ALLOWED |
| `node -e` with escaped-doublequote literals plus an arrow-fn tail | ALLOWED | ALLOWED |
| `echo 'build → test → ship'` | ALLOWED | ALLOWED |
| `grep -n '→ the URL' AGENTS.md` | ALLOWED | ALLOWED |

And their negative twins — an otherwise-similar command carrying a REAL ASCII redirect — stay blocked, so the allow side is not widened for redirection at large:

| command | before | after |
| --- | --- | --- |
| `echo 'build → ship'` redirected into `steps.txt` | blocked | blocked |
| the same `node -e` redirected into `pkg/out.json` | blocked | blocked |

## Parity accounting — every remaining difference from upstream

The port was produced by **splicing upstream's text verbatim** (extracted from `objectstack-ai/objectstack@origin/main` by line range), not by re-implementing from the card's prose. `diff -u upstream ours` was then read line by line. Every remaining difference falls into one of two buckets:

**A. Pre-existing localisations, untouched by this PR** — the example path `packages/fields/src/x.tsx`; the direction-of-travel provenance paragraph (this copy is the origin: `objectui#3435`, same family as `#3430`); the `guard-shared-stash.sh` cross-references (fail-open boundary note, jq-less fallback note, the `split_segments`/`tokenize` header paragraphs); the "mirroring both sibling hooks" exit-code line; the `→`-in-AGENTS.md paragraph where upstream cites its own `➜` CLI banner; `cd /home/user/objectui` in the `maybe_cd` example; `objectui#3435` in the block message; and in the selftest, the provenance line, `pnpm --filter @object-ui/app-shell test`, and the arrow-glyph allow case.

**B. Issue-reference localisation on the newly ported lines** — this copy prefixes upstream issue numbers, so `(#11131)` → `(objectstack#11131)`, `(#11133)` → `(objectstack#11133)`, `(#10570)` → `(objectstack#10570)`. That is the same convention already carried on `objectstack#4890`, `objectstack#10247` and `objectstack#10570` elsewhere in both files, and is exactly what the parity contract names as localised ("only issue references, example paths and the package name in the self-test are localised").

**No other difference remains.** Every logic line — the `strip_line_comment()` body, the backslash branch in `split_segments()`, the two `scan=` lines in `strip_heredocs()`, the `Four layers:` header, and all 21 new selftest cases — is byte-identical to upstream.

## Scope

Port only. No cases added, nothing improved on upstream, nothing else in the hook touched. `guard-main-checkout.sh`, `guard-shared-stash.sh` and every other hook are untouched — `git status` on this branch shows exactly two modified files.

One out-of-scope observation was measured and **filed as its own card, not folded in**: `guard-shared-stash.sh` has the same objectstack#11131-class backslash hole in *its* `split_segments()`, in both repos. Filed as #6042, which remains open and is not addressed here.

## Gates

Run at `c42985576` (the tip of this branch, working tree clean):

| gate | verdict line |
| --- | --- |
| `bash .claude/hooks/guard-main-checkout-bash.selftest.sh` | `121 passed, 0 failed` |
| `node scripts/check-control-bytes.mjs` | `✅  check-control-bytes: OK (scanned 4989 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `bash -n` on both files | syntax OK |

No changeset: this touches `.claude/` tooling only, no released package's `src/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
