### PR TITLE
test(test-support): confine the spec enum-vocabulary reader to one module (#5872 class 1)

### DIFF
--- a/.changeset/zod-internals-reader-confinement.md
+++ b/.changeset/zod-internals-reader-confinement.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only change. Four spec-parity suites each carried a byte-for-byte identical
+hand-written walk into Zod's internals to read a key's enum vocabulary; they now
+import one `shapeEnumOptions` reader from the private, never-published
+`@object-ui/test-support`. No published package's runtime behaviour changes —
+the only edits to released packages are a `devDependencies` entry each.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -91,6 +91,7 @@
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
+    "@object-ui/test-support": "workspace:*",
     "@radix-ui/react-focus-scope": "^1.1.16",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "19.2.18",

--- a/packages/components/src/__tests__/data-table-selection-mode.test.tsx
+++ b/packages/components/src/__tests__/data-table-selection-mode.test.tsx
@@ -25,20 +25,13 @@ import { describe, it, expect, vi } from 'vitest';
 import { fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SelectionConfigSchema } from '@objectstack/spec/ui';
+import { shapeEnumOptions } from '@object-ui/test-support';
 import { renderComponent } from './test-utils';
 import { SUPPORTED_SELECTION_MODES } from '../renderers/complex/data-table';
 // Registers the renderers at module scope, NOT inside a `beforeAll` — there the
 // cold transform is billed to `hookTimeout`, which is why this carried a raised
 // timeout. See object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
 import '../renderers';
-
-/** The spec's selection vocabulary, read through the `.default()` wrapper. */
-function specSelectionModes(): string[] {
-  const typeSchema = (SelectionConfigSchema as unknown as { shape?: Record<string, unknown> })
-    .shape?.type as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
-  const options = typeSchema?.def?.innerType?.options;
-  return Array.isArray(options) ? [...options] : [];
-}
 
 const baseSchema = {
   type: 'data-table' as const,
@@ -53,7 +46,7 @@ const baseSchema = {
 };
 
 describe('data-table selection mode covers the spec selection vocabulary', () => {
-  const specNames = specSelectionModes();
+  const specNames = shapeEnumOptions(SelectionConfigSchema, 'type');
 
   it('reads a non-empty enum from the spec', () => {
     expect(specNames, 'could not read SelectionConfigSchema.shape.type options from the spec').not.toEqual([]);

--- a/packages/plugin-list/package.json
+++ b/packages/plugin-list/package.json
@@ -54,6 +54,7 @@
     "@object-ui/mobile": "workspace:*",
     "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
+    "@object-ui/test-support": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",
     "@types/react": "19.2.18",

--- a/packages/plugin-list/src/__tests__/add-record-position-spec-parity.test.tsx
+++ b/packages/plugin-list/src/__tests__/add-record-position-spec-parity.test.tsx
@@ -24,6 +24,7 @@ import { render, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { AddRecordConfigSchema } from '@objectstack/spec/ui';
+import { shapeEnumOptions } from '@object-ui/test-support';
 import { ListView, resolveAddRecordPlacement } from '../ListView';
 import type { ListViewSchema } from '@object-ui/types';
 import { SchemaRendererProvider } from '@object-ui/react';
@@ -43,16 +44,8 @@ beforeAll(() => {
   });
 });
 
-/** The spec's position vocabulary, read through the `.default()` wrapper. */
-function specPositions(): string[] {
-  const positionSchema = (AddRecordConfigSchema as unknown as { shape?: Record<string, unknown> })
-    .shape?.position as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
-  const options = positionSchema?.def?.innerType?.options;
-  return Array.isArray(options) ? [...options] : [];
-}
-
 describe('resolveAddRecordPlacement covers the spec position vocabulary', () => {
-  const specNames = specPositions();
+  const specNames = shapeEnumOptions(AddRecordConfigSchema, 'position');
 
   it('reads a non-empty enum from the spec', () => {
     expect(specNames, 'could not read AddRecordConfigSchema.shape.position options from the spec').not.toEqual([]);

--- a/packages/plugin-list/src/__tests__/user-filter-arity-spec-parity.test.tsx
+++ b/packages/plugin-list/src/__tests__/user-filter-arity-spec-parity.test.tsx
@@ -27,6 +27,7 @@ import * as React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { UserFilterFieldSchema } from '@objectstack/spec/ui';
+import { shapeEnumOptions } from '@object-ui/test-support';
 import { UserFilters, FILTER_CONTROL_KINDS } from '../UserFilters';
 
 const objectDef = {
@@ -44,16 +45,8 @@ const objectDef = {
   },
 };
 
-/** The spec's control-type vocabulary, read through the `.optional()` wrapper. */
-function specControlTypes(): string[] {
-  const typeSchema = (UserFilterFieldSchema as unknown as { shape?: Record<string, unknown> })
-    .shape?.type as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
-  const options = typeSchema?.def?.innerType?.options;
-  return Array.isArray(options) ? [...options] : [];
-}
-
 describe('FILTER_CONTROL_KINDS covers the spec user-filter control vocabulary', () => {
-  const specNames = specControlTypes();
+  const specNames = shapeEnumOptions(UserFilterFieldSchema, 'type');
 
   it('reads a non-empty enum from the spec', () => {
     expect(specNames, 'could not read UserFilterFieldSchema.shape.type options from the spec').not.toEqual([]);

--- a/packages/plugin-timeline/package.json
+++ b/packages/plugin-timeline/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@object-ui/data-objectstack": "workspace:*",
+    "@object-ui/test-support": "workspace:*",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@vitejs/plugin-react": "^6.0.5",

--- a/packages/plugin-timeline/src/__tests__/timeline-scale-spec-parity.test.ts
+++ b/packages/plugin-timeline/src/__tests__/timeline-scale-spec-parity.test.ts
@@ -16,17 +16,11 @@
  */
 import { describe, it, expect } from 'vitest';
 import { TimelineConfigSchema } from '@objectstack/spec/ui';
+import { shapeEnumOptions } from '@object-ui/test-support';
 import { TIMELINE_SCALES, resolveTimelineScale, generateTimeScaleHeaders } from '../renderer';
 
-function specScales(): string[] {
-  const scaleSchema = (TimelineConfigSchema as unknown as { shape?: Record<string, unknown> })
-    .shape?.scale as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
-  const options = scaleSchema?.def?.innerType?.options;
-  return Array.isArray(options) ? [...options] : [];
-}
-
 describe('timeline covers the spec scale vocabulary', () => {
-  const specNames = specScales();
+  const specNames = shapeEnumOptions(TimelineConfigSchema, 'scale');
 
   it('reads a non-empty enum from the spec', () => {
     expect(specNames, 'could not read TimelineConfigSchema.shape.scale options from the spec').not.toEqual([]);

--- a/packages/test-support/README.md
+++ b/packages/test-support/README.md
@@ -60,6 +60,24 @@ code imports — nothing in `src/` of a released package may import this.
   (the last two converged off local structural-only copies by objectui#4947).
   No copy of the judgement is left in-tree: gates import this module, they do
   not write the criterion out again.
+- `src/spec-enum-options.ts` — the spec enum-vocabulary reader:
+  `shapeEnumOptions(schema, key)`. Answers "which names does this key of the
+  contract accept?" — the question four spec-parity suites each answered with a
+  byte-for-byte identical hand-written walk into Zod's `def.innerType`
+  (objectui#5872). Consumed by
+  `packages/components/src/__tests__/data-table-selection-mode.test.tsx`,
+  `packages/plugin-list/src/__tests__/add-record-position-spec-parity.test.tsx`,
+  `packages/plugin-list/src/__tests__/user-filter-arity-spec-parity.test.tsx`
+  and `packages/plugin-timeline/src/__tests__/timeline-scale-spec-parity.test.ts`.
+  No copy of this reader is left in-tree. The other Zod-internals reader classes
+  the same card censused — array-element unwrapping, the wrapper-key walk — are
+  NOT confined here yet and are still hand-copied; converting them is a separate
+  round, one reader class at a time.
+- `src/__tests__/spec-enum-options.test.ts` — the calibration for that reader:
+  one synthetic fixture per wrapper spelling it claims to walk (bare enum,
+  `.optional()`, `.default()`, a stack, and a `lazySchema()` thunk), the `[]`
+  cases that keep a consuming suite's non-vacuity assertion from being a rubber
+  stamp, and a non-empty check against the four real `@objectstack/spec` pairs.
 - `src/__tests__/spec-tombstones.test.ts` — the calibration for that judge: one
   synthetic fixture per recognition channel (so neither can quietly stop
   working), plus a cross-check of the structural verdict against what the

--- a/packages/test-support/src/__tests__/spec-enum-options.test.ts
+++ b/packages/test-support/src/__tests__/spec-enum-options.test.ts
@@ -1,0 +1,104 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * THE ENUM READER PROVES ITSELF — once, for every parity gate that imports it
+ * (objectui#5872).
+ *
+ * Two halves, and the second is the one that earns the consolidation:
+ *
+ *   - SYNTHETIC fixtures pin each wrapper spelling the reader claims to walk,
+ *     ALONE. The four hand copies this module replaced read exactly one
+ *     (`def.innerType`), so the whole value of a shared reader is the spellings
+ *     it adds; a fixture set that only exercised the one they already had would
+ *     leave every addition untested and free to be silently wrong.
+ *   - the REAL `@objectstack/spec` half pins the reader against the four
+ *     (schema, key) pairs the converged suites actually ask about, asserting
+ *     only that each vocabulary is NON-EMPTY. The names themselves stay
+ *     un-pinned here on purpose: each consuming suite pins its own vocabulary
+ *     against the renderer it judges, and a copy of those names in this file
+ *     would be a fifth place to forget — the exact shape of the problem this
+ *     module exists to end.
+ *
+ * The negative cases matter as much: `[]` is this reader's "could not read",
+ * and a reader that returned a non-empty array for a member with no enum at all
+ * would turn every consuming suite's non-vacuity assertion into a rubber stamp.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import {
+  AddRecordConfigSchema,
+  SelectionConfigSchema,
+  TimelineConfigSchema,
+  UserFilterFieldSchema,
+} from '@objectstack/spec/ui';
+
+import { shapeEnumOptions } from '../spec-enum-options';
+
+describe('shapeEnumOptions walks every wrapper spelling it claims to', () => {
+  const VOCAB = ['alpha', 'beta', 'gamma'] as const;
+
+  it('reads a bare, unwrapped enum member', () => {
+    const schema = z.object({ key: z.enum(VOCAB) });
+    expect(shapeEnumOptions(schema, 'key')).toEqual([...VOCAB]);
+  });
+
+  it('reads through .optional()', () => {
+    const schema = z.object({ key: z.enum(VOCAB).optional() });
+    expect(shapeEnumOptions(schema, 'key')).toEqual([...VOCAB]);
+  });
+
+  it('reads through .default() — the spelling all four hand copies carried', () => {
+    const schema = z.object({ key: z.enum(VOCAB).default('alpha') });
+    expect(shapeEnumOptions(schema, 'key')).toEqual([...VOCAB]);
+  });
+
+  it('reads through a stack of wrappers, not just one level', () => {
+    const schema = z.object({ key: z.enum(VOCAB).nullable().optional() });
+    expect(shapeEnumOptions(schema, 'key')).toEqual([...VOCAB]);
+  });
+
+  it('reads a member of a lazily-resolved shape', () => {
+    const inner = z.object({ key: z.enum(VOCAB).optional() });
+    // The `lazySchema()` thunk spelling `resolvePropsShape` exists for: the
+    // shape is a FUNCTION that must be called before it has any keys at all.
+    const thunked = { shape: () => inner.shape };
+    expect(shapeEnumOptions(thunked, 'key')).toEqual([...VOCAB]);
+  });
+});
+
+describe('shapeEnumOptions answers [] rather than guessing', () => {
+  it('returns [] for a key the shape does not carry', () => {
+    expect(shapeEnumOptions(z.object({ other: z.string() }), 'key')).toEqual([]);
+  });
+
+  it('returns [] for a member that is not an enum', () => {
+    expect(shapeEnumOptions(z.object({ key: z.string().optional() }), 'key')).toEqual([]);
+  });
+
+  it('returns [] for something that is not a schema at all', () => {
+    expect(shapeEnumOptions(undefined, 'key')).toEqual([]);
+    expect(shapeEnumOptions({}, 'key')).toEqual([]);
+  });
+});
+
+describe('shapeEnumOptions reads the real contract the parity gates ask about', () => {
+  const pairs: ReadonlyArray<readonly [string, unknown, string]> = [
+    ['SelectionConfigSchema.type', SelectionConfigSchema, 'type'],
+    ['AddRecordConfigSchema.position', AddRecordConfigSchema, 'position'],
+    ['UserFilterFieldSchema.type', UserFilterFieldSchema, 'type'],
+    ['TimelineConfigSchema.scale', TimelineConfigSchema, 'scale'],
+  ];
+
+  it.each(pairs)('reads a non-empty vocabulary for %s', (_label, schema, key) => {
+    const options = shapeEnumOptions(schema, key);
+    expect(options.length, 'the reader went quietly empty on a live spec enum').toBeGreaterThan(0);
+    expect(options.every((name) => typeof name === 'string')).toBe(true);
+  });
+});

--- a/packages/test-support/src/index.ts
+++ b/packages/test-support/src/index.ts
@@ -40,3 +40,5 @@ export {
   tombstoneEvidence,
   tombstonedShapeKeys,
 } from './spec-tombstones';
+
+export { shapeEnumOptions } from './spec-enum-options';

--- a/packages/test-support/src/spec-enum-options.ts
+++ b/packages/test-support/src/spec-enum-options.ts
@@ -1,0 +1,112 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * SPEC ENUM VOCABULARY — one reader for every parity gate that asks
+ * "which names does this key of the contract accept?" (objectui#5872).
+ *
+ * ## The reader this replaces
+ *
+ * Four spec-parity suites in four packages each wrote out, byte-for-byte
+ * identical apart from the schema and key names:
+ *
+ *     const v = (Schema as unknown as { shape?: Record<string, unknown> })
+ *       .shape?.key as { def?: { innerType?: { options?: readonly string[] } } } | undefined;
+ *     const options = v?.def?.innerType?.options;
+ *     return Array.isArray(options) ? [...options] : [];
+ *
+ * `spec-tombstones.ts` already argues at length why that is worth ending, and
+ * says of `resolvePropsShape`: "Reaching into internals is confined to this
+ * module so that a gate never has to." That was true of SHAPE resolution and
+ * false of everything else a parity gate reads off a Zod node. This module is
+ * that sentence made true for one more reader class.
+ *
+ * ## Why the copies could not move together
+ *
+ * The hand copy reads EXACTLY ONE wrapper spelling — `def.innerType` — so it
+ * answers correctly only while the member is wrapped exactly once and Zod
+ * exposes `def`. A member that stops being `.optional()`/`.default()`, or a Zod
+ * build that exposes only `_def`, yields `undefined` and the derived vocabulary
+ * silently becomes the EMPTY SET. That is the objectui#4434 failure mode: every
+ * "the renderer implements every name the spec accepts" assertion built on an
+ * empty set passes over nothing. Four textually identical copies is the sharp
+ * case, because a reviewer who diffs one of them sees nothing that says the
+ * other three did not move.
+ *
+ * ## What this reader does that the copies did not
+ *
+ * - resolves the shape through `resolvePropsShape`, so all three `.shape`
+ *   spellings and the `lazySchema()` thunk work, not just the plain one;
+ * - walks the wrapper chain instead of assuming a single level, and accepts
+ *   `unwrap()`, `def.innerType` and `_def.innerType` as the step;
+ * - reads `.options` at every level, so an UNWRAPPED enum member answers too.
+ *
+ * All three are widenings — this reader answers wherever a hand copy answered,
+ * and in cases where a hand copy went quietly empty. Verdict preservation was
+ * measured rather than assumed when the four call sites converged: against the
+ * installed pin (`@objectstack/spec@17.2.0`, `zod@4.4.3`) it returns the
+ * identical array, in the identical order, for all four (schema, key) pairs.
+ *
+ * ## `[]` and the non-vacuity duty it leaves with the caller
+ *
+ * `[]` means "no vocabulary could be read", and it is deliberately NOT
+ * distinguished from "this enum is empty" — because no spec enum is empty, and
+ * every caller in-tree already carries the assertion that makes the difference
+ * observable: one `it('reads a non-empty enum from the spec')` per suite. A
+ * caller that adopts this reader owes that assertion too; without it a broken
+ * reader and a satisfied parity check look exactly alike.
+ */
+
+import { resolvePropsShape } from './spec-tombstones';
+
+/** A Zod node, as far as unwrapping to an enum needs to see it. */
+interface EnumCarrier {
+  options?: unknown;
+  unwrap?: () => unknown;
+  def?: { innerType?: unknown };
+  _def?: { innerType?: unknown };
+}
+
+/**
+ * How many wrappers deep to look before giving up.
+ *
+ * Bounded rather than `while (node)`: the step below is reached through
+ * `unknown`, so a node that unwraps to itself — a shape this reader cannot
+ * rule out and should not hang on — ends the walk instead of the process. Eight
+ * is far past anything the contract stacks today (the deepest in-tree member is
+ * one wrapper: `.default()` or `.optional()`).
+ */
+const MAX_WRAPPER_DEPTH = 8;
+
+/**
+ * The enum names one key of a props schema accepts, unwrapped past
+ * `.optional()` / `.default()` / `.nullable()` — `[]` when it cannot be read.
+ *
+ * Signature deliberately mirrors `shapeMemberTypeName(schema, key)` in
+ * `spec-tombstones.ts`: same question shape ("about ONE member of a shape"),
+ * same tolerance of a schema this pin does not carry.
+ */
+export function shapeEnumOptions(schema: unknown, key: string): string[] {
+  const shape = resolvePropsShape(schema);
+  if (!shape) return [];
+
+  let node = shape[key] as EnumCarrier | undefined;
+  for (let depth = 0; node && depth <= MAX_WRAPPER_DEPTH; depth += 1) {
+    const options = node.options;
+    // Not filtered to strings: the four converging call sites did not filter
+    // either, and dropping a non-string member here would narrow a vocabulary
+    // silently — the one thing this module exists to stop.
+    if (Array.isArray(options)) return [...options] as string[];
+    const inner =
+      typeof node.unwrap === 'function'
+        ? node.unwrap()
+        : (node.def?.innerType ?? node._def?.innerType);
+    node = inner as EnumCarrier | undefined;
+  }
+  return [];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,6 +1135,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@radix-ui/react-focus-scope':
         specifier: ^1.1.16
         version: 1.1.16(patch_hash=41d44316f54bd1c52774d12640dfe9062604489561eee39886b1912c4197e822)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2263,6 +2266,9 @@ importers:
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@object-ui/types':
         specifier: workspace:*
         version: link:../types
@@ -2522,6 +2528,9 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18


### PR DESCRIPTION
Refs #5872 — reader class **(1)** only, the four verbatim copies. Classes (2), (3) and (4) from the card's census stay hand-copied, so this does not close the card.

## What this is

`packages/test-support/src/spec-tombstones.ts` says of `resolvePropsShape`:

> Reaching into internals is confined to this module so that a gate never has to.

That was true of **shape resolution** and false of every other reader a spec-parity gate runs over a Zod node. This PR makes it true for one more reader class: the **enum vocabulary of one key**.

New module `packages/test-support/src/spec-enum-options.ts`, one export `shapeEnumOptions(schema, key)`, and the four call sites converted onto it.

## Census, re-derived on the merge-base (not read off the card)

Merge-base `b0de7a85c`. The card's census is from 2026-08-23; re-derived today:

| the card said | measured on `b0de7a85c` | delta |
|---|---|---|
| class (1): four verbatim copies, four packages | **4**, same four files | none |
| "~10 parity tests" reading Zod internals | **11** files match `innerType` (10 tests + `core/src/actions/actionKeys.ts`, a comment) | +1 vs "~10", and one file is not a test |

Two census notes worth stating because the dispatch flagged them:

- `packages/types/src/__tests__/zod-mirror-parity.test.ts` — the file PR #6032 rewrites — **is not in this census at all.** It does not read `innerType` and is not one of the ~10. Nothing here goes near `packages/types`, so #6032's enqueued state constrained nothing in practice.
- `packages/types/src/__tests__/gantt-view-mode-declared.test.ts:53` (`while (cur?._def?.innerType) cur = cur._def.innerType;`) is new since the card was filed and belongs to class (4), not class (1). Untouched — `packages/types` also carries live sibling work.

## "Verbatim" verified byte-for-byte, not by eye

Each of the four readers was extracted, the schema identifier, the member key and the local variable name normalised to `S` / `K` / `V`, and the result hashed:

```
sha256(normalised) = 226c3eb04c1dafc0   x4
DISTINCT NORMALISED FORMS: 1 of 4
```

Raw byte lengths differ only by identifier length (337 / 344 / 335 / 331). So all four are genuinely identical — no copy differs by a `?.` or a default. The class the card called verbatim really is verbatim.

## Verdict preservation, measured

The shared reader is a **widening** of the hand copy in three ways: it resolves the shape through `resolvePropsShape` (all three `.shape` spellings plus the `lazySchema()` thunk, where the copies read only the plain one), walks the wrapper chain instead of assuming a single `def.innerType` level, and reads `.options` at every level so an unwrapped enum answers too. A widening is exactly where a verdict can flip, so it was measured before anything was converted — the old reader and the candidate run side by side against the installed pin (`@objectstack/spec@17.2.0`, `zod@4.4.3`):

```
SelectionConfigSchema.type      OLD(3) ["none","single","multiple"]                        NEW(3) identical
AddRecordConfigSchema.position  OLD(3) ["top","bottom","both"]                             NEW(3) identical
UserFilterFieldSchema.type      OLD(5) ["select","multi-select","boolean","date-range",…]  NEW(5) identical
TimelineConfigSchema.scale      OLD(6) ["hour","day","week","month","quarter","year"]      NEW(6) identical

DISAGREEMENTS: 0 of 4
```

Same arrays, same order. **No verdict flipped, and no test was adjusted to keep it green** — nothing needed adjusting.

Then the same suites, same invocation, before and after — counts *and* the test-name fingerprint, because a suite that loses one test and gains another is all-green:

| | files | tests | fingerprint of (file, sorted test names) |
|---|---|---|---|
| before | 4 passed (4) | 31 passed (31) | `c909f7b78011cad5c33d` |
| after | 4 passed (4) | 31 passed (31) | `c909f7b78011cad5c33d` |

Per file, identical both times: 8 / 5 / 10 / 8.

The only test-count movement anywhere is the new calibration suite in `test-support`, declared rather than folded in: 2 files / 13 tests before, 3 files / 25 tests after — the 12 new calibration tests, with the two pre-existing suites unmoved.

## Confinement, falsified rather than asserted

After the change, searching the whole repo for the reader class outside `packages/test-support`:

```
A. innerType?.options | innerType?: { options   outside packages/test-support   ->  0
B. CONTROL — innerType inside packages/test-support/src/                        ->  8
   (3 executable: spec-enum-options.ts:71,72,108; 5 in the docblocks that
    quote the copies this module retired)
C. CONTROL — shapeEnumOptions call sites                                        ->  4 consumers + index + calibration
```

A zero with a control that finds the reader where it now lives, and finds every consumer asking through the export.

## Reverse verification — direction predicted before running

**Prediction, written down first:** break the shared reader so it reports an empty vocabulary and *all four* converted files must go red, each at minimum through its own `reads a non-empty enum from the spec`; if only some go red the sites are not really sharing the reader.

Mutation (anchor asserted unique first, 1 occurrence): `return [...options] as string[]` → `return [] as string[]` — the quiet-permissive failure this module exists to stop. Proved on disk before reading anything: injected text count 1, removed text count 0, landing site printed (`spec-enum-options.ts:104`).

```
Test Files  5 failed (5)
     Tests  17 failed | 26 passed (43)
```

All five, and per file:

- `data-table-selection-mode` — `reads a non-empty enum from the spec`, `does not accept selection modes the spec rejects`
- `add-record-position-spec-parity` — `reads a non-empty enum from the spec`, `gives every spec position a placement that matches its name`
- `user-filter-arity-spec-parity` — `reads a non-empty enum from the spec`, `does not declare control types the spec rejects`
- `timeline-scale-spec-parity` — `reads a non-empty enum from the spec`, `declares exactly the spec scales`
- `spec-enum-options.test.ts` — all 5 wrapper fixtures + all 4 real-contract pairs

Exactly as predicted. Restored under `trap … EXIT INT TERM`; `git diff HEAD --stat` empty afterwards.

Worth naming what the ablation also shows: in three of the four suites, the *parity* assertion in the "spec accepts a name we do not implement" direction stayed **green** on an empty vocabulary. That is the card's own argument, reproduced — an empty option set makes half of each parity gate pass over nothing, and only the non-vacuity assertion catches it.

## The new dependency edge, declared

None of `@object-ui/components`, `@object-ui/plugin-list`, `@object-ui/plugin-timeline` depended on `@object-ui/test-support`. Each gains `"@object-ui/test-support": "workspace:*"` in **devDependencies** (the README's convention; no consumer ships it), plus the `pnpm-lock.yaml` update. `node scripts/check-phantom-dependencies.mjs` exit **0**.

`@object-ui/test-support` is `private: true` and never published, so no published surface widens.

## Gates

Run on `3b010122f`; exit codes captured before any pipe.

| gate | exit |
|---|---|
| `pnpm --filter @object-ui/test-support run type-check` (`tsc --noEmit`) | **0** |
| `pnpm --filter @object-ui/components run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | **0** |
| `pnpm --filter @object-ui/plugin-list run type-check` (same two-step) | **0** |
| `pnpm --filter @object-ui/plugin-timeline run type-check` (same two-step) | **0** |
| `pnpm exec vitest run packages/test-support/src packages/plugin-list/src packages/plugin-timeline/src --maxWorkers=2` — 58 files, 770 tests | **0** |
| `pnpm exec vitest run packages/components/src --maxWorkers=2` — 183 files, 1681 tests | **0** |
| `node scripts/check-phantom-dependencies.mjs` | **0** |
| `node scripts/check-changeset-presence.mjs` | **0** |
| `pnpm exec eslint .` in each of the four packages | **0** (0 errors; pre-existing warnings only, none on a changed line) |

Script names are echoed in each run, so a zero-match silent pass cannot read as green. The dependency closure was built first — `pnpm --filter '@object-ui/components^...' --filter '@object-ui/plugin-list^...' --filter '@object-ui/plugin-timeline^...' build`, exit 0 — so a `Cannot find module` reading could not be mistaken for a real failure.

Changeset has **empty frontmatter** — this repo's "releases nothing" declaration. It is accurate: the only edits to released packages are three `devDependencies` lines and four test files.

## Not in this PR

Per the triage fence, one reader class at a time. Left exactly as found, and why:

- **(2) array-element unwrapping** — three *different* spellings for one question (`recordDetailsInputs.spec-parity.test.ts:83`, `previews/__tests__/block-config.test.ts`, `clientValidation.optOuts.test.ts`). Not verbatim, so a shared reader has to pick a behaviour where three disagree — the flip risk this card explicitly refuses to run blind. It needs its own round with its own before/after measurement.
- **(3) the wrapper-key walk** — the literal `['in','out','innerType','schema','left','right']` in three files. Textually a list, not an expression; a separate reader shape.
- **(4) `recordRelatedListInputs.spec-parity.test.ts:61-65`** and the newer `packages/types/src/__tests__/gantt-view-mode-declared.test.ts:53` — single-site `_def.innerType ?? _def.type` unwraps. `packages/types` and `packages/plugin-detail` both carry live sibling work this round.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_
