### PR TITLE
chore(providers): drop the unused @objectstack/spec dependency

### DIFF
--- a/.changeset/5753-providers-drop-spec-dep.md
+++ b/.changeset/5753-providers-drop-spec-dep.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/providers': patch
+---
+
+`@object-ui/providers` no longer declares `@objectstack/spec` as a dependency. Nothing
+in the package imports it, so consumers stop installing it on this package's account
+(objectui#5753).
+
+The edge was live for exactly one release cycle. It was promoted from `devDependencies`
+to `dependencies` when `ThemePreference` was derived from the spec's `ThemeMode` union,
+because the package's public `.d.ts` then referenced the spec. objectui#5716 re-pointed
+that derivation at `@object-ui/types` (`ThemeMode` / `THEME_MODES`), which removed the
+last three import sites — `src/types.ts` and the two retirement-era test files — and
+left the declaration behind with no reader.
+
+Re-measured on `origin/main` at `ad0f5f11f` before removal, with a positive control so
+the empty result is a real absence rather than a broken command: the import-shaped grep
+(`from` / `require(` / `import(` / `vi.mock(` against `@objectstack/spec`, bare name and
+every subpath) returns **0** hits under `packages/providers/` and **434** across
+`packages/` + `apps/` — same command, same invocation. The only surviving mentions in
+the package are the declaration itself, immutable `CHANGELOG.md` history, and a prose
+comment in `tsconfig.test.json` that this change corrects.
+
+No API change and no behaviour change: `dist/types.d.ts` imports only `react` and
+`@object-ui/types`, and no emitted file references a spec symbol. Consumers on an
+isolated `node_modules` (pnpm) never had supported access to the spec through this
+package, so nothing they could legitimately import goes away — the change is to the
+install graph only, which is why it is scored `patch` rather than `minor`.

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -30,8 +30,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@object-ui/types": "workspace:*",
-    "@objectstack/spec": "^17.0.0"
+    "@object-ui/types": "workspace:*"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/providers/tsconfig.test.json
+++ b/packages/providers/tsconfig.test.json
@@ -9,9 +9,9 @@
     // The package build emits `dist`; this project emits nothing, so it must
     // not inherit `composite` / `declaration` from the build config.
     "composite": false,
-    // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` and
-    // `@objectstack/spec` resolve through the workspace dependency's built
-    // `.d.ts` instead of pulling sibling sources in as program inputs (TS6059).
+    // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` resolves
+    // through the workspace dependency's built `.d.ts` instead of pulling
+    // sibling sources in as program inputs (TS6059).
     "paths": {}
   },
   "include": ["src/**/*.test.ts", "src/**/*.test.tsx"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2656,9 +2656,6 @@ importers:
       '@object-ui/types':
         specifier: workspace:*
         version: link:../types
-      '@objectstack/spec':
-        specifier: ^17.0.0
-        version: 17.2.0(ai@7.0.65(zod@4.4.3))
       react:
         specifier: 19.2.8
         version: 19.2.8


### PR DESCRIPTION
Fixes #5753

`@object-ui/providers` declared `@objectstack/spec` in `dependencies` and imported it
nowhere. This drops the declaration and corrects the now-inaccurate prose comment in
`packages/providers/tsconfig.test.json`, per the unlock comment and the PM dispatch order
(`#5753#issuecomment-5396525948`) — both of which supersede the body's proposal to defer
this to the spec-pin refresh chain.

## Premise re-verification — the whole justification is "zero import sites"

Measured on `origin/main` at `ad0f5f11f`, **before** removing anything. The card's original
measurement was taken on a branch that has since merged, so it had to be re-taken.

**The instrument** — import-shaped only (`from` / `require(` / `import(` / `vi.mock(` /
`jest.mock(`), matching the bare name *and* every subpath (`/ui`, `/data`, …), and covering
type-only imports because `import type … from '…'` matches the same anchor:

```
grep -rnE "(from|require\(|import\(|vi\.mock\(|jest\.mock\()[[:space:]]*['\"]@objectstack/spec" \
  TREE --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=.turbo
```

| TREE | Hits |
|---|---|
| `packages/providers/` | **0** |
| `packages/` + `apps/` (**positive control**, same command) | **434** |

An empty grep is not a reading on its own. The identical invocation returning 434 hits one
directory level up proves the instrument works and the zero is a real absence. Two narrower
controls agree: `@objectstack/spec/data` import sites across `packages/` + `apps/` = 90, and
a plain substring `objectstack/spec` across the same trees = 2381.

Beyond `src/`, checked and clear: both test files, `tsconfig.json`, `tsconfig.test.json`,
side-effect imports (bare `import '…'`), triple-slash reference-types directives,
`declare module`, and tsconfig `types` arrays. `packages/providers` has no `vitest.config.ts`
or build config of its own (`build` is bare `tsc`). Every remaining mention of the string in
the package:

- `package.json:34` — the declaration, removed here.
- `tsconfig.test.json:13` — prose, corrected here.
- `CHANGELOG.md` ×4 — immutable release history, deliberately untouched.

The only imports left in the package are `react`, `@object-ui/types`, relative paths, and
`vitest` / `@testing-library/react` in tests.

## ⚠️ What `check-phantom-dependencies.mjs` does and does not prove here

The card flagged that this gate guards the **inverse** direction — import without a
declaration — and that is correct in one important sense: **it never could have reddened on
the dead edge, and its green does not validate that the dependency was unused.** A
declared-but-unimported dependency is invisible to it by construction, which is exactly why
this defect needed a human-filed finding rather than a gate.

In the other direction it is load-bearing, and worth stating precisely because it covers a
gap that `type-check` does **not**: after the declaration is gone, any surviving import site
becomes a phantom dependency, which is what this gate is built to catch.

That distinction matters here because `type-check` alone is **not** proof of absence. The
root `package.json` declares `@objectstack/spec` (line 89), so pnpm places it in the
workspace-root `node_modules`, and Node's/TypeScript's upward walk reaches it from any
package directory. Measured after `pnpm install` with the declaration removed:

```
$ cd packages/providers && node -e "require.resolve('@objectstack/spec', {paths:[process.cwd()]})"
resolved: …/node_modules/.pnpm/@objectstack+spec@17.2.0…/node_modules/@objectstack/spec/dist/index.js
```

So a stray spec import in this package would still typecheck and still build green. This is
the trap `check-phantom-dependencies.mjs`'s own header documents (objectui#4394): "a
dependency-direction check performed BY RESOLUTION returns the wrong answer, and returns it
confidently." The grep above and the phantom-deps gate are the two readings that actually
bear weight; the green `type-check` is corroboration, not proof.

## Gates — verdict lines as each gate printed them

Run at `89c03822c` (the final commit; working tree clean). Exit codes captured before any
pipe.

| Gate | Exit | Verdict line |
|---|---|---|
| `pnpm install` | 0 | `Done in 17.2s using pnpm v10.31.0` — resolves cleanly with the entry gone; lockfile diff is exactly the one removed importer entry |
| `pnpm --filter '@object-ui/providers^...' build` | 0 | dependency closure (`@object-ui/types`) built first, so the checks below read a fresh `.d.ts` |
| `pnpm --filter '@object-ui/providers' run type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` — both projects, no output |
| `pnpm --filter '@object-ui/providers' run build` | 0 | `tsc` |
| `pnpm exec vitest run packages/providers/` | 0 | `Test Files 2 passed (2)` · `Tests 7 passed (7)` |
| `pnpm --filter '@object-ui/providers' run lint` | 0 | `✖ 15 problems (0 errors, 15 warnings)` — all pre-existing in `src/`, which this PR does not touch |
| `node scripts/check-phantom-dependencies.mjs` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ No source of a released package changed in this range, so no changeset is owed.` (1 changeset added anyway — see below) |
| `node scripts/check-changeset-fixed.mjs` | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `✅ No changeset declares a major bump.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 4990 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-package-self-import.mjs` | 0 | `✅ No package names itself inside its own src/.` |
| `node scripts/check-lint-coverage.mjs` | 0 | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `node scripts/check-type-check-coverage.mjs` | 0 | `✅ type-check coverage: 45/46 via type-check … 41/41 packages compile their tests` |

Two notes on how the suite was run, both deliberate:

- The dispatch order named `pnpm --filter '@object-ui/providers' run test`. This repo's own
  guard **refuses** that invocation (`vitest 调用被拒绝`, objectui#3378): a package-directory
  vitest root silently runs `apps/console`'s 22 files and reports them as green while running
  none of this package's. Re-run from the repo root as the guard instructs, which is what the
  passing `2 files / 7 tests` above reports.
- `node scripts/check-published-dist-tooling.mjs` was **not** run locally — a declared
  narrowing. It rebuilds every package and exceeds this container's foreground limit; CI owns
  it. It is also unreachable by this diff, which touches no `src/`, no build script and no
  tsconfig the build uses (`tsconfig.test.json` is `noEmit`). `packages/providers/dist/` was
  inspected directly and carries no tooling material.

## Published surface

Built and inspected: `dist/types.d.ts` imports only `react` and `@object-ui/types`; no
emitted `.d.ts` or `.js` references a spec symbol. The four `objectstack` strings surviving
in `dist/` are prose in doc comments (`@objectstack/service-storage` in an adapter's TSDoc,
two issue references) plus one adapter name string literal — no module specifier among them.

## Changeset

`check-changeset-presence.mjs` says none is owed (it scores `src/` changes, and this diff has
none). Added one anyway, scored **`patch`**, because the honest question is what consumers
install and that genuinely changes: the published manifest loses a `dependencies` entry.

`patch`, not `minor`: there is no API or behaviour change, and no supported access goes away.
Consumers on an isolated `node_modules` never had legitimate reach-through to
`@objectstack/spec` via this package — any consumer that did import it was relying on flat-
install hoisting, which was never a contract. The install graph is the only thing that moves.
For contrast, the change that *added* this edge was scored `minor` because it changed the
public `.d.ts`; nothing in this PR touches a type.

## Scope

Exactly the two files the card names, plus the changeset and the lockfile line `pnpm install`
regenerated. No other package's spec declaration is touched — the range question for packages
whose published `d.ts` references spec-17.1.0-only symbols is #5793's, a separate
un-dispatched card.

_(Body edited once after creation: GitHub's body sanitizer had eaten two short
angle-bracket fragments — the `TREE` placeholder in the grep block and the triple-slash
directive name. Same content, spelled without angle brackets.)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_