### PR TITLE
ci: give each merge its own concurrency group so the coverage gate survives

### DIFF
--- a/.changeset/5422-coverage-lane-concurrency.md
+++ b/.changeset/5422-coverage-lane-concurrency.md
@@ -1,0 +1,14 @@
+---
+---
+
+CI-only change: `ci.yml`'s workflow `concurrency` group now carries `github.sha` on
+the `push` trigger, so a merge to `main` no longer cancels the previous merge's
+still-running CI. The `pull_request` group (the PR number, `cancel-in-progress: true`)
+and the `merge_group` fallback to `github.ref` are both unchanged.
+
+The push lane is the only lane that runs the coverage gate, and the merged 4-shard
+report is what enforces `coverage.thresholds` for a commit. Measured over the 64
+completed push-lane runs on `main` between 2026-08-23T06:34Z and 2026-08-24T13:56Z,
+39 of them — 61% — lost that gate to cancellation rather than to a red suite.
+
+No published package changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,66 @@ on:
   # on a queue build is the queue's own generation — measured on objectstack,
   # `gh-readonly-queue/main/pr-6594-251e888ac9ace8226f3a8450951e5b40a0a84c2c`.
   # It can collide with neither a pull-request group (a bare PR number) nor a
-  # push group (`refs/heads/main`), so a queue build and the PR build it came
-  # from never cancel each other.
+  # push group (a commit sha since objectui#5422), so a queue build and the PR
+  # build it came from never cancel each other.
   merge_group:
     types: [checks_requested]
 
+# ── Concurrency (objectui#5422) ───────────────────────────────────
+# On `pull_request` the group is the PR number and `cancel-in-progress` cancels
+# that PR's previous run. That is correct and is deliberately UNCHANGED here: a
+# superseded PR push has nothing left to deliver.
+#
+# On `push` the group now carries `github.sha`, so every merge to `main` gets a
+# group of its own and no merge can cancel another merge's run. Until #5422 the
+# push branch of this expression fell back to `github.ref` — `refs/heads/main`
+# for EVERY merge — so each merge cancelled the previous merge's still-running
+# CI.
+#
+# That matters because the push lane is the only lane that runs the coverage
+# gate (`test-coverage` + `coverage-report` below are push-only), and the merged
+# 4-shard report is what enforces `coverage.thresholds` for a commit. Measured
+# on this repository over the 64 completed push-lane runs on `main` between
+# 2026-08-23T06:34Z and 2026-08-24T13:56Z: the merged report was produced for
+# 20, five lost it to a red suite, and 39 — 61% — lost it to CANCELLATION.
+# Over the 30 strictly consecutive push runs of 2026-08-24 alone it is 15 of 28
+# completed (54%). The lane needs ~13.5 min end to end while the median
+# inter-merge interval is 8.8 min, so most merges are overtaken before the gate
+# can report at all.
+#
+# ⚠️ This has to live at WORKFLOW level, not on the coverage jobs. A job-level
+# `concurrency:` only decides whether a job waits for another job in the same
+# group; it grants no exemption from the workflow-level `cancel-in-progress`,
+# which cancels the whole run and every job in it. A per-sha group on
+# `test-coverage` alone would therefore NOT have protected it.
+#
+# ⛔ Not `cancel-in-progress: false` on a `github.ref` group: that does not
+# serialise. With `cancel-in-progress` unset GitHub holds ONE pending run per
+# group and DISCARDS the rest — measured on this repository's release lane at
+# 95 of 200 runs never executing at all (objectui#5395). It would trade
+# cancellation for silent dropping, which is strictly worse.
+#
+# The cost is the one option A named on #5422: a burst of merges no longer
+# collapses into a single surviving run, so the push lane's other jobs also run
+# to completion and runner minutes rise. Nothing is weakened by that — every
+# merged commit now gets its own verdict, which is the only post-merge signal
+# this repository has while the merge queue validates nothing (objectui#4986).
+#
+# Trigger by trigger:
+#   pull_request  `github.event.pull_request.number` is set, so the chain stops
+#                 there                                       => ci-CI-<number>
+#   push          the number is null and `github.event_name == 'push'` is true,
+#                 so `&&` yields the sha                       => ci-CI-<sha>
+#   merge_group   the number is null and the `push` test is false, so `&&`
+#                 yields false and the chain falls through to `github.ref`,
+#                 which on a queue build is the queue's own generation ref
+#                 (`gh-readonly-queue/main/pr-<n>-<sha>`) — colliding with
+#                 neither a PR group nor a push group, exactly as before.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ci-${{ github.workflow }}-${{ github.event.pull_request.number
+    || (github.event_name == 'push' && github.sha)
+    || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Fixes #5422

Measure first, then fix — per the dispatch ruling on #5422. The measurement said the loss is material (54–61% against a 20% threshold), so option **A** is implemented.

> ⚠️ Placeholders below are written as `{number}` / `{sha}` / `{n}` rather than with angle brackets, because GitHub's body sanitizer silently strips `<word>` tokens — it ate every one of them on the first version of this description, including inside backticks.

## The measurement

**Method.** `GET /actions/workflows/ci.yml/runs` filtered to `branch=main, event=push`, three pages. Every record's own `event` and `head_branch` fields were re-checked client-side rather than trusted from the filter. Per-run delivery was then read from **`list_workflow_run_artifacts`**: the coverage lane's deliverable today is the `coverage-report` artifact (the merged 4-shard report that enforces `coverage.thresholds`), so its presence *is* the "did the gate deliver for this commit" signal.

⚠️ Note the Codecov framing on the card is stale: **the Codecov upload was removed by #5436** (maintainer ruling 2026-08-22). What cancellation destroys now is the merged report and the coverage **threshold gate**, not an upload.

**Primary window — 30 strictly consecutive push-lane runs, 2026-08-24T04:19Z .. 13:56Z** (28 completed):

| outcome | runs | share |
|---|---|---|
| coverage gate delivered | 13 | 46% |
| **lost to cancellation** | **15** | **54%** |
| lost to a red suite | 0 | 0% |

**Corroboration — all 66 unique push-lane runs collected, 2026-08-23T06:34Z .. 2026-08-24T13:56Z** (64 completed):

| outcome | runs | share |
|---|---|---|
| coverage gate delivered | 20 | 31% |
| **lost to cancellation** | **39** | **61%** |
| lost to a red suite | 5 | 8% |

**Why.** The sharded lane needs **~13.5 min** end to end (measured: shards ~12 min + the report job ~1 min; the 18 fully-green runs span 13.1–14.1 min). The **median inter-merge interval is 8.8 min** (p25 2.6, p75 20.4), and **63% of intervals are shorter than the lane**. The card body's "median 25.2 min" is from 2026-08-19/20 and no longer holds.

### Counter-probes

A zero is not a reading, and this lane has a documented history of misleading queries (#5393's retracted finding 2).

1. **The delivery signal returns non-zero for cases known to exist.** The same `list_workflow_run_artifacts` call that returns `total_count: 0` for cancelled runs returns a `coverage-report` artifact for runs that delivered — e.g. run `32735665660` and run `32633543905`. Critically it also returns one for **two runs whose run-level conclusion is `cancelled`** (`32730945699`, `32650838484`): they were cancelled *after* the gate had already reported. Those two are counted as **delivered**, not lost.
2. **Run-level `cancelled` was rejected as a proxy** precisely because of (1) — it overstates loss. Every cancelled run was checked individually.
3. **A stale-file error I made and corrected.** I first computed a rate over a directory glob of saved tool results and got a set containing 30 `pull_request` runs, which I initially read as the `event` filter being ignored. That was wrong: the contaminating file was a **saved result from an earlier session**, and my own three filtered pages were clean (30 push/main runs each). Re-derived from my own responses only. The filter works — independently confirmed by `event=merge_group` returning `total_count: 0` (consistent with #4986, the merge queue that has never produced a build) and `event=pull_request` + `branch=main` returning 0.

## The change

```yaml
# before
group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
cancel-in-progress: true

# after
group: >-
  ci-${{ github.workflow }}-${{ github.event.pull_request.number
  || (github.event_name == 'push' && github.sha)
  || github.ref }}
cancel-in-progress: true
```

Resolution per trigger — GitHub's `||` yields the first truthy operand, `&&` yields its right operand when the left is truthy:

| trigger | `pull_request.number` | `(event_name == 'push' && sha)` | resulting group |
|---|---|---|---|
| `pull_request` | set → chain stops here | — | `ci-CI-{number}` — **unchanged** |
| `push` | null | `true && sha` → the sha | `ci-CI-{sha}` — **new, one per commit** |
| `merge_group` | null | `false && …` → `false` | falls through to `github.ref` = `ci-CI-gh-readonly-queue/main/pr-{n}-{sha}` — **unchanged** |

The PR lane's `cancel-in-progress: true` is untouched, as the dispatch required. Two consecutive merges no longer share a group, so neither can cancel the other.

### ⚠️ A deviation from option A's literal wording, and why

Option A says "give the coverage lane its own `concurrency` group". **That mechanism does not exist.** A job-level `concurrency:` only decides whether a job waits for another job in the same group; it grants **no exemption from the workflow-level `cancel-in-progress`**, which cancels the whole run and every job in it. A per-sha group on `test-coverage` alone would not have protected it. The group therefore had to move at workflow level, on the `push` branch of the expression.

The consequence — and it is a real one the PM may want to rule on — is that this protects **the whole push lane**, not only the coverage jobs. Bursty merges no longer collapse into one surviving run, so `Type Check`, `Build Docs` and `Build & E2E` also run to completion and **runner minutes rise**. That is the cost option A itself named ("costs runner minutes when merges come in bursts"). Nothing is weakened: every merged commit now gets its own verdict, which is the only post-merge signal this repository has while #4986 leaves the merge queue validating nothing. If the narrower blast radius is wanted, the only way to get it is to split the coverage lane into its own workflow file — a much larger change that moves the `Test (coverage)` check between workflows, so I did not take it unasked.

### ⛔ Option B is refuted — not taken

`cancel-in-progress: false` on a `github.ref` group does **not** serialise. With `cancel-in-progress` unset GitHub holds **one** pending run per group and **discards** the rest — measured on this repository's release lane at **95 of 200 runs never executing at all** (#5395). It trades cancellation for silent dropping and is strictly worse than the status quo. The correction is posted on #5422 so the option text is not re-proposed.

## Verification, and its limit

⚠️ **A workflow change cannot be reverse-verified by running it.** Nothing here is an observation of the new concurrency behaviour in production — the argument is on the YAML, and that is the honest boundary of what was checked. What *was* verified, on `fd788e60a`:

- **The file parses and the folded scalar is what it looks like.** `yaml.safe_load` resolves `concurrency.group` to the single-line string `ci-${{ github.workflow }}-${{ github.event.pull_request.number || (github.event_name == 'push' && github.sha) || github.ref }}` with no embedded newline; `cancel-in-progress` is still `true`.
- **The per-trigger table above is executed, not asserted** — GitHub's `||`/`&&` truthiness rules were simulated over the four cases, confirming the PR group is byte-identical to before, the `merge_group` fallback is unchanged, and two different merge SHAs produce different groups.
- **`pnpm vitest run scripts/__tests__ --maxWorkers=2` → `Test Files 64 passed (64)`, `Tests 1711 passed (1711)`**, run on `fd788e60a` after the final commit. 22 of those files read `ci.yml`, including `merge-queue-reporting.test.ts` and `ci-cd-pipeline-doc.test.ts`. No pin needed updating: this change adds no job, renames no job, and adds no `run:` command, which is the granularity those tests judge at.
- `node scripts/check-changeset-presence.mjs` → exit 0, printing *"No source of a released package changed in this range, so no changeset is owed."* An empty-frontmatter changeset is included anyway, per the repo convention for a non-publishing change.
- `node scripts/check-control-bytes.mjs` → exit 0, *"scanned 4990 tracked text file(s)"*.
- **Lint scope, declared rather than skipped:** eslint's own `--format json` output for the changed file reports `"File ignored because no matching configuration was supplied."` Every block in `eslint.config.*` targets `**/*.{ts,tsx}` or narrower, and the diff contains no `.ts`/`.tsx` file at all, so it cannot move any untouched file's verdict. A repo-wide `pnpm lint` would judge exactly zero of the changed bytes.

Two dispatch-clue corrections: `scripts/check-workflow-*.mjs` **does not exist** in this repository, and there is no actionlint/yamllint gate — the workflow-pinning coverage is entirely in `scripts/__tests__/`.

Out of scope and untouched, as instructed: `changeset-release.yml`, shard counts, timeouts, the Codecov upload condition, and the merge queue (#4986, a repository-settings action no PR can perform).

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_