### PR TITLE
feat(types,plugin-gantt): declare the ten gantt keys ObjectGantt reads through a cast

### DIFF
--- a/.changeset/5903-objectgantt-declared-keys.md
+++ b/.changeset/5903-objectgantt-declared-keys.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-gantt': minor
+---
+
+`ObjectGanttSchema` declares the ten gantt keys `ObjectGantt` actually reads
+(objectui#5903, triage 2026-08-24). Every one is a real, working, documented
+feature — `readOnly`, `mobileReadOnly`, `markers`, `navigation`, `skipWeekends`,
+`holidays`, `criticalPath`, `showBaselines`, `persistLayout`, `viewName` — and
+none of them was discoverable from the published type, because all ten were read
+as `(schema as any).K`. The cast was the load-bearing part: it kept the read
+invisible to `tsc`, to the zod mirror and to the designer's registry `inputs`.
+
+Both halves move together. The TS declaration (`packages/types/src/objectql.ts`)
+and its zod mirror (`src/zod/objectql.zod.ts`) gain the same ten keys at the same
+requiredness — all optional — so the `zod-mirror-parity` ratchet stays at zero
+drift for this pair and no `KnownDrift` entry is added. `navigation` is taken
+from `@objectstack/spec`'s `NavigationConfigSchema` by reference rather than
+restated, matching `ObjectGridSchema.navigation`.
+
+`ObjectGanttProps.schema` is retyped from `ObjectGridSchema` to
+`ObjectGanttSchema`. That is what makes the declaration load-bearing: the ten
+keys are not grid keys, so with the old prop type, dropping the casts would have
+left the reads landing on `BaseSchema`'s index signature — the same invisibility
+in different syntax. The grid-style `{ gantt: { … } }` block is unaffected;
+`getGanttConfig` reads it through that index signature exactly as before, and the
+registered renderer passes `schema: any`, so no runtime shape is turned away.
+
+Accept-set change, stated plainly: a **declared** key is now type-validated, so
+`readOnly: 'yes'` is refused where it used to parse green — the same narrowing
+objectui#5074 landed for `viewMode`. An **undeclared** key is still accepted:
+`BaseSchema` is `.passthrough()` and carries an index signature (objectui#5155's
+structural ceiling), so declaring these ten did not buy rejection of a
+misspelling. `packages/types/src/__tests__/gantt-declared-keys.test.ts` pins both
+halves so neither can be misread.
+
+The eleventh reported key, `label`, needed no declaration — `BaseSchema` already
+carries it — so only its cast was dropped.

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -24,7 +24,7 @@
 
 import React, { useContext, useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
-import type { ObjectGridSchema, DataSource, ViewData, GanttConfig } from '@object-ui/types';
+import type { ObjectGanttSchema, ObjectGridSchema, DataSource, ViewData, GanttConfig } from '@object-ui/types';
 import { GanttConfigSchema } from '@objectstack/spec/ui';
 import { useNavigationOverlay, SchemaRendererContext } from '@object-ui/react';
 import { useLocalization, useDisplayLocale, resolveFieldCurrency } from '@object-ui/i18n';
@@ -274,7 +274,22 @@ export function normalizeDependencies(raw: unknown): GanttDependency[] {
 }
 
 export interface ObjectGanttProps {
-  schema: ObjectGridSchema;
+  /**
+   * The gantt node. Typed as {@link ObjectGanttSchema} (objectui#5903) — the
+   * declaration this component's schema reads actually resolve against.
+   *
+   * It used to be `ObjectGridSchema`, and that is why ten genuine reads had to
+   * be spelled `(schema as any).K`: the keys are not grid keys, so the only
+   * thing that admitted them was `BaseSchema`'s index signature, under a cast
+   * that hid even that. Removing the casts without moving the type would have
+   * changed nothing — the reads would still land on the index signature.
+   *
+   * The grid-style `{ gantt: { … } }` block keeps working exactly as before:
+   * `getGanttConfig` reads it through the same index signature, and the
+   * registered renderer (`index.tsx`) passes `schema: any`, so no runtime shape
+   * is turned away.
+   */
+  schema: ObjectGanttSchema;
   dataSource?: DataSource;
   className?: string;
   onTaskClick?: (record: any) => void;
@@ -296,7 +311,7 @@ export interface ObjectGanttProps {
 /**
  * Helper to get data configuration from schema
  */
-function getDataConfig(schema: ObjectGridSchema): ViewData | null {
+function getDataConfig(schema: ObjectGanttSchema): ViewData | null {
   if (schema.data) {
     return schema.data;
   }
@@ -888,8 +903,8 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // holiday list, duration/reschedule math is measured in working days. The
   // holidays array (ISO yyyy-mm-dd strings) becomes a Set for O(1) lookups.
   const workingCalendar = useMemo<WorkingCalendar | undefined>(() => {
-    const sw = (schema as any).skipWeekends;
-    const hol = (schema as any).holidays as string[] | undefined;
+    const sw = schema.skipWeekends;
+    const hol = schema.holidays;
     if (!sw && (!hol || hol.length === 0)) return undefined;
     return {
       skipWeekends: !!sw,
@@ -1020,9 +1035,9 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // snapshot under persistLayoutKey and fires onLayoutChange; the chips live up
   // here, so they get a sibling localStorage key and restore on mount.
   const persistLayoutKey =
-    (schema as any).persistLayout === false
+    schema.persistLayout === false
       ? undefined
-      : `${schema.objectName || (dataConfig?.provider === 'object' ? dataConfig.object : '') || 'gantt'}:${(schema as any).viewName || 'default'}`;
+      : `${schema.objectName || (dataConfig?.provider === 'object' ? dataConfig.object : '') || 'gantt'}:${schema.viewName || 'default'}`;
   const filtersStorageKey = persistLayoutKey ? `gantt-layout:${persistLayoutKey}:filters` : null;
   const [filterValues, setFilterValues] = useState<Record<string, string[]>>(() => {
     if (!filtersStorageKey || typeof window === 'undefined') return {};
@@ -1129,7 +1144,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // providing its own `navigation` config (e.g., page mode).
   // detail panel inline (no full-page navigation). Schema can override by
   // providing its own `navigation` config (e.g., page mode).
-  const navConfig = (schema as any).navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' };
+  const navConfig = schema.navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' };
   const navIsOverlay = navConfig.mode === 'drawer' || navConfig.mode === 'modal' || navConfig.mode === 'split' || navConfig.mode === 'popover';
   const navigation = useNavigationOverlay({
     navigation: navConfig,
@@ -1468,15 +1483,15 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           onTaskDelete={requestDelete}
           onDependencyCreate={ganttConfig?.dependenciesField ? handleDependencyCreate : undefined}
           onDependencyDelete={ganttConfig?.dependenciesField ? handleDependencyDelete : undefined}
-          markers={(schema as any).markers}
+          markers={schema.markers}
           autoSchedule={!!ganttConfig?.dependenciesField}
           rescheduleOnConflict={!!ganttConfig?.dependenciesField}
-          criticalPathDefault={!!(schema as any).criticalPath}
+          criticalPathDefault={!!schema.criticalPath}
           workingCalendar={workingCalendar}
           shiftSegments={shiftSegments}
-          showBaselines={(schema as any).showBaselines !== false}
-          readOnly={!!(schema as any).readOnly}
-          mobileReadOnly={(schema as any).mobileReadOnly !== false}
+          showBaselines={schema.showBaselines !== false}
+          readOnly={!!schema.readOnly}
+          mobileReadOnly={schema.mobileReadOnly !== false}
           persistLayoutKey={persistLayoutKey}
           onLayoutChange={filtersStorageKey ? persistFilters : undefined}
           groupBy={groupByAccessor}
@@ -1491,7 +1506,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
             // `label` off the schema it hands us — then the bound object's
             // label, then its API name.
             String(
-              ganttConfig?.exportFileName ?? (schema as any).label ?? objectSchema?.label ?? schema.objectName ?? ''
+              ganttConfig?.exportFileName ?? schema.label ?? objectSchema?.label ?? schema.objectName ?? ''
             ) || undefined
           }
           inlineEdit
@@ -1520,7 +1535,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         // Row-level lock (lockField) and global readOnly must also lock the
         // drawer: omitting onFieldSave/onDelete renders it strictly read-only.
         const recLocked =
-          !!(schema as any).readOnly ||
+          !!schema.readOnly ||
           (ganttConfig?.lockField ? !!rec[ganttConfig.lockField] : false);
         // #2473: prefer the fetched business record + schema over the raw row
         // payload (see the drawerFetch effect above for why they can differ).

--- a/packages/types/src/__tests__/gantt-declared-keys.test.ts
+++ b/packages/types/src/__tests__/gantt-declared-keys.test.ts
@@ -1,0 +1,200 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Declaration pin — the ten gantt keys `ObjectGantt` reads that
+ * `ObjectGanttSchema` did not declare (objectui#5903).
+ *
+ * ## What was wrong
+ *
+ * All ten were read as `(schema as any).K` in
+ * `plugin-gantt/src/ObjectGantt.tsx`. Every one is a real, working, documented
+ * feature (they are named in the package README), but nothing connected the
+ * read to a declaration: not `tsc`, not the registry `inputs`, not this
+ * package's zod mirror. An author following the published type could not
+ * discover any of them.
+ *
+ * Eleven keys were reported. `label` is the eleventh and it needed no
+ * declaration — `BaseSchema` already declares it — so only its cast was
+ * dropped. `label` is pinned below anyway, because "already declared" is the
+ * claim that would silently stop being true.
+ *
+ * ## What the pin has teeth against, and what it does not
+ *
+ * `BaseSchema` is `.passthrough()` on the zod side and carries
+ * `[key: string]: any` on the TS side (objectui#5155 records that ceiling), so:
+ *
+ *   - an UNDECLARED key is still accepted, by both halves. Declaring these ten
+ *     did NOT buy rejection of a misspelling, and the test below pins that
+ *     plainly rather than leaving it to be assumed;
+ *   - a DECLARED key IS validated. `readOnly: 'yes'` parsed green before this
+ *     card and is refused now — that is the accept-set narrowing landed here,
+ *     the same one objectui#5074 landed for `viewMode`;
+ *   - on the TS side the index signature means a read site can never be the
+ *     detector: `schema.readOnly` type-checks as `any` whether or not the key
+ *     is declared. So the compile-time pin is the `@ts-expect-error` block at
+ *     the bottom — remove a declaration and its member resolves to `any`, the
+ *     wrong-typed assignment starts succeeding, and the now-unused directive
+ *     fails the build (TS2578) NAMING the key. `tsconfig.test.json` compiles
+ *     this file, so that is real enforcement and not decoration (#3009).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectGanttSchema } from '../zod/objectql.zod.js';
+import type { ObjectGanttSchema as ObjectGanttSchemaTS } from '../objectql.js';
+
+const MINIMAL = {
+  type: 'object-gantt',
+  objectName: 'task',
+  startDateField: 'start',
+  endDateField: 'end',
+} as const;
+
+/** The ten keys this card declared, each with a value its declared type refuses. */
+const DECLARED: ReadonlyArray<readonly [string, unknown]> = [
+  ['skipWeekends', 'yes'],
+  ['holidays', [1]],
+  ['persistLayout', 'no'],
+  ['viewName', 1],
+  ['navigation', 'drawer'],
+  ['markers', [{ date: 5 }]],
+  ['criticalPath', 'on'],
+  ['showBaselines', 'off'],
+  ['readOnly', 'yes'],
+  ['mobileReadOnly', 'yes'],
+];
+
+describe('ObjectGanttSchema — the ten cast-read keys are declared (objectui#5903)', () => {
+  it('the mirror declares every one of them', () => {
+    const shape = Object.keys(ObjectGanttSchema.shape);
+    for (const [key] of DECLARED) expect(shape, `mirror is missing ${key}`).toContain(key);
+  });
+
+  it('declares them all OPTIONAL — none of the ten may become required', () => {
+    // Requiredness is the half the zod-mirror-parity ratchet compares against
+    // `../objectql.ts`, where all ten are `?:`. A mirror that required one would
+    // reject every gantt already published.
+    for (const [key] of DECLARED) {
+      const result = ObjectGanttSchema.safeParse(MINIMAL);
+      expect(result.success, `omitting ${key} must stay legal`).toBe(true);
+    }
+  });
+
+  it('materialises NO defaults — an omitted key stays absent after parse', () => {
+    // `showBaselines` and `mobileReadOnly` default ON *in the renderer*, which
+    // reads `!== false`. A `.default(true)` here would arrive downstream as an
+    // explicit author choice; the two spellings are not interchangeable.
+    const result = ObjectGanttSchema.safeParse(MINIMAL);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    for (const [key] of DECLARED) expect(key in result.data, `${key} must stay absent`).toBe(false);
+  });
+
+  it('refuses a wrong-typed value on each declared key (declared-key validation under passthrough)', () => {
+    for (const [key, bad] of DECLARED) {
+      const result = ObjectGanttSchema.safeParse({ ...MINIMAL, [key]: bad });
+      expect(result.success, `${key} accepted ${JSON.stringify(bad)}`).toBe(false);
+      if (result.success) continue;
+      const issue = result.error.issues.find((i) => i.path[0] === key);
+      expect(issue, `${key} failed, but not on the ${key} path`).toBeTruthy();
+    }
+  });
+
+  it('accepts a well-typed value on each declared key', () => {
+    // Counter-probe for the assertion above: it must be the VALUE being refused,
+    // not the key. A pin that only ever sees red proves nothing.
+    const good = {
+      ...MINIMAL,
+      skipWeekends: true,
+      holidays: ['2024-06-05'],
+      persistLayout: false,
+      viewName: 'shift-plan',
+      navigation: { mode: 'page' as const, view: 'task_detail', openNewTab: false },
+      markers: [{ date: '2024-06-05', label: 'Release', color: '#ef4444' }],
+      criticalPath: true,
+      showBaselines: false,
+      readOnly: true,
+      mobileReadOnly: false,
+    };
+    const result = ObjectGanttSchema.safeParse(good);
+    expect(result.success ? null : result.error.issues).toBe(null);
+  });
+
+  it('`label` needs no declaration here — BaseSchema already carries it', () => {
+    // The eleventh reported key. It was cast-read too, but the cast was the only
+    // defect: dropping it is the whole fix. Pinned so that "already declared"
+    // cannot quietly stop being true.
+    const inherited = ObjectGanttSchema.safeParse({ ...MINIMAL, label: 'Shift Plan' });
+    expect(inherited.success).toBe(true);
+    expect(ObjectGanttSchema.safeParse({ ...MINIMAL, label: 5 }).success).toBe(false);
+  });
+
+  it('does NOT reject an undeclared key — objectui#5155’s ceiling, measured not assumed', () => {
+    // Declaring the ten bought validation of DECLARED keys, not rejection of
+    // undeclared ones: `BaseSchema` is `.passthrough()`. Anyone reading this
+    // card as "misspellings now fail" is reading it wrong, and this pin says so
+    // in the one place that cannot rot.
+    const misspelled = ObjectGanttSchema.safeParse({ ...MINIMAL, readonly: true, skipWeekend: true });
+    expect(misspelled.success).toBe(true);
+  });
+});
+
+describe('ObjectGanttSchema (TS) — compile-time pin on the same ten keys', () => {
+  it('refuses a wrong-typed value on every declared key', () => {
+    // Each directive below fails the build (TS2578, "unused '@ts-expect-error'")
+    // the moment its key stops being declared, because the member then resolves
+    // to `any` through `BaseSchema`'s index signature and the assignment starts
+    // succeeding. That failure is the signal this card exists to create.
+
+    // @ts-expect-error — declared `boolean | undefined`.
+    const skipWeekends: ObjectGanttSchemaTS['skipWeekends'] = 'yes';
+    // @ts-expect-error — declared `string[] | undefined`.
+    const holidays: ObjectGanttSchemaTS['holidays'] = [1];
+    // @ts-expect-error — declared `boolean | undefined`.
+    const persistLayout: ObjectGanttSchemaTS['persistLayout'] = 'no';
+    // @ts-expect-error — declared `string | undefined`.
+    const viewName: ObjectGanttSchemaTS['viewName'] = 1;
+    // @ts-expect-error — declared `ViewNavigationConfig | undefined`, an object.
+    const navigation: ObjectGanttSchemaTS['navigation'] = 'drawer';
+    // @ts-expect-error — `date` is declared `string` (schemas are JSON).
+    const markers: ObjectGanttSchemaTS['markers'] = [{ date: 5 }];
+    // @ts-expect-error — declared `boolean | undefined`.
+    const criticalPath: ObjectGanttSchemaTS['criticalPath'] = 'on';
+    // @ts-expect-error — declared `boolean | undefined`.
+    const showBaselines: ObjectGanttSchemaTS['showBaselines'] = 'off';
+    // @ts-expect-error — declared `boolean | undefined`.
+    const readOnly: ObjectGanttSchemaTS['readOnly'] = 'yes';
+    // @ts-expect-error — declared `boolean | undefined`.
+    const mobileReadOnly: ObjectGanttSchemaTS['mobileReadOnly'] = 'yes';
+
+    expect([
+      skipWeekends, holidays, persistLayout, viewName, navigation,
+      markers, criticalPath, showBaselines, readOnly, mobileReadOnly,
+    ]).toHaveLength(10);
+  });
+
+  it('accepts the well-typed value on every declared key', () => {
+    // Counter-probe for the directives above: without this, a declaration
+    // narrowed to `never` would satisfy all ten of them.
+    const ok: ObjectGanttSchemaTS = {
+      type: 'object-gantt',
+      objectName: 'task',
+      skipWeekends: true,
+      holidays: ['2024-06-05'],
+      persistLayout: false,
+      viewName: 'shift-plan',
+      navigation: { mode: 'page', view: 'task_detail', openNewTab: false },
+      markers: [{ date: '2024-06-05', label: 'Release', color: '#ef4444' }],
+      criticalPath: true,
+      showBaselines: false,
+      readOnly: true,
+      mobileReadOnly: false,
+    };
+    expect(ok.markers?.[0].date).toBe('2024-06-05');
+  });
+});

--- a/packages/types/src/__tests__/gantt-declared-keys.test.ts
+++ b/packages/types/src/__tests__/gantt-declared-keys.test.ts
@@ -151,25 +151,25 @@ describe('ObjectGanttSchema (TS) — compile-time pin on the same ten keys', () 
     // to `any` through `BaseSchema`'s index signature and the assignment starts
     // succeeding. That failure is the signal this card exists to create.
 
-    // @ts-expect-error — declared `boolean | undefined`.
+    // @ts-expect-error — `skipWeekends` is declared `boolean | undefined`.
     const skipWeekends: ObjectGanttSchemaTS['skipWeekends'] = 'yes';
-    // @ts-expect-error — declared `string[] | undefined`.
+    // @ts-expect-error — `holidays` is declared `string[] | undefined`.
     const holidays: ObjectGanttSchemaTS['holidays'] = [1];
-    // @ts-expect-error — declared `boolean | undefined`.
+    // @ts-expect-error — `persistLayout` is declared `boolean | undefined`.
     const persistLayout: ObjectGanttSchemaTS['persistLayout'] = 'no';
-    // @ts-expect-error — declared `string | undefined`.
+    // @ts-expect-error — `viewName` is declared `string | undefined`.
     const viewName: ObjectGanttSchemaTS['viewName'] = 1;
-    // @ts-expect-error — declared `ViewNavigationConfig | undefined`, an object.
+    // @ts-expect-error — `navigation` is declared `ViewNavigationConfig | undefined`, an object.
     const navigation: ObjectGanttSchemaTS['navigation'] = 'drawer';
-    // @ts-expect-error — `date` is declared `string` (schemas are JSON).
+    // @ts-expect-error — `markers[].date` is declared `string` (schemas are JSON).
     const markers: ObjectGanttSchemaTS['markers'] = [{ date: 5 }];
-    // @ts-expect-error — declared `boolean | undefined`.
+    // @ts-expect-error — `criticalPath` is declared `boolean | undefined`.
     const criticalPath: ObjectGanttSchemaTS['criticalPath'] = 'on';
-    // @ts-expect-error — declared `boolean | undefined`.
+    // @ts-expect-error — `showBaselines` is declared `boolean | undefined`.
     const showBaselines: ObjectGanttSchemaTS['showBaselines'] = 'off';
-    // @ts-expect-error — declared `boolean | undefined`.
+    // @ts-expect-error — `readOnly` is declared `boolean | undefined`.
     const readOnly: ObjectGanttSchemaTS['readOnly'] = 'yes';
-    // @ts-expect-error — declared `boolean | undefined`.
+    // @ts-expect-error — `mobileReadOnly` is declared `boolean | undefined`.
     const mobileReadOnly: ObjectGanttSchemaTS['mobileReadOnly'] = 'yes';
 
     expect([

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1974,6 +1974,104 @@ export interface ObjectGanttSchema extends BaseSchema {
    * author choice and defeat that seeding.
    */
   viewMode?: SpecGanttConfig['viewMode'];
+  /**
+   * Skip weekends in duration / auto-schedule math (objectui#5903).
+   *
+   * When true (or when `holidays` is non-empty) `ObjectGantt` builds a
+   * `WorkingCalendar` and `GanttView` measures durations, cascades and the
+   * critical path in WORKING days — weekends are stepped over rather than
+   * consumed. Read at `plugin-gantt/src/ObjectGantt.tsx` (`workingCalendar`).
+   *
+   * Declared here rather than derived: the spec's `GanttConfigSchema` models no
+   * working-calendar member, so this is objectui's own display extension — the
+   * same standing `timeSegments` has on {@link GanttConfig}.
+   */
+  skipWeekends?: boolean;
+  /**
+   * Non-working dates for the same working calendar as {@link skipWeekends} —
+   * ISO `yyyy-mm-dd` (UTC) keys, e.g. `['2024-06-05']`. Non-empty enables the
+   * working calendar on its own. Read at `ObjectGantt.tsx` (`workingCalendar`).
+   */
+  holidays?: string[];
+  /**
+   * Opt OUT of layout persistence. `false` disables it; any other value (and
+   * omission) keeps it on, which is why this is not spelled as an enable flag.
+   *
+   * `GanttView` persists its column/zoom snapshot and `ObjectGantt` persists the
+   * quick-filter chips under a sibling localStorage key, both derived from
+   * `persistLayoutKey`. Read at `ObjectGantt.tsx` (`persistLayoutKey`).
+   */
+  persistLayout?: boolean;
+  /**
+   * Layout-persistence scope. Distinguishes two gantts bound to the SAME object
+   * so they keep separate saved layouts; the storage key is
+   * `objectName:viewName` and defaults to `objectName:default`. Read at
+   * `ObjectGantt.tsx` (`persistLayoutKey`).
+   */
+  viewName?: string;
+  /**
+   * Record navigation behaviour when a bar is clicked (drawer / dialog / page).
+   * Defaults to an inline right-side drawer; set `{ mode: 'page' }` to route to
+   * the standalone detail page instead. Read at `ObjectGantt.tsx`
+   * (`navConfig`).
+   *
+   * The spec owns the member list — `mode`, `view`, `preventNavigation`,
+   * `openNewTab`, `size`, `width` — and its schema REFUSES anything else. In
+   * particular there is no `basePath`: the package README shows one, and no read
+   * site in this repo consumes it (filed separately). Do not restate the
+   * vocabulary here; that is the drift this derivation exists to prevent.
+   *
+   * Same spec type as {@link ObjectGridSchema.navigation} and
+   * {@link ObjectViewSchema.navigation} — aligned with `@objectstack/spec`
+   * `ListView.navigation` rather than restated, so the vocabulary cannot fork.
+   */
+  navigation?: ViewNavigationConfig;
+  /**
+   * Extra vertical reference lines drawn like the Today marker (deadline,
+   * sprint boundary, release…). Forwarded to `GanttView`'s `markers` prop and
+   * read at `ObjectGantt.tsx`.
+   *
+   * `date` is declared as a STRING here, not `Date | string` like the runtime
+   * `GanttMarker` this feeds: a schema is serialisable authored metadata and a
+   * `Date` instance cannot survive JSON. The renderer keeps accepting both,
+   * because a narrower authoring surface is assignable to the wider prop.
+   */
+  markers?: Array<{
+    /** Marker position, ISO date or datetime string (e.g. `'2024-06-05'`). */
+    date: string;
+    /** Text drawn against the line. */
+    label?: string;
+    /** Line colour — any CSS colour. */
+    color?: string;
+  }>;
+  /**
+   * Start with the critical-path highlight enabled. The toolbar toggle stays
+   * available either way — this only seeds its initial state. Read at
+   * `ObjectGantt.tsx` (`criticalPathDefault`).
+   */
+  criticalPath?: boolean;
+  /**
+   * Render planned-vs-actual baseline bars when tasks carry baseline dates.
+   * Defaults to ON — only an explicit `false` turns them off, which is why the
+   * read site compares against `false` rather than coercing. Read at
+   * `ObjectGantt.tsx`.
+   */
+  showBaselines?: boolean;
+  /**
+   * Read-only mode. Disables every write path — bar drag / resize / progress
+   * handle, inline edit, delete, dependency-link drag, row reorder,
+   * auto-schedule and the Undo/Redo buttons — and locks the record drawer.
+   * Clicking a task and switching granularity still work. Read at
+   * `ObjectGantt.tsx` (`readOnly`, and the drawer's `recLocked`).
+   */
+  readOnly?: boolean;
+  /**
+   * Auto-enter read-only mode on narrow viewports (< 640px) so touch users get
+   * a scrollable thumbnail instead of error-prone drag editing. Defaults to ON;
+   * only an explicit `false` turns it off. Independent of (and OR-combined
+   * with) {@link readOnly}. Read at `ObjectGantt.tsx`.
+   */
+  mobileReadOnly?: boolean;
 }
 
 /**

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -613,6 +613,35 @@ export const ObjectGanttSchema = BaseSchema.extend({
   viewMode: SpecGanttConfigSchema.shape.viewMode.describe(
     'Initial timeline granularity, honoured by both renderer branches; when omitted, a persisted layout may seed it'
   ),
+  // objectui#5903 — ten keys `ObjectGantt` reads and this mirror did not
+  // declare. They were reachable only through `(schema as any).K`, so nothing
+  // connected the read to a declaration. Mirrored here at the SAME requiredness
+  // as `../objectql.ts` (all optional) so the zod-mirror-parity ratchet stays at
+  // zero drift for this pair. `label` is NOT among them: `BaseSchema` already
+  // declares it, so that read only needed its cast dropped.
+  //
+  // What declaring buys under `.passthrough()`: an undeclared key is still waved
+  // through (objectui#5155's structural ceiling), but a DECLARED key is now
+  // type-validated — `readOnly: 'yes'` is refused where it used to parse green.
+  skipWeekends: z.boolean().optional().describe('Skip weekends in duration / auto-schedule math (working calendar)'),
+  holidays: z.array(z.string()).optional().describe("Non-working dates for the working calendar, ISO 'yyyy-mm-dd' (UTC)"),
+  persistLayout: z.boolean().optional().describe('Opt OUT of layout persistence — only an explicit false disables it'),
+  viewName: z.string().optional().describe("Layout-persistence scope; storage key is `objectName:viewName` (default 'default')"),
+  navigation: SpecNavigationConfigSchema.optional().describe('Record navigation behaviour on task click (drawer/dialog/page)'),
+  markers: z
+    .array(
+      z.object({
+        date: z.string().describe('Marker position, ISO date or datetime string'),
+        label: z.string().optional().describe('Text drawn against the line'),
+        color: z.string().optional().describe('Line colour — any CSS colour'),
+      })
+    )
+    .optional()
+    .describe('Extra vertical reference lines drawn like the Today marker'),
+  criticalPath: z.boolean().optional().describe('Seed the critical-path highlight ON (toolbar toggle stays available)'),
+  showBaselines: z.boolean().optional().describe('Render planned-vs-actual baseline bars — defaults ON, only an explicit false disables'),
+  readOnly: z.boolean().optional().describe('Disable every write path and lock the record drawer'),
+  mobileReadOnly: z.boolean().optional().describe('Auto read-only on narrow viewports — defaults ON, only an explicit false disables'),
 });
 
 /**


### PR DESCRIPTION
Fixes #5903

Verified at `fb876485d` (final commit; every gate result below was re-run on that
tree). Merge-base `b0de7a85c`.

## What landed

`ObjectGanttSchema` declares the ten keys `ObjectGantt` reads — `skipWeekends`,
`holidays`, `persistLayout`, `viewName`, `navigation`, `markers`, `criticalPath`,
`showBaselines`, `readOnly`, `mobileReadOnly` — on **both** its TS declaration
and its zod mirror, at the same requiredness (all optional). All twelve
`(schema as any).K` read sites are gone.

`navigation` is taken from the spec's `NavigationConfigSchema` by reference, the
same way `ObjectGridSchema.navigation` is, rather than restated. The other nine
have no spec member (`GanttConfigSchema` models none of them), so they are
declared as objectui's own display extension — the standing `timeSegments`
already has on `GanttConfig`.

**`ObjectGanttProps.schema` is retyped `ObjectGridSchema` → `ObjectGanttSchema`.**
This is the load-bearing part of the change, not a tidy-up. The ten keys are not
grid keys, so under the old prop type dropping the casts would have left every
read landing on `BaseSchema`'s index signature — the same invisibility in
different syntax. The grid-style `{ gantt: { … } }` block is unaffected:
`getGanttConfig` reads it through that same index signature exactly as before,
and the registered renderer (`index.tsx`) passes `schema: any`, so no runtime
shape is turned away. There is no other in-repo caller.

## Per-key verdict — declare, delete, or already declared

Two outcomes were admissible per key. **No read was deleted:** all eleven are
live, and PR #5900's README (landed) documents all eleven as genuine working
features. Read sites are cited at the merge-base line numbers.

| Key | Verdict | Read site | Evidence it is live |
| --- | --- | --- | --- |
| `skipWeekends` | declare | `:891` | builds `workingCalendar`; `GanttView.workaxis.test.tsx` drives it |
| `holidays` | declare | `:892` | same `workingCalendar`; same test |
| `persistLayout` | declare | `:1023` | gates `persistLayoutKey`; `ObjectGantt.persistfilters.test.tsx`, `ObjectGantt.test.tsx:530` |
| `viewName` | declare | `:1025` | scopes `persistLayoutKey` |
| `navigation` | declare | `:1132` | feeds `useNavigationOverlay`; drawer-vs-page mode |
| `markers` | declare | `:1471` | `GanttView` `markers` prop → `resolvedMarkers` |
| `criticalPath` | declare | `:1474` | seeds `React.useState(criticalPathDefault)` (`GanttView:2864`) |
| `showBaselines` | declare | `:1477` | read at `GanttView:2996`, `:3848` |
| `readOnly` | declare | `:1478`, `:1523` | disables writes; locks drawer (`ObjectGantt.drawerlock.test.tsx:84`) |
| `mobileReadOnly` | declare | `:1479` | `effectiveReadOnly` (`GanttView:752`) |
| `label` | **already declared** — cast dropped only | `:1494` | `BaseSchema.label: string \| I18nLabel` |

**Delta against the card, key by key.** The card's count of 11 holds exactly on
merge-base `b0de7a85c` — same eleven keys, same line numbers, nothing added or
removed by today's `packages/types` traffic. Neither #6003 (dashboard widget
vocabulary) nor #6012 (`IconSchema`'s glyph key rename) touches any of them. One
correction: the card lists `label` as undeclared, and it is **not** — `BaseSchema`
has carried it since #4580. So this card declares **ten**, not eleven. `label` is
pinned in the new test anyway, because "already declared" is the claim that would
silently stop being true.

## Enumeration method, and its counter-probe

The card's reproduce command is a regex over `(schema as X).KEY`. That is blind
by construction to `(schema as any)['foo']`, to a destructure off an `any`-typed
local, and to a cast spanning lines — three spellings of one defect with no
shared pattern. So the read set was re-derived with an **AST walk** instead: an
expression counts as schema-rooted after stripping parenthesis / `as` /
`satisfies` / non-null wrappers, with local aliases chased to a fixed point;
property access, string-literal element access, and object-binding patterns are
all collected.

Result on merge-base: **47** distinct top-level keys read off `schema`, of which
**11** are cast reads — precisely the card's eleven.

**Counter-probe (the method must find keys that are legitimately declared, or it
is blind):** it finds `objectName`, `viewMode`, `startDateField`, `endDateField`,
`titleField`, `dependencyField`, `progressField` — the seven already on
`ObjectGanttSchema` — and `label`, already on `BaseSchema`. After the change the
same walk reports **zero** cast reads and the same 47 keys.

The other 36 keys are read bare through the index signature rather than through a
cast; that is a different mechanism and out of this card's fence, filed as #6051.

## Reverse verification — the signal this card exists to create

Directions were predicted before running. Both mutations were proved on disk in
both directions (removed text → 0, surviving anchor → 1), run under
`trap … EXIT INT TERM`, and `git diff HEAD --stat` is empty afterwards.

**Ablation A — restore `ObjectGanttSchema`'s TS declaration to its pre-card state.**
`packages/types` tests import source-relative, but `plugin-gantt` resolves
`@object-ui/types` through `exports` → `dist`, so the types package was rebuilt
between mutation and reading, and the mutation was confirmed to have reached
`dist/objectql.d.ts` (`skipWeekends` count 1 → 0).

- Predicted **RED** on `@object-ui/types type-check`. **Measured:** exit `2`,
  **ten** `error TS2578: Unused '@ts-expect-error' directive.` — one per declared
  key, at the ten pinned lines. Mechanism: with the declaration gone each member
  resolves to `any` through the index signature, the wrong-typed assignment
  starts succeeding, and the directive becomes unused. Each directive names its
  key, so the failure is self-describing.
- Predicted **GREEN** on `@object-ui/plugin-gantt type-check`, and stated as a
  non-signal up front. **Measured:** exit `0`. Under the index signature a read
  site can never be the detector — `schema.readOnly` type-checks as `any` either
  way. This is why the pin lives in `packages/types`, compiled by
  `tsconfig.test.json`, and not at the read site.

**Ablation B — restore only the zod mirror, TS declaration intact.** This tests
the dispatch's mechanism assumption 3 ("declaring on the TS side alone will turn
`zod-mirror-parity` red").

- **That assumption does not hold for this pair, measured.** The parity test:
  `5 passed`, exit `0`. Its compile-time half (the `LedgerMismatch` assignment,
  which runs under `tsc -p tsconfig.test.json`, not vitest): exit `0`. Both green
  with the mirror missing all ten keys.
- Cause, read off the construction rather than guessed — the drift type
  `NarrowerThanDeclared` maps over the intersection of the mirror's mirrored keys
  with `keyof` the declaration, so a key present in the declaration but **absent
  from the mirror's `.shape`** drops out of the comparison entirely. The ratchet
  detects a mirror that is *narrower on a shared key*; it cannot detect a mirror
  that is *missing* one. The reverse direction is blind too, and for a second
  reason: `ObjectGanttSchema`'s declaration carries `BaseSchema`'s index
  signature, so `keyof` it is `string | number` and every indexed lookup resolves
  to `any`, which is assignable to anything the mirror could say.
- Consequence: **no `KnownDrift` entry was ever on the table** — the ledger is
  unchanged, still 17 entries on this merge-base (the "13" figure describes the
  post-#6032 state, which has not landed). The new pin caught the missing mirror
  instead: `2 failed | 7 passed`, exit `1`.

**Counter-probe on enforcement — measured, not assumed, exactly as the dispatch
asked.** `BaseSchema` is `.passthrough()` with an index signature (#5155's
structural ceiling), so the two halves differ and the test pins both:

- a **declared** key is now validated — `readOnly: 'yes'` is refused, where it
  parsed green before. That is the accept-set narrowing this card lands, the same
  one #5074 landed for `viewMode`;
- an **undeclared** key is still accepted — `{ readonly: true, skipWeekend: true }`
  parses green. Declaring these ten did **not** buy rejection of a misspelling.
  Anyone reading this card as "misspellings now fail" is reading it wrong, and
  the test says so in the one place that cannot rot.

Both halves also have positive counter-probes so neither can pass vacuously: a
well-typed value is accepted on every key (runtime), and the correctly-typed
literal assigns on every key (compile time) — without which a declaration
narrowed to `never` would satisfy all ten directives.

## Gates — by name, with exit codes

Exit codes captured before any pipe. Every reading below is from `fb876485d`.

| Gate | Exit |
| --- | --- |
| `pnpm --filter @object-ui/types type-check` (runs `tsc --noEmit`, then the examples and test projects) | `0` |
| `pnpm --filter @object-ui/plugin-gantt type-check` (runs `tsc --noEmit`, then the test project) | `0` |
| `pnpm exec vitest run packages/types/src packages/plugin-gantt/src` (root form) | `0` — 101 files, **1006 tests** passed |
| `pnpm --filter '...@object-ui/types' build` (downstream) | `0` — 91 packages |
| `pnpm --filter '...@object-ui/types' type-check` (downstream) | `0` — 42 packages |
| `eslint .` in `packages/types` | `0` — 0 errors, 244 warnings (all pre-existing `no-explicit-any`) |
| `eslint .` in `packages/plugin-gantt` | `0` — 0 errors, 251 warnings |
| `check:control-bytes` | `0` |
| `check:spec-symbols` | `0` |
| `check:doc-types` | `0` |
| `check:self-import`, `check:phantom-deps`, `lint:coverage` | `0` |
| `check-changeset-presence`, `check-changeset-no-major` | `0` |
| `regenerate-known-schema-types --check` | `0` |

The script name is echoed in each `type-check` log, so a zero-match silent pass
cannot read as green. The **prefix** form `'...@object-ui/types'` is the
**downstream consumer** direction — the correct one for a contract tightening.
`@object-ui/react-runtime` was built separately first; it is not in the prefix
closure but `packages/components` needs its `dist`. Per the dispatch that is a
known local gotcha, not a finding.

## Serial constraints

`packages/types` was taken after #5927's PR #6032 was confirmed **not merged**
into `origin/main` (checked by commit-log scan at branch time). The predicted
conflict on `zod-mirror-parity.test.ts` **does not arise**: that file is not in
this diff at all — declaring on both sides at constant requiredness leaves the
ratchet at zero drift for this pair, so there was nothing to edit there. No
sibling-claimed file was touched: `packages/test-support` and the parity test
files (#5872), `RecordDetailView.tsx` (#5835), `form.tsx` (#6010) and
`plugin-detail/src/renderers/__tests__/` (#5808) are all untouched.

## Out-of-scope findings (filed, not fixed here)

- **#6050** — the plugin-gantt README's `navigation` example shows `basePath`,
  which nothing in the repo reads and which the spec's `NavigationConfigSchema`
  actively **rejects**. Found because the new pin test used that README snippet
  verbatim as its well-typed fixture and it failed with `unrecognized_keys`. The
  one place this PR touches is its own new doc comment, which had been drafted
  from that README line — the phantom is removed there and the absence recorded.
- **#6051** (`finding`) — `getGanttConfig` reads 24 further top-level keys that
  neither schema declares, invisible through the index signature rather than a
  cast. Same defect class, different mechanism; whether the flat spelling is a
  sanctioned second authoring form for `GanttConfig` is a ruling.
- **#6052** — `String(schema.label)` stringifies an `I18nLabel` locale map to
  `[object Object]` in the export filename. Pre-existing; this PR is deliberately
  behaviour-preserving there, but dropping the cast makes the union visible at
  the call site for the first time.

⛔ Class card #4631 is **not** reopened — triage said doing this per-package
specimen does not reopen the class, and nothing here widens past `ObjectGantt`.

⛔ Draft on purpose: the PM lands this. Not marked ready, not enqueued, no
auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_