### PR TITLE
fix(console): omit a cleared server-owned field from a create submit

### DIFF
--- a/.changeset/lucky-forms-omit-server-defaults.md
+++ b/.changeset/lucky-forms-omit-server-defaults.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/console': patch
+---
+
+Console form pages no longer submit a cleared server-owned field as a blank.
+
+A field whose declared `defaultValue` is an instruction the server resolves per
+insert (a `NOW()` / `current_user` token, or a CEL expression envelope) opens
+with an empty control on a create form, and its key stays out of the payload
+while nothing touches it. But a submitter who typed into that control and then
+cleared it put the key back holding `''` — and `ObjectQL.applyFieldDefaults`
+resolves a declared default only for a field arriving absent or null, so the
+blank was stored and the declaration silently defeated.
+
+Such a key is now dropped from a CREATE submit on both the internal
+`/forms/:name` and the anonymous `/f/:slug` route. A blank cleared from a field
+with no runtime default — or with a static one — is still submitted, because
+that is the user removing a value; and an edit submit is untouched, where a
+cleared column is a deliberate removal.

--- a/apps/console/src/components/FormPage.serverDefaults.test.tsx
+++ b/apps/console/src/components/FormPage.serverDefaults.test.tsx
@@ -1,0 +1,358 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#5883 — a CLEARED server-owned control must not put its key in the
+ * create payload.
+ *
+ * ## The mechanism these tests pin
+ *
+ * Since objectui#5727 this renderer opens a runtime-default control EMPTY and
+ * leaves the key out of `values` (`readPrefill` skips `isRuntimeDefault`
+ * defaults). But `handleSubmit` submitted `values` WHOLESALE, and a control the
+ * user touches writes back through `onChange` — so a user who types into such a
+ * control and then clears it puts the key back, holding `''`.
+ *
+ * `ObjectQL.applyFieldDefaults` resolves a declared default only for a field
+ * that arrives ABSENT or NULL. A blank string is neither, so submitting one
+ * stores `''` and silently defeats the declaration — the same suppression
+ * #5727 closed, reached by the other door. The sibling chain already names the
+ * pairing: `@object-ui/plugin-form`'s `omitServerResolvedDefaults` says
+ * "excusing a server-owned field from `required` is only half an answer if the
+ * form then submits the key anyway."
+ *
+ * ## What each arm of `FieldInput` actually writes when cleared
+ *
+ * Measured on this file's own controls rather than assumed, because the
+ * filter's notion of "empty" is the whole fix:
+ *
+ *   - text / email / url / date / time / datetime / textarea / select →  `''`
+ *   - number / integer / decimal / currency → `null` (the arm spells
+ *     `e.target.value === '' ? null : Number(...)`, so no `NaN` is reachable)
+ *   - boolean / radio → nothing "cleared" exists; `false` and a picked option
+ *     are real values, and `isMissingForRequired` deliberately does not treat
+ *     `false` as absent.
+ *
+ * Both reachable spellings — `''` and `null` — are inside
+ * `isMissingForRequired`, which is exactly why the fix reads THAT predicate
+ * rather than testing for `''`. (A submitted `null` is one the engine would
+ * still have resolved; a submitted `''` is not. Dropping both keeps this
+ * renderer's notion of empty identical to the sibling's instead of inventing a
+ * narrower second one.)
+ *
+ * ## The counter-probes are the load-bearing half
+ *
+ * "The key is omitted" is satisfiable by omitting everything, so the positive
+ * assertions are worth nothing without these:
+ *
+ *   - a field with NO runtime default that the user clears still submits `''`
+ *     — clearing it is intent, and a filter that ate it would be a new defect;
+ *   - a field the user typed a real value into submits that value;
+ *   - an EDIT form submits the cleared key, because there the token was
+ *     resolved at insert and a blank is a deliberate removal.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { FormPage } from './FormPage';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+/**
+ * One object carrying every shape the fix has to tell apart:
+ *
+ *   - `title`  — no default at all (counter-probe: typed value, and a cleared
+ *                blank, both survive)
+ *   - `status` — a STATIC literal default (counter-probe: seeded, and a clear
+ *                is a real removal)
+ *   - `owner`  — a runtime TOKEN default on the text arm
+ *   - `remind_at` — a runtime TOKEN default on the date arm
+ *   - `priority`  — a CEL envelope default on the number arm (writes `null`)
+ *   - `stage`     — a CEL envelope default on the select arm
+ */
+const OBJECT_SCHEMA = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: {
+    title: { type: 'text', label: 'Title' },
+    status: { type: 'text', label: 'Status', defaultValue: 'draft' },
+    owner: { type: 'user', label: 'Owner', defaultValue: 'current_user' },
+    remind_at: { type: 'date', label: 'Remind At', defaultValue: 'NOW()' },
+    priority: {
+      type: 'number',
+      label: 'Priority',
+      defaultValue: { dialect: 'cel', source: 'defaultPriority()' },
+    },
+    stage: {
+      type: 'select',
+      label: 'Stage',
+      options: [
+        { value: 'new', label: 'New' },
+        { value: 'done', label: 'Done' },
+      ],
+      defaultValue: { dialect: 'cel', source: 'initialStage()' },
+    },
+  },
+};
+
+const FIELD_NAMES = ['title', 'status', 'owner', 'remind_at', 'priority', 'stage'];
+
+function viewEnvelope() {
+  return {
+    name: 'showcase_task.edit',
+    object: 'showcase_task',
+    viewKind: 'form',
+    label: 'Task',
+    config: { type: 'simple', sections: [{ label: 'Task', fields: FIELD_NAMES }] },
+  };
+}
+
+const CREATE_RESPONSE = {
+  object: 'showcase_task',
+  id: 'task-42',
+  record: { id: 'task-42' },
+};
+
+/** The stored row an EDIT form opens on. */
+const STORED_RECORD = {
+  object: 'showcase_task',
+  id: 'task-7',
+  record: {
+    id: 'task-7',
+    title: 'Stored title',
+    status: 'active',
+    owner: 'user-1',
+    remind_at: '2026-01-02',
+    priority: 3,
+    stage: 'new',
+  },
+};
+
+/** Every write this page makes, with its parsed body — the PAYLOAD, not state. */
+let writes: Array<{ url: string; method: string; body: Record<string, unknown> }> = [];
+
+function stubFetch(routes: Record<string, unknown>) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET';
+    if (method === 'POST' || method === 'PATCH') {
+      writes.push({
+        url: String(url),
+        method,
+        body: init?.body ? JSON.parse(String(init.body)) : {},
+      });
+    }
+    const key = Object.keys(routes).find((k) => String(url).includes(k));
+    if (!key) throw new Error(`unstubbed fetch: ${url}`);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => routes[key],
+      text: async () => JSON.stringify(routes[key]),
+    } as unknown as Response;
+  });
+}
+
+function renderInternal(query = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/forms/showcase_task.edit${query}`]}>
+      <Routes>
+        <Route path="/forms/:name" element={<FormPage mode="internal" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function renderPublic() {
+  return render(
+    <MemoryRouter initialEntries={['/f/contact-us']}>
+      <Routes>
+        <Route path="/f/:slug" element={<FormPage mode="public" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+const CREATE_ROUTES = {
+  '/meta/view/': viewEnvelope(),
+  '/meta/object/': OBJECT_SCHEMA,
+  '/data/showcase_task': CREATE_RESPONSE,
+};
+
+/** The single write this page made, as the server would receive it. */
+async function submittedPayload(): Promise<Record<string, unknown>> {
+  await waitFor(() => expect(writes).toHaveLength(1));
+  return writes[0].body;
+}
+
+beforeEach(() => {
+  writes = [];
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('create submit — a touched-then-cleared server-owned field', () => {
+  it('omits the key entirely on the text arm, so the declared token still resolves', async () => {
+    vi.stubGlobal('fetch', stubFetch(CREATE_ROUTES));
+    renderInternal();
+
+    const owner = await screen.findByLabelText(/Owner/);
+    // #5727 already guarantees the control opens EMPTY — the token is not
+    // seeded. The user is what puts the key back.
+    expect(owner).toHaveValue('');
+    await userEvent.type(owner, 'someone');
+    await userEvent.clear(owner);
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(Object.prototype.hasOwnProperty.call(body, 'owner')).toBe(false);
+  });
+
+  it('omits it on the date arm too', async () => {
+    vi.stubGlobal('fetch', stubFetch(CREATE_ROUTES));
+    renderInternal();
+
+    const remind = await screen.findByLabelText(/Remind At/);
+    // `fireEvent.change` rather than `userEvent.type` on the date/number/select
+    // arms: what is under test is the `onChange` write itself, and a date input
+    // is exactly where synthetic keystroke emulation is least faithful.
+    fireEvent.change(remind, { target: { value: '2026-03-04' } });
+    fireEvent.change(remind, { target: { value: '' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(Object.prototype.hasOwnProperty.call(body, 'remind_at')).toBe(false);
+  });
+
+  it('omits it on the number arm, whose cleared write is `null` rather than a blank string', async () => {
+    vi.stubGlobal('fetch', stubFetch(CREATE_ROUTES));
+    renderInternal();
+
+    const priority = await screen.findByLabelText(/Priority/);
+    fireEvent.change(priority, { target: { value: '7' } });
+    fireEvent.change(priority, { target: { value: '' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(Object.prototype.hasOwnProperty.call(body, 'priority')).toBe(false);
+  });
+
+  it('omits it on the select arm, cleared back to the placeholder option', async () => {
+    vi.stubGlobal('fetch', stubFetch(CREATE_ROUTES));
+    renderInternal();
+
+    const stage = await screen.findByLabelText(/Stage/);
+    await userEvent.selectOptions(stage, 'done');
+    await userEvent.selectOptions(stage, '');
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(Object.prototype.hasOwnProperty.call(body, 'stage')).toBe(false);
+  });
+
+  it('does the same on the anonymous public route', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/forms/contact-us/submit': { ok: true },
+        '/forms/contact-us': {
+          slug: 'contact-us',
+          object: 'showcase_task',
+          label: 'Contact us',
+          form: { type: 'simple', sections: [{ fields: FIELD_NAMES }] },
+          objectSchema: OBJECT_SCHEMA,
+        },
+      }),
+    );
+    renderPublic();
+
+    const owner = await screen.findByLabelText(/Owner/);
+    await userEvent.type(owner, 'someone');
+    await userEvent.clear(owner);
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(Object.prototype.hasOwnProperty.call(body, 'owner')).toBe(false);
+  });
+});
+
+describe('counter-probes — what the filter must NOT eat', () => {
+  it('still submits a blank the user cleared from a field with no runtime default', async () => {
+    vi.stubGlobal('fetch', stubFetch(CREATE_ROUTES));
+    renderInternal();
+
+    const title = await screen.findByLabelText(/Title/);
+    await userEvent.type(title, 'draft idea');
+    await userEvent.clear(title);
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(Object.prototype.hasOwnProperty.call(body, 'title')).toBe(true);
+    expect(body.title).toBe('');
+  });
+
+  it('still submits a blank the user cleared from a STATIC default, which is a real removal', async () => {
+    vi.stubGlobal('fetch', stubFetch(CREATE_ROUTES));
+    renderInternal();
+
+    const status = await screen.findByLabelText(/Status/);
+    // The static default IS seeded (#4068), so clearing it removes a value the
+    // user could see.
+    expect(status).toHaveValue('draft');
+    await userEvent.clear(status);
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(Object.prototype.hasOwnProperty.call(body, 'status')).toBe(true);
+    expect(body.status).toBe('');
+  });
+
+  it('submits the real value a user typed into a server-owned field', async () => {
+    vi.stubGlobal('fetch', stubFetch(CREATE_ROUTES));
+    renderInternal();
+
+    const owner = await screen.findByLabelText(/Owner/);
+    await userEvent.type(owner, 'user-99');
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(body.owner).toBe('user-99');
+    // And the rest of the payload is still there — "omit the key" must not
+    // become "drop the payload".
+    expect(body.status).toBe('draft');
+  });
+
+  it('leaves an EDIT submit alone: a cleared server-owned column is a deliberate removal', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetch({
+        '/meta/view/': viewEnvelope(),
+        '/meta/object/': OBJECT_SCHEMA,
+        '/data/showcase_task/task-7': STORED_RECORD,
+      }),
+    );
+    renderInternal('?recordId=task-7&recordObject=showcase_task');
+
+    const owner = await screen.findByLabelText(/Owner/);
+    expect(owner).toHaveValue('user-1');
+    await userEvent.clear(owner);
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    const body = await submittedPayload();
+    expect(writes[0].method).toBe('PATCH');
+    expect(Object.prototype.hasOwnProperty.call(body, 'owner')).toBe(true);
+    expect(body.owner).toBe('');
+  });
+});

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -91,6 +91,16 @@
  * values, exactly as a hidden field's do (triage ruling, 2026-08-22, following
  * #5594 and the plugin-form chain). Nothing in this file makes visibility a
  * submit-payload rule, at either granularity.
+ *
+ * ## The one thing that IS a submit-payload rule (objectui#5883)
+ *
+ * A field whose declared `defaultValue` is an instruction the SERVER resolves
+ * per insert is left out of a create payload when the control is empty — see
+ * {@link omitServerOwnedBlanks}. That is not a visibility rule wearing a
+ * different hat: the key is withheld precisely so the producer supplies the
+ * value, which is the whole meaning of the declaration. It is the submit half
+ * of the fence {@link readPrefill} put on seeding for objectui#5727, and the
+ * sibling of `@object-ui/plugin-form`'s `omitServerResolvedDefaults`.
  */
 
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
@@ -98,6 +108,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import {
   evalFieldPredicate,
+  isMissingForRequired,
   isRuntimeDefault,
   isServerOwnedValue,
   resolveFieldRuleState,
@@ -971,6 +982,93 @@ export function readPrefill(
   return out;
 }
 
+/**
+ * Drop the keys a CREATE payload must leave to the producer (objectui#5883).
+ *
+ * ## The other half of {@link readPrefill}'s #5727 fence
+ *
+ * #5727 stopped this renderer from SEEDING a runtime default, so such a control
+ * opens empty and its key never enters `values` from the declaration. That is
+ * the half that handles a form nobody touched. This is the half that handles a
+ * key the USER put there: a rendered control writes back through its `onChange`
+ * the moment it is touched, so a submitter who types into a server-owned field
+ * and then clears it puts the key back — holding a blank.
+ *
+ * `ObjectQL.applyFieldDefaults` resolves a declared default only for a field
+ * that arrives ABSENT or NULL. A blank string is neither, so submitting one
+ * stores `''` and silently defeats the declaration — the same suppression
+ * #5727 closed, reached by the other door. Omitting the key is what makes the
+ * server the single authority for the value.
+ *
+ * ## What "empty" means here, and why it is not spelled out
+ *
+ * The arms of {@link FieldInput} do not agree on what a cleared control writes,
+ * and the filter's notion of empty is the whole fix. Measured on this
+ * renderer's own controls: the text / email / url / date / time / datetime /
+ * textarea / select arms write `''`; the number family writes `null` (the arm
+ * spells `e.target.value === '' ? null : Number(...)`, so no `NaN` is
+ * reachable); the boolean and radio arms have no "cleared" state at all —
+ * `false` and a picked option are real values. A filter testing for `''` would
+ * therefore have left the number arm behind.
+ *
+ * So emptiness is `@object-ui/core`'s {@link isMissingForRequired} — the same
+ * PRESENCE predicate the `required` rule reads, which covers `undefined`,
+ * `null`, a blank string and an empty array while deliberately keeping `false`
+ * and `0` as values. "Left empty" cannot come to mean two different things in
+ * the two halves of this fix, and it cannot come to mean something narrower
+ * here than it does on the sibling chain.
+ *
+ * ## Why the two predicates rather than the sibling function
+ *
+ * `@object-ui/plugin-form`'s `omitServerResolvedDefaults`
+ * (`src/schemaDefaults.ts`) is this rule on the OTHER form chain and states the
+ * pairing outright — "excusing a server-owned field from `required` is only
+ * half an answer if the form then submits the key anyway". Calling it from here
+ * is not available: that package's `exports` map publishes `.` alone, and its
+ * root (`src/index.tsx`) does not re-export `schemaDefaults`, so the function
+ * has no spelling a consumer can import.
+ *
+ * What matters is that the CLASSIFIERS are not copied, and they are not: both
+ * are imported from `@object-ui/core`, which is where they live precisely so
+ * every layer that decides server-ownership reads one answer
+ * (`validation/server-owned-value.ts` says so, and lists this renderer's
+ * `resolveFieldRuleState` among the consumers). `omitServerResolvedDefaults` is
+ * itself only such a local application of the same two calls. This file already
+ * reads `isRuntimeDefault` directly for #5727's seeding fence, and
+ * `plugin-kanban` and `@object-ui/components`' form renderer read
+ * `isMissingForRequired` the same way. Publishing the sibling helper from
+ * plugin-form's root would let this call site shrink to one line; that is a
+ * change to another package's published surface, not to this one.
+ *
+ * ## The two boundaries
+ *
+ * - **CREATE only.** On an edit form the token was resolved at insert, so a
+ *   cleared column is a deliberate removal and dropping the key would silently
+ *   discard the user's edit. `isCreateForm` is the caller's fact, read off the
+ *   same URL switch `resolveRowState` uses.
+ * - **Runtime defaults only.** A field with no default, or with a STATIC one
+ *   (which #4068 says IS seeded into the control), keeps its blank: the user
+ *   cleared something that was there, or is expressing "leave this empty", and
+ *   either way that `''` is intent the form must carry.
+ */
+export function omitServerOwnedBlanks(
+  values: Record<string, unknown>,
+  fields: RenderableField[],
+  isCreateForm: boolean,
+): Record<string, unknown> {
+  if (!isCreateForm) return values;
+  const serverOwned = new Set(
+    fields.filter((f) => isRuntimeDefault(f.defaultValue)).map((f) => f.name),
+  );
+  if (serverOwned.size === 0) return values;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (serverOwned.has(key) && isMissingForRequired(value)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
 /** Authed/anonymous fetch — credentials included so cookies (auth) flow. */
 async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
   return fetch(`${API_BASE}${path}`, {
@@ -1534,10 +1632,19 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
     setSubmitting(true);
     setError(null);
     try {
+      // A server-owned field the user touched and cleared must not travel as a
+      // blank — that stores `''` and defeats the declaration the empty control
+      // was honouring (objectui#5883). Both routes, because `/f/:slug` is a
+      // create by construction and its payload reaches the same insert path.
+      const payload = omitServerOwnedBlanks(
+        values,
+        sections.flatMap((s) => s.fields),
+        isCreateForm,
+      );
       const result =
         mode === 'public'
-          ? await submitPublic(identifier, values)
-          : await submitInternal(loaded.object, values, editingId);
+          ? await submitPublic(identifier, payload)
+          : await submitInternal(loaded.object, payload, editingId);
       toast.success('Submitted');
       // Behaviour after submit
       switch (behavior.kind) {
@@ -1582,7 +1689,13 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
           const written = unwrapTransportEnvelope(result)?.record;
           const writtenId = editingId ?? readCreatedRecordId(result);
           const verdict = resolveSubmitRedirect(behavior.url, {
-            ...values,
+            // `payload`, not `values` — "the values as SUBMITTED" is what this
+            // scope has always claimed to be, and since objectui#5883 the two
+            // differ: a key the submit deliberately withheld is not part of the
+            // record it wrote, so resolving `{{record.x}}` from it would put
+            // the very blank we refused to send into a URL. The server echo
+            // below still supplies the value the producer resolved.
+            ...payload,
             ...(written && typeof written === 'object' ? (written as Record<string, unknown>) : {}),
             ...(writtenId ? { id: writtenId } : {}),
           });


### PR DESCRIPTION
Fixes #5883

## The mechanism

Since #5727 a create form on the console's two form routes correctly opens a runtime-default control **empty** and leaves the key out of `values`. But `handleSubmit` submitted `values` **wholesale**, and a rendered control writes back through its `onChange` the moment the user touches it — so a submitter who types into a server-owned field and then clears it puts the key back, holding a blank.

`ObjectQL.applyFieldDefaults` resolves a declared default only for a field arriving **absent or null**. A blank string is neither, so submitting one stores `''` and silently defeats the declaration: the same suppression #5727 closed, reached by the other door.

**Reproduced before fixing** — the card was explicitly not browser-verified, so its reachability claim was not inherited. `FormPage.serverDefaults.test.tsx` at the pre-fix commit: **5 failed, 4 passed (9)**, the four passes being the counter-probes, which are guards on both sides of the change.

## The fix

`omitServerOwnedBlanks` in `FormPage.tsx` drops those keys from a **CREATE** payload on both the internal `/forms/:name` and the anonymous `/f/:slug` route. The `redirect` submit behaviour's token scope moves from `values` to the same payload, since "the values as submitted" is what that scope has always claimed to be and the two now differ.

**The classifiers are not re-implemented.** Both come from `@object-ui/core`: `isRuntimeDefault` (already imported in this file for #5727's seeding fence) and `isMissingForRequired`. That is where they live precisely so every layer deciding server-ownership reads one answer, and it is how `plugin-kanban` and `@object-ui/components`' form renderer read them too.

### Delta from the card: the sibling helper is not importable

The card and the dispatch both assumed the shape question was "adapt the console's data to `omitServerResolvedDefaults`, or adapt its inputs". Measured on the merge-base, neither is available: `@object-ui/plugin-form`'s `exports` map publishes `.` alone, and its root `src/index.tsx` does not re-export `schemaDefaults` — so `omitServerResolvedDefaults` has **no spelling an importing package can write**. Reaching it would mean editing another package's published surface, outside this card's file surface. Recorded as a separate observation in #6059, which is left open for triage and is **not** addressed by this PR. `omitServerResolvedDefaults` itself is only a local application of the same two `@object-ui/core` calls, so the thing that must not fork has not forked.

### What "empty" means, measured rather than assumed

A filter testing for `''` would have left arms behind. Measured on this renderer's own controls, submitting after a touch-then-clear on each:

| arm | cleared write |
|---|---|
| text / user / email / url / password / textarea / date / time / datetime | `string ""` |
| number / integer / decimal / currency | `object null` — the arm spells `e.target.value === '' ? null : Number(...)`, so **no `NaN` is reachable** |
| select / picklist / enum (back to the placeholder option) | `string ""` |
| boolean / toggle / checkbox (toggled on then off) | `boolean false` — a real value, not a clear |
| radio | no cleared state; only a picked option is ever written |

Both reachable empty spellings are inside `isMissingForRequired`, and `false` correctly is not — which is exactly why the fix reads that predicate rather than testing for a blank string.

## Boundaries, each pinned

- **CREATE only.** On an edit form the token was resolved at insert, so a cleared column is a deliberate removal; dropping the key would silently discard the user's edit.
- **Runtime defaults only.** A field with no default, or with a **static** one (which #4068 says *is* seeded into the control), keeps its blank — the user removed a value that was there, or is expressing "leave this empty".

## Verification

Direction predicted before running: the positive assertions go red on the **submitted payload**, the counter-probes stay green.

**Ablation** — call site reverted to `const payload = values` at `5bd1ee015`, mutation proven on disk by grepping the injected marker (1 hit) **and separately** the removed text (0 hits), landing site printed and anchor uniqueness asserted before writing; restored under `trap ... EXIT INT TERM` with a cwd-independent `git -C /abs/worktree checkout -- /abs/worktree/apps/console/src/components/FormPage.tsx`:

| leg | result |
|---|---|
| mutated | `Tests 5 failed \| 4 passed (9)` — every positive assertion red, every counter-probe green |
| restored | `Tests 9 passed (9)`, injected marker 0 hits, removed text back, `git diff HEAD --stat` empty |

No rebuild step sits between the mutation and the measurement: the console's vitest run aliases workspace packages to their `src/`, and the mutated file is the console's own source.

**Gate union, run after the final commit, at `5bd1ee015`:**

| gate | verdict line |
|---|---|
| `pnpm --filter @object-ui/console type-check` (hyphenated; script name echoed as `> @object-ui/console@17.6.0 type-check`) | exit 0 |
| `pnpm exec vitest run` over 14 console form suites | `Test Files 14 passed (14)` · `Tests 236 passed (236)` |
| `eslint` on the two changed files (plain, no `--no-inline-config`) | `21 problems (0 errors, 21 warnings)` — base measured at 20; delta is **+1 `react-refresh/only-export-components`**, the warning each of this file's 12 existing exported helpers already carries |
| `node scripts/check-phantom-dependencies.mjs` | `Every in-scope import is declared by the package that publishes it.` |
| `node scripts/check-changeset-presence.mjs` | `2 source file(s) ... declares 1 changeset(s)` |
| `node scripts/check-control-bytes.mjs` | `OK (scanned 5000 tracked text file(s))` |
| `check-changeset-no-major` / `check-changeset-fixed` / `check-lint-coverage` / `check-type-check-coverage` | exit 0 each |

The first `type-check` run was the **unbuilt-closure** red (`Cannot find module '@object-ui/...'`) rather than a missing-`node_modules` one; fixed by `pnpm --filter '@object-ui/console^...' build`, not by reinstalling.

_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_