### PR TITLE
docs(contributing): correct the false CodeQL security-scan claim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,8 +388,9 @@ The project enforces minimum test coverage thresholds to maintain code quality:
 These thresholds are intentionally set just below current coverage levels to prevent CI failures from minor fluctuations while we improve test coverage. New code should aim for higher coverage than these minimums.
 
 #### Security Scans
-- **CodeQL**: Scans for security vulnerabilities in code
-- **Dependency Scanning**: Checks for known vulnerabilities in dependencies
+- **Dependabot**: Opens weekly dependency-update PRs for npm and GitHub Actions (configured in `.github/dependabot.yml`), and GitHub's Dependabot alerts report known vulnerabilities in dependencies. Unlike the checks above, this runs on a schedule against the default branch rather than on your PR.
+
+This repository does **not** run static-analysis security scanning of its own source code (CodeQL or equivalent) -- do not assume code you push is scanned for vulnerabilities beyond its dependencies.
 
 #### PR Automation
 - **Auto-labeling**: Automatically labels PRs based on changed files


### PR DESCRIPTION
Fixes #5964

`CONTRIBUTING.md` line 391 listed **CodeQL** under `#### Security Scans`, in a section introduced as "automated GitHub workflows that will run when you create a PR". No CodeQL scan runs in this repository. This is the same defect class as #5408 (the stale CodeQL badge in `README.md`, PR #5963), one file over.

## Premise re-derived on `origin/main` @ `a1c41c516`

**1. The false line still stands.** `CONTRIBUTING.md:391`:

```
- **CodeQL**: Scans for security vulnerabilities in code
```

**2. CodeQL is genuinely not registered — with a positive control.** The registered-workflow listing returns **33** workflows. Four are `dynamic/*`, which is the control that makes this a reading rather than an empty result — the enumeration demonstrably *does* surface dynamic workflows:

- `dynamic/copilot-swe-agent/copilot`
- `dynamic/copilot-pull-request-reviewer/copilot-pull-request-reviewer`
- `dynamic/dependabot/dependabot-updates`
- `dynamic/agents/anthropic-code-agent`

There is no `dynamic/github-code-scanning/codeql` — the entry CodeQL "default setup" registers when enabled. On disk, `find .github -iname '*codeql*'` matches nothing while the same pattern form `-iname '*lint*'` matches `.github/workflows/lint.yml`. Both probes agree: CodeQL was never set up here.

## ⚠️ The correction target in the issue body is itself false — do not restore it

Both #5964's body and #5408's dispatch state that `.github/workflows/secret-scan.yml` ("Secret Scanning") "is registered and active", and propose describing it here. **That claim does not hold on `main`, and writing it into this file would have introduced a fresh false claim of exactly the class this PR removes.** Measured:

- `git cat-file -e origin/main:.github/workflows/secret-scan.yml` → `does not exist in 'origin/main'` (control: the same probe on `ci.yml` resolves).
- `git log origin/main --full-history -- '*secret-scan.yml'` → **empty**. The file never existed on `main`. It was added and then deleted (`041dfb107` "删除 secret-scan.yml") on the unmerged branch `copilot/add-github-workflows`; neither commit is an ancestor of `main`.
- Its only **3 runs ever** were on that PR branch in January 2026, and **all three concluded `failure`**. It has never run on `main`.

The registry entry `Secret Scanning` / `.github/workflows/secret-scan.yml` with `state: "active"` is a **stale record for a file that is not on the default branch**. That is a general pattern in this repo's listing, not a one-off: `changeset-check.yml`, `validate-docs-links.yml` and both `proto-5395-*.yml` are likewise registered `active` with no file on `main`. **`state: "active"` in the workflow listing is not evidence that a workflow exists or runs** — worth knowing for the next reader who reaches for that API to settle a question like this one.

## What actually runs, by name

Only **Dependabot**: the `dynamic/dependabot/dependabot-updates` workflow is registered and active, and `.github/dependabot.yml` is present on `main` — weekly npm and GitHub Actions update PRs. GitHub's Dependabot alerts are enabled on the repository (the push to this branch printed the `security/dependabot` advisory banner). `.github/workflows/dependabot-auto-merge.yml` is on disk and registered.

The corrected text names that, and adds one explicit negative sentence so the same false inference does not silently re-form from a bare omission.

## Scope

`CONTRIBUTING.md` only — 3 insertions, 2 deletions, one file. Per the ruling: ⛔ **no CodeQL workflow was registered**, and ⛔ no workflow file was touched at all. Whether this repo *should* adopt code scanning is a maintainer-floor decision and is deliberately not back-derived from a docs fix. The neighbouring inconsistency the correction exposes is fixed in place rather than by editing the section lead-in: with CodeQL gone, the only remaining item is not PR-triggered, so the bullet says so ("runs on a schedule against the default branch rather than on your PR") while the lead-in stays accurate for the other three subsections.

## Verification — and its honest limits

⚠️ **No gate caught this, and none will keep it true.** "Which security scans are registered" is a repository-settings fact that a PR-level gate cannot read reliably, so ⛔ no gate was added (deliberately — that would be scope creep on a one-line prose correction). This section can drift again exactly as the README badge did. The only thing standing behind the corrected text is the measurement recorded above.

What could be run, all against final head `4088dc654` (working tree clean), exit codes captured before any pipe, quoting each gate's own verdict line:

| gate | verdict |
|:--|:--|
| `node scripts/check-control-bytes.mjs` | exit 0 — `check-control-bytes: OK (scanned 5015 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-doc-links.mjs` | exit 0 — `Links are valid across 15 scan roots.` |
| `node scripts/check-changeset-presence.mjs --base origin/main` | exit 0 — `No source of a released package changed in this range, so no changeset is owed.` |

Also: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' CONTRIBUTING.md` → no matches. `check-links.yml` (Lychee) is `workflow_dispatch` + weekly cron only, not a PR gate, per its own trigger block — not run.

**No test pins the old sentence:** `grep -rn -i 'Scans for security vulnerabilities|Security Scans|CodeQL'` across `*.ts/tsx/mjs/js/json` (excluding `node_modules`) returns nothing. No changeset — `CONTRIBUTING.md` sits outside every package's `src/`, confirmed by running the gate rather than assuming.

The one remaining tracked CodeQL claim in the repo is `packages/vscode-extension/SUMMARY.md:164` (「CodeQL扫描通过」), already filed as #5965 and out of this card's scope.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_