### PR TITLE
test(console): refresh the reference_rail.entries exemption note after the #5494 ruling

### DIFF
--- a/.changeset/reference-rail-entries-stale-prose.md
+++ b/.changeset/reference-rail-entries-stale-prose.md
@@ -1,0 +1,11 @@
+---
+---
+
+Test-only comment refresh in `registry-inputs-spec-parity.test.ts`: the
+`record:reference_rail.entries` exemption note no longer narrates the
+`ReferenceRailEntry` `icon` divergence as an open contract question (ruled
+Option B 2026-08-22, objectui#5494 landed the derivation from
+`@objectstack/spec/ui`), and drops the "the renderer reads it" premise that was
+false when written. The exemption itself is unchanged — `inputs` is a flat
+scalar carrier and still cannot express an array of objects. No published
+behaviour changes.

--- a/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
+++ b/apps/console/src/__tests__/registry-inputs-spec-parity.test.ts
@@ -714,13 +714,26 @@ const UNPUBLISHED_EXEMPTIONS: Record<string, string> = {
   // renderer cannot honour, which is this gate's own failure mode one layer in
   // (the `page:tabs.alwaysShowStrip` note above).
   //
-  // Also blocked on a real contract question, so it is not merely unbuilt: the
-  // item shape is `ReferenceRailEntrySchema`, whose `$strict` object REFUSES the
-  // `icon` key this repo's own local `ReferenceRailEntry` declares and the
-  // renderer reads. Publishing an entries editor means first deciding whether
-  // `icon` survives — objectui#5494.
+  // NOT blocked on a contract question any more — that half is settled. The
+  // maintainer ruled Option B (2026-08-22) and objectui#5494 landed it:
+  // `ReferenceRailEntry` is now DERIVED from `@objectstack/spec/ui`
+  // (re-exported, never re-declared — `check:spec-symbols` enforces that), and
+  // the `icon` key the old local interface carried retired with the
+  // derivation. The spec's `ReferenceRailEntrySchema` is `$strict` over
+  // {objectName, relationshipField, title?, limit?, displayField?} and refuses
+  // `icon` at save, so it survives on neither side of the contract.
+  //
+  // The note this replaces also asserted that the renderer READ that key. It
+  // did not — that premise was false when it was written, which is the whole
+  // reason this block was rewritten (objectui#5792). Measured twice,
+  // independently: the spec's `ui-reference-rail-unknown-keys-refused`
+  // migration entry, and a grep over `plugin-detail/src` where the only
+  // surviving `icon` mention in `record-reference-rail.tsx` is prose, while the
+  // same grep finds real reads of `entry.objectName`, `.relationshipField`,
+  // `.title`, `.limit` and `.displayField`. So the SHAPE limit above is the
+  // entire justification for this exemption — it always was sufficient alone.
   'record:reference_rail.entries':
-    'An array of {objectName, relationshipField, title, limit, displayField} objects; `inputs` is a flat scalar carrier and cannot express it. Newly judged rather than newly missing — @objectstack/spec 17.1.0 added record:reference_rail to ComponentPropsMap, and the registration (plugin-detail/src/index.tsx:675) has always published only `hideEmpty`. An entries editor also needs the `icon` divergence settled first: objectui#5494.',
+    'An array of {objectName, relationshipField, title, limit, displayField} objects; `inputs` is a flat scalar carrier and cannot express it. Newly judged rather than newly missing — @objectstack/spec 17.1.0 added record:reference_rail to ComponentPropsMap, and the registration (plugin-detail/src/index.tsx:675) has always published only `hideEmpty` — the 17.1.0 pin, objectui#5328. The flat-carrier shape limit is the entire reason: the `icon` divergence that once also blocked an entries editor was settled by Option B (maintainer 2026-08-22, objectui#5494).',
 };
 
 /**


### PR DESCRIPTION
Fixes #5792

Stale-prose cleanup of the #4918 class. Two pieces of comment text in
`apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` were written
while objectui#5494 was an **open contract question**. That question has since
been ruled (Option B, maintainer 2026-08-22) and the derivation landed, so both
pieces are stale — and one of them was false when it was written.

The exemption itself is **unchanged**. `inputs` is a flat scalar carrier and
cannot express an array of objects; that was always the sufficient justification
and it is all that remains stated.

## What changed

1. **Comment block above the exemption** (now lines 717-734). Dropped "Also
   blocked on a real contract question" and the claim that the local
   `ReferenceRailEntry` declares an `icon` key "the renderer reads". Replaced
   with the post-ruling facts plus the measurement behind them.
2. **The exemption reason string.** Dropped the trailing sentence "An entries
   editor also needs the `icon` divergence settled first". The provenance
   sentence now cites the 17.1.0 pin (objectui#5328) — see the deviation note
   below for why an issue reference had to stay.
3. A changeset with **empty frontmatter** — this repo's "releases nothing"
   declaration, which `scripts/check-changeset-presence.mjs` accepts explicitly.

## The "renderer reads it" premise — measured, not repeated

This card exists because the previous comment asserted a renderer read that did
not exist, so the replacement text was verified rather than restated.

**Probe** — the only `icon` occurrence left in
`packages/plugin-detail/src/renderers/record-reference-rail.tsx` is prose (a
comment saying no render path read it). `packages/plugin-detail/src/synth/buildDefaultPageSchema.ts:934`
independently records that emitting `rel.icon` wrote a key the strict schema
refuses.

**Counter-probe**, same grep method, same file — these keys of
`ReferenceRailEntry` *do* have real reads, which is what makes the null result
above a genuine absence rather than a broken probe:

| key | read at |
| --- | --- |
| `objectName` | `record-reference-rail.tsx:175, 184, 186, 262, 267, 284, 310` |
| `relationshipField` | `:187, 284` |
| `limit` | `:188` |
| `title` | `:265` |
| `displayField` | `:308` |

## Deviation from the dispatch's assumption: the reason string is NOT inert

The dispatch assumed only the map's **keys** are asserted
(`Object.keys(UNPUBLISHED_EXEMPTIONS)`), making the reason text prose to the
gate. Measured on the merge-base, that is **not true**: the test `every
unpublished-key exemption states a reason and references a tracking issue`
(line ~1129) does `Object.entries(UNPUBLISHED_EXEMPTIONS).filter(([, reason]) => !/#\d+/.test(reason))`
— it reads the reason and requires an issue reference. The pre-edit reason's
only such reference was the very `objectui#5494` mention being retired, so a
naive trim to the surviving first sentence would have gone red. The reason
therefore keeps a tracking reference, now the 17.1.0 pin.

**Ablation proving that** (not theatre — it has a real verdict): stripping every
issue reference from this one reason string turns the suite red on exactly that
test and nothing else.

```
ABLATED_VITEST_EXIT=1
 Tests  1 failed | 74 passed (75)
 x  ... > every unpublished-key exemption states a reason and references a tracking issue
```

Mutation was confirmed on disk before the run (injected marker present, removed
text absent, zero `#`-digit sequences left on the reason line) and the restore
leg ran under `trap ... EXIT INT TERM` with a cwd-independent restore, verified
afterwards. No rebuild step applies — vitest resolves this app suite from source,
not from a package `dist/`.

## Gates, all at final head `e9be2bdbf`

| gate | exit | verdict line |
| --- | --- | --- |
| `pnpm exec vitest run apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` (root form) | 0 | `Test Files  1 passed (1)` / `Tests  75 passed (75)` |
| `pnpm --filter @object-ui/console type-check` | 0 | script name echoed as `type-check`; no `Cannot find module '@object-ui/...'` (closure built) and no missing-`node_modules` signature |
| `pnpm exec eslint src/__tests__/registry-inputs-spec-parity.test.ts` (in `apps/console`) | 0 | 1 file, 0 errors, 0 warnings — merge-base delta 0/0, same file linted at `origin/main` also 0/0 |
| `node scripts/check-changeset-presence.mjs` | 0 | empty frontmatter accepted as "releases nothing" |

**Test count and names unchanged:** 75 before, 75 after; the sorted list of test
names diffs clean against the pre-edit baseline (`diff` exit 0). **Exemption
integrity:** the map's key list is byte-identical before and after (11 keys, same
order) and `'record:reference_rail.entries':` is still present and still keyed
the same way — the edit landed only in the comment block above it and in that
entry's value.

Draft on purpose: not ready, not enqueued, no auto-merge — the PM lands it.

_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_