### PR TITLE
ComponentMeta: re-export the one declaration, then deprecate PluginComponentMeta at its final meaning

### DIFF
--- a/.changeset/component-meta-converge-and-deprecate-alias-5893.md
+++ b/.changeset/component-meta-converge-and-deprecate-alias-5893.md
@@ -1,0 +1,70 @@
+---
+'@object-ui/types': minor
+---
+
+`ComponentMeta` is now declared once and re-exported, and `PluginComponentMeta` is
+deprecated in favour of `ComponentMeta` (objectui#5893).
+
+## The convergence
+
+`@object-ui/types` published `ComponentMeta` twice, from two different declarations:
+`base.ts` and `plugin-scope.ts` (the latter published as `PluginComponentMeta`). They
+were structural copies, not an alias pair. `plugin-scope.ts`' `ComponentMeta` is now
+`export type { ComponentMeta } from './base.js'` — the disposition objectui#4580 ruled
+for the identical shape, *a structural copy would reproduce the defect the moment either
+side moved*, and the same move objectui#5671 made for the sibling type `ComponentInput`
+in the same file.
+
+Either side had already moved. `base.ts` declared eleven keys; the plugin-scoped copy
+declared nine — the same nine, **minus `tags` and `description`**. So a plugin author
+typing against the plugin-facing declaration could not write two keys the main surface
+advertises, and which the runtime validator already accepted: `ComponentMetaSchema` in
+`zod/base.zod.ts` declares all eleven, so two of the three authorities agreed and the
+plugin-facing one did not. `resizeConstraints`' six members were identical in both, so
+the delta was exactly those two keys.
+
+What changes for a consumer: `tags` and `description` become writable on the
+plugin-facing type. Nothing narrows — no key is removed and no key's type changes, so no
+existing registration stops compiling. The convergence buys **acceptance** of two keys;
+it buys no rejection of anything. `ComponentMetaSchema` is a plain `z.object` with no
+`.strict()`, so it strips unknown keys rather than refusing them, and that is unchanged
+here.
+
+## The alias deprecation, sequenced after it
+
+`PluginComponentMeta` — the published alias for the plugin-scoped declaration — is now
+`@deprecated` in favour of `ComponentMeta`. **`PluginComponentMeta` is the name to search
+for** if you import it; replace it with `ComponentMeta` from the same entry point.
+
+This is stage 1 of objectui#5674's two-stage retirement (maintainer ruling, 2026-08-22:
+deprecate for a release, then remove). Nothing is removed here — the export still exists
+and still names the same type.
+
+The ordering is deliberate and is why the two halves ship together. Until the convergence
+above, the alias named a genuinely different nine-key interface; deprecating it then
+would have warned consumers about a name that was still about to change meaning. It is
+deprecated now, at its final meaning.
+
+**Why a deprecation window rather than a deletion.** The measurement that licenses
+deleting an export from a published package is *"no importer"*, and what can be measured
+from inside this repository is only *"no importer here"*. In-repo, `PluginComponentMeta`
+has exactly one occurrence — its own export line — searched across every root
+(`packages/`, `apps/`, `content/`, `docs/`, `skills/`, `examples/`, `e2e/`, `scripts/`,
+`eslint-rules/`, `public/`, `.changeset/` and the root docs) plus the sibling
+`objectstack` framework checkout, with controls searched identically so a broken search
+could not read as a clean one. What no search here can see is a consumer on npm. **That
+external caveat is unchanged from objectui#5674 and is not being dropped:** the window
+converts a silent break into a warned one before stage 2 lands. Stage 2 removes the alias
+and the now-dead re-export in `plugin-scope.ts` that exists only to feed it, and ships as
+a `minor` under this repo's policy that its own breaking changes never declare `major`.
+
+## Pinned by identity, not by member set
+
+A new test asserts that `plugin-scope.ts` re-exports the declaration and declares no
+`ComponentMeta` of its own. A member-set assertion cannot do this job: TypeScript is
+structurally typed, so a local re-declaration carrying the same eleven keys is mutually
+assignable with the imported one and passes every type-level check. A member-identical
+structural copy is exactly what objectui#4580 predicted would drift and exactly the state
+this card recorded — this copy started identical and acquired its two-key delta later.
+The member-set checks are kept alongside the identity pin, labelled as the control that
+shows what it cannot see.

--- a/packages/types/src/__tests__/component-meta-single-declaration.test.ts
+++ b/packages/types/src/__tests__/component-meta-single-declaration.test.ts
@@ -1,0 +1,250 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Convergence pin — `ComponentMeta` has ONE declaration (objectui#5893), and
+ * the second published name for it is deprecated.
+ *
+ * ## What was wrong
+ *
+ * `index.ts` published `ComponentMeta` twice, from two different declarations:
+ * `base.ts` (eleven keys) and `plugin-scope.ts` (nine — the same nine, minus
+ * `tags` and `description`). They were structural COPIES, not an alias pair.
+ * The runtime validator `ComponentMetaSchema` (`zod/base.zod.ts`) declares all
+ * eleven, so two of the three authorities agreed and the plugin-facing one did
+ * not: a plugin author typing against it could not write two keys the main
+ * surface and the validator both advertise.
+ *
+ * That is objectui#4580's ruling coming true rather than being cited — *"a
+ * structural copy would reproduce the defect the moment either side moved"* —
+ * and objectui#5671 had already executed the identical convergence for the
+ * sibling type `ComponentInput` in the same file.
+ *
+ * ## Why this pins the DIVERGENCE and not the resulting shape
+ *
+ * The obvious test — assert both spellings carry the same member set — is
+ * NOT sufficient, and the file below demonstrates why rather than asserting
+ * it. TypeScript is structurally typed: a local `interface ComponentMeta`
+ * re-declaring the same eleven keys is mutually assignable with the imported
+ * one, so every type-level check passes on it. A member-identical structural
+ * copy is EXACTLY the state objectui#4580 predicted would drift, and exactly
+ * the state this card is the proof of — the copy here started member-identical
+ * and acquired its two-key delta later.
+ *
+ * So the load-bearing assertion is an IDENTITY pin: `plugin-scope.ts` must
+ * RE-EXPORT the declaration and must not declare a `ComponentMeta` of its own.
+ * The member-set checks are kept alongside it, labelled, as the control that
+ * shows the identity pin catches something they cannot.
+ *
+ * ## Why the identity half reads SOURCE TEXT
+ *
+ * Two reasons, the first structural and the second practical.
+ *
+ * There is no type-level operator that distinguishes "the same declaration"
+ * from "an identical declaration" — structural identity is the whole point of
+ * TypeScript's type system, and `keyof`-based comparisons erase the difference
+ * by construction. The distinction survives only in the source and in the
+ * emitted `.d.ts` (a re-export line versus an `interface` body).
+ *
+ * And the emitted `.d.ts` is not available here: this repo's per-PR `test` job
+ * runs `pnpm test` with no build of the package under test ahead of it (turbo's
+ * `test` task `dependsOn: ["^build"]` — the DEPENDENCY closure, never the
+ * package's own build). A test requiring a fresh `dist/` would be vacuously
+ * absent-or-red on a cold cache, not a signal. Same constraint
+ * `plugin-component-input-deprecation.test.ts` and
+ * `package-exports-manifest.test.ts` record, same resolution.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { ComponentMetaSchema } from '../zod/base.zod.js';
+import type { ComponentMeta } from '../base.js';
+import type { ComponentMeta as PluginScopeComponentMeta } from '../plugin-scope.js';
+import type { ComponentMeta as IndexComponentMeta, PluginComponentMeta } from '../index.js';
+
+const PLUGIN_SCOPE_SRC = readFileSync(
+  fileURLToPath(new URL('../plugin-scope.ts', import.meta.url)),
+  'utf8',
+);
+
+const INDEX_SRC = readFileSync(
+  fileURLToPath(new URL('../index.ts', import.meta.url)),
+  'utf8',
+);
+
+/** The re-export line that makes `plugin-scope.ts` share `base.ts`' declaration. */
+const RE_EXPORT = "export type { ComponentMeta } from './base.js';";
+
+/**
+ * Any LOCAL declaration of the name, exported or not. The re-export form
+ * (`export type { ComponentMeta } from …`) cannot match: the brace after
+ * `type` is not the identifier.
+ */
+const LOCAL_DECLARATION = /^\s*(?:export\s+)?(?:interface|type|class)\s+ComponentMeta\b/m;
+
+describe('ComponentMeta — the identity pin (the assertion a structural copy fails)', () => {
+  it('plugin-scope.ts re-exports the declaration from base.ts', () => {
+    expect(PLUGIN_SCOPE_SRC).toContain(RE_EXPORT);
+  });
+
+  it('plugin-scope.ts declares no ComponentMeta of its own', () => {
+    // THIS is the pin. It goes red on a local re-declaration even when that
+    // re-declaration is member-identical — which is the case every type-level
+    // assertion below stays green on, and the case objectui#4580 ruled about.
+    expect(PLUGIN_SCOPE_SRC).not.toMatch(LOCAL_DECLARATION);
+  });
+
+  it('base.ts is the declaration site, so the pin is not vacuous', () => {
+    // Control for the regex itself: the same pattern MUST match where the one
+    // declaration actually lives. A pattern that matched nothing anywhere
+    // would pass the assertion above on any tree, including a re-diverged one.
+    const BASE_SRC = readFileSync(
+      fileURLToPath(new URL('../base.ts', import.meta.url)),
+      'utf8',
+    );
+    expect(BASE_SRC).toMatch(LOCAL_DECLARATION);
+  });
+});
+
+describe('ComponentMeta — the member-set control (green on a structural copy, kept to show the contrast)', () => {
+  it('is mutually assignable across both spellings', () => {
+    // Type-level, and really compiled: `packages/types/tsconfig.test.json` is
+    // chained from this package's `type-check` script (#3009). It is ALSO
+    // exactly what a member-identical local copy would satisfy — recorded here
+    // as the control, not as the guarantee.
+    const bothWays: [
+      PluginScopeComponentMeta extends ComponentMeta ? true : false,
+      ComponentMeta extends PluginScopeComponentMeta ? true : false,
+    ] = [true, true];
+
+    expect(bothWays).toEqual([true, true]);
+  });
+
+  it('reaches the published entry point under both names', () => {
+    const published: [
+      PluginComponentMeta extends IndexComponentMeta ? true : false,
+      IndexComponentMeta extends PluginComponentMeta ? true : false,
+    ] = [true, true];
+
+    expect(published).toEqual([true, true]);
+  });
+});
+
+describe('ComponentMeta — the two keys the convergence delivers', () => {
+  it('lets a plugin registration write `tags` and `description`', () => {
+    // The counter-probe the convergence has to survive: a consumer legitimately
+    // using the converged type must still type-check. "The duplicate is gone"
+    // is otherwise satisfiable by breaking the type for everyone.
+    //
+    // Before objectui#5893 the two annotated keys were a plain TS error on this
+    // spelling and legal on `base.ts`' — the divergence, at a call site.
+    const registration: PluginScopeComponentMeta = {
+      label: 'Kanban Board',
+      icon: 'layout-board',
+      category: 'data',
+      inputs: [{ name: 'columns', type: 'array' }],
+      isContainer: false,
+      resizable: true,
+      tags: ['board', 'kanban'],
+      description: 'Drag-and-drop board view over a grouped dataset.',
+    };
+
+    expect(registration.tags).toEqual(['board', 'kanban']);
+    expect(registration.description).toBe(
+      'Drag-and-drop board view over a grouped dataset.',
+    );
+  });
+
+  it('agrees with the runtime validator, which already carried both keys', () => {
+    // The zod mirror is the third authority and it never diverged: it declared
+    // `tags` and `description` throughout. The convergence brings the plugin
+    // face up to it rather than moving it.
+    //
+    // Note what this does NOT assert: `ComponentMetaSchema` is a plain
+    // `z.object` with no `.strict()`, so it STRIPS unknown keys rather than
+    // rejecting them (measured on zod 4.4.3 by
+    // `default-children-retired-contract-twins.test.ts`). The convergence buys
+    // ACCEPTANCE of two keys on the plugin-facing type; it buys no rejection of
+    // anything, here or anywhere else.
+    const parsed = ComponentMetaSchema.safeParse({
+      label: 'Kanban Board',
+      tags: ['board', 'kanban'],
+      description: 'Drag-and-drop board view over a grouped dataset.',
+    });
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toHaveProperty('tags', ['board', 'kanban']);
+    expect(parsed.data).toHaveProperty(
+      'description',
+      'Drag-and-drop board view over a grouped dataset.',
+    );
+  });
+});
+
+/**
+ * The JSDoc block immediately preceding an export specifier, or `null` when the
+ * specifier is not preceded by one. Anchored to the specifier rather than
+ * searching the file for `@deprecated`: this package has many unrelated
+ * deprecations and a file-wide search would go green on any of them.
+ *
+ * Same helper, same reasoning, as `plugin-component-input-deprecation.test.ts`.
+ */
+function docBlockBefore(specifier: string): string | null {
+  const at = INDEX_SRC.indexOf(specifier);
+  if (at === -1) return null;
+  const before = INDEX_SRC.slice(0, at);
+  const close = before.lastIndexOf('*/');
+  // Only whitespace may sit between the block and the specifier, otherwise the
+  // block belongs to some earlier specifier and says nothing about this one.
+  if (close === -1 || before.slice(close + 2).trim() !== '') return null;
+  const open = before.lastIndexOf('/**', close);
+  if (open === -1) return null;
+  return before.slice(open, close + 2);
+}
+
+/** The published alias specifier, exactly as `index.ts` spells it. */
+const ALIAS = 'ComponentMeta as PluginComponentMeta,';
+
+describe('PluginComponentMeta — stage 1: deprecated, at its final meaning', () => {
+  it('is still published (deprecating is not deleting)', () => {
+    // In-repo the name has zero importers; what cannot be measured from inside
+    // this repository is an importer on npm, and the window is the answer to
+    // that unmeasurable half. Stage 2 removes it.
+    expect(INDEX_SRC).toContain(ALIAS);
+  });
+
+  it('carries a JSDoc block attached to the alias specifier itself', () => {
+    expect(docBlockBefore(ALIAS)).not.toBeNull();
+  });
+
+  it('tags that block `@deprecated`', () => {
+    expect(docBlockBefore(ALIAS)).toContain('@deprecated');
+  });
+
+  it('names the replacement, so the warning is actionable', () => {
+    expect(docBlockBefore(ALIAS)).toMatch(/`ComponentMeta`/);
+  });
+
+  it('does not deprecate its neighbours in the same export block', () => {
+    // Control: the tag must attach to ONE specifier. A block comment widened
+    // to cover the whole `export type { … }` group would make every
+    // plugin-scope name read as deprecated.
+    expect(docBlockBefore('AppMetadataPlugin,')).toBeNull();
+    expect(docBlockBefore('PluginEventHandler,')).toBeNull();
+  });
+
+  it('is deprecated only AFTER the convergence — the ordering is the point', () => {
+    // Sequencing pin. Deprecating the alias while it still named a separate
+    // nine-key declaration would have warned consumers about a name that was
+    // about to change meaning. The tag is only honest because the re-export
+    // above it is in place, so the two facts are asserted together.
+    expect(PLUGIN_SCOPE_SRC).toContain(RE_EXPORT);
+    expect(docBlockBefore(ALIAS)).toContain('@deprecated');
+  });
+});

--- a/packages/types/src/__tests__/default-children-retired-contract-twins.test.ts
+++ b/packages/types/src/__tests__/default-children-retired-contract-twins.test.ts
@@ -27,6 +27,20 @@
  * The Registry twin (`@object-ui/core`) is pinned in that package instead, so
  * this suite does not have to import its own dependent.
  *
+ * ⚠️ UPDATED by objectui#5893: item 3 is no longer a separate declaration.
+ * `plugin-scope.ts` now RE-EXPORTS `base.ts`' `ComponentMeta` (the objectui#4580
+ * convergence, following objectui#5671's execution for `ComponentInput`), so
+ * the third case below no longer exercises a second declaration — it exercises
+ * a second published SPELLING of the first, which is a real consumer-facing
+ * fact only for as long as the deprecated `PluginComponentMeta` alias exists.
+ * It is deliberately kept rather than deleted: while the alias is published, an
+ * author can still reach the type by that name, and the pin costs one
+ * `@ts-expect-error`. Drop it together with the alias in objectui#5674's
+ * stage 2. Whether the declaration stays single is pinned separately and by
+ * identity, in `component-meta-single-declaration.test.ts` — a member-set
+ * assertion cannot see a structural copy, which is the defect this file was
+ * paying for.
+ *
  * Two kinds of assertion, deliberately different because the surfaces differ:
  *
  * The Zod half is NOT a refusal. Measured on zod 4.4.3, a `z.object` STRIPS
@@ -135,7 +149,10 @@ describe('the published TS twins no longer offer the retired key', () => {
     const retired: PluginScopeComponentMeta = {
       label: 'Span',
       // @ts-expect-error `defaultChildren` was retired by objectui#5051; the
-      // plugin-facing twin spelt it `any[]` and is retired in lockstep.
+      // plugin-facing twin spelt it `any[]` and was retired in lockstep. Since
+      // objectui#5893 this spelling re-exports `base.ts`' declaration, so the
+      // error above is the SAME one the case above pins, reached by the second
+      // published name.
       defaultChildren: [{ type: 'text', content: 'Inline text' }],
     };
     expect(retired.label).toBe('Span');

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -939,6 +939,21 @@ export type {
   PluginScopeConfig,
   AppPluginContext,
   AppMetadataPlugin,
+  /**
+   * @deprecated Use `ComponentMeta` instead. Since objectui#5893 converged the
+   * plugin-scoped declaration onto `base.ts`, this alias names the SAME type
+   * under a second name — it carries no information `ComponentMeta` does not.
+   * Before that convergence it named a genuinely different nine-key interface,
+   * which is why it is deprecated only now and not alongside
+   * `PluginComponentInput`: deprecating it earlier would have warned about a
+   * name that was still about to change meaning. Retirement follows
+   * objectui#5674's two-stage pattern (maintainer ruling, 2026-08-22:
+   * deprecate for a release, then remove). This deprecation window exists for
+   * consumers outside this repository, which cannot be measured from here;
+   * in-repo the name has zero importers. Removal ships as a `minor` under this
+   * repo's version policy (objectui's own breaking changes never declare
+   * `major`).
+   */
   ComponentMeta as PluginComponentMeta,
   /**
    * @deprecated Use `ComponentInput` instead. Since objectui#4972 converged the

--- a/packages/types/src/plugin-scope.ts
+++ b/packages/types/src/plugin-scope.ts
@@ -16,7 +16,7 @@
  * @packageDocumentation
  */
 
-import type { ComponentInput } from './base.js';
+import type { ComponentMeta } from './base.js';
 
 /**
  * Plugin Scope Interface
@@ -145,25 +145,36 @@ export interface PluginScope {
 
 /**
  * Component metadata for registration
+ *
+ * The plugin-scoped twin of `base.ts`' {@link ComponentMeta} is no longer a
+ * twin: it is the SAME declaration, RE-EXPORTED rather than restated
+ * (objectui#5893), following the shape objectui#5671 executed for the sibling
+ * type `ComponentInput` in this same file. This is objectui#4580's ruling
+ * applied to the second member of the family — *a structural copy would
+ * reproduce the defect the moment either side moved.*
+ *
+ * Either side HAD moved, which is why this was not hypothetical. `base.ts`
+ * carried eleven keys; this copy carried nine — `tags` and `description` were
+ * missing here. A plugin author typing against the plugin-facing declaration
+ * could not write two keys the main surface advertises, and which the runtime
+ * validator (`ComponentMetaSchema` in `zod/base.zod.ts`) already accepted: two
+ * of the three authorities agreed and this one did not. Nothing a user hits
+ * was broken today, because no plugin registration had tried to write one yet.
+ *
+ * Re-exported under this name so that `index.ts`' public
+ * `ComponentMeta as PluginComponentMeta` alias keeps naming a real export.
+ * That alias is `@deprecated` as of the same card, on objectui#5674's pattern:
+ * with the declaration shared, the second published name carries no
+ * information the first does not.
+ *
+ * Note for whoever completes that retirement: this re-export is a SEPARATE
+ * binding from the `import type { ComponentMeta }` at the top of the file. The
+ * import is what types `PluginScope.registerComponent`'s `meta` parameter and
+ * stays regardless; this re-export's only consumer is the aliased specifier in
+ * `index.ts`, so it goes dead the moment that alias is deleted and should be
+ * removed with it.
  */
-export interface ComponentMeta {
-  label?: string;
-  icon?: string;
-  category?: string;
-  inputs?: ComponentInput[];
-  defaultProps?: Record<string, any>;
-  examples?: Record<string, any>;
-  isContainer?: boolean;
-  resizable?: boolean;
-  resizeConstraints?: {
-    width?: boolean;
-    height?: boolean;
-    minWidth?: number;
-    maxWidth?: number;
-    minHeight?: number;
-    maxHeight?: number;
-  };
-}
+export type { ComponentMeta } from './base.js';
 
 /**
  * Component input definition
@@ -179,11 +190,14 @@ export interface ComponentMeta {
  * That alias is now `@deprecated` (objectui#5674): with the declaration shared,
  * the second published name carries no information the first does not.
  *
- * Note for whoever completes that retirement: this re-export is a SEPARATE
- * binding from the `import type { ComponentInput }` at the top of the file.
- * The import is what types `ComponentMeta.inputs` and stays regardless; this
- * re-export's only consumer is the aliased specifier in `index.ts`, so it goes
- * dead the moment that alias is deleted and should be removed with it.
+ * Note for whoever completes that retirement: this file no longer imports
+ * `ComponentInput` by name at all. Until objectui#5893 it did, to type the
+ * local `ComponentMeta.inputs`; that local declaration is now itself a
+ * re-export, so this line is the ONLY mention left and its only consumer is
+ * the aliased specifier in `index.ts`. It goes dead the moment that alias is
+ * deleted and should be removed with it — unlike the `ComponentMeta`
+ * re-export above, whose sibling `import type` is still load-bearing for
+ * `PluginScope.registerComponent`.
  */
 export type { ComponentInput } from './base.js';
 


### PR DESCRIPTION
Fixes #5893

Direction **(b)** as ruled: converge, then retire — in that order.

`packages/types/src/plugin-scope.ts`' `ComponentMeta` becomes `export type { ComponentMeta } from './base.js'`, and the published alias `ComponentMeta as PluginComponentMeta` is then deprecated at its final meaning. This inherits #4580's ruling with its reason — *"a structural copy would reproduce the defect the moment either side moved"* — and follows **#5671**'s executed shape for the sibling type `ComponentInput`, in the same file. No second convergence shape was invented: the diff is line-for-line the move #5671 made, one type over.

## The STOP condition was looked for first, and is not present

The ruling's stop was: *if the plugin surface deliberately excludes `tags`/`description`, stop and report.* Searched before converging, in the four places named:

| where | result |
|---|---|
| `plugin-scope.ts`' module header (`@module plugin-scope`, "Section 3.3: Plugin scope isolation types") | scope isolation only — nothing about metadata field selection |
| the declaration's own docblock | one line: `Component metadata for registration`. No exclusion, no reason |
| #4580's thread (all 5 comments) | rules on `SchemaNode`, label vocabulary, `visible`/`disabled`. `ComponentMeta` not mentioned |
| repo-wide ADR/doc grep for deliberate-omission language | hits are unrelated (`page-app-dashboard-spec-parity.test.ts`' spec-key omissions, an `objectql.ts` `viewMode` note) |

And the positive evidence runs the other way: **the zod mirror never diverged.** `ComponentMetaSchema` (`packages/types/src/zod/base.zod.ts:298`) declares all eleven keys including `tags` and `description`. Two of the three authorities carried them and the plugin-facing declaration did not — drift, not design. Converging.

## The delta, re-derived on this merge-base (`efa70ecb2`), key by key

`packages/types` moved five times on 2026-08-23/24, so this is measured here rather than carried from the card.

| key | `base.ts:511` | `plugin-scope.ts:149` | `ComponentMetaSchema` |
|---|:--:|:--:|:--:|
| `label` `icon` `category` `inputs` `defaultProps` `examples` `isContainer` `resizable` | ✅ ×8 | ✅ ×8 | ✅ ×8 |
| `resizeConstraints` | ✅ (6 members) | ✅ (same 6) | ✅ (same 6) |
| **`tags`** | ✅ `string[]` | ❌ | ✅ `z.array(z.string())` |
| **`description`** | ✅ `string` | ❌ | ✅ `z.string()` |
| totals | **11** | **9** | **11** |

**The delta is unchanged since the card was filed: exactly two keys, same two, neither grown nor closed.** `resizeConstraints`' six members verified identical, so the two-key delta is the whole of it.

## Consumers of `PluginComponentMeta`, re-measured with controls

Same method for probe and controls — `grep -rn`, excluding `node_modules/`, `dist/`, `.git/`, over every root present in the tree (`packages/ apps/ content/ docs/ skills/ examples/ e2e/ scripts/ eslint-rules/ public/ .changeset/` and root docs), plus the sibling `objectstack` framework checkout.

| name | hits | reading |
|---|--:|---|
| `PluginComponentMeta` (probe) | **1** | its own export line, `packages/types/src/index.ts:942`. Nothing imports it |
| `AppMetadataPlugin` (control — neighbour in the same `export type { … }` block) | 13 | includes a real cross-package import, `packages/core/src/registry/PluginSystem.ts:10` |
| `PluginComponentInput` (control — the sibling alias #5674 deprecated) | 13 | found by the same apparatus |
| `PluginComponentMeta` in `objectstack` checkout | 0 | with controls there: `@object-ui/types` 23 files, `SchemaRenderer` 36 files |

A zero with an apparatus that demonstrably finds names that are there.

**⚠️ In-repo zero is not npm zero, and that caveat is not being dropped.** It is restated in the changeset in full. This is why the alias is **deprecated, not deleted** — #5674's two-stage pattern (maintainer ruling, 2026-08-22: deprecate for a release, then remove). Stage 2 removes the alias and the now-dead `ComponentInput`/`ComponentMeta` re-exports in `plugin-scope.ts` that exist only to feed the aliases.

**Why the ordering is load-bearing.** Until this PR the alias named a genuinely different nine-key interface. Deprecating it first would have told consumers to stop using a name that was still about to change meaning. It is tagged now, at its final meaning — and a test asserts those two facts *together* so the sequence cannot be undone by halves.

## Verification: the divergence is pinned by IDENTITY, not by member set

New file: `packages/types/src/__tests__/component-meta-single-declaration.test.ts` (13 tests).

The load-bearing assertion is that `plugin-scope.ts` **declares no `ComponentMeta` of its own** and re-exports `base.ts`'. A member-set assertion cannot do this job, and the file says so rather than assuming it: TypeScript is structurally typed, so a local re-declaration carrying the same eleven keys is mutually assignable with the imported one. A member-identical structural copy is exactly what #4580 predicted would drift, and exactly what this card is the proof of — this copy started identical and acquired its two-key delta later.

### Ablation — direction predicted before running, and one prediction was wrong

Prediction, written to `PREDICTION.txt` before any mutation: replacing the re-export with a **member-identical** local `export interface ComponentMeta` (all eleven keys) turns the identity pin **red** while every member-set / type-level assertion stays **green**, and `type-check` stays green.

**Leg 1 — vitest.** Matched exactly: **3 failed | 10 passed**.

| red (3) | green (10, selected) |
|---|---|
| identity pin › *re-exports the declaration from base.ts* | member-set control › *is mutually assignable across both spellings* |
| identity pin › *declares no ComponentMeta of its own* | member-set control › *reaches the published entry point under both names* |
| deprecation › *is deprecated only AFTER the convergence* | counter-probe › *lets a plugin registration write `tags` and `description`* |
| | identity pin › *base.ts is the declaration site* (regex non-vacuity control — stayed green, so the pin is not matching-nothing) |

**Leg 1's type-check read was CONFOUNDED and its prediction was wrong.** I predicted exit 0; it exited **2**, with `src/plugin-scope.ts(19,15): error TS2440: Import declaration conflicts with local declaration of 'ComponentMeta'`. That red is an artifact of my mutation leaving the file's top-of-file `import type { ComponentMeta }` in place beside the injected local declaration — a name collision, saying nothing about whether the member-set assertions can see a structural copy. Reported rather than quietly re-rolled.

**Leg 2 — the controlled repeat.** Same member-identical interface, and the colliding import removed as well (which is precisely the pre-#5893 file shape, plus the two keys). Read: `pnpm --filter @object-ui/types type-check` → **exit 0, green**, its own verdict line clean across all three `tsc` invocations.

That is the decisive measurement. **Every type-level assertion in the suite — mutual assignability both ways, the published-entry-point check, and the `tags`/`description` counter-probe — compiles clean against a re-declared copy.** Only the source-level identity pin sees it. Which is the contrast the pin exists for.

Ablation hygiene, both legs: anchor uniqueness asserted before writing (`count == 1`, asserted inside the mutation script so a missed anchor aborts rather than silently no-ops); landing site printed (`plugin-scope.ts:177` / `:176`); the mutation proved on disk by grepping the **injected** text and **separately** the **removed** text, never by an editor exit code; restore under `trap … EXIT INT TERM` using **absolute paths only, no `cd`**, so it is cwd-independent; and restore *verified* afterwards rather than assumed — the restored file is **sha256-identical** to the pre-mutation backup, and `git status --porcelain` shows only the five intended files.

No package boundary is crossed by this ablation and no `dist/` is involved: the pin reads `../plugin-scope.ts` **source**, and the type imports resolve to `src/` under vitest. Stated because it is the reason no rebuild-between-mutation-and-read step appears here — not an omission of one.

### Counter-probe: consumers still type-check

"The duplicate is gone" must not be satisfiable by breaking the type for everyone.

- In-suite: a realistic plugin registration writing `label` `icon` `category` `inputs` `isContainer` `resizable` **`tags` `description`** against the plugin-scoped spelling compiles and its values round-trip. Those two keys were a plain TS error on this spelling before this PR.
- At scale: the downstream sweep below, **43 packages, all green**.

## Gates, each read from its own verdict line, all on the final commit `3640aba1a`

`git status --porcelain` was empty when these ran, so they read the committed tree.

| gate | exit | verdict |
|---|--:|---|
| `pnpm --filter @object-ui/types type-check` (script name echoed: `type-check`, hyphenated) | **0** | `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json` — all three. The third is why the type-level assertions and `@ts-expect-error`s are real enforcement |
| `pnpm exec vitest run packages/types/src --maxWorkers=2` (root form) | **0** | `Test Files 56 passed (56) · Tests 619 passed (619)` |
| the new suite alone, `--reporter=verbose` | **0** | 13 passed, each named — confirming it actually ran rather than zero-matching |
| `pnpm --workspace-concurrency=4 --filter '...@object-ui/types' build` | **0** | 42 distinct packages executed; zero `error TS`, zero `ERR_PNPM` |
| `pnpm exec eslint .` in `packages/types` (plain, no `--no-inline-config`) | **0** | `242 problems (0 errors, 242 warnings)` — all pre-existing `no-explicit-any` |
| `check:control-bytes` | **0** | `✅ OK (scanned 5013 tracked text file(s); skipped 85 binary)` |
| `check-changeset-presence` | **0** | `✅ 4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` | **0** | `✅ All workspace packages are in the changeset fixed group` |
| `check-changeset-no-major` | **0** | `✅ No changeset declares a major bump` |
| `check:esm-specifiers` | **0** | `no un-ledgered package emits an extensionless relative specifier` |
| `check:self-import` | **0** | `✅ No package names itself inside its own src/` (44 packages, 16798 specifiers) |
| `check:phantom-deps` | **0** | `✅ Every in-scope import is declared by the package that publishes it` |
| `check:doc-types` | **0** | `✅ Every documented component type is registered` |
| `check:published-dist` | **0** | `✅ No published package's build output carries tooling material` |

Exit codes captured **before** any pipe (`cmd > log 2>&1; EXIT=$?`), never from a `$?` following a `tail`.

**Notes on two gates.**

*The downstream sweep direction is **downstream*** — `--filter '...@object-ui/types'` is the **prefix** form, i.e. the 43 packages that **depend on** `@object-ui/types`. That is the correct direction for a contract change in this package: the widened type flows to consumers. `@object-ui/react-runtime` was built separately first, per the gotcha measured on #5927 — it does not depend on `@object-ui/types`, so it is never in the prefix closure, and without it `apps/site` and `packages/components` fail for reasons unrelated to any change. Not a finding; just the prerequisite.

*Nothing is claimed about rejection.* Per #6058: `check:zod-mirror-parity` **is not a gate in this repository** — grepped `.github/workflows/`, `scripts/`, and root `package.json`, zero hits — so there is no ratchet here to over-credit for a TS-side-only change. And independently of that: `ComponentMetaSchema` is a plain `z.object` with no `.strict()`, so it **strips** unknown keys rather than refusing them (measured on zod 4.4.3 by `default-children-retired-contract-twins.test.ts`). **This convergence buys ACCEPTANCE of two keys on the plugin-facing type. It buys no rejection of anything, anywhere.** The `BaseSchema` index-signature ceiling (#5155) is untouched — `ComponentMeta` does not extend `BaseSchema`, so it was never on that axis.

## Blast radius

Nothing narrows: no key removed, no key's type changed. Two optional keys become writable on one spelling. That is why 43 downstream packages build green and why the changeset is a `minor`, not a `major` (this repo's own breaking changes never declare `major`).

## Also in this diff

`default-children-retired-contract-twins.test.ts` — the file #5893 named as *"the running cost of the copy"* — has its header corrected. Its case 3 no longer exercises a second *declaration*; it exercises a second published *spelling* of the first. It is deliberately **kept**, not deleted: while the deprecated alias is published, an author can still reach the type by that name, and the pin costs one `@ts-expect-error`. It is marked to be dropped together with the alias in stage 2.

## Out of scope, filed not fixed

**#6067** — `@object-ui/core`'s `Registry.ts:37` is a **third** `ComponentMeta`, and it is missing `tags`/`description` too: the same two keys, now the only remaining structural copy of the name in the workspace. It is a superset-with-holes rather than a copy (it adds `tier`, `namespace`, `skipFallback`, `labelling`), so it cannot be a bare re-export and needs a shape decision — which is why it is filed for triage rather than folded in here. #5671 converged `ComponentInput` in that very file and left this one, deliberately, as out of its fence. Searched open issues before filing; #4972 is closed and never names `ComponentMeta`, and #4631 is the wider three-surfaces card, not this.

`packages/core` was **not** touched. `objectql.ts` was **not** touched (#5903's PR #6053 is in flight there). No file under `app-shell/src/utils/`, `plugin-kanban`, `plugin-detail`, `data-objectstack`, `apps/console`, or `metadata-admin/previews/` was touched.

_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_