### PR TITLE
docs(guide): write schema-overview's action excerpt as the live condition gate

### DIFF
--- a/content/docs/guide/schema-overview.md
+++ b/content/docs/guide/schema-overview.md
@@ -73,7 +73,7 @@ turns it into the CSS variables your components already read.
 #### [Enhanced Actions](/docs/core/enhanced-actions)
 Powerful action system with AJAX calls, chaining, conditions, and callbacks.
 
-<!-- doc-snippet: fragment — a shape excerpt: `chain`, `condition`, `onSuccess` and `tracking` are written as literal `[...]` / `{...}` ellipses so the section can list the action keys without a worked example of each -->
+<!-- doc-snippet: fragment — a shape excerpt: `chain`, `onSuccess` and `tracking` are written as literal `[...]` / `{...}` ellipses so the section can list the action keys without a worked example of each -->
 
 ```typescript
 const action: ActionSchema = {
@@ -81,7 +81,7 @@ const action: ActionSchema = {
   actionType: 'ajax',
   api: '/api/submit',
   chain: [...],
-  condition: { expression: '${...}', then: {...} },
+  condition: '${...}',
   onSuccess: {...},
   tracking: {...}
 };
@@ -94,7 +94,7 @@ const action: ActionSchema = {
 
 **Key Features:**
 - Action chaining (sequential/parallel)
-- Conditional execution (if/then/else)
+- Conditional execution (a `condition` predicate gates whether an action runs)
 - Success/failure callbacks
 - Event tracking
 - Retry logic


### PR DESCRIPTION
Fixes #5980

`content/docs/guide/schema-overview.md` was a third teaching site still writing the retired `condition: { expression, then }` branch shape, outside the fence of #3917 (PR #5981, merged). One page, three lines.

## Re-derived on `origin/main` @ `a1c41c516`

The site was still there, and genuinely outside #5981's fence — that PR touched `content/docs/core/enhanced-actions.mdx` and `content/docs/api/schema-reference.md`, not this page. (Line 76 is an HTML comment; angle brackets are written as entities below because GitHub's body sanitizer eats short `<…>` fragments even inside a code fence.)

```
76  &lt;!-- doc-snippet: fragment — a shape excerpt: `chain`, `condition`, `onSuccess` and
    `tracking` are written as literal `[...]` / `{...}` ellipses so the section can list
    the action keys without a worked example of each --&gt;
78  ```typescript
79  const action: ActionSchema = {
…
84    condition: { expression: '${...}', then: {...} },
…
97  - Conditional execution (if/then/else)
```

Line 311 (`- ✅ Conditional execution with the \`condition\` property`) stays true — `condition` survives as a predicate gate — and is untouched.

## What changed, and why it is #5981's pattern rather than a second one

| Line | Before | After |
|---|---|---|
| 84 | `condition: { expression: '${...}', then: {...} },` | `condition: '${...}',` |
| 97 | `- Conditional execution (if/then/else)` | ``- Conditional execution (a `condition` predicate gates whether an action runs)`` |
| 76 | marker reason names `condition` among the ellipsis keys | marker reason no longer names it |

Line 84 is the same edit #5981 made at `api/schema-reference.md:637` (`"condition": { "expression": … }` → `"condition": "${data.items.length &gt; 0}"`). Line 97 is the same sentence #5981 rewrote at `core/enhanced-actions.mdx:17` — `- **Conditional logic**: If/then/else execution based on data` → `- **Conditional execution**: a \`condition\` predicate gates whether an action runs`; the wording is inherited verbatim, re-punctuated only to match this list's terse parenthetical style.

Line 76 is the marker question the card asked to look at. The fragment declaration must say **why the block cannot compile**; after the correction `condition: '${...}'` is an ordinary string literal that compiles fine, so it is no longer one of those reasons and naming it would make the declaration false. `chain: [...]`, `onSuccess: {...}` and `tracking: {...}` still are, so the block stays a declared fragment. This is not a re-fence — the fence language, the marker kind and the page's coverage state are all unchanged (#5867 / #5997's lane is untouched).

## Verification — the doc is pinned to the code, not to #5981's prose

Two-way compile probe against the **built** `packages/types/dist` (`@object-ui/types` built first, so this reads the shipped `.d.ts`, not a stale one):

```
LIVE     const a: ActionSchema = { …, condition: '${...}' }                     → tsc exit 0
RETIRED  const a: ActionSchema = { …, condition: { expression: …, then: … } }   → tsc exit 2
         retired.ts(9,16): error TS2353: Object literal may only specify known
         properties, and 'expression' does not exist in type
         '{ dialect?: string | undefined; source: string; }'.
```

The shipped zod schema agrees, pinned to the `condition` key:

```
doc corrected shape  -&gt; success: true
doc previous shape   -&gt; success: false | issue: invalid_union
```

Gates, each quoting its own verdict line (measured at `5d4e5bb43`):

- `check-doc-snippet-types` — exit 0. `Covered blocks: 274 — 157 to compile, 117 declared fragment(s).` / `Semantic phase: 157 of 157 block(s) judged, 0 failed.` **Identical to the same run with this file at `a1c41c516`** (274 / 157 / 117, 157 of 157, 0 failed) — the block was and remains a declared fragment, so the covered and diagnostic counts do not move.
- `check-doc-links` — exit 0, `Links are valid across 15 scan roots.`
- `check-doc-component-types` — exit 0, `✅  Every documented component type is registered.`
- `check-control-bytes` — exit 0, `✅  check-control-bytes: OK (scanned 5015 tracked text file(s))`; plus a control-byte `grep -naP` on the changed file: no match.
- `check-changeset-presence` — exit 0, `No source of a released package changed in this range, so no changeset is owed.` Docs-only; no changeset, per this repo's "src of a released package" criterion.
- Docs build: `pnpm turbo run build` → `44 successful, 44 total`; `@object-ui/site` `✓ Compiled successfully`, `✓ Generating static pages (556/556)`. The rendered page carries `condition: '${...}'` and zero occurrences of `expression:` or `if/then/else`.

**What is not verified:** nothing runtime. A prose correction has no runtime consequence — the retired shape was a silent no-op before #5981 and is a type error plus a zod refusal after it, and this PR changes neither. The whole of the evidence is that the shape the page now documents is the shape `ActionSchema` accepts, and the shape it used to document is the one `ActionSchema` refuses.

## Sweep for a fourth site

Repo-wide over `*.md` / `*.mdx`, excluding `node_modules` and `CHANGELOG`s: `then:` near `condition` matches **only** this page, and `expression:` matches only this page plus `skills/objectui/guides/schema-expressions.md:312` and `AGENTS.md:79` — both false positives (the skills line documents the legacy `{ expression: "${…}" }` CEL-translation form for `conditionalFormatting` predicates, a different surface with no `then`; the AGENTS.md line is a comment on `hidden`). No fourth site to file.

Scope held to this one page: the `ActionSchema` type, #5981's fence, the doc-snippet gate and the ledger are all untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
