### PR TITLE
fix(tooling): count published executable source outside src/ in the changeset presence gate

### DIFF
--- a/.changeset/5733-changeset-presence-population.md
+++ b/.changeset/5733-changeset-presence-population.md
@@ -1,0 +1,18 @@
+---
+---
+
+Tooling only; no published package behaviour changes.
+
+`scripts/check-changeset-presence.mjs` counted a changed file as a package's source
+only when it sat under `<pkg>/src/`. `apps/console/index.html` does not — it is the
+console's HTML entry, compiled into the published `dist/`, and it carries two inline
+classic scripts that run in every user's browser during parse. A pull request editing
+only that file changed shipped console behaviour while the gate reported
+`No source of a released package changed in this range` (objectui#5733).
+
+The population is now the package's published, executable source: `<pkg>/src/`, plus
+the bundler's HTML entry, plus whatever the package's own `package.json` `files` list
+publishes verbatim — minus documentation and licences, which ship but are not
+behaviour. On this tree the widening adds exactly three files
+(`apps/console/index.html`, `apps/console/plugin.ts`, `packages/runner/index.html`)
+and nothing else in any package directory.

--- a/scripts/__tests__/check-changeset-presence.test.ts
+++ b/scripts/__tests__/check-changeset-presence.test.ts
@@ -5,7 +5,15 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { changedFiles, describeDeclaration, discoverPackages, readReleaseConfig, resolveBaseRef } from '../check-changeset-presence.mjs';
+import {
+  changedFiles,
+  classifyChangedPaths,
+  describeDeclaration,
+  discoverPackages,
+  isPublishedSource,
+  readReleaseConfig,
+  resolveBaseRef,
+} from '../check-changeset-presence.mjs';
 
 /**
  * objectui#3387 — a change to published source could ship with no changeset, and
@@ -29,6 +37,13 @@ import { changedFiles, describeDeclaration, discoverPackages, readReleaseConfig,
  *     `apps/console` and would have been missed — the most-edited published
  *     package in the repository, and the one the platform bump script writes a
  *     changeset for.
+ *  2b. **The POPULATION is published AND executable**, not `src/` alone
+ *     (objectui#5733). `apps/console/index.html` is compiled into the published
+ *     `dist/` and runs two inline classic scripts in every user's browser, and
+ *     the `src/`-only reading let it change with nothing said. The three legs
+ *     below keep the widening honest in both directions: red-naming-the-file,
+ *     green-when-declared, and green for a non-shipped neighbour in the same
+ *     package directory.
  *  3. **The verdicts**, against throwaway repositories rather than this one's
  *     history, so they stay decidable when the history moves.
  *  4. **Every missing input fails LOUD.** A diff gate that cannot compute its
@@ -112,8 +127,21 @@ function fixtureRepo(label: string, { classifyAll = true } = {}): Fixture {
   write('packages/alpha/README.md', 'alpha\n');
   write('packages/ignored-demo/package.json', JSON.stringify({ name: '@fixture/ignored-demo', version: '1.0.0' }));
   write('packages/ignored-demo/src/index.ts', 'export const demo = 1;\n');
-  write('apps/console/package.json', JSON.stringify({ name: '@fixture/console', version: '1.0.0' }));
+  // Shaped like the real `apps/console`: a `files` list that publishes a
+  // package-ROOT source file, an HTML build entry outside `src/`, and neighbours
+  // that live in the same directory and ship nothing executable. objectui#5733's
+  // population lives entirely in the gap between those two groups.
+  write(
+    'apps/console/package.json',
+    JSON.stringify({ name: '@fixture/console', version: '1.0.0', files: ['dist', 'plugin.ts', 'README.md'] }),
+  );
   write('apps/console/src/main.ts', 'export const main = 1;\n');
+  write('apps/console/index.html', '<!doctype html>\n<script>window.boot = 1;</script>\n');
+  write('apps/console/plugin.ts', 'export const ConsolePlugin = 1;\n');
+  write('apps/console/README.md', 'console\n');
+  write('apps/console/preview-gallery.html', '<!doctype html>\n<title>dev preview</title>\n');
+  write('apps/console/public/manifest.json', '{ "name": "Console" }\n');
+  write('apps/console/vitest.config.ts', 'export default {};\n');
   write('docs/guide.md', 'guide\n');
   if (!classifyAll) {
     // A package in NEITHER the fixed group nor `ignore` — the case the gate
@@ -280,6 +308,155 @@ describe('the guarded surface follows .changeset/config.json, not a hand-written
     const run = runGate(empty.root, lastCommitRange(empty));
     expect(run.status).toBe(1);
     expect(run.output).toMatch(/empty `fixed` group/);
+  });
+});
+
+// ── 2b. the POPULATION: published AND executable (objectui#5733) ─────────────
+
+describe("the population is a package's PUBLISHED, EXECUTABLE source — not `src/` alone", () => {
+  // objectui#5733 measured the hole on `a1c41c516`: a change confined to
+  // `apps/console/index.html` — compiled into the published `dist/`, carrying two
+  // inline classic scripts that run in every user's browser during parse — was
+  // reported as `0 of them under the src/ of a package the release covers` and
+  // passed. These are the three legs that keep the fix from being vacuous: a
+  // should-demand change goes red NAMING the file, the same change with a
+  // declaration goes green, and a genuinely non-shipped neighbour stays green so
+  // the widening did not become a blanket.
+
+  it('POSITIVE — an HTML entry outside src/ changes with no changeset, and the gate goes red naming it', () => {
+    const repo = fixtureRepo('html-entry');
+    repo.write('apps/console/index.html', '<!doctype html>\n<script>window.boot = 2;</script>\n');
+    repo.commit('fix(console): change shipped boot behaviour, undeclared');
+
+    const run = runGate(repo.root, lastCommitRange(repo));
+    expect(run.status, 'a shipped, executable file changed and nothing declared it').toBe(1);
+    expect(run.output).toMatch(/adds no changeset/);
+    expect(run.output).toMatch(/@fixture\/console/);
+    // Naming the file is the load-bearing half: a red that does not say WHICH
+    // file cannot be acted on, and would pass just as well if the matcher had
+    // caught something else entirely.
+    expect(run.output).toMatch(/apps\/console\/index\.html/);
+  });
+
+  it('NEGATIVE CONTROL 1 — the same change WITH a changeset is green', () => {
+    const repo = fixtureRepo('html-entry-declared');
+    repo.write('apps/console/index.html', '<!doctype html>\n<script>window.boot = 2;</script>\n');
+    repo.write('.changeset/quiet-otters-boot.md', '---\n"@fixture/console": patch\n---\n\nBoot script fix.\n');
+    repo.commit('fix(console): declared');
+
+    const run = runGate(repo.root, lastCommitRange(repo));
+    expect(run.status).toBe(0);
+    expect(run.output).toMatch(/declares 1 changeset/);
+  });
+
+  it('NEGATIVE CONTROL 2 — non-shipped neighbours in the SAME package directory stay green', () => {
+    // Each of these lives inside a released package's directory and is published
+    // by nothing executable: `public/` is copied verbatim into `dist/` but is
+    // static, the preview page is a dev-server route Vite never builds, the
+    // README ships as documentation, and the vitest config ships not at all. If
+    // the widening had been "the whole package directory", every one of them
+    // would now demand a declaration — which is the failure mode that gets a
+    // gate answered with empty changesets nobody reads.
+    const repo = fixtureRepo('non-shipped');
+    repo.write('apps/console/public/manifest.json', '{ "name": "Console v2" }\n');
+    repo.write('apps/console/preview-gallery.html', '<!doctype html>\n<title>dev preview 2</title>\n');
+    repo.write('apps/console/README.md', 'console, revised\n');
+    repo.write('apps/console/vitest.config.ts', 'export default { test: {} };\n');
+    repo.commit('chore(console): touch four files that ship no behaviour');
+
+    const run = runGate(repo.root, lastCommitRange(repo));
+    expect(run.status, 'none of these four is published executable source').toBe(0);
+    expect(run.output).toMatch(/no changeset is owed/);
+    expect(run.output).toMatch(/4 file\(s\) changed, 0 of them published source/);
+  });
+
+  it('a package-ROOT file the `files` list publishes verbatim counts — clause (c)', () => {
+    // `apps/console/plugin.ts` is the real package's `main`. It is source, it is
+    // published, and it is nowhere near `src/`.
+    const repo = fixtureRepo('published-root-file');
+    repo.write('apps/console/plugin.ts', 'export const ConsolePlugin = 2;\n');
+    repo.commit('fix(console): change the published plugin entry, undeclared');
+
+    const run = runGate(repo.root, lastCommitRange(repo));
+    expect(run.status).toBe(1);
+    expect(run.output).toMatch(/apps\/console\/plugin\.ts/);
+  });
+
+  it('a `files` list that publishes documentation does not make documentation count', () => {
+    // The fixture's `files` names `README.md` explicitly, so clause (c) matches
+    // it and only the documentation subtraction keeps it out. Without that
+    // subtraction this test goes red — which is what makes the subtraction a
+    // subject here rather than an untested branch.
+    const repo = fixtureRepo('published-readme');
+    repo.write('apps/console/README.md', 'console, revised again\n');
+    repo.commit('docs(console): published, but not behaviour');
+
+    const run = runGate(repo.root, lastCommitRange(repo));
+    expect(run.status).toBe(0);
+    expect(run.output).toMatch(/no changeset is owed/);
+  });
+
+  it('states the rule as a clause table `isPublishedSource` must satisfy', () => {
+    // The prose in the gate's header and this table are the same rule twice; if
+    // one is edited the other has to move with it.
+    const consoleLike = { files: ['dist', 'plugin.ts', 'README.md'] };
+    const bare = { files: [] };
+
+    // (a) under src/ — unconditional, and unchanged from before objectui#5733.
+    expect(isPublishedSource('src/main.ts', bare)).toBe(true);
+    expect(isPublishedSource('src/__tests__/main.test.ts', bare)).toBe(true);
+    // …including documentation, which (a) does NOT subtract: nothing that was
+    // guarded before this change may be guarded less now.
+    expect(isPublishedSource('src/notes.md', bare)).toBe(true);
+
+    // (b) the bundler's HTML entry, by exact name.
+    expect(isPublishedSource('index.html', bare)).toBe(true);
+    expect(isPublishedSource('preview-gallery.html', bare)).toBe(false);
+    expect(isPublishedSource('demo/index.html', bare)).toBe(false);
+
+    // (c) published verbatim by the package's own `files` list.
+    expect(isPublishedSource('plugin.ts', consoleLike)).toBe(true);
+    expect(isPublishedSource('plugin.ts', bare)).toBe(false);
+    expect(isPublishedSource('dist/plugin.js', consoleLike)).toBe(true);
+
+    // …minus documentation and licences, even when `files` names them.
+    expect(isPublishedSource('README.md', consoleLike)).toBe(false);
+    expect(isPublishedSource('CHANGELOG.md', consoleLike)).toBe(false);
+    expect(isPublishedSource('LICENSE', consoleLike)).toBe(false);
+
+    // Everything else in a package directory: still out.
+    expect(isPublishedSource('package.json', consoleLike)).toBe(false);
+    expect(isPublishedSource('vite.config.ts', consoleLike)).toBe(false);
+    expect(isPublishedSource('public/manifest.json', consoleLike)).toBe(false);
+    expect(isPublishedSource('tsconfig.json', consoleLike)).toBe(false);
+  });
+
+  it('answers THIS repository the same way — the three files the widening adds, and no fourth', () => {
+    // Read against the real tree rather than a fixture, because the fixture
+    // cannot show that the rule stayed narrow across 40 released packages. The
+    // assertion is per-file rather than a count, so it stays decidable as the
+    // tree grows.
+    const packages = discoverPackages(repoRoot, readReleaseConfig(repoRoot));
+    const guardedFiles = (paths: string[]): string[] =>
+      classifyChangedPaths(paths, packages).guarded.map((entry: { file: string }) => entry.file);
+
+    expect(
+      guardedFiles(['apps/console/index.html', 'apps/console/plugin.ts', 'packages/runner/index.html']),
+      'the shipped, executable files outside src/ that objectui#5733 measured as unguarded',
+    ).toEqual(['apps/console/index.html', 'apps/console/plugin.ts', 'packages/runner/index.html']);
+
+    expect(
+      guardedFiles([
+        'apps/console/public/manifest.json',
+        'apps/console/preview-gallery.html',
+        'apps/console/README.md',
+        'apps/console/package.json',
+        'apps/console/vite.config.ts',
+        'packages/plugin-grid/demo/index.html',
+        'packages/runner/tsconfig.json',
+      ]),
+      'the widening is not a blanket over the package directory',
+    ).toEqual([]);
   });
 });
 

--- a/scripts/check-changeset-presence.mjs
+++ b/scripts/check-changeset-presence.mjs
@@ -82,14 +82,81 @@
  * in neither `fixed` nor `ignore` — so the two gates compose into "every package
  * is classified, and every classified-as-released package's source is declared".
  *
- * Two deliberate boundaries, stated so they are not mistaken for oversights:
+ * ## Which files count as a package's source — the POPULATION (objectui#5733)
  *
- *   - **`src/**` only.** A dependency bump in a package's `package.json` can be
- *     just as user-visible, and this gate does not see it. Widening to whole
- *     package directories would demand a changeset for `README` edits and test
- *     fixtures outside `src`, which is friction with no release meaning.
+ * `<pkg>/src/` is where nearly all of a package's published source is. It is not
+ * all of it, and the difference was measured rather than argued. On `a1c41c516`,
+ * a change confined to `apps/console/index.html` — the console's HTML entry,
+ * which is compiled into the published `dist/` and carries two inline classic
+ * scripts that run in every user's browser during parse (the pre-boot
+ * branding/`runtime/config` script and the `crypto.randomUUID` shim for insecure
+ * origins, both graded by tests in `apps/console/src/__tests__/` precisely
+ * because they are shipped behaviour) — produced this verdict:
+ *
+ *     Compared the working tree with a1c41c516 (merge-base with origin/main):
+ *     1 file(s) changed, 0 of them under the src/ of a package the release
+ *     covers, 0 under a package changesets ignores, 0 changeset(s) added.
+ *     ✅  No source of a released package changed in this range, so no changeset
+ *     is owed.
+ *
+ * That verdict is quoted as it READ THEN. The summary line's wording moved with
+ * this fix — it now says `published source of a package the release covers` —
+ * so a grep for the old phrase finds this quotation and nothing else, which is
+ * the intended result rather than a leftover.
+ *
+ * ### The rule this file implements
+ *
+ * A changed file counts when it is that package's **published, executable**
+ * source. Concretely, it counts when ANY of these holds:
+ *
+ *   (a) it is under `<pkg>/src/`; or
+ *   (b) it is `<pkg>/index.html` — the bundler's HTML entry, whose content
+ *       (inline scripts included) is compiled into the published `dist/`; or
+ *   (c) the package's own `package.json` `files` list publishes it verbatim —
+ *       `apps/console`'s root `plugin.ts`, which is that package's `main`.
+ *
+ * …minus **documentation and licences** (`*.md`, `LICENSE*`), which do ship in
+ * the tarball but are not behaviour. `<pkg>/src/` is exempt from that
+ * subtraction: it keeps its existing all-of-it reading, unchanged, so nothing
+ * that was guarded before is guarded less now.
+ *
+ * `isPublishedSource` below is that rule as code, in the same clause order.
+ *
+ * On this tree the widening adds exactly three files — `apps/console/index.html`,
+ * `apps/console/plugin.ts`, `packages/runner/index.html` — and that number is the
+ * point rather than a footnote. The population has a wrong answer in each
+ * direction: too narrow and shipped executable code changes with nothing said, so
+ * consumers get a release that does not mention it; too wide and every incidental
+ * file in a package directory demands a declaration, the gate becomes noise, and
+ * people answer it with empty changesets they did not read — which is how a gate
+ * stops being read at all. "Published AND executable" is the line, and both words
+ * are load-bearing.
+ *
+ * Deliberate boundaries, stated so they are not mistaken for oversights:
+ *
+ *   - **`package.json` itself never counts.** Clause (c) reads that file; it does
+ *     not match it. A dependency bump can be just as user-visible, and this gate
+ *     still does not see it. That was the first draft's trade and it is kept.
+ *   - **`<pkg>/public/` does not count.** Vite copies it verbatim into the
+ *     published `dist/`, so it genuinely IS published — a favicon, a logo, a PWA
+ *     manifest. None of it is executable, and demanding a declaration for a logo
+ *     swap is exactly the friction that teaches authors to silence this gate.
+ *     Published-but-not-code sits with the READMEs.
+ *   - **`<pkg>/*-preview.html` and `<pkg>/demo/` do not count**, because they are
+ *     not build inputs. Vite's build entry is `index.html` alone unless
+ *     `rollupOptions.input` names more, and neither `apps/console`'s five preview
+ *     pages nor `plugin-grid`/`plugin-gantt`'s demo pages are named. They are
+ *     dev-server pages that reach no tarball.
+ *   - **Clause (b) tests the NAME, not the bundler config.** A package-root
+ *     `index.html` in this repository is always the build entry — `apps/console`
+ *     (`tsc && vite build && pnpm build:plugin`) and `packages/runner`
+ *     (`vite build`) are the only two, and both are. If one ever is not, the cost
+ *     is a single empty-frontmatter changeset. The other direction — deriving it
+ *     from a build script's spelling — fails SILENTLY the day the spelling
+ *     changes, and a silent narrowing of this population is the exact defect
+ *     objectui#5733 reported.
  *   - **No carve-out for test files under `src/`.** A change confined to
- *     `src/__tests__/**` is answered by the empty-frontmatter exemption, in one
+ *     `src/__tests__/` is answered by the empty-frontmatter exemption, in one
  *     line. The alternative — teaching the gate which files "don't count" — is
  *     where the holes live, and this gate asks for a sentence, not a release.
  *
@@ -407,12 +474,33 @@ export function readReleaseConfig(root) {
 }
 
 /**
- * `directory -> { name, versioned }` for every workspace package.
+ * The package's own `files` list, normalised to repo-shaped relative paths.
+ *
+ * `['./plugin.ts', 'dist/']` and `['plugin.ts', 'dist']` describe the same
+ * tarball, and npm accepts both spellings; clause (c) of the population rule
+ * compares changed paths against these entries, so the two spellings must not
+ * produce two different guarded surfaces.
+ *
+ * A package with NO `files` field publishes its whole directory. That is not read
+ * as "everything counts": the one such package here (`packages/vscode-extension`)
+ * is `private: true` and reaches no registry, and taking the absent field as a
+ * blanket would guard every tsconfig and doc page in it. Absent means clause (c)
+ * matches nothing, and clauses (a) and (b) still apply.
+ */
+function publishedEntries(manifest) {
+  const files = Array.isArray(manifest.files) ? manifest.files : [];
+  return files
+    .map((entry) => (typeof entry === 'string' ? entry.replace(/^\.\//, '').replace(/\/+$/, '') : ''))
+    .filter((entry) => entry !== '');
+}
+
+/**
+ * `directory -> { name, versioned, ignored, files }` for every workspace package.
  *
  * Scans the same roots as `scripts/check-changeset-fixed.mjs` — one package per
  * immediate subdirectory — so the two gates agree about what a package is.
  *
- * @returns {Map<string, { name: string, versioned: boolean, ignored: boolean }>}
+ * @returns {Map<string, { name: string, versioned: boolean, ignored: boolean, files: string[] }>}
  */
 export function discoverPackages(root, { versioned, isIgnored }) {
   const packages = new Map();
@@ -430,16 +518,64 @@ export function discoverPackages(root, { versioned, isIgnored }) {
       } catch {
         continue;
       }
-      const name = JSON.parse(readFileSync(manifest, 'utf8')).name;
+      const parsed = JSON.parse(readFileSync(manifest, 'utf8'));
+      const name = parsed.name;
       if (!name) continue;
       packages.set(`${parent}/${entry}`, {
         name,
         versioned: versioned.has(name),
         ignored: isIgnored(name),
+        files: publishedEntries(parsed),
       });
     }
   }
   return packages;
+}
+
+/**
+ * The package-root HTML file a bundler compiles into the published `dist/`.
+ *
+ * Vite's build entry is this file and no other unless `rollupOptions.input` names
+ * more, and nothing in this repository does. Sibling HTML at a package root
+ * (`apps/console`'s `*-preview.html` pages) and HTML one level down
+ * (`packages/plugin-grid/demo/index.html`) are dev-server pages that reach no
+ * tarball, and neither is matched by an equality test on this exact name.
+ */
+export const HTML_ENTRY = 'index.html';
+
+/**
+ * Documentation and licences: published in the tarball, but not behaviour.
+ *
+ * Subtracted from clauses (b) and (c) of the population rule — never from (a).
+ * `<pkg>/src/` keeps its all-of-it reading, so this predicate cannot narrow what
+ * the gate guarded before objectui#5733.
+ */
+export function isDocumentation(relative) {
+  const name = relative.slice(relative.lastIndexOf('/') + 1);
+  return /^LICEN[SC]E/i.test(name) || /\.md$/i.test(name);
+}
+
+/**
+ * Does `relative` — a path INSIDE `directory`, with the package directory already
+ * stripped — count as that package's published, executable source?
+ *
+ * The three clauses are the ones the header states, in the same order:
+ *
+ *   (a) under `src/`;
+ *   (b) the bundler's HTML entry;
+ *   (c) published verbatim by the package's own `files` list.
+ *
+ * Clause (a) answers first and unconditionally, so the documentation subtraction
+ * that (b) and (c) are subject to can never remove a file `src/` already covered.
+ *
+ * @param {string} relative
+ * @param {{ files: string[] }} pkg
+ */
+export function isPublishedSource(relative, pkg) {
+  if (relative.startsWith('src/')) return true;
+  if (isDocumentation(relative)) return false;
+  if (relative === HTML_ENTRY) return true;
+  return (pkg.files ?? []).some((entry) => relative === entry || relative.startsWith(`${entry}/`));
 }
 
 /**
@@ -464,7 +600,7 @@ export function classifyChangedPaths(paths, packages) {
   for (const path of paths) {
     let owner = null;
     for (const [directory, pkg] of packages) {
-      if (path.startsWith(`${directory}/src/`)) {
+      if (path.startsWith(`${directory}/`) && isPublishedSource(path.slice(directory.length + 1), pkg)) {
         owner = { directory, pkg };
         break;
       }
@@ -638,8 +774,8 @@ if (invokedDirectly) {
 
   console.log(
     `Compared ${head ?? 'the working tree'} with ${base.ref.slice(0, 9)} (${base.how}): ` +
-      `${analysis.changedFileCount} file(s) changed, ${analysis.guarded.length} of them under the ` +
-      `src/ of a package the release covers, ${analysis.skipped.length} under a package changesets ` +
+      `${analysis.changedFileCount} file(s) changed, ${analysis.guarded.length} of them published ` +
+      `source of a package the release covers, ${analysis.skipped.length} under a package changesets ` +
       `ignores, ${analysis.declarations.length} changeset(s) added.`,
   );
 


### PR DESCRIPTION
Fixes #5733

Verification union run at `50365b547` (the final commit).

> Note on spelling in this body: the package directory is written `PKG/…` rather than with angle brackets. GitHub's body sanitizer strips short angle-bracket fragments on every edit — even inside backticks — and the first version of this description lost every one of them.

## Where the population test actually is

The card cites `scripts/check-changeset-presence.mjs:416`. That line number is stale — the file has been edited since. Located by code (`git grep -n 'path.startsWith'`), the population test was at **line 467** on `a1c41c516`, inside `classifyChangedPaths`:

```js
if (path.startsWith(`${directory}/src/`)) {
```

## The premise, re-verified on current `origin/main`

Appended one HTML comment to `apps/console/index.html` on a clean `a1c41c516` worktree and ran the gate unchanged:

```
Compared the working tree with a1c41c516 (merge-base with origin/main): 1 file(s) changed,
0 of them under the src/ of a package the release covers, 0 under a package changesets
ignores, 0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

Exit 0. The premise holds: a shipped, executable file outside a package's `src/` changes with no changeset required. That file is compiled into the published `dist/` and carries two inline classic scripts that run in every user's browser during parse.

## The judgment: what the population should be

Picked by **published AND executable** — both words load-bearing, because the population has a wrong answer in each direction (too narrow ships undeclared executable code; too wide makes the gate noise people silence with empty changesets). The rule is stated in the file's header in checkable prose and implemented as `isPublishedSource`, same clause order.

A changed file counts when **any** of these holds:

- **(a)** it is under `PKG/src/` — unchanged, and still all-of-it;
- **(b)** it is `PKG/index.html`, the bundler's HTML entry, compiled into the published `dist/`;
- **(c)** the package's own `package.json` `files` list publishes it verbatim (`apps/console`'s root `plugin.ts`, which is that package's `main`).

…minus **documentation and licences** (`*.md`, `LICENSE*`), which ship in the tarball but are not behaviour. Clause (a) answers first and unconditionally, so the subtraction can never remove something `src/` already covered — **nothing guarded before is guarded less now**.

**On this tree the widening adds exactly three files and no fourth:** `apps/console/index.html`, `apps/console/plugin.ts`, `packages/runner/index.html`. Measured by running `classifyChangedPaths` over every tracked file in the repo: 3330 guarded, 3 of them outside `src/`.

Boundaries stated in the header rather than left as silences — `PKG/public/` (published verbatim by Vite, but static, not code), `PKG/*-preview.html` and `PKG/demo/` (dev-server pages Vite never builds), and `package.json` itself (clause (c) reads it, does not match it). Clause (b) tests the **name**, not the build script's spelling: deriving it from a script would fail silently the day the spelling changes, which is this card's own defect class.

No convention was invented that the repo has not settled — `files` is npm's own published-surface declaration and `index.html` is Vite's documented default build entry; both packages with a root `index.html` build it (`apps/console`: `tsc && vite build && pnpm build:plugin`; `packages/runner`: `vite build`).

## Non-vacuity — executable, all three legs

Run against throwaway fixture repositories in `scripts/__tests__/check-changeset-presence.test.ts` (new section 2b), plus the real tree.

- **Positive** — `apps/console/index.html` changes, no changeset ⇒ **red naming that file**.
- **Negative control 1** — same change *with* a changeset ⇒ green (`declares 1 changeset`).
- **Negative control 2** — four non-shipped neighbours in the *same* package directory (`public/manifest.json`, `preview-gallery.html`, `README.md`, `vitest.config.ts`) ⇒ green, `4 file(s) changed, 0 of them published source`. The widening did not become a blanket.

Plus a clause table over `isPublishedSource`, a clause-(c) leg on `plugin.ts`, a leg proving a `files`-published `README.md` still does not count, and a real-repo leg pinning the three-files-and-no-fourth answer.

### These tests can fail

Ablated `isPublishedSource` back to the pre-fix `return relative.startsWith('src/')` (mutation confirmed on disk: `ABLATION-5733` marker present ×1, removed text `relative === HTML_ENTRY` absent ×0) and re-ran from the repo root:

```
 Test Files  1 failed (1)
      Tests  5 failed | 33 passed (38)
     × POSITIVE — an HTML entry outside src/ changes with no changeset, and the gate goes red naming it
     × NEGATIVE CONTROL 1 — the same change WITH a changeset is green
     × a package-ROOT file the `files` list publishes verbatim counts — clause (c)
     × states the rule as a clause table `isPublishedSource` must satisfy
     × answers THIS repository the same way — the three files the widening adds, and no fourth
```

The two new tests that stayed green under ablation are both *stays-green* assertions (negative control 2, and the published-README leg), which is the correct direction for them; the clause table covers those branches and does go red. The script was restored by an `EXIT INT TERM` trap and verified byte-identical (`diff -q` clean).

## Reverse-verification against `apps/console/index.html`

Direction predicted before running: **red, naming the file**. Observed on the real repo at `a1c41c516` + this fix:

```
Compared the working tree with a1c41c516 (merge-base with origin/main): 2 file(s) changed,
1 of them published source of a package the release covers, 0 under a package changesets
ignores, 0 changeset(s) added.

❌  1 source file(s) of 1 released package(s) changed, and this change adds no changeset:

      @object-ui/console
          apps/console/index.html
```

Exit 1. Mutation proven on disk before each read (`grep -c 'objectui-5733-PROBE'` = 1, byte count 9460 → 9505). Restored with `git checkout HEAD -- apps/console/index.html` (**not** the bare form); restoration proven by empty `git diff HEAD` for the path, zero probe hits, and byte count back to 9460.

Same legs also run on the real tree for `apps/console/plugin.ts` (red naming it) and for five non-shipped files at once (green, `0 of them published source`).

## Gate verdicts — each quoted from its own output

All at `50365b547`, run from the repo root:

| gate | verdict line |
|---|---|
| `scripts/__tests__/check-changeset-presence.test.ts` | `Test Files  1 passed (1)` / `Tests  38 passed (38)` |
| whole `scripts/__tests__/` suite | `Test Files  64 passed (64)` / `Tests  1770 passed (1770)` |
| `check-changeset-presence.mjs` (this PR's own diff) | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `check-changeset-fixed.mjs` | `✅  All workspace packages are in the changeset fixed group.` |
| `check-changeset-no-major.mjs` | `✅  No changeset declares a major bump.` |
| `pnpm check:control-bytes` | `✅  check-control-bytes: OK (scanned 5016 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-lint-coverage.mjs` | `✅  lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `node scripts/check-type-check-coverage.mjs` | `✅  type-check coverage: 45/46 via type-check, 0 via their own build, 0 known-broken (0 errors outstanding), 1 not compiled.` |
| `pnpm type-check:scripts` | exit 0, no diagnostics |
| `eslint --no-inline-config` on both changed files | 2 files linted, 0 errors, 0 warnings |

**On the eslint reading:** this is not a narrowing. Root `pnpm lint` is `turbo run lint`, a per-package fan-out; `scripts/` is not a package, so `pnpm lint` does not reach either changed file. The targeted run uses the root `eslint.config.js` with `--no-inline-config` and reports `2` files from `--format json` — the complete lint population for this diff.

`node-esm-load-gate.yml` is a nightly/dispatch workflow that does a real build and is **not** a per-PR gate for this diff; it is red in this unbuilt worktree with `@object-ui/console: no-build-output — ./plugin.js does not exist after the build`, which names a file this diff does not touch (the diff is two files under `scripts/` plus a changeset).

## Changeset

The gate says none is owed for this diff (`scripts/` is no package's published source), so this is not the infinite-regress case. Added an empty-frontmatter declaration anyway, which is objectui's way of saying "ships nothing" — the gate's own documented first-class pass.

## The one boundary a reviewer may want to move

`PKG/public/` is genuinely published — Vite copies it verbatim into `dist/`, so `apps/console/public/manifest.json` reaches every user. It is excluded here because it is not executable, and demanding a declaration for a favicon swap is the friction that gets a gate answered with empty changesets nobody reads. That reasoning is written into the header as a considered exclusion rather than left silent, so moving the line is a one-clause edit if the maintainer reads it the other way.

## Out of scope, untouched

`check-changeset-fixed`, `check-changeset-no-major`, #5775's `lane`-job mirror of `readChangesetState`, and the release workflow. No gate was weakened: the only behavioural change to an existing verdict is the summary line's wording, and clause (a) preserves the prior guarded set exactly.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_