### PR TITLE
docs(tooling): record the component-registry category-list ledger entry as discharged

### DIFF
--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -314,10 +314,16 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * in this program. Hoisting a package to the repo root to buy a doc snippet
  * coverage is a real dependency edge, so those blocks are declared instead, with
  * what sits underneath them measured (via a shimmed icon import) rather than left
- * unknown. `guide/component-registry`'s six category lists are markdown BULLET
- * LISTS inside `tsx` fences — the fence language is the defect there, and
- * correcting it is a change to the page's rendering rather than to a snippet, so it
- * is declared here and left to its own change.
+ * unknown. `guide/component-registry`'s six category lists were markdown BULLET
+ * LISTS inside `tsx` fences — the fence language was the defect there rather
+ * than anything in the blocks, so they were declared here and left to their own
+ * change. objectui#5997 (PR #6056) then made that change: the six fences are
+ * plain markdown bullet lists on the page now, which takes those blocks out of
+ * the ts/tsx population this gate collects at all, so the six `FRAGMENT_MARKER`
+ * declarations came out with them — a marker on a block the gate no longer
+ * collects is debt nothing would ever fail to prompt the removal of. The entry
+ * stays here because this ledger keeps the record of why each declaration
+ * existed, not because the page still carries them.
  *
  * objectui#5343 then read that list back and cleared it for the getting-started
  * pages: no entry for `content/docs/guide/**` or for


### PR DESCRIPTION
Fixes #6054

## What

One paragraph of comment prose in `scripts/check-doc-snippet-types.mjs`'s ledger docblock. The entry for `guide/component-registry`'s six category lists was written in the **present tense about the current tree**:

> `guide/component-registry`'s six category lists **are** markdown BULLET LISTS inside `tsx` fences — the fence language **is** the defect there, and correcting it **is** a change to the page's rendering rather than to a snippet, so it **is** declared here and left to its own change.

Every neighbouring entry is a past-tense round record ("objectui#5343 then read that list back and cleared it…"). This one was not, and it is now false rather than prospectively false: `5cafb91d8` (PR #6056, card #5997) landed the re-fence, so the six blocks are plain markdown bullet lists on the page and the six `FRAGMENT_MARKER` declarations came out with them. A reader following the sentence to `content/docs/guide/component-registry.md` finds nothing there — `grep -c FRAGMENT_MARKER` on that page returns 0.

Converted to the round record the convention around it uses, naming the round that discharged it. **The entry is kept, not deleted** — this ledger deliberately keeps the history of why each declaration existed.

## Scope

Comment prose only. No strictness change, no behaviour change, no gate added, no ledger entry added or removed, `content/docs/guide/component-registry.md` untouched. Diff is `1 file changed, 10 insertions(+), 4 deletions(-)`, all inside one block comment.

Card's own pre-check re-run on `origin/main`: `grep -rn 'category lists\|six category'` still hits **only** this file, one line — no sweep needed.

## Verification — a comment change must move nothing

All runs at `7d0b901be`, after a full `pnpm build` (43/43 tasks successful), serialized through the shared verify lock.

`node scripts/check-doc-snippet-types.mjs` — its output is **byte-identical** before and after the edit (`diff` of the two captures is empty). Verdict lines:

```
Scanned 222 document(s): 178 covered (43 of them hold a ts/tsx block), 44 ungated — declared in this script, NOT verified by it.
Covered blocks: 268 — 157 to compile, 111 declared fragment(s).
Syntax phase:   every block parsed, so every one of them reached the semantic phase.
Semantic phase: 157 of 157 block(s) judged, 0 failed.

Every covered documentation snippet compiles against the built types.
```

`vitest run scripts/__tests__/check-doc-snippet-types.test.ts` (from the repo ROOT) — `Test Files  1 passed (1)` / `Tests  20 passed (20)`, identical before and after.

Also green at the same commit: `node scripts/check-control-bytes.mjs` — `✅  check-control-bytes: OK (scanned 5026 tracked text file(s); skipped 85 binary)`; `node scripts/check-changeset-presence.mjs` — `✅  No source of a released package changed in this range, so no changeset is owed`; `eslint --no-inline-config` over the changed file — 1 file linted, 0 errors, 0 warnings (`--format json` counts). The narrowing is a measurement, not a skip: `eslint.config.js` declares no `project:` / `projectService` anywhere, so type-aware linting is off and a comment-only diff in one file cannot move any untouched file's verdict. A full `eslint .` was run anyway and reached all 3655 files it covers; its 89 errors are pre-existing on `main` and none are in the changed file.

## The honest limit, which is the card's own point

**Nothing asserts on this docblock.** The test suite does not reference it, the word "category", or `component-registry`, so no run would ever have failed to prompt this correction — and nothing keeps the new text true either. The byte-identical gate output above is exactly the evidence that this change is inert to the tooling: it is a correction to the human record, held by review only.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_