### PR TITLE
fix(cli): correct check.ts's false promise that a corpus migration repays the recall debt

### DIFF
--- a/.changeset/6074-check-ts-stale-migration-comment.md
+++ b/.changeset/6074-check-ts-stale-migration-comment.md
@@ -1,0 +1,21 @@
+---
+---
+
+Comment-only fix in `packages/cli/src/commands/check.ts`: the note beside the
+structural marker gate promised that "the corpus migration repays" the recall
+debt — the real schema files the checker skips because their root carries no
+structural key. No such migration exists and none can be written. The marker it
+would stamp is the `$schema` URL the 2026-08-20 ruling declined to mint, and
+`OBJECTUI_SCHEMA_URL` / `pointsAtObjectUi()` were deleted before objectui#5334
+merged. The same file already states, twenty lines earlier, that there is
+deliberately no `$schema` arm and no URL to declare — so the file contradicted
+itself.
+
+The note now says what is true: the recall debt is real and unpaid, the
+`$schema` route was ruled against, a corpus-wide `$schema` sweep is a measured
+no-op on the skipped-file count, and the arm can be added later without
+invalidating a single file because matching would be host-based. It points the
+next reader at the tracking card and its blocker instead of at a dead route.
+
+No behaviour change and nothing to release — `objectui check` judges, skips and
+prints exactly what it did before.

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -103,8 +103,25 @@ const OBJECTUI_STRUCTURAL_KEYS: readonly string[] = [
  * ⚠️ The structural arm is a TRANSITIONAL fallback, not the contract. It is
  * drawn for precision over recall on purpose: a foreign file wrongly judged is
  * this card's defect reappearing in a user's project, while a real schema
- * wrongly skipped is a coverage debt that the corpus migration repays and that
- * the skipped-file count below keeps visible in the meantime.
+ * wrongly skipped is a RECALL DEBT — real, unpaid, and kept visible by the
+ * skipped-file count printed below.
+ *
+ * ⛔ Nothing repays that debt today, and no corpus migration can. The marker a
+ * migration would stamp is the `$schema` URL the 2026-08-20 ruling declined to
+ * mint: `OBJECTUI_SCHEMA_URL` and `pointsAtObjectUi()` were deleted before
+ * objectui#5334 merged, so there is no arm for a stamped file to match — see
+ * the block above, which records the same absence from the other side.
+ * Measured rather than reasoned: injecting a `$schema` key into a
+ * currently-skipped real corpus file leaves the skipped count unmoved, while
+ * injecting a structural key into the same file moves it by exactly one. A
+ * corpus-wide `$schema` sweep is therefore a no-op here, not an unfinished
+ * chore — an earlier card was written, claimed and worked on the belief that
+ * this sentence promised one.
+ *
+ * The debt is tracked as objectui#6075, blocked on objectui#5392
+ * (`@object-ui/types` shipping a generated JSON Schema to point at). Waiting
+ * forecloses nothing: matching would be host-based, so adding the arm then
+ * invalidates not a single file.
  */
 function isObjectUiSchemaFile(content: Record<string, unknown>): boolean {
   return OBJECTUI_STRUCTURAL_KEYS.some((key) => key in content);


### PR DESCRIPTION
Fixes #6074

`packages/cli/src/commands/check.ts` contradicted itself. One comment promised a repayment mechanism that another comment in the same file records as deliberately absent, and that merged code deleted before #5334 landed. Comment-only: behaviour, output and the skipped-file count are byte-for-byte unchanged.

## The false sentence

```
 * ⚠️ The structural arm is a TRANSITIONAL fallback, not the contract. It is
 * drawn for precision over recall on purpose: a foreign file wrongly judged is
 * this card's defect reappearing in a user's project, while a real schema
 * wrongly skipped is a coverage debt that the corpus migration repays and that
 * the skipped-file count below keeps visible in the meantime.
```

There is no corpus migration and there cannot be one. The marker such a migration would stamp is the `$schema` URL the maintainer's **2026-08-20 ruling (verbatim 「C」)** declined to mint.

## The corrected comment agrees with the code in the same file

Three pieces of evidence, all local to this file or this tree:

**1. The block twenty lines above already says the opposite** — unchanged by this PR, quoted from `main`:

```
 * ⛔ There is deliberately NO `$schema` arm, and no ObjectUI `$schema` URL
 * exists to declare.
 ...
 * Because that matching was host-based rather than literal, the arm can be
 * added later without invalidating a single file — most soundly once
 * `@object-ui/types` ships a generated JSON Schema, which is filed separately.
```

**2. The mechanism is gone from the tree.** The identifiers a `$schema` arm would need do not exist anywhere in this repository:

```
$ grep -rn "OBJECTUI_SCHEMA_URL\|pointsAtObjectUi" packages/ examples/ scripts/ docs/
$ echo $?
1                      # no match, in any file
```

#5334's merged body states the same, verbatim: *"`pointsAtObjectUi()` and the `OBJECTUI_SCHEMA_URL` constant are gone, along with the branch that called them. What remains is one arm."*

**3. The skip hint below already treats the `$schema` route as removed** — also unchanged by this PR:

```
    // previous revision of this line advised declaring a `$schema` URL — an
    // arm the 2026-08-20 ruling removed — which is exactly that failure had it
    // outlived the code it described.
```

The corrected note now says what those three already say: the recall debt is real and unpaid, the `$schema` route was ruled against, the arm can be added later without invalidating a single file, and the reader is pointed at #6075 (tracking) and #5392 (its blocker) rather than at a dead route.

## Why it was worth a card

The sentence is not decorative — it is part of what made #5329 read as actionable. That card was written, claimed and worked to the point of a full corpus re-measurement and a paired ablation before its dev established that the marker it was told to stamp does not exist. Left standing, the sentence lets the next reader of `check.ts` re-derive the same false card.

## Re-measured, not reused

The D-arm count moves (304 in #5329's stamped table, 309 five days later), so it was re-measured on this branch's base `575b71c85`, after `pnpm --filter @object-ui/types build && pnpm --filter @object-ui/cli build`:

```
$ node packages/cli/dist/cli.js check          # from the repo root
Object UI Schema Check
Analyzing 617 files...
Skipped 309 files with a root "type" and no ObjectUI schema marker.
✓ All checks passed
```

**617 analysed / 309 skipped.** That equals #5329's reading, but it is an independent measurement on a different commit, not a number carried over.

### The ablation the new comment asserts, re-run first-hand

The corrected comment claims a `$schema` sweep is a *measured* no-op, so the measurement was reproduced here rather than inherited. Paired legs on one currently-skipped real corpus file, `examples/schema-catalog/src/schemas/plugin-view/object-view-record-surface.json`:

| leg | injected at root | mutation confirmed on disk | D-arm skipped |
|---|---|---|---:|
| baseline | — | markers grep to 0 | **309** |
| A | `"$schema": "https://objectui.org/schema/v1/schema.json"` | `grep -c` = 1, `git diff --numstat` = `1 0` | **309** — unmoved |
| B (positive control) | `"className": ""` | `grep -c` = 1, `git diff --numstat` = `1 0` | **308** — moved by exactly 1 |

Leg B is what makes leg A a measurement rather than a probe that missed. Every mutation was confirmed on disk *before* any result was read; the script carried `trap … EXIT INT TERM`, and both restore legs verified clean (`grep -c` back to 0, `git status --porcelain` empty for the file). No rebuild was needed between legs: the mutation is corpus JSON read at runtime, and the CLI bundle under `dist/` was built once before the baseline and never touched again. **The corpus is unmodified in this PR's diff** — `git status --porcelain` at the final commit is empty.

## Limits of this change, stated plainly

**No gate catches a false comment, and none will keep the corrected one true.** This is prose. Nothing in CI reads it, nothing pins it to the code beside it, and it can go stale again the moment the `$schema` decision moves. What the gates do cover is that the behaviour did not change — and that is all they cover.

## Verification

All at the final commit **`084de8aad`**; `git status --porcelain` empty, so every run below is on byte-identical content.

- `pnpm exec vitest run packages/cli/src/__tests__/ --maxWorkers=2` from the **repo root** (the canonical invocation — `assertCanonicalVitestInvocation` refuses a package-cwd run): **11 files, 208 tests, all passing.**
- `pnpm --filter @object-ui/cli type-check` → clean; the run echoed `tsc --noEmit`, so it is not a zero-match silent pass.
- `pnpm --filter @object-ui/cli lint` (`eslint src`) → **0 errors, 11 warnings, none in `check.ts`** (34 files linted, counted from `--format json`; `check.ts` reports 0/0). All 11 pre-exist on `main` in other files.
- `node scripts/check-changeset-presence.mjs` → ran **before** writing anything, and its verdict decided the changeset rather than an assumption: `❌ 1 source file(s) of 1 released package(s) changed, and this change adds no changeset`. It also names the pass it permits — *"If this change really should release nothing, say so — that is a pass, not a workaround. Add a `.changeset/` markdown file with an EMPTY frontmatter"*. Now `✅ … declares 1 changeset(s) … Every one of them has an EMPTY frontmatter`.
- `node scripts/check-changeset-no-major.mjs` → `✅ No changeset declares a major bump.`
- `node scripts/check-changeset-fixed.mjs` → `✅ All workspace packages are in the changeset fixed group.`
- `node scripts/check-control-bytes.mjs` → `✅ OK (scanned 5027 tracked text file(s); skipped 85 binary)` — 5027, one more than before the commit, so the new changeset is inside the scanned set. Both touched files also self-scanned clean with `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`.

**Declared narrowing:** repo-wide `pnpm lint` (`turbo run lint`, every package) was not run locally; CI runs the farm regardless. The narrowing is a measurement, not a skip: `eslint.config.js` configures **no type-aware linting** (zero hits for `parserOptions` / `projectService` / `project:`), so a comment-only edit inside one file of one package cannot move the verdict on any file it does not touch — and the package that file lives in was linted in full, all 34 files.

## Out of scope, deliberately

Per #6074: no `$schema` arm added, no URL minted, `OBJECTUI_STRUCTURAL_KEYS` untouched, and the corpus untouched. The first two are closed maintainer rulings; the third needs per-key foreign-retention measurement first (#5334 measured `label` as held out **by name** precisely because admitting `BaseSchema`-adjacent naming keys drives foreign retention from 0 files toward all 46); the fourth is the prohibition #5329 died on. The recall debt itself stays open and tracked at #6075 — this PR neither addresses nor closes that card.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
