### PR TITLE
docs(guide): retire the hand-written version table from the release notes page

### DIFF
--- a/content/docs/guide/release-notes.md
+++ b/content/docs/guide/release-notes.md
@@ -1,71 +1,26 @@
 ---
 title: "Release Notes"
-description: "Release notes for ObjectUI — highlights, breaking changes and migration notes for each version."
+description: "Where to find what shipped in each ObjectUI release — the per-package changelogs and GitHub Releases."
 ---
 
 # Release Notes
 
-This page summarises every released version of ObjectUI. For granular, per-release
-detail, read the `CHANGELOG.md` published inside each `@object-ui/*` package —
-Changesets writes those on every release commit, so they are the source of truth
-for current history. The monorepo
+ObjectUI does not keep a hand-written release history on this page. Two sources carry
+it, both written as part of the release itself:
+
+- **Each package's own `CHANGELOG.md`** — the source of truth for granular history.
+  Changesets writes an entry into every affected `@object-ui/*` package on each release
+  commit, so the changelog beside the package you depend on states exactly what changed
+  in it, including breaking changes and migration notes. Read it in the installed
+  package (`node_modules/@object-ui/<name>/CHANGELOG.md`), on that package's npm page,
+  or in this repository under
+  [`packages/<name>/CHANGELOG.md`](https://github.com/objectstack-ai/objectui/tree/main/packages).
+- **[GitHub Releases](https://github.com/objectstack-ai/objectui/releases)** — every
+  published version, newest first, with its tag and publication date. Start here to see
+  which version is current.
+
+The monorepo
 [CHANGELOG.md](https://github.com/objectstack-ai/objectui/blob/main/CHANGELOG.md)
-is a periodically hand-curated summary, not an auto-maintained record, and can lag
-the latest releases.
-
-## v3.3.0 — 2026-04-17 · First Official Release 🚀
-
-v3.3.0 is the **first official release** of ObjectUI published for third-party
-consumption. All 39 packages under `packages/*` are now published to npm with
-complete release metadata and aligned with `@objectstack/spec` ^4.0.4 and
-`@objectstack/client` v3.3.0.
-
-### Highlights
-
-- **39 published packages** (`@object-ui/*`) with
-  standardized `package.json` metadata, per-package `LICENSE` and
-  `CHANGELOG.md`.
-- **Standard README template** applied across every package (Installation →
-  Quick Start → API → Compatibility → Links → License).
-- **Refreshed docs site** with up-to-date architecture overview, plugin
-  coverage and schema reference.
-- **Thin integration packages** — `@object-ui/app-shell` (~50 KB) and
-  `@object-ui/providers` (~10 KB) enable third-party integrations without
-  inheriting the full console.
-- **Spec v4 alignment** — plain-string `label` types across Navigation
-  schemas; Protocol bridges (`DndProtocol`, `KeyboardProtocol`,
-  `NotificationProtocol`) updated.
-- **Unified Copilot Skills** — single `skills/objectui/` tree aligned with
-  shadcn/ui best practices.
-
-### Upgrade Notes
-
-If you were pinning to the earlier `0.x` prerelease tags:
-
-1. Bump every `@object-ui/*` dependency to `^3.3.0`.
-2. Ensure peer dependencies match the new baselines
-   (`react ^18 || ^19`, `react-dom ^18 || ^19`, TypeScript `>=5.0`).
-3. Replace any `i18n` label objects (`{ key, defaultValue }`) on Navigation
-   schemas with plain strings — runtime `resolveI18nLabel()` still handles
-   both formats for backward compatibility.
-4. Remove imports of the deprecated `ViewDesigner` — its capabilities are now
-   delivered by `ViewConfigPanel`.
-
-### Compatibility Matrix
-
-| Package | Version |
-| --- | --- |
-| `@object-ui/*` | `3.3.0` |
-| `@objectstack/spec` | `^4.0.4` |
-| `@objectstack/client` | `3.3.0` |
-| React | `18.x` or `19.x` |
-| Node.js | `≥ 18` |
-| TypeScript | `≥ 5.0` (strict) |
-| Tailwind CSS | `≥ 3.4` |
-
-## Previous Versions
-
-See the [monorepo CHANGELOG](https://github.com/objectstack-ai/objectui/blob/main/CHANGELOG.md)
-for the hand-curated summary of earlier versions, including the `0.x` development
-series. It is maintained by hand rather than generated, so treat each package's own
-`CHANGELOG.md` as authoritative where the two disagree.
+is a periodically hand-curated summary, not an auto-maintained record, and can lag the
+latest releases. Treat each package's own `CHANGELOG.md` as authoritative where the two
+disagree.

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -1307,22 +1308,70 @@ describe('doc version claims - the scan itself', () => {
   });
 
   it('exercises the version-heading exemption, so the exemption is not decorative', () => {
-    // objectui#3697 names two lines as the control group that must stay green:
+    // objectui#3697 named two lines as the control group that must stay green:
     // release-notes.md's `Bump every @object-ui/* dependency to ^3.3.0` upgrade step
-    // and the `| Node.js | >= 18 |` row of the v3.3.0 compatibility matrix. Green by
-    // NOT MATCHING would prove nothing, so the floor asserts the exemption path is
-    // actually taken, and the file assertion names where.
-    expect(
-      exemptClaims.length,
-      'no claim was structurally exempted - either release-notes.md lost its version ' +
-        'sections or VERSION_HEADING stopped matching them, and the exemption this gate ' +
-        'depends on is now untested',
-    ).toBeGreaterThanOrEqual(8);
+    // and the `| Node.js | >= 18 |` row of its v3.3.0 compatibility matrix. Both are
+    // gone: objectui#5786 retired that page's hand-written version table — it had
+    // drifted ~14 majors behind the packages it described and the maintainer ruled it
+    // away in favour of the per-package `CHANGELOG.md` files — and it was the corpus's
+    // ONLY version-heading section. Measured across that change: `exemptClaims` went
+    // from 8 to 0, and this assertion was the one gate that noticed.
+    //
+    // So the control group cannot be a corpus file any more, and a floor over
+    // `exemptClaims.length` would now be a pin demanding that SOME published page keep
+    // carrying release sections — a shape this repository deliberately no longer has.
+    // The exemption is still live code that every corpus claim passes through, so it is
+    // exercised here against a fixture, via `claimsIn`, the same function the corpus
+    // goes through. The fixture keeps the retired compatibility row verbatim and states
+    // the spec range the way that page did (name, then version, within `SEP`'s six
+    // characters — `Bump every @object-ui/* dependency to ^3.3.0` is a sentence, and a
+    // sentence is not a claim: its name and version sit fourteen characters apart). The
+    // assertion is strictly stronger than the one it replaces: BOTH directions are
+    // pinned on one document, which the corpus arrangement never did — there, "green by
+    // NOT MATCHING" was ruled out only for the exempt side.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-version-claims-'));
+    try {
+      const fixture = path.join(dir, 'release-notes-shaped.md');
+      fs.writeFileSync(
+        fixture,
+        [
+          '# Release Notes',
+          '',
+          'At the time of writing it aligned with `@objectstack/spec` ^4.0.4.',
+          '',
+          '## v3.3.0 — 2026-04-17 · First Official Release',
+          '',
+          '### Compatibility Matrix',
+          '',
+          '| Node.js | >= 18 |',
+          '',
+        ].join('\n'),
+        'utf8',
+      );
 
-    const exemptFiles = new Set(exemptClaims.map((c) => c.file));
-    expect(exemptFiles, 'the v3.3.0 release section must still be reached by the exemption').toContain(
-      'content/docs/guide/release-notes.md',
-    );
+      const claims = claimsIn(fixture);
+      const exempt = claims.filter((c) => c.underVersionHeading !== null);
+      const flagged = claims.filter((c) => c.underVersionHeading === null);
+
+      expect(
+        flagged.map((c) => c.claim),
+        'the claim ABOVE the release heading must stay SCANNED - an exemption that ' +
+          'swallowed the whole file would report green over a live claim',
+      ).toEqual([expect.stringContaining('^4.0.4')]);
+
+      expect(
+        exempt.map((c) => c.claim),
+        'the claim under the release heading must be exempt, or the frozen history this ' +
+          'gate refuses to ratchet would start failing it',
+      ).toEqual([expect.stringContaining('>= 18')]);
+
+      // Via an ANCESTOR heading: the matrix row sits under `### Compatibility Matrix`,
+      // not directly under the release heading. That walk is the part of `collect` a
+      // narrower "nearest heading" rule would silently break.
+      expect(exempt[0].underVersionHeading).toBe('v3.3.0 — 2026-04-17 · First Official Release');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('does not treat a numbered section heading as a release section', () => {


### PR DESCRIPTION
Fixes #5786

Executes the maintainer's ruling of 2026-08-23 (option **D**): the hand-written version
table on `content/docs/guide/release-notes.md` is retired and the page collapses to a
short pointer at the two sources that are written as part of each release. No refresh of
the version numbers, no generation pipeline, no pin test — those were the rejected
options.

## Why not simply refresh it

Refreshing is the intuitive fix and it was ruled out twice over. It is the third instance
of the same shape (#3689 on the CLI page, #3645 across 35 package READMEs): a hand-written
version block that nothing pins drifts again as soon as it is corrected. And it is
currently unanswerable — the releases API and `QUICK_REFERENCE.md` disagree about the
current version, which is the repo-vs-npm divergence #5442 exists to settle. Retiring the
table sidesteps that question rather than enshrining one side of it.

## What the page says now

It names both sources concretely, because three entry points send readers here to learn
what shipped and a pointer that does not say *which* changelog or *where* Releases live
would be worse than a stale page:

- **each package's own `CHANGELOG.md`** — where to read it in the installed package, on
  npm, and in this repository — stated as the source of truth for granular history,
  including breaking changes and migration notes;
- **GitHub Releases**, linked, as the place to see which version is current.

#5785's correction of the granular/summary relationship (the monorepo `CHANGELOG.md` is a
hand-curated summary that can lag, and each package's own file wins where they disagree)
is preserved in substance and now carries the whole page. This change composes with that
PR; it does not undo any of it.

## The coupling this uncovered, and why the test is in the diff

`scripts/__tests__/doc-version-claims.test.ts` pinned this page **by name**:

```ts
expect(exemptFiles, 'the v3.3.0 release section must still be reached by the exemption')
  .toContain('content/docs/guide/release-notes.md');
```

That gate exempts version literals sitting under a version heading (release notes are
frozen history) and ratchets every other literal. Measured across this change, the page's
`## v3.3.0` section was the corpus's **only** version-heading section: `exemptClaims` went
from **8 to 0**, and the assertion above was the one thing in the repository that noticed.

A floor over `exemptClaims.length` would now be a pin demanding that *some* published page
keep carrying release sections — a shape this repository deliberately no longer has. The
exemption is still live code that every corpus claim passes through, so it is now exercised
against a fixture through `claimsIn`, the same function the corpus goes through. The
fixture keeps the retired compatibility row verbatim, and the new assertion is strictly
stronger than the one it replaces: it pins **both** directions on one document (the claim
above the release heading stays scanned, the one under it is exempt, and the exemption is
reached through an *ancestor* heading), where the corpus arrangement ruled out
"green by not matching" on the exempt side only.

Proven to be load-bearing rather than decorative: with `VERSION_HEADING` ablated to a
regex that never matches, the file goes to **2 failed | 16 passed**; restored, **18
passed**. The mutation was confirmed on disk before the run (injected marker present ×1,
original pattern absent), and the ablation script carried a `trap ... EXIT INT TERM`
restore — `git status` was clean afterwards.

## Verification — all at `58e18f484`, the final commit

| check | verdict line |
|:--|:--|
| `node scripts/check-doc-links.mjs` | `Links are valid across 15 scan roots.` |
| `node scripts/check-doc-component-types.mjs` | `✅  Every documented component type is registered.` |
| `node scripts/check-control-bytes.mjs` | `✅  check-control-bytes: OK (scanned 5026 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `vitest run scripts/__tests__/doc-version-claims.test.ts` | `Tests  18 passed (18)` |
| `tsc -p tsconfig.scripts.json` | exit 0 |
| `eslint` on the changed `.ts` | 1 file linted, 0 errors, 0 warnings |
| `turbo run build --filter=@object-ui/site` | `Tasks: 30 successful, 30 total` |

The page was then read out of the prerendered HTML
(`apps/site/.next/server/app/docs/guide/release-notes.html`) rather than assumed to
render: it comes out as a coherent short page — title, description, two bullets and a
closing paragraph — not an orphaned heading, and all three outbound links
(`/tree/main/packages`, `/releases`, `/blob/main/CHANGELOG.md`) are present in the article.

**Narrowing declared:** eslint was run on the one changed `.ts` file rather than repo-wide.
The other changed file is `.md`, and this repo's eslint config names no markdown files, so
the narrowing excludes nothing that eslint would have judged. CI runs the full farm either
way.

**Honest limit:** retiring a documentation surface has no runtime consequence, so there is
no behavioural test to point at. The evidence is negative by nature — nothing still points
at content that no longer exists: `check-doc-links` is green over the page's new links, the
one gate that referenced the removed content is updated in this diff, and a repo-wide grep
for `release-notes` finds only the sidebar entry (`content/docs/guide/meta.json`) and that
test.

## Inbound links: checked, none became misleading

- `content/docs/guide/meta.json` — the sidebar entry, the only thing in the repository that
  links to this page. A reader clicking "Release Notes" now gets an answer to the question
  they arrived with, so it stays.
- `README.md`'s "Changelog (summary)" and the changelog section of
  `content/docs/guide/ci-cd-pipeline.md` point at the root `CHANGELOG.md`, not at this page,
  and both already describe it as a hand-curated summary. Unaffected, and not edited.

No changeset: `content/docs/**` and `scripts/__tests__/**` touch no released package's
`src/`, which `CONTRIBUTING.md` lists explicitly under "No changeset is needed at all", and
`check-changeset-presence.mjs` agrees.

Out of scope and untouched, per the dispatch: the root `CHANGELOG.md`, `QUICK_REFERENCE.md`
and its pin tests, `check-doc-links.mjs`, and #5442's version-divergence question.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_