### PR TITLE
fix(release): align the lane's changeset mirror with both readers and pin it against the installed one

### DIFF
--- a/.changeset/5775-lane-changeset-reader-mirror.md
+++ b/.changeset/5775-lane-changeset-reader-mirror.md
@@ -1,0 +1,12 @@
+---
+---
+
+CI-only change: the `lane` job in `.github/workflows/changeset-release.yml` now scans
+`.changeset/pre/*.md` as well as `.changeset/*.md`, and matches the reader's README
+exclusion case-insensitively (`/^README\.md$/i`) instead of comparing the one exact
+spelling. `scripts/__tests__/changeset-release-lane-mirror.test.ts` pins the step's
+script against the installed `@changesets/read`, executed rather than transcribed, so a
+dependency bump that changes the ignore list fails there instead of drifting.
+
+No published package changes, and no release behaviour changes: `pending_changesets`
+gates only the release job's clear step, and both edits make it count MORE, never less.

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -273,11 +273,46 @@ jobs:
             .changeset
             packages/core
 
-      # ⛔ This must stay a faithful mirror of `readChangesetState` in
-      # `changesets/action`'s `src/index.ts` (it re-exports `@changesets/read`),
-      # because the release job's guard is only correct while the two agree:
+      # ⛔ This must stay a faithful mirror of the changeset reader behind
+      # `readChangesetState` — but "the reader" is TWO copies, at different
+      # majors, and they disagree with each other. Both were MEASURED rather
+      # than read off a changelog (objectui#5775, 2026-08-24):
       #
-      #   - every `.changeset/*.md` counts EXCEPT `README.md`;
+      #   A. `changesets/action@v1` (v1.9.0) BUNDLES `@changesets/read@^0.6.7`.
+      #      Its shipped `dist/` chunk ignores `/^README\.md$/i` and nothing
+      #      else, and it never reads `.changeset/pre/`.
+      #   B. This repository INSTALLS `@changesets/read@1.0.0`, reached through
+      #      the declared `@changesets/cli@3.0.1` (it is not resolvable from the
+      #      repo root: pnpm keeps it under the CLI). It ignores
+      #      `/^README\.md$/i` PLUS the exact names `AGENTS.md`, `CLAUDE.md`
+      #      and `GEMINI.md`, and it ALSO reads `.changeset/pre/*.md`.
+      #
+      # Both ignore dotfiles and anything that is not `*.md`, which the globs
+      # below give for free (no `dotglob`, and the pattern is `*.md`).
+      #
+      # So this step mirrors the UNION: a file counts if EITHER copy would count
+      # it. That is not a hedge, it is the only rule this output's single
+      # consumer admits. `pending_changesets` gates exactly one thing — the
+      # release job's "Clear pending changesets for the publish branch" step —
+      # and that step's obligation is one-directional: leave the tree at zero so
+      # the action takes `runPublish`. OVER-counting runs the clear step
+      # needlessly, and it removes nothing and self-checks. UNDER-counting skips
+      # it while the action still sees a changeset, which is objectui#5442's
+      # silent lost release arriving through the action.
+      #
+      # ⛔ Therefore do NOT "align" this step by ignoring `AGENTS.md` /
+      # `CLAUDE.md` / `GEMINI.md` to match copy B. `.changeset/AGENTS.md` is
+      # invisible to B and PENDING to A — ignoring it here is precisely the
+      # under-count above, on the one filename this repository's conventions
+      # make most likely to appear.
+      #
+      #   - every `.changeset/*.md` AND `.changeset/pre/*.md` counts, EXCEPT a
+      #     README matched case-INSENSITIVELY. Both copies spell it
+      #     `/^README\.md$/i`; this step used to compare the one exact spelling,
+      #     so `ReadMe.md` counted here while both readers ignored it. Only the
+      #     STEM is case-insensitive: the extension is not, on either side
+      #     (`endsWith('.md')` there, a `*.md` glob here), so `notes.MD` is
+      #     ignored by everything as a non-changeset rather than as a README;
       #   - an EMPTY changeset still counts (this repository declares "nothing to
       #     release" with empty frontmatter — see `changeset-presence.yml` — and
       #     the action's `hasChangesets` counts those too, which is why a commit
@@ -286,10 +321,22 @@ jobs:
       #     nothing anyway, so the observable behaviour is unchanged);
       #   - in pre mode ONLY, the ids already listed in `pre.json.changesets` are
       #     filtered out, because the action filters them and would therefore
-      #     publish where a naive file count says "pending". This repository is
-      #     not in pre mode and has no `pre.json`, so that branch is dormant — it
-      #     is written because the failure it prevents (a pre-mode release that
-      #     silently never publishes) is invisible until release day.
+      #     publish where a naive file count says "pending". Ids are relative to
+      #     `.changeset/`, so a `pre/` file's id keeps its `pre/` prefix — that
+      #     is the `id` copy B produces and the form `pre.json` lists. This
+      #     repository is not in pre mode and has no `pre.json`, so that branch
+      #     is dormant — it is written because the failure it prevents (a
+      #     pre-mode release that silently never publishes) is invisible until
+      #     release day.
+      #
+      # PINNED, and executably:
+      # `scripts/__tests__/changeset-release-lane-mirror.test.ts` extracts THIS
+      # step's script from THIS file (never a copy of it) and runs it against the
+      # INSTALLED `@changesets/read` — imported, not transcribed — over one
+      # fixture per case. A bump of that dependency that changes what it ignores
+      # re-fails there instead of drifting silently. Copy A cannot be pinned that
+      # way (a minified chunk behind a moving tag), so the test pins the `@v1`
+      # ref instead: bump the action and it tells you to re-measure A.
       #
       # It fails LOUDLY rather than guessing a lane: this is deterministic file
       # I/O, so an error here means something is wrong that a default would hide.
@@ -310,16 +357,27 @@ jobs:
             fi
           fi
 
+          # `/^README\.md$/i` is how both copies of the reader spell the one
+          # exclusion they agree on, so this case-folds instead of comparing a
+          # single spelling. Same idiom as the release job's clear step.
+          is_readme() {
+            [ "$(printf '%s' "${1##*/}" | tr '[:upper:]' '[:lower:]')" = 'readme.md' ]
+          }
+
           pending=false
-          for file in .changeset/*.md; do
-            name="${file##*/}"
-            if [ "$name" = 'README.md' ]; then
+          for file in .changeset/*.md .changeset/pre/*.md; do
+            if is_readme "$file"; then
               continue
             fi
-            if [ "$in_pre_mode" = true ] && printf '%s\n' "$consumed" | grep -qxF -- "${name%.md}"; then
+            # The reader's `id`: the path relative to `.changeset/`, without the
+            # extension. For a `pre/` file that keeps the `pre/` prefix, which is
+            # the form `pre.json.changesets` lists.
+            id="${file#.changeset/}"
+            id="${id%.md}"
+            if [ "$in_pre_mode" = true ] && printf '%s\n' "$consumed" | grep -qxF -- "$id"; then
               continue
             fi
-            echo "pending changeset: ${name}"
+            echo "pending changeset: ${id}"
             pending=true
           done
 
@@ -657,11 +715,16 @@ jobs:
       # plausibly the shape that makes the clear step unnecessary — which is an
       # argument for revisiting the pin eventually, not for bumping it blind.
       #
-      # Same class of drift, and live under any bump: objectui#5775 records that
-      # the `lane` job's declared mirror of `readChangesetState` already
-      # understates what the installed `@changesets/read` ignores. Any upgrade
-      # re-opens that question, because the mirror tracks a bundled copy this
-      # file does not pin.
+      # Same class of drift, and live under any bump: objectui#5775 measured the
+      # `lane` job's mirror against BOTH readers and found them at different
+      # majors — this action bundles `@changesets/read@^0.6.7`, the repository
+      # installs `1.0.0`, and they disagree on `AGENTS.md` / `CLAUDE.md` /
+      # `GEMINI.md` and on `.changeset/pre/`. The mirror now counts the UNION of
+      # the two and is pinned to the installed copy by
+      # `scripts/__tests__/changeset-release-lane-mirror.test.ts`. The bundled
+      # copy still cannot be pinned from here, so that test also pins THIS `@v1`
+      # ref: bumping the action fails it, which is the prompt to re-measure the
+      # bundle before the mirror's union silently stops covering it.
 
       # ⚠️ THE STEP THAT LETS THE PREDICATE REACH THE ACTION (objectui#5442).
       #

--- a/scripts/__tests__/changeset-release-lane-mirror.test.ts
+++ b/scripts/__tests__/changeset-release-lane-mirror.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * The pin for the `lane` job's changeset mirror in
+ * `.github/workflows/changeset-release.yml` (objectui#5775).
+ *
+ * ## What the mirror is, and why a comment was not enough
+ *
+ * That job's `Detect pending changesets` step re-implements, in bash and before
+ * any install, the file scan that `changesets/action` performs through
+ * `readChangesetState`. Its output gates the release job's clear step, which is
+ * the only thing standing between a release-merge commit and objectui#5442's
+ * silent lost release. The step therefore carried a written declaration of what
+ * the reader counts — and a written declaration is exactly the kind of claim
+ * that is true on the day it is written and unfalsifiable afterwards. It drifted:
+ * it named `README.md` as the whole exclusion list, compared that one spelling
+ * exactly, and never looked at `.changeset/pre/`.
+ *
+ * ## The measurement this file locks (2026-08-24)
+ *
+ * There is no single "the reader". There are two copies, at different majors:
+ *
+ *   A. `changesets/action@v1` is v1.9.0 and BUNDLES `@changesets/read@^0.6.7`.
+ *      Its shipped `dist/` chunk filters
+ *      `!f.startsWith('.') && f.endsWith('.md') && !/^README\.md$/i.test(f)`
+ *      over `.changeset/` only. No `AGENTS.md`, no `.changeset/pre/`.
+ *   B. This repository INSTALLS `@changesets/read@1.0.0`, via the declared
+ *      `@changesets/cli@3.0.1`. It adds the exact names `AGENTS.md`,
+ *      `CLAUDE.md`, `GEMINI.md` to the ignore list and additionally reads
+ *      `.changeset/pre/*.md`, giving those files ids like `pre/probe`.
+ *
+ * The two disagree in OPPOSITE directions, so "match the reader" has no single
+ * answer and matching B alone would be a regression: `.changeset/AGENTS.md` is
+ * invisible to B and PENDING to A, so a mirror that ignored it would skip the
+ * clear step while the action still saw a changeset. The mirror therefore counts
+ * the UNION, and the assertions below are split accordingly — the cases where it
+ * must AGREE with the installed reader, and the three cases where it must
+ * deliberately OVER-count it.
+ *
+ * ## Why this reads the installed dependency instead of a constant
+ *
+ * A pin transcribed from the same source as the code it guards drifts in
+ * lockstep with it. So nothing here spells out what the reader ignores: the
+ * reader is imported and executed over fixtures, and the mirror is EXTRACTED
+ * from the workflow file rather than copied. A `@changesets/read` bump that
+ * changes the ignore list changes these results and fails here.
+ *
+ * ⚠️ Resolution: `@changesets/read` is a transitive dependency and pnpm does not
+ * hoist it, so it is NOT resolvable from the repo root — it has to be resolved
+ * THROUGH `@changesets/cli`, the declared devDependency that owns it. Resolving
+ * it any other way (a `.pnpm/` glob, a vendored copy) would answer about a file
+ * the CLI never loads. It is ESM-only (`"type": "module"`, a single `exports`
+ * target, one `dist/index.mjs` on disk), so there is no require-vs-import
+ * divergence to pick the wrong half of.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+// ── the installed reader, resolved through the package that owns it ──────────
+const rootRequire = createRequire(path.join(repoRoot, 'noop.cjs'));
+const cliManifestPath = rootRequire.resolve('@changesets/cli/package.json');
+const fromCli = createRequire(cliManifestPath);
+const readerManifestPath = fromCli.resolve('@changesets/read/package.json');
+const readerManifest = JSON.parse(fs.readFileSync(readerManifestPath, 'utf8')) as {
+  name: string;
+  version: string;
+};
+const readerEntryPath = fromCli.resolve('@changesets/read');
+const { readChangesets } = (await import(pathToFileURL(readerEntryPath).href)) as {
+  readChangesets: (rootDir: string, sinceRef?: string) => Promise<{ id: string }[]>;
+};
+
+// ── the mirror, extracted from the workflow (never copied) ───────────────────
+const workflowPath = path.join(repoRoot, '.github/workflows/changeset-release.yml');
+const workflow = parseYaml(fs.readFileSync(workflowPath, 'utf8')) as {
+  jobs: Record<string, { steps: { id?: string; name?: string; uses?: string; run?: string }[] }>;
+};
+const detectStep = workflow.jobs.lane.steps.find((step) => step.id === 'detect');
+const mirrorScript = detectStep?.run ?? '';
+
+/** A changeset the reader can parse. Its content is irrelevant to both scans. */
+const CHANGESET = "---\n'@object-ui/core': patch\n---\n\nfixture\n";
+/** The empty-frontmatter form this repository uses for "nothing to release". */
+const EMPTY_CHANGESET = '---\n---\n\nfixture\n';
+
+function makeFixture(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-mirror-'));
+  fs.mkdirSync(path.join(dir, '.changeset'), { recursive: true });
+  for (const [relative, body] of Object.entries(files)) {
+    const full = path.join(dir, '.changeset', relative);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+  return dir;
+}
+
+type MirrorResult = { pending: string | undefined; ids: string[] };
+
+/**
+ * Runs the workflow step's own script against a fixture, with the GitHub
+ * runner's variables supplied. `set -u` is on in that script, so every variable
+ * it reads has to be present or the run fails for the wrong reason.
+ */
+function runMirror(dir: string, script: string = mirrorScript): MirrorResult {
+  const outputFile = path.join(dir, 'gh-output');
+  const summaryFile = path.join(dir, 'gh-summary');
+  fs.writeFileSync(outputFile, '');
+  fs.writeFileSync(summaryFile, '');
+  const stdout = execFileSync('bash', ['-c', script], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GITHUB_OUTPUT: outputFile,
+      GITHUB_STEP_SUMMARY: summaryFile,
+      GITHUB_EVENT_NAME: 'push',
+      GITHUB_SHA: '0'.repeat(40),
+      REFRESH_VERSION_PR: 'false',
+    },
+  });
+  const output = fs.readFileSync(outputFile, 'utf8');
+  return {
+    pending: /^pending_changesets=(\S+)$/m.exec(output)?.[1],
+    ids: [...stdout.matchAll(/^pending changeset: (.+)$/gm)].map((match) => match[1]).sort(),
+  };
+}
+
+async function runReader(dir: string): Promise<string[]> {
+  return (await readChangesets(dir)).map((changeset) => changeset.id).sort();
+}
+
+/** One case: what the installed reader saw, and what the mirror saw. */
+async function bothScans(files: Record<string, string>, script: string = mirrorScript) {
+  const dir = makeFixture(files);
+  try {
+    const mirror = runMirror(dir, script);
+    return { reader: await runReader(dir), mirror: mirror.ids, pending: mirror.pending };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('the lane mirror reads the installed @changesets/read, not a transcription of it', () => {
+  it('resolves the reader through @changesets/cli, from inside node_modules', () => {
+    // Not an aesthetic check. If this ever resolves to something inside the
+    // repository, the pin has started guarding a copy instead of the dependency.
+    expect(readerManifest.name).toBe('@changesets/read');
+    expect(readerManifestPath).toContain(`${path.sep}node_modules${path.sep}`);
+    expect(readerEntryPath).toContain(`${path.sep}node_modules${path.sep}`);
+    expect(readerEntryPath.startsWith(path.join(repoRoot, 'scripts'))).toBe(false);
+    expect(typeof readChangesets).toBe('function');
+    // Recorded so a failure elsewhere in this file names the version it measured.
+    expect(readerManifest.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('extracts the mirror from the workflow rather than restating it', () => {
+    expect(detectStep?.name).toBe('Detect pending changesets');
+    expect(mirrorScript).toContain('pending_changesets=');
+    expect(mirrorScript).toContain('.changeset/pre/*.md');
+  });
+});
+
+describe('cases where the mirror must AGREE with the installed @changesets/read', () => {
+  it('counts an ordinary changeset', async () => {
+    const { reader, mirror } = await bothScans({ 'brave-pandas-smile.md': CHANGESET });
+    expect(mirror).toEqual(['brave-pandas-smile']);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('counts an empty-frontmatter changeset — this repo\'s "nothing to release" form', async () => {
+    const { reader, mirror } = await bothScans({ 'ci-only.md': EMPTY_CHANGESET });
+    expect(mirror).toEqual(['ci-only']);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('ignores README.md', async () => {
+    const { reader, mirror } = await bothScans({ 'README.md': '# changesets\n' });
+    expect(mirror).toEqual([]);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('ignores a non-canonically-cased README — the reader matches /^README\\.md$/i', async () => {
+    // The drift objectui#5775 names, with its spelling corrected by measurement.
+    // The card offered `ReadMe.MD` as the case, and that one proves nothing:
+    // BOTH scans drop it on the EXTENSION (the reader's `endsWith('.md')` and
+    // the mirror's `*.md` glob are each case-SENSITIVE), so they agreed all
+    // along. The genuine disagreement needs a canonical extension and a
+    // non-canonical stem, which is what this fixture is.
+    const { reader, mirror } = await bothScans({ 'ReadMe.md': '# changesets\n' });
+    expect(mirror).toEqual([]);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('ignores a lowercase readme.md', async () => {
+    const { reader, mirror } = await bothScans({ 'readme.md': '# changesets\n' });
+    expect(mirror).toEqual([]);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('ignores an uppercase .MD extension — for the extension, not the README rule', async () => {
+    // Pinned separately so the reason stays visible: if either side ever
+    // case-folds the extension, this file starts counting and the case above
+    // stops being the one that tests the README rule.
+    const { reader, mirror } = await bothScans({ 'brave-pandas-smile.MD': CHANGESET });
+    expect(mirror).toEqual([]);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('counts .changeset/pre/*.md, with the `pre/` prefix the reader gives their ids', async () => {
+    // The other half of the drift: the mirror globbed `.changeset/*.md` only, so
+    // this whole directory was invisible to it.
+    const { reader, mirror } = await bothScans({ 'pre/probe.md': CHANGESET });
+    expect(mirror).toEqual(['pre/probe']);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('ignores a README inside .changeset/pre/ too — the reader filters on the basename', async () => {
+    const { reader, mirror } = await bothScans({ 'pre/README.md': '# pre\n' });
+    expect(mirror).toEqual([]);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('ignores dotfiles', async () => {
+    const { reader, mirror } = await bothScans({ '.hidden.md': CHANGESET });
+    expect(mirror).toEqual([]);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('ignores files that are not .md', async () => {
+    const { reader, mirror } = await bothScans({ 'notes.txt': 'not a changeset\n' });
+    expect(mirror).toEqual([]);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('counts a lowercase `agents.md` — the reader compares those three names EXACTLY', async () => {
+    // Only the README exclusion is case-insensitive. A mirror that case-folded
+    // the whole ignore list would under-count here against both readers.
+    const { reader, mirror } = await bothScans({ 'agents.md': CHANGESET });
+    expect(mirror).toEqual(['agents']);
+    expect(mirror).toEqual(reader);
+  });
+
+  it('reports pending=false for a tree the reader also finds empty', async () => {
+    const { reader, mirror, pending } = await bothScans({ 'README.md': '# changesets\n' });
+    expect(reader).toEqual([]);
+    expect(mirror).toEqual([]);
+    expect(pending).toBe('false');
+  });
+});
+
+describe('cases where the mirror must deliberately OVER-count the installed reader', () => {
+  // `changesets/action@v1` bundles `@changesets/read@^0.6.7`, which does NOT
+  // ignore these three. The mirror gates the clear step, whose obligation is
+  // one-directional, so counting them is required: ignoring them would skip the
+  // clear step while the action still saw a changeset (objectui#5442).
+  //
+  // One assertion per name, so a regression names which one it broke.
+  for (const name of ['AGENTS.md', 'CLAUDE.md', 'GEMINI.md']) {
+    it(`counts .changeset/${name}, which the installed reader ignores`, async () => {
+      const { reader, mirror, pending } = await bothScans({ [name]: CHANGESET });
+      expect(reader).toEqual([]);
+      expect(mirror).toEqual([name.replace(/\.md$/, '')]);
+      expect(pending).toBe('true');
+    });
+  }
+
+  it('still pins the action ref those three names are justified by', () => {
+    // The bundled copy is a minified chunk behind a moving tag, so it cannot be
+    // executed here. What CAN be pinned is the ref: bump it and re-measure the
+    // bundle, because the union above may no longer cover it.
+    const uses = workflow.jobs.release.steps.map((step) => step.uses).filter(Boolean);
+    expect(uses).toContain('changesets/action@v1');
+  });
+});
+
+describe('the pin can fail (non-vacuity)', () => {
+  // Each mutation is asserted to have APPLIED before its result is read — a
+  // no-op edit would leave the unmutated script running and report a healthy
+  // green that means nothing.
+  function mutate(from: string, to: string): string {
+    const mutated = mirrorScript.replace(from, to);
+    expect(mutated, `mutation did not apply: ${from}`).not.toBe(mirrorScript);
+    return mutated;
+  }
+
+  it('goes red when `.changeset/pre/` is dropped from the mirror', async () => {
+    const script = mutate('for file in .changeset/*.md .changeset/pre/*.md; do', 'for file in .changeset/*.md; do');
+    const { reader, mirror } = await bothScans({ 'pre/probe.md': CHANGESET }, script);
+    expect(reader).toEqual(['pre/probe']);
+    expect(mirror).toEqual([]);
+    expect(mirror).not.toEqual(reader);
+  });
+
+  it('goes red when the README exclusion is compared case-sensitively again', async () => {
+    const script = mutate(
+      `[ "$(printf '%s' "\${1##*/}" | tr '[:upper:]' '[:lower:]')" = 'readme.md' ]`,
+      `[ "\${1##*/}" = 'README.md' ]`,
+    );
+    const { reader, mirror } = await bothScans({ 'ReadMe.md': '# changesets\n' }, script);
+    expect(reader).toEqual([]);
+    expect(mirror).toEqual(['ReadMe']);
+    expect(mirror).not.toEqual(reader);
+  });
+
+  it('goes red when the mirror stops counting AGENTS.md', async () => {
+    // The mutation the mirror's ⛔ comment forbids, made executable: this is the
+    // under-count that skips the clear step while the action still sees a file.
+    const script = mutate(
+      'if is_readme "$file"; then',
+      'if is_readme "$file" || [ "${file##*/}" = \'AGENTS.md\' ]; then',
+    );
+    const { mirror, pending } = await bothScans({ 'AGENTS.md': CHANGESET }, script);
+    expect(mirror).toEqual([]);
+    expect(pending).toBe('false');
+  });
+});


### PR DESCRIPTION
Fixes #5775

The `lane` job's `Detect pending changesets` step carried a ⛔ declaration that it
is a faithful mirror of the changeset reader behind `readChangesetState`, and had
drifted from it. This aligns the mirror and — the durable half — pins it against
the installed dependency so the next `@changesets/read` bump re-fails honestly
instead of drifting again.

## ⚠️ One deliberate deviation from the dispatch order, and why

The order said "align the mirror with the installed reader". Re-deriving first
turned up a fact neither the card nor the order had: **there is no single reader.
There are two copies, at different majors, and they disagree in opposite
directions.** Both measured 2026-08-24, on this branch's `origin/main` base
`0fe7d0649`:

| | copy A — what the action runs | copy B — what this repo installs |
|---|---|---|
| identity | `changesets/action@v1` is **v1.9.0**, and its `package.json` depends on `@changesets/read@^0.6.7` | **`@changesets/read@1.0.0`** |
| how it was read | its shipped `dist/` chunk (`dist/lt-CTruzcfj.js`), which is what actually executes | `.../node_modules/.pnpm/@changesets+read@1.0.0/node_modules/@changesets/read/dist/index.mjs` |
| ignores | `/^README\.md$/i` and nothing else | `/^README\.md$/i` **plus** the exact names `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` |
| `.changeset/pre/*.md` | **never read** | **read**, with ids like `pre/probe` |
| both | ignore dotfiles and anything not `*.md` | same |

Copy A's filter, lifted verbatim out of the bundle:

```js
o=r.filter(e=>!e.startsWith(`.`)&&e.endsWith(`.md`)&&!/^README\.md$/i.test(e))
```

So matching copy B *alone* would have been a regression, not a fix.
`.changeset/AGENTS.md` — the single most likely file to appear, and the one the
card leads with — is **invisible to B and PENDING to A**. `pending_changesets`
gates exactly one thing, the release job's `Clear pending changesets for the
publish branch` step, whose obligation is one-directional: leave the tree at zero
so the action takes `runPublish`. Over-counting runs that step needlessly (it
removes nothing and self-checks). Under-counting skips it while the action still
sees a changeset — which is #5442's silent lost release, arriving through the
action instead of through the job guard.

**The mirror therefore counts the UNION: a file counts if either copy would
count it.** That satisfies the order's other ⛔ ("do not weaken the lane's
behaviour"), which the literal reading would have violated. The residual
question — whether `changesets/action@v1` should be pinned to a SHA so the mirror
has a stable referent at all — is filed separately as #6081 rather than decided
here.

## What changed in the mirror

Both edits make it count **more**, never less:

- `.changeset/pre/*.md` is scanned alongside `.changeset/*.md`, and ids are now
  the path relative to `.changeset/` minus the extension, so a `pre/` file keeps
  its `pre/` prefix — the form both copy B's `id` and `pre.json.changesets` use;
- the README exclusion is case-folded (`/^README\.md$/i`), matching the same
  `tr '[:upper:]' '[:lower:]'` idiom the clear step already uses, instead of
  comparing the single spelling `README.md`.

`AGENTS.md` / `CLAUDE.md` / `GEMINI.md` deliberately keep counting, with a ⛔
comment saying so and naming the failure that ignoring them would cause.

**A correction to the card, found by measurement.** The card lists
`.changeset/ReadMe.MD` as a differing case ("ignored by the reader, counted by
the mirror"). It is not: both sides drop it on the **extension** — the reader's
`endsWith('.md')` and the mirror's `*.md` glob are each case-*sensitive* — so
they agreed all along. The genuine disagreement needs a canonical extension and a
non-canonical stem (`ReadMe.md`, `readme.md`). The pin now carries all three
fixtures, with the uppercase-extension one asserted separately so the reason
stays visible.

## The pin — `scripts/__tests__/changeset-release-lane-mirror.test.ts`

It does not restate anything:

- the **mirror** is extracted from `.github/workflows/changeset-release.yml`
  (`jobs.lane.steps[id=detect].run`) and executed under `bash`, never copied;
- the **reader** is `import`ed from the installed package and executed over
  fixtures, so nothing here transcribes an ignore list. A bump that changes what
  it ignores changes these results.

⚠️ **Resolution hazard, handled explicitly.** `@changesets/read` is transitive and
pnpm does not hoist it: it is **not resolvable from the repo root** at all, and
has to be resolved *through* `@changesets/cli` — the declared devDependency that
owns it. Measured:

```
root resolve @changesets/read => FAILED MODULE_NOT_FOUND
cli pkg json: .../node_modules/.pnpm/@changesets+cli@3.0.1/node_modules/@changesets/cli/package.json
read pkg json: .../node_modules/.pnpm/@changesets+read@1.0.0/node_modules/@changesets/read/package.json
read version: 1.0.0
read type: module exports: {".":"./dist/index.mjs","./package.json":"./package.json"}
files on disk: index.d.mts, index.mjs
```

No dual-package split to pick the wrong half of: `"type": "module"`, one
`exports` target, one file on disk. The test asserts the resolved paths are
inside `node_modules` and outside `scripts/`, so it cannot silently start
guarding a copy.

Assertions are **one per case**, so a regression names which one broke:

- 12 cases where the mirror must **agree** with the installed reader — ordinary
  changeset, empty-frontmatter changeset, `README.md`, `ReadMe.md`, `readme.md`,
  uppercase `.MD` extension, `pre/probe.md`, `pre/README.md`, `.hidden.md`,
  `notes.txt`, lowercase `agents.md` (the ignore list is case-*sensitive* for
  those three names), and `pending=false` on an empty tree;
- 3 cases where it must deliberately **over-count** the installed reader —
  `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, one `it()` each;
- a pin on the `changesets/action@v1` ref itself, since copy A cannot be executed
  from a test: bump the action and this fails, which is the prompt to re-measure
  the bundle before assuming the union still covers it.

## Non-vacuity — the pin was observed failing

Three mutations live **inside** the test file, so non-vacuity stays proven on
every CI run rather than being a claim in this description. Each asserts the
mutation applied before its result is read (a no-op edit would leave the real
script running and report a meaningless green).

On top of that, the workflow itself was mutated on the committed tree and the
pin observed going red, then green on restore. The mutation was confirmed on
disk against the **lane step's own YAML-extracted script** — not a bare
`git diff` — because the release job's clear step carries a byte-identical loop
and helper body, so a naive anchor lands on the wrong step and still reports a
healthy diff. Both legs restore under a `trap … EXIT INT TERM`:

```
=== MUTATION 1: drop .changeset/pre/*.md from the LANE mirror's glob ===
LANE step's own script: removed-text before=1 after=0 | injected-text after=1
MUTATION_1_VITEST_EXIT=1
     × extracts the mirror from the workflow rather than restating it
     × counts .changeset/pre/*.md, with the `pre/` prefix the reader gives their ids
     × goes red when `.changeset/pre/` is dropped from the mirror
      Tests  3 failed | 18 passed (21)
RESTORE LEG: removed-text back in LANE script = 1 (expect 1)

=== MUTATION 2: put back the exact-spelling README compare (LANE step) ===
LANE step's own script: removed-text after=0 (expect 0) | injected-text after=1 (expect 1)
MUTATION_2_VITEST_EXIT=1
     × ignores a non-canonically-cased README — the reader matches /^README\.md$/i
     × ignores a lowercase readme.md
     × goes red when the README exclusion is compared case-sensitively again
      Tests  3 failed | 18 passed (21)
```

An earlier attempt at mutation 2 hit `AssertionError: anchor count 2` and its
reading was **discarded** rather than re-run until something landed — that is the
clear step's identical helper, and it is why the confirmation is anchored on the
extracted lane script.

## Gates — union re-run on the final commit `254f76435`

Run from the repo root (never package-scoped, per objectui#3378), each quoting
its own verdict line:

| gate | verdict |
|---|---|
| `pnpm exec vitest run scripts/` | `Test Files  66 passed (66)` · `Tests  1803 passed (1803)` |
| `pnpm exec vitest run scripts/__tests__/changeset-release-lane-mirror.test.ts` | `Test Files  1 passed (1)` · `Tests  21 passed (21)` |
| `pnpm type-check:scripts` | `tsc -p tsconfig.scripts.json` — exit 0, no diagnostics |
| `pnpm lint:root` | `✖ 26 problems (0 errors, 26 warnings)` — all pre-existing `no-explicit-any` in files this PR does not touch |
| `pnpm check:control-bytes` | `✅  check-control-bytes: OK (scanned 5028 tracked text file(s); skipped 85 binary).` |
| `pnpm changeset:check` | `✅  All workspace packages are in the changeset fixed group.` · `✅  No changeset declares a major bump.` |

Exit codes were captured **before** any pipe (`cmd > file 2>&1; EXIT=$?`), not
after a `tail`.

**Lint scope, as a measurement rather than an omission.** The repo-wide
`pnpm lint` (`turbo run lint`) is CI's; what ran here is `lint:root`, unmodified,
which is the *governing* config for every file in this diff. (1) The population
comes from that script's own ignore patterns — `packages/*/**`, `examples/*/**`,
`apps/*/**`, `docs/**` — and this diff contains **zero** files in any of them
(`.changeset/…`, `.github/workflows/…`, `scripts/__tests__/…`). (2) The new file
was also linted alone with `--no-inline-config --format json`: `files linted: 1`,
`errors 0`, `warnings 0`. (3) `eslint.config.js` declares no `projectService`,
`project:`, `tsconfigRootDir` or `recommendedTypeChecked`, so linting is not
type-aware and this diff cannot move the verdict on any file it does not touch.

## Scope

Only the `lane` job's mirror was touched inside `changeset-release.yml`. The
release job, its `if:`, the clear step, the npm-presence predicate and the
`changesets/action@v1` steps are unchanged — as are `check-changeset-presence.mjs`
(PR #6073 is open against it), `check-changeset-fixed`, `check-changeset-no-major`
and the release workflow's behaviour.

One in-place fix beyond the mirror step, named here because an unnamed drive-by
is unreviewable: the release job's header comment cited this issue as a *live*
defect ("the mirror ... **already understates** what the installed
`@changesets/read` ignores"). Landing this PR would have made that sentence false
while leaving it reading as authoritative — the same defect class the card is
about. It now records the measurement and points at the pin. No behaviour, no
`uses:`, no `if:` was touched.

The changeset carries empty frontmatter: nothing published changes.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_