### PR TITLE
refactor(types): retire the orphaned ObjectTrigger and ObjectRelationship exports

### DIFF
--- a/.changeset/5859-retire-orphaned-object-exports.md
+++ b/.changeset/5859-retire-orphaned-object-exports.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/types': minor
+---
+
+`ObjectTrigger` and `ObjectRelationship` are removed from `@object-ui/types` — two
+hand-written interfaces orphaned by the `ObjectSchemaMetadata` derivation
+(objectui#5859, triage adjudication 2026-08-24; the derivation itself was
+objectui#5362).
+
+**Breaking for anyone importing either name.** The two symbols are, verbatim:
+
+- `ObjectTrigger` — the `{ name, when, on, condition?, action, config? }` trigger
+  configuration
+- `ObjectRelationship` — the `{ name, object, type, foreign_key?, cascade_delete? }`
+  relationship configuration
+
+Both existed solely to type members of the retired hand-written object-document mirror:
+`triggers?: ObjectTrigger[]` and `relationships?: ObjectRelationship[]`. objectui#5362
+replaced that mirror by deriving `ObjectSchemaMetadata` from `@objectstack/spec/data`'s
+`ServiceObject`, and the spec's object document declares neither member — so the two
+interfaces have had nothing to type since. objectui#5362 deliberately left them standing
+because cutting published exports is a separate decision from the ruled derivation; this
+is that decision.
+
+Measured before removing, on `main`: zero references in this repo outside the declaration
+and the `src/index.ts` re-export (`packages/`, `apps/`, `examples/`, `*.ts`/`*.tsx`,
+`node_modules` and `dist` excluded), and zero in the sibling `objectstack` checkout, which
+does import `@object-ui/types` in eleven files. Absence of a spec correspondence was
+verified at type level against the installed `@objectstack/spec` 17.2.0 rather than
+inherited from the card: neither `triggers` nor `relationships` is a key of
+`ServiceObject`. `DataModelDesigner`'s `relationships` state is its own local model and
+never referenced these types.
+
+**That measurement cannot see npm.** In-repo zero is not consumer zero — an external
+application importing either name from `@object-ui/types` will fail to compile after this
+release, and nothing in this repository can detect that. Both names are spelled out above
+so a host can search its own sources for them. If you were importing either, the shapes
+were client-side vocabulary with no runtime behaviour and no spec backing: copy the
+interface into your own code, or model the concept against `@objectstack/spec`, which owns
+the object document.
+
+Type-only change; nothing is emitted and no runtime behaviour moves. Ships `minor`, not
+`major`, per the version-alignment convention in AGENTS.md — objectui's major tracks
+`@objectstack`'s, and breaking changes of objectui's own carry `minor` with the semantics
+stated in the body.

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -815,36 +815,6 @@ export type FieldMetadata =
   | MasterDetailFieldMetadata;
 
 /**
- * Object trigger configuration (Phase 3.1.3)
- */
-export interface ObjectTrigger {
-  /**
-   * Trigger name
-   */
-  name: string;
-  /**
-   * When to execute the trigger
-   */
-  when: 'before' | 'after';
-  /**
-   * Which operation triggers this
-   */
-  on: 'create' | 'update' | 'delete' | 'read';
-  /**
-   * Trigger condition (optional)
-   */
-  condition?: string;
-  /**
-   * Action to execute
-   */
-  action: 'validation' | 'workflow' | 'notification' | 'calculation' | 'custom';
-  /**
-   * Action configuration
-   */
-  config?: Record<string, any>;
-}
-
-/**
  * Object document type — derived from `@objectstack/spec/data` rather than
  * restated (objectui#5362; maintainer ruling 2026-08-20: the object document
  * type belongs to `@objectstack/spec`, objectui derives rather than
@@ -929,29 +899,3 @@ export type ObjectSchemaMetadata = ServiceObject & ObjectSchemaClientExtensions;
  */
 import type { ObjectIndex } from '@objectstack/spec/data';
 export type { ObjectIndex };
-
-/**
- * Object relationship configuration
- */
-export interface ObjectRelationship {
-  /**
-   * Relationship name
-   */
-  name: string;
-  /**
-   * Related object
-   */
-  object: string;
-  /**
-   * Relationship type
-   */
-  type: 'one-to-one' | 'one-to-many' | 'many-to-one' | 'many-to-many';
-  /**
-   * Foreign key field
-   */
-  foreign_key?: string;
-  /**
-   * Cascade delete
-   */
-  cascade_delete?: boolean;
-}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -474,11 +474,9 @@ export type {
   RatingFieldMetadata,
   MasterDetailFieldMetadata,
   FieldMetadata,
-  ObjectTrigger,
   ObjectSchemaMetadata,
   ObjectSchemaClientExtensions,
   ObjectIndex,
-  ObjectRelationship,
 } from './field-types.js';
 
 // System / audit / ownership field classification — runtime helper + name set,


### PR DESCRIPTION
Fixes #5859

Retires `ObjectTrigger` and `ObjectRelationship` from `@object-ui/types` — two hand-written interfaces orphaned by the `ObjectSchemaMetadata` derivation (#5362). Option A of the card, per the triage adjudication of 2026-08-24.

Verified at head `2d5cadc6d`.

## What was removed

| Symbol | Declaration | Barrel |
| --- | --- | --- |
| `ObjectTrigger` | `packages/types/src/field-types.ts:817` | `packages/types/src/index.ts:477` |
| `ObjectRelationship` | `packages/types/src/field-types.ts:902` | `packages/types/src/index.ts:480` |

Both halves for both symbols — declaration and barrel entry together. Deleting either half alone is a build break or a dead declaration. 58 lines removed, type-only; nothing is emitted and no runtime behaviour moves.

## Why they are orphans

Both existed solely to type members of the hand-written object-document mirror that #5362 retired: `triggers?: ObjectTrigger[]` and `relationships?: ObjectRelationship[]`. That mirror is now derived from `@objectstack/spec/data`'s `ServiceObject`, and the spec's object document declares neither member. `DataModelDesigner`'s `relationships` state is its own local model and never referenced these types.

## Measurements

The card's premise was re-measured rather than inherited. Every instrument below was given a control, because a zero-hit from an untested instrument is not a measurement.

**Reference sweep** (`packages/`, `apps/`, `examples/`, `*.ts`/`*.tsx`, `node_modules` and `dist` excluded): both names appear only at their own declaration and the barrel re-export. Control by the identical method: `ObjectSchemaMetadata` in 3 files, `ObjectIndex` in 2, `FieldMetadata` in 26 — the instrument finds live names.

**Cross-repo probe** in the sibling `objectstack` checkout (head `3637731`): zero hits for both names. Control: that repo imports `@object-ui/types` in 11 files, so the probe could have found a cross-repo consumer had one existed.

**Spec correspondence**, verified at type level against the installed `@objectstack/spec` 17.2.0 rather than by grep: neither `triggers` nor `relationships` is a key of `ServiceObject`. The probe carried controls in both directions — `fields` and `name` assert present, and flipping one expectation made it fail with `error TS2322`, so the instrument can produce both answers. The `triggers` hits elsewhere in the spec are the plugin-manifest legacy alias (`triggers` maps to `hooks`) and webhook/automation events, neither of which is the object document.

## Verification, and why the green means something

A deletion's verification is the reverse of a feature's: the sweep staying **green** is the positive evidence nothing consumed the symbols.

That green is weak alone — it is equally consistent with a build that never looked. So the same sweep was shown to go **red**: removing `FieldMetadata`, a live sibling on the *same barrel line*, rebuilt to `dist`, produced `error TS2724: '"@object-ui/types"' has no exported member named 'FieldMetadata'` at three consumer sites in `packages/plugin-detail`, exit 2. The sweep detects exactly the failure a wrongly-removed export causes.

| Gate | Exit |
| --- | --- |
| `pnpm --filter @object-ui/types type-check` | 0 |
| `vitest run packages/types/src` — 56 files, 615 tests | 0 |
| `pnpm --filter '...@object-ui/types' type-check` — 42 consumers, all `Done` | 0 |
| `eslint` over the merge-base delta | 0 (6 pre-existing `any` warnings, 0 errors) |
| `pnpm check:esm-specifiers` | 0 |

The prefix form `...@object-ui/types` is the **downstream/dependent** direction — 42 packages, against 1 for the suffix form, which is the correct direction for a published-type removal. `apps/site` and `packages/components` pass because `@object-ui/react-runtime` was built first. `check:esm-specifiers` was run although the diff moves no relative import.

## Caveat this PR cannot measure away

**In-repo zero is not npm zero.** This is a published removal and an external consumer cannot be detected from this repository. An application importing either name will fail to compile after release. The changeset names both symbols verbatim so a host can search its own sources, and states the caveat rather than implying the removal is free.

Changeset ships **`minor`**, not `major`: objectui's major tracks `@objectstack`'s, and `check-changeset-no-major.mjs` refuses `major` outright.

Draft, not enqueued, no auto-merge — the PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_