### PR TITLE
fix(hooks): close the backslash fail-open in guard-shared-stash.sh split_segments()

### DIFF
--- a/.claude/hooks/guard-shared-stash.selftest.sh
+++ b/.claude/hooks/guard-shared-stash.selftest.sh
@@ -81,6 +81,24 @@ expect allow 'grep -rn "cd x && git stash pop" .claude/'
 expect allow 'echo "never run git stash pop in a shared checkout"'
 expect allow 'git grep -n "git stash"'
 
+echo "== an UNQUOTED \\\" opens no quote, so the stash behind it is still seen (objectstack#11131) =="
+# The measured hole: segmentation read the escaped `"` as OPENING a quoted region that never
+# closed. Every separator behind it went inert, the command collapsed into one `echo`
+# segment, and the real `git stash` was just another argument.
+expect block 'echo \" ; git stash'
+expect block 'echo \" ; git stash pop'
+expect block 'printf \" ; git stash drop'
+expect block "$(printf 'echo \\"\ngit stash pop\n')"
+# Precision twins: the escape must not manufacture a stash where none is run, and the forms
+# this guard deliberately allows stay allowed when reached through the same escape. (Upstream's
+# twin aims the command at a linked worktree; this hook reads no cwd, so the SHA-pinned and
+# read-only allow-list is the analogous precision surface.)
+expect allow 'echo \" ; echo hello'
+expect allow 'echo \" ; cat README.md'
+expect allow 'echo a\ b'
+expect allow 'echo \\ ; grep -n worktree README.md'
+expect allow 'echo \" ; git stash list'
+
 echo "== escape hatch =="
 expect allow 'git stash pop' OS_ALLOW_STASH=1
 

--- a/.claude/hooks/guard-shared-stash.sh
+++ b/.claude/hooks/guard-shared-stash.sh
@@ -46,8 +46,8 @@
 # for anyone who means it. Widening it to string-match anywhere in the command would block
 # every `grep "git stash"` run against this very file.
 #
-# Self-test (32 cases, no network, no build): .claude/hooks/guard-shared-stash.selftest.sh
-# 32 = 30 `expect ` lines + 2 inline specials (empty-tool_input fail-open, no-jq fallback).
+# Self-test (41 cases, no network, no build): .claude/hooks/guard-shared-stash.selftest.sh
+# 41 = 39 `expect ` lines + 2 inline specials (empty-tool_input fail-open, no-jq fallback).
 # Re-derive when the matrix changes: `grep -c '^expect ' <selftest>` + 2, and the run's own
 # tail prints the total ("N passed, N failed") — keep this number equal to it.
 
@@ -75,6 +75,14 @@ fi
 # A separator inside '…' or "…" does NOT split, so writing *about* the ban is never caught
 # by the ban: `grep -n "cd x && git stash pop" AGENTS.md` stays one segment whose first
 # word is grep. (objectstack#4890's lesson — the PR writing a rule must not trip it.)
+#
+# OUTSIDE quotes a backslash escapes the NEXT character, so an escaped `\"` opens no quoted
+# region at all. Without a branch for it this pass read that `"` as OPENING a region that
+# never closed, went inert for every separator behind it, collapsed the whole command into
+# one segment whose head word was the harmless one, and waved a real `git stash` through as
+# a mere argument of `echo`. That is a fail-OPEN in the backstop for the one rule whose
+# breach silently corrupts ANOTHER agent's work (objectstack#11131, the same defect the
+# sibling hook guard-main-checkout-bash.sh carried; objectui#6042).
 segments=()
 split_segments() {
   local s="$1" seg="" q="" ch i n=${#1}
@@ -86,6 +94,15 @@ split_segments() {
       continue
     fi
     case "$ch" in
+      '\')
+        # An escaped character opens no quote and separates nothing: consume BOTH characters
+        # and keep scanning outside quotes, so the separator behind a `\"` still splits
+        # (objectstack#11131). Both are kept verbatim because this pass only SPLITS —
+        # check_segment() re-reads the segment with `read -r -a`, and `-r` leaves the
+        # backslash literal, exactly as a real shell argument would carry it.
+        seg+="$ch"
+        if [ $((i + 1)) -lt "$n" ]; then i=$((i + 1)) ; seg+="${s:i:1}" ; fi
+        ;;
       "'" | '"') q="$ch" ; seg+="$ch" ;;
       ';' | '|' | '&' | '(' | ')' | '{' | '}' | $'\n') segments+=("$seg") ; seg="" ;;
       *) seg+="$ch" ;;


### PR DESCRIPTION
Fixes #6042

Ports the `split_segments()` backslash branch into this repo's `.claude/hooks/guard-shared-stash.sh`, closing the measured fail-open in the guard behind the **⛔ Never `git stash`** rule.

## ⛔ Governed surface — draft PR, human merge only

`.claude/**` is a governed surface in this repo. This PR is deliberately a **draft** and must stay one: not to be marked ready, not to be put on auto-merge, not to be merged by an agent. **A human merges this one.**

## The defect

Outside quotes a backslash escapes the next character, so an escaped backslash-doublequote opens no quoted region at all. `split_segments()` had no branch for it, so the pass read the doublequote as opening a region that never closed, went inert for every separator behind it, collapsed the whole command into a single segment whose head word was the harmless one, and let a real `git stash` through as a mere argument of `echo`.

That is the fail-open in the backstop for the one rule whose breach silently corrupts a *different* agent's work: `refs/stash` lives in the common `.git` directory, so every worktree shares one LIFO stack (objectui#3430 swapped two agents' in-flight changes with `pop` reporting success).

## Source of the port, and what did NOT come with it

`guard-main-checkout-bash.sh` carries the same defect and it was corrected upstream by objectstack#11131 (objectstack PR objectstack-ai/objectstack#11278). **That correction is not on this repo's `main` yet** — objectui PR #6046 carries it here and is still an open draft awaiting human merge. So the shape here was read from **objectstack PR #11278's diff** (cross-checked against #6046's, which is the same text with issue-reference localisation) and **does not depend on #6046 having landed**. Verified: `grep -c 11131 .claude/hooks/guard-main-checkout-bash.sh` on `main` returns 0, and that file is untouched by this PR.

**Only the objectstack#11131 half applies.** The objectstack#11133 comment-heredoc half has **no analogue here** — `guard-shared-stash.sh` has no `strip_heredocs()` pass to carry that defect, so nothing was ported for it and no place was invented to put it.

### Two deliberate adaptations, not improvements

Upstream's branch could not be spliced byte-for-byte, because this hook's `split_segments()` is the simpler of the two:

1. **No `word=1` line.** Upstream's `split_segments()` tracks a `word` flag for its unquoted-`#` comment rule; this hook has no comment rule and no such variable. Carrying the assignment would have created a write to a variable nothing reads.
2. **The comment prose names `check_segment()`, not `tokenize()`.** Upstream justifies keeping both characters verbatim by pointing at `tokenize()`, which re-reads the escape. This hook has no `tokenize()` — word-splitting is `read -r -a w`, and `-r` leaves the backslash literal, which is the same justification through a different mechanism. The prose states this hook's mechanism so the comment stays true here.

The branch body itself — `seg+="$ch"` then the bounded lookahead that consumes the escaped character — is upstream's, unchanged.

## Evidence

### 1. Self-test, before and after

| revision | `bash .claude/hooks/guard-shared-stash.selftest.sh` |
| --- | --- |
| before (`7c96c9420`, the branch point) | `32 passed, 0 failed` |
| after (`0835db154`) | `41 passed, 0 failed` |

**32 to 41 cases** (39 `expect` lines + the 2 inline specials). The hook header carries a re-derivable count line — `Self-test (32 cases …)` / `32 = 30 expect lines + 2 inline specials` — and it is updated to `41` / `39` so the file's own invariant stays true (objectui#3721 is the card about that count drifting).

### 2. The measured probe flips ALLOWED to blocked, with the control held

Fed as the PreToolUse payload shape, `{cwd, tool_name:"Bash", tool_input:{command}}` — the same fixture shape the selftest uses.

| command | before (`7c96c9420`) | after (`0835db154`) |
| --- | --- | --- |
| `git stash` — the control | **blocked** | **blocked** |
| `echo` backslash-doublequote, then `;`, then `git stash` — the hole | **ALLOWED** | **blocked** |

The control matters: without it, "ALLOWED" could mean the harness never reached the guard rather than that the guard let it past. It is blocked on both sides, so the guard was reached both times.

### 3. Every new block case was a genuine fail-open before

Each new case was run against the pre-fix hook (`git show HEAD:…` extracted to a temp copy) and against the post-fix hook:

| new case | before | after |
| --- | --- | --- |
| `echo \" ; git stash` | ALLOWED | blocked |
| `echo \" ; git stash pop` | ALLOWED | blocked |
| `printf \" ; git stash drop` | ALLOWED | blocked |
| `echo \"` + newline + `git stash pop` | ALLOWED | blocked |

So the new cases discriminate: they are not cases that already passed.

### 4. No over-blocking — the deliberately-allowed forms stay allowed

A guard that blocks more than intended is a defect, not extra safety. All the forms this hook allows on purpose, measured after the change:

| command | after |
| --- | --- |
| `git stash list` | ALLOWED |
| `git stash show -p` | ALLOWED |
| `git stash create` | ALLOWED |
| `git stash --help` | ALLOWED |
| `git stash apply abc1234` (literal hex id) | ALLOWED |
| `git stash apply --index deadbeefcafe1234` | ALLOWED |
| `git stash store -m "WIP issue-3430" b52e3aa1234567` | ALLOWED |

And the new precision twins — the escape must not manufacture a block where nothing stashes, and an allowed form reached *through* the same escape stays allowed:

| command | before | after |
| --- | --- | --- |
| `echo \" ; echo hello` | ALLOWED | ALLOWED |
| `echo \" ; cat README.md` | ALLOWED | ALLOWED |
| `echo a\ b` | ALLOWED | ALLOWED |
| `echo \\ ; grep -n worktree README.md` | ALLOWED | ALLOWED |
| `echo \" ; git stash list` | ALLOWED | ALLOWED |

The last row is this repo's stand-in for upstream's precision twin, which re-aims the same command at a linked worktree. This hook reads no `cwd`, so the read-only / SHA-pinned allow-list is the analogous precision surface. Everything the pre-existing 32 cases asserted still holds: `41 passed, 0 failed`, and 41 = 32 + 9.

## Scope

Port only. `guard-main-checkout.sh`, `guard-main-checkout-bash.sh` and every other hook are untouched — `git status` on this branch shows exactly two modified files, and the sibling matrix still reports `100 passed, 0 failed` at this tip.

The same hole is claimed present in objectstack's copy, tracked as objectstack#11738; that card is out of scope here and remains open — objectui only, so the two can be reviewed as one patch shape.

One out-of-scope observation was measured and filed rather than folded in — see the report on #6042.

## Gates

Run at `0835db154` (the tip of this branch, working tree clean):

| gate | verdict line |
| --- | --- |
| `bash .claude/hooks/guard-shared-stash.selftest.sh` | `41 passed, 0 failed` |
| `bash .claude/hooks/guard-main-checkout-bash.selftest.sh` (untouched sibling) | `100 passed, 0 failed` |
| `node scripts/check-control-bytes.mjs` | `✅  check-control-bytes: OK (scanned 5036 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `bash -n` on both changed files | syntax OK |

`.github/workflows/hook-selftests.yml` is the CI caller for both matrices and fires on `.claude/hooks/**`, so it runs this on the PR.

No changeset: this touches `.claude/` tooling only, no released package's `src/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_