### PR TITLE
test(scripts): assert shipped sidebar.tsx keeps the Tailwind v4 `(--var)` spelling

### DIFF
--- a/.changeset/6027-sidebar-tailwind-v4-spelling-guard.md
+++ b/.changeset/6027-sidebar-tailwind-v4-spelling-guard.md
@@ -1,0 +1,24 @@
+---
+---
+
+Tests only; no published behaviour changes.
+
+Adds an offline assertion that the shipped
+`packages/components/src/ui/sidebar.tsx` contains no Tailwind **v3**
+`[--var]` arbitrary values, wired into the existing
+`scripts/__tests__/shadcn-local-patches.test.ts` suite (no new workflow).
+
+The Tailwind v4 custom-property migration (`925051db6`) is an *undeclared*
+local edit — prose in `shadcn-components.json` (`localEdits`), with nothing in
+`scripts/shadcn-local-patches.mjs` re-applying it — so a `--force` sync drops
+it. It is the only one of `sheet`/`sidebar`'s four undeclared edits that no
+gate catches: the v3 spelling compiles, renders, and emits invalid CSS that
+browsers silently discard. The assertion closes that silence from the cheap
+side rather than declaring ~20 class-string anchors.
+
+Asserted against the file the repo **ships**, not a vendored fixture — the
+regression being guarded is "a forced sync overwrote the shipped file", which a
+fixture-based check would pass straight through. The block also guards the
+inverse (the correct v4 `(--var)` spellings must not trip it) and pins the
+tolerated/refused counts, and its docblock records the other three undeclared
+edits with the gate that catches each.

--- a/scripts/__tests__/shadcn-local-patches.test.ts
+++ b/scripts/__tests__/shadcn-local-patches.test.ts
@@ -588,3 +588,181 @@ describe('declared anchors were written from REGISTRY bytes (objectui#4996)', ()
     expect(onDisk).toEqual([...patchedComponents()].sort());
   });
 });
+
+/**
+ * objectui#6027 — the Tailwind v4 custom-property migration on the SHIPPED
+ * `sidebar.tsx`, guarded from the other side.
+ *
+ * `925051db6` converted every Tailwind arbitrary value holding a bare CSS
+ * custom property from the v3 spelling `w-[--sidebar-width]` to the v4
+ * spelling `w-(--sidebar-width)`. Under Tailwind 4.x the v3 spelling no longer
+ * resolves the variable — it compiles to a bare custom-property *name* as a
+ * value, which is invalid CSS that browsers silently discard, collapsing the
+ * sidebar to 0 width over the main content.
+ *
+ * That migration is an UNDECLARED local edit: it lives only as prose in
+ * `packages/components/shadcn-components.json` (`localEdits`), with nothing in
+ * `scripts/shadcn-local-patches.mjs` re-applying it. A `--force` sync — which
+ * bypasses the `localOnlyLines` refusal by design — drops it.
+ *
+ * ## Why only this one of the four undeclared edits is guarded here
+ *
+ * Declaring the migration as a patch family would mean anchoring ~20 class
+ * strings, each a maintenance surface that can drift out of agreement with
+ * upstream. This assertion buys the same protection from the other side, for
+ * one regex, and is the option objectui#6027 itself costed as "much cheaper".
+ * The other three undeclared edits are NOT guarded here because each already
+ * fails through an existing gate — recorded so a reader knows why:
+ *
+ *   | undeclared edit                          | file        | gate that catches its loss |
+ *   |------------------------------------------|-------------|----------------------------|
+ *   | `hideOverlay` prop suppressing overlay    | `sheet.tsx` | type-check — but see the caveat below |
+ *   | `eslint-disable react-hooks/purity`       | `sidebar.tsx` | Lint. The rule arrives via `reactHooks.configs.recommended.rules` (`eslint.config.js:39`) and is NOT downgraded by the repo's overrides (unlike `react-hooks/refs`, `immutability`, `set-state-in-effect`, …), so the skeleton's random width errors without the directive. |
+ *   | unconditional `data-collapsible` + `group-data-[state=collapsed]:` qualifiers | `sidebar.tsx` | Test locator — `packages/app-shell/src/__tests__/print-stylesheet-4462.test.ts` pins the selector `[data-collapsible][data-side][data-state]`. |
+ *   | Tailwind v4 `[--var]` → `(--var)`         | `sidebar.tsx` | **nothing — this block** |
+ *
+ * ⚠️ Caveat measured while writing this (objectui#6027): `hideOverlay` has
+ * **zero consumers** in the tree today — the `DesignDrawer` that ROADMAP.md
+ * credits no longer exists. It is an optional prop, so a `--force` sync
+ * dropping it would type-check clean. The type-check gate that card credits is
+ * vacuous as things stand; it re-arms the moment anything passes the prop.
+ * Filed separately rather than fixed here.
+ *
+ * Deliberately asserted against the file this repo SHIPS, not against a
+ * vendored fixture: the regression is "a forced sync overwrote the shipped
+ * file", which a fixture-based check would sail straight past.
+ */
+describe('shipped sidebar.tsx keeps the Tailwind v4 custom-property spelling (objectui#6027)', () => {
+  const sidebarRelPath = 'packages/components/src/ui/sidebar.tsx';
+  const sidebarPath = path.join(uiDir, 'sidebar.tsx');
+
+  /**
+   * The v3 spelling this refuses: `[` followed IMMEDIATELY by a custom-property
+   * name and closed by `]` — i.e. the whole arbitrary value is the bare
+   * variable name (`w-[--sidebar-width]`).
+   *
+   * What it deliberately does NOT match, so it stays a spelling check rather
+   * than a blanket "no `--var` in brackets" trap:
+   *
+   *   - `w-[calc(var(--sidebar-width-icon)_+_1rem)]` — a `var()` call inside an
+   *     arbitrary value is correct on v4; `[` is followed by `calc`, not `--`.
+   *   - `shadow-[0_0_0_1px_hsl(var(--sidebar-border))]` — same shape.
+   *   - `[--sidebar-width:16rem]` — the arbitrary *property* form, which SETS a
+   *     custom property and remains valid on v4. The trailing `:` breaks the
+   *     match, which is intentional: this guard is about arbitrary *values*.
+   */
+  const V3_BARE_VAR = /\[--[a-zA-Z0-9-]+\]/g;
+
+  /**
+   * The v4 spelling that must stay green. `(` preceded by the utility's `-`
+   * (`w-(--sidebar-width)`), which is what distinguishes the Tailwind shorthand
+   * from a plain CSS `var(--x)` call — there `(` is preceded by `r`.
+   */
+  const V4_SHORTHAND = /-\(--[a-zA-Z0-9-]+\)/g;
+
+  const readSidebar = () => fs.readFileSync(sidebarPath, 'utf-8');
+
+  /** Offending spellings with line numbers, so a failure names WHAT and WHERE. */
+  const findV3Spellings = (source: string): string[] =>
+    source
+      .split('\n')
+      .flatMap((line, i) =>
+        (line.match(V3_BARE_VAR) ?? []).map(
+          (spelling) => `${sidebarRelPath}:${i + 1}: ${spelling}`,
+        ),
+      );
+
+  /**
+   * The gate. Goes red on a `--force` sync that reverts the migration, offline,
+   * on every PR.
+   */
+  it('contains no Tailwind v3 `[--var]` arbitrary values', () => {
+    const offenders = findV3Spellings(readSidebar());
+
+    expect(
+      offenders,
+      `${sidebarRelPath} contains Tailwind v3 bare-custom-property arbitrary ` +
+        `value(s), which Tailwind 4.x compiles to invalid CSS that browsers ` +
+        `silently discard. Rewrite each \`[--var]\` as \`(--var)\` (see ` +
+        `925051db6). Offenders:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  /**
+   * The inverse guard. Without this the block above is satisfied by a file that
+   * has no custom-property utilities at all — including one where a bad sync
+   * stripped them — and it would equally be satisfied by a pattern so greedy it
+   * forbids the correct v4 spelling, making this a trap for the next person who
+   * does a migration RIGHT.
+   */
+  it('tolerates the v4 `(--var)` spellings that are supposed to be there', () => {
+    const source = readSidebar();
+    const v4 = source.match(V4_SHORTHAND) ?? [];
+
+    // The migration's own targets, still in their v4 form.
+    expect(source).toContain('w-(--sidebar-width)');
+    expect(source).toContain('w-(--sidebar-width-icon)');
+    expect(source).toContain('max-w-(--skeleton-width)');
+
+    expect(v4.length).toBeGreaterThanOrEqual(7);
+    expect(findV3Spellings(source)).toEqual([]);
+  });
+
+  /**
+   * The distinguishing evidence: the pattern separates the two spellings rather
+   * than matching any `--var` occurrence. Asserted on literals, not on the file,
+   * so it keeps proving the pattern's shape even after the file changes.
+   */
+  it('distinguishes the v3 spelling from every valid v4 neighbour', () => {
+    const refused = [
+      'w-[--sidebar-width]',
+      'max-w-[--skeleton-width]',
+      'group-data-[collapsible=icon]:w-[--sidebar-width-icon]',
+    ];
+    for (const s of refused) {
+      expect(s.match(V3_BARE_VAR), `${s} must be refused as a v3 spelling`).not.toBeNull();
+    }
+
+    const tolerated = [
+      // v4 shorthand — the correct spelling.
+      'w-(--sidebar-width)',
+      'max-w-(--skeleton-width)',
+      // `var()` inside an arbitrary value — correct on v4, present in the file.
+      'w-[calc(var(--sidebar-width-icon)_+_1rem)]',
+      'left-[calc(var(--sidebar-width)*-1)]',
+      'shadow-[0_0_0_1px_hsl(var(--sidebar-border))]',
+      // arbitrary *property* form — sets the variable, still valid on v4.
+      '[--sidebar-width:16rem]',
+      // unrelated arbitrary values that merely use brackets.
+      'group-data-[collapsible=offcanvas]:left-0',
+      '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+    ];
+    for (const s of tolerated) {
+      expect(s.match(V3_BARE_VAR), `${s} must NOT be flagged`).toBeNull();
+    }
+  });
+
+  /**
+   * The counts objectui#6027 asked to be reported alongside each other: what the
+   * pattern tolerates vs. what it refuses, measured on the shipped file. Pinned
+   * so that a sync which quietly deletes the custom-property utilities — rather
+   * than respelling them — cannot pass as "no v3 spellings found".
+   */
+  it('reports the v4 spellings it tolerates alongside the v3 it refuses', () => {
+    const source = readSidebar();
+
+    const v4Shorthand = source.match(V4_SHORTHAND) ?? [];
+    const varCalls = source.match(/var\(--[a-zA-Z0-9-]+\)/g) ?? [];
+    const v3 = findV3Spellings(source);
+
+    expect({
+      v4Shorthand: v4Shorthand.length,
+      varCallsInsideArbitraryValues: varCalls.length,
+      v3BareVar: v3.length,
+    }).toEqual({
+      v4Shorthand: 7,
+      varCallsInsideArbitraryValues: 6,
+      v3BareVar: 0,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6027

Tests only — no published behaviour changes. Verified green at `0eadb67ab`.

## What and why

The Tailwind v4 custom-property migration (`925051db6`) on `packages/components/src/ui/sidebar.tsx` is an **undeclared** local edit: it lives only as prose in `shadcn-components.json` (`localEdits`), with nothing in `scripts/shadcn-local-patches.mjs` re-applying it. A `--force` sync — which bypasses the `localOnlyLines` refusal by design — drops it.

Of `sheet`/`sidebar`'s four undeclared edits it is the outlier: the v3 spelling **compiles, renders, and emits invalid CSS that browsers silently discard** (the sidebar collapses to 0 width over the main content). This adds the cheap offline assertion that catches that regression from the other side.

Per the dispatch ruling, the migration is deliberately **not** declared as a patch family — that would anchor ~20 class strings, each a maintenance surface that can drift out of agreement with upstream, the exact failure class #4996 just finished measuring.

Wired into the existing `scripts/__tests__/shadcn-local-patches.test.ts` suite. No new workflow.

## Asserted against the SHIPPED file, not a fixture

The regression guarded is "a forced sync overwrote the shipped file", so a fixture-based check would pass while the defect landed. The block reads `packages/components/src/ui/sidebar.tsx` off disk.

## The pattern distinguishes the two spellings

It refuses `[` followed **immediately** by a custom-property name and closed by `]` (`w-[--sidebar-width]`) — not any `--var` occurrence. Measured on the shipped file:

| kind | count | verdict |
|---|---|---|
| v4 shorthand (`w-(--sidebar-width)`) | **7** | tolerated |
| `var()` inside an arbitrary value (`w-[calc(var(--sidebar-width-icon)_+_1rem)]`, `shadow-[0_0_0_1px_hsl(var(--sidebar-border))]`) | **6** | tolerated |
| v3 bare custom property (`w-[--sidebar-width]`) | **0** | refused |

Also deliberately tolerated: the arbitrary *property* form `[--sidebar-width:16rem]`, which **sets** a variable and remains valid on v4 — the trailing `:` breaks the match. Guarding the inverse matters: without it the check is a trap for whoever does the next migration correctly.

All three counts are pinned, so a sync that quietly **deletes** the custom-property utilities rather than respelling them cannot pass as "no v3 spellings found".

## Non-vacuity — shown going red

Reintroduced the v3 spelling on line 199, proved it reached disk by grepping the literal (not by trusting the editor's exit code):

```
-- injected literal 'w-[--sidebar-width]' occurrences: 1
199:            "flex h-full w-[--sidebar-width] flex-col bg-sidebar text-sidebar-foreground",
-- removed literal 'w-(--sidebar-width) flex-col' occurrences (expect 0): 0
```

The assertion failed **naming the spelling and the file**:

```
AssertionError: packages/components/src/ui/sidebar.tsx contains Tailwind v3
bare-custom-property arbitrary value(s), which Tailwind 4.x compiles to invalid
CSS that browsers silently discard. Rewrite each `[--var]` as `(--var)`
(see 925051db6). Offenders:
  packages/components/src/ui/sidebar.tsx:199: [--sidebar-width]
```

Three tests went red (`3 failed | 40 passed`) — the guard, the inverse guard (`expected 6 to be greater than or equal to 7`) and the count pin (`v4Shorthand: 6` vs `7`). Restored with `git checkout HEAD -- <path>`; `git diff HEAD` empty, counts back to 7 v4 / 0 v3. The mutation script carried a `trap … EXIT INT TERM` restore so a mid-run kill could not leave the tree mutated.

No rebuild leg applies here: the assertion reads the `.tsx` source directly via `fs.readFileSync`, so there is no `dist/` resolution path that could serve stale bytes.

## The record of the other three edits

Half the deliverable, and it lives in the assertion's docblock: each of the other three undeclared edits with the gate that catches its loss — `eslint-disable react-hooks/purity` → Lint (the rule arrives via `reactHooks.configs.recommended.rules` at `eslint.config.js:39` and is **not** downgraded by the repo's overrides), and the unconditional `data-collapsible` qualifiers → the locator `[data-collapsible][data-side][data-state]` pinned in `packages/app-shell/src/__tests__/print-stylesheet-4462.test.ts`.

⚠️ One correction the record carries: `hideOverlay` — credited with a type-check failure — has **zero consumers** in the tree (the `DesignDrawer` that `ROADMAP.md` credits no longer exists). It is an optional prop, so a sync dropping it type-checks clean; that gate is vacuous as things stand. Recorded in the docblock and filed separately as #6090 rather than fixed here. Out of scope for this PR.

## Scope

Untouched, as ruled: `scripts/shadcn-local-patches.mjs` patch declarations, the vendored registry fixtures (#4996 / PR #6030 owns those — branched off current `main`, `7c96c9420`, which includes it), and `shadcn-components.json`. No `shadcn` sync of any kind was run.

## Verification

- `npx vitest run scripts/__tests__/` from the repo **root** (never package-scoped) at `0eadb67ab` — **65 files, 1793 tests passed**, including `scripts-type-check.test.ts` and `check-changeset-fixed.test.ts`.
- `npx eslint scripts/__tests__/shadcn-local-patches.test.ts` — exit 0.
- Control-byte scan over the changed file — clean.

Exit codes captured before any pipe, not through `tail`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_