### PR TITLE
fix(console): name the unresolved import when the eager-closure walk hits a non-chunk

### DIFF
--- a/.changeset/5996-eager-closure-missing-chunk.md
+++ b/.changeset/5996-eager-closure-missing-chunk.md
@@ -1,0 +1,19 @@
+---
+---
+
+Build tooling only — `apps/console/vite.config.ts`, which is not published
+source (`@object-ui/console`'s `files` list carries `dist`, `plugin.*` and
+`README.md`), so nothing ships from this change.
+
+`emit-eager-closure-report`'s `writeBundle` hook read every member of the eager
+closure off disk with an unguarded `fs.readFileSync`. The closure walk seeds
+itself from `chunk.imports`, and rolldown lists a chunk's EXTERNAL imports in
+that array beside the file names of real chunks — so a bare specifier vite could
+not resolve joins the closure under its own name and is then read as a path. The
+result was a bare `ENOENT` from `node:fs`, several frames from the cause, naming
+neither the plugin nor the unresolved import.
+
+The read is now guarded by an existence check that `this.error()`s with the
+missing name, the chunk that imports it, and the diagnosis. The failure stays
+loud — that direction is correct, and the two counter-probes above it exist to
+keep it that way; only its message changes.

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -292,7 +292,40 @@ function emitEagerClosureReport(reportFileName = 'eager-closure.json'): Plugin {
       }
 
       const files = [...eager].sort().map((fileName) => {
-        const raw = fs.readFileSync(path.join(outDir, fileName));
+        const filePath = path.join(outDir, fileName);
+
+        // A closure member with no file on disk is not a missing build output —
+        // it is an UNRESOLVED BARE IMPORT that the walk above swept in. Rolldown
+        // lists a chunk's EXTERNAL imports in `chunk.imports` beside the file
+        // names of real chunks, and the walk follows that array without asking
+        // whether the name is in `chunks`, so a specifier vite could not resolve
+        // joins `eager` under its own name and is then read as a path. Left
+        // unguarded that is a bare `ENOENT` from `node:fs`, several frames from
+        // the cause and naming neither this plugin nor the import (objectui#5996).
+        if (!fs.existsSync(filePath)) {
+          const importers = [...chunks.values()]
+            .filter((chunk) => (chunk.imports ?? []).includes(fileName))
+            .map((chunk) => chunk.fileName);
+          this.error(
+            `[emit-eager-closure-report] eager-closure member \`${fileName}\` has no file in ` +
+              `\`${outDir}\`, so its bytes cannot be weighed. It is almost certainly an ` +
+              `UNRESOLVED BARE IMPORT, not a missing build output: rolldown lists a chunk's ` +
+              `EXTERNAL imports in \`chunk.imports\` beside the file names of real chunks, and ` +
+              `the walk above follows that array, so a specifier vite could not resolve enters ` +
+              `the closure under its own name and is then read as a path. The name is the tell — ` +
+              `a real chunk here is \`assets/<name>-<hash>.js\`, and this one is not a key of the ` +
+              `output bundle map at all. (imported by: ${importers.join(', ') || 'NONE'}) ` +
+              `Fix the import rather than skipping the member here: a bare specifier the browser ` +
+              `cannot load is a broken bundle, not a measurement gap, and dropping it from the ` +
+              `walk would make this report under-count — the one direction the counter-probes ` +
+              `above exist to refuse. The known source is an out-of-tree override whose own ` +
+              `dependencies do not resolve from where it lives: check \`OBJECTSTACK_CLIENT_DIST\` ` +
+              `and \`OBJECTSTACK_SPEC_DIST\`, and vite's own "could not be resolved" warnings ` +
+              `earlier in this build.`,
+          );
+        }
+
+        const raw = fs.readFileSync(filePath);
         // Level 6 — zlib's default, and the level `gzip -c` uses in the
         // workflow's entry-chunk check, so the two numbers in one PR comment
         // are measured the same way.


### PR DESCRIPTION
Fixes #5996

Shape 1 of the card, as ruled in the dispatch order. Shape 2 was investigated and is reported below — no chunking configuration was touched.

## The premise was partly spent — re-derived first

`b0de7a85c` (PR #5995, card #5391 — the commit that makes the spec-dist override fail fast when its own declared deps cannot be found) **is** on `origin/main`, so the route the card was found through is closed: `resolveSpecDistInjection` now rejects an `OBJECTSTACK_SPEC_DIST` override whose declared `dependencies` do not resolve, before the build starts.

The crash is still reachable through the **`OBJECTSTACK_CLIENT_DIST` sibling hook**, which the card named as a candidate and which #5995 did not touch. That hook is a plain Vite string alias (`workspaceAliases['@objectstack/client'] = resolved`) with no validation of the override's own dependencies. Reproduction: copy the installed `@objectstack/client@17.2.0` `dist/` to a directory outside the workspace and point the hook at it. Its three bare imports — `@objectstack/core/logger`, `@objectstack/spec/api`, `@objectstack/spec/data` — have no `node_modules` to resolve from at that location.

## Before / after, same reproduction

Both runs use the same override, the same tree, and configs that differ by **exactly this PR's diff** (each generated from its side by one identical `sed` that removes `viteIneffectiveDynamicImports()` — see "A second defect" below for why that removal is needed to see either error at all).

**Before** (`vite.config.ts` at `7c96c9420`):

```
error during build:
Build failed with 1 error:

[plugin emit-eager-closure-report]
Error: ENOENT: no such file or directory, open '/home/user/objectui-5996/apps/console/dist/@objectstack/core/logger'
    at Object.openSync (node:fs:560:18)
    at Object.readFileSync (node:fs:444:35)
```

**After** (this branch), exact text:

```
error during build:
Build failed with 1 error:

[plugin emit-eager-closure-report]
RolldownError: [emit-eager-closure-report] eager-closure member `@objectstack/core/logger` has no
file in `/home/user/objectui-5996/apps/console/dist`, so its bytes cannot be weighed. It is almost
certainly an UNRESOLVED BARE IMPORT, not a missing build output: rolldown lists a chunk's EXTERNAL
imports in `chunk.imports` beside the file names of real chunks, and the walk above follows that
array, so a specifier vite could not resolve enters the closure under its own name and is then read
as a path. The name is the tell — a real chunk here is `assets/[name]-[hash].js`, and this one is
not a key of the output bundle map at all. (imported by: assets/framework-Bwcc-tp7.js) Fix the
import rather than skipping the member here: a bare specifier the browser cannot load is a broken
bundle, not a measurement gap, and dropping it from the walk would make this report under-count —
the one direction the counter-probes above exist to refuse. The known source is an out-of-tree
override whose own dependencies do not resolve from where it lives: check `OBJECTSTACK_CLIENT_DIST`
and `OBJECTSTACK_SPEC_DIST`, and vite's own "could not be resolved" warnings earlier in this build.
```

Two spots are rendered with square brackets above where the real message uses angle brackets (`assets/[name]-[hash].js`, and the compiled-config path in the next section): GitHub's body sanitizer deletes short angle-bracket fragments from a PR body, code fence or not. `apps/console/vite.config.ts` in this diff carries the angle-bracket spelling, which is what a developer actually sees in the terminal.

It names the missing file, the chunk that imports it, and the assumption. The failure stays a build failure — only its message changed.

## Which artifact was under test

Vite compiles the config through `configLoader: 'native'` into `apps/console/node_modules/.vite-temp/[config].timestamp-[ms]-[rand].mjs`, **freshly per invocation** — the two paired runs name different files in their stack traces (`…before.ts.timestamp-1787588787207-3d31ebadb622b.mjs` vs `…after.ts.timestamp-1787588797390-b421aa65b219f.mjs`), so neither read a cached compile. Independently, the "after" output contains sentence text that exists nowhere in this repository except this PR's diff, which no stale artifact could have produced. Every build below was run from a dedicated worktree at the commit under test; the final verification union was run on `b3e278420`, this branch's head.

## Non-vacuity — the guard does not fire on a normal build

Real `vite.config.ts` (this branch), no override, on `b3e278420`:

```
[plugin emit-eager-closure-report] eager closure: 52/508 chunks, 3298242 bytes gzipped (3220.9 KB) → eager-closure.json
✓ built in 13.39s
```

Byte-identical to the pre-fix baseline measured on `7c96c9420` (`52/508 chunks, 3298242 bytes`), and the guard's message appears zero times in the log. The reason it is silent is measured, not assumed: on a normal build the only externals in the bundle are `module`, `fs` and `path`, reached from `@objectstack/lint`, which sits behind the lazy boundary — so they never enter the eager set.

## Shape 2 — investigation only, no configuration changed

**The card's stated mechanism is not what happens, and `advancedChunks` is not implicated.** Instrumented the real bundle map inside `writeBundle` on the reproduction:

```json
{ "bundleKeys": 515, "chunkCount": 508, "eagerCount": 55,
  "phantomsInEagerSet": ["@objectstack/core/logger", "@objectstack/spec/api", "@objectstack/spec/data"],
  "phantomIsBundleKey": [{ "fn": "@objectstack/core/logger", "inBundleMap": false, "fileExists": false }, …],
  "listedInImportsOf": [{ "fn": "@objectstack/core/logger",
    "chunks": [{ "fileName": "assets/framework-Bwcc-tp7.js", "isEntry": false,
      "imports": ["assets/rolldown-runtime-C0FnF6B9.js", "assets/vendor-react-CsWFRkED.js",
                  "assets/vendor-objectstack-BGBxHuAB.js", "assets/vendor-i18n-Cpia2wlg.js",
                  "@objectstack/spec/data", "@objectstack/spec/api", "@objectstack/core/logger"] }] }] }
```

- Rolldown does **not** emit a chunk entry for the unresolvable specifier. It is not a key of the output bundle at all (`inBundleMap: false`; 515 bundle keys = 508 chunks + 7 assets, none of them the specifier). A first pass that listed bundle entries with no file on disk returned `missing: []` while the crash still occurred — that is what pointed at the real path.
- What contains it is `OutputChunk.imports`, which rolldown populates with a chunk's **external** imports beside the file names of real chunks.
- The closure walk pushes every element of `imports` onto its queue and does `eager.add(fileName)` without asking `chunks.has(fileName)`, so externals join the eager set and are then read as paths. That is the whole mechanism.
- **No `advancedChunks.groups` test matches these ids.** An unresolved specifier keeps its bare form (`@objectstack/core/logger`, and the card's `pg-connection-string`), which carries neither a `/node_modules/` segment nor a `/@objectstack+` segment, so `VENDOR_OBJECTSTACK_TEST` and every other group test miss it. The suspicion that a group test matches bare external specifiers is **not supported**; nothing here argues for touching chunking configuration.

The obvious alternative — teach the walk to skip names that are not in `chunks` — is deliberately **not** taken. It would silence a genuinely broken bundle (a bare specifier no browser can load) and make this report under-count, which is the exact direction the module's two counter-probes exist to refuse.

## A second defect this uncovered — filed, not fixed here

Under the **real** console plugin stack, neither the old `ENOENT` nor the new message reaches the developer. `viteIneffectiveDynamicImports()`'s `closeBundle` counter-probe fires whenever the build died before the pinned warnings were emitted, and its error **replaces** the reported build error. On the reproduction with the unmodified plugin list, the only thing printed is `43 pinned ineffective dynamic import(s) did NOT fire` — the eager-closure error appears zero times, before and after this PR. That masking is why the paired runs above remove that one plugin, and it is a separate defect in a different plugin (#5325's ledger), out of this card's scope. Filed as objectui#6093. This PR's improvement is real but will only be visible to developers once that masking is fixed.

Also filed: objectui#6094 — `OBJECTSTACK_CLIENT_DIST` has no equivalent of the fail-fast dependency validation #5995 gave `OBJECTSTACK_SPEC_DIST`, which is the asymmetry this reproduction exploits.

## Verification run on `b3e278420`

| check | result |
|---|---|
| `pnpm exec vite build` (apps/console, no override) | exit 0 — `52/508 chunks, 3298242 bytes gzipped`, guard silent |
| `pnpm exec vite build` (apps/console, reproduction) | exit 1 — guard fires with the message quoted above |
| `pnpm --filter @object-ui/console type-check` | exit 0 (`tsc --noEmit && tsc -b tsconfig.node.json --force`; `tsconfig.node.json` is the project that contains `vite.config.ts`) |
| `pnpm --filter @object-ui/console lint` | exit 0 — `✖ 203 problems (0 errors, 203 warnings)`, all pre-existing |
| `pnpm exec vitest run` (repo root) on the 6 config-adjacent suites | `Test Files 6 passed (6)` · `Tests 157 passed (157)` |
| `node scripts/check-changeset-presence.mjs` | `✅ No source of a released package changed in this range, so no changeset is owed.` |

The vitest selection is `scripts/__tests__/{check-eager-closure-budget,vite-ineffective-dynamic-imports,vite-objectstack-spec-dist,scripts-type-check,side-effects-declaration-consistency,check-changeset-presence}.test.ts` — the suites that reach `apps/console/vite.config.ts` or the plugins it imports. Run from the repo root, never package-scoped. This is a declared narrowing of the repo-wide suite; CI runs the full farm and owns that verdict.

The first `type-check` run reported 352 `TS2882` errors in `src/**` and `packages/app-shell/**`. That was the unbuilt-dependency-closure trap, not this change: none of the 352 named `vite.config.ts`, and after `pnpm --workspace-concurrency=2 --filter '@object-ui/console^...' build` the same command exits 0.

A changeset with **empty frontmatter** is included: `apps/console/vite.config.ts` is not published source — `@object-ui/console`'s `files` list is `["dist", "plugin.ts", "plugin.js", "plugin.d.ts", "README.md"]` — so this ships nothing, and the presence gate agrees.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
