### PR TITLE
docs(tooling): correct invoked-as.mjs's claim that a gate enforces its single-spelling rule

### DIFF
--- a/scripts/invoked-as.mjs
+++ b/scripts/invoked-as.mjs
@@ -7,11 +7,16 @@
  *   node scripts/invoked-as.mjs --self-test
  *
  * Every CLI script in `scripts/` has to separate "node ran me" from "something
- * imported me" before it decides whether to do anything. Each one used to
- * answer that with its own hand-typed comparison of `process.argv[1]` against
- * `import.meta.url`, and the copies had drifted into ELEVEN distinct spellings
- * across 33 files -- measured, not estimated. Nine of the eleven were wrong,
- * and wrong in a direction nothing in CI can see.
+ * imported me" before it decides whether to do anything. Left to a hand-typed
+ * comparison of `process.argv[1]` against `import.meta.url`, those answers
+ * drift: in the objectstack tree this module was ported FROM (#5984) they had
+ * reached ELEVEN distinct spellings across 33 files -- measured, not estimated
+ * -- and nine of the eleven were wrong, in a direction nothing in CI can see.
+ *
+ * THIS repository has not been swept, and no gate here enforces the rule. Read
+ * "## Nothing here enforces this yet" below before concluding otherwise: every
+ * path this header names outside `scripts/` is objectstack's, and several under
+ * `scripts/` are too.
  *
  * ## The bug every hand-typed spelling had
  *
@@ -22,19 +27,25 @@
  *
  * That is the silent-success direction this tree treats as worse than no check
  * at all. The CI wrappers spawn these tools and hold `result.status` only, so
- * an inert child is a GREEN gate. Measured on the tree that motivated this
- * module:
+ * an inert child is a GREEN gate. Measured HERE, on a real blocking gate, with
+ * one guide file made deliberately wrong so that the direct run is RED:
  *
- *   scripts/pm/check-governed-merges.mjs --test AGENTS.md
- *     direct  : exit=3, "GOVERNED -- no seat arms auto-merge"
- *     symlink : exit=0, no output
+ *   node scripts/check-skills-paths.mjs
+ *     direct  : exit=1, 696 bytes naming the dead path and how to fix it
+ *     symlink : exit=0, no output at all
  *
- * and `EXIT_TEST_NOT_GOVERNED` is 0. So through a symlink the register's
- * "this PR is GOVERNED, a human merge is the review record" answer and its
- * "NOT governed, ordinary queue landing applies" answer are the SAME EXIT CODE.
- * A seat reading the status rather than the printed verdict gets a clearance
- * to arm auto-merge from a tool that never ran, on the one surface where human
- * merge IS the review record (Prime Directive #14).
+ * Same tree, same defect, same gate -- reached through a symlink it reports the
+ * clean answer, and a wrapper holding `result.status` cannot tell that apart
+ * from a pass. `check-skills-paths.mjs` carries the no-realpath spelling, as do
+ * 27 of its neighbours; see below.
+ *
+ * The same measurement in objectstack, where this module came from, lands on a
+ * gate whose exit codes make it worse still: `scripts/pm/check-governed-merges.mjs`
+ * prints "GOVERNED -- no seat arms auto-merge" with exit 3 directly and exits 0
+ * with no output through a symlink -- and its `EXIT_TEST_NOT_GOVERNED` is also
+ * 0, so the two opposite verdicts collapse to one status and a seat reading the
+ * status gets a clearance to arm auto-merge from a tool that never ran. That
+ * file and that directive number are objectstack's; neither exists here.
  *
  * ## The two other directions the copies failed in
  *
@@ -70,27 +81,54 @@
  * it, exported so the predicate is pinned by cases rather than trusted by
  * reading.
  *
- * `scripts/check-entry-guard.mjs` enforces this: a `process.argv[1]` in an
- * entry-guard position anywhere in `scripts/**` that is not this module is a
- * failure. That gate is what stops a TWELFTH spelling, which is the whole
- * reason this file exists rather than a one-time sweep.
+ * ## Nothing here enforces this yet -- the rule is a CONVENTION
  *
- * ## The sibling in `packages/cli`, and why the duplication is deliberate
+ * An earlier version of this paragraph said `scripts/check-entry-guard.mjs`
+ * enforces the rule -- that a `process.argv[1]` in an entry-guard position
+ * anywhere in `scripts/**` outside this module is a failure. It does not. That
+ * file has never existed in this repository. It exists in objectstack, wired
+ * there as `check:entry-guard`; the port (#5984) brought this module and its
+ * prose, and neither the gate nor the sweep the prose describes. Measured on
+ * `7c96c9420`:
  *
- * `packages/cli/src/utils/invocation.ts` exports `isProcessEntry`, the same
- * predicate for the same reason (its header cites this defect). It is NOT
- * imported here and this is not imported there: `scripts/` runs as plain .mjs
+ *   git grep -n 'check-entry-guard'             -> ONE hit: this paragraph
+ *   git grep -l 'isEntrypoint' -- scripts       -> this file, and ONE adopter
+ *   git grep -l 'process.argv\[1\]' -- scripts   -> 30 files
+ *
+ * The one adopter is `scripts/pm/check-half-states.mjs`, which arrived in the
+ * same PR. The 30 files are this one plus TWENTY-NINE hand-typed guards: 28
+ * `.mjs`, in NINE textually distinct spellings and not one carrying a realpath
+ * leg -- including the exact percent-encoding spelling this header warns about
+ * above, still in `check-node-esm-load.mjs:847` -- and `scripts/shadcn-sync.js`,
+ * the only hand-typed guard here that does carry the realpath leg.
+ *
+ * A gate is still the right answer: without one, converting those 29 is a
+ * one-time sweep that starts rotting the day it merges, because nothing stops a
+ * THIRTIETH spelling from being typed next week. Both halves -- the gate and
+ * the sweep -- are tracked in #6092. Until that lands, `isEntrypoint` here is a
+ * convention: reach for it in new scripts, and do not read this file as
+ * evidence that the tree already has.
+ *
+ * ## The siblings, and why the duplication is deliberate
+ *
+ * objectstack's `packages/cli/src/utils/invocation.ts` exports `isProcessEntry`,
+ * the same predicate for the same reason (its header cites this defect). Note
+ * the repo: objectui's `packages/cli` has no such util, and `isProcessEntry`
+ * appears nowhere in this tree, so the pairing below is a CROSS-REPO obligation
+ * rather than a local one.
+ *
+ * Why the copies are not collapsed into one: `scripts/` runs as plain .mjs
  * against a possibly-unbuilt tree, and making the whole tooling layer depend on
  * a package build to answer "was I run?" trades this bug for a worse one.
  *
- * The duplication is therefore structural, but DIVERGENCE is not allowed --
- * two predicates answering this question differently is precisely the defect
- * being closed. Both carry the same two legs: realpath for symlinks, and
- * directory resolution for `node <dir>`. Change one, change the other.
+ * The duplication is therefore structural, but DIVERGENCE is not allowed -- two
+ * predicates answering this question differently is precisely the defect being
+ * closed. All three copies carry the same two legs: realpath for symlinks, and
+ * directory resolution for `node <dir>`. Change one, change the others.
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -164,7 +202,14 @@ export function selfTest() {
   t('an absent argv[1] is not this module -- the `node --eval` importer', !invokedAs(undefined, SELF) && !invokedAs('', SELF));
   t('an exact path is this module', invokedAs(SELF, SELF));
   t('a relative path resolving to this module is this module', invokedAs(relative(process.cwd(), SELF), SELF));
-  t('an unrelated existing file is not this module', !invokedAs(resolve(SELF, '..', 'js-comment-mask.mjs'), SELF));
+  // A neighbour that must really be there. The ported spelling of this case
+  // named `js-comment-mask.mjs`, which exists in objectstack and NOT here -- so
+  // it silently became a second copy of the case below it, and both passed. The
+  // existence assertion is what stops that from happening again the next time
+  // the named file moves.
+  const neighbour = resolve(SELF, '..', 'check-control-bytes.mjs');
+  t('the neighbour fixture still exists (or the next case tests nothing)', existsSync(neighbour), neighbour);
+  t('an unrelated existing file is not this module', !invokedAs(neighbour, SELF));
   t('an entry path that cannot be read is not this module (no throw)', !invokedAs(resolve(SELF, '..', 'no-such-file-here.mjs'), SELF));
 
   // ── the fixture: a probe reached three ways ────────────────────────────────


### PR DESCRIPTION
Fixes #6078

Prose-only, one file: `scripts/invoked-as.mjs`. The card named two things; this PR takes only the first. Converting the hand-typed guards and porting the missing gate is #6092, filed with the measurements below and left unassigned for triage.

## What was actually wrong

The header named `scripts/check-entry-guard.mjs` as the gate that fails any `process.argv[1]` in an entry-guard position outside the module. That file has never existed here, so the module read to the next session as evidence that the tree was already converted and policed. Nothing fails today; the **claim** is the defect.

Re-measured on `origin/main` @ `7c96c9420` — the card's own figures were taken at `a1c41c516` and two of them have moved.

**The gate is absent, with a positive control:**

```
ls scripts/check-entry-guard.mjs    -> No such file or directory
ls scripts/check-control-bytes.mjs  -> exists, 16244 bytes          (positive control)

git ls-files | grep -c 'check-entry-guard'    -> 0
git ls-files | grep -c 'check-control-bytes'  -> 2                  (positive control)

git grep -n 'check-entry-guard'   -> 1 hit, scripts/invoked-as.mjs:73 (the sentence itself)
git grep -l 'check-control-bytes' -> 16 files                       (positive control)
```

That single hit is over all tracked files, so it covers `package.json` and `.github/workflows/` too — nothing runs such a gate.

**The root cause is the port, not a deletion.** Five paths the header names, checked in both trees:

| path | objectui `7c96c9420` | objectstack `644ad5043` |
| --- | --- | --- |
| `scripts/invoked-as.mjs` | EXISTS | EXISTS |
| `scripts/check-entry-guard.mjs` | **MISSING** | EXISTS (787 lines, wired `check:entry-guard`) |
| `scripts/pm/check-governed-merges.mjs` | **MISSING** | EXISTS |
| `packages/cli/src/utils/invocation.ts` | **MISSING** | EXISTS |
| `scripts/js-comment-mask.mjs` | **MISSING** | EXISTS |

The header is a faithful description of objectstack's tree, sitting in objectui. #5984 ported the module and its prose without the gate or the sweep that made the prose true. So the correction is not just deleting one sentence — four separate passages had to be re-attributed.

**The counts, corrected:**

| | card said | measured now | command |
| --- | --- | --- | --- |
| modules importing `isEntrypoint` | 2 | **1** (`scripts/pm/check-half-states.mjs:777`) | `git grep -l 'isEntrypoint' -- .` |
| hand-typed `process.argv[1]` guards | 27 | **29** (28 `.mjs` + `shadcn-sync.js`) | `git grep -l 'process\.argv\[1\]' -- 'scripts/'` → 30 files, minus `invoked-as.mjs` |
| of those, no realpath leg | 27 ("all") | **28 of 29** | only `shadcn-sync.js:1048-1057` has one |
| distinct spellings | 1 implied | **9** across the 28 `.mjs` | `git grep -n … \| cut -d: -f3- \| sort \| uniq -c` |

Both deltas reconcile rather than contradict the card: the second `isEntrypoint` adopter is the #5793 gate, which has not landed on `main` yet; and `scripts/check-designer-field-key-parity.mjs` has landed since `a1c41c516`, adding a 28th `.mjs` guard (`comm -13` on the two file sets: one added, none removed). The "all one shape" claim is the one that was simply wrong — one of the nine, `check-node-esm-load.mjs:847`, is the percent-encoding failure the header itself warns about, verbatim.

## The "silently inert through a symlink" claim is now measured, not quoted

Rather than inherit it. One guide file made deliberately wrong (untracked, removed by trap in the same command), then a real blocking gate run two ways against the identical defective tree:

```
node scripts/check-skills-paths.mjs              direct  : exit=1, 696 bytes naming the dead path
node …/link/check-skills-paths.mjs   (symlink)   symlink : exit=0, 0 bytes
```

A red gate reports clean through a symlink, and a wrapper holding `result.status` cannot tell that apart from a pass. That measurement replaced the borrowed objectstack example in the header; the objectstack one is kept, but now attributed.

Also measured, since the header asserts it: the `` import.meta.url === `file://${argv[1]}` `` spelling goes inert in a directory named `a#b c` with **no symlink at all** (`file:///…/a%23b%20c/enc.mjs` vs `/…/a#b c/enc.mjs`).

## One bounded in-place fix, named here rather than left silent

The self-test case `'an unrelated existing file is not this module'` reached for `resolve(SELF, '..', 'js-comment-mask.mjs')` — another objectstack-only path. With the file absent, that case had silently become a duplicate of the next one (`'an entry path that cannot be read is not this module'`) and passed for the wrong reason, losing its "existing file" coverage entirely. Same defect class as the card (a path named inside this module that does not exist here), same file, mechanical, no new verification surface.

It now names a file that is really present, with an existence assertion so the case cannot degrade that way again. Reverse-verified — mutation confirmed on disk by anchored greps in both directions before reading any result:

```
injected 'js-comment-mask.mjs');       count = 1
removed  'check-control-bytes.mjs');   count = 0
git diff --stat                        1 file changed, 1 insertion(+), 1 deletion(-)

node scripts/invoked-as.mjs --self-test
  ✗ the neighbour fixture still exists (or the next case tests nothing) -- …/scripts/js-comment-mask.mjs
  ✗ invoked-as self-test: 1 of 12 case(s) failed.                          exit=1
```

Predicted direction was red; it went red, and only the new assertion fired — the old case still passed with the dead path, which is the vacuity being closed. Restored and re-run green (12/12, `git status` clean).

## Verification — all on `f726727cd`, the final commit, clean tree

| check | result |
| --- | --- |
| `node scripts/invoked-as.mjs --self-test` | exit 0 — `✓ invoked-as self-test: 12 cases pass` (was 11) |
| `npx vitest run scripts/__tests__ --maxWorkers=2`, from repo ROOT | exit 0 — `Test Files 65 passed (65)`, `Tests 1789 passed (1789)` |
| `pnpm check:control-bytes` | exit 0 — `✅ check-control-bytes: OK (scanned 5036 tracked text file(s); skipped 85 binary)` |
| `pnpm check:skills-paths` | exit 0 — `✅ check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined)` — also confirms the temp probe file is gone |
| `pnpm check:esm-specifiers` | exit 0 — `Specifier leg: no un-ledgered package emits an extensionless relative specifier.` |
| `pnpm check:node-esm-load` | exit 0 |
| `node scripts/check-changeset-presence.mjs` | exit 0 — `✅ No source of a released package changed in this range, so no changeset is owed.` Following the gate's verdict: **no changeset**. |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` on the changed file | clean |

**Lint — narrowed, and the narrowing is measured.** `scripts/` is not a workspace package, so `pnpm lint` (`turbo run lint`, per-package fan-out) never reaches the changed file. Measured, not assumed: `pnpm-workspace.yaml` globs `packages/*`, `examples/*`, `apps/*`, `docs`, and of the 47 workspace packages **none** has a directory containing `scripts/`. So the file was linted directly:

```
npx eslint scripts/invoked-as.mjs --format json    exit=0, files linted: 1, errors=0, warnings=0
```

eslint's own `--print-config` resolves a config for the file, so it is covered rather than merely unmatched; and `eslint.config.js` enables no type-aware linting (no `projectService`, no `parserOptions.project`, no `recommendedTypeChecked`), so a one-file diff with no config change cannot move any untouched file's verdict.

**`pnpm check:published-dist` was not run locally — declared narrowing.** Its criterion is the file list of every published package's tarball after a real build, which exceeded this container's 10-minute foreground cap. It is sound to narrow here for the same measured reason as lint: `scripts/` is inside no workspace package, so this diff cannot appear in any package's `dist/` or change any tarball's file list. CI runs it regardless.

## What this PR does not do, and cannot

- ⛔ Does not convert the 29 guards, and does not build the missing gate. Several of them are blocking gates on the publish path (`check-published-dist-tooling`) and per-PR lanes (`check-doc-component-types`, `check-action-forward-parity`); that is a behaviour change across many files wanting its own reverse-verification per lane. Tracked in #6092 — out of scope here, and that card stays open.
- **No gate catches a false comment, and none will keep the corrected one true.** That is this card's own point: the header asserted an enforcement that did not exist, and nothing in CI noticed. The correction is prose, verified by reading and by the measurements above, and it will rot the same way the original did if the tree changes underneath it. The durable remedy is the gate tracked in #6092, which would make the claim mechanically checkable instead of merely accurate today.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
