### PR TITLE
fix(tooling): declare sheet's hideOverlay prop as a local patch family

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -482,8 +482,8 @@ ObjectUI is a universal Server-Driven UI (SDUI) engine built on React + Tailwind
 - [x] Add Vitest tests (15 DashboardRenderer design mode + 9 DashboardEditor external selection + 8 DashboardView integration = 32 new tests)
 
 **Phase 7 — Non-Modal Drawer & Property Panel UX Fix:**
-- [x] `SheetContent` — added `hideOverlay` prop to conditionally skip the full-screen backdrop overlay
-- [x] `DesignDrawer` — `modal={false}` + `hideOverlay` so preview widgets are clickable while drawer is open
+- [x] `SheetContent` — added `hideOverlay` prop to conditionally skip the full-screen backdrop overlay (retained, and declared as a patch family in `scripts/shadcn-local-patches.mjs` since objectui#6090, so an upstream `--force` sync cannot drop it silently)
+- [x] `DesignDrawer` — `modal={false}` + `hideOverlay` so preview widgets are clickable while drawer is open — **superseded by Phase 8 below**: `DesignDrawer` was replaced by the inline config panels and no longer exists in this tree, so `hideOverlay` has **no current in-repo consumer**. It is retained regardless because `@object-ui/components` is published and external consumers of the prop are not visible from here.
 - [x] `DashboardEditor` — property panel renders above widget grid (stacked `flex-col` layout) for immediate visibility in narrow drawer
 - [x] `DashboardEditor` — property panel uses full width (removed fixed `w-72`) for better readability in drawer context
 - [x] Preview click → editor property panel linkage now works end-to-end (select, switch, deselect)

--- a/packages/components/shadcn-components.json
+++ b/packages/components/shadcn-components.json
@@ -269,7 +269,7 @@
         "radix-ui"
       ],
       "registryDependencies": [],
-      "localEdits": "Adds a `hideOverlay` prop that suppresses `<SheetOverlay />`, for sheets that must not dim the page behind them. Upstream renders the overlay unconditionally. Also carries the objectstack#5505 i18n close patch (see `dialog` for the full rationale): `SheetContent`'s auto-rendered close button renders `<CloseSrLabel />` instead of a hardcoded English `sr-only` span. Declared in `scripts/shadcn-local-patches.mjs` and RE-APPLIED automatically by every sync, so unlike the `hideOverlay` edit above it does not depend on anyone remembering it."
+      "localEdits": "Adds a `hideOverlay` prop that suppresses `<SheetOverlay />`, for sheets that must not dim the page behind them. Upstream renders the overlay unconditionally. Also carries the objectstack#5505 i18n close patch (see `dialog` for the full rationale): `SheetContent`'s auto-rendered close button renders `<CloseSrLabel />` instead of a hardcoded English `sr-only` span. BOTH edits are declared in `scripts/shadcn-local-patches.mjs` and RE-APPLIED automatically by every sync; neither depends on anyone remembering it. `hideOverlay` was the exception until objectui#6090 — it was documented here and declared nowhere, and because it is an OPTIONAL prop with no in-repo call site, a `--force` sync that dropped it would have type-checked clean. Declaring it also made `sheet` the second family to regenerate byte-for-byte from registry bytes (`roundTrip: true` in `scripts/__tests__/shadcn-local-patches.test.ts`), which is what now proves nothing else in this file diverges undeclared."
     },
     "sidebar": {
       "source": "https://ui.shadcn.com/r/styles/default/sidebar.json",

--- a/scripts/__tests__/shadcn-local-patches.test.ts
+++ b/scripts/__tests__/shadcn-local-patches.test.ts
@@ -148,13 +148,15 @@ const REGISTRY_FIXTURES: Record<string, RegistryFixture> = {
     repoPath: 'apps/v4/public/r/styles/default/sheet.json',
     headSha: '8a7701ec27eb9cb8e0377db769fbe6d744113c52',
     sha256: '9051eb9d885a18c0521c63c945480effcfca29282d2a342cb3ce7f9d080c6d38',
-    // objectui#4996 measured this: `sheet.tsx` also carries the `hideOverlay`
-    // prop, an UNDECLARED local edit (`shadcn-components.json` documents it and
-    // says outright that, unlike the i18n patch, "it does depend on anyone
-    // remembering it"). So patched upstream is 2 lines short of the shipped
-    // file by design, and byte-equality is not available for this family until
-    // that edit is either declared here or upstreamed.
-    roundTrip: 'ships the undeclared `hideOverlay` prop (shadcn-components.json)',
+    // Promoted to `true` by objectui#6090. It read
+    // `'ships the undeclared `hideOverlay` prop'` until then: that edit was
+    // documented in `shadcn-components.json` but declared nowhere, so patched
+    // upstream came out exactly 3 lines short of the shipped file and equality
+    // was genuinely unavailable. Declaring the `hideOverlay` family closed the
+    // last gap, and this entry is the measurement — `sheet` now accounts for
+    // EVERY way it differs from upstream, which is a strictly stronger gate
+    // than the pinned-inequality branch it used to take.
+    roundTrip: true,
   },
   dialog: {
     url: 'https://ui.shadcn.com/r/styles/default/dialog.json',
@@ -215,9 +217,40 @@ const UPSTREAM_DIALOG = upstreamFor('dialog');
 const UPSTREAM_SLIDER = upstreamFor('slider');
 
 describe('shadcn local patches — application to fresh upstream (objectstack#5505)', () => {
+  /**
+   * Scoped to the close-label family's own `issue`, NOT to every patch declared
+   * for the primitive. `sheet` carries a second family since objectui#6090
+   * (`hideOverlay`), so a whole-list equality here would assert that no
+   * primitive may ever carry more than one — the same over-reach the
+   * `closeLabelComponents` derivation above exists to avoid. Order within the
+   * family still matters and is still asserted: the import must land before the
+   * label swap.
+   */
   it.each(closeLabelComponents)('%s declares the i18n close patch', (name: string) => {
-    const ids = LOCAL_PATCHES[name].map((p: { id: string }) => p.id);
+    const ids = LOCAL_PATCHES[name]
+      .filter((p: { issue: string }) => p.issue === 'objectstack#5505')
+      .map((p: { id: string }) => p.id);
     expect(ids).toEqual([`${name}-i18n-close-import`, `${name}-i18n-close-label`]);
+  });
+
+  /**
+   * The fourth family: sheet's `hideOverlay` prop (objectui#6090).
+   *
+   * All three halves are listed because dropping any one of them leaves a state
+   * that still compiles: without the prop declaration external consumers lose
+   * the API, without the destructure the value leaks to the DOM as
+   * `hideoverlay="true"` and the conditional reads `undefined`, and without the
+   * conditional the prop is accepted and silently ignored.
+   */
+  it('sheet declares the hideOverlay patches', () => {
+    const ids = LOCAL_PATCHES.sheet
+      .filter((p: { issue: string }) => p.issue === 'objectui#6090')
+      .map((p: { id: string }) => p.id);
+    expect(ids).toEqual([
+      'sheet-hide-overlay-prop',
+      'sheet-hide-overlay-destructure',
+      'sheet-hide-overlay-conditional',
+    ]);
   });
 
   /** The other declared family: the sidebar collapse-persistence patch. */

--- a/scripts/shadcn-local-patches.mjs
+++ b/scripts/shadcn-local-patches.mjs
@@ -285,12 +285,98 @@ const sliderThumbPassThroughPatches = [
 ];
 
 /**
+ * The sheet `hideOverlay` patch (objectui#6090).
+ *
+ * `SheetContent` renders `<SheetOverlay />` unconditionally upstream, which
+ * dims and pointer-blocks everything behind the drawer. A non-modal sheet —
+ * one whose host page must stay clickable while it is open — needs the
+ * backdrop suppressed, so objectui added an optional `hideOverlay` prop.
+ *
+ * ## Why this is declared rather than left as a documented hand edit
+ *
+ * It was a hand edit for months, recorded only in `shadcn-components.json`,
+ * and objectui#6090 measured what that actually bought: nothing. The
+ * protection it was credited with was a type error at the call sites a
+ * `--force` sync would break — and there are no call sites in this repo (still
+ * none, re-measured on `main` at 0c282d979). `hideOverlay` is OPTIONAL, so a
+ * sync that dropped it would type-check clean and the prop would vanish
+ * silently.
+ *
+ * `@object-ui/components` is PUBLISHED, though, so "no call sites" is a
+ * statement about this repository and not about the population that would
+ * break. Retiring the prop on the strength of an in-repo grep would be a
+ * breaking change to a published API justified by evidence that cannot see its
+ * own consumers. Declaring it instead makes the loss loud regardless of
+ * whether a consumer exists — which is the property the type-check gate was
+ * wrongly credited with, now held by `verifyLocalPatches` and by the round-trip
+ * assertion in `scripts/__tests__/shadcn-local-patches.test.ts`.
+ *
+ * ## Why the payload is inline here, unlike every family above
+ *
+ * The families above deliberately keep their payload out of `src/ui/**` and
+ * anchor a one-line reference to `src/lib/`. That is not available here and not
+ * being skipped: the payload IS the primitive's own prop surface — an optional
+ * member on `SheetContentProps`, its destructuring, and the conditional it
+ * guards. There is no implementation to host elsewhere. What the rule is really
+ * protecting against — a large inlined body that upstream churn will shred — is
+ * absent: three anchors, each one line, all of them structural lines of
+ * `SheetContent` rather than incidental formatting.
+ *
+ * All three `find` strings were written from the vendored registry bytes in
+ * `scripts/__tests__/fixtures/shadcn-registry/sheet.registry.txt`, not from the
+ * shipped file (objectui#4976 is what happens otherwise), and the round-trip
+ * assertion holds them to it.
+ *
+ * @type {LocalPatch[]}
+ */
+const sheetHideOverlayPatches = [
+  {
+    id: 'sheet-hide-overlay-prop',
+    issue: 'objectui#6090',
+    reason:
+      'Declares the optional `hideOverlay` prop on SheetContentProps. Anchored ' +
+      "on upstream's empty interface body `{}`, which is what makes the prop " +
+      'visible to consumers of the published package at all — drop it and every ' +
+      'external `hideOverlay` call site becomes a type error.',
+    find: '    VariantProps<typeof sheetVariants> {}',
+    replace: '    VariantProps<typeof sheetVariants> {\n  hideOverlay?: boolean\n}',
+    marker: 'hideOverlay?: boolean',
+    occurrences: 1,
+  },
+  {
+    id: 'sheet-hide-overlay-destructure',
+    issue: 'objectui#6090',
+    reason:
+      'Withholds `hideOverlay` from the `...props` spread that lands on ' +
+      'SheetPrimitive.Content. Without this half the prop is forwarded to the ' +
+      'DOM as `hideoverlay="true"` (React unknown-attribute leak) AND the ' +
+      'conditional below has nothing to read.',
+    find: '>(({ side = "right", className, children, ...props }, ref) => (',
+    replace: '>(({ side = "right", className, children, hideOverlay, ...props }, ref) => (',
+    marker: 'children, hideOverlay, ...props',
+    occurrences: 1,
+  },
+  {
+    id: 'sheet-hide-overlay-conditional',
+    issue: 'objectui#6090',
+    reason:
+      'The behaviour itself: skip the dimming, pointer-blocking backdrop when ' +
+      'the host asked for a non-modal sheet. Upstream renders SheetOverlay ' +
+      'unconditionally, so this is the only line that can honour the prop.',
+    find: '    <SheetOverlay />\n',
+    replace: '    {!hideOverlay && <SheetOverlay />}\n',
+    marker: '{!hideOverlay && <SheetOverlay />}',
+    occurrences: 1,
+  },
+];
+
+/**
  * Component name (as tracked in `shadcn-components.json`) → patches it needs.
  *
  * @type {Record<string, LocalPatch[]>}
  */
 export const LOCAL_PATCHES = {
-  sheet: i18nCloseLabelPatches('Sheet'),
+  sheet: [...i18nCloseLabelPatches('Sheet'), ...sheetHideOverlayPatches],
   dialog: i18nCloseLabelPatches('Dialog'),
   sidebar: sidebarCookieReadPatches,
   slider: sliderThumbPassThroughPatches,


### PR DESCRIPTION
Fixes #6090

Declares `sheet.tsx`'s `hideOverlay` prop as a patch family in `scripts/shadcn-local-patches.mjs`, per the ruling on the card. The prop, `sheet.tsx`, and every byte of shipped behaviour are unchanged.

## Why declare rather than retire

The card measured zero consumers and offered retirement as the cheap option. Re-measured on current `origin/main` (`0c282d979`, i.e. after #6091 merged) — still zero in this repo, and still no `DesignDrawer*` file anywhere in the tree.

But `@object-ui/components` is a **published** package, so "zero consumers" is a statement about *this repository*, not about the population a removal would break. `hideOverlay` is an optional prop: an external call site passing it is invisible from here, and nothing in this tree would show it. Retiring it would be a breaking change to a published API justified by evidence that structurally cannot see its own consumers.

Declaring it instead makes the loss loud **independently of whether a consumer exists** — which is exactly the property the type-check gate was wrongly credited with.

## The gate was vacuous — measured, not asserted

Reconstructed what `pnpm shadcn:update --force sheet` would have written under the pre-change declaration set (registry fixture + the two then-declared i18n patches), then ran both declaration sets against that file:

```
base declared patch ids for sheet: [ 'sheet-i18n-close-import', 'sheet-i18n-close-label' ]
regenerated file contains hideOverlay: false
BASE gate verdict on that file  -> []                                   (empty = SILENT / vacuous)
THIS gate verdict on that file  -> ["sheet-hide-overlay-prop","sheet-hide-overlay-destructure","sheet-hide-overlay-conditional"]  (LOUD)
```

## The anchors apply to real registry bytes (#4996 / #4976)

All three `find` strings were written from `scripts/__tests__/fixtures/shadcn-registry/sheet.registry.txt` (the vendored bytes PR #6030 landed), not from the shipped file. Each occurs exactly `1x` there.

The strongest available proof that this is true is now in place: **`sheet` regenerates byte-for-byte from registry bytes**, so its `REGISTRY_FIXTURES` entry is promoted from a pinned-inequality reason to `roundTrip: true`. An anchor reverse-engineered from `src/ui/**` — the #4976 defect — could not produce equality.

### Round-trip measurement

The card asked whether declaring this moves `sheet` closer to round-trip. It does not move it closer; it **completes** it. `hideOverlay` was the *only* remaining divergence.

| | patched upstream vs shipped `sheet.tsx` |
|---|---|
| before | not equal — 144 shipped lines vs 142; exactly the 3 `hideOverlay` lines |
| after | **equal** |

`sidebar` is untouched and stays on the pinned-inequality branch (three systematic undeclared edits; the Tailwind family is explicitly out of scope here).

## Non-vacuity, executed

Mutated `packages/components/src/ui/sheet.tsx` to the pre-#6090 regenerated form, proved the mutation reached disk by grepping the literals (`1,1,1` becomes `0,0,0`, with the translated close label still present so the file is a real regenerated artefact and not a truncation), then ran the suite. The script carried a `trap ... EXIT INT TERM` restore throughout.

```
× sheet.tsx carries its declared patches
× sheet: byte round-trip holds, or its unavailability is pinned with a reason
AssertionError: sheet.tsx lost declared patch(es); re-apply with: node scripts/shadcn-sync.js --update sheet:
  expected [ 'sheet-hide-overlay-prop', …(2) ] to deeply equal []
+   "sheet-hide-overlay-prop",
+   "sheet-hide-overlay-destructure",
+   "sheet-hide-overlay-conditional",
Tests  2 failed | 38 passed (40)
```

Two independent gates go red and the first one **names all three ids**. Restored with `git checkout HEAD -- packages/components/src/ui/sheet.tsx`; `git diff HEAD` and `git status --short` both empty afterwards.

## The stale record (the true half of option 3)

`ROADMAP.md:485-486` credited `DesignDrawer` as the consumer. No such file exists — Phase 8, four lines further down the same document, replaced `DesignDrawer` with the inline config panels. Corrected to record that the prop is retained and declared, with **no current in-repo consumer**, and why it is retained anyway.

`packages/components/shadcn-components.json`'s `sheet.localEdits` said `hideOverlay` "does depend on anyone remembering it" — no longer true, and corrected.

Not touched, per the dispatch order: the prop itself, `sheet.tsx`, the `sidebar` Tailwind family, and #6027's table on the issue.

## Verification

Gate union run at `76fff2994` on a clean tree, each quoting its own verdict line:

| gate | verdict |
|---|---|
| `vitest run` (7 files, from repo ROOT) | `Test Files 7 passed (7)` · `Tests 202 passed (202)` |
| `check-changeset-presence.mjs` | `✅ No source of a released package changed in this range, so no changeset is owed.` (`4 file(s) changed, 0 of them published source`) |
| `pnpm changeset:check` | `✅ All workspace packages are in the changeset fixed group.` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 5042 tracked text file(s); skipped 85 binary)` |
| `pnpm type-check:scripts` | exit 0 (`tsc -p tsconfig.scripts.json`, no output) |
| `pnpm lint:root` | `✖ 26 problems (0 errors, 26 warnings)` — 0 errors; all 26 are pre-existing `no-explicit-any` warnings in files this diff does not touch |
| `pnpm docs:check-links` | exit 0 |
| `pnpm check:node-esm-load`, `pnpm check:esm-specifiers` | exit 0 |

`pnpm lint:root` is the **whole** eslint population for this diff, not a narrowing: the two linted files here are `scripts/shadcn-local-patches.mjs` and `scripts/__tests__/shadcn-local-patches.test.ts`, and `lint:root` is `eslint .` with only `packages/*`, `examples/*`, `apps/*` and `docs/**` ignored. The other two changed files are `.json` and `.md`, which eslint does not target.

`pnpm shadcn:check` is **not** run here — it needs the registry over the network, which does not resolve from this sandbox. That is the weekly `Check Shadcn Components` job's reading (upstream drift); this PR's reading is anchor provenance, which is offline and covered above. The two are not substitutes, as the test file's own docblock states.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_