### PR TITLE
fix(types): retire the designer-surface dashboard aria pair (#5852)

### DIFF
--- a/.changeset/dashboard-config-aria-retired-5852.md
+++ b/.changeset/dashboard-config-aria-retired-5852.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/types': minor
+---
+
+**Retired the designer-surface dashboard `aria` pair — `DashboardConfig.aria` and `DashboardConfigSchema.aria`** (objectui#5852).
+
+Both spellings are named verbatim above so a host can grep its own sources: the
+retired member is `aria`, on the TypeScript interface `DashboardConfig`
+(`@object-ui/types`, `designer.ts`) and on its Zod mirror `DashboardConfigSchema`
+(`@object-ui/types/zod`). It declared `{ label?: string; description?: string }`.
+
+**Why.** The spellings `label`/`description` match neither `@objectstack/spec`'s
+`AriaProps` vocabulary (`ariaLabel` / `ariaDescribedBy` / `role`) nor anything a
+renderer maps, so no read point could have consumed them even in principle.
+Re-measured on `main` at the retirement: zero `.aria` reads in
+`packages/plugin-designer/src`, `packages/plugin-dashboard/src` and
+`apps/console/src`; zero occurrences of either name anywhere in the `objectstack`
+repo; and `DashboardConfigPanel.tsx` — the panel the interface's own doc comment
+says it serves — imports neither name.
+
+**The two directions differ, and neither is a no-op:**
+
+- **TypeScript (a narrowed suggestion, not a compile break).** `DashboardConfig`
+  carries a `[key: string]: any` catch-all, so an existing `aria:` line still
+  compiles; what is gone is the editor suggestion and the false implication that
+  the key was part of the contract.
+- **Zod (a behaviour change — read this one).** `aria` is now an ADR-0049
+  retirement tombstone (`z.never().optional()`), following this package's
+  existing convention. Previously an authored `aria` was **accepted and
+  preserved** in `safeParse` output; it is now **refused by name**, with `aria`
+  in the issue path and a message telling the author to delete the key. A plain
+  deletion was deliberately not taken: `DashboardConfigSchema` is a bare
+  `z.object` with no `.strict()`, so deleting the key would have made an
+  authored `aria` **silently disappear** from the parsed output instead — a
+  quiet data loss in place of a loud refusal.
+
+**External caveat.** In-repo consumer count is zero, but that is not the npm
+count: `@object-ui/types` is published, and stored dashboard configuration is
+not reachable from this repo. A host that authored `aria` on a `DashboardConfig`
+document will now see a validation error naming the key where it previously saw
+a silently carried value. The remedy is to delete the key — it never reached a
+renderer.

--- a/packages/types/src/__tests__/dashboard-config.test.ts
+++ b/packages/types/src/__tests__/dashboard-config.test.ts
@@ -62,7 +62,11 @@ describe('DashboardConfig TypeScript Types', () => {
       headerActions: [
         { label: 'Export', action: 'export', icon: 'Download', variant: 'outline' },
       ],
-      aria: { label: 'Sales dashboard', description: 'Interactive sales overview' },
+      // `aria: { label, description }` REMOVED (objectui#5852): the member is
+      // gone from the `DashboardConfig` declaration. Kept here it would have
+      // gone on compiling through the interface's `[key: string]: any`
+      // catch-all while asserting the opposite of the contract — the
+      // green-wash objectui#5830 called out on the sibling member.
     };
     expect(config.widgets).toHaveLength(1);
     expect(config.widgets![0].type).toBe('metric');
@@ -199,9 +203,43 @@ describe('DashboardConfig Zod Validation', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should validate aria accessibility attributes', () => {
+  // `should validate aria accessibility attributes` was FLIPPED, not deleted
+  // (objectui#5852). It asserted `success === true` for an authored `aria`.
+  // After the retirement a PLAIN DELETION would have kept it green — this
+  // schema is a bare `z.object` with no `.strict()`, so an undeclared key is
+  // accepted and silently stripped (measured; the same behaviour objectui#6068
+  // recorded). That green would have meant "nothing looked", which is why the
+  // mirror carries a `z.never()` tombstone instead and this pin now asserts the
+  // refusal by name.
+  it('refuses the retired `aria` key by name, with the removal message', () => {
     const result = DashboardConfigSchema.safeParse({
       aria: { label: 'Sales dashboard', description: 'Interactive overview' },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => i.path.join('.') === 'aria');
+    expect(issue, 'no issue at path `aria`').toBeTruthy();
+    // The message is asserted, not just its existence: a `z.never()` with no
+    // `error` would refuse with zod's generic "expected never, received
+    // object", which names the key only via the path and tells the author
+    // nothing about what to do. The tombstone carries a real message.
+    expect(issue!.message).toMatch(/RETIRED \(objectui#5852\)/);
+    expect(issue!.message).toMatch(/delete the key/);
+  });
+
+  it('CONTROL: an arbitrary undeclared key is NOT refused — the red above is the tombstone, not strictness', () => {
+    // Without this control, the refusal above is equally consistent with the
+    // schema having become `.strict()`, which would refuse every unknown key.
+    const result = DashboardConfigSchema.safeParse({ objectui5852NotAKey: 'x' });
+    expect(result.success).toBe(true);
+    // ...and it is dropped from the output, which is exactly what a plain
+    // deletion of `aria` would have silently done to an authored value.
+    expect(result.success && 'objectui5852NotAKey' in result.data).toBe(false);
+  });
+
+  it('CONTROL: a legal config still parses green — the tombstone narrowed nothing else', () => {
+    const result = DashboardConfigSchema.safeParse({
+      title: 'Sales', columns: 12, showHeader: true,
     });
     expect(result.success).toBe(true);
   });

--- a/packages/types/src/designer.ts
+++ b/packages/types/src/designer.ts
@@ -620,12 +620,29 @@ export interface DashboardConfig {
   }>;
 
   // -- Accessibility ---------------------------------------------------------
-
-  /** ARIA properties */
-  aria?: {
-    label?: string;
-    description?: string;
-  };
+  //
+  // `aria?: { label?, description? }` was DECLARED here until objectui#5852.
+  // It was never a contract: the spellings (`label`/`description`) match
+  // neither `@objectstack/spec`'s `AriaProps` (`ariaLabel` / `ariaDescribedBy`
+  // / `role`) nor anything a renderer maps, so no read point could have
+  // consumed it even in principle. Measured on `origin/main` at the retirement:
+  // zero `.aria` reads in `packages/plugin-designer/src`,
+  // `packages/plugin-dashboard/src` and `apps/console/src` (the same grep
+  // family finds the live `schema.aria` reads in `plugin-detail`'s
+  // `record-quick-actions.tsx` and `plugin-list`'s `ListView.tsx`), and zero
+  // occurrences of either name in the `objectstack` repo.
+  //
+  // `DashboardConfigPanel.tsx` — the panel this interface's own doc comment
+  // says it serves — imports `ConfigPanelSchema` from `@object-ui/components`
+  // and neither `DashboardConfig` nor `DashboardConfigSchema`, so the key
+  // documented an integration that does not exist.
+  //
+  // Note the `[key: string]: any` catch-all below still types an authored
+  // `aria` as `any`: this deletion removes the type-level SUGGESTION, not a
+  // key that ever rendered (same shape as objectui#5830 on
+  // `DashboardComponentSchema.aria`). The Zod twin does carry teeth — see the
+  // `z.never()` tombstone in `zod/complex.zod.ts`. Pinned by
+  // `__tests__/dashboard-config.test.ts`.
 
   /** Catch-all for additional properties */
   [key: string]: any;

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -563,6 +563,18 @@ export const DashboardWidgetConfigSchema = z.object({
  * Dashboard Config Schema — Zod validator for DashboardConfigPanel data model.
  *
  * Validates the unified dashboard configuration used by create/edit workflows.
+ *
+ * The `aria` member is an ADR-0049 retirement tombstone (objectui#5852),
+ * following this package's convention (`data-display.zod.ts`
+ * `StaticTableColumnSchema`, the set `crud.zod.ts` `confirm` established):
+ * `z.never().optional()` REFUSES an authored value at parse time with the key
+ * named in the error path, rather than letting it be silently stripped the way
+ * an undeclared key would be on this non-`.strict()` object. Loud refusal is
+ * the ruled outcome — `aria` was accepted-and-preserved for as long as it was
+ * declared, so a plain deletion would have converted a preserved key into a
+ * silent drop. The TS twin (`../designer.ts` `DashboardConfig`) no longer
+ * declares it at all; both halves are pinned by
+ * `__tests__/dashboard-config.test.ts`.
  */
 export const DashboardConfigSchema = z.object({
   id: z.string().optional().describe('Dashboard identifier'),
@@ -592,10 +604,7 @@ export const DashboardConfigSchema = z.object({
     icon: z.string().optional(),
     variant: z.string().optional(),
   })).optional().describe('Header action buttons'),
-  aria: z.object({
-    label: z.string().optional(),
-    description: z.string().optional(),
-  }).optional().describe('ARIA accessibility attributes'),
+  aria: z.never({ error: 'RETIRED (objectui#5852) — `aria` is no longer part of DashboardConfig; delete the key. The `{ label, description }` spellings matched no renderer vocabulary and nothing ever read them.' }).optional().describe('RETIRED (objectui#5852) — the `{ label, description }` spellings matched no renderer vocabulary and no read point ever consumed them; delete the key. For real ARIA use the spec vocabulary (`ariaLabel` / `ariaDescribedBy` / `role`) on a surface that reads it.'),
 });
 
 /**


### PR DESCRIPTION
Fixes #5852

Retires the designer-surface dashboard `aria` pair: `DashboardConfig.aria`
(`packages/types/src/designer.ts`) and its Zod twin `DashboardConfigSchema.aria`
(`packages/types/src/zod/complex.zod.ts`).

## The premise, re-measured on `main` (not inherited)

The pair declared `{ label?: string; description?: string }` — spellings that
match neither `@objectstack/spec`'s `AriaProps` vocabulary
(`ariaLabel` / `ariaDescribedBy` / `role`) nor anything a renderer maps.

| probe | result |
| --- | --- |
| `.aria` non-test reads in `plugin-designer/src`, `plugin-dashboard/src`, `apps/console/src` | **0 / 0 / 0** |
| `DashboardConfigSchema` refs outside `packages/types` | **0** (defn, barrel re-export, 2 test files only) |
| `DashboardConfig` type refs outside `packages/types` | **0** (defn, `index.ts` re-export, 2 test files only) |
| either name anywhere in the `objectstack` repo (`3637731`) | **0** |
| **control** — `PageNodeSchema` by the identical grep | **24** hits outside `packages/types` |
| **control** — live `.aria` member reads by the identical grep | found in `plugin-detail/renderers/record-quick-actions.tsx:201`, `record-path.tsx`, `plugin-list/ListView.tsx:2661` |

The controls matter: a zero-hit grep with no known-present control is an untested
instrument, not a measurement.

**The card's second claim also holds.** `packages/plugin-dashboard/src/DashboardConfigPanel.tsx`
— the panel `DashboardConfig`'s own doc comment says it serves — imports
`ConfigPanelSchema` from `@object-ui/components` and neither `DashboardConfig`
nor `DashboardConfigSchema`, and contains no `aria` read. So this is a
retirement, not a wiring card.

## The shape, mirrored from #5830 / PR #5855

That sibling's landed shape was: delete the TS member, leave an in-place comment
tombstone, and let the Zod twin **refuse the key by name with a message** (it
inherited a `retiredKey` tombstone from the spec). Its aria-only test was
replaced by a house-style removal note, not silently dropped.

This card has **no spec tombstone to inherit** — `DashboardConfig` is a
designer-local model. Mirroring #5830's *end state* rather than only its
mechanism:

- **TS half** — plain deletion plus a comment tombstone. `DashboardConfig` carries
  `[key: string]: any`, so an authored `aria` still compiles; what is removed is
  the type-level suggestion and the false contract claim. Same honest caveat
  #5830 recorded for its own index signature.
- **Zod half** — an ADR-0049 tombstone, `z.never({ error }).optional().describe(...)`,
  following this package's existing convention (`data-display.zod.ts`
  `StaticTableColumnSchema`, the set `crud.zod.ts` `confirm` established), whose
  doc block states the ruling directly: *"Loud refusal is the ruled outcome."*

### Why not a plain deletion of the Zod key — measured, not assumed

`DashboardConfigSchema` is a bare `z.object` with no `.strict()`. Measured on
built `dist/` before the change:

```
BEFORE  safeParse({title,aria:{label,description}})  -> success:true, aria PRESERVED in output
        safeParse({title, someUndeclaredKey:'x'})    -> success:true, key SILENTLY STRIPPED
```

So a plain deletion would have converted an accepted-and-**preserved** key into a
silently **dropped** one — quiet data loss, and precisely the #6068 behaviour
("a plain `z.object` with no `.strict()` strips unknown keys rather than refusing
them"). After the tombstone, measured on `dist/`:

```
AFTER   safeParse({title,aria:{...}})  -> success:false
                                          path:    ["aria"]
                                          message: RETIRED (objectui#5852) — `aria` is no longer
                                                   part of DashboardConfig; delete the key. ...
        safeParse({title, someUndeclaredKey:'x'})  -> success:true (control: the red is the
                                                     tombstone, NOT strictness)
        safeParse({title, columns:12})             -> success:true (control: nothing else narrowed)
```

`z.never({ error })` rather than a bare `z.never()` because the bare form refuses
with zod's generic `Invalid input: expected never, received object` — the key is
named only via the issue path and the `.describe()` text never reaches the
author.

## Test readers — flipped, not deleted

Both references live in `packages/types/src/__tests__/dashboard-config.test.ts`:

1. The `aria:` line inside the *"should accept a full DashboardConfig"* TS literal
   → replaced with a removal note. Kept, it would have gone on compiling through
   the index signature while asserting the opposite of the contract — the exact
   green-wash #5830 called out.
2. `it('should validate aria accessibility attributes')`, which asserted
   `success === true` → **flipped** to assert refusal by name and message, plus two
   controls. Note that after a *plain* deletion this test would have stayed
   **green** (unknown key stripped), which is why the flip matters.

## Verification

Predicted before running: after a removal the sweeps must stay **green** (the
positive evidence nothing consumed the pair), and that green is weak alone — so a
counter-probe must show the same instrument going **red**.

| gate | command | exit |
| --- | --- | --- |
| package type-check | `pnpm --filter @object-ui/types type-check` | **0** |
| unit tests | `vitest run packages/types/src --maxWorkers=2` | **0** — 57 files, 630 tests passed |
| downstream sweep (cold) | `turbo run type-check --filter='...@object-ui/types' --concurrency=2 --force` | **0** — 78/78 tasks, **0 cached**, 8m53s |
| changeset presence | `node scripts/check-changeset-presence.mjs` | **0** |
| changeset no-major | `node scripts/check-changeset-no-major.mjs` | **0** |
| changeset fixed group | `node scripts/check-changeset-fixed.mjs` | **0** |
| esm specifiers | `pnpm check:esm-specifiers` | **0** |
| eslint (delta) | `npx eslint` over the 3 changed files, `--format json` | **0** — 0 errors, 12 warnings, all pre-existing `no-explicit-any` |
| control bytes | `grep -naP` control-byte class on changed files | clean |

All run on committed head `697226d36`. The cold sweep is deliberately `--force`:
an earlier run reported 77/78 **cached**, which is indistinguishable from a build
that never looked.

**Filter direction demonstrated, not asserted:** prefix `...@object-ui/types`
matches **43** packages (downstream dependents); suffix `@object-ui/types...`
matches **1** (itself — the package has no workspace deps). The
`@object-ui/types^...` build form prints *"No projects matched the filters"* and
exits **0**; that zero-match is **genuine** here, provable from the manifest,
whose only deps are the external `@objectstack/spec` and `zod`.

### Counter-probe (at the `dist/` layer, after committing)

Downstream resolves `@object-ui/types` through `exports` to `dist/`, so a
source-only mutation would leave the sweep green and read as "nothing consumes
it". Renamed the genuinely-consumed `PageNodeSchema` in `layout.ts`, proved the
mutation on disk in **both** directions (injected marker present / removed text
absent), rebuilt, and proved it reached `dist/layout.d.ts`:

- `packages/components` `tsc --noEmit`: **exit 0 → exit 2**. The instrument has teeth.
- Observed direction reported as observed: the red surfaced as `TS7006` at
  `renderers/layout/page.tsx:597` (collapsed inference), **not** the crisp
  `TS2305` — because the failing build never re-emitted `dist/index.d.ts`, so the
  barrel still re-exported a symbol `layout.d.ts` no longer had.
- Restore leg rebuilt and verified too: marker gone from `dist/` (0 files),
  `PageNodeSchema` back, this PR's own changes still present in `dist/`,
  `git diff HEAD --stat` empty, and `packages/components` `tsc --noEmit` back to
  **exit 0** — so the red was caused solely by the ablation.

Mutation/restore ran under `trap … EXIT INT TERM` with a cwd-independent
`git -C` pinned to the worktree path plus `checkout --`, and the edit was
committed **first** so the trap could not revert un-committed work along with the
probe (the #5859 lesson).

## Changeset

`minor` per the public-type-break policy (never `major` —
`check-changeset-no-major.mjs` refuses it outright). It names **both** retired
spellings verbatim so a host can grep its own sources, states the two directions
separately (narrowed TS suggestion vs. changed runtime accept/reject), and
carries the external caveat: in-repo zero is not npm zero, and stored dashboard
configuration is not reachable from this seat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_