### PR TITLE
docs(fields): re-fence 24 plaintext TypeScript blocks as `ts` (#5867 batch 1)

### DIFF
--- a/.changeset/5867-plaintext-fenced-ts-batch1.md
+++ b/.changeset/5867-plaintext-fenced-ts-batch1.md
@@ -1,0 +1,15 @@
+---
+---
+
+Docs only, publishes nothing: twenty-four TypeScript snippets across thirteen
+`content/docs/fields/*.mdx` reference pages were fenced ```plaintext, so
+`check-doc-snippet-types` — which reads only `ts` / `tsx` fences — never saw
+them (objectui#5867, batch 1 of N). Triage's classifier is the one applied: a
+plaintext block whose first line starts with `import` / `export` / `interface` /
+`type X =` / `const x: T` is code, and those fences are now `ts`; genuinely
+prose blocks on the same pages (a bare object literal, a comment-only
+illustration) are left alone. The gate's blocks-to-compile count rises from 157
+to 181 — exactly the batch — with diagnostics at 0, no new `FRAGMENT_MARKER`
+declarations, and the covered/ungated sets unmoved. The blocks also stop
+rendering as unstyled plaintext and pick up TypeScript highlighting, which is
+the reader-visible half.

--- a/content/docs/fields/boolean.mdx
+++ b/content/docs/fields/boolean.mdx
@@ -19,7 +19,7 @@ The Boolean Field component provides a switch or checkbox input for collecting t
 
 ## Field Schema
 
-```plaintext
+```ts
 interface BooleanFieldSchema {
   type: 'boolean';
   name: string;                  // Field name/ID
@@ -45,7 +45,7 @@ interface BooleanFieldSchema {
 
 In tables/grids, boolean values are displayed as badges:
 
-```plaintext
+```ts
 import { BooleanCellRenderer } from '@object-ui/fields';
 
 // Renders:

--- a/content/docs/fields/currency.mdx
+++ b/content/docs/fields/currency.mdx
@@ -15,7 +15,7 @@ The Currency Field component provides a formatted currency input with proper loc
 
 ## Field Schema
 
-```plaintext
+```ts
 interface CurrencyFieldSchema {
   type: 'currency';
   name: string;                  // Field name/ID
@@ -46,7 +46,7 @@ interface CurrencyFieldSchema {
 
 In tables/grids, currency values are formatted with the appropriate symbol:
 
-```plaintext
+```ts
 import { CurrencyCellRenderer } from '@object-ui/fields';
 
 // Renders: $1,234.56 or €1.234,56 based on locale

--- a/content/docs/fields/date.mdx
+++ b/content/docs/fields/date.mdx
@@ -15,7 +15,7 @@ The Date Field component provides a date picker for selecting dates and optional
 
 ## Field Schema
 
-```plaintext
+```ts
 interface DateFieldSchema {
   type: 'date' | 'datetime';
   name: string;                  // Field name/ID
@@ -55,7 +55,7 @@ The date field supports various display formats:
 
 In tables/grids, dates are formatted consistently:
 
-```plaintext
+```ts
 import { DateCellRenderer } from '@object-ui/fields';
 
 // Renders: Dec 31, 2024

--- a/content/docs/fields/datetime.mdx
+++ b/content/docs/fields/datetime.mdx
@@ -23,7 +23,7 @@ The DateTime Field component provides a combined date and time input for collect
 
 ## Field Schema
 
-```plaintext
+```ts
 interface DateTimeFieldSchema {
   type: 'datetime';
   name: string;                  // Field name/ID
@@ -52,7 +52,7 @@ Example: `2024-03-15T14:30` represents March 15, 2024 at 2:30 PM
 
 When used in data tables or grids:
 
-```plaintext
+```ts
 import { DateTimeCellRenderer } from '@object-ui/fields';
 
 // Renders: Mar 15, 2024, 02:30 PM

--- a/content/docs/fields/email.mdx
+++ b/content/docs/fields/email.mdx
@@ -15,7 +15,7 @@ The Email Field component provides a text input with built-in email validation a
 
 ## Field Schema
 
-```plaintext
+```ts
 interface EmailFieldSchema {
   type: 'email';
   name: string;                  // Field name/ID
@@ -41,7 +41,7 @@ The email field automatically validates:
 
 In tables/grids, email addresses are clickable links:
 
-```plaintext
+```ts
 import { EmailCellRenderer } from '@object-ui/fields';
 
 // Renders as: <a href="mailto:user@example.com">user@example.com</a>

--- a/content/docs/fields/number.mdx
+++ b/content/docs/fields/number.mdx
@@ -19,7 +19,7 @@ The Number Field component provides a numeric input for collecting integer or de
 
 ## Field Schema
 
-```plaintext
+```ts
 interface NumberFieldSchema {
   type: 'number';
   name: string;                  // Field name/ID
@@ -50,7 +50,7 @@ interface NumberFieldSchema {
 
 In tables/grids, numbers are displayed with tabular formatting:
 
-```plaintext
+```ts
 import { NumberCellRenderer } from '@object-ui/fields';
 
 // Renders with precision and tabular-nums font

--- a/content/docs/fields/password.mdx
+++ b/content/docs/fields/password.mdx
@@ -19,7 +19,7 @@ The Password Field component provides a secure text input for passwords with a t
 
 ## Field Schema
 
-```plaintext
+```ts
 interface PasswordFieldSchema {
   type: 'password';
   name: string;                  // Field name/ID

--- a/content/docs/fields/percent.mdx
+++ b/content/docs/fields/percent.mdx
@@ -23,7 +23,7 @@ The Percent Field component provides a percentage input that automatically conve
 
 ## Field Schema
 
-```plaintext
+```ts
 interface PercentFieldSchema {
   type: 'percent';
   name: string;                  // Field name/ID
@@ -61,7 +61,7 @@ Example:
 
 In tables/grids, values are formatted with percentage symbol:
 
-```plaintext
+```ts
 import { PercentCellRenderer } from '@object-ui/fields';
 
 // Renders: 85.50%

--- a/content/docs/fields/phone.mdx
+++ b/content/docs/fields/phone.mdx
@@ -15,7 +15,7 @@ The Phone Field component provides a text input optimized for phone number entry
 
 ## Field Schema
 
-```plaintext
+```ts
 interface PhoneFieldSchema {
   type: 'phone';
   name: string;                  // Field name/ID
@@ -33,7 +33,7 @@ interface PhoneFieldSchema {
 
 In tables/grids, phone numbers are clickable tel: links:
 
-```plaintext
+```ts
 import { PhoneCellRenderer } from '@object-ui/fields';
 
 // Renders as: <a href="tel:+15551234567">+1 (555) 123-4567</a>

--- a/content/docs/fields/text.mdx
+++ b/content/docs/fields/text.mdx
@@ -23,7 +23,7 @@ The Text Field component provides a single-line text input for collecting basic 
 
 ## Field Schema
 
-```plaintext
+```ts
 interface TextFieldSchema {
   type: 'text';
   name: string;                  // Field name/ID
@@ -53,7 +53,7 @@ interface TextFieldSchema {
 
 When used in data tables or grids, the text field is rendered as simple truncated text:
 
-```plaintext
+```ts
 import { TextCellRenderer } from '@object-ui/fields';
 
 // Automatically used for type: 'text' in grids/tables

--- a/content/docs/fields/textarea.mdx
+++ b/content/docs/fields/textarea.mdx
@@ -19,7 +19,7 @@ The TextArea Field component provides a multi-line text input for collecting lon
 
 ## Field Schema
 
-```plaintext
+```ts
 interface TextAreaFieldSchema {
   type: 'textarea';
   name: string;                  // Field name/ID
@@ -49,7 +49,7 @@ interface TextAreaFieldSchema {
 
 When displayed in tables or grids, long text is truncated:
 
-```plaintext
+```ts
 import { TextCellRenderer } from '@object-ui/fields';
 
 // Same renderer as text field - truncates long content

--- a/content/docs/fields/time.mdx
+++ b/content/docs/fields/time.mdx
@@ -23,7 +23,7 @@ The Time Field component provides a time-only input for collecting hour and minu
 
 ## Field Schema
 
-```plaintext
+```ts
 interface TimeFieldSchema {
   type: 'time';
   name: string;                  // Field name/ID

--- a/content/docs/fields/url.mdx
+++ b/content/docs/fields/url.mdx
@@ -15,7 +15,7 @@ The URL Field component provides a text input with URL validation and clickable 
 
 ## Field Schema
 
-```plaintext
+```ts
 interface UrlFieldSchema {
   type: 'url';
   name: string;                  // Field name/ID
@@ -40,7 +40,7 @@ The URL field automatically validates:
 
 In tables/grids, URLs are clickable external links:
 
-```plaintext
+```ts
 import { UrlCellRenderer } from '@object-ui/fields';
 
 // Renders as: <a href="https://example.com" target="_blank">https://example.com</a>


### PR DESCRIPTION
Part of #5867 — batch 1 of N. The card's remaining blocks are listed at the bottom so the next batch does not have to re-derive them.

## What this changes

Twenty-four fences, thirteen files, nothing else. `content/docs/fields/*.mdx` scalar-field reference pages had their TypeScript examples fenced as `plaintext`, so `check-doc-snippet-types` — which reads only `ts` / `tsx` fences — never compiled them. Those twenty-four fences are now `ts`.

**No block body was edited.** The diff is exactly 24 changed lines, all of them the fence opener — 24 `+```ts` against 24 `-```plaintext`.

Triage's classifier is applied verbatim, not widened: a plaintext block whose first line starts with `import` / `export` / `interface` / `type X =` / `const x: T` is code. Genuinely-prose blocks on the same pages are left alone, and two of them survive as evidence of that — `date.mdx:69` (a bare object literal) and `percent.mdx:53` (a comment-only illustration) are still `plaintext`.

Files: `boolean` · `currency` · `date` · `datetime` · `email` · `number` · `password` · `percent` · `phone` · `text` · `textarea` · `time` · `url`. Whole files: every classified block on each page converted, so none is left half-done. They were chosen because the classifier is unambiguous on all of them — each block is either a complete `interface …FieldSchema { … }` using only primitives and globals, or a single `import { …CellRenderer } from '@object-ui/fields'` with comments.

## Gate counts, before and after

Both runs against the built tree; the after-run is at `542eaa0df`, this branch's head.

| | before | after | delta |
|---|---|---|---|
| documents scanned | 222 | 222 | 0 |
| covered documents | 178 | 178 | **0 — the covered set did not shrink** |
| covered documents holding a ts/tsx block | 43 | 56 | +13 = the batch's files |
| ungated documents | 44 | 44 | **0 — no covered document became ungated** |
| blocks to compile | 157 | **181** | **+24 = exactly the batch size** |
| declared fragments | 111 | 111 | **0 — no `FRAGMENT_MARKER` was declared** |
| diagnostics | 0 | **0** | syntax phase clean, 181 of 181 judged |

Gate strictness is unmoved: `scripts/check-doc-snippet-types.mjs`, `UNGATED_DOCS` and the ledger prose are untouched by this diff.

## Every block was compiled, not eyeballed

The 24 blocks are in the gate's population now and the gate reports `181 of 181 block(s) judged, 0 failed`. That is the whole claim — none of it is inferred from "it looks like TypeScript".

## The blocks still render, and they render better

`pnpm site:build` is green (Next.js prerendered all 180+ doc pages). Reading the prerendered HTML back, the converted blocks now carry real shiki TypeScript tokens where they were previously unstyled — 13 highlighted `interface` keywords plus 11 highlighted `import` keywords across the thirteen pages, which is 24, matching the batch exactly. The prose block left alone still renders with no colour spans at all (`{"children":"// Stored in database: 0.85"}`).

That is the reader-visible half: these examples stopped looking like console output.

## What reddens next, measured rather than predicted

Before choosing the batch I ran the remaining thirteen `content/docs/fields/` pages through the gate as a throwaway probe — 27 fences mutated, gate run, tree restored by an `EXIT` trap (`git status` clean afterwards). Five would pass untouched (`file`, `formula`, `rich-text`, `select`, `user`); eight red, and the diagnostics are real documentation defects:

- **Four pages import a cell renderer `@object-ui/fields` does not export** — `GridCellRenderer`, `ObjectCellRenderer`, `SummaryCellRenderer`, `VectorCellRenderer`. `grid` and `vector` have no exported renderer at all (the resolver returns an inline anonymous component), so the remedy is a documentation decision rather than a rename. Filed separately, and those files are excluded from this batch.
- `image.mdx` and `lookup.mdx` reference `FileMetadata` / `DataSource` without declaring or importing them.
- `auto-number.mdx` uses an ambient `db`; `object.mdx` imports `ajv`, not a root dependency; `location.mdx`'s block is a JSX element followed by a bare object literal and does not parse.

None of those was made to pass with a `FRAGMENT_MARKER`.

## Population, corrected

The card says 211 blocks / 122 files. Re-measured on today's `origin/main` (`f471b4f73`) with the gate's own fence walk and triage's classifier: **195 blocks across 118 files** — all under `content/docs`, none in a package README.

After this batch, **171 blocks in 105 files remain**:

| group | blocks | files |
|---|---|---|
| `content/docs/components/**` | 71 | 71 |
| `content/docs/core/**` | 32 | 4 |
| `content/docs/fields/**` | 27 | 13 |
| `content/docs/layout/**` | 12 | 3 |
| `content/docs/plugins/**` | 12 | 7 |
| `content/docs/blocks/**` | 10 | 1 |
| in `UNGATED_DOCS` — re-fencing adds 0 to the compile population | 7 | 6 |
| **total** | **171** | **105** |

## Out of scope, deliberately

The gate itself, `UNGATED_DOCS`, the ledger entries, and the future fence-language guard. No block body was rewritten and no fragment was declared.

## Verification

All at `542eaa0df`:

- `node scripts/check-doc-snippet-types.mjs` — `Every covered documentation snippet compiles against the built types.`, `181 of 181 block(s) judged, 0 failed`
- `pnpm check:doc-types` — `Every documented component type is registered.`
- `pnpm docs:check-links` — `Links are valid across 15 scan roots.`
- `pnpm check:control-bytes` — `OK (scanned 5056 tracked text file(s))`
- `pnpm exec vitest run` over `scripts/__tests__/check-doc-snippet-types.test.ts`, `check-doc-component-types.test.ts`, `check-doc-links.test.ts` and `doc-version-claims.test.ts`, from the repo root — `Test Files 4 passed (4) · Tests 165 passed (165)`
- `pnpm site:build` — green

Changeset: `.changeset/5867-plaintext-fenced-ts-batch1.md`, empty frontmatter — docs-only, publishes nothing.

Refs: #5044 (the victim that made this a card) · #5174 (the batching precedent).

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_