### PR TITLE
feat(core,data-objectstack,plugin-grid): consume the platform's per-column sortability signal

### DIFF
--- a/.changeset/5729-column-sortability-signal.md
+++ b/.changeset/5729-column-sortability-signal.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/core': minor
+'@object-ui/data-objectstack': patch
+'@object-ui/plugin-grid': patch
+---
+
+Grid headers offer a sort click only on columns the PLATFORM says it will order by
+(objectui#5729 — the consumer leg of objectstack#10235, maintainer ruling A, 2026-08-23:
+the platform serves an explicit per-column sortability signal and the grid reads it,
+rather than re-deriving "virtual ⇒ unsortable" from field type).
+
+`GET /api/v1/meta/object/:name` now answers with a `sortability` projection on its
+ENVELOPE — `{ fields: { [name]: { sortable, reason?, caveat? } } }`, computed at serve
+time from the platform's own storage predicates, deliberately beside `item` rather than
+inside it so the key stays un-authorable. The signal was reaching the browser and being
+discarded one line before its only consumer: `ObjectStackAdapter.getObjectSchema` unwraps
+the envelope to `item`, so every UI reader saw a document with no signal on it. It now
+survives that unwrap, carried on the schema under a symbol key — invisible to
+`JSON.stringify`, to `Object.keys` and to a spread, so a schema handed back at a metadata
+write endpoint can never take it into a body the server parses strictly.
+
+`@object-ui/core` gains the one spelling of the consumer contract:
+`isPlatformSortableField(projection, name)` is `true` iff an entry EXISTS for the name and
+says `sortable: true`. Absence is a refusal — it is how the platform encodes an unknown
+name, a dotted path and an unprovisioned audit column, all three of which the runtime
+doors reject — so the `!== false` spelling every other optional flag in this repo uses
+would get exactly that family backwards. A projection that is absent ALTOGETHER is a
+different question with a different answer (`undefined`: no signal was served) and is
+typed apart from an empty one, so a deployment older than the upstream change keeps the
+behaviour it had rather than being told, falsely, that nothing on the object is sortable.
+
+Three things follow in the grid. The header click on a refused column ceases to exist, so
+neither the old silent-unordered result nor the `400 INVALID_SORT` that replaced it is
+reachable from it. A sort PERSISTED before the signal existed is filtered out of both what
+the grid renders and what it emits, so a restored personalization cannot ride back into
+the next `persistViewPatch({ sort })` — the half-fix where the affordance is gone and the
+PUT still fires. And the relational carve-out is untouched and deliberately not delegated
+to this signal: the platform answers `sortable: true` for a `lookup` (it has a stored
+foreign key and both runtime doors accept ordering by it), while the grid withholds that
+header for a different reason — a column of names ordered by an invisible id.
+
+Columns carrying `caveat: 'unprovisioned-anchor'` keep their click. The runtime accepts
+those sorts; refusing what the platform does not refuse would recreate declared-≠-enforced
+drift in mirror image.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,12 @@ export * from './utils/expand-fields.js';
 // name, so its published surface is unchanged.
 export * from './utils/retired-field-types.js';
 export * from './utils/unmaterialized-fields.js';
+// [#5729] The consumer half of objectstack#10235's ruling: the SERVED
+// per-column sortability projection, and the one spelling of its contract
+// (`entry exists && sortable: true`). Homed beside the storage-fact set above
+// because a consumer that reaches for one must be able to see the other and
+// know which one the platform actually served.
+export * from './utils/column-sortability.js';
 export * from './utils/column-identity.js';
 export * from './utils/sort-values.js';
 export * from './utils/sort-query.js';

--- a/packages/core/src/utils/__tests__/column-sortability.test.ts
+++ b/packages/core/src/utils/__tests__/column-sortability.test.ts
@@ -1,0 +1,191 @@
+/**
+ * [#5729] The consumer half of objectstack#10235's ruling A: the grid reads
+ * the platform's SERVED per-column sortability signal and never re-derives
+ * "virtual ⇒ unsortable" from field type.
+ *
+ * The load-bearing assertions here are the two asymmetries the contract turns
+ * on, both of which a reasonable-looking implementation gets backwards:
+ *
+ *  - ABSENT ENTRY inside a served projection means "no platform sort behind
+ *    this name" and must answer `false`. The `!== false` spelling every other
+ *    optional flag in this repo uses answers `true` for it.
+ *  - ABSENT PROJECTION means "no signal was served", which is a different
+ *    question with a different answer, and is typed differently
+ *    (`undefined`) so the two cannot be conflated.
+ *
+ * AGREEMENT over hardcoding: the fixtures are produced by the platform's own
+ * `resolveObjectSortability` from `@objectstack/spec/api` — the resolver the
+ * REST layer serves this projection from — so these pins follow the runtime's
+ * predicate rather than a copied verdict table.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveObjectSortability } from '@objectstack/spec/api';
+import {
+  OBJECT_SORTABILITY_KEY,
+  attachObjectSortability,
+  readObjectSortability,
+  normalizeObjectSortability,
+  isPlatformSortableField,
+  filterPlatformSortableSort,
+  type ObjectSortability,
+} from '../column-sortability';
+
+/** The #10235 oracle shape: a formula column beside ordinary persisted ones. */
+const OPPORTUNITY = {
+  name: 'crm_opportunity',
+  fields: {
+    name: { type: 'text' },
+    amount: { type: 'currency' },
+    owner: { type: 'lookup', reference_to: 'sys_user' },
+    expected_revenue: { type: 'formula', expression: 'amount * probability / 100' },
+  },
+};
+
+describe('the served projection agrees with the platform resolver (#5729 / objectstack#10235)', () => {
+  it('marks the oracle formula column unsortable and its persisted siblings sortable', () => {
+    const served = resolveObjectSortability(OPPORTUNITY) as ObjectSortability;
+
+    expect(served.fields.expected_revenue).toEqual({ sortable: false, reason: 'virtual-type' });
+    expect(served.fields.amount).toEqual({ sortable: true });
+    expect(served.fields.name).toEqual({ sortable: true });
+    // The driver-provisioned primary key is always in the projection's domain.
+    expect(served.fields.id).toEqual({ sortable: true });
+  });
+
+  it('answers `sortable: true` for a RELATIONAL column — so the grid cannot delegate that rule here', () => {
+    // Measured, not assumed: a `lookup` has a stored foreign-key column and
+    // both runtime doors accept an ORDER BY over it. The grid still withholds
+    // that header, for a reason the platform does not share (ordering a column
+    // of names by an invisible id). Pinning it here is what stops someone
+    // "simplifying" the grid into asking this signal the relational question.
+    const served = resolveObjectSortability(OPPORTUNITY) as ObjectSortability;
+    expect(served.fields.owner).toEqual({ sortable: true });
+  });
+});
+
+describe('isPlatformSortableField — the contract, and its two asymmetries', () => {
+  const served = resolveObjectSortability(OPPORTUNITY) as ObjectSortability;
+
+  it('offers the affordance only when an entry EXISTS and says sortable: true', () => {
+    expect(isPlatformSortableField(served, 'amount')).toBe(true);
+    expect(isPlatformSortableField(served, 'expected_revenue')).toBe(false);
+  });
+
+  it('refuses an ABSENT entry — the case a `!== false` test gets exactly backwards', () => {
+    // Three shapes the platform encodes as absence, all refused by the runtime
+    // doors: an unknown name, a dotted path, an unprovisioned audit column.
+    expect(isPlatformSortableField(served, 'not_a_field')).toBe(false);
+    expect(isPlatformSortableField(served, 'account.name')).toBe(false);
+    expect(isPlatformSortableField(served, 'created_at')).toBe(false);
+    // The counter-probe that proves the three above are not just a broken
+    // reader answering `false` to everything.
+    expect(isPlatformSortableField(served, 'name')).toBe(true);
+    // And the spelling this function exists to forbid, stated as a fact:
+    // reading the same absence with `!== false` would have answered `true`.
+    expect((served.fields as any).not_a_field?.sortable !== false).toBe(true);
+  });
+
+  it('refuses an empty / malformed field name and a malformed entry', () => {
+    expect(isPlatformSortableField(served, undefined)).toBe(false);
+    expect(isPlatformSortableField(served, '')).toBe(false);
+    expect(isPlatformSortableField({ fields: { a: null as any } }, 'a')).toBe(false);
+    expect(isPlatformSortableField({ fields: { a: { sortable: 'yes' } as any } }, 'a')).toBe(false);
+  });
+
+  it('KEEPS the click on `caveat: unprovisioned-anchor` — the platform does not refuse it', () => {
+    // Default A of the #10235 affordance question, held until ruled: refusing
+    // what the platform accepts would recreate declared-≠-enforced drift in
+    // mirror image. The caveat is advisory; `sortable` is the enforcement fact.
+    const withCaveat: ObjectSortability = {
+      fields: { remote_anchor: { sortable: true, caveat: 'unprovisioned-anchor' } },
+    };
+    expect(isPlatformSortableField(withCaveat, 'remote_anchor')).toBe(true);
+  });
+});
+
+describe('the carrier: attach / read, and what it deliberately hides', () => {
+  it('round-trips the served projection through the schema object', () => {
+    const schema: any = { name: 'crm_opportunity', fields: OPPORTUNITY.fields };
+    attachObjectSortability(schema, resolveObjectSortability(OPPORTUNITY));
+
+    const read = readObjectSortability(schema);
+    expect(read?.fields.expected_revenue).toEqual({ sortable: false, reason: 'virtual-type' });
+    expect(isPlatformSortableField(read!, 'amount')).toBe(true);
+  });
+
+  it('is invisible to JSON.stringify, Object.keys and spread — it can never reach a write body', () => {
+    // The upstream change kept `sortability` OFF the document because
+    // `FieldSchema` is a strict object and the server rejects an undeclared
+    // key by name. A string key here would have undone that one repo away.
+    const schema: any = { name: 'crm_opportunity', fields: {} };
+    attachObjectSortability(schema, { fields: { id: { sortable: true } } });
+
+    expect(JSON.parse(JSON.stringify(schema))).toEqual({ name: 'crm_opportunity', fields: {} });
+    expect(Object.keys(schema)).toEqual(['name', 'fields']);
+    expect(readObjectSortability({ ...schema })).toBeUndefined();
+    // Counter-probe: it really is on the original object, so the three
+    // assertions above are about invisibility, not about a failed attach.
+    expect(readObjectSortability(schema)).toBeDefined();
+    expect((schema as any)[OBJECT_SORTABILITY_KEY]).toBeDefined();
+  });
+
+  it('attaches NOTHING when the envelope carried no projection — absence stays absence', () => {
+    // A backend older than objectstack#10235, an inline data source, a
+    // fixture. Stamping an empty projection here would tell every consumer,
+    // falsely, that no column on the object is sortable.
+    for (const served of [undefined, null, {}, { fields: null }, [], 'nope']) {
+      const schema: any = { name: 'x', fields: {} };
+      attachObjectSortability(schema, served as any);
+      expect(readObjectSortability(schema)).toBeUndefined();
+    }
+    // Counter-probe: a well-formed envelope value on the same helper attaches.
+    const ok: any = { name: 'x', fields: {} };
+    attachObjectSortability(ok, { fields: { id: { sortable: true } } });
+    expect(readObjectSortability(ok)).toBeDefined();
+  });
+
+  it('normalizes a served envelope value, dropping only the unusable entries', () => {
+    const normalized = normalizeObjectSortability({
+      fields: {
+        good: { sortable: true },
+        refused: { sortable: false, reason: 'virtual-type' },
+        caveated: { sortable: true, caveat: 'unprovisioned-anchor' },
+        junk: { sortable: 'maybe' },
+        alsoJunk: null,
+      },
+    });
+    expect(normalized?.fields).toEqual({
+      good: { sortable: true },
+      refused: { sortable: false, reason: 'virtual-type' },
+      caveated: { sortable: true, caveat: 'unprovisioned-anchor' },
+    });
+  });
+
+  it('reads `undefined` off a schema that was never stamped', () => {
+    expect(readObjectSortability({ name: 'x', fields: {} })).toBeUndefined();
+    expect(readObjectSortability(undefined)).toBeUndefined();
+    expect(readObjectSortability(null)).toBeUndefined();
+  });
+});
+
+describe('filterPlatformSortableSort — the restore leg', () => {
+  const served = resolveObjectSortability(OPPORTUNITY) as ObjectSortability;
+
+  it('drops a persisted sort on a column the platform refuses, keeping its siblings', () => {
+    const restored = [
+      { field: 'expected_revenue', order: 'desc' },
+      { field: 'amount', order: 'asc' },
+      { field: 'not_a_field', order: 'asc' },
+    ];
+    expect(filterPlatformSortableSort(restored, served)).toEqual([
+      { field: 'amount', order: 'asc' },
+    ]);
+  });
+
+  it('is a no-op on a sort the platform honors, and total on a sort it does not', () => {
+    const honored = [{ field: 'name', order: 'asc' }];
+    expect(filterPlatformSortableSort(honored, served)).toEqual(honored);
+    expect(filterPlatformSortableSort([{ field: 'expected_revenue', order: 'asc' }], served)).toEqual([]);
+    expect(filterPlatformSortableSort(undefined, served)).toEqual([]);
+  });
+});

--- a/packages/core/src/utils/column-sortability.ts
+++ b/packages/core/src/utils/column-sortability.ts
@@ -1,0 +1,232 @@
+/**
+ * ObjectUI — served per-column sortability projection (consumer side)
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The consumer half of objectstack#10235 (maintainer ruling A, 2026-08-23):
+ * the platform serves an explicit per-column sortability signal, and a grid
+ * reads THAT to decide whether a header offers a sort click — it never
+ * re-derives "virtual ⇒ unsortable" from the field's `type`.
+ *
+ * ## What the platform serves
+ *
+ * `GET /api/v1/meta/object/:name` answers `GetMetaItemResponseSchema`, whose
+ * ENVELOPE (never the document under `item` — `FieldSchema` is a
+ * `strictObject`, so the key must stay un-authorable) carries an optional
+ * `sortability` key when the served type is `object`, on every serving branch
+ * including the cached one:
+ *
+ * ```jsonc
+ * { "type": "object", "name": "crm_opportunity", "item": { … },
+ *   "sortability": { "fields": {
+ *     "amount":           { "sortable": true },
+ *     "expected_revenue": { "sortable": false, "reason": "virtual-type" },
+ *     "remote_anchor":    { "sortable": true,  "caveat": "unprovisioned-anchor" }
+ *   } } }
+ * ```
+ *
+ * Shape verified against the MERGED upstream change, not against a description
+ * of it: `@objectstack/spec`'s `ObjectSortabilitySchema` /
+ * `FieldSortabilitySchema` and `GetMetaItemResponseSchema.sortability`.
+ *
+ * ## The contract, and the asymmetry that makes it easy to get backwards
+ *
+ * Offer a sort affordance on a column **iff the projection has an entry for
+ * the column's field name AND that entry says `sortable: true`**.
+ *
+ * ABSENCE OF AN ENTRY MEANS "no platform sort behind this name" — never
+ * "assume sortable". The projection's domain is exactly the served field map
+ * plus the always-provisioned `id`, so an unknown name, a dotted path
+ * (`account.name`) and an unprovisioned audit column all arrive as absence,
+ * and all three are refused by the runtime doors. A `!== false` test — the
+ * spelling every other optional flag in this repo uses — answers `true` for
+ * absence and so gets exactly that family backwards. {@link isPlatformSortableField}
+ * is the only spelling of this test; do not inline a comparison at a call site.
+ *
+ * ## Present-vs-absent PROJECTION is a different question
+ *
+ * `readObjectSortability` returns `undefined` when the served metadata carried
+ * no `sortability` key at all — a backend older than the upstream change, an
+ * inline/mock data source, a fixture. That is NOT "every column is unsortable":
+ * it is "no signal was served", and the caller decides what it did before the
+ * signal existed. The two are deliberately different types (`undefined` vs an
+ * empty `fields` map) so a caller cannot conflate them by accident.
+ *
+ * ## `caveat: 'unprovisioned-anchor'` is NOT a refusal
+ *
+ * Platform-injected anchors on ADR-0015 `external` objects come back
+ * `sortable: true, caveat: 'unprovisioned-anchor'`: the runtime ACCEPTS the
+ * sort, but silently drops it (`asc` === `desc` under a `200`) when the remote
+ * table carries no such column — a degradation the platform cannot prove
+ * either way at serve time. This module treats the caveat as advisory and the
+ * `sortable` verdict as the enforcement fact, so a caveated column keeps its
+ * click. Refusing what the platform does not refuse would recreate
+ * declared-≠-enforced drift in mirror image; whether to badge or withhold on
+ * the caveat is an open affordance question, not something to settle here.
+ */
+
+/** The one refusal-backed reason the platform serves (`sortable: false`). */
+export const FIELD_UNSORTABLE_VIRTUAL_TYPE = 'virtual-type';
+
+/** The one advisory caveat the platform serves (only with `sortable: true`). */
+export const FIELD_SORTABLE_UNPROVISIONED_ANCHOR = 'unprovisioned-anchor';
+
+/** Served sortability verdict for ONE field of an object document. */
+export interface FieldSortability {
+  /**
+   * Whether the platform honors an `ORDER BY` over this field. A DERIVED
+   * verdict computed at serve time from the platform's own storage predicates
+   * — never recompute it from the field's `type`.
+   */
+  sortable: boolean;
+  /** Present exactly when `sortable` is false. */
+  reason?: string;
+  /** Present only with `sortable: true`; accepted but possibly degrading. */
+  caveat?: string;
+}
+
+/** The served per-column sortability projection for ONE object. */
+export interface ObjectSortability {
+  /**
+   * Verdict per sortable-addressable column, keyed by field name. The domain
+   * is the served field map plus `id`; a name absent from this map has no
+   * platform sort behind it.
+   */
+  fields: Record<string, FieldSortability>;
+}
+
+/**
+ * Where the projection rides on the client-side object schema.
+ *
+ * A GLOBAL-REGISTRY SYMBOL, deliberately — the same carrier shape
+ * `INFLIGHT_GET_REGISTRY_KEY` uses in `@object-ui/types`. Three properties
+ * this signal needs and a string key would not give it:
+ *
+ *  - `JSON.stringify` drops symbol-keyed properties, so a schema object that
+ *    is ever round-tripped back at a metadata WRITE endpoint cannot carry the
+ *    projection into a document the server parses `strict` and rejects by
+ *    name. The upstream change kept the key off `item` for exactly that
+ *    reason; stamping a string key here would undo it one repo away.
+ *  - `Object.keys` / spread / `for…in` do not see it, so every existing reader
+ *    that enumerates the schema (column generators, diffing, form builders)
+ *    is unchanged by its presence.
+ *  - `Symbol.for` is the cross-realm registry, so two copies of this module
+ *    (a workspace build and a published one in the same graph) agree on the
+ *    key rather than silently reading past each other.
+ */
+export const OBJECT_SORTABILITY_KEY: unique symbol = Symbol.for('objectui.objectSortability');
+
+/** Narrow one served entry, tolerating an unparsed / hand-built record. */
+function asFieldSortability(value: unknown): FieldSortability | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const sortable = (value as { sortable?: unknown }).sortable;
+  if (typeof sortable !== 'boolean') return undefined;
+  const reason = (value as { reason?: unknown }).reason;
+  const caveat = (value as { caveat?: unknown }).caveat;
+  return {
+    sortable,
+    ...(typeof reason === 'string' ? { reason } : {}),
+    ...(typeof caveat === 'string' ? { caveat } : {}),
+  };
+}
+
+/**
+ * Normalize a served `sortability` envelope value into the projection, or
+ * `undefined` when the envelope carried nothing usable.
+ *
+ * Tolerant on purpose (the same contract the upstream resolver carries): the
+ * adapter hands this whatever came back over the wire, unparsed.
+ */
+export function normalizeObjectSortability(served: unknown): ObjectSortability | undefined {
+  if (!served || typeof served !== 'object' || Array.isArray(served)) return undefined;
+  const rawFields = (served as { fields?: unknown }).fields;
+  if (!rawFields || typeof rawFields !== 'object' || Array.isArray(rawFields)) return undefined;
+  const fields: Record<string, FieldSortability> = {};
+  for (const [name, entry] of Object.entries(rawFields as Record<string, unknown>)) {
+    const verdict = asFieldSortability(entry);
+    if (verdict) fields[name] = verdict;
+  }
+  return { fields };
+}
+
+/**
+ * Stamp the served projection onto the client-side object schema, under
+ * {@link OBJECT_SORTABILITY_KEY}.
+ *
+ * Non-enumerable and non-writable-by-accident: the property is defined rather
+ * than assigned so it never shows up in a spread of the schema and cannot be
+ * clobbered by one. Returns the same object it was handed (the adapter caches
+ * that instance), and is a no-op when there is nothing usable to attach — so
+ * an older backend leaves the schema exactly as it found it rather than
+ * stamping an empty projection that would read as "nothing is sortable".
+ */
+export function attachObjectSortability<T>(schema: T, served: unknown): T {
+  const projection = normalizeObjectSortability(served);
+  if (!projection || !schema || typeof schema !== 'object') return schema;
+  Object.defineProperty(schema, OBJECT_SORTABILITY_KEY, {
+    value: projection,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return schema;
+}
+
+/**
+ * Read the served projection off a client-side object schema.
+ *
+ * `undefined` means NO SIGNAL WAS SERVED — not "nothing is sortable". See the
+ * module docblock: callers must branch on this before applying the contract.
+ */
+export function readObjectSortability(schema: unknown): ObjectSortability | undefined {
+  if (!schema || typeof schema !== 'object') return undefined;
+  const carried = (schema as Record<symbol, unknown>)[OBJECT_SORTABILITY_KEY];
+  if (!carried || typeof carried !== 'object') return undefined;
+  const fields = (carried as { fields?: unknown }).fields;
+  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) return undefined;
+  return carried as ObjectSortability;
+}
+
+/**
+ * THE contract test: does the platform offer a sort over this field name?
+ *
+ * `true` iff the projection has an entry for `fieldName` and that entry says
+ * `sortable: true`. Every other case — no entry, `sortable: false`, a
+ * malformed entry — answers `false`, because absence means "no platform sort
+ * behind this name".
+ *
+ * `sortability` is REQUIRED and non-optional on purpose: a caller holding
+ * `undefined` (no signal served) has a different question to answer and must
+ * not reach this function with it. See {@link readObjectSortability}.
+ */
+export function isPlatformSortableField(
+  sortability: ObjectSortability,
+  fieldName: string | undefined,
+): boolean {
+  if (typeof fieldName !== 'string' || fieldName.length === 0) return false;
+  const entry = sortability.fields?.[fieldName];
+  return asFieldSortability(entry)?.sortable === true;
+}
+
+/**
+ * Drop from a sort list every entry the platform will not order by.
+ *
+ * The RESTORE leg of the same contract: withholding the header click stops a
+ * fresh unsortable sort from being created, but a sort persisted BEFORE the
+ * signal existed is already in stored view state, and replaying it would keep
+ * a refused `$orderby` alive and re-persist it on the next unrelated edit.
+ * Filtering the list at the seam the grid both renders from and emits through
+ * means an already-stored entry is inert and is dropped the first time
+ * anything writes the sort back.
+ */
+export function filterPlatformSortableSort<T extends { field?: string }>(
+  sort: readonly T[] | undefined,
+  sortability: ObjectSortability,
+): T[] {
+  if (!Array.isArray(sort)) return [];
+  return sort.filter((item) => isPlatformSortableField(sortability, item?.field));
+}

--- a/packages/core/src/utils/column-sortability.ts
+++ b/packages/core/src/utils/column-sortability.ts
@@ -69,35 +69,24 @@
  * the caveat is an open affordance question, not something to settle here.
  */
 
-/** The one refusal-backed reason the platform serves (`sortable: false`). */
-export const FIELD_UNSORTABLE_VIRTUAL_TYPE = 'virtual-type';
+/**
+ * The served shape is the SPEC's, re-exported rather than restated.
+ *
+ * `FIELD_UNSORTABLE_VIRTUAL_TYPE` / `FIELD_SORTABLE_UNPROVISIONED_ANCHOR` are
+ * the two string literals the projection can carry, and `FieldSortability` /
+ * `ObjectSortability` are the wire types themselves (`z.input` of the
+ * schemas the REST layer answers with). Re-exporting is the point of a
+ * contract-first consumer: a local declaration under a spec export's name is
+ * read by the next agent as the spec's own definition, and then drifts from
+ * it — which is what `check:spec-symbols` guards, and what it caught here.
+ */
+export {
+  FIELD_UNSORTABLE_VIRTUAL_TYPE,
+  FIELD_SORTABLE_UNPROVISIONED_ANCHOR,
+} from '@objectstack/spec/api';
+export type { FieldSortability, ObjectSortability } from '@objectstack/spec/api';
 
-/** The one advisory caveat the platform serves (only with `sortable: true`). */
-export const FIELD_SORTABLE_UNPROVISIONED_ANCHOR = 'unprovisioned-anchor';
-
-/** Served sortability verdict for ONE field of an object document. */
-export interface FieldSortability {
-  /**
-   * Whether the platform honors an `ORDER BY` over this field. A DERIVED
-   * verdict computed at serve time from the platform's own storage predicates
-   * — never recompute it from the field's `type`.
-   */
-  sortable: boolean;
-  /** Present exactly when `sortable` is false. */
-  reason?: string;
-  /** Present only with `sortable: true`; accepted but possibly degrading. */
-  caveat?: string;
-}
-
-/** The served per-column sortability projection for ONE object. */
-export interface ObjectSortability {
-  /**
-   * Verdict per sortable-addressable column, keyed by field name. The domain
-   * is the served field map plus `id`; a name absent from this map has no
-   * platform sort behind it.
-   */
-  fields: Record<string, FieldSortability>;
-}
+import type { FieldSortability, ObjectSortability } from '@objectstack/spec/api';
 
 /**
  * Where the projection rides on the client-side object schema.
@@ -127,11 +116,17 @@ function asFieldSortability(value: unknown): FieldSortability | undefined {
   if (typeof sortable !== 'boolean') return undefined;
   const reason = (value as { reason?: unknown }).reason;
   const caveat = (value as { caveat?: unknown }).caveat;
+  // `reason` / `caveat` are typed as closed literal unions by the spec, and
+  // this is unparsed input off the wire. Preserve whatever string arrived
+  // rather than dropping an annotation a NEWER platform added — the verdict
+  // this module acts on is `sortable`, and an unrecognised advisory string is
+  // strictly better carried than silently erased. The assertion is the
+  // boundary cast that admission implies, and it is confined to this function.
   return {
     sortable,
     ...(typeof reason === 'string' ? { reason } : {}),
     ...(typeof caveat === 'string' ? { caveat } : {}),
-  };
+  } as FieldSortability;
 }
 
 /**

--- a/packages/data-objectstack/src/getObjectSchema.sortability.test.ts
+++ b/packages/data-objectstack/src/getObjectSchema.sortability.test.ts
@@ -1,0 +1,138 @@
+/**
+ * [#5729] The ENVELOPE's per-column sortability projection survives the unwrap.
+ *
+ * This file guards the seam that made objectstack#10235's signal invisible to
+ * every UI consumer. `GET /api/v1/meta/object/:name` serves `sortability`
+ * BESIDE `item` — deliberately, since the document is parsed `strict`
+ * server-side and the key must stay un-authorable — and this adapter's unwrap
+ * returned `item` alone. The signal was therefore not "never sent": it was
+ * dropped in transit, one line before the only consumer that needs it, with
+ * nothing failing.
+ *
+ * Both directions are pinned, because the fallback is the dangerous half: a
+ * response with NO `sortability` key must leave the schema carrying no
+ * projection at all (`undefined`), never an empty one — an empty projection
+ * reads as "no column on this object is sortable" and would blank every sort
+ * affordance in the product against a backend older than the upstream change.
+ *
+ * AGREEMENT over hardcoding: the served value is produced by the platform's
+ * own `resolveObjectSortability` from `@objectstack/spec/api` — the resolver
+ * the REST layer computes this projection with — so the pin follows the
+ * runtime's predicate instead of a copied verdict table.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { resolveObjectSortability } from '@objectstack/spec/api';
+import { readObjectSortability, isPlatformSortableField } from '@object-ui/core';
+import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
+
+/** The #10235 oracle object: a formula column beside persisted siblings. */
+const OPPORTUNITY = {
+  name: 'crm_opportunity',
+  label: 'Opportunity',
+  fields: {
+    name: { type: 'text' },
+    amount: { type: 'currency' },
+    expected_revenue: { type: 'formula', expression: 'amount * probability / 100' },
+  },
+};
+
+function makeFetch(body: unknown) {
+  // A real `res.json()` parses a fresh object per response. The mock must too:
+  // the adapter STAMPS the projection onto the document it is handed, so a
+  // shared fixture literal would carry a previous test's stamp into the next
+  // one — and the "no signal served" cells would pass while measuring nothing.
+  const fresh = () => JSON.parse(JSON.stringify(body));
+  const fetchImpl = vi.fn(async (url: any) => {
+    const u = String(url);
+    if (u.includes('/api/v1/discovery')) {
+      return { ok: true, status: 200, statusText: 'OK', json: async () => ({ success: true, data: { version: 'v1', routes: {} } }) } as any;
+    }
+    if (u.includes('/api/v1/meta/object/')) {
+      return { ok: true, status: 200, statusText: 'OK', json: async () => fresh() } as any;
+    }
+    return { ok: true, status: 200, statusText: 'OK', json: async () => ({}) } as any;
+  });
+  return fetchImpl;
+}
+
+const adapterOver = (body: unknown) =>
+  new ObjectStackAdapter({
+    baseUrl: 'http://localhost:3000',
+    autoReconnect: false,
+    fetch: makeFetch(body) as any,
+  });
+
+describe('getObjectSchema carries the envelope sortability projection (#5729)', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('survives the `{ item }` unwrap that used to discard it', async () => {
+    const served = resolveObjectSortability(OPPORTUNITY);
+    const schema: any = await adapterOver({
+      type: 'object',
+      name: 'crm_opportunity',
+      item: OPPORTUNITY,
+      sortability: served,
+    }).getObjectSchema('crm_opportunity');
+
+    // The document still unwraps exactly as before — the counter-probe that
+    // this change did not start returning the envelope instead of the item.
+    expect(schema.name).toBe('crm_opportunity');
+    expect(schema.fields.amount.type).toBe('currency');
+    expect('sortability' in schema).toBe(false);
+
+    const projection = readObjectSortability(schema);
+    expect(projection).toBeDefined();
+    expect(projection!.fields.expected_revenue).toEqual({ sortable: false, reason: 'virtual-type' });
+    expect(isPlatformSortableField(projection!, 'expected_revenue')).toBe(false);
+    expect(isPlatformSortableField(projection!, 'amount')).toBe(true);
+  });
+
+  it('survives the `{ success, data }` envelope spelling too', async () => {
+    const schema: any = await adapterOver({
+      success: true,
+      data: { type: 'object', name: 'crm_opportunity', item: OPPORTUNITY, sortability: resolveObjectSortability(OPPORTUNITY) },
+    }).getObjectSchema('crm_opportunity');
+
+    const projection = readObjectSortability(schema);
+    expect(isPlatformSortableField(projection!, 'expected_revenue')).toBe(false);
+    expect(isPlatformSortableField(projection!, 'name')).toBe(true);
+  });
+
+  it('leaves NO projection when the response carried no `sortability` key', async () => {
+    // The compatibility direction. `undefined` here is what lets the grid tell
+    // "the platform refuses this column" apart from "this deployment never
+    // sent the signal" — collapsing the two is how a correct-looking change
+    // would blank every sort arrow against an older backend.
+    const schema: any = await adapterOver({
+      type: 'object', name: 'crm_opportunity', item: OPPORTUNITY,
+    }).getObjectSchema('crm_opportunity');
+
+    expect(schema.fields.expected_revenue.type).toBe('formula');
+    expect(readObjectSortability(schema)).toBeUndefined();
+  });
+
+  it('leaves no projection for a bare-item response body (no envelope at all)', async () => {
+    const schema: any = await adapterOver(OPPORTUNITY).getObjectSchema('crm_opportunity');
+    expect(schema.fields.name.type).toBe('text');
+    expect(readObjectSortability(schema)).toBeUndefined();
+  });
+
+  it('never carries the projection into a body a write endpoint would parse', async () => {
+    // `FieldSchema` is a strict object server-side: an undeclared key on a
+    // document handed back at a metadata write is rejected BY NAME. The
+    // projection rides on a symbol precisely so a round-trip through
+    // `JSON.stringify` cannot take it there.
+    const schema: any = await adapterOver({
+      type: 'object', name: 'crm_opportunity', item: OPPORTUNITY,
+      sortability: resolveObjectSortability(OPPORTUNITY),
+    }).getObjectSchema('crm_opportunity');
+
+    const serialized = JSON.parse(JSON.stringify(schema));
+    expect('sortability' in serialized).toBe(false);
+    expect(Object.keys(serialized).some((k) => k.toLowerCase().includes('sortab'))).toBe(false);
+    // Counter-probe: the projection IS on the live object, so the two
+    // assertions above measure invisibility rather than a failed attach.
+    expect(readObjectSortability(schema)).toBeDefined();
+  });
+});

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -44,6 +44,7 @@ import type {
 } from '@object-ui/types';
 import { errorCodeIs, errorCodeIsAnyOf } from '@object-ui/types';
 import {
+  attachObjectSortability,
   convertFiltersToAST,
   emulateBatchTransaction,
   normalizeSchemaReferenceKeys,
@@ -3467,7 +3468,26 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     // Unwrap defensively across server/SDK response shapes: the standard
     // `{ success, data }` envelope, an `{ item }` wrapper, or the bare item.
     const data = body && typeof body === 'object' && 'success' in body && 'data' in body ? body.data : body;
-    return data && typeof data === 'object' && 'item' in data ? data.item : data;
+    const item = data && typeof data === 'object' && 'item' in data ? data.item : data;
+    // [#5729] Carry the ENVELOPE's per-column sortability projection
+    // (objectstack#10235) across the unwrap that just discarded it.
+    //
+    // This line is the whole reason the signal was invisible to the grid: the
+    // platform serves `sortability` BESIDE `item` — deliberately, since the
+    // document is parsed `strict` server-side and the key must stay
+    // un-authorable — and the unwrap above returns `item` alone, so every
+    // consumer downstream saw a document with no signal on it and could only
+    // conclude the platform had sent nothing.
+    //
+    // Re-attached under a symbol key, so it survives to the renderer without
+    // becoming a document property: invisible to `JSON.stringify`, to
+    // `Object.keys` and to a spread, which is what keeps a schema that is ever
+    // handed back to a metadata write endpoint from carrying it into a body the
+    // server would reject by name. No-op when the envelope carried no
+    // projection (a backend older than the upstream change), so such a
+    // deployment is left exactly as it was rather than being told, falsely,
+    // that nothing is sortable.
+    return attachObjectSortability(item, data && typeof data === 'object' ? (data as any).sortability : undefined);
   }
 
   /**

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -36,7 +36,7 @@ import {
   RefreshIndicator,
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, toFilterNode, ROW_HEIGHT_TO_DENSITY_MODE } from '@object-ui/core';
+import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, ROW_HEIGHT_TO_DENSITY_MODE } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { ChevronRight, ChevronDown, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
@@ -2393,6 +2393,18 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   const manualSearchOn = manualPaginationOn;
 
   /**
+   * [#5729] The SERVED per-column sortability projection for this object —
+   * objectstack#10235's ruling A, consumed rather than re-derived.
+   *
+   * `undefined` means the metadata response carried no `sortability` key at
+   * all: a backend older than the upstream change, or an inline/mock data
+   * source. That is NOT "nothing is sortable" — see the branch in
+   * `withSortability` below, which is why this stays a nullable projection
+   * instead of collapsing to an empty map at the read.
+   */
+  const platformSortability = readObjectSortability(objectSchema);
+
+  /**
    * Withhold the sort affordance from a column the server cannot honestly order
    * by, when the sort is the server's (objectui#3096 + #3106, #3950).
    *
@@ -2423,8 +2435,32 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   const withSortability = (col: any) => {
     if (!manualSortingOn || col.sortable === false) return col;
     const fieldDef = (objectSchema as any)?.fields?.[col.accessorKey];
-    const serverCanOrderBy = !isExpandableFieldType(fieldDef) && !isUnmaterializedFieldType(fieldDef);
-    return serverCanOrderBy ? col : { ...col, sortable: false };
+    // RELATIONAL — unchanged, and deliberately NOT delegated to the platform
+    // signal. The projection answers `sortable: true` for a `lookup` (measured:
+    // it has a stored column and both runtime doors accept an ORDER BY over
+    // it), because the platform's question is whether it can order by the
+    // STORED foreign key — which it can. Ours is whether that order means
+    // anything next to a column of names, and it does not. Two different
+    // questions; folding this one into the signal would hand every relational
+    // header its sort click back.
+    if (isExpandableFieldType(fieldDef)) return { ...col, sortable: false };
+    // PLATFORM — the served projection is authoritative when it was served.
+    // `isPlatformSortableField` is the contract: an entry must EXIST and say
+    // `sortable: true`. Absence is a refusal (an unknown name, a dotted path,
+    // an unprovisioned audit column), never a default of `true`.
+    if (platformSortability) {
+      return isPlatformSortableField(platformSortability, col.accessorKey)
+        ? col
+        : { ...col, sortable: false };
+    }
+    // NO SIGNAL SERVED — a deployment older than objectstack#10235, or an
+    // inline/mock data source. Behaviour is exactly what it was before this
+    // card, via the same `@objectstack/spec` set (`SEARCH_VIRTUAL_TYPES`) the
+    // platform's own projection is computed from, so the two cannot disagree
+    // about `formula`. This branch is a compatibility floor, not a second
+    // judge: the moment a backend serves the signal it is unreachable, and it
+    // is meant to be deleted when the supported floor passes that release.
+    return isUnmaterializedFieldType(fieldDef) ? { ...col, sortable: false } : col;
   };
 
   const applyColumnChrome = (col: any) => withSortability(applyDensity(col));
@@ -2846,12 +2882,44 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   const declaredSort = parseSchemaSort(
     schemaSort ?? (schema.defaultSort ? [schema.defaultSort] : undefined),
   );
-  const manualSort: TableSortItem[] = externalManualPagination
+  /**
+   * [#5729] The RESTORE leg of objectstack#10235's contract, and the guard
+   * that keeps the personalization PUT off an unsortable column.
+   *
+   * Withholding the header click (see `withSortability`) stops a NEW sort on
+   * such a column from ever being created — `DataTable` emits `onSortChange`
+   * only out of `handleSort`, which is itself gated on `col.sortable !== false`
+   * — but it says nothing about a sort that is ALREADY in stored view state,
+   * persisted before the signal existed. Replayed, that entry would put a
+   * refused `$orderby` on the wire, paint an active-sort arrow on a header
+   * that offers no click, and ride along into the next
+   * `persistViewPatch({ sort })` the toolbar issues for an unrelated reason —
+   * the exact half-fix where the affordance is gone and the PUT still fires.
+   *
+   * So both directions run through the same filter: what the grid RENDERS the
+   * sort state as, and what it EMITS back to whoever persists it. A stale
+   * entry is inert on arrival and is dropped the first time anything writes
+   * the sort back. Only under a served projection — with no signal there is no
+   * verdict to filter by, and the pre-#10235 behaviour stands unchanged.
+   */
+  const rawManualSort: TableSortItem[] = externalManualPagination
     ? (hostSort ?? [])
     : (headerSort ?? declaredSort);
-  const manualOnSortChange = externalManualPagination
+  const manualSort: TableSortItem[] = platformSortability
+    ? filterPlatformSortableSort(rawManualSort, platformSortability)
+    : rawManualSort;
+  const rawManualOnSortChange = externalManualPagination
     ? hostOnSortChange
     : setHeaderSort;
+  // Wrap only when there is BOTH a projection to judge by and a handler to
+  // wrap. Manufacturing a function where the host offered none would flip
+  // `DataTable`'s `sortingEnabled` (`!manualSorting || !!onSortChange`) from
+  // false to true and hand sort clicks to a host that never asked for them.
+  const manualOnSortChange = platformSortability && rawManualOnSortChange
+    ? (next: TableSortItem[]) => rawManualOnSortChange(
+        filterPlatformSortableSort(next, platformSortability),
+      )
+    : rawManualOnSortChange;
 
   // The search term, in whichever server mode applies. When a parent owns the
   // rows it owns the term too (ListView already does, from its own toolbar —

--- a/packages/plugin-grid/src/__tests__/columnSortabilitySignal.test.tsx
+++ b/packages/plugin-grid/src/__tests__/columnSortabilitySignal.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * [#5729] The grid consumes the platform's per-column sortability signal —
+ * objectstack#10235's ruling A, downstream leg.
+ *
+ * The header used to offer a sort click on any column whose field type the
+ * grid itself judged orderable. On a `formula` column that click was a lie:
+ * the platform returned `asc` and `desc` in byte-identical order under a 200,
+ * and since objectstack#9313/#10234 it refuses the same click loudly
+ * (`400 INVALID_SORT`). The ruling's answer is that the PLATFORM says which
+ * columns it will order by, on the metadata envelope, and the grid reads that
+ * — it does not re-derive "virtual ⇒ unsortable" from the field's type.
+ *
+ * ORACLE, both directions, in the SAME render. A "no sort affordance"
+ * assertion is trivially satisfied by a grid that renders no header at all, so
+ * every negative cell here sits beside a positive control on the same table: a
+ * sortable sibling column whose header is still clickable and still puts its
+ * `$orderby` on the wire. The two upstream oracle objects are used as they
+ * were measured — `crm_opportunity.expected_revenue` and
+ * `showcase_project.budget_remaining`.
+ *
+ * AGREEMENT over hardcoding: the served projection each data source hands over
+ * is produced by the platform's own `resolveObjectSortability`
+ * (`@objectstack/spec/api`) — the resolver the REST layer serves it from — so
+ * these cells follow the runtime's predicate rather than a copied table.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { resolveObjectSortability } from '@objectstack/spec/api';
+import { attachObjectSortability } from '@object-ui/core';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = vi.fn(() => false) as any;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+const TOTAL = 300;
+const PAGE_SIZE = 50;
+
+const OBJECTS: Record<string, any> = {
+  crm_opportunity: {
+    name: 'crm_opportunity',
+    fields: {
+      id: { type: 'text' },
+      name: { type: 'text' },
+      amount: { type: 'currency' },
+      expected_revenue: { type: 'formula', expression: 'amount * probability / 100' },
+    },
+  },
+  showcase_project: {
+    name: 'showcase_project',
+    fields: {
+      id: { type: 'text' },
+      name: { type: 'text' },
+      budget: { type: 'currency' },
+      budget_remaining: { type: 'formula', expression: 'budget - spent' },
+    },
+  },
+};
+
+/**
+ * A data source whose `getObjectSchema` answers the way the adapter now does:
+ * the document, carrying the served projection. `servesSignal: false` models a
+ * deployment older than objectstack#10235 — no projection at all.
+ */
+function makeDataSource(objectName: string, opts: { servesSignal?: boolean } = {}) {
+  const doc = OBJECTS[objectName];
+  const find = vi.fn(async (_object: string, params: any) => {
+    const top = params.$top ?? PAGE_SIZE;
+    const skip = params.$skip ?? 0;
+    const rows = Array.from({ length: Math.max(0, Math.min(top, TOTAL - skip)) }, (_, i) => ({
+      id: `id-${skip + i}`,
+      name: `Row ${skip + i}`,
+      amount: 100 + i,
+      budget: 100 + i,
+      expected_revenue: 42,
+      budget_remaining: 42,
+    }));
+    return { data: rows, total: TOTAL, hasMore: skip + rows.length < TOTAL, pageSize: top };
+  });
+  return {
+    find,
+    getObjectSchema: async () => {
+      const schema = JSON.parse(JSON.stringify(doc));
+      if (opts.servesSignal !== false) {
+        attachObjectSortability(schema, resolveObjectSortability(doc));
+      }
+      return schema;
+    },
+  } as any;
+}
+
+function renderGrid(objectName: string, columns: string[], opts: Record<string, any> = {}, dsOpts = {}) {
+  const ds = makeDataSource(objectName, dsOpts);
+  const schema: any = {
+    type: 'object-grid',
+    objectName,
+    columns: columns.map((field) => ({ field, label: field })),
+    pagination: { pageSize: PAGE_SIZE },
+    ...opts,
+  };
+  const utils = render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} dataSource={ds} {...(opts.gridProps ?? {})} />
+    </ActionProvider>,
+  );
+  return { ...utils, ds };
+}
+
+const headerCell = (container: HTMLElement, label: string) =>
+  Array.from(container.querySelectorAll('thead th')).find((th) =>
+    th.textContent?.trim() === label,
+  ) as HTMLElement;
+
+/**
+ * Whether this header offers a sort. Read off the affordance itself, not off a
+ * prop: DataTable makes a sortable header `cursor-pointer` and paints a sort
+ * icon, and does neither for `sortable: false`.
+ */
+const offersSort = (th: HTMLElement) => th.className.includes('cursor-pointer');
+
+const lastFindParams = (ds: any) => ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+
+describe('#5729 oracle — the refusal cells become unofferable clicks', () => {
+  it('crm_opportunity.expected_revenue offers no sort, while `amount` on the same grid still does', async () => {
+    const { container, ds } = renderGrid('crm_opportunity', ['name', 'amount', 'expected_revenue']);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    // NEGATIVE: the platform refuses this column, so the click ceases to exist.
+    expect(offersSort(headerCell(container, 'expected_revenue'))).toBe(false);
+    // POSITIVE CONTROL, same render: without it "the click is gone" is also
+    // true of a grid that rendered no headers.
+    expect(offersSort(headerCell(container, 'amount'))).toBe(true);
+    expect(offersSort(headerCell(container, 'name'))).toBe(true);
+
+    // And the control's click still reaches the wire.
+    fireEvent.click(headerCell(container, 'amount'));
+    await waitFor(() =>
+      expect(lastFindParams(ds).$orderby).toEqual([{ field: 'amount', order: 'asc' }]),
+    );
+  });
+
+  it('clicking the refused header puts no $orderby on the wire at all', async () => {
+    const { container, ds } = renderGrid('crm_opportunity', ['name', 'amount', 'expected_revenue']);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+    const before = ds.find.mock.calls.length;
+
+    fireEvent.click(headerCell(container, 'expected_revenue'));
+    fireEvent.click(headerCell(container, 'expected_revenue'));
+
+    // No refetch, and nothing ordered by the refused name.
+    await waitFor(() => expect(lastFindParams(ds).$orderby).toBeUndefined());
+    expect(ds.find.mock.calls.length).toBe(before);
+
+    // Counter-probe in the same test: the identical gesture on the sortable
+    // sibling DOES refetch, so the assertion above measures the withheld
+    // affordance and not an inert grid.
+    fireEvent.click(headerCell(container, 'amount'));
+    await waitFor(() =>
+      expect(lastFindParams(ds).$orderby).toEqual([{ field: 'amount', order: 'asc' }]),
+    );
+  });
+
+  it('showcase_project.budget_remaining offers no sort, while `budget` on the same grid does', async () => {
+    const { container } = renderGrid('showcase_project', ['name', 'budget', 'budget_remaining']);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    expect(offersSort(headerCell(container, 'budget_remaining'))).toBe(false);
+    expect(offersSort(headerCell(container, 'budget'))).toBe(true);
+  });
+
+  it('withholds a column ABSENT from the projection — absence is a refusal, not a default', async () => {
+    // The asymmetry a `!== false` test gets exactly backwards. `created_at` is
+    // hard-admitted by the ingress gate but provisioned by nobody here, so the
+    // projection has no entry for it; the platform has no sort behind the name.
+    const { container } = renderGrid('crm_opportunity', ['name', 'amount', 'created_at']);
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    expect(offersSort(headerCell(container, 'created_at'))).toBe(false);
+    expect(offersSort(headerCell(container, 'amount'))).toBe(true);
+  });
+});
+
+describe('#5729 scope item 2 — the personalization PUT never carries a refused column', () => {
+  it('a RESTORED sort on a refused column is inert: no affordance, no emission', async () => {
+    // The half-fix this leg exists to prevent: the header click is gone, but a
+    // sort persisted before the signal existed is replayed out of stored view
+    // state and rides into the next `persistViewPatch({ sort })`.
+    const onSortChange = vi.fn();
+    const ds = makeDataSource('crm_opportunity');
+    const { container } = render(
+      <ActionProvider>
+        <ObjectGrid
+          schema={{
+            type: 'object-grid',
+            objectName: 'crm_opportunity',
+            columns: [
+              { field: 'name', label: 'name' },
+              { field: 'amount', label: 'amount' },
+              { field: 'expected_revenue', label: 'expected_revenue' },
+            ],
+            pagination: { pageSize: PAGE_SIZE },
+          } as any}
+          dataSource={ds}
+          manualPagination
+          rowCount={TOTAL}
+          page={1}
+          pageSize={PAGE_SIZE}
+          onPageChange={vi.fn()}
+          onPageSizeChange={vi.fn()}
+          sort={[{ field: 'expected_revenue', order: 'desc' }]}
+          onSortChange={onSortChange}
+        />
+      </ActionProvider>,
+    );
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    // The restore alone writes nothing back — a PUT here would re-persist the
+    // refused column on every page load.
+    expect(onSortChange).not.toHaveBeenCalled();
+    // And the header it names offers no click to re-emit it with.
+    expect(offersSort(headerCell(container, 'expected_revenue'))).toBe(false);
+    fireEvent.click(headerCell(container, 'expected_revenue'));
+    expect(onSortChange).not.toHaveBeenCalled();
+
+    // POSITIVE CONTROL, same render: the sortable sibling still emits, so the
+    // three assertions above are about the refused column and not about a
+    // grid whose sort callback was never wired.
+    fireEvent.click(headerCell(container, 'amount'));
+    await waitFor(() => expect(onSortChange).toHaveBeenCalled());
+    expect(onSortChange.mock.calls[0][0]).toEqual([{ field: 'amount', order: 'asc' }]);
+    // Nothing the grid ever emits names the refused column.
+    for (const [emitted] of onSortChange.mock.calls) {
+      expect((emitted as any[]).some((s) => s.field === 'expected_revenue')).toBe(false);
+    }
+  });
+});
+
+describe('#5729 — a deployment that serves no signal is unchanged', () => {
+  it('keeps today behaviour when the metadata response carried no projection', async () => {
+    // `undefined` projection means "no signal was served", NOT "nothing is
+    // sortable". Collapsing the two would blank every sort arrow in the
+    // product against a backend older than objectstack#10235.
+    const { container } = renderGrid(
+      'crm_opportunity',
+      ['name', 'amount', 'expected_revenue'],
+      {},
+      { servesSignal: false },
+    );
+    await waitFor(() => expect(screen.getByText('Row 0')).toBeInTheDocument());
+
+    expect(offersSort(headerCell(container, 'amount'))).toBe(true);
+    expect(offersSort(headerCell(container, 'name'))).toBe(true);
+    // The pre-existing withholding (bound to the same `@objectstack/spec`
+    // storage set the platform computes its projection from) still stands.
+    expect(offersSort(headerCell(container, 'expected_revenue'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #5729

Downstream leg of objectstack-ai/objectstack#10235 (maintainer 2026-08-23, ruling A): the platform serves an explicit per-column sortability signal, and the grid reads it rather than re-deriving "virtual means unsortable" from field type.

All gate results below are from `57870ce55`, the branch head.

## The measured envelope shape, versus the one the thread described

Read from the merged upstream change in the `objectstack` checkout, not from the issue thread. **The description was accurate in every particular.**

- `packages/spec/src/api/protocol.zod.ts:413` — `GetMetaItemResponseSchema` gains `sortability: ObjectSortabilitySchema.optional()`, on the envelope beside `item`, never inside it (`FieldSchema` is a `strictObject`, so the key has to stay un-authorable).
- `packages/spec/src/api/sortability.zod.ts` — `{ fields: Record<string, { sortable: boolean; reason?: 'virtual-type'; caveat?: 'unprovisioned-anchor' }> }`, exactly as claimed.
- `packages/rest/src/rest-server.ts:2609` — computed in `translateMetaEnvelope`, the one seam every single-item exit passes through, so the signal is present on every branch including the cached one.

Two details worth carrying forward that the thread did not spell out: the projection's domain always includes `id` even when the document declares no such field, and it is computed from the FINAL post-masking document, so its domain equals the field set this caller is served.

Verified by running the platform's own `resolveObjectSortability` from the installed `@objectstack/spec@17.2.0` against the oracle documents. `crm_opportunity.expected_revenue` and `showcase_project.budget_remaining` both come back `{ sortable: false, reason: 'virtual-type' }`; `amount`, `name`, `budget` and `id` come back `{ sortable: true }`.

## The real work: the signal was reaching the browser and being thrown away

`ObjectStackAdapter.fetchObjectSchemaFresh` unwrapped the response to `data.item` and returned it. The envelope key — and with it the entire signal — was discarded one line before its only consumer, so every UI reader saw a document with nothing on it and could only conclude the platform had sent nothing. That line is the substance of this change.

It now survives the unwrap, carried on the schema under `Symbol.for('objectui.objectSortability')`. The symbol is load-bearing, not decoration: `JSON.stringify`, `Object.keys` and spread all skip it, so a schema handed back at a metadata write endpoint cannot take the projection into a body the server parses strictly. Putting it on a string key would have undone the upstream decision to keep it off `item`, one repo away. Pinned directly, with a counter-probe proving the assertions measure invisibility rather than a failed attach.

## The contract, and the asymmetry it turns on

`@object-ui/core` gains the one spelling: `isPlatformSortableField(projection, name)` is `true` iff an entry EXISTS for the name and says `sortable: true`.

Absence is a refusal. It is how the platform encodes an unknown name, a dotted path and an unprovisioned audit column, all three of which the runtime doors reject — so the `!== false` spelling every other optional flag in this repo uses gets exactly that family backwards. Ablation A below is the pin.

A projection that is absent ALTOGETHER is a different question with a different answer. `readObjectSortability` returns `undefined` when the metadata response carried no `sortability` key, which means "no signal was served", not "nothing is sortable"; the two are typed apart so a caller cannot conflate them. `isPlatformSortableField` takes a non-optional projection for the same reason.

The spec's own names are re-exported rather than restated. `check:spec-symbols` caught four hand-written declarations under names `@objectstack/spec/api` already owns (`FIELD_UNSORTABLE_VIRTUAL_TYPE`, `FIELD_SORTABLE_UNPROVISIONED_ANCHOR`, `FieldSortability`, `ObjectSortability`); the second commit replaces all four with re-exports, which is the contract-first shape and one fewer thing to drift.

## What changed in the grid

**The header click on a refused column ceases to exist**, so neither the old silent-unordered result nor the `400 INVALID_SORT` that replaced it is reachable from it.

**The restore leg gets its own guard.** `DataTable` emits `onSortChange` only out of `handleSort`, itself gated on `col.sortable !== false`, so withholding the affordance already stops a NEW refused sort from being created. It says nothing about one ALREADY in stored view state, persisted before the signal existed: replayed, it would paint an active-sort arrow on a header that offers no click and ride into the next `persistViewPatch({ sort })` the toolbar issues for an unrelated reason. Both directions now run through the same filter — what the grid renders the sort state as, and what it emits back to whoever persists it.

**The relational carve-out is untouched, and deliberately not delegated to this signal.** Measured and pinned: the projection answers `sortable: true` for a `lookup`, because the platform's question is whether it can order by the stored foreign key, which it can. The grid's question is whether that order means anything beside a column of names, and it does not. Folding the two together would have handed every relational header its sort click back.

**Columns carrying `caveat: 'unprovisioned-anchor'` keep their click** — default A, held rather than decided. See the ruling request below.

## Verification

Directions predicted before running; both ablations restore under `trap ... EXIT INT TERM` with cwd-independent commands, and `git diff HEAD --stat` was confirmed empty after each. No rebuild is needed for either: the root `vitest.config.mts` aliases every `@object-ui/*` specifier to that package's `src/`, so the mutated source is what the run executes.

**Ablation A** — `isPlatformSortableField` rewritten to the naive `!== false` spelling. Predicted: red on the ABSENT-entry cells ONLY, with the `sortable: false` cells staying green, since that is the whole asymmetry. Observed exactly that: 4 failed, 15 passed; the four are "refuses an ABSENT entry", "refuses an empty / malformed field name and a malformed entry", "drops a persisted sort on a column the platform refuses", and the grid's "withholds a column ABSENT from the projection". `expected_revenue` and `budget_remaining` stayed green throughout, confirming the two rules are separately load-bearing. Mutation confirmed on disk by grepping the injected marker (1) and the removed anchor (0) separately, with the anchor asserted unique first.

**Ablation B** — the transit carry dropped (`return item`). Predicted: the three carry cells red, the two "no projection served" cells green. Observed exactly that: 3 failed, 2 passed.

**Cross-package type reverse-check** — a value the new signature must reject, fed to `isPlatformSortableField` from `plugin-grid`. Red as predicted, with `error TS2345` naming the spec's literal union (`"virtual-type" | undefined`, `"unprovisioned-anchor" | undefined`), which proves tsc read the freshly built `.d.ts` across the package boundary rather than a cached one.

One red found and fixed rather than reported: my first fixture returned the same object literal from every mocked response, and the adapter stamps the projection onto the document it is handed — so a previous test's stamp leaked into the "no signal served" cells and made them pass while measuring nothing. The mock now returns fresh JSON per response, as a real `res.json()` does.

**Gates** (each exit code captured before any pipe; each verdict quoted from the gate's own output):

| gate | exit | result |
| --- | --- | --- |
| `pnpm --filter @object-ui/core type-check` | 0 | script name echoed, so not a zero-match no-op |
| `pnpm --filter @object-ui/data-objectstack type-check` | 0 | same |
| `pnpm --filter @object-ui/plugin-grid type-check` | 0 | same |
| `npx vitest run packages/core/src packages/data-objectstack/src` | 0 | `Test Files 143 passed (143)` / `Tests 2628 passed (2628)` |
| `npx vitest run packages/plugin-grid/src` | 0 | `Test Files 86 passed (86)` / `Tests 811 passed (811)` |
| `pnpm --filter '...@object-ui/core' type-check` (downstream) | 2 | see below |
| `npx eslint <merge-base delta>` | 0 | `377 problems (0 errors, 377 warnings)` — all pre-existing `no-explicit-any` |
| `pnpm check:spec-symbols` | 0 | after the re-export commit; RED before it, and correctly so |
| `pnpm check:esm-specifiers` | 0 | `no un-ledgered package emits an extensionless relative specifier` |
| `pnpm check:phantom-deps` | 0 | `Every in-scope import is declared by the package that publishes it` |
| `pnpm check:self-import` | 0 | `No package names itself inside its own src/` |
| `node scripts/check-changeset-presence.mjs` | 0 | `7 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-fixed.mjs` | 0 | `All workspace packages are in the changeset fixed group` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump` |
| `node scripts/check-control-bytes.mjs` | 0 | `scanned 5040 tracked text file(s)` |

The downstream sweep's direction, stated because the claim is unreadable without it: `'...@object-ui/core'` is the PREFIX form, so it selects the packages that DEPEND ON core — the consumers a contract change lands on. 35 ran the script; exactly one failed, `apps/site`, on `Cannot find module '@object-ui/example-schema-catalog'`. That is the unbuilt-closure class the sweep is known to produce for workspaces outside `packages/**` (I built `--filter './packages/**'` first, which is why `packages/components` and `plugin-dashboard` pass here and did not on the first attempt). No `error TS` anywhere else, and nothing naming sortability.

Gate set derived by enumerating each CI job's own step list rather than top-level script names, per the standing rule — which is how `check:esm-specifiers` and `check:spec-symbols` got run at all; both live as steps inside the `Type Check` job under names that do not read like one, and `check:spec-symbols` was a genuine red.

## Ruling requested, not taken

**`caveat: 'unprovisioned-anchor'` stays on default A** — the click is kept. The runtime accepts these sorts; refusing what the platform does not refuse would recreate declared-versus-enforced drift in mirror image. Option B (drop the affordance) or C (click plus a degraded-order warning) remain open and are the maintainer's to pick; the caveat is preserved through the whole path and pinned, so either is a small change on top.

**The one thing I would like ruled**, because it is the closest this change comes to scope item 3's prohibition: when NO projection was served, `withSortability` still falls back to the pre-existing `isUnmaterializedFieldType` read. My reasoning for keeping it, and why I think it is not the shadow derivation the ruling forbids: it is bound to `@objectstack/spec`'s own `SEARCH_VIRTUAL_TYPES`, the identical predicate the platform computes its projection from, so it cannot disagree about `formula`; it is unreachable the moment a backend serves the signal; and deleting it outright would hand every formula header its refused click back on any deployment older than objectstack#10235. It is a compatibility floor, not a second judge, and it is commented as one — but if the ruling wants it gone now, it is a two-line deletion plus one test.

## Runtime dependency and what was actually runnable

The installed `@objectstack/spec@17.2.0` carries the change, and the pins here run against that resolver directly. **I did not boot a dev stack**, so the three oracle cells are pinned at unit level against the platform's own resolver rather than claimed as a served-backend measurement — which is the discipline the requeue obligation asked for when the runtime leg cannot be run, and I would rather report it that way than report an oracle I did not execute. Every negative cell carries its positive control in the same render (a sortable sibling column, still clickable, still putting its `$orderby` on the wire), so "the click is gone" cannot be satisfied by a grid that rendered nothing.

## Scope

`packages/components` was **not** needed — `DataTable` already renders no cursor, no click handler and no sort icon for `col.sortable === false`, and emits `onSortChange` only from the gated `handleSort`. `plugin-detail` untouched.

Filed out of scope, unassigned: #6108 — the other two sort-axis consumers (`ListView`'s toolbar sort picker and `RelatedList`) still re-derive from field type. The picker one is not cosmetic: its in-use exception keeps a refused field listed, so an unrelated edit in that popover re-emits the whole sort array into `persistViewPatch({ sort })`. This PR closes that leak at the grid seam; the picker is a second door onto the same stored state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_