### PR TITLE
fix(react,cli): name the case-only spelling an unknown component type missed

### DIFF
--- a/.changeset/unknown-component-type-case-suggestion-5247.md
+++ b/.changeset/unknown-component-type-case-suggestion-5247.md
@@ -1,0 +1,14 @@
+---
+"@object-ui/react": patch
+"@object-ui/cli": patch
+---
+
+Name the case-only spelling when a component type misses the registry.
+
+Registry lookup is exactly case-sensitive, so a node typed `Page` misses a registered `page` and falls through to the OBJUI-001 "Unknown component type" panel. Because the mistake is usually uniform across a document, the symptom is not one broken widget — it is the whole page rendering as error panels, with nothing in the message pointing at the cause.
+
+Both surfaces that report the miss now name the spelling that would have resolved. `SchemaRenderer`'s panel reads `Unknown component type: Page — did you mean 'page'?`, and `objectui check` reports `Unknown schema type "Page" in <file> — did you mean "page"?`. When no known type differs by case alone, neither says anything extra — `zzz` gains no bogus suggestion, and this is case matching, not an edit distance, so `pge` suggests nothing either.
+
+**Lookup itself does not change.** `Page` still misses, still fails, and still renders the panel; only the message teaches. Normalising the lookup was considered and rejected (objectui#5247, maintainer ruling 2026-08-19): it would make two spellings valid everywhere, permanently, and legalise the typo class (`PAGE`, `pAge`) along with the PascalCase convention.
+
+Each surface reads its candidates from the set it can actually trust — the renderer from the live `ComponentRegistry` (including pending lazy stubs), the CLI from the registration-derived `KNOWN_SCHEMA_TYPES` snapshot — so neither can suggest a type nothing registers.

--- a/packages/cli/src/__tests__/check-unknown-type-case-suggestion.test.ts
+++ b/packages/cli/src/__tests__/check-unknown-type-case-suggestion.test.ts
@@ -1,0 +1,165 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5247 — `objectui check` names the case-only spelling it missed.
+ *
+ * The maintainer ruled Option C on 2026-08-19: keep lookup strict, make the
+ * failure teach. `Page` remains an UNKNOWN type on both surfaces — the CLI
+ * still warns about it and `SchemaRenderer` still paints the OBJUI-001 panel —
+ * and only the wording gains ` — did you mean "page"?`. Making `Page` valid is
+ * the rejected option B.
+ *
+ * Which assertions here would survive a revert of that change, and why they are
+ * present anyway:
+ *
+ *   - "the warning is still printed" and "the type is still reported unknown"
+ *     both pass on a revert. They are the anti-option-B guard: without them a
+ *     future change could satisfy the suggestion assertions by simply accepting
+ *     the mis-cased type.
+ *   - "no suggestion for `zzz`" passes on a revert too, by construction. It is
+ *     the counter-probe against a clause that fires unconditionally, and it is
+ *     only meaningful in the same run as the positive case below.
+ *   - `did you mean "page"` is the one assertion that fails on a revert.
+ *
+ * Fixtures live under `os.tmpdir()`, never in the repo tree: `check()` globs
+ * every JSON file under the directory it is handed, so a fixture committed
+ * inside this workspace would be scanned by the repository's own `pnpm check`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { check } from '../commands/check.js';
+import { KNOWN_SCHEMA_TYPES } from '../utils/known-schema-types.js';
+import {
+  suggestKnownTypeByCase,
+  didYouMeanClause,
+} from '../utils/known-type-case-suggestion.js';
+
+let cwd: string;
+let lines: string[];
+let restore: () => void;
+
+/**
+ * The CSI sequences chalk may add. The escape byte is built with
+ * `String.fromCharCode` rather than spelled into the source, so this file holds
+ * no raw control character and no escape a tooling pass could materialise into
+ * one (objectui AGENTS.md byte discipline).
+ */
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+function unknownTypeWarnings(): string[] {
+  return lines
+    .map((l) => l.replace(ANSI, ''))
+    .filter((l) => l.includes('Unknown schema type'));
+}
+
+/** A file that clears the objectui#5127 marker gate and so gets type-judged. */
+function writeSchema(name: string, type: string): void {
+  writeFileSync(join(cwd, name), JSON.stringify({ type, children: [] }));
+}
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'objectui-check-case-'));
+  lines = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  };
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    void code;
+    return undefined as never;
+  }) as never);
+  restore = () => {
+    console.log = originalLog;
+    exitSpy.mockRestore();
+  };
+});
+
+afterEach(() => {
+  restore();
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe('objectui check — a case-only miss names the spelling that works', () => {
+  it('still reports `Page` as unknown AND names `page`', async () => {
+    // Sanity: `page` is a type the derivation actually knows. Without this the
+    // two assertions below could agree about a type that does not exist.
+    expect(KNOWN_SCHEMA_TYPES).toContain('page');
+
+    writeSchema('page.json', 'Page');
+    await check(cwd);
+
+    const warnings = unknownTypeWarnings();
+    // Passes on a revert — the anti-option-B guard.
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Unknown schema type "Page"');
+    // Fails on a revert — the load-bearing pin.
+    expect(warnings[0]).toContain('did you mean "page"');
+  });
+
+  it('says nothing extra when no known type differs by case alone', async () => {
+    writeSchema('zzz.json', 'zzz');
+    await check(cwd);
+
+    const warnings = unknownTypeWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Unknown schema type "zzz"');
+    expect(warnings[0]).not.toContain('did you mean');
+  });
+
+  it('reports both, each with the right clause, in one run', async () => {
+    writeSchema('a.json', 'Page');
+    writeSchema('b.json', 'zzz');
+    await check(cwd);
+
+    const warnings = unknownTypeWarnings();
+    expect(warnings).toHaveLength(2);
+    expect(warnings.filter((w) => w.includes('did you mean'))).toHaveLength(1);
+    expect(warnings.find((w) => w.includes('"Page"'))).toContain('did you mean "page"');
+  });
+});
+
+describe('objectui#5247 — the suggestion is case, and only case', () => {
+  it('matches a namespaced spelling', () => {
+    expect(KNOWN_SCHEMA_TYPES).toContain('view:grid');
+    expect(suggestKnownTypeByCase('VIEW:Grid')).toBe('view:grid');
+  });
+
+  it('does not reach for an edit distance', () => {
+    // One deletion from `page`. The ruling granted case and only case.
+    expect(suggestKnownTypeByCase('pge')).toBeUndefined();
+    expect(suggestKnownTypeByCase('Buttonn')).toBeUndefined();
+  });
+
+  it('never suggests the spelling it was handed', () => {
+    expect(suggestKnownTypeByCase('page')).toBeUndefined();
+    expect(suggestKnownTypeByCase('')).toBeUndefined();
+  });
+
+  it('only ever suggests a type the derivation holds', () => {
+    // The staleness guard objectui#5115 exists for: every suggestion this can
+    // produce is drawn from `KNOWN_SCHEMA_TYPES` itself, so it cannot name a
+    // type nothing registers.
+    for (const known of KNOWN_SCHEMA_TYPES) {
+      const suggestion = suggestKnownTypeByCase(known.toUpperCase());
+      if (suggestion !== undefined) {
+        expect(KNOWN_SCHEMA_TYPES).toContain(suggestion);
+        expect(suggestion.toLowerCase()).toBe(known.toLowerCase());
+      }
+    }
+  });
+
+  it('emits an empty clause when there is nothing to say', () => {
+    expect(didYouMeanClause('zzz')).toBe('');
+    expect(didYouMeanClause('Page')).toBe(' — did you mean "page"?');
+  });
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { parse as parseJsonc, printParseErrorCode, type ParseError } from 'jsonc-parser';
 
 import { isKnownSchemaType } from '../utils/known-schema-types.js';
+import { didYouMeanClause } from '../utils/known-type-case-suggestion.js';
 
 /**
  * Root keys that positively identify a file as an ObjectUI schema node.
@@ -217,7 +218,15 @@ export async function check(cwd: string = process.cwd()) {
               // registration calls (see `packages/cli/src/utils/known-schema-types.ts`
               // and the script that writes it), not typed by hand. The array that
               // used to sit here had drifted both ways at once — objectui#5115.
-              console.log(chalk.yellow(`⚠️ Unknown schema type "${content.type}" in ${file}`));
+              // objectui#5247 — the type is still UNKNOWN and still reported;
+              // the clause only names the spelling that would have resolved,
+              // and is empty whenever no known type differs by case alone.
+              console.log(
+                chalk.yellow(
+                  `⚠️ Unknown schema type "${content.type}" in ${file}` +
+                    didYouMeanClause(content.type)
+                )
+              );
             }
           }
         }

--- a/packages/cli/src/utils/known-type-case-suggestion.ts
+++ b/packages/cli/src/utils/known-type-case-suggestion.ts
@@ -1,0 +1,78 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * "Did you mean" for `objectui check`, on CASE ALONE (objectui#5247).
+ *
+ * The 2026-08-19 ruling on objectui#5247 chose Option C — keep lookup strict,
+ * make the failure teach. Nothing here makes a mis-cased type VALID: `check`
+ * still reports `Page` as an unknown schema type, and `SchemaRenderer` still
+ * paints the OBJUI-001 panel for it. All that changes is that the report names
+ * the spelling that would have worked. Resolving `Page` to `page` is the
+ * REJECTED option B.
+ *
+ * ## Why the candidate set is `KNOWN_SCHEMA_TYPES` and not a list typed here
+ *
+ * `KNOWN_SCHEMA_TYPES` is DERIVED from this repository's registration calls by
+ * `scripts/regenerate-known-schema-types.mjs` and pinned by
+ * `scripts/__tests__/known-schema-types-derivation-5115.test.ts`. Reading it is
+ * the whole point: a suggestion built against a hand-maintained copy goes stale
+ * silently and then confidently names a type nothing registers any more.
+ * objectui#5115 measured that copy drifting in BOTH directions at once, which
+ * is why the derivation exists.
+ *
+ * ## Why this is not shared with the renderer's copy of the same clause
+ *
+ * `packages/react/src/SchemaRenderer.tsx` emits the same clause for the
+ * OBJUI-001 panel, from `ComponentRegistry.getKnownTypes()`. The two cannot
+ * share one implementation because they cannot share a candidate SET. The
+ * published CLI runs inside a USER's project and depends on neither
+ * `@object-ui/core` nor the plugin packages that register most component
+ * types; the header of `scripts/regenerate-known-schema-types.mjs` records the
+ * measurement (eleven of the fifteen real types in the old hand list are
+ * registered by packages the CLI does not depend on) and the reason a runtime
+ * lookup would answer the wrong question anyway. What the two surfaces DO share
+ * is the emitted wording, and each side pins it in its own test.
+ *
+ * ## Case only
+ *
+ * Case is the only trigger the ruling grants. This is deliberately not an edit
+ * distance — `pge` suggests nothing — because a fuzzy match is scope the
+ * ruling did not give and would guess where this merely names.
+ */
+
+import { KNOWN_SCHEMA_TYPES } from './known-schema-types.js';
+
+/**
+ * The known schema type that differs from `type` only in case, if there is one.
+ *
+ * Returns `undefined` when nothing matches case-insensitively — the caller must
+ * then say nothing at all, so `Unknown schema type "zzz"` never acquires a
+ * bogus suggestion.
+ */
+export function suggestKnownTypeByCase(type: string): string | undefined {
+  if (typeof type !== 'string' || type === '') return undefined;
+  const wanted = type.toLowerCase();
+  for (const candidate of KNOWN_SCHEMA_TYPES) {
+    if (candidate !== type && candidate.toLowerCase() === wanted) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * The suggestion clause `objectui check` appends to an unknown-type warning, or
+ * the empty string when there is nothing to suggest.
+ *
+ * Quoting follows this surface's own convention — the warning already spells
+ * the offending type as `"Page"` — so the two halves of one line agree. The
+ * OBJUI-001 panel quotes with `'…'` for the same reason on its side.
+ */
+export function didYouMeanClause(type: string): string {
+  const match = suggestKnownTypeByCase(type);
+  return match === undefined ? '' : ` — did you mean "${match}"?`;
+}

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -296,6 +296,45 @@ function winningVisibilityKey(node: Record<string, unknown>): string | undefined
 }
 
 /**
+ * The registry key that differs from `type` only in case, when there is one.
+ *
+ * objectui#5247 ruled Option C — keep lookup strict, make the failure teach.
+ * Registry lookup stays exactly case-sensitive (`ComponentRegistry.get` is a
+ * plain `Map.get`), so a node typed `Page` still MISSES `page` and still
+ * renders the OBJUI-001 panel below. What changes is only what that panel
+ * SAYS: when the miss is a case mismatch and nothing else, it names the
+ * spelling that would have worked. Making `Page` resolve is the REJECTED
+ * option B — it would legalise `PAGE` / `pAge` across docs, the designer,
+ * `sdui-intrinsics.d.ts` and every registration site, permanently.
+ *
+ * The candidate set is read from the LIVE registry — `getKnownTypes()`, which
+ * is loaded registrations plus pending `registerLazy` stubs — never from a
+ * list typed alongside it. A hand-kept copy goes stale silently and then
+ * confidently suggests a type nothing registers any more; objectui#5115
+ * measured exactly that drift on the CLI's copy, in both directions at once.
+ *
+ * Case is the ONLY trigger the ruling grants. This is deliberately not an edit
+ * distance: `pge` suggests nothing.
+ *
+ * `objectui check` emits the same clause from
+ * `packages/cli/src/utils/known-type-case-suggestion.ts`. The two surfaces
+ * cannot share one implementation because they cannot share a candidate SET:
+ * the published CLI runs inside a USER's project and depends on neither
+ * `@object-ui/core` nor the plugin packages that register most types, so it
+ * answers from the generated `KNOWN_SCHEMA_TYPES` snapshot instead — the
+ * measurement is in `scripts/regenerate-known-schema-types.mjs`. Keep the
+ * emitted wording in step with that file; both are pinned by tests.
+ */
+function suggestTypeByCase(type: unknown): string | undefined {
+  if (typeof type !== 'string' || type === '') return undefined;
+  const wanted = type.toLowerCase();
+  for (const candidate of ComponentRegistry.getKnownTypes()) {
+    if (candidate !== type && candidate.toLowerCase() === wanted) return candidate;
+  }
+  return undefined;
+}
+
+/**
  * Per-component Error Boundary for SchemaRenderer.
  * Catches render errors in individual components, preventing one broken
  * component from crashing the entire page.
@@ -935,9 +974,21 @@ export const SchemaRenderer: ForwardRefExoticComponent<
 
     debugLog('schema', 'Component not found in registry', { type: evaluatedSchema.type });
     const errorInfo = ERROR_CODES['OBJUI-001'];
+    // objectui#5247 — the lookup above still missed and this node still fails.
+    // The suggestion only names the spelling that would have resolved.
+    const caseSuggestion = suggestTypeByCase(evaluatedSchema.type);
     return (
       <div className="p-4 border border-red-500 rounded text-red-500 bg-red-50 my-2" role="alert">
-        <p className="font-medium">Unknown component type: <strong>{evaluatedSchema.type}</strong></p>
+        <p className="font-medium">
+          Unknown component type: <strong>{evaluatedSchema.type}</strong>
+          {caseSuggestion !== undefined ? (
+            <>
+              {" — did you mean '"}
+              <strong>{caseSuggestion}</strong>
+              {"'?"}
+            </>
+          ) : null}
+        </p>
         {lazyError && (
           <p className="text-xs mt-1">Failed to load plugin: {lazyError.message}</p>
         )}

--- a/packages/react/src/__tests__/SchemaRenderer.unknownTypeCaseSuggestion.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.unknownTypeCaseSuggestion.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5247 — the OBJUI-001 panel names the case-only spelling it missed.
+ *
+ * ## What was ruled, and what this suite therefore has to prove
+ *
+ * The maintainer ruled Option C on 2026-08-19: **keep lookup strict, make the
+ * failure teach.** Registry lookup stays exactly case-sensitive, so a node
+ * typed `Page` still MISSES a registered `page` and still fails; only the
+ * message changes. Option B — normalising at lookup so `Page` renders — was
+ * rejected as a permanent stack-wide contract change that also legalises the
+ * typo class (`PAGE`, `pAge`).
+ *
+ * Every case below therefore asserts BOTH halves in one assertion set:
+ *
+ *   1. the node still fails — the registered component did not render, and the
+ *      `role="alert"` panel did;
+ *   2. the panel carries `did you mean '<the spelling that works>'`.
+ *
+ * Half 1 alone would pass on a revert of objectui#5247 — it is the guard
+ * against implementing option B by accident, not the pin on this change. Half 2
+ * is the load-bearing assertion: it is the only one here that fails if the
+ * suggestion is removed. The same is true of the no-match case: `not.toContain`
+ * passes on a revert by construction, which is exactly why it runs in the same
+ * file as the match case rather than on its own — together they distinguish
+ * "says the right thing" from "says nothing" and from "says something always".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+
+/** Marker text that appears ONLY if the component actually rendered. */
+const RENDERED_MARKER = 'the-component-actually-rendered';
+
+const Stub: React.FC = () => <div>{RENDERED_MARKER}</div>;
+
+const originalWarn = console.warn;
+
+beforeEach(() => {
+  console.warn = vi.fn();
+  ComponentRegistry.register('page', Stub, { namespace: 'test5247' });
+  ComponentRegistry.register('button', Stub, { namespace: 'ui' });
+});
+
+afterEach(() => {
+  ComponentRegistry.unregister('page', 'test5247');
+  ComponentRegistry.unregister('button', 'ui');
+  console.warn = originalWarn;
+});
+
+describe('objectui#5247 — case-only miss on the OBJUI-001 panel', () => {
+  it("still fails on 'Page' AND names 'page'", () => {
+    // Sanity: the canonical spelling is the one the registry holds. Without
+    // this the suite could pass against a registry that holds neither, which
+    // would make the two assertions below agree about nothing.
+    expect(ComponentRegistry.getKnownTypes()).toContain('page');
+
+    const { container } = render(<SchemaRenderer schema={{ type: 'Page' }} />);
+    const text = container.textContent ?? '';
+
+    // Half 1 — the ruled behaviour that must NOT change (this passes on a
+    // revert; it is the anti-option-B guard).
+    expect(text).not.toContain(RENDERED_MARKER);
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(text).toContain('Unknown component type');
+    expect(text).toContain('Page');
+
+    // Half 2 — the load-bearing pin. Fails if objectui#5247 is reverted.
+    expect(text).toContain("did you mean 'page'");
+  });
+
+  it('names the namespaced spelling too', () => {
+    const { container } = render(<SchemaRenderer schema={{ type: 'UI:Button' }} />);
+    const text = container.textContent ?? '';
+
+    expect(text).not.toContain(RENDERED_MARKER);
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(text).toContain("did you mean 'ui:button'");
+  });
+
+  it('says nothing when no registered type differs by case alone', () => {
+    // The counter-probe for the "always suggests" failure mode. On its own it
+    // is a phantom — it passes on a revert — so it is pinned in the same run as
+    // the two cases above.
+    const { container } = render(<SchemaRenderer schema={{ type: 'zzz' }} />);
+    const text = container.textContent ?? '';
+
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(text).toContain('Unknown component type');
+    expect(text).not.toContain('did you mean');
+  });
+
+  it('does not reach for an edit distance — a typo that is not a case typo suggests nothing', () => {
+    // `pge` is one deletion away from `page`. The ruling granted case, and only
+    // case; a fuzzy match here would be scope it did not give.
+    const { container } = render(<SchemaRenderer schema={{ type: 'pge' }} />);
+    const text = container.textContent ?? '';
+
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(text).not.toContain('did you mean');
+  });
+
+  it('reads its candidates from the live registry, not from a snapshot', () => {
+    // Unregister the canonical spelling and the suggestion must disappear —
+    // this is what makes the candidate set demonstrably the registry's own.
+    // A hand-kept list would keep suggesting `page` here (objectui#5115).
+    ComponentRegistry.unregister('page', 'test5247');
+    expect(ComponentRegistry.getKnownTypes()).not.toContain('page');
+
+    const { container } = render(<SchemaRenderer schema={{ type: 'Page' }} />);
+    const text = container.textContent ?? '';
+
+    expect(container.querySelector('[role="alert"]')).not.toBeNull();
+    expect(text).not.toContain('did you mean');
+  });
+});


### PR DESCRIPTION
Fixes #5247

Implements the maintainer ruling of 2026-08-19 — **Option C: keep lookup strict, make the failure teach.** Registry lookup stays exactly case-sensitive. A node typed `Page` still misses a registered `page`, still fails, and still renders the OBJUI-001 panel; only the message changes. Normalising the lookup (option B) is **not** implemented and is not implementable from this diff — nothing here resolves a mis-cased type.

## What changed, per surface

| surface | emit point | new output |
| --- | --- | --- |
| OBJUI-001 panel | `packages/react/src/SchemaRenderer.tsx` (the registry-lookup-miss branch) | `Unknown component type: Page — did you mean 'page'?` |
| `objectui check` | `packages/cli/src/commands/check.ts` (the single unknown-type warning) | `⚠️ Unknown schema type "Page" in a.json — did you mean "page"?` |

Quoting follows each surface's own existing convention (the CLI warning already spells the offending type as `"Page"`), so each line agrees with itself. The clause itself is identical on both sides and each side pins it in its own test.

Verified against the built binary, not just the source:

```
⚠️ Unknown schema type "zzz" in b.json
⚠️ Unknown schema type "Page" in a.json — did you mean "page"?
```

## Candidate sets, and why the two surfaces do not share one implementation

Each surface reads its candidates from the set it can actually trust, never from a list typed alongside it:

- the renderer from the **live registry** — `ComponentRegistry.getKnownTypes()`, loaded registrations plus pending `registerLazy` stubs;
- the CLI from `KNOWN_SCHEMA_TYPES`, the snapshot **derived** from this repository's registration calls by `scripts/regenerate-known-schema-types.mjs` and pinned by `scripts/__tests__/known-schema-types-derivation-5115.test.ts` (objectui#5115 / PR #5128). It is reused, not re-forked.

They cannot share one implementation because they cannot share a candidate **set**. The published CLI runs inside a *user's* project and depends on neither `@object-ui/core` nor the plugin packages that register most component types — the header of `scripts/regenerate-known-schema-types.mjs` records the measurement (eleven of the fifteen real types in the old hand-written list are registered by packages the CLI does not depend on) and the reason a runtime registry lookup would answer the wrong question there anyway. The only module both packages could import is `@object-ui/react`, and putting a helper in its public surface would mint a new published export, which this card's dispatch classifies as out of scope. So each side keeps a short unexported helper, cross-referenced in both files' headers, with the wording pinned behaviourally on both sides.

## Scope held

- **Case only.** `pge` suggests nothing — no edit distance, no Levenshtein. Pinned on both surfaces.
- **Silence when there is no match.** `zzz` gains no bogus suggestion. Pinned on both surfaces, in the same runs as the positive cases.
- **No second message producer.** The panel already had exactly one; this adds to it.

## The real emit point, established by counter-probe

The OBJUI-001 text is assembled in two candidate places, so it was measured rather than assumed. Mutating `ERROR_CODES['OBJUI-001'].message` in `packages/core/src/errors/index.ts` to a marker left the panel byte-identical — that template is dead for the panel (and `createError('OBJUI-001', …)`, its only route, has no call site outside `packages/core/src/errors/__tests__/errors.test.ts`). Mutating `ERROR_CODES['OBJUI-001'].suggestion` **did** reach the panel, which is the dev-only static hint line it reads. So the sentence is assembled inline in `SchemaRenderer.tsx`, and that is where the suggestion was added.

`packages/plugin-report/src/LegacyReportRenderer.tsx` prints its own "Unknown component type" string for an unresolved chart type; that is a plugin-local fallback, not the registry-lookup-miss path, and is untouched.

## Which assertions would still pass on a revert

Stated explicitly, because half of them would:

- **Pass on a revert, deliberately** — "the node still fails", "the registered component did not render", "the `role="alert"` panel is present", "`Page` is still reported unknown", and both no-match `not.toContain('did you mean')` legs. The first group is the anti-option-B guard; the second is the counter-probe against a clause that fires unconditionally, which is only meaningful in the same run as a positive case.
- **Fail on a revert** — every `did you mean` assertion. Demonstrated, not asserted: ablating the renderer helper turned exactly the 2 renderer clause cases red (11 others green); ablating the CLI clause turned exactly the 3 CLI clause cases red (10 others green). Both matched the prediction written before the run, and both mutations were proved on disk (injected marker located, removed line separately confirmed absent) and restored under `trap … EXIT INT TERM`.

One phantom **instrument** was self-caught along the way: the first counter-probe reported its verdict from a `console.log` vitest never surfaced, so it returned "marker did not reach the panel" in the baseline too — the same answer in both states of the world. It was replaced with a probe that writes the panel text to disk and a baseline self-check on a control string present in both versions of the file.

## Gates (all on `8537adb1c`, the final commit)

| gate | command | exit |
| --- | --- | --- |
| type-check (touched packages, forced) | `pnpm turbo run type-check --filter=@object-ui/react --filter=@object-ui/cli --force` | 0 — `0 cached, 11 total` |
| type-check downstream sweep | `pnpm --workspace-concurrency=4 --filter '...@object-ui/react' --filter '...@object-ui/cli' run type-check` | 0 — `Scope: 33 of 47`, 32 real `tsc --noEmit` runs, no turbo cache |
| tests (new) | `pnpm exec vitest run <the two new files>` | 0 — 13 passed |
| tests (blast radius) | `pnpm exec vitest run packages/cli/src/__tests__ packages/react/src/__tests__ packages/core/src/errors/__tests__ scripts/__tests__/known-schema-types-derivation-5115.test.ts scripts/__tests__/check-doc-component-types.test.ts` | 0 — 40 files, 588 tests passed |
| eslint (merge-base delta) | `pnpm exec eslint <5 changed .ts/.tsx>` | 0 — 0 errors, 17 pre-existing `no-explicit-any` warnings, none on a changed line |
| lint (packages, forced) | `pnpm turbo run lint --filter=@object-ui/react --filter=@object-ui/cli --force` | 0 — `0 cached, 3 total`, 0 errors |
| CLI self-check (lint.yml job) | `pnpm --filter '@object-ui/cli...' build` then `pnpm check` | 0 / 0 — `✓ All checks passed` on this repository |
| changeset presence | `node scripts/check-changeset-presence.mjs` | 0 |
| control bytes | `node scripts/check-control-bytes.mjs` | 0 — 5061 tracked files |
| known-types derivation | `node scripts/regenerate-known-schema-types.mjs --check` | 0 — generated file untouched |
| lint / type-check coverage | `node scripts/check-lint-coverage.mjs`, `node scripts/check-type-check-coverage.mjs` | 0 / 0 |

The downstream filter direction was demonstrated rather than asserted: the prefix form `...@object-ui/react` selects **33** packages (consumers, including `apps/**` and `examples/**`), the suffix form `@object-ui/react...` selects **5** (upstream dependencies) — opposite directions.

Changeset: `patch` for `@object-ui/react` and `@object-ui/cli` — a message improves; no type moves.

## Serial fence

None of the six files touched here is held by #5373: `packages/react/src/SchemaRenderer.tsx`, `packages/cli/src/commands/check.ts`, `packages/cli/src/utils/known-type-case-suggestion.ts` (new), the two new test files, and the changeset. The one adjacency worth naming is that #5373 holds `packages/cli/src/__tests__/check-known-types.test.ts`, which exercises the `check.ts` line this PR edits — that test was **not** modified and passes in the sweep above. Nothing under `plugin-grid`, `plugin-detail`, `app-shell` or `packages/types` was touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_