### PR TITLE
docs(ci): drop the two hand-copied self-test case counts from ci-cd-pipeline.md

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1132,8 +1132,8 @@ The rendered summary says that surface is **UNREAD**, never that it is clean
 **Trigger:** PR to `main`/`develop`, and push to `main`, **when `.claude/hooks/**` or this
 workflow file changes**. **Blocks a PR:** yes.
 
-Runs `.claude/hooks/guard-main-checkout-bash.selftest.sh` (100 cases) and
-`.claude/hooks/guard-shared-stash.selftest.sh` (32 cases) — the hermetic self-test matrices for
+Runs `.claude/hooks/guard-main-checkout-bash.selftest.sh` and
+`.claude/hooks/guard-shared-stash.selftest.sh` — the hermetic self-test matrices for
 the two PreToolUse guards behind the rule both `CLAUDE.md` files state as binding: worktree-first,
 and never `git stash` (AGENTS.md §9). Each self-test builds its own throwaway git fixture and
 needs only `jq` and `git`, both preinstalled on `ubuntu-latest` — no install, no build.


### PR DESCRIPTION
Fixes #6100

## What changed

Two lines of prose in `content/docs/guide/ci-cd-pipeline.md`, in the **Hook Self-Tests
(`hook-selftests.yml`)** section. The sentence named a case count for each of the two
PreToolUse guard matrices; both counts are gone:

```diff
-Runs `.claude/hooks/guard-main-checkout-bash.selftest.sh` (100 cases) and
-`.claude/hooks/guard-shared-stash.selftest.sh` (32 cases) — the hermetic self-test matrices for
+Runs `.claude/hooks/guard-main-checkout-bash.selftest.sh` and
+`.claude/hooks/guard-shared-stash.selftest.sh` — the hermetic self-test matrices for
```

Nothing else on the page is touched — not the `ci.yml` job table, not the workflow
inventory, not the hooks or their matrices. The remaining half of the sentence is
grammatical as-is; no further rewording was needed.

## Why removal, not an update

This is option 1 of the three the card laid out, per the dispatch ruling on the issue.

1. It mirrors the ruling already made on #6089 one file over. That PR removed the
   workflow's three copies, so this page was the **only** remaining hand-copied copy —
   and the one a contributor actually reads.
2. **The page already enforces this exact principle on itself.**
   `scripts/__tests__/ci-cd-pipeline-doc.test.ts` carries a test named *"states no job
   count, so the number cannot drift away from the table"*, whose comment reads: *"a
   hand-maintained count drifts by construction and a stale one still reads as
   authoritative. 'Seven jobs, all parallel' outlived the seventh job by three months."*
   That decision (#3451, #3212) was made for the `ci.yml` job count on this same page.
   These two case counts were the identical construction one section down.

The numbers remain available twice, correctly: each run's own tail prints
`N passed, N failed`, and `guard-shared-stash.sh`'s header carries its count **with the
recipe to re-derive it**.

Deliberately **not** updated to 41 / 121. Two drafts move them (#6042 and #5789 are the
cards behind those), and re-typing the new numbers re-arms the same drift.

## The pin check, done rather than inherited

The card's reading was that every pin on this page is scoped to `ci.yml` or to workflow
*filenames*, leaving these two numbers unpinned. Verified independently, and wider than
one file:

- `ci-cd-pipeline-doc.test.ts` matches **zero** times on `selftest`, `Self-Test`, `cases`,
  `guard-main-checkout`, `guard-shared-stash`.
- Repo-wide, no `.ts`/`.tsx`/`.mjs` file contains the literals `100 cases` or `32 cases`.
- Every other file that reads this page — `lint-workflow.test.ts`,
  `merge-queue-reporting.test.ts`, `dependabot-merge-gate.test.ts`,
  `doc-version-claims.test.ts`, `check-action-forward-parity.test.ts`,
  `quick-reference-current-release-4143.test.ts`, `scripts-type-check.test.ts` — was
  checked for a read of this sentence. None has one. (`doc-version-claims.test.ts` does
  hold a registry entry for this page, but for the `Node 22.x` claim, not a case count.)

So no pin was part of this diff.

## Verification — at `80dcab88d`

| Check | Verdict line it printed |
|---|---|
| `vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` | `Test Files  1 passed (1)` / `Tests  32 passed (32)` |
| `vitest run scripts/` (all 67 script suites, incl. every reader of this page) | `Test Files  67 passed (67)` / `Tests  1848 passed (1848)` |
| `docs:check-links` | `Links are valid across 15 scan roots.` |
| `check:doc-types` | `Every documented component type is registered.` (183 doc files, 1054 code blocks) |
| `check:control-bytes` | `check-control-bytes: OK (scanned 5062 tracked text file(s); skipped 85 binary).` |
| `check-changeset-presence.mjs` | `No source of a released package changed in this range, so no changeset is owed.` |

Control-byte scan over the diff's own file, beyond the gate:
`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' content/docs/guide/ci-cd-pipeline.md` — no
match. Run from the repo root throughout; vitest reported root
`/home/user/objectui-6100`, so neither invocation trap applies.

**Docs build — a declared narrowing.** Rather than a full `next build` of `apps/site`
(which pulls in a build of every workspace package), the docs compile was run directly:
`fumadocs-mdx` in `apps/site`, exit 0, `[MDX] generated files`. The narrowing is a
measurement, not a skip: the population is every file under `content/docs`, which is what
`fumadocs-mdx` compiles wholesale (the same 183-file docs set `check:doc-types` reports
scanning); and the diff is prose inside one paragraph — no link, no code fence, no
frontmatter, no new component type — so it cannot move any other file's compile. CI runs
the full build regardless.

## Reverse verification — and the honest limit

Predicted direction: **stays green**, because the claim under test is that these numbers
were unpinned. Re-inserted a deliberately false count (`9999 cases`) on top of the
committed fix, confirmed on disk by an anchored `grep -c` returning 1, then ran the doc
suite and `check-doc-links` again: `Tests 32 passed (32)` and `Links are valid across 15
scan roots`. Both stayed green. The restore leg was a `trap ... EXIT` `git checkout`, also
confirmed on disk: `grep -c '9999 cases'` returns 0, the corrected text greps back at 1,
`git status --porcelain` empty, suite re-run green.

That is the honest limit, and it is the argument for this fix rather than against it: **no
gate caught the stale numbers, and no gate will keep the corrected text true.** A pin that
derived them (option 2) was rejected in the dispatch ruling — it would have a docs test
reach into `.claude/**`, a governed surface, creating a coupling that itself needs
maintaining, in exchange for two numbers a reader does not need. Deleting the duplicated
number is the version of this that cannot go stale.

## Scope

Prose only, one file, two lines. Out of scope and untouched: the `ci.yml` job table, the
workflow inventory, the hooks and their self-test matrices, and the two drafts that change
the counts. No changeset — nothing under a released package's source changed, confirmed by
the gate above.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_