### PR TITLE
docs(fields): correct the four Cell Renderer imports and bring the blocks under the type gate

### DIFF
--- a/content/docs/fields/grid.mdx
+++ b/content/docs/fields/grid.mdx
@@ -158,12 +158,16 @@ const gridValue = [
 
 ## Cell Renderer
 
-In tables/grids, displays row count:
+In tables/grids, a `grid` value is shown as a compact placeholder, not as a
+nested table. It has no named renderer export of its own — the component is
+resolved by field type, which is the supported path for every type:
 
-```plaintext
-import { GridCellRenderer } from '@object-ui/fields';
+```ts
+import { getCellRenderer } from '@object-ui/fields';
 
-// Renders: "5 rows"
+const GridCell = getCellRenderer('grid');
+
+// <GridCell value={rows} field={field} /> renders: [Grid]
 ```
 
 ## Full Grid Functionality

--- a/content/docs/fields/object.mdx
+++ b/content/docs/fields/object.mdx
@@ -122,12 +122,16 @@ The object field stores data as parsed JSON:
 
 ## Cell Renderer
 
-In tables/grids, displays formatted JSON preview:
+In tables/grids, an `object` value is rendered by the JSON cell renderer —
+`getCellRenderer('object')` resolves to this same component, shared with `json`,
+`composite` and `record`:
 
-```plaintext
-import { ObjectCellRenderer } from '@object-ui/fields';
+```ts
+import { JsonCellRenderer } from '@object-ui/fields';
 
-// Shows: [Object] or truncated JSON in read-only mode
+// <JsonCellRenderer value={specs} field={field} /> renders single-line JSON,
+// truncated to the column width with the full text in the cell's `title`.
+// A null or empty value renders an em-dash instead.
 ```
 
 ## Schema Validation

--- a/content/docs/fields/summary.mdx
+++ b/content/docs/fields/summary.mdx
@@ -99,12 +99,15 @@ interface SummaryFieldSchema {
 
 ## Cell Renderer
 
-In tables/grids, displays with tabular numbers:
+In tables/grids, a `summary` value is rendered by the formula cell renderer —
+`getCellRenderer('summary')` resolves to this same component:
 
-```plaintext
-import { SummaryCellRenderer } from '@object-ui/fields';
+```ts
+import { FormulaCellRenderer } from '@object-ui/fields';
 
-// Renders: 15,750.50 (formatted with proper precision)
+// <FormulaCellRenderer value={15750.5} field={field} /> renders the computed
+// value as monospace text: 15750.5
+// A null or empty value renders an em-dash instead.
 ```
 
 ## Backend Implementation

--- a/content/docs/fields/vector.mdx
+++ b/content/docs/fields/vector.mdx
@@ -67,12 +67,16 @@ const embedding: number[] = [
 
 ## Cell Renderer
 
-In tables/grids, displays compact preview:
+In tables/grids, a `vector` value is shown as a compact placeholder, not as its
+components. It has no named renderer export of its own — the component is
+resolved by field type, which is the supported path for every type:
 
-```plaintext
-import { VectorCellRenderer } from '@object-ui/fields';
+```ts
+import { getCellRenderer } from '@object-ui/fields';
 
-// Renders: [0.1234, -0.5678, 0.9012...] (768D)
+const VectorCell = getCellRenderer('vector');
+
+// <VectorCell value={embedding} field={field} /> renders: [Vector]
 ```
 
 ## Vector Operations


### PR DESCRIPTION
Fixes #6107

Four `content/docs/fields/*.mdx` pages documented a Cell Renderer example importing a
symbol `@object-ui/fields` does not export. This PR corrects all four and brings the
blocks into the `check-doc-snippet-types` compile population, per the PM ruling at
objectui#6107 (comment 5398904856).

> Note on this body: GitHub's sanitizer strips short angle-bracket fragments even
> inside code spans, so every generic parameter and JSX tag below is written in words
> rather than in brackets.

## Re-derived the defect on `origin/main` before editing

A throwaway probe re-fenced only those four `plaintext` blocks as `ts`, ran the gate
against the built `dist/*.d.ts`, and restored the tree from an `EXIT` trap (`git status`
clean afterwards, verified inside the trap). The gate's own lines on `b9c367717`:

```
[semantic]  content/docs/fields/grid.mdx:164:10  TS2724: '"@object-ui/fields"' has no exported member named 'GridCellRenderer'. Did you mean 'UrlCellRenderer'?
[semantic]  content/docs/fields/object.mdx:128:10  TS2724: '"@object-ui/fields"' has no exported member named 'ObjectCellRenderer'. Did you mean 'getCellRenderer'?
[semantic]  content/docs/fields/summary.mdx:105:10  TS2724: '"@object-ui/fields"' has no exported member named 'SummaryCellRenderer'. Did you mean 'UrlCellRenderer'?
[semantic]  content/docs/fields/vector.mdx:73:10  TS2724: '"@object-ui/fields"' has no exported member named 'VectorCellRenderer'. Did you mean 'getCellRenderer'?
```

## Two different defects, two different fixes

**`summary` and `object` — rename the import.** `getCellRenderer`'s `standardMap`
(`packages/fields/src/index.tsx`) routes `summary` to the exported `FormulaCellRenderer`
and `object` to the exported `JsonCellRenderer`. The names were the whole difference:
both are declared in the shipped `packages/fields/dist/index.d.ts` as
`export declare function ...({ value }: CellRendererProps): React.ReactElement`
(lines 261 and 287), and the corrected imports compile clean.

**`grid` and `vector` — rewrite to the real API. No new exports were minted.** The same
map answers both with an **inline anonymous component** — `grid` and `vector` each map to
an arrow function returning a muted span whose only text is the literal `[Grid]` /
`[Vector]` — so there is no symbol to import. Their snippets now show the supported path,
`getCellRenderer(type)`, which `packages/fields/dist/index.d.ts:331` declares as a
function taking `fieldType: string` and returning `React.FC` parameterised by
`CellRendererProps`. The honest snippet was writable, so the "stop and report" branch of
the ruling did not apply.

**No `FRAGMENT_MARKER` was added to any of the four blocks.** Declared fragments are
unmoved at 111.

## Rendered-output comments corrected in the same pass

Each block's neighbouring comment asserted output the code does not produce. These were
rewritten from the `standardMap` entries and renderer bodies rather than from the prose:

| page | old claim | what the code does |
|---|---|---|
| `grid` | `// Renders: "5 rows"` | renders the placeholder `[Grid]`; the row-count renderer is `repeater`, a different type |
| `vector` | `// Renders: [0.1234, ...] (768D)` | renders the placeholder `[Vector]` |
| `summary` | "tabular numbers", `15,750.50` | `FormulaCellRenderer` is `font-mono` and does `String(safe)` — no thousands separator, no precision |
| `object` | "Shows: `[Object]`" | `JsonCellRenderer` emits truncated single-line JSON with the full text in `title`; it never emits a literal `[Object]` |

Leaving a knowingly-false comment beside a corrected import would have shipped half the fix.

## Verification — all at `53ce33ca1` (the final commit)

Packages built first (`turbo run build` over the 20 filters the gate itself derives via
`--build-filter`), so every result below is measured against the **shipped**
`packages/*/dist/*.d.ts`, never against source. The gate's `resolution` control confirms
it each run: `resolved to '.../packages/types/dist/index.d.ts'`.

`node scripts/check-doc-snippet-types.mjs` — before/after:

| | `origin/main` (`b9c367717`) | main + probe re-fence | this PR (`53ce33ca1`) |
|---|---|---|---|
| blocks to compile | 181 | 185 | **185** |
| declared fragments | 111 | 111 | **111** (unmoved) |
| diagnostics | 0 | **4** | **0** |

Verdict line on this branch:

```
Semantic phase: 185 of 185 block(s) judged, 0 failed.
Every covered documentation snippet compiles against the built types.
```

**Ablation — each corrected import is load-bearing.** With the fix committed, all four
import names were replaced with bogus ones (`getCellRendererNotAnExport`, …), confirmed
on disk per file (removed-text count 1 to 0, injected-text count 1, `git diff --stat`
non-empty), the gate re-run, and the tree restored from an `EXIT` trap. The gate went red
on exactly the four blocks, each naming its own file:

```
[semantic]  content/docs/fields/grid.mdx:166:10  TS2305: ... has no exported member 'getCellRendererNotAnExport'.
[semantic]  content/docs/fields/object.mdx:130:10  TS2305: ... has no exported member 'JsonCellRendererNotAnExport'.
[semantic]  content/docs/fields/summary.mdx:106:10  TS2305: ... has no exported member 'FormulaCellRendererNotAnExport'.
[semantic]  content/docs/fields/vector.mdx:75:10  TS2305: ... has no exported member 'getCellRendererNotAnExport'.
Semantic phase: 185 of 185 block(s) judged, 4 failed.
```

So the four blocks genuinely reach the semantic phase — the green above is a measurement,
not a silent skip. (No rebuild leg was needed: the mutation is in the documents, not in a
package whose `dist/` the program reads.)

Other gates implicated by this diff, each quoting its own verdict line:

- `check:doc-types` — `Every documented component type is registered.` (886 `type` literals)
- `docs:check-links` — `Links are valid across 15 scan roots.`
- `check:control-bytes` — `check-control-bytes: OK (scanned 5062 tracked text file(s))`
- `check-changeset-presence` — `No source of a released package changed in this range, so no changeset is owed.` (docs-only; nothing under a released package's `src/`)
- vitest from the repo **root**: `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts scripts/__tests__/check-doc-component-types.test.ts` — `Test Files 2 passed (2) · Tests 54 passed (54)`

**Docs render — a declared narrowing, with the measurement.** Instead of a full
`apps/site` Next build, the four changed pages were compiled directly with the repo's own
`@mdx-js/mdx@3.1.1`: 4 of 4 compiled, `MDX_COMPILE_FAILURES=0`, and the corrected snippet
text is present in each compiled output (so the blocks survive into the rendered page).
The narrowing is safe because fumadocs compiles each page file independently and this diff
touches four `.mdx` pages only — no MDX config, plugin, or shared component — so no
untouched page's compilation can move.

**ESLint — narrowing read from ESLint's own config, not guessed.** `eslint.config.js`
declares its linted population as `files: ['**/*.{ts,tsx}']`; `.mdx` appears in no config
block. Measured rather than asserted, via `eslint --no-inline-config --format json` over
the four changed files: 4 files reported, 0 errors, and each message is
`File ignored because no matching configuration was supplied.` A diff confined to `.mdx`
cannot move any ESLint verdict.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_