### PR TITLE
docs(core): compile twenty-one plaintext-fenced TypeScript snippets (#5867 batch 2)

### DIFF
--- a/.changeset/5867-plaintext-fenced-ts-batch2.md
+++ b/.changeset/5867-plaintext-fenced-ts-batch2.md
@@ -1,0 +1,20 @@
+---
+---
+
+Docs only, publishes nothing: twenty-one TypeScript snippets across three
+`content/docs/core/*.mdx` reference pages were fenced ```plaintext, so
+`check-doc-snippet-types` — which reads only `ts` / `tsx` fences — never saw
+them (objectui#5867, batch 2 of N). Triage's classifier is the one applied: a
+plaintext block whose first line starts with `import` / `export` / `interface` /
+`type X =` / `const x: T` is code, and those fences are now `ts` / `tsx`;
+genuinely prose blocks on the same pages are left alone. Compiling them found
+three real documentation defects, now fixed: `app-schema` documented an
+`AppSchema` type `@object-ui/types` has never exported (the shipped name is
+`AppComponentSchema`), and two `enhanced-actions` callbacks authored an
+`ActionCallback.dialog` object with no `type` key, which `SchemaNode` requires.
+Blocks that referenced ambient names are made self-contained with the import a
+reader copying them needs. The gate's blocks-to-compile count rises from 181 to
+202 — exactly the batch — with diagnostics at 0, no new `FRAGMENT_MARKER`
+declarations, and the covered/ungated sets unmoved. The blocks also stop
+rendering as unstyled plaintext and pick up TypeScript highlighting, which is
+the reader-visible half.

--- a/content/docs/core/app-schema.mdx
+++ b/content/docs/core/app-schema.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Application Schema (AppSchema)"
+title: "Application Schema (AppComponentSchema)"
 description: "Configure your entire application with navigation, branding, and global settings"
 ---
 
@@ -7,11 +7,11 @@ import { SchemaExample } from '@/app/components/ComponentDemo';
 
 # Application Schema
 
-The `AppSchema` defines the top-level configuration for your entire ObjectUI application, including navigation menus, branding, layout strategies, and global actions.
+The `AppComponentSchema` defines the top-level configuration for your entire ObjectUI application, including navigation menus, branding, layout strategies, and global actions.
 
 ## Overview
 
-AppSchema provides a declarative way to configure:
+AppComponentSchema provides a declarative way to configure:
 - **Navigation menus** - Hierarchical menu structures with icons and badges
 - **Branding** - Logo, title, favicon
 - **Layout strategies** - Sidebar, header, or empty layout
@@ -29,10 +29,10 @@ AppSchema provides a declarative way to configure:
 
 ## Basic Usage
 
-```plaintext
-import type { AppSchema } from '@object-ui/types';
+```ts
+import type { AppComponentSchema } from '@object-ui/types';
 
-const app: AppSchema = {
+const app: AppComponentSchema = {
   type: 'app',
   name: 'my-crm',
   title: 'My CRM Application',
@@ -87,7 +87,7 @@ const app: AppSchema = {
 
 The `menu` property accepts an array of `MenuItem` objects:
 
-```plaintext
+```ts
 interface MenuItem {
   type?: 'item' | 'group' | 'separator';
   label?: string;
@@ -137,7 +137,9 @@ interface MenuItem {
 
 The `actions` property defines global toolbar buttons:
 
-```plaintext
+```ts
+import type { MenuItem } from '@object-ui/types';
+
 interface AppAction {
   type: 'button' | 'dropdown' | 'user';
   label?: string;
@@ -154,8 +156,10 @@ interface AppAction {
 
 ## Complete Example
 
-```plaintext
-const crm: AppSchema = {
+```ts
+import type { AppComponentSchema } from '@object-ui/types';
+
+const crm: AppComponentSchema = {
   type: 'app',
   name: 'acme-crm',
   title: 'Acme CRM',
@@ -274,10 +278,16 @@ const crm: AppSchema = {
 
 Use Zod validation to ensure your app configuration is correct:
 
-```plaintext
-import { AppSchema } from '@object-ui/types/zod';
+```ts
+import { AppComponentSchema } from '@object-ui/types/zod';
 
-const result = AppSchema.safeParse(myAppConfig);
+const myAppConfig = {
+  type: 'app',
+  name: 'my-crm',
+  title: 'My CRM Application',
+};
+
+const result = AppComponentSchema.safeParse(myAppConfig);
 
 if (result.success) {
   console.log('Valid app configuration');
@@ -301,7 +311,7 @@ Use expression syntax to show/hide menu items based on user permissions:
 
 ## Use Cases
 
-AppSchema is ideal for:
+AppComponentSchema is ideal for:
 
 - **Multi-page applications** - Configure complex application structures with multiple routes
 - **Admin dashboards** - Create comprehensive admin panels with role-based navigation

--- a/content/docs/core/enhanced-actions.mdx
+++ b/content/docs/core/enhanced-actions.mdx
@@ -39,7 +39,9 @@ The enhanced `ActionSchema` provides:
 
 Execute API calls with full request configuration:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const ajaxAction: ActionSchema = {
   type: 'action',
   label: 'Load Data',
@@ -75,7 +77,9 @@ const ajaxAction: ActionSchema = {
 
 Show confirmation dialog before executing:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const confirmAction: ActionSchema = {
   type: 'action',
   label: 'Delete Record',
@@ -98,7 +102,9 @@ const confirmAction: ActionSchema = {
 
 Open a modal or dialog:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const dialogAction: ActionSchema = {
   type: 'action',
   label: 'Edit Details',
@@ -170,7 +176,9 @@ submitted before its uploaded fileId is ready.
 
 Execute multiple actions in sequence or parallel:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const chainedAction: ActionSchema = {
   type: 'action',
   label: 'Process Order',
@@ -215,7 +223,9 @@ const chainedAction: ActionSchema = {
 `condition` is a **gate**, not a branch: the action executes only while the
 predicate holds.
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const gatedAction: ActionSchema = {
   type: 'action',
   label: 'Require Manager Approval',
@@ -252,7 +262,9 @@ There is no `then` / `else` - a branch is expressed as **separate actions with
 mutually exclusive conditions**. Each action is gated on its own, so exactly one
 of them runs:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const approvalActions: ActionSchema[] = [
   {
     type: 'action',
@@ -294,7 +306,9 @@ for an either/or.
 
 Handle success and failure scenarios:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const actionWithCallbacks: ActionSchema = {
   type: 'action',
   label: 'Submit',
@@ -310,6 +324,7 @@ const actionWithCallbacks: ActionSchema = {
   onFailure: {
     type: 'dialog',
     dialog: {
+      type: 'dialog',
       title: 'Submission Failed',
       content: {
         type: 'text',
@@ -333,7 +348,9 @@ const actionWithCallbacks: ActionSchema = {
 
 Track actions for analytics:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const trackedAction: ActionSchema = {
   type: 'action',
   label: 'Download Report',
@@ -356,7 +373,9 @@ const trackedAction: ActionSchema = {
 
 Automatically retry failed requests:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const retryAction: ActionSchema = {
   type: 'action',
   label: 'Submit',
@@ -377,7 +396,9 @@ const retryAction: ActionSchema = {
 
 A comprehensive action combining multiple features:
 
-```plaintext
+```ts
+import type { ActionSchema } from '@object-ui/types';
+
 const complexAction: ActionSchema = {
   type: 'action',
   label: 'Process Order',
@@ -433,6 +454,7 @@ const complexAction: ActionSchema = {
   onFailure: {
     type: 'dialog',
     dialog: {
+      type: 'dialog',
       title: 'Order Processing Failed',
       content: {
         type: 'text',
@@ -467,8 +489,15 @@ const complexAction: ActionSchema = {
 
 ## Runtime Validation
 
-```plaintext
+```ts
 import { ActionSchema } from '@object-ui/types/zod';
+
+const myAction = {
+  type: 'action',
+  label: 'Delete Record',
+  actionType: 'confirm',
+  confirmText: 'Are you sure?',
+};
 
 const result = ActionSchema.safeParse(myAction);
 

--- a/content/docs/core/schema-renderer.mdx
+++ b/content/docs/core/schema-renderer.mdx
@@ -9,7 +9,7 @@ The SchemaRenderer is the heart of ObjectUI. It takes a JSON schema and dynamica
 
 The SchemaRenderer uses the Component Registry to look up the appropriate component for each schema type and renders it with the provided props.
 
-```plaintext
+```tsx
 import { SchemaRenderer } from '@object-ui/react';
 
 <SchemaRenderer schema={{
@@ -33,7 +33,7 @@ The SchemaRenderer automatically handles nested schemas:
 
 ## Schema Structure
 
-```plaintext
+```ts
 interface SchemaNode {
   type: string;                  // Component type (e.g., 'card', 'button', 'text')
   id?: string;                   // Unique identifier
@@ -54,8 +54,13 @@ When an unknown component type is encountered, SchemaRenderer displays a helpful
 
 The SchemaRenderer uses the Component Registry to resolve component types:
 
-```plaintext
+```tsx
 import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '@object-ui/react';
+
+function MyWidgetComponent() {
+  return <div>My widget</div>;
+}
 
 // Register a custom component
 ComponentRegistry.register('my-widget', MyWidgetComponent);
@@ -71,7 +76,7 @@ ComponentRegistry.register('my-widget', MyWidgetComponent);
 
 ### Simple Rendering
 
-```plaintext
+```tsx
 import { SchemaRenderer } from '@object-ui/react';
 
 function App() {
@@ -89,7 +94,7 @@ function App() {
 
 ### Dynamic Schemas
 
-```plaintext
+```tsx
 import { SchemaRenderer } from '@object-ui/react';
 import { useState, useEffect } from 'react';
 


### PR DESCRIPTION
Part of #5867 — batch 2 of N. Batches remain, so this does not close the card.

Twenty-one TypeScript snippets across three `content/docs/core/*.mdx` pages were fenced as `plaintext`, which `check-doc-snippet-types` does not read (`TS_FENCE_LANGUAGES` is `ts` / `tsx` / `typescript`). They are now `ts` / `tsx`, so the gate compiles them — and compiling them found three real documentation defects, fixed here.

## The classifier is triage's, applied unchanged

> A plaintext block whose first line starts with `import` / `export` / `interface` / `type X =` / `const x: T` **is code**.

Nothing was widened. Prose blocks on the same pages are untouched — `schema-renderer.mdx` keeps three (a bare object-shape excerpt and two deliberately-invalid `SchemaRenderer` usages), and they still render unstyled, which is the control for the render check below.

## Files, and why these

| page | blocks |
|---|---|
| `content/docs/core/app-schema.mdx` | 5 |
| `content/docs/core/enhanced-actions.mdx` | 11 |
| `content/docs/core/schema-renderer.mdx` | 5 |
| **total** | **21** |

Whole files only. Scope was chosen **by measurement, not by eye**: all 44 blocks of the `core` + `layout` remainder were re-fenced in a throwaway probe, the gate was run, and the tree restored under a `trap … EXIT INT TERM`. The probe reddened 31 blocks; those readings are what the exclusions below stand on, rather than a reading of the pages.

## What compiling them reddened, and the fix for each

1. **`app-schema.mdx` documented a type that has never existed.** Every block annotated `AppSchema` from `@object-ui/types`; the gate answered `TS2724: has no exported member named 'AppSchema'`. The shipped name is **`AppComponentSchema`** — pinned by three independent pieces of evidence inside the package: `app.d.ts:283` declares it, `wizardDraftToAppSchema(draft): AppComponentSchema` names the mapping, and the Zod twin exports the same spelling (`zod/index.zod.d.ts:35`). Renamed on the page (title, prose and code, 9 occurrences). The literal was then checked against the real type and passes unchanged, which is the evidence that `AppComponentSchema` is the type the page always meant.
2. **Two `enhanced-actions.mdx` callbacks authored an `ActionCallback.dialog` with no `type` key.** `ActionCallback.dialog` is `SchemaNode` (`crud.d.ts:51`), and `SchemaNode` extends `BaseSchema`, which requires `type` — so the documented `dialog: { title, content }` cannot exist. `type: 'dialog'` added to both; `dialog` is a registered component (`packages/components/src/renderers/overlay/dialog.tsx:22`), and `ActionRunner`'s own test pins the same shape.
3. **Blocks that leaned on ambient names are now self-contained.** Ten action examples annotate `ActionSchema` and never imported it; `interface AppAction` referenced `MenuItem`; two validation examples called `safeParse` on undeclared values; the registry example called `ComponentRegistry.register('my-widget', MyWidgetComponent)` with no such component and rendered a `SchemaRenderer` element without importing it. Each got the import — or, for the two `safeParse` blocks, the small literal — that a reader copying the block needs anyway. ⛔ No `FRAGMENT_MARKER` was declared; the ledger and `UNGATED_DOCS` are untouched.

## Excluded, each with a filed blocker rather than a marker

- `content/docs/core/report-schema.mdx` (11 blocks) → **#6121**. After the ambient-name imports it still reds on four separate contract mismatches — `dataSource` is annotated with `DataSource`, the *runtime adapter interface*, while every example authors a `{ provider, read }` config; `exports` is a total `Record` over all five formats; `ChartDataSeries` has no `type`. Which side is wrong is a ruling, not a docs edit.
- `content/docs/layout/**` (12 blocks, 3 files) → **#6120**. Five blocks red only on `TS2307: Cannot find module 'lucide-react'` — a declared dependency of `@object-ui/layout` that is not resolvable from the repository root, where the snippet program compiles. The snippets are correct; the resolution environment is the gap.
- `content/docs/core/app-schema.mdx` was **not** excluded for the same class of reason, because its rename is pinned by the package's own exports, while #6121 and #6120 are not.

## Verification

All at branch head `0ee4e87dd`, tree clean, heavy runs through the container's shared verify lock.

**Gate, before → after** (`node scripts/check-doc-snippet-types.mjs`, quoting its own lines):

```
BEFORE  Scanned 222 document(s): 178 covered (56 of them hold a ts/tsx block), 44 ungated
        Covered blocks: 292 - 181 to compile, 111 declared fragment(s).
        Semantic phase: 181 of 181 block(s) judged, 0 failed.

AFTER   Scanned 222 document(s): 178 covered (59 of them hold a ts/tsx block), 44 ungated
        Covered blocks: 313 - 202 to compile, 111 declared fragment(s).
        Syntax phase:   every block parsed, so every one of them reached the semantic phase.
        Semantic phase: 202 of 202 block(s) judged, 0 failed.
        Every covered documentation snippet compiles against the built types.
```

Blocks-to-compile **+21 = exactly the batch**; diagnostics **0**; declared fragments **111, unmoved**; covered **178, unchanged** (the set did not shrink); ungated **44, unchanged** (no document newly ungated). Gate strictness unmoved — `scripts/` is not in this diff.

**Other gates at the same head**, exit codes captured before any pipe, each quoted by its own verdict line: `check:doc-snippets` exit=0 · `check:doc-types` exit=0 *"Every documented component type is registered."* (890 `type` literals, up from 887 — the three this diff adds are all registered) · `docs:check-links` exit=0 *"Links are valid across 15 scan roots."* · `check:control-bytes` exit=0 *"OK (scanned 5063 tracked text file(s); skipped 85 binary)"*.

**Vitest, from the repository root:** `check-doc-snippet-types` · `check-doc-component-types` · `check-doc-links` · `check-changeset-presence` — *"Test Files 4 passed (4), Tests 185 passed (185)"*.

**Render:** `pnpm site:build` green (after building `@object-ui/plugin-gantt` and `@object-ui/plugin-map`, which sit outside the gate's `--build-filter` closure — the same unrelated build note batch 1 recorded). Reading the **prerendered HTML** back, all **21** converted blocks now carry shiki keyword spans on `import` / `const` / `interface` where they were previously unstyled — 5 + 11 + 5, the batch exactly — and `schema-renderer.mdx`'s three untouched plaintext blocks still render with **zero** shiki spans.

## Remainder

151 blocks in 103 files, handed back on #5867 for batch 3 with a measured breakdown of which files compile untouched.

⛔ Draft on purpose: not marked ready, no auto-merge.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_