### PR TITLE
docs(fields): compile seventeen plaintext-fenced TypeScript snippets (#5867 batch 3)

### DIFF
--- a/.changeset/5867-plaintext-fenced-ts-batch3.md
+++ b/.changeset/5867-plaintext-fenced-ts-batch3.md
@@ -1,0 +1,23 @@
+---
+---
+
+Docs only, publishes nothing: seventeen TypeScript snippets across ten
+`content/docs/fields/*.mdx` reference pages were fenced ```plaintext, so
+`check-doc-snippet-types` — which reads only `ts` / `tsx` fences — never saw
+them (objectui#5867, batch 3 of N). Triage's classifier is the one applied: a
+plaintext block whose first line starts with `import` / `export` / `interface` /
+`type X =` / `const x: T` is code, and those fences are now `ts`; genuinely
+prose blocks on the same pages are left alone. Compiling them found two real
+documentation defects, now fixed: `image` annotated `ImageFieldSchema.value`
+with `FileMetadata`, a name `@object-ui/types` does not export — it was
+deliberately renamed to `UploadedFileMetadata` (objectstack#4115) because the
+spec's same-named type is the storage layer's file record, a different shape —
+and `lookup` referenced `DataSource` without importing it. The gate's
+blocks-to-compile count rises from 206 to 223 — exactly the batch — with
+diagnostics at 0, no new `FRAGMENT_MARKER` declarations, and the
+covered/ungated sets unmoved. The blocks also stop rendering as unstyled
+plaintext and pick up TypeScript highlighting, which is reader-visible. Three
+further `fields` pages are excluded by measurement with blockers filed:
+`auto-number` (an ambient backend `db` handle), `object` (imports `ajv`, not a
+workspace dependency) and `location` (one fence welds a JSX element and a bare
+metadata object literal, so it parses as neither `ts` nor `tsx`).

--- a/content/docs/fields/file.mdx
+++ b/content/docs/fields/file.mdx
@@ -19,7 +19,7 @@ The File Field component provides a file upload interface with support for multi
 
 ## Field Schema
 
-```plaintext
+```ts
 interface FileFieldSchema {
   type: 'file';
   name: string;                  // Field name/ID
@@ -79,7 +79,7 @@ accept: ['image/*']  // All images
 
 In tables/grids, displays file count:
 
-```plaintext
+```ts
 import { FileCellRenderer } from '@object-ui/fields';
 
 // Renders: "3 files" or "document.pdf"

--- a/content/docs/fields/formula.mdx
+++ b/content/docs/fields/formula.mdx
@@ -19,7 +19,7 @@ The Formula Field component displays computed values calculated from other field
 
 ## Field Schema
 
-```plaintext
+```ts
 interface FormulaFieldSchema {
   type: 'formula';
   name: string;                  // Field name/ID
@@ -70,7 +70,7 @@ formula: 'end_date - start_date'
 
 In tables/grids, displays with monospace font:
 
-```plaintext
+```ts
 import { FormulaCellRenderer } from '@object-ui/fields';
 
 // Renders computed value in monospace font

--- a/content/docs/fields/grid.mdx
+++ b/content/docs/fields/grid.mdx
@@ -19,7 +19,7 @@ The Grid Field component provides an inline table for managing related records o
 
 ## Field Schema
 
-```plaintext
+```ts
 interface GridFieldSchema {
   type: 'grid';
   name: string;                  // Field name/ID

--- a/content/docs/fields/image.mdx
+++ b/content/docs/fields/image.mdx
@@ -15,12 +15,14 @@ The Image Field component provides an image upload interface with thumbnail prev
 
 ## Field Schema
 
-```plaintext
+```ts
+import type { UploadedFileMetadata } from '@object-ui/types';
+
 interface ImageFieldSchema {
   type: 'image';
   name: string;                  // Field name/ID
   label?: string;                // Field label
-  value?: FileMetadata | FileMetadata[];  // Current image(s)
+  value?: UploadedFileMetadata | UploadedFileMetadata[];  // Current image(s)
   required?: boolean;            // Is field required
   readonly?: boolean;            // Read-only mode
   disabled?: boolean;            // Disabled state
@@ -58,7 +60,7 @@ accept: ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
 
 In tables/grids, displays image thumbnails:
 
-```plaintext
+```ts
 import { ImageCellRenderer } from '@object-ui/fields';
 
 // Shows up to 3 thumbnails plus count if more

--- a/content/docs/fields/lookup.mdx
+++ b/content/docs/fields/lookup.mdx
@@ -15,7 +15,9 @@ The Lookup Field component provides a reference field for creating relationships
 
 ## Field Schema
 
-```plaintext
+```ts
+import type { DataSource } from '@object-ui/types';
+
 interface LookupFieldSchema {
   type: 'lookup' | 'master_detail';
   name: string;                  // Field name/ID
@@ -140,7 +142,7 @@ The Record Picker dialog provides:
 
 In tables/grids, lookup values display the referenced record name:
 
-```plaintext
+```ts
 import { LookupCellRenderer } from '@object-ui/fields';
 
 // Single value: Display name/label

--- a/content/docs/fields/rich-text.mdx
+++ b/content/docs/fields/rich-text.mdx
@@ -15,7 +15,7 @@ The Rich Text Field component provides a WYSIWYG editor for creating formatted t
 
 ## Field Schema
 
-```plaintext
+```ts
 interface RichTextFieldSchema {
   type: 'markdown' | 'html';
   name: string;                  // Field name/ID
@@ -57,7 +57,7 @@ interface RichTextFieldSchema {
 
 In tables/grids, rich text is shown as plain text:
 
-```plaintext
+```ts
 import { TextCellRenderer } from '@object-ui/fields';
 
 // Strips formatting, shows plain text only

--- a/content/docs/fields/select.mdx
+++ b/content/docs/fields/select.mdx
@@ -90,7 +90,7 @@ candidate query is filtered server-side and paginated. See
 
 ## Field Schema
 
-```plaintext
+```ts
 interface SelectFieldSchema {
   type: 'select';
   name: string;                  // Field name/ID
@@ -141,7 +141,7 @@ interface SelectOption {
 
 In tables/grids, select values are displayed as colored badges:
 
-```plaintext
+```ts
 import { SelectCellRenderer } from '@object-ui/fields';
 
 // Single value: Colored badge

--- a/content/docs/fields/summary.mdx
+++ b/content/docs/fields/summary.mdx
@@ -19,7 +19,7 @@ The Summary Field component displays aggregated values from related records. Thi
 
 ## Field Schema
 
-```plaintext
+```ts
 interface SummaryFieldSchema {
   type: 'summary';
   name: string;                  // Field name/ID

--- a/content/docs/fields/user.mdx
+++ b/content/docs/fields/user.mdx
@@ -23,7 +23,7 @@ it display-only.
 
 ## Field Schema
 
-```plaintext
+```ts
 interface UserFieldSchema {
   type: 'user';
   name: string;                  // Field name/ID
@@ -73,7 +73,7 @@ text input. Write `{ type: 'user', name: 'owner' }` instead.
 
 In tables/grids, displays avatar with name:
 
-```plaintext
+```ts
 import { UserCellRenderer } from '@object-ui/fields';
 
 // Single user: Avatar + name

--- a/content/docs/fields/vector.mdx
+++ b/content/docs/fields/vector.mdx
@@ -15,7 +15,7 @@ The Vector Field component displays vector embeddings used in AI/ML applications
 
 ## Field Schema
 
-```plaintext
+```ts
 interface VectorFieldSchema {
   type: 'vector';
   name: string;                  // Field name/ID


### PR DESCRIPTION
Part of #5867

Batch 3 of N. Re-fences **17** TypeScript blocks across **10 whole `content/docs/fields` pages** from `plaintext` to `ts`, so `check-doc-snippet-types` compiles them against the built types, and fixes the two blocks that reddened as a result.

All measurements at branch head `d6378e44e`, tree clean at run time; every heavy run through the container's shared verify lock.

## Population, re-derived on today's `origin/main` (`133e2ea1e`)

**146 blocks across 102 files** — down from batch 2's handback of 151/103. PR #6119 (card #6107) landed in between and converted four `fields` blocks itself (27 → 23), and one `components` page moved (72 → 71). Derived with the gate's **own** `listDocuments` and `UNGATED_DOCS`, plus triage's classifier applied to `plaintext` fences.

## What this batch takes, and why

`content/docs/fields` — the only group PM's batch-3 order left unblocked, `components` (#6122) and `layout` (#6120) being in flight with other devs.

Scope chosen **by measurement**: all 23 classifier-matching fences across the 13 `fields` pages were re-fenced in a throwaway probe, the closure rebuilt, the gate run, and the tree restored under a `trap ... EXIT INT TERM`. The mutation was proved on disk before the run — per-file `plaintext` fence counts dropped to their expected values, `git diff --stat` showed 23 insertions / 23 deletions — and `git status --porcelain` was empty after the restore.

That probe measured 229 blocks to compile (206 + 23) with **1 syntax and 4 semantic failures across 5 files**. The 10 files with no failure, plus the 2 whose failures are fixable in scope, are this batch.

| taken | blocks |
|---|---|
| `file`, `formula`, `grid`, `rich-text`, `select`, `summary`, `user`, `vector` — compile untouched | 13 |
| `image`, `lookup` — compile after the two fixes below | 4 |
| **total** | **17** |

## The two documentation defects compiling these found

Both are the #5044 class: a page teaching a name against a type that does not accept it, under a gate that reported the file as covered.

- **`image.mdx`** annotated `ImageFieldSchema.value` with **`FileMetadata`, a name `@object-ui/types` does not export.** It was deliberately renamed to `UploadedFileMetadata` (objectstack#4115) precisely because the spec's same-named type is a *different shape* — the storage layer's file record, not the field-value payload; re-exporting the spec's would have deleted `url`. The page now imports and annotates `UploadedFileMetadata`.
- **`lookup.mdx`** referenced `DataSource` without importing it. `DataSource` **is** exported from `@object-ui/types`; the import is now there, which is also what a reader copying the block needs. (`LookupOption`, referenced beside it, is declared inside the same block and needed nothing.)

No other block body was edited. No `FRAGMENT_MARKER` was declared. The gate, `UNGATED_DOCS` and the ledger are untouched — `scripts/` is not in this diff, so gate strictness is unmoved.

## Gate counts, before and after

| | before | after | delta |
|---|---|---|---|
| covered documents | 178 | 178 | unchanged — set did not shrink |
| of them holding a ts/tsx block | 63 | 70 | +7 |
| ungated | 44 | 44 | unchanged — no document newly ungated |
| covered blocks | 317 | 334 | |
| **blocks to compile** | **206** | **223** | **+17 = exactly the batch** |
| declared fragments | 111 | 111 | **unmoved** |
| diagnostics | 0 | **0** | |

Verbatim after: `Semantic phase: 223 of 223 block(s) judged, 0 failed.` / `Every covered documentation snippet compiles against the built types.`

## Other gates, at the same head

Exit codes captured before any pipe; each gate's own verdict line quoted.

- `check:doc-types` exit=0 — `Every documented component type is registered.`
- `docs:check-links` exit=0 — `Links are valid across 15 scan roots.`
- `check:control-bytes` exit=0 — `OK (scanned 5081 tracked text file(s); skipped 85 binary)`

Vitest from the repo **root**: `check-doc-snippet-types` · `check-doc-component-types` · `check-doc-links` · `check-changeset-presence` — `Test Files 4 passed (4)`, `Tests 185 passed (185)`.

## Render check

`pnpm site:build` green (556 static pages). Reading the prerendered HTML back from `apps/site/.next/server/app/docs/fields/*.html`, counting `pre` blocks that contain a shiki keyword-coloured span:

| page | `ts` fences @`origin/main` | `ts` fences @HEAD | highlighted blocks rendered |
|---|---|---|---|
| file, formula, image, lookup, rich-text, select, user | 0 | 2 each | 2 each |
| grid, summary, vector | 1 each | 2 each | 2 each |

Rendered highlighted blocks equal the `ts` fence count on **every** page, and the fence total moves **3 → 20 = +17**, the batch exactly.

Control, on the same pages: unhighlighted rendered blocks equal the remaining `plaintext` fences everywhere — `image` 3/3, `lookup` 2/2, `grid` 8/8, `summary` 5/5 — and the untouched prose blocks on `date` (1/1) and `percent` (1/1) still carry zero keyword spans.

Build note, unrelated to this diff and identical to batches 1 and 2: the site build needs `@object-ui/plugin-gantt` and `@object-ui/plugin-map` built first, both outside the gate's `--build-filter` closure.

## Excluded by measurement, with blockers filed

Three `fields` pages (6 blocks) red for reasons that need a ruling rather than an edit, so the whole file is excluded in each case rather than marked:

- **#6126** — `auto-number.mdx` leans on a fabricated ambient `db` handle (`TS2304` + `TS7006`), and `object.mdx` imports `ajv`, which is resolvable from neither the repo root nor any workspace `package.json` (`TS2307`).
- **#6127** — `location.mdx` welds a JSX element and a bare metadata object literal into one fence; measured to fail under **both** `ts` (2 diagnostics) and `tsx` (5), so no fence language fixes it.

## Remainder for batch 4

146 measured, 17 taken — **129 blocks in 92 files remain**:

| group | blocks | files | state |
|---|---|---|---|
| `content/docs/components/**` | 71 | 71 | blocked on #6122 |
| `content/docs/layout/**` | 12 | 3 | blocked on #6120 |
| `content/docs/plugins/**` | 12 | 7 | triaged by batch 2's probe 2 |
| `content/docs/core/**` | 11 | 1 | blocked on #6121 |
| `content/docs/blocks/**` | 10 | 1 | triaged by batch 2's probe 2 |
| `content/docs/fields/**` | 6 | 3 | blocked on #6126, #6127 |
| named in `UNGATED_DOCS` — adds **zero** to the compile population | 7 | 6 | leave |

The 7 blocks in 6 `UNGATED_DOCS` pages were **not** re-fenced: the document is not compiled at all, so re-fencing them moves blocks-to-compile by zero and the "+N = batch size" check does not apply. They are left alone deliberately, not overlooked.

Docs only — the changeset carries empty frontmatter and publishes nothing.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_