### PR TITLE
docs(components,plugins): resolve the undeclared `ActionConfig` annotation per site against the built types

### DIFF
--- a/content/docs/components/basic/pagination.mdx
+++ b/content/docs/components/basic/pagination.mdx
@@ -24,7 +24,7 @@ interface PaginationSchema {
   totalItems?: number;            // Total number of items
   
   // Events
-  onPageChange?: string | ActionConfig;
+  onPageChange?: (page: number) => void;
   
   // Styling
   className?: string;

--- a/content/docs/components/disclosure/toggle-group.mdx
+++ b/content/docs/components/disclosure/toggle-group.mdx
@@ -38,7 +38,7 @@ interface ToggleGroupSchema {
   size?: 'sm' | 'default' | 'lg';
   
   // Events
-  onValueChange?: string | ActionConfig;
+  onValueChange?: (value: string | string[]) => void;
   
   // States
   disabled?: boolean;

--- a/content/docs/components/feedback/sonner.mdx
+++ b/content/docs/components/feedback/sonner.mdx
@@ -28,10 +28,10 @@ The Sonner component provides beautiful toast notifications with a rich API.
 
 ```plaintext
 interface SonnerSchema {
-  action: 'sonner';
+  type: 'sonner';
   message: string;                // Toast message
   description?: string;           // Additional description
-  type?: 'default' | 'success' | 'error' | 'warning' | 'info';
+  variant?: 'default' | 'success' | 'error' | 'warning' | 'info';
   duration?: number;              // Auto-close duration (ms)
   
   // Action

--- a/content/docs/components/form/button.mdx
+++ b/content/docs/components/form/button.mdx
@@ -61,7 +61,7 @@ interface ButtonSchema {
   loading?: boolean;
   
   // Actions
-  onClick?: string | ActionConfig;  // Action on click
+  onClick?: () => void | Promise<void>;  // Click handler
   href?: string;                    // Link URL (renders as link)
   
   // Styling

--- a/content/docs/components/form/form.mdx
+++ b/content/docs/components/form/form.mdx
@@ -47,7 +47,7 @@ interface FormSchema {
   };
   
   // Events
-  onSubmit?: string | ActionConfig;
+  onSubmit?: (data: Record<string, any>) => void | Promise<void>;
   
   // Layout
   columns?: number;               // Grid layout

--- a/content/docs/components/form/input-otp.mdx
+++ b/content/docs/components/form/input-otp.mdx
@@ -32,8 +32,8 @@ interface InputOTPSchema {
   separator?: boolean;            // Show visual separator
   
   // Events
-  onChange?: string | ActionConfig;
-  onComplete?: string | ActionConfig;
+  onChange?: (value: string) => void;
+  onComplete?: (value: string) => void;
   
   // States
   disabled?: boolean;

--- a/content/docs/plugins/plugin-dashboard.mdx
+++ b/content/docs/plugins/plugin-dashboard.mdx
@@ -329,12 +329,19 @@ from widget `options`. In particular, on a dataset-bound gauge:
 ## TypeScript Support
 
 ```plaintext
-import type { DashboardSchema, MetricCardSchema } from '@object-ui/plugin-dashboard';
+import type { DashboardComponentSchema, DashboardWidgetSchema } from '@object-ui/types';
 
-const dashboard: DashboardSchema = {
+const widget: DashboardWidgetSchema = {
+  id: 'revenue',
+  title: 'Revenue',
+  type: 'metric-card',
+  layout: { x: 0, y: 0, w: 1, h: 1 },
+};
+
+const dashboard: DashboardComponentSchema = {
   type: 'dashboard',
   columns: 3,
-  widgets: [...]
+  widgets: [widget],
 };
 ```
 


### PR DESCRIPTION
Part of #6122

> **Notation note.** GitHub's body sanitizer deletes `‹…›`-shaped fragments as if they were HTML tags — fenced code does not protect them, and the first revision of this body lost every generic type argument that way. So throughout this body, **type arguments are written with ⟨ ⟩ (U+27E8/U+27E9)** where TypeScript writes the ASCII angle brackets. The committed `.mdx` files carry the real ASCII form; only this prose substitutes.

`ActionConfig` is named by **16 references across 15 `content/docs/components` pages** and is exported by nothing. Measured, not assumed: a probe importing it from `@object-ui/types` through the gate's own `paths` derivation reports

```
TS2724: '"@object-ui/types"' has no exported member named 'ActionConfig'. Did you mean 'AIConfig'?
```

and no file under `packages/*/src` declares it.

Per the ruling on #6122 (`#6122#issuecomment-5399663646`): **no blanket substitution.** Each of the 16 sites was resolved individually against the **built** `packages/*/dist/*.d.ts`. This PR corrects the sites the built types determine, fixes the two one-file defects the same probe surfaced, and leaves the rest for a ruling. `ActionConfig` is **not** minted — the refusal on #5329 / #6107 stands.

## The measured 16-site table

Resolved with the TypeScript compiler API against `packages/*/dist/*.d.ts`, using `derivePackageTypePaths()` from `scripts/check-doc-snippet-types.mjs` — the gate's own `exports.types` derivation, so nothing resolves to source. Resolution control for the probe:

```
RESOLUTION-CONTROL @object-ui/types -> packages/types/dist/index.d.ts
RESOLUTION-CONTROL lands in dist/*.d.ts: YES
RESOLUTION-CONTROL packages/*/src leakage: NONE
```

| # | doc site | shipped type | doc prop | shipped counterpart | type in the built `.d.ts` | this PR |
|---|---|---|---|---|---|---|
| 1 | `basic/pagination.mdx:27` | `PaginationSchema` | `onPageChange` | **same name** | `(page: number) => void` @ `navigation.d.ts:256` | **fixed** |
| 2 | `disclosure/toggle-group.mdx:41` | `ToggleGroupSchema` | `onValueChange` | **same name** | `(value: string \| string[]) => void` @ `disclosure.d.ts:170` | **fixed** |
| 3 | `form/button.mdx:64` | `ButtonSchema` | `onClick` | **same name** | `() => void \| Promise⟨void⟩` @ `form.d.ts:56` | **fixed** |
| 4 | `form/form.mdx:50` | `FormSchema` | `onSubmit` | **same name** | `(data: Record⟨string, any⟩) => void \| Promise⟨void⟩` @ `form.d.ts:1158` | **fixed** |
| 5 | `form/input-otp.mdx:35` | `InputOTPSchema` | `onChange` | **same name** | `(value: string) => void` @ `form.d.ts:720` | **fixed** |
| 6 | `form/input-otp.mdx:36` | `InputOTPSchema` | `onComplete` | **same name** | `(value: string) => void` @ `form.d.ts:724` | **fixed** |
| 7 | `form/command.mdx:34` | `CommandSchema` | `onSelect` | `onChange` (renamed) | `(value: string) => void` @ `form.d.ts:1376` | left for ruling |
| 8 | `form/radio-group.mdx:50` | `RadioGroupSchema` | `onValueChange` | `onChange` (renamed) | `(value: string \| number) => void` @ `form.d.ts:394` | left for ruling |
| 9 | `form/date-picker.mdx:34` | `DatePickerSchema` | `onDateChange` | `onChange` (renamed) | `(date: Date \| undefined) => void` @ `form.d.ts:642` | left for ruling |
| 10 | `form/combobox.mdx:44` | `ComboboxSchema` | `onValueChange` | `onChange` (renamed) | `(value: string) => void` @ `form.d.ts:1324` | left for ruling |
| 11 | `feedback/toast.mdx:36` | `ToastSchema` | `onAction` | nested `action.onClick` | `action?: { label: string; onClick: () => void }` @ `feedback.d.ts:135` | left for ruling |
| 12 | `feedback/sonner.mdx:40` | `SonnerSchema` | `action.onClick` | **no `action` prop at all** | — | left for ruling |
| 13 | `overlay/context-menu.mdx:27` | `ContextMenuSchema` | `onSelect` | **no event prop at all** | — | left for ruling |
| 14 | `overlay/menubar.mdx:34` | `MenubarSchema` | `onSelect` | **no event prop at all** | — | left for ruling |
| 15 | `overlay/dropdown-menu.mdx:42` | `DropdownMenuSchema` | `onSelect` | only `onOpenChange` | — | left for ruling |
| 16 | `basic/button-group.mdx:47` | `ButtonGroupSchema` | `onValueChange` | **no event prop at all** | — | left for ruling |

### The distribution — the ruling's `ActionSchema` trap does not fire

| resolves to | sites |
|---|---|
| `ActionSchema` — `crud.d.ts:62`, the **deprecated** declaration | **0** |
| `ActionSchema` — `ui-action.d.ts:331`, re-exported as `UIActionSchema` | **0** |
| a declared **function** type under the **same** prop name | **6** |
| a declared **function** type under a **different** prop name | **4** |
| a declared function type nested one level down | **1** |
| **nothing — the prop is absent from the shipped type** | **5** |

Both `ActionSchema` declarations were resolved and are reported for the record — `packages/types/dist/crud.d.ts:62` (deprecated) and `packages/types/dist/ui-action.d.ts:331`, which `index.d.ts:982` re-exports as `UIActionSchema`. **Neither is what any of the 16 sites resolves to**, so the "which declaration" question the ruling flagged never arises, and no documentation is pointed at a deprecated type.

The candidate set the card named — `UIActionSchema`, `ActionSchema`, or a new narrow action type — is wrong for **all sixteen** sites. Every slot the shipped types actually declare is a plain **function callback**, not an action reference. See "What still needs a ruling" below.

## The six corrections

Each replaces `string | ActionConfig` with the signature the shipped `.d.ts` declares for **that exact prop on that exact type** — no prop renamed, no new claim introduced. (⟨ ⟩ per the notation note; the files carry ASCII angle brackets.)

```diff
-  onPageChange?: string | ActionConfig;
+  onPageChange?: (page: number) => void;
-  onValueChange?: string | ActionConfig;
+  onValueChange?: (value: string | string[]) => void;
-  onClick?: string | ActionConfig;  // Action on click
+  onClick?: () => void | Promise⟨void⟩;  // Click handler
-  onSubmit?: string | ActionConfig;
+  onSubmit?: (data: Record⟨string, any⟩) => void | Promise⟨void⟩;
-  onChange?: string | ActionConfig;
+  onChange?: (value: string) => void;
-  onComplete?: string | ActionConfig;
+  onComplete?: (value: string) => void;
```

## The two one-file defects

**`feedback/sonner.mdx` — `action` declared twice in one interface** (TS2300 x2, TS2687 x2, TS2717). The first occurrence was the discriminant, misspelt. The built `SonnerSchema` (`feedback.d.ts:194`) declares `type: 'sonner'`, and the variant union the page called `type?` is the shipped `variant?` — which is also the key the renderer reads (`packages/components/src/renderers/feedback/sonner.tsx:22-25`, `schema.variant === 'success' ? toast.success : ...`). Correcting the discriminant alone would have moved the duplicate onto `type`; both halves are needed and both are read off the built type.

**`plugins/plugin-dashboard.mdx` — a block that has never parsed.** `widgets: [...]` is a spread with no operand, so `TS1109: Expression expected` at line 337 — the only syntax-phase failure among the blocks this card touches. Fixing the parse alone would have revealed a second defect of the same class the card is about, so it was fixed in the same stroke and is reported here rather than left to surface later: the block imported `DashboardSchema` and `MetricCardSchema` from `@object-ui/plugin-dashboard`, and **that package exports neither**. Measured against its built `dist/index.d.ts`:

```
RESOLUTION-CONTROL @object-ui/plugin-dashboard -> packages/plugin-dashboard/dist/index.d.ts
TS2305: Module '"@object-ui/plugin-dashboard"' has no exported member 'DashboardSchema'.
TS2305: Module '"@object-ui/plugin-dashboard"' has no exported member 'MetricCardSchema'.
```

The real surface is `DashboardComponentSchema` / `DashboardWidgetSchema` from `@object-ui/types` — the pair `DashboardRendererProps` itself is declared against (`packages/plugin-dashboard/dist/DashboardRenderer.d.ts:1`). The block was rewritten against it and compiles clean (`CANDIDATE DIAGNOSTICS: 0`); `'metric-card'` is a member of the closed `DASHBOARD_COMPONENT_WIDGET_TYPES` (`complex.d.ts:677`).

The fence stays `plaintext` on both pages — re-fencing is #5867 batch 3's job, and this PR does not take it.

## Verification

Both the before and after readings come from a **throwaway re-fence probe** under a `trap ... EXIT INT TERM`: it flips the fences of exactly the blocks under test to `ts`, runs the gate, and restores the tree. It is never committed. Each leg proved the mutation landed on disk before any reading was taken — the anchor text was counted before and after, not inferred from an editor's exit code:

```
MUTATION-ON-DISK components: plaintext before=15 after=0 ; ts after=15
MUTATION-ON-DISK plugin-dashboard: 1 fence flipped (TypeScript Support block only)
```

Harness controls, quoted from the gate's own output — resolution lands on a **built** artifact, so nothing was judged against source:

```
  resolution   Module name '@object-ui/types' was successfully resolved to '/home/user/objectui-6122/packages/types/dist/index.d.ts'
  sentinel     importing 'ThisNameIsDefinitelyNotExported' produced 1 diagnostic(s) (TS2305)
  positive     importing 'ComponentSchema' produced 0 diagnostic(s)
```

| reading | on `origin/main` `133e2ea1e` | on this branch `cbf03d111` |
|---|---|---|
| `TS2304: Cannot find name 'ActionConfig'` | **16** | **10** |
| `sonner.mdx` duplicate `action` (TS2300 / TS2687 / TS2717) | **5** | **0** |
| `plugin-dashboard.mdx` syntax phase | `TS1109` at :337 | `every block parsed` |
| declared fragments | **111** | **111** — unmoved |

The declared-fragment count is unchanged in both directions, which is the proof that **no `FRAGMENT_MARKER` was used**: these blocks are genuinely TypeScript and were made to compile, not declared exempt.

Gates run on the committed tree, each quoting its own verdict line — the exit code was captured before any pipe:

```
node scripts/check-doc-snippet-types.mjs        EXIT=0
  Semantic phase: 206 of 206 block(s) judged, 0 failed.
  Every covered documentation snippet compiles against the built types.

node scripts/check-doc-component-types.mjs      EXIT=0
  Every documented component type is registered.

node scripts/check-doc-links.mjs                EXIT=0
  Links are valid across 15 scan roots.

node scripts/check-control-bytes.mjs            EXIT=0
  check-control-bytes: OK (scanned 5080 tracked text file(s); skipped 85 binary).

node scripts/check-changeset-presence.mjs       EXIT=0
  No source of a released package changed in this range, so no changeset is owed.
```

The packages were built **before** any of this was judged (`pnpm build --concurrency=2`, exit 0), so every reading above is against the shipped `.d.ts` and not against a stale one. No changeset: the diff is `content/docs/**` only, and the presence gate says so in its own words rather than on my say-so.

## What still needs a ruling — the card's premise did not survive the measurement

The card asked which **action** type these props meant, offering `UIActionSchema`, `ActionSchema`, or a new narrow type. The measurement answers: **none of them, at any of the 16 sites.** Every slot the shipped types declare is a plain function callback, and 5 of the 16 props do not exist on the shipped type at all.

Two further measurements bear on the ruling:

1. **The `string |` half of every one of the 16 annotations documents a shape this repo has already ruled is dropped.** objectui#4453 is exactly this: an authored `onAction: 'NOT-A-FUNCTION'` reaching a handler slot. The accepted fix narrows to `typeof onAction === 'function'` and drops anything else — see the comment at `packages/plugin-calendar/src/calendar-view-renderer.tsx:322-331`. So the pages are teaching authors to write a value the runtime discards.

2. **No renderer reads any of these schema-level slots.** Grepping `packages/*/src` for a `schema.` property access on each of the nine documented prop names returns **no hit for any of the 15 components** — the only hits anywhere are `alert-dialog`'s `schema.onAction`, `plugin-editor` / `plugin-view`'s `schema.onChange`, and the builder writing `this.schema.onClick` / `onSubmit` (`packages/core/src/builder/schema-builder.ts:157,206`). The documented surface is declared-but-unconsumed where it is declared at all.

Correcting the remaining ten therefore is **not** a name substitution. Four need the documented prop **renamed** (`onValueChange`/`onSelect`/`onDateChange` to `onChange`), one needs restructuring into the shipped nested `action` object, and five have no target at all — for those the choice is to delete a reader-facing prop, to move the handler onto the item (which is where the shipped `MenuItem.onClick` lives, `overlay.d.ts:334`), or to treat it as a gap in the types. That last fork decides whether ObjectUI's component schemas are meant to carry JSON-authorable action references at all, which is a public-contract question about the SDUI event model and is not mine to settle. It is put back to #6122 rather than guessed, precisely because the card warns that getting it wrong fossilizes a shape across 15 reader-facing pages.

This PR is deliberately titled `Part of #6122`, not a closing reference — merging it must not close the card while those ten sites are unresolved.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
