### PR TITLE
feat(tooling): gate scripts/ entry guards on one predicate (PR 1 of 2)

### DIFF
--- a/.changeset/cyan-donkeys-tickle.md
+++ b/.changeset/cyan-donkeys-tickle.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tooling only, no package released: port `scripts/check-entry-guard.mjs` from objectstack and wire it into `Lint`, so a `scripts/**` entry guard hand-typed with `process.argv[1]` cannot land. The 29 guards this tree already carries are baselined SHRINK-ONLY and converted separately (objectui#6092).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -159,6 +159,48 @@ jobs:
         if: steps.relevant.outputs.should_run == 'true'
         run: node scripts/check-lint-coverage.mjs
 
+      # ── One entry guard, one predicate (objectui#6092) ───────────────────
+      # A `scripts/**` CLI has to answer "did node run me, or did something
+      # import me?" before it does anything, and the hand-typed answers in this
+      # tree had drifted into NINE spellings across 28 `.mjs` files. Every one
+      # of them fails the same way: node resolves symlinks for the module graph
+      # but leaves `process.argv[1]` as the caller typed it, so a script reached
+      # through a symlink compares two different paths, answers false, and does
+      # NOTHING — exit 0, no output. The wrappers that spawn these tools hold
+      # `result.status` only, so an inert child is a green gate. Measured on a
+      # real blocking gate in this repository (objectui#6078):
+      # `check-skills-paths.mjs` run directly on a deliberately broken tree
+      # exits 1 with 696 bytes naming the dead path; run through a symlink
+      # against the SAME tree it exits 0 with no output.
+      #
+      # `scripts/invoked-as.mjs` landed here in #5984 with a header stating that
+      # a gate enforced the single-spelling rule. It did not exist, and the
+      # sweep it described had not happened either (objectui#6078). This is that
+      # gate. It lands BEFORE the conversion on purpose: the worklist grew while
+      # the card sat open, so a sweep with nothing under it can be undone
+      # silently by the next pull request. The 29 existing guards are baselined,
+      # SHRINK-ONLY, and the script's own header says why that is safe.
+      #
+      # Runs before install, next to `check-lint-coverage.mjs` above and for the
+      # same reason: it reads sources with no dependency beyond node builtins
+      # and two local modules, so nothing it needs is in `node_modules`. Placed
+      # before `pnpm install` it also cannot be made green by an install
+      # failure. `--self-test` runs FIRST and is the half that stops the gate
+      # rotting into decoration — it drives the scanner over fixture sources,
+      # including the nine spellings measured in this tree, and pins the
+      # baseline in every direction it can move.
+      #
+      # Invoked as `node` rather than through the `pnpm check:entry-guard` alias
+      # for the pre-install placement, matching `check-lint-coverage.mjs` above
+      # and `check-cross-repo-closer-outcome.mjs` below. The alias exists in
+      # `package.json` for local use and `scripts/__tests__/entry-guard-wiring.test.ts`
+      # holds the two spellings to the same script.
+      - name: Verify every scripts/ entry guard goes through one predicate
+        if: steps.relevant.outputs.should_run == 'true'
+        run: |
+          node scripts/check-entry-guard.mjs --self-test
+          node scripts/check-entry-guard.mjs
+
       - name: Turbo Cache
         if: steps.relevant.outputs.should_run == 'true'
         uses: actions/cache@v6

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "check:doc-types": "node scripts/check-doc-component-types.mjs",
     "check:doc-snippets": "node scripts/check-doc-snippet-types.mjs",
     "check:eager-closure": "node scripts/check-eager-closure-budget.mjs",
+    "check:entry-guard": "node scripts/check-entry-guard.mjs",
     "cli": "node packages/cli/dist/cli.js",
     "objectui": "node packages/cli/dist/cli.js",
     "create-plugin": "node packages/create-plugin/dist/index.js",

--- a/scripts/__tests__/entry-guard-wiring.test.ts
+++ b/scripts/__tests__/entry-guard-wiring.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+const GATE = 'scripts/check-entry-guard.mjs';
+
+/**
+ * objectui#6092: `scripts/invoked-as.mjs` arrived from objectstack (#5984)
+ * carrying a header that named `scripts/check-entry-guard.mjs` as the gate
+ * enforcing its single-spelling rule. That file did not exist here, nothing in
+ * `package.json` or `.github/workflows/` ran such a gate, and the sweep the
+ * header described had not happened either — the string `check-entry-guard`
+ * appeared in exactly one place in the whole repository, which was that
+ * sentence about itself (objectui#6078).
+ *
+ * The failure that made it expensive was not the missing file. It was that a
+ * reader — human or agent — could open `invoked-as.mjs`, read a confident
+ * present-tense claim, and conclude the tree was converted and enforced when
+ * neither was true. So this file pins the claim to the mechanism, in the one
+ * direction that can go wrong quietly: a gate can stop being wired without
+ * anything going red, because a gate nobody runs is indistinguishable from a
+ * gate that passes.
+ *
+ * What is asserted, and why each one:
+ *
+ *   1. the script exists and its `package.json` alias points at it — the alias
+ *      is what a developer runs, and an alias naming a moved file fails loudly
+ *      only if something runs it;
+ *   2. `lint.yml` really runs it, on pull requests, in a step that executes —
+ *      the wiring claim itself;
+ *   3. the workflow's spelling and the alias's spelling name the SAME script,
+ *      so the pre-install `node` invocation and `pnpm check:entry-guard` cannot
+ *      drift into checking different things;
+ *   4. it runs BEFORE `pnpm install`, which is not decoration: placed after,
+ *      an install failure would take the gate with it and the tree would go
+ *      unjudged with the job red for an unrelated reason;
+ *   5. the gate's own `--self-test` is what the workflow runs first, and it
+ *      passes — a scan whose recogniser is broken reports a clean tree.
+ *
+ * Deliberately NOT asserted: any count of guards, spellings or baseline
+ * entries. Those numbers live in the gate's output and its baseline, they move
+ * as objectui#6092's second half converts call sites, and a hand-copied
+ * enumeration here would drift by construction — the lesson `lint-workflow.test.ts`
+ * records at length for this same workflow.
+ */
+describe('check-entry-guard is wired, not merely present', () => {
+  const workflow = parseYaml(fs.readFileSync(path.join(ROOT, '.github/workflows/lint.yml'), 'utf8'));
+  const steps: Array<Record<string, unknown>> = workflow.jobs.lint.steps;
+  const gateSteps = steps.filter((s) => typeof s.run === 'string' && (s.run as string).includes(GATE));
+
+  it('the gate script exists', () => {
+    expect(fs.existsSync(path.join(ROOT, GATE))).toBe(true);
+  });
+
+  it('package.json aliases it, and the alias points at the script that exists', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+    const alias = pkg.scripts['check:entry-guard'];
+    expect(alias).toBeTruthy();
+    expect(alias).toContain(GATE);
+  });
+
+  it('lint.yml runs it — exactly one step, both legs', () => {
+    expect(gateSteps).toHaveLength(1);
+    const run = gateSteps[0].run as string;
+    expect(run).toContain(`node ${GATE} --self-test`);
+    expect(run.split('\n').some((l) => l.trim() === `node ${GATE}`)).toBe(true);
+  });
+
+  it('that step is not disabled — it runs whenever the job runs its other steps', () => {
+    const condition = gateSteps[0].if;
+    const others = steps
+      .filter((s) => s !== gateSteps[0] && typeof s.uses !== 'undefined')
+      .map((s) => s.if);
+    // Same guard the rest of the job uses, rather than a hard-coded string:
+    // objectui#3523's shape may be renamed, and a test pinning the literal
+    // would fail on a rename while a step commented out with `if: false` would
+    // not.
+    expect(others).toContain(condition);
+  });
+
+  it('lint.yml still gates pull requests, or the step above is inert', () => {
+    // `on` parses as the boolean `true` in YAML 1.1; `yaml` gives back `on`.
+    const on = workflow.on ?? workflow[true as unknown as string];
+    expect(Object.keys(on)).toContain('pull_request');
+  });
+
+  it('it runs BEFORE pnpm install, so an install failure cannot take it with it', () => {
+    const gateIndex = steps.indexOf(gateSteps[0]);
+    const installIndex = steps.findIndex((s) => typeof s.run === 'string' && (s.run as string).includes('pnpm install'));
+    expect(installIndex).toBeGreaterThan(-1);
+    expect(gateIndex).toBeLessThan(installIndex);
+  });
+
+  it('its self-test passes — the half that makes a green scan mean something', () => {
+    const out = execFileSync('node', [GATE, '--self-test'], { cwd: ROOT, encoding: 'utf8' });
+    expect(out).toMatch(/check-entry-guard self-test: \d+ cases pass/);
+  });
+});

--- a/scripts/check-entry-guard.mjs
+++ b/scripts/check-entry-guard.mjs
@@ -1,0 +1,995 @@
+#!/usr/bin/env node
+
+/**
+ * check-entry-guard -- every `scripts/**` entry guard goes through ONE predicate.
+ *
+ *   node scripts/check-entry-guard.mjs              # scan the tree
+ *   node scripts/check-entry-guard.mjs --list       # every exporting file, and what runs on import
+ *   node scripts/check-entry-guard.mjs --self-test  # verify the checker itself
+ *
+ * Ported from objectstack's gate of the same name (objectstack#10784 and the
+ * cards above it), NOT copied: objectstack swept its tree BEFORE landing the
+ * gate, so its spelling rule admits no exceptions at all. This repository has
+ * not been swept. The port therefore carries a baseline that objectstack has
+ * no need for, and the whole design question of this file is how that baseline
+ * is shaped so it cannot become an allowlist. See "The baseline" below.
+ *
+ * Two rules live here. The first is about the SPELLING of a guard that exists;
+ * the second, further down, is about a guard that is MISSING from a file that
+ * exports. They are separate because the second one is meaningless for the
+ * files here that export nothing.
+ *
+ * ## What this gate is for
+ *
+ * A CLI script has to answer "did node run me, or did something import me?"
+ * before it does anything. Hand-typed answers to that question have drifted
+ * into NINE distinct spellings across 28 `.mjs` files in `scripts/` here --
+ * measured on `133e2ea1e`, not estimated -- and every one of them is wrong in
+ * the same way. The dominant failure:
+ *
+ *   node resolves symlinks for the module graph but leaves `process.argv[1]`
+ *   as the caller typed it
+ *
+ * so a script reached through a symlink compares two different paths, answers
+ * `false`, and does nothing -- **exit 0, no output**. The CI wrappers spawn
+ * these tools and hold `result.status` only, so an inert child is a green gate.
+ *
+ * That is measured in THIS tree, on a real blocking gate (objectui#6078):
+ *
+ *   node scripts/check-skills-paths.mjs              direct  : exit=1, 696 bytes
+ *   node /…/link/check-skills-paths.mjs  (symlink)   symlink : exit=0, 0 bytes
+ *
+ * Same tree, same defect, same gate. A second spelling here goes inert with no
+ * symlink at all: `check-node-esm-load.mjs:847` writes
+ * ``import.meta.url === `file://${process.argv[1]}` ``, which percent-encodes
+ * apart from `argv[1]` in any directory whose name needs encoding (measured in
+ * a directory named `a#b c`).
+ *
+ * `scripts/invoked-as.mjs` is the only place allowed to read `process.argv[1]`;
+ * everywhere else spells the guard
+ *
+ *   if (isEntrypoint(import.meta.url)) { ... }
+ *
+ * which has no comparison in it to get wrong.
+ *
+ * ## Why the gate lands BEFORE the sweep
+ *
+ * The sweep on its own is worth little: nothing would stop a TENTH spelling
+ * from being typed the next time someone adds a script, and the next one would
+ * be just as invisible. That is not hypothetical here -- objectui#6092 measured
+ * the worklist growing while the card sat open: `check-designer-field-key-parity.mjs`
+ * added a guard between `a1c41c516` and `7c96c9420`. A sweep with no gate under
+ * it can be silently undone by the next pull request. So the gate lands first
+ * and names its own worklist; the conversion of the 29 existing call sites is
+ * the second half of objectui#6092 and is deliberately NOT in this file's PR.
+ *
+ * ## The baseline, and why it is not an allowlist
+ *
+ * ⛔ SHRINK-ONLY, and shaped so the difference is mechanical rather than a
+ * promise. `KNOWN_HAND_TYPED_GUARDS` maps a file to the NUMBER of masked
+ * `process.argv[1]` occurrences it carried when this gate landed. Three
+ * consequences, and the third is the one that makes the whole thing worth
+ * landing:
+ *
+ *   • a file NOT in the map that carries a guard fails -- a 30th spelling
+ *     cannot land;
+ *   • a file IN the map that carries MORE than its number fails -- a second
+ *     guard cannot be smuggled into an already-owed file, which a
+ *     path-only baseline would have accepted silently;
+ *   • a file that carries FEWER fails as STALE and names itself, with the
+ *     remedy being to lower or delete the line. There is no supported route
+ *     that raises a number. That is what stops the map from rotting into a
+ *     list nobody re-reads.
+ *
+ * Every entry has the same one-line remedy -- `isEntrypoint(import.meta.url)`
+ * -- so no entry records a judgement anyone has to re-make. That is the
+ * property that makes a debt list safe, and it is the only reason one is here.
+ *
+ * ONE entry is different in kind and is labelled as such rather than left to be
+ * re-derived: `scripts/shadcn-sync.js` hand-types the CORRECT two-leg shape
+ * (`realpathSync(resolved) === __filename`, objectui#6092). It is not a defect
+ * and this gate never reports it as one. It is in the map because the rule is
+ * "one predicate", not "one predicate or a second correct implementation" --
+ * converting it is a simplification, not a fix.
+ *
+ * ## Why a spelling gate rather than a behavioural sweep
+ *
+ * The tempting alternative is to RUN every `scripts/**` entry point and assert
+ * it produced something. That was rejected upstream on measurement, and the
+ * same reasoning holds here:
+ *
+ *   • many of these scripts have real side effects (`shadcn-sync`,
+ *     `sync-quick-reference-release`, `regenerate-known-schema-types`), so a
+ *     gate that spawns all of them is a gate nobody can run locally;
+ *   • "produced output" is not a decidable property of an arbitrary tool -- a
+ *     quiet-on-success script is legitimate, so the assertion would have to be
+ *     per-script, which is the same per-file hand-wiring this gate replaces.
+ *
+ * The behavioural evidence lives once, at the predicate: `invoked-as.mjs`'s
+ * self-test drives a real probe through a real symlink, a differently-named
+ * symlink, a path needing percent-encoding, and both import directions.
+ *
+ * ## What it reads
+ *
+ * Comments AND string/template/regex literals are masked before the scan
+ * (`js-comment-mask.mjs`), because a `process.argv[1]` inside a string payload
+ * for a spawned child is not an entry guard, and neither is one inside a
+ * docblock -- `shadcn-sync.js:1046` really does write one in prose, and an
+ * allowlist to excuse it would be a hole the next such file falls through
+ * silently.
+ *
+ * ## What was deliberately NOT ported
+ *
+ * objectstack's copy carries a `ROOT_DIR_WATCH_HINTS` declaration read by its
+ * `scripts/pm/dispatch-gates.mjs`. There is no such tool in this repository, so
+ * the declaration would be a literal nothing reads, and its self-test cases
+ * would assert a contract with an absent consumer. It is left out rather than
+ * carried as decoration -- a ported claim about a file that does not exist here
+ * is the exact defect objectui#6078 recorded against `invoked-as.mjs`'s header.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isEntrypoint } from './invoked-as.mjs';
+import { blank, scanSource } from './js-comment-mask.mjs';
+
+const HERE = resolve(fileURLToPath(import.meta.url), '..');
+const REPO_ROOT = resolve(HERE, '..');
+const SCRIPTS = HERE;
+
+/** This file, which quotes the idioms it bans. */
+const SELF = resolve(fileURLToPath(import.meta.url));
+
+/** The one module allowed to read `process.argv[1]`. */
+const PREDICATE_HOME = join(SCRIPTS, 'invoked-as.mjs');
+
+/** The canonical guard, and the only accepted call shape. */
+export const CANONICAL = 'isEntrypoint(import.meta.url)';
+
+/**
+ * Entry-guard idioms other than `process.argv[1]`. Each one answers the same
+ * question and each has its own way of being wrong under a symlink or a bundler,
+ * so none of them is a permitted second spelling. None is written in this tree
+ * today (measured), and they are listed so that the first one cannot arrive
+ * quietly as "not the shape the gate looks for".
+ */
+const OTHER_IDIOMS = [
+  ['require.main', /\brequire\.main\b/g],
+  ['import.meta.main', /\bimport\.meta\.main\b/g],
+  ['process.mainModule', /\bprocess\.mainModule\b/g],
+];
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name.startsWith('.')) continue;
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (name.endsWith('.mjs') || name.endsWith('.js') || name.endsWith('.cjs')) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Code only: comments, strings, templates and regex literals blanked — MINUS
+ * the bytes a `${...}` interpolation contributes, which the language runs.
+ *
+ * That subtraction is not a refinement, it is the difference between this gate
+ * seeing this tree's worst guard and not seeing it. `comment || literal` is
+ * `js-comment-mask.mjs`'s documented answer and is right for its other callers,
+ * but under it the line
+ *
+ *   import.meta.url === `file://${process.argv[1]}`
+ *
+ * at `scripts/check-node-esm-load.mjs:847` is prose. Measured: the first cut of
+ * this gate, using the plain view, listed 28 of this tree's 29 hand-typed
+ * guards and omitted exactly that one — the spelling objectui#6092 singles out
+ * as the one that goes inert with no symlink at all. `interpolation` is the
+ * third array added for this; `js-comment-mask.mjs` states what it excludes and
+ * pins it.
+ */
+export function codeOnly(source) {
+  const { comment, literal, interpolation } = scanSource(source);
+  const both = new Uint8Array(comment.length);
+  for (let i = 0; i < both.length; i++) both[i] = comment[i] || (literal[i] && !interpolation[i]);
+  return blank(source, both);
+}
+
+function lineOf(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
+/**
+ * Findings for one file's source. Exported so the self-test drives the real
+ * scanner over fixture sources rather than over this tree, which would only
+ * prove what today's tree happens to contain.
+ */
+export function scanFile(rel, source, { isPredicateHome = false } = {}) {
+  const findings = [];
+  const code = codeOnly(source);
+
+  if (!isPredicateHome) {
+    const re = /process\.argv\[1\]/g;
+    let m;
+    while ((m = re.exec(code))) {
+      findings.push({
+        rel,
+        line: lineOf(source, m.index),
+        what: 'process.argv[1]',
+        why: 'a hand-typed entry guard',
+      });
+    }
+    for (const [name, pattern] of OTHER_IDIOMS) {
+      pattern.lastIndex = 0;
+      let n;
+      while ((n = pattern.exec(code))) {
+        findings.push({ rel, line: lineOf(source, n.index), what: name, why: 'a second entry-guard idiom' });
+      }
+    }
+  }
+
+  // `isEntrypoint` takes the caller's own `import.meta.url`. Any other argument
+  // is a guard asking about somebody else, which is the same class of wrong.
+  // `(?<!function\s+)` so the DECLARATION of the predicate is not read as a
+  // call on somebody else's url — `export function isEntrypoint(importMetaUrl)`
+  // is what defines the shape, not a violation of it.
+  const call = /(?<!function\s{1,4})\bisEntrypoint\s*\(([^)]*)\)/g;
+  let c;
+  while ((c = call.exec(code))) {
+    const arg = c[1].trim();
+    if (arg && arg !== 'import.meta.url') {
+      findings.push({
+        rel,
+        line: lineOf(source, c.index),
+        what: `isEntrypoint(${arg})`,
+        why: 'the guard must ask about the caller itself',
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * ⛔ SHRINK-ONLY. The hand-typed entry guards this tree carried when the gate
+ * landed, as `path -> number of masked process.argv[1] occurrences`. The
+ * rationale, and why a COUNT rather than a bare path, is in the header. Two
+ * shapes appear because a guard written
+ * `const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === …`
+ * reads `argv[1]` twice.
+ *
+ * The remedy for every line is the same:
+ *
+ *   import { isEntrypoint } from './invoked-as.mjs';
+ *   if (isEntrypoint(import.meta.url)) { … }
+ *
+ * then delete the line from here. objectui#6092's second half does this sweep.
+ */
+const KNOWN_HAND_TYPED_GUARDS = new Map([
+  ['scripts/check-action-forward-parity.mjs', 2],
+  ['scripts/check-changeset-fixed.mjs', 2],
+  ['scripts/check-changeset-no-major.mjs', 2],
+  ['scripts/check-changeset-presence.mjs', 2],
+  ['scripts/check-control-bytes.mjs', 2],
+  ['scripts/check-cross-repo-closer-outcome.mjs', 1],
+  ['scripts/check-designer-field-key-parity.mjs', 1],
+  ['scripts/check-doc-component-types.mjs', 2],
+  ['scripts/check-doc-links.mjs', 2],
+  ['scripts/check-doc-snippet-types.mjs', 2],
+  ['scripts/check-eager-closure-budget.mjs', 2],
+  ['scripts/check-i18n-call-site-keys.mjs', 2],
+  ['scripts/check-i18n-dead-keys.mjs', 2],
+  ['scripts/check-i18n-en-drift.mjs', 2],
+  ['scripts/check-lucide-icon-record-names.mjs', 2],
+  ['scripts/check-node-esm-load.mjs', 1],
+  ['scripts/check-package-self-import.mjs', 2],
+  ['scripts/check-phantom-dependencies.mjs', 2],
+  ['scripts/check-published-dist-tooling.mjs', 2],
+  ['scripts/check-skills-paths.mjs', 2],
+  ['scripts/check-spec-symbol-derivation.mjs', 2],
+  ['scripts/check-type-check-coverage.mjs', 2],
+  ['scripts/dependabot-merge-gate.mjs', 2],
+  ['scripts/extract-mdx-demos.mjs', 2],
+  ['scripts/regenerate-known-schema-types.mjs', 2],
+  ['scripts/render-budget-comment.mjs', 2],
+  ['scripts/shadcn-check-report.mjs', 2],
+  ['scripts/shadcn-sync.js', 1],
+  ['scripts/sync-quick-reference-release.mjs', 2],
+]);
+
+/**
+ * The one entry above that is NOT a defect: it hand-types the CORRECT two-leg
+ * shape already. Named here so a reader of the map is not left to re-derive
+ * which of the entries is which, and so nothing later reports it as broken.
+ */
+const CORRECT_SHAPE_BUT_HAND_TYPED = new Set(['scripts/shadcn-sync.js']);
+
+/**
+ * Reconcile what the tree carries against the shrink-only baseline. Pure, and
+ * exported, because "the gate reddens on a 30th" is the entire justification
+ * for landing it before the sweep — and a run over today's tree can only ever
+ * show that today's tree is green. Recognition has to be pinned here, or it is
+ * not pinned anywhere.
+ *
+ * `observed` is `rel -> count`; `baseline` is the map above.
+ */
+export function reconcileGuards(observed, baseline) {
+  const fresh = [];
+  const stale = [];
+  for (const [rel, count] of observed) {
+    const owed = baseline.get(rel);
+    if (owed === undefined) fresh.push({ rel, count, owed: 0 });
+    else if (count > owed) fresh.push({ rel, count, owed });
+  }
+  for (const [rel, owed] of baseline) {
+    const count = observed.get(rel) ?? 0;
+    if (count < owed) stale.push({ rel, count, owed });
+  }
+  fresh.sort((a, b) => a.rel.localeCompare(b.rel));
+  stale.sort((a, b) => a.rel.localeCompare(b.rel));
+  return { fresh, stale };
+}
+
+/**
+ * ## The second finding kind: an EXPORTING file whose top level runs on import
+ *
+ * The spelling half above says nothing about a file with NO guard, and that is
+ * correct for the pure CLIs in this tree that export nothing: nobody can import
+ * them, so nothing can be hurt by what their top level does. It is exactly
+ * wrong for a file that DOES export, because `import { helper } from
+ * './check-thing.mjs'` then runs the tool — and several of these reach
+ * `process.exit(0)` while the importer is still mid-import, so the importer's
+ * own code after the `import` never runs and its caller reads success. That is
+ * the same silent-exit-0 shape the spelling half of this gate exists for,
+ * arriving through a different door.
+ *
+ * ## What the rule asserts, and why it needs no exception list
+ *
+ * A `scripts/**` file that exports a binding must have every top-level statement
+ * that RUNS something inside the guard. Declarations are not statements that run
+ * — `const HERE = resolve(...)` is how every file in here computes its own
+ * paths, and flagging those would flag the whole tree. A file that exports
+ * nothing is never reached, and neither is a module of declarations only, so
+ * pure library modules need no entry anywhere — which is the point of shaping
+ * it this way. An exception list would have been judgements nobody re-checks,
+ * i.e. the same drift one level up.
+ */
+
+/** A statement head that opens a block, so its `}` ends the statement. */
+const BLOCK_HEAD = /^(?:export\s+(?:default\s+)?)?(?:async\s+)?(?:function|class|if|for|while|do|try|switch)\b/;
+
+/** A statement head that continues the statement before it. */
+const CONTINUATION = /^(?:else|catch|finally)\b/;
+
+/** A head that declares rather than runs. */
+const DECLARATION_HEAD = /^(?:import|export|const|let|var|function|class|async\s+function)\b/;
+
+/** Keyword parens, which are not calls. Stripped before looking for a call. */
+const KEYWORD_PAREN = /\b(?:if|for|while|switch|catch|function|do|else|return|typeof|await|new|delete|void|in|of|yield)\s*\(/g;
+
+/** What a call looks like once the keyword parens are gone. */
+const CALL_SHAPE = /(?:[A-Za-z_$][\w$]*|\])\s*\(/;
+
+/**
+ * The top-level statements of already-masked code, as
+ * `{ head, start, end }` — `head` with every nested `()`/`[]`/`{}` body elided
+ * so it can be classified by its first token, and `[start, end)` indexing the
+ * masked source so the body can still be read.
+ *
+ * Depth counting is enough here, and a parser is not needed, BECAUSE the input
+ * is already masked: comments, strings, templates and regex literals are blank,
+ * so the only brackets left are real ones and valid JS balances them. Exported
+ * so the self-test drives the real slicer over fixture sources.
+ */
+export function topLevelStatements(code) {
+  const out = [];
+  let depth = 0;
+  let head = '';
+  let start = 0;
+  const put = (ch, i) => {
+    if (head.trim() === '' && !/\s/.test(ch)) start = i;
+    head += ch;
+  };
+  const flush = (endIdx) => {
+    const text = head.trim();
+    if (text) out.push({ head: text, start, end: endIdx + 1 });
+    head = '';
+  };
+  for (let i = 0; i < code.length; i++) {
+    const ch = code[i];
+    if (ch === '(' || ch === '[' || ch === '{') {
+      if (depth === 0) put(ch, i);
+      depth++;
+      continue;
+    }
+    if (ch === ')' || ch === ']' || ch === '}') {
+      depth--;
+      if (depth === 0) {
+        put(ch, i);
+        if (ch === '}' && BLOCK_HEAD.test(head.trim())) flush(i);
+      }
+      continue;
+    }
+    if (depth !== 0) continue;
+    if (ch === ';') {
+      flush(i);
+      continue;
+    }
+    put(ch, i);
+  }
+  if (head.trim()) out.push({ head: head.trim(), start, end: code.length });
+
+  // `else` / `catch` / `finally` continue the statement before them, so a guard
+  // written `if (isEntrypoint(import.meta.url)) { … } else { … }` is ONE
+  // statement and the `else` half is inside the guard, not beside it.
+  const merged = [];
+  for (const s of out) {
+    const prev = merged[merged.length - 1];
+    if (prev && CONTINUATION.test(s.head)) {
+      prev.head += ` ${s.head}`;
+      prev.end = s.end;
+    } else merged.push({ ...s });
+  }
+  return merged;
+}
+
+/** A hand-typed entry guard, whatever its nine spellings. */
+const HAND_TYPED = /process\.argv\[1\]/;
+
+/**
+ * Top-level bindings whose value IS the guard. `const isMain =
+ * isEntrypoint(import.meta.url); … if (isMain) { … }` is the same guard stored
+ * once, and a rule that only looked for the call inside the `if` would call
+ * every file that spells it that way a violation.
+ *
+ * ## Why a HAND-TYPED initializer counts here too
+ *
+ * This is the port's one substantive divergence from objectstack's copy, and
+ * it exists because objectstack swept before landing the gate and this tree has
+ * not. `const invokedDirectly = process.argv[1] && resolve(…) === …;` is a
+ * BADLY SPELLED guard — rule 1 above says so, by name, on its own line — but it
+ * is still a guard: on an `import` the comparison is false and the dispatch
+ * does not run. Refusing to recognise it would make rule 2 report all 29 of
+ * those files as "runs on import", which is FALSE, and the baseline of 34 that
+ * produced would have been a list of 29 untruths plus 5 real entries.
+ *
+ * A debt list is only safe while every line is true and has one remedy. So the
+ * two rules divide the tree honestly: rule 1 owns the SPELLING complaint about
+ * these files, rule 2 owns files with no guard at all. Converting a file clears
+ * it from rule 1's map and never touches rule 2's.
+ */
+export function guardAliases(code) {
+  const names = [];
+  const canonical = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*isEntrypoint\s*\(\s*import\.meta\.url\s*\)\s*;/g;
+  let m;
+  while ((m = canonical.exec(code))) names.push(m[1]);
+  const hand = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([^;]*);/g;
+  let h;
+  while ((h = hand.exec(code))) if (HAND_TYPED.test(h[2])) names.push(h[1]);
+  return names;
+}
+
+/**
+ * Named functions whose BODY is an entry-guard test, so `if (invokedAsCli())`
+ * is the same guard behind one more indirection. `scripts/shadcn-sync.js`
+ * writes exactly that, and it is the file objectui#6092 singles out as already
+ * CORRECT — reporting it as running on import would have been the one entry in
+ * a debt list that was both false and pointed at the best-behaved file in the
+ * tree.
+ */
+export function guardPredicates(code) {
+  const names = [];
+  const re = /\bfunction\s+([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\{/g;
+  let m;
+  while ((m = re.exec(code))) {
+    const open = code.indexOf('{', m.index + m[0].length - 1);
+    if (open < 0) continue;
+    let d = 0;
+    let end = -1;
+    for (let i = open; i < code.length; i++) {
+      if (code[i] === '{') d++;
+      else if (code[i] === '}' && --d === 0) {
+        end = i;
+        break;
+      }
+    }
+    if (end < 0) continue;
+    const body = code.slice(open, end);
+    if (HAND_TYPED.test(body) || /isEntrypoint\s*\(\s*import\.meta\.url\s*\)/.test(body)) names.push(m[1]);
+  }
+  return names;
+}
+
+/** A condition that opens with the guard, `!` and all. */
+function guardConditionRe(aliases) {
+  const terms = ['isEntrypoint\\s*\\(\\s*import\\.meta\\.url\\s*\\)'];
+  if (aliases.length) terms.push(`(?:${aliases.map((a) => a.replace(/\$/g, '\\$')).join('|')})\\b`);
+  return new RegExp(`^\\s*(!\\s*)?(?:${terms.join('|')})`);
+}
+
+/** The parenthesised condition of a statement, `''` when there is none. */
+function conditionOf(raw) {
+  const open = raw.indexOf('(');
+  if (open < 0) return '';
+  let depth = 0;
+  for (let i = open; i < raw.length; i++) {
+    if (raw[i] === '(') depth++;
+    else if (raw[i] === ')' && --depth === 0) return raw.slice(open + 1, i);
+  }
+  return '';
+}
+
+/**
+ * An `if` split into the branch that runs when the condition is FALSE-on-import
+ * and the branch that runs when it is true: `{ body, rest }` where `body` is the
+ * first branch and `rest` is every `else` after it.
+ */
+function firstBranch(raw) {
+  const open = raw.indexOf('(');
+  if (open < 0) return null;
+  let d = 0;
+  let condEnd = -1;
+  for (let i = open; i < raw.length; i++) {
+    if (raw[i] === '(') d++;
+    else if (raw[i] === ')' && --d === 0) {
+      condEnd = i;
+      break;
+    }
+  }
+  if (condEnd < 0) return null;
+  const brace = raw.indexOf('{', condEnd);
+  const semi = raw.indexOf(';', condEnd);
+  // A braceless `if (g) f();` ends at its semicolon; a braced one at its `}`.
+  if (brace >= 0 && (semi < 0 || brace < semi)) {
+    let b = 0;
+    for (let i = brace; i < raw.length; i++) {
+      if (raw[i] === '{') b++;
+      else if (raw[i] === '}' && --b === 0) return { body: raw.slice(brace + 1, i), rest: raw.slice(i + 1) };
+    }
+    return { body: raw.slice(brace + 1), rest: '' };
+  }
+  if (semi < 0) return { body: raw.slice(condEnd + 1), rest: '' };
+  return { body: raw.slice(condEnd + 1, semi), rest: raw.slice(semi + 1) };
+}
+
+/**
+ * Is this whole top-level `if` behind the guard? Both spellings count, and they
+ * put the import-time branch in opposite places:
+ *
+ *   if (isMain) { run(); }                     → nothing runs on import
+ *   if (!isMain) { } else if (…) { run(); }    → the FIRST branch runs on import
+ *
+ * so the second form is accepted only when that first branch is empty.
+ */
+export function isGuardedStatement(head, raw, guardRe) {
+  if (!/^if\b/.test(head)) return false;
+  const condition = conditionOf(raw);
+  const m = guardRe.exec(condition);
+  // A condition that IS a hand-typed guard, written inline rather than stored
+  // in a binding — `if (process.argv[1] && resolve(…) === …) { main(); }`, the
+  // shape 12 of this tree's files write. See `guardAliases` for why rule 2
+  // recognises it while rule 1 still fails it.
+  const negated = m ? Boolean(m[1]) : /^\s*!/.test(condition);
+  if (!m && !HAND_TYPED.test(condition)) return false;
+  const split = firstBranch(raw);
+  if (!split) return false;
+  return !runsOnImport(negated ? split.body : split.rest);
+}
+
+/**
+ * Does this statement RUN something, as opposed to declaring something? A call
+ * anywhere in it — including inside the body of a top-level `if`/`for`/`try` —
+ * counts; a bare assignment of a literal (`TABLE[0x00] = 1`, which is how a
+ * lookup table is built) does not.
+ */
+export function runsOnImport(raw) {
+  return CALL_SHAPE.test(raw.replace(KEYWORD_PAREN, ' ('));
+}
+
+/**
+ * Does this masked source export anything? ONE definition, because the census
+ * below needs the same answer and two spellings of it is how a rule ends up
+ * enforced in one path and not the other.
+ */
+export function exportsBindings(code) {
+  return /^export\b/m.test(code);
+}
+
+/**
+ * The top-level statements of `source` that would run on `import`, or `[]` when
+ * the file exports nothing (nobody can import it) or is already inert.
+ */
+export function importUnsafeStatements(source) {
+  const code = codeOnly(source);
+  if (!exportsBindings(code)) return [];
+  const guardRe = guardConditionRe([...guardAliases(code), ...guardPredicates(code)]);
+  const found = [];
+  for (const s of topLevelStatements(code)) {
+    if (DECLARATION_HEAD.test(s.head)) continue;
+    const raw = code.slice(s.start, s.end);
+    if (isGuardedStatement(s.head, raw, guardRe)) continue;
+    if (!runsOnImport(raw)) continue;
+    found.push({ line: lineOf(source, s.start), head: s.head.replace(/\s+/g, ' ').slice(0, 68) });
+  }
+  return found;
+}
+
+/**
+ * ⛔ SHRINK-ONLY. The exporting `scripts/` files whose top level still runs on
+ * import, as measured when this rule landed. A DEBT list, not an exception
+ * list: every entry has the same one-line remedy and none records a judgement
+ * anyone re-makes. A file this rule newly reaches is a failure with one remedy,
+ * never a line in here. An entry whose file has since been fixed fails as STALE
+ * and names itself, which is what stops this from rotting into an allowlist.
+ *
+ * ONE entry, and that is the point: this rule recognises a hand-typed guard AS
+ * a guard (see `guardAliases`), so the 29 badly-spelled files are rule 1's
+ * business and do not appear here. `check-lucide-icon-record-names.mjs` builds
+ * two lookup maps in top-level `for` loops at :242 and :244, outside any guard,
+ * and really does run them inside an importer. That is a true sentence with one
+ * remedy, which is the only kind of line a debt list may carry.
+ */
+const KNOWN_IMPORT_UNSAFE = new Set(['scripts/check-lucide-icon-record-names.mjs']);
+
+/** Every exporting file, with the statements that would run on import. */
+function importSafetyCensus(files) {
+  const rows = [];
+  for (const abs of files) {
+    const rel = relative(REPO_ROOT, abs);
+    const source = readFileSync(abs, 'utf8');
+    if (!exportsBindings(codeOnly(source))) continue;
+    rows.push({ rel, unsafe: importUnsafeStatements(source) });
+  }
+  return rows;
+}
+
+const REMEDY =
+  `\n    Replace the guard with:` +
+  `\n` +
+  `\n      import { isEntrypoint } from './invoked-as.mjs';   // '../invoked-as.mjs' from a subdir` +
+  `\n      if (${CANONICAL}) { ... }` +
+  `\n` +
+  `\n    scripts/invoked-as.mjs carries the rationale and the symlink fixture.`;
+
+function main() {
+  const files = walk(SCRIPTS).sort();
+  const observed = new Map();
+  const sites = new Map();
+  for (const abs of files) {
+    if (abs === SELF) continue; // this file quotes the idioms it bans
+    const rel = relative(REPO_ROOT, abs);
+    const found = scanFile(rel, readFileSync(abs, 'utf8'), { isPredicateHome: abs === PREDICATE_HOME });
+    if (found.length) {
+      observed.set(rel, found.length);
+      sites.set(rel, found);
+    }
+  }
+
+  const { fresh, stale } = reconcileGuards(observed, KNOWN_HAND_TYPED_GUARDS);
+
+  if (fresh.length) {
+    const total = fresh.reduce((n, f) => n + (f.count - f.owed), 0);
+    console.error(`❌  check:entry-guard — ${total} hand-typed entry guard(s) in scripts/ beyond the baseline:\n`);
+    for (const f of fresh) {
+      for (const s of sites.get(f.rel) ?? []) console.error(`  ${s.rel}:${s.line}  ${s.what}  — ${s.why}`);
+      if (f.owed) console.error(`    (${f.rel} is baselined at ${f.owed}; it now carries ${f.count}. The baseline only shrinks.)`);
+    }
+    console.error(
+      `\n    Every scripts/** entry guard goes through ONE predicate, because the` +
+        `\n    hand-typed forms are silently WRONG: node leaves process.argv[1] as the` +
+        `\n    caller typed it, so a script reached through a symlink compares two` +
+        `\n    different paths, answers false, and does nothing — exit 0, no output.` +
+        `\n` +
+        REMEDY +
+        `\n` +
+        `\n    KNOWN_HAND_TYPED_GUARDS is SHRINK-ONLY: adding a line, or raising a` +
+        `\n    number, is not a supported way to make this pass.`,
+    );
+    return 1;
+  }
+
+  if (stale.length) {
+    console.error(`❌  check:entry-guard — ${stale.length} stale KNOWN_HAND_TYPED_GUARDS entry/entries:\n`);
+    for (const s of stale) {
+      console.error(`  ${s.rel}  — baselined at ${s.owed}, now carries ${s.count}`);
+    }
+    console.error(
+      `\n    Good news, and the list must say so: ${stale.some((s) => s.count === 0) ? 'delete the zero lines' : 'lower the numbers'} in` +
+        `\n    KNOWN_HAND_TYPED_GUARDS in scripts/check-entry-guard.mjs (delete the entry` +
+        `\n    when it reaches 0). The list only ever shrinks, and a stale line is how it` +
+        `\n    would have started drifting into an allowlist nobody re-reads.`,
+    );
+    return 1;
+  }
+
+  // ── second kind: an exporting file whose top level runs on import ─────────
+  const census = importSafetyCensus(files);
+  const unsafe = census.filter((r) => r.unsafe.length);
+  const freshUnsafe = unsafe.filter((r) => !KNOWN_IMPORT_UNSAFE.has(r.rel));
+  const reached = new Set(unsafe.map((r) => r.rel));
+  const staleUnsafe = [...KNOWN_IMPORT_UNSAFE].filter((rel) => !reached.has(rel)).sort();
+
+  if (freshUnsafe.length) {
+    console.error(`❌  check:entry-guard — ${freshUnsafe.length} scripts/ file(s) export bindings AND run on import:\n`);
+    for (const r of freshUnsafe) {
+      for (const s of r.unsafe) console.error(`  ${r.rel}:${s.line}  ${s.head}`);
+    }
+    console.error(
+      `\n    A scripts/** file that exports a binding can be imported FOR those` +
+        `\n    exports. Whatever its top level runs then runs inside the importer —` +
+        `\n    and a top-level process.exit(0) ends the importer mid-import, so its` +
+        `\n    caller reads success.` +
+        `\n` +
+        REMEDY +
+        `\n` +
+        `\n    A file that exports nothing is never reached by this rule, and neither` +
+        `\n    is one whose top level only declares. Nothing else is a way out.`,
+    );
+    return 1;
+  }
+
+  if (staleUnsafe.length) {
+    console.error(`❌  check:entry-guard — ${staleUnsafe.length} stale KNOWN_IMPORT_UNSAFE entry/entries:\n`);
+    for (const rel of staleUnsafe) console.error(`  ${rel}  — no longer runs on import`);
+    console.error(
+      `\n    Good news, and the list must say so: delete each line above from` +
+        `\n    KNOWN_IMPORT_UNSAFE in scripts/check-entry-guard.mjs. The list only` +
+        `\n    ever shrinks, and a stale line is how it would have started drifting` +
+        `\n    into an allowlist nobody re-reads.`,
+    );
+    return 1;
+  }
+
+  const owedGuards = [...KNOWN_HAND_TYPED_GUARDS.values()].reduce((a, b) => a + b, 0);
+  const inert = census.length - unsafe.length;
+  console.log(
+    `✓ check:entry-guard: ${files.length} scripts/ file(s) — no entry guard outside the baseline; ` +
+      `${KNOWN_HAND_TYPED_GUARDS.size} file(s) still hand-type one (${owedGuards} occurrence(s), ⛔ SHRINK-ONLY, objectui#6092); ` +
+      `${census.length} export bindings, ${inert} of them inert on import (${unsafe.length} known-unsafe, ⛔ SHRINK-ONLY).`,
+  );
+  return 0;
+}
+
+/** `--list`: what both rules see, for burning the lists down. */
+function list() {
+  const files = walk(SCRIPTS).sort();
+  console.log('── hand-typed entry guards ─────────────────────────────────');
+  for (const abs of files) {
+    if (abs === SELF) continue;
+    const rel = relative(REPO_ROOT, abs);
+    const found = scanFile(rel, readFileSync(abs, 'utf8'), { isPredicateHome: abs === PREDICATE_HOME });
+    if (!found.length) continue;
+    const note = CORRECT_SHAPE_BUT_HAND_TYPED.has(rel) ? '  [correct shape, hand-typed]' : '';
+    console.log(`  ${String(found.length).padStart(2)}  ${rel}${note}`);
+    for (const f of found) console.log(`         :${f.line}  ${f.what}`);
+  }
+  console.log('\n── exporting files, and what runs on import ────────────────');
+  const census = importSafetyCensus(files);
+  for (const r of census.sort((a, b) => a.rel.localeCompare(b.rel))) {
+    const known = KNOWN_IMPORT_UNSAFE.has(r.rel) ? ' [known]' : '';
+    console.log(`${r.unsafe.length ? 'RUNS ' : 'inert'}  ${r.rel}${known}`);
+    for (const s of r.unsafe) console.log(`         :${s.line}  ${s.head}`);
+  }
+  console.log(`\n${census.length} exporting file(s); ${census.filter((r) => r.unsafe.length).length} run on import.`);
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Self-test -- fixture sources, not this tree
+// ---------------------------------------------------------------------------
+
+export function selfTest() {
+  const cases = [];
+  const t = (name, ok, detail) => cases.push({ name, ok: Boolean(ok), detail });
+  const n = (src, opts) => scanFile('f.mjs', src, opts).length;
+
+  // ── the nine spellings measured in THIS tree on 133e2ea1e ─────────────────
+  const SPELLINGS = [
+    'const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));',
+    'const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);',
+    'const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);',
+    'const invokedDirectly = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;',
+    'if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {}',
+    'if (resolve(process.argv[1] ?? "") === resolve(fileURLToPath(import.meta.url))) {}',
+    'if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {}',
+    "if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {}",
+    'if (import.meta.url === `file://${process.argv[1]}`) {}',
+  ];
+  SPELLINGS.forEach((src, i) => t(`spelling ${i + 1} of ${SPELLINGS.length} is rejected`, n(src) > 0, src));
+
+  // The percent-encoding spelling lives inside a TEMPLATE, so it is only
+  // visible through the interpolation-aware view above. Pinned here because
+  // `codeOnly` reverting to `comment || literal` is a one-character change that
+  // makes this gate blind to the worst guard in the tree while staying green.
+  t(
+    'the percent-encoding guard is seen THROUGH the template it is written in',
+    n('if (import.meta.url === `file://${process.argv[1]}`) {}') > 0,
+  );
+  t(
+    '...while a process.argv[1] in the template BODY, outside any interpolation, is not a guard',
+    n('const s = `node x.mjs process.argv[1]`;\n') === 0,
+  );
+
+  // The shape `shadcn-sync.js` writes — CORRECT, and still not the predicate.
+  // Pinned so nobody later decides the gate should "know" a correct two-leg
+  // hand-roll and stop seeing it: it is baselined, not invisible.
+  t(
+    "shadcn-sync.js's correct two-leg shape is still a hand-typed guard",
+    n('const entry = process.argv[1];\nreturn realpathSync(path.resolve(entry)) === __filename;') > 0,
+  );
+
+  // ── the canonical form is accepted ────────────────────────────────────────
+  t('the canonical guard is accepted', n(`if (${CANONICAL}) { main(); }`) === 0);
+  t('a file with no guard at all is accepted', n("console.log('hello');\n") === 0);
+
+  // ── the predicate's own home may read argv ────────────────────────────────
+  t(
+    'invoked-as.mjs itself may read process.argv[1]',
+    n('return invokedAs(process.argv[1], fileURLToPath(u));', { isPredicateHome: true }) === 0,
+  );
+  t(
+    '...and that exemption is NOT extended to any other file',
+    n('return invokedAs(process.argv[1], fileURLToPath(u));') > 0,
+  );
+
+  // ── prose and payloads are not guards ─────────────────────────────────────
+  t('a process.argv[1] in a LINE COMMENT is not a guard', n('// process.argv[1] is left as typed\n') === 0);
+  t('a process.argv[1] in a BLOCK COMMENT is not a guard', n('/**\n * process.argv[1] as typed\n */\n') === 0);
+  t(
+    'a process.argv[1] inside a STRING payload for a child is not a guard',
+    n(`const s = 'require("fs").writeFileSync(process.argv[1], x)';\n`) === 0,
+  );
+  t(
+    'a process.argv[1] inside a TEMPLATE payload is not a guard',
+    n('const s = `node -e "f(process.argv[1])"`;\n') === 0,
+  );
+
+  // ── the other idioms ──────────────────────────────────────────────────────
+  t('require.main is rejected', n('if (require.main === module) {}') > 0);
+  t('import.meta.main is rejected', n('if (import.meta.main) {}') > 0);
+  t('process.mainModule is rejected', n('if (process.mainModule === module) {}') > 0);
+
+  // ── the call shape ────────────────────────────────────────────────────────
+  t('isEntrypoint on someone else’s url is rejected', n('if (isEntrypoint(other.url)) {}') > 0);
+  t('isEntrypoint(import.meta.url) is accepted', n('if (isEntrypoint(import.meta.url)) {}') === 0);
+  t(
+    'the DECLARATION of the predicate is not read as a call on someone else',
+    n('export function isEntrypoint(importMetaUrl) {\n  return invokedAs(process.argv[1], u);\n}', { isPredicateHome: true }) === 0,
+  );
+
+  // ── the line number is the one a reader can open ──────────────────────────
+  const multi = 'line one\nline two\nconst g = process.argv[1] === x;\n';
+  t('a finding reports the line the guard is ON', scanFile('f.mjs', multi)[0]?.line === 3, JSON.stringify(scanFile('f.mjs', multi)));
+
+  // ── the baseline, driven directly ─────────────────────────────────────────
+  //
+  // THE NON-VACUITY CONTROL. This gate lands on a tree it does not enforce yet:
+  // 29 hand-typed guards are baselined as owed. A baseline that accepted its
+  // own contents AND everything after them would be worth nothing, and a run
+  // over today's green tree cannot tell the two apart. So recognition is pinned
+  // here, positively, in every direction the baseline can move.
+  const base = new Map([['scripts/a.mjs', 2]]);
+  const r = (obs) => reconcileGuards(new Map(obs), base);
+  t('the baseline accepts exactly what it owes', r([['scripts/a.mjs', 2]]).fresh.length === 0 && r([['scripts/a.mjs', 2]]).stale.length === 0);
+  t('a THIRTIETH guard, in a file the baseline never named, is FRESH', r([['scripts/a.mjs', 2], ['scripts/new.mjs', 1]]).fresh.some((f) => f.rel === 'scripts/new.mjs'));
+  t(
+    '...and the finding says it owed nothing',
+    r([['scripts/a.mjs', 2], ['scripts/new.mjs', 1]]).fresh.find((f) => f.rel === 'scripts/new.mjs')?.owed === 0,
+  );
+  t('a SECOND guard smuggled into an already-owed file is FRESH', r([['scripts/a.mjs', 3]]).fresh.length === 1);
+  t('...which a path-only baseline could not have seen', r([['scripts/a.mjs', 3]]).fresh[0]?.owed === 2);
+  t('a file that lost one guard is STALE, not silently accepted', r([['scripts/a.mjs', 1]]).stale.length === 1);
+  t('a file that lost them all is STALE', r([]).stale[0]?.count === 0);
+  t('...and STALE is never also FRESH', r([]).fresh.length === 0);
+
+  // ── the second kind: an EXPORTING file whose top level runs on import ────
+  //
+  // Asserted POSITIVELY in both directions. This gate prints files SCANNED, not
+  // files recognised, so "the count moved" is not evidence available to a reader.
+  const u = (src) => importUnsafeStatements(src).length;
+  const first = (src) => importUnsafeStatements(src)[0];
+
+  // reject side
+  t('an exporting file whose top level dispatches is REJECTED', u('export function f() {}\nmain();\n') === 1);
+  t('...and the finding names the statement', first('export function f() {}\nmain();\n')?.head === 'main()');
+  t('...and reports the line the statement is ON', first('export const a = 1;\n\nmain();\n')?.line === 3);
+  t('a top-level process.exit() in an exporting file is rejected', u('export const a = 1;\nprocess.exit(main());\n') === 1);
+  t(
+    'a top-level argv branch in an exporting file is rejected',
+    u("export const a = 1;\nif (process.argv.includes('--self-test')) { selfTest(); }\n") === 1,
+  );
+  t('a top-level try/catch that runs is rejected', u('export const a = 1;\ntry { main(); } catch (e) { report(e); }\n') === 1);
+  t(
+    'a guard on someone else’s url does not make a dispatch inert',
+    u('export const a = 1;\nif (isEntrypoint(other.url)) { main(); }\n') === 1,
+  );
+
+  // accept side — every one of these is a real shape in scripts/, and none of
+  // them costs an allowlist entry.
+  t('a file that exports NOTHING is not reached', u('main();\nprocess.exit(0);\n') === 0);
+  t('a module of declarations only is not reached', u("export const A = new Set(['x']);\nexport function f(x) { return g(x); }\n") === 0);
+  t(
+    'a const initializer that calls is a declaration, not a dispatch',
+    u("export const HERE = resolve(fileURLToPath(import.meta.url), '..');\n") === 0,
+  );
+  t('a top-level literal assignment is not a dispatch', u("export const T = [];\nT[0] = 1;\nfor (const c of 'ab') T[c] = 0;\n") === 0);
+  t('the canonical guard makes the dispatch inert', u(`export const a = 1;\nif (${CANONICAL}) { process.exit(main()); }\n`) === 0);
+  t('a braceless guarded dispatch is accepted', u(`export const a = 1;\nif (${CANONICAL}) main();\n`) === 0);
+  t('a guard stored in a const is the same guard', u(`export const a = 1;\nconst isMain = ${CANONICAL};\nif (isMain) { main(); }\n`) === 0);
+  t(
+    '...including with a further conjunct',
+    u(`export const a = 1;\nconst isMain = ${CANONICAL};\nif (isMain && !process.argv.includes('--x')) { main(); }\n`) === 0,
+  );
+  t(
+    'the INVERTED guard with an empty import branch is accepted',
+    u(`export const a = 1;\nconst m = ${CANONICAL};\nif (!m) {\n  // imported — do nothing\n} else if (process.argv.includes('--x')) {\n  selfTest();\n} else {\n  main();\n}\n`) === 0,
+  );
+  t(
+    '...and REJECTED when that import branch runs after all',
+    u(`export const a = 1;\nconst m = ${CANONICAL};\nif (!m) {\n  warmCache();\n} else {\n  main();\n}\n`) === 1,
+  );
+
+  // ── rule 2 recognises a hand-typed guard AS a guard (the port's divergence)
+  //
+  // Pinned in both directions. Recognition here is what keeps rule 2's debt
+  // list TRUE while the tree is unswept; rule 1 is where these files are still
+  // failed, and its own cases above assert that.
+  t(
+    'an INLINE hand-typed guard makes a dispatch inert for rule 2',
+    u('export const a = 1;\nif (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) { main(); }\n') === 0,
+  );
+  t(
+    'a hand-typed guard STORED in a const is the same guard for rule 2',
+    u('export const a = 1;\nconst invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);\nif (invokedDirectly) { main(); }\n') === 0,
+  );
+  t(
+    'a hand-typed guard behind a named PREDICATE is the same guard for rule 2',
+    u('export const a = 1;\nfunction invokedAsCli() {\n  const e = process.argv[1];\n  return realpathSync(e) === __filename;\n}\nif (invokedAsCli()) { main(); }\n') === 0,
+  );
+  t(
+    '...and rule 1 still FAILS every one of those spellings',
+    n('if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) { main(); }') > 0 &&
+      n('function invokedAsCli() { return process.argv[1] === __filename; }') > 0,
+  );
+  t(
+    'a predicate that does NOT test entry is not a guard',
+    u('export const a = 1;\nfunction ready() { return true; }\nif (ready()) { main(); }\n') === 1,
+  );
+  t(
+    'an INVERTED hand-typed guard whose import branch runs is still rejected',
+    u('export const a = 1;\nconst m = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);\nif (!m) {\n  warmCache();\n} else {\n  main();\n}\n') === 1,
+  );
+
+  // ── the slicer, driven directly ──────────────────────────────────────────
+  t('an import declaration is ONE top-level statement', topLevelStatements(codeOnly("import { a, b } from 'x';\n")).length === 1);
+  t('a destructuring declaration is ONE top-level statement', topLevelStatements(codeOnly('const { a } = f();\n')).length === 1);
+  t('else continues the statement before it', topLevelStatements(codeOnly('if (a) { x(); } else { y(); }\n')).length === 1);
+  t('catch continues the statement before it', topLevelStatements(codeOnly('try { x(); } catch (e) { y(); }\n')).length === 1);
+
+  // ── the labelled entry is really in the baseline it is labelled against ──
+  // A label naming a file the map does not carry is a sentence about nothing,
+  // which is the failure mode this whole card exists to stop.
+  for (const rel of CORRECT_SHAPE_BUT_HAND_TYPED) {
+    t(`${rel} is labelled AND baselined, not just labelled`, KNOWN_HAND_TYPED_GUARDS.has(rel), rel);
+  }
+
+  const failed = cases.filter((c) => !c.ok);
+  for (const c of failed) console.error(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+  if (failed.length) {
+    console.error(`✗ check-entry-guard self-test: ${failed.length} of ${cases.length} case(s) failed.`);
+    return 1;
+  }
+  console.log(
+    `✓ check-entry-guard self-test: ${cases.length} cases pass — all ${SPELLINGS.length} spellings measured in this tree rejected, ` +
+      `canonical form and masked prose/payloads accepted, the shrink-only baseline pinned in every direction it can move ` +
+      `(a thirtieth guard is FRESH, a second guard in an owed file is FRESH, a removed one is STALE), ` +
+      `and the import-safety rule recognised on both sides.`,
+  );
+  return 0;
+}
+
+if (isEntrypoint(import.meta.url)) {
+  const argv = process.argv;
+  process.exit(argv.includes('--self-test') ? selfTest() : argv.includes('--list') ? list() : main());
+}

--- a/scripts/js-comment-mask.mjs
+++ b/scripts/js-comment-mask.mjs
@@ -1,0 +1,589 @@
+#!/usr/bin/env node
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * js-comment-mask -- the ONE answer to "is this span a comment, or code?"
+ *
+ *   node scripts/js-comment-mask.mjs --self-test
+ *
+ * Every source-scanning gate in this tree has to separate code from prose
+ * before it decides anything: a docblock naming a retired error code is not a
+ * producer of that code, and a paragraph explaining why an alias is wrong is
+ * not an alias. Each gate used to answer that question with its own private
+ * `stripComments`, and the copies had drifted into two families with two
+ * different failure modes -- both silent, and in opposite directions.
+ *
+ * ## The two families, and why neither was safe
+ *
+ * **Naive regex** -- `src.replace(/\/\*[\s\S]*?\*\//g, '')` and a `//`-to-end-
+ * of-line rule. A regex has no idea what a string literal is, so any source
+ * carrying a block-comment OPENER inside a string opens a PHANTOM comment that
+ * runs to the next real terminator, usually a docblock far below, deleting every
+ * line of real code in between. The trigger shapes are ordinary: a glob, a route wildcard, a URL
+ * (the `//` rule), a `/*` mentioned inside a template. The gate then reports
+ * clean over code it never looked at -- the failure direction AGENTS.md names
+ * as worse than no verifier at all, because it reports success.
+ *
+ * **String-aware scanner, regex-blind** -- tracks strings and templates, but
+ * treats a `/` as division. A regex literal whose character class holds a quote
+ * character (`/["'`]/` -- and this tree really writes those) opens a phantom
+ * STRING instead. Because a scanner SKIPS string spans, every comment inside
+ * the phantom span is never blanked, and the gate reads genuinely commented-out
+ * text as live code: it FABRICATES a hit rather than missing one. A backtick is
+ * the worst of them, because a template is not line-bounded and the phantom
+ * span runs to the next backtick, or to end of file.
+ *
+ * So the two questions are one question, and a scanner has to know about all
+ * three literal forms to answer it. That is what lives here, once.
+ *
+ * ## Blank, never delete
+ *
+ * Comment spans are replaced with spaces, newlines kept, so every byte offset
+ * and every line number survives the mask. A gate that deletes comments reports
+ * findings against line numbers that no longer exist in the file it read, and
+ * the drift is invisible until someone opens the file at the reported line.
+ *
+ * ## The direction it fails in -- a guarantee this module once claimed falsely
+ *
+ * Over-masking is the direction to fail in: a gate that over-masks under-
+ * reports loudly the next time someone re-derives its scope, while a gate that
+ * under-masks manufactures findings out of prose and burns a reader's
+ * afternoon proving the sentence it quoted meant the opposite.
+ *
+ * This header used to state that as a property -- "cannot fabricate a lead".
+ * It was not one. Measured in OBJECTSTACK's tree on 2026-08-21
+ * (objectstack#10427): walk every `.{ts,tsx,mts,cts,js,mjs,cjs,jsx}` file
+ * (minus `node_modules`, `dist`, `.next`, `build`, `.turbo`, `coverage`), parse
+ * each with `@typescript-eslint/parser` (`{ comment: true, range: true }`), and
+ * diff the comment ranges it reports against this scan's `comment` array byte
+ * for byte. Over 4,739 files, 16 disagreed -- 15 in the FABRICATES direction,
+ * up to 10,252 comment bytes handed to a caller as live code in a single file.
+ * The cause was the template scan above; the same sweep after the fix disagrees
+ * on 0 files.
+ *
+ * ## What is NOT here, said plainly
+ *
+ * In objectstack that sweep is a script -- `scripts/check-comment-mask-corpus.mjs`
+ * -- wired into its CI, carrying a `--masker <path>` control that re-derives the
+ * 16 files above against the pre-fix implementation. **That script is not ported
+ * to objectui and nothing in this repository runs it.** The measurement quoted
+ * above was made against objectstack's tree, not this one.
+ *
+ * This paragraph is written negatively on purpose. `scripts/invoked-as.mjs`
+ * arrived in this repository from the same upstream carrying a header that
+ * named a gate as its enforcement; the gate had not been ported, and a reader
+ * reasonably concluded the tree was already enforced when it was not
+ * (objectui#6078). A ported header that names an absent file is the defect, so
+ * the honest form is to name it AND say it is absent.
+ *
+ * What holds in THIS tree is the self-test at the bottom of this file, run by
+ * `node scripts/js-comment-mask.mjs --self-test`, plus whatever its callers'
+ * own self-tests assert. That is a set of shapes someone thought of -- it is
+ * strictly weaker than a corpus sweep, and no claim here should be read as
+ * covering shapes nobody wrote a case for.
+ *
+ * The lesson is about the claim, not the bug. A failure DIRECTION is a
+ * property of an implementation, not of an intention, and this one could not be
+ * read off the code -- it took an independent parser over a whole tree to find
+ * out which way the module actually failed. So the honest statement is the one
+ * that can be re-derived: the shapes below are pinned, and neither direction is
+ * promised by construction.
+ *
+ * Both mutation directions were measured upstream in one sitting
+ * (objectstack#10640): deleting the brace counting inside `${...}` fails a case
+ * below, while dropping `return` from `REGEX_AFTER_KEYWORD` passes all of them
+ * and is caught only by the corpus sweep. The shape that mutation misreads is
+ * live in THIS tree too -- `scripts/check-changeset-presence.mjs:555` and
+ * `scripts/check-doc-links.mjs:616` both write `return /.../` today -- so in
+ * objectui that mutation is undetected by anything that runs. Recorded as a
+ * known limit of the port, not as coverage.
+ */
+
+/** A character that can end an identifier -- i.e. a value, so `/` is division. */
+import { isEntrypoint } from './invoked-as.mjs';
+
+const IDENT_CHAR = /[\w$]/;
+
+/**
+ * Keywords after which a `/` opens a REGEX, not a division. `return /x/` reads
+ * as a value character followed by a slash, and only the keyword tells them
+ * apart. Measured cost of omitting this: a gate whose corpus contained
+ * `return /["`]/.test(s)` fabricated hits out of every comment below it.
+ */
+const REGEX_AFTER_KEYWORD = new Set([
+  'return', 'typeof', 'instanceof', 'in', 'of', 'case', 'delete', 'void',
+  'yield', 'await', 'new', 'do', 'else', 'throw',
+]);
+
+/**
+ * One left-to-right pass over a JS source, flagging every character as COMMENT
+ * content and/or LITERAL content (inside a string, template or regex). Both
+ * come back as same-length byte arrays, so a caller can blank a span without
+ * moving any other offset.
+ *
+ * The literal flag covers a literal's CONTENT, not its delimiters, so a caller
+ * blanking comments still sees every string intact. Template interiors are
+ * reported as literal through `${...}` as well, so a caller reading raw
+ * characters sees them either way.
+ *
+ * That is the FLAG. The SCAN of an interpolation is not the same question, and
+ * conflating the two is the defect objectstack#10427 measured: `${...}` was walked as
+ * plain literal text on the reasoning that its braces are balanced by
+ * construction, which is true of the braces and false of everything else the
+ * interpolation may hold. It is code, so it can hold a nested template
+ * (``${xs.map((x) => `<${x}>`)}``, exactly how this tree formats a list of
+ * names), a backtick inside a regex or a string (`packages/cli`'s `quoteIdent`
+ * writes both), or a brace inside a string. Reading a nested opener as the
+ * outer template's CLOSER flipped the parity of every backtick after it, and
+ * the phantom span ran to the next backtick anywhere in the file. So the
+ * interpolation is scanned as code here -- the same loop, with the same string,
+ * regex and comment branches -- and its bytes are flagged literal at the end.
+ *
+ * @param {string} source
+ * @returns {{ comment: Uint8Array, literal: Uint8Array }}
+ */
+export function scanSource(source) {
+  const n = source.length;
+  const comment = new Uint8Array(n);
+  const literal = new Uint8Array(n);
+  // The code bytes INSIDE `${...}` — see the closing block of this function.
+  const interpolation = new Uint8Array(n);
+  let i = 0;
+  let prev = ''; // last significant CODE character
+  let word = ''; // ...and the identifier it is the tail of, if any
+
+  // Open templates, innermost last. `braces` is the `{` depth inside the
+  // frame's CURRENT interpolation: 0 means the scanner is in that template's
+  // literal BODY, and > 0 means it is inside `${...}`, where the language says
+  // the bytes are code. `start` is where that `${` began.
+  const templates = [];
+  // Closed `${...}` spans, flushed to `literal` after the pass -- see the
+  // closing block of this function for why they are not flagged inline.
+  const interpolations = [];
+
+  // A shebang is a comment to node; it is also the one line whose slashes are
+  // neither division nor a regex.
+  if (source.startsWith('#!')) {
+    while (i < n && source[i] !== '\n') comment[i++] = 1;
+  }
+
+  while (i < n) {
+    const frame = templates.length ? templates[templates.length - 1] : null;
+
+    // A template's literal BODY: every byte is content until `${` opens an
+    // interpolation, a backtick closes the template, or the file ends.
+    if (frame && frame.braces === 0) {
+      const ch = source[i];
+      if (ch === '\\' && i + 1 < n) {
+        literal[i] = 1;
+        literal[++i] = 1;
+        i++;
+        continue;
+      }
+      if (ch === '`') {
+        templates.pop();
+        // A NESTED template's delimiters are the outer template's content.
+        if (templates.length) literal[i] = 1;
+        i++;
+        prev = 'x'; // a value just ended
+        word = '';
+        continue;
+      }
+      if (ch === '$' && source[i + 1] === '{') {
+        literal[i] = 1;
+        literal[i + 1] = 1;
+        frame.braces = 1;
+        frame.start = i;
+        i += 2;
+        prev = ''; // `${/re/.test(x)}` -- the interpolation starts a fresh expression
+        word = '';
+        continue;
+      }
+      literal[i] = 1;
+      i++;
+      continue;
+    }
+
+    const c = source[i];
+    const next = source[i + 1];
+
+    if (c === '/' && next === '/') {
+      while (i < n && source[i] !== '\n') comment[i++] = 1;
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      comment[i++] = 1;
+      comment[i++] = 1;
+      while (i < n && !(source[i] === '*' && source[i + 1] === '/')) comment[i++] = 1;
+      if (i < n) comment[i++] = 1;
+      if (i < n) comment[i++] = 1;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      i++; // the opening quote is code, so a caller can still pair it
+      while (i < n && source[i] !== c && source[i] !== '\n') {
+        literal[i] = 1;
+        if (source[i] === '\\' && i + 1 < n) literal[++i] = 1;
+        i++;
+      }
+      if (i < n && source[i] === c) i++;
+      prev = 'x'; // a value just ended
+      word = '';
+      continue;
+    }
+    if (c === '`') {
+      // A template OPENS here -- at the top level, or nested inside a `${...}`
+      // this same loop is already reading as code. The body, and the matching
+      // closer, are handled by the template-body branch above.
+      if (templates.length) literal[i] = 1;
+      templates.push({ braces: 0, start: -1 });
+      i++;
+      continue;
+    }
+    if (c === '/' && !(IDENT_CHAR.test(prev) || prev === ')' || prev === ']')) {
+      i++; // regex literal: `/` after anything that is not a value
+      let inClass = false;
+      while (i < n && source[i] !== '\n') {
+        const ch = source[i];
+        if (ch === '\\' && i + 1 < n) {
+          literal[i] = 1;
+          literal[++i] = 1;
+          i++;
+          continue;
+        }
+        if (ch === '[') inClass = true;
+        else if (ch === ']') inClass = false;
+        else if (ch === '/' && !inClass) break;
+        literal[i] = 1;
+        i++;
+      }
+      if (i < n && source[i] === '/') i++;
+      prev = 'x';
+      word = '';
+      continue;
+    }
+    if (c === '/' && REGEX_AFTER_KEYWORD.has(word)) {
+      // `return /x/` -- a value character precedes, but it is a keyword.
+      prev = '';
+      word = '';
+      continue; // re-read this `/` with prev cleared, as a regex
+    }
+    // Inside `${...}`: balance the braces, so the interpolation ends at ITS
+    // `}` and not at one quoted inside it. A `{` or `}` in a string, regex or
+    // comment never reaches here -- its own branch consumed it already.
+    if (frame && frame.braces > 0) {
+      if (c === '{') frame.braces++;
+      else if (c === '}' && --frame.braces === 0) {
+        interpolations.push([frame.start, i + 1, true]);
+        frame.start = -1;
+      }
+    }
+    if (!/\s/.test(c)) {
+      prev = c;
+      word = IDENT_CHAR.test(c) ? word + c : '';
+    }
+    i++;
+  }
+
+  // `${...}` is CODE to the language, and the scan above reads it as code so a
+  // backtick quoted inside it cannot flip the template's parity. The flag it
+  // reports is the documented one: an interpolation's bytes are the enclosing
+  // template's LITERAL content, marked in one pass at the end because the span
+  // is only known once its closing brace is found. An unterminated one (EOF
+  // inside `${`) still gets flagged, so truncated source cannot leak code
+  // bytes into a caller's "this is not a literal" test.
+  for (const frame of templates) if (frame.braces > 0 && frame.start >= 0) interpolations.push([frame.start, n, false]);
+  // Snapshot BEFORE the blanket flush below: a byte the scan already called a
+  // literal (a nested template's body, a quoted string inside the expression)
+  // is content wherever it sits, and must not come back as code.
+  const wasLiteral = literal.slice();
+  for (const [start, end] of interpolations) for (let k = start; k < end; k++) literal[k] = 1;
+
+  // ── `interpolation`: the third array, and why it is not just `!literal` ──
+  //
+  // ADDED IN OBJECTUI (objectui#6092); objectstack's copy of this module does
+  // not carry it. `literal` above is the DOCUMENTED answer and does not move:
+  // an interpolation's bytes are the enclosing template's literal content, and
+  // every existing caller keeps exactly the mask it had.
+  //
+  // But that answer is wrong for one question, and the question is load-bearing
+  // enough to have been the thing that made this port necessary. A guard
+  // written
+  //
+  //   import.meta.url === `file://${process.argv[1]}`
+  //
+  // is the spelling that goes inert with NO SYMLINK AT ALL — it percent-encodes
+  // apart from `argv[1]` in any directory whose name needs encoding — and it is
+  // written in this tree today, at `scripts/check-node-esm-load.mjs:847`. Under
+  // `comment || literal` those bytes are prose, so a gate scanning for
+  // hand-typed guards reads that line as a string and reports clean. Measured:
+  // the first cut of `check-entry-guard.mjs` listed 28 of the tree's 29 guards
+  // and silently omitted exactly this one — the worst of them.
+  //
+  // So this array marks the bytes an interpolation contributes as CODE, which
+  // a caller can subtract from `literal` to get a view the language would
+  // execute. It is NOT `!literal`: the `${` and its closing `}` stay masked, so
+  // a caller counting brackets over the subtracted view stays balanced, and a
+  // NESTED template's body inside the interpolation stays masked too, because
+  // those bytes really are content. Both exclusions are pinned in the
+  // self-test; without them the subtracted view either desyncs a bracket
+  // counter or hands back string content as code, which is the fabrication
+  // direction this module's header calls the worse one.
+  for (const [start, end, terminated] of interpolations) {
+    // `[start, end)` spans `${` … `}`; the interior is what the language runs.
+    // An unterminated span (EOF inside `${`) has no closing brace to skip.
+    const stop = terminated ? end - 1 : end;
+    for (let k = start + 2; k < stop; k++) if (!wasLiteral[k]) interpolation[k] = 1;
+  }
+  // ── the delimiters of EVERY span, including a nested one ────────────────
+  //
+  // A second pass, and it is not tidiness. `${a ${b} c}` cannot happen, but
+  // `${xs.map((v) => `n${v}`)}` does: the INNER `${` is flagged literal inline
+  // by its own template frame, while the inner `}` is only reached by the
+  // blanket flush — so the inner `}` looked like interior code of the OUTER
+  // span and came back as a brace with no opener. Measured while porting: it
+  // desynced `check-entry-guard.mjs`'s top-level statement slicer badly enough
+  // that four files whose dispatch really is guarded were reported as running
+  // on import. A delimiter is a delimiter no matter whose interior it sits in.
+  for (const [start, end, terminated] of interpolations) {
+    interpolation[start] = 0;
+    if (start + 1 < n) interpolation[start + 1] = 0;
+    if (terminated) interpolation[end - 1] = 0;
+  }
+  return { comment, literal, interpolation };
+}
+
+/** Replace every flagged character with a space, keeping newlines and offsets. */
+export function blank(source, flags) {
+  const out = source.split('');
+  for (let k = 0; k < out.length; k++) if (flags[k] && out[k] !== '\n') out[k] = ' ';
+  return out.join('');
+}
+
+/**
+ * The source with its COMMENT characters REMOVED but every newline kept.
+ *
+ * The same scanner as `maskComments`, projected differently: line NUMBERS
+ * survive (a comment line becomes an empty line) but byte offsets do not, and
+ * the text gets much shorter.
+ *
+ * ## Why both projections exist, measured
+ *
+ * Blanking is the safer default and the only one that can carry a byte offset.
+ * But a caller that scans the result with a lazy regex pays for every byte the
+ * mask leaves behind: `check-test-source-alias.mjs` matches imports with
+ * `(?:import|export)\s+([\s\S]*?)\s*from` , and a lazy `[\s\S]*?` walked
+ * across the whitespace runs blanking leaves is quadratic in the comment bytes.
+ * Converting that gate to `maskComments` alone took its runtime from 6.4s to
+ * 5m27s on this tree -- same verdict, 51x the cost. Deleting the comment
+ * characters instead restores it, and that gate reports package-level findings,
+ * so it never needed the offsets.
+ *
+ * Pick by what the caller does with the result: reports a LINE or an offset
+ * into the original text -> `maskComments`; feeds a scanner and reports neither
+ * -> `stripComments`.
+ */
+export function stripComments(source) {
+  const { comment } = scanSource(source);
+  let out = '';
+  for (let k = 0; k < source.length; k++) {
+    if (!comment[k] || source[k] === '\n') out += source[k];
+  }
+  return out;
+}
+
+/**
+ * The source with its COMMENT spans blanked -- line, block and shebang.
+ *
+ * Strings, templates and regex literals are left INTACT: a gate's signal is
+ * usually itself a string literal, so "drop everything quoted" would erase the
+ * thing being looked for. Only prose goes.
+ */
+export function maskComments(source) {
+  return blank(source, scanSource(source).comment);
+}
+
+// ---------------------------------------------------------------------------
+// Self-test -- the shapes, not the corpus
+// ---------------------------------------------------------------------------
+
+/**
+ * A green run over today's tree proves only that today's tree lacks the shape.
+ * These cases ARE the contract, and each one is valid JavaScript, so the
+ * expected answer is the one the language gives rather than the one a
+ * particular implementation happens to produce.
+ *
+ * `REAL` marks source that must SURVIVE the mask (dropping it BLINDS the gate);
+ * `GHOST` marks genuinely commented-out text that must NOT survive (keeping it
+ * makes the gate FABRICATE a finding out of prose).
+ */
+export function selfTest() {
+  const BT = String.fromCharCode(96); // backtick, kept out of the literal below
+  const cases = [
+    ['string containing a block-comment opener',
+      ["const AUTH = '/api/v1/auth/*';", "err.code = 'REAL';", '/** docblock far below */'].join('\n')],
+    ['URL inside a string',
+      "const DOCS = 'https://objectstack.ai/docs'; err.code = 'REAL';"],
+    ['bare // inside a string',
+      "const GLOB = 'packages//src'; err.code = 'REAL';"],
+    ['block-comment opener inside a template literal',
+      ['const HINT = ' + BT + 'use /* to open a block comment' + BT + ';', "err.code = 'REAL';", '/** doc */'].join('\n')],
+    ['regex character class holding a double quote',
+      ['const Q = /["\'' + BT + ']/g;', "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['regex character class holding a BACKTICK first',
+      ['const Q = /[' + BT + '\'"]/g;', "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['markdown regex carrying a backtick',
+      ['const H = /^(#{1,6})\\s(.*)$|^(' + BT + '{3,})/gm;', "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['regex literal containing an escaped //',
+      "const P = /https:\\/\\//; err.code = 'REAL';"],
+    ['line comment immediately after a colon',
+      ["const m = { a:// err.code = 'GHOST'", "  1 };", "err.code = 'REAL';"].join('\n')],
+    ['regex literal after the `return` keyword',
+      ['function f(s) { return /["' + BT + ']/.test(s); }', "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['regex literal after the `case` keyword',
+      ["switch (true) { case /['" + BT + "]/.test(x): break; }", "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['shebang is a comment',
+      ['#!/usr/bin/env node', "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['division after a paren, then a quote-bearing regex',
+      ['const r = (a) / b;', 'const q = /["' + BT + ']/g;', "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    // Templates whose interior puts a real backtick where a flat scan expects
+    // the closer. Each pins BOTH sides: a genuine comment that must go, and
+    // live code after it that must stay. A parity flip anywhere in the line
+    // moves one of the two, so neither assertion can pass by accident.
+    ['nested template inside an interpolation',
+      ['const g = ' + BT + '${xs.map((x) => ' + BT + '\\' + BT + '${x}\\' + BT + BT + ").join(', ')} tail" + BT + ';',
+        "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['escaped backtick inside a template, without nesting',
+      ['const t = ' + BT + 'a \\' + BT + ' b' + BT + ';',
+        "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    // Depth alone is NOT a defect shape: matched backticks pair off whatever a
+    // scan believes about nesting, and this case stayed green under every
+    // mutation of the fix that produced it (objectstack#10427). It is here for coverage of
+    // the depth-2 path. The shapes that DO discriminate are the ones below,
+    // where nesting meets an escape or a quoted backtick and the pairing breaks.
+    ['template nested inside a nested template',
+      ['const d = ' + BT + '${rows.map((r) => ' + BT + '${r.cells.map((c) => ' + BT + '<${c}>' + BT + ").join('')}" + BT + ").join('')}" + BT + ';',
+        "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['template spanning lines, carrying a nested template',
+      ['const m = ' + BT + 'head',
+        '  ${xs.map((x) => ' + BT + '\\' + BT + '${x}\\' + BT + BT + ").join(', ')}",
+        'tail' + BT + ';', "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    // The interpolation is CODE, so a backtick or a brace QUOTED inside it is
+    // neither a delimiter nor a nesting level. Both shapes are live in this
+    // tree (`quoteIdent` in packages/cli writes the first one verbatim), and a
+    // scan that only counts `${`/`}` desyncs on both.
+    ['a backtick inside a regex inside an interpolation',
+      ['const q = ' + BT + '\\' + BT + '${name.replace(/' + BT + "/g, '" + BT + BT + "')}\\" + BT + BT + ';',
+        "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['an object literal, then a nested template, in one interpolation',
+      ['const o = ' + BT + '${fmt({ a: 1 }, ' + BT + '\\' + BT + BT + ')} tail' + BT + ';',
+        "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['a brace and a backtick quoted inside an interpolation',
+      ['const b = ' + BT + "${fmt({ a: 1 }, '" + BT + "')} tail" + BT + ';',
+        "/* err.code = 'GHOST' */", "err.code = 'REAL';"].join('\n')],
+    ['a real comment inside an interpolation',
+      ['const c = ' + BT + "${x /* err.code = 'GHOST' */} tail" + BT + ';', "err.code = 'REAL';"].join('\n')],
+    ['a genuine docblock is still removed',
+      ['/** Retired: err.code = ' + "'GHOST'" + ' must never come back. */', "err.code = 'REAL';"].join('\n')],
+    ['a genuine line comment is still removed',
+      ["// err.code = 'GHOST'", "err.code = 'REAL';"].join('\n')],
+  ];
+
+  // Both projections are driven, on every shape: they share one scanner, so a
+  // shape either family gets wrong is a scanner bug, and a disagreement between
+  // them about what IS a comment is the thing that must never ship.
+  let failed = 0;
+  for (const [name, src] of cases) {
+    const masked = maskComments(src);
+    const stripped = stripComments(src);
+    const problems = [];
+    for (const [proj, out] of [['mask', masked], ['strip', stripped]]) {
+      if (/REAL/.test(src) && !/REAL/.test(out)) problems.push(`${proj}: BLINDS (real code removed)`);
+      if (/GHOST/.test(src) && /GHOST/.test(out)) problems.push(`${proj}: FABRICATES (comment text survived)`);
+      if (src.split('\n').length !== out.split('\n').length) problems.push(`${proj}: line count changed`);
+    }
+    if (masked.length !== src.length) problems.push(`mask: offset drift (${src.length} -> ${masked.length})`);
+    if (stripped.length > src.length) problems.push('strip: grew');
+    if (problems.length) failed++;
+    console.log(`  ${problems.length ? '\u2717' : '\u2713'} ${name}${problems.length ? ' -- ' + problems.join('; ') : ''}`);
+  }
+
+  // ── the `interpolation` array (objectui#6092) ────────────────────────────
+  //
+  // Driven directly rather than through the GHOST/REAL corpus above, because
+  // the property is about a SUBTRACTED view (`literal` minus `interpolation`)
+  // that no existing caller asks for. Every case states what the view must
+  // contain and what it must NOT — a one-sided assertion here would pass on an
+  // array that flags everything.
+  const codeView = (src) => {
+    const { comment, literal, interpolation } = scanSource(src);
+    const flags = new Uint8Array(src.length);
+    for (let k = 0; k < flags.length; k++) flags[k] = comment[k] || (literal[k] && !interpolation[k]);
+    return blank(src, flags);
+  };
+  const extra = [];
+  const x = (name, ok, detail) => extra.push([name, Boolean(ok), detail]);
+
+  const guard = 'if (import.meta.url === ' + BT + 'file://${process.argv[1]}' + BT + ') {}';
+  x('the percent-encoding guard is CODE in the subtracted view', codeView(guard).includes('process.argv[1]'), codeView(guard));
+  // The documented `comment || literal` view — what every existing caller
+  // computes, and the reason the third array had to exist at all.
+  const documentedView = (src) => {
+    const { comment, literal } = scanSource(src);
+    const flags = new Uint8Array(src.length);
+    for (let k = 0; k < flags.length; k++) flags[k] = comment[k] || literal[k];
+    return blank(src, flags);
+  };
+  x('...and still a LITERAL under the documented comment||literal view, which is unchanged',
+    !documentedView(guard).includes('process.argv[1]'), documentedView(guard));
+  x('the template body around it stays masked', !codeView(guard).includes('file://'), codeView(guard));
+
+  const delim = 'const s = ' + BT + 'a${ b }c' + BT + ';';
+  const dv = codeView(delim);
+  x('the ${ and } delimiters stay masked, so a bracket counter stays balanced',
+    (dv.match(/[{}]/g) || []).length === 0, dv);
+  x('...while the expression inside them is code', dv.includes('b'), dv);
+
+  const nested = 'const t = ' + BT + '${xs.map((v) => ' + BT + 'x${v}y' + BT + ').join("")}' + BT + ';';
+  const nv = codeView(nested);
+  x('a NESTED template body inside an interpolation stays masked', !nv.includes('x') || !/x\$?\{?v/.test(nv), nv);
+  x('...while the interpolation expression around it is code', nv.includes('xs.map'), nv);
+
+  const inner = 'const t = ' + BT + '${xs.map((v) => ' + BT + 'n${v}' + BT + ')}' + BT + ';';
+  const iv = codeView(inner);
+  x('a NESTED interpolation contributes NO unbalanced brace to the code view',
+    (iv.match(/\{/g) || []).length === (iv.match(/\}/g) || []).length, iv);
+  x('...and the outer interpolation expression is still code', iv.includes('xs.map'), iv);
+
+  const quoted = 'const q = ' + BT + '${f("process.argv[1]")}' + BT + ';';
+  x('a STRING quoted inside an interpolation is not code', !codeView(quoted).includes('process.argv[1]'), codeView(quoted));
+
+  const plain = "const s = 'process.argv[1]';";
+  x('an ordinary string literal is untouched by any of this', !codeView(plain).includes('process.argv[1]'), codeView(plain));
+
+  const unterminated = 'const u = ' + BT + '${ g(';
+  x('an unterminated interpolation does not throw and yields its code', codeView(unterminated).includes('g('), codeView(unterminated));
+
+  for (const [name, ok, detail] of extra) {
+    if (!ok) failed++;
+    console.log(`  ${ok ? '\u2713' : '\u2717'} ${name}${ok ? '' : ' -- ' + JSON.stringify(detail)}`);
+  }
+  const total = cases.length + extra.length;
+
+  if (failed) {
+    console.error(`\u2717 js-comment-mask self-test: ${failed} of ${total} case(s) failed.`);
+    process.exit(1);
+  }
+  console.log(`\u2713 js-comment-mask self-test: ${total} cases pass (${cases.length} mask/strip corpus, ${extra.length} interpolation view).`);
+}
+
+// Executed only as a CLI. Importing this module must have NO side effect: the
+// gates below it are the callers, and a shared module that exits on import is
+// a shared module nobody can share.
+if (isEntrypoint(import.meta.url)) {
+  if (process.argv.includes('--self-test')) selfTest();
+  else {
+    console.error('usage: node scripts/js-comment-mask.mjs --self-test');
+    process.exit(2);
+  }
+}


### PR DESCRIPTION
Part of #6092

PR **1 of 2**. This ports the gate and wires it. It **converts nothing** — the 29 hand-typed guards are PR 2, per the dispatch order on #6092.

## Why the gate lands before the sweep

The card's own evidence: the worklist grows while the card sits open (`check-designer-field-key-parity.mjs` added a guard between `a1c41c516` and `7c96c9420`). A sweep with nothing under it can be undone silently by the next PR. So the gate lands first and names its own worklist.

## Re-measured at claim, on `133e2ea1e`

| figure | #6078 / #6092 (`7c96c9420`) | measured here (`133e2ea1e`) | difference |
| --- | --- | --- | --- |
| hand-typed entry guards under `scripts/` | 29 (28 `.mjs` + `shadcn-sync.js`) | **29** | none — `comm -3` on the two file sets is empty |
| distinct spellings across the 28 `.mjs` | 9 | **9** | none |
| files importing `isEntrypoint` | 1 adopter | **2 adopters** | `check-spec-range-floors.mjs` (the #5793 gate) has since landed on `main` |
| `process.argv[1]` occurrences (what the baseline counts) | not measured | **54** | 25 files spell it twice, 4 once |

The one figure that moved is the adopter count, and it moved in the good direction.

## The wiring decision, and its reasoning

Two spellings, one script:

- **`package.json`** gets `"check:entry-guard": "node scripts/check-entry-guard.mjs"` — the name upstream uses, so the two trees keep one vocabulary, and what a developer runs locally.
- **`.github/workflows/lint.yml`** runs it as a step, **before `pnpm install`**, invoked as `node` — matching `check-lint-coverage.mjs` (pre-install, bare `node`) and `check-cross-repo-closer-outcome.mjs` (`--self-test` first, then the scan) in that same job.

Why `lint.yml` and not `ci.yml`: the gate reads sources and nothing else. Its entire import graph is `node:fs`, `node:path`, `node:url`, plus `./invoked-as.mjs` and `./js-comment-mask.mjs` — measured by copying the three files to an empty directory with no `node_modules` anywhere on the path and importing the graph, which loads. So it belongs with the other install-free gates, and placing it *before* the install also means an install failure cannot take the gate down with it and leave the tree unjudged.

Why both spellings cannot drift: `scripts/__tests__/entry-guard-wiring.test.ts` asserts the alias and the workflow name the same script, that the step is not disabled, that it sits before `pnpm install`, and that `lint.yml` still gates pull requests. That last one matters — a gate nobody runs is indistinguishable from a gate that passes, which is the failure this whole card is about.

## This was not a copy-paste

Upstream's gate is 787 lines written for a tree that had already been swept. Five substantive differences:

1. **A baseline upstream has no need for.** `KNOWN_HAND_TYPED_GUARDS` maps a file to the **number** of masked `process.argv[1]` occurrences it carries, not just the path. A path-only baseline would accept a second guard smuggled into an already-owed file; this one does not. Shrink-only in both directions: more than owed fails, fewer fails as STALE and names itself, and there is no supported route that raises a number.
2. **`ROOT_DIR_WATCH_HINTS` dropped.** It is read by objectstack's `scripts/pm/dispatch-gates.mjs`. There is no such tool here, so the declaration would be a literal nothing reads and its self-test cases would assert a contract with an absent consumer. Carrying it would repeat exactly the defect #6078 recorded.
3. **`js-comment-mask.mjs` had to be ported too** — the gate's masker. objectui's only comparable helper is the private `stripComments` in `check-doc-component-types.mjs`, which is the regex-blind, string-preserving family the shared module was written to replace.
4. **The ported prose was corrected before it could lie.** `js-comment-mask.mjs`'s header named `check-comment-mask-corpus.mjs` and `check-test-source-alias.mjs` — neither exists here — and carried bare `#10427` / `#10640` refs that read as *objectui* issues in this repo. All now qualified `objectstack#`, with an explicit paragraph saying the corpus sweep is **not** ported and nothing here runs it. A ported header that names an absent file is the defect this card exists for.
5. **A third array in the masker, because the port was blind to this tree's worst guard.** See below.

## The one guard the straight port could not see

`scripts/check-node-esm-load.mjs:847` writes the percent-encoding spelling:

```js
if (import.meta.url === `file://${process.argv[1]}`) {
```

Under `js-comment-mask.mjs`'s documented `comment || literal` view, an interpolation's bytes are the enclosing template's *literal* content — so those bytes are prose, and the first cut of this gate listed **28** of the tree's 29 guards, silently omitting exactly the one #6092 singles out as going inert with no symlink at all.

`scanSource` now returns a third array, `interpolation`, marking the bytes an interpolation contributes as code. `comment` and `literal` are unchanged, so every existing caller keeps the mask it had. The subtraction excludes the `${` and its closing `}` and any nested template body, both pinned — without the first, a caller counting brackets desyncs; without the second, string content comes back as code, the fabrication direction that module's header calls the worse one.

That exclusion is not theoretical. A nested interpolation put the inner `}` into the outer span's interior with its `${` masked, and the resulting unmatched brace desynced the statement slicer badly enough that four files whose dispatch really *is* guarded were reported as running on import.

**This is an upstream defect too** — objectstack's gate would miss a newly written percent-encoding guard the same way. Filed separately, unassigned; see the report on #6092.

## Rule 2's baseline, and the port's one behavioural divergence

The import-safety rule now recognises a **hand-typed** guard as a guard. Upstream does not need to, because upstream swept first. Without it, all 29 badly-spelled files read as "runs on import" — which is **false**: on an `import` the comparison is false and the dispatch does not run. That would have made the baseline a list of 29 untruths plus one real entry, and a debt list is only safe while every line is true.

So the two rules divide the tree honestly: rule 1 owns the *spelling* complaint about those 29 (by name, on its own line); rule 2 owns files with no guard at all. Its whole baseline is **one** file — `check-lucide-icon-record-names.mjs`, which builds two lookup maps in top-level `for` loops at `:242` and `:244`, outside any guard, and really does run them inside an importer.

Recognition covers all three indirections (inline condition, `const` alias, named predicate function). The third is why `shadcn-sync.js` is not in rule 2's list: its `if (invokedAsCli())` is a real guard.

## Verification

**Non-vacuity control** — the justification for landing the gate before the sweep. Five legs, each with the mutation confirmed on disk before the gate was read, all restored by a `trap ... EXIT INT TERM`. Verdicts are the gate's own printed lines:

| leg | what changed | gate |
| --- | --- | --- |
| baseline | nothing | `exit=0` · `✓ check:entry-guard: 41 scripts/ file(s) — no entry guard outside the baseline; 29 file(s) still hand-type one (54 occurrence(s), ⛔ SHRINK-ONLY, objectui#6092); 36 export bindings, 35 of them inert on import (1 known-unsafe, ⛔ SHRINK-ONLY).` |
| **a 30th guard, new file** | `check-the-thirtieth-spelling.mjs` with a hand-typed guard | **`exit=1`** · `❌  check:entry-guard — 2 hand-typed entry guard(s) in scripts/ beyond the baseline:` naming `:3` |
| same new file, canonical guard | `isEntrypoint(import.meta.url)` instead | `exit=0`, 42 files scanned — the remedy really is a way out |
| **2nd guard into an owed file** | one line appended to `check-doc-links.mjs` (1 → 2 matching lines) | **`exit=1`** · names `:970` and the new `:1043` |
| **a guard removed** | `check-doc-links.mjs` converted (1 → 0 matching lines) | **`exit=1`** · `❌  check:entry-guard — 1 stale KNOWN_HAND_TYPED_GUARDS entry/entries:` · `scripts/check-doc-links.mjs  — baselined at 2, now carries 0` |
| **`shadcn-sync.js`** | untouched | `exit=0`, and the string `shadcn-sync` appears **0** times in the gate's output — it is never reported |

The gate's `--self-test`, which the workflow runs first, drives the scanner over fixture sources: 63 cases, including all nine spellings measured in *this* tree, the percent-encoding one seen through its template, and `reconcileGuards` pinned in every direction the baseline can move.

**Gate union at `cd58be980`** (working tree clean, 0 modified), each quoting its own verdict line:

```
node scripts/check-entry-guard.mjs --self-test   exit=0  ✓ check-entry-guard self-test: 63 cases pass — …
node scripts/check-entry-guard.mjs               exit=0  ✓ check:entry-guard: 41 scripts/ file(s) — …
node scripts/check-control-bytes.mjs             exit=0  ✅  check-control-bytes: OK (scanned 5084 tracked text file(s); skipped 85 binary).
node scripts/check-changeset-presence.mjs        exit=0  ✅  No source of a released package changed in this range, so no changeset is owed.
node scripts/check-changeset-fixed.mjs           exit=0  ✅  All workspace packages are in the changeset fixed group.
node scripts/check-changeset-no-major.mjs        exit=0  ✅  No changeset declares a `major` bump.
pnpm type-check:scripts                          exit=0  (tsc -p tsconfig.scripts.json, no diagnostics)
npx vitest run scripts/__tests__/ --maxWorkers=2 exit=0  Test Files 69 passed (69) · Tests 1884 passed (1884)
```

vitest was run from the repo **root**, never package-scoped.

**ESLint, narrowed with the narrowing shown to be safe.** `pnpm lint` is `eslint . --no-inline-config`, a repo-wide scan CI owns and runs in this same job. Locally the three changed lintable files were linted directly: `--format json` reports **3** file objects, `errorCount=0` / `warningCount=0` on each, so the files were read rather than skipped. The narrowing excludes nothing: `eslint.config.js` sets no `project` / `parserOptions.project` — type-aware linting is off — so no untouched file's verdict can depend on this diff.

**Control bytes**: a control-character grep over all six changed files returns no matches, and `check-control-bytes.mjs` is green over the tracked tree.

## Inherited, not re-derived

Both demonstrations come from #6078 and are cited rather than repeated: a red blocking gate reporting clean through a symlink (`check-skills-paths.mjs` direct → `exit=1`, 696 bytes; via symlink → `exit=0`, 0 bytes, same defective tree), and the percent-encoding spelling going inert in a directory named `a#b c` with no symlink at all.

## Not in this PR

Converting any guard · `invoked-as.mjs`'s header (corrected by #6096) · the two one-file defects on #6092's sub-notes. `#6092 remains open` after this merges — hence `Part of`, not a closing keyword.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_