### PR TITLE
docs(blocks,plugins): compile nineteen plaintext-fenced TypeScript snippets (#5867 batch 4)

### DIFF
--- a/.changeset/5867-plaintext-fenced-ts-batch4.md
+++ b/.changeset/5867-plaintext-fenced-ts-batch4.md
@@ -1,0 +1,22 @@
+---
+---
+
+Docs only, publishes nothing: nineteen TypeScript snippets across
+`content/docs/blocks/block-schema.mdx` and six `content/docs/plugins/*.mdx`
+reference pages were fenced ```plaintext, so `check-doc-snippet-types` — which
+reads only `ts` / `tsx` fences — never saw them (objectui#5867, batch 4 of N).
+Triage's classifier is the one applied: a plaintext block whose first line
+starts with `import` / `export` / `interface` / `type X =` / `const x: T` is
+code, and those fences are now `ts`; genuinely prose blocks on the same pages
+are left alone. Compiling them found real documentation defects on
+`block-schema`, now fixed: the *Complete Example*, *Block Slots* and
+*Marketplace Example* blocks annotated `BlockSchema` / `SchemaNode` /
+`BlockLibrarySchema` without importing them, and three blocks referenced values
+defined in other blocks on the page. Resolving `BlockLibrarySchema` then
+un-masked a defect the unresolved name had been suppressing: both marketplace
+listings carried `schema: { /* block schema */ }`, an empty object that
+`BlockLibraryItem.schema` rejects because `BlockSchema` requires `type`. The
+gate's blocks-to-compile count rises from 206 to 225 — exactly the batch — with
+diagnostics at 0, no new `FRAGMENT_MARKER` declarations, and the
+covered/ungated sets unmoved. The blocks also stop rendering as unstyled
+plaintext and pick up TypeScript highlighting, which is the reader-visible half.

--- a/content/docs/blocks/block-schema.mdx
+++ b/content/docs/blocks/block-schema.mdx
@@ -62,7 +62,7 @@ expanded. None of them goes through `BlockSchema`: there is nothing that expands
 
 ## Basic Usage
 
-```plaintext
+```ts
 import type { BlockSchema } from '@object-ui/types';
 
 const heroBlock: BlockSchema = {
@@ -108,7 +108,7 @@ const heroBlock: BlockSchema = {
 
 ### Block Metadata
 
-```plaintext
+```ts
 interface BlockMetadata {
   name: string;              // Block identifier
   label?: string;            // Display name
@@ -129,7 +129,7 @@ interface BlockMetadata {
 
 Variables define configurable properties:
 
-```plaintext
+```ts
 interface BlockVariable {
   name: string;                    // Variable name
   label?: string;                  // Display label
@@ -146,7 +146,9 @@ interface BlockVariable {
 
 Slots define content injection points:
 
-```plaintext
+```ts
+import type { SchemaNode } from '@object-ui/types';
+
 interface BlockSlot {
   name: string;                    // Slot name
   label?: string;                  // Display label
@@ -186,7 +188,9 @@ this family it is **declared but not yet consumed** - no renderer reads it today
 
 ## Complete Example
 
-```plaintext
+```ts
+import type { BlockSchema } from '@object-ui/types';
+
 const cardBlock: BlockSchema = {
   type: 'block',
   
@@ -325,7 +329,7 @@ const cardBlock: BlockSchema = {
 variable values, what slot content. It is a definition, not a component - nothing
 resolves `blockId` or expands the block it names.
 
-```plaintext
+```ts
 import type { BlockInstanceSchema } from '@object-ui/types';
 
 const instance: BlockInstanceSchema = {
@@ -365,8 +369,11 @@ selected it and the listings it returned. It is a data shape, not a browser comp
 nothing renders a library, and `onInstall` / `onPreview` name handlers that no dispatcher
 looks up.
 
-```plaintext
-import type { BlockLibrarySchema } from '@object-ui/types';
+```ts
+import type { BlockLibrarySchema, BlockSchema } from '@object-ui/types';
+
+// The block defined under "Basic Usage" above.
+declare const heroBlock: BlockSchema;
 
 const library: BlockLibrarySchema = {
   type: 'block-library',
@@ -403,8 +410,11 @@ const library: BlockLibrarySchema = {
 open and which panels a host would show. It is a configuration shape, not an editor
 component - no block editor exists to consume it.
 
-```plaintext
-import type { BlockEditorSchema } from '@object-ui/types';
+```ts
+import type { BlockEditorSchema, BlockSchema } from '@object-ui/types';
+
+// The block defined under "Complete Example" above.
+declare const cardBlock: BlockSchema;
 
 const editor: BlockEditorSchema = {
   type: 'block-editor',
@@ -423,7 +433,9 @@ const editor: BlockEditorSchema = {
 
 ## Marketplace Example
 
-```plaintext
+```ts
+import type { BlockLibrarySchema } from '@object-ui/types';
+
 const marketplace: BlockLibrarySchema = {
   type: 'block-library',
   apiEndpoint: 'https://blocks.objectui.com/api',
@@ -444,7 +456,7 @@ const marketplace: BlockLibrarySchema = {
         premium: false,
         preview: 'https://blocks.objectui.com/previews/pricing-table.png'
       },
-      schema: { /* block schema */ },
+      schema: { type: 'block', meta: { name: 'pricing-table-pro' } },
       installs: 5420,
       rating: 4.9,
       ratingCount: 234,
@@ -463,7 +475,7 @@ const marketplace: BlockLibrarySchema = {
         version: '1.3.0',
         premium: true
       },
-      schema: { /* block schema */ },
+      schema: { type: 'block', meta: { name: 'testimonial-slider' } },
       installs: 2150,
       rating: 4.7,
       ratingCount: 89
@@ -474,8 +486,11 @@ const marketplace: BlockLibrarySchema = {
 
 ## Runtime Validation
 
-```plaintext
+```ts
 import { BlockSchema } from '@object-ui/types/zod';
+
+// The block configuration to validate.
+declare const myBlock: unknown;
 
 const result = BlockSchema.safeParse(myBlock);
 

--- a/content/docs/plugins/plugin-charts.mdx
+++ b/content/docs/plugins/plugin-charts.mdx
@@ -262,7 +262,7 @@ const schema = {
 
 ## TypeScript Support
 
-```plaintext
+```ts
 import type { BarChartSchema } from '@object-ui/plugin-charts'
 
 const chartSchema: BarChartSchema = {

--- a/content/docs/plugins/plugin-editor.mdx
+++ b/content/docs/plugins/plugin-editor.mdx
@@ -137,7 +137,7 @@ This keeps your main application bundle small while providing full IDE-like edit
 
 ## TypeScript Support
 
-```plaintext
+```ts
 import type { CodeEditorSchema } from '@object-ui/plugin-editor'
 
 const editorSchema: CodeEditorSchema = {

--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -212,7 +212,7 @@ spec rejects `pane` on non-split form types at parse.)
 
 ### Registration is a side effect of the import
 
-```plaintext
+```ts
 import '@object-ui/plugin-form';
 ```
 
@@ -242,7 +242,7 @@ claims it.
 To serve one of this package's components under a key of your own, register the
 exported component — that is what a manual registration is here:
 
-```plaintext
+```ts
 import { ComponentRegistry } from '@object-ui/core';
 import { ObjectForm } from '@object-ui/plugin-form';
 

--- a/content/docs/plugins/plugin-grid.mdx
+++ b/content/docs/plugins/plugin-grid.mdx
@@ -170,7 +170,7 @@ view whose columns are all `none` (or carry no `summary`) has no footer.
 
 ### Registration is a side effect of the import
 
-```plaintext
+```ts
 import '@object-ui/plugin-grid';
 ```
 
@@ -200,7 +200,7 @@ the CSS Grid *layout* container in `@object-ui/components`
 To serve the data grid under a key of your own, register the exported renderer —
 that is what a manual registration is here:
 
-```plaintext
+```ts
 import { ComponentRegistry } from '@object-ui/core';
 import { ObjectGridRenderer } from '@object-ui/plugin-grid';
 

--- a/content/docs/plugins/plugin-markdown.mdx
+++ b/content/docs/plugins/plugin-markdown.mdx
@@ -347,7 +347,7 @@ The plugin uses lazy loading to optimize bundle size:
 
 ## TypeScript Support
 
-```plaintext
+```ts
 import type { MarkdownSchema } from '@object-ui/plugin-markdown'
 
 const markdownSchema: MarkdownSchema = {

--- a/content/docs/plugins/plugin-view.mdx
+++ b/content/docs/plugins/plugin-view.mdx
@@ -202,7 +202,7 @@ path only (the row above, and the section below), so on a non-grid
 
 ### Registration is a side effect of the import
 
-```plaintext
+```ts
 import '@object-ui/plugin-view';
 ```
 
@@ -238,7 +238,7 @@ than as a schema key.
 To serve one of this package's components under a key of your own, register the
 exported component — that is what a manual registration is here:
 
-```plaintext
+```ts
 import { ComponentRegistry } from '@object-ui/core';
 import { ViewSwitcher } from '@object-ui/plugin-view';
 


### PR DESCRIPTION
Part of #5867

Batch 4 of N, taking the two groups batch 3's handback named as the only unblocked ones: `plugins` and `blocks`. All readings below are at branch head `4430ac30d`, and every heavy run went through the container's shared verify lock.

## What this changes

19 fences re-fenced from ` ```plaintext ` to ` ```ts ` across 7 whole pages — `content/docs/blocks/block-schema.mdx` (10) and six `content/docs/plugins/*.mdx` (9: charts 1, editor 1, form 2, grid 2, markdown 1, view 2) — so `check-doc-snippet-types` compiles them.

Triage's classifier is the one applied, unwidened: a plaintext block whose first line starts with `import` / `export` / `interface` / `type X =` / `const x: T` is code. Genuinely-prose blocks on the same pages are left alone — 12 of them survive across the batch pages, including `block-schema.mdx`'s `slotContent` illustration, which opens with a comment and would not parse.

No `FRAGMENT_MARKER` was declared. The gate, `UNGATED_DOCS` and the ledger are untouched; `scripts/` is not in the diff.

## The defects compiling them found, all fixed rather than marked

All on `block-schema.mdx`; the six plugins pages compiled untouched, as batch 2's probe 2 predicted.

| block | what was wrong | fix |
| --- | --- | --- |
| *Block Slots* | `BlockSlot.defaultContent` is typed `SchemaNode`, never imported | import `SchemaNode` |
| *Complete Example* | annotates `BlockSchema`, never imported | import `BlockSchema` |
| *Marketplace Example* | annotates `BlockLibrarySchema`, never imported | import `BlockLibrarySchema` |
| *Block Library* | references `heroBlock`, defined in a different block on the page | `declare const heroBlock: BlockSchema` |
| *Block Editor* | references `cardBlock`, defined in a different block on the page | `declare const cardBlock: BlockSchema` |
| *Runtime Validation* | validates `myBlock`, the reader's own value | `declare const myBlock: unknown` |

`declare const` is this repo's existing idiom for a value a snippet does not define — seven prior uses across `components/basic/icon.mdx`, `guide/notifications.md` and `guide/troubleshooting.md`.

### The defect that only appeared once the first fix landed

Resolving `BlockLibrarySchema` un-masked one the unresolved name had been suppressing. Both *Marketplace Example* listings carried:

```
schema: { /* block schema */ },
```

While `BlockLibrarySchema` was `TS2304`, its annotation degraded to `any` and the member was never checked. With the import in place the gate reddened it as `TS2741: Property 'type' is missing in type '{}' but required in type 'BlockSchema'` — `BlockLibraryItem.schema` is a required `BlockSchema`, and an empty object is not one. Both now carry a real minimal block schema naming the listing they belong to. This is the #5044 class exactly: a block teaching a shape the types reject, under a gate that reported the page as covered.

## Verification

**Gate, before and after**, on the built tree:

| reading | before (`133e2ea1e`) | after (`4430ac30d`) |
| --- | --- | --- |
| blocks to compile | 206 | **225** (+19 = exactly the batch) |
| diagnostics | 0 | **0** |
| declared fragments | 111 | **111** (unmoved) |
| covered documents | 178 | **178** (set did not shrink) |
| ungated | 44 | **44** (none newly ungated) |
| covered docs holding a ts/tsx block | 63 | 64 |

The gate's own verdict line after: `Every covered documentation snippet compiles against the built types.` The `--build-filter` closure is byte-identical before and after.

**Other gates**, exit codes captured before any pipe, quoting each gate's own verdict line:

- `check:doc-types` exit=0 — `Every documented component type is registered.`
- `docs:check-links` exit=0 — `Links are valid across 15 scan roots.`
- `check:control-bytes` exit=0 — `OK (scanned 5081 tracked text file(s); skipped 85 binary)`

**Vitest**, from the repo root: `check-doc-snippet-types` · `check-doc-component-types` · `check-doc-links` · `check-changeset-presence` — `Test Files 4 passed (4), Tests 185 passed (185)`.

**Lint**, narrowed and the narrowing measured: the diff is 7 `.mdx` files plus one `.changeset/*.md`. ESLint's own configuration reports every one of them as `File ignored because no matching configuration was supplied` — `eslint.config.js` matches only `**/*.{ts,tsx}`, and type-aware linting is not enabled, so this diff cannot move the verdict on any untouched file. File count read from `--format json`: 2 probed, 2 ignored, 0 errors.

### Render check

`pnpm site:build` green. The reader-visible half is measured against a **rebuilt baseline** rather than asserted: the site was rebuilt with `content/docs` reverted to the pre-batch commit, counted, then restored under a trap.

`block-schema.mdx` renders as literal `<pre>` blocks, so its count is exact:

| | before | after |
| --- | --- | --- |
| rendered blocks with shiki token spans | 0 | **10** |
| rendered blocks with none | 11 | **1** |
| shiki keyword spans | 0 | **52** |

Ten blocks moved from unstyled to tokenised — the page's whole share of the batch — and the one surviving prose block still carries zero token spans.

The six plugins pages render most blocks through the RSC flight payload, so the same before/after counter was run on both representations, reading keyword spans:

| page | before | after | delta | converted |
| --- | --- | --- | --- | --- |
| plugin-charts | 10 | 13 | +3 | 1 |
| plugin-editor | 5 | 8 | +3 | 1 |
| plugin-form | 7 | 12 | +5 | 2 |
| plugin-grid | 16 | 21 | +5 | 2 |
| plugin-markdown | 8 | 11 | +3 | 1 |
| plugin-view | 50 | 55 | +5 | 2 |
| **plugin-dashboard** (control, untouched) | **0** | **0** | **0** | **0** |

Build note, unrelated to this diff and identical to batches 1–3: the site build needs `@object-ui/plugin-gantt` and `@object-ui/plugin-map` built first, both outside the gate's `--build-filter` closure.

### Scope selection was measured, not eyeballed

All 22 candidate blocks across all 8 candidate files were re-fenced in a throwaway probe, the mutation proved on disk first (per-file plaintext counts dropped to their expected values; `git diff --stat` showed 22 insertions / 22 deletions), the tree rebuilt, the gate run, and the tree restored under `trap … EXIT INT TERM` using `git checkout HEAD -- ` on the two directories, never the bare form. The probe read `Covered blocks: 339 — 228 to compile` (206 + 22, so every re-fence landed in the population) and named exactly one file this batch then excluded.

## Excluded, with a measured reason

**`content/docs/plugins/plugin-dashboard.mdx`** — 3 blocks, whole file left as plaintext. Its *TypeScript Support* block fails the syntax phase (`TS1109` on `widgets: [...]`, an English ellipsis at expression position), which #6122 already records. Measuring behind that failure found more than #6122 knew: the block also imports `DashboardSchema` and `MetricCardSchema`, and **neither name exists anywhere** — not on `@object-ui/plugin-dashboard`'s built export surface, not in `@object-ui/types`, not declared in any `packages/*/src`. The syntax failure had been masking both. Reported on #6122 rather than filed fresh, because that card already owns this file's defect record and is in flight; the comment there also points at #5015 / PR #5069, which settled the identical fabricated-name defect in this package's README and pins the correct form, so the file needs no new ruling.

The **7 blocks in 6 `UNGATED_DOCS` pages** were not re-fenced and should not be: those documents are not compiled at all, so re-fencing moves blocks-to-compile by zero. Left alone deliberately, not overlooked.

## Population, re-derived

146 blocks / 102 files on `origin/main` `133e2ea1e`, reproducing batch 3's reading exactly. Widening the derivation's fence-language set to `text` and `plain` moves it to 147/103 and surfaces one block the whole lane has been blind to — filed as **#6135**, unassigned, with the file it names blocked on #6122.

Remainder after this batch: **110 blocks / 85 files**, handed back on the card in batch 3's shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_