### PR TITLE
docs(fields): narrow two snippets to ObjectUI's own contract instead of an ambient db handle and an undeclared ajv

### DIFF
--- a/.changeset/6126-fields-unresolvable-imports.md
+++ b/.changeset/6126-fields-unresolvable-imports.md
@@ -1,0 +1,34 @@
+---
+---
+
+Docs only, publishes nothing: two `content/docs/fields` snippets referenced
+identifiers the snippet program cannot resolve, so both pages were held out of
+objectui#5867's batch 3 (objectui#6126). Neither is fixed by making the compiler
+happy — each was narrowed to what ObjectUI actually owns.
+
+`auto-number`'s Sequence Management block called `db.transaction` on a `db`
+declared nowhere in the workspace and exported by nothing (TS2304, plus TS7006
+on the `tx` that fell out of it). Declaring an ambient `db` would have had the
+renderer's documentation mint a backend contract it does not own, so the block
+is now the metadata the backend actually reads — a literal annotated with the
+exported `AutoNumberFieldMetadata`, carrying `format` and `starting_number` —
+and the transactional sketch is prose: one counter per object-and-field pair,
+incremented in the same transaction that inserts the record. The page now also
+says the thing it never said, which is that ObjectUI never allocates a value at
+all and renders a placeholder until the saved record comes back.
+
+`object`'s Backend Validation block opened `import Ajv from 'ajv'`, and `ajv` is
+declared by no `package.json` in this repository and resolves from nowhere
+(TS2307). Adding it as a dependency to satisfy a checker was refused, so the
+block keeps the ObjectUI half — an `ObjectFieldMetadata` literal whose `schema`
+is the JSON Schema a server validates against — and the Ajv call sequence, which
+was Ajv's documentation rather than ObjectUI's, is a prose sentence naming it as
+one option among any JSON Schema validator. The section now states the fact a
+reader most needs: `ObjectField` checks JSON syntax only and never enforces
+`schema`, so structural validation is the server's.
+
+Both pages join the compile population with the batch's own classifier: the four
+`plaintext`-fenced blocks whose first line starts with `import` or `interface`
+are now `ts`. The gate's blocks-to-compile count rises from 206 to 210 — exactly
+those four — with diagnostics at 0, no new `FRAGMENT_MARKER` declarations, and
+the covered/ungated and declared-fragment sets unmoved.

--- a/content/docs/fields/auto-number.mdx
+++ b/content/docs/fields/auto-number.mdx
@@ -19,7 +19,7 @@ The AutoNumber Field component displays auto-generated sequence numbers. This is
 
 ## Field Schema
 
-```plaintext
+```ts
 interface AutoNumberFieldSchema {
   type: 'auto_number';
   name: string;                  // Field name/ID
@@ -104,26 +104,33 @@ generateAutoNumber('ORD-{YYYY}-{0000}', 42);
 
 ## Sequence Management
 
-The backend maintains sequence counters:
+Allocating the next number is the backend's job, not the renderer's. ObjectUI
+never generates a value: `AutoNumberField` displays whatever the saved record
+already carries, and renders a muted placeholder dash while the field is still
+empty. What ObjectUI owns is the metadata the backend reads — where the
+sequence starts, and how each value is formatted:
 
-```plaintext
-interface SequenceCounter {
-  object: string;           // Object name
-  field: string;            // Field name
-  current_value: number;    // Current sequence number
-  prefix?: string;          // Optional prefix for partitioning
-}
+```ts
+import type { AutoNumberFieldMetadata } from '@object-ui/types';
 
-// Increment sequence atomically
-const getNextSequence = async (object: string, field: string) => {
-  return await db.transaction(async (tx) => {
-    const counter = await tx.findOne('sequences', { object, field });
-    const nextValue = (counter?.current_value || 0) + 1;
-    await tx.upsert('sequences', { object, field }, { current_value: nextValue });
-    return nextValue;
-  });
+const orderNumber: AutoNumberFieldMetadata = {
+  type: 'auto_number',
+  name: 'order_number',
+  label: 'Order Number',
+  format: 'ORD-{YYYY}-{0000}',
+  starting_number: 1,
 };
 ```
+
+On the backend, keep one counter per object-and-field pair and increment it in
+the same transaction that inserts the record, so two concurrent inserts cannot
+read the same current value. Partition the counter (per year, per prefix) only
+if the format resets — `'ORD-{YYYY}-{0000}'` needs one counter per year if the
+sequence is meant to restart each January.
+
+Because the number is assigned at insert time, it does not exist while the
+record is still being drafted: a create form shows the field empty, and the
+value appears once the saved record comes back.
 
 ## Use Cases
 

--- a/content/docs/fields/object.mdx
+++ b/content/docs/fields/object.mdx
@@ -23,7 +23,7 @@ The Object Field component provides a JSON editor for storing and editing struct
 
 ## Field Schema
 
-```plaintext
+```ts
 interface ObjectFieldSchema {
   type: 'object';
   name: string;                  // Field name/ID
@@ -199,33 +199,36 @@ For typed object fields, you can define a schema in two formats:
 
 ## Backend Validation
 
-Example backend validation:
+ObjectUI does not enforce `schema`. `ObjectField` checks JSON **syntax** only —
+it accepts any value `JSON.parse` accepts, and simply declines to propagate a
+draft it cannot parse — so nothing on the client rejects a well-formed object
+whose shape is wrong. Structural validation belongs on the server.
 
-```plaintext
-import Ajv from 'ajv';
+The `schema` you author is carried on the field metadata untouched, and in the
+JSON Schema Format above it is an ordinary JSON Schema document. That is the
+whole integration point: the server validates the incoming value against the
+very same object, using whichever JSON Schema validator it already has (Ajv,
+for instance — ObjectUI ships none and names none).
 
-const ajv = new Ajv();
+```ts
+import type { ObjectFieldMetadata } from '@object-ui/types';
 
-const validateObjectField = (value: any, schema: any) => {
-  if (!schema) return { valid: true };
-  
-  const validate = ajv.compile(schema);
-  const valid = validate(value);
-  
-  return {
-    valid,
-    errors: validate.errors
-  };
-};
-
-// Example schema
-const configSchema = {
+const apiConfig: ObjectFieldMetadata = {
   type: 'object',
-  properties: {
-    api_key: { type: 'string', minLength: 1 },
-    timeout: { type: 'number', minimum: 0 },
-    enabled: { type: 'boolean' }
+  name: 'api_config',
+  label: 'API Configuration',
+  schema: {
+    type: 'object',
+    properties: {
+      api_key: { type: 'string', minLength: 1 },
+      timeout: { type: 'number', minimum: 0 },
+      enabled: { type: 'boolean' },
+    },
+    required: ['api_key'],
   },
-  required: ['api_key']
 };
 ```
+
+One caveat when you do: the Simplified Format above is
+documentation for a reader, not a validator input — only the JSON Schema Format
+can be handed to a JSON Schema validator as-is.


### PR DESCRIPTION
Fixes #6126

## Route taken: narrowing, not the #6120 environment fix — and why

The card's hedge said to follow #6120's route if it turned out to cover
`object.mdx`. Checked before implementing: **PR #6129 is still open and
unmerged**, and by its own description it derives paths for *the specifiers each
imported package declares in its own `dependencies`*. `ajv` is declared by no
`package.json` in this repository, so there is nothing for that route to resolve
to even once it lands. Narrowing it is, exactly as ruled.

## Re-measured on `origin/main` first

The card's readings come from batch 3's probe, so they were re-taken here before
anything was edited: `origin/main` `133e2ea1e`, the four classifier-matching
`plaintext` fences on the two pages re-fenced to `ts` in a throwaway probe under
an `EXIT` trap (restore verified: `plaintext` counts back to 7 and 8). All three
diagnostics reproduce verbatim:

```
[semantic]  content/docs/fields/auto-number.mdx:119:16  TS2304: Cannot find name 'db'.
[semantic]  content/docs/fields/auto-number.mdx:119:38  TS7006: Parameter 'tx' implicitly has an 'any' type.
[semantic]  content/docs/fields/object.mdx:205:17  TS2307: Cannot find module 'ajv' or its corresponding type declarations.
```

## `auto-number.mdx` — the ambient `db` handle

The Sequence Management block called `db.transaction` on a handle declared
nowhere in the workspace. No ambient `db`, no `declare` shim, no backend client:
the block is now the part ObjectUI genuinely owns — a literal annotated with the
**exported** `AutoNumberFieldMetadata`, carrying the two keys that type actually
declares, `format` and `starting_number`.

The transactional sketch moves to prose, which the ruling names as its home: one
counter per object-and-field pair, incremented inside the same transaction that
inserts the record, partitioned only when the format resets.

What the section gains rather than loses: it now states the fact the page never
stated, which is that **ObjectUI never allocates a value at all**.
`AutoNumberField` renders whatever the saved record carries and shows a
placeholder until it comes back — so a create form shows the field empty. The
old block implied the opposite by presenting an allocation routine as
copy-pasteable code.

## `object.mdx` — the unresolvable `ajv`

No dependency was added anywhere. The block keeps the ObjectUI half — an
`ObjectFieldMetadata` literal whose `schema` holds the same JSON Schema document
the page's JSON Schema Format section teaches — and the Ajv call sequence is
gone, because on inspection it was *Ajv's* documentation (construct, compile,
call, read `errors`) rather than ObjectUI's. Ajv survives as a prose example of
"whichever JSON Schema validator the server already has".

Again the section gains the ObjectUI-specific fact it was missing, measured from
`packages/fields/src/widgets/ObjectField.tsx`: the widget checks JSON **syntax**
only — it declines to propagate a draft `JSON.parse` rejects and does nothing
else — so **nothing on the client enforces `schema`**, and structural validation
is the server's. A reader who copied the old block learned an Ajv idiom; a reader
of the new one learns where the boundary is.

## The blocks are genuinely checked, not merely collected

Both imported types are sealed (`BaseFieldMetadata` carries no index signature),
so the annotations really excess-check. Ablated on the committed fix to prove the
gate can fail on them — one unknown key injected into each narrowed literal,
restore under an `EXIT` trap, and the mutation confirmed on disk by grepping for
the injected text (a first attempt was **rejected by that check**: the anchor
`label: 'API Configuration',` matched twice in `object.mdx`, so the reading was
declared void and the anchor retargeted before re-running):

```
MUTATION-ON-DISK: injected sequence_reset x1 in auto-number, validator_library x1 in object

  [semantic]  content/docs/fields/auto-number.mdx:122:3  TS2353: Object literal may only specify known properties, and 'sequence_reset' does not exist in type 'AutoNumberFieldMetadata'.
  [semantic]  content/docs/fields/object.mdx:217:3  TS2353: Object literal may only specify known properties, and 'validator_library' does not exist in type 'ObjectFieldMetadata'.
Semantic phase: 210 of 210 block(s) judged, 2 failed.
```

No rebuild leg applies: the mutation is in the documents the gate reads, not in a
package's sources, and the resolution control below shows the same built `.d.ts`
the green run used.

## Population moved by exactly the batch, fragments unmoved

Baseline measured in this worktree with the two files reverted to `133e2ea1e`
under a trap, restore verified:

```
before  Scanned 222 document(s): 178 covered (63 of them hold a ts/tsx block), 44 ungated
        Covered blocks: 317 — 206 to compile, 111 declared fragment(s).

after   Scanned 222 document(s): 178 covered (64 of them hold a ts/tsx block), 44 ungated
        Covered blocks: 321 — 210 to compile, 111 declared fragment(s).
```

Four blocks, exactly the four classifier-matching fences on these two pages.
**No `FRAGMENT_MARKER` anywhere** — these are genuinely TypeScript — and the
declared-fragment, covered and ungated sets are all unmoved. `auto-number` is the
page joining the ts/tsx population; `object` already held one `ts` block.

## Verification

Union re-run at final HEAD `f2145987a` with a clean tree, each gate quoting its
own verdict line:

| gate | verdict line |
| --- | --- |
| `node scripts/check-doc-snippet-types.mjs` | `Every covered documentation snippet compiles against the built types.` · `Semantic phase: 210 of 210 block(s) judged, 0 failed.` |
| `node scripts/check-doc-component-types.mjs` | `Every documented component type is registered.` |
| `node scripts/check-doc-links.mjs` | `Links are valid across 15 scan roots.` |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 5081 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | `No source of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `node scripts/check-skills-paths.mjs` | `check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined).` |
| `pnpm lint:root` | `28 problems (0 errors, 28 warnings)` — all pre-existing; this diff contains no `.ts` / `.tsx` file |
| `pnpm vitest run` (repo ROOT) on the three doc-tooling suites | `Test Files  3 passed (3)` · `Tests  72 passed (72)` |
| `pnpm site:build` | `SITE-EXIT=0`, 180-plus doc paths prerendered |

The gate reads the BUILT dist, quoted from its own resolution control on the
final run:

```
  resolution   Module name '@object-ui/types' was successfully resolved to
               '/home/user/objectui-6126/packages/types/dist/index.d.ts'
```

**Both pages render coherently**, checked in the prerendered HTML rather than
assumed: `.next/server/app/docs/fields/auto-number.html` and `object.html` both
carry the new prose and the highlighted `ts` blocks, and the strings
`db.transaction`, `SequenceCounter`, `ajv.compile` and the `ajv` import appear
zero times in either. The first `pnpm site:build` in this worktree failed on
`Module not found` for `@object-ui/plugin-gantt` and `@object-ui/plugin-map` —
environmental, those two sit outside the doc-snippet gate's build filter and were
simply unbuilt here; building them made it green with no edit to the diff.

**Declaring the docs-only status**: this repository has no `skip-changeset`
label, so the declaration is an empty-frontmatter changeset, the same shape
objectui#5867's batches use.

## Out of scope, deliberately

The other `plaintext` fences on both pages are left alone: they do not match
triage's classifier (their first lines are `format: ...`, `const name = ...` and
bare object literals), which is the same line batch 3 drew.
`content/docs/fields/location.mdx` is the sibling blocker under #6127 and is
untouched here. #5867 is not addressed by this PR — it is the parent, and it
stays open.

One finding surfaced while measuring and is filed separately rather than fixed
here: the hand-written `interface AutoNumberFieldSchema` / `ObjectFieldSchema`
blocks on these pages declare keys (`value`, `className`, `disabled`) that the
exported `AutoNumberFieldMetadata` / `ObjectFieldMetadata` and their shared
`BaseFieldMetadata` do not have. Because those interfaces are self-declarations,
they compile vacuously — the gate reports the pages green and can never see the
divergence.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_