### PR TITLE
docs(components): name the shipped handler on five action props (#6122 PR 2)

### DIFF
--- a/.changeset/6122-action-prop-renames.md
+++ b/.changeset/6122-action-prop-renames.md
@@ -1,0 +1,29 @@
+---
+---
+
+Docs only, publishes nothing: five `content/docs/components` reference pages
+annotated an event prop as `string | ActionConfig` — a type `@object-ui/types`
+has never exported. Each site was resolved individually against the freshly
+built `packages/types/dist/*.d.ts`, and in every case the shipped slot is a
+plain function callback that the page had also named wrongly:
+
+| page | documented | shipped slot | declaration |
+| --- | --- | --- | --- |
+| `form/command.mdx` | `onSelect` | `onChange?: (value: string) => void` | `form.d.ts:1376` |
+| `form/radio-group.mdx` | `onValueChange` | `onChange?: (value: string \| number) => void` | `form.d.ts:394` |
+| `form/date-picker.mdx` | `onDateChange` | `onChange?: (date: Date \| undefined) => void` | `form.d.ts:642` |
+| `form/combobox.mdx` | `onValueChange` | `onChange?: (value: string) => void` | `form.d.ts:1324` |
+| `feedback/toast.mdx` | `actionLabel` + `onAction` | `action?: { label: string; onClick: () => void }` | `feedback.d.ts:137` |
+
+The `string |` half of each annotation goes with the name, and that is the
+substance rather than a tidy-up: objectui#4453 narrowed the runtime to
+`typeof === 'function'`, so an authored string handler is **dropped**
+(`packages/plugin-calendar/src/calendar-view-renderer.tsx`). A reference page
+promising `string | Fn` is exactly what makes an AI author emit a handler that
+publishes, validates, and silently does nothing.
+
+No type was minted to make the prose true. Measured with a throwaway re-fence
+probe: `TS2304: Cannot find name 'ActionConfig'` **10 → 5** across the
+`components` group, and the 5 that remain are objectui#6132's, untouched here.
+
+Part of objectui#6122.

--- a/content/docs/components/feedback/toast.mdx
+++ b/content/docs/components/feedback/toast.mdx
@@ -31,9 +31,11 @@ interface ToastSchema {
   description?: string;           // Toast message
   variant?: 'default' | 'destructive';
   
-  // Action
-  actionLabel?: string;           // Action button label
-  onAction?: string | ActionConfig;
+  // Action button
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
   
   // Timing
   duration?: number;              // Auto-dismiss time in ms

--- a/content/docs/components/form/combobox.mdx
+++ b/content/docs/components/form/combobox.mdx
@@ -41,7 +41,7 @@ interface ComboboxSchema {
   emptyText?: string;             // Text when no results
   
   // Events
-  onValueChange?: string | ActionConfig;
+  onChange?: (value: string) => void;
   
   // States
   disabled?: boolean;

--- a/content/docs/components/form/command.mdx
+++ b/content/docs/components/form/command.mdx
@@ -31,7 +31,7 @@ interface CommandSchema {
   emptyText?: string;             // Text when no results
   
   // Events
-  onSelect?: string | ActionConfig;
+  onChange?: (value: string) => void;
   
   // Styling
   className?: string;

--- a/content/docs/components/form/date-picker.mdx
+++ b/content/docs/components/form/date-picker.mdx
@@ -31,7 +31,7 @@ interface DatePickerSchema {
   placeholder?: string;           // Placeholder text
   
   // Events
-  onDateChange?: string | ActionConfig;
+  onChange?: (date: Date | undefined) => void;
   
   // States
   disabled?: boolean;

--- a/content/docs/components/form/radio-group.mdx
+++ b/content/docs/components/form/radio-group.mdx
@@ -47,7 +47,7 @@ interface RadioGroupSchema {
   direction?: 'vertical' | 'horizontal';
   
   // Events
-  onValueChange?: string | ActionConfig;
+  onChange?: (value: string | number) => void;
   
   // States
   disabled?: boolean;


### PR DESCRIPTION
Part of #6122 — option A's mechanical half, dispatched as PR 2 in https://github.com/objectstack-ai/objectui/issues/6122#issuecomment-5401039277.

PR #6130 landed the 6 sites the built types determined outright. This one takes the 5 where the shipped slot exists but the page had also named the prop wrongly. The 5 sites with **no** target at all are #6132 and are left byte-identical here.

## The 5 corrections

Every signature below was re-read from a **freshly built** `packages/types/dist/*.d.ts` in this worktree and written verbatim. The gate's own resolution control confirms which file the readings came from:

```
resolution   Module name '@object-ui/types' was successfully resolved to
             '/home/user/objectui-6122-pr2/packages/types/dist/index.d.ts'
sentinel     importing 'ThisNameIsDefinitelyNotExported' produced 1 diagnostic(s) (TS2305)
positive     importing 'ComponentSchema' produced 0 diagnostic(s)
```

| page | documented | shipped slot, verbatim | declaration |
| --- | --- | --- | --- |
| `form/command.mdx` | `onSelect?: string \| ActionConfig` | `onChange?: (value: string) => void` | `form.d.ts:1376` |
| `form/radio-group.mdx` | `onValueChange?: string \| ActionConfig` | `onChange?: (value: string \| number) => void` | `form.d.ts:394` |
| `form/date-picker.mdx` | `onDateChange?: string \| ActionConfig` | `onChange?: (date: Date \| undefined) => void` | `form.d.ts:642` |
| `form/combobox.mdx` | `onValueChange?: string \| ActionConfig` | `onChange?: (value: string) => void` | `form.d.ts:1324` |
| `feedback/toast.mdx` | `actionLabel` + `onAction?: string \| ActionConfig` | `action?: { label: string; onClick: () => void }` | `feedback.d.ts:137` |

⚠️ **One line number moved and the shipped type wins.** The dispatch cited `feedback.d.ts:135` from the measurement at `133e2ea1e`; on `bfdb9f906` the declaration sits at **`feedback.d.ts:137`** (`ToastSchema` itself opens at `:109`, the JSDoc *Action button* at `:135–136`). The four `form.d.ts` numbers are unchanged.

### The `string |` half goes with the name

This is the substance, not a tidy-up. #4453 narrowed the runtime to `typeof === 'function'`, so an authored string handler is **dropped** — see `packages/plugin-calendar/src/calendar-view-renderer.tsx`. A reference page promising `string | Fn` is precisely what makes an AI author emit a handler that publishes, validates, and silently does nothing. Each page now documents the declared function type, alone.

### ⚠️ `toast.mdx` also loses `actionLabel`, named here rather than left silent

The ordered restructure replaces `onAction` with the nested `action` object — and that object carries `label`. `actionLabel` is **absent from the shipped surface**: it appears nowhere in `packages/types/dist/feedback.d.ts` (checked by name, not by grep of `src/`). Keeping it beside `action.label` would have documented two ways to set one label, one of them inert — the same defect the card exists to remove, in the same section being rewritten. Folded into the restructure and called out here so it is reviewable rather than incidental.

## Measurement

A **throwaway** re-fence probe under `trap '…' EXIT INT TERM`, flipping the single `plaintext` fence in each of the 10 `ActionConfig`-bearing pages to `ts`, running the gate, and restoring. ⛔ Nothing was re-fenced for real — `content/docs/components` is #5867's lane and still blocked on #6132. Each leg proved the mutation reached disk before any reading was taken:

```
MUTATION-ON-DISK [BEFORE]: plaintext before=10 after=0 ; ts after=10
MUTATION-ON-DISK [AFTER] : plaintext before=10 after=0 ; ts after=10
TRAP-RESTORE: 0 dirty path(s) left
```

The restore leg is `git checkout HEAD -- content/docs/components`, never a bare `git checkout --`, and the fix was **committed before the probe ran** — a bare restore wiped the entire uncommitted fix on this card's PR 1.

**The prediction held exactly.**

| reading | before | after |
| --- | --- | --- |
| `TS2304: Cannot find name 'ActionConfig'` | **10** | **5** |
| semantic-phase failures | 10 of 235 judged | 5 of 235 judged |
| declared fragments | **111** | **111** — unmoved |
| syntax phase | every block parsed | every block parsed |

The 5 that remain are exactly #6132's, by file: `basic/button-group.mdx`, `feedback/sonner.mdx`, `overlay/context-menu.mdx`, `overlay/dropdown-menu.mdx`, `overlay/menubar.mdx`. Nothing else changed — no new diagnostic appeared under any of the 5 corrected blocks, which is the reading that says these annotations are now valid TypeScript and not merely different text.

⛔ No `ActionConfig` was minted, no `FRAGMENT_MARKER` declared — the unmoved 111 is that proof.

## Render check on `toast.mdx`

The restructure changes the shape a reader copies, so the page was **prerendered** — parsed with the site's own `@mdx-js/mdx` and rendered through `react-dom/server` — and the HTML read back:

```html
<h2>Schema</h2>
<pre><code class="language-plaintext">interface ToastSchema {
  ...
  // Action button
  action?: {
    label: string;
    onClick: () =&gt; void;
  };

  // Timing
  duration?: number;              // Auto-dismiss time in ms
}
</code></pre>
```

⚠️ **Read that block from the source, not from this rendered page.** GitHub's body sanitizer strips attributes out of quoted markup even inside a fence, so the `code` element above very likely shows bare here; in the actual prerender output it carried `class="language-plaintext"`, which is the part that proves the fence language is unchanged.

The nested object survives intact and escaped, the fence is still `plaintext`, and the section reads as one coherent shape. The other four pages were prerendered too; all five render.

## Gates

Union re-run on the **final** commit `6600c7ad7`, each quoting its own verdict line, exit code captured before any pipe.

| gate | exit | its own verdict line |
| --- | --- | --- |
| `check-doc-snippet-types` | 0 | `Semantic phase: 225 of 225 block(s) judged, 0 failed.` / `Every covered documentation snippet compiles against the built types.` |
| `check-doc-component-types` | 0 | `Every documented component type is registered.` |
| `check-doc-links` | 0 | `Links are valid across 15 scan roots.` |
| `check-control-bytes` | 0 | `check-control-bytes: OK (scanned 5088 tracked text file(s); skipped 85 binary).` |
| `check-changeset-presence` | 0 | `No source of a released package changed in this range, so no changeset is owed.` |
| `check-changeset-fixed` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-changeset-no-major` | 0 | `No changeset declares a major bump.` |

**Vitest: the diff implicates no suite**, stated rather than silently skipped. The diff is `content/docs/**` plus one `.changeset` file and touches no package source. No vitest test reads any of the five pages — the tests that read `content/docs` pin `api/schema-reference.md`, `components/basic/span.mdx`, `layout/*.mdx`, `plugins/plugin-calendar.mdx`, `utilities/cli.mdx` and the guide pages, none of them these. `e2e/docs-smoke.spec.ts` pins `/docs/components/form/button` and `/docs/components/feedback/alert`, also not these.

**Lint narrowing, declared — and it is a measurement, not a skip.** The repo-wide `eslint .` was not run locally. Three readings, from eslint's own configuration rather than from a guess about which files count: (1) all six changed paths return `true` from `ESLint#isPathIgnored`, so the linted population contains **zero** of them; (2) 0 of 6 changed files are linted; (3) type-aware linting is **off** — `calculateConfigForFile` reports no `parserOptions.project` and no `projectService` — so this diff cannot move the verdict on any untouched file. CI runs `pnpm lint` unfiltered regardless.

A changeset is included with **empty frontmatter** (`Docs only, publishes nothing`), matching the convention the sibling docs PRs in this lane use; the presence gate independently agrees none is owed.

## Out of scope, filed not fixed

Filed as **#6143**, not reconciled here, per the dispatch. The prerender and a per-prop sweep of these same five pages surfaced a **separate class** the gate structurally cannot see: these `## Schema` blocks **re-declare** their interface rather than importing it, so a self-declared interface compiles no matter what it says. `ActionConfig` was only ever visible because it was an *undefined name*; a key that is merely **wrong** produces no diagnostic at all. Four divergences on five pages, e.g. `toast.mdx` documents `variant?: 'default' | 'destructive'` where the shipped union is `'default' | 'success' | 'warning' | 'error' | 'info'` — `'destructive'` is not a member, and it is exactly the plausible-looking value a reader arrives with.

## Scope

⛔ #6132's five files are untouched and byte-identical to `origin/main` — verified with `git diff origin/main --` over exactly those paths, which returns empty. `plugin-dashboard.mdx` is likewise untouched. **This card stays open** for both.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
