### PR TITLE
feat(tooling): pin the fence vocabulary so no spelling hides a TypeScript block (#6135)

### DIFF
--- a/.github/workflows/doc-fence-languages.yml
+++ b/.github/workflows/doc-fence-languages.yml
@@ -1,0 +1,85 @@
+name: Doc Fence Languages
+
+# Why this is its own workflow rather than a step in `ci.yml` or `lint.yml`: the
+# defect it exists for arrives in a DOCS-ONLY pull request, and that is exactly
+# the shape both of those workflows skip — their "does this change need a full
+# run" diff excludes `content/**` and `'**/*.md'`, which is the entire surface
+# this gate reads. `doc-component-types.yml`'s header records the reasoning in
+# full; this is the sixth instance of the same shape, and `control-bytes.yml`'s
+# header names the consequence of getting it wrong: a gate that cannot see a
+# markdown-only change "rebuilds the hole it exists to close".
+#
+# Hence: no `paths` and no `paths-ignore` here, deliberately.
+# `scripts/__tests__/check-doc-fence-languages.test.ts` fails if either is ever
+# added, and fails too if a second workflow starts running the same script — one
+# gate, one home.
+#
+# It needs no install and no build. The script reads the checkout with `node:fs`
+# only — the same 222 documents `check-doc-snippet-types` covers — and it
+# deliberately re-implements that gate's document walk rather than importing it,
+# because that gate imports `typescript` and an install-gated docs check is one
+# a docs-only pull request skips. The copy is held to the original by the pin
+# test above, which imports BOTH walks and compares them. Keep this job
+# install-free: the moment it needs `pnpm install` it stops being cheap enough
+# to run unfiltered, and the filter is the hole.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  # Merge queue (objectui#3523 — see `ci.yml`'s trigger block for the full note
+  # and the measurements behind it). A required check that does not report on a
+  # queue build stalls the queue until the ruleset's 60-minute timeout fails it,
+  # so an unfiltered gate that could become required subscribes here from the
+  # start. `types:` is named although `checks_requested` is currently the only
+  # activity type GitHub defines for `merge_group`.
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: doc-fence-languages-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  doc-fence-languages:
+    name: Doc Fence Language Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.x'
+
+      # `check-doc-snippet-types` compiles `ts` / `tsx` / `typescript` fences and
+      # nothing else, so a TypeScript block fenced any other way is invisible to
+      # it — objectui#5867, whose remediation lane collected its population from
+      # ```plaintext fences only. `plaintext` is not the only spelling of an
+      # unhighlighted fence: objectui#6135 measured a ```text block opening
+      # `interface FileUploadSchema {` sitting outside the gate AND outside the
+      # lane that exists to close it, for no reason but how its fence is spelled.
+      #
+      # This gate reads block BODIES with objectui#5867's own triage classifier,
+      # so no list of languages is on the enforcement path and `txt`, `console`,
+      # `raw` or a bare fence with no info string at all cannot reopen the gap.
+      # Today's residue is declared, SHRINK-ONLY, and is that lane's remaining
+      # population per file.
+      #
+      # `--self-test` runs FIRST and is the half that stops the gate rotting into
+      # decoration: it drives the real scanner over fixture sources, including
+      # the three spellings named on objectui#6135, and pins the shrink-only
+      # baseline in every direction it can move. A scanner whose recogniser is
+      # broken reports a clean tree.
+      - name: Check that no fence spelling hides a TypeScript block
+        run: |
+          node scripts/check-doc-fence-languages.mjs --self-test
+          node scripts/check-doc-fence-languages.mjs

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -32,6 +32,7 @@ one has its own section below.
 | `skills-paths.yml` | Skill Guide Path Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a path stated in a `skills/` guide does not exist |
 | `doc-component-types.yml` | Doc Component Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a `content/docs/**.mdx` snippet teaches a `type` nothing registers |
 | `doc-snippet-types.yml` | Doc Snippet Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a covered documentation snippet no longer compiles against the packages' built types |
+| `doc-fence-languages.yml` | Doc Fence Language Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a TypeScript block sits under a fence the snippet gate does not read |
 | `performance-budget.yml` | Bundle Analysis | Push / PR touching `packages/**`, `apps/console/**`, `pnpm-lock.yaml` | **Yes** — the console entry gzip budget |
 | `live-e2e.yml` | Live E2E (informational) | PR to `main`, `develop` (code paths); nightly cron `30 6 * * *`; manual | No — informational lane, `continue-on-error` |
 | `labeler.yml` | Auto Label PRs | PR `opened`, `synchronize`, `reopened` | No |
@@ -672,6 +673,54 @@ script's header states plainly rather than letting a green run imply otherwise.
 at the harness. Either fix what the snippet teaches, or — if the block is genuinely partial — declare
 it with a reason. Run it locally with `pnpm check:doc-snippets` (after building the packages it
 names: `pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter)`).
+
+## Fence Languages (`doc-fence-languages.yml`)
+
+**Triggers:** Push and PR to `main`/`develop`, merge-queue builds, plus manual dispatch — **no path
+filter**, for the same reason as the two sections above. It appears in the checks list as **Doc Fence
+Language Check**.
+
+Runs `scripts/check-doc-fence-languages.mjs`. It answers the question the gate above cannot ask about
+itself: *is every TypeScript block in the documentation actually fenced as TypeScript?*
+`check-doc-snippet-types` reads `ts` / `tsx` / `typescript` fences and nothing else, so a TypeScript
+block fenced any other way is invisible to it —
+[#5867](https://github.com/objectstack-ai/objectui/issues/5867), whose remediation lane collected its
+population from ```plaintext fences only.
+
+**`plaintext` is not the only spelling of an unhighlighted fence.**
+[#6135](https://github.com/objectstack-ai/objectui/issues/6135) measured a ```text block opening
+`interface FileUploadSchema {` sitting outside the gate *and* outside the lane that exists to close
+it, for no reason but how its fence is spelled. Widening the lane's derivation once would fix that
+block; it would not stop a sixth spelling reopening the identical gap.
+
+**So it reads bodies, not a list of languages.** No enumeration of allowed fence languages is on the
+enforcement path — an enumeration is the thing that rots, and it rots silently. Every fence's body is
+put to #5867's own binding triage classifier (*a block whose first line starts with `import` /
+`export` / `interface` / `type X =` / `const x: T` is code*), quoted rather than extended. `txt`,
+`console`, `raw`, or a bare fence with no info string at all therefore cannot hide a block.
+
+**Two failure modes, because only one can be auto-classified.** A *known* spelling of an
+unhighlighted fence (`plaintext`, `text`, `plain`, `txt`, no info string) is #5867's population and
+its remedy is mechanical, so it is the only mode the baseline describes. Any *other* spelling might
+be a sixth synonym or a real highlighter language — that is a human's call, so it is reported
+separately and can **never** be baselined.
+
+**The baseline is #5867's remaining population.** `KNOWN_UNHIGHLIGHTED_TS_FENCES` maps a path to the
+number of hidden blocks it carries, ⛔ **shrink-only** in the shape
+[#6133](https://github.com/objectstack-ai/objectui/issues/6133) landed for
+`KNOWN_HAND_TYPED_GUARDS`: a file not in the map that carries one fails, a file carrying more than
+its number fails, and a file carrying fewer fails as *stale* and names itself. Every #5867 batch now
+lowers these numbers in the same pull request that re-fences the blocks, so the lane's arithmetic
+lives in the repository instead of being re-derived by hand in each handback.
+
+**`--self-test` runs first.** It drives the real scanner over fixture sources — including a
+`text`-fenced, a `txt`-fenced and an info-string-less TypeScript block — and pins the shrink-only
+baseline in every direction it can move. A scanner whose recogniser is broken reports a clean tree,
+which is why the probe runs before the verdict.
+
+**If it fails:** each line is `file:line ```<language> — <first line of the block>`. Re-fence the
+block ```ts (or ```tsx) and fix whatever `check-doc-snippets` then reports, then lower the file's
+number. Run it locally with `pnpm check:doc-fences`; it needs no install and no build.
 
 ## Link Checking (`check-links.yml`)
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "check:skills-paths": "node scripts/check-skills-paths.mjs",
     "check:doc-types": "node scripts/check-doc-component-types.mjs",
     "check:doc-snippets": "node scripts/check-doc-snippet-types.mjs",
+    "check:doc-fences": "node scripts/check-doc-fence-languages.mjs",
     "check:eager-closure": "node scripts/check-eager-closure-budget.mjs",
     "check:entry-guard": "node scripts/check-entry-guard.mjs",
     "cli": "node packages/cli/dist/cli.js",

--- a/scripts/__tests__/check-doc-fence-languages.test.ts
+++ b/scripts/__tests__/check-doc-fence-languages.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+import { census, listDocuments as fenceDocuments, TS_FENCE_LANGUAGES as GUARD_TS_FENCES } from '../check-doc-fence-languages.mjs';
+import { listDocuments as snippetDocuments, TS_FENCE_LANGUAGES as GATE_TS_FENCES } from '../check-doc-snippet-types.mjs';
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+const GUARD = 'scripts/check-doc-fence-languages.mjs';
+const WORKFLOW = 'doc-fence-languages.yml';
+
+/**
+ * objectui#6135. `check-doc-snippet-types` reads `ts` / `tsx` / `typescript`
+ * fences, so a TypeScript block fenced any other way is invisible to it, and
+ * objectui#5867's remediation lane collected its population from `plaintext`
+ * fences only — one spelling of an unhighlighted fence out of several. A
+ * ```text block opening `interface FileUploadSchema {` was outside both.
+ *
+ * `check-doc-fence-languages.mjs` closes that by reading BODIES rather than
+ * pinning a list of languages. This file pins the two things its correctness
+ * rests on and cannot check about itself:
+ *
+ *   1. **The scan surface really is the gate's.** The guard re-implements
+ *      `listDocuments` so it needs no `pnpm install` — the gate imports
+ *      `typescript`, and an install-gated docs check is one a docs-only pull
+ *      request skips, which is the hole `doc-component-types.yml`'s header
+ *      records. A copy that is never compared is a copy free to drift, and the
+ *      drift direction is silent: a document the guard stops walking is a
+ *      document nothing reports on. So both walks are imported and compared.
+ *   2. **The wiring.** A gate nobody runs is indistinguishable from a gate that
+ *      passes (`entry-guard-wiring.test.ts` records that lesson for its own
+ *      subject). The alias, the workflow, the self-test leg and the
+ *      unfiltered triggers are asserted here.
+ *
+ * Deliberately NOT asserted: the size of the baseline or the number of blocks it
+ * carries. Those move with every objectui#5867 batch, and a hand-copied
+ * enumeration in a test drifts by construction — the lesson `lint-workflow.test.ts`
+ * records for this repository at length. The guard's own output is the honest
+ * place for those numbers.
+ */
+describe('check-doc-fence-languages: the scan surface is check-doc-snippet-types’s', () => {
+  it('walks exactly the documents the snippet gate walks', () => {
+    expect(fenceDocuments(ROOT)).toEqual(snippetDocuments(ROOT));
+  });
+
+  it('…and that is a non-empty set, so the comparison is not vacuous', () => {
+    expect(fenceDocuments(ROOT).length).toBeGreaterThan(100);
+  });
+
+  it('treats exactly the snippet gate’s fence languages as already-covered', () => {
+    expect([...GUARD_TS_FENCES].sort()).toEqual([...GATE_TS_FENCES].sort());
+  });
+});
+
+describe('check-doc-fence-languages: non-vacuity, through the shipped module', () => {
+  const TS_BODY = 'interface FileUploadSchema {\n  accept?: string;\n}';
+  const doc = (info: string, body: string = TS_BODY) => [
+    { rel: 'probe.mdx', source: ['```' + info, body, '```'].join('\n') },
+  ];
+  const modes = (info: string, body?: string) =>
+    census(doc(info, body)).sites.map((s: { mode: string }) => s.mode);
+
+  // The three spellings the 2026-08-24 ruling on objectui#6135 named by hand.
+  it.each(['text', 'txt', ''])('a TypeScript block fenced %o is found', (info) => {
+    expect(modes(info)).toEqual(['synonym']);
+  });
+
+  it('names the file and the fence line, rather than only counting', () => {
+    const [site] = census(doc('text')).sites;
+    expect(site).toMatchObject({ rel: 'probe.mdx', line: 1, language: 'text', mode: 'synonym' });
+  });
+
+  it.each(['ts', 'tsx', 'typescript'])('the same block fenced %o is not a finding', (info) => {
+    expect(modes(info)).toEqual([]);
+  });
+
+  it('a spelling nobody has thought of is the OTHER failure mode', () => {
+    expect(modes('console')).toEqual(['unknown']);
+  });
+
+  it('prose under an unhighlighted fence is not a finding — the classifier is quoted, not widened', () => {
+    expect(modes('plaintext', 'Upload a file, then press Save.')).toEqual([]);
+  });
+});
+
+describe('check-doc-fence-languages is wired, not merely present', () => {
+  const workflow = parseYaml(fs.readFileSync(path.join(ROOT, '.github/workflows', WORKFLOW), 'utf8'));
+  const steps: Array<Record<string, unknown>> = workflow.jobs['doc-fence-languages'].steps;
+  const gateSteps = steps.filter((s) => typeof s.run === 'string' && (s.run as string).includes(GUARD));
+
+  it('the guard script exists', () => {
+    expect(fs.existsSync(path.join(ROOT, GUARD))).toBe(true);
+  });
+
+  it('package.json aliases it, and the alias points at the script that exists', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+    expect(pkg.scripts['check:doc-fences']).toContain(GUARD);
+  });
+
+  it('the workflow runs it — one step, both legs', () => {
+    expect(gateSteps).toHaveLength(1);
+    const run = gateSteps[0].run as string;
+    expect(run).toContain(`node ${GUARD} --self-test`);
+    expect(run.split('\n').some((l) => l.trim() === `node ${GUARD}`)).toBe(true);
+  });
+
+  it('one gate, one home — no other workflow runs the same script', () => {
+    const dir = path.join(ROOT, '.github/workflows');
+    const others = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith('.yml') && f !== WORKFLOW)
+      .filter((f) => fs.readFileSync(path.join(dir, f), 'utf8').includes(GUARD));
+    expect(others).toEqual([]);
+  });
+
+  it('has no paths filter — the defect it catches arrives in a docs-only pull request', () => {
+    // `on` parses as the boolean `true` in YAML 1.1; `yaml` gives back `on`.
+    const on = workflow.on ?? workflow[true as unknown as string];
+    expect(Object.keys(on)).toContain('pull_request');
+    expect(on.pull_request).not.toHaveProperty('paths');
+    expect(on.pull_request).not.toHaveProperty('paths-ignore');
+  });
+
+  it('subscribes to the merge queue, so it cannot stall one if it becomes required', () => {
+    const on = workflow.on ?? workflow[true as unknown as string];
+    expect(Object.keys(on)).toContain('merge_group');
+  });
+
+  it('needs no install — nothing in the job runs pnpm', () => {
+    const runs = steps.map((s) => (typeof s.run === 'string' ? s.run : '')).join('\n');
+    expect(runs).not.toContain('pnpm');
+  });
+
+  it('its self-test passes — the half that makes a green scan mean something', () => {
+    const out = execFileSync('node', [GUARD, '--self-test'], { cwd: ROOT, encoding: 'utf8' });
+    expect(out).toMatch(/check-doc-fence-languages self-test: \d+ cases pass/);
+  });
+});

--- a/scripts/check-doc-fence-languages.mjs
+++ b/scripts/check-doc-fence-languages.mjs
@@ -1,0 +1,602 @@
+#!/usr/bin/env node
+/**
+ * A fenced block whose BODY is TypeScript must be fenced `ts` / `tsx` /
+ * `typescript`. No spelling of an unhighlighted fence may hide one from
+ * `check-doc-snippet-types`.
+ *
+ * Run:  node scripts/check-doc-fence-languages.mjs   (also `pnpm check:doc-fences`)
+ *       node scripts/check-doc-fence-languages.mjs --self-test
+ *       node scripts/check-doc-fence-languages.mjs --list
+ * Exit: 0 = no TypeScript block sits under a non-TypeScript fence beyond the
+ *       declared, shrink-only debt below. 1 = one does, or the debt list is
+ *       stale.
+ *
+ * ## The hole this closes (objectui#6135, measured, not predicted)
+ *
+ * `check-doc-snippet-types` compiles `ts` / `tsx` / `typescript` fences and
+ * nothing else, so a TypeScript block fenced any other way is invisible to it —
+ * that is objectui#5867, and its remediation lane collects the population by
+ * walking ```plaintext fences.
+ *
+ * ⚠️ `plaintext` is not the only spelling of an unhighlighted fence, and until
+ * this file landed nothing pinned the vocabulary. Re-running objectui#5867's own
+ * derivation on `origin/main` `bfdb9f906` with the fence-language set widened by
+ * `text` and `plain`, and nothing else changed, moved the population by exactly
+ * one block:
+ *
+ *     plaintext                        127 blocks / 91 files
+ *     plaintext + text + plain         128 blocks / 92 files
+ *     …+ txt + no info string at all   128 blocks / 92 files
+ *
+ * The block the wider set adds is `content/docs/components/form/file-upload.mdx:27`,
+ * a ```text fence opening `interface FileUploadSchema {`. It had been outside the
+ * lane's population — and outside the gate — the whole time, for no reason other
+ * than how its fence is spelled.
+ *
+ * Widening the lane's derivation once fixes that one block. It does NOT stop a
+ * sixth spelling reopening the identical gap tomorrow, and the 2026-08-24 ruling
+ * on objectui#6135 (route "A then C") is explicit that the durable half is the
+ * point: "A alone chases spellings … Fixing the lane's arithmetic without pinning
+ * the vocabulary means this card gets refiled under a different fence name."
+ *
+ * ## Why this reads BODIES rather than pinning a list of languages
+ *
+ * The obvious shape — enumerate the allowed fence languages and ban the rest —
+ * was measured and rejected here, because the enumeration IS the thing that
+ * rots. It has to be extended every time a page picks up a new highlighter
+ * language, each extension is a place to get it wrong, and the failure direction
+ * is silent: a spelling nobody added is a spelling nobody notices.
+ *
+ * Reading the body removes the list from the load-bearing path entirely. The
+ * question asked of every fence is triage's, not this file's:
+ *
+ *     a block whose first line starts with `import` / `export` / `interface` /
+ *     `type X =` / `const x: T` IS code
+ *
+ * — objectui#5867's binding triage ruling, 2026-08-24. ⛔ That classifier is
+ * quoted here, not extended: this gate widens WHICH FENCES are examined, never
+ * what counts as code. Those are two different edges and only the second was
+ * ruled. A block that fails the classifier is prose and this gate says nothing
+ * about it, whatever its fence says.
+ *
+ * The consequence is the property the ruling asked for: `txt`, `console`, `raw`,
+ * `output`, a bare ``` with no info string at all — none of them is named
+ * anywhere in the enforcement path, and every one of them fails the moment it
+ * carries a TypeScript body.
+ *
+ * ## The two failure modes, because only one of them can be auto-classified
+ *
+ * SYNONYM   the fence is a KNOWN spelling of an unhighlighted block —
+ *           `plaintext`, `text`, `plain`, `txt`, or no info string at all
+ *           (`UNHIGHLIGHTED_SPELLINGS`). The gate knows exactly what this is:
+ *           objectui#5867's population, one block of it. The remedy is
+ *           mechanical — re-fence it `ts` or `tsx` — so it is the only mode a
+ *           baseline entry can describe.
+ *
+ * UNKNOWN   the fence names something else — a spelling nobody has thought of.
+ *           The gate CANNOT auto-classify it: `raw` might be a sixth synonym of
+ *           an unhighlighted fence, or a real highlighter language whose block
+ *           happens to open with `import`. Deciding which is a human's call, so
+ *           this mode ⛔ can never be baselined and fails on sight. There are
+ *           ZERO of them in the tree today, which is what makes "never
+ *           baselined" affordable rather than aspirational.
+ *
+ * `UNHIGHLIGHTED_SPELLINGS` therefore chooses a MESSAGE, never a verdict. Adding
+ * a spelling to it moves a finding from UNKNOWN to SYNONYM; it does not excuse
+ * the block, because SYNONYM findings still have to be inside a shrink-only
+ * baseline that no supported route adds to. There is no edit to this file that
+ * makes a new TypeScript-under-a-non-TypeScript-fence block pass.
+ *
+ * ## The baseline, and why it is the lane's population rather than a permit
+ *
+ * ⛔ SHRINK-ONLY, in the shape objectui#6133 landed for
+ * `KNOWN_HAND_TYPED_GUARDS`: `path -> number of SYNONYM blocks the file carried
+ * when this gate landed`. A count rather than a bare path, for that card's third
+ * reason, which is the one that matters — a path-only baseline silently accepts a
+ * SECOND hidden block being smuggled into an already-owed file.
+ *
+ *   • a file NOT in the map that carries one fails — a new hidden block cannot land;
+ *   • a file IN the map carrying MORE than its number fails;
+ *   • a file carrying FEWER fails as STALE and names itself, the remedy being to
+ *     lower or delete the line. No supported route raises a number.
+ *
+ * The map is not a debt list this gate invented. It IS objectui#5867's remaining
+ * population, per file, machine-readable and in the repository — 92 entries and
+ * 128 blocks at the commit this landed on, reconciling exactly with that card's
+ * own derivation. Every batch of that lane now lowers these numbers in the same
+ * pull request that re-fences the blocks, which is what stops the lane's
+ * arithmetic from being a figure re-derived by hand in each handback and trusted
+ * by the next dispatch. When the last entry goes, so does the map, and the rule
+ * above stands alone.
+ *
+ * ## What it reads, and what it deliberately does not
+ *
+ * The scan surface is `check-doc-snippet-types`'s, exactly: every `.mdx` and
+ * `.md` under `content/docs`, plus every `packages/<name>/README.md`. It is
+ * re-implemented here rather than imported so this gate needs NO install — that
+ * gate imports `typescript`, and an install-gated docs check is one that a
+ * docs-only pull request skips, which is the shape objectui#5174 and
+ * `doc-component-types.yml`'s header both record as the hole. The copy is not
+ * left to drift: `scripts/__tests__/check-doc-fence-languages.test.ts` imports
+ * BOTH walks and fails if they ever return different document lists, and pins
+ * this file's TypeScript-fence set against the gate's own `TS_FENCE_LANGUAGES`.
+ *
+ * ⛔ It compiles nothing. Whether a block that reaches a `ts` fence then passes
+ * `--strict` is `check-doc-snippet-types`'s question; this gate only makes sure
+ * the block is asked.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// ── The scan surface — kept identical to check-doc-snippet-types by test ─────
+
+const DOCS_ROOT = 'content/docs';
+const PACKAGES_DIR = 'packages';
+const DOC_EXTENSIONS = ['.mdx', '.md'];
+
+/** Every document in the scan set, in a stable order. */
+export function listDocuments(root = repoRoot) {
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir).sort()) {
+      const p = join(dir, entry);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (DOC_EXTENSIONS.some((ext) => entry.endsWith(ext))) out.push(relative(root, p).split(sep).join('/'));
+    }
+  };
+  const docsRoot = join(root, DOCS_ROOT);
+  if (existsSync(docsRoot)) walk(docsRoot);
+  const pkgDir = join(root, PACKAGES_DIR);
+  if (existsSync(pkgDir)) {
+    for (const entry of readdirSync(pkgDir).sort()) {
+      const readme = join(pkgDir, entry, 'README.md');
+      if (existsSync(readme)) out.push(relative(root, readme).split(sep).join('/'));
+    }
+  }
+  return out;
+}
+
+// ── The vocabulary: one set gates, one set only labels ───────────────────────
+
+/** Fences `check-doc-snippet-types` already compiles. Pinned against that gate's
+ *  own export by the test, so a change there cannot leave this one behind. */
+export const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
+
+/**
+ * Known spellings of an UNHIGHLIGHTED fence, including the empty info string.
+ * This set picks the failure MODE and its remedy text; it never decides whether
+ * a block fails. See the header: adding a spelling here moves a finding from
+ * UNKNOWN to SYNONYM and nothing else.
+ */
+export const UNHIGHLIGHTED_SPELLINGS = new Set(['plaintext', 'text', 'plain', 'txt', '']);
+
+// ── Triage's classifier, quoted rather than extended ─────────────────────────
+
+/**
+ * objectui#5867's binding triage ruling (2026-08-24): a block whose FIRST LINE
+ * starts with `import` / `export` / `interface` / `type X =` / `const x: T` is
+ * code.
+ *
+ * "First line" is read literally — line 1 of the body, no leading whitespace
+ * tolerated — and that is a measurement rather than a preference. A variant that
+ * trims first agrees with this one on all 127 `plaintext` blocks and on the
+ * `text` one, and disagrees on exactly one block in the tree:
+ * `content/docs/guide/architecture-overview.md:123`, an ASCII-art plugin
+ * lifecycle diagram whose first line is an INDENTED `import 'plugin-kanban'`
+ * inside a box drawing. It is not TypeScript, and the strict reading is the one
+ * that says so.
+ */
+export function classifiesAsTypeScript(body) {
+  const line = body.split('\n')[0];
+  return (
+    /^import\b/.test(line) ||
+    /^export\b/.test(line) ||
+    /^interface\s/.test(line) ||
+    /^type\s+[A-Za-z_$][\w$]*\s*(<[^=]*>)?\s*=/.test(line) ||
+    /^const\s+[A-Za-z_$][\w$]*\s*:/.test(line)
+  );
+}
+
+// ── Fence scanning ───────────────────────────────────────────────────────────
+
+/**
+ * EVERY fenced block in one document, with its info-string language. Fences are
+ * matched by their own run length — the same walk `check-doc-snippet-types`
+ * uses — so a ```` ```` ```` wrapper containing ``` does not confuse it. This
+ * one filters nothing: the whole point is to see the fences that gate cannot.
+ */
+export function scanFences(source) {
+  const lines = source.split('\n');
+  const blocks = [];
+  for (let i = 0; i < lines.length; i++) {
+    const open = /^([ \t]*)(`{3,})(.*)$/.exec(lines[i]);
+    if (!open) continue;
+    const ticks = open[2];
+    let close = lines.length;
+    for (let j = i + 1; j < lines.length; j++) {
+      const c = /^[ \t]*(`{3,})[ \t]*$/.exec(lines[j]);
+      if (c && c[1].length >= ticks.length) {
+        close = j;
+        break;
+      }
+    }
+    const info = open[3].trim();
+    blocks.push({
+      fenceLine: i + 1,
+      language: (info.split(/\s+/)[0] || '').toLowerCase(),
+      body: lines.slice(i + 1, close).join('\n'),
+    });
+    i = close;
+  }
+  return blocks;
+}
+
+/** `null` when the block is nothing to this gate; otherwise its failure mode. */
+export function classifyFence(block) {
+  if (TS_FENCE_LANGUAGES.has(block.language)) return null;
+  if (!classifiesAsTypeScript(block.body)) return null;
+  return UNHIGHLIGHTED_SPELLINGS.has(block.language) ? 'synonym' : 'unknown';
+}
+
+/**
+ * Every hidden TypeScript block across a set of `{ rel, source }` documents.
+ * Pure, so the self-test drives it over fixture sources rather than the tree.
+ */
+export function census(documents) {
+  const sites = [];
+  for (const { rel, source } of documents) {
+    for (const block of scanFences(source)) {
+      const mode = classifyFence(block);
+      if (!mode) continue;
+      sites.push({
+        rel,
+        line: block.fenceLine,
+        language: block.language,
+        mode,
+        head: (block.body.split('\n')[0] || '').trim().slice(0, 72),
+      });
+    }
+  }
+  const observed = new Map();
+  for (const s of sites.filter((s) => s.mode === 'synonym')) observed.set(s.rel, (observed.get(s.rel) ?? 0) + 1);
+  return { sites, observed, unknown: sites.filter((s) => s.mode === 'unknown') };
+}
+
+// ── The debt: objectui#5867's remaining population, per file ─────────────────
+
+/**
+ * ⛔ SHRINK-ONLY. `path -> number of SYNONYM-mode blocks the file carried when
+ * this gate landed` — objectui#5867's remaining population, per file, at
+ * `bfdb9f906`: 92 files, 128 blocks. The rationale, and why a COUNT rather than
+ * a bare path, is in the header; the shape is objectui#6133's.
+ *
+ * The remedy for every line is the same, which is the property that makes a debt
+ * list safe: re-fence the block ```ts (or ```tsx), fix whatever
+ * `check-doc-snippet-types` then reports, and lower the number here — deleting
+ * the line when it reaches 0. That is objectui#5867's batches, and no entry
+ * records a judgement anyone has to re-make.
+ *
+ * ⚠️ ONE entry is different in kind and is labelled rather than left to be
+ * re-derived. `content/docs/components/form/file-upload.mdx` is the block this
+ * card surfaced, and it is NOT merely blocked — objectui#6138 measured that a
+ * block declaring its OWN `interface` and then being checked against it compiles
+ * VACUOUSLY, and `file-upload.mdx:27` opens `interface FileUploadSchema {`. Its
+ * line comes down when objectui#6138 rules on what such a block should be, not
+ * when someone re-fences it; re-fencing it today would add a block that reports
+ * green while checking nothing.
+ *
+ * @type {Map<string, number>}
+ */
+export const KNOWN_UNHIGHLIGHTED_TS_FENCES = new Map([
+  ['content/docs/blocks/block-schema.mdx', 10],
+  ['content/docs/components/basic/button-group.mdx', 1],
+  ['content/docs/components/basic/html.mdx', 1],
+  ['content/docs/components/basic/icon.mdx', 1],
+  ['content/docs/components/basic/image.mdx', 1],
+  ['content/docs/components/basic/navigation-menu.mdx', 1],
+  ['content/docs/components/basic/pagination.mdx', 1],
+  ['content/docs/components/basic/separator.mdx', 1],
+  ['content/docs/components/basic/sidebar.mdx', 1],
+  ['content/docs/components/basic/text.mdx', 1],
+  ['content/docs/components/complex/carousel.mdx', 1],
+  ['content/docs/components/complex/data-table.mdx', 1],
+  ['content/docs/components/complex/filter-builder.mdx', 1],
+  ['content/docs/components/complex/filter-ui.mdx', 1],
+  ['content/docs/components/complex/resizable.mdx', 1],
+  ['content/docs/components/complex/scroll-area.mdx', 1],
+  ['content/docs/components/complex/sort-ui.mdx', 1],
+  ['content/docs/components/complex/table.mdx', 1],
+  ['content/docs/components/complex/view-switcher.mdx', 1],
+  ['content/docs/components/data-display/alert.mdx', 1],
+  ['content/docs/components/data-display/avatar.mdx', 1],
+  ['content/docs/components/data-display/badge.mdx', 1],
+  ['content/docs/components/data-display/breadcrumb.mdx', 1],
+  ['content/docs/components/data-display/kbd.mdx', 1],
+  ['content/docs/components/data-display/list.mdx', 1],
+  ['content/docs/components/data-display/statistic.mdx', 1],
+  ['content/docs/components/data-display/tree-view.mdx', 1],
+  ['content/docs/components/disclosure/accordion.mdx', 1],
+  ['content/docs/components/disclosure/collapsible.mdx', 1],
+  ['content/docs/components/disclosure/toggle-group.mdx', 1],
+  ['content/docs/components/feedback/empty.mdx', 1],
+  ['content/docs/components/feedback/loading.mdx', 1],
+  ['content/docs/components/feedback/progress.mdx', 1],
+  ['content/docs/components/feedback/skeleton.mdx', 1],
+  ['content/docs/components/feedback/sonner.mdx', 1],
+  ['content/docs/components/feedback/spinner.mdx', 1],
+  ['content/docs/components/feedback/toast.mdx', 1],
+  ['content/docs/components/feedback/toaster.mdx', 1],
+  ['content/docs/components/form/button.mdx', 1],
+  ['content/docs/components/form/calendar.mdx', 1],
+  ['content/docs/components/form/checkbox.mdx', 1],
+  ['content/docs/components/form/combobox.mdx', 1],
+  ['content/docs/components/form/command.mdx', 1],
+  ['content/docs/components/form/date-picker.mdx', 1],
+  ['content/docs/components/form/file-upload.mdx', 1],
+  ['content/docs/components/form/form.mdx', 1],
+  ['content/docs/components/form/input-otp.mdx', 1],
+  ['content/docs/components/form/input.mdx', 1],
+  ['content/docs/components/form/label.mdx', 1],
+  ['content/docs/components/form/radio-group.mdx', 1],
+  ['content/docs/components/form/select.mdx', 1],
+  ['content/docs/components/form/slider.mdx', 1],
+  ['content/docs/components/form/switch.mdx', 1],
+  ['content/docs/components/form/textarea.mdx', 1],
+  ['content/docs/components/layout/aspect-ratio.mdx', 1],
+  ['content/docs/components/layout/card.mdx', 1],
+  ['content/docs/components/layout/container.mdx', 1],
+  ['content/docs/components/layout/flex.mdx', 1],
+  ['content/docs/components/layout/grid.mdx', 1],
+  ['content/docs/components/layout/page.mdx', 1],
+  ['content/docs/components/layout/stack.mdx', 1],
+  ['content/docs/components/layout/tabs.mdx', 1],
+  ['content/docs/components/navigation/header-bar.mdx', 1],
+  ['content/docs/components/overlay/alert-dialog.mdx', 1],
+  ['content/docs/components/overlay/context-menu.mdx', 1],
+  ['content/docs/components/overlay/dialog.mdx', 1],
+  ['content/docs/components/overlay/drawer.mdx', 1],
+  ['content/docs/components/overlay/dropdown-menu.mdx', 1],
+  ['content/docs/components/overlay/hover-card.mdx', 1],
+  ['content/docs/components/overlay/menubar.mdx', 1],
+  ['content/docs/components/overlay/popover.mdx', 1],
+  ['content/docs/components/overlay/sheet.mdx', 1],
+  ['content/docs/components/overlay/tooltip.mdx', 1],
+  ['content/docs/core/report-schema.mdx', 11],
+  ['content/docs/fields/auto-number.mdx', 2],
+  ['content/docs/fields/object.mdx', 2],
+  ['content/docs/layout/app-shell.mdx', 4],
+  ['content/docs/layout/page-header.mdx', 3],
+  ['content/docs/layout/sidebar-nav.mdx', 5],
+  ['content/docs/plugins/plugin-calendar.mdx', 1],
+  ['content/docs/plugins/plugin-charts.mdx', 1],
+  ['content/docs/plugins/plugin-chatbot.mdx', 2],
+  ['content/docs/plugins/plugin-dashboard.mdx', 3],
+  ['content/docs/plugins/plugin-editor.mdx', 1],
+  ['content/docs/plugins/plugin-form.mdx', 2],
+  ['content/docs/plugins/plugin-gantt.mdx', 1],
+  ['content/docs/plugins/plugin-grid.mdx', 2],
+  ['content/docs/plugins/plugin-kanban.mdx', 1],
+  ['content/docs/plugins/plugin-map.mdx', 1],
+  ['content/docs/plugins/plugin-markdown.mdx', 1],
+  ['content/docs/plugins/plugin-timeline.mdx', 1],
+  ['content/docs/plugins/plugin-view.mdx', 2],
+]);
+
+/** Split observed counts against the baseline. Both directions are failures. */
+export function reconcile(observed, baseline) {
+  const fresh = [];
+  for (const [rel, count] of observed) {
+    const owed = baseline.get(rel) ?? 0;
+    if (count > owed) fresh.push({ rel, count, owed });
+  }
+  const stale = [];
+  for (const [rel, owed] of baseline) {
+    const count = observed.get(rel) ?? 0;
+    if (count < owed) stale.push({ rel, count, owed });
+  }
+  return { fresh: fresh.sort((a, b) => (a.rel < b.rel ? -1 : 1)), stale: stale.sort((a, b) => (a.rel < b.rel ? -1 : 1)) };
+}
+
+// ── Verdict ──────────────────────────────────────────────────────────────────
+
+const REMEDY_SYNONYM =
+  `\n    That block is TypeScript by objectui#5867's triage classifier, under a` +
+  `\n    fence check-doc-snippet-types does not read. Re-fence it \`\`\`ts (or` +
+  `\n    \`\`\`tsx) and fix what that gate then reports.` +
+  `\n` +
+  `\n    KNOWN_UNHIGHLIGHTED_TS_FENCES is SHRINK-ONLY: adding a line, or raising` +
+  `\n    a number, is not a supported way to make this pass.`;
+
+const REMEDY_UNKNOWN =
+  `\n    A TypeScript body under a fence language this gate has never seen. It` +
+  `\n    cannot auto-classify that, so it will not guess — and ⛔ this mode is` +
+  `\n    never baselined. Two remedies, and the choice is yours to state:` +
+  `\n` +
+  `\n      • the block is TypeScript      -> re-fence it \`\`\`ts / \`\`\`tsx;` +
+  `\n      • the fence is another spelling of an UNHIGHLIGHTED block` +
+  `\n                                     -> add the spelling to` +
+  `\n                                        UNHIGHLIGHTED_SPELLINGS *and* re-fence` +
+  `\n                                        the block. Adding the spelling alone` +
+  `\n                                        changes the message, never the verdict.`;
+
+export function analyze(documents, baseline = KNOWN_UNHIGHLIGHTED_TS_FENCES) {
+  const { sites, observed, unknown } = census(documents);
+  return { sites, observed, unknown, ...reconcile(observed, baseline) };
+}
+
+function readTree(root) {
+  return listDocuments(root).map((rel) => ({ rel, source: readFileSync(join(root, rel), 'utf8') }));
+}
+
+function list() {
+  const { sites } = census(readTree(repoRoot));
+  for (const s of sites) console.log(`${s.rel}:${s.line}  [${s.language || 'no info string'}]  ${s.mode}  ${s.head}`);
+  console.log(`${sites.length} hidden TypeScript block(s).`);
+  return 0;
+}
+
+function main() {
+  const documents = readTree(repoRoot);
+  const { sites, observed, unknown, fresh, stale } = analyze(documents);
+  const byFile = new Map();
+  for (const s of sites) byFile.set(s.rel, [...(byFile.get(s.rel) ?? []), s]);
+
+  if (unknown.length) {
+    console.error(`❌  check:doc-fences — ${unknown.length} TypeScript block(s) under an UNKNOWN fence language:\n`);
+    for (const s of unknown) console.error(`  ${s.rel}:${s.line}  \`\`\`${s.language}  — ${s.head}`);
+    console.error(REMEDY_UNKNOWN);
+    return 1;
+  }
+
+  if (fresh.length) {
+    const total = fresh.reduce((n, f) => n + (f.count - f.owed), 0);
+    console.error(`❌  check:doc-fences — ${total} TypeScript block(s) under an unhighlighted fence, beyond the baseline:\n`);
+    for (const f of fresh) {
+      for (const s of byFile.get(f.rel) ?? []) console.error(`  ${s.rel}:${s.line}  \`\`\`${s.language || '(no info string)'}  — ${s.head}`);
+      if (f.owed) console.error(`    (${f.rel} is baselined at ${f.owed}; it now carries ${f.count}. The baseline only shrinks.)`);
+    }
+    console.error(REMEDY_SYNONYM);
+    return 1;
+  }
+
+  if (stale.length) {
+    console.error(`❌  check:doc-fences — ${stale.length} stale KNOWN_UNHIGHLIGHTED_TS_FENCES entry/entries:\n`);
+    for (const s of stale) console.error(`  ${s.rel}  — baselined at ${s.owed}, now carries ${s.count}`);
+    console.error(
+      `\n    Good news, and the list has to say so: ${stale.some((s) => s.count === 0) ? 'delete the zero lines' : 'lower the numbers'} in` +
+        `\n    KNOWN_UNHIGHLIGHTED_TS_FENCES in scripts/check-doc-fence-languages.mjs` +
+        `\n    (delete the entry when it reaches 0). This map is objectui#5867's` +
+        `\n    remaining population; a stale line is that number drifting away from` +
+        `\n    the tree, which is the whole reason it is kept here rather than` +
+        `\n    re-derived by hand in each handback.`,
+    );
+    return 1;
+  }
+
+  const owed = [...KNOWN_UNHIGHLIGHTED_TS_FENCES.values()].reduce((a, b) => a + b, 0);
+  console.log(
+    `✅  check:doc-fences — every TypeScript block in ${documents.length} document(s) is fenced ts/tsx/typescript, ` +
+      `except ${KNOWN_UNHIGHLIGHTED_TS_FENCES.size} declared file(s) carrying ${owed} block(s) of objectui#5867's ` +
+      `remaining population (⛔ SHRINK-ONLY). No unknown fence spelling hides one.`,
+  );
+  return 0;
+}
+
+// ── Self-test — a guard that has never been shown to fail is not a guard ─────
+
+/**
+ * Drives the real scanner over fixture sources. The three probes the 2026-08-24
+ * ruling on objectui#6135 named by hand are the first three cases, and they are
+ * here rather than only in a throwaway mutation so that the day this gate stops
+ * seeing them is a red CI run rather than nothing at all.
+ */
+export function selfTest() {
+  const cases = [];
+  const t = (name, ok, detail) => cases.push({ name, ok, detail });
+
+  const TS_BODY = 'interface FileUploadSchema {\n  accept?: string;\n}';
+  const doc = (info, body = TS_BODY) => [{ rel: 'probe.mdx', source: ['```' + info, body, '```'].join('\n') }];
+  const modeOf = (info, body) => census(doc(info, body)).sites[0]?.mode ?? 'none';
+  const named = (info) => {
+    const { sites } = census(doc(info));
+    return sites.length === 1 && sites[0].rel === 'probe.mdx' && sites[0].line === 1;
+  };
+
+  // ── the three spellings the ruling named, each reddening AND named ────────
+  t('a ```text-fenced TypeScript block is a SYNONYM finding', modeOf('text') === 'synonym');
+  t('a ```txt-fenced TypeScript block is a SYNONYM finding', modeOf('txt') === 'synonym');
+  t('a TypeScript block with NO info string is a SYNONYM finding', modeOf('') === 'synonym');
+  t('…and each is reported with its file and fence line', named('text') && named('txt') && named(''));
+  t('```plain and ```plaintext are the same finding', modeOf('plain') === 'synonym' && modeOf('plaintext') === 'synonym');
+
+  // ── corrected blocks go green ────────────────────────────────────────────
+  t('the SAME block fenced ```ts is not a finding', modeOf('ts') === 'none');
+  t('…fenced ```tsx is not a finding', modeOf('tsx') === 'none');
+  t('…fenced ```typescript is not a finding', modeOf('typescript') === 'none');
+
+  // ── a spelling nobody has thought of is the OTHER mode, never baselined ──
+  t('a TypeScript block fenced ```console is an UNKNOWN finding', modeOf('console') === 'unknown');
+  t('…so is ```raw, and ```output', modeOf('raw') === 'unknown' && modeOf('output') === 'unknown');
+  t(
+    'an UNKNOWN finding fails even when its file is baselined',
+    (() => {
+      const { unknown } = analyze(doc('console'), new Map([['probe.mdx', 99]]));
+      return unknown.length === 1;
+    })(),
+  );
+
+  // ── the classifier is quoted, not widened ────────────────────────────────
+  t('a prose block under any of those fences is NOT a finding', modeOf('text', 'Upload a file, then press Save.') === 'none');
+  t('a bare object literal is NOT a finding', modeOf('plaintext', '{\n  "accept": "image/*"\n}') === 'none');
+  t('a comment-opening block is NOT a finding', modeOf('plaintext', '// the shape a slot receives\nfoo();') === 'none');
+  t(
+    'every limb of triage’s classifier fires',
+    ['import x from "y";', 'export const a = 1;', 'interface A {}', 'type A = B;', 'const a: A = b;'].every(
+      (b) => modeOf('plaintext', b) === 'synonym',
+    ),
+  );
+  t(
+    'an INDENTED first line is not code — the ASCII-diagram reading',
+    modeOf('', "  import 'plugin-kanban'\n       │\n       ▼") === 'none',
+  );
+
+  // ── the fence walk is the gate's: run length, not a bare ``` ─────────────
+  t(
+    'a ```` block is closed by its OWN run length, not by an inner ```',
+    (() => {
+      const s = ['````text', 'import a from "b";', '```', 'still inside', '````'].join('\n');
+      const { sites } = census([{ rel: 'p.mdx', source: s }]);
+      return sites.length === 1 && sites[0].line === 1 && sites[0].mode === 'synonym';
+    })(),
+  );
+  t(
+    'a ```ts fence QUOTED inside a ```` block is that block’s body, not a block',
+    census([{ rel: 'p.mdx', source: ['````plaintext', '```ts', 'import a from "b";', '```', '````'].join('\n') }]).sites.length === 0,
+  );
+  t(
+    'an info string with attributes still reads its language',
+    modeOf('text title="schema.ts"') === 'synonym' && modeOf('ts title="schema.ts"') === 'none',
+  );
+
+  // ── the baseline moves in exactly one direction ──────────────────────────
+  const two = [{ rel: 'a.mdx', source: ['```text', TS_BODY, '```', '```plain', TS_BODY, '```'].join('\n') }];
+  t('a file not in the map that carries one is FRESH', analyze(two, new Map()).fresh.length === 1);
+  t('a file carrying MORE than its number is FRESH', analyze(two, new Map([['a.mdx', 1]])).fresh.length === 1);
+  t('a file carrying exactly its number is clean', (() => {
+    const r = analyze(two, new Map([['a.mdx', 2]]));
+    return r.fresh.length === 0 && r.stale.length === 0;
+  })());
+  t('a file carrying FEWER is STALE', analyze(two, new Map([['a.mdx', 3]])).stale.length === 1);
+  t('a baselined file that no longer carries any is STALE', analyze([], new Map([['a.mdx', 1]])).stale.length === 1);
+
+  // ── the map describes the SYNONYM mode only ─────────────────────────────
+  t(
+    'UNHIGHLIGHTED_SPELLINGS carries the empty info string',
+    UNHIGHLIGHTED_SPELLINGS.has('') && UNHIGHLIGHTED_SPELLINGS.has('text') && UNHIGHLIGHTED_SPELLINGS.has('txt'),
+  );
+  t('no TS fence language is also an unhighlighted spelling', [...TS_FENCE_LANGUAGES].every((l) => !UNHIGHLIGHTED_SPELLINGS.has(l)));
+
+  const failed = cases.filter((c) => !c.ok);
+  for (const c of failed) console.error(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+  if (failed.length) {
+    console.error(`✗ check-doc-fence-languages self-test: ${failed.length} of ${cases.length} case(s) failed.`);
+    return 1;
+  }
+  console.log(
+    `✓ check-doc-fence-languages self-test: ${cases.length} cases pass — a TypeScript block fenced text, txt, plain or ` +
+      `with no info string at all is found and NAMED, the same block fenced ts/tsx/typescript is not, an unrecognised ` +
+      `spelling is the second failure mode and is never baselined, triage's classifier is quoted rather than widened, ` +
+      `and the shrink-only baseline is pinned in every direction it can move.`,
+  );
+  return 0;
+}
+
+if (isEntrypoint(import.meta.url)) {
+  const argv = process.argv;
+  process.exit(argv.includes('--self-test') ? selfTest() : argv.includes('--list') ? list() : main());
+}

--- a/scripts/check-doc-fence-languages.mjs
+++ b/scripts/check-doc-fence-languages.mjs
@@ -20,13 +20,19 @@
  *
  * ⚠️ `plaintext` is not the only spelling of an unhighlighted fence, and until
  * this file landed nothing pinned the vocabulary. Re-running objectui#5867's own
- * derivation on `origin/main` `bfdb9f906` with the fence-language set widened by
- * `text` and `plain`, and nothing else changed, moved the population by exactly
- * one block:
+ * derivation on `origin/main` with the fence-language set widened by `text` and
+ * `plain`, and nothing else changed, moves the population by exactly one block.
+ * Measured twice, because objectui#5867's batches were landing underneath this
+ * card while it was written — the delta is stable, the totals are not:
  *
- *     plaintext                        127 blocks / 91 files
- *     plaintext + text + plain         128 blocks / 92 files
- *     …+ txt + no info string at all   128 blocks / 92 files
+ *                                      at bfdb9f906   at 273537957
+ *     plaintext                        127 / 91       104 / 82
+ *     plaintext + text + plain         128 / 92       105 / 83
+ *     …+ txt + no info string at all   128 / 92       105 / 83
+ *
+ * (blocks / files. The 23 blocks across 9 files that left between those two
+ * readings are objectui#5867 batch 4, PR #6136, plus PR #6137 — which is exactly
+ * what the SHRINK-ONLY baseline below is for, and it caught the drift itself.)
  *
  * The block the wider set adds is `content/docs/components/form/file-upload.mdx:27`,
  * a ```text fence opening `interface FileUploadSchema {`. It had been outside the
@@ -101,8 +107,8 @@
  *     lower or delete the line. No supported route raises a number.
  *
  * The map is not a debt list this gate invented. It IS objectui#5867's remaining
- * population, per file, machine-readable and in the repository — 92 entries and
- * 128 blocks at the commit this landed on, reconciling exactly with that card's
+ * population, per file, machine-readable and in the repository — 83 entries and
+ * 105 blocks at the commit this landed on, reconciling exactly with that card's
  * own derivation. Every batch of that lane now lowers these numbers in the same
  * pull request that re-fences the blocks, which is what stops the lane's
  * arithmetic from being a figure re-derived by hand in each handback and trusted
@@ -184,8 +190,8 @@ export const UNHIGHLIGHTED_SPELLINGS = new Set(['plaintext', 'text', 'plain', 't
  *
  * "First line" is read literally — line 1 of the body, no leading whitespace
  * tolerated — and that is a measurement rather than a preference. A variant that
- * trims first agrees with this one on all 127 `plaintext` blocks and on the
- * `text` one, and disagrees on exactly one block in the tree:
+ * trims first agrees with this one on every `plaintext` block in the tree and on
+ * the `text` one, and disagrees on exactly one block in the tree:
  * `content/docs/guide/architecture-overview.md:123`, an ASCII-art plugin
  * lifecycle diagram whose first line is an INDENTED `import 'plugin-kanban'`
  * inside a box drawing. It is not TypeScript, and the strict reading is the one
@@ -272,7 +278,7 @@ export function census(documents) {
 /**
  * ⛔ SHRINK-ONLY. `path -> number of SYNONYM-mode blocks the file carried when
  * this gate landed` — objectui#5867's remaining population, per file, at
- * `bfdb9f906`: 92 files, 128 blocks. The rationale, and why a COUNT rather than
+ * `273537957`: 83 files, 105 blocks. The rationale, and why a COUNT rather than
  * a bare path, is in the header; the shape is objectui#6133's.
  *
  * The remedy for every line is the same, which is the property that makes a debt
@@ -293,7 +299,6 @@ export function census(documents) {
  * @type {Map<string, number>}
  */
 export const KNOWN_UNHIGHLIGHTED_TS_FENCES = new Map([
-  ['content/docs/blocks/block-schema.mdx', 10],
   ['content/docs/components/basic/button-group.mdx', 1],
   ['content/docs/components/basic/html.mdx', 1],
   ['content/docs/components/basic/icon.mdx', 1],
@@ -367,24 +372,16 @@ export const KNOWN_UNHIGHLIGHTED_TS_FENCES = new Map([
   ['content/docs/components/overlay/sheet.mdx', 1],
   ['content/docs/components/overlay/tooltip.mdx', 1],
   ['content/docs/core/report-schema.mdx', 11],
-  ['content/docs/fields/auto-number.mdx', 2],
-  ['content/docs/fields/object.mdx', 2],
   ['content/docs/layout/app-shell.mdx', 4],
   ['content/docs/layout/page-header.mdx', 3],
   ['content/docs/layout/sidebar-nav.mdx', 5],
   ['content/docs/plugins/plugin-calendar.mdx', 1],
-  ['content/docs/plugins/plugin-charts.mdx', 1],
   ['content/docs/plugins/plugin-chatbot.mdx', 2],
   ['content/docs/plugins/plugin-dashboard.mdx', 3],
-  ['content/docs/plugins/plugin-editor.mdx', 1],
-  ['content/docs/plugins/plugin-form.mdx', 2],
   ['content/docs/plugins/plugin-gantt.mdx', 1],
-  ['content/docs/plugins/plugin-grid.mdx', 2],
   ['content/docs/plugins/plugin-kanban.mdx', 1],
   ['content/docs/plugins/plugin-map.mdx', 1],
-  ['content/docs/plugins/plugin-markdown.mdx', 1],
   ['content/docs/plugins/plugin-timeline.mdx', 1],
-  ['content/docs/plugins/plugin-view.mdx', 2],
 ]);
 
 /** Split observed counts against the baseline. Both directions are failures. */

--- a/scripts/dependabot-merge-gate.mjs
+++ b/scripts/dependabot-merge-gate.mjs
@@ -125,6 +125,7 @@ import { pathToFileURL } from 'node:url';
  *   changeset-presence.yml   Changeset Declaration
  *   doc-component-types.yml  Doc Component Type Check
  *   doc-snippet-types.yml    Doc Snippet Type Check
+ *   doc-fence-languages.yml  Doc Fence Language Check
  *
  * The four shards are spelled out individually on purpose. A single `Test`
  * entry, or any pattern match, would be satisfied by whichever shard happened
@@ -146,6 +147,7 @@ export const REQUIRED_CONTEXTS = Object.freeze([
   'Changeset Declaration',
   'Doc Component Type Check',
   'Doc Snippet Type Check',
+  'Doc Fence Language Check',
 ]);
 
 /**


### PR DESCRIPTION
Fixes #6135

Route **A then C** as ruled. **A** — the lane's population is re-derived with `text` / `plain` (and `txt`, and the empty info string) treated as synonyms of `plaintext`, and the remainder is restated below. **C** — the durable half lands with it, as `scripts/check-doc-fence-languages.mjs`.

⛔ Triage's **classifier** is quoted verbatim, never widened. ⛔ No document is re-fenced. `UNGATED_DOCS`, the ledger and `check-doc-snippet-types.mjs` are untouched; no `FRAGMENT_MARKER` is declared.

---

## 0. ⭐ The guard failed its own first CI run, and nobody staged it

The strongest non-vacuity evidence in this PR is not one of the injected probes below. It is this, from the very first `Doc Fence Language Check` job:

```
❌  check:doc-fences — 9 stale KNOWN_UNHIGHLIGHTED_TS_FENCES entry/entries:

  content/docs/blocks/block-schema.mdx  — baselined at 10, now carries 0
  content/docs/fields/auto-number.mdx  — baselined at 2, now carries 0
  content/docs/fields/object.mdx  — baselined at 2, now carries 0
  content/docs/plugins/plugin-charts.mdx  — baselined at 1, now carries 0
  …six in total under plugins/
```

Nothing was wrong with the tree. **#6136** (#5867 batch 4) and **#6137** merged while this branch was open and re-fenced **23 blocks across exactly those 9 files**. The baseline had been measured at `bfdb9f906` and the tree had moved under it — which is the one failure this design exists to make loud, arriving unprompted, in the *good* direction (the debt shrank), naming every file and printing the remedy.

A guard that only ever passes is indistinguishable from no guard. This one did not get to be that, on day one.

The remedy is followed literally: the nine zero lines are deleted, nothing else moves, and the population is **re-derived on the merged base** rather than subtracted by hand. `diff` of the old map against the new one is **nine deletions, no line added, no number raised** — shrink-only held in both directions. ⛔ The staleness check was not weakened and the baseline is not pinned to a commit.

---

## 1. The population, re-derived on current `origin/main`

Derived with `check-doc-snippet-types`'s **own** `listDocuments` (imported, not re-implemented) and a byte-for-byte copy of its own run-length fence walk, with exactly one thing changed — the language set is a parameter instead of the hard-coded `TS_FENCE_LANGUAGES`. That single difference is what makes the delta attributable.

**Control first.** Run against the card's own commit `133e2ea1e`, the same derivation reproduces the card's numbers to the block:

| fence-language set | at `133e2ea1e` | card says |
| --- | --- | --- |
| `plaintext` | 146 blocks / 102 files | 146 / 102 ✓ |
| `plaintext` + `text` + `plain` | 147 blocks / 103 files | 147 / 103 ✓ |

**Measured twice**, because #5867's batches were landing underneath this card while it was written. The delta is stable; the totals are not — which is itself the argument for keeping the number in the repository rather than in a handback:

| fence-language set | at `bfdb9f906` | at `273537957` (this base) |
| --- | --- | --- |
| `plaintext` (what every batch has used) | 127 / 91 | **104 blocks / 82 files** |
| `plaintext` + `text` + `plain` | 128 / 92 | **105 blocks / 83 files** |
| …+ `txt` | 128 / 92 | 105 / 83 |
| …+ no info string at all | 128 / 92 | 105 / 83 |

**The delta is +1 block / +1 file at both readings**, and it is the block the card named: `content/docs/components/form/file-upload.mdx:27`, a ```` ```text ```` fence opening `interface FileUploadSchema {`. `txt` and the empty info string add nothing today — worth measuring precisely because the card predicted them as the *next* spellings, and the answer is that the gap they would open is unrealised rather than already realised.

**105 / 83 is a measurement, not the arithmetic.** The PM predicted `128 − 23 = 105 / 83`; the re-derivation on the merged base returns exactly that, so prediction and measurement agree.

### The remainder, in batch 4's handback shape

105 blocks in 83 files. This table is generated from `KNOWN_UNHIGHLIGHTED_TS_FENCES` — it is not a figure re-derived by hand, and a #5867 batch that re-fences blocks without lowering the map goes red, as §0 demonstrates.

| group | blocks | files | state |
| --- | --- | --- | --- |
| `content/docs/components/**` | 72 | 72 | ⛔ blocked on #6132 |
| `content/docs/layout/**` | 12 | 3 | ⛔ blocked on #6120 |
| `content/docs/core/**` | 11 | 1 | ⛔ blocked on #6121 |
| named in `UNGATED_DOCS` — re-fencing adds **zero** to the compile population | 7 | 6 | leave |
| `content/docs/plugins/**` | 3 | 1 | ⛔ `plugin-dashboard.mdx`, recorded on #6122 |
| **total** | **105** | **83** | |

`content/docs/blocks/**` and `content/docs/fields/**` are **gone from the table entirely** — batch 4 and #6137 took them, which is what §0 caught.

The `components` count is **72**, not 71: it is the group's 71 `plaintext` blocks **plus** `file-upload.mdx:27`. That is deliverable A's whole visible effect on the arithmetic.

### `content/docs/components/form/file-upload.mdx` — in the population, not fixable

Named here rather than touched, for the two independent reasons the ruling gives:

1. it is in the `components` group, blocked on **#6132**;
2. more decisively and newer than the card, **#6138** measured that a block declaring its **own** `interface` and then being checked against it compiles **vacuously**. `file-upload.mdx:27` is exactly that form. Re-fencing it would add a block that reports green while checking nothing — the #5044 class this lane exists to close, arriving by the lane's own hand.

Its baseline line is labelled in the map so nobody re-derives that judgement: it comes down when **#6138** rules on what such a block should be, not when someone re-fences it.

---

## 2. The guard — the mechanism, and why this one

The ruling deliberately did not prescribe the mechanism. Three were measured.

**Rejected — widen the derivation's language set.** This is A without C. It fixes one block and pins nothing: `console`, `raw`, `output`, a bare fence with no info string are all still free, and the card gets refiled under a different fence name.

**Rejected — enumerate the allowed fence languages and ban the rest** (the "normalisation that makes alternate spellings not expressible" route). The measured objection is that **the enumeration is the thing that rots**: the tree carries 20 distinct fence languages today, the list needs extending every time a page picks up a new highlighter language, and the failure direction is silent — a spelling nobody added is a spelling nobody notices. It also cannot be landed inside this card's scope: banning the empty info string alone would demand re-fencing 36 blocks, and ⛔ re-fencing is out of scope.

**Chosen — read block BODIES, so no list of languages is on the enforcement path.** The rule is one sentence:

> A fenced block whose **body** is TypeScript must be fenced `ts` / `tsx` / `typescript`.

The question put to every fence is triage's, quoted rather than extended — *a block whose first line starts with `import` / `export` / `interface` / `type X =` / `const x: T` is code*. Because the fence spelling is never consulted to decide **whether** a block fails, `txt`, `console`, `raw` and a bare ``` are all closed by construction, without any of them being named anywhere in the enforcement path. That is the outcome the ruling asked for: after this lands, no spelling of an unhighlighted fence can hide a TypeScript block from the lane again.

### The two failure modes, kept apart because only one can be auto-classified

| mode | when | why it is separate |
| --- | --- | --- |
| **SYNONYM** | the fence is a *known* spelling of an unhighlighted block — `plaintext`, `text`, `plain`, `txt`, or no info string (`UNHIGHLIGHTED_SPELLINGS`) | the gate knows exactly what this is: #5867's population. The remedy is mechanical — re-fence ```` ```ts ````. So it is the **only** mode a baseline entry can describe. |
| **UNKNOWN** | any other spelling | the gate **cannot** auto-classify it: `raw` might be a sixth synonym, or a real highlighter language whose block happens to open with `import`. That is a human's call, so this mode ⛔ **can never be baselined** and fails on sight. **Zero in the tree today**, which is what makes "never baselined" affordable rather than aspirational. |

`UNHIGHLIGHTED_SPELLINGS` therefore chooses a **message**, never a verdict. Adding a spelling to it moves a finding from UNKNOWN to SYNONYM; it does not excuse the block, because SYNONYM findings still have to sit inside a shrink-only baseline that no supported route adds to. **There is no edit to this file that makes a new hidden TypeScript block pass.**

### The baseline

`KNOWN_UNHIGHLIGHTED_TS_FENCES`, `path -> count`, ⛔ **SHRINK-ONLY**, in the exact shape **#6133** landed for `KNOWN_HAND_TYPED_GUARDS` — including that card's third reason, which is the one that matters: a path-only baseline silently accepts a *second* hidden block smuggled into an already-owed file.

It is not a debt list this gate invented. It **is** #5867's remaining population per file, in the repository. Every batch of that lane now lowers these numbers in the same pull request that re-fences the blocks, which is what stops the arithmetic being a figure re-derived by hand in each handback and trusted by the next dispatch. §0 is what that looks like when it is *not* done in the same pull request. When the last entry goes, so does the map.

### Where it runs

Its own workflow (`doc-fence-languages.yml`), no `paths` filter, `merge_group` subscribed — because the defect arrives in a docs-only pull request, which is exactly the shape `ci.yml` and `lint.yml` skip. It is **install-free and build-free**: it re-implements the snippet gate's document walk rather than importing it (that gate imports `typescript`), and the copy is held to the original by a test that imports **both** walks and compares them, plus a comparison of its TS-fence set against that gate's own `TS_FENCE_LANGUAGES` export.

---

## 3. Non-vacuity — the whole deliverable

Beyond §0, which is the unstaged half.

**Durable half, in CI.** `--self-test` runs *before* the verdict, driving the real scanner over fixture sources: **26 cases**, covering the three spellings the ruling named, the corrected forms, the second failure mode, the classifier's limbs, the run-length walk, and the baseline in every direction it can move. Plus `scripts/__tests__/check-doc-fence-languages.test.ts`, 20 tests.

**One-off half, on disk, through the shipped gate process.** Each leg proved its mutation on disk by grepping the injected marker *before* any result was read, and restored under `trap … EXIT INT TERM`; `git status --porcelain` was empty afterwards.

| leg | on disk | gate |
| --- | --- | --- |
| clean tree | — | **exit 0** |
| ```` ```text ```` TS block, unbaselined file | marker×1, ` ```text ` at :1368 | **exit 1** — `content/docs/guide/ci-cd-pipeline.md:1368  ```text  — interface ObjectUI6135ProbeSchema {` |
| ```` ```txt ```` TS block | marker×1, ` ```txt ` at :1368 | **exit 1** — same line, `` ```txt `` |
| **no info string** TS block | marker×1, ` ``` ` at :1368 | **exit 1** — same line, `` ```(no info string) `` |
| the same block corrected to ```` ```ts ```` | marker×1, ` ```ts ` at :1368 | **exit 0** ✅ |
| ```` ```console ```` TS block (unknown spelling) | marker×1 | **exit 1** — reported as the **UNKNOWN** mode, with both remedies and "⛔ never baselined" |
| an 11th hidden block in a file baselined at **10** | marker×1 | **exit 1** — `block-schema.mdx is baselined at 10; it now carries 11` |
| one hidden block *removed* from that file | ` ```plaintext ` count 11 → 10 | **exit 1** — **STALE**, `baselined at 10, now carries 9` |
| **prose** under a ```` ```text ```` fence | marker×1 | **exit 0** — the classifier is quoted, not widened |

The last two rows are the ones that make the rest mean something: the baseline moves in exactly one direction, and the gate says nothing about prose whatever its fence says. (The staleness row was a probe; §0 is the same thing happening for real, nine files at once.)

**A measured note on the classifier's edge.** "First line" is read literally — line 1 of the body, no leading whitespace tolerated. A variant that trims first agrees with this one on every `plaintext` block in the tree and on the `text` one, and disagrees on exactly one block: `content/docs/guide/architecture-overview.md:123`, an ASCII-art plugin-lifecycle diagram whose first line is an **indented** `import 'plugin-kanban'` inside a box drawing. It is not TypeScript, and the strict reading is the one that says so. Pinned as a self-test case.

---

## 4. A second defect this found

`scripts/dependabot-merge-gate.mjs` partitions every check a pull request produces into required and optional buckets, and an **unclassified blocking check is one the gate would let a Dependabot merge past**. The new workflow carries no trigger-level path filter, so every pull request produces `Doc Fence Language Check`. Caught by `scripts/__tests__/dependabot-merge-gate.test.ts` — the pin that exists for exactly this — and registered in its own commit.

---

## Verification

All at final head **`072dfe8f9`**, pushed at that same head, `git status --porcelain` empty at run time. Exit codes captured before any pipe; every gate quoted by **its own verdict line**. Heavy runs went through the container's shared verify lock. vitest from the repository **ROOT**, never package-scoped (objectui#3378).

The branch was brought up to date with **`git merge origin/main`**, twice — ⛔ never rebase, never force-push. The second merge takes **#6142** (`273537957` → `228909995`), which lands after §0 and edits five `content/docs/components/**` pages this baseline owes lines for. **It moves none of them**: those edits change block *bodies*, not fences, so the map is byte-identical across that merge and `check:doc-fences` is green on the merged tree. That is worth stating rather than assuming, because it is the same hazard §0 is about, checked instead of hoped for.

| check | exit | its own verdict line |
| --- | --- | --- |
| `check:doc-fences --self-test` | 0 | `✓ check-doc-fence-languages self-test: 26 cases pass — …the shrink-only baseline is pinned in every direction it can move.` |
| `check:doc-fences` | 0 | `✅ check:doc-fences — every TypeScript block in 222 document(s) is fenced ts/tsx/typescript, except 83 declared file(s) carrying 105 block(s) of objectui#5867's remaining population (⛔ SHRINK-ONLY). No unknown fence spelling hides one.` |
| `check:entry-guard` | 0 | `✓ check:entry-guard: 42 scripts/ file(s) — no entry guard outside the baseline; …` |
| `check:doc-types` | 0 | `✅ Every documented component type is registered.` |
| `docs:check-links` | 0 | `Links are valid across 15 scan roots.` |
| `check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 5094 tracked text file(s); skipped 85 binary).` |
| `check:changeset-presence` | 0 | `✅ No source of a released package changed in this range, so no changeset is owed.` |
| `check:changeset-fixed` | 0 | `✅ privatePackages declared: version=true, tag=false.` |
| `check:changeset-no-major` | 0 | `✅ No changeset declares a major bump.` |
| `check:lint-coverage` | 0 | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, no diagnostics |
| vitest, repo root, `scripts/` | 0 | `Test Files 70 passed (70)` / `Tests 1914 passed (1914)` |

The new gate's own file also carries the entry-guard's canonical predicate (`isEntrypoint(import.meta.url)`) rather than a hand-typed one, so `KNOWN_HAND_TYPED_GUARDS` does not grow.

**Changeset:** none owed, and that is a measurement rather than a judgement — `check-changeset-presence` reports `0 of them published source of a package the release covers`. This PR's own diff is `scripts/`, `.github/workflows/`, root `package.json` and one docs page.

**Lint, narrowed with the narrowing measured rather than asserted — and the measurement corrected one of my own claims.** Three pieces of evidence, all three required:

1. the population is read from **eslint's own configuration resolution**, not from a guess. `eslint --print-config` on each changed file: `scripts/__tests__/check-doc-fence-languages.test.ts` resolves **116 configured rules**; `scripts/check-doc-fence-languages.mjs` and `scripts/dependabot-merge-gate.mjs` resolve **0** — `eslint.config.js` names only `**/*.{ts,tsx}` globs, so this repository's `.mjs` gate scripts sit outside every rule block. That is a pre-existing property of the repo, not something this diff created. `.github/workflows/doc-fence-languages.yml`, `content/docs/guide/ci-cd-pipeline.md` and `package.json` each come back `File ignored because no matching configuration was supplied`;
2. file counts read from `--format json`: `eslint` exit 0, **0 errors / 0 warnings** across the three files it was given;
3. **type-aware linting is not enabled** — `eslint.config.js` declares no `parserOptions.project` and no `projectService` — so this diff cannot move the verdict on any untouched file.

⚠️ Stated plainly rather than left to be inferred from a green: **exactly one file in this diff is rule-linted.** The first draft of this section said all three were, which the `--print-config` reading above disproves. The `.mjs` half's correctness therefore rests on `type-check:scripts` (which compiles the pin test with `allowJs`, so the gate's exported signatures are inferred from the gate itself and cannot drift from it), on the gate's own `--self-test`, and on the 20-test pin file — not on eslint.

**`check:doc-snippets` was not run locally, and the narrowing is declared with its evidence.** It needs a filtered turbo build; this PR's own diff cannot move it, measured rather than asserted: `content/docs/guide/ci-cd-pipeline.md` holds **0** `ts`/`tsx`/`typescript` fences before and after, and the diff on that file adds **no fence-opening line at all**. `UNGATED_DOCS`, the ledger and the gate's source are untouched. CI runs it unfiltered regardless.

Refs: #5867 (the lane) · #6136 / #6137 (what moved the tree under §0) · #6142 (checked against the baseline, moves nothing) · #6133 (the shrink-only baseline precedent) · #6138 (why `file-upload.mdx` is worse than blocked) · #6132 / #6120 / #6121 / #6122 (what blocks the remainder) · #5044 (the class) · #5174 (why the scan surface is stated and pinned).

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
