### PR TITLE
refactor(tooling): route all 29 scripts/ entry guards through isEntrypoint

### DIFF
--- a/.changeset/6092-entry-guard-sweep.md
+++ b/.changeset/6092-entry-guard-sweep.md
@@ -1,0 +1,4 @@
+---
+---
+
+Tooling only, no package released: every `scripts/**` entry guard now goes through one predicate. The 29 hand-typed guards `check-entry-guard.mjs` baselined (nine distinct spellings across 28 `.mjs` files, plus `shadcn-sync.js`) are converted to `isEntrypoint(import.meta.url)` and `KNOWN_HAND_TYPED_GUARDS` is empty. Twenty-eight of them were silently wrong: reached through a symlink they compared two different paths, answered `false`, and did nothing — exit 0 with no output, which a CI wrapper holding `result.status` reads as a pass (objectui#6092).

--- a/scripts/__tests__/check-doc-component-types.test.ts
+++ b/scripts/__tests__/check-doc-component-types.test.ts
@@ -546,9 +546,35 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
     const yaml = yamlOf('doc-component-types.yml');
     expect(yaml).not.toContain('pnpm install');
     expect(yaml).not.toContain('corepack');
-    const gate = fs.readFileSync(path.join(repoRoot, SCRIPT), 'utf8');
-    const imports = [...gate.matchAll(/^import .* from '([^']+)';$/gm)].map((m) => m[1]);
-    expect(imports.every((spec) => spec.startsWith('node:')), `non-builtin import in the gate: ${imports}`).toBe(true);
+
+    // Walk the WHOLE static import graph, not just the gate's own first line.
+    // objectui#6092 converted this gate's entry guard to `./invoked-as.mjs`, a
+    // relative import — install-free, but not spelled `node:`. Asserting on the
+    // gate's own imports alone would have had to be loosened to let that
+    // through, and a loosened one-file assertion is how a relative import that
+    // DOES pull a package in later lands unnoticed. Following the graph keeps
+    // the original claim ("this needs no node_modules") literally true, and
+    // makes it true of every module the gate reaches.
+    const seen = new Set<string>();
+    const external: string[] = [];
+    const walk = (abs: string) => {
+      if (seen.has(abs)) return;
+      seen.add(abs);
+      const source = fs.readFileSync(abs, 'utf8');
+      for (const m of source.matchAll(/^import .* from '([^']+)';$/gm)) {
+        const spec = m[1];
+        if (spec.startsWith('node:')) continue;
+        if (!spec.startsWith('.')) {
+          external.push(`${path.relative(repoRoot, abs)} -> ${spec}`);
+          continue;
+        }
+        walk(path.resolve(path.dirname(abs), spec));
+      }
+    };
+    walk(path.join(repoRoot, SCRIPT));
+
+    expect(seen.size, 'the import walk read only the gate itself — it followed nothing').toBeGreaterThan(1);
+    expect(external, `the gate's import graph reaches a package, so it needs an install: ${external}`).toEqual([]);
   });
 });
 

--- a/scripts/check-action-forward-parity.mjs
+++ b/scripts/check-action-forward-parity.mjs
@@ -127,6 +127,7 @@ import { createRequire } from "module";
 import { readFileSync, existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import { isEntrypoint } from "./invoked-as.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
@@ -1058,7 +1059,7 @@ export function analyze(root = REPO_ROOT, options = {}) {
 }
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   let result;

--- a/scripts/check-changeset-fixed.mjs
+++ b/scripts/check-changeset-fixed.mjs
@@ -62,6 +62,7 @@
 import { readFileSync, readdirSync, statSync } from "fs";
 import { resolve, dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { isEntrypoint } from "./invoked-as.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -229,6 +230,6 @@ function main() {
 }
 
 // Only run when invoked as a script — the tests import the helpers above.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isEntrypoint(import.meta.url)) {
   process.exit(main());
 }

--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -44,6 +44,7 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const changesetDir = resolve(root, '.changeset');
@@ -158,6 +159,6 @@ release sets OBJECTUI_ALLOW_MAJOR=1.
 }
 
 // Only run when invoked as a script — the tests import the parser above.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isEntrypoint(import.meta.url)) {
   process.exit(main());
 }

--- a/scripts/check-changeset-presence.mjs
+++ b/scripts/check-changeset-presence.mjs
@@ -247,6 +247,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -722,7 +723,7 @@ export function verdict(analysis) {
 
 // -- CLI ----------------------------------------------------------------------
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const argOf = (name) => {

--- a/scripts/check-control-bytes.mjs
+++ b/scripts/check-control-bytes.mjs
@@ -88,6 +88,7 @@ import { execFileSync } from 'node:child_process';
 import { lstatSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 /**
  * Control characters that are never legitimate in a text file: the C0 range
@@ -356,7 +357,7 @@ nobody removes is how a baseline turns into a permanent skip-list.`);
 // Run only when invoked directly — the test suite imports `scan`/`classify`
 // from here and must not trigger a repo scan (or a process.exit) on import.
 // Same guard shape as scripts/check-changeset-no-major.mjs.
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   if (process.argv.includes('--list')) {

--- a/scripts/check-cross-repo-closer-outcome.mjs
+++ b/scripts/check-cross-repo-closer-outcome.mjs
@@ -129,8 +129,8 @@ import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
 import { isMap, isSeq, parseDocument } from 'yaml';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const WORKFLOW = '.github/workflows/cross-repo-issue-closer.yml';
 const JOB = 'close-foreign-issues';
@@ -1170,7 +1170,7 @@ async function selfTest() {
 // reverse-verification route needs `extractScript` / `judge` pointed at another
 // tree (a pre-fix checkout), and a module that runs its gate on import would
 // silently judge THIS repo instead and print a pass about the wrong subject.
-if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+if (isEntrypoint(import.meta.url)) {
   if (process.argv.includes('--self-test')) await selfTest();
   else if (process.argv.includes('--list')) list();
   else await main();

--- a/scripts/check-designer-field-key-parity.mjs
+++ b/scripts/check-designer-field-key-parity.mjs
@@ -125,6 +125,7 @@ import { createRequire } from "module";
 import { readFileSync, existsSync } from "fs";
 import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
+import { isEntrypoint } from "./invoked-as.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
@@ -459,6 +460,6 @@ async function main() {
   console.log("\ndesigner-field-key-parity: OK");
 }
 
-if (resolve(process.argv[1] ?? "") === resolve(fileURLToPath(import.meta.url))) {
+if (isEntrypoint(import.meta.url)) {
   await main();
 }

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -137,6 +137,7 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -995,7 +996,7 @@ const HINTS = {
     'A doc file has an unclosed ``` fence. The scan cannot separate code from prose past that point.',
 };
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const argOf = (name) => {

--- a/scripts/check-doc-links.mjs
+++ b/scripts/check-doc-links.mjs
@@ -460,6 +460,7 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const DOCS_ROUTE_PREFIX = '/docs';
 const MARKDOWN_LINK_RE = /\[[^\]]+\]\(([^)]+)\)/g;
@@ -967,7 +968,7 @@ export function collectBrokenLinks(repoRoot) {
 // Run only when invoked directly — the test suite imports the helpers above and
 // must not trigger a repo scan (or a `process.exit`) on import. Same guard shape
 // as scripts/check-control-bytes.mjs.
-const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 const HINTS = {
   relative:

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -259,6 +259,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -1162,7 +1163,7 @@ function main() {
   return 0;
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+if (isEntrypoint(import.meta.url)) {
   process.exit(main());
 }
 

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -93,7 +93,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 /**
  * Ceiling for the console eager closure, in gzipped bytes. See the header for
@@ -340,6 +340,6 @@ export function main(argv = process.argv.slice(2)) {
   return result.status === 'fail' ? 1 : 2;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isEntrypoint(import.meta.url)) {
   process.exit(main());
 }

--- a/scripts/check-entry-guard.mjs
+++ b/scripts/check-entry-guard.mjs
@@ -9,10 +9,13 @@
  *
  * Ported from objectstack's gate of the same name (objectstack#10784 and the
  * cards above it), NOT copied: objectstack swept its tree BEFORE landing the
- * gate, so its spelling rule admits no exceptions at all. This repository has
- * not been swept. The port therefore carries a baseline that objectstack has
- * no need for, and the whole design question of this file is how that baseline
- * is shaped so it cannot become an allowlist. See "The baseline" below.
+ * gate, so its spelling rule admits no exceptions at all. This repository was
+ * swept the other way round -- gate first, then the sweep -- so the port landed
+ * carrying a baseline of 29 owed files that objectstack has no need for. That
+ * baseline is now EMPTY: objectui#6092's second half converted all 29 and
+ * deleted every line. The design question the shape answers -- how a baseline
+ * is kept from becoming an allowlist -- is what got it to empty, and is still
+ * what keeps a new line from being added. See "The baseline" below.
  *
  * Two rules live here. The first is about the SPELLING of a guard that exists;
  * the second, further down, is about a guard that is MISSING from a file that
@@ -22,10 +25,12 @@
  * ## What this gate is for
  *
  * A CLI script has to answer "did node run me, or did something import me?"
- * before it does anything. Hand-typed answers to that question have drifted
+ * before it does anything. Hand-typed answers to that question HAD drifted
  * into NINE distinct spellings across 28 `.mjs` files in `scripts/` here --
- * measured on `133e2ea1e`, not estimated -- and every one of them is wrong in
- * the same way. The dominant failure:
+ * measured on `133e2ea1e`, not estimated -- and every one of them was wrong in
+ * the same way. All 29 sites (those 28 plus `shadcn-sync.js`) now go through
+ * the predicate; what this gate is for is the TENTH spelling, which nothing
+ * else in CI can see. The dominant failure:
  *
  *   node resolves symlinks for the module graph but leaves `process.argv[1]`
  *   as the caller typed it
@@ -34,16 +39,18 @@
  * `false`, and does nothing -- **exit 0, no output**. The CI wrappers spawn
  * these tools and hold `result.status` only, so an inert child is a green gate.
  *
- * That is measured in THIS tree, on a real blocking gate (objectui#6078):
+ * That was measured in THIS tree, on a real blocking gate (objectui#6078),
+ * against the spelling `check-skills-paths.mjs` carried before the sweep:
  *
  *   node scripts/check-skills-paths.mjs              direct  : exit=1, 696 bytes
  *   node /…/link/check-skills-paths.mjs  (symlink)   symlink : exit=0, 0 bytes
  *
- * Same tree, same defect, same gate. A second spelling here goes inert with no
- * symlink at all: `check-node-esm-load.mjs:847` writes
+ * Same tree, same defect, same gate. A second spelling went inert with no
+ * symlink at all: `check-node-esm-load.mjs` wrote
  * ``import.meta.url === `file://${process.argv[1]}` ``, which percent-encodes
  * apart from `argv[1]` in any directory whose name needs encoding (measured in
- * a directory named `a#b c`).
+ * a directory named `a#b c`). Both files now use the predicate; the two
+ * measurements are kept because they are why the rule exists, not a to-do.
  *
  * `scripts/invoked-as.mjs` is the only place allowed to read `process.argv[1]`;
  * everywhere else spells the guard
@@ -52,45 +59,51 @@
  *
  * which has no comparison in it to get wrong.
  *
- * ## Why the gate lands BEFORE the sweep
+ * ## Why the gate landed BEFORE the sweep
  *
  * The sweep on its own is worth little: nothing would stop a TENTH spelling
  * from being typed the next time someone adds a script, and the next one would
  * be just as invisible. That is not hypothetical here -- objectui#6092 measured
  * the worklist growing while the card sat open: `check-designer-field-key-parity.mjs`
  * added a guard between `a1c41c516` and `7c96c9420`. A sweep with no gate under
- * it can be silently undone by the next pull request. So the gate lands first
- * and names its own worklist; the conversion of the 29 existing call sites is
- * the second half of objectui#6092 and is deliberately NOT in this file's PR.
+ * it can be silently undone by the next pull request. So the gate landed first
+ * and named its own worklist, and the conversion of those 29 call sites landed
+ * against it -- each conversion had to lower or delete its own baseline line or
+ * this gate failed STALE and named the file, which is what made the sweep
+ * self-checking rather than a claim.
  *
  * ## The baseline, and why it is not an allowlist
  *
  * ⛔ SHRINK-ONLY, and shaped so the difference is mechanical rather than a
  * promise. `KNOWN_HAND_TYPED_GUARDS` maps a file to the NUMBER of masked
- * `process.argv[1]` occurrences it carried when this gate landed. Three
- * consequences, and the third is the one that makes the whole thing worth
- * landing:
+ * `process.argv[1]` occurrences it carried when this gate landed. It is EMPTY
+ * now; the shape is what emptied it, in three consequences:
  *
- *   • a file NOT in the map that carries a guard fails -- a 30th spelling
- *     cannot land;
- *   • a file IN the map that carries MORE than its number fails -- a second
- *     guard cannot be smuggled into an already-owed file, which a
+ *   • a file NOT in the map that carries a guard fails -- with the map empty
+ *     that is every file, so this is the whole live rule today and a 30th
+ *     spelling cannot land;
+ *   • a file IN the map that carries MORE than its number failed -- a second
+ *     guard could not be smuggled into an already-owed file, which a
  *     path-only baseline would have accepted silently;
- *   • a file that carries FEWER fails as STALE and names itself, with the
- *     remedy being to lower or delete the line. There is no supported route
- *     that raises a number. That is what stops the map from rotting into a
- *     list nobody re-reads.
+ *   • a file that carried FEWER failed as STALE and named itself, with the
+ *     remedy being to lower or delete the line. There was no supported route
+ *     that raised a number, and there is none that adds one back.
  *
- * Every entry has the same one-line remedy -- `isEntrypoint(import.meta.url)`
- * -- so no entry records a judgement anyone has to re-make. That is the
- * property that makes a debt list safe, and it is the only reason one is here.
+ * The last two are unreachable while the map is empty, and they stay in
+ * `reconcileGuards` (and pinned by the self-test) precisely because that is the
+ * state a re-added line would have to pass through: a baseline that only ever
+ * shrank cannot be re-opened as an allowlist.
  *
- * ONE entry is different in kind and is labelled as such rather than left to be
- * re-derived: `scripts/shadcn-sync.js` hand-types the CORRECT two-leg shape
- * (`realpathSync(resolved) === __filename`, objectui#6092). It is not a defect
- * and this gate never reports it as one. It is in the map because the rule is
- * "one predicate", not "one predicate or a second correct implementation" --
- * converting it is a simplification, not a fix.
+ * Every entry had the same one-line remedy -- `isEntrypoint(import.meta.url)`
+ * -- so no entry recorded a judgement anyone had to re-make. That is the
+ * property that made the debt list safe, and it is the only reason one was here.
+ *
+ * ONE of the 29 was different in kind: `scripts/shadcn-sync.js` hand-typed the
+ * CORRECT two-leg shape (`realpathSync(resolved) === __filename`), so this gate
+ * never reported it as a defect. It was in the map because the rule is "one
+ * predicate", not "one predicate or a second correct implementation" -- its
+ * conversion was a simplification, not a fix, and that distinction is now
+ * recorded at the call site in `shadcn-sync.js` rather than here.
  *
  * ## Why a spelling gate rather than a behavioural sweep
  *
@@ -114,9 +127,13 @@
  * Comments AND string/template/regex literals are masked before the scan
  * (`js-comment-mask.mjs`), because a `process.argv[1]` inside a string payload
  * for a spawned child is not an entry guard, and neither is one inside a
- * docblock -- `shadcn-sync.js:1046` really does write one in prose, and an
- * allowlist to excuse it would be a hole the next such file falls through
- * silently.
+ * docblock. That masking is load-bearing, not defensive: after the sweep the
+ * only `scripts/` files that still contain the string at all are this gate
+ * (skipped -- it quotes the idioms it bans), `invoked-as.mjs` (the one module
+ * allowed to read it), and `js-comment-mask.mjs`, whose own corpus carries 8
+ * occurrences in literals. Unmasked, that last file would read as a 30th
+ * hand-typed guard, and an allowlist to excuse it would be a hole the next such
+ * file falls through silently.
  *
  * ## What was deliberately NOT ported
  *
@@ -252,58 +269,22 @@ export function scanFile(rel, source, { isPredicateHome = false } = {}) {
 }
 
 /**
- * ⛔ SHRINK-ONLY. The hand-typed entry guards this tree carried when the gate
- * landed, as `path -> number of masked process.argv[1] occurrences`. The
- * rationale, and why a COUNT rather than a bare path, is in the header. Two
- * shapes appear because a guard written
- * `const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === …`
- * reads `argv[1]` twice.
+ * ⛔ SHRINK-ONLY, and now EMPTY. This carried the 29 hand-typed entry guards
+ * the tree had when the gate landed, as `path -> number of masked
+ * process.argv[1] occurrences`; objectui#6092's second half converted all 29
+ * and deleted every line. The rationale, and why a COUNT rather than a bare
+ * path, is in the header.
  *
- * The remedy for every line is the same:
+ * It stays here, empty, because the reconciliation it feeds is the live rule:
+ * a `scripts/` file that hand-types a guard is now a file the map does not
+ * carry, so it fails as FRESH and names itself. There is no supported route
+ * that adds a line back — the remedy for a new hand-typed guard is the same
+ * one-liner every deleted line had:
  *
  *   import { isEntrypoint } from './invoked-as.mjs';
  *   if (isEntrypoint(import.meta.url)) { … }
- *
- * then delete the line from here. objectui#6092's second half does this sweep.
  */
-const KNOWN_HAND_TYPED_GUARDS = new Map([
-  ['scripts/check-action-forward-parity.mjs', 2],
-  ['scripts/check-changeset-fixed.mjs', 2],
-  ['scripts/check-changeset-no-major.mjs', 2],
-  ['scripts/check-changeset-presence.mjs', 2],
-  ['scripts/check-control-bytes.mjs', 2],
-  ['scripts/check-cross-repo-closer-outcome.mjs', 1],
-  ['scripts/check-designer-field-key-parity.mjs', 1],
-  ['scripts/check-doc-component-types.mjs', 2],
-  ['scripts/check-doc-links.mjs', 2],
-  ['scripts/check-doc-snippet-types.mjs', 2],
-  ['scripts/check-eager-closure-budget.mjs', 2],
-  ['scripts/check-i18n-call-site-keys.mjs', 2],
-  ['scripts/check-i18n-dead-keys.mjs', 2],
-  ['scripts/check-i18n-en-drift.mjs', 2],
-  ['scripts/check-lucide-icon-record-names.mjs', 2],
-  ['scripts/check-node-esm-load.mjs', 1],
-  ['scripts/check-package-self-import.mjs', 2],
-  ['scripts/check-phantom-dependencies.mjs', 2],
-  ['scripts/check-published-dist-tooling.mjs', 2],
-  ['scripts/check-skills-paths.mjs', 2],
-  ['scripts/check-spec-symbol-derivation.mjs', 2],
-  ['scripts/check-type-check-coverage.mjs', 2],
-  ['scripts/dependabot-merge-gate.mjs', 2],
-  ['scripts/extract-mdx-demos.mjs', 2],
-  ['scripts/regenerate-known-schema-types.mjs', 2],
-  ['scripts/render-budget-comment.mjs', 2],
-  ['scripts/shadcn-check-report.mjs', 2],
-  ['scripts/shadcn-sync.js', 1],
-  ['scripts/sync-quick-reference-release.mjs', 2],
-]);
-
-/**
- * The one entry above that is NOT a defect: it hand-types the CORRECT two-leg
- * shape already. Named here so a reader of the map is not left to re-derive
- * which of the entries is which, and so nothing later reports it as broken.
- */
-const CORRECT_SHAPE_BUT_HAND_TYPED = new Set(['scripts/shadcn-sync.js']);
+const KNOWN_HAND_TYPED_GUARDS = new Map([]);
 
 /**
  * Reconcile what the tree carries against the shrink-only baseline. Pure, and
@@ -626,9 +607,18 @@ export function importUnsafeStatements(source) {
  * ONE entry, and that is the point: this rule recognises a hand-typed guard AS
  * a guard (see `guardAliases`), so the 29 badly-spelled files are rule 1's
  * business and do not appear here. `check-lucide-icon-record-names.mjs` builds
- * two lookup maps in top-level `for` loops at :242 and :244, outside any guard,
- * and really does run them inside an importer. That is a true sentence with one
- * remedy, which is the only kind of line a debt list may carry.
+ * two lookup maps in top-level `for` loops at :243 and :245, outside any guard,
+ * and really does run them inside an importer.
+ *
+ * ⚠️ Its remedy is NOT "move the loops behind the guard": those maps are read by
+ * the exported `liveSpellingFor` / `describeName`, which importers really call
+ * (`scripts/__tests__/check-lucide-icon-record-names.test.ts`), so guarding them
+ * turns a working import into a broken one. Measured on this branch, not
+ * reasoned: with the loops moved behind the guard that suite fails. objectui#6092
+ * ruled the restructuring out of scope rather than trade an import for a
+ * baseline; the entry stays, and its remedy is a judgement someone still has to
+ * make -- which is exactly what the rest of this comment says a debt line must
+ * not be. It is the one line here that owes a card, not a one-liner.
  */
 const KNOWN_IMPORT_UNSAFE = new Set(['scripts/check-lucide-icon-record-names.mjs']);
 
@@ -760,7 +750,6 @@ function list() {
     const rel = relative(REPO_ROOT, abs);
     const found = scanFile(rel, readFileSync(abs, 'utf8'), { isPredicateHome: abs === PREDICATE_HOME });
     if (!found.length) continue;
-    const note = CORRECT_SHAPE_BUT_HAND_TYPED.has(rel) ? '  [correct shape, hand-typed]' : '';
     console.log(`  ${String(found.length).padStart(2)}  ${rel}${note}`);
     for (const f of found) console.log(`         :${f.line}  ${f.what}`);
   }
@@ -967,12 +956,15 @@ export function selfTest() {
   t('else continues the statement before it', topLevelStatements(codeOnly('if (a) { x(); } else { y(); }\n')).length === 1);
   t('catch continues the statement before it', topLevelStatements(codeOnly('try { x(); } catch (e) { y(); }\n')).length === 1);
 
-  // ── the labelled entry is really in the baseline it is labelled against ──
-  // A label naming a file the map does not carry is a sentence about nothing,
-  // which is the failure mode this whole card exists to stop.
-  for (const rel of CORRECT_SHAPE_BUT_HAND_TYPED) {
-    t(`${rel} is labelled AND baselined, not just labelled`, KNOWN_HAND_TYPED_GUARDS.has(rel), rel);
-  }
+  // ── the baseline is empty, and that is an assertion, not a description ──
+  // With no lines left, the ONLY thing the map can still do is redden on a file
+  // that hand-types a guard. A test that read the map's size would pass on an
+  // empty map that had also stopped being consulted, so this asserts the
+  // reconciliation instead: an empty baseline must call a real guard FRESH.
+  t(
+    'an EMPTY baseline still reddens on a hand-typed guard',
+    reconcileGuards(new Map([['scripts/anything.mjs', 1]]), new Map([])).fresh.length === 1,
+  );
 
   const failed = cases.filter((c) => !c.ok);
   for (const c of failed) console.error(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);

--- a/scripts/check-entry-guard.mjs
+++ b/scripts/check-entry-guard.mjs
@@ -610,15 +610,23 @@ export function importUnsafeStatements(source) {
  * two lookup maps in top-level `for` loops at :243 and :245, outside any guard,
  * and really does run them inside an importer.
  *
- * ⚠️ Its remedy is NOT "move the loops behind the guard": those maps are read by
- * the exported `liveSpellingFor` / `describeName`, which importers really call
- * (`scripts/__tests__/check-lucide-icon-record-names.test.ts`), so guarding them
- * turns a working import into a broken one. Measured on this branch, not
- * reasoned: with the loops moved behind the guard that suite fails. objectui#6092
- * ruled the restructuring out of scope rather than trade an import for a
- * baseline; the entry stays, and its remedy is a judgement someone still has to
- * make -- which is exactly what the rest of this comment says a debt line must
- * not be. It is the one line here that owes a card, not a one-liner.
+ * ⚠️ Its remedy is NOT "move the loops behind the guard". Those maps are read by
+ * the exported `liveSpellingFor` / `describeName`, which importers really call,
+ * so guarding them empties the maps for every importer. Measured on objectui#6092's
+ * branch rather than reasoned: with the two loops moved inside the guard, rule 2
+ * goes green and reports the entry as STALE -- and
+ * `scripts/__tests__/check-lucide-icon-record-names.test.ts` fails 5 of 25.
+ * The failure is not merely a red test. `describeName('BarChart3')` stops saying
+ * "write `chart-column`" and says "no live key names the same glyph" instead:
+ * a WRONG diagnosis for a real violation, printed by a gate that still exits 1,
+ * which is a worse outcome than the unguarded loops.
+ *
+ * So objectui#6092 ruled the restructuring out of scope rather than trade a
+ * working import for a baseline line. The entry stays, and its remedy is a
+ * judgement someone still has to make -- which is exactly what the rest of this
+ * comment says a debt line must not be. It is the one line here that owes a
+ * card, not a one-liner. A lazy build of the two maps inside `liveSpellingFor`
+ * would satisfy both, and is the shape that card should consider.
  */
 const KNOWN_IMPORT_UNSAFE = new Set(['scripts/check-lucide-icon-record-names.mjs']);
 

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -332,6 +332,7 @@ import ts from 'typescript';
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
 import { resolve, dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -1908,7 +1909,7 @@ const HINTS = {
 const quote = (text) =>
   JSON.stringify(text).replace(/[^\x20-\x7e]/g, (character) => `\\u${character.charCodeAt(0).toString(16).padStart(4, '0')}`);
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const root = resolve(scriptDir, '..');

--- a/scripts/check-i18n-dead-keys.mjs
+++ b/scripts/check-i18n-dead-keys.mjs
@@ -112,6 +112,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { analyze, collectEnKeys } from './check-i18n-call-site-keys.mjs';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -269,7 +270,7 @@ export function sweep(root) {
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const root = resolve(scriptDir, '..');

--- a/scripts/check-i18n-en-drift.mjs
+++ b/scripts/check-i18n-en-drift.mjs
@@ -145,6 +145,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -550,7 +551,7 @@ export function analyze(root, { base, head = null }) {
   return { before, after, findings, counters };
 }
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const argOf = (name) => {

--- a/scripts/check-lucide-icon-record-names.mjs
+++ b/scripts/check-lucide-icon-record-names.mjs
@@ -88,6 +88,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 /** This gate's OWN repo — where lucide and typescript are resolved from. */
 const gateRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -573,7 +574,7 @@ export function analyze(root, {
 }
 
 // ── CLI ──────────────────────────────────────────────────────────────────────
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 if (invokedDirectly) {
   const result = analyze(gateRoot);
   const { counters, discovered, errors, violations } = result;

--- a/scripts/check-node-esm-load.mjs
+++ b/scripts/check-node-esm-load.mjs
@@ -101,6 +101,7 @@ import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 
 import { SKIP_DIRS, TOOLING_FILE, discoverPackages, moduleSpecifiers } from './check-phantom-dependencies.mjs';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -844,7 +845,7 @@ function main(argv) {
   return failed ? 1 : 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isEntrypoint(import.meta.url)) {
   process.exit(main(process.argv.slice(2)));
 }
 

--- a/scripts/check-package-self-import.mjs
+++ b/scripts/check-package-self-import.mjs
@@ -123,6 +123,7 @@ import {
   moduleSpecifiers,
   packageNameOf,
 } from './check-phantom-dependencies.mjs';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -443,7 +444,7 @@ const HINTS = {
     'site has gone silently widens the hole for the next file that lands there.',
 };
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const argOf = (name) => {

--- a/scripts/check-phantom-dependencies.mjs
+++ b/scripts/check-phantom-dependencies.mjs
@@ -200,6 +200,7 @@ import { builtinModules } from 'node:module';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -703,7 +704,7 @@ const HINTS = {
     'gone covers a package that may now be shipping undeclared imports.',
 };
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const argOf = (name) => {

--- a/scripts/check-published-dist-tooling.mjs
+++ b/scripts/check-published-dist-tooling.mjs
@@ -118,6 +118,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { PACKAGE_ROOTS, TOOLING_FILE, readReleaseGroup } from './check-phantom-dependencies.mjs';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 
@@ -397,7 +398,7 @@ const HINTS = {
     'unexaminable package must not read as a clean one (objectui#4846).',
 };
 
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   const argOf = (name) => {

--- a/scripts/check-skills-paths.mjs
+++ b/scripts/check-skills-paths.mjs
@@ -99,6 +99,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 /** The scan surface, relative to the repo root: markdown under this directory. */
 export const SCAN_ROOT = 'skills';
@@ -351,7 +352,7 @@ exemption nobody removes is how a baseline turns into a permanent skip-list.`);
 // Run only when invoked directly — the test suite imports `scan()` and the
 // extractor from here and must not trigger a repo scan (or a `process.exit`) on
 // import. Same guard shape as `scripts/check-control-bytes.mjs`.
-const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) {
   if (process.argv.includes('--list')) {

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -152,6 +152,7 @@ import { createRequire } from "module";
 import { readFileSync, readdirSync, statSync } from "fs";
 import { resolve, dirname, join, relative } from "path";
 import { fileURLToPath } from "url";
+import { isEntrypoint } from "./invoked-as.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -1176,5 +1177,5 @@ process.exit(1);
 // `scanFileForClaims` / `normalizeDoc` from here and must not trigger a repo
 // scan (or a process.exit) on import. Same guard shape as
 // scripts/check-control-bytes.mjs.
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const invokedDirectly = isEntrypoint(import.meta.url);
 if (invokedDirectly) main();

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -64,6 +64,7 @@
 import { readFileSync, readdirSync, statSync } from "fs";
 import { resolve, dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { isEntrypoint } from "./invoked-as.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -802,6 +803,6 @@ export function main() {
 // imports `collect()` / `auditPackages()` from here and must not trigger a repo
 // scan (or a `process.exit`) on import. Same guard shape as
 // `scripts/check-skills-paths.mjs` and `scripts/check-control-bytes.mjs`.
-const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+const invokedDirectly = isEntrypoint(import.meta.url);
 
 if (invokedDirectly) main();

--- a/scripts/dependabot-merge-gate.mjs
+++ b/scripts/dependabot-merge-gate.mjs
@@ -109,7 +109,7 @@
  */
 
 import fs from 'node:fs';
-import { pathToFileURL } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 /**
  * Blocking checks whose workflow subscribes `pull_request` with NO trigger-level
@@ -499,7 +499,7 @@ export async function main({ api, env = process.env } = {}) {
   return result;
 }
 
-const invokedDirectly = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+const invokedDirectly = isEntrypoint(import.meta.url);
 if (invokedDirectly) {
   await main();
 }

--- a/scripts/extract-mdx-demos.mjs
+++ b/scripts/extract-mdx-demos.mjs
@@ -29,6 +29,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import vm from 'node:vm';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');
@@ -413,6 +414,5 @@ export { DEMO_MODULE, findDemoImports, rewriteDemoImports, stripCode };
 
 // Only run the CLI when executed directly — the import rewriter above is
 // imported by scripts/__tests__/extract-mdx-demos.test.ts.
-const invokedDirectly =
-  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+const invokedDirectly = isEntrypoint(import.meta.url);
 if (invokedDirectly) main();

--- a/scripts/regenerate-known-schema-types.mjs
+++ b/scripts/regenerate-known-schema-types.mjs
@@ -75,6 +75,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { deriveRegistryKeys } from './check-doc-component-types.mjs';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 export const TARGET = 'packages/cli/src/utils/known-schema-types.ts';
@@ -184,6 +185,6 @@ function main() {
   console.log(`wrote ${TARGET}`);
 }
 
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (isEntrypoint(import.meta.url)) {
   main();
 }

--- a/scripts/render-budget-comment.mjs
+++ b/scripts/render-budget-comment.mjs
@@ -27,7 +27,7 @@
  */
 
 import fs from 'node:fs';
-import { pathToFileURL } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 /**
  * The only two statuses that carry a measurement. Kept as an explicit
@@ -191,7 +191,7 @@ export function renderFromEnv(env = process.env, sizeReportPath = 'size-report.m
 }
 
 // CLI: write the comment body to stdout for the workflow to capture.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isEntrypoint(import.meta.url)) {
   const { kind, body } = renderFromEnv();
   process.stderr.write(`Rendered performance budget comment (kind: ${kind})\n`);
   process.stdout.write(body);

--- a/scripts/shadcn-check-report.mjs
+++ b/scripts/shadcn-check-report.mjs
@@ -58,7 +58,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 /**
  * How many consecutive unreachable runs escalate into the issue channel.
@@ -605,8 +605,7 @@ export async function main({ api } = {}) {
   return { alarm, reasons, checkClass, analyzeClass, registryState, streak };
 }
 
-const invokedDirectly =
-  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+const invokedDirectly = isEntrypoint(import.meta.url);
 if (invokedDirectly) {
   await main();
 }

--- a/scripts/shadcn-sync.js
+++ b/scripts/shadcn-sync.js
@@ -22,9 +22,9 @@
  */
 
 import fs from 'fs/promises';
-import { realpathSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { isEntrypoint } from './invoked-as.mjs';
 import https from 'https';
 import { spawnSync } from 'child_process';
 import crypto from 'crypto';
@@ -1036,27 +1036,14 @@ async function main() {
   }
 }
 
-/**
- * Is this file the process entry point?
- *
- * The CLI must keep running exactly as before when invoked as
- * `node scripts/shadcn-sync.js …`, while an `import` of this module (the tests
- * in `scripts/__tests__/shadcn-sync-fetch-cache.test.ts`) must NOT execute it.
- * Compared through `realpathSync` because ESM resolves `import.meta.url` to the
- * real path while `process.argv[1]` may still carry a symlink.
- */
-function invokedAsCli() {
-  const entry = process.argv[1];
-  if (!entry) return false;
-  const resolved = path.resolve(entry);
-  try {
-    return realpathSync(resolved) === __filename;
-  } catch {
-    return resolved === __filename;
-  }
-}
-
-if (invokedAsCli()) {
+// This file is the ONE of objectui#6092's 29 hand-typed guards that was not
+// wrong: the deleted `invokedAsCli()` compared through `realpathSync`, so it
+// already answered correctly through a symlink. Replacing it with the shared
+// predicate is therefore a SIMPLIFICATION, not a fix — one spelling fewer for a
+// reader to re-derive, and one fewer place for the realpath leg to be dropped
+// by a later edit. `scripts/invoked-as.mjs` carries the rationale, and adds the
+// `node <dir>` case this hand-typed copy never had.
+if (isEntrypoint(import.meta.url)) {
   main().catch(error => {
     log(`Fatal error: ${error.message}`, 'red');
     console.error(error);

--- a/scripts/sync-quick-reference-release.mjs
+++ b/scripts/sync-quick-reference-release.mjs
@@ -62,6 +62,7 @@
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isEntrypoint } from './invoked-as.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -405,6 +406,6 @@ export function main(argv = process.argv.slice(2), root = repoRoot) {
 }
 
 // Only run when invoked as a script — the tests import the functions above.
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (isEntrypoint(import.meta.url)) {
   process.exit(main());
 }


### PR DESCRIPTION
Part of #6092

PR 2 of 2. PR #6133 landed the gate and the shrink-only baseline it measured; this converts every one of the 29 sites that baseline named and empties it. The card's other open item — `check-lucide-icon-record-names.mjs`'s unguarded top-level loops — is **reported, not restructured**, on the dispatch order's own STOP condition. Details below.

Everything here was measured at final commit `06ad4dff0`, working tree clean apart from an untracked throwaway harness directory.

## Re-measurement at claim

`main` moved by six merges since PR 1's figures (#6128, #6130, #6133, #6134, #6136, #6137). Branched from `bfdb9f906`.

| figure | PR 1 @ `133e2ea1e` | this branch @ `bfdb9f906` | delta |
| --- | --- | --- | --- |
| hand-typed guard files | 29 | **29** | none |
| `process.argv[1]` occurrences | 54 | **54** | none |
| distinct spellings | 9 | **9** | none |
| `isEntrypoint` importers | 3 | **5** | +2 — `check-entry-guard.mjs` and `js-comment-mask.mjs`, both landed by PR 1 itself |

The gate's own verdict line at the branch point reproduced PR 1's numbers exactly:

```
✓ check:entry-guard: 41 scripts/ file(s) — no entry guard outside the baseline; 29 file(s) still
  hand-type one (54 occurrence(s), ⛔ SHRINK-ONLY, objectui#6092); 36 export bindings, 35 of them
  inert on import (1 known-unsafe, ⛔ SHRINK-ONLY).
```

and at the end of this PR:

```
✓ check:entry-guard: 41 scripts/ file(s) — no entry guard outside the baseline; 0 file(s) still
  hand-type one (0 occurrence(s), ⛔ SHRINK-ONLY, objectui#6092); 36 export bindings, 35 of them
  inert on import (1 known-unsafe, ⛔ SHRINK-ONLY).
```

**29 files → 0. 54 occurrences → 0.** `KNOWN_HAND_TYPED_GUARDS` is empty; `--list`'s hand-typed section prints nothing. Only three `scripts/` files still contain the string `process.argv[1]` at all: the gate (skipped — it quotes the idioms it bans), `invoked-as.mjs` (the one module allowed to read it), and `js-comment-mask.mjs`, whose 8 occurrences are all inside literals in its own corpus.

> Note on this body: angle-bracket placeholders are written out in words throughout. GitHub's body sanitizer silently ate three of them from the first revision of this description — `node scripts/` followed by a bracketed FILE, and two mentions of the `node` command given a bracketed DIRECTORY — turning measured sentences into nonsense. Same class of hazard as the guards this PR converts: it fails quietly and reads fine.

## Per-lane both-leg verification, and the harness's positive control

⛔ Not a bulk sed. A two-leg harness ran **every one of the 29** before and after, each with its **own** argv chosen so the run crosses the guard without doing anything destructive (`--check` for the two writers, `--help` for `shadcn-sync.js`, `--self-test` for `check-cross-repo-closer-outcome.mjs`, `--no-build` for `check-published-dist-tooling.mjs`, and so on).

- **CLI leg** — the script invoked as a command. Dispatched iff it did *not* do the one thing an inert guard does: exit 0 having printed nothing.
- **Import leg** — the same file imported. Inert iff the graph loaded, control returned, and the module printed nothing of its own.

**Result: 29/29 dispatched on the CLI leg and inert on the import leg. 27 of 29 produced byte-identical CLI output before and after** (same exit code, same sha256 of stdout+stderr).

The two that differ, both explained and neither caused by the conversion:

- `check-changeset-presence.mjs`, 296 → 297 bytes: it reports on the branch's own diff. `"0 file(s) changed"` → `"30 file(s) changed"`. A lane whose output was *identical* here would mean it had stopped reading the tree.
- `check-i18n-dead-keys.mjs`, 49115 → 28719 bytes: its stdout is truncated nondeterministically when it is a pipe (the script ends in `process.exit`, so a large piped write is not flushed). Proved by running the **same** post-conversion tree three ways: 49115 bytes through a file redirect, 28719 and 32813 bytes through the harness's pipe. Byte count is not a stable signature for this lane in either direction; its stable signature — exit code, dispatch, and first lines — is unchanged.

### ⛔ The harness reports red, and here is the proof

A harness that has never reported red is not a reading. Two deliberate mis-conversions of `check-skills-paths.mjs`, each confirmed on disk by a before/after occurrence count, each restored by `trap … EXIT INT TERM` using `git checkout HEAD --` (the fix was committed first):

| mutation | on-disk confirmation | CLI leg | import leg | harness |
| --- | --- | --- | --- | --- |
| guard **inverted** (`!isEntrypoint(…)`) | canonical spelling 1 → 0, inverted present = 1 | `exit=0, 0 bytes` — the silent-success signature itself | **NOT inert**, 97 bytes | **FAIL** |
| guard **deleted** (`if (true)`) | guarded dispatch 1 → 0, unguarded present = 1 | `exit=0, 97 bytes` (dispatches) | **NOT inert**, 97 bytes | **FAIL** |

Both directions caught, and the inverted case reproduces the card's whole thesis: a converted-then-broken gate goes silently inert while its own work reappears inside anyone who imports it.

## The conversion is a real behaviour change, in the good direction

Measured on this branch through a **real symlink**, on `check-skills-paths.mjs` — the gate #6078 used for its demonstration. Restore leg `git checkout HEAD --`, comparison leg `git checkout bfdb9f906 --`:

| spelling on disk | direct | through a symlink |
| --- | --- | --- |
| **converted** (`isEntrypoint`) | `exit=0, 96 bytes`, prints its verdict | `exit=0, 96 bytes`, **same verdict** |
| **pre-conversion** (`path.resolve(argv[1]) === fileURLToPath(import.meta.url)`) | `exit=0, 96 bytes` | `exit=0, **0 bytes**` — silently inert |

**Nothing relies on the inert behaviour.** How that was checked, rather than assumed:

1. `git ls-files -s | awk '$1=="120000"'` — the tree contains **no** tracked symlinks.
2. Every invocation of every converted script, across `.github/workflows/**` and `package.json`, is the literal command `node` followed by the plain relative path of the file, run from the repo root — no symlink, no directory argument. The full list was enumerated, not sampled.
3. `scripts/` contains no `index.mjs`/`index.js`, so the case where node is handed a DIRECTORY and resolves its index — which the predicate additionally handles — cannot arise here either.
4. The 1894-test `scripts/__tests__` suite — which spawns these scripts from 56 sites — is green.

So the only situation in which old and new answer differently is one no current caller can reach; the change is latent-hazard removal, exactly as the card framed it.

## The pre-install path, verified rather than reasoned about

PR 1 wired the gate into `lint.yml` **before `pnpm install`**. A parse of every workflow found **8 steps that invoke a converted script before any `pnpm install` in the same job**: `changeset-guard.yml`, `changeset-presence.yml`, `ci.yml` (×2), `control-bytes.yml`, `doc-component-types.yml`, `docs-links.yml`, `skills-paths.yml`.

All 29 converted files sit at `scripts/` depth 0, so `./invoked-as.mjs` is right for every one — but that was checked, not assumed. Each of the 8 was loaded under a resolver hook that **throws on any specifier that would need `node_modules`**: all 8 exit 0.

The hook is not vacuous, and the depth check is not vacuous:

- **control A** — the same hook on `check-doc-snippet-types.mjs` (a post-install lane): `Error: NEEDS_NODE_MODULES: typescript`, exit 1.
- **control B** — a probe importing `'../invoked-as.mjs'` from `scripts/`: `ERR_MODULE_NOT_FOUND`. A wrong relative depth is a hard load failure, never a silent one.

### One test had to be strengthened, and it is stronger, not looser

`scripts/__tests__/check-doc-component-types.test.ts`'s `needs no install` case asserted that **every import in that gate starts with `node:`**. The conversion adds `./invoked-as.mjs` — install-free, but not that spelling — so the test failed. This is the trap working.

Loosening the predicate to "builtin **or** relative" would have been the wrong repair: it would let a relative import that *does* pull a package in later land unnoticed. Instead the assertion now **walks the whole static import graph** and requires every leaf to be a builtin, which keeps the original claim ("this needs no `node_modules`") literally true and extends it to every module the gate reaches.

Positive control, mutation confirmed on disk and restored by trap: adding `import ts from 'typescript'` to `scripts/invoked-as.mjs` — **one hop away from the gate, invisible to the old single-file assertion** — reddens it:

```
AssertionError: the gate's import graph reaches a package, so it needs an install:
  scripts/invoked-as.mjs -> typescript: expected [ Array(1) ] to deeply equal []
```

## ⚠️ `check-lucide-icon-record-names.mjs` — STOP, per the dispatch order

The order ruled: *"⛔ If those loops feed module-level exports that importers actually read, STOP and report rather than restructuring the module."* **They do, and the measurement is worse than the condition anticipated.**

The two top-level `for` loops (now `:243`/`:245`, one line lower after the added import) build `keyByComponent` and `kebabByKey`. Those are module-private, but they are read by the exported `liveSpellingFor` and `describeName`, which importers really call — `scripts/__tests__/check-lucide-icon-record-names.test.ts` calls both.

Ablation on this branch, mutation confirmed on disk (top-level loop lines 1 → 0, indented-behind-guard 1), restored by trap:

- rule 2 **goes green** and reports the `KNOWN_IMPORT_UNSAFE` entry as STALE — the baseline is satisfied;
- the importing suite **fails 5 of 25**;
- and the failure is not merely a red test. `describeName('BarChart3')` stops saying ``write `chart-column` `` and says *"no live key names the same glyph"* instead — **a wrong diagnosis for a real violation**, printed by a gate that still exits 1. That is a worse outcome than the unguarded loops, not a better one.

So the loops are **left alone**, the `KNOWN_IMPORT_UNSAFE` entry stays at one, and the gate's comment now records the measurement instead of claiming the entry has "one remedy" (it does not — it needs a judgement, which is precisely what that comment says a debt line must not be). A lazy build of the two maps inside `liveSpellingFor` would satisfy both sides and is noted there as the shape a follow-up card should consider. Its guard **spelling** is converted with the other 28; only the import-safety restructuring is deferred.

## `shadcn-sync.js` — a simplification, kept visibly distinct

It hand-typed the **correct** two-leg shape (`realpathSync(resolved) === __filename`) and the gate never flagged it. Converting it deletes an 11-line `invokedAsCli()` and the `realpathSync` import it existed for. The call site now carries a comment saying, in the file itself, that this one was a simplification rather than a fix — and that the shared predicate additionally handles the node-given-a-directory case the hand-typed copy never had.

## The gate's header, rewritten to the swept state

PR 1's own lesson — a ported header describing a tree that no longer exists is the defect #6078 recorded — applies to this PR too. Every claim in `check-entry-guard.mjs`'s header was re-checked against the post-sweep tree, and four had gone false:

- "This repository has not been swept" / "have drifted into NINE distinct spellings" — now past tense, with the baseline described as empty and the reason it stays.
- The three baseline consequences — the STALE and count-raising legs are unreachable while the map is empty; they stay in `reconcileGuards` (and pinned by the self-test) because that is the state a re-added line would have to pass through.
- The `shadcn-sync.js` paragraph — its distinction now lives at the call site.
- **The masking example was stale in a way worth naming**: the header cited ``shadcn-sync.js:1046`` as the file that "really does write one in prose" — and that docblock is exactly what this PR deletes. It now cites the measured survivor, `js-comment-mask.mjs`'s 8 in-literal occurrences, which would read as a 30th hand-typed guard if the masking ever regressed.

One self-test case changed shape: the loop over `CORRECT_SHAPE_BUT_HAND_TYPED` was data-driven and becomes vacuous once that set is empty, so it is replaced by an explicit assertion that **an empty baseline still calls a real guard FRESH**. A test reading the map's *size* would have passed on an empty map that had also stopped being consulted; this one asserts the reconciliation. Count is unchanged at 63.

## Verification, each quoting its own verdict line

All at final commit `06ad4dff0`. Exit codes captured before any pipe.

```
node scripts/check-entry-guard.mjs --self-test    exit=0
  ✓ check-entry-guard self-test: 63 cases pass — all 9 spellings measured in this tree rejected, …
node scripts/check-entry-guard.mjs                exit=0
  ✓ check:entry-guard: 41 scripts/ file(s) … 0 file(s) still hand-type one (0 occurrence(s) …
node scripts/js-comment-mask.mjs --self-test      exit=0
  ✓ js-comment-mask self-test: 35 cases pass (23 mask/strip corpus, 12 interpolation view).
node scripts/invoked-as.mjs --self-test           exit=0
  ✓ invoked-as self-test: 12 cases pass (real symlink, different-name symlink, percent-encoding …
node scripts/check-control-bytes.mjs              exit=0
  ✅  check-control-bytes: OK (scanned 5088 tracked text file(s); skipped 85 binary).
node scripts/check-lint-coverage.mjs              exit=0
  ✅  lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).
node scripts/check-changeset-presence.mjs         exit=0
  ✅  No source of a released package changed in this range, so no changeset is owed.
node scripts/check-changeset-no-major.mjs         exit=0
  ✅  No changeset declares a `major` bump.
node scripts/check-changeset-fixed.mjs            exit=0
  ✅  privatePackages declared: version=true, tag=false.
node scripts/check-skills-paths.mjs               exit=0
  ✅  check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined).
node scripts/check-doc-links.mjs                  exit=0
  Links are valid across 15 scan roots.
```

Plus: the remaining 18 converted gates all ran as the harness's CLI leg above, with their verdicts captured before and after.

```
npx vitest run scripts/__tests__/ --maxWorkers=2   exit=0
  Test Files  69 passed (69) · Tests  1894 passed (1894)      # run from the repo ROOT, never package-scoped
pnpm type-check:scripts                            exit=0     # tsc -p tsconfig.scripts.json, no diagnostics
pnpm lint:root                                     exit=0     # the FULL root scan covering scripts/, 6.8s
  ✖ 28 problems (0 errors, 28 warnings)                       # all pre-existing — see below
```

**No lint narrowing was needed.** `pnpm lint:root` (`eslint .` over everything outside `packages`/`examples`/`apps`/`docs`, which is where this whole diff lives) ran the full population in under seven seconds. Its 28 warnings are all pre-existing: `eslint --format json` over the 31 changed lintable files reports exactly 31 file objects with `errorCount=0` and `warningCount=0` each, so none of the 28 is in this diff. `pnpm lint` (`turbo run lint`) is per-package and this diff touches no package source.

**Control bytes:** `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over every changed file returns no matches, and `check-control-bytes.mjs` is green above.

**Not done, and not owed by this seat:** CI convergence. The report lands at draft-PR time per the dispatch contract; the PM verifies the real gate jobs.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_