### PR TITLE
fix(i18n): define home.recentApps.itemType.report and .metadata in all ten packs

### DIFF
--- a/.changeset/6023-recent-item-type-keys.md
+++ b/.changeset/6023-recent-item-type-keys.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/i18n': patch
+---
+
+All ten locale packs now define `home.recentApps.itemType.report` and
+`home.recentApps.itemType.metadata` (objectui#6023). `RecentItem['type']` is a six-member
+union and `useTrackRouteAsRecent` writes both of these at runtime — `metadata` on any
+`/metadata/<type>/<name>` route visit, `report` on any `/report/<name>` visit — but the
+packs defined only four of the six, so the Recently Accessed and Starred cards labelled
+those two items from the call sites' inline `defaultValue` instead of from the pack.
+
+Ten packs missing the same member is full parity, so no pack-vs-pack gate could see it,
+and the prefix rule only ever asked whether `home.recentApps.itemType` resolved, which it
+did. What made it quiet rather than loud is the `defaultValue`: English readers saw a
+plausible `Report` / `Metadata` (lowercase in the rail) rather than a raw key, and the
+other nine locales saw those English words — objectui#3517's mechanism for hiding a
+missing key for months.
+
+The nine translations were taken from each pack's own existing rendering of the same word
+rather than composed: the singular `Report` that `appDesigner.navReport`,
+`appDesigner.navTypeReport` and `search.badgeReport` already carry (ar `تقرير`, de
+`Bericht`, es `Informe`, fr `Rapport`, ja `レポート`, ko `보고서`, pt `Relatório`, ru
+`Отчёт`, zh `报表`), and the `Metadata` that `layout.metadata.label` already carries (ar
+`البيانات الوصفية`, de `Metadaten`, es `Metadatos`, fr `Métadonnées`, ja `メタデータ`, ko
+`메타데이터`, pt `Metadados`, ru `Метаданные`, zh `元数据`). No new vocabulary was invented
+for any locale.
+
+The two matching entries in `scripts/i18n-call-site-key-baseline.json`'s `missingMembers`
+are cleared, since that list is a ratchet: a baselined entry whose defect is gone fails the
+build too. The union itself is untouched — narrowing `RecentItem['type']` is the other
+resolution the gate accepts, and it would have been a lie about data both call sites
+demonstrably write.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -2309,7 +2309,9 @@ const ar = {
         object: "كائن",
         dashboard: "لوحة تحكم",
         page: "صفحة",
+        report: "تقرير",
         record: "سجل",
+        metadata: "البيانات الوصفية",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -2302,7 +2302,9 @@ const de = {
         object: "Objekt",
         dashboard: "Dashboard",
         page: "Seite",
+        report: "Bericht",
         record: "Datensatz",
+        metadata: "Metadaten",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -2543,7 +2543,9 @@ const en = {
         object: 'Object',
         dashboard: 'Dashboard',
         page: 'Page',
+        report: 'Report',
         record: 'Record',
+        metadata: 'Metadata',
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -2306,7 +2306,9 @@ const es = {
         object: "Objeto",
         dashboard: "Panel",
         page: "Página",
+        report: "Informe",
         record: "Registro",
+        metadata: "Metadatos",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -2304,7 +2304,9 @@ const fr = {
         object: "Objet",
         dashboard: "Tableau de bord",
         page: "Page",
+        report: "Rapport",
         record: "Enregistrement",
+        metadata: "Métadonnées",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -2304,7 +2304,9 @@ const ja = {
         object: "オブジェクト",
         dashboard: "ダッシュボード",
         page: "ページ",
+        report: "レポート",
         record: "レコード",
+        metadata: "メタデータ",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -2301,7 +2301,9 @@ const ko = {
         object: "오브젝트",
         dashboard: "대시보드",
         page: "페이지",
+        report: "보고서",
         record: "레코드",
+        metadata: "메타데이터",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -2301,7 +2301,9 @@ const pt = {
         object: "Objeto",
         dashboard: "Painel",
         page: "Página",
+        report: "Relatório",
         record: "Registro",
+        metadata: "Metadados",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -2315,7 +2315,9 @@ const ru = {
         object: "Объект",
         dashboard: "Панель",
         page: "Страница",
+        report: "Отчёт",
         record: "Запись",
+        metadata: "Метаданные",
       },
     },
     starredApps: {

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -2375,7 +2375,9 @@ const zh = {
         object: '对象',
         dashboard: '仪表盘',
         page: '页面',
+        report: '报表',
         record: '记录',
+        metadata: '元数据',
       },
     },
     starredApps: {

--- a/scripts/i18n-call-site-key-baseline.json
+++ b/scripts/i18n-call-site-key-baseline.json
@@ -34,8 +34,5 @@
     "Both entries below were measured by the check's first run, not created by it."
   ],
 
-  "missingMembers": {
-    "home.recentApps.itemType.metadata": "objectui#6023",
-    "home.recentApps.itemType.report": "objectui#6023"
-  }
+  "missingMembers": {}
 }


### PR DESCRIPTION
Fixes #6023

All ten locale packs now define `home.recentApps.itemType.report` and
`home.recentApps.itemType.metadata`, and the two matching `missingMembers` entries in
`scripts/i18n-call-site-key-baseline.json` are cleared.

Verified at `cd8d6594d`.

## Premise re-verified, not inherited

The card rules out narrowing `RecentItem['type']`, and that ruling-out holds. Both members
are written at runtime, in `packages/app-shell/src/hooks/useTrackRouteAsRecent.ts`:

```
:105          type: 'metadata',     // inside `if (seg2 === 'metadata')`, for /metadata/:metaType/:metaName
:148          type: 'report',       // inside `case 'report':`, for /report/:seg3
```

The union at `packages/app-shell/src/context/RecentItemsProvider.tsx:47` is unchanged.
Narrowing it would have shrunk the check rather than paid off the debt — the exact
resolution the gate's own hint text warns against.

## The nine translations were found, not composed

Every pack already renders both words, so nothing was invented for any locale. Sources:

- **report** — the singular `Report` carried by `appDesigner.navReport`,
  `appDesigner.navTypeReport` and `search.badgeReport` (that last one is the closest
  analogue: a type badge on a search result).
- **metadata** — the `Metadata` carried by `layout.metadata.label`, the nav entry for the
  same `/metadata/...` surface these recent items point at.

| locale | report | source | metadata | source |
|---|---|---|---|---|
| ar | تقرير | found (3 keys agree) | البيانات الوصفية | found (7 uses) |
| de | Bericht | found (3 keys agree) | Metadaten | found (7 uses) |
| es | Informe | found (3 keys agree) | Metadatos | found (7 uses) |
| fr | Rapport | found (3 keys agree) | Métadonnées | found (7 uses) |
| ja | レポート | found (3 keys agree) | メタデータ | found (7 uses) |
| ko | 보고서 | found (3 keys agree) | 메타데이터 | found (7 uses) |
| pt | Relatório | found (3 keys agree) | Metadados | found (7 uses) |
| ru | Отчёт | found (3 keys agree) | Метаданные | found (7 uses) |
| zh | 报表 | found — see note | 元数据 | found (7 uses) |

**One judgement call, zh `report`.** The pack is not unanimous: 12 uses of `报表` against 1
of `报告` (`console.breadcrumb.reports`). Five of the six report-valued keys, including all
three singular ones, read `报表`, so `报表` is what the pack says. The lone `报告` outlier is
noted here rather than touched — out of scope for this card.

Register and capitalisation follow each pack's own four existing `itemType` members rather
than English title case; the found values already matched (capitalised in de/es/fr/pt/ru,
caseless in ar/ja/ko/zh), so no case was adjusted.

## Verification

**The ratchet does work — the ablation pair.** Keys added and baseline cleared, the gate is
green. With the two `en` lines deleted and the baseline still cleared, it reddens and names
both members. The mutation was confirmed on disk before the result was read (grep count on
each anchor line went 1 to 0, and the `itemType` block was printed back), and the restore
leg ran under a trap, verified clean by `git status`.

- `pnpm check:i18n-keys` (fixed state) — exit `0`, its own verdict line:
  `Every in-scope call-site key resolves against the en pack (2822 keys), … and every
  dynamic key family either checks its members against a declared vocabulary or says in
  writing why it has none.` — with `18 with a static vocabulary (112 member key(s) checked
  exactly)`.
- `pnpm check:i18n-keys` (ablated state) — exit `1`:
  `2 dynamic-family findings — the head resolves, so the prefix rule is satisfied; these
  are about the MEMBERS behind it:` followed by
  `HomeRail.tsx:251:21  [missing-member]  home.recentApps.itemType.metadata` and
  `HomeRail.tsx:251:21  [missing-member]  home.recentApps.itemType.report`.
- `pnpm vitest run packages/i18n/src/__tests__` (root vitest, never package-scoped) —
  exit `0`, `Test Files  54 passed (54)` / `Tests  898 passed (898)`. All ten packs pass
  `all-locales-key-parity.test.ts` individually: `zh|ja|ko|de|fr|es|pt|ru|ar defines every
  en key` plus `… defines no key that en lacks`, and `placeholders match en in every pack`.
- `pnpm check:i18n-drift` — exit `0`:
  `Compared the ten locale packs at 7797e3b74 (merge-base with origin/main) with the
  working tree: 0 en value(s) changed (2 key(s) added, 0 removed …)`.
- `node scripts/check-changeset-presence.mjs` — exit `0`:
  `✅  10 source file(s) of 1 released package(s) changed, and this change declares 1
  changeset(s)`.
- `pnpm changeset:check` — exit `0`, `✅  No changeset declares a major bump.`
- `node scripts/check-control-bytes.mjs` — exit `0`,
  `✅  check-control-bytes: OK (scanned 5098 tracked text file(s); skipped 85 binary).`
- `pnpm turbo run type-check --filter=@object-ui/i18n` — exit `0`,
  `Tasks:    4 successful, 4 total`.
- `pnpm check:i18n-dead-keys` — a report, not a gate; neither new key appears in it (both
  are dynamic-template-reachable).

Every exit code above was captured before any pipe (redirect to a file, then read the
file), and each line quoted is the gate's own, not a bare `$?`.

**Lint was narrowed, and here is why the narrowing is a measurement.** eslint ran over the
ten changed `.ts` files rather than the repo. (1) The universe comes from eslint's own
config, not a guess: run against the other two changed paths, eslint reports `File ignored
because no matching configuration was supplied.` for both `scripts/i18n-call-site-key-baseline.json`
and the changeset `.md`, so the diff's lintable set is exactly those ten files. (2) The
count comes from `--format json`: `files eslint actually linted: 10`, `errors: 0
warnings: 0`, exit `0`. (3) `eslint.config.js` enables no type-aware linting — its
`languageOptions` carries only `ecmaVersion` and `globals`, with no `project` or
`projectService` — so no untouched file's verdict can move because of this diff. CI runs
the full farm regardless.

## Two things reported, not fixed

**`HomeRail.tsx:251` falls back to the bare lowercase `it.type`** while `RecentApps.tsx:55`
and `StarredApps.tsx:61` both pass `capitalizeFirst(item.type)`. Once these keys exist the
fallback stops firing for `report` and `metadata`, so it is moot for them — but it stays
wrong for any future member, and it is the reason the English rail read `report` where the
cards read `Report`. Out of scope here; flagged for the PM to decide whether it wants a
card.

**The baseline `note` was left exactly as it is**, per the standing instruction. Reporting
one consequence rather than acting on it: the note's sentence
`missingMembers is a THIRD list (objectui#4964), NOT part of that pair and NOT empty` now
has a stale clause, because this change takes `missingMembers` to zero. The load-bearing
half is untouched and still true — the `BOTH LISTS ARE NOW EMPTY` sentinel is scoped to the
`missingKeys` + `missingPrefixes` pair, and `residue-namespaces-3546.test.tsx`'s
`the ratchet is empty — this is the terminal state, not a partial one` passes. Not edited;
the PM decides.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_