### PR TITLE
fix(plugin-form): declare object-master-detail-form formType as a closed, measured vocabulary

### DIFF
--- a/.changeset/master-detail-formtype-vocabulary.md
+++ b/.changeset/master-detail-formtype-vocabulary.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+`object-master-detail-form` declares `formType` as a closed vocabulary instead of a bare `string`.
+
+The block declared `formType` as `type: 'string'` while the sibling `object-form` declared the
+same key as an `enum`, and both funnel into the renderer that switches on those variant names. A
+value outside the vocabulary therefore matched no branch and fell through to the flat field list
+with no diagnostic — measured, a `formType` of `'wizzard'` renders the parent half with its
+authored sections silently gone.
+
+The declared set is `simple | tabbed`, measured against the master-detail composition rather than
+copied from the sibling's six: `drawer` and `modal` host the parent half in a portal dialog outside
+the master-detail container, so its single bottom Save bar has no form to submit; `wizard` mounts
+only the current step's fields and turns that Save bar into a `Next`; `split` renders inline but
+persists through `dataSource.create` instead of the atomic batch.
+
+Authoring-surface only. The manifest, the JSX-page compiler and the save gate now report an
+out-of-vocabulary value as `invalid-enum`; rejection at publish time remains `@objectstack/spec`'s.

--- a/apps/console/src/__tests__/masterDetailFormTypeManifest.test.ts
+++ b/apps/console/src/__tests__/masterDetailFormTypeManifest.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * What tightening `object-master-detail-form.formType` to an `enum` actually
+ * BUYS, measured at the layer that reads the declaration (objectui#5939).
+ *
+ * The declaration is not documentation: `manifestFromConfigs` serializes
+ * `inputs` into the manifest the JSX-page compiler and the save gate validate
+ * against, and `sdui-parser`'s `checkType` raises `invalid-enum` at severity
+ * `error` when a prop's only declared arm is an `enum` and the written value is
+ * outside it (`packages/sdui-parser/src/validate.ts`). While the key was a bare
+ * `string`, every string passed — `'wizzard'` included — and the renderer then
+ * matched no branch and dropped the authored sections with no diagnostic.
+ *
+ * ⚠️ Scope, stated plainly rather than implied. This is the AUTHORING surface —
+ * the manifest, the compiler, the save gate, and what a probe samples. Per
+ * objectui#5155's standing maintainer ruling, REJECTION lives at the zod/publish
+ * boundary, and `@objectstack/spec`'s `ObjectMasterDetailFormPropsSchema.formType`
+ * still accepts any string. The last test below asserts that gap rather than
+ * papering over it, so this file cannot be read as "the hole is closed".
+ */
+import { describe, it, expect } from 'vitest';
+import { ComponentRegistry } from '@object-ui/core';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+import type { Diagnostic, SchemaElement } from '@object-ui/sdui-parser';
+import '@object-ui/components';
+import '../register-plugins';
+
+const manifest = manifestFromConfigs(
+  ComponentRegistry.getAllConfigs() as unknown as Parameters<typeof manifestFromConfigs>[0],
+);
+
+/**
+ * The manifest key, which carries the registration's namespace — the bare
+ * `object-master-detail-form` is not a key here, and asserting against it would
+ * have made every "no diagnostic" claim below vacuous. The reachability test
+ * caught exactly that while this file was being written.
+ */
+const BLOCK = 'plugin-form:object-master-detail-form';
+
+const nodeWith = (formType: string): SchemaElement =>
+  ({
+    type: BLOCK,
+    objectName: 'po',
+    details: [{ childObject: 'po_line', relationshipField: 'po' }],
+    formType,
+  }) as unknown as SchemaElement;
+
+const diagnose = (formType: string): Diagnostic[] =>
+  validateTree(nodeWith(formType), manifest).diagnostics.filter((d) => d.code === 'invalid-enum');
+
+describe('object-master-detail-form.formType — the manifest carries the closed vocabulary', () => {
+  it('the block is in the manifest at all (reachability before absence)', () => {
+    // Without this, every "no diagnostic" assertion below would pass vacuously
+    // on an unregistered block — `unknown-component` is a different code.
+    expect(manifest.components[BLOCK], `${BLOCK} is not in the manifest`).toBeDefined();
+  });
+
+  it('serializes the enum, so the compiler and save gate see the same two values', () => {
+    const input = manifest.components[BLOCK].inputs.find((i) => i.name === 'formType');
+    expect(input?.type).toBe('enum');
+    expect([...(input?.enum ?? [])].sort()).toEqual(['simple', 'tabbed']);
+  });
+
+  it.each(['simple', 'tabbed'])('accepts the honoured value `%s`', (value) => {
+    expect(diagnose(value)).toEqual([]);
+  });
+
+  it.each(['wizzard', 'x', 'wizard', 'drawer'])(
+    'reports `%s` as `invalid-enum` at severity error — nothing reported it before',
+    (value) => {
+      const [d] = diagnose(value);
+      expect(d, `no invalid-enum diagnostic for ${JSON.stringify(value)}`).toBeDefined();
+      expect(d.severity).toBe('error');
+      expect(d.message).toContain('formType');
+    },
+  );
+
+  it('⚠️ does NOT make the value rejected at the publish boundary (objectui#5155)', async () => {
+    // The other half of the honest reading. objectstack owns this schema; the
+    // objectui enum cannot narrow it, and a reader who stopped at the test above
+    // would conclude the value is now impossible to publish. It is not.
+    const spec: any = await import('@objectstack/spec/ui');
+    const schema = spec.ObjectMasterDetailFormPropsSchema;
+    expect(schema, 'ObjectMasterDetailFormPropsSchema is not exported').toBeDefined();
+    expect(schema.safeParse({ objectName: 'po', details: [], formType: 'wizzard' }).success).toBe(
+      true,
+    );
+  });
+});

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -308,7 +308,24 @@ ComponentRegistry.register('object-master-detail-form', MasterDetailFormRenderer
     { name: 'sections', type: 'array', label: 'Parent Sections' },
     { name: 'details', type: 'array', label: 'Detail Collections', required: true },
     { name: 'recordId', type: 'string', label: 'Parent Record Id', description: 'The parent record to load in `edit` mode. Leave unset for `create`.' },
-    { name: 'formType', type: 'string', label: 'Parent Form Presentation', description: 'How the PARENT half of the form is presented. The detail grids below it are unaffected.' },
+    // TWO values, not the six `object-form` declares (objectui#5939). A bare
+    // `string` here let an out-of-vocabulary value match NO renderer branch and
+    // fall through to the flat field list with no diagnostic — measured: a
+    // `formType` of `'wizzard'` renders the parent half with its section headers
+    // silently gone. The vocabulary is narrowed to what the master-detail
+    // composition actually supports, which the repo already states twice:
+    // `MasterDetailFormSchema.formType?: 'simple' | 'tabbed'`
+    // (MasterDetailForm.tsx) and the coercion `formType === 'tabbed' ? 'tabbed'
+    // : 'simple'` ObjectForm.tsx uses when it routes a `subforms` schema in here.
+    // The other four are reachable branches that BREAK this composition, each
+    // observed rather than assumed: `drawer`/`modal` host the parent half in a
+    // portal dialog outside the master-detail container, so the single bottom
+    // Save bar finds no `<form>` to submit; `wizard` mounts only the current
+    // step's fields and turns that Save bar into a `Next`; `split` renders two
+    // panels but persists through `dataSource.create` instead of the batch.
+    // Declaring them would mint choices an authoring UI offers and this block
+    // cannot honour.
+    { name: 'formType', type: 'enum', label: 'Parent Form Presentation', enum: ['simple', 'tabbed'], description: 'How the PARENT half of the form is presented. The detail grids below it are unaffected.' },
     { name: 'fields', type: 'array', label: 'Parent Fields', description: 'Which parent fields to show, in order. Ignored when `sections` is given — sections carry their own field lists.' },
     { name: 'title', type: 'string', label: 'Title' },
     { name: 'submitText', type: 'string', label: 'Submit Button Text', description: 'Label of the button that saves the parent and every detail row in one batch.' },

--- a/packages/plugin-form/src/masterDetailFormTypeVocabulary.test.tsx
+++ b/packages/plugin-form/src/masterDetailFormTypeVocabulary.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `object-master-detail-form.formType` declares a CLOSED vocabulary, and the
+ * vocabulary is the measured one (objectui#5939).
+ *
+ * ## What went wrong
+ *
+ * The block declared `formType` as a bare `string` while `object-form` declared
+ * the same key as an `enum` of six. Both funnel into `ObjectForm`, which
+ * switches on those six names, so a value outside them matched NO branch and
+ * fell through to the flat field list with no diagnostic — an author who typed
+ * `'wizzard'` got a plausible-looking form and no signal.
+ *
+ * That is not a cosmetic gap. In objectui#3840's binding-reach probe the generic
+ * sample for a `string` input is `'x'`, so `object-master-detail-form` skipped
+ * the section loop entirely and read GREEN, while `object-form` (enum sample
+ * `'simple'`) painted an error card on the identical malformed input. A value
+ * outside a prop's vocabulary routes AROUND the block instead of exercising it —
+ * here, around a real crash, for as long as anyone had looked.
+ *
+ * ## Why TWO values and not the sibling's six
+ *
+ * Copying the six across would have minted a declared-but-inert vocabulary: an
+ * authoring UI offering choices this composition cannot honour. So the set was
+ * measured rather than assumed, and the four exclusions are each pinned below by
+ * the way they BREAK the master-detail composition, not by assertion:
+ *
+ *   `simple`  → ObjectForm.tsx:1134 (SimpleObjectForm sections path). Honoured.
+ *   `tabbed`  → ObjectForm.tsx:236  (TabbedForm). Presentation honoured.
+ *   `wizard`  → ObjectForm.tsx:260  (WizardForm) — mounts only the CURRENT
+ *               step's fields, and the master-detail's single bottom Save bar
+ *               drives the wizard's `Next` instead of saving.
+ *   `split`   → ObjectForm.tsx:287  (SplitForm) — renders two panels inline.
+ *   `drawer`  → ObjectForm.tsx:316  (DrawerForm) — hosts the parent half in a
+ *               PORTAL dialog, outside the master-detail container, so the Save
+ *               bar has no `<form>` to submit.
+ *   `modal`   → ObjectForm.tsx:346  (ModalForm) — same portal shape.
+ *
+ * The repo already stated the same two independently, which is the corroboration
+ * this file is derived against rather than a second guess:
+ * `MasterDetailFormSchema.formType?: 'simple' | 'tabbed'` (MasterDetailForm.tsx)
+ * and the coercion `formType === 'tabbed' ? 'tabbed' : 'simple'` ObjectForm.tsx
+ * applies when it routes a `subforms` schema into this block.
+ *
+ * ## Scope, stated so it is not over-read
+ *
+ * The `enum` fixes the AUTHORING surface — what a designer offers, what a probe
+ * samples, and what `sdui-parser`'s `validateTree` reports (see
+ * `apps/console/src/__tests__/masterDetailFormTypeManifest.test.ts`). Per
+ * objectui#5155's standing ruling, rejection lives at the zod/publish boundary,
+ * and `@objectstack/spec`'s `ObjectMasterDetailFormPropsSchema.formType` still
+ * accepts any string. This declaration does not make the value rejected there.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor, fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { registerAllFields } from '@object-ui/fields';
+import { MasterDetailForm } from './MasterDetailForm';
+import './index';
+
+vi.mock('@object-ui/components', async (orig) => {
+  const actual = await (orig as any)();
+  return { ...actual, toast: { success: vi.fn(), error: vi.fn() } };
+});
+
+registerAllFields();
+
+/** The vocabulary `object-form` declares — the set this block was measured against. */
+const OBJECT_FORM_SIX = ['simple', 'tabbed', 'wizard', 'split', 'drawer', 'modal'] as const;
+
+/** The subset the master-detail composition honours. */
+const HONOURED = ['simple', 'tabbed'] as const;
+
+const parentObject = {
+  name: 'po',
+  fields: { ref: { type: 'text', label: 'Ref' }, memo: { type: 'text', label: 'Memo' } },
+};
+
+function mountWith(formType: string) {
+  const batchTransaction = vi.fn().mockResolvedValue({ results: [{ id: 'po1' }] });
+  const create = vi.fn().mockResolvedValue({ id: 'po1' });
+  const dataSource = {
+    getObjectSchema: vi.fn().mockResolvedValue(parentObject),
+    find: vi.fn().mockResolvedValue({ data: [] }),
+    create,
+    update: vi.fn().mockResolvedValue({ id: 'po1' }),
+    delete: vi.fn(),
+    bulk: vi.fn(),
+    batchTransaction,
+  } as any;
+  const view = render(
+    <MasterDetailForm
+      schema={{
+        objectName: 'po',
+        mode: 'create',
+        formType,
+        sections: [
+          { name: 's1', label: 'Sec One', fields: ['ref'] },
+          { name: 's2', label: 'Sec Two', fields: ['memo'] },
+        ],
+        details: [
+          {
+            childObject: 'po_line',
+            relationshipField: 'po',
+            columns: [{ key: 'qty', label: 'Qty', type: 'number' } as any],
+          },
+        ],
+      } as any}
+      dataSource={dataSource}
+    />,
+  );
+  return { ...view, batchTransaction, create };
+}
+
+/** Drive the master-detail's own bottom Save bar, the single Save this layout owns. */
+async function clickHostSave(container: HTMLElement) {
+  const ref = (container.querySelector('input[name="ref"]') ??
+    document.querySelector('input[name="ref"]')) as HTMLInputElement | null;
+  if (ref) fireEvent.change(ref, { target: { value: 'PO-1' } });
+  const buttons = screen.queryAllByRole('button', { name: /^create$/i });
+  if (!buttons.length) return false;
+  fireEvent.click(buttons[0]);
+  return true;
+}
+
+const declaredInput = () =>
+  ComponentRegistry.getConfig('object-master-detail-form')?.inputs?.find(
+    (i: any) => i.name === 'formType',
+  ) as any;
+
+describe('object-master-detail-form `formType` — a closed, measured vocabulary (objectui#5939)', () => {
+  it('is declared as an `enum`, not a bare `string`', () => {
+    const input = declaredInput();
+    expect(input, '`formType` is not declared on object-master-detail-form').toBeDefined();
+    expect(input.type).toBe('enum');
+  });
+
+  it('declares EXACTLY the honoured subset — no more, no fewer', () => {
+    // Order-insensitive on purpose: the claim is the SET, not the listing order.
+    expect([...declaredInput().enum].sort()).toEqual([...HONOURED].sort());
+  });
+
+  it('every declared value is one `object-form` also declares (no private dialect)', () => {
+    for (const value of declaredInput().enum) {
+      expect(OBJECT_FORM_SIX).toContain(value);
+    }
+  });
+
+  it('agrees with `MasterDetailFormSchema["formType"]`, the type contract for the same key', () => {
+    // Compile-time half: every declared value must be assignable to the schema
+    // type. A widened `enum` that the type rejects fails `type-check`, not here.
+    const assignable: Array<NonNullable<
+      import('./MasterDetailForm').MasterDetailFormSchema['formType']
+    >> = ['simple', 'tabbed'];
+    expect([...declaredInput().enum].sort()).toEqual([...assignable].sort());
+  });
+});
+
+describe('the measurement the vocabulary is derived from', () => {
+  it('`simple`: renders both sections inline and saves through the ATOMIC batch', async () => {
+    const { container, batchTransaction, create } = mountWith('simple');
+    await waitFor(() => expect(container.querySelector('input[name="ref"]')).toBeTruthy());
+    expect(container.textContent).toContain('Sec One');
+    expect(container.textContent).toContain('Sec Two');
+    expect(await clickHostSave(container)).toBe(true);
+    await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
+    // The batch is the whole point of this block — the parent must NOT be
+    // written on its own, or a failed child leg orphans a committed parent.
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('`tabbed`: renders the parent half as tabs, inline in the master-detail host', async () => {
+    const { container } = mountWith('tabbed');
+    await waitFor(() => expect(container.querySelectorAll('[role="tab"]').length).toBe(2));
+    expect(container.querySelectorAll('form').length).toBe(1);
+    expect(container.textContent).toContain('Sec One');
+  });
+
+  it.each(['drawer', 'modal'] as const)(
+    '`%s` is excluded: the parent half lands in a PORTAL dialog, leaving the host with no form to save',
+    async (formType) => {
+      const { container } = mountWith(formType);
+      await waitFor(() =>
+        expect(document.querySelectorAll('[role="dialog"]').length).toBeGreaterThan(0),
+      );
+      // Nothing of the parent half is inside the master-detail container, so the
+      // bottom Save bar's `formHostRef.querySelector('form')` returns null and
+      // the click is a no-op.
+      expect(container.querySelectorAll('form').length).toBe(0);
+      expect(container.querySelectorAll('input[name="ref"]').length).toBe(0);
+    },
+  );
+
+  it('`wizard` is excluded: only the current step is mounted, and the host Save acts as `Next`', async () => {
+    const { container, batchTransaction, create } = mountWith('wizard');
+    await waitFor(() => expect(container.querySelector('input[name="ref"]')).toBeTruthy());
+    // Step 1 only — `memo` (step 2) is not mounted, so a save here could never
+    // carry the whole parent record.
+    expect(container.querySelector('input[name="memo"]')).toBeNull();
+    expect(await clickHostSave(container)).toBe(true);
+    await waitFor(() => expect(container.textContent).toContain('Step 2 of 2'));
+    expect(batchTransaction).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('`split` is excluded: it renders inline but persists AROUND the atomic batch', async () => {
+    const { container, batchTransaction, create } = mountWith('split');
+    await waitFor(() => expect(container.querySelector('input[name="ref"]')).toBeTruthy());
+    expect(await clickHostSave(container)).toBe(true);
+    // `submitHandler` — the hook MasterDetailForm hands the parent form to route
+    // the save through `batchTransaction` — is read only by SimpleObjectForm
+    // (ObjectForm.tsx:820). SplitForm writes the parent directly instead.
+    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+    expect(batchTransaction).not.toHaveBeenCalled();
+  });
+
+  it('the harm the closed vocabulary guards: an out-of-vocabulary value silently drops the sections', async () => {
+    const { container } = mountWith('wizzard');
+    await waitFor(() => expect(container.querySelector('input[name="ref"]')).toBeTruthy());
+    // Both fields render, so nothing LOOKS wrong…
+    expect(container.querySelector('input[name="memo"]')).toBeTruthy();
+    // …but the authored section structure is gone: no branch matched, so the
+    // parent half fell through to the flat field list with no diagnostic.
+    expect(container.textContent).not.toContain('Sec One');
+    expect(container.textContent).not.toContain('Sec Two');
+  });
+});


### PR DESCRIPTION
Part of #5939

⚠️ Deliberately `Part of`, not `Fixes`. The card asks two questions and this PR answers one: the declaration is tightened, and the **renderer fall-through** remedy is reported for a ruling rather than implemented (§4). Merging this should not close the card until that ruling lands.

`object-master-detail-form` declared `formType` as a bare `string` while the sibling `object-form` declared the same key as an `enum` of six. Both funnel into `ObjectForm`, which switches on those six names, so a value outside them matched **no** branch and fell through to the flat field list with no diagnostic.

The declared set here is **`simple | tabbed`** — measured against the master-detail composition, not copied from the sibling.

Verified on `e8f171366` (final commit; every gate reading below is from that tree).

---

## 1. The per-value measurement (step 1 of the dispatch order)

Mounted `object-master-detail-form` with two parent sections (`Sec One` → `ref`, `Sec Two` → `memo`) and one detail collection, then drove the master-detail's **own** bottom Save bar. Counts are calls on one stub `dataSource`.

| value | branch reached | parent half renders | host Save bar | honoured? |
|---|---|---|---|---|
| `simple` | `ObjectForm.tsx:1134` → `SimpleObjectForm` sections path | inline, both sections, both inputs | `batchTransaction` ×1, `create` ×0 | ✅ |
| `tabbed` | `ObjectForm.tsx:236` → `TabbedForm` | inline, 2 tabs, both inputs | `batchTransaction` ×0, `create` ×1 | ✅ presentation (see the caveat in §4) |
| `wizard` | `ObjectForm.tsx:260` → `WizardForm` | **only step 1** mounts (`memo` absent) | click advanced to `Step 2 of 2`; nothing persisted | ❌ |
| `split` | `ObjectForm.tsx:287` → `SplitForm` | inline, 2 panels | `batchTransaction` ×0, `create` ×1 | ❌ |
| `drawer` | `ObjectForm.tsx:316` → `DrawerForm` | **portal dialog**, outside the host: 0 forms, 0 inputs in the container | no Create button in the host at all | ❌ |
| `modal` | `ObjectForm.tsx:346` → `ModalForm` | same portal shape | same | ❌ |
| `'wizzard'` (out-of-vocabulary control) | no branch — falls through | both inputs render, **section headers gone** | saves | — the harm |

Two independent statements already in the repo agree with the measured two, which is what the enum is derived against rather than a second guess:

- `MasterDetailFormSchema.formType?: 'simple' | 'tabbed'` (`MasterDetailForm.tsx:93`) — the type contract for the same key.
- `formType === 'tabbed' ? 'tabbed' : 'simple'` (`ObjectForm.tsx:215`) — the coercion `ObjectForm` applies when it routes a `subforms` schema **into** this block. Declaring fewer than two would have made the renderer itself emit an out-of-vocabulary value.

Declaring all six would have minted a declared-but-inert vocabulary — choices an authoring UI offers and this composition cannot honour. The table is pinned as regression coverage in `packages/plugin-form/src/masterDetailFormTypeVocabulary.test.tsx`, so a value that starts or stops being honoured turns it red instead of drifting.

---

## 2. ⭐ The green-because-it-never-ran result, reproduced — then turned into a real reading

This is the card's whole argument, so it is measured in both directions rather than asserted.

**Ablation** — `apps/console/src/__tests__/public-block-binding-reach.test.tsx` restored to its pre-#3840 generic sampling by deleting the two by-name samples (`sections`, `formType`), so the probe once again hands `object-master-detail-form` the generic `'x'` for a `string` input. The mutation was confirmed **on disk**, per anchor, before either leg ran:

```
sections-by-name-sample: 0     (was 1)
formType-by-name-sample: 0     (was 1)
generic-array-sample   : 1     (the ['name'] path, intact)
generic-default-sample : 1     (the 'x' path, intact)
```

No rebuild leg is required and none was run: the root `vitest.config.mts` aliases every `@object-ui/*` specifier to `packages/*/src`, so the mutation reaches the module under test directly — there is no `dist/` in the resolution path to go stale. The declaration leg was moved with `git checkout` against **committed** state in both directions, and the whole script carried `trap restore EXIT INT TERM`.

**LEG A — before the fix** (declaration reverted to `type: 'string'`; on-disk proof `0 enum / 1 string`):

```
× object-form asks the data layer for its objectName
Test Files  1 failed (1)
     Tests  1 failed | 15 passed (16)
```

`object-master-detail-form` **passed** — green, while carrying the identical latent crash. It never reached the section loop.

**LEG B — after the fix** (declaration `enum: ['simple','tabbed']`; on-disk proof `1 enum / 0 string`):

```
× object-form asks the data layer for its objectName
× object-master-detail-form asks the data layer for its objectName
Test Files  1 failed (1)
     Tests  2 failed | 14 passed (16)
```

and the two failures are now the same reading. Quoted with the block name in backticks where the runner prints it wrapped in angle brackets, so the body sanitizer cannot eat the identifier:

```
AssertionError: `object-form` threw during render — that is a crash, not a binding verdict:
… Component "object-form" failed to render … Cannot read properties of undefined (reading 'map')

AssertionError: `object-master-detail-form` threw during render — that is a crash, not a binding verdict:
… Component "object-master-detail-form" failed to render … Cannot read properties of undefined (reading 'map')
```

The declaration is what decided whether the probe exercised the block or routed around it. Restoration was verified afterwards: probe anchors back to `1`/`1`, declaration back to `1 enum / 0 string`, `git status --porcelain` empty.

---

## 3. ⚠️ What catches an out-of-vocabulary value now — and what still does not

**Caught.** `manifestFromConfigs` serializes `inputs` into the manifest the JSX-page compiler and the save gate validate against, and `sdui-parser`'s `checkType` raises **`invalid-enum` at severity `error`** when a prop's only declared arm is an `enum` (`packages/sdui-parser/src/validate.ts:198`). While the key was a bare `string`, every string passed. Pinned in `apps/console/src/__tests__/masterDetailFormTypeManifest.test.ts` for `'wizzard'`, `'x'`, `'wizard'` and `'drawer'`, with `'simple'` / `'tabbed'` asserted clean and a reachability guard ahead of both (that guard earned its place: the manifest key is `plugin-form:object-master-detail-form`, and the first draft asserted against the bare name, which would have made every "no diagnostic" claim vacuous).

**Not caught, stated plainly.** Per #5155's standing maintainer ruling, rejection lives at the zod/publish boundary, and that boundary is `@objectstack/spec`'s, not this repo's:

```ts
ObjectMasterDetailFormPropsSchema.safeParse({ objectName: 'po', details: [], formType: 'wizzard' }).success
// → true, still
```

That is asserted as a **test** in the same file rather than left as prose, so this PR cannot be read as "the hole is closed". Filed as the cross-repo half with the full measurement in it: **objectstack#11873**. The spec is not touched here.

---

## 4. The renderer fall-through — reported, not implemented

The card's second remedy (reject/report an unknown `formType` instead of falling through) is **not** in this PR, per the dispatch order. The census it asked for, over every **tracked** file (`git ls-files`, so `node_modules` and build output are out by construction), excluding this PR's own four files:

| value | occurrences |
|---|---|
| `wizard` | 34 |
| `modal` | 19 |
| `tabbed` | 13 |
| `simple` | 11 |
| `drawer` | 11 |
| `split` | 10 |
| **out-of-vocabulary** | **0** |

98 authored literal values, every one of them inside the six-name vocabulary. Nothing in the repo — fixtures, examples, catalog entries, tests — authors an out-of-vocabulary `formType` today. So the blast radius of a reject-or-report change is zero *in this repo*; it is not zero for already-published apps, which is the part only the PM can rule on.

**One measurement that qualifies the vocabulary, reported rather than quietly shipped:** `submitHandler` — the seam `MasterDetailForm` hands the parent form so the save routes through `batchTransaction` — is read in exactly one place, `ObjectForm.tsx:820` inside `SimpleObjectForm`. `TabbedForm` and `SplitForm` call `dataSource.create` directly instead. So `tabbed`, which this PR declares, is presentationally honoured but **escapes the atomic batch**: the parent commits on its own and a failing child leg orphans it. Dropping `tabbed` from the enum was rejected as the wrong lever — it would contradict both in-repo statements of the vocabulary and make `ObjectForm.tsx:215` emit an undeclared value. Filed as **#6176** instead, with the measurement.

---

## 5. Gates

Each quotes its own verdict line; the exit code was captured before any pipe (`cmd > log 2>&1; EXIT=$?`), never off a `tail`. Root vitest only, never package-scoped (#3378). Every heavy run went through the container's shared verify lock.

| gate | exit | its own verdict line |
|---|---|---|
| root vitest — new tests + console contract/parity suites + the probe | `0` | `Test Files  9 passed (9)` · `Tests  179 passed (179)` |
| root vitest — `packages/plugin-form/` (whole package path) | `0` | `Test Files  60 passed (60)` · `Tests  613 passed (613)` |
| `turbo run type-check --filter=@object-ui/plugin-form --filter=@object-ui/console` | `0` | `Tasks:    37 successful, 37 total` |
| `turbo run lint` (same two packages) | `0` | `Tasks:    3 successful, 3 total` — `0 errors` in both (`637`/`203` pre-existing `no-explicit-any` warnings) |
| `check:control-bytes` | `0` | `check-control-bytes: OK (scanned 5102 tracked text file(s); skipped 85 binary).` |
| `check:phantom-deps` | `0` | `Every in-scope import is declared by the package that publishes it.` |
| `check:self-import` | `0` | `No package names itself inside its own src/.` |
| `check:i18n-keys` | `0` | `Every in-scope call-site key resolves against the en pack (2820 keys)…` |
| `lint:coverage` | `0` | `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `type-check:coverage` | `0` | `type-check coverage: 45/46 via type-check, 0 via their own build, 0 known-broken` |
| `changeset:check` | `0` | `All workspace packages are in the changeset fixed group.` · `No changeset declares a major bump.` |
| `check-changeset-presence` | `0` | `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/master-detail-formtype-vocabulary.md.` |

**Declared narrowing.** `lint` was run per-package (`plugin-form`, `console`) rather than as a whole-repo `eslint .`, and the narrowing is a measurement rather than a skip: the population is the repo's own package boundary (not a hand-picked file list), both packages that this diff touches ran in full, and `eslint.config.js` enables **no** type-aware linting — no `project`, no `projectService`, no `recommendedTypeChecked` — so this diff cannot move the verdict on any file it does not contain. CI runs the whole farm regardless.

Control bytes: the four changed files were also scanned outside the gate with `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` — no matches.

---

## Files

- `packages/plugin-form/src/index.tsx` — the declaration, `type: 'string'` → `type: 'enum', enum: ['simple','tabbed']`, with the exclusions recorded next to it.
- `packages/plugin-form/src/masterDetailFormTypeVocabulary.test.tsx` — the vocabulary and the measurement behind it.
- `apps/console/src/__tests__/masterDetailFormTypeManifest.test.ts` — what the tightening buys at the manifest/save-gate layer, and the publish-boundary gap it does not close.
- `.changeset/master-detail-formtype-vocabulary.md`

Related: #3840 (where this surfaced, and the probe that read green) · #3838 · #5155 (why the enum is not by itself a rejection) · #6158 (the declared-but-inert trap this measurement exists to avoid) · #6176 (filed here) · objectstack#11873 (the spec half).

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_