### PR TITLE
docs(i18n): correct the stale `NOT empty` clause in the i18n baseline note

### DIFF
--- a/scripts/i18n-call-site-key-baseline.json
+++ b/scripts/i18n-call-site-key-baseline.json
@@ -12,7 +12,7 @@
     "with was paid off across seven slices, the last of them two template families. Keep both",
     "of that pair: empty is their terminal, load-bearing state. Any NEW unresolved call-site",
     "key is `unexpected` against an empty baseline and fails the build, which is the point.",
-    "missingMembers is a THIRD list (objectui#4964), NOT part of that pair and NOT empty -- so",
+    "missingMembers is a THIRD list (objectui#4964), NOT part of that pair and empty since objectui#6023 -- so",
     "the sentence above counts missingKeys and missingPrefixes only, never all three. It holds",
     "debt the exact-member check MEASURED on its first run, not debt this repo took on."
   ],


### PR DESCRIPTION
Fixes #6164

Verified at `d76de60c9`.

`scripts/i18n-call-site-key-baseline.json`'s `note` claimed `missingMembers` was `NOT empty`. #6023 / PR #6163 took that list to zero, so the clause became false. One line changes; nothing else in the file, and nothing else in the repo.

```
-    "missingMembers is a THIRD list (objectui#4964), NOT part of that pair and NOT empty -- so",
+    "missingMembers is a THIRD list (objectui#4964), NOT part of that pair and empty since objectui#6023 -- so",
```

## Premise re-verified, not inherited

An earlier round on this card **stopped** because `missingMembers` still held its 2 entries. That stop was correct then, so the premise was re-measured rather than taken from the dispatch:

- PR #6163 reports `"merged":true`, `merged_at 2026-08-24T22:25:09Z`.
- It was **squash**-merged, so `git branch -r --contains cd8d6594d` still prints only its own feature branch — the containment check has to run on the squash commit. `git merge-base --is-ancestor b08b7eba9 origin/main` exits `0`, and `b08b7eba9 fix(i18n): define home.recentApps.itemType.report and .metadata in all ten packs (#6163)` is in `git log origin/main`.
- The decisive check, on `origin/main` at `e5263ed33`: `missingKeys` len `0`, `missingPrefixes` len `0`, **`missingMembers` len `0`**. The clause is false; the edit is owed.

## The note as it stood on `main`, before editing

```
 7 'Of the three lists in this file, missingKeys and missingPrefixes are the PAIR that'
 8 'objectui#3546 ratcheted to zero -- BOTH LISTS ARE NOW EMPTY. The 258-key stock it opened'
 9 'with was paid off across seven slices, the last of them two template families. Keep both'
10 'of that pair: empty is their terminal, load-bearing state. Any NEW unresolved call-site'
11 'key is `unexpected` against an empty baseline and fails the build, which is the point.'
12 'missingMembers is a THIRD list (objectui#4964), NOT part of that pair and NOT empty -- so'
13 'the sentence above counts missingKeys and missingPrefixes only, never all three. It holds'
14 'debt the exact-member check MEASURED on its first run, not debt this repo took on.'
```

Only element 12 changes. The pair sentinel (element 8), both in-note occurrences of `fails the build` (elements 1 and 11) and the third-list scoping — `NOT part of that pair` plus element 13's `counts missingKeys and missingPrefixes only, never all three` — are kept byte-for-byte. The element **count** is unchanged at 15, so no prose was reflowed across an element boundary; that matters because the guard asserts on the **joined** array and is sensitive to the join spaces.

## Both sentinels are load-bearing, and both were proved so

`residue-namespaces-3546.test.tsx:792-793` asserts **two** literal substrings, not one. One red proves one string is checked, so each was ablated separately, each with the other left intact as a control. Every mutation was confirmed **on disk** by anchored `grep -c` on the target text before the result was read, and each leg restored under a `trap ... EXIT INT TERM` running `git checkout HEAD --` followed by the path (the change was committed first, so the restore had a commit to return to). `git status --porcelain` was empty after both.

**Leg A — mutate the sentinel to the exact tempting rewrite the card warns about** (`BOTH LISTS ARE NOW EMPTY` to `ALL THREE LISTS ARE NOW EMPTY`; `fails the build` count held at 3 as a control). Guard exit `1`:

```
AssertionError: expected 'Keys a t() call site references that …' to contain 'BOTH LISTS ARE NOW EMPTY'
 Tests  1 failed | 42 passed (43)
```

**Leg B — mutate only the two in-`note` occurrences of `fails the build`** to `breaks the build`, leaving the sentinel present and leaving the third occurrence (in `//missingMembers`) untouched as a control. That control is the interesting half: `grep -c "fails the build"` still returns `1` for the file, yet the guard reddens — so the assertion reads `note` specifically, not the file. Guard exit `1`:

```
AssertionError: expected 'Keys a t() call site references that …' to contain 'fails the build'
 Tests  1 failed | 42 passed (43)
```

**Restored, then green again** — exit `0`, the same test named:

```
✓ |dom| … the ratchet is empty — this is the terminal state, not a partial one 1ms
 Test Files  1 passed (1) / Tests  43 passed (43)
```

## Gates

Every exit code captured **before** any pipe (redirect to a file, then read it), and each line quoted is the gate's own verdict, not a bare `$?`. Root vitest only, per objectui#3378.

- `pnpm check:i18n-keys` — exit `0`: `Every in-scope call-site key resolves against the en pack (2822 keys), … and every dynamic key family either checks its members against a declared vocabulary or says in writing why it has none.`
- `pnpm vitest run packages/i18n/src/__tests__ scripts/__tests__/check-i18n-call-site-keys.test.ts` — exit `0`, `Test Files  55 passed (55)` / `Tests  993 passed (993)`.
- `node scripts/check-changeset-presence.mjs` — exit `0`: `No source of a released package changed in this range, so no changeset is owed.` No changeset, and no `skip-changeset` label — that label does not exist in this repo.
- `node scripts/check-control-bytes.mjs` — exit `0`, `OK (scanned 5101 tracked text file(s); skipped 85 binary)`. Also scanned the edited file directly with a `grep -naP` control-character class — no match.
- **JSON parse and key stability, asserted rather than eyeballed**: the file parses; top-level key order is identical; `missingKeys`, `//`, `missingPrefixes`, `//missingMembers` and `missingMembers` all compare **equal** to `HEAD`; `note` differs at exactly **one** index, 12.
- **Lint narrowing is a measurement, not a skip**: eslint's own config puts this file outside its universe — `File ignored because no matching configuration was supplied` — so the diff's lintable set is empty. CI runs the full farm regardless.

## Reported, not fixed

The same merge left **two more** stale statements in this file, both outside this card's one-clause scope: `note`'s closing `It holds debt …` (present tense about an empty list) and `//missingMembers`'s `Both entries below …` (there are now zero entries below). Widening the diff would have spent this card's safety margin on prose that is not load-bearing, so both are filed as **#6179** with the ablation findings carried across. The PM decides whether the tense of a comment is above the line.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_