### PR TITLE
docs(i18n): correct two stale statements in the call-site key baseline

### DIFF
--- a/scripts/i18n-call-site-key-baseline.json
+++ b/scripts/i18n-call-site-key-baseline.json
@@ -13,7 +13,7 @@
     "of that pair: empty is their terminal, load-bearing state. Any NEW unresolved call-site",
     "key is `unexpected` against an empty baseline and fails the build, which is the point.",
     "missingMembers is a THIRD list (objectui#4964), NOT part of that pair and empty since objectui#6023 -- so",
-    "the sentence above counts missingKeys and missingPrefixes only, never all three. It holds",
+    "the sentence above counts missingKeys and missingPrefixes only, never all three. It held",
     "debt the exact-member check MEASURED on its first run, not debt this repo took on."
   ],
 
@@ -31,7 +31,7 @@
     "all-locales-key-parity.test.ts demand it in the other nine packs) and deleting the line",
     "here -- NOT by narrowing the vocabulary the family declares, which would shrink the check",
     "rather than pay off the debt.",
-    "Both entries below were measured by the check's first run, not created by it."
+    "The two entries this list held were measured by the check's first run, not created by it."
   ],
 
   "missingMembers": {}


### PR DESCRIPTION
Fixes #6179

Two statements in `scripts/i18n-call-site-key-baseline.json` went false when the `missingMembers` list reached zero. Both are prose inside the file's comment arrays; nothing executable changes.

## The diff — two element strings, nothing else

```
 "note": [
-  "... never all three. It holds",
+  "... never all three. It held",
    "debt the exact-member check MEASURED on its first run, not debt this repo took on."
 ],
 "//missingMembers": [
-  "Both entries below were measured by the check's first run, not created by it."
+  "The two entries this list held were measured by the check's first run, not created by it."
 ],
```

**1. `note` (elements 13–14, joined).** `It holds debt …` was present tense about a list that is now `{}`. Only the tense changes. The claim the sentence exists to make — that whatever the list held was *measured by the exact-member check on its first run, not debt this repo took on* — is preserved word for word. The sentence is not deleted, and the clause before it (`the sentence above counts missingKeys and missingPrefixes only, never all three`) is untouched: that one is still true.

**2. `//missingMembers` (last element).** `Both entries below …` named two entries that are no longer there. Rewritten to name what the list *held*, keeping the same claim (measured by the check's first run, not created by it). No test reads `//missingMembers`.

Nothing else in the file is touched. Widening this into a gate for the class — prose that restates a declared state with nothing checking it — is out of scope here and belongs to #6086.

## Neither array was re-flowed

The guard asserts on `note.join(' ')`, so the joined string is the invariant and element boundaries carry the join spaces. Element counts are unchanged (`note` 15, `//missingMembers` 9) and exactly two element strings differ, so no phrase moved across a boundary and no join space was added or removed.

## Ablation — re-run on this branch, direction predicted before each run

The finding recorded an ablation done on another branch; an inherited ablation is a claim, not a reading, so all four steps were re-run here. Root vitest from the repo root (per objectui#3378), one file, mutations applied by exact-anchor replacement with a hit-count assertion and confirmed on disk by anchored `grep -c` of both the removed and the injected text before each run.

| # | Step | Predicted | Observed |
|---|---|---|---|
| 1 | Guard at the final commit | green | `Test Files 1 passed (1)` / `Tests 43 passed (43)` |
| 2 | Mutate `BOTH LISTS ARE NOW EMPTY` | red at line 792 only | `Tests 1 failed \| 42 passed (43)` — `AssertionError: expected … to contain 'BOTH LISTS ARE NOW EMPTY'` at `residue-namespaces-3546.test.tsx:792:37` |
| 3 | Mutate the two `fails the build` occurrences inside `note` (the third, in `//missingMembers`, left intact) | red at line 793 | `Tests 1 failed \| 42 passed (43)` — `AssertionError: expected … to contain 'fails the build'` at `residue-namespaces-3546.test.tsx:793:37` |
| 4 | Restore with `git checkout HEAD -- scripts/i18n-call-site-key-baseline.json` (never the bare form) | empty diff | `git diff HEAD` empty; the file compares byte-identical to `git show HEAD:scripts/i18n-call-site-key-baseline.json` |

Both sentinels are alive, and step 3 is also the evidence that this edit did not move either `fails the build` occurrence out of `note` — had it, mutating them would have been a no-op and the guard would have stayed green. The mutation script carried a `trap … EXIT INT TERM` restore so an interrupted run could not leave the tree mutated.

In runs 2 and 3 the failure counts are `1 failed | 42 passed`: only the one assertion moves, which also confirms no other test in the file depends on this prose.

## Gate union — run at `1dd3a5fd9`, the final commit

Exit codes captured by redirect before any pipe.

- `pnpm check:i18n-keys` — exit 0. Its own verdict line: *"Every in-scope call-site key resolves against the en pack (2822 keys), every literal inline defaultValue matches the value the pack serves, every call site passes exactly the arguments that value has holes for, no call site carries a literal fallback beside itself, and every dynamic key family either checks its members against a declared vocabulary or says in writing why it has none."*
- `pnpm check:control-bytes` — exit 0. Verdict line: *"✅ check-control-bytes: OK (scanned 5109 tracked text file(s); skipped 85 binary)."*
- Root vitest over the guard plus every other test that reads this baseline (`organization-` / `auth-` / `console-` / `marketplace-preview-` / `perm-home-namespace-3546.test.tsx` and `scripts/__tests__/check-i18n-call-site-keys.test.ts`) — exit 0, `Test Files 7 passed (7)` / `Tests 322 passed (322)`.
- `node scripts/check-changeset-presence.mjs` — exit 0. Verdict line: *"✅ No source of a released package changed in this range, so no changeset is owed."* The diff is one file under `scripts/`, not published source of any release-covered package.

**`pnpm lint` was narrowed, and the narrowing is measured rather than assumed.** Population read from eslint's own config resolution, not from a guess about which files count: `pnpm exec eslint --format json scripts/i18n-call-site-key-baseline.json` reports `"message": "File ignored because no matching configuration was supplied."` — `.json` is not in eslint's checked set at all. File count from that same `--format json` output: one result, `errorCount: 0`. Invariance for untouched files: `eslint.config.js` enables no type-aware linting (no `projectService`, no `parserOptions.project`), and a JSON file is not importable by any TypeScript source, so this diff cannot move the verdict on any file eslint does read. CI runs the full farm regardless.

Context, none of it changed here: #6023 / PR #6163 is the merge that falsified these; #6164 corrected the first of the three statements the same merge broke; #3546 owns the guard and both its assertions; #4964 introduced the third list. #6086 remains open and is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_