### PR TITLE
docs(plugins): qualify `FormField` to the copy plugin-form.mdx describes

### DIFF
--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -48,11 +48,14 @@ npm install @object-ui/plugin-form
 
 ### Form Field
 
-`FormField` is declared once, in `@object-ui/types`
-(`packages/types/src/form.ts`) — this page does not redeclare it, because a
-locally written `interface` compiles no matter how far it has drifted from the
-real one. It has **23 declared keys**, and `name` is the only **required** one:
-`type` and `label` are both optional.
+`FormField` here means the one declared by `@object-ui/types`
+(`packages/types/src/form.ts`) — `@objectstack/spec` ships its own copy of this
+name (`json-schema/ui/FormField.json`) with a different key set, so read this
+table against the `@object-ui/types` copy rather than the same-named schema in
+the spec. This page does not redeclare it, because a locally written
+`interface` compiles no matter how far it has drifted from the real one. It
+has **23 declared keys**, and `name` is the only **required** one: `type` and
+`label` are both optional.
 
 | Key | Type | What it does |
 | --- | --- | --- |


### PR DESCRIPTION
Part of #6172 — the dispatchable half only. **Not** a closing reference: the collision class itself (rename vs re-export vs a gate forbidding a second declaration of an exported schema name) is a contract decision carrying `needs-user-decision`, and #6172 stays open for it.

## What was false

`content/docs/plugins/plugin-form.mdx:51` asserted:

> `FormField` is declared once, in `@object-ui/types` (`packages/types/src/form.ts`) — this page does not redeclare it…

Under the closure rule adopted on #6086, *"declared once"* is a closure claim, and it is false.

## Re-measured at the claim SHA (`b37d3f0fd`), not inherited from the card

| declaration | keys |
| --- | --- |
| `@object-ui/types` — `packages/types/src/form.ts:911` | **23** |
| `@objectstack/spec@17.2.0` — `json-schema/ui/FormField.json` | **29** |
| in common | **14** |

- Types copy counted from the interface body with the `[key: string]: any` index signature excluded (it is present, and it is not a declared member).
- Spec copy counted from the installed dependency, whose version is the one `pnpm-lock.yaml` resolves at this SHA (`17.2.0`), confirmed via `require('@objectstack/spec/package.json').version`.
- Types-only: `condition`, `description`, `disabled`, `id`, `inputType`, `name`, `readonlyWhen`, `requiredWhen`, `validation`.
- Spec-only: `disclosure`, `fields`, `helpText`, `immutable`, `keyField`, `language`, `max`, `maxLength`, `min`, `minLength`, `multiple`, `precision`, `publicPicker`, `reference`, `scale`.

The card's 23 / 29 / 14 reproduce exactly. One drift: the types declaration is now at line **911**, not 906.

## The change

The name is qualified to the copy the page actually describes, following the shape PR #6168 used for `MarkdownSchema` on `plugin-markdown.mdx` — *"the plugin ships its own copy of this name, so read it there rather than the same-named interface in `@object-ui/types`"*. Qualifying says what the page describes; it does not settle which declaration is canonical.

No new closure claim replaces the old one. The page now points at the other copy by file path — an existence claim a reader can check by opening it — instead of asserting that no third copy exists.

⭐ **The 21-row table is untouched.** It restates the `@object-ui/types` copy exactly, and the diff is prose-only: zero fence lines and zero table rows changed.

## Verification — exit codes captured by redirect before any pipe, union re-run at the final commit `a0ed3fb39`

| gate | exit | its own verdict line |
| --- | --- | --- |
| `check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 5109 tracked text file(s); skipped 85 binary).` |
| `check:doc-types` | 0 | `✅  Every documented component type is registered.` |
| `docs:check-links` | 0 | `Links are valid across 15 scan roots.` |
| `check:doc-fences` | 0 | `✅  check:doc-fences — every TypeScript block in 223 document(s) is fenced ts/tsx/typescript…` |
| `check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| changeset presence | 0 | `✅  No source of a released package changed in this range, so no changeset is owed.` |

Root vitest (objectui#3378), scoped to the one suite that reads this page — `scripts/__tests__/check-doc-component-types.test.ts`: **34 passed**, exit 0.

### Scope derived from each gate's own configuration, and the exclusion measured

- The dispatch named `check:doc-snippet-types`; that is the **script file**, and the npm script is `check:doc-snippets`. Re-deriving from `package.json` and `.github/workflows/` also surfaced **`check:doc-fences`**, which the dispatch did not name and which shares the snippet gate's exact scan surface — run here, green.
- All three doc gates take `DOCS_ROOT = 'content/docs'` over `.mdx`/`.md`, so this file is in population by their own configuration. `check:doc-snippets` reports 179 covered / 44 ungated, and the 44 are a list declared in the script: `content/docs/plugins/plugin-form.mdx` is **not** in it, and the page holds 4 TS-family fences, so it is one of the 74 covered docs that actually compile.
- `check:control-bytes` scans `git ls-files` minus `/(^|\/)(node_modules|dist|build|\.next|\.turbo|\.wt-[^/]*)\//`; the path is tracked and matches no exclusion.
- **eslint is out of population, measured rather than asserted** — `eslint --format json content/docs/plugins/plugin-form.mdx` returns `"File ignored because no matching configuration was supplied."`
- Built the 20 packages the snippet gate's own `--build-filter` names before judging, and confirmed `dist` materialized in *this* worktree (`packages/types/dist/form.d.ts:905` holds `export interface FormField {`) rather than trusting the turbo cache-hit log, which replayed a path from another agent's worktree.

## Sibling-page sweep — reported, not widened

The literal pattern appears **once in the whole docs tree**, on the page corrected here:

```
content/docs/plugins/plugin-form.mdx:51:`FormField` is declared once, in `@object-ui/types`
```

No other page says *"declared once"*, *"redeclare"*, *"sole declaration"* or *"declared exactly"*. Three neighbours in the same closure-claim **family** (negative existence over the whole tree) were found and deliberately **not** touched — see the report on #6172 for the measurements.

Part of #6172.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_