### PR TITLE
docs(core): name report-schema.mdx's subject ReportComponentSchema

### DIFF
--- a/content/docs/core/report-schema.mdx
+++ b/content/docs/core/report-schema.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Report Schema (ReportSchema)"
+title: "Report Schema (ReportComponentSchema)"
 description: "Enterprise reports with aggregation, export, and scheduling"
 ---
 
@@ -7,11 +7,11 @@ import { SchemaExample } from '@/app/components/ComponentDemo';
 
 # Report Schema
 
-The `ReportSchema` enables creating comprehensive data reports with field aggregation, multiple export formats, and automated scheduling.
+The `ReportComponentSchema` enables creating comprehensive data reports with field aggregation, multiple export formats, and automated scheduling.
 
 ## Overview
 
-ReportSchema provides:
+ReportComponentSchema provides:
 - **Field aggregation** - Sum, average, count, min, max, distinct
 - **Export formats** - PDF, Excel, CSV, JSON, HTML
 - **Scheduled reports** - Daily, weekly, monthly, quarterly, yearly
@@ -455,7 +455,7 @@ if (result.success) {
 
 ## Use Cases
 
-ReportSchema is perfect for:
+ReportComponentSchema is perfect for:
 
 - **Analytics dashboards** - Display key business metrics and KPIs
 - **Business intelligence** - Generate insights from operational data


### PR DESCRIPTION
Fixes #6171

Renames the subject of `content/docs/core/report-schema.mdx` from `ReportSchema` to `ReportComponentSchema`. Prose and frontmatter only — no source change, no fence touched.

## Why this is more than a typo

`ReportSchema` is not a dead name, so a reader following it landed on a **real but wrong** declaration rather than on nothing. Stated from live readings in this tree rather than inherited from the card:

- `@objectstack/spec` 17.2.0 **does** export `ReportSchema`, for the dataset-bound report shape shipped as `json-schema/ui/Report.json`. Its top-level properties measure as `name / label / description / type / dataset / rows / columns / values / runtimeFilter / order / drilldown / chart / blocks / …` — a different shape, and the one `content/docs/plugins/plugin-report.mdx` documents, where the name is **correct and untouched here**.
- `@object-ui/types` does **not** export the bare name. It imports the spec symbol and deliberately re-exports it prefixed — `packages/types/src/spec-report.ts:103`, `export const SpecReportSchema = SpecReportSchema_;`, under a comment reading *"Spec\* prefix to avoid collision with legacy reports.ts"*. The repo had already renamed around this collision everywhere except the prose on this page.
- The shape the page actually documents is `ReportComponentSchema`, declared at `packages/types/src/reports.ts:359`.

## What changed — the set was measured, not taken on trust

The card named three sites; the measured set is **four**, all prose/frontmatter, none inside a fence:

| Line | Before |
|---|---|
| 2 | frontmatter `title: "Report Schema (ReportSchema)"` |
| 10 | H1 lead — "The `ReportSchema` enables creating…" |
| 14 | Overview — "ReportSchema provides:" |
| 458 | Use Cases — "ReportSchema is perfect for:" |

Lines 14 and 458 are the two the card's explicit list did not name. After the edit: exact-word `ReportSchema` on the page = **0** (was 4); `ReportComponentSchema` = **12** (was 8, all 8 pre-existing ones left byte-identical — PR #6168 landed those tables and the example fence, and re-touching them would stack this diff on a sweep for no reason).

**The exclusion is measured, not asserted.** `git status --porcelain` reports exactly **1** changed file, and `content/docs/plugins/plugin-report.mdx` re-measures to the same `sha256 6003c22e…e1bf3` it had before the edit, still carrying its 1 correct `ReportSchema` occurrence.

## Verification — at final head `0f04ff605`

Exit codes captured by redirect **before** any pipe; each gate quoted by its own verdict line, never a bare `$?`.

| Gate | Exit | Its own verdict line |
|---|---|---|
| `check:doc-snippets` | 0 | "Semantic phase: 251 of 251 block(s) judged, 0 failed." / "Every covered documentation snippet compiles against the built types." |
| `check:doc-types` | 0 | "✅ Every documented component type is registered." (184 doc files, 1057 code blocks, 895 `type` literals) |
| `docs:check-links` | 0 | "Links are valid across 15 scan roots." |
| `check:control-bytes` | 0 | "✅ check-control-bytes: OK (scanned 5110 tracked text file(s); skipped 85 binary)." |
| `check:doc-fences` | 0 | "✅ every TypeScript block in 223 document(s) is fenced ts/tsx/typescript, except 83 declared file(s) carrying 105 block(s) … (⛔ SHRINK-ONLY)" |

`check:doc-fences` was **not** in the dispatch list — it was added by deriving scope from each gate's own configuration (`DOCS_ROOT = 'content/docs'`), which covers this file. Its #5867 shrink-only ratchet reading is **unmoved**: this diff touches no fence.

Also note the dispatch named the gate `check:doc-snippet-types`; the script exists but the package script is spelled **`check:doc-snippets`** (`scripts/check-doc-snippet-types.mjs`). The real spelling is what ran.

**First run of `check:doc-snippets` exited 1 and was not a failure of this diff** — it printed *"The snippet program was NOT run: the packages it resolves against are not built"*. After `turbo run build` (43/43 successful) it re-ran green. Recorded because the unbuilt-tree exit is indistinguishable from a real failure at the exit-code level.

**Changeset:** none, per the presence gate's own verdict — objectui has no `skip-changeset` label mechanism, so this verdict is the declaration form:

> ✅ No source of a released package changed in this range, so no changeset is owed.

**Root vitest** (per objectui#3378, never package-scoped) — run narrowed, and the narrowing is declared as a measurement rather than an omission:

1. Population read from vitest's own config, not guessed: `vitest list --filesOnly` = **1971** test files.
2. Of that exact 1971-file population, **0** reference `core/report-schema`.
3. Config invariance: `vitest.config.mts` include globs are `packages/**`, `examples/**`, `eslint-rules/**`, `scripts/**` — the string `content/docs` appears **0** times in the config, so no project can pick up an `.mdx` under it.

The one test file that even mentions this page does so in a prose comment and never reads it from disk; it was run anyway: **1 passed (1), 5 tests passed**.

## In-flight interest on this page

Per the repo's shared-surface guidance, two other cards hold interest in `content/docs/core/report-schema.mdx`:

- **#6121** covers this same page's *authoring examples* contradicting their types (`dataSource`, `exports`) and carries `needs-user-decision`. Out of scope here, and checked rather than assumed: its subject lines live inside the fences and the property table (lines 88, 231), while this diff is lines 2, 10, 14 and 458. **No overlap**, so nothing was decided on its behalf.
- **#5867**'s `core` group (11 blocks / 1 file) covers this page's `plaintext` fences and is blocked behind #6121. This diff changes no fence, and `check:doc-fences` confirms the ratchet population is unchanged.

Neither is addressed by this PR; both remain open.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_