### PR TITLE
docs(plugin-chatbot): name the authored key as `requestBody`, not `body`

### DIFF
--- a/content/docs/plugins/plugin-chatbot.mdx
+++ b/content/docs/plugins/plugin-chatbot.mdx
@@ -107,7 +107,7 @@ const schema = {
   model?: string,
   streamingEnabled?: boolean,
   headers?: Record<string, string>,
-  body?: Record<string, unknown>,
+  requestBody?: Record<string, unknown>,
   maxToolRoundtrips?: number, // deprecated - inert, see below
   onError?: (error: Error) => void,
 }
@@ -151,7 +151,7 @@ const schema = {
 | `model` | string | - | AI model identifier (e.g., `gpt-4o`) |
 | `streamingEnabled` | boolean | `true` | Enable SSE streaming for AI responses |
 | `headers` | object | - | Additional headers for API requests |
-| `body` | object | - | Additional body params for API requests |
+| `requestBody` | object | - | Additional body parameters sent with each API request. Authored on the node as `requestBody`; the renderer forwards it to the chat runtime under its own `body` option. Writing `body` on the node instead sets the base schema's children container and never reaches the API |
 | `maxToolRoundtrips` | number | - | **Deprecated - has no effect.** Nothing reads this value, so it never capped anything. Cap tool-calling loops on the agent instead (`planning.maxIterations`). Still accepted so existing documents keep parsing; slated for removal in a future major |
 | `surface` | `'card' \| 'plain'` | `'card'` | Controls whether the chat renders as a bordered panel or a frameless full-page workspace |
 | `processVisibility` | `'hidden' \| 'summary' \| 'debug'` | `'summary'` | Controls how much agent reasoning and tool detail is shown |


### PR DESCRIPTION
Part of #6169 — the dispatchable half only. The card's other half (the unnamed inline intersection at `packages/plugin-chatbot/src/renderer.tsx:62`) is escalated as a contract decision and is untouched here, so the card must stay open: no closing keyword is used in this body.

## The defect

`content/docs/plugins/plugin-chatbot.mdx`'s Properties table carried a `body` row reading *"Additional body params for API requests"*. That is false as authoring guidance, and it fails silently:

- The node key that carries those params is **`requestBody`**. The renderer maps it to the chat runtime's own option named `body` (`packages/plugin-chatbot/src/renderer.tsx:87`), so `body` was the name of the *prop it becomes*, never the key an author writes.
- The `body` an author would actually hit on the node is **`BaseSchema.body`** — the children container (`packages/types/src/base.ts:121`, documented there as "Child components or content").

So `body` **exists** on the node. Authoring it produces no error and no unknown-key warning; the API params just reach the children container instead. A row naming a key that did not exist would at least have failed loudly.

No source change: `renderer.tsx:87` is correct as written, and the table is what was wrong.

## What changed

Two lines in one file, both the same false key:

1. The Properties table row now names `requestBody`, described as the authored key rather than the prop it becomes, and says what happens if `body` is written instead.
2. **Bounded in-place fix, named here rather than left silent:** the `## Schema API` block above the table (line 110) declared the identical false `body` key for the same authored node. It is the same defect, in the same file, pinned by the same evidence, so leaving it would have shipped a PR that fixes the row while the identical false statement survives one screen above it — and the Schema API block is what a reader meets first. Only that one key was touched in the block; nothing else in it was renamed, added, or removed.

## Verification, before and after

The card's claim is a *collision between two real keys*, so a single grep proves nothing. All five readings, at the claim base `670f57320`:

1. `renderer.tsx` still does `body: schema.requestBody` — present at lines 87, 305 and 438.
2. `ChatbotSchema` declares `requestBody` (`packages/types/src/complex.ts`), documented as "Additional body parameters to include with each API request."
3. `BaseSchema` declares `body` as the children container (`packages/types/src/base.ts:121`).
4. `ChatbotSchema` declares **no** `body` of its own with the documented meaning — a grep for a `body` key inside the interface block matches zero times.
5. After the edit, the page's only remaining `body` occurrences are: the table cell that names it to warn against it, and line 432's `fetch()` call option inside an `onSend` example, which is the Fetch API's own `body` and correct as written.

## Gate union at `37e63ecba` (the commit this PR points at)

Every exit code captured by redirect **before** any pipe, each quoting the gate's own verdict line. Gate list derived from `package.json` and `.github/workflows/`, not from the dispatch order.

- `check:doc-fences` — exit 0 — "every TypeScript block in 223 document(s) is fenced ts/tsx/typescript, except 83 declared file(s) carrying 105 block(s) ... No unknown fence spelling hides one."
- `check:doc-types` — exit 0 — "Every documented component type is registered."
- `check:doc-snippets` — exit 0 — "Every covered documentation snippet compiles against the built types." Run against the built `dist`, its resolution control reporting `@object-ui/types` resolved to `packages/types/dist/index.d.ts`.
- `docs:check-links` — exit 0 — "Links are valid across 15 scan roots."
- `check:control-bytes` — exit 0 — "OK (scanned 5110 tracked text file(s); skipped 85 binary)."
- Root vitest, 6 doc-reading suites — "Test Files 6 passed (6) / Tests 241 passed (241)".

**Changeset: none owed, per the presence gate's own verdict** — "No source of a released package changed in this range, so no changeset is owed." (objectui has no `skip-changeset` label mechanism, so that verdict is the declaration form.)

Each gate's inclusion was measured from its own configuration rather than asserted: the three doc gates scan `DOCS_ROOT = 'content/docs'` across both `.md` and `.mdx`, which includes this file; the snippet gate additionally lists this page among its 44 `UNGATED_DOCS` and collects only `ts`/`tsx`/`typescript` fences, while the edited block at line 110 sits inside a `plaintext` fence — two independent reasons its 21 known parse diagnostics cannot move.

## Deliberately out of scope

- The **11 keys declared only at the anonymous inline intersection** (`renderer.tsx:62`). Escalated as a contract decision; not ruled on, not implemented, not proposed in this diff.
- The 11 unbacked table rows are **not** deleted. They are not dead surface — `autoResponse` / `autoResponseText` / `autoResponseDelay` are read by a live consumer at `packages/app-shell/src/console/ai/AiChatPage.tsx:1599-1601`.
- No "which type does this table describe?" sentence was added. No single declared shape carries the 25 rows, so any name written here would be false — that is the escalated half.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_