### PR TITLE
test(scripts): re-derive the `ValidationRule` absence claim, not just the sentence

### DIFF
--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -99,9 +99,11 @@ is bound to react-hook-form, whose initial values come from the form.
 
 #### `validation` is an object keyed by rule name
 
-There is no `ValidationRule` type in this repository, under any spelling. The
-type of the key is `FieldValidationRules` (`packages/types/src/form.ts`), and it
-is **not** an array of `{ type, value, message }` entries:
+There is no `ValidationRule` type in this repository. Near-spellings do exist —
+`AdvancedValidationRule`, `ValidationRuleType`, `ObjectValidationRule` and
+`DesignerValidationRule` — and none of them types this key. The type of the key
+is `FieldValidationRules` (`packages/types/src/form.ts`), and it is **not** an
+array of `{ type, value, message }` entries:
 
 | Rule | Type | Notes |
 | --- | --- | --- |

--- a/scripts/__tests__/check-doc-component-types.test.ts
+++ b/scripts/__tests__/check-doc-component-types.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -8,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 // `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
 // re-adding one is now itself an error (TS2578). See objectui#3494.
 import { analyze, deriveRegistryKeys, scanDocs } from '../check-doc-component-types.mjs';
+import { blank, scanSource } from '../js-comment-mask.mjs';
 
 /**
  * objectui#4823 — the test for `scripts/check-doc-component-types.mjs`.
@@ -578,6 +580,71 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
   });
 });
 
+/**
+ * Comments AND string / template / regex literal CONTENT blanked, offsets kept.
+ *
+ * Both halves are load-bearing, and the second one is what lets the scan below
+ * read THIS file without reding on it: the fixture table writes the very
+ * declaration it is looking for, as a string. `maskComments` alone leaves those
+ * strings live. Measured over the 3,603 TypeScript files git tracks, blanking
+ * literal content as well loses 16 of 2,324 top-level exported declarations, in
+ * exactly two files — `packages/sdui-parser/src/codegen.ts`, which EMITS a
+ * declaration from a template, and `check-spec-symbol-derivation.test.ts`, whose
+ * fixtures are template literals. Both are the direction to lose them in: source
+ * that declares nothing must not be read as declaring something.
+ */
+function codeOnly(source: string): string {
+  const { comment, literal } = scanSource(source);
+  const flags = new Uint8Array(source.length);
+  for (let i = 0; i < source.length; i++) flags[i] = comment[i] || literal[i];
+  return blank(source, flags);
+}
+
+/**
+ * Every site in `source` that puts the BARE name `ValidationRule` into this
+ * repository's types, reported as `line: what`. Empty means the sentence on
+ * `content/docs/plugins/plugin-form.mdx` holds for this file.
+ *
+ * ⛔ Why this is written the long way (objectui#6186). A substring match on
+ * `ValidationRule` matched 106 lines when this was written, every one of them a
+ * real and DIFFERENT type: `AdvancedValidationRule`, `ValidationRuleType`,
+ * `ObjectValidationRule`, `DesignerValidationRule` and `FieldValidationRules`,
+ * plus `ValidationRuleSchema`, `ValidationRuleDraft`, `BaseValidationRuleShape`
+ * and `buildValidationRules`. A naive match therefore reds on a TRUE claim, and
+ * the next person to hit that deletes the assertion — which puts the claim back
+ * where it started, unguarded. So every spelling above is fixtured as a NEGATIVE
+ * in the test below rather than remembered here.
+ */
+function bareValidationRuleSites(source: string): string[] {
+  const code = codeOnly(source);
+  const lineOf = (index: number) => code.slice(0, index).split('\n').length;
+  const sites: string[] = [];
+
+  // A declaration of the exact name. The trailing `\b` is what keeps
+  // `ValidationRuleType` and `ValidationRuleDraft` out; requiring the keyword and
+  // the whitespace immediately before the name is what keeps
+  // `AdvancedValidationRule`, `ObjectValidationRule`, `DesignerValidationRule`
+  // and `FieldValidationRules` out.
+  for (const m of code.matchAll(/\b(?:interface|class|enum)\s+ValidationRule\b|\btype\s+ValidationRule\s*[=<]/g)) {
+    sites.push(`${lineOf(m.index ?? 0)}: declares \`${m[0].replace(/\s+/g, ' ').trim()}\``);
+  }
+
+  // A re-export publishes the name without declaring it here, so a check that
+  // read declarations alone would call the page true while
+  // `import { ValidationRule } from '@object-ui/types'` compiled for the reader.
+  // Specifiers are SPLIT rather than matched inside the braces, which is what
+  // keeps `export { ValidationRuleSchema }` out — and `export { ValidationRule as
+  // SpecRule }` too, because that publishes a different name.
+  for (const m of code.matchAll(/\bexport\s+(?:type\s+)?\{([^}]*)\}/g)) {
+    for (const specifier of m[1].split(',')) {
+      const published = specifier.trim().split(/\s+as\s+/).pop()?.trim().replace(/^type\s+/, '');
+      if (published === 'ValidationRule') sites.push(`${lineOf(m.index ?? 0)}: re-exports \`ValidationRule\``);
+    }
+  }
+
+  return sites;
+}
+
 describe('objectui#5118 — the plugin-form page teaches the real `validation` shape', () => {
   // The `type` literals this gate judges were only half the drift on that page.
   // `### Form Field` redeclared a local `interface FormField` whose `validation`
@@ -597,6 +664,100 @@ describe('objectui#5118 — the plugin-form page teaches the real `validation` s
     // the declaration a reader copies.
     expect(body).not.toMatch(/validation\??\s*:\s*ValidationRule/);
     expect(body).toContain('There is no `ValidationRule` type in this repository');
+  });
+
+  // ── The OTHER half of that pin (objectui#6186) ─────────────────────────────
+  // `toContain` above asserts the sentence is PRESENT. It cannot assert the
+  // sentence is TRUE. Land a bare declaration of the name tomorrow and the page
+  // turns false while that assertion stays green — worse than no pin at all,
+  // because a green test reads as coverage of the claim it quotes. The two tests
+  // below re-derive the claim from source instead of pinning the prose that
+  // states it. Presence and truth are different assertions; there is now one of
+  // each and neither pretends to do the other's job.
+  //
+  // ⛔ The pin above stays exactly as it is. Its job — keeping the fiction from
+  // being authored back into a snippet a reader copies — is not this one's.
+
+  it('the bare-`ValidationRule` match discriminates every near-spelling that really exists', () => {
+    // Fixtures rather than the tree, so the negative control stays decidable
+    // when the types move. Every negative is a spelling this repository really
+    // writes, cited where it lives — an assertion that red on `FieldValidationRules`
+    // would be deleted by the first person who hit it, and the claim would be
+    // back to unguarded.
+    for (const source of [
+      'export interface ValidationRule {\n  type: string;\n}',
+      'export type ValidationRule = { type: string };',
+      'export type ValidationRule<T> = T[];',
+      'interface ValidationRule {}',
+      'export declare class ValidationRule {}',
+      'export enum ValidationRule {}',
+      "export { ValidationRule } from './rules';",
+      "export type { SpecRule as ValidationRule } from '@objectstack/spec';",
+    ]) {
+      expect(bareValidationRuleSites(source), source).not.toEqual([]);
+    }
+
+    for (const source of [
+      'export interface AdvancedValidationRule {}', //          packages/types/src/data-protocol.ts:708
+      "export type ValidationRuleType = 'required';", //        packages/types/src/data-protocol.ts:748
+      'export type ObjectValidationRule = { name: string };', // packages/types/src/data-protocol.ts:1129
+      'export interface DesignerValidationRule {}', //           packages/types/src/designer.ts:762
+      'export interface FieldValidationRules {}', //             packages/types/src/form.ts:744
+      'interface ValidationRuleDraft {}', //                     app-shell ObjectValidationsPanel.tsx:46
+      'interface BaseValidationRuleShape {}', //                 quoted at types/src/data-protocol.ts:980
+      "import { ValidationRuleSchema } from '@objectstack/spec/data';",
+      "export { ValidationRuleSchema } from '@objectstack/spec/data';",
+      'export function buildValidationRules(field: unknown) {\n  return field;\n}',
+      'const rules: ObjectValidationRule[] = [];',
+      "export { ValidationRule as SpecRule } from '@objectstack/spec';", // publishes another name
+      '// nothing here declares interface ValidationRule', //             prose is masked
+      "const fixture = 'export interface ValidationRule {}';", //         a fixture is masked
+    ]) {
+      expect(bareValidationRuleSites(source), source).toEqual([]);
+    }
+  });
+
+  it('re-derives the claim: nothing this repository declares is a bare `ValidationRule`', () => {
+    // SCANNED POPULATION, stated because the sentence says "in this repository":
+    // every TypeScript file git tracks — `git ls-files` filtered to the `.ts`
+    // family, `.d.ts` included. 3,603 files on the tree this was written against.
+    // It is DERIVED, not listed: `node_modules`, `dist` and every other build
+    // output are untracked and so are out by construction, and a TypeScript type
+    // cannot be declared in a file outside that family.
+    // `scripts/check-control-bytes.mjs` reads this repository the same way, for
+    // the same reason.
+    //
+    // ⚠️ The population and the sentence have to stay co-extensive. If this scan
+    // ever has to be narrowed, narrow the sentence on the page with it — a gate
+    // that asserts less than the prose while looking like it covers it is the
+    // exact defect objectui#6186 filed.
+    const tracked = execFileSync('git', ['ls-files', '-z'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    })
+      .split('\0')
+      .filter((rel) => /\.(?:[cm]?ts|tsx)$/.test(rel));
+
+    // The walk cannot collapse quietly: an empty population makes the assertion
+    // below vacuous and green forever, which is the shape this whole block exists
+    // to stop.
+    expect(tracked.length, 'the source walk found no TypeScript files at all').toBeGreaterThan(1000);
+
+    const sites: string[] = [];
+    for (const rel of tracked) {
+      const source = fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+      // Prefilter on the raw bytes. Masking only ever REMOVES text, so a site in
+      // the masked code implies the raw file carries the name.
+      if (!source.includes('ValidationRule')) continue;
+      for (const site of bareValidationRuleSites(source)) sites.push(`${rel}:${site}`);
+    }
+
+    expect(
+      sites,
+      'content/docs/plugins/plugin-form.mdx tells the reader there is no `ValidationRule` type here. ' +
+        `These declare or publish one, so either the page or the type has to go:\n${sites.join('\n')}`,
+    ).toEqual([]);
   });
 
   it('authors `validation` as an object keyed by rule name, never an array', () => {


### PR DESCRIPTION
Part of #6186 — claim 1 only. The card stays open: claims 2 and 3 are the escalated `needs-user-decision` policy question and are untouched here.

## What was one-sided

`scripts/__tests__/check-doc-component-types.test.ts` pinned that `content/docs/plugins/plugin-form.mdx` **contains** the sentence:

> There is no `ValidationRule` type in this repository

Presence is not truth. Land a bare declaration of that name tomorrow and the page turns false while the pin stays green — worse than no pin, because a green test reads as coverage of the claim it quotes.

The existing pin is **untouched**. Its own comment says why it exists — to stop the fiction being authored back into a snippet a reader copies — and that is a different, legitimate job. This adds the other half so that presence and truth are two assertions, neither pretending to do the other's work.

## The trap, and why the assertion is written the long way

A substring match on `ValidationRule` matches **106 lines** on today's tree, every one of them a real and *different* type:

| Spelling | Declared at |
| --- | --- |
| `AdvancedValidationRule` | `packages/types/src/data-protocol.ts:708` |
| `ValidationRuleType` | `packages/types/src/data-protocol.ts:748` |
| `ObjectValidationRule` | `packages/types/src/data-protocol.ts:1129` |
| `DesignerValidationRule` | `packages/types/src/designer.ts:762` |
| `FieldValidationRules` | `packages/types/src/form.ts:744` |

Plus four the card had not listed: `ValidationRuleSchema`, `ValidationRuleDraft`, `BaseValidationRuleShape`, `buildValidationRules`.

A naive assertion reds on a **true** claim, and the next person to hit that deletes it — putting the claim back where it started. So `bareValidationRuleSites()` matches a **declaration of the exact name** (`interface` / `class` / `enum` / `type`) or a **re-export that publishes it**, and every spelling above is fixtured as a negative control beside the positives, rather than remembered in a comment.

Comments and string/template/regex literal content are blanked with the repo's own `scripts/js-comment-mask.mjs` before matching. That is load-bearing twice over: it keeps prose from fabricating a finding, and it is what lets the scan read **its own fixture table** without reding on it.

## Scanned population, stated

`git ls-files` filtered to the `.ts` family (`.ts`, `.tsx`, `.mts`, `.cts`, `.d.ts` included) — **3,603 files** on this tree. Derived, not listed: `node_modules`, `dist` and every other build output are untracked and so are out by construction, and a TypeScript type cannot be declared outside that family. `scripts/check-control-bytes.mjs` reads this repository the same way. The scan refuses to collapse quietly: a population under 1,000 files fails rather than passing vacuously.

Fidelity of the mask was measured rather than assumed: over those 3,603 files, blanking literal content loses 16 of 2,324 top-level exported declarations, in exactly two files — `packages/sdui-parser/src/codegen.ts`, which *emits* a declaration from a template, and `check-spec-symbol-derivation.test.ts`, whose fixtures are template literals. Both are the direction to lose them in.

## The prose overclaimed, so it was narrowed

The sentence carried a rider — *"under any spelling"* — which the assertion cannot check and which is **measurably false**: five near-spellings do exist. Leaving it would reproduce this card's own defect, a gate asserting less than the prose while looking like it covers it. The page now names the near-spellings and says none of them types the key; the pinned clause itself is unchanged, so the presence pin needed no edit.

(The card cited the sentence at `plugin-form.mdx:99`; PR #6185 moved it to line 102. Branched from `b04646b63` and re-read.)

## Verification

Reverse verification, each direction predicted **before** running, mutation proven on disk by anchored counts (not an editor exit code), restored with `git checkout HEAD -- path` and proven with an empty `git diff HEAD`. No build leg: the subject is read off disk with `fs.readFileSync`, never resolved through a package `exports` into `dist/`.

1. **Positive control** — appended `export interface ValidationRule` to `packages/types/src/form.ts` (anchored count 0 to 1). Predicted red, naming it. Observed: `1 failed | 35 passed`, message `packages/types/src/form.ts:1403: declares interface ValidationRule`.
2. **Negative controls** — the five near-spellings confirmed present by anchored count, plus three more injected (`SuperValidationRule`, `ValidationRuleName`, `ValidationRuleRunner`, and an aliasing re-export). Predicted green. Observed: `36 passed`, exit 0.
3. **The existing pin was not traded away** — removed the sentence from the page (anchored count 1 to 0). Predicted: the presence pin reds, the new tree scan stays green. Observed exactly that: `1 failed | 35 passed`, the failure being `no longer authors ValidationRule, and says outright that it does not exist`.

Gate union re-run at `4188af3f9` on a clean tree, gate list derived from `package.json` and `.github/workflows/` rather than from the dispatch:

| Gate | Exit | Its own verdict line |
| --- | --- | --- |
| root `vitest run scripts/__tests__/` | 0 | `Test Files 71 passed (71) / Tests 1935 passed (1935)` |
| `pnpm check:doc-types` | 0 | `Every documented component type is registered.` |
| `pnpm check:doc-fences` | 0 | `every TypeScript block in 223 document(s) is fenced ts/tsx/typescript…` |
| `pnpm check:control-bytes` | 0 | `OK (scanned 5110 tracked text file(s); skipped 85 binary).` |
| `pnpm docs:check-links` | 0 | `Links are valid across 15 scan roots.` |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source of a released package changed in this range, so no changeset is owed.` |
| `pnpm type-check:scripts` | 0 | clean `tsc -p tsconfig.scripts.json` |
| `pnpm lint:root` | 0 | `28 problems (0 errors, 28 warnings)` — all pre-existing, none in the changed files |

Every exit code captured by redirect **before** any pipe.

**No changeset**, per the presence gate's own verdict quoted above — objectui has no `skip-changeset` label mechanism, so that verdict is the declaration form.

**Declared narrowing:** `pnpm check:doc-snippets` exits 1 in this worktree with `The snippet program was NOT run: the packages it resolves against are not built` — an unbuilt-`dist/` precondition listing 20 packages, independent of this diff, which changes no fenced snippet (prose only). CI builds and runs it.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_