### PR TITLE
fix(plugin-form): decline to fetch a line-items child schema with no childObject

### DIFF
--- a/.changeset/6188-line-items-child-object-decline.md
+++ b/.changeset/6188-line-items-child-object-decline.md
@@ -1,0 +1,20 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+`record:line_items` declines to fetch the child schema of a panel whose child object it never resolved, instead of calling `getObjectSchema(undefined)`.
+
+`childObject` is declared `required: true` on the block's registry entry and typed `string` on
+`LineItemsPanelSchema`, but nothing enforces either — `inputs[].required` is designer metadata, and
+the block has no spec schema — so a node reaches the renderer straight off an authored schema with
+the key `undefined`, and the child-schema effect asked the data layer for it anyway. Measured:
+mounting the block through the registry with `childObject` unset issued
+`getObjectSchema(undefined)`, and a real backend receives a query for an object literally named
+`undefined`. The effect's `.catch` then turned the answer into a null child schema, so the visible
+outcome was a silently unsanitized child grid rather than an error.
+
+The effect now declines and warns, naming the key and what to set it to, and clears the cached child
+schema so a later save is never sanitized against a previous object's fields. This is the choice
+`RelatedList` already makes for the same class of missing key (*"has no referenceField/parentId —
+refusing to fetch all rows"*), and the one `object-master-detail-form` makes on this exact key. A
+panel that names its child object fetches exactly as before.

--- a/packages/plugin-form/src/LineItemsPanel.childObjectDecline.test.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.childObjectDecline.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `record:line_items` must DECLINE TO FETCH the child schema of a panel whose
+ * child object it never resolved — not call `getObjectSchema(undefined)`
+ * (objectui#6188).
+ *
+ * Same defect, same key name and same package as objectui#5940, which fixed the
+ * sibling site in `MasterDetailForm`. `childObject` is declared
+ * `required: true` on the registry entry for `record:line_items`
+ * (`index.tsx`) and is typed `string` on `LineItemsPanelSchema`, but NOTHING
+ * enforces either: `inputs[].required` is designer metadata (WidgetRegistry
+ * copies it onto the ComponentRegistry entry and no one parses a node against
+ * it), and the block has no spec schema at all — `@objectstack/spec` names
+ * `record:line_items` only as an example of a type authored in the wild outside
+ * its union. So a node reaches this renderer straight off an authored schema
+ * with the key `undefined`, and the effect asked the data layer for it anyway.
+ *
+ * ## Why the assertions read a CALL LIST
+ *
+ * The symptom here is quieter than #5940's: the effect's `.catch` turns
+ * whatever a real backend returns for an object literally named `undefined`
+ * into a NULL child schema, and a null child schema is exactly what the panel
+ * holds before any fetch resolves. So "it did not crash" and "the schema is
+ * null" were both TRUE while the defect was live — no assertion on resulting
+ * state could have caught it. Only the calls themselves distinguish the two
+ * worlds.
+ *
+ * ## Why the second test is not redundant
+ *
+ * A "fix" that declined to fetch EVERYTHING would also make the bad call
+ * disappear and would pass an absence-only assertion. Both directions are
+ * therefore pinned: the unresolved panel does NOT fetch its child schema, and a
+ * well-formed one still DOES.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// Registers `record:line_items`.
+import './index';
+
+const COLUMNS = [{ name: 'qty', label: 'Qty', type: 'number' as const }];
+
+/**
+ * The recording data source, the same shape objectui#5940's test used: a Proxy,
+ * so ANY method the block reaches for is recorded rather than crashing it.
+ *
+ * Each call is recorded as `method(firstArgument)` — the OBJECT NAME argument,
+ * which is the whole subject here, and `undefined` is spelled out rather than
+ * collapsing to an empty argument. Deliberately NOT the full argument list: the
+ * child fetch also carries `$filter` / `$top`, and pinning those would make this
+ * file fail for changes that have nothing to do with the object name.
+ */
+function recordingDataSource(calls: string[]) {
+  const record =
+    (key: string) =>
+    (...args: unknown[]) => {
+      calls.push(`${key}(${args.length === 0 ? '' : (JSON.stringify(args[0]) ?? 'undefined')})`);
+      return /^on[A-Z]/.test(key) || key === 'subscribe' ? () => {} : Promise.resolve({ data: [] });
+    };
+  const seeded: Record<string, unknown> = {};
+  for (const m of ['find', 'findOne', 'create', 'update', 'delete', 'aggregate', 'getObjectSchema']) {
+    seeded[m] = record(m);
+  }
+  return new Proxy(seeded, {
+    get: (t, k: string) => (k in t ? (t as any)[k] : record(k)),
+  }) as any;
+}
+
+async function callsFor(schemaExtra: Record<string, unknown>): Promise<string[]> {
+  const calls: string[] = [];
+  const schema: any = {
+    type: 'record:line_items',
+    relationshipField: 'invoice',
+    // Authored directly, as `LineItemsPanel.elementDataSource.test.tsx` does:
+    // this panel is bound to an EXISTING parent record, so a fixture without one
+    // would settle the question for a panel no author ships.
+    parentId: 'inv-1',
+    columns: COLUMNS,
+    ...schemaExtra,
+  };
+  const view = render(
+    <SchemaRendererProvider dataSource={recordingDataSource(calls)}>
+      <SchemaRenderer schema={schema} />
+    </SchemaRendererProvider>,
+  );
+  // Settle: both reads run in effects, and the row load runs a second pass once
+  // the first response lands.
+  for (let i = 0; i < 10; i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+  }
+  try {
+    view.unmount();
+  } catch {
+    /* teardown is not the subject */
+  }
+  return calls;
+}
+
+describe('record:line_items — a panel with no childObject (objectui#6188)', () => {
+  it('declines to fetch the child schema instead of calling getObjectSchema(undefined)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const calls = await callsFor({});
+
+    // The FULL LIST, not `.not.toContain(...)`: an absence-only assertion would
+    // also pass for a panel that stopped fetching altogether, and the list is
+    // what makes the remaining entry visible instead of implied.
+    //
+    // ⚠️ `find(undefined)` IS STILL HERE AND IS STILL WRONG. It is the SIBLING
+    // site in this same component — `load()` guards `dataSource` and `parentId`
+    // but not `schema.childObject`, so the row fetch still queries an object
+    // literally named `undefined`. It is deliberately NOT fixed by objectui#6188,
+    // whose dispatch order scoped this card to the `getObjectSchema` call and
+    // said to FILE any further unguarded sub-key site rather than fix it; filed
+    // as objectui#6194. Pinned here rather than hidden behind a narrower fixture
+    // so the hole is recorded where the next reader will see it. When #6194
+    // lands, this expectation becomes `toEqual([])` and the line below it goes.
+    expect(calls).toEqual(['find(undefined)']);
+
+    // Stated separately so a failure names which half broke.
+    expect(calls).not.toContain('getObjectSchema(undefined)');
+
+    // Declining silently would leave an author with a grid that is quietly
+    // unsanitized and no reason why; `RelatedList` warns for the same class of
+    // missing key ("has no referenceField/parentId — refusing to fetch all
+    // rows"), and the warning names the key and what to set it to rather than
+    // reporting that something was undefined.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('childObject'));
+    warn.mockRestore();
+  });
+
+  it('still fetches the child schema of a panel that names its child object', async () => {
+    // ⭐ The other direction. Without this, a panel that declined to fetch
+    // EVERYTHING would pass the test above.
+    const calls = await callsFor({ childObject: 'invoice_line' });
+
+    expect(calls).toEqual(['getObjectSchema("invoice_line")', 'find("invoice_line")']);
+    expect(calls).not.toContain('getObjectSchema(undefined)');
+  });
+});

--- a/packages/plugin-form/src/LineItemsPanel.tsx
+++ b/packages/plugin-form/src/LineItemsPanel.tsx
@@ -111,6 +111,28 @@ export const LineItemsPanel: React.FC<{ schema: LineItemsPanelSchema }> = ({ sch
   useEffect(() => {
     const ds: any = dataSource;
     if (!ds || typeof ds.getObjectSchema !== 'function') return;
+    // Decline to fetch when the child object never resolved (objectui#6188).
+    // `childObject` is declared `required: true` on this block's registry entry
+    // and typed `string` above, but nothing enforces either — `inputs[].required`
+    // is designer metadata, and the block has no spec schema — so a node reaches
+    // this renderer straight off an authored schema with the key `undefined`, and
+    // the fetch below then asked the data layer for an object literally named
+    // `undefined`. `RelatedList` already takes the other choice for the same class
+    // of missing key ("has no referenceField/parentId — refusing to fetch all
+    // rows", RelatedList.tsx), and `MasterDetailForm` declines on this exact key
+    // (objectui#5940) with its child-schema cache spelling it `.filter(Boolean)`.
+    //
+    // Clearing the cache rather than just returning: an unresolvable panel HAS no
+    // child schema, and leaving a previous object's schema in place would sanitize
+    // the next save against the wrong object's fields. `null` is what the `.catch`
+    // below already produces, so the sanitize path needs no new case.
+    if (!schema.childObject) {
+      setChildSchema(null);
+      console.warn(
+        `[LineItemsPanel] a line-items panel has no childObject — refusing to fetch its child schema. Set childObject to the child object the panel lists.`,
+      );
+      return;
+    }
     let cancelled = false;
     ds.getObjectSchema(schema.childObject)
       .then((s: any) => { if (!cancelled) setChildSchema(s ?? null); })


### PR DESCRIPTION
Fixes #6188

## The measurement this card was for, first

The card explicitly did not verify reachability. Both halves are now measured, and the answer is the **stronger** reading, not the weaker one:

**Is `childObject` declared a required input for `record:line_items`?** Yes — `packages/plugin-form/src/index.tsx:404`, `{ name: 'childObject', type: 'string', label: 'Child Object', required: true }`.

**Is that declaration enforced anywhere?** No. `inputs[].required` is designer metadata: `WidgetRegistry.ts:180` copies it onto the `ComponentRegistry` entry and nothing parses an authored node against it. Grepped for every consumer of `.required` under `packages/core/src` — the hits are field-level rules (`evaluator/fieldRules.ts`), the record-level validators, and the schema builder; none of them sees a block's declared inputs.

**Does the spec's `RecordLineItemsProps` make it required?** There is no `RecordLineItemsProps`. Grep over `@objectstack/spec@17.2.0` (`src` and `dist`) and over this whole repo returns zero hits. The spec names this block exactly once, as an example of the opposite: *"`type` is an open union (unregistered types like `record:line_items` are authored in the wild)"* (`src/ui/component.zod.ts:105`). So the block has no spec schema at all, and the registry's `required: true` is the only place the requirement is written down.

**Does a bare mount reproduce the call?** Yes — through the registered authoring surface, not only through direct component use. `packages/plugin-form/src/LineItemsPanel.childObjectDecline.test.tsx` renders a plain authored node through `SchemaRenderer` (so it goes through `ComponentRegistry` and the `ElementDataSourceGate` wrapper, the real path), with `childObject` simply absent. Recorded calls, by first argument, against unmodified `origin/main` @ `b04646b`:

```
['getObjectSchema(undefined)', 'find(undefined)']
```

**So the severity claim stands at its stronger reading**: an author who omits `childObject` triggers this. Nothing between the authored JSON and the effect rejects the node — the key is declared required in a place that only a designer UI reads.

## The fix

`LineItemsPanel`'s child-schema effect guarded the *data source* (`ds`, and that `getObjectSchema` is callable) but never the *argument*. It now declines and warns.

Following PR #6191 (card #5940), which landed the same decision on the same key in this package, with both of its deliberate choices checked against this component rather than copied:

1. **#6191 returns the entry rather than dropping it, because the surrounding array is index-matched against row state.** That coupling does **not** exist here — there is no array. `LineItemsPanel` is one panel with one `childSchema` state, so the analogous question is what that state should hold when the fetch is declined, and the answer is `null`: an unresolvable panel *has* no child schema, and leaving a previous object's schema cached would sanitize a later save against the wrong object's fields. `null` is also what the effect's own `.catch` already produces, so the sanitize path needs no new case.
2. **The warning names the key and says what to set it to** — *"a line-items panel has no childObject — refusing to fetch its child schema. Set childObject to the child object the panel lists."* — rather than reporting that something was undefined.

The precedent it joins: `RelatedList` declines when it cannot scope (*"has no referenceField/parentId — refusing to fetch all rows"*, `RelatedList.tsx:498`), `MasterDetailForm`'s child-schema cache has always spelled it `.filter(Boolean)`, and after #6191 its detail-resolve effect declines on this exact key.

## Why the test asserts the call list

The symptom here is quieter than #5940's, and that shaped the test. The `.catch` turns whatever a real backend returns for an object named `undefined` into a **null child schema** — and a null child schema is exactly what the panel holds before any fetch resolves. So *"it did not crash"* and *"the schema is null"* were both **true while the defect was live**. No assertion on resulting state could have caught this. Only the calls distinguish the two worlds.

Both directions are pinned, because a guard that declined **everything** would also make the bad call vanish and would pass an absence-only assertion:

| fixture | recorded calls (by first argument) |
|---|---|
| `childObject` unset — before | `['getObjectSchema(undefined)', 'find(undefined)']` |
| `childObject` unset — after | `['find(undefined)']` (see below) |
| `childObject: 'invoice_line'` — after | `['getObjectSchema("invoice_line")', 'find("invoice_line")']` |

The recorder deliberately captures `method(firstArgument)` rather than the full argument list: the child fetch also carries `$filter` / `$top`, and pinning those would make the file fail for changes that have nothing to do with the object name.

## The entry still in that list — a further site, filed not fixed

`find(undefined)` is the **sibling site in this same component**: `load()` guards `dataSource` and `parentId` but not `schema.childObject`, so the row fetch still queries an object literally named `undefined`. It is out of this card's scope by dispatch order, which scoped this to the `getObjectSchema` call and said to file any further unguarded sub-key site. Filed as #6194, which stays open — it is not addressed here.

It is pinned in the test as *current* behaviour, with a comment pointing at #6194 and saying what to change the line to, rather than hidden behind a narrower fixture that omits `parentId`. Hiding it would have made this PR's test read as if the component were clean.

That card is not a one-line rider, which is the other reason it is separate: declining a *schema* fetch has no visible consequence, but declining the *row* fetch does — `load` owns `loading`, and the render branches `loading ? … : !parentId ? … : grid`, so an unresolvable panel with a parent id bound would land on the grid branch and show an empty editable grid over an object that does not exist. Whether that wants its own config-hint branch is a question, not a mechanical fix.

## Lint note

The new `setChildSchema(null)` raises one `react-hooks/set-state-in-effect` **warning**. It is the same warning the effect below it already carries (`void load()`, line 203), the rule is configured `'warn'` repo-wide (`eslint.config.js:95`), and `lint.yml` deliberately does not set `--max-warnings` (*"warnings repo-wide run into the…"*, line 20). Package lint is **0 errors**.

## Verification — all at `fd7525d9b`, the commit this PR ships

Exit codes captured by redirect before any pipe. Heavy runs went through the shared verify lock.

| gate | command | result |
|---|---|---|
| targeted test, BEFORE the guard | `pnpm exec vitest run packages/plugin-form/src/LineItemsPanel.childObjectDecline.test.tsx` | `Tests 1 failed \| 1 passed (2)` — reproduced, exactly as predicted |
| tests | `pnpm exec vitest run packages/plugin-form/ apps/console/src/__tests__/record-block-record-reach.test.tsx apps/console/src/__tests__/public-block-binding-reach.test.tsx apps/console/src/__tests__/public-contract.test.ts` | `Test Files 64 passed (64)` / `Tests 655 passed (655)` |
| type-check | `pnpm exec turbo run type-check --filter=@object-ui/plugin-form --concurrency=2` | `Tasks: 13 successful, 13 total` (includes the dependency build and `tsconfig.test.json`) |
| lint | `eslint .` in `packages/plugin-form` | `641 problems (0 errors, 641 warnings)` |
| control bytes | `node scripts/check-control-bytes.mjs` | `OK (scanned 5112 tracked text file(s))` |
| changeset | `pnpm run changeset:check` | both checks OK |

**How the gate scope was derived** — from each workflow's own configuration, not assumed. `ci.yml` and `lint.yml` carry `paths-ignore` for `**/*.md` / `content` / `docs` / `.changeset` only, so a `packages/**` diff runs both in full; `control-bytes.yml` and `changeset-presence.yml` deliberately carry no path filter at all; `changeset-guard.yml` filters to `.changeset/**`, which this PR touches. `performance-budget.yml` (Bundle Analysis) filters on `packages/**` and so applies — it is a full turbo build plus a console build, a repo-level run CI owns; not reproduced locally.

**Why the lint narrowing is a measurement, not an omission**: the universe comes from eslint's own resolution (`eslint .` from the package directory, which is what `turbo run lint` invokes for this package — `packages/plugin-form/package.json` `"lint": "eslint ."`), and the root `eslint.config.js` declares no `project` / `projectService`, so type-aware linting is off and this diff cannot move the verdict on any file it does not touch. Files outside `packages/plugin-form` are therefore invariant under this change.

Docs are untouched, matching #6191: this is a guard on an existing read path, not a change to the authorable surface any document describes.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_