### PR TITLE
chore(runner): drop the unused "@app" vite alias and empty its ratchet

### DIFF
--- a/packages/runner/vite.config.ts
+++ b/packages/runner/vite.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
       "@/hooks": path.resolve(__dirname, "../../packages/components/src/hooks"),
       
       "@": path.resolve(__dirname, "./src"),
-      // ⚡️ DX: App Data Symlink
-      "@app": path.resolve(__dirname, "./src/app-data"),
 
       // ⚡️ DX: Map imports to source code for Hot Module Replacement
       //

--- a/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
+++ b/scripts/__tests__/vitest-config-alias-targets-3944.test.ts
@@ -788,32 +788,39 @@ function packageAliasTargetExists(abs: string): boolean {
 }
 
 /**
- * objectui#5380 — one entry whose target does not exist and which this PR
- * deliberately does NOT delete, for the same reason objectui#4820 was carved
- * out of the `paths` half rather than fixed in it.
+ * objectui#5380 — RESOLVED, and this ratchet is empty as a result.
  *
- * `packages/runner`'s `"@app"` points at `packages/runner/src/app-data`, which
- * is absent in every form (no directory, no `app-data.<ext>`). Its comment reads
- * `DX: App Data Symlink`, and nothing in the repo imports `@app` — the
- * declaration is the only occurrence. So the fix is either "drop the line" or
- * "restore the symlink this DX affordance was written for", and which one is a
- * maintainer call, not a rider on a gate that is only supposed to start looking.
- * Filed as objectui#5380; this file's job here is to stop it being invisible.
+ * It briefly carved out `packages/runner`'s `"@app"`, which pointed at
+ * `packages/runner/src/app-data`. #5380 ruled direction A′: delete the alias
+ * line, on the measured ground that it had **zero importers** and that the
+ * documented App Data Symlink DX does not route through it —
+ * `packages/runner/src/lib/MetadataLoader.ts`'s `LocalBundleLoader` reads that
+ * directory through relative `import.meta.glob('../app-data/…')`, never through
+ * the alias. Deleting the line changed no behaviour.
  *
- * Note it is NOT an `@object-ui/*` key. The finding that opened objectui#5168
- * counted 196 `@object-ui/*` entries, and a gate scoped to that prefix would
- * have shipped green over this. That is the second time this exact config has
- * outlived a target: its own comment records objectui#3593, where a
- * `2>/dev/null` kept a dead `data-objectql` entry quiet.
+ * ⚠️ Read the ground carefully before carving out anything that looks like
+ * this again: `src/app-data/` is NOT a dead target. It is git-ignored
+ * (`packages/runner/.gitignore:1`) and **user-supplied** — the reader creates it
+ * by following `packages/runner/README.md` or `content/docs/utilities/runner.mdx`,
+ * and it is absent from a fresh checkout **by design**. What was dead was the
+ * unused alias, not the thing it named. An existence check reads a
+ * user-supplied directory as missing on CI and present on the machine of anyone
+ * who followed the docs; that checkout-state dependence is objectui#5968's
+ * subject, and this ratchet reaching empty is what removed its only instance
+ * here — not a fix for the class.
  *
- * A shrink-only ratchet, not an exemption. The list may not grow — a NEW dead
- * target is still red — and the pin below asserts the listed entry is still
- * declared AND still missing, so resolving it either way turns this file red
- * until the list is emptied with it.
+ * Note the entry was NOT an `@object-ui/*` key. The finding that opened
+ * objectui#5168 counted 196 `@object-ui/*` entries, and a gate scoped to that
+ * prefix would have shipped green over it. That is why this half takes its
+ * scope from EVERY entry in every table, and why narrowing it to a prefix would
+ * silently shrink the surface.
+ *
+ * A shrink-only ratchet, not an exemption: it may not grow. Empty is its
+ * terminal state — every package alias entry is now guarded with no exemptions,
+ * and the pin below keeps it that way. A NEW dead target is meant to go red in
+ * the existence check above, not to be carved out.
  */
-const KNOWN_MISSING_PACKAGE_ALIAS_TARGETS: readonly { config: string; specifier: string }[] = [
-  { config: 'packages/runner/vite.config.ts', specifier: '@app' },
-];
+const KNOWN_MISSING_PACKAGE_ALIAS_TARGETS: readonly { config: string; specifier: string }[] = [];
 
 const isCarvedOut = (entry: PackageAliasEntry): boolean =>
   KNOWN_MISSING_PACKAGE_ALIAS_TARGETS.some(
@@ -884,7 +891,25 @@ describe('objectui#5168 — package-level vite.config.ts alias tables', () => {
     }
   );
 
-  it('the objectui#5168 carve-out still describes exactly the entries it was written for', () => {
+  it('the objectui#5168 carve-out is empty, so no package alias entry is exempt', () => {
+    // objectui#5380 was resolved by deleting the one carved-out line, so this
+    // list is empty and the existence check above now covers every entry.
+    //
+    // ⚠️ Asserted rather than left implicit. With an empty list BOTH
+    // expectations below are vacuous — each filters an empty list (or filters
+    // by `isCarvedOut`, which is false for everything) and compares [] with [],
+    // so neither can fail for ANY repo state. A silently vacuous pin is the
+    // exact trap the `toBeGreaterThanOrEqual` cases at the top of this block
+    // guard against, so the expectation that still bites at zero has to be
+    // written down: emptiness itself. This one goes red the moment the list is
+    // re-populated, which is the only way the two below become meaningful again.
+    expect(
+      KNOWN_MISSING_PACKAGE_ALIAS_TARGETS,
+      'KNOWN_MISSING_PACKAGE_ALIAS_TARGETS is a shrink-only ratchet that reached empty when ' +
+        'objectui#5380 landed. Re-populating it needs a card of its own — a new dead alias ' +
+        'target is meant to go red in the existence check above, not to be carved out.'
+    ).toEqual([]);
+
     const declared = KNOWN_MISSING_PACKAGE_ALIAS_TARGETS.filter((known) =>
       packageAliasEntries.some((e) => e.config === known.config && e.specifier === known.specifier)
     );


### PR DESCRIPTION
Fixes #5380

Implements triage's **A′** re-ruling. All gates below were run on `bbcc46e7a`, the branch head.

## What changed, and on what ground

`packages/runner/vite.config.ts` declared `"@app"` pointing at `./src/app-data`. Two lines gone (the alias and its `DX: App Data Symlink` comment), on the narrower ground the re-ruling measured:

- **Zero importers.** A repo-wide sweep for `@app` returns three hits: the declaration itself, and two prose lines in the ratchet file describing the carve-out. Nothing imports `@app` or any subpath of it.
- **The documented DX does not route through the alias.** `LocalBundleLoader` in `packages/runner/src/lib/MetadataLoader.ts` reads the directory through relative `import.meta.glob('../app-data/app.json')` and siblings. `packages/runner/README.md` and `content/docs/utilities/runner.mdx` teach `src/app-data/` as a path; neither mentions the alias.

So deleting the line changes no behaviour and breaks no documented workflow. Verified rather than assumed: `pnpm exec vite build` in `packages/runner` after the deletion — 4459 modules transformed, `built in 5.49s`, exit 0.

### What is explicitly NOT the ground

`src/app-data/` is **not** a dead target. It is git-ignored (`packages/runner/.gitignore:1`) and **user-supplied** — absent from a fresh checkout **by design**, and created by any reader who follows the Development Workflow the README documents. The dead thing was the unused alias, not the directory it named. This distinction is the whole history of the card and the reason the earlier reasoning was retired; the code comment now carries it so the next reader cannot re-derive the wrong version.

## The same-PR obligation, and what an empty list does to the pins

#5168's shrink-only pin asserts each carved-out entry is *still declared and still missing*, so deleting the alias without touching the carve-out reddens it. Measured, not assumed — the intermediate state was run:

```
× the objectui#5168 carve-out still describes exactly the entries it was written for
  Tests  1 failed | 288 passed (289)
```

That entry was the list's only member, so removing it **empties** the ratchet. Every consumer of `KNOWN_MISSING_PACKAGE_ALIAS_TARGETS` was read:

| consumer | behaviour at zero |
|:--|:--|
| `isCarvedOut`, filtering the per-entry existence `it.each` | **stronger** — nothing is filtered out, so every package alias entry is now guarded with no exemptions |
| pin: `declared` compared with the list | **silently vacuous** — filters an empty list, compares `[]` with `[]`, cannot fail for any repo state |
| pin: `nowResolving` (entries that are carved out *and* now resolve) | **silently vacuous** — `isCarvedOut` is false for everything, so this is `[]` unconditionally |

Both of the pin's expectations become unfailable. Shipping that would be exactly the trap this file guards against elsewhere — the `toBeGreaterThanOrEqual` cases at the top of the same block exist because *"a zero-hit parse would make every case below vacuous"*.

**Fix, matching the shape #4820 already left on `KNOWN_MISSING_TARGETS` in this same file** (that ratchet reached empty in cb83cec1a / #5966): the pin now asserts **emptiness itself** first, which does bite at zero, and states in-line that the two expectations after it are knowingly vacuous rather than accidentally so. The list itself is **kept, not deleted** — deleting it would remove the subject of that assertion and unwire `isCarvedOut`, making a future re-population an ordinary edit instead of a visible one; empty is its terminal state, and re-populating it needs a card.

**The new assertion was ablated to prove it can fail.** Re-populating the list with one probe entry, with the mutation confirmed on disk before the run (injected marker present 1, empty-list declaration present 0):

```
× the objectui#5168 carve-out is empty, so no package alias entry is exempt
AssertionError: KNOWN_MISSING_PACKAGE_ALIAS_TARGETS is a shrink-only ratchet that reached
empty when objectui#5380 landed. ...: expected [ { …(2) } ] to deeply equal []
  Tests  1 failed | 288 passed (289)
```

The restore leg ran from a trap and was confirmed on disk by absent-marker (probe present 0, empty-list declaration present 1) with `git status` clean.

## Gates

Derived from `package.json` and `.github/workflows/`, not from the dispatch order. Root vitest only, exit codes captured by redirect before any pipe.

| gate | result |
|:--|:--|
| `vitest run` on both affected test files + `packages/runner/` | exit 0 — `Test Files 5 passed (5)`, `Tests 332 passed (332)` |
| `pnpm lint:root` (covers `scripts/`) | exit 0 — `28 problems (0 errors, 28 warnings)`, all pre-existing `no-explicit-any` in untouched files |
| `eslint .` in `packages/runner` | exit 0 — `20 problems (0 errors, 20 warnings)`, same |
| `pnpm type-check:scripts` | exit 0 — and `--listFiles` confirms the edited test file is in that program, so the green is not vacuous |
| `pnpm type-check` in `packages/runner` | exit 0 **after** building the dependency closure (see note) |
| `pnpm exec vite build` in `packages/runner` | exit 0 — 4459 modules, `built in 5.49s` |
| `pnpm check:control-bytes` | exit 0 — `OK (scanned 5113 tracked text file(s))` |
| `pnpm changeset:check` | exit 0 |
| `node scripts/check-changeset-presence.mjs` | exit 0 — see below |

**Note on the runner type-check.** It first failed with `TS2307: Cannot find module '@object-ui/types'` and implicit-`any` fallout — the unbuilt-dependency-`dist` trap in a fresh worktree, not this diff. Attribution was established before rerunning: `tsc --listFiles` shows `packages/runner/vite.config.ts` is **not in that program at all** (`tsconfig.json` includes only `src`), and every erroring file is one this PR never touches. After `turbo run build --filter=@object-ui/runner^...` (14 tasks successful) the same command exits 0.

**No changeset.** The presence gate reports it directly: *"2 file(s) changed, 0 of them published source of a package the release covers ... No source of a released package changed in this range, so no changeset is owed."* A build config and a pin test are not published source; nothing user-visible ships here.

## Shared-surface coordination

#4820's `KNOWN_MISSING_TARGETS` lives in the same file. **It is not in flight — it already landed** as cb83cec1a (#5966), and its list is already `[]` on `main`. This PR does not touch it: `git diff BASE..HEAD | grep -c KNOWN_MISSING_TARGETS` returns 0. A scan of the 40 most recently active remote branches for commits touching either of my two files since their merge-base with `main` returned nothing, so there is no union to declare.

#5968 (the `fs.existsSync` checkout-state dependence class) is untouched and stays its own card. Emptying this ratchet removes the only entry that exhibited that shape, but the class is #5968's subject, not this PR's — and the code comment says so, so nobody reads the empty list as a fix for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_