### PR TITLE
test(layout,scripts): read the registered component keys through one shared reader

### DIFF
--- a/.changeset/4894-shared-registration-key-reader.md
+++ b/.changeset/4894-shared-registration-key-reader.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-and-tooling change only; no published behaviour changes. The four pins that read
+"which component keys does `packages/layout/src/index.ts` register?" now share one reader
+(`scripts/component-registrations.mjs`) instead of four copies of a regex that accepted a
+single-quoted key and nothing else — a double-quoted registration was legal, lint-clean
+and invisible to all four at once (objectui#4894).

--- a/packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx
+++ b/packages/layout/src/__tests__/app-shell-not-a-component-key.test.tsx
@@ -66,6 +66,12 @@ import { join, resolve } from 'node:path';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer } from '@object-ui/react';
 
+// The shared registration reader (objectui#4894). Plain JS, and this package's
+// test program sets `allowJs: false`, so the import is untyped here — the local
+// annotation below is what keeps the call site checked.
+// @ts-expect-error — plain-JS shared helper, intentionally untyped
+import { readComponentRegistrations } from '../../../../scripts/component-registrations.mjs';
+
 import { registerLayout, AppShell } from '../index';
 
 /** Repo root — four levels up from `packages/layout/src/__tests__`. */
@@ -75,11 +81,17 @@ const LAYOUT_INDEX_SRC = readFileSync(
   'utf8',
 );
 
-/** Component keys `registerLayout()` registers, read out of the source. */
+/**
+ * Component keys `registerLayout()` registers, read out of the source.
+ *
+ * `scripts/component-registrations.mjs` (objectui#4894) — the one reader the
+ * four pins on this key list share. This file's source-side assertion is the
+ * least urgent of the four, because the live-registry assertion below catches a
+ * re-registration this read misses; it is wired to the shared reader anyway, so
+ * the two faces are not read by two different definitions of "registered".
+ */
 const registeredKeys = (): string[] =>
-  [...LAYOUT_INDEX_SRC.matchAll(/ComponentRegistry\.register\(\s*'([^']+)'/g)].map(
-    (match) => match[1],
-  );
+  readComponentRegistrations(LAYOUT_INDEX_SRC, 'packages/layout/src/index.ts').keys;
 
 beforeAll(() => {
   // The barrel registers on evaluation, but say so explicitly: this file's

--- a/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
+++ b/packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts
@@ -90,6 +90,12 @@ import { join, resolve } from 'node:path';
 import { BarChart3, DollarSign, Home, LayoutDashboard, Settings, Users } from 'lucide-react';
 import type { NavGroup, NavItem, SidebarNavProps } from '../SidebarNav';
 
+// The shared registration reader (objectui#4894). Plain JS, and this package's
+// test program sets `allowJs: false`, so the import is untyped here — the local
+// annotation below is what keeps the call site checked.
+// @ts-expect-error — plain-JS shared helper, intentionally untyped
+import { readComponentRegistrations } from '../../../../scripts/component-registrations.mjs';
+
 /** Repo root — five levels up from `packages/layout/src/__tests__`. */
 const REPO_ROOT = resolve(__dirname, '../../../..');
 const GUIDE = readFileSync(join(REPO_ROOT, 'content', 'docs', 'guide', 'layout.md'), 'utf8');
@@ -324,11 +330,19 @@ function sidebarNavTagProps(body: string): string[] {
   return props;
 }
 
-/** Component keys `registerLayout()` registers, read out of the source. */
+/**
+ * Component keys `registerLayout()` registers, read out of the source.
+ *
+ * `scripts/component-registrations.mjs` (objectui#4894) — the one reader the
+ * four pins on this key list share. It replaced four copies of a regex that
+ * accepted a single-quoted key and nothing else, which is a real failure here
+ * and not a tidy one: this page LISTS the keys correctly, so a registration the
+ * read misses reds the assertion below with the message "the page names a key
+ * that is not registered" — sending the reader off to edit a page that was
+ * right.
+ */
 function registeredKeys(): string[] {
-  return [...LAYOUT_INDEX_SRC.matchAll(/ComponentRegistry\.register\(\s*'([^']+)'/g)].map(
-    (match) => match[1],
-  );
+  return readComponentRegistrations(LAYOUT_INDEX_SRC, 'packages/layout/src/index.ts').keys;
 }
 
 /**

--- a/packages/layout/src/__tests__/readme-registration-keys.test.ts
+++ b/packages/layout/src/__tests__/readme-registration-keys.test.ts
@@ -56,13 +56,14 @@
  * a red test here is always "fix the README (or the barrel)", never "update the
  * test".
  *
- * That parse has a dependency worth naming, because it is easy to break from the
- * other side: the source reader is a regex for `ComponentRegistry` + `.register(`,
- * so a register call QUOTED VERBATIM inside a comment in `src/index.ts` would be
- * collected as a live registration. `src/index.ts` describes the removed
- * `app-shell` call in prose for precisely this reason (objectui#4841 wrote that
- * note); this pin is a third beneficiary of that discipline, and anyone tempted
- * to paste a real call into a comment there breaks this file too.
+ * That parse is `scripts/component-registrations.mjs` (objectui#4894), the one
+ * reader all four pins on this list now share. It is comment- and literal-aware
+ * via `scripts/js-comment-mask.mjs`, so a register call quoted VERBATIM inside a
+ * comment in `src/index.ts` is prose, not a registration — the hazard this
+ * paragraph used to name. `src/index.ts` still describes the removed `app-shell`
+ * call in prose rather than quoting it (objectui#4841 wrote that note), and that
+ * note is still worth keeping: this reader is not the only thing that has ever
+ * read that file.
  *
  * ## Scan surface — deliberately narrow
  *
@@ -88,20 +89,44 @@
  *   - the `### SidebarNav` note that `SidebarNav` is not on the registry. Its
  *     surface is `readme-sidebar-nav-example.test.ts`.
  *
- * The reader below is this repo's fourth copy of the same three-line
- * `ComponentRegistry.register` regex (the others are in
- * `guide-layout-sidebar-nav-doc.test.ts`, `app-shell-not-a-component-key.test.tsx`
- * and `scripts/__tests__/side-effects-declaration-consistency.test.ts`).
- * Extracting a shared helper is raised as a
- * side option on objectui#4860 and is deliberately NOT taken here: it would edit
- * three pin files to serve one, and each of those files is self-contained on
- * purpose — a pin that imports its own reader from a shared module can be
- * silently neutered from outside the file it defends.
+ * ## The reader is shared now, and this paragraph used to say the opposite
+ *
+ * This file landed as the FOURTH copy of one three-line
+ * `ComponentRegistry.register` regex (the others: `guide-layout-sidebar-nav-doc.test.ts`,
+ * `app-shell-not-a-component-key.test.tsx` and
+ * `scripts/__tests__/side-effects-declaration-consistency.test.ts`), and it said
+ * so — extraction was raised as a side option on objectui#4860 and deliberately
+ * declined, because it would have edited three self-contained pin files to serve
+ * one, and a pin that imports its own reader can be neutered from outside the
+ * file it defends.
+ *
+ * That was right on the evidence then, and objectui#4894 changed the evidence.
+ * All four copies accepted ONE quote character, and nothing in this repo enforces
+ * a quote style — no `.prettierrc`, no `prettier` field, no `quotes` rule — so
+ * `ComponentRegistry.register("some-key", …)` was legal, lint-clean, CI-green and
+ * invisible to all four at once. The reason to extract stopped being tidiness and
+ * became correctness: widen in one place, four benefit. So the reader moved to
+ * `scripts/component-registrations.mjs`, and the objection above was answered
+ * rather than overruled — that module has its own pin
+ * (`scripts/__tests__/component-registrations.test.ts`) whose first case is that
+ * an empty read FAILS, because `[]` is exactly the value that would make all four
+ * of these set-difference assertions pass while defending nothing.
+ *
+ * What is NOT shared is what each pin ASSERTS. The four check four different
+ * things — guide table parity, `app-shell` absence, side-effect survival, and
+ * this file's README parity — and merging those is the coupling actually worth
+ * avoiding.
  */
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+
+// The shared registration reader (objectui#4894). Plain JS, and this package's
+// test program sets `allowJs: false`, so the import is untyped here — the local
+// annotation below is what keeps the call site checked.
+// @ts-expect-error — plain-JS shared helper, intentionally untyped
+import { readComponentRegistrations } from '../../../../scripts/component-registrations.mjs';
 
 /** `packages/layout` — two levels up from `src/__tests__`. */
 const PKG_DIR = resolve(__dirname, '../..');
@@ -124,9 +149,7 @@ const REGISTRATION_SENTENCE = /registers\s+its\s+component\s+keys\s*\(([^)]*)\)/
 
 /** Component keys `registerLayout()` registers, read out of the source. */
 function registeredKeys(): string[] {
-  return [...LAYOUT_INDEX_SRC.matchAll(/ComponentRegistry\.register\(\s*'([^']+)'/g)].map(
-    (match) => match[1],
-  );
+  return readComponentRegistrations(LAYOUT_INDEX_SRC, 'packages/layout/src/index.ts').keys;
 }
 
 /** Component keys the README's `## Registration` sentence names. */

--- a/scripts/__tests__/component-registrations.test.ts
+++ b/scripts/__tests__/component-registrations.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS shared helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
+// re-adding one is itself an error (TS2578). See objectui#3494.
+import {
+  findComponentRegistrations,
+  readComponentRegistrations,
+} from '../component-registrations.mjs';
+
+/**
+ * `scripts/component-registrations.mjs` is the shared reader four pins use to
+ * answer "which component keys does `packages/layout/src/index.ts` register?"
+ * (objectui#4894). This is its pin.
+ *
+ * ## Why this file has to exist before the extraction is allowed
+ *
+ * The four call sites — `guide-layout-sidebar-nav-doc.test.ts`,
+ * `app-shell-not-a-component-key.test.tsx`, `readme-registration-keys.test.ts`
+ * and `side-effects-declaration-consistency.test.ts` — are deliberately
+ * self-contained pins, and that independence is worth something: four guards
+ * that fail separately are more robust than four sharing a dependency. The
+ * extraction spends some of it, and this file is the exchange.
+ *
+ * The risk it buys down is specific and asymmetric. Every one of those four
+ * assertions is a set difference or an absence check, and ALL of them pass
+ * trivially on an empty key list. A shared reader that silently returned `[]`
+ * would therefore not break four pins — it would make four pins green for a
+ * reason unrelated to what they defend, which is strictly worse than the four
+ * copies of one narrow regex that objectui#4894 started from. So the
+ * non-vacuity cases below are the load-bearing half of this file, not a
+ * completeness gesture.
+ *
+ * ## The corpus is shapes, not this tree
+ *
+ * A green run over today's `packages/layout/src/index.ts` proves only that
+ * today's source has no double-quoted call in it. The fixtures below are the
+ * contract; the one case that reads the real file asserts only that the reader
+ * is still pointed at something real.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** A register call written with the quote character `quote`. */
+const call = (quote: string, key: string) =>
+  `ComponentRegistry.register(${quote}${key}${quote}, Thing, { namespace: 'layout' });`;
+
+describe('the reader accepts every quote character the language does (objectui#4894)', () => {
+  // The defect this module exists for. The four copies it replaced matched a
+  // single-quoted key and nothing else, while this repo enforces no quote style
+  // at all — no `.prettierrc`, no `prettier` field in package.json, no `quotes`
+  // rule in eslint.config.js. A double-quoted registration was therefore legal,
+  // lint-clean, CI-green and invisible to all four pins at once.
+  it.each([
+    ["single quotes", "'"],
+    ["double quotes", '"'],
+    ["backticks", '`'],
+  ])('reads a key written with %s', (_label, quote) => {
+    expect(findComponentRegistrations(call(quote, 'page-header')).keys).toEqual(['page-header']);
+  });
+
+  it('reads a file that mixes them, in source order', () => {
+    const source = [call("'", 'page-header'), call('"', 'page:card'), call('`', 'responsive-grid')].join(
+      '\n',
+    );
+    expect(findComponentRegistrations(source).keys).toEqual([
+      'page-header',
+      'page:card',
+      'responsive-grid',
+    ]);
+  });
+
+  it('and reads a call the formatter has wrapped or spaced out', () => {
+    const source = 'ComponentRegistry\n  .register(\n    "app-schema-renderer",\n    Thing,\n  );';
+    expect(findComponentRegistrations(source).keys).toEqual(['app-schema-renderer']);
+  });
+});
+
+describe('an empty read is a FAILURE, never an answer (objectui#4894)', () => {
+  // The whole reason the extraction needs its own pin: every call site asserts a
+  // set difference or an absence, so `[]` is the one return value that makes all
+  // four of them pass while defending nothing.
+  it('throws when the source registers nothing', () => {
+    expect(() => readComponentRegistrations('export const nothing = 1;\n', 'fixture.ts')).toThrow(
+      /No `ComponentRegistry\.register` call was found in fixture\.ts/,
+    );
+  });
+
+  it('throws when the only call is commented out — a ghost is not a registration', () => {
+    const source = `// ${call("'", 'app-shell')}\n`;
+    expect(() => readComponentRegistrations(source, 'fixture.ts')).toThrow(
+      /No `ComponentRegistry\.register` call was found/,
+    );
+  });
+
+  it('and says what to do about it, rather than only that it happened', () => {
+    let message = '';
+    try {
+      readComponentRegistrations('', 'packages/layout/src/index.ts');
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    // The message is read here because a reader that fails at the wrong volume
+    // gets "fixed" by re-pointing it at something that answers.
+    expect(message).toContain('packages/layout/src/index.ts');
+    expect(message).toContain('pass trivially on an empty list');
+    expect(message).toContain('scripts/component-registrations.mjs');
+  });
+});
+
+describe('a key the reader cannot READ is a refusal, not an omission (objectui#4894)', () => {
+  // Widening one quote character to three does not close the class the card is
+  // about; it closes one member of it. Any call whose key this reader cannot see
+  // drops out of all four pins in silence — the doc-parity pins then red saying
+  // the DOC names an unregistered key (pointing the reader at a correct page),
+  // and the side-effect pin goes green without asserting that key at all.
+  it.each([
+    ['a computed key', 'ComponentRegistry.register(KEY, Thing);'],
+    ['an interpolated template', 'ComponentRegistry.register(`page:${kind}`, Thing);'],
+    ['an unterminated literal', "ComponentRegistry.register('page-header, Thing);"],
+  ])('refuses to answer around %s', (_label, source) => {
+    const scan = findComponentRegistrations(source);
+    expect(scan.calls).toBe(1);
+    expect(scan.keys).toEqual([]);
+    expect(scan.unreadable).toHaveLength(1);
+    expect(() => readComponentRegistrations(source, 'fixture.ts')).toThrow(
+      /cannot read/,
+    );
+  });
+
+  it('names the line, so the refusal is actionable', () => {
+    const source = [call("'", 'page-header'), 'ComponentRegistry.register(KEY, Thing);'].join('\n');
+    let message = '';
+    try {
+      readComponentRegistrations(source, 'packages/layout/src/index.ts');
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('line 2');
+    expect(message).toContain('ComponentRegistry.register(KEY, Thing);');
+  });
+});
+
+describe('prose is not code (objectui#4894)', () => {
+  // `packages/layout/src/index.ts` carries a note saying its retired `app-shell`
+  // call is DESCRIBED rather than quoted, because a verbatim copy inside a
+  // comment read to the old regexes as a live registration. A reader that widens
+  // its quote set while keeping that blind spot trades one silent miss for one
+  // silent fabrication — and a fabricated key reds every doc-parity pin with a
+  // demand to document a component that does not exist.
+  it.each([
+    ['a line comment', `// ${call("'", 'line-ghost')}`],
+    ['a block comment', `/* ${call('"', 'block-ghost')} */`],
+    ['a docblock', `/**\n * ${call("'", 'doc-ghost')}\n */`],
+    ['a string literal', `const note = "see ${call("'", 'string-ghost')}";`],
+    ['a template literal', 'const note = `see ' + call('"', 'tpl-ghost') + '`;'],
+  ])('does not collect a registration mentioned in %s', (_label, ghost) => {
+    const source = [ghost, call("'", 'real-key')].join('\n');
+    const scan = findComponentRegistrations(source);
+    expect(scan.keys).toEqual(['real-key']);
+    expect(scan.calls).toBe(1);
+  });
+});
+
+describe('the reader is still pointed at the real barrel (objectui#4894)', () => {
+  // One case that touches this tree. It deliberately asserts no key NAMES — the
+  // four call sites own those, and a fifth opinion here would be the coupling
+  // the extraction was allowed on the condition of avoiding.
+  it('reads packages/layout/src/index.ts and finds every call it contains', () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, 'packages', 'layout', 'src', 'index.ts'),
+      'utf8',
+    );
+    const scan = readComponentRegistrations(source, 'packages/layout/src/index.ts');
+    expect(scan.keys.length).toBeGreaterThan(1);
+    // Exact, and derived: every call the reader saw yielded a key it could read.
+    expect(scan.keys).toHaveLength(scan.calls);
+    expect(scan.unreadable).toEqual([]);
+  });
+});

--- a/scripts/__tests__/side-effects-declaration-consistency.test.ts
+++ b/scripts/__tests__/side-effects-declaration-consistency.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest';
+
+// The shared registration reader (objectui#4894). Types are INFERRED from the
+// .mjs source by `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error`.
+import { readComponentRegistrations } from '../component-registrations.mjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -1434,20 +1438,50 @@ describe('objectui#3899 specimen: @object-ui/layout registers through the source
     // a test asserting a component that does not exist. (`SidebarNav` reaches
     // the registry under NO key at all — it is consumed as a plain React
     // component in JSX, corrected in objectui#3999.)
-    const registeredKeys = [
-      ...fs.readFileSync(path.join(layoutSrc, 'index.ts'), 'utf8').matchAll(/ComponentRegistry\.register\(\s*'([^']+)'/g),
-    ].map((match) => match[1]);
+    //
+    // The read is `scripts/component-registrations.mjs` (objectui#4894), shared
+    // with the three pins in `packages/layout/src/__tests__/`. It replaced four
+    // copies of a regex that accepted a single-quoted key and nothing else, and
+    // this file was the copy whose failure was SILENT: see the census note below.
+    const registrations = readComponentRegistrations(
+      fs.readFileSync(path.join(layoutSrc, 'index.ts'), 'utf8'),
+      'packages/layout/src/index.ts',
+    );
+    const registeredKeys = registrations.keys;
 
-    // A floor, not a census: it exists so a regex that stops matching cannot
-    // turn the loop below into a no-op. It read `6` until objectui#4841
-    // deregistered `app-shell` (ADR-0049 remove side), which is the one way this
-    // number is allowed to move — DOWN, with a register call deleted in the same
-    // commit. The keys themselves are pinned by name in
+    // A CENSUS, not a floor — and this is the half of objectui#4894 that widening
+    // a regex does not fix.
+    //
+    // This assertion read `toBeGreaterThanOrEqual(5)`, and its own comment said
+    // "a floor, not a census". A floor cannot see a key that is MISSING FROM THE
+    // READ: "five single-quoted calls plus one double-quoted call" satisfied it,
+    // so the sixth key's "survives the side-effect-only bundle" assertion simply
+    // never ran, and nothing anywhere went red. Of the four pins on this key
+    // list, this was the one that failed in silence — the two doc-parity pins at
+    // least reddened (with a backwards message), and the `app-shell` pin has a
+    // live-registry second line of defence.
+    //
+    // An exact LITERAL was the other candidate and is worse: it read `6` until
+    // objectui#4841 deregistered `app-shell`, and a number kept here reds on every
+    // legitimate registration added — which is how an exact count gets loosened
+    // back to a floor by the next person who adds a key. So the count is exact and
+    // DERIVED: every `ComponentRegistry.register` call the reader saw in code has
+    // to have yielded a key it could read. Add a key and it still holds; write one
+    // in a form the reader cannot see and it does not.
+    //
+    // The shared reader refuses a partial read at source — it throws rather than
+    // returning a short list — so on today's tree this line cannot be the thing
+    // that reddens first. It is stated here anyway, because it is the fact THIS
+    // loop depends on, and it is what still holds the loop honest if that refusal
+    // is ever relaxed. The keys themselves are pinned by name in
     // `packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts`.
     expect(
       registeredKeys.length,
-      'No `ComponentRegistry.register` call found in src/index.ts — the loop below would assert nothing.',
-    ).toBeGreaterThanOrEqual(5);
+      `src/index.ts has ${registrations.calls} \`ComponentRegistry.register\` call(s) but only ` +
+        `${registeredKeys.length} readable key(s), so the loop below would skip one in silence. ` +
+        'Unreadable: ' +
+        (registrations.unreadable.map((c: { line: number }) => `line ${c.line}`).join(', ') || 'none'),
+    ).toBe(registrations.calls);
 
     for (const key of registeredKeys) {
       expect(code, `the \`${key}\` registration must survive a side-effect-only import`).toContain(key);

--- a/scripts/component-registrations.mjs
+++ b/scripts/component-registrations.mjs
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * component-registrations -- the ONE answer to "which component keys does this
+ * source register?"
+ *
+ * Four pins read `packages/layout/src/index.ts` for the list of keys
+ * `registerLayout()` registers, and each of them used to carry its own copy of
+ * one regex:
+ *
+ *     ComponentRegistry\.register\(\s*'([^']+)'
+ *
+ * `packages/layout/src/__tests__/guide-layout-sidebar-nav-doc.test.ts` (the
+ * guide's key table), `.../app-shell-not-a-component-key.test.tsx` (`app-shell`
+ * is absent), `.../readme-registration-keys.test.ts` (the README's key list) and
+ * `scripts/__tests__/side-effects-declaration-consistency.test.ts` (every key
+ * survives a side-effect-only bundle).
+ *
+ * ## Why the copies were a defect and not merely duplication (objectui#4894)
+ *
+ * That regex accepts ONE quote character. Nothing in this repository enforces
+ * single quotes -- there is no `.prettierrc`, no `prettier` field in
+ * `package.json` and no `quotes` rule in `eslint.config.js` -- so
+ * `ComponentRegistry.register("some-key", ...)` is legal, lints clean, passes
+ * CI, and is invisible to all four readers at once. The input surface was one
+ * quote character narrower than the readers believed, and nothing watched the
+ * part that was missing.
+ *
+ * The three failure modes it produced were NOT the same, which is why "widen the
+ * regex" was not the whole job:
+ *
+ *   - the two doc-parity pins RED WITH A BACKWARDS DIAGNOSIS. The doc lists the
+ *     key correctly, the source read misses it, and the message says "the doc
+ *     names a key that is not registered" -- sending the reader off to break a
+ *     correct page.
+ *   - the side-effect pin goes GREEN AND SILENT. Its `toBeGreaterThanOrEqual(5)`
+ *     floor is satisfied by "5 single-quoted + 1 double-quoted", so the missing
+ *     key's "survives the bundle" assertion simply never runs.
+ *   - the `app-shell` pin misses a double-quoted re-registration on its SOURCE
+ *     face only; its live-registry assertion (`ComponentRegistry.getConfig` /
+ *     `has`) still catches it. That one has a second line of defence.
+ *
+ * objectui#4860 considered extracting this module and deliberately declined,
+ * because at that moment it would have been de-duplication only: editing three
+ * intentionally self-contained pin files to serve a fourth. That reasoning was
+ * right then. It stopped applying when the shared blind spot was measured --
+ * this is now "widen in one place, four benefit", which is a correctness reason
+ * rather than a tidiness one.
+ *
+ * ## What the extraction owes in exchange
+ *
+ * Four guards that fail independently are more robust than four that share a
+ * dependency, and this module spends some of that. So it is a TESTED module --
+ * `scripts/__tests__/component-registrations.test.ts` is its own pin, and it
+ * covers the non-vacuity case first: a shared reader that silently returned `[]`
+ * would convert four green-because-empty pins into one bug, which is strictly
+ * worse than the four copies were.
+ *
+ * It extracts only the EXTRACTION. What the four call sites ASSERT stays theirs
+ * -- they check four different things, and merging those is the coupling
+ * actually worth avoiding.
+ *
+ * ## Two refusals, not one
+ *
+ * `readComponentRegistrations` throws rather than returning a short list when:
+ *
+ *   1. it finds NO register call at all (the vacuity case -- the pins above are
+ *      all set-difference or absence assertions, every one of which passes
+ *      trivially on an empty list);
+ *   2. it finds a register call whose key it CANNOT READ -- a computed key, a
+ *      template with an interpolation, an unterminated literal. This is the
+ *      objectui#4894 shape generalised past the quote character: any call this
+ *      reader cannot see is a key that drops out of all four pins in silence.
+ *      Widening from one quote to three does not close that class; refusing to
+ *      under-read does.
+ *
+ * ## Comments and strings are not code
+ *
+ * The scan is comment- and literal-aware via `scripts/js-comment-mask.mjs`, this
+ * tree's one answer to "is this span code, or prose". The old regexes had no
+ * such idea, and `packages/layout/src/index.ts` carries a note saying so: the
+ * retired `app-shell` call is DESCRIBED there rather than quoted, because a
+ * verbatim copy inside a comment read to those regexes as a live registration.
+ * That workaround is no longer load-bearing here -- but it is left in place,
+ * because this module is not the only thing that has ever read that file.
+ */
+
+import { scanSource } from './js-comment-mask.mjs';
+
+/**
+ * `ComponentRegistry.register(`, allowing the whitespace a formatter may insert.
+ * The member access is matched rather than assumed adjacent so a wrapped call
+ * (`ComponentRegistry\n  .register(`) is a call, not an invisible one.
+ */
+const REGISTER_CALL = /ComponentRegistry\s*\.\s*register\s*\(/g;
+
+/** The three ways this language spells a string literal. */
+const QUOTES = new Set(["'", '"', '`']);
+
+/** 1-based line number of `index` in `source`. */
+function lineOf(source, index) {
+  let line = 1;
+  for (let k = 0; k < index; k++) if (source[k] === '\n') line += 1;
+  return line;
+}
+
+/**
+ * The key argument of a register call whose `(` ends at `from`, or `null` when
+ * this reader cannot read it.
+ *
+ * `null` is never "no key" -- it is "a key is there and I cannot see it", which
+ * the caller turns into a refusal.
+ */
+function readKeyArgument(source, from) {
+  let i = from;
+  while (i < source.length && /\s/.test(source[i])) i += 1;
+  const quote = source[i];
+  if (!QUOTES.has(quote)) return null;
+  let key = '';
+  for (let k = i + 1; k < source.length; k++) {
+    const ch = source[k];
+    // An escape or an interpolation means the key is not a plain literal, and a
+    // reader that guessed at either would be back to reporting a key that is
+    // not the one the registry gets.
+    if (ch === '\\') return null;
+    if (quote === '`' && ch === '$' && source[k + 1] === '{') return null;
+    if (ch === '\n') return null;
+    if (ch === quote) return key.length > 0 ? key : null;
+    key += ch;
+  }
+  return null;
+}
+
+/**
+ * @typedef {object} RegistrationScan
+ * @property {string[]} keys      Component keys, in source order.
+ * @property {number}   calls     `ComponentRegistry.register(` calls found in CODE.
+ * @property {{ line: number, text: string }[]} unreadable
+ *           Calls whose key this reader could not read -- `calls` minus `keys`.
+ */
+
+/**
+ * Every `ComponentRegistry.register` call in `source`, without judging the
+ * result. The primitive; `readComponentRegistrations` is what call sites want.
+ *
+ * @param {string} source
+ * @returns {RegistrationScan}
+ */
+export function findComponentRegistrations(source) {
+  const { comment, literal } = scanSource(source);
+  const keys = [];
+  const unreadable = [];
+  let calls = 0;
+  for (const found of source.matchAll(REGISTER_CALL)) {
+    const at = found.index;
+    // A commented-out call is not a registration, and neither is a mention of
+    // one inside a string or a template. `js-comment-mask` flags a literal's
+    // CONTENT (not its delimiters), and it flags `${...}` interiors too, so this
+    // one test covers both prose forms.
+    if (comment[at] || literal[at]) continue;
+    calls += 1;
+    const key = readKeyArgument(source, at + found[0].length);
+    if (key === null) {
+      const eol = source.indexOf('\n', at);
+      unreadable.push({
+        line: lineOf(source, at),
+        text: (eol === -1 ? source.slice(at) : source.slice(at, eol)).trim(),
+      });
+      continue;
+    }
+    keys.push(key);
+  }
+  return { keys, calls, unreadable };
+}
+
+/**
+ * The component keys `source` registers -- or a thrown error saying why this
+ * reader will not answer.
+ *
+ * @param {string} source     The file's text.
+ * @param {string} sourceLabel Repo-relative path, for the diagnostics.
+ * @returns {RegistrationScan}
+ */
+export function readComponentRegistrations(source, sourceLabel) {
+  const scan = findComponentRegistrations(source);
+
+  if (scan.calls === 0) {
+    throw new Error(
+      [
+        `No \`ComponentRegistry.register\` call was found in ${sourceLabel}.`,
+        '',
+        'Every pin that reads this list asserts a set difference or an absence, and all of',
+        'those pass trivially on an empty list -- so an empty read is reported as a failure',
+        'here rather than handed back as a fact (objectui#4894). Either the registrations',
+        'really are gone (then the pins have to be rewritten, not re-pointed), or this reader',
+        'has stopped seeing them: scripts/component-registrations.mjs.',
+      ].join('\n'),
+    );
+  }
+
+  if (scan.unreadable.length > 0) {
+    throw new Error(
+      [
+        `${sourceLabel} registers a component key this reader cannot read:`,
+        ...scan.unreadable.map((call) => `  line ${call.line}: ${call.text}`),
+        '',
+        'The key argument is not a plain string literal (a computed key, an interpolated',
+        'template, an escape). Returning the other keys and dropping this one is precisely',
+        'the objectui#4894 failure: the doc-parity pins would then red saying the DOC names an',
+        'unregistered key -- pointing the reader at a correct page -- and the side-effect pin',
+        'would go green without ever asserting this key survives the bundle.',
+        '',
+        'Write the key as a plain literal, or teach scripts/component-registrations.mjs to',
+        'resolve this form -- do not let it be read as absent.',
+      ].join('\n'),
+    );
+  }
+
+  return scan;
+}


### PR DESCRIPTION
Fixes #4894

Four pins asked `packages/layout/src/index.ts` the same question — *which component keys does `registerLayout()` register?* — with four copies of one regex:

```
ComponentRegistry\.register\(\s*'([^']+)'
```

That regex accepts **one** quote character, and nothing in this repo enforces a quote style: no `.prettierrc`, no `prettier` field in `package.json`, no `quotes` rule in `eslint.config.js`. So `ComponentRegistry.register("some-key", …)` is legal, lints clean, passes CI, and is invisible to all four readers at once.

The read now lives in **`scripts/component-registrations.mjs`**, and only the read is shared — each pin keeps its own assertions.

## Why extract now, when #4860 deliberately did not

#4860 raised extraction as a side option and **declined it on purpose**: at that moment it would have been de-duplication only — editing three intentionally self-contained pin files to serve a fourth. That reasoning was right on the evidence it had.

This card changed the evidence. The four copies did not merely repeat each other; they repeated a **blind spot**. The reason to extract stopped being tidiness and became correctness: **widen in one place, four benefit**. The paragraph in `readme-registration-keys.test.ts` that recorded the old decision now records the reversal, so the next reader who finds #4860 sees why it was reversed rather than overlooked.

## What the extraction owed in exchange, and how it is paid

Four guards that fail independently are more robust than four sharing a dependency, and this spends some of that. The coupling is therefore to a **tested** module — `scripts/__tests__/component-registrations.test.ts`, 18 cases, whose **first** cases are non-vacuity: a shared reader that silently returned an empty list would turn four green-because-empty pins into one bug, strictly worse than the four copies. Every one of the four call sites asserts a set difference or an absence, and all of them pass trivially on an empty list.

So the reader **refuses** rather than returning a short list. Two refusals, not one:

1. **no register call found at all** (the vacuity case);
2. **a register call whose key it cannot read** — a computed key, an interpolated template, an unterminated literal. Widening from one quote character to three closes one member of the class; refusing to under-read closes the class.

It is also comment- and literal-aware, through `scripts/js-comment-mask.mjs` (this tree's one answer to "is this span code, or prose"). A register call quoted verbatim in a comment is no longer read as a live registration — the hazard `packages/layout/src/index.ts` describes the retired `app-shell` call in prose to avoid. That note stays: this reader is not the only thing that has ever read that file.

## The half a widened regex does NOT fix: the floor

`side-effects-declaration-consistency.test.ts` asserted `toBeGreaterThanOrEqual(5)` — **a floor, not a census**, as its own comment said. A floor cannot see a key missing from the *read*: *"5 single-quoted + 1 double-quoted"* satisfies it, so the sixth key's "survives the side-effect-only bundle" assertion never runs and nothing goes red. Of the four pins, this was the one that failed **in silence**.

An exact **literal** was the other candidate and is worse: it read `6` until #4841 deregistered `app-shell`, and a number kept in the test reds on every legitimate registration added — which is how an exact count gets loosened back to a floor by the next person. So the count is exact and **derived**: every `ComponentRegistry.register` call the reader saw in code must have yielded a key it could read. Add a key and it still holds; write one in a form the reader cannot see and it does not.

## Controls — each direction predicted before running

Both controls mutate `packages/layout/src/index.ts` on disk, prove the mutation with **anchored counts** (never an editor's exit code), and restore with `git checkout HEAD --` plus the explicit path, under a trap, proven with an empty `git diff HEAD`. Each was run in **two trees**: this branch, and a detached worktree at the merge-base `17ccec977` (pre-fix).

**Control 1 — POSITIVE, conversion.** Rewrote the `page:card` call with double quotes.
`PROOF: injected-double-quoted=1 deleted-single-quoted=0`

| tree | result |
|---|---|
| pre-fix `17ccec977` | **RED**, 3 failed / 50 passed — and the two doc-parity messages point **backwards**: *"The `## Registration` list in packages/layout/README.md names a component key that `registerLayout()` does not register"*, sending the reader off to edit a correct page |
| this branch | **GREEN** (exit 0). Old regex over the same bytes: **4** keys, `page:card` missing. New reader: **5** |

**Control 1b — POSITIVE, additive** — the card's actually-silent shape, which the conversion above does *not* reproduce (converting a key drops the count to 4 and the floor catches it; **adding** one does not). Added a sixth, double-quoted `dq-probe` registration.
`PROOF: injected-double-quoted-call=1 register-call-lines=6`

| tree | result |
|---|---|
| pre-fix `17ccec977` | **ALL FOUR PINS GREEN**, exit 0, and the string `dq-probe` appears **0** times in the whole run — the key's survival assertion never ran, exactly as the card describes |
| this branch | **RED**, 2 failed / 51 passed, `dq-probe` named 5 times — and the message now points **forwards**: *"packages/layout/src/index.ts registers a component key the `## Registration` list in packages/layout/README.md does not name"* |

**Control 2 — NEGATIVE.** The reader does not collect a registration mentioned in a line comment, a block comment, a docblock, a string literal or a template literal (five cases in the module's own test; the real registration beside each ghost is still collected).

**Control 3 — BEFORE/AFTER on today's tree.** Predicted 5 either way, since all five calls are currently single-quoted. Measured: old regex **5**, new reader **5**, byte-identical lists in the same order.

## Scope

The shared reader, its test, and the four call sites. No prettier config, no eslint `quotes` rule, and no source-style change in `packages/layout/src/index.ts` — its five calls stay single-quoted.

Re-derived rather than inherited (the card's line numbers are from 2026-08-17 and had moved): the fourth call site is `scripts/__tests__/side-effects-declaration-consistency.test.ts:1438`, not `side-effects-manifest.test.ts:302` — #3943 converged the latter into the former. A **fifth** file matches the same identifier, `packages/layout/src/__tests__/page-node-renderer-stays-deleted.test.ts:76`, and is deliberately left alone: it is a different shape (`not.toMatch` for one named key) and it **already** spells a two-character quote class, so it is not in this defect class.

Verification union re-run on `3444ec3c0`, the final commit:

- `pnpm exec vitest run scripts/__tests__/ packages/layout/` — **91 files, 2156 tests passed**
- `pnpm type-check:scripts` — exit 0 · `pnpm --filter @object-ui/layout type-check` — exit 0 (the `@ts-expect-error` on the plain-JS import in the three layout pins is consumed, not stale: an unused one is TS2578 and would fail this run)
- `pnpm lint:root` — exit 0 (28 pre-existing warnings) · `turbo run lint --filter=@object-ui/layout` — exit 0 (41 pre-existing warnings); both new files confirmed inside eslint's scope, 0 errors / 0 warnings
- `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed`, `check-control-bytes`, `check-entry-guard`, `check-lint-coverage`, `check-type-check-coverage`, `check-pre-install-import-graph`, `check-package-self-import`, `check:esm-specifiers` — all exit 0

Gate list derived from `package.json` and `.github/workflows/`, not from the dispatch order. Changeset added with empty frontmatter: this is test-and-tooling only and publishes nothing.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_