### PR TITLE
docs(scripts): record the MEASURED .d.ts projection rule in the changeset-presence gate header

### DIFF
--- a/.changeset/components-react-page-published-dts-text-5666.md
+++ b/.changeset/components-react-page-published-dts-text-5666.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/components': patch
+---
+
+Published declaration text for the react page renderer changed: `kind:'react'` page `source` styling is now stated in the shipped `.d.ts`
+
+`dist/renderers/layout/react-page.d.ts` is in this package's npm tarball, and the
+declaration emitter reproduces that module's file-header documentation into it
+verbatim. Two things a consumer reads — on hover over `ReactKindPage` in an editor,
+or straight out of the tarball — now say something different:
+
+- The injected-scope note no longer tells authors that layout is left to "plain
+  HTML + Tailwind". It says plain HTML.
+- A new paragraph states the styling contract for `kind:'react'` page `source`:
+  `source` is runtime metadata, not build input. Style with inline `style` objects
+  using `hsl(var(--token))` theme colors, and render overlays through `ObjectForm`
+  with `formType` `"drawer"` or `"modal"` rather than a hand-rolled `fixed inset-0`
+  backdrop. Do **not** author Tailwind utility classes in page `source`: the
+  console's Tailwind is compiled at build time by scanning the console's own `src`
+  and there is no safelist, so an authored utility class silently produces no CSS
+  and no error anywhere. `os validate` reports it as
+  `page-source-className-tailwind`. (ADR-0065; ADR-0080's 2026-06-30 amendment;
+  see `content/docs/guide/react-pages.md`.)
+
+That is guidance an author can act on, and it contradicts what this package's
+declarations previously told them, so it is a change to the published surface
+rather than an internal edit. No runtime behaviour changed and no export moved.
+
+This entry is corrective. The text landed under objectui#5461 with a changeset that
+declared only `@object-ui/types`, on the stated grounds that the edits "do not
+project into any `.d.ts`". Rebuilding the package shows that they do — the reasoning
+and the measurement are recorded in `scripts/check-changeset-presence.mjs`'s header,
+where the next author will meet them.

--- a/scripts/check-changeset-presence.mjs
+++ b/scripts/check-changeset-presence.mjs
@@ -241,6 +241,91 @@
  * its own control at once: the phrase is known-present, and it returned these
  * five plus one unrelated i18n test under `packages/fields`. Six files means the
  * search worked; zero means it broke, not that the copies are gone.
+ *
+ * ## Comment text in `src` DOES reach a published `.d.ts` (objectui#5666)
+ *
+ * Recorded here because this gate's own limitation is what let it through, and
+ * because the FALSE version of the finding is already merged in a changeset
+ * where the next author will reasonably cite it.
+ *
+ * `.changeset/page-source-tailwind-framing-5461.md` (PR #5471, `a691c0bee`)
+ * justifies giving a comment-only edit to
+ * `packages/components/src/renderers/layout/react-page.tsx` no entry of its own:
+ *
+ *     Those are internal comments — they do not project into any `.d.ts` and
+ *     change no export — so they get no entry of their own; there is nothing an
+ *     `@object-ui/components` consumer could read in a CHANGELOG and act on.
+ *
+ * The first clause is false, and it is false for that exact file. Re-measured
+ * on `c9a725263` (the finding's own reading is from 2026-08-22 and was NOT
+ * quoted forward), building `@object-ui/components` — 17.6.0, `private` unset,
+ * `files` lists `dist`, so the emitted declarations are in the npm tarball:
+ *
+ *   - `src/renderers/layout/react-page.tsx`'s file header, including the whole
+ *     styling paragraph #5461 added, is present VERBATIM in
+ *     `dist/renderers/layout/react-page.d.ts` — `page-source-className-tailwind`
+ *     on line 37 of the emitted file. The text the changeset said no consumer
+ *     could read sits inside a file that is published verbatim.
+ *   - Of #5461's THREE edits to that file, two are in the header and reach the
+ *     emitted `.d.ts` (the injected-scope note losing `+ Tailwind`, and the new
+ *     styling paragraph); the third does not. That third one is the
+ *     `buildComponentScope` comment, which sits above a NON-EXPORTED function —
+ *     the identifier `buildComponentScope` does not occur in the `.d.ts` at all,
+ *     so neither does anything attached to it. One changeset, one file, both
+ *     answers.
+ *   - `src/renderers/basic/html-elements.tsx`'s file header likewise reaches
+ *     `dist/renderers/basic/html-elements.d.ts`, whose only other content is
+ *     `export {};` — there, the comment is very nearly the whole shipped file.
+ *   - A comment inside a FUNCTION BODY does not project, and that half is
+ *     load-bearing: without it this note would read as "comments project",
+ *     which is false in the other direction. Control: the `kind === 'html'`
+ *     dispatch arm inside `src/renderers/layout/page.tsx`'s `useMemo`. Three
+ *     distinct phrases from it each occur exactly once under `src` and zero
+ *     times anywhere under `dist`.
+ *
+ * ### Do NOT simplify this to "a file header projects"
+ *
+ * That is the shape the finding arrived in, and measuring the package instead
+ * of two files does not support it. Of the 202 files under
+ * `packages/components/src` that carry the licence file-header AND emit a
+ * `.d.ts`, 165 have that header in the emitted file — and 37 do not.
+ *
+ * `page.tsx` is one of the 37, which makes it a single file demonstrating both
+ * halves: its function-body comment is the negative control above, and its
+ * header (`The Page renderer interprets PageSchema into structured layouts.`)
+ * is likewise absent from all of `dist`, while its `PageRenderer` declaration
+ * is emitted normally. Position in the file is NECESSARY, not SUFFICIENT.
+ *
+ * The 37 split by what the declaration emitter did with the statement the
+ * header was attached to. 11 emit an empty `.d.ts` (barrels whose every line is
+ * a side-effect import), so there is no node left for the comment to hang on.
+ * In the other 26 the first statement the emitter produced is not the one the
+ * header was attached to: `import React, { useMemo } from 'react'` is re-emitted
+ * as `import { default as React } from 'react'`, `import type` becomes a value
+ * import, an all-values import is dropped and a later one becomes first. A
+ * rebuilt node carries no leading comment. That correlation holds across all 37
+ * — but it is a reading of emitter behaviour, not a contract TypeScript
+ * documents, and `vite-plugin-dts` post-processes on top of it.
+ *
+ * ### So do not reason about it — build and look
+ *
+ *     pnpm --filter '<pkg>^...' --filter <pkg> build
+ *     git diff --stat -- <pkg>/dist
+ *
+ * If emitted `.d.ts` text moved, the package ships changed bytes and owes a
+ * changeset that says so. THIS GATE CANNOT TELL YOU: it checks changeset
+ * PRESENCE, not per-package correctness, so #5461 declaring `@object-ui/types`
+ * satisfied it while `@object-ui/components`' emitted declarations changed with
+ * nothing describing them. Making it per-package is a much larger change and was
+ * deliberately not ruled here; the counter-statement is.
+ *
+ * One correction to the finding as filed, since it changes only the tense and
+ * not the conclusion: at the time of writing the text had NOT yet been released.
+ * `.changeset/page-source-tailwind-framing-5461.md` is still un-compiled in
+ * `.changeset/` (its opening sentence appears in no CHANGELOG), so the release
+ * that carries this declaration text is still ahead. The corrective entry
+ * therefore lands WITH that release rather than apologising for it afterwards —
+ * which is the outcome to aim for whenever this is caught in time.
  */
 
 import { execFileSync } from 'node:child_process';


### PR DESCRIPTION
Part of #5666

Triage ruled two halves on 2026-08-22, and both are here. The merged changeset is **not** rewritten.

**(a)** `scripts/check-changeset-presence.mjs`'s header gains the projection finding — this repo's stated home for findings of this shape, and the gate whose own limitation let the false version through.

**(b)** One corrective **patch** changeset for `@object-ui/components` describing the declaration text that changed, written as something a consumer can act on rather than as "a comment was corrected".

## ⚠️ I did not write down the rule the order specified — because I measured it and it is not true

The order was explicit that this card exists because a confident, unverified claim got merged, so the counter-statement must not be a second one. I measured, and the measurement refines the card. **The card's three named measurements all reproduce exactly.** Its *generalisation* — "a file-header block comment projects" — does not survive being measured across the package, so the note records what I measured instead.

Everything below was measured on `c9a725263` (this branch's base), after `pnpm --filter '@object-ui/components^...' build` and `pnpm --filter @object-ui/components build`, both exit 0. `@object-ui/components` is 17.6.0, `private` unset, `files` lists `dist` — so the emitted declarations are in the npm tarball.

### The card's three, re-derived

| # | Claim | Result |
|---|---|---|
| 1 | `react-page.tsx`'s file header projects | ✅ `page-source-className-tailwind` on **line 37** of `dist/renderers/layout/react-page.d.ts` — the same reading the card took on 2026-08-22, re-derived not quoted. The whole styling paragraph is verbatim. |
| 2 | The `kind === 'html'` dispatch-arm comment in `page.tsx`'s `useMemo` does **not** | ✅ Three distinct phrases from that arm occur **once each** under `src` and **zero times** anywhere under `dist`. |
| 3 | `html-elements.tsx`'s header projects | ✅ Present in `dist/renderers/basic/html-elements.d.ts`, whose only other content is `export {};` — there the comment is very nearly the whole shipped file. |

### The counterexample class the card did not measure

Of the **202** files under `packages/components/src` that carry the licence file-header *and* emit a `.d.ts`, **165** have that header in the emitted file and **37 do not**.

`page.tsx` is one of the 37 — the same file that supplies measurement 2's negative control. Its header (`The Page renderer interprets PageSchema into structured layouts.`) is absent from all of `dist`, while its `PageRenderer` declaration is emitted normally. So a single file demonstrates both halves, and **position in the file is necessary, not sufficient.**

The 37 split by what the declaration emitter did with the statement the header was attached to:

- **11** emit an empty `.d.ts` (barrels whose every line is a side-effect import) — no node left for the comment to hang on.
- **26** where the first statement the emitter produced is not the one the header was attached to — `import React, { useMemo } from 'react'` is re-emitted as `import { default as React } from 'react'`, `import type` becomes a value import, an all-values import is dropped and a later one becomes first. A rebuilt node carries no leading comment.

The note states that correlation **and labels it emitter behaviour rather than a contract** — TypeScript documents no rule here and `vite-plugin-dts` post-processes on top. The operative advice it leaves is procedural: build the package and diff `dist`, do not reason about it.

### A bonus datum from the same file

Of #5461's **three** edits to `react-page.tsx`, **two** are in the header and reach the emitted `.d.ts` (the injected-scope note losing `+ Tailwind`, and the new styling paragraph). The third — the `buildComponentScope` comment — does not: that function is not exported, the identifier does not occur in the `.d.ts` at all, so neither does anything attached to it. One changeset, one file, both answers.

### One correction of tense, which does not change the conclusion

The card describes the `.d.ts` change as already **released**. It is not. `.changeset/page-source-tailwind-framing-5461.md` is still un-compiled in `.changeset/` (328 pending changesets; its opening sentence appears in no CHANGELOG, grep exit 1). The corrective entry therefore lands **with** the release that carries the text rather than apologising for it afterwards — a better outcome than the one triage was ruling on, and the reason the changeset is written in the ordinary forward-looking voice.

## Scope

`scripts/check-changeset-presence.mjs`'s header comment and one new `.changeset/*.md`. Nothing else — `react-page.tsx`, the merged changeset, and #5469's sites are untouched. The gate was **not** made per-package; that was ruled out and I agree it is a separate, much larger question.

## Gates

Derived from `package.json` and `.github/workflows/`, not from the dispatch order. Exit codes captured by redirect before any pipe. Re-run at the final commit `117fae83b`:

| Gate | Exit |
|---|---|
| `node scripts/check-changeset-presence.mjs` | 0 |
| `pnpm changeset:check` (`check-changeset-fixed` + `check-changeset-no-major`) | 0 |
| `pnpm check:control-bytes` | 0 |
| `pnpm type-check:scripts` | 0 |
| `pnpm lint:root` | 0 (28 pre-existing warnings, none in either edited file) |
| root `vitest run` — `check-changeset-presence`, `check-changeset-fixed`, `check-changeset-no-major`, `check-pre-install-import-graph` | 0 · 4 files, 91 tests passed |

This PR is the first thing exercising the note's neighbourhood, so the gate being edited judges its own changeset. Its verdict line at `117fae83b`:

```
Compared the working tree with c9a725263 (merge-base with origin/main): 2 file(s) changed, 0 of them published source of a package the release covers, 0 under a package changesets ignores, 1 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

Repo-wide scans (`pnpm lint`, `pnpm check`, full `vitest run`) are CI's run and were not duplicated locally.

## Why this stays `Part of` rather than closing the card

The order said to stop and report on any disagreement with the card. I am reporting one and shipping the honest note rather than the specified one, so the card should stay open until triage confirms the wording — a merge should not close it silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_