### PR TITLE
fix(build): wire both shared vite-plugin-dts factories into every dts package, and ratchet them there

### DIFF
--- a/.changeset/5483-5439-dts-config-wiring.md
+++ b/.changeset/5483-5439-dts-config-wiring.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/components': patch
+'@object-ui/fields': patch
+'@object-ui/plugin-ai': patch
+'@object-ui/plugin-calendar': patch
+'@object-ui/plugin-charts': patch
+'@object-ui/plugin-chatbot': patch
+'@object-ui/plugin-dashboard': patch
+'@object-ui/plugin-designer': patch
+'@object-ui/plugin-detail': patch
+'@object-ui/plugin-editor': patch
+'@object-ui/plugin-form': patch
+'@object-ui/plugin-gantt': patch
+'@object-ui/plugin-grid': patch
+'@object-ui/plugin-kanban': patch
+'@object-ui/plugin-list': patch
+'@object-ui/plugin-map': patch
+'@object-ui/plugin-markdown': patch
+'@object-ui/plugin-report': patch
+'@object-ui/plugin-timeline': patch
+'@object-ui/plugin-tree': patch
+'@object-ui/plugin-view': patch
+---
+
+Published typings from every `vite-plugin-dts` package now carry an explicit extension on
+every relative specifier, and a type error in the declaration build now fails the build
+instead of being printed and ignored (objectui#5439, objectui#5483).
+
+**Consumers on `moduleResolution: nodenext` or `node16` may see NEW type errors, and that
+is the fix working.** These packages re-export mostly through NAMED re-exports —
+`export { useObjectChat } from './useObjectChat'`. TypeScript could not follow the
+extensionless hop, but it still DECLARED the name, so the symbol resolved to a silent
+`any`. Nothing errored; consumers simply got no types. With the extension emitted, the
+symbol carries its real type, and any call site that was relying on the `any` now type
+checks for the first time. This is the mode that produced the 21 residual `TS7006` on
+`@object-ui/app-shell` reported against objectui#5365 — a type hole that opened quietly,
+unlike objectui#5365's own `export * from './ui'` packages where the same defect surfaced
+immediately as `TS2305: has no exported member`.
+
+410 extensionless relative specifiers across 19 packages were emitted before this change;
+the count is now 0 in all 22 packages that build typings through `vite-plugin-dts`.
+`@object-ui/fields` was already clean — its sources write explicit `.js` specifiers — and
+is wired so it stays that way.
+
+The second half changes no emitted output today: 22/22 packages built green unmodified, so
+making the declaration step's exit code honest turns nothing red. It changes what a FUTURE
+regression does — print and exit 0, versus fail the build.

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -12,6 +12,7 @@ import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
 import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
   plugins: [
@@ -35,6 +36,9 @@ export default defineConfig({
       // verdict about specifier-preserving `.js` builds — correctly never
       // scanned this package. See the module header for the full argument.
       ...createDtsExplicitExtensions({ packageDir: __dirname }),
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/fields/vite.config.ts
+++ b/packages/fields/vite.config.ts
@@ -14,6 +14,14 @@ export default defineConfig({
       // this package's `rootDir` — which would emit TS6059 rootDir errors.
       compilerOptions: { rootDir: path.resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
+      // Deliberately NOT spreading `createDtsFailOnTypeErrors` here, unlike the
+      // other 21 `dts(` call sites — objectui#5483. This package's build script is
+      // `tsc && vite build && node scripts/build-css.mjs`, and that leading `tsc` is
+      // not redundant: it is what makes a type error fatal for this package, and it
+      // exits non-zero BEFORE `vite build` ever runs, so a dts-leg exit code could
+      // never be what decides this build. Drop the `tsc &&` prefix and this package
+      // owes the factory instead — `scripts/__tests__/vite-dts-wiring-ratchet.test.ts`
+      // reads that script and fails here if the prefix goes away.
     }),
   ],
   resolve: {

--- a/packages/fields/vite.config.ts
+++ b/packages/fields/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import path from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -14,6 +16,10 @@ export default defineConfig({
       // this package's `rootDir` — which would emit TS6059 rootDir errors.
       compilerOptions: { rootDir: path.resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // Deliberately NOT spreading `createDtsFailOnTypeErrors` here, unlike the
       // other 21 `dts(` call sites — objectui#5483. This package's build script is
       // `tsc && vite build && node scripts/build-css.mjs`, and that leading `tsc` is

--- a/packages/plugin-ai/vite.config.ts
+++ b/packages/plugin-ai/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -16,6 +18,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-ai/vite.config.ts
+++ b/packages/plugin-ai/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -18,6 +19,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-calendar/vite.config.ts
+++ b/packages/plugin-calendar/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -32,6 +33,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-calendar/vite.config.ts
+++ b/packages/plugin-calendar/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   test: {
     globals: true,
@@ -30,6 +32,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-charts/vite.config.ts
+++ b/packages/plugin-charts/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -26,6 +27,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-charts/vite.config.ts
+++ b/packages/plugin-charts/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -24,6 +26,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-chatbot/vite.config.ts
+++ b/packages/plugin-chatbot/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -26,6 +27,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-chatbot/vite.config.ts
+++ b/packages/plugin-chatbot/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -24,6 +26,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-dashboard/vite.config.ts
+++ b/packages/plugin-dashboard/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -16,6 +18,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-dashboard/vite.config.ts
+++ b/packages/plugin-dashboard/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -18,6 +19,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-designer/vite.config.ts
+++ b/packages/plugin-designer/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -16,6 +18,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-designer/vite.config.ts
+++ b/packages/plugin-designer/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -18,6 +19,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-detail/vite.config.ts
+++ b/packages/plugin-detail/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -18,6 +19,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-detail/vite.config.ts
+++ b/packages/plugin-detail/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -16,6 +18,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-editor/vite.config.ts
+++ b/packages/plugin-editor/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -25,6 +26,10 @@ export default defineConfig({
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-editor/vite.config.ts
+++ b/packages/plugin-editor/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -23,6 +25,9 @@ export default defineConfig({
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-form/vite.config.ts
+++ b/packages/plugin-form/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -15,6 +17,9 @@ export default defineConfig({
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-form/vite.config.ts
+++ b/packages/plugin-form/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -17,6 +18,10 @@ export default defineConfig({
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-gantt/vite.config.ts
+++ b/packages/plugin-gantt/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -26,6 +27,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-gantt/vite.config.ts
+++ b/packages/plugin-gantt/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -24,6 +26,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-grid/vite.config.ts
+++ b/packages/plugin-grid/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -17,6 +18,10 @@ export default defineConfig({
       // this package's `rootDir` — which would emit TS6059 rootDir errors.
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-grid/vite.config.ts
+++ b/packages/plugin-grid/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -15,6 +17,9 @@ export default defineConfig({
       // this package's `rootDir` — which would emit TS6059 rootDir errors.
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-kanban/vite.config.ts
+++ b/packages/plugin-kanban/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -26,6 +27,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-kanban/vite.config.ts
+++ b/packages/plugin-kanban/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -24,6 +26,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-list/vite.config.ts
+++ b/packages/plugin-list/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -18,6 +19,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-list/vite.config.ts
+++ b/packages/plugin-list/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -16,6 +18,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       outDir: 'dist',
       tsconfigPath: './tsconfig.json',
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-map/vite.config.ts
+++ b/packages/plugin-map/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -26,6 +27,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-map/vite.config.ts
+++ b/packages/plugin-map/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -24,6 +26,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-markdown/vite.config.ts
+++ b/packages/plugin-markdown/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -25,6 +26,10 @@ export default defineConfig({
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-markdown/vite.config.ts
+++ b/packages/plugin-markdown/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -23,6 +25,9 @@ export default defineConfig({
       compilerOptions: { rootDir: resolve(__dirname, 'src'), paths: {} },
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-report/vite.config.ts
+++ b/packages/plugin-report/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   define: {
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production'),
@@ -19,6 +21,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-report/vite.config.ts
+++ b/packages/plugin-report/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -21,6 +22,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-timeline/vite.config.ts
+++ b/packages/plugin-timeline/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -26,6 +27,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-timeline/vite.config.ts
+++ b/packages/plugin-timeline/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -24,6 +26,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-tree/vite.config.ts
+++ b/packages/plugin-tree/vite.config.ts
@@ -11,6 +11,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -26,6 +27,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/packages/plugin-tree/vite.config.ts
+++ b/packages/plugin-tree/vite.config.ts
@@ -11,6 +11,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   plugins: [
     react(),
@@ -24,6 +26,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', 'node_modules'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   resolve: {

--- a/packages/plugin-view/vite.config.ts
+++ b/packages/plugin-view/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
+
 export default defineConfig({
   define: {
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production'),
@@ -19,6 +21,9 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx'],
+      // A type error the declaration program already found and printed used to
+      // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
+      ...createDtsFailOnTypeErrors({ packageDir: __dirname }),
     }),
   ],
   build: {

--- a/packages/plugin-view/vite.config.ts
+++ b/packages/plugin-view/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'path';
 
+import { createDtsExplicitExtensions } from '../../scripts/vite-dts-explicit-extensions.ts';
 import { createDtsFailOnTypeErrors } from '../../scripts/vite-dts-fail-on-type-errors.ts';
 
 export default defineConfig({
@@ -21,6 +22,10 @@ export default defineConfig({
       aliasesExclude: [/^@object-ui\//],
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx'],
+      // Relative specifiers in the EMITTED typings get their explicit extension
+      // here — objectui#5365 / #5439. A NAMED re-export through an extensionless
+      // hop still declares the name under `nodenext` and silently types it `any`.
+      ...createDtsExplicitExtensions({ packageDir: __dirname }),
       // A type error the declaration program already found and printed used to
       // leave `vite build` exiting 0 — objectui#5370 / #5483. This makes it fatal.
       ...createDtsFailOnTypeErrors({ packageDir: __dirname }),

--- a/scripts/__tests__/vite-dts-wiring-ratchet.test.ts
+++ b/scripts/__tests__/vite-dts-wiring-ratchet.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+
+/**
+ * Every `vite-plugin-dts` build in this repository spreads BOTH shared dts
+ * factories into its `dts()` call, and this is the gate that keeps it that way.
+ *
+ * ## Why a gate and not a convention
+ *
+ * Both fixes are one line per `vite.config.ts`, and the absence of that line is
+ * invisible: the build stays green, the typings still get written, and nothing
+ * anywhere says a package opted out. That is not a hypothetical failure mode —
+ * it is the recorded history of both modules:
+ *
+ *  - `scripts/vite-dts-fail-on-type-errors.ts` landed with objectui#5370 wired
+ *    into ONE of 22 call sites. For the other 21, the declaration program kept
+ *    printing a type error and `vite build` kept exiting 0 (objectui#5483).
+ *  - `scripts/vite-dts-explicit-extensions.ts` landed with objectui#5365 wired
+ *    into TWO of 22. The other 20 kept emitting extensionless relative
+ *    specifiers into `dist/**\/*.d.ts` — 410 of them, measured on the tree this
+ *    gate was written against (objectui#5439).
+ *
+ * In the words of objectui#5483: 1-of-22 is "a state someone has to remember",
+ * and forgetting costs nothing at the moment of forgetting. A new dts package
+ * cannot land unwired for either reason once this file exists.
+ *
+ * ## What is asserted, and why each one
+ *
+ *  1. The POPULATION is derived from the tree, never listed here — a
+ *     hand-copied enumeration drifts by construction, and the direction it
+ *     drifts is toward checking fewer packages.
+ *  2. The population has a FLOOR. A walk that finds nothing must go red, not
+ *     green: a renamed directory or a changed config filename would otherwise
+ *     turn this whole file into a gate that passes because it checks zero
+ *     things — the one failure mode a ratchet cannot notice about itself.
+ *  3. Both spreads are located by AST, not by substring. `toContain` is
+ *     satisfied by the factory's name appearing in a COMMENT, which is exactly
+ *     the shape of a call site someone disabled and explained.
+ *  4. Exclusions are a fixed, capped table, and each one's stated reason is
+ *     RE-DERIVED from the tree rather than trusted as prose. An exclusion whose
+ *     premise stopped holding fails here instead of quietly exempting a package
+ *     forever.
+ */
+
+/** The two shared factories every dts build owes. */
+const FACTORIES = [
+  {
+    name: 'createDtsExplicitExtensions',
+    module: 'scripts/vite-dts-explicit-extensions.ts',
+    defect: 'extensionless relative specifiers in the emitted typings (objectui#5365 / #5439)',
+  },
+  {
+    name: 'createDtsFailOnTypeErrors',
+    module: 'scripts/vite-dts-fail-on-type-errors.ts',
+    defect: '`vite build` exiting 0 on a type error the dts program printed (objectui#5370 / #5483)',
+  },
+] as const;
+
+/**
+ * The floor the population may not fall below.
+ *
+ * 22 config files call `dts(` today. The floor is deliberately BELOW that — it
+ * is a vacuity guard, not a second copy of the count, so retiring a plugin
+ * package is an ordinary green change while a walk that resolves nothing is
+ * not. Raise it only alongside a reason that the smaller number is impossible.
+ */
+const POPULATION_FLOOR = 15;
+
+/** Read a workspace package's `build` script. */
+function buildScript(pkgDir: string): string {
+  const manifest = path.join(ROOT, pkgDir, 'package.json');
+  return JSON.parse(fs.readFileSync(manifest, 'utf8')).scripts?.build ?? '';
+}
+
+/**
+ * Call sites deliberately NOT wired to one factory.
+ *
+ * `holds()` re-derives the stated reason from the tree. A reason that stops
+ * being true takes the exclusion with it, so this table cannot decay into a
+ * list of packages nobody remembers exempting.
+ */
+const EXCLUSIONS: ReadonlyArray<{
+  readonly config: string;
+  readonly factory: string;
+  readonly reason: string;
+  readonly holds: () => boolean;
+}> = [
+  {
+    config: 'packages/fields/vite.config.ts',
+    factory: 'createDtsFailOnTypeErrors',
+    reason:
+      "@object-ui/fields builds with `tsc && vite build && …`; the leading `tsc` exits " +
+      'non-zero on the same diagnostics BEFORE `vite build` runs, so the dts leg’s exit ' +
+      'code is not what decides this build (objectui#5483).',
+    holds: () => /^tsc\s*&&/.test(buildScript('packages/fields')),
+  },
+];
+
+/**
+ * Ceiling on the exclusion table.
+ *
+ * Equal to its length today, on purpose: adding an exclusion means editing two
+ * places and reading this paragraph, which is the review point. The number may
+ * go DOWN freely — that is a package getting wired.
+ */
+const MAX_EXCLUSIONS = 1;
+
+function isExcluded(config: string, factory: string): boolean {
+  return EXCLUSIONS.some((e) => e.config === config && e.factory === factory);
+}
+
+/** Every `vite.config.*` under the workspace roots, repo-relative. */
+function viteConfigs(): string[] {
+  const found: string[] = [];
+  for (const root of ['packages', 'apps', 'examples']) {
+    const dir = path.join(ROOT, root);
+    if (!fs.existsSync(dir)) continue;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      for (const name of ['vite.config.ts', 'vite.config.mts', 'vite.config.js']) {
+        const file = path.join(dir, entry.name, name);
+        if (fs.existsSync(file)) found.push(path.relative(ROOT, file));
+      }
+    }
+  }
+  return found.sort();
+}
+
+interface DtsCallSite {
+  /** Repo-relative path to the config. */
+  readonly config: string;
+  /** Factory names spread into the `dts()` options object, by AST. */
+  readonly spreads: ReadonlySet<string>;
+  /** Module specifiers the config imports, by AST. */
+  readonly imports: ReadonlySet<string>;
+}
+
+/**
+ * The `dts()` call in a config, or null if it has none.
+ *
+ * `dts` must be the local name bound to the `vite-plugin-dts` default import —
+ * a same-named local helper is not this population, and pretending otherwise
+ * would let a package join the gate's subject set by coincidence.
+ */
+function dtsCallSite(config: string): DtsCallSite | null {
+  const file = path.join(ROOT, config);
+  const source = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+  );
+
+  const imports = new Set<string>();
+  let dtsLocalName: string | null = null;
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    imports.add(statement.moduleSpecifier.text);
+    if (statement.moduleSpecifier.text !== 'vite-plugin-dts') continue;
+    const name = statement.importClause?.name;
+    if (name !== undefined) dtsLocalName = name.text;
+  }
+  if (dtsLocalName === null) return null;
+
+  const spreads = new Set<string>();
+  let sawCall = false;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === dtsLocalName
+    ) {
+      sawCall = true;
+      const [options] = node.arguments;
+      if (options !== undefined && ts.isObjectLiteralExpression(options)) {
+        for (const property of options.properties) {
+          if (!ts.isSpreadAssignment(property)) continue;
+          const spread = property.expression;
+          if (ts.isCallExpression(spread) && ts.isIdentifier(spread.expression)) {
+            spreads.add(spread.expression.text);
+          }
+        }
+      }
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+
+  return sawCall ? { config, spreads, imports } : null;
+}
+
+const CONFIGS = viteConfigs();
+const CALL_SITES = CONFIGS.map(dtsCallSite).filter((s): s is DtsCallSite => s !== null);
+
+describe(`vite-plugin-dts wiring ratchet — ${CALL_SITES.length} dts( call sites of ${CONFIGS.length} vite configs`, () => {
+  it(`finds a real population: ${CALL_SITES.length} call sites, floor ${POPULATION_FLOOR}`, () => {
+    // Non-vacuity. Everything below is a statement about CALL_SITES, so an
+    // empty walk would make every one of those assertions pass by having
+    // nothing to judge. This is the assertion that cannot be satisfied that way.
+    expect(CALL_SITES.length).toBeGreaterThanOrEqual(POPULATION_FLOOR);
+    expect(CONFIGS.length).toBeGreaterThanOrEqual(CALL_SITES.length);
+  });
+
+  for (const factory of FACTORIES) {
+    it(`every dts( call site spreads ${factory.name}`, () => {
+      const missing = CALL_SITES.filter(
+        (site) => !site.spreads.has(factory.name) && !isExcluded(site.config, factory.name),
+      ).map((site) => site.config);
+
+      expect(
+        missing,
+        `${missing.length} vite-plugin-dts call site(s) do not spread ` +
+          `\`${factory.name}({ packageDir: __dirname })\`, so they still carry ` +
+          `${factory.defect}:\n` +
+          missing.map((c) => `  - ${c}`).join('\n') +
+          `\n\nAdd the spread, in the form pinned by packages/layout/vite.config.ts. If a ` +
+          `package genuinely cannot be wired, that is a finding worth an issue — and an ` +
+          `entry in EXCLUSIONS above with a reason this file can re-derive, not a silent ` +
+          `omission.`,
+      ).toEqual([]);
+    });
+
+    it(`every call site that spreads ${factory.name} imports it from ${factory.module}`, () => {
+      // A spread of a same-named local function would satisfy the assertion
+      // above while running none of the shared module's code.
+      const wrong = CALL_SITES.filter((site) => site.spreads.has(factory.name)).filter((site) => {
+        const wanted = path
+          .relative(path.dirname(path.join(ROOT, site.config)), path.join(ROOT, factory.module))
+          .split(path.sep)
+          .join('/');
+        return !site.imports.has(wanted);
+      });
+      expect(wrong.map((s) => s.config)).toEqual([]);
+    });
+  }
+
+  it('exclusions stay capped, and each one names a live call site', () => {
+    expect(EXCLUSIONS.length).toBeLessThanOrEqual(MAX_EXCLUSIONS);
+    for (const exclusion of EXCLUSIONS) {
+      expect(
+        CALL_SITES.some((site) => site.config === exclusion.config),
+        `EXCLUSIONS names ${exclusion.config}, which is not a dts( call site any more. ` +
+          `A stale exclusion must go red here rather than exempt a path that no longer exists.`,
+      ).toBe(true);
+      expect(FACTORIES.map((f) => f.name)).toContain(exclusion.factory);
+    }
+  });
+
+  it('every exclusion re-derives its stated reason from the tree', () => {
+    for (const exclusion of EXCLUSIONS) {
+      expect(
+        exclusion.holds(),
+        `The reason ${exclusion.config} is exempt from ${exclusion.factory} no longer holds:\n` +
+          `  ${exclusion.reason}\n` +
+          `Wire the factory in, or replace the exclusion with one whose premise is true.`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #5483
Fixes #5439

Folded dispatch, chain head #5483. Two commits, two acceptance criteria, and **one** ratchet over the population both cards describe — which is the reason they were folded rather than run serially. Run serially this would have produced two near-duplicate gates over one population, each checking one module.

- `6c768e219` — #5483: `createDtsFailOnTypeErrors` into the remaining 20 call sites.
- `beeb94058` — #5439: `createDtsExplicitExtensions` into the remaining 20 call sites, plus the shared ratchet.

---

## Population, re-derived on today's `main` (`17ccec977`)

Both cards' populations were stale — #5483's from 2026-08-21, #5439's from 2026-08-20, and #5439's said so about itself. Re-derived from the tree:

- **22** `vite.config.ts` files call `dts(` — `components`, `fields`, `layout`, and 19 `plugin-*`.
- `createDtsFailOnTypeErrors` was wired into **1 of 22** (`layout`). Now **21 of 22**.
- `createDtsExplicitExtensions` was wired into **2 of 22** (`components`, `layout`). Now **22 of 22**.

#5439's 13-package table is not the population. The six it listed as *"outside the closure built here and are untested, not clean"* were all measured here and all needed wiring: `plugin-gantt` 17, `plugin-timeline` 4, `plugin-ai` 3, `plugin-markdown` 3, `plugin-map` 1, `plugin-tree` 1 extensionless specifiers. `plugin-detail` measured 82, not 81.

### The one package that stays unwired, and why

`packages/fields` keeps its `tsc &&` prefix and does **not** spread `createDtsFailOnTypeErrors`. Its build script is `tsc && vite build && node scripts/build-css.mjs`; the leading `tsc` exits non-zero on the same diagnostics *before* `vite build` runs, so a dts-leg exit code could never be what decides that build. The prefix is load-bearing, not redundant next to the 21 wired call sites, and the call site now says so.

The card asked for that as a comment at the build script. `package.json` cannot hold a comment and this repo has no `"//"`-key convention to borrow (zero occurrences repo-wide), so the note lives at the `dts()` call in `packages/fields/vite.config.ts` and names the build script — **and the claim is machine-checked**: the ratchet's exclusion entry re-derives the `tsc &&` prefix from `packages/fields/package.json`. Drop the prefix and the gate reds, demanding the factory instead. That is strictly stronger than prose, which is why it was done this way rather than inventing a JSON comment convention across 39 manifests.

`fields` **does** get `createDtsExplicitExtensions` — measured 0 extensionless both before and after, because its sources already write explicit `.js` specifiers, so wiring it changes nothing today and stops it drifting back.

---

## #5439 is not "#5365 again" — this is the whole severity argument

A PR body that describes this as "wire the extensions module into more packages" loses the reason it matters.

- #5365's two packages re-export mostly through `export * from './ui'`. A star re-export from a module the compiler cannot resolve contributes **no names**, so the consumer gets a loud `TS2305: has no exported member` — a wall, hit immediately.
- **These** packages re-export mostly through **named** re-exports — `export { useObjectChat } from './useObjectChat'`. TypeScript still **declares** the name and merely fails to type it. The consumer gets **no error at all and a silent `any`**.

Proven on `@object-ui/plugin-chatbot` in #5439 by compiling the same built `dist` twice against a probe (generics spaced to survive GitHub's body sanitizer):

```
type IsAny< T > = 0 extends 1 & T ? true : false;
const assertAny: IsAny< typeof useHitlInChat > = true;
```

- `moduleResolution: nodenext` — compiles clean, i.e. the symbol **is** `any`.
- `moduleResolution: bundler` — `TS2322`, i.e. properly typed.

That is the worse of the two failure modes: it opens **quietly**, the moment a consumer pins `nodenext`, and it is what produces the 21 residual `TS7006` on `@object-ui/app-shell` reported in #5365's PR.

---

## Measurements

### #5483 — blast radius, re-measured on today's `main`: zero

`turbo run build --filter=!@object-ui/site --concurrency=2 --continue` with the factory wired into 21 call sites: **43/43 tasks successful**, 4m12s. None of the 22 dts packages was a cache hit (verified against the run's `cache hit` / `cache miss` lines — the 14 hits are `types`, `core`, `react`, `i18n`, `mobile`, `permissions`, `providers`, `auth`, `collaboration`, `sdui-parser`, `data-objectstack`, `react-runtime`, `create-plugin`, `object-ui`), so all 22 built fresh. Wiring turns nothing green red.

### #5439 — per package, built with the module wired before the final diff

`vite-dts-explicit-extensions` **throws** on any specifier it cannot resolve, so this half could have redded a currently-green build. It did not: same full build with both modules wired, **43/43 successful**, 3m45s, zero throws. **No package had to be left unwired**, so there is no finding of that kind to report.

Extensionless relative specifiers in emitted `dist/**/*.d.ts` (AST-located module specifiers, so JSDoc prose is excluded — the same criterion #5439 used), before → after:

| package | before | after | | package | before | after |
|---|---:|---:|---|---|---:|---:|
| `plugin-detail` | 82 | 0 | | `plugin-list` | 16 | 0 |
| `plugin-designer` | 62 | 0 | | `plugin-report` | 14 | 0 |
| `plugin-chatbot` | 53 | 0 | | `plugin-charts` | 9 | 0 |
| `plugin-grid` | 36 | 0 | | `plugin-calendar` | 5 | 0 |
| `plugin-dashboard` | 31 | 0 | | `plugin-timeline` | 4 | 0 |
| `plugin-form` | 31 | 0 | | `plugin-ai` | 3 | 0 |
| `plugin-kanban` | 22 | 0 | | `plugin-markdown` | 3 | 0 |
| `plugin-view` | 19 | 0 | | `plugin-editor` | 1 | 0 |
| `plugin-gantt` | 17 | 0 | | `plugin-map` | 1 | 0 |
| | | | | `plugin-tree` | 1 | 0 |

**410 → 0.** `components` (119 relative specifiers), `layout` (8) and `fields` (155) were already 0 and stay 0. The *before* column is a real rebuild, not an inference: the spread was reverted with `git checkout HEAD~1 --` after the fix was committed, the tree rebuilt, and the count re-taken; the restore was proven with an empty `git diff HEAD`.

Verification here is deliberately **not** "it still compiles" — named re-exports yield a silent `any`, so compiling proves nothing. It is a direct count driven to zero.

---

## The ratchet — `scripts/__tests__/vite-dts-wiring-ratchet.test.ts`

One AST walk over every `vite.config.*` under `packages/`, `apps/`, `examples/` that calls `dts(`, asserting **both** spreads. Verdict line carries the count:

```
vite-plugin-dts wiring ratchet — 22 dts( call sites of 26 vite configs
  ✓ finds a real population: 22 call sites, floor 15
  ✓ every dts( call site spreads createDtsExplicitExtensions
  ✓ every call site that spreads createDtsExplicitExtensions imports it from scripts/vite-dts-explicit-extensions.ts
  ✓ every dts( call site spreads createDtsFailOnTypeErrors
  ✓ every call site that spreads createDtsFailOnTypeErrors imports it from scripts/vite-dts-fail-on-type-errors.ts
  ✓ exclusions stay capped, and each one names a live call site
  ✓ every exclusion re-derives its stated reason from the tree
```

Detection is by AST, not substring: `toContain` is satisfied by the factory's name appearing in a **comment**, which is the exact shape of a call site someone disabled and explained. `dts` must also be the local name bound to the `vite-plugin-dts` default import, so a same-named local helper cannot join the population by coincidence.

### Non-vacuity, each direction predicted before it was run

1. **Positive control, extensions module** — dropped `...createDtsExplicitExtensions(...)` from `packages/layout/vite.config.ts`, leaving its import in place so the miss is the spread and not the import. Predicted: exactly one test red, naming the file and the module. Observed exactly that — `1 vite-plugin-dts call site(s) do not spread createDtsExplicitExtensions… - packages/layout/vite.config.ts`, `1 failed | 6 passed`.
2. **Positive control, fail-on-error module** — dropped `...createDtsFailOnTypeErrors(...)` from `packages/plugin-grid/vite.config.ts`, leaving the *other* factory's spread in place so the control is single-module. Observed: `1 failed | 6 passed`, naming `packages/plugin-grid/vite.config.ts` and that module. A gate that only noticed one would be half a gate.
3. **Population non-vacuity** — pointed the walk at a directory that does not exist. Predicted: red, not green. Observed **2 failed | 5 passed** — `expected 0 to be greater than or equal to 15`, plus the stale-exclusion guard. The 5 that still passed are precisely the vacuously-satisfiable ones, which is why the floor assertion exists.
4. **Exclusion re-derivation** — removed the `tsc &&` prefix from `packages/fields`'s build script. Observed: red, `The reason packages/fields/vite.config.ts is exempt from createDtsFailOnTypeErrors no longer holds`.

Every mutation was proven on disk by anchored counts of the injected and the removed text — never an editor's exit code — and every restore by an empty `git diff HEAD`.

### End-to-end for #5483

One deliberate `TS2322` appended to `packages/plugin-tree/src/index.tsx`, exit code read from `${PIPESTATUS[0]}` as the card did, same injection both legs:

| leg | `packages/plugin-tree/vite.config.ts` | `pnpm --filter @object-ui/plugin-tree build` |
|---|---|---|
| A | reverted to `origin/main` (unwired) | **exit 0**, with `TS2322` printed in the log |
| B | as this branch ships it (wired) | **exit 1**, `Error: [dts-fail-on-type-errors] the declaration build … reported 1 type error, so it must not exit 0: src/index.tsx(49,14): error TS2322` |

Restored, proven with an empty `git diff HEAD`.

---

## Gates run locally, on final head `beeb94058`

Gate list derived from `package.json` and `.github/workflows/`, not from the dispatch. Exit codes captured by redirect before any pipe.

| gate | exit |
|---|---|
| `pnpm exec vitest run scripts/` (root vitest, objectui#3378) | 0 — **72 files, 1967 tests passed** |
| `pnpm lint` | 0 — 47/47 tasks, 0 cached (full repo, not narrowed) |
| `pnpm lint:root` | 0 — 0 errors, 28 pre-existing warnings |
| `pnpm type-check` | 0 — 81/81 tasks |
| `pnpm type-check:scripts` / `:coverage` / `pnpm lint:coverage` | 0 / 0 / 0 |
| `pnpm check:esm-specifiers`, `check:node-esm-load`, `check:published-dist` | 0 |
| `pnpm check:phantom-deps`, `check:self-import`, `check:entry-guard` | 0 |
| `pnpm check:spec-symbols`, `check:action-forward-parity`, `check:designer-field-key-parity`, `check:icon-record-names` | 0 |
| `pnpm check:i18n-keys`, `check:i18n-drift`, `check:skills-paths` | 0 |
| `node scripts/check-control-bytes.mjs` | 0 — 5115 files scanned |
| `check-changeset-presence` / `-no-major` / `-fixed` | 0 / 0 / 0 |

Heavy runs were serialised through the container's shared verify lock.

## Changeset

A real one, not `skip-changeset`: this changes **published typings**. `check-changeset-presence` says none is owed (no published `src/` changed — only build configs), which is exactly the gap worth writing through by hand. Bumps are `patch`; per AGENTS.md no changeset in this repo declares `major`.

Downstream `TS2305` / `TS7006` surfacing in consumers is **the fix working**, not a regression: those call sites were being handed a silent `any`.

## Scope

The `vite.config.ts` files of both sets, `fields`'s one clarifying comment, the ratchet and its test, and the changeset. Neither shared module's behaviour was touched — both are landed and pinned by existing call sites, and their own unit tests (`scripts/__tests__/vite-dts-*.test.ts`) are unchanged and green. No pre-existing type error was fixed; none surfaced.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_