### PR TITLE
docs(components): cover packages/components/README.md with the doc-snippet type gate

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -175,6 +175,7 @@ them draw the notification's `severity` icon unless it declares an `icon`
 override naming a real Lucide icon. See the
 [notifications guide](https://objectui.org/docs/guide/notifications).
 
+<!-- doc-snippet: fragment — router-layout excerpt: `Outlet` is react-router's, supplied by the host application -->
 ```tsx
 import { NotificationBanners, NotificationAlerts } from '@object-ui/components';
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -456,8 +456,6 @@ const UNGATED_DOCS = {
     '1 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 15 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2741x1 — candidate real defects, un-triaged',
   'packages/collaboration/README.md':
     '13 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x2 TS2353x1 TS2554x1 TS2739x1 — candidate real defects, un-triaged',
-  'packages/components/README.md':
-    '1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/core/README.md':
     '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the ' +
     'page never defines; plus TS2339x1 — TRIAGED, and NOT a defect: the remaining one is ' +


### PR DESCRIPTION
Fixes #5259

Implements the 2026-08-19 maintainer ruling (「全部接受」, Option A): declare the one remaining fragment, delete the `UNGATED_DOCS` ledger entry, and accept the filter growth. `packages/components/README.md` — a README that ships to npm — moves from unverified to permanently gated.

## What changed

- `packages/components/README.md`: the router-layout excerpt at the notification-surfaces section carries the documented fragment marker. `Outlet` is react-router's, supplied by the host application — precisely the case `scripts/check-doc-snippet-types.mjs` names in its own header ("a call into the host's own router"). The marker spelling was taken verbatim from `FRAGMENT_MARKER_EXAMPLES` in the gate's source, not from the card (the card's body shows an empty fence there — GitHub's sanitizer ate it).
- `scripts/check-doc-snippet-types.mjs`: the `packages/components/README.md` entry is deleted from `UNGATED_DOCS`. No other ledger entry and no gate logic touched.

## Premise re-derivation — confirmed, with one correction to the cost figure

The card's "1 diagnostic" figure is from 2026-08-18. Re-derived on today's `main` (`e9e55524e`), it is exactly right, same code and same line:

```
[semantic]  packages/components/README.md:183:4  TS2304: Cannot find name 'Outlet'.
Semantic phase: 256 of 256 block(s) judged, 1 failed.
```

Nothing else. No further host fragments, no real defects, nothing needing classification.

**The build-filter figure, however, is stale — and the correction runs in the cheap direction.** The card priced this at 11 -> 15 packages. On today's `main` the filter is already **20** packages, and it already contains `@object-ui/components` and `@object-ui/i18n`, put there by documents covered in the seven days since. So the measured delta of this PR is:

| | before | after |
|---|---|---|
| filter size | 20 | 20 |
| delta | — | **+0 packages** |

Both lists are byte-identical:

```
--filter=@object-ui/app-shell --filter=@object-ui/auth --filter=@object-ui/cli --filter=@object-ui/components --filter=@object-ui/core --filter=@object-ui/data-objectstack --filter=@object-ui/fields --filter=@object-ui/i18n --filter=@object-ui/plugin-charts --filter=@object-ui/plugin-dashboard --filter=@object-ui/plugin-detail --filter=@object-ui/plugin-editor --filter=@object-ui/plugin-form --filter=@object-ui/plugin-grid --filter=@object-ui/plugin-kanban --filter=@object-ui/plugin-markdown --filter=@object-ui/plugin-timeline --filter=@object-ui/plugin-view --filter=@object-ui/react --filter=@object-ui/types
```

The reason is mechanical, not a measurement artifact: this README imports only `@object-ui/components`, `@object-ui/react` and `@object-ui/core`, and all three are already in the filter. `@object-ui/react-runtime` and `@object-ui/sdui-parser` are absent from the emitted filter both before and after — they are transitive dependencies turbo pulls in topologically, not packages the gate emits. The ruled cost was +4; the realised cost is **0**, so this lands strictly inside what the ruling priced.

## Coverage is real, not cosmetic — the non-vacuity control

A zero filter delta is exactly the signature the dispatch order warns about ("a silent no-op wearing a green tick"), so coverage was proven directly instead of inferred from the filter. A fabricated export was injected into a **different** `tsx` block of this README — the `registerDefaultRenderers`-shaped fabrication the card names by name — and the gate went red on it:

```
[semantic]  packages/components/README.md:209:18  TS2305: Module '"@object-ui/components"' has no exported member 'registerDefaultRenderers'.
Semantic phase: 255 of 255 block(s) judged, 1 failed.   (exit 1)
```

Mutation and restore were both proven on disk by anchored counts, never by an editor's exit code; the restore leg left `git diff HEAD` empty. That block was unverified before this PR and is verified after it, which is the whole value of the change.

## Verification at `a74f8d748`

| check | result |
|---|---|
| `check:doc-snippets` | exit 0 — *"Every covered documentation snippet compiles against the built types."* `255 of 255 block(s) judged, 0 failed`; controls (resolution / sentinel / positive / undeclared) all green |
| `check:doc-fences` | exit 0 |
| `check:doc-types` | exit 0 |
| `check:control-bytes` | exit 0 (5118 tracked text files) |
| `check-changeset-presence.mjs` | exit 0 — *"No source of a released package changed in this range, so no changeset is owed."* |
| `vitest run scripts/__tests__/check-doc-snippet-types.test.ts` | exit 0 — 30 passed |

Ledger accounting moved as expected: covered blocks `367 — 255 to compile, 112 declared fragment(s)` (was `256 to compile, 111 declared fragment(s)`). Build was the gate's own derived filter, `turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2`, exit 0.

No changeset: the repo's own presence gate reports none owed, and the README edit is an HTML comment that no reader or renderer sees.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_