### PR TITLE
fix(components,plugin-grid): fire column-state persistence on column resize and reorder

### DIFF
--- a/.changeset/6175-column-state-persistence.md
+++ b/.changeset/6175-column-state-persistence.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/components': patch
+'@object-ui/plugin-grid': patch
+---
+
+Column width and order that a user drags in `ObjectGrid` now actually persist
+(objectui#6175). Both halves of `saveColumnState`'s only two call sites were dead, so a
+drag was written nowhere — not to `localStorage`, not through `onColumnStateChange` to the
+host's `dataSource.updateViewConfig`. The saved state was read back correctly forever; it
+was simply never written.
+
+Two independent breaks, one per package:
+
+- **`@object-ui/components`** — `DataTableSchema` has declared
+  `onColumnResize?: (columnKey, width) => void` all along, and `data-table.tsx` invoked it
+  **nowhere**: the resize drag updated the table's local `columnWidths` state and stopped
+  there. It now reports the settled width once, at `mouseup`. Once, deliberately — the host
+  turns this callback into a write to shared view config, so a per-`mousemove` callback
+  would be a write storm.
+- **`@object-ui/plugin-grid`** — `ObjectGrid` emitted `onColumnReorder` (singular) while the
+  renderer invokes the near-duplicate `onColumnsReorder` (with the `s`), a different declared
+  key with a different signature. The producer now emits the spelling the renderer actually
+  invokes, mapping the reported `TableColumn[]` to the `accessorKey` order `columnState`
+  stores.
+
+**Nothing is retired.** Both spellings remain declared on `DataTableSchema`;
+`onColumnReorder` stays declared and stays unwired, exactly as the `RuntimeOnlyDeclared`
+ledger in `zod-mirror-parity.test.ts` records it. Which of the two survives is a
+declared-surface ruling that stays open and is deliberately not settled here.
+
+⚠️ Behavioural note for hosts: `onColumnStateChange` now fires where it previously never
+did, which means `dataSource.updateViewConfig` is now reached on a column drag. That call
+was unreachable by this path before, so any permission gate on that write now sees traffic
+it never saw.
+
+The renderer's resize/reorder gestures, the inbound seeding of `columnState`, and the
+declared surface are all unchanged.

--- a/packages/components/src/renderers/complex/__tests__/data-table-column-resize-callback.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-column-resize-callback.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `DataTable` reports a settled column resize through `onColumnResize`
+ * (objectui#6175).
+ *
+ * `DataTableSchema` has declared `onColumnResize?: (columnKey, width) => void`
+ * (`data-display.ts:791`) all along, and this renderer invoked it NOWHERE — the
+ * resize drag mutated local `columnWidths` state and stopped there. ObjectGrid's
+ * `saveColumnState` hung off exactly that key, so no user-dragged column width
+ * ever reached `localStorage` or the host's `dataSource.updateViewConfig`.
+ *
+ * ⚠️ These assertions observe the CALL, not a rendered width: the drag already
+ * applied the width to local state before the fix, so anything that only inspects
+ * the DOM after a drag passes on the UNFIXED renderer too.
+ *
+ * Spies are created per case — no module-level mock carrying one case's calls
+ * into the next.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import '../data-table';
+
+const baseSchema = {
+  columns: [
+    { header: 'Name', accessorKey: 'name' },
+    { header: 'Amount', accessorKey: 'amount' },
+  ],
+  data: [{ name: 'Alice', amount: 100 }],
+  pagination: false,
+  searchable: false,
+};
+
+function renderTable(extra: Record<string, any>) {
+  const DataTable = ComponentRegistry.get('data-table') as any;
+  if (!DataTable) throw new Error('data-table not registered');
+  return render(<DataTable schema={{ ...baseSchema, ...extra }} />);
+}
+
+function resizeHandleFor(header: string): HTMLElement {
+  const th = screen.getByText(header).closest('th') as HTMLElement;
+  expect(th).toBeTruthy();
+  const handle = th.querySelector('.cursor-col-resize') as HTMLElement;
+  expect(handle).toBeTruthy();
+  return handle;
+}
+
+describe('data-table reports column resizes to the host', () => {
+  it('fires onColumnResize once at mouseup, with the column key and settled width', () => {
+    const onColumnResize = vi.fn();
+    renderTable({ resizableColumns: true, onColumnResize });
+
+    fireEvent.mouseDown(resizeHandleFor('Name'), { clientX: 100 });
+    expect(onColumnResize).not.toHaveBeenCalled();
+
+    // Two moves in ONE drag: the host turns this callback into a persisted write
+    // to shared view config, so it must report the settled value once rather than
+    // stream every intermediate width.
+    fireEvent.mouseMove(document, { clientX: 200 });
+    fireEvent.mouseMove(document, { clientX: 260 });
+    expect(onColumnResize).not.toHaveBeenCalled();
+
+    fireEvent.mouseUp(document);
+
+    expect(onColumnResize).toHaveBeenCalledTimes(1);
+    expect(onColumnResize).toHaveBeenCalledWith('name', 160);
+  });
+
+  it('does not fire when the drag never moved', () => {
+    const onColumnResize = vi.fn();
+    renderTable({ resizableColumns: true, onColumnResize });
+
+    fireEvent.mouseDown(resizeHandleFor('Amount'), { clientX: 100 });
+    fireEvent.mouseUp(document);
+
+    expect(onColumnResize).not.toHaveBeenCalled();
+  });
+});

--- a/packages/components/src/renderers/complex/__tests__/data-table-column-resize-callback.test.tsx
+++ b/packages/components/src/renderers/complex/__tests__/data-table-column-resize-callback.test.tsx
@@ -75,6 +75,15 @@ describe('data-table reports column resizes to the host', () => {
     expect(onColumnResize).toHaveBeenCalledWith('name', 160);
   });
 
+  /**
+   * ⚠️ Measured: this case is the ONE assertion here that still PASSES on a
+   * revert of the fix — the unfixed renderer fires nothing at all, so "did not
+   * fire" is trivially true there. It is a guard against over-firing (a future
+   * per-mousemove or per-mouseup-without-drag callback would redden it), NOT a
+   * pin of the fix. The three cases that DO distinguish the two states of the
+   * world are the one above and both cases in
+   * `plugin-grid/src/__tests__/columnStatePersistence.test.tsx`.
+   */
   it('does not fire when the drag never moved', () => {
     const onColumnResize = vi.fn();
     renderTable({ resizableColumns: true, onColumnResize });

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -927,6 +927,12 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const resizingColumn = useRef<string | null>(null);
   const startX = useRef<number>(0);
   const startWidth = useRef<number>(0);
+  /**
+   * Final width produced by the in-flight drag, so `handleResizeEnd` can report
+   * it once. It has to be a ref, not state: the document-level listeners are one
+   * render's closures and cannot observe a later `columnWidths` update.
+   */
+  const lastResizeWidth = useRef<number | null>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
   // When an edit ends via Enter (already saved) or Escape (cancelled), the
   // input also blurs. This flag tells the blur handler not to save again so we
@@ -1282,6 +1288,7 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
     
     resizingColumn.current = columnKey;
     startX.current = e.clientX;
+    lastResizeWidth.current = null;
     
     const headerCell = (e.target as HTMLElement).closest('th');
     if (headerCell) {
@@ -1302,12 +1309,25 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
       ...prev,
       [resizingColumn.current!]: newWidth
     }));
+    lastResizeWidth.current = newWidth;
   };
 
   const handleResizeEnd = () => {
+    const resizedColumn = resizingColumn.current;
+    const finalWidth = lastResizeWidth.current;
     resizingColumn.current = null;
+    lastResizeWidth.current = null;
     document.removeEventListener('mousemove', handleResizeMove);
     document.removeEventListener('mouseup', handleResizeEnd);
+    // objectui#6175: report the SETTLED width, once, at mouseup — never per
+    // mousemove. `onColumnResize` was declared here and invoked nowhere, which
+    // is why ObjectGrid's `saveColumnState` never ran and column widths never
+    // persisted. The host turns this into a real write (localStorage plus
+    // `onColumnStateChange` -> `dataSource.updateViewConfig`), so a per-move
+    // callback would be a write storm on shared view config.
+    if (resizedColumn && finalWidth != null) {
+      schema.onColumnResize?.(resizedColumn, finalWidth);
+    }
   };
 
   // Column reordering handlers

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -3087,10 +3087,21 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
         widths: { ...columnState.widths, [columnKey]: width },
       });
     },
-    onColumnReorder: (newOrder: string[]) => {
+    // objectui#6175: the renderer invokes `onColumnsReorder` (with the `s`) —
+    // `data-table.tsx:handleColumnDrop` — and has never invoked the singular
+    // `onColumnReorder` this used to emit, so reorders were never persisted.
+    // Producer-side fix (AGENTS #0.1: fix the producer, don't teach the renderer
+    // a second spelling), which retires nothing: `onColumnReorder` stays declared
+    // on `DataTableSchema` and stays unwired, exactly as the RuntimeOnlyDeclared
+    // ledger records it. Which of the two declared spellings survives is still an
+    // open ruling and is deliberately NOT settled here.
+    onColumnsReorder: (newColumns: any[]) => {
+      const order = newColumns
+        .map((c) => c?.accessorKey)
+        .filter((key): key is string => typeof key === 'string' && key.length > 0);
       saveColumnState({
         ...columnState,
-        order: newOrder,
+        order,
       });
     },
   };

--- a/packages/plugin-grid/src/__tests__/columnStatePersistence.test.tsx
+++ b/packages/plugin-grid/src/__tests__/columnStatePersistence.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * ObjectGrid column-state persistence — the OUTBOUND half (objectui#6175).
+ *
+ * The inbound half (seed `columnState` from the host / localStorage, re-sync on
+ * external change) already worked and is pinned by `gridNonAuthorKeys.test.tsx`.
+ * The outbound half was DEAD: `saveColumnState` (`ObjectGrid.tsx:661`) had exactly
+ * two call sites — `onColumnResize` and `onColumnReorder` on the synthesised
+ * `dataTableSchema` — and `data-table.tsx` invoked NEITHER, so a user's drag was
+ * never written anywhere.
+ *
+ * ⚠️ These tests deliberately observe the WRITE, never the read-back. A test that
+ * seeds a width and re-reads it passes with the outbound half still dead, because
+ * the inbound half is what answers it. Each case therefore asserts on BOTH outbound
+ * channels of `saveColumnState`:
+ *   1. `localStorage.setItem(columnStorageKey, …)` — the per-browser fallback, and
+ *   2. the `onColumnStateChange` prop — the host channel that `ObjectView` turns
+ *      into `dataSource.updateViewConfig`.
+ *
+ * Every spy and the storage are recreated per case (no module-level mock object
+ * carrying one case's write into the next).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { __clearRecordCrudVerdictCache } from '../hooks/useRecordCrudVerdicts';
+import { installExplainDouble } from './explainDouble';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+const rows = [
+  { id: '1', name: 'Alice', amount: 100 },
+  { id: '2', name: 'Bob', amount: 200 },
+];
+
+beforeEach(() => {
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
+  localStorage.clear();
+});
+afterEach(() => { vi.unstubAllGlobals(); localStorage.clear(); });
+
+const STORAGE_KEY = 'grid-columns-test_object';
+
+function renderGrid(onColumnStateChange: (s: any) => void, opts?: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'test_object',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'amount', label: 'Amount', type: 'number' },
+    ],
+    data: { provider: 'value', items: rows },
+    ...opts,
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} onColumnStateChange={onColumnStateChange} />
+    </ActionProvider>
+  );
+}
+
+/** Drag the resize handle of the header cell whose label is `header`. */
+function dragResize(container: HTMLElement, header: string, byPx: number) {
+  const th = screen.getByText(header).closest('th') as HTMLElement;
+  expect(th).toBeTruthy();
+  const handle = th.querySelector('.cursor-col-resize') as HTMLElement;
+  expect(handle).toBeTruthy();
+  fireEvent.mouseDown(handle, { clientX: 100 });
+  fireEvent.mouseMove(document, { clientX: 100 + byPx });
+  fireEvent.mouseUp(document);
+}
+
+describe('ObjectGrid column-state persistence (outbound half)', () => {
+  it('writes the new width to localStorage AND notifies the host when a column is resized', async () => {
+    const onColumnStateChange = vi.fn();
+    const { container } = renderGrid(onColumnStateChange);
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+
+    expect(onColumnStateChange).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    dragResize(container, 'Name', 160);
+
+    // Channel 1 — the host callback that reaches dataSource.updateViewConfig.
+    await waitFor(() => expect(onColumnStateChange).toHaveBeenCalled());
+    const notified = onColumnStateChange.mock.calls.at(-1)![0];
+    expect(notified.widths).toEqual({ name: 160 });
+
+    // Channel 2 — the per-browser fallback.
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).widths).toEqual({ name: 160 });
+  });
+
+  it('writes the new order to localStorage AND notifies the host when columns are reordered', async () => {
+    const onColumnStateChange = vi.fn();
+    renderGrid(onColumnStateChange, { reorderableColumns: true });
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+
+    expect(onColumnStateChange).not.toHaveBeenCalled();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+    const nameTh = screen.getByText('Name').closest('th') as HTMLElement;
+    const amountTh = screen.getByText('Amount').closest('th') as HTMLElement;
+    const dataTransfer = { effectAllowed: '', dropEffect: '' };
+    fireEvent.dragStart(nameTh, { dataTransfer });
+    fireEvent.dragOver(amountTh, { dataTransfer });
+    fireEvent.drop(amountTh, { dataTransfer });
+
+    await waitFor(() => expect(onColumnStateChange).toHaveBeenCalled());
+    const notified = onColumnStateChange.mock.calls.at(-1)![0];
+    expect(notified.order).toEqual(['amount', 'name']);
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!).order).toEqual(['amount', 'name']);
+  });
+});

--- a/packages/plugin-grid/src/__tests__/columnStatePersistence.test.tsx
+++ b/packages/plugin-grid/src/__tests__/columnStatePersistence.test.tsx
@@ -65,7 +65,7 @@ function renderGrid(onColumnStateChange: (s: any) => void, opts?: Record<string,
 }
 
 /** Drag the resize handle of the header cell whose label is `header`. */
-function dragResize(container: HTMLElement, header: string, byPx: number) {
+function dragResize(header: string, byPx: number) {
   const th = screen.getByText(header).closest('th') as HTMLElement;
   expect(th).toBeTruthy();
   const handle = th.querySelector('.cursor-col-resize') as HTMLElement;
@@ -78,13 +78,13 @@ function dragResize(container: HTMLElement, header: string, byPx: number) {
 describe('ObjectGrid column-state persistence (outbound half)', () => {
   it('writes the new width to localStorage AND notifies the host when a column is resized', async () => {
     const onColumnStateChange = vi.fn();
-    const { container } = renderGrid(onColumnStateChange);
+    renderGrid(onColumnStateChange);
     await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
 
     expect(onColumnStateChange).not.toHaveBeenCalled();
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 
-    dragResize(container, 'Name', 160);
+    dragResize('Name', 160);
 
     // Channel 1 — the host callback that reaches dataSource.updateViewConfig.
     await waitFor(() => expect(onColumnStateChange).toHaveBeenCalled());

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -985,13 +985,19 @@ interface UnmirroredDeclared {
 interface RuntimeOnlyDeclared {
   /**
    * 12 of `DataTableSchema`'s former 29. OVERSIGHT group — this mirror already
-   * declares four callbacks. ⚠️ Two of these are additionally read NOWHERE:
-   * `onColumnResize`/`onColumnReorder` are the only call sites of `saveColumnState`
-   * and `data-table.tsx` invokes neither, so column-state persistence never fires
-   * (objectui#6175, filed separately — NOT fixed by this reclassification). And
-   * `onColumnReorder` is a near-duplicate of the MIRRORED `onColumnsReorder`: one
-   * event, two declared spellings, different signatures. Which spelling survives is
-   * an open ruling and is deliberately not settled here.
+   * declares four callbacks. ⚠️ `onColumnReorder` is still read NOWHERE, and
+   * deliberately so. objectui#6175 repaired the persistence half this entry used to
+   * describe: `onColumnResize` is now invoked by `data-table.tsx` (at the end of a
+   * resize drag), and ObjectGrid now emits the MIRRORED near-duplicate
+   * `onColumnsReorder` — the spelling the renderer already invoked — instead of the
+   * singular `onColumnReorder` it used to write and nothing read. So column-state
+   * persistence DOES fire now, and `onColumnReorder` is left declared, mirrored by
+   * nothing, and wired to nothing.
+   *
+   * That residue is the open question, not an oversight: one event, two declared
+   * spellings, different signatures. objectui#6175 wired persistence WITHOUT
+   * retiring anything, because retiring either spelling is a declared-surface change
+   * and that ruling is still OPEN. Nothing about this entry's membership changed.
    */
   'data-display.zod.ts#DataTableSchema':
     | 'onAddRecord' | 'onBatchSave' | 'onCellChange' | 'onColumnReorder' | 'onColumnResize'


### PR DESCRIPTION
Fixes #6175

A user drags a column wider or reorders columns in `ObjectGrid`, and nothing persists. The
saved state is read back correctly forever; it is simply never written. Both call sites of
`saveColumnState` were dead, for two *different* reasons — one per package.

## Re-derived line numbers (measured at `2c8474c04`, the merge-base of this branch)

The card's numbers were measured 2026-08-24 22:29Z. Re-derived here; every one still held.

| Site | Line | Note |
|---|---|---|
| `saveColumnState` definition | `ObjectGrid.tsx:661` | unchanged |
| `onColumnStateChange` notify inside it | `ObjectGrid.tsx:669-670` | unchanged |
| `const dataTableSchema: any` | `ObjectGrid.tsx:2937` | unchanged |
| `onColumnResize` producer call site | `ObjectGrid.tsx:3084` | unchanged |
| `onColumnReorder` producer call site | `ObjectGrid.tsx:3090` | unchanged |
| `SchemaRenderer schema={dataTableSchema}` | `ObjectGrid.tsx:3735` | unchanged |
| `onColumnsReorder` — the renderer's only reorder call | `data-table.tsx:1346-1347` | unchanged |
| `onColumnResize` in `data-table.tsx` | — | **zero occurrences**, confirmed |
| `onColumnReorder` in `data-table.tsx` | — | **zero occurrences**, confirmed |
| `onColumnsReorder?: (columns: TableColumn[]) => void` | `data-display.ts:718` | unchanged |
| `onColumnResize?: (columnKey, width) => void` | `data-display.ts:791` | unchanged |
| `onColumnReorder?: (newOrder: string[]) => void` | `data-display.ts:796` | unchanged |

One site the card did not name and that mattered: `ObjectGrid.tsx:2992` sets
`reorderableColumns: schema.reorderableColumns ?? false`, so grid reordering is **off by
default** — the reorder test has to enable it explicitly or it measures nothing.

## The change

**`@object-ui/components` — `data-table.tsx`.** `DataTableSchema` declared `onColumnResize`
all along and this renderer invoked it nowhere: the drag updated local `columnWidths` state
and stopped. `handleResizeEnd` now reports the settled width **once, at `mouseup`**, via a
`lastResizeWidth` ref (the document listeners are one render's closures and cannot read a
later state update). Once, deliberately: the host turns this into a write to shared view
config, so a per-`mousemove` callback would be a write storm.

**`@object-ui/plugin-grid` — `ObjectGrid.tsx`.** The producer emitted `onColumnReorder`
(singular) while the renderer invokes the near-duplicate `onColumnsReorder` (with the `s`) —
a different declared key with a different signature. The producer now emits the spelling the
renderer actually invokes, mapping the reported `TableColumn[]` to the `accessorKey` order
`columnState` stores.

Producer-side, per AGENTS.md #0.1 (*fix the producer, don't add a lenient alias in the
consumer*). Teaching the renderer to *also* call the singular spelling was the alternative
and is rejected here: it would give one event two live call paths, which is the
consumer-side dialect that commandment bans — and it would make the open ruling below
strictly harder, converting a dead-key removal into a behaviour change.

## ⛔ Nothing is retired, and the deferred ruling is left standing

Both spellings remain declared on `DataTableSchema`; `packages/types/src/data-display.ts` is
untouched. `onColumnReorder` stays declared and stays unwired — exactly its status before
this branch. **The two-spelling ruling was not needed and was not taken.** PR #6181 parked
that ruling on the card this branch implements, and it is still parked: which spelling
survives is a declared-surface change and remains open.

**Which spelling the renderer invokes after this change: `onColumnsReorder`, the same one it
invoked before.** The renderer's reorder path is unchanged. `onColumnReorder` is
**unchanged in reachability too — still declared, still invoked by nothing.** What changed
is that it is no longer *emitted* by ObjectGrid either, so it is now dead on both ends
rather than written-but-unread.

## ⚠️ Interaction with the permission gate in flight

`onColumnStateChange` reaches `dataSource.updateViewConfig`. That path was **unreachable
from a column drag** before this branch and is reachable now — a resize or reorder now
produces a real write to shared view config where it previously produced none. Any
permission gate on that write (#5232, via PR #6125) will therefore see traffic on a path
that had never carried any. `updateViewConfig` itself is not touched here.

## ⛔ Not repaired here (deliberately)

`const dataTableSchema: any` (`ObjectGrid.tsx:2937`) is the enabling cause and is left
alone — it belongs to #6004, not to this branch. **A typed handoff would have caught the
reorder half and not the resize half:** with a real `DataTableSchema` on the producer,
`onColumnReorder` would still have type-checked (it is genuinely declared, with the exact
signature ObjectGrid used) — the two declared spellings defeat the type. The resize half is
different: no type system flags a consumer that never reads a declared optional key. That
asymmetry is worth carrying to #6004.

## Verification

Reproduce-before-fix, then ablate-after-commit. Both directions predicted before running.

- **Repro (before the change):** both `columnStatePersistence` cases red, and red for a
  *value* reason — `AssertionError: expected "vi.fn()" to be called at least once`, not a
  query or harness error.
- **Ablation (change reverted, tests kept, restore under `trap … EXIT INT TERM`):** 3 of 4
  cases red; `git diff HEAD --stat` empty afterwards. Mutation proven on disk both ways —
  injected strings absent, removed strings back, with `handleResizeEnd` / `saveColumnState`
  as controls present in **both** versions of each file.
- **⚠️ The one assertion that survives a revert:** `does not fire when the drag never moved`.
  The unrepaired renderer fires nothing at all, so "did not fire" is trivially true there.
  It is a guard against over-firing, not a pin of the change, and the test file says so
  inline. The three cases that do distinguish the two states of the world are the other
  three.

The pins observe the **write**, never the read-back: `localStorage` actually written **and**
`onColumnStateChange` actually fired. A test that seeds a width and re-reads it passes with
the outbound half still dead, because the already-working inbound half answers it.

| Gate | Command | Exit |
|---|---|---|
| `type-check` (both packages, uncached) | `turbo run type-check --filter=@object-ui/components --filter=@object-ui/plugin-grid --force` | **0** — `Tasks: 15 successful, 15 total` |
| `type-check` downstream sweep, uncached | `turbo run type-check --filter='...@object-ui/components' --filter='...@object-ui/plugin-grid' --force` | **0** — `Tasks: 66 successful, 66 total`, 31 packages |
| vitest, both packages | `pnpm exec vitest run packages/plugin-grid packages/components` | **0** — `273 passed (273)` files, `2516 passed (2516)` |
| vitest, `packages/types` | `pnpm exec vitest run packages/types` | **0** — `58 passed (58)` files, `632 passed (632)` |
| eslint (merge-base delta, plain) | `pnpm exec eslint` over the 5 changed paths | **0** — 0 errors |
| `check-control-bytes` | `node scripts/check-control-bytes.mjs` | **0** — `scanned 5125 tracked text file(s)` |
| `check-lint-coverage` | `node scripts/check-lint-coverage.mjs` | **0** — `46/46 packages linted` |
| `check-type-check-coverage` | `node scripts/check-type-check-coverage.mjs` | **0** — `41/41 packages compile their tests` |
| `check-changeset-presence` | `node scripts/check-changeset-presence.mjs` | **0** — 1 changeset for 5 source files |
| `check-changeset-no-major` | `node scripts/check-changeset-no-major.mjs` | **0** — changeset is `patch` |

The downstream filter direction is **demonstrated, not asserted**: `--filter '...@object-ui/components'`
resolves to 31 packages including `plugin-grid`, `app-shell`, `console` and all four
`example-*` apps (consumers); `--filter '@object-ui/components...'` resolves to 9 including
`types`, `core`, `react` (dependencies). The prefix form is the downstream one, and it is
what ran — so `./examples/**` is built and type-checked here.

Every turbo gate treated as evidence ran with `--force`; `Cached: 0 cached` on the run that
reports it. The ratchet-family gates and eslint were re-run on the final head
**`a31843d79`** with a clean tree, after the last commit.

## Deviation from the declared file surface, declared

The dispatch named `data-table.tsx`, `ObjectGrid.tsx`, tests and a changeset. One file
beyond that is touched: `packages/types/src/__tests__/zod-mirror-parity.test.ts` — a **doc
comment only**, no assertion and no ledger membership changed (that file's 5 tests pass, and
`RuntimeOnlyDeclared` is about zod *mirroring*, not about being read). Its
`RuntimeOnlyDeclared` note stated that `onColumnResize` is "read NOWHERE" and that
"column-state persistence never fires". After this branch both sentences are false, and the
note names this very card — leaving it would have left a documented falsehood pointing at
its own repair. The note now restates the two-spelling residue as the deliberate open ruling
it is. No changeset bump for `@object-ui/types`: the change is a comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_