### PR TITLE
ci(release): validate the post-version tree before the version PR is refreshed

### DIFF
--- a/.changeset/5397-release-pr-post-version-validation.md
+++ b/.changeset/5397-release-pr-post-version-validation.md
@@ -1,0 +1,8 @@
+---
+---
+
+CI-only: the changeset release workflow's refresh lane now renders the
+post-version tree, validates the surfaces `changeset version` can move
+(`QUICK_REFERENCE.md`, the generated `CHANGELOG.md` files, the manifest
+versions as the tooling suite reads them) and restores the tree before
+`changesets/action` opens or updates the version PR. No package changes.

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -92,6 +92,17 @@ name: Changeset Release
 #                                          someone can get wrong.
 #   dispatch without the input          -> NOTHING, loudly. See the input's note.
 #
+# THE REFRESH LANE VALIDATES WHAT IT IS ABOUT TO RENDER (objectui#5397)
+# ---------------------------------------------------------------------
+# The release PR runs no CI and cannot be made to — 849 `ci.yml` runs on
+# `changeset-release/main`, every recent one `action_required`, created and
+# parked with nothing executed — so the release commit is the only commit that
+# reaches `main` without passing the merge queue. Before the refresh step
+# invokes the action, this job therefore renders the post-version tree itself,
+# validates the surfaces the version step can move, and puts the tree back. The
+# ruling, the measurements that chose that scope over a 40-minute `pnpm test`,
+# and why the restore is load-bearing are at "POST-VERSION VALIDATION" below.
+#
 # WHY THE PUBLISH LANE IS KEYED ON npm AND NOT ON `.changeset/`
 # -------------------------------------------------------------
 # It used to be keyed on "does this commit carry pending changesets?", and that
@@ -843,6 +854,196 @@ jobs:
 
           echo "::error::${ANCHOR_PKG}@${EXPECTED} is STILL not on npm after a publish run that reported success. The repository declares a version the registry has never seen — this is objectui#5442's silent failure, made loud. Check the 'Publish to npm' step's log for which branch changesets/action took."
           exit 1
+
+      # ══════════════════════════════════════════════════════════════════════
+      # POST-VERSION VALIDATION — THE ONLY GATE THE RELEASE COMMIT EVER PASSES
+      # (objectui#5397)
+      # ══════════════════════════════════════════════════════════════════════
+      # The release PR runs NO CI, and cannot be made to. Re-measured
+      # 2026-08-25: `ci.yml` has 849 runs on `changeset-release/main` and every
+      # recent one is `action_required` with
+      # `created_at == run_started_at == updated_at` — created and immediately
+      # parked, nothing executed. GitHub does not start workflow runs from
+      # events raised by `GITHUB_TOKEN`, and the refresh step below force-pushes
+      # that branch, so there is no stable head for a human to re-run against
+      # either. On the 17.6.0 release PR the check-runs endpoint returned
+      # `total_count: 1` — one job, started 7 SECONDS AFTER the merge. The
+      # largest machine-generated diff of the week is therefore the only commit
+      # that reaches `main` without passing the merge queue.
+      #
+      # Maintainer ruling 2026-08-22 (「接受所有」): validate the POST-VERSION
+      # tree HERE, before the action opens or updates the PR. Not by giving the
+      # PR a PAT / GitHub App token (widens the supply-chain trust surface and
+      # adds rotation obligations), and not by guaranteeing outputs one artifact
+      # at a time (objectui#5396 saved exactly one doc row and did not
+      # generalise). The ruling attached a condition — PRICE IT FIRST — and the
+      # price is what chose the shape below.
+      #
+      # WHY THIS IS NOT `pnpm test` (measured 2026-08-25, not argued)
+      # ------------------------------------------------------------
+      # The naive reading of the ruling is "run the suite on the post-version
+      # tree". It is the wrong shape, because THE VERSION STEP CANNOT MOVE A
+      # SOURCE BYTE. Rendered against this repository's real tree (328 pending
+      # changesets, 17.6.0 -> 17.7.0) `pnpm changeset:version` touches 411 paths
+      # and every one of them is one of four kinds:
+      #
+      #     330  .changeset/*.md      deleted (consumed by the version)
+      #      40  */package.json       the `"version"` key and NOTHING else —
+      #                               80 changed lines, all of them `"version":`
+      #      40  */CHANGELOG.md       generated from the changeset bodies
+      #       1  QUICK_REFERENCE.md   rewritten by `changeset:version`'s
+      #                               `sync-quick-reference-release.mjs`
+      #
+      # Zero `.ts`, zero `.tsx`, zero config. The source in the post-version
+      # tree is byte-identical to the `main` commit this run checked out, and
+      # `ci.yml`'s push lane already ran the whole suite over that commit under
+      # coverage across four shards. A `pnpm test` here would re-test bytes that
+      # were tested ~13 min ago and would report nothing new — at 40 minutes a
+      # go (`ci.yml` measured its own unsharded suite at 39 min 51 s of tests /
+      # 40 min 19 s of job), four times a day on the cron below, i.e. ~2.7 h of
+      # runner time daily for a PR nobody reads until release day. That is the
+      # cost objectstack#10850 was closed to REMOVE, walking back in.
+      #
+      # So the validation is scoped to what the diff can actually move, and the
+      # union — `ci.yml` on the source, these steps on the version outputs — is
+      # the whole post-version tree.
+      #
+      #     pnpm quick-reference:check   QUICK_REFERENCE.md          ~1 s
+      #     pnpm check:control-bytes     the 40 generated CHANGELOGs  ~4 s
+      #     pnpm test scripts/__tests__  73 files / 1996 tests       ~50 s
+      #
+      # The tooling suite is named as a DIRECTORY rather than as a list of test
+      # files, deliberately: every test in this repository that reads a
+      # manifest version, `QUICK_REFERENCE.md` or a `CHANGELOG.md` lives in it
+      # (measured — 7 of 7 matches), `doc-version-claims.test.ts` among them,
+      # and a list would go stale the first time someone adds an eighth.
+      # Measured green on a real rendered tree: 1 s + 4 s + 50 s.
+      #
+      # ⛔ WHAT IS DELIBERATELY NOT RUN, AND WHY IT IS NOT AN OMISSION.
+      # `check:spec-floors` and `check:published-dist` read dependency RANGES
+      # and built `dist/` output. The measurement above is what rules them out:
+      # no range moved (the only changed key is `"version"`) and no source moved,
+      # so on this tree they can only restate the verdict they gave on `main`.
+      # `check:published-dist` also costs a full build (8 m 39 s cold, measured),
+      # and `pnpm changeset:publish` runs both of them first on the publish lane
+      # anyway, where the tree they judge is the one being shipped.
+      #
+      # ⛔ WHY THERE IS NO "ONLY WHEN THE PR CONTENT CHANGED" CONDITION. That
+      # layer was the other half of the ruling's condition, and the measurement
+      # retired it: across the seven consecutive 6-hourly windows from
+      # 2026-08-23T06:08Z to 2026-08-25T00:10Z, SIX carried new changeset files
+      # (median 18 per window; 219, 46, 23, 18, 13, 9, and one zero). This
+      # repository lands ~18 merges a working day and most carry a changeset, so
+      # a content-change predicate would skip about one refresh in seven — it
+      # would buy ~14% of 70 seconds while adding exactly the thing
+      # objectui#6081 just deleted from this file: a local prediction of another
+      # project's state that is free to be wrong silently. The cost was solved
+      # by SCOPE, so frequency does not need solving.
+      #
+      # FAILURE SEMANTICS. A red validation fails the job and the refresh step
+      # below never runs, so the standing PR keeps its last VALIDATED content
+      # instead of being force-pushed to a broken one. If the post-version tree
+      # stays broken the PR goes stale — but loudly, on a red run every six
+      # hours, which is the opposite of this card's defect. Nothing here can
+      # block the publish lane: every step is scoped to `schedule` /
+      # `workflow_dispatch`, and `push` skips all three.
+      #
+      # ⚠️ THE RESTORE STEP IS LOAD-BEARING — DO NOT DROP IT. These steps render
+      # the version into the runner's working tree, and `changesets/action`
+      # picks its branch from that tree: with `.changeset/` already consumed it
+      # would find `hasChangesets` false, and with no `publish:` input on the
+      # refresh step `hasPublishScript` is false too, so v1 takes
+      # `case !hasChangesets && !hasPublishScript` (`src/index.ts` line 68),
+      # logs "No changesets present or were removed by merging release PR", and
+      # RETURNS. The refresh becomes a permanent no-op and the PR fossilises
+      # with nothing failing anywhere — this file's own failure class, one lane
+      # over. So the tree is put back and the restoration is ASSERTED rather
+      # than assumed, in the same shape the clear step asserts its own work.
+      # The action then runs `pnpm changeset:version` itself, on the inputs
+      # these steps measured, and it — not this job — owns the commit and the
+      # push.
+      - name: Render the post-version tree
+        id: post_version
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # `/^README\.md$/i` is how `@changesets/read` spells its exclusion, so
+          # the comparison is case-folded rather than matching one spelling.
+          count_pending() {
+            local n=0 file
+            for file in .changeset/*.md .changeset/pre/*.md; do
+              if [ "$(printf '%s' "${file##*/}" | tr '[:upper:]' '[:lower:]')" = 'readme.md' ]; then
+                continue
+              fi
+              n=$((n + 1))
+            done
+            printf '%s' "$n"
+          }
+
+          pending_before=$(count_pending)
+          echo "pending_before=${pending_before}" >> "$GITHUB_OUTPUT"
+
+          pnpm changeset:version
+
+          changed=$(git status --porcelain | wc -l | tr -d ' ')
+          {
+            echo "- post-version tree rendered from \`${GITHUB_SHA}\`"
+            echo "- pending changesets consumed: \`${pending_before}\`"
+            echo "- paths the version step moved: \`${changed}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Validate the post-version tree
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          pnpm quick-reference:check
+          pnpm check:control-bytes
+          pnpm test scripts/__tests__
+
+      - name: Restore the pre-version tree
+        if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+        env:
+          PENDING_BEFORE: ${{ steps.post_version.outputs.pending_before }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          if [ -z "${PENDING_BEFORE}" ]; then
+            echo "The render step did not run, so there is nothing to restore."
+            exit 0
+          fi
+
+          git checkout -- .
+          # Narrow on purpose: the version step can only create files beside a
+          # package manifest, and a `git clean` in a job that also publishes
+          # should never be able to reach further than the thing it undoes.
+          git clean -fdq -- packages apps examples .changeset
+
+          count_pending() {
+            local n=0 file
+            for file in .changeset/*.md .changeset/pre/*.md; do
+              if [ "$(printf '%s' "${file##*/}" | tr '[:upper:]' '[:lower:]')" = 'readme.md' ]; then
+                continue
+              fi
+              n=$((n + 1))
+            done
+            printf '%s' "$n"
+          }
+
+          pending_after=$(count_pending)
+          # `--untracked-files=no`: the build that ran earlier in this job
+          # leaves its own untracked output around, and none of it is part of
+          # what the version step moved or of what the action reads. Tracked
+          # state plus the pending count is the whole restoration.
+          dirty=$(git status --porcelain --untracked-files=no | wc -l | tr -d ' ')
+
+          if [ "${pending_after}" != "${PENDING_BEFORE}" ] || [ "${dirty}" -ne 0 ]; then
+            echo "::error::The pre-version tree was not restored (${PENDING_BEFORE} changesets before, ${pending_after} after; ${dirty} tracked path(s) still modified). changesets/action would read this tree, find nothing pending and return without refreshing the PR — a silent permanent no-op (objectui#5397)."
+            exit 1
+          fi
+          echo "Pre-version tree restored: ${pending_after} pending changeset(s), working tree clean."
 
       # REFRESH. No `publish:` input, so `runPublish` is unreachable; no npm
       # credentials in `env:`, so it is unreachable a second time over. Both are

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -936,6 +936,54 @@ the Published Dist Gate above. A published package whose `dist/` carries tooling
 the publish before a single tarball reaches npm, which is where that defect actually costs
 anything ([#4846](https://github.com/objectstack-ai/objectui/issues/4846)).
 
+#### The release PR runs no CI, so the refresh lane validates the tree itself
+
+The version PR gets **no checks of its own, and cannot be given any**. Measured 2026-08-25:
+`ci.yml` has **849** runs on `changeset-release/main` and every recent one is `action_required`
+with `created_at == run_started_at == updated_at` — created and immediately parked, nothing
+executed. GitHub does not start workflow runs from events raised by `GITHUB_TOKEN`, and the
+refresh force-pushes that branch, so there is no stable head to re-run against either. On the
+17.6.0 release PR the check-runs endpoint returned `total_count: 1`: one job, started **7 seconds
+after the merge**. The release commit is therefore the only commit that reaches `main` without
+passing the merge queue ([#5397](https://github.com/objectstack-ai/objectui/issues/5397)).
+
+So the refresh lane renders `pnpm changeset:version` into the runner's working tree, validates it,
+restores the tree, and only then invokes the action — which does its own versioning and owns the
+commit and the push.
+
+**What it validates, and why that is not `pnpm test`.** The version step cannot move a source
+byte. Measured against the real tree (328 pending changesets, 17.6.0 → 17.7.0) it touches 411
+paths: 330 `.changeset/*.md` deleted, 40 `package.json` (the `"version"` key and nothing else), 40
+generated `CHANGELOG.md`, and `QUICK_REFERENCE.md`. The source in the post-version tree is
+byte-identical to the `main` commit `ci.yml`'s push lane just tested under coverage across four
+shards, so a suite run here would re-test tested bytes at ~40 minutes a go, four times a day —
+~2.7 h of daily runner time for a PR nobody reads until release day, which is the cost
+[objectstack#10850](https://github.com/objectstack-ai/objectstack/issues/10850) was closed to
+remove. The validation is scoped to the surfaces the diff can move instead:
+
+| Command | Covers | Measured |
+|---|---|---|
+| `pnpm quick-reference:check` | `QUICK_REFERENCE.md` | ~1 s |
+| `pnpm check:control-bytes` | the 40 generated `CHANGELOG.md` | ~4 s |
+| `pnpm test scripts/__tests__` | 73 files / 1996 tests — every test that reads a manifest version, `QUICK_REFERENCE.md` or a `CHANGELOG.md` | ~50 s |
+
+`check:spec-floors` and `check:published-dist` are deliberately **not** here: they read dependency
+ranges and built `dist/`, neither of which the version step moves, and `pnpm changeset:publish`
+runs both first on the publish lane anyway.
+
+There is also **no "only when the PR content changed" condition**, for a measured reason: across
+the seven consecutive 6-hourly windows from 2026-08-23T06:08Z to 2026-08-25T00:10Z, six carried
+new changeset files (median 18). Such a predicate would skip about one refresh in seven while
+adding a local prediction of another project's state that can be wrong silently — the shape
+[#6081](https://github.com/objectstack-ai/objectui/issues/6081) just deleted from this file.
+
+**Failure semantics.** A red validation fails the job and the refresh never runs, so the standing
+PR keeps its last validated content rather than being force-pushed to a broken one. Nothing here
+can touch the publish lane: all three steps are scoped to `schedule` / `workflow_dispatch`. The
+restore step is load-bearing — with `.changeset/` left consumed the action would find nothing
+pending, take its no-op branch and return, and the PR would fossilise with nothing failing
+anywhere — so the restoration is asserted, not assumed.
+
 Both lanes configure a pnpm-lock.yaml merge driver to prevent lock file conflicts.
 
 ### Published Dist Gate (`published-dist-gate.yml`)


### PR DESCRIPTION
Part of #5397

Maintainer ruling 2026-08-22 (「接受所有」): **option A** — validate the post-version tree inside `changeset-release.yml`, after the version step and before `changesets/action` opens or updates the release PR. The ruling attached a binding pre-condition — **price it first** — and the price is what chose the implementation shape below.

## The measurement came first, and it changed the answer

**Re-measured today (the card asked for this explicitly).** The defect still holds and is worse than filed: `ci.yml` now has **849** runs on `changeset-release/main` (736 when the card was filed), and every recent one is `conclusion: action_required` with `created_at == run_started_at == updated_at` — created and immediately parked, nothing executed. Most recent: `2026-08-25T00:12:42Z`, run [32792689033](https://github.com/objectstack-ai/objectui/actions/runs/32792689033).

**But the cost premise in the card expired two days ago.** The card (2026-08-20) and the dispatch order both price naive option A against a refresh that runs *on every push to `main`* — ~18/day × 40 min ≈ 12 h of daily runner time. objectstack#10850 moved the refresh onto a 6-hourly cron, and the Actions API shows the changeover precisely: refresh runs were many-per-hour through `2026-08-23T05:39Z`, and from `2026-08-23T06:10Z` they are exactly 6 hours apart. Measured: **8 schedule runs in 42 h = 4.0/day**, not 18.

| | measured |
|---|---|
| refresh cadence today | 4/day (cron `0 */6 * * *`) |
| refresh lane runner time today | **106 s** (run [32792567720](https://github.com/objectstack-ai/objectui/actions/runs/32792567720): `lane` 6 s + `release` 100 s; install 13 s, build 37 s, the changesets step incl. `pnpm changeset:version` **13 s**) |
| naive A (full `pnpm test` post-version) | **+~40 min/refresh** → ~2.7 h/day |
| this PR (scoped A) | **+~68 s/refresh** → ~4.5 min/day |

`ci.yml`'s own instrumented figure for the unsharded suite is **39 min 51 s of tests / 40 min 19 s of job**, recorded in its header.

## Why naive option A is the wrong shape — the version step cannot move a source byte

Rendered against this repository's real tree (328 pending changesets, 17.6.0 → 17.7.0), `pnpm changeset:version` touches **411 paths**, and all of them are one of four kinds:

| count | path | what moves |
|---|---|---|
| 330 | `.changeset/*.md` | deleted (consumed by the version) |
| 40 | `*/package.json` | the `"version"` key **and nothing else** — 80 changed lines, every one of them `"version":` |
| 40 | `*/CHANGELOG.md` | generated from the changeset bodies |
| 1 | `QUICK_REFERENCE.md` | rewritten by `changeset:version`'s `sync-quick-reference-release.mjs` |

Zero `.ts`, zero `.tsx`, zero config, zero dependency ranges. The **source** in the post-version tree is byte-identical to the `main` commit the job checked out — the commit `ci.yml`'s push lane already ran the whole suite over, under coverage, across four shards (~13.8 min wall, median of 30 recent runs). A `pnpm test` here would re-test bytes tested minutes earlier and report nothing new, at 40 minutes a go, four times a day. That is the cost objectstack#10850 was closed to *remove*, walking back in through a different door — exactly what the dispatch order forbade shipping unmeasured.

So the validation is scoped to what the diff can actually move, and the **union** — `ci.yml` on the source, these steps on the version outputs — is the whole post-version tree.

## What the refresh lane now does

Three steps, all scoped to `schedule` / `workflow_dispatch`, inserted immediately before `Refresh the version PR`:

1. **Render the post-version tree** — `pnpm changeset:version` into the runner's working tree.
2. **Validate the post-version tree**:

   | command | covers | measured |
   |---|---|---|
   | `pnpm quick-reference:check` | `QUICK_REFERENCE.md` — the drift #5394 cashed three times | ~1 s |
   | `pnpm check:control-bytes` | the 40 generated `CHANGELOG.md`, whose prose comes from changeset bodies | ~4 s |
   | `pnpm test scripts/__tests__` | 73 files / 1996 tests | ~50 s |

3. **Restore the pre-version tree**, and *assert* the restoration.

The tooling suite is named as a **directory, not a file list**, deliberately: every test in this repository that reads a manifest version, `QUICK_REFERENCE.md` or a `CHANGELOG.md` lives in it (measured — 7 of 7 grep matches), `doc-version-claims.test.ts` among them, and a hand-list would go stale the first time someone adds an eighth.

**Deliberately not run, and it is not an omission.** `check:spec-floors` reads dependency *ranges* and `check:published-dist` reads built `dist/` — the measurement above rules both out (no range moved, no source moved), so on this tree they can only restate the verdict they gave on `main`. `check:published-dist` also costs a full build (**8 m 39 s** cold, measured here), and `pnpm changeset:publish` runs both of them first on the publish lane anyway, where the tree they judge is the one being shipped.

**No "only when the PR content changed" conditional**, and that is the other half of the ruling's condition, retired by measurement rather than by preference: across the seven consecutive 6-hourly windows from `2026-08-23T06:08Z` to `2026-08-25T00:10Z`, **six carried new changeset files** — 219, 46, 23, 18, 13, 9, and one zero (median 18). This repo lands ~18 merges a working day and most carry a changeset, so a content-change predicate would skip about **one refresh in seven**: ~14 % of 68 seconds, bought with exactly the thing #6081 deleted from this file last night — a local prediction of another project's state that is free to be wrong silently. The cost was solved by **scope**, so frequency did not need solving.

## Failure semantics, and the restore

A red validation fails the job and the refresh step never runs, so the standing version PR keeps its last **validated** content instead of being force-pushed to a broken one. If the post-version tree stays broken the PR goes stale — but *loudly*, on a red run every six hours, which is the opposite of this card's defect.

⚠️ **The restore step is load-bearing.** `changesets/action@v1` picks its branch from the tree: with `.changeset/` left consumed it finds `hasChangesets` false, and the refresh step passes no `publish:` input so `hasPublishScript` is false too — v1 then takes `case !hasChangesets && !hasPublishScript` (`src/index.ts` line 68), logs *"No changesets present or were removed by merging release PR"*, and returns. The refresh becomes a permanent no-op and the PR fossilises with nothing failing anywhere. So the tree is put back and the restoration is **asserted** (pending count restored *and* no tracked path still modified), in the same shape the existing clear step asserts its own work. The action then runs `pnpm changeset:version` itself and — as today — owns the commit and the push.

The publish lane is untouched: steps 10–12 (`Clear pending changesets` / `Publish to npm` / `Verify the release reached npm`) keep their conditions and their order byte-for-byte, and all three new steps skip on `push`.

## Verification — and its honest limit

Union re-run at **`44f70009c`** (the head this PR points at), exit codes captured by redirect before any pipe:

```
EXIT=0 :: pnpm check:control-bytes  :: ✅ OK (scanned 5123 tracked text file(s); skipped 85 binary)
EXIT=0 :: pnpm check:doc-fences     :: ✅ every TypeScript block in 223 document(s) is fenced ts/tsx/typescript
EXIT=0 :: pnpm docs:check-links     :: Links are valid across 15 scan roots
EXIT=0 :: pnpm changeset:check      :: ✅ All workspace packages are in the changeset fixed group
EXIT=0 :: pnpm test scripts/__tests__ :: Test Files 73 passed (73) · Tests 1996 passed (1996)
```

The two tests that read this workflow were also run alone — `changeset-release-action-ref-pin.test.ts` and `ci-cd-pipeline-doc.test.ts`, **2 files / 39 tests passed**. The ref-pin test asserts the exact set `['release / Publish to npm', 'release / Refresh the version PR']`, so it would have caught a fourth `changesets/action` usage or a renamed lane; this PR adds neither.

**The render → validate → restore sequence was executed for real**, locally, against the actual 328-changeset tree: `pnpm changeset:version` (exit 0), then `quick-reference:check` (1 s), `check:control-bytes` (4 s, scanned the regenerated CHANGELOGs), `pnpm test scripts/__tests__` (50 s, 1996 passed) — all green on the rendered tree — then the restore, verified on disk: **328 pending changesets back, working tree clean**. `git status` reported **0** untracked files created by the version step, so the tracked-files scan covers the whole moved surface on today's tree.

⛔ **No release was executed, and this cannot be proven end-to-end without one.** What remains unobserved: the runner-side behaviour of the sequence — that the action's own `changeset version` after the restore produces the same tree, and that the PR refreshes normally. That is exercised by the **first scheduled tick after this merges** (within 6 hours, no release required); what genuinely waits for the next real release is only the merge of a validated PR. The `action_required` reading itself will not change — this PR does not make `ci.yml` run on `changeset-release/main`, and nothing can while the bot authors that branch with `GITHUB_TOKEN`.

## Docs

`content/docs/guide/ci-cd-pipeline.md` gains a subsection under **Changeset Release** carrying the measurements, the scope argument, and the failure semantics — the page is the repository's single workflow inventory and `ci-cd-pipeline-doc.test.ts` enforces that.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_