### PR TITLE
Hold every inline defaultValue to the placeholder spelling the provider-less fallback resolves

### DIFF
--- a/.changeset/4905-inline-default-value-pin.md
+++ b/.changeset/4905-inline-default-value-pin.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/plugin-detail': patch
+---
+
+Inline `t(key, { defaultValue })` strings are now held to the one placeholder spelling a
+provider-less host can resolve, and five of them are pinned to the pack value for the first
+time (objectui#4905).
+
+`check:i18n-keys`' `default-value-drift` class pins an inline default byte-identical to its
+`en` row, and objectui#3512 holds `en` to the one spelling `createSafeTranslation`'s
+`fallbackT` interpolates — so most inline defaults were covered transitively. Re-measured
+on this tree, 66 of 1003 were not: three literal defaults on dynamic keys, and 63 written
+as a computed expression. A new `unresolvable-default-spelling` class in
+`scripts/check-i18n-call-site-keys.mjs` now judges the text every inline default carries —
+the folded sentence, or a template literal's static segments — so `{{ name }}`,
+`{{count, number}}`, `{{- name}}` and `$t(key)` are refused wherever they are written,
+rather than only inside a copy table.
+
+Four call sites gain a real pin because their default carries no placeholder at all: the
+record-form submit button now falls back to `Update`/`Create` (the pack's wording) instead
+of `Save`/`Create` via a nested `t('common.save')`, the context selector's package label
+and the approvals separator now state their literal. One more (`detail.showEmptyFields`)
+is behind a `createSafeTranslation` hook, whose fallback does interpolate, so it can safely
+say what the pack says.
+
+The other 61 are deliberately left computed, and the measurement behind that is the useful
+part: react-i18next's not-ready `t` returns `options.defaultValue` **verbatim, without
+interpolating it**. At a call site bound to a bare `useObjectTranslation()`, a default
+written as `` `Signed in as ${user.email}` `` is therefore the only form that renders
+correctly with no provider — rewriting it to `'Signed in as {{email}}'` would put literal
+braces in front of the user, which is the exact defect this family of cards exists to
+prevent. Those sites keep their template literals and are covered by the spelling class
+instead.

--- a/packages/app-shell/src/console/AppContent.tsx
+++ b/packages/app-shell/src/console/AppContent.tsx
@@ -1099,8 +1099,8 @@ export function AppContent({ extraRoutes, extraRoutesNoApp }: AppContentProps = 
                 showSubmit: true,
                 showCancel: true,
                 submitText: editingRecord
-                  ? t('form.update', { defaultValue: t('common.save', { defaultValue: 'Save' }) })
-                  : t('form.create', { defaultValue: t('common.create', { defaultValue: 'Create' }) }),
+                  ? t('form.update', { defaultValue: 'Update' })
+                  : t('form.create', { defaultValue: 'Create' }),
                 cancelText: t('common.cancel'),
               }}
               dataSource={dataSource}

--- a/packages/app-shell/src/layout/ContextSelectors.tsx
+++ b/packages/app-shell/src/layout/ContextSelectors.tsx
@@ -405,7 +405,7 @@ function SelectorControl({
   const Icon = getIcon(def.icon);
   const rawLabel = resolveKeyedI18nLabel(def.label as any, t) || def.id;
   const label = rawLabel === 'Package'
-    ? (t?.('common.package', { defaultValue: rawLabel }) ?? rawLabel)
+    ? (t?.('common.package', { defaultValue: 'Package' }) ?? rawLabel)
     : rawLabel;
   const placeholder = t?.('actionDialog.selectPlaceholder', {
     label,

--- a/packages/app-shell/src/utils/approverIdentity.ts
+++ b/packages/app-shell/src/utils/approverIdentity.ts
@@ -362,7 +362,7 @@ export function approverCopyFrom(
   const str = (out: unknown, fallbackText: string): string =>
     typeof out === 'string' && out ? out : fallbackText;
   const separator = str(
-    t('approvalsInbox.approverNameSeparator', { defaultValue: DEFAULT_NAME_SEPARATOR }),
+    t('approvalsInbox.approverNameSeparator', { defaultValue: ', ' }),
     DEFAULT_NAME_SEPARATOR,
   );
   return {

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -490,7 +490,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
             )}
             {showEmptyOverride
               ? t('detail.hideEmptyFields', { defaultValue: 'Hide empty fields' })
-              : t('detail.showEmptyFields', { count: emptyCount, defaultValue: `Show ${emptyCount} empty field${emptyCount === 1 ? '' : 's'}` })}
+              : t('detail.showEmptyFields', { count: emptyCount, defaultValue: 'Show {{count}} empty fields' })}
           </Button>
         </div>
       )}

--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -16,6 +16,7 @@ import {
   PACK_HOOK,
   readVocabulary,
   RESERVED_OPTION_NAMES,
+  unresolvableSpellings,
 } from '../check-i18n-call-site-keys.mjs';
 
 /**
@@ -1065,8 +1066,159 @@ export const A = (name: string, label: string, n: number) => {
       path.join(repoRoot, 'packages/app-shell/src/layout/ContextSelectors.tsx'),
       'utf8',
     );
-    expect(selectors).toContain("t?.('common.package', { defaultValue: rawLabel }) ?? rawLabel");
+    // Pinned on the OPTIONAL CALL and the `??` OPERAND — the two things this
+    // rule abstained on — and deliberately not on the options object between
+    // them. objectui#4905 rewrote both calls' `defaultValue` ARGUMENT (to the
+    // `en` value, so class 3 pins them where it previously could not), which is
+    // a different rule acting on a different position; a marker spanning both
+    // made that fix read as this rule's regression.
+    expect(selectors).toContain("t?.('common.package'");
+    expect(selectors).toContain(') ?? rawLabel');
     expect(selectors).toContain('}) ?? `Select ${label}…`');
+  });
+});
+
+describe('an inline defaultValue spells its holes the one way the fallback resolves (objectui#4905)', () => {
+  /**
+   * Class 7. `fallbackT` interpolates with an exact literal needle, so it
+   * resolves `{{name}}` and nothing else; i18next also accepts `{{ name }}`,
+   * `{{count, number}}`, `{{- name}}` and `$t(key)`. The divergence is visible
+   * only WITHOUT a provider, which is the one host nobody watches.
+   *
+   * objectui#3512 gated this rule over the copy TABLES and said in writing that
+   * inline defaults were out of its scope, because finding one means classifying
+   * the call site — the walk this file owns. The residue it recorded is what
+   * objectui#4905 closed: most of it at the SOURCE (call sites rewritten so the
+   * drift rule pins them), the rest here.
+   */
+  function spellingOf(root: string): string[] {
+    return analyze(root, { families: [] })
+      .findings.filter((f: { reason: string }) => f.reason === 'unresolvable-default-spelling')
+      .map((f: { detail: string; actual: string }) => `${f.detail}: ${f.actual}`)
+      .sort();
+  }
+
+  const withDefault = (expression: string) => ({
+    'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+    'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = (name: string) => { const { t } = useObjectTranslation(); return t('interp.greet', { name, defaultValue: ${expression} }); };
+`,
+  });
+
+  it('the rule itself: canonical passes, each of the four i18next-only spellings fails', () => {
+    // A unit pin on the predicate, so the four dialects are named once in a
+    // place that does not depend on the walk finding them.
+    expect(unresolvableSpellings('Hello {{name}}')).toEqual([]);
+    expect(unresolvableSpellings('Hello {{ name }}')).toHaveLength(1);
+    expect(unresolvableSpellings('Deleted {{count, number}} rows')).toHaveLength(1);
+    expect(unresolvableSpellings('Hello {{- name}}')).toHaveLength(1);
+    expect(unresolvableSpellings('Hello $t(common.save)')).toHaveLength(1);
+    expect(unresolvableSpellings('Hello {{user.name}}')).toHaveLength(1);
+    expect(unresolvableSpellings('{{a}} and {{b}}')).toEqual([]);
+  });
+
+  it('is silent when the default spells its hole the way the fallback reads it', () => {
+    const { findings, counters } = analyze(repoWith(withDefault("'Hello {{name}}'")), { families: [] });
+    expect(findings).toEqual([]);
+    expect(counters.spellingJudgedDefaults).toBe(1);
+  });
+
+  it.each([
+    ["'Hello {{ name }}'", 'whitespace inside the braces'],
+    ["'Hello {{name, upper}}'", 'an i18next format spec'],
+    ["'Hello {{- name}}'", 'the {{- x}} unescape prefix'],
+    ["'Hello $t(common.save)'", 'i18next nesting'],
+  ])('RED on %s', (expression, fragment) => {
+    const found = spellingOf(repoWith(withDefault(expression)));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain(fragment);
+  });
+
+  it('reaches a COMPUTED default, which class 3 structurally cannot judge', () => {
+    // The residue the card is about: a template literal is not a comparable
+    // sentence, so `default-value-drift` counts it and moves on — but its
+    // literal SEGMENTS are text the fallback renders verbatim.
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+      'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = (name: string, n: number) => {
+  const { t } = useObjectTranslation();
+  return t('interp.both', { name, n, defaultValue: \`Hello \${name}, you have {{ n }} messages\` });
+};
+`,
+    });
+    const { counters } = analyze(root, { families: [] });
+    expect(counters.computedDefaultValues).toBe(1);
+    expect(spellingOf(root)).toEqual(['interp.both: "{{ n }}" — whitespace inside the braces; the fallback resolves only {{name}}']);
+  });
+
+  it('reaches a default on a DYNAMIC key, which no transitive pin can cover', () => {
+    // No single `en` value exists, so there is nothing for class 3 to compare
+    // and nothing #3512 covers transitively. The spelling is still judged.
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+      'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = (which: string, name: string) => {
+  const { t } = useObjectTranslation();
+  return t(\`common.\${which}\`, { name, defaultValue: 'Hello {{ name }}' });
+};
+`,
+    });
+    expect(spellingOf(root)).toEqual(['(dynamic key): "{{ name }}" — whitespace inside the braces; the fallback resolves only {{name}}']);
+  });
+
+  it('a hole straddling a substitution is reported, not silently joined into a valid one', () => {
+    // Joining the segments would invent an adjacency the runtime never
+    // produces: at runtime the substitution sits between the braces, so
+    // neither interpolator can resolve it. Reading it as `{{name}}` would be
+    // the false green.
+    const found = spellingOf(repoWith(withDefault('`{{ ${name} }}`')));
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain('unterminated `{{`');
+  });
+
+  it('counts, and does not judge, a default with no readable text at all', () => {
+    const root = repoWith(withDefault('name'));
+    const { findings, counters } = analyze(root, { families: [] });
+    expect(findings).toEqual([]);
+    expect(counters.opaqueDefaultText).toBe(1);
+    expect(counters.spellingJudgedDefaults).toBe(0);
+  });
+
+  it('leaves single-brace holes alone — objectui#4135 spells a downstream fill that way', () => {
+    expect(spellingOf(repoWith(withDefault("'Hello {name}'")))).toEqual([]);
+    expect(unresolvableSpellings('Resend in {seconds}s')).toEqual([]);
+  });
+
+  it('leaves JSX object-literal braces out of range by construction', () => {
+    // `style={{ opacity: 0 }}` is `{{` that is syntax, not copy. The rule is
+    // handed the TEXT of a literal, never source, so a JSX brace cannot reach
+    // it — excluded by where the rule looks, not by an allow-list.
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_FIXTURE,
+      'packages/x/src/A.tsx': `import { useObjectTranslation } from '${I18N_PKG}';
+export const A = (name: string) => {
+  const { t } = useObjectTranslation();
+  return <span style={{ opacity: 0 }} data-x={{ a: 1 }}>{t('interp.greet', { name, defaultValue: 'Hello {{name}}' })}</span>;
+};
+`,
+    });
+    expect(spellingOf(root)).toEqual([]);
+  });
+
+  it('main carries no unresolvable spelling, which is why this rule has no baseline', () => {
+    expect(spellingOf(repoRoot)).toEqual([]);
+  });
+
+  it('and that green is not vacuous — it is measured over hundreds of real defaults', () => {
+    // The trap this rule's own card named: a coverage number that looks like
+    // success and can be reached by judging nothing. The CLI exits non-zero
+    // below 500; this pins the same floor where the counter is readable.
+    const { counters } = analyze(repoRoot);
+    expect(counters.spellingJudgedDefaults).toBeGreaterThan(500);
+    // The residue route C could not reach is still IN the judged set, not
+    // quietly dropped from it.
+    expect(counters.spellingJudgedResidueDefaults).toBeGreaterThan(0);
   });
 });
 

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -5,7 +5,9 @@
  * must say the same thing the pack does (objectui#3810) — and the interpolation
  * arguments the call site passes must be exactly the holes the `en` value has
  * to receive them (objectui#3845) — and the OTHER spelling of a fallback,
- * `t(key) || 'English'`, must not exist at all (objectui#4117).
+ * `t(key) || 'English'`, must not exist at all (objectui#4117) — and whatever
+ * text that inline default carries must spell its placeholders the one way the
+ * provider-less fallback can resolve them (objectui#4905).
  *
  * Run:  node scripts/check-i18n-call-site-keys.mjs   (also `pnpm check:i18n-keys`)
  * Exit: 0 = every in-scope call-site key resolves (or is baselined), no inline
@@ -292,6 +294,58 @@
  *    112 checked member keys), and a missing translation is a gap to surface, not
  *    something to invent pack entries for.
  *
+ * 7. `unresolvable-default-spelling` (objectui#4905) — an inline `defaultValue`
+ *    spells a placeholder in one of the four dialects i18next accepts and
+ *    `createSafeTranslation`'s `fallbackT` does not (`{{ name }}`,
+ *    `{{count, number}}`, `{{- name}}`, `$t(key)`). WITH a provider the pack
+ *    value wins and nothing is visible; WITHOUT one the braces reach the user.
+ *
+ *    This is objectui#3512's rule, and the reason it is HERE rather than there
+ *    is the whole of objectui#4905. That card gated the three copy TABLE
+ *    surfaces and left inline defaults out in writing, because a `defaultValue`
+ *    is a call-site OPTION rather than a table: finding one means resolving
+ *    which `t` is in scope at that position and reading the call's arguments —
+ *    the classifier this file already is, and a second independently-rotting
+ *    copy of it anywhere else. The residue #3512 recorded was 3 "not
+ *    comparable" plus 62 computed inline defaults with no transitive pin.
+ *
+ *    Closing that residue at the SOURCE — rewriting a computed default as the
+ *    `en` value so class 3 pins it — turns out to reach only 5 of the 66 sites
+ *    measured on this tree, and the reason is worth stating because it is the
+ *    opposite of what the card assumed. THREE things can render an inline
+ *    default, and only two of them interpolate it:
+ *
+ *      1. i18next, with a provider. It interpolates — but the pack value wins,
+ *         so the default never renders at all. Moot.
+ *      2. `createSafeTranslation`'s `fallbackT`. It interpolates, with the exact
+ *         literal needle this class is named for. SAFE to rewrite.
+ *      3. react-i18next's not-ready `t`, which is what a bare
+ *         `useObjectTranslation()` yields when no i18next instance is
+ *         initialised. Measured in `react-i18next/dist/es/useTranslation.js`:
+ *         `notReadyT` returns `options.defaultValue` VERBATIM — it does not
+ *         interpolate at all.
+ *
+ *    So at a `useObjectTranslation` call site, a default written as
+ *    `` `Signed in as ${user.email}` `` is not an unpinned near-miss to be
+ *    tidied into `'Signed in as {{email}}'` — the template literal is the only
+ *    one of the two that renders correctly there, and "fixing" it would put
+ *    literal braces in front of a user on exactly the provider-less host this
+ *    whole family of cards is about. `objectBulkActionDispatch.test.tsx` fails
+ *    on precisely that substitution, which is how it was found.
+ *
+ *    Hence only 5 rewrites: four whose default carries no hole (nothing to
+ *    interpolate, so all three renderers agree) and one behind a
+ *    `createSafeTranslation` hook. The rest stay computed, and this class is
+ *    what covers them.
+ *
+ *    Judged over EVERY inline default, not just the residue. A pinned default is
+ *    byte-equal to an `en` value #3512 already holds to this rule, so those
+ *    verdicts are green twice over — which is the point: it makes the judged
+ *    count a live control (hundreds, guarded), instead of a rule whose whole
+ *    subject is three strings that could silently become zero. HARD from day
+ *    one, like classes 3-5: the first full run found 0 violations, so there is
+ *    no debt for a ratchet to hold, and 0 stops being luck.
+ *
  * ## Dynamic keys: the explicit policy
  *
  * A key that is not a string literal cannot be resolved statically. Those call
@@ -455,6 +509,95 @@ export function holesOf(value) {
     if (name) names.add(name);
   }
   return names;
+}
+
+/**
+ * A `{{…}}` pair and its contents. `[^{}]*` deliberately: a placeholder never
+ * nests braces, and refusing to cross one keeps an unterminated `{{` from
+ * swallowing the rest of the sentence into a bogus "placeholder".
+ */
+const DOUBLE_BRACE = /\{\{([^{}]*)\}\}/g;
+
+/** Every `{{` occurrence, matched or not — the balance check's other half. */
+const DOUBLE_BRACE_OPEN = /\{\{/g;
+
+/**
+ * The one placeholder spelling `createSafeTranslation`'s `fallbackT` resolves.
+ * The option name comes from `Object.entries(options)` and is spliced into the
+ * needle raw (``value.split(`{{${k}}}`)``), so the accepted name is exactly a
+ * bare identifier: no whitespace, no format spec, no `-` prefix, no keypath.
+ */
+const CANONICAL_HOLE_NAME = /^[A-Za-z0-9_]+$/;
+
+/** i18next's nesting syntax. The fallback has no notion of it at all. */
+const NESTING_MARKER = '$t(';
+
+/** Why one placeholder is not something `fallbackT` can resolve. */
+function unresolvableReason(inner) {
+  if (inner !== inner.trim()) return 'whitespace inside the braces';
+  if (inner.startsWith('-')) return 'the {{- x}} unescape prefix';
+  if (inner.includes(',')) return 'an i18next format spec';
+  if (inner.includes('.')) return 'a dotted/keyed placeholder path';
+  return 'a non-identifier placeholder name';
+}
+
+/**
+ * Placeholder spellings the provider-less fallback cannot resolve
+ * (objectui#4905, class 7 — the rule is objectui#3512's, applied to the one
+ * copy surface that card left out).
+ *
+ * `fallbackT` interpolates with an EXACT literal needle, so it recognises
+ * `{{name}}` and nothing else. i18next — which serves the SAME string whenever
+ * an `I18nProvider` is mounted — additionally recognises `{{ name }}`,
+ * `{{count, number}}`, `{{- name}}` and `$t(otherKey)`. Those four render
+ * correctly through the provider and leak literal braces without one, which is
+ * a divergence only a provider-less host ever sees.
+ *
+ * Returns one human-readable violation per offending placeholder, and `[]` for
+ * text both paths render identically.
+ *
+ * ## What is structurally out of range, and why that matters
+ *
+ *   - **Single braces.** `{shown}` / `{seconds}` is objectui#4135's spelling for
+ *     a hole filled DOWNSTREAM of `t()`. Only the inside of a `{{…}}` pair is
+ *     ever inspected, so a single-brace hole cannot reach a verdict here —
+ *     excluded by where the rule looks, not by an allow-list that could rot.
+ *   - **JSX object literals.** `style={{ opacity: 0 }}` is `{{` that is syntax,
+ *     not copy. This rule never greps source text: it is handed the TEXT of a
+ *     string literal or the literal segments of a template, and a JSX brace is
+ *     not inside either.
+ *
+ * ## The sibling copy, named rather than hidden
+ *
+ * `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`
+ * carries the same rule as `placeholderViolations`, over the ten locale packs
+ * and the 31+3 defaults TABLES. This copy exists because that gate is a vitest
+ * suite reading copy tables and this one is a node script reading call-site
+ * ARGUMENTS — the walk that finds a `defaultValue` is the classifier this file
+ * already owns, and rebuilding it there was rejected on objectui#4905. The
+ * self-test pins this copy against all four i18next-only spellings and both
+ * out-of-range classes, so the two can only drift by someone editing one and
+ * not the other with both self-tests in front of them.
+ */
+export function unresolvableSpellings(value) {
+  const out = [];
+  const regions = [...value.matchAll(DOUBLE_BRACE)];
+  for (const region of regions) {
+    const inner = region[1];
+    if (CANONICAL_HOLE_NAME.test(inner)) continue;
+    out.push(`${JSON.stringify(region[0])} — ${unresolvableReason(inner)}; the fallback resolves only {{name}}`);
+  }
+  // An unterminated `{{` renders as literal braces on BOTH paths, so it is not
+  // an i18next divergence — but it is never intentional copy, and the regions
+  // above cannot report what they did not match. A hole straddling a template
+  // substitution (`` `{{ ${name} }}` ``) lands here, which is the one shape
+  // neither interpolator can resolve.
+  const opens = (value.match(DOUBLE_BRACE_OPEN) ?? []).length;
+  if (opens > regions.length) out.push('an unterminated `{{` with no closing `}}`');
+  if (value.includes(NESTING_MARKER)) {
+    out.push('`$t(` — i18next nesting, which the fallback emits verbatim');
+  }
+  return out;
 }
 
 /**
@@ -871,6 +1014,40 @@ function staticString(node, source) {
 }
 
 /**
+ * Every piece of an expression that is STATIC TEXT, or `null` when none of it
+ * is (objectui#4905).
+ *
+ * `staticString` above answers "is this whole expression one readable string",
+ * which is what the drift rule needs — it compares a sentence. The spelling
+ * rule asks something weaker and therefore reaches further: a template literal
+ * is not a readable sentence, but its literal SEGMENTS are text a placeholder
+ * can be misspelled in, and that text renders verbatim on a provider-less host.
+ * `` `Uploading… ({{ pct }}%)` `` is `null` to `staticString` and two segments
+ * here, and the second is where the defect lives.
+ *
+ * The segments are judged one by one rather than joined, because joining them
+ * would invent adjacencies the runtime never produces: the substitution between
+ * two segments becomes arbitrary text at runtime, so a `{{` in one and a `}}`
+ * in the next is not a placeholder either interpolator can resolve, and reading
+ * it as one would be the false green.
+ */
+function staticTextSegments(node, source) {
+  const inner = unwrapExpression(node);
+  if (!inner) return null;
+  if (ts.isStringLiteral(inner) || ts.isNoSubstitutionTemplateLiteral(inner)) return [inner.text];
+  if (ts.isTemplateExpression(inner)) {
+    return [inner.head.text, ...inner.templateSpans.map((span) => span.literal.text)];
+  }
+  if (ts.isBinaryExpression(inner) && inner.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = staticTextSegments(inner.left, source);
+    const right = staticTextSegments(inner.right, source);
+    if (left === null && right === null) return null;
+    return [...(left ?? []), ...(right ?? [])];
+  }
+  return null;
+}
+
+/**
  * Dotted leaf paths of `packages/i18n/src/locales/en.ts`, read from its AST,
  * plus the leaf VALUES — the strings the app actually renders.
  *
@@ -1182,6 +1359,11 @@ function literalKeysOf(argument, source) {
  * `{ present: true, text: null }` — written, but computed (a template with a
  *                                   substitution, a variable, a ternary). Not
  *                                   comparable, so it is counted, never failed.
+ *
+ * `segments` is the same expression read for STATIC TEXT rather than for a
+ * whole sentence (objectui#4905): `null` when nothing in it is readable text,
+ * otherwise every literal piece. A computed default is `text: null` and can
+ * still carry segments — that is the surface class 7 judges and class 3 cannot.
  */
 function inlineDefaultValue(node, source) {
   for (const argument of node.arguments.slice(1)) {
@@ -1192,10 +1374,14 @@ function inlineDefaultValue(node, source) {
       const name =
         ts.isIdentifier(property.name) || ts.isStringLiteral(property.name) ? property.name.text : null;
       if (name !== 'defaultValue') continue;
-      return { present: true, text: staticString(property.initializer, source) };
+      return {
+        present: true,
+        text: staticString(property.initializer, source),
+        segments: staticTextSegments(property.initializer, source),
+      };
     }
   }
-  return { present: false, text: null };
+  return { present: false, text: null, segments: null };
 }
 
 /**
@@ -1414,6 +1600,9 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
     matchingDefaultValues: 0,
     computedDefaultValues: 0,
     unjudgedDefaultValues: 0,
+    spellingJudgedDefaults: 0,
+    spellingJudgedResidueDefaults: 0,
+    opaqueDefaultText: 0,
     judgedInterpolation: 0,
     unjudgedInterpolation: 0,
     opaqueOptions: 0,
@@ -1575,6 +1764,42 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
               counters.matchingDefaultValues += 1;
             } else {
               findings.push({ reason: 'default-value-drift', ...at, detail: key, expected: enValue, actual: inlineDefault.text });
+            }
+          }
+
+          // objectui#4905 — class 7. Whatever the drift rule decided above, the
+          // TEXT this default carries is text `fallbackT` may be asked to
+          // render, and `fallbackT` resolves exactly one placeholder spelling.
+          // Judged on every inline default, not only the ones drift leaves
+          // unpinned: a pinned default is byte-equal to its `en` value and
+          // objectui#3512 holds `en` to the same rule, so those come back green
+          // twice over — which is what makes the count a live control on this
+          // rule rather than a set of three strings nobody would notice
+          // emptying.
+          if (inlineDefault.present) {
+            // The folded sentence when there is one, else the literal pieces of
+            // a template — never both, so a `+`-concatenated default is judged
+            // whole rather than once per operand.
+            const subjects = inlineDefault.text !== null ? [inlineDefault.text] : (inlineDefault.segments ?? []);
+            const pinnedByDrift = inlineDefault.text !== null && enValue !== undefined;
+            if (subjects.length === 0) {
+              // A bare runtime value (`defaultValue: label`). There is no text
+              // to spell, and saying so is not the same as saying it is fine.
+              counters.opaqueDefaultText += 1;
+            } else {
+              counters.spellingJudgedDefaults += 1;
+              if (!pinnedByDrift) counters.spellingJudgedResidueDefaults += 1;
+              for (const subject of subjects) {
+                for (const violation of unresolvableSpellings(subject)) {
+                  findings.push({
+                    reason: 'unresolvable-default-spelling',
+                    ...at,
+                    detail: key ?? '(dynamic key)',
+                    expected: subject,
+                    actual: violation,
+                  });
+                }
+              }
             }
           }
 
@@ -1891,6 +2116,19 @@ const HINTS = {
     ' EXTERNALLY_INTERPOLATED_HOLES with the file that does the substitution — and note that' +
     ' those keys must still NOT be passed the argument, or i18next consumes the hole before the' +
     ' consumer gets to see it.',
+  'unresolvable-default-spelling':
+    'This inline `defaultValue` spells a placeholder in a dialect only i18next understands' +
+    ' (objectui#4905). `createSafeTranslation`\'s `fallbackT` interpolates with an EXACT literal' +
+    ' needle — ``value.split(`{{${k}}}`)`` — so `{{name}}` is the only spelling it resolves,' +
+    ' while i18next also accepts `{{ name }}`, `{{count, number}}`, `{{- name}}` and `$t(key)`.' +
+    ' The consequence is invisible where we usually look: WITH an `I18nProvider` the pack value' +
+    ' wins and this string never renders at all; without one it renders and the braces reach the' +
+    ' user verbatim. Fix it at the CALL SITE by respelling the hole as `{{name}}` — the' +
+    ' maintainer\'s objectui#4135 ruling is that `{{x}}` is exclusively i18next-bound copy, so' +
+    ' teaching the fallback more dialects is not the fix. A hole this component fills ITSELF,' +
+    ' downstream of `t()`, is spelled with SINGLE braces (`{x}`) and is out of this rule\'s range' +
+    ' by construction. Same rule, same reasons, over the copy TABLES:' +
+    ' `packages/i18n/src/__tests__/fallback-placeholder-spelling-3512.test.ts`.',
   'dead-sibling-fallback':
     'The key EXISTS in `en`, and this fallback is written as the call\'s SIBLING' +
     ' (`t(key) || \'English\'`) rather than as an argument — so it is dead on every path, not just' +
@@ -1927,6 +2165,21 @@ if (invokedDirectly) {
     process.exit(1);
   }
 
+  // The same guard for class 7's own subject (objectui#4905). The rule above is
+  // silent on a tree with no inline defaults in it, and silent is exactly how a
+  // broken `inlineDefaultValue` or `staticTextSegments` would read — so the
+  // spelling verdict asserts it had something to judge, rather than inheriting
+  // the key-count guard's word for it.
+  if (counters.spellingJudgedDefaults < 500) {
+    console.error(
+      `The inline-default spelling scan collapsed: ${counters.spellingJudgedDefaults} default(s) with readable` +
+        ` text, ${counters.opaqueDefaultText} without. Expected hundreds — this repo carries` +
+        ' roughly a thousand inline defaults, so a number this small means the reader stopped' +
+        ' reading them and the spelling rule is passing on an empty set.',
+    );
+    process.exit(1);
+  }
+
   const { unexpected, stale } = applyBaseline(findings, readBaseline(root));
 
   console.log(
@@ -1940,6 +2193,11 @@ if (invokedDirectly) {
     `Inline defaults: ${counters.literalDefaultValues} literal ` +
       `(${counters.matchingDefaultValues} match their en value, ${counters.unjudgedDefaultValues} not comparable), ` +
       `${counters.computedDefaultValues} computed (report-only).`,
+  );
+  console.log(
+    `Inline default spelling: ${counters.spellingJudgedDefaults} default(s) carry readable text and are held to ` +
+      `the one placeholder spelling the provider-less fallback resolves — ${counters.spellingJudgedResidueDefaults} ` +
+      `of them on call sites the drift rule cannot pin, ${counters.opaqueDefaultText} with no readable text at all.`,
   );
   console.log(
     `Interpolation parity: ${counters.judgedInterpolation} call sites compared against their en value's holes, ` +
@@ -1967,6 +2225,7 @@ if (invokedDirectly) {
   const drift = unexpected.filter((finding) => finding.reason === 'default-value-drift');
   const parity = unexpected.filter((finding) => finding.reason === 'interpolation-parity');
   const siblings = unexpected.filter((finding) => finding.reason === 'dead-sibling-fallback');
+  const spelling = unexpected.filter((finding) => finding.reason === 'unresolvable-default-spelling');
   // objectui#4964's classes read on their own too: they are all about a template
   // family whose HEAD resolves, which is precisely the case the two key classes
   // above declare out of scope.
@@ -1979,7 +2238,12 @@ if (invokedDirectly) {
     'empty-vocabulary',
   ]);
   const families = unexpected.filter((finding) => FAMILY_CLASSES.has(finding.reason));
-  const VALUE_CLASSES = new Set(['default-value-drift', 'interpolation-parity', 'dead-sibling-fallback']);
+  const VALUE_CLASSES = new Set([
+    'default-value-drift',
+    'interpolation-parity',
+    'dead-sibling-fallback',
+    'unresolvable-default-spelling',
+  ]);
   const keyFindings = unexpected.filter(
     (finding) => !VALUE_CLASSES.has(finding.reason) && !FAMILY_CLASSES.has(finding.reason),
   );
@@ -1988,8 +2252,9 @@ if (invokedDirectly) {
     console.log(
       `Every in-scope call-site key resolves against the en pack (${enKeyCount} keys), every` +
         ' literal inline defaultValue matches the value the pack serves, every call site passes' +
-        ' exactly the arguments that value has holes for, no call site carries a literal' +
-        ' fallback beside itself, and every dynamic key family either checks its members' +
+        ' exactly the arguments that value has holes for, every inline defaultValue spells its' +
+        ' placeholders the one way the provider-less fallback resolves, no call site carries a' +
+        ' literal fallback beside itself, and every dynamic key family either checks its members' +
         ' against a declared vocabulary or says in writing why it has none.',
     );
     process.exit(0);
@@ -2048,6 +2313,21 @@ if (invokedDirectly) {
       console.error(`  ${finding.file}:${finding.line}:${finding.column}  [${finding.reason}]  ${finding.detail}`);
       console.error(`      en renders:  ${quote(finding.expected)}`);
       console.error(`      dead ${finding.operator} operand: ${quote(finding.actual)}`);
+    }
+  }
+
+  if (spelling.length > 0) {
+    const distinct = new Set(spelling.map((finding) => `${finding.file}:${finding.line}`));
+    console.error(
+      `\n${spelling.length} placeholder${spelling.length === 1 ? '' : 's'} in an inline defaultValue ` +
+        `cannot be resolved by the provider-less fallback (${distinct.size} call ` +
+        `site${distinct.size === 1 ? '' : 's'}) — with a provider i18next renders ` +
+        'them correctly, so the braces reach the user only where nobody is looking:',
+    );
+    for (const finding of spelling) {
+      console.error(`  ${finding.file}:${finding.line}:${finding.column}  [${finding.reason}]  ${finding.detail}`);
+      console.error(`      default text: ${quote(finding.expected)}`);
+      console.error(`      ${finding.actual}`);
     }
   }
 


### PR DESCRIPTION
Part of #4905

## What this closes

`check:i18n-keys`' `default-value-drift` class pins an inline `defaultValue` byte-identical to its `en` row, and objectui#3512 holds `en` to the one placeholder spelling `createSafeTranslation`'s `fallbackT` interpolates — so most inline defaults are covered transitively. **Re-derived on this tree (the card's census is from 2026-08-21 and has moved):**

```
BEFORE @ 50d0d6cc5   Inline defaults: 940 literal (937 match their en value, 3 not comparable), 63 computed.
                     residue with no transitive pin = 66 of 1003   (card said 65 of 971)
AFTER  @ 50d30a8c4   Inline defaults: 943 literal (940 match), 58 computed.
                     Inline default spelling: 977 judged — 37 of them on call sites the drift
                     rule cannot pin, 24 with no readable text at all.
```

Route **B** is the primary deliverable; route **C** turned out to reach only 5 sites, and *why* is the load-bearing result below. **A was not attempted.**

## The measurement that inverted route C

The card, the triage note and the dispatch all assumed the 63 computed defaults were unpinned near-misses — `` `Signed in as ${user.email}` `` where the pack says `Signed in as {{email}}` — and that rewriting them to the `en` value would be behaviour-preserving. I applied that rewrite to all 39 comparable sites, and `packages/plugin-grid/src/__tests__/objectBulkActionDispatch.test.tsx` went red on three cases. Bisected to one line, then measured the cause in `react-i18next/dist/es/useTranslation.js`:

```js
const notReadyT = (k, optsOrDefaultValue) => {
  if (isObject(optsOrDefaultValue) && isString(optsOrDefaultValue.defaultValue)) return optsOrDefaultValue.defaultValue;
```

**react-i18next's not-ready `t` returns `defaultValue` verbatim — it does not interpolate.** Three things can render an inline default, and only two of them interpolate it:

| renderer | interpolates? | reachable when |
|---|---|---|
| i18next, provider mounted | yes — but the pack value wins, so the default never renders | moot |
| `createSafeTranslation`'s `fallbackT` | yes, with the literal `{{k}}` needle | provider-less, key absent from the defaults map |
| react-i18next `notReadyT` | **no** | bare `useObjectTranslation()` with no i18next instance |

So at a call site bound to a bare `useObjectTranslation()`, the template literal is the *only* one of the two forms that renders correctly with no provider. "Making it comparable" would have put literal `{{braces}}` in front of a user on exactly the provider-less host this family of cards is about — a coverage number bought by introducing the defect. Per the dispatch's "do not weaken the pin to make sites fit", those sites stay computed and are covered by the spelling class instead.

**Also left alone, for a separate measured reason:** the five `PermissionFacetLink` sites. Four of their keys are i18next plural families (`perm.facet.objects` + `perm.facet.objects_one`), so the drift rule's `enValue` is the family's *base* form; byte-equality against it would delete the English singular that `perm-home-namespace-3546.test.tsx` already pins count by count in all ten languages — a strictly stronger assertion than the one it would have been traded for. The fifth (`perm.facet.more`) is flat and safe, but its source spelling is the declared *premise* of that same equivalence case, and it is already covered there.

### The 5 that are safe, and why each one is

Four carry **no placeholder at all**, so all three renderers agree; one sits behind a `createSafeTranslation` hook, which does interpolate.

| site | change | why safe |
|---|---|---|
| `AppContent.tsx` submit button ×2 | `t('common.save', …)` / `t('common.create', …)` → `'Update'` / `'Create'` | hole-free. Also **a real drift fix**: the nested call resolved to `Save` where the pack renders `Update` |
| `ContextSelectors.tsx` | `rawLabel` → `'Package'` | hole-free, and provably equal inside the `rawLabel === 'Package'` guard two lines up |
| `approverIdentity.ts` | `DEFAULT_NAME_SEPARATOR` → `', '` | hole-free, byte-identical to the constant |
| `DetailSection.tsx` | template → `'Show {{count}} empty fields'` | `useDetailTranslation` is a `createSafeTranslation` factory, so `fallbackT` interpolates it |

## Route B — class 7, `unresolvable-default-spelling`

objectui#3512's rule, placed beside `holesOf()` where the call-site classification already lives, applied to the text an inline default carries: the folded sentence, or a template literal's **static segments** (the surface class 3 structurally cannot judge). `{{ name }}`, `{{count, number}}`, `{{- name}}` and `$t(key)` are refused wherever they are written.

Judged over **every** inline default (977), not only the residue — a pinned default is byte-equal to an `en` value #3512 already covers, so those come back green twice over, which is what makes the count a live control instead of a rule whose whole subject is a handful of strings that could silently become zero. Single-brace `{x}` holes (objectui#4135) and JSX `style={{…}}` braces are out of range **by construction**: the rule is handed a literal's text, never source.

## Non-vacuity — each direction predicted before it was run

1. **Pin strength unchanged.** Mutated a previously-covered site (`ReportConfigPanel.tsx:198`, `'Save'` → `'Save changes'`). Staged a copy of the pre-change gate and ran both. Verdicts **byte-identical**, both `exit 1`:
   ```
   packages/app-shell/src/views/ReportConfigPanel.tsx:198:12  [default-value-drift]  common.save
       en renders: "Save"    call site:  "Save changes"
   ```
2. **A newly covered site reds.** `DeviceAuthPage.tsx:314` is one of the 5 → mutated `'Signed in as {{email}}'` → `'{{ email }}'`. Predicted both classes; got both — `default-value-drift` *and* `unresolvable-default-spelling`, `exit 1`. The pre-change gate also reds on it now, which is the point: route C moved it under the **existing** pin rather than under the new rule.
3. **The residue reds, and only the new rule sees it.** `HomePage.tsx:415` (dynamic key, so no transitive pin can ever reach it) → `'Welcome'` → `'Welcome {{ name }}'`. **Pre-change gate: `exit 0`, silent. New gate: `exit 1`,** naming the site. This is B's non-vacuity proof.
4. **Zero must fail.** A second collapse guard beside the existing one: under 500 judged defaults the CLI exits non-zero rather than passing on an empty set, and the self-test pins the same floor.

Every mutation was proven on disk by anchored counts (anchor `1→0`, injection `0→1`) — never an editor's exit code — and restored with `git checkout HEAD --` plus the explicit path, proven by an empty `git diff HEAD`.

## Verification, at `50d30a8c4` (the final commit)

- `pnpm lint` — **47/47 tasks successful, 0 errors** (2673 pre-existing warnings). Full repo, not narrowed.
- `check:i18n-keys` `exit 0` · `check:i18n-drift` `exit 0` — *"0 en value(s) changed"*, no pack was touched · `check:control-bytes` `exit 0` · `check:phantom-deps` `exit 0` · `check:i18n-dead-keys` `exit 0` (report-only; candidate count unchanged at 389)
- `changeset:check` `exit 0` · `type-check:scripts` `exit 0`
- Root vitest: self-test + `packages/plugin-detail/` + `packages/plugin-grid/` — **191 files, 1899 tests passed**; the 36 app-shell test files reading the changed modules — **319 tests passed**.

Exit codes captured by redirect before any pipe; gate results quoted from each gate's own verdict line.

`scripts/i18n-call-site-key-baseline.json` is **not** touched.

### One test assertion narrowed

`scripts/__tests__/check-i18n-call-site-keys.test.ts` pinned `"t?.('common.package', { defaultValue: rawLabel }) ?? rawLabel"` as one string. That case is about the `dead-sibling-fallback` rule abstaining on an **optional call with a live `??` operand** — the options object between them is a different rule's territory. Narrowed to the optional call and the `??` operand, so a class-3 fix stops reading as a class-5 regression.


---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_