### PR TITLE
docs(agents): generalise the shared-stash rule to all shared ref namespaces

### DIFF
--- a/.changeset/5700-shared-ref-namespaces.md
+++ b/.changeset/5700-shared-ref-namespaces.md
@@ -1,0 +1,26 @@
+---
+---
+
+Instruction-file only. `AGENTS.md` §9 多 agent 协作纪律 gains one bullet beside the
+existing `git stash` bullet, generalising it: a worktree isolates your checkout and
+exactly four ref namespaces (`HEAD`, `refs/bisect`, `refs/worktree`, `refs/rewritten`)
+and nothing else — not the object store, not the repo config, not any other ref. The
+existing stash rule is reframed as one case of that, because a reader who learns only
+the stash rule draws the opposite general conclusion.
+
+Two further instances that have cost work are stated: `refs/remotes/*` (a sibling
+agent's fetch advances *your* `origin/main`, so a path-scoped `git checkout origin/main`
+restores whatever that ref points at now — possibly newer than your branch base — and
+stages it), and `FETCH_HEAD` (last fetch in the checkout wins; the symptom is an empty
+diff that exits 0, which reads as "the change is not there" rather than as wrong
+content — a confidently wrong review conclusion about someone else's work).
+
+The `FETCH_HEAD` isolation boundary is stated as measured rather than extrapolated from
+`refs/stash`: on git 2.43 `git rev-parse --git-path FETCH_HEAD` resolves per-worktree in
+a linked worktree, so a sibling's fetch in *its* worktree does not move yours; the
+hazard is the shared primary checkout, where the same command resolves to the common
+`.git/FETCH_HEAD` and where every agent's first fetch lands before it creates a worktree.
+
+No hook is added — the safe forms are ordinary commands and the unsafe form is
+legitimate elsewhere, so a mechanical block would fire on correct usage. No published
+package changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,21 @@ AGENTS.md 的「只跑受影响的包」指的是**用上面的路径过滤缩�
   ```
 
   三者的共同点是**先把未提交状态捕获下来**再动工作区;任何「先覆盖、事后再从某个 ref 取回」的写法都**不是**替代做法 —— 它假设你的改动已经提交,而反向验证时通常没有(objectstack#7800:那条推荐语害一个 agent 丢了在途改动)。一个 **PreToolUse 钩子**(`.claude/hooks/guard-shared-stash.sh`)**强制**此规则:拦截 push/pop/drop/clear 共享栈的 `Bash` 命令,放行拿不到别人条目的形式 —— `git stash list`/`show`/`create`,以及 `git stash apply <sha>` / `store <sha>` 且 sha 为**字面十六进制 object id**(绝不用 `stash@{N}` —— 那是你并不拥有的那个栈里的一个**位置**)。确知栈只属于你时用 `OS_ALLOW_STASH=1` 放行;改了钩子就重跑 `.claude/hooks/guard-shared-stash.selftest.sh`。
+- **上一条不是孤例 —— worktree 只隔离你的 checkout 和四个 ref 命名空间,其余一切共享。** Git 的 per-worktree ref 命名空间**恰好四个**:`HEAD`、`refs/bisect`、`refs/worktree`、`refs/rewritten`。**除此之外全部共享** —— 不是 object store,不是 repo config,也不是任何别的 ref。上一条的 `refs/stash` 是本规则的一个**特例**,不是一条孤立的怪癖;只读到那一条就以为「worktree 隔离 ref、只有 stash 例外」的,恰好把结论记反了。判据只有一条命令:`git rev-parse --git-dir` 与 `--git-common-dir` **不同**说明你在 linked worktree 里,而**凡是落在 common dir 底下的东西都是共用的**(实测本仓:linked worktree 的 `--git-dir` 是 `.git/worktrees/<name>`,`--git-common-dir` 是 `.git`;`HEAD` 两棵树各有一份、读数不同,`refs/remotes/` 在 per-worktree 目录里**根本不存在**,只有 common dir 那一份)。除 stash 外,另外两个已经吃过亏的实例:
+
+  1. **`refs/remotes/*`** —— 别的 agent 在**它自己的** worktree 里 `git fetch`,推进的是**你的** `origin/main`。于是 `git checkout origin/main -- <paths>` 在 worktree 里**不是**「还原到我的分支基点」,而是「还原到 `origin/main` **此刻**指向的地方」—— 那可能比你切分支的那个 commit 更新,别人刚合并的改动就以「revert」的名义进了你的工作区,随后一次 `git add -A` 把它们扫进你的 PR。实测本仓:四个 agent 并行时 `origin/main` **十分钟内动了三次**。⚠️ 而且 path-scoped checkout 会**顺带 stage** 它还原的内容 —— 污染到达时已经在 index 里了。
+  2. ⭐ **`FETCH_HEAD`** —— **它的症状是「没有内容」而不是「内容不对」,这是前两个实例推不出来的那一半。** `FETCH_HEAD` 是「**本 checkout 里最后一次 fetch** 的结果」,谁 fetch 的都算。`git fetch X && git diff …FETCH_HEAD` 写成**一条**命令是安全的;拆成**两条**就不是 —— 中间任何一次 fetch 都把它换成了另一条分支,而 `git diff` **退出 0、什么都不打印**。那个输出最自然的读法是「这个改动根本不在」:一个关于**别人**工作的、基于看起来很干净的证据的、自信的错误结论。⚠️ 对**做评审的座位**尤其致命 —— PM 拿 PR 比对 `main` 做的正是这个操作,而它朝「活儿没做」的方向失败。
+
+  ⚠️ **`FETCH_HEAD` 的隔离边界和前两个不一样,别照着 `refs/stash` 外推**(实测 git 2.43):`git rev-parse --git-path FETCH_HEAD` 在 linked worktree 里解析到 `.git/worktrees/<name>/FETCH_HEAD`,**B 在自己 worktree 里 fetch 并不会动 A 的 `FETCH_HEAD`** —— 这一点已经量过。它咬人的地方是**共享的主 checkout**:那里同一条命令解析到 common dir 的 `.git/FETCH_HEAD`,而每个 agent 在建自己 worktree**之前**的第一条 `git fetch` 都落在那儿,评审座位更是整天待在那儿。所以这一条按 **checkout** 说、不按 worktree 说:**同一个 checkout 里,最后一次 fetch 说了算**。
+
+  三条做法(都是**做法**,不是禁令):
+
+  - **钉住基点。** 建 worktree 时记下 `BASE=$(git rev-parse HEAD)`,还原一律 `git checkout "$BASE" -- <paths>`,绝不用一个会动的 remote-tracking 名字。真要以 `origin/main` 为源,就**按 commit 说**,别按 ref 名说。
+  - **确实点了 remote-tracking ref,就核验到手的内容。** 规则不是「绝不点名」,而是「它会在你脚下动,所以要查清楚拿到的是什么」—— 用磁盘上的出现次数**正反两个方向**查。objectui#5235 是这个缓解措施成功的实例:`resetInFlightRef` 计数 `7 → 0`,同时确认修复前的注释文本回到 2 处;`origin/main` 若已漂到另一个版本,这两个数都对不上。
+  - **fetch 进一个你自己命名的 ref。** `git fetch origin <branch>:refs/<namespace>/<id> -f`,然后读**那个** ref —— 没有任何 sibling 动得了它。这是 `FETCH_HEAD` 的解法。
+  - 任何 path-scoped 还原做完之后,把还原的那几个路径和记录的基点 diff 一次,**确认为空再 stage**。
+
+  ⛔ **这一条不会有钩子兜底**(上面 worktree 与 stash 两条各有一个 PreToolUse 钩子):安全形式就是 `git checkout` / `git fetch` 这些日常命令,而不安全的那个形式在别处完全正当 —— 机械拦截只会拦在正确用法上。所以这条规则的全部效力,就在于你还记不记得基点是**钉住的那个 commit**。
 - **临时文件所在的 scratchpad 目录跨会话共享 —— 提交信息与 PR 正文一律别落到那里。** 容器发给每个会话的「scratchpad」临时目录事实上被多个并行会话映射到**同一个路径**,和上一条的 stash 栈同族:一块位于 worktree 之外的共享可写状态,worktree 隔离**管不到它**。两个 agent 各写一份同名的 `commitmsg.txt` / `pr-body.md`,后写的整份顶掉先写的;而 `git commit -F` 读到别人的文件**不报错**,每一步都报成功 —— 受害的是**另一个** agent 的产出(你的提交信息落到别人的 commit 上,你这边什么都看不出来),没有任何错误可供发现。实测在 20 分钟内撞了两次,可见的损伤是 `main` 上一条 squash commit:提交信息描述的是一张卡、diff 实施的是另一张卡,两者毫无关系;`main` 不重写,于是这条误导永久留在 git 考古里 —— 下一个人按 `git log --grep` 找那张卡,会得出「已经做过了」的错误结论。两条做法,**有先后之分**:
 
   1. **首选机制:让内容根本不落共享盘。** 提交信息用 `git commit -F -` 配 heredoc(或多个 `-m`),PR 正文直接作为工具参数传(用 `gh` 就把正文写成进程内的 heredoc,别先写文件再 `--body-file`)。内容不落盘,就无从被顶掉。


### PR DESCRIPTION
Fixes #5700

## ⛔ Governed surface — this stays a draft

`AGENTS.md` is a governed face under the 2026-08-18 maintainer ruling. This PR is deliberately a **draft**, review requested from `os-zhuang`. It is not ready-flipped, has no auto-merge, and is not in the merge queue. A human lands it. Green is necessary here, not sufficient.

## What changes

One bullet added to `AGENTS.md` §9 多 agent 协作纪律, immediately after the existing `git stash` bullet, plus an empty-frontmatter changeset. **41 insertions, 0 deletions, one hunk.** Nothing around it is reflowed, renumbered or re-indented.

The existing stash rule teaches the right lesson at too narrow a scope. The general fact is:

> A worktree isolates your **checkout** and exactly four ref namespaces — `HEAD`, `refs/bisect`, `refs/worktree`, `refs/rewritten`. It does **not** isolate the object store, the repo config, or any other ref.

`refs/stash` is one *case* of that. A reader who learns only the stash bullet concludes "worktrees isolate refs, except stash" — the opposite of the truth — so the new text references the stash bullet as its own special case rather than restating it, and adds the two further instances that have cost work:

- **`refs/remotes/*`** — a sibling agent's fetch advances **your** `origin/main`, so a path-scoped `git checkout origin/main -- PATHS` restores whatever that ref points at *now*, possibly newer than your branch base — another agent's merged work entering your tree under the name of a "revert". A path-scoped checkout also **stages** what it restores, so contamination arrives already in the index.
- **`FETCH_HEAD`** — the instance whose symptom the other two cannot teach: an **absence**, not wrong content. A `git diff` against a moved `FETCH_HEAD` exits 0 and prints nothing, and the natural reading is *"the change is not there"* — a confidently wrong review conclusion about someone else's work, on evidence that looks clean. Called out as hitting **reviewing** seats hardest, since comparing a PR against `main` is exactly that operation.

Then three practices, stated as practices rather than prohibitions: pin `BASE=$(git rev-parse HEAD)` at worktree creation and restore against that commit; if you do name a remote-tracking ref, verify the content you got by occurrence counts on disk, in both directions; fetch into a ref you own (`git fetch origin BRANCH:refs/NAMESPACE/ID -f`) and read that.

## ⛔ No hook, by design

The safe forms are `git checkout` and `git fetch` — ordinary commands — and the unsafe form is legitimate elsewhere, so a mechanical block would fire on correct usage. The card's own reasoning is binding on this and the new text says so explicitly. None is added and none is proposed.

## ⚠️ One deviation from the dispatch order, and why

The dispatch order described `FETCH_HEAD` as living in the common `.git` directory and being shared by every worktree. **I measured it instead of copying it, and that wording is not right for linked worktrees on git 2.43.** Writing it into a governed instruction file would have repeated this very card's original error — an unverified scope claim — in the opposite direction.

```
# in a linked worktree
git rev-parse --git-path FETCH_HEAD  ->  .git/worktrees/NAME/FETCH_HEAD
# in the shared primary checkout
git rev-parse --git-path FETCH_HEAD  ->  .git/FETCH_HEAD
```

Empirically: worktree B fetching a *different* branch did **not** move worktree A's `FETCH_HEAD`; a second fetch inside A itself **did** replace it. So the landed text states the rule per **checkout**, not per worktree — *the last fetch in this checkout wins* — and names the real hazard site: the **shared primary checkout**, where reviewing seats work all day and where every agent's first `git fetch` lands before it creates a worktree. That is fully consistent with the incident recorded on the card, which happened in the shared checkout, and it explains it precisely.

## Verification — the positive control is the measurement

Two worktrees of this repo, A (this task's) and B (a detached probe), with a genuinely per-worktree ref contrasted against a shared one. Without that contrast "this ref is shared" and "I measured nothing" print the same thing.

| reading | A | B | verdict |
|---|---|---|---|
| `--git-dir` | `.git/worktrees/objectui-issue-5700` | `.git/worktrees/…-probe` | per-worktree |
| `--git-common-dir` | `.git` | `.git` | shared root |
| **`HEAD`** ⭐ positive control | `65d3e767f` | `41b7ce3ce` | **differs — genuinely per-worktree** |
| **`refs/remotes/origin/main`** | `65d3e767f` | `65d3e767f` | **identical — shared** |

On disk, the same split: `.git/worktrees/NAME/HEAD` exists once per worktree, while `refs/remotes` has **no** per-worktree copy at all — only `.git/refs/remotes`.

`FETCH_HEAD`, four steps:

| step | action | `FETCH_HEAD` read |
|---|---|---|
| 1 | A fetches `main` | A = `65d3e767f` |
| 2 | B fetches a different branch | B = `0c36cd3c4` |
| 3 | re-read A (A did nothing) | A = `65d3e767f` — **not moved by B** |
| 4 | a second fetch inside A itself | A = `0c36cd3c4` — **replaced** |

⚠️ **Not extrapolated past what was measured.** The four-namespace list is git's documented per-worktree ref set, as stated on the card; of it I verified `HEAD` directly, and verified `refs/remotes/*` and `FETCH_HEAD` directly. `refs/tags` and `refs/notes` were **not** tested here and the landed text does not claim measurement for them. Offline man pages were unavailable in this container, so the documented list is cited as documentation, not as something I re-derived.

## Gates

All at final head **`e5099dee7`** (tree `42b3eed7a`), each exit code captured by redirect before any pipe, each quoted from the gate's own verdict line:

| gate | exit | verdict line |
|---|---|---|
| `check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 5130 tracked text file(s); skipped 85 binary).` |
| `check-doc-links.mjs` | 0 | `Links are valid across 15 scan roots.` |
| `check-changeset-presence.mjs` | 0 | `✅ No source of a released package changed in this range, so no changeset is owed.` |
| `changeset:check` | 0 | `✅ All workspace packages are in the changeset fixed group.` / `✅ No changeset declares a major bump.` |
| `pnpm lint:root` | 0 | `✖ 28 problems (0 errors, 28 warnings)` |

`lint:root` ran **in full, unnarrowed**. Its 28 warnings are pre-existing `no-explicit-any` in `e2e/`, `scripts/__tests__/` and `vitest.setup.base.ts` — none of them files this PR touches. Measured from eslint's own config via `--format json`: it lints **191 files, 0 of them `.md`**, and neither changed file (`AGENTS.md`, `.changeset/5700-shared-ref-namespaces.md`) is in its population at all. A control-byte self-scan over the changed file (`grep -naP` across the C0 range plus DEL) is clean independently of the gate.

The changeset carries empty frontmatter — this repo's declaration form for a change that publishes nothing.

## Coordination

- **#6183 is an outstanding draft against this same file, with a disjoint insertion point.** It appends a new `###` subsection at the end of §9, immediately before the `### ⛔ 受管面(governed surface)` heading; this PR inserts a list item in the earlier bullet run beside the stash bullet. The two regions do not overlap and neither reflows the other's context, so **merge order between them is free**.
- The same lesson belongs in objectstack's `AGENTS.md` / `CLAUDE.md`. That edit is the skills lane's and is out of scope here, so it is filed as the upstream twin card objectstack-ai/objectstack#11946 (unassigned, `finding`) — including the `FETCH_HEAD` correction above, so it is not copied upstream in the unverified form.
- No file under `content/docs/releases/` is touched.

Refs: #3430 (the stash instance) · #5202 and #5235 (the remote-tracking instances) · the card's 2026-08-24 comment (the `FETCH_HEAD` instance).

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_