### PR TITLE
docs(core,data-objectstack): let each adapter README document its own directory

### DIFF
--- a/.changeset/6213-core-adapters-readme-owns-its-directory.md
+++ b/.changeset/6213-core-adapters-readme-owns-its-directory.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/core': patch
+'@object-ui/data-objectstack': patch
+---
+
+`packages/core/src/adapters/README.md` now documents the adapters that are actually in that
+directory, and the ObjectStack material it carried moved to the package that owns the behaviour
+(objectui#6213). Both files ship to consumers — `@object-ui/core` publishes its `src/`, and a
+README rides every tarball — so this was published documentation describing the wrong package.
+
+The page had been left behind when the ObjectStack adapter moved out to
+`@object-ui/data-objectstack`: its headings, feature list, filter-operator table and
+query-parameter table were all about that adapter, and its one-entry "Available Adapters" list
+told a reader Object UI has exactly one adapter and that it comes from `@object-ui/core`.
+`ApiDataSource`, `ValueDataSource`, `resolveDataSource`, `runBatchTransaction` and
+`emulateBatchTransaction` — the five exports that directory really ships — were named nowhere.
+
+- **`@object-ui/core`**: the page now opens with what the directory holds, gives each export a
+  usage snippet and a `provider` mapping, and points at `@object-ui/data-objectstack` for the
+  ObjectStack adapter. `## Creating Custom Adapters` is unchanged — it is the one section that was
+  always about this directory.
+- **`@object-ui/data-objectstack`**: gains a `## Query Translation` section carrying the
+  filter-operator and query-parameter mapping tables, the AST conversion example and the sorting
+  example. That material existed **only** in the `core` copy — this package's README documented
+  query translation as a single feature bullet — so it is ported, not dropped.
+
+No runtime behaviour changes; the duplicate copy of one package's documentation living under
+another package is what goes away.

--- a/packages/core/src/adapters/README.md
+++ b/packages/core/src/adapters/README.md
@@ -1,137 +1,131 @@
 # Data Source Adapters
 
-This directory contains data source adapters that bridge various backend protocols with the ObjectUI DataSource interface.
+This directory holds the `DataSource` adapters that ship **inside
+`@object-ui/core`** — the backend-agnostic ones, with no external SDK
+dependency. They are what a schema's `viewData` block resolves to at runtime.
 
-## ObjectStack Adapter
+> **Looking for the ObjectStack adapter?** It is not in this directory.
+> `ObjectStackAdapter` / `createObjectStackAdapter` ship as their own package,
+> **[`@object-ui/data-objectstack`](../../../data-objectstack/README.md)**,
+> whose README owns the ObjectStack material — connection handling, metadata
+> caching, error hierarchy, and the filter-operator and query-parameter
+> translation tables.
 
-The `ObjectStackAdapter` provides seamless integration with ObjectStack Protocol servers.
+## Available Adapters
 
-### Features
+Every export below is re-exported from the package root, so consumers import
+them from `@object-ui/core`.
 
-- ✅ Full CRUD operations (find, findOne, create, update, delete)
-- ✅ Bulk operations (createMany, updateMany, deleteMany)
-- ✅ Auto-discovery of server capabilities
-- ✅ Query parameter translation (OData-style → ObjectStack)
-- ✅ Proper error handling
-- ✅ TypeScript types
+| Export | Kind | Role |
+| --- | --- | --- |
+| `ApiDataSource` | class | `provider: 'api'` — raw HTTP against the `HttpRequest` configs carried in `ViewData` |
+| `ValueDataSource` | class | `provider: 'value'` — an in-memory array; no network at all |
+| `resolveDataSource` | function | builds the adapter a `ViewData` config asks for (`object` / `api` / `value`) |
+| `runBatchTransaction` / `emulateBatchTransaction` | functions | ordered cross-object save — the adapter's own `batchTransaction` when it has one, a sequential non-atomic emulation when it does not |
 
-### Usage
+Backend-specific adapters live in their own packages rather than here; today
+that is `@object-ui/data-objectstack`.
 
-```typescript
-import { createObjectStackAdapter } from '@object-ui/core';
+### `ApiDataSource`
 
-// Create the adapter
-const dataSource = createObjectStackAdapter({
-  baseUrl: 'https://api.example.com',
-  token: 'your-auth-token', // Optional
-});
-
-// Use it with ObjectUI components
-const schema = {
-  type: 'data-table',
-  dataSource,
-  resource: 'users',
-  columns: [
-    { header: 'Name', accessorKey: 'name' },
-    { header: 'Email', accessorKey: 'email' },
-  ]
-};
-```
-
-### Advanced Usage
+For `provider: 'api'`. The endpoint comes from the `HttpRequest` configs, not
+from the `resource` argument — `find`/`findOne` use `read`, and
+`create`/`update`/`delete` use `write` (falling back to `read` when `write` is
+absent). `QueryParams` are flattened onto the query string.
 
 ```typescript
-import { ObjectStackAdapter } from '@object-ui/core';
+import { ApiDataSource } from '@object-ui/core';
 
-const adapter = new ObjectStackAdapter({
-  baseUrl: 'https://api.example.com',
-  token: process.env.API_TOKEN,
-  fetch: customFetch // Optional: use custom fetch (e.g., Next.js fetch)
+const dataSource = new ApiDataSource({
+  read: { url: 'https://api.example.com/users', method: 'GET' },
+  write: { url: 'https://api.example.com/users' },
+  defaultHeaders: { Authorization: 'Bearer …' },
+  // fetch: customFetch,   // optional; defaults to globalThis.fetch
 });
 
-// Manually connect (optional, auto-connects on first request)
-await adapter.connect();
-
-// Query with filters (MongoDB-like operators)
-const result = await adapter.find('tasks', {
-  $filter: { 
-    status: 'active',
-    priority: { $gte: 2 }
-  },
-  $orderby: { createdAt: 'desc' },
-  $top: 20,
-  $skip: 0
-});
-
-// Access the underlying client for advanced operations
-const client = adapter.getClient();
-const metadata = await client.meta.getObject('task');
+const { data, total } = await dataSource.find('users', { $top: 20 });
 ```
 
-### Filter Conversion
+A generic HTTP endpoint exposes no metadata, so `getObjectSchema()` returns a
+minimal stub (`{ name, fields: {} }`) and `getView()` / `getApp()` return
+`null` — enough that schema-dependent components do not crash.
 
-The adapter automatically converts MongoDB-like filter operators to **ObjectStack FilterNode AST format**. This ensures compatibility with the latest ObjectStack Protocol (v0.1.2+).
+### `ValueDataSource`
 
-#### Supported Filter Operators
-
-| MongoDB Operator | ObjectStack Operator | Example |
-|------------------|---------------------|---------|
-| `$eq` or simple value | `=` | `{ status: 'active' }` → `['status', '=', 'active']` |
-| `$ne` | `!=` | `{ status: { $ne: 'archived' } }` → `['status', '!=', 'archived']` |
-| `$gt` | `>` | `{ age: { $gt: 18 } }` → `['age', '>', 18]` |
-| `$gte` | `>=` | `{ age: { $gte: 18 } }` → `['age', '>=', 18]` |
-| `$lt` | `<` | `{ age: { $lt: 65 } }` → `['age', '<', 65]` |
-| `$lte` | `<=` | `{ age: { $lte: 65 } }` → `['age', '<=', 65]` |
-| `$in` | `in` | `{ status: { $in: ['active', 'pending'] } }` → `['status', 'in', ['active', 'pending']]` |
-| `$nin` / `$notin` | `notin` | `{ status: { $nin: ['archived'] } }` → `['status', 'notin', ['archived']]` |
-| `$contains` / `$regex` | `contains` | `{ name: { $contains: 'John' } }` → `['name', 'contains', 'John']` |
-| `$startswith` | `startswith` | `{ email: { $startswith: 'admin' } }` → `['email', 'startswith', 'admin']` |
-| `$between` | `between` | `{ age: { $between: [18, 65] } }` → `['age', 'between', [18, 65]]` |
-
-#### Complex Filter Examples
-
-**Multiple conditions** are combined with `'and'`:
+For `provider: 'value'`. Everything runs against an in-memory array, which is
+deep-cloned on construction so the caller's array is never mutated. Useful for
+static content, fixtures, and previews.
 
 ```typescript
-// Input
-$filter: {
-  age: { $gte: 18, $lte: 65 },
-  status: 'active'
-}
+import { ValueDataSource } from '@object-ui/core';
 
-// Converted to AST
-['and', 
-  ['age', '>=', 18],
-  ['age', '<=', 65],
-  ['status', '=', 'active']
-]
-```
-
-### Query Parameter Mapping
-
-The adapter automatically converts ObjectUI query parameters (OData-style) to ObjectStack protocol:
-
-| ObjectUI ($) | ObjectStack | Description |
-|--------------|-------------|-------------|
-| `$select` | `select` | Field selection |
-| `$filter` | `filters` (AST) | Filter conditions (converted to FilterNode AST) |
-| `$orderby` | `sort` | Sort order |
-| `$skip` | `skip` | Pagination offset |
-| `$top` | `top` | Limit records |
-
-### Example with Sorting
-
-```typescript
-// OData-style
-await dataSource.find('users', {
-  $orderby: { 
-    createdAt: 'desc',
-    name: 'asc'
-  }
+const dataSource = new ValueDataSource({
+  items: [
+    { id: '1', name: 'Alice', age: 30 },
+    { id: '2', name: 'Bob', age: 24 },
+  ],
+  // idField: 'id',   // optional; defaults to `id`, then `_id`
 });
 
-// Converted to ObjectStack: ['-createdAt', 'name']
+const { data, total } = await dataSource.find('people', {
+  $filter: { age: { $gte: 25 } },
+  $orderby: { name: 'asc' },
+});
 ```
+
+It implements `$filter` (both MongoDB-style objects and FilterNode AST arrays),
+`$search`, `$orderby`, `$skip`, `$top` and `$select` locally, plus `bulk()`,
+`aggregate()` and `onMutation()`. `getAll()` returns a cloned snapshot and
+`count` the current length.
+
+### `resolveDataSource`
+
+Turns a `ViewData` config into a concrete adapter. This is the function a
+renderer calls; components do not branch on `provider` themselves.
+
+```typescript
+import { resolveDataSource } from '@object-ui/core';
+
+const dataSource = resolveDataSource(
+  { provider: 'api', read: { url: '/api/users' } },
+  contextDataSource, // used for `provider: 'object'`, and as the fallback
+);
+```
+
+| `viewData.provider` | Result |
+| --- | --- |
+| `'object'` | the `fallback` — the `DataSource` from context, typically `ObjectStackAdapter` |
+| `'api'` | a new `ApiDataSource` built from `read` / `write` |
+| `'value'` | a new `ValueDataSource` over `items` |
+| unknown, or no `viewData` | the `fallback`, else `null` |
+
+### `runBatchTransaction` / `emulateBatchTransaction`
+
+The single entry point for an ordered **cross-object** save (the master-detail
+case). `runBatchTransaction` calls the adapter's native `batchTransaction` when
+it implements one — `ObjectStackAdapter` does, and against a backend
+advertising `capabilities.transactionalBatch` that is a real server
+transaction — and otherwise falls back to `emulateBatchTransaction`. Callers
+stay ignorant of which one ran.
+
+```typescript
+import { runBatchTransaction } from '@object-ui/core';
+
+// `{ $ref: 0 }` resolves to the id minted by operation 0 (the parent).
+await runBatchTransaction(dataSource, [
+  { object: 'invoice',      action: 'create', data: { no: 'INV-1' } },
+  { object: 'invoice_line', action: 'create', data: { invoice: { $ref: 0 }, amount: 10 } },
+]);
+```
+
+⚠️ The emulation is **not** atomic. It runs the operations in order and, on
+failure, best-effort deletes the records it created (children before parent)
+before rethrowing; updates and deletes that already ran cannot be undone, and a
+create's side effects (hooks, rollups, webhooks) are not undone by a later
+delete. It exists so a save is still possible against a backend without server
+atomicity — see
+[`@object-ui/data-objectstack`](../../../data-objectstack/README.md#cross-object-atomic-batch-batchtransaction)
+for the capability negotiation that decides which path is taken.
 
 ## Creating Custom Adapters
 
@@ -168,13 +162,9 @@ export class MyCustomAdapter<T = any> implements DataSource<T> {
 }
 ```
 
-## Available Adapters
-
-- **ObjectStackAdapter** - For ObjectStack Protocol servers
-- More adapters coming soon (REST, GraphQL, Supabase, Firebase, etc.)
-
 ## Related Packages
 
-- `@objectstack/client` - ObjectStack Client SDK
-- `@objectstack/spec` - ObjectStack Protocol Specification
-- `@object-ui/types` - ObjectUI Type Definitions
+- `@object-ui/types` — the `DataSource`, `QueryParams` and `ViewData` definitions these adapters implement
+- `@object-ui/data-objectstack` — the ObjectStack Protocol adapter, and the owner of the ObjectStack documentation
+- `@objectstack/client` — ObjectStack Client SDK (a dependency of `@object-ui/data-objectstack`, not of `@object-ui/core`)
+- `@objectstack/spec` — ObjectStack Protocol Specification

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -71,6 +71,96 @@ const dataSource = createObjectStackAdapter({
 - ✅ **Auto-Reconnect**: Automatic reconnection with exponential backoff on connection failures.
 - ✅ **Batch Progress**: Progress events for tracking bulk operation status.
 
+## Query Translation
+
+`find()` accepts Object UI's OData-style `QueryParams` and translates them into
+ObjectStack's native query format, so a schema never has to be written in the
+protocol's own shape:
+
+```typescript
+// Query with filters (MongoDB-like operators)
+const result = await dataSource.find('tasks', {
+  $filter: {
+    status: 'active',
+    priority: { $gte: 2 },
+  },
+  $orderby: { createdAt: 'desc' },
+  $top: 20,
+  $skip: 0,
+});
+
+// Escape hatch: reach the underlying ObjectStack client for anything
+// the DataSource interface does not cover
+const client = dataSource.getClient();
+const metadata = await client.meta.getObject('task');
+```
+
+### Query Parameter Mapping
+
+| Object UI (`$`) | ObjectStack | Description |
+|--------------|-------------|-------------|
+| `$select` | `select` | Field selection |
+| `$filter` | `filters` (AST) | Filter conditions (converted to FilterNode AST) |
+| `$orderby` | `sort` | Sort order |
+| `$skip` | `skip` | Pagination offset |
+| `$top` | `top` | Limit records |
+
+### Filter Conversion
+
+The adapter converts MongoDB-like filter operators into **ObjectStack FilterNode
+AST format**. This is what keeps it compatible with the ObjectStack Protocol
+(v0.1.2+).
+
+#### Supported Filter Operators
+
+| MongoDB Operator | ObjectStack Operator | Example |
+|------------------|---------------------|---------|
+| `$eq` or simple value | `=` | `{ status: 'active' }` → `['status', '=', 'active']` |
+| `$ne` | `!=` | `{ status: { $ne: 'archived' } }` → `['status', '!=', 'archived']` |
+| `$gt` | `>` | `{ age: { $gt: 18 } }` → `['age', '>', 18]` |
+| `$gte` | `>=` | `{ age: { $gte: 18 } }` → `['age', '>=', 18]` |
+| `$lt` | `<` | `{ age: { $lt: 65 } }` → `['age', '<', 65]` |
+| `$lte` | `<=` | `{ age: { $lte: 65 } }` → `['age', '<=', 65]` |
+| `$in` | `in` | `{ status: { $in: ['active', 'pending'] } }` → `['status', 'in', ['active', 'pending']]` |
+| `$nin` / `$notin` | `notin` | `{ status: { $nin: ['archived'] } }` → `['status', 'notin', ['archived']]` |
+| `$contains` / `$regex` | `contains` | `{ name: { $contains: 'John' } }` → `['name', 'contains', 'John']` |
+| `$startswith` | `startswith` | `{ email: { $startswith: 'admin' } }` → `['email', 'startswith', 'admin']` |
+| `$between` | `between` | `{ age: { $between: [18, 65] } }` → `['age', 'between', [18, 65]]` |
+
+#### Complex Filter Examples
+
+**Multiple conditions** are combined with `'and'`:
+
+```typescript
+// Input
+const $filter = {
+  age: { $gte: 18, $lte: 65 },
+  status: 'active',
+};
+
+// Converted to AST
+const ast = [
+  'and',
+  ['age', '>=', 18],
+  ['age', '<=', 65],
+  ['status', '=', 'active'],
+];
+```
+
+### Sorting
+
+```typescript
+// OData-style
+await dataSource.find('users', {
+  $orderby: {
+    createdAt: 'desc',
+    name: 'asc',
+  },
+});
+
+// Converted to ObjectStack: ['-createdAt', 'name']
+```
+
 ## Metadata Caching
 
 The adapter includes built-in metadata caching to improve performance when fetching schemas:


### PR DESCRIPTION
Fixes #6213

Route **A, as a port** — decided by the measurement the triage named as deciding, not by preference. 3 files, +216 / −108.

## The measurement, first, because it chooses A vs B

I read `packages/data-objectstack/README.md` (486 lines) before moving anything. Section by section against the ObjectStack half of `packages/core/src/adapters/README.md`:

| `core/src/adapters/README.md` section | Already in `data-objectstack`'s README? | Disposition |
| --- | --- | --- |
| `### Features` (6 bullets) | **Yes** — `## Features` (9 bullets) is a superset: CRUD, bulk, metadata, query translation, error handling, plus caching / connection / reconnect / progress | dropped as duplicate |
| `### Usage` (`createObjectStackAdapter` basic) | **Yes** — `## Usage → ### Basic Setup`, same call, correct import path | dropped as duplicate |
| `### Advanced Usage` — `new ObjectStackAdapter({ baseUrl, token, fetch })`, `connect()` | **Yes** — `## API Reference → ### ObjectStackAdapter → #### Constructor` carries the same shape including `fetch`, and `#### Methods` lists `connect()` | dropped as duplicate |
| `### Advanced Usage` — the `find()` call with `$filter` / `$orderby` / `$top` / `$skip`, and the `getClient()` escape hatch | **No** — `getClient()` is a one-line method entry with no example; the query call appears nowhere | **ported** |
| `### Filter Conversion` + `#### Supported Filter Operators` (11 rows) | **No** — the entire translation layer is one feature bullet there: *"Converts Object UI's OData-like query parameters to ObjectStack's native query format"* | **ported** |
| `#### Complex Filter Examples` (the `'and'` AST) | **No** | **ported** |
| `### Query Parameter Mapping` (5 rows) | **No** | **ported** |
| `### Example with Sorting` | **No** | **ported** |
| `## Available Adapters` — one entry, `ObjectStackAdapter`, "from `@object-ui/core`" | n/a — stale prose | **replaced** with the exports actually in the directory |
| `## Creating Custom Adapters` | n/a | **kept byte-for-byte**, as ⭐ instructed |

So **B is wrong on the evidence**: deleting the page's ObjectStack half would have dropped the operator and parameter tables from the repository entirely — `data-objectstack` documents *that* it translates queries and never *how*. A is a port, and the tables land in the package that owns the behaviour. C stays rejected.

## What the two pages now say

**`packages/core/src/adapters/README.md`** (180 → 171 lines) opens with what the directory holds, sends ObjectStack readers to `@object-ui/data-objectstack`, and gives each real export a snippet plus its `provider` mapping:

| Export | Kind | Role |
| --- | --- | --- |
| `ApiDataSource` | class | `provider: 'api'` — raw HTTP against the `HttpRequest` configs in `ViewData` |
| `ValueDataSource` | class | `provider: 'value'` — in-memory array, no network |
| `resolveDataSource` | function | builds the adapter a `ViewData` config asks for |
| `runBatchTransaction` / `emulateBatchTransaction` | functions | ordered cross-object save; native `batchTransaction` when the adapter has one, sequential non-atomic emulation when it does not |

**Five exports, not the four the card names**, and that is deliberate: `batchTransaction.ts` exports `emulateBatchTransaction` **and** `runBatchTransaction` — there is no export called `batchTransaction`. Naming the file rather than its exports is what put the old page in this state, so the table names what `index.ts` actually re-exports. Every behavioural claim is read from the source, not from the old page: `ApiDataSource` ignores its `resource` argument (the URL comes from the config) and returns a `{ name, fields: {} }` stub from `getObjectSchema`; `ValueDataSource` deep-clones on construction and implements `$filter` / `$search` / `$orderby` / `$skip` / `$top` / `$select` locally.

**`packages/data-objectstack/README.md`** gains one `## Query Translation` section (+90 lines) between `## Features` and `## Metadata Caching`, carrying the ported material above.

## ⚠️ Premise correction: PR #6212 has **not** landed, and its two lines were never on `main`

The dispatch said #6212 was "armed and merging right now" and to "expect #6212's two import-path lines to already be present". Measured rather than assumed, twice — at branch point and again after the final merge:

- `packages/core/src/adapters/README.md:21` on `origin/main` still reads ``import { createObjectStackAdapter } from '@object-ui/core';`` — the pre-#6212 text;
- `git show origin/main:package.json | grep -c "check:readme-exports"` → **0**; `scripts/check-readme-exports.mjs` is not on `main`;
- PR #6212 at the time of this push: `state: open`, `merged: false`, and it moved from `mergeable_state: clean` to **`dirty`** while this card was in flight.

Two consequences, both stated rather than worked around:

1. **I did not re-apply or revert those lines.** I did not need to — both snippets were part of the ObjectStack half and are gone from this page entirely, so the repair they made is moot here rather than reverted. When #6212 lands, this file will conflict; whoever lands second resolves it, and the resolution is *this* version of the page (the wider staleness supersedes the two-line repair). ⛔ No rebase and no force-push anywhere on this branch: `origin/main` was merged in as a merge commit at `b3bcc49c4`, clean, zero conflicts, and it touched none of my three files.
2. **`check:readme-exports` could not be run as a repo gate**, because it does not exist on `main`. I ran **#6212's own script**, fetched from `origin/claude/issue-5043-readme-exports-gate` into `scripts/` as an untracked file, executed, then deleted (`git status --porcelain` empty afterwards — it is not in this diff). Declaring that plainly because `node some/missing/file.mjs` exits 1 and would have been indistinguishable from a red gate had I just run the path.

Its census on this tree, quoted from the line the script printed:

```
✅  check-readme-exports: OK (43 README(s) under packages/ (0 outside any package), 399 fenced
block(s) (304 parsed as code, 6 untagged); 497 import binding(s), 378 of them self-imports judged
(378 real, 0 wrong-path, 0 fabricated); 3242 export symbol(s) read from 37 of 40 package(s) (39
carry a README) (0 unbuilt, 3 declare no types); 17 side-effect import(s), 0 namespace, 11 deep
self-path, 91 to other packages).
```

Against #6212's own census the movements are the expected ones: self-bindings judged 374 → **378** (this page's four new `@object-ui/core` imports — `ApiDataSource`, `ValueDataSource`, `resolveDataSource`, `runBatchTransaction`, each a real export via `packages/core/src/index.ts`'s `export * from './adapters/index.js'`), other-package bindings 93 → **91** (the two ObjectStack snippets are gone), **0 wrong-path** either way.

## ⚠️ A gate whose green does **not** cover the file I edited

`docs:check-links` is green, and on this page that green is nearly vacuous — stated because a reader would otherwise assume it was checked. `SCAN_ROOTS`' `packages/*` row excludes the basename `README.md` **at every depth**, so a *nested* README is scanned by nothing. The gate's own header names this file as the example (`scripts/check-doc-links.mjs`, "**`README.md`, at every depth**"), and `check-doc-links.test.ts` pins it with `packages/core/src/adapters/README.md` as the fixture. So the two relative links I added are unjudged by CI and I verified them by hand:

- `../../../data-objectstack/README.md` from `packages/core/src/adapters/` resolves to `packages/data-objectstack/README.md` — **exists on disk**;
- the fragment `#cross-object-atomic-batch-batchtransaction` — the heading **## Cross-Object Atomic Batch (`batchTransaction`)** is at `packages/data-objectstack/README.md:372`, and GitHub's slug for it is exactly that string.

That gap is already filed as its own card — **#6026**, still open, which measured the same four nested READMEs and found zero dead links in them at the time. I did not re-file it; this PR adds two links to one of those four unscanned files, which is worth knowing when #6026 is priced.

## Verification — every run at `87fd2a789`, the merged head, and re-run after the merge

Exit codes captured **by redirect before any pipe** (`node scripts/GATE-NAME > log 2>&1; E=$?`), never `$?` after a pipeline, and each verdict quoted from the line the gate itself printed.

```
check-readme-exports.mjs (from #6212's branch)  EXIT=0   census above
check-doc-fence-languages.mjs                   EXIT=0   223 document(s); SHRINK-ONLY debt unchanged
check-control-bytes.mjs                         EXIT=0   5137 tracked text file(s); 85 binary skipped
check-doc-links.mjs                             EXIT=0   Links are valid across 15 scan roots
check-doc-snippet-types.mjs                     EXIT=0   267 of 267 block(s) judged, 0 failed
check-changeset-presence.mjs                    EXIT=0   1 source file of 1 released package; 1 changeset
check-changeset-fixed.mjs                       EXIT=0
check-changeset-no-major.mjs                    EXIT=0
check-shell-escape-residue.mjs                  EXIT=0   (new on main this hour; run because it arrived)
check-lint-coverage.mjs                         EXIT=0   46/46 packages linted
check-type-check-coverage.mjs                   EXIT=0   41/41 packages compile their tests
vitest run --project unit scripts/__tests__     EXIT=0   Test Files 76 passed (76) | Tests 2110 passed (2110)
```

`check-doc-snippet-types` **required a build** (`turbo run build --filter='./packages/*'`, 39 successful, 3m03s) — on the unbuilt tree it exits 1 with *"the packages it resolves against are not built"*, which is a real red, not a skip. Same build is what makes the readme-exports export surface readable.

**Test scope, derived from disk rather than guessed.** `grep -rln` for readers of the three changed paths across `*.test.ts` / `*.test.tsx` in `packages`, `apps`, `scripts`, `e2e` returns exactly one file — `scripts/__tests__/check-doc-links.test.ts`, and it names `packages/core/src/adapters/README.md` only as a **synthetic fixture path**, reading nothing off disk. The whole `scripts/__tests__` directory was run anyway, from the **repo root** (objectui#3378), never package-scoped. It was re-run after the `main` merge because that merge changed `scripts/check-doc-snippet-types.mjs` and added a suite: 75 files / 2071 tests before, 76 / 2110 after.

**Lint, stated rather than run.** All three changed files are `.md`. `eslint.config.js` declares no markdown processor and no `**/*.md` block, so no file in this diff is inside eslint's population at all — this is not a narrowing, it is an empty intersection. `check-lint-coverage.mjs` is green at 46/46 regardless.

Everything above is local. The authoritative reading is the CI job conclusions on this PR.

## Scope

No source, no behaviour, no `content/docs/releases/` edit, and the `check-readme-exports` gate itself was **not** touched — I only executed a copy of it and deleted the copy. `@object-ui/core` and `@object-ui/data-objectstack` both take a `patch` changeset: `core` publishes its `src/`, so this page ships in its tarball, and a README rides `data-objectstack`'s tarball too.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_