### PR TITLE
fix(ci): check the doc-snippet build filter's exit status, and refuse an empty filter

### DIFF
--- a/.github/workflows/doc-snippet-types.yml
+++ b/.github/workflows/doc-snippet-types.yml
@@ -85,12 +85,48 @@ jobs:
       # covered documents import. A package the snippets need but nothing built
       # is reported by the gate as `unbuilt-package` — its own failure reason,
       # never as a page full of broken imports.
+      #
+      # ⛔ Do not fold this back into `echo "args=$(node …)" >> "$GITHUB_OUTPUT"`
+      # (objectui#6221). A command substitution contributes its STDOUT to the
+      # surrounding word and nothing else — the step's status is `echo`'s — so a
+      # gate that failed reads as a gate that named no packages, `args` is
+      # silently empty, and the step below expands to a bare `turbo run build`
+      # over the whole workspace: the one thing this workflow's header forbids,
+      # with no signal anywhere. `set -o pipefail` is not the remedy and would
+      # not help; there is no pipe here. Capture the status, then write the
+      # output.
       - name: Derive the packages the covered snippets import
         id: filter
-        run: echo "args=$(node scripts/check-doc-snippet-types.mjs --build-filter)" >> "$GITHUB_OUTPUT"
+        run: |
+          status=0
+          args="$(node scripts/check-doc-snippet-types.mjs --build-filter)" || status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Could not derive the build filter: \`node scripts/check-doc-snippet-types.mjs --build-filter\` exited $status. Refusing to continue — carrying on would build every package in the workspace instead of the ones the covered snippets import." >&2
+            exit "$status"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
 
+      # The empty-filter refusal is the second half, deliberately kept HERE
+      # rather than beside the status check above: it holds for every route to
+      # an empty filter, including a gate that exits 0 while naming nothing.
+      # An empty filter can only ever mean something went wrong — the covered
+      # document population is never zero and the gate's own floors already
+      # refuse that — and an unfiltered `turbo run build` is a far worse answer
+      # than a red step. `args` arrives through the environment so the check has
+      # a value to test; it stays unquoted on the `turbo` line because it is a
+      # LIST of `--filter=` words that must word-split.
       - name: Build those packages
-        run: pnpm exec turbo run build ${{ steps.filter.outputs.args }} --concurrency=2
+        env:
+          FILTER_ARGS: ${{ steps.filter.outputs.args }}
+        run: |
+          case "$FILTER_ARGS" in
+            *--filter=*) ;;
+            *)
+              echo "::error::The derived build filter names no package (got: '$FILTER_ARGS'). Refusing to run an unfiltered build — see this workflow's header." >&2
+              exit 1
+              ;;
+          esac
+          pnpm exec turbo run build $FILTER_ARGS --concurrency=2
 
       - name: Compile documentation snippets against the built types
         run: node scripts/check-doc-snippet-types.mjs

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -652,6 +652,13 @@ per-PR full-repo build the 2026-08-16 ruling on
 [#4846](https://github.com/objectstack-ai/objectui/issues/4846) rejected; see *Published Dist Gate*
 below.
 
+**And the filter is checked, twice.** The step that derives it fails the job if the gate exits
+non-zero, and the build step refuses a filter that names no package
+([#6221](https://github.com/objectstack-ai/objectui/issues/6221)). Written the obvious way —
+`echo "args=$(node …)" >> "$GITHUB_OUTPUT"` — the step's status is `echo`'s, so a gate that failed
+would read as a gate that named nothing, and `turbo run build` with no filter is the whole-workspace
+build this section just said the job must never run.
+
 **Fragments are declared, never guessed.** Documentation legitimately carries partial snippets, so a
 block that is not meant to compile carries a marker line immediately above its fence with a written
 reason — `{/* doc-snippet: fragment - why */}` in `.mdx`, the HTML-comment form in `.md`. A block

--- a/scripts/__tests__/check-doc-snippet-types.test.ts
+++ b/scripts/__tests__/check-doc-snippet-types.test.ts
@@ -3,6 +3,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { parse as parseYaml } from 'yaml';
 
 // Plain-JS CI helper; its types are inferred from the .mjs source by
 // `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here.
@@ -410,5 +412,110 @@ describe('wiring — a script nothing runs is not a gate', () => {
   it('is reachable by name from the workspace root', () => {
     const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
     expect(pkg.scripts['check:doc-snippets']).toBe(`node ${SCRIPT}`);
+  });
+});
+
+/**
+ * The step's own shell, executed — objectui#6221.
+ *
+ * The defect this pins was not in the gate but in the SHELL wrapped around it:
+ * `echo "args=$(node …)" >> "$GITHUB_OUTPUT"` gives the step `echo`'s status, so
+ * a gate that exited non-zero read as a gate that named no packages, and the
+ * build step below it expanded to a bare `turbo run build` over the whole
+ * workspace — the one thing this workflow's header forbids, with no signal
+ * anywhere. A regex over the YAML would pin the letter of the fix; these run the
+ * step scripts the workflow actually carries, under the runner's own default
+ * shell (`bash -e {0}`), with `node` and `pnpm` shimmed so that what is measured
+ * is the shell's handling of a failure rather than the gate's behaviour.
+ */
+describe('the build-filter steps propagate failure instead of silently building everything (objectui#6221)', () => {
+  const stepScript = (name: string): string => {
+    const workflow = parseYaml(fs.readFileSync(path.join(repoRoot, '.github/workflows/doc-snippet-types.yml'), 'utf8')) as {
+      jobs: Record<string, { steps?: { name?: string; run?: string }[] }>;
+    };
+    const step = Object.values(workflow.jobs)
+      .flatMap((job) => job.steps ?? [])
+      .find((s) => s.name === name);
+    expect(step?.run, `doc-snippet-types.yml must keep a step named "${name}" with a run: script`).toBeTypeOf(
+      'string',
+    );
+    return step!.run!;
+  };
+
+  /** Run a step's `run:` script as the runner does, with the named executables shimmed. */
+  const runStep = (script: string, shims: Record<string, string>, env: Record<string, string> = {}) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-snippet-step-'));
+    const bin = path.join(dir, 'bin');
+    fs.mkdirSync(bin);
+    for (const [name, body] of Object.entries(shims)) {
+      fs.writeFileSync(path.join(bin, name), body);
+      fs.chmodSync(path.join(bin, name), 0o755);
+    }
+    const scriptPath = path.join(dir, 'step.sh');
+    fs.writeFileSync(scriptPath, script);
+    const githubOutput = path.join(dir, 'github_output');
+    fs.writeFileSync(githubOutput, '');
+    const turboArgv = path.join(dir, 'turbo_argv');
+    // `bash -e {0}` is the default shell for a `run:` step on a Linux runner.
+    const proc = spawnSync('bash', ['-e', scriptPath], {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, GITHUB_OUTPUT: githubOutput, TURBO_ARGV: turboArgv, ...env },
+    });
+    return {
+      status: proc.status,
+      stderr: proc.stderr,
+      githubOutput: fs.readFileSync(githubOutput, 'utf8'),
+      turboInvoked: fs.existsSync(turboArgv),
+      turboArgv: fs.existsSync(turboArgv) ? fs.readFileSync(turboArgv, 'utf8').trim() : null,
+    };
+  };
+
+  const failingGate = '#!/usr/bin/env bash\necho "the filter could not be derived" >&2\nexit 3\n';
+  const healthyGate = '#!/usr/bin/env bash\necho "--filter=@object-ui/core --filter=@object-ui/react"\n';
+  const recordingPnpm = '#!/usr/bin/env bash\necho "$*" > "$TURBO_ARGV"\n';
+
+  it('fails the filter step when the gate fails, and writes no output at all', () => {
+    const result = runStep(stepScript('Derive the packages the covered snippets import'), { node: failingGate });
+    expect(result.status, 'a failed filter must not read as a successful step').not.toBe(0);
+    expect(result.stderr, 'the step must say what failed, not just fail').toContain('--build-filter');
+    expect(result.stderr, 'a failure the log does not annotate is a failure someone has to go looking for').toContain(
+      '::error::',
+    );
+    expect(
+      result.githubOutput,
+      'an `args=` line written after a failed gate is the empty filter that becomes an unfiltered build',
+    ).toBe('');
+  });
+
+  it('writes the derived filter through unchanged when the gate succeeds', () => {
+    const result = runStep(stepScript('Derive the packages the covered snippets import'), { node: healthyGate });
+    expect(result.status).toBe(0);
+    expect(result.githubOutput.trim()).toBe('args=--filter=@object-ui/core --filter=@object-ui/react');
+  });
+
+  it('refuses an empty filter in the build step rather than building the whole workspace', () => {
+    const result = runStep(stepScript('Build those packages'), { pnpm: recordingPnpm }, { FILTER_ARGS: '' });
+    expect(result.status, 'an empty filter can only mean something upstream went wrong').not.toBe(0);
+    expect(result.turboInvoked, 'turbo must not run at all on an empty filter').toBe(false);
+    expect(result.stderr, 'the refusal must be the step\'s own, not a shell error that happens to mention a filter').toContain(
+      '::error::',
+    );
+  });
+
+  it('hands turbo the derived packages as separate words when the filter is real', () => {
+    const result = runStep(stepScript('Build those packages'), { pnpm: recordingPnpm }, {
+      FILTER_ARGS: '--filter=@object-ui/core --filter=@object-ui/react',
+    });
+    expect(result.status).toBe(0);
+    expect(result.turboArgv).toBe(
+      'exec turbo run build --filter=@object-ui/core --filter=@object-ui/react --concurrency=2',
+    );
+  });
+
+  it('never puts the gate back inside a command substitution whose status is discarded', () => {
+    expect(
+      stepScript('Derive the packages the covered snippets import'),
+      'the step status would be `echo`\'s again, and a failed gate would read as an empty filter',
+    ).not.toMatch(/echo\s+"?args=\$\(/);
   });
 });


### PR DESCRIPTION
Fixes #6221 — dispositions 1 and 2, both, and nothing else.

## The defect, and why it is silent

`.github/workflows/doc-snippet-types.yml` derived its build filter like this:

```yaml
run: echo "args=$(node scripts/check-doc-snippet-types.mjs --build-filter)" >> "$GITHUB_OUTPUT"
```

A command substitution contributes its **stdout** to the surrounding word and nothing else, so the step's status is `echo`'s. A gate that exited non-zero therefore read as a gate that named no packages: `args` is silently the empty string, and the next step —

```yaml
run: pnpm exec turbo run build ${{ steps.filter.outputs.args }} --concurrency=2
```

— expands to a bare `turbo run build` over **every package in the workspace**: precisely what this workflow's own header forbids in as many words (*"⛔ Do not replace the filtered build with `pnpm build`. The filter is the reason this job is allowed to run on every pull request at all."*). `set -o pipefail` is not the remedy and would not have helped; there is no pipe.

**The card's premise holds, and it is reachable today, not only after a future edit.** The card frames the hole as one that opens "the day anything makes that flag exit non-zero" — the natural future change being "make `--build-filter` strict too". True, but the flag can already exit non-zero without any edit: `--build-filter` runs the full `analyze({})` before it prints, and the script is `process.exit(main())` with no `try` around it, so anything that throws in the collector — a `package.json` that does not parse, an unreadable directory — leaves through a stack trace and a non-zero status. That path produces no stdout at all, which is exactly the empty-`args` case measured below. The card's "no evidence this has ever fired" stands; its "latent until someone changes the flag" is one step stronger than the code supports.

## The change

**1. The filter step checks the gate's status** (split, as ruled), and fails the job with the gate's own exit code, naming what happened:

```
::error::Could not derive the build filter: `node scripts/check-doc-snippet-types.mjs --build-filter` exited 2. Refusing to continue — carrying on would build every package in the workspace instead of the ones the covered snippets import.
```

**2. The build step refuses a filter that names no package.** Kept in the build step rather than folded into the check above, deliberately: there it covers *every* route to an empty filter, including a gate that exits 0 while naming nothing. An empty filter can only mean something went wrong — the covered-document population is never zero, and the gate's own floors already refuse that — and an unfiltered build is a far worse answer than a red step. `args` reaches that step through `env:` so the guard has a value to test (`[ -z "${{ … }}" ]` would expand to `[ -z ]`, which is *true* as a one-argument test — the guard would be worse than none); it stays unquoted on the `turbo` line because it is a **list** of `--filter=` words that must word-split.

**`--build-filter` itself is untouched and stays lenient**, exiting 0 on an unbuilt tree. It runs one step *before* the build and must tolerate exactly that state; #6215 pins that step order mechanically, and inverting it was explicitly out of scope.

## Verification — three readings, stated as three, each predicted before it ran

Every leg runs the step scripts **extracted from the workflow file itself** (parsed with `yaml`), never a retyped copy, under the runner's own default step shell `bash -e {0}`. Exit codes captured by redirect before any pipe.

The mutation for legs 1 and 2 is a temporary local edit making `--build-filter` exit non-zero with no stdout — the crash/strict shape:

```
marker before: 0
anchor occurrences: 1 (exactly one) — replacement written to scripts/check-doc-snippet-types.mjs
marker after: 2
git diff --numstat: 3	0	scripts/check-doc-snippet-types.mjs
```

| # | leg | prediction | measured |
|---|---|---|---|
| 1 | the step **as written today**, mutated gate | step **succeeds**, `args` empty | `GATE_EXIT=2`, gate stdout 0 bytes → `OLD_STEP_EXIT=0`, `$GITHUB_OUTPUT` = `[args=]`, next step would run `pnpm exec turbo run build  --concurrency=2` |
| 2 | the **fixed** step, same mutation | step **fails**, naming the cause | `NEW_STEP_EXIT=2` (the gate's own code), stderr carries the `::error::…exited 2…` line above, `$GITHUB_OUTPUT` = `[]` — nothing written |
| 3 | **healthy path**, no mutation | real filter, step succeeds | `HEALTHY_FILTER_STEP_EXIT=0`, `args=--filter=@object-ui/app-shell … --filter=@object-ui/types` (21 packages); build step with those args: `HEALTHY_BUILD_STEP_EXIT=0`, and the shimmed `pnpm` recorded `exec turbo run build` + the 21 `--filter=` words + `--concurrency=2` — 26 argv words, so the list word-splits as intended |

A fourth reading for disposition 2 in isolation: the build step with an **empty** `FILTER_ARGS` → `EMPTY_ARGS_BUILD_STEP_EXIT=1`, stdout empty (the shimmed `pnpm` was never invoked at all), stderr = `::error::The derived build filter names no package (got: ''). Refusing to run an unfiltered build — see this workflow's header.`

Both mutations were restored by `git checkout HEAD --` followed by the explicit path, under a `trap … EXIT INT TERM`, proven by an empty `git diff HEAD` and the marker count back to 0. No `git stash` anywhere.

## The tests, and their ablation

Five assertions added to `scripts/__tests__/check-doc-snippet-types.test.ts`. They **execute** the step scripts the workflow carries — `node` and `pnpm` shimmed, so what is measured is the shell's handling of a failure rather than the gate's behaviour — rather than pattern-matching the YAML. One regex pin sits beside them for the literal line the card names.

Non-vacuity: the two steps were mutated back to their pre-fix form on disk, proven by anchored counts (`args=$(node` 1 → 2 — the fixed file keeps that spelling once, inside the ⛔ comment; `FILTER_ARGS` 4 → 0; `git diff --numstat` `10 0`). Predicted 4 of 5 red, with the healthy-passthrough assertion staying green because the old form does write a successful filter through correctly. Measured:

```
VITEST_EXIT=1
 × fails the filter step when the gate fails, and writes no output at all
 × refuses an empty filter in the build step rather than building the whole workspace
 × hands turbo the derived packages as separate words when the filter is real
 × never puts the gate back inside a command substitution whose status is discarded
 Tests  4 failed | 31 passed (35)
```

No rebuild is owed on this leg and none was done: the assertions read `.github/workflows/doc-snippet-types.yml` from disk at test time, so no `dist/` is on the path. Restore was verified byte-identical (`cmp -s` → yes).

## Gate batch, all at `7895b12c6`, working tree clean

Derived from the files this PR touches, not from the dispatch order: every test file under `scripts/__tests__/` that reads `.github/workflows` (38 of them — the reader set for a workflow change), which includes `check-doc-snippet-types`, `check-doc-fence-languages`, `ci-cd-pipeline-doc`, `merge-queue-reporting` and `doc-version-claims`. Exit codes captured by redirect before any pipe.

| gate | result |
|---|---|
| root vitest, the 38 workflow-reading suites | `UNION_VITEST_EXIT=0` — **Test Files 38 passed (38) · Tests 1062 passed (1062)** |
| `pnpm type-check:scripts` | `TYPECHECK_SCRIPTS_EXIT=0` |
| `node scripts/check-control-bytes.mjs` | `EXIT=0` — *"OK (scanned 5132 tracked text file(s); skipped 85 binary)"* |
| `node scripts/check-doc-links.mjs` | `EXIT=0` — *"Links are valid across 15 scan roots."* |
| `node scripts/check-doc-fence-languages.mjs` | `EXIT=0` — *"every TypeScript block in 223 document(s) is fenced ts/tsx/typescript…"* |
| `node scripts/check-changeset-presence.mjs` | `EXIT=0` — *"3 file(s) changed, 0 of them published source of a package the release covers … no changeset is owed"* |
| `pnpm lint:root` (covers `scripts/**`) | `LINT_ROOT_EXIT=0` — 28 pre-existing warnings, 0 errors; `eslint` on the changed test file alone: 1 file, 0 errors, 0 warnings |

`pnpm check:doc-snippets` itself was **not** run and is not owed by this diff: the doc edit adds prose only — the diff adds **0** fenced blocks — so the gate's covered block set is unchanged, and CI runs the gate on this PR regardless.

## Coordination with #6215

#6215 is open on the same subject and touches `scripts/check-doc-snippet-types.mjs` + the same test file; **this PR touches neither the script nor #6215's regions**, and its new pin still holds against this shape: it looks for `turbo run build` before `run: node scripts/check-doc-snippet-types.mjs$`, and both are still there in that order. To keep the test-file diffs from colliding, the new imports go above the comment block #6215 edits and the new `describe` goes at the end of the file, away from #6215's insertion point.

## Out of scope, reported not fixed: the same shape elsewhere in `.github/workflows/**`

Asked for as scoping data for the separate card the issue raises. 27 workflow files, 38 command substitutions outside comments. Triaged:

- **Two live instances of the exact shape** — `ci.yml:1010` and `live-e2e.yml:140`, the same line in both: `run: echo "version=$(pnpm list @playwright/test --depth=0 --json | jq -r '…')" >> $GITHUB_OUTPUT`. Status discarded twice over (`echo` owns it, and there is a pipe inside). The value feeds a cache key — `key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}` — so a failure degrades it to `playwright-Linux-` (or `playwright-Linux-null`, since `jq -r` prints `null` and exits 0 for a missing field): a silently wrong cache bucket, milder than an unfiltered build but the same class.
- **One benign instance** — `performance-budget.yml:138`, `echo "entry_file=$(basename $ENTRY_FILE)" >> "$GITHUB_OUTPUT"`. Same shape, no realistic failure.
- **Everything else is already safe**, and mostly by the repo's own convention: `X=$(cmd)` as a bare assignment does propagate under `set -e`, and the checked form `if ! CHANGED=$(git diff …)` appears five times (`ci.yml` ×4, `lint.yml`).

That distribution is the useful part for scoping: a naive `$(` scan is 38 hits and almost all false positives, as the card warns — but the narrower rule *"a command substitution whose whole value is interpolated into an `echo … >> $GITHUB_OUTPUT`"* has exactly **3** hits repo-wide, 2 of them real. No fix here, no issue filed, no scan added — that is the separate card's call to make.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_
