### PR TITLE
fix(ci): check the Playwright version pipeline's status before it becomes a cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,7 +1007,27 @@ jobs:
       - name: Get Playwright version
         if: steps.relevant.outputs.should_run == 'true'
         id: playwright-version
-        run: echo "version=$(pnpm list @playwright/test --depth=0 --json | jq -r '.[0].devDependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+        run: |
+          # This pipeline's exit status is load-bearing: the value it produces
+          # becomes the Playwright browser cache key in the next step. Without
+          # `pipefail` a failing `pnpm list` is masked by `jq`, and `jq -r`
+          # prints the string `null` and exits 0 when the field is missing — so
+          # either failure used to yield a *successful* step and a key that had
+          # silently degraded to `playwright-Linux-` / `playwright-Linux-null`.
+          # That wrong bucket is stable, so two Playwright versions can share
+          # one cache entry and restore a stale browser (objectui#6231).
+          # The same block is duplicated verbatim in `ci.yml` and `live-e2e.yml`
+          # — keep them byte-identical so they stay greppable as a pair.
+          set -eo pipefail
+          if ! version=$(pnpm list @playwright/test --depth=0 --json | jq -r '.[0].devDependencies["@playwright/test"].version'); then
+            echo "::error::Reading the @playwright/test version failed (pnpm list --json | jq). Refusing to write a Playwright browser cache key from it."
+            exit 1
+          fi
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "::error::Could not resolve the @playwright/test version (got: '${version}'). Refusing to write an empty or null version into the Playwright browser cache key."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         if: steps.relevant.outputs.should_run == 'true'

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -137,7 +137,27 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(pnpm list @playwright/test --depth=0 --json | jq -r '.[0].devDependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+        run: |
+          # This pipeline's exit status is load-bearing: the value it produces
+          # becomes the Playwright browser cache key in the next step. Without
+          # `pipefail` a failing `pnpm list` is masked by `jq`, and `jq -r`
+          # prints the string `null` and exits 0 when the field is missing — so
+          # either failure used to yield a *successful* step and a key that had
+          # silently degraded to `playwright-Linux-` / `playwright-Linux-null`.
+          # That wrong bucket is stable, so two Playwright versions can share
+          # one cache entry and restore a stale browser (objectui#6231).
+          # The same block is duplicated verbatim in `ci.yml` and `live-e2e.yml`
+          # — keep them byte-identical so they stay greppable as a pair.
+          set -eo pipefail
+          if ! version=$(pnpm list @playwright/test --depth=0 --json | jq -r '.[0].devDependencies["@playwright/test"].version'); then
+            echo "::error::Reading the @playwright/test version failed (pnpm list --json | jq). Refusing to write a Playwright browser cache key from it."
+            exit 1
+          fi
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "::error::Could not resolve the @playwright/test version (got: '${version}'). Refusing to write an empty or null version into the Playwright browser cache key."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v6


### PR DESCRIPTION
Fixes #6231

## The defect

`.github/workflows/ci.yml:1010` and `.github/workflows/live-e2e.yml:140` carried the same line, byte for byte:

```yaml
run: echo "version=$(pnpm list @playwright/test --depth=0 --json | jq -r '.[0].devDependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
```

The exit status was discarded twice over — `echo` owned the step's status, and the pipe inside the substitution reported `jq`'s. The value feeds `key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}`, so either failure degraded the key to `playwright-Linux-` or `playwright-Linux-null` with a **green step**. The `-null` bucket is the sharper one: it is a stable, valid key, so two Playwright versions can share one cache entry.

## The fix

Both steps now:

- run `set -eo pipefail` — the runner's default step shell is `bash -e {0}`, which does **not** set `pipefail`, so a failing `pnpm list` would otherwise be masked by a successful `jq`;
- read the version through the repo's existing checked-assignment convention, `if ! version=$(… | jq -r …)` — the same shape `ci.yml` (×4) and `lint.yml` already use for `git diff`;
- refuse an empty or `null` version with a named `::error::` annotation before anything reaches the cache key.

The two blocks are **byte-identical** (verified: both `run` scripts sha256 `48795af62105ad9b863967e1018869695f5b0942335f26ba22ab78133699e489`). The copy already happened once, and keeping them identical keeps them greppable as a pair; the alternative — a composite action or reusable step — is a bigger change than this card authorises and is noted in the report instead.

Scope is deliberately **only these two instances**. No repo-wide scan or gate was added, and the safe forms are untouched: a bare `X=$(cmd)` assignment already propagates its status under `set -e`, and the five checked `if ! CHANGED=$(git diff …)` sites keep working exactly as before.

## Verification — controls, each reading predicted before it was run

The step scripts were extracted from the shipped YAML with a real parser (PyYAML, keyed on `id: playwright-version`) and executed under `bash -e script` — the runner's default step shell — with `pnpm` shimmed and the real `jq`. Pre-fix behaviour was read from the merge-base blob (`git show 2cf69e433:…`), so both sides are shipped bytes, not paraphrases. Every leg prints anchored counts of the old one-liner and the new checked assignment, so it is provable which text ran.

| leg | step | shim | predicted | observed |
|---|---|---|---|---|
| 1 | pre-fix | `pnpm` exits 1 | succeeds, empty version | exit **0**, `GITHUB_OUTPUT` = `version=` |
| 2 | pre-fix | JSON lacks the field | succeeds, `null` version | exit **0**, `GITHUB_OUTPUT` = `version=null` |
| 3a | fixed | `pnpm` exits 1 | fails, names the cause | exit **1**, `::error::Reading the @playwright/test version failed …`, nothing written |
| 3b | fixed | JSON lacks the field | fails, names the cause | exit **1**, `::error::Could not resolve the @playwright/test version (got: 'null') …`, nothing written |
| 4 | fixed | healthy | version passes through unchanged | exit **0**, `version=1.55.1` |

All ten legs (five per workflow) matched their predictions. The healthy path was additionally run against **real** `pnpm` + `jq` in this worktree: pre-fix and fixed both produce `version=1.62.1`, exit 0 — the quoting change does not disturb the working path.

One control worth recording: weakening only `pipefail` (in a scratch copy, never on disk) still fails the `pnpm`-dies case — but via the empty-value guard, reporting `got: ''` instead of the real cause. So the two nets are independent: `pipefail` makes the status check meaningful and gives the correct diagnosis; the value guard is what catches `jq`'s exit-0 `null`.

## Tests

The set was derived from disk, not assumed: 43 test files reference `workflows` (39 of them `.github/workflows` literally). Run from the repo root on the tree that is this PR's head, `e62eb714b`:

```
pnpm exec vitest run --maxWorkers=2 $(43 files)
 Test Files  43 passed (43)
      Tests  1280 passed (1280)
```

Plus `check:control-bytes` (OK, 5147 files), `check:shell-escape-residue` (OK), `check:action-forward-parity` (OK), and `node scripts/check-changeset-presence.mjs` — "No source of a released package changed in this range, so no changeset is owed", so no changeset accompanies this PR.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_