### PR TITLE
refactor(plugin-view)!: retire the `direction` sort spelling from the published `toSortItems` export

### DIFF
--- a/.changeset/6011-tosortitems-order-spelling.md
+++ b/.changeset/6011-tosortitems-order-spelling.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/plugin-view': minor
+---
+
+**Breaking (shipped as `minor` per AGENTS.md §版本号策略).** The published `toSortItems`
+export now reads its sort direction from **`order`** only. The retired spelling is
+**`direction`** — named here so that a host still writing it can find this entry by
+searching the old key (objectui#6011).
+
+```diff
+  import { toSortItems } from '@object-ui/plugin-view';
+
+- toSortItems([{ field: 'created_at', direction: 'desc' }]);
++ toSortItems([{ field: 'created_at', order: 'desc' }]);
+```
+
+**What changed, exactly.** `toSortItems` folded `s.order || s.direction || 'asc'`: two
+spellings for one key, silently preferring the canonical one. It now folds
+`s.order || 'asc'`. Everything else about the helper is unchanged — `id` is still
+preserved when present and minted with `crypto.randomUUID()` otherwise, `field` still
+defaults to `''`, and a non-array draft still yields `[]`.
+
+**The failure mode if you do not migrate is silent.** A draft entry spelled
+`{ field: 'created_at', direction: 'desc' }` used to produce
+`{ field: 'created_at', order: 'desc' }`; it now produces
+`{ field: 'created_at', order: 'asc' }` — the documented default for an entry that names
+no direction. Nothing throws and nothing warns: the `SortBuilder` row renders, and it
+renders **ascending**. If you have a studio inspector draft, a persisted view body, or any
+other producer that still writes `direction`, grep for the key and re-spell it to `order`.
+
+**Why the tolerant read went rather than staying.** objectui#4869 ruled that a spelling the
+sink does not recognise gets ruled into the contract or rejected at the producer, never
+absorbed by a tolerance layer. objectui#5293 retired the same word on
+`ObjectViewProps.views[].sort` and shipped it as a `minor`; this entry finishes the job on
+the sort family's public surface, so `order` is now the one spelling repo-wide and declared
+equals enforced. The scope note in the objectui#5293 entry — that this export was *not*
+retired by that change — described that release's scope correctly and is superseded here.
+
+`SortUI` is untouched. Its own file-local `toSortItems` is a different symbol, and
+`direction` is the key `SortUISchema` legitimately declares.

--- a/packages/plugin-view/README.md
+++ b/packages/plugin-view/README.md
@@ -88,7 +88,7 @@ import {
   RECORD_SURFACE_PAGE_THRESHOLD,
   deriveFieldOptions, // object fields -> picker options
   toFilterGroup, // filter rules -> FilterGroup
-  toSortItems, // sort config -> SortItem[]
+  toSortItems, // sort config ({ field, order }) -> SortItem[]
   VIEW_TYPE_LABELS,
   VIEW_TYPE_OPTIONS,
   isImageLikeField,

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -255,11 +255,12 @@ export interface ObjectViewProps {
    * remove a working feature; it converts that silent wrong answer into a loud
    * type error.
    *
-   * The claim is scoped to those three consumers on purpose. Elsewhere in this
-   * package the published `toSortItems` export still folds
+   * The claim is scoped to those three consumers on purpose. The published
+   * `toSortItems` export elsewhere in this package used to fold
    * `s.order || s.direction` for the studio inspector-draft — a different
-   * surface, unreachable from this prop, and deliberately not retired here
-   * (objectui#6011).
+   * surface, unreachable from this prop, which is why it was not retired with
+   * this rename. It has since been retired on its own card (objectui#6011), so
+   * `order` is now the only sort spelling this package reads on either surface.
    *
    * ⛔ Deliberately NOT a tolerant dual-read (`direction ?? order`) — that is
    * the tolerance layer objectui#4869 ruled against, and re-adding it here

--- a/packages/plugin-view/src/__tests__/ObjectView.filterSources.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.filterSources.test.tsx
@@ -157,9 +157,18 @@ describe('ObjectView hands the view filter to the delegated renderer', () => {
     expect(seen[0]?.filter).toEqual(rules);
   });
 
+  // Spelled `order`, the key `ObjectGridSchema.defaultSort` actually declares
+  // (`packages/types/src/objectql.ts`, and the zod mirror agrees). It used to
+  // say `direction` — a spelling this surface never declared, retired
+  // repo-wide by objectui#5293 / objectui#6011. Re-spelling changes nothing
+  // this test grades: the assertion pins VERBATIM pass-through and never reads
+  // the direction key, so any word passed. The remaining `as any` is about
+  // ARITY, not spelling — `defaultSort` is declared a single `{ field, order }`
+  // and this passes an array on purpose (see ObjectView.namedViewSortArity for
+  // what the arity costs elsewhere).
   it('forwards the sort alongside it', () => {
-    const seen = renderDelegated({ table: { defaultSort: [{ field: 'name', direction: 'asc' }] } as any });
-    expect(seen[0]?.sort).toEqual([{ field: 'name', direction: 'asc' }]);
+    const seen = renderDelegated({ table: { defaultSort: [{ field: 'name', order: 'asc' }] } as any });
+    expect(seen[0]?.sort).toEqual([{ field: 'name', order: 'asc' }]);
   });
 
   it('forwards nothing when the view declares neither', () => {

--- a/packages/plugin-view/src/config/__tests__/view-config-utils.toSortItems.test.ts
+++ b/packages/plugin-view/src/config/__tests__/view-config-utils.toSortItems.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `toSortItems` — the retired `direction` sort spelling (objectui#6011).
+ *
+ * `toSortItems` is a **published export**: re-exported from the package root
+ * (`src/index.tsx`) and listed in the README. It used to read
+ * `s.order || s.direction || 'asc'` — two spellings for one key, silently
+ * preferring the canonical one. That is the tolerance layer objectui#4869
+ * ruled against (a spelling the sink does not recognise gets ruled into the
+ * contract or rejected at the producer, never absorbed by a tolerance layer),
+ * and objectui#5293 executed the identical retirement for the `views[].sort`
+ * path. `order` is now the only spelling this export reads.
+ *
+ * These are the ONLY assertions that grade the retirement. The function has no
+ * in-repo production caller — the studio inspector-draft surface it serves
+ * (`SortBuilder`) is reached from out-of-tree hosts, and the one in-repo
+ * importer of the published symbol
+ * (`apps/console/src/__tests__/insecure-origin-crypto.test.ts`) passes the
+ * canonical `order` and only grades `crypto.randomUUID`. So no pre-existing
+ * suite can go red for this change; the `direction` case below is what does.
+ *
+ * ⚠️ `packages/plugin-view/src/SortUI.tsx` declares a DIFFERENT, file-local
+ * `const toSortItems` that maps `SortEntry[]`. Its `direction` key is
+ * type-correct on `SortUISchema`, it is not this symbol, and it is deliberately
+ * untouched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toSortItems } from '../view-config-utils';
+
+describe('toSortItems reads only the canonical `order` spelling', () => {
+  it('reads `order`', () => {
+    const items = toSortItems([
+      { field: 'created_at', order: 'desc' },
+      { field: 'name', order: 'asc' },
+    ]);
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.field).toBe('created_at');
+    expect(items[0]?.order).toBe('desc');
+    expect(items[1]?.field).toBe('name');
+    expect(items[1]?.order).toBe('asc');
+  });
+
+  it('does NOT read the retired `direction` spelling — it falls back to `asc`', () => {
+    // The unmigrated out-of-tree caller. Before objectui#6011 this returned
+    // `order: 'desc'`; the fallback is gone, so the entry now takes the
+    // documented default. This assertion is the retirement: it fails against
+    // the tolerant `s.order || s.direction || 'asc'` read.
+    const items = toSortItems([{ field: 'created_at', direction: 'desc' }]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.field).toBe('created_at');
+    expect(items[0]?.order).toBe('asc');
+  });
+
+  it('ignores `direction` even when it is the only key that could answer', () => {
+    const items = toSortItems([
+      { field: 'a', direction: 'desc' },
+      { field: 'b', order: 'desc' },
+    ]);
+
+    expect(items.map((i) => i.order)).toEqual(['asc', 'desc']);
+  });
+
+  it('defaults a sort entry with no direction key at all to `asc`', () => {
+    const items = toSortItems([{ field: 'name' }]);
+
+    expect(items[0]?.order).toBe('asc');
+  });
+
+  it('preserves an explicit id and mints one otherwise', () => {
+    const items = toSortItems([{ id: 'fixed', field: 'name', order: 'asc' }, { field: 'other' }]);
+
+    expect(items[0]?.id).toBe('fixed');
+    expect(items[1]?.id).toEqual(expect.any(String));
+    expect(items[1]?.id).not.toBe('');
+  });
+
+  it('returns an empty list for a non-array draft', () => {
+    expect(toSortItems(undefined)).toEqual([]);
+    expect(toSortItems(null)).toEqual([]);
+    expect(toSortItems({ field: 'name', order: 'asc' })).toEqual([]);
+  });
+});

--- a/packages/plugin-view/src/config/view-config-utils.ts
+++ b/packages/plugin-view/src/config/view-config-utils.ts
@@ -320,12 +320,28 @@ export function toFilterGroup(draftFilter: any): FilterGroup {
     return { id: 'root', logic: parsed.logic, conditions: parsed.conditions };
 }
 
-/** Convert draft sort → SortItem[] for SortBuilder */
+/**
+ * Convert draft sort → SortItem[] for SortBuilder.
+ *
+ * Reads **`order`**, and only `order`. The retired spelling is **`direction`**
+ * (objectui#6011): this used to fold `s.order || s.direction || 'asc'`, which
+ * accepted two spellings for one key and silently preferred the canonical one.
+ * That is the tolerance layer objectui#4869 ruled against — a spelling the sink
+ * does not recognise gets ruled into the contract or rejected at the producer,
+ * never absorbed here — and objectui#5293 retired the same word on
+ * `ObjectViewProps.views[].sort`. A draft entry still spelled
+ * `{ field, direction }` now takes the `'asc'` default instead of the direction
+ * it asked for.
+ *
+ * ⛔ Do not re-add the alias. `SortUI`'s own file-local `toSortItems` is a
+ * DIFFERENT symbol: it maps `SortEntry[]`, whose `direction` key is
+ * type-correct on `SortUISchema`, and it is not this export.
+ */
 export function toSortItems(draftSort: any): SortItem[] {
     return (Array.isArray(draftSort) ? draftSort : []).map((s: any) => ({
         id: s.id || crypto.randomUUID(),
         field: s.field || '',
-        order: (s.order || s.direction || 'asc') as 'asc' | 'desc',
+        order: (s.order || 'asc') as 'asc' | 'desc',
     }));
 }
 


### PR DESCRIPTION
Fixes #6011

Retires the `direction` sort spelling from `toSortItems`, a published export of
`@object-ui/plugin-view`. The ruling is inherited, not made here: #4869 ruled that a
spelling the sink does not recognise gets ruled into the contract or rejected at the
producer, never absorbed by a tolerance layer; #5293 executed the identical retirement for
`ObjectViewProps.views[].sort` and shipped it `minor`. This is the same treatment on the
last dormant tolerance layer of the sort family's public surface.

## Clause ② — contract review (published-export acceptance change)

**What the export accepted before.** `toSortItems(draftSort)` folded
`s.order || s.direction || 'asc'` per entry. It therefore accepted **two spellings for one
key** — `{ field, order }` and `{ field, direction }` — and, when both were present,
silently preferred `order`. No warning, no rejection, no record that a second spelling was
in play.

**What it accepts after.** `s.order || 'asc'`. **`order` only.** `direction` is now an
unrecognised key like any other: read by nothing, reported by nothing.

Nothing else about the helper moved. `id` is preserved when present and minted with
`crypto.randomUUID()` otherwise; `field` still defaults to `''`; a non-array draft still
yields `[]`. The TypeScript signature is byte-identical (`(draftSort: any): SortItem[]`),
so no downstream consumer's types change — this is an acceptance change only, invisible to
the compiler on both sides.

**Exact failure mode of an unmigrated caller.** A caller passing
`{ field: 'created_at', direction: 'desc' }` used to get
`{ id, field: 'created_at', order: 'desc' }`. It now gets
`{ id, field: 'created_at', order: 'asc' }` — the documented default for an entry naming no
direction. **The break is silent and it is a wrong answer, not an absent one:** nothing
throws, nothing warns, the `SortBuilder` row renders, the field is right, and the list sorts
**ascending** while the caller asked for descending. That is the whole cost, and it is the
cost #5293's changeset already priced for the sibling surface.

**Why the unknown out-of-tree caller is not a blocker.** The card is right that this repo
cannot answer whether any host calls it (zero in-repo production callers). objectui's stated
policy — it ships its own breaks as `minor` with a changeset naming the retired key — is the
answer to that unknown, not a reason to keep the tolerant read.

## The trap this card carries, and how the change was actually graded

`toSortItems` has **no in-repo production caller**. The one in-repo importer of the published
symbol, `apps/console/src/__tests__/insecure-origin-crypto.test.ts`, passes the canonical
`order` and only grades `crypto.randomUUID`. So **no pre-existing suite could go red for this
change** — a green run of the existing suites proves nothing about the retirement.

The pin was therefore written first and measured red against the unfixed function
(`packages/plugin-view/src/config/__tests__/view-config-utils.toSortItems.test.ts`):

```
Tests  2 failed | 4 passed (6)

 FAIL  … > does NOT read the retired `direction` spelling — it falls back to `asc`
AssertionError: expected 'desc' to be 'asc'
 FAIL  … > ignores `direction` even when it is the only key that could answer
AssertionError: expected [ 'desc', 'desc' ] to deeply equal [ 'asc', 'desc' ]
```

Both flipped green with the one-line fix; the predicted failing pair and the predicted
received values matched the run exactly.

### Which of these assertions would still pass on a revert

Stated plainly, because most of them would:

| assertion | survives a revert? |
| --- | --- |
| `does NOT read the retired direction spelling — it falls back to asc` | **NO — this is the retirement.** Reverting returns `'desc'`. |
| `ignores direction even when it is the only key that could answer` | **NO.** Reverting returns `['desc','desc']`. |
| `reads order` | yes — `order` was always read first |
| `defaults a sort entry with no direction key at all to asc` | yes — the `\|\| 'asc'` tail is unchanged |
| `preserves an explicit id and mints one otherwise` | yes — untouched behaviour |
| `returns an empty list for a non-array draft` | yes — untouched behaviour |

Two of six assertions grade the change. The other four are regression cover for the parts
deliberately **not** touched, and a revert leaves them green. Every other suite in the repo
also stays green on a revert — that is the point of the trap above, not an oversight.

## Also in this diff

- **`packages/plugin-view/src/ObjectView.tsx`** — the `views` prop doc paragraph recorded
  this export as folding `s.order || s.direction` and "deliberately not retired here
  (objectui#6011)". True when #5293 landed, false the moment this does. Rewritten to say the
  retirement has since happened on its own card.
- **`packages/plugin-view/src/__tests__/ObjectView.filterSources.test.tsx`** — the stale
  fixture the card recorded, which wrote `direction` behind an `as any` on `table.defaultSort`,
  a surface declaring `order` (`packages/types/src/objectql.ts`, zod mirror agreeing).
  **Re-spelled after reading what it pins**: the assertion pins *verbatim pass-through* of the
  forwarded value and never reads the direction key, so any word passed and re-spelling changes
  nothing it grades. A comment now records that the surviving `as any` is about **arity**
  (`defaultSort` is declared a single `{ field, order }`, the fixture passes an array on
  purpose), not spelling — so the canonical key is not misread as declaration conformance.
- **`packages/plugin-view/README.md:91`** — the documented export line described the return
  shape but not the accepted one. Now names `{ field, order }`.
- **`packages/plugin-view/src/SortUI.tsx` — deliberately untouched.** Its file-local
  `const toSortItems` is a different symbol that maps `SortEntry[]`, and `direction` is the key
  `SortUISchema` legitimately declares. A grep for `toSortItems` reads it as a caller; it is not
  one.
- The `.changeset` entry is **`minor`** and **names `direction` in words**, so a host greping
  the retired key lands on it. It also records that #5293's scope note — which said this export
  was *not* retired by that change — described that release's scope correctly and is superseded
  here.

## Verification

All of the following on final head **`b0d186b79`**, with the working tree clean
(`git diff HEAD --stat` empty).

| gate | verdict line |
| --- | --- |
| `vitest run packages/plugin-view apps/console/…/insecure-origin-crypto.test.ts` | `Test Files 24 passed (24) / Tests 237 passed (237)` |
| `pnpm --filter @object-ui/plugin-view type-check` | exit 0 — `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/console type-check` | exit 0 (see note) |
| `pnpm --filter @object-ui/plugin-view lint` | `✖ 247 problems (0 errors, 247 warnings)` — all pre-existing |
| `check-changeset-presence.mjs` | `✅ 4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |
| `check-changeset-fixed.mjs` | `✅ All workspace packages are in the changeset fixed group.` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 5140 tracked text file(s))` |
| `check:phantom-deps` | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:self-import` | `✅ No package names itself inside its own src/.` |
| `check:vi-mock-specifiers` | `✅ check-vi-mock-specifiers: OK` |
| `check:shell-escape-residue` | `✅ check-shell-escape-residue: OK` |
| `lint:coverage` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `type-check:coverage` | `✅ type-check coverage: 45/46 via type-check … 0 errors outstanding` |

**Note on the console type-check.** It first failed with five `Cannot find module` errors for
`@object-ui/app-shell` / `plugin-view` / `plugin-list` / `plugin-detail` / `auth` — the
unbuilt-dependency shape, not this diff. After `pnpm --filter '@object-ui/console^...' build`
it is exit 0. Recorded because that red reads identically to "your change broke an import".

**Declared narrowing.** `pnpm lint` (`turbo run lint`, 46 packages) was not run whole; the
`@object-ui/plugin-view` lint task was run directly, which is the complete unit turbo would run
for this diff. Evidence the narrowing excludes nothing: (1) the population comes from eslint's
own config resolution, not a hand-picked file list; (2) `--format json` reports **38 files
linted, 0 errors, 247 warnings**; (3) `eslint.config.js` declares **no** `parserOptions.project`
and **no** `projectService`, so type-aware linting is off and a change inside this package
cannot move the verdict on any file outside it — and each package's `lint` script is `eslint .`
rooted in its own directory. `lint:coverage` independently reports 46/46 packages at 0 errors.
CI runs the full farm regardless.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_