### PR TITLE
fix(plugin-form): deliver authored FormSection.visibleWhen to the renderer in all four layouts

### DIFF
--- a/.changeset/6111-formsection-visiblewhen.md
+++ b/.changeset/6111-formsection-visiblewhen.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/plugin-form': minor
+'@object-ui/types': minor
+---
+
+⚠️ **Behaviour change: an authored `FormSection.visibleWhen` that has been doing nothing
+will now START HIDING SECTIONS.** Read this before upgrading if any of your metadata
+authors a section predicate.
+
+`@objectstack/spec` declares `FormSection.visibleWhen` and this repo's spec bridge maps it
+through, but every plugin-form layout renders a section header as a virtual
+`section-divider` pseudo-field and none of them copied the predicate onto it. On the
+object-view chain — the create/edit modal, the drawer, the split form, and the full-page
+record form — the key was declared, mapped, carried, and then dropped one hop before
+anything could evaluate it. The section rendered unconditionally, with no diagnostic
+(objectui#6111).
+
+**Why nobody noticed, and why the fix is felt as a regression.** `visibleWhen` fails OPEN:
+a section that renders is what you get when the predicate resolves TRUE, when the predicate
+never arrives, *and* when the predicate faults. Those three worlds were indistinguishable,
+so an app that authored a section predicate saw its section render and had no way to tell
+that the rule was inert. Every such app has been running with the rule switched off, and
+some will have been authored — or simply grown used to — that state. After this change the
+predicate is evaluated for real, and sections that have always been visible will disappear
+for the users the rule excludes.
+
+This is the intended ADR-0089 contract being delivered, not a new capability: the key was
+already declared, already documented, and already honoured by the console form renderer.
+The object-view chain was the one that silently ignored it.
+
+**Before upgrading**, audit any `sections[].visibleWhen` in your form-view metadata and
+confirm each predicate says what you actually want, evaluated against `record` +
+`current_user`. A predicate that was written speculatively, or left behind after a rework,
+now takes effect.
+
+**Measured scope of the hide.** The predicate gates the section's HEADER row. The renderer
+treats `section-divider` as presentational and holds no association between it and the
+fields that follow it, so a false predicate removes the heading and the section's fields
+keep rendering. The console renderer (`apps/console`) drops the whole `<section>`, fields
+included. That divergence is real, is pinned honestly by this change's tests rather than
+implied away, and is filed separately — it needs a renderer-side grouping contract, not
+another line in a layout.
+
+Two hops were dropping the key and both are repaired: `ObjectForm` rebuilds each section
+key by key when it delegates to Split/Drawer/Modal (and `ModalForm`'s own `groups` map does
+it again), so a key those maps did not copy never reached the layout at all; and the six
+`section-divider` synthesis sites across the four layout files.
+
+`@object-ui/types` gains the matching `ObjectFormSection.visibleWhen` declaration.

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -90,6 +90,12 @@ export interface DrawerFormSectionConfig {
   fields: (string | FormField)[];
   collapsible?: boolean;
   collapsed?: boolean;
+  /**
+   * ADR-0089 `FormSection.visibleWhen` — conditional visibility for the
+   * section's divider HEADER, evaluated by the form renderer with the canonical
+   * engine and the host predicate scope (#6010/#6111). Fails OPEN.
+   */
+  visibleWhen?: string | { dialect?: string; source: string };
   /** Custom CSS class for the section's divider header. */
   className?: string;
 }
@@ -547,6 +553,9 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
           name: `__section_${sectionKey}`,
           label: section.label || '',
           type: 'section-divider',
+          // ADR-0089 section predicate (#6111) — the renderer evaluates it on
+          // this pseudo-field with the host predicate scope bound (#6010).
+          visibleWhen: (section as any).visibleWhen,
           colSpan: 4,
           collapsible: section.collapsible,
           collapsed: isCollapsed,
@@ -603,6 +612,8 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
             name: `__section_${sectionKey}`,
             label: title,
             type: 'section-divider',
+            // ADR-0089 section predicate (#6111).
+            visibleWhen: (section as any).visibleWhen,
             colSpan: 4,
             collapsible: section.collapsible,
             collapsed: isCollapsed,

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -78,6 +78,12 @@ export interface ModalFormSectionConfig {
   description?: string;
   columns?: 1 | 2 | 3 | 4;
   fields: (string | FormField)[];
+  /**
+   * ADR-0089 `FormSection.visibleWhen` — conditional visibility for the
+   * section's divider HEADER, evaluated by the form renderer with the canonical
+   * engine and the host predicate scope (#6010/#6111). Fails OPEN.
+   */
+  visibleWhen?: string | { dialect?: string; source: string };
   /** Custom CSS class for the section's header row (stacked layout). */
   className?: string;
   /**
@@ -616,6 +622,9 @@ export const ModalForm: React.FC<ModalFormProps> = ({
             key: sectionKey(section, index),
             title: sectionTitle(section),
             description: section.description,
+            // Key-by-key rebuild: an uncopied key never reaches the divider
+            // synthesis below (#6111).
+            visibleWhen: section.visibleWhen,
             className: section.className,
             gridClassName: section.gridClassName,
             fields: formColumns > 1
@@ -665,6 +674,9 @@ export const ModalForm: React.FC<ModalFormProps> = ({
             label: g.title,
             description: g.description,
             type: 'section-divider',
+            // ADR-0089 section predicate (#6111) — the renderer evaluates it on
+            // this pseudo-field with the host predicate scope bound (#6010).
+            visibleWhen: g.visibleWhen,
             colSpan: 4,
             className: g.className,
           } as any);
@@ -695,6 +707,8 @@ export const ModalForm: React.FC<ModalFormProps> = ({
             name: `__section_${section.name || index}`,
             label: title,
             type: 'section-divider',
+            // ADR-0089 section predicate (#6111).
+            visibleWhen: (section as any).visibleWhen,
           } as any);
         }
         allFields.push(...(columns > 1 ? applyAutoColSpan(body, columns) : body));

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -300,6 +300,9 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             // rebuilds each section key by key, so a key it doesn't copy is
             // silently dropped — exactly how `visibleOn` once vanished here.
             pane: s.pane,
+            // ADR-0089 section predicate (#6111) — same reason as `pane` above:
+            // a key this map does not copy never reaches the layout at all.
+            visibleWhen: (s as any).visibleWhen,
             className: (s as any).className,
             gridClassName: (s as any).gridClassName,
           })),
@@ -330,6 +333,9 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             fields: s.fields,
             collapsible: (s as any).collapsible,
             collapsed: (s as any).collapsed,
+            // ADR-0089 section predicate (#6111) — key-by-key rebuild, so an
+            // uncopied key is silently dropped before DrawerForm ever sees it.
+            visibleWhen: (s as any).visibleWhen,
             className: (s as any).className,
           })),
           open: schema.open,
@@ -358,6 +364,9 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
             description: s.description,
             columns: s.columns,
             fields: s.fields,
+            // ADR-0089 section predicate (#6111) — key-by-key rebuild, so an
+            // uncopied key is silently dropped before ModalForm ever sees it.
+            visibleWhen: (s as any).visibleWhen,
             className: (s as any).className,
             gridClassName: (s as any).gridClassName,
           })),
@@ -1195,6 +1204,11 @@ const SimpleObjectForm: React.FC<ObjectFormComponentProps> = ({
           name: `__section_${sectionKey}`,
           label,
           type: 'section-divider',
+          // ADR-0089 `FormSection.visibleWhen` (#6111). The renderer evaluates
+          // a `visibleWhen` on this pseudo-field with the host predicate scope
+          // bound (#6010), so copying it here is what makes the authored
+          // section predicate reach an evaluator at all.
+          visibleWhen: (section as any).visibleWhen,
           colSpan: 4,
           collapsible: section.collapsible,
           collapsed: isCollapsed,

--- a/packages/plugin-form/src/SplitForm.tsx
+++ b/packages/plugin-form/src/SplitForm.tsx
@@ -46,6 +46,12 @@ export interface SplitFormSectionConfig {
    */
   pane?: 'primary' | 'secondary';
   fields: (string | FormField)[];
+  /**
+   * ADR-0089 `FormSection.visibleWhen` — conditional visibility for the
+   * section's divider HEADER, evaluated by the form renderer with the canonical
+   * engine and the host predicate scope (#6010/#6111). Fails OPEN.
+   */
+  visibleWhen?: string | { dialect?: string; source: string };
   /** Custom CSS class for the section's header row. */
   className?: string;
   /**
@@ -339,6 +345,9 @@ export const SplitForm: React.FC<SplitFormProps> = ({
           label: section.label,
           description: section.description,
           type: 'section-divider',
+          // ADR-0089 section predicate (#6111) — the renderer evaluates it on
+          // this pseudo-field with the host predicate scope bound (#6010).
+          visibleWhen: section.visibleWhen,
           colSpan: 4,
           className: section.className,
         } as any);

--- a/packages/plugin-form/src/__tests__/sectionVisibleWhen-6111.test.tsx
+++ b/packages/plugin-form/src/__tests__/sectionVisibleWhen-6111.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6111 — an authored `FormSection.visibleWhen` must REACH an evaluator
+ * on the object-view chain, in every plugin-form layout.
+ *
+ * `@objectstack/spec` declares `FormSection.visibleWhen`; this repo's spec
+ * bridge carries it (`packages/react/src/spec-bridge/bridges/form-view.ts:250`);
+ * `RecordFormPage` / `resolveFormViewLayout` wire whole `sections` objects into
+ * the layouts. Every layout then renders a section header as a virtual
+ * `section-divider` pseudo-field — and none of them copied the predicate onto
+ * it, so the key was declared, mapped, carried, and dropped one hop before
+ * anything evaluated it.
+ *
+ * The renderer half already works: `packages/components/src/renderers/form/
+ * form.tsx` runs EVERY pseudo-field through `resolveFieldRuleState` with the
+ * host predicate scope bound (#6010) before it reaches the `section-divider`
+ * branch, so a divider carrying a `visibleWhen` hides exactly like a field
+ * does. `predicate-scope-parity-6010.test.tsx`'s `sectionSurface` row pins that
+ * directly, hand-authoring the pseudo-field this file makes the layouts emit.
+ *
+ * ## ⚠️ Why every case below asserts HIDDEN, and never merely SHOWN
+ *
+ * `visibleWhen` fails OPEN. A section that renders is the outcome of three
+ * different worlds — the predicate resolved TRUE, the predicate never arrived,
+ * and the predicate faulted — so **an assertion that a section IS shown
+ * distinguishes none of them** and is green on unfixed code. The deliverable is
+ * therefore the DENIED row: the heading is ABSENT while a predicate that
+ * resolves false is authored on the section.
+ *
+ * The ALLOWED row is the control and nothing more. Without it, "hidden" is
+ * satisfiable by a layout that dropped the heading for some unrelated reason
+ * (an empty section, a bad label lookup), which would be a worse defect and
+ * completely invisible to the DENIED row alone.
+ *
+ * ## Why one parameterised case would NOT have been enough
+ *
+ * There are SIX `section-divider` synthesis sites across FOUR layout files, and
+ * a fix applied to five of six still passes a suite that exercises five. Each
+ * layout is therefore mounted BY NAME below, through the entry the product
+ * actually uses.
+ *
+ * Two hops had to be repaired per layout, and only the second was on the card:
+ *
+ *   1. `ObjectForm` rebuilds each section KEY BY KEY when it delegates to
+ *      Split/Drawer/Modal (`ObjectForm.tsx` ~296/~331/~388) — a key that map
+ *      does not copy never reaches the layout at all. `ModalForm`'s own
+ *      `groups` map does the same thing again. The file's own comment on the
+ *      split map already recorded the hazard: *"this mapping rebuilds each
+ *      section key by key, so a key it doesn't copy is silently dropped —
+ *      exactly how `visibleOn` once vanished here."*
+ *   2. The `section-divider` synthesis sites themselves.
+ *
+ * Routing the modal/drawer/split rows through `ObjectForm` (which is what
+ * `RecordFormPage` does) exercises BOTH hops; the direct `ModalForm` row covers
+ * `resolveFormViewLayout`, which mounts `ModalForm` without passing through
+ * `ObjectForm` at all.
+ *
+ * ## Reverse verification (direction predicted BEFORE running)
+ *
+ * Revert the `visibleWhen:` copy at any ONE synthesis site and that layout's
+ * DENIED row — and only that one — goes red in the SHOWN direction (the heading
+ * comes back), because the fallback is fail-open. Every ALLOWED row stays green
+ * everywhere, which is precisely why the ALLOWED rows could never have caught
+ * this.
+ *
+ * ## Scope, measured — what this does NOT claim
+ *
+ * The renderer treats `section-divider` as a presentational ROW and holds no
+ * association between it and the fields that follow it, so a false predicate
+ * removes the HEADING and leaves the section's fields rendering. The console
+ * renderer (`apps/console/src/components/FormPage.tsx:1819`) drops the whole
+ * `<section>`, fields included. That divergence is real and is filed
+ * separately — it needs a renderer-side grouping contract, not another line in
+ * a layout. The `stillRendersItsFields` case below pins the CURRENT behaviour
+ * honestly rather than letting the file imply a guarantee it does not deliver.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import React from 'react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectForm } from '../ObjectForm';
+import { ModalForm } from '../ModalForm';
+
+registerAllFields();
+
+/**
+ * The canonical wire shape — `@objectstack/spec` normalizes an authored
+ * predicate into a `{ dialect: 'cel' }` envelope at parse (ADR-0089 D2), and a
+ * bare string would route to a different engine on some surfaces (measured in
+ * `predicate-scope-parity-6010.test.tsx`). Same spelling as that file, on
+ * purpose: one authored text, one verdict, every surface.
+ */
+const cel = (source: string) => ({ dialect: 'cel', source });
+
+/** THE authored section predicate. One text, asked of every layout below. */
+const GATE = cel("'sales_manager' in current_user.positions");
+
+/** The host scope `ExpressionProvider` mounts, transcribed (see #6010's pin). */
+function hostScope(positions: string[]) {
+  const user = { id: 'u1', name: 'Kim', positions };
+  return { current_user: user, user, ctx: { user }, os: { user }, app: {}, data: {}, features: {} };
+}
+
+const DENIED = hostScope(['sales']);
+const ALLOWED = hostScope(['sales_manager']);
+
+const objectSchema = {
+  name: 'crm_case',
+  fields: {
+    subject: { type: 'text', label: 'Subject' },
+    salary: { type: 'text', label: 'Salary' },
+  },
+};
+
+let dataSource: any;
+
+beforeEach(() => {
+  dataSource = {
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Two sections: `Always` carries no predicate and is the paired control that
+ * proves the form rendered AT ALL — so a missing `Compensation` heading is a
+ * verdict and not an inability. `Compensation` carries the gate.
+ */
+const sections = () => [
+  { name: 'always', label: 'Always', fields: ['subject'] },
+  { name: 'pay', label: 'Compensation', visibleWhen: GATE, fields: ['salary'] },
+];
+
+/** Mount through `ObjectForm` — the entry `RecordFormPage` itself uses. */
+const renderObjectForm = async (
+  scope: Record<string, unknown>,
+  extra: Record<string, unknown>,
+) => {
+  render(
+    <PredicateScopeProvider scope={scope as any}>
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          objectName: 'crm_case',
+          mode: 'create',
+          sections: sections(),
+          ...extra,
+        } as any}
+        dataSource={dataSource}
+      />
+    </PredicateScopeProvider>,
+  );
+  // The un-gated sibling heading is the readiness signal AND the control.
+  await waitFor(() => expect(screen.getByText('Always')).toBeTruthy());
+};
+
+/** Mount `ModalForm` directly — the shape `resolveFormViewLayout` produces. */
+const renderModalFormDirect = async (scope: Record<string, unknown>) => {
+  render(
+    <PredicateScopeProvider scope={scope as any}>
+      <ModalForm
+        schema={{
+          type: 'modal-form',
+          objectName: 'crm_case',
+          mode: 'create',
+          open: true,
+          sections: sections(),
+        } as any}
+        dataSource={dataSource}
+      />
+    </PredicateScopeProvider>,
+  );
+  await waitFor(() => expect(screen.getByText('Always')).toBeTruthy());
+};
+
+/** The gated section's heading — `null` when the layout hid it. */
+const gatedHeading = () => screen.queryByText('Compensation');
+
+/**
+ * Every layout, by name, with the mount that reaches its own synthesis site.
+ * Named individually because a fix applied to five of six sites still passes a
+ * suite that exercises five.
+ */
+const LAYOUTS: { label: string; mount: (scope: Record<string, unknown>) => Promise<void> }[] = [
+  {
+    label: 'ObjectForm — stacked `simple` sections (ObjectForm.tsx section-divider)',
+    mount: (scope) => renderObjectForm(scope, { formType: 'simple' }),
+  },
+  {
+    label: 'ModalForm — via ObjectForm delegation (key-by-key remap + ModalForm groups map)',
+    mount: (scope) => renderObjectForm(scope, { formType: 'modal', open: true }),
+  },
+  {
+    label: 'ModalForm — mounted directly (the resolveFormViewLayout shape)',
+    mount: (scope) => renderModalFormDirect(scope),
+  },
+  {
+    label: 'DrawerForm — via ObjectForm delegation (key-by-key remap + explicit-sections divider)',
+    mount: (scope) => renderObjectForm(scope, { formType: 'drawer', open: true }),
+  },
+  {
+    label: 'SplitForm — via ObjectForm delegation (key-by-key remap + paneFields divider)',
+    mount: (scope) => renderObjectForm(scope, { formType: 'split' }),
+  },
+];
+
+describe('#6111 — an authored section `visibleWhen` reaches an evaluator in every layout', () => {
+  describe('DENIED — the predicate resolves FALSE, so the section heading is HIDDEN', () => {
+    // ⚠️ THE deliverable. Green here is the only observation that separates
+    // "the predicate arrived and was evaluated" from "it never arrived" —
+    // every other row in this file is green on unfixed code.
+    for (const layout of LAYOUTS) {
+      it(layout.label, async () => {
+        await layout.mount(DENIED);
+        expect(gatedHeading()).toBeNull();
+      });
+    }
+  });
+
+  describe('ALLOWED — the SAME predicate text, a user it admits ⇒ still SHOWN', () => {
+    // The control. Without it, "hidden" is satisfied by a layout that dropped
+    // the heading for an unrelated reason — a worse defect, invisible above.
+    for (const layout of LAYOUTS) {
+      it(layout.label, async () => {
+        await layout.mount(ALLOWED);
+        expect(gatedHeading()).not.toBeNull();
+      });
+    }
+  });
+
+  describe('FAULTED — a genuinely unbound root still fails OPEN (unchanged)', () => {
+    // Pinned so the DENIED rows above mean "evaluated and false" rather than
+    // "could not be evaluated at all". Asserted against the DENIED user on
+    // purpose: the only difference from the DENIED block is the ROOT the
+    // predicate names, so a fail-CLOSED regression cannot hide behind the
+    // membership test.
+    for (const layout of LAYOUTS) {
+      it(layout.label, async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => {});
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        const unbound = cel("'sales_manager' in no_such_root.positions");
+        render(
+          <PredicateScopeProvider scope={DENIED as any}>
+            <ObjectForm
+              schema={{
+                type: 'object-form',
+                objectName: 'crm_case',
+                mode: 'create',
+                formType: 'simple',
+                sections: [
+                  { name: 'always', label: 'Always', fields: ['subject'] },
+                  { name: 'pay', label: 'Compensation', visibleWhen: unbound, fields: ['salary'] },
+                ],
+              } as any}
+              dataSource={dataSource}
+            />
+          </PredicateScopeProvider>,
+        );
+        await waitFor(() => expect(screen.getByText('Always')).toBeTruthy());
+        expect(gatedHeading()).not.toBeNull();
+      });
+    }
+  });
+
+  it('measured scope: a hidden section still renders its FIELDS (objectui#6111 follow-up)', async () => {
+    // NOT an endorsement — an honest pin of what this change does and does not
+    // deliver. `section-divider` is a presentational ROW; the renderer holds no
+    // association between it and the fields after it, so the heading goes and
+    // the fields stay. The console renderer drops the whole `<section>`.
+    // Reconciling the two needs a renderer-side grouping contract and is filed
+    // separately; this assertion turning red is the SIGNAL that it landed.
+    await renderObjectForm(DENIED, { formType: 'simple' });
+    expect(gatedHeading()).toBeNull();
+    expect(screen.getByLabelText(/salary/i)).toBeTruthy();
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -941,6 +941,22 @@ export interface ObjectFormSection {
   fields: (string | FormField)[];
 
   /**
+   * Conditional visibility for the SECTION HEADER, as an authored predicate.
+   * Aligns with @objectstack/spec FormSection.visibleWhen (ADR-0089) — the same
+   * canonical `@object-ui/core` engine and record scope every other
+   * `visibleWhen` surface uses, so one authored predicate text means one thing
+   * everywhere (#6010). A broken predicate fails OPEN (the header renders).
+   *
+   * ⚠️ Scope, measured: this gates the section's `section-divider` HEADER row.
+   * The renderer treats that row as presentational and holds no association
+   * between it and the fields that follow, so a false predicate removes the
+   * heading and leaves its fields rendering (objectui#6111). The console
+   * renderer drops the whole `<section>`; reconciling the two is filed
+   * separately.
+   */
+  visibleWhen?: string | { dialect?: string; source: string };
+
+  /**
    * Custom CSS class for the section's wrapper (Card, when the form variant
    * renders sections as cards; the divider header, for the flat/simple path).
    */


### PR DESCRIPTION
Fixes #6111

Gate union run on `4ecd4dc25` (the final commit on this branch).

## What was broken

`@objectstack/spec` declares `FormSection.visibleWhen`, this repo's spec bridge maps it (`packages/react/src/spec-bridge/bridges/form-view.ts:250`), and `RecordFormPage` / `resolveFormViewLayout` wire whole `sections` objects into the layouts. Every plugin-form layout then renders a section header as a virtual `section-divider` pseudo-field, and none of them copied the predicate onto it. On the object-view chain the key was declared, mapped, carried, and dropped one hop before anything evaluated it. `visibleWhen` fails OPEN, so the section rendered unconditionally with no diagnostic.

## The card's diagnosis was incomplete — the key was dropped at TWO hops

This is the part that would have made a six-site fix still ship inert. `ObjectForm` rebuilds each section **key by key** when it delegates, so `visibleWhen` never reached three of the four layouts regardless of what the synthesis sites did:

| site | map | what it dropped |
|---|---|---|
| `ObjectForm.tsx:296` | → `SplitForm` | everything not in `{name,label,description,columns,fields,pane,className,gridClassName}` |
| `ObjectForm.tsx:331` | → `DrawerForm` | " (`collapsible`/`collapsed`/`className` variant) |
| `ObjectForm.tsx:388` | → `ModalForm` | " |
| `ModalForm.tsx:612` | `sections` → `groups` | " (`{key,title,description,className,gridClassName,fields}`) |

The split map's own comment had already recorded the hazard: *"this mapping rebuilds each section key by key, so a key it doesn't copy is silently dropped — exactly how `visibleOn` once vanished here."* Both hops are repaired.

The six `section-divider` synthesis sites, re-derived on `f66072d1b` (the card was measured on `a100f77`) — **count is still six**: `ObjectForm.tsx:1206`, `ModalForm.tsx:676`, `ModalForm.tsx:709`, `DrawerForm.tsx:555`, `DrawerForm.tsx:614`, `SplitForm.tsx:347`.

`@object-ui/types` gains the matching `ObjectFormSection.visibleWhen` declaration.

## PM mechanism assumptions — all five verified on `f66072d1b`

1. **Bridge still carries it** — ✅ `form-view.ts:250`, unchanged.
2. **Not dropped earlier than the layouts** — ✅ *and this is where the card was wrong.* `RecordFormPage.tsx:256` (`sections: formDef.sections`) and `recordFormNavigation.ts:142` (`layout.sections = formView.sections`) both pass whole objects untouched. But `ObjectForm`'s delegating remaps DO drop it — see the table above.
3. **Six synthesis sites** — ✅ re-derived, still six, line numbers above.
4. ⭐ **`form.tsx` already evaluates it — verified by RUNNING, not reading.** `pnpm exec vitest run packages/components/src/renderers/form/__tests__/predicate-scope-parity-6010.test.tsx` → `Test Files 1 passed (1) · Tests 15 passed (15)`. That file's `sectionSurface` row hand-authors `{ name: 'pay', type: 'section-divider', visibleWhen }` and its DENIED block asserts it resolves **false ⇒ hidden**, with `current_user` bound from the host scope. The mechanism is generic: `form.tsx:1991` `if (!ruleState.visible) return null` runs every pseudo-field through `resolveFieldRuleState` with `predicateScope` bound **before** the `section-divider` branch at `:2014`.
5. **`config-panel-renderer.tsx:291` is a different contract** — ✅ confirmed and left alone. It calls `section.visibleWhen(draft)` — a **function** predicate, not the authored CEL key.

## ⚠️ Fold-or-serial with #6110 — answered: **SERIAL**, this card first

Three of the five gates fail, including the load-bearing one.

| gate | verdict |
|---|---|
| ① same defect shape + same fix | ❌ **FAIL.** This card: the key is never copied onto the pseudo-field (a data-plumbing omission in layout synthesis). #6110: the key *arrives* at an evaluator and the scope argument is `undefined` (an argument-binding omission at the evaluator). Same narrative, different defect, different fix. The rubric explicitly excludes "同关键词/同子系统" — a shared contract narrative is exactly that trap. |
| ② same package / area | ❌ **FAIL.** This: `packages/plugin-form` (+ a type in `packages/types`). #6110: `apps/console/src/components/FormPage.tsx` + `packages/plugin-form/src/WizardForm.tsx` — two packages, one of them a different app. Not one changeset, not one queue slot. |
| ③ every member already adjudicated, none in the decision box | ❌ **FAIL — decisive.** #6110's own body says *"Deciding what an anonymous form binds is part of this card"*: the public `/f/:slug` route has no authenticated principal, and it shares the call site with the authed route, so what `current_user` means there is an open contract question. Folding would wash an unadjudicated decision into an adjudicated PR — precisely what this gate exists to prevent. |
| ④ each member independently verifiable | ✅ pass |
| ⑤ dispatch names an exclusion list | ❌ not named |

**Order, and why this one goes first.** This card is mechanical and its fix shape is fully pinned by existing evidence (the renderer already evaluates; the #6010 pin proves it by running). #6110 needs a maintainer ruling before any code. Landing this first also makes #6110's console-side gap *observable* rather than theoretical — with section predicates live on the object-view chain, the console route's divergent binding becomes a reproducible difference instead of a reading. And #6110's `WizardForm` half lands in `packages/plugin-form`, this wave's exclusive surface for this seat, so serialising hands it a clean tree instead of a race.

⛔ **#6110 is untouched and unclaimed.** No edit to `FormPage.tsx` or `WizardForm.tsx` — so the flagged overlap with the i18n agent's census in `apps/console` **did not arise**.

## Tests — every case asserts HIDDEN, never merely SHOWN

`packages/plugin-form/src/__tests__/sectionVisibleWhen-6111.test.tsx` — 16 tests, all green.

`visibleWhen` fails OPEN, so a section that renders is what you get when the predicate is TRUE, when it never arrived, **and** when it faulted. An assertion that a section IS shown distinguishes none of them and is green on unfixed code. The deliverable is therefore the DENIED block: the heading is **absent** while a false predicate is authored on the section. Each of the five layout rows mounts a **named** layout through the entry the product actually uses (modal/drawer/split via `ObjectForm`, exercising both hops; plus `ModalForm` mounted directly, which is the `resolveFormViewLayout` shape that never passes through `ObjectForm`).

### Per-site ablation — direction predicted BEFORE running, and confirmed

Predicted: reverting one synthesis site turns **only** that layout's DENIED row red, in the **SHOWN** direction (the heading comes back, fail-open); every ALLOWED and FAULTED row stays green everywhere. Each leg proved the mutation on disk (anchor uniqueness bounded to the file, removed text grepped to zero, `git diff --stat` printed), restored under `trap … EXIT INT TERM`, and ended with `git diff HEAD --stat` empty.

| ablated site | result | direction |
|---|---|---|
| `ObjectForm.tsx` | `2 failed \| 14 passed` — `ObjectForm — stacked simple sections` + the measured-scope case | `AssertionError: expected <span …></span> to be null` ✅ SHOWN |
| `ModalForm.tsx` (`g.visibleWhen`) | `2 failed \| 14 passed` — both ModalForm rows (delegated **and** direct) | ✅ SHOWN |
| `DrawerForm.tsx` (explicit-sections arm) | `1 failed \| 15 passed` — `DrawerForm — via ObjectForm delegation` | ✅ SHOWN |
| `SplitForm.tsx` | `1 failed \| 15 passed` — `SplitForm — via ObjectForm delegation` | ✅ SHOWN |

The first DrawerForm attempt used an anchor that occurs **twice** in that file; the guard refused to mutate rather than hit the wrong arm, and it was re-run with an anchor bounded to the explicit-sections span. Recording that because a silent wrong-site mutation would have read as a successful ablation.

No rebuild was needed for these legs and that is a property of the setup, not an omission: the pin imports `../ObjectForm` — the **source** file being edited — so the mutation reaches the running code directly. The four reds are themselves the proof it did.

## ⚠️ Which assertions would still pass on a revert

Stated plainly, as asked:

- **Every ALLOWED row (5)** — a true predicate shows the section, which is also what unfixed code does. Pure control.
- **Every FAULTED row (5)** — an unbound root fails open and the section shows, identical before and after. It exists so the DENIED rows mean "evaluated and false" rather than "could not be evaluated".
- **The `Always` readiness/control assertion** in every row — the un-gated sibling heading renders either way.

That is **11 of 16 assertions green on a full revert.** The 5 that would go red are the DENIED rows plus the measured-scope case, and they are the entire deliverable of this file.

## Measured scope — what this does NOT deliver

The predicate gates the section's **header row**. `form.tsx:2014` treats `section-divider` as presentational and holds no association between it and the fields that follow, so a false predicate removes the heading and **the section's fields keep rendering**. The console renderer (`apps/console/src/components/FormPage.tsx:1819`) drops the whole `<section>`, fields included.

That divergence is real. It is pinned honestly by the `measured scope: a hidden section still renders its FIELDS` case rather than implied away — **that assertion turning red is the signal the follow-up landed.** It is not fixed here because there is no free slot to stamp the section predicate into (a field's `visibleWhen` carries the object-level rule and its `visibleOn` carries the authored per-field view predicate — both already spoken for), and composing two predicate sources into one CEL string inside a layout is exactly the consumer-side tolerance contract-first forbids. The fix belongs in the renderer as a real section grouping. Filed as #6236.

**The tabbed arm (`ModalForm.tsx:638` `fieldTabs`) — the measurement, not a silent skip.** It synthesises no divider at all, so there is nothing to copy onto; and `FormFieldTab` (`packages/types/src/form.ts:825-849`) declares exactly `key`/`label`/`description`/`fields`/`containerClass` — no predicate slot — while `form.tsx:1309/1335/1402` never evaluate one for a tab. It cannot carry a predicate without a new public contract, and the semantics are undecided in a way that matters: `form.tsx:1301` force-mounts every panel *deliberately* so tabs keep values **and validation**, because #2959 exists precisely because unmounting *"let a required field on a tab nobody opened sail past the client and return as a server 400"*. Filed as #6237. `TabbedForm`/`WizardForm` have the same limitation, so this PR deliberately does **not** plumb `visibleWhen` into their section configs — carrying a key into a type that declares it and a renderer that ignores it is the declared-not-enforced class these cards exist to close.

## Behaviour change — in the changeset, in words

`.changeset/6111-formsection-visiblewhen.md`, `minor` (never `major`). It states explicitly that previously-inert authored metadata will **start hiding sections**; that fail-open is why nobody noticed and why this lands as a felt regression; that it is the intended ADR-0089 contract rather than a new capability; and it tells authors to audit any `sections[].visibleWhen` before upgrading.

## Verification

| gate | result |
|---|---|
| `predicate-scope-parity-6010.test.tsx` (assumption 4, by running) | ✅ `Tests 15 passed (15)` |
| `sectionVisibleWhen-6111.test.tsx` (new) | ✅ `Tests 16 passed (16)` |
| `vitest run packages/plugin-form/` | ✅ `Test Files 63 passed (63) · Tests 633 passed (633)` |
| `vitest run packages/components/src/renderers/form/` | ✅ `Test Files 52 passed (52) · Tests 346 passed (346)` |
| `type-check` @object-ui/types (`tsc --noEmit` ×3 projects) | ✅ `EXIT=0` |
| `type-check` @object-ui/plugin-form (`tsc --noEmit` ×2 projects) | ✅ `EXIT=0` |
| `turbo run lint --filter=@object-ui/plugin-form --filter=@object-ui/types --force` | ✅ `Tasks: 3 successful, 3 total` (uncached) |
| `check-changeset-no-major.mjs` | ✅ `No changeset declares a major bump.` |
| `check-changeset-presence.mjs` | ✅ `6 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed.mjs` | ✅ `All workspace packages are in the changeset fixed group.` |
| `check:spec-symbols` | ✅ `1304 files scanned against 4959 spec export names` |
| `check-control-bytes.mjs` | ✅ `OK (scanned 5140 tracked text file(s))` |

Gate set derived by enumerating each CI job's own step list (`ci.yml` `type-check`/`test`/`changeset-check`, `lint.yml`, `changeset-guard.yml`, `changeset-presence.yml`, `control-bytes.yml`), not top-level script names. Exit codes captured before any pipe.

**One declared narrowing.** `pnpm type-check` is `turbo run type-check`, which drives the full 72-task repo build; it was killed at the container's ~10-minute foreground cap with `@object-ui/plugin-designer#build` OOM-killed (exit 137) — a repo-scale run CI owns. It was replaced by invoking `tsc --noEmit` directly in each of the two changed packages, which is the same compiler over the same sources with the build graph removed. `pnpm lint` is `turbo run lint` (per-package `eslint .`), so the lint above is the **complete** CI lint unit for both changed packages, not a narrowing. Everything else in the farm runs on CI exactly once.

⛔ Left as **draft** — not marked ready, not enqueued, no auto-merge. The PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_