### PR TITLE
fix(ci): name which eager-closure half objected in the budget PR comment

### DIFF
--- a/.changeset/6230-budget-comment-half-status.md
+++ b/.changeset/6230-budget-comment-half-status.md
@@ -1,0 +1,29 @@
+---
+---
+
+CI-only: the Bundle Analysis PR comment now names *which* eager-closure half
+objected, instead of reporting only that something did.
+
+`scripts/check-eager-closure-budget.mjs` evaluates three halves and publishes a
+verdict for each to `$GITHUB_OUTPUT` — `closure_status` (the aggregate ceiling),
+`closure_chunk_status` (the per-chunk ceilings) and `closure_headroom_status`
+(ceiling sensitivity). `.github/workflows/performance-budget.yml` passed only
+the first into the comment step, so the two others were published and never
+read. The step's exit code folds all three into one `budget_status`, which meant
+the comment could say a budget objected but not which half — a reader had to
+open the job log to learn whether the total grew, one chunk grew, or a ceiling
+had stopped measuring anything.
+
+- Both missing verdicts are now passed into the comment step and rendered.
+- The healthy comment is unchanged: the breakdown appears only when a half is
+  not `pass`, verified byte-for-byte against the previous renderer.
+- A drifted ceiling (exit 2) reads as a broken **gauge** rather than a size
+  failure, and no longer claims "nothing was measured" while showing two
+  ceilings that passed.
+- `render-budget-comment.test.ts` now fails if the checker publishes a
+  `closure_*` verdict the workflow does not wire through, so a fourth half
+  cannot repeat this.
+
+The exit-code mapping is untouched: exit 2 still maps to `budget_status=error`,
+any other non-zero to `fail`, and `error` still outranks `fail` across all three
+halves.

--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -152,7 +152,16 @@ jobs:
           echo ""
           echo "📦 Eager closure (what a page load actually pays for):"
           # Writes closure_status / closure_gzip_kb / closure_budget_kb /
-          # closure_chunks to $GITHUB_OUTPUT itself. Exit codes are distinct on
+          # closure_chunks / closure_chunk_status / closure_headroom_status to
+          # $GITHUB_OUTPUT itself. EVERY key it publishes is passed into the
+          # comment step below and rendered there — a verdict published to
+          # $GITHUB_OUTPUT that no consumer reads is a verdict the PR comment
+          # cannot name, which is what objectui#6230 was (the per-chunk and
+          # sensitivity halves both went unread). A fourth half added here must
+          # be wired through too; `render-budget-comment.test.ts` fails if it is
+          # not.
+          #
+          # Exit codes are distinct on
           # purpose: 1 = over budget (a verdict about the bundle), 2 = no
           # trustworthy measurement (a verdict about the gauge). Reporting one as
           # the other is how a broken gauge gets read as a size regression, and a
@@ -243,6 +252,12 @@ jobs:
           BUDGET_CLOSURE_GZIP_KB: ${{ steps.budget.outputs.closure_gzip_kb }}
           BUDGET_CLOSURE_BUDGET_KB: ${{ steps.budget.outputs.closure_budget_kb }}
           BUDGET_CLOSURE_CHUNKS: ${{ steps.budget.outputs.closure_chunks }}
+          # The per-chunk (objectui#5490) and sensitivity (objectui#5924) halves.
+          # The step's exit code folds all three halves into one `budget_status`,
+          # so without these the comment can say a budget objected but not which
+          # half did — the reader has to open the job log to find out.
+          BUDGET_CLOSURE_CHUNK_STATUS: ${{ steps.budget.outputs.closure_chunk_status }}
+          BUDGET_CLOSURE_HEADROOM_STATUS: ${{ steps.budget.outputs.closure_headroom_status }}
           BUDGET_STEP_OUTCOME: ${{ steps.budget.outcome }}
           BUILD_PACKAGES_OUTCOME: ${{ steps.build_packages.outcome }}
         run: node scripts/render-budget-comment.mjs > budget-comment.md

--- a/scripts/__tests__/render-budget-comment.test.ts
+++ b/scripts/__tests__/render-budget-comment.test.ts
@@ -11,6 +11,7 @@ import { renderBudgetComment, renderFromEnv } from '../render-budget-comment.mjs
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 const workflowPath = path.join(repoRoot, '.github/workflows/performance-budget.yml');
 const rendererPath = path.join(repoRoot, 'scripts/render-budget-comment.mjs');
+const checkerPath = path.join(repoRoot, 'scripts/check-eager-closure-budget.mjs');
 const NO_SUCH_REPORT = path.join(repoRoot, 'scripts/__tests__/__no-size-report__.md');
 
 /**
@@ -190,6 +191,142 @@ describe('renderBudgetComment', () => {
   });
 });
 
+/**
+ * objectui#6230: the closure checker evaluates THREE halves — the aggregate
+ * ceiling, the per-chunk ceilings (objectui#5490) and ceiling sensitivity
+ * (objectui#5924) — and publishes a verdict for each. The step's exit code
+ * folds all three into one `budget_status`, so a comment rendering only that
+ * says "something objected" and nothing more: a reader had to open the job log
+ * to learn whether the total grew, one chunk grew, or a ceiling had stopped
+ * measuring anything.
+ *
+ * The per-chunk case is the one the whole gate family exists for. objectui#5266
+ * was a 89 KiB regression that landed OUTSIDE the entry chunk and inside the
+ * aggregate ceiling's headroom — exactly the shape where both numbers the
+ * comment prints are green and the verdict is still FAIL.
+ */
+describe('per-half closure verdicts', () => {
+  const halves = {
+    gzipKb: '28.1',
+    budgetKb: '350',
+    entryFile: 'index-BRKCVm_4.js',
+    closureGzipKb: '3222.6',
+    closureBudgetKb: '3266.6',
+    closureChunks: '58',
+    closureStatus: 'pass',
+    closureChunkStatus: 'pass',
+    closureHeadroomStatus: 'pass',
+  };
+
+  /**
+   * The load-bearing leg. An observability change that rewrites the HEALTHY
+   * output is a regression: every green PR comment in the repo would change
+   * shape to report nothing new.
+   */
+  it('adds nothing at all to the comment when every half passed', () => {
+    const { kind, body } = renderBudgetComment({ status: 'pass', ...halves });
+
+    expect(kind).toBe('pass');
+    expect(body).not.toContain('Which half objected');
+    expect(body).not.toContain('Eager-closure half');
+    expect(body).toContain('| Status | **PASS** | — |');
+    expect(body).not.toContain('FAIL');
+  });
+
+  it('names the AGGREGATE half when the total is over its ceiling', () => {
+    const { body } = renderBudgetComment({
+      status: 'fail',
+      ...halves,
+      closureGzipKb: '3400.0',
+      closureStatus: 'fail',
+    });
+
+    expect(body).toContain('**Which half objected:**');
+    expect(body).toContain('| Aggregate closure ceiling | ❌ over its ceiling |');
+    expect(body).toContain('| Per-chunk ceilings | ✅ pass |');
+    expect(body).toContain('| Ceiling sensitivity (headroom) | ✅ pass |');
+  });
+
+  /**
+   * The objectui#5266 shape. Note the numbers here are IDENTICAL to the
+   * all-pass case above: before this wiring the two comments differed only in
+   * `PASS` vs `FAIL`, with both printed metrics comfortably inside budget and
+   * nothing anywhere in the body saying why.
+   */
+  it('names the PER-CHUNK half when one chunk is over while the total is not', () => {
+    const { kind, body } = renderBudgetComment({
+      status: 'fail',
+      ...halves,
+      closureChunkStatus: 'fail',
+    });
+
+    expect(kind).toBe('fail');
+    // Both printed metrics are green; only the half table explains the FAIL.
+    expect(body).toContain('| **Eager closure** (gzip, 58 chunks) | **3222.6 KB** | 3266.6 KB |');
+    expect(body).toContain('| Status | **FAIL** | — |');
+    expect(body).toContain('| Per-chunk ceilings | ❌ over its ceiling |');
+    expect(body).toContain('| Aggregate closure ceiling | ✅ pass |');
+  });
+
+  /**
+   * A drifted ceiling is exit 2, which `performance-budget.yml` maps to
+   * `budget_status=error` — so it lands in the NOT-MEASURED branch, not the
+   * verdict branch. It must read as a verdict about the gauge, and must never
+   * acquire a ❌: nothing grew.
+   */
+  it('names a drifted ceiling as a broken GAUGE, never as a size failure', () => {
+    const { kind, body } = renderBudgetComment({
+      status: 'error',
+      ...halves,
+      closureHeadroomStatus: 'error',
+      message: 'the eager-closure gauge produced no trustworthy measurement',
+      budgetOutcome: 'failure',
+      buildOutcome: 'success',
+    });
+
+    expect(kind).toBe('not-measured');
+    expect(body).toContain('| Ceiling sensitivity (headroom) | ⚠️ broken gauge |');
+    expect(body).toContain('a verdict about the ceiling, not about the bundle');
+    expect(body).not.toContain('❌');
+    expect(body).not.toContain('FAIL');
+    // The closure WAS measured on this path, so the comment must not claim the
+    // opposite two lines above a table showing two ceilings that passed.
+    expect(body).not.toContain('Nothing was measured');
+    expect(body).toContain('gauge not trustworthy');
+  });
+
+  it('keeps the "not measured" wording when nothing really was measured', () => {
+    // dist missing / no JS / cancelled: the checker never ran, so it published
+    // no closure numbers. This branch must be untouched by the above.
+    const { kind, body } = renderBudgetComment({
+      status: 'error',
+      message: 'Build output not found at apps/console/dist/assets',
+      budgetOutcome: 'failure',
+      buildOutcome: 'success',
+    });
+
+    expect(kind).toBe('not-measured');
+    expect(body).toContain('## ℹ️ Console Performance Budget — not measured');
+    expect(body).toContain('Nothing was measured');
+    expect(body).not.toContain('Which half objected');
+  });
+
+  it('renders no half table when no half status was handed over', () => {
+    // The objectui#3152 failure mode, in its per-half form: blanks must render
+    // as silence, never be inferred into verdicts.
+    const { body } = renderBudgetComment({
+      status: 'fail',
+      ...halves,
+      closureStatus: '',
+      closureChunkStatus: '',
+      closureHeadroomStatus: '',
+    });
+
+    expect(body).not.toContain('Which half objected');
+    expect(body).not.toContain('| Per-chunk ceilings |');
+  });
+});
+
 describe('renderFromEnv', () => {
   it('reads the exact env names the workflow sets', () => {
     const { kind, body } = renderFromEnv(
@@ -280,6 +417,32 @@ describe('performance-budget.yml contract', () => {
     expect(declared.length).toBeGreaterThan(0);
     for (const name of declared) {
       expect(renderer, `renderer must read env.${name}`).toContain(`env.${name}`);
+    }
+  });
+
+  /**
+   * objectui#6230: `closure_chunk_status` (objectui#5490) and
+   * `closure_headroom_status` (objectui#5924) were both published to
+   * `$GITHUB_OUTPUT` and never read, each following the precedent of the last.
+   * The card's explicit ask was that a THIRD round of this not happen — so the
+   * obligation is pinned mechanically rather than left to review: a half added
+   * to the checker fails here until it reaches the comment.
+   */
+  it('passes every closure verdict the checker publishes into the comment step', () => {
+    const checker = fs.readFileSync(checkerPath, 'utf8');
+    const call = checker.slice(checker.lastIndexOf('writeGithubOutput({'));
+    const published = [...call.slice(0, call.indexOf('});')).matchAll(/(closure_\w+):/g)].map(
+      (m) => m[1],
+    );
+
+    // Guard the guard: a regex that matched nothing would pass silently.
+    expect(published).toContain('closure_status');
+    expect(published).toContain('closure_chunk_status');
+    expect(published).toContain('closure_headroom_status');
+
+    for (const key of published) {
+      expect(workflow, `workflow must pass steps.budget.outputs.${key} to the comment step`)
+        .toContain(`steps.budget.outputs.${key}`);
     }
   });
 

--- a/scripts/render-budget-comment.mjs
+++ b/scripts/render-budget-comment.mjs
@@ -48,6 +48,8 @@ const text = (value) => (typeof value === 'string' ? value.trim() : '');
  * @param {string} [input.closureGzipKb]  measured gzip size of the eager closure, in KB
  * @param {string} [input.closureBudgetKb] the closure ceiling it was compared against
  * @param {string} [input.closureChunks]  how many chunks the eager closure spans
+ * @param {string} [input.closureChunkStatus]    `closure_chunk_status` — the per-chunk half
+ * @param {string} [input.closureHeadroomStatus] `closure_headroom_status` — the sensitivity half
  * @param {string} [input.message]       human-readable reason when `status` is `error`
  * @param {string} [input.budgetOutcome] `steps.budget.outcome`
  * @param {string} [input.buildOutcome]  `steps.build_packages.outcome`
@@ -66,6 +68,8 @@ export function renderBudgetComment(input = {}) {
     gzipKb: text(input.closureGzipKb),
     budgetKb: text(input.closureBudgetKb),
     chunks: text(input.closureChunks),
+    chunkStatus: text(input.closureChunkStatus),
+    headroomStatus: text(input.closureHeadroomStatus),
   };
 
   // A verdict needs an affirmative status AND the numbers that status was
@@ -82,9 +86,71 @@ export function renderBudgetComment(input = {}) {
         buildOutcome: text(input.buildOutcome),
         sizeReport,
         runUrl: text(input.runUrl),
+        closure,
       });
 
   return { kind: measured ? status : 'not-measured', body };
+}
+
+/**
+ * The eager-closure checker evaluates three halves and publishes a verdict for
+ * each. The step's exit code folds all three into ONE `budget_status`, so a
+ * comment that renders only that says "something objected" and sends the reader
+ * to the job log to learn which — the aggregate total, one chunk, or a ceiling
+ * that has stopped measuring anything (objectui#6230). These labels name the
+ * halves the way the step log names them.
+ */
+const CLOSURE_HALVES = [
+  ['status', 'Aggregate closure ceiling'],
+  ['chunkStatus', 'Per-chunk ceilings'],
+  ['headroomStatus', 'Ceiling sensitivity (headroom)'],
+];
+
+/**
+ * `error` is deliberately NOT worded as a size verdict. It is what exit 2 means
+ * in the checker: the report cannot be trusted, or a ceiling has drifted out of
+ * range of the regression it must catch. Nothing grew.
+ */
+const HALF_VERDICT = {
+  pass: '✅ pass',
+  fail: '❌ over its ceiling',
+  error: '⚠️ broken gauge',
+};
+
+const halfVerdict = (status) => HALF_VERDICT[status] ?? `\`${status}\``;
+
+/**
+ * Renders the per-half breakdown, and renders NOTHING in the two cases where it
+ * would be noise:
+ *
+ *   - every half passed — the healthy comment stays byte-for-byte what it was.
+ *     An observability change that rewrites the green output is a regression;
+ *   - no half status was handed over — a caller that does not pass them gets
+ *     silence, never a table of blanks inferred into verdicts, which is the
+ *     objectui#3152 failure mode this whole file exists to prevent.
+ */
+function closureHalfLines(closure) {
+  const rows = CLOSURE_HALVES.map(([key, label]) => [label, closure[key] ?? '']).filter(
+    ([, status]) => status !== '',
+  );
+  if (rows.length === 0 || rows.every(([, status]) => status === 'pass')) {
+    return [];
+  }
+  const lines = [
+    '**Which half objected:**',
+    '',
+    '| Eager-closure half | Verdict |',
+    '|--------------------|---------|',
+    ...rows.map(([label, status]) => `| ${label} | ${halfVerdict(status)} |`),
+    '',
+  ];
+  if (rows.some(([, status]) => status === 'error')) {
+    lines.push(
+      '> ⚠️ A **broken gauge** half is a verdict about the ceiling, not about the bundle: that line has drifted out of range of the regression it exists to catch, or the report behind it cannot be trusted. It does not say anything grew. The `Check console performance budget` step log carries the ceiling and the number it was compared against.',
+      '',
+    );
+  }
+  return lines;
 }
 
 function verdictBody({ status, gzipKb, budgetKb, entryFile, sizeReport, closure }) {
@@ -108,6 +174,7 @@ function verdictBody({ status, gzipKb, budgetKb, entryFile, sizeReport, closure 
     // gate (objectui#5324).
     'The **eager closure** is every chunk the entry reaches through static imports — what the browser fetches and parses before the app renders. The entry chunk on its own is a small fraction of it.',
     '',
+    ...closureHalfLines(closure),
   ];
   if (!closureMeasured) {
     // Never let an absent closure figure render as a quiet table with one row.
@@ -120,20 +187,52 @@ function verdictBody({ status, gzipKb, budgetKb, entryFile, sizeReport, closure 
   return withSizeReport(lines.join('\n'), sizeReport);
 }
 
-function notMeasuredBody({ message, budgetOutcome, buildOutcome, sizeReport, runUrl }) {
-  const lines = [
-    '## ℹ️ Console Performance Budget — not measured',
-    '',
-    'This run did not produce a console bundle to measure, so there is **no pass/fail verdict** for the performance budget.',
-    '',
-    '**This is not a budget violation.** Nothing was measured — the numbers a real violation would carry are simply absent.',
-    '',
+function notMeasuredBody({
+  message,
+  budgetOutcome,
+  buildOutcome,
+  sizeReport,
+  runUrl,
+  closure = {},
+}) {
+  // objectui#6230: `error` does not always mean "nothing was measured". A
+  // ceiling that has drifted out of range of the regression it must catch is
+  // exit 2 with a perfectly good measurement behind it, and then the "nothing
+  // was measured" wording below is FALSE — the comment would deny a measurement
+  // in the same breath as the half table showing two ceilings that passed on
+  // one. Discriminate on the same emptiness the verdict branch keys on: the
+  // checker publishes `closure_gzip_kb` EMPTY when it has no report, never as a
+  // stale number, and that is pinned by its own tests.
+  const closureMeasured = (closure.gzipKb ?? '') !== '' && (closure.budgetKb ?? '') !== '';
+  const lines = closureMeasured
+    ? [
+        '## ⚠️ Console Performance Budget — gauge not trustworthy',
+        '',
+        'The eager closure was measured, but one of the ceilings it is measured against no longer means what it names, so this run carries **no pass/fail verdict** for the performance budget.',
+        '',
+        '**This is not a budget violation.** Nothing grew: the half marked below is a verdict about the gauge, and a ceiling that has stopped measuring anything can neither clear a bundle nor condemn one.',
+        '',
+      ]
+    : [
+        '## ℹ️ Console Performance Budget — not measured',
+        '',
+        'This run did not produce a console bundle to measure, so there is **no pass/fail verdict** for the performance budget.',
+        '',
+        '**This is not a budget violation.** Nothing was measured — the numbers a real violation would carry are simply absent.',
+        '',
+      ];
+  lines.push(
     '| Step | Outcome |',
     '|------|---------|',
     `| Build packages | \`${outcome(buildOutcome)}\` |`,
     `| Check console performance budget | \`${outcome(budgetOutcome)}\` |`,
     '',
-  ];
+    // Exit 2 — a drifted ceiling, or a report that cannot be trusted — maps to
+    // `budget_status=error`, and error lands HERE rather than in the verdict
+    // body. So this branch needs the halves as much as that one does: they are
+    // the only thing in the comment that says WHICH gauge is broken.
+    ...closureHalfLines(closure),
+  );
 
   if (message) {
     lines.push(`Reason: ${message}`, '');
@@ -183,6 +282,8 @@ export function renderFromEnv(env = process.env, sizeReportPath = 'size-report.m
     closureGzipKb: env.BUDGET_CLOSURE_GZIP_KB,
     closureBudgetKb: env.BUDGET_CLOSURE_BUDGET_KB,
     closureChunks: env.BUDGET_CLOSURE_CHUNKS,
+    closureChunkStatus: env.BUDGET_CLOSURE_CHUNK_STATUS,
+    closureHeadroomStatus: env.BUDGET_CLOSURE_HEADROOM_STATUS,
     budgetOutcome: env.BUDGET_STEP_OUTCOME,
     buildOutcome: env.BUILD_PACKAGES_OUTCOME,
     sizeReport: readSizeReport(sizeReportPath),


### PR DESCRIPTION
Fixes #6230

Takes disposition 1 from the card: wire the unread verdicts into the comment and render them.

## The defect, confirmed from source

`scripts/check-eager-closure-budget.mjs` publishes **six** keys, three of them verdicts:

```
closure_status · closure_gzip_kb · closure_budget_kb · closure_chunks
closure_chunk_status · closure_headroom_status
```

`.github/workflows/performance-budget.yml` passed **four** into the comment step. `closure_chunk_status` (#5490) and `closure_headroom_status` (#5924) were written and never read.

The step's exit code folds all three halves into one `budget_status`, so the comment could say a budget objected but not which half did. Two things I found beyond the card's description:

- **`closure_status` reached the renderer and was dropped on the floor.** `renderBudgetComment` read `input.closureStatus` into its `closure` object; `verdictBody` never referenced it. So *no* half verdict was rendered — not even the aggregate one that was wired. This change makes it live.
- **A drifted ceiling never reached the verdict branch at all.** Exit 2 maps to `budget_status=error`, which is not in `MEASURED_STATUSES`, so it lands in `notMeasuredBody`. See "the leg-4 consequence" below.

## The shape this is for

The per-chunk case is #5266's: a regression that lands outside the entry chunk and inside the aggregate ceiling's headroom. Both numbers the comment prints are green and the verdict is still FAIL.

Rendering the **old** renderer against all-pass and chunk-fail env with **identical numbers**, the whole diff is:

```
1c1
< kind: pass                                 > kind: fail
3c3
< ## ✅ Console Performance Budget            > ## ❌ Console Performance Budget
10c10
< | Status | **PASS** | — |                  > | Status | **FAIL** | — |
```

A ❌ FAIL whose two visible metric rows are both inside budget, and nothing anywhere saying why. The new renderer on the same env adds:

```
**Which half objected:**

| Eager-closure half | Verdict |
|--------------------|---------|
| Aggregate closure ceiling | ✅ pass |
| Per-chunk ceilings | ❌ over its ceiling |
| Ceiling sensitivity (headroom) | ✅ pass |
```

## The exit-code mapping is untouched

Checked mechanically, not by eye. Every `budget_status=`, `CLOSURE_CODE`, `ENTRY_OVER` and `MAX_ENTRY_GZIP_KB=` line in the workflow is byte-identical to `0409b766d`:

```
$ diff <(git show 0409b766d:....yml | grep 'CLOSURE_CODE\|budget_status=\|ENTRY_OVER\|MAX_ENTRY_GZIP_KB=\|exit 1') \
       <(grep '...' .github/workflows/performance-budget.yml)
IDENTICAL — every exit-code / budget_status line is unchanged
```

Exit 2 still maps to `error`, any other non-zero to `fail`, and `error` still outranks `fail` across all three halves. Only line numbers moved, by the comment block added above the checker invocation. This PR changes what the step *reports*, not what it *does*.

## The leg-4 consequence, called out rather than buried

A drifted ceiling is exit 2 → `budget_status=error` → the **not-measured** branch. Rendering the halves there exposed a sentence that is false on that path: the body said *"Nothing was measured — the numbers a real violation would carry are simply absent"* directly above a table showing two ceilings that had just measured fine.

That contradiction is latent on `main` (the halves weren't shown); showing them makes it visible, so leaving it would mean shipping a self-contradicting comment. The branch now discriminates on the same emptiness the verdict branch already keys on — the checker publishes `closure_gzip_kb` **empty** when it has no report, never as a stale number, and that is pinned by its own tests:

- closure numbers present + `error` → *"gauge not trustworthy"*: the closure was measured, a ceiling stopped meaning what it names, nothing grew.
- closure numbers absent (dist missing, no JS, cancelled) → the existing *"not measured"* wording, untouched and pinned by a test.

This is the only wording change to an existing path, and it is confined to the case the card's leg 4 is about.

## Verification

Renderer is a plain node script, so each leg was rendered from the env that scenario produces, against **both** this renderer and the pre-change one read from the `0409b766d` git blob (no working-tree mutation). Each was predicted before running; all four matched.

| Leg | Result |
|-----|--------|
| all three `pass` | **byte-for-byte identical** to the old renderer (`cmp` clean) — the green comment does not change |
| aggregate `fail` | names `Aggregate closure ceiling ❌ over its ceiling`, other two `✅ pass` |
| aggregate `pass`, chunk `fail` | names `Per-chunk ceilings ❌`, aggregate row `✅` — the #5266 shape |
| headroom `error` | `kind: not-measured`, `Ceiling sensitivity (headroom) ⚠️ broken gauge`, no `❌` anywhere, no "Nothing was measured" |

The all-pass leg is the one that mattered most, so it is asserted as byte equality rather than by reading.

**Reverse-verification of the new contract guard.** Its logic, applied to the pre-change workflow from the git blob:

```
checker publishes: closure_status, closure_gzip_kb, closure_budget_kb,
                   closure_chunks, closure_chunk_status, closure_headroom_status
OLD workflow (0409b766d, pre-change): RED — unread: closure_chunk_status, closure_headroom_status
NEW workflow (this branch):           GREEN — every published verdict is wired
```

It reds on exactly the two keys this card reports, and greens here. That is the card's ⛔ "no third round of this" made mechanical: a fourth half fails the suite until it reaches the comment.

**Suites** — the four under `scripts/__tests__` that read these two files, at final commit `af60a25b8`:

```
pnpm vitest run scripts/__tests__/render-budget-comment.test.ts \
  scripts/__tests__/check-eager-closure-budget.test.ts \
  scripts/__tests__/ci-cd-pipeline-doc.test.ts \
  scripts/__tests__/turbo-build-inputs.test.ts --maxWorkers=2
  → Test Files 4 passed (4) · Tests 167 passed (167)
```

All 7 new tests confirmed collected by name in a `--reporter=verbose` run, not inferred from the total.

**Gates**, each read from its own printed verdict line:

- `pnpm type-check:scripts` → exit 0 (script name echoed; not a zero-match `--filter`)
- `pnpm lint:root` → `✖ 28 problems (0 errors, 28 warnings)`, exit 0. Run unnarrowed over the whole root scope; zero occurrences of my files in the output, all 28 warnings pre-existing and elsewhere.
- `check-control-bytes` → `✅ OK (scanned 5149 tracked text file(s); skipped 85 binary)`
- `check:entry-guard` → `✓ 46 scripts/ file(s) — no entry guard outside the baseline` (shrink-only ratchet unmoved)
- `check-vi-mock-specifiers` → `✅ OK`
- `check:esm-specifiers` → no un-ledgered extensionless relative specifier
- `changeset:check` → all three lines ✅
- Workflow YAML re-parsed with a real YAML parser; the render step's env block carries all six closure keys.

Heavy commands ran through the shared verify lock.

## Changeset

Empty-frontmatter, following the repo's precedent for CI-only changes (objectui has no `skip-changeset` label). Nothing here ships to a package.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_