### PR TITLE
fix(components): forward RadioGroupSchema.orientation to the rendered radio group

### DIFF
--- a/.changeset/6158-radio-group-orientation.md
+++ b/.changeset/6158-radio-group-orientation.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/components': minor
+---
+
+`radio-group` now renders the `orientation` its own type has always declared (objectui#6158).
+
+`RadioGroupSchema.orientation` was declared in two layers and read by none. The shipped TS
+type carries `orientation?: 'horizontal' | 'vertical'` with `@default 'vertical'`
+(`packages/types/src/form.ts:383`) and the zod mirror carries the matching
+`z.enum(['horizontal', 'vertical'])` (`packages/types/src/zod/form.zod.ts:282`), while
+`packages/components/src/renderers/form/radio-group.tsx` contained neither the string
+`orientation` nor `direction` and forwarded only `defaultValue`, `className`, the
+form-control DOM whitelist and the designer props.
+
+The consequence was measurable rather than cosmetic: every radiogroup root the library
+rendered came back byte-identical on that axis — no `data-orientation`, no
+`aria-orientation` — so the docs page's `## Layout Options` section demonstrated a
+distinction the product could not make, and its horizontal demo rendered vertically. An
+author reading the shipped type had every reason to write `orientation: 'horizontal'` and
+no way to discover it was inert.
+
+The key is now forwarded to the underlying Radix `RadioGroup`, which accepts it natively
+with the same two-value vocabulary and puts it on the root as `aria-orientation` and
+`data-orientation`; the layout utilities follow it so the visible difference the docs
+promise is real. This restores declared = enforced **without widening the acceptance
+set** — no new key is accepted, and no spelling outside the declared enum becomes legal.
+
+Two behaviour notes for anyone already shipping radio groups:
+
+- The declared `@default 'vertical'` is now actually applied instead of being left to
+  Radix's own `undefined`. A group that never authored the key keeps the vertical stack it
+  already rendered, and additionally announces `aria-orientation="vertical"` — the
+  announced orientation now agrees with the rendered one rather than being absent. Arrow
+  key roving focus narrows to Up/Down for those groups, which is the correct pairing for a
+  vertical stack.
+- Author `className` still wins: the orientation layout utilities compose first and the
+  authored class last, so tailwind-merge resolves every conflict in the author's favour.
+
+Registry meta `inputs` for `radio-group` gains `orientation` in the same change — it was
+the third surface that omitted the key, and leaving it out would have kept the designer
+palette disagreeing with the type.

--- a/packages/components/src/renderers/form/__tests__/radio-group-orientation.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/radio-group-orientation.test.tsx
@@ -41,10 +41,6 @@
  * that divergence is objectui#6157's scope and is deliberately not touched by
  * this branch. Until it lands, the two shipped docs demos still render
  * identically to each other even with this renderer fix in place.
- *
- * The two fixtures differ in EXACTLY one key. Same `id`, same options, same
- * order — so a difference in the rendered roots cannot come from anywhere but
- * `orientation`, and the byte comparison stays a real measurement.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -55,20 +51,29 @@ import type { RadioGroupSchema } from '@object-ui/types';
 // `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
 import '../../../renderers';
 
-const BASE = {
-  type: 'radio-group',
-  id: 'os6158-size',
-  options: [
-    { value: 'sm', label: 'Small' },
-    { value: 'md', label: 'Medium' },
-    { value: 'lg', label: 'Large' },
-  ],
-} as const;
+/**
+ * One factory, one parameter — so "the fixtures differ in EXACTLY one key" is
+ * a property of the code rather than a claim in a comment. Same `id`, same
+ * options, same order; a difference in the rendered roots cannot come from
+ * anywhere but `orientation`.
+ */
+function fixture(orientation?: 'horizontal' | 'vertical'): RadioGroupSchema {
+  return {
+    type: 'radio-group',
+    id: 'os6158-size',
+    options: [
+      { value: 'sm', label: 'Small' },
+      { value: 'md', label: 'Medium' },
+      { value: 'lg', label: 'Large' },
+    ],
+    ...(orientation ? { orientation } : {}),
+  };
+}
 
-const HORIZONTAL: RadioGroupSchema = { ...BASE, orientation: 'horizontal' };
-const VERTICAL: RadioGroupSchema = { ...BASE, orientation: 'vertical' };
+const HORIZONTAL = fixture('horizontal');
+const VERTICAL = fixture('vertical');
 /** `orientation` omitted entirely — the `@default 'vertical'` case. */
-const DEFAULTED: RadioGroupSchema = { ...BASE };
+const DEFAULTED = fixture();
 
 function renderRoot(schema: RadioGroupSchema): HTMLElement {
   const Component = ComponentRegistry.get(schema.type);

--- a/packages/components/src/renderers/form/__tests__/radio-group-orientation.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/radio-group-orientation.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RadioGroupSchema.orientation` must reach the DOM (objectui#6158).
+ *
+ * The key was DECLARED in two layers and read by none:
+ *
+ *   - `packages/types/src/form.ts:383` — `orientation?: 'horizontal' | 'vertical'`
+ *     with `@default 'vertical'`;
+ *   - `packages/types/src/zod/form.zod.ts:282` —
+ *     `z.enum(['horizontal', 'vertical']).optional()`;
+ *   - `packages/components/src/renderers/form/radio-group.tsx` — contained
+ *     neither the string `orientation` nor `direction`, and forwarded only
+ *     `defaultValue`, `className`, the form-control DOM whitelist and the
+ *     designer props.
+ *
+ * The measurable consequence: EVERY radiogroup root the library rendered was
+ * byte-identical on that axis — no `data-orientation`, no `aria-orientation` —
+ * so the docs page's `## Layout Options` section demonstrated a distinction the
+ * product could not make. The horizontal demo rendered vertically.
+ *
+ * ## Why these assertions are shaped the way they are
+ *
+ * A pin that asserts `orientation: 'horizontal'` renders SOMETHING is a phantom:
+ * it passes on the unfixed renderer too, because the unfixed renderer renders
+ * something for every input. The defect is an EQUALITY — two authored values
+ * producing one output — so the pin has to assert the INEQUALITY. `renders
+ * different markup for the two orientations` below is that assertion, and it is
+ * red on the unfixed renderer for the right reason: the two roots come back
+ * character-for-character equal.
+ *
+ * Both fixtures are authored HERE rather than reusing
+ * `examples/schema-catalog/src/schemas/components-form-radio-group/*`. Those
+ * catalog fixtures currently spell the key `direction`, which nothing declares —
+ * that divergence is objectui#6157's scope and is deliberately not touched by
+ * this branch. Until it lands, the two shipped docs demos still render
+ * identically to each other even with this renderer fix in place.
+ *
+ * The two fixtures differ in EXACTLY one key. Same `id`, same options, same
+ * order — so a difference in the rendered roots cannot come from anywhere but
+ * `orientation`, and the byte comparison stays a real measurement.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import type { RadioGroupSchema } from '@object-ui/types';
+// Module scope, not `beforeAll` — the cold transform must not be billed to
+// `hookTimeout`. See object-ui/no-dynamic-import-in-test-hook (objectui#3010).
+import '../../../renderers';
+
+const BASE = {
+  type: 'radio-group',
+  id: 'os6158-size',
+  options: [
+    { value: 'sm', label: 'Small' },
+    { value: 'md', label: 'Medium' },
+    { value: 'lg', label: 'Large' },
+  ],
+} as const;
+
+const HORIZONTAL: RadioGroupSchema = { ...BASE, orientation: 'horizontal' };
+const VERTICAL: RadioGroupSchema = { ...BASE, orientation: 'vertical' };
+/** `orientation` omitted entirely — the `@default 'vertical'` case. */
+const DEFAULTED: RadioGroupSchema = { ...BASE };
+
+function renderRoot(schema: RadioGroupSchema): HTMLElement {
+  const Component = ComponentRegistry.get(schema.type);
+  if (!Component) throw new Error('radio-group is not registered');
+  const { container } = render(<Component schema={schema} />);
+  const root = container.querySelector<HTMLElement>('[role="radiogroup"]');
+  if (!root) throw new Error('no [role="radiogroup"] root was rendered');
+  return root;
+}
+
+describe('radio-group renderer — orientation (objectui#6158)', () => {
+  it('renders DIFFERENT markup for the two orientations', () => {
+    const horizontal = renderRoot(HORIZONTAL).outerHTML;
+    const vertical = renderRoot(VERTICAL).outerHTML;
+
+    // The whole defect in one line. On the unfixed renderer these two strings
+    // are equal, which is precisely the bug the card measured off the built
+    // site. Anything weaker than an inequality passes before AND after the fix.
+    expect(horizontal).not.toBe(vertical);
+  });
+
+  it('carries the authored orientation onto the radiogroup root', () => {
+    const horizontal = renderRoot(HORIZONTAL);
+    const vertical = renderRoot(VERTICAL);
+
+    // Asserted on the DOM, not on a spy over the props reaching Radix: a Radix
+    // version that accepted the prop and ignored it would satisfy a spy and
+    // still ship the byte-identical markup this card is about.
+    expect(horizontal.getAttribute('data-orientation')).toBe('horizontal');
+    expect(horizontal.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(vertical.getAttribute('data-orientation')).toBe('vertical');
+    expect(vertical.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  it('lays the horizontal group out as a row and the vertical group as a stack', () => {
+    const horizontal = renderRoot(HORIZONTAL);
+    const vertical = renderRoot(VERTICAL);
+
+    // The attributes above are the a11y/keyboard half. This is the half a
+    // reader of the docs page actually sees: `## Layout Options` promises a
+    // visual difference, so the layout utilities have to diverge too.
+    expect(horizontal.className).toContain('flex');
+    expect(horizontal.className).not.toContain('grid');
+    expect(vertical.className).toContain('grid');
+    expect(vertical.className).not.toContain('flex');
+  });
+
+  it('enforces the declared `@default \'vertical\'` when orientation is omitted', () => {
+    const defaulted = renderRoot(DEFAULTED);
+
+    // Red before the fix: the unfixed renderer emitted no orientation
+    // attribute at all, so the declared default was as unenforced as the
+    // explicit values were.
+    expect(defaulted.getAttribute('data-orientation')).toBe('vertical');
+    expect(defaulted.getAttribute('aria-orientation')).toBe('vertical');
+
+    // ⚠️ This half passes on a revert as well — before the fix the two roots
+    // were equal because BOTH were orientation-less. It is kept because it is
+    // what makes "the default is vertical" (rather than merely "some default")
+    // fall out of the assertion above, and it fails loudly if a later change
+    // gives the omitted case its own branch.
+    expect(defaulted.outerHTML).toBe(renderRoot(VERTICAL).outerHTML);
+  });
+
+  it('lets an author className still win over the orientation layout classes', () => {
+    const Component = ComponentRegistry.get('radio-group')!;
+    const { container } = render(
+      <Component schema={HORIZONTAL} className="gap-8" />,
+    );
+    const root = container.querySelector<HTMLElement>('[role="radiogroup"]');
+
+    // tailwind-merge resolves the conflict in the author's favour; the
+    // orientation classes are a default, not an override.
+    expect(root?.className).toContain('gap-8');
+    expect(root?.className).not.toContain('gap-4');
+  });
+});

--- a/packages/components/src/renderers/form/radio-group.tsx
+++ b/packages/components/src/renderers/form/radio-group.tsx
@@ -9,8 +9,31 @@
 import { ComponentRegistry } from '@object-ui/core';
 import type { RadioGroupSchema } from '@object-ui/types';
 import { RadioGroup, RadioGroupItem, Label } from '../../ui';
+import { cn } from '../../lib/utils';
 import { toControlValue } from './option-value';
 import { toFormControlDomProps } from '../../lib/form-control-dom-props';
+
+/**
+ * The declared default (`packages/types/src/form.ts` — `@default 'vertical'`).
+ * Applied here rather than left to Radix's own `undefined`, because a default
+ * the type documents and nothing applies is the same declared-but-unenforced
+ * defect as the key itself was (objectui#6158). Vertical is also what the
+ * group has always LOOKED like — the `grid gap-2` stack — so this makes the
+ * announced orientation agree with the rendered one instead of being absent.
+ */
+const DEFAULT_ORIENTATION = 'vertical' as const;
+
+/**
+ * Layout utilities per orientation. `vertical` deliberately names no class:
+ * the `ui/radio-group` wrapper already applies `grid gap-2`, and that stack IS
+ * the vertical layout. Author `className` is composed LAST so tailwind-merge
+ * resolves every conflict in the author's favour — these are a default, not an
+ * override.
+ */
+const ORIENTATION_CLASS: Record<'horizontal' | 'vertical', string | undefined> = {
+  horizontal: 'flex flex-row flex-wrap items-center gap-4',
+  vertical: undefined,
+};
 
 ComponentRegistry.register('radio-group', 
   ({ schema, className, ...props }: { schema: RadioGroupSchema; className?: string; [key: string]: any }) => {
@@ -22,12 +45,21 @@ ComponentRegistry.register('radio-group',
         ...radioProps 
     } = props;
 
+    // Forwarded BY NAME, not by reopening the spread: `toFormControlDomProps`
+    // is a closed whitelist and `orientation` is not on it, which is exactly
+    // the objectui#4435 route that file documents for a key like this. Radix's
+    // `RadioGroup` takes `orientation` natively with the same two-value
+    // vocabulary, and puts it on the root as both `aria-orientation` and (via
+    // RovingFocusGroup) `data-orientation`.
+    const orientation = schema.orientation ?? DEFAULT_ORIENTATION;
+
     return (
     // Radix speaks strings — stringify authored (possibly numeric) values for
     // the control; ids stay stable via the same stringification (#3090).
     <RadioGroup
         defaultValue={toControlValue(schema.defaultValue)}
-        className={className}
+        orientation={orientation}
+        className={cn(ORIENTATION_CLASS[orientation], className)}
         {...toFormControlDomProps(radioProps)}
         // Apply designer props to the root element
         {...{ 'data-obj-id': dataObjId, 'data-obj-type': dataObjType, style }}
@@ -53,6 +85,7 @@ ComponentRegistry.register('radio-group',
         label: 'Options',
         description: 'Array of {label, value} objects'
       },
+      { name: 'orientation', type: 'enum', enum: ['horizontal', 'vertical'], defaultValue: 'vertical', label: 'Orientation' },
       { name: 'className', type: 'string', label: 'CSS Class' }
     ],
     defaultProps: {


### PR DESCRIPTION
Fixes #6158

`RadioGroupSchema.orientation` was declared in two layers and read by none. This forwards it to the underlying Radix `RadioGroup`, restoring declared = enforced **without widening the acceptance set** — no new key becomes legal, and no spelling outside the already-declared enum is accepted.

## What was re-derived, not assumed

All four of the dispatch's mechanism assumptions were checked against this branch's tree before any code was written. All four held, but two of them moved:

| Assumption | Verdict |
|---|---|
| Renderer is `packages/components/src/renderers/form/radio-group.tsx` | ✅ Confirmed. Registration spans lines 15–67; the file contained neither the string `orientation` nor `direction`. |
| `orientation` declared on the TS type **and** the zod mirror, with enum + default | ✅ Confirmed, but the card's line numbers point at `dist/`. The **source** sites are `packages/types/src/form.ts:383` (`orientation?: 'horizontal' \| 'vertical'`, `@default 'vertical'`) and `packages/types/src/zod/form.zod.ts:282` (`z.enum(['horizontal', 'vertical']).optional()`). |
| Radix accepts `orientation` natively with the same vocabulary | ✅ Confirmed **against `node_modules`, not memory**: installed `@radix-ui/react-radio-group@1.4.7`, whose `RadioGroupProps.orientation` is `RovingFocusGroupProps['orientation']` = `AriaAttributes['aria-orientation']` = `'horizontal' \| 'vertical'`. Exact match — so this is a real forward, not a silent no-op. |
| Registry meta `inputs` omits `orientation` | ✅ Confirmed — it listed only `defaultValue`, `id`, `options`, `className`. |

**On the default.** The declared default is `'vertical'`, and it matters: the unfixed renderer's `grid gap-2` stack already *looked* vertical, so it accidentally matched the vertical state **visually** — but it emitted no `data-orientation` and no `aria-orientation`, so in the DOM it matched **neither** state. That is why the pin asserts attributes and not just appearance.

## The change

- `schema.orientation` is forwarded **by name**, not by reopening the DOM spread. `toFormControlDomProps` is a closed whitelist that does not carry `orientation`, and forwarding-by-name is exactly the objectui#4435 route that file documents for a key like this.
- The declared `@default 'vertical'` is **applied** rather than left to Radix's own `undefined`. A default the type documents and nothing applies is the same declared-but-unenforced defect as the key itself.
- The layout utilities follow the key, because `## Layout Options` promises a *visible* difference. Author `className` composes last, so tailwind-merge resolves every conflict in the author's favour.
- Registry meta `inputs` gains `orientation`, in the house `type: 'enum'` shape (matching `overlay/sheet.tsx:48`, which likewise carries a `defaultValue`). This is the third surface the card measured as omitting the key.

### Behaviour note for existing radio groups

A group that never authored the key keeps the vertical stack it already rendered, and now additionally announces `aria-orientation="vertical"` — the announced orientation agrees with the rendered one instead of being absent. Arrow-key roving focus narrows from all-arrows to Up/Down for those groups, which is the correct pairing for a vertical stack. Called out here because it is the one user-visible change that reaches groups which did not opt in.

## ⚠️ Serial boundary with #6157 — the shared docs demos still render identically

This branch deliberately **does not touch** `examples/schema-catalog/src/schemas/components-form-radio-group/*`. Those fixtures — including `horizontal-layout.json` and `vertical-layout.json`, the two demos behind the docs page's `## Layout Options` heading — currently spell the key **`direction`**, which nothing declares. That divergence is **#6157's scope**.

**Consequence, stated plainly: with this PR alone, the two shipped docs demos still render identically to each other.** The renderer can now tell the orientations apart; those two fixtures still do not ask it to. Triage asked that "the horizontal demo's markup actually diverges once both land" be asserted — that assertion is not possible from this branch and is not attempted here. The pin asserts divergence against **its own** fixtures instead. This is the serial boundary, not an incomplete card; the docs page becomes correct when #6157 lands.

## Verification

Pin written **first** and proven **red on the unfixed renderer** before the fix existed, then re-run as an ablation against the final tree so the red measurement matches what is shipping.

Ablation restored the renderer to the branch point with `git checkout f66072d1b -- packages/components/src/renderers/form/radio-group.tsx`, under `trap … EXIT INT TERM`. Mutation proven on disk in both directions — `orientation` occurrences `10 → 0`, `ORIENTATION_CLASS` `→ 0`, `1 file changed, 1 insertion(+), 34 deletions(-)`; `git diff HEAD --stat` empty after restore:

```
 × renders DIFFERENT markup for the two orientations
 × carries the authored orientation onto the radiogroup root
 × lays the horizontal group out as a row and the vertical group as a stack
 × enforces the declared `@default 'vertical'` when orientation is omitted
 Tests  4 failed | 1 passed (5)
```

The core failure is the defect itself: an `AssertionError` reporting that the horizontal root's markup `not to be` the vertical root's markup, with the two truncated strings printed identically — `Object.is` equality on two roots that are character-for-character the same.

With the fix: `Test Files 1 passed (1)` / `Tests 5 passed (5)`.

### Which assertions would still pass on a revert

Stated because a pin that is green either way pins nothing:

- **`lets an author className still win over the orientation layout classes` — passes on a revert.** It asserts `gap-8` present and `gap-4` absent; on the unfixed renderer no `gap-4` is ever emitted, so it is vacuously true. Kept because it guards the composition order going forward, but it is **not** evidence for this card.
- **One half of `enforces the declared @default 'vertical'` — passes on a revert.** The byte-identity of the omitted case against explicit `vertical` held before the fix too, because *both* were orientation-less. The `data-orientation`/`aria-orientation` half of that same test is red on a revert, and that is the half that does the work.
- The other three tests are red on a revert.

### Gates run (all on `fbc603df7`, the final commit; tree clean)

Derived by enumerating each CI job's own step list, then re-run as a union after the last commit.

- `pnpm test` (targeted): `packages/components/` — **186 files / 1706 tests passed**; plus the three suites that reference `radio-group` (`widget-dom-leak-sweep`, `form-control-dom-leak-5632`, `form-renderers`) — **239 passed**. The DOM-leak sweep passing matters: the two new attributes are not read as leaks.
- `type-check`: `@object-ui/components` green, plus the **dependent** direction — every one of the 30 dependent packages that has a `type-check` script ran a real `tsc` and passed. (`@object-ui/example-hello-world` has no such script and says so loudly — `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`, exit 1 — rather than exiting 0 on a zero-script match.)
- `lint`: `@object-ui/components` with `--force` (`Cached: 0 cached`) — **0 errors**, 907 pre-existing warnings.
- `check:designer-field-key-parity`, `check:doc-types`, `check:doc-snippets`, `check:control-bytes`, `check:phantom-deps`, `check:self-import`, `check:action-forward-parity`, `check:icon-record-names`, `check:i18n-keys`, `check:doc-fences` — all green.
- `check:eager-closure` — first run exited **2** ("broken gauge, not a passing budget") because it needs a console build; built and re-run rather than counted as a pass: `Console eager closure 3222.6 KB / 3990.2 KB budget`, and `ui-components 382.0 KB / 389.6 KB ceiling`.
- `check-changeset-presence` / `check-changeset-no-major` — green. Changeset is `minor` (never `major`, per the fixed-group rule).

Two local red readings were chased down and are **not** regressions — both were unbuilt local dependencies, proven by building them and re-running to green: `@object-ui/console` (missing `plugin-gantt` / `plugin-map` builds) and `@object-ui/site` (missing `example-schema-catalog` build).

## Scope

Bounded to the radio-group renderer, its registry meta entry, its changeset, and one new test file. `packages/components/src/ui/radio-group.tsx` is untouched — the shadcn wrapper already spreads its remaining props after `className`, so the prop reaches Radix without editing a no-touch file. Nothing needed to reach wider.

⛔ Left **draft** deliberately — the PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_