### PR TITLE
fix(plugin-detail): say out loud when an unrecognised `filterMode` folds onto `all`

### DIFF
--- a/.changeset/lucky-buttons-warn.md
+++ b/.changeset/lucky-buttons-warn.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`record:activity` now says out loud when an unrecognised `filterMode` is folded onto `all`.
+
+`normalizeFilterMode` folds every value it does not recognise onto `'all'` — the widest of the four declared modes — so a near-miss like `comments-only` opened the panel on the unfiltered stream instead of the slice the author asked for, and said nothing. The fallback is kept (a dropdown handed a value with no matching item renders blank), but the fold now emits one deduped diagnostic naming the offending value and the declared modes. Nothing that renders changes.

--- a/packages/plugin-detail/src/renderers/__tests__/recordActivityFeed.test.ts
+++ b/packages/plugin-detail/src/renderers/__tests__/recordActivityFeed.test.ts
@@ -30,6 +30,7 @@ import {
   normalizeLimit,
   resetUnknownActivityTypeWarnings,
   resetUnrecognisedFeedTypeWarnings,
+  resetUnrecognisedFilterModeWarnings,
   UNMAPPED_ACTIVITY_FEED_TYPE,
 } from '../recordActivityFeed';
 
@@ -371,6 +372,10 @@ describe('a scheduled activity reaches the feed (objectui#5840)', () => {
 
 describe('input normalisation reads its vocabulary from the spec', () => {
   it('accepts every FeedFilterMode the spec declares, and only those', () => {
+    // Spied and reset because the unrecognised legs below now also emit a
+    // diagnostic (objectui#5891). This case pins the RETURN VALUE only; the
+    // emission is pinned in its own suite, which owns the dedupe bucket.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     for (const mode of SpecFilterMode.options) {
       expect(normalizeFilterMode(mode)).toBe(mode);
     }
@@ -379,6 +384,8 @@ describe('input normalisation reads its vocabulary from the spec', () => {
     expect(normalizeFilterMode('x')).toBe('all');
     expect(normalizeFilterMode(undefined)).toBe('all');
     expect(normalizeFilterMode(7)).toBe('all');
+    resetUnrecognisedFilterModeWarnings();
+    warn.mockRestore();
   });
 
   it('accepts every FeedItemType the spec declares, read from the spec itself', () => {
@@ -619,5 +626,117 @@ describe('mergeFeedItems', () => {
     );
     expect(merged.map((i) => i.id)).toEqual(['a', 'b']);
     expect(merged[1].body).toBe('newer');
+  });
+});
+
+/**
+ * objectui#5891 — the `filterMode` fold is SAID OUT LOUD.
+ *
+ * Ruled in-lane by triage (2026-08-25) as option A: the `'all'` fallback stays
+ * (there is no defensible narrower default, and passing an unrecognised value
+ * through renders a blank dropdown — objectui#3151's posture), and what is
+ * repaired is its INVISIBILITY. So the deliverable is a diagnostic, not a
+ * behaviour change, and this suite is written accordingly.
+ *
+ * ⚠️ The trap this suite exists to avoid: a pin that asserts only "still
+ * returns `'all'`" is green before AND after the fix, forever — it never
+ * touches the verdict channel the card is about. Every case below therefore
+ * spies on the channel the diagnostic writes to, and the suite asserts BOTH
+ * directions: an unrecognised value emits (once, naming itself and the declared
+ * modes), and a recognised or absent one emits NOTHING.
+ *
+ * ⚠️ The dedupe bucket is module scope, so a case could see an empty channel
+ * purely because an earlier case already consumed the one warning for that
+ * value. Two independent guards: the bucket is cleared in `afterEach` through
+ * the exported seam, AND every case uses a value no other case uses.
+ */
+describe('an unrecognised `filterMode` still folds onto `all`, but says so (objectui#5891)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetUnrecognisedFilterModeWarnings();
+  });
+
+  const quiet = () => vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  /**
+   * The near-miss the card was filed for: the declared spelling is
+   * `comments_only`. Its unrecognisedness is DERIVED from the spec rather than
+   * asserted by hand — if it ever became declared, the guard below fails loudly
+   * instead of this suite quietly testing nothing.
+   */
+  const NEAR_MISS = 'comments-only';
+
+  it('the value this suite treats as a near-miss is outside the declared vocabulary', () => {
+    expect(SpecFilterMode.options).not.toContain(NEAR_MISS);
+    // …and it really is a near-miss of a declared mode, not an arbitrary string.
+    expect(SpecFilterMode.options).toContain(NEAR_MISS.replace('-', '_'));
+  });
+
+  it('names the offending value AND every declared mode, exactly once', () => {
+    const warn = quiet();
+
+    expect(normalizeFilterMode(NEAR_MISS)).toBe('all');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0][0]);
+    // The author has to be able to see WHICH value was dropped…
+    expect(message).toContain(NEAR_MISS);
+    // …and WHAT they could have written instead. The list is read from the
+    // spec here for the same reason the source reads it from the spec: a pin
+    // that re-states the enum it is pinning cannot fail when the enum moves.
+    expect(message).toContain(SpecFilterMode.options.join(', '));
+    // And the widening is stated, because that is the severity of the fold.
+    expect(message).toContain('WIDEST');
+  });
+
+  it('warns once per distinct value, not once per call', () => {
+    // A page re-runs this on every render; an authoring mistake is ONE mistake.
+    const warn = quiet();
+    for (let i = 0; i < 5; i += 1) {
+      expect(normalizeFilterMode('changes-only')).toBe('all');
+    }
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // A DIFFERENT typo is a different mistake and is still named.
+    expect(normalizeFilterMode('tasksOnly')).toBe('all');
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(String(warn.mock.calls[1][0])).toContain('tasksOnly');
+  });
+
+  it('reports a value of the wrong TYPE by its type, and still opens on `all`', () => {
+    const warn = quiet();
+    expect(normalizeFilterMode(7)).toBe('all');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toContain('number');
+  });
+
+  it('stays SILENT for every mode the spec declares', () => {
+    // The control that stops the emit assertions above from passing for the
+    // wrong reason: a helper that warned unconditionally would satisfy them.
+    const warn = quiet();
+    for (const mode of SpecFilterMode.options) {
+      expect(normalizeFilterMode(mode)).toBe(mode);
+    }
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('stays SILENT when no `filterMode` was authored at all', () => {
+    // Absent is not a mistake, and a warning about a non-mistake teaches
+    // authors to ignore the channel — the reason the sibling `sys_activity`
+    // diagnostic does not fire for deliberate exclusions either.
+    const warn = quiet();
+    expect(normalizeFilterMode(undefined)).toBe('all');
+    expect(normalizeFilterMode(null)).toBe('all');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps its channel apart from the `types` channel', () => {
+    // Same reasoning as the `types` ↔ `sys_activity.type` pair: one channel
+    // having spoken must not silence another that shares a spelling.
+    const warn = quiet();
+    normalizeFilterMode('comment');       // a declared FeedItemType, not a filter mode
+    normalizeFeedTypes(['comments_only']); // a declared filter mode, not a feed type
+    expect(warn).toHaveBeenCalledTimes(2);
+    resetUnrecognisedFeedTypeWarnings();
   });
 });

--- a/packages/plugin-detail/src/renderers/recordActivityFeed.ts
+++ b/packages/plugin-detail/src/renderers/recordActivityFeed.ts
@@ -191,20 +191,6 @@ export interface SysActivityRow {
 }
 
 /**
- * Coerce an authored `filterMode` to a value the timeline understands.
- *
- * Unknown values fall back to `'all'` rather than being passed through: a
- * `<Select>` handed a value with no matching item renders blank and the
- * dropdown reads as broken. Same posture as objectui#3151 — an unrecognised
- * filter token is skipped, never turned into a filter that can't match.
- */
-export function normalizeFilterMode(value: unknown): FeedFilterMode {
-  return typeof value === 'string' && FILTER_MODE_VALUES.includes(value)
-    ? (value as FeedFilterMode)
-    : 'all';
-}
-
-/**
  * Warn ONCE per distinct key on a channel, never again for a key already named.
  *
  * One plumbing for both diagnostics in this file rather than two conventions.
@@ -239,6 +225,70 @@ const warnedUnrecognisedFeedTypes = new Set<string>();
 /** Test seam: forget which `types` entries have already been named. */
 export function resetUnrecognisedFeedTypeWarnings(): void {
   warnedUnrecognisedFeedTypes.clear();
+}
+
+/** Authored `filterMode` values already named as unrecognised. See {@link warnOnce}. */
+const warnedUnrecognisedFilterModes = new Set<string>();
+
+/** Test seam: forget which `filterMode` values have already been named. */
+export function resetUnrecognisedFilterModeWarnings(): void {
+  warnedUnrecognisedFilterModes.clear();
+}
+
+/**
+ * Coerce an authored `filterMode` to a value the timeline understands.
+ *
+ * Unknown values fall back to `'all'` rather than being passed through: a
+ * `<Select>` handed a value with no matching item renders blank and the
+ * dropdown reads as broken. Same posture as objectui#3151 — an unrecognised
+ * filter token is skipped, never turned into a filter that can't match.
+ *
+ * ## Why that fallback needs a diagnostic (objectui#5891)
+ *
+ * `'all'` is the WIDEST of the four declared modes — `filterItems` in
+ * `RecordActivityTimeline` narrows to ONE feed type for each of the other three
+ * and returns the feed untouched for `'all'` — so every unrecognised value
+ * lands on the one option that shows the author MORE than they asked for. A
+ * near-miss like `comments-only` or `commentsOnly` therefore opens the panel on
+ * the unfiltered stream, and the tell is a PLAUSIBLE result (a populated
+ * timeline) rather than an empty one that gets investigated. That is the same
+ * shape objectui#5841 removed from the sibling `types` sanitiser.
+ *
+ * The ruling on this card (triage, 2026-08-25) is that the defect is the
+ * INVISIBILITY, not the fallback: `filterMode` seeds a control the user can
+ * change, and there is no defensible narrower default to fall back to instead.
+ * So nothing that renders changes here — what changes is that the fold is now
+ * SAID OUT LOUD, once per distinct offending value (see {@link warnOnce}).
+ *
+ * Absent (`undefined` / `null`) is silent: no `filterMode` was authored, which
+ * is not a mistake, and a warning about a decision teaches authors to ignore
+ * the channel. Only a value the author actually wrote is reported.
+ *
+ * The declared modes named in the message are read from `@objectstack/spec`'s
+ * `FeedFilterMode` at runtime, never re-typed here — see the file header for
+ * what a hand copy of a spec enum cost.
+ */
+export function normalizeFilterMode(value: unknown): FeedFilterMode {
+  if (typeof value === 'string' && FILTER_MODE_VALUES.includes(value)) {
+    return value as FeedFilterMode;
+  }
+
+  // Absent means no `filterMode` was authored — not a mistake, nothing to report.
+  // Anything else is a value the author wrote and this block cannot honour.
+  if (value !== undefined && value !== null) {
+    const shown = typeof value === 'string' ? `"${value}"` : typeof value;
+    const key = typeof value === 'string' ? value : `non-string ${shown}`;
+    warnOnce(warnedUnrecognisedFilterModes, [key], () =>
+      `[record:activity] ignoring an unrecognised \`filterMode\` (${shown}) and opening `
+        + 'on "all" instead — the WIDEST mode, which shows EVERY activity rather than the '
+        + 'slice that was asked for. No declared filter mode matches it. The fallback is '
+        + 'kept rather than passing the value through because a dropdown handed a value '
+        + 'with no matching item renders blank (objectui#3151), so this is a diagnostic, '
+        + 'not a refusal. Declared filter modes: '
+        + `${FILTER_MODE_VALUES.join(', ')}.`);
+  }
+
+  return 'all';
 }
 
 /**


### PR DESCRIPTION
Fixes #5891

Option A as ruled by triage in-lane (2026-08-25): keep the `'all'` fallback, add a deduped `warnOnce` diagnostic naming the unrecognised value and the declared options. **The deliverable is a diagnostic, not a behaviour change** — every return value of `normalizeFilterMode` is byte-for-byte what it was, and nothing that renders changes.

## What was measured before writing anything

Three things the card's severity argument rests on, re-measured on `origin/main` @ `c5fbe0b99` rather than inherited:

1. **The `warnOnce` seam still has its per-channel bucket.** Confirmed on the current ref: `warnOnce(bucket, keys, build)` — where `bucket` is a per-channel string Set — takes the bucket as its first parameter, and two independent buckets (`warnedUnrecognisedFeedTypes`, `warnedUnknownActivityTypes`) already use it. #5841's shape survived, so this wires a *third* channel to it with its own bucket rather than reshaping the seam.
2. **Every unrecognised value really did fold onto `'all'`,** with no other branch — the pre-fix body was a single ternary whose whole else-arm was `'all'`, so `7`, `{}`, `null` and `comments-only` all landed there identically.
3. **`'all'` really is the widest option.** `filterItems` in `RecordActivityTimeline.tsx` narrows to exactly one feed type for each of `comments_only` / `changes_only` / `tasks_only` and returns the feed untouched under `default:`. So the fold sends every typo to the one mode that shows *more* than was asked for.

**The declared option set was enumerated from its declaration, not from the sanitiser's arms.** The declaration is `@objectstack/spec`'s `FeedFilterMode` (`src/data/feed.zod.ts`), `['all', 'comments_only', 'changes_only', 'tasks_only']`. The two lists **agree** — the sanitiser reads `FeedFilterMode.options` at runtime and never hand-copies it, and `getFilterOptions` in the timeline renders those same four. No disagreement to report.

## Which assertions would still pass on a revert

The point of the pin, so it is stated plainly. Reverting `normalizeFilterMode` to its pre-fix one-line ternary was run as an ablation (mutation proved on disk, restored under `trap … EXIT INT TERM`, `git diff HEAD --stat` empty afterwards). Predicted before running, and observed exactly:

**Still GREEN on a revert — these do NOT discriminate, and are here only as controls:**

- every `expect(normalizeFilterMode(x)).toBe('all')` / `.toBe(mode)` return-value assertion, including the pre-existing `accepts every FeedFilterMode the spec declares, and only those`;
- `the value this suite treats as a near-miss is outside the declared vocabulary` (a vocabulary guard);
- `stays SILENT for every mode the spec declares`;
- `stays SILENT when no filterMode was authored at all`.

**RED on a revert — these are what actually pins the fix:**

| case | on revert |
| --- | --- |
| `names the offending value AND every declared mode, exactly once` | `expected "warn" to be called 1 times, but got 0 times` |
| `warns once per distinct value, not once per call` | `expected "warn" to be called 1 times, but got 0 times` |
| `reports a value of the wrong TYPE by its type, and still opens on 'all'` | `expected "warn" to be called 1 times, but got 0 times` |
| `keeps its channel apart from the 'types' channel` | `expected "warn" to be called 2 times, but got 1 times` |

Ablation result: `Tests  4 failed | 44 passed (48)` — matching the prediction case for case. A pin asserting only "still renders `all`" would have been green on both sides forever, which is why the suite spies on the channel the diagnostic writes to.

## Cross-test state (the dedup is module scope)

`warnedUnrecognisedFilterModes` memoises in module scope, so a case could see an empty channel purely because an earlier case consumed the warning. **Both guards are in place, deliberately:**

- **the bucket is reset between cases** through a new exported test seam, `resetUnrecognisedFilterModeWarnings()`, called in the suite's `afterEach` — the same convention the two existing channels already use (`resetUnrecognisedFeedTypeWarnings`, `resetUnknownActivityTypeWarnings`);
- **and every case uses a value no other case uses** (`comments-only`, `changes-only`, `tasksOnly`, `7`), so the suite is order-independent even if the seam were removed.

One pre-existing case (`accepts every FeedFilterMode the spec declares, and only those`) now provokes the new diagnostic on its `'x'` and `7` legs; it was given a `console.warn` spy and a bucket reset so it cannot leak into the new suite or spray warnings into test output. It still pins return values only — the emission is pinned in its own suite.

## Silence where silence is correct

An absent `filterMode` (`undefined` / `null`) emits **nothing**: no filter mode was authored, which is not a mistake, and a warning about a non-mistake is what teaches authors to ignore the channel — the same reason the sibling `sys_activity` diagnostic stays quiet for its deliberate exclusions. Only a value the author actually wrote is reported.

## Verification

All commands run from the **repo root** — `pnpm --filter PKG test` is refused here by the objectui#3378 guard, which fired as expected (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`) rather than silently reporting `apps/console`'s files green.

Union re-run on the final commit **`49f1ec60b`**, after the changeset landed:

- `pnpm exec vitest run packages/plugin-detail --maxWorkers=2` → `Test Files 104 passed (104)` / `Tests 986 passed (986)`
- `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail' type-check` → exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`; the dependency closure was built first with `--filter '@object-ui/plugin-detail^...' build`)
- `node scripts/check-changeset-presence.mjs` → `✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/lucky-buttons-warn.md.` — its earlier verdict was `❌  2 source file(s) of 1 released package(s) changed, and this change adds no changeset`, so one **is** owed; scored `patch`.
- `node scripts/check-changeset-no-major.mjs` → `✅  No changeset declares a 'major' bump.`
- `node scripts/check-changeset-fixed.mjs` → `✅  All workspace packages are in the changeset fixed group.`
- `node scripts/check-control-bytes.mjs` → `✅  check-control-bytes: OK (scanned 5154 tracked text file(s); skipped 85 binary).`
- `node scripts/check-vi-mock-specifiers.mjs` → `✅  check-vi-mock-specifiers: OK (…677 relative specifier(s) resolved…)`
- `node scripts/check-spec-symbol-derivation.mjs` → `✅  spec symbol derivation: 1304 files scanned against 4959 spec export names`
- `node scripts/check-lint-coverage.mjs` → `✅  lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).`
- `node scripts/check-type-check-coverage.mjs` → `✅  type-check coverage: 45/46 via 'type-check' …`

### Declared narrowing: lint

⚠️ **`pnpm lint` repo-wide (`turbo run lint`) was NOT run to completion** — it hit this container's ~10-minute foreground cap (SIGTERM, exit 143) under load from parallel agents. What was run instead is a **narrowed but complete** measurement, `pnpm exec eslint packages/plugin-detail --format json` → **exit 0, 156 files, 0 errors, 847 warnings** (`.github/workflows/lint.yml` sets no `--max-warnings`, so warnings are not a gate failure). The three pieces of evidence that make this a measurement rather than a skip:

1. **Population read from eslint's own config, not guessed** — both changed files appear in the JSON as linted entries with real rule verdicts, not as "File ignored because of a matching ignore pattern".
2. **File count read from `--format json`** — 156, above.
3. **Invariance for untouched files** — `eslint.config.js` sets no `parserOptions.project` and no `projectService`, so typescript-eslint runs **without type-aware linting**; and every custom rule in `eslint-rules/` is a single-file AST rule (no `fs` access anywhere in that directory). Every verdict is therefore computed from a file's own source plus the shared config, so a diff confined to two files under `packages/plugin-detail/src/renderers/` cannot move any untouched file's verdict.

CI runs the full farm regardless; this is the cheap half.

## Scope

Two files plus a changeset, all inside `packages/plugin-detail`. `record-details.tsx` is untouched. Nothing was folded in from #6178, #6190 or #6241.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSoz9uGhaaSgiq3hshtN7L)_