### PR TITLE
docs(tooling): re-anchor invoked-as.mjs's enforcement section to the tree it describes

### DIFF
--- a/scripts/invoked-as.mjs
+++ b/scripts/invoked-as.mjs
@@ -13,10 +13,10 @@
  * reached ELEVEN distinct spellings across 33 files -- measured, not estimated
  * -- and nine of the eleven were wrong, in a direction nothing in CI can see.
  *
- * THIS repository has not been swept, and no gate here enforces the rule. Read
- * "## Nothing here enforces this yet" below before concluding otherwise: every
- * path this header names outside `scripts/` is objectstack's, and several under
- * `scripts/` are too.
+ * THIS repository has since been swept, and a gate here enforces the rule. Read
+ * "## What enforces this, and what it took to get here" below for the numbers
+ * and the commit they were taken on. Two paths this header names are
+ * objectstack's and do not exist here; each is labelled where it appears.
  *
  * ## The bug every hand-typed spelling had
  *
@@ -36,8 +36,10 @@
  *
  * Same tree, same defect, same gate -- reached through a symlink it reports the
  * clean answer, and a wrapper holding `result.status` cannot tell that apart
- * from a pass. `check-skills-paths.mjs` carries the no-realpath spelling, as do
- * 27 of its neighbours; see below.
+ * from a pass. `check-skills-paths.mjs` CARRIED the no-realpath spelling when
+ * that was measured, as did 27 of its neighbours; every one of them routes
+ * through `isEntrypoint` now -- see below for what closed them, and what keeps
+ * them shut.
  *
  * The same measurement in objectstack, where this module came from, lands on a
  * gate whose exit codes make it worse still: `scripts/pm/check-governed-merges.mjs`
@@ -81,33 +83,54 @@
  * it, exported so the predicate is pinned by cases rather than trusted by
  * reading.
  *
- * ## Nothing here enforces this yet -- the rule is a CONVENTION
+ * ## What enforces this, and what it took to get here
  *
- * An earlier version of this paragraph said `scripts/check-entry-guard.mjs`
- * enforces the rule -- that a `process.argv[1]` in an entry-guard position
- * anywhere in `scripts/**` outside this module is a failure. It does not. That
- * file has never existed in this repository. It exists in objectstack, wired
- * there as `check:entry-guard`; the port (#5984) brought this module and its
- * prose, and neither the gate nor the sweep the prose describes. Measured on
- * `7c96c9420`:
+ * `scripts/check-entry-guard.mjs` enforces the rule: a `process.argv[1]` in an
+ * entry-guard position anywhere in `scripts/**` outside this module is a
+ * failure. It is wired in `package.json` as `check:entry-guard` and run by
+ * `.github/workflows/lint.yml` BEFORE `pnpm install`, so an install failure
+ * cannot take the gate down with it. `scripts/__tests__/entry-guard-wiring.test.ts`
+ * pins that wiring rather than the numbers, because a gate nobody runs is
+ * indistinguishable from a gate that passes.
  *
- *   git grep -n 'check-entry-guard'             -> ONE hit: this paragraph
- *   git grep -l 'isEntrypoint' -- scripts       -> this file, and ONE adopter
- *   git grep -l 'process.argv\[1\]' -- scripts   -> 30 files
+ * Measured on `2dc4aa709`. Naming the commit is the point: these are a
+ * SNAPSHOT, and an older snapshot left standing in the present tense is exactly
+ * what this section had to be rewritten to fix.
  *
- * The one adopter is `scripts/pm/check-half-states.mjs`, which arrived in the
- * same PR. The 30 files are this one plus TWENTY-NINE hand-typed guards: 28
- * `.mjs`, in NINE textually distinct spellings and not one carrying a realpath
- * leg -- including the exact percent-encoding spelling this header warns about
- * above, still in `check-node-esm-load.mjs:847` -- and `scripts/shadcn-sync.js`,
- * the only hand-typed guard here that does carry the realpath leg.
+ *   pnpm check:entry-guard                      -> 47 scripts/ files scanned, no
+ *                                                  guard outside the baseline;
+ *                                                  0 still hand-type one
+ *                                                  (SHRINK-ONLY); 42 export
+ *                                                  bindings, 42 inert on import
+ *   git grep -l 'isEntrypoint' -- scripts       -> 40 files
+ *   git grep -l 'process.argv\[1\]' -- scripts   -> 3 files
  *
- * A gate is still the right answer: without one, converting those 29 is a
- * one-time sweep that starts rotting the day it merges, because nothing stops a
- * THIRTIETH spelling from being typed next week. Both halves -- the gate and
- * the sweep -- are tracked in #6092. Until that lands, `isEntrypoint` here is a
- * convention: reach for it in new scripts, and do not read this file as
- * evidence that the tree already has.
+ * Those three are this module -- the one place allowed to read `argv[1]` -- and
+ * `check-entry-guard.mjs` and `js-comment-mask.mjs`, which carry the broken
+ * spellings as FIXTURE data rather than as guards; the gate's comment/string
+ * masking is what tells those apart from the real thing.
+ *
+ * The history, because the figures above only mean something against it. This
+ * module arrived from objectstack (#5984) with prose describing OBJECTSTACK'S
+ * tree: it named a gate that did not exist here and a sweep that had not
+ * happened here. Measured then, on `7c96c9420`: `check-entry-guard` appeared in
+ * exactly ONE place, the paragraph claiming it; `isEntrypoint` had a single
+ * adopter (`scripts/pm/check-half-states.mjs`); and 29 hand-typed guards stood
+ * in NINE textually distinct spellings, 28 of them with no realpath leg --
+ * including the exact percent-encoding spelling this header warns about above,
+ * then still in `check-node-esm-load.mjs`. objectui#6092 closed both halves:
+ * the gate landed (#6133), the 29 call sites were converted (#6145), and the
+ * second rule's baseline reached zero (#6156).
+ *
+ * The gate, not the sweep, is what holds. A one-time sweep starts rotting the
+ * day it merges, because nothing stops a THIRTIETH spelling from being typed
+ * next week; `KNOWN_HAND_TYPED_GUARDS` is empty and SHRINK-ONLY, so typing one
+ * is now RED rather than a convention politely ignored.
+ *
+ * When these numbers move, re-take them and re-name the commit -- do not edit
+ * the figures in place under the old one. A refreshed count under a stale
+ * commit is a measurement nobody can reproduce, and that is the failure this
+ * whole section records.
  *
  * ## The siblings, and why the duplication is deliberate
  *


### PR DESCRIPTION
Fixes #6243

`scripts/invoked-as.mjs`'s header carried a section — `## Nothing here enforces this yet -- the rule is a CONVENTION` — whose four assertions were all false on `main`, all in the same direction, and which the header explicitly instructs the reader to believe over the tree.

## Every row of the card's table, re-verified before touching anything

Measured in a clean worktree at `origin/main` = `2dc4aa709`.

| header claim | measured | verdict |
| --- | --- | --- |
| `check-entry-guard.mjs` "has never existed in this repository" | `git cat-file -e origin/main:scripts/check-entry-guard.mjs` → rc 0 | **false** — it exists |
| `git grep -n 'check-entry-guard'` → ONE hit, this paragraph | **26** hits: the script, `package.json:59`, `.github/workflows/lint.yml:201-202`, two changesets, three tests, three sibling scripts | **false** |
| 29 hand-typed guards remain, in nine spellings | gate prints `0 file(s) still hand-type one (0 occurrence(s), ⛔ SHRINK-ONLY)`; `git grep -l 'process.argv\[1\]' -- scripts` → **3** files, none of them a guard | **false** |
| "Until [#6092] lands, `isEntrypoint` here is a convention" | #6092 is **closed/completed**; `git grep -l 'isEntrypoint' -- scripts` → **40** files | **false** |

The gate's own verdict line, run here:

```
✓ check:entry-guard: 47 scripts/ file(s) — no entry guard outside the baseline; 0 file(s) still hand-type one
  (0 occurrence(s), ⛔ SHRINK-ONLY, objectui#6092); 42 export bindings, 42 of them inert on import
  (0 known-unsafe, ⛔ SHRINK-ONLY).
```

The card quoted 46/0/41 at `0409b766d`; the tree has gained one script since, and the middle figure — the one the claim rests on — is 0 in both. Every row reproduces. The premise stands.

## Disposition: rewrite (option 1), not delete

Three reasons, in the order they decided it:

1. **The pointer.** Line 17 of the same header names the section — "read '## Nothing here enforces this yet' below **before concluding otherwise**". Deleting the section leaves that pointer aimed at nothing, so option 2 is not one edit but two, and the second one is the easy one to forget.
2. **Deletion removes the wrong half.** Option 2's premise is that the warning "has nothing left to do". Only its *direction* expired. What the section is really warning about is over-trusting this header — and the reason that warning was ever needed is intact: the file is prose ported across repos. Re-pointing it at the gate ("here is the mechanism, here is what it printed, here is the commit") keeps the warning and fixes its aim.
3. **The narrative is the file's own subject.** Prose ported from objectstack that stayed put while this tree moved is, self-referentially, the exact failure `invoked-as.mjs` documents — and this section already narrates one earlier round of it. Deleting it deletes the only in-tree record of how that happens, right after it happened again.

So the section is kept, retitled `## What enforces this, and what it took to get here`, and the measured history is kept **as history** under the commit it was taken on.

## Measurements re-taken, not edited in place

The `7c96c9420` figures are left where they belong — in the history paragraph, attached to that commit. The present-tense figures are new, taken on `2dc4aa709`, and the section now names that commit and says why:

> Measured on `2dc4aa709`. Naming the commit is the point: these are a SNAPSHOT, and an older snapshot left standing in the present tense is exactly what this section had to be rewritten to fix.

...and closes with the instruction that would have prevented this round: re-take and re-name, never edit the figures in place under the old commit.

## Three sentences, not one — they carry the same claim

Rewriting only the section would have left the file contradicting itself two paragraphs later. All three are the same claim, mechanically pinned by the same gate output, in the same file:

- **line 16** — "THIS repository has not been swept, and no gate here enforces the rule", plus its pointer at the old section name;
- **line 39** — "`check-skills-paths.mjs` carries the no-realpath spelling, as do 27 of its neighbours", now past tense (it routes through `isEntrypoint`, as do all 29);
- **the section** itself.

Nothing else in the diff. Two objectstack-only paths the header names (`scripts/pm/check-governed-merges.mjs`, `packages/cli/src/utils/invocation.ts`) were re-checked as still absent here and are still labelled as objectstack's where they appear.

## Sibling check — reported, not edited

The `## The siblings` section says "change one, change the others" and names objectstack's `packages/cli/src/utils/invocation.ts`. Checked against objectstack `origin/main` = `497ded780`, read-only, no worktree, no edit:

- `packages/cli/src/utils/invocation.ts` — **not stale**. 186 lines, zero occurrences of `check-entry-guard`, `never existed`, `CONVENTION`, `Nothing here enforces` or `Until that lands`. It never carried this paragraph.
- objectstack's own `scripts/invoked-as.mjs` — **not stale either**, and it is where the ported prose came from. It carries the *correct* original: "`scripts/check-entry-guard.mjs` enforces this: a `process.argv[1]` in an entry-guard position anywhere in `scripts/**` that is not this module is a failure." True in that tree, and true here now.

So nothing is owed in objectstack for this defect. One asymmetry is worth a separate look and is listed as an out-of-scope finding rather than fixed here.

## Changeset: none, deliberately

`check-changeset-presence.mjs` exits 0 either way, so it is not deciding this. Its printed verdict on this diff:

```
Compared the working tree with 2dc4aa709 (merge-base with origin/main): 1 file(s) changed,
0 of them published source of a package the release covers, 0 under a package changesets ignores,
0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

Read directly: the diff is 89 changed lines, **every one a block-comment body line** in a `scripts/` tool that no package publishes. There is no behaviour for a release note to describe. Precedent from tonight: #6216 and #6212 are tooling PRs that changed real gate behaviour and carried none; a prose-only change is bounded above by those.

## Verification

All of the below on the final commit, `ca12cb8b`, clean tree. Exit codes captured by redirect before any pipe; each line is the gate's own printed verdict.

| gate | verdict |
| --- | --- |
| `check:entry-guard` | `✓ check:entry-guard: 47 scripts/ file(s) … 0 file(s) still hand-type one (0 occurrence(s), ⛔ SHRINK-ONLY…)` — rc 0 |
| `check-entry-guard.mjs --self-test` | `✓ check-entry-guard self-test: 63 cases pass` — rc 0 |
| `invoked-as.mjs --self-test` | `✓ invoked-as self-test: 12 cases pass (real symlink, different-name symlink, percent-encoding path, and both import directions).` — rc 0 |
| `check-doc-links.mjs` | `Links are valid across 15 scan roots.` — rc 0 |
| `check:doc-fences` | `✅ check:doc-fences — every TypeScript block in 223 document(s) …` — rc 0 |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 5157 tracked text file(s); skipped 85 binary).` — rc 0 |
| `check:shell-escape-residue` | `✅ check-shell-escape-residue: OK (4/4 root(s) resolved …)` — rc 0 |
| `type-check:scripts` | rc 0; pnpm echoed `> tsc -p tsconfig.scripts.json`, so it is not a zero-match no-op |
| `lint:root` **unnarrowed** | rc 0 — `✖ 28 problems (0 errors, 28 warnings)`, all pre-existing `no-explicit-any` warnings in `e2e/`, `vitest.setup.base.ts` and two `scripts/__tests__/vite-*` files, none touched here |
| `vitest run scripts/` | rc 0 — `Test Files 77 passed (77) · Tests 2194 passed (2194)` |
| also green | `check-node-esm-load.mjs` (builds all 43 packages, rc 0), `check-pre-install-import-graph.mjs`, `check-vi-mock-specifiers.mjs`, `check-eager-closure-budget.mjs` |

**One declared narrowing.** The full root suite (`pnpm test`) was started under the shared verify lock and was killed by this container's ~10-minute foreground cap (SIGTERM, exit 143) — it is CI's run. Narrowed to `vitest run scripts/`, and the narrowing is measured rather than assumed:

- **population**: `git diff --name-only` = 1 file; 89 changed lines, 0 of them outside a block-comment body (`git diff -U0 | grep -cvE '^[+-] \*'` → 0), so the module's runtime is byte-identical in behaviour — confirmed independently by its own self-test;
- **who can see it**: `git grep -l 'invoked-as' -- '**/*.test.ts' '**/*.test.tsx' '**/*.test.mts'` → 5 files, **all** under `scripts/__tests__/`, i.e. entirely inside the narrowed run. Run explicitly as well: 5 passed, 144 tests;
- **no test pins this prose**: `entry-guard-wiring.test.ts` asserts the wiring and states in its own header that it deliberately pins no counts or header text; the other four only mention the module's path.

No test needed updating.

_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_