### PR TITLE
test(ci): pin the `skip-changeset` phantom — nothing wires it, and the page keeps denying it

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1266,18 +1266,30 @@ its major; it sets `OBJECTUI_ALLOW_MAJOR=1`. `pnpm test` asserts the same reposi
 the rule survives this workflow being skipped.
 
 > **A changeset IS now required, by `changeset-presence.yml` — but there is still no
-> `skip-changeset` label.** Until [#3387](https://github.com/objectstack-ai/objectui/issues/3387)
+> `skip-changeset` mechanism.** Until [#3387](https://github.com/objectstack-ai/objectui/issues/3387)
 > nothing in CI asked whether a PR had added one, and this note said so at length, because the
 > opposite had been documented for months: a second workflow inventory at `.github/WORKFLOWS.md`
 > — unpinned, therefore free to drift — gave a "Changeset Check" workflow its own numbered
 > section, failing any PR touching `packages/` without a `.changeset/*.md` and skippable with a
 > `skip-changeset` or `dependencies` label. None of it existed;
-> [#3724](https://github.com/objectstack-ai/objectui/issues/3724) deleted the page. The label
-> still does not exist (checked against the labels API, 2026-08-08 — of the two names only
-> `dependencies` exists, applied by the auto-labeler and read by no gate), and the real gate has
-> no label escape hatch by design: its exemption is a changeset with an **empty frontmatter**,
-> which lives in the repository where the next reader finds it, rather than a label that vanishes
-> from history.
+> [#3724](https://github.com/objectstack-ai/objectui/issues/3724) deleted the page.
+>
+> ⚠️ **The label object came back, and it still does nothing.** This note used to report a
+> point-in-time labels-API reading (2026-08-08: of the two names only `dependencies` existed).
+> That reading has since expired — a `skip-changeset` label now exists in this repository's
+> label set, because GitHub mints a label the first time one is applied by name, so a single
+> API call that applies it is enough to create it. By 2026-08-25 it sat on **seven** pull
+> requests, carrying the default grey `ededed` and an empty description that tell an
+> auto-minted label apart from a curated one.
+> [#4912](https://github.com/objectstack-ai/objectui/issues/4912) tracks deleting the object.
+>
+> ⛔ **Whether or not you can still see it in the picker, applying it declares nothing** — no
+> gate in this repository reads it. The real gate has no label escape hatch by design: its
+> exemption is a changeset with an **empty frontmatter**, which lives in the repository where
+> the next reader finds it, rather than a label that vanishes from history. The name is wired
+> in the `objectstack` sibling, not here, which is how it reaches agents that then look for it
+> in this repo. If you were told to apply it, the instruction is wrong; declare an empty
+> changeset instead.
 >
 > The three real things with adjacent names each do something different, and none of them
 > subsumes another. `changeset-guard.yml` reads pending changesets and rejects a `major` bump.

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -212,6 +212,105 @@ describe('ci-cd-pipeline.md — workflow inventory', () => {
     expect(doc).not.toMatch(/size-check\.yml/);
     expect(workflowFiles).not.toContain('size-check.yml');
   });
+
+  /**
+   * objectui#4912: `skip-changeset` is the other phantom that deleted page left behind, and
+   * unlike `size-check.yml` it did not stay dead. The label *object* was re-minted in this
+   * repository's label set — GitHub creates a label the first time one is applied by name, so
+   * one API call that applies it is enough — and by 2026-08-25 it sat on seven pull requests,
+   * carrying the default grey `ededed` and the empty description that tell an auto-minted
+   * label apart from a curated one. It is now actively read as a mechanism: a triage comment
+   * on objectui#6243 instructed a PR to carry it, the developer refused on the grounds
+   * recorded above, and the refusal was upheld on PR #6260. That is the exact harm #4912
+   * predicted, arriving after the card was filed.
+   *
+   * ⛔ What these two cases can and cannot see, said plainly because the boundary is the whole
+   * design of this file: **a label lives in GitHub's data, not in the tree, so nothing here
+   * can assert the label object is gone.** Deleting it is an administrative act, and a test
+   * that reached for the labels API would put a network call and a credential in a suite that
+   * deliberately has neither. The pins below are therefore not restatements of "the label does
+   * nothing" — that needs no pin. They hold the two things that *are* ours and that a future
+   * commit could change without anyone noticing.
+   */
+  it('never wires the phantom `skip-changeset` label into a workflow or a gate', () => {
+    // Option B of #4912 — give the changeset gates a labelled skip path — was declined by
+    // #3724 and again by the #4912 ruling: the presence gate has no bypass by design, and its
+    // exemption is an empty-frontmatter changeset, which lives in the repo where the next
+    // reader finds it rather than in a label that vanishes from history. So a read of this
+    // name appearing under `.github/` or `scripts/` is that declined option landing without a
+    // decision. The name IS wired in the `objectstack` sibling (lint.yml, pr-automation.yml,
+    // check-empty-changeset.mjs), which is how it reaches agents who then look for it here —
+    // copying that wiring across is precisely what this catches.
+    const selfPath = path.resolve(fileURLToPath(import.meta.url));
+    const offenders: string[] = [];
+
+    function scan(dir: string): void {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name === 'node_modules' || entry.name === '.turbo') continue;
+          scan(full);
+        } else if (entry.isFile() && path.resolve(full) !== selfPath) {
+          // This file is the one legitimate mention: it records the history above.
+          if (fs.readFileSync(full, 'utf8').includes('skip-changeset')) {
+            offenders.push(path.relative(repoRoot, full));
+          }
+        }
+      }
+    }
+
+    for (const root of ['.github', 'scripts']) scan(path.join(repoRoot, root));
+
+    expect(
+      offenders.sort(),
+      `these files under .github/ or scripts/ mention \`skip-changeset\`:\n` +
+        offenders.map((f) => `  - ${f}`).join('\n') +
+        `\n\nNo gate in this repository reads that label and none is supposed to. If this is a ` +
+        `workflow or script that now honours it, that is objectui#4912 option B — a labelled ` +
+        `bypass on a changeset gate that deliberately has none — and it was declined twice ` +
+        `(#3724, and the #4912 ruling). Land the decision to reverse those before the code. ` +
+        `To declare that a PR publishes nothing, add a changeset with empty frontmatter; that ` +
+        `is the mechanism, and it is the one content/docs/guide/ci-cd-pipeline.md documents.`,
+    ).toEqual([]);
+  });
+
+  it('keeps the page denying `skip-changeset` rather than describing it', () => {
+    // `ci-cd-pipeline.md` is where a contributor looks up "how do I declare this PR publishes
+    // nothing", so the page is the surface that decides whether the next reader believes the
+    // label. Unlike the `size-check.yml` pin, absence is the wrong assertion here: the page
+    // has to keep NAMING the label in order to deny it, or the phantom is simply undocumented
+    // again. So the denial itself is what gets pinned.
+    //
+    // Blockquote markers are stripped before matching — the whole passage is a `>` block, and
+    // its sentences wrap across lines, so a raw substring search would silently never match
+    // and this pin would be vacuously green.
+    const prose = doc.replace(/^[ \t]*>[ \t]?/gm, '').replace(/\s+/g, ' ');
+
+    expect(
+      prose,
+      'content/docs/guide/ci-cd-pipeline.md must keep stating that nothing reads the ' +
+        '`skip-changeset` label. The label object exists in this repository (auto-minted by ' +
+        'being applied, objectui#4912) and agents are being told to use it, so a page that ' +
+        'stops denying it leaves the label as the most authoritative-looking answer in reach.',
+    ).toContain('no gate in this repository reads it');
+
+    expect(
+      prose,
+      'the page must keep telling the reader what to do INSTEAD of the label — a denial with ' +
+        'no alternative sends them back to the label. The real exemption is a changeset with ' +
+        'empty frontmatter.',
+    ).toContain('declare an empty changeset instead');
+
+    // The 2026-08-08 labels-API reading this note used to carry ("the label still does not
+    // exist") had expired by the time #4912 was worked: the object had been re-minted. A
+    // point-in-time API reading is not a fact this repository can keep true, and restating one
+    // is how the page came to assert something false about the very phantom it documents.
+    expect(
+      prose,
+      'do not put a point-in-time labels-API reading back on this page. Nothing in the tree ' +
+        'can keep it true, and the last one was false within weeks (objectui#4912).',
+    ).not.toContain('checked against the labels API');
+  });
 });
 
 /**


### PR DESCRIPTION
Part of #4912

⚠️ **`Part of`, not `Fixes`, deliberately.** #4912 closes when **both** halves are done: this
pin, and the deletion of the `skip-changeset` **label object**. I could not perform the
deletion (evidence below), so a closing keyword here would silently close a card whose
administrative half is still owed.

## What this changes

Two files, no runtime code:

| file | change |
|---|---|
| `scripts/__tests__/ci-cd-pipeline-doc.test.ts` | +2 cases in the existing phantom-mechanism family |
| `content/docs/guide/ci-cd-pipeline.md` | corrects a claim on the page that had become **false** |

## The card got stronger while it sat — the predicted harm actually happened

#4912 predicted: *"the next agent that greps for 'how do I declare this PR publishes nothing'
finds a label, applies it, and believes the declaration landed."*

That occurred on 2026-08-25, hours before this PR. Verified rather than taken on trust:

- The triage comment on #6243 (`claude[bot]`, `2026-08-25T04:21:23Z`) ends with a bare
  instruction: `` `skip-changeset`. ``
- The developer **refused** and flagged the conflict rather than complying or silently
  ignoring it (report comment on #6243).
- The refusal was **upheld** in the PM review on #6260.

So the label is no longer a latent phantom — it is actively being read as a mechanism by
agents, which is the harm the card described.

## Premise re-measured on `origin/main` @ `ef2a3bd8d` — unchanged

```
$ git grep -n 'skip-changeset' origin/main -- .github scripts package.json
scripts/__tests__/ci-cd-pipeline-doc.test.ts:184:  * changeset gate skippable with a `skip-changeset` label; neither the workflow nor the
```

Exactly **one** hit, the prose the card names. No changeset gate has a label-keyed skip path:
`check-changeset-presence.mjs`, `check-changeset-fixed.mjs` and `check-changeset-no-major.mjs`
contain no read of any label. No workflow reads it either.

⚠️ **One measurement came out bigger than the card knew.** The card names PR #4639 as carrying
the label. It is on **seven** PRs, all closed: #4700, #4665, #4639, #4630, #4628, #4615, #4129.
⛔ I removed it from none of them — I opened none of them.

## What the pin can and cannot observe

A label lives in GitHub's data, not in the tree. **No test here can assert the label object is
gone**, and this suite has no network call or credential anywhere in it — every other assertion
reads the filesystem. Reaching for the labels API to pin this would be the one test in the file
that can fail because of an outage.

⚠️ It was also correctly objected on the card that a pin merely restating *"nothing reads the
label"* is already true, stays true, and does not address the defect. That objection is why the
pin is **not** that. The two cases hold things a future commit could change without anyone
noticing:

1. **`never wires the phantom skip-changeset label into a workflow or a gate`** — walks
   `.github/` and `scripts/` and fails on any occurrence outside the test file that records the
   history. This is the guard against **option B landing without a decision**: a labelled bypass
   on a changeset gate that deliberately has none, declined by #3724 and again by the #4912
   ruling. The name **is** wired in the `objectstack` sibling (`lint.yml`, `pr-automation.yml`,
   `check-empty-changeset.mjs`), which is how it reaches agents who then look for it here, so
   copying that wiring across is a live risk, not a theoretical one.
2. **`keeps the page denying skip-changeset rather than describing it`** — `ci-cd-pipeline.md`
   is where a contributor looks up "how do I declare this PR publishes nothing", so the page is
   what decides whether the next reader believes the label. Unlike the `size-check.yml` pin
   above it, absence is the wrong assertion: the page must keep **naming** the label in order to
   deny it. So the denial itself is pinned, along with the alternative to reach for instead — a
   denial with no alternative sends the reader back to the label.

## ⭐ The page was asserting something false about this very phantom

Found while verifying, and it is the reason this PR is worth landing **before** the deletion
rather than after. The page carried:

> The label still does not exist (checked against the labels API, 2026-08-08 — of the two names
> only `dependencies` exists, applied by the auto-labeler and read by no gate)

**That is false today.** Measured via `get_label` on `objectstack-ai/objectui`:

```
name:        skip-changeset
color:       ededed      (GitHub's default grey)
description: ""          (empty)
```

The object exists, with exactly the auto-minted signature the card describes. So the worst
possible combination was in place: a contributor reads "the label does not exist", sees it in
the label picker, concludes the page is stale — and treats the label as the real mechanism.

A **point-in-time API reading is not a fact this repository can keep true**, and this one was
false within weeks. It is replaced with the durable invariant (nothing reads it; here is what to
do instead), and the third assertion pins that a point-in-time reading is not put back.

## Verification

All on the final commit **`1a1e7bc07`** (`git rev-parse --short HEAD`), clean tree. Exit codes
captured **by redirect before any pipe** (`cmd > out 2>&1; echo EXIT=$?`); every line quoted is
the gate's own printed verdict, never a bare `$?`.

| gate | exit | its own verdict line |
|---|---|---|
| `vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts --reporter=verbose` | 0 | `Test Files  1 passed (1)` · `Tests  34 passed (34)` |
| `type-check:scripts` | 0 | pnpm echoed `> tsc -p tsconfig.scripts.json` |
| `lint:root` **UNNARROWED** | 0 | `✖ 28 problems (0 errors, 28 warnings)` |
| `check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 5171 tracked text file(s); skipped 85 binary).` |
| `check-doc-links.mjs` | 0 | `Links are valid across 15 scan roots.` |
| `check-changeset-presence.mjs` | 0 | `✅  No source of a released package changed in this range, so no changeset is owed.` |
| `vitest run scripts/` (the narrowed union) | 0 | `Test Files  77 passed (77)` · `Tests  2209 passed (2209)` |

**Both new cases confirmed COLLECTED BY NAME** under `--reporter=verbose`, not inferred from a
total:

```
✓ |unit| scripts/__tests__/ci-cd-pipeline-doc.test.ts > ci-cd-pipeline.md — workflow inventory
    > never wires the phantom `skip-changeset` label into a workflow or a gate 25ms
✓ |unit| scripts/__tests__/ci-cd-pipeline-doc.test.ts > ci-cd-pipeline.md — workflow inventory
    > keeps the page denying `skip-changeset` rather than describing it 4ms
```

`lint:root` was run **unnarrowed**. Its 28 warnings are all pre-existing
`@typescript-eslint/no-explicit-any` in `e2e/live/**`, `vitest.setup.base.ts` and two
`scripts/__tests__/vite-*` files — **zero** in either file this PR touches (`grep -c
'ci-cd-pipeline'` over the lint output → `0`), and the same set PR #6260 reported.

### Reverse-verification — both pins fail when violated

Run from the committed state, each leg with a `trap … EXIT INT TERM` restore so a cap-kill
could not leave the tree mutated. No build or `dist/` is involved — vitest transforms these
tests from source, and the ablation exercised the byte-identical walker and normalizer.

| leg | mutation confirmed on disk | result |
|---|---|---|
| plant `.github/planted-ablation-probe.yml` reading the label | `grep -c` in planted file → `1`, file exists → `1` | offenders → `[".github/planted-ablation-probe.yml"]` (**detected**) |
| remove the plant | file absent → `1` | offenders → `[]` (**restored**) |
| strip the denial sentence from the page | anchor hits → `1`; denial count after edit → `0`; `git diff --stat` non-empty | assertion subject gone (**detected**) |
| `git checkout --` the page | denial count → `1` | **restored**, `git status --porcelain` empty |

⚠️ Mutation was confirmed by **counting the anchored text**, never by an editor's exit status —
a zero-match `replace` exits 0 and would have produced a green no-op ablation.

### ⚠️ ONE DECLARED NARROWING

The **full root vitest suite was not run here**; it is narrowed to `vitest run scripts/`. Reason:
this container caps a foreground command at ~10 minutes, and the shared verify lock was held by
sibling agents running the full farm — one acquisition attempt burned its whole budget and
returned `VERDICT queue-timeout (exit 99) · never acquired`. That run is CI's.

The narrowing is **measured, not assumed**:

- **Population** — 2 changed files. One is the test file itself, run explicitly and verbosely.
  The other is markdown; no package imports it.
- **Readers of the changed doc** — `git grep -ln 'ci-cd-pipeline'` over source and tests returns
  10 files. Exactly **one** reads the file: `scripts/__tests__/ci-cd-pipeline-doc.test.ts`
  (`docPath` → `readFileSync`). Of the rest,
  `scripts/__tests__/check-action-forward-parity.test.ts` uses the path only as a **string
  literal in a glob-match example**, `packages/auth/src/__tests__/reserved-auth-features.test.ts`
  names it only in a prose comment ("follows the … pattern"), and the others match on the
  unrelated `dependabot-merge-gate` / `lint-workflow` prose.
- **Config invariance** — the new assertions add no new verification surface: they read the same
  two files the suite already read, with `node:fs` the file already imports.

## Changeset — none, deliberately

⭐ `check-changeset-presence.mjs` **exits 0 whether or not a changeset is present**, so it is not
deciding this. I read the diff: a test file and a documentation page, neither of them source of
any published package, with no behaviour a release note could describe. The gate's own count
agrees — `2 file(s) changed, 0 of them published source of a package the release covers`.
Precedents that carried none: #6216, #6212, #6260.

⛔ **And no `skip-changeset` label on this PR** — on this card of all cards, applying an inert
label to declare "publishes nothing" would re-create the exact defect the PR exists to pin.

## ⛔ The label deletion — attempted, and I could not do it

Reported plainly rather than worked around.

- The GitHub MCP toolset exposes **`get_label` only** — read. There is no create, update, or
  delete label tool; confirmed by searching the tool surface, not assumed.
- Direct REST from this seat is refused:

```
$ curl -sS -w 'HTTP %{http_code}' -H "Authorization: Bearer $GITHUB_TOKEN" \
    https://api.github.com/repos/objectstack-ai/objectui/labels/skip-changeset
HTTP 403
{"message":"GitHub access is not enabled for this session. An org admin must connect
 the Claude GitHub App for this organization."}
```

  (`GITHUB_TOKEN` in this container is the literal 14-byte string `proxy-injected`; the real
  credential is added by the proxy, and the proxy refuses this route.)

**The remaining act is `DELETE /repos/objectstack-ai/objectui/labels/skip-changeset`, or
Settings → Labels.** Nothing is lost by it: nothing reads the label, and all seven PRs carrying
it are closed. #4912 stays open until it is done.

## Not armed

⛔ Draft, and **auto-merge is deliberately NOT enabled** — that is the PM's call after review
against GitHub.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_