### PR TITLE
fix(tooling): judge lucide icon names on untyped child items of a declared container

### DIFF
--- a/scripts/__tests__/check-lucide-icon-record-names.test.ts
+++ b/scripts/__tests__/check-lucide-icon-record-names.test.ts
@@ -93,7 +93,27 @@ interface FixtureOptions {
   declaredRecordReaders?: string[];
   declaredDynamicReaders?: string[];
   negativeControl?: string;
+  recordReadingTypes?: CensusTable;
 }
+
+/** The census-table shape `analyze` accepts, derived from the gate, not restated. */
+type CensusTable = NonNullable<NonNullable<Parameters<typeof analyze>[1]>['recordReadingTypes']>;
+type CensusEntry = CensusTable[string];
+
+/**
+ * The authored-node census with every `descendants` declaration stripped —
+ * the fixture default, for the same reason `anchors` defaults to `[]` here:
+ * a throwaway tree contains none of this repository's authored nodes, and a
+ * descent declaration carries a `min` that ERRORS when it reaches nothing
+ * (objectui#5992). A fixture inheriting the repo's declarations would be
+ * testing that error instead of what it means to test. Tests that are ABOUT
+ * descent pass their own table.
+ */
+const FIXTURE_TYPES: CensusTable = Object.fromEntries(
+  Object.entries(RECORD_READING_TYPES).map(([type, spec]): [string, CensusEntry] => (
+    [type, { paths: spec.paths, resolver: spec.resolver }]
+  )),
+);
 
 function fixtureRepo(label: string, files: Record<string, string>): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), `icon-record-${label}-`));
@@ -112,6 +132,7 @@ function judge(label: string, options: FixtureOptions) {
     declaredRecordReaders: options.declaredRecordReaders ?? [RESOLVER_FILE],
     declaredDynamicReaders: options.declaredDynamicReaders ?? [],
     negativeControl: options.negativeControl,
+    recordReadingTypes: options.recordReadingTypes ?? FIXTURE_TYPES,
   });
 }
 
@@ -245,6 +266,131 @@ describe('a name whose resolver this gate cannot identify is declined, not flagg
   });
 });
 
+// ── 3b. icons on UNTYPED child items of a DECLARED container ─────────────────
+
+/**
+ * objectui#5992. Part 2 judged an `icon` only on a node whose OWN `type` was
+ * censused. `ui:dropdown-menu` menu items are child objects with no `type` key
+ * at all, so they were never judged — harmless while nothing resolved them, and
+ * a live hole the moment objectui#5930 routed them through `resolveIcon`. The
+ * published fixture that carries them is a declared AI few-shot retrieval
+ * source, so a dead spelling there teaches a dead name.
+ *
+ * The rule pinned here is the one that closed it: an untyped node's `icon` is
+ * judged against its NEAREST TYPED ANCESTOR, and only when that ancestor's
+ * census entry declares `descendants`.
+ */
+describe('an icon on an UNTYPED child of a container that declares descent', () => {
+  /** A fixture container declaring descent, so these tests own their table. */
+  const DESCENT_TYPES: CensusTable = {
+    ...FIXTURE_TYPES,
+    'fixture-menu': {
+      paths: [],
+      descendants: true,
+      min: 1,
+      resolver: RESOLVER_FILE,
+    },
+  };
+
+  const menu = (items: unknown): string => JSON.stringify({ type: 'fixture-menu', items }, null, 2);
+
+  it('goes RED, naming the child node and the container it answers to', () => {
+    const result = judge('descend-red', {
+      files: { 'examples/catalog/menu.json': menu([{ label: 'Edit', icon: 'edit' }]) },
+      recordReadingTypes: DESCENT_TYPES,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].where).toBe('examples/catalog/menu.json $.items[0].icon');
+    expect(result.violations[0].site).toBe('fixture-menu (untyped child item)');
+    expect(result.violations[0].detail).toContain('write `square-pen`');
+    expect(result.counters.authoredDescendantJudged).toBe(1);
+  });
+
+  it('goes GREEN on a live name at the same site — and it was really judged', () => {
+    const result = judge('descend-green', {
+      files: { 'examples/catalog/menu.json': menu([{ label: 'Edit', icon: 'square-pen' }]) },
+      recordReadingTypes: DESCENT_TYPES,
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.counters.authoredDescendantJudged).toBe(1);
+  });
+
+  it('reaches ARBITRARY nesting depth — the case a `items[].icon` path cannot express', () => {
+    // Why the nearest-typed-ancestor rule was chosen over declaring child-item
+    // keys per container. `renderMenuItems` RECURSES into `item.children` and
+    // resolves the submenu trigger through the SAME `resolveIcon` call, so a
+    // retired name three levels down reaches the record exactly as the leaf
+    // does. The `paths` grammar is `^(\w+)\[\]\.icon$` — one level, by
+    // construction — so a key list would have closed the leaf and left the
+    // submenu open, which is the narrower version of the same bug objectui#5930
+    // explicitly refused to ship.
+    const result = judge('descend-deep', {
+      files: {
+        'examples/catalog/menu.json': menu([
+          { label: 'More', children: [{ label: 'Deeper', children: [{ label: 'Deepest', icon: 'more-horizontal' }] }] },
+        ]),
+      },
+      recordReadingTypes: DESCENT_TYPES,
+    });
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0].where).toBe('examples/catalog/menu.json $.items[0].children[0].children[0].icon');
+    expect(result.violations[0].detail).toContain('write `ellipsis`');
+  });
+
+  it('STOPS at a typed child — the child\'s own `type` still answers for it', () => {
+    // A `type: 'separator'` menu item is returned early by the renderer and
+    // draws no icon. Descent that ran through it would invent a violation no
+    // resolver would ever produce, and this gate would get suppressed.
+    const result = judge('descend-typed-child', {
+      files: {
+        'examples/catalog/menu.json': menu([
+          { type: 'separator', icon: 'edit' },
+          { type: 'text', icon: 'filter' },
+        ]),
+      },
+      recordReadingTypes: DESCENT_TYPES,
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.counters.authoredDescendantJudged).toBe(0);
+    // …and it SAW them: silence is a decision, not a miss.
+    expect(result.counters.authoredDeclined).toBe(2);
+  });
+
+  it('does NOT leak descent into a container that never declared it', () => {
+    // The reason `descendants` is opt-in per container rather than a blanket
+    // "nearest censused ancestor" rule: `breadcrumb`/`button-group`/`command`
+    // items were measured and none of their renderers reads `icon` at all.
+    const result = judge('descend-undeclared', {
+      files: { 'examples/catalog/crumbs.json': JSON.stringify({ type: 'breadcrumb', items: [{ icon: 'layout' }] }, null, 2) },
+      recordReadingTypes: DESCENT_TYPES,
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.counters.authoredDescendantJudged).toBe(0);
+    expect(result.counters.authoredDeclined).toBe(1);
+  });
+
+  it('ERRORS rather than passing when a descent declaration reaches NOTHING', () => {
+    // The vacuity this whole card is about, one level up: a declaration that
+    // stops reaching its nodes produces zero violations and reads exactly like
+    // a clean tree. Same precondition ANCHORED_MAPS states with `min`.
+    const result = judge('descend-vacuous', {
+      files: { 'examples/catalog/other.json': JSON.stringify({ type: 'text', label: 'hi' }, null, 2) },
+      recordReadingTypes: DESCENT_TYPES,
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.errors.join('\n')).toContain('`fixture-menu` declares its icon names on UNTYPED child items');
+    expect(result.errors.join('\n')).toContain('reached 0 of them — fewer than the 1');
+  });
+});
+
 // ── 4. the census is measured, not remembered ────────────────────────────────
 
 describe('the surface census is re-derived on every run', () => {
@@ -373,6 +519,28 @@ describe('this repository', () => {
     expect(repoResult.counters.anchoredJudged).toBeGreaterThan(30);
   });
 
+  it('really judges the untyped child items objectui#5992 opened up', () => {
+    // Without this, the descent rule could stop reaching the catalog and the
+    // repository would stay green — which is precisely the shape of the defect
+    // that card was filed for. The gate carries a `min` for the same reason;
+    // this is the reading of it from outside.
+    expect(repoResult.counters.authoredDescendantJudged).toBeGreaterThan(0);
+    const declaring = Object.entries(RECORD_READING_TYPES)
+      .filter(([, spec]) => 'descendants' in spec && spec.descendants)
+      .map(([type]) => type);
+    expect(declaring).toContain('dropdown-menu');
+  });
+
+  it('did NOT grow part 1 in the process — descent is a part-2 rule', () => {
+    // objectui#5930 routes menu icons through `resolveIcon`, not through a
+    // fresh `icons` import, so `renderers/overlay/dropdown-menu.tsx` correctly
+    // stays OUT of the record-reader census. A descent declaration that moved
+    // this number would have altered the wrong part of the gate.
+    expect(repoResult.discovered.record).toHaveLength(8);
+    expect(repoResult.discovered.record).not.toContain('packages/components/src/renderers/overlay/dropdown-menu.tsx');
+    expect(RECORD_READING_TYPES['dropdown-menu'].resolver).toContain('renderers/action/resolve-icon.ts');
+  });
+
   it('carries more record-reading resolvers than objectui#5633 catalogued by hand', () => {
     // The card's table listed four. Discovery found eight, which is the whole
     // argument for measuring the population instead of maintaining a list: the
@@ -428,6 +596,21 @@ describe('the gate is wired and the local pins it subsumes are gone', () => {
     expect(anchored).toContain('packages/plugin-detail/src/DetailView.tsx::items.push');
     expect(anchored).toContain('packages/plugin-view/src/ViewSwitcher.tsx::DEFAULT_VIEW_ICONS');
     expect(anchored).toContain('packages/plugin-view/src/ObjectView.tsx::iconMap');
+  });
+
+  it('no longer carries the parenthetical objectui#5930 falsified', () => {
+    // The header used to state, as a measurement, that the untyped catalog
+    // icons were "eight ... child items of `button-group`, `breadcrumb`,
+    // `command` and `dropdown-menu` — three of which never read `icon`, and the
+    // fourth renders it as raw text". objectui#5930 made the fourth resolve
+    // through the record, and the count was low by 53. A stale measurement in
+    // the header of a gate is what the next reader reasons from.
+    const header = fs.readFileSync(path.join(repoRoot, GATE), 'utf8');
+    expect(header).not.toContain('the fourth renders it as raw text');
+    expect(header).toContain('Re-measured over the schema catalog at objectui@ef2a3bd8d');
+    for (const container of ['button-group', 'breadcrumb', 'command', 'context-menu', 'timeline', 'tree-view']) {
+      expect(header, `the re-measured table dropped ${container}`).toContain(container);
+    }
   });
 
   it('the pin the gate does NOT subsume is kept, and says why', () => {

--- a/scripts/check-lucide-icon-record-names.mjs
+++ b/scripts/check-lucide-icon-record-names.mjs
@@ -54,11 +54,48 @@
  *    schema object literals embedded in first-party TS) and checks the `icon`
  *    names on nodes whose `type` is a censused record-reading renderer. The
  *    node's own `type` is what answers "which resolver does this string
- *    reach?", which is why this check can be broad without being suppressible:
- *    an `icon` on an UNTYPED node is not judged at all (measured: the eight
- *    such names in the schema catalog are child items of `button-group`,
- *    `breadcrumb`, `command` and `dropdown-menu` — three of which never read
- *    `icon`, and the fourth renders it as raw text).
+ *    reach?", which is why this check can be broad without being suppressible.
+ *
+ *    An `icon` on an UNTYPED node is judged only when its NEAREST TYPED
+ *    ANCESTOR is a censused container whose entry DECLARES that its child items
+ *    carry icon names (`descendants: true`) — a fact read off that container's
+ *    renderer, exactly the way every `paths` entry in the table below was. A
+ *    typed node ENDS any descent it sits inside, because its own `type` is
+ *    still the answer to which resolver its string reaches. Untyped icons under
+ *    every other ancestor remain declined, not flagged.
+ *
+ *    ── Re-measured over the schema catalog at objectui@ef2a3bd8d ────────────
+ *    The parenthetical this replaced read "the eight such names in the schema
+ *    catalog are child items of `button-group`, `breadcrumb`, `command` and
+ *    `dropdown-menu` — three of which never read `icon`, and the fourth renders
+ *    it as raw text". objectui#5930 falsified its second half, and the count
+ *    was low by 53. Re-measured, by reading each renderer (objectui#5992):
+ *
+ *      61 untyped `icon` names, across SEVEN containers. Exactly ONE of them
+ *      reaches a record-reading resolver:
+ *
+ *        dropdown-menu   3  RECORD — `resolveIcon(item.icon)` in
+ *                           `renderers/overlay/dropdown-menu.tsx` (objectui#5930).
+ *                           JUDGED HERE. Judged RECURSIVELY, because that
+ *                           renderer recurses into `item.children` for submenus
+ *                           and resolves the submenu trigger's icon through the
+ *                           same call — a depth no single-level `items[].icon`
+ *                           path can express.
+ *        button-group    8  `renderers/basic/button-group.tsx` never reads
+ *                           `button.icon` at all; the names render nothing
+ *        breadcrumb      3  renderer never reads `icon`
+ *        command         9  renderer never reads `icon`
+ *        context-menu    4  renderer never reads `icon` — dropdown-menu's twin,
+ *                           and NOT routed by objectui#5930
+ *        timeline        4  rendered as RAW TEXT, `<span>{item.icon}</span>`;
+ *                           the four authored names are emoji, not lucide names
+ *        tree-view      30  read, but as a TWO-VALUED literal switch
+ *                           (`node.icon === 'folder'`) — never a record lookup
+ *
+ *    `dropdown-menu.tsx` itself is correctly ABSENT from part 1's census: it
+ *    imports `resolveIcon`, not `icons`, so the record read happens in
+ *    `renderers/action/resolve-icon.ts`, which is already declared. Part 1
+ *    stays at eight resolvers; this is a part-2 rule, not a census change.
  *
  * 3. ANCHORED MAPS — the first-party const maps that feed a record-reading
  *    resolver but are not authored nodes. This is the population the retired
@@ -132,6 +169,16 @@ export const SCAN_ROOTS = ['packages', 'apps', 'examples'];
 // from this table is not judged, because nothing here knows which vocabulary
 // (if any) its icons reach — and a gate that guessed would be a gate that gets
 // suppressed.
+//
+// `descendants: true` extends that same declaration to the container's UNTYPED
+// child items — see the part-2 paragraph in the header. It is deliberately
+// OPT-IN per container rather than a blanket "nearest typed ancestor" rule:
+// applying descent to every censused entry would extend a judgement that was
+// measured against one shape (`action:bar`'s `actions[]`) to descendant shapes
+// nobody read off a renderer, which is the guessing this table exists to
+// refuse. `min` is the non-vacuity precondition ANCHORED_MAPS uses below: a
+// descent that reaches NOTHING reports no violations and reads exactly like a
+// clean tree.
 export const RECORD_READING_TYPES = {
   'button': { paths: ['icon'], resolver: 'packages/components/src/renderers/form/button.tsx' },
   'action:bar': { paths: ['actions[].icon'], resolver: 'packages/components/src/renderers/action/resolve-icon.ts' },
@@ -140,6 +187,16 @@ export const RECORD_READING_TYPES = {
   'action:icon': { paths: ['icon'], resolver: 'packages/components/src/renderers/action/resolve-icon.ts' },
   'action:menu': { paths: ['icon', 'actions[].icon'], resolver: 'packages/components/src/renderers/action/resolve-icon.ts' },
   'data-table': { paths: ['rowActionDefs[].icon'], resolver: 'packages/components/src/renderers/complex/data-table.tsx' },
+  // The container's OWN `icon` is never read (`paths: []`); its item icons sit
+  // on untyped children, recursively, and every one of them goes through the
+  // single `resolveIcon(item.icon)` call that serves BOTH the leaf arm and the
+  // submenu-trigger arm (objectui#5930, objectui#5992).
+  'dropdown-menu': {
+    paths: [],
+    descendants: true,
+    min: 1,
+    resolver: 'packages/components/src/renderers/action/resolve-icon.ts (via renderers/overlay/dropdown-menu.tsx)',
+  },
   'view-switcher': { paths: ['views[].icon', 'viewActions[].icon'], resolver: 'packages/plugin-view/src/ViewSwitcher.tsx' },
 };
 
@@ -399,13 +456,17 @@ export function discoverResolvers(root, files) {
 // ── Part 2: authored nodes ───────────────────────────────────────────────────
 const ARRAY_PATH = /^(\w+)\[\]\.icon$/;
 
-function judgeAuthoredNodes(root, { sources, documents }) {
+function judgeAuthoredNodes(root, { sources, documents }, types = RECORD_READING_TYPES) {
   const violations = [];
+  const errors = [];
   let judged = 0;
   let declined = 0;
+  let descendantJudged = 0;
+  /** Per declaring container `type`, how many untyped child icons descent reached. */
+  const descentReach = new Map();
 
   const judge = (typeName, gather, locate) => {
-    const spec = RECORD_READING_TYPES[typeName];
+    const spec = types[typeName];
     if (!spec) return;
     for (const path of spec.paths) {
       for (const found of gather(path)) {
@@ -417,16 +478,43 @@ function judgeAuthoredNodes(root, { sources, documents }) {
     }
   };
 
+  /**
+   * The descent site a node's children inherit. A node's OWN `type` is still
+   * the answer to "which resolver does this string reach?", so a typed node
+   * ENDS whatever descent it sits inside and opens a new one only if its own
+   * census entry declares one. That is what keeps a `type: 'separator'` menu
+   * item — which this renderer returns early for, drawing no icon — declined
+   * rather than judged.
+   */
+  const descentBelow = (typeName, inherited) => {
+    if (!typeName) return inherited;
+    const spec = types[typeName];
+    return spec?.descendants ? { type: typeName, spec } : null;
+  };
+
+  /** Judge one untyped child icon against the container that declared descent. */
+  const judgeDescendant = (site, value, where) => {
+    judged += 1;
+    descendantJudged += 1;
+    descentReach.set(site.type, (descentReach.get(site.type) ?? 0) + 1);
+    if (!isLiveKey(value)) {
+      violations.push({ where, site: `${site.type} (untyped child item)`, resolver: site.spec.resolver, detail: describeName(value) });
+    }
+  };
+
   for (const file of documents) {
     if (isTestPath(file)) continue;
     let document;
     try { document = JSON.parse(readFileSync(join(root, file), 'utf8')); } catch { continue; }
-    // One walker, carrying a JSON-pointer trail so a violation names the node.
-    const walk = (node, trail) => {
-      if (Array.isArray(node)) { node.forEach((child, index) => walk(child, `${trail}[${index}]`)); return; }
+    // One walker, carrying a JSON-pointer trail so a violation names the node,
+    // and the descent site (if any) its untyped children answer to.
+    const walk = (node, trail, descent) => {
+      if (Array.isArray(node)) { node.forEach((child, index) => walk(child, `${trail}[${index}]`, descent)); return; }
       if (!node || typeof node !== 'object') return;
       const typeName = typeof node.type === 'string' ? node.type : null;
-      if (typeof node.icon === 'string' && !(typeName && RECORD_READING_TYPES[typeName])) declined += 1;
+      const inherits = !typeName && descent && typeof node.icon === 'string';
+      if (inherits) judgeDescendant(descent, node.icon, `${file} ${trail}.icon`);
+      if (typeof node.icon === 'string' && !inherits && !(typeName && types[typeName])) declined += 1;
       if (typeName) {
         judge(typeName, (path) => {
           const found = [];
@@ -441,9 +529,10 @@ function judgeAuthoredNodes(root, { sources, documents }) {
           return found;
         }, (where) => `${file} ${where}`);
       }
-      for (const [key, value] of Object.entries(node)) walk(value, `${trail}.${key}`);
+      const below = descentBelow(typeName, descent);
+      for (const [key, value] of Object.entries(node)) walk(value, `${trail}.${key}`, below);
     };
-    walk(document, '$');
+    walk(document, '$', null);
   }
 
   for (const file of sources) {
@@ -451,12 +540,17 @@ function judgeAuthoredNodes(root, { sources, documents }) {
     const text = readFileSync(join(root, file), 'utf8');
     if (!text.includes('icon')) continue;
     const sf = parseSource(root, file);
-    const visit = (node) => {
+    const visit = (node, descent) => {
+      let below = descent;
       if (ts.isObjectLiteralExpression(node)) {
         const typeInit = objectProp(node, 'type');
         const iconInit = objectProp(node, 'icon');
         const typeName = typeInit && ts.isStringLiteral(typeInit) ? typeInit.text : null;
-        if (iconInit && ts.isStringLiteral(iconInit) && !(typeName && RECORD_READING_TYPES[typeName])) declined += 1;
+        below = descentBelow(typeName, descent);
+        const iconLiteral = iconInit && ts.isStringLiteral(iconInit) ? iconInit : null;
+        const inherits = !typeName && descent && iconLiteral;
+        if (inherits) judgeDescendant(descent, iconLiteral.text, `${file}:${lineOf(sf, iconLiteral)}`);
+        if (iconLiteral && !inherits && !(typeName && types[typeName])) declined += 1;
         if (typeName) {
           judge(typeName, (path) => {
             const found = [];
@@ -477,12 +571,30 @@ function judgeAuthoredNodes(root, { sources, documents }) {
           }, (where) => `${file}:${lineOf(sf, where)}`);
         }
       }
-      ts.forEachChild(node, visit);
+      ts.forEachChild(node, (child) => visit(child, below));
     };
-    ts.forEachChild(sf, visit);
+    ts.forEachChild(sf, (child) => visit(child, null));
   }
 
-  return { violations, judged, declined };
+  // Non-vacuity, the precondition ANCHORED_MAPS states in full below: a descent
+  // declaration that reached NOTHING produces zero violations and reads exactly
+  // like a clean tree. That is the failure this whole card is about one level
+  // up, so it is an ERROR here rather than a shrug.
+  for (const [typeName, spec] of Object.entries(types)) {
+    if (!spec.descendants) continue;
+    const reached = descentReach.get(typeName) ?? 0;
+    const min = spec.min ?? 1;
+    if (reached < min) {
+      errors.push(
+        `\`${typeName}\` declares its icon names on UNTYPED child items (\`descendants: true\`), but the authored-node walk `
+        + `reached ${reached} of them — fewer than the ${min} it is declared to carry. Either the authored nodes moved `
+        + 'or the descent no longer reaches them; a descent that reaches nothing reports no violations and reads as green. '
+        + `Resolved through: ${spec.resolver}`,
+      );
+    }
+  }
+
+  return { violations, errors, judged, declined, descendantJudged };
 }
 
 // ── Part 3: anchored first-party maps ────────────────────────────────────────
@@ -547,11 +659,32 @@ function judgeAnchoredMaps(root, anchors) {
 }
 
 // ── The whole judgement ──────────────────────────────────────────────────────
+/**
+ * One authored-node census entry. Spelled out as a type rather than left to be
+ * inferred from `RECORD_READING_TYPES`, because every override this function
+ * takes exists to be a DIFFERENT table from the declared one — inferring the
+ * parameter from the default makes the declared table the only one that fits,
+ * which is precisely backwards for a seam whose job is substitution.
+ *
+ * @typedef {{ paths: string[], resolver: string, descendants?: boolean, min?: number }} RecordReadingType
+ *
+ * @typedef {{
+ *   anchors?: readonly any[],
+ *   declaredRecordReaders?: readonly string[],
+ *   declaredDynamicReaders?: readonly string[],
+ *   negativeControl?: string,
+ *   recordReadingTypes?: Record<string, RecordReadingType>,
+ * }} AnalyzeOptions
+ *
+ * @param {string} root
+ * @param {AnalyzeOptions} [options]
+ */
 export function analyze(root, {
   anchors = ANCHORED_MAPS,
   declaredRecordReaders = DECLARED_RECORD_READERS,
   declaredDynamicReaders = DECLARED_DYNAMIC_READERS,
   negativeControl = DISCOVERY_NEGATIVE_CONTROL,
+  recordReadingTypes = RECORD_READING_TYPES,
 } = {}) {
   const errors = [...selfTest()];
   const { sources, documents } = collectFiles(root);
@@ -581,9 +714,9 @@ export function analyze(root, {
     errors.push(`discovery classified ${negativeControl} as a lucide resolver. It builds its OWN local \`icons\` object — discovery is matching the NAME rather than the IMPORT.`);
   }
 
-  const authored = judgeAuthoredNodes(root, { sources, documents });
+  const authored = judgeAuthoredNodes(root, { sources, documents }, recordReadingTypes);
   const anchored = judgeAnchoredMaps(root, anchors);
-  errors.push(...anchored.errors);
+  errors.push(...authored.errors, ...anchored.errors);
 
   return {
     discovered,
@@ -594,6 +727,7 @@ export function analyze(root, {
       documents: documents.length,
       authoredJudged: authored.judged,
       authoredDeclined: authored.declined,
+      authoredDescendantJudged: authored.descendantJudged,
       anchoredJudged: anchored.judged,
     },
   };
@@ -613,7 +747,7 @@ if (invokedDirectly) {
     for (const file of discovered.record) console.log(`    ${file}`);
     console.log(`dynamic-surface resolvers discovered (${discovered.dynamic.length}), NOT judged here:`);
     for (const file of discovered.dynamic) console.log(`    ${file}`);
-    console.log(`authored icon names judged: ${counters.authoredJudged} | icon names on nodes this gate declines to judge: ${counters.authoredDeclined}`);
+    console.log(`authored icon names judged: ${counters.authoredJudged} (${counters.authoredDescendantJudged} of them on UNTYPED child items of a declared container) | icon names on nodes this gate declines to judge: ${counters.authoredDeclined}`);
     console.log(`anchored map entries judged: ${counters.anchoredJudged}`);
     console.log('');
   }


### PR DESCRIPTION
Fixes #5992

## The gap

`scripts/check-lucide-icon-record-names.mjs` part 2 judged an `icon` name only on a node whose **own** `type` was a censused record-reading renderer. `ui:dropdown-menu` menu items are child objects carrying no `type` key at all, so they were never judged — the gate's own header stated that boundary explicitly.

That was harmless until #5930 routed those icons through `resolveIcon`. Since then a retired lucide spelling in `examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/with-icons.json` renders **no glyph** and the gate stays green. That fixture is a declared AI few-shot retrieval source, so the failure mode is teaching a dead name, not merely a missing icon.

### Premise re-verified on current `origin/main` (`ef2a3bd8d`) before changing anything

The card's proof was measured on the #5930 branch. Re-run here on `origin/main`, mutating the fixture on disk under a restoring trap:

```
proof on disk — retired 'edit' present (expect 1): 1
proof on disk — live 'square-pen' present (expect 0): 0
 .../components-overlay-dropdown-menu/with-icons.json | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
gate exit with retired 'edit' in fixture = 0
OK  lucide icon names: 64 authored/declared names reaching 8 record-reading resolvers are live `icons` keys
```

Exit 0. The gap is live; the premise holds. Fixture restored, `git diff --exit-code` clean.

## The option chosen, and why

Both listed options require the same first move, which the card's framing does not make obvious. I measured it before writing anything: a **pure** nearest-typed-ancestor rule, applied with no other change, judges **zero** additional names — `dropdown-menu` is not in `RECORD_READING_TYPES` at all, so an untyped item has no censused ancestor to answer to. The container type must be declared either way. The options therefore differ only in **what gets judged under the declared container**.

**Option 1 (nearest typed ancestor), and the reason is mechanical, not stylistic.** `renderMenuItems` **recurses**:

```tsx
const Icon = resolveIcon(item.icon);
if (item.children) { … <DropdownMenuSubTrigger>{Icon && <Icon …/>}… }
```

Both the leaf arm and the submenu-trigger arm read the same `resolveIcon(item.icon)`, so a name at **any** depth reaches the record. The `paths` grammar is `^(\w+)\[\]\.icon$` — one level, by construction. Option 2's `items[].icon` would have closed the leaf and left the submenu open, which is the narrower version of the same bug #5930 explicitly refused to ship. Proven with a nested ablation, below.

**But descent is opt-in per container, not blanket.** Applying "nearest censused ancestor" to *every* entry would extend a judgement measured against one shape (`action:bar`'s `actions[]`) to descendant shapes nobody read off a renderer — `data-table`'s `columns[]`, say — which is exactly the guessing that table's header exists to refuse. So a censused entry declares `descendants: true`, a fact read off the renderer the same way every `paths` entry was. That is one boolean per container, not a key registry that drifts as schema shapes change.

Two properties fall out and are pinned:

- A **typed** child **ends** descent — its own `type` still answers for it. A `type: 'separator'` item is returned early by the renderer and draws no icon; descent running through it would invent a violation no resolver would ever produce.
- A descent declaration that reaches **nothing** is an **ERROR** (`min`), not zero violations — the precondition `ANCHORED_MAPS` already states, applied to the population this card added.

## Acceptance evidence — the RED is the deliverable

All three runs mutate the fixture on disk under a restoring `trap`, with the mutation confirmed by `grep -c` on both the injected and the removed text; the tree is verified byte-identical afterwards.

**A — the card's probe, retired `edit` at `items[0]` (depth 1):**

```
proof on disk — retired 'edit' present (expect 1): 1
proof on disk — live 'square-pen' present (expect 0): 0
gate exit with retired 'edit' in fixture = 1
FAIL  lucide icon names

    - examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/with-icons.json $.items[0].icon  [dropdown-menu (untyped child item)]
      "edit" -> `Edit` is not a key of the runtime `icons` record. lucide keeps it only as a DEPRECATED EXPORT of the same glyph — write `square-pen` (the spelling the record carries).
      Resolved through: packages/components/src/renderers/action/resolve-icon.ts (via renderers/overlay/dropdown-menu.tsx)
```

**B — nested submenu, retired `more-horizontal` at `items[0].children[0]` (depth 2) — the case a single-level `items[].icon` path cannot express:**

```
proof on disk — nested retired 'more-horizontal' present (expect 1): 1
gate exit with nested retired name = 1
FAIL  lucide icon names

    - …with-icons.json $.items[0].children[0].icon  [dropdown-menu (untyped child item)]
      "more-horizontal" -> `MoreHorizontal` is not a key of the runtime `icons` record. … write `ellipsis` …
```

**C — control, retired `edit` on a `type: 'separator'` item (descent must stop at a typed child):**

```
proof on disk — retired 'edit' on a type:'separator' item (expect 1): 1
gate exit with retired 'edit' on a TYPED (non-censused) item = 0
OK  lucide icon names: 67 authored/declared names …
```

**Green once the fixture is back to a live name**, and the fixture is byte-identical to `HEAD`:

```
--- restored fixture; git diff --exit-code -- …with-icons.json:
CLEAN (byte-identical to HEAD)

OK  lucide icon names: 67 authored/declared names reaching 8 record-reading resolvers are live `icons` keys (record 1767 keys; dynamic surface 4 sites, 2025 names, not judged here).
```

### Part 1's census is UNCHANGED at 8

`--report`, before → after:

```
record-reading resolvers discovered (8):        →  record-reading resolvers discovered (8):   [identical list]
authored icon names judged: 30 | declines: 350  →  authored icon names judged: 33 (3 of them
                                                   on UNTYPED child items of a declared
                                                   container) | declines: 347
anchored map entries judged: 34                 →  anchored map entries judged: 34
OK … 64 authored/declared names                 →  OK … 67 authored/declared names
```

+3 judged, −3 declined, census untouched. #5930 routes through `resolveIcon` rather than importing `icons`, so `renderers/overlay/dropdown-menu.tsx` correctly stays **out** of `DECLARED_RECORD_READERS`; the entry's `resolver` field names `renderers/action/resolve-icon.ts`, which is already declared. Pinned by a new test that asserts `discovered.record` has length 8 and does not contain `dropdown-menu.tsx`.

## The stale header sentence — re-measured, not reworded

The header carried, as a measurement:

> the eight such names in the schema catalog are child items of `button-group`, `breadcrumb`, `command` and `dropdown-menu` — three of which never read `icon`, and the fourth renders it as raw text

Both halves are wrong. Re-measured over the schema catalog at `ef2a3bd8d`, by reading each renderer rather than adjusting the wording: **61** untyped `icon` names across **seven** containers, and exactly **one** reaches a record-reading resolver.

| container | names | what the renderer does with `icon` |
|---|---:|---|
| `dropdown-menu` | 3 | **RECORD** — `resolveIcon(item.icon)` (#5930). **Judged here, recursively.** |
| `button-group` | 8 | `basic/button-group.tsx` never reads `button.icon` at all — the names render nothing |
| `breadcrumb` | 3 | never reads `icon` |
| `command` | 9 | never reads `icon` |
| `context-menu` | 4 | never reads `icon` — dropdown-menu's twin, **not** routed by #5930 |
| `timeline` | 4 | raw text, `<span>{item.icon}</span>`; the four authored names are emoji |
| `tree-view` | 30 | read, but as a two-valued literal switch (`node.icon === 'folder'`) — never a record lookup |

The old count was low by 53 and did not know `context-menu`, `timeline` or `tree-view` existed. The replacement is anchored to `objectui@ef2a3bd8d` in the file, and a test pins that the falsified sentence is gone and that all seven containers are named.

Unrelated but worth flagging for a reviewer: `scripts/check-entry-guard.mjs` says this suite "fails 5 of 25". That is a *recorded* measurement explicitly anchored to #6092's branch, not a live count — it is deliberately left alone rather than updated to 34, since rewriting a recorded measurement falsifies it.

## Verification

Exit codes captured **by redirect before any pipe**; each verdict is the gate's own printed line.

| check | result |
|---|---|
| `node scripts/check-lucide-icon-record-names.mjs` (clean tree) | `EXIT=0` · `OK  lucide icon names: 67 authored/declared names …` |
| the gate, three ablations | `1`, `1`, `0` — quoted above |
| `pnpm exec vitest run scripts/__tests__/check-lucide-icon-record-names.test.ts --reporter=verbose` | `Test Files 1 passed (1)` · `Tests 34 passed (34)`; all 9 new tests collected by name |
| `pnpm run type-check:scripts` (`tsc -p tsconfig.scripts.json` — script name echoed as a positive control) | `EXIT=0` |
| `pnpm run lint:root` — **unnarrowed**, the full root script | `EXIT=0` · `✖ 28 problems (0 errors, 28 warnings)`; **zero** warnings in the two changed files, and 28 is the pre-change baseline |
| `pnpm run check:control-bytes` | `EXIT=0` · `✅  check-control-bytes: OK (scanned 5171 tracked text file(s); skipped 85 binary).` |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over both changed files | no match |
| `pnpm run check:icon-record-names` (the wired script name, as a positive control) | `EXIT=0` · same `OK` line |
| `pnpm exec vitest run scripts/__tests__ --maxWorkers=2` | `Test Files 77 passed (77)` · `Tests 2216 passed (2216)` |
| root `pnpm exec vitest run --maxWorkers=2` | **narrowed — declared and measured, below** |

All of the above ran on `e78f7c811`, the branch head.

### The one narrowing, declared with its measurement

The unnarrowed root suite was attempted first, under the shared verify lock. It held the lock for **663s and produced zero test-file results** — its output was `RUN v4.1.10` followed by nothing but `Error: connect ECONNREFUSED 127.0.0.1:3000`, an environment precondition of that suite (a dev server nobody started) which no part of this diff touches — while two other agents queued behind it on the same lock. I stopped my own process tree by PID and released it.

The replacement is a **measurement**, not a guess, and it is three parts:

1. **Population read from vitest's own configuration**, not from my idea of which files count: `pnpm exec vitest list --filesOnly` → **1995** test files in the root suite.
2. **How many of those 1995 can observe this change**: grepped every one of them for an import of the changed module → exactly **1**, `scripts/__tests__/check-lucide-icon-record-names.test.ts`, which is run green above (34/34, verbose, each new test named). The four other repo references to the gate are prose comments, not imports.
3. **Invariance for the untouched files**: the diff, anchored to the branch point `ef2a3bd8d` (not two-dot `origin/main..HEAD`, which by now attributes four siblings' landed PRs to this branch), changes **two files, both under `scripts/`**. `scripts/` is not a workspace package and is in no package's `tsconfig` or `src`, so no package test can import it; nothing in `packages/`, `apps/` or `examples/` changed, and no untouched test's verdict can move.

On top of that single observer I ran the whole of `scripts/__tests__` — 77 files, 2216 tests — which is where the pins that govern this file live (`check-entry-guard`, `scripts-type-check`, the type-check- and lint-coverage gates). CI runs the full farm regardless.

New tests, all collected by name under `--reporter=verbose`:

```
✓ an icon on an UNTYPED child of a container that declares descent > goes RED, naming the child node and the container it answers to
✓ … > goes GREEN on a live name at the same site — and it was really judged
✓ … > reaches ARBITRARY nesting depth — the case a `items[].icon` path cannot express
✓ … > STOPS at a typed child — the child's own `type` still answers for it
✓ … > does NOT leak descent into a container that never declared it
✓ … > ERRORS rather than passing when a descent declaration reaches NOTHING
✓ this repository > really judges the untyped child items objectui#5992 opened up
✓ this repository > did NOT grow part 1 in the process — descent is a part-2 rule
✓ the gate is wired … > no longer carries the parenthetical objectui#5930 falsified
```

## No changeset, deliberately

The diff touches `scripts/` only — `scripts/check-lucide-icon-record-names.mjs` and its pin test. `scripts/` is not a workspace package and publishes nothing, so `check-changeset-presence.mjs` (which guards *published package source*) exits 0 either way and is not what decided this. What decided it is the precedent: the previous change to this very file, `94bc6e5a4 refactor(tooling): build the lucide gate's two lookup maps lazily`, carried no changeset, as does the commit this branch is cut from. The fixture under `examples/` was mutated only inside the ablations and is byte-identical to `HEAD` in the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_