### PR TITLE
fix(tooling): emit the dependency closure from check-doc-snippet-types --build-filter

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -649,8 +649,14 @@ rather than new capability.
 snippets import must exist as `dist/*.d.ts` first. The build is filtered to exactly those packages,
 and the filter is emitted by the gate itself (`node scripts/check-doc-snippet-types.mjs
 --build-filter`) rather than hand-maintained in the workflow — so it can never drift from what the
-documents import, and the cost grows only when coverage grows. This is deliberately **not** the
-per-PR full-repo build the 2026-08-16 ruling on
+documents import, and the cost grows only when coverage grows. Each emitted filter carries pnpm and
+turbo's dependency-closure suffix (`--filter=@object-ui/react...`), because the packages the
+documents import are not a buildable unit on their own: they depend on workspace packages no snippet
+names, and those have to exist first. Under `turbo run build` the suffix selects the same tasks
+`dependsOn: ["^build"]` already did; under `pnpm ... run build`, which selects exactly what it
+matches, it is the difference between a build that completes and one that dies on an import the
+reader never wrote ([#5911](https://github.com/objectstack-ai/objectui/issues/5911)). This is
+deliberately **not** the per-PR full-repo build the 2026-08-16 ruling on
 [#4846](https://github.com/objectstack-ai/objectui/issues/4846) rejected; see *Published Dist Gate*
 below.
 

--- a/scripts/__tests__/check-doc-snippet-types.test.ts
+++ b/scripts/__tests__/check-doc-snippet-types.test.ts
@@ -15,6 +15,7 @@ import {
   UNGATED_DOCS,
   analyze,
   blockingPreconditions,
+  buildFilterArgs,
   deriveDeclaredDependencyPaths,
   derivePackageTypePaths,
   findInstalledCopy,
@@ -478,6 +479,48 @@ describe('wiring — a script nothing runs is not a gate', () => {
       build,
       'invoked before its own build, the gate would red a healthy pull request on a precondition',
     ).toBeLessThan(invoke);
+  });
+
+  /**
+   * objectui#5911 — the emitted list must be BUILDABLE, not merely accurate.
+   *
+   * The set the gate computes is the packages the DOCUMENTS import. That is a
+   * true answer to a different question than "what do I build": those packages
+   * depend on workspace packages no snippet names, and without them the build
+   * the gate prescribes dies on an import the reader never wrote. Measured on
+   * this tree before the fix: `pnpm <bare list> run build` selected 21 packages
+   * and failed with `TS2307: Cannot find module '@object-ui/sdui-parser'`.
+   *
+   * The suffix is pinned rather than the list, because the list is supposed to
+   * move as coverage grows — that is the property `--build-filter` exists for.
+   */
+  it('emits the dependency-closure suffix on every filter, so the build it prescribes is complete', () => {
+    const args = buildFilterArgs(['@object-ui/react', '@object-ui/core']);
+    expect(args).toBe('--filter=@object-ui/core... --filter=@object-ui/react...');
+    for (const word of args.split(' ')) {
+      expect(word, 'a bare --filter= builds the package without what it depends on').toMatch(
+        /^--filter=\S+\.\.\.$/,
+      );
+    }
+  });
+
+  it('keeps the emission sorted and shell-safe — the workflow word-splits it unquoted', () => {
+    const args = buildFilterArgs(['@object-ui/types', '@object-ui/app-shell', '@object-ui/i18n']);
+    expect(args.split(' ')).toEqual([
+      '--filter=@object-ui/app-shell...',
+      '--filter=@object-ui/i18n...',
+      '--filter=@object-ui/types...',
+    ]);
+    expect(args, 'a glob or quote here would be re-interpreted by the runner shell').not.toMatch(
+      /["'`$*?]/,
+    );
+  });
+
+  it('names every package it is given, so the closure suffix never replaces a name', () => {
+    const names = ['@object-ui/react', '@object-ui/core', '@object-ui/i18n'];
+    const args = buildFilterArgs(names);
+    for (const name of names) expect(args).toContain(`--filter=${name}...`);
+    expect(args.split(' ')).toHaveLength(names.length);
   });
 
   it('is reachable by name from the workspace root', () => {

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -5,7 +5,8 @@
  * reader who copies it actually imports.
  *
  * Run:  node scripts/check-doc-snippet-types.mjs   (also `pnpm check:doc-snippets`)
- *       node scripts/check-doc-snippet-types.mjs --build-filter   (turbo filter args)
+ *       node scripts/check-doc-snippet-types.mjs --build-filter   (filter args for
+ *       turbo or pnpm; each carries the `...` dependency-closure suffix)
  * Exit: 0 = every covered snippet parses and type-checks, the harness proved
  *       itself on its own controls, and the coverage ledger is exact.
  *       1 = THE GATE RAN AND FOUND ERRORS. A snippet failed to parse or to
@@ -1082,18 +1083,56 @@ export function blockingPreconditions(findings) {
   );
 }
 
+/**
+ * The filter arguments that name the packages the covered snippets import, each
+ * carrying pnpm/turbo's DEPENDENCY-CLOSURE suffix `...` ("this package AND the
+ * packages it depends on").
+ *
+ * The closure suffix is why this is a function and not an inline `map`. The set
+ * this gate computes is the packages the DOCUMENTS import, which is not a
+ * buildable unit: a package the docs import pulls in workspace packages no
+ * snippet ever names, and those still have to be built before the imported one
+ * can compile. Emitting the bare names left that gap to the caller's tool to
+ * close by accident (objectui#5911):
+ *
+ *   - `turbo run build <args>` closed it silently, because this repository's
+ *     `build` task declares `dependsOn: ["^build"]`. Measured on this tree, the
+ *     bare list and the `...` list select the IDENTICAL 33 tasks, so the suffix
+ *     changes nothing for the workflow that consumes this — it is a no-op where
+ *     the closure was already right.
+ *   - `pnpm <args> run build` did NOT, because pnpm's `--filter` selects exactly
+ *     what it matches and runs each package's own script. Measured on this tree:
+ *     21 packages selected instead of 33, and the build died at
+ *     `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @object-ui/components` on
+ *     `TS2307: Cannot find module '@object-ui/sdui-parser'` — a workspace
+ *     package no snippet imports, so nothing put it in the list.
+ *
+ * Both spellings wear the same `--filter=` flag, so which one closes the gap was
+ * invisible at the point of use. Carrying the closure in the emitted list makes
+ * the answer independent of the tool the reader reaches for, which matters most
+ * for the reader who is here because the gate just told them to build something.
+ *
+ * @param {Iterable<string>} packages package names the covered snippets import
+ * @returns {string} space-separated `--filter=<pkg>...` words, sorted
+ */
+export function buildFilterArgs(packages) {
+  return [...packages].sort().map((n) => `--filter=${n}...`).join(' ');
+}
+
 function main() {
   const argv = process.argv.slice(2);
   const state = analyze({});
 
   if (argv.includes('--build-filter')) {
-    // Turbo filter arguments for exactly the packages the covered snippets
-    // import. Coverage grows -> the build grows, and nothing else does.
+    // Filter arguments for exactly the packages the covered snippets import,
+    // plus their dependency closure. Coverage grows -> the build grows, and
+    // nothing else does. Why the closure travels in the list: see
+    // `buildFilterArgs` above.
     // ⛔ This query answers from an UNBUILT tree by design and must keep exiting
     // 0 there: it is what the workflow runs to learn what to build, one step
     // BEFORE the build. Making it share the precondition exit would deadlock the
     // gate against its own build step.
-    process.stdout.write([...state.neededPackages].sort().map((n) => `--filter=${n}`).join(' '));
+    process.stdout.write(buildFilterArgs(state.neededPackages));
     process.stdout.write('\n');
     return 0;
   }


### PR DESCRIPTION
Fixes #5911

`scripts/check-doc-snippet-types.mjs --build-filter` emitted the packages the
covered documents import. That is a true answer to a different question than
"what do I build": those packages depend on workspace packages no snippet names,
and without them the build the gate prescribes dies on an import the reader never
wrote.

Each emitted filter now carries pnpm/turbo's dependency-closure suffix `...`.

## Premise check — the issue's example is stale, the class is live

The issue names `@object-ui/i18n` as the package missing from the list. That is
no longer true: coverage grew and `@object-ui/i18n` is emitted directly today.
The **closure gap itself is unchanged** — six workspace packages the emitted set
depends on are still absent from it:

```
@object-ui/collaboration  <- @object-ui/app-shell
@object-ui/react-runtime  <- @object-ui/components
@object-ui/sdui-parser    <- @object-ui/components
@object-ui/providers      <- @object-ui/fields, @object-ui/app-shell
@object-ui/permissions    <- @object-ui/app-shell, @object-ui/plugin-form, @object-ui/plugin-grid
@object-ui/mobile         <- @object-ui/plugin-grid, @object-ui/plugin-timeline
```

One more correction worth recording, because it changes what the fix is for. The
gate's printed remedy uses **turbo**, and turbo was never broken: this repo's
`build` task declares `dependsOn: ["^build"]`, so it supplied the closure all
along. Measured with `turbo run build --dry-run=json`, the bare list and the
closure list select the **identical 33 tasks** — `only in NEW: []`,
`only in OLD: []`. So the suffix is a **no-op for CI and for the printed
command**, and a fix for every other spelling of the same flag.

The gap is real on the **pnpm** spelling, which wears the same `--filter=` flag
and selects exactly what it matches. Which of the two closed the gap was
invisible at the point of use — that is the actual defect.

## The emitted list, before and after

Before (21 words, bare):

```
--filter=@object-ui/app-shell --filter=@object-ui/auth --filter=@object-ui/cli ... --filter=@object-ui/types
```

After (21 words, each carrying the closure suffix):

```
--filter=@object-ui/app-shell... --filter=@object-ui/auth... --filter=@object-ui/cli... ... --filter=@object-ui/types...
```

Package selection: `pnpm <bare> exec pwd` → **21** packages; `pnpm <closure> exec pwd` → **33**.

## The build pair — same command, same unbuilt start

Both runs started from a tree with `dists=0 tsbuildinfo=0` (fresh worktree for
the first; for the second, the dirs the first run built were removed and the
count re-measured at 0 before starting).

**OLD list — fails:**

```
$ pnpm $(bare list) --workspace-concurrency=2 run build
packages/components build: src/renderers/basic/div.tsx:10:32 - error TS2307: Cannot find module '@object-ui/sdui-parser' or its corresponding type declarations.
packages/components build: src/renderers/layout/react-page.tsx:45:36 - error TS2307: Cannot find module '@object-ui/react-runtime' or its corresponding type declarations.
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @object-ui/components@17.6.0 build: `vite build && node scripts/build-css.mjs`
EXIT=1
```

Same shape as the issue reported, with the package names moved — a workspace
package no snippet imports, so nothing put it in the list.

**NEW list — succeeds:**

```
$ pnpm $(closure list) --workspace-concurrency=2 run build
packages/app-shell build: Done
EXIT=0
```

`grep -c "TS2307\|ERR_PNPM"` over the new-list log: **0**.

## The gate returns a real verdict after that build

Not the precondition message — a verdict:

```
Semantic phase: 267 of 267 block(s) judged, 0 failed.

Every covered documentation snippet compiles against the built types.
```

`check:doc-snippets` exit **0**.

## Consumers of the emitted format — checked

`grep -rn build-filter` reaches four files. None pinned the bare spelling:

- `.github/workflows/doc-snippet-types.yml` — consumes the list through
  `turbo run build`, unquoted so it word-splits. Unchanged: turbo selects the
  same 33 tasks either way (measured above), and the suffix introduces no
  character the runner shell re-interprets (pinned by a new test).
- `scripts/__tests__/check-doc-snippet-types.test.ts` — the three assertions
  near the old format (`--filter=@object-ui/core --filter=@object-ui/react`) pin
  a **stubbed** gate's stdout for objectui#6221's shell tests, not the real
  gate's emission. They still pass unchanged; the stub is testing the step's
  handling of a failure, not the format.
- `content/docs/guide/ci-cd-pipeline.md` — prose; updated in this commit to say
  what the suffix is for and why it is a no-op under turbo.
- the gate's own header — updated.

## Tests

The emission moves into an exported `buildFilterArgs` so the **suffix** is
pinned rather than the **list**, which is supposed to move as coverage grows.
Three new tests, collected by name under `--reporter=verbose`:

```
✓ emits the dependency-closure suffix on every filter, so the build it prescribes is complete
✓ keeps the emission sorted and shell-safe — the workflow word-splits it unquoted
✓ names every package it is given, so the closure suffix never replaces a name
Test Files  1 passed (1)
     Tests  44 passed (44)
```

**Reverse-verification** (from the committed state, so restoring is a checkout).
Stripping the `...` from the emission — mutation confirmed on disk before the
run: closure marker `1 → 0`, injected bare form `1`, `git diff --stat` one line
— turns exactly those three red and nothing else:

```
× emits the dependency-closure suffix on every filter, so the build it prescribes is complete
× keeps the emission sorted and shell-safe — the workflow word-splits it unquoted
× names every package it is given, so the closure suffix never replaces a name
Test Files  1 failed (1)
     Tests  3 failed | 41 passed (44)
```

No rebuild leg applies: the suite imports the gate as `../check-doc-snippet-types.mjs`,
a relative path to plain JS source, so no package `exports` and no `dist/` sit
between the mutation and the run. Restore leg confirmed: `git status --short`
clean, marker back to `1`, emission carrying `...`.

## Gates, all on `3e9c50a63` (the final commit)

| gate | verdict line |
|---|---|
| `pnpm exec vitest run scripts/__tests__` | `Test Files  77 passed (77)` / `Tests  2210 passed (2210)` |
| `pnpm type-check:scripts` | exit 0 — ran `tsc -p tsconfig.scripts.json` (echoed as positive control) |
| `pnpm lint:root` (UNNARROWED) | `✖ 28 problems (0 errors, 28 warnings)` — exit 0, warnings all pre-existing |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 5178 tracked text file(s); skipped 85 binary).` |
| `pnpm check:doc-snippets` | `Every covered documentation snippet compiles against the built types.` |
| `pnpm check:doc-types` | `✅ Every documented component type is registered.` |
| `pnpm check:doc-fences` | `✅ check:doc-fences — every TypeScript block in 223 document(s) is fenced ts/tsx/typescript…` |
| `pnpm docs:check-links` | `Links are valid across 15 scan roots.` |
| `pnpm check:skills-paths` | `✅ check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined).` |

Every exit code was captured by redirect before any pipe.

## Changeset

None owed, and this is the gate's own verdict on this diff rather than an
assumption:

```
$ GITHUB_BASE_REF=main node scripts/check-changeset-presence.mjs
Compared the working tree with a76b18cf2 (merge-base with origin/main): 3 file(s) changed,
0 of them published source of a package the release covers, 0 under a package changesets
ignores, 0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

Exit 0. No label applied — `skip-changeset` does not exist in this repository.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_