### PR TITLE
fix(tooling): census `ui:icon` in the lucide gate, repair the three retired spellings it finds

### DIFF
--- a/examples/schema-catalog/src/schemas/marketing/call-to-action.json
+++ b/examples/schema-catalog/src/schemas/marketing/call-to-action.json
@@ -51,7 +51,7 @@
               "children": [
                 {
                   "type": "icon",
-                  "icon": "check-circle",
+                  "icon": "circle-check-big",
                   "className": "h-4 w-4"
                 },
                 {
@@ -67,7 +67,7 @@
               "children": [
                 {
                   "type": "icon",
-                  "icon": "check-circle",
+                  "icon": "circle-check-big",
                   "className": "h-4 w-4"
                 },
                 {
@@ -83,7 +83,7 @@
               "children": [
                 {
                   "type": "icon",
-                  "icon": "check-circle",
+                  "icon": "circle-check-big",
                   "className": "h-4 w-4"
                 },
                 {

--- a/scripts/__tests__/check-lucide-icon-record-names.test.ts
+++ b/scripts/__tests__/check-lucide-icon-record-names.test.ts
@@ -242,6 +242,63 @@ describe('an authored icon name reaching a record-reading resolver', () => {
   });
 });
 
+/**
+ * `ui:icon` — the node type whose whole job is naming a glyph, and the one that
+ * could not be censused until objectui#5631 moved its key from `name` (the SDUI
+ * IDENTITY key) to `icon`. Until objectui#6009 added its census entry, its
+ * authored names were SEEN and DECLINED: 96 of them, three carrying a retired
+ * spelling that rendered the placeholder.
+ *
+ * Pinned separately from `button` above because the two answer part 1
+ * differently, and that difference is the reasoning the entry rests on:
+ * `icon.tsx` imports the `icons` record DIRECTLY, so it is a part-1 resolver in
+ * its own right, where `dropdown-menu.tsx` routes through `resolveIcon` and
+ * correctly stays out (objectui#5992).
+ */
+describe('the `ui:icon` node type', () => {
+  const iconNode = (icon: string): string => JSON.stringify({ type: 'icon', icon }, null, 2);
+
+  it('goes RED on a retired spelling, naming `icon.tsx` as the resolver', () => {
+    const result = judge('ui-icon-red', {
+      files: { 'examples/catalog/cta.json': iconNode('check-circle') },
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.violations).toHaveLength(1);
+    const [violation] = result.violations;
+    expect(violation.site).toBe('icon');
+    expect(violation.resolver).toBe('packages/components/src/renderers/basic/icon.tsx');
+    expect(violation.where).toBe('examples/catalog/cta.json $.icon');
+    // Derived by object identity, not read off a list: lucide's `CheckCircle`
+    // export IS `CircleCheckBig`, so `circle-check-big` is the spelling that
+    // keeps the SAME glyph. `circle-check` is a different one.
+    expect(violation.detail).toContain('write `circle-check-big`');
+  });
+
+  it('goes GREEN on the live spelling — and the name was really judged', () => {
+    const result = judge('ui-icon-green', {
+      files: { 'examples/catalog/cta.json': iconNode('circle-check-big') },
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.counters.authoredJudged).toBe(1);
+  });
+
+  it('declares NO descent — the renderer resolves one name and never walks children', () => {
+    // A `descendants: true` here would carry a `min` that ERRORS when it
+    // reaches nothing, and there is nothing for it to reach: `icon.tsx`
+    // returns a single element.
+    expect(RECORD_READING_TYPES.icon.paths).toEqual(['icon']);
+    // `'descendants' in …`, not `.descendants` — the same idiom the descent
+    // test below uses. `RECORD_READING_TYPES` is a plain object literal, so the
+    // key is absent from `icon`'s INFERRED TYPE, and reading it does not
+    // type-check. Asserting absence of the key is also the stronger fact.
+    expect('descendants' in RECORD_READING_TYPES.icon).toBe(false);
+    expect(RECORD_READING_TYPES.icon.resolver).toBe('packages/components/src/renderers/basic/icon.tsx');
+  });
+});
+
 // ── 3. it is not a blanket string scan ───────────────────────────────────────
 
 describe('a name whose resolver this gate cannot identify is declined, not flagged', () => {
@@ -539,6 +596,25 @@ describe('this repository', () => {
     expect(repoResult.discovered.record).toHaveLength(8);
     expect(repoResult.discovered.record).not.toContain('packages/components/src/renderers/overlay/dropdown-menu.tsx');
     expect(RECORD_READING_TYPES['dropdown-menu'].resolver).toContain('renderers/action/resolve-icon.ts');
+  });
+
+  it('really judges the `ui:icon` nodes objectui#6009 opened up', () => {
+    // The card's whole subject is a population that was SEEN and DECLINED while
+    // the gate stayed green, so "no violations" is not evidence on its own.
+    // Measured on this tree, the census entry moved 96 names from `declined` to
+    // `judged`; a floor well under that fails loudly if the walk stops reaching
+    // the corpus, without pinning a figure the catalog is free to move.
+    expect(Object.keys(RECORD_READING_TYPES)).toContain('icon');
+    expect(repoResult.counters.authoredJudged).toBeGreaterThan(100);
+  });
+
+  it('did NOT grow part 1 for `ui:icon` either — it was ALREADY a declared resolver', () => {
+    // The asymmetry against dropdown-menu, pinned: `icon.tsx` imports the
+    // `icons` record directly and has been in part 1's census since
+    // objectui#5633's own discovery run. objectui#6009 supplies only the part-2
+    // fact — which `type` sends names there — so this count must not move.
+    expect(repoResult.discovered.record).toContain('packages/components/src/renderers/basic/icon.tsx');
+    expect(repoResult.discovered.record).toHaveLength(8);
   });
 
   it('carries more record-reading resolvers than objectui#5633 catalogued by hand', () => {

--- a/scripts/check-lucide-icon-record-names.mjs
+++ b/scripts/check-lucide-icon-record-names.mjs
@@ -97,6 +97,25 @@
  *    `renderers/action/resolve-icon.ts`, which is already declared. Part 1
  *    stays at eight resolvers; this is a part-2 rule, not a census change.
  *
+ *    ── Re-taken at objectui@e3784607f, and UNCHANGED ──────────────────────
+ *    objectui#6009 censused the `icon` TYPE, which looks like it should move
+ *    this table and does not: the table counts UNTYPED names, and a
+ *    `type: 'icon'` node is typed, so the two populations are disjoint. The
+ *    per-container figures above re-measure identically. Recorded rather than
+ *    left implicit — "the numbers did not move" is a measurement, and the next
+ *    reader should not have to re-derive that it was taken.
+ *
+ *    ⚠️ SCOPE, which the count above does not carry on its face: it is
+ *    measured over `examples/schema-catalog/`, while this gate SCANS
+ *    `packages/`, `apps/` and `examples/`. Over the full scan roots the same
+ *    walk finds 76 untyped names across NINE containers — the extra 15 all in
+ *    `packages/types/examples/` (`tree-view` +6, `timeline` +3, plus `list` 3
+ *    and `sidebar` 3, two containers this table does not name at all). Both
+ *    extra containers were read: `data-display/list.tsx` and
+ *    `navigation/sidebar.tsx` never read `icon`, so those names reach no
+ *    resolver and decline correctly. The table is right about what it judges;
+ *    it is simply not the whole unjudged census.
+ *
  * 3. ANCHORED MAPS — the first-party const maps that feed a record-reading
  *    resolver but are not authored nodes. This is the population the retired
  *    local pins covered, generalised: each anchor carries a minimum entry
@@ -197,6 +216,21 @@ export const RECORD_READING_TYPES = {
     min: 1,
     resolver: 'packages/components/src/renderers/action/resolve-icon.ts (via renderers/overlay/dropdown-menu.tsx)',
   },
+  // `ui:icon` — the node type whose WHOLE job is naming a glyph. It could not
+  // have been censused before objectui#5631: that renderer named its glyph with
+  // `name`, the SDUI IDENTITY key, and every path in this table is an `icon`
+  // path. Post-#5631 it reads `schema.icon` straight out of lucide's runtime
+  // record (`import { icons } from 'lucide-react'` + `(icons as any)[key]`), so
+  // it is a DIRECT record reader, not a `resolveIcon` router — which is why
+  // part 1's `DECLARED_RECORD_READERS` already carries it and dropdown-menu's
+  // does not. Part 1 knowing a module and part 2 knowing its `type` are two
+  // independent facts; this entry supplies the second (objectui#6009).
+  //
+  // NO `descendants`: the renderer resolves exactly one name and returns a
+  // single element. It never walks `children`, so there is no untyped-child
+  // population for a descent to reach — and a descent that reaches nothing is
+  // an ERROR here, by the non-vacuity rule below.
+  'icon': { paths: ['icon'], resolver: 'packages/components/src/renderers/basic/icon.tsx' },
   'view-switcher': { paths: ['views[].icon', 'viewActions[].icon'], resolver: 'packages/plugin-view/src/ViewSwitcher.tsx' },
 };
 


### PR DESCRIPTION
Fixes #6009

`ui:icon` has resolved `schema.icon` straight out of lucide's runtime `icons` record since #5631 — `import { icons } from 'lucide-react'` plus `(icons as any)[mappedIconName]` — which makes it exactly the resolver class `check-lucide-icon-record-names.mjs` exists for. Its `type` was absent from part 2's `RECORD_READING_TYPES`, so its 96 authored glyph names were **seen and declined** while the gate stayed green. That is the failure shape this gate was built to end, occurring one level up inside its own census: not a gate that fails, a gate whose judged population quietly shrank relative to what now reaches a resolver.

Both halves land together because they cannot separate: the census entry alone turns the gate red on three nodes, and that red is the non-vacuity proof.

## Re-derived against post-#6277 `main`

The card was written before PR #6277 landed at `e3784607f`, and its line references and counters were stale. Branch point contains `e3784607f` (`git merge-base --is-ancestor` confirmed). Everything below is re-measured against the file as it now is.

| card said | actually |
|---|---|
| `check-circle` at lines ~53 / 69 / 85 | lines **54 / 70 / 86** |
| `judged: 30 \| declined: 254/350` | `judged: 33 \| declined: 347` at `e3784607f` (#6277's own landing moved judged 30→33) |
| replacement is `circle-check` | **`circle-check-big`** — see below |
| census count in the OK line rises 8 → 9 | **stays 8**, correctly — see part 1 |

The card's central measurement held exactly: **+96**.

## Part 1 needed no change, and got none

`icon.tsx` imports the `icons` record **directly** and indexes it, so `DECLARED_RECORD_READERS` has carried it since #5633's own discovery run — it is already in the discovered set on `main`. This is the asymmetry against `dropdown-menu.tsx`, which routes through `resolveIcon` and correctly stays out (the finding #5992 recorded).

Part 1 knowing a *module* and part 2 knowing which *`type`* sends names to it are two independent facts. This PR supplies only the second. `discovered.record` stays at **8** and is pinned by a new test, so a future change that moved the wrong part of the gate fails loudly.

The OK line's `N record-reading resolvers` reads `discovered.record.length` (part 1's modules), not the size of `RECORD_READING_TYPES` — which is why it does not move. `RECORD_READING_TYPES` goes 9 → 10 entries; that count is not printed anywhere.

## No `descendants`

Read off the renderer, the way every `paths` entry in that table was: `icon.tsx` resolves one name and returns a single element — the resolved `Icon` component, or the `SquareDashed` placeholder. It never walks `children`. So there is no untyped-child population for a descent to reach — and under the non-vacuity rule a descent that reaches nothing is an **error**, not a shrug.

## The repair is `circle-check-big`, derived by identity

The dispatch proposed `circle-check`. Probed against the installed lucide-react 1.31.0 instead of taken on trust:

```
CheckCircle export exists:               true
CheckCircle === CircleCheckBig :         true
CheckCircle === CircleCheck    :         false
record has CheckCircle   : false
record has CircleCheck   : true
record has CircleCheckBig: true
```

`check-circle`'s retired export **is** `CircleCheckBig`. `circle-check` is a live key naming a *different glyph*, so that repair would have silently changed the rendered artwork while going green. `circle-check-big` keeps the same glyph — and is what the gate's own identity derivation prints, unprompted, in the red output below.

## RED, then GREEN

Census entry alone — `EXIT=1`, all three sites named:

```
FAIL  lucide icon names

    - examples/schema-catalog/src/schemas/marketing/call-to-action.json $.children[0].children[3].children[0].children[0].icon  [icon]
      "check-circle" -> `CheckCircle` is not a key of the runtime `icons` record. lucide keeps it only as a DEPRECATED EXPORT of the same glyph — write `circle-check-big` (the spelling the record carries).
      Resolved through: packages/components/src/renderers/basic/icon.tsx
    - … $.children[0].children[3].children[1].children[0].icon  [icon]   (same diagnosis)
    - … $.children[0].children[3].children[2].children[0].icon  [icon]   (same diagnosis)
```

Counters across the two steps:

| | `judged` | `declined` | anchored | OK-line total | resolvers |
|---|---|---|---|---|---|
| `e3784607f` baseline | 33 | 347 | 34 | 67 | 8 |
| + census entry (RED) | **129** | **251** | 34 | — | 8 |
| + fixture repair (GREEN) | **129** | **251** | 34 | **163** | 8 |

`+96 / −96`, exactly the population the card measured, and `anchoredJudged` and the resolver count both hold still.

## The header's container table: re-taken, and unchanged

#6277 re-measured it at `ef2a3bd8d` as **61 untyped names across 7 containers**. Re-taken at `e3784607f`: **identical**, per-container figures and all. It looks like this change should move it and it does not — the table counts **untyped** names, and a `type: 'icon'` node is typed, so the two populations are disjoint. Recorded in the header rather than left implicit, following the #6277/#6260 pattern of naming the commit rather than editing figures in place.

Re-measuring also surfaced a scope caveat the count did not carry on its face, now written into the header: the table is measured over `examples/schema-catalog/`, while the gate **scans** `packages/`, `apps/` and `examples/`. Over the full scan roots the same walk finds **76 untyped names across 9 containers** — the extra 15 all in `packages/types/examples/` (`tree-view` +6, `timeline` +3, plus `list` 3 and `sidebar` 3, two containers the table does not name at all). Both extra containers were read: `data-display/list.tsx` and `navigation/sidebar.tsx` never read `icon`, so those names reach no resolver and decline correctly. All 15 were also checked against the record and are live spellings, so nothing is hiding there — the table is right about what it judges, it is simply not the whole unjudged census.

## Tests

Five new tests, and an ablation showing they are not vacuous. Deleting the census entry (mutation confirmed on disk, anchored grep `1 → 0`, restored under a `trap`):

```
 × the `ui:icon` node type > goes RED on a retired spelling, naming `icon.tsx` as the resolver
 × the `ui:icon` node type > goes GREEN on the live spelling — and the name was really judged
 × the `ui:icon` node type > declares NO descent — the renderer resolves one name and never walks children
 × this repository > really judges the `ui:icon` nodes objectui#6009 opened up
 ✓ this repository > did NOT grow part 1 for `ui:icon` either — it was ALREADY a declared resolver
      Tests  4 failed | 35 passed (39)
```

The fifth staying green is the correct reading, not a hole: it asserts that `icon.tsx` was *already* a part-1 resolver, which is true independently of the part-2 entry. Restore leg confirmed on disk (entry back, tree clean against `HEAD`, gate green).

`type-check:scripts` earned its keep here — it caught `expect(RECORD_READING_TYPES.icon.descendants)` as `TS2339`, since `RECORD_READING_TYPES` is a plain object literal and the key is absent from `icon`'s inferred type. Fixed at the assertion using the file's own `'descendants' in …` idiom, which also asserts the stronger fact (the key is absent, not merely `undefined`) — not by widening the type to accommodate the test.

#6277's 9 tests all still pass.

## Verification — union re-run on the final commit `1443fcbf0`

Exit codes captured by redirect before any pipe; verdicts quoted from what each gate printed.

| gate | exit | verdict |
|---|---|---|
| `check:icon-record-names` | 0 | `OK  lucide icon names: 163 authored/declared names reaching 8 record-reading resolvers are live` `icons` `keys` |
| `type-check:scripts` | 0 | clean |
| `lint:root` **unnarrowed** | 0 | `✖ 28 problems (0 errors, 28 warnings)` — all pre-existing `no-explicit-any` warnings |
| `check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 5178 tracked text file(s); skipped 85 binary).` |
| `pnpm exec vitest run scripts/__tests__` | 0 | `Test Files 77 passed (77)` · `Tests 2223 passed (2223)` |
| `check-changeset-presence` | 0 | `✅  No source of a released package changed in this range, so no changeset is owed.` |

No narrowing anywhere — `lint:root` ran unnarrowed and the scripts suite ran whole.

## Changeset

**None**, on the presence gate's own verdict rather than on my reading of `examples/`: `@object-ui/example-schema-catalog` is `private: true` **and** matches `@object-ui/example-*` in `.changeset/config.json`'s `ignore` list. The gate reports `3 file(s) changed, 0 of them published source of a package the release covers`. `scripts/` needs none. No `skip-changeset` label was created or applied — that label does not exist in this repo.

## Not addressed here

- #5935 — the resolver-consolidation card. `ui:icon` being a record-reading site is an input to its table; out of scope: #5935 remains open.
- #5622 / #5586 — the retired-spelling family. This PR repairs the three instances the new census entry surfaces, and nothing else.

---
_Generated by [Claude Code](https://claude.ai/code/session_019b5UBNMtTzKbVtZZGvFuxe)_