### PR TITLE
fix(plugin-detail): resolve `headerColor` through literal Tailwind classes, not a template literal

### DIFF
--- a/.changeset/6178-detail-section-header-color.md
+++ b/.changeset/6178-detail-section-header-color.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`DetailSection` now resolves `section.headerColor` through a lookup of complete
+Tailwind class literals instead of building `bg-` + the authored value as a
+template literal (objectui#6178).
+
+Tailwind v4 has no runtime — it builds the stylesheet by scanning source text
+for complete class tokens, and this workspace ships no `bg-*` safelist — so the
+old expression contributed nothing to the compiled CSS. Measured, not assumed:
+compiling `apps/console/src/index.css` with that expression deleted produced a
+byte-identical stylesheet (same sha256). An authored value styled the header
+only when some other source file happened to author the identical class
+literally, which is why both documented examples appeared to work: `bg-muted`
+occurs 691 times and `bg-primary/10` 63 times elsewhere in the workspace. That
+liveness was accidental and moved with unrelated edits in unrelated packages.
+
+The shape matches the sibling this repo already solved the same way —
+`useRowColor`'s `COLOR_TO_CLASS` in `@object-ui/plugin-grid`:
+
+- a lookup of literal, tint-only design-system classes: `muted`, `muted/50`,
+  `accent`, `primary/10`, `secondary/10`, `destructive/10`. Both values the
+  `@object-ui/types` mirror documents (`muted`, `primary/10`) are in it, so
+  nothing that rendered before renders differently now;
+- a value that is already a complete `bg-*` class is passed through untouched.
+  This is new — `headerColor: 'bg-muted'` previously produced the meaningless
+  `bg-bg-muted`;
+- anything else contributes no class at all, instead of a fabricated one.
+
+Behaviour change to be aware of: an undocumented bare suffix outside the
+vocabulary (say `headerColor: 'blue-100'`) no longer reaches the DOM as
+`bg-blue-100`. It rendered before only where another file happened to author
+that exact class; write it as the complete class (`headerColor: 'bg-blue-100'`)
+to keep it, on the same terms as any `className` a schema carries. No value is
+rejected and the declared type is unchanged.
+
+`headerColor` remains undeclared on the strict `@objectstack/spec`
+`record:details` section schema, which refuses it today on the strength of this
+defect (objectstack#11661). Declaring it, and with which vocabulary, is a
+separate spec decision.

--- a/packages/plugin-detail/src/DetailSection.tsx
+++ b/packages/plugin-detail/src/DetailSection.tsx
@@ -34,6 +34,7 @@ import { useSafeFieldLabel } from '@object-ui/react';
 import { PermissionFacetLink } from './renderers/PermissionFacetLink';
 import { NON_EDITABLE_SYSTEM_FIELDS } from './systemFields';
 import { InlineFieldInput } from './InlineFieldInput';
+import { headerColorClass } from './headerColor';
 import {
   enrichDetailField,
   isComputedFieldType,
@@ -510,7 +511,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
     return (
       <Card className={cn(section.showBorder === false ? 'border-none shadow-none' : '', className)}>
         {section.title && (
-          <CardHeader className={cn('py-3 px-4 sm:py-4 sm:px-6', section.headerColor && `bg-${section.headerColor}`)}>
+          <CardHeader className={cn('py-3 px-4 sm:py-4 sm:px-6', headerColorClass(section.headerColor))}>
             <CardTitle className="flex items-center justify-between text-base font-semibold tracking-tight">
               <div className="flex items-center gap-2">
                 {section.icon && <SectionIcon name={section.icon} />}
@@ -539,7 +540,7 @@ export const DetailSection: React.FC<DetailSectionProps> = ({
         <CollapsibleTrigger asChild>
           <CardHeader className={cn(
             "py-3 px-4 sm:py-4 sm:px-6 cursor-pointer hover:bg-muted/50 transition-colors",
-            section.headerColor && `bg-${section.headerColor}`
+            headerColorClass(section.headerColor)
           )}>
             <CardTitle className="flex items-center justify-between text-base font-semibold tracking-tight">
               <div className="flex items-center gap-2">

--- a/packages/plugin-detail/src/__tests__/DetailSection.headerColor.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.headerColor.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DetailSection } from '../DetailSection';
+import type { DetailViewSection } from '@object-ui/types';
+
+/**
+ * objectui#6178 — `headerColor` reached the DOM as a template-literal Tailwind
+ * class, which the v4 source scan never sees as a complete token, so the class
+ * had no rule behind it unless another file happened to author the same class
+ * literally.
+ *
+ * WHAT THIS FILE CAN AND CANNOT SHOW. It renders the real `DetailSection` and
+ * inspects the class list the header receives. That proves which class string
+ * reaches the DOM; it proves NOTHING about whether Tailwind emitted a rule for
+ * it — asserting a `className` is exactly the blind instrument this defect
+ * hides behind. The CSS-generation half is `headerColor.test.ts`, which asks
+ * the Tailwind design system for the rule and reads this module's source text
+ * the way the scanner does. Neither file alone is the evidence.
+ */
+
+const TITLE = 'Billing';
+
+const baseSection = (extra: Partial<DetailViewSection>): DetailViewSection =>
+  ({ title: TITLE, fields: [{ name: 'amount', label: 'Amount' }], ...extra }) as DetailViewSection;
+
+/**
+ * The header element, located by the two padding classes `DetailSection`
+ * passes to `CardHeader` on both render branches. `getBy`-style: it throws
+ * when the header did not render at all, so a negative assertion below cannot
+ * pass vacuously against a header that is not on screen.
+ */
+function headerOf(container: HTMLElement): HTMLElement {
+  const matches = Array.from(container.querySelectorAll<HTMLElement>('.py-3.px-4'));
+  expect(matches, 'exactly one section header should render').toHaveLength(1);
+  return matches[0];
+}
+
+const classesOf = (el: HTMLElement) => el.className.split(/\s+/).filter(Boolean);
+
+describe('DetailSection headerColor -> a class the stylesheet can carry (objectui#6178)', () => {
+  // ---- the instrument, before anything is asserted with it ----------------
+  it('control: the header renders, carries its base classes, and shows the title', () => {
+    const { container, getByText } = render(
+      <DetailSection section={baseSection({})} data={{ amount: 1 }} />,
+    );
+    const header = headerOf(container);
+    expect(getByText(TITLE)).toBeTruthy();
+    expect(classesOf(header)).toEqual(expect.arrayContaining(['py-3', 'px-4', 'sm:px-6']));
+    // No headerColor authored -> no background utility at all.
+    expect(classesOf(header).filter((c) => c.startsWith('bg-'))).toEqual([]);
+  });
+
+  describe.each([
+    ['non-collapsible (titled Card)', {}],
+    ['collapsible (CollapsibleTrigger header)', { collapsible: true }],
+  ])('%s', (_label, extra) => {
+    it('a mapped token renders its literal class', () => {
+      const { container, getByText } = render(
+        <DetailSection section={baseSection({ ...extra, headerColor: 'muted' })} data={{ amount: 1 }} />,
+      );
+      const header = headerOf(container);
+      expect(getByText(TITLE)).toBeTruthy(); // positive probe: the header is real
+      expect(classesOf(header)).toContain('bg-muted');
+    });
+
+    it('the second documented example (`primary/10`) renders its literal class', () => {
+      const { container } = render(
+        <DetailSection
+          section={baseSection({ ...extra, headerColor: 'primary/10' })}
+          data={{ amount: 1 }}
+        />,
+      );
+      expect(classesOf(headerOf(container))).toContain('bg-primary/10');
+    });
+
+    it('a value that is already a `bg-*` class passes through, not doubled', () => {
+      const { container } = render(
+        <DetailSection
+          section={baseSection({ ...extra, headerColor: 'bg-accent' })}
+          data={{ amount: 1 }}
+        />,
+      );
+      const classes = classesOf(headerOf(container));
+      expect(classes).toContain('bg-accent');
+      // The old concatenation produced `bg-bg-accent` for this input.
+      expect(classes).not.toContain('bg-bg-accent');
+    });
+
+    it('an unmapped value contributes no class at all — never a fabricated one', () => {
+      const { container, getByText } = render(
+        <DetailSection
+          section={baseSection({ ...extra, headerColor: 'not-a-token' })}
+          data={{ amount: 1 }}
+        />,
+      );
+      const header = headerOf(container);
+      // Positive probe first: the header IS rendered, so the two negative
+      // assertions below are about a real element.
+      expect(getByText(TITLE)).toBeTruthy();
+      const classes = classesOf(header);
+      expect(classes).toContain('py-3');
+      expect(classes).not.toContain('bg-not-a-token');
+      expect(classes.filter((c) => c.startsWith('bg-'))).toEqual([]);
+    });
+
+    it('an inherited Object.prototype key is not a vocabulary entry', () => {
+      const { container } = render(
+        <DetailSection
+          section={baseSection({ ...extra, headerColor: 'constructor' })}
+          data={{ amount: 1 }}
+        />,
+      );
+      const classes = classesOf(headerOf(container));
+      expect(classes.filter((c) => c.startsWith('bg-'))).toEqual([]);
+      expect(classes.some((c) => c.includes('Object'))).toBe(false);
+    });
+  });
+});

--- a/packages/plugin-detail/src/__tests__/headerColor.test.ts
+++ b/packages/plugin-detail/src/__tests__/headerColor.test.ts
@@ -1,0 +1,164 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { __unstable__loadDesignSystem } from 'tailwindcss';
+import { headerColorClass, headerColorVocabulary } from '../headerColor';
+
+/**
+ * objectui#6178 — the CSS-GENERATION half of the fix.
+ *
+ * `DetailSection.headerColor.test.tsx` proves which class string reaches the
+ * DOM. That is not the property this defect is about: the previous code put
+ * `bg-<value>` in the DOM too, and a rendering assertion was green the whole
+ * time it generated no CSS. Tailwind v4 emits a rule only when BOTH hold —
+ *
+ *   1. the class appears as a COMPLETE token in text the `@source` scan reads,
+ *   2. the class is a utility the design system can actually build.
+ *
+ * so both are asserted here, against the two artifacts that decide them: the
+ * module's own source text, and Tailwind's design system loaded on this
+ * workspace's real `@theme`.
+ *
+ * What this file still cannot show: it does not run the scanner (that lives in
+ * `@tailwindcss/oxide`, which this workspace does not declare at the root) and
+ * it does not verify any app's `@source` globs. It asserts the token property
+ * the scanner requires, on the file the globs cover.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+const moduleSource = fs.readFileSync(path.join(here, '..', 'headerColor.ts'), 'utf8');
+const callSiteSource = fs.readFileSync(path.join(here, '..', 'DetailSection.tsx'), 'utf8');
+
+/** Every class the vocabulary can put in the DOM. */
+const vocabularyClasses = Object.values(headerColorVocabulary);
+
+/**
+ * The workspace theme, as shipped. `@object-ui/components`' `index.css` is the
+ * one `@theme` block every consuming app loads (see `skills/objectui/rules/
+ * styling.md`), so a token this vocabulary spends has to be defined there —
+ * `bg-accent` is not a stock Tailwind utility, it exists only because that
+ * block defines `--color-accent`.
+ */
+function themeBlock(): string {
+  const css = fs.readFileSync(path.join(repoRoot, 'packages/components/src/index.css'), 'utf8');
+  const start = css.indexOf('@theme {');
+  expect(start, 'components/src/index.css should declare a @theme block').toBeGreaterThan(-1);
+  let depth = 0;
+  for (let i = css.indexOf('{', start); i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}' && --depth === 0) return css.slice(start, i + 1);
+  }
+  throw new Error('unterminated @theme block');
+}
+
+async function designSystem() {
+  const twEntry = path.join(repoRoot, 'node_modules/tailwindcss/index.css');
+  const twDir = path.dirname(fs.realpathSync(twEntry));
+  return __unstable__loadDesignSystem(`@import "tailwindcss";\n${themeBlock()}\n`, {
+    base: repoRoot,
+    loadStylesheet: async (id: string, base: string) => {
+      const file = id === 'tailwindcss'
+        ? path.join(twDir, 'index.css')
+        : id.startsWith('tailwindcss/')
+          ? path.join(twDir, id.slice('tailwindcss/'.length))
+          : path.resolve(base, id);
+      return { base: path.dirname(file), path: file, content: fs.readFileSync(file, 'utf8') };
+    },
+  });
+}
+
+describe('headerColor — the resolver', () => {
+  it('maps the two values the @object-ui/types mirror documents', () => {
+    // These are the examples on `DetailViewSection.headerColor`. Both worked
+    // before this module — by collision with other files' literal classes —
+    // so the fix has to keep them working, not merely stop lying.
+    expect(headerColorClass('muted')).toBe('bg-muted');
+    expect(headerColorClass('primary/10')).toBe('bg-primary/10');
+  });
+
+  it('passes a value that is already a `bg-*` class through untouched', () => {
+    expect(headerColorClass('bg-accent')).toBe('bg-accent');
+    expect(headerColorClass('bg-[color:var(--brand)]')).toBe('bg-[color:var(--brand)]');
+  });
+
+  it('returns undefined rather than fabricating a class', () => {
+    for (const input of [undefined, '', '   ', 'not-a-token', 'blue-100', 'muted-'])
+      expect(headerColorClass(input)).toBeUndefined();
+  });
+
+  it('does not hand back an inherited Object.prototype member', () => {
+    for (const input of ['constructor', 'toString', 'hasOwnProperty', '__proto__'])
+      expect(headerColorClass(input)).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace before looking up', () => {
+    expect(headerColorClass('  muted  ')).toBe('bg-muted');
+  });
+});
+
+describe('headerColor — (1) the scanner can extract every class it can emit', () => {
+  it('the vocabulary is non-empty and every entry is a complete `bg-` class', () => {
+    expect(vocabularyClasses.length).toBeGreaterThan(0);
+    for (const cls of vocabularyClasses) {
+      expect(cls.startsWith('bg-')).toBe(true);
+      // A complete token, not a fragment awaiting concatenation.
+      expect(cls).not.toMatch(/[${}`\s]/);
+    }
+  });
+
+  it('every class appears VERBATIM in the module source the @source glob reads', () => {
+    // This is the property the v4 extractor needs and the old code lacked.
+    for (const cls of vocabularyClasses) expect(moduleSource).toContain(`'${cls}'`);
+  });
+
+  it('neither the module nor the call sites build a class by interpolation', () => {
+    // The regression pin. `bg-` + an interpolation is never a complete token,
+    // so it contributes nothing to the stylesheet — measured on the console
+    // build, deleting the old expression left the compiled CSS byte-identical.
+    // Scoped to the colour-utility prefixes: an interpolated React `key` or
+    // DOM id is not this defect, and four of them live in sibling files here.
+    const interpolatedUtility =
+      /`(?:bg|text|border|ring|from|via|to|fill|stroke|shadow|outline|decoration|divide|placeholder)-\$\{/;
+    for (const [name, src] of [['headerColor.ts', moduleSource], ['DetailSection.tsx', callSiteSource]] as const) {
+      expect(src, `${name} must not interpolate a Tailwind class`).not.toMatch(interpolatedUtility);
+    }
+    // …and the call sites do go through the resolver, so the check above is
+    // not passing because `headerColor` stopped being read at all.
+    expect(callSiteSource.match(/headerColorClass\(section\.headerColor\)/g) ?? []).toHaveLength(2);
+  });
+});
+
+describe('headerColor — (2) Tailwind emits a rule for every class it can emit', () => {
+  it('the instrument answers NO for a non-utility (control)', async () => {
+    const ds = await designSystem();
+    // `bg-` is exactly what the extractor could take from the old template
+    // literal, and it builds nothing — the defect, at the compiler.
+    expect(ds.candidatesToCss(['bg-'])[0]).toBeNull();
+    expect(ds.candidatesToCss(['bg-not-a-token'])[0]).toBeNull();
+    expect(ds.candidatesToCss(['bg-mutedd'])[0]).toBeNull();
+    // …and YES for a class this workspace's theme defines, so a green result
+    // below means "emitted", not "instrument inert".
+    expect(ds.candidatesToCss(['bg-muted'])[0]).toContain('background-color');
+  });
+
+  it('every vocabulary class builds against the shipped @theme', async () => {
+    const ds = await designSystem();
+    const built = Object.fromEntries(
+      vocabularyClasses.map((cls) => [cls, ds.candidatesToCss([cls])[0]]),
+    );
+    for (const cls of vocabularyClasses) {
+      expect(built[cls], `${cls} produced no CSS rule`).toBeTruthy();
+      expect(built[cls]).toContain('background-color');
+    }
+  });
+});

--- a/packages/plugin-detail/src/headerColor.ts
+++ b/packages/plugin-detail/src/headerColor.ts
@@ -1,0 +1,92 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `DetailViewSection.headerColor` -> a Tailwind background class.
+ *
+ * ## Why a lookup and not a template literal (objectui#6178)
+ *
+ * Tailwind v4 has no runtime. It builds the stylesheet by scanning source
+ * TEXT for complete class tokens (the `@source` globs in each consuming app's
+ * CSS entry; this workspace ships no `bg-*` safelist). The previous read here
+ * was a template literal — `bg-` concatenated with the authored value — which
+ * is never a complete token in scanned text, so the call site contributed
+ * NOTHING to the compiled stylesheet. Measured, not assumed: compiling
+ * `apps/console/src/index.css` with the template literal deleted produced a
+ * byte-identical stylesheet (same sha256, 441302 bytes), and offering `bg-`
+ * to the design system as a candidate emits no rule.
+ *
+ * An authored value therefore styled the header only when some OTHER source
+ * file happened to use the identical class literally — `bg-muted` appears 691
+ * times and `bg-primary/10` 63 times elsewhere in the workspace, which is why
+ * both documented examples appeared to work. That liveness was accidental and
+ * unversioned: it moved with unrelated edits in unrelated packages.
+ *
+ * Every class below is a COMPLETE literal, present verbatim in this file, and
+ * this file is inside every consuming app's scan (`packages/plugin-detail/
+ * src/**` in `apps/console`, `examples/console-starter`, and
+ * `examples/byo-backend-console`). The key now works because this module
+ * declares it, not because a neighbour happens to.
+ *
+ * ## Shape
+ *
+ * The same one this repo already uses for the sibling problem — `useRowColor`'s
+ * `COLOR_TO_CLASS` in `@object-ui/plugin-grid`: a lookup of literal classes, a
+ * verbatim pass-through for a value that is already a `bg-*` class, and
+ * `undefined` for everything else. Never a fabricated class string.
+ *
+ * The AGENTS.md custom-property carve-out (`bg-[color:var(--os-…)]` fed by an
+ * inline custom property, as `getBadgeHexAppearance` does in `@object-ui/
+ * fields`) is the right answer for a key whose value is a CSS COLOUR. It does
+ * not fit this one: `headerColor` is documented as a Tailwind class and its
+ * values are design-system tokens (`muted`, `primary/10`), which have no
+ * meaning as a CSS colour.
+ *
+ * ## Vocabulary
+ *
+ * Tints only. `CardHeader` sets no foreground colour, so a solid `bg-primary`
+ * or `bg-destructive` would leave the section title unreadable; those need a
+ * paired `text-*-foreground` and are left to the pass-through, where the
+ * pairing is the author's explicit choice. Both values the `@object-ui/types`
+ * mirror documents (`muted`, `primary/10`) are in the map, so nothing that
+ * worked before this module stops working.
+ */
+const HEADER_COLOR_CLASSES: Readonly<Record<string, string>> = Object.freeze({
+  muted: 'bg-muted',
+  'muted/50': 'bg-muted/50',
+  accent: 'bg-accent',
+  'primary/10': 'bg-primary/10',
+  'secondary/10': 'bg-secondary/10',
+  'destructive/10': 'bg-destructive/10',
+});
+
+/** The declared vocabulary, for tests and for callers that enumerate it. */
+export const headerColorVocabulary = HEADER_COLOR_CLASSES;
+
+/**
+ * Resolve an authored `headerColor` to a class the stylesheet actually
+ * carries, or `undefined` when there is none — never a concatenated guess.
+ *
+ * A value that is already a complete `bg-*` class is handed through
+ * untouched, exactly as `useRowColor` does. It then renders on the same terms
+ * as any `className` a schema carries: the host app's Tailwind build has to
+ * generate it.
+ */
+export function headerColorClass(headerColor: string | undefined): string | undefined {
+  if (!headerColor) return undefined;
+  const value = headerColor.trim();
+  if (!value) return undefined;
+  if (value.startsWith('bg-')) return value;
+  // `hasOwnProperty` rather than a bare index: a plain object literal inherits
+  // `constructor`, `toString` and friends, and indexing it with an authored
+  // string would hand one of those back as the "class". (`Object.hasOwn` is
+  // ES2022; this workspace compiles against the ES2020 lib.)
+  return Object.prototype.hasOwnProperty.call(HEADER_COLOR_CLASSES, value)
+    ? HEADER_COLOR_CLASSES[value]
+    : undefined;
+}


### PR DESCRIPTION
Fixes #6178

## The premise, re-measured

The card is **correct**, and the strongest evidence it predicted exists.

**The repo's own reading.** `apps/console/src/__tests__/sdui-preview-page-source-styling.test.ts`, header:

> The console's Tailwind is compiled at BUILD time by scanning the console's own `src` (`@source '../src/**'` in `apps/console/src/index.css`) with no safelist, so **a utility class authored in real page metadata produces no CSS and no error anywhere** — the ADR-0065 "works only by coincidence" failure.

**The compiled stylesheet, not an inference.** I compiled `apps/console/src/index.css` the way the console build does (`@tailwindcss/postcss`, v4.3.3), then again with the `bg-` template literal deleted from both call sites. The two sheets are **byte-identical** — 441302 bytes, sha256 `dffcd88d…e7e3b2`. That call site contributed **zero** rules. Asking Tailwind's design system for the candidate `bg-` (all the extractor could take from a template literal) returns no rule either.

**"Works only by collision" — measured, and it matters.** Both values the `@object-ui/types` mirror documents are present in the built console CSS today: `.bg-muted` and `.bg-primary/10` are 2 of 227 distinct `bg-*` selectors. They are there because *other* files author them literally — `bg-muted` 691 times, `bg-primary/10` 63 times elsewhere in the workspace. So the key was not inert in effect; it was **live by accident**, and the fix had to keep the documented examples working rather than simply stop lying.

Two corrections to the card's wording, neither changing its conclusion:

- "no safelist" is imprecise. `apps/console/src/index.css` **does** use `@source inline(...)` — nine lines of it, for streamdown's runtime classes. There is no `bg-*` safelist, which is what the argument needs.
- the third `headerColor` mention is `packages/plugin-detail/src/index.tsx:310` (not `:287`), and it is the `detail-section` **registry input row** — a declaration, not a fourth read site. The two read sites are `DetailSection.tsx:513` / `:542`, exactly as filed.

The issue body shows **no sanitizer truncation**: it contains no angle-bracket fragments at all, and the split spelling of the template literal in bullet 1 reads as the author working around the sanitizer, not as damage.

## The shape, decided by measurement

Triage asked for a closed vocabulary mapped to static literal classes **or** inline style from the authored value — whichever matches how sibling colour keys here already solved it. Three sibling species exist:

| sibling | what the author writes | how it renders |
|---|---|---|
| `getBadgeHexAppearance` (`@object-ui/fields`) | a **CSS colour** | `bg-[color:var(--os-badge-bg)]` + inline custom properties — the AGENTS.md carve-out |
| `columnColors` (`PivotTable`) | a **complete Tailwind class** | passed verbatim into `cn()`, no prefix |
| **`useRowColor` (`@object-ui/plugin-grid`)** | **a colour token, or a complete class** | **a lookup of literal classes + a `bg-` pass-through + `undefined` otherwise** |

`useRowColor` is the same problem, and this PR is the same answer. The custom-property carve-out does not fit: it is for values that are CSS **colours**, and `headerColor`'s values (`muted`, `primary/10`) have no meaning as one. And `DetailSection` was the **only** `` `bg-${…}` ``-shaped class in the entire workspace — every sibling had already avoided this shape.

New module `packages/plugin-detail/src/headerColor.ts`:

- **lookup of complete literals**, tint-only: `muted`, `muted/50`, `accent`, `primary/10`, `secondary/10`, `destructive/10`. `CardHeader` sets no foreground, so solid `bg-primary` / `bg-destructive` would leave the title unreadable — those need a paired `text-*-foreground` and are left to the pass-through, where the pairing is the author's explicit choice. Both documented examples are in the map, so nothing that rendered before renders differently;
- **pass-through** for a value already spelled as a complete `bg-*` class. New behaviour: `headerColor: 'bg-muted'` previously produced the meaningless `bg-bg-muted`;
- **`undefined`** otherwise — never a fabricated class. `hasOwnProperty`, not a bare index, so `headerColor: 'constructor'` cannot hand back an `Object.prototype` member.

The literals now live in a file every consuming app scans (`packages/plugin-detail/src/**` appears in `apps/console`, `examples/console-starter`, `examples/byo-backend-console`), so the key works because this module declares it, not because a neighbour happens to.

## Evidence

**Two instruments, because one of them is blind.** Asserting a `className` in the DOM proves nothing about CSS emission — the old code put `bg-<value>` in the DOM too. So:

1. `DetailSection.headerColor.test.tsx` — renders the real component, asserts which class reaches the header. States in its header that it **cannot** show CSS generation.
2. `headerColor.test.ts` — the generation half. (a) every vocabulary class appears **verbatim** in the module's source text, the property the v4 extractor needs; (b) every vocabulary class **builds a rule** against this workspace's real `@theme` (`__unstable__loadDesignSystem` from `tailwindcss`, root devDependency), with `bg-`, `bg-mutedd`, `bg-not-a-token` as the negative controls that prove the instrument can say no. It states what it still cannot show: it does not run the oxide scanner, and it does not verify any app's `@source` globs.

Every negative pin has a positive probe beside it (the header element is located `getBy`-style and the assertion fails if no header rendered, so nothing passes vacuously).

**Per-point ablation** — direction predicted before each run, all four correct:

| point | mutation (confirmed on disk, 1 → 0 occurrences) | predicted | observed |
|---|---|---|---|
| P1 | revert **only** the non-collapsible call site | that branch reds, collapsible stays green | 4 red / 17 pass — 3 non-collapsible cases + the interpolation pin; **all 5 collapsible cases green** |
| P2 | revert **only** the collapsible call site | mirror of P1 | 4 red / 17 pass — 3 collapsible cases + the interpolation pin; **all 5 non-collapsible cases green** |
| P3 | `bg-muted` → `bg-mutedd` (still a complete literal) | design-system test reds, verbatim-source test stays green | 5 red / 16 pass — **"appears VERBATIM in the module source" stayed green** |
| P4 | `'bg-muted'` → `['bg-', 'muted'].join('')` (still a valid utility at runtime) | verbatim-source test reds, everything else green | **exactly 1 red** / 20 pass — the design-system test, the resolver tests and every render test stayed green |

P4 is #6178 reproduced in miniature: a class that is valid at runtime but unextractable from source, with **every instrument except the source-text one reporting green**. P1/P2 record the honest limit of the render tests — under P1 the two "a mapped token renders its literal class" cases **still passed**, because the old concatenation produced the same string for a mapped value.

Each ablation script carries a `trap … EXIT INT TERM` restore and refuses to run (exit 90) unless the mutation is confirmed on disk; the restore leg is printed each time.

## Gates

Run at `799d2385e`, which is the HEAD of this branch and byte-identical to the tree every measurement above was taken on (`git status --porcelain` empty).

- `pnpm exec vitest run packages/plugin-detail` — **106 files / 1007 tests passed** (the two new files contribute 21).
- `pnpm --filter @object-ui/plugin-detail type-check` — clean (`tsc --noEmit && tsc -p tsconfig.test.json`, both echoed).
- `check:control-bytes`, `check:phantom-deps`, `check:entry-guard`, `check:self-import`, `check:vi-mock-specifiers`, `check:esm-specifiers`, `check-type-check-coverage`, `check-lint-coverage`, `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-fixed` — all exit 0. Changeset gate prints: `4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`.
- **Two gates report a broken gauge, both pre-existing to this branch** and both self-diagnosing: `check:eager-closure` ("No eager-closure report at `apps/console/dist/eager-closure.json` … an absent report means the console was not built") and `check:readme-exports` ("its type entry `./dist/index.d.ts` is not on disk — run `pnpm build` first"). This worktree had **0 of 40** packages built and no `apps/console/dist` when they ran; CI builds first. Neither names a file in this diff.

**Lint, run narrowed and the narrowing declared.** `pnpm exec eslint packages/plugin-detail --format json` — exit 0, **0 errors** across the **159 files eslint's own config resolution judged** (count read from the JSON, not from my guess at what counts). My four files: `headerColor.ts` 0/0, `headerColor.test.ts` 0/0, `DetailSection.headerColor.test.tsx` 0/0, `DetailSection.tsx` 0 errors and 12 pre-existing warnings at lines 70/102/105/111/122/147/221/223/261/261/263/428 — none on the three lines this PR touches (37, 514, 543). The narrowing is a measurement rather than a skip because `eslint.config.js` configures **no** type-aware linting (no `projectService`, no `parserOptions.project`) and no custom rule in `eslint-rules/` reads another file, so a file's verdict is a function of its own text and the shared config — neither of which this diff moves outside `packages/plugin-detail`. Repo-wide `pnpm lint` is CI's run.

## Scope

`packages/plugin-detail/src/**` and its tests only, as dispatched. Deliberately **not** touched:

- `packages/types/src/views.ts` / `zod/views.zod.ts` — the `headerColor` declaration and its `@example 'muted', 'primary/10'`. Out of this PR's file surface, and objectui#6267 holds that package. The examples stay accurate: both still render. Naming the vocabulary in that JSDoc is a follow-up for whoever owns it next.
- the `detail-section` registry input row (`index.tsx:310`) — a `string` input, still accurate.
- `@objectstack/spec`, which **refuses** `headerColor` on the strict `record:details` section schema today, with a pinned test whose comment cites this exact defect ("declaring it would advertise a capability the renderer does not deliver"). That refusal is the thing this PR makes obsolete; flipping it is a spec decision, raised as an open question in the dev report rather than taken here. Back-link: objectstack-ai/objectstack#11661.

## The one thing a reviewer should rule on

The declared type is unchanged and no value is rejected, but the **effective** value set is reshaped: an undocumented bare suffix that happened to collide with another file's literal (say `headerColor: 'blue-100'`) no longer reaches the DOM as `bg-blue-100`. Ending that accidental liveness is the point of the fix, not a side effect of it — no fix satisfying the card can preserve it. Three things bound the risk: zero producers author `headerColor` anywhere in either repo (only declarations and the spec-side refusal); both documented examples are preserved; and every previously-colliding suffix has a one-word migration through the pass-through (`'blue-100'` → `'bg-blue-100'`). Whether the vocabulary should be exactly these six, and whether the spec should now declare the key over them, is the maintainer's call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mn4BZ5AVDM81pvfij1WwM9)_