### PR TITLE
ComponentMeta at the registry: derive it from the one declaration, extend it under a named type

### DIFF
--- a/.changeset/6067-component-meta-derive-from-canonical.md
+++ b/.changeset/6067-component-meta-derive-from-canonical.md
@@ -1,0 +1,81 @@
+---
+'@object-ui/core': minor
+---
+
+`ComponentMeta` at the registry is now DERIVED from the one declaration in
+`@object-ui/types` instead of restating it, and `tags` / `description` reach the
+registration surface (objectui#6067).
+
+## The convergence
+
+`packages/core/src/registry/Registry.ts` declared its own `ComponentMeta`: thirteen
+keys, of which nine were restated from `@object-ui/types`' `base.ts`, four were
+registry-only (`tier`, `namespace`, `skipFallback`, `labelling`), and `tags` /
+`description` were **absent** — although both are declared on the canonical type and on
+the `ComponentMetaSchema` zod mirror. Two of the three authorities agreed and the
+registration surface did not, so those two keys were unwritable at exactly the
+declaration most component registrations import. That is the same two-key delta
+objectui#5893 had just closed inside `@object-ui/types`, arriving a third time on a
+third declaration, and objectui#5671 had already made the identical move for the sibling
+type `ComponentInput` in this very file.
+
+It is now:
+
+```ts
+export type RegistryComponentMetaExtras = {
+  tier?: 'public' | 'internal';
+  namespace?: string;
+  skipFallback?: boolean;
+  labelling?: 'control' | 'group' | 'display';
+};
+
+export type ComponentMeta = CanonicalComponentMeta & RegistryComponentMetaExtras;
+```
+
+`RegistryComponentMetaExtras` is newly exported from `@object-ui/core`.
+
+**What changes for a consumer: `tags` and `description` become writable on the registry's
+`ComponentMeta`. Nothing narrows.** No key is removed, no key is renamed, and no key's
+type changes, so no existing registration stops compiling — verified by type-checking all
+37 workspace consumers of `@object-ui/core` (`pnpm --filter '...@object-ui/core'`), which
+is why this is a widening rather than the contract break a rename would have been. All
+four registry-only keys have live consumers, and they are still declared here.
+
+This is `minor` under this repository's policy that its own breaking changes never declare
+`major` (`scripts/check-changeset-no-major.mjs`); nothing here is breaking in any case.
+
+## Converge rather than rename, and why the four keys did not move
+
+The alternative dispositions were to rename the type so the name stops claiming a mirror,
+or to move the four registry keys onto `@object-ui/types`' `ComponentMeta` and re-export
+it outright the way objectui#5671 handled `ComponentInput`.
+
+Renaming was rejected because it cannot be done without a break: `@object-ui/core` is
+published, `ComponentMeta` is exported from it, and dropping the name would break every
+external consumer — while keeping it as an alias would leave the mirror claim standing
+under a second spelling, which fixes nothing.
+
+Moving the four keys was rejected because `skipFallback` and `namespace` are registration
+mechanics — they describe how the registry keys an entry, not what a component is — and
+`@object-ui/types`' `ComponentMeta` is the general, plugin-facing, AI-facing type. The
+extension keeps them where they are read, under their own named type, while the eleven
+shared members exist in exactly one place and can no longer drift.
+
+## Pinned by key set, not by assignability
+
+Every member of both shapes is optional, so `extends` is mutually **true** across the
+diverged pair — an assignability assertion is green on the defect and would not have
+caught it. Measured on the emitted `.d.ts` of both packages, before and after:
+
+| reading | before | after |
+|---|---|---|
+| `Core extends Canonical` | `true` | `true` |
+| `Canonical extends Core` | `true` | `true` |
+| `Exclude<keyof Canonical, keyof Core>` | `"tags" \| "description"` | `never` |
+| `Exclude<keyof Core, keyof Canonical>` | the four registry keys | the four registry keys |
+
+The new pin asserts the third row and names the fourth explicitly; the assignability pair
+is kept beside it, labelled, as the control that shows what it cannot see. A source-level
+assertion that the canonical members are not restated locally covers the remaining failure
+mode — a member-identical copy, which every `keyof` comparison stays green on and which is
+how the copy this replaces began.

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { ComponentInput } from '@object-ui/types';
+import type { ComponentMeta as CanonicalComponentMeta } from '@object-ui/types';
 import { PUBLIC_BLOCKS } from './public-blocks.js';
 
 export type ComponentRenderer<T = any> = T;
@@ -34,10 +34,27 @@ export type ComponentRenderer<T = any> = T;
  */
 export type { ComponentInput } from '@object-ui/types';
 
-export type ComponentMeta = {
-  label?: string; // Display name in designer
-  icon?: string; // Icon name or svg string
-  category?: string; // Grouping category
+/**
+ * The keys the REGISTRY adds on top of the one `ComponentMeta` declaration:
+ * registration mechanics (`tier` / `namespace` / `skipFallback`) and the
+ * host-labelling contract (`labelling`). None of the four has a counterpart on
+ * the general type in `@object-ui/types`, and none is being moved there —
+ * publishing registry mechanics on the general type was the alternative
+ * objectui#6067 weighed and rejected.
+ *
+ * They live in their OWN named type so that `ComponentMeta` below can be
+ * DERIVED from the canonical declaration instead of restating it. Until
+ * objectui#6067 this file carried a second, thirteen-key structural copy of
+ * the name: the nine shared members restated from `@object-ui/types`' `base.ts`,
+ * these four added here, and `tags` / `description` — declared on the canonical
+ * type and on the `ComponentMetaSchema` zod mirror — simply absent. That is
+ * objectui#4580's ruling coming true for the third type in a row: *a
+ * structural copy would reproduce the defect the moment either side moved.*
+ * objectui#5671 executed the same convergence for `ComponentInput` in this very
+ * file, and objectui#5893 closed the identical two-key delta inside
+ * `@object-ui/types`.
+ */
+export type RegistryComponentMetaExtras = {
   /**
    * Public contract tier (ADR-0080). `'public'` = part of the curated,
    * type-checked, AI-facing block set (gets a strengthened contract, the
@@ -95,20 +112,31 @@ export type ComponentMeta = {
    * unlabelled group.
    */
   labelling?: 'control' | 'group' | 'display';
-  inputs?: ComponentInput[];
-  defaultProps?: Record<string, any>; // Default props when dropped
-  examples?: Record<string, any>; // Example configurations
-  isContainer?: boolean; // Whether the component can have children
-  resizable?: boolean; // Whether the component can be resized in the designer
-  resizeConstraints?: {
-    width?: boolean;
-    height?: boolean;
-    minWidth?: number;
-    maxWidth?: number;
-    minHeight?: number;
-    maxHeight?: number;
-  };
 };
+
+/**
+ * What a registration DECLARES about one component — the type every
+ * `ComponentRegistry.register` / `registerLazy` call is checked against.
+ *
+ * ONE declaration of the shared members: this is `@object-ui/types`'
+ * `ComponentMeta` (the declaration `ComponentMetaSchema` mirrors and the
+ * plugin-facing surface publishes) intersected with the registry-only keys
+ * above. The nine shared members are no longer restated here, so they cannot
+ * drift again, and `tags` / `description` now reach the registration surface —
+ * the two keys the divergence had made unwritable at the very declaration most
+ * component registrations import.
+ *
+ * NOTE for anyone pinning this: every member of both halves is OPTIONAL, so
+ * `extends` is mutually TRUE between the two shapes even when their key sets
+ * differ. Measured on the EMITTED `.d.ts` of both packages immediately before
+ * this convergence: `Core extends Canonical` and `Canonical extends Core` were
+ * BOTH `true` while `tags` / `description` were missing and four keys were
+ * extra. An assignability assertion is therefore a ghost here — it was green on
+ * the diverged tree. `__tests__/component-meta-derives-from-canonical.test.ts`
+ * compares `keyof` sets instead and keeps the assignability check beside it as
+ * the labelled control that shows why.
+ */
+export type ComponentMeta = CanonicalComponentMeta & RegistryComponentMetaExtras;
 
 export type ComponentConfig<T = any> = ComponentMeta & {
   type: string;

--- a/packages/core/src/registry/__tests__/component-meta-derives-from-canonical.test.ts
+++ b/packages/core/src/registry/__tests__/component-meta-derives-from-canonical.test.ts
@@ -1,0 +1,248 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Convergence pin — `@object-ui/core`'s `ComponentMeta` is DERIVED from the one
+ * declaration in `@object-ui/types`, not a structural copy of it
+ * (objectui#6067).
+ *
+ * ## What was wrong
+ *
+ * `Registry.ts` declared its own thirteen-key `ComponentMeta`: the nine members
+ * restated from `@object-ui/types`' `base.ts`, four registry-only keys added
+ * here (`tier` / `namespace` / `skipFallback` / `labelling`), and `tags` /
+ * `description` absent — though both are declared on the canonical type AND on
+ * the `ComponentMetaSchema` zod mirror. Two of the three authorities agreed and
+ * the registration surface did not, so the two keys were unwritable at exactly
+ * the declaration most component registrations import. That is the identical
+ * two-key delta objectui#5893 had just closed inside `@object-ui/types`, and
+ * objectui#5671 had already executed the identical convergence for the sibling
+ * type `ComponentInput` in this very file.
+ *
+ * ## Why the load-bearing assertion compares `keyof` sets, not assignability
+ *
+ * EVERY member of both shapes is optional. A type with fewer optional members
+ * is assignable to one with more and vice versa, so `extends` is mutually TRUE
+ * across a diverged pair — excess-property checking only ever fires on object
+ * literals, never on the type relation. Measured on the EMITTED `.d.ts` of both
+ * packages on the tree immediately BEFORE this convergence:
+ *
+ *     coreExtendsCanonical = true          <- green on the DIVERGED tree
+ *     canonicalExtendsCore = true          <- green on the DIVERGED tree
+ *     onlyInCanonical      = "tags" | "description"
+ *     onlyInCore           = "tier" | "namespace" | "skipFallback" | "labelling"
+ *
+ * and on the tree after it:
+ *
+ *     coreExtendsCanonical = true          <- UNCHANGED
+ *     canonicalExtendsCore = true          <- UNCHANGED
+ *     onlyInCanonical      = never         <- the only reading that moved
+ *     onlyInCore           = "tier" | "namespace" | "skipFallback" | "labelling"
+ *
+ * An assignability assertion is therefore a GHOST here: it could not have gone
+ * red on the defect and it cannot go red on its return. `Exclude<keyof …>` is
+ * the instrument that moved, so it is the pin; the assignability pair is kept
+ * below, labelled, as the control that demonstrates the contrast rather than
+ * asserting it. Same shape of reasoning, and the same conclusion about
+ * member-set checks being insufficient on their own, as
+ * `packages/types/src/__tests__/component-meta-single-declaration.test.ts`.
+ *
+ * ## Which declaration these type-level assertions actually read
+ *
+ * The EMITTED one. `packages/core/tsconfig.test.json` sets `"paths": {}`,
+ * dropping the root config's source-tree mapping so `@object-ui/types` resolves
+ * through the workspace dependency's built `dist/index.d.ts`; that project is
+ * chained from this package's `type-check` script, which is what CI's `Type
+ * Check` job runs, and turbo's `type-check` task `dependsOn: ["^build"]`, so the
+ * dependency IS built there. Under vitest the same file resolves to `src/`
+ * instead, and every annotation below is erased — `expect(x).toBe(true)` on a
+ * literal `true` proves nothing on its own. `tsc` is the enforcement; the
+ * runtime assertions exist so a failure has a named test to report against, the
+ * arrangement objectui#3181 recorded for this package.
+ *
+ * Deliberately NOT asserted here: anything read out of `packages/core/dist`.
+ * The CI `test` job runs `pnpm test` (root `vitest run`) with no build ahead of
+ * it at all, so a dist-reading assertion would be absent-or-red depending on
+ * whether someone happened to run a build — "an assertion whose colour depends
+ * on whether someone ran a build is not a pin"
+ * (`src/actions/__tests__/actionKeys.types.test.ts`). The emitted-declaration
+ * half is covered by the `type-check` route described above.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import type { ComponentMeta as CanonicalComponentMeta } from '@object-ui/types';
+import type { ComponentMeta, RegistryComponentMetaExtras } from '../Registry.js';
+
+/** Keys the canonical declaration has that the registration surface does not. */
+type OnlyOnCanonical = Exclude<keyof CanonicalComponentMeta, keyof ComponentMeta>;
+
+/** Keys the registration surface adds on top of the canonical declaration. */
+type OnlyOnRegistry = Exclude<keyof ComponentMeta, keyof CanonicalComponentMeta>;
+
+/**
+ * Mutual-subset equality, wrapped in tuples so neither side distributes over a
+ * union and `never` compares as the empty set rather than vanishing.
+ */
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+describe('ComponentMeta (core registry) — the key-set pin (the assertion a structural copy fails)', () => {
+  it('leaves no canonical key unreachable at the registration surface', () => {
+    // THIS is the pin. It read `"tags" | "description"` before objectui#6067
+    // and `never` after — the one reading that moved. It goes red the moment a
+    // key is added to `@object-ui/types`' `ComponentMeta` and not reflected
+    // here, which is precisely how the copy this replaces acquired its delta.
+    const noCanonicalKeyIsMissing: Exact<OnlyOnCanonical, never> = true;
+
+    expect(noCanonicalKeyIsMissing).toBe(true);
+  });
+
+  it('adds exactly the four registry-only keys, named', () => {
+    // The other half of the symmetric difference, pinned to a literal union
+    // rather than to `keyof RegistryComponentMetaExtras` — comparing the extras
+    // type against itself would be true by construction. Spelling the four out
+    // is what catches a fifth key drifting onto the registration surface, and
+    // what catches one of these four being quietly moved onto the general type
+    // in `@object-ui/types` (the direction objectui#6067 weighed and rejected:
+    // `skipFallback` and `namespace` are registry mechanics and do not belong
+    // on a type published to every metadata author).
+    const registryOnlyKeys: Exact<
+      OnlyOnRegistry,
+      'tier' | 'namespace' | 'skipFallback' | 'labelling'
+    > = true;
+
+    // And the extras type is the thing that supplies them, so the named type
+    // the ruling asked for is load-bearing rather than decorative.
+    const extrasSupplyThem: Exact<
+      OnlyOnRegistry,
+      keyof RegistryComponentMetaExtras
+    > = true;
+
+    expect([registryOnlyKeys, extrasSupplyThem]).toEqual([true, true]);
+  });
+});
+
+describe('ComponentMeta (core registry) — the assignability control (green on the diverged tree, kept to show the contrast)', () => {
+  it('is mutually assignable with the canonical declaration — and WAS before the convergence too', () => {
+    // Both readings were `true` while `tags` and `description` were missing.
+    // Recorded here as the control, not as the guarantee: if this pair were the
+    // only assertion in the file, reverting objectui#6067 would leave it green.
+    const bothWays: [
+      ComponentMeta extends CanonicalComponentMeta ? true : false,
+      CanonicalComponentMeta extends ComponentMeta ? true : false,
+    ] = [true, true];
+
+    expect(bothWays).toEqual([true, true]);
+  });
+});
+
+describe('ComponentMeta (core registry) — the two keys the convergence delivers', () => {
+  it('lets a registration write `tags` and `description` alongside the registry keys', () => {
+    // The counter-probe the convergence has to survive. "The copy is gone" is
+    // otherwise satisfiable by narrowing the type for everyone, and narrowing
+    // is exactly what was NOT permitted here: `@object-ui/core` is published,
+    // `ComponentMeta` is exported from it, and all four registry-only keys have
+    // live consumers. Nothing was removed; two keys were added.
+    //
+    // Before objectui#6067 the two annotated keys were a plain TS error on this
+    // spelling and legal on `@object-ui/types`' — the divergence, at a call site.
+    const registration: ComponentMeta = {
+      label: 'Kanban Board',
+      icon: 'layout-board',
+      category: 'data',
+      tier: 'public',
+      namespace: 'view',
+      skipFallback: true,
+      labelling: 'group',
+      inputs: [{ name: 'columns', type: 'array' }],
+      isContainer: false,
+      resizable: true,
+      tags: ['board', 'kanban'],
+      description: 'Drag-and-drop board view over a grouped dataset.',
+    };
+
+    expect(registration.tags).toEqual(['board', 'kanban']);
+    expect(registration.description).toBe(
+      'Drag-and-drop board view over a grouped dataset.',
+    );
+    // The four registry keys are still writable on the same object — the
+    // convergence widened the surface, it did not swap one half for the other.
+    expect([
+      registration.tier,
+      registration.namespace,
+      registration.skipFallback,
+      registration.labelling,
+    ]).toEqual(['public', 'view', true, 'group']);
+  });
+});
+
+const REGISTRY_SRC = readFileSync(
+  fileURLToPath(new URL('../Registry.ts', import.meta.url)),
+  'utf8',
+);
+
+/** The import that makes this file share `@object-ui/types`' declaration. */
+const CANONICAL_IMPORT =
+  "import type { ComponentMeta as CanonicalComponentMeta } from '@object-ui/types';";
+
+/** The derived declaration, exactly as `Registry.ts` spells it. */
+const DERIVED_DECLARATION =
+  'export type ComponentMeta = CanonicalComponentMeta & RegistryComponentMetaExtras;';
+
+/** A property declaration for `name`, at any nesting depth. */
+const memberDeclaration = (name: string) => new RegExp(`^\\s*${name}\\??:`, 'm');
+
+/** The eleven members that belong to the canonical declaration and only there. */
+const CANONICAL_MEMBERS = [
+  'label',
+  'icon',
+  'category',
+  'inputs',
+  'defaultProps',
+  'examples',
+  'isContainer',
+  'resizable',
+  'resizeConstraints',
+  'tags',
+  'description',
+];
+
+/** The four this file legitimately declares. */
+const REGISTRY_MEMBERS = ['tier', 'namespace', 'skipFallback', 'labelling'];
+
+describe('ComponentMeta (core registry) — the source-identity pin', () => {
+  it('imports the canonical declaration instead of restating it', () => {
+    expect(REGISTRY_SRC).toContain(CANONICAL_IMPORT);
+    expect(REGISTRY_SRC).toContain(DERIVED_DECLARATION);
+  });
+
+  it('declares none of the canonical members locally', () => {
+    // The type-level pin above catches a MISSING key. This catches the other
+    // failure mode, which no `keyof` comparison can see: a member-identical
+    // restatement. That is the state objectui#4580 ruled about — mutually
+    // assignable, key sets equal, every assertion in this file green, and
+    // drifting again the moment either side moves. It is also how the copy this
+    // replaces began.
+    const restated = CANONICAL_MEMBERS.filter((m) =>
+      memberDeclaration(m).test(REGISTRY_SRC),
+    );
+
+    expect(restated).toEqual([]);
+  });
+
+  it('still declares the four registry-only members here, so the pattern is live', () => {
+    // Control for the regex itself. A pattern that matched nothing anywhere
+    // would pass the assertion above on any tree, including a re-diverged one.
+    const declared = REGISTRY_MEMBERS.filter((m) =>
+      memberDeclaration(m).test(REGISTRY_SRC),
+    );
+
+    expect(declared).toEqual(REGISTRY_MEMBERS);
+  });
+});


### PR DESCRIPTION
Fixes #6067

`@object-ui/core`'s `ComponentMeta` no longer restates the canonical declaration. It is now derived from it, and `tags` / `description` reach the registration surface.

```ts
// packages/core/src/registry/Registry.ts
import type { ComponentMeta as CanonicalComponentMeta } from '@object-ui/types';

export type RegistryComponentMetaExtras = {
  tier?: 'public' | 'internal';
  namespace?: string;
  skipFallback?: boolean;
  labelling?: 'control' | 'group' | 'display';
};

export type ComponentMeta = CanonicalComponentMeta & RegistryComponentMetaExtras;
```

---

## 1. Premise, re-derived on today's `main` — it holds

Re-derived from scratch at merge-base `c456d91f4`, **not** carried from the card.

**Declaration census.** A repo-wide search for a `type` / `interface` / `class` declaration of the exact name returns exactly two:

| declaration | form |
|---|---|
| `packages/types/src/base.ts:511` | `export interface ComponentMeta {` — the canonical one |
| `packages/core/src/registry/Registry.ts:37` | `export type ComponentMeta = {` — the structural copy |

So core's is the **only remaining structural copy**, exactly as the 04:18Z triage comment graded it, and the count the first triage comment (16:29Z) asked to be re-verified on the merged ref is confirmed: #5893 collapsed `packages/types`' two onto one, and the card's title ("a THIRD declaration") is the pre-#5893 count.

**Control probe for the census**, because the whole task is counting declarations and a zero-hit is not a reading on its own: the same pattern run against the sibling type `ComponentInput` returns exactly one declaration (`packages/types/src/base.ts:379`) — the state #5671 left it in — and the pattern matches both the `export type` and the `export interface` spellings, which is where the card's own filing probe went wrong.

**Key sets, re-counted** — canonical 11, core 13, symmetric difference 6, all confirmed:

- **Only on the canonical type (2):** `tags`, `description`
- **Only on core's (4):** `tier`, `namespace`, `skipFallback`, `labelling`
- **Shared (9):** `label`, `icon`, `category`, `inputs`, `defaultProps`, `examples`, `isContainer`, `resizable`, `resizeConstraints` — including `resizeConstraints`, whose six members were identical

## 2. The disposition: converge, not rename

The ruling admitted two resolutions. This PR converges, and the reason is that **rename cannot be executed here without a contract break**:

- `@object-ui/core` is published, and `ComponentMeta` is part of its export surface: `src/index.ts` carries `export * from './registry/Registry.js'`, and `package.json` maps `"."` → `./dist/index.d.ts`.
- Dropping the name would break every external consumer; keeping it as an alias would leave the mirror claim standing under a second spelling, which the ruling explicitly says fixes nothing.

The other rejected option was moving the four registry keys onto `@object-ui/types`' `ComponentMeta` and re-exporting outright, the way #5671 handled `ComponentInput`. `skipFallback` and `namespace` describe **how the registry keys an entry**, not what a component is, and `@object-ui/types`' `ComponentMeta` is the general, plugin-facing, AI-facing type. They stay where they are read, under their own named type.

**Nothing is removed and nothing is renamed.** All fifteen keys on the resulting type are writable; two of them are new.

## 3. The four registry-only keys ARE published behaviour with consumers

Requested by the dispatch as the measurement that decides whether converge-with-extension is safe. It is, and this is why a rename would not have been.

| key | writers (in-repo, non-test) | readers | published-type consumers |
|---|---|---|---|
| `namespace` | ~137 registration call sites across `packages/**` | `Registry.ts:247`, `Registry.ts:315` — the bare-key fallback decision | — |
| `skipFallback` | 44 literal writes across 23 files (`action-bar.tsx`, `action-button.tsx`, `record-approvals-renderer.tsx`, …) | `Registry.ts:247`, `Registry.ts:315`, same decision | — |
| `labelling` | 45 field widgets carry a decision via `FIELD_WIDGET_LABELLING` (`packages/fields/src/index.tsx:2934`); 14 of them (10 `group` + 4 `display`) write the key into the meta at `index.tsx:3009` — `'control'` is spelled as absence | `packages/components/src/renderers/form/form.tsx:446` — `ComponentRegistry.getMeta(…)?.labelling` | `packages/fields/src/index.tsx:2936`, `packages/app-shell/…/DashboardWidgetInspector.tsx:581` and `packages/app-shell/…/widgets.tsx:2547` all take an **indexed access** `ComponentMeta['labelling']` off the type published by `@object-ui/core` |
| `tier` | 0 in-repo as a meta key — the in-repo opt-in is the `PUBLIC_BLOCKS` list; `tier: 'public'` is the documented per-registration opt-in (ADR-0080) | `Registry.ts:560`, `Registry.ts:564` (`getPublicConfigs`), `packages/sdui-parser/src/index.ts:148` (`publicOnly`) | — |

`labelling` additionally appears in three shipped CHANGELOGs as "`@object-ui/core` — `ComponentMeta` gains `labelling?: 'control' \| 'group'`", so it is published behaviour on the record, not merely in-repo usage.

Direct importers of the type itself: `packages/fields/src/index.tsx:11`, `packages/app-shell/…/widgets.tsx:44`, `packages/app-shell/…/DashboardWidgetInspector.tsx:33`.

## 4. The measurement that shaped the pin: `extends` is a ghost here

**Every member of both shapes is optional**, so a type with fewer optional members is assignable to one with more and vice versa. Mutual assignability therefore holds **across the diverged pair** — an `extends`-based mirror assertion is green on the defect and could never have caught it.

Measured with a TypeScript program resolved against the **emitted `.d.ts` of both packages** (`packages/types/dist/index.d.ts` and `packages/core/dist/registry/Registry.d.ts`), before and after:

| reading | before (diverged) | after (this PR) |
|---|---|---|
| `Core extends Canonical` | `true` | `true` |
| `Canonical extends Core` | `true` | `true` |
| `Exclude<keyof Canonical, keyof Core>` | `"tags" \| "description"` | `never` |
| `Exclude<keyof Core, keyof Canonical>` | `"tier" \| "namespace" \| "skipFallback" \| "labelling"` | unchanged |

Exactly one reading moved. That reading is the pin; the assignability pair is kept beside it in the test, labelled, as the control that demonstrates the contrast.

This also means the triage wording *"asserting a mirror relationship that is false in both directions"* is true of the **key sets** and false of TypeScript assignability. Recorded because acting on the assignability reading would have produced a test that cannot fail.

## 5. Pinning against the emitted declaration, not the source

The dispatch flagged the #6267 trap: a source-level assertion passing while the shipped `.d.ts` is wrong. Measured rather than assumed for this package:

- `@object-ui/core`'s `build` is a bare `tsc`, not a `.d.ts` bundler, so a module re-export survives into the emit rather than being inlined. **Natural control:** #5671's `export type { ComponentInput } from '@object-ui/types';` appears verbatim at `dist/registry/Registry.d.ts:31` on the pre-change tree. After this PR, `dist/registry/Registry.d.ts` likewise carries `import type { ComponentMeta as CanonicalComponentMeta } from '@object-ui/types';` and `export type ComponentMeta = CanonicalComponentMeta & RegistryComponentMetaExtras;` — so the **shipped** declaration references the canonical one by module specifier. There is one declaration of the shared eleven in the published artifact, not a copy of it.
- The type-level assertions in the new test are compiled by `packages/core/tsconfig.test.json`, which sets `"paths": {}` so `@object-ui/types` resolves through the workspace dependency's **built `dist/index.d.ts`**. That project is chained from this package's `type-check` script, and turbo's `type-check` task `dependsOn: ["^build"]`, so CI's Type Check job builds the dependency before compiling it. The canonical half of every assertion is therefore read off the emitted declaration.
- Deliberately **not** asserted: anything read out of `packages/core/dist`. CI's `test` job runs `pnpm test` (root `vitest run`) with **no build ahead of it at all**, so a dist-reading assertion would be absent-or-red depending on whether someone ran a build — the standard this repo already records in `src/actions/__tests__/actionKeys.types.test.ts`: *an assertion whose colour depends on whether someone ran a build is not a pin.* The `packages/core/dist` half is covered by the out-of-band measurement above and reported here rather than encoded as a green-by-luck test.

## 6. Evidence — per-point ablation

Direction predicted before each run; both predictions held. Each ablation restored under `trap … EXIT INT TERM` with a cwd-independent `git -C … checkout HEAD --`, and each restore printed an empty `git diff HEAD --stat`. Mutations proved on disk by grepping the injected **and** the removed text separately, with anchor uniqueness asserted before the edit. Committed before ablating.

### A. Revert only the convergence (`Registry.ts` back to `origin/main`; test and changeset kept)

*Predicted: the key-set pin and the `tags`/`description` counter-probe go red; the assignability control stays green.*

`tsc -p tsconfig.test.json` → **exit 2**, six diagnostics, all naming the pin file:

```
(81,30):  TS2305 Module '"../Registry.js"' has no exported member 'RegistryComponentMetaExtras'.
(101,11): TS2322 Type 'true' is not assignable to type 'false'.      <- the key-set pin
(122,11): TS2322 Type 'true' is not assignable to type 'false'.
(166,7):  TS2353 Object literal may only specify known properties, and 'tags' does not exist in type 'ComponentMeta'.
(170,25): TS2339 Property 'tags' does not exist on type 'ComponentMeta'.
(171,25): TS2339 Property 'description' does not exist on type 'ComponentMeta'.
```

Root `vitest` → **exit 1**, `Tests 2 failed | 5 passed (7)`: `imports the canonical declaration instead of restating it`, `declares none of the canonical members locally`.

**Still passing after the revert** — reported because it is the point of the exercise:
- `is mutually assignable with the canonical declaration` — **no diagnostic at all under `tsc`, and green under vitest.** This is the ghost, demonstrated on the real defect.
- `adds exactly the four registry-only keys, named` (line 113) — no diagnostic: the pre-convergence type also carried exactly those four, so this assertion is correctly indifferent to the convergence.
- `still declares the four registry-only members here` — green: the old declaration still declared them.
- Both type-level tests and the `tags`/`description` counter-probe pass **under vitest**, because annotations are erased there. `tsc` is their enforcement, which is why both legs are reported.

### B. Delete exactly one registry-only key (`labelling`) from `RegistryComponentMetaExtras`

*Predicted: the named-keys assertion goes red while the canonical-key pin stays green — proving the two are independent instruments, not one assertion written twice.*

Anchor asserted unique (1 occurrence) before the edit; landing site `1 file changed, 1 deletion(-)`.

`tsc -p tsconfig.test.json` → **exit 2**, three diagnostics:

```
(115,11): TS2322 Type 'true' is not assignable to type 'false'.       <- registryOnlyKeys
(162,7):  TS2353 … 'labelling' does not exist in type 'ComponentMeta'.
(180,20): TS2339 Property 'labelling' does not exist on type 'ComponentMeta'.
```

Root `vitest` → **exit 1**, `Tests 1 failed | 6 passed (7)`: `still declares the four registry-only members here`.

**Still passing:** `leaves no canonical key unreachable at the registration surface` (line 101 — no diagnostic), the assignability control, and — informatively — `extrasSupplyThem` (line 122), which compares the extras type against itself and so shrinks with it. That contrast is exactly why the four keys are pinned to a **literal union** as well.

## 7. Gates run locally

All exit codes captured before any pipe. Union run at `8ef81a944`, the final commit.

| gate | result |
|---|---|
| `turbo run build --filter=@object-ui/core --force` | exit 0 — `2 successful, 2 total` |
| `pnpm --filter @object-ui/core type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0 |
| `pnpm exec vitest run packages/core/` (repo root) | exit 0 — `Test Files 100 passed (100)`, `Tests 2023 passed (2023)` |
| `pnpm exec vitest run packages/core/src/registry/__tests__/component-meta-derives-from-canonical.test.ts` | exit 0 — `Tests 7 passed (7)` |
| `turbo run type-check --filter='...@object-ui/core' --filter='!@object-ui/site' --force` | exit 0 — `Tasks: 71 successful, 71 total` |
| `node scripts/check-changeset-presence.mjs` | exit 0 — *"1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"* |
| `node scripts/check-changeset-no-major.mjs` | exit 0 — *"No changeset declares a `major` bump."* |
| `pnpm --filter @object-ui/core lint` | exit 0 — 0 errors (515 pre-existing `no-explicit-any` warnings; the new test file contributes none) |
| `node scripts/check-control-bytes.mjs` | exit 0 — *"scanned 5182 tracked text file(s)"* |
| `node scripts/check-type-check-coverage.mjs` | exit 0 — *"41/41 packages compile their tests"* |
| `node scripts/check-lint-coverage.mjs` | exit 0 — *"46/46 packages linted"* |
| `node scripts/check-phantom-dependencies.mjs` | exit 0 |
| `node scripts/check-package-self-import.mjs` | exit 0 |
| `node scripts/check-vi-mock-specifiers.mjs` | exit 0 |
| `node scripts/check-doc-component-types.mjs` | exit 0 — *"Every documented component type is registered."* |
| `node scripts/check-shell-escape-residue.mjs` | exit 0 |

**Filter direction demonstrated, not asserted** — the consumer direction is the prefix form, and it is the one used above:

```
pnpm --filter '...@object-ui/core' → 38 packages (core + 37 dependents)
pnpm --filter '@object-ui/core...' →  2 packages (core + @object-ui/types, its dependency)
```

**Declared narrowings.** `pnpm test` / `pnpm lint` / `pnpm type-check` repo-wide, `check:readme-exports`, `check:doc-snippets`, `check:esm-specifiers`, `check:node-esm-load`, `check:published-dist` and `check:eager-closure` were **not** run locally; CI runs the farm regardless. The downstream `type-check` row above is the load-bearing one for a published-type change and it was run in full. `@object-ui/site` is excluded from the downstream row for runtime; it consumes `@object-ui/core` only through documentation snippets, which `check:doc-snippets` covers in CI.

## 8. Scope

- **Files touched:** `packages/core/src/registry/Registry.ts`, `packages/core/src/registry/__tests__/component-meta-derives-from-canonical.test.ts`, `.changeset/6067-component-meta-derive-from-canonical.md`. Nothing outside `packages/core/src/registry/**` plus the mandatory changeset.
- **`packages/types` was not edited.** Convergence did not require it: the canonical declaration already carries everything core needed, so importing it was sufficient. That package is held by #6267.
- **No docs edit is owed.** `content/docs/guide/component-registry.md` is the only doc that names `ComponentMeta`; it shows a registration literal and does not enumerate the key set, so nothing it states became false. Enumerating the newly reachable keys there would be a docs change outside this card's file surface.
- **PR stays draft.** No ready flip, no merge queue, no auto-merge.

## Out-of-scope finding, not fixed here

`ComponentConfig` is the same species one type down: `packages/core/src/registry/Registry.ts:141` declares `export type ComponentConfig<T = any> = ComponentMeta & { … }` while `packages/types/src/base.ts:578` declares `export interface ComponentConfig extends ComponentMeta { … }` — two same-named published declarations, differing in genericity and in which `ComponentMeta` half they build on. This PR **reduces** it (the shared eleven are now single-sourced through `ComponentMeta` on both) without closing it. Filed separately, unassigned, as a `finding`. #4631 does not cover it — that card is about a component type's three disagreeing surfaces (schema type / registry `inputs` / renderer reads), and names `ComponentConfig` nowhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mn4BZ5AVDM81pvfij1WwM9)_