### PR TITLE
fix(plugin-form): honour the declared `submitHandler` seam in every form variant

### DIFF
--- a/.changeset/submithandler-variant-forms.md
+++ b/.changeset/submithandler-variant-forms.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/plugin-form": patch
+---
+
+Honour the declared `submitHandler` seam in every form variant, not just the simple one.
+
+`ObjectFormSchema.submitHandler` is documented as the seam a host uses to own persistence: the form validates and hands the collected values over instead of calling `dataSource.create` / `dataSource.update`. `ObjectForm` forwarded the key into every variant it routes to, but only `SimpleObjectForm` read it — `TabbedForm`, `WizardForm`, `SplitForm`, `DrawerForm` and `ModalForm` persisted directly.
+
+**Behaviour change on a persistence path.** A master-detail parent half rendered `tabbed` (or `split`) now commits through the atomic `batchTransaction` together with its child collections, instead of writing the parent independently through `dataSource.create`. Previously the child leg was never attempted on those layouts: the parent was committed alone, the entered line items were silently discarded, no compensation ran, and a success toast confirmed the save. A failing child leg now leaves no committed parent, on every layout that renders the parent half inline.
+
+`WizardForm` additionally skips its own default success toast / redirect arms when a `submitHandler` is present, matching `ObjectForm`, so a host that owns the write also owns the outcome.
+
+The `object-master-detail-form.formType` vocabulary is unchanged and stays `simple | tabbed`.

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useState, useCallback, useEffect, useMemo, useRef, useId } from 'react';
-import type { FormField, DataSource } from '@object-ui/types';
+import type { FormField, DataSource, ObjectFormSchema } from '@object-ui/types';
 import {
   Sheet,
   SheetContent,
@@ -157,9 +157,10 @@ export interface DrawerFormSchema {
   layout?: 'vertical' | 'horizontal';
   columns?: number;
   /**
-   * Override persistence — the seam a host uses to own the write. Mirrors
-   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
-   * variant. When supplied, the form validates and hands the collected values
+   * Override persistence — the seam a host uses to own the write. Declared as
+   * `ObjectFormSchema['submitHandler']` rather than restated, so this variant
+   * and the canonical key `ObjectForm` forwards can never drift apart.
+   * When supplied, the form validates and hands the collected values
    * to this handler INSTEAD of calling `dataSource.create` /
    * `dataSource.update`; the returned record is passed on to `onSuccess`.
    *
@@ -168,7 +169,7 @@ export interface DrawerFormSchema {
    * item 4). A renderer that does not read it writes the parent on its own and
    * escapes that transaction — objectui#6176.
    */
-  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+  submitHandler?: ObjectFormSchema['submitHandler'];
 
   onSuccess?: (data: any) => void | Promise<void>;
   onError?: (error: Error) => void;

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -156,6 +156,20 @@ export interface DrawerFormSchema {
   readOnly?: boolean;
   layout?: 'vertical' | 'horizontal';
   columns?: number;
+  /**
+   * Override persistence — the seam a host uses to own the write. Mirrors
+   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
+   * variant. When supplied, the form validates and hands the collected values
+   * to this handler INSTEAD of calling `dataSource.create` /
+   * `dataSource.update`; the returned record is passed on to `onSuccess`.
+   *
+   * `MasterDetailForm` supplies it to route the parent AND its child
+   * collections through one atomic `batchTransaction` (#2679 / ADR-0034
+   * item 4). A renderer that does not read it writes the parent on its own and
+   * escapes that transaction — objectui#6176.
+   */
+  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+
   onSuccess?: (data: any) => void | Promise<void>;
   onError?: (error: Error) => void;
   onCancel?: () => void;
@@ -394,14 +408,25 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
 
       let result;
       const payload = sanitizeFormData(data, objectSchema);
-      if (schema.mode === 'create') {
-        // Omit the fields the producer owns (#4069) — see
-        // `omitServerResolvedDefaults` for why an empty key is not the same as
-        // no key at insert time.
-        result = await dataSource.create(
-          schema.objectName,
-          omitServerResolvedDefaults(payload, objectSchema),
-        );
+      // Omit the fields the producer owns (#4069) — see
+      // `omitServerResolvedDefaults` for why an empty key is not the same as
+      // no key at insert time. Create only: on an edit form a cleared column is
+      // a real removal. Computed ONCE so every persistence route below — the
+      // host-owned seam included — writes the identical payload.
+      const writePayload = schema.mode === 'create'
+        ? omitServerResolvedDefaults(payload, objectSchema)
+        : payload;
+
+      if (schema.submitHandler) {
+        // The host owns persistence (e.g. MasterDetailForm batching the parent
+        // + its child collections into ONE atomic transaction). The form
+        // validates and hands the values over; it does NOT create/update
+        // itself. Same seam and same precedence as SimpleObjectForm — every
+        // renderer `ObjectForm` routes to must check it FIRST, or a declared
+        // host-owned write silently becomes an independent one (objectui#6176).
+        result = await schema.submitHandler(writePayload);
+      } else if (schema.mode === 'create') {
+        result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {
         // OCC-guarded: sends `ifMatch` from the record we read; a 409 asks the
         // user to keep editing (drawer stays open, draft intact) or overwrite.

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useState, useCallback, useEffect, useMemo, useId, useRef } from 'react';
-import type { FormField, DataSource } from '@object-ui/types';
+import type { FormField, DataSource, ObjectFormSchema } from '@object-ui/types';
 import {
   Dialog,
   MobileDialogContent,
@@ -153,9 +153,10 @@ export interface ModalFormSchema {
   layout?: 'vertical' | 'horizontal';
   columns?: number;
   /**
-   * Override persistence — the seam a host uses to own the write. Mirrors
-   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
-   * variant. When supplied, the form validates and hands the collected values
+   * Override persistence — the seam a host uses to own the write. Declared as
+   * `ObjectFormSchema['submitHandler']` rather than restated, so this variant
+   * and the canonical key `ObjectForm` forwards can never drift apart.
+   * When supplied, the form validates and hands the collected values
    * to this handler INSTEAD of calling `dataSource.create` /
    * `dataSource.update`; the returned record is passed on to `onSuccess`.
    *
@@ -164,7 +165,7 @@ export interface ModalFormSchema {
    * item 4). A renderer that does not read it writes the parent on its own and
    * escapes that transaction — objectui#6176.
    */
-  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+  submitHandler?: ObjectFormSchema['submitHandler'];
 
   onSuccess?: (data: any) => void | Promise<void>;
   onError?: (error: Error) => void;

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -152,6 +152,20 @@ export interface ModalFormSchema {
   readOnly?: boolean;
   layout?: 'vertical' | 'horizontal';
   columns?: number;
+  /**
+   * Override persistence — the seam a host uses to own the write. Mirrors
+   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
+   * variant. When supplied, the form validates and hands the collected values
+   * to this handler INSTEAD of calling `dataSource.create` /
+   * `dataSource.update`; the returned record is passed on to `onSuccess`.
+   *
+   * `MasterDetailForm` supplies it to route the parent AND its child
+   * collections through one atomic `batchTransaction` (#2679 / ADR-0034
+   * item 4). A renderer that does not read it writes the parent on its own and
+   * escapes that transaction — objectui#6176.
+   */
+  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+
   onSuccess?: (data: any) => void | Promise<void>;
   onError?: (error: Error) => void;
   onCancel?: () => void;
@@ -446,14 +460,26 @@ export const ModalForm: React.FC<ModalFormProps> = ({
         }
         payload = stripped;
       }
-      if (schema.mode === 'create') {
-        // Omit the fields the producer owns (#4069) — see
-        // `omitServerResolvedDefaults` for why an empty key is not the same as
-        // no key at insert time.
-        result = await dataSource.create(
-          schema.objectName,
-          omitServerResolvedDefaults(payload, objectSchema),
-        );
+      // Omit the fields the producer owns (#4069) — see
+      // `omitServerResolvedDefaults` for why an empty key is not the same as
+      // no key at insert time. Create only: on an edit form a cleared column is
+      // a real removal. Computed ONCE (after the FLS strip above) so every
+      // persistence route below — the host-owned seam included — writes the
+      // identical payload.
+      const writePayload = schema.mode === 'create'
+        ? omitServerResolvedDefaults(payload, objectSchema)
+        : payload;
+
+      if (schema.submitHandler) {
+        // The host owns persistence (e.g. MasterDetailForm batching the parent
+        // + its child collections into ONE atomic transaction). The form
+        // validates and hands the values over; it does NOT create/update
+        // itself. Same seam and same precedence as SimpleObjectForm — every
+        // renderer `ObjectForm` routes to must check it FIRST, or a declared
+        // host-owned write silently becomes an independent one (objectui#6176).
+        result = await schema.submitHandler(writePayload);
+      } else if (schema.mode === 'create') {
+        result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {
         // OCC-guarded: sends `ifMatch` from the record we read; a 409 asks the
         // user to keep editing (modal stays open, draft intact) or overwrite.

--- a/packages/plugin-form/src/SplitForm.tsx
+++ b/packages/plugin-form/src/SplitForm.tsx
@@ -24,7 +24,7 @@
  */
 
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
-import type { FormField, DataSource } from '@object-ui/types';
+import type { FormField, DataSource, ObjectFormSchema } from '@object-ui/types';
 import { cn } from '@object-ui/components';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
@@ -106,9 +106,10 @@ export interface SplitFormSchema {
   initialData?: Record<string, any>;
   readOnly?: boolean;
   /**
-   * Override persistence — the seam a host uses to own the write. Mirrors
-   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
-   * variant. When supplied, the form validates and hands the collected values
+   * Override persistence — the seam a host uses to own the write. Declared as
+   * `ObjectFormSchema['submitHandler']` rather than restated, so this variant
+   * and the canonical key `ObjectForm` forwards can never drift apart.
+   * When supplied, the form validates and hands the collected values
    * to this handler INSTEAD of calling `dataSource.create` /
    * `dataSource.update`; the returned record is passed on to `onSuccess`.
    *
@@ -117,7 +118,7 @@ export interface SplitFormSchema {
    * item 4). A renderer that does not read it writes the parent on its own and
    * escapes that transaction — objectui#6176.
    */
-  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+  submitHandler?: ObjectFormSchema['submitHandler'];
 
   onSuccess?: (data: any) => void | Promise<void>;
   onError?: (error: Error) => void;

--- a/packages/plugin-form/src/SplitForm.tsx
+++ b/packages/plugin-form/src/SplitForm.tsx
@@ -105,6 +105,20 @@ export interface SplitFormSchema {
   initialValues?: Record<string, any>;
   initialData?: Record<string, any>;
   readOnly?: boolean;
+  /**
+   * Override persistence — the seam a host uses to own the write. Mirrors
+   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
+   * variant. When supplied, the form validates and hands the collected values
+   * to this handler INSTEAD of calling `dataSource.create` /
+   * `dataSource.update`; the returned record is passed on to `onSuccess`.
+   *
+   * `MasterDetailForm` supplies it to route the parent AND its child
+   * collections through one atomic `batchTransaction` (#2679 / ADR-0034
+   * item 4). A renderer that does not read it writes the parent on its own and
+   * escapes that transaction — objectui#6176.
+   */
+  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+
   onSuccess?: (data: any) => void | Promise<void>;
   onError?: (error: Error) => void;
   onCancel?: () => void;
@@ -232,14 +246,25 @@ export const SplitForm: React.FC<SplitFormProps> = ({
 
     try {
       let result;
-      if (schema.mode === 'create') {
-        // Omit the fields the producer owns (#4069) — see
-        // `omitServerResolvedDefaults` for why an empty key is not the same as
-        // no key at insert time.
-        result = await dataSource.create(
-          schema.objectName,
-          omitServerResolvedDefaults(data, objectSchema),
-        );
+      // Omit the fields the producer owns (#4069) — see
+      // `omitServerResolvedDefaults` for why an empty key is not the same as
+      // no key at insert time. Create only: on an edit form a cleared column is
+      // a real removal. Computed ONCE so every persistence route below — the
+      // host-owned seam included — writes the identical payload.
+      const writePayload = schema.mode === 'create'
+        ? omitServerResolvedDefaults(data, objectSchema)
+        : data;
+
+      if (schema.submitHandler) {
+        // The host owns persistence (e.g. MasterDetailForm batching the parent
+        // + its child collections into ONE atomic transaction). The form
+        // validates and hands the values over; it does NOT create/update
+        // itself. Same seam and same precedence as SimpleObjectForm — every
+        // renderer `ObjectForm` routes to must check it FIRST, or a declared
+        // host-owned write silently becomes an independent one (objectui#6176).
+        result = await schema.submitHandler(writePayload);
+      } else if (schema.mode === 'create') {
+        result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {
         // OCC-guarded: sends `ifMatch` from the record we read; a 409 asks the
         // user to keep editing (skip the success path) or overwrite.
@@ -247,7 +272,7 @@ export const SplitForm: React.FC<SplitFormProps> = ({
           dataSource,
           objectName: schema.objectName,
           recordId: schema.recordId,
-          payload: data,
+          payload: writePayload,
           baseRecord: formData,
         });
         if (outcome.status === 'cancelled') return;

--- a/packages/plugin-form/src/TabbedForm.tsx
+++ b/packages/plugin-form/src/TabbedForm.tsx
@@ -146,6 +146,20 @@ export interface TabbedFormSchema {
   readOnly?: boolean;
   
   /**
+   * Override persistence — the seam a host uses to own the write. Mirrors
+   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
+   * variant. When supplied, the form validates and hands the collected values
+   * to this handler INSTEAD of calling `dataSource.create` /
+   * `dataSource.update`; the returned record is passed on to `onSuccess`.
+   *
+   * `MasterDetailForm` supplies it to route the parent AND its child
+   * collections through one atomic `batchTransaction` (#2679 / ADR-0034
+   * item 4). A renderer that does not read it writes the parent on its own and
+   * escapes that transaction — objectui#6176.
+   */
+  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+
+  /**
    * Callbacks
    */
   onSuccess?: (data: any) => void | Promise<void>;
@@ -302,14 +316,25 @@ export const TabbedForm: React.FC<TabbedFormProps> = ({
     try {
       let result;
       
-      if (schema.mode === 'create') {
-        // Omit the fields the producer owns (#4069) — see
-        // `omitServerResolvedDefaults` for why an empty key is not the same as
-        // no key at insert time.
-        result = await dataSource.create(
-          schema.objectName,
-          omitServerResolvedDefaults(data, objectSchema),
-        );
+      // Omit the fields the producer owns (#4069) — see
+      // `omitServerResolvedDefaults` for why an empty key is not the same as
+      // no key at insert time. Create only: on an edit form a cleared column is
+      // a real removal. Computed ONCE so every persistence route below — the
+      // host-owned seam included — writes the identical payload.
+      const writePayload = schema.mode === 'create'
+        ? omitServerResolvedDefaults(data, objectSchema)
+        : data;
+
+      if (schema.submitHandler) {
+        // The host owns persistence (e.g. MasterDetailForm batching the parent
+        // + its child collections into ONE atomic transaction). The form
+        // validates and hands the values over; it does NOT create/update
+        // itself. Same seam and same precedence as SimpleObjectForm — every
+        // renderer `ObjectForm` routes to must check it FIRST, or a declared
+        // host-owned write silently becomes an independent one (objectui#6176).
+        result = await schema.submitHandler(writePayload);
+      } else if (schema.mode === 'create') {
+        result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {
         // OCC-guarded: sends `ifMatch` from the record we read; a 409 asks the
         // user to keep editing (skip the success path) or overwrite.
@@ -317,7 +342,7 @@ export const TabbedForm: React.FC<TabbedFormProps> = ({
           dataSource,
           objectName: schema.objectName,
           recordId: schema.recordId,
-          payload: data,
+          payload: writePayload,
           baseRecord: formData,
         });
         if (outcome.status === 'cancelled') return;

--- a/packages/plugin-form/src/TabbedForm.tsx
+++ b/packages/plugin-form/src/TabbedForm.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useState, useCallback, useRef } from 'react';
-import type { FormField, DataSource } from '@object-ui/types';
+import type { FormField, DataSource, ObjectFormSchema } from '@object-ui/types';
 import { cn } from '@object-ui/components';
 import { SchemaRenderer, useSafeFieldLabel } from '@object-ui/react';
 import { buildSectionFields as buildSectionFieldsShared } from './sectionFields';
@@ -146,9 +146,10 @@ export interface TabbedFormSchema {
   readOnly?: boolean;
   
   /**
-   * Override persistence — the seam a host uses to own the write. Mirrors
-   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
-   * variant. When supplied, the form validates and hands the collected values
+   * Override persistence — the seam a host uses to own the write. Declared as
+   * `ObjectFormSchema['submitHandler']` rather than restated, so this variant
+   * and the canonical key `ObjectForm` forwards can never drift apart.
+   * When supplied, the form validates and hands the collected values
    * to this handler INSTEAD of calling `dataSource.create` /
    * `dataSource.update`; the returned record is passed on to `onSuccess`.
    *
@@ -157,7 +158,7 @@ export interface TabbedFormSchema {
    * item 4). A renderer that does not read it writes the parent on its own and
    * escapes that transaction — objectui#6176.
    */
-  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+  submitHandler?: ObjectFormSchema['submitHandler'];
 
   /**
    * Callbacks

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -204,6 +204,20 @@ export interface WizardFormSchema {
   readOnly?: boolean;
   
   /**
+   * Override persistence — the seam a host uses to own the write. Mirrors
+   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
+   * variant. When supplied, the form validates and hands the collected values
+   * to this handler INSTEAD of calling `dataSource.create` /
+   * `dataSource.update`; the returned record is passed on to `onSuccess`.
+   *
+   * `MasterDetailForm` supplies it to route the parent AND its child
+   * collections through one atomic `batchTransaction` (#2679 / ADR-0034
+   * item 4). A renderer that does not read it writes the parent on its own and
+   * escapes that transaction — objectui#6176.
+   */
+  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+
+  /**
    * Callbacks
    */
   onSuccess?: (data: any) => void | Promise<void>;
@@ -550,14 +564,26 @@ export const WizardForm: React.FC<WizardFormProps> = ({
         }
         
         let result;
-        if (schema.mode === 'create') {
-          // Omit the fields the producer owns (#4069) — see
-          // `omitServerResolvedDefaults` for why an empty key is not the same
-          // as no key at insert time.
-          result = await dataSource.create(
-            schema.objectName,
-            omitServerResolvedDefaults(mergedData, objectSchema),
-          );
+        // Omit the fields the producer owns (#4069) — see
+        // `omitServerResolvedDefaults` for why an empty key is not the same
+        // as no key at insert time. Create only: on an edit form a cleared
+        // column is a real removal. Computed ONCE so every persistence route
+        // below — the host-owned seam included — writes the identical payload.
+        const writePayload = schema.mode === 'create'
+          ? omitServerResolvedDefaults(mergedData, objectSchema)
+          : mergedData;
+
+        if (schema.submitHandler) {
+          // The host owns persistence (e.g. MasterDetailForm batching the
+          // parent + its child collections into ONE atomic transaction). The
+          // form validates and hands the values over; it does NOT create/update
+          // itself. Same seam and same precedence as SimpleObjectForm — every
+          // renderer `ObjectForm` routes to must check it FIRST, or a declared
+          // host-owned write silently becomes an independent one
+          // (objectui#6176).
+          result = await schema.submitHandler(writePayload);
+        } else if (schema.mode === 'create') {
+          result = await dataSource.create(schema.objectName, writePayload);
         } else if (schema.mode === 'edit' && schema.recordId) {
           // OCC-guarded: sends `ifMatch` from the record we read; a 409 asks
           // the user to keep editing (skip the success path) or overwrite.
@@ -567,7 +593,7 @@ export const WizardForm: React.FC<WizardFormProps> = ({
             dataSource,
             objectName: schema.objectName,
             recordId: schema.recordId,
-            payload: mergedData,
+            payload: writePayload,
             baseRecord: formData,
           });
           if (outcome.status === 'cancelled') return;
@@ -576,7 +602,7 @@ export const WizardForm: React.FC<WizardFormProps> = ({
         
         if (schema.onSuccess) {
           await schema.onSuccess(result);
-        } else if (schema.submitBehavior) {
+        } else if (!schema.submitHandler && schema.submitBehavior) {
           const behavior = schema.submitBehavior;
           switch (behavior.kind) {
             case 'redirect': {
@@ -636,8 +662,12 @@ export const WizardForm: React.FC<WizardFormProps> = ({
               break;
             }
           }
-        } else {
+        } else if (!schema.submitHandler) {
           // Legacy declarative success behaviors for metadata-only wizards.
+          // Skipped when a `submitHandler` owns persistence: the host already
+          // reports the outcome, so a second toast/redirect here would
+          // double-confirm (the guard SimpleObjectForm applies for the same
+          // reason).
           const nav = resolveSuccessNavigate(schema.navigateOnSuccess, result);
           if (nav) {
             // Landing on the saved record is the confirmation — no toast needed.

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { useState, useCallback, useMemo } from 'react';
-import type { FormField, DataSource } from '@object-ui/types';
+import type { FormField, DataSource, ObjectFormSchema } from '@object-ui/types';
 import { Button, cn, toast } from '@object-ui/components';
 import { AlertCircle, Check, ChevronLeft, ChevronRight, Loader2 } from 'lucide-react';
 import { resolveFieldRuleState, evalFieldPredicate, isMissingForRequired, isServerOwnedValue } from '@object-ui/core';
@@ -204,9 +204,10 @@ export interface WizardFormSchema {
   readOnly?: boolean;
   
   /**
-   * Override persistence — the seam a host uses to own the write. Mirrors
-   * `ObjectFormSchema.submitHandler`, the key `ObjectForm` forwards into this
-   * variant. When supplied, the form validates and hands the collected values
+   * Override persistence — the seam a host uses to own the write. Declared as
+   * `ObjectFormSchema['submitHandler']` rather than restated, so this variant
+   * and the canonical key `ObjectForm` forwards can never drift apart.
+   * When supplied, the form validates and hands the collected values
    * to this handler INSTEAD of calling `dataSource.create` /
    * `dataSource.update`; the returned record is passed on to `onSuccess`.
    *
@@ -215,7 +216,7 @@ export interface WizardFormSchema {
    * item 4). A renderer that does not read it writes the parent on its own and
    * escapes that transaction — objectui#6176.
    */
-  submitHandler?: (values: Record<string, any>) => any | Promise<any>;
+  submitHandler?: ObjectFormSchema['submitHandler'];
 
   /**
    * Callbacks

--- a/packages/plugin-form/src/masterDetailFormTypeVocabulary.test.tsx
+++ b/packages/plugin-form/src/masterDetailFormTypeVocabulary.test.tsx
@@ -36,6 +36,9 @@
  *               step's fields, and the master-detail's single bottom Save bar
  *               drives the wizard's `Next` instead of saving.
  *   `split`   → ObjectForm.tsx:287  (SplitForm) — renders two panels inline.
+ *               (It ALSO escaped the atomic batch when this file was written;
+ *               objectui#6176 fixed that, so only the presentation difference
+ *               is left. The set below is unchanged regardless.)
  *   `drawer`  → ObjectForm.tsx:316  (DrawerForm) — hosts the parent half in a
  *               PORTAL dialog, outside the master-detail container, so the Save
  *               bar has no `<form>` to submit.
@@ -210,15 +213,24 @@ describe('the measurement the vocabulary is derived from', () => {
     expect(create).not.toHaveBeenCalled();
   });
 
-  it('`split` is excluded: it renders inline but persists AROUND the atomic batch', async () => {
+  it('`split` renders inline and now saves through the ATOMIC batch — its persistence rationale is spent (objectui#6176)', async () => {
     const { container, batchTransaction, create } = mountWith('split');
     await waitFor(() => expect(container.querySelector('input[name="ref"]')).toBeTruthy());
     expect(await clickHostSave(container)).toBe(true);
-    // `submitHandler` — the hook MasterDetailForm hands the parent form to route
-    // the save through `batchTransaction` — is read only by SimpleObjectForm
-    // (ObjectForm.tsx:820). SplitForm writes the parent directly instead.
-    await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
-    expect(batchTransaction).not.toHaveBeenCalled();
+    // This row used to read `create 1 / batchTransaction 0`. `submitHandler` —
+    // the hook MasterDetailForm hands the parent form so the save routes
+    // through `batchTransaction` — was read only by SimpleObjectForm, and
+    // SplitForm wrote the parent directly instead. objectui#6176 made every
+    // renderer honour the declared seam, so this row now reads like `simple`.
+    await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
+    expect(create).not.toHaveBeenCalled();
+    // ⚠️ The VOCABULARY is deliberately unchanged and stays `simple | tabbed`
+    // (asserted above). Admitting `split` would be a contract change, and
+    // objectui#6176 — a declared-vs-enforced restoration — did not make it.
+    // What this case now records is narrower than before: the PERSISTENCE
+    // reason for excluding `split` no longer holds, so whatever keeps it out is
+    // presentational and is an open question for triage, not a fact this file
+    // may assert.
   });
 
   it('the harm the closed vocabulary guards: an out-of-vocabulary value silently drops the sections', async () => {

--- a/packages/plugin-form/src/submitHandlerSeam.test.tsx
+++ b/packages/plugin-form/src/submitHandlerSeam.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * `submitHandler` is the DECLARED seam a host uses to own persistence, and
+ * EVERY renderer `ObjectForm` routes to must honour it (objectui#6176).
+ *
+ * ## What went wrong
+ *
+ * `ObjectFormSchema.submitHandler` is documented as "the form validates and
+ * hands the collected values to the host INSTEAD of calling dataSource.create /
+ * dataSource.update". `ObjectForm` forwards the key into every variant it
+ * routes to — the `{...schema}` spread carries it — but only `SimpleObjectForm`
+ * ever read it. `TabbedForm`, `WizardForm`, `SplitForm`, `DrawerForm` and
+ * `ModalForm` called `dataSource.create` directly instead.
+ *
+ * That is not cosmetic. `MasterDetailForm` supplies `submitHandler:
+ * submitViaBatch` precisely so the parent AND its child collections commit as
+ * ONE `batchTransaction` (#2679 / ADR-0034 item 4). With the parent half
+ * rendered `tabbed`, the measured reading on `main` was:
+ *
+ *     batchTransaction 0 · dataSource.create 1 · args ["po", {"ref":"PO-1"}]
+ *
+ * and the consequence is worse than a bypassed transaction: the child leg was
+ * never ATTEMPTED at all. The parent committed alone, the operator's entered
+ * line items were silently discarded, no compensation ran, and a SUCCESS toast
+ * confirmed it. `split` measured identically.
+ *
+ * ## What each block below pins
+ *
+ * 1. The data-integrity claim — a failing child leg must leave NO committed
+ *    parent. This is the assertion that distinguishes the two worlds; "the
+ *    parent was created" is true in both.
+ * 2. The seam itself, per renderer — all six, because a fix landing on four of
+ *    five still passes a suite that only exercises four.
+ * 3. The master-detail composition reading the card measured.
+ *
+ * ## Scope, stated so it is not over-read
+ *
+ * This restores an implementation to a decision already taken; it does NOT
+ * change the `object-master-detail-form.formType` vocabulary, which stays
+ * `simple | tabbed` (objectui#5939). See `masterDetailFormTypeVocabulary.test.tsx`
+ * — one exclusion rationale there is updated because this fix falsifies it, but
+ * the SET is untouched.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, fireEvent, screen } from '@testing-library/react';
+import React from 'react';
+import { registerAllFields } from '@object-ui/fields';
+import { MasterDetailForm } from './MasterDetailForm';
+import { ObjectForm } from './ObjectForm';
+import './index';
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('@object-ui/components', async (orig) => {
+  const actual = await (orig as any)();
+  return {
+    ...actual,
+    toast: {
+      success: (...a: any[]) => toastSuccess(...a),
+      error: (...a: any[]) => toastError(...a),
+    },
+  };
+});
+
+registerAllFields();
+
+/** The full vocabulary `object-form` declares — every renderer `ObjectForm` routes to. */
+const OBJECT_FORM_SIX = ['simple', 'tabbed', 'wizard', 'split', 'drawer', 'modal'] as const;
+
+/**
+ * The variants that render the parent half INLINE, so the master-detail host's
+ * single Save bar can actually reach a `<form>`. `wizard` (mounts one step at a
+ * time, and the Save bar drives its `Next`) and `drawer` / `modal` (parent half
+ * lands in a portal dialog) are excluded by LAYOUT, not by the seam — that
+ * exclusion is measured in `masterDetailFormTypeVocabulary.test.tsx`.
+ */
+const INLINE_PARENT_VARIANTS = ['simple', 'tabbed', 'split'] as const;
+
+const parentObject = {
+  name: 'po',
+  fields: { ref: { type: 'text', label: 'Ref' }, memo: { type: 'text', label: 'Memo' } },
+};
+
+const masterDetailSchema = (formType: string) => ({
+  objectName: 'po',
+  mode: 'create',
+  formType,
+  sections: [
+    { name: 's1', label: 'Sec One', fields: ['ref'] },
+    { name: 's2', label: 'Sec Two', fields: ['memo'] },
+  ],
+  details: [
+    {
+      childObject: 'po_line',
+      relationshipField: 'po',
+      columns: [{ name: 'qty', label: 'Qty', type: 'number' }],
+    },
+  ],
+});
+
+/**
+ * Fill the parent header AND the first (ghost) line, so the save carries BOTH
+ * legs. Without a real child row the batch would be a single-op list and the
+ * atomicity claim would have nothing to be atomic about.
+ */
+async function fillHeaderAndLine(container: HTMLElement) {
+  const ref = await waitFor(() => {
+    const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+    if (!el) throw new Error('parent form not ready');
+    return el;
+  });
+  fireEvent.change(ref, { target: { value: 'PO-1' } });
+  const qty = await waitFor(() => screen.getAllByLabelText('Qty')[0] as HTMLInputElement);
+  fireEvent.change(qty, { target: { value: '5' } });
+}
+
+const clickHostSave = () =>
+  fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+beforeEach(() => {
+  toastSuccess.mockClear();
+  toastError.mockClear();
+});
+
+describe('a failing child leg leaves NO committed parent, whichever variant renders the parent half (objectui#6176)', () => {
+  // A dataSource with NO `batchTransaction`: `runBatchTransaction` falls back to
+  // `emulateBatchTransaction`, which drives the ops in order and COMPENSATES on
+  // failure. The compensating delete is the observable stand-in for a rollback,
+  // which is why this shape is used rather than a rejecting atomic stub — a
+  // rejecting stub can only show that nothing was written, never that an
+  // already-written parent gets removed.
+  it.each(INLINE_PARENT_VARIANTS)(
+    'formType `%s`: the child create fails → the just-created parent is compensated away, and the operator is told',
+    async (formType) => {
+      const create = vi.fn(async (object: string, data: any) => {
+        if (object === 'po_line') throw new Error('child create failed');
+        return { id: 'po1', ...data };
+      });
+      const del = vi.fn(async () => true);
+      const dataSource = {
+        getObjectSchema: vi.fn().mockResolvedValue(parentObject),
+        find: vi.fn().mockResolvedValue({ data: [] }),
+        create,
+        update: vi.fn(),
+        delete: del,
+        bulk: vi.fn(),
+        // deliberately NO batchTransaction
+      } as any;
+
+      const { container } = render(
+        <MasterDetailForm schema={masterDetailSchema(formType) as any} dataSource={dataSource} />,
+      );
+      await fillHeaderAndLine(container);
+      clickHostSave();
+
+      // POSITIVE PROBE — the child leg was actually attempted. Without this the
+      // assertions below pass vacuously on a form that never submitted at all,
+      // which is exactly how the broken `tabbed` path read: parent written, the
+      // child collection silently dropped, nothing to fail.
+      await waitFor(() =>
+        expect(create).toHaveBeenCalledWith('po_line', expect.objectContaining({ po: 'po1' })),
+      );
+
+      // THE PIN — no committed parent survives the failed leg.
+      await waitFor(() => expect(del).toHaveBeenCalledWith('po', 'po1'));
+      // …and the failure is surfaced. On the broken path the operator got a
+      // SUCCESS toast over a half-written document.
+      await waitFor(() => expect(toastError).toHaveBeenCalled());
+      expect(toastSuccess).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('every renderer ObjectForm routes to honours the declared `submitHandler` seam', () => {
+  // Mounted through `ObjectForm` itself — the component that OWNS the routing —
+  // so this exercises the same forwarding path a real host uses, not each
+  // variant in isolation.
+  it.each(OBJECT_FORM_SIX)(
+    'formType `%s`: hands the values to the host and does NOT persist on its own',
+    async (formType) => {
+      const submitHandler = vi.fn().mockResolvedValue({ id: 'p1' });
+      const create = vi.fn().mockResolvedValue({ id: 'p1' });
+      const update = vi.fn().mockResolvedValue({ id: 'p1' });
+      const dataSource = {
+        getObjectSchema: vi.fn().mockResolvedValue(parentObject),
+        find: vi.fn().mockResolvedValue({ data: [] }),
+        create,
+        update,
+        delete: vi.fn(),
+        bulk: vi.fn(),
+      } as any;
+
+      render(
+        <ObjectForm
+          schema={{
+            type: 'object-form',
+            objectName: 'po',
+            mode: 'create',
+            formType,
+            // `drawer` / `modal` host the form in a dialog — open it, or there
+            // is no form to submit and every assertion below passes vacuously.
+            open: true,
+            submitText: 'Save Now',
+            sections: [{ name: 's1', label: 'Sec One', fields: ['ref'] }],
+            submitHandler,
+          } as any}
+          dataSource={dataSource}
+        />,
+      );
+
+      const ref = await waitFor(() => {
+        const el = document.querySelector('input[name="ref"]') as HTMLInputElement | null;
+        if (!el) throw new Error('form not ready');
+        return el;
+      });
+      fireEvent.change(ref, { target: { value: 'PO-1' } });
+      fireEvent.click(screen.getByRole('button', { name: /save now/i }));
+
+      // POSITIVE — the host was handed the collected values. A bare
+      // "create was not called" would also hold for a form that never submitted.
+      await waitFor(() => expect(submitHandler).toHaveBeenCalledTimes(1));
+      expect(submitHandler).toHaveBeenCalledWith(expect.objectContaining({ ref: 'PO-1' }));
+      // NEGATIVE — the form did not write on its own behind the host's back.
+      expect(create).not.toHaveBeenCalled();
+      expect(update).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('master-detail: the parent commits INSIDE the atomic batch, not beside it', () => {
+  // The card's own measurement, re-expressed as a pin. On `main` the `tabbed`
+  // and `split` rows read `batchTransaction 0 / create 1`.
+  it.each(INLINE_PARENT_VARIANTS)(
+    'formType `%s`: one batchTransaction carrying BOTH legs, and zero independent creates',
+    async (formType) => {
+      const batchTransaction = vi.fn().mockResolvedValue({ results: [{ id: 'po1' }] });
+      const create = vi.fn().mockResolvedValue({ id: 'po1' });
+      const dataSource = {
+        getObjectSchema: vi.fn().mockResolvedValue(parentObject),
+        find: vi.fn().mockResolvedValue({ data: [] }),
+        create,
+        update: vi.fn(),
+        delete: vi.fn(),
+        bulk: vi.fn(),
+        batchTransaction,
+      } as any;
+
+      const { container } = render(
+        <MasterDetailForm schema={masterDetailSchema(formType) as any} dataSource={dataSource} />,
+      );
+      await fillHeaderAndLine(container);
+      clickHostSave();
+
+      await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
+      const ops = batchTransaction.mock.calls[0][0];
+      // BOTH legs in one operation list — the parent at index 0 and the child
+      // pointing at it through `$ref: 0`, which is what makes the commit atomic.
+      expect(ops).toHaveLength(2);
+      expect(ops[0]).toMatchObject({ object: 'po', action: 'create', data: { ref: 'PO-1' } });
+      expect(ops[1]).toMatchObject({ object: 'po_line', action: 'create', data: { po: { $ref: 0 } } });
+      // The escape this card closed.
+      expect(create).not.toHaveBeenCalled();
+    },
+  );
+});


### PR DESCRIPTION
Fixes #6176

`ObjectFormSchema.submitHandler` is documented as the seam a host uses to own persistence — "the form validates and hands the collected values to the host INSTEAD of calling `dataSource.create` / `dataSource.update`". `ObjectForm` forwards the key into every variant it routes to (the `{...schema}` spread carries it), but only `SimpleObjectForm` ever read it. `TabbedForm`, `WizardForm`, `SplitForm`, `DrawerForm` and `ModalForm` persisted directly instead. This is a declared-vs-enforced restoration against ADR-0034 item 4 / #2679, which chose the atomic batch.

## Premise reproduced before any source was touched

Measured on `origin/main` @ `c456d91f4`, master-detail parent with two sections and one detail collection, driving the master-detail's own bottom Save bar. Counts are calls on the same stub `dataSource`:

| parent `formType` | `batchTransaction` | `dataSource.create` | observed argument |
|---|---|---|---|
| `simple` | 1 | 0 | — |
| `tabbed` | **0** | **1** | `["po", {"ref":"PO-1"}]` |
| `wizard` | 0 | 0 | Save bar drives `Next` |
| `split` | **0** | **1** | `["po", {"ref":"PO-1"}]` |
| `drawer` / `modal` | 0 | 0 | parent half is in a portal dialog |

That is the card's measurement, including its observed argument, reproduced exactly.

⚠️ The first version of that probe read `0 / 0` on **every** row — `simple` included — because it clicked before the form had mounted. The `simple` positive control is what caught it; the numbers above are from the corrected probe.

### The consequence is worse than "the batch is bypassed"

With `formType: tabbed` (and `split`), the child leg is **never attempted at all**. Measured on the emulated path (a `dataSource` with no `batchTransaction`, whose child create fails):

| | `simple` (on `main`) | `tabbed` / `split` (on `main`) |
|---|---|---|
| creates issued | `po`, `po_line` | `po` only |
| child leg attempted | yes | **no** |
| compensating delete | `delete('po','po1')` | **none** |
| operator sees | error toast | **success toast** |

So the parent commits alone, the entered line items are silently discarded, nothing rolls back, and the save is confirmed as successful.

## The fix

Each of the five variants now checks `schema.submitHandler` first, with the same precedence `SimpleObjectForm` uses, and declares the key on its own schema interface. Two supporting choices:

- **One `writePayload` per handler.** The create-mode `omitServerResolvedDefaults` call was hoisted so the host-owned route and the direct route cannot write different payloads. On the non-handler path the value is provably identical (in the edit branch `mode === 'edit'`, so `writePayload === data`).
- **Declared by reference, not restated.** `submitHandler?: ObjectFormSchema['submitHandler']` rather than a copied signature, so the variant key and the canonical key can never drift. (This also removed the 15 `no-explicit-any` warnings the restated version introduced.)

`WizardForm` additionally guards its default success arms with `!schema.submitHandler`, mirroring `ObjectForm`, so a host that owns the write also owns the outcome instead of double-confirming.

## Evidence

**Per-point ablation** — five repair points, each reverted alone to `c456d91f4`, with the mutation proven on disk each leg (seam marker `0` in the ablated file, `1` in the other four) and restoration proven the same way. Restore ran under `trap … EXIT INT TERM`; `git diff HEAD --stat` was empty afterwards.

| reverted | red cases | still green |
|---|---|---|
| `TabbedForm` | 3 — `tabbed` in all three blocks | 20/23, incl. the whole vocabulary file |
| `SplitForm` | 4 — `split` in all three blocks **+ the vocabulary file's `split` case** | 19/23 |
| `WizardForm` | 1 — `wizard` seam pin | 22/23 |
| `DrawerForm` | 1 — `drawer` seam pin | 22/23 |
| `ModalForm` | 1 — `modal` seam pin | 22/23 |

`simple` stayed green in **every** leg — the control that keeps the negative assertions from passing vacuously.

⚠️ Worth noting from the `TabbedForm` leg: the entire pre-existing vocabulary file stayed green, **including its `tabbed` case**. That case asserts only presentation, so it passes in both the broken and the fixed world — it was never an instrument for this defect. The new pins are.

**New file `submitHandlerSeam.test.tsx`** (12 cases) pins, in order of what matters:
1. *a failing child leg leaves no committed parent* — for `simple`/`tabbed`/`split`, with a **positive probe** that the child leg was actually attempted, so the rollback assertion cannot pass on a form that never submitted;
2. the seam itself for **all six** renderers, mounted through `ObjectForm` so the forwarding path is the real one — positive (handler received the values) **and** negative (`create`/`update` untouched);
3. the master-detail reading: one `batchTransaction` carrying **both** legs, zero independent creates.

## Vocabulary deliberately unchanged — and one open question

The `object-master-detail-form.formType` vocabulary stays `simple | tabbed`. Narrowing or widening it is a contract change and is not this card's to make.

⚠️ **But this fix falsifies one of the vocabulary file's stated exclusion rationales.** `masterDetailFormTypeVocabulary.test.tsx` excluded `split` because it "renders inline but persists AROUND the atomic batch". The second half is no longer true — `split` now saves through the batch like `simple`. That case is updated to pin the new true reading and to record that the *persistence* reason for excluding `split` is spent. **Whether `split` should now be admitted to the vocabulary is a contract question left open for triage** — deliberately not decided here.

## Gates

Run from the repo root at `403488be2` (the final commit):

| gate | result |
|---|---|
| `vitest run packages/plugin-form/` | 65 files / 650 tests passed |
| `plugin-form type-check` | exit 0 |
| `plugin-form lint` | `0 errors, 673 warnings` (base `c456d91f4` = `0 errors, 663 warnings`; the +10 are `as any` stubs in the new test file — **zero** new warnings in the five source files) |
| `check-changeset-presence` | declares 1 changeset |
| `check-changeset-no-major` / `-fixed` | no `major`; all packages in the fixed group |
| `check-control-bytes` | OK (5184 files) |
| `check-vi-mock-specifiers` | OK |

**Consumer sweep, downstream direction** (dependents of `plugin-form`): `plugin-designer` + `plugin-view` 34 files / 297 tests; `app-shell` 18 files / 262 tests; `apps/console` 8 files / 203 tests — all passed.

⚠️ **Declared narrowing.** The full `packages/app-shell` suite hit the container's ~10-minute foreground cap (`exit 143`, no failures in the partial log) and was narrowed to the 18 files that reach `plugin-form`. The narrowing rests on a measured invariance, not a guess: **no code outside `packages/plugin-form` supplies a `submitHandler` anywhere in `packages/` or `apps/`**, so the new behavioural arm is unreachable from every consumer; the only reachable change is the `writePayload` hoist, which is value-identical. CI runs the full farm regardless.

_Generated by [Claude Code](https://claude.ai/code/session_01Mn4BZ5AVDM81pvfij1WwM9)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mn4BZ5AVDM81pvfij1WwM9)_