### PR TITLE
refactor(plugin-gantt): drop the deprecated `width` from the drawer default, state the navConfig comment once

### DIFF
--- a/.changeset/gantt-navconfig-comment-once.md
+++ b/.changeset/gantt-navconfig-comment-once.md
@@ -1,0 +1,6 @@
+---
+---
+
+Comment-only cleanup in `ObjectGantt`: the block above the `navConfig` default
+repeated its own last two lines verbatim, leaving a mid-sentence fragment. The
+sentence is now stated once, in full. No published behaviour changes.

--- a/.changeset/gantt-navconfig-comment-once.md
+++ b/.changeset/gantt-navconfig-comment-once.md
@@ -1,6 +1,15 @@
 ---
 ---
 
-Comment-only cleanup in `ObjectGantt`: the block above the `navConfig` default
-repeated its own last two lines verbatim, leaving a mid-sentence fragment. The
-sentence is now stated once, in full. No published behaviour changes.
+`ObjectGantt` internal cleanup, measured as a zero-pixel change:
+
+- The comment block above the `navConfig` default repeated its own last two
+  lines verbatim, leaving a mid-sentence fragment. The sentence is now stated
+  once, in full.
+- The drawer default no longer spells the spec-deprecated `width`
+  (`@deprecated [#2578 -> size]`). It is now `{ mode: 'drawer' }`, so
+  `resolveOverlayWidth` returns `undefined` and `RecordDetailDrawer`'s own
+  `width` default supplies the identical `min(960px, 60vw)`. The resolved
+  overlay width is unchanged on every viewport, and is now pinned by a test.
+
+No published behaviour changes.

--- a/packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Pins the drawer width a gantt gets when it declares no `navigation`.
+ *
+ * ObjectGantt used to hard-code `{ mode: 'drawer', width: 'min(960px, 60vw)' }`
+ * as that default. `width` is `@deprecated [#2578 -> size]` and
+ * `resolveOverlayWidth` gives an explicit `width` priority OVER `size`, so
+ * spelling it kept the deprecated branch load-bearing on the path most gantts
+ * take. The default is now `{ mode: 'drawer' }`: `resolveOverlayWidth` returns
+ * `undefined` and RecordDetailDrawer's own `width` default supplies the
+ * identical CSS — a zero-pixel change.
+ *
+ * That equivalence was previously pinned by NOTHING: a repo-wide search for
+ * `min(960px, 60vw)` returned only producers, zero assertions, and the whole
+ * 402-test gantt suite stayed green when the value was changed. Both halves
+ * below are load-bearing and fail for different reasons:
+ *
+ *   half 1 — the gantt must stop injecting a width of its own (it has to hand
+ *            `undefined` down, or the drawer's default can never apply);
+ *   half 2 — the width the REAL drawer then resolves must still be that value.
+ *            Without this half the gantt would follow a moved drawer default
+ *            invisibly, which is the regression the indirection introduces.
+ *
+ * Both assert the resolved width VALUE — never a `className`, never "it
+ * renders", either of which passes in both worlds.
+ */
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectGantt } from './ObjectGantt';
+
+/** The width the gantt's drawer has always resolved to. Must not drift. */
+const EXPECTED_WIDTH = 'min(960px, 60vw)';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks, onTaskClick }: any) => (
+    <div data-testid="gantt-view">
+      {tasks.map((t: any) => (
+        <button key={t.id} data-testid={`gv-view-${t.id}`} onClick={() => onTaskClick?.(t)}>
+          {t.title}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+// Record the props ObjectGantt hands down, then delegate to the REAL drawer so
+// half 2 measures the actual resolution rather than a stub's idea of it.
+let drawerProps: any = null;
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  const Real = actual.RecordDetailDrawer;
+  return {
+    ...actual,
+    RecordDetailDrawer: (props: any) => {
+      drawerProps = props;
+      return <Real {...props} />;
+    },
+  };
+});
+
+function makeSchema(): any {
+  return {
+    type: 'gantt',
+    objectName: 'tasks',
+    gantt: { titleField: 'name', startDateField: 'start_date', endDateField: 'end_date' },
+    data: {
+      provider: 'value',
+      items: [{ id: '1', name: 'Row', start_date: '2024-01-01', end_date: '2024-01-05' }],
+    },
+  };
+}
+
+async function openDrawer() {
+  render(<ObjectGantt schema={makeSchema()} />);
+  await waitFor(() => expect(screen.getByTestId('gv-view-1')).toBeDefined());
+  fireEvent.click(screen.getByTestId('gv-view-1'));
+  await waitFor(() => expect(drawerProps).not.toBeNull());
+}
+
+describe('gantt drawer width with no declared `navigation`', () => {
+  beforeEach(() => {
+    drawerProps = null;
+    // Cross-test leakage guard: the drawer prefers a drag-resized width
+    // persisted in localStorage over its prop, which would mask half 2.
+    try { window.localStorage.clear(); } catch { /* ignore */ }
+  });
+
+  it('half 1: the gantt injects no width of its own (so the drawer default applies)', async () => {
+    await openDrawer();
+    expect(drawerProps.width).toBeUndefined();
+  });
+
+  it('half 2: the width the real drawer resolves is still the pinned value', async () => {
+    await openDrawer();
+    // The drawer applies the resolved width as an inline style on its panel,
+    // as BOTH `width` and `max-width`. happy-dom's CSS parser drops the
+    // `width` longhand when the value is a `min()` expression but keeps
+    // `max-width`, so the surviving declaration is what we read — it is the
+    // same resolved string, not a proxy for it.
+    const panel = document.querySelector('[role="dialog"]') as HTMLElement | null;
+    expect(panel, 'drawer panel').not.toBeNull();
+    expect(panel!.style.maxWidth).toBe(EXPECTED_WIDTH);
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -1147,7 +1147,24 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // Default to a right-side drawer so clicking a task opens an editable
   // detail panel inline (no full-page navigation). Schema can override by
   // providing its own `navigation` config (e.g., page mode).
-  const navConfig = schema.navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' };
+  //
+  // No width is spelled here on purpose. `width` is `@deprecated [#2578 ->
+  // size]` in the spec that owns this shape, and `resolveOverlayWidth` gives
+  // an explicit `width` priority OVER `size` — so spelling it kept the
+  // deprecated branch load-bearing on the path most gantts take (no declared
+  // `navigation`), and made the size buckets unreachable there. Omitting both
+  // leaves `resolveOverlayWidth` returning `undefined`, which is what
+  // RecordDetailDrawer's own `width` default is for; that default is the
+  // identical `min(960px, 60vw)`, so this is a zero-pixel change on every
+  // viewport. Pinned by ObjectGantt.navWidthDefault.test.tsx — both halves,
+  // because the equivalence now depends on the drawer's default too.
+  //
+  // Deliberately NOT converged on `size: 'lg'`: that bucket is
+  // `min(92vw, 960px)`, which agrees with the above only at viewport >=
+  // 1600px and is up to 53% wider below it. Whether the renderers should move
+  // to the bucket is open (#6259), and spans kanban/calendar/RecordDetailDrawer
+  // as one decision (#6303).
+  const navConfig = schema.navigation ?? { mode: 'drawer' };
   const navIsOverlay = navConfig.mode === 'drawer' || navConfig.mode === 'modal' || navConfig.mode === 'split' || navConfig.mode === 'popover';
   const navigation = useNavigationOverlay({
     navigation: navConfig,

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -1147,8 +1147,6 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // Default to a right-side drawer so clicking a task opens an editable
   // detail panel inline (no full-page navigation). Schema can override by
   // providing its own `navigation` config (e.g., page mode).
-  // detail panel inline (no full-page navigation). Schema can override by
-  // providing its own `navigation` config (e.g., page mode).
   const navConfig = schema.navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' };
   const navIsOverlay = navConfig.mode === 'drawer' || navConfig.mode === 'modal' || navConfig.mode === 'split' || navConfig.mode === 'popover';
   const navigation = useNavigationOverlay({


### PR DESCRIPTION
Fixes #6258
Fixes #6259

Two-card family dispatch on four consecutive lines of `packages/plugin-gantt/src/ObjectGantt.tsx`. One commit per member. Base `origin/main` @ `090927f4f`; all evidence below at `ae7898efb`.

---

## #6258 — the comment (commit `21cfe3142`)

The block above `navConfig` repeated its own last two lines verbatim, so the text ran on into a fragment. On `090927f4f` it was five lines, `:1147-:1151`:

```
1147  // Default to a right-side drawer so clicking a task opens an editable
1148  // detail panel inline (no full-page navigation). Schema can override by
1149  // providing its own `navigation` config (e.g., page mode).
1150  // detail panel inline (no full-page navigation). Schema can override by
1151  // providing its own `navigation` config (e.g., page mode).
```

`:1147-:1149` already state the sentence completely and in order; `:1150-:1151` were a byte-for-byte repeat of `:1148-:1149`. **Removed `:1150-:1151`.**

**Judge** — the sentence appears exactly once, in full, in order: PASS.
**Ablation** — re-inserting the duplicate pair (proved on disk: each line's count 1→2, blob `82ede38`→`22d30b9`) turns that judge red (`VERDICT=FAIL`, exit 1) while the gantt suite stays green. The suite is *not* the judge for this leg; the explicit check is.

---

## #6259 — the deprecated `width` in the drawer default (commit `ae7898efb`)

```diff
-  const navConfig = schema.navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' };
+  const navConfig = schema.navigation ?? { mode: 'drawer' };
```

`width` is `@deprecated [#2578 → size]` in the spec that owns the shape, and `resolveOverlayWidth` gives an explicit `width` priority **over** `size` — so while the default spelled it, a gantt declaring no `navigation` could never be reached by the size buckets, and the deprecated branch stayed load-bearing on the path most gantts take.

Dropping `width` **without** adding `size` removes that branch at a **measured zero-pixel change**: `resolveOverlayWidth` returns `undefined`, and `RecordDetailDrawer`'s own `width` default supplies the byte-identical `min(960px, 60vw)`.

### Why not `size: 'lg'`

The bucket is not equivalent. Measured on the real render path (gantt with no `navigation`, drawer opened, asserting the resolved width — not a `className`, not "it renders"):

| viewport | today / after this PR | `size: 'lg'` | delta |
| ---: | ---: | ---: | --- |
| 414 | 248.4 | 380.9 | **+53.3%** |
| 768 | 460.8 | 706.6 | **+53.3%** |
| 1024 | 614.4 | 942.1 | **+53.3%** |
| 1280 | 768.0 | 960.0 | **+25.0%** |
| 1440 | 864.0 | 960.0 | **+11.1%** |
| 1600 | 960.0 | 960.0 | equal |
| 1920 | 960.0 | 960.0 | equal |

The shared 960px cap is real but reached at **different viewports**: 1600px for `min(960px, 60vw)` vs 1043.5px for `lg`'s `min(92vw, 960px)`. Below the cap the two take different proportions of the viewport — 60% vs 92%; on a phone the drawer would stop being a side panel. That is a real layout change across three renderers and is **not** made here — it stays with the maintainer on #6259 / #6303.

### The pin (new)

Nothing pinned this width before: a repo-wide search for `min(960px, 60vw)` returned only *producers*, zero assertions, and the full 402-test gantt suite stayed **identically green** when the value was changed. Since the resolved width now comes from `RecordDetailDrawer`'s default, a later move of that default would propagate here invisibly — so `ObjectGantt.navWidthDefault.test.tsx` pins **both halves**, which fail for different reasons:

| half | asserts | red when |
| --- | --- | --- |
| 1 | the gantt hands the drawer **no** width of its own | the gantt re-injects a width |
| 2 | the **real** drawer then resolves to `min(960px, 60vw)` | the drawer's own default moves |

**Ablation, both directions, each proved on disk (injected text and removed text grepped separately):**

- Mutating `RecordDetailDrawer`'s own default (`min(960px, 60vw)` → `min(800px, 50vw)`, blob `da15724`→`323f315`) → **half 2 red, half 1 green**.
- Re-injecting the deprecated width into `navConfig` (blob `ae81c5c`→`e34659f`) → **half 1 red, half 2 green** — the resolved string is identical, so half 2 cannot see it, which is precisely why half 1 exists.

Restored under `trap ... EXIT INT TERM` with absolute paths; `git diff HEAD --stat` empty and both blob hashes back to their HEAD values afterwards.

`plugin-calendar`, `plugin-kanban`, `RecordDetailDrawer` and their render-site `?? 'min(960px, 60vw)'` fallbacks are deliberately untouched — that is #6303's surface, and #6303 is blocked behind the bucket decision.

---

## Verification at `ae7898efb`

- `pnpm exec vitest run packages/plugin-gantt` → **48 files / 404 tests passed** (was 47/402; +1 file, +2 tests = the new pin)
- `turbo run type-check --filter=@object-ui/plugin-gantt --force` → exit 0, 14/14 tasks (`cache bypass, force executing` — not a cached green). The package's `type-check` is `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file is type-checked too.
- `check-changeset-presence` → ✅ *"Every one of them has an EMPTY frontmatter — declared as releasing nothing"*
- `check-changeset-no-major` → ✅ *"No changeset declares a `major` bump."*
- `check-changeset-fixed` → ✅ *"All workspace packages are in the changeset fixed group."*
- `check-control-bytes` → ✅ *"OK (scanned 5197 tracked text file(s))"*
- `check-vi-mock-specifiers` → ✅ OK · `check-shell-escape-residue` → ✅ OK
- ESLint: repo-wide `pnpm lint` exceeds the container's foreground cap (exit 124, still in `app-shell`). **Declared narrowing** with its three proofs: ① CI's `pnpm lint` is `turbo run lint`, each package running `eslint .`, and this PR touches exactly one package; ② `eslint packages/plugin-gantt --format json` → **78 files, 0 errors** (270 warnings; the 6 added by the new test are `no-explicit-any`, matching the neighbouring gantt tests); ③ `eslint.config.js` configures **no** type-aware linting, so no rule's verdict on an untouched file can depend on this diff. CI runs the full farm regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_