### PR TITLE
feat(cli): recognise ObjectUI schemas by validity, and report the broken ones

### DIFF
--- a/.changeset/6075-check-validity-recogniser-recall.md
+++ b/.changeset/6075-check-validity-recogniser-recall.md
@@ -21,7 +21,7 @@ Validity alone would have answered two different questions with one word.
 A broken ObjectUI schema fails validation exactly as a foreign file does, so a
 two-bucket report would have filed it as "not ObjectUI" — and the symptom of
 that is an absence: the file simply stops being mentioned. Measured, that bucket
-is not empty; 54 real corpus files land in it.
+is not empty: 54 files land in it and 53 of them are real corpus content.
 
 So files the recogniser refuses are split. When the root `type` names a
 component this build registers, the file is **listed by name** as ObjectUI

--- a/.changeset/6075-check-validity-recogniser-recall.md
+++ b/.changeset/6075-check-validity-recogniser-recall.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/cli': minor
+---
+
+`objectui check` recognises a schema by validating it, and reports broken ObjectUI files instead of filing them as foreign ones.
+
+A file with a root `type` was judged only when its root carried an ObjectUI
+structural key (`children`, `body`, `className`, …). Leaf schemas carry only
+their own vocabulary, so nothing checked them: measured on this repository, 475
+files were eligible, 166 were judged and 309 were skipped.
+
+The command now has a second recogniser arm — the document validates as an
+ObjectUI component schema under `@object-ui/types`' own Zod union — which the
+maintainer's 2026-08-25 ruling selected over shipping a JSON Schema artifact to
+point a `$schema` URL at. It admits 209 of those 309 files. The structural arm
+still runs first, so recognition costs nothing for files that already had a
+marker, and `package.json` is still never judged: `"type": "module"` names no
+component the protocol models.
+
+Validity alone would have answered two different questions with one word.
+A broken ObjectUI schema fails validation exactly as a foreign file does, so a
+two-bucket report would have filed it as "not ObjectUI" — and the symptom of
+that is an absence: the file simply stops being mentioned. Measured, that bucket
+is not empty; 54 real corpus files land in it.
+
+So files the recogniser refuses are split. When the root `type` names a
+component this build registers, the file is **listed by name** as ObjectUI
+content that did not validate, pointing at `objectui validate <file>` for the
+reason — either the document is off-spec or its component type is not modelled
+by `@object-ui/types`. Everything else is counted as skipped, as before. The
+printed explanation now describes both arms, and only unreadable JSON still
+makes the command exit non-zero.

--- a/content/docs/utilities/cli.mdx
+++ b/content/docs/utilities/cli.mdx
@@ -160,7 +160,27 @@ objectui validate ./schemas/dashboard.yaml
 
 ### `objectui check`
 
-Validate every schema file detected in the project. No flags.
+Scan the project for ObjectUI schema files and report on the ones it
+recognises. No flags.
+
+A JSON file with a root `type` is recognised when its root carries an ObjectUI
+structural key (`children`, `body`, `className`, …) **or** when the whole
+document validates as an ObjectUI component schema. Recognised files have their
+`type` checked against the component types this build registers.
+
+Files that are recognised by neither arm fall into one of two reports, and the
+distinction matters:
+
+- **Reported by name** when the root `type` *does* name a registered component.
+  That is ObjectUI content the validator could not accept — either the document
+  is off-spec, or its component type is not modelled by `@object-ui/types`. Run
+  `objectui validate <file>` for the reason.
+- **Counted as skipped** otherwise. A root `type` heads several unrelated JSON
+  vocabularies — `package.json`'s `"type": "module"` most of all — and those are
+  not ObjectUI files.
+
+Only unreadable JSON makes `objectui check` exit non-zero; everything above is a
+report. Use `objectui validate` when you want a failing exit code.
 
 ### `objectui doctor`
 

--- a/packages/cli/src/__tests__/check-schema-marker.test.ts
+++ b/packages/cli/src/__tests__/check-schema-marker.test.ts
@@ -82,6 +82,23 @@ function advertisedKeys(): string[] {
   return match[1].split(', ');
 }
 
+/**
+ * The per-file lines of the unvalidated-candidate report (objectui#6075) — the
+ * bucket that exists so a broken ObjectUI file is never filed as a foreign one.
+ */
+function candidateLines(): string[] {
+  return plainLines().filter((l) => /^ {3}\S.*\(type "/.test(l));
+}
+
+/** The headline count of that report, or 0 when it did not print. */
+function candidateCount(): number {
+  const line = plainLines().find((l) => l.includes('did not validate as an ObjectUI schema'));
+  if (!line) return 0;
+  const match = /(\d+) files? carr/.exec(line);
+  if (!match) throw new Error(`candidate line present but unparseable: ${line}`);
+  return Number(match[1]);
+}
+
 /** The count `check` reports for files it declined to judge, or 0 if silent. */
 function skippedCount(): number {
   const line = plainLines().find((l) => l.startsWith('Skipped '));
@@ -130,6 +147,13 @@ describe('objectui check — foreign root-`type` vocabularies are never judged',
     // reason that has nothing to do with the marker. `array` is not registered,
     // so the array document is one that genuinely warned before.
     //
+    // objectui#6075 split what used to be one bucket. Because `object` IS a
+    // registered key, the draft-07 document lands in the unvalidated-candidate
+    // report rather than the skipped count — the ONE false positive that
+    // discriminator has, pinned here so it stays a known, one-line cost and
+    // never silently grows. Neither document is JUDGED, which is what this
+    // suite is about.
+    //
     // Note the array document carries `items`, which is why `items` is absent
     // from the structural-key set even though ObjectUI nodes use it: a marker
     // key shared with JSON Schema re-admits exactly the files this gate exists
@@ -149,7 +173,14 @@ describe('objectui check — foreign root-`type` vocabularies are never judged',
     });
     await check(cwd);
     expect(unknownTypeWarnings()).toEqual([]);
-    expect(skippedCount()).toBe(2);
+    // The array document is unrecognisable by every arm: skipped.
+    expect(skippedCount()).toBe(1);
+    // The `object` document is refused by both recogniser arms but its root
+    // type is registered, so it is reported by name instead of counted.
+    expect(candidateCount()).toBe(1);
+    expect(candidateLines()).toEqual([
+      expect.stringContaining('thing.schema.json (type "object")'),
+    ]);
   });
 
   it('says nothing about a deployment resource descriptor', async () => {
@@ -205,10 +236,21 @@ describe('objectui check — foreign root-`type` vocabularies are never judged',
     // `form` IS a registered component key, so this file was silent before the
     // marker too — but for the wrong reason. Pinning it keeps the gate honest:
     // the file is out of scope, not accidentally acceptable.
+    //
+    // The load-bearing assertion is the first one: NOT JUDGED. A manifest whose
+    // `type` collides with a component key is refused by both recogniser arms —
+    // the structural arm sees no ObjectUI key, and the validity arm rejects it
+    // because a `FormSchema` needs more than a name. That the collision then
+    // costs one advisory line in the unvalidated-candidate report is the
+    // measured price of using the registered-type universe as the
+    // report/skip discriminator (objectui#6075), recorded here rather than
+    // discovered later. ⛔ The alternative — exempting files called
+    // `package.json` — is the filename skip list this gate was built to avoid.
     writeSchema('package.json', { name: 'x', type: 'form' });
     await check(cwd);
     expect(unknownTypeWarnings()).toEqual([]);
-    expect(skippedCount()).toBe(1);
+    expect(candidateCount()).toBe(1);
+    expect(skippedCount()).toBe(0);
   });
 });
 
@@ -262,14 +304,19 @@ describe('objectui check — the narrowed judgement surface is never silent (opt
   it('reports how many eligible files went unjudged, and how to opt one in', async () => {
     writeSchema('package.json', { name: 'x', type: 'module' });
     // The two leaves are the majority shape of the real in-repo corpus: a
-    // single node with no structural key, which is precisely the coverage this
-    // interim gives up and which this count keeps visible.
+    // single node with no structural key. They used to be counted as lost
+    // coverage here — that was the recall debt objectui#6075 tracked, and the
+    // validity arm repays it: both now VALIDATE as ObjectUI components and are
+    // judged, so only the manifest remains unrecognised. The assertion is
+    // deliberately still a count of what went unjudged; what changed is which
+    // files are in it.
     writeSchema('leaf-1.json', { type: 'button', label: 'Send Email', icon: 'mail' });
     writeSchema('leaf-2.json', { type: 'badge', variant: 'default' });
     await check(cwd);
-    // Two leaves plus the manifest: three files had a root `type` string and
-    // no marker.
-    expect(skippedCount()).toBe(3);
+    // The manifest alone. Both leaves are recognised now, and neither is a
+    // candidate: they validate.
+    expect(skippedCount()).toBe(1);
+    expect(candidateCount()).toBe(0);
     const hint = hintLine();
     expect(hint).toContain('children');
     expect(hint).toContain('className');

--- a/packages/cli/src/__tests__/check-validity-recogniser.test.ts
+++ b/packages/cli/src/__tests__/check-validity-recogniser.test.ts
@@ -1,0 +1,280 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `objectui check`'s validity arm and the three-bucket report (objectui#6075).
+ *
+ * The structural marker (objectui#5127) bought precision with recall: a leaf
+ * schema that carries only its own vocabulary — `{ "type": "statistic",
+ * "label": …, "value": … }`, the majority shape of the real corpus — has no
+ * `children`, no `className` and no `body`, so nothing validated it. The
+ * maintainer's 2026-08-25 ruling on objectui#5392 (Option B, no shipped schema
+ * artifact) selected `safeValidateSchema` as the second recogniser arm.
+ *
+ * ## What this file exists to stop
+ *
+ * A recogniser built on validation answers ONE question ("does this document
+ * parse as an ObjectUI component?") with TWO meanings: "not ours" and "ours,
+ * and broken". Collapsing them files every broken ObjectUI schema as a foreign
+ * file — and the symptom of that bug is an ABSENCE. The file stops being
+ * mentioned; no count moves in a direction anyone would question; nothing
+ * prompts a re-read. It is precisely the defect `check` exists to catch,
+ * hidden by the mechanism meant to catch it.
+ *
+ * So the command reports three buckets, and half of the tests below are
+ * negative: they fail if a future simplification back to two buckets swallows
+ * the broken-schema case. A suite that only proved the newly-recognised files
+ * are judged would pass that simplification without a murmur.
+ *
+ * Fixtures live under `os.tmpdir()`, never in the repo tree: `check()` globs
+ * every JSON file under the directory it is handed, so a fixture committed
+ * inside this workspace would be scanned by every other run of the command,
+ * the repo's own `pnpm check` included.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { check } from '../commands/check.js';
+
+let cwd: string;
+let lines: string[];
+let exitCodes: number[];
+let restoreLog: () => void;
+
+function writeSchema(name: string, body: unknown): void {
+  writeFileSync(join(cwd, name), JSON.stringify(body));
+}
+
+/**
+ * The CSI sequences chalk may add. The escape byte is built with
+ * `String.fromCharCode` rather than spelled into the source, so this file holds
+ * no raw control character and no escape a tooling pass could materialise into
+ * one (objectui AGENTS.md byte discipline).
+ */
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+function plainLines(): string[] {
+  return lines.map((l) => l.replace(ANSI, ''));
+}
+
+function unknownTypeWarnings(): string[] {
+  return plainLines().filter((l) => l.includes('Unknown schema type'));
+}
+
+/** The count of files no recogniser arm admitted, or 0 when the line is absent. */
+function skippedCount(): number {
+  const line = plainLines().find((l) => l.startsWith('Skipped '));
+  if (!line) return 0;
+  const match = /^Skipped (\d+) file/.exec(line);
+  if (!match) throw new Error(`skip line present but unparseable: ${line}`);
+  return Number(match[1]);
+}
+
+/** The headline count of the unvalidated-candidate report, or 0 if silent. */
+function candidateCount(): number {
+  const line = plainLines().find((l) => l.includes('did not validate as an ObjectUI schema'));
+  if (!line) return 0;
+  const match = /(\d+) files? carr/.exec(line);
+  if (!match) throw new Error(`candidate line present but unparseable: ${line}`);
+  return Number(match[1]);
+}
+
+/** The per-file lines of that report — the part a bare count cannot replace. */
+function candidateLines(): string[] {
+  return plainLines().filter((l) => /^ {3}\S.*\(type "/.test(l));
+}
+
+/** Every printed line that names this file, whatever bucket named it. */
+function mentionsOf(file: string): string[] {
+  return plainLines().filter((l) => l.includes(file));
+}
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'objectui-check-validity-'));
+  lines = [];
+  exitCodes = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  };
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+    exitCodes.push(code ?? 0);
+    return undefined as never;
+  }) as never);
+  restoreLog = () => {
+    console.log = original;
+    exitSpy.mockRestore();
+  };
+});
+
+afterEach(() => {
+  restoreLog();
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe('objectui check — the validity arm repays the recall debt', () => {
+  it('judges a leaf schema that carries no structural key at all', async () => {
+    // Copied from `examples/schema-catalog/.../with-description.json`. No
+    // `children`, no `className`, no `body`: invisible to the structural arm,
+    // and one of the 209 files this change moves into judgement.
+    writeSchema('with-description.json', {
+      type: 'statistic',
+      label: 'Total Sales',
+      value: '145,892',
+      description: 'Across all products this quarter',
+    });
+    await check(cwd);
+    expect(skippedCount()).toBe(0);
+    expect(candidateCount()).toBe(0);
+    // Judged and clean: `statistic` is registered, so nothing is warned about.
+    expect(unknownTypeWarnings()).toEqual([]);
+  });
+
+  it('still refuses the manifest the marker gate was built for', async () => {
+    // The precision half. `"type": "module"` names no component the protocol
+    // models, so the validity arm rejects it exactly as the structural arm did
+    // — and `module` is not a registered type either, so it stays in the skip
+    // count rather than being reported as a broken schema.
+    writeSchema('package.json', { name: 'x', version: '1.0.0', type: 'module' });
+    await check(cwd);
+    expect(unknownTypeWarnings()).toEqual([]);
+    expect(candidateCount()).toBe(0);
+    expect(skippedCount()).toBe(1);
+  });
+});
+
+describe('objectui check — a broken ObjectUI schema is never filed as a foreign file', () => {
+  it('names the file, rather than counting it as skipped', async () => {
+    // ⭐ The load-bearing test of objectui#6075. Copied verbatim from
+    // `examples/schema-catalog/.../components-basic-text/small.json`: real
+    // corpus content, and genuinely invalid — `TextSchema.variant` is an enum
+    // of `h1`…`overline`, and `small` is not in it. Under a two-bucket
+    // recogniser this file would be reported as "not ObjectUI".
+    writeSchema('small.json', { type: 'text', content: 'Small text', variant: 'small' });
+    await check(cwd);
+    expect(candidateCount()).toBe(1);
+    expect(candidateLines()).toEqual([
+      expect.stringContaining('small.json (type "text")'),
+    ]);
+    // ⛔ The negative half, and the one that catches the failure mode: it must
+    // not have been absorbed into the skip count.
+    expect(skippedCount()).toBe(0);
+  });
+
+  it('mentions it by name even when it is the only file in the project', async () => {
+    // The absence-detector. If a later change collapses the report back to two
+    // buckets, this run goes quiet about the file entirely — which is the whole
+    // hazard, expressed as an assertion rather than a paragraph.
+    writeSchema('small.json', { type: 'text', content: 'Small text', variant: 'small' });
+    await check(cwd);
+    expect(mentionsOf('small.json').length).toBeGreaterThan(0);
+  });
+
+  it('reports a registered component type the bundled schemas do not model', async () => {
+    // The other half of the bucket, and why its wording says "off-spec OR not
+    // modelled": `kanban` is a real registered plugin type that
+    // `AnyComponentSchema` has no member for, so a perfectly good kanban board
+    // fails the validity arm. Reporting it is right — a component type the
+    // shipped validator cannot validate is itself a finding — but calling it
+    // invalid would overclaim.
+    writeSchema('board.json', {
+      type: 'kanban',
+      columns: [{ id: 'backlog', title: 'Backlog', cards: [] }],
+    });
+    await check(cwd);
+    expect(candidateCount()).toBe(1);
+    expect(candidateLines()).toEqual([
+      expect.stringContaining('board.json (type "kanban")'),
+    ]);
+    expect(skippedCount()).toBe(0);
+  });
+
+  it('separates the two refusals in one run', async () => {
+    // Both refusals side by side, because either bucket alone could be produced
+    // by a predicate that got the OTHER one wrong.
+    writeSchema('package.json', { name: 'x', type: 'module' });
+    writeSchema('small.json', { type: 'text', content: 'Small text', variant: 'small' });
+    await check(cwd);
+    expect(candidateCount()).toBe(1);
+    expect(candidateLines()).toEqual([
+      expect.stringContaining('small.json (type "text")'),
+    ]);
+    expect(skippedCount()).toBe(1);
+    expect(mentionsOf('package.json')).toEqual([]);
+  });
+
+  it('is a report, not a failure — the run still passes', async () => {
+    // Deliberate: `errors` still counts parse failures only. Escalating a
+    // validation finding to a non-zero exit would change the contract of a
+    // released command for every consumer's CI at once, which is a different
+    // decision from this one.
+    writeSchema('small.json', { type: 'text', content: 'Small text', variant: 'small' });
+    await check(cwd);
+    expect(candidateCount()).toBe(1);
+    expect(plainLines().some((l) => l.includes('All checks passed'))).toBe(true);
+    expect(exitCodes).toEqual([]);
+  });
+});
+
+describe('objectui check — the buckets close over the eligible files', () => {
+  it('puts every eligible file in exactly one of judged, candidate or skipped', async () => {
+    // The accounting assertion. Each bucket is reachable and no file appears in
+    // two of them, so a future arm cannot quietly move files into a bucket
+    // nobody prints — the objectui#6075 hazard restated as arithmetic.
+    writeSchema('package.json', { name: 'x', type: 'module' }); // skipped
+    writeSchema('leaf.json', { type: 'statistic', label: 'a', value: '1' }); // judged, clean
+    writeSchema('node.json', { type: 'totally-made-up-xyz', children: [] }); // judged, warned
+    writeSchema('broken.json', { type: 'text', content: 'x', variant: 'small' }); // candidate
+    await check(cwd);
+    const judged = unknownTypeWarnings().length + 1; // the warned node, plus the clean leaf
+    expect(judged).toBe(2);
+    expect(candidateCount()).toBe(1);
+    expect(skippedCount()).toBe(1);
+    expect(judged + candidateCount() + skippedCount()).toBe(4);
+  });
+
+  it('leaves the one shape no signal can separate from a foreign file in the skip count', async () => {
+    // ⚠️ The honest limit, pinned so it is not mistaken for an oversight.
+    // An unregistered root `type`, no structural key, and a document that does
+    // not validate is byte-for-byte the same evidence a foreign file offers.
+    // This fixture is real — `examples/schema-catalog/.../core-schema-renderer/
+    // unknown-component-type.json` — and it is the single real corpus file
+    // still counted as skipped after this change. Admitting it would mean
+    // admitting `package.json`, which is the trade objectui#5127 already made.
+    writeSchema('unknown-component-type.json', { type: 'unknown-component', someData: {} });
+    await check(cwd);
+    expect(candidateCount()).toBe(0);
+    expect(skippedCount()).toBe(1);
+    expect(unknownTypeWarnings()).toEqual([]);
+  });
+});
+
+describe('objectui check — the printed explanation describes the predicate it runs', () => {
+  it('states both arms under the skip count', async () => {
+    // objectui#6074 removed a comment in this command that promised something
+    // the code did not do. The same defect in the user-facing hint would be
+    // worse: the reader acts on it. Both arms are advertised because both are
+    // honoured.
+    writeSchema('package.json', { name: 'x', type: 'module' });
+    await check(cwd);
+    const hint = plainLines().filter((l) => l.includes('checked when')).join('\n');
+    // Both advisory lines, not one: the sentence that names the structural keys
+    // and the sentence that names the validity arm.
+    expect(hint.split('\n')).toHaveLength(2);
+    expect(hint).toContain('structural key');
+    expect(hint).toContain('validates as an ObjectUI component schema');
+    // ⛔ No `$schema` URL exists to advertise (maintainer ruling 2026-08-20,
+    // verbatim C; objectui#5392 Option B on 2026-08-25 removed the artifact
+    // that would have justified minting one).
+    expect(hint).not.toContain('$schema');
+    expect(hint).not.toContain('http');
+  });
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -149,11 +149,12 @@ function isObjectUiSchemaFile(content: Record<string, unknown>): boolean {
  * bug is an ABSENCE: the file simply stops being mentioned, and nothing
  * prompts a re-read.
  *
- * It is not a theoretical bucket. Measured over this repository at the commit
- * that introduced this function, 100 eligible files failed the validity arm,
- * and 54 of them were real ObjectUI content — schema-catalog leaves such as
+ * It is not a theoretical bucket. Measured over a clean checkout of this
+ * repository at the commit that introduced this function, 100 eligible files
+ * failed the validity arm; 54 of those land here, and 53 of the 54 are real
+ * ObjectUI content — schema-catalog leaves such as
  * `{ "type": "text", "content": "Small text", "variant": "small" }`, whose
- * `variant` is not in `TextSchema`'s enum. Reported as foreign, all 54 would
+ * `variant` is not in `TextSchema`'s enum. Reported as foreign, all 53 would
  * have gone quiet.
  *
  * The discriminator is `isKnownSchemaType`: does the root `type` name a

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -11,6 +11,7 @@ import { globSync } from 'glob';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { parse as parseJsonc, printParseErrorCode, type ParseError } from 'jsonc-parser';
+import { safeValidateSchema } from '@object-ui/types/zod';
 
 import { isKnownSchemaType } from '../utils/known-schema-types.js';
 import { didYouMeanClause } from '../utils/known-type-case-suggestion.js';
@@ -79,12 +80,18 @@ const OBJECTUI_STRUCTURAL_KEYS: readonly string[] = [
  *   delivered.
  *
  * Because that matching was host-based rather than literal, the arm can be
- * added later without invalidating a single file — most soundly once
- * `@object-ui/types` ships a generated JSON Schema, which is filed separately.
+ * added later without invalidating a single file. The trigger that clause once
+ * pointed at is gone: `@object-ui/types` shipping a generated JSON Schema was
+ * objectui#5392, and the maintainer ruled it Option B on 2026-08-25 — no
+ * shipped artifact. There is therefore no document a `$schema` URL could name,
+ * and the recall that arm was being kept in reserve for is repaid instead by
+ * the validity arm below, which reads the Zod schemas already in
+ * `node_modules` rather than a URL fetched over HTTP.
  */
 
 /**
- * Does this parsed file positively read as an ObjectUI schema (objectui#5127)?
+ * Does this parsed file positively read as an ObjectUI schema (objectui#5127,
+ * objectui#6075)?
  *
  * `type` carries at least seven unrelated vocabularies in JSON — the most
  * common of them being `package.json`'s `"type": "module"` — so the presence
@@ -95,37 +102,79 @@ const OBJECTUI_STRUCTURAL_KEYS: readonly string[] = [
  * produced were exactly that.
  *
  * The fix is a positive marker, not a consumer-side skip list: a file is
- * judged when it is structurally recognisable as an ObjectUI node. A list of
- * filenames to exclude was
- * considered and rejected — it is a second hand-maintained list of the shape
- * objectui#5115 had just finished deleting, and it can only ever enumerate the
- * foreign vocabularies someone already thought of.
+ * judged when it is recognisable as an ObjectUI node. A list of filenames to
+ * exclude was considered and rejected — it is a second hand-maintained list of
+ * the shape objectui#5115 had just finished deleting, and it can only ever
+ * enumerate the foreign vocabularies someone already thought of.
  *
- * ⚠️ The structural arm is a TRANSITIONAL fallback, not the contract. It is
- * drawn for precision over recall on purpose: a foreign file wrongly judged is
- * this card's defect reappearing in a user's project, while a real schema
- * wrongly skipped is a RECALL DEBT — real, unpaid, and kept visible by the
- * skipped-file count printed below.
+ * There are two arms, and the ORDER is load-bearing:
  *
- * ⛔ Nothing repays that debt today, and no corpus migration can. The marker a
- * migration would stamp is the `$schema` URL the 2026-08-20 ruling declined to
- * mint: `OBJECTUI_SCHEMA_URL` and `pointsAtObjectUi()` were deleted before
- * objectui#5334 merged, so there is no arm for a stamped file to match — see
- * the block above, which records the same absence from the other side.
- * Measured rather than reasoned: injecting a `$schema` key into a
- * currently-skipped real corpus file leaves the skipped count unmoved, while
- * injecting a structural key into the same file moves it by exactly one. A
- * corpus-wide `$schema` sweep is therefore a no-op here, not an unfinished
- * chore — an earlier card was written, claimed and worked on the belief that
- * this sentence promised one.
+ * 1. The structural arm (`OBJECTUI_STRUCTURAL_KEYS`, above) — a set-membership
+ *    test over the parsed root, and the cheap one. It runs first so the
+ *    common case never pays for arm 2.
+ * 2. The validity arm — the document parses as an ObjectUI component schema
+ *    under `@object-ui/types`' own Zod union. This is the recogniser the
+ *    2026-08-25 ruling on objectui#5392 selected (Option B, no shipped schema
+ *    artifact): measured over this repository it admits schemas the structural
+ *    arm cannot see — leaf nodes that carry only their own vocabulary — while
+ *    refusing every `package.json`, because `"module"` is not a component the
+ *    protocol models.
  *
- * The debt is tracked as objectui#6075, blocked on objectui#5392
- * (`@object-ui/types` shipping a generated JSON Schema to point at). Waiting
- * forecloses nothing: matching would be host-based, so adding the arm then
- * invalidates not a single file.
+ * ⛔ There is deliberately no third arm reading a registered root `type`
+ * alone. `{ "name": "x", "type": "form" }` is a plausible `package.json` and
+ * `form` is a real component key; admitting on the type name re-creates the
+ * exact defect this gate exists to remove. Recognition needs SHAPE.
+ *
+ * ⚠️ The validity arm couples this command's recall to `@object-ui/types`:
+ * tightening a Zod schema moves files out of recognition. That is not a
+ * hazard left to chance — it is the reason `check` reports a third bucket
+ * rather than two (see `UNVALIDATED_CANDIDATE` below). A file that stops
+ * validating stops being *judged*, but it does not stop being *mentioned*.
  */
 function isObjectUiSchemaFile(content: Record<string, unknown>): boolean {
-  return OBJECTUI_STRUCTURAL_KEYS.some((key) => key in content);
+  return (
+    OBJECTUI_STRUCTURAL_KEYS.some((key) => key in content) ||
+    safeValidateSchema(content).success
+  );
+}
+
+/**
+ * `UNVALIDATED_CANDIDATE` — the bucket a validity-based recogniser MUST report
+ * rather than swallow (objectui#6075).
+ *
+ * A recogniser built on validation conflates two entirely different findings:
+ * "this file is not ours" and "this file is ours and it is broken". The second
+ * is the more valuable of the two — it is the thing this command exists to
+ * find — and filing it under the first makes it vanish. The symptom of that
+ * bug is an ABSENCE: the file simply stops being mentioned, and nothing
+ * prompts a re-read.
+ *
+ * It is not a theoretical bucket. Measured over this repository at the commit
+ * that introduced this function, 100 eligible files failed the validity arm,
+ * and 54 of them were real ObjectUI content — schema-catalog leaves such as
+ * `{ "type": "text", "content": "Small text", "variant": "small" }`, whose
+ * `variant` is not in `TextSchema`'s enum. Reported as foreign, all 54 would
+ * have gone quiet.
+ *
+ * The discriminator is `isKnownSchemaType`: does the root `type` name a
+ * component THIS BUILD registers? It is the same derived universe the
+ * judgement arm uses, so it needs no second list, and it is the one signal
+ * that separates a broken `"type": "text"` node from `"type": "module"`.
+ *
+ * Its cost, stated rather than hidden: a foreign document whose root `type`
+ * happens to collide with a registered component key lands here. A JSON Schema
+ * document with `"type": "object"` is exactly that, and this repository
+ * contains one. The cost is one advisory line naming a file — not a warning
+ * about the reader's `package.json`, which is the failure this gate was built
+ * for. The opposite error is the one that cannot be seen.
+ *
+ * ⛔ This bucket is REPORTED, never counted as skipped. Moving files from the
+ * skipped count into an unreported bucket would make the recall debt look
+ * repaid while nothing had been repaid, which is the one outcome objectui#6075
+ * names as unacceptable.
+ */
+function isUnvalidatedCandidate(type: string): boolean {
+  return isKnownSchemaType(type);
 }
 
 /**
@@ -159,11 +208,17 @@ export async function check(cwd: string = process.cwd()) {
   
   let errors = 0;
   // Files that a root `type` string made ELIGIBLE for type judgement and that
-  // no ObjectUI marker admitted. Reported below so the narrowed judgement
+  // no ObjectUI recogniser admitted. Reported below so the narrowed judgement
   // surface is never silent (objectui#5127) — a check that quietly stops
   // checking is worse than one that warns too loudly, because nothing prompts
   // a re-read.
   let skipped = 0;
+  // The third bucket (objectui#6075): eligible files the recogniser refused
+  // whose root `type` nevertheless names a component this build registers.
+  // These are ObjectUI content that does not validate — a finding, not a
+  // foreign file — so they are listed by name rather than folded into the
+  // count above.
+  const unvalidatedCandidates: { file: string; type: string }[] = [];
   
   for (const file of files) {
     try {
@@ -212,7 +267,15 @@ export async function check(cwd: string = process.cwd()) {
             // is. The glob also matches `.yaml`/`.yml`, and those files are
             // read by neither arm, before this change or after it.
             if (!isObjectUiSchemaFile(content as Record<string, unknown>)) {
-              skipped++;
+              // Refused. Which of the two refusals is this? A file whose root
+              // `type` names a registered component is ObjectUI content the
+              // recogniser could not validate — say so. Everything else is
+              // simply not ours.
+              if (isUnvalidatedCandidate(content.type)) {
+                unvalidatedCandidates.push({ file, type: content.type });
+              } else {
+                skipped++;
+              }
             } else if (!isKnownSchemaType(content.type)) {
               // The known-type universe is DERIVED from the repository's
               // registration calls (see `packages/cli/src/utils/known-schema-types.ts`
@@ -237,10 +300,40 @@ export async function check(cwd: string = process.cwd()) {
     }
   }
 
+  // Printed BEFORE the skipped count, and per file rather than as a bare
+  // number: this bucket is the one a two-bucket report would have destroyed,
+  // and a count alone is not enough to act on (objectui#6075). The list is
+  // uncapped for the same reason the unknown-type warnings above are — a cap
+  // is a quieter way of losing the finding.
+  if (unvalidatedCandidates.length > 0) {
+    const n = unvalidatedCandidates.length;
+    console.log(
+      chalk.yellow(
+        `⚠️ ${n} file${n === 1 ? '' : 's'} carr${n === 1 ? 'ies' : 'y'} a registered ObjectUI component type but did not validate as an ObjectUI schema:`
+      )
+    );
+    for (const { file, type } of unvalidatedCandidates) {
+      console.log(chalk.yellow(`   ${file} (type "${type}")`));
+    }
+    console.log(
+      chalk.dim('   Run `objectui validate <file>` on any of them for the reason.')
+    );
+    console.log(
+      chalk.dim(
+        '   Either the document is off-spec, or its component type is not modelled by @object-ui/types.'
+      )
+    );
+    console.log(
+      chalk.dim(
+        '   These are NOT counted as skipped: a schema that fails validation is a broken schema, not a foreign file.'
+      )
+    );
+  }
+
   if (skipped > 0) {
     console.log(
       chalk.dim(
-        `Skipped ${skipped} file${skipped === 1 ? '' : 's'} with a root "type" and no ObjectUI schema marker.`
+        `Skipped ${skipped} file${skipped === 1 ? '' : 's'} with a root "type" that no ObjectUI recogniser admitted.`
       )
     );
     // The hint names the marker keys by rendering the gate's OWN array, never
@@ -253,6 +346,15 @@ export async function check(cwd: string = process.cwd()) {
     console.log(
       chalk.dim(
         `  A file is checked when its root carries an ObjectUI structural key: ${OBJECTUI_STRUCTURAL_KEYS.join(', ')}.`
+      )
+    );
+    // The second arm, stated because the sentence above no longer describes
+    // the whole predicate — and an explanation that has stopped describing
+    // what the code does is the defect class objectui#6074 had just finished
+    // removing from this file.
+    console.log(
+      chalk.dim(
+        '  It is also checked when the whole document validates as an ObjectUI component schema.'
       )
     );
   }


### PR DESCRIPTION
Fixes #6075

`objectui check` judged a file's root `type` only when the file carried an ObjectUI structural key (`children`, `body`, `className`, …). Leaf schemas carry only their own vocabulary, so nothing checked them. This adds the second recogniser arm the maintainer's 2026-08-25 ruling on #5392 selected — the document validates as an ObjectUI component under `@object-ui/types`' own Zod union — and splits the files the recogniser refuses into two reports instead of one count.

> ⚠️ Editor's note: this body originally quoted the CLI's hint verbatim, with a `validate` argument written in angle brackets. GitHub's body sanitizer silently ate every angle-bracket fragment, including the ones inside code fences, so the argument is spelled `FILE` throughout instead. Mentioning it because the same erasure is invisible on the way in.

## Measured on my own base, not adopted from any card

`origin/main` @ `090927f4f`, **clean checkout** (see the caveat below — this matters). Harness reproduces the command's own predicate: same glob, same `jsonc-parser` settings, same structural-key list.

| | before | after |
|---|--:|--:|
| globbed | 617 | 617 |
| eligible (root `type` string) | 475 | 475 |
| **judged** | **166** | **375** (166 structural + 209 validity) |
| **reported as unvalidated candidates** | — | **54** |
| **skipped** | **309** | **46** |

The counts close: `375 + 54 + 46 = 475`.

The 46 that remain skipped are 45 `package.json` (`"type": "module"`) plus one file discussed under "the honest limit" below. So the precision the marker gate was built for is intact: the command still says nothing about the reader's package manifest.

⚠️ **Every number here depends on whether the tree was built**, and that is a defect I found on the way, not a property of this change: `check`'s ignore list is `['node_modules/**','dist/**','.git/**']`, and glob matches those relative to `cwd`, so only a **top-level** `dist/` is excluded. After a full build of this workspace the same command globs 1047 files and every count roughly doubles. Filed as **#6320**; deliberately not fixed here.

## The design decision this card owns

A validity-based recogniser answers one question with two meanings. "This document does not validate" is the same sentence for *a foreign file* and for *an ObjectUI file that is broken* — and the second is the more valuable finding, because it is the thing `check` exists to catch. Collapsing them files every broken schema as "not ObjectUI", and **the symptom of that bug is an absence**: the file stops being mentioned, no count moves in a direction anyone would question, and nothing prompts a re-read.

**Measured rather than assumed: the bucket is not empty.** 100 eligible files fail the validity arm. 45 are `package.json`. Of the rest, **53 are real ObjectUI content** — schema-catalog leaves like

```json
{ "type": "text", "content": "Small text", "variant": "small" }
```

whose `variant` is not in `TextSchema`'s enum. A two-bucket recogniser would have reported all 53 as foreign files.

**Decision: three buckets, and the third one is reported by name, not counted.** A file the recogniser refuses whose root `type` names a component this build registers is listed as ObjectUI content that did not validate, pointing at `objectui validate FILE` for the reason. Everything else is counted as skipped, as before.

```
⚠️ 54 files carry a registered ObjectUI component type but did not validate as an ObjectUI schema:
   examples/schema-catalog/src/schemas/components-basic-text/small.json (type "text")
   … 53 more
   Run `objectui validate FILE` on any of them for the reason.
   Either the document is off-spec, or its component type is not modelled by @object-ui/types.
   These are NOT counted as skipped: a schema that fails validation is a broken schema, not a foreign file.
Skipped 46 files with a root "type" that no ObjectUI recogniser admitted.
```

### Why `isKnownSchemaType` is the discriminator

It is the same derived universe the judgement arm already uses — read out of the repository's own registration calls — so the split needs no second hand-maintained list, which is the shape #5115 deleted and #5127 declined to re-create. And it is the one signal that separates a broken `"type": "text"` node from `"type": "module"`.

### Its cost, stated

**A foreign document whose root `type` collides with a registered component key lands in the report.** This repository contains exactly one: `packages/vscode-extension/schemas/objectui-schema.json`, a draft-07 JSON Schema document whose root type is `object` — a real ObjectUI component key. So of the 54 reported files, 53 are genuine and 1 is a false positive. That cost is **pinned as a test**, not left to be rediscovered, so it stays a known one-line cost and cannot silently grow. The alternative — exempting files by name — is the filename skip list this gate was built to avoid, and it fails on the general case anyway.

The opposite error is the one that cannot be seen. I took the visible cost.

### Why the report does not fail the build

`errors` still counts unreadable JSON only, so `objectui check` still exits non-zero on exactly what it did before. Escalating a validation finding to a failing exit would change the contract of a released command for every consumer's CI at once — a different decision from this one, and not this card's to make.

### The honest limit

One real corpus file stays in the skip count: `examples/schema-catalog/src/schemas/core-schema-renderer/unknown-component-type.json`. An unregistered root `type`, no structural key, and a document that does not validate is byte-for-byte the same evidence a foreign file offers — no available signal separates them. Admitting it would mean admitting `package.json`. Pinned as a test so the limit is visible rather than forgotten.

## On the `check` ↔ `validate` coupling — yes, intended, and it is why the third bucket exists

`objectui check` and `objectui validate` now share one recogniser, so tightening a Zod schema moves files out of `check`'s recognition. That is real, and it is the reason this change is three buckets rather than two: **a file that stops validating stops being *judged*, but it does not stop being *mentioned***. Without the third bucket the coupling would be a hazard — validation tightens somewhere in `packages/types`, and files silently reclassify as foreign in a command nobody was looking at. With it, the same tightening produces a named list. The bucket is the shock absorber for the coupling, not an extra.

## Not done, per the rulings

No `$schema` arm, no minted URL, no marker stamped into any corpus file, and `OBJECTUI_STRUCTURAL_KEYS` is **unchanged** — the set still grows only when `BaseSchema` grows, and admitting `BaseSchema`-adjacent naming keys is what drives foreign retention from 0 files toward all 46. `packages/types` is untouched: `safeValidateSchema` was already exported and already consumed by `validate.ts`; no export was widened and no validation behaviour changed.

## What changed

- `packages/cli/src/commands/check.ts` — the second recogniser arm, the third bucket, and the two docblocks that described the old predicate. The user-facing explanation under the skip count now names **both** arms; a sentence that no longer describes the predicate is the defect class #6074 had just finished removing from this file.
- `packages/cli/src/__tests__/check-validity-recogniser.test.ts` — new. 10 tests, over half of them negative.
- `packages/cli/src/__tests__/check-schema-marker.test.ts` — fixture triage on the three cases this change moves (below).
- `content/docs/utilities/cli.mdx` — the `objectui check` entry said "Validate every schema file detected in the project", which described neither the old predicate nor the new one. It now describes what the command does.
- `.changeset/6075-check-validity-recogniser-recall.md` — `@object-ui/cli: minor`.

### Fixture triage on the existing suite

Three tests in `check-schema-marker.test.ts` moved, each for a different reason, and each re-pinned rather than renumbered:

1. **`reports how many eligible files went unjudged`** — its two leaves (`{type: 'button', …}`, `{type: 'badge', …}`) now validate and are judged. That fixture *was* the recall debt; the assertion still counts what went unjudged, and what changed is which files are in it.
2. **`says nothing about a JSON Schema document`** — the draft-07 `object` document moves into the candidate report. Re-pinned as the known false positive, with the load-bearing assertion (never *judged*) unchanged.
3. **`does not judge a foreign file even when its type happens to name a real component`** — `{name: 'x', type: 'form'}` is still refused by both arms (a `FormSchema` needs more than a name), so it is still never judged; it now costs one advisory line. Re-pinned with the cost written down.

## Tests and gates — run at `1c2ade6a8`, the final commit

Exit codes captured by redirect **before** any pipe; each verdict below is the gate's own printed line.

| gate | verdict |
|---|---|
| `vitest run packages/cli/` | `Test Files 13 passed (13)` · `Tests 226 passed (226)` |
| `pnpm --filter @object-ui/cli run type-check` | echoed `@object-ui/cli@17.6.0 type-check` → `tsc --noEmit`, exit 0 |
| `pnpm lint` (whole repo, not narrowed) | `Tasks: 47 successful, 47 total` · 0 errors |
| `check-changeset-presence.mjs` | `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 5197 tracked text file(s); skipped 85 binary)` |
| `check-lint-coverage.mjs` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `check-type-check-coverage.mjs` | `✅ test type-check coverage: 41/41 packages compile their tests` |
| `check-doc-snippet-types.mjs` | `Semantic phase: 267 of 267 block(s) judged, 0 failed.` |
| `check-doc-links.mjs` | `Links are valid across 17 scan roots.` |
| `check-phantom-dependencies.mjs` | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check-vi-mock-specifiers.mjs`, `check-doc-fence-languages.mjs`, `check-doc-component-types.mjs`, `check-package-self-import.mjs`, `check-published-dist-tooling.mjs`, `check-node-esm-load.mjs`, `check-changeset-no-major.mjs`, `check-changeset-fixed.mjs`, `check-shell-escape-residue.mjs`, `check-skills-paths.mjs`, `lint:root` | all exit 0 |

`--listFiles` confirms both test files and `check.ts` are in the CLI's typecheck program, so "typecheck clean" is a statement about them and not about a set that excluded them.

### Reverse verification — the bucket tests are not decorative

Predicted direction: **red**. Ablation: collapse the third bucket back to two (`isUnvalidatedCandidate` returns `false`), so every refused file becomes "skipped" — the exact failure mode this card names.

Mutation confirmed on disk before the run, not inferred from an editor's exit code: injected marker `grep -c` = 1, and `git hash-object` moved `95832826` → `3929785e`. Restore ran through a `trap … EXIT INT TERM` against an absolute path and was proved afterwards, not assumed: `git diff HEAD` empty, marker residue 0, hash back to `95832826`.

Result: **8 tests failed**, including every test in *"a broken ObjectUI schema is never filed as a foreign file"* and the absence-detector that asserts the file is mentioned at all. No rebuild is involved on either leg — the suite imports `../commands/check.js`, a relative specifier vitest resolves to source, so no `dist/` could go stale under it.

## Findings filed, not fixed here

- **#6318** — the 53 real corpus files this report now names, split by cause: 49 violate a schema the union models, 4 carry a registered type (`code-editor`, `bar-chart`) that has no Zod schema at all. Also records the 36 already-judged files that fail validation too, and that Zod 4 collapses every failure to `invalid_union` at the root.
- **#6320** — the `dist/**` scan-scope hole above.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_