### PR TITLE
fix(app-shell): resolve the Home item-type label through one shared helper

### DIFF
--- a/.changeset/6165-home-item-type-label-parity.md
+++ b/.changeset/6165-home-item-type-label-parity.md
@@ -1,0 +1,17 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Home renders one agreed label for an item kind that has no translation key.
+
+The rail (`HomeContinue`), `RecentApps` and `StarredApps` all resolve the same
+`home.recentApps.itemType.*` label, and each spelled the lookup itself. They had
+drifted: the rail fell back to the bare kind (`report`) where both card surfaces
+fell back to the capitalised one (`Report`) — two spellings of the same word on
+one screen. All three now resolve through a single `recentItemTypeLabel` helper,
+so the fallback cannot drift apart again.
+
+User-visible: the rail's label for an unkeyed kind changes from `report` to
+`Report`. Every kind shipping today carries a key, so no label changes for them;
+this is about the next kind added, and any host passing a kind the locales do
+not carry.

--- a/packages/app-shell/src/console/home/HomeRail.tsx
+++ b/packages/app-shell/src/console/home/HomeRail.tsx
@@ -20,6 +20,7 @@ import { useObjectTranslation } from '@object-ui/i18n';
 import type { ActivityItem } from '../../layout/ActivityFeed.js';
 import type { HomeInboxStatus, HomeNotification } from '../../hooks/useHomeInbox.js';
 import type { RecentItem } from '../../hooks/useRecentItems.js';
+import { recentItemTypeLabel } from './recentItemTypeLabel.js';
 import { timeAgo } from '../../utils/relativeTime.js';
 
 type TFn = (key: string, opts?: any) => string;
@@ -248,7 +249,7 @@ export function HomeContinue({ items, onOpen, t }: { items: RecentItem[]; onOpen
               icon={RECENT_ICON[it.type] || FileText}
               iconClass={RECENT_TONE[it.type] || 'bg-muted text-muted-foreground'}
               label={it.label}
-              meta={t(`home.recentApps.itemType.${it.type}`, { defaultValue: it.type })}
+              meta={recentItemTypeLabel(t, it.type)}
               onClick={() => onOpen(it.href)}
             />
           ))}

--- a/packages/app-shell/src/console/home/RecentApps.tsx
+++ b/packages/app-shell/src/console/home/RecentApps.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Card, CardContent, cn } from '@object-ui/components';
 import { Clock, ArrowUpRight, Database, FileText, LayoutDashboard, File } from 'lucide-react';
-import { capitalizeFirst } from '../../utils/index.js';
+import { recentItemTypeLabel } from './recentItemTypeLabel.js';
 import type { RecentItem } from '../../hooks/useRecentItems.js';
 
 interface RecentAppsProps {
@@ -52,9 +52,7 @@ export function RecentApps({ items }: RecentAppsProps) {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
         {items.map((item) => {
           const Icon = TYPE_ICONS[item.type] || Database;
-          const typeLabel = t(`home.recentApps.itemType.${item.type}`, {
-            defaultValue: capitalizeFirst(item.type),
-          });
+          const typeLabel = recentItemTypeLabel(t, item.type);
           const tone = TYPE_TONES[item.type] || TYPE_TONES.object;
           return (
             <Card

--- a/packages/app-shell/src/console/home/StarredApps.tsx
+++ b/packages/app-shell/src/console/home/StarredApps.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { Card, CardContent, cn } from '@object-ui/components';
 import { Star, ArrowUpRight, Database, FileText, LayoutDashboard, File } from 'lucide-react';
-import { capitalizeFirst } from '../../utils/index.js';
+import { recentItemTypeLabel } from './recentItemTypeLabel.js';
 import type { FavoriteItem } from '../../hooks/useFavorites.js';
 
 interface StarredAppsProps {
@@ -56,11 +56,9 @@ export function StarredApps({ items }: StarredAppsProps) {
           const tone = TYPE_TONES[item.type] || TYPE_TONES.object;
           // Reuse the recentApps.itemType.* keys so Starred and Recently
           // Accessed surface the same localized labels (e.g. "记录" vs
-          // "Record"). Falls back to the capitalized english type so
-          // unknown types still render readably.
-          const typeLabel = t(`home.recentApps.itemType.${item.type}`, {
-            defaultValue: capitalizeFirst(item.type),
-          });
+          // "Record"). Resolved through the shared helper so all three Home
+          // surfaces fall back identically (objectui#6165).
+          const typeLabel = recentItemTypeLabel(t, item.type);
           return (
             <Card
               key={item.id}

--- a/packages/app-shell/src/console/home/__tests__/HomeItemTypeLabel.parity.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomeItemTypeLabel.parity.test.tsx
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Home item-type label parity (objectui#6165).
+ *
+ * Three Home surfaces render a label for the same item kind — the rail
+ * (`HomeRail.HomeContinue`), the Recently-Accessed cards (`RecentApps`) and
+ * the Starred cards (`StarredApps`) — through one key namespace,
+ * `home.recentApps.itemType.*`. They disagreed on the FALLBACK: the cards
+ * rendered `capitalizeFirst(type)` while the rail rendered the bare `type`,
+ * so an unkeyed kind read `Report` on the cards and `report` in the rail, on
+ * the same screen.
+ *
+ * ⚠️ WHY THE FIXTURE USES A SYNTHETIC KIND. Every member of the union today
+ * (`object|dashboard|page|report|record|metadata`, plus `nav` on the favorite
+ * side) HAS a key, so a test built on a real member takes the keyed path and
+ * never reaches the fallback — it passes both before and after the fix and
+ * proves nothing. The pin therefore uses a kind with NO key. That is the
+ * whole point of the card: the defect is dormant for today's members and
+ * wakes up for the next one added.
+ *
+ * ⚠️ WHAT IS ASSERTED. The defect is DISAGREEMENT BETWEEN CONSUMERS, so the
+ * assertion is agreement — all three surfaces resolving one kind to one
+ * string — not any single component's output in isolation.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+
+import type { RecentItem } from '../../../hooks/useRecentItems.js';
+import type { FavoriteItem } from '../../../hooks/useFavorites.js';
+import { capitalizeFirst } from '../../../utils/index.js';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+/**
+ * One translator for all three surfaces.
+ *
+ * The keyed entry is spelled in zh (verbatim from
+ * `packages/i18n/src/locales/zh.ts`) on purpose: `capitalizeFirst` could
+ * never produce `报表`, so the keyed control below cannot pass by accidentally
+ * running the fallback. Anything not in this map misses, exactly as i18next
+ * misses an absent key, and the call site's `defaultValue` decides.
+ */
+vi.mock('@object-ui/i18n', async (importOriginal) => {
+  const KEYED: Record<string, string> = {
+    'home.recentApps.itemType.report': '报表',
+  };
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    useObjectTranslation: () => ({
+      t: (key: string, options?: Record<string, unknown>) =>
+        KEYED[key] ?? String(options?.defaultValue ?? key),
+      language: 'zh',
+    }),
+  };
+});
+
+import { useObjectTranslation } from '@object-ui/i18n';
+import { HomeContinue } from '../HomeRail.js';
+import { RecentApps } from '../RecentApps.js';
+import { StarredApps } from '../StarredApps.js';
+
+/** A kind with NO `home.recentApps.itemType.*` key. */
+const UNKEYED_KIND = 'playbook';
+/** A kind WITH a key — the control that must stay untouched. */
+const KEYED_KIND = 'report';
+
+const ITEM_LABEL = 'Quarterly revenue';
+
+/**
+ * The rail takes `t` as a prop while the cards pull it from the hook. Reading
+ * it from the same hook here is what makes this a parity test rather than two
+ * unrelated renders: all three surfaces are driven by one translator.
+ */
+function Rail({ items }: { items: RecentItem[] }) {
+  const { t } = useObjectTranslation();
+  return <HomeContinue items={items} onOpen={() => {}} t={t} />;
+}
+
+/**
+ * Every surface renders the item label followed by the type label inside the
+ * item node, so the type label is what remains once the known label is
+ * removed. The two `expect`s are instrument checks — they fail loudly if a
+ * surface stops rendering in that shape, instead of silently returning `''`
+ * and making a comparison of two empty strings look like agreement.
+ */
+function typeLabelOf(node: HTMLElement, itemLabel: string): string {
+  const text = (node.textContent ?? '').trim();
+  expect(text.startsWith(itemLabel)).toBe(true);
+  const typeLabel = text.slice(itemLabel.length).trim();
+  expect(typeLabel).not.toBe('');
+  return typeLabel;
+}
+
+function renderAllThree(kind: string) {
+  const recent: RecentItem[] = [
+    {
+      id: 'r1',
+      label: ITEM_LABEL,
+      href: '/x',
+      type: kind as RecentItem['type'],
+      visitedAt: new Date().toISOString(),
+    },
+  ];
+  const favorites: FavoriteItem[] = [
+    {
+      id: 'f1',
+      label: ITEM_LABEL,
+      href: '/x',
+      type: kind as FavoriteItem['type'],
+      favoritedAt: new Date().toISOString(),
+    },
+  ];
+
+  render(
+    <>
+      <div data-testid="rail-surface">
+        <Rail items={recent} />
+      </div>
+      <RecentApps items={recent} />
+      <StarredApps items={favorites} />
+    </>,
+  );
+
+  return {
+    rail: typeLabelOf(within(screen.getByTestId('rail-surface')).getByRole('button'), ITEM_LABEL),
+    recentCard: typeLabelOf(screen.getByTestId('recent-item-r1'), ITEM_LABEL),
+    starredCard: typeLabelOf(screen.getByTestId('starred-item-f1'), ITEM_LABEL),
+  };
+}
+
+describe('Home item-type label parity across the three consumers', () => {
+  it('fixture guard: the two candidate spellings differ for the unkeyed kind', () => {
+    // Without this, a single-character or already-capitalized kind would make
+    // both spellings identical and the pin below would agree trivially —
+    // passing while proving nothing.
+    expect(UNKEYED_KIND.length).toBeGreaterThan(1);
+    expect(capitalizeFirst(UNKEYED_KIND)).not.toBe(UNKEYED_KIND);
+  });
+
+  it('THE PIN: a kind with no translation key renders one identical label on all three surfaces', () => {
+    const { rail, recentCard, starredCard } = renderAllThree(UNKEYED_KIND);
+
+    // Agreement is the assertion. Before objectui#6165 the rail answered
+    // 'playbook' here while both cards answered 'Playbook'.
+    expect(rail).toBe(recentCard);
+    expect(rail).toBe(starredCard);
+
+    // And the agreed spelling is the readable one the two cards already used
+    // — pinning the DIRECTION of the convergence, so a future "make them all
+    // agree" that converges on the bare lowercase fails here too.
+    expect(rail).toBe(capitalizeFirst(UNKEYED_KIND));
+  });
+
+  it('control: a kind WITH a translation key still resolves through the key on all three surfaces', () => {
+    // Passes before and after the fix by design: the change is bounded to the
+    // fallback, and this is what proves it. `报表` is unreachable from the
+    // fallback, so a green here means the keyed path genuinely ran.
+    const { rail, recentCard, starredCard } = renderAllThree(KEYED_KIND);
+
+    expect(rail).toBe('报表');
+    expect(recentCard).toBe('报表');
+    expect(starredCard).toBe('报表');
+  });
+});

--- a/packages/app-shell/src/console/home/recentItemTypeLabel.ts
+++ b/packages/app-shell/src/console/home/recentItemTypeLabel.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * recentItemTypeLabel
+ *
+ * The ONE place the `home.recentApps.itemType.*` label is resolved.
+ *
+ * Three Home surfaces render a label for the same item kind — the rail
+ * (`HomeRail.HomeContinue`), the Recently-Accessed cards (`RecentApps`) and
+ * the Starred cards (`StarredApps`). Each used to spell the lookup itself,
+ * and they drifted: the two card surfaces fell back to
+ * `capitalizeFirst(type)` while the rail fell back to the bare `type`, so any
+ * kind without a translation key rendered as `Report` on the cards and
+ * `report` in the rail — on the same screen (objectui#6165).
+ *
+ * The duplication is what allowed the drift, so the fix removes the
+ * duplication rather than only re-spelling the odd one out. A fourth surface
+ * gets the agreed behaviour by construction.
+ *
+ * ⚠️ `type` is deliberately `string`, not a union. The three call sites do
+ * NOT share one union: the rail and `RecentApps` take `RecentItem['type']`
+ * (`… | 'metadata'`) while `StarredApps` takes `FavoriteItem['type']`
+ * (`… | 'nav'`). They share the KEY NAMESPACE, not the type — narrowing this
+ * parameter to either union would reject a legitimate caller.
+ *
+ * @module
+ */
+
+import { capitalizeFirst } from '../../utils/index.js';
+
+type TFn = (key: string, opts?: any) => string;
+
+/**
+ * Resolve the display label for a Home item kind.
+ *
+ * Falls back to the capitalized kind (`report` -> `Report`) when the locale
+ * carries no `home.recentApps.itemType.<type>` key, matching what the card
+ * surfaces have always rendered.
+ */
+export function recentItemTypeLabel(t: TFn, type: string): string {
+  return t(`home.recentApps.itemType.${type}`, { defaultValue: capitalizeFirst(type) });
+}


### PR DESCRIPTION
Fixes #6165

Three Home surfaces render a label for the same item kind through the `home.recentApps.itemType.*` key namespace, and each spelled the lookup itself. They had drifted: the two card surfaces fell back to `capitalizeFirst(type)` while the rail fell back to the bare `type`, so a kind with no key rendered `Report` on the cards and `report` in the rail — on the same screen.

All three now resolve through one `recentItemTypeLabel` helper.

## Premise re-derivation (every PM assumption checked against `main`)

| assumption | verdict |
|---|---|
| line numbers have moved (`HomeRail.tsx:251`, `RecentApps.tsx:55`, `StarredApps.tsx:61`) | ❌ **wrong — all three were exact.** `main` advanced several times, but none of it touched these files. |
| the census is three consumers | ✅ confirmed. `grep` for `home.recentApps.itemType` finds exactly these three call sites. |
| all three consume the same `RecentItem['type']` union | ❌ **wrong — two unions, one namespace.** |
| `capitalizeFirst` is one shared helper, not two copies | ✅ both siblings import `../../utils/index.js`. (A second, unrelated copy exists at `apps/console/src/utils.ts:32`; neither sibling uses it.) |
| #6023 added `report` + `metadata`, so the fallback is dormant | ✅ confirmed on `main` — all six members are keyed in `en.ts`. |

**The two-union finding matters for the fix's shape.** The rail and `RecentApps` take `RecentItem['type']` (`object|dashboard|page|report|record|**metadata**`); `StarredApps` takes `FavoriteItem['type']` (`object|dashboard|page|report|record|**nav**`). They share the *key namespace*, not the type — `StarredApps` reuses the `recentApps.itemType.*` keys deliberately, and says so in a comment. So the helper's parameter is `string`, not a union: narrowing it to either one would reject a legitimate caller. That is documented at the helper.

A side-effect worth recording: **`nav` has no `home.recentApps.itemType.nav` key**, so on the favorite side the fallback is *not* fully dormant today. `nav` items are documented as excluded from Starred, and `StarredApps` is a public export whose caller supplies the items, so whether the path is reachable depends on the host. Not fixed here — out of this card's scope.

**Fourth-consumer census:** `views/metadata-admin/StudioHomePage.tsx` also types on `RecentItem['type']`, but only for `RECENT_ICONS`; it renders no type *label* and uses `translateMetadataType` for a different concern. So the count really is three.

## Why a helper rather than a one-line change

The ruling permitted either, conditional on the helper being the honest shape. It is: three identical expressions, one key namespace, one directory, and the card exists *because* they drifted. Re-spelling the odd one out fixes this instance; removing the duplication removes the recurrence. The two card surfaces' **rendered output is unchanged** — they keep `capitalizeFirst`, which is what the ruling protects; only the expression's home moves. No fourth spelling, and nothing outside `console/home/` is touched. The helper is deliberately **not** added to `console/home/index.ts` — it is internal, and there is no call for widening the package's public surface.

## The test is a parity pin, not a ghost assertion

Every union member shipping today **has** a key, so a fixture built on a real member takes the keyed path, never reaches the fallback, and passes identically before and after — the easy and worthless test here. The pin therefore uses a **synthetic unkeyed kind** (`playbook`), and asserts **agreement between consumers** rather than one component's output:

- **the pin** — `playbook` renders one identical string across the rail, `RecentApps` and `StarredApps` (all three pinned, not the two the ruling required), and that string is the capitalising form, pinning the *direction* of the convergence.
- **fixture guard** — asserts the two candidate spellings actually differ for this kind, so the pin cannot pass by degenerating on a single-character or already-capitalised fixture.
- **keyed control** — a kind *with* a key still resolves through the key on all three surfaces; green before and after **by design**, which is what proves the change is bounded to the fallback. Its expected value is the zh `报表`, which `capitalizeFirst` could never produce — so a green control means the keyed path genuinely ran, rather than the fallback quietly answering.

All three surfaces are driven by **one** translator: the rail takes `t` as a prop while the cards pull it from the hook, so the test reads it from that same hook and passes it down. Otherwise it would be comparing two unrelated renders.

## Ablation — proven red before

Committed first, then reverted **only** `HomeRail`'s fallback expression, restore under `trap … EXIT INT TERM` with absolute paths (`REPO_ROOT` via `git rev-parse --show-toplevel`).

Mutation proven on disk in **both** directions (this is a replacement, so both genuinely exist — before: fixed-form 1 / reverted-form 0; after: fixed-form 0 / reverted-form 1), plus a blob-hash change (`18c1e559…` → `e44b3acb…`).

```
AssertionError: expected 'playbook' to be 'Playbook'
Test Files  1 failed (1)
     Tests  1 failed | 2 passed (3)
```

Exactly the predicted direction and count: the rail read `playbook` while the cards read `Playbook`. Restore verified — `git diff HEAD --stat` empty and the blob hash back to `18c1e559…`.

No rebuild was needed for either leg, and that is measured rather than assumed: `vitest.config.mts` aliases every `@object-ui/*` to `packages/*/src`, and the test imports its subjects relatively, so no `dist/` sits on the path.

## Verification — all at `2510207aa` (final commit, tree clean)

| gate | verdict line |
|---|---|
| pin (targeted) | `Test Files 1 passed (1)` · `Tests 3 passed (3)` |
| affected population, 34 files | `Test Files 34 passed (34)` · `Tests 429 passed (429)` |
| `pnpm type-check` (`@object-ui/app-shell`) | exit 0, 0 errors |
| `pnpm lint` (`@object-ui/app-shell`) | `✖ 2679 problems (0 errors, 2679 warnings)` — exit 0 |
| `check-changeset-presence` | `✅ … declares 1 changeset(s)` |
| `check-changeset-no-major` | `✅ No changeset declares a major bump.` |
| `check-control-bytes` | `✅ OK (scanned 5208 tracked text file(s))` |
| `check-vi-mock-specifiers` | `✅ OK (… 0 non-static …)` |
| `check:i18n-keys` | exit 0 — the dynamic key family still resolves against the en pack |
| `check:i18n-drift` | `No en value changed in this range.` |
| `check:i18n-dead-keys`, `check:self-import`, `check-shell-escape-residue` | exit 0 |

Gate set derived by enumerating each CI job's own step list under `.github/workflows/`, not from memory.

**Declared narrowing** (the whole-package `app-shell` suite is ~784 s and would be killed by the container's ~10 min foreground cap):
1. Population read from a real source — `grep -rln` for tests importing or mentioning the changed modules, not my guess about what is affected. It is a superset: it matches any test naming `HomePage`/`console/home` at all.
2. Count from vitest's own report: **34 files, 429 tests**, matching the 34-file population exactly — the sanity check against objectui#3378, where a mis-invocation silently runs the wrong package and reports it green.
3. Invariance: `eslint.config.js` sets no `parserOptions.project`, so linting is not type-aware and this diff cannot move the verdict on any untouched file. The full farm runs in CI regardless.

Two coverage facts measured with `--listFiles` rather than assumed: `app-shell`'s base `tsconfig.json` **excludes** the new test (0 hits), while `tsconfig.test.json` — the second program in `type-check` — **includes** it. The shipped helper is in both. So "type-check is clean" genuinely covers the new test.

`recentItemTypeLabel.ts` adds one `@typescript-eslint/no-explicit-any` **warning**, from the `TFn` alias it carries over verbatim from `HomeRail.tsx:26`. Kept identical to the line it replaces rather than diverging; the gate is green (warnings, not errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_