### PR TITLE
fix(app-shell): pin nodenext and read Monaco's named Editor export

### DIFF
--- a/.changeset/app-shell-nodenext-pin-5440.md
+++ b/.changeset/app-shell-nodenext-pin-5440.md
@@ -1,0 +1,7 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Pin `module` / `moduleResolution` to `nodenext` in `@object-ui/app-shell`'s build config, matching the pins `@object-ui/react`, `@object-ui/fields` and five other packages already carry. This package builds with a bare `tsc`, which never rewrites import specifiers, so what the source writes is exactly what `dist` ships; under `nodenext` a missing relative extension is a compile error, so the extensionless-specifier defect that made published entries unloadable under plain Node cannot come back silently here.
+
+The lazy `@monaco-editor/react` imports in the metadata designer's source editors now read the package's named `Editor` export instead of its default. `@monaco-editor/react@4.7.0` is CommonJS and ships no `exports` map, so under `nodenext` the default resolves to the module namespace rather than to the component. The two names are one declaration in that package's own typings and the same object at runtime in both its CommonJS and ESM builds, so the editor that renders is unchanged.

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.fallback.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.fallback.test.tsx
@@ -10,10 +10,14 @@ import { render, screen } from '@testing-library/react';
 
 // Monaco "loads" (loader.init resolves) but renders nothing, so the DOM-poll
 // backstop — not the loader fast-fail path — is what must engage here.
-vi.mock('@monaco-editor/react', () => ({
-  default: () => null,
-  loader: { init: () => Promise.resolve({}) },
-}));
+//
+// `Editor` and `default` are ONE declaration in the real package, and the
+// component under test imports the NAMED one (objectui#5440), so the stub is
+// bound to both names rather than to `default` alone.
+vi.mock('@monaco-editor/react', () => {
+  const Editor = () => null;
+  return { Editor, default: Editor, loader: { init: () => Promise.resolve({}) } };
+});
 
 import { JsonSourceEditor } from './JsonSourceEditor';
 

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.monaco-export.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.monaco-export.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The lazy Monaco import must resolve to the EDITOR component (objectui#5440).
+ *
+ * `packages/app-shell/tsconfig.json` pins `moduleResolution: nodenext`, under
+ * which `@monaco-editor/react`'s CommonJS default is the module namespace
+ * rather than the component, so the lazy import reads the named `Editor`
+ * export instead.
+ *
+ * The compiler covers more of that spelling than one might assume, and this
+ * was measured rather than guessed: reverting the factory to the namespace
+ * default is TS2345, and pointing it at the sibling `DiffEditor` is TS2353 on
+ * the first option this call site passes that a diff editor does not take
+ * (`tabSize`). So the wrong-component-but-typed case does NOT survive
+ * `type-check` here, and this test is not what catches it.
+ *
+ * What nothing else covers is the editor resolving to NOTHING. Both Monaco
+ * suites next door assert the textarea FALLBACK, and a lazy import that never
+ * yields a component produces exactly that fallback — measured: remove
+ * `Editor` from `JsonSourceEditor.fallback.test.tsx`'s stub, leaving the lazy
+ * factory reading an export that is not there, and that suite still passes,
+ * because the DOM-poll backstop flips to the textarea before the broken import
+ * is ever rendered. Green there means "the fallback works", never "the editor
+ * works". This is the test that renders the editor and asserts it painted.
+ *
+ * The stub mirrors the real module — `Editor` and `DiffEditor` distinguishable,
+ * and `default` bound to the namespace-shaped object `nodenext` hands the code.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@monaco-editor/react', () => {
+  const Editor = () => <div className="view-line" data-testid="monaco-editor" />;
+  const DiffEditor = () => <div className="view-line" data-testid="monaco-diff-editor" />;
+  return {
+    Editor,
+    DiffEditor,
+    default: { Editor, DiffEditor },
+    loader: { init: () => Promise.resolve({}) },
+  };
+});
+
+import { JsonSourceEditor } from './JsonSourceEditor';
+
+describe('JsonSourceEditor — lazy Monaco export shape', () => {
+  it('renders the named `Editor` export, not `DiffEditor` and not the namespace default', async () => {
+    // A long grace period so the textarea fallback cannot engage on a timer:
+    // if it appears at all, it is because the editor never painted.
+    render(
+      <JsonSourceEditor
+        value={{ name: 'work_order' }}
+        onChange={() => {}}
+        fallbackDelayMs={60_000}
+      />,
+    );
+
+    expect(await screen.findByTestId('monaco-editor', {}, { timeout: 2000 })).toBeInTheDocument();
+    expect(screen.queryByTestId('monaco-diff-editor')).toBeNull();
+    expect(screen.queryByLabelText('JSON source')).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/JsonSourceEditor.tsx
@@ -27,9 +27,22 @@ import { useMonacoFallback } from './useMonacoFallback.js';
 
 // Lazy: Monaco's React wrapper itself pulls in the editor core
 // (~3MB), so we keep it out of the initial app-shell chunk.
+//
+// The NAMED `Editor` export, not `default`: `@monaco-editor/react@4.7.0` is
+// CommonJS and ships no `exports` map, so under this package's `nodenext`
+// resolution the default is the module NAMESPACE rather than the component,
+// and `React.lazy` rejects it (TS2345 — objectui#5440).
+//
+// It is the SAME component, not a near-enough substitute — checked in the
+// installed 4.7.0 rather than assumed from the name. Its own typings alias one
+// declaration to both spellings (`export { _default as Editor, ...,
+// _default as default }`), and the two are identical at runtime in its CJS
+// build and its ESM build alike. That is what makes this safe under `bundler`
+// resolution too, which is what the console actually bundles with and where
+// the previous spelling worked.
 const LazyMonaco = React.lazy(async () => {
   const mod = await import('@monaco-editor/react');
-  return { default: mod.default };
+  return { default: mod.Editor };
 });
 
 export interface JsonIssue {

--- a/packages/app-shell/src/views/metadata-admin/previews/SourcePageEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/SourcePageEditor.tsx
@@ -27,9 +27,16 @@ import { SchemaRenderer } from '@object-ui/react';
 import { PreviewShell, PreviewErrorBoundary } from './PreviewShell.js';
 import { useMonacoFallback } from '../useMonacoFallback.js';
 
+// Lazy for the same reason as JsonSourceEditor — Monaco's core is ~3MB and
+// stays out of the initial app-shell chunk.
+//
+// The NAMED `Editor` export for the same reason too: under `nodenext` this
+// CommonJS package's default is the module namespace, not the component
+// (objectui#5440). `../JsonSourceEditor.tsx` carries the interop reading and
+// the evidence that both spellings are one declaration.
 const LazyMonaco = React.lazy(async () => {
   const mod = await import('@monaco-editor/react');
-  return { default: mod.default };
+  return { default: mod.Editor };
 });
 
 export interface SourcePageEditorProps {

--- a/packages/app-shell/src/views/metadata-admin/useMonacoFallback.fastfail.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/useMonacoFallback.fastfail.test.tsx
@@ -9,11 +9,18 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-vi.mock('@monaco-editor/react', () => ({
-  default: () => null,
-  // Simulate the CDN loader script failing to load.
-  loader: { init: () => Promise.reject(new Error('CDN blocked')) },
-}));
+// `Editor` and `default` are ONE declaration in the real package, and the
+// component under test imports the NAMED one (objectui#5440), so the stub is
+// bound to both names rather than to `default` alone.
+vi.mock('@monaco-editor/react', () => {
+  const Editor = () => null;
+  return {
+    Editor,
+    default: Editor,
+    // Simulate the CDN loader script failing to load.
+    loader: { init: () => Promise.reject(new Error('CDN blocked')) },
+  };
+});
 
 import { JsonSourceEditor } from './JsonSourceEditor';
 

--- a/packages/app-shell/tsconfig.json
+++ b/packages/app-shell/tsconfig.json
@@ -8,7 +8,26 @@
     "types": ["node", "vite/client"],
     "noEmit": false,
     "declaration": true,
-    "composite": true
+    "composite": true,
+
+    // See `packages/react/tsconfig.json` for the full argument: under
+    // `nodenext` a missing relative extension is TS2835 and a bare directory
+    // import is TS2834, so the extension property this package's `dist` needs
+    // is enforced by the compiler instead of by review. It is load-bearing
+    // HERE in particular: this package builds with a bare `tsc`
+    // (`"build": "tsc"`), and `tsc` never rewrites specifiers, so what the
+    // source writes is exactly what `dist` ships — objectui#4538's failure.
+    //
+    // Landed last of the consumer pins because it was the largest, and each
+    // number below was a different card's work, measured with this pin used as
+    // an instrument before it was used as enforcement (objectui#5440):
+    // 1097 errors before objectui#5365 taught `@object-ui/components` to emit
+    // resolvable typings, 23 after it, 2 after objectui#5439 cleared the
+    // extensionless typings `@object-ui/plugin-chatbot` re-exported through.
+    // Re-measured on this branch at f8c70f4f3: unpinned 0, pinned 2, both of
+    // them the `@monaco-editor/react` interop site fixed in this same commit.
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"],


### PR DESCRIPTION
Fixes #5440

Lands the `module` / `moduleResolution: nodenext` pin in `packages/app-shell/tsconfig.json` — the last of the consumer pins, and the largest — and resolves the two `@monaco-editor/react` interop errors that were the only thing standing between the pin and a green enforcement.

*(Generics below are written with a space after the opening angle bracket, following the card's own convention: GitHub's body sanitizer strips an angle bracket followed by a letter as an HTML tag.)*

## The table, re-derived rather than inherited

Every number in the card was measured on 2026-08-20 at `32ef595f4` and was explicitly not re-measured at dispatch. Re-derived here at `f8c70f4f3`, closure built first (`pnpm --filter '@object-ui/app-shell^...' build`, exit 0), via `pnpm --filter @object-ui/app-shell exec tsc --noEmit`:

| state of `packages/app-shell/tsconfig.json` | errors | exit |
|---|---|---|
| no pin (control) | **0** | 0 |
| `nodenext` pin, before this change | **2** — both TS2345 | 1 |
| `nodenext` pin, after this change | **0** | 0 |

The control row still holds — `app-shell` type-checks clean unpinned, so every error is produced by the pin, which is what made it usable as a measuring instrument before it was usable as enforcement.

**The 21 TS7006 are gone.** Triage asked for this specifically: they were attributed to #5439, and #5439 landed. None survived, so there is no new residue to report and nothing was widened. The card's 23 is now 2, and the line/column anchors re-anchored unchanged at `JsonSourceEditor.tsx(30,31)` and `previews/SourcePageEditor.tsx(30,31)`.

## The monaco call: named export, and why `m.Editor` is verifiably the component

Taken as triage presumed — the named-export shape. The card's worry was that a lazy import can type-check and still render the wrong thing, which a green type-check would not catch, so the name was checked in the installed `@monaco-editor/react@4.7.0` rather than assumed:

- **Its own typings alias one declaration to both names.** The last line of `dist/index.d.ts` is `export { ..., _default as Editor, ..., _default as default, useMonaco }`, and `_default` is `react.MemoExoticComponent< typeof Editor >`. `Editor` and `default` are not two symbols that happen to agree — they are the same declaration.
- **Runtime identity holds in both module formats.** In the CommonJS build (`dist/index.js`, what `nodenext` resolves through `main`, since the package ships no `exports` map): `m.default === m.Editor` is `true`, with `$$typeof` = `Symbol(react.memo)`. In the ESM build (`dist/index.mjs`, what the bundler path uses today): the emitted export line is `export{we as DiffEditor,de as Editor,Ft as default,...}` with `Ft=de`, and importing it gives `m.default === m.Editor` `true`.

So this is the same object the default was resolving to, under both resolutions — the swap cannot change which component renders. That is established by identity, not by a browser run: **I did not boot the app or drive Monaco in a browser**, and the assertion here is the narrower one that identity permits.

## What the ablation contradicted

I predicted that pointing the factory at `DiffEditor` would type-check green — the "typed but wrong" case that motivated adding a render-level test. **That prediction was wrong**, and the measurement is reported rather than the template:

| mutation | `tsc --noEmit` | new test |
|---|---|---|
| `mod.default` (the namespace) | **red** — TS2345 | **red** |
| `mod.DiffEditor` | **red** — TS2353, `'tabSize' does not exist in type 'IDiffEditorConstructionOptions'` | **red** |

The compiler already rejects both wrong components at this call site, because the two components' prop types differ and this call site passes editor-shaped options. So the new test is *not* what catches a wrong component.

Measuring what it does catch turned up a real hole: **an editor that resolves to nothing is invisible to the existing suites**, because they assert the textarea *fallback* and a broken lazy import produces exactly that fallback. Measured — remove `Editor` from `JsonSourceEditor.fallback.test.tsx`'s stub, leaving the factory reading an export that is not there, and that suite still passes (exit 0): the DOM-poll backstop flips to the textarea before the broken import is ever rendered. Green there means "the fallback works", never "the editor works". `JsonSourceEditor.monaco-export.test.tsx` is the one test that renders the editor and asserts it painted. Its docstring states this measured reasoning, not my original assumption.

Each ablation leg mutated source only (vitest and `tsc` both read these sources directly — no `dist` is involved for `app-shell`'s own tree), proved the mutation landed on disk by grep count of the injected and removed text, and restored under a trap with absolute paths, proving restoration by blob hash against the `HEAD` blob plus an empty `git diff HEAD` — not by an exit code.

## File surface

Two files beyond the three the claim declared, plus one new test, all inside `packages/app-shell/**`:

- `packages/app-shell/tsconfig.json` — the pin.
- `JsonSourceEditor.tsx`, `previews/SourcePageEditor.tsx` — the named export.
- `JsonSourceEditor.fallback.test.tsx`, `useMonacoFallback.fastfail.test.tsx` — **added surface.** Both stubs bound the component to `default` only, so the change would have left them handing `React.lazy` an undefined export. They are rebound to both names, as the real module does.
- `JsonSourceEditor.monaco-export.test.tsx` — **new**, per the hole measured above.
- `.changeset/app-shell-nodenext-pin-5440.md` — `patch`, per `check-changeset-presence.mjs`'s own verdict.

**No pin asserts the *set* of packages carrying the nodenext lines**, so this change has no second half. Checked rather than assumed: every mention of `nodenext` / `node16` in tracked files outside `node_modules` is either a package's own tsconfig (8 of them, now 9), a `vite.config.ts`, a changelog, or prose. The gate that reads these configs — `check-node-esm-load.mjs` — reads only `noEmit`, which this change does not touch, so `app-shell` stays in the specifier leg exactly as before.

## Gates

All run at `ae4546995`, exit codes captured by redirect **before** any pipe, each quoted from the gate's own verdict line.

| gate | exit | verdict |
|---|---|---|
| `pnpm --filter @object-ui/app-shell type-check` (**acceptance**) | 0 | ran both legs: `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm exec vitest run` — `views/metadata-admin/` + `views/studio-design/` | 0 | `Test Files 239 passed (239)`, `Tests 2225 passed / 1 skipped` |
| `check:vi-mock-specifiers` | 0 | `OK (3744 tracked source file(s) ... 437 carry a mock ...)` |
| `check:esm-specifiers` | 0 | `Specifier leg: no un-ledgered package emits an extensionless relative specifier.` |
| `check-node-esm-load.test.ts` (asserts every tsconfig in the repo parses) | 0 | `Test Files 1 passed`, `Tests 44 passed` |
| `check:control-bytes` | 0 | `OK (scanned 5217 tracked text file(s); skipped 85 binary)` |
| `type-check:coverage` | 0 | `45/46 via type-check ... 41/41 packages compile their tests` |
| `check:lint-coverage` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `check:published-dist` | 0 | `No published package's build output carries tooling material.` |
| `check:eager-closure` | 0 | `Console eager closure is 3223.1 KB gzipped across 52 of 508 chunks (budget: 3266.6 KB, headroom: 43.5 KB)` |
| `check:changeset-presence` / `-no-major` / `-fixed` | 0 / 0 / 0 | `declares 1 changeset(s)` · `No changeset declares a major bump.` · `All workspace packages are in the changeset fixed group.` |
| `pnpm --filter @object-ui/console build` | 0 | consumer still compiles; also what makes the eager-closure gauge real rather than absent |

`check:eager-closure` first came back exit 2 with `No eager-closure report at apps/console/dist/eager-closure.json ... This is a broken gauge, not a passing budget` — a missing prerequisite, not a finding. It is reported above only after building the console, which is the run that makes it a measurement.

**Declared narrowing:** repo-wide `pnpm lint` (`turbo run lint`, 46 packages) was narrowed to `pnpm --filter @object-ui/app-shell lint` — exit 0, `0 errors, 2678 warnings` (warnings pre-existing). The narrowing is a measurement rather than a gap, on three counts: the population comes from eslint's own config resolution rather than my guess; `--format json` reports **962 files inspected**, all 5 of my touched-or-new files among them; and `eslint.config.js` enables no type-aware linting (no `projectService`, no `parserOptions.project`), so no rule reads types across a package boundary and a diff confined to `packages/app-shell/**` cannot move any untouched package's verdict. CI runs the full farm regardless.

CI had not converged when this was opened — reporting at draft-PR time is the dispatch contract, and red gates come back as a patch round on this same claim.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_