### PR TITLE
docs(core): replace the dangling SECURITY_FIX_SUMMARY @see with its rationale

### DIFF
--- a/.changeset/issue-6275-validation-engine-dangling-see.md
+++ b/.changeset/issue-6275-validation-engine-dangling-see.md
@@ -1,0 +1,7 @@
+---
+---
+
+Comment-only change in `@object-ui/core`: the `SimpleExpressionEvaluator` doc block
+no longer points at the deleted `SECURITY_FIX_SUMMARY.md`, and states the security
+rationale inline instead. Releases nothing — the class is not exported, so the doc
+block reaches no `.d.ts`, and no behaviour, type or API surface changes.

--- a/packages/core/src/validation/validators/object-validation-engine.ts
+++ b/packages/core/src/validation/validators/object-validation-engine.ts
@@ -199,7 +199,15 @@ export interface ValidationExpressionEvaluator {
  * Simple expression evaluator using a simple parser (no dynamic code execution)
  *
  * SECURITY: This implementation parses expressions into an AST and evaluates them
- * without using eval() or new Function(). It supports:
+ * without using eval() or new Function(). That is a remediation, not a style
+ * preference: an earlier revision compiled the predicate with
+ * `new Function(...contextKeys, "'use strict'; return (" + expression + ")")`,
+ * and CodeQL flagged it as "Unsafe code constructed from library input" —
+ * expressions reach this class from validation metadata, so that shape is a
+ * code-injection vector in any consumer that renders metadata it does not
+ * control. Never reintroduce eval(), new Function() or any other dynamic-code
+ * path here to buy expressiveness or speed; extend the parser, or inject a
+ * richer evaluator through the constructor (see NOT CEL below). Supports:
  * - Comparison operators: ==, !=, >, <, >=, <=
  * - Logical operators: &&, ||, !
  * - Property access: record.field, record['field']
@@ -218,7 +226,10 @@ export interface ValidationExpressionEvaluator {
  * pre-check agree with the server on richer predicates, pass a CEL-backed
  * `ValidationExpressionEvaluator` to the constructor.
  *
- * @see https://github.com/objectstack-ai/objectui/blob/main/SECURITY_FIX_SUMMARY.md
+ * The write-up this block used to link to (`SECURITY_FIX_SUMMARY.md`) was
+ * deleted with no successor; its load-bearing reasoning is inline above, and
+ * the original text remains readable at
+ * `git show ea72f1886^:SECURITY_FIX_SUMMARY.md`.
  */
 class SimpleExpressionEvaluator implements ValidationExpressionEvaluator {
   evaluate(expression: string, context: Record<string, any>): any {


### PR DESCRIPTION
Fixes #6275

`SimpleExpressionEvaluator`'s doc block in `packages/core/src/validation/validators/object-validation-engine.ts` pointed at a `SECURITY_FIX_SUMMARY.md` that has not existed since January. This replaces the dead `@see` with the load-bearing reasoning that file carried.

## Premise table — re-measured on `origin/main` @ `79ebf30d1` (the card was written against `c38162d7c`; `main` moved 30+ commits)

| # | assumption | verdict | how measured |
|---|---|---|---|
| M1 | the `@see` sits at `object-validation-engine.ts:221` | ✅ held | line number **re-derived**, not trusted: `grep -n SECURITY_FIX_SUMMARY <file>` → `221: * @see https://github.com/objectstack-ai/objectui/blob/main/SECURITY_FIX_SUMMARY.md` |
| M2 | `SECURITY_FIX_SUMMARY.md` exists nowhere in the tree | ✅ held | `git ls-tree -r --name-only HEAD \| grep -i SECURITY_FIX_SUMMARY` → 0 hits |
| M3 | exactly one hit across `packages/` and `apps/` | ✅ held | `grep -rn` over both, excluding `node_modules`/`dist` → count `1`; `git grep` over all tracked files agrees |

**All three held.** One *subsidiary* claim in the card body did not — see "Two card claims that did not survive measurement" below.

## The three-way choice, and the evidence from `ea72f1886`

**Chosen: fold the load-bearing sentence into the doc block, then drop the dead `@see`.** (Not "repoint" — nothing to repoint at. Not "just delete" — the reference was not redundant.)

**Evidence the content was dropped, not moved:**

```
$ git show --shortstat --format="" ea72f1886
 20 files changed, 6742 deletions(-)
```

Zero insertions. The commit — *"Delete obsolete files and documentation related to PR #300 and v0.4.0 release; remove security fix summary and CRM app fix scripts"* — is a bulk removal of 20 root-level summary docs (`ARCHITECTURE_EVALUATION.md`, `RELEASE_SUMMARY_v0.4.0.md`, `SECURITY_FIX_SUMMARY.md`, …). Nothing was written anywhere in the same commit, so there is no successor path to repoint at, and no ADR or docs page anywhere in the tree covers it (`git grep -il codeql -- content/ docs/` → empty).

**Evidence the reference was not redundant** — from `git show ea72f1886^:SECURITY_FIX_SUMMARY.md`:

Most of what it carried *is* already in the doc block — the operator list, and the LIMITATIONS list reproduced there verbatim. One thing is not, and is the reason the parser has the shape it has:

> **Alert**: Unsafe code constructed from library input
> **Issue**: Use of `new Function()` constructor with user-provided expressions, enabling potential code injection attacks

The doc block said *what* the code does ("without using eval() or new Function()") but never *why it must stay that way*. A maintainer who wanted chained comparisons or more speed had, in the file, no reason not to reach for `new Function()` — the ban read as taste. That is the sentence now inlined. The provenance line points at `git show ea72f1886^:SECURITY_FIX_SUMMARY.md`, an immutable git object, rather than another `main` blob path that can rot the same way.

## Two card claims that did not survive measurement

Neither changes the disposition — both are recorded so the record is accurate.

1. **The card says the `@see` was "the only pointer the doc block offers for the security rationale behind this evaluator's fail-open polarity".** The deleted file contains **zero** mention of polarity or fail-open — its whole subject is the injection fix. The polarity rationale was already inline in the doc block (the `NOT CEL` paragraph, ending "…fails OPEN — the same outcome the server produces for an un-evaluable predicate"), and is untouched here.

2. **The card says "this dead link ships in the released package's type declarations".** It ships, but not there. Measured by building the package (`tsc`) and reading the emitted output:

   | artifact | carries the doc block? |
   |---|---|
   | `dist/validation/validators/object-validation-engine.d.ts` | **no** — `SimpleExpressionEvaluator` is not exported, so `tsc` emits no declaration for it; the only occurrence of the name is a passing mention inside the *module-level* doc block |
   | `dist/validation/validators/object-validation-engine.js` | **yes** — `tsc` preserves comments, and `package.json` `files: ["dist", …]` publishes it |

   So the dead link did reach consumers, in the published JavaScript. This is what decides the changeset form below.

## Changeset

`node scripts/check-changeset-presence.mjs` is followed by **its own verdict line**, not by memory:

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s):
    .changeset/issue-6275-validation-engine-dangling-see.md.
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

**Empty frontmatter, deliberately.** The change is comment-only on a class that is not exported: no behaviour, no type surface, no API. Nothing a consumer can import, call or depend on moves. The counterweight is concrete — `.changeset/config.json` puts all **43** packages in one `fixed` group, so any non-empty bump versions the entire monorepo for a comment. If a reviewer reads the published-`.js` comment as user-visible enough to warrant a release line, this flips to `patch` with a one-line edit; the measurement above is the fact that decides it. Never `major` (`check-changeset-no-major.mjs` ✅).

## Gates

Gate set derived by **reading the CI job step lists under `.github/workflows/`** — every workflow's `on:` block parsed for a `pull_request` trigger and its path filter, then each firing job's `run:` steps read. Verdict lines below are the gates' own; exit codes captured before any pipe (`cmd > file 2>&1; EXIT=$?`), never through `tail`.

Union re-run **after the final commit**, at `ad39293c9`:

| gate (CI workflow) | exit | the gate's own verdict line |
|---|---|---|
| `check-changeset-presence` (changeset-presence.yml) | 0 | `✅ 1 source file(s) … declares 1 changeset(s) … EMPTY frontmatter … a complete answer to this gate.` |
| `check-changeset-no-major` (changeset-guard.yml) | 0 | ``✅ No changeset declares a `major` bump.`` |
| `check-changeset-fixed` (ci.yml) | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `check-control-bytes` (control-bytes.yml) | 0 | `✅ check-control-bytes: OK (scanned 5225 tracked text file(s); skipped 85 binary).` |
| `check-doc-component-types` (doc-component-types.yml) | 0 | `✅ Every documented component type is registered.` |
| `check-doc-fence-languages` (doc-fence-languages.yml) | 0 | `✅ check:doc-fences — every TypeScript block in 223 document(s) is fenced ts/tsx/typescript …` |
| `check-doc-links` (docs-links.yml) | 0 | `Links are valid across 17 scan roots.` — **blind, see below** |
| `check-shell-escape-residue` (shell-escape-residue.yml) | 0 | `✅ check-shell-escape-residue: OK (4/4 root(s) resolved …)` |
| `check-skills-paths` (skills-paths.yml) | 0 | `✅ check-skills-paths: OK (93/94 stated path(s) resolve …)` |
| `check-vi-mock-specifiers` (vi-mock-specifiers.yml) | 0 | `✅ check-vi-mock-specifiers: OK (3748 tracked source file(s) …)` |
| `check-lint-coverage` (lint.yml) | 0 | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `check-entry-guard` (lint.yml) | 0 | `✓ check:entry-guard: 47 scripts/ file(s) — no entry guard outside the baseline …` |
| `check-cross-repo-closer-outcome` (lint.yml) | 0 | `check-cross-repo-closer-outcome: OK (105 assertions over 18 scenarios …)` |
| `check-pre-install-import-graph` (pre-install-import-graph.yml) | 0 | `✅ check-pre-install-import-graph: OK — 16 pre-install step(s) in 15 job(s) …` |
| `check-type-check-coverage` (ci.yml) | 0 | `✅ test type-check coverage: 41/41 packages compile their tests, 0 declared debt …` |
| `turbo run lint --filter=@object-ui/core` (lint.yml) | 0 | `✖ 515 problems (0 errors, 515 warnings)` — all warnings pre-existing, none on the changed lines |
| `turbo run type-check --filter=@object-ui/core` (ci.yml) | 0 | `Tasks: 5 successful, 5 total` |
| `vitest run packages/core/` (ci.yml test shards) | 0 | `Test Files 100 passed (100) · Tests 2023 passed (2023)` |

### Gates that are structurally blind to this change

- **`check-doc-links.mjs` (docs-links.yml) — blind, and its green run above is not evidence for this PR.** Not a judgement call: its walker is
  `scripts/check-doc-links.mjs:650` → `if (!/\.(md|mdx)$/.test(entry.name)) continue;`
  so a `.ts` file cannot enter the population at all. Worth noting the near-miss the issue flagged: the gate *does* already know how to decide this exact URL shape — `https://github.com/objectstack-ai/objectui/(blob|tree)/main/<path>` is a case it handles for markdown (`check-doc-links.mjs:154`). The link was undecidable only because of *where* it was written, not *what* it was. Widening the population to `@see` URLs in TS source is explicitly **out of scope** here (triage: "separate call, not minted this round") and is not attempted.
- **Every test gate.** `vitest run packages/core/` (100 files, 2023 tests) passes, but a comment-only diff cannot move any assertion — it is a regression guard, not evidence the link is fixed.
- **`readme-exports`, `performance-budget`, `doc-snippet-types`.** They fire on these paths and are left to CI: none can observe a comment. The bundle budget sees no byte change in any minified artifact; the export surface is unchanged (nothing was exported before or after).

The only evidence that the defect is fixed is the direct measurement: `blob/main/SECURITY_FIX_SUMMARY.md` occurrences across `packages/` + `apps/` went `1 → 0`, and the injected text (`CodeQL`, `Unsafe code constructed from library input`, `ea72f1886`) is present exactly once each on disk.

### Narrowing declared

`lint`, `type-check` and `test` were run **filtered to `@object-ui/core`** rather than across all 46 packages. Three pieces of evidence that the narrowing excludes nothing:

1. **Population from the tool's own config, not a guess** — `pnpm exec eslint . --format json` inside `packages/core` reports **195** files linted, and the changed file is in that set (checked by path, not assumed).
2. **Counts read from `--format json`** — 0 errors, 515 warnings, of which 17 are on the changed file and all pre-date this PR.
3. **Invariance for untouched files** — no eslint config in the repo enables type-aware linting (no `project:` / `projectService` in the single root `eslint.config.js`), so this diff cannot move any untouched file's verdict. Independently, the diff changes only comment bytes in a non-exported class, so no type, value or module-graph fact crosses a package boundary.

`check-lint-coverage` and `check-type-check-coverage` above still ran repo-wide and confirm 46/46 and 41/41 clean.

## Scope

Fix confined to `packages/core` (T3 — sibling agents hold `packages/plugin-form` #5034 and `packages/plugin-map` #5977; no file overlap). The sweep was **not** widened (T1): the repo-wide `grep` found this to be the only `SECURITY_FIX_SUMMARY` reference, and no other dangling `@see` or doc link was repaired here. `content/docs/releases/` untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_