### PR TITLE
test(plugin-map): point the reach test narration at where the 'Marker' placeholder actually lives

### DIFF
--- a/.changeset/plugin-map-reach-test-narration.md
+++ b/.changeset/plugin-map-reach-test-narration.md
@@ -1,0 +1,4 @@
+---
+---
+
+Comment-only correction in `packages/plugin-map/src/ObjectMap.listViewMapConfigReach.test.tsx`: the narration above the `titleField` arm attributed the `'Marker'` placeholder to `getMapConfig`, which never held it. No assertion, fixture or published behaviour changes.

--- a/packages/plugin-map/src/ObjectMap.listViewMapConfigReach.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.listViewMapConfigReach.test.tsx
@@ -134,10 +134,16 @@ describe('a view-level `map` block reaches getMapConfig through ListView (object
     await waitFor(() => expect(screen.getAllByTestId('map-marker').length).toBe(2));
 
     // The title is a real read, not a forwarded prop: `getMapConfig` resolves
-    // `titleField`, the marker transform reads `record[titleField]`, and the
-    // popup renders it. Before the forward landed this read `'Marker'` — the
-    // literal `getMapConfig` falls back to — which is the `undefined`/placeholder
-    // marker-title symptom the card was filed for.
+    // the declared `titleField`, the marker transform hands it to
+    // `getRecordDisplayName` as `options.titleField` — step 0 of that resolver,
+    // so a declared binding still wins outright — and the popup renders it.
+    // Before the forward landed the block never reached `getMapConfig` at all:
+    // the flat branch forged `titleField: 'name'` (dropped by objectui#5953)
+    // and these records carry no `name`, so this read `undefined` — the
+    // marker-title symptom the card was filed for. `'Marker'` is not a
+    // `getMapConfig` literal and never was: it is `getRecordDisplayName`'s
+    // `fallback` option in the marker transform, reached now only by an
+    // id-less record.
     fireEvent.click(screen.getAllByTestId('map-marker')[0]);
     await waitFor(() => expect(screen.queryByTestId('map-popup')).not.toBeNull());
     expect(screen.getByText('Install rooftop unit')).toBeTruthy();


### PR DESCRIPTION
Fixes #5977

Comment-only change to one test file. Head `4cb788f4e`.

## 1. Dispatch premise table

Every coordinate re-derived against `origin/main` @ `79ebf30d1` (the dispatch order and the claim comment were written against `c38162d7c`; `main` moved between them).

| # | assumption | verdict | measurement |
|---|---|---|---|
| M1 | narrating file is `packages/plugin-map/src/ObjectMap.listViewMapConfigReach.test.tsx`, directly under `src/`, not `src/__tests__/` | **held** | `ls packages/plugin-map/src/` — the file is a direct child; `plugin-map` has no `src/__tests__/` |
| M2 | narrating comment sits at roughly `:136-141`, not exactly `:138` | **held** | the comment block is `:136-140`; `:141` is the `fireEvent.click` it precedes |
| M3 | `getMapConfig` is defined at `ObjectMap.tsx:345` | **held** | `function getMapConfig(schema: MapConfigSource): ObjectMapConfig {` at `:345` |
| M4 | `fallback: 'Marker'` is at `ObjectMap.tsx:771`, outside `getMapConfig` | **held** | `:771`, inside the marker-building `useMemo` that begins at `:735` — `getMapConfig` ends at `:415` |

The claim comment's corrected framing — **misattributed, not deleted** — holds. The `'Marker'` literal is alive at `:771`; what the narration got wrong is whose literal it is.

## 2. What I established the two functions actually do

**`getMapConfig` (`ObjectMap.tsx:345-415`)** has three return paths, and *none* of them now forges a title binding:

1. a declared `map` block wins outright — `return { ...config, style: config.style || style }`, so `titleField` is exactly what the author wrote and nothing more;
2. the internal flat form carries `titleField: schema.titleField` with an in-code note reading `No || 'name' (objectui#5953)`;
3. the default branch sets coordinate keys and `descriptionField` only, with `Deliberately NO titleField (objectui#5953)`.

**The marker path (`ObjectMap.tsx:735-800`)** no longer does a bare property read. At `:769`:

```ts
const title = getRecordDisplayName(objectSchema, record, {
  titleField: mapConfig.titleField,
  fallback: 'Marker',
});
```

`'Marker'` is therefore an **option handed to the resolver**, not a `getMapConfig` literal. In `packages/core/src/utils/record-title.ts` the resolver checks `options.titleField` at step 0 (`valueAt(record, options?.titleField) ?? valueAt(record, objectDef?.titleField)`), so a declared binding still wins outright; `options.fallback` is only reached at the very floor — `Record #<id>` handles any record that has an id, so `'Marker'` now surfaces only for a truly id-less record.

### The historical half — measured, and it needed correcting too

The dispatch asked me to determine whether the history was still accurate. It was not, and this is exactly the merge the card body called out.

The forward is `e2e8e68f1` (*feat(plugin-list): read the spec's view-level `map` block on list views*). At its parent:

- read site (`ObjectMap.tsx:668` at `e2e8e68f1^`): `const title = mapConfig.titleField ? record[mapConfig.titleField] : 'Marker';` — so `'Marker'` was the **else-arm of the read site's ternary**, reachable only when *no* binding existed;
- `getMapConfig`'s flat branch (`:375`) carried `titleField: schema.titleField || 'name'`, and its default branch (`:395`) carried `titleField: 'name'`. **`'name'`, never `'Marker'`, is what `getMapConfig` fell back to.**

For *this arm* specifically: pre-forward `ListView`'s `case 'map'` read `schema.options?.map` only and always emitted `locationField: schema.options?.map?.locationField || 'location'`. This test declares `map` at the schema root, so the block was dropped, `locationField: 'location'` still arrived, `getMapConfig` took the **flat** branch, and `titleField` came out as the forged `'name'`. The fixture records are `{ id, title, blurb, location }` — no `name` key. So the pre-forward title was **`undefined`**, not `'Marker'`.

The old comment asserted the `'Marker'` symptom and the `undefined` symptom as one thing. They are two branches with two visibly different outcomes.

## 3. The narration, before and after

**Before** (`:136-140`):

```
// The title is a real read, not a forwarded prop: `getMapConfig` resolves
// `titleField`, the marker transform reads `record[titleField]`, and the
// popup renders it. Before the forward landed this read `'Marker'` — the
// literal `getMapConfig` falls back to — which is the `undefined`/placeholder
// marker-title symptom the card was filed for.
```

**After** (`:136-146`):

```
// The title is a real read, not a forwarded prop: `getMapConfig` resolves
// the declared `titleField`, the marker transform hands it to
// `getRecordDisplayName` as `options.titleField` — step 0 of that resolver,
// so a declared binding still wins outright — and the popup renders it.
// Before the forward landed the block never reached `getMapConfig` at all:
// the flat branch forged `titleField: 'name'` (dropped by objectui#5953)
// and these records carry no `name`, so this read `undefined` — the
// marker-title symptom the card was filed for. `'Marker'` is not a
// `getMapConfig` literal and never was: it is `getRecordDisplayName`'s
// `fallback` option in the marker transform, reached now only by an
// id-less record.
```

The reason the discriminating arm exists is kept — the arm still pins that the title is a real read of the declared binding rather than a forwarded prop, and the pre-forward symptom is still narrated. Only the pointer and the symptom's identity changed.

## 4. Verification — and what is structurally blind here

**The test suite cannot verify this change, and that is expected.** Comments do not execute: the 92 assertions in `packages/plugin-map` produce byte-identical results before and after, by construction. A green run is evidence the change is *inert*, not evidence the new prose is *true*. Type-check is blind for the same reason one level down — TypeScript strips comments, so the file parses identically either way; it only proves I did not break the comment syntax. Lint, control-byte and `vi.mock` scans read the changed bytes but judge form, never claims. Changeset presence judges declaration, not content.

**The actual verification is the code reading in §2** — `getMapConfig`'s three branches at `ObjectMap.tsx:345-415`, the resolver call at `:769-772`, `getRecordDisplayName`'s step ordering in `packages/core/src/utils/record-title.ts`, and `git show e2e8e68f1^` for the pre-forward read site, flat branch and `ListView` map case. Every sentence in the new comment traces to one of those.

### Gate table

Gate set derived from the job step lists under `.github/workflows/`. Exit codes captured before any pipe; verdict lines are each gate's own output.

| CI job (workflow) | command run locally | exit | the gate's own verdict line |
|---|---|---|---|
| Changeset Declaration (`changeset-presence.yml`) | `node scripts/check-changeset-presence.mjs` | 0 | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` |
| Changeset Bump Policy (`changeset-guard.yml`) | `node scripts/check-changeset-no-major.mjs` | 0 | ``✅ No changeset declares a `major` bump.`` |
| Control Byte Scan (`control-bytes.yml`) | `node scripts/check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 5225 tracked text file(s); skipped 85 binary).` |
| Inert vi.mock Specifier Check (`vi-mock-specifiers.yml`) | `node scripts/check-vi-mock-specifiers.mjs` | 0 | `✅ check-vi-mock-specifiers: OK (3748 tracked source file(s), 2060 test-named; 439 carry a mock; 684 relative specifier(s) resolved …)` |
| Shell Escape Residue (`shell-escape-residue.yml`) | `node scripts/check-shell-escape-residue.mjs` | 0 | `✅ check-shell-escape-residue: OK (4/4 root(s) resolved … 0 occurrence(s) outside a fence)` |
| Type Check (`ci.yml`) | `pnpm --filter @object-ui/plugin-map run type-check` | 0 | script echo ``> @object-ui/plugin-map@17.6.0 type-check`` → ``> tsc --noEmit && tsc -p tsconfig.test.json``, no diagnostics |
| Test (`ci.yml`) | `pnpm exec vitest run --maxWorkers=2 packages/plugin-map/` | 0 | `Test Files 16 passed (16)` · `Tests 92 passed (92)` |
| Lint (`lint.yml`) | `pnpm --filter @object-ui/plugin-map run lint` | 0 | `✖ 126 problems (0 errors, 126 warnings)` — all pre-existing; the three in this file are `no-explicit-any` at `:47/:50/:54`, far above the edit |

Supporting evidence, since "green" is cheap and the ways to fake it are not:

- **the type-check is not blind at the parse level**: `tsc -p tsconfig.test.json --listFiles` lists `ObjectMap.listViewMapConfigReach.test.tsx` (1 hit), so the edited file really is in that program;
- **the test file really ran**: `packages/plugin-map/src` contains exactly 16 test files and vitest reported `16 passed (16)`;
- **the gate union was re-run on the final commit** `4cb788f4e`, and `git status --porcelain` plus `git diff HEAD --stat` are both empty, so the heavy runs above measured exactly this commit's tree;
- **one NOT-MEASURED run, disclosed**: my first attempt was `pnpm --filter @object-ui/plugin-map exec vitest run`, which the repo's own guard refused (*vitest 调用被拒绝:从包目录跑 vitest 会静默跑错测试集, objectui#3378*). That exit 1 is a refused invocation, not a red gate; it is superseded by the repo-root form in the table, which is what CI runs.

**Declared narrowing**: I ran the package-scoped equivalents (`--filter @object-ui/plugin-map`) rather than the repo-wide `pnpm test` / `pnpm type-check` / `pnpm lint` that CI runs across every package. The diff is one comment block in one package plus one changeset; CI runs the full farm on this PR regardless.

## 5. The changeset, and a correction about `skip-changeset`

Triage suggested the `skip-changeset` label. **That label is a phantom in this repository** — it exists as a label object but nothing reads it. `scripts/__tests__/ci-cd-pipeline-doc.test.ts` pins this deliberately:

> `content/docs/guide/ci-cd-pipeline.md` must keep stating that nothing reads the `skip-changeset` label. The label object exists in this repository (auto-minted by being applied, objectui#4912) and agents are being told to use it, so a page that stops denying it leaves the label as the most authoritative-looking answer in reach.

Confirmed independently: neither `.github/workflows/changeset-presence.yml` nor `scripts/check-changeset-presence.mjs` mentions it. So I followed the gate's own verdict line instead and declared the change with an **empty-frontmatter changeset** (`.changeset/plugin-map-reach-test-narration.md`) — the route the gate names as "a complete answer". No label was applied or minted. No `major` anywhere; `content/docs/releases/` untouched.

## 6. Out-of-scope finding — reported, not fixed

Per the dispatch, the sweep was not widened. Of the other files narrating `getMapConfig`, `ListView.tsx`, `ListView.mapViewLevelConfig.test.tsx`, `ObjectMap.markerTitle.test.tsx` and `InterfaceListPage.mapConfig.test.tsx` are all clean — they either discuss precedence (objectui#5018) or already speak of `'name'` in the **past** tense. `CHANGELOG.md` was not touched.

One file does carry the same defect class, and it is more than prose — **`packages/app-shell/src/views/InterfaceListPage.tsx:230-241`**:

> its `getMapConfig` fills an absent `titleField` with the LITERAL `'name'`, and the marker title is then a plain `record[titleField]` read. So for any object whose display field is not literally `name`, every marker popup titles itself `undefined`.
>
> … it survives `ListView`'s whitelisted flatten and reaches `getMapConfig` ahead of that `'name'` literal. It is NOT the general fix — an `ObjectMap` that resolved titles through `getRecordDisplayName` like its siblings would not need a derived binding at all … Filed separately.

All three present-tense claims are false on `main` today, and the "filed separately" general fix **has landed** (objectui#5953, PR #5975). The prose is stale, but the live question underneath it is whether the derived title binding at that seam is now redundant — or worse, actively harmful: it lands as `options.titleField`, which the resolver evaluates at **step 0**, ahead of the object's own declared `nameField`. That is a behaviour question for triage, not a comment fix. Left entirely untouched for the PM to file.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_