### PR TITLE
fix(types): align TimelineSchema with the keys the timeline renderer reads

### DIFF
--- a/.changeset/6170-timeline-schema-declared-keys.md
+++ b/.changeset/6170-timeline-schema-declared-keys.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/plugin-timeline': minor
+'@object-ui/types': minor
+---
+
+`TimelineSchema` now declares the presentational keys the timeline renderer actually reads
+(objectui#6170, maintainer ruling 2026-08-25 — the same family rule adopted on
+objectui#6172: the exported type aligns to the measured authored + read set).
+
+Before this, `TimelineSchema` declared `events` (required), `orientation` and `position`,
+and nothing else. `TimelineRenderer` is annotated `schema: TimelineSchema` and reads nine
+keys off that node — `variant`, `items`, `dateFormat`, `onItemClick`, `minDate`, `maxDate`,
+`rowLabel`, `scale`, `timeScale` — and **none** of the three that were declared. The docs
+property table and the registration's own designer `inputs` had agreed with the renderer
+all along; only the exported type disagreed. It was invisible to `tsc` because `BaseSchema`
+carries `[key: string]: any`, so every undeclared key resolved as `any` and the annotation
+constrained nothing.
+
+The most visible casualty was the docs page's own TypeScript example, which did not
+compile: `Property 'events' is missing in type '{ type: "timeline"; variant: string; items:
+… }' but required in type 'TimelineSchema'`. The page taught an authoring form its own
+published type refused.
+
+**Declared now** (TS interface and the `@object-ui/types/zod` mirror together): `variant`,
+`items`, `dateFormat`, `scale`, `timeScale`, `rowLabel`, `minDate`, `maxDate`. `onItemClick`
+is deliberately left undeclared — it is a runtime slot `ObjectTimeline` installs, and this
+package keeps callback-shaped keys off the authored surface.
+
+**`scale` is the canonical axis key.** It is `@objectstack/spec`'s `ui/TimelineConfig.json`
+spelling and the one `resolveTimelineScale` reads first (`scale ?? timeScale`). The designer
+now offers it, with all six buckets: `hour` / `quarter` / `year` have rendered correctly
+since objectui#2942 but were offered by neither the designer (which listed three) nor the
+exported type (which listed none), so they were authorable and undiscoverable. `timeScale`
+stays as a deprecated alias so stored JSON keeps working; retiring it is routed separately.
+
+**`events` is now optional.** It was required, which is why the documented authoring form
+did not type-check. That widening is the only non-additive change here — strictly more
+programs compile and strictly more input parses than before. `events`, `orientation` and
+`position` remain declared and remain read by nothing; a timeline authored with `events`
+still renders an empty rail. Their removal is a breaking narrowing of a published type and
+is routed through ADR-0049 enforce-or-remove as its own change, not smuggled into this one.
+
+Accept-set note for consumers: keys that previously resolved as `any` are now typed, so a
+value the renderer never implemented — `variant: 'diagonal'`, `dateFormat: 'medieval'`,
+`scale: 'fortnight'` — is a type error and a Zod rejection where it used to pass silently.
+Nothing that renders today stops rendering. `BaseSchema`'s index signature is untouched, so
+an undeclared key is still accepted by both halves (objectui#5155 / objectui#6269 own that
+ceiling).

--- a/content/docs/plugins/plugin-timeline.mdx
+++ b/content/docs/plugins/plugin-timeline.mdx
@@ -58,7 +58,7 @@ const schema = {
 - **Customizable Markers**: Color-coded markers with icon support
 - **Date Formatting**: Multiple date format options
 - **Gantt Charts**: Project timeline visualization with task bars
-- **Time Scales**: Day, week, or month scales for Gantt view
+- **Time Scales**: Hour, day, week, month, quarter, or year scales for Gantt view
 - **Lightweight**: Pure CSS and React components
 
 ## Schema API
@@ -72,7 +72,8 @@ const schema = {
   items?: TimelineItem[],
   dateFormat?: 'short' | 'long' | 'iso',
   // Gantt-specific
-  timeScale?: 'day' | 'week' | 'month',
+  scale?: 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year',
+  timeScale?: 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year',  // deprecated alias of `scale`
   rowLabel?: string,
   minDate?: string,
   maxDate?: string,
@@ -115,11 +116,23 @@ const schema = {
 | `variant` | string | `'vertical'` | Timeline layout: vertical, horizontal, or gantt |
 | `items` | array | `[]` | Array of timeline items |
 | `dateFormat` | string | `'short'` | Date formatting: short, long, or iso |
-| `timeScale` | string | `'month'` | Gantt time scale: day, week, or month |
+| `scale` | string | `'month'` | Gantt axis bucket: hour, day, week, month, quarter, or year |
+| `timeScale` | string | — | **Deprecated** — the pre-spec spelling of `scale`, still read as a fallback |
 | `rowLabel` | string | `'Items'` | Label for Gantt rows |
 | `minDate` | string | auto | Override min date for Gantt (YYYY-MM-DD) |
 | `maxDate` | string | auto | Override max date for Gantt (YYYY-MM-DD) |
 | `className` | string | `''` | Additional Tailwind CSS classes |
+
+Every key above is declared on the exported `TimelineSchema`, so an editor
+completes them and a wrong value is a type error. `scale` is the canonical axis
+key — it is `@objectstack/spec`'s `ui/TimelineConfig.json` spelling and the one
+the renderer reads first (`scale ?? timeScale`).
+
+<Callout type="warn">
+`events`, `orientation` and `position` are also declared on `TimelineSchema`
+and are **read by nothing**. A timeline authored with `events` renders an empty
+rail — use `items`. They are deprecated and scheduled for removal.
+</Callout>
 
 ## Variants
 

--- a/packages/plugin-timeline/src/renderer.tsx
+++ b/packages/plugin-timeline/src/renderer.tsx
@@ -524,12 +524,32 @@ ComponentRegistry.register(
         label: 'Date Format',
         defaultValue: 'short',
       },
+      // The designer's axis key is `scale` — the spec's spelling
+      // (`ui/TimelineConfig.json`) and the one `resolveTimelineScale` prefers.
+      // It offers all six buckets: `hour` / `quarter` / `year` have rendered
+      // correctly since #2942 but were offered by neither the designer nor the
+      // exported type, so they were authorable and undiscoverable (objectui#6170).
+      {
+        name: 'scale',
+        type: 'enum',
+        enum: [...TIMELINE_SCALES],
+        label: 'Time Scale (Gantt only)',
+        defaultValue: 'month',
+      },
+      // Kept so a stored `timeScale` still round-trips through the designer.
+      // Deprecated in favour of `scale`; retiring the alias is routed separately
+      // (objectui#6170 maintainer ruling 2026-08-25). `ComponentInput` has no
+      // `deprecated` slot and no index signature, so the notice lives in
+      // `description` — this package's stated ceiling for anything the coarse
+      // `type` cannot express.
       {
         name: 'timeScale',
         type: 'enum',
-        enum: ['day', 'week', 'month'],
+        enum: [...TIMELINE_SCALES],
         label: 'Time Scale (Gantt only)',
-        defaultValue: 'month',
+        description:
+          'DEPRECATED — use `scale`, which @objectstack/spec owns and this renderer reads first. Kept so stored JSON keeps working.',
+        advanced: true,
       },
       {
         name: 'rowLabel',

--- a/packages/types/src/__tests__/timeline-declared-keys.test.ts
+++ b/packages/types/src/__tests__/timeline-declared-keys.test.ts
@@ -1,0 +1,279 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Declaration pin — the eight presentational keys `TimelineRenderer` reads that
+ * `TimelineSchema` did not declare (objectui#6170).
+ *
+ * ## What was wrong
+ *
+ * `TimelineSchema` declared `events` (REQUIRED), `orientation` and `position`,
+ * and nothing else. `TimelineRenderer`
+ * (`plugin-timeline/src/renderer.tsx:250`) is annotated `schema:
+ * TimelineSchema` and reads nine keys off it — `variant`, `items`,
+ * `dateFormat`, `onItemClick`, `minDate`, `maxDate`, `rowLabel`, `scale`,
+ * `timeScale` — and NONE of the three that were declared. So the exported type
+ * matched neither what authors write, nor what the designer offers (the
+ * registration's own `inputs`), nor what the renderer reads; those three agreed
+ * with each other all along.
+ *
+ * The divergence was invisible to `tsc` because `BaseSchema` carries
+ * `[key: string]: any`, so every undeclared key resolved as `any` and the
+ * annotation constrained nothing. Its most visible casualty was the docs page's
+ * own TypeScript example, which did not compile — `events` was required and
+ * nothing on the page ever writes it. That example is pinned below.
+ *
+ * Eight of the nine are declared. `onItemClick` is deliberately NOT: it is a
+ * runtime slot `ObjectTimeline` installs when it composes the schema it hands
+ * to `TimelineRenderer`, and this package keeps callback-shaped keys off the
+ * authored surface (`RuntimeOnlyDeclared` in `zod-mirror-parity.test.ts`).
+ *
+ * ## What the pin has teeth against, and what it does not
+ *
+ * Same ceiling as objectui#5903's gantt pin, and stated here rather than left
+ * to be assumed. `BaseSchema` is `.passthrough()` on the zod side and carries
+ * an index signature on the TS side (objectui#5155 / objectui#6269 own that
+ * ceiling; this card does not touch it), so:
+ *
+ *   - an UNDECLARED key is still accepted by both halves. Declaring these eight
+ *     did NOT buy rejection of a misspelling;
+ *   - a DECLARED key IS validated. `variant: 'diagonal'` type-checked and
+ *     parsed green before this card and is refused now — that is the accept-set
+ *     narrowing landed here;
+ *   - on the TS side a read site can never be the detector, because the index
+ *     signature types `schema.variant` as `any` either way. So the compile-time
+ *     pin is the `@ts-expect-error` block at the bottom: remove a declaration
+ *     and its member resolves to `any`, the wrong-typed assignment starts
+ *     succeeding, and the now-unused directive fails the build (TS2578) NAMING
+ *     the key. `tsconfig.test.json` compiles this file, so that is real
+ *     enforcement and not decoration (objectui#3009).
+ *
+ * ## The three keys that are still declared and still dead
+ *
+ * `events` / `orientation` / `position` have zero read points. Their RETIREMENT
+ * is routed, not done — objectui#6170's maintainer ruling (2026-08-25) sends
+ * them down the ADR-0049 enforce-or-remove route, which is a breaking removal
+ * from a published type. `events` went required → OPTIONAL here, which is a
+ * strict widening and the smallest change that lets the documented authoring
+ * form compile. They are pinned below as STILL DECLARED so the removal, when it
+ * comes, is a deliberate edit against a red test rather than a silent drift.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TimelineConfigSchema } from '@objectstack/spec/ui';
+import { TimelineSchema } from '../zod/data-display.zod.js';
+import type { TimelineSchema as TimelineSchemaTS, TimelineScale } from '../data-display.js';
+
+const MINIMAL = { type: 'timeline' } as const;
+
+/** Unwrap ZodOptional/ZodDefault/description wrappers down to the inner enum schema. */
+function unwrap(schema: any): any {
+  let cur = schema;
+  while (cur?._def?.innerType) cur = cur._def.innerType;
+  return cur;
+}
+
+/** The eight keys this card declared, each with a value its declared type refuses. */
+const DECLARED: ReadonlyArray<readonly [string, unknown]> = [
+  ['variant', 'diagonal'],
+  ['items', 'not-an-array'],
+  ['dateFormat', 'medieval'],
+  ['scale', 'fortnight'],
+  ['timeScale', 'fortnight'],
+  ['rowLabel', 5],
+  ['minDate', 20240101],
+  ['maxDate', 20241231],
+];
+
+describe('TimelineSchema — the eight presentational keys are declared (objectui#6170)', () => {
+  it('the mirror declares every one of them', () => {
+    const shape = Object.keys(TimelineSchema.shape);
+    for (const [key] of DECLARED) expect(shape, `mirror is missing ${key}`).toContain(key);
+  });
+
+  it('declares them all OPTIONAL — a bare `{ type: "timeline" }` still parses', () => {
+    // Requiredness is the half the zod-mirror-parity ratchet compares against
+    // `../data-display.ts`, where all eight are `?:`. A mirror that required one
+    // would reject every timeline already published — including the three
+    // fixtures in `examples/schema-catalog/src/schemas/plugin-timeline/`.
+    const result = TimelineSchema.safeParse(MINIMAL);
+    expect(result.success ? null : result.error.issues).toBe(null);
+  });
+
+  it('materialises NO defaults — an omitted key stays absent after parse', () => {
+    // `variant` and `dateFormat` default IN THE RENDERER, by destructuring
+    // (`variant = 'vertical'`). A `.default()` here would arrive downstream as
+    // an explicit author choice; the two spellings are not interchangeable.
+    const result = TimelineSchema.safeParse(MINIMAL);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    for (const [key] of DECLARED) expect(key in result.data, `${key} must stay absent`).toBe(false);
+  });
+
+  it('refuses a wrong-typed value on each declared key (declared-key validation under passthrough)', () => {
+    for (const [key, bad] of DECLARED) {
+      const result = TimelineSchema.safeParse({ ...MINIMAL, [key]: bad });
+      expect(result.success, `${key} accepted ${JSON.stringify(bad)}`).toBe(false);
+      if (result.success) continue;
+      const issue = result.error.issues.find((i) => i.path[0] === key);
+      expect(issue, `${key} failed, but not on the ${key} path`).toBeTruthy();
+    }
+  });
+
+  it('accepts a well-typed value on each declared key', () => {
+    // Counter-probe for the assertion above: it must be the VALUE being refused,
+    // not the key. A pin that only ever sees red proves nothing.
+    const good = {
+      ...MINIMAL,
+      variant: 'gantt',
+      items: [{ label: 'Backend', items: [{ title: 'API', startDate: '2024-01-01', endDate: '2024-01-31' }] }],
+      dateFormat: 'iso',
+      scale: 'quarter',
+      timeScale: 'month',
+      rowLabel: 'Projects',
+      minDate: '2024-01-01',
+      maxDate: '2024-12-31',
+    };
+    const result = TimelineSchema.safeParse(good);
+    expect(result.success ? null : result.error.issues).toBe(null);
+  });
+
+  it('does NOT reject an undeclared key — objectui#5155’s ceiling, measured not assumed', () => {
+    // Declaring the eight bought validation of DECLARED keys, not rejection of
+    // undeclared ones: `BaseSchema` is `.passthrough()`. Anyone reading this
+    // card as "misspellings now fail" is reading it wrong, and this pin says so
+    // in the one place that cannot rot.
+    const misspelled = TimelineSchema.safeParse({ ...MINIMAL, varient: 'gantt', timescale: 'month' });
+    expect(misspelled.success).toBe(true);
+  });
+});
+
+describe('TimelineSchema — `scale` is canonical and shares the spec vocabulary', () => {
+  // The renderer resolves `scale ?? timeScale` and accepts six values on either
+  // (`resolveTimelineScale`, pinned against the spec by
+  // `plugin-timeline/src/__tests__/timeline-scale-spec-parity.test.ts`). This is
+  // the third leg of that agreement: the exported TYPE offers the same six.
+  const specScales: string[] = unwrap(TimelineConfigSchema.shape.scale).options;
+
+  it('reads a non-empty scale enum from the spec', () => {
+    expect(specScales, 'could not read TimelineConfigSchema.shape.scale options').not.toEqual([]);
+  });
+
+  it('`scale` and the deprecated `timeScale` alias accept exactly the spec vocabulary', () => {
+    for (const key of ['scale', 'timeScale'] as const) {
+      for (const value of specScales) {
+        const result = TimelineSchema.safeParse({ ...MINIMAL, [key]: value });
+        expect(result.success, `${key} refused spec scale '${value}'`).toBe(true);
+      }
+    }
+  });
+
+  it('the registry `inputs` three-value timeScale enum is NOT the contract', () => {
+    // Before this card the designer offered `timeScale: day | week | month` and
+    // the type offered neither key. `hour` / `quarter` / `year` were authorable,
+    // rendered correctly, and were undiscoverable from both surfaces.
+    for (const value of ['hour', 'quarter', 'year']) {
+      expect(TimelineSchema.safeParse({ ...MINIMAL, scale: value }).success, value).toBe(true);
+    }
+  });
+});
+
+describe('TimelineSchema — the three unread keys are still declared (ADR-0049 route pending)', () => {
+  it('`events` / `orientation` / `position` remain in the mirror', () => {
+    const shape = Object.keys(TimelineSchema.shape);
+    for (const key of ['events', 'orientation', 'position']) {
+      expect(shape, `${key} left the mirror — see the ADR-0049 note in data-display.ts`).toContain(key);
+    }
+  });
+
+  it('`events` is OPTIONAL — this is the widening objectui#6170 landed', () => {
+    // It was required. That is why the docs page's own TypeScript example did
+    // not compile, and it is the single non-additive change in this card.
+    expect(TimelineSchema.safeParse({ type: 'timeline', items: [] }).success).toBe(true);
+  });
+
+  it('still validates them when authored, so retirement is a visible edit', () => {
+    expect(TimelineSchema.safeParse({ ...MINIMAL, orientation: 'diagonal' }).success).toBe(false);
+    expect(TimelineSchema.safeParse({ ...MINIMAL, position: 'centre' }).success).toBe(false);
+    expect(TimelineSchema.safeParse({ ...MINIMAL, events: 'nope' }).success).toBe(false);
+  });
+});
+
+describe('TimelineSchema (TS) — compile-time pin on the same keys', () => {
+  it('accepts the docs page’s own TypeScript example', () => {
+    // `content/docs/plugins/plugin-timeline.mdx` — the "TypeScript Support"
+    // block, verbatim. Before objectui#6170 this exact object was
+    // `TS2741: Property 'events' is missing … but required in type
+    // 'TimelineSchema'`. The page taught an authoring form its own published
+    // type refused.
+    const timelineSchema: TimelineSchemaTS = {
+      type: 'timeline',
+      variant: 'vertical',
+      items: [
+        { time: '2024-01-15', title: 'Event', description: 'Description', variant: 'success' },
+      ],
+    };
+    expect(timelineSchema.items).toHaveLength(1);
+  });
+
+  it('refuses a wrong-typed value on every declared key', () => {
+    // Each directive below fails the build (TS2578, "unused '@ts-expect-error'")
+    // the moment its key stops being declared, because the member then resolves
+    // to `any` through `BaseSchema`'s index signature and the assignment starts
+    // succeeding. That failure is the signal this card exists to create.
+
+    // @ts-expect-error — `variant` is declared `'vertical' | 'horizontal' | 'gantt' | undefined`.
+    const variant: TimelineSchemaTS['variant'] = 'diagonal';
+    // @ts-expect-error — `dateFormat` is declared `'short' | 'long' | 'iso' | undefined`.
+    const dateFormat: TimelineSchemaTS['dateFormat'] = 'medieval';
+    // @ts-expect-error — `scale` is declared `TimelineScale | undefined`.
+    const scale: TimelineSchemaTS['scale'] = 'fortnight';
+    // @ts-expect-error — `timeScale` is the deprecated alias, same six values.
+    const timeScale: TimelineSchemaTS['timeScale'] = 'fortnight';
+    // @ts-expect-error — `rowLabel` is declared `string | undefined`.
+    const rowLabel: TimelineSchemaTS['rowLabel'] = 5;
+    // @ts-expect-error — `minDate` is declared `string | undefined` (schemas are JSON).
+    const minDate: TimelineSchemaTS['minDate'] = 20240101;
+    // @ts-expect-error — `maxDate` is declared `string | undefined`.
+    const maxDate: TimelineSchemaTS['maxDate'] = 20241231;
+    // @ts-expect-error — `orientation` is declared `'vertical' | 'horizontal' | undefined`.
+    const orientation: TimelineSchemaTS['orientation'] = 'diagonal';
+    // @ts-expect-error — `position` is declared `'left' | 'right' | 'alternate' | undefined`.
+    const position: TimelineSchemaTS['position'] = 'centre';
+
+    expect([
+      variant, dateFormat, scale, timeScale, rowLabel, minDate, maxDate, orientation, position,
+    ]).toHaveLength(9);
+  });
+
+  it('accepts the well-typed value on every declared key', () => {
+    // Counter-probe for the directives above: without this, a declaration
+    // narrowed to `never` would satisfy all nine of them.
+    const ok: TimelineSchemaTS = {
+      type: 'timeline',
+      variant: 'gantt',
+      items: [{ label: 'Backend', items: [{ title: 'API', startDate: '2024-01-01', endDate: '2024-01-31' }] }],
+      dateFormat: 'iso',
+      scale: 'quarter',
+      timeScale: 'month',
+      rowLabel: 'Projects',
+      minDate: '2024-01-01',
+      maxDate: '2024-12-31',
+      orientation: 'vertical',
+      position: 'left',
+    };
+    expect(ok.rowLabel).toBe('Projects');
+  });
+
+  it('`TimelineScale` is the one axis vocabulary, not a second spelling', () => {
+    const every: TimelineScale[] = ['hour', 'day', 'week', 'month', 'quarter', 'year'];
+    // @ts-expect-error — the type is closed; a seventh bucket is not authorable.
+    const extra: TimelineScale = 'fortnight';
+    expect([...every, extra]).toHaveLength(7);
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -1199,21 +1199,151 @@ export interface TimelineEvent {
 }
 
 /**
- * Timeline component
+ * The axis-bucket vocabulary for the `gantt` variant.
+ *
+ * One spelling, one source: these are exactly the six values of
+ * `@objectstack/spec` `ui/TimelineConfig.json#scale`, and exactly the six
+ * `TIMELINE_SCALES` that `packages/plugin-timeline/src/renderer.tsx`
+ * (`resolveTimelineScale`) accepts. Declared here so the two agree by
+ * construction rather than by coincidence.
+ */
+export type TimelineScale = 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
+
+/**
+ * Timeline component (`type: 'timeline'`).
+ *
+ * ## The members below are the set `TimelineRenderer` actually reads
+ *
+ * objectui#6170, maintainer ruling 2026-08-25 (「同意」), the same family rule
+ * adopted on objectui#6172: **the exported type aligns to the measured
+ * authored + read set.** Before that ruling this interface declared `events` /
+ * `orientation` / `position` and nothing else, and the divergence was
+ * invisible to `tsc` because {@link BaseSchema} carries `[key: string]: any` —
+ * every key the renderer reads resolved as `any`, so `schema: TimelineSchema`
+ * constrained nothing. (The index signature itself is objectui#5155 /
+ * objectui#6269, deliberately not touched here.)
+ *
+ * Measured on `origin/main` @ `79ebf30d1`: `TimelineRenderer`
+ * (`plugin-timeline/src/renderer.tsx:250`) reads NINE keys off this node —
+ * `variant`, `items`, `dateFormat`, `onItemClick`, `minDate`, `maxDate`,
+ * `rowLabel`, `scale`, `timeScale` — and NONE of `events` / `orientation` /
+ * `position`. EIGHT of those nine are declared below; `onItemClick` is not, on
+ * purpose — it is a runtime slot `ObjectTimeline` installs when it composes
+ * this schema, not authorable metadata, and this package's convention keeps
+ * callback-shaped keys off the authored surface (see `RuntimeOnlyDeclared` in
+ * `__tests__/zod-mirror-parity.test.ts`). The registration's own `inputs` metadata and
+ * `content/docs/plugins/plugin-timeline.mdx`'s property table agreed with the
+ * renderer all along; only this type disagreed — including with the docs
+ * page's own TypeScript example, which did not compile, because `events` was
+ * required and nothing writes it.
+ *
+ * ## Two timelines, and this is the presentational one
+ *
+ * `TimelineSchema` describes HOW TO DRAW a rail from items already in hand.
+ * The OBJECT-BOUND config — WHICH RECORD FIELDS to project — is
+ * `@objectstack/spec`'s `TimelineConfig`, surfaced here as
+ * {@link ListViewTimelineConfig} (`startDateField` / `titleField` / …) and
+ * consumed by `ObjectTimeline`, which resolves those field names against
+ * fetched records and composes the presentational shape below before handing
+ * it to `TimelineRenderer`. The two vocabularies are disjoint by design; only
+ * `scale` is common to both, deliberately spelled the same in each.
  */
 export interface TimelineSchema extends BaseSchema {
   type: 'timeline';
   /**
-   * Timeline events
+   * Layout variant. The renderer implements exactly these three and returns
+   * `null` for anything else.
+   * @default 'vertical'
    */
-  events: TimelineEvent[];
+  variant?: 'vertical' | 'horizontal' | 'gantt';
   /**
-   * Timeline orientation
+   * The rows to draw.
+   *
+   * TWO element shapes, discriminated by `variant`, both read dynamically by
+   * the renderer (`items.map((item: any) => …)`), so the element type is left
+   * open rather than narrowed to either one:
+   *
+   * - `vertical` / `horizontal` — a feed item:
+   *   `{ time, title, description?, variant?, icon?, color?, content?, className?, meta?, group? }`
+   * - `gantt` — a row:
+   *   `{ label, items: [{ title, startDate, endDate, variant? }] }`
+   *
+   * `content/docs/plugins/plugin-timeline.mdx` carries both in full.
+   */
+  items?: any[];
+  /**
+   * How item dates are rendered.
+   * @default 'short'
+   */
+  dateFormat?: 'short' | 'long' | 'iso';
+  /**
+   * Gantt axis bucket size. **Canonical spelling** — it is `@objectstack/spec`
+   * `ui/TimelineConfig.json`'s axis key AND the renderer's preferred read
+   * (`resolveTimelineScale` resolves `scale ?? timeScale`).
+   * @default 'month'
+   */
+  scale?: TimelineScale;
+  /**
+   * Gantt axis bucket size — this renderer's pre-spec dialect, still read as a
+   * fallback so stored JSON keeps working.
+   *
+   * @deprecated Use {@link TimelineSchema.scale}, which `@objectstack/spec`
+   * owns and this renderer prefers. Retiring the alias is routed separately
+   * (objectui#6170 maintainer ruling 2026-08-25: "`timeScale` goes the
+   * alias-retirement route, not a silent second spelling").
+   */
+  timeScale?: TimelineScale;
+  /**
+   * Header label above the Gantt row-label gutter.
+   * @default 'Items'
+   */
+  rowLabel?: string;
+  /**
+   * Override the auto-calculated Gantt axis start (`YYYY-MM-DD`).
+   */
+  minDate?: string;
+  /**
+   * Override the auto-calculated Gantt axis end (`YYYY-MM-DD`).
+   */
+  maxDate?: string;
+  /**
+   * Timeline events.
+   *
+   * ⚠️ ZERO read points — `packages/plugin-timeline` never reads this key, so a
+   * timeline authored with `events` renders an EMPTY rail. It was `required`
+   * until objectui#6170, which is why the docs page's own TypeScript example
+   * did not compile; it is OPTIONAL now so that documented authoring form
+   * type-checks, and that widening is the whole of the change made here.
+   *
+   * Its RETIREMENT is routed, not done: objectui#6170's maintainer ruling
+   * (2026-08-25) sends this key, {@link TimelineSchema.orientation} and
+   * {@link TimelineSchema.position} down the ADR-0049 enforce-or-remove route.
+   * That is a breaking removal from a published type and therefore its own
+   * change; the house form for it is the `?: never` tombstone convention on
+   * {@link StaticTableColumn} above (objectui#5474).
+   *
+   * @deprecated Never read by any renderer. Use `items` — see
+   * `content/docs/plugins/plugin-timeline.mdx`.
+   */
+  events?: TimelineEvent[];
+  /**
+   * Timeline orientation.
+   *
+   * ⚠️ ZERO read points — the renderer discriminates on
+   * {@link TimelineSchema.variant}, not on this key. Retirement routed via
+   * ADR-0049; see {@link TimelineSchema.events}.
+   *
+   * @deprecated Never read by any renderer. Use `variant`.
    * @default 'vertical'
    */
   orientation?: 'vertical' | 'horizontal';
   /**
-   * Timeline position (for vertical)
+   * Timeline position (for vertical).
+   *
+   * ⚠️ ZERO read points. Retirement routed via ADR-0049; see
+   * {@link TimelineSchema.events}.
+   *
+   * @deprecated Never read by any renderer.
    * @default 'left'
    */
   position?: 'left' | 'right' | 'alternate';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -200,6 +200,7 @@ export type {
   PivotTableSchema,
   DrillDownConfig,
   TimelineEvent,
+  TimelineScale,
   TimelineSchema,
   KbdSchema,
   HtmlSchema,

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -299,13 +299,44 @@ export const TimelineEventSchema = z.object({
 });
 
 /**
+ * Timeline scale — the six values of `@objectstack/spec`
+ * `ui/TimelineConfig.json#scale`, which are also the six `TIMELINE_SCALES` the
+ * gantt renderer accepts. Mirrors `TimelineScale` in `../data-display.ts`.
+ *
+ * Deliberately NOT exported: every exported const in this directory has to be
+ * registered in `zod-mirror-parity.test.ts`'s `MIRRORS` or `EXCLUSIONS`, and a
+ * shared inline enum is not a mirror of any declaration — it is spelling reuse
+ * between the two keys below.
+ */
+const TimelineScaleSchema = z.enum(['hour', 'day', 'week', 'month', 'quarter', 'year']);
+
+/**
  * Timeline Schema - Timeline component
+ *
+ * Mirrors `TimelineSchema` in `../data-display.ts`, which objectui#6170 aligned
+ * to the key set `TimelineRenderer` actually reads (maintainer ruling
+ * 2026-08-25). `zod-mirror-parity.test.ts` pins the two together: a key
+ * declared there and absent here is `UnmirroredDeclaredKeys` and reddens the
+ * pair, so the nine presentational keys below are not optional to carry.
+ *
+ * `events` / `orientation` / `position` stay declared and stay mirrored: they
+ * have zero read points, but removing them is a breaking narrowing routed
+ * through ADR-0049 rather than done here. `events` follows the declaration from
+ * required to OPTIONAL — strictly more input parses than before.
  */
 export const TimelineSchema = BaseSchema.extend({
   type: z.literal('timeline'),
-  events: z.array(TimelineEventSchema).describe('Timeline events'),
-  orientation: z.enum(['vertical', 'horizontal']).optional().describe('Timeline orientation'),
-  position: z.enum(['left', 'right', 'alternate']).optional().describe('Event position'),
+  variant: z.enum(['vertical', 'horizontal', 'gantt']).optional().describe('Layout variant'),
+  items: z.array(z.any()).optional().describe('Rows to draw — feed items, or gantt rows when variant is gantt'),
+  dateFormat: z.enum(['short', 'long', 'iso']).optional().describe('How item dates are rendered'),
+  scale: TimelineScaleSchema.optional().describe('Gantt axis bucket size (canonical spelling — the spec key)'),
+  timeScale: TimelineScaleSchema.optional().describe('DEPRECATED pre-spec alias for scale; still read as a fallback'),
+  rowLabel: z.string().optional().describe('Header label above the gantt row-label gutter'),
+  minDate: z.string().optional().describe('Override the auto-calculated gantt axis start (YYYY-MM-DD)'),
+  maxDate: z.string().optional().describe('Override the auto-calculated gantt axis end (YYYY-MM-DD)'),
+  events: z.array(TimelineEventSchema).optional().describe('DEPRECATED — zero read points; renders an empty rail. Use items'),
+  orientation: z.enum(['vertical', 'horizontal']).optional().describe('DEPRECATED — zero read points. Use variant'),
+  position: z.enum(['left', 'right', 'alternate']).optional().describe('DEPRECATED — zero read points'),
 });
 
 /**


### PR DESCRIPTION
Part of #6170.

Gates measured at **`e3c074869`**, which is this branch's head and the tree every number below was read from.

---

## ⚠️ Read first — a dispatch/ruling conflict, flagged not resolved

My dispatch carried a **STOP-AND-REPORT** clause: *if the fix would widen or narrow the accept set of a published type, stop and report the fork instead of picking a side* — naming the deletion of `events`/`orientation`/`position` and the absorption of object-bound keys as the two examples.

The card already carries a **maintainer ruling (2026-08-25, verbatim 「同意」)** that decides exactly that fork: *"`TimelineSchema` aligns to what authors write and `TimelineRenderer` reads"*, `scale` canonical, `events`/`orientation`/`position` to the ADR-0049 route, docs re-verified, `Clause-②: yes — published type surface changes, contract-review tier at dispatch`. The dispatch's assumption table and hypothesis never reference that ruling, which suggests it was composed from the pre-ruling `needs-user-decision` framing.

I did not pick a side on the part the ruling did not settle. This PR lands **only the non-breaking subset**:

* every change is either an added declaration or a strict widening;
* **nothing is removed**, and nothing that compiles or renders today stops;
* the **breaking half — the ADR-0049 tombstoning of `events`/`orientation`/`position` — is NOT here.** It is written up below as a fork for the maintainer.

That is why this is `Part of #6170` and not a closing reference: merging it leaves the ADR-0049 removal and the `timeScale` alias retirement live on the card.

---

## The census — mine, exact, both directions

Measured on `origin/main` @ `79ebf30d1`, over `packages/plugin-timeline/src` excluding test files.

**Declared** by `TimelineSchema` beyond `type` (`packages/types/src/data-display.ts:1204`): `events` (**required**), `orientation`, `position` — **3**.

**Read**, split by the component that reads it:

| component | keys read off the schema node | n |
|---|---|---|
| `TimelineRenderer` (`renderer.tsx:250`) — presentational | destructured `variant`, `items`, `dateFormat`, `onItemClick`; dotted `minDate`, `maxDate`, `rowLabel`, `scale`, `timeScale` | **9** |
| `ObjectTimeline` (`ObjectTimeline.tsx`) — object-bound | `objectName`, `timeline`, `filter`, `sort`, `limit`, `mapping`, `titleField`, `dateField`, `startDateField`, `endDateField`, `descriptionField`, `groupByField`, `colorField`, `scale`, `bind`, `items`, `className` | 17 |
| `index.tsx` (registration + dataSource mapping) | `objectName`, `limit` | 2 |

Distinct dotted `schema.*` reads across the package: **21**. Adding the three destructured-only keys (`variant`, `dateFormat`, `onItemClick`) gives **24 distinct read keys**.

**The difference, both ways:**

* **Declared and never read — 3:** `events`, `orientation`, `position`. Zero read points anywhere in the repository, not just in `plugin-timeline`. (`TimelineEvent`, the element type `events` names, is dead with it — its `date` key is not even the `time` key the renderer reads.)
* **Read and never declared — 23 of the 24.** Only `className` was declared, and by `BaseSchema`. Against `TimelineRenderer` alone, **9** undeclared reads.

> ⚠️ **The card's "seven" does not survive.** The card counted `variant`, `items`, `dateFormat`, `timeScale`, `minDate`, `maxDate`, `rowLabel`. Today the renderer also reads `scale` (added by objectui#2942, and preferred over `timeScale`) and `onItemClick`. The measured figure is **9**, not 7. The card's "declares three it never reads" **is exact** and survives.

---

## M1–M5 verdicts

| # | assumption | verdict |
|---|---|---|
| **M1** | `TimelineSchema` (`data-display.ts:1204`) declares, beyond `type`, exactly `events`/`orientation`/`position` | ✅ **TRUE** — line number exact; `events` required |
| **M2** | ~21 distinct `schema.*` reads, none of them those three | ✅ **TRUE** — exactly 21 dotted reads; none is any of the three |
| **M3** | `renderer.tsx:250` types `schema` as `TimelineSchema` | ✅ **TRUE** — verbatim, line 250 |
| **M4** | `ObjectTimeline.tsx:52` widens it by hand | ✅ **TRUE** — line 52, 14 added keys |
| **M5** | `ListViewTimelineConfig` = spec `TimelineConfig` `& { dateField?; [key: string]: any }` | ✅ **TRUE** — `objectql.ts:116`; untouched here (objectui#5155 / objectui#6269) |

All five hold.

---

## The hypothesis: **diagnosis confirmed, proposed remedy refuted**

> *"There may be two different timelines… the renderer may be typed against the wrong one, and the honest fix is re-pointing the type at the shape the code already consumes — mechanical, no published accept set moves."*

**Two timelines: CONFIRMED.**

* **presentational** — how to draw a rail from items in hand. Read by `TimelineRenderer`.
* **object-bound** — which record fields to project. `@objectstack/spec`'s `TimelineConfig` via `ListViewTimelineConfig`, read by `ObjectTimeline`.

The composition seam is real and correct: `ObjectTimeline` resolves field names against fetched records, builds `effectiveSchema`, and calls `<TimelineRenderer schema={effectiveSchema} />` (`ObjectTimeline.tsx:443`).

**"The renderer is typed against the wrong one": REFUTED.** `renderer.tsx` reads **only** presentational keys and **not one** object-bound key. `TimelineSchema` is meant to be the presentational type — it is the *right* one of the two. Its problem is that its member list is a **third, unimplemented vocabulary** (`events`/`orientation`/`position` — an MUI/Ant-style Timeline API that was never built) which is neither presentational-as-implemented nor object-bound.

**Consequence: the "mechanical re-point" is not available.** Re-pointing requires an existing type that declares `variant`/`items`/`dateFormat`/`rowLabel`/`minDate`/`maxDate`. **No such type exists** — I searched every `TimelineSchema` reference repo-wide and every spec `ui` export. So the fix necessarily *changes* `TimelineSchema`'s member list, which is why the STOP clause was reached and why the maintainer ruling is load-bearing.

**Supporting evidence gathered:**

* **Does anything author the presentational `events` shape?** One artifact: `packages/types/examples/data-display-examples.json` authors `{ type: 'timeline', events, orientation, position }`. It is imported by nothing, type-checked by nothing (`tsconfig.examples.json` includes only `examples/**/*.ts`), and would render an **empty rail**. Left untouched on purpose — see findings.
* **Which registration mounts what?** ⭐ `'timeline'` is registered **twice**: `renderer.tsx:498` → `TimelineRenderer` (namespace `plugin-timeline`), and `index.tsx:366` → `ObjectTimelineRenderer` (namespace `view`). `index.tsx:300` (`export * from './renderer'`) evaluates first, so the later call wins the bare-name fallback and **`type: 'timeline'` resolves to `ObjectTimelineRenderer`**, which delegates inward to `TimelineRenderer`. Filed as a finding — the collision guard in `Registry.register` warns on exactly this.
* **Do the docs describe one timeline or two?** One. `content/docs/plugins/plugin-timeline.mdx` documents only the presentational vocabulary, and agrees with the renderer and the registry `inputs` on all 8 rows.

---

## Producer-boundary check (binding per the ruling): **spec does NOT need to move**

`@objectstack/spec@17.2.0` `ui/TimelineConfig.json` declares `startDateField`, `endDateField`, `titleField`, `groupByField`, `colorField`, `scale`, with `additionalProperties: false` and `required: [startDateField, titleField, scale]`.

Every key is a **field name** — object-bound. The presentational vocabulary is entirely absent from it and, under `additionalProperties: false`, could never live there. The two shapes are disjoint by construction.

The **only** overlap is `scale`, and it already agrees: the spec's six values are byte-identical to the renderer's `TIMELINE_SCALES`, pinned by `plugin-timeline/src/__tests__/timeline-scale-spec-parity.test.ts`. Declaring `scale` on `TimelineSchema` with those same six adopts the spec's spelling rather than competing with it.

⇒ **No spec change needed; no fork to the `domain:spec` lane.** `packages/spec` was not touched.

---

## T1 — the mistyped-before / correct-after demonstration

A types-only change proves nothing by compiling, so both directions were measured with the same probe file against the same `tsc` invocation.

**Probe A — the docs page's own TypeScript example** (`plugin-timeline.mdx`, "TypeScript Support", verbatim):

```
BEFORE: error TS2741: Property 'events' is missing in type
        '{ type: "timeline"; variant: string; items: {...}[]; }'
        but required in type 'TimelineSchema'.
AFTER:  compiles.
```

The published page taught an authoring form its own published type refused.

**Probe B — values the renderer never implemented** (`variant: 'diagonal'`, `dateFormat: 'medieval'`, `scale: 'fortnight'`):

```
BEFORE: no error at all — all three absorbed by BaseSchema's index signature.
AFTER:  error TS2322: Type '"diagonal"' is not assignable to type '"horizontal" | "vertical" | "gantt" | undefined'.
        error TS2322: Type '"medieval"' is not assignable to type '"short" | "long" | "iso" | undefined'.
        error TS2322: Type '"fortnight"' is not assignable to type 'TimelineScale | undefined'.
```

Both probes are now permanent in `packages/types/src/__tests__/timeline-declared-keys.test.ts`, which `tsconfig.test.json` compiles — verified by `tsc --listFiles | grep -c timeline-declared-keys.test.ts` → **1**, so the `@ts-expect-error` pins are real enforcement and not decoration.

**Ablation — the pin has teeth.** Predicted direction: removing one declaration reddens `tsc` with **TS2578** naming that key (the member falls back to `any` and the wrong-typed assignment starts succeeding). Renaming `variant?:` → `variantABLATED?:` in `data-display.ts`, confirmed on disk in both directions (deleted-text count `1 → 0`, injected-text count `1`, blob hash ≠ `HEAD` blob):

```
ABLATION_TSC_EXIT=2
src/__tests__/timeline-declared-keys.test.ts(230,5): error TS2578: Unused '@ts-expect-error' directive.
src/__tests__/zod-mirror-parity.test.ts(1203,14): error TS2322: Type '"data-display.zod.ts#TimelineSchema"' is not assignable to type 'never'.
```

Predicted instrument fired; a **second** independent instrument (the mirror-parity ratchet) fired too. No build leg was needed — `tsconfig.test.json` resolves `../data-display.js` to source, not `dist/`. Restore leg proven, not assumed: `git checkout HEAD -- <abs path>`, then blob hash byte-identical to the `HEAD` blob (`44a3416d…`), residual marker count `0`, `git diff HEAD` empty.

---

## What changed

**`packages/types/src/data-display.ts`** — `TimelineSchema` declares the eight authorable keys `TimelineRenderer` reads: `variant`, `items`, `dateFormat`, `scale`, `timeScale`, `rowLabel`, `minDate`, `maxDate`. New exported `TimelineScale` (the six spec buckets). `events` goes **required → optional**. `events`/`orientation`/`position` keep their declarations, gain `@deprecated` + a zero-read-points warning + the ADR-0049 route note.

`onItemClick` — the ninth read key — is **deliberately left undeclared**: it is a runtime slot `ObjectTimeline` installs, and this package keeps callback-shaped keys off the authored surface (`RuntimeOnlyDeclared`, `zod-mirror-parity.test.ts`). Declaring it would have required a new entry in that shared ledger for no authoring gain.

`items` is declared `any[]` rather than a narrowed union: the renderer accepts **two** element shapes discriminated by `variant` and reads both dynamically. Pinning a precise element union is a separate question (filed below), and narrowing it here would have been the one genuinely risky move in the diff.

**`packages/types/src/zod/data-display.zod.ts`** — the mirror follows key-for-key. Non-negotiable: `zod-mirror-parity.test.ts` registers this pair with **no** `KnownDrift`/`UnmirroredDeclared` entry, so a declared-but-unmirrored key reddens the ratchet. `TimelineScaleSchema` is module-local, not exported — every *exported* const in that directory must be registered in `MIRRORS` or `EXCLUSIONS`, and a shared inline enum is not a mirror of any declaration.

**`packages/plugin-timeline/src/renderer.tsx`** — the designer now offers `scale` with all six buckets, sourced from the existing `TIMELINE_SCALES` const. `timeScale` stays for round-tripping stored JSON, marked `advanced` with a DEPRECATED `description` (`ComponentInput` has no `deprecated` slot and no index signature, so `description` is this package's stated ceiling). Before this the designer offered only `timeScale` with **three** of the six — `hour`/`quarter`/`year` have rendered correctly since objectui#2942 but were offered by neither the designer nor the type, so they were authorable and undiscoverable from both surfaces.

> **Declared bounded in-place fix:** the registry `inputs` edit is not named in the ruling's four bullets. It is included because bullet 2 (`scale` canonical, *"not a silent second spelling"*) is about the vocabulary, and the designer is one of the three vocabularies this card is about — leaving it offering `timeScale: day|week|month` against a type declaring `scale: hour…year` would re-create the exact divergence being closed. It is additive, mechanical, and in the same gate family.

**`content/docs/plugins/plugin-timeline.mdx`** — property table gains `scale`, marks `timeScale` deprecated; the Schema API block and the "Time Scales" feature line corrected from three buckets to six; a callout that `events`/`orientation`/`position` are read by nothing and render an empty rail.

**`packages/types/src/__tests__/timeline-declared-keys.test.ts`** — new, modelled on `gantt-declared-keys.test.ts` (objectui#5903), the house form for this defect class. 16 assertions across runtime + compile-time halves, including the objectui#5155 ceiling stated explicitly ("declaring these did NOT buy rejection of a misspelling") and counter-probes so a `never`-narrowed declaration cannot satisfy the `@ts-expect-error` block.

---

## ⛔ The fork I did NOT take — for the maintainer

The ruling routes `events`/`orientation`/`position` to **ADR-0049 enforce-or-remove**. Both directions, with costs:

**Direction A — remove (tombstone).** The house form is already in this same file: `StaticTableColumn` (objectui#5474, maintainer ruling 2026-08-22, Option C) uses `?: never` members with `@deprecated`, twinned by `z.never().optional()` in the mirror, giving a tsc error and a loud parse rejection.

* Cost: **breaking narrowing of a published type.** Every value carrying `events: [...]` — legal and type-checking today — becomes a tsc error *and* a Zod rejection. `events` is currently *required*, so this is the maximal-breakage direction.
* Breaks: nothing in-repo reads these keys (measured: zero read points). In-repo *authors*: one artifact, `packages/types/examples/data-display-examples.json`. Out-of-repo consumers are unmeasurable from here — the same unmeasurable half objectui#5674's ruling answered with a deprecation window (deprecate one release, then delete). This PR ships that window's first half.
* Also needs: replacing the example fixture (it pins the removed branch), and a check against `check-lucide-icon-record-names.mjs`, whose census counts 3 timeline icon names in that file.

**Direction B — enforce (implement).** Build an `events`-driven presentational timeline alongside the `items`-driven one.

* Cost: two presentational timelines to maintain, for a vocabulary with **zero** measured pull — no author, no fixture, no example app uses it. objectui#5474 declined the analogous Option A for exactly this reason.
* Startup scope discipline says no; a published-but-unconsumed capability gets no exemption from sunk cost.

**My recommendation: A**, on the deprecation-window shape — this PR is stage 1 (declared, deprecated, documented, still accepted), a follow-up card is stage 2 (tombstone). It keeps the ruling's direction, gives external consumers a warned break rather than a silent one, and matches the two precedents this repo has already set. **But the timing of stage 2 is a maintainer call, not mine, and no code here presumes it.**

The `timeScale` alias retirement is routed the same way and is likewise not done here.

---

## Gates — each gate's own verdict line, at `e3c074869`

| gate | exit | its own verdict line |
|---|---|---|
| `turbo run build --filter='!@object-ui/site'` | 0 | `Tasks: 43 successful, 43 total` |
| `vitest run packages/types/ packages/plugin-timeline/` | 0 | `Test Files 69 passed (69)` / `Tests 729 passed (729)` |
| `@object-ui/types` `type-check` | 0 | script echoed `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json` |
| `@object-ui/plugin-timeline` `type-check` | 0 | script echoed `tsc --noEmit && tsc -p tsconfig.test.json` |
| downstream sweep `--filter '...@object-ui/types'` | 0 | **42** consumer packages `type-check: Done` |
| `check-changeset-presence` | 0 | `✅ 4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | 0 | `✅ No changeset declares a 'major' bump.` |
| `check-lint-coverage` | 0 | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `eslint packages/types packages/plugin-timeline` | 0 | 138 files, `errorCount: 0` (311 pre-existing warnings; `lint.yml` sets no `--max-warnings`) |
| `check:doc-types` | 0 | `✅ Every documented component type is registered.` |
| `check:doc-snippets` | 0 | `Semantic phase: 267 of 267 block(s) judged, 0 failed.` |
| `check:doc-fences` | 0 | `✅ every TypeScript block in 223 document(s) is fenced ts/tsx/typescript` |
| `check:control-bytes` | 0 | `✅ OK (scanned 5226 tracked text file(s); skipped 85 binary).` |
| `check:readme-exports` | 0 | `✅ OK (… 378 self-imports judged (378 real, 0 wrong-path, 0 fabricated); 3246 export symbol(s) read from 37 of 40 package(s) (0 unbuilt…)` |
| `check:icon-record-names` | 0 | `OK  lucide icon names: 167 authored/declared names … are live 'icons' keys` |
| `check:designer-field-key-parity` | 0 | `designer-field-key-parity: OK` |
| `check:spec-symbols` | 0 | `✅ 1306 files scanned against 4959 spec export names` |
| `check:self-import` | 0 | `✅ No package names itself inside its own src/.` |
| `check:phantom-deps` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:vi-mock-specifiers` | 0 | `✅ OK (3749 tracked source file(s)…)` |
| `check:shell-escape-residue` | 0 | `✅ OK (4/4 root(s) resolved…)` |
| `pnpm check` (the CLI check `lint.yml` runs) | 0 | `✓ All checks passed` |
| the three published catalog fixtures, `objectui validate` | 0,0,0 | vertical / horizontal / gantt all still validate under the narrowed type |

Two runs were **NOT MEASURED** rather than red, and are recorded as such: `check:readme-exports` and `check:doc-snippets` first returned a precondition failure (`the population COLLAPSED — this run proves nothing`; `PRECONDITION NOT MET (exit 2) — the snippet program was NOT run`) because packages were unbuilt. Both are green above, re-run after the build. `check-half-states.mjs` exits 3 (`no reading at all`) — it is a scheduled GitHub-board patrol, not a PR gate.

**Lint scope, declared.** Repo-scale `turbo run lint` was narrowed to the two affected packages. The narrowing is a measurement, not a skip, on three pieces of evidence: ① the population came from eslint's own config resolution, not my guess; ② the count is from `--format json` — 138 files, 0 errors; ③ **type-aware linting is not enabled** — `eslint.config.js`'s `languageOptions` carries only `ecmaVersion` and `globals`, with no `parserOptions.project`/`projectService` — so no rule's verdict on an untouched file can depend on this diff. `check-lint-coverage.mjs` independently reports 46/46 packages clean.

---

## Out-of-scope findings (to be filed unassigned, not fixed here)

1. **`'timeline'` is registered twice**, and the bare-name fallback silently goes to the later registration (`index.tsx:366`, `ObjectTimelineRenderer`) over `renderer.tsx:498` (`TimelineRenderer`). `Registry.register`'s own collision guard exists to warn about this. Working-as-intended is plausible; *undocumented and order-dependent* is not.
2. **`packages/types/examples/data-display-examples.json` teaches the dead vocabulary** — its `timeline` node authors `events`/`orientation`/`position` and would render an empty rail. It is imported by nothing and type-checked by nothing. Best replaced in the same change as the ADR-0049 removal, since it must move then anyway and `check-lucide-icon-record-names.mjs` counts 3 icon names in it.
3. **`TimelineEvent` is dead with `events`** — nothing reads it, and its `date` key is not even the `time` key the renderer reads. Belongs to the same ADR-0049 sweep.
4. **`items` has no declared element type.** Two shapes discriminated by `variant`; declaring them precisely is real authoring value but a genuine narrowing, so it wants its own card and its own measurement.
5. **`schema.bind` is read undeclared** (`ObjectTimeline.tsx:142`, `useDataScope(schema.bind)`) — not on `BaseSchema`, not on any timeline shape; it rides the index signature. Likely a repo-wide pattern rather than a timeline defect.


---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_