### PR TITLE
fix(components): resolve the declared action type for a bar-hosted action:icon

### DIFF
--- a/.changeset/6306-action-icon-type-resolution.md
+++ b/.changeset/6306-action-icon-type-resolution.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/components': patch
+---
+
+An `action:icon` hosted by an `action:bar` now reaches its handler. It forwarded the
+COMPONENT id as the action type, so the click resolved nothing at all — no error, no
+toast, a button that silently did nothing (objectui#6306, the objectstack#2169 "Mark Done
+does nothing" shape).
+
+`action:bar` does not route members through `SchemaRenderer`. It pulls each member's
+renderer off the registry and RENAMES the declared type as it spreads it onto the child:
+`type` becomes the component id (`'action:icon'`) and the real declaration moves to
+`actionType`. `action:button` has always resolved that pair when it forwards
+(`schema.actionType || schema.type`); `action:icon` read `schema.type` alone and dropped
+`actionType` entirely. `ActionRunner.execute` resolves its handler from
+`action.type || action.actionType || action.name`, and `'action:icon'` binds no registered
+handler and no builtin — for a declaration carrying `target` rather than `endpoint` it does
+not reach the legacy `navigate`/`api` fallback either, so it fell through to
+`executeActionSchema` and the authored action never ran.
+
+**The bug was a function of the layout, not the declaration.** One authored action executed
+or did nothing depending on which `component` the host picked for it — the same asymmetry
+objectui#5493 fixed on this renderer for `onSuccess`, one key over.
+
+`check:action-forward-parity` could not have caught this and its green run was never
+evidence: `type` **is** in the forward whitelist, and that gate diffs key PRESENCE against
+the owed set. This is a wrong-VALUE defect behind a present key, a class the gate has no
+opinion on by construction. The existing icon coverage could not catch it either — it
+rendered `action:icon` bar members three times and asserted only `visible`/`enabled`, never
+that a click reached a handler, which is exactly how this shipped.
+
+Pinned by `action-bar-member-type-resolution.test.tsx`, which executes clicks rather than
+inspecting props. Every row that reads the icon member's zero renders a sibling
+`action:button` member of the SAME declaration in the SAME bar and reads its one first, so
+a zero cannot be "the harness never executed anything". One row registers a trap handler
+keyed on the component id, making the unfixed behaviour a positive artefact (the trap
+fires) rather than only a missing call. A standalone row stays green in both worlds on
+purpose: it refuses a "fix" written as `schema.actionType` alone, which would trade this
+defect for its mirror image on the surface where `type` IS the action type.
+
+Scope is this one renderer. `type: schema` appears in exactly two files under
+`renderers/action/` — `action-button.tsx` (already correct) and `action-icon.tsx`;
+`action:group` and `action:menu` compose their members differently and are untouched.

--- a/packages/components/src/renderers/action/__tests__/action-bar-member-type-resolution.test.tsx
+++ b/packages/components/src/renderers/action/__tests__/action-bar-member-type-resolution.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6306 — an `action:icon` hosted by an `action:bar` forwarded the
+ * COMPONENT id as the action type, so the click resolved no handler and
+ * nothing happened: no error, no toast, the objectstack#2169 "Mark Done does
+ * nothing" shape.
+ *
+ * ## The composition, and where the two leaves disagreed
+ *
+ * `action:bar` does not route members through `SchemaRenderer`. It pulls each
+ * member's renderer off the registry and RENAMES the declared type as it
+ * spreads (`action-bar.tsx`):
+ *
+ *     type: componentType,        // 'action:button' | 'action:icon' | …
+ *     actionType: action.type,    // the real action type ('api', 'script', …)
+ *
+ * So on this host path the member's own `schema.type` is the component id and
+ * `schema.actionType` is the declaration. `action:button` resolves the pair
+ * when it forwards (`schema.actionType || schema.type`); `action:icon` read
+ * `schema.type` alone and dropped `actionType` entirely, handing the runner
+ * `type: 'action:icon'`. `ActionRunner.execute` resolves the handler from
+ * `action.type || action.actionType || action.name`, and `'action:icon'` binds
+ * nothing: no registered handler, no builtin, and — for a declaration carrying
+ * `target` rather than `endpoint` — no legacy `navigate`/`api` fallback either.
+ * It falls through to `executeActionSchema` and the authored action never runs.
+ *
+ * ## Why these rows are readings and not a dead probe
+ *
+ * Every row that reads the icon member's ZERO renders a sibling `action:button`
+ * member of the SAME declaration in the SAME bar and reads its ONE first. A
+ * harness that executes nothing at all — an unmounted renderer, a member pushed
+ * into the overflow menu, an assertion racing the async `execute` — reports
+ * zero on both members, so the control tells the two apart from the failure
+ * message alone. The two members differ in exactly one authored key,
+ * `component`; `name`/`label` differ only because they are the addressing
+ * handles, and the runner never consults them here (`type` is always truthy on
+ * this path, so the `|| action.name` leg is unreachable).
+ *
+ * The `component id never reaches the runner` row makes the defect two-sided
+ * rather than merely absent: it registers a TRAP handler keyed on the component
+ * id itself, so the unfixed renderer produces a positive artefact (the trap
+ * fires) instead of only a missing call. Nothing about the production path
+ * changes — the trap only gives the wrong value somewhere to land.
+ *
+ * ## The standalone row is a guard, not a duplicate
+ *
+ * Rendered on its own, `action:icon` never sees an `actionType` — its own
+ * registry `inputs` declare `type` as the action type. That row is green in
+ * both worlds ON PURPOSE: it is what refuses a "fix" written as
+ * `schema.actionType` alone, which would trade this defect for the mirror one.
+ *
+ * Scope note: `type: schema` appears in exactly TWO files under
+ * `renderers/action/` — `action-button.tsx` and `action-icon.tsx`. `action:group`
+ * and `action:menu` compose their members differently and are not part of this
+ * defect; that census is a control here rather than an assumption.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import type { ActionContext, ActionDef, ActionResult } from '@object-ui/core';
+import { ActionProvider } from '@object-ui/react';
+// Module-scope side-effect imports so the three renderers are in the registry
+// when `ComponentRegistry.get` runs — the light `dom` project does not load the
+// `@object-ui/components` graph, and `action:bar` resolves its members through
+// the registry at render time. Module scope, not a `beforeAll`, per
+// AGENTS.md §测试纪律.
+import '../action-button';
+import '../action-icon';
+import '../action-bar';
+
+/**
+ * The authored declaration. `target` and NOT `endpoint` — deliberately: an
+ * `endpoint` would let the runner's legacy `action.api || action.endpoint`
+ * fallback reach `executeAPI` even with an unresolved type, which would mask
+ * exactly the defect under test.
+ */
+const DECLARATION = {
+  type: 'api',
+  target: '/api/v1/tasks/mark_done',
+} as const;
+
+/** One declaration, mounted twice; `component` is the only variable. */
+const iconMember = { ...DECLARATION, name: 'mark_done_icon', label: 'Mark done icon', component: 'action:icon' };
+const buttonMember = { ...DECLARATION, name: 'mark_done_button', label: 'Mark done button', component: 'action:button' };
+
+let api: Mock<(action: ActionDef, ctx: ActionContext) => Promise<ActionResult>>;
+/** Keyed on the COMPONENT id — fires only if the unresolved type reaches the runner. */
+let trap: Mock<(action: ActionDef, ctx: ActionContext) => Promise<ActionResult>>;
+
+beforeEach(() => {
+  api = vi.fn(async () => ({ success: true }));
+  trap = vi.fn(async () => ({ success: true }));
+});
+
+/**
+ * The real `action:bar` host. BOTH ceilings are pinned high: the inline/overflow
+ * split reads `mobileMaxVisible ?? 1` when `useIsMobile()` is true, so pinning
+ * only `maxVisible` would leave the split at the mercy of the environment's
+ * viewport and could push a member into the overflow menu — a zero that is not
+ * about type resolution at all.
+ */
+function renderBar(handlers: Record<string, Mock<(a: ActionDef, c: ActionContext) => Promise<ActionResult>>>) {
+  const Bar = ComponentRegistry.get('action:bar');
+  if (!Bar) throw new Error('action:bar is not registered');
+  return render(
+    <ActionProvider handlers={handlers} onToast={vi.fn()}>
+      <Bar
+        schema={{
+          type: 'action:bar',
+          maxVisible: 10,
+          mobileMaxVisible: 10,
+          actions: [buttonMember, iconMember],
+        } as never}
+      />
+    </ActionProvider>,
+  );
+}
+
+const clickMember = (label: string) => fireEvent.click(screen.getByRole('button', { name: label }));
+
+/** The def the handler was handed — i.e. what actually reached the runner. */
+const defOf = (m: Mock<(a: ActionDef, c: ActionContext) => Promise<ActionResult>>, i = 0) =>
+  m.mock.calls[i][0];
+
+describe('action:bar member type resolution — action:icon (objectui#6306)', () => {
+  it('positive control — the action:button member reaches the api handler', async () => {
+    renderBar({ api });
+
+    clickMember('Mark done button');
+
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(1));
+    expect(defOf(api).type).toBe('api');
+  });
+
+  it('the action:icon member of the same bar reaches the same handler', async () => {
+    renderBar({ api });
+
+    // The control first, in the same render: its ONE is what makes the icon
+    // member's count a reading rather than "the harness never executed".
+    clickMember('Mark done button');
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(1));
+
+    clickMember('Mark done icon');
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(2));
+    expect(defOf(api, 1).type).toBe('api');
+  });
+
+  it('the runner is handed the declared type, not the component id', async () => {
+    renderBar({ api, 'action:icon': trap });
+
+    clickMember('Mark done icon');
+
+    // Settle on EITHER path before reading, so the row is about WHICH handler
+    // resolved and never about async timing. Asserting the trap FIRST is what
+    // makes the unfixed world produce a naming artefact ("expected trap not to
+    // be called, but it was") instead of a generic missing call.
+    await waitFor(() => expect(api.mock.calls.length + trap.mock.calls.length).toBe(1));
+    expect(trap).not.toHaveBeenCalled();
+    expect(api).toHaveBeenCalledTimes(1);
+    expect(defOf(api).type).toBe('api');
+  });
+
+  it('both members of one declaration resolve to the same action type', async () => {
+    renderBar({ api });
+
+    clickMember('Mark done button');
+    clickMember('Mark done icon');
+
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(2));
+    expect(api.mock.calls.map(([def]) => def.type)).toEqual(['api', 'api']);
+  });
+
+  it('regression guard — a standalone action:icon still resolves its own declared type', async () => {
+    // No host, so no `actionType` at all: `type` IS the action type here, as
+    // this renderer's own registry `inputs` declare. Green before and after the
+    // fix on purpose — it refuses a rewrite that reads `actionType` alone.
+    const Icon = ComponentRegistry.get('action:icon');
+    if (!Icon) throw new Error('action:icon is not registered');
+    render(
+      <ActionProvider handlers={{ api }} onToast={vi.fn()}>
+        <Icon schema={{ ...DECLARATION, name: 'standalone', label: 'Standalone icon' } as never} />
+      </ActionProvider>,
+    );
+
+    clickMember('Standalone icon');
+
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(1));
+    expect(defOf(api).type).toBe('api');
+  });
+});

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -32,10 +32,13 @@ import { hasDeclaredVisibilityGate } from './visibility-gate';
  * `locations`, `enabled` and `size` are all modern-only keys this renderer
  * forwards, and the legacy `crud.ts` `ActionSchema` is `@deprecated` and pins
  * `type: 'action'` where this renderer's own registry `inputs` declare
- * `'script' | 'url' | 'modal' | 'flow' | 'api'`.
+ * `'script' | 'url' | 'modal' | 'flow' | 'api'`. `actionType` stays on the
+ * intersection for the same reason it does on `action:button`: it is the
+ * host-composed override this renderer reads FIRST
+ * (`schema.actionType || schema.type`), and it is not a `UIActionSchema` key.
  */
 export interface ActionIconProps {
-  schema: UIActionSchema & { type: string; className?: string };
+  schema: UIActionSchema & { type: string; className?: string; actionType?: string };
   className?: string;
   context?: Record<string, any>;
   [key: string]: any;
@@ -96,7 +99,18 @@ const ActionIconRenderer = forwardRef<
         // (objectui#4281). `...localContext` is still merged last, so the object
         // reaching `execute` is unchanged.
         const forwarded: ActionDef = {
-          type: schema.type,
+          // The host path renames the declared type (objectui#6306). `action:bar`
+          // does not route members through `SchemaRenderer` — it spreads the
+          // member onto this renderer's schema as `type: componentType,
+          // actionType: action.type`, so on that path `schema.type` is the
+          // COMPONENT id and `schema.actionType` is the declaration. Reading
+          // `schema.type` alone handed the runner `type: 'action:icon'`, which
+          // `ActionRunner.execute` resolves to no handler and no builtin: the
+          // click did nothing, with no error and no toast. Same resolution
+          // `action:button` has always had; the `|| schema.type` leg is what
+          // keeps the STANDALONE surface (where `type` IS the action type, as
+          // this renderer's own registry `inputs` declare) working.
+          type: schema.actionType || schema.type,
           name: schema.name,
           // See action-button.tsx — the param-collection dialog reads its title
           // and description off these (objectui#4192, measured on `action:menu`


### PR DESCRIPTION
Fixes #6306

An `action:icon` rendered as a member of an `action:bar` forwarded the **component id** as the action type, so the click resolved no handler: nothing happened, with no error and no toast — the objectstack#2169 "Mark Done does nothing" shape.

All gate readings below were taken on the final commit of this branch, `afb35717b`.

## Premise, re-derived on `origin/main` @ `194fae184`

Not taken on trust from the card. Every line number in the report reproduces exactly on the ref this branch is cut from:

```
action-bar.tsx:309       actionType: action.type,                  <- the real action type is composed
action-button.tsx:148    type: schema.actionType || schema.type,   <- resolved
action-icon.tsx:99       type: schema.type,                        <- NOT resolved; actionType dropped
ActionRunner.ts:954      const actionType = action.type || action.actionType || action.name || '';
```

`action:bar` does not route members through `SchemaRenderer`. It pulls each member's renderer off the registry and **renames the declared type** as it spreads it onto the child: `type` becomes the component id, and the real declaration moves to `actionType`. `action:button` resolves that pair when it forwards; `action:icon` read `schema.type` alone and dropped `actionType` entirely, handing the runner `type: 'action:icon'`.

`'action:icon'` binds no registered handler and no builtin. For a declaration carrying `target` rather than `endpoint` it does not reach the legacy `navigate`/`api` fallback either, so it falls through to `executeActionSchema` and the authored action never runs. **The bug was a function of the layout, not the declaration** — one authored action executed or did nothing depending only on which `component` the host picked for it.

### Census (a control, not an assumption)

`type: schema` appears in exactly **two** files under `renderers/action/`: `action-button.tsx` (already correct) and `action-icon.tsx`. `action:group` (`:249`) and `action:menu` (`:220`) forward `type: action.type` from their **own** member array — the member's declared type is used directly and never renamed, which is why the construct does not appear there. They are a genuinely different composition, not a third instance. **No third case was found**; nothing else was touched.

## The fix

`action-icon.tsx` gets the same resolution `action-button.tsx` already had. `actionType` joins the props intersection for the same reason it sits on `action:button`'s — it is the host-composed override read first, and it is not a `UIActionSchema` key. No accept set is widened; this restores declared behaviour only.

The `|| schema.type` leg is load-bearing in the other direction: rendered standalone, `action:icon` never sees an `actionType`, and its own registry `inputs` declare `type` as the action type.

## The pin executes clicks, and carries a positive control

The reason this shipped is that the existing icon coverage (`action-bar-member-visible-gate.test.tsx:195-213`) renders `action:icon` bar members three times and asserts only `visible`/`enabled` — it never asserts that a click reaches a handler. The new pin asserts execution, not props.

**Positive control.** Every row that reads the icon member's zero renders a sibling `action:button` member of the **same declaration** in the **same bar**, with an `api` handler registered through `ActionProvider`, and reads its **one** first. This is what makes a zero a *reading* rather than a dead probe: a harness that executes nothing at all — an unmounted renderer, a member pushed into the overflow menu, an assertion racing the async `execute` — reports zero on *both* members, so the control tells the two apart from the failure message alone. The two members differ in exactly one authored key, `component`; `name`/`label` differ only as addressing handles, and the runner never consults them here (`type` is always truthy on this path, so its `|| action.name` leg is unreachable).

Two further design points:

- **A trap handler keyed on the component id** (`handlers: { api, 'action:icon': trap }`) makes the defect *two-sided* rather than merely absent — the unfixed renderer produces a positive artefact instead of only a missing call. Measured on the unfixed tree: `expected "vi.fn()" to not be called at all, but actually been called 1 times`. That is direct evidence the component id reached the runner as the action type, and the row fails in 22 ms instead of timing out at ~1000 ms.
- **Both ceilings are pinned** (`maxVisible: 10` **and** `mobileMaxVisible: 10`). The inline/overflow split reads `mobileMaxVisible ?? 1` when `useIsMobile()` is true, so pinning only `maxVisible` would leave the split at the mercy of the environment's viewport — a zero that is not about type resolution at all.
- **The standalone row is green in both worlds on purpose.** It refuses a "fix" written as `schema.actionType` alone, which would trade this defect for its mirror image on the surface where `type` *is* the action type.

## Ablation — predicted before running, then compared

Prediction was recorded before the first run: **5 rows, 3 red / 2 green** before the fix, 5 green after, with the zero caused by fall-through to `executeActionSchema` (silent, no throw).

| row | predicted | actual (unfixed tree) |
|---|---|---|
| positive control — `action:button` member reaches the handler | green | **green** |
| the `action:icon` member reaches the same handler | red | **red** — `expected "vi.fn()" to be called 2 times, but got 1 times` |
| the runner is handed the declared type, not the component id | red | **red** |
| both members of one declaration resolve to the same type | red | **red** — `expected "vi.fn()" to be called 2 times, but got 1 times` |
| regression guard — standalone `action:icon` | green | **green** |

Observed: `Tests  3 failed | 2 passed (5)` — rows and counts exactly as predicted. After the fix: `Tests  5 passed (5)`.

**Where the prediction was wrong.** In the trap row the `api` `waitFor` was written first, so it timed out and the trap's own assertion never evaluated — the "two-sided" half was *asserted rather than measured*. The row was restructured to settle on either path (`api.mock.calls.length + trap.mock.calls.length`) and assert the trap **first**, and the ablation was re-run: the trap then fired observably (quoted above). The two-sided claim above is measured, not inferred.

## `check:action-forward-parity` is blind to this defect — and its green run is not evidence

`type` **is** in the forward whitelist, and the gate diffs key **presence** against the owed set. This is a wrong-**value** defect behind a present key, a class the gate has no opinion on by construction.

This was measured, not merely argued. Running the gate against the **unfixed** `action-icon.tsx` (restored from `194fae184`, mutation confirmed on disk, then restored and verified byte-identical to `HEAD`) produces output identical to the fixed tree, including the per-surface counts:

```
✅  action forward parity: 5 surfaces checked against 39 runtime-read keys from 4 consumers; ...
    action:icon    owes 25, forwards 19, payload excess-property CHECKED
```

Same `owes 25, forwards 19`, same `✅`, same exit 0 in both worlds — because the fix changes a value expression, not the key set.

**Could the gate be taught to catch it?** Report only — `scripts/check-action-forward-parity.mjs` is `domain:devx` territory and is **not modified here**. The observation, for whoever owns that call: the gate already parses each forward site's payload object literal, so it has the *expression* for each key in hand and currently uses only the key's presence. A narrow extension would be a per-key **value contract** for keys the host is known to rename — specifically, that any surface reachable as an `action:bar` member must spell `type` as `schema.actionType || schema.type`, since `action-bar.tsx` is the single composer of that rename (exactly one site repo-wide). That is a real design decision with a false-positive surface (a renderer legitimately composing `type` some other way), which is why it is filed as an observation rather than attempted here.

## Gates

Derived by reading the CI job step lists under `.github/workflows/` (`ci.yml` Type Check / Test jobs, `lint.yml`, `changeset-presence.yml`, `changeset-guard.yml`, `control-bytes.yml`, `vi-mock-specifiers.yml`), not from memory. Exit codes captured **before** any pipe; each row quotes the gate's own verdict line.

| gate | verdict line (the gate's own) | exit |
|---|---|---|
| `vitest run packages/components/` | `Test Files  191 passed (191)` / `Tests  1736 passed (1736)` | 0 |
| the new pin alone | `Test Files  1 passed (1)` / `Tests  5 passed (5)` | 0 |
| `@object-ui/components type-check` | `tsc --noEmit && tsc -p tsconfig.test.json` — no diagnostics | 0 |
| `check:action-forward-parity` | `✅  action forward parity: 5 surfaces checked against 39 runtime-read keys from 4 consumers` | 0 |
| `check:vi-mock-specifiers` | `✅  check-vi-mock-specifiers: OK (3753 tracked source file(s), 2065 test-named; …)` | 0 |
| `check:control-bytes` | `✅  check-control-bytes: OK (scanned 5235 tracked text file(s); skipped 85 binary).` | 0 |
| `check-changeset-presence.mjs` | `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` | 0 |
| `changeset:check` | `✅  All workspace packages are in the changeset fixed group.` + `✅  No changeset declares a `major` bump.` | 0 |
| `pnpm lint` (repo-wide) | **NOT MEASURED as a whole** — see below | 143 |

**The typecheck green is a real measurement of this diff.** `tsconfig.test.json` includes `src/**/*.test.tsx`, and `--listFiles` confirms both the new test file **and** the fixed `action-icon.tsx` are program inputs (1 hit each) — so this is not the "typecheck excludes tests" shape where a green says nothing about new coverage.

**Lint, stated honestly.** The repo-wide `pnpm lint` (`turbo run lint`) was attempted and the container's ~10-minute foreground cap killed it with `SIGTERM` (`exit 143`) — that reads as *not measured*, not as red. It got through **46 of 47** tasks first, and **`@object-ui/components:lint` was among them**: `✖ 912 problems (0 errors, 912 warnings)`. The single task cut off was `@object-ui/app-shell#lint`, which this diff does not touch. No completed task reported any errors.

The narrowed measurement, with the three things that make a narrowing a measurement rather than a skip: (1) the population is read from eslint's own config — 3752 files; (2) file counts come from `--format json` — both changed files linted, **0 errors**; (3) `eslint.config.js` enables **no type-aware linting** (no `projectService`, no `parserOptions.project` — zero matches), so this diff cannot move the verdict of any file it does not touch. The 12 warnings on `action-icon.tsx` are pre-existing and were measured against the base file rather than assumed: **12 before, 12 after, delta 0**.

One caution for anyone re-running this: a bare `eslint .` from the repo root is **not** the gate and reports 89 pre-existing errors across 74 files. The root `lint:root` script deliberately ignores `packages/*/**`, so that invocation lints package sources under the wrong config. The gate is `turbo run lint` (per-package `eslint .`), which is what the table reports.

## Scope

`packages/components/src/renderers/action/action-icon.tsx` plus its new coverage and one changeset. `renderers/overlay/` and `packages/app-shell` are untouched. No labels attached.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_