### PR TITLE
fix(data-objectstack): carry the producer's `userMessage` through both re-wraps in `normaliseClientError`

### DIFF
--- a/.changeset/normalise-client-error-user-message-5901.md
+++ b/.changeset/normalise-client-error-user-message-5901.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+Preserve the producer's `userMessage` marking when `normaliseClientError` re-wraps a refusal.
+
+`ApiErrorSchema.userMessage` (objectstack#9934) is the opt-in channel an application author
+sets at throw time to say "this text is for the end user", and the contract states it
+status-agnostic — any refusal status may carry it. Both of the shapes this adapter re-wraps
+into typed errors dropped the marking: a hook that refused a write with `VALIDATION_FAILED`
+or `CONCURRENT_UPDATE` and marked its own sentence had that sentence discarded at the
+adapter boundary, before any surface could render it. Nothing threw and the typed error was
+otherwise correct, so the only symptom was the user reading a generic string instead of the
+sentence their administrator wrote.
+
+The marking now rides both re-wraps, in the form the shared reader (`declaredUserMessage`)
+already looks for: on the details bag for `DataApiValidationError`, exactly the way `fields`
+already survives, and on a new readonly `userMessage` member for `ConcurrentUpdateError`,
+which has no details bag. Unmarked refusals are untouched — they carry no key and still read
+as `null`, so nothing a producer did not opt into can reach a user.

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -8,6 +8,7 @@
 
 import { ObjectStackClient, type QueryOptions as ObjectStackQueryOptions } from '@objectstack/client';
 import type { DroppedFieldsEvent } from '@objectstack/spec/data';
+import type { ApiError } from '@objectstack/spec/api';
 // #4237 — the metadata save door's advisory reader, shared with `MetadataClient`
 // rather than forked. ONE reader, two call sites: the other client class calls it
 // from `MetadataClient.save` (#4133/#4236), this one from the interceptor below.
@@ -1005,11 +1006,29 @@ export class ConcurrentUpdateError extends Error {
   readonly httpStatus = 409;
   readonly currentVersion: string | null;
   readonly currentRecord: unknown;
-  constructor(opts: { currentVersion: string | null; currentRecord: unknown; message?: string }) {
+  /**
+   * The refusal text the PRODUCER marked as addressed to the end user
+   * (`ApiErrorSchema.userMessage`, objectstack#9934), or `null` when the
+   * refusal carried no marking.
+   *
+   * Declared on the class because this error has no `details` bag: the shared
+   * reader (`declaredUserMessage` in `@object-ui/react`) looks at the
+   * top-level field first, so parking it here is what makes the marking
+   * readable at the surface. The contract is status-agnostic — a 409 carries
+   * it exactly like a 400 or a 403 does.
+   */
+  readonly userMessage: string | null;
+  constructor(opts: {
+    currentVersion: string | null;
+    currentRecord: unknown;
+    message?: string;
+    userMessage?: string | null;
+  }) {
     super(opts.message ?? 'Record was modified by another user');
     this.name = 'ConcurrentUpdateError';
     this.currentVersion = opts.currentVersion;
     this.currentRecord = opts.currentRecord;
+    this.userMessage = opts.userMessage ?? null;
   }
 }
 
@@ -1025,6 +1044,47 @@ export function isConcurrentUpdateError(error: unknown): error is ConcurrentUpda
 }
 
 /**
+ * The one declared key this boundary carries, anchored to the contract rather
+ * than to a string literal: `ApiError` is `z.input<typeof ApiErrorSchema>` in
+ * `@objectstack/spec`, so a rename there fails this file at compile time
+ * instead of silently going quiet. The same anchor `@object-ui/react`'s
+ * reader uses.
+ */
+type MarkedRefusal = Pick<ApiError, 'userMessage'>;
+
+/**
+ * Lift the producer's user-facing marking off a client error.
+ *
+ * `userMessage` (`ApiErrorSchema.userMessage`, objectstack#9934) is the opt-in
+ * channel an application author sets at throw time to say "this text is for
+ * the end user". The contract states it **status-agnostic** — not a 403
+ * special case, any refusal status may carry it — so this read is
+ * deliberately gated on neither a status nor a code.
+ *
+ * Read from the same two places, under the same declared key, as the shared
+ * reader `declaredUserMessage` in `@object-ui/react`: the error itself
+ * (`@objectstack/client` lifts a marked body onto `err.userMessage`, from
+ * either wire dialect) and `details`, which the client falls back to the WHOLE
+ * response body — the identical pair the `fields[]` read below uses. The
+ * predicate (non-empty after trimming, returned untrimmed) matches that reader
+ * exactly, so a marking that survives this boundary is one the surface accepts.
+ *
+ * Deliberately not imported from `@object-ui/react`: that package depends on
+ * THIS one, so the symbol cannot travel in this direction. The key is anchored
+ * to the contract type rather than to either copy of the predicate.
+ */
+function liftUserMessage(
+  e: Record<string, unknown>,
+  details: Record<string, unknown>,
+): MarkedRefusal['userMessage'] | null {
+  if (typeof e.userMessage === 'string' && e.userMessage.trim()) return e.userMessage;
+  if (typeof details.userMessage === 'string' && details.userMessage.trim()) {
+    return details.userMessage;
+  }
+  return null;
+}
+
+/**
  * Convert any error thrown by the upstream client into a typed error when we
  * recognise its shape. Returns the original error untouched otherwise, so
  * callers can simply `throw normaliseClientError(err)` from their catch blocks.
@@ -1034,6 +1094,12 @@ export function isConcurrentUpdateError(error: unknown): error is ConcurrentUpda
  *   - `400` + `VALIDATION_FAILED` → {@link DataApiValidationError}, carrying the
  *     server's per-field entries so a form can mark the offending inputs
  *     instead of showing one undirected toast.
+ *
+ * Both re-wraps preserve the producer's `userMessage` marking (see
+ * {@link liftUserMessage}). Re-wrapping used to drop it, which made the
+ * marking unreadable at every surface downstream of this boundary — nothing
+ * threw, the typed error was otherwise correct, and the user simply got a
+ * generic string.
  */
 export function normaliseClientError(error: unknown): unknown {
   if (!error || typeof error !== 'object') return error;
@@ -1042,6 +1108,9 @@ export function normaliseClientError(error: unknown): unknown {
   // the WHOLE body — and the validation envelope has no `details` key, so this
   // is where `fields[]` lands.
   const details = (e.details ?? {}) as Record<string, unknown>;
+  // Status-agnostic on purpose: lifted before either branch decides a shape,
+  // so a 400 and a 409 carry the marking identically.
+  const userMessage = liftUserMessage(e, details);
 
   if (e.code === 'VALIDATION_FAILED' || e.name === 'ValidationError') {
     const rawFields = Array.isArray(details.fields)
@@ -1068,7 +1137,13 @@ export function normaliseClientError(error: unknown): unknown {
       typeof e.message === 'string' ? e.message : 'Validation failed',
       validationErrors[0]?.field,
       validationErrors,
-      { fields: rawFields },
+      // The marking rides the details bag exactly the way `fields` already
+      // does, landing on `err.details.userMessage` — the second of the two
+      // places the shared reader looks. Purely additive: `field`,
+      // `validationErrors` and `fields` are untouched, so the per-field
+      // marking a form already draws keeps working. Omitted entirely when
+      // unmarked, so an unmarked refusal carries no empty key.
+      userMessage === null ? { fields: rawFields } : { fields: rawFields, userMessage },
     );
   }
 
@@ -1078,6 +1153,7 @@ export function normaliseClientError(error: unknown): unknown {
     currentVersion: typeof details.currentVersion === 'string' ? details.currentVersion : null,
     currentRecord: details.currentRecord ?? null,
     message: typeof e.message === 'string' ? e.message : undefined,
+    userMessage,
   });
 }
 

--- a/packages/data-objectstack/src/userMessage-normalisation.test.ts
+++ b/packages/data-objectstack/src/userMessage-normalisation.test.ts
@@ -1,0 +1,142 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { normaliseClientError, ConcurrentUpdateError } from './index';
+import { DataApiValidationError } from './errors';
+
+/**
+ * `userMessage` (`ApiErrorSchema.userMessage`, objectstack#9934) is the
+ * producer-side marking: an application author sets it at throw time to say
+ * "this text is for the end user". The contract states it status-agnostic —
+ * any refusal status may carry it.
+ *
+ * `normaliseClientError` re-wraps two shapes into typed errors, and both
+ * re-wraps used to drop the marking: the constructed error was otherwise
+ * correct, nothing threw, and the user simply got a generic string. These pins
+ * hold the marking across both re-wraps, in the form the shared reader
+ * (`declaredUserMessage` in `@object-ui/react`) actually looks for — the
+ * end-to-end leg through that reader is pinned in
+ * `packages/react/src/utils/error-message.normalisation-boundary.test.ts`,
+ * the only place the two halves may meet without a dependency cycle.
+ */
+describe('normaliseClientError — userMessage marking', () => {
+  describe('VALIDATION_FAILED re-wrap', () => {
+    // The client sets `details` to the parsed body's `details` OR — as here,
+    // since the validation envelope has no such key — the whole body.
+    const markedInBody = () =>
+      Object.assign(new Error('Amount is not allowed'), {
+        code: 'VALIDATION_FAILED',
+        httpStatus: 400,
+        details: {
+          error: 'Amount is not allowed',
+          code: 'VALIDATION_FAILED',
+          userMessage: 'Amounts over 10k need finance approval.',
+          fields: [{ field: 'amount', code: 'not_allowed', message: 'Amount is not allowed' }],
+        },
+      });
+
+    it('carries a marking parked on the response body', () => {
+      const normalised = normaliseClientError(markedInBody()) as DataApiValidationError;
+      expect(normalised).toBeInstanceOf(DataApiValidationError);
+      expect(normalised.details?.userMessage).toBe('Amounts over 10k need finance approval.');
+    });
+
+    it('carries a marking the client already lifted onto the error', () => {
+      const err = Object.assign(new Error('nope'), {
+        code: 'VALIDATION_FAILED',
+        userMessage: 'Pick a close date inside the open quarter.',
+        details: { fields: [{ field: 'close_date', message: 'out of range' }] },
+      });
+      const normalised = normaliseClientError(err) as DataApiValidationError;
+      expect(normalised.details?.userMessage).toBe('Pick a close date inside the open quarter.');
+    });
+
+    it('preserves the per-field entries alongside the marking', () => {
+      // The marking is additive: the per-field detail a form draws on each
+      // input must survive untouched next to it.
+      const normalised = normaliseClientError(markedInBody()) as DataApiValidationError;
+      expect(normalised.validationErrors).toEqual([
+        { field: 'amount', message: 'Amount is not allowed' },
+      ]);
+      expect(normalised.field).toBe('amount');
+      expect(normalised.details?.fields).toHaveLength(1);
+      expect(normalised.details?.userMessage).toBe('Amounts over 10k need finance approval.');
+    });
+
+    it('adds no key at all when the producer marked nothing', () => {
+      const err = Object.assign(new Error('Validation failed'), {
+        code: 'VALIDATION_FAILED',
+        details: { fields: [{ field: 'name', message: 'Name is required' }] },
+      });
+      const normalised = normaliseClientError(err) as DataApiValidationError;
+      expect(normalised.details).not.toHaveProperty('userMessage');
+    });
+
+    it('ignores a blank marking rather than carrying an empty channel', () => {
+      const err = Object.assign(new Error('Validation failed'), {
+        code: 'VALIDATION_FAILED',
+        details: { userMessage: '   ', fields: [{ field: 'name', message: 'required' }] },
+      });
+      const normalised = normaliseClientError(err) as DataApiValidationError;
+      expect(normalised.details).not.toHaveProperty('userMessage');
+    });
+  });
+
+  describe('CONCURRENT_UPDATE re-wrap', () => {
+    it('carries a marking parked on the response body', () => {
+      const err = Object.assign(new Error('Record was modified by another user'), {
+        code: 'CONCURRENT_UPDATE',
+        httpStatus: 409,
+        details: {
+          currentVersion: '2026-05-22T07:14:00.000Z',
+          currentRecord: { id: 'rec_1' },
+          userMessage: 'Someone in your team saved this first — reload before retrying.',
+        },
+      });
+      const normalised = normaliseClientError(err) as ConcurrentUpdateError;
+      expect(normalised).toBeInstanceOf(ConcurrentUpdateError);
+      expect(normalised.userMessage).toBe(
+        'Someone in your team saved this first — reload before retrying.',
+      );
+      // …without disturbing what the conflict dialog already reads.
+      expect(normalised.currentVersion).toBe('2026-05-22T07:14:00.000Z');
+      expect((normalised.currentRecord as { id: string }).id).toBe('rec_1');
+    });
+
+    it('carries a marking the client already lifted onto the error', () => {
+      const err = Object.assign(new Error('stale write'), {
+        code: 'CONCURRENT_UPDATE',
+        httpStatus: 409,
+        userMessage: 'This quote was re-priced while you were editing.',
+      });
+      const normalised = normaliseClientError(err) as ConcurrentUpdateError;
+      expect(normalised.userMessage).toBe('This quote was re-priced while you were editing.');
+    });
+
+    it('answers null when the producer marked nothing', () => {
+      const err = Object.assign(new Error('stale'), {
+        code: 'CONCURRENT_UPDATE',
+        httpStatus: 409,
+      });
+      const normalised = normaliseClientError(err) as ConcurrentUpdateError;
+      expect(normalised.userMessage).toBeNull();
+    });
+
+    it('ignores a blank marking rather than carrying an empty channel', () => {
+      const err = Object.assign(new Error('stale'), {
+        code: 'CONCURRENT_UPDATE',
+        httpStatus: 409,
+        details: { userMessage: '' },
+      });
+      const normalised = normaliseClientError(err) as ConcurrentUpdateError;
+      expect(normalised.userMessage).toBeNull();
+    });
+  });
+});

--- a/packages/react/src/utils/error-message.normalisation-boundary.test.ts
+++ b/packages/react/src/utils/error-message.normalisation-boundary.test.ts
@@ -1,0 +1,96 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { normaliseClientError } from '@object-ui/data-objectstack';
+import { declaredUserMessage } from './error-message';
+
+/**
+ * The two halves of the `userMessage` channel, pinned where they meet.
+ *
+ * `@object-ui/data-objectstack` parks the producer's marking on the typed
+ * error it constructs; `declaredUserMessage` here lifts it back off. Neither
+ * half can pin the pair alone — the adapter cannot import this reader (this
+ * package depends on THAT one, so the symbol cannot travel upstream), and the
+ * reader's own unit tests build their inputs by hand and so never exercise the
+ * adapter's re-wrap.
+ *
+ * That gap is exactly where the defect lived: both re-wraps dropped the
+ * marking, every unit test on both sides stayed green, and the only visible
+ * symptom was a user reading a generic string instead of the sentence their
+ * administrator wrote. These pins fail if either half stops holding up its end.
+ */
+describe('userMessage survives the adapter boundary', () => {
+  it('survives the VALIDATION_FAILED re-wrap', () => {
+    const raw = Object.assign(new Error('Amount is not allowed'), {
+      code: 'VALIDATION_FAILED',
+      httpStatus: 400,
+      details: {
+        code: 'VALIDATION_FAILED',
+        userMessage: 'Amounts over 10k need finance approval.',
+        fields: [{ field: 'amount', message: 'Amount is not allowed' }],
+      },
+    });
+    // The marking is readable before the boundary…
+    expect(declaredUserMessage(raw)).toBe('Amounts over 10k need finance approval.');
+    // …and must still be readable after it.
+    expect(declaredUserMessage(normaliseClientError(raw))).toBe(
+      'Amounts over 10k need finance approval.',
+    );
+  });
+
+  it('survives the CONCURRENT_UPDATE re-wrap', () => {
+    const raw = Object.assign(new Error('Record was modified by another user'), {
+      code: 'CONCURRENT_UPDATE',
+      httpStatus: 409,
+      details: {
+        currentVersion: '2026-05-22T07:14:00.000Z',
+        currentRecord: { id: 'rec_1' },
+        userMessage: 'Someone in your team saved this first — reload before retrying.',
+      },
+    });
+    expect(declaredUserMessage(raw)).toBe(
+      'Someone in your team saved this first — reload before retrying.',
+    );
+    expect(declaredUserMessage(normaliseClientError(raw))).toBe(
+      'Someone in your team saved this first — reload before retrying.',
+    );
+  });
+
+  it('leaves the untouched passthrough arm exactly as it was', () => {
+    // A 403 is returned unchanged by `normaliseClientError` — it is neither of
+    // the two re-wrapped shapes. Pinned as the control: it reads the same
+    // before and after, so a failure in the two above is about the re-wraps
+    // and not about the reader.
+    const raw = Object.assign(new Error('FORBIDDEN: insufficient privileges'), {
+      code: 'FORBIDDEN',
+      httpStatus: 403,
+      userMessage: 'Ask finance to approve this record first.',
+    });
+    expect(normaliseClientError(raw)).toBe(raw);
+    expect(declaredUserMessage(normaliseClientError(raw))).toBe(
+      'Ask finance to approve this record first.',
+    );
+  });
+
+  it('still answers null for an unmarked refusal on both re-wrapped shapes', () => {
+    // objectstack#3821 holds by construction: nothing the producer did not
+    // opt into can reach the user through this channel.
+    const validation = Object.assign(new Error('Validation failed'), {
+      code: 'VALIDATION_FAILED',
+      details: { fields: [{ field: 'name', message: 'Name is required' }] },
+    });
+    const conflict = Object.assign(new Error('stale'), {
+      code: 'CONCURRENT_UPDATE',
+      httpStatus: 409,
+    });
+    expect(declaredUserMessage(normaliseClientError(validation))).toBeNull();
+    expect(declaredUserMessage(normaliseClientError(conflict))).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #5901

`normaliseClientError` re-wraps two refusal shapes into typed errors, and both re-wraps dropped `ApiErrorSchema.userMessage` — the opt-in channel an application author sets at throw time to say "this text is for the end user" (objectstack#9934). The contract states the marking **status-agnostic**, so a hook refusing a write with `VALIDATION_FAILED` or `CONCURRENT_UPDATE` lost its marked sentence at this boundary, before any surface could render it.

This is declared-≠-enforced restoration: it pulls behaviour back to a stated contract and **widens no accept set**. Unmarked refusals are untouched.

## Premise re-derivation

Re-derived on `origin/main` @ `194fae184` (the same SHA the card measured), rather than trusting the line numbers:

| Card's claim | Measured |
|---|---|
| `normaliseClientError` at `packages/data-objectstack/src/index.ts:1038` | ✅ exact |
| `VALIDATION_FAILED` → `new DataApiValidationError(message, field, validationErrors, { fields: rawFields })`, four args, none is `userMessage` | ✅ verbatim |
| `CONCURRENT_UPDATE` → `ConcurrentUpdateError({ currentVersion, currentRecord, message })`, no marking | ✅ verbatim |

Premise stands in full; nothing contradicted §1 or §2 of the dispatch.

## T1 — `userMessage` census, with a control

The suspicion that `userMessage` may not appear in this package at all is **confirmed**, and confirmed as a *reading* rather than a broken pathspec — a known-present control was run over the identical pathspec:

| Token | Hits in `packages/data-objectstack/src/` |
|---|---|
| `userMessage` (target) | **0** |
| `normaliseClientError` (control) | 34 |
| `ConcurrentUpdateError` (control) | 30 |
| files traversed | 51 |

So the key had **no reader and no writer in this package**. That is what decided the shape below: "carry it through" cannot mean "hand it to a local reader", because there is none — it has to mean *land it in the form the downstream reader looks for*.

## T2 — who is supposed to read it

The reader is **`declaredUserMessage`**, `packages/react/src/utils/error-message.ts:125`. It looks in exactly two places, under the same declared key:

1. `err.userMessage` — where `@objectstack/client` lifts a marked body, from either wire dialect;
2. `err.details.userMessage` — `details` being the client's fallback to the *whole* response body.

Its live consumer is `packages/components/src/renderers/form/form.tsx:1836` — the form submit-error surface (`setSubmitError` + `toast.error`), which is precisely where a rejected write lands. So the marking has a real reader today, not a hypothetical one.

**The dependency direction is what forced the shape:** `@object-ui/react` depends on `@object-ui/data-objectstack`, so the adapter **cannot** import `declaredUserMessage` — the symbol cannot travel upstream. The predicate is therefore mirrored locally (non-empty after trimming, returned untrimmed — the identical predicate), and the *key* is anchored to the shared contract via `Pick<ApiError, 'userMessage'>` from `@objectstack/spec/api`, so a rename in the spec fails this file at compile time instead of going quiet.

**One nuance worth recording** (and relevant to #5902): `form.tsx` returns early when *every* rejected field maps to a rendered input, so a fully-attributed `VALIDATION_FAILED` never consults `declaredUserMessage`. The marking reaches the reader on the paths that matter — a `VALIDATION_FAILED` with no per-field entries, one whose fields aren't all rendered, and every `CONCURRENT_UPDATE`.

## The fix

The marking is lifted **once, ahead of either branch** (status-agnostic by construction), then parked where the reader looks:

- **`DataApiValidationError`** — rides the details bag, exactly the way `fields` already survives, landing on `err.details.userMessage`. No constructor signature change. Omitted entirely when unmarked, so an unmarked refusal carries no empty key.
- **`ConcurrentUpdateError`** — a new readonly `userMessage` member, because this class has no details bag. This is the one place the card flagged as wanting a ruling ("whether these should declare it as a typed member"); there is nowhere else to put it, so it is declared, additively and optionally.

## T3 — ablations, predicted before running

Prediction recorded **before** the run. Ablation = revert *only* the two constructor call sites (the card's literal fix shape), keeping the helper and the class member, so it removes the carry and nothing else.

Mutation confirmed on disk before measuring — injected text present (1), both deleted anchors at 0, and blob hash `19c8dfc1` → `b029fa67` (≠ HEAD, so the ablation provably ran). No `dist` rebuild needed: the root vitest config aliases both `@object-ui/data-objectstack` and `@object-ui/react` to `src`, so the suites execute the mutated source directly.

| | Predicted | Actual |
|---|---|---|
| `userMessage-normalisation.test.ts` | 5 failing | **5 failing** |
| `error-message.normalisation-boundary.test.ts` | 2 failing | **2 failing** |
| **Total** | **7 failing / 2 files** | **7 failed \| 6 passed (13)**, 2 files |

`Tests  7 failed | 6 passed (13)` — and the seven were the seven predicted, test-for-test by name. **I was not wrong anywhere**; direction was red as predicted. The 403 passthrough control **passed** under ablation, proving the ablation was targeted at the re-wraps rather than at the reader.

Restore leg proven by state, not by exit code: `git diff HEAD` empty, `git status` clean, and the blob hash back to `19c8dfc1…` — byte-identical to HEAD. Re-ran green afterwards: `Test Files 2 passed (2) / Tests 13 passed (13)`.

## T4 — existing behaviour not degraded

**No existing assertion was edited.** The diff is 4 files: one source file, two *new* test files, one changeset. The pre-existing pins for the per-field behaviour (`validation-error.test.ts`, `occ.test.ts`, `errors.test.ts`, `error-message.test.ts`) all stay green **unchanged**, and a new assertion pins the per-field entries *alongside* the marking so the two cannot drift apart.

## Gates

Gate set derived by reading the CI job step lists under `.github/workflows/` — not from memory. Exit codes captured **before** any pipe; verdicts quoted from each gate's own line.

| Gate | Exit | Its own verdict line |
|---|---|---|
| `vitest` (union, at `a67da4612`) | 0 | `Test Files  50 passed (50)` / `Tests  667 passed (667)` |
| `check:changeset-presence` | 0 | `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | 0 | `✅  No changeset declares a 'major' bump.` |
| `check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 5238 tracked text file(s); skipped 85 binary).` |
| `check:phantom-deps` | 0 | `✅  Every in-scope import is declared by the package that publishes it.` |
| `check:self-import` | 0 | `✅  No package names itself inside its own src/.` |
| `check:esm-specifiers` | 0 | (clean, no findings emitted) |
| `check:entry-guard` | 0 | (clean, no findings emitted) |
| `check:spec-symbols` | 0 | `✅  spec symbol derivation: 1306 files scanned against 4959 spec export names` |
| `check:readme-exports` | 0 | `✅  check-readme-exports: OK (43 README(s) …, 3245 export symbol(s) … 0 unbuilt)` |
| `check:published-dist` | 0 | `✅  No published package's build output carries tooling material.` |
| `check:node-esm-load` | 0 | (clean, no findings emitted) |
| `eslint` (3 changed source files) | 0 | `files linted: 3 \| errors: 0 \| warnings: 121` |
| `type-check` — `data-objectstack`, `react`, `plugin-form` | 0 | each echoed its own script name (not a zero-match) |
| `check:spec-floors` | 1 | ⚠️ **pre-existing, filed as #6361 — not caused by this PR** |
| `turbo run type-check` (repo-wide) | — | **NOT RUN — narrowed, declared below** |

### `check:spec-floors` — pre-existing, and not this PR's

Red on `main` independent of this change: it reports `floor-too-low` for four *sortability* symbols in `@object-ui/core` and `@object-ui/data-objectstack`. Those symbols appear **0 times** in `packages/data-objectstack/src/index.ts` both at `194fae184` and here; this PR modifies no `package.json`; and this PR's own new `import type { ApiError }` produced **0** findings. It is also deliberately **not** a `pull_request` job (`⛔ Do not add pull_request here`) — but it *does* block `changeset:publish`, so it is filed as **#6361** rather than left silent.

### Declared narrowing — repo-wide `type-check`

`turbo run type-check` exceeded the foreground budget (killed at 520s, exit 124), so the repo-wide run is CI's. The narrowing is a **measurement**, not a skip:

1. **Population from the tool's own config** — each package's own `tsconfig.json`, the same config the gate runs, via `tsc -p <pkg>/tsconfig.json --listFiles`.
2. **Counts from the tool's output** — `data-objectstack`: `index.ts` 1 hit, new test 1 hit (both compiled). `react`: `error-message.ts` 1 hit, new boundary test **0 hits**.
3. **Invariance for untouched files** — `tsc` here is per-package with project references; this diff changes no `tsconfig`, no manifest, and adds only an *additive optional* member to an exported class, which cannot move an untouched package's verdict. The downstream consumer sweep was run in the **dependent** direction (`grep` for the widened symbols across all 9 packages depending on `data-objectstack`): only `plugin-form` consumes them, and its `type-check` is green.

⚠️ **One honest NOT MEASURED:** `packages/react/tsconfig.json` excludes `**/*.test.ts`, so `react`'s `type-check` says **nothing** about the new boundary test file (`--listFiles`: 0 hits). It is exercised at runtime by vitest and is consistent with every existing react test file, but its *types* are unchecked by that gate. Reporting it as unmeasured rather than green.

## Note for #5902

Deliberately **not** touched here — the kanban and calendar surfaces were read for evidence only. Three findings for that dispatch:

- `plugin-form/src/occSave.tsx:151` reads `currentVersion` off the conflict error but has **no** `userMessage` reader — a third surface beyond kanban and calendar.
- The `form.tsx` early-return above means a fully-attributed `VALIDATION_FAILED` never reaches `declaredUserMessage`; a surface wanting the marking on that path needs its own read.
- `ConcurrentUpdateError.userMessage` is now a typed member, so those surfaces can read it directly without duck-typing.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_