### PR TITLE
fix(plugin-grid): guard useRowColor's object-literal lookups with hasOwnProperty

### DIFF
--- a/.changeset/rowcolor-prototype-guard-6295.md
+++ b/.changeset/rowcolor-prototype-guard-6295.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+Guard `useRowColor`'s two object-literal lookups with `Object.prototype.hasOwnProperty.call`.
+
+Both `config.colors` (the authored map) and the module's `COLOR_TO_CLASS` literal inherit
+`Object.prototype`, and both were reached with a bare index. A record whose colour field
+held `constructor`, `toString`, `valueOf` or `hasOwnProperty` resolved to an inherited
+function: the `if (!color)` guard passed it (functions are truthy) and `colorToClass` then
+called `.startsWith` on it, throwing a `TypeError` inside the row-className resolver during
+render — a grid crash triggered by record data rather than by metadata. The same shape one
+call deeper in `colorToClass` did not throw; it handed an `Object.prototype` member back as
+the row's `className`, which reached React as a class attribute. Both now resolve to
+`undefined`, as an undeclared value always did.

--- a/packages/plugin-grid/src/__tests__/useRowColor.prototypeGuard.test.tsx
+++ b/packages/plugin-grid/src/__tests__/useRowColor.prototypeGuard.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { RowColorConfig } from '@object-ui/types';
+import { useRowColor } from '../useRowColor';
+
+/**
+ * objectui#6295 — `useRowColor` reached two plain object literals with a bare
+ * index, and both inherit `Object.prototype`. The two halves fail differently,
+ * so they are pinned separately below:
+ *
+ *   :67  `config.colors[value]`, where `value` comes from RECORD DATA. An
+ *        inherited member is a function, `if (!color)` passes it (truthy), and
+ *        `colorToClass` calls `.startsWith` on it — a TypeError thrown inside
+ *        the row-className resolver during render. LOUD: the grid crashes, and
+ *        the trigger is data, not metadata.
+ *
+ *   :52  `COLOR_TO_CLASS[lower]`, one call deeper, where `lower` comes from the
+ *        AUTHORED colour value. This one never threw: it returned the inherited
+ *        member, so a function left the resolver as the row's `className` and
+ *        reached React as a class attribute. QUIET, and the same defect.
+ *
+ * Shape mirrors `packages/plugin-detail/src/headerColor.ts` (objectui#6178 /
+ * PR objectui#6294), which guarded the analogous lookup one package over.
+ */
+
+/** Render the hook and hand back the row-className resolver it produces. */
+function resolverFor(config: RowColorConfig) {
+  return renderHook(() => useRowColor(config)).result.current;
+}
+
+/**
+ * The names every plain object literal inherits from `Object.prototype`.
+ *
+ * All of them reach the `:67` read, which indexes the authored map with the
+ * record value VERBATIM.
+ */
+const INHERITED_MEMBERS: string[] = [
+  'constructor',
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+  '__proto__',
+];
+
+/**
+ * The subset that reaches the `:52` read — and the reason this list is SHORTER
+ * than the one above, which is easy to "helpfully" expand back into ghost
+ * assertions.
+ *
+ * `colorToClass` lower-cases before indexing (`color.toLowerCase().trim()`), so
+ * `toString` arrives as `tostring`, `valueOf` as `valueof`, and so on — none of
+ * which is an inherited member. Only the two names that are ALREADY lower-case
+ * survive the transform and actually hit `Object.prototype`. Measured against
+ * unmodified `main`: the six camelCase names return `undefined` there too, so
+ * asserting them here would assert nothing.
+ */
+const LOWERCASE_INHERITED_MEMBERS: string[] = ['constructor', '__proto__'];
+
+/**
+ * The degenerate control. `open` -> `bg-green-100` is the fixture that proves
+ * the guard did not simply switch ordinary lookups off; it is asserted first,
+ * and it is green both before and after the fix.
+ */
+const CONTROL_CONFIG: RowColorConfig = {
+  field: 'status',
+  colors: { open: 'green', closed: 'red', urgent: 'bg-red-200' },
+};
+
+describe('useRowColor — ordinary lookups still work (degenerate control)', () => {
+  it('resolves an authored colour name to its Tailwind class', () => {
+    const resolve = resolverFor(CONTROL_CONFIG);
+    expect(resolve({ status: 'open' })).toBe('bg-green-100');
+    expect(resolve({ status: 'closed' })).toBe('bg-red-100');
+  });
+
+  it('passes a value that is already a bg-* class through untouched', () => {
+    expect(resolverFor(CONTROL_CONFIG)({ status: 'urgent' })).toBe('bg-red-200');
+  });
+
+  it('returns undefined for a value the author did not declare', () => {
+    expect(resolverFor(CONTROL_CONFIG)({ status: 'archived' })).toBeUndefined();
+  });
+});
+
+describe('useRowColor — record data naming an Object.prototype member (:67, the loud half)', () => {
+  it('does not throw when a record colour field holds `constructor`', () => {
+    // The exact chain the card reproduced. Before the fix this threw
+    // `TypeError: color.startsWith is not a function`.
+    const resolve = resolverFor(CONTROL_CONFIG);
+    expect(() => resolve({ status: 'constructor' })).not.toThrow();
+    expect(resolve({ status: 'constructor' })).toBeUndefined();
+  });
+
+  it.each(INHERITED_MEMBERS)('resolves to undefined for a record value of %s', (member) => {
+    expect(resolverFor(CONTROL_CONFIG)({ status: member })).toBeUndefined();
+  });
+
+  it('is inert even when the author declared no colours at all', () => {
+    // The authored map does not have to mention the value for the crash: the
+    // inherited member is found whether or not anything was declared.
+    const resolve = resolverFor({ field: 'status', colors: {} });
+    for (const member of INHERITED_MEMBERS) {
+      expect(() => resolve({ status: member })).not.toThrow();
+      expect(resolve({ status: member })).toBeUndefined();
+    }
+  });
+});
+
+describe('useRowColor — COLOR_TO_CLASS cannot emit an inherited member (:52, the quiet half)', () => {
+  it.each(LOWERCASE_INHERITED_MEMBERS)(
+    'returns undefined when the authored colour value is %s',
+    (member) => {
+      const resolve = resolverFor({ field: 'status', colors: { open: member } });
+      expect(resolve({ status: 'open' })).toBeUndefined();
+    },
+  );
+
+  it('never hands back a non-string as the row className', () => {
+    // The property that matters at the call site: `getRowClassName(row)` feeds
+    // `rowClassName` in ObjectGrid, so anything but a string or undefined is a
+    // class attribute React should never have been handed.
+    for (const member of LOWERCASE_INHERITED_MEMBERS) {
+      const cls = resolverFor({ field: 'status', colors: { open: member } })({ status: 'open' });
+      expect(cls === undefined || typeof cls === 'string').toBe(true);
+      expect(typeof cls).not.toBe('function');
+    }
+  });
+});

--- a/packages/plugin-grid/src/useRowColor.ts
+++ b/packages/plugin-grid/src/useRowColor.ts
@@ -49,7 +49,15 @@ function colorToClass(color: string): string | undefined {
   if (color.startsWith('bg-')) return color;
 
   const lower = color.toLowerCase().trim();
-  return COLOR_TO_CLASS[lower];
+  // `hasOwnProperty` rather than a bare index (objectui#6295, the quiet half):
+  // this object literal inherits `constructor`, `toString` and friends, so an
+  // authored colour value naming one of them used to hand the inherited member
+  // back as the row's className. That never threw — it reached React as a class
+  // attribute. (`Object.hasOwn` is ES2022; this workspace compiles against the
+  // ES2020 lib.)
+  return Object.prototype.hasOwnProperty.call(COLOR_TO_CLASS, lower)
+    ? COLOR_TO_CLASS[lower]
+    : undefined;
 }
 
 /**
@@ -64,7 +72,17 @@ export function useRowColor(config: RowColorConfig | undefined) {
       if (!config?.field || !config.colors) return undefined;
 
       const value = String(row[config.field] ?? '');
-      const color = config.colors[value];
+      // The same guard one call out, and this read is reached with RECORD DATA
+      // (objectui#6295, the loud half): the authored map inherits
+      // `Object.prototype`, so a record whose colour field holds `constructor` /
+      // `toString` / `valueOf` / `hasOwnProperty` resolved to an inherited
+      // FUNCTION. `if (!color)` below passes it (functions are truthy) and
+      // `colorToClass` then called `.startsWith` on it — a TypeError thrown
+      // inside the row-className resolver during render, crashing the grid on
+      // data rather than on metadata.
+      const color = Object.prototype.hasOwnProperty.call(config.colors, value)
+        ? config.colors[value]
+        : undefined;
       if (!color) return undefined;
 
       return colorToClass(color);


### PR DESCRIPTION
Fixes #6295

`useRowColor` reached two plain object literals with a bare index, and both inherit `Object.prototype`. Both reads are now guarded with `Object.prototype.hasOwnProperty.call`, mirroring the guard #6178 / PR #6294 applied to the analogous lookup in `packages/plugin-detail/src/headerColor.ts`.

## The two halves

**`config.colors[value]` (`:67`) — the loud half.** Indexed with **record data**. A record whose colour field held `constructor` / `toString` / `valueOf` / `hasOwnProperty` resolved to an inherited *function*; `if (!color)` passed it (functions are truthy) and `colorToClass` then called `.startsWith` on it — `TypeError: color.startsWith is not a function`, thrown inside the row-className resolver during render. A grid crash triggered by data rather than by metadata. The authored map does not have to mention the value: an empty `colors: {}` crashes just the same, which this PR pins.

**`COLOR_TO_CLASS[lower]` (`:52`) — the quiet half.** Same shape one call deeper, reached with the *authored* colour value. It never threw; it returned the inherited member, so a **function** left the resolver as the row's `className` and reached React as a class attribute. Fixing only the thrower would have left this.

Both now resolve to `undefined`, exactly as an undeclared value always did.

`Object.hasOwn` is ES2022 and is **not** available here — verified rather than assumed: `tsconfig.json` (which `packages/plugin-grid/tsconfig.json` extends without overriding) sets `"lib": ["ES2020", "DOM", "DOM.Iterable"]`. Worth noting for the next reader: `packages/plugin-grid/tsconfig.test.json` deliberately sits one notch above at `ES2022`, so `Object.hasOwn` *would* have compiled in a test while failing in shipped source.

## Ghost-assertion guard — both readings

New assertions run against **unmodified `origin/main`** (fix not yet applied), then against the fix. Same file, same command.

**Before — 13 failed | 3 passed (16):**

```
FAIL ... (:67, the loud half) > does not throw when a record colour field holds `constructor`
AssertionError: expected [Function] to not throw an error but
  'TypeError: color.startsWith is not a …' was thrown

FAIL ... (:52, the quiet half) > returns undefined when the authored colour value is constructor
AssertionError: expected [Function Object] to be undefined
  - Expected: undefined
  + Received: [Function Object]

FAIL ... (:52, the quiet half) > returns undefined when the authored colour value is __proto__
AssertionError: expected { …(12) } to be undefined
  + Received: {}
```

`TypeError: color.startsWith is not a function` appears 4× in that run. All 13 failures are in the two defect describes; the 3 that passed are the control below.

**After — 16 passed (16):**

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

## Degenerate control

The control fixture is **`CONTROL_CONFIG`** — `{ field: 'status', colors: { open: 'green', closed: 'red', urgent: 'bg-red-200' } }` — in `useRowColor — ordinary lookups still work (degenerate control)`. Its three tests (`open` → `bg-green-100`, `closed` → `bg-red-100`, the `bg-*` pass-through, and an undeclared value → `undefined`) are the 3 that were **green both before and after**, so the guard is shown not to have switched ordinary lookups off.

One deliberate asymmetry, called out so nobody "helpfully" widens it into ghost assertions: the quiet half asserts only `constructor` and `__proto__`, not the full eight. `colorToClass` lower-cases before indexing, so `toString` arrives as `tostring`, `valueOf` as `valueof`, and so on — none of which is an inherited member. Measured on unmodified `main`, those six return `undefined` there too, so asserting them would assert nothing. Only the two already-lower-case names actually reach `Object.prototype`. The loud half indexes the record value verbatim, so all eight apply there and all eight are pinned.

## Verification

All readings below are from the **final commit, `e9f263574`** (after merging `origin/main`).

| Check | Result |
|---|---|
| `pnpm exec vitest run packages/plugin-grid/` | `Test Files 91 passed (91)` / `Tests 853 passed (853)`, exit 0 |
| `pnpm --filter @object-ui/plugin-grid type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/plugin-grid lint` | `✖ 691 problems (0 errors, 691 warnings)`, exit 0 |
| `node scripts/check-changeset-presence.mjs` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |

**Lint delta measured, not assumed.** `useRowColor.ts` carries two warnings (`react-hooks/preserve-manual-memoization`, `@typescript-eslint/no-explicit-any`). Both are **pre-existing**: eslint `--format json` on the file at `origin/main` and at this branch returns identical per-rule counts (`{preserve-manual-memoization: 1, no-explicit-any: 1}`, `errorCount=0` both). This change introduces no new lint finding.

**Typecheck coverage proven, not inferred.** `packages/plugin-grid/tsconfig.json` excludes `**/__tests__/**`, so "typecheck clean" could have been true while saying nothing about the new test. `tsc --listFiles` confirms both changed files are real program inputs — `useRowColor.prototypeGuard.test.tsx` in the `tsconfig.test.json` program, `useRowColor.ts` in the build program.

**Declared narrowing.** Local verification is scoped to `@object-ui/plugin-grid` (its full suite, its typecheck, its lint) plus the repo-wide changeset-presence check — not a repo-wide `pnpm lint`/`pnpm test`. CI runs the full farm regardless; this is a declared narrowing, not a skipped check.

## Scope

`packages/plugin-grid/src/useRowColor.ts` (the two index reads only), one new test file, one changeset. The colour-resolution flow, the authored `colors` map shape, and `plugin-detail`'s already-fixed sibling are untouched. No edits to `content/docs/releases/`.

Draft, and staying draft — the PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_