### PR TITLE
fix(chatbot): accept the landed AI quota ledger vocabulary (four dialects)

### DIFF
--- a/.changeset/ai-quota-ledger-vocabulary-3804.md
+++ b/.changeset/ai-quota-ledger-vocabulary-3804.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/plugin-chatbot': patch
+---
+
+Recognize the landed AI quota ledger vocabulary in the chat error path
+
+`parseAiQuotaError` now accepts the three SCREAMING_SNAKE ledger codes the cloud
+token guardrail emits (`AI_ALLOWANCE_EXHAUSTED`, `AI_DESIGN_QUOTA_EXHAUSTED`,
+`AI_DATA_CHAT_TRIAL_EXHAUSTED`) alongside the legacy lowercase trio, which stays
+readable for producers that have not converged yet. The companion fields
+(`messageEn` / `upgrade` / `topUp` / `resetsTonight`) are now read from the
+declared envelope's `error.details` as well as their legacy top-level position,
+with the declared position winning.
+
+A quota-exhausted user gets the upgrade / top-up CTA again instead of the
+generic "Response failed" banner. The per-turn message cap's generic
+`QUOTA_EXCEEDED` deliberately keeps its existing rate-limit path — it has no
+upgrade or top-up next step.

--- a/packages/plugin-chatbot/src/tool-display.test.ts
+++ b/packages/plugin-chatbot/src/tool-display.test.ts
@@ -82,20 +82,48 @@ describe('parseAiQuotaError', () => {
     expect(parseAiQuotaError('')).toBeNull();
   });
 
-  // The three-dialect matrix (objectui#3491 / cloud#944). The two live producers
-  // fill `error` in opposite ways and ADR-0112 declares a third shape they are
-  // converging on (cloud#1168); every one of them must be readable HERE before
-  // any producer moves, and every one must miss on a non-quota code.
+  // The FOUR-dialect matrix (objectui#3491 / cloud#944, widened by
+  // objectui#3804). The two live producers fill `error` in opposite ways,
+  // ADR-0112 declares the envelope shape, and cloud#1168 -> cloud PR #1238
+  // landed the fourth: that envelope carrying the SCREAMING_SNAKE ledger
+  // vocabulary with the companions inside `error.details`. Every one of them
+  // must be readable HERE, and every one must miss on a non-quota code.
+  //
+  // ⚠️ DEGENERATE-CONTROL NOTE. This file already exercised the lowercase trio
+  // heavily, so a lowercase-only case proves nothing about this change: it
+  // passes against the unfixed code too. The assertions that actually pin the
+  // NEW behavior are exactly (a) everything driven by `LEDGER_CODES`, and
+  // (b) the `declared envelope + ledger vocabulary` describe below, including
+  // its `error.details` companion reads (which fail on the old code even with
+  // a lowercase code, because `error.details` was not read at all).
   describe('dialect matrix', () => {
     const err = (payload: unknown) => new Error(JSON.stringify(payload));
+    // Legacy vocabulary — transition-period producers still emit it.
     const CODES = [
       'ai_design_quota_exhausted',
       'ai_data_chat_trial_exhausted',
       'ai_allowance_exhausted',
     ] as const;
+    // Ledger vocabulary landed by cloud PR #1238. NEW-BEHAVIOR assertions.
+    const LEDGER_CODES = [
+      'AI_DESIGN_QUOTA_EXHAUSTED',
+      'AI_DATA_CHAT_TRIAL_EXHAUSTED',
+      'AI_ALLOWANCE_EXHAUSTED',
+    ] as const;
 
     describe('flat guardrail dialect — `error` holds the code', () => {
       it.each(CODES)('hits on %s', (code) => {
+        expect(parseAiQuotaError(err({ error: code, message: 'zh', upgrade: true }))).toMatchObject({
+          code,
+          message: 'zh',
+          upgrade: true,
+        });
+      });
+
+      // NEW BEHAVIOR: the guardrail's flat limb now speaks the ledger
+      // vocabulary too, so a producer that converged its CODE before its SHAPE
+      // is still parsed.
+      it.each(LEDGER_CODES)('hits on the ledger code %s', (code) => {
         expect(parseAiQuotaError(err({ error: code, message: 'zh', upgrade: true }))).toMatchObject({
           code,
           message: 'zh',
@@ -124,9 +152,17 @@ describe('parseAiQuotaError', () => {
         ).toMatchObject({ code: 'ai_allowance_exhausted', message: prose });
       });
 
+      // NEW BEHAVIOR: same limb, ledger vocabulary.
+      it.each(LEDGER_CODES)('hits on the ledger code %s', (code) => {
+        expect(
+          parseAiQuotaError(err({ error: '', code, resetAt: '2026-08-09T00:00:00Z' })),
+        ).toMatchObject({ code, message: '' });
+      });
+
       it('misses on the code service-ai emits today, which is not in the set', () => {
-        // Documents a real remaining gap rather than asserting it away: the
-        // shape is now readable, the vocabulary is cloud#1168's to align.
+        // Documents a real remaining gap rather than asserting it away. Still
+        // a gap after cloud#1238: `ai_quota_exhausted` is in NEITHER vocabulary
+        // — not the legacy trio, not the ledger trio.
         expect(
           parseAiQuotaError(err({ error: '', code: 'ai_quota_exhausted', resetAt: 'x' })),
         ).toBeNull();
@@ -135,6 +171,14 @@ describe('parseAiQuotaError', () => {
 
     describe('declared envelope (ADR-0112) — code nested under `error`', () => {
       it.each(CODES)('hits on %s', (code) => {
+        expect(
+          parseAiQuotaError(err({ success: false, error: { code, message: 'zh' } })),
+        ).toMatchObject({ code, message: 'zh' });
+      });
+
+      // NEW BEHAVIOR: the envelope now carries the ledger vocabulary, which is
+      // the only vocabulary a spec-conformant `error.code` may use.
+      it.each(LEDGER_CODES)('hits on the ledger code %s', (code) => {
         expect(
           parseAiQuotaError(err({ success: false, error: { code, message: 'zh' } })),
         ).toMatchObject({ code, message: 'zh' });
@@ -150,6 +194,171 @@ describe('parseAiQuotaError', () => {
 
       it('misses when the nested error carries no code at all', () => {
         expect(parseAiQuotaError(err({ success: false, error: { message: 'zh' } }))).toBeNull();
+      });
+    });
+
+    // ---- THE FOURTH DIALECT (objectui#3804) --------------------------------
+    // What cloud PR #1238 actually shipped: the declared envelope, the ledger
+    // vocabulary, and the companion fields nested inside `error.details`.
+    // EVERY assertion in this describe is a new-behavior assertion — the old
+    // code never read `error.details` at all, so even the lowercase-code case
+    // here fails against origin/main.
+    describe('declared envelope + ledger vocabulary — companions in `error.details`', () => {
+      const landed = (code: string) => ({
+        success: false,
+        error: {
+          code,
+          message: 'zh',
+          details: {
+            messageEn: 'Your AI allowance is used up.',
+            upgrade: false,
+            topUp: true,
+            resetsTonight: true,
+          },
+        },
+      });
+
+      it.each(LEDGER_CODES)('reads %s with its nested companion fields', (code) => {
+        expect(parseAiQuotaError(err(landed(code)))).toEqual({
+          code,
+          message: 'zh',
+          messageEn: 'Your AI allowance is used up.',
+          upgrade: false,
+          topUp: true,
+          resetsTonight: true,
+        });
+      });
+
+      it('prefers the declared `error.details` companions over the legacy top-level ones', () => {
+        // The realistic transitional producer double-emits. The declared
+        // position wins, matching the total order the code lookup already uses.
+        expect(
+          parseAiQuotaError(
+            err({
+              success: false,
+              error: {
+                code: 'AI_ALLOWANCE_EXHAUSTED',
+                message: 'zh',
+                details: { messageEn: 'nested', upgrade: true, topUp: false },
+              },
+              messageEn: 'top-level',
+              upgrade: false,
+              topUp: true,
+            }),
+          ),
+        ).toMatchObject({
+          messageEn: 'nested',
+          upgrade: true,
+          topUp: false,
+        });
+      });
+
+      it('falls back to the top-level companions when the envelope carries no details', () => {
+        // The legacy limb stays reachable — this is the shape a producer that
+        // moved its CODE but not its COMPANIONS emits.
+        expect(
+          parseAiQuotaError(
+            err({
+              success: false,
+              error: { code: 'AI_DESIGN_QUOTA_EXHAUSTED', message: 'zh' },
+              messageEn: 'top-level',
+              upgrade: true,
+            }),
+          ),
+        ).toMatchObject({
+          code: 'AI_DESIGN_QUOTA_EXHAUSTED',
+          messageEn: 'top-level',
+          upgrade: true,
+          topUp: false,
+        });
+      });
+
+      it('leaves resetsTonight undefined unless a producer sends an actual boolean', () => {
+        // The POSITION of this field is measured (cloud#1238 puts it in
+        // `error.details`); its TYPE is not pinned by anything we can read from
+        // this repo. So a non-boolean is dropped rather than coerced into a
+        // `false` no producer declared.
+        const r = parseAiQuotaError(
+          err({
+            success: false,
+            error: {
+              code: 'AI_ALLOWANCE_EXHAUSTED',
+              details: { resetsTonight: '2026-08-26T00:00:00Z' },
+            },
+          }),
+        );
+        expect(r?.resetsTonight).toBeUndefined();
+        expect(
+          parseAiQuotaError(
+            err({
+              success: false,
+              error: { code: 'AI_ALLOWANCE_EXHAUSTED', details: { resetsTonight: false } },
+            }),
+          )?.resetsTonight,
+        ).toBe(false);
+      });
+
+      it('ignores a non-object `details` instead of throwing', () => {
+        expect(
+          parseAiQuotaError(
+            err({ success: false, error: { code: 'AI_ALLOWANCE_EXHAUSTED', details: [1, 2] } }),
+          ),
+        ).toMatchObject({ code: 'AI_ALLOWANCE_EXHAUSTED', upgrade: false, topUp: false });
+        expect(
+          parseAiQuotaError(
+            err({ success: false, error: { code: 'AI_ALLOWANCE_EXHAUSTED', details: 'nope' } }),
+          ),
+        ).toMatchObject({ code: 'AI_ALLOWANCE_EXHAUSTED', upgrade: false, topUp: false });
+      });
+    });
+
+    // ---- THE VOCABULARY THAT STAYS GENERIC (objectui#3804) -----------------
+    // cloud PR #1238 deliberately left `POST /api/v1/ai/agents/:name/chat`'s
+    // per-turn message cap on the standard `QUOTA_EXCEEDED`: it has no upgrade
+    // / top-up / trial next step, which is the exact distinction the 2026-08-11
+    // Option A ruling drew when admitting the three `AI_*` codes to the ledger.
+    //
+    // ⚠️ These assertions PASS against origin/main as well — they are
+    // regression pins for behavior this PR PRESERVES, not new-behavior
+    // assertions. They exist because the cross-seat relay asked for a pin that
+    // per-turn 429s keep being handled, and this is where that handling lives.
+    describe('generic QUOTA_EXCEEDED (per-turn cap) keeps the rate-limit path', () => {
+      const perTurn = {
+        success: false,
+        error: {
+          code: 'QUOTA_EXCEEDED',
+          message: 'zh',
+          category: 'rate_limit',
+          details: { resetAt: '2026-08-26T00:00:00Z' },
+        },
+      };
+
+      it('is not a quota-CTA refusal, so no upgrade / top-up CTA is offered', () => {
+        // Recognizing it here would render ErrorBanner's "Upgrade needed" +
+        // "Upgrade plan" to a user whose cap resets in a minute.
+        expect(parseAiQuotaError(err(perTurn))).toBeNull();
+      });
+
+      it('routes to the unsent rate-limit notice instead', () => {
+        // ChatbotEnhanced renders SendErrorNotice (with the "you're sending
+        // too quickly" copy and the typed text restored) exactly when
+        // `isUnsentSendError(e) && !parseAiQuotaError(e)`.
+        const e = tagged(429, JSON.stringify(perTurn));
+        expect(isUnsentSendError(e)).toBe(true);
+        expect(isRateLimitError(e)).toBe(true);
+        expect(isUnsentSendError(e) && !parseAiQuotaError(e)).toBe(true);
+      });
+
+      it('a non-quota 429 still falls through to the generic path', () => {
+        const e = tagged(
+          429,
+          JSON.stringify({
+            success: false,
+            error: { code: 'RATE_LIMIT_EXCEEDED', message: 'zh' },
+          }),
+        );
+        expect(parseAiQuotaError(e)).toBeNull();
+        expect(isUnsentSendError(e) && !parseAiQuotaError(e)).toBe(true);
       });
     });
 

--- a/packages/plugin-chatbot/src/tool-display.ts
+++ b/packages/plugin-chatbot/src/tool-display.ts
@@ -145,8 +145,22 @@ export function summarizeChatError(err: unknown): {
   };
 }
 
-/** AI quota refusal codes emitted by the cloud token guardrail (HTTP 429). */
+/**
+ * AI quota refusal codes emitted by the cloud token guardrail (HTTP 429).
+ *
+ * TWO vocabularies, both live. cloud#1238 (the cloud#1168 convergence) landed
+ * the SCREAMING_SNAKE ledger codes — which is what a spec-conformant
+ * `error.code` must be, an `ErrorCode` ledger member. The lowercase trio is
+ * the legacy vocabulary that transition-period producers still emit, so it is
+ * KEPT rather than swapped out: dropping it would silently stop parsing every
+ * producer that has not converged yet (objectui#3804).
+ */
 export type AiQuotaCode =
+  // Ledger vocabulary (cloud#1238) — registered `ErrorCode` members.
+  | 'AI_DESIGN_QUOTA_EXHAUSTED'
+  | 'AI_DATA_CHAT_TRIAL_EXHAUSTED'
+  | 'AI_ALLOWANCE_EXHAUSTED'
+  // Legacy vocabulary — still emitted by producers that have not converged.
   | 'ai_design_quota_exhausted'
   | 'ai_data_chat_trial_exhausted'
   | 'ai_allowance_exhausted';
@@ -161,9 +175,23 @@ export interface AiQuotaError {
   upgrade: boolean;
   /** Paid tier -> buy a credit top-up pack. */
   topUp: boolean;
+  /**
+   * The allowance replenishes at the next daily reset, so "wait" is a real
+   * option alongside the CTA. Only set when the producer sends an actual
+   * boolean: the landed envelope carries this inside `error.details`
+   * (cloud#1238) and that POSITION is measured, but an absent or
+   * otherwise-typed value stays `undefined` rather than being coerced to a
+   * `false` no producer declared.
+   */
+  resetsTonight?: boolean;
 }
 
 const AI_QUOTA_CODES = new Set<string>([
+  // Ledger vocabulary (cloud#1238).
+  'AI_DESIGN_QUOTA_EXHAUSTED',
+  'AI_DATA_CHAT_TRIAL_EXHAUSTED',
+  'AI_ALLOWANCE_EXHAUSTED',
+  // Legacy vocabulary, still live during the transition.
   'ai_design_quota_exhausted',
   'ai_data_chat_trial_exhausted',
   'ai_allowance_exhausted',
@@ -186,6 +214,24 @@ function asText(value: unknown): string | undefined {
 }
 
 /**
+ * The first candidate that is an actual boolean, or undefined. Lets the
+ * declared `error.details` position win over the legacy top-level one while a
+ * non-boolean (`'true'`, `1`) is ignored exactly as the old `=== true` read
+ * ignored it.
+ */
+function asOptionalFlag(...candidates: unknown[]): boolean | undefined {
+  for (const candidate of candidates) {
+    if (typeof candidate === 'boolean') return candidate;
+  }
+  return undefined;
+}
+
+/** {@link asOptionalFlag} for the CTA flags, which are never absent. */
+function asFlag(...candidates: unknown[]): boolean {
+  return asOptionalFlag(...candidates) ?? false;
+}
+
+/**
  * Recognize the cloud AI token guardrail's 429 quota refusals so the chat UI can
  * show a friendly upgrade / top-up CTA instead of a generic "response failed".
  *
@@ -194,26 +240,39 @@ function asText(value: unknown): string | undefined {
  * strip the same retry/format prefixes summarizeChatError handles, locate the
  * JSON object, and find the code in it. Returns null for anything else.
  *
- * ## Three dialects, one code set
+ * ## Four dialects, two vocabularies
  *
- * The two cloud 429 producers fill the same `error` key in OPPOSITE ways, and
- * ADR-0112 declares a third shape they are converging on (objectui#3491,
- * cloud#944). All three are read here so the consumer is ready BEFORE the
- * producers move (cloud#1168) — the alternative is a silent misfit at the
- * moment they converge:
+ * The two cloud 429 producers fill the same `error` key in OPPOSITE ways
+ * (objectui#3491, cloud#944), and ADR-0112's declared envelope has now LANDED
+ * on the producer side (cloud#1168 -> cloud PR #1238), adding a fourth
+ * dialect: the declared envelope carrying the SCREAMING_SNAKE ledger
+ * vocabulary with its companion fields inside `error.details`. All four are
+ * read here, because the producers converge asymmetrically and the legacy
+ * dialects are still live (objectui#3804):
  *
- * | dialect                      | shape                                          |
- * |------------------------------|------------------------------------------------|
- * | declared envelope (ADR-0112) | `{ success: false, error: { code, message } }`  |
- * | flat guardrail               | `{ error: CODE, message, upgrade, topUp }`     |
- * | service-ai sibling key       | `{ error: PROSE, code: CODE }`                 |
+ * | dialect                       | shape                                           |
+ * |-------------------------------|-------------------------------------------------|
+ * | declared envelope + ledger    | `{ error: { code: AI_*, message, details } }`    |
+ * | declared envelope + legacy    | `{ success: false, error: { code, message } }`   |
+ * | flat guardrail                | `{ error: CODE, message, upgrade, topUp }`       |
+ * | service-ai sibling key        | `{ error: PROSE, code: CODE }`                   |
  *
- * Only the code's LOCATION widens; the recognized code set is unchanged, so an
- * unknown shape still degrades to today's behavior (null). Note that a
- * spec-conformant `error.code` must be an `ErrorCode` ledger member
- * (SCREAMING_SNAKE) and none of these three codes is registered today, so the
- * nested branch matches the legacy vocabulary only — aligning the vocabulary is
- * cloud#1168's call and needs a follow-up here, not a guess now.
+ * Both the code's LOCATION and the recognized code SET widen; an unknown shape
+ * still degrades to today's behavior (null).
+ *
+ * ## What this deliberately does NOT recognize: generic `QUOTA_EXCEEDED`
+ *
+ * `POST /api/v1/ai/agents/:name/chat`'s per-turn message cap keeps emitting the
+ * standard `QUOTA_EXCEEDED` (`error.details.resetAt`, `category: 'rate_limit'`)
+ * and did NOT move to the three `AI_*` codes — it has no upgrade / top-up /
+ * trial next step, which is exactly the distinction the 2026-08-11 Option A
+ * ruling drew when it admitted the three codes to the closed ledger.
+ *
+ * It is NOT dropped, it is handled one branch along: `isUnsentSendError` +
+ * `isRateLimitError` route it to the "you're sending too quickly" notice, with
+ * the user's text restored. Returning an `AiQuotaError` for it here would put
+ * an "Upgrade plan" CTA in front of a user whose cap resets in a minute.
+ * `tool-display.test.ts` pins that routing so the split cannot close silently.
  *
  * ## Parse priority (a total order, deliberately)
  *
@@ -247,6 +306,15 @@ export function parseAiQuotaError(err: unknown): AiQuotaError | null {
       ? (body.error as Record<string, unknown>)
       : undefined;
 
+  // The declared envelope nests the companion fields under `error.details`
+  // (cloud#1238); the legacy flat dialects keep them top-level. Same total
+  // order as the code itself — the declared position wins, and the legacy limb
+  // stays reachable when the declared one is absent.
+  const details =
+    nested?.details && typeof nested.details === 'object' && !Array.isArray(nested.details)
+      ? (nested.details as Record<string, unknown>)
+      : undefined;
+
   const flatCode = asAiQuotaCode(body.error);
   const code = asAiQuotaCode(nested?.code) ?? flatCode ?? asAiQuotaCode(body.code);
   if (!code) return null;
@@ -261,13 +329,13 @@ export function parseAiQuotaError(err: unknown): AiQuotaError | null {
       // its own code ('ai_allowance_exhausted') to the user as the message.
       (flatCode ? undefined : asText(body.error)) ??
       '',
-    // Companion fields keep their established top-level read. Their position in
-    // the declared envelope is NOT presumed here (`error.details.upgrade`? a
-    // sibling of `error.code`?) — cloud#1168 decides the real shape, and
-    // inventing a nested key now would fossilize a contract nobody agreed to.
-    messageEn: asText(body.messageEn),
-    upgrade: body.upgrade === true,
-    topUp: body.topUp === true,
+    // Companion fields: `error.details` is the position cloud#1238 shipped, and
+    // it wins; the top-level read stays for the flat/legacy dialects that still
+    // emit them there. No longer a presumption — the position is measured.
+    messageEn: asText(details?.messageEn) ?? asText(body.messageEn),
+    upgrade: asFlag(details?.upgrade, body.upgrade),
+    topUp: asFlag(details?.topUp, body.topUp),
+    resetsTonight: asOptionalFlag(details?.resetsTonight, body.resetsTonight),
   };
 }
 


### PR DESCRIPTION
Fixes #3804

All readings below were taken at `7e8272312` (this branch's head).

## What was shipping

`AI_QUOTA_CODES` / `AiQuotaCode` in `packages/plugin-chatbot/src/tool-display.ts` held only the three lowercase legacy literals, and `asAiQuotaCode` is an exact `Set.has`. cloud PR #1238 landed the SCREAMING_SNAKE ledger vocabulary on the producer side, so every converged 429 missed the quota branch and a quota-exhausted user got the generic red "Response failed" banner instead of the upgrade / top-up CTA.

## Changes

1. **Two vocabularies in the code set.** Added `AI_ALLOWANCE_EXHAUSTED`, `AI_DESIGN_QUOTA_EXHAUSTED`, `AI_DATA_CHAT_TRIAL_EXHAUSTED` — **keeping** the lowercase trio, which transition-period producers still emit.
2. **Companion fields read from `error.details`.** `messageEn` / `upgrade` / `topUp` now read from the declared envelope's `error.details` (the position cloud PR #1238 shipped) with the legacy top-level read as the fallback limb. The declared position wins, matching the total order the code lookup already used. Non-boolean flag values are ignored exactly as the old `=== true` read ignored them.
3. **`resetsTonight` added** to `AiQuotaError`, set **only** when a producer sends an actual boolean. The field's *position* is measured; its *type* is not pinned by anything readable from this repo, so an otherwise-typed value stays `undefined` rather than being coerced to a `false` no producer declared.
4. **Dialect matrix widened from three to four.**

## Test readings — ghost-assertion guard (both directions)

The fix file was reverted to unmodified `origin/main` while the new tests stayed in place, then restored.

| leg | command | reading |
|---|---|---|
| **RED** — `tool-display.ts` at `origin/main`, new tests present | `pnpm exec vitest run packages/plugin-chatbot/src/tool-display.test.ts` | `Test Files 1 failed (1)` · **`Tests 16 failed \| 33 passed (49)`** · exit 1 |
| **GREEN** — fix restored | same command | `Test Files 1 passed (1)` · **`Tests 49 passed (49)`** · exit 0 |

**Mutation proven on disk before measuring**, not inferred from an exit code: uppercase-code occurrences in the file went `6 → 0` and `nested.details` reads `1 → 0`; the mutated blob hash equalled the `origin/main` blob and differed from the HEAD blob.

**Restore proven on disk**: restored blob `652041b63c16cad90f8ac4342431747d83a544c9` matched the HEAD blob, `git diff HEAD --stat` was empty, and the uppercase count was back to `6`.

⚠️ Recorded because it nearly became a false reading: the **first** ablation attempt named a mistyped path (`tool-display.tsest.ts`) and exited 1 with `No test files found`. That is a zero-match exit, **not** a red gate — it was discarded and the ablation was re-run with the correct path. The 16-failure reading above is the real one.

### The 16 failing assertions were exactly the new-behavior ones

- 9 × `it.each(LEDGER_CODES)` — three uppercase codes across each of the three pre-existing dialects (flat guardrail, service-ai sibling key, declared envelope).
- 7 × the new `declared envelope + ledger vocabulary — companions in error.details` describe.

## Degenerate-control guard

`tool-display.test.ts` already exercised the lowercase trio heavily, so a lowercase-only case proves nothing — it passes against the unfixed code. **The assertions that actually pin this change are:**

1. Everything driven by the new `LEDGER_CODES` constant (the three uppercase literals).
2. The whole `declared envelope + ledger vocabulary` describe — including its `error.details` reads, which fail against `origin/main` **even with a lowercase code**, because `error.details` was not read at all before.

Both groups are called out in an in-file `DEGENERATE-CONTROL NOTE` comment so the next reader does not have to re-derive it.

### No existing assertion weakened or deleted

`git diff -U0 <base> -- packages/plugin-chatbot/src/tool-display.test.ts | grep '^-'` returns **six lines, all comments** — zero `it(` and zero `expect(` lines removed. The two pre-existing `QUOTA_EXCEEDED` assertions (`misses on a declared non-quota code`, `falls through to a legacy limb when the nested code is unrecognized`) are untouched and still green. One stale comment was refreshed: it said the `ai_quota_exhausted` gap was "cloud#1168's to align", which has now resolved — the assertion itself is unchanged and still correct, since `ai_quota_exhausted` is in *neither* vocabulary.

## ⚠️ One dispatch instruction was NOT executed — this needs a ruling

The dispatch order said to accept **three** vocabularies, including generic `QUOTA_EXCEEDED`, in `parseAiQuotaError`. **That one item is not implemented here, on measured grounds.** Everything else in the order is.

**What the consumer actually does today** (`packages/plugin-chatbot/src/ChatbotEnhanced.tsx`):

- `sendAwareFetch` tags every non-2xx with `notSent: true` and `status` (`useObjectChat.ts`).
- Line 2990 renders `SendErrorNotice` when `isUnsentSendError(error) && !parseAiQuotaError(error)`.
- So a per-turn-cap 429 **is already handled**: `isRateLimitError` sees status 429 and the user gets *"You're sending messages too quickly. Your message is kept below — wait a moment and try again."* with the typed text restored. Correct copy for a cap that resets in a minute.

**What adding `QUOTA_EXCEEDED` to the set would do:** `parseAiQuotaError` returns truthy, the predicate flips, and `ErrorBanner` renders instead — title **"Upgrade needed"** (unconditional, `ChatbotEnhanced.tsx:4026`) plus, when the host wires `onUpgrade`, an **"Upgrade plan"** button. `packages/app-shell/src/console/ai/AiChatPage.tsx:2182` wires exactly that, to `window.open(cloudPricingDeepLink())`. A user who hit the per-turn message cap would be sent to the **pricing page**.

That contradicts the 2026-08-11 Option A rationale it was meant to serve — the three `AI_*` codes were admitted to the closed ledger *because* they carry distinct CTAs, while the per-turn cap deliberately stayed generic for having none.

**The cross-seat relay's premise appears to be inaccurate about this repo.** It warned against `parseAiQuotaError` "dropping its `QUOTA_EXCEEDED` branch". `origin/main`'s `parseAiQuotaError` never had one — it explicitly asserted `null` for `QUOTA_EXCEEDED`. The handling the relay wanted preserved lives one branch along, in `isUnsentSendError` / `isRateLimitError`. This is worth routing back to the `repo:cloud` seat.

**What this PR does instead:** pins that routing where it actually lives, so the split the relay was worried about cannot close silently. Three assertions in `generic QUOTA_EXCEEDED (per-turn cap) keeps the rate-limit path` assert `parseAiQuotaError` misses it, that `isUnsentSendError` + `isRateLimitError` both hold, and that a non-quota 429 (`RATE_LIMIT_EXCEEDED`) still falls through to the generic path.

⚠️ **These three assertions pass against `origin/main` too** — they are regression pins for preserved behavior, *not* ghost-guarded new-behavior assertions, and are labelled as such in the file. If the PM/maintainer rules the other way, it is a one-line change (add the literal to `AI_QUOTA_CODES`) plus inverting those pins.

## Gates run locally

| gate | reading |
|---|---|
| `pnpm exec vitest run packages/plugin-chatbot/src/tool-display.test.ts` | `Tests 49 passed (49)` · exit 0 |
| `pnpm --filter @object-ui/plugin-chatbot type-check` | exit 0 |
| `pnpm --filter @object-ui/plugin-chatbot lint` | `✖ 88 problems (0 errors, 88 warnings)` · exit 0 |
| `node scripts/check-changeset-presence.mjs` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 5248 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-vi-mock-specifiers.mjs` | `✅ check-vi-mock-specifiers: OK` |

Notes on the two readings that needed care:

- **`type-check` first came back exit 2** with a wall of `TS2307: Cannot find module '@object-ui/components'`. That is the unbuilt-dependency signature in a fresh worktree, not a red gate — this package's `tsconfig.json` replaces the root `paths`, so `@object-ui/*` resolves to `dist/*.d.ts`. After `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-chatbot^...' build` (exit 0), `type-check` is exit 0.
- **The edited test file is genuinely covered by `type-check`.** `tsconfig.json` excludes `**/*.test.ts`, so that half says nothing about it; `tsc -p tsconfig.test.json --listFiles` was checked and returns **1 hit** for `src/tool-display.test.ts`.

The lint warnings are pre-existing and in unrelated files (`usePendingActions.ts` and friends); the gate is `0 errors`.

Repo-wide scans (`pnpm lint` across the workspace, the `check:*` farm) are CI's run and were not duplicated locally.

## Not touched

`content/docs/releases/` — the release-notes input here is the changeset (`.changeset/ai-quota-ledger-vocabulary-3804.md`, `patch` on `@object-ui/plugin-chatbot`).

The `cloud` repo is outside this session's scope; the producer reading used is the 2026-08-12 cross-seat relay recorded on the card, not a guess at the producer's shape.

---

⛔ Left as **draft** deliberately — the PM lands this. Not self-merged, not marked ready.

_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_