### PR TITLE
fix(plugin-form): refuse a submit with no target instead of reporting success

### DIFF
--- a/.changeset/tidy-forms-refuse-target-less-submit.md
+++ b/.changeset/tidy-forms-refuse-target-less-submit.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+Variant forms refuse a submit that has nowhere to go, instead of reporting success
+
+`TabbedForm`, `WizardForm`, `SplitForm`, `DrawerForm` and `ModalForm` each opened
+`handleSubmit` with `if (!dataSource) { await schema.onSuccess?.(data); return data; }`
+— a success signal emitted without consulting a declared `submitHandler` and without
+persisting anything. Through `MasterDetailForm`, whose parent schema declares both
+`submitHandler: submitViaBatch` and `onSuccess: handleSaved`, that produced a success
+toast and, in create mode, a form reset clearing values nobody wrote.
+
+All five now answer the question the same way `SimpleObjectForm` and the `object-form`
+element gate already do. A form has a submit target when it has a `dataSource` or a
+declared `submitHandler`; with neither, the one legitimate shape is inline fields —
+a non-empty `customFields`, or `sections` whose fields are all inline runtime
+`FormField` objects — whose `onSuccess` is the write. Anything else throws
+`DataSource is required for form submission (inline mode not configured)`, which
+reaches `schema.onError` and is rethrown. A declared `submitHandler` is consulted
+first, so a host that owns the write is never bypassed for want of an adapter it
+never needed.

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -137,9 +137,10 @@ The renderers this package registers for itself are internal wrappers rather
 than these exported components. `SchemaRenderer` hands a registered component its
 `schema` (plus the schema's own props), but never a `dataSource` — that travels
 on `SchemaRendererContext` — so each wrapper reads it off the context first.
-`ObjectForm` takes `dataSource` as a prop, optional because inline `customFields`
-need no adapter, so a custom-key registration either supplies one or wraps the
-component the same way.
+`ObjectForm` takes `dataSource` as a prop, optional because inline fields need no
+adapter, so a custom-key registration either supplies one or wraps the component
+the same way. "Optional" is not "absent is fine for every form", though — see
+[What a form submits to](#what-a-form-submits-to).
 
 ## Schema API
 
@@ -532,7 +533,10 @@ A section's `fields` accepts three shapes — a field **name**, a spec
 `FormField` object. The inline shape is what lets a wizard run with no data
 source at all, which is the closest equivalent of the old snippet; note that
 `WizardForm` reports a data-source-less submit through `onSuccess` (there is no
-`onSubmit` on this schema):
+`onSubmit` on this schema). **Every** step's fields have to be the inline shape
+for that to hold — one bare name among them means the form needed object
+metadata it could not fetch, and the submit is refused rather than confirmed
+(again, [What a form submits to](#what-a-form-submits-to)):
 
 ```tsx
 import { WizardForm } from '@object-ui/plugin-form';
@@ -625,6 +629,30 @@ const schema: FormSchema = {
 Each rule appears **once**, under its own name — an object, not a list. A second
 `minLength` cannot exist, which is the point: the shape the renderer hands
 react-hook-form is one rule per kind.
+
+## What a form submits to
+
+A form has somewhere to put the values when it has **either** a `dataSource` (it
+writes through the adapter) **or** a declared `submitHandler` (the host owns the
+write and needs no adapter of its own). With neither, exactly one shape is still
+legitimate: **fields authored inline**, where the author's `onSuccess` *is* the
+write. That is
+
+- a non-empty `customFields`, or
+- `sections` whose fields are **all** inline runtime `FormField` objects.
+
+Anything else — a form naming fields the object schema would have to resolve,
+with no adapter to fetch it and no host seam to hand the values to — **refuses**
+the submit with `DataSource is required for form submission (inline mode not
+configured)`. The error reaches `schema.onError` and is rethrown.
+
+This is uniform across all six renderers (`simple`, `tabbed`, `wizard`, `split`,
+`drawer`, `modal`). It used to be uniform in the other direction: the five
+variant renderers answered an adapter-less submit by calling `onSuccess` and
+returning, which reported a save that never happened and, through
+`MasterDetailForm`, produced a success toast over a form it then cleared
+(objectui#6300). A declared `submitHandler` is consulted first, so a host that
+said it owns the write is never bypassed for want of an adapter it never needed.
 
 ## Integration with Data Sources
 

--- a/packages/plugin-form/src/DrawerForm.tsx
+++ b/packages/plugin-form/src/DrawerForm.tsx
@@ -51,6 +51,7 @@ import { sanitizeFormData } from './sanitize';
 import { seedCreateValues, omitServerResolvedDefaults } from './schemaDefaults';
 import { usePermissions } from '@object-ui/permissions';
 import { useOccSave } from './occSave';
+import { hasInlineFieldSource, noSubmitTargetError } from './submitTarget';
 
 /**
  * Container-query-based grid classes for form field layout.
@@ -398,7 +399,14 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
   const handleSubmit = useCallback(async (data: Record<string, any>) => {
     setIsSubmitting(true);
     try {
-      if (!dataSource) {
+      // No submit TARGET: a declared `submitHandler` owns the write and needs no
+      // adapter of its own (objectui#6176's seam), so only a form with NEITHER it
+      // nor a `dataSource` is target-less. The one target-less form that is still
+      // legitimate is the inline-fields collector, whose `onSuccess` IS the write.
+      // This arm used to be `if (!dataSource)` alone: it confirmed EVERY
+      // adapter-less submit, bypassing a declared host seam and persisting
+      // nothing (objectui#6300). See `submitTarget.ts` for the whole rule.
+      if (!dataSource && !schema.submitHandler && hasInlineFieldSource(schema)) {
         if (schema.onSuccess) {
           await schema.onSuccess(data);
         }
@@ -426,6 +434,10 @@ export const DrawerForm: React.FC<DrawerFormProps> = ({
         // renderer `ObjectForm` routes to must check it FIRST, or a declared
         // host-owned write silently becomes an independent one (objectui#6176).
         result = await schema.submitHandler(writePayload);
+      } else if (!dataSource) {
+        // No route left: no host seam and no adapter. Refuse instead of reporting
+        // success — the `catch` below hands this to `schema.onError` and rethrows.
+        throw noSubmitTargetError();
       } else if (schema.mode === 'create') {
         result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {

--- a/packages/plugin-form/src/ModalForm.tsx
+++ b/packages/plugin-form/src/ModalForm.tsx
@@ -53,6 +53,7 @@ import { sanitizeFormData } from './sanitize';
 import { seedCreateValues, omitServerResolvedDefaults } from './schemaDefaults';
 import { usePermissions } from '@object-ui/permissions';
 import { useOccSave } from './occSave';
+import { hasInlineFieldSource, noSubmitTargetError } from './submitTarget';
 
 // Localized strings for the unsaved-changes guard. Falls back to English when
 // no i18n provider is mounted (createSafeTranslation handles that).
@@ -440,7 +441,14 @@ export const ModalForm: React.FC<ModalFormProps> = ({
   const handleSubmit = useCallback(async (data: Record<string, any>) => {
     setIsSubmitting(true);
     try {
-      if (!dataSource) {
+      // No submit TARGET: a declared `submitHandler` owns the write and needs no
+      // adapter of its own (objectui#6176's seam), so only a form with NEITHER it
+      // nor a `dataSource` is target-less. The one target-less form that is still
+      // legitimate is the inline-fields collector, whose `onSuccess` IS the write.
+      // This arm used to be `if (!dataSource)` alone: it confirmed EVERY
+      // adapter-less submit, bypassing a declared host seam and persisting
+      // nothing (objectui#6300). See `submitTarget.ts` for the whole rule.
+      if (!dataSource && !schema.submitHandler && hasInlineFieldSource(schema)) {
         if (schema.onSuccess) {
           await schema.onSuccess(data);
         }
@@ -479,6 +487,10 @@ export const ModalForm: React.FC<ModalFormProps> = ({
         // renderer `ObjectForm` routes to must check it FIRST, or a declared
         // host-owned write silently becomes an independent one (objectui#6176).
         result = await schema.submitHandler(writePayload);
+      } else if (!dataSource) {
+        // No route left: no host seam and no adapter. Refuse instead of reporting
+        // success — the `catch` below hands this to `schema.onError` and rethrows.
+        throw noSubmitTargetError();
       } else if (schema.mode === 'create') {
         result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {

--- a/packages/plugin-form/src/SplitForm.tsx
+++ b/packages/plugin-form/src/SplitForm.tsx
@@ -32,6 +32,7 @@ import { seedCreateValues, omitServerResolvedDefaults } from './schemaDefaults';
 import { usePermissions } from '@object-ui/permissions';
 import { applyAutoColSpan, containerGridColsFor } from './autoLayout';
 import { useOccSave } from './occSave';
+import { hasInlineFieldSource, noSubmitTargetError } from './submitTarget';
 
 export interface SplitFormSectionConfig {
   name?: string;
@@ -238,7 +239,14 @@ export const SplitForm: React.FC<SplitFormProps> = ({
 
   // Handle form submission
   const handleSubmit = useCallback(async (data: Record<string, any>) => {
-    if (!dataSource) {
+    // No submit TARGET: a declared `submitHandler` owns the write and needs no
+    // adapter of its own (objectui#6176's seam), so only a form with NEITHER it
+    // nor a `dataSource` is target-less. The one target-less form that is still
+    // legitimate is the inline-fields collector, whose `onSuccess` IS the write.
+    // This arm used to be `if (!dataSource)` alone: it confirmed EVERY
+    // adapter-less submit, bypassing a declared host seam and persisting
+    // nothing (objectui#6300). See `submitTarget.ts` for the whole rule.
+    if (!dataSource && !schema.submitHandler && hasInlineFieldSource(schema)) {
       if (schema.onSuccess) {
         await schema.onSuccess(data);
       }
@@ -264,6 +272,10 @@ export const SplitForm: React.FC<SplitFormProps> = ({
         // renderer `ObjectForm` routes to must check it FIRST, or a declared
         // host-owned write silently becomes an independent one (objectui#6176).
         result = await schema.submitHandler(writePayload);
+      } else if (!dataSource) {
+        // No route left: no host seam and no adapter. Refuse instead of reporting
+        // success — the `catch` below hands this to `schema.onError` and rethrows.
+        throw noSubmitTargetError();
       } else if (schema.mode === 'create') {
         result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {

--- a/packages/plugin-form/src/TabbedForm.tsx
+++ b/packages/plugin-form/src/TabbedForm.tsx
@@ -22,6 +22,7 @@ import { seedCreateValues, omitServerResolvedDefaults } from './schemaDefaults';
 import { usePermissions } from '@object-ui/permissions';
 import { applyAutoColSpan, containerGridColsFor } from './autoLayout';
 import { useOccSave } from './occSave';
+import { hasInlineFieldSource, noSubmitTargetError } from './submitTarget';
 
 export interface FormSectionConfig {
   /**
@@ -307,7 +308,14 @@ export const TabbedForm: React.FC<TabbedFormProps> = ({
 
   // Handle form submission
   const handleSubmit = useCallback(async (data: Record<string, any>) => {
-    if (!dataSource) {
+    // No submit TARGET: a declared `submitHandler` owns the write and needs no
+    // adapter of its own (objectui#6176's seam), so only a form with NEITHER it
+    // nor a `dataSource` is target-less. The one target-less form that is still
+    // legitimate is the inline-fields collector, whose `onSuccess` IS the write.
+    // This arm used to be `if (!dataSource)` alone: it confirmed EVERY
+    // adapter-less submit, bypassing a declared host seam and persisting
+    // nothing (objectui#6300). See `submitTarget.ts` for the whole rule.
+    if (!dataSource && !schema.submitHandler && hasInlineFieldSource(schema)) {
       if (schema.onSuccess) {
         await schema.onSuccess(data);
       }
@@ -334,6 +342,10 @@ export const TabbedForm: React.FC<TabbedFormProps> = ({
         // renderer `ObjectForm` routes to must check it FIRST, or a declared
         // host-owned write silently becomes an independent one (objectui#6176).
         result = await schema.submitHandler(writePayload);
+      } else if (!dataSource) {
+        // No route left: no host seam and no adapter. Refuse instead of reporting
+        // success — the `catch` below hands this to `schema.onError` and rethrows.
+        throw noSubmitTargetError();
       } else if (schema.mode === 'create') {
         result = await dataSource.create(schema.objectName, writePayload);
       } else if (schema.mode === 'edit' && schema.recordId) {

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -32,6 +32,7 @@ import {
   type PendingSubmitRedirect,
 } from './submitRedirectNavigation';
 import { useOccSave } from './occSave';
+import { hasInlineFieldSource, noSubmitTargetError } from './submitTarget';
 import type { FormSectionConfig } from './TabbedForm';
 
 /**
@@ -556,7 +557,14 @@ export const WizardForm: React.FC<WizardFormProps> = ({
       // Final submission
       setSubmitting(true);
       try {
-        if (!dataSource) {
+        // No submit TARGET: a declared `submitHandler` owns the write and needs no
+        // adapter of its own (objectui#6176's seam), so only a form with NEITHER it
+        // nor a `dataSource` is target-less. The one target-less form that is still
+        // legitimate is the inline-fields collector, whose `onSuccess` IS the write.
+        // This arm used to be `if (!dataSource)` alone: it confirmed EVERY
+        // adapter-less submit, bypassing a declared host seam and persisting
+        // nothing (objectui#6300). See `submitTarget.ts` for the whole rule.
+        if (!dataSource && !schema.submitHandler && hasInlineFieldSource(schema)) {
           if (schema.onSuccess) {
             await schema.onSuccess(mergedData);
           }
@@ -582,6 +590,10 @@ export const WizardForm: React.FC<WizardFormProps> = ({
           // host-owned write silently becomes an independent one
           // (objectui#6176).
           result = await schema.submitHandler(writePayload);
+        } else if (!dataSource) {
+          // No route left: no host seam and no adapter. Refuse instead of reporting
+          // success — the `catch` below hands this to `schema.onError` and rethrows.
+          throw noSubmitTargetError();
         } else if (schema.mode === 'create') {
           result = await dataSource.create(schema.objectName, writePayload);
         } else if (schema.mode === 'edit' && schema.recordId) {

--- a/packages/plugin-form/src/submitTarget.ts
+++ b/packages/plugin-form/src/submitTarget.ts
@@ -1,0 +1,163 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Does a form have anything to submit TO? — the ONE answer for every renderer
+ * `ObjectForm` routes to (objectui#6300).
+ *
+ * ## What went wrong
+ *
+ * Each of the five variant containers opened `handleSubmit` with
+ *
+ *     if (!dataSource) { await schema.onSuccess?.(data); return data; }
+ *
+ * — a SUCCESS signal emitted without consulting `submitHandler` and without
+ * persisting anything. Measured on `main` with a `submitHandler` supplied and no
+ * `dataSource`, all five read `onSuccess 1 / submitHandler 0`. Through
+ * `MasterDetailForm` — whose parent schema declares BOTH
+ * `submitHandler: submitViaBatch` and `onSuccess: handleSaved` — that early
+ * return reached `handleSaved` directly: a success toast (measured:
+ * `toast.success("Created")`) and, in create mode, a form reset clearing the
+ * line items nobody wrote. Silent data loss in the worst direction, because the
+ * submitter is told it worked.
+ *
+ * ## The rule this module carries
+ *
+ * A form has a submit target when it has EITHER a `dataSource` (it writes) or a
+ * declared `submitHandler` (the host writes — objectui#6176's seam, which needs
+ * no adapter of its own). With neither, exactly one shape is still legitimate:
+ * fields authored INLINE, where the author's `onSuccess` IS the write. Anything
+ * else must refuse, loudly, instead of confirming.
+ *
+ * ## What counts as inline, and why it has two limbs
+ *
+ * Neither limb is a new predicate. Both name a shape this package already
+ * documents as working with no adapter, and the test refuses everything else.
+ *
+ * **(a) `customFields` is non-empty.** `SimpleObjectForm` (`ObjectForm.tsx`)
+ * gates its own carve-out on exactly this, the `object-form` element gate
+ * (`index.tsx`) declares `requiresDataSource={!(schema?.customFields?.length > 0)
+ * && …}` and says so in as many words — *"The one escape hatch is inline
+ * `customFields`, which is exactly what `hasInlineFields` gates on inside the
+ * component, so the two stay in step"* — and `ObjectFormSchema` glosses the key
+ * as *"when used with inline field definitions (without dataSource), this
+ * becomes the primary field source"*.
+ *
+ * **(b) every section field is an inline runtime `FormField`.** This limb is not
+ * optional and not an invention: it is how the sectioned variants express the
+ * same thing, because `TabbedFormSchema` / `SplitFormSchema` /
+ * `WizardFormSchema` have no `customFields` of their own — they build from
+ * `sections`. This package's README documents the shape and ships an example of
+ * it, `<WizardForm schema={wizard} />` under the comment *"dataSource omitted:
+ * every step lists inline fields"*, introduced by *"The inline shape is what
+ * lets a wizard run with no data source at all"*. Measured before this module
+ * existed: that example renders and submits. A `customFields`-only test would
+ * have made the repo's own published example throw — which is why the limb is
+ * here.
+ *
+ * The limb is deliberately ALL-or-nothing, and it is the taxonomy
+ * `normalizeSectionField` already keeps: a section field is a name string
+ * (shape 1), a spec `FormFieldSchema` whose identity key `field` is a STRING
+ * (shape 2), or an inline runtime `FormField` carrying its own `name` (shape 3).
+ * Only shape 3 is self-describing; shapes 1 and 2 name fields that only an
+ * object schema — and therefore only an adapter — can resolve. So one bare name
+ * anywhere in the sections means the form DID need metadata it could not get,
+ * and it refuses. Erring that way is the loud direction; the silent one is the
+ * defect.
+ *
+ * `TabbedForm` / `SplitForm` / `WizardForm` do not declare `customFields` on
+ * their own schema surface — the key reaches them through `ObjectForm`'s
+ * `{...schema}` spread, and limb (a) reads it there only as that SIGNAL.
+ * Reading it is deliberately not the same as claiming they render it.
+ */
+
+/** The shape this module reads — deliberately narrower than any form schema. */
+export interface InlineFieldSource {
+  customFields?: unknown;
+  sections?: unknown;
+}
+
+/**
+ * `normalizeSectionField`'s shape (3): an already-built runtime `FormField`,
+ * carrying its own `name`, needing no object schema to resolve.
+ *
+ * A STRING `field` is the disambiguator for shape (2), the spec
+ * `FormFieldSchema` — there `field` is the field NAME; on a runtime `FormField`
+ * the `field` slot holds the metadata OBJECT. A missing `name` is not treated as
+ * inline either: shape 3 without one is what used to crash the form renderer on
+ * `name.split('.')`, so it is malformed rather than self-describing.
+ */
+function isInlineFieldDef(def: unknown): boolean {
+  if (def === null || typeof def !== 'object' || Array.isArray(def)) return false;
+  const fd = def as { field?: unknown; name?: unknown };
+  return typeof fd.field !== 'string' && typeof fd.name === 'string';
+}
+
+/** Whether EVERY field the sections declare is self-describing (and there is one). */
+function sectionsAreFullyInline(sections: unknown): boolean {
+  if (!Array.isArray(sections) || sections.length === 0) return false;
+  let seen = 0;
+  for (const section of sections) {
+    if (section === null || typeof section !== 'object') return false;
+    const fields = (section as { fields?: unknown }).fields;
+    if (!Array.isArray(fields)) return false;
+    for (const def of fields) {
+      if (!isInlineFieldDef(def)) return false;
+      seen += 1;
+    }
+  }
+  return seen > 0;
+}
+
+/**
+ * Whether the author declared the form's fields inline, i.e. the form is a
+ * self-contained collector whose `onSuccess` is the write.
+ *
+ * Literally `SimpleObjectForm`'s test, kept in one place so the six renderers
+ * cannot answer it six ways.
+ *
+ * The parameter is `object`, not `InlineFieldSource`, on purpose: three of the
+ * five callers (`TabbedFormSchema` / `SplitFormSchema` / `WizardFormSchema`) do
+ * NOT declare `customFields` on their own surface — the key arrives through
+ * `ObjectForm`'s `{...schema}` spread — and TypeScript's weak-type check rejects
+ * an argument sharing no property with a wholly-optional interface. Widening the
+ * three schema interfaces instead would declare a field source those three do
+ * not render, which is the declared-≠-enforced shape this card exists to undo.
+ */
+export function hasInlineFieldSource(schema: object | null | undefined): boolean {
+  const s = schema as InlineFieldSource | null | undefined;
+  if (Array.isArray(s?.customFields) && s.customFields.length > 0) return true;
+  return sectionsAreFullyInline(s?.sections);
+}
+
+/**
+ * The refusal message. `SimpleObjectForm`'s own wording, verbatim, so a host
+ * that already matches on it sees one string from all six renderers.
+ */
+export const NO_SUBMIT_TARGET_MESSAGE =
+  'DataSource is required for form submission (inline mode not configured)';
+
+/**
+ * The refusal itself.
+ *
+ * Thrown from INSIDE each container's persistence chain — as the branch taken
+ * when none of the real routes (host seam / create / OCC-guarded edit) applies
+ * — rather than from a pre-`try` guard, for two reasons:
+ *
+ *  1. it is where the fact belongs: "there is no route to persist by" is a
+ *     verdict about the persistence chain, and expressing it there is also what
+ *     lets TypeScript narrow `dataSource` for the routes that use it, with no
+ *     assertion;
+ *  2. the container's `catch` runs `schema.onError?.(err)` and RETHROWS, so the
+ *     host learns why. That is what turns the `MasterDetailForm` reading above
+ *     from `toast.success("Created")` into `toast.error(<this message>)` with
+ *     the form left intact — the visible half of the fix.
+ */
+export function noSubmitTargetError(): Error {
+  return new Error(NO_SUBMIT_TARGET_MESSAGE);
+}

--- a/packages/plugin-form/src/submitTargetRefusal.test.tsx
+++ b/packages/plugin-form/src/submitTargetRefusal.test.tsx
@@ -1,0 +1,398 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * A form with nothing to submit TO must REFUSE, never confirm (objectui#6300).
+ *
+ * ## What went wrong
+ *
+ * Each of the five variant containers opened `handleSubmit` with
+ *
+ *     if (!dataSource) { await schema.onSuccess?.(data); return data; }
+ *
+ * — a success signal emitted without consulting `submitHandler` and without
+ * persisting anything. Re-derived on the merged tree (2e11c8c5b), driving each
+ * `formType` through `ObjectForm` with a `submitHandler` declared and NO
+ * `dataSource`:
+ *
+ *     variant | rendered | onSuccess | submitHandler
+ *     tabbed  |   yes    |     1     |      0
+ *     wizard  |   yes    |     1     |      0
+ *     split   |   yes    |     1     |      0
+ *     drawer  |   yes    |     1     |      0
+ *     modal   |   yes    |     1     |      0
+ *     simple  |   NO     |     0     |      0   ← never renders a form at all
+ *
+ * The `simple` row is the contrast, and it is not "throws on submit":
+ * `SimpleObjectForm` refuses at LOAD — with no `dataSource` and no inline
+ * `customFields` its schema effect takes the branch it comments as "cannot
+ * proceed" and no submittable form is ever mounted, so its
+ * `'DataSource is required for form submission'` throw is not reached on this
+ * path. The five variants build their fields from `sections` and therefore DO
+ * render, which is why the refusal has to live at submit time for them.
+ *
+ * ## Why it is user-reachable, not just a unit-level oddity
+ *
+ * `MasterDetailForm` builds its parent schema with BOTH
+ * `submitHandler: submitViaBatch` and `onSuccess: handleSaved`. The early
+ * return jumped straight to `handleSaved`, measured on the merged tree as
+ * `toast.success("Created")` — plus, in create mode, a `formKey` bump that
+ * remounts and CLEARS the parent form. The submitter is told the save worked
+ * and watches their input disappear, with nothing written and
+ * `submitViaBatch` (which would have said `dataSource is required`) never
+ * called. That is the half this file pins in `describe` block 5.
+ *
+ * ## The blocks below
+ *
+ * 1. the declared `submitHandler` seam is consulted with no `dataSource`;
+ * 2. no seam, no adapter, no inline fields → refuse loudly;
+ * 3. CARVE-OUT — a legitimate inline-fields form still works, in BOTH the
+ *    shapes this package documents (`customFields`, and sections of inline
+ *    runtime fields — the README's own wizard example), plus the boundary case
+ *    that keeps the carve-out from widening into a blanket escape;
+ * 4. DEGENERATE CONTROL — `dataSource` present, the write really happens, so
+ *    blocks 1-2 are attributable to its ABSENCE and not to a blanket change;
+ * 5. the `MasterDetailForm` reachability path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, fireEvent, screen, cleanup } from '@testing-library/react';
+import React from 'react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectForm } from './ObjectForm';
+import { MasterDetailForm } from './MasterDetailForm';
+import { NO_SUBMIT_TARGET_MESSAGE } from './submitTarget';
+import './index';
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('@object-ui/components', async (orig) => {
+  const actual = await (orig as any)();
+  return {
+    ...actual,
+    toast: {
+      success: (...a: any[]) => toastSuccess(...a),
+      error: (...a: any[]) => toastError(...a),
+    },
+  };
+});
+
+registerAllFields();
+
+/** The five renderers `ObjectForm` routes to that own an early-return submit. */
+const VARIANTS = ['tabbed', 'wizard', 'split', 'drawer', 'modal'] as const;
+/** The two of them that implement an inline-`customFields` field source. */
+const INLINE_RENDERERS = ['drawer', 'modal'] as const;
+
+const parentObject = {
+  name: 'po',
+  fields: { ref: { type: 'text', label: 'Ref' } },
+};
+
+/** A self-describing field — no object schema, and therefore no adapter, needed. */
+const INLINE_FIELDS = [{ name: 'ref', label: 'Ref', type: 'text' }] as any[];
+
+const baseSchema = (formType: string, extra: Record<string, unknown> = {}) => ({
+  type: 'object-form',
+  objectName: 'po',
+  mode: 'create',
+  formType,
+  // `drawer` / `modal` host the form in a dialog — open it, or there is no form
+  // to submit and every assertion below passes vacuously.
+  open: true,
+  submitText: 'Save Now',
+  sections: [{ name: 's1', label: 'Sec One', fields: ['ref'] }],
+  ...extra,
+});
+
+/** Type into the one field and press the form's own submit button. */
+async function fillAndSubmit(value = 'PO-1') {
+  const ref = await waitFor(() => {
+    const el = document.querySelector('input[name="ref"]') as HTMLInputElement | null;
+    if (!el) throw new Error('form never rendered — the assertions below would pass vacuously');
+    return el;
+  });
+  fireEvent.change(ref, { target: { value } });
+  fireEvent.click(screen.getByRole('button', { name: /save now/i }));
+}
+
+beforeEach(() => {
+  toastSuccess.mockClear();
+  toastError.mockClear();
+});
+afterEach(cleanup);
+
+describe('1. a declared `submitHandler` is consulted even with NO dataSource', () => {
+  it.each(VARIANTS)(
+    'formType `%s`: the host seam runs and success is reported from ITS result',
+    async (formType) => {
+      const submitHandler = vi.fn().mockResolvedValue({ id: 'p1' });
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+
+      render(
+        <ObjectForm
+          schema={baseSchema(formType, { submitHandler, onSuccess, onError }) as any}
+        />,
+      );
+      await fillAndSubmit();
+
+      // THE PIN. On the merged tree this read 0: the early return fired first,
+      // so a host that had DECLARED it owns the write was never asked.
+      await waitFor(() => expect(submitHandler).toHaveBeenCalledTimes(1));
+      expect(submitHandler).toHaveBeenCalledWith(expect.objectContaining({ ref: 'PO-1' }));
+      // Success is still reported — but only AFTER the host wrote, and carrying
+      // what the host returned rather than the raw form values.
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+      expect(onSuccess).toHaveBeenCalledWith({ id: 'p1' });
+      expect(onError).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('2. no seam, no adapter, no inline fields → refuse loudly', () => {
+  it.each(VARIANTS)(
+    'formType `%s`: onSuccess is NOT called and the reason reaches onError',
+    async (formType) => {
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+
+      render(<ObjectForm schema={baseSchema(formType, { onSuccess, onError }) as any} />);
+      await fillAndSubmit();
+
+      // THE PIN — the false success is gone.
+      await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+      expect((onError.mock.calls[0][0] as Error).message).toBe(NO_SUBMIT_TARGET_MESSAGE);
+      expect(onSuccess).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(INLINE_RENDERERS)(
+    'formType `%s`: the dialog is NOT dismissed over an unwritten record',
+    async (formType) => {
+      const onOpenChange = vi.fn();
+      const onError = vi.fn();
+
+      render(
+        <ObjectForm schema={baseSchema(formType, { onOpenChange, onError }) as any} />,
+      );
+      await fillAndSubmit();
+
+      await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+      // The old early return closed the overlay as part of its "success",
+      // taking the submitter's still-unsaved input off screen with it.
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    },
+  );
+});
+
+describe('3. CARVE-OUT: a legitimate inline-fields form still works', () => {
+  it.each(INLINE_RENDERERS)(
+    'formType `%s`: fields authored inline, no adapter — onSuccess IS the write',
+    async (formType) => {
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+
+      // No `sections` at all: `customFields` is the whole field source, which is
+      // the shape `ObjectFormSchema` documents as working without a dataSource
+      // and the one the `object-form` element gate exempts from
+      // `requiresDataSource`.
+      render(
+        <ObjectForm
+          schema={{
+            type: 'object-form',
+            objectName: 'po',
+            mode: 'create',
+            formType,
+            open: true,
+            submitText: 'Save Now',
+            customFields: INLINE_FIELDS,
+            onSuccess,
+            onError,
+          } as any}
+        />,
+      );
+      await fillAndSubmit();
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ ref: 'PO-1' }));
+      expect(onError).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(VARIANTS)(
+    'formType `%s`: sections of inline runtime fields — the README\u2019s own shape — still work',
+    async (formType) => {
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+
+      // This package's README ships exactly this: `<WizardForm schema={wizard} />`
+      // under *"dataSource omitted: every step lists inline fields"*. It is the
+      // sectioned variants' inline mode — they have no `customFields` of their
+      // own — and a `customFields`-only carve-out would have made the repo's own
+      // published example throw. Measured before the guard existed: it rendered
+      // and submitted.
+      render(
+        <ObjectForm
+          schema={baseSchema(formType, {
+            sections: [{ name: 's1', label: 'Sec One', fields: INLINE_FIELDS }],
+            onSuccess,
+            onError,
+          }) as any}
+        />,
+      );
+      await fillAndSubmit();
+
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+      expect(onSuccess).toHaveBeenCalledWith(expect.objectContaining({ ref: 'PO-1' }));
+      expect(onError).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(VARIANTS)(
+    'formType `%s`: BOUNDARY — one bare field name among inline ones still refuses',
+    async (formType) => {
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+
+      // The carve-out is all-or-nothing on purpose. `'memo'` is a NAME: only an
+      // object schema can say what it is, and only an adapter can serve one. A
+      // form that needed metadata it could not get did not collect what it was
+      // authored to collect, so confirming it would be the same false success in
+      // a narrower dress. Without this case the carve-out could quietly become a
+      // blanket escape the moment any form declared one inline field.
+      render(
+        <ObjectForm
+          schema={baseSchema(formType, {
+            sections: [{ name: 's1', label: 'Sec One', fields: [...INLINE_FIELDS, 'memo'] }],
+            onSuccess,
+            onError,
+          }) as any}
+        />,
+      );
+      await fillAndSubmit();
+
+      await waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+      expect((onError.mock.calls[0][0] as Error).message).toBe(NO_SUBMIT_TARGET_MESSAGE);
+      expect(onSuccess).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('4. DEGENERATE CONTROL: with a dataSource the write really happens', () => {
+  // Passes on the merged tree AND after the fix — deliberately. It is what makes
+  // blocks 1-2 attributable to the ABSENCE of a dataSource rather than to a
+  // blanket refusal bolted onto every submit.
+  it.each(VARIANTS)(
+    'formType `%s`: dataSource.create is called and success is reported',
+    async (formType) => {
+      const create = vi.fn().mockResolvedValue({ id: 'p1' });
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+      const dataSource = {
+        getObjectSchema: vi.fn().mockResolvedValue(parentObject),
+        find: vi.fn().mockResolvedValue({ data: [] }),
+        findOne: vi.fn().mockResolvedValue({}),
+        create,
+        update: vi.fn(),
+        delete: vi.fn(),
+        bulk: vi.fn(),
+      } as any;
+
+      render(
+        <ObjectForm
+          schema={baseSchema(formType, { onSuccess, onError }) as any}
+          dataSource={dataSource}
+        />,
+      );
+      await fillAndSubmit();
+
+      await waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+      expect(create).toHaveBeenCalledWith('po', expect.objectContaining({ ref: 'PO-1' }));
+      await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+      expect(onError).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('5. MasterDetailForm — the path that made this user-visible', () => {
+  const masterDetailSchema = {
+    objectName: 'po',
+    mode: 'create',
+    formType: 'tabbed',
+    sections: [{ name: 's1', label: 'Sec One', fields: ['ref'] }],
+    details: [
+      {
+        childObject: 'po_line',
+        relationshipField: 'po',
+        columns: [{ name: 'qty', label: 'Qty', type: 'number' }],
+      },
+    ],
+  };
+
+  const clickHostSave = () =>
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+  it('with NO dataSource: no success toast, no reset — the failure is reported instead', async () => {
+    const { container } = render(
+      <MasterDetailForm schema={masterDetailSchema as any} />,
+    );
+
+    const ref = await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      if (!el) throw new Error('parent form never rendered');
+      return el;
+    });
+    fireEvent.change(ref, { target: { value: 'PO-1' } });
+    clickHostSave();
+
+    // THE PIN — on the merged tree this was `toast.success("Created")`.
+    //
+    // The message is the HOST's own, not `NO_SUBMIT_TARGET_MESSAGE`, and that is
+    // the fix working as designed: `MasterDetailForm` DECLARED `submitHandler`,
+    // so the seam is consulted first (block 1) and `submitViaBatch` gets to
+    // state the precise reason. The renderer's generic refusal is what a form
+    // with no seam at all falls through to (block 2).
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    expect(String(toastError.mock.calls[0][0])).toBe('MasterDetailForm: dataSource is required');
+    expect(toastSuccess).not.toHaveBeenCalled();
+
+    // …and the submitter's input is still there. `handleSaved` bumps `formKey`
+    // in create mode, which remounts the parent form and wipes it — the visible
+    // half of the data loss.
+    const after = container.querySelector('input[name="ref"]') as HTMLInputElement;
+    expect(after.value).toBe('PO-1');
+  });
+
+  it('CONTROL — with a dataSource the batch commits and the save is confirmed', async () => {
+    const batchTransaction = vi.fn().mockResolvedValue({ results: [{ id: 'po1' }] });
+    const dataSource = {
+      getObjectSchema: vi.fn().mockResolvedValue(parentObject),
+      find: vi.fn().mockResolvedValue({ data: [] }),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      bulk: vi.fn(),
+      batchTransaction,
+    } as any;
+
+    const { container } = render(
+      <MasterDetailForm schema={masterDetailSchema as any} dataSource={dataSource} />,
+    );
+
+    const ref = await waitFor(() => {
+      const el = container.querySelector('input[name="ref"]') as HTMLInputElement | null;
+      if (!el) throw new Error('parent form never rendered');
+      return el;
+    });
+    fireEvent.change(ref, { target: { value: 'PO-1' } });
+    clickHostSave();
+
+    await waitFor(() => expect(batchTransaction).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #6300

`TabbedForm`, `WizardForm`, `SplitForm`, `DrawerForm` and `ModalForm` each opened `handleSubmit` with

```js
if (!dataSource) { await schema.onSuccess?.(data); return data; }
```

— a success signal emitted without consulting a declared `submitHandler` and without persisting anything.

## Re-derived measurement — both sides, not inherited

The card states a limit on its own table and asks for both sides to be re-derived. Done, on the merged tree (`2e11c8c5b`), driving each `formType` through `ObjectForm` with a `submitHandler` declared and **no** `dataSource`:

| variant | card said | measured here | agrees? |
|---|---|---|---|
| `tabbed` | onSuccess 1 · submitHandler 0 | rendered · onSuccess **1** · submitHandler **0** | yes |
| `wizard` | onSuccess 1 · submitHandler 0 | rendered · onSuccess **1** · submitHandler **0** | yes |
| `split` | onSuccess 1 · submitHandler 0 | rendered · onSuccess **1** · submitHandler **0** | yes |
| `drawer` | *(source-read only)* | rendered · onSuccess **1** · submitHandler **0** | now measured |
| `modal` | *(source-read only)* | rendered · onSuccess **1** · submitHandler **0** | now measured |
| `simple` | *(not measured; source-read as "throws")* | **never renders a form at all** | **differs — see below** |

### Where the numbers differ from the card

**1. The `simple` contrast is "refuses at LOAD", not "throws at submit".** With no `dataSource` and no inline `customFields`, `SimpleObjectForm`'s schema effect takes the branch it comments as *"No objectName or dataSource and no inline fields — cannot proceed"*, and no submittable form is mounted — measured `rendered=false`, `onSuccess=0`. Its `'DataSource is required for form submission (inline mode not configured)'` throw is not reached on this path. That is very likely why the #6176 dev's `simple` leg "failed in its own harness": there was nothing to submit.

This changes where the fix has to live, not whether it is needed. The five variants build their fields from `sections` and therefore **do** render, so their refusal has to be at submit time.

**2. `SimpleObjectForm`'s own inline carve-out bypasses a declared `submitHandler` too** — measured `simple` + `customFields` + `submitHandler` + no `dataSource` → `onSuccess 1 / submitHandler 0`. Its carve-out is checked *before* the seam. The triage direction ("when a `submitHandler` is declared, a missing `dataSource` must never bypass it") is followed here for the five, which means `simple` now differs from them in that one cell. Deliberately **left alone** in this PR — `ObjectForm.tsx` is outside this card's five files, and it is #6176's defect class rather than this one's. Recorded as its own card, #6388, and reported to the PM.

**3. `MasterDetailForm` reachability, measured rather than inferred:** with no `dataSource`, the parent form's early return reached `handleSaved` and produced `toast.success("Created")`, `toastError 0`, and a `formKey` bump that remounts and clears the parent form. Exactly the described failure.

## The fix

One rule, in one place (`submitTarget.ts`), consumed by all five containers. A form has a submit target when it has **either** a `dataSource` **or** a declared `submitHandler` (the host owns the write and needs no adapter of its own). With neither, one shape is still legitimate — fields authored inline, whose `onSuccess` *is* the write:

- **(a)** a non-empty `customFields` — `SimpleObjectForm`'s own test, and the one the `object-form` element gate already keys `requiresDataSource` on, under the comment *"The one escape hatch is inline `customFields`, which is exactly what `hasInlineFields` gates on inside the component, so the two stay in step."*
- **(b)** `sections` whose fields are **all** inline runtime `FormField` objects — the sectioned variants' inline mode, since they have no `customFields` of their own.

Everything else throws. The throw sits **inside** the persistence chain, as the branch taken when none of the real routes applies: that is where the fact belongs, it narrows `dataSource` for the routes that use it with no assertion, and each container's `catch` runs `schema.onError` and rethrows — which is what turns the `MasterDetailForm` reading from `toast.success("Created")` into a reported failure with the form left intact.

No accept set is widened and no key is added. `packages/spec` is untouched. #6176 / PR #6299's work on the normal path is untouched — the seam check it added is what limb-first precedence now routes through.

### Limb (b) is not decoration — a `customFields`-only rule broke this repo's own published example

`packages/plugin-form/README.md` documents and ships a `WizardForm` element rendered with `schema={wizard}` and no `dataSource` prop, annotated `// dataSource omitted: every step lists inline fields` and introduced by *"The inline shape is what lets a wizard run with no data source at all"*. Its inline fields live in `sections[].fields`, not `customFields`. Measured against an intermediate `customFields`-only version of this guard:

```
README wizard (inline secs)  | rendered=true | onSuccess=0 | onError=DataSource is required for form submission (inline mode not configured)
tabbed (inline secs)         | rendered=true | onSuccess=0 | onError=DataSource is required for form submission (inline mode not configured)
split  (inline secs)         | rendered=true | onSuccess=0 | onError=DataSource is required for form submission (inline mode not configured)
```

That is the over-broad refusal the card warned about, caught before it shipped. Limb (b) is all-or-nothing on purpose — it keeps `normalizeSectionField`'s own taxonomy, where only shape (3) is self-describing and shapes (1)/(2) name fields that only an object schema can resolve. One bare name anywhere means the form did need metadata it could not get, and it refuses.

## Ghost-assertion guard — every new assertion captured failing, then passing

Ablation: the five variant files reverted to unmodified `origin/main` bytes — `git checkout 2e11c8c5b --` against the five variant paths — with the test file left as written; measured, then restored. Both legs proved on disk by blob hash rather than by exit code, and the restore leg proved by an empty `git diff HEAD`. No rebuild is involved: these tests import the containers by relative path and run from source under the root vitest config.

```
mutation proof (disk blob == origin/main blob, != HEAD blob)
  TabbedForm.tsx  disk=3ee782c965fd base=3ee782c965fd head=900b4e111193  MUTATED
  SplitForm.tsx   disk=019531292509 base=019531292509 head=827b6460fc2f  MUTATED
  WizardForm.tsx  disk=a19a5e655f44 base=a19a5e655f44 head=8a4ec4f8f5d4  MUTATED
  DrawerForm.tsx  disk=2b76bfea0e5c base=2b76bfea0e5c head=030264133df8  MUTATED
  ModalForm.tsx   disk=9c1cda697019 base=9c1cda697019 head=8f59da0cd9bc  MUTATED
guard-symbol grep in the five: 0 · 0 · 0 · 0 · 0
restore: restore-diff-empty=YES · all five RESTORED · guard-symbol grep: 2 · 2 · 2 · 2 · 2
```

**BEFORE — unmodified `origin/main` source:** `Tests 18 failed | 13 passed (31)` · `VITEST_EXIT=1`. Every failure reads `AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times` — the false-success signature: `submitHandler`, `onError` and `toast.error` all silent.

```
× formType tabbed|wizard|split|drawer|modal: the host seam runs and success is reported from ITS result    (5)
× formType tabbed|wizard|split|drawer|modal: onSuccess is NOT called and the reason reaches onError        (5)
× formType drawer|modal: the dialog is NOT dismissed over an unwritten record                              (2)
× formType tabbed|wizard|split|drawer|modal: BOUNDARY — one bare field name among inline ones still refuses (5)
× MasterDetailForm with NO dataSource: no success toast, no reset — the failure is reported instead        (1)
```

**AFTER — with the fix:** `Test Files 1 passed (1)` · `Tests 31 passed (31)` · `VITEST_EXIT=0`.

### Which fixture is which

The 13 that pass in **both** readings are deliberately the non-discriminating half — they are what makes the 18 failures attributable to the *absence* of a submit target rather than to a blanket change:

| fixture | role | main | after |
|---|---|---|---|
| block 4 · all five, `dataSource` present, `create` really called (5 cases) | **degenerate control** | pass | pass |
| block 3 · `drawer`/`modal`, `customFields` only (2 cases) | carve-out limb (a) | pass | pass |
| block 3 · all five, inline **section** fields — the README's shape (5 cases) | carve-out limb (b) | pass | pass |
| block 5 · `MasterDetailForm` **with** a `dataSource`, batch commits, save confirmed (1 case) | control for the reachability path | pass | pass |
| block 1 · the declared seam runs with no adapter (5) | the pin | **fail** | pass |
| block 2 · refuse loudly; dialog not dismissed (7) | the pin | **fail** | pass |
| block 3 · BOUNDARY, one bare name among inline ones still refuses (5) | keeps the carve-out from widening | **fail** | pass |
| block 5 · `MasterDetailForm` with no adapter: no success toast, no reset (1) | the user-facing half | **fail** | pass |

All six paths named in the dispatch are pinned: the five variants, and the `MasterDetailForm` reachability path.

## Verification

All readings below are from the tree of the pushed commit `c33ddf2fa` (verified at `3107b210f`, whose tree `68cbc1a34` is byte-identical — same tree, collapsed history), after merging `origin/main` (`631d81dbf`) and rebuilding the dependency closure.

| check | verdict line |
|---|---|
| `pnpm --filter @object-ui/plugin-form type-check` | `TYPECHECK_EXIT=0` |
| `pnpm --filter @object-ui/plugin-form lint` | `✖ 690 problems (0 errors, 690 warnings)` · `LINT_EXIT=0` |
| `pnpm exec vitest run packages/plugin-form/` | `Test Files 68 passed (68)` · `Tests 705 passed (705)` · `PKGTESTS_EXIT=0` |
| downstream consumers (console binding-reach, master-detail manifest, app-shell previews, react element-data-source + spec-bridge) | `Test Files 53 passed (53)` · `Tests 745 passed (745)` · `DOWNSTREAM_EXIT=0` |
| `node scripts/check-changeset-presence.mjs` | `✅ 7 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump` |
| control-byte scan over the changed files | clean |

The `type-check` script's second project (`tsconfig.test.json`) demonstrably compiles the new test file — `tsc -p tsconfig.test.json --listFiles | grep -c submitTargetRefusal.test.tsx` → `1` — so "typecheck is clean" is a statement about the new assertions too, not only about `src`.

**Declared narrowing:** the repo-wide `pnpm lint` (`turbo run lint`) was narrowed to the one package whose files changed. Evidence, all three parts: (1) the population is eslint's own — `eslint .` over the package, not a hand-picked file list; (2) the count is read from `--format json`: **98 files**, 0 errors, 690 warnings; (3) `eslint.config.js` declares no `parserOptions.project` / `projectService`, so linting is not type-aware and this diff cannot move a verdict in any file it does not touch. CI runs the full farm regardless.

## Notes for the PM

- `packages/spec` untouched, as instructed. No spec note is needed: `ObjectFormSchema.customFields` already glosses itself as *"when used with inline field definitions (without dataSource), this becomes the primary field source"*, which is the contract this restores rather than changes.
- One out-of-scope finding was filed, deliberately not addressed in this PR: #6388 — `SimpleObjectForm`'s inline carve-out skips a declared `submitHandler`. It remains open and this branch does not touch `ObjectForm.tsx`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_
