### PR TITLE
fix(cli): anchor `objectui check`'s ignore patterns at every depth

### DIFF
--- a/.changeset/6320-check-nested-dist-ignore.md
+++ b/.changeset/6320-check-nested-dist-ignore.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/cli': patch
+---
+
+Fix `objectui check` scanning build output because its ignore list only excluded a
+root-level `dist/` / `node_modules/` (objectui#6320).
+
+`packages/cli/src/commands/check.ts` passed `ignore: ['node_modules/**', 'dist/**',
+'.git/**']` to `globSync`. `glob` matches `ignore` patterns against the path relative to
+`cwd`, so an unanchored `dist/**` / `node_modules/**` excludes only a directory of that
+name at the scan root — every nested `packages/<name>/dist/`, `examples/<name>/dist/`,
+`apps/<name>/dist/` (and their `node_modules/`) was still scanned. In a built workspace
+this means `objectui check` re-reads the author's own schemas a second time from build
+output, roughly doubling every count it reports (measured on this repository: 617 → 1047
+files globbed after a full build) with nothing in the output explaining why.
+
+The ignore patterns are now anchored at every depth (`'**/dist/**'`, `'**/node_modules/**'`),
+matching the fix's stated intent: exclude build output and installed dependencies wherever
+they live, not only at the project root. A root-level `dist/` / `node_modules/` remains
+excluded, unchanged.
+
+Confirmed before widening: no example, template, or docs fixture in this repository
+authors a schema under a directory literally named `dist` — the widened pattern excludes
+only generated content.

--- a/packages/cli/src/__tests__/check-nested-dist-ignore.test.ts
+++ b/packages/cli/src/__tests__/check-nested-dist-ignore.test.ts
@@ -1,0 +1,134 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `objectui check`'s ignore list matches `glob`'s `ignore` patterns against
+ * the path RELATIVE TO `cwd` (objectui#6320). An unanchored ignore pattern
+ * (root-level "dist" or "node_modules" only) therefore excludes only a
+ * directory of that name AT THE SCAN ROOT — every nested build-output or
+ * dependency directory one level or more down (a package's own "dist",
+ * an example's own "node_modules", and so on) was still scanned, so a built
+ * workspace re-read the author's own schemas a second time, from build
+ * output. Measured on this repository: every reported count roughly doubles
+ * once packages are built.
+ *
+ * This file pins two things at once, because widening a pattern is exactly
+ * where an exclusion can accidentally stop covering the case it already
+ * handled:
+ * - a NESTED `dist/` / `node_modules/` is now excluded (the fix);
+ * - a ROOT-level `dist/` / `node_modules/` is STILL excluded (the regression
+ *   guard for the fix itself).
+ *
+ * Fixtures live under `os.tmpdir()`, never in the repo tree: `check()` globs
+ * every JSON file under the directory it is handed, so a fixture committed
+ * inside this workspace would be scanned by every other run of the command as
+ * well — including the repo's own `pnpm check` (see `check-schema-marker.test.ts`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { check } from '../commands/check.js';
+
+let cwd: string;
+let lines: string[];
+let restoreLog: () => void;
+
+/**
+ * The CSI sequences chalk may add. The escape byte is built with
+ * `String.fromCharCode` rather than spelled into the source, so this file
+ * holds no raw control character (objectui AGENTS.md byte discipline).
+ */
+const ANSI = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+
+function plainLines(): string[] {
+  return lines.map((l) => l.replace(ANSI, ''));
+}
+
+function unknownTypeWarnings(): string[] {
+  return plainLines().filter((l) => l.includes('Unknown schema type'));
+}
+
+/** Was a file whose basename is `name` warned about? A file the scan never
+ * globbed prints nothing at all, so absence here means "not scanned". */
+function warnedAbout(name: string): boolean {
+  return unknownTypeWarnings().some((l) => l.includes(name));
+}
+
+/**
+ * Write a fixture that is unmistakable if — and only if — `check()` globs it:
+ * it positively reads as an ObjectUI schema (the structural key `children`),
+ * and its `type` is deliberately unregistered, so a scanned copy prints an
+ * "Unknown schema type" warning naming its own path. Directories are created
+ * as needed, so `relPath` may nest arbitrarily deep.
+ */
+function writeProbe(relPath: string): void {
+  const abs = join(cwd, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, JSON.stringify({ type: 'totally-made-up-xyz', children: [] }));
+}
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'objectui-check-nested-ignore-'));
+  lines = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  };
+  // `check()` calls `process.exit(1)` itself; none of these fixtures are
+  // malformed JSON, but mock it anyway so a surprise does not tear the
+  // Vitest worker down (same convention as check-schema-marker.test.ts).
+  const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+  restoreLog = () => {
+    console.log = original;
+    exitSpy.mockRestore();
+  };
+});
+
+afterEach(() => {
+  restoreLog();
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe('objectui check — the ignore list is anchored at every depth (objectui#6320)', () => {
+  it('does not scan a NESTED dist/ directory', async () => {
+    writeProbe('packages/x/dist/nested-dist-file.json');
+    // Counter-probe, outside dist/: without it, silence above would be
+    // indistinguishable from a scan that read nothing at all.
+    writeProbe('packages/x/src/sibling-file.json');
+    await check(cwd);
+    expect(warnedAbout('nested-dist-file.json')).toBe(false);
+    expect(warnedAbout('sibling-file.json')).toBe(true);
+  });
+
+  it('does not scan a NESTED node_modules/ directory', async () => {
+    writeProbe('packages/y/node_modules/some-dep/nested-node-modules-file.json');
+    writeProbe('packages/y/src/sibling-file.json');
+    await check(cwd);
+    expect(warnedAbout('nested-node-modules-file.json')).toBe(false);
+    expect(warnedAbout('sibling-file.json')).toBe(true);
+  });
+
+  it('still excludes a ROOT-level dist/ — widening must not stop covering the case it already handled', async () => {
+    writeProbe('dist/root-dist-file.json');
+    writeProbe('src/sibling-file.json');
+    await check(cwd);
+    expect(warnedAbout('root-dist-file.json')).toBe(false);
+    expect(warnedAbout('sibling-file.json')).toBe(true);
+  });
+
+  it('still excludes a ROOT-level node_modules/ — same regression guard', async () => {
+    writeProbe('node_modules/some-dep/root-node-modules-file.json');
+    writeProbe('src/sibling-file.json');
+    await check(cwd);
+    expect(warnedAbout('root-node-modules-file.json')).toBe(false);
+    expect(warnedAbout('sibling-file.json')).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -200,9 +200,17 @@ export async function check(cwd: string = process.cwd()) {
   console.log(chalk.bold('Object UI Schema Check'));
 
   // 1. Find all JSON/YAML files
-  const files = globSync('**/*.{json,yaml,yml}', { 
-    cwd, 
-    ignore: ['node_modules/**', 'dist/**', '.git/**'] 
+  const files = globSync('**/*.{json,yaml,yml}', {
+    cwd,
+    // `glob` matches `ignore` patterns against the path relative to `cwd`, so
+    // an unanchored `dist/**`/`node_modules/**` excludes only a directory of
+    // that name at the scan root — every nested `packages/*/dist/`,
+    // `examples/*/dist/`, `apps/*/dist/` (and their `node_modules/`) is still
+    // scanned. `**/` anchors the match at any depth (objectui#6320): measured
+    // on this repository, a built tree without it reports roughly double the
+    // files of a clean checkout, almost all of it re-reading the author's own
+    // schemas from build output.
+    ignore: ['**/node_modules/**', '**/dist/**', '.git/**']
   });
   
   console.log(`Analyzing ${files.length} files...`);


### PR DESCRIPTION
Fixes #6320

## The defect

`packages/cli/src/commands/check.ts` passed `ignore: ['node_modules/**', 'dist/**', '.git/**']` to `globSync`. `glob` matches `ignore` patterns against the path **relative to `cwd`**, so `dist/**` / `node_modules/**` excluded only a directory of that name at the scan root — every nested `packages/<name>/dist/`, `examples/<name>/dist/`, `apps/<name>/dist/` (and their `node_modules/`) was still scanned, re-reading the author's own schemas a second time from build output.

## Step 1 — the confirmation (done BEFORE the fix, per the dispatch order)

Grepped `examples/`, `templates/` (absent in this repo — verified with `ls -d templates` → no output) and docs fixtures for any *authored* (git-tracked) schema living under a path segment literally named `dist`:

```
$ git ls-files -- 'examples/**/dist/**' 'examples/*/dist/**' 'content/docs/**/dist/**' 'docs/**/dist/**' 'scripts/__tests__/fixtures/**/dist/**'
(zero output)
```

**Control term** (same sweep roots, proving the glob syntax itself works and a zero-hit above isn't a broken pattern): the same roots really do contain tracked schema files outside any `dist/` segment —

```
$ git ls-files -- 'examples/**/*.json' 'examples/**/*.yaml' 'examples/**/*.yml' | grep -v node_modules | wc -l
441
```

(sample hits include a 4-level-deep path, confirming `**` matches at depth: `examples/schema-catalog/src/schemas/actions/action-button-variants.json`.)

Filesystem-level double-check (not just git-tracked, in case a `dist/` had been built but not committed) on a clean, unbuilt checkout:

```
$ find examples content/docs docs scripts/__tests__/fixtures -type d -name dist -not -path "*/node_modules/*"
(zero output)
```

**Confirmation holds**: nothing in this repository authors a schema under a directory literally named `dist`. Proceeding to the fix per step 2 of the dispatch order.

## Step 2 — the fix

`packages/cli/src/commands/check.ts:203-214` — widened both ignore patterns to anchor at any depth:

```diff
-  const files = globSync('**/*.{json,yaml,yml}', { 
-    cwd, 
-    ignore: ['node_modules/**', 'dist/**', '.git/**'] 
-  });
+  const files = globSync('**/*.{json,yaml,yml}', {
+    cwd,
+    ignore: ['**/node_modules/**', '**/dist/**', '.git/**']
+  });
```

`.git/**` is left as-is — it was never in scope (there is no nested `.git/` case analogous to nested `dist/`/`node_modules/`), matching the ruled fix exactly.

## The test — `packages/cli/src/__tests__/check-nested-dist-ignore.test.ts` (new file)

Four assertions, using a probe fixture that is unmistakable if-and-only-if it gets scanned (a positive ObjectUI structural key + an unregistered `type`, so a scanned copy prints an "Unknown schema type" warning naming its own path):

1. a nested `packages/x/dist/…json` is **not** scanned (the fix)
2. a nested `packages/y/node_modules/…json` is **not** scanned (the fix, `node_modules` arm)
3. a **root-level** `dist/…json` is **still** excluded (regression guard — widening a pattern is exactly where an exclusion can accidentally stop covering the case it already handled)
4. a **root-level** `node_modules/…json` is **still** excluded (same regression guard)

Each test also writes a sibling file outside the excluded directory as a counter-probe, so a "not scanned" assertion can't be silently satisfied by a scan that read nothing at all.

### Two-direction proof (required by the dispatch order)

Committed the fix + test first (commit `fe74ba7e3`) so there was a real restore point, then:

1. **Reverted** `check.ts` to the pre-fix content via `git show HEAD~1:packages/cli/src/commands/check.ts > <path>` (`HEAD~1` is `631d81dbf` = `origin/main` at claim time), under a `trap restore EXIT INT TERM` where `restore() { git checkout HEAD -- <path>; }`.
2. Ran the new test file against that reverted content → **RED**:
   ```
   Test Files  1 failed (1)
        Tests  2 failed | 2 passed (4)
   × does not scan a NESTED dist/ directory
   × does not scan a NESTED node_modules/ directory
   ```
   (The two root-level regression-guard tests passed even pre-fix, as expected — root exclusion was never broken; only the nested-directory tests are the pinning assertions, and both went red.)
3. **Restored** via `git checkout HEAD -- <path>`, then proved the restore:
   - `git hash-object <path>` → `4602e7b8f6f4961d75358b3307080b910107fbfc`, identical to `git rev-parse HEAD:packages/cli/src/commands/check.ts` taken **before** the mutation (`4602e7b8f6f4961d75358b3307080b910107fbfc`) — exact match.
   - `git diff HEAD -- <path>` → empty.
4. Ran the same test file again against the restored (fixed) content → **GREEN**: `Test Files 1 passed (1)` / `Tests 4 passed (4)`.

`git status --porcelain` was empty after the whole sequence — the working tree exactly matches the commit.

## Other checks run locally

- `pnpm exec vitest run packages/cli/` → `Test Files 14 passed (14)` / `Tests 230 passed (230)` (226 pre-existing + 4 new).
- `pnpm exec turbo run lint --filter=@object-ui/cli` → exit 0, 0 errors (pre-existing warnings only, none touching the edited files).
- `pnpm exec turbo run type-check --filter=@object-ui/cli` → exit 0, no errors.
- `node scripts/check-changeset-presence.mjs` → `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`.
- Byte discipline: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the edited files → no matches.

## Files changed

- `packages/cli/src/commands/check.ts` (lines 203-214) — the ignore-list fix.
- `packages/cli/src/__tests__/check-nested-dist-ignore.test.ts` (new) — the pinning test.
- `.changeset/6320-check-nested-dist-ignore.md` (new) — patch, `@object-ui/cli`.

## Nothing contradicts the card or the dispatch order

The measured pre-fix behaviour, the confirmation result, and the ruled fix all matched what #6320 and the dispatch order predicted — no surprises to flag.

_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_