### PR TITLE
ci(dependabot-auto-merge): drop the lockfile merge driver it cannot invoke

### DIFF
--- a/.changeset/6369-dead-lockfile-merge-driver.md
+++ b/.changeset/6369-dead-lockfile-merge-driver.md
@@ -1,0 +1,25 @@
+---
+---
+
+CI/doc-only: `.github/workflows/dependabot-auto-merge.yml` no longer configures the
+`pnpm-lock.yaml` merge driver, and the pinned "Lockfile Merge Driver" table in
+`content/docs/guide/ci-cd-pipeline.md` loses the row that named it (objectui#6369).
+
+A merge driver runs only when git has to merge the attributed path *on the runner*. The
+only merge that job performs is `gh pr merge --auto --squash`, which GitHub executes
+server-side in the merge queue — the runner's local git config takes no part in it, so
+the driver had no occasion to fire. Swept the whole file before removing: no `git
+merge`, `rebase`, `pull`, `cherry-pick`, `am`, `apply` or `revert` anywhere in it, the
+`git config` pair being the only `git` present; `actions/checkout` checks out the merge
+commit GitHub already computed rather than computing one; and the gate script imports
+`node:fs` only.
+
+Same no-occasion property objectui#6358 measured on `changelog.yml`, reached by a
+different route — that job never merged at all, this one merges only where local config
+cannot reach. With both dead copies gone the mechanism has one row left,
+`changeset-release.yml`.
+
+The guide sentence that produced both copies is narrowed in the same change: it now asks
+for a **local** merge, and records that neither a push nor a server-side merge is one.
+
+No source and no behaviour change; nothing a consumer installs is affected.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -102,12 +102,31 @@ jobs:
           # pnpm store doesn't exist and setup-node's post-job cache save fails
           # with "Path Validation Error", which marks the whole job as failed.
 
-      - name: Configure Git merge driver for pnpm-lock.yaml
-        run: |
-          # Configure custom merge driver for pnpm-lock.yaml
-          # This allows Git to automatically resolve lockfile conflicts by regenerating it
-          git config merge.pnpm-merge.name "pnpm-lock.yaml merge driver"
-          git config merge.pnpm-merge.driver "pnpm install --no-frozen-lockfile"
+      # No lockfile merge driver here, deliberately (objectui#6369).
+      #
+      # This job configured one until 2026-08-25. A merge driver is invoked by
+      # git only when git itself has to MERGE the attributed path, on the
+      # runner. The only merge this job performs is the last step's `gh pr
+      # merge --auto --squash`, and GitHub executes that SERVER-SIDE: the merge
+      # commit is produced by GitHub's own machinery in the merge queue, so the
+      # runner's local git config is never consulted and cannot participate.
+      # The driver therefore had no occasion to fire.
+      #
+      # Swept before removing: this file contains no `git merge`, `rebase`,
+      # `pull`, `cherry-pick`, `am`, `apply` or `revert` -- the `git config`
+      # pair this comment replaces was the only `git` in it. `actions/checkout`
+      # fetches a ref and checks it out; on a `pull_request` event that ref is
+      # the merge commit GitHub has ALREADY computed, so checking it out merges
+      # nothing locally (and `submodules: true` finds no `.gitmodules` here).
+      # `scripts/dependabot-merge-gate.mjs` imports `node:fs` and one local
+      # helper -- it shells out to nothing.
+      #
+      # Same no-occasion property as `changelog.yml` (objectui#6358), reached by
+      # a different route: that job never merged at all, this one merges only
+      # where local config cannot reach.
+      #
+      # Restoring it needs a real LOCAL merge in this job first. A server-side
+      # merge is not one, and missing that distinction is what put the step here.
 
       - name: Dependabot metadata
         id: metadata

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -775,8 +775,9 @@ shrinks. A hard-coded list would break silently the first time someone moved a s
 install, which is exactly the edit that needs catching. Two anchoring decisions the derivation
 depends on, each with a case in this repository: `pnpm exec playwright install chromium` installs a
 browser rather than the workspace, and `git config merge.pnpm-merge.driver "pnpm install …"` in
-`dependabot-auto-merge.yml` *configures* a driver in a job that never installs — reading either as an
-install would move a boundary and silently drop a script out of the population.
+`changeset-release.yml` *configures* a driver — the `pnpm install` there is a quoted argument, and
+that job's real install is a later step — reading either as an install would move a boundary and
+silently drop a script out of the population.
 
 **It walks the graph, not the entry file.** Requiring each of the entry's own imports to start with
 `node:` is too narrow in one direction (a relative import of a builtins-only local module is fine,
@@ -1524,7 +1525,9 @@ Dependabot bump never touches `.claude/hooks/**`, so it is never waited for) rat
 
 - **Patch/minor updates**: approved and enqueued — **but only after an explicit wait**, see below.
 - **Major updates**: commented for manual review; never approved, never enqueued.
-- Configures a pnpm-lock.yaml merge driver for conflict resolution.
+- Configures **no** lockfile merge driver ([#6369](https://github.com/objectstack-ai/objectui/issues/6369)):
+  its only merge is `gh pr merge`, which GitHub runs server-side, where the runner's git config
+  cannot reach.
 
 **The wait, and why it exists.** This workflow used to run `gh pr merge --auto --squash`
 unconditionally for every patch/minor bump. `--auto` lands the merge as soon as GitHub considers
@@ -1584,8 +1587,8 @@ pnpm-lock.yaml merge=pnpm-merge
 ```
 
 Git does not ship a `pnpm-merge` driver, and an attribute naming a driver nothing defines falls
-back to an ordinary text merge. So every workflow that merges, rebases, or commits onto a branch
-that may have moved defines it immediately after checkout:
+back to an ordinary text merge. So every workflow that performs a **local** merge or rebase --
+one git carries out on the runner -- defines it immediately after checkout:
 
 ```yaml
 - name: Configure Git merge driver for pnpm-lock.yaml
@@ -1594,12 +1597,11 @@ that may have moved defines it immediately after checkout:
     git config merge.pnpm-merge.driver "pnpm install --no-frozen-lockfile"
 ```
 
-Two workflows carry that step, for two different reasons:
+One workflow carries that step:
 
 | Workflow | Why it needs the driver |
 |---|---|
 | `changeset-release.yml` | version bumps rewrite the lockfile on the release branch |
-| `dependabot-auto-merge.yml` | squash-merges dependency PRs whose entire content is often a lockfile change |
 
 `scripts/__tests__/ci-cd-pipeline-doc.test.ts` pins that table against the workflows that
 actually configure `merge.pnpm-merge`, in both directions. It is pinned because the claim had
@@ -1615,12 +1617,19 @@ configured with a plain `pnpm install` under **Configure Git Merge Driver for pn
 `CONTRIBUTING.md`; contributors want it for the same reason CI does, on rebases of long-lived
 branches.
 
-Adding a workflow that **merges**? Add the step after checkout and before the merge, and add its
-row above — the pin fails otherwise. ⛔ Pushing is not merging, and this sentence said "merges or
-pushes" until [#6358](https://github.com/objectstack-ai/objectui/issues/6358): `changelog.yml`
-carried the step on the strength of that word, having no merge to resolve. A
-workflow that only commits and pushes needs no driver, and giving it one buys nothing while
-implying a lockfile hazard it does not have.
+Adding a workflow that merges **locally** — a merge git performs on the runner? Add the step
+after checkout and before the merge, and add its row above — the pin fails otherwise. This
+sentence has been read too widely twice, and each reading left a dead copy behind:
+
+⛔ **Pushing is not merging.** It said "merges or pushes" until
+[#6358](https://github.com/objectstack-ai/objectui/issues/6358): `changelog.yml` carried the step
+on the strength of that word, having no merge to resolve. A workflow that only commits and pushes
+needs no driver, and giving it one buys nothing while implying a lockfile hazard it does not have.
+
+⛔ **A server-side merge is not a local one.** `dependabot-auto-merge.yml` carried the step until
+[#6369](https://github.com/objectstack-ai/objectui/issues/6369) for a merge it genuinely performs
+— `gh pr merge`. But GitHub executes that one itself, not on the runner, so no local git config
+takes part in it.
 
 ## Adding a New Workflow
 

--- a/scripts/__tests__/check-pre-install-import-graph.test.ts
+++ b/scripts/__tests__/check-pre-install-import-graph.test.ts
@@ -111,9 +111,9 @@ describe('the population follows the workflows', () => {
   });
 
   it('does not read an install out of a shell comment or a quoted argument', () => {
-    // Both shapes are in this repository: `dependabot-auto-merge.yml` configures
-    // a merge driver whose VALUE is `"pnpm install --no-frozen-lockfile"` in a
-    // job that never installs, and block scalars carry `#` lines that are shell
+    // Both shapes are in this repository: `changeset-release.yml` configures a
+    // merge driver whose VALUE is `"pnpm install --no-frozen-lockfile"`, ahead of
+    // that job's real install, and block scalars carry `#` lines that are shell
     // comments rather than YAML ones. Reading either as an install moves the
     // boundary earlier and silently drops a script out of the population — the
     // shrinking direction, which costs coverage rather than raising a false red.

--- a/scripts/__tests__/dependabot-merge-gate.test.ts
+++ b/scripts/__tests__/dependabot-merge-gate.test.ts
@@ -540,7 +540,8 @@ describe('the workflow cannot merge without consulting the gate', () => {
     expect(workflow).toMatch(/steps\.metadata\.outputs\.update-type == 'version-update:semver-major'/);
   });
 
-  it('keeps the lockfile merge driver `ci-cd-pipeline.md` pins it for', () => {
-    expect(workflow).toContain('merge.pnpm-merge.driver');
-  });
+  // No merge-driver assertion here any more (objectui#6369). It existed to hold
+  // this workflow to the row `ci-cd-pipeline.md` pinned for it; that row is gone,
+  // because the only merge this workflow performs is server-side `gh pr merge`
+  // and a local driver cannot participate in one.
 });

--- a/scripts/check-pre-install-import-graph.mjs
+++ b/scripts/check-pre-install-import-graph.mjs
@@ -273,9 +273,9 @@ function shellCode(run) {
  *     BROWSER, not the workspace. The package-manager anchor is what excludes
  *     it, since `playwright` is not `pnpm`.
  *   - `git config merge.pnpm-merge.driver "pnpm install --no-frozen-lockfile"`
- *     (`dependabot-auto-merge.yml`) CONFIGURES a merge driver; it installs
- *     nothing in that job, which explicitly never installs. The command-position
- *     anchor is what excludes it -- the `pnpm` there is inside an argument.
+ *     (`changeset-release.yml`) CONFIGURES a merge driver; it installs nothing,
+ *     and that job's real install is a later step. The command-position anchor
+ *     is what excludes it -- the `pnpm` there is inside an argument.
  *
  * Getting that second one wrong would move the install boundary to step 4 and
  * silently drop `scripts/dependabot-merge-gate.mjs` out of the population --


### PR DESCRIPTION
Fixes #6369

`.github/workflows/dependabot-auto-merge.yml` configured the `pnpm-lock.yaml` merge driver, and had no occasion to invoke it. Both halves the pin requires ship here together.

## The falsification attempt came first

The card's reading only stands if nothing in that job merges locally, so the sweep ran over the **whole** file before anything was deleted — with a control term on every zero-hit, since a zero-hit with no control is not a reading:

```
$ grep -inE '\bgit[[:space:]]+(merge|rebase|pull|cherry-pick|am|apply|revert|stash|checkout|reset|fetch|clone|push|commit|add)\b' .github/workflows/dependabot-auto-merge.yml
105:      - name: Configure Git merge driver for pnpm-lock.yaml      <- a step NAME, not an invocation

$ grep -inE '\bgit[[:space:]]+(config|merge|rebase)\b' .github/workflows/dependabot-auto-merge.yml   # control
105:      - name: Configure Git merge driver for pnpm-lock.yaml
109:          git config merge.pnpm-merge.name "pnpm-lock.yaml merge driver"
110:          git config merge.pnpm-merge.driver "pnpm install --no-frozen-lockfile"
```

The control proves the sweep reads: `git config` is matched by the same regex shape a `git merge` would be. Every literal `git ` in the file is on lines 105–110, and the only two that execute are the `git config` pair being removed. `rebase`, `cherry-pick` and `git apply` are zero across the file.

Three things that could have merged without spelling it `git`, each checked rather than assumed:

- **`actions/checkout@v7`** fetches a ref and checks it out. On a `pull_request` event that ref is the merge commit **GitHub has already computed** — checking out an existing commit performs no three-way merge, so no driver is consulted. (`submodules: true` also finds no `.gitmodules` in this repo.)
- **`scripts/dependabot-merge-gate.mjs`**, the job's only `node` step, imports `node:fs` and one local helper. No `child_process`, no `exec`, no `spawn`, no `git` — control term `GATE_TIMEOUT_SECONDS` hits in the same sweep.
- **`dependabot/fetch-metadata@v3`** and **`actions/github-script@v9`** read the API and post a comment; the inline script is visible in the file and only calls `issues.createComment`.

The one merge the job really does perform is the last step's `gh pr merge --auto --squash`, and **GitHub executes that server-side** in the merge queue. The runner's local git config is not consulted and cannot participate. So the driver was inert — the same *no-occasion* property #6358 measured on `changelog.yml`, reached by a different route: that job never merged at all, this one merges only where local config cannot reach.

⛔ Not claimed: that the configuration was harmful. It cost two lines and no runtime. The claim is only that it was inert, and that the repo was teaching otherwise.

## What the table is down to

This is the reason the change is worth making. `scripts/__tests__/ci-cd-pipeline-doc.test.ts` pins the "Lockfile Merge Driver" table against the workflows that actually configure `merge.pnpm-merge`, in **both directions** — so it is documentation with a gate behind it. With `changelog.yml` removed by #6358 and this one removed here, that table has **one row left**: `changeset-release.yml`.

⚠️ One thing this PR deliberately does **not** assert, because I did not measure it: that the remaining row is itself live. The same sweep over `changeset-release.yml` finds no `git merge`, `rebase` or `pull` either — its commits and pushes go through `changesets/action@v1`, which force-pushes the version branch. Whether that reaches a driver is a **separate question on a workflow this card does not cover**, and I have left it entirely alone. It is called out in my report for triage rather than answered here.

## Both halves, because they are pinned against each other

Reverse-verified rather than asserted. From the committed state, each half was restored alone and the pin re-run:

| Ablation | Result | Failure message |
|---|---|---|
| doc row restored, workflow edited | **red** | *the "Lockfile Merge Driver" table names workflows that do NOT configure `merge.pnpm-merge`* |
| workflow step restored, doc edited | **red** | *these workflows configure the pnpm-lock.yaml merge driver but have no row* |

Each mutation was confirmed on disk by a `git hash-object` change before the run, and each restoration proven by `git diff HEAD` reporting zero changed paths afterwards — not by a trap having fired.

## Changed

- **`.github/workflows/dependabot-auto-merge.yml`** `:105–110` — the step goes; a comment in its place records why, what was swept, and that restoring it needs a real *local* merge first.
- **`content/docs/guide/ci-cd-pipeline.md`** `:1527` (the workflow's own section bullet), `:1597–1602` (the pinned table row, and "Two workflows" → "One workflow").
- **`scripts/__tests__/dependabot-merge-gate.test.ts`** `:543–545` — a **third** pin, not named in the card and red without this: the test named *"keeps the lockfile merge driver ci-cd-pipeline.md pins it for"* asserted the workflow still contained `merge.pnpm-merge.driver`. Its own title states its premise is the doc row, so it goes with the row. Test count moves 69 → 68 on those two files, which is exactly this one assertion.

Two citations my deletion would have silently falsified — both used this workflow's driver line as the repo's live worked example for "a quoted `pnpm install` that is not an install" — are re-pointed at `changeset-release.yml:525–526`, which still carries the identical line:

- **`scripts/check-pre-install-import-graph.mjs`** `:275–278`
- **`scripts/__tests__/check-pre-install-import-graph.test.ts`** `:114–117` (comment only; the fixture beside it is a synthetic string and unaffected)
- **`content/docs/guide/ci-cd-pipeline.md`** `:777–779`, the same example in prose

## Stopping the class from regenerating (#6369 disposition 3)

#6358 already corrected "merges **or pushes**" in this guide. Two residues of the same over-wide instruction remained, and both are sentence-level, in the section this PR is already editing:

1. "every workflow that merges, rebases, **or commits onto a branch that may have moved**" — the exact phrasing #6358 repudiated, still standing three paragraphs above the correction. Now: a **local** merge or rebase, one git carries out on the runner.
2. "Adding a workflow that **merges**?" would still have caught this workflow, which *does* merge — server-side. That is precisely how this dead copy got written, so the guide now names both readings that produced one: a push is not a merge, and a server-side merge is not a local one.

## Verification

`pnpm vitest run scripts/__tests__` on the committed tree `901c56704`: **79 files, 2278 tests, all passed**. The two named pins verbose: `lists exactly the workflows that configure merge.pnpm-merge — in both directions` ✓ and `keeps the .gitattributes half of the mechanism true` ✓ (`.gitattributes` is untouched — `changeset-release.yml` still needs it).

Gates touched by these edits, each read from its own verdict line: `check-pre-install-import-graph` OK (16 pre-install steps, 18 modules walked) · `check-changeset-no-major` OK · `check-control-bytes` OK (5262 files) · `check-changeset-presence` OK. Changeset is empty-frontmatter — no published package `src/` is touched, so this declares "no release" explicitly.

## Note, not asserted

With the driver gone, `corepack enable` and `pnpm --version` (`:91–95`) are the only pnpm-related steps left in a job whose own comment says it "never runs `pnpm install`" — the driver body was the only thing in it that needed pnpm. Removing them is a judgement I did not make here, and `actions/setup-node` must stay regardless (the gate script needs Node). Flagged for the reviewing seat rather than acted on.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_