### PR TITLE
fix(tooling): derive QUICK_REFERENCE's Node/pnpm floor as full version

### DIFF
--- a/.changeset/6313-quick-reference-node-floor.md
+++ b/.changeset/6313-quick-reference-node-floor.md
@@ -1,0 +1,16 @@
+---
+---
+
+Tooling-only fix (objectui#6313): `QUICK_REFERENCE.md`'s "Current Release" pin
+(`scripts/__tests__/quick-reference-current-release-4143.test.ts`) and the sync
+generator (`scripts/sync-quick-reference-release.mjs`) derived the Node/pnpm
+version floors with `match(/(\d+)/)?.[1]`, which keeps only the LEADING integer
+group. Against root `engines.node: ">=22.11"` (objectui#5306 / PR #6311) that
+produced a floor of `22`, silently discarding the `.11` — so a row reading
+exactly `≥ 22` passed a pin whose whole premise is disagreeing with its own
+cited anchor. Both derivations now strip the comparator and keep the WHOLE
+version string; `pnpm quick-reference:sync` regenerated the Node.js row to
+`≥ 22.11`. Added regression coverage pinning that a `≥ 22`-shaped row is now
+rejected and that a `≥ 220`-shaped row still is (objectui#4913), and corrected
+the test file's docblock, which had gone stale on the same anchor one decimal
+place up. No published package source changed.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -127,7 +127,7 @@ behind (objectui#5394 — that had happened once per release, three times).
   `apps/console/package.json`)
 - **Client:** `@objectstack/client` ^17.0.0 (declared by `apps/console/package.json`
   and `packages/data-objectstack/package.json`)
-- **Node.js:** ≥ 22 (see root `engines.node`)
+- **Node.js:** ≥ 22.11 (see root `engines.node`)
 - **pnpm:** ≥ 10 (the workspace pins `pnpm@10.31.0` via `packageManager`)
 - **React:** 18.x or 19.x (the `peerDependencies.react` range the packages declare)
 - **TypeScript:** ≥ 5.0 (strict mode) — the stack floor stated in AGENTS.md §2, not a

--- a/scripts/__tests__/quick-reference-current-release-4143.test.ts
+++ b/scripts/__tests__/quick-reference-current-release-4143.test.ts
@@ -12,10 +12,19 @@ import { fileURLToPath } from 'node:url';
  *
  * The card's premise also said the block's Node/pnpm/React rows were "currently
  * accurate". Two of the three were. **Node was not** — the row read `≥ 20` while
- * root `engines.node` has been `>=22`, and the row *names that anchor in its own
- * text*. A claim that cites its anchor and disagrees with it is the strongest
- * possible argument that review alone does not hold this block: the reviewer had
- * the pointer and still did not follow it.
+ * root `engines.node` was `>=22` at the time, and the row *names that anchor in
+ * its own text*. A claim that cites its anchor and disagrees with it is the
+ * strongest possible argument that review alone does not hold this block: the
+ * reviewer had the pointer and still did not follow it.
+ *
+ * `engines.node` has since moved again, to `>=22.11` (objectui#5306 / PR #6311) —
+ * and objectui#6313 is the same shape of drift one decimal place down: the
+ * forward assertion below derived its expected floor with `match(/(\d+)/)`,
+ * which keeps only the LEADING integer group and silently discards everything
+ * after it. `>=22.11` derived a floor of `22`, so a row reading exactly `≥ 22`
+ * (missing the `.11` its own anchor carries) passed. The derivation below now
+ * strips the comparator and keeps the WHOLE version string instead, so the row
+ * and the anchor can no longer disagree at the minor version.
  *
  * ## Why a per-block pin and not the repo's existing ratchet
  *
@@ -121,6 +130,21 @@ function peerMajors(range: string): string[] {
     .split('||')
     .map((comparator) => comparator.trim().match(/^[\^~>=<\s]*(\d+)\./)?.[1])
     .filter((major): major is string => major !== undefined);
+}
+
+/**
+ * The floor an `engines`-style range states, as the WHOLE version string — not just
+ * its leading integer group.
+ *
+ * objectui#6313: the previous derivation, `match(/(\d+)/)?.[1]`, kept only the
+ * leading digits, so `>=22.11` produced a floor of `22` and silently discarded the
+ * `.11` rather than failing. A row reading exactly `≥ 22` then satisfied an anchor
+ * that actually says `22.11`. Stripping the comparator and keeping the remainder
+ * whole means the row and the anchor can no longer disagree at any segment the
+ * anchor carries.
+ */
+function versionFloor(range: string): string | undefined {
+  return range.match(/^[\^~>=<\s]*(.+)$/)?.[1];
 }
 
 /**
@@ -314,8 +338,8 @@ describe('QUICK_REFERENCE.md "Current Release" — toolchain rows', () => {
     const engine = rootManifest.engines?.node;
     expect(engine, 'root package.json must still declare engines.node').toBeDefined();
 
-    const floor = (engine as string).match(/(\d+)/)?.[1];
-    expect(floor, `engines.node must still carry a numeric floor (got "${engine}")`).toBeDefined();
+    const floor = versionFloor(engine as string);
+    expect(floor, `engines.node must still carry a version floor (got "${engine}")`).toBeDefined();
     expectRowStates(
       'Node.js',
       [`≥ ${floor}`],
@@ -323,10 +347,64 @@ describe('QUICK_REFERENCE.md "Current Release" — toolchain rows', () => {
     );
   });
 
+  /**
+   * objectui#6313: `match(/(\d+)/)?.[1]` on `engines.node` kept only the leading
+   * integer group, so `>=22.11` derived a floor of `22` and a row reading exactly
+   * `≥ 22` — missing the `.11` its own anchor states — passed. Two properties, both
+   * measured against the REAL `engines.node` rather than a hard-coded literal, so
+   * this cannot itself go stale the way the row it guards did:
+   *
+   * - The old (leading-integer) and new (whole-string) derivations must disagree
+   *   whenever the anchor carries a minor — proving the fix changed what floor
+   *   comes OUT, not just how it is computed. If `engines.node` ever loses its
+   *   minor this assertion goes quiet, which is why the next one does not depend
+   *   on that disagreement to make its point.
+   * - A row stating the coarser, pre-fix floor must be REJECTED by the same
+   *   equality `expectRowStates` uses above. This is the entire point of the card:
+   *   if `≥ 22` were accepted before the fix and still accepted after it, the
+   *   derivation changed without changing what the pin enforces.
+   */
+  it('derives the Node floor as the whole version, not just its leading integer group', () => {
+    const engine = rootManifest.engines?.node as string;
+    const staleFloor = engine.match(/(\d+)/)?.[1];
+    const floor = versionFloor(engine);
+
+    expect(
+      floor,
+      `engines.node ("${engine}") no longer carries a minor segment for the leading-integer ` +
+        `derivation ("${staleFloor}") to differ from — objectui#6313's regression case needs one ` +
+        're-anchored to keep exercising the disagreement',
+    ).not.toBe(staleFloor);
+
+    expect(
+      statedLiterals(`≥ ${staleFloor}`),
+      `a row reading "≥ ${staleFloor}" must NOT satisfy the derived Node floor "≥ ${floor}" — ` +
+        'accepting it is exactly the objectui#6313 staleness this pin exists to catch',
+    ).not.toEqual(statedLiterals(`≥ ${floor}`));
+  });
+
+  /**
+   * The coarseness objectui#4913 already fixed for `toContain` (a numerically-prefixed
+   * SUPERSET like `≥ 220` passing against a derived `≥ 22`) must not come back now that
+   * the floor is derived differently. Built off the real anchor's leading integer group
+   * so this states the exact shape the card's own history section records, rather than
+   * a made-up number.
+   */
+  it('rejects a `≥ 220`-shaped row as equal to a shorter derived Node floor', () => {
+    const engine = rootManifest.engines?.node as string;
+    const staleFloor = engine.match(/(\d+)/)?.[1] as string;
+
+    expect(
+      statedLiterals(`≥ ${staleFloor}0`),
+      `"≥ ${staleFloor}0" must not equal "≥ ${staleFloor}" — a numeric-prefix superset is not the ` +
+        'same version literal, the objectui#4913 regression this guards',
+    ).not.toEqual(statedLiterals(`≥ ${staleFloor}`));
+  });
+
   it('states the pnpm floor and the pinned `packageManager`', () => {
     const engine = rootManifest.engines?.pnpm;
     expect(engine, 'root package.json must still declare engines.pnpm').toBeDefined();
-    const floor = (engine as string).match(/(\d+)/)?.[1];
+    const floor = versionFloor(engine as string);
 
     const pinned = rootManifest.packageManager;
     expect(pinned, 'root package.json must still declare packageManager').toBeDefined();
@@ -420,8 +498,8 @@ describe('QUICK_REFERENCE.md "Current Release" — no un-derived literal', () =>
     add(consoleManifest.version);
     add(rootManifest.devDependencies?.['@objectstack/spec']);
     add(consoleManifest.devDependencies?.['@objectstack/client']);
-    add(`≥ ${rootManifest.engines?.node?.match(/(\d+)/)?.[1]}`);
-    add(`≥ ${rootManifest.engines?.pnpm?.match(/(\d+)/)?.[1]}`);
+    add(`≥ ${versionFloor(rootManifest.engines?.node ?? '')}`);
+    add(`≥ ${versionFloor(rootManifest.engines?.pnpm ?? '')}`);
     add(rootManifest.packageManager?.split('@').pop());
     for (const major of peerMajors(reactManifest.peerDependencies?.react ?? '')) {
       add(`${major}.x`);

--- a/scripts/sync-quick-reference-release.mjs
+++ b/scripts/sync-quick-reference-release.mjs
@@ -88,8 +88,8 @@ export const normalize = (literal) => literal.replace(/\s+/g, '');
  * @property {string} version      the one version the `fixed` group carries
  * @property {string} spec         the `@objectstack/spec` range
  * @property {string} client       the `@objectstack/client` range
- * @property {string} nodeFloor    numeric floor out of root `engines.node`
- * @property {string} pnpmFloor    numeric floor out of root `engines.pnpm`
+ * @property {string} nodeFloor    version floor out of root `engines.node`
+ * @property {string} pnpmFloor    version floor out of root `engines.pnpm`
  * @property {string} pnpmPinned   the version half of root `packageManager`
  * @property {string[]} reactMajors the majors named by the react peer range
  */
@@ -112,6 +112,21 @@ export function peerMajors(range) {
     .split('||')
     .map((comparator) => comparator.trim().match(/^[\^~>=<\s]*(\d+)\./)?.[1])
     .filter((major) => major !== undefined);
+}
+
+/**
+ * The floor an `engines`-style range states, as the WHOLE version string — not
+ * just its leading integer group.
+ *
+ * objectui#6313: the previous derivation, `match(/(\d+)/)?.[1]`, kept only the
+ * leading digits, so `>=22.11` produced a floor of `22` and this script would
+ * regenerate `≥ 22`, silently discarding the `.11` the anchor actually states.
+ * Stripping the comparator and keeping the remainder whole means the row this
+ * script writes and the anchor it reads can no longer disagree at any segment
+ * the anchor carries. Same derivation as the gate's copy of this function.
+ */
+export function versionFloor(range) {
+  return range.match(/^[\^~>=<\s]*(.+)$/)?.[1];
 }
 
 /**
@@ -180,11 +195,11 @@ export function readAnchors(root = repoRoot) {
     );
   }
 
-  const nodeFloor = rootManifest.engines?.node?.match(/(\d+)/)?.[1];
-  const pnpmFloor = rootManifest.engines?.pnpm?.match(/(\d+)/)?.[1];
+  const nodeFloor = rootManifest.engines?.node && versionFloor(rootManifest.engines.node);
+  const pnpmFloor = rootManifest.engines?.pnpm && versionFloor(rootManifest.engines.pnpm);
   const pnpmPinned = rootManifest.packageManager?.split('@').pop();
-  if (!nodeFloor) throw new Error('root package.json must still declare a numeric engines.node floor');
-  if (!pnpmFloor) throw new Error('root package.json must still declare a numeric engines.pnpm floor');
+  if (!nodeFloor) throw new Error('root package.json must still declare a version-floor engines.node');
+  if (!pnpmFloor) throw new Error('root package.json must still declare a version-floor engines.pnpm');
   if (!pnpmPinned) throw new Error('root package.json must still declare packageManager');
 
   const peer = reactManifest.peerDependencies?.react;


### PR DESCRIPTION
Fixes #6313

## What

`scripts/__tests__/quick-reference-current-release-4143.test.ts` and the sync
generator `scripts/sync-quick-reference-release.mjs` both derived the Node/pnpm
version floors with `match(/(\d+)/)?.[1]` — keeping only the **leading integer
group**. Against root `engines.node: ">=22.11"` (objectui#5306 / PR #6311) that
produced a floor of `22`, silently discarding the `.11`, so `QUICK_REFERENCE.md`'s
Node.js row read exactly `≥ 22` and passed a pin whose entire premise is
disagreeing with its own cited anchor.

Per the triage ruling (disposition 1, closed — dispositions 2/3 not re-argued):

1. **`scripts/__tests__/quick-reference-current-release-4143.test.ts`** — added a
   `versionFloor()` helper (strip the comparator, keep the rest of the string
   whole) and switched the Node forward assertion, the pnpm forward assertion, and
   both `add(...)` calls in the reverse "no un-derived literal" sweep to use it.
2. **`scripts/sync-quick-reference-release.mjs`** — same `versionFloor()` helper
   and the same switch for `nodeFloor`/`pnpmFloor` in `readAnchors()`, so the
   script that actually writes the row derives the same value the gate checks.
3. **`QUICK_REFERENCE.md`** — regenerated via `pnpm quick-reference:sync` (not
   typed by hand); the Node.js row now reads `≥ 22.11`.
4. **Docblock** — corrected the sentence claiming root `engines.node` "has been
   `>=22`" (false since PR #6311 landed `>=22.11` today) and added a paragraph
   recording the objectui#6313 drift for future readers.

Also added two regression tests, both deriving from the real manifest rather than
a hard-coded literal:

- a `≥ 22`-shaped row is now rejected against the derived Node floor (the entire
  point of the card — this passed both the derivation's old AND a naive
  reimplementation's output would have to be checked against it, not assumed)
- a `≥ 220`-shaped row is rejected too (objectui#4913's coarseness, now checked
  against the new derivation rather than just the old one)

No published package source changed; the changeset declares no release
(tooling/test/doc only).

## Evidence

**Before (old derivation, on the real manifest strings):**
```
engines.node ">=22.11" -> match(/(\d+)/)?.[1]           -> "22"
engines.pnpm ">=10"    -> match(/(\d+)/)?.[1]           -> "10"
```

**After (new `versionFloor`, same real strings):**
```
engines.node ">=22.11" -> versionFloor()                -> "22.11"
engines.pnpm ">=10"    -> versionFloor()                -> "10"   (unharmed today, fixed for when it isn't)
```

**The card's core property — a `≥ 22` row now fails where it used to pass** (code
fix committed, doc not yet regenerated — the doc still said `≥ 22` at this point):
```
 FAIL  … > states the Node floor from root `engines.node`
 AssertionError: QUICK_REFERENCE.md must state the Node floor as exactly "≥ 22.11"
 to match engines.node ">=22.11": expected [ '≥22' ] to deeply equal [ '≥22.11' ]
 FAIL  … > contains only version literals this test derives from a manifest
 Test Files  1 failed (1) / Tests 2 failed | 8 passed (10)
```
Ran `pnpm quick-reference:sync` (rewrote the row to `≥ 22.11`) → re-ran → `Test
Files 2 passed (2) / Tests 22 passed (22)` across both the gate and the
generator's own test file.

**The `≥ 220` negative case, against the real committed file** (plant → RED →
`git checkout HEAD -- QUICK_REFERENCE.md` under a `trap … EXIT INT TERM` →
restore verified by blob hash + empty `git diff HEAD` → GREEN):
```
sed -i 's/**Node.js:** ≥ 22.11/**Node.js:** ≥ 220/' QUICK_REFERENCE.md
 FAIL  … Tests 2 failed | 8 passed (10)
(trap restores)
git hash-object QUICK_REFERENCE.md   == HEAD:QUICK_REFERENCE.md   (4097a911b…)
git diff HEAD -- QUICK_REFERENCE.md  == (empty)
 Test Files 2 passed (2) / Tests 22 passed (22)
```

## Checks run locally

- `pnpm exec vitest run scripts/__tests__/quick-reference-current-release-4143.test.ts scripts/__tests__/sync-quick-reference-release.test.ts` → 2 passed, 22 tests
- `pnpm exec vitest run scripts/` (full `scripts/` suite) → 79 files / 2281 tests passed
- `pnpm quick-reference:check` → in sync
- `node scripts/check-changeset-presence.mjs` → no source of a released package changed; changeset added
- `node scripts/check-changeset-no-major.mjs` → clean
- `pnpm run type-check:scripts` (covers `scripts/__tests__/*.ts`) → clean
- `node scripts/check-type-check-coverage.mjs` → 45/46 + 41/41, unaffected
- `pnpm run lint:root` (covers `scripts/**`) → 0 errors, 28 pre-existing warnings elsewhere, none in touched files
- `node scripts/check-control-bytes.mjs` → clean

CI (`ci.yml`) will run the full suite; leaving this in draft for the PM seat to
arm per dispatch order.


---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_