### PR TITLE
docs(guide): replace invented Node/pnpm floors with what CI exercises, and let the version-claim scan see emphasis

### DIFF
--- a/.changeset/6307-bold-version-literals.md
+++ b/.changeset/6307-bold-version-literals.md
@@ -1,0 +1,35 @@
+---
+---
+
+Docs and gate change; no published surface.
+
+Two consumer-facing guides stated Node/pnpm floors this project neither declares nor
+tests: `content/docs/guide/quick-start.md` carried `**Node.js** 20+` / `**pnpm** 9+ or
+npm/yarn`, and `content/docs/guide/building-crud-app.md` the same pair on one line. Both
+pages address the reader's OWN project, so the root `engines` field never governed them,
+and no published package supplies a floor either — of the 46 workspace manifests, zero
+declare `engines.node` or `engines.pnpm` (the only `engines` block outside the root is
+`packages/vscode-extension`'s `engines.vscode`). The pages now state what is measurable
+instead: the packages are built and tested on Node 22.x with pnpm 10.x — 26 of the 27
+`node-version:` declarations in `.github/workflows` read `'22.x'` and the 27th reads
+`'22'`; the root `packageManager` field is `pnpm@10.31.0`, which is what `corepack enable`
+hands every CI job. Worded as what CI exercises, not as a requirement the project has not
+measured.
+
+The reason nothing objected: `scripts/__tests__/doc-version-claims.test.ts` scans
+`content/docs` for exactly this, and the `SEP` character class between a toolchain name
+and its version admitted backticks, quotes, whitespace, colons, commas, pipes and brackets
+— but not `*`. So `**Node.js** 20+` never matched `TOOLCHAIN + SEP + VERSION`, and the
+ratchet reported green over four literals it had never examined. `SEP` now admits `*` and
+`_`; measured over the 241 files the three scan roots resolve to, the corpus goes from 33
+matched literals to 37 — exactly those four, none lost. None of the four was ledgered:
+they were deleted, which is what the gate's own failure message asks for when a literal
+restates no manifest and no lane tests it, and the sentences replacing them are inventoried
+as `anchored` entries naming the anchor each can be re-measured against.
+
+A new fixture test keeps the widening measurable now that the repaired corpus carries no
+emphasised claim at all, and pins the one boundary it does not cross: `_Node.js_ 20+` stays
+invisible, because `_` is a word character and the `\b` on each side of the toolchain name
+therefore fires on neither side of it (measured: zero such spellings in the corpus today).
+
+objectui#6307.

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -9,7 +9,7 @@ This tutorial walks you through building a **Task Manager** CRUD application wit
 
 ## Prerequisites
 
-- **Node.js** 20+ and **pnpm** 9+
+- **Node.js**, plus **pnpm**, npm or yarn to install with. The published ObjectUI packages declare no Node or pnpm `engines` floor, so this guide states no minimum — what the project measures is CI, which builds and tests them on Node 22.x with pnpm 10.x.
 - Basic knowledge of **React** and **TypeScript**
 
 ## Step 1: Project Setup

--- a/content/docs/guide/building-crud-app.md
+++ b/content/docs/guide/building-crud-app.md
@@ -9,7 +9,7 @@ This tutorial walks you through building a **Task Manager** CRUD application wit
 
 ## Prerequisites
 
-- **Node.js**, plus **pnpm**, npm or yarn to install with. The published ObjectUI packages declare no Node or pnpm `engines` floor, so this guide states no minimum — what the project measures is CI, which builds and tests them on Node 22.x with pnpm 10.x.
+- **Node.js** and **pnpm** (or npm/yarn) — ObjectUI is tested on Node 22.x with pnpm 10.x.
 - Basic knowledge of **React** and **TypeScript**
 
 ## Step 1: Project Setup

--- a/content/docs/guide/quick-start.md
+++ b/content/docs/guide/quick-start.md
@@ -9,8 +9,7 @@ Get up and running with ObjectUI in a small Vite app. This guide installs the co
 
 ## Prerequisites
 
-- **Node.js** 20+
-- **pnpm** 9+ or npm/yarn
+- **Node.js**, plus **pnpm**, npm or yarn to install with. The published ObjectUI packages declare no Node or pnpm `engines` floor, so this guide states no minimum — what the project measures is CI, which builds and tests them on Node 22.x with pnpm 10.x.
 - Basic knowledge of **React** and **TypeScript**
 
 ## Step 1: Create a React Project

--- a/content/docs/guide/quick-start.md
+++ b/content/docs/guide/quick-start.md
@@ -9,7 +9,7 @@ Get up and running with ObjectUI in a small Vite app. This guide installs the co
 
 ## Prerequisites
 
-- **Node.js**, plus **pnpm**, npm or yarn to install with. The published ObjectUI packages declare no Node or pnpm `engines` floor, so this guide states no minimum — what the project measures is CI, which builds and tests them on Node 22.x with pnpm 10.x.
+- **Node.js** and **pnpm** (or npm/yarn) — ObjectUI is tested on Node 22.x with pnpm 10.x.
 - Basic knowledge of **React** and **TypeScript**
 
 ## Step 1: Create a React Project

--- a/scripts/__tests__/doc-version-claims.test.ts
+++ b/scripts/__tests__/doc-version-claims.test.ts
@@ -277,6 +277,46 @@ import { fileURLToPath } from 'node:url';
  * manifests (it wires Tailwind 4 through `@tailwindcss/postcss` instead), so there is
  * nothing here to compare against, whatever the page teaches.
  *
+ * ## What objectui#6307 added: the SPELLING the scan could not see
+ *
+ * Every widening above added a surface or a name. This one added a SEPARATOR, and it is
+ * the first whose absence was invisible from inside this gate's own output: a green
+ * ratchet looks identical whether it examined a line or never matched it at all.
+ *
+ * `SEP` admitted backticks, quotes, whitespace, colons, commas, pipes, brackets and a
+ * dash — and not `*`. So `**Node.js** 20+` never matched `TOOLCHAIN + SEP + VERSION`,
+ * while markdown emphasis around a toolchain name is one of this corpus's ordinary
+ * spellings: measured at this cut, six files across the three scan roots write one in
+ * bold. Two of them were the consumer guides' prerequisite bullets, where the number is
+ * exactly what a reader acts on.
+ *
+ * Measured across the widening, over the 241 files the three roots resolve to: 33
+ * matched literals before, 37 after — four new, none lost, all four on the two pages
+ * objectui#6307 names (`quick-start.md:12-13` and `building-crud-app.md:12`).
+ *
+ * NOT ONE of the four earned an inventory entry, and that is the half of this change
+ * worth carrying forward. They were not a floor this project declares — of the 46
+ * workspace manifests, ZERO declare `engines.node` or `engines.pnpm`, the only
+ * `engines` block outside the root being `packages/vscode-extension`'s `engines.vscode`
+ * — and not one it tests: 26 of the 27 `node-version:` declarations in
+ * `.github/workflows` read `'22.x'` and the 27th reads `'22'`, so nothing anywhere runs
+ * the Node 20 those bullets named. A number a reader will act on, restating no manifest
+ * and tested by no lane, is precisely what the ratchet's own failure message says to
+ * DELETE rather than ledger. The pages now state what CI exercises instead, and THOSE
+ * sentences are the four `anchored` entries below — an entry per literal, each naming
+ * the anchor it can be re-measured against.
+ *
+ * Which leaves the trap this section exists to stop. After that repair the corpus holds
+ * no emphasised claim at all, so reverting `SEP` would change nothing observable and
+ * this file would report green over the same blind spot again.
+ * `it('reads a claim through markdown emphasis…')` is the permanent witness, and it
+ * also pins the boundary the widening does NOT cross: `_` is in the class, yet
+ * `_Node.js_ 20+` still cannot match, because `_` is a word character and the `\b` on
+ * each side of `TOOLCHAIN` therefore fires on neither side of the name. Measured: zero
+ * underscore-emphasised toolchain names in the corpus today (control, same sweep: six
+ * files carry the bold spelling), so it is recorded as a boundary rather than repaired
+ * by widening those boundaries into a lookaround nothing has asked for.
+ *
  * ## The census that set the design (measured on d46b40324, the merge of PR #3698)
  *
  * The dispatch expected the bare-claim count to be zero, since #3688 and #3698 had just
@@ -446,7 +486,7 @@ const TOOLCHAIN =
  * spelled without the wildcard in the comments here.
  */
 const TICK = '\u0060';
-const SEP = '[' + TICK + '\'"\\s:,|)\\]]{0,6}(?:[-—]\\s*)?[' + TICK + '\'"]?\\s*';
+const SEP = '[' + TICK + '\'"\\s:,|)\\]*_]{0,6}(?:[-—]\\s*)?[' + TICK + '\'"]?\\s*';
 
 /**
  * Case-insensitive, and the reason is the biggest single class in the corpus: the
@@ -687,6 +727,18 @@ const PEER_RESTATEMENT_OK =
 const KNOWN_CLAIMS: KnownClaim[] = [
   // --- content/docs ------------------------------------------------------------
   {
+    file: 'content/docs/guide/building-crud-app.md',
+    claim: 'Node 22.x',
+    kind: 'anchored',
+    why: "Anchored on the workflows: of the 27 node-version declarations in .github/workflows, 26 read '22.x' and the 27th (half-state-patrol.yml) reads '22'. Written by objectui#6307, which replaced an invented consumer floor (`**Node.js** 20+`) on this page. The sentence around it states what CI EXERCISES, not what a reader's project requires - no manifest in this tree declares a consumer engines.node, so a floor here would be a number nobody measured.",
+  },
+  {
+    file: 'content/docs/guide/building-crud-app.md',
+    claim: 'pnpm 10.x',
+    kind: 'anchored',
+    why: 'Anchored on the root packageManager field, pnpm@10.31.0: 17 corepack enable steps across 12 workflow files mean the pnpm that installs and builds these packages in CI is the one that field names. Same objectui#6307 rewrite as the Node line above, replacing `**pnpm** 9+` - a floor zero manifests in this workspace declare.',
+  },
+  {
     file: 'content/docs/guide/ci-cd-pipeline.md',
     claim: 'Node 22.x',
     kind: 'anchored',
@@ -723,6 +775,18 @@ const KNOWN_CLAIMS: KnownClaim[] = [
     kind: 'anchored',
     skeletonDep: 'vite',
     why: 'Same skeleton, same anchor, same assertion (objectui#3855). This was the worst of the pair: it read ^5.0.0 against a workspace unanimously on ^8.2.1 — three majors — and the entry excusing it said the plugin author picks their own bundler version, which is not what a workspace:* manifest with a vite build script means.',
+  },
+  {
+    file: 'content/docs/guide/quick-start.md',
+    claim: 'Node 22.x',
+    kind: 'anchored',
+    why: "Same anchor and same objectui#6307 rewrite as the building-crud-app.md entry above (26 of 27 node-version declarations read '22.x'); this page carried the same invented floor in two bullets, `**Node.js** 20+` and `**pnpm** 9+`, and both were invisible to this scan until SEP admitted emphasis markers.",
+  },
+  {
+    file: 'content/docs/guide/quick-start.md',
+    claim: 'pnpm 10.x',
+    kind: 'anchored',
+    why: 'Same anchor as the building-crud-app.md pnpm entry above: the root packageManager field, pnpm@10.31.0, is what corepack hands every CI job that installs this workspace. Written by objectui#6307 in place of `**pnpm** 9+`.',
   },
   {
     file: 'content/docs/guide/theming.md',
@@ -1372,6 +1436,66 @@ describe('doc version claims - the scan itself', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it('reads a claim through markdown emphasis, so the widened separator is not decorative', () => {
+    // objectui#6307. `SEP` admitted backticks, quotes, whitespace, colons, commas,
+    // pipes and brackets — and not `*` — so `**Node.js** 20+` never matched
+    // `TOOLCHAIN + SEP + VERSION`. Both consumer guides spelled their prerequisite
+    // floors that way, four literals across two pages, and this gate reported green
+    // over every one of them: the failure its own header warns about for other
+    // classes, arriving through the scan instead.
+    //
+    // This fixture is the widening's only PERMANENT witness, which is why it is here
+    // rather than left to the corpus. The four literals that motivated the change
+    // were DELETED by the same change (they stated a consumer floor this project
+    // neither declares nor tests, objectui#6307 half 1), and the sentences that
+    // replaced them put a plain space between each name and its version. So on the
+    // corpus alone, reverting `SEP` to its pre-#6307 spelling would change nothing
+    // observable and the blind spot would come back unnoticed.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doc-version-claims-emphasis-'));
+    try {
+      const fixture = path.join(dir, 'prerequisites-shaped.md');
+      fs.writeFileSync(
+        fixture,
+        ['# Prerequisites', '', '- **Node.js** 20+', '- *pnpm* 9+ or npm/yarn', ''].join('\n'),
+        'utf8',
+      );
+
+      expect(
+        claimsIn(fixture).map((c) => c.claim),
+        'a toolchain name wrapped in markdown emphasis must still produce a claim',
+      ).toEqual(['Node.js** 20+', 'pnpm* 9+']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+
+    // The two spellings pinned side by side, so that "the widening bought something"
+    // is asserted rather than believed: the pre-#6307 class, rebuilt here, must FAIL
+    // on the same line the current one matches.
+    const claimWith = (sep: string): RegExp =>
+      new RegExp('(?:@[a-z0-9-]+/)?\\b' + TOOLCHAIN + '\\b' + sep + '(' + VERSION + ')', 'i');
+    const SEP_BEFORE_6307 = '[' + TICK + '\'"\\s:,|)\\]]{0,6}(?:[-—]\\s*)?[' + TICK + '\'"]?\\s*';
+
+    expect(claimWith(SEP).test('- **Node.js** 20+'), 'the current SEP must match the bold spelling').toBe(true);
+    expect(
+      claimWith(SEP_BEFORE_6307).test('- **Node.js** 20+'),
+      'the pre-objectui#6307 SEP must be shown NOT to match, or nothing here says what the widening changed',
+    ).toBe(false);
+
+    // The residual, asserted rather than left for someone to assume away: `_` is in
+    // the class (it costs nothing between a name and a version) but underscore
+    // EMPHASIS around the name is still invisible, and no character class can reach
+    // it. `_` is a word character, so `\b` fires on neither side of `_Node.js_` —
+    // the match fails before `SEP` is ever consulted. Measured at this cut across the
+    // three scan roots: ZERO underscore-emphasised toolchain names (control, same
+    // sweep: six files carry the bold spelling), so this is a documented boundary and
+    // not a live hole. A corpus that starts spelling it that way needs the BOUNDARIES
+    // widened, not the class.
+    expect(
+      claimWith(SEP).test('- _Node.js_ 20+'),
+      'if this ever goes true the boundary was changed too - update this comment with what it now covers',
+    ).toBe(false);
   });
 
   it('does not treat a numbered section heading as a release section', () => {


### PR DESCRIPTION
Fixes #6307

Both halves, in the ruled order: half 2 first, because it defines half 1's surface.

All readings below were taken on `992bcec7f`, the final commit of this branch.

## Half 2 — the scan was blind to `**bold**`

`SEP`, the class between a toolchain name and its version, admitted backticks, quotes, whitespace, colons, commas, pipes and brackets — and not `*`. It now admits `*` and `_`:

```diff
-const SEP = '[' + TICK + '\'"\\s:,|)\\]]{0,6}(?:[-—]\\s*)?[' + TICK + '\'"]?\\s*';
+const SEP = '[' + TICK + '\'"\\s:,|)\\]*_]{0,6}(?:[-—]\\s*)?[' + TICK + '\'"]?\\s*';
```

### Blind, then seeing — the gate's own output in both states

**Before** (`b362c1b47`, the branch point), `pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts`:

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Green — and green here does not mean "examined and found sound". The two pages carrying `**Node.js** 20+` appear in no `KNOWN_CLAIMS` entry and in no failure, because the scan never matched them.

Proven positively rather than inferred from a green run, with a control in the same sweep. The probe lifts `OP`, `VERSION`, `FIRST_PARTY`, `TOOLCHAIN`, `TICK`, `SEP` and `CLAIM_RES` verbatim out of the test file's own source and evaluates them, so the only difference between the two runs is that file's `SEP` line:

```
# SEP as of b362c1b47
content/docs/guide/quick-start.md       -> 0 claim(s)
content/docs/guide/building-crud-app.md -> 0 claim(s)
content/docs/guide/ci-cd-pipeline.md    -> 1 claim(s)      <- CONTROL, matched
   content/docs/guide/ci-cd-pipeline.md:196: Node 22.x

# SEP with * and _
content/docs/guide/quick-start.md       -> 2 claim(s)
   content/docs/guide/quick-start.md:12: Node.js** 20+
   content/docs/guide/quick-start.md:13: pnpm** 9+
content/docs/guide/building-crud-app.md -> 2 claim(s)
   content/docs/guide/building-crud-app.md:12: Node.js** 20+
   content/docs/guide/building-crud-app.md:12: pnpm** 9+
content/docs/guide/ci-cd-pipeline.md    -> 1 claim(s)      <- CONTROL, still matched
   content/docs/guide/ci-cd-pipeline.md:196: Node 22.x
```

**After** the `SEP` line changed and before anything else, the gate itself goes red and names them:

```
AssertionError: These doc surfaces state a version and nothing in this repository can tell whether it is still true:
  - content/docs/guide/building-crud-app.md:12  "Node.js** 20+"
  - content/docs/guide/building-crud-app.md:12  "pnpm** 9+"
  - content/docs/guide/quick-start.md:12  "Node.js** 20+"
  - content/docs/guide/quick-start.md:13  "pnpm** 9+"
```

Corpus-wide delta, over the 241 files the three `SCAN_ROOTS` resolve to: **33 matched literals before, 37 after — four new, none lost.** The four are exactly the ones above.

### Triage — every literal the widened scan surfaced

| Literal | Disposition | Reason |
|:--|:--|:--|
| `quick-start.md:12` `**Node.js** 20+` | **Deleted**, no ledger entry | A floor nothing declares and nothing tests — see half 1. The gate's own failure message prefers deleting over ledgering for exactly this case, and the downward half of the ratchet forbids an entry naming a claim no longer in the tree. |
| `quick-start.md:13` `**pnpm** 9+` | **Deleted**, no ledger entry | Same. |
| `building-crud-app.md:12` `**Node.js** 20+` | **Deleted**, no ledger entry | Same. |
| `building-crud-app.md:12` `**pnpm** 9+` | **Deleted**, no ledger entry | Same. |

No other literal anywhere in the three scan roots changed state, so nothing was bulk-added to keep the gate quiet. The four entries this PR *does* add to `KNOWN_CLAIMS` are for the sentences that replace them, each `anchored` and each naming the anchor it can be re-measured against.

### The widening keeps a witness after the repair

After half 1 the corpus holds **no** emphasised claim at all, and the replacement sentences separate name from version with a plain space. So on the corpus alone, reverting `SEP` would change nothing observable and this gate would report green over the same blind spot — the second-order form of the defect. `it('reads a claim through markdown emphasis, so the widened separator is not decorative')` is the permanent witness: a fixture through `claimsIn`, plus the pre-#6307 class rebuilt inline and asserted **not** to match the same line.

Reverse-verified on the committed tree (mutation confirmed on disk by blob hash `51dc12f…` to `2d1d830…` and by the widened spelling going to 0 occurrences; restored by `git checkout HEAD --` plus the absolute path, verified back to `51dc12f…` with `git diff HEAD` empty):

```
 ❯ reverting SEP to its pre-#6307 spelling
 FAIL  reads a claim through markdown emphasis, so the widened separator is not decorative
 AssertionError: a toolchain name wrapped in markdown emphasis must still produce a claim:
   expected [] to deeply equal [ 'Node.js** 20+', 'pnpm* 9+' ]

 Test Files  1 failed (1)
      Tests  1 failed | 18 passed (19)
```

Predicted direction and observed direction agree, including which test goes red: **only** the new fixture. The ratchet stays green, which is the whole reason the fixture had to exist.

### The boundary the widening does not cross, pinned rather than assumed

`_` is in the class and costs nothing, but underscore *emphasis* around a name is still invisible and no character class can reach it: `_` is a word character, so the `\b` on each side of `TOOLCHAIN` fires on neither side of `_Node.js_`, and the match fails before `SEP` is consulted. Measured across the three scan roots: **zero** underscore-emphasised toolchain names (control, same sweep: six files carry the bold spelling, e.g. `content/docs/utilities/runner.mdx:446`). Recorded as a documented boundary with an assertion that goes red if it ever changes, not repaired by widening `\b` into a lookaround nothing has asked for.

## Half 1 (ruled B) — say what is true, not a floor nobody measured

Both pages, identically:

```diff
-- **Node.js** 20+
-- **pnpm** 9+ or npm/yarn
+- **Node.js** and **pnpm** (or npm/yarn) — ObjectUI is tested on Node 22.x with pnpm 10.x.
```

It leads with what the reader installs, and states the measured fact as what this project *tests on* — never as a requirement. (First wording on this branch put the `engines` audit in the bullet itself; that reasoning lives in the changeset, the file docblock and the card, not on a getting-started page.)

Re-measured on this branch's base rather than copied from the card's 12:16Z reading:

- **Node** — 27 `node-version:` declarations across `.github/workflows`: 26 read `'22.x'`, the 27th (`half-state-patrol.yml:196`) reads `'22'`. Nothing runs Node 20.
- **pnpm** — root `packageManager` is `pnpm@10.31.0`, and 17 `run: corepack enable` steps across 12 workflow files mean that field is what CI installs with. (`pnpm install` in this worktree reported `pnpm v10.31.0`.)
- **No consumer floor exists to restate** — of 46 workspace manifests, **zero** declare `engines.node` or `engines.pnpm`; the only `engines` block outside the root is `packages/vscode-extension`'s `engines.vscode` (control for that zero: the root manifest, which does declare `node: ">=22.11"` / `pnpm: ">=10"`).

Root `engines` is deliberately **not** what these pages cite: they address the reader's own project, which is why #5306 left them alone.

Both literals the ledger pins on these pages survive the rewrite verbatim — one occurrence each, per page:

```
content/docs/guide/quick-start.md       | Node 22.x -> 1   :12
content/docs/guide/quick-start.md       | pnpm 10.x -> 1   :12
content/docs/guide/building-crud-app.md | Node 22.x -> 1   :12
content/docs/guide/building-crud-app.md | pnpm 10.x -> 1   :12
```

## Verification

Run at `992bcec7f` (the final commit), from the repo root:

| Check | Result |
|:--|:--|
| `pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts` | `Test Files 1 passed (1) / Tests 19 passed (19)` |
| `pnpm exec vitest run scripts/__tests__/` (whole gate-test tree) | `Test Files 79 passed (79) / Tests 2280 passed (2280)` |
| `node scripts/check-doc-links.mjs` | `Links are valid across 17 scan roots.` |
| `node scripts/check-doc-fence-languages.mjs` | `✅ check:doc-fences — every TypeScript block in 223 document(s) …` |
| `pnpm run check:doc-types` | `✅ Every documented component type is registered.` |
| `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 5277 tracked text file(s); …)` |
| `node scripts/check-changeset-presence.mjs` | `✅ No source of a released package changed in this range …` |
| `node scripts/check-changeset-no-major.mjs` | ``✅ No changeset declares a `major` bump.`` |
| `node scripts/check-changeset-fixed.mjs` | `✅ All workspace packages are in the changeset fixed group.` |
| `pnpm run type-check:scripts` | exit 0; `--listFiles` confirms `doc-version-claims.test.ts` is in the program (133 files from `scripts/`) |
| `pnpm run lint:root` | exit 0 — full run, 9s, 28 warnings, 0 errors, none in the changed file |

The whole-tree, changeset, type-check and lint rows were measured on `37f6f5990`; the follow-up commit `992bcec7f` changes two lines of markdown prose and nothing else, and the gate, doc-link, doc-fence and doc-type rows above were re-run on it.

**Declared narrowing, one check:** `pnpm run check:doc-snippets` exits **2 = PRECONDITION NOT MET** here ("the snippet program was NOT run"; it needs 21 packages built first) — so it is *not measured* locally, neither green nor red. Narrowed on the grounds that it compiles **fenced** `ts`/`tsx` blocks and this diff touches none: the changed hunks are at line 12 of each page and the first fence delimiter in each file is at line 19. CI runs it in full regardless.

## Scope notes

- PR #6390 (card #6313) touches `QUICK_REFERENCE.md` and the quick-reference pin — a different gate from this card's version-literal ledger. Checked: no file overlap with this branch (`.changeset/6307-bold-version-literals.md`, the two guide pages, `scripts/__tests__/doc-version-claims.test.ts`), and the two jobs are kept separate.
- One out-of-scope defect found and **filed unassigned as #6400**, deliberately not touched here: the neighbouring `ci-cd-pipeline.md :: Node 22.x` ledger entry's reason still says "the 14 node-version: 22.x declarations" (measured today: 26 of 27), and `ci-cd-pipeline-doc.test.ts` does not in fact pin that literal (`grep -cP '\b22\b'` on it returns 0; control, same file: `ci.yml` returns 28).
- Option A from the card — declaring per-package `engines` across the workspace — is closed by the triage ruling and was not done.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_
