### PR TITLE
docs(ci-cd-pipeline): point at a living workflow instead of a fossil snippet

### DIFF
--- a/.changeset/6308-living-workflow-example.md
+++ b/.changeset/6308-living-workflow-example.md
@@ -1,0 +1,26 @@
+---
+---
+
+Docs change; no published surface.
+
+`content/docs/guide/ci-cd-pipeline.md`'s "Adding a New Workflow" section told a
+contributor to "follow the existing pattern for pnpm + Turbo setup" and then gave a copied
+YAML block in which every line had drifted: `actions/setup-node@v4` where every workflow
+in this repository now uses `@v7`, a hardcoded `node-version: 20` where every workflow
+declares `'22.x'` (and 20 sits below the floor the root `package.json`'s `engines` field
+now declares), and `pnpm/action-setup@v4`, which no workflow here has ever used — pnpm
+comes from `corepack enable` plus the root `packageManager` field instead. Re-measured on
+this change's own HEAD: `actions/setup-node@v7` — 28 occurrences, no other version;
+`node-version:` — 27 `'22.x'` and 1 `'22'`; `pnpm/action-setup` — 0.
+
+A copied block is a fossil by construction, so the section now points at
+`readme-exports.yml` as a living example instead of repeating one: it is short, runs on
+every pull request, and its setup is the complete pattern most new build/test/lint
+workflows need (checkout, `corepack enable`, `actions/setup-node` with pnpm's cache,
+`pnpm install --frozen-lockfile`, then a `turbo run build` step). Only the two steps that
+hold regardless of which Node or pnpm version the repository is on — the checkout step and
+`corepack enable` — stay quoted on the page; the reader copies the version-specific steps
+from the workflow itself. No new version literal was introduced, so no
+`doc-version-claims.test.ts` `KNOWN_CLAIMS` entry was needed.
+
+objectui#6308.

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1734,17 +1734,28 @@ takes part in it.
 > because nothing checked, and one of them is a PR gate.
 
 1. Create a new `.yml` file in `.github/workflows/`.
-2. Follow the existing pattern for pnpm + Turbo setup:
+2. Copy the pnpm + Turbo setup from a workflow that runs today, not from a snippet on this
+   page. A copied YAML block is a fossil the moment it is pasted — this page used to keep
+   one here, and every line of it had drifted: `actions/setup-node@v4` where every workflow
+   now uses `@v7`, a hardcoded `node-version: 20` where every workflow declares `'22.x'`
+   (and 20 sat below the floor the root `package.json`'s `engines` field now declares), and
+   `pnpm/action-setup@v4`, which no workflow in this repository has ever used — pnpm comes
+   from `corepack enable` plus the root `packageManager` field instead.
 
-```yaml
-- uses: actions/checkout@v4
-- uses: pnpm/action-setup@v4
-- uses: actions/setup-node@v4
-  with:
-    node-version: 20
-    cache: 'pnpm'
-- run: pnpm install --frozen-lockfile
-```
+   `readme-exports.yml` (see the **README Exports** section above) is a good one to read: it
+   is short, runs on every pull request, and its setup is the complete pattern most new
+   build/test/lint workflows need — checkout, enable Corepack, `actions/setup-node` with
+   pnpm's own cache, `pnpm install --frozen-lockfile`, then a `turbo run build` step for
+   whatever it needs built. Two of its steps hold for any workflow no matter which Node or
+   pnpm version the repository is on when you read this:
+
+   ```yaml
+   - uses: actions/checkout@v7
+   - run: corepack enable
+   ```
+
+   Copy everything else — the Node version, the cache key, the install command — from the
+   workflow itself, not from this page.
 
 3. Use Turbo for any build/test/lint steps to leverage caching:
 


### PR DESCRIPTION
Fixes #6308

`content/docs/guide/ci-cd-pipeline.md`'s "Adding a New Workflow" section told a
contributor to "follow the existing pattern for pnpm + Turbo setup" and then gave a copied
YAML block in which every line had drifted from what any workflow in this repository
actually does.

## Re-measured on this PR's own HEAD (`6d551e44e` merge-base, after merging #6402)

```
$ grep -rn "actions/setup-node@" .github/workflows/ | sed -E 's/.*(actions\/setup-node@[^ ]+).*/\1/' | sort | uniq -c
     28 actions/setup-node@v7

$ grep -rn "node-version:" .github/workflows/ | sed -E "s/.*node-version:\s*//" | sort | uniq -c
      1 '22'
     27 '22.x'

$ grep -rn "pnpm/action-setup" .github/workflows/ | wc -l
0

$ grep -n '"engines"' -A3 package.json
  "engines": {
    "node": ">=22.11",
    "pnpm": ">=10"
  },
```

| snippet said | measured reality (fresh, not the card's `090927f4f` figures) |
|:--|:--|
| `actions/setup-node@v4` | `@v7` — 28 occurrences, no other version (up from the card's 27 — #6402 added `docs-route-eager-closure.yml` today, one more `setup-node@v7`) |
| `node-version: 20` | `'22.x'` × 27, `'22'` × 1 — and 20 is below the `engines.node` floor of `>=22.11` |
| `pnpm/action-setup@v4` | 0 occurrences anywhere. pnpm comes from `corepack enable` (14 workflows) + root `packageManager: pnpm@10.31.0` |

## What changed

A copied YAML block is a fossil the moment it's pasted, so the section no longer repeats
one. It now points at **`readme-exports.yml`** as the living example — chosen because it
is small, PR-triggered (not scheduled, unlike e.g. `spec-range-floors.yml`), and its setup
is the *complete* pattern most new build/test/lint workflows need: checkout, `corepack
enable`, `actions/setup-node` with pnpm's own cache, `pnpm install --frozen-lockfile`, then
a `turbo run build` step. (The repo's other cheap-tier gates — `control-bytes.yml`,
`changeset-presence.yml` — deliberately skip install/build, so they don't demonstrate the
"pnpm + Turbo" pattern this section is teaching.)

Only the two steps that hold regardless of which Node/pnpm version the repo is on when
read stay quoted on the page — checkout and `corepack enable` — everything
version-specific (Node version, cache key, install command) is now "read it from the
workflow" rather than copied here.

**No new version literal was introduced** — the replacement names a workflow file, not a
Node/pnpm version, so no `doc-version-claims.test.ts` `KNOWN_CLAIMS` entry was needed. (The
existing `ci-cd-pipeline.md` / `'Node 22.x'` `anchored` entry at line ~199, "Uses: Node
22.x, pnpm via corepack", is untouched by this PR.)

**Correcting the record on "why nothing caught this":** the issue and dispatch both said
`doc-version-claims.test.ts` "skips fences by design." On this HEAD that's no longer
accurate — the file's own header says "Fences are SCANNED... the opposite of
`check-doc-links.mjs`, on purpose" and the scan loop does call `collect()` on fenced lines.
The real reason nothing caught this snippet: none of its three false lines match the
ledger's `TOOLCHAIN + SEP + VERSION` regex regardless of fencing —
`actions/setup-node@v4` has `@` between the toolchain word and the version (not in `SEP`'s
character class), `pnpm/action-setup@v4` has `/action-setup@` in the way, and
`node-version: 20` has the literal word `version` between `node` and `20`, which `SEP`
also can't cross. Re-verified by running the two-file targeted suite before and after the
edit (both green — see Tests).

## Tests

Full tree (per dispatch instruction — this page carries `ci-cd-pipeline-doc.test.ts`,
`merge-queue-reporting.test.ts` (#4154), and the version-literal ledger, and a subset
chosen from just this snippet's subject matter would miss the ones that fire on the page
as a whole, per today's #6402 rework):

```
$ pnpm exec vitest run scripts/__tests__
 Test Files  80 passed (80)
      Tests  2303 passed (2303)
```
(HEAD `54fc0c337`, `git rev-parse --short HEAD`.)

Plus targeted doc gates over the edited page:

```
$ pnpm check:doc-fences   → ✅ (223 docs scanned)
$ node scripts/check-doc-links.mjs → Links are valid across 17 scan roots.
$ pnpm check:doc-types    → ✅ Every documented component type is registered.
$ node scripts/check-changeset-presence.mjs → ✅ 1 changeset added
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' content/docs/guide/ci-cd-pipeline.md .changeset/6308-living-workflow-example.md
  (no output — clean)
```

## Notes

- Branched from `main` after confirming #6402 (`docs-route-eager-closure.yml`) had landed,
  per this card's dispatch order — fast-forward merge, no rebase, no force-push.
- `#6280` (stale `check-doc-links` coverage claims on the same page) is explicitly out of
  scope per the dispatch order's fold decline; not touched here.
- Draft — this seat arms it per the dispatch order.


---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_