### PR TITLE
docs(check-doc-links): re-derive two stale scan-surface claims from SCAN_ROOTS

### DIFF
--- a/.changeset/6280-scan-surface-claims.md
+++ b/.changeset/6280-scan-surface-claims.md
@@ -1,0 +1,24 @@
+---
+---
+
+Doc-only fixes in `@object-ui/components` and the docs site: two stale claims about
+`scripts/check-doc-links.mjs`'s scan surface, both frozen at an earlier `SCAN_ROOTS`
+shape (objectui#6280).
+
+- `packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts`'s
+  `## Scan surface` docblock said `README_SHADCN_SYNC.md` had "never been scanned by
+  anything" — false since objectui#4938, whose `packages/*` row excludes only the
+  basenames `README.md`/`CHANGELOG.md` and so does include this file. Rewritten to
+  argue from the current tree: the file IS scanned, but check-doc-links only inspects
+  `[text](href)` markdown-link syntax (never the backticked code spans this README
+  uses for every in-repo path) and has no notion of prose-vs-manifest consistency —
+  so the hand-rolled checks below survive regardless of scan surface, for reasons
+  unrelated to whether the surface reaches this file.
+- `content/docs/guide/ci-cd-pipeline.md` described the scan surface twice (prose and
+  the two-link-checkers table), both frozen at the objectui#3622 shape ("the internal
+  `docs/` tree and every package `README.md`"). Re-derived from the live `SCAN_ROOTS`
+  table (17 rows) and rewritten to include the app READMEs and root-level markdown
+  (objectui#4148), the rest of each package/app directory tree (objectui#4938), and
+  every nested `README.md` (objectui#6026).
+
+No source or behaviour change; text and a test docblock only.

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -423,9 +423,13 @@ all**, which is the point of the workflow. It appears in the checks list as **In
 Check**.
 
 Runs `scripts/check-doc-links.mjs`, which walks every `.md` / `.mdx` file in the surfaces listed in
-its `SCAN_ROOTS` — `content/docs/`, `examples/`, the root `README.md`, `CONTRIBUTING.md`,
-`ROADMAP.md`, the internal `docs/` tree and every package `README.md` — and asks of each internal
-markdown link whether its target is really there.
+its `SCAN_ROOTS` (17 rows as of objectui#6280) — `content/docs/`, `examples/`, the internal `docs/`
+tree, every package and app `README.md`, the rest of each package's and app's directory tree (every
+file except `README.md` and `CHANGELOG.md`, the latter excluded everywhere as changesets output
+rather than authored prose), every nested `README.md` a package or app carries below its top level,
+and the root-level markdown files (`README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `AGENTS.md`,
+`CHANGELOG.md`, `CLAUDE.md`, `LICENSE-THIRD-PARTY.md`, `QUICK_REFERENCE.md`) — and asks of each
+internal markdown link whether its target is really there.
 
 **Two rules, because the two groups are read through different machinery** (objectui#3536). For
 `content/docs/` the question is the one a site reader cares about, **does the site serve this URL?**
@@ -1058,7 +1062,7 @@ There are **two** link checkers, and they cover different things (objectui#3213)
 
 | | Covers | Network | Runs |
 |---|---|---|---|
-| `scripts/check-doc-links.mjs` | **Internal** links in `content/docs/` (relative hrefs, `/docs/...` routes, every other site-absolute href against `apps/site`), in `examples/`, `README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `docs/` and every package `README.md` (as paths on disk), plus this repo's own `blob/main/` and `tree/main/` GitHub URLs and this site's own `objectui.org` URLs everywhere — **except** anything inside a code fence | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
+| `scripts/check-doc-links.mjs` | **Internal** links in `content/docs/` (relative hrefs, `/docs/...` routes, every other site-absolute href against `apps/site`), and, as paths on disk: `examples/`, the internal `docs/` tree, every package and app `README.md`, the rest of each package's and app's directory tree (everything but `README.md`/`CHANGELOG.md`), every nested `README.md`, and the root-level markdown files (`README.md`, `CONTRIBUTING.md`, `ROADMAP.md`, `AGENTS.md`, `CHANGELOG.md`, `CLAUDE.md`, `LICENSE-THIRD-PARTY.md`, `QUICK_REFERENCE.md`) — plus this repo's own `blob/main/` and `tree/main/` GitHub URLs and this site's own `objectui.org` URLs everywhere — **except** anything inside a code fence | No | `docs-links.yml` — every push and PR, no path filter (previous section) |
 | Lychee (this workflow) | **External** URLs, plus **relative** in-repo file links, in `content/docs/`, `docs/` and `README.md` | Yes | Weekly cron and manual dispatch |
 
 Lychee sweeps **both** documentation trees: `content/docs/` (the 183 pages the site publishes) and

--- a/packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts
+++ b/packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts
@@ -90,14 +90,44 @@
  * components (`pnpm shadcn:update button`) legitimately — fenced blocks are
  * stripped before the section is judged for that reason.
  *
- * The path check is here because no link gate can see this file:
- * `check-doc-links.mjs`'s per-package `SCAN_ROOTS` row globs one directory level
- * and then matches the exact filename `README.md`, so `README_SHADCN_SYNC.md` has
- * never been scanned by anything — which is also how its `## Files` section came
- * to claim `shadcn-sync.js` sits in this directory when it has always been at the
- * repo root. Widening that scan root is a separate change with its own entry
- * price (the objectui#3603 / objectui#3622 shape: one row plus whatever it turns
- * red) and is deliberately not taken here.
+ * **`check-doc-links.mjs` DOES scan this file today.** The claim that stood
+ * here — that no link gate can see it, because the per-package `SCAN_ROOTS` row
+ * globbed one directory level and matched only the exact filename `README.md` —
+ * became false with objectui#4938: that row now walks every markdown file under
+ * each package directory and excludes only the basenames `README.md` and
+ * `CHANGELOG.md`, at every depth. `README_SHADCN_SYNC.md` is neither, so it is
+ * inside that row (re-verified against the live `SCAN_ROOTS` table for
+ * objectui#6280 — 17 rows total, this file collected by the `packages/*` row
+ * and by no other).
+ *
+ * That does not make the checks below redundant, for two reasons that would
+ * each independently survive `check-doc-links.mjs` scanning every byte of this
+ * README:
+ *
+ *   - **It cannot see the paths this file names.** Every in-repo path here —
+ *     `shadcn-components.json`, `scripts/shadcn-sync.js`,
+ *     `scripts/shadcn-local-patches.mjs` — is written as a backticked code
+ *     span, never as a `[text](href)` markdown link, and `check-doc-links.mjs`
+ *     blanks every inline code span (`stripCode()`) before its link regex ever
+ *     runs, by design — a command example like `` `pnpm shadcn:update button` ``
+ *     must not be misread as a broken link. This README's only actual markdown
+ *     links (8, all external: `ui.shadcn.com`, `github.com/shadcn-ui/...`, and
+ *     the Radix/Tailwind/CVA sites) carry nothing check-doc-links would resolve
+ *     against this repo. So scanning this file today asserts nothing about the
+ *     paths the last `it` block below checks — the objectui#3881 path drift
+ *     (`## Files` claiming `shadcn-sync.js` sits in this directory when it has
+ *     always been at the repo root) would go just as uncaught by that gate
+ *     under today's widened surface as it did before objectui#4938.
+ *   - **It has no notion of this file's actual defect class.** objectui#3881
+ *     was two prose censuses disagreeing with `shadcn-components.json` about
+ *     which components belong where — a comparison against a JSON manifest,
+ *     not a link target. No widening of `SCAN_ROOTS`, at any width, gives a
+ *     link checker that question to ask.
+ *
+ * The first reason is why the path check (the last `it` block) survives; the
+ * second is why the category/manifest comparisons above it do. Both hold
+ * regardless of `check-doc-links.mjs`'s scan surface — not because that
+ * surface stops short of this file, since it no longer does.
  */
 
 import { describe, it, expect } from 'vitest';


### PR DESCRIPTION
Fixes #6280

Two stale claims about `scripts/check-doc-links.mjs`'s scan surface, both corrected by
re-deriving from the live `SCAN_ROOTS` table rather than from card history.

## (a) The test docblock's justification was two cards stale

`packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts`'s `## Scan
surface` docblock said `README_SHADCN_SYNC.md` "has never been scanned by anything" and
that widening the scan root was "a separate change with its own entry price."

**Verified false, not assumed:**

```
$ node --input-type=module -e "
import { collectFiles } from './scripts/check-doc-links.mjs';
const files = collectFiles('./packages/*', new Set(['README.md','CHANGELOG.md']));
console.log(files.filter(f => f.includes('components/README_SHADCN_SYNC')));
"
[ 'packages/components/README_SHADCN_SYNC.md' ]
```

`check-doc-links.mjs`'s `packages/*` row excludes only the basenames `README.md` /
`CHANGELOG.md` (objectui#4938); `README_SHADCN_SYNC.md` is neither, so it is inside that
row today.

**Assertion-by-assertion: does the test still earn its keep?** Per the ruling, yes, keep
it if its checks exceed what the link checker asserts — they do, on every one of the
file's 5 `it` blocks, and for two independent reasons:

| # | Test assertion | Covered by `check-doc-links.mjs`? |
|---|---|---|
| 1 | README's documented "diverged" set ⊆ manifest's marked-diverged set | No — compares prose against a JSON manifest (`shadcn-components.json`); not a link at all |
| 2 | manifest's marked-diverged set ⊆ README's documented set | No — same reason, inverse direction |
| 3 | manifest parse sanity + partition invariant + "diverged section present iff manifest marks something" | No — manifest-structure invariants, no link syntax involved |
| 4 | "Component Categories" prose names no `components`-registry key inline | No — backtick-token vs. JSON-key comparison, not a link |
| 5 | every backticked in-repo path in the README exists on disk | **Structurally invisible to check-doc-links regardless of scan surface** — see below |

For #5, the closest analog: I measured what `check-doc-links.mjs` actually sees in this
file today —

```
$ node --input-type=module -e "
import { readFileSync } from 'node:fs';
/* ...stripCode() + MARKDOWN_LINK_RE reimplemented verbatim from check-doc-links.mjs... */
"
markdown-link hrefs found after stripCode: [
  'https://github.com/shadcn-ui/ui/tree/main/apps/www/registry/default/ui',
  'https://github.com/shadcn-ui/ui/releases',
  'https://github.com/shadcn-ui/ui/releases',
  'https://github.com/radix-ui/primitives/releases',
  'https://ui.shadcn.com',
  'https://www.radix-ui.com',
  'https://tailwindcss.com',
  'https://cva.style'
]
```

All 8 of this README's actual `[text](href)` markdown links are external URLs. Every
in-repo path it names (`shadcn-components.json`, `scripts/shadcn-sync.js`,
`scripts/shadcn-local-patches.mjs`) is written as a **backticked code span**, never as
markdown-link syntax — and `check-doc-links.mjs`'s own `stripCode()` blanks every inline
code span before its link regex ever runs, by design (so a command example like
`` `pnpm shadcn:update button` `` can't be misread as a broken link). So even scanning
this file today, check-doc-links resolves zero repo-relative targets in it.

**Conclusion: the test survives**, for reasons unrelated to scan-surface width — 4 of 5
assertions ask a question no link checker can ask (prose vs. JSON manifest), and the 5th
checks a syntax (backticked paths) the link checker structurally never inspects. Rewrote
the docblock to argue from this, not from "not yet scanned."

## (b) Both `ci-cd-pipeline.md` surface lists were frozen at #3622

The page described `check-doc-links.mjs`'s surface twice (prose in "Internal Docs Links",
the two-link-checkers table in "Link Checking"), both ending at "the internal `docs/`
tree and every package `README.md`" — the surface as of #3622. Widened three times since
(#4148, #4938, #6026) and neither list knew.

**Re-derived from the script itself, not from the card table:**

```
$ node scripts/check-doc-links.mjs
Links are valid across 17 scan roots.
```

`SCAN_ROOTS` (17 rows): `content/docs` (docs rule); `examples`, root `README.md`,
`CONTRIBUTING.md`, `ROADMAP.md`, `docs` (disk); `packages/*/README.md`,
`apps/*/README.md` (disk); `packages/*` / `apps/*` excluding `README.md`+`CHANGELOG.md`
at every depth (disk, #4938); `packages/*/*` / `apps/*/*` collecting only nested
`README.md` (disk, #6026); root `AGENTS.md`, `CHANGELOG.md`, `CLAUDE.md`,
`LICENSE-THIRD-PARTY.md`, `QUICK_REFERENCE.md` (disk, #4148). 17 matches the gate's own
printed verdict above — the cheap cross-check the dispatch order suggested.

Both lists rewritten to enumerate this surface instead of the #3622 shape.

## Sequencing

`content/docs/guide/ci-cd-pipeline.md` was contended 4 times today; per the dispatch
order I waited for #6408 to land (`9e35810ba`) before touching the file, merged it into
this branch (`git merge origin/main`, no rebase), and re-ran the surface re-derivation on
top of that merge — both spots were untouched by #6408 (which edited a different
section), and `SCAN_ROOTS` itself was untouched, so 17 held before and after the merge.

Per the dispatch order, `#6308`'s section of this page (the fold triage suggested and the
PM seat declined) is untouched here, and the `skip-changeset` / `#4912` staleness the PM
seat flagged is not addressed in this PR.

## Tests

Full tree, per dispatch instruction (this page carries `ci-cd-pipeline-doc.test.ts`,
`merge-queue-reporting.test.ts`, and the doc-version-claims ledger, and none of them pin
the exact prose I rewrote — verified by grep before editing):

```
$ pnpm exec vitest run scripts/__tests__ packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts
 Test Files  82 passed (82)
      Tests  2322 passed (2322)
```
(HEAD `bd2ce2abf`, `git rev-parse --short HEAD`.)

Plus targeted doc gates:

```
$ node scripts/check-doc-links.mjs        → Links are valid across 17 scan roots.
$ pnpm check:doc-fences                   → ✅ 223 documents scanned
$ node scripts/check-changeset-presence.mjs → ✅ 1 changeset added (empty frontmatter — no release)
$ node scripts/check-changeset-no-major.mjs → ✅ No changeset declares a major bump
$ grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' packages/components/src/__tests__/readme-shadcn-sync-categories.test.ts content/docs/guide/ci-cd-pipeline.md .changeset/6280-scan-surface-claims.md
  (no output — clean)
```

## Notes

- Draft — this seat arms it per the dispatch order.
- No source or behaviour change: a test docblock and a docs page, text only.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_