### PR TITLE
refactor(i18n): retire the dead `appDesigner.fieldDesigner.formula` key

### DIFF
--- a/.changeset/6310-designer-formula-key-retired.md
+++ b/.changeset/6310-designer-formula-key-retired.md
@@ -27,3 +27,12 @@ Not touched: `designer.field.formula` (`'Formula (CEL)'`) in
 `packages/app-shell/src/views/metadata-admin/i18n.ts`, a different and live key belonging
 to metadata-admin's `ObjectFieldInspector` — the surface that still authors formula
 expressions.
+
+`packages/i18n/src/__tests__/appDesigner-fieldDesigner-formula-retired-6310.test.ts` pins the
+removal by name, following the four prior retirements (objectui#4145, objectui#4392,
+objectui#4730, objectui#5504). Every i18n gate here runs call site → key, so none of them can
+see a dead key come BACK into the packs: the reverse sweep that found this one is report-only
+by design, `all-locales-key-parity` is fully satisfied by ten packs agreeing on a dead key, and
+`check:i18n-drift` only fires when a value changes. Reverse-verified rather than asserted —
+reviving the row in all ten packs turns exactly that one case red, naming each pack, while the
+parity gate and the defaults-map mirror stay green.

--- a/.changeset/6310-designer-formula-key-retired.md
+++ b/.changeset/6310-designer-formula-key-retired.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/i18n': patch
+'@object-ui/plugin-designer': patch
+---
+
+`appDesigner.fieldDesigner.formula` is retired — one row removed from each of the ten
+locale packs plus the designer defaults map, 11 lines, zero readers (objectui#6310).
+
+objectui#6043 retired the Field Designer's formula-expression textarea, which was the
+key's only call site (`FieldDesigner.tsx`, the `{ name: 'formula', label:
+t('appDesigner.fieldDesigner.formula') }` field descriptor). The value outlived it in
+eleven places: `DESIGNER_DEFAULT_TRANSLATIONS` in
+`packages/plugin-designer/src/hooks/useDesignerTranslation.ts`, and the `appDesigner >
+fieldDesigner > formula` leaf of `packages/i18n/src/locales/{en,de,es,fr,pt,ru,ja,ko,zh,ar}.ts`.
+
+Removed under objectui#4658's evidence standard, re-measured on this branch rather than
+inherited from the card: zero `t()`/`tt()` call sites, no dynamic template head that could
+reach it (`appDesigner.fieldDesigner.typeCategory.` is the namespace's only one), and its
+sole textual occurrence anywhere in the repo was the defaults-map row this change removes
+with it — so the key goes from NEEDS-REVIEW to no footprint at all.
+
+The map and all ten packs move in one commit, which is what keeps
+`defaults-maps-mirror-en-pack` green: that gate fails a map row whose key the `en` pack
+lacks, and `all-locales-key-parity` fails a pack left behind.
+
+Not touched: `designer.field.formula` (`'Formula (CEL)'`) in
+`packages/app-shell/src/views/metadata-admin/i18n.ts`, a different and live key belonging
+to metadata-admin's `ObjectFieldInspector` — the surface that still authors formula
+expressions.

--- a/packages/i18n/src/__tests__/appDesigner-fieldDesigner-formula-retired-6310.test.ts
+++ b/packages/i18n/src/__tests__/appDesigner-fieldDesigner-formula-retired-6310.test.ts
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `appDesigner.fieldDesigner.formula` is retired from all ten packs, and the
+ * Field Designer vocabulary it sat in must keep naming real controls
+ * (objectui#6310).
+ *
+ * ## What was removed and why
+ *
+ * One row per pack (`en: 'Formula'`, `zh: '公式'`, `ru: 'Формула'`, …). objectui#6043
+ * retired the Field Designer's formula-expression textarea, which held the key's
+ * ONLY call site — the `{ name: 'formula', label:
+ * t('appDesigner.fieldDesigner.formula') }` field descriptor in
+ * `FieldDesigner.tsx`. The label outlived the control it labelled by eleven
+ * files: the ten packs, plus the `DESIGNER_DEFAULT_TRANSLATIONS` row that mirrors
+ * them.
+ *
+ * ## Why this pin is NEGATIVE, and why it is needed at all
+ *
+ * Every i18n gate in this repo runs **call site -> key**, never key -> call site
+ * (objectui#4145's mechanism, restated by objectui#4392, objectui#4730 and
+ * objectui#5504):
+ *
+ *   - `scripts/check-i18n-call-site-keys.mjs` asks whether each call site's key
+ *     resolves in `en`. A key with no call site is never visited.
+ *   - `all-locales-key-parity.test.ts` compares the ten packs' key SETS to each
+ *     other. One dead key present in all ten is exactly what it wants.
+ *   - `scripts/check-i18n-en-drift.mjs` only fires when an `en` value CHANGES.
+ *   - `scripts/check-i18n-dead-keys.mjs` IS the reverse direction, and it is
+ *     report-only by design and wired into no workflow (objectui#4658).
+ *
+ * So the retired row can return to all ten packs with every gate green, and a
+ * translator filling in "the missing formula label" is a plausible way for that
+ * to happen — the surrounding vocabulary still describes a field editor, so the
+ * gap reads like an oversight rather than a decision. Restoring it goes red here.
+ *
+ * ## The other half of the retirement is guarded elsewhere, on purpose
+ *
+ * The `DESIGNER_DEFAULT_TRANSLATIONS` row is pinned by
+ * `app-shell/src/__tests__/defaults-maps-mirror-en-pack.test.tsx` (objectui#4401),
+ * which fails any map row whose key the `en` pack lacks. This file cannot assert
+ * it: `@object-ui/plugin-designer` depends on `@object-ui/i18n`, so importing the
+ * map back into this package inverts the dependency — the same reason #4401's
+ * gate lives in `app-shell` and `gantt-count-interpolation-4157.test.ts` asserts
+ * `en` values as literals. The two halves interlock: re-add the pack key and this
+ * file reds; re-add the map row alone and #4401's gate reds.
+ *
+ * ## What this file does NOT claim
+ *
+ * - **`designer.field.formula` (`'Formula (CEL)'`) is a DIFFERENT, LIVE key** —
+ *   metadata-admin's `ObjectFieldInspector`, the surface that still authors
+ *   formula expressions, reads it from
+ *   `packages/app-shell/src/views/metadata-admin/i18n.ts`. It is not in the
+ *   locale packs and is out of this file's reach by the same dependency
+ *   direction as above. Two keys end in `.formula`; only the
+ *   `appDesigner.fieldDesigner.*` spelling is retired. Grep the full dotted path.
+ * - **`appDesigner.fieldDesigner` is a live namespace.** Only the one leaf went;
+ *   {@link SURVIVING} exists so a green here cannot be bought by deleting the
+ *   neighbourhood.
+ * - **{@link SURVIVING} is deliberately not "the rows next to it".** The row that
+ *   followed the retired one (`options`) is absent from that list, along with
+ *   `addOption`, `addRule`, `noFields`, `searchPlaceholder`, `systemBadge`,
+ *   `ungrouped` and `validationRules`: objectui#6310 measured all eight as
+ *   NEEDS-REVIEW candidates of the same reverse sweep, with the same
+ *   defaults-map-only footprint the retired key had, and none of them has been
+ *   individually confirmed either way (that is objectui#4730's job). Pinning
+ *   "these survive" against keys that may themselves be dead would bake an
+ *   unverified claim into the guard. Every key in {@link SURVIVING} was confirmed
+ *   live by call site in `packages/plugin-designer/src/FieldDesigner.tsx`.
+ */
+import { describe, it, expect } from 'vitest';
+import { builtInLocales } from '../locales/index';
+
+type LocaleCode = keyof typeof builtInLocales;
+const LANGS = Object.keys(builtInLocales) as LocaleCode[];
+
+const at = (pack: unknown, path: string): unknown =>
+  path.split('.').reduce<unknown>((n, k) => (n as Record<string, unknown> | undefined)?.[k], pack);
+
+/** The retired leaf, named rather than counted. */
+const RETIRED = 'appDesigner.fieldDesigner.formula';
+
+/**
+ * Rows the deletion swept around — each one confirmed live by a `t()` call site
+ * in `FieldDesigner.tsx`, not merely by sitting nearby. `referenceTo` is the row
+ * that immediately PRECEDED the retired one in every pack, and
+ * `typeSpecificSection` is the drawer section the formula textarea used to be
+ * rendered in, so a sweep that over-reached would land on them first.
+ */
+const SURVIVING = [
+  'appDesigner.fieldDesigner.referenceTo',
+  'appDesigner.fieldDesigner.typeSpecificSection',
+  'appDesigner.fieldDesigner.defaultValue',
+  'appDesigner.fieldDesigner.placeholder',
+  'appDesigner.fieldDesigner.fieldType',
+  'appDesigner.fieldDesigner.title',
+  'appDesigner.fieldDesigner.allTypes',
+] as const;
+
+/**
+ * The namespace's only dynamically built family —
+ * ``t(`appDesigner.fieldDesigner.typeCategory.${cat}`)`` at
+ * `FieldDesigner.tsx`. No member is spelled literally at any call site, so a
+ * future reverse sweep reading only literal arguments is precisely where these
+ * would look dead. They are the live half of the same namespace and are pinned
+ * by name here.
+ */
+const TYPE_CATEGORY = [
+  'appDesigner.fieldDesigner.typeCategory.text',
+  'appDesigner.fieldDesigner.typeCategory.number',
+  'appDesigner.fieldDesigner.typeCategory.date',
+  'appDesigner.fieldDesigner.typeCategory.choice',
+  'appDesigner.fieldDesigner.typeCategory.relation',
+  'appDesigner.fieldDesigner.typeCategory.advanced',
+] as const;
+
+describe('`appDesigner.fieldDesigner.formula` is retired from the ten packs (objectui#6310)', () => {
+  it('covers all ten packs and a live `appDesigner.fieldDesigner` root', () => {
+    // Guards the premise the rest of the file rests on: a pin that iterates an
+    // empty pack list, or asserts absence inside a namespace that itself
+    // vanished, is green for the wrong reason.
+    expect(LANGS).toHaveLength(10);
+    for (const lang of LANGS) {
+      const root = at(builtInLocales[lang], 'appDesigner.fieldDesigner');
+      expect(root, `${lang} lost the appDesigner.fieldDesigner root`).toBeDefined();
+      expect(Object.keys(root as Record<string, unknown>).length, lang).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  it('no pack defines the retired formula label', () => {
+    const revived: string[] = [];
+    for (const lang of LANGS) {
+      if (at(builtInLocales[lang], RETIRED) !== undefined) revived.push(`${lang} :: ${RETIRED}`);
+    }
+    // Named, not counted: a half-reverted retirement is repaired pack by pack.
+    expect(
+      revived,
+      'The retired Field Designer formula label is back in a locale pack. It ' +
+        'labelled a formula-expression textarea that objectui#6043 removed, so ' +
+        'nothing reads it — and no other i18n gate can see a dead key return, ' +
+        'because every one of them runs call site -> key (objectui#6310). If a ' +
+        'formula control is being reintroduced to the Field Designer, author ' +
+        'its label alongside the control rather than restoring this row. The ' +
+        'live key for the surface that DOES author formula expressions is ' +
+        '`designer.field.formula` in ' +
+        'packages/app-shell/src/views/metadata-admin/i18n.ts — a different key, ' +
+        'not this one.',
+    ).toEqual([]);
+  });
+
+  it('the deletion swept around its neighbours', () => {
+    for (const lang of LANGS) {
+      for (const key of SURVIVING) {
+        const value = at(builtInLocales[lang], key);
+        expect(typeof value, `${lang} :: ${key}`).toBe('string');
+        expect((value as string).length, `${lang} :: ${key}`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('keeps every member of the dynamically built `typeCategory` family', () => {
+    // `all-locales-key-parity` would be satisfied by all ten packs dropping a
+    // member together, and no literal-argument scan can see these are read at
+    // all. State the vocabulary here, by name, so the substitution cannot be
+    // left pointing at a key nothing defines.
+    const missing: string[] = [];
+    for (const lang of LANGS) {
+      for (const key of TYPE_CATEGORY) {
+        if (typeof at(builtInLocales[lang], key) !== 'string') missing.push(`${lang} :: ${key}`);
+      }
+    }
+    expect(
+      missing,
+      'a member of the `appDesigner.fieldDesigner.typeCategory.*` family is gone; ' +
+        'FieldDesigner.tsx builds these keys by substitution, so the loss renders ' +
+        'as a raw key in the type filter rather than failing any other gate',
+    ).toEqual([]);
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1360,7 +1360,6 @@ const ar = {
       defaultValue: "القيمة الافتراضية",
       placeholder: "نص تلميحي",
       referenceTo: "مرجع إلى",
-      formula: "صيغة",
       options: "خيارات",
       addOption: "إضافة خيار",
       validationRules: "قواعد التحقق",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1353,7 +1353,6 @@ const de = {
       defaultValue: "Standardwert",
       placeholder: "Platzhalter",
       referenceTo: "Verweis auf",
-      formula: "Formel",
       options: "Optionen",
       addOption: "Option hinzufügen",
       validationRules: "Validierungsregeln",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1522,7 +1522,6 @@ const en = {
       defaultValue: 'Default Value',
       placeholder: 'Placeholder',
       referenceTo: 'Reference To',
-      formula: 'Formula',
       options: 'Options',
       addOption: 'Add Option',
       validationRules: 'Validation Rules',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1357,7 +1357,6 @@ const es = {
       defaultValue: "Valor predeterminado",
       placeholder: "Marcador de posición",
       referenceTo: "Referencia a",
-      formula: "Fórmula",
       options: "Opciones",
       addOption: "Agregar opción",
       validationRules: "Reglas de validación",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1355,7 +1355,6 @@ const fr = {
       defaultValue: "Valeur par défaut",
       placeholder: "Espace réservé",
       referenceTo: "Référence à",
-      formula: "Formule",
       options: "Options",
       addOption: "Ajouter une option",
       validationRules: "Règles de validation",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1353,7 +1353,6 @@ const ja = {
       defaultValue: "デフォルト値",
       placeholder: "プレースホルダー",
       referenceTo: "参照先",
-      formula: "数式",
       options: "オプション",
       addOption: "オプションを追加",
       validationRules: "検証ルール",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1353,7 +1353,6 @@ const ko = {
       defaultValue: "기본값",
       placeholder: "자리 표시자",
       referenceTo: "참조 대상",
-      formula: "수식",
       options: "옵션",
       addOption: "옵션 추가",
       validationRules: "유효성 검사 규칙",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1352,7 +1352,6 @@ const pt = {
       defaultValue: "Valor padrão",
       placeholder: "Espaço reservado",
       referenceTo: "Referência a",
-      formula: "Fórmula",
       options: "Opções",
       addOption: "Adicionar opção",
       validationRules: "Regras de validação",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1363,7 +1363,6 @@ const ru = {
       defaultValue: "Значение по умолчанию",
       placeholder: "Заполнитель",
       referenceTo: "Ссылка на",
-      formula: "Формула",
       options: "Параметры",
       addOption: "Добавить параметр",
       validationRules: "Правила валидации",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1418,7 +1418,6 @@ const zh = {
       defaultValue: '默认值',
       placeholder: '占位文本',
       referenceTo: '引用对象',
-      formula: '公式',
       options: '选项',
       addOption: '添加选项',
       validationRules: '验证规则',

--- a/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
+++ b/packages/plugin-designer/src/hooks/useDesignerTranslation.ts
@@ -190,7 +190,6 @@ export const DESIGNER_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'appDesigner.fieldDesigner.defaultValue': 'Default Value',
   'appDesigner.fieldDesigner.placeholder': 'Placeholder',
   'appDesigner.fieldDesigner.referenceTo': 'Reference To',
-  'appDesigner.fieldDesigner.formula': 'Formula',
   'appDesigner.fieldDesigner.options': 'Options',
   'appDesigner.fieldDesigner.addOption': 'Add Option',
   'appDesigner.fieldDesigner.validationRules': 'Validation Rules',


### PR DESCRIPTION
Fixes #6310

One key, eleven lines, zero readers: the `appDesigner > fieldDesigner > formula` leaf of all
ten locale packs plus its `DESIGNER_DEFAULT_TRANSLATIONS` row — and, since the PM's ruling
below, a pin so it cannot come back unnoticed.

## Premise re-derived on this branch, not inherited from the card

objectui#6043 retired the Field Designer's formula-expression textarea, which held the key's
only call site (the `{ name: 'formula', label: t('appDesigner.fieldDesigner.formula') }` field
descriptor in `FieldDesigner.tsx`). Re-measured at merge-base `062943f86`:

| check | result |
|---|---|
| `t()`/`tt()` call sites for the dotted key | 0 (`grep -rn 'appDesigner\.fieldDesigner\.formula'` → 1 hit, the defaults-map row itself) |
| dynamic template head that could reach it | none — `` t(`appDesigner.fieldDesigner.typeCategory.${cat}`) `` is the namespace's only one, and `formula` is not under it |
| concatenation-built spelling (`'…fieldDesigner.' + 'formula'`) | 0 |
| test / snapshot / fixture referencing the key | 0 — `grep -rln fieldDesigner --include='*.test.ts*' --include='*.snap'` returns nothing |
| present in all ten packs | yes, one row each |

So the key's *sole* textual occurrence anywhere in the repo was the defaults-map row this PR
removes with it. That is why the reverse sweep tiered it NEEDS-REVIEW rather than CONFIRMED —
the footprint it found was the other half of the same deletion.

## The card's fence held

`designer.field.formula` (`'Formula (CEL)'`, `packages/app-shell/src/views/metadata-admin/i18n.ts`)
is a **different, live** key belonging to metadata-admin's `ObjectFieldInspector` — the surface
that still authors formula expressions. It is untouched; `app-shell` is not in this diff at all.
Every grep in this PR was run on the **full dotted path**, never the `formula` leaf. The pin's
failure message points a future reader at that key by name, so the next person to meet the two
spellings meets them together.

## Map and packs move together

`defaults-maps-mirror-en-pack` fails a map row whose key the `en` pack lacks ("not an exception,
a finding"), and `all-locales-key-parity` fails a pack left behind. One commit moves all eleven,
so neither can go red — verified below rather than asserted.

## The retirement pin — asked for, then ruled on

This PR originally shipped **without** a test, because the dispatch order held that a deletion
adds no behaviour to pin and that inventing an assertion would be theatre. That conflicted with
a four-instance convention in this repo, so the conflict was reported rather than silently
resolved either way. **The PM ruled the dispatch clause wrong for this case and asked for the
pin**, and the reasoning is worth keeping next to the code: every i18n gate here runs **call
site → key**, so a dead key coming *back* into the packs is invisible to all of them. That is an
unguarded direction, not a ritual.

`packages/i18n/src/__tests__/appDesigner-fieldDesigner-formula-retired-6310.test.ts` is the
fifth in the series (objectui#4145, objectui#4392, objectui#4730, objectui#5504) and matches
their shape: the retired leaf absent from all ten packs, plus surviving-sibling assertions so a
green cannot be bought by deleting the neighbourhood.

⚠️ **The surviving list is not "the rows next to it".** The row that immediately followed the
retired one — `options` — is deliberately **excluded**, along with `addOption`, `addRule`,
`noFields`, `searchPlaceholder`, `systemBadge`, `ungrouped` and `validationRules`: all eight are
NEEDS-REVIEW candidates of the same reverse sweep, with the same defaults-map-only footprint the
retired key had, and none has been individually confirmed either way. Pinning "these survive"
against keys that may themselves be dead would bake an unverified claim into the guard. Every
key the list *does* name was confirmed live by call site in `FieldDesigner.tsx`. A fourth case
pins the `typeCategory.*` family, whose members are reached only by substitution and are
therefore exactly what a future literal-argument sweep would mistake for dead.

**Reverse-verified, direction predicted before running.** Reviving the row in all ten packs
(mutation proven on disk first: 10 revived rows, `10 files changed, 10 insertions(+)`):

```
× no pack defines the retired formula label
  expected [ …(10) ] to deeply equal []
  + [ "en :: appDesigner.fieldDesigner.formula", "zh :: …", "ja :: …", "ko :: …", "de :: …",
      "fr :: …", "es :: …", "pt :: …", "ru :: …", "ar :: …" ]

Test Files  1 failed | 2 passed (3)
     Tests  1 failed | 47 passed (48)
```

Exactly one case red, naming each pack; `all-locales-key-parity` and
`defaults-maps-mirror-en-pack` both stayed **green** through the revival — which is the whole
argument for the pin, demonstrated instead of claimed. Restore was proven by bytes, not by an
exit code: all ten packs hash-equal to their `HEAD` blobs, `git diff HEAD` empty for the locales
directory, and every measurement quoted below ran after that restore.

## Before / after, and a positive control on the measuring tool

**`node scripts/check-i18n-dead-keys.mjs --strict`:**

```
before: Pack keys (en …): 2848 … 390 candidate(s) … across 55 namespace(s):
        150 CONFIRMED, 240 NEEDS-REVIEW
        appDesigner.fieldDesigner (0 confirmed, 9 needs-review):
          [needs-review]  appDesigner.fieldDesigner.formula
            → textual hit: packages/plugin-designer/src/hooks/useDesignerTranslation.ts

after:  Pack keys (en …): 2847 … 389 candidate(s) … across 55 namespace(s):
        150 CONFIRMED, 239 NEEDS-REVIEW
        appDesigner.fieldDesigner (0 confirmed, 8 needs-review):
          (formula absent)
```

Exactly one key left the pack and one candidate left the report; the CONFIRMED tier and every
other namespace are unchanged, and re-running it at the final commit confirms the new test file
adds no textual footprint that would move another key's tier. ⚠️ `--strict` exits 1 **both
before and after** — that exit code is about the 150 CONFIRMED keys of the standing backlog
(#4730), not about this change. It is quoted here so nobody later reads a `1` as a regression
this PR introduced.

**Positive control — the tool still names a key I know is live, when asked.** Ablation on
`appDesigner.fieldDesigner.allTypes` (live: one call site at `FieldDesigner.tsx:402`, one
defaults-map row, absent from the report at HEAD), each leg proven on disk by occurrence count
before reading any output:

```
baseline                     call sites 1 · defaults-map rows 1 · absent from report
leg A  remove the call site  call sites 0 → [needs-review] appDesigner.fieldDesigner.allTypes
                                             textual hit: useDesignerTranslation.ts
leg B  also remove the row   map rows 0   → [confirmed]    appDesigner.fieldDesigner.allTypes
restore                      FieldDesigner.tsx         f857c299103d0e8694280dd055ad885f019061f6 == HEAD blob
                             useDesignerTranslation.ts f540bc504e4328fee3e9e9e5e855af5d536d01ed == HEAD blob
                             git diff HEAD for both paths: empty
```

Leg A reproduces, on a key that was live thirty seconds earlier, the *exact* report signature
`formula` carried before this PR — NEEDS-REVIEW whose only footprint is the defaults map. Leg B
shows the tier promoting to CONFIRMED once that last footprint goes. The tool is measuring, not
idling.

## The backlog this key came from is NOT swept here

The dispatch asked for the size before landing a large deletion. Measured:

```
389 candidate(s) with no call site this pass can see, across 55 namespace(s):
150 CONFIRMED, 239 NEEDS-REVIEW
```

That is a hundred-key sweep across 55 namespaces — a different review from this card, and it is
already tracked, open and unassigned, by #4730 ("Reverse i18n sweep: ~384 confirmed-dead locale
keys across 58 namespaces"). Sweeping it inside this PR would take a queued card's scope without
a claim, so this PR is the one key #6310 names. The backlog has shrunk since that card was
filed: 626/384/58 there, 389/150/55 today.

## Verification — all at `ccacdc43b`, the final commit

```
pnpm exec vitest run packages/app-shell/src/__tests__/defaults-maps-mirror-en-pack.test.tsx packages/i18n/
  Test Files  57 passed (57)          ← 56 i18n test files + the mirror gate; counted, not assumed
       Tests  926 passed (926)

pnpm exec vitest run packages/plugin-designer/          (at b1cf72cca; unchanged by the pin commit)
  Test Files  13 passed (13)
       Tests  89 passed (89)

pnpm exec turbo run type-check --filter=@object-ui/i18n --filter=@object-ui/plugin-designer
  Tasks:    17 successful, 17 total
  (each package's task runs `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file is
   inside the measurement rather than excluded from it)

node scripts/check-i18n-call-site-keys.mjs        → exit 0
  "Every in-scope call-site key resolves against the en pack (2847 keys) …"
node scripts/check-i18n-en-drift.mjs              → exit 0
  "0 en value(s) changed (0 key(s) added, 1 removed — those are all-locales-key-parity's)"
node scripts/check-designer-field-key-parity.mjs  → "designer-field-key-parity: OK"
node scripts/check-control-bytes.mjs              → "OK (scanned 5304 tracked text file(s))"
node scripts/check-changeset-presence.mjs         → "11 source file(s) of 2 released package(s)
                                                     changed, and this change declares 1 changeset(s)"
node scripts/check-changeset-fixed.mjs            → exit 0
node scripts/check-changeset-no-major.mjs         → "No changeset declares a `major` bump."
```

**Lint was narrowed, and the narrowing is measured rather than assumed.** `eslint --no-inline-config`
over the changed `.ts` files: **11 files** for the deletion commit and **1** for the pin, counts read
from `--format json` rather than from my own list, **0 errors, 0 warnings**, exit 0 both times. The
narrowing excludes nothing: the flat config's base block matches `**/*.{ts,tsx}` and every changed
file resolved into the result set (none ignored), and `eslint.config.js` extends
`tseslint.configs.recommended` with **no** `parserOptions.project` or `projectService` — no
type-aware rules exist, so a change inside these files cannot move a verdict on a file it does not
touch. The repo-wide `pnpm lint` farm is CI's run, as always.

CI convergence is not waited on here — this report is delivered at draft-PR time by the dispatch
contract. Draft on purpose: **the PM lands this**, it is not self-merged and not marked ready.

Changeset: `patch` for `@object-ui/i18n` and `@object-ui/plugin-designer`, the two packages whose
published source changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_


---
_Generated by [Claude Code](https://claude.ai/code)_