### PR TITLE
fix(components): stop `previousValues` leaking onto the <form> DOM node

### DIFF
--- a/.changeset/6396-previous-values-dom-leak.md
+++ b/.changeset/6396-previous-values-dom-leak.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/components': patch
+---
+
+The form renderer no longer leaks `FormSchema.previousValues` onto the `<form>` DOM node
+(objectui#6396).
+
+`previousValues` is a declared schema key with a real consumer: the renderer's
+`previousRecord` memo, which binds `previous` for field-rule CEL predicates and is the
+INSERT/UPDATE signal the read-only submit strip gates on (objectui#3484). That consumer
+reads it off `schema` and is unchanged. The defect was on the other channel —
+`SchemaRenderer` spreads every non-metadata top-level schema key as a React prop *in
+addition* to handing the node over as `schema`, so an edit-mode host (`ObjectForm`, which
+is what the `object-master-detail-form` header composes) delivered a second, top-level copy
+in `...props`. The renderer already consume-and-drops that whole family before its DOM
+spread — `objectName`, `onDirtyChange`, `defaultValues`, `fields`, `layout`, … —
+and `previousValues` was the one member missing from the list.
+
+Two things followed, on every edit-mode header render. React declined the prop and printed
+`React does not recognize the previousValues prop on a DOM element`, and — measured on
+React 19, and not recorded on the card — the persisted record was still stamped onto the
+element as `previousvalues="[object Object]"`. Consume-and-dropping the duplicate removes
+both.
+
+Scope is the runtime leak only. The declared key stays exactly as declared
+(`packages/types/src/form.ts`, `packages/types/src/zod/form.zod.ts` are untouched): it has
+a live consumer, so there is nothing here for the enforce-or-remove channel.

--- a/packages/components/src/renderers/form/__tests__/form-previous-values-dom-leak.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/form-previous-values-dom-leak.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FormSchema.previousValues` must not reach the `<form>` DOM node — objectui#6396.
+ *
+ * ## The leak, and why the existing `previousValues` tests never saw it
+ *
+ * `previousValues` is a DECLARED schema key with a real consumer: the form
+ * renderer destructures it off `schema` and builds `previousRecord` from it,
+ * which binds `previous` for field-rule CEL and is the INSERT/UPDATE signal the
+ * read-only submit strip gates on (objectui#3484). That consumer reads
+ * `schema.previousValues` and is untouched by this file.
+ *
+ * The leak is on the OTHER channel. `SchemaRenderer` spreads every non-metadata
+ * top-level schema key as a React prop in addition to handing the node over as
+ * `schema` — so an edit-mode host (`ObjectForm`, which is what the
+ * `object-master-detail-form` header composes) puts `previousValues` into its
+ * form node and the renderer receives a second, top-level copy in `...props`.
+ * The renderer already consume-and-drops that family before its DOM spread
+ * (`objectName`, `onDirtyChange`, `defaultValues`, …); `previousValues` was
+ * simply missing from the list, so it rode `...formProps` onto `<form>` and
+ * React declined it:
+ *
+ *     React does not recognize the `previousValues` prop on a DOM element. …
+ *
+ * Every existing `previousValues` test renders `<Form schema={…} />` directly
+ * off the registry, which never populates `...props` — which is exactly why a
+ * declared key could leak to the DOM on every edit-mode header render without a
+ * single test noticing. This file therefore renders through `SchemaRenderer`,
+ * the host path.
+ *
+ * ## The instrument
+ *
+ * ⭐ The symptom is a React `console.error`, not a thrown error and not a DOM
+ * difference — a test that merely renders and passes would prove nothing. So
+ * the assertion reads CAPTURED console output, and two controls keep that
+ * capture honest:
+ *
+ *   - `catches a real unknown-prop warning` — the positive control. It proves
+ *     the capture still sees React's unknown-prop notice at all. Without it the
+ *     pin would keep passing if the capture broke, or if React stopped warning:
+ *     a green vacuous assertion, which is the failure mode this card is about.
+ *   - `tolerates unrelated console output` — the degenerate control. The pin
+ *     matches the `previousValues` notice specifically, NOT "the render printed
+ *     nothing", so the next unrelated warning cannot break it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { SchemaRenderer } from '@object-ui/react';
+// Module-scope import (not `beforeAll`) so the cold transform is billed to the
+// import phase — objectui#3010 / object-ui/no-dynamic-import-in-test-hook.
+import '../../../renderers';
+
+/**
+ * Run `fn` with `console.error` captured, and return one string per call.
+ *
+ * Each call's arguments are joined rather than read positionally on purpose:
+ * React formats this notice as a `%s` template plus separate arguments, so the
+ * prop name is NOT inside the format string. Matching over the joined call is
+ * what makes the matcher below survive that (and survive React changing which
+ * half carries the name).
+ */
+function captureConsoleError(fn: () => void): string[] {
+  const calls: string[] = [];
+  const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    calls.push(args.map((a) => String(a)).join(' '));
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return calls;
+}
+
+/**
+ * The captured unknown-prop notices naming `prop`.
+ *
+ * Deliberately two conditions ANDed, never "the capture is empty": this is the
+ * degenerate-control guard in code form. An unrelated warning — or a second,
+ * different unknown prop — must not make this fire.
+ */
+function unknownPropWarnings(calls: string[], prop: string): string[] {
+  return calls.filter(
+    (c) => /does not recognize/i.test(c) && new RegExp(`\\b${prop}\\b`).test(c),
+  );
+}
+
+/** The header form node an edit-mode `ObjectForm` hands to `SchemaRenderer`. */
+const HEADER_FORM_NODE = {
+  type: 'form',
+  objectName: 'po',
+  fields: [
+    { name: 'ref', label: 'Ref', type: 'input' },
+    { name: 'status', label: 'Status', type: 'input' },
+  ],
+  defaultValues: { ref: 'PO-1', status: 'closed' },
+  // Edit mode: the persisted record. Its PRESENCE is what makes this an update
+  // rather than an insert (objectui#3484) — and what used to reach the DOM.
+  previousValues: { ref: 'PO-1', status: 'closed' },
+  showSubmit: false,
+  showCancel: false,
+};
+
+describe('form renderer — `previousValues` must not reach the DOM (#6396)', () => {
+  it('does not leak `previousValues` onto <form> on an edit-mode header render', () => {
+    const calls = captureConsoleError(() => {
+      render(<SchemaRenderer schema={HEADER_FORM_NODE as any} />);
+    });
+
+    expect(unknownPropWarnings(calls, 'previousValues')).toEqual([]);
+  });
+
+  it('still renders the header, and the DOM node carries no previousvalues attribute', () => {
+    const { container } = render(<SchemaRenderer schema={HEADER_FORM_NODE as any} />);
+
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    // React lowercases an accepted custom attribute, so check that spelling too
+    // — "no warning" and "no attribute" are two different facts and a future
+    // `previousvalues` spelling would silence the warning without fixing this.
+    expect(form!.getAttribute('previousvalues')).toBeNull();
+    expect(form!.getAttribute('previousValues')).toBeNull();
+  });
+
+  it('POSITIVE CONTROL: the capture catches a real unknown-prop warning', () => {
+    // A bare DOM element with an unknown prop — guaranteed to warn, and
+    // independent of any renderer. If this goes red the pin above has become
+    // vacuous (broken capture, or React no longer warning) and must not be read
+    // as "the leak is fixed".
+    const calls = captureConsoleError(() => {
+      render(React.createElement('div', { madeUpProp: { a: 1 } }));
+    });
+
+    expect(unknownPropWarnings(calls, 'madeUpProp')).not.toEqual([]);
+  });
+
+  it('DEGENERATE CONTROL: tolerates unrelated console output on a clean render', () => {
+    const calls = captureConsoleError(() => {
+      const { previousValues: _dropped, ...insertNode } = HEADER_FORM_NODE;
+      render(<SchemaRenderer schema={insertNode as any} />);
+      // Something else entirely printed during this render. The pin must not
+      // care — it pins one named prop, not silence.
+      console.error('unrelated: some other component complained');
+    });
+
+    expect(calls.some((c) => c.includes('unrelated: some other component complained'))).toBe(true);
+    expect(unknownPropWarnings(calls, 'previousValues')).toEqual([]);
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -2565,6 +2565,17 @@ ComponentRegistry.register('form',
           // `schema` destructure above already consumes them; drop the
           // top-level copies here so nothing bleeds through `...formProps`.
           objectName: _objectName,
+          // The persisted record (objectui#6396). It has a real consumer — the
+          // `previousRecord` memo above, which binds `previous` for field-rule
+          // CEL and is the INSERT/UPDATE signal the read-only submit strip
+          // gates on — but that consumer reads it off `schema`, never off
+          // `props`. This top-level copy is purely the SDUI-dispatch duplicate
+          // described above, and it was the one member of this family missing
+          // from the list: it rode `...formProps` onto <form>, where React
+          // declined it ("does not recognize the `previousValues` prop") AND
+          // still stamped the node with `previousvalues="[object Object]"` —
+          // seen on every edit-mode `object-master-detail-form` header render.
+          previousValues: _previousValuesProp,
           onDirtyChange: _onDirtyChangeProp,
           onCancel: _onCancelProp,
           fields: _fields,


### PR DESCRIPTION
Fixes #6396

Verified tree: **`643094dee`** — every reading below was taken on that exact tree (working tree clean at push time).

## Step 1 — the fork: does `previousValues` have a real consumer on the master-detail header path?

**Yes.** This is step 2 (spread hygiene), not step 3 (enforce-or-remove). The measurement:

- `packages/components/src/renderers/form/form.tsx:979` destructures `previousValues` **off `schema`**, and `:1140-1147` builds `previousRecord` from it. That memo is load-bearing twice: it binds `previous` for field-rule CEL predicates, and `isCreateForm = previousRecord === undefined` is the INSERT/UPDATE signal the read-only submit strip gates on (objectui#3484).
- The producer on the header path is live: `ObjectForm.tsx:1057` computes `previousValues` for `mode === 'edit' && recordId`, and puts it on the form node at both `:1270` and `:1423`. `MasterDetailForm.tsx:976` renders that `ObjectForm` as its header.
- Three existing suites exercise that consumer end-to-end (`form-readonly-when-previous`, `form-readonly-submit-strip`, `form-required-when-server-owned`).

So the declared key is **not** dead, nothing here goes to the enforce-or-remove channel, and the authorable surface is untouched: `packages/types/src/form.ts` and `packages/types/src/zod/form.zod.ts` are not in this diff. Clause-② **no**.

## The defect

The consumer above reads `schema.previousValues`. The leak is on the *other* channel.

`SchemaRenderer` spreads every non-metadata top-level schema key as a React prop **in addition** to handing the node over as `schema` (`packages/react/src/SchemaRenderer.tsx:1035` / `:1105`). So an edit-mode host delivers a *second*, top-level copy of `previousValues` in the renderer's `...props`.

The renderer already consume-and-drops that entire family before its DOM spread — `objectName`, `onDirtyChange`, `defaultValues`, `fields`, `layout`, `columns`, … at `form.tsx:2531-2582`, with a comment naming exactly this mechanism ("Some callers / the SDUI dispatch spread the whole form node at the top level … so these arrive in `props` and would leak onto the DOM"). `previousValues` was the one member of the family missing from that list, so it rode `...formProps` onto `<form>`.

The one-line fix adds it to the existing list. The `schema` consumer never reads `props`, so it cannot be affected.

## Premise re-derived on the merged tree

The card measured this on `origin/main @ 631d81dbf`; `main` has moved many times since. Re-derived on `062943f86` (the merge-base this branch was cut from) — still present, and **worse than the card recorded**. React 19 does not merely decline the prop, it also stamps it on the element:

```
React does not recognize the `%s` prop on a DOM element. … previousValues previousvalues
```
```
expected '[object Object]' to be null   ← form.getAttribute('previousvalues')
```

So the persisted record was reaching the DOM as `previousvalues="[object Object]"` on every edit-mode header render. (The attribute stringifies to `[object Object]`, so no field values were exposed — but the attribute should not be there at all.)

## Ghost-assertion guard — both readings

The instrument asserts on **captured `console.error`**, because the symptom is a React console warning, not a thrown error or a DOM difference. Each call's arguments are joined before matching, since React passes the prop name as a separate `%s` argument rather than inside the format string.

**Against unmodified `origin/main` (source untouched, test file only) — FAILING:**

```
 ❯ form-previous-values-dom-leak.test.tsx (4 tests | 2 failed)
   × does not leak `previousValues` onto <form> on an edit-mode header render
   × still renders the header, and the DOM node carries no previousvalues attribute

AssertionError: expected [ Array(1) ] to deeply equal []
+ [ "React does not recognize the `%s` prop on a DOM element. … previousValues previousvalues" ]

AssertionError: expected '[object Object]' to be null

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

**With the fix — PASSING:**

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## The two controls that keep the pin honest

The 2 tests that passed in *both* runs are deliberate, and they are the reason a green pin means something:

- **Positive control** — `POSITIVE CONTROL: the capture catches a real unknown-prop warning` renders a bare `<div madeUpProp={…}>` and asserts the capture *does* return React's notice. Without it, the pin would keep passing if the capture broke or React stopped warning — a green vacuous assertion, which is the exact failure class this card is about.
- **Degenerate control** — `DEGENERATE CONTROL: tolerates unrelated console output on a clean render` renders the same node *without* `previousValues`, emits an unrelated `console.error`, and asserts the pin still passes. The matcher requires `/does not recognize/` **and** the prop name, so it pins one named prop rather than "the render printed nothing"; the next unrelated warning cannot break it.

The new test renders through `SchemaRenderer` rather than pulling the component off the registry directly. That is the whole reason a declared key could leak to the DOM on every edit-mode header render without a single existing test noticing: `<Form schema={…} />` never populates `...props`.

## Verification

All heavy runs serialized through the container's shared verify lock; exit codes captured before any pipe, and each verdict quoted from the tool's own output.

| Check | Result |
|---|---|
| New pin, unmodified `main` | `Tests 2 failed \| 2 passed (4)` — ghost-assertion guard |
| New pin, with fix | `Tests 4 passed (4)` |
| `vitest run packages/components/src/renderers/form/` | `Test Files 55 passed (55)` / `Tests 366 passed (366)` |
| `vitest run packages/plugin-form/` (master-detail host path) | `Test Files 71 passed (71)` / `Tests 726 passed (726)` |
| `pnpm --filter @object-ui/components run type-check` | `TYPECHECK_EXIT=0` |
| `eslint .` — **whole repo, one pass** | `files linted: 3788`, `errorCount total: 0` |
| `check:control-bytes` | `OK (scanned 5302 tracked text file(s))` |
| `check:phantom-deps` / `check:self-import` / `check:esm-specifiers` / `check:vi-mock-specifiers` | all `EXIT=0` |
| `check-changeset-presence` | `1 source file(s) of 1 released package(s) changed … declares 1 changeset(s)` |
| `check-changeset-no-major` | `No changeset declares a major bump` |

The lint reading is a **full repo-wide run**, not a narrowed one — no scope-reduction argument is being relied on.

Type-check coverage was measured rather than assumed: `tsc -p packages/components/tsconfig.test.json --listFiles` reports the new test file **and** `renderers/form/form.tsx` each present in the program (1 hit each), so "type-check clean" actually covers this diff.

Dependency closure (`pnpm --filter '@object-ui/components^...' build`) was built before type-checking, so the `.d.ts` files read are current rather than stale.

## Scope

One line of production change plus its test and changeset (`@object-ui/components`, `patch`).

Deliberately **not** touched:
- The declared surface (`packages/types/src/form.ts`, `packages/types/src/zod/form.zod.ts`) — the key has a live consumer, so there is nothing to retire.
- #6033 is **not addressed here** and remains open: it covers `previousValues` only as a row in the zod-mirror drift census. This PR is the runtime DOM leak, a separate concern.


---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_