### PR TITLE
feat(types,fields): publish LocationValue and bind LocationField to it

### DIFF
--- a/.changeset/6154-location-value-type.md
+++ b/.changeset/6154-location-value-type.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/types': minor
+'@object-ui/fields': minor
+---
+
+Publish `LocationValue` — the declared shape of a `location` field's value — and bind the
+`LocationField` widget's produce and consume sites to `LocationValue | null`
+(objectui#6154, maintainer ruling 2026-08-25).
+
+The coordinates a location field carries are the field's **value**, not metadata:
+`LocationFieldMetadata` correctly declares only `default_zoom` of its own. But no exported
+type declared the value either, so a shape every consumer has to agree on was written down
+nowhere a consumer could import, and the docs page had to describe it in prose while every
+other page in the section annotates against an exported type.
+
+`LocationValue` is `{ latitude: number; longitude: number }`, declared in `@object-ui/types`
+beside `LocationFieldMetadata`. This is **additive**: no existing declaration is changed or
+removed, and there is no behaviour change — the widget already produced exactly this shape.
+
+Two things the declaration deliberately does NOT do, both ruled rather than overlooked.
+It does not widen to the alias spellings the display path tolerates (`{ lat, lng }`,
+`{ lat, lon }`, a `"lat,lng"` string, a `[lat, lng]` array): those are not contract, and
+publishing them would fossilize a five-spelling dialect as protocol with nothing canonical
+for an author or a code generator to aim at. And it does not narrow the runtime — the
+display-side tolerance is untouched, so host data in an alias spelling keeps rendering
+exactly as before. Retiring that tolerance is sequenced after this change, as objectui#6272.
+
+The binding is `LocationValue | null` rather than `LocationValue`: clearing the input emits
+`null`, which is measured widget output rather than defensive padding.

--- a/content/docs/fields/location.mdx
+++ b/content/docs/fields/location.mdx
@@ -38,8 +38,10 @@ const officeLocation: LocationFieldMetadata = {
 
 The coordinates themselves are the field's **value**, not metadata: the widget stores
 an object carrying a `latitude` and a `longitude` and displays it as a comma-separated
-pair. No exported type declares that value shape today, which is tracked as
-[objectui#6154](https://github.com/objectstack-ai/objectui/issues/6154).
+pair. That value shape is declared as `LocationValue` (`@object-ui/types`), which is
+what the widget stores -- the display path additionally tolerates some alias spellings
+that are not contract, tracked as
+[objectui#6272](https://github.com/objectstack-ai/objectui/issues/6272).
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).
@@ -89,7 +91,7 @@ Render it directly when you build the form yourself:
 ```tsx
 import { useState } from 'react';
 import { LocationField } from '@object-ui/fields';
-import type { LocationFieldMetadata } from '@object-ui/types';
+import type { LocationFieldMetadata, LocationValue } from '@object-ui/types';
 
 const field: LocationFieldMetadata = {
   type: 'location',
@@ -98,7 +100,7 @@ const field: LocationFieldMetadata = {
 };
 
 export function StoreLocationInput() {
-  const [value, setValue] = useState<{ latitude: number; longitude: number } | null>(null);
+  const [value, setValue] = useState<LocationValue | null>(null);
   return <LocationField field={field} value={value} onChange={setValue} />;
 }
 ```

--- a/packages/fields/src/widgets/LocationField.tsx
+++ b/packages/fields/src/widgets/LocationField.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { Input, EmptyValue } from '@object-ui/components';
+import type { LocationValue } from '@object-ui/types';
 import { FieldWidgetComponentProps } from './types.js';
 import { toDomProps } from './toDomProps.js';
 
 /**
  * LocationField - Geographic coordinate input for latitude and longitude
- * Stores location as { latitude, longitude } object and displays as comma-separated pair
+ * Stores location as a `LocationValue` (`@object-ui/types`) -- the published
+ * declaration of the `{ latitude, longitude }` shape this widget writes -- and
+ * displays it as a comma-separated pair. The binding is `LocationValue | null`
+ * because clearing the input emits `null` (see `handleChange` below).
  */
-export function LocationField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<any>) {
+export function LocationField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<LocationValue | null>) {
   const config = field;
   // Location is stored as { latitude, longitude } object
   // For display, convert to "latitude, longitude" string format

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -403,6 +403,37 @@ export interface LocationFieldMetadata extends BaseFieldMetadata {
 }
 
 /**
+ * The value a `location` field stores: the coordinate pair itself, which is the
+ * field's VALUE and not metadata (`LocationFieldMetadata` above declares the
+ * authoring keys, of which the coordinates are deliberately not one).
+ *
+ * Scope of this declaration, stated because it is narrower than it looks: this
+ * declares **what the `LocationField` widget stores**, NOT what every reader of
+ * a `location` value accepts. Measured 2026-08-25 by driving the real widget:
+ * `LocationField` (`@object-ui/fields`) produces exactly this shape, plus `null`
+ * when the input is cleared -- which is why its produce/consume sites bind to
+ * `LocationValue | null`, the `null` arm being measured output rather than
+ * defensive padding. The DISPLAY path is more tolerant than this type:
+ * `LocationCellRenderer` (`@object-ui/fields`) and `ObjectMap`
+ * (`@object-ui/plugin-map`) additionally read `{ lat, lng }`, `{ lat, lon }`, a
+ * `"lat,lng"` string and a `[lat, lng]` array.
+ *
+ * Those alias spellings are NOT contract (ruled 2026-08-25) and are left
+ * undeclared here on purpose: declaring them would fossilize a five-spelling
+ * dialect as protocol, the second de-facto contract AGENTS.md #0.1 forbids, and
+ * would leave nothing canonical for an author -- or a code generator -- to aim
+ * at. Leaving them undeclared keeps them retirable. The divergence between the
+ * two sides is tracked as objectui#6272, whose fix direction is retiring the
+ * display-side tolerance, NOT widening this type.
+ */
+export interface LocationValue {
+  /** Latitude in decimal degrees, -90 to 90 (negative South, positive North). */
+  latitude: number;
+  /** Longitude in decimal degrees, -180 to 180 (negative West, positive East). */
+  longitude: number;
+}
+
+/**
  * Column definition for the Record Picker dialog table.
  */
 export interface LookupColumnDef {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -454,6 +454,7 @@ export type {
   UploadedFileMetadata,
   ImageFieldMetadata,
   LocationFieldMetadata,
+  LocationValue,
   LookupFieldMetadata,
   LookupColumnDef,
   LookupFilterDef,


### PR DESCRIPTION
> [!CAUTION]
> **⛔ DO NOT MERGE. The premise under this PR is void, and the change below is wrong.**
>
> `check:spec-symbols` caught it: **`@objectstack/spec/data` already exports `LocationValue`** —
> and its shape is **not** the one this PR declares. Measured on
> `@objectstack/spec@17.2.0`, the version installed against this branch:
>
> ```ts
> // @objectstack/spec/data — the CANONICAL stored form (ADR-0104 D1)
> LocationValue = { lat: number; lng: number; altitude?: number; accuracy?: number }
> ```
>
> The spec's own header states the direction outright: *"'Reality wins': where the deployed
> stored shape is coherent, the contract adopts it — deployed data is a wire contract we don't
> get to rewrite by editing Zod. … `location` is `{lat, lng}` (what field-zoo stores), **not the
> never-consumed `{latitude, longitude}` shape**."* The `{latitude, longitude}` spelling exists
> upstream as `LocationCoordinates` and is **`@deprecated`** — *"Never consumed by the runtime,
> and its key names contradict what the platform actually stores … Removal rides the next spec
> major."*
>
> Runtime measurement against the spec's enforced contract
> (`valueSchemaFor({ type: 'location' })`, identical result from `LocationValueSchema`):
>
> | value | spec verdict |
> |---|---|
> | `{ latitude, longitude }` — what `LocationField` produces | **REJECT** (`invalid_type` at `lat`, `lng`) |
> | `{ lat, lng }` — the two in-repo fixtures | **ACCEPT** |
> | `{ lat, lng, altitude, accuracy }` | **ACCEPT** |
>
> So the ruling this PR implements is inverted by the spec at three points, and every one of
> them was measured against objectui's own tree only — `@objectstack/spec` is an upstream
> published dependency and was never in any of the censuses:
>
> 1. **The name is not objectui's to mint.** The card, the bounce report, the ruling and the
>    dispatch all rested on "no exported type declares the location value".
> 2. **The alias spelling is the contract, not the dialect.** `{lat, lng}` is canonical
>    upstream; `{latitude, longitude}` is the deprecated one.
> 3. **#6272's ruled fix direction is backwards.** Retiring the display-side tolerance and
>    re-fixturing the two `{lat, lng}` files would retire the *spec-canonical* spelling and
>    re-fixture *spec-conformant* fixtures. `LocationCellRenderer` reading `lat`/`lng` first is
>    spec-correct; the real divergence is that **`LocationField` produces a deprecated shape the
>    spec's contract rejects**.
>
> This goes back to the decision box — that escalation is the PM's call, not this seat's. The
> closing keyword has been removed from this description so an accidental merge cannot close
> a card that is being re-opened for a ruling. Everything below this banner is the original
> description and is **retained only as a record**; its central claim — that `LocationValue`
> was 0 occurrences and unowned — is false at the spec boundary.

---

Relates to #6154 (deliberately not a closing reference — see the banner above).

Publishes `LocationValue` and binds `LocationField`'s produce/consume sites to it. This is
step **A** of the ruling recorded on the card at 2026-08-25T10:12Z, which accepted Option A
with both of the bouncing dev's conditions. It is a declaration catching up to enforced
reality: no behaviour changes.

## Contract review — the exact new published surface

Clause-② applies: this expands the public surface of `@object-ui/types`. The complete
addition, and nothing else:

```ts
// @object-ui/types  ·  packages/types/src/field-types.ts:429, beside LocationFieldMetadata (:400)
export interface LocationValue {
  latitude: number;
  longitude: number;
}
```

Re-exported by name from the package barrel (`packages/types/src/index.ts`), and verified in
the **emitted** declarations rather than the source — `packages/types/dist/field-types.d.ts:381`
carries both members intact, so #6151's `BaseSchema` index-signature erasure did not apply
here (it could not: `LocationValue` extends nothing, and `BaseFieldMetadata` is a standalone
interface outside that inheritance path).

**Additive. No existing declaration is changed or removed.** The only other source change is
one generic argument on the widget:

```
- FieldWidgetComponentProps<any>
+ FieldWidgetComponentProps<LocationValue | null>
```

`LocationValue` was **0 occurrences repo-wide** before this branch (positive control on the
same pathspec: `latitude|longitude` returns 252 non-test hits, so the zero was a real zero and
not a broken pathspec), so the name collides with nothing.

The `null` arm is not defensive padding — it is measured widget output. `LocationField.tsx:25`
emits `onChange(null)` on cleared input, and the docs page already taught that arm. A
non-nullable type would reject what the widget provably produces.

## What this deliberately does NOT do

Each of these is a ruled decision, recorded so review does not read one as an oversight:

- **It does not widen to the measured dialect.** The display path additionally tolerates
  `{ lat, lng }`, `{ lat, lon }`, a `"lat,lng"` string and a `[lat, lng]` array. Those are
  **not contract**. Publishing them would fossilize a five-spelling dialect as protocol — the
  second de-facto contract AGENTS.md #0.1 forbids — and would leave nothing canonical for an
  author, or a code generator, to aim at.
- **It does not narrow the runtime.** `LocationCellRenderer` and `ObjectMap` are untouched and
  the two `{ lat, lng }` fixtures are un-refixtured, so host data in an alias spelling renders
  exactly as before. That retirement is step **D**, sequenced after this card as #6272's fix
  direction. (That number is named here as a pointer only; #6272 remains open.)
- **It does not unify with `GeolocationValue`** (`@object-ui/fields`). The ruling names the
  duplication a conscious "two places for now"; unification is a possible later card.
- **It does not touch `packages/app-shell/src/utils/paramValueShape.ts:164`**, which already
  documents `location` in prose as `'{ latitude, longitude } object.'` — consistent with this
  type, and deliberately out of scope.

## The docs page, named explicitly

`content/docs/fields/location.mdx` is the only file here beyond the three the card scopes, and
it is truth-maintenance of statements **this change itself falsifies**, not scope creep:

- `:41` asserted "No exported type declares that value shape today, which is tracked as
  #6154". Landing the type makes that sentence false; it now names `LocationValue` and points
  the divergence at #6272.
- `:101` self-declared `useState<{ latitude: number; longitude: number } | null>(null)`. It now
  annotates against the exported type, which is what the card was filed for — #6138's
  conversion could not carry a shape that had no exported type.

That page is **covered** by `check:doc-snippets` (it is not in `UNGATED_DOCS`), so its snippet
compiles against the built `dist` — which makes it a live pin of the new export, proven below.

## Verification

Everything below ran on the final commit, `4a218439d`, on a built tree. Exit codes were
captured before any pipe; each verdict quotes the gate's own line.

**Build closure first** (a stale `.d.ts` lies in both directions):
`turbo run build` for the `check:doc-snippets` closure and `pnpm --filter '@object-ui/fields^...'`
— both `VERDICT command-exit 0`.

**Type-check, with coverage measured rather than assumed.** `pnpm --filter @object-ui/types
--filter @object-ui/fields run type-check` → `VERDICT command-exit 0`, and the output echoes
`Scope: 2 of 47 workspace projects` plus both script names, so this is not pnpm's silent
zero-match exit-0. Note the spelling is `type-check`, hyphenated. Coverage proved with
`tsc --listFiles`: `field-types.ts` ✓, `index.ts` ✓, `LocationField.tsx` ✓, and
`AddressCellRenderer.test.tsx` ✓ inside `tsconfig.test.json`'s program — so the green covers
the test files, not just `src`.

**Downstream direction, demonstrated rather than asserted.** `pnpm --filter '...@object-ui/fields'`
(prefix) selects **20** packages including `plugin-detail`, `plugin-map`, `app-shell`, the three
example apps and `site`; `'@object-ui/fields...'` (suffix) selects a different set of **11**
upstream deps. The downstream run — `turbo run type-check --filter '...@object-ui/fields'` —
reports `Tasks: 56 successful, 56 total` with `Cached: 1 cached, 56 total`, so 55 tasks really
executed and this green is a measurement, not a cache replay. `plugin-detail` matters
specifically: `InlineFieldInput.tsx:398` is the one `<LocationField>` call site outside the
package, and it type-checks unchanged.

**The two `{ lat, lng }` fixtures still pass, unchanged** — the evidence this stayed inside the
ruling and did not narrow the runtime. `AddressCellRenderer.test.tsx` (the live assertion at
`:65,153`) and `DetailSection.addressDisplay.test.tsx`: `Test Files 2 passed (2)`,
`Tests 17 passed (17)`. Full affected package: `Test Files 113 passed (113)`,
`Tests 1850 passed (1850)`. Run from the repo root per objectui#3378.

### Ghost-assertion guard: two pins, each proven able to fail

**Pin 1 — the binding rejects the alias spelling.** Predicted before running: red, TS2345.
Mutated the produce site to `onChange({ lat, lng })`; mutation proven on disk in both
directions (injected present = 1, removed absent = 0) before anything was read.

- **Observed: red, `tsc` exit 2** — `LocationField.tsx(39,20): error TS2353: Object literal may
  only specify known properties, and 'lat' does not exist in type 'LocationValue'.`
- Correction, stated rather than smoothed over: I predicted **TS2345** and got **TS2353**. The
  direction was right; the code differs because TypeScript's excess-property check on a fresh
  object literal fires ahead of the outer assignability error. Same fact, more specific code.
- **Positive control** — the leg that proves the *binding* does the work, not the mutation:
  with the identical mutation in place, reverting only the signature to
  `FieldWidgetComponentProps<any>` compiles **clean, exit 0, 0 errors**. So on `main` this
  mutation was silently green; it is red only because of this PR.
- Restored by **hash**, not by exit code: blob back to `1db57a6da…`, `git diff HEAD --stat` empty.

**Pin 2 — the docs snippet is a live pin of the export.** Predicted: red, TS2305, naming
`location.mdx`. Renamed the imported symbol in the page only.

- **Observed: red, gate exit 1**, `Semantic phase: 267 of 267 block(s) judged, 1 failed` —
  `content/docs/fields/location.mdx:94:38 TS2724: '"@object-ui/types"' has no exported member
  named 'LocationValueXX'. Did you mean 'LocationValue'?` plus TS2304 at `:103`.
- Correction again: predicted **TS2305**, observed **TS2724**. That is the "did you mean"
  variant, which TypeScript selects *because a near-match export exists* — so the diagnostic is
  itself independent confirmation that `LocationValue` is a real exported member of the built
  `dist`, which is stronger than what I predicted.
- Restored by hash; `git diff HEAD --stat` empty.

Unmutated, the gate reports exit 0, `267 of 267 block(s) judged, 0 failed`, and resolves
`@object-ui/types` to `packages/types/dist/index.d.ts`.

### Gates

Green, each quoting its own verdict: `check-doc-snippet-types` (0), `check-doc-component-types`
(0), `check-doc-fence-languages` (0), `check-doc-links` (0), `check-changeset-fixed` (0),
`check-changeset-no-major` (0), `check-changeset-presence` (0 — "3 source file(s) of 2 released
package(s) changed, and this change declares 1 changeset(s)"), `check-control-bytes` (0),
`check-phantom-dependencies` (0), `check-package-self-import` (0), `check-type-check-coverage`
(0), `check-lint-coverage` (0), `check-readme-exports` (0).

One of those needs its history stated. `check-readme-exports` first exited **1** — but on
`@object-ui/plugin-ai`'s three README imports, with the gate's own message "its type entry
`./dist/index.d.ts` is not on disk — run `pnpm build` first". That is the gate's
prerequisite-not-met arm, not a verdict about this diff; `plugin-ai` is simply not in this
change's build closure. After building it the gate reports exit 0 with `0 unbuilt` and
`378 real, 0 wrong-path, 0 fabricated`. Recorded rather than quietly re-run.

**Lint — a declared narrowing, with its three pieces of evidence.** The repo-wide `pnpm lint`
is CI's run; here the two affected packages' own `lint` ran instead: `VERDICT command-exit 0`,
**0 errors** in both (`0 errors, 244 warnings` in `types`; `0 errors, 871 warnings` in `fields` —
both the pre-existing baseline). That narrowing is a measurement because: (1) the covered
population comes from eslint's own ledger, `check-lint-coverage` reporting 46/46 packages
linted with 0 outstanding errors; (2) the count comes from `--format json` — 5 files linted,
0 errors, and the 6 warnings on `field-types.ts` sit at lines 102/150/158/593/659/751, all
outside the added range 406-436, all pre-existing `no-explicit-any`; (3) **invariance**: no
`eslint.config.*` in the repo enables type-aware linting (no `projectService`, no
`parserOptions.project`), so this diff cannot move the verdict on any file it did not touch.

`changeset`: `minor` on `@object-ui/types` and `@object-ui/fields`, never `major`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_


---
_Generated by [Claude Code](https://claude.ai/code)_