### PR TITLE
chore(ci): remove vestigial pnpm setup from dependabot-auto-merge.yml

### DIFF
--- a/.changeset/6392-vestigial-pnpm-steps.md
+++ b/.changeset/6392-vestigial-pnpm-steps.md
@@ -1,0 +1,13 @@
+---
+---
+
+CI-only change in `.github/workflows/dependabot-auto-merge.yml` (objectui#6392): removed the
+`corepack enable` + `pnpm --version` steps left behind once objectui#6389 removed the lockfile
+merge driver that had been their only consumer. Nothing in this job runs `pnpm install` or
+otherwise shells out to `pnpm`, so the two lines were a package manager enabled and
+version-printed for zero consumers. A comment in the workflow records the reasoning for the
+removal (and for not keeping `pnpm --version` alone as a fail-fast) so a future reader does not
+re-add it unexplained; the `cache: 'pnpm'` comment on the `Setup Node.js` step below was reworded
+to note that no pnpm setup happens in this job at all.
+
+No source or behaviour change outside the workflow file; no published package touched.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -88,19 +88,34 @@ jobs:
         with:
           submodules: true
 
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Verify pnpm version
-        run: pnpm --version
-
+      # No pnpm setup here, deliberately (objectui#6392).
+      #
+      # This job ran `corepack enable` + `pnpm --version` until 2026-08-25,
+      # as a leftover of the lockfile merge driver removed in objectui#6389
+      # (see the "No lockfile merge driver here" note below) -- that driver
+      # step was the only thing in this job that ever needed pnpm. Once it
+      # was gone, enabling corepack and printing a pnpm version was a package
+      # manager set up for zero consumers: the Setup Node.js step right below
+      # already explains that this job never runs `pnpm install`, and nothing
+      # else here shells out to `pnpm`.
+      #
+      # Considered and rejected: keeping `pnpm --version` alone as a "proves
+      # corepack activated" fail-fast, so a future pnpm dependency would fail
+      # clearly instead of confusingly. Rejected because that failure mode
+      # has no occasion to matter until something in this job actually calls
+      # pnpm, and nothing does today -- an unexplained two-line "just in
+      # case" setup with no consumer is exactly the residue this issue is
+      # about, and keeping half of it recreates the same shape. If a future
+      # step here grows a real pnpm dependency, add `corepack enable` back
+      # next to that step, where a reader can see what it's for.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
           node-version: '22.x'
-          # No `cache: 'pnpm'` here: this job never runs `pnpm install`, so the
-          # pnpm store doesn't exist and setup-node's post-job cache save fails
-          # with "Path Validation Error", which marks the whole job as failed.
+          # No `cache: 'pnpm'` here: this job doesn't set up pnpm at all (see
+          # the note above) and never runs `pnpm install`, so the pnpm store
+          # doesn't exist and setup-node's post-job cache save would fail
+          # with "Path Validation Error", marking the whole job as failed.
 
       # No lockfile merge driver here, deliberately (objectui#6369).
       #


### PR DESCRIPTION
Fixes #6392

## Premise, re-verified on `main` at this branch's own HEAD (`9602dc820`)

Both halves confirmed before touching anything:

```
$ grep -n "merge\.pnpm-merge\.name\|merge\.pnpm-merge\.driver" .github/workflows/dependabot-auto-merge.yml
(no output, exit 1)                       # driver step is gone (#6389 merged)

$ grep -n "corepack enable\|pnpm --version" .github/workflows/dependabot-auto-merge.yml
92:        run: corepack enable
95:        run: pnpm --version           # both still present
```

## What changed

Removed both pnpm steps (`corepack enable`, `pnpm --version`) from
`dependabot-auto-merge.yml`. `actions/setup-node` stays — the merge-gate script
is a `node` step and needs the runtime regardless.

**Decision: cut both, don't keep `pnpm --version` as a fail-fast.** The
reasoning is written into the workflow file itself (right where the two steps
used to be), summarized here:

- Nothing in this job calls `pnpm` today — its own next step already says it
  never runs `pnpm install`.
- The "proves corepack activated" fail-fast only matters once something in
  this job actually depends on pnpm, and nothing does. Keeping it is an
  unexplained two-line "just in case" setup with no consumer — which is the
  exact shape of residue this issue is about; keeping half of the removal
  recreates the same shape it names.
- If a future step here grows a real pnpm dependency, the `corepack enable`
  setup should go back in next to *that* step, where a reader can see what
  it's for, not sitting two steps away from its only would-be consumer.

## The `cache: 'pnpm'` comment

Re-read, not reflex-deleted, per the card's warning. Its underlying claim
("this job never runs `pnpm install`, so a pnpm store cache would break
`setup-node`'s post-job save") is still true and still the right warning for
the next person who reaches for `cache: 'pnpm'` on this job — reworded only to
note that the job doesn't set up pnpm at all any more, which makes the warning
even more clearly applicable, not less.

## Scope

Only `dependabot-auto-merge.yml`'s two pnpm lines. Per PM dispatch, #6391 (same
mechanism family) is explicitly out of scope for this PR — `changeset-
release.yml`, the `.gitattributes` line, and the "Lockfile Merge Driver"
table's remaining row are untouched.

## Tests

- `pnpm exec vitest run scripts/__tests__/` (whole tree, as required because
  `ci-cd-pipeline-doc.test.ts` pins `content/docs/guide/ci-cd-pipeline.md`
  against `.github/workflows/` in both directions): **81 test files passed,
  2317 tests passed**, run at commit `121ae518e` (this branch's head).
- `node scripts/check-changeset-presence.mjs`: confirms no published-package
  source changed and the changeset already added is sufficient — "No source of
  a released package changed in this range, so no changeset is owed."
- Re-parsed the edited YAML with `python3 -c "import yaml; yaml.safe_load(...)"`
  and listed the job's step names to confirm the two pnpm steps are gone and
  every other step (including `actions/setup-node`) is untouched.
- `grep -rn "Enable Corepack\|Verify pnpm version" .github/workflows/` —
  confirms `dependabot-auto-merge.yml` no longer appears in that list while
  every workflow that genuinely runs `pnpm install` (`ci.yml`, `lint.yml`,
  `changeset-release.yml`, etc.) is untouched.

## Changeset

`.changeset/6392-vestigial-pnpm-steps.md`, empty frontmatter (CI-only change,
no published package touched — objectui declares "no release" this way; the
`skip-changeset` label mechanism doesn't exist in this repo).


---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_