### PR TITLE
fix(core): repoint two deprecation warnings off the deleted MIGRATION_GUIDE.md

### DIFF
--- a/.changeset/6342-dead-migration-guide-pointers.md
+++ b/.changeset/6342-dead-migration-guide-pointers.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/core': patch
+---
+
+Two deprecation warnings pointed at `MIGRATION_GUIDE.md`, a file deleted from the
+repository in `8c5d20455` (objectui#6342).
+
+`Registry.register()`'s missing-namespace warning now points at the live docs page
+that documents namespaced registration
+(`/docs/guide/plugin-development#namespaced-registration`) instead of the deleted
+guide. `ValidationEngine`'s function-based-condition warning drops its `See:` line
+entirely: the deleted guide covered component namespaces and lazy field
+registration and never documented conditions at all, so that pointer was
+misdirected as well as dead, and the warning already carries the complete
+before/after migration inline.
+
+Both are console messages shipped to application developers, so neither can use
+the immutable `git show <sha>^:<path>` provenance form objectui#6275 used for a
+docblock — a reader of the npm package has no repository to run it against.

--- a/packages/core/src/registry/Registry.ts
+++ b/packages/core/src/registry/Registry.ts
@@ -225,7 +225,7 @@ export class Registry<T = any> {
         `  registry.register('${type}', MyComponent);\n\n` +
         `  // After:\n` +
         `  registry.register('${type}', MyComponent, { namespace: 'my-plugin' });\n\n` +
-        `  See: https://github.com/objectstack-ai/objectui/blob/main/MIGRATION_GUIDE.md`
+        `  See: https://www.objectui.org/docs/guide/plugin-development#namespaced-registration`
       );
     }
     

--- a/packages/core/src/validation/validation-engine.ts
+++ b/packages/core/src/validation/validation-engine.ts
@@ -407,8 +407,7 @@ export class ValidationEngine {
         '  // Before (deprecated):\n' +
         '  { condition: (values) => values.age > 18 }\n\n' +
         '  // After:\n' +
-        '  { condition: { field: "age", operator: ">", value: 18 } }\n\n' +
-        '  See: https://github.com/objectstack-ai/objectui/blob/main/MIGRATION_GUIDE.md'
+        '  { condition: { field: "age", operator: ">", value: 18 } }'
       );
       return false; // Security: reject function-based conditions
     }


### PR DESCRIPTION
Part of #6342

The card asked for a census first, and said the census decides the fork. It does.
**The census says SMALL, so this PR takes the small fork: two hand repairs, and the
gate is left alone.** The measurement also turned up something the card did not
know, which independently argues against widening — see "Why not widen" below.

## The census

Population: `github.com/objectstack-ai/objectui/(blob|tree)/main/…` in tracked files,
by extension.

| ext | occurrences | in the gate's population today? |
|---|---:|---|
| `.md` | 84 | yes |
| `.mdx` | 33 | yes |
| `.ts` | 18 | **no** |
| `.mjs` | 2 | **no** |
| `.tsx` | 1 | **no** |

**21 occurrences sit outside the gate's population.** Broken down by what they
actually are:

| what | count | dead? |
|---|---:|---|
| `scripts/__tests__/check-doc-links.test.ts` — the gate's own fixtures | 16 | deliberately dead (`packages/gone/README.md`, `blob/main/../../../etc/hosts`, `blob/12b287d8b/…`) |
| `scripts/check-doc-links.mjs` — the literal ellipsis `blob/main/...` in its own hint text | 2 | not a link |
| **genuine authored links in product source** | **3** | **2 dead** |

The three genuine ones:

| site | target | state |
|---|---|---|
| `apps/site/app/(home)/page.tsx:79` | `blob/main/LICENSE` | alive |
| `packages/core/src/registry/Registry.ts:228` | `blob/main/MIGRATION_GUIDE.md` | **dead** |
| `packages/core/src/validation/validation-engine.ts:411` | `blob/main/MIGRATION_GUIDE.md` | **dead** |

**Already dead: 2**, both naming the same target, deleted in `8c5d20455`.

### Control terms

Every zero reading here is paired with a known-present string run through the
*same* command shape:

- Variant spellings `raw/main`, `blame/`, `blob/main` with no trailing slash → **0 files**.
  Control in the identical command shape: `objectui/blob/main/MIGRATION` → **2 files**. The
  zeros are real absences, not a broken sweep.
- The extension table above is itself controlled: `.md`/`.mdx` return 84/33, the population
  the gate already scans.

## Why not widen — the census is small, and widening would not have worked anyway

The card's model is that the gate can already decide this URL and is only missing the
*file*. That is **half** true, and the missing half is decisive.

The gate's extractor is markdown link syntax only:

```js
const MARKDOWN_LINK_RE = /\[[^\]]+\]\(([^)]+)\)/g;   // scripts/check-doc-links.mjs:518
```

**It never extracts a bare URL.** All three genuine source-file links are bare URLs, and
both dead ones sit inside a runtime `console.warn` *string literal*, not a docblock:

```
`  See: https://github.com/objectstack-ai/objectui/blob/main/MIGRATION_GUIDE.md`
```

Measured — the gate's own `stripCode()` + its own extractor over those files:

```
packages/core/src/registry/Registry.ts                        extracted=0  self-repo-blob=0
packages/core/src/validation/validation-engine.ts             extracted=0  self-repo-blob=0
packages/core/.../validators/object-validation-engine.ts      extracted=0  self-repo-blob=0
CONTROL README.md: extracted=62      CONTROL CONTRIBUTING.md: extracted=15
CONTROL same dead URL in [x](y) form: extracted=1, selfRepoPath=MIGRATION_GUIDE.md, existsOnDisk=false
```

So widening the extension filter alone is a **no-op for this defect shape** — it would not
have caught #6275's link either. The two populations spell links differently, and that is
measurable in both directions: inside the gate's current markdown population, **116 of 116**
self-repo blob/tree URLs are written as `[x](y)` and **0** are bare; in source files, **3 of 3**
are bare.

The real fix would therefore be population widening **plus a new bare-URL extractor** — a
materially larger gate than "one row in `SCAN_ROOTS`". That decision is handed back.

On the `stripCode()` analogue the card asked about: source files are all code, so the
analogue is the inverse — mask everything that is *not* a comment, which this repo already
answers once in `scripts/js-comment-mask.mjs`. But that helper keeps **comments only**, and
both dead links live in **string literals**, which it masks out. The correct protection and
the target defect are mutually exclusive here.

## The noise a widened sweep admits

Pointing the existing pipeline at 3,764 source files under `packages`, `apps`, `scripts`,
`e2e`, `examples` extracts 257 `[x](y)` matches and would emit **194 findings — none of them
a genuine defect**:

```
TOTAL findings a widened source-file sweep would emit: 194
   172  disk-path
    18  site-absolute-url
     4  self-repo-url

Top files:  135  scripts/__tests__/check-doc-links.test.ts
             17  apps/console/src/pages/doc-links.test.ts
              9  apps/console/vite.config.ts
```

135 of them come from the gate's **own test file** — a widened gate's first act is to fail on
its own fixtures. 48 of the 257 extractions are not links at all, just TypeScript that matches
the regex:

| file | extracted "href" |
|---|---|
| `packages/react/src/context/NotificationContext.tsx` | `n.title, { description: n.message }` |
| `packages/react/src/hooks/useActionRunner.ts` | `msg` |
| `packages/cli/src/__tests__/app-generator.test.ts` | a regex character class |
| `packages/plugin-markdown/src/markdown-render.test.tsx` | `javascript:alert(1` |

Triage's ratchet instruction was "if the widened sweep floods with historical debt, freeze it
in a reasoned baseline". What it floods with is not historical debt — it is **test fixtures and
non-links**. Baselining 194 fixture strings would not be a ratchet, so the instruction's
precondition is not met and no baseline is proposed.

## Two-direction proof

Both dead-URL spellings planted in `packages/core/src/registry/Registry.ts`, under
`trap restore EXIT INT TERM`, target `DEAD_PROBE_6342.md` confirmed absent:

```
mutation confirmed ON DISK:  bare spelling: 1   md spelling: 1

DIRECTION 1 — current gate:        exit=0  "Links are valid across 17 scan roots."   (invisible)
DIRECTION 2 — widened extension filter, same file:
    BROKEN self-repo-url  Registry.ts:181  .../blob/main/DEAD_PROBE_6342.md
    WIDENED-SIM VERDICT: RED (1 finding)
```

Line 181 is the **markdown** spelling. Line 180, the **bare** spelling — the shape both real
dead links actually use — is not reported. That is the whole argument, measured.

Control that the simulator works: run on the gate's own fixture file it reports RED with 4
findings (`packages/gone/README.md`, `examples/crm`).

Restore verified, not assumed:

```
git hash-object after restore = a2972821634e46789042b94184438aacd4b8ce4c  == HEAD blob
git diff HEAD  ->  empty
grep -c PROBE-6342  ->  0
re-run: gate exit=0 "Links are valid across 17 scan roots."   widened-sim: GREEN (0 findings)
```

## What this PR changes

- `packages/core/src/registry/Registry.ts` — the missing-namespace warning now points at the
  live docs page that documents namespaced registration,
  `/docs/guide/plugin-development#namespaced-registration`. Verified with the gate's own
  resolver: `routeExists('/docs/guide/plugin-development')` → resolves; dead control
  `/docs/guide/definitely-not-a-real-page-xyz` → dead.
- `packages/core/src/validation/validation-engine.ts` — the function-based-condition warning
  drops its `See:` line. The deleted guide covered component namespaces and lazy field
  registration and **never documented conditions at all** (`grep -i condition` over
  `git show 8c5d20455^:MIGRATION_GUIDE.md` → no output), so that pointer was misdirected as
  well as dead. The message already carries a complete before/after inline.
- Changeset: `@object-ui/core` patch.

Neither site can use the immutable `git show SHA^:PATH` provenance form #6275 used — that
was a docblock read by contributors with the repo; these are console messages read by
application developers who have only the npm package.

Because the gate's scan surface is unchanged, the surface descriptions #6280 rewrote stay
accurate; nothing there needed updating in this PR.

## Verification

Union re-run on the final commit `5beb3e6ed`, clean tree:

```
node scripts/check-doc-links.mjs      exit=0  "Links are valid across 17 scan roots."
node scripts/check-control-bytes.mjs  exit=0  "OK (scanned 5314 tracked text file(s); skipped 85 binary)."
pnpm exec vitest run --maxWorkers=2 scripts/__tests__ packages/core/
                                      exit=0  Test Files 181 passed (181)   Tests 4340 passed (4340)
pnpm --filter '@object-ui/core' run type-check   exit=0  (tsc --noEmit && tsc -p tsconfig.test.json)
```

The whole `scripts/__tests__` tree is included, as the dispatch required (81 files on its own
run; 181 in the union above with `packages/core/`).

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_