### PR TITLE
fix(app-shell): converge both confirm runtimes on one close reset shape

### DIFF
--- a/.changeset/confirm-runtime-close-parity-6034.md
+++ b/.changeset/confirm-runtime-close-parity-6034.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Console action runtime: closing an action confirm dialog now keeps the dialog's
+text instead of blanking it mid-fade.
+
+`useConsoleActionRuntime` reset its confirm state by replacing the whole object
+(`{ open: false, message: '' }`), which cleared `message` and dropped `options`.
+Radix keeps `AlertDialogContent` mounted through its exit animation, so the
+dialog's description went blank and its title and button labels reverted to
+their defaults while it was still fading out. It now flips only `open` and keeps
+every field, matching `RecordDetailView`'s second confirm runtime, which already
+closed this way. Both runtimes feed one `ActionConfirmDialog`; the parity pin now
+covers the close path as well as the open path.

--- a/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
+++ b/packages/app-shell/src/hooks/useConsoleActionRuntime.tsx
@@ -692,8 +692,25 @@ export function useConsoleActionRuntime(opts: ConsoleActionRuntimeOptions): Cons
 
   const dialogs = (
     <>
+      {/*
+        Close = flip `open` and KEEP every other field (objectui#6034). Radix
+        holds `AlertDialogContent` mounted through its exit animation
+        (`data-[state=closed]:animate-out … duration-200`), so
+        `ActionConfirmDialog` goes on reading `state.message` into the
+        description and `state.options` into the title and both button labels
+        for the whole fade-out. The `{ open: false, message: '' }` this replaced
+        blanked the description and reverted the labels to their i18n defaults
+        mid-fade. The retained `resolve` is inert — the dialog settles the
+        promise BEFORE it asks for the close, and the open path above replaces
+        the whole state object, so nothing stale survives a reopen.
+
+        `RecordDetailView` mounts a SECOND runtime into this same dialog and
+        already closed this way; that both runtimes hand the dialog one field
+        set on open AND reset it one way on close is pinned by
+        `views/RecordDetailView.confirmRuntimeParity-5835.test.tsx`.
+      */}
       <ActionConfirmDialog state={confirmState} onOpenChange={(open) => {
-        if (!open) setConfirmState({ open: false, message: '' });
+        if (!open) setConfirmState(s => ({ ...s, open: false }));
       }} />
       <ActionParamDialog state={paramState} onOpenChange={(open) => {
         if (!open) setParamState({ open: false, params: [] });

--- a/packages/app-shell/src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx
@@ -15,6 +15,12 @@
  * - `views/RecordDetailView.tsx` does NOT consume that hook. It builds a second,
  *   near-identical `confirmHandler` and renders its own `<ActionConfirmDialog>`.
  *
+ * This file pins BOTH halves of that relationship. The OPEN half is #5835's and
+ * comes first; the CLOSE half (objectui#6034) is the second `describe` at the
+ * bottom, with its own header explaining which reset shape won and why. They
+ * live in ONE file on purpose: two parity pins for one relationship could
+ * disagree with each other, which is the very defect the two runtimes had.
+ *
  * Merging the two is a larger refactor and is deliberately NOT this file's job.
  * What this file buys instead is the property the duplication threatens: the
  * dialog is one component with one set of reads, so whichever runtime opened it
@@ -85,9 +91,29 @@ vi.mock('sonner', () => ({
  * a per-path double could drift exactly the way the runtimes did.
  */
 let dialogState: any = null;
+
+/**
+ * The CLOSE path's subject (objectui#6034). `dialogState` above only records
+ * while `open` is true, so it structurally cannot see what a runtime writes
+ * when the dialog CLOSES — the exact half these two runtimes disagreed on.
+ *
+ * - `dialogStates` records EVERY `state` the dialog is handed, so the object
+ *   that arrives after the close is observable.
+ * - `closeViaRuntime` is the runtime's OWN `onOpenChange` prop — driving the
+ *   real seam, not a re-spelling of it. A test that called `setConfirmState`
+ *   itself would pin the test's idea of the reset shape, not the runtime's.
+ */
+let dialogStates: any[] = [];
+const NO_DIALOG_RENDERED = () => {
+  throw new Error('ActionConfirmDialog never rendered — no runtime close seam to drive');
+};
+let closeViaRuntime: (open: boolean) => void = NO_DIALOG_RENDERED;
+
 vi.mock('./ActionConfirmDialog', () => ({
-  ActionConfirmDialog: ({ state }: any) => {
+  ActionConfirmDialog: ({ state, onOpenChange }: any) => {
     if (state?.open) dialogState = state;
+    dialogStates.push(state);
+    closeViaRuntime = onOpenChange;
     return null;
   },
 }));
@@ -244,10 +270,34 @@ async function confirmViaConsoleRuntime(...args: unknown[]) {
   return dialogState;
 }
 
+/**
+ * Close path — hand the runtime its own `onOpenChange(false)` and return the
+ * `state` object it writes in response (objectui#6034).
+ *
+ * The call ORDER mirrors `ActionConfirmDialog.handleCancel` exactly: the dialog
+ * settles the promise FIRST and only then calls `onOpenChange(false)`. That
+ * order is the whole reason a `resolve` retained past the close is inert — a
+ * second call on a settled promise is a no-op — so a close-path pin that
+ * skipped the settle would be pinning a sequence production never runs.
+ */
+async function closeFromRuntime(openState: any) {
+  const before = dialogStates.length;
+  await act(async () => {
+    openState.resolve?.(false);
+    closeViaRuntime(false);
+    await Promise.resolve();
+  });
+  const written = dialogStates.slice(before);
+  expect(written.length).toBeGreaterThan(0);
+  return written[written.length - 1];
+}
+
 beforeEach(() => {
   cleanup();
   captured.length = 0;
   dialogState = null;
+  dialogStates = [];
+  closeViaRuntime = NO_DIALOG_RENDERED;
   vi.stubGlobal(
     'fetch',
     vi.fn(async () =>
@@ -313,5 +363,93 @@ describe('app-shell — both confirm runtimes feed ActionConfirmDialog the same 
       expect(viewFields).toContain(field);
       expect(hookFields).toContain(field);
     }
+  });
+});
+
+/**
+ * ## The CLOSE half (objectui#6034)
+ *
+ * The block above is the OPEN half and it is #5835's. Its assertions stay green
+ * under either reset shape, so within this file they are **controls, not
+ * evidence** — they establish that both runtimes still reach the dialog at all,
+ * which is what makes a difference measured after the close attributable to the
+ * close handler.
+ *
+ * The divergence this half pins: `useConsoleActionRuntime` used to close with
+ * `setConfirmState({ open: false, message: '' })` — replacing the whole object,
+ * blanking `message` and dropping the `options` / `resolve` keys outright —
+ * while `RecordDetailView` closed with `setConfirmState(s => ({ ...s, open:
+ * false }))`, flipping one flag and keeping every field.
+ *
+ * **Field-preserving is the shape that won, because of who reads the state
+ * after the close.** `AlertDialogContent` carries `data-[state=closed]:
+ * animate-out … duration-200`, so Radix's `Presence` keeps the dialog MOUNTED
+ * through its exit animation — `ActionConfirmDialog` goes on reading
+ * `state.message` into `AlertDialogDescription` and `state.options` into the
+ * title and both button labels for the whole fade-out. Blanking rewrites the
+ * dialog's visible text mid-fade; preserving fades it out intact. The cost of
+ * preserving is a settled promise's `resolve` left reachable in state, which is
+ * inert: the dialog settles it before it ever asks for the close, and the open
+ * path replaces the entire state object, so nothing stale survives a reopen.
+ */
+describe('app-shell — both confirm runtimes reset ActionConfirmDialog the same way on CLOSE (objectui#6034)', () => {
+  it('RecordDetailView: the close flips `open` and keeps every other dialog-read field', async () => {
+    const opened = await confirmViaRecordDetailView(MESSAGE, BAG);
+    expect(opened.open).toBe(true);
+
+    const closed = await closeFromRuntime(opened);
+    expect(closed.open).toBe(false);
+    // By NAME, not by count: a shape that drops keys is red on the key set, and
+    // a shape that blanks `message` is red on the value even if the key stays.
+    expect(Object.keys(closed).sort()).toEqual(DIALOG_READS);
+    expect(closed.message).toBe(MESSAGE);
+    expect(closed.options).toEqual(BAG);
+    expect(typeof closed.resolve).toBe('function');
+  });
+
+  it('useConsoleActionRuntime: the close flips `open` and keeps every other dialog-read field', async () => {
+    const opened = await confirmViaConsoleRuntime(MESSAGE, BAG);
+    expect(opened.open).toBe(true);
+
+    const closed = await closeFromRuntime(opened);
+    expect(closed.open).toBe(false);
+    expect(Object.keys(closed).sort()).toEqual(DIALOG_READS);
+    expect(closed.message).toBe(MESSAGE);
+    expect(closed.options).toEqual(BAG);
+    expect(typeof closed.resolve).toBe('function');
+  });
+
+  it('the two runtimes write the same post-close state, field for field', async () => {
+    const viewClosed = await closeFromRuntime(await confirmViaRecordDetailView(MESSAGE, BAG));
+    cleanup();
+    const hookClosed = await closeFromRuntime(await confirmViaConsoleRuntime(MESSAGE, BAG));
+
+    expect(Object.keys(viewClosed).sort()).toEqual(Object.keys(hookClosed).sort());
+    expect(Object.keys(viewClosed).sort()).toEqual(DIALOG_READS);
+    expect(viewClosed.open).toBe(hookClosed.open);
+    expect(viewClosed.message).toBe(hookClosed.message);
+    expect(viewClosed.options).toEqual(hookClosed.options);
+    expect(typeof viewClosed.resolve).toBe(typeof hookClosed.resolve);
+  });
+
+  it('the close-path fixture is multi-field, so the two reset shapes are distinguishable here', async () => {
+    // Non-degeneracy guard. With an empty or single-field confirm state,
+    // "blanked" and "preserved" produce the SAME object and every assertion
+    // above passes without measuring anything. Applied to THIS fixture, the two
+    // shapes app-shell actually shipped must disagree — on the key set AND on a
+    // value — or the pin above is decorative.
+    const opened = await confirmViaRecordDetailView(MESSAGE, BAG);
+    const blanked: any = { open: false, message: '' };
+    const preserved: any = { ...opened, open: false };
+
+    expect(Object.keys(blanked).sort()).not.toEqual(Object.keys(preserved).sort());
+    expect(blanked).not.toHaveProperty('options');
+    expect(blanked).not.toHaveProperty('resolve');
+    expect(blanked.message).not.toBe(preserved.message);
+    expect(preserved.options).toEqual(BAG);
+
+    // …and the fixture itself is what makes those inequalities real.
+    expect(MESSAGE.length).toBeGreaterThan(0);
+    expect(Object.keys(BAG).length).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
Fixes #6034

`app-shell` mounts two confirm runtimes into one `ActionConfirmDialog`. They agreed on **open** and disagreed on **close**. This converges the close handlers on one reset shape and extends #5835's existing parity pin to cover the close path.

## Census, re-derived on `origin/main` `9602dc820`

|  | open | close |
|---|---|---|
| `packages/app-shell/src/hooks/useConsoleActionRuntime.tsx` | `:193` `setConfirmState({ open: true, message, options, resolve })` | `:696` `setConfirmState({ open: false, message: '' })` — **blanks the whole state** |
| `packages/app-shell/src/views/RecordDetailView.tsx` | `:518` — identical shape | `:2511` `setConfirmState(s => ({ ...s, open: false }))` — **preserves fields** |

Reproduces exactly as filed. #5835's pin covered **open only**.

## Close-path consumer enumeration — every hop, both runtimes

Not inherited; derived here. `confirmState` appears on exactly **four** lines in `packages/*/src` (two `useState` declarations, two `<ActionConfirmDialog state={confirmState}>` reads) and nowhere else, so the consumer chain is short and closed:

- **Hop 1 — the state variable.** Read only by the JSX that mounts the dialog, one per runtime.
- **Hop 2 — `ActionConfirmDialog`** (`views/ActionConfirmDialog.tsx`), one component serving both. It reads `state.open`, `state.message`, `state.options?.title`, `state.options?.confirmText`, `state.options?.cancelText`, `state.resolve`.
- **Hop 3 — Radix.** `state.open` reaches `AlertDialog`; `AlertDialogContent` carries `data-[state=closed]:animate-out … duration-200`, so `Presence` keeps the subtree **mounted through the exit animation** and hop 2 keeps reading for the whole fade-out.

**Mount sites, so the "fix three of four sites" trap can be checked rather than asserted away:** the console runtime's dialog is mounted from four places (`console/ConsoleShell.tsx:83`, `views/ObjectView.tsx:1060`, `views/DeclaredActionsBar.tsx:463`, and `views/PageView.tsx` via `ConsoleActionRuntimeProvider`), plus `RecordDetailView`'s own — five mount sites. None of them touches `confirmState`; each runtime owns its reset in exactly one place, so changing the hook converges four sites at once and the fifth was already the target shape. No third consumer at a second hop.

`plugin-designer/src/hooks/useConfirmDialog.ts` exports a name-colliding `ConfirmDialogState`, but it is an unrelated hook (`isOpen`/`title`/`message`, resolver in a ref) that never feeds `ActionConfirmDialog`. Not a hop.

## Which shape won, and why: **field-preserving**

`useConsoleActionRuntime` now closes with `setConfirmState(s => ({ ...s, open: false }))`, matching `RecordDetailView`.

The decision follows from hop 3. Because Radix holds the content mounted for the ~200 ms fade-out, the state written *on close* is what the user sees *during* the close. Blanking rewrote the dialog's visible text mid-fade — the description emptied, and the title and both button labels reverted from the caller's `options` to their i18n defaults. Preserving fades the dialog out intact. That is the only observable difference in the consumer set, and it points one way.

The cost of preserving is a `resolve` left reachable in state after close. It is **inert**, and provably so from the dialog's own code:

- `ActionConfirmDialog.handleConfirm` / `handleCancel` call `state.resolve?.(…)` **before** `onOpenChange(false)`, so the promise is already settled when the reset runs; a later call on a settled promise is a no-op.
- The **open** path replaces the entire state object (`{ open: true, message, options, resolve }`, `options` present-but-`undefined` at the runner arity), so no stale field can leak into a reopen.

Secondary, same direction: the functional-updater form is also the safer one under a close/reopen race — a whole-object replacement discards whatever a newly-opened confirm has just written, including its `resolve`, which would strand that action's promise forever.

**No close-path consumer depends on the divergent shape**, so nothing needed to be reported and stopped on under that clause, and the divergence is not preserved behind a flag or an option.

## The pin: extended, not duplicated

`packages/app-shell/src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx` gains a second `describe` for the close path. #5835's file keeps ownership of this relationship — a parallel pin would leave two pins that can disagree, which is the same defect class as the two runtimes.

⚠️ **The open-path assertions are controls here, not evidence.** They stay green under either reset shape. What they establish is that both runtimes still reach the dialog at all, which is what makes a difference measured *after* the close attributable to the close handler. Do not read the four green open-path tests as proof that this change is correct.

Against the degenerating-pin trap, the close half:

- opens with a **multi-field** state — `MESSAGE` plus the full `{ title, confirmText, cancelText }` bag — so "blanked" and "preserved" are different objects;
- asserts the surviving fields **by name** (`Object.keys(...)` against the dialog-read list, `message`, `options`, `typeof resolve`), not by count;
- drives the runtime's **own** `onOpenChange` prop, in `ActionConfirmDialog.handleCancel`'s exact order (settle the promise, *then* close), so it pins the runtime's reset rather than the test's idea of it;
- carries a **non-degeneracy test** that applies both shipped shapes to this fixture and asserts they disagree — on the key set *and* on a value. With an empty or single-field state every one of those inequalities collapses, and that test is what fails if a later edit hollows out the fixture.

## Verification

All vitest runs from the repo root with root-relative paths (objectui#3378), under the container's shared heavy-verify lock.

**Red before the fix** — pin written first, source untouched at `9602dc820`. Predicted 6 pass / 2 fail, with the console-runtime close test and the cross-runtime parity test red. Observed exactly that:

```
 × useConsoleActionRuntime: the close flips `open` and keeps every other dialog-read field
 × the two runtimes write the same post-close state, field for field
      Tests  2 failed | 6 passed (8)
AssertionError: expected [ 'message', 'open' ] to deeply equal [ 'message', 'open', 'options', …(1) ]
```

That assertion text is the divergence itself: blanking drops the `options` and `resolve` keys outright.

**Green after** — `Tests 8 passed (8)`.

**Ablation, post-commit** (fix reverted to the blanked shape, restored by hash): mutation confirmed on disk by grepping the injected *and* the removed text (`0` fixed-shape hits, `1` blanked-shape hit) and by `git hash-object` differing from the `HEAD` blob; re-run went `2 failed | 6 passed`; restore under `trap … EXIT INT TERM` with absolute paths, verified by the restored blob hash equalling the `HEAD` blob (`fb54c32240712ba5355384823c96380ae6936fff`) and `git diff HEAD` empty. No `dist` is in this path — the pin imports `../hooks/useConsoleActionRuntime` relatively, so vitest loads the mutated source directly and no rebuild leg applies.

Every reading below is on final head **`1dd499571`**:

| check | verdict line |
|---|---|
| the pin | `Test Files 1 passed (1)` / `Tests 8 passed (8)` |
| both edited files' own suites (5 files) | `Test Files 5 passed (5)` / `Tests 67 passed (67)` |
| all `RecordDetailView.*.test.tsx` (17 files) | `Test Files 17 passed (17)` / `Tests 134 passed (134)` |
| `pnpm --filter @object-ui/app-shell type-check` | exit `0`, script echoed as `tsc --noEmit && tsc -p tsconfig.test.json` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 5313 tracked text file(s))` |
| `check:vi-mock-specifiers` | `✅ check-vi-mock-specifiers: OK` |
| `check:action-forward-parity` | exit `0` |
| `check-changeset-presence.mjs` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |

**Type-check coverage was measured, not assumed.** `tsc -p tsconfig.json --listFiles` contains `useConsoleActionRuntime.tsx` but **not** the `.test.tsx`; `tsc -p tsconfig.test.json --listFiles` contains **both**. The package's `type-check` script runs both programs, so the second half is what puts the edited test file under the compiler. Dependency closure built first (`pnpm --filter '@object-ui/app-shell^...' build`), so `tsc`'s `dist`-resolved workspace deps were current.

**Lint was narrowed to `packages/app-shell`, and the narrowing is measured:** (1) the population comes from eslint's own config — the package has no local `eslint.config.*`, so `eslint .` resolves the root flat config, which is the same invocation `turbo run lint` uses for this package; (2) `--format json` reports **975 files inspected, 0 errors, 2684 pre-existing warnings**, and both edited files are in that population with `errors=0`; (3) `eslint.config.js` declares no `project` / `projectService` / `parserOptions.project`, so type-aware linting is off and a change inside `app-shell` cannot move the verdict on a file in another package. CI runs the full farm regardless.

## Changeset

`.changeset/confirm-runtime-close-parity-6034.md`, `patch` on `@object-ui/app-shell` — a real behaviour change on close, stated in words. Not `major` (fixed group).

## Out of scope, filed

**#6431** — `ActionParamDialog` carries the **same** close divergence between the same two runtimes (`useConsoleActionRuntime.tsx:716` blanks `{ open: false, params: [] }`; `RecordDetailView.tsx:2519` preserves). Deliberately not fixed here: this card's fence is the confirm path, and the param call is not the same mechanical one — `ParamDialogState` carries `params` and in-flight collection state, so blanking on close may be the *deliberate* choice there rather than the mid-fade defect. That needs a ruling. The third dialog in the same pair, `ActionResultDialog`, does **not** diverge (both close with `setResultDialogState({ open: false })`), so the drift is two of three.

## Collision check

`packages/app-shell` is shared, so: this PR touches `src/hooks/useConsoleActionRuntime.tsx` and `src/views/RecordDetailView.confirmRuntimeParity-5835.test.tsx` only. Open draft PR #6283 in the same package is on `src/views/metadata-admin/previews/block-types.ts` — no file-level overlap.

⛔ Left as **draft** for the PM to land — not marked ready, not self-merged, no auto-merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_