### PR TITLE
docs(ci): measure the last lockfile merge-driver row instead of removing it

### DIFF
--- a/.changeset/6391-lockfile-merge-driver-measurement.md
+++ b/.changeset/6391-lockfile-merge-driver-measurement.md
@@ -1,0 +1,29 @@
+---
+---
+
+CI/doc-only: records the measurement of the last remaining "Lockfile Merge Driver" row
+(objectui#6391). No mechanism is added or removed.
+
+`changeset-release.yml` performs no local merge, so the driver it configures cannot fire in
+that job. Swept the whole file with a control term on every zero-hit — no `git merge`,
+`rebase`, `pull`, `cherry-pick`, `am`, `apply` or `revert`; every `git` in it is the two
+`git config` lines, `git status` twice, and the `git checkout -- .` / `git clean` pair that
+undoes the version step, `checkout -- .` being an index-restore rather than a merge. The
+deciding fact is in the marketplace action: read at `changesets/action` v1.9.0 (`a45c4d5`),
+`src/git.ts` and the shipped `dist/` agreeing, its entire git surface is `checkout`,
+`reset --hard`, `add .`, `commit -m`, `push --force` and `config user.*` — the version branch
+is updated by `reset --hard` plus a force-push, and a force-push resolves no merge.
+
+⭐ The `.gitattributes` line is NOT dead, which is why the row was not removed with the other
+two. `CONTRIBUTING.md` has contributors configure the same driver and then `git merge
+upstream/main` — a real local merge on the attributed path. Measured in a scratch repository
+with one variable changed: with the attribute the driver fires and the lockfile is
+regenerated; without it the identical merge ends in `CONFLICT (content)`. The CI half is dead
+and the repository-wide half is live, while `ci-cd-pipeline-doc.test.ts` binds them together,
+so the removal is a decision rather than a cleanup and is escalated instead of guessed.
+
+The row's stated reason ("version bumps rewrite the lockfile") was wrong and is corrected — a
+rewrite is not a merge — and the guide gains the third ⛔ note in the series that already
+records "pushing is not merging" and "a server-side merge is not a local one".
+
+No source and no behaviour change; nothing a consumer installs is affected.

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -518,6 +518,52 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      # ⚠️ MEASURED 2026-08-26 (objectui#6391): this job performs NO local merge,
+      # so the driver configured below has no occasion to fire HERE. The step is
+      # kept anyway — see the ⛔ at the bottom of this comment, which is the part
+      # that matters.
+      #
+      # The sweep, so nobody re-derives it a fourth time (objectui#6358 and
+      # objectui#6369 each re-derived it for a different workflow):
+      #
+      #   Every `git` in this file, enumerated rather than grepped-for-absence:
+      #   the two `git config` lines below, `git status --porcelain` (x2),
+      #   `git checkout -- .` and `git clean -fdq` in "Restore the pre-version
+      #   tree". No `merge`, `rebase`, `pull`, `cherry-pick`, `am`, `apply` or
+      #   `revert` anywhere in the file — each of those zero-hits was taken with
+      #   a control term that DID hit the same file, because a zero-hit with no
+      #   control is not a reading.
+      #
+      #   `git checkout -- .` (below, in the restore step) takes tracked paths
+      #   from the INDEX to undo what `pnpm changeset:version` wrote. That is a
+      #   discard, not a merge; no merge driver participates.
+      #
+      # ⭐ The load-bearing part is not in this file at all — it is what
+      # `changesets/action@v1` does, and it has to be read to be known. Read at
+      # v1.9.0 (`a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d`), `src/git.ts` and the
+      # executed `dist/` bundle agreeing: the action's COMPLETE git surface is
+      # `checkout <branch>` / `checkout -b`, `reset --hard <sha>`, `add .`,
+      # `commit -m`, `push origin HEAD:<branch> --force`, `push origin <tag>`
+      # and `config user.*`. The version-branch update is `prepareBranch`
+      # (checkout, then `reset --hard github.context.sha`) followed by a commit
+      # and a FORCE-PUSH. It never merges, rebases or three-ways anything, so on
+      # this side too the driver has no occasion to fire. (Its `commitMode:
+      # github-api` path — not selected here; the default is `git-cli` — builds
+      # the commit through the GitHub API instead, and the bundle reads no
+      # `.gitattributes` and implements no merge driver at all.)
+      #
+      # ⛔ DO NOT delete this step "because it is dead" without a ruling. It is
+      # dead only in the CI half. The `.gitattributes` line it depends on
+      # (`pnpm-lock.yaml merge=pnpm-merge`) is NOT dead: `CONTRIBUTING.md` tells
+      # contributors to configure this same driver locally and then to
+      # `git merge upstream/main`, which is a real local merge on the attributed
+      # path. Measured both ways in a scratch repo: with the attribute the driver
+      # fires and the lockfile is regenerated; with the attribute removed and
+      # nothing else changed, the same merge ends in `CONFLICT (content)` with
+      # conflict markers in `pnpm-lock.yaml`. Removing the CI half forces
+      # `ci-cd-pipeline-doc.test.ts` to demand the attribute's removal too, which
+      # would break that live contributor path — so the two must be decided
+      # together, not dropped as one more dead row. objectui#6391 carries it.
       - name: Configure Git merge driver for pnpm-lock.yaml
         run: |
           # Configure custom merge driver for pnpm-lock.yaml

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1699,7 +1699,35 @@ One workflow carries that step:
 
 | Workflow | Why it needs the driver |
 |---|---|
-| `changeset-release.yml` | version bumps rewrite the lockfile on the release branch |
+| `changeset-release.yml` | ⚠️ configures it — but performs no local merge, see the measurement below |
+
+⚠️ **That row's stated reason was wrong, and the row is now the whole question**
+([#6391](https://github.com/objectstack-ai/objectui/issues/6391)). It used to read "version bumps
+rewrite the lockfile on the release branch". A **rewrite is not a merge**: `changeset:version`
+overwrites `pnpm-lock.yaml` outright, and git runs a merge driver only when it has to *reconcile
+two versions* of an attributed path. Measured on `changeset-release.yml`, and recorded in the file
+itself so it is not re-derived a fourth time:
+
+- Every `git` in that workflow, enumerated rather than grepped for absence: the two `git config`
+  lines, `git status --porcelain` twice, and `git checkout -- .` plus `git clean -fdq` in "Restore
+  the pre-version tree". No `merge`, `rebase`, `pull`, `cherry-pick`, `am`, `apply` or `revert` —
+  every zero-hit taken with a control term that hit the same file.
+- `git checkout -- .` there takes tracked paths from the **index** to undo what the version step
+  wrote. That is a discard, not a merge.
+- The deciding fact is in the marketplace action, not the workflow. Read at `changesets/action`
+  v1.9.0 (`a45c4d5`), `src/git.ts` and the shipped `dist/` bundle agreeing: its entire git surface
+  is `checkout`, `reset --hard`, `add .`, `commit -m`, `push --force` and `config user.*`. The
+  version-branch update is a checkout, a `reset --hard` to the triggering commit, a commit, and a
+  **force-push**. A force-push resolves no merge, so the driver has no occasion to fire.
+
+⭐ **But the `.gitattributes` line is not dead, and that is why this is not simply a third
+removal.** The attribute is repository-wide, and its live consumer is the contributor path this
+page already points at: `CONTRIBUTING.md` tells contributors to configure this same driver and
+then to `git merge upstream/main`. Measured in a scratch repository, one variable changed between
+the two runs — **with** the attribute the driver fires and the lockfile is regenerated; **without**
+it, and nothing else altered, the identical merge ends in `CONFLICT (content)` with conflict
+markers left in `pnpm-lock.yaml`. So the CI half is dead and the repository half is live, while the
+pin below binds them together. Resolving that is a decision, not a cleanup.
 
 `scripts/__tests__/ci-cd-pipeline-doc.test.ts` pins that table against the workflows that
 actually configure `merge.pnpm-merge`, in both directions. It is pinned because the claim had
@@ -1728,6 +1756,12 @@ needs no driver, and giving it one buys nothing while implying a lockfile hazard
 [#6369](https://github.com/objectstack-ai/objectui/issues/6369) for a merge it genuinely performs
 — `gh pr merge`. But GitHub executes that one itself, not on the runner, so no local git config
 takes part in it.
+
+⛔ **A rewrite is not a merge, and a force-push resolves none.** `changeset-release.yml` carries
+the step on the strength of "version bumps rewrite the lockfile"
+([#6391](https://github.com/objectstack-ai/objectui/issues/6391)). Regenerating a file is not
+reconciling two versions of it, and the version branch is updated by `reset --hard` plus a
+force-push inside `changesets/action`, which merges nothing on the runner.
 
 ## Adding a New Workflow
 


### PR DESCRIPTION
Part of #6391

⭐ **The falsification attempt succeeded on the workflow and FAILED on the `.gitattributes` line, so this PR records the measurement instead of shipping the removal.** The card asked for a four-part removal; the fourth part turns out to be live, and the doc pin binds all four together. That makes the removal a decision, not a cleanup, and it is escalated rather than guessed at.

⚠️ **Framing:** this is **not** a gate weakening and **not** a mechanism removal — nothing is deleted here. It is the measurement the card asked for, written into the files so it is not re-derived a fourth time.

## Step 1 — the sweep of `changeset-release.yml`

Every `git` in the file, enumerated rather than grepped for absence: the two `git config` lines, `git status --porcelain` twice, and `git checkout -- .` + `git clean -fdq` in "Restore the pre-version tree".

Merge family, **with a control term on every zero-hit** (a zero-hit with no control is not a reading):

| term | hits | control | control hits |
|:--|--:|:--|--:|
| `rebase` | 0 | `base` | 2 |
| `cherry-pick` | 0 | `pick` | 4 |
| `apply` | 0 | `app` | 8 |
| `revert` | 0 | `rev` | 5 |
| `git am` | 0 | `git ` | 10 |

`merge` itself hits 28 times: 26 are prose about the **version-PR merge** (a human/server-side act) and the remaining 2 are the driver configuration.

Confirmed rather than assumed, both as the card asked:
- **`git checkout -- .` (~:1018) is not a merge.** It sits in "Restore the pre-version tree" and takes tracked paths from the **index** to undo what `pnpm changeset:version` wrote. A discard.
- **`git config` (~:525–526) is the configuration itself**, not an invocation.
- There is no `pull_request` trigger, so `actions/checkout@v7` never checks out a GitHub-computed merge ref either.

## ⭐ Step 2 — reading `changesets/action@v1` itself

The load-bearing question, unanswerable from the workflow. Read at the tag the workflow pins, which currently resolves to **v1.9.0 (`a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d`)**, with `src/git.ts` and the executed `dist/` bundle agreeing line for line.

The action's **complete** git surface (uppercase words are placeholders — GitHub's body sanitizer eats angle-bracket ones, even inside a fence):

```
git checkout BRANCH   /   git checkout -b BRANCH
git reset --hard SHA
git add .
git commit -m MESSAGE
git push origin HEAD:BRANCH --force
git push origin TAG
git config user.name / user.email
```

The version-branch update is `prepareBranch` — checkout, then **`git reset --hard github.context.sha`** — followed by `commitAll` and a **force-push**. It never merges, rebases or three-ways anything. **A force-push resolves no merge, so the driver has no occasion to fire.** Zero merge-family verbs across `src/` and `dist/`, again with hitting controls (`push`, `checkout`, `reset`, `commit`, `status`).

Its alternative `commitMode: github-api` path is **not** selected here (default is `git-cli`); it builds the commit through the GitHub API, and the bundle reads no `.gitattributes` and implements no merge driver at all.

**So rows 1–3 of the card are confirmed: the CI half of this mechanism is dead.**

## ⛔ Why the removal did not ship: the `.gitattributes` line is live

The card treats `pnpm-lock.yaml merge=pnpm-merge` as the last piece of a mechanism nothing exercises. It is not. The attribute is **repository-wide**, and its live consumer is the contributor path **this very guide section already points at**: `CONTRIBUTING.md` → *Configure Git Merge Driver for pnpm-lock.yaml* tells contributors to set the same driver, and then to `git merge upstream/main` — a real local merge on the attributed path.

Measured in a scratch repository, one variable changed between two otherwise identical runs:

| `.gitattributes` | result of the same conflicting local merge |
|:--|:--|
| **with** `pnpm-lock.yaml merge=pnpm-merge` | driver **fires**, lockfile regenerated, merge succeeds |
| **without** it | `CONFLICT (content)`, conflict markers left in `pnpm-lock.yaml` |

Deleting the attribute would not retire dead configuration — it would convert a clean auto-resolve into a hand-resolved lockfile conflict for every contributor who followed `CONTRIBUTING.md`. A hand-edited `pnpm-lock.yaml` is a high-blast-radius artifact.

The pins force the two halves together: dropping the CI config makes `ci-cd-pipeline-doc.test.ts` demand the attribute's removal in its own failure message. So **the CI half is dead and the repository-wide half is live, and the pin cannot express that.** Resolving it needs a ruling — see the report on #6391.

## What the table is down to

**One row**, `changeset-release.yml` — after the two removals that landed as #6367 (from #6358) and #6389 (from #6369). That row survives here, but its stated reason was **wrong** and is corrected: it read *"version bumps rewrite the lockfile on the release branch"*, and **a rewrite is not a merge**. The guide gains the third ⛔ note in the existing series (*"pushing is not merging"*, *"a server-side merge is not a local one"*, and now *"a rewrite is not a merge, and a force-push resolves none"*).

## Changes

1. `.github/workflows/changeset-release.yml` — the measurement recorded beside the step, including the ⛔ note that it must not be deleted on "it is dead" grounds without the attribute question being settled. **The config is unchanged.**
2. `content/docs/guide/ci-cd-pipeline.md` — row reason corrected, the measurement and the contributor-path finding recorded, third ⛔ note added.
3. Changeset with empty frontmatter (CI/doc-only; nothing published).

Untouched, deliberately: `.gitattributes`, `CONTRIBUTING.md`, `scripts/__tests__/ci-cd-pipeline-doc.test.ts`, and `dependabot-auto-merge.yml` (#6392 landed its own PR #6423).

## Verification

Run on the final commit `e5ad9e9d8`:

- `pnpm exec vitest run scripts/__tests__` — the **whole** tree as required, not a subset: **81 files, 2317 tests passed**.
- `scripts/__tests__/ci-cd-pipeline-doc.test.ts` isolated — 34 passed, both directions of the pin and the `.gitattributes` assertion green.
- `pnpm check:control-bytes` — OK (5320 files) · `pnpm check:pre-install-import-graph` — OK (this gate reads `changeset-release.yml`, so the added comment block is directly implicated; the install boundary is unmoved) · `pnpm docs:check-links` — valid across 17 scan roots.

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_