### PR TITLE
Base the worktree recipe on a fetched origin/main

### DIFF
--- a/.changeset/6208-worktree-recipe-fetch-base.md
+++ b/.changeset/6208-worktree-recipe-fetch-base.md
@@ -1,0 +1,25 @@
+---
+---
+
+Instruction-file and PreToolUse-hook prose only: no published package's `src/` changed, so
+nothing ships.
+
+The documented worktree recipe branched off the **local** `main` ref, which nothing in the
+recipe or its surrounding prose fetches. A worktree created by following it literally starts
+as far back as whoever last happened to update that ref — and on a long-lived shared
+checkout, nobody has a reason to. `origin/main` alone would carry the same defect one layer
+down (it too is a local ref only a fetch moves), so each in-scope site now begins with an
+explicit `git fetch origin main &&` and names `origin/main` as the base:
+
+```
+git fetch origin main && git worktree add ../<repo>-<task> -b <branch> origin/main && cd ../<repo>-<task> && pnpm install
+```
+
+Four sites repaired — `CLAUDE.md`, `AGENTS.md` §9 多 agent 协作纪律, and the recipe both
+worktree guards print when they block an edit (`.claude/hooks/guard-main-checkout.sh`,
+`.claude/hooks/guard-main-checkout-bash.sh`), which is the copy an agent is most likely to
+run verbatim. The two `-cmp` comparison-tree lines are unchanged: they take an explicit ref
+from the caller and are correct as written.
+
+Ports the repair landed upstream in objectstack#11934 (objectstack#11540); this repo's copy
+was deliberately left to this card. Net ±0 lines on every file touched.

--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -541,7 +541,7 @@ only, so the identical edit expressed as a shell command used to slip through in
 its HEAD switched and its tree reset under you, clobbering uncommitted work. A feature
 branch on the shared checkout is NOT enough; you need a dedicated worktree:
 
-  git worktree add ../${name}-<task> -b <branch> main
+  git fetch origin main && git worktree add ../${name}-<task> -b <branch> origin/main
   cd ../${name}-<task> && pnpm install    # then re-run the command there
 
 Always fine, no flag needed:

--- a/.claude/hooks/guard-main-checkout.sh
+++ b/.claude/hooks/guard-main-checkout.sh
@@ -54,7 +54,7 @@ This repo is edited by multiple agents at once — the shared checkout gets its 
 switched and tree reset under you, silently clobbering uncommitted work. A feature
 branch on the shared checkout is NOT enough; you must be in a dedicated worktree:
 
-  git worktree add ../${name}-<task> -b <branch> main
+  git fetch origin main && git worktree add ../${name}-<task> -b <branch> origin/main
   cd ../${name}-<task> && pnpm install    # then re-run your edits there
 
 This guard checks the edited file's OWN repo, so sibling repos are covered too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ AGENTS.md 的「只跑受影响的包」指的是**用上面的路径过滤缩�
 本仓库有**多个 agent 并行**修改 —— 分支会被切换、共享文件会在你工作时被改动(正常现象,不是 bug):
 
 - **只改你任务需要的文件**;别去"修"无关的 diff、回退或别人的在途编辑,也别管整棵工作树。
-- **必须一个任务一个 git worktree**(`git worktree add ../objectui-<task> -b <branch> main`,新树里跑 `pnpm install`)做物理隔离 —— 这是强制而非「首选」。共享的 `main` checkout **不是**可用退路:HEAD 会被别的 agent 切换、你刚写的文件会在操作中途被 reset 掉。一个 **PreToolUse 钩子**(`.claude/hooks/guard-main-checkout.sh`)**强制**此规则:除非被编辑文件位于专属 **worktree** 否则拦截 `Edit`/`Write`/`NotebookEdit`——在共享 checkout 上开 feature 分支**也不行**(仍会被切走),且按**被编辑文件所属的仓库**判断(sibling 仓 `framework`/`cloud` 一并守住)(确属非任务的临时改动用 `OS_ALLOW_MAIN_EDITS=1` 放行)。即便在自己的 worktree 里,下面这些防御性条款仍然适用。
+- **必须一个任务一个 git worktree**(`git fetch origin main && git worktree add ../objectui-<task> -b <branch> origin/main`,新树里跑 `pnpm install`)做物理隔离 —— 这是强制而非「首选」。共享的 `main` checkout **不是**可用退路:HEAD 会被别的 agent 切换、你刚写的文件会在操作中途被 reset 掉。一个 **PreToolUse 钩子**(`.claude/hooks/guard-main-checkout.sh`)**强制**此规则:除非被编辑文件位于专属 **worktree** 否则拦截 `Edit`/`Write`/`NotebookEdit`——在共享 checkout 上开 feature 分支**也不行**(仍会被切走),且按**被编辑文件所属的仓库**判断(sibling 仓 `framework`/`cloud` 一并守住)(确属非任务的临时改动用 `OS_ALLOW_MAIN_EDITS=1` 放行)。即便在自己的 worktree 里,下面这些防御性条款仍然适用。
 - **绝不 `git stash` —— stash 栈不在上一条的 worktree 隔离范围内。** `git stash` 把栈存在**共享 `.git` 目录**里的 `refs/stash`,**每个 worktree 共用同一个 LIFO 栈**:上一条的物理隔离**不覆盖它**。两个 agent 各自在自己的 worktree 里 stash,push/pop 的是同一个栈 —— 你的 `pop` 取回的是对方刚压进去的改动,你自己的改动留在栈上等着被对方取走;而 `pop` **报成功**,唯一的症状是别人的文件出现在你的 `git status` 里,随后一次 `git add -A` 就把对方的在途工作合进了你的 PR。不是假想:objectui#3430 两个并行 agent 在反向验证中间踩实,双方在途改动都丢了(只能作为 unreachable commit 捞回)。替代做法只有下面这些 —— 都不碰共享状态,都在你自己的 worktree 内,且**首选先 commit 再还原**(上面反向验证那条已把它定为标准写法):
 
   ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ shared checkout is NOT enough** — it still gets switched under you. You MUST b
 **dedicated per-task worktree**:
 
 ```
-git worktree add ../<repo>-<task> -b <branch> main && cd ../<repo>-<task> && pnpm install
+git fetch origin main && git worktree add ../<repo>-<task> -b <branch> origin/main && cd ../<repo>-<task> && pnpm install
 ```
 
 Make all edits there, **one worktree per repo** a task spans. A PreToolUse hook


### PR DESCRIPTION
Fixes #6208

Ports the repair landed upstream in objectstack#11934 (objectstack#11540), whose body notes this repo's copy was **deliberately left** to this card.

## The defect

The documented worktree recipe branched off the **local** `main` ref, which nothing in the recipe or its surrounding prose fetches. A worktree created by following it literally starts as far back as whoever last happened to update that ref — and on a long-lived shared checkout, nobody has a reason to.

## Drift re-measured on THIS repo, not relayed

Measured on this repo's live shared checkout (`/home/user/objectui`) at claim time. The upstream card's numbers are its own snapshot of a different repo; these are this one's.

```
$ git -C /home/user/objectui rev-parse --short main origin/main
60d452ee0
c8ea8af9c
$ git -C /home/user/objectui log -1 --format='%ci' main
2026-08-21 03:27:52 +0000
$ git -C /home/user/objectui log -1 --format='%ci' origin/main
2026-08-26 00:13:35 +0000
$ git -C /home/user/objectui rev-list --count main..origin/main
473
$ git -C /home/user/objectui rev-list --count origin/main..main
0
```

| reading | value |
|---|---|
| local `main` | `60d452ee0` · 2026-08-21T03:27:52Z |
| `origin/main` | `c8ea8af9c` · 2026-08-26T00:13:35Z |
| local `main` behind `origin/main` | **473 commits** |
| age gap | **116.8 hours** (4.9 days) |

The second `rev-list` is the positive control: `0` in the other direction, so this is a strict lag, not a divergence.

It is not an abstract lag for this PR in particular. Across that same range:

```
$ git -C /home/user/objectui diff --numstat main...origin/main -- AGENTS.md CLAUDE.md
109	1	AGENTS.md
```

Following the old recipe to fix the old recipe would have based this branch on a copy of `AGENTS.md` that is 109 lines out of date.

`origin/main` alone would have the same defect one layer down — it is a local ref only a fetch moves — so each fixed site begins with an explicit `git fetch origin main &&`. Measured here: that fetch moved `origin/main` **0 commits**, because another agent had fetched ten minutes earlier. Luck, not a guarantee, which is the point.

## Sites enumerated and judged one by one

Enumerated independently (`git grep -n 'worktree add' origin/main`, plus a wider `worktree` sweep across the repo) rather than inherited from the card:

| site | verdict | why |
|---|---|---|
| `CLAUDE.md:16` | **in** | bare `main` base — the site the card named |
| `AGENTS.md:234` (§9 多 agent 协作纪律) | **in** | bare `main` base, inside the fuller Chinese statement of the rule |
| `.claude/hooks/guard-main-checkout.sh:57` | **in** | ⭐ the recipe the guard **prints when it blocks an edit** — same bare `main` base. Not named by the card. This is the copy an agent is most likely to run verbatim, because it arrives at the exact moment the agent needs it |
| `.claude/hooks/guard-main-checkout-bash.sh:544` | **in** | ⭐ same recipe, same defect, in the Bash-side guard's block message |
| `CLAUDE.md:40` | **out** | the `-cmp` comparison-tree line takes an explicit `<ref>` from the caller — correct as written |
| `AGENTS.md:240` | **out** | same |
| `.claude/hooks/guard-main-checkout-bash.selftest.sh:40` | **out** | test scaffolding: `git worktree add -q "$WT" -b selftest-wt` inside a throwaway temp repo. Not a recipe anyone follows, and it has no shared checkout to be stale against |
| `content/docs/guide/ci-cd-pipeline.md:1592` | **out** | prose that mentions the worktree-first rule; carries no recipe |
| `scripts/pm/check-half-states.mjs:1494` | **out** | a comment reading "fixed at `git worktree add` time"; not a recipe |

After the change, `grep -rn 'worktree add' --include='*.md' --include='*.sh' | grep -v origin/main` returns exactly the three **out** sites and nothing else.

## What the upstream template did differently, and why

- **Site set.** objectstack#11934's three in-scope sites were all prose (`AGENTS.md:173`, `AGENTS.md:203`, `CLAUDE.md:33`); one of them had **no base ref at all**, which this repo has no equivalent of. Its `.claude/` guards do not print the recipe in their block message, so it had no hook sites to judge. This repo's two guards do, so two sites are in here that had no counterpart upstream.
- **Second half not ported.** #11934 also taught `scripts/pm/dispatch-gates.mjs` to announce a stale tree. That file does not exist in this repo (`scripts/pm/` here holds only `check-half-states.mjs`), so there is nothing to port; the recipe half is the whole of this card.
- **Line-budget fence.** Upstream both files sat at shrink-only ratchet ceilings with zero headroom and the repair had to be paid by reflowing a paragraph. This repo has **no line ratchet on `AGENTS.md` / `CLAUDE.md`** — no `CEILINGS` map covers them and no workflow measures their length. Checked rather than assumed. The repair was still spliced in place: **net ±0 lines on all four files** (`CLAUDE.md` 51, `AGENTS.md` 448, `guard-main-checkout.sh` 64, `guard-main-checkout-bash.sh` 561 — identical before and after).

## The shape now landed

```
git fetch origin main && git worktree add ../<repo>-<task> -b <branch> origin/main && cd ../<repo>-<task> && pnpm install
```

## Gates — all run at `3e77bb6c3`, the final commit

The whole `scripts/__tests__` tree, not a subject-matter subset:

```
$ pnpm exec vitest run --project unit --maxWorkers=2 scripts/__tests__
 Test Files  81 passed (81)
      Tests  2318 passed (2318)
VITEST_EXIT=0
```

(That run prints a `check-vi-mock-specifiers: the population COLLAPSED` banner on stderr. It is a deliberate fixture — `scripts/__tests__/check-vi-mock-specifiers.test.ts:371` asserts the gate emits exactly that text when fed an empty tree — not a failure.)

Every gate family the changed paths (`AGENTS.md`, `CLAUDE.md`, `.claude/hooks/*.sh`, `.changeset/*.md`) trigger, derived from this repo's own `package.json` and `.github/workflows/`, quoting each gate's own verdict line:

```
check:control-bytes          ✅  check-control-bytes: OK (scanned 5327 tracked text file(s); skipped 85 binary).
check:shell-escape-residue   ✅  check-shell-escape-residue: OK (4/4 root(s) resolved -- AGENTS.md: 1 file(s), 13 fence(s); CLAUDE.md: 1 file(s), 2 fence(s); …)
check:doc-fences             ✅  check:doc-fences — every TypeScript block in 223 document(s) is fenced ts/tsx/typescript …
check:skills-paths           ✅  check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined).
check-changeset-no-major     ✅  No changeset declares a `major` bump.
check-changeset-presence     ✅  No source of a released package changed in this range, so no changeset is owed.
docs:check-links             Links are valid across 17 scan roots.
guard-main-checkout-bash.selftest.sh   121 passed, 0 failed
guard-shared-stash.selftest.sh          41 passed, 0 failed
```

Both hook self-tests are re-run because `.claude/hooks/*.sh` changed; `.github/workflows/hook-selftests.yml` runs them in CI. Note `guard-main-checkout.sh` has **no** self-test of its own — its edited line is a message string, unpinned by any gate here.

Changeset added with empty frontmatter (`.changeset/6208-worktree-recipe-fetch-base.md`): instruction-file and hook prose only, no published package's `src/` changed, so nothing ships. This repo has no `skip-changeset` label; the empty-frontmatter changeset is how that is declared here.

## Governance

⛔ Governed surface (`CLAUDE.md`, `AGENTS.md`, `.claude/**`). This PR stays **draft** — not flipped ready, not armed, not queued. `update_pull_request` was deliberately not called: that endpoint sends `draft: false` alongside a reviewers-only update and published a governed-surface draft into the merge queue earlier today (PR #6183, recorded as objectstack#12200 and decision card #6325). No reviewer was requested through the API for the same reason.

Review requested from @os-zhuang by mention — a mention notifies without touching draft state. The hand-merge is the review record.

## One declared deviation

The dispatch order said to create the worktree with the recipe **as written** (`… -b <branch> main`). It was created off a freshly fetched `origin/main` instead, and this is flagged rather than done quietly: the measurement above put local `main` 473 commits behind with `AGENTS.md` itself 109 lines out of date, so following the defective recipe would have written this repair on top of a stale copy of the very file it repairs. Base commit: `c8ea8af9c`, which is `origin/main` at claim time.

_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012CZgmFFzqA9cX8tBMhvpFe)_