### PR TITLE
fix(plugin-detail): declare `code` optional in isConcurrentUpdateError's narrowed type

### DIFF
--- a/.changeset/6421-concurrent-update-code-optional.md
+++ b/.changeset/6421-concurrent-update-code-optional.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`isConcurrentUpdateError` no longer promises a `code` its runtime check
+knowingly accepts values without.
+
+The exported predicate matches on two limbs — `code === 'CONCURRENT_UPDATE'`
+(the wire shape) **or** `name === 'ConcurrentUpdateError'` (the deliberate
+cross-realm discriminator, for a host that bundles the adapter twice so
+`instanceof` fails). Its narrowed type declared `code: 'CONCURRENT_UPDATE'` as
+a **required** literal, so for exactly the case the second limb exists to serve
+the predicate handed the caller a property the value does not have. `code` is
+now declared optional (`code?: 'CONCURRENT_UPDATE'`), stating only what both
+limbs guarantee.
+
+**Type-level only; zero runtime change.** The two-limb check is byte-identical
+— it is deliberate and documented, and the diff touches nothing but the return
+type and the comment above it. There was no runtime symptom to fix: the only
+consumer (`InlineEditSaveBar`'s conflict builder) reads just the optional
+`currentVersion` / `currentRecord` fields.
+
+**Breaking for TypeScript consumers that read the narrowed `code`.** After
+narrowing, `err.code` is now `'CONCURRENT_UPDATE' | undefined` instead of
+`'CONCURRENT_UPDATE'`, so code that assigned it to a non-optional `string` will
+newly fail to compile. That failure is the point: on a name-only error the
+value was already `undefined` at runtime, and the old declaration was the
+reason the compiler could not say so. Guard the read (`err.code ===
+'CONCURRENT_UPDATE'` still narrows fine) or branch on the predicate itself
+rather than on the field.
+
+Pinned by `ConcurrentUpdateDialog.narrowedCode-6421.test.tsx`, which asserts
+the invariant by assignability — the value the runtime accepts through the
+`name` limb must be assignable to the type the predicate returns — alongside
+runtime coverage of both limbs, which `plugin-detail` had none of.

--- a/packages/plugin-detail/src/ConcurrentUpdateDialog.tsx
+++ b/packages/plugin-detail/src/ConcurrentUpdateDialog.tsx
@@ -219,9 +219,25 @@ export default ConcurrentUpdateDialog;
  * raise the same kind of error) while still recognising the canonical
  * shape: `code === 'CONCURRENT_UPDATE'` carrying optional
  * `currentVersion` / `currentRecord` fields.
+ *
+ * The second limb — `name === 'ConcurrentUpdateError'` — is the deliberate
+ * cross-realm discriminator, and it stays: a host that bundles the adapter
+ * twice makes `instanceof` fail, leaving the class name as the only thing
+ * left to match on. The rationale is recorded above `isConcurrentUpdateError`
+ * in `packages/data-objectstack/src/index.ts` and, in full, above
+ * `isViewConfigPermissionDeniedError` in the same file.
+ *
+ * That limb is also why `code` is declared OPTIONAL below (objectui#6421). An
+ * error matched by `name` alone carries no `code` at all, so promising
+ * `code: 'CONCURRENT_UPDATE'` as a REQUIRED literal handed the caller a
+ * property the value does not have: `err.code === 'CONCURRENT_UPDATE'` would
+ * type-check and be `undefined` at runtime, with no compiler help. Declared =
+ * enforced — the narrowed type states only what BOTH limbs guarantee, which
+ * is the two optional payload fields its one consumer already reads. Pinned
+ * by `__tests__/ConcurrentUpdateDialog.narrowedCode-6421.test.tsx`.
  */
 export function isConcurrentUpdateError(err: unknown): err is {
-  code: 'CONCURRENT_UPDATE';
+  code?: 'CONCURRENT_UPDATE';
   currentVersion?: string;
   currentRecord?: Record<string, unknown> | null;
   message?: string;

--- a/packages/plugin-detail/src/__tests__/ConcurrentUpdateDialog.narrowedCode-6421.test.tsx
+++ b/packages/plugin-detail/src/__tests__/ConcurrentUpdateDialog.narrowedCode-6421.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `isConcurrentUpdateError` — declared = enforced inside the type predicate
+ * (objectui#6421).
+ *
+ * The runtime check has TWO limbs and KEEPS them: `code === 'CONCURRENT_UPDATE'`
+ * (the wire shape) OR `name === 'ConcurrentUpdateError'` (the deliberate
+ * cross-realm discriminator, for a host that bundles the adapter twice so
+ * `instanceof` fails). The narrowed TYPE used to declare `code:
+ * 'CONCURRENT_UPDATE'` as a REQUIRED literal — a property the second limb
+ * knowingly accepts values without. Nothing read it, so there was no runtime
+ * symptom: the sole consumer, `InlineEditSaveBar`'s `buildConflict`, takes
+ * `err: any` and reads only `currentVersion` / `currentRecord`. The next
+ * caller to write `err.code === 'CONCURRENT_UPDATE'` would have got a silent
+ * `undefined` with the compiler agreeing it could not happen.
+ *
+ * WHAT EACH PIN BELOW IS FOR. The two kinds are labelled, because a pin that
+ * passes against `origin/main` too proves nothing about this change:
+ *
+ *  - DISAGREES — red before this change, green after. These are the pins that
+ *    measure the fix, and all of them sit on the one shape where the old and
+ *    new types differ: an error with `name` set and NO `code`.
+ *  - CONTROL — passes both ways ON PURPOSE. Each names the future wrong shape
+ *    it exists to catch, and together they stop the DISAGREES pins from
+ *    passing vacuously: a predicate that stopped being exported, stopped
+ *    narrowing, or widened `code` to `string` would all satisfy "`code` is
+ *    optional" while destroying the contract.
+ *
+ * The compile-time half is ERASED at runtime — vitest proves nothing about it.
+ * `tsc -p packages/plugin-detail/tsconfig.test.json`, chained off this
+ * package's `type-check` script, is the only thing that checks it, and it
+ * reads `../ConcurrentUpdateDialog` as SOURCE (a relative import), never
+ * through a built `dist/*.d.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isConcurrentUpdateError } from '../ConcurrentUpdateDialog';
+
+/* -------------------------------------------------------------------------- */
+/* The witness                                                                 */
+/*                                                                             */
+/* Exactly what the `name` limb accepts and the old narrowed type refused: a   */
+/* cross-realm error object carrying NO `code` at all. Two deliberate choices: */
+/*                                                                             */
+/*  - A named interface, NOT an inline object literal. Excess-property         */
+/*    checking fires only on FRESH literals, so a literal would have gone red  */
+/*    in BOTH directions (on `name`, which is on neither version of the        */
+/*    narrowed type) and measured nothing about `code`. Declared this way the  */
+/*    pins below bite by ASSIGNABILITY, which is the relation that actually    */
+/*    changed.                                                                 */
+/*  - `message: string` is load-bearing, not decoration. The new narrowed type */
+/*    has only optional properties, i.e. it is a "weak type"; TypeScript       */
+/*    rejects a source that shares NO property name with a weak type. `message`*/
+/*    is the shared name that keeps the assignability pin a real measurement   */
+/*    of `code` rather than an accident of weak-type detection.                */
+/* -------------------------------------------------------------------------- */
+
+interface NameOnlyConcurrentUpdateError {
+  name: 'ConcurrentUpdateError';
+  message: string;
+}
+
+const nameOnly: NameOnlyConcurrentUpdateError = {
+  name: 'ConcurrentUpdateError',
+  message: 'record changed underneath',
+};
+
+describe('isConcurrentUpdateError: both runtime limbs stay', () => {
+  // CONTROL (passes both ways) — the predicate is live at RUNTIME and the
+  // two-limb check is intact. Guards the "simplification" that drops the
+  // `name` limb, which is the very thing the optional `code` describes.
+  it('accepts the wire shape', () => {
+    expect(isConcurrentUpdateError({ code: 'CONCURRENT_UPDATE' })).toBe(true);
+  });
+
+  it('accepts a name-only error — the limb that carries no `code`', () => {
+    expect(isConcurrentUpdateError(nameOnly)).toBe(true);
+    // The witness really is code-less; the type pins below describe THIS value.
+    expect((nameOnly as { code?: unknown }).code).toBeUndefined();
+  });
+
+  it('rejects everything else', () => {
+    expect(isConcurrentUpdateError(new Error('boom'))).toBe(false);
+    expect(isConcurrentUpdateError({ code: 'NOT_FOUND' })).toBe(false);
+    expect(isConcurrentUpdateError({ name: 'ValidationError' })).toBe(false);
+    expect(isConcurrentUpdateError({ httpStatus: 409 })).toBe(false);
+    expect(isConcurrentUpdateError(null)).toBe(false);
+    expect(isConcurrentUpdateError('CONCURRENT_UPDATE')).toBe(false);
+  });
+});
+
+describe('the narrowed type promises only what BOTH limbs guarantee', () => {
+  it('narrows a name-only error, and `code` reads back as possibly-absent', () => {
+    const err: unknown = nameOnly;
+    if (!isConcurrentUpdateError(err)) {
+      // CONTROL — if the `name` limb ever stops accepting a code-less error,
+      // every compile-time pin in this file becomes a statement about an
+      // unreachable branch. Fail loudly rather than pass vacuously.
+      throw new Error('the `name` limb no longer accepts a code-less error');
+    }
+    // DISAGREES — a `typeof` query reads the DECLARED type of the symbol, so
+    // `code` is captured through a const rather than as `typeof err.code`
+    // (which does not see control-flow narrowing). `'CONCURRENT_UPDATE'` under
+    // the old required declaration; `'CONCURRENT_UPDATE' | undefined` now.
+    const code = err.code;
+    type _CodeReadsAsMaybeUndefined = Assert<
+      Equal<typeof code, 'CONCURRENT_UPDATE' | undefined>
+    >;
+    // ...and the runtime agrees with what the type now admits.
+    expect(code).toBeUndefined();
+    expect(err.currentVersion).toBeUndefined();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins                                                           */
+/*                                                                             */
+/* Erased at runtime; checked only by `tsc -p tsconfig.test.json`, which this  */
+/* package's `type-check` script runs after `tsc --noEmit`. `Assert<false>` is */
+/* a TS2344 "does not satisfy the constraint 'true'" error, so a false verdict */
+/* is a red build, not a skipped assertion.                                    */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Extends<A, B> = [A] extends [B] ? true : false;
+type IsNever<T> = [T] extends [never] ? true : false;
+
+/**
+ * The type a `x is T` predicate narrows to — `never` when the function is not
+ * a type predicate at all. That collapse is what lets the liveness control
+ * below tell "narrows to an optional-`code` object" apart from "stopped
+ * narrowing", since `never` is assignable to everything and would satisfy
+ * every other pin here silently.
+ */
+type NarrowedBy<F> = F extends (arg: unknown) => arg is infer N ? N : never;
+type Narrowed = NarrowedBy<typeof isConcurrentUpdateError>;
+
+// CONTROL (passes both ways) — the import above still resolves to a live,
+// exported TYPE PREDICATE over `unknown`. Guards a future change to a bare
+// `boolean` return (like `plugin-form`'s copy) or to a different parameter
+// type: either collapses `Narrowed` to `never` and turns this line red.
+type _PredicateStillNarrows = Assert<Equal<IsNever<Narrowed>, false>>;
+
+// CONTROL (passes both ways) — `code`, when present, is still the exact wire
+// literal. Guards the WRONG way to make this type honest: widening it to
+// `code?: string`, which satisfies "optional" while throwing the
+// discriminator away.
+type _CodeIsStillTheWireLiteral = Assert<
+  Equal<NonNullable<Narrowed['code']>, 'CONCURRENT_UPDATE'>
+>;
+
+// CONTROL (passes both ways) — the two payload fields the only consumer
+// actually reads are still on the narrowed type and still optional. Guards a
+// future "tidy-up" that trims the narrowed type down to `code` alone.
+type _PayloadFieldsSurvive = Assert<
+  Equal<Narrowed['currentVersion'], string | undefined>
+>;
+
+// DISAGREES — `code` is an OPTIONAL property: the narrowed type still accepts
+// a value with that key removed. Stated as an assignability relation rather
+// than as `undefined extends Narrowed['code']`, because the latter measures
+// the property's TYPE (which `exactOptionalPropertyTypes` moves) instead of
+// whether the key may be missing (which is the actual invariant).
+type _CodeIsOptional = Assert<Extends<Omit<Narrowed, 'code'>, Narrowed>>;
+
+// DISAGREES — the invariant itself, in one line: the value the RUNTIME accepts
+// through the `name` limb is assignable to the type the predicate hands its
+// caller. This is the same `nameOnly` witness the runtime block above asserts
+// `true` for, so the two halves cannot drift apart.
+type _NameOnlyErrorIsAssignableToTheNarrowedType = Assert<
+  Extends<NameOnlyConcurrentUpdateError, Narrowed>
+>;


### PR DESCRIPTION
Fixes #6421

`isConcurrentUpdateError` no longer promises a `code` its runtime check knowingly accepts values without.

## What moved

The exported predicate in `packages/plugin-detail/src/ConcurrentUpdateDialog.tsx` matches on two limbs — `code === 'CONCURRENT_UPDATE'` (the wire shape) **or** `name === 'ConcurrentUpdateError'` (the deliberate cross-realm discriminator, for a host that bundles the adapter twice so `instanceof` fails). Its narrowed type declared `code: 'CONCURRENT_UPDATE'` as a **required** literal, so for exactly the case the second limb exists to serve it handed the caller a property the value does not have.

One character in the return type, plus the comment that now explains why:

```diff
 export function isConcurrentUpdateError(err: unknown): err is {
-  code: 'CONCURRENT_UPDATE';
+  code?: 'CONCURRENT_UPDATE';
```

**The two-limb runtime check is byte-identical.** Per the triage ruling, only the narrowed *type* moves. The three body lines do not appear in the diff at all, and the other two copies of this predicate (`data-objectstack` narrows to the class; `plugin-form`'s `occSave` returns bare `boolean`) are untouched.

## Premise re-derived on `origin/main` — one contradiction to record

Verified rather than taken on faith, each with a positive control:

| Card claim | Measurement | Verdict |
|---|---|---|
| the narrowed type requires `code` | `ConcurrentUpdateDialog.tsx:224` on `origin/main`: `code: 'CONCURRENT_UPDATE';` | confirmed |
| the `name` limb admits objects lacking `code` | `return e.code === 'CONCURRENT_UPDATE' \|\| e.name === 'ConcurrentUpdateError';` | confirmed |
| consumers read the fields optionally | one consumer repo-wide, `InlineEditSaveBar.tsx:183`; its `buildConflict(draft, err)` takes `err: any` and reads only `currentVersion` / `currentRecord` | confirmed, and stronger than claimed — the narrowing is discarded at that boundary, so nothing reads it at all |

**Contradiction:** the claim comment's file face named `packages/plugin-detail/src/index.tsx` as "the predicate and its narrowed type". It is not there. `index.tsx:74-76` is a re-export block; the definition lives in `ConcurrentUpdateDialog.tsx:223`, which is where the issue body itself points. This PR does not touch `index.tsx` — the export list is unchanged.

## Public surface (clause ②) — stated, not inferred

- **Export list: unchanged.** `packages/plugin-detail/src/index.tsx` is not in the diff. The built `dist/index.d.ts:49` still reads `export { ConcurrentUpdateDialog, isConcurrentUpdateError, } from './ConcurrentUpdateDialog.js';`.
- **Narrowed type: one property moves from required to optional.** The emitted `dist/ConcurrentUpdateDialog.d.ts:53-58` now carries `code?: 'CONCURRENT_UPDATE';` — the annotation reaches the published surface verbatim.
- **Not a widened surface.** Nothing is added and nothing new is accepted: the parameter stays `unknown`, so the set of values the predicate takes is identical. What shrinks is what it *promises*. Calling this a widening would be backwards.
- **It is source-breaking for TypeScript consumers that read the narrowed `code`.** `err.code` is now `'CONCURRENT_UPDATE' | undefined`, so `const c: string = err.code` compiled before and will not now. **Could a consumer have relied on the stronger promise? Yes — and that reliance was already wrong.** On a name-only error the value is `undefined` at runtime; the old declaration was precisely the reason the compiler could not say so. The change converts a silent `undefined` into a compile error. No such consumer exists in this repo (only `InlineEditSaveBar`, via `err: any`).
- Declared `minor` with the breaking semantics spelled out in the changeset, per AGENTS.md's no-`major` rule for the fixed group.

## The pin, and why it is not blind

`packages/plugin-detail/src/__tests__/ConcurrentUpdateDialog.narrowedCode-6421.test.tsx`. Every assertion is labelled **DISAGREES** (red before, green after) or **CONTROL** (passes both ways, on purpose, naming the future wrong shape it guards).

- It bites by **assignability**, over a **named witness interface** (`name` set, no `code`) rather than an object literal. That is load-bearing: excess-property checking fires only on fresh literals, so a literal would have gone red in both directions — on `name`, which is on neither version of the type — and measured nothing about `code`.
- `message: string` on the witness is also load-bearing. The new narrowed type is all-optional, i.e. a *weak type*, and TypeScript rejects a source sharing no property name with a weak type; `message` is what keeps the pin a measurement of `code` rather than an accident of weak-type detection.
- Nothing casts past it — there is no `as any` in the file, and the one cast present (`nameOnly as { code?: unknown }`) is a runtime read asserting the witness really is code-less.
- **Ghost-assertion controls:** `_PredicateStillNarrows` fails if the predicate stops being an exported type predicate (`Narrowed` would collapse to `never`, which is assignable to everything and would satisfy every other pin silently); `_CodeIsStillTheWireLiteral` fails if someone "fixes" this by widening to `code?: string`; a `throw` inside the narrowing test fires if the `name` limb ever stops accepting a code-less error.
- **Not resolved through a stale `dist/`.** `tsc -p tsconfig.test.json --listFiles` puts `packages/plugin-detail/src/ConcurrentUpdateDialog.tsx` (source, line 1424 of 1686) and the pin file (line 1465) in the program, with no `plugin-detail/dist` entry at all. The dependency closure was built first, and dependencies do resolve through their built `.d.ts` (`packages/components/dist/...` is in the same listing).

## Reverse verification

Direction predicted **before** the run: putting the required `code` back turns `tsc -p tsconfig.test.json` red at exactly the three DISAGREES pins, while `tsc --noEmit` (which excludes tests) and vitest both stay green.

Mutation proven on disk by grepping both the injected and the deleted text — never a diffstat, never an editor's exit code: `injected_required_form_count=1`, `deleted_optional_form_count=0`.

```
MUT_SRC_TSC_EXIT=0        # tsc --noEmit — green, as predicted: no pin lives in that project
MUT_TEST_TSC_EXIT=2
  ConcurrentUpdateDialog.narrowedCode-6421.test.tsx(114,7):  error TS2344: Type 'false' does not satisfy the constraint 'true'.
  ConcurrentUpdateDialog.narrowedCode-6421.test.tsx(172,31): error TS2344: Type 'false' does not satisfy the constraint 'true'.
  ConcurrentUpdateDialog.narrowedCode-6421.test.tsx(179,3):  error TS2344: Type 'false' does not satisfy the constraint 'true'.
MUT_VITEST_EXIT=0         # Test Files 1 passed (1) / Tests 4 passed (4)
```

Lines 114 / 172 / 179 are `_CodeReadsAsMaybeUndefined`, `_CodeIsOptional`, `_NameOnlyErrorIsAssignableToTheNarrowedType` — the three DISAGREES pins, and only those. The controls at 150 / 156 / 163 stayed green, which is what makes the red a measurement of `code`'s optionality rather than of the file failing to compile.

`MUT_VITEST_EXIT=0` is the other half of the result and worth stating plainly: **the whole runtime suite passes against the defect.** A runtime-only pin could not have caught this, which is why the instrument here is a type pin.

Restore proven by state, not by exit code: worktree blob `7c30e8c69c1feb3d0d07a695b2a6ed86b587155c` equals the `HEAD` blob, `git diff HEAD` empty, `git status` clean. An `EXIT`/`INT`/`TERM` trap held absolute paths resolved from `git rev-parse --show-toplevel`, and the restore named the ref — `git checkout HEAD -- ABSPATH` — rather than the bare `git checkout -- ABSPATH`, which reads the **index** and would have handed the mutation straight back.

## Gates — verdict lines, exit codes captured before any pipe

All run on the final commit, `2bd48ad6d`:

| Gate | Verdict |
|---|---|
| `pnpm --filter @object-ui/plugin-detail type-check` | `FINAL_TYPECHECK_EXIT=0`, echoing `> tsc --noEmit && tsc -p tsconfig.test.json` (not a zero-match no-op) |
| `pnpm exec vitest run` over the affected files | `Test Files  5 passed (5)` / `Tests  76 passed (76)` |
| `pnpm --filter '@object-ui/plugin-detail^...' build` | `os-verify-lock: VERDICT command-exit 0` |
| `pnpm --filter @object-ui/plugin-detail build` | `BUILD_DETAIL_EXIT=0` |
| `node scripts/check-changeset-presence.mjs` | `✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | exit `0` |
| control-byte scan | `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over both edited files: no match |

Test scope is the measured affected set, not a guess: the change is a type annotation plus a comment, so the only tests that can observe it are the three that import the module (`ConcurrentUpdateDialog.narrowedCode-6421`, `InlineEditSaveBar`, `InlineEditSaveBar.savingNoProviderFallback`) and the two that read its source text as a path string (`i18n/residue-namespaces-3546`, `i18n/fallback-placeholder-spelling-3512`). A full-package run was attempted first and was killed by the container's ~10-minute foreground cap.

**Lint, narrowed and measured** (counts from eslint's own `--format json`):

- Diff: **2 files**, 0 errors, 1 warning — `react-refresh/only-export-components` on the `export function isConcurrentUpdateError` line, pre-existing: the rule reads the file's export list, which this diff does not change (no export added, moved or removed; the line number shifted only because the doc comment grew).
- Population eslint's config selected for the package: **161 files**, 0 errors, 855 warnings (warnings are ambient here and ungated — `errorCount` 0, eslint exits 0).
- **Why nothing outside that set can move:** linting in this repo is *not type-aware* — `eslint.config.js` extends `tseslint.configs.recommended`, not `recommendedTypeChecked`, and no `parserOptions.project` / `projectService` appears anywhere in it, so every file is linted from its own AST alone. A type annotation in one file cannot change any verdict in a file whose bytes did not change. The third changed file is a `.md` changeset, which is not in eslint's population at all (`files: ['**/*.{ts,tsx}']`).

The repo-wide farm (`turbo run lint`, the full `check:*` set) is CI's run and is left to it.

Found from #6375.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_