### PR TITLE
fix(app-shell,plugin-detail,react): offer approval recall to the submitter only

### DIFF
--- a/.changeset/6464-recall-submitter-gate.md
+++ b/.changeset/6464-recall-submitter-gate.md
@@ -1,0 +1,61 @@
+---
+'@object-ui/react': minor
+'@object-ui/plugin-detail': patch
+'@object-ui/app-shell': patch
+---
+
+The record page's approval band offers its **Recall** button to the approval's submitter
+only (objectui#6464).
+
+Field report on `@objectstack/*@17.2.0`: user A submits a record into a 4-level approval;
+user B — not the submitter, read access, not an admin — opens the record and the band still
+lights a clickable recall button. The click cannot succeed. The recall endpoint authorizes
+on submitter identity and refuses everyone else, so the only outcome available to that
+button was a failure toast. Record state was never at risk; this was purely a
+writability-feedback mismatch, the same family as objectui#3794.
+
+The button's only gate was `dataSource.cancelPendingApproval` — "can this adapter recall at
+all" — which is a question about the DataSource, not about the viewer. Identity now joins
+it, threaded the way every other signal on that band already travels: the HOST resolves it
+and passes it through `InlineEditProvider`, so the renderer stays DataSource-agnostic and
+never re-derives who submitted what.
+
+- `@object-ui/react` — `InlineEditProvider` accepts `approvalIsSubmitter`, surfaced on
+  `InlineEditContextValue`. Additive and optional; no existing prop changes.
+- `@object-ui/plugin-detail` — the band's recall button is withdrawn when that signal is a
+  resolved `false`.
+- `@object-ui/app-shell` — `RecordDetailView` resolves the verdict from its existing
+  approvals read and threads it.
+
+**The signal is tri-state, and the third state is the load-bearing one.** `true` offers
+recall, `false` withdraws it, and **`undefined` — a host that resolves no approval identity
+— renders exactly as it did before this release.** Omission preserving prior behaviour
+mirrors how `approvalPending` falls back to `locked`. Defaulting the unknown case to "hide"
+would have traded a cosmetic defect for a functional loss: every host whose band runs off
+the record's `approval_status` mirror alone would silently lose its submitter's only way to
+unlock their own record.
+
+**Withdrawn rather than disabled-with-reason.** The card offered either. For a
+non-submitter this control is never actionable on any pending record, so a permanently
+disabled button is standing clutter rather than a lesson; and the two sibling submitter
+levers already hide — the approvals panel's Remind button, and the declared
+`approval_recall` action's `visible` predicate. The band, its quorum tally and the
+approvals timeline still tell a non-submitter exactly what state the record is in. Only the
+lever they can never pull is gone.
+
+**This changes no permission.** Nothing about what the server allows moves, `canEdit` and
+the approval lock are untouched, and nothing downstream reads `approvalIsSubmitter` as an
+authorization verdict — the recall endpoint remains the sole authority, and it refused
+these callers before this change and refuses them after. There is deliberately **no admin
+carve-out** (the reporter ruled that case out, cf. objectstack#9464).
+
+The derivation itself is now one function, `isSubmitterOf` — server-resolved
+`viewer.is_submitter` first (framework#3310), an id comparison as the fallback for backends
+that predate it, joined with `??` so a server that resolved `false` is believed rather than
+re-litigated client-side. The approvals panel's Remind gate, which already carried that
+expression inline and whose behaviour is unchanged, now reads the same answer: two copies
+would have been two definitions of who submitted.
+
+The **untranslated refusal text** the reporter also saw ("No pending approval request found
+for this record", concatenated after a localized prefix) is a separate defect and is not
+addressed here; it is tracked on objectstack#11993.

--- a/packages/app-shell/src/hooks/__tests__/useRecordApprovals.isSubmitterOf.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/useRecordApprovals.isSubmitterOf.test.ts
@@ -1,0 +1,103 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isSubmitterOf, type ApprovalRequestLite } from '../useRecordApprovals';
+
+/**
+ * `isSubmitterOf` — the ONE derivation of "did this viewer submit this
+ * approval" (objectui#6464).
+ *
+ * Two surfaces gate on the answer: the approvals panel's Remind button and the
+ * record band's Recall button. Both are server-authorized on submitter
+ * identity, so two client-side copies of the derivation would be two
+ * definitions of who submitted — the drift `utils/approverIdentity` already
+ * exists to prevent on the display side.
+ *
+ * What the cells below actually protect is the SOURCE ORDER. The server's
+ * `viewer.is_submitter` (framework#3310) is the resolution the endpoint will
+ * enforce; the id comparison exists only for backends that predate the `viewer`
+ * block. Joining them with `||` instead of `??` would look identical on every
+ * agreeing row and quietly overturn the server on the one row where it says no.
+ */
+
+const row = (over: Partial<ApprovalRequestLite> = {}): ApprovalRequestLite => ({
+  id: 'req_1',
+  process_name: 'flow:budget_review',
+  object_name: 'budget',
+  record_id: 'B1',
+  status: 'pending',
+  submitter_id: 'u_alice',
+  ...over,
+});
+
+describe('isSubmitterOf — server-resolved first (objectui#6464)', () => {
+  it('believes the server when it says the viewer IS the submitter', () => {
+    expect(isSubmitterOf(row({ viewer: { can_act: false, is_submitter: true } }), 'u_bob')).toBe(true);
+  });
+
+  it('believes the server when it says the viewer is NOT the submitter', () => {
+    expect(isSubmitterOf(row({ viewer: { can_act: false, is_submitter: false } }), 'u_bob')).toBe(false);
+  });
+
+  /**
+   * The cell that separates `??` from `||`. The server resolved `false` while
+   * the raw `submitter_id` matches the signed-in id — a real shape whenever the
+   * server's answer accounts for something the bare column does not (a
+   * delegated or system-rewritten submission). `||` would re-litigate the
+   * server's refusal client-side and return `true`, lighting a lever the recall
+   * endpoint then rejects: the very defect this gate exists to close.
+   */
+  it('does not let a matching submitter_id overturn a server `false`', () => {
+    expect(
+      isSubmitterOf(row({ submitter_id: 'u_alice', viewer: { can_act: false, is_submitter: false } }), 'u_alice'),
+    ).toBe(false);
+  });
+});
+
+describe('isSubmitterOf — the id fallback for pre-`viewer` backends', () => {
+  it('matches the submitter by id when the server sends no viewer block', () => {
+    expect(isSubmitterOf(row({ submitter_id: 'u_alice' }), 'u_alice')).toBe(true);
+  });
+
+  it('rejects a non-submitter by id when the server sends no viewer block', () => {
+    expect(isSubmitterOf(row({ submitter_id: 'u_alice' }), 'u_bob')).toBe(false);
+  });
+
+  /**
+   * Fallback-also-absent: an older server AND no signed-in id to compare
+   * against. This resolves to a definite `false`, NOT to "unknown" — the
+   * authoritative row is in hand and nothing in it identifies this viewer as
+   * the submitter. It is also the same answer the Remind gate has always given
+   * in this shape, which is the point of there being one derivation.
+   */
+  it('resolves to false when there is no id to compare against', () => {
+    expect(isSubmitterOf(row({ submitter_id: 'u_alice' }), undefined)).toBe(false);
+    expect(isSubmitterOf(row({ submitter_id: 'u_alice' }), null)).toBe(false);
+    expect(isSubmitterOf(row({ submitter_id: 'u_alice' }), '')).toBe(false);
+  });
+
+  it('resolves to false when the row itself names no submitter', () => {
+    // Both sides absent must not collapse into `undefined === undefined`.
+    expect(isSubmitterOf(row({ submitter_id: null }), undefined)).toBe(false);
+    expect(isSubmitterOf(row({ submitter_id: undefined }), undefined)).toBe(false);
+  });
+});
+
+describe('isSubmitterOf — "unknown" is its own answer', () => {
+  /**
+   * No request to consult is NOT a denial. Callers feeding a feedback gate keep
+   * their prior behaviour on `undefined`; collapsing it to `false` here would
+   * hide the affordance on every backend that exposes no approvals API at all.
+   * Asserted with `toBeUndefined`, since `toBeFalsy` passes for both.
+   */
+  it('returns undefined — not false — with no request', () => {
+    expect(isSubmitterOf(null, 'u_alice')).toBeUndefined();
+    expect(isSubmitterOf(undefined, 'u_alice')).toBeUndefined();
+  });
+});

--- a/packages/app-shell/src/hooks/useRecordApprovals.ts
+++ b/packages/app-shell/src/hooks/useRecordApprovals.ts
@@ -199,6 +199,43 @@ export function recordLockedByApproval(request: ApprovalRequestLite | null | und
   return request.lock_record !== false;
 }
 
+/**
+ * Did the current viewer submit this approval request?
+ *
+ * The submitter's levers — Remind on the approvals panel, Recall on the record
+ * band (objectui#6464) — are the ones the server authorizes on submitter
+ * identity and refuses to anyone else. This is the ONE place that answer is
+ * derived, so the two surfaces cannot drift into disagreeing about who the
+ * submitter is (the identical hazard `utils/approverIdentity` exists for on the
+ * display side).
+ *
+ * Source order, and it matters: the server-resolved `viewer.is_submitter`
+ * (framework#3310) wins, because the server already did the resolution the
+ * recall endpoint will enforce. The id comparison is the FALLBACK for backends
+ * that predate the `viewer` block — `??` and not `||`, so a server that
+ * resolved `false` is believed rather than being re-litigated client-side.
+ *
+ * Returns `undefined` — "unknown", not "no" — when there is no request to
+ * consult. A caller feeding a feedback gate must keep its prior behaviour on
+ * `undefined` rather than reading it as a denial; a caller that needs a plain
+ * boolean coerces explicitly. With a request in hand, an unresolvable viewer is
+ * a definite `false`: the authoritative row is present and nothing in it
+ * identifies this viewer as the submitter.
+ *
+ * ⚠️ FEEDBACK ONLY — this decides which affordances are SHOWN, never who MAY
+ * act. Every lever it gates is authorized server-side independently.
+ */
+export function isSubmitterOf(
+  request: ApprovalRequestLite | null | undefined,
+  currentUserId: string | null | undefined,
+): boolean | undefined {
+  if (!request) return undefined;
+  return (
+    request.viewer?.is_submitter
+    ?? (!!currentUserId && request.submitter_id === currentUserId)
+  );
+}
+
 interface UseRecordApprovalsResult {
   loading: boolean;
   available: boolean;

--- a/packages/app-shell/src/views/RecordApprovalsPanel.tsx
+++ b/packages/app-shell/src/views/RecordApprovalsPanel.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 import { createAuthenticatedFetch } from '@object-ui/auth';
 import { useObjectTranslation } from '@object-ui/react';
 import {
+  isSubmitterOf,
   listApprovalActions,
   remindApprovalRequest,
   type ApprovalActionLite,
@@ -268,11 +269,14 @@ export const RecordApprovalsPanel: React.FC<RecordApprovalsPanelProps> = ({
    * Remind is the submitter's lever (server-authorized): prefer the
    * server-resolved `viewer.is_submitter` from the enriched pending row and
    * fall back to a plain id match for backends predating framework#3310.
+   *
+   * The derivation moved to `isSubmitterOf` unchanged (objectui#6464) so the
+   * record band's Recall gate reads the SAME answer — two copies of it would be
+   * two definitions of who submitted. `?? false` restates this call site's own
+   * reading of "no pending request": there is nothing to remind about, so the
+   * button is gone either way.
    */
-  const isSubmitter = pendingRequest
-    ? pendingRequest.viewer?.is_submitter
-      ?? (!!currentUserId && pendingRequest.submitter_id === currentUserId)
-    : false;
+  const isSubmitter = isSubmitterOf(pendingRequest, currentUserId) ?? false;
 
   const handleRemind = React.useCallback(async () => {
     if (!pendingRequest) return;

--- a/packages/app-shell/src/views/RecordDetailView.approvalRecallGate.test.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.approvalRecallGate.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The record page resolves WHO MAY SEE the recall lever, and threads that
+ * verdict to the approval band (objectui#6464).
+ *
+ * `DetailView.approvalRecallGate` pins what the band does with the verdict, and
+ * `useRecordApprovals.isSubmitterOf` pins how the verdict is derived. Neither
+ * can catch a host that derives it correctly and forgets to thread it — the
+ * whole defect lives in that seam, so this suite mounts the real record page
+ * against a stubbed approvals API and reads the verdict off the live
+ * `InlineEditContext`.
+ *
+ * The band itself is rendered through the page's schema tree; stubbing
+ * `SchemaRenderer` with a PROBE instead of `null` keeps the mount cheap while
+ * still measuring the one value the seam carries. What the probe renders is
+ * the tri-state verbatim, so `false` (a resolved non-submitter) never reads the
+ * same as `undefined` (a host that resolved nothing).
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const SIGNED_IN_USER = 'u_qcdir';
+
+const authFetchSpy = vi.fn(async () =>
+  new Response(JSON.stringify({ data: {} }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }),
+);
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u_qcdir', name: 'QC Director', image: null }, activeOrganization: null }),
+  createAuthenticatedFetch: () => authFetchSpy,
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRecordPresence: () => [],
+  PresenceAvatars: () => null,
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(), error: vi.fn(), info: vi.fn(),
+    warning: vi.fn(), loading: vi.fn(), dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('./ActionConfirmDialog', () => ({ ActionConfirmDialog: () => null }));
+vi.mock('./ActionParamDialog', () => ({ ActionParamDialog: () => null }));
+vi.mock('./ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+vi.mock('./FlowRunner', () => ({ FlowRunner: () => null }));
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+vi.mock('../hooks/useActionModal', () => ({
+  useActionModal: () => ({
+    modalHandler: vi.fn(async () => ({ success: true })),
+    modalElement: null,
+    closeModal: () => {},
+    resolveModalTarget: vi.fn(async () => null),
+  }),
+}));
+vi.mock('../utils/consoleServerAction', () => ({
+  createConsoleServerActionHandler: () => vi.fn(async () => ({ success: true })),
+}));
+
+/**
+ * The probe. It stands exactly where the page body (and with it the approval
+ * band) would render, inside the page's own `<InlineEditProvider>`, and prints
+ * the threaded verdict rather than the band — so this file measures the seam
+ * and `DetailView.approvalRecallGate` measures the band.
+ */
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/react')>();
+  const Probe = () => {
+    const inline = actual.useInlineEdit();
+    return (
+      <div
+        data-testid="inline-probe"
+        data-approval-is-submitter={String(inline?.approvalIsSubmitter)}
+        data-approval-pending={String(inline?.approvalPending)}
+      />
+    );
+  };
+  return { ...actual, SchemaRenderer: Probe };
+});
+
+import { MetadataCtx } from '@object-ui/react';
+import { RecordDetailView } from './RecordDetailView';
+
+const OBJECT_NAME = 'qif_report';
+const RECORD_ID = 'QIF202607310002';
+const REQUEST_ID = 'req_qif_1';
+
+const OBJECTS = [
+  {
+    name: OBJECT_NAME,
+    label: 'QIF Report',
+    fields: { id: { type: 'text', label: 'Id' }, name: { type: 'text', label: 'Name' } },
+  },
+];
+
+/**
+ * The pending request as the server sends it. `submitter_id` is deliberately
+ * NOT the signed-in user in the default row: the discriminating case is a
+ * reader who is not the submitter, which is the whole field report.
+ */
+const pendingRequest = (over: Record<string, unknown> = {}) => ({
+  id: REQUEST_ID,
+  process_name: 'flow:qif_quality_review',
+  object_name: OBJECT_NAME,
+  record_id: RECORD_ID,
+  status: 'pending',
+  submitter_id: 'u_inspector',
+  current_step: 'qc_director_review',
+  pending_approvers: ['position:qc_director'],
+  lock_record: true,
+  ...over,
+});
+
+let approvalsFetch: ReturnType<typeof vi.fn>;
+
+function stubApprovalsApi(row: Record<string, unknown> | null) {
+  approvalsFetch = vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u.includes(`/approvals/requests/${REQUEST_ID}/actions`)) {
+      return { ok: true, json: async () => ({ data: [] }) } as any;
+    }
+    if (u.endsWith(`/approvals/requests/${REQUEST_ID}`)) {
+      // `getRequest` — the read that attaches the `viewer` block.
+      return { ok: true, json: async () => row } as any;
+    }
+    if (u.includes('/approvals/requests?object=')) {
+      return { ok: true, json: async () => ({ data: row ? [row] : [] }) } as any;
+    }
+    return { ok: true, json: async () => ({ data: [] }) } as any;
+  });
+  vi.stubGlobal('fetch', approvalsFetch);
+}
+
+const METADATA = {
+  objects: OBJECTS,
+  pages: [],
+  loading: false,
+  error: null,
+  refresh: async () => {},
+  invalidate: () => {},
+  ensureType: async () => [],
+  getItem: async () => null,
+  getItemsByType: () => [],
+} as any;
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => ({ id: RECORD_ID, name: 'Incoming batch 0731', approval_status: 'pending' })),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+    cancelPendingApproval: vi.fn(async () => ({ requestId: REQUEST_ID, status: 'recalled' })),
+  } as any;
+}
+
+function renderRecordPage() {
+  return render(
+    <MemoryRouter initialEntries={[`/app/qms/${OBJECT_NAME}/${RECORD_ID}`]}>
+      <MetadataCtx.Provider value={METADATA}>
+        <RecordDetailView
+          dataSource={makeDataSource()}
+          objects={OBJECTS}
+          onEdit={() => {}}
+          objectNameOverride={OBJECT_NAME}
+          recordIdOverride={RECORD_ID}
+          embedded
+        />
+      </MetadataCtx.Provider>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Read the verdict off the live context. Waiting on `approval-pending` first is
+ * what keeps every assertion below a MEASUREMENT: the approvals read is async,
+ * and a probe queried before it lands reports `undefined` for every case —
+ * which happens to be the right answer for one of them, so a bare read would
+ * make the "no approvals API" case pass without ever exercising it.
+ */
+async function settledProbe(expectPending: boolean) {
+  const probe = await screen.findByTestId('inline-probe');
+  await waitFor(() =>
+    expect(probe.getAttribute('data-approval-pending')).toBe(String(expectPending)),
+  );
+  return probe;
+}
+
+beforeEach(() => {
+  cleanup();
+  authFetchSpy.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('record page → band: who may see recall (objectui#6464)', () => {
+  /**
+   * THE DEFECT, at the seam. A reader who is not the submitter: the server
+   * resolved `is_submitter: false`, and the page must carry that verdict down
+   * to the band rather than leaving it unset.
+   */
+  it('threads a resolved NON-submitter verdict to the band', async () => {
+    stubApprovalsApi(pendingRequest({ viewer: { can_act: true, is_submitter: false, can_override: false } }));
+    renderRecordPage();
+
+    const probe = await settledProbe(true);
+    expect(probe.getAttribute('data-approval-is-submitter')).toBe('false');
+  });
+
+  /** The opposite failure: the submitter must not lose the lever. */
+  it('threads a resolved SUBMITTER verdict to the band', async () => {
+    stubApprovalsApi(pendingRequest({ viewer: { can_act: false, is_submitter: true, can_override: false } }));
+    renderRecordPage();
+
+    const probe = await settledProbe(true);
+    expect(probe.getAttribute('data-approval-is-submitter')).toBe('true');
+  });
+
+  /**
+   * Older server, no `viewer` block: the page falls back to comparing the row's
+   * `submitter_id` against the signed-in id — and must reach the SAME verdict,
+   * both ways.
+   */
+  it('falls back to the id comparison when the server sends no viewer block', async () => {
+    stubApprovalsApi(pendingRequest({ submitter_id: SIGNED_IN_USER }));
+    renderRecordPage();
+
+    const probe = await settledProbe(true);
+    expect(probe.getAttribute('data-approval-is-submitter')).toBe('true');
+  });
+
+  it('resolves a non-submitter through the fallback too', async () => {
+    stubApprovalsApi(pendingRequest({ submitter_id: 'u_inspector' }));
+    renderRecordPage();
+
+    const probe = await settledProbe(true);
+    expect(probe.getAttribute('data-approval-is-submitter')).toBe('false');
+  });
+
+  /**
+   * No pending request to consult — the band runs off the record's own
+   * `approval_status` mirror. The page resolves NO identity here and must
+   * thread `undefined`, which the band reads as "unchanged from before this
+   * gate existed". Threading `false` instead would hide recall from the
+   * submitter on every backend without an approvals API.
+   */
+  it('threads `undefined` — not `false` — when there is no request to consult', async () => {
+    stubApprovalsApi(null);
+    renderRecordPage();
+
+    // Still pending: `approval_status: 'pending'` on the record is the mirror
+    // that keeps the band up with no approvals row behind it.
+    const probe = await settledProbe(true);
+    expect(probe.getAttribute('data-approval-is-submitter')).toBe('undefined');
+  });
+});

--- a/packages/app-shell/src/views/RecordDetailView.tsx
+++ b/packages/app-shell/src/views/RecordDetailView.tsx
@@ -44,7 +44,7 @@ import { AUDIT_FIELD_NAMES, HIDDEN_SYSTEM_FIELD_NAMES } from './record-detail-sy
 import type { FeedItem } from '@object-ui/types';
 import type { ActionDef, ActionParamDef, ConfirmationHandler } from '@object-ui/core';
 import type { ConsoleActionDispatch } from '../consoleActionDispatch.js';
-import { useRecordApprovals, recordLockedByApproval } from '../hooks/useRecordApprovals.js';
+import { useRecordApprovals, recordLockedByApproval, isSubmitterOf } from '../hooks/useRecordApprovals.js';
 import { RecordAttachmentsPanel } from './RecordAttachmentsPanel.js';
 import { RecordApprovalsPanel } from './RecordApprovalsPanel.js';
 import { DeclaredActionsBar } from './DeclaredActionsBar.js';
@@ -1023,6 +1023,21 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
   // whether their click closes the step. Server-computed; `first_response`
   // nodes carry none and the band then shows nothing extra.
   const approvalProgress = approvals.pendingRequest?.decision_progress;
+  // Who may RECALL the pending approval (objectui#6464). Recall is the
+  // submitter's lever and the server refuses everyone else, so a non-submitter
+  // reading a pending record was being offered a button whose click could only
+  // fail. Same source order the approvals panel's Remind gate uses — one
+  // `isSubmitterOf` for both, so the two levers cannot disagree about who
+  // submitted.
+  //
+  // `undefined` when there is no pending request to consult: the band is then
+  // running off the record's `approval_status` mirror alone (a backend with no
+  // approvals API), the host has resolved no identity, and the DetailView keeps
+  // its pre-#6464 behaviour rather than hiding on absent information.
+  //
+  // This gates the AFFORDANCE only. `canEdit` / `approvalLocked` below are
+  // untouched by it, and the recall endpoint authorizes the recall itself.
+  const approvalIsSubmitter = isSubmitterOf(approvals.pendingRequest, user?.id);
 
   // A decision landed through the declared-action bar (objectui#3055). The
   // action itself already POSTed and the runtime already toasted; what the HOST
@@ -2322,6 +2337,7 @@ export function RecordDetailView({ dataSource, objects, onEdit, objectNameOverri
           locked={approvalLocked}
           approvalPending={approvalPending}
           approvalProgress={approvalProgress}
+          approvalIsSubmitter={approvalIsSubmitter}
           lockedReason={t('detail.lockedTooltip', {
             defaultValue: 'This record has a pending approval request; editing is locked',
           })}

--- a/packages/plugin-detail/README.md
+++ b/packages/plugin-detail/README.md
@@ -294,6 +294,16 @@ shared draft (`InlineEditProvider` from `@object-ui/react`), committed by
 - **Approval lock**: hosts pass `locked` / `lockedHint` to the save bar and
   gate `InlineEditProvider.canEdit` when the record is approval-locked, so a
   locked record hides its edit affordances instead of rejecting at Save.
+- **Approval band & recall** (#6464): the band reads `approvalPending` /
+  `approvalProgress` from the same provider, and offers its **Recall** button
+  only where the click can succeed. Recall is the submitter's lever — the
+  server authorizes it on submitter identity and refuses everyone else — so
+  hosts that resolve approvals pass `InlineEditProvider.approvalIsSubmitter`.
+  It is tri-state on purpose: `false` withdraws the button from a resolved
+  non-submitter, `true` keeps it, and **omitting it leaves the button exactly
+  as it was** — a host that resolves no approval identity is unchanged rather
+  than losing its submitter's only unlock lever. It gates the affordance only;
+  the recall endpoint remains the authority on who may actually recall.
 
 ## Links
 

--- a/packages/plugin-detail/src/DetailView.tsx
+++ b/packages/plugin-detail/src/DetailView.tsx
@@ -1280,8 +1280,31 @@ export const DetailView: React.FC<DetailViewProps> = ({
                 </span>
               </span>
               {/* Recall belongs to the approval, not to the lock: an editable
-                  pending approval is just as recallable as a locked one. */}
-              {dataSource?.cancelPendingApproval && (
+                  pending approval is just as recallable as a locked one.
+
+                  It also belongs to the SUBMITTER (objectui#6464). The server
+                  authorizes recall on submitter identity and refuses everyone
+                  else, so rendering the button for every reader of a pending
+                  record offers a lever whose click must fail — the
+                  writability-feedback mismatch, not a permission question: what
+                  the server permits is unchanged by this gate, and nothing
+                  downstream treats `approvalIsSubmitter` as authorization.
+
+                  Withdrawn rather than disabled-with-reason, matching the
+                  sibling submitter levers (the approvals panel's Remind, the
+                  declared `approval_recall` action's `visible` predicate): for a
+                  non-submitter this control is never actionable on any pending
+                  record, so a permanently disabled button would be standing
+                  clutter on a band that already states the record is in
+                  approval. The band, its tally and the approvals timeline still
+                  explain the state to everyone; only the lever they can never
+                  pull is gone.
+
+                  `undefined` means the host resolves no approval identity, and
+                  then this renders exactly as it did before the signal existed
+                  — hiding on absent information would take the submitter's own
+                  unlock lever away (see InlineEditContextValue). */}
+              {dataSource?.cancelPendingApproval && inline?.approvalIsSubmitter !== false && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/packages/plugin-detail/src/__tests__/DetailView.approvalRecallGate.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailView.approvalRecallGate.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DetailView } from '../DetailView';
+import { InlineEditProvider, type ApprovalProgress } from '@object-ui/react';
+import type { DetailViewSchema } from '@object-ui/types';
+
+/**
+ * Recall is the SUBMITTER's lever — the approval band must not offer it to
+ * anyone else (objectui#6464).
+ *
+ * Field report on `@objectstack/*@17.2.0`: user B opens a record user A put
+ * into approval. B is not the submitter and not an admin, and the band still
+ * lit its recall button. The click cannot succeed — the recall endpoint
+ * authorizes on submitter identity and refuses everyone else — so the only
+ * thing the button could produce was a failure toast. Same
+ * writability-feedback mismatch family as objectui#3794.
+ *
+ * The gate is FEEDBACK, not permission: nothing here changes what the server
+ * allows, and the band, its tally and the approvals timeline still tell a
+ * non-submitter exactly what state the record is in. Only the lever they can
+ * never pull is withdrawn — the same choice the sibling submitter levers
+ * already make (the approvals panel's Remind button is hidden, and the
+ * declared `approval_recall` action gates through a `visible` predicate).
+ *
+ * The two failure modes are OPPOSITE and both are pinned below:
+ *   1. still lit for a non-submitter  — the defect;
+ *   2. hidden from the actual submitter — a regression that would remove the
+ *      only lever for unlocking one's own record.
+ * Plus the case that decides how much of the fleet this can break: a host that
+ * threads NO submitter identity at all (`undefined`), which must render exactly
+ * as it did before this gate existed.
+ */
+
+const RECALL = /Recall approval/;
+
+const baseSchema: DetailViewSchema = {
+  type: 'detail-view',
+  title: 'Budget',
+  objectName: 'budget',
+  // The band renders only when DetailView's own header is suppressed (composed
+  // under a Lightning-style page header) and inline editing is on.
+  showHeader: false,
+  data: { id: 'B1', name: 'Q3 Budget' },
+  sections: [{ title: 'Basics', fields: [{ name: 'name', label: 'Name' }] }],
+};
+
+/** A quorum tally, so every case below has a second control to measure against. */
+const QUORUM: ApprovalProgress = { behavior: 'quorum', got: 1, need: 2 };
+
+/**
+ * A DataSource that speaks recall. `cancelPendingApproval`'s PRESENCE is the
+ * pre-existing gate — an adapter that cannot recall never offered the button —
+ * so it is supplied everywhere except the one case that pins the two gates are
+ * ANDed rather than swapped.
+ */
+function makeDataSource(overrides: Record<string, unknown> = {}) {
+  return {
+    find: vi.fn(async () => ({ data: [] })),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+    getObjectSchema: vi.fn(async () => null),
+    cancelPendingApproval: vi.fn(async () => ({ requestId: 'r1', status: 'recalled' })),
+    ...overrides,
+  } as any;
+}
+
+function renderBand(
+  providerProps: {
+    locked?: boolean;
+    approvalPending?: boolean;
+    approvalIsSubmitter?: boolean;
+    approvalProgress?: ApprovalProgress;
+    canEdit?: boolean;
+  },
+  dataSource: any = makeDataSource(),
+) {
+  return render(
+    <InlineEditProvider canEdit={providerProps.canEdit ?? false} {...providerProps}>
+      <DetailView schema={baseSchema} dataSource={dataSource} inlineEdit />
+    </InlineEditProvider>,
+  );
+}
+
+/**
+ * Every absence assertion below is paired with these. "The button is not in the
+ * document" is also true of a panel that never rendered, or a band whose
+ * pending state never engaged — in which case the assertion passes while
+ * measuring nothing. Asserting the band and its tally in the SAME query turns
+ * the absence into a measurement.
+ */
+function expectBandRendered(label: string) {
+  expect(screen.getByRole('status'), 'band must render').toBeInTheDocument();
+  expect(screen.getByText(label)).toBeInTheDocument();
+  expect(screen.getByRole('progressbar'), 'tally must render').toBeInTheDocument();
+}
+
+describe('DetailView – recall is the submitter\'s lever (objectui#6464)', () => {
+  /**
+   * THE DEFECT. A non-submitter viewing a pending record: old and new
+   * behaviour disagree here and nowhere else, so this is the cell that decides
+   * whether the fix is present at all.
+   */
+  it('withdraws recall from a non-submitter on a pending record', () => {
+    renderBand({
+      locked: false,
+      approvalPending: true,
+      approvalIsSubmitter: false,
+      approvalProgress: QUORUM,
+    });
+
+    expectBandRendered('In approval · editable');
+    expect(screen.queryByRole('button', { name: RECALL })).not.toBeInTheDocument();
+  });
+
+  /**
+   * THE OPPOSITE FAILURE. The submitter must keep the lever — a gate that
+   * hides recall from everyone would pass the test above and still be a
+   * regression, because recall is the submitter's only way to unlock a record
+   * they themselves sent into approval.
+   */
+  it('keeps recall for the submitter of the same pending record', () => {
+    renderBand({
+      locked: false,
+      approvalPending: true,
+      approvalIsSubmitter: true,
+      approvalProgress: QUORUM,
+    });
+
+    expectBandRendered('In approval · editable');
+    const btn = screen.getByRole('button', { name: RECALL });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toBeEnabled();
+  });
+
+  /**
+   * The host that resolves no approval identity — a backend with no approvals
+   * API, whose band runs off the record's own `approval_status` mirror. It
+   * threads `undefined`, and `undefined` is UNKNOWN, not "no": behaviour is
+   * exactly what it was before this signal existed. Reading absent information
+   * as a denial would silently take recall away from every such host's
+   * submitter, trading a cosmetic defect for a functional loss.
+   */
+  it('offers recall unchanged when the host threads no submitter identity', () => {
+    renderBand({ locked: false, approvalPending: true, approvalProgress: QUORUM });
+
+    expectBandRendered('In approval · editable');
+    expect(screen.getByRole('button', { name: RECALL })).toBeInTheDocument();
+  });
+
+  /**
+   * The gate is about the APPROVAL, not the lock — recall survives on a
+   * `lockRecord: false` node (objectui#2902) and must be withdrawn on a locked
+   * one just the same. Running both cells stops the new gate from accidentally
+   * riding on `locked`.
+   */
+  it('withdraws recall from a non-submitter on a LOCKED record too', () => {
+    renderBand({
+      locked: true,
+      approvalPending: true,
+      approvalIsSubmitter: false,
+      approvalProgress: QUORUM,
+    });
+
+    expectBandRendered('Locked for approval');
+    expect(screen.queryByRole('button', { name: RECALL })).not.toBeInTheDocument();
+  });
+
+  it('keeps recall for the submitter on a LOCKED record', () => {
+    renderBand({
+      locked: true,
+      approvalPending: true,
+      approvalIsSubmitter: true,
+      approvalProgress: QUORUM,
+    });
+
+    expectBandRendered('Locked for approval');
+    expect(screen.getByRole('button', { name: RECALL })).toBeInTheDocument();
+  });
+
+  /**
+   * The two gates are ANDed, not swapped. An adapter with no
+   * `cancelPendingApproval` never offered recall, and being the submitter does
+   * not conjure a recall the DataSource cannot perform.
+   */
+  it('still offers no recall to the submitter when the adapter cannot recall', () => {
+    renderBand(
+      { locked: true, approvalPending: true, approvalIsSubmitter: true, approvalProgress: QUORUM },
+      makeDataSource({ cancelPendingApproval: undefined }),
+    );
+
+    expectBandRendered('Locked for approval');
+    expect(screen.queryByRole('button', { name: RECALL })).not.toBeInTheDocument();
+  });
+
+  /**
+   * The verdict is LIVE, and the same mount must follow it both ways.
+   *
+   * `viewer.is_submitter` arrives with the enriched pending row, one render
+   * after the band first engages, so a gate that only reads its prop at mount —
+   * or a context value memoized without the new signal in its dependency list —
+   * would show the correct thing on a fresh page and the stale thing on every
+   * update. Re-rendering the SAME tree also proves no verdict leaks across
+   * cases: whatever this assertion sees, it saw the previous prop first.
+   */
+  it('follows the verdict on re-render, in both directions', () => {
+    const ds = makeDataSource();
+    const props = { locked: true, approvalPending: true, approvalProgress: QUORUM };
+    const tree = (isSubmitter: boolean | undefined) => (
+      <InlineEditProvider canEdit={false} {...props} approvalIsSubmitter={isSubmitter}>
+        <DetailView schema={baseSchema} dataSource={ds} inlineEdit />
+      </InlineEditProvider>
+    );
+
+    const { rerender } = render(tree(false));
+    expect(screen.queryByRole('button', { name: RECALL })).not.toBeInTheDocument();
+
+    rerender(tree(true));
+    expect(screen.getByRole('button', { name: RECALL })).toBeInTheDocument();
+
+    rerender(tree(false));
+    expect(screen.queryByRole('button', { name: RECALL })).not.toBeInTheDocument();
+
+    // …and back to "unknown", which must read as the pre-#6464 behaviour
+    // rather than inheriting the `false` that preceded it.
+    rerender(tree(undefined));
+    expect(screen.getByRole('button', { name: RECALL })).toBeInTheDocument();
+    expectBandRendered('Locked for approval');
+  });
+});

--- a/packages/react/src/context/InlineEditContext.tsx
+++ b/packages/react/src/context/InlineEditContext.tsx
@@ -94,6 +94,37 @@ export interface InlineEditContextValue {
    */
   approvalProgress?: ApprovalProgress;
   /**
+   * Whether the viewer is the SUBMITTER of the pending approval request
+   * (objectui#6464). Recall is the submitter's lever and the server enforces
+   * exactly that — a non-submitter's recall is refused — so a recall button
+   * lit for everyone who can read the record is a button whose click must
+   * fail. The host resolves the identity (server-resolved `viewer.is_submitter`
+   * on the pending request, with an id comparison as the pre-framework#3310
+   * fallback) for the same reason it resolves `locked`: the renderer stays
+   * DataSource-agnostic and never re-derives who submitted what.
+   *
+   * TRI-STATE, and the third state is the load-bearing one:
+   *   `true`      — the viewer submitted this approval; offer recall.
+   *   `false`     — the host consulted the pending request and this viewer is
+   *                 not its submitter; withdraw the recall affordance.
+   *   `undefined` — the host does not resolve submitter identity at all
+   *                 (no approvals API, band driven by the record's
+   *                 `approval_status` mirror alone). Behaviour is UNCHANGED
+   *                 from before this signal existed: recall stays offered.
+   *
+   * The `undefined` case defaults to *showing* on purpose, mirroring how
+   * `approvalPending` falls back to `locked`: omission preserves a host's
+   * previous behaviour. Defaulting it to "hide" would silently take the
+   * submitter's only unlock lever away from every host that never learns of
+   * this prop — trading a cosmetic defect for a functional loss.
+   *
+   * ⚠️ FEEDBACK ONLY. This decides who is SHOWN the entry, never who MAY
+   * recall: the server authorizes the recall itself and rejects a
+   * non-submitter regardless of what any client renders. Nothing may treat
+   * this as an authorization verdict.
+   */
+  approvalIsSubmitter?: boolean;
+  /**
    * Human-readable reason for the approval lock, surfaced as the band's
    * tooltip. Optional — consumers fall back to their own localized default
    * when omitted.
@@ -153,6 +184,14 @@ export interface InlineEditProviderProps {
    * for `first_response` nodes and for hosts that don't read approvals.
    */
   approvalProgress?: ApprovalProgress;
+  /**
+   * Whether the viewer submitted the pending approval request
+   * (objectui#6464). Surfaced verbatim so the recall affordance is offered to
+   * the submitter only. Omitted ⇒ `undefined` ⇒ recall is offered exactly as
+   * it was before this prop existed (see `InlineEditContextValue`), so a host
+   * that resolves no approval identity is unchanged.
+   */
+  approvalIsSubmitter?: boolean;
   /** Optional human-readable lock reason, surfaced as the band tooltip. */
   lockedReason?: string;
   children: React.ReactNode;
@@ -163,6 +202,7 @@ export const InlineEditProvider: React.FC<InlineEditProviderProps> = ({
   locked = false,
   approvalPending,
   approvalProgress,
+  approvalIsSubmitter,
   lockedReason,
   children,
 }) => {
@@ -211,6 +251,7 @@ export const InlineEditProvider: React.FC<InlineEditProviderProps> = ({
       locked,
       approvalPending: pending,
       approvalProgress,
+      approvalIsSubmitter,
       lockedReason,
       draft,
       autoFocusField,
@@ -223,7 +264,7 @@ export const InlineEditProvider: React.FC<InlineEditProviderProps> = ({
       setSaving,
       setError,
     }),
-    [editing, canEdit, locked, pending, approvalProgress, lockedReason, draft, autoFocusField, saving, error, enter, setField, teardown],
+    [editing, canEdit, locked, pending, approvalProgress, approvalIsSubmitter, lockedReason, draft, autoFocusField, saving, error, enter, setField, teardown],
   );
 
   return <InlineEditContext.Provider value={value}>{children}</InlineEditContext.Provider>;


### PR DESCRIPTION
Fixes #6464

All evidence below was produced on **`977b301f1`**, which is this branch's final commit — the tree every run measured.

## The defect, and where it actually lives

The card says *withdraw*; the code says `cancelApproval` / **Recall**. Censusing the shape rather than the word also moved the site: the button is **not** in `RecordApprovalsPanel.tsx` (that file has only the Remind lever). It is the approval band's recall button in `packages/plugin-detail/src/DetailView.tsx`, and its only gate was

```tsx
{dataSource?.cancelPendingApproval && (
```

— a question about the **adapter** ("can this DataSource recall at all"), never about the **viewer**. So every reader of a pending record got a lit button, which matches the field report exactly. The English text the reporter saw concatenated after a localized prefix is thrown by `packages/data-objectstack/src/index.ts` (`NO_PENDING_REQUEST`, 404) when the request list comes back empty for a non-submitter.

`RecordApprovalsPanel.tsx:266-274` was still the right precedent — its Remind gate states the source order — but it is twenty lines from a *different* control in a different package.

## The fix

Identity now joins the adapter gate, threaded the way every other band signal already travels: the **host** resolves it, the renderer stays DataSource-agnostic.

| package | change |
|---|---|
| `@object-ui/react` | `InlineEditProvider` accepts `approvalIsSubmitter`, surfaced on `InlineEditContextValue` |
| `@object-ui/plugin-detail` | the band's recall button is withdrawn on a resolved `false` |
| `@object-ui/app-shell` | `RecordDetailView` resolves the verdict from its existing approvals read and threads it |

**Tri-state, and the third state is load-bearing.** `true` offers recall, `false` withdraws it, and **`undefined` — a host that resolves no approval identity — renders exactly as before.** Omission preserving prior behaviour mirrors how `approvalPending` falls back to `locked`. Defaulting the unknown case to *hide* would have traded a cosmetic defect for a functional loss: every host whose band runs off the record's `approval_status` mirror alone would silently lose its submitter's only way to unlock their own record.

**Hide, not disable-with-reason.** The card offered either; this picks hide, on three grounds. For a non-submitter this control is never actionable on *any* pending record, so a permanently disabled button is standing clutter rather than a lesson. Both sibling submitter levers already hide — the approvals panel's Remind button, and the declared `approval_recall` action's `visible` predicate — so disabling here would make one of three identical levers behave differently. And nothing is withheld by hiding it: the band, its quorum tally and the approvals timeline still tell a non-submitter exactly what state the record is in.

**This changes no permission.** `canEdit` and the approval lock are untouched, the recall endpoint remains the sole authority, and nothing downstream reads `approvalIsSubmitter` as an authorization verdict — it decides who is *shown* the entry, not who *may* act. There is deliberately **no admin carve-out** (the reporter ruled that case out). The refusal-message i18n half is not addressed here; out of scope: it stays on `objectstack#11993`.

### One derivation, not two

`isSubmitterOf` is now the single answer to "did this viewer submit this approval" — server-resolved `viewer.is_submitter` first, id comparison as the pre-`framework#3310` fallback, joined with `??` so a server that resolved `false` is believed rather than re-litigated client-side. The Remind gate, which carried that expression inline, now reads the same function; **its behaviour is unchanged** and its existing suites are run below as controls. Two copies would have been two definitions of who submitted — the hazard `utils/approverIdentity` already exists to prevent on the display side.

## Reverse verification — both halves, prediction stated before each run

Direction predicted **before** each run, and printed into the log ahead of it. Restore proven by blob-hash equality against `HEAD` plus an empty `git diff HEAD`, under an `EXIT`/`INT`/`TERM` trap holding absolute paths; mutation proven by grepping the injected **and** the deleted text, never a diffstat.

**No rebuild is needed for either leg, and that is a property of this repo, not an omission.** `vitest.config.mts` aliases `@object-ui/react` and `@object-ui/plugin-detail` to their own `src/`, and both suites import the mutated modules relatively (`../DetailView`, `./RecordDetailView`). Nothing here resolves a dependency through its `dist/` exports, so a rebuild would change nothing these runs read.

**Leg A — ablate the band's gate** (`DetailView.tsx` → base `a672ae917`). On-disk proof: deleted text `inline?.approvalIsSubmitter !== false` count **0**, restored bare gate count **1**, guard comment count **0**.

```
Test Files  1 failed | 4 passed (5)
     Tests  3 failed | 44 passed (47)
```

The 3 red are exactly the 3 predicted discriminating cells (non-submitter pending, non-submitter locked, the re-render walk). The **4 control cells in the same file stayed green** — submitter keeps it, `undefined` unchanged, adapter-cannot-recall — as did all of `RecordDetailView.approvalRecallGate`, `isSubmitterOf`, `DetailView.approvalBand` and `RecordApprovalsPanel`.

**Leg B — ablate the host threading** (`RecordDetailView.tsx` → base). On-disk proof: deleted prop **0**, deleted `isSubmitterOf(...)` call **0**, deleted comment **0**, injected base import **1**.

```
Test Files  1 failed | 2 passed (3)
     Tests  4 failed | 16 passed (20)
```

The 4 red are the four resolved-verdict cells. The fifth test in that same file — *"threads `undefined` — not `false` — when there is no request to consult"* — **stayed green**, which is the cell that proves this leg isolated the seam rather than flipping everything.

Both restores: `worktree blob == HEAD blob`, `git diff HEAD` empty, `git status --porcelain` empty.

## Tests

Every absence assertion is paired with a positive one in the same query (`role="status"` band + `role="progressbar"` tally), so "the button is not in the document" is a measurement rather than a blank page. The re-render walk (`false → true → false → undefined`) doubles as the isolation pin: each assertion has already seen the previous verdict on the same mount.

```
Test Files  10 passed (10)
     Tests  102 passed (102)
```

New: `DetailView.approvalRecallGate.test.tsx` (7), `useRecordApprovals.isSubmitterOf.test.ts` (9), `RecordDetailView.approvalRecallGate.test.tsx` (5). Controls run alongside: `DetailView.approvalBand`, `InlineEditContext`, `RecordApprovalsPanel` ×3, `RecordDetailView.approvalDeclaredActions`, `approvalOverride`.

`type-check` green in all three packages (`TYPECHECK_EXIT` captured directly, not through a pipe; script names echoed, so no zero-match false green). Both pin files confirmed in the tsc program via `tsc -p tsconfig.test.json --listFiles` — plugin-detail **1**, app-shell **2**.

## Clause ② — is the published surface widened? **Yes, in one package. Stated in as many words:**

The entry-file diff (`git diff --stat -- '**/src/index.ts'`) is **empty, and that does not settle it.**

- **`@object-ui/react` — WIDENED.** `src/index.ts` does `export * from './context/index.js'` → `export * from './InlineEditContext.js'`, so `InlineEditContextValue` and `InlineEditProviderProps` are already exported by name, and this PR adds an optional member to each. Confirmed in the built artefact: `packages/react/dist/context/InlineEditContext.d.ts` carries `approvalIsSubmitter?: boolean;` at both sites, reachable from `dist/index.d.ts`. Additive and optional — no existing consumer stops compiling — but it is a widened surface, and the changeset marks this package `minor` for exactly that reason.
- **`@object-ui/app-shell` — NOT widened.** `isSubmitterOf` is internal. Two named-only hops (`src/index.ts` ← `hooks/index.js` ← `useRecordApprovals.js`), neither naming it; **zero** `export *` in either barrel; `package.json#exports` publishes only `.`. This is settled from source, not from `dist/` — `packages/app-shell/dist` does not exist in this worktree, so a `dist` grep here would have proven nothing.
- **`@object-ui/plugin-detail` — NOT widened.** A JSX condition and comments; no type declaration changed, `DetailViewProps` untouched.

## Gates

Verdict lines as each gate printed them; exit codes captured before any pipe.

| gate | exit | verdict |
|---|---|---|
| `check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 5360 tracked text file(s); skipped 85 binary).` |
| `check:vi-mock-specifiers` | 0 | `✅ check-vi-mock-specifiers: OK (… 451 carry a mock; 701 relative specifier(s) resolved …)` |
| `check:phantom-deps` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:self-import` | 0 | `✅ No package names itself inside its own src/.` |
| `check:entry-guard` | 0 | `✓ check:entry-guard: 50 scripts/ file(s) — no entry guard outside the baseline` |
| `check:i18n-keys` | 0 | `Every in-scope call-site key resolves against the en pack (2856 keys) …` |
| changeset presence | 0 | `✅ 5 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)` |
| changeset no-major | 0 | `✅ No changeset declares a 'major' bump.` |

Two gates are **NOT MEASURED locally — a missing prerequisite, read as neither green nor red:**

- `check:readme-exports` exits 1 with `❌ 69 self-import(s) could not be judged`, every entry carrying the gate's own remedy *"run `pnpm build` first"*. Only dependency **closures** were built here, so seven packages have no `dist/index.d.ts`. **None of the 69 names `plugin-detail`** — the one README this PR touches — whose `dist/index.d.ts` *does* exist (built as a dependency of app-shell), so its self-import at README line 58 was judged and passed. The added bullet contributes **0** imports and **0** code fences, so it cannot move this gate either way.
- `check:eager-closure` exits 2 with `❌ No eager-closure report at apps/console/dist/eager-closure.json … This is a broken gauge, not 3 budgets that all passed.` It needs a console build. Both are CI's to run against a full build.

A raw control-character scan was also run outside the gate over all ten changed files (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`): no hits.

## Lint — narrowed, and the narrowing is measured

Not a repo-wide `pnpm lint`; eslint was run over the changed `.ts`/`.tsx` set. Three pieces of evidence, so this is a measurement rather than a skip:

1. **Population from eslint's own config, not a guess.** `eslint.config.js` scopes rules to `files: ['**/*.{ts,tsx}']`, so the two Markdown files in this diff are outside the linted population entirely.
2. **File count from `--format json`:** **8 files linted**, `ESLINT_EXIT=0`, **0 errors**, 191 warnings.
3. **Why nothing outside the set can move.** eslint here is **not type-aware** — `tseslint.configs.recommended` (not `recommendedTypeChecked`), and **zero** occurrences of `project` / `projectService` anywhere in `eslint.config.js`. Every file's verdict is computed from that file plus static config, so a diff confined to these files cannot change the verdict of any file it did not touch.

Intersecting eslint's reported line numbers with the lines this diff adds: on the 5 **modified** files, **183 pre-existing warnings, 0 of them on a line this diff added.** The remaining 8 are on the new test files, all `@typescript-eslint/no-explicit-any` on `fetch` / metadata / DataSource stub casts — the house pattern of the sibling harness (`RecordDetailView.approvalDeclaredActions.test.tsx`, 7 such casts).

## Notes for review

- **Not landing this myself** — draft, no auto-merge, per dispatch.
- Worth relaying to `objectstack#11993`: the mixed-language refusal text may not be server-emitted at all. `"No pending approval request found for this record"` is thrown **client-side** by `packages/data-objectstack/src/index.ts` when the request lookup returns no visible pending row — the shape a non-submitter gets. That card is scoped `domain:services` on the premise the server emits it; the string is at least also present on this side. Not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_