### PR TITLE
fix(examples,docs): correct the toast demos to spellings the engine executes

### DIFF
--- a/.changeset/6250-toast-demo-shapes.md
+++ b/.changeset/6250-toast-demo-shapes.md
@@ -1,0 +1,18 @@
+---
+---
+
+Docs and fixtures only: the seven `components-feedback-toast/*` and seven
+`components-feedback-sonner/*` `SchemaExample` fixtures hung an action object off
+`onClick` (`{"type":"button", …, "onClick":{"action":"toast", …}}`) — a shape
+`ButtonSchema` declares as a FUNCTION and no dispatcher reads, so all fourteen were a
+RED `safeParse` on the envelope and clicking the rendered demo raised no toast
+(objectui#6250). They now author the registered spellings the engine already executes,
+`type: 'toast'` and `type: 'sonner'`, whose renderers draw their own trigger button and
+call sonner's `toast()` from it. `feedback/toast.mdx` and `feedback/sonner.mdx` follow,
+including two keys sonner's page taught that neither `SonnerSchema` declares nor its
+renderer reads (`duration`, `action`).
+
+No package source or behaviour change; fixtures, docs and pins only. Two things the
+fixture correction deliberately does NOT do, both left to the maintainer: declare an
+action union on `ButtonSchema.onClick` and build a dispatcher for it, and give the toast
+renderers the in-toast action button and promise form the removed demos implied.

--- a/content/docs/components/feedback/sonner.mdx
+++ b/content/docs/components/feedback/sonner.mdx
@@ -9,6 +9,11 @@ The Sonner component provides beautiful toast notifications with a rich API.
 
 ## Basic Usage
 
+A `sonner` node renders its own trigger button. Clicking the button raises the toast the
+node declares, so the whole demo is one schema node with no handler to wire up.
+`buttonLabel` and `buttonVariant` style that trigger; `message`, `description` and
+`variant` describe the toast it raises.
+
 <SchemaExample id="components-feedback-sonner/basic-sonner-toast" />
 
 ## Toast Types
@@ -20,7 +25,9 @@ The Sonner component provides beautiful toast notifications with a rich API.
   <SchemaExample id="components-feedback-sonner/info" />
 </DemoGrid>
 
-## With Action
+## With Description
+
+`description` adds a secondary line under the message.
 
 <SchemaExample id="components-feedback-sonner/toast-with-action" />
 
@@ -29,21 +36,19 @@ The Sonner component provides beautiful toast notifications with a rich API.
 ```plaintext
 interface SonnerSchema {
   type: 'sonner';
-  message: string;                // Toast message
+  message?: string;               // Toast message
+  title?: string;                 // Alias for message
   description?: string;           // Additional description
   variant?: 'default' | 'success' | 'error' | 'warning' | 'info';
-  duration?: number;              // Auto-close duration (ms)
   
-  // Action
-  action?: {
-    label: string;
-    onClick: string | ActionConfig;
-  };
+  // Trigger button
+  buttonLabel?: string;           // Trigger button text (default: 'Show Toast')
+  buttonVariant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link';
 }
 ```
 
 ## Examples
 
-### Promise Toast
+### Custom Trigger Button
 
 <SchemaExample id="components-feedback-sonner/promise-based-toast" />

--- a/content/docs/components/feedback/toast.mdx
+++ b/content/docs/components/feedback/toast.mdx
@@ -9,18 +9,24 @@ The Toast component displays brief notifications to users that appear temporaril
 
 ## Basic Usage
 
+A `toast` node renders its own trigger button. Clicking the button raises the toast the
+node declares — the title, description, variant and duration are all read off the node
+itself, so the whole demo is one schema node with no handler to wire up.
+
 <SchemaExample id="components-feedback-toast/basic-toast" />
 
 ## Variants
 
+`variant` selects the toast style. `ToastSchema` declares exactly five members —
+`default`, `success`, `warning`, `error` and `info`; the four below plus `success`,
+which the Success Message example uses.
+
 <DemoGrid>
   <SchemaExample id="components-feedback-toast/default" />
   <SchemaExample id="components-feedback-toast/destructive" />
+  <SchemaExample id="components-feedback-toast/toast-with-action" />
+  <SchemaExample id="components-feedback-toast/toast-with-undo" />
 </DemoGrid>
-
-## With Action
-
-<SchemaExample id="components-feedback-toast/toast-with-action" />
 
 ## Schema
 
@@ -51,7 +57,3 @@ interface ToastSchema {
 ### Error Message
 
 <SchemaExample id="components-feedback-toast/error-toast" />
-
-### With Undo Action
-
-<SchemaExample id="components-feedback-toast/toast-with-undo" />

--- a/examples/schema-catalog/src/catalog-meta.json
+++ b/examples/schema-catalog/src/catalog-meta.json
@@ -36,6 +36,51 @@
       "verification"
     ]
   },
+  "components-feedback-sonner/promise-based-toast": {
+    "title": "Custom Trigger Button",
+    "description": "A success toast whose trigger button is styled through buttonVariant.",
+    "tags": [
+      "toast",
+      "sonner",
+      "button"
+    ]
+  },
+  "components-feedback-sonner/toast-with-action": {
+    "title": "Message With Description",
+    "description": "A sonner toast carrying both a message and a secondary description line.",
+    "tags": [
+      "toast",
+      "sonner",
+      "description"
+    ]
+  },
+  "components-feedback-toast/destructive": {
+    "title": "Error Variant",
+    "description": "The 'error' toast variant. 'destructive' is a button variant, not a toast variant.",
+    "tags": [
+      "toast",
+      "variant",
+      "error"
+    ]
+  },
+  "components-feedback-toast/toast-with-action": {
+    "title": "Info Variant",
+    "description": "The 'info' toast variant, used here for an update notice.",
+    "tags": [
+      "toast",
+      "variant",
+      "info"
+    ]
+  },
+  "components-feedback-toast/toast-with-undo": {
+    "title": "Warning Variant",
+    "description": "The 'warning' toast variant, used here for a deletion notice.",
+    "tags": [
+      "toast",
+      "variant",
+      "warning"
+    ]
+  },
   "components-form-form/basic-form": {
     "title": "Basic Form",
     "description": "A hand-built `form` node from `@object-ui/components`: name, email, country and newsletter fields declared inline, with no object behind them. For a form generated from an object's own metadata, see the `plugin-form` examples.",

--- a/examples/schema-catalog/src/index.ts
+++ b/examples/schema-catalog/src/index.ts
@@ -1658,9 +1658,10 @@ const REGISTRY: Record<string, Example> = {
   'components-feedback-sonner/promise-based-toast': {
     id: 'components-feedback-sonner/promise-based-toast',
     meta: {
-      title: "Promise Based Toast",
-      description: "",
+      title: "Custom Trigger Button",
+      description: "A success toast whose trigger button is styled through buttonVariant.",
       category: 'components-feedback-sonner',
+      tags: ["toast", "sonner", "button"],
     },
     schema: components_feedback_sonner_promise_based_toast,
   },
@@ -1676,9 +1677,10 @@ const REGISTRY: Record<string, Example> = {
   'components-feedback-sonner/toast-with-action': {
     id: 'components-feedback-sonner/toast-with-action',
     meta: {
-      title: "Toast With Action",
-      description: "",
+      title: "Message With Description",
+      description: "A sonner toast carrying both a message and a secondary description line.",
       category: 'components-feedback-sonner',
+      tags: ["toast", "sonner", "description"],
     },
     schema: components_feedback_sonner_toast_with_action,
   },
@@ -1766,9 +1768,10 @@ const REGISTRY: Record<string, Example> = {
   'components-feedback-toast/destructive': {
     id: 'components-feedback-toast/destructive',
     meta: {
-      title: "Destructive",
-      description: "",
+      title: "Error Variant",
+      description: "The 'error' toast variant. 'destructive' is a button variant, not a toast variant.",
       category: 'components-feedback-toast',
+      tags: ["toast", "variant", "error"],
     },
     schema: components_feedback_toast_destructive,
   },
@@ -1793,18 +1796,20 @@ const REGISTRY: Record<string, Example> = {
   'components-feedback-toast/toast-with-action': {
     id: 'components-feedback-toast/toast-with-action',
     meta: {
-      title: "Toast With Action",
-      description: "",
+      title: "Info Variant",
+      description: "The 'info' toast variant, used here for an update notice.",
       category: 'components-feedback-toast',
+      tags: ["toast", "variant", "info"],
     },
     schema: components_feedback_toast_toast_with_action,
   },
   'components-feedback-toast/toast-with-undo': {
     id: 'components-feedback-toast/toast-with-undo',
     meta: {
-      title: "Toast With Undo",
-      description: "",
+      title: "Warning Variant",
+      description: "The 'warning' toast variant, used here for a deletion notice.",
       category: 'components-feedback-toast',
+      tags: ["toast", "variant", "warning"],
     },
     schema: components_feedback_toast_toast_with_undo,
   },

--- a/examples/schema-catalog/src/schemas/components-feedback-sonner/basic-sonner-toast.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-sonner/basic-sonner-toast.json
@@ -1,8 +1,5 @@
 {
-  "type": "button",
-  "label": "Show Sonner Toast",
-  "onClick": {
-    "action": "sonner",
-    "message": "Event has been created"
-  }
+  "type": "sonner",
+  "message": "Event has been created",
+  "buttonLabel": "Show Sonner Toast"
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-sonner/error.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-sonner/error.json
@@ -1,10 +1,7 @@
 {
-  "type": "button",
-  "label": "Error",
-  "variant": "destructive",
-  "onClick": {
-    "action": "sonner",
-    "type": "error",
-    "message": "Something went wrong"
-  }
+  "type": "sonner",
+  "variant": "error",
+  "message": "Something went wrong",
+  "buttonLabel": "Error",
+  "buttonVariant": "destructive"
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-sonner/info.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-sonner/info.json
@@ -1,9 +1,6 @@
 {
-  "type": "button",
-  "label": "Info",
-  "onClick": {
-    "action": "sonner",
-    "type": "info",
-    "message": "New update available"
-  }
+  "type": "sonner",
+  "variant": "info",
+  "message": "New update available",
+  "buttonLabel": "Info"
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-sonner/promise-based-toast.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-sonner/promise-based-toast.json
@@ -1,11 +1,7 @@
 {
-  "type": "button",
-  "label": "Save Changes",
-  "onClick": {
-    "action": "sonner",
-    "type": "promise",
-    "loading": "Saving changes...",
-    "success": "Changes saved!",
-    "error": "Failed to save changes"
-  }
+  "type": "sonner",
+  "variant": "success",
+  "message": "Changes saved!",
+  "buttonLabel": "Save Changes",
+  "buttonVariant": "outline"
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-sonner/success.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-sonner/success.json
@@ -1,9 +1,6 @@
 {
-  "type": "button",
-  "label": "Success",
-  "onClick": {
-    "action": "sonner",
-    "type": "success",
-    "message": "Operation completed successfully"
-  }
+  "type": "sonner",
+  "variant": "success",
+  "message": "Operation completed successfully",
+  "buttonLabel": "Success"
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-sonner/toast-with-action.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-sonner/toast-with-action.json
@@ -1,12 +1,7 @@
 {
-  "type": "button",
-  "label": "Show with Action",
-  "onClick": {
-    "action": {
-      "label": "View",
-      "onClick": "viewFile"
-    },
-    "message": "File uploaded",
-    "description": "Your file has been uploaded successfully"
-  }
+  "type": "sonner",
+  "variant": "success",
+  "message": "File uploaded",
+  "description": "Your file has been uploaded successfully",
+  "buttonLabel": "Upload File"
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-sonner/warning.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-sonner/warning.json
@@ -1,9 +1,6 @@
 {
-  "type": "button",
-  "label": "Warning",
-  "onClick": {
-    "action": "sonner",
-    "type": "warning",
-    "message": "Please review your input"
-  }
+  "type": "sonner",
+  "variant": "warning",
+  "message": "Please review your input",
+  "buttonLabel": "Warning"
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-toast/basic-toast.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toast/basic-toast.json
@@ -1,9 +1,5 @@
 {
-  "type": "button",
-  "label": "Show Toast",
-  "onClick": {
-    "action": "toast",
-    "title": "Success",
-    "description": "Your changes have been saved."
-  }
+  "type": "toast",
+  "title": "Success",
+  "description": "Your changes have been saved."
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-toast/default.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toast/default.json
@@ -1,9 +1,6 @@
 {
-  "type": "button",
-  "label": "Default Toast",
-  "onClick": {
-    "action": "toast",
-    "title": "Notification",
-    "description": "This is a default toast message."
-  }
+  "type": "toast",
+  "variant": "default",
+  "title": "Notification",
+  "description": "This is a default toast message."
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-toast/destructive.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toast/destructive.json
@@ -1,11 +1,6 @@
 {
-  "type": "button",
-  "label": "Destructive Toast",
-  "variant": "destructive",
-  "onClick": {
-    "action": "toast",
-    "variant": "error",
-    "title": "Error",
-    "description": "Something went wrong."
-  }
+  "type": "toast",
+  "variant": "error",
+  "title": "Error",
+  "description": "Something went wrong."
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-toast/error-toast.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toast/error-toast.json
@@ -1,11 +1,6 @@
 {
-  "type": "button",
-  "label": "Submit",
-  "variant": "destructive",
-  "onClick": {
-    "action": "toast",
-    "variant": "error",
-    "title": "Submission Failed",
-    "description": "Please check your input and try again."
-  }
+  "type": "toast",
+  "variant": "error",
+  "title": "Submission Failed",
+  "description": "Please check your input and try again."
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-toast/success-toast.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toast/success-toast.json
@@ -1,10 +1,7 @@
 {
-  "type": "button",
-  "label": "Save",
-  "onClick": {
-    "action": "toast",
-    "title": "Saved Successfully",
-    "description": "Your changes have been saved.",
-    "duration": 3000
-  }
+  "type": "toast",
+  "variant": "success",
+  "title": "Saved Successfully",
+  "description": "Your changes have been saved.",
+  "duration": 3000
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-toast/toast-with-action.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toast/toast-with-action.json
@@ -1,10 +1,6 @@
 {
-  "type": "button",
-  "label": "Show Toast with Action",
-  "onClick": {
-    "action": "toast",
-    "title": "Update Available",
-    "description": "A new version is available.",
-    "actionLabel": "Update Now"
-  }
+  "type": "toast",
+  "variant": "info",
+  "title": "Update Available",
+  "description": "A new version is available."
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-toast/toast-with-undo.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-toast/toast-with-undo.json
@@ -1,10 +1,6 @@
 {
-  "type": "button",
-  "label": "Delete Item",
-  "onClick": {
-    "action": "toast",
-    "title": "Item Deleted",
-    "description": "The item has been removed.",
-    "actionLabel": "Undo"
-  }
+  "type": "toast",
+  "variant": "warning",
+  "title": "Item Deleted",
+  "description": "The item has been removed."
 }

--- a/examples/schema-catalog/test/component-fixture-declared-keys.test.ts
+++ b/examples/schema-catalog/test/component-fixture-declared-keys.test.ts
@@ -43,15 +43,26 @@
  *      `direction`. The probe must be structural — asserting `.success` here
  *      would assert nothing at all.
  *
- * ## The one key on these fixtures that is CORRECT and must stay
+ * ## SUPERSEDED by objectui#6250 — where the toast fixtures went
  *
- * Both toast fixtures ALSO carry a **top-level** `"variant": "destructive"`.
- * That one is a genuine `ButtonSchema` member (`form.d.ts:30`,
- * `zod/form.zod.js:153`) — the demo's button really is destructive-styled. Only
- * the occurrence nested inside the `onClick` toast payload was invented. A
- * blanket find-and-replace over `destructive` in these two files breaks two
- * working buttons; the first `describe` block below exists to make that
- * mistake turn this file red.
+ * The two toast fixtures used to be `{ "type": "button", …, "onClick": { action:
+ * 'toast', … } }`, and the block that used to head this file asserted that the
+ * **top-level** `"variant": "destructive"` — a genuine `ButtonSchema` member —
+ * survived any correction to the nested payload.
+ *
+ * #6250 removed the envelope that fact was about. `ButtonSchema.onClick` is
+ * `z.function()`, so all fourteen `components-feedback-toast/*` and
+ * `components-feedback-sonner/*` fixtures were a RED `safeParse` on the
+ * ENVELOPE, and nothing anywhere read a handler key as an action object — the
+ * demos are now the registered `type: 'toast'` / `type: 'sonner'` nodes their
+ * own renderers execute. There is no button schema left to carry a button
+ * variant, so that block is REPLACED rather than reworded: what #6157 actually
+ * established — that the toast variant VALUE is a declared `ToastSchema`
+ * member, with `destructive` refused — is carried forward below against the
+ * top-level `variant` those nodes now declare, counter-probe and all.
+ *
+ * `toast-demo-dispatch-6250.test.tsx` carries the other half: that clicking
+ * each corrected demo raises a real toast, which no parse can see.
  *
  * ## What this file deliberately does not assert
  *
@@ -69,7 +80,7 @@ import {
   RadioGroupSchema,
   ToastSchema,
 } from '@object-ui/types/zod';
-import { getExample } from '../src/index.js';
+import { allExamples, getExample } from '../src/index.js';
 
 type Json = Record<string, unknown>;
 
@@ -96,45 +107,53 @@ const TOAST_FIXTURES = [
   'components-feedback-toast/error-toast',
 ] as const;
 
-describe('toast fixtures: the top-level button variant is CORRECT and stays (objectui#6157 rider)', () => {
-  const buttonVariants = enumOptionsOf(ButtonSchema.shape.variant);
-
-  it('ButtonSchema really does declare `destructive` — the control for this whole block', () => {
-    expect(buttonVariants).toContain('destructive');
+describe('toast fixtures: the registered spelling, not an action object off `onClick` (objectui#6250)', () => {
+  it.each(TOAST_FIXTURES)('%s is a `toast` node that parses green under ToastSchema', (id) => {
+    const fixture = schemaOf(id);
+    expect(fixture.type).toBe('toast');
+    expect(fixture).not.toHaveProperty('onClick');
+    const result = ToastSchema.safeParse(fixture);
+    expect(result.error?.issues ?? []).toEqual([]);
+    expect(result.success).toBe(true);
   });
 
-  it.each(TOAST_FIXTURES)('%s keeps a top-level destructive button', (id) => {
-    const fixture = schemaOf(id);
-    expect(fixture.type).toBe('button');
-    expect(fixture.variant).toBe('destructive');
-    expect(buttonVariants).toContain(fixture.variant as string);
+  it('counter-probe: the retired envelope is still RED under ButtonSchema, so the block above bites', () => {
+    const retired = {
+      type: 'button',
+      label: 'Destructive Toast',
+      variant: 'destructive',
+      onClick: {
+        action: 'toast',
+        variant: 'error',
+        title: 'Error',
+        description: 'Something went wrong.',
+      },
+    };
+    const result = ButtonSchema.safeParse(retired);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['onClick']);
+    expect(result.error?.issues[0]?.message).toContain('expected function, received object');
   });
 });
 
-describe('toast fixtures: the nested onClick payload uses a declared toast variant', () => {
-  /**
-   * The payload is `{ action: 'toast', ... }` hung off `onClick`. The shipped
-   * surface declares `ButtonSchema.onClick` as a FUNCTION, so this action-object
-   * idiom has no declared type of its own — `ToastSchema` is the nearest
-   * governing declaration, and it is unambiguous here: the payload's other keys
-   * (`title`, `description`, `duration`) are exactly ToastSchema's.
-   */
-  const asToast = (fixture: Json): Json => {
-    const { action, ...rest } = fixture.onClick as Json;
-    expect(action).toBe('toast');
-    return { type: 'toast', ...rest };
-  };
+describe('toast fixtures: the variant value is a declared member (objectui#6157, carried forward)', () => {
+  const toastVariants = enumOptionsOf(ToastSchema.shape.variant);
 
-  it.each(TOAST_FIXTURES)('%s payload parses green under ToastSchema', (id) => {
-    const result = ToastSchema.safeParse(asToast(schemaOf(id)));
-    expect(result.error?.issues ?? []).toEqual([]);
-    expect(result.success).toBe(true);
+  it('ToastSchema declares `error` and refuses `destructive` — the control for this block', () => {
+    expect(toastVariants).toContain('error');
+    expect(toastVariants).not.toContain('destructive');
+  });
+
+  it.each(TOAST_FIXTURES)('%s declares a variant ToastSchema knows', (id) => {
+    const fixture = schemaOf(id);
+    expect(fixture.variant).toBe('error');
+    expect(toastVariants).toContain(fixture.variant as string);
   });
 
   it.each(TOAST_FIXTURES)(
     '%s counter-probe: the pre-#6157 value is still refused, so the assertion above bites',
     (id) => {
-      const payload = { ...asToast(schemaOf(id)), variant: 'destructive' };
+      const payload = { ...schemaOf(id), variant: 'destructive' };
       const result = ToastSchema.safeParse(payload);
       expect(result.success).toBe(false);
       expect(result.error?.issues[0]?.path).toEqual(['variant']);
@@ -197,5 +216,59 @@ describe('radio-group fixtures: the layout key is the declared one', () => {
     expect(fixture.orientation).toBe(value);
     expect(enumOptionsOf(RadioGroupSchema.shape.orientation)).toContain(value);
     expect(RadioGroupSchema.safeParse(fixture).success).toBe(true);
+  });
+});
+
+/**
+ * objectui#6250, generalized past the two pages that reported it.
+ *
+ * The card's shape is "an action object hung off a handler key", and a grep for
+ * one literal (`"action": "toast"`) under-counts it by construction — the sonner
+ * half spells the same shape `{ action: 'sonner', … }`, and one fixture spells
+ * it `{ action: { label, onClick } }`. So the sweep is over the SHAPE: every key
+ * that reads as a handler slot, at every depth, in every entry.
+ *
+ * What it deliberately does NOT cover: a handler key holding a STRING. That is
+ * the handler-EXPRESSION dialect — whether an expression is a supported handler
+ * form is objectui#6182's open decision, not this card's — and the corpus still
+ * has exactly one, which is what the positive control below pins. A sweep that
+ * banned handler keys outright would be answering #6182 by accident.
+ */
+describe('catalog corpus: no fixture hangs an action object off a handler key (objectui#6250)', () => {
+  type Handler = { where: string; value: unknown };
+
+  const isHandlerKey = (key: string) => /^on[A-Z]/.test(key) || key === 'events';
+
+  function collect(node: unknown, where: string, acc: Handler[] = []): Handler[] {
+    if (Array.isArray(node)) {
+      node.forEach((n, i) => collect(n, `${where}[${i}]`, acc));
+      return acc;
+    }
+    if (!node || typeof node !== 'object') return acc;
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      if (isHandlerKey(key)) acc.push({ where: `${where}.${key}`, value });
+      collect(value, `${where}.${key}`, acc);
+    }
+    return acc;
+  }
+
+  const entries = allExamples();
+  const handlers = entries.flatMap((e) => collect(e.schema, e.id));
+
+  it('the walker descends into nested children — positive control', () => {
+    // A zero result from a walker that never descends is an untested tool, not
+    // a measurement. This hit is two levels down, inside `children`, and it is
+    // the handler-EXPRESSION case #6182 owns.
+    expect(handlers.map((h) => h.where)).toContain(
+      'components-feedback-toaster/with-toast-trigger.children[0].onClick',
+    );
+    expect(entries.length).toBeGreaterThan(400);
+  });
+
+  it('every handler value in the corpus is a string expression, never an action object', () => {
+    const objectValued = handlers
+      .filter((h) => h.value !== null && typeof h.value === 'object')
+      .map((h) => `${h.where} = ${JSON.stringify(h.value)}`);
+    expect(objectValued).toEqual([]);
   });
 });

--- a/examples/schema-catalog/test/form-control-dom-leak-5632.test.tsx
+++ b/examples/schema-catalog/test/form-control-dom-leak-5632.test.tsx
@@ -116,7 +116,12 @@ const MEASURED_TYPES = [
  * early reads CLEAN below and has earned nothing.
  */
 const NODE_CENSUS: Readonly<Record<string, { rendered: number; noElement: number }>> = {
-  button: { rendered: 140, noElement: 0 },
+  // 140 -> 126 with objectui#6250: the fourteen `components-feedback-toast/*`
+  // and `components-feedback-sonner/*` demos were `type: 'button'` nodes
+  // carrying an action object on `onClick`, and are now the registered
+  // `toast` / `sonner` nodes their own renderers execute. Catalog-authored,
+  // no renderer touched — the case this table's header sanctions.
+  button: { rendered: 126, noElement: 0 },
   input: { rendered: 48, noElement: 0 },
   checkbox: { rendered: 12, noElement: 0 },
   switch: { rendered: 7, noElement: 0 },

--- a/examples/schema-catalog/test/toast-demo-dispatch-6250.test.tsx
+++ b/examples/schema-catalog/test/toast-demo-dispatch-6250.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6250 — the fourteen `components-feedback-toast/*` and
+ * `components-feedback-sonner/*` demos hung an action object off `onClick`:
+ *
+ *   { "type": "button", "label": "Destructive Toast", "variant": "destructive",
+ *     "onClick": { "action": "toast", "variant": "error", "title": "Error", … } }
+ *
+ * That shape is declared nowhere and executed nowhere, and the docs page prints
+ * `JSON.stringify(schema)` right beside the demo
+ * (`apps/site/app/components/InteractiveDemo.tsx`), so it is the literal
+ * copy-paste surface for every reader and every few-shot retriever.
+ *
+ * ## The half this file carries
+ *
+ * The DECLARED half — `ButtonSchema.onClick` is `z.function()`
+ * (`zod/form.zod.ts`), so all fourteen were a RED `safeParse` on the ENVELOPE —
+ * belongs to `component-fixture-declared-keys.test.ts`. This file carries the
+ * EXECUTED half, which no schema parse can see.
+ *
+ * `ActionRunner`'s runnable vocabulary is `script | url | modal | flow | api |
+ * form | navigation` (`builtinExecutors`, `core/src/actions/ActionRunner.ts`) —
+ * there is no `toast` and no `sonner` executor, and nothing anywhere reads a
+ * handler key as an action object. So `{ action: 'toast', … }` had no
+ * dispatcher on any tree.
+ *
+ * ⚠️ It was WORSE than inert, and that is measured below rather than asserted.
+ * `onClick` is a member of `SDUI_DOM_PASS_THROUGH_KEYS`
+ * (`core/src/utils/dom-props.ts`), so the action object was forwarded to the
+ * rendered `<button>`'s DOM listener slot, and React rejects it on click:
+ * `Expected 'onClick' listener to be a function, instead got a value of
+ * 'object' type.` The counter-probe at the end pins that, so "the old shape did
+ * nothing" is a reading taken in this harness rather than a claim inherited
+ * from the card.
+ *
+ * The registered spellings DO run: `ComponentRegistry.register('toast', …)` and
+ * `('sonner', …)` each render their own trigger button and call sonner's
+ * `toast()` from its handler. The correction is therefore to a spelling the
+ * engine already executes, and this file measures the execution.
+ *
+ * ## Why a real click against a real `<Toaster />`, and not `vi.mock('sonner')`
+ *
+ * A mock would prove the renderer CALLS something; it would not prove a reader
+ * who copies the JSON sees a toast. `sonner` is also not a dependency of this
+ * example package, so the mock specifier would resolve to a different module
+ * than the one `renderers/feedback/toast.tsx` imports — a mock that cannot
+ * fail. `Toaster` re-exported from `@object-ui/components` is the same module
+ * instance the renderers use.
+ *
+ * ## Why toasts are identified by NODE IDENTITY, not by their text
+ *
+ * sonner's toast store is MODULE-GLOBAL and replays to every newly mounted
+ * `<Toaster />`, so `cleanup()` alone does not clear it — see the `afterEach`
+ * below, which does. Even with the store cleared, identity beats text here:
+ * `basic-toast` and `success-toast` share the description "Your changes have
+ * been saved.", and a text query found it twice on the first run. Diffing
+ * `[data-sonner-toast]` nodes by identity is immune to that, and to any two
+ * fixtures ever authoring the same string.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@object-ui/components';
+import { Toaster, toast } from '@object-ui/components';
+import { SchemaRenderer } from '@object-ui/react';
+import { allExamples } from '../src/index.js';
+
+type Json = Record<string, unknown>;
+
+/** Every demo on the two pages this card covers, straight from the catalog. */
+const DEMOS = allExamples()
+  .filter(
+    (e) =>
+      e.meta.category === 'components-feedback-toast' ||
+      e.meta.category === 'components-feedback-sonner',
+  )
+  .map((e) => [e.id, e.schema as unknown as Json] as const);
+
+/**
+ * The strings a reader must see after clicking. `title` is `ToastSchema`'s
+ * heading, `message` is `SonnerSchema`'s, and both renderers pass `description`
+ * through as sonner's `description` option.
+ */
+function authoredToastText(schema: Json): string[] {
+  return [schema.title, schema.message, schema.description].filter(
+    (v): v is string => typeof v === 'string' && v.trim().length > 0,
+  );
+}
+
+const toastNodes = () => Array.from(document.querySelectorAll('[data-sonner-toast]'));
+
+function renderDemo(schema: unknown) {
+  return render(
+    <>
+      <SchemaRenderer schema={schema as never} />
+      <Toaster visibleToasts={20} />
+    </>,
+  );
+}
+
+/**
+ * sonner replays every ACTIVE toast to each newly mounted `<Toaster />`
+ * (`getActiveToasts().forEach(subscriber)` in its `Observer.subscribe`), and
+ * that replay lands in a mount effect — AFTER a snapshot taken right after
+ * `render()`. Measured before this hook existed: the last case in the file saw
+ * 14 foreign toast nodes appear around its click.
+ *
+ * `toast.dismiss()` with no id adds every active id to sonner's
+ * `dismissedToasts` set, which `getActiveToasts` filters on — so the next
+ * `<Toaster />` has nothing to replay. It is the same module instance the
+ * renderers import: `@object-ui/components` re-exports it through
+ * `ui/index.ts`'s `export * from './sonner'`.
+ */
+afterEach(() => {
+  toast.dismiss();
+  cleanup();
+});
+
+describe('objectui#6250 — every toast/sonner demo raises a real toast when clicked', () => {
+  it('the corpus is the fourteen entries this card covers — non-vacuity control', () => {
+    expect(DEMOS).toHaveLength(14);
+    expect(
+      DEMOS.filter(([, schema]) => schema.type === 'toast' || schema.type === 'sonner'),
+    ).toHaveLength(14);
+  });
+
+  it('no demo hangs a payload off a handler key any more — the retired shape', () => {
+    const violations = DEMOS.flatMap(([id, schema]) =>
+      Object.entries(schema)
+        .filter(([key]) => /^on[A-Z]/.test(key) || key === 'events')
+        .map(([key, value]) => `${id}.${key} = ${JSON.stringify(value)}`),
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it.each(DEMOS)('%s fires its toast on click', async (id, schema) => {
+    const texts = authoredToastText(schema);
+    expect(texts.length, `${id} authors no toast text to assert on`).toBeGreaterThan(0);
+
+    renderDemo(schema);
+    const before = new Set(toastNodes());
+
+    await userEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => {
+      const added = toastNodes().filter((n) => !before.has(n));
+      expect(added).toHaveLength(1);
+      for (const text of texts) {
+        expect(added[0].textContent ?? '').toContain(text);
+      }
+    });
+  });
+
+  it('counter-probe: the retired action-object shape raises no toast in this same harness', async () => {
+    const retired = {
+      type: 'button',
+      label: 'Destructive Toast',
+      variant: 'destructive',
+      onClick: {
+        action: 'toast',
+        variant: 'error',
+        title: 'Error',
+        description: 'Something went wrong.',
+      },
+    };
+
+    renderDemo(retired);
+    const before = new Set(toastNodes());
+    expect(screen.getByRole('button').textContent).toContain('Destructive Toast');
+
+    let thrown: unknown;
+    try {
+      await userEvent.click(screen.getByRole('button'));
+    } catch (error) {
+      thrown = error;
+    }
+
+    // The load-bearing half: no toast, whatever the click did.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(toastNodes().filter((n) => !before.has(n))).toHaveLength(0);
+
+    // The measured half: the payload reached the DOM listener slot through
+    // `SDUI_DOM_PASS_THROUGH_KEYS` and React refused it. Pinned as a literal so
+    // a change in that behaviour turns this red for review rather than quietly
+    // becoming a different fact.
+    expect(String((thrown as Error | undefined)?.message ?? '')).toContain(
+      "Expected `onClick` listener to be a function, instead got a value of `object` type.",
+    );
+  });
+});


### PR DESCRIPTION
Fixes #6250

All measurements below are on `076ed3b51`, branched from `origin/main` `7975f2d85`, with `packages/types` built fresh.

## Before → after, as a reading

The seven `components-feedback-toast/*` and seven `components-feedback-sonner/*` `SchemaExample` fixtures hung an action object off `onClick`. Parsing each fixture against the mirror its own `type` selects:

```
BEFORE   red=14 green=5     (5 green are the untouched components-feedback-toaster/* entries)
AFTER    red=0  green=19
```

Every one of the 14 was the same issue, on the ENVELOPE and not on any variant — `ButtonSchema.onClick` is `z.function()` (`zod/form.zod.ts:179`):

```json
{"code":"invalid_type","expected":"function","path":["onClick"],
 "message":"Invalid input: expected function, received object"}
```

## The census, run on the shape rather than on a literal

A grep for `"action": "toast"` under-counts by construction: the sonner half spells the same shape `{ action: 'sonner', … }`, and one fixture spells it `{ action: { label, onClick } }`. So the sweep walks every catalog entry at every depth for any key that reads as a handler slot (`/^on[A-Z]/` or `events`), bucketed by the value's kind:

```
BEFORE   object=14   string=2   array=0
AFTER    object=0    string=1   array=0
```

The 14 object-valued hits were exactly the two directories this card names — no others anywhere in the 430-entry corpus. Independent corroboration: `docs/audits/2026-08-zod-to-json-schema-fidelity.md:317` counted the same 14, from a different instrument, before this card was filed. That audit is a dated snapshot and is deliberately left as written.

The remaining `string=1` is `components-feedback-toaster/with-toast-trigger.json`'s `children[0].onClick: "toast(\"Hello from ObjectUI!\")"` — the handler-EXPRESSION dialect, which is #6182's open decision and a different shape. Untouched on purpose; a sweep that banned handler keys outright would be answering #6182 by accident.

## What actually runs, measured rather than picked for idiom

- `ActionRunner`'s runnable vocabulary is `script | url | modal | flow | api | form | navigation` (`builtinExecutors`, `core/src/actions/ActionRunner.ts:845`). No `toast`, no `sonner` — so `{ action: 'toast' }` had no dispatcher even if something had read it.
- Nothing reads a handler key as an action object anywhere in `packages/react`, `packages/core`, `packages/components`, `packages/layout`. Every `onClick` hit is a *call* of a function (`await action.onClick()`).
- `ComponentRegistry.register('toast', …)` and `('sonner', …)` DO run: each renders its own trigger button and calls sonner's `toast()` from its handler.
- Prior art check: **zero** `type: 'toast'` or `type: 'sonner'` fixtures existed anywhere in the corpus. Positive control — the same search finds 5 `type: 'toaster'` fixtures. The registered spelling had no demo at all; the demos used an unregistered one.

⚠️ **It was worse than inert, and this is a new reading.** `onClick` is a member of `SDUI_DOM_PASS_THROUGH_KEYS` (`core/src/utils/dom-props.ts:88`), so the action object reached the rendered button's DOM listener slot. Clicking it throws:

```
Expected `onClick` listener to be a function, instead got a value of `object` type.
```

That is pinned as a counter-probe, so "the old shape did nothing" is a measurement taken in this harness rather than a claim inherited from the card.

## The key rule the corrections follow

Only keys that the governing schema **declares** AND the renderer **reads**:

| | `toast` | `sonner` |
|---|---|---|
| declared ∧ read | `title`, `description`, `variant`, `duration`, `className` | `message`, `title`, `description`, `variant`, `buttonLabel`, `buttonVariant`, `className` |
| read, undeclared | `buttonLabel`, `buttonVariant` — **not used** | — |
| declared, unread | `action`, `onDismiss`, `position` — **not used** | — |

`SonnerSchema` declares `buttonLabel`/`buttonVariant`; `ToastSchema` does not, though its renderer reads both. That asymmetry is why the sonner demos carry per-demo trigger labels and the toast demos render the default `Show Toast`. Teaching them on `toast` would have re-introduced an undeclared key into the fixtures this card is cleaning — #6161 set the posture on these same pages ("a key a renderer genuinely reads would have been routed out as an undeclared capability rather than deleted"). Routed out as #6496.

## Two demos had no working spelling, and that is why they changed premise

The `toast` renderer has no in-toast action button and no dismiss callback; the `sonner` renderer has no promise form. So "With Action", "With Undo Action" and "Promise Toast" could not be corrected into working demos of what their headings promised. They now demonstrate the `info`, `warning`, `description` and `buttonVariant` surfaces that do run, and the pages follow. Curated titles for those five entries went into `src/catalog-meta.json` — the sidecar the generator only ever reads — so both the docs page and the standalone catalog gallery read correctly without renaming any fixture or changing any catalog id. `index.ts` is regenerated by `scripts/regenerate-catalog-index.py`; `--check` was green on the untouched tree first, so the 15/10 diff there is only those five entries.

The missing capability is filed as #6496, not built here.

## Overlap with an open card — needs your call, not mine

**#6347 is still open and this PR lands two of its four items.** It independently measured that `sonner.mdx` documents `duration` (which `SonnerSchema` does not declare and the renderer does not pass) and that its "With Action" section renders a fixture that is a `button`, not a sonner node. Both are on a page inside this card's declared file face, both are the same defect class, and both had their correct form already pinned by `SonnerSchema` plus the renderer — so they are corrected here rather than left contradicting the fixtures beside them. The `action` row went with them, on the same evidence.

**#6347's `button-group.mdx` half — `value`, `selectionMode`, and the whole Selection Mode section — is untouched by this PR**, and that card should stay open for it. `content/docs/components/basic/button-group.mdx` is not in this diff.

## Beyond the declared file face — declared, not slipped in

- `examples/schema-catalog/test/form-control-dom-leak-5632.test.tsx` — `NODE_CENSUS.button` 140 → 126. That is an exact census, not a shrink-only baseline, and its own header sanctions this case: "These move when the CATALOG is authored, not when a renderer changes." The gate's diff moved exactly one number, by exactly 14 — itself a corroboration of the census above. No renderer was touched.
- `examples/schema-catalog/src/catalog-meta.json` and the regenerated `src/index.ts` — described above.
- `content/docs/components/form/button.mdx` was in the dispatched face and is **not** in this diff: the shape census found no handler-object payload in `components-form-button/*`, and line 64's `onClick?: () => void | Promise<void>` is accurate to `ButtonSchema`. A measured non-edit.

## Clause ② — public surface, following the re-export chain

**No public surface is touched.** Checked three ways, none of them a symbol-name grep:

1. **No file under `packages/` is in this diff at all** — so no published package's entry, and no chain from one, can reach a changed file.
2. The one changed file that IS a package entry (`examples/schema-catalog/src/index.ts`) has an identical export-statement set before and after — same five statements, same signatures, only line numbers shifted by the five added `tags` entries. It contains no `export *`; its one re-export is `export type { Example, ExampleMeta } from './types.js'`, and `types.ts` is untouched.
3. Following the chain outward: `@object-ui/example-schema-catalog` is `private: true` and matched by the changesets `ignore` pattern `@object-ui/example-*`. Its only consumer in the workspace is `@object-ui/site`, which is itself in `ignore`. The chain terminates at an app, never at a published package.

Corroborated by `check:readme-exports` and `check:entry-guard`, both green.

## Tests

Two pins, one per half of the defect.

- `examples/schema-catalog/test/toast-demo-dispatch-6250.test.tsx` (new) — renders each of the 14 demos against a real `<Toaster />`, clicks the trigger, and asserts the authored strings land in a toast node. Toasts are identified by **node identity**, not text: sonner's store is module-global and replays to every newly mounted `<Toaster />`, which was measured — `basic-toast` and `success-toast` share a description and a text query found it twice. No `vi.mock('sonner')`: sonner is not a dependency of this package, so the specifier would resolve to a different module than the renderer imports — a mock that cannot fail.
- `examples/schema-catalog/test/component-fixture-declared-keys.test.ts` — the #6157 pin asserted `fixture.type === 'button'` and destructured `fixture.onClick`, i.e. it pinned the exact branch this card removes. Measured red first (6 failed / 10 passed), then **replaced** rather than reworded: what #6157 established — the toast variant value is a declared `ToastSchema` member, with `destructive` refused — is carried forward against the top-level `variant` these nodes now declare, counter-probe intact. A corpus-wide census assertion was added, with a positive control that the walker really descends (it names the one nested handler key the corpus still carries).

### Reverse verification — predicted RED, observed RED

The fix was committed first, then one fixture (`components-feedback-toast/destructive.json`) was reverted to the retired shape. The mutation was proved on disk before any reading — `grep -c '"action": "toast"'` = 1, `grep -c '"type": "toast"'` = 0, and `git hash-object` differing from the HEAD blob — and restored through an `EXIT INT TERM` trap using an absolute path.

Reverting **one** fixture turned **7** assertions red across both files:

```
toast-demo-dispatch-6250.test.tsx    3 failed | 14 passed
  × the corpus is the fourteen entries this card covers — non-vacuity control
  × no demo hangs a payload off a handler key any more — the retired shape
  × components-feedback-toast/destructive fires its toast on click
component-fixture-declared-keys.test.ts   4 failed | 15 passed
  × …/destructive is a `toast` node that parses green under ToastSchema
  × …/destructive declares a variant ToastSchema knows
  × …/destructive counter-probe: the pre-#6157 value is still refused
  × every handler value in the corpus is a string expression, never an action object
```

Restore proved byte-identical (`git hash-object` == `git rev-parse HEAD:<path>` = `b4a37b1c1`, both non-empty; `git diff HEAD` empty), and both files returned to green — 36 passed (36).

## Gates — all at `076ed3b51`, each quoted from its own verdict line

Exit codes captured before any pipe.

| gate | exit | verdict |
|---|---|---|
| `check:doc-types` | 0 | `✅ Every documented component type is registered.` (184 docs, 1064 blocks, 895 `type` literals) |
| `check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` — `Semantic phase: 267 of 267 block(s) judged, 0 failed.` |
| `check:doc-fences` | 0 | `✅ check:doc-fences — every TypeScript block in 223 document(s) is fenced ts/tsx/typescript…` |
| `check:docs-route-closure` | 0 | `✅ gauge: 1349 modules crawled from 148 route roots (144 MDX)… 18 of 46 workspace packages stay OUTSIDE the closure` |
| `check-doc-links` | 0 | `Links are valid across 17 scan roots.` |
| `check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 5363 tracked text file(s); skipped 85 binary).` |
| `check:entry-guard` | 0 | `✓ check:entry-guard: 50 scripts/ file(s) — no entry guard outside the baseline…` |
| `check:readme-exports` | 0 | `✅ check-readme-exports: OK (43 README(s)… 378 self-imports judged (378 real, 0 wrong-path, 0 fabricated))` |
| `check:vi-mock-specifiers` | 0 | `✅ check-vi-mock-specifiers: OK (3816 tracked source file(s)…)` |
| `check:phantom-deps` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `regenerate-catalog-index.py --check` | 0 | `examples/schema-catalog/src/index.ts is up to date (430 entries).` |
| `check-changeset-presence` | 0 | `✅ No source of a released package changed in this range, so no changeset is owed.` (1 changeset added anyway, empty frontmatter — the repo's first-class "declares no release") |
| `check-changeset-no-major` | 0 | `✅ No changeset declares a `major` bump.` |
| `check-changeset-fixed` | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `vitest examples/schema-catalog/ scripts/__tests__/catalog-index-regenerable-4633.test.ts` | 0 | `Test Files 15 passed (15) · Tests 1824 passed (1824)` |
| `pnpm --filter @object-ui/example-schema-catalog type-check` | 0 | script name echoed, `tsc --noEmit && tsc -p tsconfig.test.json`, no output |

**Two non-zero exits that were NOT MEASURED, excluded from the table and named here:** `check:readme-exports` first exited 1 with *"3 self-import(s) could not be judged — `@object-ui/plugin-ai`'s type entry `./dist/index.d.ts` is not on disk — run `pnpm build` first"*, and the catalog `type-check` first exited 2 with two `TS2882`s naming `@object-ui/plugin-gantt` and `@object-ui/plugin-map` in a file this PR does not touch. Both were missing `dist/`, not defects; both went green after building those packages. Neither is counted as a failure.

### Lint — a measured narrowing, not a skipped run

Repo-wide lint is CI's run. Locally the narrowing is measured, from eslint's own config rather than from a guess about which files count:

1. **Population source.** Asked eslint directly, per file. `.mdx`, `.json` and `.md` come back `File ignored because no matching configuration was supplied` — 16 of the 19 changed files are **outside** the configured population, so a green on them would have been a non-reading, not a pass.
2. **File count, from `--format json`.** The three changed files that ARE in the population (`.ts` / `.tsx`) report 0 errors, 0 warnings. The bounding package's whole population is 17 files, all genuinely linted: 0 errors, 1 warning — `'ExampleMeta' is defined but never used` in the generated `src/index.ts`, present verbatim on `7975f2d85` and on a line this diff does not touch. Left alone; the generator owns that file.
3. **Immutability of untouched files.** `eslint.config.js` configures no type-aware linting — no `projectService`, no `parserOptions.project`, no `project:` anywhere in it — so no rule's verdict on a file outside this diff can depend on this diff.

## Filed in passing

- #6494 — the `toaster` demos and page teach a `provider` key `ToasterSchema` does not declare and the renderer does not read. Two "provider" demos render byte-identically. Same defect class, different shape, and the page makes a capability claim, so it is a contract question rather than a typo.
- #6496 — `ToastSchema` and its renderer disagree in **both** directions: `buttonLabel`/`buttonVariant` read but undeclared, `action`/`onDismiss` declared but unread. This is what constrained the two decisions above.
- #6497 — the action-object dialect **is already declared and exported**: `EventableSchema.onClick?: UIEventHandler | string` (`api-types.ts:278`), public in `dist/index.d.ts`, with no zod mirror, no component schema extending it, and no reader. It refines this card's "declared nowhere" and is a direct input to the #6182 / #6124 decision — the declaration half is not a blank page.

All three unassigned, `finding` label only, no grading.

## The fence — held

⛔ No action union declared on `ButtonSchema.onClick`. ⛔ No dispatcher built. ⛔ No `toast` or `sonner` executor added to `ActionRunner`. ⛔ No `packages/` file changed at all. #6249 is out of scope here and remains open. The maintainer's route is not foreclosed by anything in this diff — and #6497 is new evidence for it.

Draft, no auto-merge: the PM lands this.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_

---
_Generated by [Claude Code](https://claude.ai/code)_