### PR TITLE
fix(i18n): zh `console.breadcrumb.reports` reads 报表, per the maintainer ruling

### DIFF
--- a/.changeset/6166-zh-breadcrumb-reports.md
+++ b/.changeset/6166-zh-breadcrumb-reports.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/i18n': patch
+---
+
+The zh pack's `console.breadcrumb.reports` renders 报表, the noun the rest of the pack
+already uses for the report feature (objectui#6166).
+
+**The authority for this edit is the maintainer ruling of 2026-08-25, not an occurrence
+count.** The card was filed explicitly as a native-speaker call and explicitly forbade
+resolving it by normalising to the majority: 报表 (a tabular/data report) and 报告 (a
+written/narrative report) are not interchangeable, so a pack that spells one key
+differently from its siblings is evidence of a majority and never, on its own, evidence of
+a mistake. The maintainer ruled that no deliberate narrative-report distinction was
+intended here and that the breadcrumb names the same report feature the rest of the pack
+calls 报表.
+
+The render context corroborates the ruling and closes the confidence gap triage recorded
+when it declined to decide this itself. `console.breadcrumb.reports` labels the
+`routeType === 'report'` **list** route in app-shell's `AppHeader` — a structural sibling
+of the `dashboards`, `pages` and `system` segments beside it — and drilling through it
+appends a metadata report definition, the same feature named by
+`console.commandPalette.reports`, `console.nav.navReport`, `search.typeReports`,
+`search.badgeReport` and `search.reportNotFound`. Nothing narrative renders beneath it.
+
+A comment at the key records that this was **ruled** rather than counted, and states the
+报表/报告 distinction it was ruled against, so the next reader measuring pack consistency
+neither re-files it nor quietly restores 报告 after reading the render context and
+disagreeing. That comment is half of the deliverable; the value change alone would leave
+the decision unrecorded, which is the failure mode the card was most concerned about.
+
+**Scope: one key, one pack.** This is not a licence to normalise vocabulary across the ten
+packs — the card names that hazard explicitly and says it would need its own ruling, and
+this ruling grants nothing beyond the single key it names. No `en` value changes, so no
+other pack is asked to follow, and no other pack was touched.

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1449,8 +1449,8 @@ const zh = {
       pages: '页面',
       // objectui#6166 — 报表 here is a maintainer RULING (2026-08-25), not a
       // majority count. 报表 (tabular/data report) and 报告 (written/narrative
-      // report) are NOT interchangeable, so this key holding 报告 against its
-      // twelve siblings was read as evidence of a majority and never, on its
+      // report) are NOT interchangeable, so this key holding 报告 against the
+      // rest of the pack was read as evidence of a majority and never, on its
       // own, as evidence of a mistake; the call was made on what renders. This
       // segment labels the `routeType === 'report'` LIST route (app-shell
       // AppHeader) — a structural sibling of dashboards/pages that drills into

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1447,7 +1447,19 @@ const zh = {
     breadcrumb: {
       dashboards: '仪表盘',
       pages: '页面',
-      reports: '报告',
+      // objectui#6166 — 报表 here is a maintainer RULING (2026-08-25), not a
+      // majority count. 报表 (tabular/data report) and 报告 (written/narrative
+      // report) are NOT interchangeable, so this key holding 报告 against its
+      // twelve siblings was read as evidence of a majority and never, on its
+      // own, as evidence of a mistake; the call was made on what renders. This
+      // segment labels the `routeType === 'report'` LIST route (app-shell
+      // AppHeader) — a structural sibling of dashboards/pages that drills into
+      // metadata report definitions, i.e. the same feature that
+      // `console.commandPalette.reports`, `console.nav.navReport` and
+      // `search.badgeReport` already call 报表. Nothing narrative renders
+      // beneath it. Don't re-file this as a pack inconsistency, and don't
+      // restore 报告 without a new ruling.
+      reports: '报表',
       system: '系统',
     },
     nav: {


### PR DESCRIPTION
Fixes #6166

The zh pack's `console.breadcrumb.reports` renders 报表, the noun the rest of the pack already uses for the report feature, plus a comment at the key recording that this was **ruled** rather than counted.

## The authority is the ruling, not the count

The card was filed explicitly as a native-speaker call and explicitly forbade resolving it by normalising to the majority. That framing is correct and this PR keeps it: 报表 (a tabular/data report) and 报告 (a written/narrative report) are not interchangeable, so one key spelled differently from its siblings is evidence of a **majority** and never, on its own, evidence of a **mistake**.

What licenses the edit is the maintainer ruling of 2026-08-25 (verbatim: 「6132 6166 同意」), recorded by triage as: `console.breadcrumb.reports` changes 报告 → 报表, the breadcrumb names the same report feature the rest of the pack calls 报表, and no deliberate narrative-report distinction was intended.

⛔ Deliberately **not** a reason used anywhere in this PR, its commits, its changeset, or the key comment: the occurrence split. A reader who takes the count as the reason would draw the wrong conclusion about what is safe to do to the other nine packs.

## Render context — the confidence gap triage recorded is now closed

Triage declined to decide this itself, noting it had not read the page the breadcrumb points at. It has now been read, and it corroborates the ruling on the merits rather than by arithmetic. `console.breadcrumb.reports` labels the `routeType === 'report'` **list** route in `packages/app-shell/src/layout/AppHeader.tsx` — a structural sibling of the `dashboards`, `pages` and `system` segments constructed beside it — and drilling through it appends a metadata **report definition** (`metadataReports` → `reportLabel`). It is the same feature named by `console.commandPalette.reports`, `console.nav.navReport`, `search.typeReports`, `search.badgeReport` and `search.reportNotFound`, all of which already read 报表. Nothing narrative renders beneath it, so outcome 2 on the card (a genuine contextual split worth preserving) does not hold here.

## The key comment is half the deliverable

The value change alone would leave the decision unrecorded — the failure mode the card was most worried about, in both directions: a future agent measuring pack consistency re-files it, or one who reads the render context and disagrees quietly restores 报告. The comment therefore states the 报表/报告 distinction explicitly and says it was ruled against here, so it reads as a decision that considered the difference rather than a sweep that failed to notice it.

**The comment deliberately carries no occurrence count** (fixed in `f23a70d45` after review; the first draft said "against its twelve siblings"). Three reasons, the first being the real one:

1. The comment's own thesis is that the count is not the argument. Citing a number in the sentence that says the number is not the reason undercuts that sentence and invites exactly the majority-counting reflex the comment exists to stop.
2. The figure was stale on arrival and is still moving — 12 at filing, 13 on `main`, 14 once this lands. A permanent comment that hardcodes a moving number is guaranteed to read stale, and a reader who greps a different one may conclude the comment predates something and discount the ruling it records.
3. "Siblings" was imprecise in a second way (see the population note below): no single number is a count of siblings in the sense that sentence used. Dropping it resolves that without having to define the population.

## Reproduction — the numbers moved, the ruling did not

The card's own command on today's `main` (`9ea4cdee3`) gives **13** occurrences of 报表 and 1 of 报告, not the 12 and 1 recorded when the card was filed:

```
$ rg -n '报表|报告' packages/i18n/src/locales/zh.ts
1450:      reports: '报告',        <- console.breadcrumb.reports (the outlier)
1556:      reports: '报表',        <- console.commandPalette.reports
```

The drift is fully accounted for: commit `b08b7eba9` (2026-08-24, *"fix(i18n): define home.recentApps.itemType.report and .metadata in all …"*) landed after the card was filed and added the thirteenth — `home.recentApps.itemType.report: '报表'`, the very key the referenced work (refs #6023) was translating when it took the original measurement. The outlier was unchanged at one.

**Two populations, kept apart.** After this PR the pack contains **14 occurrences of the string 报表** as a value, of which only **7 are keys whose value is exactly `'报表'`** — `nav.navReport`, `nav.navTypeReport`, `console.breadcrumb.reports` (this PR), `console.commandPalette.reports`, `home.recentApps.itemType.report`, `search.typeReports`, `search.badgeReport`. The other 7 are **prose strings that contain the word**: the two matrix-report errors, `panelTitle: '编辑报表'`, the search placeholder and its aria-label, `reportNotFound` and `reportNotFoundDescription`. The occurrence count and the sibling-key count are different measurements and neither is the reason for this change; they are recorded here only so the next reader is not misled by a `rg` total. 报告 as a value is now **0** — the string survives in the file solely inside the new comment, which is the recorded reason.

## Scope held: one key, one pack

No other pack was touched and no `en` value changes, so no pack is asked to follow. A read of all ten packs found every other pack already agrees between `console.breadcrumb.reports` and `console.commandPalette.reports`, so zh was the sole splitter on this axis and there is no sibling inconsistency to file. The one other 报告 in the repo — `packages/app-shell/src/views/metadata-admin/i18n.ts:3767`, `逐层报告各层的贡献` — is the **verb** "to report", unrelated to this noun, and correctly left alone.

**No i18n pin was added.** It was optional and not ruled; the ruling's transition line scopes this card to "one-line + key comment", and a pin is a new maintained artifact beyond that size. It was considered and declined deliberately, recorded here so the next reader knows it was a choice: the guard against a silent revert is the comment sitting at the key, which any edit to that value passes through in review. A general cross-pack vocabulary gate is out of scope in any case — that is the banned sweep wearing a gate's clothes, and the card says it would need its own ruling.

## Verification

Re-run in full on the final commit `f23a70d45` (`git rev-parse --short HEAD` from that run), each gate quoted from its own verdict line rather than a piped `$?`:

| Gate | Result |
|---|---|
| `pnpm exec vitest run packages/i18n/ --maxWorkers=2` | `Test Files 56 passed (56)` / `Tests 914 passed (914)` — vitest reported `RUN v4.1.10 /home/user/objectui-6166`, i.e. root resolved to the repo root, so neither AGENTS.md silent-green trap applies |
| `pnpm --filter @object-ui/i18n run type-check` | clean, script name echoed (`> @object-ui/i18n@17.6.0 type-check`) so this was not a zero-match no-op |
| `pnpm --filter @object-ui/i18n run lint` | 0 errors; `zh.ts` itself 0 errors / 0 warnings |
| `check:i18n-keys` | exit 0 — every call-site key resolves against the en pack (2856 keys, 2562 call sites compared) |
| `check:i18n-drift` | `No en value changed in this range.` |
| `check-changeset-presence` | `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `No changeset declares a major bump.` |

`all-locales-key-parity` and `en-zh-key-parity` are inside the vitest run and are green — this change moves a value, not a key set. The dep closure was built first (`pnpm --workspace-concurrency=2 --filter "@object-ui/i18n^..." build`); without it `type-check` fails `TS6305` purely because a fresh worktree has no `packages/core/dist`, which is not a measurement of this change.

**Declared narrowing:** repo-wide `turbo run lint` and the other packages' test jobs were not run locally; CI runs the farm regardless. The narrowing is measured, not assumed: the linted population is read from eslint's own config resolution (82 files, `zh.ts` confirmed among them) via `--format json`, and `eslint.config.js` enables **no** type-aware linting (no `projectService`, no `parserOptions.project`), so a one-file value edit cannot move the verdict of any untouched file in any package. Every heavy run went through the shared verify lock (`VERDICT command-exit 0`).

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_