### PR TITLE
test(plugin-detail): pin the synthesized `fieldGroups` detail page's section headings

### DIFF
--- a/.changeset/6241-fieldgroups-section-heading-pin.md
+++ b/.changeset/6241-fieldgroups-section-heading-pin.md
@@ -1,0 +1,21 @@
+---
+---
+
+Tests only, no release: pin the synth → renderer seam for the default
+`fieldGroups` record detail page (objectui#6241).
+
+`buildDefaultPageSchema` synthesizes one detail section per declared
+`fieldGroups` entry and app-shell's `RecordDetailView` renders that output as
+the default record page for every object declaring `fieldGroups` with no
+assigned page — but nothing asserted end-to-end that those synthesized sections
+render their headings. The synthesizer's own suite asserts its return value and
+never renders; the `record:details` renderer suites render hand-authored
+section fixtures and never consume synthesizer output. Measured on `9ea4cdee3`:
+with the consumer's read of the emitted heading removed, all 109 files / 1031
+tests of `packages/plugin-detail/` still passed.
+
+The new file renders the real `buildDefaultPageSchema` output through the real
+registry into the DOM and asserts the declared heading TEXT, its declared
+order, and that a group's internal key never stands in for its label. It
+asserts no key spelling, so it stays independent of the `title` / `label`
+convergence open in objectui#6190 / objectstack#11661.

--- a/packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx
+++ b/packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The default `fieldGroups` detail page renders its section HEADINGS — the
+ * synth → renderer seam (objectui#6241).
+ *
+ * ## The gap this closes
+ *
+ * `buildDefaultPageSchema` synthesizes one detail section per declared
+ * `fieldGroups` entry, and app-shell's `RecordDetailView` renders that output
+ * as the default record page for every object that declares `fieldGroups` and
+ * has no assigned page — i.e. every tenant that never authored one. Two suites
+ * already sit on either side of that seam and NEITHER spans it:
+ *
+ * - `synth/__tests__/buildDefaultPageSchema.test.ts` asserts the synthesizer's
+ *   RETURN VALUE. It never renders, so it cannot see the heading reaching (or
+ *   failing to reach) the screen.
+ * - the `record:details` renderer suites (e.g. `recordDetailsBodySource`)
+ *   render HAND-AUTHORED section fixtures. They never consume synthesizer
+ *   output, so they stay green while the synthesized page breaks.
+ *
+ * Measured on `9ea4cdee3`: with the consumer's read of the heading the
+ * synthesizer emits removed, the whole `packages/plugin-detail/` suite —
+ * 109 files / 1031 tests — still passed. The break is tenant-visible on a
+ * default page path and produced zero test signal. This file is the pin that
+ * makes it produce one; it has been observed RED in exactly that state (and
+ * also with the PRODUCER's heading emptied instead, which is the same seam
+ * broken from the other end).
+ *
+ * ## ⛔ What this file must never assert
+ *
+ * NOT the synthesizer's return value, and NOT a key spelling. objectui#6190 /
+ * objectstack#11661 are deciding whether the section heading slot converges on
+ * one spelling; this pin is deliberately INDEPENDENT of that outcome and must
+ * stay so. So the expectation is the **rendered heading TEXT** — the label the
+ * author declared on `fieldGroups[].label` — which is invariant under whichever
+ * way that convergence rules. Nothing below may read `sections[i].title` or
+ * `sections[i].label`; a future edit that reaches for either has re-encoded the
+ * open question into this pin and should be rejected.
+ *
+ * The failure mode is worth naming precisely, because it is NOT a blank: when
+ * the declared label stops reaching the renderer, the heading falls back to the
+ * group's internal KEY (`_sections.<key>.label` misses, and the i18n fallback
+ * is the key itself). A tenant sees `basic_info` where `Basic Information`
+ * belongs — which is why the key assertion below is part of the pin.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, within } from '@testing-library/react';
+import { RecordContextProvider, SchemaRenderer } from '@object-ui/react';
+// Module-scope side-effect imports: the registry must hold the page/record
+// renderers and the field widgets they render into BEFORE the first render
+// (AGENTS.md 测试纪律 — a lazily resolved registry entry races the assertion).
+import '@object-ui/components';
+import '@object-ui/fields';
+import '../index';
+import { buildDefaultPageSchema } from '../synth/buildDefaultPageSchema';
+
+const OBJECT_NAME = 'crm_account';
+
+/** What the AUTHOR declared — the only source of the expected heading text. */
+const DECLARED_GROUPS = [
+  { key: 'basic_info', label: 'Basic Information' },
+  { key: 'financials', label: 'Financial Details' },
+];
+
+/**
+ * An object declaring `fieldGroups` and NOTHING that would route around the
+ * synthesizer: no page assignment (the caller below never provides one) and no
+ * `sections` override.
+ *
+ * `highlightFields` is declared on purpose. Left undeclared, the synthesizer's
+ * heuristic strip claims up to four fields and hands them to `record:details`
+ * as `hideFields`, which would empty the very sections this file measures. One
+ * declared, UNGROUPED highlight keeps the strip populated and every grouped
+ * field in the body where it belongs.
+ */
+const objectDef = {
+  name: OBJECT_NAME,
+  label: 'Account',
+  highlightFields: ['website'],
+  fieldGroups: DECLARED_GROUPS,
+  fields: {
+    name: { label: 'Account Name', type: 'text' },
+    website: { label: 'Website', type: 'url' },
+    industry: { label: 'Industry', type: 'text', group: 'basic_info' },
+    phone: { label: 'Phone', type: 'text', group: 'basic_info' },
+    credit_terms: { label: 'Credit Terms', type: 'text', group: 'financials' },
+  },
+};
+
+const RECORD = {
+  id: 'A1',
+  name: 'Acme Corporation',
+  website: 'https://acme.test',
+  industry: 'Manufacturing',
+  phone: '555-0100',
+  credit_terms: 'Net 30',
+};
+
+/** Collect every node of `type` in a page schema tree. */
+function collectNodes(node: any, type: string, out: any[] = []): any[] {
+  if (!node || typeof node !== 'object') return out;
+  if (Array.isArray(node)) {
+    for (const entry of node) collectNodes(entry, type, out);
+    return out;
+  }
+  if (node.type === type) out.push(node);
+  for (const value of Object.values(node)) collectNodes(value, type, out);
+  return out;
+}
+
+/**
+ * Render the default record detail page the way a tenant with no assigned page
+ * gets it: the REAL `buildDefaultPageSchema` output, dispatched through the
+ * REAL registry, inside the record context app-shell's `RecordDetailView`
+ * provides. Returns the rendered `record:details` block so assertions are
+ * scoped to the synthesized body rather than to page chrome that happens to
+ * carry similar text.
+ */
+function renderDefaultPage(): HTMLElement {
+  const page = buildDefaultPageSchema(objectDef as any);
+
+  // Harness guard, not the pin: if the default page ever stops carrying a
+  // single `record:details` node, every assertion below would go red for a
+  // reason that has nothing to do with headings. Fail here instead, loudly.
+  expect(
+    collectNodes(page, 'record:details'),
+    'the default page must carry exactly one `record:details` node',
+  ).toHaveLength(1);
+
+  const { container } = render(
+    <RecordContextProvider
+      objectName={OBJECT_NAME}
+      recordId="A1"
+      data={RECORD}
+      objectSchema={objectDef}
+    >
+      <SchemaRenderer schema={page} />
+    </RecordContextProvider>,
+  );
+
+  const block = container.querySelector<HTMLElement>('[data-obj-type="record:details"]');
+  expect(block, 'the synthesized `record:details` node must render its own block').not.toBeNull();
+  return block as HTMLElement;
+}
+
+afterEach(cleanup);
+
+describe('default `fieldGroups` detail page — synthesized section headings reach the DOM (#6241)', () => {
+  it('renders the declared heading text of every group inside the details block', () => {
+    const block = renderDefaultPage();
+
+    for (const group of DECLARED_GROUPS) {
+      expect(within(block).getByText(group.label)).toBeInTheDocument();
+    }
+  });
+
+  it('reads in declared order, each heading followed by its own group members', () => {
+    const block = renderDefaultPage();
+
+    // Heading, then that group's field labels, then the next heading. Asserted
+    // on rendered text order, so it pins BOTH that each heading is on screen
+    // and that it heads the group it was declared for — a heading rendered
+    // without its members, or the groups collapsed into one, breaks this.
+    const expectedReadingOrder = [
+      'Basic Information', 'Industry', 'Phone',
+      'Financial Details', 'Credit Terms',
+    ];
+    const text = block.textContent ?? '';
+    const positions = expectedReadingOrder.map((needle) => text.indexOf(needle));
+
+    expect(
+      expectedReadingOrder.filter((_, i) => positions[i] < 0),
+      'every heading and group member must be on screen',
+    ).toEqual([]);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it('never surfaces a group\'s internal key in place of its declared heading', () => {
+    // The observed shape of the break, not a hypothetical one: when the
+    // declared label stops reaching the renderer, the i18n section-label
+    // lookup falls back to the group key and the tenant reads `basic_info`
+    // as a section heading.
+    const block = renderDefaultPage();
+
+    for (const group of DECLARED_GROUPS) {
+      expect(within(block).queryByText(group.key)).not.toBeInTheDocument();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6241

Tests only. One new file plus an empty-frontmatter changeset (this repo's explicit "no release" declaration); no source changed.

## The gap

`buildDefaultPageSchema` synthesizes one detail section per declared `fieldGroups` entry, and app-shell's `RecordDetailView` renders that output as the default record detail page for every object declaring `fieldGroups` with no assigned page. Nothing asserted end-to-end that those synthesized sections render their headings — the two suites either side of the seam each cover one half:

- `synth/__tests__/buildDefaultPageSchema.test.ts` asserts the synthesizer's **return value** and never renders.
- the `record:details` renderer suites render **hand-authored** section fixtures and never consume synthesizer output.

## The instrument

`packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx` renders the **real** `buildDefaultPageSchema` output for an object declaring `fieldGroups` with no assigned page and no `sections` override, dispatched through the **real** registry inside the record context `RecordDetailView` provides, and asserts inside the rendered `record:details` block:

1. every declared group's heading **text** is in the DOM;
2. the page reads in declared order, each heading followed by its own group's members;
3. a group's internal key never stands in for its declared heading.

It asserts no key spelling. Nothing in it reads `sections[i].title` or `sections[i].label`, so it is invariant under whichever way the heading-slot convergence open in objectui#6190 / objectstack#11661 rules — that invariance is measured below, not merely intended.

## Reverse verification (all runs at `403f37150` unless noted)

**Baseline, before the pin existed** — `pnpm exec vitest run packages/plugin-detail/ --maxWorkers=2` at `9ea4cdee3`: `Test Files 109 passed (109)` / `Tests 1031 passed (1031)`. The card reports 104 / 979; counted on today's `main` it is **109 / 1031**. The finding stands, the numbers had drifted.

**Ablation A — the card's own measurement, the consumer stops reading the emitted heading.** `record-details.tsx:190` `s.title ?? s.label` → `s.label`, confirmed on disk (removed-text hits 0, injected-text hits 1, blob `83f46137` → `1aa63f06`). Whole-package run in that state:

```
Test Files  1 failed | 109 passed (110)
     Tests  3 failed | 1031 passed (1034)
```

The 109 files / 1031 tests that existed before this PR **all still pass** with the heading broken; the only red is this PR's file, all 3 of its tests. (The `--exclude` flag passed to that run did not take effect — 110 files ran. The decomposition above is exact, and the pin was also run alone in the same state: `Test Files 1 failed (1)` / `Tests 3 failed (3)`.)

**What the break actually looks like — a correction to the card.** It is not a blank heading. With the declared label no longer reaching the renderer, the section-label i18n lookup falls back to the group's internal key, and the assertion that catches it reads `expected document not to contain element, found` — followed by the rendered heading span, whose text is `basic_info`. A tenant reads `basic_info` where `Basic Information` belongs. Still tenant-visible, still zero signal from the existing suite.

**Ablation B — the invariance this card required.** Both ends moved to the declared `label` slot at once (synth emits `label`, renderer reads only `label`), both mutations confirmed on disk. The pin stays **green** (`Tests 3 passed (3)`) — it asserts rendered text, not a spelling. For contrast, in that same state the return-value suite goes red (`Tests 3 failed | 90 passed (93)`), because it does encode the spelling. This PR takes no position on that convergence and does not touch objectui#6190's proposed edit.

**Restore proven by hash, not by an exit code.** Both mutated paths back to their `HEAD` blobs — `record-details.tsx` `83f46137cf2d60a7a790cc9acf5a140bf10cee02`, `buildDefaultPageSchema.ts` `83721a3c827d64cb663ccd4ff78170570f4967aa` — for each path, `git hash-object PATH` equal to `git rev-parse HEAD:PATH`, with `git diff HEAD` empty. Both ablation scripts carried a `trap … EXIT INT TERM` restore.

**Green after restore** — `pnpm exec vitest run packages/plugin-detail/ --maxWorkers=2` at `403f37150`: `Test Files 110 passed (110)` / `Tests 1034 passed (1034)` — the baseline plus this file's 3.

## Other gates run locally (`403f37150`)

- `eslint` on the new file: `✖ 4 problems (0 errors, 4 warnings)` — the warnings are `no-explicit-any` on the schema-tree walker; CI deliberately sets no `--max-warnings`.
- `node scripts/check-control-bytes.mjs`: `✅ check-control-bytes: OK (scanned 5371 tracked text file(s); skipped 85 binary).`
- `node scripts/check-type-check-coverage.mjs`: `✅ test type-check coverage: 41/41 packages compile their tests, 0 declared debt (0 errors outstanding)…`
- `node scripts/check-lint-coverage.mjs`: `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).`
- `node scripts/check-changeset-presence.mjs`: `✅ No source of a released package changed in this range, so no changeset is owed.` (the empty-frontmatter changeset is added anyway, as the explicit no-release declaration.)
- **Not measured locally:** `pnpm --filter @object-ui/plugin-detail type-check`. `tsconfig.test.json` deliberately drops the source-tree `paths` so `@object-ui/*` resolves through each workspace dependency's built `.d.ts`, and this worktree has no `dist` — running it there would report missing modules, which is not a reading of this file. Vitest resolves through the root alias table, so the suites above did not need the build. CI's `type-check` job runs it against a built closure. The file was kept inside the shapes the sibling suites in the same tsconfig program already compile.

App-shell was read, never edited — no overlap with the `MetadataService.ts` work in flight on #6480.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_