### PR TITLE
test(examples): the catalog mirror declares the `select` options the host declares

### DIFF
--- a/examples/schema-catalog/test/catalog-gallery-render.test.tsx
+++ b/examples/schema-catalog/test/catalog-gallery-render.test.tsx
@@ -304,6 +304,13 @@ const AUTHORED_TEXT_EXEMPT: Record<string, string> = {};
  * mirror reproduces is the host's SURFACE and its rows; the query semantics
  * ($search / $orderby / windowing) are the host's, and the parity case pins the
  * method names rather than re-deriving them here.
+ *
+ * objectui#6317 widened that guard where it had to be widened. Pinning method
+ * NAMES left the field declarations unwatched, and they drifted: the host
+ * declared `options` on `role` / `status` in `4b0b12630` and this schema did
+ * not follow for 330 commits, with every case in this file green throughout.
+ * The `USERS_SCHEMA` below is now compared to the host's WHOLE, options
+ * included — see the #6317 cases at the end of this file.
  */
 const USERS_ROWS = [
   { id: '1', name: 'Alice Johnson', email: 'alice@example.com', role: 'admin', department: 'Engineering', status: 'active', created_at: '2024-01-14' },
@@ -319,9 +326,25 @@ const USERS_SCHEMA = {
   fields: {
     name: { label: 'Name', type: 'text' },
     email: { label: 'Email', type: 'email' },
-    role: { label: 'Role', type: 'select' },
+    role: {
+      label: 'Role',
+      type: 'select',
+      options: [
+        { label: 'Admin', value: 'admin' },
+        { label: 'Member', value: 'member' },
+        { label: 'Viewer', value: 'viewer' },
+      ],
+    },
     department: { label: 'Department', type: 'text' },
-    status: { label: 'Status', type: 'select' },
+    status: {
+      label: 'Status',
+      type: 'select',
+      options: [
+        { label: 'Active', value: 'active' },
+        { label: 'Invited', value: 'invited' },
+        { label: 'Suspended', value: 'suspended' },
+      ],
+    },
     created_at: { label: 'Created', type: 'date' },
   },
 };
@@ -1231,4 +1254,151 @@ describe('objectui#5113 — the docs-site hosts supply the same fixture', () => 
       expect(read(host)).toContain('dataSource: galleryDataSource');
     },
   );
+});
+
+/**
+ * objectui#6317 — every `select` field in the fixture declares the options its
+ * own rows use, and this mirror declares exactly what the host declares.
+ *
+ * ## The defect
+ *
+ * `ObjectForm` copies a field's options through verbatim — `formField.options =
+ * field.options || []` (`packages/plugin-form/src/ObjectForm.tsx`) — so a
+ * `select` field with no `options` renders the "No options available" empty
+ * state. Measured through this file's own render path, an `object-form` over
+ * `users` with no `fields` restriction:
+ *
+ *   before: "NameEmailRoleNo options availableDepartmentStatusNo options
+ *            availableCancelUpdate"
+ *   after:  "NameEmailRoleAdminAdminMemberViewerDepartmentStatusActiveActive
+ *            InvitedSuspendedCancelUpdate"
+ *
+ * and the record's own `role` / `status` join the form's control values
+ * (`["Alice Johnson","alice@example.com","Engineering"]` → `["Alice Johnson",
+ * "alice@example.com","admin","Engineering","active"]`), so the two fields stop
+ * being dropped on the way in.
+ *
+ * ## Why the grid and view tiles do NOT move with it
+ *
+ * Worth recording, because the expectation going in was that they would.
+ * `ObjectGrid` SYNTHESISES options for an option-less select from the distinct
+ * values in the loaded rows (`packages/plugin-grid/src/ObjectGrid.tsx` —
+ * `fieldMeta.options = uniqueValues.map(v => ({ value: v, label:
+ * humanizeLabel(String(v)) }))`), so `admin` already printed as "Admin".
+ * Measured: the tile text of all seven `users`-bound entries is byte-identical
+ * before and after this declaration. The grid has a fallback for the missing
+ * declaration; the FORM path has none. That asymmetry is the whole card.
+ *
+ * ## Two directions, because a one-sided pin cannot see this drift
+ *
+ * The host declared these options in `4b0b12630` and this mirror did not
+ * follow for 330 commits — with every case in this file green throughout. The
+ * `select`-coverage case below catches a fixture that declares neither; the
+ * parity case catches the two files declaring different things.
+ */
+
+interface UsersFieldDecl {
+  label?: string;
+  type?: string;
+  options?: Array<{ label: string; value: string }>;
+}
+
+/** Distinct values the mirror's rows carry for one field — walked, not grepped. */
+function distinctRowValues(field: string): Set<string> {
+  const seen = new Set<string>();
+  for (const row of USERS_ROWS) {
+    const value = (row as Record<string, unknown>)[field];
+    if (value !== undefined && value !== null) seen.add(String(value));
+  }
+  return seen;
+}
+
+/**
+ * The host's `USERS_SCHEMA`, read off its source. `apps/**` is outside every
+ * root Vitest project, which is the same constraint that makes this file a
+ * mirror in the first place. Brace-matched rather than pattern-matched and then
+ * JSON-ified, so an extraction that stops working fails LOUDLY here rather than
+ * quietly comparing less than it claims to.
+ */
+function readHostUsersFields(source: string): Record<string, UsersFieldDecl> {
+  const start = source.indexOf('const USERS_SCHEMA = {');
+  expect(start, 'the host fixture no longer declares `const USERS_SCHEMA = {`').toBeGreaterThan(-1);
+  const open = source.indexOf('{', start);
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth += 1;
+    else if (source[i] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  expect(end, 'the host `USERS_SCHEMA` literal has unbalanced braces').toBeGreaterThan(-1);
+  const json = source
+    .slice(open, end + 1)
+    .replace(/'/g, '"')
+    .replace(/([{,[]\s*)([A-Za-z_$][A-Za-z0-9_$]*)\s*:/g, '$1"$2":')
+    .replace(/,(\s*[}\]])/g, '$1');
+  let parsed: { fields?: Record<string, UsersFieldDecl> };
+  try {
+    parsed = JSON.parse(json) as { fields?: Record<string, UsersFieldDecl> };
+  } catch (error) {
+    throw new Error(
+      'the host `USERS_SCHEMA` is no longer a plain single-quoted literal, so this ' +
+        'parity case can no longer read it — a comment inside the literal, or an ' +
+        'apostrophe inside a string, would each do it. Fix the reader, not the pin.',
+      { cause: error },
+    );
+  }
+  expect(parsed.fields, 'the host `USERS_SCHEMA` declares no `fields`').toBeTruthy();
+  return parsed.fields as Record<string, UsersFieldDecl>;
+}
+
+describe('objectui#6317 — a `select` field declares the options its rows use', () => {
+  const mirrorFields = USERS_SCHEMA.fields as Record<string, UsersFieldDecl>;
+  const selectFields = Object.entries(mirrorFields)
+    .filter(([, field]) => field.type === 'select')
+    .map(([name]) => name);
+
+  it('the fixture declares select fields at all — otherwise the cases below are vacuous', () => {
+    expect(selectFields).not.toEqual([]);
+  });
+
+  it.each(selectFields)('`%s` declares options, and they cover its rows exactly', (name) => {
+    const declared = mirrorFields[name].options;
+    expect(
+      declared,
+      `\`${name}\` is declared \`type: 'select'\` with no \`options\`. ObjectForm copies ` +
+        'a field\'s options through verbatim, so a form bound to it renders the "No ' +
+        'options available" empty state — on a docs page whose whole purpose is to ' +
+        'show the component working.',
+    ).toBeTruthy();
+    const optionValues = new Set((declared ?? []).map((option) => String(option.value)));
+    const rowValues = distinctRowValues(name);
+    expect(
+      [...rowValues].filter((value) => !optionValues.has(value)),
+      `rows carry these \`${name}\` values that no option declares — they would render as a blank cell`,
+    ).toEqual([]);
+    expect(
+      [...optionValues].filter((value) => !rowValues.has(value)),
+      `these \`${name}\` options match no row, so nothing in the gallery demonstrates them`,
+    ).toEqual([]);
+  });
+
+  it('the host fixture declares the SAME field surface, options included', () => {
+    const hostSource = fs.readFileSync(
+      path.join(process.cwd(), 'apps/site/app/components/galleryDataSource.ts'),
+      'utf8',
+    );
+    expect(
+      readHostUsersFields(hostSource),
+      'the host fixture and this mirror declare different `users` field surfaces. They ' +
+        'are ONE fixture in two files and have to move together: the host gained its ' +
+        '`role` / `status` options in 4b0b12630 and this mirror did not follow for 330 ' +
+        'commits, with every case in this file green the whole time.',
+    ).toEqual(mirrorFields);
+  });
 });


### PR DESCRIPTION
Fixes #6317

## The card's premise was half dead, and the surviving half is the mirror

The issue reports that `apps/site/app/components/galleryDataSource.ts` declares `users.role` / `users.status` as `select` with no `options`. Verified against `origin/main` at `831be7285` before writing any code: **the host fixture already declares them**, and has since `4b0b12630` (#5113 / #5857, 2026-08-23) — 330 commits before this branch point, and two days before the issue was filed.

```
$ git log -S"{ label: 'Admin', value: 'admin' }" --oneline origin/main -- apps/site/app/components/galleryDataSource.ts
4b0b12630 docs(plugin-view): make the three Interactive Examples real object-view nodes (#5113) (#5857)

$ git grep -n "label: 'Role', type: 'select'" origin/main
origin/main:examples/schema-catalog/test/catalog-gallery-render.test.tsx:322:    role: { label: 'Role', type: 'select' },
```

Exactly one file in the repo still carried the option-less declaration: **the catalog-test mirror**. So the host fixture is untouched by this PR (nothing to do), and the whole change is the mirror plus the pins that would have caught the drift.

This is the failure mode the card names in its own words — *two declarations of one fixture disagreeing* — running in the direction the existing parity case could not see. That case pins the host's **method names**; the field declarations were unwatched, and they drifted for 330 commits with every one of this file's 572 cases green throughout.

## The values, derived structurally

Walked rather than grepped — every record the fixture's own `find('users')` returns, and every key on every record, with no field list decided up front:

```
rows returned = 5   total reported = 5
role         distinct=3  admin(x1) member(x3) viewer(x1)
status       distinct=3  active(x3) invited(x1) suspended(x1)
```

Three and three, agreeing with the dispatch's reading. The same walk over the **mirror's** rows returns the same two sets, so the mirror's schema was declaring `select` with no options over rows that carry three values each.

## The before/after, and the part of it that did not happen

Triage expected the `plugin-grid` / `plugin-view` tiles to start rendering labels instead of raw values, and ruled that deliberate. **Measured: they do not change at all.** All seven `users`-bound entries render byte-identical text before and after:

```
### plugin-grid/object-grid-columns
  BEFORE: "User Directory#Full NameEmailRoleDepartmentStatus1OpenAlice Johnson…AdminEngineeringActive…"
   AFTER: "User Directory#Full NameEmailRoleDepartmentStatus1OpenAlice Johnson…AdminEngineeringActive…"
  CHANGED: false
```

The mechanism, which is the part worth keeping: `ObjectGrid` **synthesises** options for an option-less select from the distinct values in the loaded rows —

```ts
// packages/plugin-grid/src/ObjectGrid.tsx
if (inferredType === 'select' && !fieldMeta.options) {
  const uniqueValues = Array.from(new Set(data.map(row => row[col.field]).filter(Boolean)));
  fieldMeta.options = uniqueValues.map(v => ({ value: v, label: humanizeLabel(String(v)) }));
}
```

so `admin` already printed as `Admin`. The grid has a fallback for the missing declaration. **The form path has none**, and that is where the change is real — the shape the issue itself measured, an `object-form` over `users` with no `fields` restriction:

```
BEFORE text: "NameEmailRoleNo options availableDepartmentStatusNo options availableCancelUpdate"
 AFTER text: "NameEmailRoleAdminAdminMemberViewerDepartmentStatusActiveActiveInvitedSuspendedCancelUpdate"

BEFORE controls: ["Alice Johnson","alice@example.com","Engineering"]
 AFTER controls: ["Alice Johnson","alice@example.com","admin","Engineering","active"]
```

The `BEFORE` string is byte-identical to the one in the issue body, so the probe is measuring the reported defect and not something adjacent. Note the labels were **not** narrowed to equal the values to keep anything green — they are the Title Case labels triage asked for, and they coincide with `humanizeLabel`'s output by construction, which is *why* the grid text is unchanged rather than a sign the change is inert.

## What this PR changes

`examples/schema-catalog/test/catalog-gallery-render.test.tsx` only:

1. `USERS_SCHEMA` declares `options` on `role` and `status`, byte-shaped like the host's so future diffs between the two files stay readable.
2. Four new cases under `objectui#6317`, closing the class in both directions:
   - every `select` field must declare `options` whose values **equal** the distinct values its own rows carry — both directions, so an uncovered row value and an option no row uses each fail;
   - a vacuity guard, so the case above cannot pass by matching nothing;
   - the mirror's whole `users` field surface is compared to the **host's**, options included. The host literal is read by brace-matching and then JSON-ifying, so an extraction that stops working fails loudly here rather than quietly comparing less than it claims to.
3. The fixture's header comment records what the parity now covers, and why it had to be widened.

## Reverse verification

Assertion written first, run against the untouched fixture:

```
❯ examples/schema-catalog/test/catalog-gallery-render.test.tsx (576 tests | 3 failed | 572 skipped)
  × `role` declares options, and they cover its rows exactly
  × `status` declares options, and they cover its rows exactly
  × the host fixture declares the SAME field surface, options included

AssertionError: `role` is declared `type: 'select'` with no `options`. … expected undefined to be truthy
AssertionError: the host fixture and this mirror declare different `users` field surfaces … 
  + "options": [ { "label": "Admin", "value": "admin" }, … ]   ← received (host)
```

The mutation was then proved on disk by counting the changed text rather than trusting the editor's exit code:

```
BEFORE  optionless role decl: 1   optionless status decl: 1   option pairs: 0
AFTER   optionless role decl: 0   optionless status decl: 0   option pairs: 6
file sha ef0d4294… → 0a12070a…
```

## Verification — all on `a9494bc32` (the final commit; working tree clean, tested blob `cad7f9d7…` equals `HEAD:`'s blob)

| gate | command | its own verdict line |
|---|---|---|
| tests | `pnpm exec vitest run examples/schema-catalog/test/catalog-gallery-render.test.tsx` | `Test Files 1 passed (1)` / `Tests 576 passed (576)` |
| type-check | `pnpm --filter @object-ui/example-schema-catalog run type-check` | exit 0, script name echoed (`> … type-check`) |
| lint | `pnpm exec eslint .` in `examples/schema-catalog` | exit 0 |
| changeset | `node scripts/check-changeset-presence.mjs` | `✅ No source of a released package changed in this range, so no changeset is owed.` |
| control bytes | `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 5394 tracked text file(s); skipped 85 binary).` |

Dependency closure built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/example-schema-catalog^...' build`), so the type-check reads real `.d.ts` rather than the missing-dist `TS2307` noise a fresh worktree produces. The edited file is provably *inside* the checked set — `tsc -p tsconfig.test.json --listFiles` lists `catalog-gallery-render.test.tsx` (1 hit), so "type-check green" actually covers this edit.

**Declared narrowing:** the repo-wide `eslint .` scan was not run. What was run is this package's own lint command in full — 17 files, which is eslint's own enumeration for `examples/schema-catalog` (read from `--format json`, not from a guess about which files count), with no narrowing *within* the package. For untouched files elsewhere: `eslint.config.js` sets no `parserOptions.project` / `projectService`, so type-aware linting is off and a diff confined to one file in one package cannot move any other file's verdict. CI runs the full farm regardless.

**No changeset**, on the gate's own verdict above: `apps/site` and `examples/schema-catalog` are both `private`, and `@object-ui/site` / `@object-ui/example-*` sit in the changeset `ignore` list, so no released package's source changed.

## Out of scope, filed not folded

- **#6537** — the two `plugin-form` catalog entries author `fields` lists that omit `role` / `status`. Triage noted that after this card those entries can stop steering around them; #6167 is where they were written and is not touched here. That is a consequence to record, not work for this card, and its file face is the entry JSON rather than the fixture.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_