### PR TITLE
fix(plugin-designer): key MetadataObjectsPage's name lookups as own entries

### DIFF
--- a/.changeset/6522-objects-page-lookup-keying.md
+++ b/.changeset/6522-objects-page-lookup-keying.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/plugin-designer': patch
+---
+
+`MetadataObjectsPage` keys its object-name lookups as own entries, so deleting an object
+named `constructor` (or `__proto__`) from the Object Manager actually deletes it
+(objectui#6522).
+
+Both name lookups in the page were plain object literals filled by assignment, and the
+consequential one was a READ. The delete scan asked `!nextByName[name]`, which for an
+object named `constructor` answered out of `Object.prototype` with the `Object` function —
+truthy — so the deletion read as "still present" and `client.reset('object', …)` never
+fired. Not a refusal: the row disappeared from the manager, no error was shown, the save
+reported success, and the object was still there after the next reload. Measured against
+the installed `@objectstack/spec`, `ObjectSchema` pins object names to
+`/^[a-z_][a-z0-9_]*$/` and accepts both `constructor` and `__proto__` — those two are
+exactly the intersection with `Object.prototype`'s own names, so both are storable and
+neither was deletable.
+
+The second lookup, one function over, failed on the WRITE instead: `byName[item.name] =
+item` for an object named `__proto__` invoked the prototype setter rather than creating a
+key, so the object never became an own property, never reached the Object Manager at all,
+and left its payload on the lookup's prototype chain for later name lookups to answer out
+of. Both are now `Map`s — neither container is ever serialised, only its values are, so a
+`Map` fits where the sibling `MetadataFieldsPage` fields map (which IS the PUT body) needs
+`Object.fromEntries`.
+
+Keying only. Nameless and duplicate entries behave exactly as before: this page writes
+per-object, so the refusal semantics objectui#6489 added to the fields map are a separate
+question and are deliberately not ported here.

--- a/packages/plugin-designer/src/MetadataObjectsPage.lookupKeying.test.tsx
+++ b/packages/plugin-designer/src/MetadataObjectsPage.lookupKeying.test.tsx
@@ -1,0 +1,383 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6522 — `MetadataObjectsPage` keys its name lookups so that an
+ * object whose name collides with `Object.prototype` is still reachable.
+ *
+ * Same construction defect the objectui#6489 / objectui#6240 family already
+ * ruled on, in a third page. This file is `MetadataObjectsPage`; the sibling
+ * `MetadataFieldsPage.fieldsMapKeying.test.tsx` holds the fields-map half.
+ *
+ * ## Two sites, one construction — and the consequential one is a READ
+ *
+ * SITE A — `handleObjectsChange`, the delete scan (the card's site).
+ *   The lookup of the manager's NEW list was a plain object literal filled by
+ *   assignment, and the delete scan asked `!nextByName[name]`. For an object
+ *   named `constructor` that lookup answers out of `Object.prototype` and
+ *   returns the `Object` function — truthy — so the object reads as "still
+ *   present" and `client.reset('object', 'constructor')` never fires. The row
+ *   disappears from the manager, no error is shown, the save reports success,
+ *   and the object is still there after a reload. A silent no-op, not a
+ *   refusal: the strongest evidence here is not the shape of the lookup but
+ *   the object SURVIVING the round trip, which is what these tests assert.
+ *
+ * SITE B — `reload`, the raw-payload lookup keyed by object name.
+ *   The same construction, one function over, failing on the write instead of
+ *   the read: `byName[item.name] = item` for an object named `__proto__`
+ *   invokes the prototype setter rather than creating a key. The entry never
+ *   becomes an own property, so `Object.values(...)` never yields it and the
+ *   object is invisible in the Object Manager — unlistable, uneditable,
+ *   undeletable — while the server holds it happily. It also leaves that
+ *   payload on the lookup's prototype chain, so later lookups for unrelated
+ *   names (`label`, `icon`, `fields`, …) answer out of it.
+ *
+ * Both names are legal. Measured against the installed `@objectstack/spec`,
+ * and pinned below in `the instrument` so this file does not merely assert
+ * that the page handles a name the platform would have refused anyway.
+ *
+ * ## Why `Map` here and `Object.fromEntries` in the sibling
+ *
+ * The fields map in `MetadataFieldsPage` IS the serialised `fields` body of a
+ * PUT, so it must remain a plain object and the family fix there is
+ * `Object.fromEntries` + `Object.prototype.hasOwnProperty.call(...)` on every
+ * read. Neither lookup in THIS file is ever serialised: site A is built, read
+ * and discarded inside one callback, and site B holds raw payloads whose
+ * VALUES are spread into a PUT body while the container itself never reaches
+ * the wire. A `Map` has neither hazard structurally — a string key is just a
+ * key, there is no prototype to answer out of and no setter to trip — instead
+ * of requiring every future read in the file to remember a guard.
+ *
+ * ## ⛔ Fixture rule (objectui#6524)
+ *
+ * `{ __proto__: v }` in an object literal SETS THE PROTOTYPE (Annex B.3.1);
+ * it does not add a key. A fixture written that way has zero own keys and
+ * passes for the wrong reason. Every `__proto__` key in this file is spelled
+ * `['__proto__']`, a computed key, and the rule itself is pinned below.
+ * `JSON.parse` does define an own `__proto__` property, which is why the
+ * server payloads this page reads (parsed bytes) carry the name honestly.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { ObjectSchema } from '@objectstack/spec/data';
+import { MetadataClient } from '@object-ui/data-objectstack';
+import type { ObjectDefinition } from '@object-ui/types';
+
+interface ServerItem {
+  name: string;
+  label: string;
+  pluralLabel?: string;
+  icon?: string;
+  isSystem?: boolean;
+  fields: Record<string, unknown>;
+}
+
+const item = (name: string, label: string): ServerItem => ({
+  name,
+  label,
+  pluralLabel: `${label}s`,
+  isSystem: false,
+  fields: { name: { type: 'text', label: 'Name' } },
+});
+
+interface RecordedManagerProps {
+  objects: ObjectDefinition[];
+  onObjectsChange?: (objects: ObjectDefinition[]) => void;
+  showSystemObjects?: boolean;
+  readOnly?: boolean;
+}
+
+let managerProps: RecordedManagerProps | null = null;
+
+vi.mock('./ObjectManager', () => ({
+  ObjectManager: (props: RecordedManagerProps) => {
+    managerProps = props;
+    return null;
+  },
+}));
+
+import { MetadataObjectsPage } from './MetadataObjectsPage';
+
+/**
+ * A server that actually holds state, so "the object survives the round trip"
+ * is observable rather than inferred. GET serves the current contents, DELETE
+ * removes, PUT upserts — the same three doors `MetadataClient` uses.
+ */
+let serverObjects: ServerItem[] = [];
+let deletes: string[] = [];
+let puts: Array<{ name: string; body: Record<string, unknown> }> = [];
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const nameFromUrl = (url: string): string =>
+  decodeURIComponent(url.split('/api/v1/meta/object/')[1]?.split('?')[0] ?? '');
+
+function realClient(): MetadataClient {
+  return new MetadataClient({
+    baseUrl: 'http://localhost:3000',
+    fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      const url = String(input);
+      if (method === 'DELETE') {
+        const name = nameFromUrl(url);
+        deletes.push(name);
+        serverObjects = serverObjects.filter((o) => o.name !== name);
+        return json({ success: true, reset: true });
+      }
+      if (method === 'PUT') {
+        const name = nameFromUrl(url);
+        const body = JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>;
+        puts.push({ name, body });
+        serverObjects = [
+          ...serverObjects.filter((o) => o.name !== name),
+          body as unknown as ServerItem,
+        ];
+        return json({ success: true });
+      }
+      return json({ items: serverObjects });
+    }) as unknown as typeof fetch,
+  });
+}
+
+const shownError = (): string | null =>
+  screen.queryByTestId('metadata-objects-page-error')?.textContent ?? null;
+
+/** Render against the current `serverObjects` and wait for the first paint. */
+async function renderPage(expectedRows: number) {
+  render(<MetadataObjectsPage client={realClient()} />);
+  await waitFor(() => expect(managerProps).not.toBeNull());
+  await waitFor(() => expect(managerProps!.objects).toHaveLength(expectedRows));
+}
+
+/** Remove one row through the manager, exactly as `ObjectManager` would. */
+async function deleteThroughManager(name: string) {
+  const next = managerProps!.objects.filter((o) => o.name !== name);
+  await act(async () => {
+    managerProps!.onObjectsChange!(next);
+  });
+}
+
+const namesOnServer = (): string[] => serverObjects.map((o) => o.name).sort();
+const namesInManager = (): string[] => managerProps!.objects.map((o) => o.name).sort();
+
+beforeEach(() => {
+  serverObjects = [];
+  deletes = [];
+  puts = [];
+  managerProps = null;
+});
+
+afterEach(() => {
+  managerProps = null;
+});
+
+const parsesAsObjectName = (name: string): boolean =>
+  ObjectSchema.safeParse({
+    name,
+    label: 'C',
+    fields: { n: { type: 'text', label: 'N' } },
+  }).success;
+
+describe('the instrument', () => {
+  it('the spec ACCEPTS both prototype-colliding names, so this is the page`s problem to solve', () => {
+    // Without this, every case below could be dismissed as "the platform would
+    // have refused that name anyway". It would not: measured against the
+    // installed `@objectstack/spec` 17.2.0.
+    expect(parsesAsObjectName('constructor')).toBe(true);
+    expect(parsesAsObjectName('__proto__')).toBe(true);
+  });
+
+  it('and those two are the WHOLE reachable set — the rest of the prototype is refused by name', () => {
+    // Why the cases below stop at two names rather than sweeping the whole
+    // prototype. `ObjectSchema` pins object names to /^[a-z_][a-z0-9_]*$/, and
+    // every other own name on `Object.prototype` carries a capital
+    // (`toString`, `hasOwnProperty`, `valueOf`, `__defineGetter__`, …), so it
+    // can never be stored in the first place. This is a measurement, not an
+    // assumption: if the spec ever loosens that pattern, or a future engine
+    // adds a lowercase member, this test reds and names what the page's
+    // lookups newly have to survive.
+    const reachable = Object.getOwnPropertyNames(Object.prototype)
+      .filter(parsesAsObjectName)
+      .sort();
+    expect(reachable).toEqual(['__proto__', 'constructor']);
+    expect(parsesAsObjectName('toString')).toBe(false);
+  });
+});
+
+describe('the mechanic — plain JavaScript, before any claim about the page', () => {
+  it('a plain-object lookup answers out of `Object.prototype`; a `Map` does not', () => {
+    // SITE A in one assertion. Nothing named `constructor` was ever put in.
+    const assigned: Record<string, unknown> = {};
+    assigned['account'] = { name: 'account' };
+    expect(Boolean(assigned['constructor'])).toBe(true);
+    expect(Boolean(assigned['toString'])).toBe(true);
+
+    const built = new Map<string, unknown>([['account', { name: 'account' }]]);
+    expect(built.has('constructor')).toBe(false);
+    expect(built.has('toString')).toBe(false);
+  });
+
+  it('assigning `__proto__` sets the prototype instead of adding a key — and then answers for OTHER names', () => {
+    // SITE B in one assertion: the entry never becomes a key (so it is never
+    // yielded by `Object.values`), and it poisons unrelated lookups.
+    const assigned: Record<string, unknown> = {};
+    assigned['__proto__'] = { name: '__proto__', label: 'Proto' };
+    expect(Object.keys(assigned)).toEqual([]);
+    expect(Object.values(assigned)).toEqual([]);
+    expect(assigned['label']).toBe('Proto');
+
+    const built = new Map<string, unknown>([
+      ['__proto__', { name: '__proto__', label: 'Proto' }],
+    ]);
+    expect([...built.keys()]).toEqual(['__proto__']);
+    expect(built.get('label')).toBeUndefined();
+  });
+
+  it('is a fixture rule too: `{ __proto__: v }` in a LITERAL sets the prototype, it does not add a key', () => {
+    // objectui#6524. Why every `__proto__` key in this file is computed. A
+    // fixture written the plain way carries zero own keys and passes for the
+    // wrong reason — the assertion would be about `{}`.
+    const plain = { __proto__: { name: '__proto__', label: 'P' } } as Record<string, unknown>;
+    expect(Object.keys(plain)).toEqual([]);
+    const computed = { ['__proto__']: { name: '__proto__', label: 'P' } } as Record<string, unknown>;
+    expect(Object.keys(computed)).toEqual(['__proto__']);
+    // And why payloads parsed from the wire read honestly: `JSON.parse`
+    // defines an own property rather than invoking the setter.
+    expect(Object.keys(JSON.parse('{"__proto__":{"label":"P"}}'))).toEqual(['__proto__']);
+  });
+});
+
+describe('objectui#6522 · SITE A — the delete scan issues the DELETE for a prototype-named object', () => {
+  it('C0 (control): an ordinary object is deleted and is gone after the reload', async () => {
+    // Green before and after this card. Its job is to prove the cases below
+    // are about the lookup keying and not about deletes having stopped.
+    serverObjects = [item('account', 'Account'), item('contact', 'Contact')];
+    await renderPage(2);
+
+    await deleteThroughManager('contact');
+
+    // Outcome first, mechanism second — the order every case in this group
+    // uses, so a regression fails on the user-visible fact rather than on the
+    // request log.
+    expect(shownError()).toBeNull();
+    await waitFor(() => expect(namesInManager()).toEqual(['account']));
+    expect(namesOnServer()).toEqual(['account']);
+    expect(deletes).toEqual(['contact']);
+  });
+
+  it('H1: an object named `constructor` is really deleted — it does NOT survive the reload', async () => {
+    // THE case this card exists for, and the realistic one: an ordinary
+    // lowercase identifier a business object could plausibly be called.
+    //
+    // Before the fix `!nextByName['constructor']` answered out of
+    // `Object.prototype` with the `Object` function — truthy — so `reset` was
+    // never called. The row vanished from the manager, NO error was shown,
+    // and the object came straight back on the next load.
+    serverObjects = [item('account', 'Account'), item('constructor', 'Constructor')];
+    await renderPage(2);
+
+    await deleteThroughManager('constructor');
+
+    // The silence first: whatever happened, the page reported success.
+    expect(shownError()).toBeNull();
+    // THE silent-no-op assertion, and the one that reds without the fix: the
+    // object is still listed after the reload. It was never a refusal that
+    // stopped the delete — nothing was shown, the row just came back.
+    await waitFor(() => expect(namesInManager()).toEqual(['account']));
+    expect(namesOnServer()).toEqual(['account']);
+    // Only then the mechanism that produced it.
+    expect(deletes).toEqual(['constructor']);
+  });
+
+  it('H2: an object named `__proto__` is really deleted — it does NOT survive the reload', async () => {
+    // Needs both sites correct: site B must key it as an own property for it
+    // to be listed at all, and site A must not read it back off the prototype.
+    serverObjects = [item('account', 'Account'), item('__proto__', 'Proto')];
+    await renderPage(2);
+
+    await deleteThroughManager('__proto__');
+
+    expect(shownError()).toBeNull();
+    await waitFor(() => expect(namesInManager()).toEqual(['account']));
+    expect(namesOnServer()).toEqual(['account']);
+    expect(deletes).toEqual(['__proto__']);
+  });
+
+  it('the deletes above are the only writes — no object is resurrected by a stray save', async () => {
+    // Falsification for the whole group: a page that PUT every row on every
+    // change would keep `namesOnServer()` correct for the wrong reason.
+    serverObjects = [item('account', 'Account'), item('constructor', 'Constructor')];
+    await renderPage(2);
+
+    await deleteThroughManager('constructor');
+
+    expect(puts).toEqual([]);
+  });
+});
+
+describe('objectui#6522 · SITE B — the raw-payload lookup keys every server object as an own entry', () => {
+  it('an object named `__proto__` served by the server actually reaches the manager', async () => {
+    // The second construction in this file, failing on the WRITE. Built by
+    // assignment, `byName['__proto__'] = item` invoked the prototype setter,
+    // so `Object.values(...)` never yielded it: the object was invisible in
+    // the Object Manager while the server held it.
+    serverObjects = [item('account', 'Account'), item('__proto__', 'Proto')];
+    await renderPage(2);
+
+    expect(namesInManager()).toEqual(['__proto__', 'account']);
+    const proto = managerProps!.objects.find((o) => o.name === '__proto__')!;
+    expect(proto.label).toBe('Proto');
+    // Derived like every other row — it is a first-class object, not a stub.
+    expect(proto.group).toBe('Custom Objects');
+    expect(proto.fieldCount).toBe(1);
+  });
+
+  it('non-vacuity: the fixture really is what the server sent, own key and all', () => {
+    // If the `__proto__` fixture ever lost its name the case above would stay
+    // green while testing nothing. Parsed bytes, so the key is honest.
+    const [, proto] = JSON.parse(
+      JSON.stringify([item('account', 'Account'), item('__proto__', 'Proto')]),
+    ) as ServerItem[];
+    expect(proto.name).toBe('__proto__');
+    // …and the name really is one blind assignment drops: this is the exact
+    // construction the page used, run on the exact fixture.
+    const dropped: Record<string, unknown> = {};
+    dropped[proto.name] = proto;
+    expect(Object.keys(dropped)).toEqual([]);
+  });
+
+  it('an object named `constructor` round-trips an edit onto its OWN payload', async () => {
+    // The read half of site B: `prev[updated.name]` is what the save-back
+    // merges onto. Off a plain object literal a name that is not an own key
+    // answers with an inherited value instead of `undefined`, so the merge
+    // base and the redundant-save guard both consult the wrong thing.
+    serverObjects = [item('constructor', 'Constructor')];
+    await renderPage(1);
+
+    const next = managerProps!.objects.map((o) => ({ ...o, label: 'Renamed' }));
+    await act(async () => {
+      managerProps!.onObjectsChange!(next);
+    });
+    await waitFor(() => expect(puts).toHaveLength(1));
+
+    expect(puts[0].name).toBe('constructor');
+    expect(puts[0].body.label).toBe('Renamed');
+    // The rest of the server document survived the merge — proof the base was
+    // the real payload rather than something off the prototype chain.
+    expect(puts[0].body.pluralLabel).toBe('Constructors');
+    expect(puts[0].body.fields).toBeDefined();
+    expect(deletes).toEqual([]);
+    expect(shownError()).toBeNull();
+  });
+});

--- a/packages/plugin-designer/src/MetadataObjectsPage.tsx
+++ b/packages/plugin-designer/src/MetadataObjectsPage.tsx
@@ -110,8 +110,23 @@ function toObjectDefinition(raw: ServerObjectSchema): ObjectDefinition {
 interface ServerObjectsState {
   loading: boolean;
   error: string | null;
-  /** Raw server payloads, indexed by object name (for save-back merging). */
-  byName: Record<string, ServerObjectSchema>;
+  /**
+   * Raw server payloads, indexed by object name (for save-back merging).
+   *
+   * A `Map`, not a plain object (objectui#6522). Object names are server data:
+   * `ObjectSchema` pins them to /^[a-z_][a-z0-9_]*$/, which accepts BOTH
+   * `constructor` and `__proto__`. Filled by assignment into an object
+   * literal, the `__proto__` entry invoked the prototype setter instead of
+   * creating a key — the object never became an own property, so it never
+   * reached the manager at all and left its payload on the lookup's prototype
+   * chain for every later name to answer out of. A `Map` key is just a key.
+   *
+   * Nothing serialises this container — only its VALUES are spread into a PUT
+   * body — so unlike the fields map in the sibling `MetadataFieldsPage` it has
+   * no reason to stay a plain object. Same ruling (objectui#6489 /
+   * objectui#6240), the shape that fits this lookup.
+   */
+  byName: Map<string, ServerObjectSchema>;
 }
 
 export function MetadataObjectsPage({
@@ -133,17 +148,17 @@ export function MetadataObjectsPage({
   const [state, setState] = useState<ServerObjectsState>({
     loading: true,
     error: null,
-    byName: {},
+    byName: new Map(),
   });
 
   const reload = useCallback(async () => {
     setState((s) => ({ ...s, loading: true, error: null }));
     try {
       const items = await client.list<ServerObjectSchema>('object');
-      const byName: Record<string, ServerObjectSchema> = {};
+      const byName = new Map<string, ServerObjectSchema>();
       for (const item of items) {
         if (item && typeof item === 'object' && typeof item.name === 'string') {
-          byName[item.name] = item;
+          byName.set(item.name, item);
         }
       }
       setState({ loading: false, error: null, byName });
@@ -151,7 +166,7 @@ export function MetadataObjectsPage({
       setState({
         loading: false,
         error: err instanceof Error ? err.message : String(err),
-        byName: {},
+        byName: new Map(),
       });
     }
   }, [client]);
@@ -161,7 +176,7 @@ export function MetadataObjectsPage({
   }, [reload]);
 
   const objects = useMemo<ObjectDefinition[]>(
-    () => Object.values(state.byName).map(toObjectDefinition),
+    () => [...state.byName.values()].map(toObjectDefinition),
     [state.byName],
   );
 
@@ -179,14 +194,21 @@ export function MetadataObjectsPage({
    */
   const handleObjectsChange = useCallback(async (next: ObjectDefinition[]) => {
     const prev = state.byName;
-    const nextByName: Record<string, ObjectDefinition> = {};
-    for (const o of next) nextByName[o.name] = o;
+    // objectui#6522 — a `Map`, because the READ below is the consequential
+    // half. Built by assignment into an object literal, `!nextByName[name]`
+    // answered out of `Object.prototype`: for an object named `constructor`
+    // the lookup returned the `Object` function, the deletion read as "still
+    // present", and `client.reset` never fired. No error, no refusal — the row
+    // vanished from the manager, the save reported success, and the object was
+    // still there after the reload. `Map.has` consults nothing but the entries
+    // actually put in. Never serialised: built, read and discarded right here.
+    const nextByName = new Map<string, ObjectDefinition>(next.map((o) => [o.name, o]));
 
     const errors: string[] = [];
 
     // Deletions
-    for (const name of Object.keys(prev)) {
-      if (!nextByName[name]) {
+    for (const name of prev.keys()) {
+      if (!nextByName.has(name)) {
         try {
           await client.reset('object', name);
         } catch (err) {
@@ -197,7 +219,13 @@ export function MetadataObjectsPage({
 
     // Inserts + updates
     for (const updated of next) {
-      const base = prev[updated.name] ?? { name: updated.name };
+      // One own-entry lookup feeding both the merge base and the
+      // redundant-save guard below (objectui#6522). Off a plain object literal
+      // a name that was never stored still answered — `prev['constructor']`
+      // handed back the `Object` function — so the merge spread the wrong base
+      // and the guard below compared against inherited `undefined`s.
+      const previous = prev.get(updated.name);
+      const base = previous ?? { name: updated.name };
       const merged: ServerObjectSchema = {
         ...base,
         name: updated.name,
@@ -217,11 +245,11 @@ export function MetadataObjectsPage({
       delete merged.group;
       // Don't issue redundant saves if nothing visible changed.
       if (
-        prev[updated.name]
-        && prev[updated.name].label === merged.label
-        && prev[updated.name].pluralLabel === merged.pluralLabel
-        && prev[updated.name].description === merged.description
-        && prev[updated.name].icon === merged.icon
+        previous
+        && previous.label === merged.label
+        && previous.pluralLabel === merged.pluralLabel
+        && previous.description === merged.description
+        && previous.icon === merged.icon
       ) {
         continue;
       }
@@ -239,7 +267,7 @@ export function MetadataObjectsPage({
   }, [client, reload, state.byName]);
 
   const handleSelectObject = useCallback((obj: ObjectDefinition) => {
-    const raw = state.byName[obj.name];
+    const raw = state.byName.get(obj.name);
     if (raw && onSelectObject) onSelectObject(obj, raw);
   }, [onSelectObject, state.byName]);
 


### PR DESCRIPTION
Fixes #6522

Deleting an object named `constructor` from the Object Manager was a **silent no-op**: the row vanished, no error was shown, the save reported success, and the object was still there after the reload.

Verification union ran at **`38b4469ae`** (the final commit; `git status` clean at that sha).

## The defect

`handleObjectsChange` built its lookup of the manager's new list by blind assignment into a plain object literal, then asked `!nextByName[name]`. For an object named `constructor` that read answers out of `Object.prototype` with the `Object` function — truthy — so the deletion read as "still present" and `client.reset('object', …)` never fired. The consequential half is the **read**, not the write.

Measured against the installed `@objectstack/spec` 17.2.0, `ObjectSchema` pins object names to `/^[a-z_][a-z0-9_]*$/`:

```
ACCEPT   constructor
ACCEPT   __proto__
refuse   toString, valueOf, hasOwnProperty, isPrototypeOf, propertyIsEnumerable,
         toLocaleString, __defineGetter__, __defineSetter__, __lookupGetter__,
         __lookupSetter__      (invalid_format: must match /^[a-z_][a-z0-9_]*$/)
```

So `constructor` and `__proto__` are **exactly** the intersection of the spec's accept set with `Object.prototype`'s own names — both storable, neither deletable. That measurement is pinned in the new suite (`the instrument`), so a loosened pattern or a new lowercase prototype member reds here and names what the lookups newly have to survive, rather than passing quietly.

## The second site — measured, then fixed under the same ruling, and named here

The dispatch order asked me to measure `:146` (`byName[item.name] = item` in `reload`) rather than silently fix or silently skip it. **It is the same defect class**, failing on the write instead of the read:

- `byName['__proto__'] = item` invokes the prototype setter rather than creating a key. The entry never becomes an own property, so `Object.values(...)` never yields it: an object named `__proto__` **never reaches the Object Manager at all** — unlistable, uneditable, undeletable — while the server holds it happily.
- It also leaves that payload on the lookup's prototype chain, so later lookups for unrelated names answer out of it (`prev['label']` returns the `__proto__` object's label string, and `{...base}` then spreads a *string* into the PUT body).
- The read half of the same site, `prev[updated.name]` at the merge base and in the redundant-save guard, is prototype-reachable for the same reason.

Boundary scan for that in-place fix: same defect class, mechanical, shape already ruled by the family, same file and same gate family, no new verification surface, and no other claim holds this file (`MetadataFieldsPage.tsx` is untouched — #6527 holds it).

One reachability note stated honestly rather than pinned: the redundant-save guard could in principle skip a *create* whose inherited lookup compared equal, but `ObjectDefinition.label` is a required `string`, so the all-`undefined` comparison that would trigger it is not reachable through the typed path. Fixed as part of the same construction, not claimed as an independently reachable bug.

## Why `Map` and not `Object.fromEntries`

The family fix in the sibling `MetadataFieldsPage` (landed by PR #6520) is `Object.fromEntries` + `Object.prototype.hasOwnProperty.call(...)`, and that is right *there*: that map **is** the serialised `fields` body of the PUT, so it has to stay a plain object.

Neither lookup here is ever serialised. `nextByName` is built, read and discarded inside one callback; `byName` holds raw payloads whose **values** are spread into a PUT body while the container itself never reaches the wire. A `Map` removes both hazards structurally — a string key is just a key, with no prototype to answer out of and no setter to trip — instead of requiring every future read in the file to remember a guard. Three read sites collapse to `.get()`/`.has()`.

`ServerObjectsState` is a local, unexported interface; the exported surface (`MetadataObjectsPage`, `MetadataObjectsPageProps`) is unchanged.

## ⛔ The fence: keying only, no refusals

objectui#6489 landed three things — own-property keying plus refusals for nameless and duplicate entries. **Only the keying is ported.** Nameless and duplicate entries behave exactly as before.

I did **not** conclude refusals are needed here, so there is no fork to escalate — for one measured reason: `MetadataClient.save` already refuses an empty name at the call boundary (`name must be non-empty … the PUT route requires a name segment`), so a nameless entry surfaces as an error in the page's error box rather than as a silent misroute. The one behaviour the keying fix changes incidentally is that a nameless entry now keys as `undefined` instead of the *string* `"undefined"`, which strictly narrows the misroute (it can no longer collide with an object legally named `undefined`). Duplicates remain last-write-wins.

## Reverse verification

The pin was written **first** and observed failing against the untouched tree, and the failure is the **silent no-op**, not a shape assertion. Assertions in each delete case are ordered outcome-first (silence → survival → mechanism) precisely so the first red is the user-visible fact:

```
H1: an object named `constructor` is really deleted — it does NOT survive the reload
AssertionError: expected [ 'account', 'constructor' ] to deeply equal [ 'account' ]
  ❯ await waitFor(() => expect(namesInManager()).toEqual(['account']));
```

`expect(shownError()).toBeNull()` passes on the same run — the page reported success while the object came straight back. Source tree was byte-identical to `origin/main` for that run (`git diff HEAD -- MetadataObjectsPage.tsx` → 0 lines).

Repeated as a hashed ablation against the **committed** fix, identical test bytes on both legs (test blob `76b074a11`):

| leg | `MetadataObjectsPage.tsx` blob on disk | result |
|---|---|---|
| ablated (`origin/main` @ `c18acb09e`) | `33e2fde1a` (== BASE blob, verified) | `Tests 3 failed \| 9 passed (12)` |
| restored (HEAD) | `5cf52af3d` (== HEAD blob, verified) | `Tests 113 passed (113)` (whole package) |

Both legs proved on disk by blob hash rather than by an editor's exit code; the restore leg additionally proved by `git diff HEAD` = 0 lines and a clean index. No build participates in this ablation: the root vitest config aliases `@object-ui/*` to `src/`, and the file under test is imported by relative path within its own package, so there is no `dist/` staleness axis to rebuild past.

The 9 green tests on the ablated leg are the controls doing their job — the ordinary-object delete, the plain-JS mechanics, the spec measurement, and the `constructor` edit round-trip (`constructor` *is* an own key when the server sends it, so its edit path was never broken).

## Verification

All at `38b4469ae`:

- `pnpm exec vitest run packages/plugin-designer/` → `Test Files 15 passed (15)`, `Tests 113 passed (113)` (12 of them new)
- `packages/plugin-designer` `pnpm run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) → exit 0. The new test file is genuinely inside that program, not merely excluded-and-silent: confirmed with `tsc -p tsconfig.test.json --listFiles`
- dependency closure built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-designer^...' build`) — before that, `type-check` reported `TS2307: Cannot find module '@object-ui/types'` across the whole package, i.e. a stale-worktree artefact rather than a real result
- `check:designer-field-key-parity` → `designer-field-key-parity: OK` (this file is one of its `wire` shapes; the `ServerObjectSchema` interface it reads is unchanged)
- `check:control-bytes` → `OK (scanned 5399 tracked text file(s))` · `check:vi-mock-specifiers` → `OK (3836 tracked source file(s), 456 carry a mock)` — both re-run **after** staging, since both scan *tracked* files only; the counts moving (5397→5399, 3835→3836, 455→456) is the proof the new file was actually scanned
- `check:phantom-deps` → `Every in-scope import is declared by the package that publishes it`
- `check-changeset-presence` → `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` · `check-changeset-no-major` → OK · `check-lint-coverage` → `46/46 packages linted`

**ESLint — declared narrowing.** Repo-wide `pnpm lint` is CI's run; locally this is scoped to `packages/plugin-designer` and the narrowing is measured, not assumed: (1) the population came from ESLint's own config resolution rather than my own file list — `pnpm exec eslint packages/plugin-designer --format json`; (2) that JSON reports **51 files linted, 0 errors, 67 warnings**, all pre-existing, with the changed files at `MetadataObjectsPage.tsx` 0 errors / 1 warning and `MetadataObjectsPage.lookupKeying.test.tsx` 0 / 0; (3) `eslint.config.js` declares no `parserOptions.project` and no `projectService`, so type-aware linting is off and every verdict is a pure function of the file under lint plus the config — this diff touches no config file, so no untouched file's verdict can move. The single warning is `react-hooks/set-state-in-effect` on `void reload()` inside `useEffect`, which sits in an unchanged region of the diff (context lines only) and predates this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_