### PR TITLE
fix(plugin-gantt): pin every restated `GanttConfig` member against its twin

### DIFF
--- a/.changeset/6471-ganttconfigex-restatement-pin.md
+++ b/.changeset/6471-ganttconfigex-restatement-pin.md
@@ -1,0 +1,36 @@
+---
+---
+
+Pin every member `plugin-gantt`'s `GanttConfigEx` restates on top of `GanttConfig`
+against its twin, so two declarations of one key can no longer drift apart in silence
+(objectui#6471).
+
+**No release.** Type-only and package-private: no runtime code changes, and the published
+surface is untouched on both sides. `packages/types` has zero changed files, so
+`GanttConfig`'s member list in the built `dist/index.d.ts` is byte-for-byte what it was;
+the new `GanttConfigRestated` alias is exported from `ObjectGantt.tsx` for the pin to
+import but is not re-exported by the package entry, and `plugin-gantt/dist/index.d.ts`
+carries zero occurrences of it after a real build (positive control: `QuickFilterDef`,
+which *is* re-exported, appears there).
+
+`GanttConfigEx` is `GanttConfig & { … }` and the intersection's second half re-declares
+keys the first half already declares — nine of them arriving from the spec's
+`GanttConfigSchema`, which declares 19 keys as of rc.6. The restatements are deliberate:
+their JSDoc is the only prose in this repo describing what the renderer does with each
+key, and the spec emits no per-member documentation, so deleting the members deletes the
+documentation. What was missing was any assertion that the two declarations still agree.
+
+The local half is now a named type, and that is the whole mechanism rather than a tidying
+step. An assertion phrased over `GanttConfigEx` cannot measure anything: `GanttConfigEx[K]`
+is already `GanttConfig[K] & local[K]`, so it is assignable to `GanttConfig[K]` by
+construction and stays green no matter how far the two declarations drift. Naming the
+local half gives the pin two independent operands.
+
+Measured, not assumed: **all twelve** restated members are mutually assignable with their
+`GanttConfig` twin today — including `quickFilters` and `timeSegments`, which the card and
+its triage both describe as load-bearing NARROWINGS. On current `main` they narrow
+nothing. objectui#6051/#6472 lifted `timeSegments` onto `GanttConfig` in the shape that is
+structurally `ShiftSegmentsConfig`, and rc.6's `GanttConfigSchema.quickFilters` already
+models `field` / `label` / `options` exactly as `QuickFilterDef` does. Both are kept and
+pinned as a measured state rather than deleted, so a future spec bump surfaces as a
+decision instead of a silent widening.

--- a/packages/plugin-gantt/src/ObjectGantt.configPin.test.ts
+++ b/packages/plugin-gantt/src/ObjectGantt.configPin.test.ts
@@ -1,0 +1,218 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Declaration pin — every member `ObjectGantt` restates on top of
+ * {@link GanttConfig} still means what its twin means (objectui#6471).
+ *
+ * ## The defect this closes
+ *
+ * `GanttConfigEx` is `GanttConfig & GanttConfigRestated`. The second half
+ * re-declares keys the first half already declares — nine of them arriving on
+ * `GanttConfig` from the spec's `GanttConfigSchema` (19 keys as of rc.6). Two
+ * declarations of one key CAN disagree, and until this file nothing asserted
+ * that they still agree after a spec bump. They are kept rather than deleted
+ * because their JSDoc is the only prose in this repo describing what this
+ * renderer does with each key; this pin is what makes keeping them safe.
+ *
+ * ## Why the local half had to be NAMED first
+ *
+ * The pin is impossible to write against `GanttConfigEx` itself, and writing it
+ * that way is the trap: `GanttConfigEx[K]` is ALREADY `GanttConfig[K] &
+ * GanttConfigRestated[K]`, so it is assignable to `GanttConfig[K]` by
+ * construction. An assertion phrased over the intersection passes no matter how
+ * far the two declarations drift — green, permanent, and measuring nothing.
+ * Splitting the local half into its own named type is what gives the assertions
+ * below two INDEPENDENT operands.
+ *
+ * ## What was measured, and what it contradicts
+ *
+ * All TWELVE restated members are mutually assignable with their `GanttConfig`
+ * twin today — including `quickFilters` and `timeSegments`. The card
+ * (objectui#6471) and its triage both describe those two as load-bearing
+ * NARROWINGS; on current `main` they narrow nothing, and the reason is
+ * traceable rather than mysterious:
+ *
+ *   - `timeSegments` — objectui#6051/#6472 lifted the member onto `GanttConfig`
+ *     in `@object-ui/types`, and the shape it lifted is structurally
+ *     {@link ShiftSegmentsConfig};
+ *   - `quickFilters` — rc.6's `GanttConfigSchema.quickFilters` already models
+ *     `field` / `label` / `options` exactly as {@link QuickFilterDef} does.
+ *
+ * Both are pinned below as the MEASURED state rather than deleted: the type each
+ * one names is still this plugin's own runtime vocabulary, and a spec bump that
+ * moves either side should surface here as a decision, not as a silent widening.
+ * That is the whole point of the instrument.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { GanttConfig } from '@object-ui/types';
+import type { GanttConfigRestated, QuickFilterDef } from './ObjectGantt';
+import type { ShiftSegmentsConfig } from './shifts';
+
+/**
+ * Mutual assignability. Both sides are wrapped in a 1-tuple so a naked union
+ * distributes as one type rather than member-by-member, which would report a
+ * union and its own member as equal.
+ */
+type Mutual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+/** `true` only for `any` — the one operand that makes `Mutual` unconditionally true. */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/**
+ * The restated keys that no longer agree with their `GanttConfig` twin.
+ * `never` is the contract, and a violation NAMES the key in the compiler error.
+ *
+ * Derived over `keyof GanttConfigRestated`, so there is no key list here to fall
+ * out of date: add a member to `GanttConfigRestated` and it is pinned the moment
+ * it exists.
+ */
+type Diverged = {
+  [K in keyof GanttConfigRestated]-?: Mutual<GanttConfigRestated[K], GanttConfig[K]> extends true
+    ? never
+    : K;
+}[keyof GanttConfigRestated];
+
+/** Restated keys where either operand is `any`, which would make `Diverged` blind. */
+type AnyOperand = {
+  [K in keyof GanttConfigRestated]-?: IsAny<GanttConfigRestated[K]> extends true
+    ? K
+    : IsAny<GanttConfig[K]> extends true
+      ? K
+      : never;
+}[keyof GanttConfigRestated];
+
+/** The census, as a runtime list the type side holds to account below. */
+const RESTATED = [
+  'parentField',
+  'typeField',
+  'baselineStartField',
+  'baselineEndField',
+  'groupByField',
+  'resourceView',
+  'assigneeField',
+  'effortField',
+  'capacity',
+  'quickFilters',
+  'autoZoomToFilter',
+  'timeSegments',
+] as const;
+
+/** A member of `GanttConfigRestated` missing from `RESTATED` above. `never` is the contract. */
+type UncensusedKey = Exclude<keyof GanttConfigRestated, (typeof RESTATED)[number]>;
+/** A `RESTATED` entry that is no longer a member. `never` is the contract. */
+type StaleCensusEntry = Exclude<(typeof RESTATED)[number], keyof GanttConfigRestated>;
+
+describe('GanttConfigRestated — every restatement still agrees with its GanttConfig twin', () => {
+  it('no restated member has diverged from GanttConfig', () => {
+    // THE PIN. A spec bump (or an edit to `@object-ui/types`) that re-types one
+    // of these stops compiling HERE, naming the key — instead of being silently
+    // intersected back to the old type by `GanttConfigEx` and read as unchanged.
+    const noDivergence: Diverged extends never ? true : Diverged = true;
+    expect(noDivergence).toBe(true);
+  });
+
+  it('the census is the measured twelve, with no member unpinned', () => {
+    // Non-vacuity for the runtime loop below, and a self-maintaining list: a new
+    // member of `GanttConfigRestated` that nobody added here fails to compile.
+    const noUncensused: UncensusedKey extends never ? true : UncensusedKey = true;
+    const noStale: StaleCensusEntry extends never ? true : StaleCensusEntry = true;
+    expect([noUncensused, noStale]).toEqual([true, true]);
+    expect(RESTATED).toHaveLength(12);
+    expect(new Set(RESTATED).size).toBe(12);
+  });
+
+  it('the pin is not vacuous', () => {
+    // Four ways `Diverged` could be `never` while proving nothing.
+    //
+    // 1. `Mutual` degenerating to always-true. The directive below is USED today
+    //    (string and number are not mutually assignable, so the annotation is
+    //    `never` and the assignment is an error). If `Mutual` ever stopped having
+    //    teeth the assignment would start succeeding and this directive would go
+    //    unused — TS2578, a failed build. The control guards itself.
+    // @ts-expect-error — `Mutual<string, number>` must be `false`.
+    const mutualHasTeeth: Mutual<string, number> extends true ? true : never = true;
+    // 2. an `any` on either side of the comparison, which `Mutual` swallows.
+    const noAnyOperand: AnyOperand extends never ? true : AnyOperand = true;
+    // 3. `keyof GanttConfigRestated` degenerating to `string` — the index-signature
+    //    trap `gantt-flat-config-declared-keys.test.ts` records on the other side
+    //    of this vocabulary. `GanttConfig` really does carry `[x: string]: unknown`
+    //    (its spec schema is `$loose`), so this is a live hazard, not a ritual.
+    const keysNotWidened: string extends keyof GanttConfigRestated ? never : true = true;
+    // 4. `GanttConfigRestated` having no members at all would leave nothing to map.
+    const hasMembers: 'parentField' extends keyof GanttConfigRestated ? true : never = true;
+    expect([mutualHasTeeth, noAnyOperand, keysNotWidened, hasMembers])
+      .toEqual([true, true, true, true]);
+  });
+
+  it('records the MEASURED state of the two the card calls narrowings', () => {
+    // The card and its triage both call these load-bearing NARROWINGS. Measured
+    // on current `main` they narrow nothing — they are mutually assignable with
+    // their twins, exactly like the other ten. Pinned as a measured state so the
+    // claim is not re-inherited from prose: if a spec bump makes either a real
+    // narrowing again, `Diverged` above fires and this line is where the next
+    // agent reads what changed.
+    const quickFiltersNarrowsNothing: Mutual<
+      GanttConfigRestated['quickFilters'],
+      GanttConfig['quickFilters']
+    > extends true
+      ? true
+      : never = true;
+    const timeSegmentsNarrowsNothing: Mutual<
+      GanttConfigRestated['timeSegments'],
+      GanttConfig['timeSegments']
+    > extends true
+      ? true
+      : never = true;
+    expect([quickFiltersNarrowsNothing, timeSegmentsNarrowsNothing]).toEqual([true, true]);
+  });
+
+  it('both still name THIS plugin\'s runtime vocabulary', () => {
+    // What deleting them would actually cost, stated as a type rather than as a
+    // belief: the members bind the config to the plugin's own named types, which
+    // is what `QuickFilterBar` and `normalizeShiftSegments` consume. When one of
+    // these two lines and the pair above disagree, the SPEC side moved; when they
+    // agree and `Diverged` fires, this plugin's side moved.
+    const quickFiltersIsPluginType: Mutual<
+      GanttConfigRestated['quickFilters'],
+      QuickFilterDef[] | undefined
+    > extends true
+      ? true
+      : never = true;
+    const timeSegmentsIsPluginType: Mutual<
+      GanttConfigRestated['timeSegments'],
+      ShiftSegmentsConfig | undefined
+    > extends true
+      ? true
+      : never = true;
+    expect([quickFiltersIsPluginType, timeSegmentsIsPluginType]).toEqual([true, true]);
+  });
+
+  it('GanttConfigEx still carries every restated key at its agreed type', () => {
+    // The consumer-side half: the intersection the renderer actually reads is
+    // unchanged by the split. This is assignability in the direction that would
+    // break reads, and it is the runtime-facing claim behind "no behaviour change".
+    const cfg: import('./ObjectGantt').GanttConfigRestated = {
+      parentField: 'parent',
+      typeField: 'kind',
+      baselineStartField: 'plan_start',
+      baselineEndField: 'plan_end',
+      groupByField: 'owner',
+      resourceView: true,
+      assigneeField: 'owner',
+      effortField: 'effort',
+      capacity: 2,
+      quickFilters: [{ field: 'owner', label: 'Owner' }],
+      autoZoomToFilter: false,
+      timeSegments: { bands: [{ label: 'Day', start: '08:00', end: '20:00' }] },
+    };
+    const asConfig: Partial<GanttConfig> = cfg;
+    expect(Object.keys(asConfig).sort()).toEqual([...RESTATED].sort());
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -103,7 +103,36 @@ export interface QuickFilterDef {
  * Each key is now declared once and both faces derive from it: the `gantt` block
  * and the flattened top-level spelling on `ObjectGanttSchema`.
  */
-type GanttConfigEx = GanttConfig & {
+type GanttConfigEx = GanttConfig & GanttConfigRestated;
+
+/**
+ * The members this renderer states ON TOP of {@link GanttConfig} — twelve, as
+ * measured against the shipped `GanttConfig` on `main` (objectui#6471; the card
+ * counted eleven before objectui#6051/#6472 landed part of the lift).
+ *
+ * Ten are RESTATEMENTS: `GanttConfig` already declares them (nine of the ten
+ * arrive from the spec's `GanttConfigSchema`, which declares 19 keys), and the
+ * type written here is mutually assignable with the twin. They are kept, not
+ * deleted, for ONE reason — their JSDoc is the only prose in this repo describing
+ * what this renderer DOES with each key. The spec emits no per-member docs
+ * (`z.input<typeof GanttConfigSchema>` carries none), so deleting the members
+ * deletes the documentation, and JSDoc cannot be attached to a member a type
+ * merely inherits.
+ *
+ * Two are NARROWINGS and load-bearing: `quickFilters` and `timeSegments` pin the
+ * plugin's own runtime types (`QuickFilterDef[]` / {@link ShiftSegmentsConfig}),
+ * which is precision the intersection would otherwise lose.
+ *
+ * ⚠️ NAMED rather than inlined into the intersection above, and that is the
+ * whole mechanism: inside `GanttConfigEx` there is nothing left to compare,
+ * because `GanttConfigEx[K]` is ALREADY `GanttConfig[K] & <local>[K]` and is
+ * therefore assignable to `GanttConfig[K]` by construction — an assertion written
+ * against `GanttConfigEx` passes no matter how far the two declarations drift.
+ * Naming the local half is what gives `ObjectGantt.configPin.test.ts` two
+ * independent operands, so a spec bump that re-types one of the ten breaks the
+ * build at the pin instead of silently intersecting the old type back in.
+ */
+export type GanttConfigRestated = {
   parentField?: string;
   /**
    * Record field whose value maps onto a node kind (see {@link normalizeTaskType}):


### PR DESCRIPTION
Fixes #6471

Verified at `8ec2e80cd` (the final commit — the gate union below was re-run on this exact tree).

## The measurement, re-derived on current `main` — the card's number is stale

The card says **eleven** restated members; triage repeats it. On `main` at `c18acb09e`, `GanttConfigEx` is a **`type` alias** at `ObjectGantt.tsx:106` declaring **twelve**:

`parentField` · `typeField` · `baselineStartField` · `baselineEndField` · `groupByField` · `resourceView` · `assigneeField` · `effortField` · `capacity` · `quickFilters` · `autoZoomToFilter` · `timeSegments`

The card's list of eleven omitted `timeSegments` (it discussed that one separately), and its "nine pure duplicates" is one short of its own list. **Twelve is the count that stands.**

> Grep note, since the dispatch order asked for a positive control: `grep -c "interface GanttConfigEx"` returns **0** — the declaration is a `type`. The positive control `grep -n "GanttConfigEx"` returns 5 hits (`:106`, `:332`, `:337`, `:455`, `:459`).

## What the measurement contradicts: neither "narrowing" narrows anything

The charter keeps `quickFilters` and `timeSegments` as load-bearing NARROWINGS. Measured with a compiled type-level probe, **all twelve** members — those two included — are **mutually assignable** with their `GanttConfig` twin on current `main`. They narrow nothing today, and the reason is traceable rather than mysterious:

- **`timeSegments`** — #6051/#6472 lifted the member onto `GanttConfig` in `@object-ui/types`, and the shape it lifted is structurally `ShiftSegmentsConfig`;
- **`quickFilters`** — rc.6's `GanttConfigSchema.quickFilters` already models `field` / `label` / `options` exactly as `QuickFilterDef` does.

**They are kept anyway**, per the charter, and both are now pinned as a *measured state* rather than as inherited prose. The probe was proven non-vacuous before this claim was believed: seven controls, all of which had to fail and did — `Mutual<string, number>` refused, a cross-key mismatch refused, and neither operand of either pair being `any` (an `any` on either side makes the comparison unconditionally true).

## Route: the pin, not the JSDoc lift — chosen by measurement

**Option A ("lift the JSDoc onto `GanttConfig`, delete the restatements") is refuted, not disliked.** Nine of the twelve keys arrive on `GanttConfig` from `SpecGanttConfig` = `z.input<typeof GanttConfigSchema>`, a type declared in `@objectstack/spec`. TypeScript cannot attach JSDoc to a member a type merely inherits, and the spec emits no per-member documentation of its own. So Option A has exactly two spellings, and both are refused:

1. **Delete the members and their prose** → the documentation is lost, which the charter forbids and which is the reason the restatements exist.
2. **Re-declare the members on `GanttConfig` to carry the JSDoc** → this does not *remove* a duplicate declaration, it **relocates** it out of a package-private type into the published `@object-ui/types`, onto the very type both authoring faces derive from. Per clause ②, that is a widened published surface and a different review tier.

**Option B — the type-level mutual-assignability pin — closes the defect with neither cost.** The prose stays exactly where it is (the diff is `+30 / −1` on `ObjectGantt.tsx`: pure addition, no line of documentation deleted), and no published surface moves.

> Derivation (`parentField?: GanttConfig['parentField']`, the pattern #6051 used for the flat face) was considered and rejected **for these keys**: `GanttConfig` carries `[x: string]: unknown` because its spec schema is `$loose`, so an indexed access into it never errors — a key the spec *removed* would silently resolve to `unknown` rather than failing. Deriving would also make the pin vacuous by construction, since both operands would become the same expression. The pin is what keeps a spec bump loud.

## The mechanism: naming the local half is the whole fix

The pin is impossible to write against `GanttConfigEx`, and writing it that way is the trap:

```ts
type GanttConfigEx = GanttConfig & { parentField?: string; /* … */ };
```

`GanttConfigEx['parentField']` is **already** `GanttConfig['parentField'] & string`, so it is assignable to `GanttConfig['parentField']` *by construction*. An assertion phrased over the intersection is green forever, no matter how far the two declarations drift — it measures nothing. Splitting the local half into a named `GanttConfigRestated` is what gives the pin two **independent** operands.

The core invariant is derived over `keyof GanttConfigRestated`, so there is no key list to fall out of date, and a violation **names the key** in the compiler error.

## Reverse verification — both legs, mutation proven on disk

Neither leg trusts an editor's exit code; each mutation was confirmed by anchored grep counts on both the injected and the removed text, plus a `git hash-object` comparison against the HEAD blob. Both scripts carried `trap … EXIT INT TERM` with absolute paths, and each restoration was proven **byte-identical to the HEAD blob** (not by the restore command's exit code).

**Leg 1 — the pin has teeth.** Predicted direction: red, naming the key. Mutated `capacity?: number` → `capacity?: string` (`number;` count 1→0, `string;` count 0→1, disk hash ≠ HEAD blob), then compiled:

```
src/ObjectGantt.configPin.test.ts(117,11): error TS2322: Type 'true' is not assignable to type '"capacity"'.
```

The error **names `capacity`** — that is the instrument doing its job. Restored: disk hash `e39b5b07…` = HEAD blob `e39b5b07…`.

**Leg 2 — the vacuity control guards itself.** Predicted direction: TS2578. Mutated `Mutual` into an always-true form, then compiled:

```
src/ObjectGantt.configPin.test.ts(139,5): error TS2578: Unused '@ts-expect-error' directive.
```

So the `@ts-expect-error` in the non-vacuity test is **live**: if `Mutual` ever stops having teeth, the directive goes unused and the build fails. Restored: disk hash `830af148…` = HEAD blob `830af148…`.

No `@ts-expect-error` directive elsewhere was disturbed — `packages/types` `type-check` (which compiles `gantt-flat-config-declared-keys.test.ts`, whose `:354` / `:358` directives pin `quickFilters` and `timeSegments`) is clean, with `grep -c 'error TS'` = 0. This change touches zero files under `packages/types`.

## Clause ② — established on built `dist/index.d.ts`, not on source keywords

- **`@object-ui/types`: no member added, removed or re-typed.** The diff touches **zero** files in that package. Re-export chain shown to terminate: `dist/index.d.ts:72` re-exports `GanttConfig` `from './objectql.js'` → `dist/objectql.d.ts:141` `export type GanttConfig = SpecGanttConfig & {`. That is the terminus, and it is untouched.
- **`@object-ui/plugin-gantt`: `GanttConfigRestated` does not reach the published entry.** After a real `vite build`, `packages/plugin-gantt/dist/index.d.ts` carries **0** occurrences of it (`index.tsx` re-exports named symbols explicitly and this is not among them). Positive control on the same file: `QuickFilterDef`, which *is* re-exported, appears **1** time — so the grep can find what is there.

No published surface changes, which is precisely why this route was chosen over the JSDoc lift.

## Verification

Every heavy command ran through the container's shared verify lock; each verdict below is the gate's own printed line, and exit codes were captured before any pipe.

| Gate | Result |
| --- | --- |
| `pnpm --filter @object-ui/plugin-gantt run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0` |
| `vitest run` — pin suite + `quickfilter` + `shifts` + `blockPrecedence` | `Test Files 4 passed (4)` · `Tests 45 passed (45)` |
| `vitest run` — pin suite alone (non-vacuity: it really runs) | `Test Files 1 passed (1)` · `Tests 6 passed (6)` |
| `pnpm --filter @object-ui/types run type-check` | clean, `error TS` count 0 — no TS2578 |
| `check-changeset-presence` | `✅ … declares 1 changeset(s) … EMPTY frontmatter … a complete answer to this gate` |
| `check-changeset-no-major` | `✅ No changeset declares a 'major' bump.` |
| `check:control-bytes` · `check:self-import` · `check:phantom-deps` · `check:vi-mock-specifiers` · `lint:coverage` | exit 0 each |
| `pnpm --filter @object-ui/plugin-gantt lint` | `VERDICT command-exit 0` — 0 errors; the new file contributes 0 findings |

**Lint scope.** The affected package was linted **whole** (`turbo run lint`'s own unit), so nothing was narrowed inside it. Only `packages/plugin-gantt` has changed files, and no other package's lint program input moved — established above on the built `dist/index.d.ts`, not assumed.

**One gate is NOT MEASURED, and is reported as such rather than as green.** `check:readme-exports` exits 1 with its own `❌ the population COLLAPSED -- this run proves nothing`, naming the cause: `packagesRead: found 14, floor is 25`, with `23 unbuilt`. It needs a full-workspace build, which CI performs. It reads no file this diff touches (no README changed; no package entry export added). Recorded as a prerequisite-not-met, not as a passing or failing measurement.

Also self-scanned both changed files and the changeset for raw control bytes (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`): no matches.

## Scope

`#6470` — the `dependencyField` alias card in the same file family — is **not addressed here** and remains open, as the dispatch order directed. `packages/types/src/feedback.ts` and `packages/types/src/zod/feedback.zod.ts` were not touched.

_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_