### PR TITLE
fix(types): narrow `SonnerSchema.buttonVariant` to the six Button variants

### DIFF
--- a/.changeset/6541-sonner-button-variant-enum.md
+++ b/.changeset/6541-sonner-button-variant-enum.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/types': minor
+---
+
+**Accept-set NARROWING on a published surface.** `SonnerSchema.buttonVariant` in the zod
+mirror (`@object-ui/types/zod`) was `z.string()`; it is now
+`z.enum(['default', 'secondary', 'destructive', 'outline', 'ghost', 'link'])`. Values
+outside those six — `'primary'`, `'danger'`, `'Default'`, `''` — used to validate and now
+fail. Stated as a narrowing rather than as a fix, because it removes values the published
+mirror accepted (objectui#6541).
+
+**What was wrong.** The same key on the same component shipped as two disagreeing published
+faces: an open string to anyone validating (`@object-ui/types/zod`), and a closed
+six-member union to anyone type-checking (`@object-ui/types`, `SonnerSchema.buttonVariant`
+in `feedback.ts`). The TS face was already correct — only the mirror is changed here, so
+this is the mirror being made to agree with a declaration that sat beside it all along.
+
+**Why the wide face was wrong and not merely wide.** `renderers/feedback/sonner.tsx` passes
+the value straight into `<Button variant={…}>`, whose vocabulary is exactly those six keys
+of `buttonVariants`. Measured on `cva` 0.7.1, an unrecognised key contributes **no** variant
+class, and `defaultVariants` applies only when the value is absent *or falsy*:
+
+```
+buttonVariants({ variant: undefined }) -> "… bg-primary text-primary-foreground …"  default look
+buttonVariants({ variant: 'ghost'   }) -> "… hover:bg-accent …"                     real variant
+buttonVariants({ variant: 'primary' }) -> "…"                                       NO colour at all
+buttonVariants({ variant: ''        }) -> "… bg-primary …"                          silently 'default'
+```
+
+So the mirror was validating values the renderer visibly breaks on: `'primary'` — the
+likeliest wrong spelling, since the default variant's own class is `bg-primary` — rendered a
+button with no background and no text colour, and `''` was silently reinterpreted as
+`default`. Nothing that renders correctly today stops validating.
+
+**Blast radius, measured.** The key stays optional, so every published `sonner` node that
+omits it keeps parsing. The two fixtures in the repo that set it
+(`examples/schema-catalog/src/schemas/components-feedback-sonner/{error,promise-based-toast}.json`)
+use `destructive` and `outline` — both inside the six. No consumer was found relying on a
+seventh spelling.
+
+**Model inherited, not invented.** objectui#6496 landed exactly this spelling on
+`ToastSchema` for the same trigger mechanism, matched to `ButtonProps['variant']` as ground
+truth. This card applies the settled shape to the sibling that still disagreed with itself.

--- a/packages/components/src/__tests__/toast-button-variant-parity.test.ts
+++ b/packages/components/src/__tests__/toast-button-variant-parity.test.ts
@@ -7,15 +7,17 @@
  */
 
 /**
- * `ToastSchema['buttonVariant']` ↔ Button vocabulary parity (objectui#6496).
+ * `buttonVariant` ↔ Button vocabulary parity, for BOTH nodes that carry the key
+ * (objectui#6496 for `toast`, objectui#6541 for `sonner`).
  *
  * objectui#6496 declared `buttonLabel` / `buttonVariant` on `ToastSchema`, and
  * the shape of the second one was the card's whole judgement call. The sibling
- * it was told to copy disagrees with ITSELF — `SonnerSchema` spells
+ * it was told to copy disagreed with ITSELF — `SonnerSchema` spelled
  * `buttonVariant` as `z.string()` in the zod mirror and as a six-member union
- * in TS — so "match the sibling" picks nothing. The ground truth is what the
+ * in TS — so "match the sibling" picked nothing. The ground truth is what the
  * value REACHES: `renderers/feedback/toast.tsx:30` passes it straight into
- * `<Button variant={…}>`, so `ButtonProps['variant']` is the authority.
+ * `<Button variant={…}>`, so `ButtonProps['variant']` is the authority. (That
+ * sibling disagreement is closed by objectui#6541, below.)
  *
  * `@object-ui/types` has zero deps and cannot import the Button, so the
  * declaration there is necessarily a hand-copied list. THIS file is what stops
@@ -29,14 +31,47 @@
  * does not render "some other style", it renders a button with no background
  * and no text colour. That is the concrete cost the enum buys out, and it is
  * measured here rather than asserted in prose.
+ *
+ * ## objectui#6541 — `sonner` joins, and its ZOD MIRROR is pinned here too
+ *
+ * The `sonner` node carries the same two keys and reaches the same `<Button>`
+ * (`renderers/feedback/sonner.tsx` passes `variant={schema.buttonVariant}`).
+ * Its TS face had declared the six all along; its zod MIRROR was an open
+ * `z.string()`, so one key on one component shipped as a closed union to
+ * type-checkers and an open string to validators. #6541 narrowed the mirror to
+ * the enum — an accept-set NARROWING on a published surface, stated as such.
+ *
+ * That narrowing is pinned HERE rather than in
+ * `types/src/__tests__/zod-mirror-parity.test.ts`, and the reason is the reason
+ * the drift survived: that census compares in ONE direction — "the mirror
+ * accepts everything the declaration declares". A mirror WIDER than its
+ * declaration passes it and earns no ledger entry, so the wider-than-declared
+ * class is invisible across all 158 pairs. The block below measures the other
+ * direction — everything the mirror ACCEPTS is a value the Button actually
+ * draws — and it can only be measured somewhere `Button` is in scope, which
+ * `@object-ui/types` (zero deps, no React) by construction is not.
+ *
+ * ⛔ The one-directionality of that census is its own subject and is NOT
+ * touched here.
  */
 
 import { describe, it, expect } from 'vitest';
-import type { ToastSchema } from '@object-ui/types';
+import type { SonnerSchema, ToastSchema } from '@object-ui/types';
+import { SonnerSchema as SonnerMirror } from '@object-ui/types/zod';
 import { buttonVariants, type ButtonProps } from '../ui/button';
 
-/** The six as `ToastSchema` declares them. */
+/** The six as `ToastSchema` and `SonnerSchema` both declare them. */
 const DECLARED = ['default', 'secondary', 'destructive', 'outline', 'ghost', 'link'] as const;
+
+/** A minimal `sonner` node — every key on it other than `type` is optional. */
+const MINIMAL_SONNER = { type: 'sonner' } as const;
+
+/**
+ * The values that make the open `z.string()` wrong, each paired with what the
+ * Button actually draws for it. Read as a table so the schema-side assertions
+ * below cannot drift away from the rendering they claim to justify.
+ */
+const NOT_A_VARIANT = ['primary', 'danger', 'warning', 'Default', '__not-a-variant__'] as const;
 
 /**
  * What `buttonVariants` emits for a value it does not recognise: the base
@@ -44,6 +79,29 @@ const DECLARED = ['default', 'secondary', 'destructive', 'outline', 'ghost', 'li
  * is measured against this string rather than against a hand-written class list.
  */
 const NO_VARIANT_CLASSES = buttonVariants({ variant: '__not-a-variant__' as never });
+
+/**
+ * The zod mirror's accept-set for `SonnerSchema.buttonVariant`, READ off the
+ * schema instead of restated next to it — a restated list is the same artefact
+ * the drift keeps producing.
+ *
+ * `.options` exists only on `ZodEnum`. If this key ever goes back to
+ * `z.string()` there is nothing to read, and this throws naming the card rather
+ * than comparing an empty list against an empty list and passing.
+ */
+function mirrorAcceptSet(): readonly string[] {
+  type Unwrappable = { unwrap?: () => unknown; def?: { innerType?: unknown } };
+  const key: unknown = SonnerMirror.shape.buttonVariant;
+  const inner = (key as Unwrappable).unwrap?.() ?? (key as Unwrappable).def?.innerType ?? key;
+  const options: unknown = (inner as { options?: unknown }).options;
+  if (!Array.isArray(options)) {
+    throw new Error(
+      "`SonnerSchema.buttonVariant` is not an enum in the zod mirror: it accepts more than " +
+        'the Button can draw (objectui#6541).',
+    );
+  }
+  return options as readonly string[];
+}
 
 describe('the declared `buttonVariant` vocabulary is the Button’s own', () => {
   it('every declared value is a real Button variant (it contributes a class)', () => {
@@ -109,5 +167,68 @@ describe('why the mirror is an enum and not `z.string()`', () => {
     // schema: omission already has a defined, styled outcome downstream.
     expect(buttonVariants({ variant: undefined })).toBe(buttonVariants({ variant: 'default' }));
     expect(buttonVariants({ variant: undefined })).not.toBe(NO_VARIANT_CLASSES);
+  });
+});
+
+describe('`sonner` declares the same vocabulary on BOTH of its published faces', () => {
+  it('the TS face matches `ButtonProps["variant"]` in BOTH directions', () => {
+    // Same construction as the `toast` pin above, against the same ground
+    // truth. This half was already true before objectui#6541 — the TS face was
+    // never the problem — but it is what the mirror is now pinned equal to, so
+    // it belongs in the same file rather than being assumed.
+    type Accepted = NonNullable<ButtonProps['variant']>;
+    type Declared = NonNullable<SonnerSchema['buttonVariant']>;
+
+    const declaredIsAccepted: Accepted = null as unknown as Declared;
+    const acceptedIsDeclared: Declared = null as unknown as Accepted;
+
+    expect([declaredIsAccepted, acceptedIsDeclared]).toHaveLength(2);
+  });
+
+  it('the ZOD MIRROR accepts exactly the six — the direction the census cannot see', () => {
+    // Set equality, read off the schema rather than restated. Under the old
+    // `z.string()` there is no `.options` to read at all, so `mirrorAcceptSet`
+    // throws naming the card instead of quietly comparing nothing.
+    expect([...mirrorAcceptSet()].sort()).toEqual([...DECLARED].sort());
+  });
+
+  it('the mirror accepts every value the Button actually draws', () => {
+    // The direction `zod-mirror-parity.test.ts` does cover, kept here so the
+    // pair is symmetric: a later narrowing that dropped a real look would fail
+    // BOTH the census and this line.
+    for (const value of DECLARED) {
+      const result = SonnerMirror.safeParse({ ...MINIMAL_SONNER, buttonVariant: value });
+      expect(result.success, `mirror refused real Button variant '${value}'`).toBe(true);
+    }
+  });
+
+  it('the mirror refuses the values that render colourless — measured, not assumed', () => {
+    // Each rejection is paired with the rendering that justifies it, in the
+    // same iteration: the schema refuses the value AND the Button draws no
+    // variant class for it. Neither half is load-bearing alone — the first
+    // without the second is taste, the second without the first is the bug.
+    for (const value of NOT_A_VARIANT) {
+      expect(buttonVariants({ variant: value as never }), value).toBe(NO_VARIANT_CLASSES);
+      const result = SonnerMirror.safeParse({ ...MINIMAL_SONNER, buttonVariant: value });
+      expect(result.success, `mirror accepted non-variant '${value}'`).toBe(false);
+    }
+  });
+
+  it('the mirror refuses `""` — the one wrong value that does not look wrong', () => {
+    // Its own pin because its rendering is the opposite of the block above:
+    // `cva`'s falsy fallback resolves `''` to `default`, so under the old
+    // `z.string()` an author could write `buttonVariant: ''`, see a correctly
+    // styled button, and never learn the value meant nothing.
+    expect(buttonVariants({ variant: '' as never })).toBe(buttonVariants({ variant: 'default' }));
+    expect(SonnerMirror.safeParse({ ...MINIMAL_SONNER, buttonVariant: '' }).success).toBe(false);
+  });
+
+  it('the key stays OPTIONAL — a bare `{ type: "sonner" }` still parses', () => {
+    // The narrowing is on the accept-set of the VALUE, not on requiredness.
+    // Every published `sonner` node that omits the key keeps parsing, and the
+    // two catalog fixtures that set it (`destructive`, `outline`) are inside
+    // the six — this is what bounds the blast radius of the narrowing.
+    const result = SonnerMirror.safeParse(MINIMAL_SONNER);
+    expect(result.success ? null : result.error.issues).toBe(null);
   });
 });

--- a/packages/types/src/__tests__/toast-button-keys.test.ts
+++ b/packages/types/src/__tests__/toast-button-keys.test.ts
@@ -145,11 +145,13 @@ describe('ToastSchema — the two trigger-button keys are declared (objectui#649
     }
   });
 
-  it('is NOT `z.string()` — the shape `SonnerSchema`’s mirror uses for the same key', () => {
+  it('is NOT `z.string()` — the shape `SonnerSchema`’s mirror used for the same key', () => {
     // Stated as a pin because the obvious way to write this card was to copy the
-    // sibling mirror verbatim. Sonner's two faces disagree with each other
-    // (`z.string()` vs the six-member union); that disagreement is filed as
-    // objectui#6541 and deliberately NOT resolved here.
+    // sibling mirror verbatim, and at the time Sonner's two faces disagreed with
+    // each other (`z.string()` vs the six-member union). That disagreement was
+    // filed as objectui#6541 rather than fixed here, and #6541 has since
+    // narrowed Sonner's mirror to this same enum — so the two nodes now agree,
+    // and this pin keeps guarding the shape rather than the sibling.
     expect(ToastSchema.safeParse({ ...MINIMAL, buttonVariant: 'anything-at-all' }).success).toBe(false);
   });
 

--- a/packages/types/src/zod/feedback.zod.ts
+++ b/packages/types/src/zod/feedback.zod.ts
@@ -80,9 +80,9 @@ export const ToastSchema = BaseSchema.extend({
   // `buttonVariants`. `cva` contributes no variant class for an unrecognised
   // key, so a non-empty string outside the six renders an unstyled button —
   // and `''` is silently resolved to `default` by cva's falsy fallback
-  // (objectui#6496). ⚠️ `SonnerSchema` below spells the same key
-  // `z.string()` while its TS face declares the six-member union — that
-  // disagreement is filed as objectui#6541, NOT resolved here.
+  // (objectui#6496). `SonnerSchema` below carries the same pair of keys and
+  // now the same enum: it spelled `buttonVariant` as `z.string()` while its TS
+  // face declared the six-member union, and objectui#6541 closed that gap.
   buttonLabel: z.string().optional().describe('Trigger button label'),
   buttonVariant: z
     .enum(['default', 'secondary', 'destructive', 'outline', 'ghost', 'link'])
@@ -134,7 +134,19 @@ export const SonnerSchema = BaseSchema.extend({
   description: z.string().optional().describe('Toast description'),
   variant: z.enum(['default', 'success', 'warning', 'error', 'info']).optional().describe('Toast variant'),
   buttonLabel: z.string().optional().describe('Action button label'),
-  buttonVariant: z.string().optional().describe('Action button variant'),
+  // Narrowed from `z.string()` by objectui#6541 — an accept-set NARROWING on a
+  // published surface, not a widening. The reason is the one spelled out on
+  // `ToastSchema` above: `renderers/feedback/sonner.tsx` hands this value
+  // straight to `<Button variant={…}>`, whose vocabulary is the six keys of
+  // `buttonVariants`, and `cva` contributes no variant class outside them. The
+  // TS face in `../feedback.ts` has declared exactly these six all along — this
+  // mirror is what disagreed with it. Pinned against the Button's own
+  // vocabulary, in BOTH directions, in
+  // `components/src/__tests__/toast-button-variant-parity.test.ts`.
+  buttonVariant: z
+    .enum(['default', 'secondary', 'destructive', 'outline', 'ghost', 'link'])
+    .optional()
+    .describe('Action button variant'),
 });
 
 /**


### PR DESCRIPTION
Fixes #6541

## ⚠️ This is an accept-set NARROWING on a published surface

Read this as a narrowing, not as a fix. `@object-ui/types/zod` currently accepts **any string**
for `SonnerSchema.buttonVariant`; after this PR it accepts exactly six. `'primary'`, `'danger'`,
`'Default'` and `''` validate green today and start failing.

Measured on the **built, published** artifact, before and after (method below):

| `buttonVariant` | before (`bf3a03c1d`) | after (`a5c2ac6e8`) | what the Button draws |
|---|---|---|---|
| `'default'` / `'ghost'` / `'link'` (and the other three) | ACCEPTED | ACCEPTED | the real variant |
| `'primary'` | ACCEPTED | **REJECTED** | no background, no text colour |
| `'danger'` | ACCEPTED | **REJECTED** | no background, no text colour |
| `'Default'` | ACCEPTED | **REJECTED** | no background, no text colour |
| `''` | ACCEPTED | **REJECTED** | silently the `default` look |
| omitted | ACCEPTED | ACCEPTED | the `default` look |

The direction is right — it restores declared = enforced, and every value that stops validating
is one the renderer visibly breaks on — but it removes values a published validator accepted, so
it wants the review a narrowing gets rather than the review a fix gets.

## What was actually wrong

One key, on one component, shipped as **two disagreeing published faces**:

```
packages/types/src/zod/feedback.zod.ts:137   buttonVariant: z.string().optional()…      ← open to validators
packages/types/src/feedback.ts:255           buttonVariant?: 'default' | … | 'link';    ← closed to type-checkers
```

The TS face was already correct. **`packages/types/src/feedback.ts` is untouched by this PR** —
this is the mirror being made to agree with a declaration that had been sitting beside it all
along, not a shape being chosen.

Why the open string is wrong and not merely wide: `packages/components/src/renderers/feedback/sonner.tsx:36`
passes the value straight into `<Button variant={…}>`, whose vocabulary is exactly the six keys of
`buttonVariants`. On `cva` 0.7.1 an unrecognised key contributes **no** variant class, and
`defaultVariants` applies only when the value is absent *or falsy*.

The shape is **inherited, not invented**: #6496 landed exactly this `z.enum` on `ToastSchema` for
the same trigger mechanism (merged as `bf3a03c1d`), matched to `ButtonProps['variant']` as ground
truth.

## Clause ② — the published shape change, established on the BUILT artifact

Not from a source `export` keyword and not from a grep of the entry file. The chain, walked to its
terminus, on `packages/types/dist` built from this branch:

1. `packages/types/package.json` → `exports['./zod'].types` = `./dist/zod/index.zod.d.ts`
2. `dist/zod/index.zod.d.ts:40` → `export { …, SonnerSchema, … } from './feedback.zod.js';`
3. `dist/zod/feedback.zod.d.ts:436` → `export declare const SonnerSchema: z.ZodObject<{ … }>` — terminal declaration:

```ts
    buttonLabel: z.ZodOptional<z.ZodString>;          // still z.string() — the contrast in-artifact
    buttonVariant: z.ZodOptional<z.ZodEnum<{
        default: "default";  secondary: "secondary";  destructive: "destructive";
        outline: "outline";  ghost: "ghost";          link: "link";
    }>>;
```

The same three lines at `bf3a03c1d`, built the same way in a throwaway worktree, read
`buttonVariant: z.ZodOptional<z.ZodString>;`.

The runtime half was measured through the **published specifier**, not through a source path —
`import.meta.resolve('@object-ui/types/zod')` reported
`file:///…/packages/types/dist/zod/index.zod.js` on both trees. That is where the before/after
table above comes from.

## The pin, and why it is not in the mirror census

`packages/types/src/__tests__/zod-mirror-parity.test.ts` compares in **one direction** — "the
mirror accepts everything the declaration declares" — so a mirror *wider* than its declaration
passes it and earns no ledger entry. That is why this stood. It is one-directional by
construction and **is not touched here**; if that should change it is its own card.

The pin instead extends `packages/components/src/__tests__/toast-button-variant-parity.test.ts`,
which is where `Button` is in scope (`@object-ui/types` has zero deps and cannot import it) and
where the two-direction check already lived. Five new assertions on `sonner`:

- the TS face matches `ButtonProps['variant']` in both directions (type-level, and it *is*
  compiled — see below);
- the **zod mirror** accepts exactly the six, by set equality read off `.options` rather than
  restated. Under a `z.string()` there is no `.options` to read, so it throws naming the card
  instead of comparing two empty lists and passing;
- every value the Button draws is accepted;
- every value that renders colourless is refused — each rejection paired **in the same iteration**
  with the `buttonVariants()` call that shows the breakage, so neither half can drift from the
  other;
- `''` gets its own pin, because its rendering is the opposite of the others (silently `default`);
- the key stays optional, so a bare `{ type: 'sonner' }` still parses.

## Reverse verification

Performed on the committed state, restored from `HEAD` (not from `origin/main`), with a
`trap … EXIT INT TERM` and absolute paths.

Mutation: the enum put back to `z.string()`. Proven on disk before measuring — injected text
`grep -c` = 1, removed text `grep -c` = 1, and the blob hash moved
`6f8dd04f…` → `c2c969e4…`. No rebuild was involved and none was needed: the vitest alias
(`vitest.config.mts:260`) maps `@object-ui/types/zod` to **source**, and `dist/` still held the
enum at that moment — so a pin reading `dist` would have stayed green. It did not:

```
 × the ZOD MIRROR accepts exactly the six — the direction the census cannot see
     Error: `SonnerSchema.buttonVariant` is not an enum in the zod mirror … (objectui#6541)
 × the mirror refuses the values that render colourless — measured, not assumed
     AssertionError: mirror accepted non-variant 'primary': expected true to be false
 × the mirror refuses `""` — the one wrong value that does not look wrong
 Test Files  1 failed | 1 passed (2)   Tests  3 failed | 15 passed (18)
```

**The second measurement is the point of the card**: in that same run
`zod-mirror-parity.test.ts` **passed**. The census is green on the exact defect, which is the
blindness #6541 documents, reproduced rather than quoted.

Restore leg proven the same way, not by an exit code: `git diff HEAD` empty and the blob hash back
to `6f8dd04f…`, byte-identical to `HEAD`. Re-run on the restored tree: 4 files, 61 tests, all
passing.

## Also in this diff — one comment correction, named rather than slipped in

`packages/types/src/__tests__/toast-button-keys.test.ts` carried, from #6496, a test title and
comment asserting in the present tense that Sonner's mirror **is** `z.string()` and that the
disagreement is "deliberately NOT resolved here". This PR makes both sentences false. Prose only —
the assertion under them is unchanged and still guards `ToastSchema`. Same defect class, same file
family, same gate family, and no in-flight PR touches `packages/types`. The stale sentence in the
parity test's own header got the same treatment.

`content/docs/components/feedback/sonner.mdx:46` needed **no** change — it already documented the
six-member union, because it was describing the TS face. The mirror was the outlier; the docs now
match both faces. (Verified, not assumed.)

## Blast radius

The key stays optional. The only fixtures in the repo that set it —
`examples/schema-catalog/src/schemas/components-feedback-sonner/{error,promise-based-toast}.json` —
use `destructive` and `outline`, both inside the six. A repo-wide `buttonVariant` sweep found no
consumer relying on a seventh spelling, so there is no fork to report.

## Verification (all on `a5c2ac6e8`, the final commit)

Heavy commands ran through the container's shared verify lock; each verdict below is the gate's own
line, not a bare `$?`.

- `pnpm exec vitest run packages/components/src/__tests__/toast-button-variant-parity.test.ts packages/types/src/__tests__/toast-button-keys.test.ts packages/types/src/__tests__/zod-mirror-parity.test.ts examples/schema-catalog/test/component-fixture-declared-keys.test.ts`
  → `Test Files 4 passed (4)` / `Tests 61 passed (61)`
- `pnpm --filter @object-ui/types type-check && pnpm --filter @object-ui/components type-check` → exit 0
  (both script names echoed, so neither was a zero-match no-op). `tsc -p packages/components/tsconfig.test.json
  --listFiles` confirms the edited test file **is** in the program — the type-level pins are compiled,
  not merely written.
- `node scripts/check-changeset-presence.mjs` → `✅ 3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)`
- `check-changeset-no-major` → `✅ No changeset declares a major bump.` · `check-changeset-fixed` → `✅` ·
  `check-changeset-overwrite` → `✅ No pre-existing changeset was modified or deleted.`
- `check-control-bytes` → `✅ OK (scanned 5407 tracked text file(s))`, plus a direct
  `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over the four changed files: no match.
- `check:phantom-deps` → `✅ Every in-scope import is declared by the package that publishes it.`
  (the new `@object-ui/types/zod` import is a declared dependency of `@object-ui/components`) ·
  `check:self-import` `✅` · `check:doc-types` `✅` · `check:designer-field-key-parity` `OK` ·
  `check:vi-mock-specifiers` `✅`

**Declared narrowings, so they read as measurements and not as gaps:**

- **Lint** was run on the three changed source files (`--no-inline-config`, `--format json`:
  3 files, 0 errors, 0 warnings) rather than repo-wide. The narrowing is sound because
  `eslint.config.js` enables **no type-aware linting** (no `project` / `projectService`) and no
  package carries its own config — so this diff cannot move the verdict on any file it does not
  touch. CI runs the full farm regardless.
- `check:doc-snippets` and `check-readme-exports` were **NOT MEASURED** here, not green and not
  red: both exited on their own precondition (`PRECONDITION NOT MET (exit 2) — the snippet program
  was NOT run`; `the population COLLAPSED — this run proves nothing`, `packagesRead: found 2, floor
  is 25`), because they need the whole workspace built. Not narrowed, not skipped quietly — CI owns
  them.
- Full `pnpm test` / `pnpm type-check` / `pnpm lint` belong to CI.

## Overlap with in-flight work

None. Open PRs #6543 (`plugin-designer`), #6544 (`app-shell`), #6546 (`plugin-gantt`) share no file
or package with this diff, and the named in-flight cards (#6465, #6332, #6534, #6538) are in other
packages.

## Out of scope

A third specimen for the "three declared surfaces disagree" class — `buttonVariant` is declared on
both published faces of both `toast` and `sonner` and read by both renderers, but appears in
neither registry `inputs` array — was recorded as a comment on #4631 rather than filed as a new
card, because that is the class #4631 is `pm:on-hold` to decide and a separate issue would fragment
it. #4631 remains open and nothing here changes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_