### PR TITLE
fix(app-shell): answer `id: null` for a signed-out predicate identity, so a `ctx.user.id` gate bites instead of failing open

### DIFF
--- a/.changeset/anonymous-expression-user-id-6534.md
+++ b/.changeset/anonymous-expression-user-id-6534.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The predicate identity bound for a signed-out visitor now carries `id: null`, so a
+`ctx.user.id` visibility gate BITES instead of failing open (objectui#6534).
+
+`buildExpressionUser` has two branches, and only the signed-in one carried `id`.
+So `'id' in buildExpressionUser(null)` was `false`, and an absent key is not
+`false`: a CEL predicate naming `ctx.user.id` / `current_user.id` / `os.user.id`
+hit an unbound key for a signed-out visitor and FAULTED. A faulting visibility
+predicate fails OPEN (`evaluateVisibility`), so the gated field or action rendered
+for exactly the principal it was written to exclude, with nothing on screen to say
+the gate had not bitten — silently, for every signed-out visitor.
+
+Because the defect was in the shared normaliser rather than at a mount site, it
+reached EVERY mount site, including `AppContent` and the console's
+`InternalFormRoute`, both of which have always called the normaliser correctly.
+This is the same fault-open mechanism objectui#6515 fixed one level up, where
+`RecordFormPage` hand-rolled a descriptor missing `id` and `isPlatformAdmin`.
+
+`null` rather than `undefined`, and rather than leaving the key absent, is settled
+by precedent on this exact object rather than chosen here. objectui#5424 removed
+`roles` from it because a present-and-always-`undefined` key "is the shape that
+teaches the wrong thing" — the context answers rather than being plainly absent,
+and the answer is silently wrong; `undefined` here would reproduce that defect one
+key over. Leaving it absent IS the defect. `null` is a VALUE a CEL author can
+compare against, so `ctx.user.id == '…'` resolves to a clean FALSE. Measured, not
+assumed: at a real mount site with `authState.user = null` and a field gated on
+`ctx.user.id == 'u_admin'`, the field is now filtered OUT of the schema handed to
+`ObjectForm`, where before it was present.
+
+This also closes the last asymmetry between the two branches. Both now advertise
+the same six keys, which is the symmetry objectui#5424 was closing when it removed
+`roles` — and the shape pin now asserts the key sets are equal, so a future edit
+that adds a key to one branch and forgets the other fails whichever branch it
+forgets.
+
+NOT CHANGED, deliberately: fail-open on a predicate that DOES fault. That is
+shipped permission-boundary policy (objectui#6443 / #6487 / #6445) and remains
+exactly as it was — an unevaluable `visible` still renders. This change removes a
+REASON to fault; it does not touch what happens once a predicate has. No accept set
+is widened, no gate is relaxed and no fallback is added: the only behavioural
+movement is that an id-gated surface which used to render for anonymous visitors
+now hides from them.

--- a/packages/app-shell/src/console/__tests__/AppContent.expressionUserShape.test.ts
+++ b/packages/app-shell/src/console/__tests__/AppContent.expressionUserShape.test.ts
@@ -113,12 +113,95 @@ describe('objectui#5424 — `buildExpressionUser` stops advertising the retired 
     const anonymous = buildExpressionUser(null);
 
     expect('roles' in anonymous).toBe(false);
+    // objectui#6534 widened this from five keys to six by adding `id: null`.
+    // That is a TIGHTENING of the pin, not a weakening of it, and it was graded
+    // as part of the fix rather than a breach — triage, 2026-08-26, verbatim:
+    //
+    //   "Updating `AppContent.expressionUserShape.test.ts`'s five-key pin is
+    //    part of the fix, not a breach"
+    //
+    // The pin's job is unchanged and its strictness is unchanged: it still
+    // enumerates the WHOLE object with `toStrictEqual`, so an added key, a
+    // dropped key or a key written as explicit `undefined` all still fail here.
+    // Only the enumerated set moved, and it moved to CLOSE the last asymmetry
+    // between the two branches — which is the same symmetry objectui#5424 was
+    // closing when it removed `roles`.
     expect(anonymous).toStrictEqual({
+      id: null,
       name: 'Anonymous',
       email: '',
       role: 'guest',
       isPlatformAdmin: false,
       positions: [],
     });
+  });
+});
+
+/**
+ * objectui#6534 — the anonymous branch ANSWERS `id` instead of omitting it.
+ *
+ * `id` was signed-in-only, so `'id' in buildExpressionUser(null)` was `false`.
+ * An absent key is not `false`: `ctx.user.id == '…'` FAULTS for a signed-out
+ * visitor, and a faulting visibility predicate fails OPEN
+ * (`evaluateVisibility`), so an id-gated field rendered for exactly the
+ * principal it was written to exclude — at EVERY mount site, including the two
+ * that have always called this normaliser correctly.
+ *
+ * ## Why `null` and not `undefined`
+ *
+ * Settled by precedent on this very object, not chosen here. objectui#5424
+ * removed `roles` because present-and-always-`undefined` "is the shape that
+ * teaches the wrong thing" — the context answers rather than being plainly
+ * absent, and the answer is silently wrong. `null` is a VALUE: a CEL author can
+ * compare against it and the comparison resolves. `undefined` would reproduce
+ * exactly the defect objectui#5424 measured, one key over.
+ *
+ * ## Why `in` and not just a value assertion
+ *
+ * Same reason the `roles` pin above uses it: `{ id: undefined }` and `{}` both
+ * read as `undefined` at `user.id`, so only key PRESENCE distinguishes the
+ * three candidate shapes. The `in` check and the value check together are what
+ * separate `null` from both rejected alternatives — neither alone does.
+ *
+ * ## Fenced boundary
+ *
+ * This is NOT a change to fail-open. A predicate that faults still renders
+ * (objectui#6443 / #6487 / #6445 — deliberate, and untouched by this card).
+ * What changed is that this predicate no longer faults.
+ */
+describe('objectui#6534 — the anonymous branch answers `id` rather than omitting it', () => {
+  it('advertises `id` on the anonymous branch', () => {
+    // The pin. This is the assertion that was `false` before the fix, and it is
+    // the one that moves between all three candidate shapes.
+    expect('id' in buildExpressionUser(null)).toBe(true);
+  });
+
+  it('answers `null` there — a value a predicate can compare against', () => {
+    const anonymous = buildExpressionUser(null);
+
+    expect(anonymous.id).toBeNull();
+    // Explicitly NOT `undefined`: that is the shape objectui#5424 rejected on
+    // this object, and `toBeNull` alone would not catch it being reintroduced
+    // as `undefined` on a future edit — `toBeUndefined` would pass on `{}` too.
+    expect(anonymous.id).not.toBeUndefined();
+  });
+
+  it('agrees with the signed-in branch on the key set — the asymmetry is closed', () => {
+    // objectui#5424 removed `roles` to make the two branches agree on one
+    // shape; `id` was the last key they still disagreed on. A future edit that
+    // adds a key to one branch and forgets the other fails HERE, whichever
+    // branch it forgets, without needing to know which key was added.
+    const signedIn = buildExpressionUser(PROTOCOL_17_USER);
+    const anonymous = buildExpressionUser(null);
+
+    expect(Object.keys(anonymous).sort()).toEqual(Object.keys(signedIn).sort());
+  });
+
+  it('still distinguishes anonymous from a signed-in user by VALUE, not by key set', () => {
+    // The converse guard: converging the key sets must not make the two
+    // branches indistinguishable. A gate excluding a signed-out visitor reads
+    // the value, and the values still differ.
+    expect(buildExpressionUser(null).id).toBeNull();
+    expect(buildExpressionUser(PROTOCOL_17_USER).id).toBe('u_1');
   });
 });

--- a/packages/app-shell/src/providers/expressionUser.mountParity.test.tsx
+++ b/packages/app-shell/src/providers/expressionUser.mountParity.test.tsx
@@ -58,9 +58,11 @@
  *     `toContain` — the fault fails OPEN, so the field is PRESENT;
  *   - the same for the signed-IN `ctx.user.id` case, and for the signed-out
  *     `isPlatformAdmin` case;
- *   - `RECORDS: a ctx.user.id gate STILL fails open for a signed-out visitor`
- *     stays GREEN both ways — it measures the normaliser's own anonymous
- *     branch, which this card does not touch;
+ *   - `hides a ctx.user.id-gated field from a signed-out visitor` stays GREEN
+ *     both ways — it measures the normaliser's own anonymous branch, which
+ *     THIS card does not touch. (It was named `RECORDS: a ctx.user.id gate
+ *     STILL fails open for a signed-out visitor` and asserted the opposite
+ *     until objectui#6534 fixed that branch; see the case body.)
  *   - `grants ... to a platform admin` stays GREEN — fail-open and a correct
  *     `true` are indistinguishable at the call site, which is the whole reason
  *     the excluded-user cases carry the pin.
@@ -259,29 +261,41 @@ describe('objectui#6515 — the record form page publishes the normaliser’s `c
     expect(lastFields()).not.toContain('plan_canonical');
   });
 
-  it('RECORDS: a `ctx.user.id` gate STILL fails open for a signed-out visitor', async () => {
-    // Measurement, not endorsement — and NOT something this card changes.
+  it('hides a `ctx.user.id`-gated field from a signed-out visitor', async () => {
+    // objectui#6534 — this case is the inverted successor of objectui#6515's
+    // `RECORDS: a ctx.user.id gate STILL fails open for a signed-out visitor`.
     //
-    // `buildExpressionUser(null)` returns `{ name, email, role,
-    // isPlatformAdmin, positions }`. There is no `id` key on that branch, so
-    // `ctx.user.id == '…'` faults for a signed-out visitor and fails OPEN, at
-    // EVERY mount site — `AppContent` and `InternalFormRoute` included, both of
-    // which have always called the normaliser. That asymmetry is in the
-    // normaliser's own anonymous branch, not in this page, and closing it means
-    // changing the shape `AppContent.expressionUserShape.test.ts` pins, which
-    // is a decision of its own (`id: null`? `id: undefined`? — objectui#5424
-    // rejected present-and-undefined as the shape that teaches the wrong
-    // thing). Filed separately rather than widened into this PR.
+    // That case recorded the defect as a passing fact: `'id' in
+    // buildExpressionUser(null)` was `false` and the excluded field was
+    // `toContain`-present. Both assertions are flipped below, and the flip is
+    // this card's reverse verification — the pin was GREEN on `origin/main`
+    // (measured: 13/13 passing) and went RED the instant `id: null` landed,
+    // which is what proves the normaliser's anonymous branch is the thing that
+    // moved.
     //
-    // Pinned so the follow-up has a red test to turn green, and so this stays
-    // a measured fact rather than an assumption. The signed-IN case above is
-    // the one this card fixes: there `id` is present and the gate bites.
+    // ⚠️ The SECOND assertion is the load-bearing one and it is not
+    // interchangeable with the first. `'id' in …` only proves the key exists;
+    // it says nothing about whether CEL can compare against `null` rather than
+    // faulting on it a second way. Only the rendered field list proves the gate
+    // actually BITES — that `ctx.user.id == 'u_admin'` resolves to a clean
+    // FALSE for an anonymous visitor and the field is filtered out. If `null`
+    // merely relocated the fault, the first assertion would still pass and this
+    // one would still find the field present.
+    //
+    // Fenced boundary (objectui#6443 / #6487 / #6445): fail-open on a predicate
+    // that DOES fault is deliberate and is untouched. This asserts that this
+    // predicate no longer faults, not that a faulting one now fails closed.
     authState.user = null;
     renderPage();
     await waitFor(() => expect(formSchemas.length).toBeGreaterThan(0));
 
-    expect('id' in buildExpressionUser(null)).toBe(false);
-    expect(lastFields()).toContain('self_note');
+    expect('id' in buildExpressionUser(null)).toBe(true);
+    expect(buildExpressionUser(null).id).toBeNull();
+    // Ungated fields are untouched — this narrowed exactly one gate, and the
+    // filter still lets everything else by. Without this line a change that
+    // dropped ALL fields would pass the assertion below.
+    expect(lastFields()).toContain('name');
+    expect(lastFields()).not.toContain('self_note');
   });
 
   it('grants the `isPlatformAdmin` gate to a platform admin', async () => {

--- a/packages/app-shell/src/providers/expressionUser.ts
+++ b/packages/app-shell/src/providers/expressionUser.ts
@@ -51,6 +51,25 @@
  * two branches agree on one shape. Both branches carry `isPlatformAdmin` and
  * `positions` for the same reason: a predicate naming either must evaluate to
  * FALSE, not fault.
+ *
+ * `id` is on BOTH branches for that same reason, and it is the last place the
+ * two disagreed (objectui#6534). It used to be signed-in-only, so
+ * `'id' in buildExpressionUser(null)` was `false` and a gate naming
+ * `ctx.user.id` / `current_user.id` / `os.user.id` faulted for every signed-out
+ * visitor — measured at a real mount site in
+ * `expressionUser.mountParity.test.tsx`, where the excluded field was PRESENT
+ * in the schema handed to `ObjectForm`. Anonymous now answers `null`, which is
+ * a VALUE a CEL author can compare against, so the predicate resolves FALSE
+ * instead of faulting.
+ *
+ * ## What this module does NOT decide
+ *
+ * Fail-open on a predicate that DOES fault stays deliberate policy
+ * (objectui#6443 / #6487 / #6445): an unevaluable `visible` still renders, and
+ * that verdict is `evaluateVisibility`'s to make, not this normaliser's. Every
+ * shape rule above works the same way — it removes REASONS to fault, so fewer
+ * predicates ever reach that policy. None of them touches what the policy does
+ * once one has.
  */
 export function buildExpressionUser(user: unknown): Record<string, unknown> {
   const u = user as
@@ -58,7 +77,23 @@ export function buildExpressionUser(user: unknown): Record<string, unknown> {
     | null
     | undefined;
   if (!u) {
-    return { name: 'Anonymous', email: '', role: 'guest', isPlatformAdmin: false, positions: [] };
+    return {
+      // `null`, not absent — objectui#6534. An ABSENT key is not `false`: it
+      // makes `ctx.user.id == '…'` FAULT, and a faulting visibility predicate
+      // fails OPEN (`evaluateVisibility`), so an id-gated field rendered for
+      // exactly the signed-out visitor it was written to exclude, silently, at
+      // EVERY mount site. `null` ANSWERS: the comparison is a clean FALSE and
+      // the gate bites. Not `undefined` — objectui#5424 measured on this same
+      // object that a present-and-always-`undefined` key "is the shape that
+      // teaches the wrong thing", which is why `roles` is absent rather than
+      // forwarded as `undefined`.
+      id: null,
+      name: 'Anonymous',
+      email: '',
+      role: 'guest',
+      isPlatformAdmin: false,
+      positions: [],
+    };
   }
   return {
     id: u.id,


### PR DESCRIPTION
Fixes #6534

`buildExpressionUser` carried `id` on its signed-in branch only, so `'id' in buildExpressionUser(null)` was `false`. An absent key is not `false`: a CEL predicate naming `ctx.user.id` / `current_user.id` / `os.user.id` hit an unbound key for a signed-out visitor and FAULTED, and a faulting visibility predicate fails OPEN (`evaluateVisibility`) — so the gated field rendered for exactly the principal it was written to exclude, silently, for every signed-out visitor. Because the defect was in the shared normaliser rather than at a mount site, it reached **every** mount site, `AppContent` and the console's `InternalFormRoute` included, both of which have always called the normaliser correctly.

The anonymous branch now answers `id: null`.

## The shape was graded, not chosen here

`null` rather than `undefined` rather than absent is settled by existing rulings. Triage's grading, 2026-08-26, verbatim:

> of the card's three shapes, `id: undefined` is barred by #5424's own precedent on this exact object ("present-and-always-undefined teaches the wrong thing"), and "leave it absent" *is* the defect (accepting fail-open on anonymous sessions, defensible only via a census nobody has taken) — so the dispatch shape is **`id: null` on the anonymous branch** […] **Updating `AppContent.expressionUserShape.test.ts`'s five-key pin is part of the fix, not a breach — cite this grading in the PR.**

So, on the record: **the five-key pin becoming a six-key pin is a graded part of this fix, not a weakened pin.** Its strictness is untouched — it still enumerates the whole object with `toStrictEqual`, so an added key, a dropped key, or a key written as explicit `undefined` all still fail there. Only the enumerated set moved, and it moved to *close* the last asymmetry between the two branches, which is the same symmetry objectui#5424 was closing when it removed `roles`. The pin also gains a key-set-equality assertion, so a future edit that adds a key to one branch and forgets the other now fails whichever branch it forgets, without needing to know which key was added.

## ⭐ The fenced boundary is intact

Fail-open on a predicate that **does** fault stays deliberate policy (objectui#6443 / #6487 / #6445) and this diff does not touch it. **Nothing in the diff is in a fault-handling path** — `evaluateVisibility`, `reportUnresolvableVisibilityPredicate` and every `catch` are untouched; the only production change is one key added to one object literal. This removes a *reason* to fault; it does not change what happens once a predicate has.

Likewise the scope fence: this is a tightening and only a tightening. No accept set is widened, no gate is relaxed, and **no fallback is added** — in particular the signed-in branch is deliberately left as `id: u.id` rather than gaining a `?? null` (see "Out of scope" below). The only behavioural movement is that an id-gated surface which used to render for anonymous visitors now hides from them.

## Reverse verification

The card arrived with its own pin, so I did not author the primary red. **One correction worth recording: it arrives GREEN, not red.** objectui#6515's dev wrote `RECORDS: a ctx.user.id gate STILL fails open for a signed-out visitor` to record the defect as a *passing fact* —

```ts
expect('id' in buildExpressionUser(null)).toBe(false);
expect(lastFields()).toContain('self_note');
```

— so it passes on `main` and goes RED the instant `id: null` lands. Its own file header predicts exactly that ("stays GREEN both ways" for #6515's diff). The flip is the reverse verification.

**Direction predicted before running**, then measured, on the untouched pins against the modified source:

| | predicted | measured |
|---|---|---|
| `RECORDS: …` | RED | RED — `expected true to be false` at `'id' in buildExpressionUser(null)` |
| anonymous `toStrictEqual` five-key | RED | RED — `+ "id": null` in the received object |
| all other cases | GREEN | GREEN |

`2 failed | 11 passed (13)` — exactly the two cases named, no unforeseen movement.

⚠️ **The `RECORDS:` case died on its *first* assertion, so that run did not prove the gate actually bites.** `'id' in …` only shows the key exists; it says nothing about whether CEL can compare against `null` rather than faulting a second way. The rewritten case proves the behavioural half, and it is the load-bearing assertion:

```ts
expect(lastFields()).toContain('name');        // the filter still lets everything else by
expect(lastFields()).not.toContain('self_note'); // the gate BITES
```

That now passes: with `authState.user = null` and a field gated `ctx.user.id == 'u_admin'`, the field is filtered OUT of the schema handed to `ObjectForm`, where before it was present. This is corroborated by the repo's own documentation of the engine — `content/docs/layout/page-header.mdx` names both halves, the fault (`Reason: [runtime] No such key: id`) and the fact that a `null` operand is "a clean `false`" rather than a fault.

## Evidence

All runs serialized through the container's shared verify lock; verdicts are the lock's own VERDICT lines, not a bare `$?`.

**Union re-run after the final commit, at `bf422b783`, tree clean:**

```
pnpm exec vitest run $(cat scope.txt)        # 51 files, the measured import radius
 Test Files  51 passed (51)
      Tests  593 passed (593)
os-verify-lock: VERDICT command-exit 0 · held the lock 148s (2m28s)
```

- **Typecheck** — `tsc --noEmit` and `tsc -p tsconfig.test.json` in `packages/app-shell`, after building the dependency closure (`--filter '@object-ui/app-shell^...' build`, VERDICT command-exit 0). Both green, zero `error TS`. The test project is the one that compiles tests, and I verified my edited files are genuinely *in* those programs rather than trusting a clean run: `--listFilesOnly` finds `AppContent.expressionUserShape.test.ts` and `expressionUser.mountParity.test.tsx` in the test program (of 4459 files) and `providers/expressionUser.ts` in the source program.
- **Lint** — full repo `pnpm lint`: `47 successful, 47 total`, VERDICT command-exit 0. The five `no-explicit-any` **warnings** reported against `expressionUser.mountParity.test.tsx` are pre-existing and inherited from `main` — they sit at lines 88/89/118/125/180 in the untouched fixture region, while this diff's hunks are `@@ -61,3 +61,5 @@` and `@@ -262…292 @@`.
- **Changeset gates** — `check-changeset-presence.mjs`: `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`. `check-changeset-no-major.mjs`: `✅ No changeset declares a major bump.`
- **Control bytes** — `✅ check-control-bytes: OK (scanned 5407 tracked text file(s))`, plus a direct `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` over all four changed files: clean.
- `check:esm-specifiers` ✅, `check:self-import` ✅ (`0 self-import`).

### Declared narrowing, and one gate not measured locally

`packages/app-shell` has **551 test files**, past this container's foreground budget, so I ran a **measured** import radius rather than a guessed subset: every test file that imports the normaliser (5), plus every test file importing one of the four modules that call it or the package barrel (19), plus the whole predicate/expression surface of the two packages that mount it (36) — union 51, listed in the run above. CI runs the full farm regardless; this narrowing is declared, not silent.

`check:eager-closure` is **NOT MEASURED** locally — it needs a built `apps/console/dist/eager-closure.json` and says so itself ("This is a broken gauge, not a sensitive gate"), i.e. a prerequisite failure, not a red gate. It is also structurally unaffected: `expressionUser.ts` remains a zero-import leaf, and the diff adds **no import statement anywhere** (verified against the diff). Left to CI.

## Census: no fork

The card said to stop and report if any anonymous surface relies on the key's *absence*. I looked and found none: no `'id' in user`, no `hasOwnProperty('id')`, no predicate written to exploit it anywhere in `packages/` or `apps/`. The only `'id' in` against this object in the repo was the `RECORDS:` pin itself, which is this card's to flip. No fork.

## Out of scope

objectui#6551 records an adjacent observation this change made visible by fixing the other half: the **signed-in** branch forwards `id` / `name` / `email` raw out of a cast that declares all three optional, so a session missing one yields the present-and-`undefined` shape objectui#5424 barred — while the three keys below it already guard with `??`. It is not reachable today (the only production input is a better-auth principal whose `id` is required) and its correct shape is a genuine decision, not a mechanical edit, and one candidate is a consumer-side fallback that this card's fence forbids. Filed unassigned rather than folded in.

## Notes

- No docs change: nothing in `content/docs/` or the package README states the anonymous identity's key set, so nothing became false. Checked, not assumed.
- No collision with the in-flight cards — the file face is `packages/app-shell/src/providers/` and `src/console/__tests__/`; nothing here cites `tsconfig.typetests.json` or "compiled by nothing".
- Left as **draft** with no auto-merge, per the dispatch contract: CI convergence is the PM's to read.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_