### PR TITLE
fix(app-shell): make the Action designer's two panes agree on the param type vocabulary

### DIFF
--- a/.changeset/action-designer-param-vocabulary.md
+++ b/.changeset/action-designer-param-vocabulary.md
@@ -1,0 +1,24 @@
+---
+"@object-ui/app-shell": patch
+---
+
+fix(app-shell): the Action designer's preview draws what the runtime dialog will draw
+
+`ActionDefaultInspector` offers eight param `type` spellings; `ActionPreview`'s
+dialog mock switched on five of them over a private table, so three of the eight
+previewed as a control `ActionParamDialog` does not render — `datetime` and a
+targeted `lookup` as plain text boxes, and a `select` whose options were not
+authored yet as a text box as well. A `text` param that happened to carry
+`options` previewed as a select the runtime never draws, for the same reason in
+the other direction.
+
+The mock now resolves each param through `paramToField`'s
+`resolveParamWidgetType` / `paramDegradesWithoutTarget` — the same adapter the
+dialog itself renders through — so the two panes cannot disagree about a
+spelling again. `datetime` draws a date/time control, a `lookup` with a declared
+`reference` draws a record picker, a targetless one draws the record-id text box
+the dialog degrades to and says why, and a `select` always draws a picker.
+
+The per-param editor also gains an `options` control for `select` params. It had
+none, and `params` is hidden from the collapsed "More fields" form, so the panel
+that offered the type had nowhere to author the choices the type needs.

--- a/packages/app-shell/src/views/metadata-admin/ActionDesigner.paramVocabulary.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/ActionDesigner.paramVocabulary.test.tsx
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * **The Action designer's two panes agree on the param `type` vocabulary**
+ * (objectui#6538).
+ *
+ * `ActionPreview`'s declared job is "a faux button / dialog rendered so authors
+ * can see the visual weight before they ship it" — it shows what WILL render.
+ * `ActionDefaultInspector`'s `PARAM_TYPE_OPTS` decides what an author can pick.
+ * Until this card the two disagreed, and the preview lost: for three of the
+ * eight offered spellings it drew a control the runtime dialog does not draw.
+ *
+ * ## Where "what the runtime draws" comes from
+ *
+ * `ActionParamDialog` renders every param through the shared form field widgets
+ * (ADR-0059): `paramToField()` resolves the param's `type` to a widget key via
+ * `resolveParamWidgetType`, `paramDegradesWithoutTarget()` decides whether a
+ * picker collapses to a text box for want of a declared target, and
+ * `getLazyFieldWidget(key)` renders it. So the runtime's answer for a spelling
+ * is a pure function this file can call, and does — see {@link runtimeWidgetFor}.
+ *
+ * ## Why the expectations are hand-declared AND cross-checked
+ *
+ * `EXPECTED` below is read out of the runtime by a human: `datetime` renders
+ * `DateTimeField`, so its mock must be a datetime control, not a text box. If
+ * the test DERIVED each expectation from the same resolver the preview calls,
+ * it could never catch the preview calling the resolver wrongly — the pin would
+ * assert the implementation against itself. So the per-case expectation is
+ * literal, and a separate drift guard asserts that the literal table still
+ * matches what the resolver says. The first half is the pin; the second keeps
+ * it honest as the widget map moves.
+ *
+ * ## The population is EIGHT, not forty-nine
+ *
+ * `PARAM_TYPE_OPTS` is the population, imported rather than restated: the
+ * defect is that two panes of ONE designer disagree, not that the preview is
+ * incomplete against the spec's whole 49-member `FieldType`. The coverage
+ * guards below fail if a ninth spelling is offered without a case here, and if a
+ * case names a spelling the inspector does not offer.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, within } from '@testing-library/react';
+import type { ActionParam, ResolvableParamFieldType } from '@object-ui/types';
+
+// ActionDefaultInspector calls useObjectOptions()/useObjectFields() at mount
+// (objectui#4697) — stub the shared client so mounting escapes to no network.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('./useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
+import { paramDegradesWithoutTarget, resolveParamWidgetType } from '../../utils/paramToField.js';
+import { ActionPreview } from './previews/ActionPreview';
+import { ActionDefaultInspector, PARAM_TYPE_OPTS } from './inspectors/ActionDefaultInspector';
+import { __setCelFormulaLoader } from './celAuthoring';
+
+beforeEach(() => {
+  // Both ConditionBuilders mount unconditionally; give them a loader that
+  // resolves so nothing reaches for the real CEL engine during these renders.
+  __setCelFormulaLoader(() =>
+    Promise.resolve({
+      validateExpression: () => ({ ok: true, errors: [], warnings: [] }),
+      introspectScope: () => ({ fields: [], roots: [], functions: [] }),
+      inferExpressionType: () => 'boolean' as const,
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  __setCelFormulaLoader(undefined);
+});
+
+/** The eight spellings the inspector offers — the population, by reference. */
+const OFFERED: readonly string[] = PARAM_TYPE_OPTS.map((o) => o.value);
+
+/**
+ * A control the preview's dialog mock can draw, as a stable spelling.
+ * `input:*` is the DOM `type` of the rendered `<input>`; `record-picker` is the
+ * disabled combobox the preview mocks a `LookupField` with.
+ */
+type MockControl =
+  | 'input:text'
+  | 'input:number'
+  | 'input:date'
+  | 'input:datetime-local'
+  | 'input:checkbox'
+  | 'textarea'
+  | 'select'
+  | 'record-picker';
+
+/**
+ * The faithful mock for each runtime widget key the eight can resolve to.
+ * Hand-written on purpose (see the header): this is a human reading of what
+ * `@object-ui/fields` renders, which is the thing the preview is supposed to
+ * show. The drift guard below re-checks it against the resolver.
+ */
+const MOCK_FOR_RUNTIME_WIDGET: Readonly<Record<string, MockControl>> = {
+  text: 'input:text',
+  textarea: 'textarea',
+  number: 'input:number',
+  boolean: 'input:checkbox',
+  select: 'select',
+  date: 'input:date',
+  datetime: 'input:datetime-local',
+  lookup: 'record-picker',
+};
+
+interface Case {
+  /** One of the eight `PARAM_TYPE_OPTS` spellings. */
+  readonly spelling: ResolvableParamFieldType;
+  /** Extra authored keys that change what the runtime does with the spelling. */
+  readonly extra?: Partial<ActionParam>;
+  /** What the RUNTIME dialog draws for this param — read out of the runtime. */
+  readonly expected: MockControl;
+  readonly why: string;
+}
+
+const CASES: readonly Case[] = [
+  { spelling: 'text', expected: 'input:text', why: 'TextField' },
+  {
+    spelling: 'text',
+    extra: { options: [{ label: 'Duplicate', value: 'dup' }] },
+    expected: 'input:text',
+    why: 'options on a `text` param are ignored by the runtime — it still renders TextField',
+  },
+  { spelling: 'textarea', expected: 'textarea', why: 'TextAreaField' },
+  { spelling: 'number', expected: 'input:number', why: 'NumberField' },
+  { spelling: 'boolean', expected: 'input:checkbox', why: 'BooleanField, widget `checkbox`' },
+  {
+    spelling: 'select',
+    extra: { options: [{ label: 'Duplicate', value: 'dup' }, { label: 'Spam', value: 'spam' }] },
+    expected: 'select',
+    why: 'SelectField',
+  },
+  {
+    spelling: 'select',
+    expected: 'select',
+    why: 'SelectField renders an EMPTY picker with a placeholder — not a text box',
+  },
+  { spelling: 'date', expected: 'input:date', why: 'DateField' },
+  { spelling: 'datetime', expected: 'input:datetime-local', why: 'DateTimeField' },
+  {
+    spelling: 'lookup',
+    extra: { reference: 'account' },
+    expected: 'record-picker',
+    why: 'LookupField — a record picker, once a target is declared',
+  },
+  {
+    spelling: 'lookup',
+    expected: 'input:text',
+    why: 'a targetless lookup DEGRADES to a record-id text box (paramDegradesWithoutTarget)',
+  },
+];
+
+function paramFor(c: Case): ActionParam {
+  return { name: 'p', label: 'P', type: c.spelling, ...c.extra };
+}
+
+function describeCase(c: Case): string {
+  const extra = c.extra ? ` + ${Object.keys(c.extra).join('/')}` : '';
+  return `${c.spelling}${extra}`;
+}
+
+/**
+ * What `ActionParamDialog` would resolve this AUTHORED param to.
+ *
+ * The one rename this crossing needs: the authoring key is `reference`
+ * (`ActionParamSchema`), the resolved key `paramToField` reads is `referenceTo`
+ * — `resolveActionParams()` performs exactly that copy before the dialog sees a
+ * param. Nothing else is restated; the membership tables stay where they are.
+ */
+function runtimeWidgetFor(param: ActionParam): string {
+  const type = param.type as string;
+  const resolved = { name: param.name ?? '', label: '', type, referenceTo: param.reference };
+  return paramDegradesWithoutTarget(resolved) ? 'text' : resolveParamWidgetType(type);
+}
+
+function renderPreviewWith(param: ActionParam): HTMLElement {
+  const { container } = render(
+    <ActionPreview
+      type="action"
+      name="approve"
+      draft={{ name: 'approve', label: 'Approve', type: 'script', target: 'true', params: [param] }}
+    />,
+  );
+  return container as HTMLElement;
+}
+
+/**
+ * The one control the dialog mock drew for the one param in the draft.
+ *
+ * Asserting the count is part of the instrument: an empty match would make
+ * every `not.toBe('input:text')` pass vacuously, and two matches would mean the
+ * query is picking up something outside the mock.
+ */
+function drawnControl(container: HTMLElement): MockControl {
+  const controls = Array.from(
+    container.querySelectorAll('input, textarea, select, button[aria-haspopup="dialog"]'),
+  );
+  expect(controls.map((el) => el.outerHTML), 'exactly one control per param mock').toHaveLength(1);
+  const el = controls[0]!;
+  const tag = el.tagName.toLowerCase();
+  if (tag === 'select') return 'select';
+  if (tag === 'textarea') return 'textarea';
+  if (tag === 'button') return 'record-picker';
+  return `input:${(el as HTMLInputElement).type}` as MockControl;
+}
+
+describe('Action designer — the preview draws what the runtime dialog will draw (#6538)', () => {
+  it.each(CASES.map((c) => [describeCase(c), c] as const))(
+    'previews an offered `%s` param as the control the runtime renders',
+    (_name, c) => {
+      const container = renderPreviewWith(paramFor(c));
+      expect(
+        drawnControl(container),
+        `the inspector offers "${c.spelling}"; the runtime dialog draws ${c.why}`,
+      ).toBe(c.expected);
+    },
+  );
+
+  it('draws no offered spelling as a plain text box unless the runtime does', () => {
+    // The disagreement, stated as one sentence rather than per case: a text box
+    // in the preview is a CLAIM that the runtime shows a text box.
+    const lying = CASES.filter((c) => {
+      const drawn = drawnControl(renderPreviewWith(paramFor(c)));
+      cleanup();
+      return drawn === 'input:text' && MOCK_FOR_RUNTIME_WIDGET[runtimeWidgetFor(paramFor(c))] !== 'input:text';
+    }).map(describeCase);
+    expect(lying, 'these spellings preview as a text box the runtime dialog will not draw').toEqual([]);
+  });
+
+  // ── Guards on the instrument itself ──────────────────────────────────────
+
+  it('covers every spelling the inspector offers, and no other', () => {
+    const covered = [...new Set(CASES.map((c) => c.spelling as string))].sort();
+    expect(covered, 'PARAM_TYPE_OPTS is the population — a ninth entry needs a case here').toEqual(
+      [...OFFERED].sort(),
+    );
+  });
+
+  it('the hand-declared expectations still match what the runtime resolver says', () => {
+    const drifted = CASES.filter((c) => MOCK_FOR_RUNTIME_WIDGET[runtimeWidgetFor(paramFor(c))] !== c.expected).map(
+      (c) => `${describeCase(c)} → ${runtimeWidgetFor(paramFor(c))} (expected mock ${c.expected})`,
+    );
+    expect(drifted, 'the widget map moved under this table — re-read the runtime before editing').toEqual([]);
+  });
+
+  it('every runtime widget the eight resolve to has a declared mock', () => {
+    const unmapped = CASES.map((c) => runtimeWidgetFor(paramFor(c))).filter(
+      (w) => MOCK_FOR_RUNTIME_WIDGET[w] === undefined,
+    );
+    expect([...new Set(unmapped)]).toEqual([]);
+  });
+
+  it('an untyped (field-backed) param keeps inferring from its options', () => {
+    // Not one of the eight: a `{ field: … }` param carries no `type` in the
+    // draft and the designer does not resolve object metadata here, so options
+    // are the only evidence the preview has. Pinned so the type-driven
+    // switch above cannot quietly take this case with it.
+    const withOptions = renderPreviewWith({ field: 'status', options: [{ label: 'Open', value: 'open' }] });
+    expect(drawnControl(withOptions)).toBe('select');
+    cleanup();
+    expect(drawnControl(renderPreviewWith({ field: 'status' }))).toBe('input:text');
+  });
+});
+
+/* ─────────────── The other half of the same seam ─────────────── */
+
+/**
+ * Stateful harness — the inspector is CONTROLLED, so a committed patch has to
+ * round-trip through the draft or the next commit reverts the last one.
+ */
+function InspectorHarness({ onDraft, params }: {
+  onDraft: (d: Record<string, unknown>) => void;
+  params: ActionParam[];
+}) {
+  const [draft, setDraft] = React.useState<Record<string, unknown>>({
+    name: 'approve',
+    label: 'Approve',
+    type: 'script',
+    params,
+  });
+  React.useEffect(() => onDraft(draft), [draft, onDraft]);
+  return (
+    <ActionDefaultInspector
+      type="action"
+      name="approve"
+      draft={draft}
+      onPatch={(patch: Record<string, unknown>) => setDraft((d) => ({ ...d, ...patch }))}
+      readOnly={false}
+      locale={'en-US' as never}
+    />
+  );
+}
+
+function renderInspector(params: ActionParam[]) {
+  const seen: Record<string, unknown>[] = [];
+  const onDraft = (d: Record<string, unknown>) => { seen.push(d); };
+  render(<InspectorHarness onDraft={onDraft} params={params} />);
+  return { latestParams: () => (seen.at(-1)?.params ?? []) as ActionParam[] };
+}
+
+describe('Action designer — the panel that offers `select` can author its options (#6538)', () => {
+  it('offers an options editor for a select param', () => {
+    renderInspector([{ name: 'reason', label: 'Reason', type: 'select' }]);
+    // Before this card the per-param editor had controls for field, name,
+    // label, type, placeholder, required and defaultFromRow — and no way at all
+    // to author `options`. `params` is in CURATED_FIELDS, so the collapsed
+    // "More fields" SchemaForm hides the whole array too: there was nowhere in
+    // this panel to put them.
+    expect(screen.getByRole('group', { name: 'Options' })).toBeInTheDocument();
+  });
+
+  it('writes an authored option onto the param the preview reads', () => {
+    const { latestParams } = renderInspector([{ name: 'reason', label: 'Reason', type: 'select' }]);
+    const group = () => screen.getByRole('group', { name: 'Options' });
+    fireEvent.click(within(group()).getByRole('button', { name: /add option/i }));
+    fireEvent.change(within(group()).getByLabelText('Label'), { target: { value: 'Duplicate' } });
+    fireEvent.change(within(group()).getByLabelText('Value'), { target: { value: 'dup' } });
+    expect(latestParams()[0]?.options).toEqual([{ label: 'Duplicate', value: 'dup' }]);
+  });
+
+  it('shows no options editor for a spelling the runtime does not read options for', () => {
+    renderInspector([{ name: 'note', label: 'Note', type: 'text' }]);
+    expect(screen.queryByRole('group', { name: 'Options' })).toBeNull();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ActionDefaultInspector.tsx
@@ -112,7 +112,15 @@ const BODY_LANG_OPTS = [
  * the way `long_text` reached `ActionPreview` while the local `type?: string`
  * was still in force (objectui#6329).
  */
-const PARAM_TYPE_OPTS = [
+/*
+ * Exported for objectui#6538's pin, which compares what this dropdown OFFERS
+ * against what `ActionPreview` draws — and reads the eight from here by
+ * reference rather than restating them, so a ninth entry has to fail that pin.
+ * A hand-kept copy of the vocabulary could not. The cost is this panel's fast
+ * refresh, which the directive below accepts by name.
+ */
+// eslint-disable-next-line react-refresh/only-export-components -- see above
+export const PARAM_TYPE_OPTS = [
   { value: 'text', label: 'Text' },
   { value: 'textarea', label: 'Long text' },
   { value: 'number', label: 'Number' },
@@ -298,6 +306,94 @@ function FieldPicker({ label, objectName, value, onCommit, disabled }: {
     return <InspectorTextField label={label} value={value ?? ''} onCommit={onCommit} disabled={disabled} mono />;
   }
   return <InspectorSelectField label={label} value={value || undefined} options={[{ value: '', label: '—' }, ...options]} onCommit={onCommit} disabled={disabled} />;
+}
+
+/** One entry of `ActionParam.options`, read off the published type. */
+type ActionParamOption = NonNullable<ActionParam['options']>[number];
+
+/**
+ * Options editor for a `select` param — the choices the dialog will offer.
+ *
+ * ## Why this exists (objectui#6538)
+ *
+ * `PARAM_TYPE_OPTS` offers `Select`, and `ActionPreview` draws the picker the
+ * dialog will render — but until this card the per-param editor had controls
+ * for `field`, `name`, `label`, `type`, `placeholder`, `required` and
+ * `defaultFromRow`, and none for `options`. The panel that offered the type
+ * could not produce the data the type needs.
+ *
+ * Triage allowed either a real control or a visible POINTER to wherever options
+ * are authored. The pointer lost on measurement: `params` is listed in
+ * {@link CURATED_FIELDS}, so the collapsed "More fields" `SchemaForm` hides the
+ * whole array too. The only surface that could author `options` was the raw
+ * JSON source tab — i.e. the pointer would have had to say "leave the
+ * designer", which is the designer conceding it cannot author its own offered
+ * type. So: a control.
+ *
+ * ## Scoped to `select`, deliberately
+ *
+ * `select` is the only spelling among the eight whose runtime widget reads
+ * `options` (`SelectField`). A `text` param carrying `options` is not an
+ * author's mistake to be enabled here — `TextField` ignores them, which is
+ * exactly what the preview now shows.
+ *
+ * Localised labels: an option label committed here is written as a plain
+ * string, flattening an authored `{ en, fr-FR }` map — the same trade the
+ * param's own "Label" control above has always made. Locale maps stay
+ * authorable through the JSON source tab.
+ */
+function ParamOptionsEditor({ options, onCommit, disabled }: {
+  options: ActionParamOption[] | undefined;
+  onCommit: (next: ActionParamOption[]) => void;
+  disabled?: boolean;
+}) {
+  const opts = Array.isArray(options) ? options : [];
+  return (
+    <div role="group" aria-label="Options" className="space-y-1.5 rounded-md border border-dashed border-border p-2">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Options</div>
+      {opts.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground/80">
+          No choices yet — a Select with no options opens an empty picker in the dialog.
+        </p>
+      ) : (
+        opts.map((o, j) => (
+          <div key={j} className="flex items-start gap-1">
+            <div className="grid flex-1 grid-cols-2 gap-2">
+              <InspectorTextField
+                label="Label"
+                value={localize(o.label)}
+                onCommit={(v) => onCommit(spliceArray(opts, j, { ...o, label: v }))}
+                disabled={disabled}
+              />
+              <InspectorTextField
+                label="Value"
+                value={o.value ?? ''}
+                onCommit={(v) => onCommit(spliceArray(opts, j, { ...o, value: v }))}
+                disabled={disabled}
+                mono
+              />
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="mt-[22px] h-6 w-6"
+              disabled={disabled}
+              aria-label={`Remove option ${j + 1}`}
+              onClick={() => onCommit(spliceArray(opts, j, null))}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ))
+      )}
+      {!disabled && (
+        <Button type="button" variant="outline" size="sm" onClick={() => onCommit(appendArray(opts, { label: '', value: '' }))}>
+          <Plus className="mr-1 h-3.5 w-3.5" /> Add option
+        </Button>
+      )}
+    </div>
+  );
 }
 
 /*
@@ -495,6 +591,16 @@ export function ActionDefaultInspector({
               <InspectorTextField label="Label" value={localize(p.label)} onCommit={(v) => patchParam(i, { label: v })} disabled={readOnly} />
               {!p.field && (
                 <InspectorSelectField label="Type" value={p.type || undefined} options={PARAM_TYPE_OPTS} onCommit={(v) => patchParam(i, { type: asParamFieldType(v) })} disabled={readOnly} />
+              )}
+              {/* `select` is the one offered spelling whose runtime widget reads
+                  `options` — see ParamOptionsEditor for why this is a control
+                  and not a pointer (objectui#6538). */}
+              {!p.field && p.type === 'select' && (
+                <ParamOptionsEditor
+                  options={p.options}
+                  onCommit={(next) => patchParam(i, { options: next.length > 0 ? next : undefined })}
+                  disabled={readOnly}
+                />
               )}
               <InspectorTextField label="Placeholder" value={p.placeholder ?? ''} onCommit={(v) => patchParam(i, { placeholder: v })} disabled={readOnly} />
               <div className="flex flex-wrap gap-x-4 gap-y-1">

--- a/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
@@ -36,12 +36,14 @@ import {
   MoreHorizontal,
   Pencil,
   RefreshCw,
+  Search,
   Sparkles,
   Square,
   Workflow,
   icons as lucideIcons,
 } from 'lucide-react';
 import type { ActionParam } from '@object-ui/types';
+import { paramDegradesWithoutTarget, resolveParamWidgetType } from '../../../utils/paramToField.js';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewMessage, PreviewErrorBoundary } from './PreviewShell.js';
 
@@ -368,50 +370,172 @@ function DialogMock({ title, params, variant }: { title: string; params: ActionP
   );
 }
 
+/**
+ * Stand-in target for a FIELD-BACKED picker. Not a real object name — only a
+ * non-empty value, so `paramDegradesWithoutTarget` answers "a target exists".
+ * The real one arrives from the bound field at runtime
+ * (`resolveActionParams`: `referenceTo: param.reference ?? field.reference_to`).
+ */
+const INHERITED_TARGET = '(inherited from the bound field)';
+
+/**
+ * The widget key `ActionParamDialog` will render this param through, and
+ * whether that widget DEGRADED to a text box for want of a target.
+ *
+ * Asked of the adapter that PERFORMS the mapping (`paramToField`'s
+ * `resolveParamWidgetType` / `paramDegradesWithoutTarget`), never restated
+ * here. The preview's declared job is to show what will render, so "what will
+ * render" has to be one question with one answer — the same discipline
+ * objectui#5654 imposed on the dialog's own hint logic.
+ *
+ * Before objectui#6538 this function did not exist: `renderFieldMock` switched
+ * on the RAW authored spelling over a private table of five, while
+ * `PARAM_TYPE_OPTS` offered eight. Three of the eight previewed as something
+ * the runtime does not draw — `datetime` and `lookup` as plain text boxes, and
+ * a `select` whose options were not authored yet as a text box too — and a
+ * `text` param that happened to carry `options` previewed as a select the
+ * runtime never renders (it resolves `text`, and `TextField` reads no options).
+ *
+ * Two crossings this function owns, and nothing else:
+ *
+ *  1. **`reference` → `referenceTo`.** `reference` is the AUTHORING spelling
+ *     (`ActionParamSchema`); `referenceTo` is the RESOLVED one the predicate
+ *     reads. `resolveActionParams()` performs exactly that copy before the
+ *     dialog sees a param, and this preview reads the UNRESOLVED draft, so the
+ *     rename happens here. The membership tables stay where they are.
+ *  2. **A field-backed param is never previewed as degraded.** Its target is
+ *     inherited from the bound field at runtime; the designer has not resolved
+ *     that field here, so claiming the degradation would be the same lie
+ *     pointing the other way.
+ *
+ * `widget: undefined` means the draft declares no `type` at all — a field-backed
+ * param whose type the runtime inherits from object metadata this preview does
+ * not load. Genuinely unresolvable here, which is why the caller may fall back
+ * to the only other evidence it has; see there.
+ */
+function runtimeWidgetFor(p: ActionParam): { widget: string | undefined; degraded: boolean } {
+  if (!p.type) return { widget: undefined, degraded: false };
+  const referenceTo = p.reference ?? (p.field ? INHERITED_TARGET : undefined);
+  const degraded = paramDegradesWithoutTarget({ name: p.name ?? '', label: '', type: p.type, referenceTo });
+  return { widget: degraded ? 'text' : resolveParamWidgetType(p.type), degraded };
+}
+
 function renderFieldMock(p: ActionParam): React.ReactElement {
   const cls = 'w-full text-xs px-2 py-1 border rounded bg-background pointer-events-none';
   const placeholder = p.placeholder || (p.defaultFromRow ? '(from selected row)' : '');
   const def = p.defaultValue;
-  if (Array.isArray(p.options) && p.options.length > 0) {
-    return (
-      <select className={cls} disabled value="">
-        <option value="">{placeholder || '— select —'}</option>
-        {p.options.map((o, i) => (
-          <option key={i} value={o.value}>
-            {localize(o.label)}
-          </option>
-        ))}
-      </select>
-    );
-  }
-  if (p.type === 'boolean') {
-    return (
-      <label className="inline-flex items-center gap-1.5 text-xs">
-        <input type="checkbox" disabled className="pointer-events-none" /> Toggle
-      </label>
-    );
-  }
-  // No `long_text` / `integer` branches (objectui#6329). Both are spellings
-  // from OTHER vocabularies — `long_text` from the console's form-builder
-  // dialect (`apps/console/src/components/FormPage.tsx`), `integer` from JSON
-  // Schema (`ToolPreview.tsx`, `json-schema-to-fields.ts`) — and neither is in
-  // `ResolvableParamFieldType`, which is the spec's 49-member `FieldType` plus
-  // objectui's three declared param aliases. `ActionParamSchema` is `.strict()`
-  // with a `FieldType` enum on `type`, so a param spelled either way is a parse
-  // rejection on the server and can never reach this preview. The local
-  // `type?: string` was the only thing that made the comparisons compile.
-  if (p.type === 'textarea' || p.type === 'html') {
-    return <textarea className={`${cls} min-h-[48px]`} placeholder={placeholder} value={def != null ? String(def) : ''} readOnly />;
-  }
-  return (
-    <input
-      type={p.type === 'number' ? 'number' : p.type === 'date' ? 'date' : 'text'}
-      className={cls}
-      placeholder={placeholder}
-      value={def != null ? String(def) : ''}
-      readOnly
-    />
+  const value = def != null ? String(def) : '';
+  const options = Array.isArray(p.options) ? p.options : [];
+  const label = localize(p.label) || p.name || p.field || 'value';
+  const { widget, degraded } = runtimeWidgetFor(p);
+
+  const inputMock = (type: string) => (
+    <input type={type} className={cls} placeholder={placeholder} value={value} readOnly />
   );
+  const selectMock = (
+    <select className={cls} disabled value="">
+      <option value="">{placeholder || `Select ${label}`}</option>
+      {options.map((o, i) => (
+        <option key={i} value={o.value}>
+          {localize(o.label)}
+        </option>
+      ))}
+    </select>
+  );
+  const note = (text: React.ReactNode) => <div className="text-[10px] text-amber-700">{text}</div>;
+
+  // No declared `type`: a field-backed param inherits its type from the object
+  // field, and this preview resolves no object metadata. Authored `options` are
+  // then the only evidence of what the dialog will draw, so they still decide —
+  // the one place in this function where they may. Everywhere below, the
+  // resolved WIDGET decides and options are read only where the widget reads
+  // them, because that is what the runtime does.
+  if (widget === undefined) return options.length > 0 ? selectMock : inputMock('text');
+
+  // A targetless picker collapses to a record-id text box in the dialog, with
+  // its own placeholder and help text (#3405). The box alone would be honest
+  // about the control and silent about the reason, which is the state that
+  // help text was added for.
+  if (degraded) {
+    return (
+      <div className="space-y-0.5">
+        <input type="text" className={cls} placeholder={placeholder || `Record id for ${label}`} value={value} readOnly />
+        {note(
+          <>
+            No <code className="font-mono">reference</code> object is configured, so the record picker is
+            unavailable and the dialog asks for a record id.
+          </>,
+        )}
+      </div>
+    );
+  }
+
+  switch (widget) {
+    case 'boolean':
+      return (
+        <label className="inline-flex items-center gap-1.5 text-xs">
+          <input type="checkbox" disabled className="pointer-events-none" /> Toggle
+        </label>
+      );
+    // `html` is NOT one of the eight spellings `PARAM_TYPE_OPTS` offers, and
+    // objectui#6538 scoped this preview's population to exactly those eight. It
+    // rides along with `textarea` because that is what this function already
+    // drew for it; dropping it while narrowing to the population would be a
+    // regression wearing a narrowing's clothes.
+    //
+    // No `long_text` / `integer` branches (objectui#6329). Both are spellings
+    // from OTHER vocabularies — `long_text` from the console's form-builder
+    // dialect (`apps/console/src/components/FormPage.tsx`), `integer` from JSON
+    // Schema (`ToolPreview.tsx`, `json-schema-to-fields.ts`) — and neither is in
+    // `ResolvableParamFieldType`. `ActionParamSchema` is `.strict()` with a
+    // `FieldType` enum on `type`, so a param spelled either way is a parse
+    // rejection on the server and can never reach this preview.
+    case 'textarea':
+    case 'html':
+      return <textarea className={`${cls} min-h-[48px]`} placeholder={placeholder} value={value} readOnly />;
+    case 'select':
+      // `SelectField` renders a picker either way — an EMPTY one when no
+      // choices are authored. Drawing a text box there was the preview
+      // disagreeing with the dialog about the control; drawing a silent empty
+      // picker would disagree with it about whether anything is missing.
+      return options.length > 0 ? (
+        selectMock
+      ) : (
+        <div className="space-y-0.5">
+          {selectMock}
+          {note('No choices authored yet — the dialog opens an empty picker.')}
+        </div>
+      );
+    case 'number':
+      return inputMock('number');
+    case 'date':
+      return inputMock('date');
+    case 'datetime':
+      return inputMock('datetime-local');
+    case 'lookup':
+      // `LookupField` is a combobox that opens a record picker — mocked with
+      // the same disabled-combobox shape the designer's other pickers use, so
+      // an author can tell a record picker from a text box at a glance.
+      return (
+        <button
+          type="button"
+          disabled
+          role="combobox"
+          aria-expanded={false}
+          aria-haspopup="dialog"
+          className={`${cls} flex items-center gap-1.5 text-left text-muted-foreground`}
+        >
+          <Search className="h-3 w-3 shrink-0" aria-hidden />
+          <span className="truncate">{placeholder || `Search ${p.reference ?? 'records'}…`}</span>
+        </button>
+      );
+    default:
+      // Every remaining widget key is outside the eight this designer offers: a
+      // param can only carry one by hand-editing the JSON source, and the text
+      // box is what this preview has always drawn for them. Extending the mock
+      // vocabulary past `PARAM_TYPE_OPTS` is deliberately not this card.
+      return inputMock('text');
+  }
 }
 
 function ResultDialogMock({ dialog }: { dialog: ResultDialog }) {

--- a/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/ActionPreview.tsx
@@ -356,7 +356,7 @@ function DialogMock({ title, params, variant }: { title: string; params: ActionP
                 <span className="ml-1 font-mono text-[9px] text-muted-foreground">{fieldName}</span>
                 {p.type && <span className="font-mono text-[9px] text-muted-foreground">{p.type}</span>}
               </label>
-              {renderFieldMock(p)}
+              {renderFieldMock(p, fieldLabel)}
               {p.helpText && <div className="text-[10px] text-muted-foreground">{p.helpText}</div>}
             </div>
           );
@@ -420,13 +420,34 @@ function runtimeWidgetFor(p: ActionParam): { widget: string | undefined; degrade
   return { widget: degraded ? 'text' : resolveParamWidgetType(p.type), degraded };
 }
 
-function renderFieldMock(p: ActionParam): React.ReactElement {
+/**
+ * @param fieldLabel The label `DialogMock` already derived for this param, and
+ * renders directly above this control. Passed in rather than re-derived: the
+ * param-name chain behind it -- the one `DialogMock` computes as `fieldName` --
+ * is the ONE reader this file is allowed (objectui#3104's ratchet inventory
+ * records this file at a single `two-layer` read, "Action param name, same
+ * layering as resolveActionParams"), and re-deriving it here was a second
+ * open-coding of one concept: the shape objectui#3174 removed from
+ * `resolveActionParams` itself by routing every call site in that file through
+ * one named reader. Note for the next editor: that ratchet's scanner is a
+ * LINE-level heuristic and is blind to comments, so do not spell the chain out
+ * in prose here -- a comment quoting it counts as a second read.
+ *
+ * NOT converged onto `columnIdentity()`, and deliberately: that reader is
+ * canonical-first because a column IS the object field it shows, whereas a
+ * param merely BINDS one. The inventory's `resolveActionParams` entry refuses
+ * the same borrowing in the same words -- it would invert the param-name
+ * precedence and rename every field-backed param that also names itself.
+ *
+ * Passing it also makes the mock's placeholders name the param the way the
+ * visible label right above them does, instead of by a near-copy of it.
+ */
+function renderFieldMock(p: ActionParam, fieldLabel: string): React.ReactElement {
   const cls = 'w-full text-xs px-2 py-1 border rounded bg-background pointer-events-none';
   const placeholder = p.placeholder || (p.defaultFromRow ? '(from selected row)' : '');
   const def = p.defaultValue;
   const value = def != null ? String(def) : '';
   const options = Array.isArray(p.options) ? p.options : [];
-  const label = localize(p.label) || p.name || p.field || 'value';
   const { widget, degraded } = runtimeWidgetFor(p);
 
   const inputMock = (type: string) => (
@@ -434,7 +455,7 @@ function renderFieldMock(p: ActionParam): React.ReactElement {
   );
   const selectMock = (
     <select className={cls} disabled value="">
-      <option value="">{placeholder || `Select ${label}`}</option>
+      <option value="">{placeholder || `Select ${fieldLabel}`}</option>
       {options.map((o, i) => (
         <option key={i} value={o.value}>
           {localize(o.label)}
@@ -459,7 +480,7 @@ function renderFieldMock(p: ActionParam): React.ReactElement {
   if (degraded) {
     return (
       <div className="space-y-0.5">
-        <input type="text" className={cls} placeholder={placeholder || `Record id for ${label}`} value={value} readOnly />
+        <input type="text" className={cls} placeholder={placeholder || `Record id for ${fieldLabel}`} value={value} readOnly />
         {note(
           <>
             No <code className="font-mono">reference</code> object is configured, so the record picker is


### PR DESCRIPTION
Fixes #6538

Branched from `main` at `bf3a03c1d`, which contains `11f23e9a5` (the #6329 / PR #6536 convergence). Both files were re-read on that tip before planning.

## The disagreement, re-derived on current `main`

**What `PARAM_TYPE_OPTS` offers — eight**, unchanged by this PR:
`text` · `textarea` · `number` · `boolean` · `select` · `date` · `datetime` · `lookup`

**What `renderFieldMock` branched on — five raw `type` spellings**:
`boolean` · `textarea` · `html` · `number` · `date`, plus one branch keyed on `options` rather than on `type` at all.

The card's counts (eight offered / five branched) hold, but the **membership** of the five is not what the card's table implies. Two corrections, both measured:

- `html` is one of the five branched spellings and the inspector does **not** offer it — so the two sets are not nested in either direction. Offered∖branched = `{text, select, datetime, lookup}`; branched∖offered = `{html}`.
- `text` and `select` are in that difference because neither is type-branched: `text` is the untyped fallback, and `select` is drawn only when `options` are present, whatever the declared type.

**What the runtime draws** is not a hand-read table either — `ActionParamDialog` renders every param through `paramToField()` → `resolveParamWidgetType()` → `getLazyFieldWidget()` (ADR-0059), so it is a pure function this PR calls. Resolved over the eight:

| offered | runtime widget | preview before | agreed? |
|---|---|---|---|
| `text` | `TextField` | text input | yes |
| `text` + `options` | `TextField` (options ignored) | **select** | **no** |
| `textarea` | `TextAreaField` | textarea | yes |
| `number` | `NumberField` | number input | yes |
| `boolean` | `BooleanField` (`widget: checkbox`) | checkbox | yes |
| `select` + `options` | `SelectField` | select | yes |
| `select`, no `options` | `SelectField` (empty picker) | **text input** | **no** |
| `date` | `DateField` | date input | yes |
| `datetime` | `DateTimeField` | **text input** | **no** |
| `lookup` + `reference` | `LookupField` record picker | **text input** | **no** |
| `lookup`, no `reference` | degrades to a record-id text box | text input, no reason given | control yes, reason missing |

So **four** disagreeing cases across three spellings, not two — the card named `datetime` and `lookup`; `select`-without-`options` was its second observation, and `text`-carrying-`options` is the same defect pointing the other way and had not been named.

## The fix — one member set, answered once

`renderFieldMock` no longer switches on the raw authored spelling. It resolves each param through `paramToField`'s `resolveParamWidgetType` / `paramDegradesWithoutTarget` — the same adapter the dialog renders through — and switches on the resulting widget key. It restates no membership table (the fork `paramToField`'s own TSDoc records for objectui#5654), and owns exactly two crossings:

1. **`reference` → `referenceTo`.** `reference` is the authoring spelling (`ActionParamSchema`); `referenceTo` is the resolved one the degradation predicate reads. `resolveActionParams()` performs that copy before the dialog sees a param; this preview reads the *unresolved* draft, so the rename happens here.
2. **A field-backed param is never previewed as degraded.** Its target is inherited from the bound field at runtime (`param.reference ?? field.reference_to`), and the designer has not resolved that field — claiming the degradation would be the same lie pointing the other way.

A param with no declared `type` at all is field-backed and genuinely unresolvable here, so it keeps inferring from its `options` — pinned, so the type-driven switch cannot quietly take that case with it.

Resulting mocks: `datetime` → a date/time control · `lookup` + `reference` → a disabled record-picker combobox (the same shape the designer's other pickers use) · targetless `lookup` → the record-id text box the dialog degrades to, **plus the reason** · `select` → always a picker, with a note when no choices are authored yet · `text` + `options` → a text input, because that is what `TextField` renders.

**The population stays eight.** No `FieldType` mock gallery; `long_text` / `integer` stay deleted. `html` rides along with `textarea` because that is what the tree already drew for it — dropping it while narrowing to the population would be a regression wearing a narrowing's clothes. Every other widget key still falls to the text box, `master_detail` included: it resolves to its own widget key, is outside the eight, and extending the mock vocabulary past `PARAM_TYPE_OPTS` is deliberately not this card.

`ActionParamDialog` is untouched — no spelling needed it. No fork to report.

## The `select` / `options` half — a control, decided by measurement

Triage allowed either a real control or a visible pointer to where options are authored. The pointer lost:

- the per-param editor had controls for `field`, `name`, `label`, `type`, `placeholder`, `required`, `defaultFromRow` — and none for `options`;
- **`params` is listed in `CURATED_FIELDS`**, so the collapsed "More fields" `SchemaForm` hides the whole array. The issue body's "reachable only through the collapsed More fields SchemaForm" is false — it is not reachable there at all;
- the only surface that could author `options` is the raw JSON source tab (`JsonSourceEditor`).

A pointer would therefore have had to read "leave the designer", i.e. the designer conceding it cannot author its own offered type. So: a real `ParamOptionsEditor`, scoped to `select` — the one offered spelling whose runtime widget reads `options`. A `text` param carrying `options` is not an author mistake to be enabled here; `TextField` ignores them, which is exactly what the preview now shows.

## Reverse verification

The pin was written first and run against the untouched tree (only `PARAM_TYPE_OPTS`' `export` added, which fixes nothing). **7 failed | 12 passed**, and the failures are the disagreement itself, not a branch count:

```
AssertionError: the inspector offers "select"; the runtime dialog draws SelectField renders an
  EMPTY picker with a placeholder — not a text box: expected 'input:text' to be 'select'
AssertionError: the inspector offers "datetime"; the runtime dialog draws DateTimeField:
  expected 'input:text' to be 'input:datetime-local'
AssertionError: the inspector offers "lookup"; the runtime dialog draws LookupField — a record
  picker, once a target is declared: expected 'input:text' to be 'record-picker'
AssertionError: the inspector offers "text"; the runtime dialog draws options on a `text` param
  are ignored by the runtime — it still renders TextField: expected 'select' to be 'input:text'
AssertionError: these spellings preview as a text box the runtime dialog will not draw:
  expected [ 'select', 'datetime', …(1) ] to deeply equal []
```
plus both inspector cases (`getByRole('group', { name: 'Options' })` finds nothing). After the fix: **19 passed**.

The pin reads the population from `PARAM_TYPE_OPTS` by reference, so a ninth offered spelling fails it. Its per-case expectations are hand-declared from the runtime on purpose — deriving them from the same resolver the preview calls could never catch the preview calling that resolver wrongly — with a separate drift guard asserting the literal table still matches what the resolver says.

## Verification

Union re-run at `ac2a2023a`, the final commit, all exit codes captured before any pipe:

| check | verdict line |
|---|---|
| `column-identity.ratchet` (the check that was red — see Follow-up) | `Test Files 1 passed (1)` · `Tests 7 passed (7)` |
| `@object-ui/app-shell` `type-check` (`tsc --noEmit` **and** `tsc -p tsconfig.test.json`) | `TYPECHECK_EXIT=0` |
| `eslint` on the three changed/added files | `ESLINT_EXIT=0`, no output |
| 6 affected suites | `Test Files 6 passed (6)` · `Tests 108 passed (108)` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 5409 tracked text file(s))` |
| `check:vi-mock-specifiers` | `✅ check-vi-mock-specifiers: OK (…457 carry a mock…)` |
| `check:designer-field-key-parity` | `designer-field-key-parity: OK` |
| `check:action-forward-parity` | `✅ action forward parity: 5 surfaces checked…` |
| `lint:coverage` | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `type-check:coverage` | `✅ test type-check coverage: 41/41 packages compile their tests` |
| `changeset:check` | `✅ All workspace packages are in the changeset fixed group.` |
| `check:i18n-keys` / `check:i18n-drift` | exit 0 — `0 en value(s) changed` |

Suites: `ActionDesigner.paramVocabulary` (new) · `ActionParam.one-authority` · `ActionPreview.locations` · `ActionDefaultInspector.celGate` · `paramToField` · `ActionParamDialog`.

The package `type-check` compiles `tsconfig.test.json` as well, so the new pin is type-checked rather than merely executed.

**Declared narrowing:** the repo-wide `pnpm lint` (`turbo run lint`, 46 packages) was not run; `eslint` was run over **the whole changed package** first — 993 files, `errors: 0`, counted from `--format json` — and then over the three changed files after a comment-only follow-up edit. The narrowing is measurable rather than assumed: the population comes from eslint's own config resolution, the count from its JSON reporter, and `eslint.config.js` declares no `project` / `projectService` / `parserOptions`, so type-aware linting is off and this diff cannot move the verdict on any file it does not touch. Not run locally and left to CI: `check:eager-closure` (needs a console build to emit `eager-closure.json`) — the new import is `packages/app-shell/src/utils/paramToField.js`, already imported by `ActionParamDialog` in the same package, so it adds the module itself and no new package edge.

## Follow-up — the column-identity ratchet (`ac2a2023a`)

CI came back red on one check of 7079: `column-identity.ratchet.test.ts` (objectui#3104) counts `ActionPreview.tsx` at **one** `two-layer` dual read, and the rewrite in `8c545bf1f` added a second — a `label` derivation inside `renderFieldMock` that re-open-coded the param-name chain `DialogMock` had already computed one function up. Reproduced locally before touching anything, byte-identical to CI:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ [ "app-shell/src/views/metadata-admin/previews/ActionPreview.tsx: 2 dual reads,
+    inventory says 1 — converge it onto columnIdentity() instead of adding another." ]
```

**The inventory count is unchanged at 1 and the ratchet was not touched.** The added read is gone from the source, not hidden from the matcher: `renderFieldMock` now takes the `fieldLabel` its caller already derived and renders directly above the control, so the mock's placeholders name the param exactly the way its visible label does.

**Not converged onto `columnIdentity()`, and the inventory refuses that borrowing in its own words.** This file's verdict is `two-layer`, "Action param name, same layering as resolveActionParams" — and the `resolveActionParams` entry states that `columnIdentity()` is canonical-first because a column *is* the object field it shows, whereas a param merely *binds* one, so borrowing it "would invert the param-name precedence and rename every field-backed param that also names itself". The route taken is instead the one objectui#3174 took for that same file: every call site in the file goes through one named reader, so the count is the number of **concepts** rather than the number of open-codings.

One trap worth recording, because the first attempt hit it: the scanner is a **line-level heuristic and blind to comments**, so a TSDoc line quoting the chain in prose is itself counted. The rewritten TSDoc says so, next to the place the next editor would write it.

The card's own suites were re-run to prove the convergence changed nothing about what the preview draws — `Tests 108 passed (108)`, including all 19 pin cases, which assert the rendered control kind per offered spelling.

## Scope

File face exactly as dispatched: `previews/ActionPreview.tsx`, `inspectors/ActionDefaultInspector.tsx`, one new pin, one changeset. `previews/index.ts` and `inspectors/index.ts` untouched; `ActionParamDialog` untouched. Nothing in #6465 / #6332 / #6534 / #6541 or PRs #6543 / #6544 / #6546 was touched.

`PARAM_TYPE_OPTS`' new `export` costs this panel fast refresh; the `react-refresh/only-export-components` directive accepts that by name, next to the reason.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_

---
_Generated by [Claude Code](https://claude.ai/code)_