### PR TITLE
fix(examples): put `role` / `status` back in the two `plugin-form` catalog entries

### DIFF
--- a/examples/schema-catalog/src/schemas/plugin-form/object-form-record.json
+++ b/examples/schema-catalog/src/schemas/plugin-form/object-form-record.json
@@ -4,6 +4,6 @@
   "mode": "edit",
   "recordId": "1",
   "columns": 2,
-  "fields": ["name", "email", "department"],
+  "fields": ["name", "email", "role", "department", "status"],
   "submitText": "Save changes"
 }

--- a/examples/schema-catalog/src/schemas/plugin-form/object-form-tabbed-sections.json
+++ b/examples/schema-catalog/src/schemas/plugin-form/object-form-tabbed-sections.json
@@ -7,7 +7,8 @@
   "defaultTab": "identity",
   "sections": [
     { "name": "identity", "label": "Identity", "columns": 2, "fields": ["name", "email"] },
-    { "name": "organisation", "label": "Organisation", "fields": ["department", "created_at"] }
+    { "name": "organisation", "label": "Organisation", "fields": ["department", "created_at"] },
+    { "name": "access", "label": "Access", "fields": ["role", "status"] }
   ],
   "submitText": "Save changes"
 }

--- a/examples/schema-catalog/test/catalog-gallery-render.test.tsx
+++ b/examples/schema-catalog/test/catalog-gallery-render.test.tsx
@@ -1402,3 +1402,165 @@ describe('objectui#6317 — a `select` field declares the options its rows use',
     ).toEqual(mirrorFields);
   });
 });
+
+/**
+ * objectui#6537 — the two `plugin-form` entries stop steering around the
+ * fixture's `select` fields.
+ *
+ * ## What the entries were working around
+ *
+ * Both `plugin-form` entries authored a field list that omitted `role` and
+ * `status` — the only two `select` fields the `users` fixture declares:
+ * `object-form-record` listed `["name","email","department"]` and
+ * `object-form-tabbed-sections` sectioned over `[name,email]` /
+ * `[department,created_at]`. That was never an authoring choice. Until
+ * objectui#6317 this mirror declared both fields with NO `options`, and
+ * `ObjectForm` copies a field's options through verbatim (`formField.options =
+ * field.options || []`), so a form over either one painted the "No options
+ * available" empty state — on a docs page whose whole purpose is to show the
+ * component working. The five `plugin-grid` / `plugin-view` entries over the
+ * same object never steered around them, because `ObjectGrid` SYNTHESISES
+ * options for an option-less select from the loaded rows. That asymmetry is
+ * what #6317 measured, and it is why only the FORM entries carried a
+ * workaround.
+ *
+ * #6317 declared the options in the host fixture's `users` schema and in this
+ * mirror, so the constraint is gone and both entries carry the full field
+ * surface again.
+ *
+ * Measured through this file's own render path, before and after this card:
+ *
+ *   object-form-record
+ *     before "NameEmailDepartmentCancelSave changes"
+ *     after  "NameEmailRoleAdminAdminMemberViewerDepartmentStatusActiveActive
+ *             InvitedSuspendedCancelSave changes"
+ *   object-form-tabbed-sections
+ *     before "IdentityOrganisationNameEmailDepartmentCreatedCancelSave changes"
+ *     after  "IdentityOrganisationAccessNameEmailDepartmentCreatedRoleAdmin
+ *             AdminMemberViewerStatusActiveActiveInvitedSuspendedCancelSave
+ *             changes"
+ *
+ * ("Admin" twice: the closed trigger shows the selected option's label, and
+ * the option list carries it again.) The record's own values join the form's
+ * controls with them — `["Alice Johnson","alice@example.com","Engineering"]`
+ * becomes `["Alice Johnson","alice@example.com","admin","Engineering",
+ * "active"]` — so the two fields stop being dropped on the way in.
+ *
+ * That the text MOVES is the point, and it is the half #6317 could not show:
+ * the seven `users`-bound tiles were byte-identical across that card because
+ * the grid synthesises what the declaration was missing. The form path has no
+ * such fallback, so here the declaration is visible.
+ *
+ * The tabbed entry is measurable from its `identity` default tab because
+ * `TabbedForm` keeps EVERY panel mounted inside one `<form>` (objectui#2959,
+ * so a tab the user leaves keeps its values and one submit spans them all) —
+ * the `Access` tab's controls are in the DOM without activating it.
+ *
+ * ## Why this is a pin and not just an edit
+ *
+ * The workaround is invisible in the entries themselves — a shorter `fields`
+ * list reads as a deliberately trimmed demo, and every case in this file was
+ * green the whole time it was there. Nothing would notice it coming back. So
+ * the rule is stated positively and DERIVED from the fixture: every
+ * `plugin-form` entry authors every `select` field the fixture declares, and
+ * each of those fields puts its declared option labels on screen. A field that
+ * becomes a `select`, or an option that is added, joins this pin with no edit
+ * here; an entry that drops one turns it red.
+ *
+ * The render half is what makes it a measurement rather than a restatement of
+ * the JSON: an authored field that renders the empty state satisfies the
+ * authoring half and fails here.
+ */
+
+/** The empty state a `select` with no options paints (`packages/fields/src/widgets/useFieldTranslation.ts`, `packages/components/src/renderers/form/form.tsx`). Copied as a literal for the same reason the three diagnostics at the top of this file are: it is user-visible contract for this pin. */
+const OPTIONS_EMPTY = 'No options available';
+
+/**
+ * Field NAMES an entry authors, at any depth: the string members of any
+ * `fields` array. Walked rather than read off a known path, because the two
+ * entries put them in different places — one at the root, one inside
+ * `sections[].fields` — and a path-specific reader would report the tabbed
+ * entry as authoring none, which is the vacuous green this pin has to avoid.
+ */
+function authoredFieldNames(node: unknown, acc: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const n of node) authoredFieldNames(n, acc);
+    return acc;
+  }
+  if (node && typeof node === 'object') {
+    for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+      if (k === 'fields' && Array.isArray(v)) {
+        for (const f of v) if (typeof f === 'string') acc.push(f);
+      }
+      authoredFieldNames(v, acc);
+    }
+  }
+  return acc;
+}
+
+describe('objectui#6537 — the `plugin-form` entries author the fixture\'s `select` fields', () => {
+  const mirrorFields = USERS_SCHEMA.fields as Record<string, UsersFieldDecl>;
+  const selectFields = Object.entries(mirrorFields)
+    .filter(([, field]) => field.type === 'select')
+    .map(([name]) => name);
+  const formEntries = entries.filter((e) => e.meta.category === 'plugin-form');
+  const cases = formEntries.map((e) => [e.id, e.schema] as const);
+
+  it('is not vacuous: there are form entries, they restrict their fields, and the fixture has selects', () => {
+    expect(formEntries.map((e) => e.id)).not.toEqual([]);
+    expect(selectFields).not.toEqual([]);
+    // An entry that authors NO field list takes the whole object surface and
+    // would satisfy the authoring case below for free.
+    expect(
+      formEntries.filter((e) => authoredFieldNames(e.schema).length === 0).map((e) => e.id),
+    ).toEqual([]);
+  });
+
+  it.each(cases)('%s authors every select field the fixture declares', (_id, schema) => {
+    const authored = authoredFieldNames(schema);
+    expect(
+      selectFields.filter((name) => !authored.includes(name)),
+      'this entry steers around a `select` field of the object it binds to. That was a ' +
+        'workaround for an option-less fixture field (objectui#6317) and the fixture now ' +
+        'declares the options — a form demo that avoids the only pickers in its object ' +
+        'demonstrates less than the component does.',
+    ).toEqual([]);
+  });
+
+  it.each(cases)('%s puts every declared option label on screen', async (_id, schema) => {
+    const r = await renderEntry(schema);
+    try {
+      expect(
+        r.text.includes(OPTIONS_EMPTY),
+        `the tile paints "${OPTIONS_EMPTY}" — a select reached the form with no options`,
+      ).toBe(false);
+      const missing = selectFields.flatMap((name) =>
+        (mirrorFields[name].options ?? [])
+          .map((option) => option.label)
+          .filter((label) => !r.text.includes(label)),
+      );
+      expect(
+        missing,
+        'these option labels the fixture declares are not on the tile, so the picker the ' +
+          'docs page exists to show is not being shown',
+      ).toEqual([]);
+    } finally {
+      teardown(r);
+    }
+  });
+
+  it.each(cases)("%s carries the record's own select values in its controls", async (_id, schema) => {
+    const r = await renderEntry(schema);
+    try {
+      expect(r.controlValues.length).toBeGreaterThan(0);
+      const record = USERS_ROWS[0] as Record<string, unknown>;
+      expect(
+        selectFields.filter((name) => !r.controlValues.includes(String(record[name]))),
+        "the record's own values for these select fields never reached a form control, so " +
+          'the field is on screen but the record is being dropped on the way in',
+      ).toEqual([]);
+    } finally {
+      teardown(r);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6537

Both `plugin-form` catalog entries authored a field list that omitted `role` and `status` — the only two `select` fields the `users` fixture declares. That was never an authoring choice: until #6317 the fixture declared both fields with **no** `options`, and `ObjectForm` copies a field's options through verbatim (`formField.options = field.options || []`, `packages/plugin-form/src/ObjectForm.tsx`), so a form over either one painted the "No options available" empty state — on a docs page whose whole purpose is to show the component working. `ObjectGrid` **synthesises** options for an option-less select from the loaded rows, which is why the five `plugin-grid` / `plugin-view` entries over the same object never steered around them. The fixture now declares the options in both files (host since `4b0b12630`, mirror as of #6317), so these two entries were the last place in the catalog working around a defect that no longer exists.

## The change

- `object-form-record.json` — `fields` goes from `["name","email","department"]` to `["name","email","role","department","status"]`, in the object's own declaration order.
- `object-form-tabbed-sections.json` — a third section, `{ "name": "access", "label": "Access", "fields": ["role", "status"] }`, shaped exactly like the existing `organisation` section. Nothing else in either entry is restructured.
- `catalog-gallery-render.test.tsx` — a new `objectui#6537` pin (additive; the `USERS_SCHEMA` mirror, `galleryDataSource` and the #6317 cases are untouched, and `apps/site/app/components/galleryDataSource.ts` is not in this diff).

## Measured through the catalog test's own render path

Read off the real source files by rendering the catalog entries themselves, not hand-copied:

```
object-form-record
  before "NameEmailDepartmentCancelSave changes"
  after  "NameEmailRoleAdminAdminMemberViewerDepartmentStatusActiveActiveInvitedSuspendedCancelSave changes"

object-form-tabbed-sections
  before "IdentityOrganisationNameEmailDepartmentCreatedCancelSave changes"
  after  "IdentityOrganisationAccessNameEmailDepartmentCreatedRoleAdminAdminMemberViewerStatusActiveActiveInvitedSuspendedCancelSave changes"
```

and the record's own values join the form's controls:

```
before ["Alice Johnson","alice@example.com","Engineering"]
after  ["Alice Johnson","alice@example.com","admin","Engineering","active"]
```

The `before` for `object-form-record` matches what the card reports for these entries. **The text moves, as predicted** — that is the half #6317 could not show, because the grid synthesises what the declaration was missing and all seven `users`-bound tiles were byte-identical there. The form path has no such fallback. ("Admin" appears twice: the closed trigger shows the selected option's label and the option list carries it again.)

The tabbed entry is measurable from its `identity` default tab because `TabbedForm` keeps every panel mounted inside one `<form>` (#2959).

## The pin, and its reverse verification

The pin states the rule positively and **derives** it from the fixture rather than enumerating field names: every `plugin-form` entry authors every `select` field the fixture declares; each of those fields puts its declared option labels on screen and never the empty state; and the record's own values for them reach a form control. A field that becomes a `select`, or an option that is added, joins the pin with no edit there.

Written **before** the entries were touched and observed red against them — `pnpm exec vitest run examples/schema-catalog/test/catalog-gallery-render.test.tsx -t 6537`, `Tests 8 failed | 1 passed`:

- `authors every select field the fixture declares` → `expected [ 'role', 'status' ] to deeply equal []`, both entries
- `puts every declared option label on screen` → `expected [ 'Admin', 'Member', 'Viewer', 'Active', 'Invited', 'Suspended' ] to deeply equal []`, both entries
- `carries the record's own select values in its controls` → red, both entries
- the non-vacuity case passed, so the red was the rule and not a broken instrument

The mutation was proven on disk by counting the changed text rather than by an editor's exit code: `"role"` and `"status"` each `0 → 1` occurrences in both files, the literal `"fields": ["name", "email", "department"]` `1 → 0`, `"name":` section keys `2 → 3` in the tabbed entry, bytes `183 → 201` and `383 → 458`. A temporary measurement case captured the before/after tile text and was removed before commit (`MEASURE-6537` occurrences in the file: 0).

## Verification — all on `5ffd1942f`, the final commit

| gate | verdict line |
|---|---|
| `pnpm exec vitest run examples/schema-catalog/` | `Test Files 14 passed (14)` · `Tests 1835 passed (1835)` |
| `pnpm --filter @object-ui/example-schema-catalog run type-check` | clean (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm lint` (`turbo run lint`, whole farm) | exit 0 |
| `python3 scripts/regenerate-catalog-index.py --check` | `examples/schema-catalog/src/index.ts is up to date (428 entries).` |
| `node scripts/check-changeset-presence.mjs` | `✅ No source of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 5417 tracked text file(s); skipped 85 binary).` |
| `pnpm check:doc-types` | `✅ Every documented component type is registered.` |
| `pnpm check:doc-fences` | `✅ check:doc-fences — every TypeScript block in 223 document(s) …` |
| `pnpm exec vitest run scripts/__tests__/catalog-index-regenerable-4633.test.ts` | `Tests 6 passed (6)` |

Notes on two readings that are **not** verdicts:

- The catalog index `--check` was run on the **untouched** tree first and reported the same `428 entries, up to date`, so the unmoved index after the edit is a measured no-change rather than an unexamined one.
- The package `type-check` first exited 2 with `TS2882` / `TS2307` on workspace `dist/*.d.ts` across nine test files, including ones this diff does not touch. That is `NOT MEASURED` (the dependency closure was unbuilt in a fresh worktree), not a red: after `pnpm --workspace-concurrency=2 --filter '@object-ui/example-schema-catalog^...' build` it is clean. That first run is also the evidence the typecheck **covers** the edited file — `test/catalog-gallery-render.test.tsx` was among the files it reported on, so `tsconfig.test.json` is not excluding it.
- `pnpm check:doc-snippets` exits 2 with its own `PREREQUISITE NOT MET` text ("This is 'I could not run', NOT 'I ran and found errors'"). Its scan surface is `content/docs` only and this diff touches no document there, so it is outside this diff's gate face; CI runs it regardless.

No changeset: `@object-ui/example-schema-catalog` is private and in the changesets ignore list, and the gate's own verdict says none is owed. `skip-changeset` is not a label this repo carries, so nothing was applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_