### PR TITLE
docs(types): expand the flat gantt face's four bare `GanttConfig` pointers

### DIFF
--- a/.changeset/6547-flat-gantt-face-pointers.md
+++ b/.changeset/6547-flat-gantt-face-pointers.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/types': patch
+---
+
+`ObjectGanttSchema`'s flattened gantt face documents `colorField`, `parentField`,
+`tooltipFields` and `quickFilters` in its own words, instead of pointing at a type that
+says nothing about them (objectui#6547).
+
+Those four members carried a bare `See {@link GanttConfig}.` pointer. `GanttConfig` is
+`SpecGanttConfig & { … }`, and all four arrive from the **spec** half: the local half of
+that intersection declares exactly ten top-level members (`timeSegments`, `lockField`,
+`objectField`, `summaryExtent`, `defaultCollapsedDepth`, `borderColorField`,
+`dependencyTypes`, `timeZone`, `exportFileName`, `interactions`) and none of these four is
+among them. `SpecGanttConfig` is `z.input<typeof GanttConfigSchema>`, and the spec's
+emitted `.d.ts` carries no per-member JSDoc — its 19 members are bare `z.ZodOptional`
+entries under one type-level "Gantt Settings" docblock. So the pointer was not merely
+unhelpful, it was misdirecting: a reader who followed it landed on a type documenting
+nothing about the key and concluded the key was undocumented.
+
+Verified on the built artifact rather than the source: all four bare pointers were present
+in `dist/objectql.d.ts` before this change and none is after, so the defect was on the
+published surface and the repair reaches it.
+
+**Prose only — the published shape is unchanged, and that is the point.** The natural
+repair, writing the prose onto `GanttConfig`, means re-declaring these members inside the
+intersection; PR objectui#6546 measured that as a widened published surface on the built
+`dist/index.d.ts` and it was rejected there. So the shape was measured, not asserted:
+`ObjectGanttSchema`'s 45 members and their checker-resolved types are byte-identical
+before and after, and the built face's 51 declaration lines diff clean with comments
+stripped. Only comment bytes moved.
+
+The seven **member-qualified** pointers (`See {@link GanttConfig.borderColorField}`,
+`.lockField`, `.summaryExtent`, `.defaultCollapsedDepth`, `.timeSegments`,
+`.interactions`, `.exportFileName`) name members of that ten-member local half, resolve to
+real prose, and are deliberately left alone — the defect is the bare form, and a substring
+search for `{@link GanttConfig` hits both.
+
+The prose is taken from the renderer's live read sites in `plugin-gantt`, not invented:
+`colorField`'s status/state/priority/severity fallback chain and the platform default
+blue, `parentField`'s unknown-id-renders-as-root rule, `tooltipFields`' drop-empty-rows
+behaviour (which is what lets a mixed-object tree list the union of every level's fields)
+and its replacement of the default date · duration · progress tooltip line, and
+`quickFilters`' schema-resolved option domains. No behaviour change, no runtime code.

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -2417,7 +2417,14 @@ export interface ObjectGanttSchema extends BaseSchema {
   // instead of being dropped silently. So a node carrying both spellings renders
   // the `gantt` block's values — the reverse of the pre-#6469 order.
 
-  /** Record field carrying the bar fill colour. See {@link GanttConfig}. */
+  /**
+   * Record field carrying the bar's FILL colour: any CSS colour or a semantic
+   * palette name (red/orange/…), typically a server-computed status colour.
+   * When it is unset — or when the record's value is empty — the bar falls back
+   * to the record's own `status`/`state`/`priority`/`severity` value, so the
+   * timeline tells the same colour story as list/kanban. With neither, bars
+   * take the platform default blue.
+   */
   colorField?: GanttConfig['colorField'];
   /** Per-task alert stroke colour field. See {@link GanttConfig.borderColorField}. */
   borderColorField?: GanttConfig['borderColorField'];
@@ -2428,7 +2435,14 @@ export interface ObjectGanttSchema extends BaseSchema {
    * alias and this one wins.
    */
   dependenciesField?: GanttConfig['dependenciesField'];
-  /** Single-parent pointer field building the task tree. See {@link GanttConfig}. */
+  /**
+   * Record field holding this row's PARENT id — the single-parent pointer the
+   * task tree is built from: indentation, expand/collapse and summary rollup
+   * all follow it. An empty value, or one naming no loaded row, renders that
+   * row as a root. Leave unset for a flat chart; `groupByField` is the
+   * alternative, bucketing leaves under synthesized rows instead of a
+   * record-declared hierarchy.
+   */
   parentField?: GanttConfig['parentField'];
   /** Record field mapping onto a node kind (task/summary/milestone/group). */
   typeField?: GanttConfig['typeField'];
@@ -2440,7 +2454,16 @@ export interface ObjectGanttSchema extends BaseSchema {
   summaryExtent?: GanttConfig['summaryExtent'];
   /** Auto-collapse depth on first render. See {@link GanttConfig.defaultCollapsedDepth}. */
   defaultCollapsedDepth?: GanttConfig['defaultCollapsedDepth'];
-  /** Extra record fields listed in the bar tooltip. See {@link GanttConfig}. */
+  /**
+   * Extra record fields listed as label/value rows in a bar's hover tooltip, in
+   * the order given. Each entry is a field name (dot-paths allowed) or
+   * `{ field, label }` to set the label explicitly; otherwise the label comes
+   * from the object schema, falling back to a humanized field name, and the
+   * value is formatted by field type the way a list cell would render it. A row
+   * whose value is empty is DROPPED rather than dashed, so a mixed-object tree
+   * can list the union of every level's fields here. Any surviving rows replace
+   * the tooltip's default date · duration · progress line.
+   */
   tooltipFields?: GanttConfig['tooltipFields'];
   /** Baseline (planned) start field → planned-vs-actual reference bars. */
   baselineStartField?: GanttConfig['baselineStartField'];
@@ -2456,7 +2479,14 @@ export interface ObjectGanttSchema extends BaseSchema {
   effortField?: GanttConfig['effortField'];
   /** Per-resource capacity ceiling (default 1); loads above it flag overload. */
   capacity?: GanttConfig['capacity'];
-  /** Quick-filter dropdowns rendered above the chart. See {@link GanttConfig}. */
+  /**
+   * Quick-filter dropdowns rendered above the chart — a row of multi-selects,
+   * each narrowing the visible bars by one record field. A dimension's options
+   * resolve from the object schema (a select's options, or the referenced
+   * records for a lookup), so the dropdown offers that field's full domain
+   * rather than only the values present in the loaded page; declare `options`
+   * on the dimension to override that with a fixed list.
+   */
   quickFilters?: GanttConfig['quickFilters'];
   /** Recompute the timeline range when filtering (default true). */
   autoZoomToFilter?: GanttConfig['autoZoomToFilter'];


### PR DESCRIPTION
Fixes #6547

`ObjectGanttSchema`'s flattened gantt face documented four members with a bare
`See {@link GanttConfig}.` pointer that led to a type saying nothing about them. Each of
those four one-liners now stands alone. **Prose only** — one source file plus a changeset.

## The census, re-derived independently on `origin/main` @ `0235ce7c1`

The dispatch order's corrected census reproduces exactly, and I confirm it against the
card's own key list, which is wrong in both directions. There are exactly **four** bare
`See {@link GanttConfig}.` pointers on members of the flat face:

| docblock | member | named by the card? |
|---|---|---|
| `:2420` | `colorField` | no — missed by the card |
| `:2431` | `parentField` | yes |
| `:2443` | `tooltipFields` | no — missed by the card |
| `:2459` | `quickFilters` | yes |

(The card's line numbers `:2421/:2432/:2444/:2460` are the member declarations; the
docblocks sit one line above.)

The other nine spec-sourced keys the card names — `typeField`, `baselineStartField`,
`baselineEndField`, `groupByField`, `resourceView`, `effortField`, `capacity`,
`autoZoomToFilter`, `assigneeField` — carry **no pointer at all** and already have
standalone one-liners. They need nothing and are untouched.

### The premise holds, verified two ways

`GanttConfig` is `SpecGanttConfig` intersected with a local object literal, and that local
half declares exactly **ten** top-level members (`timeSegments`, `lockField`,
`objectField`, `summaryExtent`, `defaultCollapsedDepth`, `borderColorField`,
`dependencyTypes`, `timeZone`, `exportFileName`, `interactions`, ending at
`objectql.ts:306`). None of the four is among them, so all four arrive from the spec.

`SpecGanttConfig` is `z.input` applied to `typeof GanttConfigSchema`. In the installed
`@objectstack/spec@17.2.0`'s emitted `dist/view.zod-Vrw2Wzfj.d.ts`, `GanttConfigSchema`'s
19 members are bare `z.ZodOptional` entries with **no per-member JSDoc** — there is a
single type-level `Gantt Settings` docblock and nothing else. So the pointer led to a type
documenting nothing about the key. Premise confirmed; no bare pointer resolves to prose.

And the defect was on the **published** surface, not just in source: the built
`dist/objectql.d.ts` carried all four bare pointers before this change.

## ⛔ The rejected route was not taken — measured, not asserted

Members were **not** re-declared inside the intersection. PR #6546 measured that as a
widened published surface on the built `dist/index.d.ts` and it was turned down there.
`packages/spec` is untouched; the `.describe()`-upstream route stays in its own lane.

The proof is a build-and-diff of the emitted artifact, both directions:

**Shape unchanged.** A structural census over the built `dist/objectql.d.ts` — every
member of `ObjectGanttSchema` with its type text resolved through the TS checker, so
comments are definitionally invisible to it — is **byte-identical** before and after:

```
before:  # ObjectGanttSchema — 45 members
after:   # ObjectGanttSchema — 45 members
diff exit 0
```

The same holds on the raw text: the built face's **51 declaration lines** diff clean with
comment lines stripped. No member added, removed or retyped.

**Docs did move.** Bare `See {@link GanttConfig}.` in the built face went **4 → 0**, and
all four new prose blocks are present in `dist`.

**The seven member-qualified pointers stayed at 7.** `See {@link GanttConfig.borderColorField}`,
`.lockField`, `.summaryExtent`, `.defaultCollapsedDepth`, `.timeSegments`, `.interactions`
and `.exportFileName` name members of the ten-member local half, resolve to real prose, and
are correct — a substring search for `{@link GanttConfig` hits both forms, so they were
separated before editing.

**`dependenciesField` (`:2430`) is untouched** — its lenient-alias docblock belongs to
objectui#6470, deliberately held out of this batch.

## The prose is measured, not invented

Each rewrite is taken from the renderer's live read sites, because
`GanttConfigRestated` does not cover three of the four (see the note below):

- **`colorField`** — `ObjectGantt.tsx:874-886`: explicit value wins, else fall back to the
  record's `status`/`state`/`priority`/`severity`, else `GanttView`'s default blue.
- **`parentField`** — `ObjectGantt.tsx:906` and `GanttView.tsx:156`: single-parent pointer;
  an empty value or one naming no loaded row renders as a root.
- **`tooltipFields`** — `ObjectGantt.tsx:844-861` and `GanttView.tsx:181-186`: label from
  explicit → object schema → humanized name; empty values **drop** their row rather than
  render a dash (which is what lets a mixed-object tree list the union of every level's
  fields); surviving rows replace the default date · duration · progress line.
- **`quickFilters`** — `GanttConfigRestated` and `QuickFilterDef`: options resolve from the
  object schema so a dropdown offers the full domain, not just loaded values.

No pointer was swapped for another pointer, and no new `{@link}` was introduced.

## Verification — at head `ff05e60ff`, after the final commit

| gate | verdict line |
|---|---|
| `pnpm --filter @object-ui/types build` | `command-exit 0` |
| `pnpm --filter @object-ui/types type-check` | clean (`tsc --noEmit` + `tsconfig.examples.json` + `tsconfig.test.json`) |
| `pnpm --filter @object-ui/types lint` | `✖ 246 problems (0 errors, 246 warnings)` |
| `pnpm exec vitest run packages/types/` | `Test Files 65 passed (65)` · `Tests 767 passed (767)` |
| `node scripts/check-changeset-presence.mjs` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |

`type-check` includes `tsconfig.test.json`, so the test files are genuinely covered rather
than excluded. All 65 test files that exist under `packages/types` ran (65 present, 65
executed), including the three gantt pin suites. The 246 lint warnings are pre-existing
`no-explicit-any`; **0** of them fall in the edited range `2417-2490`.

**Declared narrowing on lint.** `pnpm lint` at the root is `turbo run lint`, which fans out
to each package's own `eslint .` — so the command run here is byte-for-byte the one the
repo-wide run executes for this package. Population (127 files) is read from eslint's own
config resolution via `--format json`, not guessed. Untouched files cannot move: the flat
config extends `tseslint.configs.recommended` with `languageOptions` carrying only
`ecmaVersion` and `globals` — no `project` / `projectService`, so **type-aware linting is
off** and no rule's verdict on another file can depend on a JSDoc edit in this one. The
rest of the farm is CI's run.

## Note for the record — the card's account of where the prose lives is partly wrong

The card states the renderer prose "exists — it is in `plugin-gantt`'s package-private
`GanttConfigEx` (now `GanttConfigRestated`)". For three of the four keys that is not so.
`GanttConfigRestated`'s twelve members do not include `colorField` or `tooltipFields` at
all, and its `parentField` is declared bare with **no JSDoc**. Only `quickFilters` actually
has prose there. So for three of these four keys the documentation did not exist anywhere
in the repo before this change — it had to be read off the renderer. That strengthens the
card rather than weakening it, but the "just move the prose" reading of the fix would have
come up empty.

_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_