### PR TITLE
fix(app-shell): enforce the documented nav exclusion in StarredApps

### DIFF
--- a/.changeset/6335-starred-apps-nav-exclusion.md
+++ b/.changeset/6335-starred-apps-nav-exclusion.md
@@ -1,0 +1,19 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`StarredApps` now filters out `nav`-type favorites before rendering (objectui#6335).
+
+`FavoritesProvider` has always documented `nav` favorites (sidebar entries pinned via
+the in-tree pin toggle) as "Excluded from Home/Starred and from the generic sidebar
+Favorites list so it doesn't render twice" — but `StarredApps` filtered nothing by type,
+so a `nav` favorite handed to it rendered anyway. `FavoriteItem['type']` also has no
+`nav` key under `home.recentApps.itemType.*` (only five of its six members do), so a
+`nav` card that reached `StarredApps` fell through to the raw `"nav"` label instead of a
+translated one.
+
+`StarredApps` now filters `items` to `type !== 'nav'` before rendering — the same
+exclusion already applied to the sidebar Favorites list in `AppSidebar.tsx` and
+`UnifiedSidebar.tsx` — restoring declared-equals-enforced behaviour and making the
+missing locale key correct by construction. No locale packs were touched, and the
+`FavoriteItem` / `RecentItem` union types are unchanged.

--- a/packages/app-shell/src/console/home/StarredApps.tsx
+++ b/packages/app-shell/src/console/home/StarredApps.tsx
@@ -24,9 +24,13 @@ const TYPE_TONES: Record<string, string> = {
   record: 'bg-amber-500/10 text-amber-600 dark:text-amber-400 ring-amber-500/20',
 };
 
-// Per-type icon so the four kinds (object / record / dashboard / page) are
-// visually distinguishable at a glance. `getIcon` falls back to the same
-// Database glyph for every unknown name which made all cards look identical.
+// Per-type icon for four of the six `FavoriteItem['type']` kinds (object /
+// record / dashboard / page) so those cards are visually distinguishable at
+// a glance; `report` has no dedicated glyph and falls back to the same
+// Database icon as any unrecognized name. `nav` is the sixth kind — it never
+// reaches this lookup because it is filtered out below (nav items are
+// excluded from Starred; see FavoritesProvider's `FavoriteItem['type']` doc,
+// objectui#6335).
 const TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   object: Database,
   record: FileText,
@@ -38,7 +42,19 @@ export function StarredApps({ items }: StarredAppsProps) {
   const navigate = useNavigate();
   const { t } = useObjectTranslation();
 
-  if (items.length === 0) return null;
+  // `nav` favorites (sidebar entries pinned via the in-tree pin toggle) are
+  // documented as "Excluded from Home/Starred" (FavoritesProvider.tsx) so
+  // they don't render twice — once here and once in the Pinned sidebar
+  // section. That exclusion was previously only documented, not enforced:
+  // `StarredApps` rendered whatever `items` it was handed, so a caller that
+  // included a `nav` favorite hit `home.recentApps.itemType.*`'s missing
+  // `nav` key and fell through to the raw-string fallback (objectui#6335).
+  // Filtering here restores declared-equals-enforced behaviour and matches
+  // the same `type !== 'nav'` exclusion already applied to the sidebar
+  // Favorites list (AppSidebar.tsx / UnifiedSidebar.tsx).
+  const visibleItems = items.filter((item) => item.type !== 'nav');
+
+  if (visibleItems.length === 0) return null;
 
   return (
     <section>
@@ -51,7 +67,7 @@ export function StarredApps({ items }: StarredAppsProps) {
         </h2>
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-        {items.map((item) => {
+        {visibleItems.map((item) => {
           const Icon = TYPE_ICONS[item.type] || Database;
           const tone = TYPE_TONES[item.type] || TYPE_TONES.object;
           // Reuse the recentApps.itemType.* keys so Starred and Recently

--- a/packages/app-shell/src/console/home/__tests__/StarredApps.navExclusion.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/StarredApps.navExclusion.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * StarredApps nav exclusion (objectui#6335).
+ *
+ * `FavoriteItem['type']` is a six-member union — `object | dashboard | page |
+ * report | record | nav` — but `home.recentApps.itemType.*` (the namespace
+ * `StarredApps` resolves its type label through) declares only five keys
+ * (no `nav`). `FavoritesProvider.tsx` documents `nav` favorites as "Excluded
+ * from Home/Starred and from the generic sidebar Favorites list so it
+ * doesn't render twice" — but until this fix `StarredApps` filtered nothing
+ * by type, so a `nav` favorite handed to it rendered anyway, hit the missing
+ * key, and fell through to the raw-string fallback.
+ *
+ * The pin below hands a `nav` item in directly (not just documents the
+ * exclusion) and asserts it does not render — a filter with no test
+ * exercising the excluded kind is indistinguishable from no filter.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import type { FavoriteItem } from '../../../hooks/useFavorites.js';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/i18n', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useObjectTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  }),
+}));
+
+import { StarredApps } from '../StarredApps.js';
+
+const NAV_ITEM: FavoriteItem = {
+  id: 'nav:pinned-report',
+  label: 'Pinned nav entry',
+  href: '/x/nav',
+  type: 'nav',
+  favoritedAt: new Date().toISOString(),
+  navId: 'pinned-report',
+};
+
+const OBJECT_ITEM: FavoriteItem = {
+  id: 'object:contact',
+  label: 'Contact',
+  href: '/x/object',
+  type: 'object',
+  favoritedAt: new Date().toISOString(),
+};
+
+describe('StarredApps nav exclusion', () => {
+  it('THE PIN: a nav favorite handed in does not render, while sibling kinds still do', () => {
+    render(<StarredApps items={[NAV_ITEM, OBJECT_ITEM]} />);
+
+    expect(screen.queryByTestId(`starred-item-${NAV_ITEM.id}`)).toBeNull();
+    expect(screen.queryByText(NAV_ITEM.label)).toBeNull();
+
+    expect(screen.getByTestId(`starred-item-${OBJECT_ITEM.id}`)).toBeTruthy();
+    expect(screen.getByText(OBJECT_ITEM.label)).toBeTruthy();
+  });
+
+  it('an all-nav favorites list renders nothing, matching the documented exclusion', () => {
+    const { container } = render(<StarredApps items={[NAV_ITEM]} />);
+
+    // `items.length` is nonzero, so a naive `items.length === 0` empty-guard
+    // would not catch this — it is the post-filter length that must gate the
+    // section, or an all-nav list would render an empty "Starred" heading
+    // with no cards under it.
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Starred')).toBeNull();
+  });
+
+  it('control: a non-nav kind with no dedicated icon (report) still renders', () => {
+    const reportItem: FavoriteItem = {
+      id: 'report:quarterly',
+      label: 'Quarterly report',
+      href: '/x/report',
+      type: 'report',
+      favoritedAt: new Date().toISOString(),
+    };
+
+    render(<StarredApps items={[reportItem]} />);
+
+    expect(screen.getByTestId(`starred-item-${reportItem.id}`)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #6335

## What

`StarredApps` now filters `nav`-type favorites out before rendering, enforcing the
exclusion `FavoritesProvider.tsx` already documents ("Excluded from Home/Starred and
from the generic sidebar Favorites list so it doesn't render twice") but never applied.

- `packages/app-shell/src/console/home/StarredApps.tsx`: computes
  `visibleItems = items.filter((item) => item.type !== 'nav')` and renders/gates on that
  instead of the raw `items` prop — matching the identical `type !== 'nav'` exclusion
  already used for the sidebar Favorites list (`AppSidebar.tsx` / `UnifiedSidebar.tsx`).
  The empty-state guard now checks the *post-filter* length, so an all-`nav` favorites
  list renders nothing rather than an empty "Starred" heading with no cards under it.
- Corrected the `TYPE_ICONS` comment in the same hunk: it said "the four kinds (object /
  record / dashboard / page)" but `FavoriteItem['type']` is a six-member union
  (`object | dashboard | page | report | record | nav`) — `report` has no dedicated icon
  (falls back to the shared Database glyph) and `nav` is now filtered out before this
  lookup runs.

## Why

`home.recentApps.itemType.*` (the namespace `StarredApps` resolves its type label
through, via `recentItemTypeLabel`) declares six keys matching `RecentItem['type']`, but
`FavoriteItem['type']` carries a seventh possibility — `nav` — that has no key. Since
`StarredApps` filtered nothing by type, a `nav` favorite handed to it by a composing
host rendered with the raw `"nav"` fallback label instead of a translated one, and the
documented exclusion was aspirational rather than enforced.

Triage (#6335, comment) ruled **option 2** of the three considered — enforce the
exclusion in `StarredApps` — over adding a `nav` locale key (×10 packs, contradicts the
documented exclusion) or splitting the `FavoriteItem`/`RecentItem` unions (published-type
change with no measured reachability to justify it).

## Fork-clause check (published export)

`StarredApps` is exported from `packages/app-shell/src/console/home/index.ts`. Verified
before filtering: no in-repo caller renders `<StarredApps .../>` in production code —
`HomePage.tsx` passes `favorites` to `HomeAppsStrip`, not `StarredApps`; the only JSX
usage in the tree is the `HomeItemTypeLabel.parity.test.tsx` fixture. This is the
**"no in-repo caller"** finding, not "unreachable" — a composing host could still supply
`nav` items to this public export, and no such host was found in-repo to confirm or
rule out reliance either way.

## Test

`packages/app-shell/src/console/home/__tests__/StarredApps.navExclusion.test.tsx` — new
file, 3 tests:
1. **THE PIN** — hands a `nav` item in alongside a non-nav item; asserts the `nav` item's
   test id and label are absent while the sibling item still renders.
2. An all-`nav` favorites list renders nothing (the post-filter empty guard).
3. Control: a `report` favorite (no dedicated icon, but not excluded) still renders.

```
pnpm exec vitest run packages/app-shell/src/console/home/
 Test Files  12 passed (12)
      Tests  69 passed (69)
```

(Includes the pre-existing `HomeItemTypeLabel.parity.test.tsx`, unaffected — it never
exercises the `nav` kind.)

Also, after building the full workspace dependency closure
(`pnpm --filter '@object-ui/app-shell^...' build`):

```
pnpm --filter @object-ui/app-shell type-check   # tsc --noEmit && tsc -p tsconfig.test.json
> exit 0, no errors

pnpm --filter @object-ui/app-shell build        # tsc
> exit 0

node scripts/check-i18n-call-site-keys.mjs
> every in-scope call-site key resolves against the en pack — clean

node scripts/check-i18n-en-drift.mjs
> 0 en value(s) changed — confirms no locale pack edits

node scripts/check-control-bytes.mjs
> OK
```

At `0ba61a050` (current branch head).

## Scope

`packages/app-shell/src/console/home/StarredApps.tsx`, its new test, and a changeset.
No locale pack edits. No change to the `FavoriteItem` / `RecentItem` union types.
`recentItemTypeLabel` untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_