### PR TITLE
fix(console): delete dead pre-ADR-0079 getRecordDisplayName/formatRecordTitle copy

### DIFF
--- a/.changeset/6558-remove-dead-console-record-title-copy.md
+++ b/.changeset/6558-remove-dead-console-record-title-copy.md
@@ -1,0 +1,7 @@
+---
+---
+
+Removed a dead pre-ADR-0079 `getRecordDisplayName` / `formatRecordTitle` copy from
+`apps/console/src/utils.ts`. Both were unexported-from-behaviour dead code with zero
+console importers (superseded by the unified `@object-ui/core#getRecordDisplayName`);
+no published behaviour changes.

--- a/apps/console/src/utils.ts
+++ b/apps/console/src/utils.ts
@@ -34,47 +34,11 @@ export function capitalizeFirst(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-/**
- * Format a record title using the titleFormat pattern
- * @param titleFormat Pattern like "{name} - {email}", or an Expression
- *        envelope `{ dialect: 'template', source: '...' }` produced by the
- *        framework's compile step.
- * @param record The record data object
- * @returns Formatted title string
- */
-export function formatRecordTitle(titleFormat: string | { source?: string } | undefined, record: any): string {
-  const template: string | undefined =
-    typeof titleFormat === 'string'
-      ? titleFormat
-      : (titleFormat && typeof titleFormat === 'object' && typeof titleFormat.source === 'string')
-        ? titleFormat.source
-        : undefined;
-
-  if (!template || !record) {
-    return record?.id || record?._id || 'Record';
-  }
-
-  // Replace {fieldName} patterns with actual values
-  return template.replace(/\{(\w+)\}/g, (_match, fieldName) => {
-    const value = record[fieldName];
-    if (value === null || value === undefined) {
-      return '';
-    }
-    return String(value);
-  });
-}
-
-/**
- * Get display name for a record using titleFormat or fallback
- * @param objectDef Object definition with optional titleFormat
- * @param record The record data
- * @returns Display name for the record
- */
-export function getRecordDisplayName(objectDef: any, record: any): string {
-  if (objectDef?.titleFormat) {
-    return formatRecordTitle(objectDef.titleFormat, record);
-  }
-  
-  // Fallback: Try common name fields
-  return record?.name || record?.title || record?.label || record?.id || record?._id || 'Untitled';
-}
+// `formatRecordTitle` / `getRecordDisplayName` (a pre-ADR-0079 divergent
+// resolver pair, ~6 of which existed across surfaces) were removed here as
+// dead code (objectui#6558) — zero console importers, and their presence
+// re-armed the exact trap ADR-0079 closed: a same-named, same-signature
+// resolver one import away that ignores `nameField`/`displayNameField` and
+// ranks the legacy `titleFormat` template first. Console surfaces that need
+// a record title use the unified `@object-ui/core#getRecordDisplayName`
+// (and `formatTitleTemplate`), which the console already depends on.


### PR DESCRIPTION
Fixes #6558

## What

Deletes the dead pre-ADR-0079 `getRecordDisplayName` / `formatRecordTitle` copy from
`apps/console/src/utils.ts`. Both had zero importers anywhere in `apps/console` — the
only import from that file anywhere in the console is `resolveKeyedI18nLabel` at
`apps/console/src/pages/system/AppManagementPage.tsx:70`. `formatRecordTitle`'s only
caller was `getRecordDisplayName` (the other dead function), so the pair is deleted
together rather than one at a time.

Deletion was chosen over a re-export alias per the issue's own reasoning: a re-export
would keep the trap armed under a different spelling. If a console surface ever needs a
record title, the console already depends on the unified `@object-ui/core#getRecordDisplayName`
(and `formatTitleTemplate`).

## Three-homes check (independently re-verified, not just trusted from dispatch)

`formatRecordTitle` has three occurrences repo-wide; only the first was dead:

| # | location | disposition |
|---|---|---|
| 1 | `apps/console/src/utils.ts:45` | **deleted** (this PR) |
| 2 | `packages/app-shell/src/utils/index.ts:15` — `formatTitleTemplate as formatRecordTitle` | deliberate back-compat alias (ADR-0079 note at `:7`/`:14`/`:107`) — untouched |
| 3 | `packages/fields/src/widgets/LookupField.tsx:80` | private local function, **reversed args** `(record, titleFormat)` — untouched, not converged (incompatible signature) |

## Gate this touches

`scripts/__tests__/one-authority-per-exported-name-6273.test.ts` (cites the app-shell
alias at line 481) stays green, untouched — verified by inspection and by running it:
it scans only type/interface/enum declarations and aliasing re-exports as "authorities",
and explicitly treats plain function declarations as out of its stated bound (see its
own fixture table, "Value declarations — out of the stated bound"). The deleted console
copy was a function declaration, so it was never part of this gate's population; no
inventory update needed.

## Verification

- `pnpm --filter '@object-ui/console^...' build` — dependency closure builds clean.
- `pnpm --filter @object-ui/console type-check` — clean (`tsc --noEmit && tsc -b
  tsconfig.node.json --force`, exit 0).
- `pnpm --filter @object-ui/console build` — clean, `dist/index.html` + `plugin.js` +
  `plugin.d.ts` produced.
- **Capability check** (the check is proven able to fail, not just observed to pass):
  temporarily added `import { getRecordDisplayName } from '../../utils'` to
  `AppManagementPage.tsx` (which already imports `resolveKeyedI18nLabel` from the same
  file) → typecheck failed with `TS2305: Module '"../../utils"' has no exported member
  'getRecordDisplayName'` (exit 2) → reverted via `git checkout HEAD -- <path>`,
  confirmed `git diff HEAD` clean, re-ran typecheck clean again.
- Fresh liveness grep across `apps/console` for `getRecordDisplayName`/`formatRecordTitle`
  immediately before push: only the two lines of the explanatory removal comment remain.
- `node scripts/check-changeset-presence.mjs` — passes with the added empty-frontmatter
  changeset (no published behaviour changes; both functions were dead).
- `pnpm exec vitest run scripts/__tests__/one-authority-per-exported-name-6273.test.ts`
  (root-relative invocation, per AGENTS.md) — 11/11 passed.
- `pnpm exec vitest run apps/console/` (root-relative invocation) — 80 test files / 911
  tests, all passed, exit 0.
- `pnpm exec eslint apps/console/src/utils.ts` — 0 errors (2 pre-existing `no-explicit-any`
  warnings on the untouched `resolveKeyedI18nLabel`, unrelated to this change).

## Scope

`apps/console/src/utils.ts` only, plus `.changeset/6558-remove-dead-console-record-title-copy.md`
(empty frontmatter — `check-changeset-presence` confirmed one was owed since `apps/console`
is in the fixed release group; no published behaviour changes since both functions were
dead). No changes under `apps/console/src/pages/settings/` (the #3719 shadow-check
directory) or anywhere else.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_