### PR TITLE
fix(console): hoist the InternalFormRoute import out of hop1SessionPrincipal's timed window

### DIFF
--- a/.changeset/issue-6567-hoist-internalformroute-import.md
+++ b/.changeset/issue-6567-hoist-internalformroute-import.md
@@ -1,0 +1,10 @@
+---
+---
+
+Test-only: in `apps/console/src/components/FormPage.predicateScope.test.tsx`, hoist
+`InternalFormRoute`'s import from a dynamic `await import()` inside the
+`hop1SessionPrincipal` case to module scope. That load was costing 10204ms of the
+case's 15000ms budget — it is the file's first value request for
+`@object-ui/app-shell`, aliased to source — which made the file's one anti-inert
+case fail under full-project parallel load. Same module, same binding, loaded
+before the timed window instead of inside it. No published behaviour changes.

--- a/apps/console/src/components/FormPage.predicateScope.test.tsx
+++ b/apps/console/src/components/FormPage.predicateScope.test.tsx
@@ -65,6 +65,31 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { PredicateScopeProvider } from '@object-ui/react';
 import { FormPage } from './FormPage';
 
+/**
+ * `InternalFormRoute` is imported HERE, at module scope, and deliberately NOT
+ * with a dynamic `await import()` inside `hop1SessionPrincipal` below —
+ * AGENTS.md §测试纪律, "an unbounded module load counted inside a bounded
+ * window".
+ *
+ * This module's graph is the first VALUE request for `@object-ui/app-shell` in
+ * the file (`FormPage` only `import type`s it), so it is what runs the
+ * `vi.mock('@object-ui/app-shell')` factory's `importOriginal()` below — and
+ * that specifier is aliased to `packages/app-shell/src`
+ * (`apps/console/vite.config.ts`), a barrel carrying eight side-effect imports,
+ * transformed on demand. Measured on an IDLE machine it cost **10204ms** of
+ * `hop1SessionPrincipal`'s 15000ms budget; the render and the assertions cost
+ * ~12ms, the same as the seven cases above. Nothing was wrong with the test —
+ * it was racing the module loader, and lost whenever the transform pipeline was
+ * saturated by a full-project run.
+ *
+ * Module scope moves that cost into the IMPORT phase, which no test or hook
+ * timeout bounds. `beforeAll` would not do: it is bounded by `hookTimeout`
+ * (10s), narrower than the 15s it replaces. The specifier is unchanged, so this
+ * is the same module and the same binding as the `await import()` was — only
+ * loaded before the timed window instead of inside it.
+ */
+import { InternalFormRoute } from './InternalFormRoute';
+
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 /**
@@ -312,6 +337,10 @@ describe('#6110 controls — green before AND after the fix, by construction', (
  * REAL, because they are the thing under test. `DefaultHomeLayout` is a
  * pass-through: the chrome is #4109's subject, not this card's, and stubbing it
  * cannot hide the provider, which the route mounts itself.
+ *
+ * These still apply to the module-scope `InternalFormRoute` import above:
+ * `vi.mock` calls are hoisted above every import in the file, so the factories
+ * are registered before that import executes.
  */
 vi.mock('@object-ui/app-shell', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
@@ -341,7 +370,6 @@ describe('#6110 hop 1 — `/forms/:name` publishes the SESSION principal', () =>
     // `/apps/:appName/*` subtree) and in app-shell's `RecordFormPage`, and
     // NEITHER is above `/forms/:name`. Binding the evaluator call sites without
     // this hop would have shipped a fix that reads `{}` forever.
-    const { InternalFormRoute } = await import('./InternalFormRoute');
     vi.stubGlobal(
       'fetch',
       stubFetch([


### PR DESCRIPTION
Fixes #6567

`apps/console/src/components/FormPage.predicateScope.test.tsx` loaded `InternalFormRoute` with a dynamic `await import()` **inside** `hop1SessionPrincipal`'s body — an unbounded module load counted inside a bounded 15000ms window, the shape AGENTS.md §测试纪律 declares against. This hoists that import to module scope. No timeout was raised, nothing was added to `heavyDomTests`, and no assertion changed.

## The root cause is neither candidate triage named

The card left open whether the unbounded import was `FormPage`'s own `React.lazy` or one reached through `@object-ui/react`'s registry. **It is neither**, and both were ruled out by evidence rather than by inspection alone:

- `FormPage.tsx` contains **no** `React.lazy` and no `import()` at all.
- `FormPage` never renders through the ComponentRegistry — it renders fields with its own `FieldInput` and plain `<input>` elements — and `@object-ui/react` is already loaded at module scope by `FormPage`'s own static import.

The load was the test file's own `await import('./InternalFormRoute')`. That module's graph is the **first value request for `@object-ui/app-shell` in the file** — `FormPage` only `import type`s it — so it is what runs the hoisted `vi.mock('@object-ui/app-shell')` factory's `importOriginal()`, against a specifier aliased to **source** (`packages/app-shell/src`, `apps/console/vite.config.ts:472`), a 385-line barrel carrying eight side-effect imports.

Instrumented on an idle machine, inside the test body:

```
[probe] importOriginal_auth_ms=240
[probe] importOriginal_appshell_ms=10204
[probe] dynamicImport_total_ms=10223
✓ hop1SessionPrincipal ... 10235ms
```

**10204 of the 10223ms — 99.8% — is `importOriginal('@object-ui/app-shell')`.** The render and the assertions cost ~12ms, the same as the seven cases above it. The test was not slow; it was racing the module loader for 68% of its budget before any contention was added.

## Reproducing the failure

A plain full-project run is a coin flip (the card measured green in 2 of 3). Mine came back green too — `vitest run apps/console/` on the **unfixed** tree, 920/920, hop1 at **7120ms**. So the failure was reproduced deterministically instead, by moving the threshold rather than the load — a CLI flag, no file or config edit:

| tree | invocation | hop1SessionPrincipal |
|---|---|---|
| pre-hoist | `--testTimeout=9000` | **FAILS** — `Test timed out in 9000ms.` at `FormPage.predicateScope.test.tsx:336:3` |
| post-hoist | `--testTimeout=9000` | 8 passed |

That failure is the card's signature byte for byte, down to the line number. The fixed file survives a budget **40% tighter** than the real one.

## The fix, in vitest's own phase accounting

Same file, same machine, isolated run:

| | hop1SessionPrincipal | `tests` phase | `import` phase |
|---|---|---|---|
| before | **10485ms** | 10.63s | 156ms |
| after | **9ms** | 153ms | 11.32s |

The 10.2s did not disappear — it moved out of the phase a `testTimeout` bounds and into the one nothing bounds. Total wall duration is unchanged (~28s).

## Full-project runs — three green, at and above the original saturation

All at `182be8350`, `pnpm exec vitest run apps/console/`, 81 files / 920 tests:

| run | duration | setup | result | hop1 |
|---|---|---|---|---|
| 1 | 322.69s | 721.47s | 920 passed | 9ms |
| 2 | 252.49s | 555.82s | 920 passed | 10ms |
| 3 | 372.93s | **839.99s** | 920 passed | 10ms |

Run 3 matters most: the card's red run spent **851s** in setup over a 386s duration. Run 3 reproduces that saturation (839.99s / 372.93s) and `hop1SessionPrincipal` still finishes in 10ms. The case no longer scales with load at all.

## The hoist did not change what the test exercises

Same specifier, so the same module and the same binding — ESM caches by resolved specifier, and `vi.mock` calls are hoisted above every import, so the factories are still registered before the module-scope import executes. Proven rather than asserted, by ablating the hop-1 fix (removing `ExpressionProvider` from `InternalFormRoute.tsx`) and running the same file two ways:

| test file | hop1SessionPrincipal under the ablation |
|---|---|
| hoisted (this PR) | **RED**, 19ms |
| pre-hoist (`b1a732b22`) | **RED**, 11927ms |

Byte-identical failure messages (`expected document not to contain element, found <h2 class="mb-3 text-sm font-medium"`). Same verdict, same assertion — the hoisted form just reaches it 600x sooner. The file's one anti-inert case is still anti-inert. The ablation was restored and the restore proven with an empty `git diff HEAD`.

`beforeAll` was not used: it is bounded by `hookTimeout` (10s), narrower than the 15s it would replace.

## Gates

At `182be8350`, tree clean:

- `pnpm exec vitest run apps/console/` — `Test Files 81 passed (81)`, `Tests 920 passed (920)`
- `apps/console` `tsc --noEmit` — exit 0, 0 diagnostics, after `pnpm --workspace-concurrency=2 --filter '@object-ui/console^...' build`. `--listFiles` confirms the edited test file **is** in the checked set, so this is a measurement and not a clean-by-exclusion.
- `apps/console` `eslint .` — exit 0, full scan (182 files, 37.9s), 0 errors. The one warning on the edited file is pre-existing `@typescript-eslint/no-explicit-any` on the `PredicateScopeProvider` line, unchanged and only shifted by the new comment block.
- `check-changeset-presence` ✅ · `check-changeset-fixed` ✅ · `check-changeset-no-major` ✅ · `check-control-bytes` ✅ · `check-vi-mock-specifiers` ✅

The changeset gate was asked rather than assumed: it said one **is** owed (`apps/console` is a released package) and pointed at the empty-frontmatter form for a change that publishes nothing. That is what this PR carries.

_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_