### PR TITLE
fix(plugin-kanban,plugin-calendar): stop spelling the house drawer width as a renderer default

### DIFF
--- a/.changeset/kanban-calendar-nav-width-converge.md
+++ b/.changeset/kanban-calendar-nav-width-converge.md
@@ -1,0 +1,22 @@
+---
+---
+
+`ObjectKanban` and `ObjectCalendar` internal cleanup, measured as a zero-pixel
+change — the convergence of the two renderers #6305 left behind.
+
+Each carried the house default `min(960px, 60vw)` at **two** sites: the
+`navConfig` default (`{ mode: 'drawer', width: 'min(960px, 60vw)' }`) and a
+render-site `width={(navigation.width as any) ?? 'min(960px, 60vw)'}`. Both are
+gone. `width` is spec-deprecated (`@deprecated [#2578 -> size]`) and
+`resolveOverlayWidth` gives an explicit `width` priority OVER `size`, so
+spelling it kept the deprecated branch load-bearing on the path most boards and
+calendars take. With both omitted, `resolveOverlayWidth` returns `undefined` and
+`RecordDetailDrawer`'s own `width` default supplies the identical
+`min(960px, 60vw)`.
+
+The resolved overlay width is therefore unchanged on every viewport, for both a
+board/calendar that declares no `navigation` and one that authors
+`navigation.width` — each is now pinned by a test. The three renderers agree
+again.
+
+No published behaviour changes.

--- a/packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pins the drawer width a calendar gets when it declares no `navigation`
+ * (objectui#6303 — the sibling of `ObjectGantt.navWidthDefault.test.tsx`).
+ *
+ * `ObjectCalendar` used to spell `min(960px, 60vw)` in TWO places: the
+ * `navConfig` default (`{ mode: 'drawer', width: 'min(960px, 60vw)' }`) and,
+ * further down, a render-site
+ * `width={(navigation.width as any) ?? 'min(960px, 60vw)'}`. The second is why
+ * taking only the first would have changed nothing — the old width survived by
+ * a different route.
+ *
+ * `width` is `@deprecated [#2578 -> size]` and `resolveOverlayWidth` gives an
+ * explicit `width` priority OVER `size`, so spelling it kept the deprecated
+ * branch load-bearing on the path most calendars take. The default is now
+ * `{ mode: 'drawer' }` with no render-site fallback: `resolveOverlayWidth`
+ * returns `undefined` and RecordDetailDrawer's own `width` default supplies the
+ * identical CSS — a zero-pixel change.
+ *
+ * Both halves below are load-bearing and fail for different reasons:
+ *
+ *   half 1 — the calendar must stop injecting a width of its own (it has to
+ *            hand `undefined` down, or the drawer's default can never apply).
+ *            This half is what catches a re-added `??` fallback at the render
+ *            site, which half 2 alone cannot see: the fallback's value is the
+ *            same string the drawer default produces;
+ *   half 2 — the width the REAL drawer then resolves must still be that value.
+ *            Without this half the calendar would follow a moved drawer default
+ *            invisibly, which is the regression the indirection introduces.
+ *
+ * A third case pins the other direction: an AUTHORED `navigation.width` still
+ * wins. What #6303 removed is the renderer spelling the deprecated key as its
+ * own default — not the key's acceptance as an authored value.
+ *
+ * All three assert the resolved width VALUE — never a `className`, never "it
+ * renders", either of which passes in both worlds.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { ObjectCalendar } from './ObjectCalendar';
+
+/** The width the calendar's drawer has always resolved to. Must not drift. */
+const EXPECTED_WIDTH = 'min(960px, 60vw)';
+
+// Record the props ObjectCalendar hands down, then delegate to the REAL drawer
+// so half 2 measures the actual resolution rather than a stub's idea of it.
+let drawerProps: any = null;
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  const Real = actual.RecordDetailDrawer;
+  return {
+    ...actual,
+    RecordDetailDrawer: (props: any) => {
+      drawerProps = props;
+      return <Real {...props} />;
+    },
+  };
+});
+
+/**
+ * The month grid renders whatever month `currentDate` is on, and `currentDate`
+ * initialises to `new Date()` — so the event has to sit in the CURRENT month or
+ * there is nothing on screen to click. Noon avoids a timezone shift moving it
+ * across a month boundary.
+ */
+function eventInCurrentMonth() {
+  const now = new Date();
+  return new Date(now.getFullYear(), now.getMonth(), 15, 12, 0, 0).toISOString();
+}
+
+async function openDrawer(navigation?: Record<string, unknown>) {
+  render(
+    <ObjectCalendar
+      schema={{
+        type: 'object-calendar',
+        objectName: 'events',
+        calendar: { startDateField: 'starts_at', titleField: 'name' },
+        data: {
+          provider: 'value',
+          items: [{ id: '1', name: 'On the calendar', starts_at: eventInCurrentMonth() }],
+        },
+        ...(navigation ? { navigation } : {}),
+      } as never}
+    />,
+  );
+  const event = await screen.findByText('On the calendar');
+  fireEvent.click(event);
+  await waitFor(() => expect(drawerProps).not.toBeNull());
+  await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined());
+}
+
+/**
+ * The drawer prefers a drag-resized width persisted in localStorage over its
+ * prop, which would mask half 2 — and it is keyed by `objectName`, so a value
+ * left by any earlier test in the file would be read back here.
+ */
+function readPanelWidth(): string {
+  const panel = document.querySelector('[role="dialog"]') as HTMLElement | null;
+  expect(panel, 'drawer panel').not.toBeNull();
+  // The drawer applies the resolved width as an inline style on its panel, as
+  // BOTH `width` and `max-width`. happy-dom's CSS parser drops the `width`
+  // longhand when the value is a `min()` expression but keeps `max-width`, so
+  // the surviving declaration is what we read — it is the same resolved
+  // string, not a proxy for it.
+  return panel!.style.maxWidth;
+}
+
+describe('calendar drawer width with no declared `navigation` (objectui#6303)', () => {
+  beforeEach(() => {
+    drawerProps = null;
+    try { window.localStorage.clear(); } catch { /* ignore */ }
+  });
+  afterEach(() => cleanup());
+
+  it('half 1: the calendar injects no width of its own (so the drawer default applies)', async () => {
+    await openDrawer();
+    expect(drawerProps.width).toBeUndefined();
+  });
+
+  it('half 2: the width the real drawer resolves is still the pinned value', async () => {
+    await openDrawer();
+    expect(readPanelWidth()).toBe(EXPECTED_WIDTH);
+  });
+
+  it('an authored `navigation.width` still reaches the drawer unchanged', async () => {
+    await openDrawer({ mode: 'drawer', width: '720px' });
+    expect(drawerProps.width).toBe('720px');
+    expect(readPanelWidth()).toBe('720px');
+  });
+});

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -446,7 +446,24 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
   // Must be called before any early returns to satisfy React hooks rules
   // When the local navigation mode is an overlay (drawer/modal), ignore the
   // inherited onRowClick so the local overlay wins over parent page-nav.
-  const navConfig = (schema as any).navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' };
+  // No width is spelled here on purpose (objectui#6303, converging the calendar
+  // on the shape #6305 gave ObjectGantt). `width` is `@deprecated [#2578 ->
+  // size]` in the spec that owns this shape, and `resolveOverlayWidth` gives an
+  // explicit `width` priority OVER `size` — so spelling it kept the deprecated
+  // branch load-bearing on the path most calendars take (no declared
+  // `navigation`), and made the size buckets unreachable there. Omitting both
+  // leaves `resolveOverlayWidth` returning `undefined`, which is what
+  // RecordDetailDrawer's own `width` default is for; that default is the
+  // identical `min(960px, 60vw)`, so this is a zero-pixel change on every
+  // viewport. The absent width is deliberate, not an oversight — do not
+  // "restore" it. Pinned by `ObjectCalendar.navWidthDefault.test.tsx`, both
+  // halves, because the equivalence now depends on the drawer's default too.
+  //
+  // Deliberately NOT converged on `size: 'lg'` either: that bucket is
+  // `min(92vw, 960px)`, which agrees with the above only at viewport >= 1600px
+  // and is up to 53% wider below it. That move is a real behaviour change and
+  // stays open on #6303 for a human ruling.
+  const navConfig = (schema as any).navigation ?? { mode: 'drawer' };
   const navIsOverlay = navConfig.mode === 'drawer' || navConfig.mode === 'modal' || navConfig.mode === 'split' || navConfig.mode === 'popover';
   const navigation = useNavigationOverlay({
     navigation: navConfig,
@@ -760,7 +777,10 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
             recordId={recordId}
             dataSource={dataSource}
             objectSchema={objectSchema as any}
-            width={(navigation.width as any) ?? 'min(960px, 60vw)'}
+            // No `?? 'min(960px, 60vw)'` fallback on purpose — `undefined` has
+            // to reach the drawer for its OWN identical default to apply. See
+            // the `navConfig` comment above (objectui#6303).
+            width={navigation.width as any}
             fullPageHref={deriveRecordPageHref(objectName, recordId) ?? undefined}
             onFieldSave={async (field, value) => {
               if (!dataSource?.update) return;

--- a/packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pins the drawer width a kanban gets when it declares no `navigation`
+ * (objectui#6303 — the sibling of `ObjectGantt.navWidthDefault.test.tsx`).
+ *
+ * `ObjectKanban` used to spell `min(960px, 60vw)` in TWO places: the `navConfig`
+ * default (`{ mode: 'drawer', width: 'min(960px, 60vw)' }`) and, further down, a
+ * render-site `width={(navigation.width as any) ?? 'min(960px, 60vw)'}`. The
+ * second is why taking only the first would have changed nothing — the old
+ * width survived by a different route.
+ *
+ * `width` is `@deprecated [#2578 -> size]` and `resolveOverlayWidth` gives an
+ * explicit `width` priority OVER `size`, so spelling it kept the deprecated
+ * branch load-bearing on the path most boards take. The default is now
+ * `{ mode: 'drawer' }` with no render-site fallback: `resolveOverlayWidth`
+ * returns `undefined` and RecordDetailDrawer's own `width` default supplies the
+ * identical CSS — a zero-pixel change.
+ *
+ * Both halves below are load-bearing and fail for different reasons:
+ *
+ *   half 1 — the kanban must stop injecting a width of its own (it has to hand
+ *            `undefined` down, or the drawer's default can never apply). This
+ *            half is what catches a re-added `??` fallback at the render site,
+ *            which half 2 alone cannot see: the fallback's value is the same
+ *            string the drawer default produces;
+ *   half 2 — the width the REAL drawer then resolves must still be that value.
+ *            Without this half the kanban would follow a moved drawer default
+ *            invisibly, which is the regression the indirection introduces.
+ *
+ * A third case pins the other direction: an AUTHORED `navigation.width` still
+ * wins. What #6303 removed is the renderer spelling the deprecated key as its
+ * own default — not the key's acceptance as an authored value.
+ *
+ * All three assert the resolved width VALUE — never a `className`, never "it
+ * renders", either of which passes in both worlds.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { ObjectKanban } from './ObjectKanban';
+
+// Pay the board's lazy chunk at import time, not inside a `findBy` budget
+// (AGENTS.md 测试纪律) — every assertion below sits after the Suspense
+// boundary, and a card has to be on screen before it can be clicked. The
+// specifier must stay byte-identical to the one in `./index`, which is what
+// makes the component's own lazy factory resolve immediately.
+import './KanbanImpl';
+
+/** The width the kanban's drawer has always resolved to. Must not drift. */
+const EXPECTED_WIDTH = 'min(960px, 60vw)';
+
+// Record the props ObjectKanban hands down, then delegate to the REAL drawer so
+// half 2 measures the actual resolution rather than a stub's idea of it.
+let drawerProps: any = null;
+vi.mock('@object-ui/plugin-detail', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  const Real = actual.RecordDetailDrawer;
+  return {
+    ...actual,
+    RecordDetailDrawer: (props: any) => {
+      drawerProps = props;
+      return <Real {...props} />;
+    },
+  };
+});
+
+const cards = [{ id: '1', title: 'On the board', status: 'todo' }];
+
+async function openDrawer(navigation?: Record<string, unknown>) {
+  render(
+    <ObjectKanban
+      schema={{
+        type: 'object-kanban',
+        objectName: 'contacts',
+        groupBy: 'status',
+        columns: [{ id: 'todo', title: 'To Do' }],
+        data: cards,
+        ...(navigation ? { navigation } : {}),
+      } as never}
+    />,
+  );
+  const card = await screen.findByText('On the board');
+  fireEvent.click(card);
+  await waitFor(() => expect(drawerProps).not.toBeNull());
+  await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined());
+}
+
+/**
+ * The drawer prefers a drag-resized width persisted in localStorage over its
+ * prop, which would mask half 2 — and it is keyed by `objectName`, so a value
+ * left by any earlier test in the file would be read back here.
+ */
+function readPanelWidth(): string {
+  const panel = document.querySelector('[role="dialog"]') as HTMLElement | null;
+  expect(panel, 'drawer panel').not.toBeNull();
+  // The drawer applies the resolved width as an inline style on its panel, as
+  // BOTH `width` and `max-width`. happy-dom's CSS parser drops the `width`
+  // longhand when the value is a `min()` expression but keeps `max-width`, so
+  // the surviving declaration is what we read — it is the same resolved
+  // string, not a proxy for it.
+  return panel!.style.maxWidth;
+}
+
+describe('kanban drawer width with no declared `navigation` (objectui#6303)', () => {
+  beforeEach(() => {
+    drawerProps = null;
+    try { window.localStorage.clear(); } catch { /* ignore */ }
+  });
+  afterEach(() => cleanup());
+
+  it('half 1: the kanban injects no width of its own (so the drawer default applies)', async () => {
+    await openDrawer();
+    expect(drawerProps.width).toBeUndefined();
+  });
+
+  it('half 2: the width the real drawer resolves is still the pinned value', async () => {
+    await openDrawer();
+    expect(readPanelWidth()).toBe(EXPECTED_WIDTH);
+  });
+
+  it('an authored `navigation.width` still reaches the drawer unchanged', async () => {
+    await openDrawer({ mode: 'drawer', width: '720px' });
+    expect(drawerProps.width).toBe('720px');
+    expect(readPanelWidth()).toBe('720px');
+  });
+});

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -690,7 +690,27 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
       ...(effectiveSwimlaneField ? { swimlaneField: effectiveSwimlaneField } : {}),
   };
 
-  const navConfig = (schema as any).navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' };
+  // Default to a right-side drawer so clicking a card opens an editable detail
+  // panel inline. A schema can override this with its own `navigation` config.
+  //
+  // No width is spelled here on purpose (objectui#6303, converging kanban on
+  // the shape #6305 gave ObjectGantt). `width` is `@deprecated [#2578 -> size]`
+  // in the spec that owns this shape, and `resolveOverlayWidth` gives an
+  // explicit `width` priority OVER `size` — so spelling it kept the deprecated
+  // branch load-bearing on the path most boards take (no declared
+  // `navigation`), and made the size buckets unreachable there. Omitting both
+  // leaves `resolveOverlayWidth` returning `undefined`, which is what
+  // RecordDetailDrawer's own `width` default is for; that default is the
+  // identical `min(960px, 60vw)`, so this is a zero-pixel change on every
+  // viewport. The absent width is deliberate, not an oversight — do not
+  // "restore" it. Pinned by `ObjectKanban.navWidthDefault.test.tsx`, both
+  // halves, because the equivalence now depends on the drawer's default too.
+  //
+  // Deliberately NOT converged on `size: 'lg'` either: that bucket is
+  // `min(92vw, 960px)`, which agrees with the above only at viewport >= 1600px
+  // and is up to 53% wider below it. That move is a real behaviour change and
+  // stays open on #6303 for a human ruling.
+  const navConfig = (schema as any).navigation ?? { mode: 'drawer' };
   // When this kanban is embedded in an ObjectView, the parent provides
   // `onRowClick`/`onCardClick` and owns the unified record-detail overlay.
   // We must always forward to the parent in that case — otherwise we'd open
@@ -992,7 +1012,10 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             recordId={recordId}
             dataSource={dataSource}
             objectSchema={objectDef as any}
-            width={(navigation.width as any) ?? 'min(960px, 60vw)'}
+            // No `?? 'min(960px, 60vw)'` fallback on purpose — `undefined` has
+            // to reach the drawer for its OWN identical default to apply. See
+            // the `navConfig` comment above (objectui#6303).
+            width={navigation.width as any}
             fullPageHref={deriveRecordPageHref(objectName, recordId) ?? undefined}
             onFieldSave={async (field, value) => {
               if (!dataSource?.update) return;


### PR DESCRIPTION
Fixes #6303

Converges `ObjectKanban` and `ObjectCalendar` on the shape #6305 gave `ObjectGantt`. Only the **decided `width` half**; the `size: 'lg'` bucket question is untouched and stays open on #6303 for a human ruling.

## The four sites

Each renderer carried **two** copies of the house default. Taking only the first would have left the old width alive by a different route — which is what the card was filed to prevent.

| file | line on `main` | before | after |
| :--- | ---: | :--- | :--- |
| `plugin-kanban/src/ObjectKanban.tsx` | 693 | `(schema as any).navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' }` | `(schema as any).navigation ?? { mode: 'drawer' }` |
| `plugin-kanban/src/ObjectKanban.tsx` | 995 | `width={(navigation.width as any) ?? 'min(960px, 60vw)'}` | `width={navigation.width as any}` |
| `plugin-calendar/src/ObjectCalendar.tsx` | 449 | `(schema as any).navigation ?? { mode: 'drawer', width: 'min(960px, 60vw)' }` | `(schema as any).navigation ?? { mode: 'drawer' }` |
| `plugin-calendar/src/ObjectCalendar.tsx` | 763 | `width={(navigation.width as any) ?? 'min(960px, 60vw)'}` | `width={navigation.width as any}` |

All four line numbers were re-measured on `origin/main` @ `b1a732b22` and matched the dispatch reading exactly. After this PR the literal survives in these two files only inside the explanatory comments; `grep` finds no remaining producer.

## Why this is zero-pixel

`width` is `@deprecated [#2578 -> size]` and `resolveOverlayWidth` gives an explicit `width` priority **over** `size`, so spelling it kept the deprecated branch load-bearing on the path most boards and calendars take (no declared `navigation`) and made the size buckets unreachable there. With both copies omitted, `resolveOverlayWidth` returns `undefined` and `RecordDetailDrawer`'s own `width` default supplies the identical `min(960px, 60vw)`.

The escalation clause was checked rather than assumed. Both renderers reach the drawer by the **same** path the gantt does — `import { RecordDetailDrawer } from '@object-ui/plugin-detail'`, rendered directly with `width={…}` — and `resolveOverlayWidth` returns `undefined`, never `null`, so the drawer's default *parameter* does apply. `navConfig.width` and `navigation.width` have no other consumer in either file. Nothing contradicts the zero-pixel finding.

`RecordDetailDrawer.tsx` is **not** touched: it is the source the other three now delegate to, and `:76-78` carries the only written rationale for the value.

## Pin tests, both halves each

`ObjectKanban.navWidthDefault.test.tsx` and `ObjectCalendar.navWidthDefault.test.tsx` mirror `ObjectGantt.navWidthDefault.test.tsx`'s posture — half 1 (the renderer injects no width of its own) and half 2 (the width the **real** drawer then resolves is still the pinned value), because the equivalence depends on both. A third case pins the other direction: an authored `navigation.width` still reaches the drawer unchanged, so the deprecated key stays accepted as an authored value.

## Reverse-verification — direction predicted first, then measured

Prediction: restoring the pre-fix expressions turns **only half 1** red in each file. Half 2 and the authored-width control cannot see a re-added `??` fallback — its value is the same string the drawer default produces — and that blind spot is exactly why half 1 exists.

**Leg A** — both files restored to `b1a732b22` (mutation proved on disk by grep counts of both the injected and the deleted text, not by an exit code):

```
Test Files  2 failed (2)
     Tests  2 failed | 4 passed (6)
```

Both failures are `half 1`; both `half 2` and both authored-width controls stayed green. Matches the prediction exactly.

**Leg B** — half 2's own load-bearing check: `RecordDetailDrawer`'s default temporarily moved to `min(900px, 55vw)`:

```
Test Files  2 failed (2)
     Tests  2 failed | 4 passed (6)
```

Both failures are `half 2` this time; both `half 1` and the controls stayed green — so half 2 really measures the drawer's default rather than restating half 1.

Both legs ran under a `trap … EXIT INT TERM` with absolute paths and were restored with `git checkout HEAD -- <path>`. Restoration is proved by byte identity, not by an exit code: `git diff HEAD` empty, and each file's `git hash-object` back to the HEAD blob recorded before the mutation (`ace66b96…`, `2592c8aa…`, `da15724a…`).

## Gates — each gate's own printed verdict, exit code captured before any pipe

Measured at `d8814f129`. The commit after the source commit adds `.changeset/*.md` and nothing else (`git diff 087514d61 d8814f129 --stat` = 1 file), so the suite and lint runs measured a byte-identical `packages/**`.

| gate | exit | its own verdict line |
| :--- | ---: | :--- |
| `vitest run packages/plugin-kanban/ packages/plugin-calendar/` | 0 | `Test Files 34 passed (34)` · `Tests 210 passed (210)` |
| the two new pin tests, at `d8814f129` | 0 | `Test Files 2 passed (2)` · `Tests 6 passed (6)` |
| `turbo run lint` (**whole repo**, not narrowed) | 0 | `Tasks: 47 successful, 47 total` |
| `type-check` (both packages) | 0 | `packages/plugin-{kanban,calendar} type-check: Done` |
| `turbo run build` (dependency closure) | 0 | `Tasks: 15 successful, 15 total` |
| `check-changeset-presence` | 0 | `✅ … declares 1 changeset(s)` |
| `check-changeset-no-major` | 0 | `✅ No changeset declares a major bump.` |
| `check-changeset-fixed` | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `check-changeset-overwrite` | 0 | `✅ No pre-existing changeset was modified or deleted.` |
| `check-control-bytes` | 0 | `✅ OK (scanned 5435 tracked text file(s); skipped 85 binary).` |
| `check-vi-mock-specifiers` | 0 | `✅ OK (… 694 bare (out of scope) …)` |
| `check-lint-coverage` | 0 | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `check-type-check-coverage` | 0 | `✅ type-check coverage: 45/46 via type-check …` |
| `check-package-self-import` | 0 | `✅ No package names itself inside its own src/.` |
| `check-phantom-dependencies` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |

The type-check green is proved to **cover** the new tests rather than merely coexist with them: `tsc -p tsconfig.test.json --listFiles` finds each new file as a program input (1 hit each). The two new files add 3 `@typescript-eslint/no-explicit-any` **warnings** each — the same rule the gantt pin test triggers; `lint.yml:20` deliberately sets no `--max-warnings`, and the error count is 0.

## Changeset

`.changeset/kanban-calendar-nav-width-converge.md`, **empty frontmatter**, matching what #6305 used for the gantt half. `check-changeset-presence.mjs` reports that as *"declared as releasing nothing, which is the explicit exemption and a complete answer to this gate"*. The body says the change is zero-pixel rather than inventing a behaviour claim.

## Out of scope, deliberately

- Any move to `size: 'lg'` on any renderer. `min(92vw, 960px)` agrees with the current default only at viewport >= 1600px and is up to 53% wider below it — a published-behaviour change, and #6303 stays open for it.
- `RecordDetailDrawer.tsx`, for the reason above.

One check the card did not ask for: a repo-wide sweep for a *fifth* divergent renderer found none. All three `navConfig` defaults now read `{ mode: 'drawer' }`, and `plugin-view/src/ObjectView.tsx` (`:1901`, `:1958`) already passes `navigationConfig?.width` with no literal fallback, so it delegates too. `plugin-tree` and `plugin-map` use `useNavigationOverlay` but spell no width. No new issues filed.


---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_