### PR TITLE
fix(plugin-detail): let `buildConflict` consume the narrowing it is handed

### DIFF
--- a/.changeset/6477-buildconflict-narrowed-type.md
+++ b/.changeset/6477-buildconflict-narrowed-type.md
@@ -1,0 +1,16 @@
+---
+---
+
+Type-only change in `@object-ui/plugin-detail`: `InlineEditSaveBar`'s internal
+`buildConflict` callback now takes the type `isConcurrentUpdateError` narrows to,
+instead of `any`, and the `as Record<string, unknown> | null` cast that the `any`
+made necessary is gone.
+
+Nothing releases. Measured, not assumed: building the package before and after
+the change and comparing all 52 emitted `.js` / `.cjs` / `.d.ts` artefacts leaves
+51 byte-identical, including `dist/index.js`, `dist/index.umd.cjs` and
+`dist/index.d.ts`. The single delta is `dist/InlineEditSaveBar.d.ts`, which gains
+the `BuildConflict` type its pin test reads; the package's `exports` map declares
+only `"."`, so that file is not resolvable by any consumer, and the published
+`dist/index.d.ts` does not mention the name. Published behaviour and published
+types are both unchanged.

--- a/packages/plugin-detail/src/InlineEditSaveBar.tsx
+++ b/packages/plugin-detail/src/InlineEditSaveBar.tsx
@@ -64,6 +64,39 @@ export interface InlineEditSaveBarProps {
   className?: string;
 }
 
+/**
+ * The shape `isConcurrentUpdateError` narrows to, DERIVED from the predicate
+ * rather than restated here (objectui#6477).
+ *
+ * `buildConflict` below is that predicate's ONLY in-repo consumer, and it used
+ * to take `err: any` — which discarded the narrowing one line after the call
+ * site drew it, so the predicate's return type reached no typed consumer at
+ * all. objectui#6421 / PR #6474 had just made that return type honest
+ * (`code?: 'CONCURRENT_UPDATE'`, optional because the `name` limb carries no
+ * `code`); this alias is what makes something listen.
+ *
+ * Derived, not copied, on purpose: a restated literal shape is a second
+ * declaration that drifts silently, and the two disagreeing is exactly the
+ * failure this card was opened to rule out. Written this way the compiler
+ * re-checks every read in `buildConflict` against whatever the predicate
+ * currently promises, so a future narrowing that stops covering
+ * `currentRecord` / `currentVersion` is a red build here rather than a fresh
+ * `any`.
+ */
+type NarrowedBy<F> = F extends (arg: unknown) => arg is infer N ? N : never;
+type ConcurrentUpdateErrorShape = NarrowedBy<typeof isConcurrentUpdateError>;
+
+/**
+ * Signature of the module-local `buildConflict` callback. Exported as a TYPE
+ * only, for its pin test to reach — the callback itself stays inside the
+ * component. Deliberately NOT re-exported from `src/index.tsx`, which lists
+ * every published name explicitly, so the package surface is unchanged.
+ */
+export type BuildConflict = (
+  draft: Record<string, any>,
+  err: ConcurrentUpdateErrorShape,
+) => ConcurrentUpdateConflict;
+
 /** Strip noisy backend prefixes so the inline error reads cleanly. */
 function cleanError(err: any): string {
   const raw = err?.message || err?.error || String(err ?? 'Save failed');
@@ -121,10 +154,13 @@ export const InlineEditSaveBar: React.FC<InlineEditSaveBarProps> = ({
    * single-field draft shows the classic per-field before/after; a multi-field
    * draft shows a record-level summary (the dialog JSON-stringifies objects).
    */
-  const buildConflict = React.useCallback(
-    (draft: Record<string, any>, err: any): ConcurrentUpdateConflict => {
+  const buildConflict = React.useCallback<BuildConflict>(
+    (draft, err) => {
       const keys = Object.keys(draft);
-      const current = (err?.currentRecord ?? null) as Record<string, unknown> | null;
+      // No `as` cast here: the narrowed type already declares `currentRecord`
+      // as `Record<string, unknown> | null`, which is exactly what the conflict
+      // payload takes. That cast was the only type this value ever got.
+      const current = err?.currentRecord ?? null;
       if (keys.length === 1) {
         const f = keys[0];
         return {

--- a/packages/plugin-detail/src/__tests__/InlineEditSaveBar.buildConflictNarrowed-6477.test.tsx
+++ b/packages/plugin-detail/src/__tests__/InlineEditSaveBar.buildConflictNarrowed-6477.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `buildConflict` consumes the narrowing it is handed (objectui#6477).
+ *
+ * `InlineEditSaveBar` narrows correctly at the call site —
+ * `if (isConcurrentUpdateError(err) && canAtomic)` — and then used to hand the
+ * narrowed value to a callback whose parameter was `err: any`, which discards
+ * it. The predicate's return type was inert at its only in-repo consumer, one
+ * line after the boundary was drawn. objectui#6421 / PR #6474 had just made
+ * that return type honest (`code?: 'CONCURRENT_UPDATE'`, optional because the
+ * `name` limb carries no `code`); this card is why anything listens to it.
+ *
+ * The measurement that picked this answer over "keep the `any` and write down
+ * why": `buildConflict` reads exactly TWO things off `err` — `currentRecord`
+ * and `currentVersion` — and the narrowed type declares both, at types the
+ * `ConcurrentUpdateConflict` payload accepts unchanged. Nothing forced the
+ * `any`, so it went.
+ *
+ * WHAT EACH PIN BELOW IS FOR, labelled the way the sibling
+ * `ConcurrentUpdateDialog.narrowedCode-6421.test.tsx` labels its own, because
+ * a pin that also passes against `origin/main` proves nothing about this
+ * change:
+ *
+ *  - DISAGREES — red before this change, green after.
+ *  - CONTROL — passes both ways ON PURPOSE, naming the future wrong shape it
+ *    exists to catch, so the DISAGREES pins cannot pass vacuously.
+ *
+ * KNOWN RESIDUAL, stated rather than papered over: these pins bite on the
+ * exported `BuildConflict` type, which the component applies via
+ * `React.useCallback<BuildConflict>`. A revert that deleted the generic AND
+ * re-annotated the lambda `err: any` would leave `BuildConflict` correct but
+ * unused, and this file would stay green. Nothing reachable from a test can
+ * observe a callback local to a component body; the runtime block below is
+ * what covers that flank, by driving the real component through a real 409.
+ *
+ * The compile-time half is ERASED at runtime — vitest proves nothing about it.
+ * `tsc -p packages/plugin-detail/tsconfig.test.json`, chained off this
+ * package's `type-check` script, is the only thing that checks it, and it
+ * reads `../InlineEditSaveBar` as SOURCE (a relative import), never through a
+ * built `dist/*.d.ts`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { InlineEditProvider, useInlineEdit } from '@object-ui/react';
+import { InlineEditSaveBar, type BuildConflict } from '../InlineEditSaveBar';
+import {
+  isConcurrentUpdateError,
+  type ConcurrentUpdateConflict,
+} from '../ConcurrentUpdateDialog';
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins                                                           */
+/*                                                                             */
+/* `Assert<false>` is a TS2344 "does not satisfy the constraint 'true'" error,  */
+/* so a false verdict is a red build, not a skipped assertion.                 */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Extends<A, B> = [A] extends [B] ? true : false;
+type IsNever<T> = [T] extends [never] ? true : false;
+/** `any` is the one type that is BOTH assignable to and from `1 & T`. */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/** The type a `x is T` predicate narrows to — `never` if it stopped being one. */
+type NarrowedBy<F> = F extends (arg: unknown) => arg is infer N ? N : never;
+
+type Narrowed = NarrowedBy<typeof isConcurrentUpdateError>;
+type ErrParam = Parameters<BuildConflict>[1];
+
+// CONTROL (passes both ways) — the predicate is still a live, exported type
+// predicate over `unknown`. Guards a future change to a bare `boolean` return
+// (like `plugin-form`'s copy), which collapses `Narrowed` to `never` — and
+// `never` is assignable to everything, so it would satisfy every pin below in
+// silence.
+type _PredicateStillNarrows = Assert<Equal<IsNever<Narrowed>, false>>;
+
+// CONTROL (passes both ways) — `buildConflict` is still the binary callback
+// returning the dialog's payload. Guards a refactor that reshapes the callback
+// out from under the pins rather than reverting them.
+type _StillABinaryCallback = Assert<Equal<Parameters<BuildConflict>['length'], 2>>;
+type _StillReturnsTheConflictPayload = Assert<
+  Equal<ReturnType<BuildConflict>, ConcurrentUpdateConflict>
+>;
+type _DraftParamUnchanged = Assert<Equal<Parameters<BuildConflict>[0], Record<string, any>>>;
+
+// DISAGREES — the error parameter is not `any`. This is the card's whole
+// subject stated in one line: `Equal` distinguishes `any` from every other
+// type, so this is red the moment the parameter goes back.
+type _ErrParamIsNotAny = Assert<Equal<IsAny<ErrParam>, false>>;
+
+// DISAGREES — and it is not merely "some type", it is EXACTLY what the
+// predicate narrows to. Guards the near-miss fix: a hand-restated literal
+// shape that starts out identical and drifts the first time the predicate
+// changes. The alias in the source is derived from the predicate precisely so
+// this equality cannot rot.
+type _ErrParamIsTheNarrowedType = Assert<Equal<ErrParam, Narrowed>>;
+
+// DISAGREES — the two reads `buildConflict` performs are covered by the
+// narrowed type, at types the conflict payload takes UNCHANGED. This pair is
+// also the standing proof that the `as Record<string, unknown> | null` cast
+// this change deleted was genuinely redundant: if these ever go red, the two
+// shapes have started to disagree and the cast was hiding it.
+type _CurrentRecordReadIsCovered = Assert<
+  Extends<Narrowed['currentRecord'], ConcurrentUpdateConflict['currentRecord']>
+>;
+type _CurrentVersionReadIsCovered = Assert<
+  Extends<Narrowed['currentVersion'], ConcurrentUpdateConflict['currentVersion']>
+>;
+
+/* -------------------------------------------------------------------------- */
+/* Runtime                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function Harness() {
+  const inline = useInlineEdit()!;
+  return (
+    <>
+      <button onClick={() => inline.enter('status')}>edit-enter</button>
+      <button onClick={() => inline.setField('status', 'active')}>edit-status</button>
+    </>
+  );
+}
+
+describe('buildConflict reads the narrowed payload off a name-only 409', () => {
+  // CONTROL (passes both ways) — pins the SHAPE of the two reads end-to-end, on
+  // the `name` limb specifically: the sibling test in `InlineEditSaveBar.test`
+  // covers the `code` limb, so until now nothing proved a code-less error
+  // reaches `buildConflict` at all. If a future narrowing stops covering
+  // `currentRecord` / `currentVersion` and someone "resolves" the red build by
+  // deleting the read instead of fixing the type, this goes red.
+  it('carries currentRecord and currentVersion through to the dialog', async () => {
+    const update = vi.fn().mockRejectedValue({
+      name: 'ConcurrentUpdateError',
+      message: 'record changed underneath',
+      currentVersion: '2026-08-26 10:30:00.000',
+      currentRecord: { status: 'taken' },
+    });
+
+    render(
+      <InlineEditProvider canEdit>
+        <Harness />
+        <InlineEditSaveBar
+          dataSource={{ update }}
+          objectName="proj"
+          recordId="p1"
+          data={{ updated_at: 'v1' }}
+          refresh={vi.fn()}
+        />
+      </InlineEditProvider>,
+    );
+
+    fireEvent.click(screen.getByText('edit-enter'));
+    fireEvent.click(screen.getByText('edit-status'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    const dialog = await screen.findByRole('alertdialog');
+
+    // `currentRecord` was read: the single-field draft renders the racer's
+    // value for that field as the "current value" half of the diff.
+    expect(dialog.textContent).toContain('taken');
+    // ...against the user's pending edit, so the assertion above is a real
+    // read of the server record and not an echo of the draft.
+    expect(dialog.textContent).toContain('active');
+    // `currentVersion` was read: with no `updated_at` on the racer record the
+    // dialog falls back to it for the audit line. Asserted on the year rather
+    // than the formatted string, which is locale-dependent.
+    expect(dialog.textContent).toMatch(/2026/);
+  });
+
+  // CONTROL (passes both ways) — the witness above really is code-less, so the
+  // pins describe the limb they claim to. Without this, a runtime that quietly
+  // stopped accepting name-only errors would make the block above a statement
+  // about an unreachable branch.
+  it('the witness is accepted by the predicate and carries no `code`', () => {
+    const nameOnly = {
+      name: 'ConcurrentUpdateError',
+      message: 'record changed underneath',
+      currentVersion: '2026-08-26 10:30:00.000',
+      currentRecord: { status: 'taken' },
+    };
+    expect(isConcurrentUpdateError(nameOnly)).toBe(true);
+    expect((nameOnly as { code?: unknown }).code).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #6477

`InlineEditSaveBar` narrows correctly at the call site — `if (isConcurrentUpdateError(err) && canAtomic)` — and then handed the narrowed value to a callback typed `err: any`, which discards it. The predicate's return type was inert at its only in-repo consumer, one line after the boundary was drawn.

## Step 0: the premise is live

The card was blocked behind #6421, whose PR #6474 landed on this very predicate, so the first question was whether that merge had already fixed the dependant. It had not. On `origin/main` at `12402a9b8`:

```
packages/plugin-detail/src/InlineEditSaveBar.tsx:125
    (draft: Record<string, any>, err: any): ConcurrentUpdateConflict => {
packages/plugin-detail/src/InlineEditSaveBar.tsx:127
      const current = (err?.currentRecord ?? null) as Record<string, unknown> | null;
```

## The question was decided by measurement, not preference

Both answers were authorised: take the narrowed type, or keep the `any` and write down what forces it. `buildConflict` reads **exactly two** things off `err`, and the narrowed type declares both, at types `ConcurrentUpdateConflict` accepts unchanged:

| read | narrowed type declares | conflict payload wants | covered |
|---|---|---|---|
| `err?.currentRecord` | `currentRecord?: Record<string, unknown> \| null` | `currentRecord?: Record<string, unknown> \| null` | yes |
| `err?.currentVersion` | `currentVersion?: string` | `currentVersion?: string` | yes |

Nothing forced the `any`, so **option one** was selected. As the card predicted, the `as Record<string, unknown> | null` cast then becomes redundant and is deleted — the two shapes agree, so there was no finding to report on that front. `exactOptionalPropertyTypes` is off repo-wide, so `string | undefined` flowing into `currentVersion?: string` needs no ceremony.

The type is **derived from the predicate rather than restated**:

```ts
type NarrowedBy<F> = F extends (arg: unknown) => arg is infer N ? N : never;
type ConcurrentUpdateErrorShape = NarrowedBy<typeof isConcurrentUpdateError>;
```

A hand-copied literal shape would be a second declaration free to drift from the predicate — precisely the disagreement this card exists to rule out. Derived, the compiler re-checks every read against whatever the predicate currently promises.

## `isConcurrentUpdateError` is untouched

PR #6474 deliberately made that narrowed type honest (`code?: 'CONCURRENT_UPDATE'`, optional because the `name` limb carries no `code`). Nothing here widens or otherwise edits it — this PR only changes a module-local `React.useCallback` parameter.

**The published surface is unchanged, and that is measured rather than asserted.** Building the package before and after and comparing all 52 emitted `.js` / `.cjs` / `.d.ts` artefacts leaves 51 byte-identical, including `dist/index.js`, `dist/index.umd.cjs` and `dist/index.d.ts`. The one delta is `dist/InlineEditSaveBar.d.ts`, which gains the `BuildConflict` type the pin test reads. The package's `exports` map declares only `"."` (no wildcard subpaths), so that file is unresolvable by any consumer, and `src/index.tsx` lists published names explicitly and does not re-export it — `grep -c BuildConflict dist/index.d.ts` is `0`. Hence the changeset with **empty frontmatter**: this releases nothing.

## The pins can fail — shown, not claimed

"Type-check is green" is not coverage, so both failure modes were ablated. Each mutation was confirmed on disk before measuring, and each restore confirmed byte-identical to `HEAD` via `git hash-object`.

**Ablation A — the parameter goes back to `any`.** Mutating the declared error parameter to `any`:

```
src/__tests__/InlineEditSaveBar.buildConflictNarrowed-6477.test.tsx(98,33): error TS2344: Type 'false' does not satisfy the constraint 'true'.
src/__tests__/InlineEditSaveBar.buildConflictNarrowed-6477.test.tsx(105,42): error TS2344: Type 'false' does not satisfy the constraint 'true'.
Exit status 2
```

Those are `_ErrParamIsNotAny` and `_ErrParamIsTheNarrowedType`, the two DISAGREES pins.

**Ablation B — the narrowed type stops covering a read.** Deleting `currentVersion?: string` from the predicate's narrowed type turns the **source itself** red:

```
src/InlineEditSaveBar.tsx(171,32): error TS2339: Property 'currentVersion' does not exist on type '{ code?: "CONCURRENT_UPDATE" | undefined; currentRecord?: ... }'.
src/InlineEditSaveBar.tsx(183,30): error TS2339: Property 'currentVersion' does not exist on type '{ code?: "CONCURRENT_UPDATE" | undefined; currentRecord?: ... }'.
Exit status 2
```

Under `err: any` both reads compiled silently and would have been `undefined` at runtime. That contrast is the whole point of the card.

The pin file is really in the compiler's program — `tsc -p tsconfig.test.json --listFiles` lists both it and `src/InlineEditSaveBar.tsx` (as source, not via a built `.d.ts`), so "type-check is clean" is a statement about these assertions and not a vacuous pass.

**Known residual, stated rather than papered over:** the compile-time pins bite on the exported `BuildConflict` type, which the component applies via `React.useCallback<BuildConflict>`. A revert that deleted the generic *and* re-annotated the lambda `err: any` would leave `BuildConflict` correct but unused and this file green. Nothing reachable from a test can observe a callback local to a component body; the runtime block covers that flank by driving the real component through a real 409.

The runtime half also closes a genuine gap: the existing suite covers the `code` limb only, so nothing previously proved a **code-less** (`name`-limb) error reaches `buildConflict` at all. The new test asserts both reads arrive in the dialog — the racer's value from `currentRecord`, and `currentVersion` in the audit line.

## Gates, each quoting its own verdict, on `a31b806b0`

| gate | verdict |
|---|---|
| `pnpm --filter @object-ui/plugin-detail type-check` | `command-exit 0` (both `tsc --noEmit` and `tsc -p tsconfig.test.json`) |
| `vitest run` — 4 affected files, on `a31b806b0` | `command-exit 0` · `Test Files 4 passed (4)` · `Tests 17 passed (17)` |
| `vitest run packages/plugin-detail/` — whole package, on `14bf45c12` | `command-exit 0` · `Test Files 111 passed (111)` · `Tests 1036 passed (1036)` |
| `pnpm --filter @object-ui/plugin-detail lint` | `command-exit 0` — 0 errors, 861 warnings (pre-existing baseline) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "Every one of them has an EMPTY frontmatter — declared as releasing nothing" |
| `node scripts/check-changeset-fixed.mjs` | exit 0 — "All workspace packages are in the changeset fixed group" |
| `node scripts/check-changeset-no-major.mjs` | exit 0 — "No changeset declares a `major` bump" |
| `node scripts/check-control-bytes.mjs` | exit 0 — "OK (scanned 5436 tracked text file(s))" |
| `node scripts/check-vi-mock-specifiers.mjs` | exit 0 |
| `node scripts/check-lint-coverage.mjs` | exit 0 — "46/46 packages linted, 0 with outstanding errors" |
| `node scripts/check-type-check-coverage.mjs` | exit 0 — "45/46 via `type-check`" · "41/41 packages compile their tests" |
| `node scripts/check-readme-exports.mjs` | **not measured locally** — needs a full-repo `pnpm build`; all 297 unjudged self-imports are unbuilt sibling packages ("type entry not on disk"), `plugin-detail` and `BuildConflict` appear 0 times. CI builds everything. |

The whole-package vitest run is cited against `14bf45c12`; the only later commit adds `.changeset/*.md`, which no test reads. The narrowed 4-file run above was re-run on the final head.

**Declared narrowing:** repo-wide `eslint .` is CI's run. Locally the affected package was linted with its own `lint` script — the same command `turbo run lint` invokes for it. Population comes from eslint's own config, not a guess: `--format json` reports **164 files** linted, 0 errors. The verdict for untouched files cannot move, because type-aware linting is not configured (no `project` / `projectService` in `eslint.config.js`), so no file outside the diff can change judgement.

Measured side effect worth recording: this deletes one `@typescript-eslint/no-explicit-any` warning from `InlineEditSaveBar.tsx` (8 → 7 on the same file, measured both ways), which is exactly the `err: any` the card names.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_