### PR TITLE
fix(app-shell): converge the third ActionParamDialog consumer on the field-preserving close

### DIFF
--- a/.changeset/6473-metadatatypeactions-param-dialog-close.md
+++ b/.changeset/6473-metadatatypeactions-param-dialog-close.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/app-shell': patch
+---
+
+The metadata-admin type-action param dialog no longer blanks itself while it closes
+(objectui#6473).
+
+`MetadataTypeActions` is the **third** consumer of `ActionParamDialog` in this package,
+after `useConsoleActionRuntime` and `RecordDetailView` — and it was the last one still
+writing `setParamState({ open: false, params: [] })` on close, replacing the whole state
+object. `DialogContent` carries `duration-200 data-[state=closed]:animate-out`, so Radix
+holds the content mounted through its exit animation and the dialog goes on rendering off
+`state` for the whole fade-out: a user who cancelled "Test connection" or a datasource
+sync watched the heading revert from the action's own label to the generic
+`actionDialog.title` and every param row disappear, for 200ms, on the way out. Close now
+flips `open` and keeps every other field, which is the shape objectui#6431 converged the
+other two consumers on.
+
+Not a user-data change: the values typed into the dialog never lived in `paramState` —
+they live in `ActionParamDialog`'s own `values`, reseeded from the param defaults on every
+open — so a reopen still starts from the defaults, pinned as a control.
+
+The pre-reset `paramState.resolve?.(null)` is dropped as well, on an enumeration rather
+than on "resolving twice is a no-op": `onOpenChange` is reachable from exactly three places,
+all inside `ActionParamDialog`, and every one settles the promise before asking for the
+close — `handleSubmit`, `handleCancel`, and the Radix root handler that delegates to
+`handleCancel` (the single route Escape, an overlay click and the header close button all
+take). All four routes are driven in the new test, with a census over
+`ActionParamDialog.tsx` so a later call site that skipped the settle is red there instead
+of leaving a promise pending forever.

--- a/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.paramDialogClose-6473.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.paramDialogClose-6473.test.tsx
@@ -1,0 +1,457 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `MetadataTypeActions` is the THIRD `ActionParamDialog` consumer in app-shell
+ * — pin that its close no longer blanks the dialog mid-fade (objectui#6473).
+ *
+ * The other two (`hooks/useConsoleActionRuntime.tsx` and
+ * `views/RecordDetailView.tsx`) converged on a field-preserving close in
+ * objectui#6431 and are pinned in
+ * `views/RecordDetailView.paramRuntimeParity-6431.test.tsx`. This file was
+ * neither in that card's premise nor its file face, and stayed on
+ * `setParamState({ open: false, params: [] })` — replacing the whole object,
+ * dropping `title` / `resolve` and emptying `params`.
+ *
+ * ## Why the first `describe` asserts on the DOM, not on the state object
+ *
+ * The claim that matters is about pixels during a 200ms window, not about which
+ * object a setter wrote. `DialogContent` carries `duration-200
+ * data-[state=closed]:animate-out`, so Radix holds the content mounted through
+ * the exit animation and `ActionParamDialog` goes on rendering off `state` for
+ * the whole fade-out. A test that only checked the end state — that the dialog
+ * eventually unmounts — is green under BOTH shapes and is not coverage.
+ *
+ * happy-dom has no CSS engine, so `getComputedStyle(node).animationName` is
+ * always `'none'` and Radix's `Presence` unmounts the content synchronously —
+ * the exit window does not exist unless it is modelled. `animationName` is
+ * therefore derived from the node's own live `data-state`, which is exactly what
+ * the two shipped classes do. `Presence` compares the name captured at mount
+ * against the one read at close and suspends the unmount only when they DIFFER,
+ * which is why a constant stub does not work and `data-state` is the only
+ * faithful source. The model's premise is read off the shipped `DialogContent`
+ * rather than assumed, by the first test below.
+ *
+ * ## What this site can and cannot lose (a correction to the card)
+ *
+ * The card and the dispatch both say "title, description and param rows".
+ * `title` and `params` are real here — `run()` opens with `action.label ??
+ * action.name`. `description` is NOT: this consumer never puts one in
+ * `paramState`, so the dialog falls back to the generic
+ * `actionDialog.description` under both shapes. The assertions below therefore
+ * pin `title` and the param rows, and the state-shape test states the missing
+ * `description` explicitly rather than letting a reader infer parity that is
+ * not there.
+ *
+ * ## The `resolve?.(null)` sub-decision, and why it is a test rather than a note
+ *
+ * The old close settled the promise itself (`paramState.resolve?.(null)`) before
+ * resetting. That line is gone, and the licence for dropping it is an
+ * ENUMERATION of every path into this callback — not "resolving twice is a
+ * no-op", which is true of promises and beside the point. `onOpenChange` is
+ * called from exactly three places, all inside `ActionParamDialog`:
+ *
+ *   1. `handleSubmit`  — `state.resolve?.(serializeParamValues(...))` first.
+ *   2. `handleCancel`  — `state.resolve?.(null)` first.
+ *   3. the Radix root's own `onOpenChange`, which delegates to `handleCancel`
+ *      and is the single route taken by Escape, an overlay/outside click, and
+ *      the header's X close button.
+ *
+ * The second `describe` drives every one of those routes through the real
+ * component and asserts the settle precedes the callback, plus a census over
+ * `ActionParamDialog.tsx` so a fourth, unsettled call site added later is red
+ * here instead of leaving a promise pending forever.
+ */
+
+import * as React from 'react';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, cleanup, fireEvent } from '@testing-library/react';
+
+vi.mock('@object-ui/auth', () => ({
+  createAuthenticatedFetch: () => vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => ({ success: true, data: { message: 'done' } }),
+  })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(), error: vi.fn(), info: vi.fn(),
+    warning: vi.fn(), loading: vi.fn(), dismiss: vi.fn(),
+  }),
+}));
+
+vi.mock('../ActionResultDialog', () => ({ ActionResultDialog: () => null }));
+
+/**
+ * The assertion seam. It WRAPS the real `ActionParamDialog` rather than
+ * replacing it, so the DOM half renders the genuine dialog (and the genuine
+ * Radix presence machinery) while the state half still sees every object the
+ * component hands it. A stub would pin this test's idea of the dialog instead
+ * of the dialog.
+ */
+let dialogStates: any[] = [];
+vi.mock('../ActionParamDialog', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../ActionParamDialog')>();
+  return {
+    ...actual,
+    ActionParamDialog: (props: any) => {
+      dialogStates.push(props.state);
+      return React.createElement(actual.ActionParamDialog as any, props);
+    },
+  };
+});
+
+import { MetadataTypeActions } from './MetadataTypeActions';
+
+/**
+ * A MULTI-FIELD fixture with a non-generic title, deliberately: with a single
+ * param and no title the blanking and the preserving shapes produce nearly the
+ * same render and the assertions below would pass without measuring anything.
+ * The non-degeneracy guard at the bottom applies that requirement to THIS
+ * fixture.
+ */
+const PARAMS = [
+  { name: 'reason', label: 'Reason', type: 'text', required: true },
+  { name: 'region', label: 'Region', type: 'text', defaultValue: 'us-east' },
+] as unknown[];
+
+const ACTION = {
+  name: 'sync',
+  label: 'Sync datasource',
+  type: 'api',
+  target: '/api/v1/datasources/${ctx.recordId}/sync',
+  locations: ['record_header'],
+  params: PARAMS,
+};
+
+function renderActions(params: unknown[] = PARAMS) {
+  return render(
+    <MetadataTypeActions
+      location="record_header"
+      recordId="ds1"
+      entry={{ actions: [{ ...ACTION, params }] as never }}
+    />,
+  );
+}
+
+/**
+ * Model the missing CSS engine on the two classes the real `DialogContent`
+ * carries, so `Presence` suspends the unmount the way it does in a browser.
+ * Deriving the name from the node's live `data-state` is what makes the
+ * mount-time and close-time reads DIFFER, which is the condition `Presence`
+ * actually tests.
+ */
+function modelExitAnimation() {
+  const real = window.getComputedStyle.bind(window);
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(((node: any, pe?: any) => {
+    const styles = real(node, pe);
+    return new Proxy(styles, {
+      get(target, prop) {
+        if (prop === 'animationName') {
+          const state = node?.getAttribute?.('data-state');
+          if (state === 'open') return 'os-enter';
+          if (state === 'closed') return 'os-exit';
+          return 'none';
+        }
+        const value = (target as any)[prop];
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as any;
+  }) as any);
+}
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The dialog's own chrome is labelled through `useObjectTranslation`, and the
+ * light DOM setup mounts no i18n provider — so `t('actionDialog.cancel')`
+ * returns the raw KEY here and the plain string `'Cancel'` matches nothing.
+ * Matching case-insensitively on the distinguishing word hits both spellings,
+ * so these queries neither depend on nor forbid a provider. (`Close` on the
+ * header X is not translated through that hook at all: `CloseSrLabel` carries
+ * its own no-provider default.)
+ */
+const cancelButton = () => screen.getByRole('button', { name: /cancel/i });
+const confirmButton = () => screen.getByRole('button', { name: /confirm/i });
+const closeXButton = () => screen.getByRole('button', { name: /close/i });
+
+const dialogNode = () => document.querySelector('[role="dialog"]');
+const headingText = () => document.querySelector('[role="dialog"] h2')?.textContent ?? null;
+const paragraphTexts = () =>
+  [...document.querySelectorAll('[role="dialog"] p')].map((p) => p.textContent);
+const paramLabels = () =>
+  [...document.querySelectorAll('[role="dialog"] label')].map((l) => l.textContent);
+
+/**
+ * The generic heading and description the dialog falls back to when `state`
+ * carries no `title` / `description` — MEASURED off the real component rather
+ * than hard-coded, for the same reason as the button queries above: with no
+ * i18n provider these are raw keys, with one they are English sentences, and
+ * this file should be red on the close handler rather than on the test setup.
+ * Renders and tears down its own tree, so call it before rendering a subject.
+ */
+async function genericChrome() {
+  const { ActionParamDialog } = await import('../ActionParamDialog');
+  render(<ActionParamDialog state={{ open: true, params: [] } as any} onOpenChange={() => {}} />);
+  await screen.findByRole('dialog');
+  const measured = { title: headingText(), description: paragraphTexts()[0] ?? null };
+  cleanup();
+  expect(measured.title).toBeTruthy();
+  expect(measured.description).toBeTruthy();
+  return measured;
+}
+
+/** Open the dialog through the real button, and wait for the lazy widgets. */
+async function openDialog() {
+  fireEvent.click(screen.getByTitle('Sync datasource'));
+  await screen.findByLabelText(/Reason/);
+}
+
+/** Close it the way a user does — the real Cancel button inside the dialog. */
+async function cancelDialog() {
+  await act(async () => {
+    fireEvent.click(cancelButton());
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  cleanup();
+  dialogStates = [];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('MetadataTypeActions — what ActionParamDialog RENDERS while it fades out (objectui#6473)', () => {
+  it('the exit-animation window is real in production, not just modelled here', async () => {
+    // The premise the model rests on, read off the SHIPPED component rather
+    // than assumed. Without a non-zero exit animation there is no window in
+    // which the post-close `state` is visible and this whole card is moot.
+    const { Dialog, DialogContent } = await import('@object-ui/components');
+    render(
+      <Dialog open>
+        <DialogContent>content</DialogContent>
+      </Dialog>,
+    );
+    const classes = (await screen.findByRole('dialog')).className;
+    expect(classes).toContain('data-[state=closed]:animate-out');
+    expect(classes).toContain('duration-200');
+    // The enter side too — `Presence` suspends the unmount only when the
+    // mount-time and close-time animation names DIFFER, so a content node with
+    // only one of the two would never hold through the fade.
+    expect(classes).toContain('data-[state=open]:animate-in');
+  });
+
+  it('the closing dialog keeps the action title and every param row through the exit animation', async () => {
+    // THE regression pin. Red against the pre-fix handler
+    // (`setParamState({ open: false, params: [] })`): the heading reverts to the
+    // generic `actionDialog.title` and every label disappears while the dialog
+    // is still on screen.
+    modelExitAnimation();
+    renderActions();
+    await openDialog();
+    expect(headingText()).toBe('Sync datasource');
+    expect(paramLabels()).toEqual(['Reason*', 'Region']);
+
+    await cancelDialog();
+
+    // The exit window exists: content still mounted, Radix already in `closed`.
+    const node = dialogNode();
+    expect(node).toBeTruthy();
+    expect(node!.getAttribute('data-state')).toBe('closed');
+
+    // …and the close did not rewrite what it shows mid-fade.
+    expect(headingText()).toBe('Sync datasource');
+    expect(paramLabels()).toEqual(['Reason*', 'Region']);
+    expect(document.querySelectorAll('[role="dialog"] input').length).toBe(2);
+  });
+
+  it('the close flips `open` and keeps every field this site puts in the state', async () => {
+    // The state-object half, by NAME: a shape that drops keys is red on the key
+    // set, and a shape that empties `params` is red on the value even if the key
+    // survives. `description` is absent BY CONSTRUCTION here — this consumer
+    // never supplies one — so the dialog shows the generic description under
+    // both shapes and it is not part of what the fix recovers.
+    renderActions();
+    await openDialog();
+    const opened = [...dialogStates].reverse().find((s) => s?.open);
+    expect(opened).toBeTruthy();
+    expect(Object.keys(opened).sort()).toEqual(['open', 'params', 'resolve', 'title']);
+
+    const before = dialogStates.length;
+    await cancelDialog();
+    const closed = dialogStates[dialogStates.length - 1];
+    expect(dialogStates.length).toBeGreaterThan(before);
+
+    expect(closed.open).toBe(false);
+    expect(Object.keys(closed).sort()).toEqual(['open', 'params', 'resolve', 'title']);
+    expect(closed.title).toBe('Sync datasource');
+    expect(closed.params.map((p: any) => p.name)).toEqual(['reason', 'region']);
+    expect(typeof closed.resolve).toBe('function');
+    expect(closed).not.toHaveProperty('description');
+  });
+
+  it('the blanking shape is what this replaced: it empties and re-titles the fading dialog', async () => {
+    // The negative half of the measurement, kept executable. It drives the
+    // dialog DIRECTLY with the object the old close handler wrote, so it is
+    // green on either side of the fix by construction — it is the evidence for
+    // WHY the pin above targets the fields it does, and it fails the day
+    // `ActionParamDialog` stops reading one of them (at which point the pin
+    // above would be guarding nothing).
+    modelExitAnimation();
+    const generic = await genericChrome();
+    const { ActionParamDialog } = await import('../ActionParamDialog');
+    const opened = {
+      open: true,
+      params: PARAMS,
+      title: 'Sync datasource',
+      resolve: () => {},
+    } as any;
+    const { rerender } = render(<ActionParamDialog state={opened} onOpenChange={() => {}} />);
+    await screen.findByLabelText(/Reason/);
+
+    rerender(<ActionParamDialog state={{ open: false, params: [] } as any} onOpenChange={() => {}} />);
+    await act(async () => { await Promise.resolve(); });
+
+    expect(dialogNode()?.getAttribute('data-state')).toBe('closed');
+    expect(headingText()).not.toBe('Sync datasource');
+    expect(headingText()).toBe(generic.title);
+    expect(paramLabels()).toEqual([]);
+    expect(document.querySelectorAll('[role="dialog"] input').length).toBe(0);
+    // The generic description is what this site shows under BOTH shapes, so it
+    // is the one field the fix does not recover here.
+    expect(paragraphTexts()).toContain(generic.description);
+  });
+
+  it('CONTROL — reopening still starts from the param defaults, not the previous run', async () => {
+    // Must stay green. Preserving `params` on close must not accidentally make
+    // a reopen inherit what the user typed: those values never lived in
+    // `paramState`, they live in the dialog's own `values`, reseeded from the
+    // param defaults on every `state.open` false→true edge.
+    renderActions();
+    await openDialog();
+    const reason = () => screen.getByLabelText(/Reason/) as HTMLInputElement;
+    const region = () => screen.getByLabelText(/Region/) as HTMLInputElement;
+    expect(reason().value).toBe('');
+    expect(region().value).toBe('us-east');
+
+    fireEvent.change(reason(), { target: { value: 'typed-by-user' } });
+    fireEvent.change(region(), { target: { value: 'eu-west' } });
+    await act(async () => { await Promise.resolve(); });
+    expect(reason().value).toBe('typed-by-user');
+    expect(region().value).toBe('eu-west');
+
+    await cancelDialog();
+    await openDialog();
+
+    expect(reason().value).toBe('');
+    expect(region().value).toBe('us-east');
+  });
+
+  it('the fixture is multi-field and titled, so the two reset shapes are distinguishable here', async () => {
+    // Non-degeneracy guard. With no params and no title, "blanked" and
+    // "preserved" render the same dialog and every assertion above passes
+    // without measuring anything.
+    const generic = await genericChrome();
+    renderActions();
+    await openDialog();
+    const opened = [...dialogStates].reverse().find((s) => s?.open);
+    const blanked: any = { open: false, params: [] };
+    const preserved: any = { ...opened, open: false };
+
+    expect(Object.keys(blanked).sort()).not.toEqual(Object.keys(preserved).sort());
+    expect(blanked).not.toHaveProperty('title');
+    expect(blanked).not.toHaveProperty('resolve');
+    expect(blanked.params).toEqual([]);
+    expect(preserved.params.length).toBeGreaterThan(1);
+    expect(preserved.title).toBe('Sync datasource');
+    expect(preserved.title).not.toBe(generic.title);
+  });
+});
+
+describe('MetadataTypeActions — every path into onOpenChange(false) has already settled the promise (objectui#6473)', () => {
+  /**
+   * Drive one close route through the REAL dialog and return the interleaved
+   * order of `resolve` and `onOpenChange`. The old host-side
+   * `paramState.resolve?.(null)` was dropped on the strength of this order
+   * holding on every route.
+   */
+  async function orderFor(closeRoute: () => void) {
+    const order: string[] = [];
+    const { ActionParamDialog } = await import('../ActionParamDialog');
+    const state = {
+      open: true,
+      // No `required` here: the submit route must be able to complete without
+      // the required-field guard short-circuiting it before it settles.
+      params: [{ name: 'region', label: 'Region', type: 'text' }] as unknown[],
+      title: 'Sync datasource',
+      resolve: (v: unknown) => order.push(v === null ? 'resolve(null)' : 'resolve(values)'),
+    } as any;
+    render(
+      <ActionParamDialog
+        state={state}
+        onOpenChange={(open: boolean) => order.push(`onOpenChange(${open})`)}
+      />,
+    );
+    await screen.findByLabelText(/Region/);
+    await act(async () => {
+      closeRoute();
+      await Promise.resolve();
+    });
+    cleanup();
+    return order;
+  }
+
+  it('route 1/3 — handleSubmit (the Confirm button) settles with the values first', async () => {
+    expect(await orderFor(() => fireEvent.click(confirmButton())))
+      .toEqual(['resolve(values)', 'onOpenChange(false)']);
+  });
+
+  it('route 2/3 — handleCancel (the Cancel button) settles with null first', async () => {
+    expect(await orderFor(() => fireEvent.click(cancelButton())))
+      .toEqual(['resolve(null)', 'onOpenChange(false)']);
+  });
+
+  it('route 3/3a — the Radix root (Escape) delegates to handleCancel, so it settles first', async () => {
+    expect(await orderFor(() => fireEvent.keyDown(document, { key: 'Escape' })))
+      .toEqual(['resolve(null)', 'onOpenChange(false)']);
+  });
+
+  it('route 3/3b — the Radix root (the header X button) takes the same delegation', async () => {
+    expect(await orderFor(() => fireEvent.click(closeXButton())))
+      .toEqual(['resolve(null)', 'onOpenChange(false)']);
+  });
+
+  it('the routes above are ALL of them — census over ActionParamDialog.tsx', async () => {
+    // Non-degeneracy for the enumeration itself. Four driven routes prove
+    // nothing about a FIFTH that someone adds later without a settle, and the
+    // cost of one is a promise pending forever — strictly worse than the
+    // redundant settle that was removed. `ActionParamDialog.tsx` is read-only
+    // for this card; this reads it.
+    const source = readFileSync(path.resolve(THIS_DIR, '../ActionParamDialog.tsx'), 'utf8');
+
+    // (a) Direct calls of the host's prop: exactly two, both `false`, and each
+    //     preceded by the settle in the same handler.
+    const calls = [...source.matchAll(/onOpenChange\(/g)].map((m) => m.index as number);
+    expect(calls).toHaveLength(2);
+    expect(source.match(/onOpenChange\(false\)/g)).toHaveLength(2);
+    for (const idx of calls) {
+      expect(source.slice(Math.max(0, idx - 200), idx)).toContain('state.resolve?.(');
+    }
+
+    // (b) The Radix root's own handler: exactly one, and it delegates to
+    //     `handleCancel` rather than calling the host prop itself. This is the
+    //     route Escape, an overlay/outside click and the X button all take, so
+    //     the two driven above cover the third one's siblings.
+    const collapsed = source.replace(/\s+/g, '');
+    expect(collapsed.match(/onOpenChange=\{/g)).toHaveLength(1);
+    expect(collapsed).toContain('onOpenChange={(open)=>{if(!open)handleCancel();}}');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.tsx
+++ b/packages/app-shell/src/views/metadata-admin/MetadataTypeActions.tsx
@@ -237,13 +237,48 @@ export function MetadataTypeActions({ entry, location, recordId, onAfter }: Meta
         );
       })}
 
+      {/*
+        Close = flip `open` and KEEP every other field (objectui#6473), the
+        shape the other two `ActionParamDialog` consumers in this package
+        already carry: `hooks/useConsoleActionRuntime.tsx` and
+        `views/RecordDetailView.tsx` converged on it in objectui#6431. This was
+        the third consumer and the last one still blanking.
+
+        `DialogContent` carries `duration-200 data-[state=closed]:animate-out`,
+        so Radix holds the content mounted through its exit animation and the
+        dialog goes on rendering off `state` for the whole fade-out. The
+        `{ open: false, params: [] }` this replaced dropped `title` and emptied
+        `params`, so the closing dialog re-titled itself from the action's own
+        label to the generic `actionDialog.title` and dropped every param row
+        while it faded. `run()` opens with a real title (`action.label ??
+        action.name`), so this site does have something to lose. (`description`
+        is the one field of the sibling shape this site never supplies — it is
+        the generic string under both shapes here, so it is not what was lost.)
+
+        This is NOT the form deliberately dropping stale values: the user's
+        typed values never lived in `paramState`. They live in
+        `ActionParamDialog`'s own `values`, reseeded from the param defaults on
+        every `state.open` false-to-true edge, so a reopen starts from the
+        defaults under either shape.
+
+        The `paramState.resolve?.(null)` that used to run before the reset is
+        GONE rather than retained, and that is an enumeration, not an appeal to
+        "resolving twice is a no-op". This callback is reachable from exactly
+        three places, all inside `ActionParamDialog`, and every one settles the
+        promise BEFORE it asks for the close: `handleSubmit`
+        (`state.resolve?.(serializeParamValues(...))`), `handleCancel`
+        (`state.resolve?.(null)`), and the Radix root's own `onOpenChange`,
+        which delegates to `handleCancel` and is the route Escape, an
+        overlay/outside click and the header X button all take. No path arrives
+        here unsettled. `MetadataTypeActions.paramDialogClose-6473.test.tsx`
+        drives all four routes and asserts the settle precedes this callback, so
+        a future path that skipped it is red there rather than a pending promise
+        here.
+      */}
       <ActionParamDialog
         state={paramState}
         onOpenChange={(open) => {
-          if (!open) {
-            paramState.resolve?.(null);
-            setParamState({ open: false, params: [] });
-          }
+          if (!open) setParamState((s) => ({ ...s, open: false }));
         }}
       />
       <ActionResultDialog


### PR DESCRIPTION
Fixes #6473

`packages/app-shell/src/views/metadata-admin/MetadataTypeActions.tsx` is the **third** consumer of `ActionParamDialog` in this package, and after #6431 it was the only one still replacing the whole state object on close. Close now flips `open` and keeps every other field — the shape `hooks/useConsoleActionRuntime.tsx` and `views/RecordDetailView.tsx` already carry.

`DialogContent` carries `duration-200 data-[state=closed]:animate-out`, so Radix holds the content mounted through its exit animation and the dialog goes on rendering off `state` for the whole fade-out. Under `{ open: false, params: [] }` the closing dialog re-titled itself from the action's own label to the generic `actionDialog.title` and dropped every param row while it faded.

## Premise re-measured on `main` @ `12402a9b8`

The card's line numbers were exact for the target file and stale for one sibling — re-measured before the first edit:

| consumer | open | close | before this PR |
| :--- | :--- | :--- | :--- |
| `hooks/useConsoleActionRuntime.tsx` | `:264` | `:747-749` (card said `:748`) | field-preserving |
| `views/RecordDetailView.tsx` | `:562` | `:2541-2546` (card said `:2519` — now the `HighlightFieldsProvider` close tag) | field-preserving |
| `views/metadata-admin/MetadataTypeActions.tsx` | `:115` | `:240-248` (card said `:245`, the inner `setParamState`) | **replaced the whole state** |

`:97`, `:115` and `:245` were byte-exact as the card and the dispatch claimed.

**One correction to the order.** Acceptance says the closing dialog keeps its "title, description and param rows". `title` and `params` are real here — `run()` opens with `action.label ?? action.name`. `description` is not: this consumer never puts one in `paramState`, so the dialog shows the generic `actionDialog.description` under **both** shapes. It is not part of what the fix recovers, and the tests say so explicitly rather than letting a reader infer a parity that is not there.

## The `resolve?.(null)` sub-decision: **dropped**, on an enumeration

The old close settled the promise itself before resetting. That line is gone — not because "resolving twice is a no-op", but because every path into this callback already settles. `onOpenChange` is reachable from exactly three places, all inside `ActionParamDialog` (read-only for this card, unchanged):

1. `handleSubmit` — `state.resolve?.(serializeParamValues(...))`, then `onOpenChange(false)` (`ActionParamDialog.tsx:280-281`).
2. `handleCancel` — `state.resolve?.(null)`, then `onOpenChange(false)` (`:285-286`).
3. The Radix root's own `onOpenChange` (`:295-297`), which delegates to `handleCancel`. This is the single route taken by **Escape**, an **overlay/outside click**, and the **header X button** (`DialogContent` renders a `DialogPrimitive.Close`, which flips the root).

The host itself never calls the prop, and `setParamState` appears in only two places in the file (open at `:115`, close in the JSX). So no path arrives unsettled, and the removed line was a second settle on an already-settled promise — on the submit path it was also a `null` settle over a values settle, i.e. the wrong intent had it ever been load-bearing.

The enumeration is executable rather than asserted: the new test drives **all four** routes through the real component and asserts `resolve` precedes `onOpenChange(false)` in each, plus a census over `ActionParamDialog.tsx` (exactly two direct `onOpenChange(` calls, each preceded by a settle; exactly one `onOpenChange={` prop, delegating to `handleCancel`). A fifth call site added later without a settle is red there instead of leaving a promise pending forever.

## Test — `MetadataTypeActions.paramDialogClose-6473.test.tsx` (11 cases)

Modelled on `views/RecordDetailView.paramRuntimeParity-6431.test.tsx`: it **wraps** the real `ActionParamDialog` rather than stubbing it, so the DOM half renders the genuine Radix presence machinery while the state half still sees every object handed to it. happy-dom has no CSS engine, so `animationName` is derived from the node's live `data-state` — the condition `Presence` actually tests — and the model's premise is read off the shipped `DialogContent` rather than assumed.

- **The regression pin** drives the real button → real dialog → real Cancel and asserts on what is rendered *during* `data-state="closed"`. A test that only checked the end state is green under both shapes and is not coverage.
- **Control (must stay green):** a full close→reopen round trip through the component asserts the reopened dialog is back on the param defaults (`reason` blank, `region` back to `us-east`) after the user typed over both. Those values live in the dialog's own `values`, reseeded on every `state.open` false→true edge — preserving `params` on close must not make a reopen inherit the previous run.
- **Non-degeneracy:** the fixture is multi-field and titled, and the guard asserts the two reset shapes actually disagree on this fixture — otherwise the pins are decorative.
- Chrome strings (`Cancel` / `Confirm` / the generic title) are **measured**, not hard-coded: the light DOM setup mounts no i18n provider, so `t()` returns raw keys. The file is red on the close handler, never on the test setup.

### Ablation — shown able to fail

The fix was committed first, then the handler was reverted to the pre-fix shape in place. Mutation proved on disk before the run (`grep -c` on both the injected and the removed text: `injected=1 removed_remaining=0`, blob `8d6f21f9` → `291c0bc4`), restore proved after (blob back to `8d6f21f9`, `git diff HEAD` empty), with an `EXIT INT TERM` trap on absolute paths. No rebuild leg: `vitest.config.mts` aliases every `@object-ui/*` to the sibling package's `src/`, and the subject module is imported from source, so no `dist` is in the loop.

```
× the closing dialog keeps the action title and every param row through the exit animation
    AssertionError: expected 'actionDialog.title' to be 'Sync datasource'
× the close flips `open` and keeps every field this site puts in the state
    AssertionError: expected [ 'open', 'params' ] to deeply equal [ Array(4) ]
  Tests  2 failed | 9 passed (11)
```

Predicted direction and observed direction agree: the two shape pins go red; the control, the four settle-order routes, the census, the exit-window premise and the blanking-shape evidence stay green (none of them read the host handler).

## Gates — verdicts as each gate reported them, on the final commit `c3ec4a37c`

Every heavy command ran through the container's shared verify lock; the verdict quoted is the gate's own line, not a bare `$?`.

| gate | command | verdict |
| :--- | :--- | :--- |
| affected-package type-check | `pnpm --filter @object-ui/app-shell type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0` |
| type-check actually covers the new test | `tsc -p tsconfig.test.json --listFiles` | both changed files present (1 hit each) — not a vacuous green |
| affected-package lint | `pnpm --filter @object-ui/app-shell lint` (`eslint .`, whole package, no narrowing) | `✖ 2761 problems (0 errors, 2761 warnings)`, `VERDICT command-exit 0`. The new file's 15 warnings are all `@typescript-eslint/no-explicit-any`, the same rule and shape as its siblings; `lint.yml` sets no `--max-warnings` |
| tests | `pnpm exec vitest run <17 files> --maxWorkers=2` | `Test Files 17 passed (17)`, `Tests 175 passed (175)`, `VERDICT command-exit 0` |
| changeset presence | `node scripts/check-changeset-presence.mjs` | `✅ 2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| changeset fixed group / no-major / no-overwrite | the three `check-changeset-*.mjs` | `✅` each |
| control bytes | `node scripts/check-control-bytes.mjs` | `✅ OK (scanned 5436 tracked text file(s); skipped 85 binary)` |
| vi.mock specifiers | `node scripts/check-vi-mock-specifiers.mjs` | `✅ OK (… 724 relative specifier(s) resolved …)` — the new file adds four `vi.mock` calls |
| lint / type-check coverage | `check-lint-coverage.mjs`, `check-type-check-coverage.mjs` | `✅ 46/46`, `✅ 45/46 + 41/41 test projects` |

**Declared narrowing on the test run, and only there.** `pnpm exec vitest run packages/app-shell/` (558 files) was attempted and hit the container's ~10-minute foreground cap (`exit 143`) mid-run, so the run was narrowed to a **measured** radius rather than a guessed one: a transitive-importer closure over `packages/app-shell/src` seeded at the changed module (23 modules, 15 of them test files — the only tests that can observe a change to it), plus two declared extras that guard the shared dialog without importing the changed file (`RecordDetailView.paramRuntimeParity-6431.test.tsx`, `useConsoleActionRuntime.test.tsx`). 17 files, 175 tests, green. CI runs the full farm regardless.

**One gate not measured, stated as such:** `check-eager-closure-budget.mjs` exits 2 locally with *"No eager-closure report at `apps/console/dist/eager-closure.json`, so no chunk was weighed … this is a broken gauge"* — a missing prerequisite (it needs a console build), not a failure, and not implicated by this diff, which changes no source imports.

_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_


---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_