### PR TITLE
docs(plugin-gantt): state both reasons `GanttConfigRestated` keeps a member

### DIFF
--- a/.changeset/gantt-restated-keep-rationale.md
+++ b/.changeset/gantt-restated-keep-rationale.md
@@ -1,0 +1,13 @@
+---
+---
+
+Comment-only change in `@object-ui/plugin-gantt`: no published behaviour, no
+declaration and no type changes. `GanttConfigRestated`'s docblock in
+`ObjectGantt.tsx` said its members are kept for ONE reason — their JSDoc being
+the only prose in this repo for what the renderer does with each key. Measured
+on `main` that was false in two ways: four of the twelve members carry no JSDoc
+there (`parentField`, `baselineEndField`, `assigneeField`, `effortField`), and
+`ObjectGanttSchema` in `@object-ui/types` has documented all twelve since
+objectui#6472. The docblock now states both keep-reasons — the prose, and being
+an operand of `ObjectGantt.configPin.test.ts` — so the deletability test a
+reader applies to `parentField` arrives at "keep".

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -110,18 +110,42 @@ type GanttConfigEx = GanttConfig & GanttConfigRestated;
  * measured against the shipped `GanttConfig` on `main` (objectui#6471; the card
  * counted eleven before objectui#6051/#6472 landed part of the lift).
  *
- * Ten are RESTATEMENTS: `GanttConfig` already declares them (nine of the ten
- * arrive from the spec's `GanttConfigSchema`, which declares 19 keys), and the
- * type written here is mutually assignable with the twin. They are kept, not
- * deleted, for ONE reason — their JSDoc is the only prose in this repo describing
- * what this renderer DOES with each key. The spec emits no per-member docs
- * (`z.input<typeof GanttConfigSchema>` carries none), so deleting the members
- * deletes the documentation, and JSDoc cannot be attached to a member a type
- * merely inherits.
+ * All twelve RESTATE a key `GanttConfig` already declares — eleven arrive from
+ * the spec's `GanttConfigSchema` (19 keys), `timeSegments` is objectui's own —
+ * and every one is mutually assignable with its twin. That includes
+ * `quickFilters` and `timeSegments`, which objectui#6471 called load-bearing
+ * NARROWINGS: measured on `main` they narrow nothing. What those two still do is
+ * NAME this plugin's runtime types (`QuickFilterDef[]` /
+ * {@link ShiftSegmentsConfig}), so a spec bump that moves either side surfaces as
+ * a decision. `ObjectGantt.configPin.test.ts` holds that measurement — read it
+ * there rather than re-deriving it here.
  *
- * Two are NARROWINGS and load-bearing: `quickFilters` and `timeSegments` pin the
- * plugin's own runtime types (`QuickFilterDef[]` / {@link ShiftSegmentsConfig}),
- * which is precision the intersection would otherwise lose.
+ * ## Why a member is kept rather than deleted — TWO reasons, either sufficient
+ *
+ * 1. PROSE, where there is any. The spec emits no per-member docs
+ *    (`z.input<typeof GanttConfigSchema>` carries none) and JSDoc cannot be
+ *    attached to a member a type merely inherits, so for most members the
+ *    docblock below is the fullest description of what this renderer DOES with
+ *    the key. It does NOT reach every member: four are bare here —
+ *    `parentField`, `baselineEndField`, `assigneeField`, `effortField` — the last
+ *    three covered by a neighbour's docblock, `parentField` by nothing. Nor is
+ *    this prose unique any more: since objectui#6472 the flattened face
+ *    (`ObjectGanttSchema` in `@object-ui/types`) documents all twelve, and
+ *    objectui#6561 expanded `parentField`'s entry there.
+ *
+ * 2. PIN OPERAND — this reason reaches EVERY member, and for `parentField` it is
+ *    the only one. The pin below is derived over `keyof GanttConfigRestated`: a
+ *    member that exists is compared against its twin, and a member that is
+ *    deleted simply stops being compared.
+ *
+ * ⛔ So the test for whether a member may be deleted is NOT "does it carry its
+ * own JSDoc". Applied to `parentField` that test answers "deletable", and it is
+ * wrong. Deleting `parentField` is not silent — it fails three assertions in
+ * `ObjectGantt.configPin.test.ts`: the `RESTATED` census, the non-vacuity control
+ * that names it, and the fixture. But all three fail INSIDE the pin, which is the
+ * file a reader edits to turn a red build green; follow those errors and the tree
+ * goes green with one member fewer under the pin. Delete a member here only when
+ * its twin on `GanttConfig` goes with it.
  *
  * ⚠️ NAMED rather than inlined into the intersection above, and that is the
  * whole mechanism: inside `GanttConfigEx` there is nothing left to compare,
@@ -129,7 +153,7 @@ type GanttConfigEx = GanttConfig & GanttConfigRestated;
  * therefore assignable to `GanttConfig[K]` by construction — an assertion written
  * against `GanttConfigEx` passes no matter how far the two declarations drift.
  * Naming the local half is what gives `ObjectGantt.configPin.test.ts` two
- * independent operands, so a spec bump that re-types one of the ten breaks the
+ * independent operands, so a spec bump that re-types one of the twelve breaks the
  * build at the pin instead of silently intersecting the old type back in.
  */
 export type GanttConfigRestated = {


### PR DESCRIPTION
Fixes #6563

Comment-only. No declaration, type, or behaviour changed — `GanttConfigRestated`
still has exactly the same twelve members, and the diff is the docblock above it
plus an empty-frontmatter changeset.

## Step 1 — the pin claim, verified by ablation rather than by reading

The card asked for this to be checked before anything else, and it **holds**.
`parentField` is a pin operand of `ObjectGantt.configPin.test.ts` three separate
ways. Measured by deleting the member and compiling — the mutation was confirmed
on disk first (anchored `grep -c` 1 → 0, blob hash `e39b5b07` → `99259398`), and
the tree was restored afterwards and proven byte-identical to `HEAD`
(`git diff HEAD` empty, hash back to `e39b5b07`).

`tsc -p tsconfig.test.json` went from exit 0 to **exit 2**:

```
src/ObjectGantt.configPin.test.ts(125,11): error TS2322: Type 'true' is not assignable to type '"parentField"'.
src/ObjectGantt.configPin.test.ts(149,11): error TS2322: Type 'true' is not assignable to type 'never'.
src/ObjectGantt.configPin.test.ts(202,7): error TS2353: Object literal may only specify known properties, and 'parentField' does not exist in type 'GanttConfigRestated'.
```

Line 125 is the `RESTATED` census (`StaleCensusEntry`), line 149 is the pin's own
non-vacuity control #4 — which names the literal `'parentField'` — and line 202 is
the `cfg` fixture. `parentField` is additionally a derived operand of `Diverged`,
which maps over `keyof GanttConfigRestated`.

**One correction to the card**: deleting `parentField` is *not* silent. It breaks
the build in three places, one of which names the key. The defect is still real,
but its shape is different and the docblock now says so — all three failures land
**inside the pin test**, which is the file a reader edits to turn a red build
green, and which advertises itself as a self-maintaining census. Follow those
three errors (drop the census entry, re-point the control at another key, drop the
fixture line) and you get a green tree with one member fewer under the pin.

## Step 1 — the per-member JSDoc census

Re-measured on `6a7893d57`, not the card's `0235ce7c1`. Mechanical, by checking
whether the line above each member ends a JSDoc block:

| member | own JSDoc here | prose on the flat face |
|---|---|---|
| `parentField` | **NO** | yes (block) |
| `typeField` | yes (block) | yes (1-line) |
| `baselineStartField` | yes (1-line) | yes (1-line) |
| `baselineEndField` | **NO** — neighbour's | yes (1-line) |
| `groupByField` | yes (block) | yes (1-line) |
| `resourceView` | yes (block) | yes (1-line) |
| `assigneeField` | **NO** — in `resourceView`'s | yes (1-line) |
| `effortField` | **NO** — in `resourceView`'s | yes (1-line) |
| `capacity` | yes (1-line) | yes (1-line) |
| `quickFilters` | yes (block) | yes (block) |
| `autoZoomToFilter` | yes (block) | yes (1-line) |
| `timeSegments` | yes (block) | yes (1-line) |

Four of twelve are bare here, exactly as the card measured. Three borrow a
neighbour's prose; `parentField` borrows nothing.

**Positive controls, because two columns contain a zero.** My first census script
was wrong — it only recognised multi-line blocks and so reported false zeros for
`baselineStartField` and `capacity`; the table above is from the corrected query.
For "bare here", the same query on the same type returns non-zero for the other 8
members. For "0 of the twelve lack flat-face prose", the same query over all 310
optional members of `objectql.ts` also returns 0, so that file could not serve as
its own control — instead the query was re-run against a scratchpad **copy** of
that same file with exactly one JSDoc line removed, and it reported exactly
`ObjectGanttSchema.typeField`. The repo copy was never mutated.

## Why the rationale was false, and more broadly than the card says

The docblock claimed the members are kept for `ONE reason — their JSDoc is the
only prose in this repo describing what this renderer DOES with each key`. That
is false in two independent ways, and the second one reaches **all twelve**:

1. Four members carry no JSDoc there at all.
2. `ObjectGanttSchema` in `@object-ui/types` documents **every one of the twelve**
   with renderer-behaviour prose, so the JSDoc here is not the only prose for any
   member.

The dispatch framed (2) as objectui#6561 having weakened the documentation half
for `parentField` specifically. The commit timeline says something stronger — the
claim was already false for all twelve on the day it was written:

| commit | when (2026-08-26) | what |
|---|---|---|
| `75bd83d6d` (objectui#6472) | 02:55 | declared the flat face with per-member JSDoc for all twelve |
| `64e32e6c0` (objectui#6546) | 10:24 | wrote the "ONE reason … only prose" docblock — 7.5h later |
| `f20dcf075` (objectui#6561) | 12:17 | expanded four of those pointers, `parentField` among them |

So objectui#6561 did not weaken the claim; it made an already-false claim more
visible on the one key that had no local prose to fall back on.

## Which shape was picked, and why

The card offered two. **Option 1 (reword so both reasons are stated as reasons)**,
because the measurement rules option 2 out rather than leaving it a preference:
giving `parentField` a one-liner would *not* make the stated rationale true as
written. "Their JSDoc is the only prose in this repo" stays false afterwards — the
flat face still documents all twelve — and `baselineEndField`, `assigneeField` and
`effortField` are still bare, so the ONE-reason test still misfires on three
members and on any bare member added later.

Deliberately **not** done: adding duplicate prose for `parentField` here. The
authoritative consumer-visible prose landed on `ObjectGanttSchema.parentField` in
objectui#6561, and a second copy in a package-private type is the fork that
`@object-ui/types`' own docblock says the objectui#6051 lift existed to prevent.
The docblock points at it instead.

## How the deletability test was checked, not asserted

The claim to check is that a reader applying the new test to `parentField` arrives
at "keep". The test the docblock now states is *"delete a member here only when
its twin on `GanttConfig` goes with it"*, with reason 2 given as reaching every
member. Applying it mechanically to `parentField`: its twin is
`GanttConfigSchema.parentField`, which is present in the spec's shipped
`view.zod-*.d.ts` (verified in `node_modules`, `parentField: z.ZodOptional<z.ZodString>`
among the 19 keys), so the twin has not gone → **keep**. The old test — "does this
member carry its own JSDoc" — returns "deletable" on the same input, which is the
answer the ablation above proves wrong. The two tests are stated adjacently in the
docblock precisely so the wrong one cannot be applied by accident, and
`parentField` is named as the worked example.

## Bounded in-place fix, declared

One correction beyond the card's literal subject, in the same docblock and the
same defect class (a stated keep-reason that measurement contradicts): the
neighbouring `Two are NARROWINGS and load-bearing … which is precision the
intersection would otherwise lose`. `ObjectGantt.configPin.test.ts` already
records the opposite as a measured fact — *"on current `main` they narrow
nothing"* — and its `both still name THIS plugin's runtime vocabulary` case pins
what those two members actually do. The correct form was therefore already
established by existing evidence rather than invented here. Leaving it would have
meant rewriting one paragraph to be accurate while the next asserted a keep-reason
this repo's own pin test disproves.

Also restated from measurement rather than carried forward: the origin count. The
old text said "nine of the ten arrive from the spec's `GanttConfigSchema`". Counted
against the shipped spec `.d.ts`, **eleven** of the twelve arrive from it and
`timeSegments` is objectui's own — the taxonomy had to be restated anyway once all
twelve are described as restatements.

## Files touched

| file | +/- |
|---|---|
| `packages/plugin-gantt/src/ObjectGantt.tsx` | +36 / -12 (comment lines only) |
| `.changeset/gantt-restated-keep-rationale.md` | +13 / -0 (new) |

## Gates — union run on the final commit `8ceafdfaa`, clean tree

Each exit code captured before any pipe; each verdict is the gate's own line.

| gate | exit | verdict |
|---|---|---|
| `pnpm --filter @object-ui/plugin-gantt run type-check` | 0 | echoed `tsc --noEmit && tsc -p tsconfig.test.json` (not a zero-match) |
| `vitest run packages/plugin-gantt/src/ObjectGantt.configPin.test.ts` | 0 | `Test Files 1 passed (1)` / `Tests 6 passed (6)` |
| `vitest run packages/plugin-gantt` (full suite) | 0 | `Test Files 50 passed (50)` / `Tests 420 passed (420)` |
| `check-changeset-presence.mjs` | 0 | `✅ … declares 1 changeset(s)` — empty frontmatter, "the explicit exemption and a complete answer to this gate" |
| `check-changeset-no-major.mjs` | 0 | `✅ No changeset declares a major bump.` |
| `check-changeset-fixed.mjs` | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `check-changeset-overwrite.mjs` | 0 | `✅ No pre-existing changeset was modified or deleted.` |
| `check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 5444 tracked text file(s))` |
| `check-doc-fence-languages.mjs` | 0 | `✅ check:doc-fences — every TypeScript block in 223 document(s) …` |
| `eslint .` in `packages/plugin-gantt` | 0 | 0 errors; edited file in the population at 0 errors |

Tests were run from the repo root, not `pnpm --filter <pkg> test` (objectui#3378).
Dependency closure was built first (`pnpm --filter '@object-ui/plugin-gantt^...' build`,
exit 0) because `tsconfig.test.json` sets `"paths": {}` and resolves `@object-ui/*`
through built `.d.ts`; `--listFiles` confirms `ObjectGantt.configPin.test.ts` and
`ObjectGantt.tsx` are both in that program and that 41 files resolve from
`packages/types/dist`.

**Lint narrowing, declared.** `eslint .` was run for the affected package rather
than repo-wide. Population comes from eslint's own config (80 files selected under
`packages/plugin-gantt`), the count from `--format json`, and the invariance
argument is that `eslint.config.js` declares no `projectService`/`parserOptions.project`,
so there is no cross-file type program a comment edit could move. The edited file
carries 85 pre-existing warnings, none of them line-count-sensitive
(`no-explicit-any` ×73 and react-hooks rules; no `max-len`/`max-lines`) and none
inside the edited range 108–158. An earlier run with `--no-inline-config` reported
2 errors in `demo/main.tsx`; that flag is objectstack's lint spelling, not
objectui's, and the package's real `lint` script exits 0.

## Note on the re-dispatch

The order described the branch as sitting at a stale base `6a7893d57`.
`origin/main` **is** `6a7893d57`, so the base was current, not stale;
`git log origin/main..origin/<branch>` was empty as required, and the branch was
re-cut from `origin/main` anyway. Nothing was discarded.

_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_