### PR TITLE
fix(react): memoise the scoped-style schema SchemaRenderer hands down

### DIFF
--- a/.changeset/6270-schemarenderer-scopeclass-memo.md
+++ b/.changeset/6270-schemarenderer-scopeclass-memo.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/react': patch
+---
+
+`SchemaRenderer` now hands a stable `schema` object identity to a node carrying
+`responsiveStyles` (objectui#6270).
+
+ADR-0065 scoped styles make a styled node take a branch that rebuilds the schema
+object to merge the generated scope class into `className`. That rebuild was not
+memoised, so it allocated a new object on **every** `SchemaRenderer` render — even
+when the `evaluatedSchema` memo directly above it held. Every downstream renderer
+that memoises on `[schema]` therefore saw a fresh identity and re-ran: concretely
+`ObjectMap`'s `dataConfig` and `mapConfig`, and the whole marker cascade below them
+(`markers` → `filteredMarkers` → `clusteredData` / `markerBounds` → `initialViewState`).
+Only nodes on that branch were affected — a plain node was already handed the
+memoised `evaluatedSchema` itself.
+
+The trigger is narrower than "has `responsiveStyles`" reads: it needs one of the four
+sized breakpoint keys (`large` / `medium` / `small` / `xsmall`). A `{ base: … }` shape
+never took the branch and was never affected.
+
+The scoped-style computation now lives in a `useMemo` keyed on
+`[evaluatedSchema, autoStyleId]`, hoisted above the renderer's early returns — its old
+use site sits after them, so a memo written there would have been a conditional hook.
+A genuinely changed `className`, interpolated value or breakpoint still produces a new
+identity, so nothing goes stale.

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -1098,6 +1098,71 @@ export const SchemaRenderer: ForwardRefExoticComponent<
     return newSchema;
   }, [schema, dataSource, predicateScope, pageVariables, boundRecord]);
 
+  /**
+   * SDUI scoped styling (ADR-0065): a node's `responsiveStyles` compiles to
+   * id-scoped CSS injected as a `<style>` tag, and a scope class is appended to
+   * the node's className.
+   *
+   * ## Why this is a memo, and why it is HERE and not at its use site
+   *
+   * The scope-class branch rebuilds the schema object (`{ ...evaluatedSchema,
+   * className: mergedClassName }`) so renderers that read `schema.className`
+   * see the scope class. Unmemoised, that spread allocated a NEW object on
+   * every render of this component — even when the `evaluatedSchema` memo
+   * directly above it HELD — so every downstream renderer that memoises on
+   * `[schema]` (e.g. `ObjectMap`'s `dataConfig` / `mapConfig`, and the whole
+   * marker cascade below them) saw a fresh identity and re-ran (objectui#6270).
+   * Only nodes taking this branch were affected: a plain node was handed
+   * `evaluatedSchema` itself and was already stable.
+   *
+   * It is hoisted ABOVE the early returns below because it is a HOOK. Its use
+   * site sits after `if (!evaluatedSchema) return null`, the `_hidden` return
+   * and the unresolved-component returns, so a `useMemo` written there is a
+   * CONDITIONAL hook: a node toggling hidden -> visible would call one more
+   * hook than the previous render and React would throw "Rendered more hooks
+   * than during the previous render". Hoisting is what makes the memo legal,
+   * not a stylistic preference.
+   *
+   * `[evaluatedSchema, autoStyleId]` is the complete dependency set: every
+   * value below is a pure function of the evaluated node (`className`, `id`,
+   * `responsiveStyles`) and the `useId` fallback. `evaluatedSchema` is itself a
+   * fresh object whenever anything it interpolates changes, so a genuinely
+   * changed className, value or breakpoint still produces a NEW identity here —
+   * memoising cannot make a live value go stale.
+   *
+   * Non-object / primitive nodes fall through untouched: the render pass below
+   * returns them as text before any of this is read.
+   */
+  const scopedStyling = useMemo(() => {
+    const node = evaluatedSchema;
+    if (!node || typeof node !== 'object') {
+      return { scopeClass: '', scopedCss: '', mergedClassName: undefined, schemaForComponent: node };
+    }
+    const responsiveStyles = (node as Record<string, unknown>).responsiveStyles;
+    if (!hasResponsiveStyles(responsiveStyles)) {
+      // No scope class: hand the component `evaluatedSchema` ITSELF, which the
+      // memo above already keeps stable. Never a copy — a copy here would
+      // reintroduce the same instability for every node in the tree.
+      return {
+        scopeClass: '',
+        scopedCss: '',
+        mergedClassName: node.className,
+        schemaForComponent: node,
+      };
+    }
+    const scopeClass = scopeClassFor(node.id ?? autoStyleId);
+    const mergedClassName = [node.className, scopeClass].filter(Boolean).join(' ');
+    return {
+      scopeClass,
+      scopedCss: compileScopedStyles(`.${scopeClass}`, responsiveStyles),
+      mergedClassName,
+      // Some renderers read `schema.className` directly (e.g. element:text)
+      // while others read the `className` prop (e.g. flex/container). Set both
+      // so the scope class lands regardless of which channel a renderer honours.
+      schemaForComponent: { ...node, className: mergedClassName },
+    };
+  }, [evaluatedSchema, autoStyleId]);
+
   if (!evaluatedSchema) return null;
   // If schema is just a string, render it as text
   if (typeof evaluatedSchema === 'string') return <>{evaluatedSchema}</>;
@@ -1237,21 +1302,9 @@ export const SchemaRenderer: ForwardRefExoticComponent<
     );
   }
 
-  // SDUI scoped styling (ADR-0065): a node's `responsiveStyles` compiles to
-  // id-scoped CSS injected as a <style> tag, and a scope class is appended to
-  // the node's className. Build-independent, collision-free, responsive-correct.
-  const hasScopedStyles = hasResponsiveStyles(_responsiveStyles);
-  const scopeClass = hasScopedStyles ? scopeClassFor(evaluatedSchema.id ?? autoStyleId) : '';
-  const scopedCss = hasScopedStyles ? compileScopedStyles(`.${scopeClass}`, _responsiveStyles) : '';
-  const mergedClassName = scopeClass
-    ? [evaluatedSchema.className, scopeClass].filter(Boolean).join(' ')
-    : evaluatedSchema.className;
-  // Some renderers read `schema.className` directly (e.g. element:text) while
-  // others read the `className` prop (e.g. flex/container). Set both so the
-  // scope class lands regardless of which channel a renderer honours.
-  const schemaForComponent = scopeClass
-    ? { ...evaluatedSchema, className: mergedClassName }
-    : evaluatedSchema;
+  // SDUI scoped styling (ADR-0065) — computed in the memo hoisted above the
+  // early returns; see the doc comment there for why it cannot live here.
+  const { scopeClass, scopedCss, mergedClassName, schemaForComponent } = scopedStyling;
 
   // Extract AriaPropsSchema properties for accessibility
   const ariaProps = resolveAriaProps(evaluatedSchema);

--- a/packages/react/src/__tests__/SchemaRenderer.scopedStyleSchemaIdentity.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.scopedStyleSchemaIdentity.test.tsx
@@ -35,7 +35,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { render, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React, { useState } from 'react';
 import { ComponentRegistry } from '@object-ui/core';
 import { SchemaRenderer } from '../SchemaRenderer';
@@ -92,22 +92,30 @@ const BASE_ONLY = {
   responsiveStyles: { base: { padding: '8px' } },
 };
 
-let bumpParent: () => void = () => {
-  throw new Error('harness not mounted');
-};
-
-/** A real parent re-render: parent state changes, every child re-renders,
- *  and every `schema` prop below keeps its identity. */
+/**
+ * A real parent re-render: parent state changes, every child re-renders, and
+ * every `schema` prop below keeps its identity.
+ *
+ * The re-render is driven by a real click rather than by a module-level `let`
+ * the component reassigns during render. That reassignment is itself a render
+ * side effect (`react-hooks/globals`) — in a file that measures render counts,
+ * it would be the measuring instrument breaking the rule under test.
+ */
 const Harness: React.FC = () => {
   const [, setTick] = useState(0);
-  bumpParent = () => setTick((n) => n + 1);
   return (
     <>
+      <button data-testid="bump-parent" onClick={() => setTick((n) => n + 1)} />
       <SchemaRenderer schema={PLAIN} />
       <SchemaRenderer schema={SCOPED} />
       <SchemaRenderer schema={BASE_ONLY} />
     </>
   );
+};
+
+/** One parent re-render. */
+const bumpParent = (): void => {
+  fireEvent.click(screen.getByTestId('bump-parent'));
 };
 
 describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
@@ -154,7 +162,7 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
   describe('identity is stable across a parent re-render', () => {
     it('plain node (control)', () => {
       render(<Harness />);
-      act(() => bumpParent());
+      bumpParent();
 
       expect(renderCount('plain')).toBeGreaterThanOrEqual(2);
       expect(distinctIdentities('plain')).toBe(1);
@@ -162,7 +170,7 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
 
     it('node with a `base`-only responsiveStyles shape (control)', () => {
       render(<Harness />);
-      act(() => bumpParent());
+      bumpParent();
 
       expect(renderCount('baseonly')).toBeGreaterThanOrEqual(2);
       expect(distinctIdentities('baseonly')).toBe(1);
@@ -170,7 +178,7 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
 
     it('node with a sized responsiveStyles breakpoint (the fix case)', () => {
       render(<Harness />);
-      act(() => bumpParent());
+      bumpParent();
 
       expect(renderCount('scoped')).toBeGreaterThanOrEqual(2);
       expect(distinctIdentities('scoped')).toBe(1);
@@ -178,9 +186,9 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
 
     it('holds across several parent re-renders, not just one', () => {
       render(<Harness />);
-      act(() => bumpParent());
-      act(() => bumpParent());
-      act(() => bumpParent());
+      bumpParent();
+      bumpParent();
+      bumpParent();
 
       expect(renderCount('scoped')).toBeGreaterThanOrEqual(4);
       expect(distinctIdentities('scoped')).toBe(1);
@@ -189,7 +197,7 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
 
     it('the scope class survives memoisation — a stable identity is still the RIGHT object', () => {
       render(<Harness />);
-      act(() => bumpParent());
+      bumpParent();
 
       const last = capturesFor('scoped')[renderCount('scoped') - 1];
       expect(last.schema.className).toContain('os-s-scoped');
@@ -198,6 +206,60 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
       // `responsiveStyles` reaches the renderer on the schema object (it is
       // stripped from the DOM props, not from the schema).
       expect(last.schema.responsiveStyles).toEqual({ large: { padding: '8px' } });
+    });
+  });
+
+  describe("the instability is bounded — a consumer's own setState does not re-key it", () => {
+    /**
+     * Pins the reason this finding is a redundant-recompute cost and NOT a
+     * refetch loop. A consuming renderer (`ObjectMap`) keys a fetch effect on
+     * a `[schema]`-derived memo and that effect calls `setData`. If the
+     * renderer's OWN state update re-ran `SchemaRenderer`, a fresh schema
+     * identity would re-key the effect, refetch, and set state again —
+     * unbounded.
+     *
+     * It does not: React re-renders only the subtree below the component that
+     * set state, so `SchemaRenderer` stays put and the consumer keeps the very
+     * object React last handed it. This test fixes that as a property of the
+     * renderer rather than a fact people re-derive from React semantics — it
+     * is GREEN on both sides of the fix by design (the fix changes parent-render
+     * behaviour, not this), and turns red only if something upstream starts
+     * re-rendering `SchemaRenderer` in response to a consumer's state.
+     */
+    it('a consumer re-rendering itself keeps the exact schema object it was handed', () => {
+      const selfUpdates: any[] = [];
+
+      const SelfUpdatingProbe: React.FC<any> = (props) => {
+        const [, setOwn] = useState(0);
+        selfUpdates.push(props.schema);
+        return <button data-testid="bump-self" onClick={() => setOwn((n) => n + 1)} />;
+      };
+
+      ComponentRegistry.register('self-updating-probe', SelfUpdatingProbe);
+      try {
+        render(
+          <SchemaRenderer
+            schema={{
+              type: 'self-updating-probe',
+              id: 'selfscoped',
+              responsiveStyles: { large: { padding: '8px' } },
+            }}
+          />
+        );
+
+        const handedOnce = selfUpdates.length;
+        fireEvent.click(screen.getByTestId('bump-self'));
+        fireEvent.click(screen.getByTestId('bump-self'));
+
+        // Positive control: the consumer really did re-render on its own state.
+        expect(selfUpdates.length).toBeGreaterThan(handedOnce);
+        // …and every one of those renders saw the SAME schema object.
+        expect(new Set(selfUpdates).size).toBe(1);
+        // The branch is genuinely taken here too — otherwise this pins nothing.
+        expect(selfUpdates[0].className).toContain('os-s-selfscoped');
+      } finally {
+        ComponentRegistry.unregister?.('self-updating-probe');
+      }
     });
   });
 
@@ -282,13 +344,11 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
         responsiveStyles: { large: { padding: '8px' } },
       };
 
-      let setTick: (v: any) => void = () => {
-        throw new Error('writer not mounted');
-      };
       const TickWriter: React.FC = () => {
         const { setVariable } = usePageVariables();
-        setTick = (v) => setVariable('tick', v);
-        return null;
+        return (
+          <button data-testid="set-tick" onClick={() => setVariable('tick', 'second')} />
+        );
       };
 
       render(
@@ -302,7 +362,7 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
 
       expect(capturesFor('reactive')[0].schema.content).toBe('first');
 
-      act(() => setTick('second'));
+      fireEvent.click(screen.getByTestId('set-tick'));
 
       const first = capturesFor('reactive')[0];
       const last = capturesFor('reactive')[renderCount('reactive') - 1];

--- a/packages/react/src/__tests__/SchemaRenderer.scopedStyleSchemaIdentity.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.scopedStyleSchemaIdentity.test.tsx
@@ -221,10 +221,11 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
      * It does not: React re-renders only the subtree below the component that
      * set state, so `SchemaRenderer` stays put and the consumer keeps the very
      * object React last handed it. This test fixes that as a property of the
-     * renderer rather than a fact people re-derive from React semantics — it
-     * is GREEN on both sides of the fix by design (the fix changes parent-render
-     * behaviour, not this), and turns red only if something upstream starts
-     * re-rendering `SchemaRenderer` in response to a consumer's state.
+     * renderer rather than a fact people re-derive from React semantics. It is
+     * green on both sides of the fix — the fix changes what a PARENT render
+     * hands down, and this measures renders no parent took part in — and turns
+     * red only if something upstream starts re-rendering `SchemaRenderer` in
+     * response to a consumer's own state.
      */
     it('a consumer re-rendering itself keeps the exact schema object it was handed', () => {
       const selfUpdates: any[] = [];
@@ -247,16 +248,31 @@ describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
           />
         );
 
-        const handedOnce = selfUpdates.length;
+        // Measured from the LAST render before the first click, not from mount.
+        //
+        // Mount is not a clean baseline: `SchemaRenderer` force-updates itself
+        // once after mounting (it re-checks `ComponentRegistry` for a lazily
+        // registered component), so mounting alone produces two SchemaRenderer
+        // renders — and before the fix those two already handed down two
+        // different schema objects. Counting from mount would fold that
+        // parent-render instability into this test and make it a second, worse
+        // copy of the fix-case test above instead of the independent property
+        // it is meant to pin. (Measured: this assertion goes red on the pre-fix
+        // tree when it starts at index 0, and stays green when it starts here.)
+        const mountRenders = selfUpdates.length;
+        const baseline = selfUpdates[mountRenders - 1];
+
         fireEvent.click(screen.getByTestId('bump-self'));
         fireEvent.click(screen.getByTestId('bump-self'));
 
         // Positive control: the consumer really did re-render on its own state.
-        expect(selfUpdates.length).toBeGreaterThan(handedOnce);
-        // …and every one of those renders saw the SAME schema object.
-        expect(new Set(selfUpdates).size).toBe(1);
+        expect(selfUpdates.length).toBeGreaterThan(mountRenders);
+        // The property: across the consumer's OWN re-renders, the schema object
+        // it holds never changes — SchemaRenderer did not re-run, so there was
+        // nothing to re-key. This is what makes the finding bounded.
+        expect(new Set(selfUpdates.slice(mountRenders - 1)).size).toBe(1);
         // The branch is genuinely taken here too — otherwise this pins nothing.
-        expect(selfUpdates[0].className).toContain('os-s-selfscoped');
+        expect(baseline.className).toContain('os-s-selfscoped');
       } finally {
         ComponentRegistry.unregister?.('self-updating-probe');
       }

--- a/packages/react/src/__tests__/SchemaRenderer.scopedStyleSchemaIdentity.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.scopedStyleSchemaIdentity.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Identity stability of the `schema` object `SchemaRenderer` hands down
+ * (objectui#6270).
+ *
+ * `SchemaRenderer` memoises `evaluatedSchema`, and downstream renderers key
+ * their own `useMemo`s on `[schema]` (e.g. `ObjectMap`'s `dataConfig` /
+ * `mapConfig`). A node carrying `responsiveStyles` (ADR-0065 scoped styles)
+ * takes a spread branch that merges the scope class into `schema.className` —
+ * and that spread used to run unmemoised, allocating a NEW object on every
+ * `SchemaRenderer` render even when the `evaluatedSchema` memo above it held.
+ * Every downstream `[schema]` memo therefore saw a fresh identity and re-ran.
+ *
+ * ## The reproduction trap this file exists to pin
+ *
+ * `hasResponsiveStyles` requires a `large` / `medium` / `small` / `xsmall`
+ * key. A `{ base: … }` shape does NOT take the branch — a fixture built on
+ * `base` measures "stable" no matter what the renderer does, and reads as
+ * evidence that the report was wrong. So `takes the scope-class branch` below
+ * runs FIRST and proves, from the delivered `schema.className`, which fixture
+ * is on which side of the branch. Every stability assertion after it is only
+ * meaningful because that one passed.
+ *
+ * ## Both directions are pinned
+ *
+ * Memoising an object that legitimately changes trades a re-render bug for a
+ * stale-render bug, so the `delivers a NEW identity` block pins the opposite
+ * direction: when `className`, an evaluated value, or the source schema really
+ * changes, the identity handed down MUST change with it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React, { useState } from 'react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer } from '../SchemaRenderer';
+import { PageVariablesProvider, usePageVariables } from '../hooks/usePageVariables';
+
+/** One capture per probe render: the exact `schema` object it was handed. */
+interface Capture {
+  schema: any;
+  classNameProp: unknown;
+}
+
+const captures = new Map<string, Capture[]>();
+
+/**
+ * The probe is registered in the real `ComponentRegistry` and reached through
+ * the real `SchemaRenderer` path — not a unit call to an internal helper. What
+ * it records is exactly what any downstream renderer would key a `[schema]`
+ * memo on.
+ */
+const IdentityProbe: React.FC<any> = (props) => {
+  const id = String(props.schema?.id ?? 'anon');
+  const list = captures.get(id) ?? [];
+  list.push({ schema: props.schema, classNameProp: props.className });
+  captures.set(id, list);
+  return <div data-testid={`probe-${id}`} />;
+};
+
+const capturesFor = (id: string): Capture[] => captures.get(id) ?? [];
+
+/** Number of times the probe for `id` rendered. Guards every "stable" claim:
+ *  an identity cannot be measured across a re-render that never happened. */
+const renderCount = (id: string): number => capturesFor(id).length;
+
+/** How many DISTINCT `schema` objects the probe for `id` was handed. */
+const distinctIdentities = (id: string): number =>
+  new Set(capturesFor(id).map((c) => c.schema)).size;
+
+// Module-level fixtures: a stable `schema` prop identity is the precondition
+// for the `evaluatedSchema` memo to hold, which is what makes this a test of
+// the spread branch rather than of the memo above it.
+const PLAIN = { type: 'identity-probe', id: 'plain', content: 'plain' };
+const SCOPED = {
+  type: 'identity-probe',
+  id: 'scoped',
+  content: 'scoped',
+  responsiveStyles: { large: { padding: '8px' } },
+};
+// The trap fixture: `base` is NOT one of the four sized keys, so this node
+// does not take the scope-class branch at all.
+const BASE_ONLY = {
+  type: 'identity-probe',
+  id: 'baseonly',
+  content: 'base-only',
+  responsiveStyles: { base: { padding: '8px' } },
+};
+
+let bumpParent: () => void = () => {
+  throw new Error('harness not mounted');
+};
+
+/** A real parent re-render: parent state changes, every child re-renders,
+ *  and every `schema` prop below keeps its identity. */
+const Harness: React.FC = () => {
+  const [, setTick] = useState(0);
+  bumpParent = () => setTick((n) => n + 1);
+  return (
+    <>
+      <SchemaRenderer schema={PLAIN} />
+      <SchemaRenderer schema={SCOPED} />
+      <SchemaRenderer schema={BASE_ONLY} />
+    </>
+  );
+};
+
+describe('SchemaRenderer scoped-style schema identity (objectui#6270)', () => {
+  // Registered ONCE, outside the per-test hooks: `register`/`unregister` call
+  // the registry's `notify()`, which force-updates every mounted
+  // `SchemaRenderer`. Doing that per-test fires it while the previous test's
+  // tree is still mounted, producing un-acted updates — noise that would sit
+  // on top of the very re-render counts this file measures.
+  beforeAll(() => {
+    ComponentRegistry.register('identity-probe', IdentityProbe);
+  });
+
+  afterAll(() => {
+    ComponentRegistry.unregister?.('identity-probe');
+  });
+
+  beforeEach(() => {
+    captures.clear();
+  });
+
+  afterEach(() => {
+    captures.clear();
+  });
+
+  describe('the fixtures are on the sides of the branch this file claims', () => {
+    it('only a sized-breakpoint node takes the scope-class branch', () => {
+      render(<Harness />);
+
+      // Positive control for the two zero/absent readings below, same query
+      // shape: the sized-breakpoint node DOES get a scope class, on both the
+      // `schema.className` channel and the `className` prop channel.
+      expect(capturesFor('scoped')[0].schema.className).toContain('os-s-scoped');
+      expect(String(capturesFor('scoped')[0].classNameProp)).toContain('os-s-scoped');
+
+      // The trap: `{ base: … }` is not one of the four sized keys.
+      expect(capturesFor('baseonly')[0].schema.className).toBeUndefined();
+      expect(capturesFor('baseonly')[0].classNameProp).toBeUndefined();
+
+      expect(capturesFor('plain')[0].schema.className).toBeUndefined();
+      expect(capturesFor('plain')[0].classNameProp).toBeUndefined();
+    });
+  });
+
+  describe('identity is stable across a parent re-render', () => {
+    it('plain node (control)', () => {
+      render(<Harness />);
+      act(() => bumpParent());
+
+      expect(renderCount('plain')).toBeGreaterThanOrEqual(2);
+      expect(distinctIdentities('plain')).toBe(1);
+    });
+
+    it('node with a `base`-only responsiveStyles shape (control)', () => {
+      render(<Harness />);
+      act(() => bumpParent());
+
+      expect(renderCount('baseonly')).toBeGreaterThanOrEqual(2);
+      expect(distinctIdentities('baseonly')).toBe(1);
+    });
+
+    it('node with a sized responsiveStyles breakpoint (the fix case)', () => {
+      render(<Harness />);
+      act(() => bumpParent());
+
+      expect(renderCount('scoped')).toBeGreaterThanOrEqual(2);
+      expect(distinctIdentities('scoped')).toBe(1);
+    });
+
+    it('holds across several parent re-renders, not just one', () => {
+      render(<Harness />);
+      act(() => bumpParent());
+      act(() => bumpParent());
+      act(() => bumpParent());
+
+      expect(renderCount('scoped')).toBeGreaterThanOrEqual(4);
+      expect(distinctIdentities('scoped')).toBe(1);
+      expect(distinctIdentities('plain')).toBe(1);
+    });
+
+    it('the scope class survives memoisation — a stable identity is still the RIGHT object', () => {
+      render(<Harness />);
+      act(() => bumpParent());
+
+      const last = capturesFor('scoped')[renderCount('scoped') - 1];
+      expect(last.schema.className).toContain('os-s-scoped');
+      expect(last.schema.content).toBe('scoped');
+      expect(last.schema.type).toBe('identity-probe');
+      // `responsiveStyles` reaches the renderer on the schema object (it is
+      // stripped from the DOM props, not from the schema).
+      expect(last.schema.responsiveStyles).toEqual({ large: { padding: '8px' } });
+    });
+  });
+
+  describe('delivers a NEW identity when something really changed (anti-staleness)', () => {
+    it('a changed `className` on a scoped node', () => {
+      const before = {
+        type: 'identity-probe',
+        id: 'scoped',
+        className: 'text-sm',
+        responsiveStyles: { large: { padding: '8px' } },
+      };
+      const after = {
+        type: 'identity-probe',
+        id: 'scoped',
+        className: 'text-lg',
+        responsiveStyles: { large: { padding: '8px' } },
+      };
+
+      const { rerender } = render(<SchemaRenderer schema={before} />);
+      expect(capturesFor('scoped')[0].schema.className).toBe('text-sm os-s-scoped');
+
+      rerender(<SchemaRenderer schema={after} />);
+
+      const last = capturesFor('scoped')[renderCount('scoped') - 1];
+      expect(last.schema.className).toBe('text-lg os-s-scoped');
+      expect(last.schema).not.toBe(capturesFor('scoped')[0].schema);
+    });
+
+    it('a changed value on a scoped node', () => {
+      const before = {
+        type: 'identity-probe',
+        id: 'scoped',
+        content: 'first',
+        responsiveStyles: { large: { padding: '8px' } },
+      };
+      const after = {
+        type: 'identity-probe',
+        id: 'scoped',
+        content: 'second',
+        responsiveStyles: { large: { padding: '8px' } },
+      };
+
+      const { rerender } = render(<SchemaRenderer schema={before} />);
+      rerender(<SchemaRenderer schema={after} />);
+
+      const first = capturesFor('scoped')[0];
+      const last = capturesFor('scoped')[renderCount('scoped') - 1];
+      expect(first.schema.content).toBe('first');
+      expect(last.schema.content).toBe('second');
+      expect(last.schema).not.toBe(first.schema);
+    });
+
+    it('a changed responsiveStyles value re-compiles and re-identifies', () => {
+      const before = {
+        type: 'identity-probe',
+        id: 'scoped',
+        responsiveStyles: { large: { padding: '8px' } },
+      };
+      const after = {
+        type: 'identity-probe',
+        id: 'scoped',
+        responsiveStyles: { large: { padding: '24px' } },
+      };
+
+      const { rerender } = render(<SchemaRenderer schema={before} />);
+      rerender(<SchemaRenderer schema={after} />);
+
+      const first = capturesFor('scoped')[0];
+      const last = capturesFor('scoped')[renderCount('scoped') - 1];
+      expect(last.schema).not.toBe(first.schema);
+      expect(last.schema.responsiveStyles).toEqual({ large: { padding: '24px' } });
+    });
+
+    it('a live value the node interpolates — same schema object, changed page variable', () => {
+      // The strongest anti-staleness pin: the `schema` PROP identity never
+      // changes here, so only a genuinely reactive evaluation can move the
+      // delivered identity. A memo that froze on the prop would go stale.
+      const REACTIVE = {
+        type: 'identity-probe',
+        id: 'reactive',
+        content: '${page.tick}',
+        responsiveStyles: { large: { padding: '8px' } },
+      };
+
+      let setTick: (v: any) => void = () => {
+        throw new Error('writer not mounted');
+      };
+      const TickWriter: React.FC = () => {
+        const { setVariable } = usePageVariables();
+        setTick = (v) => setVariable('tick', v);
+        return null;
+      };
+
+      render(
+        <PageVariablesProvider
+          definitions={[{ name: 'tick', type: 'string', defaultValue: 'first' } as any]}
+        >
+          <TickWriter />
+          <SchemaRenderer schema={REACTIVE} />
+        </PageVariablesProvider>
+      );
+
+      expect(capturesFor('reactive')[0].schema.content).toBe('first');
+
+      act(() => setTick('second'));
+
+      const first = capturesFor('reactive')[0];
+      const last = capturesFor('reactive')[renderCount('reactive') - 1];
+      expect(last.schema.content).toBe('second');
+      expect(last.schema).not.toBe(first.schema);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6270

Verified at `bc5773fbb`.

## The defect, re-measured

The card named `SchemaRenderer.tsx:1076`; the line is now **`:1252`** (re-measured, not inherited):

```ts
const schemaForComponent = scopeClass
  ? { ...evaluatedSchema, className: mergedClassName }
  : evaluatedSchema;
```

Confirmed: for a node taking the `scopeClass` branch this allocated a new object on every `SchemaRenderer` render, even when the `evaluatedSchema` memo directly above it held. Measured through the real `SchemaRenderer` path with a probe registered in the real `ComponentRegistry`:

| node | distinct `schema` identities across 1 parent re-render | after |
|---|---|---|
| plain node (control) | **1** (stable) | 1 |
| `responsiveStyles: { base: … }` (control) | **1** (stable) | 1 |
| `responsiveStyles: { large: … }` (fix case) | **3** (fresh every render) | **1** |

## The fix is a hoist, not a one-line `useMemo`

The card's suggested shape — "memoize `schemaForComponent` on `[evaluatedSchema, mergedClassName]`" — **cannot be written at that line.** The use site sits after `if (!evaluatedSchema) return null`, the `_hidden` return, and the unresolved-component returns. A `useMemo` there is a **conditional hook**: a node toggling hidden → visible would call one more hook than the previous render and React would throw *"Rendered more hooks than during the previous render."*

So the whole ADR-0065 scoped-styling computation moves into one `useMemo` keyed on `[evaluatedSchema, autoStyleId]`, **hoisted above the early returns**, returning `{ scopeClass, scopedCss, mergedClassName, schemaForComponent }`. That dep set is complete: every value is a pure function of the evaluated node (`className`, `id`, `responsiveStyles`) plus the `useId` fallback.

The non-scoped branch keeps handing down `evaluatedSchema` **itself**, never a copy — a copy there would spread the same instability to every node in the tree.

## Anti-staleness is pinned, not assumed

Memoising an object that legitimately changes is this fix's failure mode, so four tests pin the opposite direction — a changed `className`, a changed value, a changed breakpoint, and (the strongest) a **live interpolated value with the `schema` prop identity held constant**, driven through `PageVariablesProvider`. All four must deliver a **new** identity.

## Reverse verification

Direction predicted before running, then measured. Pre-fix `SchemaRenderer.tsx` restored from the pinned merge-base `6a7893d57`; mutation and restore both proven **on disk** (anchored grep counts in both directions + `git hash-object` against the HEAD blob), never by an exit code.

```
pre-mutation  : fixed form 1, pre-fix form 0
post-mutation : fixed form 0, pre-fix form 1   (on-disk hash == BASE blob)
  →  Tests  2 failed | 9 passed (11)
       × node with a sized responsiveStyles breakpoint (the fix case)
       × holds across several parent re-renders, not just one
post-restore  : on-disk hash == HEAD blob, `git diff HEAD` empty
```

Exactly the two fix-direction assertions go red; every control stays green.

**The first pass predicted 2 red and got 3** — the boundedness pin went red too, contradicting its own doc comment. Cause: it counted identities from mount, and `SchemaRenderer` force-updates itself once after mounting (re-checking `ComponentRegistry` for a lazily registered component), so mount alone yields two renders — which pre-fix already handed down two different objects. It was folding parent-render instability in and duplicating the fix-case test. Now measured from the last render before the first click, so it covers only re-renders the parent took no part in. Fixed in `bc5773fbb`; the run above is the corrected one.

## The two inherited claims, re-measured

**1. "Not new exposure from #6018" — CONFIRMED, with a date correction.**

| memo | keyed `[schema]` by | commit | date |
|---|---|---|---|
| `mapConfig` | #5976 → PR #6016 | `538ed9246` | 2026-08-24 |
| `dataConfig` | #6018 → PR #6266 | `2aa2c226a` | 2026-08-25 |

`mapConfig`'s `[schema]` keying predates `dataConfig`'s by one day, so #6018 genuinely only made a second memo share an existing exposure. ⚠️ One refinement: *"pre-existing"* is true, *"long-standing"* would not be — before #6016 (2026-08-24) `mapConfig` was not keyed on `[schema]` at all, it was unmemoised. The exposure was ~1 day old when the card was filed, not ancient.

Worth recording: `ObjectMap`'s own memo doc comments assert that *"the identity that reaches this component is ALREADY stable across the renders that matter"* and name `SchemaRenderer`'s `evaluatedSchema` as one of three callers handing over a memoised node. That sentence was **false for scoped-style nodes** until this PR. It is true now.

**2. "Bounded — it is NOT an infinite loop" — CONFIRMED, and now pinned as a test rather than an argument.**

React re-renders only the subtree below the component that set state, so a consumer's own `setData` never re-runs `SchemaRenderer`, and the consumer keeps the very object React last handed it. The fetch effect's other deps (`schema.filter`, `schema.sort`) are nested references a shallow spread preserves, so they were stable even pre-fix. Cost was one redundant refetch cycle per **parent** render, never runaway. `a consumer re-rendering itself keeps the exact schema object it was handed` fixes this as a property of the renderer; it is green on both sides of the fix and turns red only if something upstream starts re-rendering `SchemaRenderer` in response to a consumer's state.

⚠️ One correction to the card's framing: the instability does **not** need a parent re-render to fire at all. `SchemaRenderer`'s mount effect calls `forceUpdate()` once to re-check the registry, so **every mount** of a scoped node already handed its child two different schema objects. Still bounded; just more frequent than "on parent render" reads.

## The reproduction trap, pinned

`hasResponsiveStyles` requires `large` / `medium` / `small` / `xsmall`; `{ base: … }` does not take the branch. The first test proves from the **delivered** `schema.className` which fixture is on which side, so the trap cannot silently turn the suite into an assertion that cannot fail. Every zero reading in it has a positive control in the same query shape.

## Gates — each one's own verdict line

| gate | verdict |
|---|---|
| `vitest run packages/react/ packages/plugin-map/` | `Test Files 77 passed (77)` / `Tests 999 passed (999)` |
| `vitest run --shard=1/4` (whole repo) | `Test Files 529 passed (529)` / `Tests 6562 passed \| 1 skipped (6563)` |
| `vitest run packages/core/src/styling/ packages/plugin-detail/` | `Test Files 111 passed (111)` / `Tests 1041 passed (1041)` |
| `pnpm --filter @object-ui/react type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `eslint packages/react --format json` | 128 files, **0 errors**, 363 warnings |
| `node scripts/check-changeset-presence.mjs` | `✅ … declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |
| `node scripts/check-control-bytes.mjs` | `✅ OK (scanned 5444 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-self-import.mjs` | `✅ No package names itself inside its own src/.` |
| `check:vi-mock-specifiers` / `check:shell-escape-residue` | `✅ OK` |

Exit codes captured **before any pipe** (`cmd > file 2>&1; EXIT=$?`), never read off a `tail`.

**Type-check coverage was verified, not assumed** — `tsc -p tsconfig.test.json --listFiles` confirms both `SchemaRenderer.tsx` and the new test file are in the checked set (positive control: an existing sibling test is too). A `type-check` that excluded `*.test.ts` would have been a true statement about nothing.

**Declared narrowing.** `pnpm lint` (`turbo run lint`, whole repo) and shards 2–4 were **not** run: a single shard exceeded the 600s foreground cap. What replaces them, and why it excludes nothing this diff could move: the behaviour change reaches **only** nodes carrying `responsiveStyles`, and the complete set of files mentioning it is `core/src/styling/scoped-styles.ts` (+ its test), `plugin-detail/src/synth/buildDefaultPageSchema.ts`, `react/src/SchemaRenderer.tsx`, the new test, and two `index.css` files — every one of those packages is in a green run above. For lint: the root `eslint.config.js` declares **no** `parserOptions.project` / `projectService`, so type-aware linting is off and no untouched file's verdict can move under this diff; `packages/react` (the only package with changed source) is fully linted at 0 errors. CI still runs the full farm.

## Scope note for the reviewer

`plugin-map` and every downstream memo key were left untouched, per the dispatch order. ⚠️ The triage comment on #6270 adopted a second item into scope — re-keying the load-bearing fetch effects onto the primitives they read (`dataConfig.provider`, `dataConfig.object`) so `useMemo` returns to being a pure optimisation — and the dispatch order I received explicitly forbids touching downstream renderers' memo keys. I followed the dispatch order and am flagging the conflict rather than picking a side. That work is unstarted and still worth doing: `useMemo` is not a semantic guarantee, and the fetch effect's correctness currently rests on a cache React is allowed to discard. This PR makes the identity stable; it does not make it guaranteed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011SfZeFWrhGLHmfq61xbz4q)_