### PR TITLE
feat(chatbot,app-shell): 渲染「打开这条记录 →」交接卡片（cloud#1658）

### DIFF
--- a/.changeset/record-handoff-card.md
+++ b/.changeset/record-handoff-card.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/plugin-chatbot': patch
+'@object-ui/app-shell': patch
+---
+
+「打开这条记录 →」卡片——ask 的记录交接终于有了客户端的另一半
+
+服务端半边（cloud#1659 的 `open_record`）先落了地，实测发现它是**半活的**：agent 发出
+`status:'record_handoff'`、回答说「点击上方链接打开」，而上方根本没有链接——控制台
+有 `build_handoff` 的探测器，这个状态一处都不认识，信号被原样丢弃。
+
+按五步补齐：`detectRecordHandoff`（含持久化 `{type:'text',value}` 包裹形状——replay
+信封那课的规矩）→ live 映射提升 → 水合提升 → 卡片渲染 → 宿主回调。
+
+两个设计点：
+
+- **app 段点击时现场解析**。记录路由要 `/apps/:app/:object/record/:id`，交接载荷只有
+  对象和记录 id；宿主回调用一次同源元数据读取 `_packageId` 再导航，不给 agent 增加
+  它未必知道的参数。
+- **刻意不做「被取代」置灰**。builder 卡的旧 prompt 会过时，旧的记录链接不会——记录
+  不因为有新交接而失效。
+
+真机闭环验证：问「把《沉默的大多数》标记成已读」→ 卡片渲染
+（`沉默的大多数 — 把阅读状态改为已读`）→ 点击 → 落在
+`/apps/app.hdke/hdke_book/record/<id>` 详情页，「编辑」在手边。
+
+缺任一 id 的交接在探测器就被丢弃，与服务端的拒绝对称——指向空处的卡片比散文更糟。

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -73,6 +73,7 @@ import {
   detectDraftResult,
   detectProposedPlan,
   detectBuilderHandoff,
+  detectRecordHandoff,
   detectProposedChanges,
   detectReplayOutcome,
   detectBuiltAppPackage,
@@ -193,6 +194,7 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
         // live floating-chat mapper (extractToolInvocations) already lifts all
         // four; this is its hydration counterpart.
         const builderHandoff = detectBuilderHandoff(result);
+        const recordHandoff = detectRecordHandoff(result);
         const proposedChanges = detectProposedChanges(result);
         // objectui#5695 — a confirm-replay result becomes a terminal state on
         // the original 确认修改 card; it must never rehydrate as an ordinary
@@ -207,6 +209,7 @@ export function hydratedMessagesToChatMessages(messages: HydratedUIMessage[]): C
           ...(draftReview && !replayOutcome ? { draftReview } : {}),
           ...(proposedPlan ? { proposedPlan } : {}),
           ...(builderHandoff ? { builderHandoff } : {}),
+          ...(recordHandoff ? { recordHandoff } : {}),
           ...(proposedChanges ? { proposedChanges } : {}),
           ...(replayOutcome ? { replayOutcome } : {}),
           ...(part.errorText ? { errorText: String(part.errorText) } : {}),
@@ -1479,6 +1482,33 @@ export function ChatPane({
     [navigate, editPackageId, conversationId],
   );
 
+  // cloud#1658 — land the user on the record an `open_record` hand-off names.
+  // The payload has objectName + recordId but the canonical record route needs
+  // the APP segment (`/apps/:app/:object/record/:id`), so resolve the object's
+  // owning package on click — one same-origin metadata read — instead of
+  // burdening the agent with an id it may not know. `setup` is the fallback
+  // shell for an object no package claims.
+  const openRecord = useCallback(
+    async (handoff: { objectName: string; recordId: string }) => {
+      let app = 'setup';
+      try {
+        const r = await fetch(`/api/v1/meta/object/${encodeURIComponent(handoff.objectName)}`, {
+          credentials: 'include',
+        });
+        if (r.ok) {
+          const j = (await r.json()) as { item?: { _packageId?: unknown } };
+          if (typeof j?.item?._packageId === 'string' && j.item._packageId) app = j.item._packageId;
+        }
+      } catch {
+        /* resolution is best-effort; the fallback below still lands on the record */
+      }
+      navigate(
+        `/apps/${encodeURIComponent(app)}/${encodeURIComponent(handoff.objectName)}/record/${encodeURIComponent(handoff.recordId)}`,
+      );
+    },
+    [navigate],
+  );
+
   // ── ADR-0037 Live Canvas ────────────────────────────────────────────────
   // When a build session drafts an `app`, open the split-view canvas: the
   // drafted app rendered as-if-published (`?preview=draft`) beside the chat.
@@ -2181,6 +2211,7 @@ export function ChatPane({
         className="min-h-0 flex-1 bg-background md:max-w-5xl"
         onUpgrade={() => window.open(cloudPricingDeepLink(), '_blank', 'noopener,noreferrer')}
         onOpenBuilder={openBuilder}
+        onOpenRecord={openRecord}
         surface="plain"
         maxHeight="100%"
         headerSlot={headerSlot}

--- a/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
+++ b/packages/plugin-chatbot/src/ChatbotEnhanced.tsx
@@ -321,6 +321,17 @@ export interface ChatToolInvocation {
     packageId?: string;
   };
   /**
+   * cloud#1658 — the ask agent's `open_record` structured hand-off (the record
+   * sibling of `builderHandoff`). Rendered as a "打开这条记录 →" action landing
+   * on the record the agent already resolved.
+   */
+  recordHandoff?: {
+    objectName: string;
+    recordId: string;
+    label?: string;
+    reason?: string;
+  };
+  /**
    * objectui#5695 — the terminal verdict of a confirm-replay (`replay_<id>`
    * tool results; cloud `runApprovedProposalReplay`). Rendered as a terminal
    * state on the ORIGINAL 确认修改 card — 已生效 / 已暂存为草稿 / 未生效 — so a
@@ -642,12 +653,18 @@ export interface ChatbotEnhancedProps extends React.HTMLAttributes<HTMLDivElemen
    * → the button is disabled (nothing to route to).
    */
   onOpenBuilder?: (handoff: { prompt: string; packageId?: string }) => void;
+  /** cloud#1658 — open the record an `open_record` hand-off points at. */
+  onOpenRecord?: (handoff: { objectName: string; recordId: string; label?: string; reason?: string }) => void;
   /** Heading for the ADR-0057 P4 "Open in Builder" handoff card (default "Build this in the Builder"). */
   builderHandoffTitleLabel?: string;
   /** Label for the handoff card's primary action button (default "Open in Builder →"). */
   builderHandoffOpenLabel?: string;
   /** Tooltip on a superseded (older) handoff card's disabled button (default "A newer request is available"). */
   builderHandoffSupersededTitle?: string;
+  /** cloud#1658 — the record hand-off card's title. */
+  recordHandoffTitleLabel?: string;
+  /** cloud#1658 — the record hand-off card's action label. */
+  recordHandoffOpenLabel?: string;
   /** Label for the publish-drafts button (default "Publish"). */
   publishDraftsLabel?: string;
   /** Label for the published-state badge that replaces the button (default "Published"). */
@@ -1097,6 +1114,7 @@ function shouldRenderDetailedTool(tool: ChatToolInvocation): boolean {
     Boolean(tool.proposedChanges) ||
     // ADR-0057 P4 — the "Open in Builder →" handoff lives in the detailed body.
     Boolean(tool.builderHandoff) ||
+    Boolean(tool.recordHandoff) ||
     // A completed propose_blueprint that produced NO structured plan still needs
     // the detailed body — that's where the fallback "Build it" confirm gate
     // renders so the user is never left guessing the confirmation phrase.
@@ -1275,8 +1293,11 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
       planTitleLabel = 'Proposed plan',
       builderHandoffTitleLabel = 'Build this in the Builder',
       builderHandoffOpenLabel = 'Open in Builder →',
+      recordHandoffTitleLabel = 'Open this record',
+      recordHandoffOpenLabel = 'Open record →',
       builderHandoffSupersededTitle = 'A newer request is available',
       onOpenBuilder,
+      onOpenRecord,
       planExtendLabel = 'Adding to existing app',
       planQuestionsLabel = 'Confirm before building',
       planAssumptionsLabel = 'Assumptions',
@@ -1931,6 +1952,7 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
             Boolean(tool.proposedChanges) ||
             // ADR-0057 P4 — open so the "Open in Builder →" action is visible.
             Boolean(tool.builderHandoff) ||
+            Boolean(tool.recordHandoff) ||
             // Fallback confirm gate (unstructured proposal) must open so its
             // "Build it" button is visible without an extra click.
             isUnstructuredBuildProposal(tool)
@@ -2201,6 +2223,36 @@ const ChatbotEnhanced = React.forwardRef<HTMLDivElement, ChatbotEnhancedProps>(
                     </button>
                   );
                 })()}
+              </div>
+            ) : null}
+            {/* cloud#1658 — the record hand-off: the agent resolved the record a
+                write request names but has no action to perform the change, so
+                the card lands the user exactly there. No superseded logic on
+                purpose: unlike a build prompt, an older record link stays
+                correct — the record does not go stale because a newer hand-off
+                exists. */}
+            {tool.recordHandoff ? (
+              <div
+                className="flex flex-col gap-2 border-t bg-muted/20 px-3 py-2.5"
+                data-testid="record-handoff"
+              >
+                <span className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground/80">
+                  <Sparkles className="size-3.5" />
+                  {recordHandoffTitleLabel}
+                </span>
+                <p className="text-xs text-muted-foreground">
+                  {tool.recordHandoff.label ?? tool.recordHandoff.objectName}
+                  {tool.recordHandoff.reason ? ` — ${tool.recordHandoff.reason}` : ''}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => onOpenRecord?.(tool.recordHandoff!)}
+                  disabled={!onOpenRecord}
+                  data-testid="record-handoff-open"
+                  className="inline-flex w-fit items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {recordHandoffOpenLabel}
+                </button>
               </div>
             ) : null}
             {tool.proposedPlan ? (

--- a/packages/plugin-chatbot/src/__tests__/recordHandoff.test.ts
+++ b/packages/plugin-chatbot/src/__tests__/recordHandoff.test.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `detectRecordHandoff` — cloud#1658.
+ *
+ * The server half of this hand-off shipped first and was HALF-ALIVE: the ask
+ * agent emitted `status:'record_handoff'` with a real recordId, the reply said
+ * "点击上方链接打开", and there was no link — the console had a detector for
+ * `build_handoff` and none for this. These tests pin the client half.
+ *
+ * Wrapper coverage is not optional (the replay-envelope lesson): persisted
+ * tool outputs arrive as `{ type:'text', value:'<json-string>' }`, so a
+ * detector that only reads the bare object goes blind exactly on reload.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectRecordHandoff } from '../mapMessages';
+
+const PAYLOAD = {
+  success: true,
+  status: 'record_handoff',
+  handoff: 'record',
+  objectName: 'hdke_book',
+  recordId: '-GQDwdky1HlN_k52',
+  label: '沉默的大多数',
+  reason: '把阅读状态改为已读',
+};
+
+describe('detectRecordHandoff', () => {
+  it('lifts the bare envelope (the live SSE shape)', () => {
+    expect(detectRecordHandoff(PAYLOAD)).toEqual({
+      objectName: 'hdke_book',
+      recordId: '-GQDwdky1HlN_k52',
+      label: '沉默的大多数',
+      reason: '把阅读状态改为已读',
+    });
+  });
+
+  it('lifts the persisted wrapper — { type:"text", value:"<json>" }', () => {
+    const wrapped = { type: 'text', value: JSON.stringify(PAYLOAD) };
+    expect(detectRecordHandoff(wrapped)?.recordId).toBe('-GQDwdky1HlN_k52');
+  });
+
+  it('lifts a JSON string (the raw handler return)', () => {
+    expect(detectRecordHandoff(JSON.stringify(PAYLOAD))?.objectName).toBe('hdke_book');
+  });
+
+  it('keeps optional fields off when absent', () => {
+    const out = detectRecordHandoff({ status: 'record_handoff', objectName: 'a', recordId: 'r1' });
+    expect(out).toEqual({ objectName: 'a', recordId: 'r1' });
+  });
+
+  it('drops a hand-off missing either id — a card pointing nowhere must not render', () => {
+    expect(detectRecordHandoff({ status: 'record_handoff', objectName: 'a' })).toBeUndefined();
+    expect(detectRecordHandoff({ status: 'record_handoff', recordId: 'r1' })).toBeUndefined();
+    expect(detectRecordHandoff({ status: 'record_handoff', objectName: ' ', recordId: 'r1' })).toBeUndefined();
+  });
+
+  it('ignores every other status — build_handoff stays the Builder card', () => {
+    expect(detectRecordHandoff({ status: 'build_handoff', prompt: 'x' })).toBeUndefined();
+    expect(detectRecordHandoff({ status: 'published' })).toBeUndefined();
+    expect(detectRecordHandoff(undefined)).toBeUndefined();
+  });
+});

--- a/packages/plugin-chatbot/src/index.tsx
+++ b/packages/plugin-chatbot/src/index.tsx
@@ -358,6 +358,7 @@ export {
   detectDraftResult,
   detectProposedPlan,
   detectBuilderHandoff,
+  detectRecordHandoff,
   detectProposedChanges,
   detectReplayOutcome,
   detectAuthoringVerdict,

--- a/packages/plugin-chatbot/src/mapMessages.ts
+++ b/packages/plugin-chatbot/src/mapMessages.ts
@@ -309,6 +309,42 @@ export function detectBuilderHandoff(result: unknown): BuilderHandoff | undefine
   return { prompt, ...(packageId ? { packageId } : {}) };
 }
 
+/**
+ * cloud#1658 — the ask agent's `open_record` structured hand-off: the OTHER
+ * ending of a write request. Envelope
+ * `{ status:'record_handoff', handoff:'record', objectName, recordId, label?, reason? }`.
+ * Lifted so the chat renders an explicit "打开这条记录 →" action landing on the
+ * record the agent already resolved — the whole point is that the user never
+ * re-finds a record the agent has in hand. Both ids are REQUIRED: a hand-off
+ * with either missing is dropped here exactly as the server refuses to emit
+ * one, because a card pointing nowhere is worse than the prose it replaces.
+ */
+export interface RecordHandoff {
+  objectName: string;
+  recordId: string;
+  label?: string;
+  reason?: string;
+}
+
+export function detectRecordHandoff(result: unknown): RecordHandoff | undefined {
+  const obj = parseResultEnvelope(result);
+  if (!obj || obj.status !== 'record_handoff') return undefined;
+  const str = (v: unknown): string | undefined => {
+    const t = typeof v === 'string' ? v.trim() : '';
+    return t.length > 0 ? t : undefined;
+  };
+  const o = obj as { objectName?: unknown; recordId?: unknown; label?: unknown; reason?: unknown };
+  const objectName = str(o.objectName);
+  const recordId = str(o.recordId);
+  if (!objectName || !recordId) return undefined;
+  return {
+    objectName,
+    recordId,
+    ...(str(o.label) ? { label: str(o.label) } : {}),
+    ...(str(o.reason) ? { reason: str(o.reason) } : {}),
+  };
+}
+
 export function detectProposedChanges(result: unknown): ProposedChanges | undefined {
   const obj = parseResultEnvelope(result);
   if (!obj || obj.status !== 'changes_proposed') return undefined;
@@ -586,6 +622,7 @@ function extractToolInvocations(
       const proposedPlan = detectProposedPlan(result);
       const proposedChanges = detectProposedChanges(result);
       const builderHandoff = detectBuilderHandoff(result);
+      const recordHandoff = detectRecordHandoff(result);
       // Promote a dangling `input-*` state to a terminal one so a reloaded
       // conversation never shows "Running" forever (the server doesn't always
       // snapshot the terminal tool state). Two cases:
@@ -619,6 +656,7 @@ function extractToolInvocations(
         proposedPlan,
         proposedChanges,
         builderHandoff,
+        recordHandoff,
         replayOutcome,
       } satisfies ChatToolInvocation;
     });


### PR DESCRIPTION
实现 cloud#1658 记录交接的**客户端另一半**。

## 为什么必须有这个 PR

服务端半边（cloud#1659 的 `open_record` 工具 + `record_handoff` 技能）先落地，真机实测发现整条链是**半活的**：

- agent 正确解析记录并发出 `{ status:'record_handoff', objectName, recordId, label, reason }`；
- 回答说「点击上方链接打开」；
- **而上方没有链接**——控制台有 `build_handoff` 的探测器，这个状态一处都不认识，信号被原样丢弃。

## 按五步规则补齐

| 步骤 | 位置 |
|---|---|
| detect | `mapMessages.ts` `detectRecordHandoff`——**含持久化 `{type:'text',value:'<json>'}` 包裹形状**（replay 信封那课：漏了它就"刷新后失明"） |
| live 提升 | `extractToolInvocations` |
| 水合提升 | `AiChatPage.tsx` |
| render | `ChatbotEnhanced.tsx` 卡片（`data-testid="record-handoff"`） |
| 宿主回调 | `AiChatPage` `openRecord` |

## 两个设计点

**app 段点击时现场解析**。记录路由要 `/apps/:app/:object/record/:id`，交接载荷只有对象与记录 id。宿主回调点击时用一次同源 `GET /api/v1/meta/object/<name>` 取 `_packageId` 再导航——不给 agent 增加它未必知道的参数；解析失败回落 `setup` 壳，best-effort。

**刻意不做「被取代」置灰**。builder 卡的旧 prompt 会过时（所以它有 superseded 逻辑），旧的**记录链接不会**——记录不因为有新交接而失效。

## 真机闭环验证

```
问：把《沉默的大多数》标记成已读
→ 卡片：Open this record | 沉默的大多数 — 把阅读状态改为已读 | [Open record →]
→ 点击：/_console/apps/app.hdke/hdke_book/record/-GQDwdky1HlN_k52
→ 页面：记录详情，「编辑」按钮在手边
```

app 段 `app.hdke` 正是点击时解析出来的。

## 测试

探测器 6 条（裸信封 / 持久化包裹 / JSON 字符串 / 可选字段缺省 / **缺任一 id 丢弃**——与服务端拒绝对称 / 其他 status 不误触发）；chatbot 全量 **328 条全绿**。

## 后续（不阻塞）

卡片默认标签是英文（与兄弟卡一致），宿主可传中文标签；与工具名 i18n（#6340）同一族的本地化后续统一做。
