### PR TITLE
Stamp the persisted column width as `width`, not `size` — restore saved widths on ObjectGrid's ungrouped path

### DIFF
--- a/.changeset/6457-persisted-column-width-key.md
+++ b/.changeset/6457-persisted-column-width-key.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+ObjectGrid now restores a persisted column width on the ungrouped path — the stamp key was
+`size`, which nothing downstream reads (objectui#6457).
+
+Resize a grid column and reload: the width came back. It was written to `localStorage`
+(and reported to the host, which persists it through `dataSource.updateViewConfig`), read
+back into `columnState.widths`, and stamped onto the column — as `size`. `TableColumn`
+declares `width`, and `data-table` resolves a column's width at all four of its sites as
+`columnWidths[accessorKey] || col.width || autoSizedWidths[accessorKey]`; it reads no
+column-level `size` anywhere, and ObjectGrid never passes a `columnWidths` prop down. So
+the round trip completed and was discarded at the last hop, and the column fell back to
+the char-estimate auto width. The `persistedColumns` map now stamps `width`.
+
+The correct key was not a judgement call: the **grouped** path in the same component reads
+the same `columnState.widths` and has always stamped `width`, and it worked. One path was
+out of step with its sibling — so this restores a convention rather than teaching
+`data-table` a second spelling. `TableColumn` is not edited: the consumer's declaration
+was the correct one. Precedence is unchanged and needs no change — a persisted width still
+loses to an in-session resize and still beats auto-sizing.
+
+Two things stop it recurring. The map's callback is no longer `(col: any)`: typed as
+`ObjectGridColumn` (`TableColumn & …`, declared since objectui#6004), a stray `size` here
+is now a compile error instead of a silent, user-visible drop — the `any` was what let the
+wrong key cross a boundary that had already declared the right one. And the new pin is the
+**inbound** half — a persisted width seeded through both channels, asserted at the rendered
+header cell. The pre-existing suite asserted only the outbound half, which passes on the
+broken code, because the write is exactly what was wrong; that is the measured reason this
+shipped.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -2468,12 +2468,32 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // Apply persisted column order and widths
   let persistedColumns = [...columns];
   
-  // Apply saved widths
+  // Apply saved widths.
+  //
+  // ⭐ THE KEY IS `width` (objectui#6457). This stamp used to write `size`,
+  // and `size` is a key nothing downstream consumes: `TableColumn`
+  // (`@object-ui/types` `data-display.ts`) declares `width`, and `data-table`
+  // resolves a column's width at all four of its sites as
+  // `columnWidths[accessorKey] || col.width || autoSizedWidths[accessorKey]`
+  // — zero column-level `size` reads. So a user's resize was written to
+  // localStorage, read back into `columnState.widths`, stamped onto the column
+  // here, and then dropped at the last hop; the width was never restored on the
+  // ungrouped path.
+  //
+  // The grouped path is the control that identified `width` as the right fix
+  // rather than teaching `data-table` a second key: `groupedColumnWidths` below
+  // reads the SAME `columnState.widths` and stamps `width`, and it works.
+  //
+  // ⛔ Do not re-widen this callback to `(col: any)`. That cast is what let
+  // the wrong key through a boundary which has DECLARED the right one since
+  // objectui#6004 — `ObjectGridColumn` is `TableColumn & …`, so with the
+  // callback typed, a stray `size` here is a compile error instead of a silent,
+  // user-visible drop. Typed, this defect class cannot come back by hand.
   if (columnState.widths) {
-    persistedColumns = persistedColumns.map((col: any) => {
+    persistedColumns = persistedColumns.map((col): ObjectGridColumn => {
       const savedWidth = columnState.widths?.[col.accessorKey];
       if (savedWidth) {
-        return { ...col, size: savedWidth };
+        return { ...col, width: savedWidth };
       }
       return col;
     });

--- a/packages/plugin-grid/src/__tests__/columnWidthInbound-6457.test.tsx
+++ b/packages/plugin-grid/src/__tests__/columnWidthInbound-6457.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ObjectGrid persisted column width — the INBOUND half (objectui#6457).
+ *
+ * ⚠️ This file exists because the OUTBOUND half was already pinned and the bug
+ * shipped anyway. `columnStatePersistence.test.tsx` asserts that a resize is
+ * written to localStorage and reported to the host, and its own docblock warns
+ * that it "deliberately observe[s] the WRITE, never the read-back". That is
+ * exactly the wrong half for this defect: the write was correct, and the value
+ * came back correctly — `persistedColumns` then stamped it onto the column as
+ * `size`, a key nothing downstream reads. `TableColumn` declares `width`, and
+ * `data-table` resolves every column's width as
+ * `columnWidths[accessorKey] || col.width || autoSizedWidths[accessorKey]`.
+ * So an outbound assertion PASSES on the broken code — the write is what was
+ * wrong — and the user-visible symptom (resize a column, reload, the width is
+ * gone) was invisible to the suite.
+ *
+ * ⭐ Every case here therefore starts from a value that is ALREADY persisted
+ * and ends at the RENDERED column: `style.width` on the header cell in the
+ * DOM, which is the last hop the key has to survive. Nothing here observes the
+ * write.
+ *
+ * The seeded widths (321, 277) are deliberately unreachable by `data-table`'s
+ * auto-size heuristic, which only ever yields `min(400, max(80, maxLen*8+48))`
+ * — i.e. 80, 400, or a value ≡ 48 (mod 8). Neither 321−48=273 nor 277−48=229
+ * is divisible by 8, so a matching assertion cannot be satisfied by the
+ * fallback that runs when the persisted width is dropped.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { __clearRecordCrudVerdictCache } from '../hooks/useRecordCrudVerdicts';
+import { installExplainDouble } from './explainDouble';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+const STORAGE_KEY = 'grid-columns-test_object';
+
+const rows = [
+  { id: '1', name: 'Alice', amount: 100, category: 'West' },
+  { id: '2', name: 'Bob', amount: 200, category: 'West' },
+];
+
+beforeEach(() => {
+  __clearRecordCrudVerdictCache();
+  installExplainDouble();
+  localStorage.clear();
+});
+afterEach(() => { vi.unstubAllGlobals(); localStorage.clear(); });
+
+function renderGrid(opts?: Record<string, any>) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'test_object',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'amount', label: 'Amount', type: 'number' },
+    ],
+    data: { provider: 'value', items: rows },
+    ...opts,
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} />
+    </ActionProvider>
+  );
+}
+
+/**
+ * The rendered width of a column, read off the header cell in the DOM — the
+ * far end of the round trip. `getAllByText` because grouped mode renders one
+ * sub-table (and therefore one header row) per group.
+ */
+function renderedWidths(header: string): string[] {
+  return screen.getAllByText(header)
+    .map(el => el.closest('th') as HTMLElement)
+    .filter(Boolean)
+    .map(th => th.style.width);
+}
+
+describe('ObjectGrid persisted column width (inbound half)', () => {
+  it('applies a width persisted in localStorage to the rendered column', async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ widths: { name: 321 } }));
+
+    renderGrid();
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+
+    // The seeded column reaches the DOM with the persisted width.
+    expect(renderedWidths('Name')).toEqual(['321px']);
+
+    // …and only that column: the unseeded sibling still auto-sizes, so the
+    // assertion above cannot be satisfied by a blanket width applied to every
+    // header cell.
+    const amount = renderedWidths('Amount');
+    expect(amount).toHaveLength(1);
+    expect(amount[0]).not.toBe('321px');
+    expect(amount[0]).toMatch(/^\d+px$/);
+  });
+
+  it('applies a width handed in by the host via columnState to the rendered column', async () => {
+    // The product path: ObjectView reads the saved layout off the view def and
+    // passes it down, rather than relying on the per-browser localStorage copy.
+    renderGrid({ columnState: { widths: { name: 321, amount: 277 } } });
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+
+    expect(renderedWidths('Name')).toEqual(['321px']);
+    expect(renderedWidths('Amount')).toEqual(['277px']);
+  });
+
+  it('applies a persisted width in grouped mode too (the sibling path that always worked)', async () => {
+    // The control that identified `width` as the correct key: the grouped path
+    // reads the SAME `columnState.widths` and has always stamped `width`. It is
+    // pinned here so the two paths cannot drift apart again in either
+    // direction.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ widths: { name: 321 } }));
+
+    renderGrid({ grouping: { fields: [{ field: 'category' }] } });
+    await waitFor(() => expect(screen.getByText('Alice')).toBeInTheDocument());
+
+    const widths = renderedWidths('Name');
+    expect(widths.length).toBeGreaterThan(0);
+    for (const w of widths) expect(w).toBe('321px');
+  });
+});


### PR DESCRIPTION
Fixes #6457

Resize a grid column, reload the page: on the ungrouped path the width was not restored. It was persisted correctly, reported to the host correctly, and read back correctly — then stamped onto the column under a key nothing consumes. The `persistedColumns` map now stamps `width`.

## Re-measured on today's `main` — the card body is pre-#6461 and was not implemented as written

The card's line numbers and its `(col as any)` framing describe the file before PR #6461 landed. Every claim was re-taken by name at base `5ef9c4f5ff266380875b83b5b0e31f5cfe89e3ae`:

| claim | where it is today | verdict |
|---|---|---|
| `TableColumn` declares `width`, not `size` | `packages/types/src/data-display.ts:313` | HOLDS — unchanged by #6461 |
| ungrouped `persistedColumns` stamps `size` | `ObjectGrid.tsx:2476` (card said `:2286`) | HOLDS — drifted 190 lines |
| grouped path stamps `width` | `ObjectGrid.tsx:3460` via `groupedColumnWidths` (`:3419`, card said `:3383-3387`) | HOLDS — the control still works |
| `data-table` reads no column-level `size` | `packages/components/src/renderers/complex/data-table.tsx` | HOLDS — 0 reads; the 9 `.size` hits are all `Set`/`Map` |
| width resolved at four sites as `columnWidths[accessorKey] || col.width || autoSized[accessorKey]` | `:1865`, `:1882`, `:2134`, `:2145` | HOLDS — same four lines, this file did not drift |
| `setColumnWidths` has one call site | `:1317`, the resize handler | HOLDS |
| `columnWidths` never seeded from the schema | `:862`, initialised empty | HOLDS |
| ObjectGrid never passes a `columnWidths` prop down | `ObjectGrid.tsx` | HOLDS — 0 occurrences |

So the round trip completed and was discarded at the last hop, and the column silently fell back to `data-table`'s char-estimate auto width.

**The grouped path is the control, and it is what picks the fix.** `groupedColumnWidths` reads the *same* `columnState.widths` and has always stamped `width` — one path out of step with its sibling, not a missing convention. That is why the change is `width` here rather than a second spelling taught to `data-table`. `packages/types/src/data-display.ts` is **not** edited: the consumer's declaration was the correct one, and the producer is what was wrong.

Precedence is unchanged and needed no change: a persisted width still loses to an in-session resize and still beats auto-sizing.

## The cast route — measured for this card rather than inherited

The retracted claim on the card is correctly retracted, and this PR does not rest on it. What was measured here, on its own, is narrower and specific to this seam: the stamp ran inside `persistedColumns.map((col: any) =>`, and **that `any` is exactly what let the wrong key cross a boundary which has declared the right one since #6004**. The callback is now typed `ObjectGridColumn`.

Measurement, both directions, on the committed tree:

- typed callback + `width` (as shipped): `pnpm --filter @object-ui/plugin-grid type-check` — clean, exit 0.
- typed callback + `size` (mutated, then restored): `src/ObjectGrid.tsx(2496,26): error TS2353: Object literal may only specify known properties, and 'size' does not exist in type 'ObjectGridColumn'.` / `Exit status 2`.

This is a bounded in-place fix inside the dispatched fence (the same map, same defect class, same gate family), declared here as required: it converts this defect class from a silent user-visible drop into a compile error, so it cannot return by hand. The seven surviving `(col as any).` **reads** elsewhere in the body are untouched — they are not this card's subject and are not addressed here.

## The test is the deliverable — the INBOUND half

New: `packages/plugin-grid/src/__tests__/columnWidthInbound-6457.test.tsx` (3 cases).

The pre-existing `columnStatePersistence.test.tsx` pins only the outbound half, and its own docblock says it "deliberately observe[s] the WRITE, never the read-back". That is the measured reason this shipped: **an outbound assertion passes on the broken code, because the write is exactly what was wrong.** Every case here therefore starts from an already-persisted value and ends at the **rendered** column — `style.width` on the header cell in the DOM, the last hop the key has to survive. Nothing here observes a write.

1. a width persisted in `localStorage` reaches the rendered column — and only that column, so a blanket width cannot satisfy it;
2. a width handed in by the host through `columnState` reaches the rendered column (the `ObjectView` / `updateViewConfig` channel);
3. grouped mode honours the same seed — the sibling path pinned as a control, so the two cannot drift apart again in either direction.

Seeds are 321 and 277 by construction: `data-table`'s auto-size only ever yields `min(400, max(80, maxLen*8+48))`, and neither 273 nor 229 is divisible by 8, so no fallback value can satisfy these assertions.

**Reverse verification** (fix committed first, mutation confirmed on disk by anchored grep counts and a blob-hash comparison, restore proven by an empty `git diff HEAD` and a hash match against the HEAD blob; scripts carried `trap … EXIT INT TERM` with absolute paths). Predicted direction before running: cases 1 and 2 red, case 3 green because the grouped path reads `columnState.widths` directly and is untouched by the mutation. Observed exactly that:

```
× applies a width persisted in localStorage to the rendered column
× applies a width handed in by the host via columnState to the rendered column
AssertionError: expected [ '88px' ] to deeply equal [ '321px' ]
Test Files  1 failed (1)
     Tests  2 failed | 1 passed (3)
```

`88px` is `data-table`'s char estimate for that column (`5*8+48`) — the observed fallback, i.e. the user-visible symptom reproduced in the assertion.

## Verification — all at `5a24c45c`, the final commit

- `pnpm exec vitest run packages/plugin-grid/` — `Test Files 95 passed (95)`, `Tests 876 passed (876)`
- `pnpm --filter @object-ui/plugin-grid type-check` — exit 0. Confirmed **measuring**, not merely passing: `tsc -p tsconfig.test.json --listFiles` includes both `ObjectGrid.tsx` and the new test file, so the green covers the new test.
- `pnpm --filter @object-ui/plugin-grid lint` — `679 problems (0 errors, 679 warnings)`, the package's standing baseline. The 2 warnings on the new file are `no-explicit-any` on the shared test-harness shape every sibling suite in that directory uses.
- `pnpm check:control-bytes` — `OK (scanned 5471 tracked text file(s))`; plus a direct control-character scan of the diff, no hits.
- `node scripts/check-changeset-presence.mjs` — declares 1 changeset; `node scripts/check-changeset-no-major.mjs` — no `major`.
- `pnpm check:phantom-deps`, `check:self-import`, `check:vi-mock-specifiers`, `check:i18n-keys` — all green.

Repo-wide `pnpm lint` and the full farm are left to CI, which runs them on this ref regardless.

Changeset: `.changeset/6457-persisted-column-width-key.md`, `@object-ui/plugin-grid: patch`.

## Not in scope

- The `width` / `size` vocabulary question on the **navigation overlay** seam (#6303, #6259, open half tracked on #6584) is a different seam. It was read so the two would not be merged into one change, and it does not decide this card; nothing here touches it.
- #6424's possible deferred emit-side half near `ObjectGrid.tsx:3418` is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_