### PR TITLE
feat(app-shell): one composer for makers — ask folds into build (cloud#1674)

### DIFF
--- a/.changeset/1674-maker-single-composer.md
+++ b/.changeset/1674-maker-single-composer.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/app-shell': minor
+---
+
+One composer for makers — the built-in `ask` folds into `build` for authoring
+principals (cloud#1674 maker convergence, Phase B).
+
+Ruling: `build` is the higher-privilege admin agent and, since cloud#1673, a
+strict data superset of `ask` — it answers records/aggregation/chart questions
+with the same tools. So Ask/Build stop being peer modes for a maker:
+
+- `surfaceAgent.ts` (the ONE ADR-0063 resolver) gains rule (3b): an `ask` want
+  upgrades to `build` for a principal with `manage_metadata` when the catalog
+  serves it — including over an app's explicit `defaultAgent: 'ask'` pin (the
+  pin serves the app's business users; the maker always gets the superset).
+  New `makerConvergedOnBuild` / `makerVisibleAgents` carry the same predicate
+  to the picker sites.
+- ChatPane's agent launcher lists `makerVisibleAgents`: the built-in ask leaves
+  the list for makers (custom agents stay), computed inside ChatPane so every
+  host — full `/ai` page, Studio copilot, console dock — converges identically.
+- A maker's bare `/ai/ask` redirects to `/ai/build`; `/ai/ask/:conversationId`
+  keeps rendering, so ask history stays readable.
+- `ConversationsSidebar` gains `includeAskConversations`: the converged surface
+  lists BOTH built-in groups' threads whichever one is open (merging only ask
+  made the build history vanish the moment an ask thread was opened — measured
+  in-browser on the first pass).
+- Console home shows the single Build entry for makers; non-authoring sessions
+  (the objectstack#8270 hosted posture) keep Ask AI, and every layer is a no-op
+  for them and for deployments without a build agent.
+- `useCanAuthorMetadata` extracted from HomePage to `hooks/` so the CTAs and
+  the chat surfaces answer the same per-principal question.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -104,7 +104,9 @@ import { AppHeader } from '../../layout/AppHeader.js';
 import { armChatDockExpanded, readDockReturnLocation } from '../../layout/chatDockState.js';
 import { fetchPendingDraftCount } from '../../preview/draftStatus.js';
 import { emitMetadataRefresh } from '../../assistant/assistantBus.js';
-import { getRuntimeConfig } from '../../runtime-config.js';
+import { getRuntimeConfig, isAiStudioEnabled } from '../../runtime-config.js';
+import { makerConvergedOnBuild, makerVisibleAgents } from '../../hooks/surfaceAgent.js';
+import { useCanAuthorMetadata } from '../../hooks/useCanAuthorMetadata.js';
 import { cloudPricingDeepLink } from '../marketplace/marketplaceApi.js';
 import { useNavigationContext } from '../../context/NavigationContext.js';
 import {
@@ -815,13 +817,24 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
   // here, then stripped as the route is canonicalized to `/ai/:agent`.
   const legacyAgentParam = !agentSegment ? searchParams.get('agent') ?? undefined : undefined;
 
+  // cloud#1674 maker convergence — the ONE predicate for this page's ask→build
+  // collapse (shared with ChatPane's launcher filter via surfaceAgent.ts).
+  const canAuthorMetadata = useCanAuthorMetadata();
+  const makerConverged = makerConvergedOnBuild(agents, canAuthorMetadata, isAiStudioEnabled());
+
   // App/platform default — used for a bare `/ai` (respecting the legacy
   // `?agent=`), and as the endpoint while a legacy bare-id link is being
   // redirected to its real agent surface.
-  const fallbackAgent = useMemo(
-    () => resolveDefaultAgentName(agents, legacyAgentParam ?? defaultAgentProp ?? envDefaultAgent),
-    [agents, legacyAgentParam, defaultAgentProp, envDefaultAgent],
-  );
+  const fallbackAgent = useMemo(() => {
+    const resolved = resolveDefaultAgentName(agents, legacyAgentParam ?? defaultAgentProp ?? envDefaultAgent);
+    // cloud#1674 — a maker's bare `/ai` (or an ask-preferring `?agent=` link)
+    // lands on the converged build composer: ask is no longer a start surface
+    // for principals who can author. Custom-agent preferences pass through.
+    if (makerConverged && isAskAgent(resolved)) {
+      return resolveAgentParam('build', catalogNames) ?? resolved;
+    }
+    return resolved;
+  }, [agents, legacyAgentParam, defaultAgentProp, envDefaultAgent, makerConverged, catalogNames]);
 
   // Resolved backend agent name for this surface (route agent wins; else default).
   const activeAgent = useMemo(() => {
@@ -934,11 +947,20 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
       navigate(`/ai/${friendly}${preservedQuery}`, { replace: true });
       return;
     }
+    // cloud#1674 — a maker landing on BARE `/ai/ask` (no conversation) is
+    // redirected to the converged build composer; ask stopped being a start
+    // surface for authoring principals. WITH a conversation id the link keeps
+    // working, so existing ask threads (sidebar rows, old deep links) still
+    // open and render.
+    if (makerConverged && segmentIsAgent && isAskAgent(activeAgent) && !urlConversationId) {
+      navigate(`/ai/build${preservedQuery}`, { replace: true });
+      return;
+    }
     if (segmentIsAgent && agentSegment !== friendly) {
       const tail = urlConversationId ? `/${encodeURIComponent(urlConversationId)}` : '';
       navigate(`/ai/${friendly}${tail}${preservedQuery}`, { replace: true });
     }
-  }, [agents.length, activeAgent, agentSegment, segmentIsAgent, unavailableKnownAgent, urlConversationId, searchString, navigate]);
+  }, [agents.length, activeAgent, agentSegment, segmentIsAgent, unavailableKnownAgent, makerConverged, urlConversationId, searchString, navigate]);
 
   // ── Legacy `/ai/:conversationId` (bare id) ──────────────────────────────
   // Resolve the conversation's own agent and 301 to `/ai/:agent/:conversationId`
@@ -1229,6 +1251,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
             userId={userId}
             apiBase={apiBase}
             activeAgent={activeAgent}
+            includeAskConversations={makerConverged}
             refreshKey={refreshKey}
             titleHints={titleHints}
             className="h-full border-r-0"
@@ -1271,6 +1294,7 @@ export function AiChatPage({ apiBase: apiBaseProp, defaultAgent: defaultAgentPro
               userId={userId}
               apiBase={apiBase}
               activeAgent={activeAgent}
+              includeAskConversations={makerConverged}
               refreshKey={refreshKey}
               titleHints={titleHints}
               className="w-72 min-h-0 flex-1 border-r-0"
@@ -1460,7 +1484,16 @@ export function ChatPane({
   // The agent dropdown is a LAUNCHER now (not an in-surface mode toggle): it
   // navigates to `/ai/:agent`, so it naturally lists custom agents and can stay
   // always-available. Shown only when there's more than one agent to switch to.
-  const showAgentLauncher = agents.length > 1;
+  //
+  // cloud#1674 maker convergence: for an authoring-capable principal the
+  // built-in `ask` leaves the launcher — build subsumes it (data superset since
+  // cloud#1673), so Ask/Build stop being peer modes and the maker gets ONE
+  // composer. Computed INSIDE ChatPane so every host (full `/ai` page, Studio
+  // copilot, console dock) converges identically. Custom agents stay listed;
+  // ask conversations stay openable — only the "start here" affordance goes.
+  const canAuthorMetadata = useCanAuthorMetadata();
+  const launcherAgents = makerVisibleAgents(agents, canAuthorMetadata, isAiStudioEnabled());
+  const showAgentLauncher = launcherAgents.length > 1;
 
   // ADR-0057 P4 — the `ask` agent declined an authoring request (suggest_builder).
   // Open the full-page BUILD surface seeded with the handoff prompt (carried as
@@ -2004,7 +2037,7 @@ export function ChatPane({
     <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/50 px-4 pb-2 pt-3 sm:px-6">
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {showAgentLauncher ? (
-          agents.length <= 3 ? (
+          launcherAgents.length <= 3 ? (
             // Claude-Code-style segmented switcher (mirrors the floating
             // assistant) so Ask/Build read as visible peer modes, not a hidden
             // dropdown. Each tab navigates to that agent's surface. Falls back
@@ -2018,7 +2051,7 @@ export function ChatPane({
                 data-testid="ai-chat-agent-picker"
                 aria-label={t('console.ai.switchAssistant', { defaultValue: 'Switch assistant' })}
               >
-                {agents.map((agent) => (
+                {launcherAgents.map((agent) => (
                   <TabsTrigger
                     key={agent.name}
                     value={agent.name}
@@ -2045,7 +2078,7 @@ export function ChatPane({
                 <SelectValue placeholder={t('console.ai.chooseAgent', { defaultValue: 'Choose assistant…' })} />
               </SelectTrigger>
               <SelectContent align="start">
-                {agents.map((agent) => (
+                {launcherAgents.map((agent) => (
                   <SelectItem key={agent.name} value={agent.name} className="text-xs">
                     <span className="font-medium">
                       {localizeAgentLabel(t, agent.name, agent.label)}

--- a/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
+++ b/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
@@ -32,6 +32,14 @@ export interface ConversationsSidebarProps {
    * new ids match. Omit for an unscoped, all-agents list.
    */
   activeAgent?: string;
+  /**
+   * cloud#1674 maker convergence — also list the built-in `ask` agent's
+   * conversations alongside the active agent's. On the converged maker surface
+   * the ask picker entry is gone, so this sidebar is the ONLY road back to a
+   * maker's pre-convergence ask history; each row already navigates to its own
+   * agent's surface (`/ai/ask/:id`), which still renders. Alias-aware.
+   */
+  includeAskConversations?: boolean;
   className?: string;
   refreshKey?: number | string;
   titleHints?: Record<string, string>;
@@ -128,6 +136,7 @@ export function ConversationsSidebar({
   userId,
   apiBase,
   activeAgent,
+  includeAskConversations,
   className,
   refreshKey,
   titleHints,
@@ -148,10 +157,14 @@ export function ConversationsSidebar({
   // Friendly route segment for New/delete navigation (stays on this surface).
   const agentRoute = activeAgent ? agentRouteName(activeAgent) : undefined;
   // Names equivalent to the active agent, for scoping the list (alias-aware).
-  const agentGroup = useMemo(
-    () => (activeAgent ? new Set(agentAliasGroup(activeAgent)) : undefined),
-    [activeAgent],
-  );
+  // With `includeAskConversations` (cloud#1674) the built-in ask group joins
+  // the scope, so a converged maker keeps seeing their ask history.
+  const agentGroup = useMemo(() => {
+    if (!activeAgent) return undefined;
+    const names = new Set(agentAliasGroup(activeAgent));
+    if (includeAskConversations) for (const n of agentAliasGroup('ask')) names.add(n);
+    return names;
+  }, [activeAgent, includeAskConversations]);
 
   const decoratedConversations = useMemo(() => {
     return conversations.map((conversation) => {

--- a/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
+++ b/packages/app-shell/src/console/ai/ConversationsSidebar.tsx
@@ -157,12 +157,18 @@ export function ConversationsSidebar({
   // Friendly route segment for New/delete navigation (stays on this surface).
   const agentRoute = activeAgent ? agentRouteName(activeAgent) : undefined;
   // Names equivalent to the active agent, for scoping the list (alias-aware).
-  // With `includeAskConversations` (cloud#1674) the built-in ask group joins
-  // the scope, so a converged maker keeps seeing their ask history.
+  // With `includeAskConversations` (cloud#1674) BOTH built-in groups join the
+  // scope — the converged maker sees ONE merged history whether the open
+  // thread is a build one or a legacy ask one (merging only ask would make the
+  // build history vanish the moment an ask thread is opened; measured on the
+  // first in-browser pass).
   const agentGroup = useMemo(() => {
     if (!activeAgent) return undefined;
     const names = new Set(agentAliasGroup(activeAgent));
-    if (includeAskConversations) for (const n of agentAliasGroup('ask')) names.add(n);
+    if (includeAskConversations) {
+      for (const n of agentAliasGroup('ask')) names.add(n);
+      for (const n of agentAliasGroup('build')) names.add(n);
+    }
     return names;
   }, [activeAgent, includeAskConversations]);
 

--- a/packages/app-shell/src/console/home/HomePage.tsx
+++ b/packages/app-shell/src/console/home/HomePage.tsx
@@ -22,8 +22,11 @@ import { useRecentItems } from '../../hooks/useRecentItems.js';
 import { useFavorites } from '../../hooks/useFavorites.js';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { useAuth, useWorkspaceAdminStatus } from '@object-ui/auth';
-import { usePermissions } from '@object-ui/permissions';
 import { useAgents, isAskAgent, agentHasCapability } from '@object-ui/plugin-chatbot';
+// May this session author metadata? Shared with the chat surfaces since the
+// maker convergence (cloud#1674) — the doctrine (objectstack#8270 posture,
+// unknown→fail-open) lives with the hook.
+import { useCanAuthorMetadata } from '../../hooks/useCanAuthorMetadata.js';
 import { HomeAppsStrip } from './HomeAppsStrip.js';
 import { HomeActionCenter, HomeContinue, HomeActivity } from './HomeRail.js';
 import { useHomeInbox } from '../../hooks/useHomeInbox.js';
@@ -65,47 +68,6 @@ function useHomeAiAvailability(): {
     // cloud#816 — authoring availability by DECLARED capability (name-check fallback inside).
     buildAvailable: agents.some((a) => agentHasCapability(agents, a.name, 'authoring')),
   };
-}
-
-/**
- * [ADR-0066] The system capability every metadata-authoring surface behind the
- * home CTAs ultimately requires. The server is the authority (it refuses the
- * write either way); what follows is only the presentational half.
- */
-const AUTHORING_CAPABILITY = 'manage_metadata';
-
-/**
- * May this session author metadata?
- *
- * objectstack#8270 — on the EE single-database multi-tenant deployment a
- * workspace owner holds `org_owner` + `organization_admin` but NOT
- * `manage_metadata`; that absence is the intended hosted posture (maintainer
- * ruling 2026-08-13), not a missing grant. `useWorkspaceAdminStatus` reads the
- * session's POSITIONS (spelled `roles` until framework ADR-0090 D3 renamed it;
- * objectui#5389 moved this hook onto the live spelling, and `org_owner` is in
- * that array either way), so it says `true` for that owner and the builder CTAs
- * rendered — the owner
- * followed "Build an app", filled in the new-package dialog, and hit a raw
- * capability refusal at submit. This consumes the answer the server already
- * gives (`GET /api/v1/auth/me/permissions` → `systemPermissions`, surfaced by
- * `MePermissionsProvider`); it does NOT re-derive permission logic client-side.
- *
- * **Unknown → fail OPEN**, the same doctrine `useCapabilityGate` states for
- * ADR-0066 gates (framework#3923): the server enforces regardless, and hiding a
- * permitted user's primary CTA on missing client data is the worse failure.
- * `MePermissionsProvider` now preserves the absent-vs-empty distinction
- * natively (objectui#4656) — `hasCapabilities` itself returns `true` when the
- * backend never reported `systemPermissions` at all (a deployment predating
- * ADR-0066), and gates normally on a real answer, including a genuinely
- * EMPTY one. This hook no longer re-derives that heuristic locally; it just
- * asks the centralized signal. The ruled case is unaffected: the EE owner's
- * set is non-empty (`manage_org_users`, `setup.access`, `setup.write`), so it
- * gates closed. Hosts with no permission provider at all already fail open
- * inside `usePermissions`.
- */
-function useCanAuthorMetadata(): boolean {
-  const { hasCapabilities } = usePermissions();
-  return hasCapabilities([AUTHORING_CAPABILITY]);
 }
 
 /**
@@ -199,9 +161,12 @@ function HomeAiActions({
           {t('home.buildWithAI', { defaultValue: 'Build with AI' })}
         </Button>
       )}
-      {askAvailable && (
+      {/* cloud#1674 maker convergence: with the build CTA shown, "Ask AI" is
+          not a second door — the build composer answers data questions too
+          (data superset since cloud#1673), and `/ai/ask` would bounce a maker
+          straight back to `/ai/build`. Non-authoring sessions keep it. */}
+      {askAvailable && !showBuild && (
         <Button
-          variant={showBuild ? 'outline' : 'default'}
           onClick={() => navigate('/ai/ask')}
           data-testid="home-ask-ai"
         >

--- a/packages/app-shell/src/hooks/__tests__/surfaceAgent.test.ts
+++ b/packages/app-shell/src/hooks/__tests__/surfaceAgent.test.ts
@@ -88,3 +88,80 @@ describe('resolveSurfaceAgent — the ADR-0063 table', () => {
     expect(SURFACE_DEFAULT).toEqual({ 'studio-build': 'build', default: 'ask' });
   });
 });
+
+// ─── cloud#1674 maker convergence ────────────────────────────────────────────
+import { makerConvergedOnBuild, makerVisibleAgents } from '../surfaceAgent';
+
+describe('maker convergence (cloud#1674) — one composer for authoring principals', () => {
+  const CUSTOM = [agent('build'), agent('ask'), agent('weather_bot')];
+
+  it('a maker on a default surface upgrades ask → build', () => {
+    expect(
+      resolveSurfaceAgent('default', { agents: BOTH, canAuthorMetadata: true }),
+    ).toBe('build');
+  });
+
+  it('the upgrade is alias-aware (legacy catalog)', () => {
+    expect(
+      resolveSurfaceAgent('default', { agents: LEGACY, canAuthorMetadata: true }),
+    ).toBe('metadata_assistant');
+  });
+
+  it('a maker overrides an explicit app ask pin — the pin is for the app\'s business users', () => {
+    expect(
+      resolveSurfaceAgent('default', {
+        agents: BOTH,
+        appDefaultAgent: 'ask',
+        canAuthorMetadata: true,
+      }),
+    ).toBe('build');
+  });
+
+  it('a NON-authoring principal keeps ask everywhere (business posture untouched)', () => {
+    expect(resolveSurfaceAgent('default', { agents: BOTH })).toBe('ask');
+    expect(
+      resolveSurfaceAgent('default', { agents: BOTH, canAuthorMetadata: false }),
+    ).toBe('ask');
+  });
+
+  it('no build in the catalog → nothing to converge on (ask stays)', () => {
+    expect(
+      resolveSurfaceAgent('default', { agents: ASK_ONLY, canAuthorMetadata: true }),
+    ).toBe('ask');
+    expect(makerConvergedOnBuild(ASK_ONLY, true)).toBe(false);
+  });
+
+  it('AI Studio off → the downgrade beats the upgrade (no build to reach)', () => {
+    expect(
+      resolveSurfaceAgent('default', {
+        agents: BOTH,
+        canAuthorMetadata: true,
+        aiStudioEnabled: false,
+      }),
+    ).toBe('ask');
+    expect(makerConvergedOnBuild(BOTH, true, false)).toBe(false);
+  });
+
+  describe('makerVisibleAgents — the launcher list', () => {
+    it('drops the built-in ask for a converged maker; custom agents stay', () => {
+      expect(makerVisibleAgents(CUSTOM, true).map((a) => a.name)).toEqual([
+        'build',
+        'weather_bot',
+      ]);
+    });
+
+    it('drops the LEGACY ask alias too', () => {
+      expect(makerVisibleAgents(LEGACY, true).map((a) => a.name)).toEqual([
+        'metadata_assistant',
+      ]);
+    });
+
+    it('non-authoring principals see the catalog as-is', () => {
+      expect(makerVisibleAgents(CUSTOM, false)).toEqual(CUSTOM);
+    });
+
+    it('without a served build agent the list is untouched (nothing subsumes ask)', () => {
+      expect(makerVisibleAgents(ASK_ONLY, true)).toEqual(ASK_ONLY);
+    });
+  });
+});

--- a/packages/app-shell/src/hooks/surfaceAgent.ts
+++ b/packages/app-shell/src/hooks/surfaceAgent.ts
@@ -31,6 +31,7 @@
  */
 
 import {
+  isAskAgent,
   isBuildAgent,
   isBuiltinAgentName,
   resolveAgentParam,
@@ -66,6 +67,51 @@ export interface ResolveSurfaceAgentInput {
    * `build` want degrades to `ask`. Defaults to true.
    */
   aiStudioEnabled?: boolean;
+  /**
+   * cloud#1674 maker convergence — may THIS principal author metadata
+   * (`useCanAuthorMetadata`, per-principal; distinct from `aiStudioEnabled`,
+   * the deployment's answer)? A maker gets ONE composer: an `ask` want
+   * upgrades to `build` when the catalog serves it, so building and asking
+   * happen in the same thread (build is a strict data superset since
+   * cloud#1673). `false`/absent → business posture, unchanged.
+   */
+  canAuthorMetadata?: boolean;
+}
+
+/**
+ * cloud#1674 — is this session on the CONVERGED maker surface? True when the
+ * principal may author, the deployment offers authoring, and the catalog
+ * actually serves a build agent. This is the ONE predicate the console's chat
+ * surfaces share; sites that only need the boolean (picker filtering, ask→build
+ * redirects) call this instead of re-deriving fragments of it.
+ */
+export function makerConvergedOnBuild(
+  agents: readonly AgentDescriptor[],
+  canAuthorMetadata: boolean,
+  aiStudioEnabled = true,
+): boolean {
+  return (
+    canAuthorMetadata &&
+    aiStudioEnabled &&
+    resolveAgentParam('build', agents.map((a) => a.name)) !== undefined
+  );
+}
+
+/**
+ * The agents a maker's picker should offer (cloud#1674). On the converged
+ * surface the built-in `ask` stops being a peer mode — build subsumes it — so
+ * it leaves the list; custom agents stay. Everyone else sees the catalog as-is.
+ * The ask AGENT itself stays mounted and its existing conversations still open
+ * (`/ai/ask/:conversationId` renders); only the "start here" affordance goes.
+ */
+export function makerVisibleAgents(
+  agents: readonly AgentDescriptor[],
+  canAuthorMetadata: boolean,
+  aiStudioEnabled = true,
+): readonly AgentDescriptor[] {
+  return makerConvergedOnBuild(agents, canAuthorMetadata, aiStudioEnabled)
+    ? agents.filter((a) => !isAskAgent(a.name))
+    : agents;
 }
 
 /**
@@ -75,7 +121,7 @@ export interface ResolveSurfaceAgentInput {
  */
 export function resolveSurfaceAgent(
   surface: ChatSurface,
-  { agents, appDefaultAgent, aiStudioEnabled = true }: ResolveSurfaceAgentInput,
+  { agents, appDefaultAgent, aiStudioEnabled = true, canAuthorMetadata = false }: ResolveSurfaceAgentInput,
 ): string | undefined {
   const catalog = agents.map((a) => a.name);
   // (1) app.defaultAgent bounded to the two products — reject anything else.
@@ -84,6 +130,15 @@ export function resolveSurfaceAgent(
   const want = bounded ?? SURFACE_DEFAULT[surface] ?? SURFACE_DEFAULT.default;
   // (3) the ConsoleLayout downgrade, folded in ONCE.
   const eff = !aiStudioEnabled && isBuildAgent(want) ? 'ask' : want;
+  // (3b) cloud#1674 maker convergence — the UPGRADE mirror of (3): a maker
+  // gets one composer, so an `ask` want (surface default OR an app pin — the
+  // pin is for the app's business users; the maker always gets the superset)
+  // upgrades to `build` when the catalog serves it. Non-authoring principals
+  // never reach this line, so business surfaces are untouched.
+  const upgraded =
+    isAskAgent(eff) && makerConvergedOnBuild(agents, canAuthorMetadata, aiStudioEnabled)
+      ? 'build'
+      : eff;
   // (4) resolve against the live catalog (alias-aware); else platform default.
-  return resolveAgentParam(eff, catalog) ?? resolveDefaultAgentName(agents);
+  return resolveAgentParam(upgraded, catalog) ?? resolveDefaultAgentName(agents);
 }

--- a/packages/app-shell/src/hooks/useCanAuthorMetadata.ts
+++ b/packages/app-shell/src/hooks/useCanAuthorMetadata.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { usePermissions } from '@object-ui/permissions';
+
+/**
+ * [ADR-0066] The system capability every metadata-authoring surface ultimately
+ * requires. The server is the authority (it refuses the write either way); what
+ * follows is only the presentational half.
+ */
+export const AUTHORING_CAPABILITY = 'manage_metadata';
+
+/**
+ * May this session author metadata?
+ *
+ * Extracted from the console HomePage (where it gated the builder CTAs) when
+ * the maker convergence (cloud#1674) made the SAME question decide which chat
+ * composer a console session gets — one shared answer, not two drifting copies.
+ *
+ * objectstack#8270 — on the EE single-database multi-tenant deployment a
+ * workspace owner holds `org_owner` + `organization_admin` but NOT
+ * `manage_metadata`; that absence is the intended hosted posture (maintainer
+ * ruling 2026-08-13), not a missing grant. `useWorkspaceAdminStatus` reads the
+ * session's POSITIONS (spelled `roles` until framework ADR-0090 D3 renamed it;
+ * objectui#5389 moved this hook onto the live spelling, and `org_owner` is in
+ * that array either way), so it says `true` for that owner and the builder CTAs
+ * rendered — the owner followed "Build an app", filled in the new-package
+ * dialog, and hit a raw capability refusal at submit. This consumes the answer
+ * the server already gives (`GET /api/v1/auth/me/permissions` →
+ * `systemPermissions`, surfaced by `MePermissionsProvider`); it does NOT
+ * re-derive permission logic client-side.
+ *
+ * **Unknown → fail OPEN**, the same doctrine `useCapabilityGate` states for
+ * ADR-0066 gates (framework#3923): the server enforces regardless, and hiding a
+ * permitted user's primary CTA on missing client data is the worse failure.
+ * `MePermissionsProvider` now preserves the absent-vs-empty distinction
+ * natively (objectui#4656) — `hasCapabilities` itself returns `true` when the
+ * backend never reported `systemPermissions` at all (a deployment predating
+ * ADR-0066), and gates normally on a real answer, including a genuinely
+ * EMPTY one. This hook no longer re-derives that heuristic locally; it just
+ * asks the centralized signal. The ruled case is unaffected: the EE owner's
+ * set is non-empty (`manage_org_users`, `setup.access`, `setup.write`), so it
+ * gates closed. Hosts with no permission provider at all already fail open
+ * inside `usePermissions`.
+ */
+export function useCanAuthorMetadata(): boolean {
+  const { hasCapabilities } = usePermissions();
+  return hasCapabilities([AUTHORING_CAPABILITY]);
+}

--- a/packages/app-shell/src/layout/ChatDock.tsx
+++ b/packages/app-shell/src/layout/ChatDock.tsx
@@ -34,6 +34,7 @@ import { AiUsageIndicator } from './AiUsageIndicator.js';
 import { useChatConversation } from '../hooks/index.js';
 import { chatConversationScope, chatProductOfAgent } from '../hooks/chatScope.js';
 import { resolveSurfaceAgent } from '../hooks/surfaceAgent.js';
+import { useCanAuthorMetadata } from '../hooks/useCanAuthorMetadata.js';
 import { isAiStudioEnabled } from '../runtime-config.js';
 import {
   clampDockWidth,
@@ -255,14 +256,19 @@ function ChatDockConversation({
   onCanvasOpenChange,
 }: ChatDockConversationProps) {
   const { agents, isLoading, error } = useAgents({ apiBase });
+  // cloud#1674 maker convergence — the console dock is a maker surface, so an
+  // authoring-capable principal's ambient thread upgrades ask→build inside the
+  // ONE resolver; business sessions keep the ask ambient thread unchanged.
+  const canAuthorMetadata = useCanAuthorMetadata();
   const activeAgent = React.useMemo(
     () =>
       resolveSurfaceAgent('default', {
         agents,
         appDefaultAgent: defaultAgent,
         aiStudioEnabled: isAiStudioEnabled(),
+        canAuthorMetadata,
       }),
-    [agents, defaultAgent],
+    [agents, defaultAgent, canAuthorMetadata],
   );
   const chatApi = activeAgent
     ? `${apiBase}/agents/${encodeURIComponent(activeAgent)}/chat`


### PR DESCRIPTION
## 背景

用户裁决（objectstack-ai/cloud#1674 / cloud#1609 讨论）：**build 是更高权限的管理员 agent，ask 是业务人员的 agent；对 maker，构建/提问收敛成一个输入框**。服务端前置已在 objectstack-ai/cloud#1673 落地（build 成为 ask 的数据能力超集，含图表）。本 PR 是界面收敛（Phase B）。

## 改动

- **`surfaceAgent.ts`（ADR-0063 唯一裁决点）新增规则 (3b)**：可授权（`manage_metadata`）的主体在任何 default 表面上，ask 意向升级为 build（目录里有 build 才升级；含对 app 显式 ask pin 的覆盖——pin 服务该应用的业务用户，maker 永远拿超集）。新增 `makerConvergedOnBuild` / `makerVisibleAgents` 供各站点共用同一谓词。
- **ChatPane 的 agent 启动器**：maker 看不到内置 ask 项（custom agent 保留）；在 ChatPane 内部计算，三个宿主（/ai 全页、Studio copilot、控制台 dock）行为一致。
- **路由**：maker 的裸 `/ai/ask` 重定向 `/ai/build`；`/ai/ask/:conversationId` 照常渲染（历史可读）。
- **会话侧栏** `includeAskConversations`：收敛表面把 ask 历史和 build 历史并列展示——这是收敛后回到旧 ask 会话的唯一入口，每行本就按自身 agent 路由打开。
- **控制台首页**：maker 只见一个 Build 入口；不可授权会话（objectstack#8270 托管姿态）保留 Ask AI。
- **`useCanAuthorMetadata` 提取共享**（原 HomePage 私有），CTA 与聊天表面回答同一个问题。

## 不变式（新测试 11 条钉住）

- 不可授权主体：所有层零变化（业务姿态原样）。
- 目录无 build / AI Studio 关闭：零变化。
- 计费自动随 `agent_id`：maker 流量全记 build 池（cloud#1673 已验证）。

## 验证

- `surfaceAgent.test.ts` 21 条全过（10 旧 + 11 新）。
- app-shell 全套 5433 过；唯一红的 `anonSeedScope-5746.enumeration` 在纯 origin/main 上同样 7 连败（预存环境性破损，与本改动无关）。
- `tsc` 全净。

合并后需要 cloud 侧 pin bump 收货。

🤖 Generated with [Claude Code](https://claude.com/claude-code)