### PR TITLE
fix(app-shell): permission matrix bulk grants merge the row instead of replacing it

### DIFF
--- a/.changeset/6605-permission-bulk-merge-not-replace.md
+++ b/.changeset/6605-permission-bulk-merge-not-replace.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Permission matrix bulk buttons (R / CRUD / All) now merge into the object's
+permission row instead of replacing it, so spec-declared keys the matrix does
+not author — `allowExport` and the ADR-0057 access-depth axis `readScope` /
+`writeScope` — survive a bulk click the same way they already survived the
+per-checkbox path. Previously one click on any bulk button silently dropped
+them from the saved row, and the **All** button could widen effective read
+access by deleting a `readScope: 'own'` narrowing with no diff and no error.
+**None** deliberately keeps clearing the whole row, narrowings included:
+merging there would leave `allowExport: true` alive after a click on the
+button labelled None (objectui#6605).

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.bulkMergeKeys.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.bulkMergeKeys.test.tsx
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#6605 — the bulk buttons (R / CRUD / All / None) and the keys the
+ * matrix does not author.
+ *
+ * `bulkSetObject` used to REPLACE the object's permission row. Three
+ * spec-declared keys are modelled by neither the local `ObjectPerm` interface
+ * nor the `OBJECT_ACTIONS` column list — `allowExport`, and the ADR-0057
+ * access-depth axis `readScope` / `writeScope` — so one bulk click dropped
+ * whatever those held. The sharpest shape is the button labelled **All**: an
+ * admin clicking what reads as "grant everything" could WIDEN effective read
+ * access by deleting a `readScope: 'own'` narrowing, with no diff shown and no
+ * error.
+ *
+ * Every pin here asserts the SAVED payload, never editor state. That is the
+ * card's own argument for why the defect persisted: both save doors carry the
+ * row as-is — the environment door writes the whole record, and at package
+ * scope `mergePermissionSlice` takes in-scope rows entirely from `edited`
+ * (ADR-0086 P0), so `base` cannot restore what a bulk click dropped. An
+ * editor-state assertion would prove nothing about either door.
+ *
+ * ## `none` is pinned to keep REPLACING — that is the fix's fence, not a gap
+ *
+ * The dispatch on #6605 deliberately rejects the card's "`none` needs the same
+ * treatment" suggestion. The defect is a GRANT that silently drops a
+ * narrowing; `none` grants nothing, so nothing survives for a scope to
+ * narrow. Merging `none` would instead leave `allowExport: true` (and the
+ * scopes) alive after a click on the button labelled "None" — a permissive
+ * outcome that does not exist today, on a surface whose whole problem is
+ * silent permissiveness. What an admin's "None" means is a behaviour
+ * decision, made on #6605, not a mechanical merge. The `none` pin below makes
+ * that fence mechanical: a refactor that quietly adopts the card's suggestion
+ * goes red here and needs a maintainer decision, not a cleanup commit.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+/** Every object-permission key the matrix authors, in column order. */
+const MATRIX_KEYS = [
+  'allowCreate',
+  'allowRead',
+  'allowEdit',
+  'allowDelete',
+  'allowTransfer',
+  'viewAllRecords',
+  'modifyAllRecords',
+];
+
+interface FakeServer {
+  /** The stored record — what `layered()` answers (also the merge `base`). */
+  set: Record<string, any>;
+  /** What `list('object')` lists — the matrix rows (and, under a packageId, the slice scope). */
+  objectNames: string[];
+  saved: Record<string, any> | null;
+  savedOpts: Record<string, any> | undefined;
+}
+
+function makeClient(server: FakeServer) {
+  return {
+    layered: async () => ({ effective: server.set, code: null, overlay: null, overlayScope: null }),
+    getDraft: async () => null,
+    list: async (type: string) =>
+      type === 'object' ? server.objectNames.map((name) => ({ item: { name } })) : [],
+    get: async (type: string) => (type === 'object' ? { fields: [] } : null),
+    save: async (
+      _t: string,
+      _n: string,
+      payload: Record<string, any>,
+      opts?: Record<string, any>,
+    ) => {
+      server.saved = payload;
+      server.savedOpts = opts;
+      return payload;
+    },
+  } as any;
+}
+
+let clientImpl: any;
+
+vi.mock('./useMetadata', () => ({
+  useMetadataClient: () => clientImpl,
+  useMetadataTypes: () => ({
+    loading: false,
+    error: null,
+    entries: [{ type: 'permission', label: 'Permission', allowOrgOverride: true }],
+  }),
+}));
+vi.mock('./AssignedUsersSection', () => ({ AssignedUsersSection: () => null }));
+vi.mock('@object-ui/fields', () => ({
+  CapabilityMultiSelectField: () => <div data-testid="cap-picker" />,
+  parseCapabilityNames: (v: unknown) => (typeof v === 'string' ? JSON.parse(v) : []),
+}));
+
+import { PermissionMatrixEditPage } from './PermissionMatrixEditor';
+
+afterEach(cleanup);
+
+async function renderMatrix(
+  objects: Record<string, unknown>,
+  opts: { objectNames?: string[]; packageId?: string } = {},
+): Promise<FakeServer> {
+  const server: FakeServer = {
+    set: { name: 'sales_perms', label: 'Sales', objects, fields: {} },
+    objectNames: opts.objectNames ?? Object.keys(objects),
+    saved: null,
+    savedOpts: undefined,
+  };
+  clientImpl = makeClient(server);
+  render(
+    <MemoryRouter>
+      <PermissionMatrixEditPage type="permission" name="sales_perms" packageId={opts.packageId} />
+    </MemoryRouter>,
+  );
+  await screen.findByText('Sales');
+  return server;
+}
+
+/** The bulk button (`R` / `CRUD` / `All` / `None`) inside one object's row. */
+function bulkButton(objectName: string, label: string) {
+  const row = screen
+    .getAllByRole('row')
+    .find((r) => within(r).queryByText(objectName) != null);
+  expect(row, `row for ${objectName}`).toBeTruthy();
+  return within(row!).getByRole('button', { name: new RegExp(`^${label}$`) });
+}
+
+/** Click Save and return the payload the client was handed. */
+async function save(server: FakeServer) {
+  fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+  await waitFor(() => expect(server.saved).not.toBeNull());
+  return server.saved!;
+}
+
+describe('PermissionMatrixEditor · bulk buttons vs unmodelled keys (objectui#6605)', () => {
+  it('"All" — the widening shape — grants every column AND the saved row keeps readScope / writeScope / allowExport', async () => {
+    const server = await renderMatrix({
+      a_account: { allowRead: true, allowExport: true, readScope: 'own', writeScope: 'own' },
+    });
+
+    fireEvent.click(bulkButton('a_account', 'All'));
+    const payload = await save(server);
+
+    const row = payload.objects.a_account;
+    for (const key of MATRIX_KEYS) expect(row[key], key).toBe(true);
+    // The narrowings survive the click that used to delete them. `readScope`
+    // is the load-bearing one: dropping `own` silently widened read access.
+    expect(row.readScope).toBe('own');
+    expect(row.writeScope).toBe('own');
+    expect(row.allowExport).toBe(true);
+    expect(Object.keys(row).sort()).toEqual(
+      [...MATRIX_KEYS, 'allowExport', 'readScope', 'writeScope'].sort(),
+    );
+  });
+
+  it('"CRUD" merges the unmodelled keys through but still RESETS the matrix columns outside its grant', async () => {
+    const server = await renderMatrix({
+      a_account: {
+        allowTransfer: true,
+        viewAllRecords: true,
+        modifyAllRecords: true,
+        allowExport: true,
+        readScope: 'own',
+        writeScope: 'unit',
+      },
+    });
+
+    fireEvent.click(bulkButton('a_account', 'CRUD'));
+    const payload = await save(server);
+
+    const row = payload.objects.a_account;
+    // Falsification direction: merge must not decay into "add" — a bulk CRUD
+    // after a wider grant still means exactly CRUD for the keys the matrix owns.
+    expect(Object.keys(row).sort()).toEqual(
+      ['allowCreate', 'allowRead', 'allowEdit', 'allowDelete', 'allowExport', 'readScope', 'writeScope'].sort(),
+    );
+    expect('allowTransfer' in row).toBe(false);
+    expect('viewAllRecords' in row).toBe(false);
+    expect('modifyAllRecords' in row).toBe(false);
+    expect(row.readScope).toBe('own');
+    expect(row.writeScope).toBe('unit');
+    expect(row.allowExport).toBe(true);
+  });
+
+  it('"R" saves a read-only row that still carries the unmodelled keys', async () => {
+    const server = await renderMatrix({
+      a_account: {
+        allowCreate: true,
+        allowEdit: true,
+        allowExport: true,
+        readScope: 'own',
+        writeScope: 'unit',
+      },
+    });
+
+    fireEvent.click(bulkButton('a_account', 'R'));
+    const payload = await save(server);
+
+    const row = payload.objects.a_account;
+    expect(Object.keys(row).sort()).toEqual(
+      ['allowRead', 'allowExport', 'readScope', 'writeScope'].sort(),
+    );
+    expect(row.allowRead).toBe(true);
+    expect(row.readScope).toBe('own');
+  });
+
+  it('"None" still clears the WHOLE row — narrowings included (deliberate: the #6605 dispatch fence)', async () => {
+    // Read the header before "fixing" this pin: merging `none` would leave
+    // `allowExport: true` alive after a click on the button labelled "None".
+    const server = await renderMatrix({
+      a_account: { allowRead: true, allowExport: true, readScope: 'own', writeScope: 'own' },
+      a_contact: { allowRead: true, readScope: 'own' },
+    });
+
+    fireEvent.click(bulkButton('a_account', 'None'));
+    const payload = await save(server);
+
+    expect(payload.objects.a_account).toEqual({});
+    // Positive control in the same query shape: the untouched sibling row in
+    // the SAME saved payload still carries its narrowing, so the emptiness
+    // above is a measurement of `none`, not of a save path that drops keys.
+    expect(payload.objects.a_contact).toEqual({ allowRead: true, readScope: 'own' });
+  });
+
+  it('package door: the merged slice keeps the unmodelled keys after "All", and other packages\' rows survive byte-for-byte', async () => {
+    // In-scope: a_account (this package's row, carrying the narrowings).
+    // Out-of-scope: b_order — another package's contribution, not listed by
+    // this package, which `mergePermissionSlice` must copy verbatim from base.
+    const server = await renderMatrix(
+      {
+        a_account: { allowRead: true, allowExport: true, readScope: 'own', writeScope: 'own' },
+        b_order: { allowRead: true, viewAllRecords: true, readScope: 'unit' },
+      },
+      { objectNames: ['a_account'], packageId: 'app.a' },
+    );
+
+    fireEvent.click(bulkButton('a_account', 'All'));
+    const payload = await save(server);
+
+    const row = payload.objects.a_account;
+    for (const key of MATRIX_KEYS) expect(row[key], key).toBe(true);
+    expect(row.readScope).toBe('own');
+    expect(row.writeScope).toBe('own');
+    expect(row.allowExport).toBe(true);
+    // The other package's row is untouched — and the save went through the
+    // package door (a draft write), not a live record write.
+    expect(payload.objects.b_order).toEqual({ allowRead: true, viewAllRecords: true, readScope: 'unit' });
+    expect(server.savedOpts).toMatchObject({ mode: 'draft', packageId: 'app.a' });
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
+++ b/packages/app-shell/src/views/metadata-admin/PermissionMatrixEditor.tsx
@@ -638,14 +638,39 @@ export function PermissionMatrixEditPage({ type, name, packageId, onDraftSaved, 
 
   function bulkSetObject(objectName: string, action: 'all' | 'none' | 'crud' | 'read') {
     setDraft((prev) => {
-      const next: ObjectPerm =
-        action === 'none'
-          ? {}
-          : action === 'all'
-          ? Object.fromEntries(OBJECT_ACTIONS.map((a) => [a.key, true])) as ObjectPerm
+      // `none` REPLACES the row with `{}` — deliberately, unlike the three
+      // granting arms below (#6605). The defect those arms had was a GRANT
+      // that silently dropped a narrowing: "All" deleting a `readScope: 'own'`
+      // widens effective read access with no diff and no error. `none` grants
+      // nothing, so nothing survives for a scope to narrow; merging here would
+      // instead leave `allowExport: true` (and the scopes) alive after a click
+      // on the button labelled "None" — a permissive outcome that does not
+      // exist today. What an admin's "None" means is a behaviour decision, not
+      // a mechanical merge; pinned by
+      // `PermissionMatrixEditor.bulkMergeKeys.test.tsx`.
+      if (action === 'none') {
+        return { ...prev, objects: { ...prev.objects, [objectName]: {} } };
+      }
+      // The granting arms MERGE (#6605): start from the current row, reset the
+      // keys this matrix authors (`OBJECT_ACTIONS`), then set the granted
+      // ones. Keys the matrix does not model — `allowExport`, `readScope`,
+      // `writeScope`, anything an older or newer editor wrote — ride through
+      // exactly as they do on the per-checkbox path (`updateObjectPerm`'s
+      // spread). Replacing the row wholesale is what silently deleted them,
+      // and both save doors persist the row as-is: the environment door writes
+      // the whole record, and at package scope `mergePermissionSlice` takes
+      // in-scope rows entirely from `edited` (ADR-0086 P0), so `base` cannot
+      // restore what a bulk click dropped.
+      const cur = prev.objects[objectName] ?? {};
+      const next: ObjectPerm = { ...cur };
+      for (const a of OBJECT_ACTIONS) delete next[a.key];
+      const grants: Array<keyof ObjectPerm> =
+        action === 'all'
+          ? OBJECT_ACTIONS.map((a) => a.key)
           : action === 'crud'
-          ? { allowCreate: true, allowRead: true, allowEdit: true, allowDelete: true }
-          : { allowRead: true };
+          ? ['allowCreate', 'allowRead', 'allowEdit', 'allowDelete']
+          : ['allowRead'];
+      for (const key of grants) next[key] = true;
       return {
         ...prev,
         objects: { ...prev.objects, [objectName]: next },


### PR DESCRIPTION
Fixes #6605

## What

`bulkSetObject` in `PermissionMatrixEditor.tsx` replaced an object's permission row wholesale on every bulk click. Three spec-declared keys are modelled by neither the local `ObjectPerm` interface nor the `OBJECT_ACTIONS` column list — `allowExport`, and the ADR-0057 access-depth axis `readScope` / `writeScope` — so one click on R / CRUD / All silently deleted whatever those held, and both save doors persisted the truncated row (the environment door writes the whole record; at package scope `mergePermissionSlice` takes in-scope rows entirely from `edited`, ADR-0086 P0, so `base` cannot restore them). The sharpest shape: the button labelled **All** could WIDEN effective read access by deleting a `readScope: own` narrowing, with no diff shown and no error.

The granting arms (`all` / `crud` / `read`) now start from the current row, reset the keys the matrix authors (`OBJECT_ACTIONS`), then set the granted ones — so unmodelled keys ride through exactly as they already do on the per-checkbox path (`updateObjectPerm` spreads). Resetting the authored keys first keeps today's bulk semantics for the matrix's own columns: CRUD after All still means exactly CRUD, not "add CRUD".

## `none` is deliberately UNCHANGED — it still replaces the row with `{}`

The card's suggested fix asked for the same merge treatment on `none`. Per the PM dispatch on #6605 this PR does **not** do that, deliberately: the defect is a grant that silently drops a narrowing; `none` grants nothing, so nothing survives for a scope to narrow. Merging `none` would leave `allowExport: true` (and the scopes) alive after a click on the button labelled **None** — a permissive outcome that does not exist today, on a surface whose whole problem is silent permissiveness. What an admin's "None" means is a behaviour decision, and it was made on the card thread, not here. The `none` arm is pinned (`PermissionMatrixEditor.bulkMergeKeys.test.tsx`) so a later refactor cannot quietly adopt the card's suggestion without going red and surfacing that decision.

Load-bearing measurement behind that fence, re-taken on the merged ref (post #6607): `OBJECT_ACTIONS` contains exactly `allowCreate, allowRead, allowEdit, allowDelete, allowTransfer, viewAllRecords, modifyAllRecords` — no `allowExport`, no scopes — so all three dropped keys are "shown to reviewers, not authored by the matrix", as the dispatch asserted.

## Tests (all assert the SAVED payload, never editor state)

New `PermissionMatrixEditor.bulkMergeKeys.test.tsx`, 5 pins:

- **All** (the widening shape): a row carrying `allowExport: true, readScope: own, writeScope: own` gets every matrix column granted AND keeps all three keys in the saved payload.
- **CRUD**: unmodelled keys ride through, while `allowTransfer` / `viewAllRecords` / `modifyAllRecords` still reset — the falsification direction that merge did not decay into "add".
- **R**: saved row is exactly `allowRead` plus the three unmodelled keys.
- **None**: saved row is exactly `{}` — with a positive control in the same payload (an untouched sibling row still carries its `readScope`), so the emptiness measures `none`, not a key-dropping save path.
- **Package door**: All under a `packageId` — the merged slice keeps the three keys, another package's out-of-scope row survives byte-for-byte, and the save went through the draft door (`mode: draft`).

Every pin was shown going red (fix committed first; restores proven by observation — `git diff HEAD` empty AND blob-hash match against HEAD, never exit codes; mutations proven on disk by anchored grep counts flipping plus a blob-hash difference; no rebuild needed for either leg — the suite imports the mutated file by relative path from source, no dist resolution in the loop):

- Leg A (revert editor to pre-fix `2a23000f`): predicted the four merge pins red, `none` pin green — observed exactly that (`Tests 4 failed | 1 passed`), failing in the predicted direction (`expected undefined to be 'own'`).
- Leg B (mutate `none` to the card's suggested merge): predicted only the `none` pin red — observed exactly that (`Tests 1 failed | 4 passed`), failing with `expected { allowExport: true, … } to deeply equal {}` — the precise hazard the dispatch fence names.

Verification at final commit `b0517791` (all via the shared verify lock where heavy):

- `pnpm exec vitest run` (repo root) over the new file + `retiredLifecycleKeys` + `packageDoorFacets` + both `permission-slice` suites: `Test Files 5 passed (5) · Tests 21 passed (21)`, lock VERDICT `command-exit 0`.
- `pnpm run type-check` in app-shell (both tsconfigs): exit 0, and `tsc -p tsconfig.test.json --listFiles` shows the new test file in the checked set (nonzero, with a nonzero positive control on a sibling test file).
- `turbo run lint --filter=@object-ui/app-shell`: `0 errors` (pre-existing package-wide warnings only), lock VERDICT `command-exit 0`.
- Derived gates for this diff (objectui has no dispatch-gates script; derived by hand from package.json + workflows): `check-control-bytes: OK`, `check-vi-mock-specifiers: OK` (new `vi.mock` call sites), i18n call-site keys OK, `designer-field-key-parity: OK`, changeset presence `✅ … declares 1 changeset(s)`, changeset no-major `✅ No changeset declares a major bump`.

## Scope

- Bounded to `bulkSetObject` + tests + a patch changeset, per the dispatch fence.
- The root-cause hypothesis (derive `ObjectPerm` from the spec's `ObjectPermission` with narrowings named in an `Omit`, the PR #6618 shape) was assessed and judged **larger than this card**: `keyof ObjectPerm` is used editor-wide as the boolean-checkbox key type, and the spec type carries the non-boolean `readScope` / `writeScope` plus (in the installed spec 17.2.0) the still-declared retired lifecycle keys — deriving would force a boolean-keys split across the editor's props and, without also deriving `OBJECT_ACTIONS`, buys no compile-time guarantee. Detailed in the report on the card.
- Out of scope: #6606 remains open in its own lane (`check-designer-field-key-parity.mjs` untouched). The retired `allowRestore` / `allowPurge` keys are not part of this change; the existing #6595 pins stay green.

Session: https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_