### PR TITLE
feat(types,plugin-dashboard): land the #6425 per-key ruling — declare format/options/currency, retire decimals

### DIFF
--- a/.changeset/6425-per-key-declare-retire.md
+++ b/.changeset/6425-per-key-declare-retire.md
@@ -1,6 +1,7 @@
 ---
 '@object-ui/types': minor
 '@object-ui/plugin-dashboard': patch
+'@object-ui/plugin-grid': patch
 ---
 
 Land objectui#6425's per-key ruling for `ObjectDataTable`'s authored column
@@ -20,6 +21,12 @@ override keys (maintainer, 2026-08-27):
   `precision`), so no authored `decimals` could reach a render. The authored
   read is removed and the key falls into `AuthoredColumnOverrides`' derived
   refusal band — render output is pinned unchanged.
+- **Re-arm plugin-grid's #6004 `options` retirement with an explicit
+  tombstone**: that refusal rested on the key's NON-membership (excess-property
+  freshness), which declaring `options` on `TableColumn` silently ended.
+  `ObjectGridRetiredOptionsTombstone` (`?: never`, intersected into both
+  `ObjectGridColumnDraft` and `ObjectGridColumn`) restores the refusal by
+  assignability; #6004's verdict itself is unchanged.
 - **`referenceTo` is deliberately NOT declared as spelled** — it stays held,
   owned by objectui#6597 (fix the spelling chain or withdraw the README
   line). The remaining hold is that card's scope, not unfinished work here.

--- a/.changeset/6425-per-key-declare-retire.md
+++ b/.changeset/6425-per-key-declare-retire.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-dashboard': patch
+---
+
+Land objectui#6425's per-key ruling for `ObjectDataTable`'s authored column
+override keys (maintainer, 2026-08-27):
+
+- **Declare `format`, `options`, `currency`** on `TableColumn` and its
+  `TableColumnSchema` zod mirror, in the same stroke. All three are honoured
+  by `object-data-table`'s cell pipeline — `format` / `options` were
+  documented author overrides the published types refused (a typed author got
+  a compile error and the zod parse silently stripped the key); `currency`
+  shipped in production but was never promised. The zod mirror now passes the
+  keys through instead of stripping them; `StaticTableColumn` and its mirror
+  tombstone all three under the #5474 lockstep rule (the static renderer
+  reads no field-meta overrides).
+- **Retire `decimals`**, immediately: zero readers measured anywhere
+  (`NumberCellRenderer` reads `scale`, `PercentCellRenderer` reads
+  `precision`), so no authored `decimals` could reach a render. The authored
+  read is removed and the key falls into `AuthoredColumnOverrides`' derived
+  refusal band — render output is pinned unchanged.
+- **`referenceTo` is deliberately NOT declared as spelled** — it stays held,
+  owned by objectui#6597 (fix the spelling chain or withdraw the README
+  line). The remaining hold is that card's scope, not unfinished work here.

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -486,8 +486,10 @@ object schema once and infers the renderer from the bound field:
 | `percent` | `0%` / `0.0%` formatted (honour `format`) |
 
 Author overrides always win — pass `type`, `format`, `options`,
-`referenceTo`, or your own `cell` function on a column to bypass
-auto-detection.
+`currency`, `referenceTo`, or your own `cell` function on a column to
+bypass auto-detection. An explicit `currency` (ISO 4217 code, e.g.
+`"EUR"`) wins over both the symbol inferred from `format` and the tenant
+default currency.
 
 ```jsonc
 {

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -100,7 +100,18 @@ interface NormalizedColumn {
  * `accessorKey`, `width`, `align`, `header`, `className`, `cellClassName`,
  * `sortable`, `resizable`, `editable`, `type`, `cell`, `headerIcon`,
  * `fitContent`, and `name`. Not one of `label`, `options`, `referenceTo`,
- * `format`, `currency`, `decimals` appears — so all six retire here.
+ * `format`, `currency`, `decimals` appears — so all six retired from the
+ * emit, and this producer still SOURCES none of them from `fieldMeta`.
+ *
+ * ⚠️ Three of the six — `format`, `options`, `currency` — have since been
+ * DECLARED on `TableColumn` itself (objectui#6425, maintainer ruling
+ * 2026-08-27), so they are no longer tombstoned on this emit type: the band
+ * below derives them away the moment the declaration landed. That is not a
+ * softening of the emit rule but its other branch — an AUTHORED value now
+ * passes through `{ ...col }` as declared metadata (the cell pipeline reads
+ * it back off the authored column), while writing one out of `fieldMeta`
+ * remains retired, pinned by the runtime census in
+ * `ObjectDataTable.emitBoundary-6373.test.tsx`.
  *
  * Retiring them is behaviour-preserving because none of them was the live path
  * for its own value: everything they carried is read off `fieldMeta` by the
@@ -135,25 +146,34 @@ export type EnrichedColumn =
  * {@link EnrichedColumn} above fences on the WRITE side. objectui#6373 fenced
  * what `enrich` emits; nothing yet fenced what it consumes.
  *
- * `enrich` hands `buildFieldMeta` six values taken off the authored column.
+ * `enrich` handed `buildFieldMeta` six values taken off the authored column.
  * Five of them — `format`, `options`, `referenceTo`, `currency`, `decimals` —
- * are declared by neither `TableColumn` (`@object-ui/types`) nor its
+ * were declared by neither `TableColumn` (`@object-ui/types`) nor its
  * `TableColumnSchema` zod mirror. Three were reached through `(col as any)`;
  * the other two through {@link NormalizedColumn}'s `[key: string]: any`, which
  * answers `any` just as loudly without the tell. So the widget honoured an
  * authoring vocabulary the published types refuse, and no artefact in the repo
  * said which keys those were or why.
  *
- * ## ⛔ This declares nothing and retires nothing
+ * ## The per-key ruling landed (objectui#6425, maintainer 2026-08-27)
  *
- * Declaring these five on `TableColumn` widens a PUBLISHED type — the runtime
- * accepted set would not move, but the promise would, and a declared key
- * cannot be withdrawn later without a breaking change. Retiring any of them
- * removes a published capability that ships and is tested today. Both are
- * maintainer decisions; objectui#6425 stays open for one. What this type does
- * instead is make the tolerance VISIBLE and OWNED — every honoured key written
- * down with a verdict and an owning card, every other candidate refused by
- * default rather than admitted by silence. Same shape objectui#6461 landed for
+ * This type used to hold all five keys with ⛔ "declares nothing and retires
+ * nothing" — both branches were maintainer decisions. The ruling has since
+ * disposed of them per key, and this keyhole now CARRIES that disposition:
+ *
+ *  - `format`, `options` — DECLARED on `TableColumn` + its zod mirror
+ *    (documented AND kept; declaring is truth-maintenance). Read below at
+ *    their published types via `Pick<TableColumn, …>`.
+ *  - `currency` — DECLARED (kept in production, never promised before;
+ *    declaring makes the existing behaviour honest). Same `Pick`.
+ *  - `decimals` — RETIRED, immediately (neither promised nor kept: zero
+ *    readers measured, and the authored read below is gone). The derived
+ *    band now refuses it like any other unadjudicated `FieldMeta` member.
+ *  - `referenceTo` — ⛔ NOT declared as spelled; still HELD, owned by
+ *    objectui#6597 (the enforce-or-remove channel: fix the spelling chain so
+ *    the promise becomes real, or withdraw the README line).
+ *
+ * The shape itself is unchanged from what objectui#6461 landed for
  * `plugin-grid` (`ObjectGridColumnHolds` / `RetiredListColumnKey`); the
  * identifiers differ because this producer's seam is a READ, not an emit.
  *
@@ -206,60 +226,36 @@ export type EnrichedColumn =
  */
 
 /**
- * The undeclared-but-live override keys this producer holds. Each carries the
- * verdict measured on this tree and the card that owns it; all five are
- * objectui#6425's, and none is settled by this file.
+ * The undeclared-but-live override keys this producer still holds. One is
+ * left: objectui#6425's ruling (maintainer, 2026-08-27) declared `format` /
+ * `options` / `currency` on `TableColumn` itself (they are read via
+ * `Pick<TableColumn, …>` below, no hold needed) and retired `decimals`
+ * outright (the derived band refuses it now).
  */
 export interface ObjectDataTableColumnHolds {
   /**
-   * HELD, objectui#6425 — the strongest authoring story of the five. The
-   * package README documents it (`"Author overrides always win"`, three
-   * `format` columns in its `object-data-table` example) and
-   * `ObjectDataTable.cells.test.tsx` renders `$150,000` / `60%` from it.
-   * Read by `renderFieldValue`'s currency / percent / date branches, by
-   * `isNumericFieldMeta` (which decides `align`), and by
-   * `resolveCellRendererType`.
-   */
-  format?: string;
-  /**
-   * HELD, objectui#6425 — named as an author override by the package README.
-   * Read by `SelectCellRenderer` (`field.options`) after `buildFieldMeta`'s
-   * per-option translation pass.
-   */
-  options?: FieldMeta['options'];
-  /**
-   * HELD, objectui#6425 — named as an author override by the package README,
-   * but MEASURED with no reader on this path: `LookupCellRenderer` resolves
-   * its target from `reference_to` / `reference`, and `computeLookupExpand`
-   * builds `$expand` from the OBJECT SCHEMA's field types, never from this
-   * key. Held rather than retired because retiring a published-documented key
-   * is objectui#6425's ruling to make, not this file's.
+   * HELD — owned by objectui#6597, where objectui#6425's ruling routed it
+   * (⛔ NOT declared as spelled). Named as an author override by the package
+   * README but MEASURED with no reader on this path: `LookupCellRenderer`
+   * resolves its target from `reference_to` / `reference`, and
+   * `computeLookupExpand` builds `$expand` from the OBJECT SCHEMA's field
+   * types, never from this key. A promised-but-not-kept key: #6597 either
+   * fixes the spelling chain so the promise becomes real, or withdraws the
+   * README line — until it rules, the read stays held here, neither declared
+   * nor retired.
    */
   referenceTo?: unknown;
-  /**
-   * HELD, objectui#6425 — live but undocumented: no README line and no test
-   * authored it at column level before this card. Read by `renderFieldValue`
-   * (`fieldMeta.currency`, the `$`-format branch) and by `resolveFieldCurrency`
-   * inside `CurrencyCellRenderer`, both ahead of the tenant default (ADR-0053).
-   */
-  currency?: string;
-  /**
-   * HELD, objectui#6425 — MEASURED with no reader anywhere: zero `.decimals`
-   * reads across `@object-ui/fields`, `@object-ui/i18n` and
-   * `@object-ui/components`. `NumberCellRenderer` reads `scale`,
-   * `PercentCellRenderer` reads `precision`, and `renderFieldValue`'s percent
-   * branch parses its digit count out of the format string. Held, not retired,
-   * for the same reason as `referenceTo`.
-   */
-  decimals?: number;
 }
 
 /**
  * The candidate keys this seam refuses — DERIVED from the override vocabulary,
  * never hand-listed, so a future `FieldMeta` member has to be adjudicated onto
- * {@link ObjectDataTableColumnHolds} to escape. `type` is excluded because
- * `TableColumn` declares it (objectui#5853 owns its VALUE set, folded below by
- * `normalizeTableColumnType`).
+ * {@link ObjectDataTableColumnHolds} to escape. Keys `TableColumn` declares
+ * leave the pool by declaration: `type` (objectui#5853 owns its VALUE set,
+ * folded below by `normalizeTableColumnType`) and, since objectui#6425's
+ * ruling, `format` / `options` / `currency`. `decimals` is the member the
+ * same ruling RETIRED — it lands here, refused at the read site, which is
+ * exactly the "held-band verdict flips to RETIRED" the ruling asked for.
  */
 export type UnheldFieldMetaOverrideKey =
   Exclude<keyof FieldMeta, keyof TableColumn | keyof ObjectDataTableColumnHolds>;
@@ -270,6 +266,10 @@ export type AuthoredColumnOverrides =
   /** DECLARED by `TableColumn`; widened to `string` because the authored value
    *  is folded onto the published union downstream, not at the read. */
   & { type?: string }
+  /** DECLARED by `TableColumn` + its zod mirror (objectui#6425, maintainer
+   *  ruling 2026-08-27) — the three adjudicated override keys are read at
+   *  their published types, straight off the declaration. */
+  & Pick<TableColumn, 'format' | 'options' | 'currency'>
   & ObjectDataTableColumnHolds
   & { [K in UnheldFieldMetaOverrideKey]?: never };
 
@@ -673,10 +673,16 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
       const authored: AuthoredColumnOverrides = col;
 
       // Build the shared FieldMeta (translated select options, resolved
-      // referenceTo / currency / decimals). Column-level props override the
+      // referenceTo / currency). Column-level props override the
       // schema-derived values. Lookup fields just pass `referenceTo` through —
       // the server expands them via `$expand` so the cell value is `{ id, name }`,
       // which the lookup/user cell renderers handle natively.
+      //
+      // `decimals` is NOT read here any more — RETIRED by objectui#6425's
+      // ruling (maintainer, 2026-08-27): zero readers were measured for it
+      // (`NumberCellRenderer` reads `scale`, `PercentCellRenderer` reads
+      // `precision`), so the authored key never reached anything, and the
+      // schema-derived value `buildFieldMeta` still resolves is untouched.
       const fieldMeta = buildFieldMeta({
         accessorKey: col.accessorKey,
         label: col.header,
@@ -689,7 +695,6 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
           options: authored.options,
           referenceTo: authored.referenceTo,
           currency: authored.currency,
-          decimals: authored.decimals,
         },
       });
 

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.emitBoundary-6373.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.emitBoundary-6373.test.tsx
@@ -102,11 +102,21 @@ const DECLARED = new Set(Object.keys(shapeOf(TableColumnSchema)));
 const HELD_ALIAS = 'name';
 
 /**
- * Retired from the emit by objectui#6373. Listed here as the card's VERDICTS,
- * not as the census's input: the census above is derived, and these names are
- * what the verdict table in the PR body has to stay true to.
+ * Retired from the emit by objectui#6373 — this producer SOURCES none of them
+ * from `fieldMeta`. Listed here as the card's VERDICTS, not as the census's
+ * input: the census above is derived, and these names are what the verdict
+ * table in the PR body has to stay true to.
+ *
+ * objectui#6425's ruling (maintainer, 2026-08-27) later split the six by
+ * DECLARATION status without changing the emit: three are now declared on
+ * `TableColumn` itself (an authored value passes through `{ ...col }` as
+ * declared metadata; the producer still never writes them out of
+ * `fieldMeta`), three remain undeclared (`decimals` retired outright,
+ * `referenceTo` held for objectui#6597, `label` objectui#5351's).
  */
-const RETIRED = ['label', 'options', 'referenceTo', 'format', 'currency', 'decimals'] as const;
+const RETIRED_FROM_EMIT_UNDECLARED = ['label', 'referenceTo', 'decimals'] as const;
+const RETIRED_FROM_EMIT_DECLARED = ['options', 'format', 'currency'] as const;
+const RETIRED = [...RETIRED_FROM_EMIT_UNDECLARED, ...RETIRED_FROM_EMIT_DECLARED];
 
 /* ── fixtures ────────────────────────────────────────────────────────────── */
 
@@ -167,11 +177,15 @@ describe('the census reads a real declaration (#6373)', () => {
     expect(DECLARED.has('type')).toBe(true);
   });
 
-  it('is measuring keys the slot genuinely does not declare', () => {
-    // The verdicts below are "retire" BECAUSE the slot declares none of them.
-    // If one ever becomes declared, that is the rule's other branch and this
-    // seam has to be revisited rather than left silently inconsistent.
-    for (const key of RETIRED) expect(DECLARED.has(key)).toBe(false);
+  it('is measuring the slot as it stands after the #6425 ruling', () => {
+    // This premise used to assert the slot declares NONE of the six — the
+    // emit verdicts were "retire" because nothing declared them. The ruling
+    // took the rule's other branch for three (declared on `TableColumn`), so
+    // the premise now pins the SPLIT: the emit census below is unchanged
+    // either way, because this producer writes none of the six from
+    // `fieldMeta` — declared or not.
+    for (const key of RETIRED_FROM_EMIT_UNDECLARED) expect(DECLARED.has(key)).toBe(false);
+    for (const key of RETIRED_FROM_EMIT_DECLARED) expect(DECLARED.has(key)).toBe(true);
     expect(DECLARED.has(HELD_ALIAS)).toBe(false);
   });
 });
@@ -254,6 +268,12 @@ describe("the emit type can FAIL — otherwise the annotation is decoration (#63
       type: 'currency',
       align: 'right',
       cell: (value: any) => value,
+      // Authored passthrough of the #6425-DECLARED trio: `{ ...col }` may
+      // legitimately carry these now — they are `TableColumn` members, no
+      // longer tombstones on this emit type.
+      format: '$0,0',
+      currency: 'EUR',
+      options: [{ value: 'tech', label: 'Technology' }],
     };
     expect(accepted.accessorKey).toBe('amount');
   });
@@ -276,22 +296,26 @@ describe("the emit type can FAIL — otherwise the annotation is decoration (#63
     // — so on its own it pins "the spread is refused" without pinning WHY, and
     // would have gone on passing after the enforcement was removed.
     //
-    // `Omit<FieldMeta, 'name' | 'type'>` is exactly the retired six: `name` is
-    // the held alias, `type` carries #5853's own refusal. Nothing but the
-    // tombstones refuses this one — verified by removing them and watching this
-    // directive, and only this one, turn TS2578.
-    // @ts-expect-error objectui#6373 — the six retired members are refused by the tombstones alone.
+    // `Omit<FieldMeta, 'name' | 'type'>` spans the retired six: `name` is
+    // the held alias, `type` carries #5853's own refusal. Since the #6425
+    // ruling declared `format` / `options` / `currency` on `TableColumn`,
+    // the members still refused by tombstones are `label`, `referenceTo` and
+    // `decimals` — enough to keep this spread an error, and nothing but the
+    // tombstones refuses it.
+    // @ts-expect-error objectui#6373 — the still-tombstoned members are refused by the tombstones alone.
     const retiredRefused: EnrichedColumn = { header: 'h', accessorKey: 'a', ...({} as Omit<FieldMeta, 'name' | 'type'>) };
     expect(retiredRefused.accessorKey).toBe('a');
   });
 
   it('refuses a retired key written out by hand', () => {
-    // This one needs no tombstone: a hand-written property is subject to the
-    // excess-property check, which `TableColumn` alone already fails. Kept
-    // because it is the OTHER way a key gets added back, and separated from the
-    // spread pins because the two are enforced by different machinery.
-    // @ts-expect-error objectui#6373 — `format` retired from this emit seam.
-    const writtenRefused: EnrichedColumn = { header: 'h', accessorKey: 'a', format: '$0,0' };
+    // Kept because a hand-written property is the OTHER way a key gets added
+    // back, and separated from the spread pins because the two are enforced
+    // by different machinery. This pin carried `format` until the #6425
+    // ruling declared it (writing it by hand is now legal, see the accepted
+    // fixture above); `decimals` — the key the same ruling RETIRED — takes
+    // its place, refused by the derived tombstone.
+    // @ts-expect-error objectui#6373/#6425 — `decimals` retired from this emit seam.
+    const writtenRefused: EnrichedColumn = { header: 'h', accessorKey: 'a', decimals: 2 };
     expect(writtenRefused.accessorKey).toBe('a');
   });
 });

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.overrideSource-6425.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.overrideSource-6425.test.tsx
@@ -20,13 +20,17 @@
  * loudly without the tell. `AuthoredColumnOverrides` replaces both with a
  * written hold per key plus a derived refusal band.
  *
- * ## ⛔ Nothing here declares or retires anything published
+ * ## The ruling landed — this file now pins the ruled state
  *
- * The declare-or-retire ruling for the five is objectui#6425's own subject and
- * belongs to a maintainer. This file is the PREREQUISITE for it: the runtime
- * half below measures, per key, whether an authored override reaches anything
- * at all, so the ruling is made on evidence rather than on the plausibility of
- * a key's name.
+ * This suite began as the PREREQUISITE for the declare-or-retire ruling: the
+ * runtime half measures, per key, whether an authored override reaches
+ * anything at all, so the ruling could be made on evidence. The maintainer
+ * ruled per key on 2026-08-27 (objectui#6425): `format` / `options` /
+ * `currency` DECLARED on `TableColumn` + its zod mirror; `decimals` RETIRED
+ * immediately (the authored read is gone; the derived band refuses the key);
+ * `referenceTo` ⛔ NOT declared as spelled — still HELD, owned by
+ * objectui#6597. The measurements below are unchanged because the ruling did
+ * not change behaviour; what changed is which artefact answers for each key.
  *
  * ## Every zero here is paired with a positive control
  *
@@ -124,13 +128,15 @@ describe('per-key liveness of the five undeclared overrides (#6425)', () => {
     expect(b).toContain('€');
   });
 
-  it('decimals reaches NOTHING — no reader exists for it', async () => {
+  it('decimals reaches NOTHING — the RETIRED key changes no render (ruling, 2026-08-27)', async () => {
     // Measured statically too: zero `.decimals` reads across `@object-ui/fields`,
     // `@object-ui/i18n` and `@object-ui/components`. `NumberCellRenderer` reads
     // `scale`; `PercentCellRenderer` reads `precision`; `renderFieldValue`'s
-    // percent branch counts digits in the FORMAT STRING. This pins that as
-    // behaviour, so making the key live later has to be a deliberate change
-    // that turns this red — and retiring it stays free.
+    // percent branch counts digits in the FORMAT STRING. That measurement is
+    // what justified the ruling's RETIRE verdict — no user could reach the
+    // key — and this same pin now proves the retire itself changed nothing:
+    // an authored `decimals` renders byte-identical to its absence, before
+    // the read was removed and after.
     const { a, b } = await renderPair(
       { a: { type: 'number' }, b: { type: 'number' } },
       { a: 3.14159, b: 3.14159 },
@@ -208,7 +214,9 @@ describe('the override reads are typed, and the band can FAIL (#6425)', () => {
 
   it('accepts exactly the adjudicated set', () => {
     // The positive control. Without it the refusals below could be satisfied by
-    // a type that refuses everything, which would pin nothing.
+    // a type that refuses everything, which would pin nothing. `decimals` is
+    // deliberately NOT here any more: the ruling retired it, and its refusal
+    // is pinned with the band below.
     const accepted: AuthoredColumnOverrides = {
       accessorKey: 'amount',
       type: 'currency',
@@ -216,7 +224,6 @@ describe('the override reads are typed, and the band can FAIL (#6425)', () => {
       options: [{ value: 'tech', label: 'Technology' }],
       referenceTo: 'account',
       currency: 'EUR',
-      decimals: 2,
     };
     expect(accepted.currency).toBe('EUR');
   });
@@ -242,6 +249,14 @@ describe('the override reads are typed, and the band can FAIL (#6425)', () => {
     // @ts-expect-error objectui#6425 — `name` is in the derived refusal band.
     const nameRefused: AuthoredColumnOverrides = carriesName;
     expect(nameRefused.accessorKey).toBe('amount');
+
+    // `decimals` used to be HELD here; the ruling (2026-08-27) RETIRED it, so
+    // it fell into the derived band with no hand-edit to the band itself —
+    // removing the hold member IS the flip. This directive is the pin.
+    const carriesDecimals: { accessorKey: string; decimals?: number } = { accessorKey: 'amount' };
+    // @ts-expect-error objectui#6425 — `decimals` RETIRED into the derived refusal band.
+    const decimalsRefused: AuthoredColumnOverrides = carriesDecimals;
+    expect(decimalsRefused.accessorKey).toBe('amount');
   });
 
   it('the same source is ACCEPTED by the holds without the band', () => {

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -599,16 +599,46 @@ export interface ObjectGridColumnHolds {
  * separate from the enrichment map — so the pre-fold shape needs a name, and
  * this is it.
  */
+/**
+ * ⭐ `options` — RETIRED at this emit (objectui#6004), and this explicit
+ * tombstone is now the ONLY enforcement of that verdict. ⛔ Do not "tidy" it
+ * away as redundant.
+ *
+ * Until objectui#6425 the key needed no tombstone: it was a member of NO part
+ * of the emit types below, so TypeScript's excess-property check refused a
+ * fresh literal writing it — refusal by non-membership. #6425's maintainer
+ * ruling (2026-08-27) then declared `options` on `TableColumn` itself (the
+ * `object-data-table` cell pipeline reads it off the AUTHORED column), which
+ * made the key a member here through `Omit<TableColumn, …>` / `TableColumn`
+ * and silently ended that enforcement. Nothing went red at the moment of
+ * loss — the emit-boundary suite's directive merely turned TS2578-unused,
+ * which is luck, not design. The general rule, recorded so the next seam can
+ * check itself: **a pin enforced by a key's non-membership silently stops
+ * enforcing the moment the key becomes a member.**
+ *
+ * objectui#6004's verdict itself is unchanged — nothing on either side of
+ * THIS seam reads a column-level `options` (`data-table.tsx` has no such
+ * read; `renderCellEditor` rebuilds the field from the object schema) — only
+ * the refusal's mechanism moves, from freshness to assignability. It is
+ * intersected into BOTH the pre-fold draft and the post-fold column, because
+ * the retirement belongs to the seam, not to one of its two types; the key
+ * cannot land in the DERIVED band (`RetiredListColumnKey`) because `options`
+ * is not a `ListColumn` member, which is why this one is hand-written.
+ */
+type ObjectGridRetiredOptionsTombstone = { options?: never };
+
 export type ObjectGridColumnDraft =
   Omit<TableColumn, 'type'>
   & { type?: string }
   & ObjectGridColumnHolds
+  & ObjectGridRetiredOptionsTombstone
   & { [K in RetiredListColumnKey]?: never };
 
 /** Post-fold: what actually reaches `DataTableSchema.columns: TableColumn[]`. */
 export type ObjectGridColumn =
   TableColumn
   & ObjectGridColumnHolds
+  & ObjectGridRetiredOptionsTombstone
   & { [K in RetiredListColumnKey]?: never };
 
 /** The row heights this grid styles — the five `RowHeight` values the spec admits. */

--- a/packages/plugin-grid/src/__tests__/columnEmitBoundary-6004.test.ts
+++ b/packages/plugin-grid/src/__tests__/columnEmitBoundary-6004.test.ts
@@ -157,15 +157,28 @@ describe('objectui#6004 — the emit boundary is an instrument, not a decoration
    * it means the emit type must now REFUSE it — otherwise "retired" is just a
    * deleted line that the next edit can put back for free.
    *
-   * `options` is not a `ListColumn` key, so it is not covered by the derived
-   * tombstone above; it is refused because it is not a member of any of the
-   * emit type's parts. Freshness is deliberately left in play here — that is
-   * genuinely the only reason a non-member is refused, so this directive still
-   * has exactly one cause.
+   * ⚠️ THE MECHANISM MOVED, and the history is the warning. As first written,
+   * this refusal rested on NON-MEMBERSHIP: `options` is not a `ListColumn`
+   * key (so the derived tombstone could never cover it), and it belonged to
+   * no part of the emit type, so excess-property freshness was "genuinely the
+   * only reason a non-member is refused". objectui#6425's maintainer ruling
+   * (2026-08-27) declared `options` on `TableColumn`, the key became a member
+   * here, and that enforcement ended SILENTLY — this directive turned
+   * TS2578-unused, which is luck, not design: a pin enforced by a key's
+   * non-membership stops enforcing the moment the key becomes a member.
+   * The refusal below is now caused by `ObjectGridRetiredOptionsTombstone`
+   * (`ObjectGrid.tsx`), an explicit `?: never` that bites by ASSIGNABILITY —
+   * one cause again, just a different one. #6004's verdict is unchanged.
    */
   it('the emit type refuses the retired `options` key', () => {
-    // @ts-expect-error objectui#6004 — `options` retired from this producer's emit.
-    const refused: ObjectGridColumnDraft = { header: 'S', accessorKey: 'stage', options: [] };
+    // Routed through a non-fresh value like the other tombstone pins, so the
+    // tombstone is the single cause — freshness cannot refuse a non-fresh
+    // source, and before the tombstone existed this exact assignment was the
+    // silent hole (a fresh literal still failed; the spread road was open).
+    const emitted: { header: string; accessorKey: string; options?: unknown[] } =
+      { header: 'S', accessorKey: 'stage', options: [] };
+    // @ts-expect-error objectui#6004/#6425 — `options` retired from this producer's emit, refused by the explicit tombstone.
+    const refused: ObjectGridColumnDraft = emitted;
     expect(refused.accessorKey).toBe('stage');
   });
 

--- a/packages/types/src/__tests__/static-table-narrow-surface.test.ts
+++ b/packages/types/src/__tests__/static-table-narrow-surface.test.ts
@@ -62,10 +62,11 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 // Side 3, type level: the narrow shape declares exactly the rich shape's key
-// set — five live, ten tombstoned, none invented, none forgotten. If a key
+// set — five live, thirteen tombstoned, none invented, none forgotten. If a key
 // is ever added to `TableColumn` without a deliberate decision on the static
-// side (live or tombstone), this line goes red. (`headerIcon` is the first key
-// to arrive through that gate: added rich by objectui#6424, tombstoned here.)
+// side (live or tombstone), this line goes red. (`headerIcon` was the first
+// key to arrive through that gate — added rich by objectui#6424, tombstoned
+// here — and #6425's three declared field-meta overrides followed it.)
 type _SameKeySet = Expect<Equal<keyof StaticTableColumn, keyof TableColumn>>;
 
 /* ── fixtures ────────────────────────────────────────────────────────────── */
@@ -78,10 +79,12 @@ const LIVE_COLUMN = {
   width: 120,
 };
 
-/** The ten keys the narrow surface refuses, with the value an author would
- *  plausibly write for each: nine the #5474 split retired, plus `headerIcon`,
- *  which joined the RICH shape later (objectui#6424) and is tombstoned here
- *  under the lockstep rule — the static renderer never read it. */
+/** The thirteen keys the narrow surface refuses, with the value an author
+ *  would plausibly write for each: nine the #5474 split retired, plus the four
+ *  that joined the RICH shape later and are tombstoned here under the lockstep
+ *  rule — `headerIcon` (objectui#6424) and the three field-meta overrides
+ *  objectui#6425 declared (`format` / `options` / `currency`). The static
+ *  renderer reads none of them. */
 const RETIRED_COLUMN_KEYS: Record<string, unknown> = {
   minWidth: 80,
   align: 'right',
@@ -93,6 +96,9 @@ const RETIRED_COLUMN_KEYS: Record<string, unknown> = {
   editable: false,
   cell: () => 'x',
   headerIcon: 'lucide:hash',
+  format: '$0,0',
+  options: [{ value: 'tech', label: 'Technology' }],
+  currency: 'EUR',
 };
 
 /** Every key the rich `TableColumn` interface declares. `satisfies` keeps the
@@ -115,6 +121,9 @@ const RICH_COLUMN_KEYS = [
   'editable',
   'cell',
   'headerIcon',
+  'format',
+  'options',
+  'currency',
 ] as const satisfies readonly (keyof TableColumn)[];
 type _RichKeyListExhaustive = Expect<Equal<(typeof RICH_COLUMN_KEYS)[number], keyof TableColumn>>;
 
@@ -229,6 +238,33 @@ describe('rich `TableColumn` — NOT narrowed by the split (ruling scope, object
     }
   });
 
+  it('the #6425 trio SURVIVES the rich parse — declared, not silently stripped', () => {
+    // Same discipline as `editable: false` above and `headerIcon` in
+    // `data-table-declared-column-keys.test.tsx` (objectui#6424): a non-strict
+    // z.object() ACCEPTS an undeclared key and silently STRIPS it, so this
+    // exact parse was green BEFORE objectui#6425 declared the keys — while the
+    // authored override vanished from the output. Acceptance cannot
+    // distinguish the fix from the defect; survival into the parsed OUTPUT
+    // can. `value` is an object sentinel: it rides `z.any()`, so it must
+    // survive BY IDENTITY, which also pins that the mirror is not coercing.
+    const valueSentinel = { code: 'tech' };
+    const authored = {
+      header: 'Amount',
+      accessorKey: 'amount',
+      format: '$0,0',
+      options: [{ value: valueSentinel, label: 'Technology', color: 'blue' }],
+      currency: 'EUR',
+    };
+    const result = TableColumnSchema.safeParse(authored);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.format).toBe('$0,0');
+      expect(result.data.currency).toBe('EUR');
+      expect(result.data.options).toEqual(authored.options);
+      expect(result.data.options?.[0]?.value).toBe(valueSentinel);
+    }
+  });
+
   it('`data-table` columns still parse with the rich keys authored', () => {
     const result = DataTableZod.safeParse({
       type: 'data-table',
@@ -246,7 +282,7 @@ describe('rich `TableColumn` — NOT narrowed by the split (ruling scope, object
 /* ── 3. the two shapes stay in lockstep ──────────────────────────────────── */
 
 describe('the split itself — narrow = rich key set, live = the measured read set', () => {
-  it('narrow zod declares exactly the interface key set: 5 live + 10 tombstones', () => {
+  it('narrow zod declares exactly the interface key set: 5 live + 13 tombstones', () => {
     expect(liveKeys(StaticTableColumnSchema).sort()).toEqual(
       ['accessorKey', 'cellClassName', 'className', 'header', 'width'].sort(),
     );

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -367,6 +367,47 @@ export interface TableColumn {
    * standing instrument gap, not closed here.
    */
   headerIcon?: React.ReactNode;
+  /**
+   * Field-meta override: display format pattern for the cell value (e.g.
+   * `"$0,0"`, `"0%"`, `"YYYY-MM-DD"`), honoured by `object-data-table`'s cell
+   * pipeline — `renderFieldValue`'s currency / percent / date branches — and
+   * by the numeric right-alignment inference. Documented as an author
+   * override by `@object-ui/plugin-dashboard`'s README and exercised by its
+   * cells suite. The plain `data-table` renderer does not read it; its
+   * type-driven rendering is {@link TableColumn.type} / `cell`.
+   *
+   * Declared by objectui#6425 (maintainer ruling 2026-08-27, per-key): the
+   * widget honoured this key while the declaration refused it, so a typed
+   * author got a compile error — and a silent strip from the zod mirror —
+   * for documented, tested behaviour. Declaring is truth-maintenance.
+   */
+  format?: string;
+  /**
+   * Field-meta override: option list for select-flavoured columns — `value`
+   * matched against the cell value, `label` rendered, `color` driving the
+   * badge/dot appearance. Honoured by `object-data-table`'s cell pipeline
+   * (`SelectCellRenderer`, after the per-option translation pass) ahead of
+   * the object schema's own options; documented as an author override by
+   * `@object-ui/plugin-dashboard`'s README. The plain `data-table` renderer
+   * does not read it.
+   *
+   * Declared by objectui#6425 (maintainer ruling 2026-08-27, per-key), same
+   * stroke as {@link TableColumn.format}.
+   */
+  options?: Array<{ value: any; label: string; color?: string }>;
+  /**
+   * Field-meta override: ISO 4217 currency code (e.g. `"EUR"`) for
+   * currency-formatted cells, honoured by `object-data-table`'s cell
+   * pipeline (`renderFieldValue` and `CurrencyCellRenderer`) ahead of both
+   * the symbol inferred from {@link TableColumn.format} and the tenant
+   * default currency (ADR-0053). The plain `data-table` renderer does not
+   * read it.
+   *
+   * Declared by objectui#6425 (maintainer ruling 2026-08-27, per-key): kept
+   * in production but never promised before — declaring makes the existing
+   * behaviour honest.
+   */
+  currency?: string;
 }
 
 /**
@@ -477,6 +518,31 @@ export interface StaticTableColumn {
    * @deprecated Not part of the static `table` renderer's contract.
    */
   headerIcon?: never;
+  /**
+   * NOT on the static `table` surface (objectui#6425, under #5474's lockstep
+   * rule: every rich key needs a deliberate static-side decision). Declared
+   * on the rich {@link TableColumn} only — the static renderer reads no
+   * field-meta overrides (its measured read set is the five live keys above).
+   * Formatted cells are `data-table`'s capability.
+   * @deprecated Not part of the static `table` renderer's contract.
+   */
+  format?: never;
+  /**
+   * NOT on the static `table` surface (objectui#6425, under #5474's lockstep
+   * rule). Declared on the rich {@link TableColumn} only — the static
+   * renderer reads no field-meta overrides. Select badges are `data-table`'s
+   * capability.
+   * @deprecated Not part of the static `table` renderer's contract.
+   */
+  options?: never;
+  /**
+   * NOT on the static `table` surface (objectui#6425, under #5474's lockstep
+   * rule). Declared on the rich {@link TableColumn} only — the static
+   * renderer reads no field-meta overrides. Currency cells are
+   * `data-table`'s capability.
+   * @deprecated Not part of the static `table` renderer's contract.
+   */
+  currency?: never;
 }
 
 /**

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -127,6 +127,26 @@ export const TableColumnSchema = z.object({
   // declaration refused). Declared on the interface, mirrored here, and paired
   // in `__tests__/zod-mirror-parity.test.ts`.
   headerIcon: z.any().optional().describe('Icon node rendered into the header cell, before the header text'),
+  // The three field-meta override keys objectui#6425 declared (maintainer
+  // ruling 2026-08-27, per-key): honoured by `object-data-table`'s cell
+  // pipeline — documented behaviour for `format` / `options`, long-shipped
+  // for `currency` — and previously silently STRIPPED by this non-strict
+  // mirror, the same second de-facto contract #6424 closed for `headerIcon`.
+  // The pin is output SURVIVAL, not parse acceptance
+  // (static-table-narrow-surface.test.ts): acceptance was green before the
+  // declaration and cannot distinguish the fix from the defect.
+  format: z.string().optional().describe('Field-meta override: display format pattern (e.g. "$0,0", "0%", "YYYY-MM-DD")'),
+  options: z
+    .array(
+      z.object({
+        value: z.any().describe('Stored value the cell value is matched against'),
+        label: z.string().describe('Label rendered for the matched value'),
+        color: z.string().optional().describe('Badge/dot color for the matched value'),
+      }),
+    )
+    .optional()
+    .describe('Field-meta override: option list for select-flavoured columns'),
+  currency: z.string().optional().describe('Field-meta override: ISO 4217 currency code for currency-formatted cells'),
 });
 
 /**
@@ -158,6 +178,9 @@ export const StaticTableColumnSchema = z.object({
   editable: z.never().optional().describe('RETIRED (objectui#5474) — never read by the static table; use data-table'),
   cell: z.never().optional().describe('RETIRED (objectui#5474) — never read by the static table; use data-table'),
   headerIcon: z.never().optional().describe('NOT on the static table surface (objectui#6424) — declared on the rich TableColumn only; use data-table'),
+  format: z.never().optional().describe('NOT on the static table surface (objectui#6425) — declared on the rich TableColumn only; use data-table'),
+  options: z.never().optional().describe('NOT on the static table surface (objectui#6425) — declared on the rich TableColumn only; use data-table'),
+  currency: z.never().optional().describe('NOT on the static table surface (objectui#6425) — declared on the rich TableColumn only; use data-table'),
 });
 
 /**


### PR DESCRIPTION
Fixes #6425

Lands the maintainer's per-key ruling (2026-08-27, decision-inbox batch 6, 「其他同意」 accepting the post-merge per-key recommendation) on the five authored column override keys `ObjectDataTable.enrich()` reads. PR #6590 already landed the read-side keyhole (`AuthoredColumnOverrides`, per-key verdicts, derived `?: never` band); this PR is the verdict flip that keyhole was built to carry.

## Per-key disposition

| key | ruling | landed as |
|---|---|---|
| `format` | declare | `TableColumn.format?: string` + `TableColumnSchema` mirror, same stroke |
| `options` | declare | `TableColumn.options?: Array of value/label/color entries` + structured zod mirror |
| `currency` | declare | `TableColumn.currency?: string` + mirror; README now names it an author override (it was kept-but-unpromised; the PM order asked for an explicit decision — decided YES, a declared-but-undocumented key is where authors guess) |
| `decimals` | retire, immediate | hold member removed, so it falls into the derived refusal band (the held-band verdict flips to RETIRED with no hand-edit to the band); the authored read in `enrich()` is gone |
| `referenceTo` | ⛔ not declared as spelled | **left exactly as held — the remaining hold belongs to #6597 and is NOT unfinished scope here.** #6597 remains open: fix the spelling chain (consumers read `reference_to` / `reference`) or withdraw the README line. |

## Static-side decisions (the lockstep gate)

`static-table-narrow-surface.test.ts` pins `Equal` over the key sets of `StaticTableColumn` and `TableColumn`, so each declared key needed a deliberate static-side decision. All three are **tombstones** (`?: never` + `z.never().optional()`), not live: the static renderer's measured read set is exactly the five live keys (#5474), and all three new keys are field-meta overrides consumed by `object-data-table`'s cell pipeline, which the static `table` renderer does not have — implementing them there was #5474's rejected Option A. Census moves 5 live + 10 → 5 live + 13; `RETIRED_COLUMN_KEYS` and `RICH_COLUMN_KEYS` carry the three new entries.

## The zod mirror is pinned by OUTPUT SURVIVAL, not acceptance

A non-strict `z.object()` accepted all three keys before this PR and silently stripped them, so acceptance was green before the fix and cannot distinguish it from the defect. The new pin asserts the keys survive into the parsed output — `format` / `currency` by value, `options` deep-equal plus the option `value` sentinel surviving **by identity** through `z.any()` (same discipline as `editable: false` in #5821 and `headerIcon` in #6424).

## `decimals`: measured before cut, render pinned unchanged

Re-measured on this tree before removing the read: zero `.decimals` member reads across `@object-ui/fields`, `@object-ui/i18n`, `@object-ui/components`, `@object-ui/core` and `plugin-dashboard` itself (every other occurrence is a local variable parsed from a format string); positive control in the same query shape: `.scale` member reads hit. `NumberCellRenderer` reads `scale`, `PercentCellRenderer` reads `precision`. The suite's `decimals reaches NOTHING` pin renders an authored `decimals` column byte-identical to its absence — before and after the retire (see reverse verification).

## The #6004 `options` collision — resolved here under a PM fence extension (option A)

Declaring `options` on `TableColumn` silently disarmed #6004's `options`-retirement at `ObjectGrid`'s emit: that refusal rested on the key's **non-membership** (excess-property freshness refuses a key no part of the type declares), and membership arrived wholesale through `Omit of TableColumn`. Nothing went red at the moment of loss — `columnEmitBoundary-6004.test.ts:167` merely reported TS2578 (unused directive), which is luck, not design. The PM extended this claim's fence by exactly two files, and the patch round (`3f5c1bc7`) restores the enforcement while changing nothing about the verdict:

- `ObjectGridRetiredOptionsTombstone` (`options?: never`) in `ObjectGrid.tsx`, with a docblock recording the mechanism so the "redundant-looking" `never` cannot be tidied away. It is intersected into **both** `ObjectGridColumnDraft` (the type the order named) **and** the post-fold `ObjectGridColumn` — deliberately half a step past the order's letter, inside the named file: the post-fold type is the emit that actually reaches the `data-table` slot, its `options` membership arrived through the same inheritance, and tombstoning only the draft would leave the very seam #6004 ruled about re-openable by a fold-site write. Flagged here so the choice is reviewable, not silent.
- The emit-boundary pin is re-routed through a **non-fresh** source (the file's own discipline for tombstone pins), so the tombstone is the refusal's single cause, and its rationale comment records the mechanism move.

**The general rule, stated for the record: a pin enforced by a key's non-membership silently stops enforcing the moment the key becomes a member — and inherited membership (an `Omit`/extends of a published type) is where this dies silently, because someone else's declaration moves your type.** Survey of `columnEmitBoundary-6004.test.ts` for other pins on the same mechanism: **none** — `summary`/`label` rest on the derived `RetiredListColumnKey` band (assignability), the #5853 `lookup` pin on union membership; the `options` pin was the file's only freshness-based refusal, per its own former comment. Nearest relative outside the file, named for carding rather than fixed: `overrideSource-6425.test.tsx`'s `scale` pin refuses by non-membership too, but `AuthoredColumnOverrides`' membership is **curated** (an explicit `Pick` plus the holds), not inherited — a `TableColumn` declaration alone cannot silently disarm it; only a deliberate adjudication into the keyhole can, and that edit's own type-check reports the unused directive. Structurally the safer shape.

## Verification

Patch-round readings at final commit `3f5c1bc7` (clean tree; every heavy run through the shared verify lock, exits from its VERDICT line, never through a pipe); first-round readings at `c63f6913` where noted:

- Full `turbo run type-check` sweep — the control that found the collision — now **`Tasks: 81 successful, 81 total`**, all 45 package type-check tasks ran, **zero red**, wrapper `VERDICT command-exit 0`.
- Enforcement probe: a temporary non-directive probe authoring `options` on **both** emit types went red exactly as predicted — TS2322 at the probe's two lines (`…is not assignable to type 'ObjectGridColumnDraft'` / `…'ObjectGridColumn'`) — then removed with the restore proven by observation: `git diff HEAD` empty AND worktree blob == HEAD blob (`1d1bc3cb…` both sides), never by exit code.
- Union re-run on the shipped head: repo-root `pnpm exec vitest run` over types (lockstep + zod-mirror-parity), components (both data-table suites), `columnEmitBoundary-6004.test.ts`, and all of `packages/plugin-dashboard` — `Test Files  87 passed (87)` / `Tests  832 passed (832)`, `VERDICT command-exit 0`, the run itself printing `HEAD: 3f5c1bc7`.
- Changeset gates re-run after extending the changeset to `@object-ui/plugin-grid: patch`: presence (`8 source file(s) of 3 released package(s) … declares 1 changeset(s)`), no-major, overwrite — each exit 0 with its own OK line. `check:control-bytes` / `check:vi-mock-specifiers` / `check:phantom-deps` re-run — exit 0.
- First round, at `c63f6913`: `tsc --listFiles` proves the edited suites are program inputs (2 + 1 hits); full `pnpm build` 43/43 then `check:readme-exports` reporting **0 unbuilt** (population intact, NOT the collapse self-report); full `turbo run lint` 47/47 green.
- Reverse verification (first round, both committed-first, direction predicted before running, mutation proven on disk by anchored grep counts + blob-hash difference vs HEAD, restores proven by observation):
  - **Ablation A (mirror strip):** predicted exactly the survival pin and the mirror-census pin turn red while plain acceptance stays green → observed exactly those 2 failed / 26 passed. Vitest resolves these suites on SOURCE via the root alias table (`@object-ui/types/zod` → `packages/types/src/zod/index.zod.ts`), so no dist rebuild is part of either leg.
  - **Ablation B (decimals read restored):** predicted the whole suite STAYS GREEN (no reader exists; the currency positive control separates its pair in the same query shape) → observed 10/10 green. The runtime half staying green under restoration IS the render-unchanged evidence.

Changeset: `@object-ui/types` minor + `@object-ui/plugin-dashboard` patch + `@object-ui/plugin-grid` patch (no major — repo rule).

Out-of-scope finding filed: #6625 (`FieldMeta.decimals` is schema-written but read by nothing — the dead member this retire exposes; left in place because `recordFields.tsx` is outside the fence).

Draft on purpose; landing is the PM/maintainer's.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_