### PR TITLE
docs(plugin-form): document FormFieldTab.visibleWhen and its support boundary

### DIFF
--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -170,6 +170,7 @@ inactive tab unmount along with its values).
   fieldTabs: [
     { key: 'basics', label: 'Basics', fields: ['subject', 'status'] },
     { key: 'detail', label: 'Detail', description: 'Anything else', fields: ['description'] },
+    { key: 'billing', label: 'Billing', fields: ['vat_id'], visibleWhen: 'status == "won"' },
   ],
   defaultFieldTab?: 'basics',       // defaults to the first tab
   fieldTabsPosition?: 'top',        // 'top' | 'bottom' | 'left' | 'right'
@@ -183,7 +184,72 @@ inactive tab unmount along with its values).
 - Fields no tab claims render above the tab strip rather than disappearing.
 - Needs at least two tabs; ignored when the form uses `children`.
 
-`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` build on this.
+`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` build on this. Of the
+two, only `ModalForm` forwards a section's `visibleWhen` onto its tab — see the
+support table at the end of the next section.
+
+#### Conditional tabs (`FormFieldTab.visibleWhen`)
+
+A tab may carry a `visibleWhen` predicate — the same slot, vocabulary and
+engine as the field-level rule (`string | { dialect?, source }`, a CEL
+predicate over the live record, evaluated by `@objectstack/formula` with the
+host predicate scope bound, so it can read `current_user` / `app` / `data` /
+`features` exactly as a field rule can). Like every conditional rule in this
+system it **fails open**: a predicate that cannot be evaluated leaves the tab
+visible rather than hiding data behind a broken expression.
+
+When the predicate resolves FALSE the renderer draws **neither the tab's
+trigger nor its panel** — a hidden tab disappears from the tab strip entirely,
+it is not merely an empty panel.
+
+**Submit semantics are deliberately counter-intuitive — visibility gates
+drawing, and nothing else:**
+
+- **A hidden tab's values still submit.** Hiding a tab does not remove its
+  fields' values from the record: whatever they hold (loaded from the record,
+  seeded by defaults, or typed before the tab hid) is carried in the payload.
+  A visibility rule is not a data filter — dropping the values would turn a
+  cosmetic predicate into a silent data-loss door.
+- **A hidden tab's fields skip client-side validation.** A user is never
+  blocked by an error pointing at a control they cannot see. The flip side:
+  a *required* field on a hidden tab sails past the client — **the
+  server-side contract is the loud floor** for genuinely-required data, and a
+  submit missing it fails there, visibly.
+- **Stale errors clear.** A tab hiding mid-session (its predicate flipping on
+  a keystroke or a scope change) clears its fields' leftover validation
+  errors, the same hygiene a field's own `visibleWhen` applies.
+
+These are not tab-specific rules: they are the ruled hidden-group semantics
+every section `visibleWhen` follows, inherited through the same mechanism a
+field's own FALSE predicate uses (the fields simply stop being drawn; the form
+keeps their values and skips unmounted controls at validation).
+
+Two mechanics worth knowing:
+
+- **Selection is derived over the visible tabs.** If the predicate hides the
+  ACTIVE tab, the renderer re-selects deterministically — the user's own pick
+  if still visible, else `defaultFieldTab`, else the first visible tab — so
+  the form never shows an empty panel. The pick itself is kept: the tab the
+  user chose becomes active again the moment its predicate re-admits it.
+- **Whether the tabbed layout engages at all is judged on the DECLARED tabs**
+  (the "needs at least two tabs" rule above counts declarations, not
+  verdicts). A predicate hiding all but one tab filters what is drawn; it
+  never collapses the strip into the flat layout mid-interaction.
+
+**Where `visibleWhen` on a tab works today** — this key landed renderer-first,
+and only where the renderer actually evaluates it:
+
+| Authoring surface | Carries the predicate? |
+| --- | --- |
+| `type: 'form'` with `fieldTabs[].visibleWhen` (as above) | **Yes** — evaluated by the form renderer |
+| `ModalForm` / `formType: 'modal'` with `contentLayout: 'tabbed'` | **Yes** — the section's `visibleWhen` is copied onto its tab |
+| `TabbedForm` / `formType: 'tabbed'` sections | **No** — a section `visibleWhen` is dropped before the renderer sees it; the tab always renders |
+| `WizardForm` / `formType: 'wizard'` steps | **No** — steps are not tabs; nothing evaluates a step-level predicate |
+
+The two **No** rows are deliberate, not oversights: declaring the key on a
+surface whose renderer ignores it would make the metadata lie (objectui#6111),
+so the key stops at the boundary until each surface enforces it. Track
+objectui#6237 for both.
 
 ### Wizard steps and `allowSkip`
 
@@ -194,6 +260,10 @@ something is outstanding it returns the user to the first step that has one, mar
 that step's indicator (`data-error="true"`), and names the fields in a toast —
 nothing is sent. Conditional rules are respected (`visibleWhen` / `requiredWhen`
 are evaluated on the same canonical engine as the renderer and the server).
+
+Those conditional rules are the **fields'** rules. A wizard *step* carries no
+`visibleWhen` of its own today — see the support table under
+[Conditional tabs](#conditional-tabs-formfieldtabvisiblewhen).
 
 This matters because react-hook-form only validates the fields currently mounted,
 and a wizard mounts one step at a time — so a required field on a step nobody

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -367,6 +367,7 @@ the renderer distribute the fields:
   fieldTabs: [
     { key: 'basics', label: 'Basics', fields: ['subject', 'status'] },
     { key: 'detail', label: 'Detail', description: 'Anything else', fields: ['description'] },
+    { key: 'billing', label: 'Billing', fields: ['vat_id'], visibleWhen: 'status == "won"' },
   ],
   defaultFieldTab?: 'basics',                    // defaults to the first tab
   fieldTabsPosition?: 'top',                     // 'top' | 'bottom' | 'left' | 'right'
@@ -382,7 +383,72 @@ the renderer distribute the fields:
 - Fields no tab claims render above the tab strip rather than disappearing.
 - Needs at least two tabs, and is ignored when the form uses `children`.
 
-`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` are built on this.
+`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` are built on this. Of
+the two, only `ModalForm` forwards a section's `visibleWhen` onto its tab — see
+the support table below.
+
+#### Conditional tabs (`FormFieldTab.visibleWhen`)
+
+A tab may carry a `visibleWhen` predicate — the same slot, vocabulary and
+engine as the field-level rule (`string | { dialect?, source }`, a CEL
+predicate over the live record, evaluated by `@objectstack/formula` with the
+host predicate scope bound, so it can read `current_user` / `app` / `data` /
+`features` exactly as a field rule can). Like every conditional rule in this
+system it **fails open**: a predicate that cannot be evaluated leaves the tab
+visible rather than hiding data behind a broken expression.
+
+When the predicate resolves FALSE the renderer draws **neither the tab's
+trigger nor its panel** — a hidden tab disappears from the tab strip entirely,
+it is not merely an empty panel.
+
+**Submit semantics are deliberately counter-intuitive — visibility gates
+drawing, and nothing else:**
+
+- **A hidden tab's values still submit.** Hiding a tab does not remove its
+  fields' values from the record: whatever they hold (loaded from the record,
+  seeded by defaults, or typed before the tab hid) is carried in the payload.
+  A visibility rule is not a data filter — dropping the values would turn a
+  cosmetic predicate into a silent data-loss door.
+- **A hidden tab's fields skip client-side validation.** A user is never
+  blocked by an error pointing at a control they cannot see. The flip side:
+  a *required* field on a hidden tab sails past the client — **the
+  server-side contract is the loud floor** for genuinely-required data, and a
+  submit missing it fails there, visibly.
+- **Stale errors clear.** A tab hiding mid-session (its predicate flipping on
+  a keystroke or a scope change) clears its fields' leftover validation
+  errors, the same hygiene a field's own `visibleWhen` applies.
+
+These are not tab-specific rules: they are the ruled hidden-group semantics
+every section `visibleWhen` follows, inherited through the same mechanism a
+field's own FALSE predicate uses (the fields simply stop being drawn; the form
+keeps their values and skips unmounted controls at validation).
+
+Two mechanics worth knowing:
+
+- **Selection is derived over the visible tabs.** If the predicate hides the
+  ACTIVE tab, the renderer re-selects deterministically — the user's own pick
+  if still visible, else `defaultFieldTab`, else the first visible tab — so
+  the form never shows an empty panel. The pick itself is kept: the tab the
+  user chose becomes active again the moment its predicate re-admits it.
+- **Whether the tabbed layout engages at all is judged on the DECLARED tabs**
+  (the "needs at least two tabs" rule above counts declarations, not
+  verdicts). A predicate hiding all but one tab filters what is drawn; it
+  never collapses the strip into the flat layout mid-interaction.
+
+**Where `visibleWhen` on a tab works today** — this key landed renderer-first,
+and only where the renderer actually evaluates it:
+
+| Authoring surface | Carries the predicate? |
+| --- | --- |
+| `type: 'form'` with `fieldTabs[].visibleWhen` (as above) | **Yes** — evaluated by the form renderer |
+| `ModalForm` / `formType: 'modal'` with `contentLayout: 'tabbed'` | **Yes** — the section's `visibleWhen` is copied onto its tab |
+| `TabbedForm` / `formType: 'tabbed'` sections | **No** — a section `visibleWhen` is dropped before the renderer sees it; the tab always renders |
+| `WizardForm` / `formType: 'wizard'` steps | **No** — steps are not tabs; nothing evaluates a step-level predicate |
+
+The two **No** rows are deliberate, not oversights: declaring the key on a
+surface whose renderer ignores it would make the metadata lie (#6111), so the
+key stops at the boundary until each surface enforces it. Track #6237 for
+both.
 
 ### Wizard steps and `allowSkip`
 


### PR DESCRIPTION
Part of #6237 — the docs half of round 2 only. The two renderer arms (TabbedForm sections, WizardForm steps) stay open on that card pending a ruling; #6237 remains open and is deliberately not closed by this PR.

Session: session_01CRJge11jso9TpXRWFt1Z49 (durable copy — footer form degrades on edit).

## What this documents

`FormFieldTab.visibleWhen` landed in PR #6619 (renderer evaluation + ModalForm tabbed synthesis) as a published, declared key with nothing telling an author it exists. This PR adds a "Conditional tabs" subsection in TWO places — `content/docs/plugins/plugin-form.mdx`, and (second commit, PM order widening the fence by exactly this one file) its twin section in `packages/plugin-form/README.md`, which ships to npm and was documenting a feature-less version of the key:

- **What it gates**: both the tab trigger and its panel — a hidden tab leaves the strip entirely.
- **Vocabulary**: the same CEL predicate slot as field rules (string or dialect/source object), canonical engine, host predicate scope, fail-open.
- **The ruled submit semantics** (maintainer, 2026-08-27), stated loudly because they are counter-intuitive: a hidden tab's values still submit; its fields skip client-side validation; the server-side contract is the loud floor; stale errors clear on a verdict flip.
- **Selection and engagement mechanics**: derived re-selection over visible tabs; engagement judged on DECLARED tabs.
- **A support table naming which authoring surfaces carry the predicate today** — `fieldTabs` and ModalForm's tabbed contentLayout: Yes; TabbedForm sections and WizardForm steps: No, deliberately (objectui#6111), until each surface enforces it. Both copies carry the No rows. The content/docs wizard section also gains one sentence making explicit that its "conditional rules are respected" claim is about the FIELDS' rules, not a step-level predicate.

The two No rows are the guard this card family exists for: both pages now state the boundary instead of letting a reader infer that a section predicate works in every layout.

## Verification (at 10c73cf9, the head of this branch — two commits, clean tree; every verdict below re-run at this head)

- `check:doc-fences` — exit 0, own verdict: "every TypeScript block in 223 document(s) is fenced ts/tsx/typescript … No unknown fence spelling hides one."
- `check:doc-types` — exit 0, own verdict: "Every documented component type is registered."
- `docs:check-links` — exit 0, "Links are valid across 17 scan roots." That gate strips fragments (anchors out of its scope, stated at scripts/check-doc-links.mjs:800-832), so the one intra-page anchor (content/docs only; the README mirror adds no links) was verified against the repo's own github-slugger@2.0.0: computed slug `conditional-tabs-formfieldtabvisiblewhen` is byte-identical to the link written.
- `check:doc-snippets` — NOT run locally (needs the 21-package built dist closure); declared narrowing: its population is ts/tsx/typescript fence bodies of COVERED documents. The content/docs diff adds/removes zero fence lines (`git diff 38a123cac..HEAD -- content/docs/ | grep -c '^[+-]```'` reads 0; positive control in the same query shape reads 2 on fence-touching commits 7fdf74eb and 546ddf77). The README's one in-fence line lands in `packages/plugin-form/README.md`, which is declared UNGATED in the gate's own ledger (stale-entry rules fire only on file-missing or no-ts-blocks, neither moved). CI's doc-snippet-types.yml builds and runs the real thing.
- `check:readme-exports` — NOT MEASURED locally: exit 1 with every finding "type entry ./dist/index.d.ts is not on disk — run pnpm build first" across 36 unbuilt packages (378 self-imports unjudgeable, tree-state, none a verdict about this diff). This diff cannot move it: the README edit adds ZERO import lines (`git show 10c73cf9 -- packages/plugin-form/README.md | grep -c '^+.*import'` reads 0; positive control: commit 062943f8 reads 10 in the same query shape), and all 54 pre-existing plugin-form rows are the same unbuilt-dist class. CI builds before judging.
- `check:changeset-presence` — exit 0 at the new head, own verdict: "No source of a released package changed in this range, so no changeset is owed." (2 files changed, 0 published source; README is not under src/.)
- `check:control-bytes` — exit 0, "OK (scanned 5485 tracked text file(s))."
- Vitest, repo-root invocation (root config, invocation guard active): at eeaa6f1b the content/docs reader set ran green — `Test Files 129 passed (129)`, `Tests 4568 passed (4568)`. At 10c73cf9 the README-reader superset (all of scripts/ plus every test file outside it whose text mentions README — 30 files, grep-enumerated over every test glob) is queued behind a long-running full-suite holder on the shared verify lock; its verdict lands in the report on #6237 (the report-at-draft protocol: gate states are recorded honestly, `in_progress` included). Narrowing rationale unchanged: the diff is two documentation files no package source imports; CI shards run the whole repo on this PR.

## Reported on the card

The read-only measurement of the TabbedForm and WizardForm arms (the other half of this round's scope) is posted as the structured report on #6237 — evidence for the ruling those arms wait on. Q1/Q2 from that report are with the decision box; nothing from either is implemented here.

_Generated by [Claude Code](https://claude.ai/code)_