### PR TITLE
test(core): drop the 10 redundant `$filter` casts in ValueDataSource.test.ts

### DIFF
--- a/.changeset/6001-drop-redundant-filter-casts.md
+++ b/.changeset/6001-drop-redundant-filter-casts.md
@@ -1,0 +1,28 @@
+---
+---
+
+Test-only change; nothing published changes. `ValueDataSource.test.ts` drops the ten
+`as any` casts on its AST-array `$filter` fixtures
+(`packages/core/src/adapters/__tests__/ValueDataSource.test.ts`, objectui#6001).
+
+The casts were written when `QueryParams.$filter` was declared as the MongoDB-style
+record alone, so an author writing an ObjectQL AST array had to push the type out of the
+way. objectui#3909 / PR objectui#5999 replaced that declaration with the union the data
+sources always accepted, and all ten literals — the nine AST shapes plus the degenerate
+empty array — now assign bare. No replacement assertion, no widening, no helper, and no
+runtime assertion touched: `pnpm --filter @object-ui/core type-check` is green.
+
+One claim on the card did **not** survive measurement, and the correction is worth
+keeping. The card justified the deletion partly by predicting that the un-cast fixtures
+would become compile-time evidence — that narrowing `$filter` back to the record form
+would turn this file red. It does not. Dropping the `| FilterArray` arm locally,
+rebuilding `@object-ui/types` so the change reached the `dist/data.d.ts` that
+`packages/core/tsconfig.test.json` actually resolves, and re-running the type-check
+leaves the file green with zero errors — exactly as PR objectui#5999's own doc comment
+says it must, since `Record<string, any>` already accepts arrays structurally. A positive
+control under the identical mutation (a slot that genuinely excludes arrays) does turn
+these ten lines red, so the zero is a measurement rather than a blind apparatus.
+
+The deletion is therefore worth making for the smaller, true reason: `as any` at a site
+where the value is already legal is a no-op that reads as a live constraint, and a reader
+who trusts it concludes the array form is illegal here.

--- a/packages/core/src/adapters/__tests__/ValueDataSource.test.ts
+++ b/packages/core/src/adapters/__tests__/ValueDataSource.test.ts
@@ -165,7 +165,7 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with simple AST equality condition', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['role', '=', 'admin'] as any,
+      $filter: ['role', '=', 'admin'],
     });
     expect(result.data).toHaveLength(2);
     expect(result.data.every((r: any) => r.role === 'admin')).toBe(true);
@@ -174,7 +174,7 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with AST "in" operator', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['role', 'in', ['admin', 'guest']] as any,
+      $filter: ['role', 'in', ['admin', 'guest']],
     });
     expect(result.data).toHaveLength(3);
   });
@@ -182,7 +182,7 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with AST "and" logical operator', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['and', ['role', '=', 'admin'], ['age', '>', 30]] as any,
+      $filter: ['and', ['role', '=', 'admin'], ['age', '>', 30]],
     });
     expect(result.data).toHaveLength(1);
     expect(result.data[0].name).toBe('Charlie');
@@ -191,7 +191,7 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with AST "or" logical operator', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['or', ['role', '=', 'guest'], ['name', '=', 'Alice']] as any,
+      $filter: ['or', ['role', '=', 'guest'], ['name', '=', 'Alice']],
     });
     expect(result.data).toHaveLength(2);
   });
@@ -199,7 +199,7 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with AST "!=" operator', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['role', '!=', 'admin'] as any,
+      $filter: ['role', '!=', 'admin'],
     });
     expect(result.data).toHaveLength(3);
   });
@@ -207,7 +207,7 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with AST "not in" operator', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['role', 'not in', ['admin', 'guest']] as any,
+      $filter: ['role', 'not in', ['admin', 'guest']],
     });
     expect(result.data).toHaveLength(2);
     expect(result.data.every((r: any) => r.role === 'user')).toBe(true);
@@ -216,7 +216,7 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with AST "contains" operator', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['name', 'contains', 'li'] as any,
+      $filter: ['name', 'contains', 'li'],
     });
     expect(result.data).toHaveLength(2); // Alice, Charlie
   });
@@ -224,21 +224,21 @@ describe('ValueDataSource — AST filter', () => {
   it('should filter with nested AST (and with in operator)', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['and', ['role', 'in', ['admin', 'user']], ['age', '>=', 28]] as any,
+      $filter: ['and', ['role', 'in', ['admin', 'user']], ['age', '>=', 28]],
     });
     expect(result.data).toHaveLength(3); // Alice (30, admin), Charlie (35, admin), Diana (28, user)
   });
 
   it('should return all items with empty AST filter', async () => {
     const ds = createDS();
-    const result = await ds.find('users', { $filter: [] as any });
+    const result = await ds.find('users', { $filter: [] });
     expect(result.data).toHaveLength(5);
   });
 
   it('should combine AST filter with sort', async () => {
     const ds = createDS();
     const result = await ds.find('users', {
-      $filter: ['role', '=', 'admin'] as any,
+      $filter: ['role', '=', 'admin'],
       $orderby: { age: 'asc' },
     });
     expect(result.data).toHaveLength(2);


### PR DESCRIPTION
Fixes #6001

Deletes the ten `as any` casts on the AST-array `$filter` fixtures in
`packages/core/src/adapters/__tests__/ValueDataSource.test.ts` — lines 168, 177, 185,
194, 202, 210, 219, 227, 234, 241. Nothing is substituted for them: no replacement
assertion, no widened type, no helper, no `??` fallback, and no runtime assertion
touched. The values were already legal, so they are written bare.

The casts date from when `QueryParams.$filter` was declared as the MongoDB-style record
alone, so an author writing an ObjectQL AST array had to push the type out of the way.
#3909 / PR #5999 replaced that declaration with the union the data sources always
accepted, and all ten literals now assign bare — the nine AST shapes plus the degenerate
empty array at line 234, which was the one flagged as most likely to resist. It did not
resist; every cast came off.

Anchored grep in that one file: **10** occurrences of a `$filter` line carrying `as any`
before, **0** after. The eleven other `as any` in the file are unrelated record-shape
assertions and are untouched.

## The card's second claim did not survive measurement, and this PR does not repeat it

#6001 justified the deletion partly by predicting that the un-cast fixtures would become
compile-time evidence — that if someone narrowed the slot back to the record form, this
file would turn red. **That is false, and it was measured rather than assumed.**

The probe was local, uncommitted and proven-restored; `packages/types/` appears in no
commit on this branch.

- **Mutation** — dropped the `| FilterArray` arm in `packages/types/src/data.ts`, leaving
  the record form alone. Proven on disk, not by an exit code: the anchored grep for the
  union spelling went 1 to 0 and the narrowed spelling 0 to 1, and the source blob hash
  moved `21899561` to `f9f82421`.
- **Rebuild, which the probe is worthless without** — `packages/core/tsconfig.test.json`
  deliberately sets empty `paths`, so `@object-ui/types` resolves through the workspace
  package's built declarations, not its sources. `--listFiles` confirms the program reads
  `packages/types/dist/data.d.ts`. Mutating the source alone would have changed nothing
  the checker sees and returned a green that meant nothing, so `@object-ui/types` was
  rebuilt and the emitted declaration was checked too: `dist/data.d.ts` blob hash moved
  `eeaf49dc` to `3536a047`, with the same 1-to-0 / 0-to-1 flip.
- **Result** — `pnpm --filter @object-ui/core type-check` exits **0** under the
  narrowing. Zero errors in the program, zero mentioning `ValueDataSource.test.ts`. The
  file does **not** go red.
- **Restore, proven by observation** — source and `dist` blob hashes both back to their
  originals, `git diff HEAD` empty, `git status --short` empty.

This is exactly what PR #5999's own doc comment in `data.ts` states as a measurement:
`Record< string, any >` already accepts arrays structurally, since they satisfy its
string index, so the union documents shapes that were always legal rather than admitting
new ones. The corollary the card missed is that these casts were removable **before**
#3909 ever landed; the `Blocked-by` was never real.

### The zero has a positive control

A zero from a checker that cannot see the expressions is not a green, so the same probe
shape was run with a narrowing that genuinely excludes arrays —
`Record< string, any > & { length?: undefined }`, which rejects every array while leaving
the record-form fixtures in the same file untouched. Under it, `tsc -p tsconfig.test.json`
exits 2 and reports **10 errors at exactly lines 168, 177, 185, 194, 202, 210, 219, 227,
234, 241**:

```
src/adapters/__tests__/ValueDataSource.test.ts(168,7): error TS2322: Type 'string[]' is not assignable ...
src/adapters/__tests__/ValueDataSource.test.ts(234,45): error TS2322: Type 'never[]' is not assignable ...
```

So the apparatus does see these ten expressions and can report on them. The zero above is
a measurement, not blindness. (This control leg was run through the test project directly
rather than the chained `type-check` script, so an early failure in the first program
could not short-circuit the `&&` and hide the result.)

### What that leaves as the reason to merge

The casts are genuinely redundant, and removing them deletes a **misleading no-op**: an
`as any` at a site where the value is already legal reads as a live constraint, and a
reader who trusts it concludes the array form is illegal here — which is how the tolerant
consumer AGENTS.md #0.1 forbids gets written in the first place. That is worth doing on
its own. What it is *not* is a new compile-time witness, and the changeset says so too,
so the next reader does not re-derive the wrong lesson.

## Verification

- `pnpm --filter @object-ui/core type-check` — **exit 0**, both programs
  (`tsc --noEmit && tsc -p tsconfig.test.json`), with no replacement cast anywhere.
- `pnpm exec vitest run packages/core/src/adapters/__tests__/ValueDataSource.test.ts`
  from the repository root — **Test Files 1 passed (1), Tests 56 passed (56)**. The
  runtime assertions are untouched and still pass. (The package-scoped form was rejected
  by this repo's own vitest guard as a known false-green; the root form is the sanctioned
  one.)
- `node scripts/check-changeset-presence.mjs` — ruled that a declaration is owed
  (**exit 1**, naming this file), and the empty-frontmatter exemption it documents for a
  test-only change answers it (**exit 0**). The gate decided this, it was not pre-empted
  in either direction. `check-changeset-no-major`, `check-changeset-overwrite` and
  `check-control-bytes` all exit 0.
- Every gate result quoted above is that gate's own printed verdict line with its exit
  status captured before any pipe.

**Declared narrowing.** The lint evidence is a targeted run, not the repo-wide farm, and
the three measurements that make the narrowing a measurement rather than an omission:
the population is **3873** files, read from ESLint's own ignore resolution over tracked
sources rather than from a guess; the targeted run linted **1** file, counted from
`--format json` (0 errors, 36 pre-existing `no-explicit-any` warnings, 10 fewer than
before this change); and `eslint.config.js` configures no `parserOptions.project` and no
`projectService`, so type-aware linting is off and a change confined to one file's
expressions cannot move the verdict on any untouched file. CI runs the full farm.

**Lock disclosure.** The heavy half — the `@object-ui/types` build, the full
`@object-ui/core type-check` and the `--listFiles` program dump — ran under the shared
verify lock, holding it 56s. The remaining single-file test run and the single-project
control were run off the lock after three consecutive `exit 99` queue timeouts over
roughly 30 minutes behind a multi-shard `pnpm test` holder, as a declared narrowing.

**Draft on purpose.** Not ready, not enqueued, not merged.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_