### PR TITLE
docs(app-shell): describe the record-title ladder InterfaceListPage's map prose actually has

### DIFF
--- a/.changeset/6572-interfacelistpage-titlefield-prose.md
+++ b/.changeset/6572-interfacelistpage-titlefield-prose.md
@@ -1,0 +1,11 @@
+---
+---
+
+Comment-only: `InterfaceListPage`'s marker-title docblocks described the
+`getRecordDisplayName` precedence ladder as containing an object-level
+`titleField` rung. That rung was a second `??` leg inside step 0 and was deleted
+in objectui#6531 (`@objectstack/spec`'s object schema is a `strictObject` that
+rejects the key with `unrecognized_keys`), so the prose now names the rungs the
+resolver actually has: `options.titleField` at step 0, the declared `nameField`
+and its `displayNameField` alias at 1/2, the legacy `titleFormat` template at 3,
+and the type-aware derivation at 4. No published behaviour changes.

--- a/packages/app-shell/src/views/InterfaceListPage.mapConfig.test.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.mapConfig.test.tsx
@@ -178,13 +178,22 @@ describe('InterfaceListPage forwards the view-level `map` block (objectui#5042)'
  *
  * What was left behind was not a redundancy but an INVERSION. The binding
  * arrives at the resolver as `options.titleField`, which is precedence **step
- * 0** — ahead of `objectDef.titleField`, ahead of the declared `nameField`
- * pointer, and ahead of the legacy `titleFormat` template at step 3. Measured
- * against the resolver's ladder, a field name this page picked can only ever
- * change the answer by OUT-RANKING something the object itself declared; in
- * every other case it reproduces, at step 0, the string the resolver already
- * computes at step 1/2/4. That is the whole of its effect, which is why it
- * goes rather than gets described.
+ * 0** — ahead of the declared `nameField` pointer and its `displayNameField`
+ * alias at step 1/2, ahead of the legacy `titleFormat` template at step 3, and
+ * ahead of the type-aware derivation from `objectDef.fields` at step 4.
+ * Measured against the resolver's ladder, a field name this page picked can
+ * only ever change the answer by OUT-RANKING something the object itself
+ * declared; in every other case it reproduces, at step 0, the string the
+ * resolver already computes at step 1/2/4. That is the whole of its effect,
+ * which is why it goes rather than gets described.
+ *
+ * The ladder carries NO object-level `titleField` rung — the middle term this
+ * passage used to name. It was never a step of its own: it was a second `??`
+ * leg inside step 0, deleted in objectui#6531 because `@objectstack/spec`'s
+ * object schema is a `strictObject` that REJECTS the key with
+ * `unrecognized_keys` — the same issue code a nonsense key gets — so no
+ * spec-compliant object could ever supply it. See the `getRecordDisplayName`
+ * docblock in `@object-ui/core`'s `record-title.ts` for the ladder in full.
  *
  * These arms pin both halves: the product no longer carries a title binding
  * (shape), and the declared side therefore decides at the read site

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -204,14 +204,25 @@ export function defaultGanttFromObject(objectDef: any): { startDateField: string
  *
  * What the binding left behind once the forge was gone was not redundancy but
  * an INVERSION. It reaches the resolver as `options.titleField`, which is
- * precedence **step 0** — ahead of `objectDef.titleField`, ahead of the
- * declared `nameField` pointer (step 1/2), and ahead of the legacy
- * `titleFormat` template (step 3). Measured against that ladder, a field name
+ * precedence **step 0** — ahead of every OBJECT-level rung beneath it: the
+ * declared `nameField` pointer and its `displayNameField` alias (step 1/2),
+ * the legacy `titleFormat` template (step 3), and the type-aware derivation
+ * from `objectDef.fields` (step 4). Measured against that ladder, a field name
  * derived HERE can only ever change the answer by out-ranking something the
  * object itself declared; in every other case it reproduces, at step 0, the
  * string the resolver already computes further down. So the binding's entire
  * live effect was to let a per-view guess outrank declared metadata — the
  * governed-authority default says the declared side wins, and it now does.
+ *
+ * That ladder has NO object-level `titleField` rung — the middle term this
+ * passage used to name. It was never a step of its own: it was a second `??`
+ * leg inside step 0, deleted in objectui#6531 because `@objectstack/spec`'s
+ * object schema is a `strictObject` that REJECTS the key with
+ * `unrecognized_keys` — the same issue code a nonsense key gets — so no
+ * spec-compliant object metadata can ever supply it. Step 0 is
+ * `options.titleField` alone, and the OBJECT-level ladder starts at the
+ * declared `nameField` — see the `getRecordDisplayName` docblock in
+ * `@object-ui/core`'s `record-title.ts`.
  *
  * The async window `ObjectMap` has before its `getObjectSchema` fetch lands is
  * NOT an argument for keeping a static binding here: `ObjectKanban` fetches its


### PR DESCRIPTION
Fixes #6572

Prose only. The two marker-title docblocks in `packages/app-shell` taught the
`getRecordDisplayName` precedence ladder as containing an object-level
`titleField` rung between step 0 and the declared pointer. No such rung exists,
and the key it named is one `@objectstack/spec`'s object schema rejects
outright — a `strictObject`, so it comes back `unrecognized_keys`, the same
issue code a nonsense key gets.

## Why the passages were wrong

The rung was never a step of its own: it was a second `??` leg inside step 0 of
`getRecordDisplayName`, deleted in objectui#6531. `packages/core/src/utils/record-title.ts`
says so at the read site — "An object-level ... used to be consulted here too,
as a second `??` leg. Removed in objectui#6531".

Left standing, the prose invites precisely the two moves the finding named: a
consumer-side read-back of an undeclared key (the Commandment #0.1 shape), or a
fixture carrying a key the spec refuses.

## The ladder as it actually is

Read off the `getRecordDisplayName` docblock and its branches on the merged ref,
not off this card's prediction:

| step | rung |
| --- | --- |
| 0 | `options.titleField` — the caller's declared view-level pointer |
| 1 | `objectDef.nameField` — canonical (ADR-0079) |
| 2 | `objectDef.displayNameField` / `NAME_FIELD_KEY` — deprecated alias |
| 3 | `objectDef.titleFormat` — legacy render-only template |
| 4 | type-aware derivation from `objectDef.fields` |
| 5 | `Record #id` floor |

## The corrected passages

`InterfaceListPage.tsx` — the enumeration now names the rungs step 0 outranks,
and a note records what the middle term was:

> precedence **step 0** — ahead of every OBJECT-level rung beneath it: the
> declared `nameField` pointer and its `displayNameField` alias (step 1/2), the
> legacy `titleFormat` template (step 3), and the type-aware derivation from
> `objectDef.fields` (step 4).
>
> That ladder has NO object-level `titleField` rung — the middle term this
> passage used to name. It was never a step of its own: it was a second `??`
> leg inside step 0, deleted in objectui#6531 ...

`InterfaceListPage.mapConfig.test.tsx` carries the same correction in its own
voice. Its "reproduces, at step 0, the string the resolver already computes at
step 1/2/4" is deliberately left skipping step 3: a rendered template is not a
plain field read, so it is not a string step 0 can reproduce.

Each passage's actual argument is untouched — a derived marker title arriving as
`options.titleField` is an INVERSION because step 0 outranks everything the
object declared. Only the ladder it measures against is corrected.

## Verification

**Anchored grep, with a positive control so the zero is a measurement.** Same
grep shape (`grep -cF`), same two files:

| term | before | after |
| --- | --- | --- |
| `objectDef` + `.titleField` (target) | 1 + 1 | **0 + 0** |
| `options.titleField` (control, still present) | 1 + 3 | 2 + 3 |
| `objectDef.fields` (control, same dotted shape) | 1 + 0 | 2 + 1 |

The controls match on the post-change files, so the pattern shape is live and
the zero is an absence rather than a broken pattern.

**The touched test file, logic untouched** — from the repo root, per AGENTS.md:

```
pnpm exec vitest run packages/app-shell/src/views/InterfaceListPage.mapConfig.test.tsx
   Test Files  1 passed (1)
        Tests  9 passed (9)
```

9 passing matches the file's 9 `it(` blocks, and the file imports
`InterfaceListPage` directly — so both edited files were parsed and transformed
in that green run.

**Comment-only, proven mechanically rather than asserted.** Both files parsed
with the TypeScript compiler and their leaf token streams compared against the
merge-base with every JSDoc subtree dropped:

```
InterfaceListPage.tsx             code leaves BASE=3380 HEAD=3380, divergent 0
InterfaceListPage.mapConfig.test  code leaves BASE=1300 HEAD=1300, divergent 0
syntactic diagnostics: 0 in both
CONTROL (one identifier changed in memory): divergent 1 -> detector WORKS
```

The executable code is identical to the merge-base, so the type graph is too.

**Lint.** `eslint` on both files: **0 errors**, 39 + 9 warnings — byte-identical
counts to the same two files at the merge-base (measured by restoring the base
content, re-linting, then restoring `HEAD`). CI's lint workflow deliberately
sets no `--max-warnings`, so errors are the gating number.

Scope narrowed deliberately and declared: the full `@object-ui/app-shell`
`type-check` needs a 26-package dependency-closure build, which the token-stream
result above makes redundant for a change that alters no code token. CI runs the
farm regardless.

**Changeset** — not pre-empted in either direction. `check-changeset-presence.mjs`
was run first and demanded one, naming the empty-frontmatter declaration as the
explicit pass for a change that releases nothing; it now reports
`Every one of them has an EMPTY frontmatter — declared as releasing nothing`.
`check-changeset-no-major.mjs` green.

All measurements above were taken on `558ac4bd`, the branch head.

_Generated by [Claude Code](https://claude.ai/code/session_8ca04858-ea8e-5b85-9182-de59aa49e00c)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_