### PR TITLE
docs(types): record that `field` is excluded from the form-field pin ON PURPOSE

### DIFF
--- a/.changeset/6609-declared-keys-header-honesty.md
+++ b/.changeset/6609-declared-keys-header-honesty.md
@@ -1,0 +1,22 @@
+---
+---
+
+Comment-only truthfulness fix in `@object-ui/types`; no published behaviour changes, no
+schema change, no test-logic change.
+
+`packages/types/src/__tests__/form-field-zod-coverage.test.ts` introduced its pinned key
+list as "Every key `FormField` (../form.ts) declares by name". The interface declares one
+key the list deliberately omits — `field`, the resolved object-field metadata stash
+(objectui#3090) — so the sentence overclaimed, and the pin's own rule ("any schema edit
+must touch the list here in the same PR") read as an invitation to close the gap by adding
+`field` to `DECLARED_KEYS` and to `FormFieldSchema`. Doing that would make
+`objectui validate` accept and type a runtime-only stash on authored documents,
+re-opening the spec-vocabulary pun objectui#3090 closed at the `normalizeSectionField`
+chokepoint — a contract widening arriving disguised as housekeeping.
+
+The list header now says what the list is (the AUTHORABLE key surface) and records the
+exclusion as deliberate, with the reason: the stash is runtime-only, and the same key
+name in the authored spec form-view vocabulary is a string naming the referenced object
+field. The `FormFieldSchema` doc comment in `packages/types/src/zod/form.zod.ts` carried
+the same "keys mirror the interface" overclaim and is corrected the same way
+(objectui#6609).

--- a/packages/types/src/__tests__/form-field-zod-coverage.test.ts
+++ b/packages/types/src/__tests__/form-field-zod-coverage.test.ts
@@ -22,13 +22,36 @@
  * objectstack#4075 mechanism — see check-spec-symbol-derivation.mjs, lie #3).
  * A set-coverage assertion is the #3017 fallback for exactly this case: the
  * zod side stays deliberate and reviewed, and any schema edit must touch the
- * list here in the same PR.
+ * list here in the same PR. That list is the AUTHORABLE key surface, not every
+ * key the interface declares — one declared key sits outside it on purpose, for
+ * the reason its own note records (objectui#6609).
  */
 
 import { describe, it, expect } from 'vitest';
 import { FieldConstraintsSchema, FormFieldSchema } from '../zod/form.zod.js';
 
-/** Every key `FormField` (../form.ts) declares by name, in declaration order. */
+/**
+ * The AUTHORABLE key surface of `FormField` (../form.ts) — the keys a DOCUMENT
+ * may itself carry, and so the keys `objectui validate` parses through this
+ * schema. Ordered to follow the interface loosely, as a reading aid only: the
+ * assertion sorts both sides, so the order here carries no claim (`visibleOn`
+ * precedes `hidden`/`readonly` in the interface and follows them here).
+ *
+ * ⚠️ NOT "every key the interface declares by name", and the gap is DELIBERATE.
+ * `FormField` also declares `field` — the resolved object-field metadata stash
+ * (#3090), which the object-bound form paths fill at RUNTIME with a
+ * server-served field definition so widgets can read `precision`, `currency`,
+ * `reference_to`, … No document ever writes it. And on the SPEC form-view side
+ * — the other authoring surface, the one #3090 keeps separate — that same key
+ * name means something else entirely: a STRING naming the referenced object
+ * field. Admitting `field` here and to `FormFieldSchema` would therefore make
+ * `objectui validate` accept and type a runtime-only stash on authored
+ * documents, re-opening the exact spec-vocabulary pun #3090 closed at the
+ * `normalizeSectionField` chokepoint. The refusal is pinned below by the
+ * `still rejects the SPEC form-field vocabulary` case: `{ field: 'email' }`
+ * must not parse. So a `field` entry here is a contract widening to be ruled
+ * on — never housekeeping that restores consistency (objectui#6609).
+ */
 const DECLARED_KEYS = [
   'id',
   'name',

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -444,11 +444,17 @@ export const CommandSchema = BaseSchema.extend({
  * different layers, and `normalizeSectionField` in `@object-ui/plugin-form` is
  * the translation chokepoint between them (#3090).
  *
- * Keys mirror the `FormField` interface in `../form.ts`. Until #3090 this
- * schema validated only 13 of the interface's declared keys and *required*
- * `type` (the interface says optional) — so `objectui validate` silently
- * ignored typos in `visibleWhen`/`widget`/`dependsOn`/… (strip mode) and
- * rejected metadata the renderer accepts. The pinned key list lives in
+ * Keys mirror the AUTHORABLE surface of the `FormField` interface in
+ * `../form.ts` — not every key that interface declares. `FormField.field` (the
+ * resolved object-field metadata stash) is runtime-only and stays OUT of this
+ * schema on purpose: in the authored vocabulary that same key name carries a
+ * different meaning — a string naming the referenced object field — so
+ * validating it here would re-open the pun #3090 closed (objectui#6609).
+ *
+ * Until #3090 this schema validated only 13 of the interface's declared keys
+ * and *required* `type` (the interface says optional) — so `objectui validate`
+ * silently ignored typos in `visibleWhen`/`widget`/`dependsOn`/… (strip mode)
+ * and rejected metadata the renderer accepts. The pinned key list lives in
  * `__tests__/form-field-zod-coverage.test.ts`.
  */
 /**


### PR DESCRIPTION
Fixes #6609

Prose only. No schema change, no test-logic change, no behaviour change — every changed line in both source files is a comment line (proof below).

## The fence, honoured

⛔ `field` was **not** added to `DECLARED_KEYS` and **not** added to `FormFieldSchema`, and the new prose exists specifically to stop a future reader from doing it. The pin's own rule — "any schema edit must touch the list here in the same PR" — read as an invitation to close the discrepancy in the wrong direction; admitting `field` would make `objectui validate` accept and type a runtime-only stash on authored documents, re-opening the spec-vocabulary pun objectui#3090 closed at the `normalizeSectionField` chokepoint. The header now names that outcome so the widening cannot arrive disguised as housekeeping.

No fork to report: the schema should not carry `field`, and nothing in the merged tree argued otherwise.

## Premise re-verified on the merged tree

Branched from `origin/main` at `4de9110c1` — after objectui#6236 landed, so `fields` **is** in the list (line 79) and the card's quoted measurement is superseded. What was **not** already corrected is the header sentence itself: on `4de9110c1` it still read, verbatim,

```
/** Every key `FormField` (../form.ts) declares by name, in declaration order. */
```

and `packages/types/src/form.ts` still declares `field?: Record(string, any)` on `FormField` (the resolved object-field metadata stash, objectui#3090). So the overclaim was live and the card's premise holds.

Two further inaccuracies in that one sentence, found while correcting it and neutralised rather than restated:

1. "in declaration order" was also false — `visibleOn` precedes `hidden`/`readonly` in the interface and follows them in the list. The replacement states the order is a reading aid and that the assertion sorts both sides.
2. The `FormFieldSchema` doc comment in `packages/types/src/zod/form.zod.ts` carried the same overclaim one layer over ("Keys mirror the `FormField` interface in `../form.ts`"). Corrected the same way — the card's optional half.

## The corrected header, next to the list it describes

```ts
/**
 * The AUTHORABLE key surface of `FormField` (../form.ts) — the keys a DOCUMENT
 * may itself carry, and so the keys `objectui validate` parses through this
 * schema. Ordered to follow the interface loosely, as a reading aid only: the
 * assertion sorts both sides, so the order here carries no claim (`visibleOn`
 * precedes `hidden`/`readonly` in the interface and follows them here).
 *
 * ⚠️ NOT "every key the interface declares by name", and the gap is DELIBERATE.
 * `FormField` also declares `field` — the resolved object-field metadata stash
 * (#3090), which the object-bound form paths fill at RUNTIME with a
 * server-served field definition so widgets can read `precision`, `currency`,
 * `reference_to`, … No document ever writes it. And on the SPEC form-view side
 * — the other authoring surface, the one #3090 keeps separate — that same key
 * name means something else entirely: a STRING naming the referenced object
 * field. Admitting `field` here and to `FormFieldSchema` would therefore make
 * `objectui validate` accept and type a runtime-only stash on authored
 * documents, re-opening the exact spec-vocabulary pun #3090 closed at the
 * `normalizeSectionField` chokepoint. The refusal is pinned below by the
 * `still rejects the SPEC form-field vocabulary` case: `{ field: 'email' }`
 * must not parse. So a `field` entry here is a contract widening to be ruled
 * on — never housekeeping that restores consistency (objectui#6609).
 */
const DECLARED_KEYS = [
  'id',
  'name',
  'label',
  'description',
  'type',
  'inputType',
  'required',
  'disabled',
  'placeholder',
  'options',
  'validation',
  'condition',
  'widget',
  'dependsOn',
  'hidden',
  'readonly',
  'visibleOn',
  'visibleWhen',
  'readonlyWhen',
  'requiredWhen',
  'colSpan',
  'span',
  // objectui#6236 — the section grouping claim (section-divider rows only).
  'fields',
];
```

The file-level docblock's rule sentence gained the matching clause, since that is the sentence that does the inviting:

```
 * list here in the same PR. That list is the AUTHORABLE key surface, not every
 * key the interface declares — one declared key sits outside it on purpose, for
 * the reason its own note records (objectui#6609).
```

## Anchored proof that `field` was NOT added

Each zero is paired with a positive control in the **same query shape**, so it reads as an absence rather than a broken pattern. Run on `dc44f49d`:

```
A1 probe   grep -c "^  'field',$"  ...form-field-zod-coverage.test.ts   -> 0
A2 control grep -c "^  'fields',$" ...form-field-zod-coverage.test.ts   -> 1  (line 79)
A3 control grep -c "^  'span',$"   ...form-field-zod-coverage.test.ts   -> 1  (line 77)

B1 probe   '^  field:'  in the FormFieldSchema z.object body  -> 0
B2 control '^  fields:' in the FormFieldSchema z.object body  -> 1
B3 control '^  span:'   in the FormFieldSchema z.object body  -> 1

B4 every 'field:' token at ANY depth in that body:
   19:      z.object({ field: z.string(), param: z.string().optional() }),
```

B4 is the one hit, and it is pre-existing and unrelated: the lookup-parameter entry nested inside `dependsOn`, not a top-level schema key.

Logic untouched, measured the same way — for each source file, every added/removed line stripped of leading whitespace, counting the ones that are **not** comment lines:

```
packages/types/src/__tests__/form-field-zod-coverage.test.ts: 0
packages/types/src/zod/form.zod.ts: 0
```

## Changeset

The `Changeset Declaration` gate ruled, and it was allowed to rule rather than pre-empted. Both source files live under `packages/types/src/`, which the gate guards wholesale, so it failed with "2 source file(s) of 1 released package(s) changed, and this change adds no changeset". The answer it prescribes for a change that releases nothing is an **empty-frontmatter** changeset, which is what `.changeset/6609-declared-keys-header-honesty.md` carries. Re-run verdict:

```
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/6609-declared-keys-header-honesty.md.
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

## Verification — all on `dc44f49d`, the final commit

| check | verdict line |
|---|---|
| `pnpm exec vitest run packages/types/` | `Test Files 65 passed (65)` / `Tests 772 passed (772)` — includes the pin file, logic untouched |
| pin file alone | `Test Files 1 passed (1)` / `Tests 11 passed (11)` |
| `pnpm --filter @object-ui/types run type-check` | exit 0 (`tsc --noEmit` + `tsconfig.examples.json` + `tsconfig.test.json`) |
| `pnpm --filter @object-ui/types run lint` | `✖ 247 problems (0 errors, 247 warnings)`, exit 0 — all warnings pre-existing `no-explicit-any` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 5487 tracked text file(s); skipped 85 binary).` |
| `pnpm check:spec-symbols` | `✅ spec symbol derivation: 1315 files scanned against 4959 spec export names` |
| `node scripts/check-changeset-presence.mjs` | `✅ … declares 1 changeset(s)` |
| `pnpm changeset:check` | `✅ No changeset declares a major bump.` |
| `node scripts/check-changeset-overwrite.mjs` | `✅ No pre-existing changeset was modified or deleted.` |

The typecheck claim was itself checked rather than assumed: `tsc -p tsconfig.test.json --listFiles` lists the edited test file (1 hit) and the main project lists the edited zod file (1 hit), so "typecheck clean" actually covers both edits.

The pin test was first run through `pnpm --filter @object-ui/types exec vitest`, which this repo's vitest guard refuses by name (it would have resolved the wrong root and reported 22 console files as green). Re-run from the repo root as the guard instructs; the numbers above are from that run.

## Serial note

Held draft PR #6627 also touches `packages/types` (`retired-field-keys.ts` + the index barrel). This branch touches neither file — its whole diff is the two files above plus the changeset — so there is no crossing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_