### PR TITLE
fix(app-shell): make MetadataService.saveObject's fields argument required

### DIFF
--- a/.changeset/6490-saveobject-fields-required.md
+++ b/.changeset/6490-saveobject-fields-required.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/app-shell': minor
+---
+
+**BREAKING (in name only):** `MetadataService.saveObject(obj, existingFields)` now requires
+its second argument (objectui#6490). Calls that omitted it no longer compile.
+
+**Runtime behaviour is unchanged, and that is the whole justification.** A call that omitted
+the field list was already a guaranteed `422` — every time it ran, against every backend.
+`ObjectSchema.fields` is not merely typed, it is REQUIRED: measured against the installed
+`@objectstack/spec` 17.2.0, `ObjectSchema.safeParse({ name: 'account', label: 'Account' })`
+fails with `invalid_type @ fields`, and `metadata-protocol`'s `saveMetaItem` parses the whole
+item against that same schema and throws `422 INVALID_METADATA` **before** it persists. The
+method cannot build a valid document without the argument, so the only calls this break
+breaks are calls that already failed. The signature is now honest about it, and the diagnosis
+moves from a round trip at runtime to the compiler.
+
+Nothing new is exported and nothing new is accepted — this narrows the published surface
+rather than widening it. In-repo production call sites were measured at **zero** (only tests
+called it), so the migration for an external consumer is to pass the field list it was
+already required to send: `saveObject(obj, fields)`.
+
+⛔ Two readings were considered and declined, recorded so neither is taken later as a
+shortcut. **Not a `{}` default** — `{}` parses GREEN and `PUT /api/v1/meta/object/:name` is
+an upsert, so defaulting would delete every field of the object on a save that only meant to
+rename it, trading a loud, harmless 422 for silent data loss; the anti-wipe control from
+objectui#6240 (`omits fields entirely when the caller supplied none — it does NOT write {}`)
+moves with the signature and still guards the path a JavaScript consumer can reach. **Not
+fetch-and-merge** — an object save could GET the current document and preserve its stored
+`fields` the way `saveFields` does, but that builds capability for a path with zero measured
+pull and makes the parameter redundant.
+
+An EMPTY list stays a different statement from a missing one: `[]` means "this object has no
+fields", writes `{}`, and under the upsert performs the wipe the caller asked for — the same
+authoritative reading `saveFields` gives its own empty list. Unchanged, and now pinned,
+because the required parameter is what routes a caller with nothing to hand toward it.
+
+Scored `minor` and not `major` per AGENTS.md §版本号策略 — objectui's major is pinned to the
+`@objectstack` major so that "same major ⇒ compatible" holds across the two repos, and every
+publishable package sits in one `fixed` group, so objectui's own breaking changes ship as
+`minor` with the break spelled out in the body. That is the convention, which is why the
+break is stated in words above.

--- a/packages/app-shell/src/services/MetadataService.objectPayloadFieldsMap.test.ts
+++ b/packages/app-shell/src/services/MetadataService.objectPayloadFieldsMap.test.ts
@@ -217,7 +217,24 @@ describe('objectui#6240 · saveObject PUTs `fields` as a name-keyed map', () => 
     // caller that simply did not pass `existingFields` would delete every field
     // of the object. The body stays refused instead — unchanged from before
     // this card, and deliberately so.
+    //
+    // objectui#6490 made `existingFields` REQUIRED, and this control MOVED with
+    // the signature rather than being deleted as newly-unreachable. Both halves
+    // of it are still live, and they measure different things:
+    //
+    //   1. The `@ts-expect-error` below is the COMPILE-TIME half of #6490. This
+    //      project (`tsconfig.test.json`) compiles this file, and an unused
+    //      `@ts-expect-error` is itself an error — so the line reds if the
+    //      argument ever goes back to optional. That is the only direction the
+    //      narrowing can regress in, and this is what pins it.
+    //   2. The RUNTIME half is unchanged and still reachable. `MetadataService`
+    //      is public API (app-shell exports `useMetadataService`), so a
+    //      JavaScript consumer — or a TypeScript one that casts past the types —
+    //      can still arrive here with no field list. What it must get is the
+    //      loud, harmless 422 below, never the silent wipe.
     const { adapter, puts } = makeCapturingAdapter();
+    // @ts-expect-error objectui#6490 — `existingFields` is required. This call is
+    // exactly what the new signature refuses, and it is compiled to prove it does.
     await new MetadataService(adapter).saveObject(ACCOUNT);
 
     expect(puts).toHaveLength(1);
@@ -225,6 +242,24 @@ describe('objectui#6240 · saveObject PUTs `fields` as a name-keyed map', () => 
     expect(issuesOf(ObjectSchema.safeParse(puts[0]))).toEqual(['invalid_type @ fields']);
     // Positive control: the rest of the object still went out.
     expect(puts[0]).toMatchObject({ name: 'account', label: 'Account', pluralLabel: 'Accounts' });
+  });
+
+  it('objectui#6490 · an EMPTY list is a STATEMENT, not a missing argument — it writes `{}`', async () => {
+    // The cell the required parameter makes canonical: with the argument no
+    // longer omittable, `[]` is the only spelling left for "no fields", and it
+    // means what it says. Unchanged behaviour — `[]` is truthy, so it has always
+    // converted to `{}` — pinned now because the signature change is what routes
+    // callers to it. The two readings must stay distinguishable: the control
+    // above is about a MISSING argument and never about an empty one, and
+    // `saveFields` reads its own empty list the same authoritative way.
+    const { adapter, puts } = makeCapturingAdapter();
+    await new MetadataService(adapter).saveObject(ACCOUNT, []);
+
+    expect(puts).toHaveLength(1);
+    expect(puts[0].fields).toEqual({});
+    // And unlike the missing-argument body, this one is one the server ACCEPTS —
+    // which is the whole hazard, and why it may only ever happen on request.
+    expect(issuesOf(ObjectSchema.safeParse(puts[0]))).toEqual([]);
   });
 });
 

--- a/packages/app-shell/src/services/MetadataService.saveAdvisories.test.ts
+++ b/packages/app-shell/src/services/MetadataService.saveAdvisories.test.ts
@@ -34,7 +34,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ObjectStackAdapter, type MetadataSaveAdvisoryEvent } from '@object-ui/data-objectstack';
 import type { ObjectDefinition } from '@object-ui/types';
-import { MetadataService } from './MetadataService';
+import { MetadataService, type FieldMetadataPayload } from './MetadataService';
 import { emitSaveAdvisories, type TranslateFn } from '../providers/saveAdvisoryToast';
 
 const PURGE_ADVISORY = {
@@ -100,6 +100,15 @@ function makeWiredAdapter(body: unknown) {
 // (objectui#4040). Declared properly instead of widening the cast.
 const ACCOUNT: ObjectDefinition = { id: 'account', name: 'account', label: 'Account' };
 
+// objectui#6490 made that second parameter REQUIRED. `ObjectSchema.fields` is a
+// required record, so a `saveObject` call that omitted the list built a body the
+// server refused `422 INVALID_METADATA` every time it ran — these suites were
+// asserting the advisory channel on top of a save that could never have
+// succeeded against a real backend. The field list is not this file's subject,
+// so it hands over the smallest well-formed one; nothing else about these
+// assertions changes.
+const ACCOUNT_FIELDS: FieldMetadataPayload[] = [{ name: 'name', type: 'text', label: 'Name' }];
+
 describe('MetadataService saves reach the shell advisory surface (#4237)', () => {
   it('renders the gate findings for a save that succeeded', async () => {
     const { adapter, sink, events } = makeWiredAdapter({
@@ -107,7 +116,7 @@ describe('MetadataService saves reach the shell advisory surface (#4237)', () =>
       advisories: [PURGE_ADVISORY],
     });
 
-    await new MetadataService(adapter).saveObject(ACCOUNT);
+    await new MetadataService(adapter).saveObject(ACCOUNT, ACCOUNT_FIELDS);
 
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ type: 'object', name: 'account', mode: 'publish' });
@@ -117,7 +126,7 @@ describe('MetadataService saves reach the shell advisory surface (#4237)', () =>
   it('lands on the WARNING tier and says "Saved" first — the write succeeded', async () => {
     const { adapter, sink } = makeWiredAdapter({ ...CLEAN_BODY, advisories: [PURGE_ADVISORY] });
 
-    await new MetadataService(adapter).saveObject(ACCOUNT);
+    await new MetadataService(adapter).saveObject(ACCOUNT, ACCOUNT_FIELDS);
 
     const [title, opts] = sink.warning.mock.calls[0]!;
     expect(title).toMatch(/^Saved/);
@@ -130,7 +139,7 @@ describe('MetadataService saves reach the shell advisory surface (#4237)', () =>
   it('a clean save renders no new UI', async () => {
     const { adapter, sink, events } = makeWiredAdapter(CLEAN_BODY);
 
-    await new MetadataService(adapter).saveObject(ACCOUNT);
+    await new MetadataService(adapter).saveObject(ACCOUNT, ACCOUNT_FIELDS);
 
     expect(events).toEqual([]);
     expect(sink.warning).not.toHaveBeenCalled();
@@ -152,7 +161,7 @@ describe('MetadataService saves reach the shell advisory surface (#4237)', () =>
     const { adapter } = makeWiredAdapter({ ...CLEAN_BODY, advisories: [PURGE_ADVISORY] });
     const invalidate = vi.spyOn(adapter, 'invalidateCache');
 
-    await expect(new MetadataService(adapter).saveObject(ACCOUNT)).resolves.toBeUndefined();
+    await expect(new MetadataService(adapter).saveObject(ACCOUNT, ACCOUNT_FIELDS)).resolves.toBeUndefined();
 
     // The service's own post-save step still runs.
     expect(invalidate).toHaveBeenCalledWith('object:account');

--- a/packages/app-shell/src/services/MetadataService.ts
+++ b/packages/app-shell/src/services/MetadataService.ts
@@ -171,6 +171,13 @@ function toObjectPayload(obj: ObjectDefinition, fields?: FieldMetadataPayload[])
     // right outcome for a caller that under-specified an upsert, and the same
     // outcome as before this change. `saveFields` is the opposite case and
     // treats its argument as authoritative; see there.
+    //
+    // This parameter stays OPTIONAL after objectui#6490 made `saveObject`'s
+    // public one required, and the optionality is the point rather than a
+    // leftover: the type now says no in-repo caller can reach this branch, and
+    // the branch is what a caller who ignores the types still lands in. It is
+    // the last line of defence against the wipe, so it may not be deleted as
+    // newly-unreachable code.
     fields: fields ? toFieldsMap(fields) : undefined,
   };
 }
@@ -493,8 +500,47 @@ export class MetadataService {
   /**
    * Persist an object definition to the backend.
    * Works for both create and update (the API is an upsert).
+   *
+   * ## Why `existingFields` is REQUIRED (objectui#6490)
+   *
+   * `ObjectSchema.fields` is not merely typed, it is REQUIRED. Measured against
+   * the installed `@objectstack/spec` 17.2.0:
+   *
+   *   ObjectSchema.safeParse({ name: 'account', label: 'Account' })
+   *     => success = false   invalid_type @ fields
+   *
+   * and `metadata-protocol`'s `saveMetaItem` parses the whole item against that
+   * same schema and throws BEFORE it persists. So a call that omitted the field
+   * list built a body the server was guaranteed to refuse with
+   * `422 INVALID_METADATA` — this method cannot write a valid document without
+   * it. Requiring the argument moves that guaranteed RUNTIME failure to compile
+   * time; runtime accept/reject is unchanged, because the only calls it breaks
+   * are calls that already failed, every time they ran.
+   *
+   * An EMPTY list is a different statement from a missing one, and it is
+   * accepted: `[]` says "this object has no fields", writes `{}`, and under the
+   * upsert that is a field wipe the caller asked for — the same authoritative
+   * reading `saveFields` gives its own empty list. Pinned alongside the
+   * anti-wipe control in `MetadataService.objectPayloadFieldsMap.test.ts`, so
+   * the two readings of "no fields" stay distinguishable.
+   *
+   * Two readings were declined by the maintainer ruling (2026-08-27), recorded
+   * here so neither returns as a shortcut:
+   *
+   *   - ⛔ **Not a `{}` default.** `{}` parses GREEN, so defaulting would delete
+   *     every field of the object on a save that only meant to rename it —
+   *     trading a loud, harmless 422 for silent data loss. `toObjectPayload`
+   *     still omits the key for an input that supplies nothing, and that branch
+   *     is still reachable: this class is public API through
+   *     `useMetadataService`, so a JavaScript consumer, or one that casts past
+   *     the types, can arrive there. What it must get is the 422, not the wipe.
+   *   - ⛔ **Not fetch-and-merge.** `saveFields` GETs the current document and
+   *     spreads it, and an object save could preserve the stored `fields` the
+   *     same way — but that builds capability for a path with zero measured
+   *     pull and makes this parameter redundant, which then wants retiring on
+   *     its own terms (ADR-0049 shape).
    */
-  async saveObject(obj: ObjectDefinition, existingFields?: FieldMetadataPayload[]): Promise<void> {
+  async saveObject(obj: ObjectDefinition, existingFields: FieldMetadataPayload[]): Promise<void> {
     const client = this.adapter.getClient();
     const payload = toObjectPayload(obj, existingFields);
     await client.meta.saveItem('object', obj.name, payload);


### PR DESCRIPTION
Fixes #6490

Implements the maintainer ruling of 2026-08-27 (verbatim 「其他接受」 — Option 1): `MetadataService.saveObject`'s field-list argument becomes **required**. Verified at commit `2503a710`.

## What changed

One production character. `existingFields?: FieldMetadataPayload[]` becomes `existingFields: FieldMetadataPayload[]`. Everything else in the diff is documentation, the moved pin, and call sites.

**Runtime behaviour is unchanged, and that is the whole justification.** `ObjectSchema.fields` is not merely typed, it is REQUIRED, and `metadata-protocol`'s `saveMetaItem` parses the whole item against that schema and throws before it persists. So a call that omitted the field list built a body the server was guaranteed to refuse `422 INVALID_METADATA` — every time it ran, against every backend. The method cannot write a valid document without the argument. Requiring it moves that guaranteed runtime failure to compile time; the only calls it breaks are calls that already failed.

That measurement is not quoted from the card — it is executed in this branch. The carried-forward pin asserts `issuesOf(ObjectSchema.safeParse(body))` equals `['invalid_type @ fields']` on the omitted-argument body, against the installed `@objectstack/spec` 17.2.0, and it passes.

## The #6240 positive control moved with the signature — it is not deleted

The pin reads "omits `fields` entirely when the caller supplied none — it does NOT write `{}`". Both halves of it are still live, and they measure different things:

1. **The runtime half is unchanged and still reachable.** `MetadataService` is public API through the exported `useMetadataService`, so a JavaScript consumer — or a TypeScript one that casts past the types — can still arrive with no field list. What it must get is the loud, harmless 422, never the silent wipe. `toObjectPayload`'s parameter deliberately stays optional for exactly this: it is the last line of defence and may not be deleted as newly-unreachable code.
2. **A new compile-time half.** The call now sits under a `@ts-expect-error`, and `tsconfig.test.json` compiles this file, so an *unused* directive is itself an error. The line reds if the argument ever goes back to optional — the only direction this narrowing can regress in.

Reverse-verified, predicted direction stated before the run: reverting the signature to optional must turn the type-check **red on an unused directive**. Observed exactly that — `error TS2578: Unused '@ts-expect-error' directive.` at `MetadataService.objectPayloadFieldsMap.test.ts(236,5)`, `VERDICT command-exit 2`. Mutation confirmed on disk by counting both spellings (required 1→0, optional 0→1) and by a `git hash-object` differing from the HEAD blob; restore confirmed by the hash returning to the HEAD blob and `git diff HEAD` being empty. No rebuild was needed for either leg: `MetadataService.ts` is compiled from source by both `tsc` projects, and `tsconfig.test.json`'s empty `paths` only redirects cross-package specifiers to built `.d.ts`.

## Declined options, recorded so neither is taken later as a shortcut

- ⛔ **Not a `{}` default.** `{}` parses GREEN and the PUT is an upsert, so defaulting would delete every field of the object on a save that only meant to rename it — trading a loud, harmless 422 for silent data loss.
- ⛔ **Not fetch-and-merge.** It builds capability for a path with zero measured pull and makes the parameter redundant, incurring a retirement obligation.

## One cell newly pinned, and why it is in scope

An EMPTY list is a different statement from a missing one: `[]` means "this object has no fields", writes `{}`, and under the upsert performs the wipe the caller asked for — the same authoritative reading `saveFields` already gives its own empty list. Behaviour is unchanged (`[]` is truthy, so it has always converted to `{}`); it is pinned now because the required parameter is what routes a caller with nothing to hand toward that spelling. The two readings of "no fields" must stay distinguishable, so the pin sits directly beside the anti-wipe control.

## Call sites

In-repo production callers measured at **zero**; only tests call it. Four omitted-argument call sites, all in `MetadataService.saveAdvisories.test.ts`, now pass the smallest well-formed list — those suites are about the advisory channel, not the field list, and nothing else about their assertions changes.

Confirmed by anchored grep with a positive control in the same query shape, repo-wide over ts/tsx/js/jsx excluding `node_modules` and `dist`:

- one-argument calls, pattern `\.saveObject\(\s*[^,()]*\s*\)` — **1 hit**, and it is the deliberate `@ts-expect-error` line 238 above;
- positive control, same shape, two-argument calls `\.saveObject\(\s*[^,()]*\s*,` — **16 hits**, so the query shape is live and a zero in the first row would have meant something;
- plus a balanced-paren scanner that catches multi-line single-argument calls the regex cannot — same single hit.

## Clause-② — still "no"

**No new export was needed.** Zero added `export` statements in the diff (`git diff | grep '^+' | grep export` is empty). The change narrows the published surface rather than widening it: nothing new is exported, nothing new is accepted, and runtime accept/reject is unchanged. The stop-and-report condition was not reached.

## Verification, all at commit `2503a710`

| Run | Result |
|---|---|
| `pnpm --filter @object-ui/app-shell type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0` |
| `pnpm --workspace-concurrency=2 --filter '...@object-ui/app-shell' type-check` — the **downstream consumer** closure, 4 of 47 projects: app-shell, `@object-ui/console`, and the two console examples | `VERDICT command-exit 0`, each printing `Done` |
| `pnpm exec vitest run --maxWorkers=2 packages/app-shell/src/services/` | `Test Files 10 passed (10)` · `Tests 102 passed (102)` |
| The two pins, by name, verbose reporter | both `✓` — "omits `fields` entirely when the caller supplied none — it does NOT write `{}`" and "objectui#6490 · an EMPTY list is a STATEMENT, not a missing argument — it writes `{}`" |
| `pnpm changeset:check` | `✅ All workspace packages are in the changeset fixed group.` · `✅ No changeset declares a 'major' bump.` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 5488 tracked text file(s); skipped 85 binary).` |
| `pnpm check:designer-field-key-parity` | `designer-field-key-parity: OK` (`ObjectMetadataPayload 6 declared` — unchanged, no new keys) |
| `pnpm check:self-import` · `pnpm check:phantom-deps` | `✅ No package names itself inside its own src/.` · `✅ Every in-scope import is declared by the package that publishes it.` |

The type-check is the measurement that matters here, since the whole change is a compile-time contract. Note the first downstream run was red on `Cannot find module '@object-ui/plugin-*'` — unbuilt sibling plugins, not this change; it went green after building console's own dependency closure.

**Lint was narrowed to the affected package, declared:** `eslint .` inside `packages/app-shell` — byte-identical to what `turbo run lint` invokes for this package. Population and count read from eslint's own output, not guessed: `--format json` reports **1006 files linted, 0 errors, 2775 warnings** (the pre-existing warning baseline), and the three edited files report **0 errors** with one pre-existing `no-explicit-any` warning at `MetadataService.ts:640`, outside both of my diff hunks. Invariance for untouched files is measured rather than assumed: `eslint.config.js` declares no `parserOptions.project` and no `projectService`, so type-aware linting is off and every file's verdict is computed from its own source — this diff cannot move the verdict of a file it did not touch.

## Bump

Scored `minor`, not `major`, and this is **not** a gate refusing an honest declaration. AGENTS.md §版本号策略 defines the honest declaration in this repo: objectui's major is pinned to the `@objectstack` major so that "same major ⇒ compatible" holds across the two repos, and all publishable packages share one `fixed` group, so one `major` would carry 39 packages off that line. The written convention is that objectui's own breaking changes ship as `minor` with the break spelled out in the changeset body — which this one does, in words, including the sentence that previously-omitted-argument calls were already a guaranteed 422. `scripts/check-changeset-no-major.mjs` mechanically enforces that policy; it was not consulted to pick the score.

## One observation, no action taken

The still-pending `.changeset/6240-object-payload-fields-map.md` ends with "`saveObject(obj, existingFields)` keeps its `FieldMetadataPayload[]` parameter type — the array is converted inside — so no caller's call site changes." That is true of #6240's own change and stays true; it will simply sit alongside this entry in the same release. Editing another card's changeset would be scope widening, so it is left alone and flagged here instead.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_