### PR TITLE
feat(app-shell): caller-supplied subject vocabulary for ConditionBuilder

### DIFF
--- a/.changeset/6296-conditionbuilder-subject-vocabulary.md
+++ b/.changeset/6296-conditionbuilder-subject-vocabulary.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/app-shell': minor
+---
+
+`ConditionBuilder` now takes a caller-supplied **subject vocabulary** instead of hardcoding a
+record-scoped one (objectui#6296).
+
+The builder built every row subject as `record.` + field name, plus a fixed `record.id` /
+`user.*` / `org.*` context list. That is correct for all five files that mount it today — six
+mount sites, since `ActionDefaultInspector` mounts it twice — because every one of them is a
+record-scoped site. It is wrong for a **flattened**-scoped site such as the flow designer's
+entry condition, where the trigger record's fields *are* the top-level evaluation context
+(bare `status`) and the prior values arrive as `previous.FIELD`. This repo's own
+`flow-scope.ts` already computes that distinction (`fieldPrefix: onStart ? '' : 'record.'`,
+`includePrevious`), and objectstack's `packages/formula/src/validate.ts` defines the two
+scopes.
+
+A new optional `subjects` prop declares what a site actually binds:
+
+- `fieldPrefix` — defaults to `'record.'`; `''` declares a flattened scope.
+- `includePrevious` — also offer `previous.FIELD` per field, plus the whole-record `previous`
+  token, which is what makes the create-path idiom `previous == null` **selectable** rather
+  than something the author has to recall from help text.
+- `context` — replace the context subjects, so a flattened site does not inherit `record.id`,
+  a root it does not bind. Offering it there would make this editor emit the one spelling its
+  own sibling ref-check flags as out of scope.
+
+Declared, never inferred: the component does not guess a site's scope from the value it is
+handed. **A caller that declares nothing gets exactly the previous behaviour** — the option
+list, the `record.` prefix on a compiled row, and the single-quoted value spelling are all
+pinned positively against that default, so changing it fails rather than re-baselines.
+
+**Double-quoted string literals now round-trip into row mode.** `unfmtValue` stripped only
+single quotes while `fmtValue` re-emitted only single quotes, so `status == "done"` could
+never survive the builder's byte-for-byte adoption check and was handed to the raw CEL editor
+— even though double quotes are what the entry-condition placeholder teaches and what every
+shipped example flow uses. Each row now remembers the quote character it was parsed with and
+re-emits that one, so the author's own spelling is preserved rather than normalised, and the
+byte-for-byte safety rule is kept exactly as it was rather than loosened. Rows built in the
+builder still emit single quotes, unchanged.
+
+Measured against the shipped corpus — every start-node entry condition in objectstack's
+example apps plus the HotCRM example from objectui#6226 — row-mode adoption goes from 3/17 to
+15/17. The two that remain on raw mode are `&&` mixed with a parenthesised `||` group: a
+grammar limit of the row model, unrelated to subjects, and out of this card's scope.
+
+The component is not re-exported from the package index, so no external caller can pass the
+new prop yet; the wiring that will (objectui#6226) is a separate card. Scored `minor` for the
+added capability rather than `patch`, since the widening is real even while its only future
+caller is in-repo.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.subjectVocabulary.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.subjectVocabulary.test.tsx
@@ -1,0 +1,330 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * ConditionBuilder — caller-supplied subject vocabulary (objectui#6296).
+ *
+ * Two things are pinned here, and the second is the one that protects
+ * production:
+ *
+ *  1. A caller may declare the subject vocabulary this mount site actually
+ *     binds — a `fieldPrefix` (so a FLATTENED-scoped site such as the flow
+ *     designer's entry condition gets bare `status`, not `record.status`) and
+ *     `includePrevious` (so `previous.FIELD` subjects, and the create-path
+ *     idiom `previous == null`, are offerable).
+ *
+ *  2. DEFAULT-PATH INVARIANCE. Five consumer files mount this component
+ *     (six mount sites — ActionDefaultInspector mounts it twice), all of them
+ *     record-scoped, and all of them in production. They pass no vocabulary,
+ *     so every one of them must keep behaving exactly as it did. The pins
+ *     below assert the `record.` prefix POSITIVELY (the option list, and the
+ *     CEL a fresh row compiles to) rather than snapshotting, so changing the
+ *     default would go red rather than merely re-baseline.
+ *
+ * ── The acceptance-criterion instrument ──────────────────────────────────
+ *
+ * The corpus below is every start-node entry condition shipped in
+ * objectstack's example apps, plus the HotCRM example quoted in #6226's body.
+ * The measurement is ROW MODE adoption, and "row mode" is asserted
+ * STRUCTURALLY, never by "the editor shows my text back":
+ *
+ *   - RAW mode renders the `Builder` toggle and a CelPredicateField; it has
+ *     NO per-row remove buttons and NO compiled-CEL preview.
+ *   - ROW mode renders the `Expression` toggle, one `Remove condition` button
+ *     PER PARSED ROW, and a preview of the CEL those rows compile to.
+ *
+ * So a row-mode verdict here requires N structured rows to exist as controls.
+ * An implementation that widened the raw fallback to swallow the corpus would
+ * score zero on this instrument, not full marks: `rows` would be 0 and the
+ * `Builder` toggle would be on screen.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ConditionBuilder calls useObjectFields(objectName) unconditionally even when
+// `fields` is supplied (objectui#4697), so stub the shared metadata client to
+// keep mount-time fetches off the network. Same mechanism as
+// ConditionBuilder.test.tsx.
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
+import { ConditionBuilder } from './ConditionBuilder';
+
+afterEach(cleanup);
+
+const FIELDS = [
+  { name: 'status', label: 'Status' },
+  { name: 'amount', label: 'Amount' },
+  { name: 'secret', label: 'Secret', hidden: true },
+];
+
+/* ── mode probe ─────────────────────────────────────────────────────────── */
+
+interface Probe {
+  /** 'row' | 'raw' — from the toggle button, which is mutually exclusive. */
+  mode: 'row' | 'raw' | 'indeterminate';
+  /** Structured rows actually mounted as controls (0 in raw mode). */
+  rows: number;
+  /** The CEL those rows compile to, as previewed (null in raw mode). */
+  compiled: string | null;
+}
+
+function probe(container: HTMLElement): Probe {
+  const buttons = Array.from(container.querySelectorAll('button'));
+  const hasBuilderToggle = buttons.some((b) => b.textContent?.includes('Builder'));
+  const hasExprToggle = buttons.some((b) => b.textContent?.includes('Expression'));
+  const mode = hasExprToggle && !hasBuilderToggle
+    ? 'row'
+    : hasBuilderToggle && !hasExprToggle
+      ? 'raw'
+      : 'indeterminate';
+  const rows = container.querySelectorAll('[aria-label="Remove condition"]').length;
+  // Read the compiled preview ONLY in row mode, and only from a <div>. The raw
+  // editor is itself a mono <textarea>, so a bare `.font-mono` lookup would
+  // hand back the author's own text and make a widened raw fallback read as a
+  // successful round-trip — the exact false green this instrument exists to
+  // rule out.
+  const preview = mode === 'row' ? container.querySelector('div.font-mono') : null;
+  return { mode, rows, compiled: preview ? (preview.textContent ?? '') : null };
+}
+
+function mount(value: string, vocab?: Record<string, unknown>) {
+  const { container } = render(
+    <ConditionBuilder
+      label="Entry condition"
+      value={value}
+      onCommit={() => {}}
+      objectName="showcase_task"
+      fields={FIELDS}
+      {...vocab}
+    />,
+  );
+  return container;
+}
+
+/* ── the corpus ─────────────────────────────────────────────────────────── */
+
+/** Every start-node entry condition shipped in objectstack's example apps
+ *  (measured on objectstack `origin/main`), plus the HotCRM example from
+ *  #6226's card body. `parens` marks the two that are beyond the row grammar
+ *  for reasons that have nothing to do with subjects — mixed `&&`/`||` with a
+ *  parenthesised group. Extending the grammar is out of this card's scope, so
+ *  those two are expected to stay on raw mode and are excluded from the
+ *  round-trip denominator (counted separately, so the number stays honest). */
+const CORPUS: Array<{ src: string; cel: string; parens?: true }> = [
+  { src: 'showcase/dynamic-approval.flow.ts:29', cel: 'title != previous.title' },
+  { src: 'showcase/flows/index.ts:39', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:153', cel: 'assignee != previous.assignee' },
+  { src: 'showcase/flows/index.ts:212', cel: 'budget > 100000 && budget != previous.budget' },
+  { src: 'showcase/flows/index.ts:325', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:438', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:691', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:808', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: 'showcase/flows/index.ts:924', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:1004', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:1099', cel: 'status == "sent" && previous.status != "sent"' },
+  { src: 'showcase/flows/index.ts:1201', cel: 'health == "red" && previous.health != "red"' },
+  { src: 'showcase/flows/index.ts:1532', cel: 'status == "submitted" && previous.status != "submitted"' },
+  { src: 'showcase/flows/index.ts:1582', cel: 'status == "submitted" && previous.status != "submitted" && total_amount >= 5000' },
+  { src: 'showcase/flows/index.ts:1696', cel: "priority == 'urgent' && (previous == null || previous.priority != 'urgent')", parens: true },
+  { src: 'todo/task.flow.ts:183', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: '#6226 card body (HotCRM)', cel: 'contract_term_months > 24 && (previous == null || previous.contract_term_months <= 24)', parens: true },
+];
+
+const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+describe('#6296 acceptance criterion — shipped flow-entry conditions round-trip into ROW mode', () => {
+  const roundTrippable = CORPUS.filter((c) => !c.parens);
+
+  it.each(roundTrippable)('adopts $src as structured rows', ({ cel }) => {
+    const p = probe(mount(cel));
+    expect(p.mode).toBe('row');
+    // Structural, not textual: the rows exist as controls...
+    expect(p.rows).toBeGreaterThan(0);
+    // ...and they compile back to the author's own CEL.
+    expect(norm(p.compiled ?? '')).toBe(norm(cel));
+  });
+
+  it('reports the corpus-wide adoption rate', () => {
+    const adopted = roundTrippable.filter((c) => {
+      const p = probe(mount(c.cel));
+      cleanup();
+      return p.mode === 'row' && p.rows > 0 && norm(p.compiled ?? '') === norm(c.cel);
+    });
+    expect(adopted.length).toBe(roundTrippable.length);
+  });
+
+  it.each(CORPUS.filter((c) => c.parens))(
+    'leaves $src on raw mode — mixed joins with a parenthesised group are a GRAMMAR limit, not a subject one',
+    ({ cel }) => {
+      const p = probe(mount(cel));
+      expect(p.mode).toBe('raw');
+      expect(p.rows).toBe(0);
+      expect(p.compiled).toBeNull();
+    },
+  );
+});
+
+/* ── positive controls for the instrument itself ────────────────────────── */
+
+describe('#6296 probe instrument — positive controls', () => {
+  it('a predicate the builder has always adopted reads as ROW with rows > 0', () => {
+    const p = probe(mount("record.status == 'done'"));
+    expect(p).toMatchObject({ mode: 'row', rows: 1 });
+    expect(p.compiled).toBe("record.status == 'done'");
+  });
+
+  it('a predicate the builder has never adopted reads as RAW with rows === 0', () => {
+    const p = probe(mount("record.status in ['sent', 'paid']"));
+    expect(p).toMatchObject({ mode: 'raw', rows: 0, compiled: null });
+  });
+
+  it('an empty value opens in ROW mode with no rows (fresh condition)', () => {
+    const p = probe(mount(''));
+    expect(p).toMatchObject({ mode: 'row', rows: 0, compiled: null });
+  });
+});
+
+/* ── the subject vocabulary ─────────────────────────────────────────────── */
+
+beforeAll(() => {
+  // Radix Select probes pointer-capture APIs the test DOM lacks.
+  for (const m of ['hasPointerCapture', 'setPointerCapture', 'releasePointerCapture'] as const) {
+    if (!Element.prototype[m]) {
+      // @ts-expect-error test shim
+      Element.prototype[m] = m === 'hasPointerCapture' ? () => false : () => {};
+    }
+  }
+});
+
+/** Open the row's SUBJECT dropdown and read back every subject it offers. */
+async function subjectOptions(container: HTMLElement): Promise<string[]> {
+  const trigger = container.querySelectorAll('[role="combobox"]')[0] as HTMLElement;
+  await userEvent.click(trigger);
+  const opts = await screen.findAllByRole('option');
+  return opts.map((o) => o.textContent ?? '');
+}
+
+/** A mounted builder holding exactly one row, ready to have its subject read. */
+function mountOneRow(vocab?: Record<string, unknown>) {
+  const onCommit = vi.fn();
+  const { container } = render(
+    <ConditionBuilder
+      label="Entry condition"
+      value="placeholder_subject == 'x'"
+      onCommit={onCommit}
+      objectName="showcase_task"
+      fields={FIELDS}
+      {...vocab}
+    />,
+  );
+  return { container, onCommit };
+}
+
+describe('#6296 DEFAULT-PATH INVARIANCE — the five record-scoped consumers are untouched', () => {
+  // Five files mount this component (six mount sites; ActionDefaultInspector
+  // mounts it twice) and none of them passes `subjects`. These assert the
+  // record-scoped default POSITIVELY, so changing it goes red.
+  it('offers record.<field> for the catalog, plus the record/user/org context, and nothing else', async () => {
+    const { container } = mountOneRow();
+    const opts = await subjectOptions(container);
+    expect(opts).toEqual([
+      'record.status',
+      'record.amount',
+      'record.id',
+      'user.id',
+      'user.email',
+      'user.role',
+      'user.isAdmin',
+      'org.id',
+      // the row's own out-of-vocabulary subject is appended so it is not lost
+      'placeholder_subject',
+    ]);
+  });
+
+  it('offers no previous.* subject by default', async () => {
+    const { container } = mountOneRow();
+    const opts = await subjectOptions(container);
+    expect(opts.filter((o) => o.startsWith('previous'))).toEqual([]);
+  });
+
+  it('hides hidden fields, as it always has', async () => {
+    const { container } = mountOneRow();
+    expect(await subjectOptions(container)).not.toContain('record.secret');
+  });
+
+  it('COMPILES a chosen subject with the record. prefix — the behavioural half', async () => {
+    const { container, onCommit } = mountOneRow();
+    const opts = await subjectOptions(container);
+    expect(opts).toContain('record.amount');
+    await userEvent.click(screen.getByRole('option', { name: 'record.amount' }));
+    expect(onCommit).toHaveBeenCalledWith("record.amount == 'x'");
+  });
+
+  it('still emits single quotes for a value the author types here', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      <ConditionBuilder label="c" value="record.status == 'done'" onCommit={onCommit}
+        objectName="showcase_task" fields={FIELDS} />,
+    );
+    const valueBox = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(valueBox, { target: { value: 'sent' } });
+    expect(onCommit).toHaveBeenCalledWith("record.status == 'sent'");
+  });
+});
+
+describe('#6296 a caller may DECLARE the vocabulary its site binds', () => {
+  it("fieldPrefix: '' declares a flattened scope — bare field names", async () => {
+    const { container } = mountOneRow({ subjects: { fieldPrefix: '' } });
+    const opts = await subjectOptions(container);
+    expect(opts).toContain('status');
+    expect(opts).toContain('amount');
+    expect(opts).not.toContain('record.status');
+  });
+
+  it('includePrevious offers previous.<field> AND the whole-record `previous`', async () => {
+    const { container } = mountOneRow({ subjects: { fieldPrefix: '', includePrevious: true } });
+    const opts = await subjectOptions(container);
+    expect(opts).toContain('previous');
+    expect(opts).toContain('previous.status');
+    expect(opts).toContain('previous.amount');
+    expect(opts).not.toContain('previous.secret');
+  });
+
+  it('a declared context list replaces the record-scoped default', async () => {
+    const { container } = mountOneRow({
+      subjects: { fieldPrefix: '', context: [{ value: 'user.id' }] },
+    });
+    const opts = await subjectOptions(container);
+    expect(opts).toContain('user.id');
+    // `record.id` is not bound at a flattened site, so it must not be offered.
+    expect(opts).not.toContain('record.id');
+  });
+
+  it('authors the create-path idiom `previous == null` end to end', async () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      <ConditionBuilder label="Entry condition" value="placeholder_subject == 'x'" onCommit={onCommit}
+        objectName="showcase_task" fields={FIELDS}
+        subjects={{ fieldPrefix: '', includePrevious: true }} />,
+    );
+    await userEvent.click(container.querySelectorAll('[role="combobox"]')[0] as HTMLElement);
+    await userEvent.click(screen.getByRole('option', { name: 'previous' }));
+    const valueBox = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(valueBox, { target: { value: 'null' } });
+    expect(onCommit).toHaveBeenLastCalledWith('previous == null');
+  });
+
+  it('a flattened site round-trips its own output back into rows', () => {
+    const p = probe(mount('status == "done" && previous.status != "done"',
+      { subjects: { fieldPrefix: '', includePrevious: true } }));
+    expect(p).toMatchObject({ mode: 'row', rows: 2 });
+    expect(p.compiled).toBe('status == "done" && previous.status != "done"');
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ConditionBuilder.tsx
@@ -28,7 +28,12 @@ import { t, useMetadataLocale } from '../i18n.js';
 
 type Op = '==' | '!=' | '>' | '<' | '>=' | '<=' | 'truthy' | 'falsy';
 
-interface Row { subject: string; op: Op; value: string }
+/** The quote character a string literal was authored with. Remembered per row
+ *  so the builder re-emits the author's own spelling instead of normalising it
+ *  (objectui#6296) — see {@link fmtValue}. */
+type Quote = '"' | "'";
+
+interface Row { subject: string; op: Op; value: string; quote?: Quote }
 
 const COMPARE_OPS: Array<{ value: Op; label: string }> = [
   { value: '==', label: 'equals' },
@@ -41,6 +46,11 @@ const COMPARE_OPS: Array<{ value: Op; label: string }> = [
   { value: 'falsy', label: 'is empty / false' },
 ];
 
+/**
+ * The context subjects a record-scoped mount site binds. This is the DEFAULT
+ * vocabulary — a caller that binds something else declares it via
+ * {@link ConditionSubjectVocabulary.context}.
+ */
 const CONTEXT_SUBJECTS = [
   { value: 'record.id', label: 'record.id' },
   { value: 'user.id', label: 'user.id' },
@@ -51,6 +61,44 @@ const CONTEXT_SUBJECTS = [
 ];
 
 const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+/**
+ * The subject vocabulary a mount site binds (objectui#6296).
+ *
+ * The builder used to hardcode one: `record.` + field name, plus `record.id` /
+ * `user.*` / `org.*`. That is right for every RECORD-scoped site — which is
+ * all five that mount it today — and wrong for a FLATTENED-scoped one such as
+ * the flow designer's entry condition, where the trigger record's fields ARE
+ * the top-level evaluation context (bare `status`) and the prior values arrive
+ * as `previous.FIELD`. See `flow-scope.ts`, which already computes exactly
+ * this shape (`fieldPrefix: onStart ? '' : 'record.'`, `includePrevious`), and
+ * objectstack's `packages/formula/src/validate.ts` for the two scopes.
+ *
+ * Declared, not inferred: the component never guesses a site's scope from the
+ * value it is handed. A caller that declares nothing gets the record-scoped
+ * default, unchanged.
+ */
+export interface ConditionSubjectVocabulary {
+  /**
+   * Prefix put in front of each catalog field name. Defaults to `'record.'`.
+   * Pass `''` to declare a flattened scope, where bare `status` is the subject.
+   */
+  fieldPrefix?: string;
+  /**
+   * Also offer `previous.FIELD` for each catalog field, plus the whole-record
+   * `previous` token — which is what makes the create-path idiom
+   * `previous == null` selectable rather than something the author has to
+   * recall from help text. Defaults to `false`.
+   */
+  includePrevious?: boolean;
+  /**
+   * Replace the context subjects. Defaults to {@link CONTEXT_SUBJECTS}. A
+   * flattened site passes its own list rather than inheriting `record.id`,
+   * whose root that site does not bind — offering it would make this editor
+   * emit the one spelling its own sibling ref-check flags as out of scope.
+   */
+  context?: ReadonlyArray<{ value: string; label?: string }>;
+}
 
 /**
  * Scope roots a value typed into the value box may plainly REFERENCE, rather
@@ -105,12 +153,18 @@ const REFERENCE_RE = new RegExp(
  * any layer. Emitting the reference is also what makes it CHECKABLE: it is now
  * an identifier those existing checkers can see.
  */
-function fmtValue(v: string): string {
+function fmtValue(v: string, quote: Quote = "'"): string {
   const t = v.trim();
   if (t === 'true' || t === 'false' || t === 'null') return t;
   if (t !== '' && !Number.isNaN(Number(t))) return t;
   if (REFERENCE_RE.test(t)) return t;
-  return `'${t.replace(/'/g, "\\'")}'`;
+  // `quote` defaults to the single quote this function has always emitted, so
+  // a row the author built here — and every row parsed from single-quoted CEL
+  // — is byte-for-byte what it was before objectui#6296. Only a row parsed
+  // from a DOUBLE-quoted literal carries `"`, and those did not reach row mode
+  // at all until this change.
+  const esc = quote === "'" ? t.replace(/'/g, "\\'") : t.replace(/"/g, '\\"');
+  return `${quote}${esc}${quote}`;
 }
 
 /**
@@ -118,11 +172,17 @@ function fmtValue(v: string): string {
  * quotes to strip and passes through unchanged, which is what keeps an emitted
  * `previous == previous.status` round-tripping back into the row builder.
  */
-function unfmtValue(raw: string): string {
+function unfmtValue(raw: string): { value: string; quote?: Quote } {
   const t = raw.trim();
-  const m = /^'(.*)'$/.exec(t);
-  if (m) return m[1].replace(/\\'/g, "'");
-  return t;
+  const sq = /^'(.*)'$/.exec(t);
+  if (sq) return { value: sq[1].replace(/\\'/g, "'"), quote: "'" };
+  // Double-quoted literals are the spelling every shipped flow-entry condition
+  // uses, and the field's own placeholder teaches. Stripping only single
+  // quotes while re-emitting only single quotes meant they could never
+  // round-trip, so they were handed to the raw editor (objectui#6296).
+  const dq = /^"(.*)"$/.exec(t);
+  if (dq) return { value: dq[1].replace(/\\"/g, '"'), quote: '"' };
+  return { value: t };
 }
 
 /** Compile rows → CEL. Rows without a subject are skipped (in-progress). */
@@ -132,7 +192,7 @@ function compile(rows: Row[], join: '&&' | '||'): string {
     .map((r) => {
       if (r.op === 'truthy') return r.subject;
       if (r.op === 'falsy') return `!${r.subject}`;
-      return `${r.subject} ${r.op} ${fmtValue(r.value)}`;
+      return `${r.subject} ${r.op} ${fmtValue(r.value, r.quote)}`;
     })
     .join(` ${join} `);
 }
@@ -149,7 +209,11 @@ function parse(expr: string): { rows: Row[]; join: '&&' | '||' } | null {
   const rows: Row[] = [];
   for (const p of parts) {
     const cmp = /^([a-zA-Z_][\w.]*)\s*(==|!=|>=|<=|>|<)\s*(.+)$/.exec(p);
-    if (cmp) { rows.push({ subject: cmp[1], op: cmp[2] as Op, value: unfmtValue(cmp[3]) }); continue; }
+    if (cmp) {
+      const v = unfmtValue(cmp[3]);
+      rows.push({ subject: cmp[1], op: cmp[2] as Op, value: v.value, quote: v.quote });
+      continue;
+    }
     const neg = /^!\s*([a-zA-Z_][\w.]*)$/.exec(p);
     if (neg) { rows.push({ subject: neg[1], op: 'falsy', value: '' }); continue; }
     const truthy = /^([a-zA-Z_][\w.]*)$/.exec(p);
@@ -167,7 +231,7 @@ function initFrom(value: string): { rows: Row[]; join: '&&' | '||'; raw: boolean
   return { rows: [], join: '&&', raw: !!value };
 }
 
-export function ConditionBuilder({ label, value, onCommit, objectName, fields: fieldsProp, disabled, onBlockingIssuesChange }: {
+export function ConditionBuilder({ label, value, onCommit, objectName, fields: fieldsProp, disabled, onBlockingIssuesChange, subjects }: {
   label?: string;
   value: string;
   onCommit: (cel: string) => void;
@@ -187,15 +251,35 @@ export function ConditionBuilder({ label, value, onCommit, objectName, fields: f
    * the aggregate changes, `0` when everything is clean.
    */
   onBlockingIssuesChange?: (count: number) => void;
+  /**
+   * What this mount site's subjects are called (objectui#6296). Omit for the
+   * record-scoped default every existing consumer relies on.
+   */
+  subjects?: ConditionSubjectVocabulary;
 }) {
   const { fields: hookFields } = useObjectFields(objectName);
   const fields = fieldsProp ?? hookFields;
+  const fieldPrefix = subjects?.fieldPrefix ?? 'record.';
+  const includePrevious = subjects?.includePrevious ?? false;
+  const contextSubjects = subjects?.context ?? CONTEXT_SUBJECTS;
   const subjectOptions = React.useMemo(() => {
-    const fieldOpts = fields
-      .filter((f) => !f.hidden)
-      .map((f) => ({ value: `record.${f.name}`, label: `record.${f.name}` }));
-    return [...fieldOpts, ...CONTEXT_SUBJECTS];
-  }, [fields]);
+    const visible = fields.filter((f) => !f.hidden);
+    const fieldOpts = visible.map((f) => ({
+      value: `${fieldPrefix}${f.name}`,
+      label: `${fieldPrefix}${f.name}`,
+    }));
+    // The whole-record `previous` comes first: `previous == null` is how an
+    // author branches on the create leg of a create-or-update trigger, and it
+    // reads as the head of the group rather than as one more field.
+    const previousOpts = includePrevious
+      ? [
+          { value: 'previous', label: 'previous' },
+          ...visible.map((f) => ({ value: `previous.${f.name}`, label: `previous.${f.name}` })),
+        ]
+      : [];
+    const contextOpts = contextSubjects.map((c) => ({ value: c.value, label: c.label ?? c.value }));
+    return [...fieldOpts, ...previousOpts, ...contextOpts];
+  }, [fields, fieldPrefix, includePrevious, contextSubjects]);
   // The raw-expression editor's CEL assists (#1582): field-existence lint +
   // autocomplete need the bare field-name catalog and a locale-bound `t`.
   const locale = useMetadataLocale();


### PR DESCRIPTION
Fixes #6296

Gives `ConditionBuilder` a caller-supplied subject vocabulary, so a mount site can declare what its subjects are actually called instead of inheriting a hardcoded record-scoped one.

## Premise re-verification — the inherited baseline has MOVED

The card's acceptance criterion quotes "today's measured result is 0/16", inherited from the measurement on #6226. I re-measured on `origin/main` @ `d0889e2f` before writing a line, and got a different number.

| reading | #6226 (2026-08-25) | this branch's ref |
|---|---|---|
| corpus size | 16 (15 example-app + HotCRM) | **17** (16 example-app + HotCRM) |
| adopting into row mode | 0 | **3** |

Two independent drifts, both verified rather than assumed:

1. **#6293 landed.** `fmtValue` now emits a value under a declared root as a reference instead of quoting it into a string literal. That alone made three shipped conditions round-trip: `title != previous.title`, `assignee != previous.assignee`, and `budget greater-than 100000 && budget != previous.budget`.
2. **objectstack's example corpus grew by one.** Enumerating start-node entry conditions on objectstack `origin/main` now yields 16, not 15 — the extra is `dynamic-approval.flow.ts:29`.

The card's *structural* premise is untouched and I verified it line by line: the builder still built every row subject as `record.` + field name with a fixed `record.id` / `user.*` / `org.*` context list, and offered no `previous.*` subject at all. So the card is alive; only the quoted baseline moved. Recorded here because the criterion's "0/16" should be restated as "3/17" before anyone measures against it again.

## What changed

A new optional `subjects` prop declares the vocabulary a site binds:

- `fieldPrefix` — defaults to `'record.'`; `''` declares a flattened scope, where the trigger record's fields are the top-level evaluation context.
- `includePrevious` — also offer `previous.FIELD` per catalog field, plus the whole-record `previous` token, which is what makes the create-path idiom `previous == null` selectable rather than something the author must recall from help text.
- `context` — replace the context subjects, so a flattened site does not inherit `record.id`, a root it does not bind.

Declared, never inferred: the component does not guess a site's scope from the value it is handed. This mirrors the shape `flow-scope.ts` already computes (`fieldPrefix: onStart ? '' : 'record.'`, `includePrevious`).

**Double-quoted string literals now round-trip.** `unfmtValue` stripped only single quotes while `fmtValue` re-emitted only single quotes, so `status == "done"` could never survive the byte-for-byte adoption check — even though double quotes are what the entry-condition placeholder teaches and what nearly every shipped example flow uses. Each row now remembers the quote character it was parsed with and re-emits that one. This **keeps** the byte-for-byte safety rule rather than loosening it, and preserves the author's own spelling instead of normalising it. This is the `fmtValue`/`unfmtValue` work the card scopes in "only to the extent the 16-condition criterion forces"; it is a distinct defect from #6293, which is already landed and is not touched here.

Row-mode adoption across the corpus: **3/17 to 15/17**.

## How the pin distinguishes ROW MODE from the raw fallback

This is the criterion's central trap: an implementation that merely widened the raw-expression fallback would re-emit every input verbatim and score full marks while delivering nothing. The probe therefore never asks "does the editor show my text back". It reads three structural signals and requires all of them:

- the mode toggle, which is mutually exclusive — raw mode renders a `Builder` button, row mode renders an `Expression` button;
- **one `Remove condition` button per parsed row**, so N structured row controls must actually exist in the DOM;
- the compiled-CEL preview, which only row mode renders, matching the author's input.

A widened raw fallback scores **zero** on this instrument: it has no remove buttons and no preview.

I found this the hard way and it is worth recording. My first probe read the preview with a bare `.font-mono` selector, which also matches the raw editor's mono textarea — so the two raw-mode cases came back reporting a "compiled" value that was really just the author's own text. That is exactly the row-versus-raw conflation the criterion warns about, reproduced inside the instrument itself. The selector is now scoped to a `div` and gated on the mode verdict.

The two conditions that stay on raw mode are `&&` mixed with a parenthesised `||` group. That is a **grammar** limit of the row model, unrelated to subjects, and extending the operator/grammar vocabulary is out of scope on this card. They are pinned as expected-raw and held out of the round-trip denominator so the number stays honest rather than flattered.

## Default-path invariance — the five consumers in production

I enumerated the consumers by reading the code rather than taking the count on authority: **5 files, 6 mount sites** (`ActionDefaultInspector` mounts it twice — visible / disabled). That matches the card. None of them passes `subjects`.

The risk here is a suite that only asserts the new flattened mode and passes just as well against an implementation that silently broke `record.` prefixing for everyone else. So the default is pinned **positively**, not snapshotted:

- the subject dropdown offers exactly `record.status`, `record.amount`, then the six context subjects, and nothing else;
- no `previous.*` subject appears by default;
- choosing a subject **compiles** to `record.amount == 'x'` — the behavioural half, not just the option list;
- a value typed into a builder row still emits single quotes.

**Ablation proving those pins bite.** With the implementation committed, I changed the default `fieldPrefix` from `'record.'` to `''` and re-ran:

```
ORIG_HASH=c7261ca8d443889bdd7fb03f633ed14975b6a8e3
PRE  removed-anchor=1  injected-anchor=0
MUT_HASH=554c908815ff8890186d83d26901bdd210768a6a
POST removed-anchor=0  injected-anchor=1
ABLATED_VITEST_EXIT=1     -> 2 failed | 29 passed
BACK_HASH=c7261ca8d443889bdd7fb03f633ed14975b6a8e3
RESTORED_MATCHES_ORIG=yes   GIT_DIFF_HEAD_EMPTY=yes
```

The mutation is proven on disk in both directions (anchored grep counts plus a changed blob hash), and restoration by observation rather than by an editor's exit code. The two that went red are precisely the option-list pin and the compiled-prefix pin; the corpus pins stayed green, which is correct — they do not depend on the prefix.

## Verification

All runs below are at `5b6cd48c`, the final commit, on a tree verified clean.

| check | verdict line |
|---|---|
| new pin suite | `Test Files 1 passed (1)` · `Tests 31 passed (31)` — `VITEST_EXIT=0` |
| same suite before the fix | `Tests 16 failed / 5 passed (21)` — the 12 corpus cases failing on `expected 'raw' to be 'row'` |
| consumer regression | `Test Files 62 passed (62)` · `Tests 745 passed / 1 skipped (746)` — `CONSUMER_VITEST_EXIT=0` |
| `type-check` | `tsc --noEmit && tsc -p tsconfig.test.json` — `TYPECHECK_EXIT=0` |
| dependency closure build | `BUILD_EXIT=0` |
| eslint (changed files) | `ESLINT_EXIT=0` — 0 errors; 1 warning pre-existing and untouched |
| `check:control-bytes` | `OK (scanned 5498 tracked text file(s))` |
| `check:vi-mock-specifiers` | `OK (3879 tracked source file(s) ... 0 non-static)` |
| `check:i18n-keys` / `i18n-drift` / `i18n-dead-keys` | exit 0 |
| `check:designer-field-key-parity` | `designer-field-key-parity: OK` |

The 62-file consumer run reconciles exactly: 57 top-level `inspectors/*.test.ts*` + 2 under `inspectors/__tests__/` + the 3 files named explicitly. It covers all five consumers.

The typecheck is not a hollow green: `tsc -p tsconfig.test.json --listFiles` confirms both the implementation and the new test file are in the program, with a positive control on a file known to be present.

**Declared narrowings.** Repo-wide `pnpm lint` and the full `check:*` farm are CI's run, not duplicated here. `check:readme-exports` exits 1 locally, but as a **prerequisite failure, not a red gate**: all 378 findings read "its type entry `./dist/index.d.ts` is not on disk — run `pnpm build` first", and the gate's own coverage floors (`packagesRead: found 1, floor is 25`) say it could not measure enough to have an opinion. Zero findings name this change, checked with a positive control on the same query shape. It needs a full-repo build, which CI does.

## Scope

Only three files: `ConditionBuilder.tsx`, its own new test, and the changeset. No consumer call site is touched. Raw-expression mode is untouched. The flow-designer wiring stays with #6226, which is still open and unblocked by this; `decision` branch conditions and the operator vocabulary are untouched; the reference-quoting defect #6293 is already landed and is not re-opened here.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_