### PR TITLE
refactor(i18n): retire 25 confirmed-dead locale keys across all ten packs

### DIFF
--- a/.changeset/4730-retire-dead-locale-key-batch.md
+++ b/.changeset/4730-retire-dead-locale-key-batch.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/i18n': minor
+---
+
+Retire 25 confirmed-dead locale keys from all ten packs — 250 translated strings
+with no reader anywhere in the repo (objectui#4730's key-level trim round;
+`calendar.agenda` closes objectui#5783).
+
+Every key was confirmed individually, not swept from a tool's output. The
+inventory comes from `scripts/check-i18n-dead-keys.mjs`, which stays report-only
+by design, and each candidate then had to clear the objectui#4658 evidence
+standard on its own: zero `t()` call sites, zero textual footprint anywhere
+outside the packs, and a read of its plausible consumer confirming no i18n
+wiring reaches it. Five namespaces held nothing but retired leaves and went with
+them — `map`, `cellRender`, `rowAction`, `recordDetail`, and `home.stats`.
+
+The retirements fall into three shapes:
+
+- **Superseded twin vocabularies.** `cellRender.*` and `rowAction.*` duplicated
+  a `grid.*` vocabulary that won. `RowActionMenu.tsx` is fully i18n-wired and
+  reads `grid.openMenu` / `grid.edit` / `grid.delete`; `ObjectGrid.tsx` reads
+  `grid.empty` / `grid.yes` / `grid.no` / `grid.systemFields`. The twins had no
+  reader on either side.
+- **Labels that outlived their control.** `calendar.agenda` labelled a view mode
+  objectui#5740 retired from `CalendarViewMode` (now `'month' | 'week' | 'day'`).
+  `home.quickActions.createApp*`, `layout.systemNav.createApp`,
+  `actionDialog.defaultActionTitle` / `.ok` and `grid.bulk.selectPlaceholder`
+  sit in namespaces whose consumers are live and wired but demonstrably read
+  other siblings.
+- **Surfaces that left the product.** `map.*` is the strongest form:
+  `@object-ui/plugin-map` declares no `@object-ui/i18n` dependency and contains
+  no `t()` call at all, so it cannot consume a locale string. `home.stats.*` and
+  `recordDetail.viewersTooltip` name surfaces nothing renders.
+
+`packages/i18n/src/__tests__/dead-key-batch-retired-4730.test.ts` pins the
+retirement, following the convention of the five retirement pins already in that
+directory. It is load-bearing rather than decorative: every i18n gate in this
+repo runs call site to key, so a dead key coming **back** into the packs is
+invisible to all of them, and this pin is the only thing watching that direction.
+
+**Deliberately NOT deleted, and pinned as live.** Seven `console.*` bootstrap
+strings that this same sweep reported CONFIRMED-dead are in fact **live**, and
+were pulled back out of the batch. `LoadingScreen.tsx` is bootstrap-critical UI
+that must render before i18n loads — precisely when the server is unreachable —
+so it deliberately does not call `t()`. It imports the packs directly and reads
+them as plain object properties (`strings.loadingSteps.connecting`). That
+consumer is invisible to both legs of the sweep: there is no call for the AST
+pass to classify, and the full dotted key is never spelled in source because the
+namespace segment is bound to a local variable. The new pin asserts those keys
+stay, so the next sweep round cannot repeat the mistake.

--- a/packages/i18n/src/__tests__/dead-key-batch-retired-4730.test.ts
+++ b/packages/i18n/src/__tests__/dead-key-batch-retired-4730.test.ts
@@ -1,0 +1,268 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Twenty-five confirmed-dead locale keys are retired from all ten packs
+ * (objectui#4730's key-level trim round; `calendar.agenda` closes objectui#5783).
+ *
+ * ## Why this pin is NEGATIVE, and why it is needed at all
+ *
+ * Every i18n gate in this repo runs **call site -> key**, never key -> call site
+ * (objectui#4145's mechanism, restated by #4392, #4730, #5504 and #6310):
+ *
+ *   - `scripts/check-i18n-call-site-keys.mjs` asks whether each call site's key
+ *     resolves in `en`. A key with no call site is never visited.
+ *   - `all-locales-key-parity.test.ts` compares the ten packs' key SETS to each
+ *     other. One dead key present in all ten is exactly what it wants.
+ *   - `scripts/check-i18n-en-drift.mjs` only fires when an `en` value CHANGES.
+ *   - `scripts/check-i18n-dead-keys.mjs` IS the reverse direction, and it is
+ *     report-only by design and wired into no workflow (objectui#4658).
+ *
+ * So any retired row can return to all ten packs with every gate green. This
+ * file is the only thing watching that direction for this batch.
+ *
+ * ## The three retirement shapes in this batch
+ *
+ * 1. **Superseded twin vocabularies.** `cellRender.*` and `rowAction.*` were
+ *    whole namespaces duplicating a `grid.*` vocabulary that won: the live
+ *    `RowActionMenu.tsx` is fully i18n-wired and reads `grid.openMenu` /
+ *    `grid.edit` / `grid.delete`, and `ObjectGrid.tsx` reads `grid.empty` /
+ *    `grid.yes` / `grid.no` / `grid.systemFields`. The twins had no reader.
+ *    {@link SUPERSEDING_TWINS} pins the winners so this file cannot go green by
+ *    deleting both halves.
+ * 2. **Labels that outlived their control.** `calendar.agenda` labelled a view
+ *    mode objectui#5740 retired from `CalendarViewMode` (now
+ *    `'month' | 'week' | 'day'`); `home.quickActions.createApp*`,
+ *    `layout.systemNav.createApp`, `actionDialog.defaultActionTitle` /
+ *    `.ok` and `grid.bulk.selectPlaceholder` sit in namespaces whose consumers
+ *    are live and i18n-wired but demonstrably read other siblings.
+ * 3. **Surfaces that left the product.** `map.*` is the strongest form:
+ *    `@object-ui/plugin-map` declares no `@object-ui/i18n` dependency and
+ *    contains no `t()` call at all, so it cannot consume a locale string.
+ *    `home.stats.*` and `recordDetail.viewersTooltip` name surfaces nothing
+ *    renders.
+ *
+ * ## What this file does NOT claim
+ *
+ * It does not claim the reverse sweep's CONFIRMED tier is safe to bulk-delete.
+ * Five keys that the sweep reported CONFIRMED-dead in this very round are LIVE
+ * and were pulled back out of the batch — see {@link BLIND_SPOT_LIVE} below,
+ * which is the most load-bearing assertion in this file.
+ */
+import { describe, it, expect } from 'vitest';
+import { builtInLocales } from '../locales/index';
+
+type LocaleCode = keyof typeof builtInLocales;
+const LANGS = Object.keys(builtInLocales) as LocaleCode[];
+
+const at = (pack: unknown, path: string): unknown =>
+  path.split('.').reduce<unknown>((n, k) => (n as Record<string, unknown> | undefined)?.[k], pack);
+
+/** The retired leaves, named rather than counted. */
+const RETIRED = [
+  'calendar.agenda',
+  'calendar.noEvents',
+  'map.invalidCoordinates',
+  'map.invalidCoordinatesPlural',
+  'map.locationDetails',
+  'map.markersCount',
+  'map.searchLocations',
+  'cellRender.empty',
+  'cellRender.no',
+  'cellRender.systemFields',
+  'cellRender.yes',
+  'rowAction.delete',
+  'rowAction.edit',
+  'rowAction.openMenu',
+  'home.stats.apps',
+  'home.stats.recent',
+  'home.stats.starred',
+  'home.quickActions.createApp',
+  'home.quickActions.createAppDesc',
+  'actionDialog.defaultActionTitle',
+  'actionDialog.ok',
+  'layout.systemNav.createApp',
+  'recordDetail.viewersTooltip',
+  'chart.noData',
+  'grid.bulk.selectPlaceholder',
+] as const;
+
+/** Namespace roots that held nothing but retired leaves and went with them. */
+const RETIRED_ROOTS = ['map', 'cellRender', 'rowAction', 'recordDetail', 'home.stats'] as const;
+
+/**
+ * The `grid.*` vocabulary that superseded `cellRender.*` and `rowAction.*`.
+ * Confirmed live by call site in `plugin-grid/src/ObjectGrid.tsx` and
+ * `plugin-grid/src/components/RowActionMenu.tsx` — not merely by sitting nearby.
+ * If a later cleanup deletes these too, the twins' retirement stops being a
+ * de-duplication and becomes a loss of function; that goes red here.
+ */
+const SUPERSEDING_TWINS = [
+  'grid.empty',
+  'grid.yes',
+  'grid.no',
+  'grid.systemFields',
+  'grid.openMenu',
+  'grid.edit',
+  'grid.delete',
+] as const;
+
+/**
+ * Live siblings inside the namespaces this batch trimmed. Each confirmed live by
+ * a `t()` call site, so a green here cannot be bought by deleting the
+ * neighbourhood around each retired leaf.
+ */
+const SURVIVING = [
+  'calendar.today',
+  'calendar.day',
+  'calendar.week',
+  'calendar.month',
+  'calendar.newEvent',
+  'calendar.moreEvents',
+  'calendar.allDay',
+  'home.quickActions.title',
+  'home.quickActions.manageObjects',
+  'home.quickActions.systemSettings',
+  'actionDialog.title',
+  'actionDialog.description',
+  'actionDialog.cancel',
+  'actionDialog.confirm',
+  'layout.systemNav.applications',
+  'layout.systemNav.systemSettings',
+  'layout.systemNav.objectManager',
+  'chart.nullCategory',
+  'grid.bulk.confirmDefault',
+  'grid.bulk.affectedRecords',
+  'grid.bulk.retry',
+] as const;
+
+/**
+ * ⚠️ The most load-bearing list in this file.
+ *
+ * These keys were reported CONFIRMED-dead by `check-i18n-dead-keys.mjs` in the
+ * same run that produced {@link RETIRED} — and they are LIVE. They were pulled
+ * out of the batch after reading their consumer.
+ *
+ * `packages/app-shell/src/chrome/LoadingScreen.tsx` is bootstrap-critical UI: it
+ * must render before i18n loads (that is exactly when the server is
+ * unreachable), so it deliberately does NOT call `useObjectTranslation`. Instead
+ * it imports the packs directly (`import { en as enLocale, builtInLocales } from
+ * '@object-ui/i18n'`) and reads them as PLAIN OBJECT PROPERTIES:
+ * `strings.loadingSteps.connecting`, `strings.error.connectionFailed`, and so on.
+ *
+ * That consumer is invisible to BOTH legs of the sweep's evidence standard:
+ *
+ *   - the AST pass only classifies `t()` / `tt()` calls, and there is no call;
+ *   - the text safety net greps the FULL dotted key, and the full dotted key is
+ *     never spelled — the namespace segment is bound to a local variable, so the
+ *     source reads `strings.loadingSteps.connecting`, never
+ *     `console.loadingSteps.connecting`.
+ *
+ * A reverse sweep therefore reports this whole family as CONFIRMED dead, at the
+ * strongest tier, with no hint that anything was missed. Deleting it ships a
+ * blank splash screen in ten locales on exactly the server-down boot the screen
+ * exists to explain. Pinned by name so the next sweep round cannot repeat it.
+ */
+const BLIND_SPOT_LIVE = [
+  'console.loadingSteps.connecting',
+  'console.loadingSteps.loadingConfig',
+  'console.loadingSteps.preparingWorkspace',
+  'console.error.connectionFailed',
+  'console.error.checkServer',
+  'console.initializing',
+  'console.loadingHint',
+  'console.actions.retry',
+  'console.actions.retrying',
+] as const;
+
+describe('objectui#4730 dead-key batch is retired from the ten packs', () => {
+  it('covers all ten packs', () => {
+    // Guards the premise the rest of the file rests on: a pin that iterates an
+    // empty pack list is green for the wrong reason.
+    expect(LANGS).toHaveLength(10);
+  });
+
+  it('no pack defines any retired key', () => {
+    const revived: string[] = [];
+    for (const lang of LANGS) {
+      for (const key of RETIRED) {
+        if (at(builtInLocales[lang], key) !== undefined) revived.push(`${lang} :: ${key}`);
+      }
+    }
+    // Named, not counted: a half-reverted retirement is repaired pack by pack.
+    expect(
+      revived,
+      'A key retired by objectui#4730 is back in a locale pack. Each was ' +
+        'confirmed dead individually: zero t() call sites, zero textual ' +
+        'footprint outside the packs, and a read of its plausible consumer. No ' +
+        'other i18n gate can see a dead key return, because every one of them ' +
+        'runs call site -> key. If the surface a retired key named is being ' +
+        'reintroduced, author its label alongside the control rather than ' +
+        'restoring this row.',
+    ).toEqual([]);
+  });
+
+  it('no pack defines a namespace root that held nothing but retired keys', () => {
+    const revived: string[] = [];
+    for (const lang of LANGS) {
+      for (const root of RETIRED_ROOTS) {
+        if (at(builtInLocales[lang], root) !== undefined) revived.push(`${lang} :: ${root}`);
+      }
+    }
+    expect(
+      revived,
+      'An empty namespace container retired by objectui#4730 is back. These ' +
+        'roots held only retired leaves, so they went with them; a root that ' +
+        'returns is either an empty object (noise the parity gate happily ' +
+        'accepts) or a re-authored vocabulary that needs its own review.',
+    ).toEqual([]);
+  });
+
+  it('keeps the `grid.*` vocabulary that superseded the retired twins', () => {
+    const missing: string[] = [];
+    for (const lang of LANGS) {
+      for (const key of SUPERSEDING_TWINS) {
+        if (typeof at(builtInLocales[lang], key) !== 'string') missing.push(`${lang} :: ${key}`);
+      }
+    }
+    expect(
+      missing,
+      'A `grid.*` key that superseded a retired `cellRender.*` / `rowAction.*` ' +
+        'twin is gone. Retiring the twin was de-duplication only because these ' +
+        'still exist and are read by ObjectGrid.tsx / RowActionMenu.tsx; ' +
+        'without them the retirement becomes a loss of function.',
+    ).toEqual([]);
+  });
+
+  it('the deletion swept around the live siblings in every trimmed namespace', () => {
+    const missing: string[] = [];
+    for (const lang of LANGS) {
+      for (const key of SURVIVING) {
+        const value = at(builtInLocales[lang], key);
+        if (typeof value !== 'string' || value.length === 0) missing.push(`${lang} :: ${key}`);
+      }
+    }
+    expect(missing, 'a live sibling of a retired key is gone').toEqual([]);
+  });
+
+  it('keeps the bootstrap strings the reverse sweep reports as dead but are LIVE', () => {
+    // See BLIND_SPOT_LIVE's docstring. These are consumed by property access on
+    // the imported pack object, which neither the AST pass nor the dotted-key
+    // text net can see, so the sweep reports them CONFIRMED dead. They are not.
+    const missing: string[] = [];
+    for (const lang of LANGS) {
+      for (const key of BLIND_SPOT_LIVE) {
+        if (typeof at(builtInLocales[lang], key) !== 'string') missing.push(`${lang} :: ${key}`);
+      }
+    }
+    expect(
+      missing,
+      'A bootstrap string read by LoadingScreen.tsx is gone from a pack. ' +
+        'LoadingScreen deliberately does not call t() — it renders before i18n ' +
+        'loads — and reads these as object properties off the imported pack ' +
+        '(`strings.loadingSteps.connecting`). check-i18n-dead-keys.mjs reports ' +
+        'them CONFIRMED dead because the full dotted key is never spelled in ' +
+        'source; that report is WRONG for this family. Deleting these renders a ' +
+        'blank splash screen in ten locales on a server-down boot.',
+    ).toEqual([]);
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -341,7 +341,6 @@ const ar = {
       undo: "تراجع",
       undoing: "جارٍ التراجع…",
       done: "تم",
-      selectPlaceholder: "اختر…",
       loading: "جارٍ التحميل…",
     },
     actions: "إجراءات",
@@ -535,9 +534,7 @@ const ar = {
     month: "شهر",
     week: "أسبوع",
     day: "يوم",
-    agenda: "جدول أعمال",
     allDay: "طوال اليوم",
-    noEvents: "لا توجد أحداث",
     newEvent: "حدث جديد",
     moreEvents: "+{{count}} المزيد",
   },
@@ -1034,16 +1031,8 @@ const ar = {
     noValue: "لا قيمة",
   },
   chart: {
-    noData: "لا تتوفر بيانات للرسم البياني",
     loading: "جاري تحميل الرسم البياني…",
     nullCategory: "(غير محدد)",
-  },
-  map: {
-    searchLocations: "البحث عن المواقع…",
-    locationDetails: "تفاصيل الموقع",
-    markersCount: "{{count}} علامة",
-    invalidCoordinates: "{{count}} سجل بإحداثيات مفقودة أو غير صالحة مستبعد من الخريطة.",
-    invalidCoordinatesPlural: "{{count}} سجلات بإحداثيات مفقودة أو غير صالحة مستبعدة من الخريطة.",
   },
   dashboard: {
     noRows: "لا توجد صفوف",
@@ -2282,8 +2271,6 @@ const ar = {
     browseMarketplace: "تصفح متجر التطبيقات",
     quickActions: {
       title: "إجراءات سريعة",
-      createApp: "إنشاء تطبيق",
-      createAppDesc: "ابدأ بتطبيق جديد",
       manageObjects: "إدارة الكائنات",
       manageObjectsDesc: "تكوين نماذج البيانات",
       systemSettings: "إعدادات النظام",
@@ -2299,11 +2286,6 @@ const ar = {
     greetingNight: "وردية الليل",
     heroTagline: "استمر من حيث توقفت أو اكتشف شيئاً جديداً.",
     open: "فتح",
-    stats: {
-      apps: "التطبيقات",
-      starred: "المميزة",
-      recent: "الأخيرة",
-    },
     recentApps: {
       title: "فُتح مؤخراً",
       itemType: {
@@ -2334,7 +2316,6 @@ const ar = {
       organizations: "المؤسسات",
       roles: "الأدوار",
       configuration: "التهيئة",
-      createApp: "إنشاء تطبيق",
       administration: "الإدارة",
       datasources: "مصادر البيانات",
       documentation: "الوثائق",
@@ -2424,8 +2405,6 @@ const ar = {
     cancel: "إلغاء",
     confirm: "تأكيد",
     uploading: "جارٍ الرفع…",
-    defaultActionTitle: "إجراء",
-    ok: "موافق",
     lookupPlaceholder: "معرف السجل لـ {{label}}",
     lookupHelpText: "لم يتم تكوين كائن مرجعي لهذه المعلمة، لذا فإن أداة اختيار السجلات غير متاحة. أدخل معرف السجل، أو اطلب من المسؤول تصحيح معلمة الإجراء.",
   },
@@ -2433,11 +2412,6 @@ const ar = {
     title: "تأكيد الإجراء",
     confirm: "متابعة",
     cancel: "إلغاء",
-  },
-  rowAction: {
-    openMenu: "فتح القائمة",
-    edit: "تعديل",
-    delete: "حذف",
   },
   navigationSync: {
     addedPage: "تم تحديث التنقل: تمت إضافة الصفحة \"{{name}}\"",
@@ -2469,15 +2443,6 @@ const ar = {
     printDialogOpening: "جارٍ فتح مربع حوار الطباعة في المتصفح (ليس تصديرًا إلى PDF)",
     exportFailed: "فشل التصدير: {{message}}",
     forecastSoon: "عرض التوقعات قادم قريباً",
-  },
-  recordDetail: {
-    viewersTooltip: "المستخدمون يشاهدون هذا السجل الآن",
-  },
-  cellRender: {
-    empty: "فارغ",
-    yes: "نعم",
-    no: "لا",
-    systemFields: "النظام",
   },
   user: {
     profile: "الملف الشخصي",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -337,7 +337,6 @@ const de = {
       undo: "Rückgängig",
       undoing: "Wird rückgängig gemacht…",
       done: "Fertig",
-      selectPlaceholder: "Auswählen…",
       loading: "Wird geladen…",
     },
     actions: "Aktionen",
@@ -531,9 +530,7 @@ const de = {
     month: "Monat",
     week: "Woche",
     day: "Tag",
-    agenda: "Agenda",
     allDay: "Ganztägig",
-    noEvents: "Keine Termine",
     newEvent: "Neuer Termin",
     moreEvents: "+{{count}} weitere",
   },
@@ -1027,16 +1024,8 @@ const de = {
     noValue: "Kein Wert",
   },
   chart: {
-    noData: "Keine Diagrammdaten verfügbar",
     loading: "Diagramm wird geladen…",
     nullCategory: "(Ohne Angabe)",
-  },
-  map: {
-    searchLocations: "Orte suchen…",
-    locationDetails: "Standortdetails",
-    markersCount: "{{count}} Markierungen",
-    invalidCoordinates: "{{count}} Datensatz mit fehlenden oder ungültigen Koordinaten von der Karte ausgeschlossen.",
-    invalidCoordinatesPlural: "{{count}} Datensätze mit fehlenden oder ungültigen Koordinaten von der Karte ausgeschlossen.",
   },
   dashboard: {
     noRows: "Keine Zeilen",
@@ -2275,8 +2264,6 @@ const de = {
     browseMarketplace: "App-Marktplatz durchsuchen",
     quickActions: {
       title: "Schnellaktionen",
-      createApp: "App erstellen",
-      createAppDesc: "Beginnen Sie mit einer neuen Anwendung",
       manageObjects: "Objekte verwalten",
       manageObjectsDesc: "Datenmodelle konfigurieren",
       systemSettings: "Systemeinstellungen",
@@ -2292,11 +2279,6 @@ const de = {
     greetingNight: "Nachtschicht",
     heroTagline: "Machen Sie dort weiter, wo Sie aufgehört haben, oder entdecken Sie etwas Neues.",
     open: "Öffnen",
-    stats: {
-      apps: "Anwendungen",
-      starred: "Markiert",
-      recent: "Zuletzt verwendet",
-    },
     recentApps: {
       title: "Zuletzt geöffnet",
       itemType: {
@@ -2327,7 +2309,6 @@ const de = {
       organizations: "Organisationen",
       roles: "Rollen",
       configuration: "Konfiguration",
-      createApp: "App erstellen",
       administration: "Verwaltung",
       datasources: "Datenquellen",
       documentation: "Dokumentation",
@@ -2417,8 +2398,6 @@ const de = {
     cancel: "Abbrechen",
     confirm: "Bestätigen",
     uploading: "Wird hochgeladen…",
-    defaultActionTitle: "Aktion",
-    ok: "OK",
     lookupPlaceholder: "Datensatz-ID für {{label}}",
     lookupHelpText: "Für diesen Parameter ist kein Referenzobjekt konfiguriert, daher ist die Datensatzauswahl nicht verfügbar. Geben Sie eine Datensatz-ID ein oder bitten Sie einen Administrator, den Aktionsparameter zu korrigieren.",
   },
@@ -2426,11 +2405,6 @@ const de = {
     title: "Aktion bestätigen",
     confirm: "Weiter",
     cancel: "Abbrechen",
-  },
-  rowAction: {
-    openMenu: "Menü öffnen",
-    edit: "Bearbeiten",
-    delete: "Löschen",
   },
   navigationSync: {
     addedPage: "Navigation aktualisiert: Seite „{{name}}“ hinzugefügt",
@@ -2462,15 +2436,6 @@ const de = {
     printDialogOpening: "Druckdialog Ihres Browsers wird geöffnet (kein PDF-Export)",
     exportFailed: "Export fehlgeschlagen: {{message}}",
     forecastSoon: "Prognoseansicht kommt bald",
-  },
-  recordDetail: {
-    viewersTooltip: "Benutzer, die diesen Datensatz gerade ansehen",
-  },
-  cellRender: {
-    empty: "Leer",
-    yes: "Ja",
-    no: "Nein",
-    systemFields: "System",
   },
   user: {
     profile: "Profil",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -603,7 +603,6 @@ const en = {
       undo: 'Undo',
       undoing: 'Undoing\u2026',
       done: 'Done',
-      selectPlaceholder: 'Select\u2026',
       loading: 'Loading\u2026',
     },
   },
@@ -612,9 +611,7 @@ const en = {
     month: 'Month',
     week: 'Week',
     day: 'Day',
-    agenda: 'Agenda',
     allDay: 'All Day',
-    noEvents: 'No events',
     newEvent: 'New event',
     moreEvents: '+{{count}} more',
   },
@@ -1152,7 +1149,6 @@ const en = {
     noValue: 'No value',
   },
   chart: {
-    noData: 'No chart data available',
     loading: 'Loading chart…',
     nullCategory: '(None)',
   },
@@ -1195,13 +1191,6 @@ const en = {
       // any retired key that returns.
       panelTitle: 'Edit report',
     },
-  },
-  map: {
-    searchLocations: 'Search locations…',
-    locationDetails: 'Location Details',
-    markersCount: '{{count}} markers',
-    invalidCoordinates: '{{count}} record with missing or invalid coordinates excluded from the map.',
-    invalidCoordinatesPlural: '{{count}} records with missing or invalid coordinates excluded from the map.',
   },
   designer: {
     undo: 'Undo',
@@ -2488,11 +2477,6 @@ const en = {
       marketplaceDisabled: 'This runtime has no app marketplace configured, so there are no templates to install here.',
     },
     open: 'Open',
-    stats: {
-      apps: 'Applications',
-      starred: 'Starred',
-      recent: 'Recent items',
-    },
     loading: 'Loading workspace…',
     recent: 'Recent',
     starred: 'Starred',
@@ -2531,8 +2515,6 @@ const en = {
     browseMarketplace: 'Browse App Marketplace',
     quickActions: {
       title: 'Quick Actions',
-      createApp: 'Create App',
-      createAppDesc: 'Start with a new application',
       manageObjects: 'Manage Objects',
       manageObjectsDesc: 'Configure data models',
       systemSettings: 'System Settings',
@@ -2584,7 +2566,6 @@ const en = {
       organizations: 'Organizations',
       roles: 'Roles',
       configuration: 'Configuration',
-      createApp: 'Create App',
       administration: 'Administration',
       datasources: 'Datasources',
       documentation: 'Documentation',
@@ -2745,18 +2726,11 @@ const en = {
     cancel: 'Cancel',
     confirm: 'Confirm',
     uploading: 'Uploading…',
-    defaultActionTitle: 'Action',
-    ok: 'OK',
   },
   actionConfirm: {
     title: 'Confirm Action',
     confirm: 'Continue',
     cancel: 'Cancel',
-  },
-  rowAction: {
-    openMenu: 'Open menu',
-    edit: 'Edit',
-    delete: 'Delete',
   },
   navigationSync: {
     addedPage: 'Navigation updated: added page "{{name}}"',
@@ -2790,15 +2764,6 @@ const en = {
     printDialogOpening: 'Opening your browser’s print dialog (not a PDF export)',
     exportFailed: 'Export failed: {{message}}',
     forecastSoon: 'Forecast view coming soon',
-  },
-  recordDetail: {
-    viewersTooltip: 'Users viewing this record',
-  },
-  cellRender: {
-    empty: 'Empty',
-    yes: 'Yes',
-    no: 'No',
-    systemFields: 'System',
   },
   user: {
     profile: 'Profile',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -341,7 +341,6 @@ const es = {
       undo: "Deshacer",
       undoing: "Deshaciendo…",
       done: "Listo",
-      selectPlaceholder: "Seleccionar…",
       loading: "Cargando…",
     },
     actions: "Acciones",
@@ -535,9 +534,7 @@ const es = {
     month: "Mes",
     week: "Semana",
     day: "Día",
-    agenda: "Agenda",
     allDay: "Todo el día",
-    noEvents: "Sin eventos",
     newEvent: "Nuevo evento",
     moreEvents: "+{{count}} más",
   },
@@ -1031,16 +1028,8 @@ const es = {
     noValue: "Sin valor",
   },
   chart: {
-    noData: "No hay datos de gráfico disponibles",
     loading: "Cargando gráfico…",
     nullCategory: "(Sin especificar)",
-  },
-  map: {
-    searchLocations: "Buscar ubicaciones…",
-    locationDetails: "Detalles de ubicación",
-    markersCount: "{{count}} marcadores",
-    invalidCoordinates: "{{count}} registro con coordenadas faltantes o inválidas excluido del mapa.",
-    invalidCoordinatesPlural: "{{count}} registros con coordenadas faltantes o inválidas excluidos del mapa.",
   },
   dashboard: {
     noRows: "Sin filas",
@@ -2279,8 +2268,6 @@ const es = {
     browseMarketplace: "Explorar marketplace de apps",
     quickActions: {
       title: "Acciones rápidas",
-      createApp: "Crear app",
-      createAppDesc: "Comienza con una nueva aplicación",
       manageObjects: "Gestionar objetos",
       manageObjectsDesc: "Configura modelos de datos",
       systemSettings: "Configuración del sistema",
@@ -2296,11 +2283,6 @@ const es = {
     greetingNight: "Turno de noche",
     heroTagline: "Continúe donde lo dejó o descubra algo nuevo.",
     open: "Abrir",
-    stats: {
-      apps: "Aplicaciones",
-      starred: "Destacados",
-      recent: "Recientes",
-    },
     recentApps: {
       title: "Abiertos recientemente",
       itemType: {
@@ -2331,7 +2313,6 @@ const es = {
       organizations: "Organizaciones",
       roles: "Roles",
       configuration: "Configuración",
-      createApp: "Crear aplicación",
       administration: "Administración",
       datasources: "Fuentes de datos",
       documentation: "Documentación",
@@ -2421,8 +2402,6 @@ const es = {
     cancel: "Cancelar",
     confirm: "Confirmar",
     uploading: "Subiendo…",
-    defaultActionTitle: "Acción",
-    ok: "Aceptar",
     lookupPlaceholder: "ID de registro para {{label}}",
     lookupHelpText: "Este parámetro no tiene un objeto de referencia configurado, por lo que el selector de registros no está disponible. Ingrese un ID de registro o pida a un administrador que corrija el parámetro de la acción.",
   },
@@ -2430,11 +2409,6 @@ const es = {
     title: "Confirmar acción",
     confirm: "Continuar",
     cancel: "Cancelar",
-  },
-  rowAction: {
-    openMenu: "Abrir menú",
-    edit: "Editar",
-    delete: "Eliminar",
   },
   navigationSync: {
     addedPage: "Navegación actualizada: página \"{{name}}\" agregada",
@@ -2466,15 +2440,6 @@ const es = {
     printDialogOpening: "Abriendo el cuadro de diálogo de impresión de tu navegador (no es una exportación a PDF)",
     exportFailed: "Error al exportar: {{message}}",
     forecastSoon: "La vista de pronóstico llegará pronto",
-  },
-  recordDetail: {
-    viewersTooltip: "Usuarios viendo este registro ahora",
-  },
-  cellRender: {
-    empty: "Vacío",
-    yes: "Sí",
-    no: "No",
-    systemFields: "Sistema",
   },
   user: {
     profile: "Perfil",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -337,7 +337,6 @@ const fr = {
       undo: "Annuler",
       undoing: "Annulation…",
       done: "Terminé",
-      selectPlaceholder: "Sélectionner…",
       loading: "Chargement…",
     },
     actions: "Actions",
@@ -531,9 +530,7 @@ const fr = {
     month: "Mois",
     week: "Semaine",
     day: "Jour",
-    agenda: "Agenda",
     allDay: "Toute la journée",
-    noEvents: "Aucun événement",
     newEvent: "Nouvel événement",
     moreEvents: "+{{count}} de plus",
   },
@@ -1029,16 +1026,8 @@ const fr = {
     noValue: "Aucune valeur",
   },
   chart: {
-    noData: "Aucune donnée de graphique disponible",
     loading: "Chargement du graphique…",
     nullCategory: "(Non défini)",
-  },
-  map: {
-    searchLocations: "Rechercher des lieux…",
-    locationDetails: "Détails du lieu",
-    markersCount: "{{count}} marqueurs",
-    invalidCoordinates: "{{count}} enregistrement avec des coordonnées manquantes ou invalides exclu de la carte.",
-    invalidCoordinatesPlural: "{{count}} enregistrements avec des coordonnées manquantes ou invalides exclus de la carte.",
   },
   dashboard: {
     noRows: "Aucune ligne",
@@ -2277,8 +2266,6 @@ const fr = {
     browseMarketplace: "Parcourir la marketplace d'apps",
     quickActions: {
       title: "Actions rapides",
-      createApp: "Créer une app",
-      createAppDesc: "Commencez avec une nouvelle application",
       manageObjects: "Gérer les objets",
       manageObjectsDesc: "Configurer les modèles de données",
       systemSettings: "Paramètres système",
@@ -2294,11 +2281,6 @@ const fr = {
     greetingNight: "Travail de nuit",
     heroTagline: "Reprenez là où vous vous êtes arrêté ou découvrez quelque chose de nouveau.",
     open: "Ouvrir",
-    stats: {
-      apps: "Applications",
-      starred: "Étoilés",
-      recent: "Récents",
-    },
     recentApps: {
       title: "Récemment ouverts",
       itemType: {
@@ -2329,7 +2311,6 @@ const fr = {
       organizations: "Organisations",
       roles: "Rôles",
       configuration: "Configuration",
-      createApp: "Créer une application",
       administration: "Administration",
       datasources: "Sources de données",
       documentation: "Documentation",
@@ -2419,8 +2400,6 @@ const fr = {
     cancel: "Annuler",
     confirm: "Confirmer",
     uploading: "Téléversement…",
-    defaultActionTitle: "Action",
-    ok: "OK",
     lookupPlaceholder: "ID d'enregistrement pour {{label}}",
     lookupHelpText: "Aucun objet de référence n'est configuré pour ce paramètre, le sélecteur d'enregistrement est donc indisponible. Saisissez un ID d'enregistrement ou demandez à un administrateur de corriger le paramètre d'action.",
   },
@@ -2428,11 +2407,6 @@ const fr = {
     title: "Confirmer l’action",
     confirm: "Continuer",
     cancel: "Annuler",
-  },
-  rowAction: {
-    openMenu: "Ouvrir le menu",
-    edit: "Modifier",
-    delete: "Supprimer",
   },
   navigationSync: {
     addedPage: "Navigation mise à jour : page \"{{name}}\" ajoutée",
@@ -2464,15 +2438,6 @@ const fr = {
     printDialogOpening: "Ouverture de la boîte de dialogue d'impression de votre navigateur (ce n'est pas un export PDF)",
     exportFailed: "Échec de l'export : {{message}}",
     forecastSoon: "La vue de prévision arrive bientôt",
-  },
-  recordDetail: {
-    viewersTooltip: "Utilisateurs consultant cet enregistrement en ce moment",
-  },
-  cellRender: {
-    empty: "Vide",
-    yes: "Oui",
-    no: "Non",
-    systemFields: "Système",
   },
   user: {
     profile: "Profil",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -337,7 +337,6 @@ const ja = {
       undo: "取り消す",
       undoing: "取り消し中…",
       done: "完了",
-      selectPlaceholder: "選択…",
       loading: "読み込み中…",
     },
     actions: "アクション",
@@ -531,9 +530,7 @@ const ja = {
     month: "月",
     week: "週",
     day: "日",
-    agenda: "予定表",
     allDay: "終日",
-    noEvents: "予定はありません",
     newEvent: "新しい予定",
     moreEvents: "+{{count}} 件",
   },
@@ -1027,16 +1024,8 @@ const ja = {
     noValue: "値なし",
   },
   chart: {
-    noData: "チャートデータがありません",
     loading: "チャート読み込み中…",
     nullCategory: "（未設定）",
-  },
-  map: {
-    searchLocations: "場所を検索…",
-    locationDetails: "場所の詳細",
-    markersCount: "{{count}} 個のマーカー",
-    invalidCoordinates: "座標が欠落または無効なため、{{count}} 件のレコードが地図から除外されました。",
-    invalidCoordinatesPlural: "座標が欠落または無効なため、{{count}} 件のレコードが地図から除外されました。",
   },
   dashboard: {
     noRows: "行がありません",
@@ -2277,8 +2266,6 @@ const ja = {
     browseMarketplace: "アプリマーケットプレイスを参照",
     quickActions: {
       title: "クイックアクション",
-      createApp: "アプリを作成",
-      createAppDesc: "新しいアプリケーションを開始",
       manageObjects: "オブジェクトを管理",
       manageObjectsDesc: "データモデルを設定",
       systemSettings: "システム設定",
@@ -2294,11 +2281,6 @@ const ja = {
     greetingNight: "夜遅くまで作業中",
     heroTagline: "前回の続きを始めるか、新しいものを探索してください。",
     open: "開く",
-    stats: {
-      apps: "アプリケーション",
-      starred: "スター付き",
-      recent: "最近のアイテム",
-    },
     recentApps: {
       title: "最近アクセスしたもの",
       itemType: {
@@ -2329,7 +2311,6 @@ const ja = {
       organizations: "組織",
       roles: "ロール",
       configuration: "構成",
-      createApp: "アプリを作成",
       administration: "管理",
       datasources: "データソース",
       documentation: "ドキュメント",
@@ -2419,8 +2400,6 @@ const ja = {
     cancel: "キャンセル",
     confirm: "確認",
     uploading: "アップロード中…",
-    defaultActionTitle: "アクション",
-    ok: "OK",
     lookupPlaceholder: "{{label}} のレコードID",
     lookupHelpText: "このパラメータには参照オブジェクトが設定されていないため、レコードピッカーを利用できません。レコードIDを直接入力するか、管理者にアクションパラメータの修正を依頼してください。",
   },
@@ -2428,11 +2407,6 @@ const ja = {
     title: "操作の確認",
     confirm: "続行",
     cancel: "キャンセル",
-  },
-  rowAction: {
-    openMenu: "メニューを開く",
-    edit: "編集",
-    delete: "削除",
   },
   navigationSync: {
     addedPage: "ナビゲーション更新：ページ「{{name}}」を追加しました",
@@ -2464,15 +2438,6 @@ const ja = {
     printDialogOpening: "ブラウザーの印刷ダイアログを開いています（PDF エクスポートではありません）",
     exportFailed: "エクスポートに失敗しました：{{message}}",
     forecastSoon: "予測ビューは近日公開予定",
-  },
-  recordDetail: {
-    viewersTooltip: "このレコードを閲覧中のユーザー",
-  },
-  cellRender: {
-    empty: "空",
-    yes: "はい",
-    no: "いいえ",
-    systemFields: "システム",
   },
   user: {
     profile: "プロフィール",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -337,7 +337,6 @@ const ko = {
       undo: "되돌리기",
       undoing: "되돌리는 중…",
       done: "완료",
-      selectPlaceholder: "선택…",
       loading: "로딩 중…",
     },
     actions: "작업",
@@ -531,9 +530,7 @@ const ko = {
     month: "월",
     week: "주",
     day: "일",
-    agenda: "일정",
     allDay: "종일",
-    noEvents: "일정이 없습니다",
     newEvent: "새 일정",
     moreEvents: "+{{count}} 더보기",
   },
@@ -1027,16 +1024,8 @@ const ko = {
     noValue: "값 없음",
   },
   chart: {
-    noData: "차트 데이터가 없습니다",
     loading: "차트 로딩 중…",
     nullCategory: "(미지정)",
-  },
-  map: {
-    searchLocations: "위치 검색…",
-    locationDetails: "위치 상세",
-    markersCount: "마커 {{count}}개",
-    invalidCoordinates: "좌표가 누락되었거나 유효하지 않아 {{count}}개 레코드가 지도에서 제외되었습니다.",
-    invalidCoordinatesPlural: "좌표가 누락되었거나 유효하지 않아 {{count}}개 레코드가 지도에서 제외되었습니다.",
   },
   dashboard: {
     noRows: "행 없음",
@@ -2274,8 +2263,6 @@ const ko = {
     browseMarketplace: "앱 마켓플레이스 탐색",
     quickActions: {
       title: "빠른 작업",
-      createApp: "앱 생성",
-      createAppDesc: "새 애플리케이션으로 시작",
       manageObjects: "객체 관리",
       manageObjectsDesc: "데이터 모델 구성",
       systemSettings: "시스템 설정",
@@ -2291,11 +2278,6 @@ const ko = {
     greetingNight: "야간 작업 중",
     heroTagline: "마지막으로 중단한 곳에서 이어서 하거나 새로운 것을 발견해 보세요.",
     open: "열기",
-    stats: {
-      apps: "앱",
-      starred: "즐겨찾기",
-      recent: "최근",
-    },
     recentApps: {
       title: "최근 열린 항목",
       itemType: {
@@ -2326,7 +2308,6 @@ const ko = {
       organizations: "조직",
       roles: "역할",
       configuration: "구성",
-      createApp: "앱 만들기",
       administration: "관리",
       datasources: "데이터 소스",
       documentation: "문서",
@@ -2416,8 +2397,6 @@ const ko = {
     cancel: "취소",
     confirm: "확인",
     uploading: "업로드 중…",
-    defaultActionTitle: "작업",
-    ok: "확인",
     lookupPlaceholder: "{{label}}의 레코드 ID",
     lookupHelpText: "이 매개변수에 참조 개체가 설정되어 있지 않아 레코드 선택기를 사용할 수 없습니다. 레코드 ID를 직접 입력하거나 관리자에게 작업 매개변수 수정을 요청하세요.",
   },
@@ -2425,11 +2404,6 @@ const ko = {
     title: "작업 확인",
     confirm: "계속",
     cancel: "취소",
-  },
-  rowAction: {
-    openMenu: "메뉴 열기",
-    edit: "편집",
-    delete: "삭제",
   },
   navigationSync: {
     addedPage: "탐색 업데이트: 페이지 \"{{name}}\" 추가됨",
@@ -2461,15 +2435,6 @@ const ko = {
     printDialogOpening: "브라우저의 인쇄 대화 상자를 여는 중입니다（PDF 내보내기가 아닙니다）",
     exportFailed: "내보내기 실패: {{message}}",
     forecastSoon: "예측 보기가 곧 출시됩니다",
-  },
-  recordDetail: {
-    viewersTooltip: "현재 이 레코드를 보고 있는 사용자",
-  },
-  cellRender: {
-    empty: "비어 있음",
-    yes: "예",
-    no: "아니요",
-    systemFields: "시스템",
   },
   user: {
     profile: "프로필",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -336,7 +336,6 @@ const pt = {
       undo: "Desfazer",
       undoing: "Desfazendo…",
       done: "Concluído",
-      selectPlaceholder: "Selecionar…",
       loading: "Carregando…",
     },
     actions: "Ações",
@@ -530,9 +529,7 @@ const pt = {
     month: "Mês",
     week: "Semana",
     day: "Dia",
-    agenda: "Agenda",
     allDay: "Dia inteiro",
-    noEvents: "Sem eventos",
     newEvent: "Novo evento",
     moreEvents: "+{{count}} mais",
   },
@@ -1026,16 +1023,8 @@ const pt = {
     noValue: "Sem valor",
   },
   chart: {
-    noData: "Nenhum dado de gráfico disponível",
     loading: "Carregando gráfico…",
     nullCategory: "(Não especificado)",
-  },
-  map: {
-    searchLocations: "Pesquisar locais…",
-    locationDetails: "Detalhes do local",
-    markersCount: "{{count}} marcadores",
-    invalidCoordinates: "{{count}} registro com coordenadas ausentes ou inválidas excluído do mapa.",
-    invalidCoordinatesPlural: "{{count}} registros com coordenadas ausentes ou inválidas excluídos do mapa.",
   },
   dashboard: {
     noRows: "Sem linhas",
@@ -2274,8 +2263,6 @@ const pt = {
     browseMarketplace: "Explorar marketplace de apps",
     quickActions: {
       title: "Ações rápidas",
-      createApp: "Criar app",
-      createAppDesc: "Comece com uma nova aplicação",
       manageObjects: "Gerenciar objetos",
       manageObjectsDesc: "Configure modelos de dados",
       systemSettings: "Configurações do sistema",
@@ -2291,11 +2278,6 @@ const pt = {
     greetingNight: "Turno da noite",
     heroTagline: "Continue de onde parou ou descubra algo novo.",
     open: "Abrir",
-    stats: {
-      apps: "Aplicativos",
-      starred: "Favoritos",
-      recent: "Recentes",
-    },
     recentApps: {
       title: "Abertos recentemente",
       itemType: {
@@ -2326,7 +2308,6 @@ const pt = {
       organizations: "Organizações",
       roles: "Perfis",
       configuration: "Configuração",
-      createApp: "Criar aplicativo",
       administration: "Administração",
       datasources: "Fontes de dados",
       documentation: "Documentação",
@@ -2416,8 +2397,6 @@ const pt = {
     cancel: "Cancelar",
     confirm: "Confirmar",
     uploading: "Enviando…",
-    defaultActionTitle: "Ação",
-    ok: "OK",
     lookupPlaceholder: "ID do registro para {{label}}",
     lookupHelpText: "Este parâmetro não tem um objeto de referência configurado, portanto o seletor de registros não está disponível. Insira um ID de registro ou peça a um administrador para corrigir o parâmetro da ação.",
   },
@@ -2425,11 +2404,6 @@ const pt = {
     title: "Confirmar ação",
     confirm: "Continuar",
     cancel: "Cancelar",
-  },
-  rowAction: {
-    openMenu: "Abrir menu",
-    edit: "Editar",
-    delete: "Excluir",
   },
   navigationSync: {
     addedPage: "Navegação atualizada: página \"{{name}}\" adicionada",
@@ -2461,15 +2435,6 @@ const pt = {
     printDialogOpening: "Abrindo a caixa de diálogo de impressão do navegador (não é uma exportação para PDF)",
     exportFailed: "Falha na exportação: {{message}}",
     forecastSoon: "A exibição de previsão está chegando em breve",
-  },
-  recordDetail: {
-    viewersTooltip: "Usuários visualizando este registro agora",
-  },
-  cellRender: {
-    empty: "Vazio",
-    yes: "Sim",
-    no: "Não",
-    systemFields: "Sistema",
   },
   user: {
     profile: "Perfil",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -343,7 +343,6 @@ const ru = {
       undo: "Отменить",
       undoing: "Отмена…",
       done: "Готово",
-      selectPlaceholder: "Выберите…",
       loading: "Загрузка…",
     },
     actions: "Действия",
@@ -537,9 +536,7 @@ const ru = {
     month: "Месяц",
     week: "Неделя",
     day: "День",
-    agenda: "Расписание",
     allDay: "Весь день",
-    noEvents: "Нет событий",
     newEvent: "Новое событие",
     moreEvents: "+{{count}} ещё",
   },
@@ -1037,16 +1034,8 @@ const ru = {
     noValue: "Нет значения",
   },
   chart: {
-    noData: "Нет данных для графика",
     loading: "Загрузка графика…",
     nullCategory: "(Не указано)",
-  },
-  map: {
-    searchLocations: "Поиск местоположений…",
-    locationDetails: "Детали местоположения",
-    markersCount: "{{count}} маркеров",
-    invalidCoordinates: "{{count}} запись с отсутствующими или недействительными координатами исключена из карты.",
-    invalidCoordinatesPlural: "{{count}} записей с отсутствующими или недействительными координатами исключены из карты.",
   },
   dashboard: {
     noRows: "Нет строк",
@@ -2288,8 +2277,6 @@ const ru = {
     browseMarketplace: "Обзор маркетплейса приложений",
     quickActions: {
       title: "Быстрые действия",
-      createApp: "Создать приложение",
-      createAppDesc: "Начните с нового приложения",
       manageObjects: "Управление объектами",
       manageObjectsDesc: "Настройте модели данных",
       systemSettings: "Системные настройки",
@@ -2305,11 +2292,6 @@ const ru = {
     greetingNight: "Ночная смена",
     heroTagline: "Продолжите с того места, где остановились, или откройте что-то новое.",
     open: "Открыть",
-    stats: {
-      apps: "Приложения",
-      starred: "Отмеченные",
-      recent: "Недавние",
-    },
     recentApps: {
       title: "Недавно открытые",
       itemType: {
@@ -2340,7 +2322,6 @@ const ru = {
       organizations: "Организации",
       roles: "Роли",
       configuration: "Конфигурация",
-      createApp: "Создать приложение",
       administration: "Администрирование",
       datasources: "Источники данных",
       documentation: "Документация",
@@ -2430,8 +2411,6 @@ const ru = {
     cancel: "Отмена",
     confirm: "Подтвердить",
     uploading: "Загрузка…",
-    defaultActionTitle: "Действие",
-    ok: "ОК",
     lookupPlaceholder: "ID записи для {{label}}",
     lookupHelpText: "Для этого параметра не настроен объект ссылки, поэтому выбор записи недоступен. Введите ID записи или попросите администратора исправить параметр действия.",
   },
@@ -2439,11 +2418,6 @@ const ru = {
     title: "Подтвердите действие",
     confirm: "Продолжить",
     cancel: "Отмена",
-  },
-  rowAction: {
-    openMenu: "Открыть меню",
-    edit: "Редактировать",
-    delete: "Удалить",
   },
   navigationSync: {
     addedPage: "Навигация обновлена: страница \"{{name}}\" добавлена",
@@ -2475,15 +2449,6 @@ const ru = {
     printDialogOpening: "Открывается диалог печати браузера (это не экспорт в PDF)",
     exportFailed: "Ошибка экспорта: {{message}}",
     forecastSoon: "Прогнозное представление скоро будет",
-  },
-  recordDetail: {
-    viewersTooltip: "Пользователи, просматривающие эту запись",
-  },
-  cellRender: {
-    empty: "Пусто",
-    yes: "Да",
-    no: "Нет",
-    systemFields: "Система",
   },
   user: {
     profile: "Профиль",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -541,7 +541,6 @@ const zh = {
       undo: '撤销',
       undoing: '撤销中…',
       done: '完成',
-      selectPlaceholder: '请选择…',
       loading: '加载中…',
     },
   },
@@ -550,9 +549,7 @@ const zh = {
     month: '月',
     week: '周',
     day: '日',
-    agenda: '日程',
     allDay: '全天',
-    noEvents: '暂无事件',
     newEvent: '新建事件',
     moreEvents: '+{{count}} 更多',
   },
@@ -1066,7 +1063,6 @@ const zh = {
     noValue: '无',
   },
   chart: {
-    noData: '暂无图表数据',
     loading: '图表加载中…',
     nullCategory: '(未指定)',
   },
@@ -1095,13 +1091,6 @@ const zh = {
     editor: {
       panelTitle: '编辑报表',
     },
-  },
-  map: {
-    searchLocations: '搜索位置…',
-    locationDetails: '位置详情',
-    markersCount: '{{count}} 个标记',
-    invalidCoordinates: '{{count}} 条记录因坐标缺失或无效已从地图中排除。',
-    invalidCoordinatesPlural: '{{count}} 条记录因坐标缺失或无效已从地图中排除。',
   },
   dashboard: {
     addWidget: '添加组件',
@@ -2334,11 +2323,6 @@ const zh = {
       marketplaceDisabled: '本运行时未配置应用市场，因此这里没有可安装的模板。',
     },
     open: '打开',
-    stats: {
-      apps: '应用',
-      starred: '收藏',
-      recent: '最近访问',
-    },
     loading: '正在加载工作区…',
     recent: '最近使用',
     starred: '收藏',
@@ -2375,8 +2359,6 @@ const zh = {
     browseMarketplace: '浏览应用市场',
     quickActions: {
       title: '快捷操作',
-      createApp: '创建应用',
-      createAppDesc: '从新应用开始',
       manageObjects: '管理对象',
       manageObjectsDesc: '配置数据模型',
       systemSettings: '系统设置',
@@ -2427,7 +2409,6 @@ const zh = {
       organizations: '组织',
       roles: '角色',
       configuration: '配置',
-      createApp: '创建应用',
       administration: '管理',
       datasources: '数据源',
       documentation: '文档',
@@ -2581,18 +2562,11 @@ const zh = {
     cancel: '取消',
     confirm: '确认',
     uploading: '上传中…',
-    defaultActionTitle: '操作',
-    ok: '确定',
   },
   actionConfirm: {
     title: '确认操作',
     confirm: '继续',
     cancel: '取消',
-  },
-  rowAction: {
-    openMenu: '更多操作',
-    edit: '编辑',
-    delete: '删除',
   },
   navigationSync: {
     addedPage: '导航已更新：已添加页面 “{{name}}”',
@@ -2625,15 +2599,6 @@ const zh = {
     printDialogOpening: '正在打开浏览器打印对话框（不是导出 PDF）',
     exportFailed: '导出失败：{{message}}',
     forecastSoon: '预测视图即将上线',
-  },
-  recordDetail: {
-    viewersTooltip: '正在查看此记录的用户',
-  },
-  cellRender: {
-    empty: '空',
-    yes: '是',
-    no: '否',
-    systemFields: '系统字段',
   },
   user: {
     profile: '个人资料',


### PR DESCRIPTION
Refs #4730
Fixes #5783

Retires 25 individually hand-confirmed dead locale keys from all ten packs — 250 translated strings with no reader anywhere in the repo. The umbrella #4730 stays open: it still carries the held key-level trims (`search`, `table`, `report`, `form`, `appDesigner`), which is why this is `Refs` and not a closing keyword.

Measured at `09a1f9b3`, merge-base `813bf8323`.

## The most important finding: the evidence standard has a fourth blind spot

**Five keys this sweep reported CONFIRMED-dead in this very round are LIVE.** They were pulled back out of the batch after reading their consumer, and are now pinned as live.

`packages/app-shell/src/chrome/LoadingScreen.tsx` is bootstrap-critical UI: it must render *before* i18n loads, which is exactly when the server is unreachable. So it deliberately does not call `useObjectTranslation` — its own comment says so. Instead it imports the packs directly and reads them as **plain object properties**:

```
import { en as enLocale, builtInLocales } from '@object-ui/i18n';
...
strings.loadingSteps.connecting     // en.ts console.loadingSteps.connecting
strings.error.connectionFailed      // en.ts console.error.connectionFailed
```

That consumer is invisible to **both** legs of the #4658 standard:

- the AST pass only classifies `t()` / `tt()` calls, and there is no call;
- the text safety net greps the **full dotted key**, and the full dotted key is never spelled — the namespace segment is bound to a local variable, so the source reads `strings.loadingSteps.connecting`, never `console.loadingSteps.connecting`.

So the sweep reports the whole family at its **strongest** tier with no hint anything was missed. Deleting it ships a blank splash screen in ten locales on exactly the server-down boot the screen exists to explain.

Kept and pinned: `console.loadingSteps.connecting` / `.loadingConfig` / `.preparingWorkspace`, `console.error.connectionFailed` / `.checkServer`, plus `console.initializing`, `console.loadingHint`, `console.actions.retry` / `.retrying`.

A **fourth leg** was added to close this for the batch — a property-chain probe on the tail (`.loadingSteps.connecting`) rather than the full dotted key. It was validated with a positive and negative control before being trusted: the 5 keys proved live by reading source → detected; `console.error.serverUnreachable` / `.timeout`, which genuinely have no pack reader → 0.

## Step 1 — re-derived counts, and why a matching number was NOT confirmation

| | card body | 2026-08-25 refresh (`062943f86`) | **re-derived (`813bf8323`)** |
|---|---|---|---|
| candidates | 626 | 389 | **389** |
| CONFIRMED | 384 | 150 | **146** |
| namespaces | 58 | 55 | **55** |
| NEEDS-REVIEW | 242 | 239 | **243** |

Candidates and namespaces match the refresh **exactly**. That is a collision, not a match, and the population moved underneath it — measured with the instrument's own `collectEnKeys`:

- pack keys `2848` → `2856` (**9 added**, all `packagedAutomation.*`; **1 removed**, `appDesigner.fieldDesigner.formula`, the #6310 retirement)
- 115 commits, `en.ts` net +22 lines

So 389 = 389 sits on top of a 10-key population change with 4 keys migrating CONFIRMED → NEEDS-REVIEW. Reading the equal total as "nothing changed" would have been the wrong reading of a right number.

## Step 2 — the batch, and how each key was confirmed

25 keys, deliberately bounded. Each cleared all four legs individually; none was taken from the tool's output.

**Superseded twin vocabularies** — a `grid.*` vocabulary won, and the twin lost its reader:

| retired | live winner | read at |
|---|---|---|
| `rowAction.openMenu` / `.edit` / `.delete` | `grid.openMenu` / `grid.edit` / `grid.delete` | `RowActionMenu.tsx:638,652,663` |
| `cellRender.empty` / `.yes` / `.no` / `.systemFields` | `grid.empty` / `grid.yes` / `grid.no` / `grid.systemFields` | `ObjectGrid.tsx:3670,1725,1726,3726` |

`RowActionMenu.tsx` is *fully i18n-wired* and demonstrably reads the other namespace — the strongest leg-3 evidence available, since the consumer exists and can be shown to ask for something else.

**Labels that outlived their control:**

- `calendar.agenda` — labelled a view mode #5740 retired; `CalendarViewMode` is now `'month' | 'week' | 'day'` and the zod enum matches. The switcher renders exactly `day`/`week`/`month` (`CalendarView.tsx:347-349`) and `DEFAULT_TRANSLATIONS` (lines 77-85) carries no entry. This is what #5783 recorded.
- `calendar.noEvents` — no empty-state renders it.
- `home.quickActions.createApp` / `.createAppDesc` — `QuickActions.tsx` is wired and reads `manageObjects`, `systemSettings`, `title`; not these.
- `layout.systemNav.createApp` — `AppSidebar.tsx` / `UnifiedSidebar.tsx` read ~12 sibling `systemNav` keys; not this one.
- `actionDialog.defaultActionTitle` / `.ok` — `ActionParamDialog.tsx` reads `title`, `description`, `cancel`, `confirm`; the retired pair are superseded spellings of two of those.
- `grid.bulk.selectPlaceholder` — `BulkActionDialog.tsx` reads a dozen `grid.bulk.*` keys; not this one.
- `chart.noData` — the live `chart.nullCategory` survives; `dashboard.noDataAvailable` is a different, live key.

**Surfaces that left the product:**

- `map.*` (5 keys) — the strongest form. `@object-ui/plugin-map` declares **no** `@object-ui/i18n` dependency and contains **no** `t()` call at all, so it cannot consume a locale string. The messages have no hardcoded twin either.
- `home.stats.*` (3) and `recordDetail.viewersTooltip` — name surfaces nothing renders.

Five namespaces held nothing but retired leaves and went with them: `map`, `cellRender`, `rowAction`, `recordDetail`, `home.stats`.

## Counter-probe — per key, not per total

Identical `grep -rFn -I` pipeline, locale packs excluded, for candidates and controls.

- **25 candidates → 0 hit lines each.**
- **28 controls → every one hits at least once**, per key: `calendar.today` 3, `.day` 2, `.week` 2, `.month` 2, `.newEvent` 3, `.moreEvents` 4, `.allDay` 2, `grid.empty` 2, `grid.yes` 10, `grid.no` 10, `grid.systemFields` 2, `grid.openMenu` 2, `grid.edit` 3, `grid.delete` 3, `home.quickActions.manageObjects` 2, `.title` 1, `.systemSettings` 2, `actionDialog.title` 5, `.description` 2, `.cancel` 2, `.confirm` 2, `layout.systemNav.systemSettings` 2, `.applications` 2, `.objectManager` 2, `chart.nullCategory` 13, `grid.bulk.confirmDefault` 1, `.affectedRecords` 1, `.retry` 1.

Reported per key precisely because a total of 76 would be satisfied by one control hitting 76 times while the rest were as invisible as the retired keys.

Separately, the one fully-variable dynamic head in the repo (`useObjectLabel.ts:604`, ``t(`${ns}.${suffix}`)``) was read rather than assumed: `ns` comes from `getAppNamespaces()` (app metadata namespaces only) and every `suffix` contains `globalActions.` or `objects.…_actions.`. It cannot reach any candidate.

## Pack parity, proved before the first line came out

The deletion tool resolves every target key in every pack through the **TypeScript AST** and refuses to write anything unless all resolve:

```
PRESENCE CHECK PASSED: all 25 keys resolve in all 10 packs (250 resolutions).
```

Landing sites are AST node ranges, not regex anchors — uniqueness is by construction (a path resolves to exactly one property or the run aborts), and every site was printed as `file:line` before any write. Result: `10 files changed, 350 deletions(-)`, **35 per pack, zero insertions in any pack.** Uniformity is a property of the method, not something the parity assertion had to catch afterwards.

## Reverse verification — both legs, direction predicted first

Restore under `trap … EXIT INT TERM`; `git diff HEAD` empty after each.

**Leg A — restore one deleted key** (`calendar.agenda`, `en` only). Anchor uniqueness asserted **before** writing: `^  calendar: {` occurs exactly 1 time. Landing site printed (`en.ts:610`) and confirmed *namespace-aware* via the AST — `calendar.agenda` resolves YES, `grid.import.agenda` resolves no. Injection proved on disk (0 → 1).

⚠️ **The predicted direction was wrong, and the real one is more interesting.** I predicted CONFIRMED +1. Observed: **NEEDS-REVIEW +1**, naming `calendar.agenda`, with CONFIRMED unmoved. The reason is structural — the new pin lists every retired key as a literal string, so a returning key now has a textual footprint and lands in NEEDS-REVIEW rather than CONFIRMED. Same mechanism, measured: committing the pin moved the 5 rescued bootstrap keys from CONFIRMED to NEEDS-REVIEW (121 → 116), while `console.error.serverUnreachable` / `.timeout` — the two with genuinely no pack reader — correctly stayed CONFIRMED. The pin does not merely assert; it demotes these in the instrument's own output so a future round will not see them at the top tier.

The rest of Leg A fired as predicted: the pin went **red on exactly one assertion**, naming `en :: calendar.agenda`, with the other five green; `all-locales-key-parity` went red naming `calendar.agenda` missing from the other nine packs.

**Leg B — delete one LIVE key** (`calendar.today`, all ten packs). This is the discriminating leg.

- `check:i18n-keys` **EXIT=1**, `2585/2586 literal keys resolve` (was 2586/2586), naming `packages/plugin-calendar/src/CalendarView.tsx:291:17  [missing-key]  calendar.today`.
- The pin **split**: `the deletion swept around the live siblings` RED (`expected [ 'en :: calendar.today', …(9) ]`), while `no pack defines any retired key`, `no pack defines a namespace root …`, `keeps the grid.* vocabulary …` and `keeps the bootstrap strings …` all stayed **GREEN**.

A 1-failed/5-passed split is the proof the classifier separates live from dead; a uniform red would have proved nothing.

Leg B's landing evidence is the tool's per-pack presence assertion plus `git diff --numstat` (10 packs, 0 insertions, 10 deletions) and the AST check that `calendar.today` is absent while `calendar.day` survives.

## Why a negative pin was added

`packages/i18n/src/__tests__/dead-key-batch-retired-4730.test.ts`, following the five-instance convention already in that directory. It is load-bearing: **every i18n gate in this repo runs call site → key, so a dead key coming *back* into the packs is invisible to all of them.** `check-i18n-dead-keys.mjs` is the only reverse-direction reader and is report-only by design. The pin is the sole guard on that direction, and it also pins the live-but-reported-dead bootstrap family so the next round cannot repeat the near-miss.

## Gates (exit codes captured before any pipe, verdicts quoted)

All at `09a1f9b3`, clean tree.

- `pnpm exec vitest run packages/i18n/` **EXIT=0** — `Test Files 57 passed (57)`, `Tests 923 passed (923)`
- `pnpm --filter @object-ui/i18n type-check` **EXIT=0** — script echoed (`tsc --noEmit && tsc -p tsconfig.test.json`), so not a zero-match no-op. Coverage of the new pin proved with `--listFiles`: **1** hit under `tsconfig.test.json`, 0 under the base config (tests are excluded there) — so "type-check is clean" genuinely covers the new file.
- `pnpm --filter @object-ui/i18n lint` **EXIT=0** — 0 errors, 34 pre-existing warnings; the new file alone: 1 file, 0 errors, 0 warnings. (Plain `eslint .`, this repo's actual spelling — `--no-inline-config` manufactures phantom errors and was not used.)
- `pnpm check:i18n-keys` **EXIT=0** — "Every in-scope call-site key resolves against the en pack (2831 keys)"
- `pnpm check:i18n-drift` **EXIT=0** — "0 en value(s) changed (0 key(s) added, 25 removed)"
- `pnpm check:control-bytes` **EXIT=0** — "scanned 5500 tracked text file(s)"
- `pnpm check:published-dist` **EXIT=0** — "Inspected 39 published package(s)"
- `pnpm check:phantom-deps` / `check:entry-guard` / `check:esm-specifiers` / `check:self-import` — all **EXIT=0**
- `node scripts/check-changeset-presence.mjs` **EXIT=0** — "10 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"
- Consumer suites `pnpm exec vitest run packages/app-shell/src/__tests__/defaults-maps-mirror-en-pack.test.tsx packages/plugin-calendar/ packages/plugin-map/ packages/plugin-dashboard/` **EXIT=0** — `Test Files 114 passed (114)`, `Tests 984 passed (984)`
- `pnpm exec vitest run packages/plugin-grid/` **EXIT=0** — `Test Files 96 passed (96)`, `Tests 884 passed (884)`
- `node scripts/check-i18n-dead-keys.mjs` **EXIT=0** — before `2856` pack keys / `146` CONFIRMED; after `2831` / `116`, of which 25 are this deletion and 5 are the pin demoting the rescued bootstrap keys. **NEEDS-REVIEW is untouched at 243→248** (+5 from that same demotion), which is the scope fence showing up in the instrument's own output.

⚠️ `--strict` exits 1 both before and after this change. That `1` is the standing backlog, not a regression from this PR.

## Scope fence

- ⛔ `NEEDS-REVIEW` tier untouched in every namespace.
- ⛔ `search` (partially live, 7 `t()` sites) and `appDesigner` (heavy indirect-reference tier) not touched.
- ⛔ `scripts/check-i18n-dead-keys.mjs` untouched and still report-only.
- The umbrella keeps its held trims; repo-wide CONFIRMED now stands at **116**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_