### PR TITLE
feat(app-shell): wire the flow Start node Entry condition to ConditionBuilder

### DIFF
--- a/.changeset/flow-entry-condition-builder.md
+++ b/.changeset/flow-entry-condition-builder.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/app-shell': minor
+---
+
+flow designer: the Start node's **Entry condition** now opens in the row-based
+condition builder, with raw CEL one click away as the escape hatch (objectui#6226).
+
+The builder is given the trigger record's own vocabulary — bare field names and
+`previous.<field>`, resolved by `flow-scope.ts` — rather than the record-scoped
+default its five other consumers use, so the subjects it offers are the spelling
+this surface evaluates and teaches. 15 of the 17 entry conditions shipped in the
+example apps now open as structured rows; the remaining two mix `&&` with a
+parenthesised `||` group, which is a grammar limit of the row model and keeps
+them on raw mode by design.
+
+Compiled output is unchanged: the same CEL the runtime already evaluates, in the
+author's own quoting. The legacy `criteria` key, a schedule/manual/webhook
+trigger (which binds no record), and every other `expression`-kind flow field
+keep the single-line input they render today — the builder is opt-in per field
+descriptor and requires a declared vocabulary, never inferred.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.entryCondition.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.entryCondition.test.tsx
@@ -1,0 +1,446 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * **The flow designer's Entry condition opens in the row builder** (objectui#6226).
+ *
+ * ## What this file measures, and why it is not the sibling file's measurement
+ *
+ * `ConditionBuilder.subjectVocabulary.test.tsx` (objectui#6296) mounts
+ * `ConditionBuilder` DIRECTLY and hands it a `subjects` object written by the
+ * test. That proved the component can express a flattened vocabulary. It could
+ * not — and did not — prove anything about the flow designer, because it never
+ * mounted it: its corpus sweep would score exactly the same against a tree where
+ * `FlowNodeConfigField` has never heard of `ConditionBuilder`. Re-running that
+ * shape here would measure the prerequisite a second time and report it as this
+ * card's result.
+ *
+ * So the instrument here mounts **the flow inspector's field**, driven by the
+ * **real descriptor** out of `FLOW_NODE_CONFIG` and the **real vocabulary**
+ * `resolveFlowScope` computes from a real draft. Nothing about the wiring is
+ * supplied by the test: the test supplies a flow, and asks what the author sees.
+ *
+ * Concretely, every assertion below runs through the whole chain —
+ *
+ *     draft ──resolveFlowScope──▶ TriggerScope ──▶ FlowNodeConfigField
+ *       │                         (fieldPrefix,        │
+ *       │                          includePrevious)    ▼
+ *       └──fieldsForNodeType('start')──▶ descriptor ──▶ ConditionBuilder
+ *                                        (conditionBuilder: true)
+ *
+ * — so cutting ANY link in it goes red here. `FlowNodeInspector.entryCondition
+ * .test.tsx` next door closes the last gap by mounting the whole inspector, so
+ * the `useFlowScope` → inspector → field plumbing is measured too rather than
+ * assumed.
+ *
+ * ## Row mode is asserted structurally
+ *
+ * Same discipline as the sibling suite, for the same reason: a "row mode"
+ * verdict requires N structured row controls to EXIST, plus the compiled-CEL
+ * preview that only row mode renders. An implementation that widened a raw
+ * fallback to swallow the corpus would score zero here, not full marks.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach, beforeAll, vi } from 'vitest';
+import { render, cleanup, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * The trigger object's field catalog. Stubbed at the hook rather than at the
+ * transport so it arrives SYNCHRONOUSLY: the catalog only shapes the subject
+ * dropdown, and an async arrival would make every mode probe race a fetch it
+ * does not depend on. Same stub the sibling FlowNodeInspector suites use.
+ */
+const FIELDS = vi.hoisted(() => [
+  { name: 'status', label: 'Status', type: 'text', hidden: false },
+  { name: 'amount', label: 'Amount', type: 'number', hidden: false },
+  { name: 'contract_term_months', label: 'Contract term (months)', type: 'number', hidden: false },
+  { name: 'secret', label: 'Secret', type: 'text', hidden: true },
+]);
+vi.mock('../previews/useObjectFields', () => ({
+  useObjectFields: () => ({ fields: FIELDS, loading: false, error: null }),
+}));
+
+// The raw-mode editor (CelPredicateField) still reaches for the shared metadata
+// client; keep its mount-time fetches off the network (objectui#4697).
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
+/** Field names the stubbed catalog puts in scope. */
+const FIELD_NAMES_IN_SCOPE = FIELDS.filter((f) => !f.hidden).map((f) => f.name);
+
+import { FlowNodeConfigField } from './FlowNodeConfigField';
+import { fieldsForNodeType, type FlowConfigField } from './flow-node-config';
+import { resolveFlowScope, type TriggerScope } from './flow-scope';
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  // Radix Select probes pointer-capture APIs the test DOM lacks.
+  for (const m of ['hasPointerCapture', 'setPointerCapture', 'releasePointerCapture'] as const) {
+    if (!Element.prototype[m]) {
+      // @ts-expect-error test shim
+      Element.prototype[m] = m === 'hasPointerCapture' ? () => false : () => {};
+    }
+  }
+});
+
+/* ── the real descriptor, the real scope ─────────────────────────────────── */
+
+/** The Start node's `Entry condition` descriptor, read from the shipped config
+ *  schema — never a hand-written stand-in, so a descriptor that loses its
+ *  `conditionBuilder` flag turns this whole file red. */
+const ENTRY_CONDITION: FlowConfigField = (() => {
+  const f = fieldsForNodeType('start').find((x) => x.id === 'condition');
+  if (!f) throw new Error('start node has no `condition` field — the card premise moved');
+  return f;
+})();
+
+/** The second `expression` gate on the same node — the LEGACY `criteria` key.
+ *  Fenced out of this wiring on purpose; pinned negatively below. */
+const LEGACY_CRITERIA: FlowConfigField = (() => {
+  const f = fieldsForNodeType('start').find((x) => x.id === 'criteria');
+  if (!f) throw new Error('start node has no `criteria` field — the fence premise moved');
+  return f;
+})();
+
+/** A record-triggered flow, selected AT its start node — the surface the card
+ *  is about. `record-after-write` fires on create OR update, so `previous` is
+ *  bound (and `previous == null` is the create leg). */
+function startNodeScope(triggerType = 'record-after-write'): TriggerScope | undefined {
+  const draft = {
+    nodes: [{ id: 'start', type: 'start', config: { triggerType, objectName: 'crm_lead' } }],
+    edges: [],
+  };
+  return resolveFlowScope(draft, 'start').trigger;
+}
+
+/* ── mode probe (structural — see the header) ────────────────────────────── */
+
+interface Probe {
+  mode: 'row' | 'raw' | 'indeterminate';
+  rows: number;
+  compiled: string | null;
+}
+
+function probe(container: HTMLElement): Probe {
+  const buttons = Array.from(container.querySelectorAll('button'));
+  const hasBuilderToggle = buttons.some((b) => b.textContent?.includes('Builder'));
+  const hasExprToggle = buttons.some((b) => b.textContent?.includes('Expression'));
+  const mode = hasExprToggle && !hasBuilderToggle
+    ? 'row'
+    : hasBuilderToggle && !hasExprToggle
+      ? 'raw'
+      : 'indeterminate';
+  const rows = container.querySelectorAll('[aria-label="Remove condition"]').length;
+  // Read the compiled preview ONLY in row mode, and only from a <div>: the raw
+  // editor is itself a mono <textarea>, so a bare `.font-mono` lookup would hand
+  // back the author's own text and let a widened raw fallback read as a
+  // successful round-trip.
+  const preview = mode === 'row' ? container.querySelector('div.font-mono') : null;
+  return { mode, rows, compiled: preview ? (preview.textContent ?? '') : null };
+}
+
+/** True when the field rendered the PRE-#6226 control: a single-line
+ *  VariableTextInput, which is neither builder mode. */
+function isPlainTextInput(container: HTMLElement): boolean {
+  const p = probe(container);
+  return p.mode === 'indeterminate' && p.rows === 0 && container.querySelector('textarea, input') !== null;
+}
+
+function mountField(opts: {
+  value: string;
+  field?: FlowConfigField;
+  triggerScope?: TriggerScope;
+  onCommit?: (v: unknown) => void;
+}) {
+  const { container } = render(
+    <FlowNodeConfigField
+      field={opts.field ?? ENTRY_CONDITION}
+      value={opts.value}
+      onCommit={opts.onCommit ?? (() => {})}
+      triggerScope={'triggerScope' in opts ? opts.triggerScope : startNodeScope()}
+    />,
+  );
+  return container;
+}
+
+/* ── the corpus ──────────────────────────────────────────────────────────── */
+
+/**
+ * Every start-node entry condition shipped in objectstack's example apps, plus
+ * the HotCRM example from #6226's card body — the same frozen snapshot the
+ * sibling `ConditionBuilder.subjectVocabulary.test.tsx` measures the COMPONENT
+ * against. Held as a second copy on purpose: importing it would re-execute that
+ * file's whole suite inside this one. `CORPUS_SIZE` below pins the count in both
+ * places, so a copy that silently loses an entry goes red instead of quietly
+ * under-measuring.
+ *
+ * `parens` marks the two that are beyond the row grammar for a reason that has
+ * nothing to do with subjects — `&&` mixed with a parenthesised `||` group.
+ * Extending the grammar is explicitly a separate card, so those two are EXPECTED
+ * to stay on raw mode and are held out of the round-trip denominator instead of
+ * flattering it.
+ */
+const CORPUS: Array<{ src: string; cel: string; parens?: true }> = [
+  { src: 'showcase/dynamic-approval.flow.ts:29', cel: 'title != previous.title' },
+  { src: 'showcase/flows/index.ts:39', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:153', cel: 'assignee != previous.assignee' },
+  { src: 'showcase/flows/index.ts:212', cel: 'budget > 100000 && budget != previous.budget' },
+  { src: 'showcase/flows/index.ts:325', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:438', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:691', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:808', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: 'showcase/flows/index.ts:924', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:1004', cel: 'status == "done" && previous.status != "done"' },
+  { src: 'showcase/flows/index.ts:1099', cel: 'status == "sent" && previous.status != "sent"' },
+  { src: 'showcase/flows/index.ts:1201', cel: 'health == "red" && previous.health != "red"' },
+  { src: 'showcase/flows/index.ts:1532', cel: 'status == "submitted" && previous.status != "submitted"' },
+  { src: 'showcase/flows/index.ts:1582', cel: 'status == "submitted" && previous.status != "submitted" && total_amount >= 5000' },
+  { src: 'showcase/flows/index.ts:1696', cel: "priority == 'urgent' && (previous == null || previous.priority != 'urgent')", parens: true },
+  { src: 'todo/task.flow.ts:183', cel: 'status == "completed" && previous.status != "completed"' },
+  { src: '#6226 card body (HotCRM)', cel: 'contract_term_months > 24 && (previous == null || previous.contract_term_months <= 24)', parens: true },
+];
+
+/** Pinned in BOTH copies of the corpus. See the comment above. */
+const CORPUS_SIZE = 17;
+const ROW_ELIGIBLE = CORPUS.filter((c) => !c.parens);
+
+const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+
+/* ── ACCEPTANCE: the FLOW FIELD, before/after ────────────────────────────── */
+
+describe('#6226 acceptance — the flow Entry condition opens in ROW mode', () => {
+  it('the corpus is the size both copies pin', () => {
+    expect(CORPUS).toHaveLength(CORPUS_SIZE);
+    expect(ROW_ELIGIBLE).toHaveLength(15);
+  });
+
+  it.each(ROW_ELIGIBLE)('adopts $src as structured rows AT THE FLOW FIELD', ({ cel }) => {
+    const p = probe(mountField({ value: cel }));
+    expect(p.mode).toBe('row');
+    // The rows exist as controls…
+    expect(p.rows).toBeGreaterThan(0);
+    // …and compile back to the author's own CEL, byte for byte.
+    expect(norm(p.compiled ?? '')).toBe(norm(cel));
+  });
+
+  it('reports the adoption rate at the flow field: 15/15 row-eligible, 15/17 of the corpus', () => {
+    const adopted = ROW_ELIGIBLE.filter((c) => {
+      const p = probe(mountField({ value: c.cel }));
+      cleanup();
+      return p.mode === 'row' && p.rows > 0 && norm(p.compiled ?? '') === norm(c.cel);
+    });
+    expect(adopted).toHaveLength(ROW_ELIGIBLE.length);
+    expect(adopted.length / CORPUS.length).toBeCloseTo(15 / 17);
+  });
+
+  it.each(CORPUS.filter((c) => c.parens))(
+    'leaves $src on the raw escape hatch — a GRAMMAR limit, not a subject one',
+    ({ cel }) => {
+      const p = probe(mountField({ value: cel }));
+      expect(p.mode).toBe('raw');
+      expect(p.rows).toBe(0);
+    },
+  );
+});
+
+/* ── the instrument's own positive controls ──────────────────────────────── */
+
+describe('#6226 probe instrument — positive controls', () => {
+  it('an empty condition opens in ROW mode with no rows (a fresh flow)', () => {
+    expect(probe(mountField({ value: '' }))).toMatchObject({ mode: 'row', rows: 0, compiled: null });
+  });
+
+  it('a predicate outside the row grammar reads RAW with rows === 0', () => {
+    expect(probe(mountField({ value: "status in ['sent', 'paid']" }))).toMatchObject({
+      mode: 'raw',
+      rows: 0,
+    });
+  });
+
+  it('`isPlainTextInput` can see the PRE-#6226 control, so its absence below is a measurement', () => {
+    // Same field, vocabulary withheld → the old single-line control. If this
+    // probe could not recognise it, every "no longer a plain input" assertion
+    // in this file would be vacuous.
+    expect(isPlainTextInput(mountField({ value: 'status == "done"', triggerScope: undefined }))).toBe(true);
+  });
+});
+
+/* ── the subject vocabulary AT THIS SITE ─────────────────────────────────── */
+
+/** Open the row's SUBJECT dropdown and read back every subject offered. */
+async function subjectOptions(container: HTMLElement): Promise<string[]> {
+  const trigger = container.querySelectorAll('[role="combobox"]')[0] as HTMLElement;
+  await userEvent.click(trigger);
+  const opts = await screen.findAllByRole('option');
+  return opts.map((o) => o.textContent ?? '');
+}
+
+/** The field holding exactly one row, ready to have its subject read. The
+ *  catalog is supplied through the stubbed metadata client the builder fetches
+ *  with, so the vocabulary under test is the one the WIRING produced. */
+function mountOneRow(triggerScope: TriggerScope | undefined = startNodeScope()) {
+  const onCommit = vi.fn();
+  const { container } = render(
+    <FlowNodeConfigField
+      field={ENTRY_CONDITION}
+      value="placeholder_subject == 'x'"
+      onCommit={onCommit}
+      triggerScope={triggerScope}
+    />,
+  );
+  return { container, onCommit };
+}
+
+describe('#6226 the flow entry field offers the FLATTENED trigger vocabulary', () => {
+  it('offers BARE field names — not record.<field>', async () => {
+    const opts = await subjectOptions(mountOneRow().container);
+    expect(opts).toContain('status');
+    expect(opts).toContain('amount');
+    expect(opts).not.toContain('record.status');
+  });
+
+  it('offers `previous` and `previous.<field>` — the change-detection idiom', async () => {
+    const opts = await subjectOptions(mountOneRow().container);
+    expect(opts).toContain('previous');
+    expect(opts).toContain('previous.status');
+    expect(opts).toContain('previous.amount');
+  });
+
+  it('does NOT offer `record.id` — the root this site does not bind', async () => {
+    const opts = await subjectOptions(mountOneRow().container);
+    // The builder's record-scoped DEFAULT context would have put it here. The
+    // flow entry field declares its own (empty) context precisely so the editor
+    // cannot emit the one spelling its own sibling ref-check flags.
+    expect(opts).not.toContain('record.id');
+    expect(opts.filter((o) => o.startsWith('record.'))).toEqual([]);
+  });
+
+  it('hides hidden fields', async () => {
+    const opts = await subjectOptions(mountOneRow().container);
+    expect(opts).not.toContain('secret');
+    expect(opts).not.toContain('previous.secret');
+  });
+
+  it('every offered subject has a root the field\'s OWN ref-check accepts', async () => {
+    // The self-contradiction guard, as a closed property rather than a spot
+    // check: this editor may not offer a spelling the warning rendered directly
+    // beneath it would call out of scope. Roots come from the same resolved
+    // scope the inspector hands the check.
+    const opts = await subjectOptions(mountOneRow().container);
+    const offered = opts.filter((o) => o !== 'placeholder_subject');
+    expect(offered.length).toBeGreaterThan(0);
+    const allowedRoots = new Set([...FIELD_NAMES_IN_SCOPE, 'previous']);
+    for (const o of offered) expect(allowedRoots.has(o.split('.')[0])).toBe(true);
+  });
+
+  it('COMPILES a chosen subject BARE — the behavioural half', async () => {
+    const { container, onCommit } = mountOneRow();
+    const opts = await subjectOptions(container);
+    expect(opts).toContain('amount');
+    await userEvent.click(screen.getByRole('option', { name: 'amount' }));
+    expect(onCommit).toHaveBeenCalledWith("amount == 'x'");
+  });
+
+  it('authors the create-path idiom `previous == null` end to end', async () => {
+    const { container, onCommit } = mountOneRow();
+    await userEvent.click(container.querySelectorAll('[role="combobox"]')[0] as HTMLElement);
+    await userEvent.click(screen.getByRole('option', { name: 'previous' }));
+    const valueBox = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(valueBox, { target: { value: 'null' } });
+    expect(onCommit).toHaveBeenLastCalledWith('previous == null');
+  });
+
+  it('re-emits a double-quoted literal as authored, so an adopted flow is not rewritten', () => {
+    const onCommit = vi.fn();
+    const container = mountField({ value: 'status == "done" && previous.status != "done"', onCommit });
+    const valueBox = container.querySelectorAll('input')[0] as HTMLInputElement;
+    fireEvent.change(valueBox, { target: { value: 'shipped' } });
+    expect(onCommit).toHaveBeenCalledWith('status == "shipped" && previous.status != "done"');
+  });
+});
+
+/* ── the escape hatch ────────────────────────────────────────────────────── */
+
+describe('#6226 raw CEL remains reachable — the ruling\'s escape hatch', () => {
+  it('a row-mode field can be switched to the raw expression editor', async () => {
+    const container = mountField({ value: 'status == "done"' });
+    expect(probe(container).mode).toBe('row');
+    const toggle = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Expression'),
+    )!;
+    expect(toggle).toBeTruthy();
+    await userEvent.click(toggle);
+    expect(probe(container).mode).toBe('raw');
+  });
+
+  it('a raw-mode field offers the way back to the builder', () => {
+    const container = mountField({ value: CORPUS.find((c) => c.parens)!.cel });
+    expect(probe(container).mode).toBe('raw');
+    const back = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Builder'),
+    );
+    expect(back).toBeTruthy();
+  });
+});
+
+/* ── FENCES: what this wiring deliberately does NOT touch ────────────────── */
+
+describe('#6226 fences — declared opt-in, never inferred from `kind`', () => {
+  it('the LEGACY `criteria` gate keeps the raw input (fold-or-fence: FENCED)', () => {
+    // `criteria` is the second `expression` gate on the same node. It renders
+    // only when a stored value is already present (`showWhen.__legacy__` never
+    // matches), its own help steers authors to `condition`, and the builder
+    // recompiles a predicate wholesale on first edit — so upgrading it would
+    // polish a key the product is retiring instead of migrating it. Reasoned in
+    // the PR body; pinned here so the fence is not lost by omission.
+    expect(LEGACY_CRITERIA.kind).toBe('expression');
+    expect(LEGACY_CRITERIA.conditionBuilder).toBeUndefined();
+    expect(isPlainTextInput(mountField({ value: 'status == "active"', field: LEGACY_CRITERIA }))).toBe(true);
+  });
+
+  it('an `expression` field that did NOT opt in keeps the raw input', () => {
+    // `expression` is not a synonym for "record predicate": a `recordId` is a
+    // scalar lookup, a `collection` is an interpolate() template. Only a flagged
+    // descriptor may become a builder, even with a vocabulary in hand.
+    const plain: FlowConfigField = {
+      id: 'recordId', path: ['config', 'recordId'], label: 'Record', kind: 'expression',
+    };
+    expect(isPlainTextInput(mountField({ value: 'record.id', field: plain }))).toBe(true);
+  });
+
+  it('an opted-in field with NO declared vocabulary keeps the raw input', () => {
+    // A schedule / manual / webhook trigger binds no record, so
+    // `resolveFlowScope` returns no TriggerScope. The builder is not mounted
+    // against a guessed scope — the field degrades to what it renders today.
+    expect(startNodeScope('schedule')).toBeUndefined();
+    expect(isPlainTextInput(mountField({ value: 'status == "done"', triggerScope: undefined }))).toBe(true);
+  });
+
+  it('a template-mode expression field is never a condition builder', () => {
+    // Belt and braces for a loop/map `collection`: `{leadList}` is a legal
+    // interpolate() hole, not a predicate.
+    const templated: FlowConfigField = { ...ENTRY_CONDITION, refMode: 'template' };
+    expect(templated.conditionBuilder).toBe(true);
+    expect(isPlainTextInput(mountField({ value: '{leadList}', field: templated }))).toBe(true);
+  });
+});
+
+/* ── the field's other halves still work ─────────────────────────────────── */
+
+describe('#6226 the surrounding field behaviour is unchanged', () => {
+  it('still surfaces the ADR-0032 brace-in-CEL error beneath the builder', () => {
+    mountField({ value: '{status} == "done"' });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('still shows the descriptor help when the value is clean', () => {
+    mountField({ value: 'status == "done"' });
+    expect(screen.getByText(ENTRY_CONDITION.help!)).toBeInTheDocument();
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeConfigField.tsx
@@ -22,7 +22,28 @@ import { FlowReferenceField, type FlowReferenceContext } from './FlowReferenceFi
 import { validateExpressionClient } from './expression-validate.js';
 import { VariableTextInput } from './VariableTextInput.js';
 import type { ScopeGroup } from './useFlowScope.js';
+import type { TriggerScope } from './flow-scope.js';
+import { ConditionBuilder } from './ConditionBuilder.js';
 import { findUnknownRefs, scopeRoots, describeUnknownRefs } from './flow-ref-check.js';
+
+/**
+ * The context subjects a flow trigger condition binds — none (objectui#6226).
+ *
+ * ConditionBuilder's default context list is `record.id` / `user.*` / `org.*`,
+ * which is right for its five record-scoped consumers and wrong here: at a
+ * record-trigger gate the evaluation context is the changed record FLATTENED to
+ * top level plus `previous`, and `record` is exactly the root `flow-scope.ts`
+ * withholds on the start node. Inheriting the default would make this editor
+ * emit `record.id` — the one spelling the `findUnknownRefs` note rendered a few
+ * lines below, reading the SAME scope, flags as out of scope. One panel
+ * contradicting its own generated output.
+ *
+ * So the vocabulary offered here is exactly what `TriggerScope` declares: the
+ * trigger record's fields (bare) and `previous` / `previous.FIELD`. Roots this
+ * surface has not been shown to bind are not guessed into the list; an author
+ * who needs one still has the raw CEL escape hatch.
+ */
+const FLOW_TRIGGER_CONTEXT_SUBJECTS: ReadonlyArray<{ value: string; label?: string }> = [];
 
 export interface FlowNodeConfigFieldProps {
   field: FlowConfigField;
@@ -36,12 +57,44 @@ export interface FlowNodeConfigFieldProps {
   scopeGroups?: ScopeGroup[];
   /** #3447: approval-expression picker groups (current/trigger/vars roots). */
   approvalScopeGroups?: ScopeGroup[];
+  /**
+   * The trigger record's declared subject vocabulary at this node, when one is
+   * in scope (objectui#6226) — supplied by `useFlowScope`, resolved by
+   * `flow-scope.ts`. Required before a `conditionBuilder` field may render the
+   * row builder: the vocabulary is declared by the site, never inferred from
+   * the value.
+   */
+  triggerScope?: TriggerScope;
 }
 
-export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, context, scopeGroups, approvalScopeGroups }: FlowNodeConfigFieldProps) {
+export function FlowNodeConfigField({ field, value, onCommit, disabled, locale, context, scopeGroups, approvalScopeGroups, triggerScope }: FlowNodeConfigFieldProps) {
   const refMode: 'expression' | 'template' =
     field.refMode ?? (field.kind === 'expression' ? 'expression' : 'template');
+  // objectui#6226 — the row-based condition builder, on the fields that opted in
+  // AND at a site that declares the vocabulary. All three conjuncts are load
+  // bearing: `conditionBuilder` keeps `expression` from meaning "predicate"
+  // everywhere it appears; `triggerScope` is the declared vocabulary, absent on
+  // a trigger that binds no record; `refMode !== 'template'` keeps an
+  // `interpolate()` field (a loop `collection`) out even if one ever opts in.
+  const asConditionBuilder =
+    field.kind === 'expression' && !!field.conditionBuilder && !!triggerScope && refMode !== 'template';
   const control = (() => {
+    if (asConditionBuilder && triggerScope) {
+      return (
+        <ConditionBuilder
+          label={field.label}
+          value={value != null ? String(value) : ''}
+          onCommit={(cel) => onCommit(cel)}
+          objectName={triggerScope.objectName}
+          disabled={disabled}
+          subjects={{
+            fieldPrefix: triggerScope.fieldPrefix,
+            includePrevious: triggerScope.includePrevious,
+            context: FLOW_TRIGGER_CONTEXT_SUBJECTS,
+          }}
+        />
+      );
+    }
     switch (field.kind) {
       case 'reference':
         return (

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.entryCondition.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.entryCondition.test.tsx
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * **The whole inspector, not just the field** (objectui#6226).
+ *
+ * `FlowNodeConfigField.entryCondition.test.tsx` next door measures the field
+ * with a `TriggerScope` the test resolves itself. That leaves exactly one link
+ * of the chain unmeasured — whether `FlowNodeInspector` actually ASKS
+ * `useFlowScope` for that vocabulary and hands it down. A wiring that forgot the
+ * prop would pass every assertion over there and ship a flow designer that still
+ * renders a one-line CEL box.
+ *
+ * So this file selects a start node in the real inspector, from a real draft,
+ * and asks what an author sees. Nothing is stubbed except the two hooks that
+ * would otherwise hit the network (the engine config-schema publisher and the
+ * object field catalog) — the same stubs the sibling FlowNodeInspector suites
+ * use.
+ *
+ * The scope is resolved by the inspector itself, from the draft's own
+ * `triggerType` / `objectName`, which is what makes the two negative cases below
+ * measurements rather than restatements: the same inspector, the same field,
+ * a different trigger, a different control.
+ */
+
+import { describe, it, expect, vi, afterEach, beforeAll } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// The engine config-schema hook is stubbed empty so the inspector uses its
+// hardcoded field groups (fieldsForNodeType); the trigger field catalog is
+// stubbed so useFlowScope and ConditionBuilder resolve without a network client.
+vi.mock('../previews/useFlowNodePalette', () => ({
+  useActionConfigSchemas: () => ({}),
+  useFlowNodePalette: () => [],
+}));
+const FIELDS = vi.hoisted(() => [
+  { name: 'status', label: 'Status', type: 'text', hidden: false },
+  { name: 'amount', label: 'Amount', type: 'number', hidden: false },
+]);
+vi.mock('../previews/useObjectFields', () => ({
+  useObjectFields: () => ({ fields: FIELDS, loading: false, error: null }),
+}));
+const state = vi.hoisted(() => ({
+  metadataClient: { get: vi.fn(async () => undefined), list: vi.fn(async () => [] as unknown[]) },
+}));
+vi.mock('../useMetadata', () => ({
+  useMetadataClient: () => state.metadataClient,
+}));
+
+import { FlowNodeInspector } from './FlowNodeInspector';
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  for (const m of ['hasPointerCapture', 'setPointerCapture', 'releasePointerCapture'] as const) {
+    if (!Element.prototype[m]) {
+      // @ts-expect-error test shim
+      Element.prototype[m] = m === 'hasPointerCapture' ? () => false : () => {};
+    }
+  }
+});
+
+/** A record-triggered flow whose start node already holds a shipped-shape entry
+ *  condition. `record-after-write` fires on create OR update, so `previous` is
+ *  bound at this gate. */
+function draftWith(config: Record<string, unknown>) {
+  return { nodes: [{ id: 'start', type: 'start', label: 'When a lead changes', config }], edges: [] };
+}
+
+function renderStartNode(config: Record<string, unknown>) {
+  const onPatch = vi.fn();
+  const { container } = render(
+    <FlowNodeInspector
+      type="flow"
+      name="renewal"
+      draft={draftWith(config)}
+      selection={{ kind: 'node', id: 'start' }}
+      onPatch={onPatch}
+      onClearSelection={vi.fn()}
+      readOnly={false}
+      locale="en-US"
+    />,
+  );
+  return { container, onPatch };
+}
+
+const RECORD_TRIGGER = { triggerType: 'record-after-write', objectName: 'crm_lead' };
+
+/** Row-mode markers, read off the whole inspector. In row mode the condition
+ *  editor mounts an `Expression` toggle and one remove button per parsed row;
+ *  in raw mode a `Builder` toggle and no rows; pre-#6226 it mounted neither. */
+function modeOf(container: HTMLElement) {
+  const buttons = Array.from(container.querySelectorAll('button'));
+  return {
+    builderToggle: buttons.some((b) => b.textContent?.includes('Builder')),
+    expressionToggle: buttons.some((b) => b.textContent?.includes('Expression')),
+    rows: container.querySelectorAll('[aria-label="Remove condition"]').length,
+  };
+}
+
+describe('#6226 the flow inspector hands the entry condition its trigger vocabulary', () => {
+  it('a start node with a stored entry condition opens in ROW mode', () => {
+    const { container } = renderStartNode({
+      ...RECORD_TRIGGER,
+      condition: 'status == "done" && previous.status != "done"',
+    });
+    // The field is the one the card names.
+    expect(screen.getByText('Entry condition')).toBeInTheDocument();
+    const m = modeOf(container);
+    expect(m.expressionToggle).toBe(true);
+    expect(m.builderToggle).toBe(false);
+    expect(m.rows).toBe(2);
+  });
+
+  it('its subject dropdown offers the FLATTENED vocabulary the inspector resolved', async () => {
+    const { container } = renderStartNode({ ...RECORD_TRIGGER, condition: 'status == "done"' });
+    // The first combobox belongs to the `triggerType` select; the condition
+    // editor's subject select is the one inside the row. Find it by the row.
+    const row = container.querySelector('[aria-label="Remove condition"]')!.closest('div')!
+      .parentElement!;
+    const subject = row.querySelector('[role="combobox"]') as HTMLElement;
+    await userEvent.click(subject);
+    const opts = (await screen.findAllByRole('option')).map((o) => o.textContent ?? '');
+    expect(opts).toContain('status');
+    expect(opts).toContain('previous.status');
+    // The root this site does not bind never reaches the author.
+    expect(opts).not.toContain('record.id');
+    expect(opts.filter((o) => o.startsWith('record.'))).toEqual([]);
+  });
+
+  it('a SCHEDULE trigger keeps the raw input — no record bound, no vocabulary to declare', () => {
+    const { container } = renderStartNode({
+      triggerType: 'schedule',
+      objectName: 'crm_lead',
+      condition: 'status == "done"',
+    });
+    expect(screen.getByText('Entry condition')).toBeInTheDocument();
+    const m = modeOf(container);
+    expect(m.expressionToggle).toBe(false);
+    expect(m.builderToggle).toBe(false);
+    expect(m.rows).toBe(0);
+  });
+
+  it('a record trigger with NO object keeps the raw input', () => {
+    // `resolveFlowScope` needs an objectName before it will declare a trigger
+    // vocabulary; a half-authored start node must not get a builder over a
+    // catalog that does not exist.
+    const { container } = renderStartNode({
+      triggerType: 'record-after-update',
+      condition: 'status == "done"',
+    });
+    const m = modeOf(container);
+    expect(m.expressionToggle).toBe(false);
+    expect(m.builderToggle).toBe(false);
+  });
+
+  it('editing a row writes the compiled CEL back to config.condition', async () => {
+    const { container, onPatch } = renderStartNode({
+      ...RECORD_TRIGGER,
+      condition: 'status == "done"',
+    });
+    const valueBox = Array.from(container.querySelectorAll('input')).find(
+      (i) => (i as HTMLInputElement).value === 'done',
+    ) as HTMLInputElement;
+    expect(valueBox).toBeTruthy();
+    await userEvent.clear(valueBox);
+    await userEvent.type(valueBox, 'shipped');
+    const patch = onPatch.mock.calls.at(-1)![0] as { nodes: Array<{ config: { condition: string } }> };
+    // Same key, same CEL dialect, same double quotes the author had — the
+    // ruling's "compiled output stays the CEL the runtime already evaluates".
+    expect(patch.nodes[0].config.condition).toBe('status == "shipped"');
+  });
+});
+
+describe('#6226 the OTHER expression fields in the same inspector are untouched', () => {
+  it('a decision node\'s Branches repeater still renders its objectList cells', () => {
+    // Branch conditions are `expression`-kind COLUMNS inside an objectList, a
+    // different component with a different commit protocol. They are Q2, ruled
+    // out of this card — pinned here so "wire every expression field" cannot
+    // pass as this change.
+    const onPatch = vi.fn();
+    const { container } = render(
+      <FlowNodeInspector
+        type="flow"
+        name="renewal"
+        draft={{
+          nodes: [
+            { id: 'start', type: 'start', config: RECORD_TRIGGER },
+            { id: 'decide', type: 'decision', config: { conditions: [{ label: 'Big', expression: 'amount > 100' }] } },
+          ],
+          edges: [{ source: 'start', target: 'decide' }],
+        }}
+        selection={{ kind: 'node', id: 'decide' }}
+        onPatch={onPatch}
+        onClearSelection={vi.fn()}
+        readOnly={false}
+        locale="en-US"
+      />,
+    );
+    // The branch's expression is still an editable cell, not a row builder.
+    expect(screen.getByDisplayValue('amount > 100')).toBeInTheDocument();
+    expect(modeOf(container).rows).toBe(0);
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.tsx
@@ -178,7 +178,7 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
     [loc],
   );
   // In-scope variable references for this node, for the data-picker (#1934).
-  const { groups: scopeGroups, approvalExpressionGroups } = useFlowScope(draft as Record<string, unknown>, loc?.scopeAnchorId, nestedLoopRefs);
+  const { groups: scopeGroups, approvalExpressionGroups, trigger: triggerScope } = useFlowScope(draft as Record<string, unknown>, loc?.scopeAnchorId, nestedLoopRefs);
   // #4305 — a COMMITTED connector action (connector + action both chosen) types
   // its Input section from that action's descriptor `inputSchema`. Read the
   // committed pair and the stored input map off the node's spec-structured
@@ -453,6 +453,7 @@ export function FlowNodeInspector({ selection, draft, onPatch, onClearSelection,
             context={{ draft, node }}
             scopeGroups={scopeGroups}
             approvalScopeGroups={approvalExpressionGroups}
+            triggerScope={triggerScope}
           />
         );
       })}

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.ts
@@ -260,6 +260,25 @@ export interface FlowConfigField {
    *     legal template here, not a malformed condition).
    */
   refMode?: 'expression' | 'template';
+  /**
+   * Render this `expression` field with the row-based {@link ConditionBuilder}
+   * (raw CEL stays one click away as the escape hatch) — objectui#6226.
+   *
+   * OPT-IN PER DESCRIPTOR, never inferred from `kind`. `expression` is not a
+   * synonym for "record predicate": a loop's `collection` is an `interpolate()`
+   * template, a `recordId` is a scalar lookup, and a script body is code. Only a
+   * field that is genuinely a predicate over the TRIGGER RECORD's vocabulary
+   * flags itself here.
+   *
+   * Flagging is necessary but not sufficient. The builder's subjects are a
+   * DECLARED vocabulary, so {@link FlowNodeConfigField} mounts it only where the
+   * mount site also supplies one — the `TriggerScope` `flow-scope.ts` resolves
+   * (`fieldPrefix`, `includePrevious`, `objectName`). No declared vocabulary (a
+   * schedule / manual / webhook trigger binds no record) ⇒ the field keeps the
+   * raw expression input rather than the component guessing a scope from the
+   * value it was handed.
+   */
+  conditionBuilder?: boolean;
 }
 
 /** Convenience: a `['config', key]`-rooted field (the common case). */
@@ -321,6 +340,12 @@ const FLOW_NODE_CONFIG: Record<string, FlowConfigField[]> = {
       showWhen: { field: 'triggerType', equals: ['record-after-create', 'record-after-update', 'record-after-write', 'record-before-update', 'record-after-delete', 'schedule', 'webhook', 'event'] },
     }),
     cfg('condition', 'Entry condition', 'expression', {
+      // objectui#6226 — the one predicate every business admin meets. Row
+      // builder over the trigger record's own vocabulary (bare fields +
+      // `previous.*`, per flow-scope's TriggerScope), raw CEL as the escape
+      // hatch. Deliberately NOT set on `criteria` below: that legacy key is
+      // render-only-when-present, so nothing is ever authored into it.
+      conditionBuilder: true,
       placeholder: 'status == "qualifying" && previous.status != "qualifying"',
       help: 'CEL predicate — the flow runs only when this is true (for time-relative sweeps it gates each matched record). Leave empty to run on every event. On a "created or updated" trigger, `previous == null` selects the create path.',
       showWhen: { field: 'triggerType', equals: ['record-after-create', 'record-after-update', 'record-after-write', 'record-before-update', 'record-after-delete', 'schedule', 'time_relative', 'webhook', 'event'] },

--- a/packages/app-shell/src/views/metadata-admin/inspectors/useFlowScope.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/useFlowScope.ts
@@ -17,6 +17,7 @@ import {
   triggerFieldRefs,
   type ScopeGroupId,
   type ScopeRef,
+  type TriggerScope,
 } from './flow-scope.js';
 import { useObjectFields } from '../previews/useObjectFields.js';
 
@@ -40,6 +41,19 @@ export interface UseFlowScopeResult {
    * exactly the spelling the runtime rejects.
    */
   approvalExpressionGroups: ScopeGroup[];
+  /**
+   * The trigger record's DECLARED subject vocabulary at this node, when one is
+   * in scope — `{ objectName, fieldPrefix, includePrevious }`, straight from
+   * {@link resolveFlowScope} (objectui#6226).
+   *
+   * Re-exported rather than re-derived: the `refs` above have already been
+   * flattened and merged with variables / upstream outputs, so a consumer that
+   * needs the *shape* of the record vocabulary (the condition builder's
+   * subjects) would otherwise have to reverse-engineer the prefix back out of
+   * the tokens. Absent on a schedule / manual / webhook trigger, which binds no
+   * record — and absence is the signal that no vocabulary may be assumed.
+   */
+  trigger?: TriggerScope;
   /** True while the trigger object's fields are still loading. */
   loading: boolean;
   /** No references in scope — the field should render as a plain input. */
@@ -119,6 +133,13 @@ export function useFlowScope(
       { id: 'approval_vars' as const, label: 'Flow variables', refs: approvalVars },
     ].filter((g) => g.refs.length > 0);
 
-    return { groups, refs, approvalExpressionGroups, loading: !!scope.trigger && loading, isEmpty: refs.length === 0 };
+    return {
+      groups,
+      refs,
+      approvalExpressionGroups,
+      trigger: scope.trigger,
+      loading: !!scope.trigger && loading,
+      isEmpty: refs.length === 0,
+    };
   }, [scope, fields, loading, extraRefs]);
 }


### PR DESCRIPTION
Fixes #6226

The flow designer's Start node **Entry condition** — the predicate a business admin meets first — now opens in the row-based `ConditionBuilder`, with raw CEL one click away as the escape hatch. Per the maintainer's 2026-08-25 batch-4 ruling (Option A) and the follow-up decision-inbox ruling that put the prerequisite vocabulary card (#6296 / PR #6659) first.

## What changed

Four files, ~40 lines of implementation:

| file | change |
| --- | --- |
| `inspectors/flow-node-config.ts` | new optional `conditionBuilder` on `FlowConfigField`; set on the Start node's `condition` descriptor only |
| `inspectors/useFlowScope.ts` | re-exports the `TriggerScope` `resolveFlowScope` already computes (`objectName`, `fieldPrefix`, `includePrevious`) |
| `inspectors/FlowNodeInspector.tsx` | passes that scope down (2 lines) |
| `inspectors/FlowNodeConfigField.tsx` | renders `ConditionBuilder` for an opted-in field that has a declared vocabulary |

The vocabulary is **declared, never inferred**: `flow-scope.ts` already computed exactly the shape `ConditionSubjectVocabulary` needs, so it is passed through rather than recomputed, and the component never guesses a site's scope from the value it is handed. Three conjuncts gate the builder — the descriptor opted in, the site declared a vocabulary, and the field is not in `interpolate()` template mode — so `expression` does not silently become a synonym for "record predicate".

Context subjects at this site are **empty**, not the component's `record.id` / `user.*` / `org.*` default. `record` is precisely the root `flow-scope.ts` withholds on the start node, so inheriting the default would make the editor emit the one spelling the `findUnknownRefs` note rendered directly beneath it flags as out of scope — one panel contradicting its own generated output. A closed property test pins this: every subject the field offers has a root that same check accepts.

Compiled output is unchanged — the same CEL the runtime already evaluates, in the author's own quoting (`status == "shipped"`, double quotes preserved).

## The fold-or-fence call on `criteria`: FENCED

`flow-node-config.ts` declares two `expression` gates on the start node — `:323` `condition` ("Entry condition") and `:411` `criteria` ("Entry condition (legacy)"). Both line numbers verified on this branch's own ref. **Only `condition` is wired.** Three reasons, in order of weight:

1. **`criteria` is not an authoring surface.** Its `showWhen: { field: '__legacy__', equals: [] }` never matches, so `isFieldVisible` renders it only when a value is already stored. Nothing is ever authored into it; its whole job is keeping stored legacy metadata visible instead of falling back to raw JSON.
2. **Its own help text steers authors away** — `Legacy key — prefer "Entry condition" (condition)`. Giving the retiring key the better editor pulls in the opposite direction from the migration the field itself asks for.
3. **The builder recompiles wholesale on first edit.** Row mode emits `compile(rows, join)` for the entire predicate, so the first touch would normalise a legacy value in place. The raw input leaves the bytes alone until the author deliberately rewrites them, which is the right behaviour for a key whose intended next move is *migration to `condition`*, not polish.

Pinned negatively (`LEGACY_CRITERIA.conditionBuilder` is `undefined`, and the field still renders the plain input) so the fence cannot be lost by omission later.

## Corpus: before and after, **at the flow field**

The corpus is the 17 shipped start-node entry conditions (objectstack example apps + the HotCRM example in #6226's body). 15 are within the row grammar; 2 mix `&&` with a parenthesised `||` group, which is a grammar limit of the row model — explicitly a separate card, so they are pinned as expected-raw and held **out** of the round-trip denominator rather than flattering it.

| | measured on | row-mode adoption |
| --- | --- | --- |
| before | the flow Entry condition field | **0 / 17** — the field rendered a single-line `VariableTextInput`; row mode did not exist here |
| after | the flow Entry condition field | **15 / 17** (15/15 of the row-eligible set) |

⚠️ **This is deliberately not #6296's number re-measured.** That card's 17-condition sweep mounted `ConditionBuilder` **directly** with a `subjects` object written by the test, so it would have scored identically against a tree where `FlowNodeConfigField` had never heard of the component — it was blind to its own deliverable. Every assertion here instead runs the whole chain: a real draft → `resolveFlowScope` → the real descriptor out of `FLOW_NODE_CONFIG` → the field → the builder. `FlowNodeInspector.entryCondition.test.tsx` closes the last link by mounting the whole inspector, so "does the inspector actually ask for the vocabulary and hand it down" is measured rather than assumed.

Row mode is asserted **structurally** (N row controls exist + the compiled-CEL preview that only row mode renders), so an implementation that widened a raw fallback to swallow the corpus would score zero here, not full marks.

## Ablation — three cuts, each red on exactly the right assertions

Each cut was proved **on disk** before it was believed: an anchored count of the injected marker (want 1) *and* of the text that had to disappear (want 0), plus a blob hash that actually moved. Restoration was proved by **observation** — `git checkout HEAD -- <abs path>` (never the bare form, which restores from the index the first checkout already wrote), then blob hash back to its HEAD value and `git diff HEAD` empty for the path. All three legs ran under a `trap … EXIT INT TERM` with absolute paths. No rebuild is involved: the mutated modules are reached from the suites by relative specifier, never across a package `exports` boundary — and a cut going red without a rebuild is itself the proof that the source path is live rather than a stale `dist`.

Baseline: **44 passed / 0 failed.**

| cut | result | what it demonstrates |
| --- | --- | --- |
| **A** — `subjects` wiring removed, builder kept | 7 failed / 37 passed | Red on **only** the vocabulary pins. All 15 corpus round-trips stay **green** — because `parse()` accepts bare subjects regardless of vocabulary. This is the #6296 blindness reproduced on demand: the corpus number alone cannot see this card's deliverable, and the vocabulary pins are what actually measure it. |
| **B** — `ConditionBuilder` branch removed | 33 failed / 11 passed | Corpus, vocabulary and escape-hatch pins red. The 11 survivors are exactly the ones that assert the **pre-change** control: the four fences, the `isPlainTextInput` positive control, the corpus-size pin, the brace-error and help-text pins, and the three inspector-level negatives (schedule trigger, object-less trigger, decision branches). |
| **C** — descriptor `conditionBuilder: true` removed | 34 failed / 10 passed | B's signature **plus exactly one** test — "a template-mode expression field is never a condition builder", which reads the flag directly. A single-assertion discriminator between "render branch cut" and "descriptor opt-in cut". |

Nothing here is a uniform red.

## Default-path invariance

The five existing record-scoped consumers pass no `subjects` and are unchanged. `views/metadata-admin/widgets.tsx` — one of the five, and the subject of #6247, which sits in the decision box — was **not edited** (0 hits in `git diff origin/main --name-only`).

Pinned positively rather than by snapshot: `ConditionBuilder.subjectVocabulary.test.tsx`'s DEFAULT-PATH INVARIANCE block asserts the `record.` prefix, the `record.id` / `user.*` / `org.*` context, the absence of `previous.*`, and single-quote emission as *positive* facts, so changing the default goes red. It ran green in the regression below, alongside the suites of four of the five consumers. (`widgets.tsx` has no dedicated suite — a pre-existing gap, not one this change introduces; verified with a positive control that the path glob works.)

## Fences held

- **`decision` branch conditions are untouched.** They are `expression`-kind **columns** in an `objectList`, rendered by `FlowObjectListField`'s cell arm — different component, different commit protocol (`setCell` + blur-flush vs commit-on-change). Q2, a separate design decision. Pinned: a decision node's Branches repeater still renders an editable cell and zero builder rows.
- **No operator/grammar vocabulary was extended.** The two parenthesised conditions stay on raw mode by design.
- **No new `current_user` / root bindings.** The site declares a vocabulary; it adds no evaluator roots.
- A schedule / manual / webhook trigger, a record trigger with no object, a `recordId` lookup and a template-mode `collection` all keep the control they render today.

## Verification — every gate's own verdict line, exit code captured before any pipe

Run at final commit `903d6bec` on a clean tree (`git status --porcelain -uall` and `git diff HEAD` both empty).

| check | exit | verdict line |
| --- | --- | --- |
| `pnpm --filter '@object-ui/app-shell^...' build` | 0 | `os-verify-lock: VERDICT command-exit 0 · held the lock 163s` |
| `pnpm --filter @object-ui/app-shell type-check` | 0 | ran `tsc --noEmit && tsc -p tsconfig.test.json`, no output |
| vitest — `views/metadata-admin/` + `views/studio-design/` | 0 | `Test Files  253 passed (253)` · `Tests  2467 passed \| 1 skipped (2468)` |
| `pnpm --filter @object-ui/app-shell lint` | 0 | `✖ 2779 problems (0 errors, 2779 warnings)` — **whole package, not narrowed**; zero of them in the six files this PR touches |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ 4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `✅ No changeset declares a 'major' bump.` |
| `check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 5506 tracked text file(s); skipped 85 binary).` |
| `check:designer-field-key-parity` | 0 | `designer-field-key-parity: OK` |
| `check:vi-mock-specifiers` | 0 | `✅ check-vi-mock-specifiers: OK (… 743 relative specifier(s) resolved …)` |
| `check:esm-specifiers` | 0 | `Specifier leg: no un-ledgered package emits an extensionless relative specifier.` |
| `check:i18n-keys` | 0 | `Every in-scope call-site key resolves against the en pack (2856 keys) …` |
| `check:i18n-drift` | 0 | `No en value changed in this range.` |
| `check:entry-guard` | 0 | `✓ check:entry-guard: 50 scripts/ file(s) — no entry guard outside the baseline` |
| `check:self-import` | 0 | `✅ No package names itself inside its own src/.` |
| `check:phantom-deps` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:eager-closure` | 2 | **NOT MEASURED**, not red — see below |

`check:eager-closure` exits 2 on its own prerequisite, and says so in its verdict line: `No eager-closure report at apps/console/dist/eager-closure.json, so no ceiling could be weighed against the payload it governs. … This is a broken gauge, not a sensitive gate.` It needs a console build this run did not produce; CI builds and runs it. Analytically it is not at risk: `inspectors/index.ts` **already** statically imports both `FlowInspector` (→ `FlowNodeInspector` → `FlowNodeConfigField`) and `HookDefaultInspector` / `PageBlockInspector` / `ActionDefaultInspector` (→ `ConditionBuilder`), so `ConditionBuilder` was in the same static closure as `FlowNodeConfigField` before this change and the new import edge adds no module to it. (Checked with a control that lazy boundaries *do* exist in this tree, so "static" is a finding rather than a grep artifact.)

### Narrowings, declared

- **vitest**: ran 253 of `packages/app-shell`'s 561 test files — `views/metadata-admin/` + `views/studio-design/`, the blast radius of the diff plus every existing `ConditionBuilder` consumer. The population was read from `vitest list --filesOnly` (the tool's own resolution, not an assertion), and membership of each targeted consumer suite confirmed with a working negative control. The full 561-file package run does not fit the container's foreground ceiling; CI runs it.
- **eslint**: **not** narrowed — the whole `@object-ui/app-shell` package was linted (80s).
- Type-aware linting is **not** enabled (`tseslint.configs.recommended`, no `parserOptions.project` / `projectService`), so no untouched file's verdict can move as a consequence of this diff.
- An earlier probe that grepped the vitest log for per-file names returned false zeros — its negative control also returned zero, because the default reporter prints no file names on success. Re-measured with `vitest list`. Recording it because the zero looked clean.

## Consequence worth naming

Switching this field to the builder replaces the `{…}` variable data-picker with the builder's subject dropdown (row mode) and `CelPredicateField`'s lint + field autocomplete (raw mode). Flow **variables** are therefore no longer offered on this one field. None of the 17 shipped entry conditions references a flow variable, and the entry gate is evaluated before `seedRunVariables` runs, so this is not a measured regression — but it is a real change in what the picker offers, and it is stated rather than left to be discovered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_