### PR TITLE
fix(plugin-grid): retire four undeclared authored column reads in ObjectGrid.generateColumns()

### DIFF
--- a/.changeset/6458-retire-undeclared-column-reads.md
+++ b/.changeset/6458-retire-undeclared-column-reads.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-grid': minor
+---
+
+Retire four undeclared authored column reads in `ObjectGrid.generateColumns()`
+(objectui#6458).
+
+`ListColumnSchema` is a strict object, so an author who wrote `format`,
+`options`, `appearance` or `essential` on a list column was **refused at
+publish** with `unrecognized_keys` while the grid happily honoured the key at
+runtime. That is the `declared != enforced` split AGENTS.md #0.1 exists to
+stop, and it was reachable only through `(col as any)`. All four reads are
+removed. Each was re-measured on this branch before deletion: **zero authored
+occurrences on a column across `examples/` and `apps/`**, per key, with `field`
+as the positive control in the same query shape — so no real author's metadata
+changes behaviour today.
+
+What each retirement leaves as the only road:
+
+- `format` and `appearance` — the object-field fallback (`objectDefField?.format`
+  / `?.appearance`), which is already the road every measured author uses.
+- `options` — the object schema's select options. The column-level override was
+  exactly the shape that let AI-authored metadata drift from the schema it is
+  supposed to obey; one source for options beats two.
+- `essential` — mobile visibility stays positional (`colIndex === 0`).
+
+**Retired for want of authors, not forbidden forever.** If a real request for
+semantic mobile-column control arrives, the declare route reopens: declare the
+key on `@objectstack/spec` and read it without a cast. What stays ruled out is
+the third road — a renderer-side tolerance for a key the schema refuses.
+
+`columnReadBoundary-6458.test.ts` moves with the change: its bound on undeclared
+cast reads in that branch is now the **empty set**, so a new one goes red on
+arrival rather than accreting quietly.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -571,8 +571,11 @@ function normalizeColumns(
  *     needs no hold here. Tombstoned only in the sense that nothing writes it.
  *
  * `essential` is absent from both types on purpose: objectui#6004's suggested
- * key list named it, but it is READ off the authored column and turned into a
- * `className` — it is never emitted, and it is not a `ListColumn` member either.
+ * key list named it, but it was READ off the authored column and turned into a
+ * `className` — never emitted, and not a `ListColumn` member either. That read
+ * is now RETIRED too (objectui#6458), so mobile visibility is decided purely
+ * positionally (`colIndex === 0`) and nothing on either side of this producer
+ * carries the key.
  */
 
 /**
@@ -1951,7 +1954,10 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
             // `any[]`, and `ObjectGridColumnDraft` cannot bite on any member. Naming
             // the producer vocabulary here stops `any` at this one boundary.
             const baseInferredType: string | null = col.type || objectDefField?.type || inferColumnType({ field: col.field }) || null;
-            const formatHint = (col as any).format ?? objectDefField?.format;
+            // objectui#6458 — the column-level `format` read is RETIRED. The
+            // object-field fallback below is now the only road, which is what
+            // every measured author already used.
+            const formatHint = objectDefField?.format;
             const inferredType: string | null = baseInferredType
               ? resolveCellRendererType({ type: baseInferredType, format: formatHint })
               : null;
@@ -1976,13 +1982,11 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
               const uniqueValues = Array.from(new Set(data.map(row => row[col.field]).filter(Boolean)));
               fieldMeta.options = uniqueValues.map(v => ({ value: v, label: humanizeLabel(String(v)) }));
             }
-            if ((col as any).options) {
-              fieldMeta.options = translateOptions(schema.objectName, col.field, (col as any).options);
-            }
-            // Honor metadata-defined appearance only (col.appearance or
-            // objectDef field.appearance). When unset, the cell renders
-            // its default badge style — same as detail / form views.
-            const explicitAppearance = (col as any).appearance ?? objectDefField?.appearance;
+            // Honor metadata-defined appearance only — the objectDef FIELD's
+            // `appearance`, which since objectui#6458 is the only road (the
+            // column-level read is retired). When unset, the cell renders its
+            // default badge style — same as detail / form views.
+            const explicitAppearance = objectDefField?.appearance;
             if (explicitAppearance != null) {
               fieldMeta.appearance = explicitAppearance;
             }
@@ -2067,11 +2071,26 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
             // reads around it, and it threw away `ColumnPrefix`'s own typing, so
             // `prefixConfig.field` was `any` at every use below.
             //
-            // The four undeclared reads in this branch — `format`, `options`,
-            // `appearance`, `essential` — are deliberately NOT touched here. Each
-            // needs a declare-on-spec vs stop-reading verdict (objectui#6458
-            // escalates them), the declare leg is `@objectstack/spec` surface, and
-            // AGENTS.md #0.1 forbids answering either one renderer-side.
+            // ⭐ The four undeclared reads that used to sit in this branch —
+            // `format`, `options`, `appearance`, `essential` — are RETIRED
+            // (objectui#6458, maintainer ruling 2026-08-28, "B on all four").
+            // `ListColumnSchema` is a strict object that refuses all four at
+            // publish, so honouring them here was the `declared != enforced`
+            // split AGENTS.md #0.1 exists to stop. The retirement route (rather
+            // than declaring them on `@objectstack/spec`) follows the standing
+            // zero-authors rule: a key with no measured authors is retired at
+            // once, with no deprecation window. Re-measured on this ref before
+            // the deletion — zero authored occurrences of any of the four on a
+            // column across `examples/` and `apps/`.
+            //
+            // ⚠️ Retired for want of authors, NOT forbidden forever. If a real
+            // request for semantic mobile-column control arrives, the declare
+            // route reopens — objectstack#12715 is the precedent (removed while
+            // unenforced, re-introduced once demand and enforcement met). What
+            // is forbidden is the third road: a renderer-side tolerance for a
+            // key the schema refuses. `columnReadBoundary-6458.test.ts` now
+            // bounds this branch's undeclared cast reads to the EMPTY SET, so a
+            // new one goes red on arrival instead of accreting quietly.
             const prefixConfig = col.prefix;
             if (prefixConfig?.field) {
               const baseCellRenderer = cellRenderer;
@@ -2098,7 +2117,7 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
             const inferredAlign = col.align || (effectiveType && numericTypes.includes(effectiveType) ? 'right' as const : undefined);
 
             // Determine if column should be hidden on mobile
-            const isEssential = colIndex === 0 || (col as any).essential === true;
+            const isEssential = colIndex === 0;
 
             return {
               header,

--- a/packages/plugin-grid/src/__tests__/columnReadBoundary-6458.test.ts
+++ b/packages/plugin-grid/src/__tests__/columnReadBoundary-6458.test.ts
@@ -8,7 +8,7 @@
 
 /**
  * objectui#6458 — what `ObjectGrid.generateColumns()` is allowed to READ off
- * the AUTHORED column.
+ * the AUTHORED column. The answer is now: **only what `ListColumn` declares.**
  *
  * ## The seam, and why it is NOT the one objectui#6004 fenced
  *
@@ -18,30 +18,41 @@
  * fence is on the emit, and `columnEmitBoundary-6004.test.ts` pins it.
  *
  * This file pins the OTHER half: the same function's READ of its authored
- * input. Nothing on that side is typed at all — `col` is a `ListColumn`, and
- * every read that `ListColumn` does not declare goes through `(col as any)`,
- * which admits any key whatsoever. `ListColumnSchema` is a `strictObject`, so
- * an author who writes one of those keys is REFUSED at publish with
- * `unrecognized_keys` while this renderer honours it — the `declared !=
- * enforced` split AGENTS.md #0.1 exists to stop.
+ * input. That side was untyped — `col` is a `ListColumn`, and every read
+ * `ListColumn` did not declare went through `(col as any)`, which admits any
+ * key whatsoever. `ListColumnSchema` is a `strictObject`, so an author who
+ * wrote one of those keys was REFUSED at publish with `unrecognized_keys`
+ * while this renderer honoured it — the `declared != enforced` split
+ * AGENTS.md #0.1 exists to stop.
  *
- * ## What is pinned here, and what is deliberately NOT
+ * ## The bound is now the EMPTY SET, and that is the load-bearing part
  *
- * PINNED — the closable half: a key `ListColumn` DECLARES must never be read
- * through a cast. `prefix` was (objectui#6458's own measurement), which is the
- * worst version of the defect: it made a schema-admitted key look exactly like
- * the four that are not, and it discarded `ColumnPrefix`'s typing at every use.
- * Casting a declared key buys nothing and hides the keys that matter, so it is
- * refused mechanically rather than by review.
+ * Both halves of the defect are closed, for two different reasons:
  *
- * NOT PINNED — the four genuinely undeclared reads (`format`, `options`,
- * `appearance`, `essential`). Each needs a per-key verdict — declare it on
- * `ListColumn` in `@objectstack/spec`, or stop reading it — and neither leg is
- * this repo's to decide unilaterally: the declare leg widens a published
- * contract, and AGENTS.md #0.1 forbids answering it renderer-side either way.
- * They are held to a SUBSET assertion instead, which is the part that can be
- * enforced without prejudging any of them: the four that exist may leave as
- * they are adjudicated, and a FIFTH may not arrive anonymously.
+ *   - A key `ListColumn` DECLARES, read through a cast (`prefix` was), buys
+ *     nothing and hides the undeclared ones among lookalikes. It also throws
+ *     away the declared type at every use. Fixed by objectui#6587.
+ *   - A key `ListColumn` does NOT declare, read at all (`format`, `options`,
+ *     `appearance`, `essential` were), is the declared != enforced split
+ *     itself. RETIRED by the maintainer's 2026-08-28 ruling — "B on all four"
+ *     — under the standing zero-authors rule: zero measured authors means
+ *     immediate retirement, no deprecation window. Re-measured on the ref that
+ *     carried the deletion: zero authored occurrences of any of the four on a
+ *     column, across `examples/` and `apps/`, with `field` as the positive
+ *     control in the same query shape.
+ *
+ * So `generateColumns()`'s `ListColumn` branch now contains NO cast read of
+ * any key, and this file pins exactly that. ⛔ The deletion alone would be
+ * undone by the next person who adds a cast; this bound is what makes the
+ * retirement stick.
+ *
+ * ⚠️ Retired for want of authors, NOT forbidden forever. If a real request for
+ * semantic mobile-column control arrives, the declare route reopens —
+ * objectstack#12715 is the precedent (removed while unenforced, re-introduced
+ * once demand and enforcement met). The right move then is to declare the key
+ * on `@objectstack/spec` and read it WITHOUT a cast, which this file allows by
+ * construction. What stays forbidden is the third road: a renderer-side
+ * tolerance for a key the schema refuses.
  *
  * ## Why a source scan rather than a rendering test
  *
@@ -49,9 +60,19 @@
  * renders correctly renders exactly as correctly with a cast added back. The
  * defect is that a read is unchecked, and nothing observable at runtime
  * distinguishes `(col as any).prefix` from `col.prefix`. What CAN be measured
- * is the source, so the source is what this reads — and every anchor it needs
- * is asserted present first, because a scanner that silently matches nothing
- * is a green test that measures nothing.
+ * is the source, so the source is what this reads.
+ *
+ * ## Anti-vacuity, which matters more here than it did before
+ *
+ * The guarded region's expected answer is now ZERO cast reads, so a scanner
+ * that silently matches nothing would be indistinguishable from success. Three
+ * separate controls stop that, and each must be able to fail on its own:
+ *   1. both region anchors asserted present, BY COUNT, before any slice;
+ *   2. the regex proved able to find cast reads on a synthetic input whose
+ *      answer is known;
+ *   3. the regex proved able to find a cast read in THIS REAL FILE, at real
+ *      scale — necessarily from OUTSIDE the guarded region, since inside it
+ *      the whole point is that there is nothing left to find.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -94,57 +115,65 @@ function castReadKeys(source: string): string[] {
   return [...source.matchAll(CAST_READ)].map((m) => m[1]);
 }
 
+function guardedRegion(): string {
+  return gridSource.slice(gridSource.indexOf(REGION_START), gridSource.indexOf(REGION_END));
+}
+
 /** The keys `ListColumnSchema` admits — read from the schema, never hand-listed. */
 const DECLARED_KEYS = Object.keys(
   (ListColumnSchema as unknown as { shape: Record<string, unknown> }).shape
 );
 
 /**
- * The undeclared reads objectui#6458 measured and escalated. A SUBSET bound,
- * not an equality: retiring one as its verdict lands must not turn this red,
- * but a fifth key arriving through a cast must.
+ * The four undeclared reads objectui#6458 escalated and the maintainer RETIRED
+ * on 2026-08-28. Listed here only so a re-added read can be named in the
+ * failure message; the bound itself is the empty set and does not depend on
+ * this list, so a FIFTH key arriving is refused just as loudly as one of these
+ * four returning.
  */
-const ESCALATED_UNDECLARED_READS = ['format', 'options', 'appearance', 'essential'];
+const RETIRED_UNDECLARED_READS = ['format', 'options', 'appearance', 'essential'];
 
 describe('objectui#6458 — the read boundary of ObjectGrid.generateColumns()', () => {
   it('the scan region is anchored — both bounds present exactly once', () => {
-    // Anti-vacuity. Every "no such key" claim below is worthless if the region
-    // resolved to an empty string, so the anchors are asserted first and by
-    // count: a moved or duplicated anchor fails HERE, loudly, rather than
-    // turning the assertions that follow into green no-ops.
+    // Anti-vacuity control 1. Every "no such key" claim below is worthless if
+    // the region resolved to an empty string, so the anchors are asserted first
+    // and BY COUNT: a moved or duplicated anchor fails HERE, loudly, rather
+    // than turning the assertions that follow into green no-ops.
     expect(gridSource.split(REGION_START).length - 1).toBe(1);
     expect(gridSource.split(REGION_END).length - 1).toBe(1);
+    expect(guardedRegion().length).toBeGreaterThan(1000);
   });
 
   it('the scanner extracts a cast read (control on a synthetic input)', () => {
-    // The regex proved able to find what it is looking for, on an input whose
-    // answer is known — so a zero from the real source is a measurement and not
-    // a broken pattern.
+    // Anti-vacuity control 2. The regex proved able to find what it is looking
+    // for, on an input whose answer is known — so a zero from the real source
+    // is a measurement and not a broken pattern.
     expect(castReadKeys('const x = (col as any).someKey;')).toEqual(['someKey']);
     expect(castReadKeys('const y = (col as unknown as Foo).other;')).toEqual(['other']);
     expect(castReadKeys('const z = col.declaredKey;')).toEqual([]);
   });
 
-  it('the scanner finds cast reads in the real region (control on the real file)', () => {
-    const region = gridSource.slice(
-      gridSource.indexOf(REGION_START),
-      gridSource.indexOf(REGION_END)
-    );
-    expect(region.length).toBeGreaterThan(1000);
-    // Today this is the four escalated keys. If it ever reaches zero, every
-    // read in this branch is declared, objectui#6458 is closed, and this file
-    // goes with it — a red here is that news, not a regression.
-    expect(castReadKeys(region).length).toBeGreaterThan(0);
+  it('the scanner finds a cast read in the REAL file, outside the guarded region', () => {
+    // Anti-vacuity control 3, and the one that had to move. It used to draw its
+    // control from INSIDE the region — which worked only while the region still
+    // contained cast reads to find. Now that the region's correct answer is
+    // zero, a control drawn from inside it would be the very thing it is meant
+    // to rule out. So it is drawn from the grouped-width pass further down the
+    // file, where `(col as any).fitContent` iterates EMITTED columns rather
+    // than the authored input (objectui#6424's question, deliberately outside
+    // this guard). If that read is ever retired too, this control must be
+    // re-pointed at another real cast — never deleted, and never re-pointed
+    // back inside the region.
+    const outside = gridSource.slice(gridSource.indexOf(REGION_END));
+    expect(castReadKeys(outside)).toContain('fitContent');
   });
 
   it('⭐ no key `ListColumn` DECLARES is read through a cast', () => {
-    // The one closable half of objectui#6458. `prefix` failed this before the
-    // fix: declared by `ListColumnSchema`, read as `(col as any).prefix`.
-    const region = gridSource.slice(
-      gridSource.indexOf(REGION_START),
-      gridSource.indexOf(REGION_END)
-    );
-    const castDeclared = castReadKeys(region).filter((k) => DECLARED_KEYS.includes(k));
+    // Half one, closed by objectui#6587. `prefix` failed this before that fix:
+    // declared by `ListColumnSchema`, read as `(col as any).prefix`. Casting a
+    // declared key buys nothing, hides the undeclared ones among lookalikes,
+    // and discards the declared type at every use.
+    const castDeclared = castReadKeys(guardedRegion()).filter((k) => DECLARED_KEYS.includes(k));
     expect(
       castDeclared,
       'A declared ListColumn key read through a cast buys nothing and hides the ' +
@@ -152,30 +181,47 @@ describe('objectui#6458 — the read boundary of ObjectGrid.generateColumns()', 
     ).toEqual([]);
   });
 
-  it('no FIFTH undeclared read may arrive anonymously', () => {
-    const region = gridSource.slice(
-      gridSource.indexOf(REGION_START),
-      gridSource.indexOf(REGION_END)
-    );
-    const undeclared = [...new Set(castReadKeys(region))].filter(
+  it('⭐ no UNDECLARED key is read at all — the bound is the EMPTY SET', () => {
+    // Half two, closed by the maintainer's 2026-08-28 ruling. This is the
+    // assertion the retirement rests on: the deletion alone is undone by the
+    // next person who adds a cast, and this is what makes it stick.
+    const undeclared = [...new Set(castReadKeys(guardedRegion()))].filter(
       (k) => !DECLARED_KEYS.includes(k)
     );
-    for (const key of undeclared) {
+    expect(
+      undeclared,
+      'This key is read off the authored column and `ListColumnSchema` REFUSES ' +
+        'it, so an author who writes it gets `unrecognized_keys` at publish while ' +
+        'this renderer honours it — the `declared != enforced` split AGENTS.md ' +
+        '#0.1 exists to stop. objectui#6458 retired all four that used to be ' +
+        'here (maintainer, 2026-08-28). ⛔ Do not widen this bound to make the ' +
+        'build green, and do not add a renderer-side tolerance. If the ' +
+        'capability is genuinely wanted, DECLARE the key on `@objectstack/spec` ' +
+        'and read it without a cast — that route is open and this guard allows it.'
+    ).toEqual([]);
+  });
+
+  it('each retired key is named individually, so a re-added read says which one', () => {
+    // The bound above is already the empty set, so this adds no strictness. It
+    // adds DIAGNOSIS: a uniform "expected [x] to equal []" tells you a read came
+    // back, and this tells you which verdict it re-opens.
+    const region = guardedRegion();
+    for (const key of RETIRED_UNDECLARED_READS) {
       expect(
-        ESCALATED_UNDECLARED_READS,
-        `\`${key}\` is read off the authored column and \`ListColumnSchema\` refuses ` +
-          'it, so an author who writes it gets `unrecognized_keys` at publish while ' +
-          'this renderer honours it. Adjudicate it on objectui#6458 (declare on ' +
-          '`@objectstack/spec`, or stop reading it) — do not add a renderer-side ' +
-          'tolerance, and do not widen this list to make the build green.'
-      ).toContain(key);
+        castReadKeys(region),
+        `\`${key}\` was RETIRED by objectui#6458's maintainer ruling (2026-08-28, ` +
+          '"B on all four") under the standing zero-authors rule. Re-adding the ' +
+          'read re-opens a verdict, which is a maintainer decision, not a ' +
+          'refactor. If a real author has appeared, that is news for the card — ' +
+          'the declare route reopens (objectstack#12715 precedent).'
+      ).not.toContain(key);
     }
   });
 
-  it('the split is real — the schema refuses `essential` while the renderer reads it', () => {
-    // The card's core measurement, executable. `essential` is the clearest of
-    // the four: it is not a `ListColumn` member, it has no second road (nothing
-    // else can mark a column mobile-essential), and the repo authors it nowhere.
+  it('the split is closed — the schema still refuses `essential`, and nothing reads it', () => {
+    // The card's core measurement, executable. `essential` was the clearest of
+    // the four: not a `ListColumn` member, no second road (its fallback is
+    // positional, `colIndex === 0`), and authored nowhere in the repo.
     const refused = ListColumnSchema.safeParse({ field: 'name', essential: true });
     expect(refused.success).toBe(false);
     if (!refused.success) {
@@ -184,17 +230,21 @@ describe('objectui#6458 — the read boundary of ObjectGrid.generateColumns()', 
       expect((issue as unknown as { keys: string[] }).keys).toContain('essential');
     }
 
-    // DECLARED CONTROL, same query shape: the key this producer now reads
-    // WITHOUT a cast is genuinely admitted, so the refusal above is about
-    // `essential` and not about the fixture being malformed.
+    // DECLARED CONTROL, same query shape: a key this producer genuinely reads
+    // is admitted, so the refusal above is about `essential` and not about the
+    // fixture being malformed.
     const admitted = ListColumnSchema.safeParse({
       field: 'name',
       prefix: { field: 'stage', type: 'badge' },
     });
     expect(admitted.success).toBe(true);
+
+    // And the renderer side of the split is gone: mobile visibility is decided
+    // positionally now, with no key behind it.
+    expect(guardedRegion()).toContain('const isEssential = colIndex === 0;');
   });
 
-  it('dropping the cast restored the type — `ListColumn["prefix"]` is not `any`', () => {
+  it('the surviving reads are typed — `ListColumn["prefix"]` is not `any`', () => {
     /** True only for `any`: the one type both branches of a conditional accept. */
     type IsAny<T> = 0 extends 1 & T ? true : false;
     type Expect<T extends true> = T;

--- a/packages/plugin-grid/src/__tests__/columnReadBoundary-6458.test.ts
+++ b/packages/plugin-grid/src/__tests__/columnReadBoundary-6458.test.ts
@@ -240,8 +240,17 @@ describe('objectui#6458 — the read boundary of ObjectGrid.generateColumns()', 
     expect(admitted.success).toBe(true);
 
     // And the renderer side of the split is gone: mobile visibility is decided
-    // positionally now, with no key behind it.
-    expect(guardedRegion()).toContain('const isEssential = colIndex === 0;');
+    // positionally now, with no key behind it. Asserted as a BOOLEAN rather
+    // than `expect(region).toContain(...)`: the region is ~200 lines, and a
+    // string-containment failure prints all of it, burying the one line that
+    // matters under a diff nobody reads.
+    const POSITIONAL_ONLY = 'const isEssential = colIndex === 0;';
+    expect(
+      guardedRegion().includes(POSITIONAL_ONLY),
+      'Mobile visibility must be decided positionally, with no key behind it: ' +
+        'expected the region to contain exactly `' + POSITIONAL_ONLY + '`. ' +
+        'objectui#6458 retired the `essential` read (maintainer, 2026-08-28).'
+    ).toBe(true);
   });
 
   it('the surviving reads are typed — `ListColumn["prefix"]` is not `any`', () => {


### PR DESCRIPTION
Fixes #6458

`ObjectGrid.generateColumns()` stops reading the four authored column keys
`ListColumn` does not declare — `format`, `options`, `appearance`, `essential`
— per the maintainer's 2026-08-28 ruling (live director session, batch #4 item
4, presented as "all four B"): 「同意」.

`ListColumnSchema` is a `strictObject`, so an author who wrote any of the four
was **refused at publish** with `unrecognized_keys` while this renderer happily
honoured the key at runtime. That is the `declared != enforced` split AGENTS.md
#0.1 exists to stop, and it was reachable only through `(col as any)`.

The authority for **retiring** rather than declaring is the standing
zero-authors rule (2026-08-27, recorded on #6355 / objectstack#12668): zero
authors means immediate retirement, no deprecation window.

**All verification below is at `8353222a`, the final commit, on a clean tree
(`git status --porcelain` = 0 lines).**

---

## 1. Premise re-verified on this ref — the census was re-run, not quoted

The ruling rests on a zero-author measurement taken 2026-08-26. A key that had
gained an author since would change the answer, and a retirement is not
reversible from the author's side, so it was re-derived from scratch here.

### The population exists before anything is counted

`git ls-tree HEAD` confirms both roots: `examples/` (`byo-backend-console`,
`console-starter`, `hello-world`, `schema-catalog`) and `apps/` (`console`,
`site`). **690** tracked `.json` / `.ts` / `.tsx` / `.js` / `.mjs` files under
them: 446 JSON parsed, 243 TS parsed, **1 unparsed** (`apps/site/tsconfig.json`
— JSONC the tolerant reader still rejects). That one file is closed by
superset, not assumed: a bare word grep over it — which is a **superset** of
any key-position census — returns zero occurrences of all four words.

### The census is key-position aware, and that is load-bearing

A bare grep is wrong here in both directions. `format`, `options` and
`appearance` are entirely legal at other tiers — object-field level, widget
level, filter level, form-child level. So the scan walks **structure**: JSON via
`JSON.parse` and a recursive walk, TS/TSX via the TypeScript compiler API
(`ts.createSourceFile` + AST walk), recording every occurrence of the four words
**in key position** together with the ancestor property chain that leads to it.

### Result, per key — never as a total

| key | key-position occurrences under `examples/` + `apps/` | on a `ListColumn` column? | where they actually are |
| :--- | ---: | :--- | :--- |
| `format` | 3 | **0** | 2 at `fields[].format` (object-field tier — this is the fallback road itself), 1 at `dashboard.widgets[].format` |
| `options` | 71 | **0** | 15 form-field, 15 `widgets[]`, 11 `fields[]`, 6 settings-select, 3 `globalFilters[]`, rest form children / object-schema `fields` maps |
| `appearance` | 0 | **0** | nowhere at all |
| `essential` | 0 | **0** | nowhere at all — a bare grep also returns 0, the strongest form of zero |
| **`field`** | **98** | **POSITIVE CONTROL** | fires in the same query shape, incl. **10** at `columns[].field` in JSON + 5 at `var:COLUMNS[].field` + 2 at `columns[].field` in TS |

⭐ **The `options` row is exactly the trap this card warned about.** A bare grep
reports 71 "authors" and would have stopped a ruled retirement on false
evidence. Every one of the 71 is at a tier where the key is legal.

The single closest call is worth naming: `apps/console/src/dev/DevMasterDetail.tsx:31`
is `columns[].options` — but on `object-master-detail-form`'s `details[].columns[]`,
whose column objects are keyed by `name`, not `field`, and which is consumed by
`packages/plugin-form/src/MasterDetailForm.tsx` (`hydrateColumns`), **not** by
`ObjectGrid.generateColumns()`. Different component, different tier, not this
seam.

Narrower populations agree: of **51** JSON objects that are direct elements of a
`columns` array, **zero** carry any of the four. And a separate scan of
`packages/` finds **zero** column fixtures (object literal in a `columns` array
carrying a `field` key) authoring any of the four — so no test fixture depended
on the removed behaviour either.

**Conclusion: the premise holds on this ref. All four keys have zero authors,
per key, with a positive control that fires in the same query shape and the same
container.**

---

## 2. What each retirement leaves as the only road

- **`format`** and **`appearance`** — the object-field fallback
  (`objectDefField?.format` / `?.appearance`). Already the only road every
  measured author uses; the column-level read was a second dialect for the same
  fact.
- **`options`** — the object schema's select options. The column-level override
  was exactly the shape that lets AI-authored metadata drift from the schema it
  is supposed to obey. One source for options beats two.
- **`essential`** — mobile visibility stays **positional**: `colIndex === 0`.

⚠️ **Retired for want of authors, not forbidden forever.** If a real request for
semantic mobile-column control arrives, the **declare route reopens** — declare
the key on `@objectstack/spec` and read it without a cast, which the guard below
permits by construction. objectstack#12715 is the precedent: removed while
unenforced, re-introduced once demand and enforcement met. The changeset and the
in-code comment both say this, so neither reads as a door closed forever. What
stays ruled out is the third road — a renderer-side tolerance for a key the
schema refuses.

---

## 3. `prefix` — stated separately, because it is a separate thing (and already done)

`prefix` **is** declared by `ListColumn`, so its cast was never a retirement:
it was pure noise that made a schema-admitted key look exactly like the four
undeclared ones, and threw away `ColumnPrefix`'s typing at every use.

⚠️ **Correction to the dispatch order, in the card's favour:** that cast drop
had **already landed on `main`** in PR #6587. `ObjectGrid.tsx` at today's ref
already reads `const prefixConfig = col.prefix;`. So this PR does not touch it
and takes no credit for it — the "no declared key is read through a cast"
assertion in the guard simply continues to hold. Mentioned because the order
listed it as work to do.

---

## 4. The boundary pin moves in the same PR — this is the load-bearing half

The deletion alone is undone by the next person who adds a cast. `columnReadBoundary-6458.test.ts`
(landed by #6587) had a **subset** bound on undeclared cast reads, deliberately
loose while the four were unadjudicated. **That bound is now the empty set.**

Both halves of the defect are now refused mechanically:

- a **declared** key read through a cast (`prefix` was) — buys nothing, hides the
  undeclared ones among lookalikes;
- an **undeclared** key read at all — the `declared != enforced` split itself.

The bound does not depend on the list of four, so a **fifth** key arriving is
refused exactly as loudly as one of the four returning. A separate per-key
assertion exists only for **diagnosis** — so a re-added read names which verdict
it re-opens rather than printing an anonymous `expected [x] to equal []`.

### Anti-vacuity — three controls, and one of them had to move

The guarded region's correct answer is now **zero** cast reads, so a scanner
that silently matched nothing would be indistinguishable from success:

1. both region anchors asserted present **by count** before any slice, plus a
   region-length floor;
2. the regex proved able to find cast reads on a **synthetic** input;
3. ⭐ the regex proved able to find a cast read in **this real file, at real
   scale** — necessarily from **outside** the guarded region now, since inside
   it the whole point is that there is nothing left to find. It is drawn from
   `(col as any).fitContent` in the grouped-width pass, which iterates *emitted*
   columns rather than the authored input and is #6424's question, deliberately
   outside this guard.

Control 3 previously drew from *inside* the region — which worked only while
the region still contained cast reads. Leaving it there would have made it the
very thing it exists to rule out. The test says so, and says it must never be
re-pointed back inside.

---

## 5. Ablation — the pin bites, and it is a differentiated red

Re-added one retired read (`essential`) and measured.

**No rebuild is needed, and that is a property of the pin rather than a
shortcut:** the guard `readFileSync`s `ObjectGrid.tsx` straight off disk,
`@object-ui/types` is **aliased to `packages/types/src`** by the root
`vitest.config.mts` (line 261), and `@objectstack/spec@17.2.0` resolves from
`node_modules`. No `dist/` sits on the resolution path, so a stale build cannot
fake this result in either direction.

**Mutation proven on disk before any result was read** — never from an editor's
exit code:

```
retired form  present: 1 -> 0     (anchored grep -cF)
injected form present: 0 -> 1     (anchored grep -cF)
blob 0905b2ccc12facb49a77ec3998cbf6f539956e4f -> d1a316e9a1c3c19e394f169e1ad96f15d6804572
```

**Result — 3 failed / 5 passed, not a uniform red:**

```
× no UNDECLARED key is read at all - the bound is the EMPTY SET
    AssertionError: ... expected [ 'essential' ] to deeply equal []
× each retired key is named individually, so a re-added read says which one
    AssertionError: `essential` was RETIRED by objectui#6458's maintainer ruling ...
      expected [ 'essential' ] to not include 'essential'
× the split is closed - the schema still refuses `essential`, and nothing reads it
ABLATED_VITEST_EXIT=1
```

Assertions unrelated to that key stayed **green**, which is what makes this a
measurement rather than a blanket failure: the anchor test, the synthetic
scanner control, the real-file out-of-region control, the declared-key-cast
assertion, and the typed-`prefix` assertion.

**Restore proven by observation, not by an exit code**, under a
`trap restore EXIT INT TERM` using absolute paths, restoring with an explicit
`git checkout HEAD -- ABSPATH` (a bare `git checkout -- path` restores *from the
index*, which the mutation would be in):

```
blob now: 0905b2ccc12facb49a77ec3998cbf6f539956e4f  == HEAD blob
git diff HEAD -- packages/plugin-grid/src/ObjectGrid.tsx : 0 bytes
retired form present: 1   injected form present: 0
control re-run on the restored tree: Test Files 1 passed (1) | Tests 8 passed (8)
```

---

## 6. Gate verdicts — each quoted from the gate's own output, exit code captured before any pipe

All at `8353222a`. Every run redirects to a file and captures `$?` **before**
any `tail`, because `EXIT=$?` after `cmd | tail` reads `tail`'s status and prints
`0` for green and red alike.

| gate | exit | the gate's own verdict line |
| :--- | ---: | :--- |
| `pnpm --filter @object-ui/plugin-grid type-check` | 0 | `VERDICT command-exit 0`; script echoed as `tsc --noEmit && tsc -p tsconfig.test.json` (so this is not a zero-match pnpm filter) |
| `pnpm exec vitest run packages/plugin-grid/` | 0 | `Test Files 96 passed (96)` · `Tests 885 passed (885)` |
| `check:control-bytes` | 0 | `OK (scanned 5504 tracked text file(s); skipped 85 binary)` |
| `check:phantom-deps` | 0 | `Every in-scope import is declared by the package that publishes it.` |
| `check:self-import` | 0 | `No package names itself inside its own src/.` |
| `check:spec-symbols` | 0 | `spec symbol derivation: 1315 files scanned against 4959 spec export names` |
| `check:vi-mock-specifiers` | 0 | `OK (3881 tracked source file(s), 2179 test-named; 472 carry a mock)` |
| `check-changeset-presence.mjs` | 0 | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump.` |

The gate family was derived from **this repo's own** `package.json` scripts and
`.github/workflows/` — objectui has no `scripts/pm/dispatch-gates.mjs`; that
script lives only in objectstack and answers only about the tree it sits in.

### NOT MEASURED, checked rather than assumed

A package `typecheck` that excludes `**/*.test.ts` is a true sentence that says
nothing about an edited test file. Checked with `--listFiles`: the edited test
**is** in the `tsconfig.test.json` program (1 hit), with `columnEmitBoundary-6004`
as the positive control (1 hit) and `ObjectGrid.tsx` present (1 hit). So the
compile-time `IsAny` assertion in that file is real.

### Lint — a declared narrowing, with all three evidences

Repo-wide `eslint .` is left to CI. This run is narrowed to the two touched
files, and the narrowing is a **measurement**, not a skip:

1. **Population / type-awareness read from eslint's own config**, not asserted:
   `eslint.config.js` extends `js.configs.recommended` + `tseslint.configs.recommended`
   with **no** `parserOptions.project` and **no** `projectService`. Type-aware
   linting is off, so this diff cannot move the verdict on any file it did not
   touch.
2. **File count read from the tool's own `--format json` output:** 2 files
   linted, **0 errors**.
3. **Ratchet moves the right way, measured against base content** via
   `eslint --stdin --stdin-filename` at the same path (so no disk mutation, and
   the two readings are comparable):

| | total messages | `no-explicit-any` | `(col as any)` casts |
| :--- | ---: | ---: | ---: |
| `origin/main` | 217 | 186 | 6 |
| this branch | **212** | **181** | **1** |

Exactly **-5** on both counters, matching exactly the five cast occurrences
removed (`format` 1, `options` 2, `appearance` 1, `essential` 1) and nothing
else. The one survivor is `fitContent` at the grouped-width pass — a different
`col`, outside the guarded region, owned by #6424.

---

## Scope

Three files, all inside the dispatched fence:

- `packages/plugin-grid/src/ObjectGrid.tsx`
- `packages/plugin-grid/src/__tests__/columnReadBoundary-6458.test.ts`
- `.changeset/6458-retire-undeclared-column-reads.md` (`minor` — never `major`,
  per the fixed-group rule)

⛔ `packages/spec` is untouched: the declare route was not ruled here and that
package belongs to the spec seat. ⛔ Sibling #6424 is untouched: its `fitContent`
was ruled **declare** in the same batch — same criterion, opposite reading,
because `fitContent` has shipped authors and these four have none. Folding both
into one PR would destroy that contrast.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_