### PR TITLE
docs(fields): teach the spec's `{ lat, lng }` as the stored location value

### DIFF
--- a/content/docs/fields/location.mdx
+++ b/content/docs/fields/location.mdx
@@ -37,9 +37,10 @@ const officeLocation: LocationFieldMetadata = {
 ```
 
 The coordinates themselves are the field's **value**, not metadata: the widget stores
-an object carrying a `latitude` and a `longitude` and displays it as a comma-separated
-pair. No exported type declares that value shape today, which is tracked as
-[objectui#6154](https://github.com/objectstack-ai/objectui/issues/6154).
+an object carrying a `lat` and an `lng` and displays it as a comma-separated pair.
+That value shape is exported as `LocationValue` by `@objectstack/spec/data` —
+`{ lat, lng, altitude?, accuracy? }` — and it is what
+`valueSchemaFor({ type: 'location' })` validates a stored location against.
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).
@@ -50,18 +51,25 @@ The location field stores coordinates as an object:
 
 ```plaintext
 {
-  latitude: 37.7749,
-  longitude: -122.4194
+  lat: 37.7749,
+  lng: -122.4194
 }
 ```
 
-Input format: `latitude, longitude`
+`altitude` and `accuracy` are optional numbers on the same object.
+
+**Note**: the stored keys are `lat` and `lng`. The older `{ latitude, longitude }`
+spelling is deprecated and is **rejected** by `valueSchemaFor({ type: 'location' })`
+with `invalid_type` at `[lat]` and `[lng]` — do not author it.
+
+Input format: `latitude, longitude` — a user still types a comma-separated
+latitude-then-longitude pair; only the stored key names are `lat` / `lng`.
 - Example: `37.7749, -122.4194`
 
 ## Coordinate Ranges
 
-- **Latitude**: -90 to 90 (negative = South, positive = North)
-- **Longitude**: -180 to 180 (negative = West, positive = East)
+- **Latitude** (`lat`): -90 to 90 (negative = South, positive = North)
+- **Longitude** (`lng`): -180 to 180 (negative = West, positive = East)
 
 Examples:
 - New York: `40.7128, -74.0060`
@@ -113,7 +121,7 @@ the renderer:
   "type": "object-map",          // the registered type name — there is no `plugin:map`
   "objectName": "store",         // the records to plot
   "map": {                       // the declared config input; markers are derived from the data
-    "locationField": "location", // this page's field, read as { latitude, longitude }
+    "locationField": "location", // this page's field, read as { lat, lng }
     "titleField": "name",        // field used as the marker label
     "zoom": 12,                  // initial zoom level
     // Initial centre as [latitude, longitude]. Used only when no record
@@ -131,11 +139,11 @@ The field validates coordinate ranges:
 
 ```plaintext
 // Valid coordinates
-{ latitude: 37.7749, longitude: -122.4194 } ✓
+{ lat: 37.7749, lng: -122.4194 } ✓
 
 // Invalid - latitude out of range
-{ latitude: 95, longitude: -122.4194 } ✗
+{ lat: 95, lng: -122.4194 } ✗
 
 // Invalid - longitude out of range
-{ latitude: 37.7749, longitude: 200 } ✗
+{ lat: 37.7749, lng: 200 } ✗
 ```


### PR DESCRIPTION
Fixes #6660

`content/docs/fields/location.mdx` taught the deprecated `{ latitude, longitude }`
spelling as the canonical stored shape of a `type: 'location'` value. The contract,
measured on this branch against the pinned `@objectstack/spec`:

```
{ lat: 37.7749, lng: -122.4194 }             ACCEPT
{ latitude: 37.7749, longitude: -122.4194 }  REJECT  invalid_type@[lat] invalid_type@[lng]
{ lat: 1, lng: 2, altitude: 10, accuracy: 5 } ACCEPT
{ lat: 95, lng: -122.4194 }                  REJECT  too_big@[lat]
{ lat: 37.7749, lng: 200 }                   REJECT  too_big@[lng]
{ lat: 37.7749 }                             REJECT  invalid_type@[lng]
```

A published page instructing the next author — human or AI — to write the exact
spelling the platform's own contract refuses is the most plausible *source* of
deprecated-spelling data in the wild. That is what this PR closes.

The last two probe rows also re-confirm the page's `## Validation` section is
telling the truth: the range claims are really enforced (`too_big`), so only the
key spelling in that block needed to move.

## Per-site census

Every occurrence on the page, with the block it sits in and whether a gate reads
that block. Line numbers are on this PR's base (`8631c32a`), re-located on that ref
rather than taken from the card, whose numbers predate PR #6667.

| Site | Block | Gate reads it? | Before | After |
|---|---|---|---|---|
| `:53-54` | `plaintext` | no | `latitude:` / `longitude:` | **changed** to `lat:` / `lng:` |
| `:116` | `jsonc` comment | no | `read as { latitude, longitude }` | **changed** to `read as { lat, lng }` |
| `:134`, `:137`, `:140` | `plaintext` | no | `{ latitude: …, longitude: … }` x3 | **changed** to `{ lat: …, lng: … }` x3 |
| `:40` | prose | no | "an object carrying a `latitude` and a `longitude`" | **changed** to `lat` / `lng` |
| `:41-42` | prose | no | "No exported type declares that value shape today" + link to #6154 | **changed** — the claim is now false; names `LocationValue` from `@objectstack/spec/data` |
| `:63-64` | prose | no | "**Latitude**: -90 to 90" | **changed** to "**Latitude** (`lat`)" — ties the geographic name to the stored key |
| `:101` | `tsx` | **yes** — `check:doc-snippets` | already `{ lat: number; lng: number }` | **untouched by me** |
| `:3`, `:6` | frontmatter / prose | no | "latitude and longitude" | **kept** — the geographic quantities, not key names |
| `:33` | `ts` | yes | `placeholder: 'latitude, longitude'` | **kept** — see fence below |
| `:58` | prose | no | "Input format: `latitude, longitude`" | **kept**, clarified |
| `:119` | `jsonc` comment | no | `center` as `[latitude, longitude]` | **kept** — a positional tuple, not an object-key spelling |

After the change, `grep -n "latitude:" content/docs/fields/location.mdx` returns
**0** hits (before: 4). The surviving `latitude`/`longitude` words are the six
deliberate ones above, plus one new mention inside the note that **forbids** the
spelling — named in order to be ruled out, not taught.

## `:101` was already correct — and I did not touch it

PR #6667 moved that one line because it is the only site on the page any gate
compiles: `check:doc-snippets` collects `ts`/`tsx`/`typescript` fences
(`TS_FENCE_LANGUAGES`, `scripts/check-doc-snippet-types.mjs:317`) and the widget's
new prop type made the old `useState` type argument stop being assignable. It reads
`{ lat: number; lng: number }` on this PR's base and it does not appear in this
PR's diff.

That gate boundary is also the whole explanation for why this card exists: the
compiled block was forced correct by CI, and the `plaintext`, `jsonc` and prose
around it — which no gate compiles — kept teaching the opposite.

## Fence: `geolocation` and the geographic wording are deliberately untouched

`GeolocationField` / `type: 'geolocation'` is out of scope: `geolocation` is not a
member of the spec's closed `FieldType` union and its value schema accepts **both**
spellings, so it legitimately keeps `{ latitude, longitude }`. This page does not
document it, so nothing was changed on that account.

Separately, the page keeps saying "latitude, longitude" wherever it means the
*geographic quantities* rather than the *stored keys* — the placeholder, the input
format, and the `center` tuple. That is not an oversight; it is what the merged
implementation says, in `packages/fields/src/widgets/LocationField.tsx`:

> The coordinates are still called latitude and longitude to a human — only the
> STORED key names are the spec's, which is why the placeholder is unchanged.

The widget parses a comma-separated latitude-then-longitude string and stores
`onChange({ lat, lng })`. Rewriting the placeholder or the input format to
`lat, lng` would make the page wrong in the other direction, so the note at `:58`
now states that split explicitly instead.

`:119`'s `center` is likewise a positional `[lat, lng]` tuple, not an object —
`ObjectMap.listViewMapConfigReach.test.tsx:170` pins it as "`center` is `[lat, lng]`
(ObjectMapConfigSchema's own description)", i.e. latitude first. The doc comment
already describes that ordering correctly.

`:116` did change, because it describes what the map reads *out of this page's
field*: `ObjectMap.tsx:437-438` reads `location.lat` / `location.lng` first
(`const lat = location.lat || location.latitude;`), so `{ lat, lng }` is the
canonical answer there.

## Other pages teaching the same spelling: none found

Checked `content/docs/**` for the deprecated spelling as an **object key**
(`grep -rn "latitude:" content/docs/`), with `grep -rn "lat:" content/docs/` as the
positive control in the same query shape — the control returns hits on
`location.mdx:101` and nine `plugin-map.mdx` sites, so the query shape does find
what it is looking for.

The only hit outside this card's file is `content/docs/plugins/plugin-map.mdx:414`,
and it is **correct as written**: it sits under `### Separate Fields` and shows a
*record with separate `latitude` / `longitude` columns*, which is the map plugin's
`latitudeField` / `longitudeField` mode — those are real config keys whose defaults
are literally `'latitude'` / `'longitude'` (`ObjectMap.tsx:403-404`). That same page's
`### Object Format` section already teaches `location: { lat, lng }`.

`content/docs/plugins/index.md:200` is the prose bullet "Latitude/longitude support".

So: nothing folded in, and nothing owed to another card on this repo's docs.
(The framework-side docs defect is recorded separately as objectstack#12935 — other
repo, other seat.)

## Gates

Run on the final commit `e7cf3680`; exit codes captured before any pipe, verdict
lines quoted from each gate's own output.

| Gate | Exit | Verdict line |
|---|---|---|
| `check:doc-snippets` | **0** | `Semantic phase: 267 of 267 block(s) judged, 0 failed.` / `Every covered documentation snippet compiles against the built types.` |
| `check:doc-fences` | **0** | `✅ check:doc-fences — every TypeScript block in 223 document(s) is fenced ts/tsx/typescript … No unknown fence spelling hides one.` |
| `check:doc-types` | **0** | `✅ Every documented component type is registered.` |
| `check:control-bytes` | **0** | `✅ check-control-bytes: OK (scanned 5511 tracked text file(s); skipped 85 binary).` |
| `check:docs-route-closure` | **0** | `✅ gauge: 1349 modules crawled from 148 route roots (144 MDX), every specifier resolved …` |
| `scripts/check-doc-links.mjs` | **0** | `Links are valid across 17 scan roots.` |
| `scripts/check-changeset-presence.mjs` | **0** | `✅ No source of a released package changed in this range, so no changeset is owed.` |

`check:doc-snippets` first returned **exit 2**, `PRECONDITION NOT MET (exit 2) — The
snippet program was NOT run`. That is the gate's own "I could not run", not a
finding, so it is not reported as a red measurement: the packages it resolves
against were unbuilt in a fresh worktree. I ran the build the gate itself prescribes
(`turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter)
--concurrency=2`, 32/32 successful) and re-ran it for the exit 0 above.

`check:doc-fences` and `check:doc-snippets` are the ratchet-family gates here, so
both were re-run on the final commit rather than only pre-commit; the working tree
was clean at that point.

## Changeset

**None owed** — ruled by the gate, not guessed:

```
Compared the working tree with 8631c32ad (merge-base with origin/main): 1 file(s)
changed, 0 of them published source of a package the release covers, 0 under a
package changesets ignores, 0 changeset(s) added.
✅  No source of a released package changed in this range, so no changeset is owed.
```

## Sequencing

The card asks that this not land before #6272's widget flip. PR #6667 is already
merged (this branch is cut from it, `8631c32a`), so the page now describes the
shape the shipped widget actually produces.

Docs-only: no `packages/**` source, no `content/docs/releases/**`.

_Generated by [Claude Code](https://claude.ai/code/session_8ca04858-ea8e-5b85-9182-de59aa49e00c)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_