### PR TITLE
fix(app-shell): make buildExpressionUser's parameter the session contract

### DIFF
--- a/.changeset/6559-expression-user-input-contract.md
+++ b/.changeset/6559-expression-user-input-contract.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/app-shell': minor
+---
+
+**Breaking (compile-time only):** `buildExpressionUser`'s PARAMETER is now the session
+contract — `ExpressionUserSession | null | undefined` instead of `unknown` — so every call
+site is checked against it (objectui#6559).
+
+objectui#6551 narrowed the CAST the normaliser read its input through, so the module began
+DECLARING what a signed-in session is: `id`, `name` and `email` required, mirroring
+`@object-ui/auth`'s `AuthUser`. The parameter behind that cast stayed `unknown`, so the
+declaration bound nothing — every call site satisfied it vacuously and
+`buildExpressionUser({ name: 'B', email: 'b@c.d' })` still compiled. A declaration nothing
+checks is indistinguishable from no declaration at all (AGENTS.md #0.1). The cast is gone
+and the shape is stated once, on the parameter, so the declaration and the check are the
+same statement rather than two that merely agree.
+
+WHAT BREAKS, AND FOR WHOM. This tightens a signature published from the package entry
+(`packages/app-shell/src/index.ts`), so an external caller that passes an unchecked or
+under-declared value stops compiling on upgrade. That is accepted (maintainer ruling
+2026-08-27, option A): the only calls it refuses are calls that were never conformant with
+the contract the module already declared. It ships as `minor`, not `major` — objectui's
+major tracks `@objectstack`'s, so its own breaking changes ship as a minor with the break
+written down (`scripts/check-changeset-no-major.mjs`). ⛔ Keeping `unknown` and ⛔ adding a
+second, wider entry point were both declined.
+
+NO RUNTIME BEHAVIOUR MOVES. All four in-repo production call sites pass `useAuth().user`,
+typed `AuthUser | null`, and type cleanly unchanged — two in `console/AppContent.tsx`, one
+in `views/RecordFormPage.tsx`, one in `apps/console`'s `InternalFormRoute.tsx`. The body is
+byte-equivalent: the same keys, the same `??` defaults, the same anonymous branch. ⛔ No
+consumer-side fallback was added; `id: u.id ?? null` remains the rejected shape (triage
+ruling 2026-08-26), because a lenient default in the consumer is what AGENTS.md #0.1
+forbids and it silently equates "signed in, no id" with "signed out".
+
+Note for callers holding the SPEC's `AuthUser` rather than `@object-ui/auth`'s: the spec
+type is an `interface` with no index signature, and TypeScript infers an implicit index
+signature for type aliases only, so it is not assignable to a contract declaring
+`[key: string]: unknown`. `@object-ui/auth`'s `AuthUser` extends it and adds that index
+signature, which is what every call site here passes.
+
+Pinned by the new `expressionUser.parameterContract.types.test.ts`, compiled by the
+package's `tsconfig.test.json` (chained off `type-check`, which CI runs). Its refusals are
+`@ts-expect-error` directives, so a re-widened parameter makes them UNUSED and TS2578 turns
+the type-check red; a type equation on `Parameters<typeof buildExpressionUser>[0]` reds
+alongside them. Every refusal is routed through a non-fresh value, so what is measured is
+the parameter and not excess-property freshness.

--- a/packages/app-shell/src/providers/expressionUser.parameterContract.types.test.ts
+++ b/packages/app-shell/src/providers/expressionUser.parameterContract.types.test.ts
@@ -1,0 +1,193 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Type-level pin for objectui#6559 — `buildExpressionUser`'s PARAMETER is the
+ * session contract, so every call site is checked against it.
+ *
+ * ## What the defect was
+ *
+ * objectui#6551 narrowed the CAST the normaliser read its input through, so the
+ * module began DECLARING what a signed-in session is (`id` / `name` / `email`
+ * required, mirroring the spec's `AuthUser`). The parameter behind that cast
+ * stayed `unknown`, so the declaration bound nothing: every call site satisfied
+ * it vacuously, and `buildExpressionUser({ name: 'B', email: 'b@c.d' })` still
+ * compiled. A declaration nothing checks is indistinguishable from no
+ * declaration — AGENTS.md #0.1. That gap is what this card closes, by moving
+ * the declaration from the cast onto the parameter.
+ *
+ * Maintainer ruling 2026-08-27 (option A): the parameter narrows to
+ * `ExpressionUserSession | null | undefined`; the tightening is compile-time
+ * only and no runtime behaviour moves. ⛔ B (keep `unknown`) and ⛔ C (a second,
+ * wider entry point) were declined.
+ *
+ * ## Why the instrument is `tsc` and not a test run
+ *
+ * Every assertion here is erased before vitest sees it, so a green test run
+ * proves nothing about any of them. What makes them a pin is
+ * `packages/app-shell/tsconfig.test.json`, which compiles every
+ * `src/**\/*.test.ts` in the package and is chained off the package's
+ * `type-check` script (the script CI's `Type Check` job runs, and
+ * `scripts/check-type-check-coverage.mjs` enforces the chaining). The package's
+ * BUILD tsconfig excludes `**\/*.test.ts`, so without that project these
+ * directives would be read by no compiler at all — failing neither when the
+ * error they name disappears nor when it was never there, which is
+ * objectui#3009's failure verbatim.
+ *
+ * Two instruments, because they fail in different directions:
+ *
+ * - `Assert<Equal<…>>` on the parameter type reds if the parameter becomes
+ *   anything other than the declared contract — including `unknown`.
+ * - `@ts-expect-error` reds via TS2578 ("unused '@ts-expect-error' directive")
+ *   the moment a refusal stops biting. A widened parameter accepts these
+ *   arguments again, the suppressed error goes away, and the directive itself
+ *   becomes the error.
+ *
+ * ## Freshness is not the contract
+ *
+ * A FRESH object literal is refused by excess-property checking regardless of
+ * what the parameter declares, so a pin routed only through one measures
+ * freshness rather than the contract. Every refusal case below is therefore
+ * routed through a NON-FRESH value — a `const` of a declared type, passed by
+ * name. `UNCHECKED` in particular is the whole card in one line: an `unknown`
+ * a caller has not narrowed, which is precisely what all four production call
+ * sites were free to pass before this change.
+ *
+ * ## No build artifact sits between the edit and these assertions
+ *
+ * The import below is a relative path to the SOURCE module, and that module is
+ * a LEAF that imports nothing, so no workspace `dist` can go stale on the path
+ * and degrade a type to `any`. `AuthUser` comes from the PUBLISHED
+ * `@objectstack/spec` typings; the `IsAny` guards below fail loudly if either
+ * import stops resolving, rather than letting a silent `any` turn a refusal
+ * case green.
+ */
+import { describe, it, expect } from 'vitest';
+import type { AuthUser } from '@object-ui/auth';
+import type { AuthUser as SpecAuthUser } from '@objectstack/spec/contracts';
+
+import { buildExpressionUser, type ExpressionUserSession } from './expressionUser';
+
+type Assert<T extends true> = T;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+/** What the function actually declares it accepts. */
+type Param = Parameters<typeof buildExpressionUser>[0];
+
+// ── The pin, stated directly on the parameter ───────────────────────────────
+// Guard against the probe lying: were either type `any`, every assertion here
+// would pass while proving nothing.
+type _ParamNotAny = Assert<Equal<IsAny<Param>, false>>;
+type _SessionNotAny = Assert<Equal<IsAny<ExpressionUserSession>, false>>;
+type _AuthUserNotAny = Assert<Equal<IsAny<AuthUser>, false>>;
+type _SpecAuthUserNotAny = Assert<Equal<IsAny<SpecAuthUser>, false>>;
+
+/**
+ * The card, as one type equation. `unknown` — the shape this parameter carried
+ * before objectui#6559 — is not equal to the contract, so re-widening reds
+ * HERE first, with the parameter named in the diagnostic.
+ */
+type _ParamIsTheDeclaredContract = Assert<
+  Equal<Param, ExpressionUserSession | null | undefined>
+>;
+type _ParamIsNoLongerUnknown = Assert<Equal<Equal<Param, unknown>, false>>;
+
+/**
+ * The narrowing did not overshoot. Every production call site passes
+ * `useAuth().user`, typed `AuthUser | null` by `@object-ui/auth`, and the
+ * signed-out branch is reached by passing `null`. Without these, "reds when the
+ * parameter widens" would also be satisfied by a parameter that refuses
+ * everything, which is the other way to disagree with the contract.
+ *
+ * ⚠️ The control is `@object-ui/auth`'s `AuthUser`, NOT the spec's, and the
+ * difference is load-bearing rather than a spelling choice. The spec's
+ * `AuthUser` is an `interface` with no index signature, and TypeScript infers
+ * an implicit index signature for type ALIASES only — never for interfaces — so
+ * the bare spec principal is not assignable to a contract that declares
+ * `[key: string]: unknown`. `@object-ui/auth`'s `AuthUser` extends it and adds
+ * that index signature (better-auth projects an app's custom user columns onto
+ * the object), which is exactly why the four production call sites type
+ * cleanly. Measured: using the spec interface here produced
+ * `TS2345: Argument of type 'AuthUser' is not assignable`, which would have
+ * been a false alarm about the parameter and is really a fact about interfaces.
+ */
+type _BrowserPrincipalIsAcceptedInput = Assert<Equal<AuthUser extends Param ? true : false, true>>;
+type _NullIsAcceptedInput = Assert<Equal<null extends Param ? true : false, true>>;
+type _UndefinedIsAcceptedInput = Assert<Equal<undefined extends Param ? true : false, true>>;
+type _UncheckedIsNotAcceptedInput = Assert<Equal<unknown extends Param ? true : false, false>>;
+
+/**
+ * The refusal cases as a CALLER writes them, all routed through non-fresh
+ * values. Assignability above is the contract; a call expression is the
+ * authoring surface, and excess-property freshness makes the two differ often
+ * enough to pin both.
+ */
+const UNCHECKED: unknown = { id: 'u_1', name: 'Ada', email: 'a@e.d' };
+const NO_ID: { name: string; email: string } = { name: 'B', email: 'b@c.d' };
+const OPTIONAL_ID: { id?: string; name: string; email: string } = {
+  id: 'u_1',
+  name: 'B',
+  email: 'b@c.d',
+};
+const PRINCIPAL: AuthUser = { id: 'u_1', name: 'Ada', email: 'a@e.d' };
+/** The signed-out arm the same call sites pass — `useAuth().user` is nullable. */
+const NOBODY: AuthUser | null = null;
+
+describe('objectui#6559 — the parameter is the session contract, checked at every call site', () => {
+  it('refuses an input the caller has not narrowed', () => {
+    // THE CARD. Before this change the parameter was `unknown` and this
+    // compiled — which is why all four production call sites satisfied
+    // objectui#6551's declaration vacuously. `UNCHECKED` is a const, not a
+    // literal, so this is the parameter refusing it and not freshness.
+    // @ts-expect-error objectui#6559 — `unknown` is not a signed-in session.
+    const fromUnchecked = buildExpressionUser(UNCHECKED);
+
+    // The runtime is unmoved by the narrowing (the ruling: compile-time only),
+    // so the refused input still normalises exactly as it always did.
+    expect(fromUnchecked).toMatchObject({ id: 'u_1', name: 'Ada', email: 'a@e.d' });
+  });
+
+  it('refuses a session missing a key the contract declares required', () => {
+    // Non-fresh, and missing `id` — the exact input objectui#6551 declared
+    // illegitimate and could not refuse. `name`/`email` are pinned by the type
+    // equation above; this is the call-expression half.
+    // @ts-expect-error objectui#6559 — a session with no `id` is not signed in.
+    const built = buildExpressionUser(NO_ID);
+
+    // ⛔ NOT a fallback. `id: u.id ?? null` is the REJECTED shape (triage
+    // ruling 2026-08-26, carried into objectui#6559's dispatch): a lenient
+    // default in the CONSUMER is what AGENTS.md #0.1 forbids, and it silently
+    // equates "signed in, no id" with "signed out". The honest answer is that
+    // the type refuses the input; nothing was added below it to paper over one.
+    expect(built.id).toBeUndefined();
+    expect(built.id).not.toBeNull();
+  });
+
+  it('refuses a session whose `id` is merely optional', () => {
+    // The producer-side spelling of the same defect: a caller whose own type
+    // makes `id` optional cannot satisfy the contract even when the value is
+    // present, because the CONTRACT is what the compiler checks, not the value.
+    // @ts-expect-error objectui#6559 — `id?: string` is wider than the contract.
+    const built = buildExpressionUser(OPTIONAL_ID);
+
+    expect(built.id).toBe('u_1');
+  });
+
+  it('accepts what the production call sites actually pass', () => {
+    // The overshoot control, on the real production input type. All four call
+    // sites pass `useAuth().user`, typed `AuthUser | null`; both arms are here.
+    const signedIn = buildExpressionUser(PRINCIPAL);
+    const signedOut = buildExpressionUser(NOBODY);
+
+    expect(signedIn.id).toBe('u_1');
+    expect(signedOut.id).toBeNull();
+  });
+});

--- a/packages/app-shell/src/providers/expressionUser.sessionContract.types.test.ts
+++ b/packages/app-shell/src/providers/expressionUser.sessionContract.types.test.ts
@@ -56,6 +56,16 @@
  * three of the cases below are in that position deliberately, because "the
  * narrowing did not overshoot" is a claim that needs its own controls.
  *
+ * ## The limit this file recorded is closed (objectui#6559)
+ *
+ * The last case below used to be ACCEPTED, pinning that the parameter was
+ * `unknown` and so the narrowed cast bound no call site. objectui#6559 moved
+ * the declaration onto the parameter (maintainer ruling 2026-08-27), and that
+ * case is now a REJECTION. The parameter's own discrimination — the leg that
+ * shows a re-widened parameter turning it green again — lives in
+ * `expressionUser.parameterContract.types.test.ts`, because the reverted
+ * preamble here can only re-widen the local type alias.
+ *
  * ## Fenced boundary
  *
  * `id: u.id ?? null` is the REJECTED shape (triage ruling, 2026-08-26): a
@@ -69,7 +79,7 @@ import ts from 'typescript';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
-import { buildExpressionUser } from './expressionUser';
+import { buildExpressionUser, type ExpressionUserSession } from './expressionUser';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const MODULE_IMPORT = join(HERE, 'expressionUser').replace(/\\/g, '/');
@@ -154,13 +164,18 @@ const CASES: readonly Case[] = [
     code: `const i: ExpressionUserSession = { id: 'u_1', name: 'Ada', email: 'a@e.d', role: 'user', positions: ['user'], isPlatformAdmin: true, department__c: 'sales' }; void i;`,
   },
   {
-    // The honest limit of this change, pinned so no reader has to infer it: the
-    // PARAMETER is `unknown`, so narrowing the CAST does not make any producer
-    // loud at compile time. It makes the module stop declaring the broken input
-    // legitimate. Widening the parameter is a different question and a
-    // different card.
-    what: 'the exported function still accepts an unchecked input — the cast is not a parameter check',
-    rejected: false,
+    // objectui#6551's honest limit — and objectui#6559 CLOSED it. While the
+    // PARAMETER was `unknown`, narrowing the cast made no producer loud at
+    // compile time: the module merely stopped declaring the broken input
+    // legitimate, and this case recorded that by being ACCEPTED. The parameter
+    // now IS `ExpressionUserSession | null | undefined` (maintainer ruling
+    // 2026-08-27, option A), so the same call is refused and this case is the
+    // seam between the two cards. It is rejected on BOTH legs below: the
+    // reverted preamble re-widens the local type ALIAS, while the parameter
+    // reads the real module's. What discriminates the parameter is
+    // `expressionUser.parameterContract.types.test.ts`.
+    what: 'the exported function refuses an unchecked input — the parameter is a call-site check',
+    rejected: true,
     code: `buildExpressionUser({ name: 'B', email: 'b@c.d' });`,
   },
 ];
@@ -278,8 +293,11 @@ describe('objectui#6551 — the signed-in cast is no wider than the contract it 
  *           not move. It pins that the anonymous answer is not an input,
  *           which is a different claim from this card's.
  *   5     — the spec-derived incomplete principal.
- *   6-9   — the overshoot controls and the `unknown`-parameter limit; green on
- *           both legs by construction.
+ *   6-8   — the overshoot controls; green on both legs by construction.
+ *   9     — NOT here either, and for the OPPOSITE reason: since objectui#6559
+ *           the parameter carries the contract, so that call is refused on
+ *           both legs. This leg re-widens the local type alias only, and the
+ *           parameter reads the real module's declaration.
  */
 const EXPECTED_FLIPS = [0, 1, 2, 3, 5];
 
@@ -330,7 +348,14 @@ describe('objectui#6551 — the runtime the narrowed declaration now describes',
     // input never arrives; the type is where that is now said, and this asserts
     // nothing was quietly added below it. Re-deciding this is a card, not a
     // test edit.
-    const built = buildExpressionUser({ name: 'B', email: 'b@c.d' } as unknown);
+    // Since objectui#6559 the PARAMETER refuses this input, so reaching the
+    // runtime with it takes a deliberate double assertion — which is the
+    // honest spelling: no producer can arrive here by accident any more, and
+    // this case is only asking what the code does if one is forced through.
+    const built = buildExpressionUser({
+      name: 'B',
+      email: 'b@c.d',
+    } as unknown as ExpressionUserSession);
 
     expect(built.id).toBeUndefined();
     expect(built.id).not.toBeNull();

--- a/packages/app-shell/src/providers/expressionUser.ts
+++ b/packages/app-shell/src/providers/expressionUser.ts
@@ -90,12 +90,34 @@
  * ("the shape that teaches the wrong thing") and the one objectui#6534 refused
  * for the anonymous branch, one key over.
  *
- * The narrowing is DECLARATIVE, and deliberately only that. Nothing reachable
- * today hands this function a session without `id` — the better-auth principal
- * above always carries one — so no runtime behaviour moves here and none was
- * made to move: the defect was that the declaration LIED about the contract,
- * not that a user could reach it. What refuses the widening from coming back is
- * the compiler, via `expressionUser.sessionContract.types.test.ts`.
+ * Nothing reachable today hands this function a session without `id` — the
+ * better-auth principal above always carries one — so no runtime behaviour
+ * moves here and none was made to move: the defect was that the declaration
+ * LIED about the contract, not that a user could reach it. What refuses the
+ * widening from coming back is the compiler, via
+ * `expressionUser.sessionContract.types.test.ts`.
+ *
+ * ## This type is the PARAMETER, not a cast (objectui#6559)
+ *
+ * objectui#6551 wrote the shape above but left the parameter `unknown`, with
+ * the narrowing applied INSIDE as `user as ExpressionUserSession | …`. A cast
+ * binds nothing: every call site satisfied the declaration vacuously, and
+ * `buildExpressionUser({ name: 'B', email: 'b@c.d' })` still compiled. A
+ * declaration nothing checks is indistinguishable from no declaration at all
+ * (AGENTS.md #0.1), which is why the shape above and the signature below are
+ * now the SAME statement rather than two that merely agree.
+ *
+ * Maintainer ruling 2026-08-27 (option A): the parameter narrows to
+ * `ExpressionUserSession | null | undefined`. It is a tightening of a
+ * package-entry export, so an external caller passing an unchecked value gets a
+ * compile error on upgrade — accepted, because such a call was never
+ * contract-conformant. All four in-repo production call sites pass
+ * `useAuth().user` (`AuthUser | null`) and type cleanly, measured: two in
+ * `console/AppContent.tsx`, one in `views/RecordFormPage.tsx`, one in
+ * `apps/console`'s `InternalFormRoute.tsx`. Runtime output is unchanged for
+ * every input any producer can supply. ⛔ B (keep `unknown`) and ⛔ C (a second,
+ * wider entry point) were declined. The pin is
+ * `expressionUser.parameterContract.types.test.ts`.
  *
  * ⛔ Not a fallback. `id: u.id ?? null` was the rejected shape (triage ruling,
  * 2026-08-26): it puts a lenient default in the CONSUMER, which AGENTS.md #0.1
@@ -119,9 +141,10 @@ export type ExpressionUserSession = {
   [key: string]: unknown;
 };
 
-export function buildExpressionUser(user: unknown): Record<string, unknown> {
-  const u = user as ExpressionUserSession | null | undefined;
-  if (!u) {
+export function buildExpressionUser(
+  user: ExpressionUserSession | null | undefined,
+): Record<string, unknown> {
+  if (!user) {
     return {
       // `null`, not absent — objectui#6534. An ABSENT key is not `false`: it
       // makes `ctx.user.id == '…'` FAULT, and a faulting visibility predicate
@@ -141,21 +164,21 @@ export function buildExpressionUser(user: unknown): Record<string, unknown> {
     };
   }
   return {
-    id: u.id,
-    name: u.name,
-    email: u.email,
-    role: u.role ?? 'user',
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role ?? 'user',
     // Surface the platform-admin flag so action `visible` CEL predicates
     // gated on `ctx.user.isPlatformAdmin == true` (e.g. sys_environment
     // "Change Plan (admin)") evaluate correctly. Previously only
     // name/email/role were forwarded → isPlatformAdmin-gated actions were
     // hidden even for platform admins.
-    isPlatformAdmin: u.isPlatformAdmin ?? false,
+    isPlatformAdmin: user.isPlatformAdmin ?? false,
     // Positions are what the SERVER binds as `current_user` for per-option
     // `visibleWhen` authorization gating (ADR-0058; framework EvalUser —
     // objectui#2284). Forwarding them lets a position-gated option
     // (`'admin' in current_user.positions`) hide client-side too, instead
     // of failing open as visible and only being rejected on submit.
-    positions: u.positions ?? [],
+    positions: user.positions ?? [],
   };
 }


### PR DESCRIPTION
Fixes #6559

`buildExpressionUser`'s parameter narrows from `unknown` to
`ExpressionUserSession | null | undefined`, so the input contract objectui#6551 declared is
now checked at every call site instead of being satisfied vacuously.

Maintainer ruling 2026-08-27 (decision-inbox batch 7), option A. ⛔ B (keep `unknown`) and
⛔ C (a second, wider entry point) were declined.

## What was wrong

objectui#6551 narrowed the CAST the normaliser read its input through, so the module began
DECLARING what a signed-in session is. The parameter behind that cast stayed `unknown`:

```ts
export function buildExpressionUser(user: unknown): Record<string, unknown> {
  const u = user as ExpressionUserSession | null | undefined;
```

A cast binds nothing. Every call site satisfied the declaration vacuously, and
`buildExpressionUser({ name: 'B', email: 'b@c.d' })` still compiled — pinned as a deliberate
control case in `expressionUser.sessionContract.types.test.ts`. A declaration nothing checks
is indistinguishable from no declaration at all (AGENTS.md #0.1).

## The call-site census, as measured on this branch

Enumerated with `git grep -n buildExpressionUser` over all tracked files, with a positive
control in the same query shape (`git grep -n ExpressionProvider`, 20 hits) so a zero would
have been distinguishable from a broken query. Line numbers are current: the card's census
was taken before PR #6657 moved `providers/ExpressionProvider.tsx`, so two of them have
shifted.

| production call site | what it passes | types after the narrowing |
| --- | --- | --- |
| `packages/app-shell/src/console/AppContent.tsx:660` | `useAuth().user` — `AuthUser \| null` | clean |
| `packages/app-shell/src/console/AppContent.tsx:921` | `useAuth().user` — `AuthUser \| null` | clean |
| `packages/app-shell/src/views/RecordFormPage.tsx:187` | `useAuth().user` — `AuthUser \| null` | clean |
| `apps/console/src/components/InternalFormRoute.tsx:78` | `useAuth().user` — `AuthUser \| null` | clean |

All four pass the same thing. `@object-ui/auth`'s `AuthUser` extends the spec's `AuthUser`,
which declares `id: string; email: string; name: string`, so all four satisfy the contract
today and none needed an edit.

**The stop condition was checked and not hit.** The narrowing refuses no input any live call
site passes. The only compile error the change produced anywhere was in this repo's own pin
file — `expressionUser.sessionContract.types.test.ts:333`, the deliberate `as unknown`
objectui#6551 wrote to document the very gap this PR fills:

```
src/providers/expressionUser.sessionContract.types.test.ts(333,39): error TS2345:
  Argument of type 'unknown' is not assignable to parameter of type
  'ExpressionUserSession | null | undefined'.
```

## The narrowed shape, and why it is the one objectui#6551 declared

The type is not new and was not re-derived here. `ExpressionUserSession` is the shape
objectui#6551 already wrote and the ruling already settled — `id` / `name` / `email`
required, `role` optional, index signature retained. This PR does not restate it; it deletes
the cast and puts that same name on the parameter, so the declaration and the check are one
statement rather than two that merely agree. The body is otherwise untouched: same keys,
same `??` defaults, same anonymous branch.

⛔ No consumer-side fallback was added. `id: u.id ?? null` remains the rejected shape (triage
ruling 2026-08-26, carried in-source), and the runtime fence in
`expressionUser.sessionContract.types.test.ts` that mechanises it is unchanged and still
green.

### One thing the measurement turned up

The SPEC's `AuthUser` is an `interface` with no index signature, and TypeScript infers an
implicit index signature for type ALIASES only — never for interfaces — so the bare spec
principal is not assignable to a contract declaring an index signature of
`key: string` to `unknown`. My first draft used it as the positive control and got
`TS2345: Argument of type 'AuthUser' is not assignable`, which would have been a false alarm
about the parameter. `@object-ui/auth`'s `AuthUser` extends the spec type and ADDS that index
signature, which is exactly what all four call sites pass, so the control is that one. The
fact is recorded in the pin's header and in the changeset for external callers.

## The pin — the load-bearing half

`packages/app-shell/src/providers/expressionUser.parameterContract.types.test.ts`, compiled
by the package's `tsconfig.test.json`, which is chained off `type-check` (the script CI's
Type Check job runs). Two instruments, failing in different directions:

- An `Assert` / `Equal` type equation over `Parameters` of `buildExpressionUser`, index `0`,
  reds if the parameter becomes anything but the contract, `unknown` included.
- Three `@ts-expect-error` directives red via **TS2578** the moment a refusal stops biting: a
  widened parameter accepts the argument again, the suppressed error vanishes, and the
  directive itself becomes the error. This is why a green **type-check** is the proof and a
  green test run is not — every assertion here is erased before vitest sees it.

**`--listFiles` proof the pin is in the program** (`tsc -p tsconfig.test.json --listFiles`,
4479 files):

```
packages/app-shell/src/providers/expressionUser.parameterContract.types.test.ts   1 hit
packages/app-shell/src/providers/expressionUser.sessionContract.types.test.ts     1 hit  (positive control, file known present)
packages/core/src/index.ts                                                        0 hits (negative control)
grep -c "app-shell/dist"                                                          0
```

The last two lines matter as much as the first. The negative control shows a `1` is
meaningful rather than an artefact of a project that swallows everything, and the zero
`app-shell/dist` hits show the pin reads the module's SOURCE — no build artefact sits between
the edit and the assertion, so nothing stale can degrade a type to `any` and turn a refusal
green.

**Freshness route.** A fresh object literal is refused by excess-property checking regardless
of what the parameter declares, so every refusal case is routed through a NON-FRESH value — a
`const` of a declared type, passed by name:

```ts
const UNCHECKED: unknown = { id: 'u_1', name: 'Ada', email: 'a@e.d' };
const NO_ID: { name: string; email: string } = { name: 'B', email: 'b@c.d' };
const OPTIONAL_ID: { id?: string; name: string; email: string } = { id: 'u_1', name: 'B', email: 'b@c.d' };
```

`UNCHECKED` is the card in one line: an `unknown` the caller has not narrowed, which is
precisely what all four call sites were free to pass before this change.

## Ablation — the pin bites, and only where it should

Widened the parameter back to `unknown` on disk (the pre-PR shape: `input: unknown` plus the
cast pushed back inside, body untouched), under
`trap 'git -C REPO_ROOT checkout HEAD -- ABSOLUTE_PATH' EXIT INT TERM` with absolute paths
resolved from `git rev-parse --show-toplevel`.

**Mutation proved on disk before anything was read** — anchored grep counts plus a moved blob
hash, never an editor exit code:

```
HEAD_BLOB=13ac3e3c8dd11f80d349f24864ca819c4a034f55
BEFORE  =13ac3e3c8dd11f80d349f24864ca819c4a034f55   (tree confirmed at HEAD before mutating)
INJECTED_COUNT=1 (want 1)      DELETED_COUNT=0 (want 0)
AFTER   =2134ff28399e740a56e480c8b129a8ef46f8ef23   (differs — MUTATION CONFIRMED ON DISK)
```

**Result — six reds, every one of them an assertion about the parameter:**

```
expressionUser.parameterContract.types.test.ts(99,3):   error TS2344  <- _ParamIsTheDeclaredContract
expressionUser.parameterContract.types.test.ts(101,39): error TS2344  <- _ParamIsNoLongerUnknown
expressionUser.parameterContract.types.test.ts(125,44): error TS2344  <- _UncheckedIsNotAcceptedInput
expressionUser.parameterContract.types.test.ts(150,5):  error TS2578: Unused '@ts-expect-error' directive.
expressionUser.parameterContract.types.test.ts(162,5):  error TS2578: Unused '@ts-expect-error' directive.
expressionUser.parameterContract.types.test.ts(178,5):  error TS2578: Unused '@ts-expect-error' directive.
tsc: Command failed with exit code 2
```

**Not a uniform red**, which is what makes it evidence. Green throughout the ablation: the
four `IsAny` probe-guards, and all three overshoot controls
(`_BrowserPrincipalIsAcceptedInput`, `_NullIsAcceptedInput`, `_UndefinedIsAcceptedInput`) —
so the pin is not satisfied by a parameter that simply refuses everything. The whole
type-level side of `sessionContract.types.test.ts` stayed green too; its single runtime
casualty was exactly the control case this PR flips:

```
Tests  1 failed | 14 passed (15)
  x the exported function refuses an unchecked input — the parameter is a call-site check
```

**Restoration proved by observation, not by an exit code** — restored with an explicit
`git checkout HEAD -- ABSOLUTE_PATH` (the bare form restores from the index the mutation is
already in):

```
git diff HEAD   -> empty
git status      -> empty
on-disk hash    -> 13ac3e3c8dd11f80d349f24864ca819c4a034f55   (back to the HEAD blob)
```

No rebuild leg is reported because none applies: the pin resolves the module through a
relative SOURCE import, evidenced by the zero `app-shell/dist` hits in `--listFiles` above.

## The control case objectui#6551 left behind

Per the ruling, that card's control case flips from "still accepts an unchecked input" to
"refuses an unchecked input". Its discrimination leg cannot move it — that leg re-widens a
local type ALIAS while the parameter reads the real module's declaration — so the case is now
rejected on both legs there, and the parameter's own discrimination lives in the new file.
Both facts are written into the two headers rather than left for a reader to infer.

## Gate verdicts — exit code captured before any pipe, each gate's own verdict line quoted

Union run at `f0585e87`, the final commit.

| gate | exit | its own verdict line |
| --- | --- | --- |
| `pnpm --filter @object-ui/app-shell type-check` | 0 | `VERDICT command-exit 0` — no `error TS` |
| vitest, 5 suites from repo root | 0 | `Test Files  5 passed (5)` · `Tests  40 passed (40)` |
| `pnpm --filter @object-ui/console type-check` | 0 | `VERDICT command-exit 0` |
| `check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 5517 tracked text file(s); skipped 85 binary).` |
| `check:type-check-coverage` | 0 | `✅ test type-check coverage: 41/41 packages compile their tests, 0 declared debt` |
| `check:phantom-deps` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:spec-symbols` | 0 | `✅ spec symbol derivation: 1316 files scanned against 4959 spec export names` |
| `check:self-import` | 0 | `✅ No package names itself inside its own src/.` |
| `check:entry-guard` | 0 | `✓ check:entry-guard: 50 scripts/ file(s) — no entry guard outside the baseline` |
| `check:vi-mock-specifiers` | 0 | `✅ check-vi-mock-specifiers: OK (3889 tracked source file(s) …)` |
| `check:readme-exports` | 0 | `✅ check-readme-exports: OK (… 0 unbuilt …)` |
| `check:eager-closure` | 0 | `✅ Console eager closure is 3236.9 KB gzipped … (budget: 3266.6 KB, headroom: 29.7 KB)` |
| `check-changeset-no-major.mjs` | 0 | `✅ No changeset declares a major bump.` |
| `check-changeset-fixed.mjs` | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `eslint --no-inline-config`, 3 changed files | 0 | `0 errors, 0 warnings` |

**Two gates were NOT MEASURED on their first run and are reported as such rather than as
reds**, both for a missing precondition, both green once the thing they named was built:

- `check:readme-exports` first exited 1 with
  `its type entry ./dist/index.d.ts is not on disk -- run pnpm build first` for
  `packages/cli` and `packages/plugin-ai` — unrelated to this diff. After building those two:
  exit 0, `0 unbuilt`.
- `check:eager-closure` first exited 2 with
  `No eager-closure report at apps/console/dist/eager-closure.json … This is a broken gauge,
  not 3 budgets that all passed.` After `pnpm --filter @object-ui/console build`: exit 0,
  all three per-chunk ceilings green.

**Declared narrowing (lint).** Repo-wide `pnpm lint` is CI's run; locally I linted the 3
changed files and prove the narrowing excluded nothing: (1) the population comes from
eslint's own config, which declares no `projectService` / `parserOptions.project` /
`tsconfigRootDir` — type-aware linting is not enabled; (2) the file count is read from
`--format json` (3 files, 0 errors, 0 warnings each); (3) with no type-aware linting
configured, a change in one file cannot move another file's verdict, so no untouched file's
result can have shifted.

## Scope and fences

Four files, all inside the claimed surface `packages/app-shell/src/providers/**` plus a
changeset:

```
.changeset/6559-expression-user-input-contract.md
packages/app-shell/src/providers/expressionUser.ts
packages/app-shell/src/providers/expressionUser.parameterContract.types.test.ts   (new)
packages/app-shell/src/providers/expressionUser.sessionContract.types.test.ts
```

⛔ Untouched, as fenced: `AppContent.tsx`, the `packages/app-shell` barrel export list, and
all of `apps/console/src/**` (held by #6535, same batch), plus `packages/plugin-grid`,
`packages/types`, `renderers/complex/data-table.tsx`, `packages/sdui-parser`,
`packages/plugin-list`, `packages/i18n`, `examples/schema-catalog`.

**One dispatch constraint turned out not to be owed — flagged rather than acted on.** The
maintainer ruling directed that the deliberate `unknown` mock at
`apps/console/src/__tests__/internalFormShell.test.tsx:95`
(`buildExpressionUser: (user: unknown) => user`) be updated in the same stroke. That file is
inside the `apps/console/src/**` fence, so I measured instead of editing:
`pnpm --filter @object-ui/console type-check` is **exit 0** with the narrowed parameter, over
a fully built dependency closure. The mock needs no change — a `vi.mock` factory is not
checked against the real module's shape, and a function taking `unknown` stays compatible
with a narrower parameter by contravariance anyway. So no fence breach was necessary and none
was made.

## Changeset

`minor`, not `major`: objectui's major tracks `@objectstack`'s, so its own breaking changes
ship as a minor with the break written down (`scripts/check-changeset-no-major.mjs`). The
changeset states the compile-time break in words, names who it can affect (external callers
passing unchecked or under-declared values), and records the spec-interface index-signature
note above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_