### PR TITLE
test(console): pin the three unpinned #2762 P1/P2 approvals behaviours

### DIFF
--- a/.changeset/6395-approvals-characterization-pins.md
+++ b/.changeset/6395-approvals-characterization-pins.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only: pins three delivered-but-unasserted Approvals Inbox behaviours
+(#2762 P1/P2, shipped in #2803/#2811) — approver chips keyed by (name, group),
+the "Flow-initiated" origin cell, and the record-card `prettifyKey`/
+`decisionAmountEntry` copy — as a characterization suite (objectui#6395). No
+production behaviour changes.

--- a/apps/console/src/pages/system/ApprovalsInboxPage.characterizationPins.test.tsx
+++ b/apps/console/src/pages/system/ApprovalsInboxPage.characterizationPins.test.tsx
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Approvals Inbox — characterization pins for three #2762 P1/P2 behaviours
+ * that shipped in #2803/#2811 with no assertion of their own (objectui#6395).
+ *
+ * ## What this file is, and is not
+ *
+ * Triage's charter (objectui#6395, 2026-08-25 19:54Z): commit a characterization
+ * suite for the three behaviours below. **No production-code change is
+ * chartered** — these are pins on shipped, working behaviour, not a fix.
+ *
+ *  1. **Approver chips carry their 会签 group** — `approverChips()` keys by
+ *     (name, group), so two different approver ids sharing one display name
+ *     stay two distinguishable labelled chips instead of collapsing back into
+ *     the reported symptom (#2811).
+ *  2. **A flow-initiated request names its origin** — `isSystemSubmitter()`
+ *     plus the "Flow-initiated" cell, instead of a bare person icon + em dash
+ *     (#2803).
+ *  3. **Record-card copy and emphasis** — `prettifyKey()` drops a trailing
+ *     `id` token (`owner_id` → "Owner") and `decisionAmountEntry()` promotes
+ *     the decision amount to a lead figure, excluded from the generic field
+ *     grid so it renders exactly once (#2803).
+ *
+ * The fourth #2762 behaviour the finding named — declared action hierarchy
+ * (`variant: 'primary'` renders filled, `variant: 'danger'` renders
+ * destructive) — is already pinned at
+ * `packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx`
+ * ("maps the spec action `variant` onto Button variants"). Not duplicated
+ * here.
+ *
+ * ## Why the fixture is non-degenerate — this is the load-bearing part
+ *
+ * A single-approver or single-group fixture passes against the PRE-FIX code
+ * too, so it proves nothing about the regression each case exists to catch.
+ * One shared row therefore carries, at once:
+ *
+ *  - **two different approver ids sharing one display name, filling two
+ *    different 会签 groups** (`u_fin` → Finance, `u_leg` → Legal) — the
+ *    fixture #2811 needed: same-name collapse only shows up when there are
+ *    two people to conflate;
+ *  - a **`flow:`-prefixed submitter id** with no `submitter_name` — the shape
+ *    a real flow-initiated request arrives in;
+ *  - a payload carrying **both `owner_id` and `amount`** — `owner_id` proves
+ *    the id-token trim (a bare `id` key, or one with a resolvable non-`_id`
+ *    name, would not exercise `prettifyKey`'s trim branch at all), `amount`
+ *    proves both the lead-figure promotion and the single-render exclusion.
+ *
+ * `approverChips()` and the "Waiting on" chips are rendered only in the
+ * drawer's business summary card (`selected.status === 'pending'` gate), and
+ * `prettifyKey`/`decisionAmountEntry` back that same card — so all three cases
+ * open the drawer. `isSystemSubmitter()` also renders identically in the
+ * desktop table row and mobile card; the drawer header is exercised here
+ * because it is already open for the other two cases, not because the table
+ * row is untested code — same function, same gate, same behaviour.
+ *
+ * No build artifact sits between the edit and this test: the root Vitest
+ * config aliases every `@object-ui` specifier at that package's source
+ * directory, and the page under test is this app's own source.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+const APP = 'com.objectstack.account';
+
+// `vi.hoisted` is hoisted above ordinary module-scope `const`s (it has to run
+// before the `vi.mock` factories below, which are themselves hoisted above
+// all imports) — so the two display-value fixtures live INSIDE it and are
+// destructured out below, rather than being plain top-level `const`s the
+// hoisted block would close over before they existed.
+const { approvalsApiStub, getObjectSchema, ADAPTER, AUTH, I18N, OWNER_DISPLAY, AMOUNT_DISPLAY } = vi.hoisted(() => {
+  /** The server-resolved display value for `owner_id` — never opaque-dropped. */
+  const OWNER_DISPLAY = 'Jordan Lee';
+  /** The server-formatted decision amount, as `payload_display` would send it. */
+  const AMOUNT_DISPLAY = 'USD 42,000.00';
+
+  // Widened on purpose, same reason as ApprovalsInboxPage.hiddenFieldTrim's
+  // ROW: a literal-inferred row would make the fixture's shape a type error
+  // in the test rather than in anything under test.
+  const ROW: Record<string, unknown> = {
+    id: 'req_1',
+    process_name: 'budget_approval',
+    process_label: 'Budget Approval',
+    object_name: 'showcase_purchase',
+    object_label: 'Purchase',
+    record_id: 'po_1',
+    record_title: 'PO-9001',
+    status: 'pending',
+    // Case 1 fixture: two DIFFERENT approver ids, same display name, two
+    // different 会签 groups — the non-degenerate shape #2811 needs.
+    pending_approvers: ['u_fin', 'u_leg'],
+    pending_approver_names: { u_fin: 'Dev Admin', u_leg: 'Dev Admin' },
+    pending_approver_groups: { u_fin: ['Finance'], u_leg: ['Legal'] },
+    // Case 2 fixture: a flow-initiated submitter, no resolved name.
+    submitter_id: 'flow:budget_escalation',
+    submitted_at: '2026-08-20T00:00:00.000Z',
+    // Case 3 fixture: an `_id`-suffixed key (prettifyKey's trim branch) and
+    // an amount-like key (decisionAmountEntry's lead figure), together.
+    payload: {
+      owner_id: 'usr_9f3ma2xk1pqz88a',
+      amount: 42000,
+    },
+    payload_display: {
+      owner_id: OWNER_DISPLAY,
+      amount: AMOUNT_DISPLAY,
+    },
+  };
+
+  const getObjectSchema = vi.fn(async (_name: string): Promise<unknown> => ({ fields: {} }));
+
+  const approvalsApiStub = {
+    listRequests: vi.fn(async () => ({ data: [ROW], total: 1 })),
+    getRequest: vi.fn(async () => ({ data: ROW })),
+    listActions: vi.fn(async () => ({ data: [] })),
+    approve: vi.fn(async () => ({ data: ROW, finalized: true })),
+    reject: vi.fn(async () => ({ data: ROW, finalized: true })),
+  };
+
+  // STABLE singletons: a mocked hook handing back a fresh object per render
+  // re-runs the page's load effect forever and the drawer never settles
+  // (same pitfall documented in the sibling pin files).
+  const ADAPTER = { find: vi.fn(async () => ({ data: [{ id: 'po_1' }] })), getObjectSchema };
+  const AUTH = { user: { id: 'u_fin', email: 'approver@example.com' } };
+  const I18N = {
+    t: (key: string, options?: Record<string, unknown>) => String(options?.defaultValue ?? key),
+    language: 'en',
+  };
+
+  return { approvalsApiStub, getObjectSchema, ADAPTER, AUTH, I18N, OWNER_DISPLAY, AMOUNT_DISPLAY };
+});
+
+vi.mock('@object-ui/i18n', () => ({ useObjectTranslation: () => I18N }));
+
+vi.mock('@object-ui/auth', () => {
+  const authFetch = vi.fn(async () => new Response('{}', { status: 200 }));
+  return {
+    useAuth: () => AUTH,
+    createAuthenticatedFetch: () => authFetch,
+    TokenStorage: { get: () => null },
+  };
+});
+
+vi.mock('@object-ui/app-shell', () => ({
+  useAdapter: () => ADAPTER,
+  DeclaredActionsBar: () => null,
+  isViaOverrideRow: () => false,
+}));
+
+vi.mock('../../services/approvalsApi', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  approvalsApi: approvalsApiStub,
+}));
+
+// Imported after the mocks so the page picks them up.
+import { ApprovalsInboxPage } from './ApprovalsInboxPage';
+
+function renderInbox() {
+  return render(
+    <MemoryRouter initialEntries={[`/apps/${APP}/system/approvals?request=req_1`]}>
+      <Routes>
+        <Route path="/apps/:appName/system/approvals" element={<ApprovalsInboxPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/** Open the drawer the way a notification opens it — the `?request=` deep link. */
+async function openedDrawer(): Promise<HTMLElement> {
+  renderInbox();
+  const dialog = await screen.findByRole('dialog');
+  await within(dialog).findByText('Budget Approval');
+  return dialog;
+}
+
+beforeEach(() => {
+  getObjectSchema.mockClear();
+  getObjectSchema.mockResolvedValue({ fields: {} });
+  for (const fn of Object.values(approvalsApiStub)) fn.mockClear();
+});
+afterEach(cleanup);
+
+describe('Approvals drawer — approver chips carry their 会签 group (objectui#2811, #6395)', () => {
+  it('keeps two same-name approvers as two distinguishable, group-labelled chips', async () => {
+    const dialog = await openedDrawer();
+
+    // Two DISTINCT badges, not one deduped chip with a "×2" count — that
+    // collapse is exactly the reported symptom (#2762 P1-2) the group key
+    // exists to prevent. `getByText` matches an element by its OWN direct
+    // text-node content (ignoring child elements), so this matches the Badge
+    // itself and not its nested group `<span>`.
+    const chips = screen.getAllByText('Dev Admin');
+    expect(chips).toHaveLength(2);
+
+    const chipTexts = chips.map((el) => el.textContent ?? '').sort();
+    expect(chipTexts.some((t) => t.includes('Finance'))).toBe(true);
+    expect(chipTexts.some((t) => t.includes('Legal'))).toBe(true);
+
+    // Neither chip carries a count badge — each key was seen once.
+    for (const chip of chips) {
+      expect(chip.textContent ?? '').not.toContain('×');
+    }
+
+    // Scoped to the drawer, not incidental matches elsewhere on the page.
+    expect(within(dialog).getAllByText('Dev Admin')).toHaveLength(2);
+  });
+});
+
+describe('Approvals drawer — a flow-initiated request names its origin (objectui#2803, #6395)', () => {
+  it('shows "Flow-initiated" instead of a bare person icon for a `flow:` submitter', async () => {
+    const dialog = await openedDrawer();
+
+    expect(within(dialog).getByText('Flow-initiated')).toBeInTheDocument();
+    // The alternate (non-system) branch renders `submitterDisplay`, which for
+    // this row — no `submitter_name` — falls back to `formatIdentity`'s
+    // truncated-middle form of the raw `flow:` id. Its absence shows the
+    // system branch actually fired, not just that "Flow-initiated" appears
+    // somewhere else on the page.
+    expect(within(dialog).queryByText('flow:b…tion')).not.toBeInTheDocument();
+  });
+});
+
+describe('Approvals drawer — record-card copy and emphasis (objectui#2803, #6395)', () => {
+  it('reads `owner_id` as "Owner" and leads with the decision amount exactly once', async () => {
+    const dialog = await openedDrawer();
+
+    // prettifyKey: the trailing `id` token is dropped, so the field label
+    // reads "Owner", not "Owner Id".
+    expect(within(dialog).getByText('Owner')).toBeInTheDocument();
+    expect(within(dialog).getByText(OWNER_DISPLAY)).toBeInTheDocument();
+
+    // decisionAmountEntry: the amount is promoted to the lead figure AND
+    // excluded from the generic field grid, so its display value renders
+    // exactly once on the page — not once as the lead figure and again as an
+    // ordinary grid row.
+    expect(screen.getAllByText(AMOUNT_DISPLAY)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #6395

## What this is

Commits the characterization suite triage chartered on objectui#6395
(2026-08-25 19:54Z): pin the three `apps/console/src/pages/system/ApprovalsInboxPage.tsx`
behaviours the finding named as delivered (#2803/#2811) but unasserted anywhere
in `apps/console` or `packages/app-shell`. **No production code changes** — this
is a test-only PR, per the charter.

New file: `apps/console/src/pages/system/ApprovalsInboxPage.characterizationPins.test.tsx`.

## The three behaviours pinned, with render sites on `9d86e1d79` (this branch's base)

1. **Approver chips carry their 会签 group** (#2811) — `approverChips()`
   (`ApprovalsInboxPage.tsx:199`) keys by `(name, group)`, rendered in the
   drawer's "Waiting on" section (`ApprovalsInboxPage.tsx:2039`).
2. **A flow-initiated request names its origin** (#2803) — `isSystemSubmitter()`
   (`ApprovalsInboxPage.tsx:224`) gates the "Flow-initiated" cell, rendered in
   the desktop table row (`:1633`), the mobile card (`:1705`), and the drawer
   header (`:1922`). This suite pins it via the drawer, already open for the
   other two cases — same function, same gate, same behaviour as the table row.
3. **Record-card copy and emphasis** (#2803) — `prettifyKey()`
   (`ApprovalsInboxPage.tsx:284`) drops a trailing `id` token, and
   `decisionAmountEntry()` (`ApprovalsInboxPage.tsx:384`) promotes the decision
   amount to a lead figure, excluded from the generic field grid via the
   `excludeKey` param at the drawer's `payloadSummary()` call (`:1895`). Both
   back the drawer's business summary card.

Item 4 (declared action hierarchy: `variant: 'primary'` → filled,
`variant: 'danger'` → destructive) is already pinned at
`packages/app-shell/src/views/__tests__/DeclaredActionsBar.test.tsx` ("maps the
spec action `variant` onto Button variants", still present at this branch's
base — confirmed by direct read). Not duplicated here, and no `packages/app-shell`
file is touched by this PR (two other in-flight branches hold it — the package
barrel/`AppContent`, and `src/providers/ExpressionProvider.tsx`).

## The fixture, and why non-degenerate is the load-bearing part

A single-approver or single-group fixture passes against the **pre-fix** code
too — it proves nothing about the regression each case exists to catch. One
shared row therefore carries, at once:

- **two different approver ids sharing one display name, filling two different
  会签 groups** — `u_fin` → Finance, `u_leg` → Legal, both named "Dev Admin".
  Same-name collapse (the #2762 P1-2 symptom) only shows up when there are two
  people to conflate.
- a **`flow:`-prefixed submitter id**, no `submitter_name` — the shape a real
  flow-initiated request arrives in.
- a payload carrying **both `owner_id` and `amount`** — `owner_id` exercises
  `prettifyKey`'s id-token trim branch (a bare `id` key or a non-`_id` name
  wouldn't); `amount` exercises both the lead-figure promotion and the
  single-render exclusion.

## Ablation — four legs (one behaviour has two independently mutable
mechanisms, so it gets two), each: commit first → mutate → predict → run →
observe → restore via `git checkout HEAD -- PATH` → confirm `git diff HEAD`
empty. Full transcript with anchor counts and diff stats available on request;
summarized here.

| # | Mutation | Predicted failure | Observed |
|---|---|---|---|
| 1 | `approverChips()`: `const key = group ? ... : label` → always `label` (group dropped from key) | Two same-name approvers collapse to one chip; `getAllByText('Dev Admin')` returns 1, not 2 | `AssertionError: expected … to have a length of 2 but got 1` — exact match |
| 2 | `isSystemSubmitter()` → always `return false` | "Flow-initiated" cell never renders; `getByText('Flow-initiated')` throws not-found | `Unable to find an element with the text: Flow-initiated` — exact match |
| 3a | `prettifyKey()`: id-token-drop line removed | `owner_id` label reads "Owner Id", not "Owner"; `getByText('Owner')` throws not-found (DOM dump confirms literal "Owner Id" text) | `Unable to find an element with the text: Owner` — exact match, and the failure's own DOM dump shows "Owner Id" |
| 3b | Drawer's `payloadSummary()` call: `drawerAmount?.key` → `undefined` (amount no longer excluded from the grid) | Amount display renders twice (lead figure + grid row); `getAllByText(AMOUNT_DISPLAY)` returns 2, not 1 | `AssertionError: expected … to have a length of 1 but got 2` — exact match |

Every leg's failure landed exactly on the case naming that behaviour and no
other; the other two cases stayed green in each run. After each restore,
`git diff HEAD` was empty and the full suite (all three cases) was re-run green
before proceeding to the next leg. Final state: tree clean, equal to this PR's
head commit.

## Gates

All commands run from the repo root per AGENTS.md §怎么跑测试 (root cwd, paths
relative to repo root, no trailing `--`). Verdicts quoted from each tool's own
printed summary line, captured by redirect-then-capture (never after a pipe).
Type-check and lint ran once, pre-merge (nothing they cover — `apps/console`
type surface, the one touched file — changed in the merge, since
`ApprovalsInboxPage.tsx` was untouched on `main` in the interim); vitest and
every changeset/control-bytes gate were **re-run post-merge, on `05086ac75`**,
and the table quotes those re-run verdicts.

| Gate | Command | Verdict (own printed line) | Exit |
|---|---|---|---|
| Targeted vitest (post-ablation, re-run on merged HEAD `05086ac75`) | `pnpm exec vitest run apps/console/src/pages/system/ApprovalsInboxPage.characterizationPins.test.tsx` | `Test Files  1 passed (1)` / `Tests  3 passed (3)` | 0 |
| `apps/console` type-check | `pnpm --filter '@object-ui/console' type-check` (`tsc --noEmit && tsc -b tsconfig.node.json --force`) | no diagnostics printed | 0 |
| Lint (narrowed to the one touched `.ts`/`.tsx` file) | `pnpm exec eslint apps/console/src/pages/system/ApprovalsInboxPage.characterizationPins.test.tsx --format json` | population = 1 file (from eslint's own JSON array length — matches the single touched lint-eligible file); `errorCount: 0`, `warningCount: 0` | 0 |
| `check-control-bytes` (re-run post-merge) | `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 5530 tracked text file(s); skipped 85 binary).` | 0 |
| `check-changeset-presence` (re-run post-merge) | `node scripts/check-changeset-presence.mjs` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/6395-approvals-characterization-pins.md.` (empty-frontmatter, declares no release; merge-base correctly read as current `fff964510`) | 0 |
| `check-changeset-no-major` | `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a 'major' bump.` | 0 |
| `check-changeset-fixed` | `node scripts/check-changeset-fixed.mjs` | `✅ All workspace packages are in the changeset fixed group.` | 0 |
| `check-changeset-overwrite` | `node scripts/check-changeset-overwrite.mjs` | `✅ No pre-existing changeset was modified or deleted.` | 0 |
| `packages/app-shell` scope | — | N/A — no file under `packages/app-shell` is touched by this PR (see above); nothing to run | — |

`skip-changeset` is not applied — nothing in this repo reads it (AGENTS.md).

## A note on `origin/main` during this PR

Mid-task, `origin/main` advanced under this worktree from `9d86e1d79` (this
branch's fetch base) to `fff964510` — the shared-ref hazard AGENTS.md §9
documents (the whole repo's `refs/remotes/*` is common-`.git`-dir-shared, not
worktree-isolated). First confirmed by diffing against the pinned
`BASE=$(git rev-parse HEAD)` recorded at worktree creation rather than the live
`origin/main`: the pinned diff was exactly this PR's two files (248 lines, both
new, zero deletions) — `ApprovalsInboxPage.tsx` itself was untouched by
everything that had landed on `main` in the interim (`data-table.tsx`,
`packages/types/data-display*`, `packages/i18n/locales/ar.ts` — all unrelated).

Then synced properly per AGENTS.md (`git merge origin/main`, not rebase): a
clean merge with no conflicts, HEAD now `05086ac75`. All three characterization
cases and every gate below were **re-run on this merged, current ref** — the
table quotes those re-run verdicts, not the earlier ones against the stale
base.

---

_Generated by [Claude Code](https://claude.ai/code/session_8ca04858-ea8e-5b85-9182-de59aa49e00c)_