### PR TITLE
refactor(plugin-grid): retire the redundant ObjectGridColumnHolds.headerIcon hold

### DIFF
--- a/.changeset/6424-retire-headericon-hold.md
+++ b/.changeset/6424-retire-headericon-hold.md
@@ -1,0 +1,11 @@
+---
+---
+
+Internal type cleanup in `plugin-grid`: `ObjectGridColumnHolds` no longer declares
+`headerIcon`, which `TableColumn` has declared since objectui#6615, plus the docblock
+corrections and pins that go with it. Nothing published moves — `ObjectGridColumnHolds`
+is not part of the package entry's exported surface (measured: 0 occurrences in
+`dist/index.d.ts`, control `ObjectGridColumnState` 1), and the two emit types are
+byte-identical without the member (27 resolved members before and after, against a
+positive control that removing `pinned` instead takes them to 26). No published
+behaviour changes.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -544,10 +544,17 @@ function normalizeColumns(
  *
  * Verdicts, each with the read-count behind it:
  *
- *   - `headerIcon` — HELD. Live: `data-table.tsx` renders it into the header
- *     cell (2 reads). Whether `TableColumn` should DECLARE it is objectui#6424's
- *     call, not this card's; declared here at the seam meanwhile, so the hold is
- *     visible instead of anonymous.
+ *   - `headerIcon` — DECLARED by `TableColumn`, so NOT held. Live:
+ *     `data-table.tsx` renders it into the header cell (1 render site, 2
+ *     syntactic reads), forwarded verbatim and never re-expressed. It WAS held
+ *     here, on the "undeclared by `TableColumn`" premise; objectui#6615
+ *     declared it and that premise expired with nothing going red at the moment
+ *     of loss. objectui#6424 then removed the hold, MEASURED rather than
+ *     derived: with the member deleted both emit types below are byte-identical
+ *     (27 members, every member's resolved type unchanged), against a positive
+ *     control that deleting `pinned` instead moves them to 26. Pinned in
+ *     `columnHoldsExpiry-6424.test.ts` — which now also carries the claim the
+ *     hold used to carry implicitly, that `TableColumn` DECLARES the key.
  *   - `pinned` — HELD. Live, and consumed BEFORE the slot: the reorder pass
  *     below reads it (5 reads in this file) and re-expresses it as the sticky
  *     `className` that `data-table` actually reads. `data-table` never reads
@@ -594,11 +601,34 @@ function normalizeColumns(
  */
 export type RetiredListColumnKey = Exclude<keyof ListColumn, keyof TableColumn | 'pinned'>;
 
-/** The undeclared-but-live keys this producer holds. See the docblock above. */
+/**
+ * The undeclared-but-live keys this producer holds. See the docblock above.
+ *
+ * ⚠️ "Undeclared by `TableColumn`" is this interface's ENTRY CONDITION, and it
+ * is a claim about ANOTHER package that can stop being true with nothing going
+ * red here. So it is re-checked per key when the card owning that key closes,
+ * never inherited: `headerIcon` sat here on exactly that premise until
+ * objectui#6615 declared it on `TableColumn`, at which point the hold was
+ * redundant rather than load-bearing, and objectui#6424 removed it.
+ *
+ * ⛔ A key whose ONLY declaration on the emit types is this interface is not in
+ * that position — deleting it deletes the key from the emit. `pinned` is that
+ * key today, which is why the two verdicts differ.
+ */
 export interface ObjectGridColumnHolds {
-  /** HELD, objectui#6424 — `data-table` renders it; `TableColumn` does not declare it. */
-  headerIcon?: React.ReactNode;
-  /** HELD — consumed by this file's own reorder pass before the array reaches the slot. */
+  /**
+   * HELD, load-bearing on BOTH counts — the pair that has to hold for a hold to
+   * be real, and the contrast that made `headerIcon`'s removal safe:
+   *
+   *   1. `TableColumn` does NOT declare it, and `RetiredListColumnKey` carves it
+   *      out of the derived tombstone band, so this member is its ONLY
+   *      declaration on both emit types. Deleting it drops the key from them
+   *      (measured: 27 members → 26).
+   *   2. It has a live consumer BEFORE the slot — this file's own reorder pass
+   *      reads it and re-expresses it as the sticky `className` that
+   *      `data-table` actually reads. That is the "second road" the emit rule
+   *      demands before a key may be retired, and `wrap` failed it.
+   */
   pinned?: 'left' | 'right';
 }
 

--- a/packages/plugin-grid/src/__tests__/columnEmitBoundary-6004.test.ts
+++ b/packages/plugin-grid/src/__tests__/columnEmitBoundary-6004.test.ts
@@ -139,19 +139,22 @@ describe('objectui#6004 — the emit boundary is an instrument, not a decoration
   });
 
   /**
-   * The HELD keys — the two `ObjectGridColumnHolds` still declares, which the
-   * emit type must therefore ACCEPT: a tombstone set that swallowed either
+   * Both keys the emit type must ACCEPT: a tombstone set that swallowed either
    * would be a behaviour change wearing a type change's clothes.
    *
-   * ⚠️ Their two holds no longer rest on the same footing, and that is
-   * objectui#6424's to settle rather than this pin's. `pinned` is undeclared by
-   * `TableColumn` and has a measured live reader — `ObjectGrid`'s own reorder
-   * pass, which consumes it before the array reaches the slot. `headerIcon` was
-   * held on the same "undeclared by `TableColumn`" premise, and that premise has
-   * since expired: `TableColumn` DOES declare it today
-   * (`packages/types/src/data-display.ts`), so its entry in
-   * `ObjectGridColumnHolds` is redundant rather than load-bearing. This test
-   * pins only that both are accepted, which is true either way.
+   * ⚠️ They no longer arrive by the same route, and objectui#6424 settled
+   * that. `pinned` is still HELD: undeclared by `TableColumn`, so
+   * `ObjectGridColumnHolds` is its only declaration on the emit types, AND it
+   * has a measured live reader — `ObjectGrid`'s own reorder pass, which
+   * consumes it before the array reaches the slot. `headerIcon` reaches the
+   * emit types through `TableColumn` itself: it was held on the same
+   * "undeclared by `TableColumn`" premise, objectui#6615 declared it
+   * (`packages/types/src/data-display.ts`) and the premise expired with nothing
+   * going red, so objectui#6424 removed the hold after measuring that both emit
+   * types are unchanged without it. So `ObjectGridColumnHolds` declares ONE key
+   * today, not two. This test pins only that both keys are accepted, which is
+   * true either way; the routes themselves are pinned in
+   * `columnHoldsExpiry-6424.test.ts`.
    *
    * ⚠️ There were three until objectui#5453. `wrap` was the third, and it was
    * held for a reason that was never "a live reader": the card that owned it
@@ -161,7 +164,7 @@ describe('objectui#6004 — the emit boundary is an instrument, not a decoration
    * open card is a hold with no evidence under it yet, and it should be
    * re-checked the moment the card closes rather than aging into a fact.
    */
-  it('accepts the two held keys — headerIcon, pinned', () => {
+  it('accepts headerIcon (via TableColumn) and pinned (via the hold)', () => {
     const held = { header: 'H', accessorKey: 'a', headerIcon: null, pinned: 'left' as const };
     const accepted: ObjectGridColumnDraft = held;
     expect(accepted.pinned).toBe('left');

--- a/packages/plugin-grid/src/__tests__/columnHoldsExpiry-6424.test.ts
+++ b/packages/plugin-grid/src/__tests__/columnHoldsExpiry-6424.test.ts
@@ -1,0 +1,156 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6424 — `ObjectGridColumnHolds` after the `headerIcon` hold came out.
+ *
+ * ## What actually changed, and what this file is for
+ *
+ * `ObjectGridColumnHolds` exists for keys `data-table` READS that `TableColumn`
+ * does NOT declare. `headerIcon` was one until objectui#6615 declared it on
+ * `TableColumn`; from that moment the hold was redundant rather than
+ * load-bearing, and NOTHING WENT RED — the same silent expiry objectui#6425
+ * recorded for `options`. objectui#6424 removed the member.
+ *
+ * ⚠️ THE REMOVAL MOVED A LIVENESS CLAIM RATHER THAN DELETING ONE. While the
+ * hold existed, the emit types declared `headerIcon` on their own account; now
+ * they get it ONLY from `TableColumn`. So if `TableColumn` ever stops declaring
+ * it, the key silently vanishes from both emit types and `ObjectGrid` goes on
+ * writing it at three sites into a slot that no longer admits it. That is a
+ * NEW exposure created by the removal, and the first assertion below is what
+ * covers it — it is the guard the deleted member used to provide implicitly.
+ *
+ * ## Why these pins are compile-time
+ *
+ * The claim is about TYPES, and a rendering test is blind to it: the grid
+ * renders exactly as correctly with every type in this file deleted. What can
+ * fail is a compile, and `tsc -p tsconfig.test.json` reads this file (the
+ * package build's own program excludes `__tests__`). The `expect()` calls are
+ * there so vitest reports the file at all; the assertions that matter are the
+ * `Expect<...>` aliases, which are erased at runtime.
+ *
+ * ## Every zero here has a positive control in the same query shape
+ *
+ * A `false` from a probe that can only answer `false` measures nothing, so each
+ * negative claim is paired with a sibling that must come back the other way.
+ */
+import { describe, it, expect } from 'vitest';
+import type { ListColumn, TableColumn } from '@object-ui/types';
+import type { ObjectGridColumn, ObjectGridColumnDraft, RetiredListColumnKey } from '../ObjectGrid';
+
+/** Compile-time equality, exact in both directions (not mutual assignability). */
+type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2)
+  ? true
+  : false;
+
+type Has<K extends string, T> = K extends keyof T ? true : false;
+type Expect<T extends true> = T;
+
+describe('objectui#6424 — the holds interface after the headerIcon expiry', () => {
+  /**
+   * ⭐ THE GUARD THE REMOVED MEMBER USED TO PROVIDE.
+   *
+   * `ObjectGrid` writes `headerIcon` at three sites (all under
+   * `schema.showColumnTypeIcons`, via `getTypeIcon`) and `data-table` renders
+   * it. With the hold gone, `TableColumn` is the ONLY thing declaring the key
+   * on the emit types. Reverting objectui#6615 would otherwise drop it from
+   * both types in silence; this is what makes that loud.
+   */
+  it('`TableColumn` declares `headerIcon` — the emit types now depend on it alone', () => {
+    type _Declared = Expect<Has<'headerIcon', TableColumn>>;
+    // Controls: the probe can answer both ways in this exact shape.
+    type _CtrlPresent = Expect<Has<'width', TableColumn>>;
+    type _CtrlAbsent = Expect<Has<'zzNotAKeyZZ', TableColumn> extends false ? true : false>;
+    expect(true).toBe(true);
+  });
+
+  /**
+   * ⭐ THE RULED PROBE (objectui#6424, the seat's Option A).
+   *
+   * The removal was ruled on a type-algebra derivation — the holds member
+   * declared the identical type, so the intersection was idempotent. This runs
+   * it as a compile-time probe instead of inheriting it: the emit types' member
+   * and `TableColumn`'s must be THE SAME TYPE, not merely compatible, which is
+   * why this is `Equal` and not `extends`.
+   */
+  it('`headerIcon` on both emit types is identical to `TableColumn`s', () => {
+    type _Column = Expect<Equal<ObjectGridColumn['headerIcon'], TableColumn['headerIcon']>>;
+    type _Draft = Expect<Equal<ObjectGridColumnDraft['headerIcon'], TableColumn['headerIcon']>>;
+    // Controls on the instrument itself: `Equal` must be able to say false here,
+    // otherwise the two lines above are green for no reason.
+    type _CtrlTrue = Expect<Equal<TableColumn['headerIcon'], TableColumn['headerIcon']>>;
+    type _CtrlFalse = Expect<
+      Equal<ObjectGridColumn['headerIcon'], TableColumn['width']> extends false ? true : false
+    >;
+    expect(true).toBe(true);
+  });
+
+  /**
+   * The hold was never rescuing `headerIcon` from the DERIVED tombstone band.
+   * `RetiredListColumnKey` is `Exclude<keyof ListColumn, keyof TableColumn | 'pinned'>`,
+   * so a key that is not a `ListColumn` member can never enter it — and
+   * `headerIcon` is not one. Without this, "removing the hold is safe" would
+   * have to assume the band, and the band is exactly where a removed hold would
+   * bite (as `?: never`) instead of merely disappearing.
+   */
+  it('`headerIcon` is not a `ListColumn` member, so it was never in the derived band', () => {
+    type _NotListColumn = Expect<Has<'headerIcon', ListColumn> extends false ? true : false>;
+    type _NotInBand = Expect<
+      'headerIcon' extends RetiredListColumnKey ? false : true
+    >;
+    // Controls, same shapes: a real `ListColumn` member, and a key that IS in the band.
+    type _CtrlListColumn = Expect<Has<'width', ListColumn>>;
+    type _CtrlInBand = Expect<'wrap' extends RetiredListColumnKey ? true : false>;
+    expect(true).toBe(true);
+  });
+
+  /**
+   * ⭐ THE CONTRAST THAT MAKES THE TWO VERDICTS DIFFERENT — and the reason
+   * `pinned` must NOT follow `headerIcon` out.
+   *
+   * `pinned` fails the expiry test on both counts: `TableColumn` does not
+   * declare it, and `RetiredListColumnKey` explicitly carves it out of the
+   * Exclude, so `ObjectGridColumnHolds` is its ONLY declaration on the emit
+   * types. (Measured: deleting the member takes both emit types from 27
+   * resolved members to 26, `pinned` gone. Deleting `headerIcon` left them
+   * byte-identical — that pair of ablations is what this verdict rests on.)
+   *
+   * It also has the second road `wrap` lacked: this file's reorder pass reads
+   * it and re-expresses it as the sticky `className` `data-table` reads.
+   */
+  it('`pinned` is still load-bearing — undeclared by `TableColumn` and outside the band', () => {
+    type _Undeclared = Expect<Has<'pinned', TableColumn> extends false ? true : false>;
+    type _CarvedOut = Expect<'pinned' extends RetiredListColumnKey ? false : true>;
+    // Control: `pinned` IS a `ListColumn` member, so its absence from the band
+    // is the carve-out doing work — not non-membership, which is `headerIcon`s
+    // reason. Two different routes to the same `false`, and they must not be
+    // conflated.
+    type _CtrlIsListColumnMember = Expect<Has<'pinned', ListColumn>>;
+    // …and it is therefore still a member of both emit types.
+    type _StillOnColumn = Expect<Has<'pinned', ObjectGridColumn>>;
+    type _StillOnDraft = Expect<Has<'pinned', ObjectGridColumnDraft>>;
+    expect(true).toBe(true);
+  });
+
+  /**
+   * The behaviour that must survive the removal: `ObjectGrid` writes
+   * `headerIcon` into the slot at three sites, so the emit types still have to
+   * ACCEPT it. Routed through a non-fresh value, like the other emit-boundary
+   * pins — a fresh literal would be refused or admitted by excess-property
+   * freshness, which is a different question from membership.
+   */
+  it('the emit types still accept a written `headerIcon`', () => {
+    const emitted: { header: string; accessorKey: string; headerIcon?: unknown } = {
+      header: 'Name',
+      accessorKey: 'name',
+      headerIcon: null,
+    };
+    const draft: ObjectGridColumnDraft = emitted as ObjectGridColumnDraft;
+    expect(draft.accessorKey).toBe('name');
+  });
+});


### PR DESCRIPTION
Part of #6424

⚠️ **`Part of`, not the closing keyword, and that is a deliberate deviation from the dispatch order.** The order asked for the closing keyword on this card, on the premise that all three items would land. (That keyword is deliberately not spelled next to the card number anywhere in this body: GitHub's parser matches it regardless of any negation around it, and this card must stay open.) **Item 1 did not land** — its precondition is measurably absent on this ref (evidence below). Closing the card would bury an unfinished, already-ruled item, and the inbox filter only reads open cards. The card stays open for item 1.

Two of the three ruled items land here, both measured rather than inherited.

---

## Item 1 — the emit-side `fitContent` cast: STOPPED, with evidence

### The line, located on my own ref

Both numbers in circulation are stale. Measured at base `9d86e1d79`:

| source | line |
| --- | --- |
| the 2026-08-28 ruling | `:3418` — stale |
| this seat's ACCEPT, measured earlier today | `:3587` — stale |
| **measured here** | **`:3606`** — `if ((col as any).fitContent) continue;` |

Three independent measurements say do not remove it yet.

### 1a. The ruling's precondition is not met — PR #6673 has not merged

The ruling ties this cast to the `fitContent` declaration: it "travels with this verdict". That declaration is still in flight — PR #6673 is `state=open, merged=false`.

Measured on my ref, each zero with a positive control in the same query shape:

| probe | result | control |
| --- | --- | --- |
| `fitContent` in `packages/types/src/data-display.ts` | **0** | `headerIcon` → 2 |
| `fitContent` in `packages/types/dist/data-display.d.ts` (the artefact plugin-grid actually resolves) | **0** | `headerIcon` → 2 |
| `'fitContent'` in `keyof TableColumn`, compile-time | **false** | `'width'` → true; `'zzNotAKeyZZ'` → false |

### 1b. The cast is a no-op, but NOT for the reason the ruling assumed

Read via the TypeScript checker at the site, cast stripped:

```
line 3606  expr=`(col as any).fitContent`
   type of `col` (cast stripped) = any   isAny=true
```

`applyColumnChrome = (col: any) =>` makes `orderedColumns` an `any[]`, and the loop adds a second `as any[]`. So the cast never compensated for the undeclared key — it compensates for nothing. This is exactly the lesson PR #6673 measured on `data-table.tsx` ("cast count is not the instrument, the normalization is"), reproduced on the emit side. Removing it buys **zero** type safety, now or after #6673 lands.

### 1c. It is load-bearing as another guard's only real-file control

`columnReadBoundary-6458.test.ts` uses this exact cast as its Anti-vacuity control 3, and its own comment says: *"If that read is ever retired too, this control must be re-pointed at another real cast — never deleted, and never re-pointed back inside the region."*

Measured with the test's own scanner regex over the whole file: **`(col as any).fitContent` at `:3606` is the only `(col as ...)` cast read in `ObjectGrid.tsx`.** There is no other candidate to re-point at.

Observed, not predicted — ablation with the mutation proven on disk and restoration observed:

```
anchored BEFORE: '(col as any).fitContent'=1     blob 0905b2cc
anchored AFTER:  '(col as any).fitContent'=0     blob e19e6a6e   MUTATION PROVEN ON DISK
 FAIL  columnReadBoundary-6458.test.ts > the scanner finds a cast read in the REAL file, outside the guarded region
 AssertionError: expected [] to include 'fitContent'
 Test Files  1 failed (1) | Tests  1 failed | 7 passed (8)
restore: git diff HEAD empty, blob back to 0905b2cc
```

Baseline on the clean tree for comparison: `Test Files 1 passed (1)`, `Tests 8 passed (8)`, EXIT=0.

⇒ Removing the cast today costs a live guard its only real-file anti-vacuity control and buys nothing. **This needs the seat, not me** — it is a re-point decision plus an ordering question against #6673.

---

## Item 2 — `ObjectGridColumnHolds.headerIcon` removed. MEASURED, not inherited

The order was explicit that the previous round's type-algebra derivation must not be carried forward. It was not. **The probe confirms the derivation** — the ruling stands.

### The ruled probe

Run through the same program the test project uses (`tsconfig.test.json`, `paths: {}`, so `@object-ui/types` resolves through the built `.d.ts`):

| probe | result |
| --- | --- |
| `Equal` of `ObjectGridColumn['headerIcon']` and `TableColumn['headerIcon']` | **true** |
| `Equal` of `ObjectGridColumnDraft['headerIcon']` and `TableColumn['headerIcon']` | **true** |
| instrument control, must be false: `Equal` of `ObjectGridColumn['headerIcon']` and `TableColumn['width']` | **false** |
| instrument control, must be true: `Equal` of `TableColumn['headerIcon']` with itself | **true** |

The two controls are the point: a probe that can only answer `true` measures nothing.

### The emit-type ablation — the claim that had never been observed

The actual claim is "the emit types are unchanged with the member absent". Instrument: the TypeScript checker resolves both emit types and prints **every member with its resolved type**, sorted, to JSON — a structural snapshot, not a derivation. Each leg proves its mutation on disk (anchored grep counts plus a moved blob hash) and its restoration by observation (`git diff HEAD` empty, hash back), under a `trap ... EXIT INT TERM` with absolute paths, restoring via an explicit `git checkout HEAD -- absolute-path`.

| leg | emit-type members | snapshot vs baseline |
| --- | --- | --- |
| baseline (clean tree) | `ObjectGridColumn` 27, `ObjectGridColumnDraft` 27 | — |
| **positive control: delete `pinned` instead** | **26 / 26**, `pinned` gone from both | **DIFFERENT** |
| **the ruled claim: delete `headerIcon`** | **27 / 27** | **IDENTICAL** |

The positive control is what makes the identical result a measurement: the instrument demonstrably detects a holds-member removal that matters. The landed change re-snapshots to **IDENTICAL** against the pre-edit baseline.

### The three facts, re-confirmed with controls rather than quoted

| fact | measured | control (same query shape) |
| --- | --- | --- |
| `headerIcon` is in `keyof TableColumn` (since #6615) | **true** | `'width'` → true; `'zzNotAKeyZZ'` → false |
| `headerIcon` is not a `ListColumn` member | **false** (not a member) | `'width'` in `keyof ListColumn` → **true** |
| ⇒ so never in the derived `RetiredListColumnKey` band | **false** (not in band) | `'wrap'` in the band → **true** |
| no second road: `ObjectGrid` writes it at 3 sites, all under `schema.showColumnTypeIcons` via `getTypeIcon` | `:2129`, `:2221`, `:2271` | — |
| `data-table` reads it at 1 render site, forwarded verbatim into a `span`, never re-expressed | `data-table.tsx:1955-1956` | — |

Note on the read count: the card body says "2 reads", the ACCEPT says "1". Both are right at different granularities — **1 render site, 2 syntactic `col.headerIcon` occurrences** (a guard and the render). Stated precisely here so the next reader does not have to re-derive it.

### The `pinned` contrast, stated explicitly — and untouched

`pinned` stays load-bearing on **both** counts, which is exactly what makes `headerIcon`'s removal safe and `pinned`'s unsafe:

| | `headerIcon` | `pinned` |
| --- | --- | --- |
| declared by `TableColumn`? | **yes** (#6615) | **no** — measured `false` |
| in the derived band? | no — because it is not a `ListColumn` member | no — because the `Exclude` **carves it out**; it *is* a `ListColumn` member (control: **true**) |
| ⇒ only declaration on the emit types? | no, `TableColumn` carries it | **yes, the holds member** |
| second road to a consumer? | no — forwarded verbatim | **yes** — this file's reorder pass re-expresses it as the sticky `className` |
| ablation | emit types **unchanged** (27) | emit types **change** (26, key gone) |

Two different routes to the same "not in the band", and they must not be conflated — that conflation is how a measurement blurs the two keys. `pinned` is untouched by this PR.

### ⚠️ The removal MOVES a liveness claim rather than deleting one

While the hold existed, the emit types declared `headerIcon` on their own account. They now get it from `TableColumn` alone, so reverting #6615 would drop it from both emit types in silence while `ObjectGrid` goes on writing it at three sites. That is a **new exposure created by this change**, and the new pin's first assertion covers it — it is the guard the deleted member used to provide implicitly.

The pin is not vacuous. Simulating that revert turns it red, mutation proven on disk and restoration observed:

```
src/__tests__/columnHoldsExpiry-6424.test.ts(65,29): error TS2344: Type 'false' does not satisfy the constraint 'true'.
tsc EXIT=2      restore: git diff HEAD empty, blob back to eebaadd3
```

And the pin really is compiled — `tsc -p tsconfig.test.json --listFiles`: `columnHoldsExpiry-6424.test.ts` → **1** (control: `columnEmitBoundary-6004.test.ts` → 1; negative control `zzNoSuchFile` → 0). Green from a file the compiler never read would be worth nothing.

---

## Item 3 — the docblock's general claim, corrected

The claim that the held keys are "undeclared by `TableColumn`" is false as written since #6615. PR #6651 corrected only the one sentence it was already editing; this PR owns the rest:

- **`ObjectGrid.tsx` verdict block** — `headerIcon` moves from HELD to DECLARED, with the expiry and the measurement that retired the hold recorded.
- **`ObjectGridColumnHolds` docblock** — names "undeclared by `TableColumn`" as the interface's **entry condition**, flags that it is a claim about another package that can lapse with nothing going red, and states the rule: re-check per key when the owning card closes, never inherit. Plus the ⛔ that a key whose only declaration is this interface is not in that position.
- **the `pinned` member doc** — now records both counts that make it load-bearing, and the 27→26 measurement.
- **`columnEmitBoundary-6004.test.ts`** — its docblock still said the interface declares **two** keys and its test title said "the two held keys". Both false after this change; corrected, and the routes are now pinned in the new file rather than described in prose.

---

## Gate verdicts — each exit code captured before any pipe, each quoting the gate's own line

Union re-run **after the final commit**, at `83ad9ffec`:

| gate | exit | its own verdict line |
| --- | --- | --- |
| `plugin-grid type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | **0** | no `error TS` lines; script name echoed, so not a zero-match no-op |
| `vitest run packages/plugin-grid` | **0** | `Test Files 97 passed (97)` · `Tests 890 passed (890)` |
| `check-changeset-presence` | **0** | `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | **0** | `✅ No changeset declares a major bump.` |
| `check:control-bytes` | **0** | `✅ check-control-bytes: OK (scanned 5527 tracked text file(s); skipped 85 binary).` |
| `plugin-grid lint` | **0** | `✖ 676 problems (0 errors, 676 warnings)` — all pre-existing |
| `check:published-dist` | **0** | `✅ No published package's build output carries tooling material.` |
| `check:phantom-deps` | **0** | `✅ Every in-scope import is declared by the package that publishes it.` |
| `check:vi-mock-specifiers` | **0** | `✅ check-vi-mock-specifiers: OK (3896 tracked source file(s) ...)` |
| `check:spec-symbols` | **0** | `✅ spec symbol derivation: 1316 files scanned against 4959 spec export names` |

### Declared narrowing on lint

Repo-wide `pnpm lint` is `turbo run lint` across 40 packages; I ran the **one** package this diff touches. Three pieces of evidence, not two:

1. **Population read from eslint's own config**, not my guess: eslint itself selected **134 files** for `packages/plugin-grid`.
2. **Count from `--format json`**: 134 files; my three changed files at **0 errors** (`ObjectGrid.tsx` 214 warnings, all pre-existing; the two test files 1 and 0).
3. **Configuration invariance**: `eslint.config.js` has no `projectService` / `parserOptions` / `project:` — grep exit **1**, no matches — so **type-aware linting is off** and this diff cannot move the verdict of any file it does not touch.

⚠️ One honest note: adding `--no-inline-config` (an objectstack recipe, not this repo's) surfaces 3 errors — in `demo/main.tsx`, `predicate-surface-parity.test.tsx` and `BulkActionDialog.tsx`, **none of them in this diff**. This repo's lint script is `eslint .` without that flag, which is what CI runs and what returned 0.

### Changeset

Empty frontmatter — the gate's own explicit exemption, quoted from its help text: *"If this change really should release nothing, say so — that is a pass, not a workaround."* Justified by measurement, not assertion: `ObjectGridColumnHolds` is **not** part of the package entry's exported surface — **0** occurrences in the built `packages/plugin-grid/dist/index.d.ts` (positive control: `ObjectGridColumnState`, which the entry does re-export, → 1), and `headerIcon` → 0 there too. Runtime behaviour is untouched; this is types, comments and tests.

---

## Scope

`packages/types`, `packages/components/src/renderers/complex/data-table.tsx`, `app-shell`, `i18n`, `sdui-parser`, `plugin-list` and `@objectstack/spec` are all untouched — `git diff --name-only` is exactly the three `packages/plugin-grid` files plus the changeset.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_