### PR TITLE
feat(types,plugin-chatbot): name the chatbot node's authoring-face type

### DIFF
--- a/.changeset/6169-chatbot-authoring-face-type.md
+++ b/.changeset/6169-chatbot-authoring-face-type.md
@@ -1,0 +1,59 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-chatbot': minor
+---
+
+`ChatbotSchema` names the `chatbot` node's local-display and legacy
+auto-response keys — a new, additive published surface (objectui#6169, the
+#6172 family ruling: every component node has exactly one named, importable
+authoring-face type).
+
+`ChatbotSchema` (`@object-ui/types`) now declares ten keys that previously
+existed ONLY inside an anonymous inline intersection local to
+`packages/plugin-chatbot/src/renderer.tsx`'s `chatbot` registration, invisible
+to anything outside that one file:
+
+- `showTimestamp`, `userAvatarUrl`, `userAvatarFallback`, `assistantAvatarUrl`,
+  `assistantAvatarFallback`, `maxHeight` — display fields.
+- `autoResponse`, `autoResponseText`, `autoResponseDelay` — the local
+  auto-response (demo/playground) fields, already live via a real consumer
+  (`packages/app-shell/src/console/ai/AiChatPage.tsx`).
+- `onSend?: (content: string, messages: ChatMessage[]) => void` — the
+  send-callback, now typed against the published `ChatMessage` shape rather
+  than the plugin's internal runtime message type.
+
+Each was read-site-censused before being declared (renderer.tsx and/or
+`useObjectChat.ts` reads every one); none were dead, so none took the
+ADR-0049 retirement route. `disabled` — also present in the original
+intersection — is NOT redeclared: it is already `BaseSchema.disabled`
+(`boolean | string`), read generically for every node type, and redeclaring
+it here would have narrowed away the inherited expression-string case.
+
+**What an external consumer can now do that they could not before:** import
+`ChatbotSchema` from `@object-ui/types` and get these ten keys with real,
+checked types — previously any reference to them required either duplicating
+the anonymous type by hand or falling back to `any`. The Zod mirror
+(`@object-ui/types/zod`) gained the same ten keys in lockstep, so a `chatbot`
+node parsed through it is now validated on these keys rather than silently
+passed through unchecked (`BaseSchema`'s Zod mirror is `.passthrough()`).
+
+`packages/plugin-chatbot`'s `chatbot` registration (`renderer.tsx`) now types
+its `schema` prop as `ChatbotSchema` directly, dropping the anonymous
+intersection. No behavior change: `renderer.tsx:87`'s
+`body: schema.requestBody` forwarding — the subject of the already-merged
+#6193 — is untouched, and the render function reads the exact same keys it
+already read.
+
+This is additive (new optional keys on an interface that already carried a
+`[key: string]: any` index signature, and a new Zod-validated subset of
+previously-passthrough keys), so it ships as `minor` even though it changes
+published type surface: objectui's major is pinned to `@objectstack`'s
+(`scripts/check-changeset-no-major.mjs`), and objectui's own breaking changes
+ship as `minor` with the break spelled out — there is no break here to spell
+out, only a widening from anonymous-and-unchecked to named-and-validated.
+
+Out of scope, deliberately: the `chatbot-enhanced` and `chatbot-floating`
+registrations' own anonymous intersections (different key sets, a decision
+for a separate card in the same family), and the `surface` row on
+`content/docs/plugins/plugin-chatbot.mdx`'s Properties table, which names a
+key no registration in this package currently reads (filed separately).

--- a/content/docs/plugins/plugin-chatbot.mdx
+++ b/content/docs/plugins/plugin-chatbot.mdx
@@ -129,6 +129,11 @@ const schema = {
 
 ## Properties
 
+`showTimestamp` through `onSend` below are declared on [`ChatbotSchema`](https://github.com/objectstack-ai/objectui/blob/main/packages/types/src/complex.ts)
+(`@object-ui/types`) — previously they existed only in an anonymous type local
+to the renderer, referenceable, validatable and documentable by nothing
+outside that one file (objectui#6169).
+
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `messages` | array | `[]` | Initial chat messages |

--- a/packages/plugin-chatbot/src/renderer.tsx
+++ b/packages/plugin-chatbot/src/renderer.tsx
@@ -59,19 +59,18 @@ import { toRuntimeMessages } from './chatMessageAdapter';
  * element, which the sweep gate measured as clean.
  */
 ComponentRegistry.register('chatbot',
-  ({ schema, className, disabled: hostDisabled, ...props }: { schema: ChatbotSchema & {
-    showTimestamp?: boolean;
-    disabled?: boolean;
-    userAvatarUrl?: string;
-    userAvatarFallback?: string;
-    assistantAvatarUrl?: string;
-    assistantAvatarFallback?: string;
-    maxHeight?: string;
-    autoResponse?: boolean;
-    autoResponseText?: string;
-    autoResponseDelay?: number;
-    onSend?: (content: string, messages: ObjectChatMessage[]) => void;
-  }; className?: string; disabled?: boolean; [key: string]: any }) => {
+  // The eleven keys this destructure's parameter type used to carry as an
+  // anonymous inline intersection now live on `ChatbotSchema` itself
+  // (objectui#6169, the #6172 family ruling: every component node has
+  // exactly one named, importable authoring-face type) — each was
+  // read-site-censused first; none were dead, so none took the ADR-0049
+  // route. `schema` is that one type, referenceable and documentable from
+  // outside this file for the first time. `disabled` here is the sibling,
+  // host-EVALUATED prop (`SchemaRenderer`'s verdict on `schema.disabled` /
+  // `schema.disabledOn`, forwarded as `hostDisabled`) — a different carrier
+  // from the authored `schema.disabled` it is derived from; see the comment
+  // on `disabled={hostDisabled || isLoading}` below.
+  ({ schema, className, disabled: hostDisabled, ...props }: { schema: ChatbotSchema; className?: string; disabled?: boolean; [key: string]: any }) => {
     const {
       messages,
       isLoading,

--- a/packages/types/src/__tests__/chatbot-authoring-face-keys.test.ts
+++ b/packages/types/src/__tests__/chatbot-authoring-face-keys.test.ts
@@ -1,0 +1,175 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ChatbotSchema` declares the `chatbot` node's local-display and legacy
+ * auto-response keys by name (objectui#6169, the #6172 family ruling: every
+ * component node has exactly one named, importable authoring-face type).
+ *
+ * Before this file, `showTimestamp`, `userAvatarUrl`, `userAvatarFallback`,
+ * `assistantAvatarUrl`, `assistantAvatarFallback`, `maxHeight`,
+ * `autoResponse`, `autoResponseText`, `autoResponseDelay` and `onSend` lived
+ * ONLY in an anonymous inline intersection at
+ * `packages/plugin-chatbot/src/renderer.tsx`'s `chatbot` registration site —
+ * nothing outside that one file could reference, validate, or document them.
+ * Each was read-site-censused before being declared here (renderer.tsx and/or
+ * `useObjectChat.ts` read every one); none were dead, so none took the
+ * ADR-0049 route.
+ *
+ * `disabled` — also in the original intersection — is deliberately NOT
+ * redeclared: it is already `BaseSchema.disabled` (`boolean | string`), read
+ * generically by `SchemaRenderer` for every node type. Redeclaring it here as
+ * `boolean` only would have narrowed away the expression-string half of an
+ * inherited field for no reason; the last `it` below pins that it stays wide.
+ *
+ * ## Why the TS half is real enforcement, not decoration
+ *
+ * `BaseSchema` carries `[key: string]: any` (objectui#5155). Before this
+ * change, `autoResponseDelay: 'not-a-number'` on a `ChatbotSchema`-typed
+ * object type-checked FINE — the index signature swallowed the unlisted key
+ * as `any`. Declaring the field with its real type is what makes a wrong
+ * value refusable at the type level; the `@ts-expect-error` below is checked
+ * by `tsc -p tsconfig.test.json` (this package's `type-check` script chains
+ * it), so a regression that widens the field back toward `any` — or deletes
+ * it, letting the index signature re-absorb it — fails the build on the
+ * now-unused directive. A green test RUN cannot show this; only a green
+ * type-check can (AGENTS.md: "A green type-check is the proof a tombstone
+ * bites; a green test run is not" — the same instrument, applied to a
+ * declaration rather than a retirement).
+ *
+ * ## Why the Zod half is real enforcement, not decoration
+ *
+ * `BaseSchema`'s Zod mirror is `.passthrough()`, inherited through
+ * `.extend()`. Before this change `ChatbotSchema.safeParse({ ...,
+ * autoResponseDelay: 'not-a-number' })` returned `success: true` — an
+ * undeclared key rides through passthrough UNVALIDATED, wrong type and all.
+ * Mirroring the field is what turns that into a refusal.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ChatbotSchema, ChatMessage } from '../complex';
+import { ChatbotSchema as ChatbotZodSchema } from '../zod/complex.zod';
+
+const baseMessages: ChatMessage[] = [
+  { id: '1', role: 'user', content: 'hi' },
+];
+
+describe('ChatbotSchema: the ten local-display/legacy keys are declared, not anonymous (objectui#6169)', () => {
+  it('accepts every key at its declared type on the TypeScript interface', () => {
+    const onSend: ChatbotSchema['onSend'] = (content, messages) => {
+      expect(typeof content).toBe('string');
+      expect(Array.isArray(messages)).toBe(true);
+    };
+
+    const node: ChatbotSchema = {
+      type: 'chatbot',
+      messages: baseMessages,
+      showTimestamp: true,
+      userAvatarUrl: 'https://example.com/user.png',
+      userAvatarFallback: 'You',
+      assistantAvatarUrl: 'https://example.com/assistant.png',
+      assistantAvatarFallback: 'AI',
+      maxHeight: '500px',
+      autoResponse: true,
+      autoResponseText: 'Thanks!',
+      autoResponseDelay: 1000,
+      onSend,
+    };
+
+    expect(node.showTimestamp).toBe(true);
+    expect(node.autoResponseDelay).toBe(1000);
+    node.onSend?.('hello', baseMessages);
+  });
+
+  it('refuses a wrong-typed value on a declared key — proof the field is no longer `any` via the index signature', () => {
+    const node: ChatbotSchema = {
+      type: 'chatbot',
+      messages: baseMessages,
+      // @ts-expect-error `autoResponseDelay` is declared `number`; before this
+      // field was named, `[key: string]: any` on `BaseSchema` swallowed any
+      // value at any unlisted key and this line type-checked.
+      autoResponseDelay: 'not-a-number',
+    };
+    // Runtime shape is unaffected by the type-level assertion above.
+    expect(node.type).toBe('chatbot');
+  });
+
+  it('keeps `disabled` inherited from BaseSchema (`boolean | string`), not redeclared narrower', () => {
+    // `BaseSchema.disabled` accepts an expression STRING (evaluated by
+    // `evaluator.evaluateCondition`), not just a boolean. If this key were
+    // redeclared inside the new group as `boolean` only, this line would be
+    // the one to catch it.
+    const node: ChatbotSchema = {
+      type: 'chatbot',
+      messages: baseMessages,
+      disabled: 'record.locked === true',
+    };
+    expect(node.disabled).toBe('record.locked === true');
+  });
+
+  it('accepts every key at its declared type through the Zod mirror', () => {
+    const result = ChatbotZodSchema.safeParse({
+      type: 'chatbot',
+      messages: [{ id: '1', role: 'user', content: 'hi' }],
+      showTimestamp: true,
+      userAvatarUrl: 'https://example.com/user.png',
+      userAvatarFallback: 'You',
+      assistantAvatarUrl: 'https://example.com/assistant.png',
+      assistantAvatarFallback: 'AI',
+      maxHeight: '500px',
+      autoResponse: true,
+      autoResponseText: 'Thanks!',
+      autoResponseDelay: 1000,
+      onSend: () => {},
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('refuses a wrong-typed value on a declared key through the Zod mirror (was silently passed through before)', () => {
+    const result = ChatbotZodSchema.safeParse({
+      type: 'chatbot',
+      messages: [],
+      autoResponseDelay: 'not-a-number',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) => issue.path.join('.') === 'autoResponseDelay' && issue.code === 'invalid_type',
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it('lists all ten keys in the Zod mirror shape (mirrored, not merely passed through)', () => {
+    const shapeKeys = Object.keys(ChatbotZodSchema.shape);
+    for (const key of [
+      'showTimestamp',
+      'userAvatarUrl',
+      'userAvatarFallback',
+      'assistantAvatarUrl',
+      'assistantAvatarFallback',
+      'maxHeight',
+      'autoResponse',
+      'autoResponseText',
+      'autoResponseDelay',
+      'onSend',
+    ]) {
+      expect(shapeKeys).toContain(key);
+    }
+    // `disabled` DOES appear here too — `.extend()`'s `.shape` merges the
+    // parent's fields into the child's, so BaseSchema's `disabled` shows up
+    // without this file's `.extend({...})` call ever naming it. That merge is
+    // exactly why it was correct not to re-declare `disabled` above: doing so
+    // would have SHADOWED the inherited `boolean | string` entry with a
+    // narrower one, rather than adding a new key.
+    expect(shapeKeys).toContain('disabled');
+  });
+});

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -641,6 +641,71 @@ export interface ChatbotSchema extends BaseSchema {
    */
   onError?: (error: Error) => void;
 
+  // --- Local display + legacy auto-response fields (objectui#6169) ---
+  //
+  // Lifted from an anonymous inline intersection that used to live ONLY at
+  // `packages/plugin-chatbot/src/renderer.tsx`'s `chatbot` registration site
+  // (`ComponentRegistry.register('chatbot', ...)`), where nothing outside
+  // that one file could reference, validate, or document them. Each key
+  // below was read-site-censused before being declared here — every one has
+  // a live reader in `renderer.tsx` and/or `useObjectChat.ts`; none were
+  // dead. `disabled` is deliberately NOT redeclared in this group: it is
+  // already `BaseSchema.disabled` (`boolean | string`), read generically by
+  // `SchemaRenderer` for every node type, not specific to `chatbot`.
+
+  /**
+   * Display a timestamp on each message.
+   * @default false
+   */
+  showTimestamp?: boolean;
+  /**
+   * URL of the user's avatar image.
+   */
+  userAvatarUrl?: string;
+  /**
+   * Fallback text shown when `userAvatarUrl` is not set or fails to load.
+   * @default 'You'
+   */
+  userAvatarFallback?: string;
+  /**
+   * URL of the assistant's avatar image.
+   */
+  assistantAvatarUrl?: string;
+  /**
+   * Fallback text shown when `assistantAvatarUrl` is not set or fails to load.
+   * @default 'AI'
+   */
+  assistantAvatarFallback?: string;
+  /**
+   * Maximum height of the chat message container (CSS value).
+   * @default '500px'
+   */
+  maxHeight?: string;
+  /**
+   * Enable local auto-response (demo/playground) mode. Ignored once `api`
+   * is set — API mode replaces the local echo entirely.
+   * @default false
+   */
+  autoResponse?: boolean;
+  /**
+   * The text of the local auto-response, used when `autoResponse` is true.
+   */
+  autoResponseText?: string;
+  /**
+   * Delay in milliseconds before the local auto-response is sent.
+   * @default 1000
+   */
+  autoResponseDelay?: number;
+  /**
+   * Called after a message is sent, in both API and local auto-response
+   * mode, with the trimmed content and the full message list at that
+   * point. `messages` here is the same authoring-side {@link ChatMessage}
+   * shape as the `messages` field above; the plugin's own runtime message
+   * type is a structural superset (objectui#4424) and still satisfies a
+   * handler typed against this narrower, published shape.
+   */
+  onSend?: (content: string, messages: ChatMessage[]) => void;
+
   // --- Floating / FAB display mode ---
 
   /**

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -310,6 +310,21 @@ export const ChatbotSchema = BaseSchema.extend({
   maxToolRoundtrips: z.number().optional()
     .describe('DEPRECATED (inert, slated for removal) — Max tool-calling round-trips. Nothing reads this; cap tool loops on the agent via planning.maxIterations'),
   onError: z.function().optional().describe('Error callback'),
+  // --- Local display + legacy auto-response fields (objectui#6169) ---
+  // Mirrors the TS declaration added at ../complex.ts in lockstep, so these
+  // ten keys move from the pre-existing "declared but unmirrored, rides
+  // through .passthrough() unvalidated" state straight to mirrored — never
+  // through an interim unmirrored window.
+  showTimestamp: z.boolean().optional().describe('Display a timestamp on each message'),
+  userAvatarUrl: z.string().optional().describe("URL of the user's avatar image"),
+  userAvatarFallback: z.string().optional().describe('Fallback text for the user avatar'),
+  assistantAvatarUrl: z.string().optional().describe("URL of the assistant's avatar image"),
+  assistantAvatarFallback: z.string().optional().describe('Fallback text for the assistant avatar'),
+  maxHeight: z.string().optional().describe('Maximum height of the chat message container (CSS value)'),
+  autoResponse: z.boolean().optional().describe('Enable local auto-response (demo/playground) mode'),
+  autoResponseText: z.string().optional().describe('Text of the local auto-response'),
+  autoResponseDelay: z.number().optional().describe('Delay in milliseconds before the local auto-response is sent'),
+  onSend: z.function().optional().describe('Called after a message is sent, in both API and local auto-response mode'),
 });
 
 /**


### PR DESCRIPTION
Fixes #6169

## Docs half already merged — untouched here

PR #6193 (`ead74abe4`) already fixed the `body`/`requestBody` collision on this page. This PR does not re-touch that row's wording; it adds one sentence above the table naming the type these keys now come from (see "Docs" below).

## The re-derived key set, and where the card's list didn't reconcile

The maintainer ruling scoped this to the anonymous inline intersection at `packages/plugin-chatbot/src/renderer.tsx:62` — the `chatbot` registration specifically (not `chatbot-enhanced` / `chatbot-floating`, which have their own, different, still-anonymous intersections; out of scope, noted below). Counting that literal block:

```ts
{ schema: ChatbotSchema & {
    showTimestamp?: boolean;
    disabled?: boolean;
    userAvatarUrl?: string;
    userAvatarFallback?: string;
    assistantAvatarUrl?: string;
    assistantAvatarFallback?: string;
    maxHeight?: string;
    autoResponse?: boolean;
    autoResponseText?: string;
    autoResponseDelay?: number;
    onSend?: (content: string, messages: ObjectChatMessage[]) => void;
  }; className?: string; disabled?: boolean; [key: string]: any }
```

**11 keys inside the intersection** — matches the card's "11". Two things in the dispatch's warning did *not* reconcile, and both turned out to be measurement errors in the card, not in the count:

- **`surface`** — named by the card as one of the 11. It is not in this block, not in either of the other two registrations' blocks, and not forwarded anywhere in `renderer.tsx` (`grep -n surface packages/plugin-chatbot/src/renderer.tsx` → zero matches). It's a real prop of `ChatbotEnhanced` (`surface?: ChatbotSurface`, `ChatbotEnhanced.tsx:805`), but no registration ever reads `schema.surface` to forward it. The docs table's `surface` row (also un-backed) is a **separate, pre-existing defect** — filed as #6687, not touched here (see "Out of scope" below).
- **`disabled`** — the card said the intersection "also carries `disabled`, which the registration destructures separately." It does: `disabled?: boolean` appears **twice** — once *inside* the intersection (an authored schema key) and once at the *sibling* level of the destructure type (`; className?: string; disabled?: boolean; ...}`, the host-EVALUATED verdict SchemaRenderer forwards as `hostDisabled`). These are two different carriers for two different questions that happen to share a spelling — not a miscount. `renderer.tsx`'s own comment (right above `disabled={hostDisabled || isLoading}`) already documents why `hostDisabled` is read there and not `schema.disabled`.

## Read-site census (the clause that makes this more than a rename)

| key | read site(s) | verdict |
|---|---|---|
| `showTimestamp` | `renderer.tsx` (both `useObjectChat()` call and `<Chatbot>` render prop); `useObjectChat.ts:750,768` (sets/omits message timestamp); `index.tsx:203` (conditional render) | **IN** |
| `userAvatarUrl` | `renderer.tsx` render prop; `index.tsx:104,174` | **IN** |
| `userAvatarFallback` | `renderer.tsx` render prop; `index.tsx:105,177` | **IN** |
| `assistantAvatarUrl` | `renderer.tsx` render prop; `index.tsx:106,174` | **IN** |
| `assistantAvatarFallback` | `renderer.tsx` render prop; `index.tsx:107,178` | **IN** |
| `maxHeight` | `renderer.tsx` render prop; `index.tsx:47,88` (`style={{ maxHeight }}`) | **IN** |
| `autoResponse` | `renderer.tsx` → `useObjectChat()`; `useObjectChat.ts:427,761` (gates the auto-response timer); live consumer `packages/app-shell/src/console/ai/AiChatPage.tsx:1662` | **IN** |
| `autoResponseText` | same hook; `useObjectChat.ts:428,767`; `AiChatPage.tsx:1663` | **IN** |
| `autoResponseDelay` | same hook; `useObjectChat.ts:429,772` (`setTimeout` delay); `AiChatPage.tsx:1664` | **IN** |
| `onSend` | same hook; `useObjectChat.ts:429,718,720,755` (invoked with content + messages) | **IN** |
| `disabled` (the authored, in-intersection one) | **not** read by name inside the `chatbot` registration body — but it's inherited from `BaseSchema.disabled` (`boolean \| string`), read generically for **every** node type at `packages/react/src/SchemaRenderer.tsx:1085` (`newSchema.disabled`) | **IN, but not via this intersection** — already declared, nothing to lift |

⭐ **Zero keys took the ADR-0049 route.** Every key in the 11-key block has a real, measured reader — ten of them directly inside the very file that declared them anonymously, which is exactly the "authorable surface with no declaration anyone can import" the ruling described. `disabled` needed no action at all: it was never actually anonymous — it's `BaseSchema.disabled`, already named, already inherited by `ChatbotSchema`, and the anonymous block's local re-declaration of it (as `boolean` only) would have *narrowed away* the inherited `string`-expression case had I copied it forward. I did not.

**Positive control, same query shape:** the query that reports `disabled` as "not read in this file's body" is the same plain-text `schema\.<key>` grep run against all eleven keys — it correctly reports real hits (with line numbers) for the other ten. A zero from a query that also produces real positives on siblings is a measurement, not a blind spot.

## Structural choice: extend `ChatbotSchema` in place, not a new named type

The ruling allowed either. I extended `ChatbotSchema` (`packages/types/src/complex.ts`) directly, for three reasons:

1. **"Exactly one … type" reads most literally as one type.** Every other schema interface in this package is `<X>Schema extends BaseSchema` — there is no existing "`<X>Schema` + `<X>ExtraSchema`" pattern to follow, and inventing one here would leave the `chatbot` node with two types where the ruling asks for one.
2. **Zero new barrel-export surface.** `ChatbotSchema` is already exported from `packages/types/src/index.ts` (line 303) — I did not touch that file. (Noting this explicitly per the fence: `packages/types/src/index.ts` is the one real collision point with the concurrent #6424 dispatch, and I left it alone.)
3. **A new type would not have escaped the real hazard.** `BaseSchema` carries `[key: string]: any` (objectui#5155). Any object typed against `ChatbotSchema` — new sibling type or not — already swallows *any* unlisted key as `any`. The fix that actually matters is declaring the field with its **real type**, so a wrong value is refusable; which interface holds the declaration is secondary. See the ablation below for the empirical version of this point.

`disabled` is deliberately **not** redeclared in the new group — see the census above.

`onSend`'s message-array parameter is typed `ChatMessage[]` (the existing, already-exported authoring type `ChatbotSchema.messages` uses), not `plugin-chatbot`'s internal `ObjectChatMessage`. `renderer.tsx`'s own doc comment already established that a callback declaring `ChatMessage[]` type-checks against `ObjectChatMessage[]` (a structural superset per `chatMessageAdapter.ts`'s documented seam), so this is a no-behavior-change, dependency-direction-respecting choice: `packages/types` cannot import a `packages/plugin-chatbot`-local type without a wrong-direction dependency.

## Zod mirror — kept in lockstep (the "validatable" third of the ruling)

The ruling asks for "referenceable, validatable, and documentable." The Zod mirror (`packages/types/src/zod/complex.zod.ts`) gained the same ten keys, matched type-for-type. Two things that made this necessary, not optional:

- `BaseSchema`'s Zod mirror is `.passthrough()` (confirmed empirically — `.extend()` preserves it without restating). Before this PR, a wrongly-typed value at any of these ten keys rode through **unvalidated**: `ChatbotSchema.safeParse({ ..., autoResponseDelay: 'not-a-number' })` returned `success: true`.
- `packages/types/src/__tests__/zod-mirror-parity.test.ts` (objectui#5684/#6058's drift ratchet) already carries a `UnmirroredDeclared` ledger entry for `ChatbotSchema` (`'displayMode' | 'floatingConfig' | 'requestBody'`, pre-existing, untouched here). That ratchet **cannot absorb a second key on an already-ledgered pair** — adding these 10 keys to the TS declaration without mirroring them would have failed `packages/types`' own `type-check` (confirmed in the ablation below), not silently drifted.

## Tests

New file: `packages/types/src/__tests__/chatbot-authoring-face-keys.test.ts` — pins both the TS and Zod halves: all ten keys accept their declared type on `ChatbotSchema` and through the Zod mirror; a wrong-typed value on `autoResponseDelay` is refused by both (a `@ts-expect-error` on the TS side, `safeParse().success === false` on the Zod side); `disabled` stays wide (`boolean | string`) rather than being shadowed narrower; the Zod shape lists all ten keys by name.

## Ablation — each leg predicted before it ran, mutated on disk, restored, re-verified

Both legs mutated `packages/types` source with a `trap ... EXIT INT TERM` restoring via `git checkout HEAD -- <path>` (never bare `checkout --`), field counts asserted before AND after the mutation (never an editor's exit code), and `git diff HEAD` confirmed empty after restore, both times.

**Leg 1 — remove the ten Zod fields only, keep the TS declaration.**
*Predicted:* `packages/types type-check` goes red — the drift ratchet cannot absorb new unmirrored keys on the already-ledgered `ChatbotSchema` pair.
*First attempt, and a real correction:* I first ran only `vitest run zod-mirror-parity.test.ts` and it stayed **green** — which contradicted the prediction. The reason is itself worth recording: that file's actual drift ratchet (`ReconcileAgainstLedger` / `assertionRatchetRejectsGrowth`) is a **type-level** `export type assertion... = Expect<Equal<...>>` construct, invisible to a vitest run (transpile-only, types erased) and checked **only** by `tsc`. The file's five `it()` blocks test population completeness, not per-key drift. Re-ran against the actual instrument:
*Observed:* `pnpm --filter @object-ui/types type-check` → **exit 2** — `src/__tests__/zod-mirror-parity.test.ts(1203,14): error TS2322: Type '"complex.zod.ts#ChatbotSchema"' is not assignable to type 'never'.` Exactly the ratchet firing, exactly on the `ChatbotSchema` pair. Restored; re-ran → exit 0.

**Leg 2 — remove the ten TS declaration fields only, keep the Zod mirror.**
*Predicted:* `packages/types type-check` fails on the new test file's `@ts-expect-error` becoming an **unused** directive (TS2578) — without the declared type, the wrong-typed value no longer errors (swallowed by `BaseSchema`'s index signature as `any`), so the pin has nothing to catch. Also predicted: `packages/plugin-chatbot type-check` stays **green**, because `renderer.tsx`'s reads of `schema.showTimestamp` etc. fall through the same inherited index signature to `any` either way — the *only* place this regression is caught is the dedicated pin test, not the renderer itself.
*Observed:* `packages/types type-check` → exit 2, `chatbot-authoring-face-keys.test.ts(93,7): error TS2578: Unused '@ts-expect-error' directive.` (plus a cascading TS7006 on the now-untyped `onSend` callback params). `packages/plugin-chatbot type-check` → **exit 0**, confirming the prediction: this ablation leg has **no independent guard other than the new test file**. Restored; re-ran → exit 0.

*(One process note, not a code issue: my first pass at leg 2's `type-check` run accidentally executed from the shared primary checkout instead of this worktree — caught immediately via the repo-root guard added to the second script, confirmed the shared checkout was untouched/clean afterward, and re-ran correctly from the worktree. No shared state was affected.)*

## Docs

One sentence added above the `## Properties` table, naming `ChatbotSchema` as the type these keys now come from — the direct answer to the #6086 gap this card's parent card recorded. No table rows edited or deleted, per the fence.

## Clause-② — published type surface, at contract-review tier

Yes, this changes published type surface, per the ruling. What becomes published: `ChatbotSchema` (`@object-ui/types`) gains ten optional keys with real types (previously unreachable outside `renderer.tsx`); `@object-ui/types/zod`'s `ChatbotSchema` gains the same ten as validated Zod fields (previously silently passed through). An external consumer can now `import type { ChatbotSchema } from '@object-ui/types'` and get `autoResponseDelay: number`, etc. with real type-checking, and can `ChatbotSchema.safeParse(node)` from `@object-ui/types/zod` and have a wrong value at any of these ten keys actually refused. No `needs:contract-review` label applied (phantom label, zero readers, per this lane's standing order).

## Out of scope, deliberately

- `chatbot-enhanced` / `chatbot-floating`'s own anonymous intersections — different key sets (`enableMarkdown`, `enableFileUpload`, `onClear`, …), a decision for a separate card in the same family, per the fence.
- The docs table's `surface` row, which names a key **no** `chatbot*` registration reads anywhere (a different, pre-existing defect, structurally the `body`/`requestBody` sibling but with zero read points rather than a naming collision) — filed as #6687, not touched here.
- `ChatbotSchema`'s existing `userAvatar` / `assistantAvatar` / `showAvatars` / `markdown` / `height` / `onSendMessage` / `loading` fields, which I measured have **zero** read points anywhere in `packages/plugin-chatbot` (an older, unrelated naming generation, already declared before this PR). Not this card's subject — the ruling named the anonymous intersection, not an audit of `ChatbotSchema`'s pre-existing declared surface — but flagging it here since a future ADR-0049 pass over this exact interface will want it.

## Gate table (final commit `036da7c06`)

| gate | command | result |
|---|---|---|
| build (deps + types + plugin-chatbot) | `pnpm --filter '@object-ui/plugin-chatbot^...' build`, `--filter @object-ui/types build`, `--filter @object-ui/plugin-chatbot build` | exit 0 each |
| type-check: types | `pnpm --filter @object-ui/types type-check` (chains `tsconfig.json` + `tsconfig.examples.json` + `tsconfig.test.json`) | exit 0 |
| type-check: plugin-chatbot | `pnpm --filter @object-ui/plugin-chatbot type-check` | exit 0 |
| vitest (types + plugin-chatbot, root-level per objectui#3378) | `pnpm exec vitest run packages/types/ packages/plugin-chatbot/` | **96 files / 1176 tests passed** |
| zod-mirror-parity (population half) | `pnpm exec vitest run .../zod-mirror-parity.test.ts` | 5/5 passed (drift half is type-level; see ablation leg 1) |
| `check:control-bytes` | `node scripts/check-control-bytes.mjs` | ✅ 5530 scanned |
| `check:doc-fences` | `node scripts/check-doc-fence-languages.mjs` | ✅ |
| `check:doc-types` | `node scripts/check-doc-component-types.mjs` | ✅ |
| `check:doc-snippets` | `--build-filter` build (32 tasks) then `node scripts/check-doc-snippet-types.mjs`; `dist/complex.d.ts` re-verified on disk to carry the new fields before trusting the green | ✅ 267/267 blocks |
| `docs:check-links` | `node scripts/check-doc-links.mjs` | ✅ 17 scan roots |
| `changeset:check` (fixed-group + no-major) | `check-changeset-fixed.mjs`, `check-changeset-no-major.mjs` | ✅ both |
| changeset presence | `node scripts/check-changeset-presence.mjs` | ✅ 4 source files / 2 released packages / 1 changeset |
| eslint, scoped to the 4 touched `.ts` files, `--format json` | 0 errors, 13 warnings, all pre-existing `@typescript-eslint/no-explicit-any` — counts diffed against `origin/main`'s versions of the same files line-for-line (3/3 renderer.tsx, 8/8 complex.ts, 2/2 complex.zod.ts): **zero new** | ✅ |

Lint scope note: `eslint.config.js` uses `tseslint.configs.recommended` (not `recommendedTypeChecked`/`strictTypeChecked`, no `parserOptions.project`) — non-type-aware, so this diff cannot move any untouched file's verdict; scoping to the touched files is a complete measurement, not a sample.

_Generated by [Claude Code](https://claude.ai/code/session_8ca04858-ea8e-5b85-9182-de59aa49e00c)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_