### PR TITLE
feat(react): extract the settled-schema resolution hook

### DIFF
--- a/.changeset/settled-schema-resolution-hook-6482.md
+++ b/.changeset/settled-schema-resolution-hook-6482.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/react': minor
+---
+
+New export: `useSettledSchema` — the settled-schema RESOLUTION half shared by
+`ObjectKanban` / `ObjectView` / `ObjectCalendar`'s fetch-gate hand copies
+(objectui#6482, maintainer ruling Option A). It tracks whether an object's
+definition has finished resolving FOR THE KEY THE CURRENT RENDER IS ASKING
+ABOUT, returning `{ ready, def }` from one piece of internal state so `ready`
+and `def` can never be observed inconsistently and a stale key can never read
+as ready — the structural fix for the `ObjectTree` defect (objectui#6481)
+where a definition and a separate, one-way-latched "settled" boolean could
+disagree for a render after the object changed.
+
+Gate PLACEMENT — which effect branch actually waits on `ready` — stays a
+per-component decision and is not part of this hook; see the hook's own doc
+comment. Existing hand copies are migrated on their own subsequent cards, not
+by this change.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -158,6 +158,34 @@ falling back to the object's full scope. Use `useElementDataSourceSchema` (plus
 the exported `ElementDataSourceErrorPanel` / `ElementDataSourceLoadingPanel`) when
 a block cannot be wrapped — a renderer whose hooks must run before the panels.
 
+### useSettledSchema
+
+The settled-schema RESOLUTION half shared by `ObjectKanban` / `ObjectView` /
+`ObjectCalendar`'s fetch-gate hand copies (objectui#6482). Tracks whether an
+object's definition has finished resolving FOR THE KEY THE CURRENT RENDER IS
+ASKING ABOUT — `ready` and `def` are two views of one piece of state, so a
+stale key can never read as ready. GATE PLACEMENT — which effect actually
+waits on `ready` — stays a per-component decision; this hook only owns the
+resolution.
+
+```tsx
+import { useSettledSchema } from '@object-ui/react'
+
+function ObjectSomething({ schema, dataSource }) {
+  const key = schema.objectName ?? ''
+  const { ready, def } = useSettledSchema(key, dataSource)
+
+  useEffect(() => {
+    if (!ready) return // gate placement is local to this component
+    // issue the record query, e.g. buildExpandFields(def?.fields)
+  }, [ready, def])
+}
+```
+
+Pass `dataSource: undefined` for a render that should settle immediately with
+no definition (e.g. a provider that issues no metadata read at all) instead of
+adding a separate enable flag.
+
 ### ComponentRegistry
 
 There is no registry hook: the registry is a process-level singleton exported

--- a/packages/react/src/hooks/__tests__/useSettledSchema.test.ts
+++ b/packages/react/src/hooks/__tests__/useSettledSchema.test.ts
@@ -1,0 +1,220 @@
+/**
+ * ObjectUI — useSettledSchema Tests
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#6482: the settled-schema RESOLUTION half shared across
+ * ObjectKanban / ObjectView / ObjectCalendar's hand copies, extracted so the
+ * shape those three already got right (and objectui#6014/#6481's ObjectTree
+ * did not) is structural rather than conventional.
+ *
+ * The acceptance bar this file exists to demonstrate (per the maintainer
+ * ruling): `ready` and `def` cannot be observed inconsistently, and a STALE
+ * key can never read as ready — the exact defect objectui#6481 shipped by
+ * carrying "settled" as a second, independent boolean.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useSettledSchema } from '../useSettledSchema';
+
+/** A deferred promise, so a test controls exactly when a fetch resolves. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useSettledSchema', () => {
+  it('settles immediately with ready=true, def=null when dataSource is undefined', async () => {
+    const { result } = renderHook(() => useSettledSchema('accounts', undefined));
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toBeNull();
+  });
+
+  it('settles immediately with ready=true, def=null when the key is empty', async () => {
+    const ds: any = { getObjectSchema: vi.fn().mockResolvedValue({ fields: {} }) };
+    const { result } = renderHook(() => useSettledSchema('', ds));
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toBeNull();
+    expect(ds.getObjectSchema).not.toHaveBeenCalled();
+  });
+
+  it('settles immediately with ready=true, def=null when dataSource has no getObjectSchema', async () => {
+    const ds: any = { find: vi.fn() };
+    const { result } = renderHook(() => useSettledSchema('accounts', ds));
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toBeNull();
+  });
+
+  it('is NOT ready while the fetch is in flight, then resolves with the definition', async () => {
+    const d = deferred<any>();
+    const ds: any = { getObjectSchema: vi.fn().mockReturnValue(d.promise) };
+
+    const { result } = renderHook(() => useSettledSchema('accounts', ds));
+
+    // Not ready yet — the fetch is still pending.
+    expect(result.current.ready).toBe(false);
+    expect(result.current.def).toBeNull();
+
+    await act(async () => {
+      d.resolve({ fields: { name: { type: 'text' } } });
+      await d.promise;
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toEqual({ fields: { name: { type: 'text' } } });
+    expect(ds.getObjectSchema).toHaveBeenCalledWith('accounts');
+  });
+
+  it('settles with def=null (ready=true) when the fetch throws — "settled with nothing" is not "not ready"', async () => {
+    const d = deferred<any>();
+    const ds: any = { getObjectSchema: vi.fn().mockReturnValue(d.promise) };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useSettledSchema('accounts', ds));
+    expect(result.current.ready).toBe(false);
+
+    await act(async () => {
+      d.reject(new Error('boom'));
+      await d.promise.catch(() => {});
+    });
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toBeNull();
+    consoleError.mockRestore();
+  });
+
+  // ---------------------------------------------------------------------
+  // The acceptance bar: a stale key can never read as ready.
+  // ---------------------------------------------------------------------
+
+  it('objectui#6481 unwritable: switching keys while a fetch is in flight reads NOT ready in the SAME render — never the old key\'s def', async () => {
+    const accountsFetch = deferred<any>();
+    const contactsFetch = deferred<any>();
+    const ds: any = {
+      getObjectSchema: vi.fn((key: string) =>
+        key === 'accounts' ? accountsFetch.promise : contactsFetch.promise,
+      ),
+    };
+
+    const { result, rerender } = renderHook(
+      ({ key }) => useSettledSchema(key, ds),
+      { initialProps: { key: 'accounts' } },
+    );
+
+    // Settle the FIRST key while it is still current.
+    await act(async () => {
+      accountsFetch.resolve({ fields: { accountName: {} } });
+      await accountsFetch.promise;
+    });
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toEqual({ fields: { accountName: {} } });
+
+    // Switch keys. The new key's fetch has NOT resolved yet — this is the
+    // exact window objectui#6481's bare `schemaSettled` boolean got wrong:
+    // it stayed `true` from the 'accounts' settle, so a gated effect reading
+    // it would see "ready" while `objectSchema` still held ACCOUNTS' fields,
+    // for a key that is now CONTACTS.
+    rerender({ key: 'contacts' });
+
+    // Must read as NOT ready — synchronously, in the render right after the
+    // key changed, with no need for the new fetch to complete first — and
+    // `def` must NOT be leaking the previous ('accounts') definition.
+    expect(result.current.ready).toBe(false);
+    expect(result.current.def).toBeNull();
+
+    // Now settle the new key. `ready` flips true again, keyed to 'contacts'.
+    await act(async () => {
+      contactsFetch.resolve({ fields: { contactName: {} } });
+      await contactsFetch.promise;
+    });
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toEqual({ fields: { contactName: {} } });
+  });
+
+  it('a late resolution for an ABANDONED key never lands — the current key\'s resolution is never clobbered by a stale one arriving out of order', async () => {
+    const accountsFetch = deferred<any>();
+    const contactsFetch = deferred<any>();
+    const ds: any = {
+      getObjectSchema: vi.fn((key: string) =>
+        key === 'accounts' ? accountsFetch.promise : contactsFetch.promise,
+      ),
+    };
+
+    const { result, rerender } = renderHook(
+      ({ key }) => useSettledSchema(key, ds),
+      { initialProps: { key: 'accounts' } },
+    );
+
+    // Switch away from 'accounts' before its fetch ever resolves.
+    rerender({ key: 'contacts' });
+    expect(result.current.ready).toBe(false);
+
+    // Settle 'contacts' FIRST.
+    await act(async () => {
+      contactsFetch.resolve({ fields: { contactName: {} } });
+      await contactsFetch.promise;
+    });
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toEqual({ fields: { contactName: {} } });
+
+    // The ABANDONED 'accounts' fetch now resolves, late. Its effect's
+    // cleanup already ran (key changed), so its `isMounted` closure is
+    // false — this write must be dropped, not overwrite 'contacts'.
+    await act(async () => {
+      accountsFetch.resolve({ fields: { accountName: {} } });
+      await accountsFetch.promise.catch(() => {});
+    });
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.def).toEqual({ fields: { contactName: {} } });
+  });
+
+  it('does not call setState after unmount when a fetch resolves late', async () => {
+    const d = deferred<any>();
+    const ds: any = { getObjectSchema: vi.fn().mockReturnValue(d.promise) };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useSettledSchema('accounts', ds));
+    unmount();
+
+    await act(async () => {
+      d.resolve({ fields: {} });
+      await d.promise;
+    });
+
+    // No React "state update on an unmounted component" warning.
+    const reactWarning = consoleError.mock.calls.some((args) =>
+      String(args[0] ?? '').includes('unmounted'),
+    );
+    expect(reactWarning).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  it('re-fetches when dataSource identity changes even if the key does not', async () => {
+    const dsA: any = { getObjectSchema: vi.fn().mockResolvedValue({ fields: { a: {} } }) };
+    const dsB: any = { getObjectSchema: vi.fn().mockResolvedValue({ fields: { b: {} } }) };
+
+    const { result, rerender } = renderHook(
+      ({ ds }) => useSettledSchema('accounts', ds),
+      { initialProps: { ds: dsA } },
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.def).toEqual({ fields: { a: {} } });
+
+    rerender({ ds: dsB });
+    // Ready flips false the instant the source changes, same mechanism as a
+    // key change — there is only ever one comparison, `resolution.key === key`,
+    // gated additionally by the effect re-running on a NEW `dataSource`.
+    await waitFor(() => expect(result.current.def).toEqual({ fields: { b: {} } }));
+    expect(dsB.getObjectSchema).toHaveBeenCalledWith('accounts');
+  });
+});

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -49,3 +49,7 @@ export * from './useDatasetDimensionLabels.js';
 export * from './useDataRefresh.js';
 export * from './usePageAssignment.js';
 export * from './useRecordSearch.js';
+// The settled-schema RESOLUTION half shared across ObjectKanban / ObjectView /
+// ObjectCalendar's hand copies (objectui#6482, maintainer ruling Option A).
+// Gate PLACEMENT stays per-component — see the hook's own doc comment.
+export * from './useSettledSchema.js';

--- a/packages/react/src/hooks/useSettledSchema.ts
+++ b/packages/react/src/hooks/useSettledSchema.ts
@@ -1,0 +1,158 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useEffect, useState } from 'react';
+import type { DataSource } from '@object-ui/types';
+
+/**
+ * The settled result of `{@link useSettledSchema}`: whether the object
+ * definition for the CURRENT key has finished resolving, and the definition
+ * itself once it has.
+ *
+ * `ready` is never a fact about "a fetch completed" in isolation — it is
+ * "a fetch completed FOR THE OBJECT THIS RENDER IS ASKING ABOUT". See the
+ * hook's own doc comment for why that distinction is the entire point.
+ */
+export interface SettledSchema<TDef = unknown> {
+  /**
+   * `true` once the object definition for the key passed to this render has
+   * settled — successfully, with a thrown read, or because there was no
+   * source to read from. `false` while it is still in flight, and also
+   * `false` for exactly one render right after `key` changes, even if a
+   * PREVIOUS key's resolution is sitting in state (objectui#6481's defect,
+   * made unwritable — see the hook doc comment).
+   */
+  ready: boolean;
+  /**
+   * The resolved definition once `ready` is `true`, otherwise `null`.
+   * `null` while `ready` is `true` is a legitimate, DISTINCT outcome from
+   * "not ready yet" — it means the resolution settled with nothing (no
+   * `dataSource`, no `getObjectSchema`, no key, or a read that threw), not
+   * that the read never happened.
+   */
+  def: TDef | null;
+}
+
+/**
+ * Resolves an object's schema/definition and tracks whether that resolution
+ * has SETTLED for the object CURRENTLY being asked about — one piece of
+ * state a caller cannot observe half of.
+ *
+ * ## The shape, and why it is exactly this one
+ *
+ * This is the RESOLUTION half of the settled-schema gate four views
+ * (`ObjectKanban`, `ObjectView`, `ObjectCalendar`, and — pre-fix —
+ * `ObjectTree`) each hand-wrote (objectui#6271, #6419, #6453, #6014). Ruled
+ * objectui#6482 (maintainer, 2026-08-27, Option A): extract the resolution
+ * half as a shared, published hook; leave GATE PLACEMENT — deciding which
+ * effect branch actually waits on `ready` — to each component, because that
+ * part is genuinely component-private (`ObjectCalendar` gates only its
+ * `object`-provider branch and keys on `dataConfig.object ?? schema.objectName`
+ * rather than `schema.objectName`, because an inline `value` data set issues
+ * no metadata read at all — a whole-effect gate would hold its query open on
+ * a resolution nothing was ever going to produce).
+ *
+ * `ready` is DERIVED at render time — `resolution !== null && resolution.key
+ * === key` — from a SINGLE piece of state, `{ key, def } | null`, rather than
+ * stored as a second, independent boolean. That is not a style choice; it is
+ * the fix for the defect this card exists to close. objectui#6481's
+ * `ObjectTree` carried the definition (`objectSchema`) and "has it settled"
+ * (`schemaSettled`) as two SEPARATE `useState`s. `schemaSettled` was a
+ * one-way latch — set `true` on first settle and never reset — so when the
+ * host swapped `objectName` mid-life, the fetch effect re-ran and started
+ * refetching the NEW object's schema, but `schemaSettled` stayed `true` from
+ * the OLD object's settle. The gated effect read `schemaSettled === true`
+ * and `objectSchema` still holding the OLD object's fields, and queried with
+ * the WRONG `$expand` — a stale key reading as ready.
+ *
+ * With one state value and a render-time key comparison, that failure mode
+ * is not merely fixed, it is UNREPRESENTABLE: the instant `key` changes,
+ * `resolution.key === key` is false in that very render (no effect needs to
+ * run first), so `ready` flips to `false` in the same commit the key
+ * changed — there is no window, and no second piece of state a caller could
+ * read out of sync with the first, because there is no second piece of
+ * state. A caller cannot spell "ready for the wrong object": `ready` and
+ * `def` are two views of one value, never independently settable.
+ *
+ * Every exit of the internal fetch effect settles the resolution — success,
+ * a thrown read, and "there is no source to read from" alike — because a
+ * caller's gated effect WAITS on `ready`. An exit that returned without
+ * settling would not merely skip the expansion; it would hold that gated
+ * query open forever.
+ *
+ * ## What this hook does NOT do
+ *
+ * It does not decide when to fetch beyond "when `key` or `dataSource`
+ * change", and it does not decide what a caller's OTHER effects should wait
+ * on. A caller that should not fetch at all for the current render (e.g.
+ * `ObjectCalendar`'s inline `value` provider, which issues no metadata read)
+ * passes `dataSource: undefined` for that render rather than a new "should
+ * fetch" flag — the hook already settles-with-`null` whenever `dataSource`
+ * is absent, which is the exact "no source to read from" outcome that case
+ * needs.
+ *
+ * @param key - The identity of the object THIS render is asking about (e.g.
+ *   `dataConfig.object ?? schema.objectName ?? ''`). Computing the right key
+ *   is the caller's job — it is the component-private half of the original
+ *   hand copies, not something this hook can infer.
+ * @param dataSource - The data source to read the definition from. Pass
+ *   `undefined`/`null` for a render that should settle immediately with no
+ *   definition (no source, or a provider that needs none) rather than adding
+ *   a separate enable flag.
+ * @returns `{ ready, def }` — see {@link SettledSchema}.
+ *
+ * @example
+ * ```tsx
+ * const schemaKey = dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
+ * const { ready: objectSchemaReady, def: objectSchema } =
+ *   useSettledSchema(schemaKey ?? '', hasInlineData ? undefined : dataSource);
+ *
+ * useEffect(() => {
+ *   if (dataConfig?.provider === 'object' && !objectSchemaReady) return; // gate placement stays local
+ *   // ...issue the record query, `buildExpandFields(objectSchema?.fields)`
+ * }, [objectSchemaReady, objectSchema, /* ... *\/]);
+ * ```
+ */
+export function useSettledSchema<TDef = unknown>(
+  key: string,
+  dataSource: DataSource<any> | null | undefined,
+): SettledSchema<TDef> {
+  const [resolution, setResolution] = useState<{ key: string; def: TDef | null } | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const settleKey = key;
+
+    const resolve = async () => {
+      if (!dataSource || !settleKey || typeof dataSource.getObjectSchema !== 'function') {
+        // No source for a definition: settle with none, so anything gated on
+        // `ready` still runs (unexpanded — with no schema there is no expand
+        // set to derive).
+        if (isMounted) setResolution({ key: settleKey, def: null });
+        return;
+      }
+      try {
+        const def = await dataSource.getObjectSchema(settleKey);
+        if (isMounted) setResolution({ key: settleKey, def: def as TDef });
+      } catch (err) {
+        console.error('[useSettledSchema] getObjectSchema failed for', settleKey, err);
+        if (isMounted) setResolution({ key: settleKey, def: null });
+      }
+    };
+
+    resolve();
+    return () => {
+      isMounted = false;
+    };
+  }, [key, dataSource]);
+
+  const ready = resolution !== null && resolution.key === key;
+  const def = ready ? (resolution as { key: string; def: TDef | null }).def : null;
+
+  return { ready, def };
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -71,6 +71,7 @@ const domTsTests = [
   'packages/react/src/hooks/__tests__/useDataRefresh.test.ts',
   'packages/react/src/hooks/__tests__/useExpression.test.ts',
   'packages/react/src/hooks/__tests__/useRecordSearch.test.ts',
+  'packages/react/src/hooks/__tests__/useSettledSchema.test.ts',
 ];
 
 // Test files that render through the ComponentRegistry and therefore need the


### PR DESCRIPTION
Fixes #6482

## What this lands

Extracts the settled-schema **RESOLUTION** half — shared today across three hand
copies (`ObjectKanban` #6271, `ObjectView` #6419, `ObjectCalendar` #6453) — into a
new, published hook: `useSettledSchema`, exported from `@object-ui/react`
(`packages/react/src/hooks/useSettledSchema.ts`).

Per the maintainer ruling of 2026-08-27 (Option A), this dispatch lands **only**
the hook. Migrating the three existing hand copies rides subsequent cards that
touch those components; none of `ObjectKanban.tsx` / `ObjectView.tsx` /
`ObjectCalendar.tsx` / `ObjectTree.tsx` is touched here. The four ungated views
(`ObjectGantt`, `ObjectMap`, `ObjectTimeline`, `ObjectGallery`) are untouched too
— Option C (blanket gating) stays excluded on the card's own per-component
measurement.

## Published-surface declaration (Clause-②)

`@object-ui/react`'s public surface widens by two names, both re-exported from
the package entry (`packages/react/src/index.ts` → `hooks/index.ts` →
`useSettledSchema.ts`):

- `useSettledSchema(key: string, dataSource: DataSource | null | undefined): SettledSchema` — the hook. Generic over the definition type `TDef` (default `unknown`); `DataSource` here takes its own default type parameter.
- `SettledSchema` — the hook's return type for that same `TDef`: `{ ready: boolean; def: TDef | null }`.

An external consumer of `@object-ui/react` can now `import { useSettledSchema } from '@object-ui/react'`
and use it directly. Changeset scored `minor` (objectui's major stays pinned to
`@objectstack`'s per `scripts/check-changeset-no-major.mjs`).

**Reachability verified through the barrel and the `exports` map**, not by an
`export` keyword in a module file — same TypeScript-checker query
(`getExportsOfModule`) `scripts/check-readme-exports.mjs` itself uses, run
against the *built* `packages/react/dist/index.d.ts`, with a positive control
(`useDataRefresh`, already published) resolved through the identical query:

```
control  present: true useDataRefresh
new hook present: true useSettledSchema
new type present: true SettledSchema
total export symbols at package entry: 299
```

`AGENTS.md §3` still bars React from `@object-ui/core` ("No UI-lib deps. Logic
only.") — confirmed on this ref — which is why the hook lives in
`@object-ui/react` ("The Runtime … Bridges Core and Components"), not `core`.

## The shape, and why the resolution/gate split falls where it does

```ts
// generic over TDef, default: unknown
function useSettledSchema(
  key: string,
  dataSource: DataSource | null | undefined,
): { ready: boolean; def: TDef | null }
```

Internally: **one** piece of state — `useState` over `{ key: string; def: TDef | null } | null`, initialized to `null`,
settled by an effect keyed on `[key, dataSource]` whose every exit settles
(success, a thrown read, and "no source to read from" alike — a caller's gated
effect *waits* on `ready`, so an exit that didn't settle would hold that query
open forever). `ready` and `def` are **derived at render time**:

```ts
const ready = resolution !== null && resolution.key === key;
const def = ready ? resolution.def : null;
```

**Resolution is common; gate placement is not, and this PR keeps that split.**
The three existing hand copies already agree on the resolution shape above
(state, key, settle-on-every-exit) — that's the part this hook lifts out. They
disagree on *where* the gate sits: `ObjectCalendar` keys on
`dataConfig.object ?? schema.objectName` (not `schema.objectName`) and gates only
its `object`-provider branch, because an inline `value` data set issues no
metadata read at all — a whole-effect gate would hold a query open on a
resolution nothing was ever going to produce. That's component-private truth
established by #6453's own measurement, and this hook does not take it over:
callers compute their own `key` and pass `dataSource: undefined` for a render
that shouldn't fetch, rather than the hook growing an `enabled` flag. The
`useSettledSchema` doc comment and the new `packages/react/README.md` "Hooks"
entry both spell out this composition with a worked `ObjectCalendar`-shaped
example.

## Demonstrating #6481's defect is unwritable

#6481's root cause: `ObjectTree` carried the definition (`objectSchema`) and
"has it settled" (`schemaSettled`) as **two separate** `useState`s.
`schemaSettled` was a one-way latch — set `true` on first settle, never reset —
so when the host swapped `objectName` mid-life, the fetch effect began
refetching the *new* object's schema while `schemaSettled` stayed `true` from
the *old* object's settle. A gated effect reading `schemaSettled === true` +
the still-old `objectSchema` would query with the **wrong** `$expand`: a stale
key reading as ready.

`useSettledSchema` makes that shape unrepresentable rather than merely
avoiding it: there is no second, independently-settable boolean. `ready` is a
render-time comparison, `resolution.key === key`, against a **single** state
value — the instant `key` changes, that comparison is false in the *same*
render, before any effect runs. There is no window and nothing a caller can
observe out of sync, because there is nothing to observe *besides* the one
`{ready, def}` pair.

`packages/react/src/hooks/__tests__/useSettledSchema.test.ts` pins this
directly — `objectui#6481 unwritable: switching keys while a fetch is in
flight reads NOT ready in the SAME render — never the old key's def`: settle
`'accounts'`, switch to `'contacts'` before its fetch resolves, assert
`ready === false` and `def === null` **synchronously**, with no `waitFor`. A
sibling test additionally proves a late-arriving resolution for an
**abandoned** key can never clobber the current one (the abandoned effect's
`isMounted` closure is false by the time it resolves). 9/9 tests pass; see the
ablation below for proof the pin actually bites.

## Ablation — prediction vs observation

**Mutation** (on-disk edit to `packages/react/src/hooks/useSettledSchema.ts`,
committed baseline `877944237` before mutating, restored from `HEAD` after):

```diff
- const ready = resolution !== null && resolution.key === key;
+ const ready = resolution !== null; // drops the key comparison
```

This reproduces `ObjectTree`'s actual bug shape — a settle flag that doesn't
care which key it settled for.

**Predicted before running:** the `objectui#6481 unwritable` test and the
`ABANDONED key` test both go red — both assert `ready === false` in the render
right after a key switch, pre-settle.

**Observed:** only the `objectui#6481 unwritable` test went red
(`expected true to be false`); the `ABANDONED key` test stayed green. The
difference, on inspection: the `ABANDONED key` test switches keys *before any
resolution ever settles* — `resolution` is still `null` at that point, so
`resolution !== null` reads `false` under **both** the mutated and the
original code, and the mutation only diverges from correct behavior once a
**prior** key has already settled successfully (exactly `ObjectTree`'s bug
shape: an object whose schema had already resolved, then swapped for a new
one). Reporting the actual direction rather than forcing the initial
prediction — the pin that matches the real defect shape is the one that bit;
the other test simply doesn't exercise that window.

Mutation landing on disk was proven by an anchored `grep -c` of the exact line
(1 → 0 → mutated-marker present), not by any tool's exit code. Restoration was
proven by an **empty `git diff HEAD`** plus a byte-identical
`git hash-object` against the `HEAD` blob (`1d89c21a1f26108a715dbe4b36eef22cffe21c12`
both before and after). The mutate/restore script used a `trap ... EXIT INT TERM`
with an absolute `$REPO_ROOT`-anchored restore path. Full suite re-run green
(9/9) after restoration.

## Gate table

All commands run at repo root; exit captured by redirect-then-capture, never
after a pipe. Final union re-run **after** the commit this PR ships
(`877944237`).

| Gate | Command | Verdict (gate's own printed line) |
|---|---|---|
| `@object-ui/react` vitest (full package scope) | `pnpm exec vitest run packages/react/` | `Test Files 62 passed (62)` / `Tests 916 passed (916)` |
| `@object-ui/react` vitest (new file only) | `pnpm exec vitest run packages/react/src/hooks/__tests__/useSettledSchema.test.ts` | `Test Files 1 passed (1)` / `Tests 9 passed (9)` |
| `@object-ui/react` type-check | `pnpm --filter @object-ui/react type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0, no diagnostics; confirmed via `--listFiles` that `tsconfig.test.json` includes both the new hook and its test file |
| `check:control-bytes` | `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 5536 tracked text file(s); skipped 85 binary)` |
| `check:readme-exports` (scoped to the touched package, via the gate's own `scan()` override params — the full-repo run in this fresh worktree is `PRECONDITION NOT MET`, see below) | `scan(root, { packageDirs: ['packages/react'], readmes: ['packages/react/README.md'], floors: {} })` | `8 self-imports judged (8 real, 0 wrong-path, 0 fabricated)`; `useSettledSchema:real` |
| `changeset:check` (fixed group + no-major) | `node scripts/check-changeset-fixed.mjs && node scripts/check-changeset-no-major.mjs` | `✅ All workspace packages are in the changeset fixed group.` / `✅ No changeset declares a major bump.` |
| lint (touched files, narrowed — see below) | `pnpm exec eslint packages/react/src/hooks/useSettledSchema.ts packages/react/src/hooks/__tests__/useSettledSchema.test.ts packages/react/src/hooks/index.ts --format json` | 3 files linted, **0 errors**, 17 `@typescript-eslint/no-explicit-any` warnings (same class already present throughout the package — e.g. `DataSource`'s own default type parameter; `warn` severity, `lint.yml` sets no `--max-warnings`) |
| lint (whole package, confirmation) | `pnpm --filter @object-ui/react lint` | exit 0, `380 problems (0 errors, 380 warnings)` — all pre-existing |

**Lint narrowing justification:** ESLint here (`eslint.config.js`) uses
`tseslint.configs.recommended`, not `recommendedTypeChecked` — no
`parserOptions.project` anywhere in the config — so no rule is type-aware and
no rule reads cross-file type information. A diff confined to 3 files cannot
move any *other* file's verdict, so narrowing the run to those 3 files, with
their exact population read from eslint's own `--format json` output
(`len(data) == 3`), is a real measurement, not a shrunk one. The whole-package
run above additionally confirms nothing else in `@object-ui/react` regressed.

**`check:readme-exports` full-repo run — PRECONDITION NOT MET, reported in
those words:** this is a fresh worktree with only `@object-ui/react` and its
three workspace dependencies built (`types`, `core`, `data-objectstack`,
`i18n`); the gate's own population census reports
`packagesRead: found 6, floor is 25` and calls that a collapse, because most
packages here are pre-existing-`unbuilt` in this worktree, unrelated to this
diff. Building all 40 workspace packages locally to clear that floor is the
repo-wide farm scan `AGENTS.md` reserves for CI. What *is* measured, and
green, is the package this diff actually touches: `react`'s own self-imports
(including the new one) judged via the gate's own `scan()` function with its
documented `packageDirs`/`readmes`/`floors` overrides (the same mechanism its
fixture suite uses) — `0 fabricated`, `0 wrong-path`, `useSettledSchema:real`.
CI's full run supplies the whole-workspace verdict.

---
_Generated by [Claude Code](https://claude.ai/code/session_8ca04858-ea8e-5b85-9182-de59aa49e00c)_
