### PR TITLE
chore(scripts): re-sync the ported sweeper to upstream's H32 board-independent specimens

### DIFF
--- a/scripts/pm/check-half-states.mjs
+++ b/scripts/pm/check-half-states.mjs
@@ -12325,16 +12325,30 @@ function selfTest() {
   const busy = { unclaimed: 15, inFlight: 7 };
   const idleLane = { unclaimed: 15, inFlight: 0 };
 
+  // The `@ <repo>` specimens below DERIVE both board names rather than spelling
+  // them, because `seatLane` judges an at-repo suffix against the LIVE resolved
+  // sweep repo — `SWEEP_REPO`, not a constant. A row that hard-codes `objectui`
+  // as the sibling and `objectstack` as the own board therefore asserts THIS
+  // BOARD instead of the property, and inverts wholesale wherever the file is
+  // installed next: run verbatim in objectui on 2026-08-28 the suite failed
+  // exactly the four rows those two names feed, which is the one thing a file
+  // adopted BY COPY (see `resolveSweepRepo`) may not do. `OWN_BOARD` is the
+  // resolved repo's name half — the same half the predicate compares, derived
+  // here rather than shared, so a predicate that switched to the OWNER half
+  // still goes red. `SIBLING_BOARD` is a real neighbouring board picked so the
+  // two can never coincide, which is what stops the FOREIGN rows going
+  // vacuously green on a board that happens to be named after the specimen.
+  const OWN_BOARD = SWEEP_REPO.repo.split('/')[1];
+  const SIBLING_BOARD = OWN_BOARD === 'objectui' ? 'objectstack' : 'objectui';
+  const ownLaneSeat = (status = '🟢 os-x') => seat(`[PM seat] domain:devx @ ${OWN_BOARD} — ${status}`);
+  const siblingLaneSeat = (status = '🟢 os-x') => seat(`[PM seat] domain:devx @ ${SIBLING_BOARD} — ${status}`);
+
   // The lane parse, across the three measured title shapes.
   t('H32 lane: a plain domain lane is own-board', seatLane(seat(HELD)).lane, 'domain:spec');
   t('H32 lane: …and not foreign', seatLane(seat(HELD)).foreign, false);
-  // ADAPTED FOR THIS REPO. `seatLane` compares the `@ <repo>` suffix against
-  // the LIVE `SWEEP_REPO`, so which name is FOREIGN is install-dependent and
-  // upstream's two rows invert here. The property is identical — a sibling
-  // board's lane is unreadable from this sweep, this board's own lane is not.
-  t('H32 lane: an `@ sibling` suffix is FOREIGN', seatLane(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')).foreign, true);
-  t('H32 lane: an `@ own-repo` suffix is NOT foreign', seatLane(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')).foreign, false);
-  t('H32 lane: …and keeps the bare lane label', seatLane(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')).lane, 'domain:devx');
+  t('H32 lane: an `@ sibling` suffix is FOREIGN', seatLane(siblingLaneSeat()).foreign, true);
+  t('H32 lane: an `@ own-repo` suffix is NOT foreign', seatLane(ownLaneSeat()).foreign, false);
+  t('H32 lane: …and keeps the bare lane label', seatLane(ownLaneSeat()).lane, 'domain:devx');
   t('H32 lane: a repo-scoped seat has no countable lane', seatLane(seat('[PM seat] repo:cloud — 🟢 os-x')).lane, null);
   t('H32 lane: …and is foreign', seatLane(seat('[PM seat] repo:cloud — 🟢 os-x')).foreign, true);
   t('H32 lane: a lane-less seat (skills) is foreign', seatLane(seat('[PM seat] skills — 🟢 os-zhuang (session_x)')).foreign, true);
@@ -12343,7 +12357,7 @@ function selfTest() {
 
   // The held/vacant gate — an unheld seat is a ROUTING gap, never 怠工.
   t('H32 held: 🟢 with a holder', seatIsHeld(seat(HELD)), true);
-  t('H32 held: ⏳ vacant is NOT held', seatIsHeld(seat('[PM seat] domain:devx @ objectui — ⏳ vacant')), false);
+  t('H32 held: ⏳ vacant is NOT held', seatIsHeld(siblingLaneSeat('⏳ vacant')), false);
   t('H32 held: 🔴 收班 vacant is NOT held', seatIsHeld(seat('[PM seat] domain:spec — 🔴 收班 vacant · 上一班 os-warren')), false);
   t('H32 held: ⏸️ paused is NOT held', seatIsHeld(seat('[PM seat] domain:spec — ⏸️ paused')), false);
   t('H32 held: a Routine seat is excluded (no claim cadence of its own)', seatIsHeld(seat('[PM seat] triage (objectstack-wide) — 🟢 Routine')), false);
@@ -12355,7 +12369,7 @@ function selfTest() {
   t('H32: work IN FLIGHT is a working seat -> clean', h32SeatIdleOverQueue(seat(HELD), marker('Round-start marker — R6.', 600), busy, NOW32), null);
   t('H32: an EMPTY queue is a finished lane -> clean', h32SeatIdleOverQueue(seat(HELD), marker('Round-start marker — R6.', 600), { unclaimed: 0, inFlight: 0 }, NOW32), null);
   t('H32: a vacant seat is out of scope however deep the queue', h32SeatIdleOverQueue(seat('[PM seat] domain:spec — ⏳ vacant'), marker('收班', 6000), idleLane, NOW32), null);
-  t('H32: a FOREIGN lane is out of scope (its inventory is unreadable here)', h32SeatIdleOverQueue(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x'), marker('Round-start marker', 600), idleLane, NOW32), null);
+  t('H32: a FOREIGN lane is out of scope (its inventory is unreadable here)', h32SeatIdleOverQueue(siblingLaneSeat(), marker('Round-start marker', 600), idleLane, NOW32), null);
   t('H32: a non-seat card is out of scope', h32SeatIdleOverQueue({ ...issue(['pm:queue']), title: HELD }, marker('x', 600), idleLane, NOW32), null);
 
   // The threshold, at both edges of SEAT_IDLE_STALE_MINUTES.
@@ -12401,7 +12415,7 @@ function selfTest() {
 
   // The gathering gate buys a fetch only for seats the row can speak about.
   t('H32 gate: a held own-board seat is a candidate', h32NeedsSeatComments(seat(HELD)), true);
-  t('H32 gate: a foreign-lane seat buys no fetch', h32NeedsSeatComments(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')), false);
+  t('H32 gate: a foreign-lane seat buys no fetch', h32NeedsSeatComments(siblingLaneSeat()), false);
   t('H32 gate: a vacant seat buys no fetch', h32NeedsSeatComments(seat('[PM seat] domain:spec — ⏳ vacant')), false);
   t('H32 gate: a non-seat card buys no fetch', h32NeedsSeatComments(issue(['pm:queue'])), false);
 

--- a/scripts/upstream-port-pin.json
+++ b/scripts/upstream-port-pin.json
@@ -1,13 +1,13 @@
 {
   "upstream": {
     "repo": "objectstack-ai/objectstack",
-    "ref": "2b4178aa53ca62089f43e2cfae0b7838cf340dd1"
+    "ref": "bf10debd587f6ba891be9eadc2b76c91e15bd82b"
   },
   "files": [
     {
       "ported": "scripts/pm/check-half-states.mjs",
       "upstreamPath": "scripts/pm/check-half-states.mjs",
-      "upstreamSha256": "c06c84517630e180eb9e4bc1f0e13d069e5dfc71b6889baac0ebcd37256ea1bc",
+      "upstreamSha256": "449a0aec0cfa36738e0fc5651ec978faf846316522daeb9ca6efa1714daf6ac9",
       "divergences": [
         {
           "id": "default-sweep-repo",
@@ -56,24 +56,6 @@
           "why": "Self-test row: a 0-page window still reads UNREAD even with a floor set.",
           "upstream": "  t('summary: an unfloored pass adds no floor clause', summaryLine({ repo: 'r', issues: 1, unscoped: 1, prs: 0, merged: 0, closed: 200 }, 0).includes('are judged'), false);\n",
           "ported": "  t('summary: an unfloored pass adds no floor clause', summaryLine({ repo: 'r', issues: 1, unscoped: 1, prs: 0, merged: 0, closed: 200 }, 0).includes('are judged'), false);\n  // The DISABLED branch still wins over a floor: a 0-page window read nothing,\n  // so the line must keep saying UNREAD rather than describing a floored pass.\n  t('summary: a disabled reader with a floor set still reads UNREAD', summaryLine({ repo: 'r', issues: 1, unscoped: 1, prs: 0, merged: 0, closedWindowDisabled: true, closedFloor: '2026-08-28' }, 0).includes('UNREAD'), true);\n"
-        },
-        {
-          "id": "h32-lane-own-board",
-          "why": "`seatLane` reads the LIVE resolved sweep repo, so upstream's two rows invert in this install: here `@ objectui` is the own board and `@ objectstack` is the sibling. The property asserted is unchanged.",
-          "upstream": "  t('H32 lane: an `@ sibling` suffix is FOREIGN', seatLane(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')).foreign, true);\n  t('H32 lane: an `@ own-repo` suffix is NOT foreign', seatLane(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')).foreign, false);\n  t('H32 lane: …and keeps the bare lane label', seatLane(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')).lane, 'domain:devx');\n",
-          "ported": "  // ADAPTED FOR THIS REPO. `seatLane` compares the `@ <repo>` suffix against\n  // the LIVE `SWEEP_REPO`, so which name is FOREIGN is install-dependent and\n  // upstream's two rows invert here. The property is identical — a sibling\n  // board's lane is unreadable from this sweep, this board's own lane is not.\n  t('H32 lane: an `@ sibling` suffix is FOREIGN', seatLane(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')).foreign, true);\n  t('H32 lane: an `@ own-repo` suffix is NOT foreign', seatLane(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')).foreign, false);\n  t('H32 lane: …and keeps the bare lane label', seatLane(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')).lane, 'domain:devx');\n"
-        },
-        {
-          "id": "h32-foreign-out-of-scope",
-          "why": "Same inversion, in the H32 predicate row: the FOREIGN specimen must name a board this sweep cannot read.",
-          "upstream": "  t('H32: a FOREIGN lane is out of scope (its inventory is unreadable here)', h32SeatIdleOverQueue(seat('[PM seat] domain:devx @ objectui — 🟢 os-x'), marker('Round-start marker', 600), idleLane, NOW32), null);\n",
-          "ported": "  t('H32: a FOREIGN lane is out of scope (its inventory is unreadable here)', h32SeatIdleOverQueue(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x'), marker('Round-start marker', 600), idleLane, NOW32), null);\n"
-        },
-        {
-          "id": "h32-foreign-no-fetch",
-          "why": "Same inversion, in the H32 comment-fetch gate row.",
-          "upstream": "  t('H32 gate: a foreign-lane seat buys no fetch', h32NeedsSeatComments(seat('[PM seat] domain:devx @ objectui — 🟢 os-x')), false);\n",
-          "ported": "  t('H32 gate: a foreign-lane seat buys no fetch', h32NeedsSeatComments(seat('[PM seat] domain:devx @ objectstack — 🟢 os-x')), false);\n"
         },
         {
           "id": "sweep-repo-self-test",


### PR DESCRIPTION
Fixes objectstack-ai/objectui#6689

The gate's own documented re-sync act, owed since objectstack landed the H32 board-independent specimens (2026-08-28 15:04Z). Authored in session `session_01MnijPVVDakqK2J335JoJtq`.

## The pin bump

| | before | after |
|---|---|---|
| `upstream.ref` | `2b4178aa53ca62089f43e2cfae0b7838cf340dd1` | **`bf10debd587f6ba891be9eadc2b76c91e15bd82b`** |
| `check-half-states.mjs` digest | `c06c8451…` | **`449a0aec0cfa36738e0fc5651ec978faf846316522daeb9ca6efa1714daf6ac9`** |
| declared divergences on that file | 14 | **11** |

Moved with `node scripts/check-upstream-port-parity.mjs --resync … --ref … --path scripts/pm/check-half-states.mjs`. The digest was never hand-edited: the value the tool wrote matches the `sha256sum` taken independently of upstream's blob before anything was touched.

`scripts/invoked-as.mjs` is the other pinned file and shares the one `upstream.ref`. Its blob is **byte-identical at both refs** (`90f72bf45a2fd158b19d5774269eb96a6b8b61540251ce68c29ddce7c93bfaa7` at each), so bumping the shared ref keeps its provenance true rather than quietly re-dating it.

## The three entries deleted, and why that is safe

Deleted from `scripts/upstream-port-pin.json`:

- `h32-lane-own-board`
- `h32-foreign-out-of-scope`
- `h32-foreign-no-fetch`

Their entire content was swapping the two repo names. `seatLane` judges an `@ repo` suffix against the **live resolved sweep repo**, so upstream's old hard-coded rows asserted upstream's board instead of the property and inverted here — these three existed only to invert them back.

Upstream's fix derives both names instead of spelling them:

```js
const OWN_BOARD = SWEEP_REPO.repo.split('/')[1];
const SIBLING_BOARD = OWN_BOARD === 'objectui' ? 'objectstack' : 'objectui';
```

so the specimens are board-independent and a verbatim copy passes here. Keeping the compensation would now be actively wrong — it would re-introduce the literals it was written to correct.

Three pieces of evidence that the deletion is safe rather than assumed:

1. **The sweep for other vanished anchors.** `--resync` was run **before** any deletion. It failed loudly naming exactly these three entries and no others, and wrote nothing. So the other 11 divergences on this file still apply cleanly, and no still-needed divergence lost its anchor.
2. **The property holds on this board.** The sweeper's `--self-test` passes **1574 cases here with the three entries gone**, including the five rows they used to feed. That is the acceptance criterion the card names: a still-load-bearing entry would have red-ed.
3. **The rows are not vacuously green.** On this board the sweep repo resolves to `objectstack-ai/objectui`, giving `OWN_BOARD = objectui` and `SIBLING_BOARD = objectstack` — distinct, so the FOREIGN and own-board rows assert genuinely opposite values.

## Gate verdicts

Union re-run on the final commit `af9771c`; each exit captured before any pipe.

| gate | exit | verdict line |
|---|---|---|
| `check-upstream-port-parity` | 0 | `✓ … 2 ported file(s) match objectstack-ai/objectstack@bf10debd5 modulo their declared divergences.` |
| `check-upstream-port-parity --self-test` | 0 | `✓ … self-test: 37 cases pass` |
| `check-half-states --self-test` (this board) | 0 | `✓ check-half-states self-test: 1574 cases pass.` |
| floor end-to-end spot check | 0 | `FLOOR SPOT CHECK: PASS (4/4) — pre-floor skipped, on/post-floor reported` |
| `vitest` adaptation + parity wiring | 0 | `Test Files 2 passed (2) · Tests 30 passed (30)` |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, no diagnostics |
| `check-control-bytes` | 0 | `✅ OK (scanned 5537 tracked text file(s); skipped 85 binary).` |
| `check-entry-guard` | 0 | `✓ 51 scripts/ file(s) — no entry guard outside the baseline` |
| `check-lint-coverage` | 0 | `✅ lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `check-changeset-presence` | 0 | `✅ No source of a released package changed in this range, so no changeset is owed.` |

The floor spot check ran with the workflow's real env (`PM_SWEEP_REPO: objectstack-ai/objectui`, `PM_SWEEP_CLOSED_FLOOR: '2026-08-28'`, window pages unset so upstream's 4 applies) and asserts both directions plus a no-residue control, so a predicate that skipped everything could not pass it.

**No changeset**, per the gate's own verdict: scripts-only, no published source in range. No `skip-changeset` label applied — that label is a phantom in this repo.

### Declared narrowing

`eslint` was run on the two changed files rather than repo-wide. Population came from eslint's own config resolution (it accepted and linted both paths); `--format json` reports **2 files, 0 errors, 0 warnings**; and no type-aware linting is configured (no `projectService`, no `parserOptions.project`), so a diff confined to these two files cannot move the verdict on any file it does not touch. CI runs the full farm regardless.

`check-node-esm-load` is **not** implicated: it enumerates published packages (`discoverPackages(root)` filtered to non-private manifests), and this diff touches 0 files under `packages/` and 0 manifests.

_Generated by [Claude Code](https://claude.ai/code)_
