### PR TITLE
fix(plugin-tree): re-key ObjectTree's record-fetch effect onto dataConfig primitives (#6700)

### DIFF
--- a/.changeset/6700-objecttree-record-effect-primitives.md
+++ b/.changeset/6700-objecttree-record-effect-primitives.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/plugin-tree': patch
+---
+
+Re-key `ObjectTree`'s record-fetch effect onto the primitive fields it
+actually reads off `dataConfig` (`provider` / `object` / `items`) instead of
+the whole memoised `dataConfig` object (objectui#6700, closing out the
+census #6592 opened — the schema-resolution half of this component was
+already re-keyed onto `useSettledSchema`'s primitive `schemaKey` by #6696).
+
+`useMemo` carries no semantic guarantee — React is permitted to discard a
+memo cache and recompute even when its dependency array compares equal to
+the previous render, and the local `getDataConfig(schema)` helper builds a
+fresh `{ provider, object }` / `{ provider, items }` wrapper object on every
+call. So the record-fetch effect, keyed on `dataConfig` itself, was correct
+only for as long as that identity happened to survive a discard: a
+recompute alone (no author or caller action) was enough to re-run the
+effect and issue an extra `dataSource.find` call. Keying the effect on the
+primitives instead makes a cache discard a no-op, restoring `useMemo` to a
+pure optimisation — mirroring the fix already shipped for `ObjectMap` /
+`ObjectCalendar` / `ObjectGantt`.
+
+No behaviour change for a schema whose `useMemo` caches survive normally;
+the effect is unaffected by React discarding one.

--- a/packages/plugin-tree/src/ObjectTree.discardedConfigMemo.test.tsx
+++ b/packages/plugin-tree/src/ObjectTree.discardedConfigMemo.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6700 — the record-fetch effect is the LAST `dataConfig`-identity
+ * dependence in `ObjectTree` (the schema-resolution effect #6592 also named
+ * was already retired by #6696 in favor of `useSettledSchema`'s primitive
+ * `schemaKey`). See `ObjectMap.discardedConfigMemo.test.tsx` for the full
+ * rationale this mirrors: `useMemo` carries no semantic guarantee — React
+ * may discard its cache and recompute even when `schema` itself hasn't
+ * changed — and `getDataConfig(schema)` builds a FRESH `{ provider, object }`
+ * wrapper object on every call. A fetch effect keyed on that container
+ * object's identity therefore re-runs (and refetches) on a bare discard,
+ * with nothing about the bound object actually different.
+ *
+ * The discard proxy: two schema object literals with identical primitive
+ * content but different references. `dataConfig = useMemo(() =>
+ * getDataConfig(schema), [schema])` is keyed on `[schema]` (the whole prop
+ * object, confirmed at `ObjectTree.tsx` — `const dataConfig = useMemo(() =>
+ * getDataConfig(schema), [schema]);`), so a schema reference swap reliably
+ * forces the recompute — the same "different identity, same content" shape
+ * a genuine memo-cache discard would produce with `schema` held constant.
+ * `useSettledSchema`'s OWN internal effect is keyed on the derived primitive
+ * `schemaKey` string, not on `schema`/`dataConfig`, so this swap leaves
+ * `objectSchema`/`schemaSettled` referentially stable and cannot confound
+ * the result through that channel.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ObjectTree } from './ObjectTree';
+
+afterEach(cleanup);
+
+function makeDataSource() {
+  return {
+    find: vi.fn().mockResolvedValue([{ id: '1', name: 'Acme', parent_id: null }]),
+    getObjectSchema: vi.fn().mockResolvedValue({ name: 'business_unit', fields: {} }),
+  } as any;
+}
+
+describe('ObjectTree — record-fetch effect survives a discarded `dataConfig` memo (objectui#6700)', () => {
+  it('does not re-fire dataSource.find when `schema` gets a new reference with the SAME primitive fields', async () => {
+    const dataSource = makeDataSource();
+    const schemaA: any = {
+      type: 'object-tree',
+      objectName: 'business_unit',
+      parentField: 'parent_id',
+      labelField: 'name',
+    };
+    const schemaB: any = {
+      type: 'object-tree',
+      objectName: 'business_unit',
+      parentField: 'parent_id',
+      labelField: 'name',
+    };
+    expect(schemaA).not.toBe(schemaB);
+    expect(schemaA).toEqual(schemaB);
+
+    const { rerender } = render(<ObjectTree schema={schemaA} dataSource={dataSource} />);
+    await waitFor(() => expect(screen.getByTestId('object-tree')).toBeTruthy());
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalledTimes(1));
+
+    const findCallsAtRest = dataSource.find.mock.calls.length;
+
+    rerender(<ObjectTree schema={schemaB} dataSource={dataSource} />);
+    // Give any (incorrectly) re-triggered effect a turn of the microtask
+    // queue to actually issue its fetch before asserting it did not.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(dataSource.find.mock.calls.length).toBe(findCallsAtRest);
+  });
+
+  it('still DOES re-fire when the recomputed `dataConfig` carries a genuinely different `object`', async () => {
+    const dataSource = makeDataSource();
+    const schemaA: any = {
+      type: 'object-tree',
+      objectName: 'business_unit',
+      parentField: 'parent_id',
+      labelField: 'name',
+    };
+    const schemaB: any = {
+      type: 'object-tree',
+      objectName: 'department',
+      parentField: 'parent_id',
+      labelField: 'name',
+    };
+
+    const { rerender } = render(<ObjectTree schema={schemaA} dataSource={dataSource} />);
+    await waitFor(() =>
+      expect(dataSource.find).toHaveBeenCalledWith('business_unit', expect.any(Object)),
+    );
+    const callsBefore = dataSource.find.mock.calls.length;
+
+    rerender(<ObjectTree schema={schemaB} dataSource={dataSource} />);
+
+    await waitFor(() => expect(dataSource.find.mock.calls.length).toBeGreaterThan(callsBefore));
+    expect(dataSource.find).toHaveBeenCalledWith('department', expect.any(Object));
+  });
+});

--- a/packages/plugin-tree/src/ObjectTree.tsx
+++ b/packages/plugin-tree/src/ObjectTree.tsx
@@ -398,6 +398,30 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
     dataSource,
   );
 
+  /**
+   * The record-fetch effect below used to key on `dataConfig` itself — the
+   * whole memoised object identity. `useMemo` carries no semantic guarantee:
+   * React is permitted to discard its cache and recompute, and
+   * `getDataConfig(schema)` builds a fresh `{ provider, object }` /
+   * `{ provider, items }` wrapper object on every call even when `schema`
+   * hasn't changed. So a discard (not just a `schema` change) was enough to
+   * re-run the effect and refetch, with nothing about the bound object
+   * actually different. These are every primitive field the effect actually
+   * reads off `dataConfig`; keying on them instead of the container object
+   * makes a cache discard a no-op for it, and returns the `useMemo` above to
+   * being a pure optimisation rather than a correctness dependency —
+   * mirroring `ObjectMap`/`ObjectCalendar`/`ObjectGantt` (objectui#6592).
+   *
+   * This is the record effect #6592's branch left untouched (objectui#6700):
+   * the OTHER dataConfig-identity dependence in this component — the schema
+   * resolution effect — was already retired by #6696 in favor of
+   * `useSettledSchema`'s own primitive `schemaKey` above, so this closes out
+   * the component rather than one effect of two.
+   */
+  const dataProvider = dataConfig?.provider;
+  const dataObjectName = dataConfig?.provider === 'object' ? dataConfig.object : undefined;
+  const dataItems = dataConfig?.provider === 'value' ? dataConfig.items : undefined;
+
   // Fetch records.
   useEffect(() => {
     let cancelled = false;
@@ -412,7 +436,7 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
         // columns — which usually omit the parent field and would flatten the
         // tree. Fetching our own records (no column projection) guarantees the
         // parent field is present so the hierarchy resolves.
-        if (dataConfig?.provider === 'object' && dataSource && typeof dataSource.find === 'function') {
+        if (dataProvider === 'object' && dataSource && typeof dataSource.find === 'function') {
           // Wait for the schema before querying. `$expand` is DERIVED from it,
           // so firing early guaranteed one query whose lookup columns came back
           // as bare ids — the user saw those raw ids painted, then replaced a
@@ -421,7 +445,10 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
           // this effect re-runs the moment the latch flips.
           if (!schemaSettled) return;
           const expand = buildExpandFields(objectSchema?.fields);
-          const result = await dataSource.find(dataConfig.object, {
+          // `dataObjectName` is required on the 'object' variant of the
+          // discriminated union — same narrowing the pre-refactor
+          // `dataConfig.object` read carried.
+          const result = await dataSource.find(dataObjectName as string, {
             $filter: schema.filter,
             ...(expand.length > 0 ? { $expand: expand } : {}),
           });
@@ -442,9 +469,9 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
           return;
         }
 
-        if (dataConfig?.provider === 'value') {
+        if (dataProvider === 'value') {
           if (!cancelled) {
-            setRecords((dataConfig.items as any[]) ?? []);
+            setRecords((dataItems as any[]) ?? []);
             setLoading(false);
           }
           return;
@@ -465,7 +492,7 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [dataConfig, dataSource, schema.filter, objectSchema, schemaSettled, (rest as any).data]);
+  }, [dataProvider, dataObjectName, dataItems, dataSource, schema.filter, objectSchema, schemaSettled, (rest as any).data]);
 
   const config = useMemo(() => getTreeConfig(schema), [schema]);
   const parentField = useMemo(


### PR DESCRIPTION
Fixes #6700

## What

`packages/plugin-tree/src/ObjectTree.tsx`'s record-fetch effect closed over
`dataConfig` — a `useMemo` over the `schema` prop — as a dependency, instead
of the primitive fields it actually reads off it. This is the last
`dataConfig`-identity dependence left in the component: #6696 already
re-keyed the schema-resolution half onto `useSettledSchema`'s primitive
`schemaKey`, so this PR closes out the component (not just one effect),
completing the #6592 census for `ObjectTree`.

## Re-derived read set

Scanning the effect body directly (not the issue's suggested list, which
conflated this effect with an unrelated `headerObjectName` read at
`ObjectTree.tsx:503-504` outside this effect) — three primitives:

- `dataConfig?.provider` — gates both the `'object'` and `'value'` branches.
- `dataConfig.object` — read only inside the `provider === 'object'` branch.
- `dataConfig.items` — read only inside the `provider === 'value'` branch.

## Before / after deps

```diff
- }, [dataConfig, dataSource, schema.filter, objectSchema, schemaSettled, (rest as any).data]);
+ }, [dataProvider, dataObjectName, dataItems, dataSource, schema.filter, objectSchema, schemaSettled, (rest as any).data]);
```

with the three derived right after the `useSettledSchema` call:

```ts
const dataProvider = dataConfig?.provider;
const dataObjectName = dataConfig?.provider === 'object' ? dataConfig.object : undefined;
const dataItems = dataConfig?.provider === 'value' ? dataConfig.items : undefined;
```

Mirrors the pattern already shipped for `ObjectMap`/`ObjectCalendar`/
`ObjectGantt` (objectui#6592) — same naming, same shape.

## Discard-pin demonstration (`ObjectTree.discardedConfigMemo.test.tsx`)

Trigger: two schema object literals with identical primitive content but
different references, rerendered in place. `ObjectTree`'s own `dataConfig`
memo is `useMemo(() => getDataConfig(schema), [schema])` — keyed on the
*whole* `schema` object — so a reference swap reliably forces a recompute,
which is the same "different identity, same content" observable a genuine
`useMemo` cache discard would produce with `schema` held constant.
`useSettledSchema`'s own internal effect is keyed on the derived primitive
`schemaKey` string (not `schema`/`dataConfig`), so this swap leaves
`objectSchema`/`schemaSettled` referentially stable and can't confound the
result through that channel.

**RED-pre-fix proof** (mutation leg of the ablation below): reverted
`ObjectTree.tsx` to the pre-fix `origin/main` content, kept the new pin,
rebuilt, and ran it —

```
AssertionError: expected 2 to be 1 // Object.is equality
- 1
+ 2
 ❯ ObjectTree.discardedConfigMemo.test.tsx:77:47
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

The discard-proxy test failed (an extra `dataSource.find` call fired on the
schema-reference swap); the "still refetches for a genuinely different
object" counter-probe passed either way, as expected — that behavior
predates this fix.

## Ablation — predicted vs. observed

| Leg | Prediction | Observed |
|---|---|---|
| Revert fix, keep pin, rebuild | discard-pin RED (extra `find` call) | RED — `expected 2 to be 1` |
| Restore fix (`git checkout HEAD -- <path>`), rebuild | discard-pin GREEN | GREEN — `Tests 2 passed (2)` |

Restoration proven byte-identical: `git diff HEAD` empty, `git hash-object`
match (`94ba6dce7…` both before and after the mutation leg). Mutation
landing on disk proven by anchored `grep -c` on the pre-fix deps-array
marker (`dataConfig, dataSource, schema.filter` → 1 hit) and the post-fix
primitive marker (`dataProvider` → 0 hits) before rebuilding.

Both legs matched prediction (no direction surprise, unlike #6592's
`ObjectCalendar` trigger — verified this component's actual `[schema]`-keyed
memo forces the recompute before trusting the trigger).

## Gate table

All commands run from the repo root, exit captured by redirect-then-capture
(never after a pipe), at final commit `ee86dc339`:

| Gate | Command | Verdict |
|---|---|---|
| Build (upstream closure) | `pnpm --filter '@object-ui/plugin-tree^...' build` | exit 0 |
| Build (package) | `pnpm --filter '@object-ui/plugin-tree' build` | exit 0 |
| Type-check | `pnpm --filter '@object-ui/plugin-tree' type-check` | exit 0, no output |
| Vitest (root-level, objectui#3378) | `pnpm exec vitest run packages/plugin-tree/` | `Test Files 6 passed (6)` / `Tests 22 passed (22)` |
| `check:control-bytes` | `node scripts/check-control-bytes.mjs` | `✅ OK (scanned 5554 tracked text file(s)...)` |
| Lint (scoped, `--format json`) | `pnpm exec eslint --no-inline-config --format json <2 touched files>` | population 2 files (measured from JSON, not assumed); `errorCount 0` both files; warnings are pre-existing (`@typescript-eslint/no-explicit-any`, `react-hooks/exhaustive-deps`, `react-hooks/set-state-in-effect`) — confirmed identical rule/count set against the pre-fix source, config carries no `parserOptions.project`/`projectService` so type-aware linting is off repo-wide and this diff cannot move any untouched file's verdict |
| `check:changeset-presence` | `node scripts/check-changeset-presence.mjs` | `✅ 2 source file(s) of 1 released package(s) changed... declares 1 changeset(s)` |
| `check:changeset-no-major` | `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |
| `check:changeset-fixed` | `node scripts/check-changeset-fixed.mjs` | `✅ All workspace packages are in the changeset fixed group.` |

Changeset: `patch` on `@object-ui/plugin-tree`, per `check:changeset-presence`'s own verdict.

## Fence

`packages/plugin-tree` only. Did not touch `packages/types`, `app-shell`,
`plugin-designer` (#6527), `packages/react/src/utils/visibilityDiagnostic.ts`
(#6504), or `packages/react`'s `useSettledSchema` hook (consumed as-is).


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_