### PR TITLE
fix(react): extend the adapter-only `data.*` constant-predicate diagnostic to `disabled` / `disabledOn`

### DIFF
--- a/.changeset/6504-disabled-gate-constant-predicate.md
+++ b/.changeset/6504-disabled-gate-constant-predicate.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/react': patch
+---
+
+Extends objectui#5687's adapter-only `data.*` constant-predicate diagnostic — a node-gate
+predicate that evaluates perfectly, against the wrong object, because at the node tier
+`data` is the data-source adapter, not the row — to the `disabled` / `disabledOn` gate
+(objectui#6504, maintainer ruling 2026-08-27 option A).
+
+A node written `{ "type": "button", "disabled": "data.status == 'locked'" }` evaluates
+cleanly (no fault, so objectui#6445's fault reporter correctly stays silent), and on the
+constant's other polarity (`data.locked == null`, `!data.assignee`, or an adapter that
+answers nothing) hands the gate a constant `true` that greys the control out on every row,
+in every build, with nothing on the console. This leg now names it, in development only —
+option C (always-on) was excluded, outside the #5687 precedent.
+
+The copy is new, not reused: the visibility leg's sentence ("a constant `false` hides the
+node on every row") is written about the opposite polarity and would be false on this gate.
+The enablement leg's own sentence names the constant-`true` direction — the control renders
+DISABLED, greyed out, indistinguishable from a gate the author meant to close.
+
+Both legs carry the same dissolution pointer: this diagnostic — visibility AND enablement
+together — dissolves when objectui#5330's `data.*` deprecation window closes.
+
+Dev-only, no verdict change, no interpolation change, no published type widened (the new
+`AdapterOnlyPredicateGateKind` type and the new prefix constant are module-internal, not
+re-exported from the package entry — matching objectui#5687's own symbols, which never were
+either).

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -802,24 +802,46 @@ export const SchemaRenderer: ForwardRefExoticComponent<
      * is PRESERVED deliberately — flipping it is a shipped-behaviour change on
      * a live surface and is not this card's to make.
      *
-     * ## One engine call, both builds — no `__DEV__` split here
+     * ## One engine call, both builds — still true after objectui#6504
      *
-     * The visibility helper keeps a `__DEV__` branch because its dev leg needs
-     * a CLEANLY-evaluated verdict to run objectui#5687's adapter-only reporter
-     * on. This gate reports faults only, so `onFault` alone covers both builds:
-     * one engine call, one code path, and dev and production print the same
-     * line by construction rather than by keeping two branches in step.
+     * The FAULT report above is unconditional either way: `onFault` alone
+     * covers both builds, one engine call, one code path, dev and production
+     * print the same line by construction. objectui#6504 adds a SECOND,
+     * dev-only check after that same call returns — not a second evaluation,
+     * a lexical scan of the already-available predicate source and the
+     * already-available `dataSource` — so production keeps its one-call,
+     * one-path shape exactly as this docblock described before this leg
+     * existed; only development pays for the extra check, and only after a
+     * clean (non-faulting) evaluation.
      *
-     * objectui#5687's `reportAdapterOnlyDataPredicate` is deliberately NOT
-     * called here. Its ruling (2026-08-22, option A) is scoped to the
-     * visibility gate and its message text is written about one — "a constant
-     * `false` hides the node on every row" is not what a constant does to a
-     * `disabled` gate. Wiring it would need its own copy decision and its own
-     * ruling; filed rather than smuggled in (objectui#6504).
+     * ## objectui#5687's diagnostic, extended (objectui#6504, maintainer
+     * ruling 2026-08-27 option A)
+     *
+     * Was deliberately NOT called here — see the card this replaces filed at
+     * objectui#6504: the 2026-08-22 ruling was scoped to the visibility gate,
+     * and its message text ("a constant `false` hides the node on every row")
+     * is not what a constant does to a `disabled` gate. The 2026-08-27 ruling
+     * answers both gaps: extend to `disabled` / `disabledOn`, dev-only exactly
+     * as the visibility leg is (⛔ always-on was excluded, outside the #5687
+     * precedent), with its OWN copy — the constant-`true` direction, since on
+     * THIS gate that is the polarity that greys the control out in silence.
+     * `ADAPTER_ONLY_GATE_COPY['enablement']` (`visibilityDiagnostic.ts`) is
+     * that copy, and it carries the same #5330 dissolution pointer #5687's
+     * entry does: both legs retire together when that window closes.
+     *
+     * Reachable only on the branch where the predicate evaluated CLEANLY —
+     * `faulted` mirrors {@link evaluateVisibilityPredicate}'s try/catch split
+     * without paying for a second (`throwOnError`) engine call: `onFault` is
+     * already told exactly when the single call it wraps did not produce a
+     * clean verdict, so a local flag reuses that same signal instead of
+     * re-deriving it. A predicate that faults is the OTHER reporter's case,
+     * immediately above, in the same way it already is on the visibility leg.
      */
-    const evaluateEnablementPredicate = (raw: VisibilityPredicate, key: string): boolean =>
-      evaluator.evaluateCondition(raw, {
-        onFault: (reason) =>
+    const evaluateEnablementPredicate = (raw: VisibilityPredicate, key: string): boolean => {
+      let faulted = false;
+      const verdict = evaluator.evaluateCondition(raw, {
+        onFault: (reason) => {
+          faulted = true;
           reportUnresolvableVisibilityPredicate(
             newSchema.type,
             newSchema.id,
@@ -831,8 +853,14 @@ export const SchemaRenderer: ForwardRefExoticComponent<
             // declares, and the gate whose safe default disables the control.
             'page-component',
             'enablement',
-          ),
+          );
+        },
       });
+      if (__DEV__ && !faulted) {
+        reportAdapterOnlyDataPredicate(newSchema.type, newSchema.id, key, raw, dataSource, 'enablement');
+      }
+      return verdict;
+    };
 
     // Evaluate 'properties' — the SPEC spelling of a node's config bag, of
     // which `props` (evaluated below) is the legacy alias.

--- a/packages/react/src/__tests__/SchemaRenderer.disabledGateFaultDiagnostic.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.disabledGateFaultDiagnostic.test.tsx
@@ -64,6 +64,7 @@ import { render, screen, cleanup } from '@testing-library/react';
 import React from 'react';
 import {
   ADAPTER_ONLY_DATA_PREDICATE_PREFIX,
+  ADAPTER_ONLY_ENABLEMENT_PREDICATE_PREFIX,
   UNRESOLVABLE_ENABLEMENT_PREFIX,
   UNRESOLVABLE_VISIBILITY_PREFIX,
 } from '../utils/visibilityDiagnostic';
@@ -137,6 +138,17 @@ const reports = (warn: WarnSpy): string[] =>
 /** The sibling gate's view, for the cross-gate cases. */
 const visibilityReports = (warn: WarnSpy): string[] =>
   warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes(UNRESOLVABLE_VISIBILITY_PREFIX));
+/**
+ * The objectui#6504 leg's view — the enablement-gate extension of #5687's
+ * adapter-only constant-predicate diagnostic. A DIFFERENT fault class than
+ * `reports` above: this one names a predicate that evaluated PERFECTLY,
+ * against the wrong object, not one that could not be evaluated at all.
+ */
+const adapterOnlyReports = (warn: WarnSpy): string[] =>
+  warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes(ADAPTER_ONLY_ENABLEMENT_PREDICATE_PREFIX));
+/** The sibling (objectui#5687, visibility-gate) leg's view of the SAME diagnostic family. */
+const adapterOnlyVisibilityReports = (warn: WarnSpy): string[] =>
+  warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes(ADAPTER_ONLY_DATA_PREDICATE_PREFIX));
 /** Everything the console was asked to print, filtered by nothing. */
 const allWarnings = (warn: WarnSpy): string[] => warn.mock.calls.map((c) => String(c[0]));
 
@@ -539,28 +551,178 @@ describe('#6445 group 3 — nothing else became loud', () => {
     });
   });
 
-  it('objectui#5687 is NOT extended to this gate: an adapter-only `data.*` `disabled` predicate stays silent (filed as objectui#6504)', async () => {
-    // Deliberately out of scope. That leg reports a predicate that evaluated
-    // PERFECTLY against the wrong object — not a fault — and its ruling
-    // (2026-08-22 option A) is scoped to the visibility gate, with copy written
-    // about hiding. Pinned so the boundary is a stated decision rather than
-    // something a later reader discovers by surprise.
+  it('SUPERSEDED by objectui#6504: an adapter-only `data.*` `disabled` predicate now reports, on the enablement leg — not this fault one', async () => {
+    // Was pinned SILENT until the 2026-08-27 ruling (option A) extended
+    // objectui#5687's diagnostic to this gate. This predicate never FAULTS —
+    // it evaluates perfectly, against the wrong object — so it must never
+    // appear on THIS file's `reports()` (the #6445 fault leg); see group 6
+    // below for the positive coverage of the new leg.
     await inDevelopment((mount) => {
       const warn = spyWarn();
       mount([{ id: 'n1', disabled: "data.status == 'locked'" }]);
-      // The verdict is the documented one: a constant, here constant-false.
       expect(disabledProp()).toBe('absent');
-      // No predicate diagnostic of ANY kind: not this card's (the predicate
-      // did not fault), not objectui#5687's (not wired to this gate), not the
-      // visibility one.
       expect(reports(warn)).toHaveLength(0);
       expect(visibilityReports(warn)).toHaveLength(0);
+      // It DOES now report — on its own leg and its own prefix.
+      expect(adapterOnlyReports(warn)).toHaveLength(1);
+    });
+  });
+});
+
+/* -------------------------------------------------------------------------- *
+ * Group 6 — objectui#6504: the enablement leg of #5687's adapter-only
+ * constant-predicate diagnostic. A DIFFERENT fault class than groups 0-5
+ * above: nothing here FAULTS (the predicate evaluates perfectly, against the
+ * wrong object), so none of it belongs on `reports()` / `UNRESOLVABLE_ENABLEMENT_PREFIX`.
+ * -------------------------------------------------------------------------- */
+
+describe('#6504 group 6 — the adapter-only diagnostic, extended to `disabled` / `disabledOn`', () => {
+  it('THE acceptance criterion: the card\'s repro shape reports, dev-only, and the verdict is untouched (constant-FALSE direction)', async () => {
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([{ id: 'n1', disabled: "data.status == 'locked'" }]);
+      // Verdict UNCHANGED — `undefined == 'locked'` is `false`, so the control
+      // is NOT disabled here. This diagnostic never moves a verdict.
+      expect(disabledProp()).toBe('absent');
+      const lines = adapterOnlyReports(warn);
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain(TYPE);
+      expect(lines[0]).toContain('n1');
+      expect(lines[0]).toContain('disabled');
+      expect(lines[0]).toContain("data.status == 'locked'");
+      expect(lines[0]).toContain('data.status');
+      expect(lines[0]).toContain('CONSTANT');
+      // No fault of any kind was reported alongside it.
+      expect(reports(warn)).toHaveLength(0);
+    });
+  });
+
+  it('the DANGEROUS direction the ruling named: a constant `true` greys the control out, silently, on every row', async () => {
+    // `data.locked` is undefined on the adapter — one of the deliberate-absence
+    // idioms `unresolvedDataPaths`'s own docblock names — so `== null` is
+    // `true`: the exact "hands the gate a constant `true`" shape objectui#6504
+    // was filed about. This is the case that was previously unreported in
+    // EVERY build, with nothing on the console.
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([{ id: 'n1', disabled: 'data.locked == null' }]);
+      expect(disabledProp()).toBe('true');
+      expect(adapterOnlyReports(warn)).toHaveLength(1);
+    });
+  });
+
+  it('the copy is the constant-`true` sentence, NOT a reuse of the visibility copy', async () => {
+    // The card's whole design content. "A constant `false` hides the node" is
+    // written about a different gate and would be false here; the correct
+    // sentence for THIS gate is about a constant `true` greying it out.
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([{ id: 'n1', disabled: 'data.locked == null' }]);
+      const line = adapterOnlyReports(warn)[0];
+      expect(line).toContain('constant `true`');
+      expect(line).toContain('DISABLED');
+      expect(line).toContain('greyed out');
+      expect(line).not.toContain('hides the');
+      expect(line).not.toContain(ADAPTER_ONLY_DATA_PREDICATE_PREFIX);
+      // Still names the deprecated spelling and the fix, same as the sibling.
+      expect(line).toContain('record.status');
+      expect(line).toContain('objectui#5330');
+    });
+  });
+
+  it('and the sibling (visibility) leg still prints ITS OWN copy, unchanged — the SAME source, two gates, two different sentences', async () => {
+    // The card's other correctness requirement, restated as a same-mount
+    // control: `evaluateVisibilityPredicate`'s call site (objectui#5687,
+    // untouched by this card) and `evaluateEnablementPredicate`'s (new) fire
+    // side by side on the literal same predicate TEXT, and must not cross-talk
+    // — each keeps its own prefix and its own consequence sentence.
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([
+        { id: 'nA', visibleWhen: "data.status == 'locked'" },
+        { id: 'nB', disabled: "data.status == 'locked'" },
+      ]);
+      const visLine = adapterOnlyVisibilityReports(warn);
+      const enLine = adapterOnlyReports(warn);
+      expect(visLine).toHaveLength(1);
+      expect(enLine).toHaveLength(1);
+      expect(visLine[0]).toContain('nA');
+      expect(visLine[0]).toContain('hides the');
+      expect(visLine[0]).not.toContain('DISABLED');
+      expect(enLine[0]).toContain('nB');
+      expect(enLine[0]).toContain('DISABLED');
+      expect(enLine[0]).not.toContain('hides the');
+    });
+  });
+
+  it('FALSE-POSITIVE CONTROL: a genuinely row-dependent `record.*` predicate on `disabled` never fires this leg', async () => {
+    // The direction the ruling refuses: a diagnostic that accuses correct
+    // usage is worse than none. `record.status` is BOUND at this tier
+    // (unlike `data.*`), so this reaches opposite verdicts on the two rows —
+    // structurally incapable of being a `data.*` constant.
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([{ id: 'n1', disabled: HEALTHY_DISABLING }]);
+      expect(disabledProp()).toBe('true'); // ROW.status === 'open'
+      expect(adapterOnlyReports(warn)).toHaveLength(0);
+      expect(reports(warn)).toHaveLength(0);
+    });
+  });
+
+  it('a GENUINE adapter read on `disabled` stays silent — the half that makes the noise mean something', async () => {
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([{ id: 'n1', disabled: 'data.total > 0' }]); // ADAPTER.total === 99
+      expect(disabledProp()).toBe('true'); // a REAL verdict, from a real read
+      expect(adapterOnlyReports(warn)).toHaveLength(0);
+    });
+  });
+
+  it('`disabledOn` reports too — the same wiring as `disabled`, not a copy of it', async () => {
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([{ id: 'n1', disabledOn: "data.status == 'locked'" }]);
+      expect(adapterOnlyReports(warn)[0]).toContain('disabledOn');
+    });
+  });
+
+  it('⛔ C excluded: a PRODUCTION build reaches the SAME verdict and stays silent — this leg is dev-only, exactly as its sibling is', async () => {
+    await inProduction((mount) => {
+      const warn = spyWarn();
+      mount([{ id: 'n1', disabled: 'data.locked == null' }]);
+      // Same verdict as the dev case above — this diagnostic never moves one.
+      expect(disabledProp()).toBe('true');
+      expect(adapterOnlyReports(warn)).toHaveLength(0);
       expect(
-        allWarnings(warn).filter((m) => m.includes(ADAPTER_ONLY_DATA_PREDICATE_PREFIX)),
+        allWarnings(warn).filter((m) => m.includes(ADAPTER_ONLY_ENABLEMENT_PREDICATE_PREFIX)),
       ).toHaveLength(0);
-      // The only thing the console saw is the dev validator's pre-existing
-      // false positive on a string-valued `disabled` (objectui#6505).
-      expect(nonValidatorWarnings(warn)).toHaveLength(0);
+    });
+  });
+
+  it('COLLAPSING HALF: two nodes with different ids and the SAME source produce exactly ONE line', async () => {
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([
+        { id: 'n1', disabled: "data.status == 'locked'" },
+        { id: 'n2', disabled: "data.status == 'locked'" },
+      ]);
+      expect(adapterOnlyReports(warn)).toHaveLength(1);
+    });
+  });
+
+  it('SEPARATING HALF, across GATES: the SAME source on `disabled` and on `visibleWhen` is two lines, one per gate', async () => {
+    // `key` is part of the dedupe tuple, so the two legs of this diagnostic
+    // family cannot silence each other for the identical predicate source —
+    // the direction objectui#6445's own dedupe suite pins for the FAULT
+    // diagnostic, restated here for the adapter-only one this card adds.
+    await inDevelopment((mount) => {
+      const warn = spyWarn();
+      mount([
+        { id: 'n1', disabled: "data.status == 'locked'" },
+        { id: 'n2', visibleWhen: "data.status == 'locked'" },
+      ]);
+      expect(adapterOnlyReports(warn)).toHaveLength(1);
+      expect(adapterOnlyVisibilityReports(warn)).toHaveLength(1);
     });
   });
 });

--- a/packages/react/src/utils/visibilityDiagnostic.ts
+++ b/packages/react/src/utils/visibilityDiagnostic.ts
@@ -424,6 +424,100 @@ export const ADAPTER_ONLY_DATA_PREDICATE_PREFIX =
   '[ObjectUI] A visibility predicate resolved `data.*` against the data-source adapter';
 
 /**
+ * The `disabled` / `disabledOn` sibling of the prefix above (objectui#6504,
+ * maintainer ruling 2026-08-27 option A). Same reason
+ * {@link UNRESOLVABLE_ENABLEMENT_PREFIX} is a sibling of
+ * {@link UNRESOLVABLE_VISIBILITY_PREFIX} rather than a reuse: calling a
+ * `disabled` predicate "a visibility predicate" would send an author to the
+ * wrong gate on the first line — the one line a console filter and a `grep`
+ * both read.
+ */
+export const ADAPTER_ONLY_ENABLEMENT_PREDICATE_PREFIX =
+  '[ObjectUI] An enablement predicate resolved `data.*` against the data-source adapter';
+
+/**
+ * Which gates the objectui#5687 constant-predicate diagnostic is wired to
+ * (objectui#6504, maintainer ruling 2026-08-27 option A: extend to the
+ * enablement gate, dev-only; option C — always-on — was excluded, outside
+ * the #5687 precedent).
+ *
+ * A NARROWER union than {@link PredicateGateKind} deliberately, not an
+ * oversight: `'concealment'` (`hidden` / `hiddenOn`) is not one of them. Both
+ * of this diagnostic's call sites are unchanged by this card — the visibility
+ * one (`SchemaRenderer.tsx`'s `evaluateVisibilityPredicate`) still calls
+ * {@link reportAdapterOnlyDataPredicate} with no `gate` argument at all, for
+ * the six-leg chain exactly as objectui#5687 shipped it, so `'concealment'`
+ * was never a value this table had to answer for. Giving it an entry nobody
+ * can reach would be a decision this ruling did not make; widening this type
+ * later is a decision for whichever card makes that call, not a `??` for this
+ * table to paper over now.
+ */
+export type AdapterOnlyPredicateGateKind = Extract<PredicateGateKind, 'visibility' | 'enablement'>;
+
+/**
+ * The two parts of the message that vary with the gate, mirroring
+ * {@link GATE_KIND_COPY}'s machinery (#6445) for this SIBLING diagnostic —
+ * same discipline (indexed without a `??` fallback; the default lives on the
+ * parameter), a separate table because the message TEMPLATE differs (this one
+ * carries an "Undefined on the adapter:" line and no {@link SCOPE_TIER_ADVICE}
+ * tail; see {@link formatAdapterOnlyDataMessage}).
+ *
+ * ⛔⛔ BINDING INHERITANCE CLAUSE (2026-08-27 ruling, objectui#6504, verbatim
+ * from the card thread): "the extension inherits #5687's dissolution note
+ * verbatim — when #5330's deprecation window closes, both legs dissolve
+ * together; the new copy entry must carry the same pointer so the teardown
+ * finds it." The pointer, carried from this module's own docblock (see
+ * {@link unresolvedDataPaths}'s "why this discriminator" section): objectui#5687
+ * is "a diagnostic on a card that dissolves when objectui#5330's deprecation
+ * window closes." BOTH entries below dissolve on that same clock, together —
+ * this is not an independently-scheduled diagnostic. When that window closes,
+ * delete this table, {@link ADAPTER_ONLY_ENABLEMENT_PREDICATE_PREFIX},
+ * {@link ADAPTER_ONLY_DATA_PREDICATE_PREFIX}, {@link unresolvedDataPaths},
+ * {@link formatAdapterOnlyDataMessage} and {@link reportAdapterOnlyDataPredicate}
+ * in this file, and BOTH call sites in `SchemaRenderer.tsx`
+ * (`evaluateVisibilityPredicate` and `evaluateEnablementPredicate`), in the
+ * same stroke.
+ */
+const ADAPTER_ONLY_GATE_COPY: Record<AdapterOnlyPredicateGateKind, { prefix: string; consequence: string }> = {
+  visibility: {
+    prefix: ADAPTER_ONLY_DATA_PREDICATE_PREFIX,
+    consequence:
+      'At the node tier `data` is the DATA-SOURCE ADAPTER - the object\n' +
+      '`${data.total}` in a props bag reads - and it is NOT the row. The reads\n' +
+      'above are undefined on it, so this predicate is a CONSTANT: it does not\n' +
+      'depend on the row at all, and on this surface a constant `false` hides the\n' +
+      'node on every row while looking exactly like a gate that said no.\n' +
+      'Write the row as `record.*` (e.g. `record.status`), which page-component\n' +
+      'predicates bind alongside `current_user` and page state as `page.<var>`.\n' +
+      '`data.*` as a spelling for the row is deprecated (objectui#5330) and was\n' +
+      'never bound to the row on this tier.',
+  },
+  // The constant-`true` direction, not a reuse of the sentence above: on THIS
+  // gate the fail-soft default that BITES is `true` (a control that greys
+  // out), the mirror image of the negated visibility legs where it is
+  // `false` (a node that hides). Written to describe that direction, since it
+  // is the one that leaves nothing on screen for an author to notice —
+  // "greyed out" looks exactly like a gate that closed on purpose, the same
+  // way "not on screen" looks exactly like a gate that hid on purpose.
+  enablement: {
+    prefix: ADAPTER_ONLY_ENABLEMENT_PREDICATE_PREFIX,
+    consequence:
+      'At the node tier `data` is the DATA-SOURCE ADAPTER - the object\n' +
+      '`${data.total}` in a props bag reads - and it is NOT the row. The reads\n' +
+      'above are undefined on it, so this predicate is a CONSTANT: it does not\n' +
+      'depend on the row at all, and on THIS gate the dangerous polarity is a\n' +
+      'constant `true`: the node renders DISABLED - on screen, greyed out,\n' +
+      'refusing input - on every row, in every build, while looking exactly\n' +
+      'like a gate that said no. No pixel says the predicate is a constant, so\n' +
+      'this line is the only thing that will ever name it.\n' +
+      'Write the row as `record.*` (e.g. `record.status`), which page-component\n' +
+      'predicates bind alongside `current_user` and page state as `page.<var>`.\n' +
+      '`data.*` as a spelling for the row is deprecated (objectui#5330) and was\n' +
+      'never bound to the row on this tier.',
+  },
+};
+
+/**
  * Strip string literals before scanning for `data.*` reads.
  *
  * The scan below is LEXICAL, not a parse — it reads the predicate's source
@@ -473,7 +567,9 @@ const DATA_ROOT_PATH_RE =
  *   * "the comparison OPERAND is undefined" — the most precise reading, and it
  *     needs the expression engine to expose its operands. That is a change to
  *     `@object-ui/core`'s evaluator for a diagnostic on a card that dissolves
- *     when objectui#5330's deprecation window closes.
+ *     when objectui#5330's deprecation window closes — BOTH legs together,
+ *     the enablement one objectui#6504 added included; see
+ *     {@link ADAPTER_ONLY_GATE_COPY}'s binding inheritance clause.
  *   * "a `data.*` read the bound object does not answer" — this one. On the
  *     card's repro (`data.status` against the adapter) it fires; on
  *     `${data.total}` against `{ total: 99 }` it does not; and it is
@@ -517,29 +613,33 @@ function unresolvedDataPaths(source: string, boundData: unknown): string[] {
   return out;
 }
 
-/** Built separately from the emit, for the same reason as the message above. */
+/**
+ * Built separately from the emit, for the same reason as the message above.
+ *
+ * `gate` defaults to `'visibility'` so the historical four-argument call
+ * (objectui#5687) keeps printing the exact bytes it printed before —
+ * objectui#6504's own call site in `evaluateVisibilityPredicate`
+ * (`SchemaRenderer.tsx`) is one of those unchanged callers, passing no `gate`
+ * at all. `evaluateEnablementPredicate` is the one caller that states
+ * `'enablement'` explicitly, matching {@link formatUnresolvableVisibilityMessage}'s
+ * own compatibility-default pattern.
+ */
 export function formatAdapterOnlyDataMessage(
   type: unknown,
   id: unknown,
   key: string,
   raw: unknown,
   unresolved: string[],
+  gate: AdapterOnlyPredicateGateKind = 'visibility',
 ): string {
   const node = typeof type === 'string' && type ? '"' + type + '"' : '(untyped node)';
   const where = typeof id === 'string' && id ? ' (id: "' + id + '")' : '';
+  const copy = ADAPTER_ONLY_GATE_COPY[gate];
   return (
-    ADAPTER_ONLY_DATA_PREDICATE_PREFIX + ' - node ' + node + where + '\n' +
+    copy.prefix + ' - node ' + node + where + '\n' +
     '  ' + key + ': ' + JSON.stringify(predicateSourceText(raw)) + '\n' +
     '  Undefined on the adapter: ' + unresolved.join(', ') + '\n' +
-    'At the node tier `data` is the DATA-SOURCE ADAPTER - the object\n' +
-    '`${data.total}` in a props bag reads - and it is NOT the row. The reads\n' +
-    'above are undefined on it, so this predicate is a CONSTANT: it does not\n' +
-    'depend on the row at all, and on this surface a constant `false` hides the\n' +
-    'node on every row while looking exactly like a gate that said no.\n' +
-    'Write the row as `record.*` (e.g. `record.status`), which page-component\n' +
-    'predicates bind alongside `current_user` and page state as `page.<var>`.\n' +
-    '`data.*` as a spelling for the row is deprecated (objectui#5330) and was\n' +
-    'never bound to the row on this tier.'
+    copy.consequence
   );
 }
 
@@ -574,6 +674,22 @@ export function formatAdapterOnlyDataMessage(
  * key is tagged with this leg's name so the two diagnostics cannot silence each
  * other for the same (type, key, source) triple — they are different faults,
  * and a node that faults one way is not evidence about the other.
+ *
+ * ## `gate` (objectui#6504) — NOT in the dedupe key, for the reason
+ * {@link reportUnresolvableVisibilityPredicate}'s own docblock gives for the
+ * same omission
+ *
+ * `gate` is a FUNCTION of `key`: the enablement gate is exactly `disabled` /
+ * `disabledOn` and the visibility gate this leg is called for is the six-leg
+ * chain, two disjoint sets. Adding it to the dedupe key could not separate two
+ * entries `key` does not already separate — and the cross-gate direction is
+ * the one that would matter if it could: the SAME predicate source authored on
+ * `disabled` and on (say) `visibleWhen` must produce TWO lines, which it does
+ * today because `key` differs, with or without `gate` in the tuple.
+ *
+ * Defaults to `'visibility'` — the objectui#5687 call site
+ * (`evaluateVisibilityPredicate`) is unchanged by this card and still calls
+ * this function with five arguments.
  */
 export function reportAdapterOnlyDataPredicate(
   type: unknown,
@@ -581,6 +697,7 @@ export function reportAdapterOnlyDataPredicate(
   key: string,
   raw: unknown,
   boundData: unknown,
+  gate: AdapterOnlyPredicateGateKind = 'visibility',
 ): void {
   const source = predicateSourceText(raw);
   // Fast reject: the overwhelming majority of predicates never mention `data.`
@@ -594,5 +711,5 @@ export function reportAdapterOnlyDataPredicate(
   const dedupeKey = JSON.stringify(['adapter-only-data', type, key, source]);
   if (_warnedVisibilityPredicates.has(dedupeKey)) return;
   _warnedVisibilityPredicates.add(dedupeKey);
-  console.warn(formatAdapterOnlyDataMessage(type, id, key, raw, unresolved));
+  console.warn(formatAdapterOnlyDataMessage(type, id, key, raw, unresolved, gate));
 }


### PR DESCRIPTION
Fixes #6504

## What

Extends objectui#5687's adapter-only `data.*` constant-predicate diagnostic to the
`disabled` / `disabledOn` gate — dev-only, per the 2026-08-27 maintainer ruling (Option A)
recorded on this issue.

`reportAdapterOnlyDataPredicate` names a predicate that evaluates perfectly, against the
wrong object: at the node tier `data` is the data-source adapter, not the row, so
`data.status == 'locked'` is a constant for every row. It was wired only into the
visibility chain's dev leg (`evaluateVisibilityPredicate`). A `disabled` predicate written
the same way faults nothing (#6445's fault reporter correctly stays silent), and on the
constant's other polarity (`data.locked == null`, `!data.assignee`, or an adapter answering
nothing) hands the gate a constant `true` that greys the control out on every row, in every
build, with nothing on the console. `evaluateEnablementPredicate` now reports it too, in
development only — option C (always-on) stays excluded, outside the #5687 precedent.

## The copy, and why its direction differs from the visibility leg

The visibility leg's sentence — *"a constant `false` hides the node on every row while
looking exactly like a gate that said no"* — is about the wrong polarity for this gate and
would be a false statement here. The ruling named the direction explicitly: on `disabled`,
the dangerous constant is `true`. The new `enablement` entry in `ADAPTER_ONLY_GATE_COPY`
(`packages/react/src/utils/visibilityDiagnostic.ts`) reads:

> ...and on THIS gate the dangerous polarity is a constant `true`: the node renders
> DISABLED - on screen, greyed out, refusing input - on every row, in every build, while
> looking exactly like a gate that said no. No pixel says the predicate is a constant, so
> this line is the only thing that will ever name it.

It is not a reuse of the visibility sentence — the two are pinned as distinct strings, and
one new group-4-style test in `SchemaRenderer.disabledGateFaultDiagnostic.test.tsx` asserts
the enablement line does not contain `hides the` and the visibility line does not contain
`DISABLED`.

## Where the dissolution pointer lives, and its verbatim source

Both #5687's own docblock and the new binding-inheritance clause are carried forward:
`unresolvedDataPaths`'s "why this discriminator" section already reads (verbatim, unchanged
by this PR): *"a diagnostic on a card that dissolves when objectui#5330's deprecation
window closes."* This PR appends a clause at that exact spot — *"BOTH legs together, the
enablement one objectui#6504 added included"* — and adds a new docblock on
`ADAPTER_ONLY_GATE_COPY` itself that quotes the 2026-08-27 ruling's binding clause verbatim
and names every symbol + both call sites (`evaluateVisibilityPredicate` and
`evaluateEnablementPredicate` in `SchemaRenderer.tsx`) a #5330-window teardown has to delete
in the same stroke. Neither leg is independently scheduled.

Per the stop condition: **#5330's deprecation window is not closing near-term** — measured,
not assumed. Its Phase 2 carrier (#5741, the stored-metadata survey that gates removal) is
still open, `pm:awaiting-maintainer`, unassigned, blocked on a live-tenant data channel no
seat currently has. Proceeding per the ruling.

## Ablation — both legs predicted before running, mutation/restoration proven on disk

**Leg 1 — the new leg must produce the diagnostic, with the correct copy (`evaluateEnablementPredicate`'s new call site removed).**
Predicted: every new group-6 test that asserts a *report* turns red; every silence/negative
control stays green. Observed: **exactly as predicted** — 8/8 red (the acceptance
criterion, the constant-`true` direction, the copy-is-not-reused assertion, the
cross-gate content check, `disabledOn`, the two dedupe cases, and the pre-existing test this
PR rewrote from a negative to a positive pin), 24/24 other cases (including every
false-positive/negative control) stayed green. Mutation confirmed on disk (call-site grep
count 1→0, blob hash changed); restore confirmed (`git diff HEAD` empty, hash back to
`57c0beb3f…`).

**Leg 2 — false-positive direction (a genuinely row-dependent predicate must not fire it).**
Mutated the *shared* discriminator regex (`DATA_ROOT_PATH_RE`, unchanged by this PR's actual
diff) to also treat `record` as a matched root, to probe whether the shared false-positive
protection this leg inherits (rather than reimplements) is real. **Prediction missed, and
reported as observed rather than forced**: I predicted the new `FALSE-POSITIVE CONTROL`
test (`disabled: "record.status == 'open'"`) and `nodeGateDataPredicate.test.tsx`'s `3a`
would flip; neither did — both stay silent behind an *independent* guard
(`source.indexOf('data.') === -1` fast-reject: neither predicate string contains the
literal substring `data.` at all, so the mutated regex is never reached). What **did** flip
were two *pre-existing*, unrelated pins in `nodeGateDataPredicate.test.tsx` — `2d`
(a quoted `'data.status'` literal) and `3d` (`record.data.status`, whose `.` before `data`
the original regex's exclusion group is specifically built to reject) — both already-hardened
false-positive guards this card didn't write, doing their job against a hostile version of
code this card also didn't write. Net: this leg adds no new discriminator logic (no new
regex, no new resolution algorithm), only a second call into the existing, shared,
already-tested function with a `gate` label — so its false-positive resistance is by
construction identical to the visibility leg's, not a new surface to separately harden.
Mutation confirmed on disk (marker count 0→1, hash changed); restore confirmed (`git diff
HEAD` empty, hash back to `40e466e7d…`).

**Leg 3 — the visibility leg is unchanged.** `evaluateVisibilityPredicate`'s call site
(line ~772 in `SchemaRenderer.tsx`) is untouched — no `gate` argument added, still defaults
to `'visibility'`. `SchemaRenderer.nodeGateDataPredicate.test.tsx` (40 tests, the full
#5687/#5756 suite) and `SchemaRenderer.concealmentGateFaultDiagnostic.test.tsx` pass
unmodified, byte-identical to `origin/main`. Leg 1's mutation (which only touched the
enablement call site) independently confirms zero effect on any visibility-leg test.

## Gate table

| Gate | Command | Result |
|---|---|---|
| Build dependency closure | `pnpm --filter '@object-ui/react^...' build` | `types`/`core`/`data-objectstack`/`i18n` all `Done` |
| Type-check | `pnpm --filter '@object-ui/react' run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0, no output (clean) |
| Vitest, `disabledGateFaultDiagnostic.test.tsx` | `pnpm exec vitest run packages/react/src/__tests__/SchemaRenderer.disabledGateFaultDiagnostic.test.tsx` | `Test Files 1 passed (1)` / `Tests 32 passed (32)` |
| Vitest, sibling diagnostics (unchanged) | `pnpm exec vitest run packages/react/src/__tests__/SchemaRenderer.nodeGateDataPredicate.test.tsx packages/react/src/__tests__/SchemaRenderer.concealmentGateFaultDiagnostic.test.tsx` | `Test Files 2 passed (2)` / `Tests 40 passed (40)` |
| Vitest, full package (root-level invocation, objectui#3378) | `pnpm exec vitest run packages/react/` | `Test Files 62 passed (62)` / `Tests 926 passed (926)` — re-run after ablation restore, identical |
| `check:control-bytes` | `node scripts/check-control-bytes.mjs` | `✅ OK (scanned 5553 tracked text file(s); skipped 85 binary)` |
| Changeset presence | `node scripts/check-changeset-presence.mjs` | `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| Changeset no-major | `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump` |
| Lint (narrowed, justified) | `pnpm exec eslint --no-inline-config --format json <3 touched files>` | 3 files linted (json count), 0 errors, 18 pre-existing `no-explicit-any` warnings on `SchemaRenderer.tsx` (none on touched lines — verified against the same file's content at `origin/main`'s `9abc02ab2` via `--stdin`, also 0 errors/18 warnings, byte-identical count) |

Lint narrowing justification (repo has no type-aware linting configured — no `project` /
`projectService` in `eslint.config.js` — so this diff cannot move any judgment on an
untouched file): file count is eslint's own `--format json` output (3), not a guess; the
config's rule set is untyped, so the invariance claim is structural, not assumed.

Union re-run: `20c52cedf` (branch head, pushed) — the commit these results are quoted
against.

## Fence

Touched only `packages/react/src/utils/visibilityDiagnostic.ts`,
`packages/react/src/SchemaRenderer.tsx` (the `evaluateEnablementPredicate` call site the
existing docblock there explicitly anticipated this card would fill in), and one test file.
Did not reach `packages/types`' `exports` map, `app-shell`, or `plugin-designer` — no
overlap with #6527's in-flight patch round.

No published type widened: `AdapterOnlyPredicateGateKind` and
`ADAPTER_ONLY_ENABLEMENT_PREDICATE_PREFIX` are module-internal exports (not re-exported from
`packages/react/src/index.ts`), matching #5687's own `ADAPTER_ONLY_DATA_PREDICATE_PREFIX` /
`formatAdapterOnlyDataMessage` / `reportAdapterOnlyDataPredicate`, none of which are on the
package's public barrel either. No runtime behaviour change outside `__DEV__`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_