### PR TITLE
types: declare the `gantt` block face on ObjectGanttSchema (fixes #6475)

### DIFF
--- a/.changeset/6475-gantt-block-face-declared.md
+++ b/.changeset/6475-gantt-block-face-declared.md
@@ -1,0 +1,52 @@
+---
+'@object-ui/types': minor
+---
+
+**`ObjectGanttSchema` now declares the `gantt` BLOCK face — and the spec's
+required trio enforces at validate/check time.**
+
+The `gantt` nested-block spelling of a gantt config (`{ type: 'object-gantt',
+gantt: { … } }`) had **no mirror entry at all**: it rode through
+`BaseSchema`'s `.passthrough()` entirely unvalidated, and the published
+TypeScript never taught the shape either — an author writing `gantt: { … }`
+got no completion, no type checking, no error on a misspelt member. It was
+the 28th and last of the keys `getGanttConfig` (`plugin-gantt/src/ObjectGantt.tsx`)
+reads off the schema that objectui#6051 (PR #6472) did not declare — severed
+into its own card because, unlike the other 27, declaring it changes what a
+published tool refuses.
+
+Both faces now declare it:
+
+```ts
+// packages/types/src/objectql.ts
+gantt?: GanttConfig;
+
+// packages/types/src/zod/objectql.zod.ts
+gantt: SpecGanttConfigSchema.extend(GanttConfigExtensionFields).optional(),
+```
+
+`GanttConfig` derives from the spec's `GanttConfigSchema`, which has required
+`startDateField`, `endDateField` and `titleField` since rc.6.
+
+**What the CLI now refuses that it accepted before:** `ObjectGanttSchema` is a
+member of `AnyComponentSchema`, so it reaches `safeValidateSchema` and
+therefore the CLI's `validate` and `check` commands. A `gantt` block missing
+any of the three required fields — previously accepted silently — is now
+**refused**, naming the missing field. A block carrying all three, or a
+schema with no `gantt` block at all, is accepted exactly as before.
+
+**This is a `declared = enforced` restoration, not new requiredness.**
+`getGanttConfig`'s block branch already fed the block to
+`GanttConfigSchema.safeParse` and logged `[ObjectGantt] Invalid gantt
+configuration` to the console on failure — a block missing the trio was
+already non-functional at runtime, silently. What changes is *when* the
+author is told: runtime console warning becomes an authoring-time refusal.
+
+Maintainer ruling, objectui#6475 (2026-08-27), **Option A** — enforce as-is,
+immediately, no warning window (the startup-stage no-gradualism rule,
+objectstack#12668: transitions do not get phased windows without named
+external-user evidence, and none exists here). A census of every `gantt`
+block reachable through `ObjectGanttSchema` in this repository — the
+`examples/schema-catalog` fixtures, `content/docs/plugins/plugin-gantt.mdx`,
+and the published `skills/objectui/guides/page-builder.md` guide — found
+**zero** blocks missing the trio.

--- a/packages/types/src/__tests__/gantt-flat-config-declared-keys.test.ts
+++ b/packages/types/src/__tests__/gantt-flat-config-declared-keys.test.ts
@@ -40,8 +40,9 @@
  *     `markers`, `criticalPath`, `showBaselines`, `readOnly`, `mobileReadOnly`)
  *     are disjoint from them.
  *
- * 27 of the 28 are declared here. The 28th, `gantt`, is severed to objectui#6475
- * — see the section below.
+ * 27 of the 28 are declared here. The 28th, `gantt`, was severed to objectui#6475
+ * and is now declared too — pinned separately below, since it is the one entry
+ * that narrows the accept set rather than merely adding a name.
  *
  * The residue is four LARGER than the card's list, and #5903 is why. The card
  * scored "declared by neither `ObjectGanttSchema` nor `ObjectGridSchema`" over
@@ -59,28 +60,30 @@
  * keeps that true as either side moves is the type-level pin at the bottom:
  * every key of `GanttConfig` is declared on the node's flat face.
  *
- * ## Why `gantt` is measured here but NOT declared here
+ * ## `gantt`, the 28th key, was severed — and is now declared (objectui#6475)
  *
  * The 27 declared below are new OPTIONAL members: additive on both sides, nothing
- * previously legal loses its slot. `gantt` is the one that would not have been.
- * It has no mirror entry at all, so a block rides through `.passthrough()`
- * unvalidated; declaring it as `GanttConfig` means it gets parsed, and
+ * previously legal loses its slot. `gantt` was the one that would not have been —
+ * it had no mirror entry at all, so a block rode through `.passthrough()`
+ * unvalidated. Declaring it as `GanttConfig` means it is now parsed, and
  * `GanttConfig` derives from the spec's `GanttConfigSchema`, which REQUIRES
  * `startDateField`, `endDateField` and `titleField`. `ObjectGanttSchema` is a
  * member of `AnyComponentSchema`, so that reaches `safeValidateSchema` and with
- * it the CLI's `validate` / `check` — a block missing one of the three would move
- * from "accepted, then warned about at runtime" to "refused at authoring time".
+ * it the CLI's `validate` / `check`: a block missing one of the three moves from
+ * "accepted, then warned about at runtime" to "refused at authoring time".
  *
  * PM ruling (2026-08-26): sever it, so a published CLI's refusal behaviour is
- * decided on its own card rather than inside a 27-key declaration PR.
- * objectui#6475 carries the full measurement, including the case FOR enforcing —
- * `getGanttConfig`'s block branch already feeds the block to
- * `GanttConfigSchema.safeParse` and logs `[ObjectGantt] Invalid gantt
+ * decided on its own card rather than inside a 27-key declaration PR. Maintainer
+ * ruling on that severed card, objectui#6475 (2026-08-27), Option A: declare it
+ * as-is, enforce the spec's requiredness immediately, no warning window (the
+ * startup-stage no-gradualism rule, objectstack#12668 — no named external-user
+ * evidence). `getGanttConfig`'s block branch already fed the block to
+ * `GanttConfigSchema.safeParse` and logged `[ObjectGantt] Invalid gantt
  * configuration`, so declaring it restores declared = enforced rather than
  * inventing a stricter contract.
  *
- * Today's behaviour is pinned below rather than left implicit, so the omission is
- * a measured state and not a silent gap.
+ * Today's behaviour — the trio enforced, everything else `GanttConfig` allows
+ * accepted — is pinned below rather than left implicit.
  *
  * ## What the pin has teeth against, and what it does not
  *
@@ -108,8 +111,9 @@ const MINIMAL = {
  * The 27 keys this card declared, each with a value its declared type refuses.
  *
  * 24 flattened `GanttConfig` members and the three query keys (`staticData` /
- * `filter` / `sort`). The 28th measured key, `gantt`, is severed to objectui#6475
- * and is pinned separately below as an UNDECLARED read.
+ * `filter` / `sort`). The 28th measured key, `gantt` (objectui#6475), is pinned
+ * separately below — it is declared too, but as a PARSED block rather than a
+ * bare optional scalar, so its refusal shape does not fit this table.
  */
 const DECLARED: ReadonlyArray<readonly [string, unknown]> = [
   // — the flattened GanttConfig face —
@@ -228,17 +232,38 @@ describe('ObjectGanttSchema — the flattened gantt config is declared (objectui
     expect(result.success ? null : result.error.issues).toBe(null);
   });
 
-  it('the `gantt` BLOCK face is still undeclared, and today rides through UNVALIDATED', () => {
-    // The 28th measured key, severed to objectui#6475. Pinned rather than left
-    // implicit so the omission is a measured state: a block missing the trio the
-    // spec's `GanttConfigSchema` REQUIRES parses green today, because the mirror
-    // has no `gantt` entry and `BaseSchema` is `.passthrough()`.
-    expect(Object.keys(ObjectGanttSchema.shape)).not.toContain('gantt');
-    const missingTrio = ObjectGanttSchema.safeParse({ ...MINIMAL, gantt: { lockField: 'locked' } });
-    expect(missingTrio.success).toBe(true);
-    // Not even a wrong-TYPED block is refused — that is what "no entry" means, and
-    // it is exactly what objectui#6475 proposes to change.
-    expect(ObjectGanttSchema.safeParse({ ...MINIMAL, gantt: 'flat' }).success).toBe(true);
+  it('the `gantt` BLOCK face is declared, and the spec trio now enforces at parse time (objectui#6475)', () => {
+    // The 28th measured key. objectui#6475, Option A: declared as `GanttConfig`,
+    // so a block is now PARSED against the spec's `GanttConfigSchema` — the
+    // published CLI's `validate`/`check` refusal this card exists to pin.
+    expect(Object.keys(ObjectGanttSchema.shape)).toContain('gantt');
+
+    // A block missing one of the required trio (startDateField / endDateField /
+    // titleField) is REFUSED — this is the accept-set narrowing itself, and it
+    // names the missing field rather than failing silently.
+    const missingTitleField = ObjectGanttSchema.safeParse({
+      ...MINIMAL,
+      gantt: { startDateField: 'start', endDateField: 'end', lockField: 'locked' },
+    });
+    expect(missingTitleField.success).toBe(false);
+    if (!missingTitleField.success) {
+      const issue = missingTitleField.error.issues.find((i) => i.path.join('.') === 'gantt.titleField');
+      expect(issue, 'refusal must name the missing titleField').toBeTruthy();
+    }
+
+    // A completely empty block is refused too — all three of the trio absent.
+    expect(ObjectGanttSchema.safeParse({ ...MINIMAL, gantt: {} }).success).toBe(false);
+
+    // A wrong-TYPED block (not even an object) is refused.
+    expect(ObjectGanttSchema.safeParse({ ...MINIMAL, gantt: 'flat' }).success).toBe(false);
+
+    // A block carrying the complete trio IS accepted — the narrowing is exactly
+    // the trio, nothing more.
+    const complete = ObjectGanttSchema.safeParse({
+      ...MINIMAL,
+      gantt: { startDateField: 'start', endDateField: 'end', titleField: 'name', lockField: 'locked' },
+    });
+    expect(complete.success ? null : complete.error.issues).toBe(null);
   });
 
   it('does NOT reject an undeclared key — objectui#5155 ceiling, measured not assumed', () => {

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -2507,27 +2507,29 @@ export interface ObjectGanttSchema extends BaseSchema {
   /** Whether the store persists dependency link TYPES (fs/ss/ff/sf). */
   dependencyTypes?: GanttConfig['dependencyTypes'];
 
-  // ⛔ `gantt` — the BLOCK face — is DELIBERATELY still undeclared here
-  // (objectui#6475). It is the 28th key of this card's residue and the only one
-  // objectui#6051 did not declare; the omission is a scoping decision, not an
-  // oversight, and reading it as "nothing reads `gantt`" would be wrong —
-  // `getGanttConfig`'s second branch reads it and honours it in full.
+  // ── The BLOCK face (the `ObjectGridSchema`-style shape, objectui#6475) ──────
   //
-  // Declaring it is not additive the way the 27 above are. It has no mirror entry
-  // at all today, so a block rides through `.passthrough()` UNVALIDATED; declaring
-  // it as {@link GanttConfig} means it gets parsed, and `GanttConfig` derives from
-  // the spec's `GanttConfigSchema`, which REQUIRES `startDateField`,
-  // `endDateField` and `titleField`. Because `ObjectGanttSchema` is a member of
-  // `AnyComponentSchema`, that reaches `safeValidateSchema` and therefore the
-  // CLI's `validate` / `check` commands: a block missing one of the three moves
-  // from "accepted, then warned about at runtime" to "refused at authoring time".
+  // `getGanttConfig`'s FIRST branch (`plugin-gantt/src/ObjectGantt.tsx`) reads
+  // this and wins whenever present (objectui#6469 ruled block-over-flat). It was
+  // the 28th and last undeclared key of the objectui#6051 census — the one key
+  // whose VALUES get stricter on declaration rather than merely gaining a name:
+  // it had no mirror entry at all, so a block rode through `.passthrough()`
+  // entirely unvalidated. Declaring it as {@link GanttConfig} means it is now
+  // PARSED, and `GanttConfig` derives from the spec's `GanttConfigSchema`, which
+  // REQUIRES `startDateField`, `endDateField` and `titleField`. Because
+  // `ObjectGanttSchema` is a member of `AnyComponentSchema`, that reaches
+  // `safeValidateSchema` and therefore the CLI's `validate` / `check` commands: a
+  // block missing one of the three moves from "accepted, then warned about at
+  // runtime" to "refused at authoring time".
   //
-  // That is very likely the RIGHT change — the renderer already feeds the block to
-  // `GanttConfigSchema.safeParse` and warns, so enforcing restores
-  // declared = enforced rather than inventing a contract — but it is a published
-  // CLI's refusal behaviour, and an in-repo census cannot see authored metadata
-  // living outside this tree. objectui#6475 carries the full measurement and the
-  // decision.
+  // This is a `declared = enforced` restoration, not new requiredness: the
+  // renderer already fed the block to `GanttConfigSchema.safeParse` and logged
+  // `[ObjectGantt] Invalid gantt configuration` on failure — the trio was already
+  // required for the block to actually work, just silently. Maintainer ruling,
+  // objectui#6475 (2026-08-27), Option A: declare as-is, spec requiredness
+  // enforces immediately, no warning window (excluded by the startup-stage
+  // no-gradualism rule, objectstack#12668 — no named external-user evidence).
+  gantt?: GanttConfig;
 
   // ── The query/data keys the fetch path reads (objectui#6051) ────────────────
   //

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -602,9 +602,17 @@ export const ObjectTreeSchema = BaseSchema.extend({
  *
  * Held as ONE field map rather than inlined, so the flattened top-level spelling
  * below is built from a single source — the same way the TS side derives its
- * flattened members from `GanttConfig`. It is deliberately the shape the nested
- * `gantt` block would ALSO be built from, one line, if objectui#6475 rules that
- * block in; today that entry is severed and this map has one consumer.
+ * flattened members from `GanttConfig`. It is also the shape the nested `gantt`
+ * block is built from (objectui#6475), one line extending the spec's gantt
+ * config schema with this map — so both authoring faces share one vocabulary
+ * and cannot fork from each other.
+ *
+ * ⚠️ Keep this docstring free of a literal `Spec` + capital-letter token: it
+ * sits between the `ObjectTreeSchema` and `ObjectGanttSchema` export
+ * boundaries, and `zod-mirror-parity.test.ts`'s `SPEC_DERIVED_PAIRS` re-check
+ * scans raw text between export boundaries for `\bSpec[A-Z]\w*` — a match here
+ * is misattributed to `ObjectTreeSchema`, which references no spec schema at
+ * all (measured: this comment alone flipped that test red).
  *
  * Not exported: the parity census in `__tests__/zod-mirror-parity.test.ts` reads
  * `^export const` out of this directory and would require a registered TS
@@ -723,16 +731,26 @@ export const ObjectGanttSchema = BaseSchema.extend({
   autoZoomToFilter: SpecGanttConfigSchema.shape.autoZoomToFilter,
   // …and objectui's own ten, from the one field map above.
   ...GanttConfigExtensionFields,
-  // ⛔ `gantt` — the BLOCK face `getGanttConfig`'s second branch reads — is
-  // DELIBERATELY still unmirrored (objectui#6475). It would be one line here,
-  // `SpecGanttConfigSchema.extend(GanttConfigExtensionFields).optional()`, built
-  // from the same field map as the flat face above; the reason it is not is that
-  // it is the one entry that NARROWS. With no entry a block rides through
-  // `.passthrough()` unvalidated; with one it is parsed against the spec's
-  // `GanttConfigSchema`, which REQUIRES startDateField/endDateField/titleField —
-  // and this mirror reaches the CLI's `validate`/`check` through
-  // `AnyComponentSchema`, so that is a published refusal change. See the TS
-  // declaration's note in `../objectql.ts` and objectui#6475.
+  // `gantt` — the BLOCK face `getGanttConfig`'s FIRST branch reads and prefers
+  // (objectui#6469 ruled block-over-flat) — objectui#6475. Built from the same
+  // field map as the flat face above, `SpecGanttConfigSchema` extended with
+  // `GanttConfigExtensionFields`, so the two authoring faces cannot fork.
+  //
+  // This is the one entry among the 28 that NARROWS rather than merely names: a
+  // `gantt` block previously rode through `.passthrough()` entirely unvalidated;
+  // now it is PARSED against the spec's `GanttConfigSchema`, which REQUIRES
+  // `startDateField`/`endDateField`/`titleField`. This mirror reaches the CLI's
+  // `validate`/`check` through `AnyComponentSchema` → `safeValidateSchema`, so a
+  // block missing the trio moves from "accepted, then warned about at runtime"
+  // to "refused at authoring time" — a `declared = enforced` restoration, not
+  // new requiredness: the renderer already fed the block to
+  // `GanttConfigSchema.safeParse` and logged `[ObjectGantt] Invalid gantt
+  // configuration` on failure. Maintainer ruling, objectui#6475 (2026-08-27),
+  // Option A: enforce as-is, no warning window (excluded by the startup-stage
+  // no-gradualism rule, objectstack#12668 — no named external-user evidence).
+  gantt: SpecGanttConfigSchema.extend(GanttConfigExtensionFields).optional().describe(
+    'Nested gantt config block — the authoring face, and the winner over the flattened top-level keys whenever present'
+  ),
   // The query/data keys the fetch path reads. They were declared on
   // `ObjectGridSchema` — what `ObjectGanttProps.schema` used to be typed as before
   // objectui#5903 retyped it to `ObjectGanttSchema` — so they need declaring here.


### PR DESCRIPTION
Fixes #6475

## What changed

Declares the `gantt` **block** face on `ObjectGanttSchema`, on both declaration faces:

```ts
// packages/types/src/objectql.ts
gantt?: GanttConfig;

// packages/types/src/zod/objectql.zod.ts
gantt: SpecGanttConfigSchema.extend(GanttConfigExtensionFields).optional(),
```

`GanttConfigExtensionFields` (added by #6472) is reused unchanged, so both authoring faces (the nested block and the flattened top-level spelling) are built from one field map and cannot fork. This is the 28th and last of the keys objectui#6051's census found `getGanttConfig` reading off `schema` that `ObjectGanttSchema` did not declare — severed out of that PR because, unlike the other 27, it narrows the accept set rather than only naming a spelling.

## Maintainer ruling followed exactly

Ruling of 2026-08-27 (`以上同意`), **Option A**: declare as-is, spec requiredness enforces immediately, no warning window.

- ⛔ **C (a one-release warning window)** — excluded by the standing startup-stage no-gradualism rule (objectstack#12668): no phased window without named external-user evidence, and none exists.
- ⛔ **B (relaxing requiredness on the objectui face)** — declined, forks the vocabulary from the spec.

## Framing: this surfaces existing breakage, it does not create new breakage

A `gantt` block missing the required trio is *already* non-functional at runtime today: `getGanttConfig`'s block branch (`packages/plugin-gantt/src/ObjectGantt.tsx`) already feeds the block to `GanttConfigSchema.safeParse` and logs `[ObjectGantt] Invalid gantt configuration` on failure. What changes is **when the author is told** — runtime console silence becomes an authoring-time refusal that names the missing field. This is a `declared = enforced` restoration; the spec has required `startDateField`/`endDateField`/`titleField` since rc.6, nothing here invents requiredness.

## Clause-② — exactly what the CLI now refuses that it accepted before

`ObjectGanttSchema` is a member of `AnyComponentSchema`, so it reaches `safeValidateSchema` and therefore `packages/cli/src/commands/{validate,check}.ts`.

| | Before | After |
|---|---|---|
| `gantt` block present, missing any of `startDateField`/`endDateField`/`titleField` | **Accepted** (block rode through `.passthrough()` unvalidated) | **Refused**, naming the missing field |
| `gantt` block present, all three fields present | Accepted | Accepted (unchanged) |
| No `gantt` block (flat spelling, or none) | Accepted | Accepted (unchanged) |

Nothing else about `ObjectGanttSchema`'s accept set moves.

## Re-taken census on current `main` (post-#6472), populations kept separate

`git ls-files | wc -l` → **5641** tracked files today (the original 5095-file scan predated #6472's landing and the file count has grown since). A bare `grep -n "gantt:"` returns **121 hits across 56 files** and conflates unrelated populations, per the card's own warning. Re-run with each population isolated and a positive control on every zero:

1. **i18n translation namespaces literally named `gantt`** — `packages/i18n/src/locales/{ar,de,en,es,fr,ja,ko,pt,ru,zh}.ts` (10 files, 20 `gantt: {` hits — a nested chrome-string namespace, e.g. `gantt: { column: { taskName: … } }`), plus prose describing that namespace (`packages/plugin-gantt/docs/verification/README.md`, `packages/plugin-gantt/scripts/verify-i18n.mjs`, `packages/plugin-gantt/demo/main.tsx`'s own local `zh` pack). None reach `ObjectGanttSchema`.
2. **Prose** — CHANGELOG entries and `.changeset/*.md` bodies referencing `gantt:` as a conventional-commit scope prefix or descriptive text (7 files). Not metadata.
3. **View-type discriminator/lookup maps keyed by the literal `gantt`** (icon maps, label maps, the Create-View-Dialog per-view-type field-descriptor array, `packages/cli/src/utils/known-schema-types.ts`'s `'plugin-gantt:object-gantt'` registry string) — 7 files. These key a lookup table by the view-type string, not an authored `ObjectGanttSchema.gantt` value.
4. **`as any`-cast test fixtures that never reach the zod mirror** — `plugin-gantt`'s own 14 `.test.tsx` files (all `schema={{ … } as any}` props, including `ObjectGantt.blockPrecedence.test.tsx`'s deliberately-incomplete `{ colorField: 'flat_color' }` block used to test the renderer's own dev-mode warning, not CLI validation), plus `packages/react/src/spec-bridge/__tests__/P1SpecBridge.test.ts` (`transformListView(spec: any)`, a pure pass-through with no validation) and `packages/app-shell/src/views/ObjectView.titleFieldConvergence.test.tsx` (mocks `ListView` to *capture* `props.schema`, never renders or parses it). **Positive control**: `pnpm --filter @object-ui/plugin-gantt type-check` — clean (0 errors) — proves these are not silently-`any`-typed; they are genuinely never parsed.
5. **`ListViewSchema.gantt`** — a *different* schema (`type: 'list-view'`), unaffected by this PR: it already takes the spec's `GanttConfigSchema` **unmodified** (not `.partial()`'d, unlike kanban/calendar/gallery/timeline) via `specFieldsExcept(...)`, so it already required the trio before this PR and continues unchanged. Two fixtures under this population (`packages/plugin-list/src/__tests__/ListView.test.tsx:2696,2721`, missing `titleField`) are pre-existing `as unknown as ListViewSchema`-cast render fixtures that never reach `.safeParse` — not a casualty of this PR, and not this PR's schema.
6. **Doc/prose code-fence examples** — `content/docs/plugins/plugin-gantt.mdx` (11 `gantt: {` blocks, **all 11 trio-complete**), `packages/plugin-gantt/README.md` (one commented+elided illustration `// gantt: { startDateField: …, endDateField: …, … }`, and one *flat*-face `const gantt: ObjectGanttSchema = {...}` — a variable named `gantt`, not a `gantt:` block key), `skills/objectui/guides/page-builder.md` (1 `"gantt": {` block, trio-complete — a *different*, pre-existing defect in the same example is already tracked at #6508, not restated here). None of these are compiled or validated; all are trio-complete regardless.
7. **Real authored JSON metadata reaching `ObjectGanttSchema`'s discriminator** — `examples/schema-catalog/src/schemas/plugin-gantt/{construction-project-phases,project-timeline-with-dependencies,sprint-development-timeline}.json` (**3 files**, `type: "object-gantt"`, each with a `"gantt": {...}` block). This is the population closest to "what a human or AI author would actually write" in this repository. **All 3 are trio-complete.** (Not machine-validated by any CI workflow today — confirmed by grepping `.github/workflows/**` for `schema-catalog`, which returns only comments — so this PR does not newly break CI on them; the finding is that they would pass even if it did.)
8. **Unrelated substring false-positives** — `pnpm-lock.yaml` (`packages/plugin-gantt:` workspace path), `packages/plugin-timeline/src/renderer.tsx` + `examples/schema-catalog/.../plugin-timeline/gantt-style-timeline.json` + `packages/components/src/renderers/complex/TIMELINE.md` (all `TimelineSchema`'s own `variant: 'gantt'`, a different schema), `content/docs/api/schema-reference.md` (enum value list), `packages/plugin-gantt/src/GanttView.tsx` (an export-filename fallback string), `packages/plugin-gantt/package.json` (a `keywords` entry).

**Net: zero blocks missing the trio in every population that can plausibly reach `ObjectGanttSchema`'s parser — including the one population (`examples/schema-catalog` JSON) that is genuine authored metadata rather than a TS/TSX test fixture.** This matches, and modestly strengthens, the original 5095-file scan's finding on the now-5641-file tree.

The out-of-tree question the ruling asked to be recorded rather than answered here: whether authored `gantt` block metadata missing `titleField` exists outside this repository (customer apps, `objectstack` fixtures) remains unmeasured by an in-repo census by construction — the maintainer ruled Option A anyway, per the standing no-gradualism rule.

## The trio-missing pin, shown red before the fix (ablation)

`packages/types/src/__tests__/gantt-flat-config-declared-keys.test.ts`'s test *"the `gantt` BLOCK face is still undeclared, and today rides through UNVALIDATED"* asserted the **pre-fix** state (`gantt` absent from `ObjectGanttSchema.shape`, a trio-missing block accepted). It has been rewritten to assert the **post-fix** state — renamed *"the `gantt` BLOCK face is declared, and the spec trio now enforces at parse time"* — asserting: `gantt` now in `.shape`; a block missing `titleField` is refused and names the missing field; an empty block is refused; a wrong-typed `gantt` value is refused; a trio-complete block is accepted.

**Ablation, prediction before running:**

1. **Mutate** — `git checkout HEAD~1 -- packages/types/src/objectql.ts packages/types/src/zod/objectql.zod.ts` (revert only the two production files to their pre-fix content, keeping the rewritten test at HEAD). **Predicted**: the rewritten pin test fails red on `expect(Object.keys(ObjectGanttSchema.shape)).toContain('gantt')`; the other 16 tests in the two files (the flat 27-key pins, `zod-mirror-parity`) stay green, since nothing else in this PR touches them.
   - **Mutation confirmed on disk** (anchored counts, not editor exit code): `grep -c 'gantt?: GanttConfig;' objectql.ts` 1→**0**; `grep -c 'gantt: SpecGanttConfigSchema.extend(GanttConfigExtensionFields)' objectql.zod.ts` 1→**0**; the old severed-state comment marker `is DELIBERATELY still undeclared here` reappeared (0→**1**).
   - **Observed**, matching the prediction exactly: `Test Files 1 failed | 1 passed (2)` / `Tests 1 failed | 16 passed (17)`. The one failure is precisely the predicted assertion: `AssertionError: expected [ Array(64) ] to include 'gantt'` at the `toContain('gantt')` line.
2. **Restore** — `git checkout HEAD -- packages/types/src/objectql.ts packages/types/src/zod/objectql.zod.ts`. **Confirmed**: `git diff HEAD --stat` empty; `git hash-object` on each of the two files equals `git rev-parse HEAD:` plus that file's path, for both files; the full pin suite (`gantt-flat-config-declared-keys.test.ts` + `zod-mirror-parity.test.ts` + `gantt-declared-keys.test.ts`) reruns green (26/26).

## #6472's derived-pin family — untouched, verified still passing

`FlatFaceGaps` (in the same test file) — the type-level pin that `Exclude` of `DeclaredKeys` of `GanttConfig`, against `DeclaredKeys` of the flat `ObjectGanttSchemaTS`, must be `never` — is unmodified. Adding `gantt` to `ObjectGanttSchema`'s own declared keys only grows the `Exclude`'s *target* set (the flat face's declared-keys side), which cannot introduce residue on the source side. Still compiles clean, confirmed by the green `type-check` run below (which compiles every `*.test.ts` in the package, including the `@ts-expect-error` compile-time pins).

## A second, unrelated fix this PR needed to stay green

`zod-mirror-parity.test.ts`'s `SPEC_DERIVED_PAIRS` re-check scans **raw text** between `export const` boundaries in `packages/types/src/zod/*.zod.ts` for a `\bSpec[A-Z]\w*` token to detect which mirrors reference a spec schema. My first pass at the docstring above the private `GanttConfigExtensionFields` const — which sits textually between the `ObjectTreeSchema` and `ObjectGanttSchema` export boundaries — mentioned `SpecGanttConfigSchema` in prose, and that mention was misattributed to `ObjectTreeSchema` (which references no spec schema at all), flipping `SPEC_DERIVED_PAIRS matches what the mirror sources actually do` red. Fixed by rewording the docstring to avoid the literal token, with a comment recording the trap so the next editor of that docstring doesn't reintroduce it.

## Gate table (all on commit `698685911`, the current HEAD)

| Gate | Command | Verdict |
|---|---|---|
| `packages/types` type-check (tsc --noEmit + examples + **test** projects — compiles every `*.test.ts`, including the `@ts-expect-error` compile-time pins) | `pnpm --filter @object-ui/types type-check` | ✅ exit 0, no output |
| `packages/plugin-gantt` type-check (consumer sweep, dependency closure built first) | `pnpm --filter @object-ui/plugin-gantt type-check` | ✅ exit 0, no output |
| `packages/types` full vitest (includes zod-mirror-parity, both gantt derived-pin files, base-schema parity) | `pnpm exec vitest run --root . packages/types/` | ✅ `Test Files 69 passed (69)` / `Tests 801 passed (801)` |
| `packages/plugin-gantt` full vitest (consumer sweep) | `pnpm exec vitest run --root . packages/plugin-gantt/` | ✅ `Test Files 51 passed (51)` / `Tests 422 passed (422)` |
| `check:control-bytes` | `node scripts/check-control-bytes.mjs` | ✅ `scanned 5557 tracked text file(s)` |
| `check:spec-symbols` (relevant: this PR derives from `SpecGanttConfigSchema`) | `node scripts/check-spec-symbol-derivation.mjs` | ✅ (unchanged counts) |
| changeset presence | `node scripts/check-changeset-presence.mjs` | ✅ `1 changeset(s) added` |
| changeset no-major | `node scripts/check-changeset-no-major.mjs` | ✅ `No changeset declares a major bump` |
| `packages/types` lint, narrowed to the 3 touched files, `--format json` | `pnpm exec eslint src/objectql.ts src/zod/objectql.zod.ts src/__tests__/gantt-flat-config-declared-keys.test.ts --format json` | ✅ `0 errors`, 19 warnings — **all pre-existing**: `grep -c '\bany\b'` on `objectql.ts` is identically **25** on `origin/main` and on this branch, and linting `origin/main`'s copy of the file directly reproduces the same **19** `no-explicit-any` warnings byte-for-byte |
| `packages/types` lint, full package (canonical gate command) | `pnpm --filter @object-ui/types lint` | ✅ exit 0, `247 problems (0 errors, 247 warnings)` |

**Narrowing proof (three legs, per the repo's own convention):** ① the 247-warning population above is read from eslint's own `--format json`/text summary, not guessed; ② `eslint.config.js` has no `parserOptions.project`/`projectService` anywhere in this repo — type-aware linting is off, so nothing in this diff can move any judgment on a file this diff did not touch; ③ the direct A/B (lint `origin/main`'s `objectql.ts` bytes vs. this branch's) reproduces the identical 19-warning population, proving the narrowed run and the full-package run agree and that this diff added zero lint findings.

**objectui has no `scripts/pm/os-verify-lock.sh` or `scripts/pm/dispatch-gates.mjs`** — that shared-lock/gate-derivation infrastructure lives only in `objectstack`. Gates above were run directly per this repo's own AGENTS.md testing conventions (root-relative `pnpm exec vitest run` plus a path, never `pnpm --filter PKG test` or `cd packages/x`), and the union above is the full set the dispatch named plus the one adjacent gate (`check:spec-symbols`) this PR's spec-derived declaration touches.

## Fence held

Only `packages/types/src/objectql.ts`, `packages/types/src/zod/objectql.zod.ts`, `packages/types/src/__tests__/gantt-flat-config-declared-keys.test.ts` (updating the pin this PR's ruling directly obsoletes), and the changeset. `packages/types/src/index.ts` and its `package.json` `exports` map (held by #6527's B patch round) were not touched or read for editing purposes.

_Generated by [Claude Code](https://claude.ai/code/session_8ca04858-ea8e-5b85-9182-de59aa49e00c)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_