### PR TITLE
fix(app-shell): read the provisioned env from the nested `environment` row

### DIFF
--- a/.changeset/6629-provision-env-nested-envelope.md
+++ b/.changeset/6629-provision-env-nested-envelope.md
@@ -1,0 +1,31 @@
+---
+"@object-ui/app-shell": patch
+---
+
+`provisionProductionEnvironment` reads the created env from the nested `environment` row
+
+`POST /api/v1/cloud/environments` answers `{ success, data: { environment, warnings,
+durationMs, hostnameAssignment? } }` — the created row sits one level down, under
+`environment`. The consumer read `data` FLAT and returned it as a
+`ProvisionedEnvironment`, so `id` and `hostname` were always `undefined` and the
+envelope's siblings rode along in their place.
+
+The bug was silent by construction: both fields are optional on the type, the whole call
+is best-effort by contract (a 403/409 resolves to `alreadyProvisioned: true`) and the
+caller swallows genuine failures — so the function reported a successful provision
+carrying no environment at all, which is the exact outcome the strict envelope check in
+that file was written to prevent. That check verifies `data` is an object and nothing
+about its shape.
+
+The fix reads ONE dialect: no `data.environment ?? data` alias, and the row is projected
+to `{ id, hostname }` rather than returned whole. A wrong-shaped `data` still RESOLVES
+rather than throws — tightening the envelope check to reject it would change behaviour on
+the best-effort path the caller relies on swallowing, and is deliberately not folded in
+here.
+
+Scored `patch`, not an empty "no release" declaration: this is shipped runtime code in a
+published package whose return value is different, not a comment or a test-only change,
+so an empty frontmatter would assert something false. Not `minor` — no new capability and
+no API surface change; `ProvisionedEnvironment` is unchanged. The blast radius is small
+today (the sole in-repo caller, `CreateWorkspaceDialog`, discards the return value, and
+the symbol is not on the package barrel), but "small" is not "unreleased".

--- a/packages/app-shell/src/console/organizations/__tests__/provisionEnvironment.test.ts
+++ b/packages/app-shell/src/console/organizations/__tests__/provisionEnvironment.test.ts
@@ -4,7 +4,8 @@
  * provisionProductionEnvironment — born-with-env contract.
  *
  *   - posts `Production` + the explicit org id to the cloud env endpoint;
- *   - resolves the created env on 2xx;
+ *   - resolves the created env on 2xx, reading it from the NESTED `environment`
+ *     row the control plane wraps it in (objectui#6629);
  *   - treats 403/409 ("org already has its production env" — e.g. the control
  *     plane's auto-default-environment plugin won the race) as SUCCESS
  *     (`alreadyProvisioned`), NOT a failure;
@@ -38,7 +39,9 @@ beforeEach(() => {
 
 describe('provisionProductionEnvironment', () => {
   it('posts Production + the org id to the cloud env endpoint and returns the env', async () => {
-    authFetch.mockResolvedValue(res(200, { data: { id: 'env-1', hostname: 'os-abc.localhost' } }));
+    authFetch.mockResolvedValue(
+      res(200, { data: { environment: { id: 'env-1', hostname: 'os-abc.localhost' } } }),
+    );
 
     const out = await provisionProductionEnvironment({ organizationId: 'org-123' });
 
@@ -48,6 +51,54 @@ describe('provisionProductionEnvironment', () => {
     expect(init.method).toBe('POST');
     expect(JSON.parse(init.body)).toEqual({ displayName: 'Production', organizationId: 'org-123' });
     expect(out).toMatchObject({ id: 'env-1', hostname: 'os-abc.localhost' });
+  });
+
+  // objectui#6629 — ANTI-VACUITY PIN. The control plane's success payload nests
+  // the created row one level down — `{ environment, warnings, durationMs,
+  // hostnameAssignment? }` — so reading `data` FLAT left `id` and `hostname`
+  // permanently `undefined`. Nothing threw and nothing logged: both fields are
+  // optional on the type, the whole call is best-effort by contract, and the
+  // caller swallows failures — the only symptom was a "successful" provision
+  // carrying no environment at all. A test that merely asserts the fixed path
+  // is green would have been green BEFORE the fix too; this one is RED on the
+  // pre-fix implementation (which returns the wrapper, whose `id` is
+  // `undefined`), which is the whole reason it exists.
+  it('reads the created env from the nested `environment` row, not from the wrapper', async () => {
+    authFetch.mockResolvedValue(
+      res(201, {
+        success: true,
+        data: {
+          environment: { id: 'env-1', hostname: 'os-abc.localhost' },
+          warnings: [],
+          durationMs: 42,
+          hostnameAssignment: { hostname: 'os-abc.localhost' },
+        },
+      }),
+    );
+
+    const out = await provisionProductionEnvironment({ organizationId: 'org-123' });
+
+    // `toEqual`, not `toMatchObject`: the wrapper's siblings (`warnings`,
+    // `durationMs`, `hostnameAssignment`) must not ride along into a value
+    // typed `ProvisionedEnvironment`.
+    expect(out).toEqual({ id: 'env-1', hostname: 'os-abc.localhost' });
+  });
+
+  // Contract-first (AGENTS.md #0.1): the fix reads exactly ONE dialect. A flat
+  // `data` is not a second accepted spelling of the payload, so its keys must
+  // not be picked up — no `data.environment ?? data` alias. Note it still
+  // RESOLVES rather than throws: rejecting a wrong-shaped `data` would change
+  // behaviour on a path the caller currently relies on swallowing, and is
+  // deliberately NOT folded into this fix (objectui#6629).
+  it('does not fall back to a flat `data` shape when `environment` is absent', async () => {
+    authFetch.mockResolvedValue(
+      res(200, { success: true, data: { id: 'flat-1', hostname: 'flat.localhost' } }),
+    );
+
+    const out = await provisionProductionEnvironment({ organizationId: 'org-123' });
+
+    expect(out.id).toBeUndefined();
+    expect(out.hostname).toBeUndefined();
   });
 
   it('treats 403 (already has its production env) as success, not a failure', async () => {

--- a/packages/app-shell/src/console/organizations/provisionEnvironment.ts
+++ b/packages/app-shell/src/console/organizations/provisionEnvironment.ts
@@ -12,6 +12,10 @@
  * is resolved from `organizationId` (preferred) → the better-auth active org →
  * the actor's first membership.
  *
+ * The endpoint answers `201 { success, data: { environment, warnings,
+ * durationMs, hostnameAssignment? } }` — the created row is nested under
+ * `environment`, NOT flat on `data`.
+ *
  * Idempotent + best-effort by contract:
  *   - Some control planes auto-provision the production env on org create (the
  *     `auto-default-environment` plugin). This call then races that plugin and
@@ -81,12 +85,28 @@ export async function provisionProductionEnvironment(opts: {
   // successful provision carrying no env at all. Throwing routes it to the
   // caller's documented failure path: the onboarding gate provisions lazily on
   // first navigation.
-  const body = (await res.json().catch(() => null)) as { data?: ProvisionedEnvironment } | null;
+  const body = (await res.json().catch(() => null)) as {
+    data?: { environment?: { id?: string; hostname?: string } };
+  } | null;
   const data = body?.data;
   if (!data || typeof data !== 'object') {
     throw new Error(
       'Malformed control-plane response: expected a `{ success, data }` envelope from POST /cloud/environments',
     );
   }
-  return data;
+  // ...and inside that envelope the created row sits ONE LEVEL DOWN, under
+  // `environment` — the handler answers `{ environment, warnings, durationMs,
+  // hostnameAssignment? }`, so `data.id` / `data.hostname` never existed on the
+  // wire and reading `data` flat reported a successful provision whose `id` and
+  // `hostname` were always `undefined` (objectui#6629). Projected explicitly
+  // rather than returned whole, so the envelope's siblings can't ride along
+  // into a value typed `ProvisionedEnvironment`.
+  //
+  // Read ONE dialect (AGENTS.md #0.1): no `data.environment ?? data` alias — a
+  // flat payload is a producer contract violation, not a second spelling. It
+  // still RESOLVES rather than throws, because rejecting a wrong-shaped `data`
+  // would change behaviour on the best-effort path the caller relies on
+  // swallowing; that is a separate decision, not part of this fix.
+  const environment = data.environment;
+  return { id: environment?.id, hostname: environment?.hostname };
 }


### PR DESCRIPTION
Fixes #6629

`POST /api/v1/cloud/environments` answers `{ success, data: { environment, warnings, durationMs, hostnameAssignment? } }` — the created row sits one level down, under `environment`. `provisionProductionEnvironment` read `data` FLAT and returned it as a `ProvisionedEnvironment`, so `id` and `hostname` were always `undefined` and the envelope's siblings rode along in their place.

The row is now projected to `{ id, hostname }`.

## Which half is measured, which is inherited

**Consumer half — MEASURED here**, on merge-base `5967be095`, in `packages/app-shell/src/console/organizations/provisionEnvironment.ts`:

- `ProvisionedEnvironment` is declared `{ id?: string; hostname?: string; alreadyProvisioned?: boolean }`, with `id` documented as the control-plane `sys_environment` row id;
- the body is cast to `{ data?: ProvisionedEnvironment }`, and the envelope check is `if (!data || typeof data !== 'object') throw`;
- the function then does `return data` — the wrapper itself.

So the card's claim is confirmed against the actual code: the check verifies `data` is **an object and nothing about its shape**. A payload of `{ environment, warnings, durationMs }` passes it unchanged and is returned whole as a value typed `ProvisionedEnvironment`.

**Producer half — INHERITED, not measured.** The producer evidence is `packages/service-cloud/src/routes/environment-lifecycle.ts` in `objectstack-ai/cloud`, which this repo cannot read. I searched this repo for a second source of the wire shape and found none: no fixture, no recorded response, and no typed client declares the create-environment response (`hostnameAssignment` appears nowhere in `node_modules/@objectstack/**`). The only in-repo artifact that pinned the success-payload shape was this suite's own hand-written mock — and it pinned the FLAT shape, i.e. it pinned the bug. The fix is therefore pinned against the card's stated wire shape, declared as inherited.

## Anti-vacuity: RED before, GREEN after

This bug is quiet by construction — both fields optional, the call best-effort by contract, 403/409 resolving to `alreadyProvisioned: true`, the caller swallowing genuine failures — so a test that merely asserts the fixed path is green would have been green before the fix too. The tests were therefore written and run **against the unmodified merge-base implementation first**.

RED on `5967be095`, implementation untouched, test file only — `Tests 3 failed | 4 passed (7)`:

| test | pre-fix failure |
|---|---|
| reads the created env from the nested `environment` row, not from the wrapper | `expected { …(4) } to deeply equal { id: 'env-1', …(1) }` |
| does not fall back to a flat `data` shape when `environment` is absent | `expected 'flat-1' to be undefined` |
| posts Production + the org id … and returns the env (fixture retriaged) | `expected { environment: { id: 'env-1', …(1) } } to match object { id: 'env-1', …(1) }` |

GREEN after the fix — `Test Files 18 passed (18)` / `Tests 116 passed (116)`, run at `35fe8741b`.

The second row is the anti-alias pin: it asserts a flat `data` is **not** picked up (no `data.environment ?? data`), and it is red pre-fix precisely because the old code did read it. The third was an existing fixture that pinned the wrong wire shape; retriaged rather than deleted.

## Deliberately NOT folded in: tightening the envelope check

A wrong-shaped `data` still **resolves** (with `id`/`hostname` undefined) rather than throwing. Rejecting it is a tempting adjacent fix and may well be right, but it is a behaviour change on an error path that currently resolves best-effort. Blast radius as measured in this repo: the sole caller is `CreateWorkspaceDialog.tsx`, which wraps the call in `try/catch` and on throw logs a warning and falls through to the lazy onboarding gate — so a tightened check would convert a silent no-op into a logged failure plus a lazy re-provision on first navigation. That is a real user-visible path change and belongs in its own card, not here.

## The ADR-0006 D2 rename is not being raced

The cloud control plane is mid-rename under ADR-0006 D2 (epic objectstack-ai/objectstack#12865), where response payload keys `project` / `projects` become `environment` / `environments` on the OTHER control-plane routes. `POST /cloud/environments` is **not** part of that rename — it has always answered `environment` — so this change is stable against that work rather than racing it. Reviewers should not have to rediscover this. Originally found while implementing the producer-half rename in objectstack-ai/cloud#1691.

## Changeset

Scored `patch` in `.changeset/6629-provision-env-nested-envelope.md`. Reasoning: this is shipped runtime code in a released package whose return value is now different, not a comment or a test-only change, so an empty "no release" frontmatter would assert something false. Not `minor` — no new capability and no API surface change; `ProvisionedEnvironment` is unchanged. The blast radius is small today (the sole in-repo caller discards the return value, and the symbol is not on the package barrel), but small is not unreleased.

## Verification

All heavy runs went through the shared verify lock. Union run at `35fe8741b`; the working tree was clean at that commit, so the lint and type-check readings below are on the identical bytes.

- `pnpm exec vitest run packages/app-shell/src/console/organizations/` plus the six app-shell ratchet suites — `Test Files 18 passed (18)`, `Tests 116 passed (116)`, lock `VERDICT command-exit 0`.
- `pnpm --filter "@object-ui/app-shell" run type-check` — `VERDICT command-exit 0`. Both passes ran (`tsc --noEmit && tsc -p tsconfig.test.json`); the second is what covers test files, since `tsconfig.json` excludes them.
- `pnpm --filter "@object-ui/app-shell" run lint` — whole-package `eslint .`, `0 errors, 2779 warnings` (all pre-existing; neither changed file appears). Scoped to app-shell because it is the only package this diff touches, and the root `eslint.config.js` declares no `parserOptions.project` / `projectService`, so no untouched file's verdict can move.
- Dependency closure rebuilt first (`pnpm --filter "@object-ui/app-shell^..." run build`, 29 projects, exit 0) — the pre-existing `dist/` was from an older base.
- Gates: `check-changeset-presence`, `check-changeset-fixed`, `check-changeset-no-major`, `check-changeset-overwrite`, `check-control-bytes`, `check-vi-mock-specifiers` — all exit 0 with their own OK lines.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_