### PR TITLE
fix(plugin-dashboard): feed lookup cells their reference target in ObjectDataTable / RecordDetailDrawer (#6694)

### DIFF
--- a/.changeset/6694-dashboard-lookup-reference-meta.md
+++ b/.changeset/6694-dashboard-lookup-reference-meta.md
@@ -1,0 +1,57 @@
+---
+'@object-ui/plugin-dashboard': patch
+---
+
+Feed the lookup cells in `ObjectDataTable` and `RecordDetailDrawer` their reference target,
+so schema-aware display-name resolution and drill-through links engage for the first time
+(objectui#6694).
+
+Both widgets build their cell meta with `buildFieldMeta` and render it through
+`renderFieldValue` → `getCellRenderer` → `LookupCellRenderer` (`@object-ui/fields`). That
+renderer resolves its target from `field.reference_to || field.reference`, and `FieldMeta`
+carried neither spelling — nor `display_field`. So the renderer resolved `undefined` and two
+things failed, independently and both silently:
+
+- `useRefObjectSchema` never loaded the referenced object's schema, so the ADR-0079 /
+  objectui#2357 resolution never ran and every cell fell back to `pickRecordDisplayName`'s
+  generic `.name` / `.title` heuristic. Quiet, because that heuristic usually still produces
+  a readable name — it diverges only when the referenced object's display field is not
+  literally `name` / `title`, and then it silently shows the wrong one.
+- `ReferencedRecordLink`'s `objectName` was always `undefined`, so `navigable` was always
+  `false` and no lookup cell in either widget ever rendered a real anchor — no
+  drill-through, no middle-click-new-tab, no copy-link. Quiet, because the cell still
+  rendered its value as plain text.
+
+This RESTORES intended behaviour rather than adding surface. `ReferencedRecordLink` was
+placed in the shared cell renderer precisely so every surface would get the affordance once
+("Both surfaces resolve through `LookupCellRenderer`, so the affordance belongs here,
+once"), and `plugin-grid`'s `ObjectGrid` has fed it all along via `applyRelationalMeta` at
+all three of its column-building call sites. These two widgets simply never adopted that
+copy. Nothing new is authorable: the keys come off the OBJECT SCHEMA field def authors
+already write, never off a column override — the distinction objectui#6597 measured when it
+retired `referenceTo`, and the reason this needs no new column hold.
+
+The copy is made once in `buildFieldMeta`, the seam both widgets funnel through, so the two
+surfaces cannot drift — which is what that module exists for.
+
+⚠️ The copy set is three keys where `ObjectGrid`'s `RELATIONAL_META_KEYS` is nine, and the
+difference is measured per key, not preferred. The grid's cells are EDITABLE, so its extra
+keys drive the inline picker's query (`LookupField` / `UserField` read `id_field`,
+`description_field`, `lookup_filters`, `lookupFilters`); these two widgets are read-only and
+their render path ends at a cell renderer. `packages/fields/src/index.tsx` reads exactly
+`reference_to`, `reference` and `display_field` off a cell's `field` prop; `titleFormat` is
+never read off a field meta at all (its readers take it off the object schema, which arrives
+here through `useRefObjectSchema(reference_to)`), and `reference_to_field` has zero member
+reads anywhere in the repo. Copying the other six would mint six members written on every
+call and read by nothing — precisely what objectui#6625 (`decimals`) and objectui#6597
+(`referenceTo`) retired from this same file.
+
+No published type widened: `FieldMeta` is internal to the package — it is not re-exported
+through the barrel (`dist/index.d.ts` names neither it nor `recordFields`) and the `exports`
+map publishes only `"."`, so Node refuses `@object-ui/plugin-dashboard/recordFields` with
+`ERR_PACKAGE_PATH_NOT_EXPORTED`.
+
+Behaviour note for existing dashboards: a lookup cell whose referenced object declares a
+`nameField` other than `name` / `title` will now show that declared name instead of the
+heuristic's pick, and valued lookup cells become links wherever the host publishes
+`recordHref`.

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -355,9 +355,19 @@ export interface ObjectDataTableColumnHolds {}
  * tombstone and the band together are the same verdict, unchanged since each
  * key's ruling.
  *
- * The pool is what shrank, so what THIS band still refuses is `name` and
+ * The pool shrank, then grew again. What THIS band refuses is `name` and
  * `label` — both of them `FieldMeta` members with answers this seam already
- * has (see the docblock above).
+ * has (see the docblock above) — plus, since objectui#6694, the three
+ * relational members that card added: `reference_to`, `reference` and
+ * `display_field`.
+ *
+ * ⭐ Those three are the derivation working as designed, and their verdict is
+ * the one objectui#6597 already reached for `referenceTo`: an AUTHORED column
+ * may not source a lookup's reference target. They are refused HERE while
+ * `buildFieldMeta` writes them freely, because that write's source is the
+ * OBJECT SCHEMA field def and never the column — the same distinction
+ * objectui#6597 measured, and the reason adding them needed no new hold. They
+ * reached this band without anyone extending a list.
  */
 export type UnheldFieldMetaOverrideKey =
   Exclude<keyof FieldMeta, keyof TableColumn | keyof ObjectDataTableColumnHolds>;

--- a/packages/plugin-dashboard/src/__tests__/lookupRelationalMeta-6694.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/lookupRelationalMeta-6694.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * objectui#6694 — lookup cells in `ObjectDataTable` / `RecordDetailDrawer` must
+ * carry their reference target.
+ *
+ * Both widgets build their cell meta with `buildFieldMeta` and render it through
+ * `renderFieldValue` -> `getCellRenderer` -> `LookupCellRenderer`
+ * (`@object-ui/fields`). That renderer resolves its target from
+ * `field.reference_to || field.reference` and its display field from
+ * `field.display_field`. `buildFieldMeta` wrote NONE of those spellings, so the
+ * renderer resolved `undefined` and two things failed — independently, and both
+ * silently:
+ *
+ *  1. `useRefObjectSchema(referenceTo)` never loaded the referenced object's
+ *     schema, so `resolveLookupRecordName` fell through the ADR-0079 resolver to
+ *     `pickRecordDisplayName`'s generic `.name` / `.title` heuristic.
+ *  2. `ReferencedRecordLink`'s `objectName` was always `undefined`, so
+ *     `navigable` was always `false` and the cell never rendered a real anchor —
+ *     no drill-through, no middle-click-new-tab, no copy-link.
+ *
+ * ⚠️ Consequence 1 is pinned with a referenced object whose display field is
+ * `project_code` — NOT `name` / `title`. That is the whole point: the generic
+ * fallback usually still produces a readable name, so a fixture whose display
+ * field IS `name` passes before and after the fix and pins nothing. Each record
+ * below therefore ALSO carries a `name`, holding the value the broken path
+ * produced, and every assertion checks that the wrong one is absent.
+ *
+ * The two consequences get separate assertions because either can be fixed while
+ * the other stays broken: consequence 2 needs only `reference_to`, while
+ * consequence 1 additionally needs the referenced schema to actually load.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  SchemaRendererContext,
+  RelatedRecordActionsProvider,
+  type RelatedRecordActionsValue,
+} from '@object-ui/react';
+
+vi.mock('@object-ui/react', async () => {
+  const actual: any = await vi.importActual('@object-ui/react');
+  return {
+    ...actual,
+    // Only the table shell is stubbed. Everything the assertions depend on —
+    // `SchemaRendererContext`, `RelatedRecordActionsProvider` — is the REAL
+    // export by identity, so the contexts this file installs are the same
+    // objects `@object-ui/fields` reads from.
+    SchemaRenderer: ({ schema }: any) => {
+      const cols = schema.columns || [];
+      const rows = schema.data || [];
+      return (
+        <table>
+          <tbody>
+            {rows.map((row: any, i: number) => (
+              <tr key={i}>
+                {cols.map((c: any) => (
+                  <td key={c.accessorKey}>
+                    {typeof c.cell === 'function'
+                      ? c.cell(row[c.accessorKey], row)
+                      : String(row[c.accessorKey] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    },
+    useDataScope: () => undefined,
+  };
+});
+
+import { ObjectDataTable } from '../ObjectDataTable';
+import { RecordDetailDrawer } from '../RecordDetailDrawer';
+import { buildFieldMeta } from '../recordFields';
+
+/**
+ * The host's route builder — the ONLY thing that can turn a lookup cell into an
+ * anchor. `ReferencedRecordLink` calls it with the resolved `objectName`, so it
+ * is never reached at all while that value is `undefined`.
+ */
+const HOST: RelatedRecordActionsValue = {
+  resolve: () => ({}),
+  recordHref: (objectName, recordId) => `/app/${objectName}/view/${recordId}`,
+};
+
+/**
+ * `refObjectSchemaCache` in `@object-ui/fields` is module-level and never
+ * cleared, so each case below references its OWN object name. A shared name
+ * would let one case's resolved schema satisfy another's assertion.
+ */
+function makeDataSource(opts: {
+  ownerObject: string;
+  refObject: string;
+  rows: any[];
+}) {
+  const ownerSchema = {
+    name: opts.ownerObject,
+    fields: {
+      project: { type: 'lookup', label: 'Project', reference_to: opts.refObject },
+    },
+  };
+  const refSchema = {
+    name: opts.refObject,
+    // ADR-0079 canonical record-title pointer. Deliberately NOT `name`/`title`.
+    nameField: 'project_code',
+    fields: {
+      project_code: { type: 'text', label: 'Code' },
+      name: { type: 'text', label: 'Name' },
+    },
+  };
+  return {
+    find: async () => ({ data: opts.rows }),
+    getObjectSchema: async (n: string) => (n === opts.refObject ? refSchema : ownerSchema),
+    __ownerSchema: ownerSchema,
+  };
+}
+
+/** An `$expand`-ed lookup value whose generic `.name` is the WRONG answer. */
+function expandedProject(id: string) {
+  return { id, project_code: 'APOLLO-7', name: 'generic-fallback-name' };
+}
+
+describe('objectui#6694 — ObjectDataTable lookup cells carry their reference target', () => {
+  it('pin 1: resolves the display name through the REFERENCED object schema, not the generic .name heuristic', async () => {
+    const ds = makeDataSource({
+      ownerObject: 'account_6694_a',
+      refObject: 'project_6694_a',
+      rows: [{ project: expandedProject('p-1') }],
+    });
+
+    render(
+      <SchemaRendererContext.Provider value={{ dataSource: ds } as any}>
+        <ObjectDataTable
+          schema={{
+            type: 'object-data-table',
+            objectName: 'account_6694_a',
+            columns: [{ header: 'Project', accessorKey: 'project' }],
+          } as any}
+          dataSource={ds}
+        />
+      </SchemaRendererContext.Provider>,
+    );
+
+    // `nameField: 'project_code'` wins — the ADR-0079 / issue #2357 resolution
+    // that only runs once `useRefObjectSchema` has a reference target to load.
+    await waitFor(
+      () => expect(screen.getByText('APOLLO-7')).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    // …and the generic heuristic's answer is NOT what rendered. Without this the
+    // assertion above could pass on a fixture where both agree.
+    expect(screen.queryByText('generic-fallback-name')).not.toBeInTheDocument();
+  });
+
+  it('pin 2: renders a real drill-through anchor built by the host', async () => {
+    const ds = makeDataSource({
+      ownerObject: 'account_6694_b',
+      refObject: 'project_6694_b',
+      rows: [{ project: expandedProject('p-2') }],
+    });
+
+    render(
+      <RelatedRecordActionsProvider value={HOST}>
+        <SchemaRendererContext.Provider value={{ dataSource: ds } as any}>
+          <ObjectDataTable
+            schema={{
+              type: 'object-data-table',
+              objectName: 'account_6694_b',
+              columns: [{ header: 'Project', accessorKey: 'project' }],
+            } as any}
+            dataSource={ds}
+          />
+        </SchemaRendererContext.Provider>
+      </RelatedRecordActionsProvider>,
+    );
+
+    // `navigable` is `!!objectName && recordId != null`. The id was always
+    // there; the object name is what the missing `reference_to` withheld, so
+    // this anchor is the whole of consequence 2.
+    const link = await waitFor(() => screen.getByRole('link'), { timeout: 3000 });
+    expect(link).toHaveAttribute('href', '/app/project_6694_b/view/p-2');
+  });
+});
+
+describe('objectui#6694 — RecordDetailDrawer lookup rows carry their reference target', () => {
+  it('pin 1: resolves the display name through the REFERENCED object schema', async () => {
+    const ds = makeDataSource({
+      ownerObject: 'account_6694_c',
+      refObject: 'project_6694_c',
+      rows: [],
+    });
+
+    render(
+      <SchemaRendererContext.Provider value={{ dataSource: ds } as any}>
+        <RecordDetailDrawer
+          record={{ id: 'a-1', project: expandedProject('p-3') }}
+          objectName="account_6694_c"
+          objectSchema={ds.__ownerSchema}
+          onClose={() => {}}
+        />
+      </SchemaRendererContext.Provider>,
+    );
+
+    await waitFor(
+      () => expect(screen.getByText('APOLLO-7')).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    expect(screen.queryByText('generic-fallback-name')).not.toBeInTheDocument();
+  });
+
+  it('pin 2: renders a real drill-through anchor built by the host', async () => {
+    const ds = makeDataSource({
+      ownerObject: 'account_6694_d',
+      refObject: 'project_6694_d',
+      rows: [],
+    });
+
+    render(
+      <RelatedRecordActionsProvider value={HOST}>
+        <SchemaRendererContext.Provider value={{ dataSource: ds } as any}>
+          <RecordDetailDrawer
+            record={{ id: 'a-2', project: expandedProject('p-4') }}
+            objectName="account_6694_d"
+            objectSchema={ds.__ownerSchema}
+            onClose={() => {}}
+          />
+        </SchemaRendererContext.Provider>
+      </RelatedRecordActionsProvider>,
+    );
+
+    const link = await waitFor(() => screen.getByRole('link'), { timeout: 3000 });
+    expect(link).toHaveAttribute('href', '/app/project_6694_d/view/p-4');
+  });
+});
+
+/**
+ * The copy-set boundary.
+ *
+ * `ObjectGrid`'s `applyRelationalMeta` copies NINE keys; this seam copies THREE,
+ * and the difference is measured rather than preferred: the grid's cells are
+ * EDITABLE, so its extra keys feed the inline picker (`LookupField` / `UserField`
+ * read `id_field`, `description_field`, `lookup_filters`, `lookupFilters`).
+ * These two widgets are read-only — their only render path ends at a CELL
+ * renderer — and `packages/fields/src/index.tsx` reads exactly three relational
+ * keys off a cell's `field` prop.
+ *
+ * ⛔ This is what stops the omitted six from being added back "for parity": a
+ * `FieldMeta` member written on every call and read by nothing is precisely what
+ * objectui#6625 (`decimals`) and objectui#6597 (`referenceTo`) retired from this
+ * same file. If these widgets ever gain inline editing, that is the event that
+ * earns the picker keys — not symmetry with the grid.
+ */
+describe('objectui#6694 — buildFieldMeta copies the cell-read relational keys and no others', () => {
+  const def = {
+    type: 'lookup',
+    reference_to: 'project',
+    reference: 'project',
+    display_field: 'project_code',
+    // The six the grid also copies, which have no reader on this path:
+    reference_to_field: 'x',
+    id_field: 'x',
+    description_field: 'x',
+    lookup_filters: [['a', '=', 1]],
+    lookupFilters: [['a', '=', 1]],
+    titleFormat: '{project_code}',
+  };
+
+  it('copies reference_to / reference / display_field', () => {
+    const meta = buildFieldMeta({ accessorKey: 'project', label: 'Project', def }) as any;
+    expect(meta.reference_to).toBe('project');
+    expect(meta.reference).toBe('project');
+    expect(meta.display_field).toBe('project_code');
+  });
+
+  it('does NOT copy the picker-only keys', () => {
+    const meta = buildFieldMeta({ accessorKey: 'project', label: 'Project', def }) as any;
+    for (const k of [
+      'reference_to_field', 'id_field', 'description_field',
+      'lookup_filters', 'lookupFilters', 'titleFormat',
+    ]) {
+      expect(meta).not.toHaveProperty(k);
+    }
+  });
+
+  it('adds no relational keys at all to a non-relational field', () => {
+    const meta = buildFieldMeta({
+      accessorKey: 'amount', label: 'Amount', def: { type: 'currency' },
+    }) as any;
+    for (const k of ['reference_to', 'reference', 'display_field']) {
+      expect(meta).not.toHaveProperty(k);
+    }
+  });
+});

--- a/packages/plugin-dashboard/src/recordFields.tsx
+++ b/packages/plugin-dashboard/src/recordFields.tsx
@@ -66,6 +66,88 @@ export const NUMERIC_FIELD_TYPES = new Set([
 ]);
 
 /**
+ * Relational keys copied from the OBJECT SCHEMA field def onto the built
+ * {@link FieldMeta}, so a lookup / master_detail / tree cell can resolve the
+ * record it references (objectui#6694).
+ *
+ * ## What was broken
+ *
+ * `LookupCellRenderer` (`@object-ui/fields`) resolves its target from
+ * `field.reference_to || field.reference` and its display field from
+ * `field.display_field`. `FieldMeta` carried NONE of those spellings, so for
+ * every lookup cell in `ObjectDataTable` and `RecordDetailDrawer` the renderer
+ * resolved `undefined` and two things failed silently: `useRefObjectSchema`
+ * never loaded the referenced object's schema (so the ADR-0079 / issue #2357
+ * resolution never ran and the cell fell back to `pickRecordDisplayName`'s
+ * generic `.name`/`.title` heuristic), and `ReferencedRecordLink`'s `objectName`
+ * was always `undefined` (so `navigable` was always `false` and the cell never
+ * rendered a real anchor — no drill-through, no middle-click, no copy-link).
+ *
+ * ## This is ADOPTED, not invented
+ *
+ * `plugin-grid`'s `ObjectGrid` already makes this exact copy —
+ * `applyRelationalMeta`, off its `RELATIONAL_META_KEYS`, at all three of its
+ * column-building call sites — which is why its lookup cells have always had
+ * both behaviours. This is that same move, made once in the seam BOTH dashboard
+ * widgets funnel through, which is what this module exists for (see the file
+ * header: the two surfaces must never drift).
+ *
+ * ## ⚠️ The copy set is DELIBERATELY 3 of the grid's 9 — measured, per key
+ *
+ * `RELATIONAL_META_KEYS` is `reference_to`, `reference`, `reference_to_field`,
+ * `display_field`, `id_field`, `description_field`, `lookup_filters`,
+ * `lookupFilters`, `titleFormat`. The grid needs all nine because its cells are
+ * EDITABLE — its own docblock says the extra keys "drive the inline picker's
+ * query (LookupField reads reference_to/reference, display_field, id_field,
+ * description_field, lookup_filters)", and the defect that earned them was an
+ * inline-edited lookup showing a raw id.
+ *
+ * These two widgets are READ-ONLY. Their only render path is
+ * {@link renderFieldValue} → `getCellRenderer` → a CELL renderer; no field
+ * EDITOR is reachable from it. Measured on `packages/fields/src/index.tsx` —
+ * the module `getCellRenderer` dispatches into — the complete set of relational
+ * keys read off a cell's `field` prop is:
+ *
+ *  - `reference_to`, `reference`, `display_field` — read by
+ *    `LookupCellRenderer` itself. ✅ COPIED.
+ *  - `id_field`, `description_field`, `lookup_filters`, `lookupFilters` — ZERO
+ *    mentions in that module; read only by `fields/src/widgets/LookupField.tsx`
+ *    and `UserField.tsx`, both EDITORS. ⛔ NOT copied.
+ *  - `reference_to_field` — ZERO member reads anywhere in the repo. ⛔ NOT
+ *    copied.
+ *  - `titleFormat` — never read off a FIELD meta at all; every reader takes it
+ *    off the OBJECT schema (`getRecordDisplayName` in `@object-ui/core`,
+ *    `containers.tsx`). On this path that object schema arrives through
+ *    `useRefObjectSchema(reference_to)` — so copying `reference_to` is what
+ *    makes `titleFormat` work, and copying `titleFormat` here would reach
+ *    nothing. ⛔ NOT copied.
+ *
+ * ⛔ Do not "restore parity" by widening this to the grid's nine. A member
+ * written from the schema def on every call and read by nothing is exactly what
+ * objectui#6625 (`decimals`) and objectui#6597 (`referenceTo`) retired from this
+ * very file. Add a key when a reader on THIS path is measured, not before; if
+ * these widgets ever gain inline editing, that is the event that earns the
+ * picker keys. The boundary is pinned in
+ * `__tests__/lookupRelationalMeta-6694.test.tsx`.
+ */
+const CELL_RELATIONAL_META_KEYS = ['reference_to', 'reference', 'display_field'] as const;
+
+/**
+ * Copy {@link CELL_RELATIONAL_META_KEYS} off a schema field def, with
+ * `applyRelationalMeta`'s own semantics: a key is written only when the def
+ * actually carries it, so a non-relational field's meta gains no keys at all and
+ * an absent key never lands as an explicit `undefined`.
+ */
+function pickCellRelationalMeta(def: any): Partial<FieldMeta> {
+  const out: Partial<FieldMeta> = {};
+  if (!def) return out;
+  for (const key of CELL_RELATIONAL_META_KEYS) {
+    if (def[key] !== undefined) out[key] = def[key];
+  }
+  return out;
+}
+
+/**
  * The override vocabulary this package's two field surfaces share.
  *
  * ⚠️ This type is a DERIVATION SOURCE, not only a shape: `ObjectDataTable`'s
@@ -109,6 +191,23 @@ export const NUMERIC_FIELD_TYPES = new Set([
  * ever wanted here, it reads `reference_to` / `reference` off the schema field
  * def directly — the spelling `LookupCellRenderer` and `computeLookupExpand`
  * actually use. ⛔ Do not resurrect `referenceTo`.
+ *
+ * ⭐ That reader ARRIVED (objectui#6694): `reference_to` / `reference` /
+ * `display_field` below, copied from the SCHEMA field def by
+ * {@link buildFieldMeta} and justified per key on `CELL_RELATIONAL_META_KEYS`.
+ * They are the "future reader" both retirement notes predicted, in the spelling
+ * they named, and they change neither verdict — the source is the schema field
+ * def, never an authored column override, which is the exact distinction
+ * objectui#6597 measured and withdrew on.
+ *
+ * ⚠️ Being `FieldMeta` members they GROW both derived bands in
+ * `ObjectDataTable.tsx` — `EnrichedColumn`'s emit tombstones and
+ * `UnheldFieldMetaOverrideKey`'s read-side refusal. That is the intended
+ * verdict rather than a side effect: an AUTHORED column may not source a
+ * lookup's reference target (objectui#6597 measured no authoring story for
+ * one), while the schema-derived write is reached by neither band. They landed
+ * in both without anyone editing a list — the property this derivation exists
+ * for.
  */
 export interface FieldMeta {
   name: string;
@@ -117,6 +216,12 @@ export interface FieldMeta {
   options?: Array<{ value: any; label: string; color?: string }>;
   format?: string;
   currency?: string;
+  /** Lookup target object, snake_case — the spelling `LookupCellRenderer` reads first. */
+  reference_to?: string;
+  /** Lookup target object, ObjectStack object-metadata spelling; the renderer's `||` fallback. */
+  reference?: string;
+  /** Author-declared display field on the lookup — beats every resolver in the cell. */
+  display_field?: string;
 }
 
 /**
@@ -205,8 +310,12 @@ export function buildFieldMeta(params: BuildFieldMetaParams): FieldMeta {
     // withdraw). It resolved `overrides.referenceTo ?? meta?.referenceTo ??
     // meta?.reference(.to) ?? meta?.target` on every call and reached no
     // reader: `LookupCellRenderer` resolves its target from
-    // `reference_to` / `reference`, never this spelling. A future reader
-    // reads `reference_to` / `reference` off the schema field def.
+    // `reference_to` / `reference`, never this spelling. ⭐ That future reader
+    // ARRIVED in objectui#6694 — the spread below, in the schema field def's own
+    // spelling, which is the one that retirement note pointed at. The
+    // retirement stands: this is a SCHEMA-derived write with no `overrides.`
+    // leg, so it makes no authored key live.
+    ...pickCellRelationalMeta(meta),
   };
 }
 


### PR DESCRIPTION
Fixes #6694

`plugin-dashboard`'s `ObjectDataTable` and `RecordDetailDrawer` build their cell meta with
`buildFieldMeta` and render it through `renderFieldValue` → `getCellRenderer` →
`LookupCellRenderer` (`@object-ui/fields`). That renderer resolves its lookup target from
`field.reference_to || field.reference` and its display field from `field.display_field`.
`FieldMeta` carried **none** of those spellings, so the renderer resolved `undefined` and
two things failed — independently, and both silently.

`plugin-grid`'s `ObjectGrid` has fed exactly these keys all along, via `applyRelationalMeta`
at all three of its column-building call sites. This adopts that move; it does not invent a
second one.

## The gating measurement — `FieldMeta` is NOT a published surface

Answered before writing the fix, because a published type would put this on the human floor.
Both halves measured, neither inferred from the `export` keyword:

| Half | Result |
| --- | --- |
| Re-exported through the package barrel? | **No.** `src/index.tsx` has no `recordFields` re-export; the built `dist/index.d.ts` names neither `FieldMeta` nor `recordFields` (zero grep hits). |
| Reachable through the `exports` map? | **No.** The map publishes only `"."`. Node's own resolver, run from a real dependent (`packages/app-shell`, which declares the dep and has the workspace symlink), resolves the bare specifier but refuses `@object-ui/plugin-dashboard/recordFields` and `.../dist/recordFields.js` with `ERR_PACKAGE_PATH_NOT_EXPORTED`. |

`vite-plugin-dts` does emit a per-file `dist/recordFields.d.ts`, so the type exists on disk —
that file is precisely the "an `export` in a module file is not a published surface" trap,
and it is unreachable. Structural reachability was checked too: the only exported value that
could carry the type is `ObjectDataTable`, typed as a `React.FC` of `ObjectDataTableProps`, and
`ObjectDataTableProps` is `{ schema; dataSource?; className? }` with no `FieldMeta` in it.
The three derived types that *do* reference `keyof FieldMeta` (`EnrichedColumn`,
`UnheldFieldMetaOverrideKey`, `AuthoredColumnOverrides`) live in `ObjectDataTable.d.ts`,
which `index.d.ts` only imports the *value* from. Repo-wide there are zero cross-package
importers of either name.

**Verdict: internal ⇒ proceed.**

## The asymmetry, confirmed on the merge-base

- `ObjectGrid` still does what the card says: `applyRelationalMeta` (`ObjectGrid.tsx:456`)
  copies its `RELATIONAL_META_KEYS` off the schema field def, called at lines 2009, 2200 and
  2283.
- `plugin-dashboard` writes neither key anywhere: every `reference_to` / `reference` /
  `display_field` occurrence in `packages/plugin-dashboard/src/*.tsx` is a comment (the
  #6597 retirement notes) or an unrelated word.

## The copy set — 3 of the grid's 9, measured per key

The card suggested `reference_to` plus `display_field` / `id_field` / `description_field`
"for parity". That is not what the measurement says. The grid needs all nine because its
cells are **editable** — its own docblock says the extra keys "drive the inline picker's
query (LookupField reads reference_to/reference, display_field, id_field, description_field,
lookup_filters)". These two widgets are **read-only**: their render path ends at a cell
renderer, and no field editor is reachable from it.

Measured on `packages/fields/src/index.tsx` — the module `getCellRenderer` dispatches into —
the complete set of relational keys read off a cell's `field` prop is three:

| Key | Reader on this path | |
| --- | --- | --- |
| `reference_to` | `LookupCellRenderer` | ✅ copied |
| `reference` | `LookupCellRenderer` (the `\|\|` fallback) | ✅ copied |
| `display_field` | `LookupCellRenderer` | ✅ copied |
| `id_field`, `description_field`, `lookup_filters`, `lookupFilters` | zero mentions in that module; read only by `widgets/LookupField.tsx` and `widgets/UserField.tsx`, both editors | ⛔ not copied |
| `reference_to_field` | zero member reads anywhere in the repo | ⛔ not copied |
| `titleFormat` | never read off a *field* meta at all — every reader takes it off the *object* schema, which on this path arrives via `useRefObjectSchema(reference_to)` | ⛔ not copied |

Copying the other six would mint six members written from the schema def on every call and
read by nothing — exactly what #6625 (`decimals`) and #6597 (`referenceTo`) retired from this
same file weeks ago. The boundary is pinned, not just documented.

## Where the fix lands

Once, in `buildFieldMeta` — the seam **both** widgets funnel through, which is what
`recordFields.tsx` exists for ("these helpers centralize that logic so the two surfaces never
drift"). `pickCellRelationalMeta` uses `applyRelationalMeta`'s own semantics: a key is written
only when the def carries it, so a non-relational field's meta gains no keys and an absent key
never lands as an explicit `undefined`.

Adding three `FieldMeta` members grows both of `ObjectDataTable`'s **derived** bands — the
`EnrichedColumn` emit tombstones and `UnheldFieldMetaOverrideKey`'s read-side refusal. That is
the intended verdict, not a side effect: an authored column may not source a lookup's
reference target (#6597 measured no authoring story for one), while the schema-derived write
is reached by neither band. `enrich()` never spreads `fieldMeta` onto the emitted column, so
the emit side stays inert. Both stale docblocks are updated to say so.

## Two silent consequences, two separate pins — both RED before, GREEN after

`packages/plugin-dashboard/src/__tests__/lookupRelationalMeta-6694.test.tsx`, run for each
widget:

1. **Display-name resolution.** The referenced object declares `nameField: 'project_code'` —
   deliberately **not** `name` / `title`, because the generic fallback usually still produces
   a readable name and a fixture whose display field *is* `name` would pass before and after
   and pin nothing. Each record also carries a `name` holding the wrong answer
   (`generic-fallback-name`), and every case asserts that value is absent.
2. **Drill-through.** Asserts the real anchor renders with the host's href
   (`/app/project_6694_b/view/p-2`), not merely that the cell renders.

Red on the merge-base, with the right failure modes (the defect is silent — the cell *did*
render, showing `generic-fallback-name` as plain text with no anchor):

```
× pin 1 (ObjectDataTable)     TestingLibraryElementError: Unable to find an element with the text: APOLLO-7
× pin 2 (ObjectDataTable)     TestingLibraryElementError: Unable to find role="link"
× pin 1 (RecordDetailDrawer)  TestingLibraryElementError: Unable to find an element with the text: APOLLO-7
× pin 2 (RecordDetailDrawer)  TestingLibraryElementError: Unable to find role="link"
× copy set                    AssertionError: expected undefined to be 'project'
Tests  5 failed | 2 passed (7)
```

The 2 that pass on the merge-base are the negative-space assertions (the six picker-only keys
are absent, and a non-relational field gains no keys) — correctly green in both directions.

## Verification

All commands run from the repo root (`packages/plugin-dashboard`-scoped) as one union, on
commit `6172b4419` — the head of this branch. (Package-dir vitest is refused by this repo's
objectui#3378 guard, which is why the root form is used.)

- `pnpm exec vitest run --maxWorkers=2 packages/plugin-dashboard/` — `Test Files 84 passed
  (84)`, `Tests 788 passed (788)`.
- `pnpm --filter "@object-ui/plugin-dashboard" run type-check` — `tsc --noEmit && tsc -p
  tsconfig.test.json`, clean.
- `node scripts/check-vi-mock-specifiers.mjs` — `✅ check-vi-mock-specifiers: OK`. Implicated
  because the new test adds a `vi.mock`; the tracked-file count moves 3914 → 3915 and
  mock-carrying files 479 → 480 with the new file staged, so this reading demonstrably covers
  it.
- `node scripts/check-control-bytes.mjs` — `✅ check-control-bytes: OK` (5561 tracked text
  files).
- `npx eslint packages/plugin-dashboard` — **0 errors**, over the 114 files ESLint itself
  selected for the package (population read from its own config via `--format json`, not
  guessed). 419 warnings, all pre-existing `no-explicit-any`; `--max-warnings` is deliberately
  unset repo-wide, as `lint.yml` says in its own comment, so errors are the pass condition.

This is a narrowing of the repo-wide `pnpm lint`, and the narrowing excludes nothing that my
diff could have moved: `eslint.config.js` sets no `project` / `projectService`, so there is no
cross-file type program and every file's verdict is computed independently — my diff cannot
change the verdict of a file it does not touch. The rest of the gate farm is left to CI, which
runs it exactly once regardless.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_