### PR TITLE
fix(core,app-shell): resolve a relationship target from a `reference` STRING only — the carrier axis

### DIFF
--- a/.changeset/6648-relationship-target-carriers.md
+++ b/.changeset/6648-relationship-target-carriers.md
@@ -1,0 +1,52 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/core': patch
+---
+
+Resolve a relationship target from a `reference` STRING only — the carrier axis
+(objectui#6648).
+
+objectui#6528 narrowed both relationship-target resolvers to the single spec
+SPELLING `reference` and left the CARRIER — the shape the value may take —
+explicitly for its own census. That census is done, and it says the same thing:
+`resolveReferenceTo` (dataset designer) and its sibling
+`resolveRelationshipTarget` (`chart-series.ts`) each accepted three carriers on
+the canonical key, two of which `FieldSchema` never declared. Both are removed
+in BOTH files in one pass (they must not diverge — a fix leaving them
+disagreeing recreates the defect one file over).
+
+The measurement, with the bare string as the positive control every zero is
+measured against:
+
+| carrier | `ObjectSchema.safeParse` (spec 17.2.0) | producers at the field-def key position |
+|---|---|---|
+| `reference: 'crm_account'` | ACCEPTED | live — 587 across both trees |
+| `reference: ['crm_account']` | REFUSED — `expected string, received array` | 0 |
+| `reference: { object: 'crm_account' }` | REFUSED — `expected string, received object` | 0 |
+
+The census walked STRUCTURE, not text: JSON/YAML parsed and walked, TS/TSX read
+through the TypeScript compiler API, each hit recorded with its ancestor
+property chain and its enclosing object's sibling keys so a FIELD DEF is
+separated from the other tiers that also spell `reference` (a form field
+literally named `reference`, its translation entries, a JSON-Schema property
+descriptor, a liveness-ledger row). Every dynamic initializer at the field-def
+position resolved to a string-typed source, and every `reference` TYPE
+declaration in either tree declares `string`. The detector is not blind to the
+shape it hunted — it DID report array and `{ object }` carriers, and every one
+was a test asserting this very tolerance plus one framework lint fixture whose
+own rule already reads string-only.
+
+The array branch was also a silent PRODUCT decision: handed a multi-target
+value it returned element zero and DISCARDED the rest. Nothing declares such a
+value. Polymorphic lookup is an open, unbuilt gap in the spec's own audit report
+("Current `reference` only supports a single target", Tier 3), and the
+platform's one polymorphic reference (ADR-0018 `xRef`) is a STRING with a
+sibling discriminator, never a list. A multi-target lookup, if it lands, lands
+as a declared spec shape — not as a carrier a consumer guesses at.
+
+Behaviour change, and it is deliberate: a field def whose `reference` is not a
+non-empty string now resolves to `undefined` in both helpers. Such a document is
+already refused by `ObjectSchema`, so per AGENTS.md #0.1 it is a producer-side
+defect, and a lenient consumer is exactly where it would have stayed hidden. The
+two unit assertions that pinned the tolerant reads are converted to refusal
+pins, so re-widening the carrier turns red.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.test.ts
@@ -27,11 +27,32 @@ describe('resolveReferenceTo', () => {
     expect(resolveReferenceTo({ reference: 'account' })).toBe('account');
   });
 
-  it('reads array + object carriers off `reference`', () => {
-    // The CARRIER (bare name / one-element array / `{ object }`) is a separate
-    // axis from the SPELLING, and objectui#6528 narrowed only the latter.
-    expect(resolveReferenceTo({ reference: ['account', 'lead'] })).toBe('account');
-    expect(resolveReferenceTo({ reference: { object: 'account' } })).toBe('account');
+  /**
+   * objectui#6648 — the CARRIER axis, pinned exactly like the SPELLING axis
+   * below and for the same reason. These two assertions used to read
+   * `.toBe('account')`: they were the tolerance written down, not evidence for
+   * it.
+   *
+   * `FieldSchema.reference` is a plain `z.string()`, and `ObjectSchema.safeParse`
+   * (spec 17.2.0) REFUSES both carriers — `invalid_type: expected string,
+   * received array` / `received object` — while ACCEPTING the bare name
+   * asserted above as the positive control. A structure-walking,
+   * key-position-aware census of both trees found 587 bare-string carriers at
+   * the field-def key position and ZERO producers of either carrier below, so
+   * resolving one could only re-hide a producer defect (AGENTS.md #0.1).
+   *
+   * The array case was the worse of the two: it returned element zero and
+   * silently DISCARDED the rest of a multi-target value. No such value is
+   * declared anywhere — polymorphic lookup is an open, unbuilt spec gap — so
+   * the branch was data loss wearing a compatibility shim. Deleting the
+   * narrowing turns this RED.
+   */
+  it.each([
+    { carrier: 'array', reference: ['account', 'lead'] as unknown },
+    { carrier: 'multi-element array (the discarded-rest case)', reference: ['account', 'lead', 'case'] as unknown },
+    { carrier: '`{ object }`', reference: { object: 'account' } as unknown },
+  ])('refuses the $carrier carrier on `reference` — a producer emitting it is the bug', ({ reference }) => {
+    expect(resolveReferenceTo({ reference })).toBeUndefined();
   });
 
   /**

--- a/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.ts
@@ -115,18 +115,40 @@ export function resolveLabel(label: unknown, fallback: string): string {
  * target any other way is a PRODUCER defect, and must fail visibly here so it is
  * fixed there.
  *
- * The string / array / `{ object }` CARRIERS are untouched: they are a separate
- * axis from the spelling, and narrowing them needs its own census.
+ * The CARRIER — the shape the value may take — is narrowed on the same evidence
+ * standard as of objectui#6648. `FieldSchema.reference` is a plain `z.string()`,
+ * and `ObjectSchema.safeParse` (spec 17.2.0) REFUSES the other two carriers on
+ * the canonical key while ACCEPTING the bare name (the positive control):
+ * `reference: ['crm_account']` is `invalid_type: expected string, received
+ * array`, `reference: { object: 'crm_account' }` is `expected string, received
+ * object`.
+ *
+ * The carrier census walked STRUCTURE, not text — JSON/YAML parsed and walked,
+ * TS/TSX through the TypeScript compiler API — recording each hit's ancestor
+ * property chain and its enclosing object's sibling keys, so a FIELD DEF is
+ * separated from the other tiers that also spell `reference` (a form field
+ * literally named `reference`, its translation entries, a JSON-Schema property
+ * descriptor, a liveness-ledger row). Across both trees: 607 hits at the
+ * field-def key position, 587 of them the bare-string carrier, and ZERO array
+ * or `{ object }` carriers from any producer. Every dynamic initializer at that
+ * position resolved to a string source, and every `reference` TYPE declaration
+ * in either tree declares `string`. The detector is not blind to the shape it
+ * hunted: it DID report array and `{ object }` carriers — the two green pins
+ * that asserted this tolerance, and one framework lint FIXTURE whose own rule
+ * (`refOf`) already reads string-only.
+ *
+ * The array branch was also a silent PRODUCT decision: handed a multi-target
+ * value it returned `raw[0]` and discarded the rest. Nothing declares such a
+ * value — polymorphic lookup is an open Tier-3 gap in the spec's own audit
+ * report ("Current `reference` only supports a single target"), and the
+ * platform's one polymorphic reference (ADR-0018 `xRef`) is a STRING with a
+ * sibling discriminator, never a list. If multi-target lookups land they land
+ * as a declared spec shape; until then, silently taking element zero is data
+ * loss wearing a compatibility shim.
  */
 export function resolveReferenceTo(def: Record<string, unknown>): string | undefined {
   const raw = def.reference;
-  if (typeof raw === 'string' && raw) return raw;
-  if (Array.isArray(raw) && typeof raw[0] === 'string') return raw[0];
-  if (raw && typeof raw === 'object') {
-    const obj = (raw as { object?: unknown }).object;
-    if (typeof obj === 'string' && obj) return obj;
-  }
-  return undefined;
+  return typeof raw === 'string' && raw ? raw : undefined;
 }
 
 /** Map a framework field type onto a dataset dimension type. */

--- a/packages/core/src/utils/__tests__/chart-series.test.ts
+++ b/packages/core/src/utils/__tests__/chart-series.test.ts
@@ -196,11 +196,30 @@ describe('relabelDimensions + buildChartSeries (the value≠label chart bug, clo
 
 describe('resolveRelationshipTarget (objectui#4053)', () => {
   it('reads the target off the spec spelling `reference`', () => {
+    // The positive control: the one carrier `ObjectSchema.safeParse` ACCEPTS,
+    // and the one every zero below is measured against.
     expect(resolveRelationshipTarget({ type: 'lookup', reference: 'crm_account' })).toBe('crm_account');
-    // Array and `{ object }` carriers. The CARRIER is a separate axis from the
-    // SPELLING, and objectui#6528 narrowed only the latter.
-    expect(resolveRelationshipTarget({ type: 'lookup', reference: ['crm_account'] })).toBe('crm_account');
-    expect(resolveRelationshipTarget({ type: 'lookup', reference: { object: 'crm_account' } })).toBe('crm_account');
+  });
+
+  /**
+   * objectui#6648 — the mirror of the dataset designer's CARRIER refusal pin,
+   * kept in lockstep for the same reason the spelling pins are (see below): the
+   * two canonicalizations are one doctrine in two files, and a divergence
+   * recreates the defect one file over.
+   *
+   * These two used to assert `.toBe('crm_account')` — the tolerance written
+   * down. The census that removed them walked STRUCTURE, not text, across both
+   * trees and found ZERO producers of either carrier at the field-def key
+   * position, against 587 bare-string carriers there. `ObjectSchema.safeParse`
+   * (spec 17.2.0) REFUSES both as `invalid_type`, and the array branch also
+   * discarded every element after the first.
+   */
+  it.each([
+    { carrier: 'array', reference: ['crm_account'] as unknown },
+    { carrier: 'multi-element array (the discarded-rest case)', reference: ['crm_account', 'crm_lead'] as unknown },
+    { carrier: '`{ object }`', reference: { object: 'crm_account' } as unknown },
+  ])('refuses the $carrier carrier on `reference` — a producer emitting it is the bug', ({ reference }) => {
+    expect(resolveRelationshipTarget({ type: 'lookup', reference })).toBeUndefined();
   });
 
   /**

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -942,8 +942,10 @@ function fieldDefsOf(schema: unknown): Record<string, unknown> | null {
  *
  * The target lives under `reference` — the ONLY spelling read here, and the same
  * canonicalization as the dataset designer's `resolveReferenceTo`, which is
- * narrowed to match in the same pass (objectui#6528). The value may still carry
- * a bare name, a one-element array, or `{ object }`.
+ * narrowed to match in the same pass (objectui#6528). As of objectui#6648 the
+ * CARRIER matches too: a bare string and nothing else. The two helpers are one
+ * doctrine in two files and must never drift — a divergence recreates the
+ * defect one file over.
  *
  * The three legacy spellings this dropped (`reference_to` / `referenceTo` /
  * `reference_to_object`) were censused against every producer, with `reference`
@@ -967,6 +969,25 @@ function fieldDefsOf(schema: unknown): Record<string, unknown> | null {
  * `reference` was already HEAD of the old chain, so any doc carrying both is
  * unaffected.
  *
+ * The array and `{ object }` CARRIERS this used to accept were censused on the
+ * same standard and removed with the same reasoning (objectui#6648).
+ * `FieldSchema.reference` is a plain `z.string()`; `ObjectSchema.safeParse`
+ * (spec 17.2.0) ACCEPTS `reference: 'crm_account'` and REFUSES both
+ * `['crm_account']` and `{ object: 'crm_account' }` as `invalid_type`. A
+ * structure-walking, key-position-aware census of both trees found 587
+ * bare-string carriers at the field-def key position and ZERO array or
+ * `{ object }` carriers from any producer — the only ones in either tree were
+ * the green pins asserting this very tolerance. See `resolveReferenceTo` for
+ * the full census, including why a multi-target lookup is NOT what the array
+ * branch was serving: it returned `raw[0]` and discarded the rest, and
+ * polymorphic lookup remains an undeclared, open spec gap.
+ *
+ * This path matters MORE than the designer's for the same reason the spelling
+ * narrowing did: it reads the metadata document directly, with no `readFields`
+ * door in between, so a non-string carrier now degrades visibly (the walk
+ * yields no entry and the caller keeps the raw value) instead of being absorbed
+ * here.
+ *
  * The **type gate is deliberate**: only a declared relationship is walked, so a
  * path segment naming a plain field can never be turned into an object name and
  * fetched speculatively.
@@ -980,13 +1001,7 @@ export function resolveRelationshipTarget(fieldDef: unknown): string | undefined
   const type = typeof def.type === 'string' ? def.type.toLowerCase() : '';
   if (!RELATIONSHIP_FIELD_TYPES.has(type)) return undefined;
   const raw = def.reference;
-  if (typeof raw === 'string' && raw) return raw;
-  if (Array.isArray(raw) && typeof raw[0] === 'string' && raw[0]) return raw[0];
-  if (raw && typeof raw === 'object') {
-    const obj = (raw as { object?: unknown }).object;
-    if (typeof obj === 'string' && obj) return obj;
-  }
-  return undefined;
+  return typeof raw === 'string' && raw ? raw : undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes #6648

objectui#6528 narrowed both relationship-target resolvers to the single spec
SPELLING `reference` and deliberately left the CARRIER — the shape the value may
take — for its own census, because cutting on an unfinished census is exactly
what #6528 was filed to stop. That census is now run, to #6528's standard, and
it forces the removal.

## The census — method first

Not a grep. A bare grep for `reference` conflates tiers (PR #6670's `options`
row: 71 bare hits, zero on a `ListColumn`), so this walked STRUCTURE:

- **JSON / YAML** — parsed, then walked recursively, recording each hit's
  ancestor property chain.
- **TS / TSX / JS** — read through the **TypeScript compiler API**, recording
  each hit's ancestor property chain, the classification of its initializer by
  AST node kind (string literal / array literal / object literal / dynamic),
  and the **sibling keys of its enclosing object literal**.

Sibling keys are what make it key-position aware without depending on how a
literal is nested. **Tier A** = the key position these two resolvers actually
read — a FIELD DEF: a sibling `type` naming a relationship, or an ancestor chain
running through `fields`. **Tier B** = every other place the word `reference` is
a key.

Trees: `objectui` @ `98188c284` and `objectstack` @ `8cb96ec` (both `origin/main`;
the framework tree was checked out fresh for this, not read off a stale
working copy). 10,439 files parsed. 16 parse failures, every one a `tsconfig*.json`
written as JSONC — enumerated and none of them a metadata document.

## The census — population and result

| | objectui | objectstack | total |
|---|---:|---:|---:|
| `reference` KEY hits, all tiers | 184 | 506 | 690 |
| Tier A (field-def key position) | 146 | 461 | 607 |
| **Tier A, bare-string carrier — the positive control** | 138 | 449 | **587** |
| **Tier A, ARRAY carrier** | 1 | 0 | **1** |
| **Tier A, `{ object }` carrier** | 3 | 5 | 8 |
| Tier A, dynamic initializer | 4 | 7 | 11 |

The 449 in the framework tree corroborates #6528's independently-taken count
(445 of 565 lookup / master_detail defs).

**Every non-string Tier-A hit was run down individually.**

- The **one Tier-A array** is `chart-series.test.ts:202` — the green pin that
  asserted this very tolerance.
- Of the 8 `{ object }` hits: 2 are the other green pins; 4 are translation
  entries for a metadata-form field literally NAMED `reference`; 1 is a
  JSON-Schema property descriptor that itself says `type: 'string'`; 1 is a
  field named `reference` of `type: 'text'`; and 1 is
  `objectstack packages/lint/src/runtime-gate.object-writes.test.ts:358`, a lint
  fixture — whose own rule's reader (`refOf`) is already string-only, so the
  carrier resolves to `undefined` there and the fixture's assertion (about
  finding paths) is unaffected. Filed separately, see below.
- All 11 dynamic initializers resolve to string-typed sources: `PARENT` /
  `ACCOUNT` string consts, `foreignKey.referencedTable` (declared `string`),
  `OUTPUT_LOOKUP_OBJECTS` (`Record(string, string)`), the two designer writers'
  `referenceTo` (declared `string`), and `null` in blueprint tests whose schema
  is `z.string().nullable()`.
- Independently: **every `reference` TYPE declaration in either tree declares
  `string`** (28 of them), except three `unknown` at tolerant read sites and one
  `string | string[]` in `auditHistoryDisplay.ts` whose runtime reader refuses
  non-strings anyway.

**Producers of an array or `{ object }` carrier at the field-def key position:
ZERO.**

### The zero is not a blind query

Per this seat's rule, a zero does not exist until a positive control fires in
the same query shape — and here there are two:

1. The **string row fires at 587** in the same Tier-A query shape.
2. The **array/`{ object }` detector itself demonstrably fires** — it reported
   array and `{ object }` carriers, at exactly the field-def key position. It is
   just that every one it found was a test asserting the tolerance, or the one
   lint fixture above. The detector can see the shape; there is nothing else
   emitting it.

### The open question the card named, run down

The card asked specifically whether any **polymorphic / multi-target lookup is
intended to carry a list**. It is not:

- `Field.reference` is `type: string` in the spec's own JSON Schema, described
  as "Target object name (snake_case)". Singular.
- **Polymorphic lookup is an acknowledged, unbuilt gap** in the spec's own audit
  report: "Salesforce's WhoId/WhatId can point to multiple objects. **Current
  `reference` only supports a single target**" — listed under Tier 3
  (T3-2), i.e. future work, not a shipped shape.
- The spec's `multiple` key means multiple **values** of the SAME target, not
  multiple targets; `reference` stays one string.
- The platform's one implemented polymorphic reference (ADR-0018 `xRef`,
  approval approver values) is a **string with a sibling discriminator**, never
  a list.
- A third consumer that already met this question —
  `auditHistoryDisplay.lookupTarget`, commented "skip polymorphic" — chose to
  **refuse** the non-string carrier rather than take element zero.

If multi-target lookups ever land, they land as a declared spec shape. Nothing
today declares one, and `ObjectSchema.safeParse` refuses one.

## What changed

`FieldSchema.reference` is a plain `z.string()`. Re-measured here on spec
17.2.0, one lookup field:

| carrier | verdict |
|---|---|
| `reference: 'crm_account'` | ACCEPTED, value survives |
| `reference: ['crm_account']` | REFUSED — `invalid_type: expected string, received array` |
| `reference: ['crm_account','crm_lead']` | REFUSED — same |
| `reference: { object: 'crm_account' }` | REFUSED — `expected string, received object` |

Both resolvers branched on all three. Both are narrowed to the string carrier,
**in one pass, in both files**, so the two canonicalizations cannot diverge:

- `packages/core/src/utils/chart-series.ts` — `resolveRelationshipTarget`
- `packages/app-shell/src/views/metadata-admin/inspectors/useDatasetFields.ts` — `resolveReferenceTo`

**The array branch was a silent product decision, not a compatibility shim.**
Handed a multi-target value it returned `raw[0]` and **discarded the rest** — no
warning, no error, a plausible-looking answer. That is data loss, and it is the
precise shape AGENTS.md #0.1 forbids: the lenient consumer is where the wrong
producer hides.

## The two existing tests were cover, not evidence

The carrier assertions in `useDatasetFields.test.ts` and `chart-series.test.ts`
read `.toBe('account')` / `.toBe('crm_account')` — they were the tolerance
written down. They are converted to **refusal pins extending #6528's existing
`refuses the legacy spelling ...` shape** (same `it.each`, same
"a producer emitting it is the bug" wording, same `toBeUndefined()`), with a
third case added per file for the multi-element array — the discarded-rest case
the old branch was silently answering.

## Verification

Ablation, run after the fix was committed so the restore leg had a real
reference point. Precondition checked and stated: both test files import the
source **relatively** (`../chart-series`, `./useDatasetFields`), not through the
package `exports`, so no `dist` is in the resolution path and no rebuild leg is
required. Mutation = `git checkout origin/main --` the two resolvers; **proved on
disk** by anchored counts, not by an editor exit code (`Array.isArray(raw)`
reintroduced 1/1, narrowed return gone 0/0, plus a non-empty `git diff HEAD --stat`).
The script carried `trap ... EXIT INT TERM`.

Direction predicted before running: RED, and specifically red on the six new
carrier pins only.

```
vitest exit: 1
 × refuses the 'array' carrier on `reference` ...                      (x2 files)
 × refuses the 'multi-element array (the discarded-rest case)' ...     (x2 files)
 × refuses the '`{ object }`' carrier on `reference` ...               (x2 files)
 Test Files  2 failed (2)
      Tests  6 failed | 56 passed (62)
```

Exactly the six new pins moved; the other 56 stayed green. Restore proved by
observing state, not exit codes: `git hash-object` of each path equals its HEAD
blob, `git diff HEAD` empty, `git status --porcelain` empty.

Green union, re-run **after** the final commit, at `adb1c9ec8`:

- `pnpm exec vitest run` on both pinned files — `Test Files 2 passed (2)`,
  `Tests 62 passed (62)`
- `pnpm --filter @object-ui/core --filter @object-ui/app-shell type-check`
  (`tsc --noEmit && tsc -p tsconfig.test.json`) — `Done` for both. `--listFiles`
  confirms both edited test files are inside the test program, so "typecheck
  clean" actually covers them.
- `pnpm --filter '@object-ui/core^...' --filter '@object-ui/app-shell^...' build`
  — dependency closures built before any of the above.
- `pnpm check:control-bytes` — its own verdict line:
  `check-control-bytes: OK (scanned 5570 tracked text file(s); skipped 85 binary)`,
  plus a direct control-byte scan of the four edited files.

**Lint was narrowed, and the narrowing is measured rather than assumed:**
(1) the population comes from eslint's own config resolution, not a guess about
which files count; (2) `--format json` reports **4 files linted, 0 errors, 4
warnings**, all four warnings pre-existing in `useDatasetFields.ts` at lines
193/277/324, outside this diff; (3) the root config extends
`tseslint.configs.recommended` with **no** `parserOptions.project` and no
`projectService` — type-aware linting is off — so every file's verdict is a
function of its own text plus the shared config, and a diff touching four
source files and no config file cannot move any untouched file's verdict. CI
runs the full farm regardless.

## Changeset

`patch` for `@object-ui/app-shell` and `@object-ui/core`. Reasoning: this
removes branches that no producer can reach on any document the spec accepts, so
no user-visible behaviour changes for any valid input — the census is the
evidence for that claim, not an assumption. It is not `minor` (no new
capability, nothing additive) and not `major` (the only inputs whose result
changes are ones `ObjectSchema` already refuses, i.e. producer-side defects that
should surface rather than be absorbed). This matches the score #6528 took for
the same class of narrowing on the spelling axis.

## Filed separately, not fixed here

- `objectstack` — the lint fixture at
  `packages/lint/src/runtime-gate.object-writes.test.ts:358` spells a carrier the
  spec refuses; its own rule already reads string-only.
- `objectui` — `packages/app-shell/src/utils/auditHistoryDisplay.ts` declares
  `reference?: string | string[]` and `reference_to?: string | string[]` and
  reads `reference_to ?? reference`: a third site carrying both a widened carrier
  type and #6528's legacy-spelling chain. Its runtime read already refuses
  non-strings, so there is no live defect — hygiene on both axes, and a
  different axis from this card, so it is filed rather than ridden along.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_