### PR TITLE
docs(data-objectstack): correct stale header in aggregate-capability.test.ts

### DIFF
--- a/.changeset/5954-aggregate-capability-header.md
+++ b/.changeset/5954-aggregate-capability-header.md
@@ -1,0 +1,10 @@
+---
+---
+
+Comment-only correction of the "WHY THIS EXISTS" header in
+`packages/data-objectstack/src/aggregate-capability.test.ts`: it claimed
+`@objectstack/client`'s `analytics.query()` never throws on a non-2xx. The
+installed `@objectstack/client@17.2.0` does throw — `ObjectStackClient.fetch`
+throws on `!res.ok` before `analytics.query` reaches its own `res.json()` —
+and every test in the file depends on that throw reaching the adapter's
+`catch`. No behaviour change; test assertions are unchanged (objectui#5954).

--- a/packages/data-objectstack/src/aggregate-capability.test.ts
+++ b/packages/data-objectstack/src/aggregate-capability.test.ts
@@ -9,12 +9,22 @@
 /**
  * `aggregate()` against an analytics endpoint that cannot answer.
  *
- * WHY THIS EXISTS. `@objectstack/client`'s `analytics.query()` returns
- * `res.json()` WITHOUT checking `res.ok`, so a non-2xx never throws — the error
- * body arrives where rows were expected. The adapter's row parser matched none
- * of its shapes, produced `[]`, and returned it as a RESULT: the `catch` that
- * promises a client-side fallback never ran, and a KPI on a deployment without
- * `@objectstack/service-analytics` rendered a confident **zero**.
+ * WHY THIS EXISTS. `@objectstack/client@17.2.0`'s `analytics.query()` DOES call
+ * `res.json()`, but only after `this.fetch(...)` — `ObjectStackClient.fetch` in
+ * the installed client's `dist/index.mjs` — which throws on `!res.ok` before
+ * `analytics.query` ever reaches its own `res.json()`. So today a non-2xx never
+ * arrives as data; it arrives as a thrown, decorated `Error` (`code` flattened
+ * from `errorBody?.code ?? errorBody?.error?.code`, plus `httpStatus`,
+ * `message`, `details`), and every test below this header depends on that catch
+ * firing. This paragraph used to describe the opposite: a client that returned
+ * `res.json()` WITHOUT checking `res.ok`, so the error body arrived where rows
+ * were expected, the adapter's row parser matched none of its shapes, produced
+ * `[]`, and returned it as a RESULT — the `catch` that promises a client-side
+ * fallback never ran, and a KPI on a deployment without
+ * `@objectstack/service-analytics` rendered a confident **zero**. That defect is
+ * why this file and `classifyAnalyticsFailure` exist; it is no longer what the
+ * installed client does, so it is recorded here as history rather than as the
+ * present-tense mechanism (objectui#5954).
  *
  * That is the same lie framework#3891 removed from the server side (a degraded
  * shim answering 200 with unscoped numbers), reproduced one layer up. These


### PR DESCRIPTION
Fixes #5954

## What was wrong

The "WHY THIS EXISTS" header in
`packages/data-objectstack/src/aggregate-capability.test.ts` claimed:

> `@objectstack/client`'s `analytics.query()` returns `res.json()` WITHOUT
> checking `res.ok`, so a non-2xx never throws — the error body arrives
> where rows were expected.

That is false of the client this repo has installed. It was true history —
the defect the file was written to pin against — but stated in the present
tense, directly above tests written against the opposite behaviour.

## What I measured (not copied from triage)

- **Installed version**: `@objectstack/client@17.2.0`, confirmed via
  `pnpm-lock.yaml` and the resolved `node_modules/.pnpm/@objectstack+client@17.2.0_.../node_modules/@objectstack/client/package.json`.
- **Throw site**: `ObjectStackClient.fetch` (the `dist/index.mjs` class at
  line 614), method at line 4272:
  ```js
  const res = await this.fetchImpl(url, { ...options, headers });
  ...
  if (!res.ok) {
    let errorBody;
    try { errorBody = await res.json(); } catch { errorBody = { message: res.statusText }; }
    ...
    const error = new Error(errorMessage);
    error.code = errorCode;       // errorBody?.code ?? errorBody?.error?.code
    error.httpStatus = res.status;
    ...
    throw error;
  }
  return res;
  ```
  `analytics.query` (line 921-929) is:
  ```js
  query: async (payload) => {
    const route = this.getRoute("analytics");
    const res = await this.fetch(`${this.baseUrl}${route}/query`, { method: "POST", body: JSON.stringify(payload) });
    return res.json();
  },
  ```
  So `analytics.query` does call `res.json()`, but only after `this.fetch(...)`
  — and `this.fetch` throws before returning on any non-2xx. `res.json()`
  inside `analytics.query` is therefore unreachable for a non-2xx response.
- **Dependent assertions**: every test in the file except the two 2xx cases
  under `describe('aggregate() on a healthy analytics endpoint', …)` supplies
  a non-2xx `analyticsStatus` and asserts on the adapter's `catch`-driven
  behaviour (`classifyAnalyticsFailure`'s branches) — e.g. the very first one,
  `'404 (routes not mounted, framework#4019) falls back instead of returning
  an empty result'`, passes *because* the throw reaches that `catch`. On a
  client that truly returned the error body as data, `aggregate()` would
  short-circuit on `[]` and that assertion would fail.

Confirms the issue's premise exactly: `premise_still_valid: true`.

## What changed

Comment-only rewrite of the header's first paragraph to state the measured,
present-tense mechanism (client throws inside `fetch`, decorates the error,
`analytics.query`'s own `res.json()` is unreachable on non-2xx), with the old
paragraph kept as explicit history — the defect the file exists to catch —
rather than deleted. No test code, assertion, or behaviour changed;
`git diff` touches only the docblock.

## Tests

- `pnpm exec vitest run packages/data-objectstack/src/aggregate-capability.test.ts`
  (run from repo root — the package-directory form is blocked by this repo's
  own `OBJECTUI_VITEST_GUARD`, objectui#3378): **12 passed, 12 passed** —
  unchanged, confirming this is comment-only.
- `pnpm --filter @object-ui/data-objectstack run type-check` (`tsc --noEmit`): clean.
- `npx eslint packages/data-objectstack/src/aggregate-capability.test.ts`: 0 errors, 11 pre-existing `no-explicit-any` warnings (all in test-body code untouched by this diff, not in the header).
- `node scripts/check-changeset-presence.mjs`: ✅ — 1 published-source file changed, 1 changeset declared.
- `node scripts/check-changeset-no-major.mjs`: ✅.
- NUL/control-byte self-scan on both changed files: clean.

## Changeset

`packages/data-objectstack` is in `.changeset/config.json`'s `fixed` group,
and this PR's diff is under its `src/`, so `check-changeset-presence.mjs`
requires a declaration even though this is test-only — its own header says
so explicitly ("No carve-out for test files under `src/`"). Added
`.changeset/5954-aggregate-capability-header.md` with **empty frontmatter**
(the documented "declares no release" exemption) and a one-paragraph
explanation, per the gate's own accepted format.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_