### PR TITLE
docs(skills): align the data-integration guide with the real QueryParams, SortConfig and QueryResult contracts

### DIFF
--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -63,12 +63,13 @@ interface DataSource<T = any> {
 
 ```typescript
 interface QueryParams {
-  filter?: Record<string, any>;   // WHERE conditions
-  sort?: SortConfig[];            // ORDER BY [{field, direction}]
-  limit?: number;                 // LIMIT (page size)
-  offset?: number;                // OFFSET (for pagination)
-  fields?: string[];              // SELECT specific fields
-  expand?: string[];              // JOIN/expand related objects
+  $select?: string[];             // SELECT specific fields
+  $filter?: Record<string, any> | FilterArray;  // WHERE conditions (FilterArray: @objectstack/spec/data)
+  $orderby?: string | Record<string, 'asc' | 'desc'> | string[] | Array<{ field: string; order?: 'asc' | 'desc' }>;
+  $skip?: number;                 // OFFSET (for pagination)
+  $top?: number;                  // LIMIT (page size)
+  $expand?: string[];             // JOIN/expand related objects
+  [key: string]: any;             // why an unprefixed `limit` type-checks — and is then dropped
 }
 ```
 
@@ -76,12 +77,13 @@ interface QueryParams {
 
 ```typescript
 interface QueryResult<T = any> {
-  records?: T[];                  // Returned data array
-  pageSize?: number;              // Items per page
-  pageNumber?: number;            // Current page (1-indexed)
+  data: T[];                      // Returned data array — required, and NOT named `records`
   total?: number;                 // Total count for pagination
+  page?: number;                  // Current page (1-indexed)
+  pageSize?: number;              // Items per page
   hasMore?: boolean;              // Cursor-based pagination flag
   cursor?: string;                // Next page cursor
+  metadata?: Record<string, any>; // Additional metadata
 }
 ```
 
@@ -268,11 +270,11 @@ function MyPlugin() {
 
   const loadData = async () => {
     const result = await dataSource.find('contacts', {
-      filter: { active: true },
-      sort: [{ field: 'name', direction: 'asc' }],
-      limit: 20,
+      $filter: { active: true },
+      $orderby: [{ field: 'name', order: 'asc' }],
+      $top: 20,
     });
-    return result.records;
+    return result.data;
   };
 }
 ```
@@ -358,18 +360,18 @@ export class RestApiAdapter implements DataSource {
 
   async find(resource: string, params?: QueryParams): Promise<QueryResult> {
     const url = new URL(`${this.baseUrl}/${resource}`);
-    if (params?.filter) url.searchParams.set('filter', JSON.stringify(params.filter));
-    if (params?.limit) url.searchParams.set('limit', String(params.limit));
-    if (params?.offset) url.searchParams.set('offset', String(params.offset));
-    if (params?.sort) url.searchParams.set('sort', JSON.stringify(params.sort));
+    if (params?.$filter) url.searchParams.set('filter', JSON.stringify(params.$filter));
+    if (params?.$top) url.searchParams.set('limit', String(params.$top));
+    if (params?.$skip) url.searchParams.set('offset', String(params.$skip));
+    if (params?.$orderby) url.searchParams.set('sort', JSON.stringify(params.$orderby));
 
     const res = await fetch(url.toString());
-    const data = await res.json();
+    const body = await res.json();
 
     return {
-      records: data.items,
-      total: data.totalCount,
-      pageSize: params?.limit,
+      data: body.items,
+      total: body.totalCount,
+      pageSize: params?.$top,
     };
   }
 
@@ -429,6 +431,7 @@ unsubscribe?.();
 
 ## Common data integration mistakes
 
+- Spelling `QueryParams` options without the `$` prefix (`limit`, `filter`, `sort`): the index signature accepts them, nothing reads them, and a dropped `$top` fetches the whole table.
 - Importing `fetch` directly in components instead of using DataSource from context.
 - Forgetting to await `startMockServer()` before rendering — MSW intercepts aren't ready.
 - Mismatched `baseUrl` between MSW plugin and ObjectStackAdapter — requests bypass mocks.


### PR DESCRIPTION
Fixes #6006
Fixes #5947

One published-skill correction, folded because both cards land on the same file: `skills/objectui/guides/data-integration.md`. Every corrected snippet was checked verbatim against the real declarations, not against the cards' quoted line numbers (which had drifted — `SortConfig` is at `packages/types/src/objectql.ts:311`, not `:212`).

Authored in session https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq

## Size — the 2026-08-21 published-skills ruling

| | lines |
| --- | --- |
| before | 437 |
| after | 440 |
| net | +3 |

Whole published package, all 18 markdown files under `skills/`: 5673 before, 5676 after. This is a correction, not an expansion: three of the four defect blocks are same-line-count rewrites, and the +3 is one line per corrected interface (the real declarations carry one field more than the sketches did) plus one bullet in the existing mistakes list.

## Defect 1 — query options were spelled without the `$` prefix (#6006)

The real `QueryParams` (`packages/types/src/data.ts:43`) ends in an index signature, so an unprefixed key type-checks, is never read, and is dropped in silence. A dropped page size is an unbounded read.

| guide taught (silently dropped) | real key |
| --- | --- |
| `filter` | `$filter` |
| `sort` | `$orderby` |
| `limit` | `$top` |
| `offset` | `$skip` |
| `fields` | `$select` |
| `expand` | `$expand` |

Corrected in three places: the interface sketch, the worked `dataSource.find` example (which passed `filter` / `sort` / `limit` — all three dropped), and the `RestApiAdapter` sample, which read `params?.filter` / `params?.limit` / `params?.offset` / `params?.sort` off a real `QueryParams` and therefore read nothing. The adapter's *outgoing* query-string names are unchanged — those are its own REST wire format, and translating is the adapter's job.

## Defect 2 — the sort direction key (#6006)

`SortConfig` (`packages/types/src/objectql.ts:311`) spells the key `order`, and `convertSortToQueryParams` (`packages/core/src/utils/sort-query.ts`) folds it as `entry.order === 'desc' ? 'desc' : 'asc'` — so an entry spelled `direction` yields ascending, always, with nothing thrown.

- before: `sort: [{ field: 'name', direction: 'asc' }]`
- after: `$orderby: [{ field: 'name', order: 'asc' }]`

## Defect 3 — the `QueryResult` sketch declared a shape that does not exist (#5947)

Root cause of the bad usage, so it is fixed first. The real `QueryResult` (`packages/types/src/data.ts:139`) has a **required** `data`; the guide declared `records?` and `pageNumber?` and omitted `data` entirely.

| guide declared | real |
| --- | --- |
| `records?` | `data` (required) |
| `pageNumber?` | `page?` |
| absent | `metadata?` |

The example's `return result.records;` is now `return result.data;`, and the `RestApiAdapter` return is `data:` rather than `records:` (its local `const data` is renamed `body` so the returned key is unambiguous).

## Sweep

Swept the whole file for all three defect classes; the counts above are the complete population. The one surviving `records` token is `dataset.records` in the MSW seeding loop, which is app-manifest data and unrelated, and the one surviving `records` mention in the corrected sketch is the deliberate "NOT named `records`" callout. No prose outside the four blocks was rewritten, and no sibling guide was touched.

## Gates, at 29e9685

| gate | exit | verdict line it printed |
| --- | --- | --- |
| `check:skills-paths` | 0 | `check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined).` |
| `check:control-bytes` | 0 | `check-control-bytes: OK (scanned 5593 tracked text file(s); skipped 85 binary).` |
| `check:doc-fences` | 0 | `check:doc-fences — every TypeScript block in 223 document(s) is fenced ts/tsx/typescript ...` |
| changeset presence | 0 | `No source of a released package changed in this range, so no changeset is owed.` |

Exit codes were captured by redirecting first, never through a pipe. The union was re-run after the final commit and reports that tree.

**No changeset is owed** and none is added — the gate's own verdict, not a judgement call: `skills/` is outside the `packages` / `apps` roots the release covers. No `skip-changeset` label is applied; in this repo that label is a phantom that gates nothing.

## The coverage gap this pair is an instance of — already on file as #5465

`check-doc-snippet-types.mjs` is the gate that compiles TypeScript in docs, but its scan surface is `content/docs` plus the package READMEs. Measured by calling its own `listDocuments()`: 223 documents in surface, **0** under `skills/`, and this file absent. So no gate compiles the snippets in these published skills, which is how both defects shipped and why this PR's snippets were checked by hand against the declarations instead. That gap is already filed and dispatched as #5465, so no duplicate was opened, and it is not widened here.

_Generated by [Claude Code](https://claude.ai/code)_