### PR TITLE
docs(skills): stop teaching the table renderer's retired column aliases

### DIFF
--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -499,14 +499,14 @@ never against a current element:
   its `children` **once** and lays them out in columns. A `bind` on a `grid` is
   inert.
 - **`table`** renders rows from an inline `data` array against `columns`
-  accessors (`accessorKey`, falling back to `name`). Cell values are plain
-  property lookups — never expressions — and `table` does not read `bind`.
+  accessors (`accessorKey`). Cell values are plain property lookups — never
+  expressions — and `table` does not read `bind`.
 
 ```json
 // ✅ `table`: inline rows + column accessors, no per-row scope
 {
   "type": "table",
-  "columns": [{ "label": "Name", "accessorKey": "name" }],
+  "columns": [{ "header": "Name", "accessorKey": "name" }],
   "data": [{ "name": "Ada" }, { "name": "Linus" }]
 }
 ```


### PR DESCRIPTION
Fixes #5473

The customer-published guide `skills/objectui/guides/schema-expressions.md` taught the static `table` renderer's two retired column aliases. Both sites were re-derived against `origin/main` (line numbers in the filing had drifted) and both card premises were verified in-tree before editing.

## Alias-retirement state: LANDED

Measured in-tree at base `546f610`, not recalled:

`packages/components/src/renderers/complex/table.tsx` reads exactly two column keys, and neither alias survives:

- header: `{col.header}` — one occurrence
- cell: `{row[col.accessorKey]}` — one occurrence
- `col.label` / `col.name` — **zero** occurrences (positive control: `col.header` returns 1, so the grep is real, not a mistyped path)

The renderer imports `StaticTableColumn`, and `packages/components/src/renderers/complex/__tests__/table-column-contract.test.tsx` pins the retirement, naming it in its header:

> objectui#5350 — the static `table` renderer reads ONLY the declared `TableColumn` contract (`header` + `accessorKey`).

That test pins **this PR's exact broken example** as the failure case:

```
it('does NOT resolve a header through the retired `label` alias', () => {
  const { container } = renderTable([{ label: 'Name', accessorKey: 'name' }]);
  // `accessorKey` is declared, so the cell still renders...
  expect(screen.getByText('Ada')).toBeInTheDocument();
  // ...but `label` is not a header: the heading resolves to nothing.
  expect([...container.querySelectorAll('thead th')].map((e) => e.textContent)).toEqual(['']);
```

So the guide was shipping an example that the repo's own pin test asserts renders an empty heading.

The correction is safe in any ordering — `header` + `accessorKey` is the declared contract both before and after the retirement — but since the retirement has landed, the guide was actively wrong on `main`, not merely ahead of it.

## Declared contract, verified independently

One refinement to the filing worth reviewer attention. The card cited `TableColumn`; that interface does declare required `header` and required `accessorKey`, so the conclusion holds. But `type: "table"` columns are now typed as **`StaticTableColumn`**, the narrow split introduced by objectui#5474 (maintainer ruling 2026-08-22, Option C). It likewise declares required `header` and `accessorKey`, and carries `?: never` tombstones for the keys the static renderer never read. `TableColumn` remains the rich shape `data-table` honours. Either way `label` is declared nowhere and `name` is not an accessor.

## The change

Two edits, both inside the `type: "table"` section.

Prose — before:

```
- **`table`** renders rows from an inline `data` array against `columns`
  accessors (`accessorKey`, falling back to `name`). Cell values are plain
  property lookups — never expressions — and `table` does not read `bind`.
```

after:

```
- **`table`** renders rows from an inline `data` array against `columns`
  accessors (`accessorKey`). Cell values are plain property lookups — never
  expressions — and `table` does not read `bind`.
```

Worked example — before:

```
"columns": [{ "label": "Name", "accessorKey": "name" }],
```

after:

```
"columns": [{ "header": "Name", "accessorKey": "name" }],
```

## Scope fence

Only the `type: "table"` prose and example. The `data-table` example earlier in the same file still authors `{ "name": ..., "label": ... }` columns; that block belongs to #5120 and #5351 and is deliberately untouched here. `data-integration.md` is owned by another dispatch and is not in this diff. Those cards are not addressed by this PR and remain open.

## Line counts (published-skills ruling, 2026-08-21)

Correction, not expansion — the net is exactly zero.

| Scope | Before | After | Delta |
|---|---|---|---|
| `skills/objectui/guides/schema-expressions.md` | 621 | 621 | 0 |
| Whole published package (all 18 `.md` under `skills/`) | 5673 | 5673 | 0 |
| `SKILL.md` files only | 155 | 155 | 0 |

`git diff --numstat`: `3 3 skills/objectui/guides/schema-expressions.md` — three lines replaced, none added.

## Gates

Derived from `package.json` against the actual diff path, not recalled. Exit codes captured by redirect-then-capture; verdict lines are each gate's own.

| Gate | Verdict line | Exit |
|---|---|---|
| `check:skills-paths` | `check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined).` | 0 |
| `check:doc-types` | `Every documented component type is registered.` | 0 |
| `check:doc-fences` | `every TypeScript block in 223 document(s) is fenced ts/tsx/typescript` | 0 |
| `check:doc-snippets` | `Semantic phase: 267 of 267 block(s) judged, 0 failed.` / `Every covered documentation snippet compiles against the built types.` | 0 |
| `docs:check-links` | `Links are valid across 17 scan roots.` | 0 |
| `check:control-bytes` | `check-control-bytes: OK (scanned 5593 tracked text file(s); skipped 85 binary).` | 0 |
| `check:shell-escape-residue` | `check-shell-escape-residue: OK (... skills: 18 file(s), 235 fence(s) ...)` | 0 |
| `check-changeset-presence` | `No source of a released package changed in this range, so no changeset is owed.` | 0 |

`check:doc-snippets` first returned exit **2**, which that gate defines as "I could not run", not a failure — it needs the packages built. After `turbo run build` over its own `--build-filter` closure (32/32 tasks successful) it reached a real verdict, quoted above. Build and gate ran joined with `&&` under the shared verify lock, whose verdict was `command-exit 0`, so that number covers both parts.

`check:shell-escape-residue` reports scanning the `skills` root (18 files, 235 fences), so it genuinely covered the edited file rather than skipping it.

### Declared narrowing: `pnpm lint`

The repo-wide eslint scan was not run locally. This is a measured narrowing, not a skip — CI runs the farm regardless:

1. Population read from eslint's own config, not guessed: every `files:` selector in `eslint.config.js` is `**/*.{ts,tsx}` or `**/*.tsx`. No markdown processor is configured.
2. File count from the tool's own output: running eslint directly on the changed file returns `File ignored because no matching configuration was supplied.`
3. Invariance for untouched files: the diff contains no `ts`/`tsx` file and changes no eslint or tsconfig setting, so no untouched file's verdict can move.

## Changeset

None owed, and none added. `skills/` has no `package.json` and appears in no package's `files` — it ships through `skills-lock.json`, not an npm tarball — so no released package's source changed. `node scripts/check-changeset-presence.mjs` agrees, exit 0.

Precedent from git log matches: `9363ad0` (docs-only, `apps/console/docs/error-tracking.md`) carried no changeset, while `0a2918f` did carry one because it edited `packages/plugin-map/README.md`, which ships inside the published package. This diff is the former case. No `skip-changeset` label was applied — in this repo that label is a phantom, read by no workflow.

## Review note

This PR is left as a **draft** per dispatch. Worth flagging that `AGENTS.md` classifies the published `skills/**` tree as **not** a governed surface — the governed set is `AGENTS.md`, `CLAUDE.md`, `.claude/**`, and `docs/adr/**`, and only paths starting with `.claude/` count. So this PR is eligible for the ordinary merge-queue path once CI is green, at the maintainer's discretion.

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_