### PR TITLE
docs(skills): put the GanttConfig keys back under the gantt block

### DIFF
--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -368,17 +368,17 @@ renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
     "tooltipFields": [{ "field": "owner", "label": "Owner" }, "status", "effort"],
     "groupByField": "owner",
     "assigneeField": "owner",
-    "effortField": "effort"
+    "effortField": "effort",
+    "quickFilters": [
+      { "field": "status", "label": "状态" },
+      { "field": "project", "label": "项目" },
+      { "field": "priority", "label": "优先级", "options": ["high", "medium", "low"] }
+    ],
+    "autoZoomToFilter": true
   },
   "criticalPath": true,
   "skipWeekends": true,
   "holidays": ["2026-01-01", "2026-12-25"],
-  "quickFilters": [
-    { "field": "status", "label": "状态" },
-    { "field": "project", "label": "项目" },
-    { "field": "priority", "label": "优先级", "options": ["high", "medium", "low"] }
-  ],
-  "autoZoomToFilter": true,
   "readOnly": false,
   "bind": "project_task"
 }
@@ -418,8 +418,19 @@ view** (see below). The gantt field config may also be hoisted to top-level
 | `lockField: "is_locked"` | Marks a row **view-only / 仅查看** when the field is truthy: its bar can't be dragged/resized, progress can't be dragged, no dependency connector dot, and inline-edit + context-menu edit/delete are hidden. **Clicking still works** (open drawer / jump). Independent of `readOnly`, so you can freeze just one level (e.g. 派工单) while siblings stay editable. |
 | `defaultCollapsedDepth: 2` | **Auto-collapse 默认折叠** every tree node at or below this 0-indexed depth that has children, on first render. Roots are depth 0. The user can still expand any of them — this only seeds the initial state. Example: in a 项目(0)→产品(1)→排产计划(2)→派工单(3) tree, `2` starts with every 排产计划 (and its 派工单) folded. Omit to start fully expanded. |
 
-**Top-level display / behavior options** (siblings of `gantt` on `props`, not
-field mappings):
+**Gantt config options** (`GanttConfig` members — set them INSIDE `gantt`, or hoist
+the whole config as above; beside a `gantt` block a top-level copy is IGNORED):
+
+| Option (under `gantt`) | Effect |
+|--------|--------|
+| `resourceView: true` | Render the **resource / workload view** instead of the task grid: one row per resource with a per-column load histogram. Requires `assigneeField` to bucket tasks; each task adds `effortField` units (default 1) over its span, and any column whose summed load exceeds `capacity` is painted as over-allocated. |
+| `assigneeField` / `effortField` / `capacity` | Resource bucketing (required for `resourceView`), per-task workload weight (default `1`), and the per-resource capacity ceiling (default `1`; loads above it flag overload). |
+| `quickFilters: [{ field, label?, options? }]` | Render a **快速筛选 (quick filter)** bar above the grid — one multi-select dropdown per entry that narrows the visible task bars by that field (AND across dimensions). Option lists resolve in priority order: explicit `options` → the object schema's `select`/`enum` options (full domain) → a `lookup`/`master_detail`'s referenced records (pulled in full via the data source, so values with **no** tasks still appear) → distinct values from the loaded data. Lookup values match on the embedded record id. Selecting every option of a dimension collapses to "no constraint". |
+| `autoZoomToFilter: true` | When a quick filter narrows the set, re-derive the timeline range from the **remaining** tasks so the axis zooms to the filtered span (default `true`). Set `false` to pin the axis to the full task span so bars keep their absolute position while filtering. |
+| `viewMode: "day"\|"week"\|"month"\|"quarter"\|"year"` | Initial timeline granularity (default `day`); the toolbar segmented control switches it live. `year` widens the axis to one column per year with a decade (`2020s`) band above. |
+
+**Node-level display / behavior options** (true siblings of `gantt` on the node
+itself, not `GanttConfig` members — they apply with either face):
 
 | Option | Effect |
 |--------|--------|
@@ -427,12 +438,7 @@ field mappings):
 | `showBaselines: false` | Hide the baseline strips even when baseline fields are mapped (default `true`). |
 | `skipWeekends: true` | Working-calendar math: auto-schedule + critical path count working days only, snapping reschedules off Sat/Sun. In **day mode** this also folds weekend columns out of the timeline (非线性工作时间轴) — Friday sits against Monday and a one-column drag advances one working day. Coarser scales stay linear. |
 | `holidays: ["yyyy-mm-dd", …]` | Extra non-working days for the working calendar (combine with or instead of `skipWeekends`). In day mode these columns fold out of the axis too. |
-| `resourceView: true` | Render the **resource / workload view** instead of the task grid: one row per resource with a per-column load histogram. Requires `assigneeField` to bucket tasks; each task adds `effortField` units (default 1) over its span, and any column whose summed load exceeds `capacity` is painted as over-allocated. |
-| `assigneeField` / `effortField` / `capacity` | Resource bucketing (required for `resourceView`), per-task workload weight (default `1`), and the per-resource capacity ceiling (default `1`; loads above it flag overload). Also usable as field mappings under `gantt`. |
-| `quickFilters: [{ field, label?, options? }]` | Render a **快速筛选 (quick filter)** bar above the grid — one multi-select dropdown per entry that narrows the visible task bars by that field (AND across dimensions). Option lists resolve in priority order: explicit `options` → the object schema's `select`/`enum` options (full domain) → a `lookup`/`master_detail`'s referenced records (pulled in full via the data source, so values with **no** tasks still appear) → distinct values from the loaded data. Lookup values match on the embedded record id. Selecting every option of a dimension collapses to "no constraint". |
-| `autoZoomToFilter: true` | When a quick filter narrows the set, re-derive the timeline range from the **remaining** tasks so the axis zooms to the filtered span (default `true`). Set `false` to pin the axis to the full task span so bars keep their absolute position while filtering. |
 | `markers: [{ date, label?, color? }]` | Extra vertical marker lines (like the Today line). |
-| `viewMode: "day"\|"week"\|"month"\|"quarter"\|"year"` | Initial timeline granularity (default `day`); the toolbar segmented control switches it live. `year` widens the axis to one column per year with a decade (`2020s`) band above. |
 | `persistLayout: false` | Disable layout persistence. By default the toolbar's **保存布局 (save layout)** button snapshots the current granularity + zoom + task-list collapse to `localStorage` (key `gantt-layout:<object>:<view>`) and restores it on next load; set `false` to opt out. |
 | `readOnly: true` | **Disable all editing** — no bar drag/resize/progress, no inline edit, no delete, no dependency-link drag, no reorder, no auto-schedule, and the Undo/Redo buttons are hidden. A 🔒 只读 badge shows in the toolbar, and the right-click menu drops to view-only (or is suppressed when nothing is actionable). Task click + granularity switching still work. Use for dashboards / shared read-only views. |
 | `mobileReadOnly: false` | On a narrow viewport (≤ 640px) the chart **auto-enters read-only** to give touch users a clean, scrollable thumbnail (移动端只读缩略) — same gating as `readOnly`, applied only while narrow. Enabled by default; set `false` to keep editing live on small screens. |


### PR DESCRIPTION
Fixes #6508

`skills/objectui/guides/page-builder.md` headed one table **"Top-level display /
behavior options (siblings of `gantt` on `props`, not field mappings)"** and then
listed two different populations under it. This splits them, moving rows rather
than adding prose.

## Read-site verification (measured, not recalled)

`packages/plugin-gantt/src/ObjectGantt.tsx`, line numbers on
`546f61099` + this branch:

| Key | Read site | Face |
| --- | --- | --- |
| `resourceView` | `ganttConfig?.resourceView` (1635) | GanttConfig |
| `assigneeField` | `ganttConfig?.assigneeField` (1021, 1055) | GanttConfig |
| `effortField` | `ganttConfig?.effortField` (1058, 1065) | GanttConfig |
| `capacity` | `ganttConfig?.capacity ?? 1` (1640) | GanttConfig |
| `quickFilters` | `ganttConfig?.quickFilters` (1108), destructured (727) | GanttConfig |
| `autoZoomToFilter` | `ganttConfig?.autoZoomToFilter` (1297, 1305) | GanttConfig |
| `viewMode` | `ganttConfig?.viewMode` (1641, 1651) | GanttConfig |
| `criticalPath` | `schema.criticalPath` (1669) | node |
| `showBaselines` | `schema.showBaselines` (1672) | node |
| `skipWeekends` | `schema.skipWeekends` (1071) | node |
| `holidays` | `schema.holidays` (1072) | node |
| `markers` | `schema.markers` (1666) | node |
| `persistLayout` | `schema.persistLayout` (1203) | node |
| `readOnly` | `schema.readOnly` (1673, 1743) | node |
| `mobileReadOnly` | `schema.mobileReadOnly` (1674) | node |

Every read site the card named is confirmed, with one spelling nit: `capacity` is
`ganttConfig?.capacity ?? 1`, not `ganttConfig.capacity`. Same face either way.

`getGanttConfig` (line 508) checks `schema.gantt` **first** and returns the block
whole; the flat top-level face is branch 2 and is reached only when there is no
block and both date fields are present. So beside a `gantt` block, every key in
the GanttConfig group is read by nothing.

The split is not an inference from the read sites alone — the declaration draws
the same line by construction. In `packages/types/src/zod/objectql.zod.ts`,
`ObjectGanttSchema` takes the GanttConfig group from `SpecGanttConfigSchema.shape`
**by reference** (lines 676, 726-731) and declares the node group locally
(689-707).

### Seven keys move, not six

`viewMode` was not enumerated on the card but has the identical shape:
`SpecGanttConfigSchema.shape.viewMode` by reference at line 676, read only as
`ganttConfig?.viewMode`, and therefore also in `FLAT_GANTT_CONFIG_KEYS` — so
objectui#6469's dev-mode warning names it when it is hoisted beside a block.
Leaving it in the top-level table would have re-shipped the same false teaching
for one key while fixing it for six. Flagged here rather than filed separately
because it is the same defect in the same table this PR is already rewriting.

Conversely `markers`, `persistLayout` and `mobileReadOnly` were not enumerated
either and measure as genuinely node-level, so they stay where they sat — the
node-level population is eight rows, not five.

## Before / after table structure

**Before** — one table, 13 rows, heading true for 6 of them:

```text
**Top-level display / behavior options** (siblings of `gantt` on `props`, not field mappings)
  criticalPath  showBaselines  skipWeekends  holidays          -- node-level, correct
  resourceView  assigneeField/effortField/capacity             -- GanttConfig, inert beside a block
  quickFilters  autoZoomToFilter                               -- GanttConfig, inert beside a block
  markers  viewMode  persistLayout  readOnly  mobileReadOnly   -- viewMode: GanttConfig; rest node-level
```

**After** — two tables, 13 rows total, unchanged row bodies:

```text
**Gantt config options** (`GanttConfig` members - set them INSIDE `gantt`, or hoist
the whole config as above; beside a `gantt` block a top-level copy is IGNORED)
  resourceView
  assigneeField / effortField / capacity
  quickFilters
  autoZoomToFilter
  viewMode

**Node-level display / behavior options** (true siblings of `gantt` on the node
itself, not `GanttConfig` members - they apply with either face)
  criticalPath  showBaselines  skipWeekends  holidays
  markers  persistLayout  readOnly  mobileReadOnly
```

### Three further corrections inside that move

1. **The backwards row is dropped, not reworded.** The `assigneeField` /
   `effortField` / `capacity` row ended "Also usable as field mappings under
   `gantt`." Under `gantt` is where they work; the row now sits in the gantt-config
   table, so the clause is deleted rather than inverted.
2. **The worked example is a working shape again.** It carried a `gantt` block
   plus top-level `quickFilters` and `autoZoomToFilter` — the exact dead shape the
   card names. Those two keys move inside the block (a pure move, no line
   change). Every remaining top-level key in the example (`criticalPath`,
   `skipWeekends`, `holidays`, `readOnly`) is genuinely node-level, so
   `FLAT_GANTT_CONFIG_KEYS` now intersects the example's top level in zero keys
   and objectui#6469's warning fires zero times on it.
3. **The node-level heading no longer says "on `props`".** That phrase
   contradicted this guide's own rule two sections earlier — "Every key belongs on
   the node itself — never in a `props` envelope" — and the `schema.X` read sites.
   Since the heading was being rewritten anyway, the claim is not re-authored
   into the replacement sentence.

**Kept verbatim:** "The gantt field config may also be hoisted to top-level
`props` instead of nesting under `gantt`." That sentence is true — "instead of"
does real work, and it describes branch 2 exactly.

## Line counts (published-skills ruling, 2026-08-21)

| Measure | Before | After | Delta |
| --- | --- | --- | --- |
| `skills/objectui/guides/page-builder.md` (whole file) | 510 | 516 | +6 |
| Whole published package (all 18 `.md` under `skills/`) | 5673 | 5679 | +6 |
| `skills/objectui/SKILL.md` | 155 | 155 | 0 |
| Rows in the affected tables | 13 | 13 | 0 |

Measured with `git show origin/main:PATH | wc -l` against `git show HEAD:PATH`, not
estimated from the diff.

The +6 is the second table's scaffolding and nothing else: one blank separator,
two heading lines, one blank, one header row, one separator row. No teaching
paragraph is added; one clause is deleted. `git diff --shortstat`: 1 file
changed, 20 insertions, 14 deletions.

## Gates

Derived from `package.json` plus the workflows that carry no path filter, not
recalled. Exit codes captured by redirecting first, so no `tail` masks them.

| Gate | Command | Verdict line it printed | Exit |
| --- | --- | --- | --- |
| skills-paths | `node scripts/check-skills-paths.mjs` | "check-skills-paths: OK (93/94 stated path(s) resolve across 18 guide file(s); 1 baselined)." | 0 |
| doc-fences (self-test) | `node scripts/check-doc-fence-languages.mjs --self-test` | "check-doc-fence-languages self-test: 26 cases pass" | 0 |
| doc-fences | `node scripts/check-doc-fence-languages.mjs` | "check:doc-fences - every TypeScript block in 223 document(s) is fenced ts/tsx/typescript..." | 0 |
| control-bytes | `node scripts/check-control-bytes.mjs` | "check-control-bytes: OK (scanned 5593 tracked text file(s); skipped 85 binary)." | 0 |
| changeset-presence | `node scripts/check-changeset-presence.mjs` | "No source of a released package changed in this range, so no changeset is owed." | 0 |
| doc-links | `node scripts/check-doc-links.mjs` | "Links are valid across 17 scan roots." | 0 |

Scope notes, so the greens are readable:

- **skills-paths is the gate that measures this file.** Confirmed by
  `--list`, which prints a token from `skills/objectui/guides/page-builder.md:29`
  — the file is in its scan set, not merely adjacent to it. This diff adds no new
  path token, so the green is a no-regression reading.
- **doc-links green is NOT a reading of this file.** `skills` is absent from its
  `SCAN_ROOTS` (`scripts/check-doc-links.mjs`, line 583 onward). Recorded as run,
  not as coverage.
- **doc-component-types and doc-snippet-types are not owed.**
  `check-doc-component-types.mjs` line 212 states it walks `content/docs` "and
  nothing else: not `skills/**`"; `check-doc-snippet-types.mjs` roots at
  `content/docs` plus package READMEs.
- **No changeset, and no `skip-changeset` label.** The gate's own verdict is
  quoted above. In this repo the `skip-changeset` label exempts nothing — no
  workflow or script reads it — so it is deliberately not applied.
- **Narrowed local scope, declared:** no `pnpm install`, no build, no unit run.
  This diff touches one `.md` file and no source; each gate above imports only
  `node:` builtins, verified by reading their import blocks. eslint does not lint
  markdown here.

Also checked by hand: `grep -naP` for control bytes over the edited file (no
match), and all 10 `json` fences in the guide re-parsed with `json.loads` (10
parse, 0 fail).

## Drift protection

No code companion is owed. objectui#6469's dev-mode warning plus
`ObjectGantt.blockPrecedence.test.tsx` ("names GanttConfig keys hoisted beside a
block, with no top-level date pair") already pin the runtime behaviour this guide
now describes.

Draft on purpose: `skills/**` is a published surface and goes the maintainer
review path.

_Generated by [Claude Code](https://claude.ai/code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01MnijPVVDakqK2J335JoJtq)_