### PR TITLE
feat(plugin-form): publish omitServerResolvedDefaults + isRequiredInForm, rebind the console

### DIFF
--- a/.changeset/6059-publish-omit-server-resolved-defaults.md
+++ b/.changeset/6059-publish-omit-server-resolved-defaults.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-form': minor
+'@object-ui/console': patch
+---
+
+Publish the create-payload rule from `@object-ui/plugin-form`'s entry, so a
+second form renderer can call it instead of composing it by hand
+(objectui#6059).
+
+Newly importable from `@object-ui/plugin-form` — two functions, nothing else:
+
+```typescript
+import { omitServerResolvedDefaults, isRequiredInForm } from '@object-ui/plugin-form';
+```
+
+- `omitServerResolvedDefaults(values, objectSchema)` — drop the keys a CREATE
+  payload must leave to the producer: a field whose declared `defaultValue` is a
+  runtime instruction (`NOW()` / `current_user`, or a CEL envelope) and whose
+  submitted value is empty. `ObjectQL.applyFieldDefaults` resolves a declaration
+  only for a field that arrives absent or null, so submitting a blank stores
+  `''` and silently defeats it. **Create-only** — the caller keeps the mode gate.
+- `isRequiredInForm(field, isCreateForm)` — the `required` a form should
+  enforce, given the mode. Published as the pair's other half on purpose:
+  excusing a server-owned field from `required` and then submitting the key
+  anyway is not half a fix, it is no fix.
+
+Both are pure functions over plain data (no React, no registry). The rest of
+`schemaDefaults.ts` — `seedCreateValues`, `schemaDefaultValues`,
+`isSeedableDefault`, `isCreateFormMode`, `SeedContext` — stays module-private,
+and `isRuntimeDefault` stays `@object-ui/core`'s to publish.
+
+No behaviour change. The console's `FormPage` now calls the published helper
+instead of composing `isRuntimeDefault` + `isMissingForRequired` locally; its
+create payload is decided identically before and after, pinned against the
+deleted implementation over the full matrix of default shapes, value spellings
+and both modes.

--- a/apps/console/src/components/FormPage.omitBlanksRebind.test.ts
+++ b/apps/console/src/components/FormPage.omitBlanksRebind.test.ts
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#6059 — the rebind of {@link omitServerOwnedBlanks} onto
+ * `@object-ui/plugin-form`'s newly published `omitServerResolvedDefaults` is
+ * BEHAVIOUR-PRESERVING.
+ *
+ * The card that ordered this change says outright that nothing is currently
+ * broken: "Not a defect in behaviour — nothing is currently wrong on either
+ * chain." It is a structural fix, so the only thing worth asserting about it is
+ * the thing a structural fix can silently get wrong — that the create payload
+ * this page submits is decided identically before and after. A test that merely
+ * re-describes what the new code does would pass no matter which of the two
+ * functions it described.
+ *
+ * ## Why a reference implementation and not a table of expectations
+ *
+ * The oracle here is the code this change deleted. `handComposed` below is the
+ * pre-#6059 body of `omitServerOwnedBlanks`, verbatim — the `serverOwned` set,
+ * the `isRuntimeDefault` filter, the `isMissingForRequired` test, the early
+ * returns. Every case runs through both and the two results must agree on VALUE
+ * and on KEY ORDER (a payload is serialised, so key order is observable in the
+ * request body even though it changes no semantics).
+ *
+ * A hand-written expectation table would encode what the author BELIEVES both
+ * versions do; the deleted code encodes what the shipped one actually did.
+ *
+ * ## The counter-probes are the load-bearing half
+ *
+ * "Agrees with the reference" is satisfiable by a matrix too narrow to tell any
+ * two implementations apart, so {@link WRONG_COMPOSITIONS} carries four ways of
+ * getting this rule wrong — each one a plausible slip, not a strawman — and the
+ * suite asserts that the SHIPPED function disagrees with every one of them on
+ * this matrix, at a named case. If a future edit narrows the matrix until it
+ * stops discriminating, those assertions go red before the equivalence ones do.
+ *
+ * ## What the matrix has to cover
+ *
+ * The discriminating axes are the two predicates' own boundaries, crossed:
+ *
+ *   - the default: absent / static literal / runtime TOKEN / CEL envelope;
+ *   - the submitted value: `''` (the text-family arms), `null` (the number
+ *     family), `undefined`, and the three shapes `isMissingForRequired`
+ *     deliberately keeps as VALUES — `false`, `0`, a non-empty string — plus
+ *     `[]`, which it treats as missing;
+ *   - the mode: create and edit;
+ *   - a key in the payload that no rendered row declares.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isMissingForRequired, isRuntimeDefault } from '@object-ui/core';
+import { omitServerOwnedBlanks } from './FormPage';
+
+/** The renderer's own row type, taken from the function rather than restated. */
+type Row = Parameters<typeof omitServerOwnedBlanks>[1][number];
+
+/** A rendered row carrying `defaultValue` — every other key is inert here. */
+function row(name: string, defaultValue?: unknown): Row {
+  return {
+    name,
+    label: name,
+    type: 'text',
+    required: false,
+    readonly: false,
+    hidden: false,
+    colSpan: 1,
+    defaultValue,
+  };
+}
+
+/**
+ * The pre-#6059 body of `omitServerOwnedBlanks`, verbatim. This is the ORACLE:
+ * the rebind is correct exactly insofar as it agrees with the code it replaced.
+ */
+function handComposed(
+  values: Record<string, unknown>,
+  fields: Row[],
+  isCreateForm: boolean,
+): Record<string, unknown> {
+  if (!isCreateForm) return values;
+  const serverOwned = new Set(
+    fields.filter((f) => isRuntimeDefault(f.defaultValue)).map((f) => f.name),
+  );
+  if (serverOwned.size === 0) return values;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (serverOwned.has(key) && isMissingForRequired(value)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Ways to get the composition wrong. Each is a real slip:
+ *
+ *   - `or` — the two predicates ORed instead of ANDed. Eats every blank in the
+ *     payload AND every value on a server-owned field.
+ *   - `no-create-gate` — the rule applied on edit too, which is the #5883
+ *     docblock's first boundary and would silently discard a user's deliberate
+ *     removal.
+ *   - `blank-string-only` — "empty" narrowed to `''`, the obvious spelling,
+ *     which leaves the number family (whose cleared write is `null`) behind.
+ *   - `value-only` — the default ignored, so any blank is dropped, including
+ *     one the user cleared from a field the server will never fill.
+ */
+const WRONG_COMPOSITIONS: Record<
+  string,
+  (values: Record<string, unknown>, fields: Row[], isCreateForm: boolean) => Record<string, unknown>
+> = {
+  or: (values, fields, isCreateForm) => {
+    if (!isCreateForm) return values;
+    const byName = new Map(fields.map((f) => [f.name, f]));
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(values)) {
+      if (isRuntimeDefault(byName.get(key)?.defaultValue) || isMissingForRequired(value)) continue;
+      out[key] = value;
+    }
+    return out;
+  },
+  'no-create-gate': (values, fields) => {
+    const byName = new Map(fields.map((f) => [f.name, f]));
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(values)) {
+      if (isRuntimeDefault(byName.get(key)?.defaultValue) && isMissingForRequired(value)) continue;
+      out[key] = value;
+    }
+    return out;
+  },
+  'blank-string-only': (values, fields, isCreateForm) => {
+    if (!isCreateForm) return values;
+    const byName = new Map(fields.map((f) => [f.name, f]));
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(values)) {
+      if (isRuntimeDefault(byName.get(key)?.defaultValue) && value === '') continue;
+      out[key] = value;
+    }
+    return out;
+  },
+  'value-only': (values, _fields, isCreateForm) => {
+    if (!isCreateForm) return values;
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(values)) {
+      if (isMissingForRequired(value)) continue;
+      out[key] = value;
+    }
+    return out;
+  },
+};
+
+/**
+ * One rendered form covering every default shape the classifier tells apart.
+ * `title` has no default at all; `status` a static literal; `owner` /
+ * `remind_at` the two runtime TOKENS; `priority` / `stage` CEL envelopes.
+ */
+const ROWS: Row[] = [
+  row('title'),
+  row('status', 'draft'),
+  row('owner', 'current_user'),
+  row('remind_at', 'NOW()'),
+  row('priority', { dialect: 'cel', source: 'defaultPriority()' }),
+  row('stage', { dialect: 'cel', source: 'initialStage()' }),
+];
+
+/** Every value spelling a control on this page can write back. */
+const VALUE_SPELLINGS: Array<[string, unknown]> = [
+  ['blank string', ''],
+  ['null', null],
+  ['undefined', undefined],
+  ['empty array', []],
+  ['false', false],
+  ['zero', 0],
+  ['a typed value', 'typed'],
+];
+
+/** `values` keys the rows do not declare, plus whole-payload shapes. */
+const PAYLOAD_CASES: Array<[string, Record<string, unknown>]> = [
+  ['empty payload', {}],
+  [
+    'a full payload with every arm cleared',
+    { title: '', status: '', owner: '', remind_at: '', priority: null, stage: '' },
+  ],
+  [
+    'a full payload the user really filled in',
+    { title: 'a', status: 'b', owner: 'user-99', remind_at: '2026-03-04', priority: 7, stage: 'new' },
+  ],
+  [
+    'a key no rendered row declares, held blank',
+    { extra: '', owner: '' },
+  ],
+  [
+    'a key no rendered row declares, holding a value',
+    { extra: 'kept', owner: 'user-99' },
+  ],
+];
+
+/** Every (payload, mode) pair this suite judges, with a readable name. */
+function allCases(): Array<[string, Record<string, unknown>, boolean]> {
+  const cases: Array<[string, Record<string, unknown>, boolean]> = [];
+  for (const isCreateForm of [true, false]) {
+    const mode = isCreateForm ? 'create' : 'edit';
+    for (const r of ROWS) {
+      for (const [spelling, value] of VALUE_SPELLINGS) {
+        cases.push([`${mode}: ${r.name} holding ${spelling}`, { [r.name]: value }, isCreateForm]);
+      }
+    }
+    for (const [name, payload] of PAYLOAD_CASES) {
+      cases.push([`${mode}: ${name}`, payload, isCreateForm]);
+    }
+  }
+  return cases;
+}
+
+const CASES = allCases();
+
+describe('omitServerOwnedBlanks after the #6059 rebind', () => {
+  it('decides every case exactly as the hand-composed predicates did', () => {
+    const disagreements: string[] = [];
+    for (const [name, values, isCreateForm] of CASES) {
+      const actual = omitServerOwnedBlanks(values, ROWS, isCreateForm);
+      const expected = handComposed(values, ROWS, isCreateForm);
+      // Value AND key order: the payload is serialised, so the order the keys
+      // travel in is observable in the request body.
+      if (
+        JSON.stringify(Object.keys(actual)) !== JSON.stringify(Object.keys(expected)) ||
+        Object.keys(actual).some((k) => !Object.is(actual[k], expected[k]))
+      ) {
+        disagreements.push(name);
+      }
+    }
+    expect(disagreements).toEqual([]);
+    // The matrix is not vacuous.
+    expect(CASES.length).toBeGreaterThan(80);
+  });
+
+  it('never mutates the payload it was handed', () => {
+    const values = { owner: '', title: '' };
+    const before = { ...values };
+    omitServerOwnedBlanks(values, ROWS, true);
+    expect(values).toEqual(before);
+  });
+});
+
+describe('the matrix tells the right composition from the wrong ones', () => {
+  it.each(Object.keys(WRONG_COMPOSITIONS))(
+    'disagrees with the `%s` composition somewhere in the matrix',
+    (variant) => {
+      const wrong = WRONG_COMPOSITIONS[variant];
+      const disagreements = CASES.filter(([, values, isCreateForm]) => {
+        const shipped = omitServerOwnedBlanks(values, ROWS, isCreateForm);
+        const other = wrong(values, ROWS, isCreateForm);
+        return JSON.stringify(Object.keys(shipped)) !== JSON.stringify(Object.keys(other));
+      });
+      expect(disagreements.length).toBeGreaterThan(0);
+    },
+  );
+
+  it('keeps a real value the user typed into a server-owned field (`or` would eat it)', () => {
+    const values = { owner: 'user-99' };
+    expect(omitServerOwnedBlanks(values, ROWS, true)).toEqual({ owner: 'user-99' });
+    expect(WRONG_COMPOSITIONS.or(values, ROWS, true)).toEqual({});
+  });
+
+  it('keeps a cleared EDIT column (`no-create-gate` would drop it)', () => {
+    const values = { owner: '' };
+    expect(omitServerOwnedBlanks(values, ROWS, false)).toEqual({ owner: '' });
+    expect(WRONG_COMPOSITIONS['no-create-gate'](values, ROWS, false)).toEqual({});
+  });
+
+  it('drops a cleared NUMBER arm, whose write is `null` (`blank-string-only` would keep it)', () => {
+    const values = { priority: null };
+    expect(omitServerOwnedBlanks(values, ROWS, true)).toEqual({});
+    expect(WRONG_COMPOSITIONS['blank-string-only'](values, ROWS, true)).toEqual({ priority: null });
+  });
+
+  it('keeps a blank on a field with no runtime default (`value-only` would eat it)', () => {
+    const values = { title: '', status: '' };
+    expect(omitServerOwnedBlanks(values, ROWS, true)).toEqual({ title: '', status: '' });
+    expect(WRONG_COMPOSITIONS['value-only'](values, ROWS, true)).toEqual({});
+  });
+});

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -108,12 +108,12 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import {
   evalFieldPredicate,
-  isMissingForRequired,
   isRuntimeDefault,
   isServerOwnedValue,
   resolveFieldRuleState,
   type FieldRulePredicate,
 } from '@object-ui/core';
+import { omitServerResolvedDefaults } from '@object-ui/plugin-form';
 import { usePredicateScope } from '@object-ui/react';
 import type { FormFieldSpec, FormSectionSpec, FormViewSpec } from '@object-ui/app-shell';
 import { resolveSubmitRedirect } from './submitRedirect';
@@ -1022,27 +1022,40 @@ export function readPrefill(
  * the two halves of this fix, and it cannot come to mean something narrower
  * here than it does on the sibling chain.
  *
- * ## Why the two predicates rather than the sibling function
+ * ## The sibling function, now imported rather than re-composed (objectui#6059)
  *
  * `@object-ui/plugin-form`'s `omitServerResolvedDefaults`
  * (`src/schemaDefaults.ts`) is this rule on the OTHER form chain and states the
  * pairing outright — "excusing a server-owned field from `required` is only
- * half an answer if the form then submits the key anyway". Calling it from here
- * is not available: that package's `exports` map publishes `.` alone, and its
- * root (`src/index.tsx`) does not re-export `schemaDefaults`, so the function
- * has no spelling a consumer can import.
+ * half an answer if the form then submits the key anyway". Until #6059 it had
+ * no spelling a consumer could import: that package's `exports` map publishes
+ * `.` alone and its root did not re-export `schemaDefaults`, so this function
+ * carried the composition — `isRuntimeDefault(default) && isMissingForRequired(value)`
+ * — written out by hand. The two PREDICATES were never copied (both come from
+ * `@object-ui/core`, which is where they live so that every layer deciding
+ * server-ownership reads one answer — `validation/server-owned-value.ts` says
+ * so, and lists this renderer's `resolveFieldRuleState` among the consumers),
+ * but the COMPOSITION existed twice, which #6059 recorded as the structural
+ * reason the next renderer would write it a third time.
  *
- * What matters is that the CLASSIFIERS are not copied, and they are not: both
- * are imported from `@object-ui/core`, which is where they live precisely so
- * every layer that decides server-ownership reads one answer
- * (`validation/server-owned-value.ts` says so, and lists this renderer's
- * `resolveFieldRuleState` among the consumers). `omitServerResolvedDefaults` is
- * itself only such a local application of the same two calls. This file already
- * reads `isRuntimeDefault` directly for #5727's seeding fence, and
- * `plugin-kanban` and `@object-ui/components`' form renderer read
- * `isMissingForRequired` the same way. Publishing the sibling helper from
- * plugin-form's root would let this call site shrink to one line; that is a
- * change to another package's published surface, not to this one.
+ * The entry now publishes it, so this function is the CALLER: it keeps the two
+ * things that are genuinely this renderer's — the create-mode gate, read off
+ * the same URL switch `resolveRowState` uses, and the projection of this page's
+ * own rows onto the `{ fields: { [name]: { defaultValue } } }` shape the helper
+ * reads — and delegates the rule itself. `RenderableField.defaultValue` is
+ * copied straight off the object field in {@link buildSections} (`def`, with no
+ * FormView override for that key), so the projection carries exactly the
+ * defaults the hand-written version consulted, for exactly the same names; a
+ * key that no row declares gets `undefined`, which is what the old
+ * `serverOwned` set said about it too. The rows rather than
+ * `loaded.objectSchema` deliberately: the previous verdict was a function of
+ * the RENDERED rows, and this card is explicit that nothing about the payload
+ * may change.
+ *
+ * This file still reads `isRuntimeDefault` directly for #5727's seeding fence —
+ * that half is one predicate, not a composition, and its sibling
+ * (`isSeedableDefault`) deliberately differs about `null` (see
+ * {@link readPrefill}).
  *
  * ## The two boundaries
  *
@@ -1061,16 +1074,9 @@ export function omitServerOwnedBlanks(
   isCreateForm: boolean,
 ): Record<string, unknown> {
   if (!isCreateForm) return values;
-  const serverOwned = new Set(
-    fields.filter((f) => isRuntimeDefault(f.defaultValue)).map((f) => f.name),
-  );
-  if (serverOwned.size === 0) return values;
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(values)) {
-    if (serverOwned.has(key) && isMissingForRequired(value)) continue;
-    out[key] = value;
-  }
-  return out;
+  return omitServerResolvedDefaults(values, {
+    fields: Object.fromEntries(fields.map((f) => [f.name, { defaultValue: f.defaultValue }])),
+  });
 }
 
 /** Authed/anonymous fetch — credentials included so cookies (auth) flow. */

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -59,8 +59,10 @@ whoever else claims it.
 
 ### Public exports
 
-The package entry exports these — components, their prop/schema types, and the
-layout helpers. There is no aggregate map among them:
+The package entry exports these — components, their prop/schema types, the
+layout helpers, and the two create-payload rules a second form renderer needs
+(see [`required` + a runtime default](#required-or-requiredwhen--a-runtime-default)).
+There is no aggregate map among them:
 
 ```typescript
 import {
@@ -90,6 +92,8 @@ import {
   deriveFormFields,
   findRelationshipField,
   resolveInlineMode,
+  omitServerResolvedDefaults,
+  isRequiredInForm,
 } from '@object-ui/plugin-form';
 
 import type {
@@ -322,6 +326,25 @@ The required marker and `aria-required` go with the rule in the create case,
 since one verdict drives all three — in that mode the user genuinely is not
 required to provide the value. Showing what the server *will* supply, as a
 non-authoritative preview, is a separate follow-up.
+
+The two halves of that verdict are importable, so a host with its own form
+renderer applies the same rule rather than re-deriving it (objectui#6059):
+
+```typescript
+import { isRequiredInForm, omitServerResolvedDefaults } from '@object-ui/plugin-form';
+
+// Should this create form enforce `required` on the field?
+const required = isRequiredInForm(field, isCreateForm);
+
+// Drop the keys the producer must resolve, immediately before the insert.
+const payload = isCreateForm ? omitServerResolvedDefaults(values, objectSchema) : values;
+```
+
+They are published as a pair on purpose: excusing a server-owned field from
+`required` and then submitting the key anyway is not half a fix, it is no fix.
+Both are pure functions over plain data — no React, no registry — and
+`omitServerResolvedDefaults` is **create-only**, so the caller keeps the mode
+gate, as the example shows.
 
 Every consumer reads one predicate, `isRuntimeDefault` in `@object-ui/core`
 (re-exported for this package's own use by `src/schemaDefaults.ts`, not from the

--- a/packages/plugin-form/src/__tests__/entrySurface-6059.test.tsx
+++ b/packages/plugin-form/src/__tests__/entrySurface-6059.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6059 — what `schemaDefaults.ts` publishes from the package ENTRY,
+ * and what it deliberately does not.
+ *
+ * The card is a surface decision, so the surface is what this pins. Two names
+ * became importable and the reason they travel together is that each one's
+ * docblock names the other as its half: `omitServerResolvedDefaults` drops the
+ * keys a CREATE payload must leave to the producer, `isRequiredInForm` excuses
+ * those same fields from the client-side `required` rule, and a consumer able
+ * to reach one but not the other can build the half-fixed state #4069 and
+ * #5883 closed on the two form chains separately.
+ *
+ * ## Why the negative half is the load-bearing one
+ *
+ * "These two are exported" is proved by anything that imports them — the
+ * console's `FormPage` does, and its own suite would go red without them. What
+ * nothing else would notice is the OTHER direction: `schemaDefaults.ts` holds
+ * five more names, and `export * from './schemaDefaults'` would have published
+ * every one of them in a diff that looks tidier than the explicit list. Every
+ * added name is published surface somebody then has to keep compatible, so the
+ * withheld set is asserted rather than left to the reviewer's eye.
+ *
+ * `isRuntimeDefault` is withheld for a stronger reason than "nobody asked". It
+ * belongs to `@object-ui/core` (it moved there in #4085 exactly so a third
+ * consumer could read one answer); this module re-exports it for its own call
+ * sites, and re-publishing it from a plugin entry would put a second spelling
+ * of one classifier back into the workspace. The README says so too, in the
+ * "`required` + a runtime default" section.
+ */
+
+import { describe, expect, it } from 'vitest';
+import * as entry from '../index';
+import * as schemaDefaults from '../schemaDefaults';
+
+/** Published by the entry as of #6059 — the pair, and only the pair. */
+const PUBLISHED = ['omitServerResolvedDefaults', 'isRequiredInForm'] as const;
+
+/**
+ * Present in `schemaDefaults.ts` and deliberately NOT on the entry. `SeedContext`
+ * is type-only and cannot be probed at runtime, so it is absent from this list
+ * by construction rather than by choice.
+ */
+const WITHHELD = [
+  'seedCreateValues',
+  'schemaDefaultValues',
+  'isSeedableDefault',
+  'isCreateFormMode',
+  'isRuntimeDefault',
+] as const;
+
+describe('@object-ui/plugin-form entry — the #6059 surface addition', () => {
+  it('publishes the pair, as the very functions `schemaDefaults` defines', () => {
+    for (const name of PUBLISHED) {
+      expect(typeof (entry as Record<string, unknown>)[name]).toBe('function');
+      // Identity, not just presence: a re-export cannot quietly become a
+      // second implementation that is free to disagree with the one the
+      // package's own containers call.
+      expect((entry as Record<string, unknown>)[name]).toBe(
+        (schemaDefaults as Record<string, unknown>)[name],
+      );
+    }
+  });
+
+  it('withholds the rest of `schemaDefaults`, including the core classifier', () => {
+    for (const name of WITHHELD) {
+      // Present in the module, absent from the entry — which is the whole
+      // decision, and the thing `export *` would have undone.
+      expect(typeof (schemaDefaults as Record<string, unknown>)[name]).toBe('function');
+      expect(Object.keys(entry)).not.toContain(name);
+    }
+  });
+
+  it('adds exactly two names to the entry and no others from this module', () => {
+    const fromSchemaDefaults = Object.keys(entry).filter((k) =>
+      Object.prototype.hasOwnProperty.call(schemaDefaults, k),
+    );
+    expect(fromSchemaDefaults.sort()).toEqual([...PUBLISHED].sort());
+  });
+});

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -68,6 +68,39 @@ export type { LineItemsPanelSchema } from './LineItemsPanel';
 export { deriveDetail, deriveColumns, deriveFormFields, findRelationshipField, resolveInlineMode } from './deriveMasterDetail';
 export type { DerivedDetail, InlineMode } from './deriveMasterDetail';
 
+/**
+ * The CREATE-payload rule this package owns, published for the OTHER form
+ * renderer (objectui#6059).
+ *
+ * `omitServerResolvedDefaults` is a pure function over a values object and an
+ * object schema — no React, no registry, no container — and it is the
+ * COMPOSITION of two `@object-ui/core` predicates (`isRuntimeDefault` AND
+ * `isMissingForRequired`, on create only) rather than a third opinion about
+ * either. It stayed module-private through the whole #4047 / #4068 / #4069 /
+ * #4085 / #5683 / #5727 / #5883 chain, so the console's `FormPage` — the SECOND
+ * form renderer in this repo — had to spell that composition out by hand for
+ * #5883, and the next renderer would have had to as well. Neither PREDICATE was
+ * ever copied (both live in `@object-ui/core` precisely so they cannot fork),
+ * but two hand-written copies of the composition are still free to disagree
+ * about a case neither author had in mind. One importable function is not.
+ *
+ * `isRequiredInForm` travels with it because each one's docblock names the
+ * other as its half: excusing a server-owned field from `required` and then
+ * submitting the key anyway is not half a fix, it is no fix. A consumer able to
+ * reach one and not the other can build exactly that state, which is the defect
+ * #4069 and #5883 closed on the two chains separately.
+ *
+ * Deliberately NOT the rest of `schemaDefaults.ts`. `seedCreateValues`,
+ * `schemaDefaultValues`, `isSeedableDefault`, `isCreateFormMode` and
+ * `SeedContext` are adjacent, not asked for — no consumer outside this package
+ * has needed them, and every added name is published surface somebody then has
+ * to keep. `isRuntimeDefault` stays out for a stronger reason: it is
+ * `@object-ui/core`'s to publish, this module only re-exports it for its own
+ * call sites, and a second published spelling of one classifier is the very
+ * thing #4085 collapsed.
+ */
+export { omitServerResolvedDefaults, isRequiredInForm } from './schemaDefaults';
+
 // Register object-form component
 const ObjectFormRenderer: React.FC<{ schema: any; dataSource?: unknown }> = ({
   schema,


### PR DESCRIPTION
Fixes #6059

Triage picked option 1: *"Export the pair from the package entry and rebind the hand-composed site(s)."* No behaviour change on either chain — the card says so outright, and the pin below is what holds it.

## The gate first: is a new dependency edge being added? No.

The card's own body flags the cost triage did not: option 1 *"makes the console's form page import a heavy React widget package for a pure function."* Measured on this branch's base (`546f61099`) before anything was edited:

| Question | Reading | Where |
|---|---|---|
| Does `apps/console` declare `@object-ui/plugin-form`? | yes, `workspace:*` | `apps/console/package.json`, `devDependencies` |
| Does `apps/console/src` already import it at runtime? | yes, a side-effect import | `apps/console/src/register-plugins.ts:29` |
| Is that import on the app's eager path? | yes | `apps/console/src/main.tsx:30` imports `./register-plugins` |

So the edge already exists and the "heavy React widget package" is already paid for on every console page load. The new import in `FormPage.tsx` joins two modules that are **both** already in the eager closure — `main.tsx` reaches plugin-form through `register-plugins`, and `App.tsx:49` reaches `FormPage` — so it adds no chunk and no bytes to it. (`check:eager-closure` weighs the real number in CI off a console build.)

Had the answer been no, this PR would not exist: the order was to stop and report, because option 2 — moving the composed helper down to `@object-ui/core` beside the two predicates, as objectui#4085 already did for `isRuntimeDefault` — would then be a decision rather than an implementation choice.

## What became importable, and why not one name more

`packages/plugin-form/src/index.tsx` now re-exports exactly two names from `schemaDefaults.ts`:

- **`omitServerResolvedDefaults(values, objectSchema)`** — the rule the card is about: drop the keys a CREATE payload must leave to the producer.
- **`isRequiredInForm(field, isCreateForm)`** — its documented pairing, named by triage.

They travel together because each one's docblock names the other as its half: excusing a server-owned field from `required` and then submitting the key anyway is not half a fix, it is no fix, and a consumer able to reach one but not the other can build exactly that state.

**Deliberately withheld:** `seedCreateValues`, `schemaDefaultValues`, `isSeedableDefault`, `isCreateFormMode`, `SeedContext` — adjacent, not asked for, and every added name is published surface somebody then has to keep. `isRuntimeDefault` stays out for a stronger reason: it is `@object-ui/core`'s to publish (that is what objectui#4085 settled), and this module only re-exports it for its own call sites.

That negative half is asserted, not left to the reviewer's eye — `packages/plugin-form/src/__tests__/entrySurface-6059.test.tsx` pins that the entry adds these two and no other name from that module, and that each is the *same function object* the package's own containers call rather than a second implementation.

## The rebind

`apps/console/src/components/FormPage.tsx` `omitServerOwnedBlanks` keeps the two things that are genuinely this renderer's — the create-mode gate, and the projection of its own rendered rows onto the shape the helper reads — and delegates the rule:

```ts
if (!isCreateForm) return values;
return omitServerResolvedDefaults(values, {
  fields: Object.fromEntries(fields.map((f) => [f.name, { defaultValue: f.defaultValue }])),
});
```

`isMissingForRequired` is no longer imported here. `isRuntimeDefault` still is — objectui#5727's seeding fence is *one* predicate, not a composition, and its sibling deliberately differs about `null`.

The rows rather than `loaded.objectSchema`: the previous verdict was a function of the RENDERED rows, and `RenderableField.defaultValue` is copied straight off the object field in `buildSections` with no FormView override for that key, so the projection carries exactly the defaults the deleted code consulted, for exactly the same names. Passing the whole object schema instead would have been a behaviour change in the case where the payload holds a key no row declares — which this card does not license.

## The pin, and it is RED against a wrong composition

`apps/console/src/components/FormPage.omitBlanksRebind.test.ts`. The oracle is the code this PR deleted: `handComposed` is the pre-#6059 body verbatim, and 94 cases — every default shape (absent / static / runtime token / CEL envelope) crossed with every value spelling a control on this page writes back (`''`, `null`, `undefined`, `[]`, `false`, `0`, a typed value), in both modes, plus payloads holding a key no row declares — must agree with it on value **and key order**.

"Agrees with the reference" is satisfiable by a matrix too narrow to tell two implementations apart, so the suite also carries four ways of getting this rule wrong (`or`, `no-create-gate`, `blank-string-only`, `value-only`) and asserts the shipped function disagrees with each of them at a named case.

Two ablations, run against the committed implementation, each with the mutation confirmed on disk by counting the removed and injected text and the restore proven by an empty `git diff HEAD` plus a blob-hash match:

| Mutation | Pin |
|---|---|
| `&&` to `\|\|` in `omitServerResolvedDefaults` (plugin-form) | **RED** — 4 failed, 6 passed |
| create-mode gate deleted from `omitServerOwnedBlanks` (console) | **RED** — 3 failed, 7 passed |
| restored tree, re-read | green — 10 passed |

The first leg is the one worth noting: a one-character edit in **another package** turns the console's pin red with no build step, because both `vitest.config.mts:285` and `apps/console/vite.config.ts:456` alias `@object-ui/plugin-form` to `packages/plugin-form/src`. The delegation is really being exercised, not a stale `dist`.

## Verified — all readings on `66e7bc548`

- `pnpm exec vitest run packages/plugin-form/ apps/console/src/components/ apps/console/src/__tests__/` — **114 files, 1363 tests passed**. The existing end-to-end payload pin (`FormPage.serverDefaults.test.tsx`, objectui#5883) is in there unchanged and green, which is the create-payload behaviour asserted through the real render and the real request body.
- `pnpm --filter @object-ui/plugin-form type-check` / `pnpm --filter @object-ui/console type-check` — both `exit 0`, after building the console's dependency closure (34 tasks); before that, the TS2307s are stale-`dist` noise.
- `pnpm --filter @object-ui/plugin-form lint` / `pnpm --filter @object-ui/console lint` — `0 errors` each.
- Gates: `check:readme-exports` OK (`383 real, 0 wrong-path, 0 fabricated`, `0 unbuilt` — the two new names judged `real` at README lines 95/96/334), `check:phantom-deps` OK, `check:self-import` OK, `check:control-bytes` OK, `check:doc-fences` OK, `check:esm-specifiers` OK, `check:published-dist` OK, `check:changeset-presence` OK, `check:changeset-no-major` OK.

Repo-wide `pnpm lint` and `check:eager-closure` (which needs a console `dist`) are left to CI, which runs the farm exactly once either way.

## Changeset

`.changeset/6059-publish-omit-server-resolved-defaults.md` — `@object-ui/plugin-form: minor` (published surface grows), `@object-ui/console: patch`. It spells out exactly what becomes importable and what stays private. Not `major`: objectui's major tracks `@objectstack`'s.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_