### PR TITLE
retire the discovery-wire preview mode from the console auth boundary

### DIFF
--- a/.changeset/6654-retire-preview-mode-consumption.md
+++ b/.changeset/6654-retire-preview-mode-consumption.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/react': minor
+---
+
+Retire the discovery-wire preview mode — the console no longer turns
+authentication off because a server said `mode: 'preview'` (objectui#6654).
+
+`@objectstack/spec` retired the `RuntimeMode` value `'preview'` and the whole
+`PreviewModeConfig` block (objectstack#11846). This console still read that
+surface back off the runtime discovery payload, which is a different layer from
+the retired compile-time type — so the consumption could not simply be assumed
+dead, and its removal was ruled deliberately (2026-08-29).
+
+- `ConditionalAuthWrapper` (`@object-ui/app-shell`) drops the branch gated on
+  `discovery.mode === 'preview'`. That branch called `setAuthEnabled(false)` and
+  simulated an identity out of `discovery.previewMode`, every field behind a
+  default. Auth availability is now decided **only** by the ADR-0076 D12 service
+  reading (`isServiceUsable(discovery.services.auth)`), exactly as for any other
+  mode.
+- `DiscoveryInfo` (`@object-ui/react`) drops the `previewMode` block and stops
+  documenting `'preview'` as a runtime mode.
+
+**Accepted failure direction:** a deployment that still emits `mode: 'preview'`
+or a `previewMode` block now falls back to the ordinary auth reading — it
+requires login. That is loud, diagnosable and more secure than keeping a dormant
+auth-off path keyed on a spelling the platform no longer produces.
+
+**Not affected:** `AuthProvider`'s `previewMode` prop, `useAuth().previewMode`
+and `PreviewBanner` in `@object-ui/auth` are a separate published capability
+with a different producer (a host passing the prop). Only the discovery-wire
+producer of that prop is retired; hosts that pass it explicitly are unchanged.

--- a/.changeset/6654-retire-preview-mode-consumption.md
+++ b/.changeset/6654-retire-preview-mode-consumption.md
@@ -19,7 +19,8 @@ dead, and its removal was ruled deliberately (2026-08-29).
   reading (`isServiceUsable(discovery.services.auth)`), exactly as for any other
   mode.
 - `DiscoveryInfo` (`@object-ui/react`) drops the `previewMode` block and stops
-  documenting `'preview'` as a runtime mode.
+  documenting `'preview'` as a runtime mode; the package README's discovery
+  section is updated to match.
 
 **Accepted failure direction:** a deployment that still emits `mode: 'preview'`
 or a `previewMode` block now falls back to the ordinary auth reading — it

--- a/packages/app-shell/src/chrome/ConditionalAuthWrapper.previewRetired-6654.test.tsx
+++ b/packages/app-shell/src/chrome/ConditionalAuthWrapper.previewRetired-6654.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6654 — the discovery wire may no longer turn authentication off.
+ *
+ * ## What was removed
+ *
+ * `@objectstack/spec` retired the `RuntimeMode` value `'preview'` and the whole
+ * `PreviewModeConfig` block (objectstack#11846). This console read that wire
+ * surface back: a discovery response whose `mode` was `'preview'` took a branch
+ * that called `setAuthEnabled(false)` and simulated an identity out of
+ * `discovery.previewMode`. The producer is retired; the consumer is now gone.
+ *
+ * ## ⚠️ Which assertions here are evidence, and which are only cheap insurance
+ *
+ * The removed gate was `discovery?.mode === 'preview'` — NOT the presence of a
+ * `previewMode` block. `previewMode` only supplied the details, every one of
+ * them behind a default. That distinction decides what can be proved:
+ *
+ * - The `mode: 'preview'` cases are the LOAD-BEARING ones. Each was measured
+ *   red against the pre-change component (it handed `AuthProvider` a
+ *   `previewMode` prop and turned auth off).
+ * - The `previewMode`-without-`mode: 'preview'` case is ALREADY GREEN against
+ *   the pre-change component — that payload took the ordinary path before this
+ *   change too. It is kept as a regression net, and labelled so that no future
+ *   reader mistakes a never-red assertion for the one that bites.
+ *
+ * ## The failure direction this change accepts
+ *
+ * A deployment still emitting `mode: 'preview'` now falls back to the ordinary
+ * auth reading — it requires login. Loud, diagnosable and more secure than a
+ * dormant auth-off path keyed on a spelling the platform no longer produces.
+ *
+ * ## Deliberately NOT touched
+ *
+ * `AuthProvider`'s `previewMode` PROP, `useAuth().previewMode` and
+ * `PreviewBanner` are a separate published capability with a different producer
+ * (a host passing the prop). This file retires the discovery-wire producer of
+ * that prop, never the prop itself.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// `vi.hoisted` because the `vi.mock` factories below are hoisted above the
+// imports and would otherwise read these bindings before initialisation.
+const mocks = vi.hoisted(() => ({
+  authProviderProps: [] as Array<Record<string, unknown>>,
+}));
+
+// The published AuthProvider is replaced by a recorder: what this component
+// decides about authentication IS the props it hands the provider, so that is
+// what gets asserted. Nothing else in the auth package is exercised here.
+vi.mock('@object-ui/auth', () => ({
+  AuthProvider: (props: { children?: ReactNode } & Record<string, unknown>) => {
+    mocks.authProviderProps.push(props);
+    return <div data-testid="auth-provider">{props.children}</div>;
+  },
+}));
+
+// The real helper memoises one discovery promise per baseUrl for the process,
+// which would make every case after the first read the first case's payload.
+// Calling the fetcher through keeps the wire path (envelope unwrap included)
+// while giving each case its own response.
+vi.mock('@object-ui/data-objectstack', () => ({
+  getSharedDiscovery: (_baseUrl: string, fetcher: () => Promise<unknown>) => fetcher(),
+}));
+
+import { ConditionalAuthWrapper } from './ConditionalAuthWrapper.js';
+
+/** A usable auth service — the ordinary "login required" reading. */
+const USABLE_AUTH = { services: { auth: { enabled: true, status: 'available', handlerReady: true } } };
+
+/**
+ * The auth-relevant facts the wrapper published, i.e. everything it told
+ * `AuthProvider` except the subtree. Two payloads "behave exactly the same"
+ * when these are equal.
+ */
+function authFacts(props: Record<string, unknown>) {
+  const { children: _children, ...rest } = props;
+  return rest;
+}
+
+async function boot(discovery: Record<string, unknown>) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ success: true, data: discovery }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  render(
+    <ConditionalAuthWrapper authUrl="/api/v1/auth">
+      <div data-testid="app">app</div>
+    </ConditionalAuthWrapper>,
+  );
+  await screen.findByTestId('app');
+  const last = mocks.authProviderProps.at(-1);
+  expect(last, 'the wrapper never rendered an AuthProvider').toBeDefined();
+  return authFacts(last as Record<string, unknown>);
+}
+
+beforeEach(() => {
+  mocks.authProviderProps.length = 0;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ConditionalAuthWrapper — the retired preview wire (objectui#6654)', () => {
+  it('LOAD-BEARING: mode "preview" carrying a previewMode block behaves exactly as a payload with neither', async () => {
+    const withPreview = await boot({
+      mode: 'preview',
+      previewMode: {
+        autoLogin: true,
+        simulatedRole: 'admin',
+        simulatedUserName: 'Preview User',
+        readOnly: false,
+        expiresInSeconds: 3600,
+        bannerMessage: 'demo',
+      },
+      ...USABLE_AUTH,
+    });
+
+    mocks.authProviderProps.length = 0;
+    const control = await boot({ mode: 'production', ...USABLE_AUTH });
+
+    // The whole pin in one line: the retired wire buys the payload nothing.
+    expect(withPreview).toEqual(control);
+    // Spelled out too, so a failure names the security consequence directly.
+    expect(withPreview.previewMode, 'no simulated preview identity').toBeUndefined();
+    expect(withPreview.enabled, 'no auth-off').not.toBe(false);
+  });
+
+  it('LOAD-BEARING: mode "preview" with no previewMode block does not turn auth off either', async () => {
+    // Every field of the removed branch had a default, so a bare
+    // `mode: 'preview'` was enough to disable auth before this change.
+    const facts = await boot({ mode: 'preview', ...USABLE_AUTH });
+
+    expect(facts.previewMode).toBeUndefined();
+    expect(facts.enabled, 'no auth-off').not.toBe(false);
+  });
+
+  it('LOAD-BEARING: mode "preview" defers entirely to the auth service reading', async () => {
+    // A stub auth service is auth-off for the ordinary reason (ADR-0076 D12),
+    // and that is now the ONLY reason the wrapper ever disables auth. Before the
+    // change this payload was disabled by the preview branch instead, and
+    // carried a simulated admin identity with it.
+    const facts = await boot({
+      mode: 'preview',
+      previewMode: { simulatedRole: 'admin' },
+      services: { auth: { enabled: true, status: 'stub', handlerReady: false } },
+    });
+
+    expect(facts.previewMode, 'no simulated preview identity').toBeUndefined();
+    expect(facts.enabled, 'auth off because the service is a stub, not because of preview').toBe(false);
+  });
+
+  it('ALREADY GREEN BEFORE THIS CHANGE (regression net, not evidence): a previewMode block under another mode is inert', async () => {
+    const facts = await boot({ mode: 'production', previewMode: { simulatedRole: 'admin' }, ...USABLE_AUTH });
+
+    expect(facts.previewMode).toBeUndefined();
+    expect(facts.enabled, 'no auth-off').not.toBe(false);
+  });
+
+  it('CONTROL: an ordinary payload is unchanged — a usable auth service still gets a real AuthProvider', async () => {
+    const facts = await boot({ mode: 'production', ...USABLE_AUTH });
+
+    expect(facts).toEqual({ authUrl: '/api/v1/auth' });
+  });
+
+  it('CONTROL: an ordinary payload is unchanged — a stub auth service is still guest mode', async () => {
+    const facts = await boot({
+      mode: 'development',
+      services: { auth: { enabled: true, status: 'stub', handlerReady: false } },
+    });
+
+    expect(facts).toEqual({ authUrl: '/api/v1/auth', enabled: false });
+  });
+});

--- a/packages/app-shell/src/chrome/ConditionalAuthWrapper.tsx
+++ b/packages/app-shell/src/chrome/ConditionalAuthWrapper.tsx
@@ -3,13 +3,11 @@
  *
  * This component fetches discovery information from the server and conditionally
  * enables/disables authentication based on the server's auth service status.
- * Also detects preview mode from the server and configures the auth provider accordingly.
  */
 
 import { useState, useEffect, useCallback, ReactNode } from 'react';
 import { getSharedDiscovery } from '@object-ui/data-objectstack';
 import { AuthProvider } from '@object-ui/auth';
-import type { PreviewModeOptions } from '@object-ui/auth';
 import { LoadingScreen } from './LoadingScreen.js';
 import { isServiceUsable, type DiscoveryInfo } from '@object-ui/react';
 
@@ -34,13 +32,12 @@ const STRINGS = {
  *
  * On startup it:
  * 1. Calls `/api/v1/discovery` (with a 10s AbortController timeout)
- * 2. Detects preview mode + auth.enabled from the response
+ * 2. Reads the auth service's availability from the response
  * 3. On failure, shows the LoadingScreen in error mode with a Retry button
  *    (no silent fallback to "auth enabled" — the user is told the server is unreachable)
  */
 export function ConditionalAuthWrapper({ children, authUrl }: ConditionalAuthWrapperProps) {
   const [authEnabled, setAuthEnabled] = useState<boolean | null>(null);
-  const [previewMode, setPreviewMode] = useState<PreviewModeOptions | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
@@ -94,28 +91,23 @@ export function ConditionalAuthWrapper({ children, authUrl }: ConditionalAuthWra
         throw new Error('empty discovery response');
       }
 
-      if (discovery?.mode === 'preview') {
-        setPreviewMode({
-          autoLogin: discovery.previewMode?.autoLogin ?? true,
-          simulatedRole: discovery.previewMode?.simulatedRole ?? 'admin',
-          simulatedUserName: discovery.previewMode?.simulatedUserName ?? 'Preview User',
-          readOnly: discovery.previewMode?.readOnly ?? false,
-          expiresInSeconds: discovery.previewMode?.expiresInSeconds ?? 0,
-          bannerMessage: discovery.previewMode?.bannerMessage,
-        });
-        setAuthEnabled(false);
-      } else {
-        // ADR-0076 D12 (honest capabilities): trust the 15.1+ signals when
-        // present — a `stub` or `handlerReady:false` auth service must NOT
-        // wrap the app in a real AuthProvider (login against a dev fake).
-        // Pre-15.1 servers carry none of these fields → historical default
-        // (enabled) is preserved by isServiceUsable.
-        const isAuthEnabled = isServiceUsable(discovery?.services?.auth);
-        if (discovery?.services?.auth?.status === 'degraded') {
-          console.warn('[ConditionalAuthWrapper] auth service reports degraded — keeping auth enabled (it still serves).');
-        }
-        setAuthEnabled(isAuthEnabled);
+      // ADR-0076 D12 (honest capabilities): trust the 15.1+ signals when
+      // present — a `stub` or `handlerReady:false` auth service must NOT
+      // wrap the app in a real AuthProvider (login against a dev fake).
+      // Pre-15.1 servers carry none of these fields → historical default
+      // (enabled) is preserved by isServiceUsable.
+      //
+      // This reading is the ONLY thing that decides it. `discovery.mode` used
+      // to be consulted first: `'preview'` turned auth off outright and
+      // simulated an identity out of `discovery.previewMode`. `@objectstack/spec`
+      // retired that whole wire surface (objectstack#11846), so this consumer
+      // is retired with it (objectui#6654) — a deployment still emitting it
+      // falls back to this reading, i.e. it requires login.
+      const isAuthEnabled = isServiceUsable(discovery?.services?.auth);
+      if (discovery?.services?.auth?.status === 'degraded') {
+        console.warn('[ConditionalAuthWrapper] auth service reports degraded — keeping auth enabled (it still serves).');
       }
+      setAuthEnabled(isAuthEnabled);
       setIsLoading(false);
     } catch (e) {
       const err = e as Error;
@@ -147,15 +139,6 @@ export function ConditionalAuthWrapper({ children, authUrl }: ConditionalAuthWra
         onRetry={error ? () => runDiscovery(true) : undefined}
         retrying={retrying}
       />
-    );
-  }
-
-  // If in preview mode, wrap with a preview-configured AuthProvider
-  if (previewMode) {
-    return (
-      <AuthProvider authUrl={authUrl} previewMode={previewMode}>
-        {children}
-      </AuthProvider>
     );
   }
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -204,7 +204,7 @@ function MyComponent(props: Record<string, unknown>) {
 
 ### useDiscovery
 
-Access server discovery information including preview mode detection:
+Access server discovery information — service availability and server identity:
 
 ```tsx
 import { useDiscovery } from '@object-ui/react'
@@ -212,11 +212,6 @@ import { useDiscovery } from '@object-ui/react'
 function MyComponent() {
   const { discovery, isLoading, isAuthEnabled, isAiEnabled } = useDiscovery()
   
-  // Check if the server is in preview mode
-  if (discovery?.mode === 'preview') {
-    console.log('Preview mode active:', discovery.previewMode)
-  }
-
   // Check if AI service is available
   if (isAiEnabled) {
     console.log('AI service route:', discovery?.services?.ai?.route)
@@ -232,21 +227,17 @@ function MyComponent() {
 | --- | --- | --- |
 | `name` | `string` | Server name |
 | `version` | `string` | Server version |
-| `mode` | `string` | Runtime mode (e.g. `'development'`, `'production'`, `'preview'`) |
-| `previewMode` | `object` | Preview mode configuration (present when mode is `'preview'`) |
+| `mode` | `string` | Runtime mode the server reports (`RuntimeMode` in `@objectstack/spec`) |
 | `services` | `object` | Service availability status (auth, data, metadata, ai) |
 | `capabilities` | `string[]` | API capabilities |
 
-The `previewMode` object contains:
-
-| Property | Type | Default | Description |
-| --- | --- | --- | --- |
-| `autoLogin` | `boolean` | `true` | Skip login/registration pages |
-| `simulatedRole` | `'admin' \| 'user' \| 'viewer'` | `'admin'` | Simulated user role |
-| `simulatedUserName` | `string` | `'Preview User'` | Display name |
-| `readOnly` | `boolean` | `false` | Read-only mode |
-| `expiresInSeconds` | `number` | `0` | Session duration (0 = no expiry) |
-| `bannerMessage` | `string` | — | UI banner message |
+> The `previewMode` block and the `'preview'` runtime mode were retired in
+> objectui#6654, following their retirement in `@objectstack/spec`
+> (objectstack#11846). A server that still sends them is read as any other
+> payload: authentication follows `services.auth` alone, so a preview
+> deployment requires login rather than silently running with auth off.
+> `AuthProvider`'s `previewMode` **prop** in `@object-ui/auth` is a separate,
+> host-supplied capability and is unaffected.
 
 ### useNotifications / useNotificationsByPresentation
 

--- a/packages/react/src/hooks/__tests__/discoveryPreviewRetired-6654.test.ts
+++ b/packages/react/src/hooks/__tests__/discoveryPreviewRetired-6654.test.ts
@@ -1,0 +1,44 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6654 — `DiscoveryInfo` no longer declares the retired preview wire.
+ *
+ * `@objectstack/spec` retired the `RuntimeMode` value `'preview'` and the
+ * `PreviewModeConfig` block (objectstack#11846). The behaviour that consumed
+ * them is pinned where it lives, in
+ * `packages/app-shell/src/chrome/ConditionalAuthWrapper.previewRetired-6654.test.tsx`.
+ * This file pins the DECLARATION half: the keys are gone from the published
+ * type.
+ *
+ * ## Why this reads source text instead of asserting a type error
+ *
+ * `DiscoveryInfo` ends in `[key: string]: any`, so `discovery.previewMode`
+ * still type-checks whether or not the property is declared — a
+ * `@ts-expect-error` pin here could never fail, which is exactly the shape that
+ * reads as coverage while measuring nothing. The declaration itself is
+ * therefore what gets asserted, scoped to the one file that carries it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.resolve(here, '../useDiscovery.ts'), 'utf8');
+
+describe('DiscoveryInfo — the retired preview wire (objectui#6654)', () => {
+  it('declares no previewMode block', () => {
+    expect(source).not.toMatch(/previewMode/);
+  });
+
+  it('does not document the retired preview runtime mode', () => {
+    expect(source).not.toMatch(/'preview'/);
+  });
+});

--- a/packages/react/src/hooks/useDiscovery.ts
+++ b/packages/react/src/hooks/useDiscovery.ts
@@ -53,18 +53,8 @@ export interface DiscoveryInfo {
   name?: string;
   version?: string;
   
-  /** Runtime mode (e.g., 'development', 'production', 'preview') */
+  /** Runtime mode the server reports (`RuntimeMode` in `@objectstack/spec`) */
   mode?: string;
-
-  /** Preview mode configuration from the kernel (present when mode is 'preview') */
-  previewMode?: {
-    autoLogin?: boolean;
-    simulatedRole?: 'admin' | 'user' | 'viewer';
-    simulatedUserName?: string;
-    readOnly?: boolean;
-    expiresInSeconds?: number;
-    bannerMessage?: string;
-  };
   
   /** Service availability status */
   services?: {


### PR DESCRIPTION
Fixes #6654

Executes the 2026-08-29 maintainer ruling on that card — option A, remove now. The card itself argued at length that this must NOT be done yet, and that argument was correct until the ruling: what this repo consumed is a **runtime wire field on the discovery payload**, not a compile-time type imported from `@objectstack/spec`, so retiring the zod member upstream did not by itself make the consumer dead. Both of the card's release gates (the spec retirement being installable here, and a cloud-layer reading on whether any deployment still emits the field) were **waived** by the maintainer, who owns the cloud layer this lane could not reach — not satisfied.

## The failure direction that was chosen, not overlooked

A deployment that still emits `mode: 'preview'` or a `previewMode` block now falls back to the ordinary auth reading — **it requires login**. That is loud, diagnosable and more secure than the alternative, which was to keep a dormant auth-off path keyed on a spelling the platform no longer produces. This consequence was stated in the presentation and accepted with the ruling.

## What the branch actually did (an open confidence gap the card recorded)

Triage confirmed the six field reads and the presence of `setAuthEnabled`, but explicitly did **not** confirm that the preview path necessarily reaches `setAuthEnabled(false)`. Read in full on `origin/main` `faac0d935`:

- The gate was `discovery?.mode === 'preview'` — **not** the presence of a `previewMode` block. `previewMode` only supplied the details, every one of them behind a default (`simulatedRole ?? 'admin'`, `autoLogin ?? true`, and so on).
- On that path `setAuthEnabled(false)` is called unconditionally, and the render then wrapped the app in an `AuthProvider` carrying a simulated admin identity.

So the path does disable auth, and a bare `mode: 'preview'` with no `previewMode` block at all was enough to do it.

That distinction decides which assertion is evidence. The ruling's pin, read literally — a payload carrying `previewMode` behaves as one without it — is **already true of the unchanged code**, because such a payload took the ordinary branch unless `mode` also said `'preview'`. A pin that could never go red is not evidence. The load-bearing pins here are therefore the `mode: 'preview'` ones; the literal `previewMode`-only case is kept as a cheap regression net and is **labelled in the test file** as the already-passing case so no future reader mistakes it for the one that bites.

## Changes

- `packages/app-shell/src/chrome/ConditionalAuthWrapper.tsx` — the preview branch is deleted. Auth availability is now decided only by the ADR-0076 D12 service reading, `isServiceUsable(discovery.services.auth)`, exactly as for any other mode. That reading is byte-identical to before; it is only dedented out of the `else` arm. The now-dead local `previewMode` state, its `PreviewModeOptions` type import and the render branch that consumed it go with it.
- `packages/react/src/hooks/useDiscovery.ts` — `DiscoveryInfo` drops the `previewMode` block and stops documenting `'preview'` as a runtime mode. `mode` stays a plain optional string.
- `packages/react/README.md` — the discovery section documented both retired keys and its `useDiscovery` example read `discovery.previewMode`; updated, with a note recording where the behaviour went.
- Two pin files, and a changeset (minor on `@object-ui/app-shell` + `@object-ui/react`).

This touches an authentication boundary, so the diff is deliberately minimal: nothing outside the preview path changed, and no surrounding auth logic was restructured.

## Deliberately NOT touched — a separate published capability

`setPreviewMode` fed a host-supplied contract in `@object-ui/auth` that this card does not name: the `AuthProvider` `previewMode` **prop**, `AuthContext.previewMode`, `useAuth().previewMode`, and the exported `PreviewBanner`. Those have a different producer — a host passing a prop — and removing them would be a breaking removal of a published capability, which is not ruled. Only the discovery-wire producer of that prop is retired. Verified: the removed state was local to `ConditionalAuthWrapper` and read at exactly one site inside that same file, so nothing outside it is stranded, and the five existing suites that drive `AuthProvider previewMode` directly still pass.

## Verification

All readings taken on `897144596` unless stated. Every exit code was captured by redirect-then-capture, never after a pipe.

**Reproduce, on the base `faac0d935` with only the pin file added** — `pnpm exec vitest run` on the app-shell pin: `Tests 3 failed | 3 passed (6)`. The three failures are exactly the three `mode: 'preview'` cases; the `previewMode`-only regression net and the two controls passed against unchanged code, as predicted.

**Ablation, against the committed implementation** (`6a87e7936`), restore leg trapped on `EXIT INT TERM` with absolute paths:

- Mutation proven on disk before measuring: the restored gate text present (1 occurrence), the restored `setAuthEnabled(false)` present (1), the new marker comment absent (0), and the file's blob hash equal to the base blob `25cd24f60`.
- Mutated leg: vitest exit `1`, `Tests 3 failed | 3 passed (6)` — the three load-bearing cases red. Direction as predicted.
- Restore proven: blob hash `18efa1155` equal to that path's HEAD blob hash, `git diff HEAD --name-only` empty, gate text absent.
- Restored leg: vitest exit `0`, `Tests 6 passed (6)`.
- No rebuild is needed for this ablation and none is claimed: the subject is imported by relative path within its own package and `@object-ui/react` is aliased to `packages/react/src` in the root vitest config, so both resolve to source, not `dist`. The ablation proves this itself — a mutation written only to `src` flipped the pin red with no build in between.

**Local gate union at `897144596`**, each read from the gate's own verdict line:

- pins, both files: exit `0` — `Test Files 2 passed (2)`, `Tests 8 passed (8)`
- neighbouring suites (`packages/auth/`, `packages/app-shell/src/chrome/`, `packages/react/src/hooks/`, the console `anonSeedScope` enumeration test): exit `0` — `Test Files 45 passed (45)`, `Tests 480 passed (480)`
- `@object-ui/app-shell` type-check: exit `0`; `@object-ui/react` type-check: exit `0`. Both run `tsc --noEmit && tsc -p tsconfig.test.json`, and `--listFiles` confirms each new test file is inside its package's test program (1 hit each) — so this is a measurement of the new files, not a pass that skipped them.
- `check:control-bytes` exit `0` — "OK (scanned 5607 tracked text file(s))"; plus a direct control-byte scan of the six changed paths, no hits
- `check:vi-mock-specifiers` exit `0`; `check:phantom-deps` exit `0` — "Every in-scope import is declared by the package that publishes it"
- `check:spec-symbols` exit `0`; `check:type-check-coverage` exit `0`
- changeset presence exit `0` — "4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)"; `check-changeset-no-major` exit `0`
- `check:doc-fences` exit `0`; `check:doc-types` exit `0`; `check:doc-snippets` exit `0` after building what it names — "Semantic phase: 267 of 267 block(s) judged, 0 failed", which is what measures the edited README snippet

**One gate is NOT MEASURED, and is reported as neither pass nor fail.** `check:readme-exports` exits `1` with "46 self-import(s) could not be judged" — every one of them the gate's own `is not on disk -- run pnpm build first` precondition on four packages this diff does not touch (`plugin-ai`, `plugin-gantt` and two others). After building the packages the diff does touch, its census reads "379 self-imports judged (333 real, 0 wrong-path, 0 fabricated)" and **zero** unjudged entries name `@object-ui/app-shell` or `@object-ui/react`. CI builds the workspace before running it.

**Declared narrowing on lint.** The repo-wide `pnpm lint` was not run; eslint was run on the four changed source files instead — exit `0`, 4 files linted (count read from `--format json`), 0 errors, 5 warnings, all of them pre-existing and on lines this diff does not touch. The narrowing is a measurement rather than a skip because `eslint.config.js` configures **no type-aware linting**: it extends `tseslint.configs.recommended` and its `languageOptions` sets only `ecmaVersion` and `globals`, with no `parserOptions.project` and no `projectService` anywhere in the file. Every rule's verdict is therefore a function of one file's own text plus the shared config, so a diff confined to these files cannot move the verdict on any untouched file. CI runs the full farm regardless.

## A note on the card's `RuntimeMode` member list

The card asserted the retired enum is now a three-member list and triage flagged that as unverified. Nothing here depends on it, so it is not quoted anywhere: the `mode` field stays a plain string and its documentation now points at `RuntimeMode` in `@objectstack/spec` by name instead of restating members. (The symbol name was read from the installed package, not from the card.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_