### PR TITLE
fix(components): flex declares the containment it renders

### DIFF
--- a/.changeset/6740-flex-is-container.md
+++ b/.changeset/6740-flex-is-container.md
@@ -1,0 +1,40 @@
+---
+'@object-ui/components': patch
+---
+
+`flex` declares the containment it renders (objectui#6740).
+
+`flex` has always rendered `schema.children`, but its registration omitted
+`isContainer` while `grid`, `card`, `container` and `stack` — same directory,
+same `ui` namespace — all declared it. The render path never reads the flag, so
+nothing was broken at runtime; its consumers are elsewhere, and the gap made
+them contradict the renderer.
+
+MEASURED through the mechanism, not inferred from the property. Building the
+manifest the way the app builds it (`getKnownTypes()` + `getMeta()` ->
+`manifestFromConfigs`) and putting a `flex` node carrying children through
+`validateTree` returned `["not-a-container"]`, while `grid` / `card` /
+`container` under the identical probe returned `[]` — the control that makes
+that reading real. Downstream, objectstack's three shipped
+`examples/app-showcase` html pages drew 232 diagnostics, of which every one of
+the 32 warnings was `not-a-container` on `flex`, and `flex` was their only
+source. `validateTree` is not on objectstack's production gate path today, so
+the warnings are currently unobserved — which is why this is worth closing
+before that gate goes live rather than after.
+
+**Second consumer, and the reason this is not purely a declaration change.**
+`renderers/layout/react-page.tsx` builds the JSX scope of every `kind:'react'`
+page with `if (!tag || cfg.isContainer) continue;`. While `flex` omitted the
+flag it was the one layout primitive of the five still injected there, so
+`<Flex>` resolved in react page source — and rendered an EMPTY div, because the
+injected wrapper drops `children`. It now behaves like its four siblings and is
+not injected, which is what `content/docs/guide/react-pages.md` has documented
+all along ("Layout containers are deliberately not injected ... `<flex>`,
+`<grid>`, `<card>` and friends have no injected wrapper"). A react page that
+wrote `<Flex>` moves from silently swallowing its children to the page-level
+error panel naming the identifier, with that page's documented remedy being
+real HTML: `<div style={{ display: 'flex', gap: 16 }}>`.
+
+Pinned over the family rather than over `flex` alone: the defect's shape was
+"three declare it and one does not", and a pin covering only the one that was
+missing would let the next registration rot the same way.

--- a/packages/components/src/__tests__/layout-containers-declare-containment.test.tsx
+++ b/packages/components/src/__tests__/layout-containers-declare-containment.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `ui` layout primitives DECLARE the containment they render (objectui#6740).
+ *
+ * `flex` renders `schema.children` and always has, but its registration omitted
+ * `isContainer` while `grid`, `card`, `container` and `stack` — same directory,
+ * same namespace — all declared it. The render path never reads the flag, so
+ * nothing was broken at runtime; the consumers are elsewhere, and the gap made
+ * them contradict the renderer.
+ *
+ * MEASURED on b76ca6764, through the mechanism rather than the property: the
+ * manifest built the way the app builds it, with a `flex` node carrying children
+ * put through `validateTree`, returned `["not-a-container"]`, while `grid` /
+ * `card` / `container` under the identical probe returned `[]`. Downstream,
+ * objectstack's three shipped `examples/app-showcase` html pages drew 232
+ * diagnostics of which 32 were warnings — every one of them `not-a-container` on
+ * `flex`, and `flex` the only source of them.
+ *
+ * WHY THIS FILE PINS FOUR COMPONENTS AND NOT ONE. The defect's shape is "three
+ * declare it and one does not". A pin covering only `flex` would let the next
+ * registration rot exactly the same way and stay green while it did, so the
+ * assertion is over the family. `stack` rides along for the same reason.
+ *
+ * WHY THROUGH `validateTree` AND NOT `getConfig(t).isContainer`. The property is
+ * only interesting because a mechanism reads it; asserting the literal would
+ * stay green if the containment check were removed, mis-keyed, or fed a manifest
+ * the tag is missing from — the three ways this fact dies without anyone
+ * noticing. The reachability controls below exist for the same reason.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer, AdapterCtx } from '@object-ui/react';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+import type { Diagnostic, SchemaElement } from '@object-ui/sdui-parser';
+
+// Module scope, not a hook: this import IS the registration (AGENTS.md
+// §测试纪律 — an unbounded module load must not be billed to a bounded window).
+import '../renderers';
+
+const CONTAINMENT = 'not-a-container';
+
+/** The four `ui` layout registrations whose whole job is to hold children. */
+const LAYOUT_CONTAINERS = ['flex', 'grid', 'card', 'container'] as const;
+
+/**
+ * The manifest the running app validates against, built the way the app builds
+ * it — keyed by every KNOWN registry tag rather than by `getAllConfigs()`, whose
+ * `.type` is always the namespaced form. Mirrors `getJsxManifest()` in
+ * `renderers/layout/page.tsx:462` (module-private, hence the four lines here).
+ * Key it off `getAllConfigs()` instead and the bare `flex` tag authors write is
+ * absent from the manifest, so every assertion below would pass on
+ * `unknown-component` without ever reaching the containment check.
+ */
+const diagnose = (schema: unknown): Diagnostic[] => {
+  const configs = ComponentRegistry.getKnownTypes().map((t) => {
+    const meta = ComponentRegistry.getMeta(t);
+    return { type: t, namespace: meta?.namespace, isContainer: meta?.isContainer, inputs: meta?.inputs };
+  });
+  const manifest = manifestFromConfigs(configs as unknown as Parameters<typeof manifestFromConfigs>[0]);
+  return validateTree(schema as SchemaElement, manifest).diagnostics;
+};
+
+const withChildren = (type: string) => ({
+  type,
+  children: [{ type: 'text', content: 'child' }],
+});
+
+describe('the ui layout primitives accept children without warning (objectui#6740)', () => {
+  it.each(LAYOUT_CONTAINERS)('`%s` with children draws no `not-a-container`', (type) => {
+    const diagnostics = diagnose(withChildren(type));
+
+    // Reachability BEFORE absence — an empty result proves nothing if the
+    // containment branch never ran. Two ways it silently would not: an
+    // unresolved tag reports `unknown-component` and never reaches the check,
+    // and the branch is guarded by `node.children?.length`.
+    expect(diagnostics.filter((d) => d.code === 'unknown-component')).toEqual([]);
+    expect(withChildren(type).children.length).toBeGreaterThan(0);
+
+    // Filtered by code, not against an empty list: this file owns the
+    // CONTAINMENT fact only, so a future diagnostic on some other key belongs
+    // to that key's pin rather than here.
+    expect(diagnostics.filter((d) => d.code === CONTAINMENT)).toEqual([]);
+  });
+
+  it('still reports `not-a-container` for a component that genuinely takes none', () => {
+    // The control that keeps every assertion above meaningful. Without it the
+    // suite would stay green if the containment check were deleted outright, or
+    // if `isContainer` were defaulted on — either of which turns this file into
+    // a measurement of nothing. `badge` is a leaf: it renders its own label and
+    // never reads `schema.children`, so children under it ARE an authoring
+    // mistake the author must still hear about.
+    //
+    // If `badge` ever legitimately becomes a container, this goes red — move the
+    // control to another childless registration rather than deleting it.
+    const codes = diagnose(withChildren('badge')).map((d) => d.code);
+    expect(codes).toContain(CONTAINMENT);
+  });
+});
+
+describe('the declaration reaches the consumers that read it (objectui#6740)', () => {
+  it.each(LAYOUT_CONTAINERS)('`%s` reports as a container on the public tier', (type) => {
+    // The second consumer, and the reason it is pinned rather than left
+    // implicit: `renderers/layout/react-page.tsx:77` builds the JSX scope of
+    // every `kind:'react'` page with `if (!tag || cfg.isContainer) continue;`,
+    // reading THIS predicate off `getPublicConfigs()` — not off `getMeta()`.
+    // While `flex` omitted the flag it was the one layout primitive of the five
+    // still injected there, contradicting
+    // `content/docs/guide/react-pages.md` ("Layout containers are deliberately
+    // not injected … `<flex>`, `<grid>`, `<card>` and friends have no injected
+    // wrapper"). Declaring it lines `flex` up with its four siblings.
+    const cfg = ComponentRegistry.getPublicConfigs().find((c: { type: string }) => c.type === type);
+    expect(cfg, `\`${type}\` is not in the public tier`).toBeTruthy();
+    expect((cfg as { isContainer?: boolean }).isContainer).toBe(true);
+  });
+
+  it('leaf blocks stay injectable into a react page — containers are the only ones dropped', () => {
+    // The direction control for the assertion above. If this were empty or all
+    // falsy, "containers are excluded" would be indistinguishable from
+    // "everything is excluded", and the pin would be measuring the wrong fact.
+    for (const leaf of ['badge', 'button', 'image', 'icon']) {
+      const cfg = ComponentRegistry.getPublicConfigs().find((c: { type: string }) => c.type === leaf);
+      expect(cfg, `\`${leaf}\` is not in the public tier`).toBeTruthy();
+      expect((cfg as { isContainer?: boolean }).isContainer).toBeFalsy();
+    }
+  });
+});
+
+describe('flex still renders its children (objectui#6740)', () => {
+  it('renders children through the real SchemaRenderer, as it always did', async () => {
+    // The scope guard for acceptance "nothing else about flex changes". The
+    // render path does not consult `isContainer` — `SchemaRenderer` passes the
+    // whole node as `schema` and `flex` re-reads `schema.children` itself —
+    // so declaring the flag must leave this untouched.
+    const { container } = render(
+      <AdapterCtx.Provider value={null as never}>
+        <SchemaRenderer
+          schema={{
+            type: 'flex',
+            direction: 'col',
+            children: [{ type: 'badge', label: 'kept' }],
+          } as never}
+        />
+      </AdapterCtx.Provider>,
+    );
+
+    await waitFor(() => expect(container.querySelector('[data-obj-type="flex"]')).toBeTruthy());
+    const root = container.querySelector('[data-obj-type="flex"]');
+    expect(root?.className).toContain('flex-col');
+    expect(container.textContent).toContain('kept');
+  });
+});

--- a/packages/components/src/renderers/layout/flex.tsx
+++ b/packages/components/src/renderers/layout/flex.tsx
@@ -146,6 +146,27 @@ ComponentRegistry.register('flex',
         { type: 'button', label: 'Button 2' },
         { type: 'button', label: 'Button 3' }
       ]
-    }
+    },
+    // `flex` renders `schema.children` (see `renderChildren` above) but did not
+    // DECLARE that it does, while `grid`, `card`, `container` and `stack` — the
+    // same directory, the same `ui` namespace — all do. The flag is not read by
+    // the render path, so nothing was broken at runtime; its consumers are
+    // elsewhere, and the gap made them contradict the renderer (objectui#6740).
+    //
+    // MEASURED, not inferred. Building the manifest the way the app builds it
+    // (`getKnownTypes()` + `getMeta()` -> `manifestFromConfigs`) and putting a
+    // `flex` node WITH children through `validateTree` returned
+    // `["not-a-container"]`, while `grid` / `card` / `container` under the same
+    // probe returned `[]` — the control that makes the reading real. Downstream,
+    // objectstack's three shipped `examples/app-showcase` html pages drew 32
+    // `not-a-container` warnings, every one of them on `flex` and `flex` the
+    // only source of them.
+    //
+    // `isContainer` alone, deliberately. The four `ui`-namespace siblings pair
+    // it with `resizable` / `resizeConstraints`, but the `page:*` containers in
+    // `containers.tsx` declare `isContainer: true` on its own — so the flag is
+    // independent of designer resize affordances, and minting one here would be
+    // a behaviour change this card did not measure.
+    isContainer: true
   }
 );


### PR DESCRIPTION
Fixes #6740

`flex` has always rendered `schema.children`, but its registration omitted `isContainer` while `grid`, `card`, `container` and `stack` — same directory, same `ui` namespace — all declare it. The render path never reads the flag, so nothing was broken at runtime; the flag's consumers are elsewhere, and the gap made them contradict the renderer.

## Reproduced first, with the card's own control

Base `b76ca6764`, the card's re-check verbatim:

```
git grep -c isContainer -- packages/components/src/renderers/layout/flex.tsx   ->  no output, exit 1  (zero matches)
git grep -c isContainer -- packages/components/src/renderers/layout/grid.tsx   ->  grid.tsx:1, exit 0
```

That zero is a reading only because the positive control returns non-zero in the same corpus and under the same command shape.

## The defect measured through the mechanism, inside this repo

`@object-ui/sdui-parser` is already a dependency of `@object-ui/components`, so the downstream path is constructible here — no NOT MEASURED fallback was needed. The manifest was built exactly the way the app builds it (`getKnownTypes()` + `getMeta()` fed to `manifestFromConfigs`, mirroring `renderers/layout/page.tsx:462`) and a node carrying children put through `validateTree`.

On base `b76ca6764`:

| node | diagnostics |
|---|---|
| `flex` with children | `["not-a-container"]` |
| `grid` with children | `[]` |
| `card` with children | `[]` |
| `container` with children | `[]` |

With this change, `flex` returns `[]` and the three controls are unchanged. This is the same warning objectstack measured downstream: its three shipped `examples/app-showcase` html pages drew 232 diagnostics, and every one of the 32 warnings was `not-a-container` on `flex`, with `flex` their only source. The 200 errors are a separate matter (objectstack#12924 owns it) and are untouched here.

## The form is copied from the siblings, not invented

`grid`, `card`, `container` and `stack` all place `isContainer: true` in the registration's third argument, after `defaultProps`. This change matches that placement and value.

**Where they disagree, and the call made.** All four `ui`-namespace siblings pair `isContainer` with `resizable: true` and a `resizeConstraints` block. The `page:*` containers in `containers.tsx` declare `isContainer: true` on its own, with neither. So the flag is independent of designer resize affordances, and only `isContainer` is added here — minting a resize affordance for `flex` would be a behaviour change this card did not measure.

## Reviewer attention: a second consumer, beyond the diagnostic

The card asked that anything altering behaviour past `not-a-container` be surfaced rather than absorbed. One thing does, and it is measured rather than reasoned about.

`renderers/layout/react-page.tsx:77` builds the JSX scope of every `kind:'react'` page with `if (!tag || cfg.isContainer) continue;`, reading the predicate off `getPublicConfigs()`. While `flex` omitted the flag it was the one layout primitive of the five still injected there.

Measured by rendering real `kind:'react'` page source through `SchemaRenderer`:

| identifier | base `b76ca6764` | with this change |
|---|---|---|
| `Flex` | resolves | not defined |
| `Grid` | not defined | not defined |
| `Card` | not defined | not defined |
| `Container` | not defined | not defined |
| `Stack` | not defined | not defined |
| `Button`, `Badge`, `Text`, `Image` | resolve | resolve |

The leaf-block row is the direction control: without it, "containers are dropped" would be indistinguishable from "everything is dropped".

Two things make this the correcting direction rather than a regression, but a reviewer should still rule on it:

1. `content/docs/guide/react-pages.md` has documented this behaviour all along and names this component first — "Layout containers are deliberately not injected. The scope builder skips every container ... so `flex`, `grid`, `card` and friends have no injected wrapper." The prose predates the 2026-08-21 rewrite that added the code citation; only `flex` did not obey it.
2. The behaviour being removed is itself silently broken. The injected wrapper is `({ children: _children, ...props })` — it discards children. Measured on base: a react page writing this component around a child rendered `div data-obj-type="flex" class="flex flex-row ..."` with the child gone. After the change the author gets the page-level error panel naming the identifier, and that doc page's stated remedy is real HTML with an inline `style` object.

So the change moves a react page from silently swallowing content to failing loudly with a documented fix. It is still a user-visible change on a published package, which is why it is called out here rather than left in the diff.

## The pin covers the family, not just the one that was missing

The defect's shape is "three declare it and one does not". A pin covering only `flex` would let the next registration rot the same way and stay green while it did, so `packages/components/src/__tests__/layout-containers-declare-containment.test.tsx` asserts over all four, through `validateTree` rather than against the literal property — the property is only interesting because a mechanism reads it.

It carries three controls, each closing a way the pin could pass while measuring nothing:

- **reachability** — no `unknown-component` in the result, and the probe node really has children (the containment branch is guarded by `node.children?.length`);
- **liveness** — `badge`, a genuine leaf, must still draw `not-a-container`, so deleting the check or defaulting the flag on turns the file red;
- **direction** — the four leaf blocks must stay non-containers on the public tier, so the react-page assertion is about containers and not about everything.

A fourth test renders `flex` through the real `SchemaRenderer` and asserts its children still arrive, which is the scope guard for "nothing else changes".

## Ablation

Against the committed implementation `e44f941ba`, with the restore trapped on `EXIT INT TERM` using absolute paths.

- Mutation confirmed on disk before anything was run: anchor count 1 -> 0, and blob `9cd1720a0...` -> `f5994b334...` (a differing hash, not an exit code).
- Pin on the mutated tree: **2 failed, 9 passed, exit 1**. The two reds are exactly the two consumers — "`flex` with children draws no `not-a-container`" (`expected [ { severity: 'warning', ... } ] to deeply equal []`) and "`flex` reports as a container on the public tier" (`expected undefined to be true`). The three sibling cases stayed green, since they legitimately declare the flag.
- Restore proven, not assumed: `git checkout HEAD --` against the absolute path (naming `HEAD`, so the mutated index cannot be the source), then `git diff HEAD` empty **and** restored blob `9cd1720a0...` equal to that path's HEAD blob hash.
- Pin on the restored tree: **11 passed, exit 0**.

No rebuild step is involved and none is owed: `vitest.config.mts` aliases every `@object-ui/*` specifier to `packages/*/src`, and the pin reaches `flex.tsx` by relative import, so the mutated source is what ran. Nothing resolved through `dist`.

## Gates

All run on `e44f941ba` with a clean tree, every exit code captured by redirect-then-capture and each result quoted from the tool's own verdict line.

| gate | result |
|---|---|
| `pnpm exec vitest run packages/components/ packages/core/src/registry/ examples/schema-catalog/` | `Test Files 228 passed (228)` / `Tests 3875 passed (3875)`, exit 0 |
| console public-contract suites (5 files reading `getPublicConfigs` / `PUBLIC_BLOCKS`) | `Test Files 5 passed (5)` / `Tests 152 passed (152)`, exit 0 |
| `pnpm --filter @object-ui/components type-check` | exit 0 |
| `node scripts/check-changeset-presence.mjs` | exit 0, "1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)" |
| control-byte self-scan over the changed files | no matches |
| `eslint .` in `packages/components` (this package's own `lint` gate, which is what `turbo run lint` invokes for it) | exit 0 — **422 files, 0 errors**, 938 pre-existing warnings |

The type-check number is qualified rather than quoted bare: `packages/components/tsconfig.json` excludes `src/__tests__`, so `tsc --noEmit` alone says nothing about the new pin. The chained `tsc -p tsconfig.test.json` is what covers it, and `--listFiles` was used to confirm the file is actually in that program rather than assumed to be.

The repo-wide `pnpm lint` is `turbo run lint`, which fans out to each package's own `lint`. Only this package's run was taken, and that is a measurement rather than a skip, on three pieces of evidence: the population is eslint's own (**422** files, counted from `--format json`, not from a guess about what counts); both changed files are inside that population and were linted (the test file clean, `flex.tsx` carrying one pre-existing `no-explicit-any` warning at line 15 column 94 — the original registration signature, far from the line 146 edit); and `eslint.config.js` configures no `projectService` and no `parserOptions.project`, so type-aware linting is off and each file's verdict is a function of its own source alone — this diff cannot move a verdict in a package it does not touch.

CI owns the full farm and runs it regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_