### PR TITLE
refactor(react): one config-bag predicate, and a pin against a seventh spelling

### DIFF
--- a/.changeset/6761-one-config-bag-predicate.md
+++ b/.changeset/6761-one-config-bag-predicate.md
@@ -1,0 +1,22 @@
+---
+---
+
+Internal refactor only; no published behaviour changes. "Is this value a real config bag
+(an object, not an array, not null)?" was asked in `packages/react` in six places in four
+spellings — `SchemaRenderer`'s module-private `isConfigBag`, its `winningVisibilityKey`
+inline, `utils/propsBagDiagnostic.ts`'s private twin, and TWO in
+`utils/unevaluatedExpression.ts` (`scanBag`'s negated early return and the `hoisted`
+dedupe read). All six now read one exported predicate, `utils/configBag.ts`
+(objectui#6761).
+
+They agreed, which was never the cost: a copy that drifts produces no error, only a
+different answer on one channel — the failure mode `hasDeclaredPredicate` was created to
+end for "is a gate DECLARED?" (objectui#3850). So the convergence ships with a pin,
+`utils/configBag.pin.test.ts`, that fails when a seventh spelling appears anywhere in
+`packages/react/src`. The two sites that ask the same SHAPE question about a data ROW
+(`SchemaRenderer`'s `boundRecord`, `usePredicateRecordContext`) are deliberately NOT
+merged and are named in the pin's allowlist with that reason: their "no row → bind
+NOTHING" rule is a different ruling, and it must not move if "config bag" ever narrows.
+
+Each of the six sites was ablated individually to bare truthiness and measured, rather
+than assumed equivalent because the lines look alike.

--- a/packages/react/src/SchemaRenderer.tsx
+++ b/packages/react/src/SchemaRenderer.tsx
@@ -29,6 +29,7 @@ import { useRecordContext } from './context/RecordContext.js';
 import { usePredicateScope } from './hooks/useExpression.js';
 import { usePageVariables } from './hooks/usePageVariables.js';
 import { resolveKeyedI18nLabel } from './utils/i18n.js';
+import { isConfigBag } from './utils/configBag.js';
 import { reportUnevaluatedExpressions } from './utils/unevaluatedExpression.js';
 import { reportDroppedPropsBag } from './utils/propsBagDiagnostic.js';
 import {
@@ -138,27 +139,6 @@ function resolveAriaProps(schema: Record<string, any>): Record<string, string | 
  * component descriptor. See the hoist in the evaluation memo below.
  */
 const HOIST_PROTECTED_KEYS = new Set(['type', 'id']);
-
-/**
- * A real config bag: an object, and not an array pretending to be one
- * (objectui#6752).
- *
- * One predicate for BOTH bags. It existed only as the `properties` branch's
- * inline guard in the evaluation memo, spelled again inline in
- * {@link propsWithoutCanonicalKeys}; `props` had no equivalent at either site,
- * which is the whole of objectui#6752. `typeof null === 'object'` is covered by
- * the truthiness test.
- *
- * ⚠️ This is the FOURTH spelling of this one question in this package —
- * `propsBagDiagnostic.ts` and `unevaluatedExpression.ts` each carry their own,
- * and the visibility block below carries a fifth inline. Only the two in THIS
- * file are unified here: the other two live in objectui#6708's and
- * objectui#4795's modules, and merging them is a refactor across cards rather
- * than this one's to make. Filed rather than smuggled in.
- */
-function isConfigBag(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
-}
 
 /**
  * The legacy `props` bag, minus every key the canonical `properties` bag also
@@ -356,8 +336,7 @@ const visibilityGateKind = (key: VisibilityChainKey): PredicateGateKind =>
  */
 function winningVisibilityKey(node: Record<string, unknown>): VisibilityChainKey | undefined {
   const propertiesBag = node.properties;
-  const hasPropertiesBag =
-    propertiesBag != null && typeof propertiesBag === 'object' && !Array.isArray(propertiesBag);
+  const hasPropertiesBag = isConfigBag(propertiesBag);
   const effective = (key: string): unknown =>
     hasPropertiesBag && Object.prototype.hasOwnProperty.call(propertiesBag, key)
       ? (propertiesBag as Record<string, unknown>)[key]

--- a/packages/react/src/utils/configBag.pin.test.ts
+++ b/packages/react/src/utils/configBag.pin.test.ts
@@ -1,0 +1,128 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6761 — "is this a real config bag?" is asked in ONE place.
+ *
+ * ## Why a pin, and why this one is the point of the card
+ *
+ * The six occurrences this replaced all AGREED. Convergence alone therefore
+ * fixes today and not tomorrow: nothing stops a seventh from being written
+ * next week, and nothing would report it if it drifted — each spelling is a
+ * boolean expression, so a disagreement produces no error, only a different
+ * answer on one channel. `hasDeclaredPredicate` (`@object-ui/core`) is the
+ * repo's precedent for both halves of that lesson: three spellings with three
+ * different scopes, ended by one definition (objectui#3850).
+ *
+ * ## What it measures
+ *
+ * Every production source in `packages/react/src` (tests excluded — a test
+ * asserting on shapes is not a runtime answer that can drift on a channel),
+ * scanned for the `typeof x === 'object'` + `Array.isArray(x)` conjunction on
+ * the SAME operand, in either order and either polarity. That is the family
+ * every spelling of this question has been written in here — four of them
+ * across six occurrences, measured on `b98352a15`. A genuinely novel
+ * construction (`Object.prototype.toString.call`, a `constructor` test) would
+ * evade it; the job is to make the CHEAP path fail — copying a line that
+ * already exists — not to be a theorem about object-ness.
+ *
+ * ## The allowlist is a decision, not an escape hatch
+ *
+ * Two entries survive, and they are the SHAPE question asked about a data ROW
+ * rather than a config bag: "did a row bind?", whose answer carries its own
+ * pinned meaning (binding NOTHING rather than an empty row is what keeps a
+ * host-supplied `record` from being shadowed — `usePredicateRecordContext`).
+ * If "config bag" ever narrows, those two must not follow. Adding an entry
+ * here is how you say a new site asks a different question; importing
+ * {@link isConfigBag} is how you say it asks this one.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SRC_ROOT = path.resolve(here, '..');
+
+/** Every production `.ts`/`.tsx` under `packages/react/src`. */
+function collectSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      collectSources(full, out);
+      continue;
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue;
+    if (/\.test\.tsx?$/.test(entry.name)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+/**
+ * The conjunction, on one operand, in either operand order. `[\s\S]*?` inside
+ * a bounded window rather than `\s*` so a multi-line `&&` chain with a comment
+ * between the halves still matches.
+ */
+const SPELLINGS: RegExp[] = [
+  /typeof\s+([A-Za-z_$][\w$.]*)\s*[!=]==\s*['"]object['"]\s*(?:&&|\|\|)\s*!?\s*Array\.isArray\(\s*\1\s*\)/g,
+  /!?\s*Array\.isArray\(\s*([A-Za-z_$][\w$.]*)\s*\)\s*(?:&&|\|\|)\s*typeof\s+\1\s*[!=]==\s*['"]object['"]/g,
+];
+
+/** `<path relative to packages/react/src>: <matched text, whitespace collapsed>` */
+function findSpellings(): string[] {
+  const found: string[] = [];
+  for (const file of collectSources(SRC_ROOT).sort()) {
+    const source = readFileSync(file, 'utf8');
+    for (const pattern of SPELLINGS) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(source)) !== null) {
+        const rel = path.relative(SRC_ROOT, file).split(path.sep).join('/');
+        found.push(`${rel}: ${match[0].replace(/\s+/g, ' ')}`);
+      }
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * The definition, plus the two ROW sites. Every entry names the question it
+ * answers; a new line here without one is the drift this file exists to stop.
+ */
+const ALLOWED = [
+  // THE definition. Everything asking "is this a config bag?" reads this.
+  "utils/configBag.ts: typeof value === 'object' && !Array.isArray(value)",
+  // A data ROW, not a config bag: whether the node's bound record is a row to
+  // put in the evaluator scope at all (binding `{}` would SHADOW a
+  // host-supplied `record`).
+  "SchemaRenderer.tsx: typeof boundRecord === 'object' && !Array.isArray(boundRecord)",
+  // The same row question, one layer down — `usePredicateRecordContext`'s
+  // "no row → bind NOTHING" rule.
+  "hooks/useExpression.ts: typeof record !== 'object' || Array.isArray(record)",
+].sort();
+
+describe('objectui#6761 — one config-bag predicate', () => {
+  it('has no spelling outside the definition and the two row sites', () => {
+    expect(findSpellings()).toEqual(ALLOWED);
+  });
+
+  it('is read by every module that asks the question', () => {
+    for (const rel of [
+      'SchemaRenderer.tsx',
+      'utils/propsBagDiagnostic.ts',
+      'utils/unevaluatedExpression.ts',
+    ]) {
+      const source = readFileSync(path.resolve(SRC_ROOT, rel), 'utf8');
+      expect(source, `${rel} no longer imports the shared predicate`).toMatch(
+        /import \{ isConfigBag \} from '\.(?:\/utils)?\/configBag\.js';/
+      );
+    }
+  });
+});

--- a/packages/react/src/utils/configBag.ts
+++ b/packages/react/src/utils/configBag.ts
@@ -1,0 +1,71 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Is this value a real config bag — an object, and not an array pretending to
+ * be one? (objectui#6761)
+ *
+ * This is the ONE definition of that question in `@object-ui/react`, and it
+ * lives here rather than in whichever module happened to need it first,
+ * because every module that asks it is a CONSUMER of the same authored shape:
+ * the `properties` / `props` bags a node may carry. `typeof null === 'object'`
+ * is covered by the truthiness test.
+ *
+ * ## Why one definition, when all the copies agreed
+ *
+ * They agreed; that was never the cost. The cost is that disagreement between
+ * them produces NO error — each copy is a boolean expression, and a copy that
+ * drifts answers a different question on ONE channel while every other channel
+ * keeps the old answer. That is the same failure mode `hasDeclaredPredicate`
+ * (`@object-ui/core`) was created to end for "is a gate DECLARED?", which had
+ * three spellings with three different SCOPES before objectui#3850 —
+ * `disabled: null` greying a control out on one path and not another
+ * (objectui#3862).
+ *
+ * ## The spellings this replaces, measured on `b98352a15`
+ *
+ * Six occurrences, four spellings, all in `packages/react/src`:
+ *
+ *   1. `SchemaRenderer`'s module-private `isConfigBag` — itself already the
+ *      merge of the `properties` evaluation guard and `propsWithoutCanonicalKeys`
+ *      (objectui#6752, which unified those two because it had to touch both,
+ *      and filed the rest as objectui#6761 rather than smuggling it in);
+ *   2. `SchemaRenderer`'s `winningVisibilityKey`, inline, spelled with
+ *      `!= null` where the others spell truthiness;
+ *   3. `utils/propsBagDiagnostic.ts`'s module-private twin (objectui#6708);
+ *   4. `utils/unevaluatedExpression.ts`'s `scanBag` early return, spelled
+ *      NEGATED (objectui#4795);
+ *   5. `utils/unevaluatedExpression.ts`'s `hoisted`, in the same file as (4)
+ *      and spelled positively — this one is not in objectui#6761's inventory
+ *      of five, which counted the file once; six occurrences is the count
+ *      measured on this branch's base, and it was six on the card's base
+ *      (`b76ca6764`) too.
+ *
+ * `!= null` (2) and truthiness (1, 3, 5) cannot disagree HERE, and the
+ * difference is worth naming rather than smoothing over: they part company
+ * only on a falsy value, and every falsy value except `document.all` fails
+ * `typeof === 'object'` in the very next conjunct. The texts differ; the
+ * answers cannot.
+ *
+ * ## What this is NOT
+ *
+ * Not a general "is this a plain object?" utility, and deliberately not shared
+ * with the two sites that ask the same SHAPE question about a data ROW —
+ * `SchemaRenderer`'s `boundRecord` scope entry and
+ * `usePredicateRecordContext` (`hooks/useExpression.ts`). Those answer "did a
+ * row bind?", and their answer has its own pinned meaning: binding NOTHING
+ * rather than an empty row is what keeps a host-supplied `record` from being
+ * shadowed. Should "config bag" ever narrow (rejecting a class instance, say),
+ * the row sites must NOT follow — merging them would make that a single edit
+ * with two rulings behind it. The pin in `configBag.pin.test.ts` names both
+ * sites with this reason, so the next reader finds a decision rather than an
+ * oversight.
+ */
+export function isConfigBag(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/react/src/utils/propsBagDiagnostic.ts
+++ b/packages/react/src/utils/propsBagDiagnostic.ts
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { isConfigBag } from './configBag.js';
+
 /**
  * Dev-build diagnostic: a `props` CONFIG BAG on a node whose renderer reads its
  * config from `schema` — so the keys inside it are evaluated, spread as React
@@ -183,11 +185,6 @@ const _warnedPropsBags = new Set<string>();
  */
 export function __resetDroppedPropsBagWarnings(): void {
   _warnedPropsBags.clear();
-}
-
-/** A real config bag: an object, and not an array pretending to be one. */
-function isConfigBag(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**

--- a/packages/react/src/utils/unevaluatedExpression.ts
+++ b/packages/react/src/utils/unevaluatedExpression.ts
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { isConfigBag } from './configBag.js';
+
 /**
  * Dev-build diagnostic: an UNEVALUATED template expression reached the DOM.
  *
@@ -102,8 +104,8 @@ function scanBag(
   into: UnevaluatedExpressionFinding[],
   skip?: (key: string, value: string) => boolean
 ): void {
-  if (!bag || typeof bag !== 'object' || Array.isArray(bag)) return;
-  for (const [key, value] of Object.entries(bag as Record<string, unknown>)) {
+  if (!isConfigBag(bag)) return;
+  for (const [key, value] of Object.entries(bag)) {
     if (typeof value !== 'string') continue;
     if (skip?.(key, value)) continue;
     const expressions = findExpressionSources(value);
@@ -141,10 +143,7 @@ export function collectUnevaluatedExpressions(
 
   // The hoist copies every `properties.*` value onto the node's top level, so
   // the same residue is visible twice. Report the authored spelling only.
-  const hoisted =
-    properties && typeof properties === 'object' && !Array.isArray(properties)
-      ? (properties as Record<string, unknown>)
-      : undefined;
+  const hoisted = isConfigBag(properties) ? properties : undefined;
   scanBag(spread, 'schema', findings, (key, value) => hoisted?.[key] === value);
 
   scanBag(props, 'props', findings);


### PR DESCRIPTION
Fixes #6761

**Arm taken: converge.** One exported predicate, all six occurrences reading it, and a pin that fails when a seventh spelling appears.

## Re-derived on this branch's base (`b98352a15`), and the count is six, not five

The card names five sites. On its own base (`b76ca6764`) and on mine there are **six**: `utils/unevaluatedExpression.ts` carries **two** — `scanBag`'s negated early return (the one the card names) and the `hoisted` dedupe read 40 lines below it, spelled positively. The file was counted once. The sixth is not a rounding error: ablating it silences a diagnostic (site 6 below).

| # | site on `b98352a15` | spelling |
|---|---|---|
| 1 | `SchemaRenderer.tsx` module-private `isConfigBag` (already the merge of the `properties` guard + `propsWithoutCanonicalKeys`, #6752 / PR #6763) | truthiness |
| 2 | `SchemaRenderer.tsx` `winningVisibilityKey`, inline | `!= null` |
| 3 | `utils/propsBagDiagnostic.ts` private twin (#6708) | truthiness |
| 4 | `utils/unevaluatedExpression.ts` `scanBag` (#4795) | negated |
| 5 | `utils/unevaluatedExpression.ts` `hoisted` — **not in the card's inventory** | truthiness |

(#6752 merged what the card calls sites 1 and 2 into row 1 before this branch started, so the surviving textual count is six occurrences in four spellings.)

`!= null` and truthiness cannot disagree here, and the difference is worth naming rather than smoothing over: they part company only on a falsy value, and every falsy value except `document.all` fails `typeof x === 'object'` in the very next conjunct. The texts differ; the answers cannot.

## What landed

- `packages/react/src/utils/configBag.ts` — the one definition, with the history and the equivalence argument.
- All six occurrences now read it (9 call sites).
- `packages/react/src/utils/configBag.pin.test.ts` — **the part that matters.** It scans every production source under `packages/react/src` for the `typeof x` + `Array.isArray(x)` conjunction on the same operand, in either order and either polarity, and requires the set to equal a declared allowlist. A seventh spelling fails it. A second leg pins that the three converged modules still import the predicate, so deleting the import and re-inlining trips leg 1 and deleting the check entirely trips leg 2.
- Changeset with empty frontmatter — declared as releasing nothing, because nothing observable moved.

## Deliberately NOT merged: the two row sites

`SchemaRenderer`'s `boundRecord` scope entry and `usePredicateRecordContext` (`hooks/useExpression.ts`) ask the same SHAPE question about a data **row**, not a config bag. Their answer carries its own pinned meaning — binding NOTHING rather than an empty row is what keeps a host-supplied `record` from being shadowed. If "config bag" ever narrows (rejecting a class instance, say), those two must not follow; merging them would make that one edit with two rulings behind it. They are named in the pin's allowlist **with that reason**, so the next reader finds a decision rather than an oversight.

## No behaviour change, and the #6752 pin is the oracle

`SchemaRenderer.degeneratePropsBag.test.tsx` (from #6752 / PR #6763) is **untouched** by this PR — `git diff --name-only` over the commit does not list it — and green. It is also demonstrably the oracle: it is the file that goes red in three of the nine ablations below.

## Ablations — every call site, one at a time

Method per site: commit first, then replace `isConfigBag(x)` at exactly **one** call site with bare truthiness, prove the mutation reached disk (anchor count 1 to 0, mutation count 0 to 1, plus `git diff --numstat`), run the targeted suite, restore with `git checkout HEAD -- ABSOLUTE_PATH`, prove the restore with `git diff HEAD` empty. Driver in a `try/finally` so a kill mid-mutation still restores. No build step is involved: `vitest.config.mts` aliases `@object-ui/*` to each package's `src/`, and five of the nine ablations going red is the live proof that a source mutation reaches the run.

Targeted suite = the 7 files that cover these modules; baseline `7 passed / 123 passed`, `VITEST_EXIT=0`.

| ablated call site | targeted suite | what moved |
|---|---|---|
| `properties` evaluation guard (row 1) | **1 failed / 122** — `degeneratePropsBag` | `schema.properties` stops holding the authored value |
| `props` evaluation guard (row 1, #6752's twin) | **3 failed / 120** — `degeneratePropsBag` | the nine indexed props return |
| `propsWithoutCanonicalKeys`, `props` bag (row 1) | **2 failed / 121** — `degeneratePropsBag` | ditto, the other half |
| `propsWithoutCanonicalKeys`, `properties` bag (row 1) | 123 passed — **no test covers it** | probed: real difference, below |
| `winningVisibilityKey` (row 2) | 123 passed — no test covers it | probed: **no observable difference**, below |
| `collectDroppedPropsKeys`, authored bag (row 3) | **2 failed / 121** — `propsBagDiagnostic` | "returns null for a string / an array authored bag" |
| `collectDroppedPropsKeys`, outgoing bag (row 3) | 123 passed — no test covers it | probed: real difference, below |
| `scanBag` early return (row 4) | **1 failed / 122** — `unevaluatedExpressionDiagnostic` | "ignores non-string values and degenerate bags" |
| `hoisted` dedupe read (row 5) | 123 passed — no test covers it | probed: real difference, below |

### The four with no coverage, measured directly rather than assumed

Reading a diff shows structure, not which half is load-bearing (#6752's lesson). Each was measured through the real renderer or the exported function, guarded vs ablated, same probe both times:

- **`propsWithoutCanonicalKeys`' `properties` guard — load-bearing.** Node `props: { '0': 'ZERO', title: 'T' }` with `properties: 'ab'`: guarded the element receives `0: "ZERO"`; ablated it receives `0: "a"`. With `properties: ['X']`: `0: "ZERO"` guarded, `0: "X"` ablated. A degenerate bag was subtracting the author's own key and the hoist's copy took its place.
- **`winningVisibilityKey`'s guard — NOT load-bearing.** Five shapes (`'visible'`, `['${data.missing}']`, `42`, `true`, and a real bag), rendered outcome and `console.warn` text byte-identical both ways. It is doubly dominated: `hasOwnProperty` on a primitive or an array cannot hold a key named `visible` / `hidden` / …, and its only consumer is already gated on `rawPropertiesBag`, which is `isConfigBag`-derived. Defence-in-depth, kept (converging it costs nothing and removes a spelling), but its reason is now stated honestly rather than assumed by symmetry.
- **`collectDroppedPropsKeys`' outgoing guard — load-bearing for a direct caller, unreachable from the renderer.** Direct calls: guarded returns `null` for a string and for an array outgoing bag; ablated returns `["0"..."8"]` and `["0","1"]` — exactly the "tells the author `schema.0` is undefined, which is true and useless" failure the module's docblock names for the *authored* bag. From `SchemaRenderer` it cannot fire, because `propsWithoutCanonicalKeys` has returned an object at every exit since #6752.
- **The uncounted sixth (`hoisted`) — load-bearing.** `collectUnevaluatedExpressions({ '0': '${data.x}' }, ['${data.x}'])`: guarded reports the residual expression on the `schema` channel; ablated returns **no findings at all** — the dedupe read `['${data.x}']['0'] === '${data.x}'` matches and skips it. Ablating the spelling the card did not count silences a diagnostic.

## Commands and exit codes

All heavy runs serialized through the container's shared verify lock; verdict lines quoted, not a bare `$?`.

```
pnpm exec vitest run packages/react/                      REACT_SUITE_EXIT=0
                                                          Test Files 67 passed (67) · Tests 989 passed (989)
pnpm --filter @object-ui/react run type-check             TYPECHECK_EXIT=0   (tsc --noEmit && tsc -p tsconfig.test.json)
pnpm exec eslint FIVE_CHANGED_FILES --format json         ESLINT_EXIT=0      5 files linted, 0 errors, 16 warnings
node scripts/check-changeset-presence.mjs                 EXIT=0
node scripts/check-changeset-no-major.mjs                 NOMAJOR_EXIT=0
node scripts/check-control-bytes.mjs                      CONTROLBYTES_EXIT=0
node scripts/check-type-check-coverage.mjs                TCCOV_EXIT=0
node scripts/check-lint-coverage.mjs                      LINTCOV_EXIT=0
```

The full-suite and gate runs above were made at `f6b22b4db`, this branch's final commit, on a clean tree.

Two measurements that would otherwise be "green but nothing measured":

- The 16 eslint warnings are all pre-existing `no-explicit-any` in `SchemaRenderer.tsx`, at lines this PR does not touch; the two new files report zero messages.
- `type-check` really covers the new files: `tsc -p tsconfig.test.json --listFiles` lists both `utils/configBag.ts` and `utils/configBag.pin.test.ts`.

**Declared narrowing:** repo-wide `pnpm lint` was not run locally — eslint was scoped to the five changed files. The narrowing is a measurement, not an omission: (1) the population is eslint's own config, `files: ['**/*.{ts,tsx}']` plus its `ignores`, not my guess at what counts; (2) the file count comes from `--format json` (5 results); (3) the config declares no `parserOptions.project` and no `projectService`, so linting is not type-aware and this diff cannot move the verdict for any file it does not contain. CI runs the whole farm regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_