### PR TITLE
fix(components): the semantic sectioning tags and aspect-ratio declare the containment they render — with the full census behind the scope

### DIFF
--- a/.changeset/6764-container-declaration-census.md
+++ b/.changeset/6764-container-declaration-census.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/components': patch
+---
+
+The seven semantic sectioning tags and `aspect-ratio` declare the containment
+they render (objectui#6764).
+
+`renderers/layout/semantic.tsx` registers `aside`, `main`, `header`, `nav`,
+`footer`, `section` and `article`, and `renderers/layout/aspect-ratio.tsx`
+registers one more; all eight call
+`renderChildren(schema.children || schema.body)` and none declared
+`isContainer`. Nothing on the render path reads that flag, so children always
+rendered — what the omission did was make `validateTree` warn `not-a-container`
+on a child list it then rendered, on the tier built to accept AI-authored pages.
+A warning that lies trains authors to discount the true ones.
+
+Same reasoning as objectui#3900 (`page-header`) and objectui#6740 (`flex`):
+`children` is a base property of every node in the JSON protocol, not a
+per-component authoring key, so the flag widens no spec surface.
+
+Scoped by measurement, not by sweep. The census behind this change rendered
+every registered key through the real `SchemaRenderer` and put it through
+`validateTree`: of 131 bare authoring tags, 58 render `schema.children`, 5
+declared the flag, and 53 did not. These 8 are the subset where the second
+consumer is provably unaffected — `renderers/layout/react-page.tsx` drops
+containers from the `kind:'react'` JSX scope, but it reads `getPublicConfigs()`
+and none of the 8 is in the curated public contract. The remaining 45 are
+reported on the card rather than swept in, `button` among them precisely because
+it IS public.

--- a/packages/components/src/renderers/__tests__/container-declaration-census.test.tsx
+++ b/packages/components/src/renderers/__tests__/container-declaration-census.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The seven semantic sectioning tags and `aspect-ratio` declare the containment
+ * they render (objectui#6764) — and the two CONTROLS that keep this a census
+ * rather than a sweep.
+ *
+ * ## Why this file exists at all
+ *
+ * The same defect has now been found three times, one registration at a time:
+ * objectui#3900 (`page-header`, closed), objectui#6740 (`flex`, PR #6762), and
+ * this card. Each was filed as a one-off because nothing in the tree asks "does
+ * this registration render a child list while declaring it takes none?".
+ *
+ * The reasoning that makes the declaration correct is objectui#3900's, written
+ * out at `packages/layout/src/index.ts`: `children` is a BASE property of every
+ * node in the JSON protocol (`BASE_PROPS` in `sdui-parser/src/validate.ts`), not
+ * a per-component authoring key, so `isContainer` answers the protocol question
+ * "does this node accept a child list?" and widens no spec surface. Omitting it
+ * never made children illegal — nothing on the render path reads the flag — it
+ * made `validateTree` LIE, and a warning that lies is worse than a missing one
+ * because it trains authors (AI authors especially) to discount the TRUE
+ * `not-a-container` reports on components that really are childless.
+ *
+ * ## MEASURED on b98352a15, over the live registry, not over the source
+ *
+ * Every registered key was rendered through the real `SchemaRenderer` with one
+ * `text` child and put through `validateTree`. Of 131 bare authoring tags:
+ *
+ *   - 58 render `schema.children` (the child text reached the DOM);
+ *   - 5 of those declared the flag — `flex`, `grid`, `card`, `container`,
+ *     `stack`, exactly the control set objectui#6764 named, which is what makes
+ *     the rest a reading rather than a broken scan;
+ *   - 53 did not, and every one drew `not-a-container` on a child list it then
+ *     rendered;
+ *   - 73 render no children and correctly keep the diagnostic;
+ *   - 0 failed to render, so nothing was scored on an exception.
+ *
+ * This file pins the 8 that this change declares. The other 45 are reported on
+ * the card: they are NOT swept in here, because two of the four populations
+ * below prove the predicate has real exceptions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer, AdapterCtx } from '@object-ui/react';
+import { manifestFromConfigs, validateTree } from '@object-ui/sdui-parser';
+import type { Diagnostic, SchemaElement } from '@object-ui/sdui-parser';
+
+// Module scope, not a hook: this import IS the registration (AGENTS.md
+// §测试纪律 — an unbounded module load must not be billed to a bounded window).
+import '../index';
+
+const CONTAINMENT = 'not-a-container';
+const MARK = 'census-child';
+
+/** The eight registrations this change declares. */
+const DECLARED_HERE = [
+  // renderers/layout/semantic.tsx — one factory, seven tags
+  'aside',
+  'main',
+  'header',
+  'nav',
+  'footer',
+  'section',
+  'article',
+  // renderers/layout/aspect-ratio.tsx
+  'aspect-ratio',
+] as const;
+
+/**
+ * The manifest the running app validates against, built the way the app builds
+ * it — keyed by every KNOWN registry tag rather than by `getAllConfigs()`, whose
+ * `.type` is always the namespaced form. Mirrors `getJsxManifest()` in
+ * `renderers/layout/page.tsx`. Key it off `getAllConfigs()` instead and the bare
+ * tag an author writes is absent from the manifest, so every assertion below
+ * would pass on `unknown-component` without reaching the containment check.
+ */
+const diagnose = (schema: unknown): Diagnostic[] => {
+  const configs = ComponentRegistry.getKnownTypes().map((t) => {
+    const meta = ComponentRegistry.getMeta(t);
+    return { type: t, namespace: meta?.namespace, isContainer: meta?.isContainer, inputs: meta?.inputs };
+  });
+  const manifest = manifestFromConfigs(configs as unknown as Parameters<typeof manifestFromConfigs>[0]);
+  return validateTree(schema as SchemaElement, manifest).diagnostics;
+};
+
+const withChildren = (type: string) => ({ type, children: [{ type: 'text', content: MARK }] });
+
+/** Does this registration put an authored child list on the page? */
+const rendersChildren = async (type: string): Promise<boolean> => {
+  const { container, unmount } = render(
+    <AdapterCtx.Provider value={null as never}>
+      <SchemaRenderer schema={withChildren(type) as never} />
+    </AdapterCtx.Provider>,
+  );
+  try {
+    await waitFor(() => expect(container.textContent).toBeDefined());
+    return (container.textContent || '').includes(MARK);
+  } finally {
+    unmount();
+  }
+};
+
+describe('the sectioning tags declare the containment they render (objectui#6764)', () => {
+  it.each(DECLARED_HERE)('`%s` renders an authored child list', async (type) => {
+    // The half that makes the declaration HONEST, and it comes first: the flag
+    // is only correct because the renderer really does put the child on the
+    // page. Asserted through the real render path rather than by reading the
+    // source, because the source read is what the three previous rediscoveries
+    // each did by hand.
+    expect(await rendersChildren(type)).toBe(true);
+  });
+
+  it.each(DECLARED_HERE)('`%s` with children draws no `not-a-container`', (type) => {
+    const diagnostics = diagnose(withChildren(type));
+
+    // Reachability BEFORE absence — an empty result proves nothing if the
+    // containment branch never ran. Two ways it silently would not: an
+    // unresolved tag reports `unknown-component` and never reaches the check,
+    // and the branch is guarded by `node.children?.length`.
+    expect(diagnostics.filter((d) => d.code === 'unknown-component')).toEqual([]);
+    expect(withChildren(type).children.length).toBeGreaterThan(0);
+
+    // Filtered by code, not against an empty list: this file owns the
+    // CONTAINMENT fact only, so a future diagnostic on some other key belongs to
+    // that key's pin rather than here.
+    expect(diagnostics.filter((d) => d.code === CONTAINMENT)).toEqual([]);
+  });
+});
+
+describe('the declaration is confined to what was measured (objectui#6764)', () => {
+  it('leaves `tabs` alone — it renders `items[].content`, not `schema.children`', async () => {
+    // THE non-case objectui#6764 named, and the reason this card was not a mass
+    // edit. `tabs` also lacks the flag, but it renders `item.content` off an
+    // `items` array: a child list authored under `children` is genuinely
+    // unrendered, so `not-a-container` on it is TRUE and must survive.
+    //
+    // It is also `PUBLIC` (`PUBLIC_BLOCKS`), so sweeping it in would have
+    // deleted `<Tabs>` from the JSX scope of every `kind:'react'` page as well.
+    expect(await rendersChildren('tabs')).toBe(false);
+    expect(diagnose(withChildren('tabs')).map((d) => d.code)).toContain(CONTAINMENT);
+  });
+
+  it.each(['img', 'hr', 'br'])('leaves the void tag `%s` alone', async (type) => {
+    // The second half of the same control, inside a LOOP FACTORY. `img`/`hr`/
+    // `br` come out of the same `basic/html-elements.tsx` loop as 34 tags that
+    // DO render children, and the factory skips `renderChildren` for them by
+    // design (`VOID_TAGS`). A census that worked at file granularity — the
+    // granularity a static reader can reach — would have declared all 37
+    // together and told authors that `<br>` accepts children.
+    expect(await rendersChildren(type)).toBe(false);
+    expect(diagnose(withChildren(type)).map((d) => d.code)).toContain(CONTAINMENT);
+  });
+
+  it('leaves `badge` and `alert` alone — they read `schema.body`, a key the check never inspects', async () => {
+    // The third exception, and the one a "renders children OR body" predicate
+    // would have collapsed: these render `renderChildren(schema.body)` and never
+    // touch `schema.children`. `validateTree`'s containment branch is guarded by
+    // `node.children?.length` ALONE, so no author writing `body` on them has
+    // ever drawn a false diagnostic, and declaring the flag would buy nothing
+    // while removing both from the react-page scope (both are PUBLIC).
+    for (const type of ['badge', 'alert']) {
+      expect(await rendersChildren(type)).toBe(false);
+      expect(diagnose(withChildren(type)).map((d) => d.code)).toContain(CONTAINMENT);
+    }
+  });
+});
+
+describe('the premise that made this change safe on the SECOND consumer (objectui#6764)', () => {
+  it('none of the eight is in the curated public contract', () => {
+    // `renderers/layout/react-page.tsx` builds the JSX scope of every
+    // `kind:'react'` page with `if (!tag || cfg.isContainer) continue;`, so each
+    // declaration also REMOVES that tag as an injected identifier — the
+    // consequence objectui#6764 recorded as unmeasured. It reads
+    // `getPublicConfigs()`, not the whole registry, and none of these eight is
+    // in it: there is no `<Aside>` / `<Main>` / `<AspectRatio>` wrapper for the
+    // flag to delete. That is why this subset was safe and `button` — the one
+    // member of the same census population that IS public — was left alone.
+    //
+    // Pinned rather than left as a comment so that promoting one of these into
+    // `PUBLIC_BLOCKS` re-opens the question HERE, instead of silently dropping a
+    // tag from every react page.
+    const publicTags = new Set(
+      (ComponentRegistry.getPublicConfigs() as Array<{ type: string }>).map((c) => c.type),
+    );
+
+    // Direction control first. Without it, "none of the eight is public" is
+    // indistinguishable from "the public tier is empty / this reader broke",
+    // and the assertion below would be green for nothing.
+    expect(publicTags.size).toBeGreaterThan(0);
+    expect(publicTags.has('flex')).toBe(true);
+    expect(publicTags.has('button')).toBe(true);
+
+    expect(DECLARED_HERE.filter((t) => publicTags.has(t))).toEqual([]);
+  });
+});

--- a/packages/components/src/renderers/__tests__/container-declaration-census.test.tsx
+++ b/packages/components/src/renderers/__tests__/container-declaration-census.test.tsx
@@ -43,8 +43,11 @@
  *   - 0 failed to render, so nothing was scored on an exception.
  *
  * This file pins the 8 that this change declares. The other 45 are reported on
- * the card: they are NOT swept in here, because two of the four populations
- * below prove the predicate has real exceptions.
+ * the card: they are NOT swept in here, because the three exception populations
+ * below prove the predicate has real exceptions -- `tabs` (renders
+ * `items[].content`), the void tags out of the same loop factory as 34 that do
+ * render children, and the `schema.body` readers the containment check never
+ * inspects.
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/components/src/renderers/layout/aspect-ratio.tsx
+++ b/packages/components/src/renderers/layout/aspect-ratio.tsx
@@ -38,6 +38,13 @@ ComponentRegistry.register('aspect-ratio',
   {
     namespace: 'ui',
     label: 'Aspect Ratio',
+    // Same declaration, same reason as `semantic.tsx` (objectui#6764): the
+    // renderer falls back to `renderChildren(schema.children || schema.body)`
+    // whenever no `image` is set, so a ratio box wrapping authored content is
+    // the documented shape -- and it drew `not-a-container` for it. Not in
+    // `PUBLIC_BLOCKS`, so the react-page scope builder never saw this tag and
+    // the declaration removes no injected identifier.
+    isContainer: true,
     inputs: [
       { name: 'ratio', type: 'number', label: 'Ratio', defaultValue: 16/9 },
       { name: 'image', type: 'string', label: 'Image URL' },

--- a/packages/components/src/renderers/layout/semantic.tsx
+++ b/packages/components/src/renderers/layout/semantic.tsx
@@ -47,6 +47,26 @@ tags.forEach(tag => {
       namespace: 'ui',
       label: tag.charAt(0).toUpperCase() + tag.slice(1),
       category: 'layout',
+      // Declared because the factory above RENDERS a child list
+      // (`renderChildren(schema.children || schema.body)`), which is the whole
+      // question this flag answers -- `children` is a BASE property of every
+      // node in the JSON protocol (`BASE_PROPS` in `sdui-parser/src/validate.ts`),
+      // not a per-component authoring key, so declaring it widens no spec
+      // surface (the objectui#3900 reasoning, spelled out at
+      // `packages/layout/src/index.ts`). Leaving it off did not make children
+      // illegal -- nothing on the render path reads the flag -- it made
+      // `validateTree` LIE, warning `not-a-container` on seven sectioning tags
+      // that render children correctly.
+      //
+      // Safe on the second consumer, and that was MEASURED rather than assumed
+      // (objectui#6764): `renderers/layout/react-page.tsx` drops containers from
+      // the `kind:'react'` JSX scope, but it iterates `getPublicConfigs()`, and
+      // none of these seven tags is in the curated `PUBLIC_BLOCKS` contract --
+      // so there is no injected `<Aside>`/`<Main>`/... identifier for this flag
+      // to remove. `__tests__/container-declaration-census.test.tsx` pins that
+      // premise, so promoting one of these into the public contract re-opens the
+      // question here instead of silently deleting a tag from every react page.
+      isContainer: true,
       inputs: [
         { name: 'className', type: 'string', label: 'CSS Class' }
       ]


### PR DESCRIPTION
Fixes #6764

The card's point is the recurrence, so the census came first. It is complete, and
it is **bigger than eight**: 53 registrations, not 8. This PR fixes the 8 the card
names — the subset where every reading is unambiguous — and reports the other 45
rather than sweeping them in.

## 1. The census

Measured at **runtime, over the live registry**, not by reading source. Every
registered key was rendered through the real `SchemaRenderer` with one `text`
child, and the same key put through `validateTree` on the manifest the app
builds. Of **131 bare authoring tags** (292 registry keys once the `ns:tag`
twins are counted):

| population | count |
|---|---|
| renders `schema.children` (the child text reached the DOM) | **58** |
| — of those, declares `isContainer` | 5 |
| — of those, **does not** — draws `not-a-container` on a child list it then renders | **53** |
| renders no children, correctly keeps the diagnostic | 73 |
| — of those, renders `schema.body` only | 10 |
| failed to render (scored on an exception) | **0** |

**The control set comes back clean.** The 5 that declare it are exactly
`flex` / `grid` / `card` / `container` / `stack` — the control the card named. The
zero elsewhere is therefore a reading, not a property of the scan. It also agrees
with the existing `layout-containers-declare-containment` pin (PR #6762) on
`flex`: declared, no diagnostic, renders children.

### The 53, by the registration that owns them

| site | count | tags |
|---|---|---|
| `basic/html-elements.tsx` (loop factory) | 34 | `h1`–`h6`, `p`, `a`, `blockquote`, `pre`, `strong`, `em`, `b`, `i`, `u`, `small`, `mark`, `sub`, `sup`, `del`, `ins`, `abbr`, `ul`, `ol`, `li`, `dl`, `dt`, `dd`, `figure`, `figcaption`, `time`, `address`, `cite`, `q` |
| `layout/semantic.tsx` (loop factory) | 7 | `aside`, `main`, `header`, `nav`, `footer`, `section`, `article` |
| `layout/page.tsx` (one shared `pageMeta`) | 5 | `page`, `app`, `home`, `record`, `utility` |
| `layout/aspect-ratio.tsx` | 1 | `aspect-ratio` |
| `basic/div.tsx` · `basic/span.tsx` · `complex/scroll-area.tsx` | 3 | `div`, `span`, `scroll-area` |
| `form/form.tsx` · `form/toggle.tsx` | 2 | `form`, `toggle` |
| `form/button.tsx` | 1 | `button` — **the only public-tier member** |

**Nothing outside `packages/components/src/renderers/` is in the population.**
Every registration in the repo that renders a child list lives under that path;
the sibling-held areas (`packages/plugin-timeline/`, `packages/react/src/`,
`apps/console/`, `packages/fields/src/widgets/`) contribute zero, so there is
nothing to report out of fence.

### The two populations really are two — three separators, all measured

The card was right that collapsing them would break the second group. Three
distinct exception shapes turned up, and each is now a control in the new pin:

1. **`tabs`** — the card's named non-case. Renders `items[].content`, never
   `schema.children`. Runtime probe: **does not** put an authored child list on
   the page, so its `not-a-container` is **true** and must survive. It is also
   `PUBLIC`, so sweeping it in would have deleted its identifier from the JSX
   scope of every `kind:'react'` page as well.
2. **The void tags `img` / `hr` / `br`** — they come out of the *same loop
   factory* as 34 tags that do render children, and the factory skips
   `renderChildren` for them by design (`VOID_TAGS`). A census at **file**
   granularity — the granularity a static reader can reach — would have declared
   all 37 together and told authors that `br` accepts children.
3. **`badge` / `alert` and 8 `sidebar-*`** — they render `schema.body` and never
   touch `schema.children`. `validateTree`'s containment branch is guarded by
   `node.children?.length` **alone**, so no author has ever drawn a false
   diagnostic from them. A "renders children **or** body" predicate — the
   spelling the card itself uses — over-reports by 10.

## 2. The second consumer, measured per registration

This is the question the card recorded as unmeasured. It has a mechanical
answer: `renderers/layout/react-page.tsx` drops containers when building the JSX
scope (`if (!tag || cfg.isContainer) continue;`), but it iterates
**`getPublicConfigs()`**, not the whole registry. So the declaration can only
remove an injected identifier for a tag in the curated `PUBLIC_BLOCKS` contract.

Of the 53: **52 are private → the second consumer is a proven no-op.**
**1 is public: `button`.** Declaring it would remove `Button` from every
`kind:'react'` page scope — a real behaviour change, and `button` reads children
as a *label fallback* (`schema.label || renderChildren(schema.body || schema.children)`),
not as layout containment. It is left alone, deliberately.

A third consumer exists and is also a no-op here: `sdui-parser/codegen.ts` prints
a "container" column, and it too reads the public manifest only.

## 3. What this PR changes

Two meta objects, eight registrations:

- `renderers/layout/semantic.tsx` — one factory, 7 tags.
- `renderers/layout/aspect-ratio.tsx` — 1.

Both live under `renderers/layout/`, both render
`renderChildren(schema.children || schema.body)`, neither is in `PUBLIC_BLOCKS`.
The justification is objectui#3900's, written out at `packages/layout/src/index.ts`:
`children` is a **base property of every node** in the JSON protocol
(`BASE_PROPS` in `sdui-parser/src/validate.ts`), not a per-component authoring
key, so the flag widens no spec surface. Omitting it never made children illegal
— nothing on the render path reads it — it made `validateTree` **lie**.

### The new pin, and its relationship to the existing one

`renderers/__tests__/container-declaration-census.test.tsx` is a **new file**.
**`packages/components/src/__tests__/layout-containers-declare-containment.test.tsx`
(PR #6762) is NOT modified** — not a ratchet, not a weakening, byte-identical to
`origin/main`. Two reasons: this round's fence confines edits to
`packages/components/src/renderers/`, and the two pins own different facts (that
one owns the `ui` layout-primitive family from #6740; this one owns the eight
plus the three exception populations above). They agree on `flex` and on `badge`.

The new pin asserts, per tag: the renderer really does put an authored child list
on the page (so the declaration is honest), then that no `not-a-container` is
drawn — with reachability controls before the absence. Then the three exception
controls, then the premise that made the change safe: none of the 8 is in
`getPublicConfigs()`, pinned with a direction control so that promoting one into
the public contract re-opens the question **here** instead of silently dropping a
tag from every react page.

## 4. The gate — verdict: the predicate is NOT decidable on the source

The card asks for a gate "if and only if the census shows the predicate is
mechanically decidable on the source." **It is not**, and the census measured
four independent reasons — each one a case where a source reader fails in the
direction that reads as compliance:

1. **The tree's own registration reader cannot name 41 of the 53.** `semantic.tsx`
   and `html-elements.tsx` register from a **loop variable**.
   `scripts/component-registrations.mjs` — this repo's one answer to "which keys
   does this source register?" — refuses computed keys by design. 41 of the 53
   are invisible to it.
2. **File granularity mis-reads `page.tsx` as compliant.** That file contains two
   `isContainer` tokens, so a file-level scan (the shape of the named reference,
   `check-element-data-source-declaration.mjs` — note it is **not on `main`**; it
   lives on the unmerged `claude/issue-6678-...` branch, so anyone following the
   pointer should read it there) calls it declared. Both tokens are
   in a manifest-builder helper; **all five** of its registrations lack the flag.
   The reference script itself declines per-registration matching: "a reader that
   guesses would fail in the direction that matters (a wrong pairing reads as
   compliance)."
3. **Which registration is LIVE is a whole-program, import-order fact.** A
   source reader scores a file in isolation; the registry keeps whichever
   registration ran **last**. This tree has two recorded casualties of exactly
   that — `ui:kbd` and `ui:table` (objectui#5125), registrations that kept
   compiling, kept passing type-check and never ran. So a static reader can
   score a registration that is not live, or credit a file whose declaring
   registration is the one that loses. (I checked the instance I expected to
   find here and it is NOT one: all seven `page:*` registrations in
   `containers.tsx` carry `skipFallback: true`, so they never claim the bare
   keys and there is no collision with `semantic.tsx`. The hazard is real, this
   particular pair is clean.)
4. **`children` vs `body` is not a source distinction a naive predicate keeps.**
   The predicate that matters is `schema.children` alone; a source scan for
   "children or body" over-reports by 10. My own first scan also missed
   `schema?.children` (optional chaining) in `containers.tsx` — an under-report,
   silently green.

**What *is* decidable is the runtime form** — exactly what produced the numbers
above: iterate `getKnownTypes()`, render each with one child, ask `validateTree`.
It has no parsing problem, it sees loop factories and import order for free, and
it distinguishes `children` from `body` because it asks the consumer rather than
the source. That is also the mechanism the existing #6740 pin already uses — the
difference is that its covered set is a **literal 4-element array**, which is
precisely why the class regenerated past it.

⛔ **A gate is deliberately NOT added in this PR.** Making that runtime probe
universal is red today on 53 tags, so landing it requires either fixing all 53 or
carrying a ledger of accepted ones — and that is the design call the triage
comment reserved for the decision box, on the grounds that it could not be made
well without a denominator. The denominator is now attached: **53, of which 1 is
public and 3 exception shapes are real.**

## Scope note — the two orders on this card differ, flagged rather than resolved

The triage comment (2026-08-29 08:26) fenced this round to the census alone:
⛔ 不修那 8 个, ⛔ 不建门禁. The dispatch order (09:27) re-scoped to census →
unambiguous subset → gate-iff-decidable. This PR follows the **dispatch order for
the fix** (kept to exactly the 8 the card names, each with all four readings
unambiguous and the census complete in the same PR) and the **triage comment for
the gate** (not built; delivered as a decision with the denominator). If that
reading is wrong, the census is not lost with it: it lives in this PR body and in
the new pin's docblock, and only the two `isContainer` lines (and the eight
assertions they support) would come out.

## Verification

- **Union at `f341b9d27`** (the fix commit): `pnpm exec vitest run packages/components/ packages/sdui-parser/` — **219 files, 2091 tests, all passed** (`VERDICT command-exit 0`, 6m29s).
- The second commit `a99813cc2` is **comment-only** (a docblock sentence that named the wrong number of exception populations). Re-run on that head rather than assumed: the census pin itself — **1 file, 22 tests, passed** — plus `check:control-bytes` ✅ and `eslint` on the file (**0 errors, 0 warnings**). Nothing else in the derived gate set reads a docblock.
- Earlier targeted run, before the union: `packages/components/src/renderers/__tests__/` + the `layout-containers-declare-containment` and `react-page-scope` pins + `packages/sdui-parser/` — 16 files, 195 tests, all passed.
- **Reverse verification.** Removing the two `isContainer: true` lines from `HEAD` gives **8 failed | 14 passed (22)** — and the direction is the point: the 8 failures are *all and only* the "draws no `not-a-container`" assertions. The 8 "renders an authored child list" assertions stay **green**, which is the #3900 claim measured rather than quoted: the render path does not read the flag. Every exception control and the public-tier premise stay green too. Mutation confirmed on disk before the run (`grep -c 'isContainer: true'` 1 → 0 in each file, blob hashes differ from `HEAD`); restore confirmed after (`git diff HEAD` empty **and** byte-for-byte hash equality with the `HEAD` blobs). No build sits between the mutation and the reading — the test imports the mutated module relatively from source, which the ablation itself demonstrates by moving the result with zero build steps.
- `check:control-bytes` ✅ · `check:vi-mock-specifiers` ✅ · `check-changeset-no-major` ✅ · `check-changeset-fixed` ✅ · `check-changeset-presence` ✅ (1 changeset for 3 published source files) · `check-changeset-overwrite` ✅
- `eslint` on the three touched files: **0 errors**. The 4 `no-explicit-any` warnings are pre-existing, on lines this diff does not touch (`semantic.tsx:22`, `aspect-ratio.tsx:15` — both the `forwardRef` annotations).
- `check:sdui-registration-pins` reports **exit 2 — prerequisite not met** ("No console build to weigh"), i.e. NOT MEASURED locally, not a failure. It pins that registration *keys* survive the bundle; this diff adds no key and removes none. CI runs it.
- `pnpm --filter @object-ui/components run type-check && … run lint` — **exit 0** (`&&`-joined, so the status covers both). `tsc --noEmit && tsc -p tsconfig.test.json`: **0 errors**, and the new pin is genuinely inside that number rather than excluded — `tsc -p tsconfig.test.json --showConfig` resolves 209 files and `./src/renderers/__tests__/container-declaration-census.test.tsx` is one of them (counted, not inferred from the `include` glob). eslint for the package: `938 problems (0 errors, 938 warnings)` — all pre-existing.
  - ⚠️ The first attempt at this reported 336 `error TS` and was **not a red**: `TS2307 Cannot find module '@object-ui/core'`, i.e. the dependency closure was not built. Recorded here rather than quietly re-run: `pnpm --filter '@object-ui/components^...' build` (8 packages, exit 0) is what made the number meaningful.

## Scope of the census outside this package

The runtime census covers everything `renderers/index.ts` registers (292 registry
keys). For the rest of the tree the reading is a **source scan**: across
`packages/`, 118 files make 216 `ComponentRegistry.register` calls, and every
file that reads `schema.children` / `schema.body` is under
`packages/components/src/renderers/`. `apps/` and `examples/` make zero
non-lazy `register` calls — verified as a reading, not a blind scan: the same
grep finds 32 `registerLazy` stubs there, whose renderers live in
`packages/plugin-*` and were covered by the `packages/` pass. So there is
nothing to report out of fence for this predicate.

## Filed while measuring

- **#6773** — `finding(docs,examples)`: all **5** shipped `aspect-ratio` demos
  author `content`, a key the renderer never reads, so every demo on the
  published docs page renders an empty ratio box — and the page's own Schema
  block publishes `content` while omitting `image`/`alt`, which the renderer does
  read. The contrast that makes it a reading: all **9**
  `components-layout-semantic` fixtures author `children`, which those renderers
  do read (and which, until this PR, drew the false `not-a-container` on every
  one of them — the repo's own published demos were the warning's victims, which
  is objectui#3900's shape exactly).
- **#6771** — `finding(sdui-parser/components)`: `body` is not in
  `BASE_PROPS`, so the tier answers an authored `body` with
  `unknown-prop: badge has no prop "body"` — on the one child-list key 10
  registrations actually honour. Measured against the built parser. A different
  defect with a different fix (and two opposite candidate directions), so it is
  filed rather than swept in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_