### PR TITLE
docs(aspect-ratio): author the keys the renderer reads in all five demos

### DIFF
--- a/.changeset/6773-aspect-ratio-demo-content.md
+++ b/.changeset/6773-aspect-ratio-demo-content.md
@@ -1,0 +1,21 @@
+---
+---
+
+The five `aspect-ratio` docs demos now author the keys the renderer reads, so every demo on
+the published page draws its content instead of an empty ratio box (objectui#6773).
+
+`packages/components/src/renderers/layout/aspect-ratio.tsx` reads `ratio`, `className`,
+`image` (with `alt`) and `children || body` — never `content`, which is what all five
+entries authored and nothing else. Measured on `c6732825d`, each rendered 3 elements, no
+text and no `img`: the Radix wrapper for the ratio itself, with nothing inside it. The
+photo demo now authors `image` + `alt`, the renderer's own declared inputs, whose `<img>`
+is sized to fill the box; the four card demos author `children` at BOTH levels — the
+nested `card` never read `content` either, so moving only the outer key would have traded
+an empty box for an empty card. The page's Schema block published `content` as contract
+while omitting `image`/`alt`; it now documents what the renderer reads.
+
+Nothing publishes from this change — a docs page plus `@object-ui/example-schema-catalog`
+fixtures, both outside the release — hence the empty frontmatter. The regression control is
+`examples/schema-catalog/test/aspect-ratio-demo-content-6773.test.tsx`: category scope, not
+a list of five ids, with a counter-probe that renders the pre-fix shape and proves the
+assertion can still fail.

--- a/content/docs/components/layout/aspect-ratio.mdx
+++ b/content/docs/components/layout/aspect-ratio.mdx
@@ -21,11 +21,17 @@ The Aspect Ratio component maintains a consistent width to height ratio for cont
 
 ## Schema
 
+The box holds its content one of two ways, and the renderer reads exactly one of them:
+set `image` for a photo, which is drawn to fill the box; otherwise the box renders
+`children`.
+
 ```plaintext
 interface AspectRatioSchema {
   type: 'aspect-ratio';
-  ratio: number;                  // Width / Height ratio
-  content: ComponentSchema;       // Content to display
+  ratio?: number;                  // Width / Height ratio (default: 16 / 9)
+  image?: string;                  // Image URL, drawn to fill the box
+  alt?: string;                    // Alt text for `image`
+  children?: SchemaNode | SchemaNode[];   // Content, when no `image` is set
   className?: string;
 }
 ```

--- a/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/16-9-aspect-ratio.json
+++ b/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/16-9-aspect-ratio.json
@@ -1,9 +1,6 @@
 {
   "type": "aspect-ratio",
   "ratio": 1.7777777777777777,
-  "content": {
-    "type": "image",
-    "src": "https://images.unsplash.com/photo-1588345921523-c2dcdb7f1dcd",
-    "alt": "Photo"
-  }
+  "image": "https://images.unsplash.com/photo-1588345921523-c2dcdb7f1dcd",
+  "alt": "Photo"
 }

--- a/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/4-3.json
+++ b/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/4-3.json
@@ -1,8 +1,9 @@
 {
   "type": "aspect-ratio",
   "ratio": 1.3333333333333333,
-  "content": {
+  "children": {
     "type": "card",
-    "content": "4:3 Ratio"
+    "className": "flex h-full items-center justify-center",
+    "children": "4:3 Ratio"
   }
 }

--- a/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/square.json
+++ b/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/square.json
@@ -1,8 +1,9 @@
 {
   "type": "aspect-ratio",
   "ratio": 1,
-  "content": {
+  "children": {
     "type": "card",
-    "content": "Square (1:1)"
+    "className": "flex h-full items-center justify-center",
+    "children": "Square (1:1)"
   }
 }

--- a/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/ultrawide.json
+++ b/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/ultrawide.json
@@ -1,8 +1,9 @@
 {
   "type": "aspect-ratio",
   "ratio": 2.3333333333333335,
-  "content": {
+  "children": {
     "type": "card",
-    "content": "21:9 Ratio"
+    "className": "flex h-full items-center justify-center",
+    "children": "21:9 Ratio"
   }
 }

--- a/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/video-aspect-ratio.json
+++ b/examples/schema-catalog/src/schemas/components-layout-aspect-ratio/video-aspect-ratio.json
@@ -1,9 +1,9 @@
 {
   "type": "aspect-ratio",
   "ratio": 1.7777777777777777,
-  "content": {
+  "children": {
     "type": "card",
-    "className": "bg-muted flex items-center justify-center",
-    "content": "Video Player (16:9)"
+    "className": "bg-muted flex h-full items-center justify-center",
+    "children": "Video Player (16:9)"
   }
 }

--- a/examples/schema-catalog/test/aspect-ratio-demo-content-6773.test.tsx
+++ b/examples/schema-catalog/test/aspect-ratio-demo-content-6773.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6773 — every `components-layout-aspect-ratio` demo puts its own
+ * authored content inside the ratio box.
+ *
+ * ## The reading this file was written against
+ *
+ * All five shipped demos authored `content`, and
+ * `packages/components/src/renderers/layout/aspect-ratio.tsx` reads four keys —
+ * `ratio`, `className`, `image` (with `alt`), and `children || body` — none of
+ * them `content`. Measured on `origin/main` @ `c6732825d`, rendering each entry
+ * through the real `SchemaRenderer` the way the docs gallery does:
+ *
+ *   entry                                     elements  text  img
+ *   components-layout-aspect-ratio/16-9-…            3    ""    0
+ *   components-layout-aspect-ratio/square            3    ""    0
+ *   components-layout-aspect-ratio/4-3               3    ""    0
+ *   components-layout-aspect-ratio/ultrawide         3    ""    0
+ *   components-layout-aspect-ratio/video-…           3    ""    0
+ *
+ * Three elements is the harness wrapper plus the two Radix AspectRatio emits.
+ * The authored `content` reached the DOM only as the leaked host attribute
+ * `content="[object Object]"` — the objectui#5574 class, and `ui:aspect-ratio`
+ * is already ledgered for it in
+ * `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`.
+ *
+ * ## Why nothing already red covered it
+ *
+ * `catalog-gallery-render.test.tsx` DOES render all five, and passes: its
+ * non-vacuity control is `drewSomething(elements > WRAPPER_ELEMENTS || text)`,
+ * and an empty ratio box clears it on the wrapper Radix draws for the ratio
+ * itself. Its stronger control — the entry's own authored strings on screen —
+ * is scoped to `NEWLY_REGISTERED_CATEGORIES`, which this family is not in.
+ * Nor could a parse have caught it: `BaseSchema` is `.passthrough()` and
+ * carries `[key: string]: any`, so `content` is accepted by zod and by tsc
+ * alike (the objectui#6157 class-3 shape). `check-doc-component-types.mjs`
+ * rules the question out by name — "NOT in scope, deliberately: whether the
+ * snippet's OTHER keys are read by the renderer the type resolves to".
+ *
+ * So the control that was missing is the one below, and it is asserted at
+ * CATEGORY scope rather than over a list of five ids: a sixth demo authoring
+ * the phantom key again fails here without anyone remembering to add it.
+ *
+ * Each assertion is paired with a counter-probe that proves it can still fail
+ * — the objectui#6157 discipline. The counter-probe renders the exact pre-fix
+ * shape, so what is pinned is not "the text is somewhere on screen" but "the
+ * key that carries it is one the renderer reads".
+ *
+ * Module-scope import of `@object-ui/components`, not `beforeAll` (AGENTS.md
+ * §测试纪律): registering the renderers is an unbounded module load and must
+ * not be billed to a bounded hook timeout.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@object-ui/components';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
+import { allExamples } from '../src/index.js';
+
+const CATEGORY = 'components-layout-aspect-ratio';
+
+/**
+ * The keys `aspect-ratio.tsx` reads off the schema, plus the `type`
+ * discriminator. COPIED as literals rather than imported: they are the
+ * contract this file is about, and a renderer that starts reading a new key
+ * should turn this red for review rather than silently widen the set.
+ */
+const READ_KEYS = ['type', 'ratio', 'className', 'image', 'alt', 'children', 'body'];
+
+/** Keys that carry visible content in the nodes this family authors. */
+const TEXT_SLOTS = ['children', 'body', 'title', 'description'];
+
+/** Render one entry the way `SchemaThumbnail` does. */
+function draw(schema: unknown) {
+  const { container, unmount } = render(
+    <div className="w-full p-4">
+      <SchemaRenderer schema={toRenderableSchema(schema as never) as never} />
+    </div>,
+  );
+  return {
+    text: container.textContent ?? '',
+    images: Array.from(container.querySelectorAll('img')).map((el) => ({
+      src: el.getAttribute('src') ?? '',
+      alt: el.getAttribute('alt') ?? '',
+    })),
+    unmount,
+  };
+}
+
+/** Every string this node authors in a content slot, at any depth. */
+function authoredText(node: unknown, inSlot = false): string[] {
+  if (typeof node === 'string') return inSlot ? [node] : [];
+  if (Array.isArray(node)) return node.flatMap((child) => authoredText(child, inSlot));
+  if (!node || typeof node !== 'object') return [];
+  return Object.entries(node as Record<string, unknown>).flatMap(([key, value]) =>
+    authoredText(value, TEXT_SLOTS.includes(key)),
+  );
+}
+
+const entries = allExamples().filter((e) => e.meta.category === CATEGORY);
+
+describe(`${CATEGORY} demos render their authored content (objectui#6773)`, () => {
+  it('the category is not empty — a vacuous sweep would pass every case below', () => {
+    expect(entries.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it.each(entries.map((e) => [e.id, e] as const))(
+    '%s authors only keys the renderer reads',
+    (_id, entry) => {
+      const authored = Object.keys(entry.schema as Record<string, unknown>);
+      expect(authored.filter((key) => !READ_KEYS.includes(key))).toEqual([]);
+    },
+  );
+
+  it.each(entries.map((e) => [e.id, e] as const))(
+    '%s puts its authored content inside the box',
+    (_id, entry) => {
+      const schema = entry.schema as Record<string, unknown>;
+      const drawn = draw(schema);
+      try {
+        if (typeof schema.image === 'string') {
+          // The `image` arm: the renderer's own <img>, not a nested node.
+          expect(drawn.images).toEqual([
+            { src: schema.image, alt: (schema.alt as string) ?? '' },
+          ]);
+        }
+        const texts = authoredText(schema);
+        expect(texts.length + drawn.images.length).toBeGreaterThan(0);
+        for (const text of texts) expect(drawn.text).toContain(text);
+      } finally {
+        drawn.unmount();
+      }
+    },
+  );
+
+  it('counter-probe: the pre-#6773 `content` shape draws an EMPTY box', () => {
+    // Verbatim the shape `square.json` and `16-9-aspect-ratio.json` carried
+    // before this change. Both assertions above are satisfied by it only if
+    // they have stopped measuring anything.
+    const card = draw({
+      type: 'aspect-ratio',
+      ratio: 1,
+      content: { type: 'card', content: 'Square (1:1)' },
+    });
+    try {
+      expect(card.text.trim()).toBe('');
+      expect(card.images).toEqual([]);
+    } finally {
+      card.unmount();
+    }
+
+    const photo = draw({
+      type: 'aspect-ratio',
+      ratio: 16 / 9,
+      content: { type: 'image', src: 'https://example.test/photo.jpg', alt: 'Photo' },
+    });
+    try {
+      expect(photo.images).toEqual([]);
+      expect(photo.text.trim()).toBe('');
+    } finally {
+      photo.unmount();
+    }
+  });
+
+  it('counter-probe: the judge sees content that IS authored under a read key', () => {
+    const drawn = draw({
+      type: 'aspect-ratio',
+      ratio: 1,
+      children: { type: 'card', children: 'Square (1:1)' },
+    });
+    try {
+      expect(drawn.text).toContain('Square (1:1)');
+      expect(authoredText({ children: { type: 'card', children: 'Square (1:1)' } })).toEqual([
+        'Square (1:1)',
+      ]);
+    } finally {
+      drawn.unmount();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6773

## Re-derived on my own base (c6732825d) — 5 of 5, confirmed

`packages/components/src/renderers/layout/aspect-ratio.tsx` reads exactly `ratio`,
`className`, `image` (with `alt`), and `children || body`. It never reads `content`, and
`content` is not among its declared `inputs`. All five entries in
`examples/schema-catalog/src/schemas/components-layout-aspect-ratio/` authored `ratio` +
`content` and nothing else; a repo-wide sweep for `type: "aspect-ratio"` found no sixth
authoring site.

Measured before the fix, rendering each entry through the real `SchemaRenderer` the way the
docs gallery does (harness wrapper + `SchemaRenderer`, no data source):

| entry | elements | text | img |
| --- | --- | --- | --- |
| `16-9-aspect-ratio` | 3 | `""` | 0 |
| `square` | 3 | `""` | 0 |
| `4-3` | 3 | `""` | 0 |
| `ultrawide` | 3 | `""` | 0 |
| `video-aspect-ratio` | 3 | `""` | 0 |

Three elements is the harness wrapper plus the two Radix AspectRatio emits — the ratio box
and nothing inside it. The authored `content` reached the DOM only as the leaked host
attribute `content="[object Object]"` (the objectui#5574 class; `ui:aspect-ratio` is
already ledgered for it in `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`,
so this PR files nothing new for it).

## What each demo now authors, and why

The renderer was read first and defines the shape; the docs page was not consulted for it,
because the docs page is the thing that was wrong.

| entry | now authors | why that key |
| --- | --- | --- |
| `16-9-aspect-ratio` | `image` + `alt` | The photo demo. `image` is the renderer's own declared input and its arm draws an img element classed `rounded-md object-cover w-full h-full`, i.e. the photo fills the box. The old nested `{ type: 'image', src, alt }` node would render at natural size with no sizing class even once it was reachable. |
| `square`, `4-3`, `ultrawide` | `children` on the box, `children` on the card | The renderer's no-image arm is `renderChildren(schema.children ǀǀ schema.body)`, and `renderChildren` renders a bare string directly. **Both levels had to move**: the `ui:card` renderer reads `title`, `description`, `header`, `children ǀǀ body`, `footer` — never `content` — so moving only the outer key would have traded an empty box for an empty card. |
| `video-aspect-ratio` | same, keeping its authored `className` | Same two-level rename; `bg-muted flex items-center justify-center` was already authored. |

One presentational addition, named because it is not a pure key rename: the four card demos
now carry `flex h-full items-center justify-center`. `h-full` is what makes the card fill
the ratio box rather than sit as a strip at its top, and the centering is the intent
`video-aspect-ratio` already authored verbatim; the other three now match it.

After the fix, same measurement: the photo entry draws 4 elements with 1 img
(`src` and `alt` as authored), and each card entry draws 5 elements with its own label as
the tile's text (`"Square (1:1)"`, `"4:3 Ratio"`, `"21:9 Ratio"`, `"Video Player (16:9)"`).

## The Schema block

It published `content: ComponentSchema` as contract and omitted `image` / `alt`, which the
renderer does read and does declare. It now documents the read surface: `ratio`, `image`,
`alt`, `children`, `className`, with the two content modes stated in one line of prose.

Two deliberate choices:

- **`body` is not documented.** The renderer reads `children ǀǀ body`, but a back-compat
  read is not a second authorable spelling — the `page:card` discipline, verbatim
  (objectstack#5775 / PR #6281). `children` is also what all nine sibling
  `components-layout-semantic` fixtures author.
- **`SchemaNode`, not `ComponentSchema`.** `AspectRatioSchema` declares
  `children?: SchemaNode ǀ SchemaNode[]`; `ComponentSchema` is a real export but it is the
  blocks-component interface, not the child-node union.

The fence stays `plaintext`: this file is one of the 80 in `check-doc-fence-languages.mjs`'s
shrink-only ledger, at 1 block, and it still holds 1 block.

## Gate verdict: would anything have caught this?

**Nothing did, and the reasons are measured, not inferred:**

1. `examples/schema-catalog/test/catalog-gallery-render.test.tsx` **does render all five**
   and passes. Its non-vacuity control is
   `drewSomething = elements > WRAPPER_ELEMENTS ǀǀ text.trim().length > 0` with
   `WRAPPER_ELEMENTS = 2`, and an empty ratio box clears it on the wrapper Radix draws for
   the ratio itself (3 > 2). Its stronger control — the entry's own authored strings on
   screen — is scoped to `NEWLY_REGISTERED_CATEGORIES`, which this family is not in.
2. No parse could have caught it. `BaseSchema` is `.passthrough()` and carries
   `[key: string]: any`, so zod and tsc both **accept** `content` — the objectui#6157
   class-3 shape exactly. These five are therefore **not** part of #6318's
   `safeValidateSchema` population.
3. `check-doc-component-types.mjs` rules the question out by name: "NOT in scope,
   deliberately: whether the snippet's OTHER keys are read by the renderer the type
   resolves to."
4. The manifest tier reports `content` as `unknown-prop`, the same warning it gives a typo,
   and nothing fails on it.

**A corpus-wide "container fixture must render its authored content" sweep is NOT
source-decidable today**, and this PR does not propose one. The predicate needs "which
authored key is this renderer's content slot", and the registry cannot answer it here:
`ui:aspect-ratio` declares `isContainer: true` yet declares no `type: 'slot'` input at all
(its `inputs` are `ratio`, `image`, `alt`, `className`), while `page:card` does declare
`children` as a slot. A sweep would have to guess the slot for every renderer in the first
shape, which is the false-red generator that gets gates deleted.

**What IS decidable is the per-family pin**, so that is what ships:
`examples/schema-catalog/test/aspect-ratio-demo-content-6773.test.tsx` — the same shape
`toast-demo-dispatch-6250.test.tsx` took for the same class of fixture correction. It
asserts at **category scope**, not over a list of five ids, so a sixth demo authoring the
phantom key fails without anyone remembering to add it:

- every entry in the category authors only keys the renderer reads;
- every entry puts its authored content in the box (its img `src`/`alt` for the `image`
  arm, its authored slot strings otherwise);
- a **counter-probe** renders the exact pre-fix `content` shape and pins that it draws no
  text and no img — so the two assertions above cannot pass vacuously;
- a second counter-probe pins that the judge does see content authored under a read key.

## Verification

All at `8c093f6b5` (the final commit), heavy commands serialized through the shared verify
lock:

```
pnpm check:doc-fences      OK  every TypeScript block in 223 document(s) ... No unknown fence spelling hides one.
pnpm check:doc-types       OK  Every documented component type is registered.
pnpm check:doc-snippets    OK  Every covered documentation snippet compiles against the built types.
pnpm docs:check-links      OK  Links are valid across 17 scan roots.
pnpm check:control-bytes   OK  scanned 5648 tracked text file(s)
pnpm changeset:check       OK  + check-changeset-presence: no changeset is owed (1 added anyway)
pnpm type-check:coverage   OK  41/41 packages compile their tests
pnpm lint:coverage         OK  46/46 packages linted
pnpm exec vitest run examples/schema-catalog/     Test Files 16 passed (16) / Tests 1866 passed (1866)
turbo run lint type-check --filter=@object-ui/example-schema-catalog   32 successful, 32 total
```

`check:doc-snippets` first returned exit 2 (PRECONDITION NOT MET — packages not built); the
verdict above is from the re-run after
`turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter)`.

The repo-wide `pnpm lint` / full `pnpm test` are CI's runs, not narrowed away here: the
package-scoped `lint` and `type-check` above cover every file this PR touches that either
gate reads, and the docs page is read by the four doc gates, all four run in full.

## Scope

Only `content/docs/components/layout/aspect-ratio.mdx`, the five `aspect-ratio` fixtures,
the pin test beside them, and a changeset. The renderer is untouched — it is the contract,
and widening it to accept `content` would add a third spelling beside `children` and `body`
(AGENTS.md #0.1 direction: fix the metadata, not the renderer). No release-notes file is
touched. The changeset has an empty frontmatter: a docs page plus
`@object-ui/example-schema-catalog` fixtures publish nothing.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_