### PR TITLE
docs(app-shell): grid-columns pin measures identity churn, not a column change

### DIFF
--- a/.changeset/olive-donkeys-smoke.md
+++ b/.changeset/olive-donkeys-smoke.md
@@ -1,0 +1,9 @@
+---
+---
+
+Docs-only: correct the stale docstring on the Studio Data-pillar grid-columns pin
+(`StudioDesignSurface.gridColumns.test.tsx`). Since cloud#1652 added the
+`publishedFieldNames` filter to `gridColumns`, the second case exercises
+identity-churn liveness rather than a real column change, and its prose said the
+opposite. Comment and test title only — no assertion, no source, no published
+behaviour changes. objectui#6729.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.gridColumns.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.gridColumns.test.tsx
@@ -152,15 +152,37 @@ describe('Studio Data pillar grid — the columns array keeps a stable identity 
   });
 
   /**
-   * The dependency must stay LIVE, not be defeated. This pin is green before and
-   * after the fix on purpose — it is a must-not-change, not a red-first case.
-   * Its force comes from the path it uses: "+ Add field" mutates `objDraft.fields`
-   * WITHOUT remounting the grid (its key is `${current.name}:${gridVer}` and
-   * `gridVer` is unchanged), so the refetch it produces can only have arrived
-   * through the column-identity dependency chain. A memo that froze the columns
-   * (or returned a constant) would turn this red.
+   * Identity-churn liveness: the columns dependency must stay LIVE against a
+   * FRESH ARRAY — not be defeated by a producer-side memo that freezes the
+   * columns or constant-folds them. This pin is green before and after the
+   * #4567 fix on purpose; it is a must-not-change, not a red-first case.
+   *
+   * ⚠️ What this case drives is NOT a content change, and this docstring used
+   * to say that it was ("a REAL column change still refetches"). cloud#1652 is
+   * what moved it out from under that sentence: `gridColumns` gained a trailing
+   * `.filter((n) => publishedFieldNames.has(n))`, and `publishedFieldNames` is
+   * read from the SERVER baseline alone (the `layered()` response), never from
+   * the draft. "+ Add field" appends an UNPUBLISHED `field_<N>` to
+   * `objDraft.fields`, so the memo recomputes — new `fields`, hence a new array
+   * — and that same filter then removes `field_<N>` again. What reaches the grid
+   * is therefore an array of EQUAL CONTENT carrying a FRESH IDENTITY.
+   *
+   * Measured on origin/main while correcting this docstring (objectui#6729):
+   * across the click `find()` goes 1 -> 2 while `$select` is
+   * `["id","name","status"]` both before and after, and no `field_` ever reaches
+   * the projection. So the refetch asserted below can only have arrived through
+   * the column-IDENTITY dependency chain — and there is no remount to explain it
+   * either: the grid's key is `${current.name}:${gridVer}`, and `gridVer` does
+   * not move.
+   *
+   * ⛔ Do not read this as covering "columns whose CONTENT changed must still
+   * refetch". That case is real, and it is pinned elsewhere — plugin-list's
+   * `ListView.discardedExpandFieldsMemo.test.tsx` (objectui#6697), which moves
+   * `$select` while holding `$expand` byte-identical. Taking the old sentence at
+   * face value already cost one round: #6697's implementer concluded the content
+   * case was covered here, and had to add it there.
    */
-  it('a REAL column change still refetches — the dependency stays live', async () => {
+  it('a fresh columns array of EQUAL content still refetches — identity-churn liveness', async () => {
     const before = await mountSettledGrid();
 
     fireEvent.click(screen.getAllByRole('button', { name: /Add field/i })[0]);


### PR DESCRIPTION
Fixes #6729

## What moved

Comment and test title only, in `packages/app-shell/src/views/studio-design/StudioDesignSurface.gridColumns.test.tsx`. The assertion, the button it clicks, the field it drives and the coverage are all untouched — visible in the diff as unchanged context lines.

The second case was documented as **"a REAL column change still refetches — the dependency stays live"**. Since **cloud#1652** added the `publishedFieldNames` filter to `gridColumns`, that is no longer what it drives:

- `addField` appends an **unpublished** `field_N` to `objDraft.fields` (`StudioDesignSurface.tsx:2455-2463`) — a draft edit; nothing is published, and `setPublishedFieldNames` is not called.
- `gridColumns` recomputes (its dep is `objDraft.fields`), then ends with `.filter((n) => publishedFieldNames.has(n))` (`:2407`), and `publishedFieldNames` is populated **from the server baseline alone** (`:2349`, the `layered()` response) — never from the draft.
- So `field_N` is filtered back out, and what reaches the grid is an array of **equal content carrying a fresh identity**. There is no remount to explain the refetch either: the grid's key is `current.name` plus `gridVer` (`:2900`), and `gridVer` does not move.

The case therefore pins **identity-churn liveness**, and its prose asserted the opposite. The new docstring states that, names cloud#1652 as the cause so the next reader does not re-derive it, and points at where the genuine content-change case actually lives.

## Triage order — which branch this took

The card made dispatch conditional on two preconditions. Both verified against `origin/main`, not a branch and not the card:

1. **objectui#6697 has landed.** `git log origin/main --grep='#6725'` gives `06b8c42f6 fix(plugin-detail,components,plugin-list): re-key three fetch effects onto the primitives they read (#6697) (#6725)`.
2. **The sibling coverage holds.** `packages/plugin-list/src/__tests__/ListView.discardedExpandFieldsMemo.test.tsx` is present on `origin/main` — added by that same commit, a positive control that ties the two together — and carries the case `still DOES re-fetch when the columns change WITHOUT changing what must be expanded`: the column content moves (`['name','account']` to `['name','account','status']`), `$expand` stays byte-identical at `['account']`, a refetch is asserted, and `$select` is where the change is read. That is verbatim the case the card quoted as the one #6697's repair had to add.

⇒ **branch 2**: correct the prose and change nothing else. Not branch 3, so nothing here needs a ruling, and option B is not opened.

## Measurement behind the new docstring

Rather than deriving the drift from source alone, I drove the real pillar with a throwaway probe (an untracked copy of the suite, deleted before the commit — the tree is clean) and recorded what the grid actually asks for across the click:

```
PROBE6729 findCalls=2
PROBE6729 select_before=["id","name","status"]
PROBE6729 select_after =["id","name","status"]
```

with `expect(select_after).not.toContain('field_')` green. So the click **does** refetch (1 to 2), the projection is **unchanged**, and the new field never reaches it. Identity churn is the entire trigger — which is what the docstring now says.

## Verification

All at `3e4dfa200`. `git diff HEAD` and `git status --short` are both empty, so the tree every gate below ran against is exactly this commit.

Run from the **repo root** with repo-root-relative paths — never `pnpm --filter PKG exec vitest`, which re-roots at the package and cheerfully reports another package's files as passing. The reporter confirms the root and the executed file names:

```
RUN  v4.1.10 /home/user/objectui-6729
 ✓ |dom| packages/plugin-list/src/__tests__/ListView.discardedExpandFieldsMemo.test.tsx > ... > provesTheProxyDiscriminates: the proxy reaches the same React binding the component uses
 ✓ |dom| packages/plugin-list/src/__tests__/ListView.discardedExpandFieldsMemo.test.tsx > ... > does not re-fetch when `expandFields` is discarded under an UNCHANGED column set
 ✓ |dom| packages/plugin-list/src/__tests__/ListView.discardedExpandFieldsMemo.test.tsx > ... > still DOES re-fetch when the columns change WITHOUT changing what must be expanded
 ✓ |dom| packages/plugin-list/src/__tests__/ListView.discardedExpandFieldsMemo.test.tsx > ... > still DOES re-fetch when the column set genuinely changes what must be expanded
 ✓ |dom| packages/app-shell/src/views/studio-design/StudioDesignSurface.gridColumns.test.tsx > ... > three no-op re-renders issue NO extra find()
 ✓ |dom| packages/app-shell/src/views/studio-design/StudioDesignSurface.gridColumns.test.tsx > ... > a fresh columns array of EQUAL content still refetches — identity-churn liveness
 Test Files  2 passed (2)
      Tests  6 passed (6)
```

- **Lint — full repo, not narrowed**: `turbo run lint --concurrency=2` → `Tasks: 47 successful, 47 total`, every package reporting `0 errors` (the standing warnings are pre-existing and untouched). The edited file produces no output at all, not even a warning.
- **Type-check**: `turbo run type-check --filter @object-ui/app-shell` → `Tasks: 30 successful, 30 total`, running `tsc --noEmit && tsc -p tsconfig.test.json`. The second project is the one that matters here: its `include` is `src/**/*.test.ts(x)`, so the edited file is genuinely in the program rather than excluded from it.
- **Control bytes**: `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` on the edited file — no hits.

## Changeset

Owed, and declared as releasing nothing. The gate's own verdict decided it rather than my reading: with the edit alone it printed

```
❌  1 source file(s) of 1 released package(s) changed, and this change adds no changeset
```

because `check-changeset-presence.mjs` deliberately has **no carve-out for test files under `src/`** — its header says such a change "is answered by the empty-frontmatter exemption, in one line". Added `.changeset/olive-donkeys-smoke.md` with empty frontmatter; the gate now prints

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

`check-changeset-no-major.mjs` is green as well. No files under `content/docs/releases/` were touched.

## Out of fence

Nothing filed — no unrelated defect surfaced. The one non-green thing in this run was a second case in my own throwaway probe, which looked for the new field's machine name in the DOM; the inspector renders its **label**, not `field_N`. That was a probe-authoring miss in a file that no longer exists, not a product finding.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_