### PR TITLE
docs(core): one number for the record-title record-key-probe rung

### DIFF
--- a/.changeset/6634-record-title-step-numbering.md
+++ b/.changeset/6634-record-title-step-numbering.md
@@ -1,0 +1,15 @@
+---
+---
+
+Comment-only: `record-title.ts` gave one precedence rung two different numbers. The
+`NAME_ISH_RECORD_KEYS` probe gated by `RecordDisplayNameOptions.deriveFromRecordKeys` was
+labelled `3b` in that option's docblock and `4b` in the `getRecordDisplayName` docblock and
+on the branch itself. Both ladders in the file number the type-aware derivation from
+`objectDef.fields` as step `4` and `objectDef.titleFormat` — a rendered template, not a
+record-key probe — as step `3`, so `4b` is the number the file supports and `3b` was the
+leftover. Nothing mechanical noticed, and other files cite these numbers by hand.
+
+No published behaviour changes: `deriveFromRecordKeys` is untouched and the numbers exist
+only in comment text. A source-reading pin
+(`record-title.stepNumbering.test.ts`) now checks the file's sub-step labels against the
+file's own ladder, so a label that disagrees with the rung it sits under fails.

--- a/packages/core/src/utils/__tests__/record-title.stepNumbering.test.ts
+++ b/packages/core/src/utils/__tests__/record-title.stepNumbering.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6634 — the precedence STEP NUMBERS inside `record-title.ts` have to
+ * agree with each other.
+ *
+ * The file states its ADR-0079 ladder three times over — the module docblock,
+ * the `getRecordDisplayName` docblock, and the inline `// N.` labels on the
+ * branches themselves — and other files cite those numbers BY HAND (objectui#6572
+ * corrected `InterfaceListPage`'s prose, which names steps 0/1/2/3/4 and takes
+ * them from here). Nothing mechanical noticed when one rung ended up carrying
+ * two numbers: the `NAME_ISH_RECORD_KEYS` probe was `4b` in the resolver
+ * docblock and on the branch, but `3b` in the
+ * `RecordDisplayNameOptions.deriveFromRecordKeys` docblock — 26 lines apart in
+ * the same file. `3` is `objectDef.titleFormat` in BOTH ladders, so a reader who
+ * carried away `3b` had the record-key probe filed under the legacy template.
+ *
+ * The numbers live only in comment text, so no behavioural assertion can tell
+ * the two states apart — `deriveFromRecordKeys` behaves identically either way.
+ * This is the assertion that can. It checks the labels against the file's OWN
+ * ladder rather than against a number hard-coded here, so a deliberate
+ * renumbering stays legal as long as every label follows it; what fails is a
+ * label that disagrees with the ladder it sits under.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** packages/core/src/utils/__tests__ → packages/core/src/utils/record-title.ts */
+const SOURCE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../record-title.ts');
+const src = readFileSync(SOURCE, 'utf8');
+
+/**
+ * Every number the file hangs on the type-aware-derivation rung, wherever it
+ * states the ladder: `*   4. Type-aware derivation …` (the two precedence
+ * docblocks) and `// 4. Type-aware derivation …` (the branch itself).
+ */
+function derivationStepNumbers(): number[] {
+  return [...src.matchAll(/^\s*(?:\*|\/\/)\s+(\d+)\.\s+type-aware derivation/gim)].map((m) =>
+    Number(m[1]),
+  );
+}
+
+/**
+ * Every SUB-step label — the `b` variant sitting under a numbered rung. Two
+ * spellings are in use and both are collected: the ladder/branch label
+ * (`4b. …`) and inline prose (`precedence step 4b`).
+ */
+function subStepNumbers(): number[] {
+  return [
+    ...[...src.matchAll(/^\s*(?:\*|\/\/)\s+(\d+)b\.\s/gm)].map((m) => Number(m[1])),
+    ...[...src.matchAll(/\bstep (\d+)b\b/g)].map((m) => Number(m[1])),
+  ];
+}
+
+describe('record-title.ts — internal precedence-step numbering', () => {
+  it('gives the type-aware derivation rung ONE number everywhere it states it', () => {
+    const numbers = derivationStepNumbers();
+    // Control: three sites label that rung today (module docblock, resolver
+    // docblock, the branch comment). A drop here means the wording moved and
+    // this pin stopped measuring — re-aim the regex, do not delete the test.
+    expect(numbers.length).toBeGreaterThanOrEqual(3);
+    expect(new Set(numbers).size).toBe(1);
+  });
+
+  it('numbers every `b` sub-step under the rung it actually sits below', () => {
+    const derivation = derivationStepNumbers();
+    expect(derivation.length).toBeGreaterThanOrEqual(3);
+    const parent = derivation[0];
+
+    const subSteps = subStepNumbers();
+    // Control: three sites carry a sub-step label today (resolver docblock,
+    // the branch comment, and `RecordDisplayNameOptions.deriveFromRecordKeys`).
+    expect(subSteps.length).toBeGreaterThanOrEqual(3);
+    // The regression this file exists for: `3b` in the options docblock while
+    // the ladders and the branch said `4b`.
+    expect(subSteps.filter((n) => n !== parent)).toEqual([]);
+  });
+
+  it('cites that same number in the `deriveTitleField` docblock', () => {
+    const cited = /derivation \(precedence step (\d+)\)/i.exec(src);
+    // Control: the citation has to still be there for this to be a measurement.
+    expect(cited).not.toBeNull();
+    expect(Number(cited?.[1])).toBe(derivationStepNumbers()[0]);
+  });
+});

--- a/packages/core/src/utils/record-title.ts
+++ b/packages/core/src/utils/record-title.ts
@@ -352,7 +352,7 @@ export interface RecordDisplayNameOptions {
   fallback?: string;
   /**
    * Whether to probe standard name-ish keys (`name`/`title`/…) directly on the
-   * record when `objectDef.fields` is absent (precedence step 3b). Defaults to
+   * record when `objectDef.fields` is absent (precedence step 4b). Defaults to
    * `true`. Callers that have a better generic fallback to interleave (e.g. the
    * detail header prefers `schema.title`, the object label, over a guessed
    * record key) pass `false` so this step is skipped and the resolver returns


### PR DESCRIPTION
Fixes #6634

Comment-only. `packages/core/src/utils/record-title.ts` gave one precedence rung two different numbers, 26 lines apart in the same file.

## What I re-verified before editing

The card told me not to inherit its argument. Both ladders on `origin/main` (`26896c689`) say what it says:

| rung | module docblock | `getRecordDisplayName` docblock |
| --- | --- | --- |
| 3 | `:34` — `objectDef.titleFormat` — LEGACY render-only template | `:377` — `objectDef.titleFormat` (rendered template) — LEGACY, render-only |
| 4 | `:37` — Type-aware derivation — the first title-eligible field from `objectDef.fields` | `:380` — type-aware derivation from `objectDef.fields` |
| 5 | `:40` — the `Record #id` floor | `:384` — the same floor |

Two further witnesses inside the same file already spelled it `4` / `4b`:

- `:279` — the `deriveTitleField` docblock: *"Type-aware derivation (precedence step 4)"*
- `:437` / `:442` — the branch comments themselves: `// 4. Type-aware derivation from the object's fields.` immediately followed by `// 4b. Name-ish keys on the record itself`

So four sites number the derivation rung `4` and the `NAME_ISH_RECORD_KEYS` probe beneath it `4b`. Exactly one site disagreed — `RecordDisplayNameOptions.deriveFromRecordKeys` at `:355`, *"(precedence step 3b)"* — and `3` is `objectDef.titleFormat` in both ladders, a rendered template rather than a record-key probe. The card's reading holds: `4b` is what the file supports, `3b` was the leftover.

## The change

`:355` now reads *"(precedence step 4b)"*. That is the whole diff outside the test: nothing but comment text moved, and `deriveFromRecordKeys` is untouched.

## The mechanical pin

The card said a red/green demonstration might not exist for a comment-only change, and for the runtime it does not — the 77 existing `record-title` assertions pass identically in both states. But the defect class *is* mechanically pinnable, so this adds `packages/core/src/utils/__tests__/record-title.stepNumbering.test.ts`. It reads the source and checks the labels against the file's **own** ladder rather than against a number hard-coded in the test:

- every place the file labels the type-aware-derivation rung must use one number (3 sites today);
- every `b` sub-step label — both spellings, the ladder/branch label `4b.` and the inline prose `precedence step 4b` — must carry that same parent number (3 sites today);
- the `deriveTitleField` docblock's inline `(precedence step 4)` citation must agree.

A deliberate renumbering of the ladder therefore stays legal, as long as every label follows it. Each assertion carries a control on the match count, so the pin cannot go vacuously green if the wording moves.

## Red/green evidence

Run from the repo root under the shared verify lock, on `560fb6d24`, three legs, with the mutation and the restore both proven on disk rather than by an exit code:

```
HEAD blob        = b9bce32f5adada503268e5cf11821ddadb1fdad8
LEG 1 (implementation present)   Test Files 2 passed (2) · Tests 78 passed (78) · exit 0
MUTATE  anchor counts: '4b' 1 -> 0 ; '3b' 0 -> 1
        mutated blob = c91fd4db922eb10c87064d2e7eac029a9eea4f27   (byte-identical to origin/main)
LEG 2 (mutation on disk)         Test Files 1 failed | 1 passed (2) · Tests 1 failed | 77 passed (78) · exit 1
        FAIL  record-title.stepNumbering.test.ts > numbers every `b` sub-step under the rung it actually sits below
        AssertionError: expected [ 3 ] to deeply equal []
RESTORE restored blob = b9bce32f5adada503268e5cf11821ddadb1fdad8 · git diff HEAD --name-only => (empty)
LEG 3 (restored tree)            Test Files 2 passed (2) · Tests 78 passed (78) · exit 0
```

Leg 2 is load-bearing in both directions: the pin turns red, and the 77 pre-existing assertions stay green — the mechanical statement that this rung's number is prose and the resolver's behaviour does not depend on it. No `dist/` is involved on either leg: both test files import `../record-title` by relative path, so the mutation reaches the run through the source, not a build product.

## Gates

All from the repo root, exit captured before any pipe, quoting each gate's own printed verdict, on `560fb6d24`:

- `pnpm exec vitest run packages/core/src/utils/__tests__/record-title.stepNumbering.test.ts packages/core/src/utils/__tests__/record-title.test.ts` — `Test Files 2 passed (2)` / `Tests 78 passed (78)`, run with the verbose reporter so the executed file names are in the log.
- `pnpm --filter "@object-ui/core^..." build && pnpm --filter @object-ui/core type-check && pnpm --filter @object-ui/core lint && node scripts/check-control-bytes.mjs` — one lock verdict, `VERDICT command-exit 0`. Lint on the package is `eslint .`, not a narrowed run: 503 warnings, 0 errors, the pre-existing `no-explicit-any` baseline, and the new file contributes none of them.
- `node scripts/check-changeset-presence.mjs` — its own verdict: *"1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) ... Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate."* That is what settled the changeset question, not my reading of it.
- `node scripts/check-changeset-no-major.mjs` — *"No changeset declares a `major` bump."*
- `tsc -p packages/core/tsconfig.test.json --listFiles` — the typecheck program provably contains all three files, so "typecheck clean" is a statement about the new test file too, not merely about the shipped source.
- `node scripts/check-control-bytes.mjs` — `OK (scanned 5649 tracked text file(s); skipped 85 binary)`. The module's empty-placeholder sentinel keeps its backslash-u escape spelling and was not touched.

## Citing sites — checked, and one disagrees

The card required this sweep because these numbers are cited by hand. Repo-wide grep for step-number prose citing this ladder:

**Agree with the corrected numbering** (nothing to do):

- `packages/app-shell/src/views/InterfaceListPage.tsx:207-237` — the prose corrected in objectui#6572. Names `nameField`/`displayNameField` as step 1/2, `titleFormat` as step 3, derivation from `objectDef.fields` as step 4. Consistent.
- `packages/app-shell/src/views/InterfaceListPage.mapConfig.test.tsx:182-260` — same numbering, same verdict.
- `packages/core/src/utils/__tests__/record-title.test.ts:150` and `:245` — both say `4b`.
- `.changeset/6530-plugin-map-marker-title-precedence.md:34` — *"the record-key probe (the resolver's step 4b)"*.
- `packages/plugin-map/src/ObjectMap.markerTitle.test.tsx:30` — names the rungs without numbering them, so nothing to reconcile.

**Disagrees — reported, not touched:** `packages/core/src/utils/__tests__/record-title.test.ts:133` still says *"the record-level name probe (step 3b)"*. Same stale number, same rung, in the test file for this very module — seventeen lines above a comment that calls the same probe `4b`. The card's fence is `packages/core/src/utils/record-title.ts` alone and it asked me to report rather than renumber another file's prose, so the line is untouched here and filed separately. One consequence worth stating for review: the new pin deliberately scans only `record-title.ts`, which is why it is green today; widening its scan to the sibling test file is the natural shape of that follow-up.

## Scope

- Fence honoured: the only source edit is one word at `record-title.ts:355`. The card was split out of objectui#6572 to keep the affected-package set from widening; this PR touches `packages/core` only, so that split is preserved.
- No `content/docs/releases/` edit.
- The changeset declares an empty frontmatter: this releases nothing.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_