### PR TITLE
test: inherit the real @object-ui/react export surface in 25 hand-listed mocks

### DIFF
--- a/.changeset/6768-mock-import-original.md
+++ b/.changeset/6768-mock-import-original.md
@@ -1,0 +1,12 @@
+---
+---
+
+Test-only change: 25 test files that partially mock `@object-ui/react` now inherit the
+real export surface via `importOriginal` instead of hand-listing exports. No published
+behaviour changes — no source file is touched, and no assertion was edited or deleted.
+
+A hand-listed mock freezes its export surface at whatever the author typed that day, so
+the next export any widely-imported module reads at module scope kills those files at
+COLLECTION — zero failed assertions, the file's tests never run, and the red suite reads
+like flake. Spreading the real module makes the mock a superset, so a transitive consumer
+can never trip over an export the test never meant to replace.

--- a/packages/app-shell/src/hooks/__tests__/useNavActionDispatch.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/useNavActionDispatch.test.tsx
@@ -24,7 +24,10 @@ const getItem = vi.fn();
 const toastError = vi.fn();
 
 vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastError(...a) } }));
-vi.mock('@object-ui/react', () => ({ useAction: () => ({ execute }) }));
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useAction: () => ({ execute }),
+}));
 vi.mock('../../providers/MetadataProvider', () => ({ useMetadata: () => ({ getItem }) }));
 
 import { useNavActionDispatch } from '../useNavActionDispatch';

--- a/packages/app-shell/src/views/metadata-admin/AccessExplainPanel.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/AccessExplainPanel.test.tsx
@@ -22,7 +22,8 @@ let mockObjectList: Array<Record<string, unknown>> = [];
 vi.mock('@object-ui/auth', () => ({
   createAuthenticatedFetch: () => fetchSpy,
 }));
-vi.mock('@object-ui/react', () => ({
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => ({ find: vi.fn(async () => []) }),
 }));
 vi.mock('./useMetadata', () => ({

--- a/packages/app-shell/src/views/metadata-admin/AssignedUsersSection.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/AssignedUsersSection.test.tsx
@@ -11,7 +11,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { AssignedUsersSection } from './AssignedUsersSection';
 
-vi.mock('@object-ui/react', () => ({
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => mockAdapter,
 }));
 vi.mock('@object-ui/fields', () => ({

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.lookup.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.lookup.test.tsx
@@ -44,7 +44,8 @@ const state = vi.hoisted(() => {
 // graphs. LookupField's own behaviour (search, hydration through `id_field`,
 // commit-on-select) is covered in the fields package — this suite verifies
 // the WIRING: which cell renders per kind, and what binding it receives.
-vi.mock('@object-ui/react', () => ({
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => state.adapter,
   // @object-ui/components wires this at module scope (related-count-store).
   subscribeDataChanges: () => () => {},

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.membershipTier.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowReferenceField.membershipTier.test.tsx
@@ -64,7 +64,8 @@ const state = vi.hoisted(() => {
   };
 });
 
-vi.mock('@object-ui/react', () => ({
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useAdapter: () => null,
   // @object-ui/components wires this at module scope (related-count-store).
   subscribeDataChanges: () => () => {},

--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.test.tsx
@@ -13,7 +13,8 @@ const { schemaSpy } = vi.hoisted(() => ({ schemaSpy: vi.fn() }));
 vi.mock('../../InterfaceListPage', () => ({
   InterfaceListPage: () => <div data-testid="mock-interface-list" />,
 }));
-vi.mock('@object-ui/react', () => ({
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   SchemaRenderer: ({ schema }: { schema: any }) => {
     schemaSpy(schema);
     return <div data-testid="mock-schema-renderer" />;

--- a/packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardRenderer.designMode.test.tsx
@@ -5,9 +5,10 @@ import type { DashboardComponentSchema } from '@object-ui/types';
 
 // Mock SchemaRenderer to avoid pulling in the full renderer tree.
 // Forwards className and includes an interactive child to simulate real chart content.
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema, className }: { schema: any; className?: string }) => (
       <div data-testid="schema-renderer" className={className}>
         <button data-testid={`interactive-child-${schema?.type ?? 'unknown'}`}>

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.effectiveOps.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.effectiveOps.test.tsx
@@ -33,7 +33,8 @@ const stub = {
   objectSchema: { managedBy: 'platform' } as any,
 };
 
-vi.mock('@object-ui/react', () => ({
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useRecordContext: () => ({
     objectName: 'crm_lead',
     recordId: 'rec_1',

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.test.tsx
@@ -31,9 +31,10 @@ const stub = {
 // really calls `useContext` before the `!ctx` early return in production, and
 // that leading real-hook is what makes a fewer-hooks re-render throw #310. A
 // plain `() => value` stub would call no real hook, silently masking the bug.
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     useRecordContext: () => (React.useRef(0), stub.recordCtx),
     useHighlightFieldNames: () => (React.useRef(0), [] as string[]),
     useSafeFieldLabel: () => (React.useRef(0), {

--- a/packages/plugin-gantt/src/useGanttTranslation.test.tsx
+++ b/packages/plugin-gantt/src/useGanttTranslation.test.tsx
@@ -13,7 +13,8 @@ import { renderHook } from '@testing-library/react';
 let hostDict: Record<string, string> = {};
 const hostT = (key: string) => hostDict[key] ?? key;
 
-vi.mock('@object-ui/react', () => ({
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   useObjectTranslation: () => ({ t: hostT, language: 'zh' }),
 }));
 

--- a/packages/plugin-timeline/src/ObjectTimeline.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.test.tsx
@@ -5,9 +5,10 @@ import { ObjectTimeline } from './ObjectTimeline';
 import { DataSource } from '@object-ui/types';
 
 // Mock useDataScope and useNavigationOverlay
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     useDataScope: () => undefined,
     useNavigationOverlay: () => ({
       isOverlay: false,

--- a/packages/plugin-view/src/__tests__/ObjectView.canonicalTableKeys.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.canonicalTableKeys.test.tsx
@@ -52,9 +52,10 @@ import { render, waitFor } from '@testing-library/react';
 import { ObjectView } from '../ObjectView';
 import type { ObjectViewSchema } from '@object-ui/types';
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => <div data-testid="schema-renderer">{schema?.type}</div>,
     SchemaRendererContext: React.createContext(null),
     subscribeDataChanges: () => () => {},

--- a/packages/plugin-view/src/__tests__/ObjectView.expandGate.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.expandGate.test.tsx
@@ -83,9 +83,10 @@ import type { ObjectViewSchema } from '@object-ui/types';
 /** Every non-empty row array `ObjectView` hands the child view, in order. */
 const deliveries: any[][] = [];
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     // Records the `data` prop, which is the seam the defect is visible at:
     // ObjectView passes `data={data}` down, suppressing the child's own fetch.
     SchemaRenderer: ({ schema, data }: any) => {

--- a/packages/plugin-view/src/__tests__/ObjectView.filterSources.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.filterSources.test.tsx
@@ -36,9 +36,10 @@ import { convertSortToQueryParams } from '@object-ui/core';
 import { ObjectView } from '../ObjectView';
 import type { ObjectViewSchema } from '@object-ui/types';
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => <div data-testid="schema-renderer">{schema?.type}</div>,
     SchemaRendererContext: React.createContext(null),
     subscribeDataChanges: () => () => {},

--- a/packages/plugin-view/src/__tests__/ObjectView.formTitleI18n.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.formTitleI18n.test.tsx
@@ -70,9 +70,10 @@ import { ObjectView } from '../ObjectView';
 // Mock @object-ui/react to avoid circular dependency issues (same shape as
 // ObjectView.test.tsx — the bus exports are imported at module-eval time by the
 // real @object-ui/components, so a strict mock must expose them).
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => (
       <div data-testid="schema-renderer" data-schema-type={schema?.type}>
         {schema?.type}

--- a/packages/plugin-view/src/__tests__/ObjectView.formTitleNoProviderFallback.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.formTitleNoProviderFallback.test.tsx
@@ -51,9 +51,10 @@ import '@testing-library/jest-dom';
 import type { DataSource } from '@object-ui/types';
 import { ObjectView } from '../ObjectView';
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => (
       <div data-testid="schema-renderer" data-schema-type={schema?.type}>
         {schema?.type}

--- a/packages/plugin-view/src/__tests__/ObjectView.hostOnlyViewTypes.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.hostOnlyViewTypes.test.tsx
@@ -57,9 +57,10 @@ const rendered: any[] = [];
 /** Every schema handed to the ViewSwitcher, in order. */
 const switcherSchemas: any[] = [];
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => {
       rendered.push(schema);
       return <div data-testid="schema-renderer">{schema?.type}</div>;

--- a/packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.kanbanConditionalFormatting.test.tsx
@@ -53,9 +53,10 @@ import type { ObjectViewSchema } from '@object-ui/types';
 /** Every schema the view hands to SchemaRenderer, in order. */
 const rendered: any[] = [];
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => {
       rendered.push(schema);
       return <div data-testid="schema-renderer">{schema?.type}</div>;

--- a/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.mapFlatten.test.tsx
@@ -42,9 +42,10 @@ import { ObjectMapConfigSchema } from '@object-ui/types/zod';
 /** Every schema the view hands to SchemaRenderer, in order. */
 const rendered: any[] = [];
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => {
       rendered.push(schema);
       return <div data-testid="schema-renderer">{schema?.type}</div>;

--- a/packages/plugin-view/src/__tests__/ObjectView.refreshSignal.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.refreshSignal.test.tsx
@@ -41,9 +41,10 @@ import { render, waitFor, act } from '@testing-library/react';
 import { ObjectView } from '../ObjectView';
 import type { ObjectViewSchema, DataSourceMutationEvent } from '@object-ui/types';
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => (
       <div data-testid="schema-renderer">{schema?.type}</div>
     ),

--- a/packages/plugin-view/src/__tests__/ObjectView.sortSink.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.sortSink.test.tsx
@@ -61,9 +61,10 @@ import { convertSortToQueryParams } from '@object-ui/core';
 import { ObjectView } from '../ObjectView';
 import type { ObjectViewSchema } from '@object-ui/types';
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => <div data-testid="schema-renderer">{schema?.type}</div>,
     SchemaRendererContext: React.createContext(null),
     subscribeDataChanges: () => () => {},

--- a/packages/plugin-view/src/__tests__/ObjectView.tableColumnsForwarding.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.tableColumnsForwarding.test.tsx
@@ -74,9 +74,10 @@ import type { ObjectViewSchema } from '@object-ui/types';
 /** Every schema the view hands to SchemaRenderer, in order. */
 const rendered: any[] = [];
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => {
       rendered.push(schema);
       return <div data-testid="schema-renderer">{schema?.type}</div>;

--- a/packages/plugin-view/src/__tests__/ObjectView.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.test.tsx
@@ -12,9 +12,10 @@ import { ObjectView } from '../ObjectView';
 import type { ObjectViewSchema, DataSource } from '@object-ui/types';
 
 // Mock @object-ui/react to avoid circular dependency issues
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => (
       <div data-testid="schema-renderer" data-schema-type={schema?.type}>
         {schema?.type}

--- a/packages/plugin-view/src/__tests__/ObjectView.viewIdentityDeps.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.viewIdentityDeps.test.tsx
@@ -60,9 +60,10 @@ import type { ObjectViewSchema } from '@object-ui/types';
 
 const deliveries: any[][] = [];
 
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema, data }: any) => {
       if (Array.isArray(data) && data.length > 0) {
         const g = (globalThis as any).__objectViewChurnDeliveries as any[][] | undefined;

--- a/packages/plugin-view/src/__tests__/ViewSwitcher.test.tsx
+++ b/packages/plugin-view/src/__tests__/ViewSwitcher.test.tsx
@@ -16,9 +16,10 @@ import type { ViewSwitcherSchema, ViewType } from '@object-ui/types';
 // Mock @object-ui/react to avoid circular dependency issues; mirrors
 // ObjectView.test.tsx, including the data-invalidation bus that
 // @object-ui/components imports at module-eval time.
-vi.mock('@object-ui/react', async () => {
+vi.mock('@object-ui/react', async (importOriginal) => {
   const React = await import('react');
   return {
+    ...(await importOriginal<Record<string, unknown>>()),
     SchemaRenderer: ({ schema }: any) => (
       <div data-testid="schema-renderer" data-schema-type={schema?.type}>
         {schema?.type}


### PR DESCRIPTION
Fixes #6768

25 test files mocked `@object-ui/react` with a factory that hand-lists the exports it returns. That freezes each mock's export surface at whatever the author typed that day, making every one of them a latent **collection** failure for the next export any widely-imported module reads at module scope. They are converted to the `importOriginal` form already used by every other site, so the mock is a superset of the real module and only the overrides each test means to control are replaced.

Verified at `9ddab598a`.

## Re-derived enumeration (against `origin/main` at `26896c689`, not the card's numbers)

The card counted 36 sites "without `importOriginal`". That is a **name-based** count, and it is wrong in the safe direction: 11 of those 36 already inherit the real surface by another spelling. The real remediation set is **25**.

A semantic classifier was used instead — a mock inherits iff its factory both *obtains* the real module (its `importOriginal` callback parameter, whatever it is named, or `vi.importActual` of this specifier) and *spreads* it:

| | files |
|---|---|
| files carrying a `vi.mock` of `@object-ui/react` | 106 |
| already inherit the real surface (**control**) | 81 |
| frozen surface (**target**) | **25** |
| auto-mocks with no factory | 0 |

**Control:** the 81 come back from the same query as a non-zero count, so the matcher is not simply failing to match. Their spellings: 70 spread an `importOriginal` param, 9 spread `vi.importActual`, 1 names the param `importActual`, 1 names it `orig`.

**The 11 the card would have had us touch, which need nothing:**

- 9 in `plugin-dashboard` already do `const actual = await vi.importActual('@object-ui/react')` and spread it (`ObjectDataTable.*`, `lookupRelationalMeta-6694`). `vi.importActual` is `importOriginal` bound to the path; the export surface is equally complete.
- `EnvironmentListToolbar.test.tsx` names the param `importActual`.
- `PageView.test.tsx` names it `orig`.

They are left alone deliberately. Note for the next audit: a grep for the literal `importOriginal` will mis-flag all 11.

## Contention

Enumerated **before** editing. All 30 open PRs were listed and every changed file fetched (266 files, plus 633 on the release PR #5400, paginated to exhaustion). **Zero** of the 25 targets is occupied by an open PR, so the sweep is complete rather than partial, with nothing deferred.

## Behaviour preservation

Spreading the real module means the mock now returns exports it previously omitted, so this was checked rather than assumed:

1. **Nothing can observe the mock's key set.** No file among the targets, and no source module anywhere in the repo, does `import * as ns from '@object-ui/react'`. Absent a namespace object, there is no `Object.keys` or `in` test over the module for the added exports to change.
2. **No test can currently depend on an export being *absent*.** Vitest hard-errors on a missing export at link time rather than yielding `undefined`, so any export the graph reads is already hand-listed in a passing file. Every `toBeUndefined` / `not.toHaveProperty` / `Object.keys` assertion in these files was read: all of them are about schema objects, column objects and query params, none about the mocked module.
3. **Overrides still win.** The spread is inserted as the *first* property in every case, so each test's own stubs (including the fresh `SchemaRendererContext` several files create) shadow the real export exactly as before.
4. **Measured, not argued.** The same 34 files were run before and after the change and per-file test counts diffed: identical, 319 tests in both.

## Did any existing test move?

**None.** Mechanically, not by assertion: every removed line in the whole diff is a `vi.mock` header.

```
$ git diff -U0 | grep "^-" | grep -v "^---" | sort | uniq -c
      7 -vi.mock('@object-ui/react', () => ({
      1 -vi.mock('@object-ui/react', () => ({ useAction: () => ({ execute }) }));
     17 -vi.mock('@object-ui/react', async () => {
```

Lint agrees the added lines are inert: of 204 eslint messages on these files, **0** land on a line this PR added (all are pre-existing `no-explicit-any`).

## Ablation — the point of the card, not just the edit

A new export was added to `@object-ui/react` and a real, widely-imported module (`packages/components/src/hooks/related-count-store.ts`, which already reads `subscribeDataChanges` from it at module scope) was made to read it at module scope — the exact shape of the next PR that would have broken these files. Both legs ran on the same mutated tree; the only variable is the mock form.

The mutation was confirmed **on disk** before either leg (1 occurrence injected into the index, 2 into the store, and the old bare import confirmed gone), because an edit tool's exit code proves nothing about a zero-hit anchor.

**Leg A — converted file (this PR):**

```
LEG_A_EXIT=0
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

**Leg B — same probe, that one file reverted to its pre-conversion frozen mock:**

```
LEG_B_EXIT=1
Error: [vitest] No "__nextExport6768" export is defined on the "@object-ui/react" mock. Did you forget to return it from "vi.mock"?
 Test Files  1 failed (1)
      Tests  no tests
```

`Tests no tests` is the whole argument: the file died at collection, so its 32 tests never ran. That is a red suite with zero failed assertions — the signature that reads like flake and is neither.

No rebuild is involved on either leg, and that is not an omission: the root vitest config aliases `@object-ui/react` to `packages/react/src`, so the probe is resolved from source and `dist` plays no part. Restore was proved by an empty `git diff HEAD`, and the probe confirmed gone from both mutated files.

## Verification

Run from the repo root (a package-scoped `vitest` re-roots and reports another package's files):

- `pnpm exec vitest run` over the 25 converted files plus the 9 already-inheriting ones as an untouched control — **34 files passed, 319 tests passed**, at `9ddab598a`.
- `tsc -p packages/PKG/tsconfig.test.json --noEmit` for all six affected packages — all exit 0, zero `error TS`. Coverage proved rather than assumed: the package build tsconfigs *exclude* test files, so `--listFiles` was used to confirm all 25 edited files are inputs of the chained test program (0 missing). This mattered — the concise spelling has 17 precedents in the tree, but the block-body spelling this PR introduces had **zero**, so it was not covered by any existing green.
- `check:vi-mock-specifiers` — `OK (3955 tracked source file(s), 2245 test-named; 490 carry a mock; 751 relative specifier(s) resolved, ... 0 non-static, ... 3 via the import() form)`.
- `check:control-bytes` — `OK (scanned 5648 tracked text file(s); skipped 85 binary)`.
- `check-changeset-presence` — `25 source file(s) of 6 released package(s) changed, and this change declares 1 changeset(s) ... Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.`
- `check-changeset-no-major`, `check-changeset-fixed`, `check-changeset-overwrite` — exit 0.

**Declared narrowing:** repo-wide `pnpm lint` was not run; eslint was run on the 25 changed files only (25/25 linted by eslint's own config, count read from `--format json`, 0 errors). This narrowing excludes nothing: `eslint.config.js` enables no type-aware linting (no `project` / `projectService`), so a test-file diff cannot move the verdict of any file it does not touch. CI runs the full farm regardless.

## Changeset

Empty frontmatter — the gate's own printed verdict calls that "the explicit exemption and a complete answer". Nothing published changes: no source file is touched.

_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01CRJge11jso9TpXRWFt1Z49)_