### PR TITLE
fix(fields): compose the host `onBlur` in CurrencyField and TagsField

### DIFF
--- a/.changeset/6802-currency-tags-host-onblur.md
+++ b/.changeset/6802-currency-tags-host-onblur.md
@@ -1,0 +1,27 @@
+---
+'@object-ui/fields': patch
+---
+
+`CurrencyField` and `TagsField` now compose a host-supplied `onBlur` instead of
+overriding it (objectui#6802).
+
+`onBlur` is a DECLARED DOM pass-through key — named in `FieldWidgetDomProps`
+and in `SDUI_DOM_PASS_THROUGH_KEYS`, and forwarded by `toDomProps` — but both
+widgets wrote their own `onBlur={…}` AFTER the `{...toDomProps(props)}` spread,
+so the host's handler was overwritten and never reached the control. Each now
+resolves `toDomProps(props)` into `domProps` and calls `domProps.onBlur?.(e)`
+at the end of its own handler, the idiom the other four widgets of this package
+already use.
+
+⚠️ This is a REAL behaviour change, not the no-op the finding was filed as. The
+form renderer hosts every field through react-hook-form's `Controller` and
+spreads the controller field — `{ name, value, onChange, onBlur, ref, disabled }`
+— into the widget's props, so the overridden handler was the one that marks a
+field touched and runs its validation. Concretely: on a form declaring
+`validationMode: 'onBlur'` or `'onTouched'`, currency and tags fields were
+silently opted out of blur-mode validation while every sibling field type kept
+it. They now behave like the rest.
+
+Currency keeps emitting its rounded value before handing the event on, so a
+blur-mode validator reads the parsed amount rather than the raw text; tags
+still commits the typed draft first, so the validator reads the committed list.

--- a/packages/fields/src/__tests__/NumberInputWidgets.badInputAnnounce.test.tsx
+++ b/packages/fields/src/__tests__/NumberInputWidgets.badInputAnnounce.test.tsx
@@ -328,20 +328,27 @@ describe('GeolocationField reads its two boxes independently (objectui#6780)', (
 describe('the added onBlur composes the host handler instead of replacing it', () => {
   /**
    * `onBlur` is a DECLARED DOM pass-through key (`FieldWidgetDomProps`), so
-   * `toDomProps` delivers a host's handler onto these controls. The three
-   * widgets that gained an `onBlur` here write it AFTER that spread, so without
-   * composition they would silently drop it — this package's
-   * DECLARED-BUT-NOT-DELIVERED class (objectui#3290 / objectui#3222).
+   * `toDomProps` delivers a host's handler onto these controls. A widget that
+   * writes its own `onBlur` AFTER that spread silently drops it — this
+   * package's DECLARED-BUT-NOT-DELIVERED class (objectui#3290 / objectui#3222).
    *
-   * ⛔ `CurrencyField` is deliberately absent. It has overridden the host's
-   * `onBlur` since long before this card, no host in this repo passes one
-   * today, and changing that is an unmeasured behaviour change outside this
-   * card's ruling. Filed separately rather than folded in here.
+   * ⭐ `CurrencyField` joined this list in objectui#6802. It was excluded here
+   * on the reading that it "has overridden the host's `onBlur` since long
+   * before this card, no host in this repo passes one today". ⛔ The second
+   * half of that is FALSE, and the note is corrected rather than moved: the
+   * form renderer hosts every field through react-hook-form's `Controller` and
+   * spreads the controller field — which always carries an `onBlur` — into the
+   * widget's props, so this widget was opting currency fields out of blur-mode
+   * validation on every form in the repo. The user-visible reproduction lives
+   * in `hostOnBlurDelivery-e2e.test.tsx`; `TagsField`, which carried the same
+   * shape and is not a `type="number"` widget, is pinned in
+   * `TagsField.hostOnBlur.test.tsx`.
    */
   it.each([
     ['PercentField', PercentField, { name: 'rate', type: 'percent' }],
     ['NumberField', NumberField, { name: 'qty', type: 'number' }],
     ['GeolocationField', GeolocationField, { name: 'where', type: 'geolocation' }],
+    ['CurrencyField', CurrencyField, { name: 'amount', type: 'currency', currency: 'USD' }],
   ])('%s still calls a host onBlur', (_name, Widget, field) => {
     const hostBlur = vi.fn();
     const { box } = mountWidget(asWidget(Widget), field, undefined, { onBlur: hostBlur });

--- a/packages/fields/src/__tests__/TagsField.hostOnBlur.test.tsx
+++ b/packages/fields/src/__tests__/TagsField.hostOnBlur.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `TagsField` composes the host's `onBlur` instead of replacing it
+ * (objectui#6802) — and still commits the typed draft.
+ *
+ * `onBlur` is a DECLARED DOM pass-through key: named in `FieldWidgetDomProps`
+ * (`../widgets/types.ts`) and in `SDUI_DOM_PASS_THROUGH_KEYS`
+ * (`@object-ui/core`), and forwarded by `toDomProps`. This widget wrote
+ * `onBlur={() => addTag(draft)}` AFTER its `{...toDomProps(props)}` spread, so
+ * a host's handler was overwritten and never reached the input — this package's
+ * DECLARED-BUT-NOT-DELIVERED class (objectui#3290 / objectui#3222).
+ *
+ * ⚠️ Why a pin is required rather than nice-to-have: nothing that existed
+ * before could go red on this. The regression is invisible to every other test
+ * in the package, because none of them supplies a host `onBlur` — so the assert
+ * has to DRIVE a host handler through the real widget, not restate the
+ * predicate. The user-visible half (blur-mode validation through the real form
+ * renderer) is pinned in `hostOnBlurDelivery-e2e.test.tsx`; the four
+ * `type="number"` widgets carry the same pin in
+ * `NumberInputWidgets.badInputAnnounce.test.tsx`.
+ *
+ * ⛔ Both halves are asserted together on purpose. Composition that dropped
+ * `addTag` would satisfy a host-only assertion while losing the tag the user
+ * just typed, and the old `addTag`-only handler satisfies a tag-only assertion
+ * while losing the host — one assertion each way cannot tell those apart.
+ */
+
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { TagsField } from '../widgets/TagsField';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Mount with a host that ECHOES the emission back into `value`, the way a real
+ * form does — `TagsField` is a controlled input, so a bare spy host would leave
+ * `value` frozen and hide any second emission.
+ */
+function mountTags(extra: { onBlur?: React.FocusEventHandler<HTMLElement> } = {}) {
+  const onChange = vi.fn();
+  const Host = () => {
+    const [value, setValue] = React.useState<string[]>([]);
+    return (
+      <TagsField
+        value={value}
+        onChange={(v: string[]) => {
+          onChange(v);
+          setValue(v);
+        }}
+        field={{ name: 'labels', type: 'tags' } as any}
+        {...extra}
+      />
+    );
+  };
+  const { container } = render(<Host />);
+  const box = container.querySelector('input') as HTMLInputElement;
+  return { container, onChange, box };
+}
+
+describe('TagsField and a host-supplied onBlur (objectui#6802)', () => {
+  it('calls the host onBlur', () => {
+    const hostBlur = vi.fn();
+    const { box } = mountTags({ onBlur: hostBlur });
+
+    fireEvent.blur(box);
+
+    expect(hostBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('hands the host the real focus event, not a fabricated one', () => {
+    const hostBlur = vi.fn();
+    const { box } = mountTags({ onBlur: hostBlur });
+
+    fireEvent.blur(box);
+
+    // react-hook-form's controller `onBlur` reads the event it is handed; a
+    // composition that called `domProps.onBlur?.()` with no argument would pass
+    // the count assertion above and still break a real host.
+    const event = hostBlur.mock.calls[0]?.[0];
+    expect(event).toBeDefined();
+    expect(event.target).toBe(box);
+  });
+
+  it('still commits the typed draft as a tag on that same blur', () => {
+    const hostBlur = vi.fn();
+    const { box, onChange } = mountTags({ onBlur: hostBlur });
+
+    fireEvent.change(box, { target: { value: 'urgent' } });
+    fireEvent.blur(box);
+
+    expect(onChange).toHaveBeenCalledWith(['urgent']);
+    expect(hostBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('works with no host handler at all — the key is optional', () => {
+    const { box, onChange } = mountTags();
+
+    fireEvent.change(box, { target: { value: 'urgent' } });
+    expect(() => fireEvent.blur(box)).not.toThrow();
+
+    expect(onChange).toHaveBeenCalledWith(['urgent']);
+  });
+});

--- a/packages/fields/src/__tests__/hostOnBlurDelivery-e2e.test.tsx
+++ b/packages/fields/src/__tests__/hostOnBlurDelivery-e2e.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A host `onBlur` must survive the widget it is handed to — measured through
+ * the REAL form renderer, not a hand-built host (objectui#6802).
+ *
+ * ## Why this file exists at all
+ *
+ * `onBlur` is a DECLARED DOM pass-through key: it is named in
+ * `FieldWidgetDomProps` (`../widgets/types.ts`), named in
+ * `SDUI_DOM_PASS_THROUGH_KEYS` (`@object-ui/core`), and forwarded by
+ * `toDomProps`. `CurrencyField` and `TagsField` each wrote their own
+ * `onBlur={…}` AFTER the `{...toDomProps(props)}` spread, so the host's handler
+ * was overwritten and never reached the control — this package's
+ * DECLARED-BUT-NOT-DELIVERED class (objectui#3290 / objectui#3222).
+ *
+ * ## The measurement that makes this a REAL defect, not a latent one
+ *
+ * objectui#6802 was filed and triaged as LATENT, on the reading that "no host
+ * in this repo passes `onBlur` to a field widget". ⛔ That is FALSE on `main`,
+ * and this file is the reproduction.
+ *
+ * The form renderer hosts every field through react-hook-form's `Controller`
+ * (`<FormField>` in `@object-ui/components`) and spreads the controller's field
+ * object into the widget's props:
+ *
+ * ```tsx
+ * render={({ field: formField, fieldState }) => (
+ *   … renderFieldComponent(resolvedType, { ...fieldProps, …, ...formField, … })
+ * ```
+ * (`packages/components/src/renderers/form/form.tsx`)
+ *
+ * A react-hook-form controller field is `{ name, value, onChange, onBlur, ref,
+ * disabled }` — so **`onBlur` is on the props of every registered field widget
+ * in every form this repo renders**, and it is the handler that marks the field
+ * touched and, under `validationMode: 'onBlur'` / `'onTouched'`, runs its
+ * validation. A widget that overrides it does not drop a hypothetical key: it
+ * silently opts that field type out of blur-mode validation while every other
+ * field type on the same form keeps it.
+ *
+ * `validationMode` is authorable (`ObjectFormSchema`, wired to react-hook-form's
+ * `mode`), so an author reaches this with metadata alone.
+ *
+ * ## What is asserted
+ *
+ * The widget-level composition pins live next to their widgets
+ * (`NumberInputWidgets.badInputAnnounce.test.tsx` for the four `type="number"`
+ * widgets, `TagsField.hostOnBlur.test.tsx` for tags). THIS file asserts the
+ * consequence a user can see: a blur-mode required field announces on blur.
+ * `NumberField` — repaired in objectui#6780 — is the CONTROL: it proves the
+ * harness really does produce a blur-mode failure, so a red currency row is
+ * about the widget and not about the fixture.
+ *
+ * The widgets are registered raw rather than through `registerAllFields()`,
+ * which wraps every loader in `React.lazy`: an unbounded module load inside a
+ * bounded `findBy`/`waitFor` window is the repo's known flake generator
+ * (AGENTS.md 测试纪律, objectui#3010). Same component, no Suspense boundary.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ComponentRegistry } from '@object-ui/core';
+// Module scope: pulls in the form renderer's registration side effect.
+import '@object-ui/components';
+
+import { CurrencyField } from '../widgets/CurrencyField';
+import { TagsField } from '../widgets/TagsField';
+import { NumberField } from '../widgets/NumberField';
+
+beforeAll(() => {
+  ComponentRegistry.register('currency', CurrencyField as any, {
+    namespace: 'field',
+    skipFallback: true,
+  });
+  ComponentRegistry.register('tags', TagsField as any, {
+    namespace: 'field',
+    skipFallback: true,
+  });
+  ComponentRegistry.register('number', NumberField as any, {
+    namespace: 'field',
+    skipFallback: true,
+  });
+}, 30000);
+
+beforeEach(() => {
+  if (!(Element.prototype as any).scrollIntoView) {
+    (Element.prototype as any).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+/** The real form renderer, in the blur-driven validation mode authors declare. */
+function renderBlurModeForm(field: any) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form
+      schema={{
+        type: 'form',
+        mode: 'create',
+        showSubmit: true,
+        showCancel: false,
+        submitLabel: 'Create',
+        validationMode: 'onBlur',
+        defaultValues: {},
+        fields: [field],
+        onSubmit: () => {},
+      }}
+    />,
+  );
+}
+
+const controlOf = (name: string, selector: string): HTMLElement => {
+  const el = document.querySelector(`[data-field="${name}"] ${selector}`);
+  if (!el) throw new Error(`no ${selector} rendered for field "${name}"`);
+  return el as HTMLElement;
+};
+
+describe('the form renderer really does hand a field widget an onBlur (objectui#6802)', () => {
+  it('CONTROL: NumberField — repaired in objectui#6780 — announces on blur', async () => {
+    renderBlurModeForm({ name: 'qty', label: 'Qty', type: 'number', required: true });
+
+    fireEvent.blur(controlOf('qty', 'input[type=number]'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Qty is required')).toBeInTheDocument();
+    });
+  });
+
+  it('CurrencyField announces on blur instead of swallowing the host handler', async () => {
+    renderBlurModeForm({ name: 'amount', label: 'Amount', type: 'currency', required: true });
+
+    fireEvent.blur(controlOf('amount', 'input[type=number]'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Amount is required')).toBeInTheDocument();
+    });
+  });
+
+  it('TagsField announces on blur instead of swallowing the host handler', async () => {
+    renderBlurModeForm({ name: 'labels', label: 'Labels', type: 'tags', required: true });
+
+    fireEvent.blur(controlOf('labels', 'input'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Labels is required')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/fields/src/widgets/CurrencyField.tsx
+++ b/packages/fields/src/widgets/CurrencyField.tsx
@@ -136,6 +136,8 @@ export function CurrencyField({ value, onChange, field, readonly, error, classNa
    * warns about `1e` but silently truncates `1.2.3` teaches people that no
    * warning means the value is right. See `content/docs/guide/fields.md`.
    */
+  const domProps = toDomProps(props);
+
   // Parse and format on blur to ensure valid currency format
   const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     // objectui#6780: the blur arm. React delivers no `onChange` when `.value`
@@ -143,17 +145,33 @@ export function CurrencyField({ value, onChange, field, readonly, error, classNa
     // — and `badInput` is still true at blur time, so this is the only arm that
     // sees that route.
     //
-    // ⚠️ This widget's `onBlur` has ALWAYS overridden the host's (it is written
-    // after the `toDomProps` spread), and that is left exactly as it was: no
-    // host in this repo passes `onBlur` to a field widget today (the data-table
-    // inline editor uses a document-level pointerdown listener instead), so
-    // composing it here would be an unmeasured behaviour change outside this
-    // card's ruling. Filed separately.
+    // ⚠️ COMPOSES the host's `onBlur` rather than replacing it (objectui#6802).
+    // `onBlur` is a declared DOM pass-through key (`FieldWidgetDomProps`,
+    // `SDUI_DOM_PASS_THROUGH_KEYS`) that `toDomProps` already delivers here, so
+    // the bare handler this used to be — written AFTER the spread — silently
+    // dropped it: this package's DECLARED-BUT-NOT-DELIVERED class
+    // (objectui#3290 / objectui#3222).
+    //
+    // ⛔ NOT the no-op the card assumed. objectui#6802 was filed on the reading
+    // that "no host in this repo passes `onBlur` to a field widget"; that is
+    // FALSE. The form renderer hosts every field through react-hook-form's
+    // `Controller` and spreads the controller field — `{ name, value, onChange,
+    // onBlur, ref, disabled }` — into the widget's props
+    // (`components/src/renderers/form/form.tsx`). That `onBlur` is what marks
+    // the field touched and, under an authored `validationMode: 'onBlur'` /
+    // `'onTouched'`, runs its validation. Overriding it opted currency fields
+    // out of blur-mode validation while every sibling field kept it. The
+    // reproduction through the real renderer is
+    // `__tests__/hostOnBlurDelivery-e2e.test.tsx`.
     readBadInput(e.target);
     const val = parseFloat(e.target.value);
     if (!isNaN(val)) {
       onChange(parseFloat(val.toFixed(precision)));
     }
+    // Last: the widget's own rounding emission lands before the host is told
+    // the field was touched, so a blur-mode validator reads the parsed value
+    // rather than the raw one.
+    domProps.onBlur?.(e);
   };
 
   // ONE channel for the symbol (objectui#4414). This used to be a hand-written
@@ -176,7 +194,7 @@ export function CurrencyField({ value, onChange, field, readonly, error, classNa
           </span>
         )}
         <Input
-          {...toDomProps(props)}
+          {...domProps}
           type="number"
           value={value ?? ''}
           onChange={(e) => {

--- a/packages/fields/src/widgets/TagsField.tsx
+++ b/packages/fields/src/widgets/TagsField.tsx
@@ -33,6 +33,34 @@ export function TagsField({ value, onChange, field, readonly, className, error, 
 
   const removeTag = (t: string) => onChange(tags.filter((x) => x !== t));
 
+  const domProps = toDomProps(props);
+
+  /**
+   * Commit the typed draft as a tag on blur — and then hand the event on to the
+   * host (objectui#6802).
+   *
+   * ⚠️ `onBlur` is a DECLARED DOM pass-through key (`FieldWidgetDomProps`,
+   * `SDUI_DOM_PASS_THROUGH_KEYS`) that `toDomProps` already delivers onto this
+   * control, so the bare `onBlur={() => addTag(draft)}` this used to be —
+   * written AFTER the spread — silently overrode it: this package's
+   * DECLARED-BUT-NOT-DELIVERED class (objectui#3290 / objectui#3222).
+   *
+   * ⛔ NOT a no-op. The form renderer hosts every field through
+   * react-hook-form's `Controller` and spreads the controller field —
+   * `{ name, value, onChange, onBlur, ref, disabled }` — into the widget's
+   * props (`components/src/renderers/form/form.tsx`), so the dropped handler is
+   * the one that marks the field touched and runs blur-mode validation. The
+   * reproduction through the real renderer is
+   * `__tests__/hostOnBlurDelivery-e2e.test.tsx`.
+   *
+   * Order matters: `addTag` runs FIRST so a host validating on blur reads the
+   * committed list rather than the one the user had before typing the tag.
+   */
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    addTag(draft);
+    domProps.onBlur?.(e);
+  };
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
@@ -61,11 +89,11 @@ export function TagsField({ value, onChange, field, readonly, className, error, 
         // DOM pass-through onto the real focusable control (objectui#3318):
         // the whitelist spread carries the form renderer's id /
         // aria-describedby to the input the user actually types in.
-        {...toDomProps(props)}
+        {...domProps}
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={onKeyDown}
-        onBlur={() => addTag(draft)}
+        onBlur={handleBlur}
         disabled={props.disabled}
         // Placeholder chain (objectui#3342): the author-declared
         // `field.placeholder` wins; otherwise the widget's own copy arrives


### PR DESCRIPTION
Fixes #6802

`CurrencyField` and `TagsField` each wrote their own `onBlur` AFTER the
`{...toDomProps(props)}` spread, so a host-supplied handler was overridden and
never reached the control. `onBlur` is a DECLARED DOM pass-through key — named
in `FieldWidgetDomProps` (`packages/fields/src/widgets/types.ts`), named in
`SDUI_DOM_PASS_THROUGH_KEYS` (`packages/core/src/utils/dom-props.ts`), and
forwarded by `toDomProps` — so this is the declared-but-not-delivered class
(#3290 / #3222).

Both now use the idiom PR #6801 landed for the other three widgets: resolve
`toDomProps(props)` into `domProps`, spread `{...domProps}`, and call
`domProps.onBlur?.(e)` at the end of the local handler. No second idiom
invented; no public surface widened.

## ⛔ Read this first — the card's "latent, no-op today" premise is FALSE

The card and its triage both rest on one measurement, taken on `d06059f24`:
*"no host in this repo passes `onBlur` to a field widget"*, which made composing
a **no-op today** and the change a free buy-forward.

Re-measured on this branch's base (`1e14d70`), **that is not true**, and the
reproduction is committed as `hostOnBlurDelivery-e2e.test.tsx`.

**The call site.** The form renderer hosts every field through
react-hook-form's `Controller` — the `FormField` wrapper in
`packages/components/src/ui/form.tsx` is a thin `Controller` — and spreads the
controller's field object straight into the widget's props:

```tsx
render={({ field: formField, fieldState }) => (
  … renderFieldComponent(resolvedType, { ...fieldProps, …, ...formField, … })
```
`packages/components/src/renderers/form/form.tsx` (the `...formField` spread)

A react-hook-form controller field is `{ name, value, onChange, onBlur, ref,
disabled }`. Measured directly — a probe widget registered into the real form
renderer reported its own prop keys:

```
["field","name","value","onChange","onBlur","ref","options","placeholder",
 "disabled","readonly","error","aria-required","id","aria-describedby","aria-invalid"]
                        ^^^^^^^  typeof: function
```

So **every registered field widget in every form this repo renders is already
handed an `onBlur`**, and it is the handler that marks the field touched and,
under `validationMode` `'onBlur'` / `'onTouched'`, runs its validation.
`validationMode` is authorable on `ObjectFormSchema` and is wired straight to
react-hook-form's `mode`, so metadata alone reaches this.

**What that means for the change.** The defect is not latent — it is active and
user-visible: currency and tags fields were silently opted out of blur-mode
validation while every sibling field type on the same form kept it. The fix is
therefore a REAL behaviour change, not the free no-op the card priced it as.
The direction is unchanged (it restores declared = enforced, and the four
`type="number"` widgets already behave this way), but the risk note triage
wrote — *"could start firing onBlur-mode validation on currency fields that
never saw it"* — is now the actual, intended effect rather than a hypothetical.
Flagged rather than absorbed, because the reason for doing it now was the
premise that just failed. The changeset says so in the release notes.

## Verification

Pre-fix red, with a control (base `1e14d70`, `hostOnBlurDelivery-e2e.test.tsx`):

```
✓ CONTROL: NumberField — repaired in objectui#6780 — announces on blur
× CurrencyField announces on blur instead of swallowing the host handler
× TagsField announces on blur instead of swallowing the host handler
    Unable to find an element with the text: Amount is required
    Unable to find an element with the text: Labels is required
Tests  2 failed | 1 passed (3)
```
The control passing is what makes the two red rows about the widgets rather
than about the fixture.

Ablation on the committed fix — remove only `domProps.onBlur?.(e)` from both
widgets, run, restore. Mutation confirmed on disk before the run (`grep -c`
for the composition: `1 1` → `0 0`; both blob hashes differed from their HEAD
blobs). No rebuild leg applies: the pins import the widgets by relative source
path and the suite resolves `@object-ui/components` to source, so nothing is
read out of `dist/`.

```
× CurrencyField still calls a host onBlur                       (badInputAnnounce §5)
× CurrencyField announces on blur …                             (e2e)
× TagsField announces on blur …                                 (e2e)
× calls the host onBlur                                         (TagsField.hostOnBlur)
× hands the host the real focus event, not a fabricated one     (TagsField.hostOnBlur)
× still commits the typed draft as a tag on that same blur      (TagsField.hostOnBlur)
Tests  6 failed | 77 passed (83)
```
`PercentField` / `NumberField` / `GeolocationField` and the fourth TagsField
case (`works with no host handler at all`) stay green under the ablation, as
they should — they do not depend on the removed line. Restore leg proven, not
assumed: `git diff HEAD` empty and both files byte-identical to their HEAD
blobs (`07a8ac4…`, `b4067b7…`).

Union re-run at the shipping head **`d931710`**:

```
pnpm exec vitest run --maxWorkers=2 packages/fields/
  Test Files  123 passed (123)
       Tests  2081 passed (2081)

pnpm --filter @object-ui/fields type-check     → exit 0
  (tsc --noEmit && tsc -p tsconfig.test.json)
```
`--listFiles` confirms this is a real measurement of the edited files, not a
green that excluded them: all three edited/added test files are in the
`tsconfig.test.json` program, and both widgets are in the main program.

Gates derived for this diff's paths (`packages/fields/src/**`, `.changeset/**`):

| gate | verdict line |
|---|---|
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 5710 tracked text file(s); skipped 85 binary).` |
| `check-changeset-presence` | `✅ 5 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` | `✅ All workspace packages are in the changeset fixed group.` |
| `check-changeset-no-major` | `✅ No changeset declares a major bump.` |
| `check-changeset-overwrite` | `✅ No pre-existing changeset was modified or deleted.` |
| `check:vi-mock-specifiers` | `✅ check-vi-mock-specifiers: OK (3991 tracked source file(s) …)` |
| `check:i18n-keys` | exit 0 — every in-scope call-site key resolves against the en pack |
| `pnpm --filter @object-ui/fields lint` | exit 0 — `✖ 907 problems (0 errors, 907 warnings)`; the package's standing warning baseline. The three files touched here contribute only `@typescript-eslint/no-explicit-any` warnings, matching the sibling e2e tests. |

**Declared narrowing.** Lint was run package-scoped (`--filter
@object-ui/fields`), not repo-wide; the repo-wide `turbo run lint` is CI's
run. `check:sdui-registration-pins` and `check:eager-closure` are recorded as
NOT MEASURED, not as passes: both refuse to run without an `apps/console`
build and say so themselves (*"a run with nothing to read has measured
nothing"*). Neither reads anything this diff touches; CI builds console and
runs them.

## Scope

Both halves of the class, per triage — repairing only `CurrencyField` would
have left `TagsField` open with no card tracking it. `TagsField`'s `onBlur` IS
load-bearing in a way the currency one is not (it commits the typed draft as a
tag), so its pin asserts both effects on one blur; `addTag` runs first so a
blur-mode validator reads the committed list. Currency likewise emits its
rounded value before handing the event on.

The now-false exclusion note in `NumberInputWidgets.badInputAnnounce.test.tsx`
§5 (*"`CurrencyField` is deliberately absent … no host in this repo passes one
today"*) is corrected in place rather than deleted, and `CurrencyField` joins
that file's `it.each`.

Session (durable copy, since a body edit rewrites the footer):
`https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB`

_Generated by [Claude Code](https://claude.ai/code)_