### PR TITLE
docs(skills): mark the two non-canonical row-predicate spellings as deprecated

### DIFF
--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -304,9 +304,13 @@ paid_on:   Field.date({
 }
 ```
 
-The predicate binds the row three ways — `record.status` (canonical), bare
-`status`, and `data.status` (legacy) — plus the host predicate scope
-(`features.*`, `user.*`). The legacy ObjectUI shapes still work and are
+The predicate binds the row three ways — `record.status` (**canon**), bare
+`status` and `data.status` (both **deprecated** here: still bound, warned
+once in dev, retiring after a stored-metadata survey — see
+`packages/core/src/evaluator/rowPredicateCanon.ts`) — plus the host
+predicate scope (`features.*`, `user.*`). `data.*` is the trap: the server's
+authoring oracle accepts it silently, then binds nothing at runtime — a
+constant `false`, not an error. The legacy ObjectUI shapes still work and are
 translated to CEL transparently: the native `{ field, operator, value }` form
 (`operator` ∈ `equals` / `not_equals` / `greater_than` / `less_than` /
 `contains` / `in`) and the `{ expression: "${…}" }` template form. A string


### PR DESCRIPTION
Fixes #5759

Prose-only annotation of the three-way row-predicate sentence in the published skills guide `skills/objectui/guides/schema-expressions.md` (List-view/CEL tier). It presented `record.status`, bare `status` and `data.status` as peers, labelling `record.*` merely "canonical" — a word that reads as a style preference — while since Phase 1 (#5330 / PR #5737) the other two emit a one-time dev-console deprecation warning and retire once a stored-metadata survey sizes the window.

## What changed

One sentence, at :307. `record.*` is now stated as the **canon**; bare `status` and `data.status` are stated as **deprecated here** (still bound, warned once in dev, retiring after the survey), pointing at `packages/core/src/evaluator/rowPredicateCanon.ts`; and the card's sharper point is carried: `data.*` is the trap — the server's authoring oracle accepts it silently and it then binds nothing at runtime, a constant `false` rather than an error.

"Deprecated **here**" is deliberate, not hedging: `rowPredicateCanon.ts` scopes the deprecation to the runtime record layer, because `data` is the canonical root of a metadata-editing form (ADR-0089 D3). An unqualified sentence in this corpus would contradict that.

No example was rewritten — the nearby data-model-tier and conditional-formatting examples are already `record.*`.

## State verified on this branch, not taken from the card

The card was filed 2026-08-23; the words had to describe what is measurable now. Read at base `aca70f6`:

- `listConditional.ts:273` still binds all three — `{ ...(opts.scope ?? {}), ...rowObj, data: rowObj, record: rowObj }`. No spelling has been retired or turned into a refusal, so "still bound" is accurate and "retiring after a stored-metadata survey" is the correct tense.
- `listConditional.ts:317` calls `warnNonCanonicalRowSpelling(predicateText, rowObj, !opts.rowless, opts.label)` on the CEL path, so both non-canonical spellings do warn on this tier, and `data` names the row here (not `rowless`), which is the condition the detector needs.
- `rowPredicateCanon.ts` still reads Phase 1: "the binding is UNCHANGED and every spelling still resolves", warn-once, "removable only after a stored-metadata survey".

Phase 2 (#5741) has not advanced past "warned".

## Three-engine boundary held

Only the List-view/CEL row-predicate tier changed. The `${…}`/`On`-suffix tier earlier in the file (SafeExpressionParser, where `data.*` is correct) and the flow tier (`isFieldVisibleWhen`, `previews/screen-spec.ts`) are untouched. The one-time-warning sentence at :316-317 belongs to legacy-**syntax** routing, a different mechanism from these spellings, and is untouched — the diff hunk stops above it.

## Line-count readings (2026-08-21 whole-package ruling)

PM-set budget for this card: **+4 lines max** net on the file.

| reading | before | after | net |
|---|---|---|---|
| `skills/objectui/guides/schema-expressions.md` (whole file) | 621 | 625 | **+4** |
| published bundle — all 18 `.md` under `skills/` | 5682 | 5686 | **+4** |

`git diff --stat`: 1 file changed, 7 insertions(+), 3 deletions(-). The budget is met exactly; the wording was cut three times to reach it (measured by wrapping each candidate at the file's 78-column prose width before editing).

## Gates — each line is the gate's own verdict, re-run on the final commit `7bcfefc`

```
check-skills-paths          ✅  OK (94/95 stated path(s) resolve across 18 guide file(s); 1 baselined).
check-control-bytes         ✅  OK (scanned 5714 tracked text file(s); skipped 85 binary).
check:doc-fences            ✅  every TypeScript block in 223 document(s) is fenced ts/tsx/typescript ...
check-doc-links             Links are valid across 17 scan roots.
check-changeset-presence    ✅  No source of a released package changed in this range, so no changeset is owed.
check-doc-component-types   ✅  Every documented component type is registered.
check-shell-escape-residue  ✅  OK (4/4 root(s) resolved -- ... skills: 18 file(s), 235 fence(s) ...).
vitest (4 files)            Test Files  4 passed (4) · Tests  107 passed (107)
```

The vitest set is every test file that reads this corpus: `packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx`, `scripts/__tests__/check-skills-paths.test.ts`, `scripts/__tests__/check-control-bytes.test.ts`, `scripts/__tests__/doc-version-claims.test.ts`.

`check-skills-paths` got a positive control rather than a bare green: calling its own exported `extractPathTokens` on the edited file returns the new token — `{ line: 310, token: 'packages/core/src/evaluator/rowPredicateCanon.ts', pattern: false }` — so the 94/95 verdict demonstrably includes the path this PR added.

No changeset: `skills/**` is not published source of a released package, and the gate says so in its own words above.

## Two declared narrowings

**`check:doc-snippets` was NOT RUN.** Its own exit is 2 — "PRECONDITION NOT MET ... This is 'I could not run', NOT 'I ran and found errors'" — because it needs 21 package build closures, a repo-wide build this shared box cannot host in a foreground window. Instead its judged population was measured directly through its own exported extractor, `scanFences`:

- population read from the gate itself, not guessed: `scanFences` collects only `ts`/`tsx` fenced blocks; this file has exactly **1**, at line 250 — above the edited hunk (307-313).
- count from that output: 1 block at base `aca70f6` and 1 at head, same `fenceLine` 250, bodies byte-identical.
- counter-probe: appending a line to that block's body **does** change the extracted population, so "identical" is a measurement that could have failed rather than a vacuous pass.

**`pnpm lint` was narrowed to nothing, on eslint's own answer.** `eslint --no-inline-config --format json` on the changed file reports `"File ignored because no matching configuration was supplied"` — the repo's flat config matches no `.md` file at all, so the file count eslint judges in this diff is 0. No type-aware linting is configured, and the diff is one markdown file, so no untouched file's verdict can move either.

CI runs the full farm regardless; these two are the cheap local half, declared rather than silently skipped.

## Governed-face handling

Left as **draft** for the PM's review chain — not flipped ready, not queued, no auto-merge. Note for the record: this repo's `AGENTS.md` §"受管面" explicitly places root `skills/**` *outside* the governed surface (only `.claude/**`, `AGENTS.md`, `CLAUDE.md`, `docs/adr/**` are governed there) and would permit self-merge on green. The dispatch treats the published skills corpus as governed for this fleet's review chain, which is the stricter of the two, so draft-only satisfies both. Flagged so the divergence is visible rather than assumed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXxTW8mvPBhoHxmyPZ63de)_