### PR TITLE
test(components): assert the deprecation notice and `deprecated.replacement` name the same alternatives

### DIFF
--- a/.changeset/6823-deprecation-guidance-agreement.md
+++ b/.changeset/6823-deprecation-guidance-agreement.md
@@ -1,0 +1,23 @@
+---
+---
+
+Test-only (objectui#6823): the console deprecation notice and the machine-readable
+`deprecated.replacement` a deprecated type declares are now asserted to offer the same
+set of replacement types, one case per renderer (`div`, `span`).
+
+Since objectui#6674 a deprecated type's migration guidance is stated twice — the notice
+string literal in the renderer, and the `deprecated.replacement` on its registration,
+transcribed from the notice by hand. Nothing held them together, so a reword of either
+left the other stale, and the stale copy is the one an automated gate reads and repeats
+to authors. There is no `tsc` here to notice one string literal drifting from another.
+
+`packages/components/src/__tests__/deprecation-guidance-agreement.test.tsx` extracts the
+double-quoted type names from each side — the notice's guidance BULLETS, and the
+declaration's replacement line — and asserts set equality. Nothing about the guidance
+text is restated in the test; a third copy of the sentence is the defect one layer up,
+and per triage it is the signal to stop rather than the way to write this.
+
+Shape ruled by triage (2026-08-29): assert the agreement, do not converge the two texts.
+The notice wording is pinned byte-for-byte by four existing tests, and those pins are
+themselves objectui#4000's ruling — converging would trade one ruled invariant for
+another. No pin is touched here, and no published behaviour changes.

--- a/packages/components/src/__tests__/deprecation-guidance-agreement.test.tsx
+++ b/packages/components/src/__tests__/deprecation-guidance-agreement.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A deprecated type's migration guidance is stated TWICE, and this file is the
+ * only thing holding the two statements together (objectui#6823).
+ *
+ * 1. the human-facing console notice — `DIV_DEPRECATION_NOTICE` /
+ *    `SPAN_DEPRECATION_NOTICE`, string literals inside the renderers, and
+ * 2. the machine-readable `deprecated.replacement` on the same file's
+ *    registration, which objectui#6674 added so a gate can tell an author what
+ *    to write instead.
+ *
+ * Both say the same thing today, in different words, because the second was
+ * transcribed from the first by hand. Nothing asserted they still agree, so a
+ * reword of either left the other stale — and the stale one is the copy an
+ * automated gate reads and repeats to authors, at a scale no console notice
+ * reaches. This is the shape objectui#4580 ruled about and objectui#6067 /
+ * #5671 / #5893 executed three times since; the unit here is a sentence rather
+ * than a type, and unlike those it fails SILENTLY, because there is no `tsc` to
+ * notice a string literal drifting away from another string literal.
+ *
+ * ## Why this ASSERTS the agreement instead of deriving one text from the other
+ *
+ * Deriving the notice's guidance line from the declaration is the direction
+ * that class of ruling usually takes, and triage weighed it here and ruled
+ * against it (2026-08-29, on objectui#6823). Those precedents were about TYPES,
+ * enforced by `tsc`, with no competing ruling on their wording. This sentence
+ * is pinned BYTE-FOR-BYTE by four existing tests —
+ * `div-deprecation-provenance`, `div-deprecation-warn-once`,
+ * `span-deprecation-provenance`, `span-deprecation-warn-once` — and those pins
+ * are themselves a deliberate maintainer ruling: objectui#4000 records that the
+ * guidance is "byte-for-byte what it was." Converging the two statements means
+ * MOVING those pins, i.e. trading one ruled invariant for another, which is a
+ * judged change of its own and not a rider on a drift-prevention card.
+ *
+ * The assertion below buys the whole drift protection without touching
+ * objectui#4000 at all.
+ *
+ * ## What is compared, and why it is EXTRACTED rather than restated
+ *
+ * Restating either text here would be a THIRD copy of the sentence — the very
+ * defect, one layer up, and the point at which this file would have to stop and
+ * escalate instead. So nothing below spells out any guidance text. Both
+ * statements are reduced, mechanically, to the thing they are both about: the
+ * set of component type names offered as the replacement, read out of each text
+ * as its double-quoted runs. That convention is one both texts already follow —
+ * a replacement type is named in double quotes on both sides — and it is the
+ * half that has to agree: prose framing may differ (the notice explains WHEN to
+ * reach for each, the declaration is one line for a gate to repeat), the
+ * alternatives on offer may not.
+ *
+ * Set equality, not containment, and that is deliberate: containment one way
+ * catches a name added to the declaration but not the notice, and misses the
+ * reverse. Drift has no preferred direction, so both directions are asserted at
+ * once.
+ *
+ * ## Scope — the notice's SCOPE sentence is deliberately not read here
+ *
+ * The `surfaces` / `isHtmlTierNode` half is already pinned to itself by
+ * objectui#6674, in the two provenance tests. Extraction below is confined to
+ * the notice's guidance BULLETS, so this file cannot start failing because that
+ * sentence was reworded — the bullets are what `deprecated.replacement`
+ * restates, and their layout is itself part of what objectui#4000's four pins
+ * hold in place.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Registers the renderers at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`. See
+// object-ui/no-dynamic-import-in-test-hook (objectui#3010/#3021).
+import '../renderers';
+
+/**
+ * The component type names a piece of guidance offers: its double-quoted runs.
+ *
+ * Deliberately not a list of names kept here. A hard-coded list would be the
+ * third copy this file exists to avoid, and would go stale in exactly the way
+ * the two statements it compares can.
+ */
+function offeredTypeNames(guidance: string): Set<string> {
+  return new Set([...guidance.matchAll(/"([^"]+)"/g)].map((match) => match[1]));
+}
+
+/**
+ * The notice's migration guidance: its bullet lines, and only those.
+ *
+ * Everything else in the notice — the header naming the type, the SCOPE
+ * sentence objectui#6674 already pins elsewhere, the docs link — is out of
+ * scope for this comparison, and reading past the bullets is how this file
+ * would acquire a coupling to text that is not its business.
+ */
+function guidanceBullets(notice: string): string {
+  return notice
+    .split('\n')
+    .filter((line) => line.trimStart().startsWith('- '))
+    .join('\n');
+}
+
+/**
+ * Render one JSON-authored node of `type` and return the deprecation notices it
+ * emitted.
+ *
+ * The notice literal is module-private, as it should be — exporting it to test
+ * it would widen the package's surface for a test's convenience. It is read the
+ * way every reader reads it: off the console. The warn-once guard
+ * (objectui#3965) is a module-level Set per renderer module, so each type may be
+ * rendered in exactly one case of this file; the count assertion in each case is
+ * what would catch that rule being broken later.
+ */
+function deprecationNoticesFor(type: string): string[] {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const Component = ComponentRegistry.get(type);
+  if (!Component) throw new Error(`Component "${type}" is not registered`);
+  render(<Component schema={{ type }} />);
+  const deprecation = new RegExp(`The "${type}" component is deprecated`);
+  return warn.mock.calls
+    .map((args: unknown[]) => String(args[0]))
+    .filter((message) => deprecation.test(message));
+}
+
+/**
+ * One case's body, shared so both renderers are held to the identical check and
+ * a third deprecated type joins them in one line rather than by transcription —
+ * which is the failure mode this whole file is about.
+ */
+function expectGuidanceAndDeclarationAgree(type: string): void {
+  const notices = deprecationNoticesFor(type);
+  // Control FIRST: an agreement between two texts proves nothing if one of them
+  // was never produced. Zero notices (a renderer that stopped warning, a type
+  // that stopped resolving) would otherwise read as a pass on empty sets.
+  expect(notices).toHaveLength(1);
+
+  const bullets = guidanceBullets(notices[0]);
+  // Control: the notice really carries bullet guidance. A reflow that dissolves
+  // the bullets is a reword of the guidance, and it has to come back through
+  // here rather than silently emptying the comparison.
+  expect(bullets).not.toBe('');
+
+  const declared = ComponentRegistry.deprecationFor(type, 'json')?.replacement;
+  // Control: the declaration objectui#6674 added is still there and still says
+  // something. Without this, deleting `replacement` would turn this case green.
+  expect(declared).toBeTruthy();
+
+  const fromDeclaration = offeredTypeNames(declared as string);
+  // Control: the comparison is not vacuous. Guidance rewritten without quoted
+  // names on the declaration side would otherwise satisfy an empty-vs-empty
+  // equality while saying nothing at all.
+  expect(fromDeclaration.size).toBeGreaterThan(0);
+
+  const fromNotice = offeredTypeNames(bullets);
+
+  // The whole point: the alternatives the human is offered and the alternatives
+  // a gate would repeat are the same set. Reword either side's list — add,
+  // drop or rename one — and this goes red.
+  expect([...fromNotice].sort()).toEqual([...fromDeclaration].sort());
+}
+
+describe('deprecation guidance — the console notice and `deprecated.replacement` agree (#6823)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('div: the notice offers exactly the alternatives the declaration names', () => {
+    expectGuidanceAndDeclarationAgree('div');
+  });
+
+  it('span: the notice offers exactly the alternatives the declaration names', () => {
+    expectGuidanceAndDeclarationAgree('span');
+  });
+});


### PR DESCRIPTION
Fixes #6823

Since #6674 a deprecated type states its migration guidance **twice** — the console notice string literal in the renderer, and the machine-readable `deprecated.replacement` on the same file's registration, transcribed from the notice by hand. Nothing held them together, so a reword of either left the other stale, and the stale one is the copy an automated gate reads and repeats to authors. Unlike the type-level executions of this class (#4580 / #6067 / #5671 / #5893) there is no `tsc` to notice one string literal drifting from another.

## Shape: (a) assert the agreement — triage's ruling, not re-litigated

Triage ruled (2026-08-29) for the assertion over converging the two texts, and this PR does exactly that. The notice wording is pinned **byte-for-byte** by four existing tests, and those pins are themselves #4000's ruling that the guidance is "byte-for-byte what it was" — converging would trade one ruled invariant for another. **No pin is touched**; all four are green in the run below.

The stop condition in the triage comment did not trigger: the assertion restates **no guidance text at all**, so it never became a third copy of the sentence.

## What the assertion actually compares

`packages/components/src/__tests__/deprecation-guidance-agreement.test.tsx`, one case per renderer (`div`, `span`):

1. render one JSON-authored node of the type and read the notice **off the console** — the way every reader reads it, and without exporting a module-private literal for a test's convenience;
2. reduce both statements, mechanically, to the thing they are both about: **the set of component type names offered**, extracted as each text's double-quoted runs. That is a convention both texts already follow, and it is the half that has to agree — prose framing may differ (the notice explains when to reach for each; the declaration is one line for a gate to repeat), the alternatives on offer may not;
3. assert **set equality**, not containment. Containment one way catches a name added to the declaration but missing from the notice and misses the reverse; drift has no preferred direction.

Two deliberate boundaries:

- **Extraction is confined to the notice's guidance bullets.** The scope sentence (`surfaces` / the `isHtmlTierNode` exemption) is #6674's, already pinned to itself in the two provenance tests, and out of scope per the card. Reading past the bullets is how this file would acquire a coupling to text that is not its business — so it mechanically cannot.
- **Nothing about the guidance is hard-coded here.** A list of names kept in the test would go stale in exactly the way the two statements it compares can.

Three control assertions keep the comparison from passing while measuring nothing: exactly one notice was emitted, the notice really carries bullet guidance, and the declaration's extracted name set is non-empty (an empty-vs-empty equality would otherwise be green while saying nothing).

## Verification — all at `accc457`, on a clean tree

**Re-derived on the shipped tree, not the card's branch.** The card was measured on `claude/issue-6674-registry-deprecation-declaration` @ `eb852a052`; base here is `origin/main` @ `30266cf9a`, with #6822 / #6834 / #6841 / #6851 all landed. The symbols and paths the card names are unchanged, and **the two statements still agree** — the new cases are green on arrival, which is why the ablation below is the load-bearing evidence rather than the green.

**Ablation — the drift protection is real.** Three legs, each mutated on disk with the anchor's occurrence count checked (`injected-count=1 removed-count=0`; a zero-hit edit would have reported a no-op instead of a pass), restored from a `trap` on EXIT/INT/TERM with absolute paths, and each restore **proven** by comparing the file's `git hash-object` against its HEAD blob plus an empty `git diff HEAD`:

| leg | mutation | result |
|---|---|---|
| A | `div` **declaration** renames one alternative (`"grid"` in `deprecated.replacement`) | red — `1 failed \| 1 passed` |
| B | `div` **notice** renames the same alternative in its guidance bullet | red — `1 failed \| 1 passed` |
| C | `span` **declaration** renames one alternative (`"badge"`) | red — `1 failed \| 1 passed` |
| control | restored tree | green — `2 passed` |

Every leg failed on the intended line (the set-equality assertion), and in each the *other* renderer's case stayed green, so attribution is exact. **No rebuild leg is needed and none is claimed**: the root vitest config aliases `@object-ui/*` to each package's `src/`, and the test imports the renderers relatively (`../renderers`), so nothing in these runs resolves through `dist/`.

**Suites and gates** (exit codes captured before any pipe; verdicts quoted from each gate's own output):

- `pnpm exec vitest run packages/components/ --maxWorkers=2` — **216 files / 1995 tests passed**, which is every `*.test.ts(x)` in the package (216 by count) and includes all four #4000 pins.
- `pnpm --filter @object-ui/components run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — exit 0. `--listFiles` confirms the new file **is** a program input, so this covers it rather than merely passing beside it.
- `node scripts/check-changeset-presence.mjs` — "Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate."
- `node scripts/check-changeset-fixed.mjs`, `node scripts/check-changeset-no-major.mjs`, `node scripts/check-control-bytes.mjs`, `node scripts/check-vi-mock-specifiers.mjs` — all exit 0 on their own verdict lines.

**Lint, and the narrowing declared.** `pnpm exec eslint . --format json` from `packages/components` — **433 files, 0 errors, 934 warnings**, the package's standing baseline; the new file contributes 0 of each. This is the whole eslint surface the diff can affect, on three pieces of evidence: the population comes from eslint's own config resolution rather than a guess about which files count; the file count is read from the `--format json` output; and `eslint.config.js` declares no `parserOptions.project` / `projectService`, so type-aware linting is off and a new file cannot move any untouched file's verdict. The repo-wide `turbo run lint` is CI's run.

## Release

Test-only, no published behaviour changes: `.changeset/6823-deprecation-guidance-agreement.md` carries an **empty frontmatter**, the exemption `check-changeset-presence` names explicitly. No `skip-changeset` label — in this repo that label is read by nothing.

Session: https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB

_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_