### PR TITLE
docs(layout): describe `branding` and `rightRail` on the AppShell page

### DIFF
--- a/.changeset/4830-app-shell-branding-rightrail-prose.md
+++ b/.changeset/4830-app-shell-branding-rightrail-prose.md
@@ -1,0 +1,17 @@
+---
+---
+
+Documentation-only: `content/docs/layout/app-shell.mdx` now describes `branding` and
+`rightRail` in prose, not just in the `AppShellProps` key table. The page's Features and
+Styling sections had never mentioned either prop — the table half landed with objectui#4808
+while the prose was deliberately held back until objectui#4818 ruled on
+`AppShellBranding.logo`. That ruling was REMOVE, so the new copy describes the
+post-removal surface: the four fields `useAppShellBranding` actually reads
+(`primaryColor`, `accentColor`, `favicon`, `title`), which Shadcn theme tokens each colour
+writes (`--primary` / `--primary-foreground` / `--ring` / `--sidebar-primary` /
+`--sidebar-ring` and `--accent` / `--accent-foreground`), and that `rightRail` renders as
+a flex sibling that reflows the content rather than overlaying it (ADR-0057 P3a). Every
+sentence was checked against `packages/layout/src/AppShell.tsx` and
+`packages/components/src/index.css` rather than against the key table — that is the
+failure this page has already been corrected for four times. No published behaviour
+changes and no package source was touched.

--- a/content/docs/layout/app-shell.mdx
+++ b/content/docs/layout/app-shell.mdx
@@ -41,7 +41,7 @@ interface AppShellProps {
   children: React.ReactNode;     // Main content area
   className?: string;            // Additional CSS classes for content area
   defaultOpen?: boolean;         // Sidebar default state (default: true)
-  branding?: AppShellBranding;   // App branding — see AppShellBranding
+  branding?: AppShellBranding;   // App branding — four theme fields, see Branding
   rightRail?: React.ReactNode;   // Optional right rail beside the content, not
                                  // over it (ADR-0057 P3a)
 }
@@ -78,6 +78,32 @@ The main content area features:
 - Automatic scrolling
 - Flexible height (fills viewport)
 - Custom className support
+
+### Branding
+
+`branding` is theming, not chrome — the shell hands it to `useAppShellBranding`, and all
+four of the fields it declares are read:
+
+- `primaryColor` / `accentColor` — a six-digit hex (`#3B82F6`; the leading `#` is
+  optional, three-digit shorthand is not accepted), translated into the Shadcn theme
+  tokens listed under Styling below. A value that does not parse that way is ignored
+  silently.
+- `favicon` — overwrites the `href` of the icon link the page already has (`#favicon`,
+  otherwise `link[rel="icon"]`). It never creates one, so a document with no icon link is
+  left unchanged.
+- `title` — assigned to `document.title` as given. It is the whole title, not a suffix:
+  the caller composes the string it wants (the console passes
+  `"App label — Product name"`).
+
+All of it acts on the document rather than on the shell's subtree, and the colour
+properties are removed again when the shell unmounts.
+
+### Right Rail
+
+`rightRail` renders your node as a flex sibling of the content area, so the rail sits
+**beside** the content and reflows it rather than overlaying it (ADR-0057 P3a). The shell
+adds no wrapper and no width around it — the node you pass owns its width, border and
+scrolling; omit it and the layout is the unchanged single pane.
 
 ## Layout Structure
 
@@ -254,6 +280,16 @@ The AppShell uses Tailwind CSS and Shadcn UI components:
 
 - `SidebarProvider`: Manages sidebar state
 - `SidebarInset`: Content area wrapper
+
+Brand colours arrive as Shadcn theme tokens rather than as per-component styles: each hex
+from `branding` is converted to the `H S% L%` triple those tokens carry and set as a CSS
+custom property on `document.documentElement`. `primaryColor` writes `--primary`,
+`--primary-foreground`, `--ring`, `--sidebar-primary` and `--sidebar-ring`; `accentColor`
+writes `--accent` and `--accent-foreground`. Tailwind's utilities resolve through the same
+tokens (`--color-primary: hsl(var(--primary))`), so every `bg-primary` / `text-primary` /
+`ring-primary` / `bg-accent` consumer picks the brand colour up with no per-component
+wiring. In dark mode a lighter variant of the same hue is used instead, and the shell
+re-applies the values whenever the `dark` class on the `html` element changes.
 
 ## Accessibility
 


### PR DESCRIPTION
Fixes #4830

`content/docs/layout/app-shell.mdx` reprints all seven `AppShellProps` keys (that half landed with #4808 / PR #4829), but its **Features** and **Styling** prose mentioned neither `branding` nor `rightRail`. Confirmed on this base before writing: the words appeared only in the key table.

The prose half was deliberately parked until #4818 ruled on `AppShellBranding.logo`. That ruling was **REMOVE** (PR #5366), so this copy describes the post-removal surface. `logo` is not documented, not described as pending, and not restored from the card's older text.

## What is added

- **Features → Branding** — a short paragraph plus one bullet per field: what each of the four fields does, and where the colours go.
- **Features → Right Rail** — `rightRail` reflows the content beside it rather than overlaying it (ADR-0057 P3a), and the shell wraps it in nothing.
- **Styling** — the `branding` to Shadcn-theme-token relationship, named token by token.
- **Key table** — the `branding` comment moves from a bare type pointer to the field count the ruling settled, and points at the new section. The `AppShellProps` pin compares declaration lines only ("Prose about a prop is free"), so this is not a pin edit.

## Why a green CI proves nothing here, and what does

`check:doc-snippets` compiles fences, not prose; no gate in this repo can fail on a *wrong sentence*. This page has already been corrected four times (#3914 / #3946 / #3999 / #4793) for exactly that. So every claim below was read off the **consumer**, not off the key table and not off the card:

| Claim in the new prose | Read from |
|---|---|
| `useAppShellBranding` reads exactly four fields | `packages/layout/src/AppShell.tsx:120-229`, hook called at `:241` |
| `primaryColor` writes `--primary`, `--primary-foreground`, `--ring`, `--sidebar-primary`, `--sidebar-ring` | `AppShell.tsx:144-151` |
| `accentColor` writes `--accent`, `--accent-foreground` | `AppShell.tsx:172-176` |
| those are Shadcn tokens carried as `H S% L%` and consumed via `hsl(var(--x))` | `packages/components/src/index.css:18-48` (Tailwind 4 `@theme`, e.g. `--color-primary: hsl(var(--primary))` at `:31`), values at `:77-114` / `:160-193` |
| six-digit hex only, leading `#` optional, shorthand rejected, unparseable value silently ignored | regex `AppShell.tsx:44`, guarded by `if (effective)` at `:136` |
| dark mode uses a lighter variant of the same hue, re-applied on `dark`-class change | `hexToDarkModeHSL` `:85-94`, selected `:135` / `:167`, `MutationObserver` `:190-198` |
| `favicon` overwrites an existing icon link's `href` and never creates one | `AppShell.tsx:201-207` (`if (link)`) |
| `title` is assigned to `document.title` verbatim, caller composes the whole string | `AppShell.tsx:210-212`; the console composes it at `packages/app-shell/src/layout/ConsoleLayout.tsx:174-176` |
| properties act on the document and are removed on unmount | `AppShell.tsx:122`, cleanup `:214-227` |
| `rightRail` is a bare flex sibling of `SidebarInset`; caller owns its width | `AppShell.tsx:251-260` (no wrapper around it); the real consumer owns a resizable width in `packages/app-shell/src/layout/ChatDock.tsx` |
| post-removal field list has no `logo` | `AppShell.tsx:12-21`; feed literal `packages/layout/src/AppSchemaRenderer.tsx:579-582` |

Two aliases the hook also writes — `--brand-primary` / `--brand-accent` and their `-hsl` twins — are deliberately **not** documented: nothing in this repo reads them and the source calls them backward-compat. Filed separately as #6871 rather than taught here.

## Verification (all on `1274f61`, the final commit)

Gates, each quoting its own verdict line:

- `check:doc-snippets` — `Every covered documentation snippet compiles against the built types.` (267 of 267 blocks judged, 0 failed; run after building the gate's own `--build-filter` closure, 32 turbo tasks)
- `check:doc-types` — `Every documented component type is registered.`
- `check:doc-fences` — `every TypeScript block in 223 document(s) is fenced ts/tsx/typescript…`
- `check:control-bytes` — `OK (scanned 5727 tracked text file(s); skipped 85 binary)`
- `check:docs-route-closure` — `gauge: 1355 modules crawled from 148 route roots…`
- `docs:check-links` — `Links are valid across 17 scan roots.`
- `check-changeset-presence` — `No source of a released package changed in this range, so no changeset is owed.` (an explicit no-release changeset is included anyway, the empty-frontmatter form)

The four vitest files that read this page: `Test Files 4 passed (4)` / `Tests 34 passed (34)` — `app-shell-docs-nav-example.test.ts` (owns the `AppShellProps` parity pin), `readme-app-shell-example.test.ts`, `guide-layout-app-shell-doc.test.ts`, `guide-layout-sidebar-nav-doc.test.ts`.

**Declared narrowing:** the repo-wide `pnpm lint` was not run, and it cannot change the verdict for this diff. Asked eslint itself rather than guessing the population — `eslint --no-inline-config --format json` on both changed paths returns `File ignored because no matching configuration was supplied` for each, so 0 of 2 changed files are in eslint's matched set. The diff contains no `.ts`/`.tsx` and no config change, so it cannot move any untouched file's verdict either.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_