### PR TITLE
Build useETagCache's config object once per hook instance, not once per render

### DIFF
--- a/.changeset/6817-usetagcache-config-alloc.md
+++ b/.changeset/6817-usetagcache-config-alloc.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/react': patch
+---
+
+`useETagCache` builds its config object once per hook instance instead of once
+per render (objectui#6817).
+
+`useRef({ enabled, storage, storagePrefix, maxEntries, ttl })` evaluated that
+literal on **every** render and kept only the first result, so every later
+render allocated a five-key object that was discarded. It now comes from a
+`useMemo` keyed on the five values, which is also what the ref's
+`useInsertionEffect` write publishes.
+
+`patch`, not `minor`: nothing a published consumer can observe changes. The
+public shape, the returned callbacks' identities and the values the stable
+`[]`-deps callbacks read off the ref are all unchanged — the object's identity
+is private to the hook, so the only difference is the allocation that no longer
+happens. Same pattern PR objectui#6796 repaired in `useSchemaPersistence`; this
+is the half of that class the `react-hooks/refs` rule structurally cannot see,
+which is why it needed a test rather than a lint fix.

--- a/packages/react/src/hooks/__tests__/useETagCache.configAlloc.test.tsx
+++ b/packages/react/src/hooks/__tests__/useETagCache.configAlloc.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * ObjectUI — useETagCache config-object allocation pin (objectui#6817)
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * `useETagCache` seeded its config ref with an inline object literal:
+ *
+ *   const configRef = useRef({ enabled, storage, storagePrefix, maxEntries, ttl });
+ *
+ * `useRef` evaluates that argument on EVERY render and keeps only the first
+ * result, so every later render allocated a five-key object that was thrown
+ * away. It is the same shape PR objectui#6796 repaired in `useSchemaPersistence`
+ * (`useRef(createLocalStorageAdapter())`), with one difference that is the whole
+ * reason this needed its own card: clearing that one's `react-hooks/refs`
+ * warning REQUIRED the change, and clearing this one's did not — so the lint
+ * rule structurally cannot see this half of the class, and only a test can.
+ *
+ * ## Why this file mocks `useRef`
+ *
+ * The config object is private to the hook: nothing exports it, no in-repo
+ * consumer renders the hook (`packages/react/src/hooks/index.ts` exports it and
+ * nothing else calls it), and its identity is deliberately invisible from the
+ * outside. So "an object was allocated and discarded" has exactly one external
+ * observation point — the value handed to `useRef` on each render. The wrapper
+ * below records that argument and delegates to the real `useRef`, so the hook
+ * still runs on genuine React.
+ *
+ * The pins come in pairs on purpose. Pin 1 fails on the old code (three renders
+ * hand `useRef` three different objects). Pins 2a-2e pass on BOTH the old and
+ * the new code, and exist to stop the over-fix: memoizing on `[]` would make
+ * pin 1 pass while freezing the config at its first render — a semantics break
+ * the timing pins in `useETagCache.configTiming.test.tsx` would then catch, but
+ * these say it in the same file as the claim they qualify.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useETagCache, type ETagCacheConfig } from '../useETagCache';
+
+const { seeds } = vi.hoisted(() => ({ seeds: [] as unknown[] }));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  const useRef = (initialValue: unknown) => {
+    seeds.push(initialValue);
+    return (actual.useRef as (v: unknown) => unknown)(initialValue);
+  };
+  return { ...actual, useRef } as unknown as typeof import('react');
+});
+
+/** The five keys the hook keeps in its config ref, per useETagCache.ts. */
+const CONFIG_KEYS = ['enabled', 'storage', 'storagePrefix', 'maxEntries', 'ttl'] as const;
+
+type ConfigSeed = Record<(typeof CONFIG_KEYS)[number], unknown>;
+
+/**
+ * Every `useRef` seed recorded so far that has the config shape. The filter
+ * matters: the recorder sees every `useRef` call in the rendered tree, not just
+ * this hook's, so an unrelated ref elsewhere must not be counted as a config
+ * allocation (and must not be able to mask one either).
+ */
+function configSeeds(): ConfigSeed[] {
+  return seeds.filter(
+    (value): value is ConfigSeed =>
+      typeof value === 'object' &&
+      value !== null &&
+      CONFIG_KEYS.every((key) => key in (value as Record<string, unknown>)),
+  );
+}
+
+beforeEach(() => {
+  seeds.length = 0;
+});
+
+describe('useETagCache — the config object is built once per hook instance (#6817)', () => {
+  // ---- pin 1: THE DEFECT — red before the repair, green after ---------------
+  it('hands useRef the same config object on every render when nothing changed', () => {
+    const { rerender } = renderHook(
+      ({ ttl }: { ttl: number }) => useETagCache({ ttl, storagePrefix: 'alloc-pin' }),
+      { initialProps: { ttl: 1_000 } },
+    );
+
+    rerender({ ttl: 1_000 });
+    rerender({ ttl: 1_000 });
+
+    const seen = configSeeds();
+    // Three renders must have reached the ref seed, or this pin is measuring
+    // nothing and the identity assertion below would pass vacuously.
+    expect(seen.length).toBe(3);
+    expect(seen[1]).toBe(seen[0]);
+    expect(seen[2]).toBe(seen[0]);
+    expect(new Set(seen).size).toBe(1);
+  });
+
+  // ---- pin 2: NOT an over-fix — a real config change still allocates --------
+  // `useMemo(..., [])` would satisfy pin 1 and freeze the config at its first
+  // render. One case per key, so a dependency list missing any single one of
+  // the five fails here rather than in a consumer.
+  const changes: Array<{ key: string; before: ETagCacheConfig; after: ETagCacheConfig }> = [
+    { key: 'enabled', before: { enabled: true }, after: { enabled: false } },
+    { key: 'storage', before: { storage: 'memory' }, after: { storage: 'localStorage' } },
+    { key: 'storagePrefix', before: { storagePrefix: 'p-a' }, after: { storagePrefix: 'p-b' } },
+    { key: 'maxEntries', before: { maxEntries: 10 }, after: { maxEntries: 20 } },
+    { key: 'ttl', before: { ttl: 1_000 }, after: { ttl: 2_000 } },
+  ];
+
+  for (const { key, before, after } of changes) {
+    it(`builds a fresh config carrying the new value when \`${key}\` changes`, () => {
+      const { rerender } = renderHook(
+        ({ config }: { config: ETagCacheConfig }) => useETagCache(config),
+        { initialProps: { config: before } },
+      );
+
+      rerender({ config: after });
+
+      const seen = configSeeds();
+      expect(seen.length).toBe(2);
+      expect(seen[1]).not.toBe(seen[0]);
+      expect(seen[0][key as keyof ConfigSeed]).toBe(before[key as keyof ETagCacheConfig]);
+      expect(seen[1][key as keyof ConfigSeed]).toBe(after[key as keyof ETagCacheConfig]);
+    });
+  }
+
+  // ---- pin 3: the recorder is real ----------------------------------------
+  // If the `vi.mock` above ever stopped intercepting, every pin here would go
+  // vacuously green on an empty `seeds` array except for the length assertions.
+  // This states the same guarantee once, directly.
+  it('records a config seed at all (the useRef interception is live)', () => {
+    renderHook(() => useETagCache({ storagePrefix: 'recorder-probe' }));
+
+    const seen = configSeeds();
+    expect(seen.length).toBe(1);
+    expect(seen[0].storagePrefix).toBe('recorder-probe');
+  });
+});

--- a/packages/react/src/hooks/useETagCache.ts
+++ b/packages/react/src/hooks/useETagCache.ts
@@ -208,9 +208,23 @@ export function useETagCache(userConfig: ETagCacheConfig = {}): ETagCacheResult 
   // every layout effect, ref attachment and paint, so the sole window deferred
   // is the render phase — where `fetchWithETag` / `clearCache` and the other
   // side effects are not callable anyway.
-  const configRef = useRef({ enabled, storage, storagePrefix, maxEntries, ttl });
+  //
+  // The object itself is built by `useMemo` rather than inline at the two
+  // places that consume it. `useRef({ ... })` evaluates its argument on EVERY
+  // render and keeps only the first result, so every later render allocated a
+  // five-key object that was thrown away (objectui#6817) — the same shape PR
+  // objectui#6796 repaired in `useSchemaPersistence`. Its identity is
+  // unobservable from outside the hook: the ref is private and every reader
+  // only reads fields off `.current`, so a memo React chooses to discard is
+  // harmless — it rebuilds an equal object, which is what every render used
+  // to do unconditionally.
+  const config = useMemo(
+    () => ({ enabled, storage, storagePrefix, maxEntries, ttl }),
+    [enabled, storage, storagePrefix, maxEntries, ttl],
+  );
+  const configRef = useRef(config);
   useInsertionEffect(() => {
-    configRef.current = { enabled, storage, storagePrefix, maxEntries, ttl };
+    configRef.current = config;
   });
 
   // Hydrate memory cache from localStorage on mount


### PR DESCRIPTION
Fixes #6817

`useETagCache` seeded its config ref with an inline object literal:

```ts
const configRef = useRef({ enabled, storage, storagePrefix, maxEntries, ttl });
```

`useRef` evaluates that argument on **every** render and reads it only to seed
the initial value, so every render after the first allocated a five-key object
that was thrown away — in every component using the hook, forever, to no effect.

This is the same pattern PR #6796 repaired in `useSchemaPersistence`
(`useRef(createLocalStorageAdapter())`), and it takes the same shape that one
used: hoist the value into a `useMemo` and hand the variable to `useRef`. The
difference that earned this its own card is that clearing the
`react-hooks/refs` warning *required* the change there and does not here — so
this is the half of that class the lint rule structurally cannot see. The rule
is left alone deliberately: widening it is a gate change with its own
population, and the card does not ask for it.

## What changed

`packages/react/src/hooks/useETagCache.ts` — the five resolved values now come
from a `useMemo` keyed on all five, which is also what the ref's
`useInsertionEffect` write publishes. The ref, its readers and the insertion
effect's scheduling are untouched.

Nothing observable moves. The object's identity is private to the hook: nothing
exports it, and every reader (`isExpired`, `setEntry`, `removeEntry`,
`clearCache`, `fetchWithETag`) reads fields off `configRef.current`. The
returned callbacks keep their `[]` deps and their identities. A memo React
chooses to discard is harmless — it rebuilds an equal object, which is exactly
what every render used to do unconditionally.

## The verification problem, and how it was answered

`useETagCache` has **zero in-repo consumers**, so there is no call site to
regress and no existing test that would notice either way. A green suite proves
nothing here on its own — the whole burden is on showing the allocation really
changed.

`packages/react/src/hooks/__tests__/useETagCache.configAlloc.test.tsx` measures
it directly. The config object has exactly one external observation point: the
argument handed to `useRef` on each render. The file wraps `useRef` (delegating
to the real one, so the hook still runs on genuine React) and records that
argument.

- **Pin 1 — the defect.** Three renders with unchanged config must hand `useRef`
  the same object. Measured **red on untouched `origin/main`** before the fix
  was written, then green after it, assertion unchanged.
- **Pins 2a-2e — not an over-fix.** `useMemo` on an empty dependency list would
  satisfy pin 1 while freezing the config at its first render. One case per key
  requires a fresh object *carrying the new value* when that key changes, so a
  dependency list missing any one of the five fails here.
- **Pin 3 — the recorder is live.** Without it, an interception that stopped
  working would let the identity pins pass on an empty array.
- **Behaviour unchanged** is carried by the existing
  `useETagCache.configTiming.test.tsx`, untouched and still green: the newest
  config reaches the stable callbacks, it is in place before a child layout
  effect of the same commit, callback identity survives config changes, and
  `isExpired` judges against the latest `ttl`.

### Evidence

Suite, `pnpm exec vitest run packages/react/src` from the repo root (the
canonical invocation the config guard demands):

| | Test Files | Tests |
|:--|:--|:--|
| before, at `a04d7c6` | 66 passed (66) | 819 passed (819) |
| after, at `0cb48f9` | 67 passed (67) | **826 passed (826)** |

Plus one file and seven tests, which is exactly the new pin file; no other file
moved.

**Red-first, on the untouched source:**

```
AssertionError: expected { enabled: true, …(4) } to be { enabled: true, …(4) } // Object.is equality
 ❯ packages/react/src/hooks/__tests__/useETagCache.configAlloc.test.tsx:89:21
Tests  1 failed | 6 passed (7)
```

"Compared values have no visual difference" is the defect stated precisely:
equal content, different identity.

**Reverse-verified from the commit, prediction stated first.** Reverting only
`useETagCache.ts` to `a04d7c6` and leaving the pin untouched was predicted to
fail at line 89 with that same `Object.is` message, 1 failed / 6 passed. That
is what happened. The mutation was proven on disk before the run
(`hash-object` = `f1cf647e`, old literal present once, new form absent), and
the restore proven byte-exact after it: `hash-object` = `496af5bf` =
`git rev-parse HEAD:packages/react/src/hooks/useETagCache.ts`, and
`git diff HEAD` empty. The script carried an EXIT/INT/TERM trap using absolute
paths. No build step is involved on either leg: the pin imports the hook by a
relative source specifier, so it reads the source file itself and no `dist`
can go stale under it.

**Type-check** — `pnpm --filter @object-ui/react type-check`, echoing
`tsc --noEmit && tsc -p tsconfig.test.json`, exit 0 after building the
dependency closure. `--listFiles` confirms this is a real reading and not a
zero-match green: the source file appears in the `tsconfig.json` program and
both test files appear in the `tsconfig.test.json` program.

**Lint** — the affected package's own `eslint .`, exit 0, **132 files in
eslint's own reported population** (`--format json`), 0 errors. All three
touched files are in that population. `useETagCache.ts` carries exactly one
warning before and after — `react-hooks/set-state-in-effect`, at line 227 on
`origin/main` and line 241 here, the same pre-existing `setCacheSize` call in
the mount hydration effect, shifted by the added comment. The new test file
carries 0.

*Narrowing declared:* repo lint is `turbo run lint` over every package; this ran
the affected package only. `eslint.config.js` configures no type-aware linting
(no `parserOptions.project`, no `projectService`), so a diff confined to
`packages/react` cannot move the verdict on a file outside it. CI runs the full
farm regardless.

**Gates** — `pnpm changeset:check` (`No changeset declares a major bump`),
`pnpm check:control-bytes` (`OK (scanned 5737 tracked text file(s))`), and
`pnpm check:vi-mock-specifiers` (`OK (... 498 carry a mock ...)`, up from 497,
so the new mock is inside the scan and not skipped). All at `0cb48f9`.

## Changeset

`patch` on `@object-ui/react`. Nothing a published consumer can observe changes
— public shape, callback identities and the values read off the ref are all the
same, and the only difference is an allocation that no longer happens. Not
`minor`: there is no new capability. Not `major`, per the fixed-group rule.

## Scope

One card, one defect. #6818 is not addressed here — it is a stale-closure logic
gap, a different defect in the same directory, and it keeps its own card.
`useSchemaPersistence` is not touched; PR #6796 already repaired it.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_