### PR TITLE
test(app-shell): pin the form-view option element's narrowings, per the 2026-08-28 ruling

### DIFF
--- a/.changeset/olive-donkeys-scream.md
+++ b/.changeset/olive-donkeys-scream.md
@@ -1,0 +1,7 @@
+---
+---
+
+Pin the form-view option element's two narrowings (objectui#6263): a per-option `default`
+written on a metadata-admin form field stays refused at the type level, and the re-pointed
+`visibleWhen` still refuses the spec's `dialect`-only envelope. Type-level pins plus a
+tombstone comment recording the 2026-08-28 ruling; no published behaviour changes.

--- a/packages/app-shell/src/views/metadata-admin/form-spec.containers.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/form-spec.containers.test.tsx
@@ -33,7 +33,11 @@
  *     re-hand-writing either declaration fails here the day the spec moves,
  *     rather than years later when someone reads two files side by side. Each
  *     narrowing has a matching negative pin, so "derived" can never quietly
- *     become "widened to whatever the spec says".
+ *     become "widened to whatever the spec says". PIN I extends that promise
+ *     down one level, to the LEAF's option element (objectui#6263): its two
+ *     narrowings — `visibleWhen` re-pointed, `default` dropped — were the last
+ *     ones resting on a comment alone, and `default` is the one a maintainer
+ *     actually ruled on.
  *   • **vitest** — the render block. The widening this convergence performs is
  *     asserted INERT and, for `columns`, load-bearing: a section that spells its
  *     column count as the string `'3'` — legal metadata `FormSectionSchema`
@@ -44,6 +48,7 @@
 
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
+import type { SelectOption } from '@objectstack/spec/data';
 import type { FormSection, FormView } from '@objectstack/spec/ui';
 import { SchemaForm } from './SchemaForm';
 import type { FormFieldSpec, FormSectionSpec, FormViewSpec } from './form-spec';
@@ -211,6 +216,67 @@ export function formContainerContractPins(): void {
     label: 'Contact us',
   };
   void viewHasNoLabel;
+
+  // ── PIN I — the OPTION-ELEMENT narrowings, objectui#6263. The leaf's option
+  // element is `Omit<SelectOption, 'visibleWhen' | 'default'>` plus a re-pointed
+  // predicate (form-spec.ts), and until now NOTHING failed if either name left
+  // that `Omit` list: PIN G covers the section/view narrowings, the option
+  // element had no negative pin at all. So the one narrowing a maintainer
+  // actually ruled on rested on a comment.
+  //
+  // The ruling (2026-08-28, on objectstack#12868, executed upstream by
+  // objectstack PR #13033): the FORM-VIEW option vocabulary does not accept a
+  // per-option `default`. The pre-selected choice is declared on the OBJECT
+  // definition — the field's `defaultValue`, or the object option's own
+  // `default: true`, which the engine honours on the insert path
+  // (objectstack#7246, PR #7388, ruled `enforce`). Re-admitting the key here
+  // would give this surface a second default contract, which that same ruling
+  // says it must not have.
+  type OptionElement = NonNullable<FormFieldSpec['options']>[number];
+
+  const optionRefusesDefault: OptionElement = {
+    label: 'Open',
+    value: 'open',
+    // @ts-expect-error objectui#6263 — per-option `default` is not part of the
+    // form-view option vocabulary. Declare the pre-selected choice on the
+    // object definition instead.
+    default: true,
+  };
+  void optionRefusesDefault;
+
+  const optionNarrowsPredicate: OptionElement = {
+    label: 'Open',
+    value: 'open',
+    // @ts-expect-error narrowed to `VisibilityPredicate`, exactly as PIN G's
+    // section-level twin: `source` is REQUIRED here because that is what
+    // `evalFieldPredicate` reads, while the spec's `ExpressionInput` also
+    // admits a `dialect`-only / `ast`-only envelope no evaluator consumes.
+    visibleWhen: { dialect: 'cel' },
+  };
+  void optionNarrowsPredicate;
+
+  // Positive control for the two refusals above: this position still ACCEPTS
+  // every key it does declare. Without it, a collapsed element type (`never`,
+  // or an `Omit` that ate the whole shape) would satisfy both `@ts-expect-error`
+  // lines and read as a narrowing that is really a hole.
+  const optionAcceptsDeclaredKeys: OptionElement = {
+    label: 'Open',
+    value: 'open',
+    color: '#3B82F6',
+    visibleWhen: 'record.stage == "won"',
+  };
+  void optionAcceptsDeclaredKeys;
+
+  // Control that PIN I measures a NARROWING and not an ABSENCE, and the reason
+  // it is worth a line: `SelectOption` is shared by two surfaces and only this
+  // one drops the key. If the spec ever retired `default` outright — which
+  // would revert the ruled, implemented, pinned object-field behaviour — the
+  // expect-error above would still fire, for a reason that is not this card's,
+  // and PIN I would go on passing while the thing it guards was gone.
+  const defaultIsStillASharedSpecOptionKey: Assert<
+    'default' extends keyof SelectOption ? true : false
+  > = true;
+  void defaultIsStillASharedSpecOptionKey;
 }
 
 const schema = {

--- a/packages/app-shell/src/views/metadata-admin/form-spec.ts
+++ b/packages/app-shell/src/views/metadata-admin/form-spec.ts
@@ -133,8 +133,27 @@ export interface FormFieldSpec {
    *     it: none of the three controls that consume `options` seeds a value
    *     from it, so declaring it here would advertise an authoring key this
    *     renderer does not honour — the very shape the `visibleWhen` half of
-   *     this comment exists to close. Tracked separately as objectui#6263;
-   *     honouring it is that card's decision, not a free widening here.
+   *     this comment exists to close.
+   *
+   *     ⚠️ RULED 2026-08-28 (objectui#6263 / objectstack#12868, executed
+   *     upstream by objectstack PR #13033), so this is no longer an open
+   *     question this file is holding open: the FORM-VIEW option vocabulary
+   *     does not accept a per-option `default`, and the drop above is now the
+   *     ruled shape rather than a pending decision. **Where the pre-selected
+   *     choice IS declared:** on the OBJECT definition — the field's
+   *     `defaultValue`, or the object option's own `default: true`, which the
+   *     engine honours on the insert path (`applyFieldDefaults` falls back to
+   *     the option marked `default: true` when the field declares no
+   *     `defaultValue`; `defaultValue` wins when both are declared —
+   *     objectstack#7246, ruled `enforce`, PR #7388). That is why
+   *     `SelectOptionSchema` still carries the key and only this reference site
+   *     narrows it: one surface honours it, this one deliberately does not, and
+   *     a second default contract here is what the 2026-08-10 ruling's objectui
+   *     rider told the console not to grow.
+   *
+   *     ⛔ Removing `'default'` from the `Omit` below re-admits it. That is now
+   *     a `tsc` failure, not a code-review question: PIN I in
+   *     `form-spec.containers.test.tsx`.
    */
   options?: Array<
     Omit<SelectOption, 'visibleWhen' | 'default'> & { visibleWhen?: VisibilityPredicate }


### PR DESCRIPTION
Part of #6263

⚠️ Deliberately `Part of`, not a closing keyword. The card's deliverable is the
**re-verification**, and the re-verification came back with a correction the card should
close *on the record of*, not silently on this merge. See "What this does not close".

Generic-type spellings in this body use parentheses — `Omit(A, 'k')` — rather than angle
brackets, because the body sanitizer eats short angle-bracket fragments.

## What this is

objectstack#12868 wrote its own downstream action: *"when this lands, re-verify on the
merged ref — the ui-side derived type already tombstones the key (objectui PR #6618), so
the residual ui work is likely nil and that card closes on verification."*

The re-verification is below. The residual **is** nil, and this PR is the pin that makes
it stay nil, plus the tombstone prose the 2026-08-28 ruling asked for. No source change,
no runtime change, no published behaviour change.

## The measurements

**1 — Which spec is actually resolved, read from the built dist.**
`@objectstack/spec@17.2.0`, resolved identically by `packages/types`, `packages/app-shell`,
`packages/core` and `packages/react`. objectstack PR #13033's narrowing is **NOT in it**:
`FormSelectOptionSchema` is absent from the dist's `ui` entry, and
`FormFieldBaseSchema.options` is still `z.array(SelectOptionSchema)` — the full five-key
vocabulary. It is not merely un-bumped, it is **unpublished**: the npm registry's
`dist-tags.latest` for `@objectstack/spec` is `17.2.0`.

**2 — Does the form-view surface still accept a per-option `default`? Both levels answered,
and they disagree — which is the split this card family is about.**

| level | instrument | reading |
| --- | --- | --- |
| runtime parse door (spec `FormViewSchema.safeParse` @17.2.0) | zod | **ACCEPTED** — parsed option keys `default,label,value` |
| type level (`FormFieldSpec.options`' element) | `tsc` | **REFUSED** — TS2353, `'default' does not exist in type` |

Both readings carry a control that must hit, run in the same query:

- runtime control: the same parse with an undeclared key `zzz_not_a_key` is **REFUSED**
  (`invalid_union@sections.0.fields.0`), and the sibling declared key `visibleWhen` is
  **ACCEPTED** — so the acceptance of `default` is a real declaration, not passthrough.
- type control: an undeclared key `zzz_not_a_key` on the same position is **also TS2353** —
  excess-property checking is live there, so the refusal of `default` is a narrowing and
  not a collapsed type. `color` and a string `visibleWhen` compile clean.

The `tsc` diagnostic prints the resolved type and settles who does the dropping:
`Omit({ label; value; color?; default?; visibleWhen? }, "default" | "visibleWhen") & ...` —
the source `SelectOption` **still carries** `default`, and objectui's own `Omit` is what
removes it. The tombstone is this repo's, not an inherited narrowing.

**3 — Corpus census, one instrument over one population, with positive controls.**
There are **zero** `*.form.ts` files in this repo, so the census ran over the equivalent
authoring sites: every `options:` array literal in every git-tracked `.ts` / `.tsx` /
`.json` (dist excluded), read through the TypeScript AST, plus a recursive JSON walk.

```
FILES SCANNED: 4526        options: ARRAY LITERALS: 331        OPTION LITERALS: 615

  615  value          === POSITIVE CONTROL
  610  label          === POSITIVE CONTROL
   45  visibleWhen
   34  color
    3  disabled
    3  description
    2  icon
    1  type
    1  default        === SUBJECT
```

The single `default` hit is
`packages/components/src/__tests__/metadata-viewer.test.tsx:42` — a `TASK_OBJECT.fields.status.options`
fixture, i.e. the **object-field face**, which is ruled `enforce` (objectstack#7246, PR #7388)
and is this card's red line. Form-view sites writing the key: **0**.

**4 — Is there a reader?** One, and it is on the enforced face:
`packages/components/src/renderers/basic/metadata-viewer.tsx:148` reads an object
definition's option `default` to pick a state machine's initial state. Nothing on the
form-view path reads it — consistent with the 2026-08-10 rider that the console needs no
second default contract.

## What this PR changes

**PIN I** in `form-spec.containers.test.tsx`. That file's header already promised that
"each narrowing has a matching negative pin"; the leaf's **option element** was the one
position where that was not true. PIN G covers the section/view narrowings, and the option
element — whose `Omit` list carries the only narrowing a maintainer actually ruled on — had
no negative pin at all. Removing `'default'` from that list was a silent widening.

PIN I asserts four things, three of them controls:

- `default: true` on the option element is refused;
- `visibleWhen: { dialect: 'cel' }` is refused (the re-pointed predicate needs `source`),
  the sibling narrowing in the same `Omit`;
- every key the position **does** declare still compiles — so a collapsed element type
  cannot satisfy the two `@ts-expect-error` lines and read as a narrowing;
- `'default'` is still a key of the spec's shared `SelectOption`. This is the control that
  makes PIN I measure a **narrowing** and not an **absence**: if the key were ever retired
  outright — reverting the ruled, implemented, pinned object-field behaviour — the
  expect-error would still fire, for a reason that is not this card's, and PIN I would go
  on passing while the thing it guards was gone.

And the tombstone comment in `form-spec.ts` moves from "tracked separately as objectui#6263,
that card's decision" to the decision itself, naming where a pre-selected choice **is**
declared: the object definition's field `defaultValue`, or the object option's own
`default: true`.

## Verification

Anchored at `ae160b2b`, the final commit; `git status` clean at the time of each run. Heavy
runs went through the shared verify lock; every verdict below is the tool's own line.

- **type-check** — `pnpm --filter @object-ui/app-shell run type-check`, script echoed as
  `> @object-ui/app-shell@17.6.0 type-check` running `tsc --noEmit && tsc -p tsconfig.test.json`
  (so this is not a zero-match false green). `VERDICT command-exit 0`.
- **lint** — `pnpm --filter @object-ui/app-shell run lint`, whole package, not narrowed:
  `✖ 2798 problems (0 errors, 2798 warnings)`. Both changed files confirmed present in
  eslint's own reported population via `--format json` (2 files reported, 0 errors and
  0 warnings each).
- **vitest** — `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/` plus every
  other importer of `form-spec` (`apps/console/src/components/FormPage.fieldSpec.test.ts`,
  `scripts/__tests__/one-authority-per-exported-name-6273.test.ts`):
  `Test Files 220 passed (220)`, `Tests 2302 passed | 1 skipped (2303)`.
  Before/after on the pin file itself: `Tests 2 passed (2)` → `Tests 2 passed (2)`, unchanged
  and expected — PIN I lives in `formContainerContractPins()`, which never runs; `tsc` is the
  instrument, exactly as that file's header says.
- **gates** — `check:control-bytes` OK (5735 files), `check:spec-symbols` OK,
  `check:phantom-deps` OK, `check:self-import` OK, `check:vi-mock-specifiers` OK,
  `check:esm-specifiers` OK, `check-changeset-presence` ✅ (empty frontmatter, declared as
  releasing nothing), `check-changeset-no-major` ✅, `check-changeset-fixed` ✅.

**Reverse verification of PIN I** — predicted direction stated before the run: dropping
`'default'` from the `Omit` makes the expect-error unnecessary, so the failure is
**TS2578**, not a type error. Mutation confirmed on disk before reading anything (anchor
census `1 → 0` for the removed text and `0 → 1` for the injected text, plus the diff hunk).
Observed:

```
mutated-leg exit: 2
src/views/metadata-admin/form-spec.containers.test.tsx(240,5): error TS2578: Unused '@ts-expect-error' directive.
```

Line 240 is PIN I's `default` directive — which also proves that project actually compiles
this file, so the green above is a measurement and not a NOT-MEASURED. Restore proven
byte-exact: `hash-object` `9df80695…` equals `rev-parse HEAD:path` `9df80695…`, and
`git diff HEAD` for the file is empty. The script carried a `trap … EXIT INT TERM` with
absolute paths.

## What this does not close

The composite defect the card describes — *a per-option `default` written on a form view
parses clean* — is **still true on this tree**, because the ruled narrowing lives in
`@objectstack/spec` and that release has not shipped. objectstack#12868 is closed and its
PR merged, so nothing is owed on that side either; the gap is a release train, not work.

No objectui change is warranted for it: every package's range is `^17.0.0` / `^17.2.0`, so
the narrowing arrives on its own the next time the lockfile resolves a spec that has it.
Recorded here so that closing #6263 on this verification does not bury the fact.

⛔ Untouched, deliberately: the object-field face, the alias table, and `SelectOptionSchema`
itself. `packages/types/src/**` is untouched too — it was the card's originally declared
surface, and it turned out to be the wrong address (it is the SDUI component protocol held
in key-parity with the spec, and its `default` has a live reader on the enforced face). The
surface amendment was posted on #6263 before the first edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_