### PR TITLE
fix(plugin-form): declare WizardStepConfig independently of FormSectionConfig

### DIFF
--- a/.changeset/6237-wizard-step-config-split.md
+++ b/.changeset/6237-wizard-step-config-split.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/plugin-form': patch
+---
+
+Split `WizardStepConfig` off `FormSectionConfig`, and correct the section-predicate
+support table (objectui#6237, maintainer ruling 2026-08-30).
+
+`WizardForm` typed its steps as `Omit<FormSectionConfig, 'visibleWhen'>` — a
+subtraction from the TabbedForm section type, which is the predicate-CARRYING
+type. That defended the one key it named and left the mechanism open: every key
+added to `FormSectionConfig` reached a wizard step by default, so the next
+predicate in the same family (`readonlyWhen` / `requiredWhen`, already this
+package's field-level vocabulary) would have handed the wizard a silent slot its
+renderer does not read — the declared-but-unenforced shape the ruling split the
+types to stop.
+
+`WizardStepConfig` is now declared independently in `WizardForm.tsx`, which is
+simply what `SplitFormSectionConfig`, `ModalFormSectionConfig` and
+`DrawerFormSectionConfig` already do: each layout owns its group shape, documents
+`className` / `gridClassName` in its own terms, and declares `visibleWhen` only
+where its renderer honours it. The derivation flips from subtractive to additive
+— a key is authorable on a wizard step only if someone writes it there.
+
+No behaviour change and no key added or removed: `WizardStepConfig` exports the
+same key set it already had, and `visibleWhen` on a wizard step literal was, and
+remains, a compile error. What is new is that it stays one for the whole
+predicate family, pinned by a type-level assertion that fails the build if any
+`*When` key ever appears on the step type.
+
+Documentation repair in the same stroke: the support table in the README and in
+`content/docs/plugins/plugin-form.mdx` still said `formType: 'tabbed'` sections
+drop the predicate. That stopped being true when the tabbed arm landed — the row
+now reads **Yes**, the surrounding prose no longer claims two inert arms or a
+diagnostic that fires for `tabbed`, and the wizard row stays **No**, which is
+still exactly true.

--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -184,9 +184,9 @@ inactive tab unmount along with its values).
 - Fields no tab claims render above the tab strip rather than disappearing.
 - Needs at least two tabs; ignored when the form uses `children`.
 
-`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` build on this. Of the
-two, only `ModalForm` forwards a section's `visibleWhen` onto its tab — see the
-support table at the end of the next section.
+`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` build on this, and both
+forward a section's `visibleWhen` onto the tab they synthesise — see the support
+table at the end of the next section.
 
 #### Conditional tabs (`FormFieldTab.visibleWhen`)
 
@@ -243,28 +243,36 @@ and only where the renderer actually evaluates it:
 | --- | --- |
 | `type: 'form'` with `fieldTabs[].visibleWhen` (as above) | **Yes** — evaluated by the form renderer |
 | `ModalForm` / `formType: 'modal'` with `contentLayout: 'tabbed'` | **Yes** — the section's `visibleWhen` is copied onto its tab |
-| `TabbedForm` / `formType: 'tabbed'` sections | **No** — a section `visibleWhen` is dropped before the renderer sees it; the tab always renders |
+| `TabbedForm` / `formType: 'tabbed'` sections | **Yes** — the section's `visibleWhen` is copied onto the tab `TabbedForm` synthesises; a single-section form, which draws no tab strip, gates the group through the flat layout's own section-divider mechanism instead |
 | `WizardForm` / `formType: 'wizard'` steps | **No** — steps are not tabs; nothing evaluates a step-level predicate |
 
-The two **No** rows are deliberate, not oversights: declaring the key on a
+The remaining **No** row is deliberate, not an oversight: declaring the key on a
 surface whose renderer ignores it would make the metadata lie (objectui#6111),
-so the key stops at the boundary until each surface enforces it. Track
-objectui#6237 for both.
+so the key stops at the boundary until each surface enforces it.
 
-Both **No** rows now **report themselves** rather than failing silently. Authoring
-a section `visibleWhen` on `formType: 'tabbed'` or `formType: 'wizard'` logs a
-console warning naming the layout and the sections whose predicate is being
-dropped:
+⛔ **A wizard step has no predicate slot at all, and that is enforced by the
+type.** A step predicate is not the tab predicate under another name — steps are
+mounted one at a time and keyed by index, so a step predicate would be
+step-boundary reactive where a tab's is live-record reactive, and it would need
+navigation, indicator, `isLastStep`, final-gate and re-selection semantics that
+none of the tab machinery supplies. So `WizardStepConfig` is declared
+independently of `FormSectionConfig` (maintainer ruling 2026-08-30,
+objectui#6237) and simply does not carry the key: `visibleWhen` on a wizard step
+literal is a **compile error**, not a silently ignored key. Track objectui#6237
+for the step contract.
+
+That row also **reports itself** rather than failing silently — untyped JSON
+reaches the renderer too, so the compile-time half cannot be the only one.
+Authoring a section `visibleWhen` on `formType: 'wizard'` logs a console warning
+naming the layout and the sections whose predicate is being dropped:
 
 > `[ObjectForm] Section \`visibleWhen\` is not yet supported on this layout: the
-> \`tabbed\` layout's tabs drop the predicate, so section(s) pay render
+> \`wizard\` layout's steps drop the predicate, so section(s) pay render
 > unconditionally. …`
 
-This is an interim diagnostic, ruled 2026-08-29 alongside the decision to design
-the real repair as **one** section/group predicate contract shared by every layout
-arm instead of patching them one at a time. It changes no behaviour — the
-predicate is still dropped on those two arms — it only stops the drop from being
-invisible. Nothing warns on the four arms that honour the key.
+It changes no behaviour — the predicate is still dropped on that one arm — it
+only stops the drop from being invisible. Nothing warns on the five arms that
+honour the key.
 
 ### Wizard steps and `allowSkip`
 

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -406,9 +406,9 @@ the renderer distribute the fields:
 - Fields no tab claims render above the tab strip rather than disappearing.
 - Needs at least two tabs, and is ignored when the form uses `children`.
 
-`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` are built on this. Of
-the two, only `ModalForm` forwards a section's `visibleWhen` onto its tab — see
-the support table below.
+`ModalForm` (`contentLayout: 'tabbed'`) and `TabbedForm` are built on this, and
+both forward a section's `visibleWhen` onto the tab they synthesise — see the
+support table below.
 
 #### Conditional tabs (`FormFieldTab.visibleWhen`)
 
@@ -465,21 +465,29 @@ and only where the renderer actually evaluates it:
 | --- | --- |
 | `type: 'form'` with `fieldTabs[].visibleWhen` (as above) | **Yes** — evaluated by the form renderer |
 | `ModalForm` / `formType: 'modal'` with `contentLayout: 'tabbed'` | **Yes** — the section's `visibleWhen` is copied onto its tab |
-| `TabbedForm` / `formType: 'tabbed'` sections | **No** — a section `visibleWhen` is dropped before the renderer sees it; the tab always renders |
+| `TabbedForm` / `formType: 'tabbed'` sections | **Yes** — the section's `visibleWhen` is copied onto the tab `TabbedForm` synthesises; a single-section form, which draws no tab strip, gates the group through the flat layout's own section-divider mechanism instead |
 | `WizardForm` / `formType: 'wizard'` steps | **No** — steps are not tabs; nothing evaluates a step-level predicate |
 
-The two **No** rows are deliberate, not oversights: declaring the key on a
+The remaining **No** row is deliberate, not an oversight: declaring the key on a
 surface whose renderer ignores it would make the metadata lie (#6111), so the
-key stops at the boundary until each surface enforces it. Track #6237 for
-both.
+key stops at the boundary until each surface enforces it.
 
-Both **No** rows now **report themselves** rather than failing silently. Authoring
-a section `visibleWhen` on `formType: 'tabbed'` or `formType: 'wizard'` logs a
-console warning naming the layout and the sections whose predicate is being
-dropped. This is an interim diagnostic (ruled 2026-08-29, alongside the decision
-to design the real repair as **one** section/group predicate contract shared by
-every layout arm): it changes no behaviour, it only stops the drop from being
-invisible. Nothing warns on the four arms that honour the key.
+⛔ **A wizard step has no predicate slot at all, and that is enforced by the
+type.** A step predicate is not the tab predicate under another name — steps are
+mounted one at a time and keyed by index, so a step predicate would be
+step-boundary reactive where a tab's is live-record reactive, and it would need
+navigation, indicator, `isLastStep`, final-gate and re-selection semantics that
+none of the tab machinery supplies. So `WizardStepConfig` is declared
+independently of `FormSectionConfig` (maintainer ruling 2026-08-30, #6237) and
+simply does not carry the key: `visibleWhen` on a wizard step literal is a
+**compile error**, not a silently ignored key. Track #6237 for the step
+contract.
+
+That row also **reports itself** rather than failing silently. Authoring a
+section `visibleWhen` on `formType: 'wizard'` logs a console warning naming the
+layout and the sections whose predicate is being dropped — untyped JSON reaches
+the renderer too, so the compile-time half cannot be the only one. Nothing warns
+on the five arms that honour the key.
 
 ### Wizard steps and `allowSkip`
 

--- a/packages/plugin-form/src/TabbedForm.tsx
+++ b/packages/plugin-form/src/TabbedForm.tsx
@@ -70,11 +70,16 @@ export interface FormSectionConfig {
    * see the boundary note on `WizardStepConfig` and objectui#6237 for the
    * measured reason the server cannot read this predicate.
    *
-   * ⛔ Deliberately NOT on the wizard's step type. `WizardForm` used to borrow
-   * this very interface for its steps, and declaring the key on a type the
-   * wizard renderer never reads would manufacture the declared-but-unenforced
-   * shape this card family exists to close. `WizardStepConfig` omits it, so the
-   * key is writable exactly where it is honoured.
+   * ⛔ Deliberately NOT on the wizard's step type, and that boundary is now
+   * structural rather than subtractive (maintainer ruling 2026-08-30,
+   * objectui#6237). `WizardForm` used to type its steps as
+   * `Omit<FormSectionConfig, 'visibleWhen'>` — a derivation that defended the
+   * one key it named while every FUTURE key added here still reached a wizard
+   * step by default. `WizardStepConfig` is now declared independently, exactly
+   * as `SplitFormSectionConfig` / `ModalFormSectionConfig` /
+   * `DrawerFormSectionConfig` already are, so this type and the wizard's share
+   * nothing: a key is authorable on a wizard step only if someone writes it
+   * there, on the type whose renderer has to honour it.
    */
   visibleWhen?: string | { dialect?: string; source: string };
 

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -33,15 +33,37 @@ import {
 } from './submitRedirectNavigation';
 import { useOccSave } from './occSave';
 import { hasInlineFieldSource, noSubmitTargetError } from './submitTarget';
-import type { FormSectionConfig } from './TabbedForm';
 
 /**
- * A wizard STEP — the tabbed layout's section config minus its predicate slot
- * (objectui#6237).
+ * A wizard STEP — the wizard's OWN authored group shape (objectui#6237).
  *
- * The wizard borrows the tabbed arm's section shape because the two describe the
- * same authored thing: a named group of fields. It must NOT borrow the predicate
- * slot, and the omission is the enforcement, not a comment:
+ * ## Why this is declared here rather than derived from the tabbed layout
+ *
+ * It used to be `Omit<FormSectionConfig, 'visibleWhen'>`, which subtracted the
+ * predicate slot from `TabbedForm`'s section type. That closed the hole for the
+ * ONE key it named and left the mechanism wide open: `FormSectionConfig` is the
+ * predicate-CARRYING type, so every key added to it lands here by default and
+ * the author has to remember to widen the `Omit`. The defect the 2026-08-30
+ * ruling closes is the SILENCE — "在共享 `FormSectionConfig` 上声明 `visibleWhen`
+ * 会**静默**给 WizardForm 的 step 也发一个谓词槽而那侧无实现" — and a subtractive
+ * derivation reproduces that silence for the next key in the same family
+ * (`readonlyWhen` / `requiredWhen`, both already this repo's field-level
+ * predicate vocabulary). Declaring the step shape independently flips the
+ * derivation from subtractive to additive: a key reaches a wizard step only
+ * because someone wrote it here, on the type whose renderer has to honour it.
+ *
+ * This is also simply the house pattern. `SplitFormSectionConfig`,
+ * `ModalFormSectionConfig` and `DrawerFormSectionConfig` each declare their own
+ * group shape, each documents `className` / `gridClassName` in ITS layout's
+ * terms, and each declares `visibleWhen` only because its layout honours it
+ * (`SplitFormSectionConfig` even carries a key — `pane` — that exists nowhere
+ * else). The wizard borrowing the tabbed layout's interface was the exception,
+ * and it cost real accuracy: a wizard author reading the shared type was told
+ * `name` is "used as tab value", `label` is "used as tab trigger text", and
+ * `className` is "Unused in the tabbed layout" — while this renderer uses all
+ * three, `className` at the step container (`FormSectionContainer` below).
+ *
+ * ## ⛔ Why there is no predicate slot, and why that is not an oversight
  *
  * A step predicate is not a port of the tab predicate, it is a different
  * contract. Steps are wizard component state keyed by section INDEX, only the
@@ -55,19 +77,65 @@ import type { FormSectionConfig } from './TabbedForm';
  * stability while hiding is live, re-selection when the CURRENT step hides, and
  * a final-gate exclusion for a hidden step's required fields.
  *
- * Declaring the key on the shared type would make it WRITABLE on a step while
- * this renderer ignores it — precisely the declared-but-unenforced shape this
- * card family exists to close. Omitting it means TypeScript rejects the key on a
- * wizard step literal, which is where an author (or an agent authoring metadata)
- * finds out. `ObjectForm` additionally reports the gap at runtime for a section
- * predicate arriving on the wizard route, since untyped JSON reaches it too.
+ * Declaring the key on a type this renderer ignores would make it WRITABLE on a
+ * step — precisely the declared-but-unenforced shape this card family exists to
+ * close. Its absence means TypeScript rejects the key on a wizard step literal,
+ * which is where an author (or an agent authoring metadata) finds out.
+ * `ObjectForm` additionally reports the gap at runtime for a section predicate
+ * arriving on the wizard route, since untyped JSON reaches it too. Both halves
+ * are pinned in `__tests__/tabbedFormSectionPredicate-6237.test.tsx`, including
+ * a FAMILY-level pin that fails the build if any `*When` key ever appears here,
+ * not just the one this card was about.
  *
- * ⚠️ This omission changes nothing that used to work: `FormSectionConfig` did
- * not declare `visibleWhen` before objectui#6237 either, so a wizard step
- * literal carrying it was already a type error. The wizard's surface is exactly
- * what it was; only the tabbed arm widened.
+ * ⚠️ This changes nothing that used to work. The published surface is exactly
+ * the key set `WizardStepConfig` already had — the derivation changed, not the
+ * type — and `visibleWhen` was already a type error on a wizard step literal.
  */
-export type WizardStepConfig = Omit<FormSectionConfig, 'visibleWhen'>;
+export interface WizardStepConfig {
+  /**
+   * Step identifier. Used as the step's test handle
+   * (`data-testid="wizard-step:<name>"`) and, with `label`, as what the
+   * indicator names; falls back to the step INDEX when absent.
+   */
+  name?: string;
+
+  /**
+   * Step label — the text the step indicator shows.
+   * Falls back to `Step <n>`.
+   */
+  label?: string;
+
+  /**
+   * Step description, rendered under the step heading.
+   */
+  description?: string;
+
+  /**
+   * How densely this step fills the grid (1–4). Outranked by the form view's
+   * own `columns` (spec `FormView.columns`), which sets the grid WIDTH.
+   * @default 1
+   */
+  columns?: 1 | 2 | 3 | 4;
+
+  /**
+   * Field names or configurations in this step.
+   */
+  fields: (string | FormField)[];
+
+  /**
+   * Custom CSS class for this step's container.
+   *
+   * Honoured, unlike its tabbed counterpart: a wizard mounts ONE step at a
+   * time inside its own `FormSectionContainer`, so the step has a container to
+   * carry it.
+   */
+  className?: string;
+
+  /**
+   * Custom CSS class for this step's field grid (overrides the column classes).
+   */
+  gridClassName?: string;
+}
 
 /**
  * What the submitter is told when a DECLARED `navigateOnSuccess` produced no

--- a/packages/plugin-form/src/__tests__/tabbedFormSectionPredicate-6237.test.tsx
+++ b/packages/plugin-form/src/__tests__/tabbedFormSectionPredicate-6237.test.tsx
@@ -343,4 +343,44 @@ describe('#6237 — the wizard boundary is enforced by the TYPE, not by a commen
     };
     expect(step.name).toBe('pay');
   });
+
+  it('⛔ NO predicate-family key may appear on a wizard step — the family pin', () => {
+    // The pin above names ONE key. That was the whole weakness of the shape
+    // this replaced: `WizardStepConfig` was `Omit<FormSectionConfig,
+    // 'visibleWhen'>`, so it defended `visibleWhen` and let every FUTURE key
+    // added to the tabbed section type reach a wizard step by default — the
+    // same SILENT slot the 2026-08-30 ruling split the types to stop, one key
+    // later. `readonlyWhen` and `requiredWhen` are already this repo's
+    // field-level predicate vocabulary (see the plugin-form README's rule
+    // table), so the next key in the family is a named possibility, not a
+    // hypothetical.
+    //
+    // These are TYPE assertions: they are erased at runtime, so vitest proves
+    // nothing about them and `tsc -p tsconfig.test.json` is the only thing that
+    // can. `Expect` fails its own constraint when the argument is not `true`.
+    type Expect<T extends true> = T;
+    // `-?` strips optionality, or a mapped type over optional keys yields
+    // `K | undefined` and the `never` comparison below could never be true.
+    type PredicateKeysOf<T> = {
+      [K in keyof T]-?: K extends `${string}When` ? K : never;
+    }[keyof T];
+
+    // ⭐ The CONTROL, and it is not decoration: a `PredicateKeysOf` that
+    // silently resolved to `never` for everything would make the wizard row
+    // below pass vacuously — a phantom check that can never fail. This row
+    // proves the machinery detects a predicate key when one is really there,
+    // on the sibling type that really has one.
+    type _TabbedSectionHasThePredicateKey = Expect<
+      PredicateKeysOf<FormSectionConfig> extends 'visibleWhen' ? true : false
+    >;
+
+    // The pin itself: the wizard's step type carries no `*When` key at all.
+    type _WizardStepHasNoPredicateKey = Expect<
+      PredicateKeysOf<WizardStepConfig> extends never ? true : false
+    >;
+
+    // Keep both aliases used, so `noUnusedLocals` cannot delete the pin.
+    const pinned: [_TabbedSectionHasThePredicateKey, _WizardStepHasNoPredicateKey] = [true, true];
+    expect(pinned).toEqual([true, true]);
+  });
 });

--- a/packages/plugin-form/src/__tests__/tabbedFormSectionPredicate-6237.test.tsx
+++ b/packages/plugin-form/src/__tests__/tabbedFormSectionPredicate-6237.test.tsx
@@ -370,8 +370,16 @@ describe('#6237 — the wizard boundary is enforced by the TYPE, not by a commen
     // below pass vacuously — a phantom check that can never fail. This row
     // proves the machinery detects a predicate key when one is really there,
     // on the sibling type that really has one.
+    //
+    // ⚠️ The DIRECTION is the whole control. Written the other way round
+    // (`PredicateKeysOf<FormSectionConfig> extends 'visibleWhen'`) it would be
+    // vacuous for exactly the failure it is meant to catch: `never` is
+    // assignable to everything, so a broken helper returning `never` would
+    // satisfy it too — and then BOTH rows would pass while measuring nothing.
+    // Asking whether `'visibleWhen'` is assignable TO the helper's result is
+    // the assertion a `never` result fails.
     type _TabbedSectionHasThePredicateKey = Expect<
-      PredicateKeysOf<FormSectionConfig> extends 'visibleWhen' ? true : false
+      'visibleWhen' extends PredicateKeysOf<FormSectionConfig> ? true : false
     >;
 
     // The pin itself: the wizard's step type carries no `*When` key at all.


### PR DESCRIPTION
Part of #6237 — this discharges the 2026-08-30 maintainer ruling in full, but leaves the card open as the tracker for the wizard step contract (see "What stays open", below).

⚠️ **Draft on purpose.** The ruling routes this through `CONTRACT_REVIEW_TIER` because it touches plugin-form's published exported type face. This branch does not mark itself ready and does not merge itself.

## First: what round 3 had already built

Re-derived on my own base (`fab4802e3`, not the dispatch's `ee851c32a`), before writing anything. The ruling was written against a triage analysis that **declared its own read window as `2026-08-26T02:06Z → 2026-08-28T05:19Z`** — comment 10 of 25. It therefore could not see PR #6791, which merged on 08-29. Measured against `main`, three of the ruling's four operative demands were already satisfied:

| Ruled item | State on `fab4802e3` | Verdict |
| --- | --- | --- |
| Drop point 1 — `ObjectForm`'s tabbed section map carries the predicate | `ObjectForm.tsx:292`, and deliberately without the `as any` its three sibling maps use | already done |
| Drop point 2 — the tabbed section type declares `visibleWhen` | `TabbedForm.tsx:79` | already done |
| Drop point 3 — `tabGroups` / `fieldTabs` synthesis copies it | `TabbedForm.tsx:468`, `:514`, `:557` | already done |
| Semantics inherited from the renderer, not re-implemented | the `fieldTabs` path the modal arm has used since #6619 | already done |
| Wizard has no predicate slot | `WizardStepConfig`, plus a `@ts-expect-error` pin | done, but by **subtraction** — see below |
| "WizardForm steps = No" stays true in the docs | true | holds |
| "TabbedForm sections = No" in the same table | **false** since the tabbed arm landed | ⚠️ **stale, repaired here** |

So branch 1 of the ruling needed nothing, and this PR redoes none of it.

## The shape chosen for the "split", and why

The ruling says 拆开 `FormSectionConfig`,让 `TabbedForm` 与 `WizardForm` 不再共享它. Round 3 achieved the *effect* for one key with `WizardStepConfig = Omit<FormSectionConfig, 'visibleWhen'>`. I judged that **not** what the ruling means, and the reason is mechanical rather than stylistic:

`Omit<T, K>` is **subtractive and names exactly one key**, and `FormSectionConfig` is the predicate-*carrying* type. Every key added to it lands on a wizard step by default; the author has to remember to widen the `Omit`. The defect the ruling closes is the **silence** — 在共享 `FormSectionConfig` 上声明 `visibleWhen` 会**静默**给 WizardForm 的 step 也发一个谓词槽而那侧无实现 — and a subtractive derivation reproduces exactly that silence for the next key in the same family. `readonlyWhen` and `requiredWhen` are already this package's field-level predicate vocabulary (the README's own rule table lists all three together), so that is a named possibility, not a hypothesis. **Ablation leg B below demonstrates the leak rather than asserting it.**

There is also a house pattern, and the wizard was the one exception to it: `SplitFormSectionConfig`, `ModalFormSectionConfig` and `DrawerFormSectionConfig` each declare their own group shape, each documents `className` / `gridClassName` in **its** layout's terms, and each declares `visibleWhen` only because its renderer honours it — `SplitFormSectionConfig` even carries a key (`pane`) that exists nowhere else. Borrowing cost real accuracy: a wizard author reading the shared type was told `name` is "used as tab value", `label` is "used as tab trigger text" and `className` is "Unused in the tabbed layout", while `WizardForm.tsx:947` passes `className` straight to the step's `FormSectionContainer`.

⇒ `WizardStepConfig` is now declared independently in `WizardForm.tsx`, and `WizardForm` no longer imports anything from `TabbedForm.tsx`. The derivation flips from **subtractive to additive**: a key reaches a wizard step only because someone wrote it there, on the type whose renderer has to honour it.

## The widened surface, stated exactly

The reviewed artefact is the **plugin-form barrel's exported section/step types** — *not* `packages/types`, and not `packages/components/src/renderers/`, neither of which this branch touches.

- **`FormSectionConfig`** (exported from `index.tsx:47`): **unchanged by this PR.** It gained `visibleWhen?: string | { dialect?, source }` in #6791; this branch only rewrites a doc comment on it.
- **`WizardStepConfig`** (exported from `index.tsx:49`): **the same key set it already had** — `name?`, `label?`, `description?`, `columns?`, `fields`, `className?`, `gridClassName?`. Only the derivation changed, from `Omit<FormSectionConfig, 'visibleWhen'>` to an independent `interface`.

**What a consumer can write after this change that they could not write before: nothing.** That is the intended answer, and it is measured, not assumed — the consumer probe below compiles against the rebuilt `dist/index.d.ts`. What a consumer can **no longer accidentally be handed** is a future predicate key added to the tabbed section type. Both types remain `interface`/structural, so assignability is unchanged in both directions.

One deliberate non-addition: no third exported name. A shared base type extended by both layouts was the obvious middle option and I rejected it — it leaves the same door open (a key put on the base still reaches both silently), and it would publish a name with no consumer pull.

## Verification

All at final commit `ec4d5fdd7`, clean tree; the union was re-run there after the last edit.

**Suites — from the repo root, not package-filtered**, per AGENTS.md (a package-filtered run with no `test` script exits 0 having run nothing):

```
pnpm exec vitest run packages/plugin-form/ packages/components/src/renderers/form/
  Test Files  135 passed (135)
       Tests  1188 passed (1188)
```

Baseline on `fab4802e3` for the same command was 135 files / **1187** tests; the delta is the one family pin added here.

**Type-check** — `@object-ui/plugin-form` `type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) exit 0, after building the dependency closure. Proven to actually *read* the files it is credited with: `tsc -p tsconfig.test.json --listFiles` names both `src/WizardForm.tsx` and `src/__tests__/tabbedFormSectionPredicate-6237.test.tsx` as program inputs. This matters here more than usual — the whole enforcement is compile-time, so a type-check that silently excluded the pin file would have read as green while measuring nothing.

**Consumer probe, compiled against the REBUILT `dist/index.d.ts`** (not source, not cache), with a success control:

| probe line | expectation | observed |
| --- | --- | --- |
| `FormSectionConfig` literal carrying `visibleWhen` | compiles | no diagnostic |
| `WizardStepConfig` literal carrying `visibleWhen` | rejected | `TS2353: 'visibleWhen' does not exist in type 'WizardStepConfig'` |
| a deliberate `const control: number = 'not a number'` | reported | `TS2322` — so the file genuinely compiled, and row 1's silence is a measurement rather than an unread file |

The emitted declaration was inspected directly: `dist/WizardForm.d.ts:61` now carries `export interface WizardStepConfig { … }` with the wizard-specific prose, and has no import from `./TabbedForm`.

### Ablation — three legs, predicted before running

Fix committed **first**, so the restore leg has a real reference. Each leg proves its mutation on disk by anchored injected/deleted counts **and** a working-blob-vs-HEAD-blob comparison (an empty hash or a no-op aborts the leg with a non-zero exit), restores via `trap … EXIT INT TERM` with paths absolute off `git rev-parse --show-toplevel`, and proves the restore both ways — `git diff HEAD` empty **and** every working blob hash equal to its HEAD blob.

Pin line numbers: `_TabbedSectionHasThePredicateKey` at 381, `_WizardStepHasNoPredicateKey` at 386, the `pinned` tuple at 391.

| leg | mutation | predicted | observed |
| --- | --- | --- | --- |
| **A** — does the family pin have teeth? | add `readonlyWhen` directly to `WizardStepConfig` | type-check RED at 386, control at 381 green | `TSC_EXIT=2`; `387,7 TS2344 Type 'false' does not satisfy the constraint 'true'` + `391,93 TS2322` (the tuple, collateral). Row 381 absent. ✅ row for row |
| **B** — is the OLD subtractive shape leaky? | restore the subtractive `Omit` derivation **and** add `readonlyWhen` to `FormSectionConfig` | RED at 386 — the key leaks onto the step | `TSC_EXIT=2`; identical two rows, `387,7` + `391,93`. ✅ **the defect, demonstrated** |
| **C** — does the split close it? | the *same* `readonlyWhen` on `FormSectionConfig`, new shape in place | GREEN — nothing leaks | `TSC_EXIT=0`, zero `error TS`. ✅ |

**B and C differ in exactly one thing — the derivation.** Same injected key, same file, same command. C's exit 0 is also the success control the A/B needs: it proves the command *can* pass, so B's exit 2 is a real reading rather than a permanently-red command. (Nothing here was compared by digest; the readings are parsed diagnostics with line numbers.)

**Controls held green through all three legs, and why each proves the paths are separate rather than one edit's collateral:**

1. **`_TabbedSectionHasThePredicateKey` (381)** never appears in any diagnostic list. It is the non-vacuity guard, and its **direction is load-bearing**: written with the helper applied to the TABBED type on the left of `extends 'visibleWhen'`, it would have been satisfied by a broken helper returning `never` — `never` is assignable to everything — so both rows would have passed while measuring nothing. It is written the other way round — `'visibleWhen' extends` the helper applied to the tabbed type — which a `never` result fails. (I wrote the vacuous direction first and corrected it in `ec4d5fdd7`; the commit records why.)
2. **The original one-key `@ts-expect-error` pin** stays satisfied in every leg — no "unused `@ts-expect-error` directive" error anywhere. It and the family pin fire on different provocations, so neither is the other's collateral.
3. **The runtime suite stays green under leg A.** With the mutation on disk that turns type-check red, `vitest run …/tabbedFormSectionPredicate-6237.test.tsx` reports `Test Files 1 passed (1) / Tests 13 passed (13)`. This is the point, not a footnote: the enforcement lives exclusively in `tsc`, which is why the pin had to be written as a type assertion — a runtime-only verification would miss the leak entirely.

### Gates, each quoted from its own verdict line, exit codes captured before any pipe

- `check-control-bytes` — `OK (scanned 5751 tracked text file(s); skipped 85 binary)`; plus a self-scan of the six changed files for `[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]`, no hits.
- `check-changeset-presence` — `3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`.
- `check-changeset-no-major` — `No changeset declares a 'major' bump`. `check-changeset-overwrite` — `No pre-existing changeset was modified or deleted`. `check-changeset-fixed` — exit 0.
- `check-package-self-import` — `No package names itself inside its own src/`. `check-phantom-dependencies` — `Every in-scope import is declared by the package that publishes it` (this branch *removes* an import; nothing added).
- `check-vi-mock-specifiers`, `check-doc-fence-languages`, `check-doc-component-types`, `check-docs-route-eager-closure`, `check-i18n-call-site-keys`, `check-i18n-en-drift` (`No en value changed in this range`) — all exit 0. No author-facing string was added.
- `check-doc-snippet-types` — first run exited **2**, which the script itself labels "I could not run", NOT a verdict. Built what it names and re-ran: exit 0, `Semantic phase: 271 of 271 block(s) judged, 0 failed`.
- `check-readme-exports` — overall exit 1, and it is **tree state, not a diff verdict**: every one of the 46 findings is the `type entry ./dist/index.d.ts is not on disk -- run pnpm build first` class, in `plugin-ai` / `plugin-gantt` / `plugin-map`, three packages this branch does not touch. Findings naming `packages/plugin-form/README.md`: **0**.
- **Lint with a baseline, not a warning count**: targeted `eslint --no-inline-config` on the three changed TS files, compared per-rule against the **base versions of the same files** (extracted at `fab4802e3`, swapped in under a trap, blob-hash-proven to be the base bytes, restored with `git diff HEAD` empty). 0 errors, **0 net new warnings**, and no rule's count moved in either direction: TabbedForm 9→9, WizardForm 21→21, the pin file 9→9.

Narrowing declared: the repo-wide `pnpm lint` sweep is CI's run, not reproduced here. The config does no type-aware linting, so this diff cannot move an untouched file's verdict. Every heavy run went through the shared verify lock.

## The documentation repair, and the line the ruling protects

The ruling requires #6628's "WizardForm steps = No" line to **stay true**. It does, verbatim, and this branch does not touch that row.

Its neighbour had gone false. The support table in both mirrors still read *`TabbedForm` / `formType: 'tabbed'` sections — **No**, a section `visibleWhen` is dropped before the renderer sees it*, which stopped being true the moment that arm landed. The surrounding prose was stale with it: "the two **No** rows", "Both **No** rows now report themselves", a claim that authoring the key on `formType: 'tabbed'` logs a warning (it no longer does — the runtime diagnostic was narrowed to `wizard`), and "the four arms that honour the key" (now five). Repaired in `packages/plugin-form/README.md` and `content/docs/plugins/plugin-form.mdx`, which #6628 changed as one unit. A doc that says a working feature does not work is the same declared-vs-enforced defect this card family exists to close, running in the other direction.

⚠️ **Fence note for the reviewer.** `content/docs/plugins/plugin-form.mdx` sits outside the literal `packages/plugin-form/` fence. It is neither of the two named stop conditions, and it is the mirror of the in-fence README — updating one and not the other would manufacture exactly the drift the mirror exists to prevent. Flagging it rather than deciding it silently.

## What stays open, and why this is `Part of`

⛔ The wizard arm gets **no predicate slot**, per the ruling — WizardForm step 显隐无实测拉动,不给它无实现的槽 — and this branch does not give it one; that is what the pins hold. The remaining item is the wizard **step predicate contract** itself, which the ruling declined to design on measured-pull grounds rather than settling forever. `WizardStepConfig`'s comment and both docs mirrors point an author at #6237 for it, so the card is still the live tracker for that pointer, and a `Fixes` here would close it under those references. #6237 remains open; a seat that judges the card complete can close it deliberately.

The cross-repo half of semantic 1 (whether the server-side required check can read a form predicate) was measured in round 3 and lives on its own card in `objectstack`; nothing here changes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_