### PR TITLE
feat(types): declare `renderCellEditor` and schema-level `cellClassName` on `DataTableSchema`

### DIFF
--- a/.changeset/6882-datatable-declare-render-cell-editor-and-cell-classname.md
+++ b/.changeset/6882-datatable-declare-render-cell-editor-and-cell-classname.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+---
+
+feat(types): declare `renderCellEditor` and schema-level `cellClassName` on `DataTableSchema`
+
+`data-table` has read both keys on its production path all along — `renderCellEditor`
+through a `(schema as any)` cast, `cellClassName` by destructuring it into every body
+cell's class. Neither was declared, so authoring either one was unchecked: a
+misspelling produced no error and no widget, and no editor completion offered them.
+`DataTableSchema` now declares both, and the cast in `data-table.tsx` is gone rather
+than replaced.
+
+What you can write after this change that you could not write before, exactly:
+**nothing new runs.** Both keys had the same effect yesterday, because
+`BaseSchema`'s `[key: string]: any` already admitted them at any type at all. What
+changes is that they are now *checked* and *documented*:
+
+```ts
+const schema: DataTableSchema = {
+  type: 'data-table',
+  columns, data,
+  cellClassName: 'px-2 py-1 text-sm',        // every body cell — row-density padding
+  renderCellEditor: ({ column, value, commit, cancel }) =>
+    column.type === 'select'
+      ? <MyPicker value={value} onSelect={commit} onDismiss={cancel} />
+      : null,                                  // null → fall through to the built-in editor
+};
+```
+
+⚠️ **One reject direction, deliberate.** Because the keys were previously absorbed by
+the index signature as `any`, authored values of the *wrong shape* also compiled and
+silently did nothing. They are now compile errors:
+
+- `cellClassName` is declared `string`, matching `BaseSchema.className` and
+  `TableColumn.cellClassName`. The renderer passes it through `cn()`, which would
+  also swallow `['a','b']` or `{ a: true }` — those spellings now fail to compile.
+  One authored spelling for a class slot is the contract.
+- `renderCellEditor` is declared as the function `data-table` actually calls. A
+  non-function value (or a function with an incompatible context/return type) now
+  fails to compile instead of being ignored at runtime.
+
+No runtime behaviour changed anywhere, and nothing was retired. The zod mirror
+(`@object-ui/types/zod`) gains both keys in the same stroke, so the validator accepts
+what the published types now invite.

--- a/.changeset/6882-datatable-declare-render-cell-editor-and-cell-classname.md
+++ b/.changeset/6882-datatable-declare-render-cell-editor-and-cell-classname.md
@@ -6,9 +6,10 @@
 feat(types): declare `renderCellEditor` and schema-level `cellClassName` on `DataTableSchema`
 
 `data-table` has read both keys on its production path all along — `renderCellEditor`
-through a `(schema as any)` cast, `cellClassName` by destructuring it into every body
-cell's class. Neither was declared, so authoring either one was unchecked: a
-misspelling produced no error and no widget, and no editor completion offered them.
+through a `(schema as any)` cast, `cellClassName` by destructuring it into the class of
+its three utility cells (the selection checkbox, the row number, the row actions).
+Neither was declared, so authoring either one was unchecked: a misspelling produced no
+error and no widget, and no editor completion offered them.
 `DataTableSchema` now declares both, and the cast in `data-table.tsx` is gone rather
 than replaced.
 
@@ -21,7 +22,7 @@ changes is that they are now *checked* and *documented*:
 const schema: DataTableSchema = {
   type: 'data-table',
   columns, data,
-  cellClassName: 'px-2 py-1 text-sm',        // every body cell — row-density padding
+  cellClassName: 'px-2 py-1 text-sm',        // utility cells only (see below)
   renderCellEditor: ({ column, value, commit, cancel }) =>
     column.type === 'select'
       ? <MyPicker value={value} onSelect={commit} onDismiss={cancel} />
@@ -40,6 +41,15 @@ silently did nothing. They are now compile errors:
 - `renderCellEditor` is declared as the function `data-table` actually calls. A
   non-function value (or a function with an incompatible context/return type) now
   fails to compile instead of being ignored at runtime.
+
+⚠️ **What the schema-level `cellClassName` actually styles.** It is NOT the
+table-level twin of the per-column key: the two reach **disjoint** cells. Measured on
+the render, the schema-level key is folded into the **utility** cells only — the
+selection-checkbox cell, the row-number cell and the row-actions cell — while every
+**data** cell folds `TableColumn.cellClassName` and nothing else. Row density is
+therefore a pair of settings (`ObjectGrid` sets both), and the schema-level key alone
+leaves data cells at the primitive's default `p-4`. The docblock, the zod `describe`
+and `content/docs/components/complex/data-table.mdx` all say this now.
 
 No runtime behaviour changed anywhere, and nothing was retired. The zod mirror
 (`@object-ui/types/zod`) gains both keys in the same stroke, so the validator accepts

--- a/content/docs/components/complex/data-table.mdx
+++ b/content/docs/components/complex/data-table.mdx
@@ -43,9 +43,22 @@ interface DataTableSchema {
   // Advanced features
   resizableColumns?: boolean;            // Allow column resizing (default: true)
   reorderableColumns?: boolean;          // Allow column reordering (default: true)
-  
+
+  // Inline editing
+  editable?: boolean;                    // Enable inline cell editing (default: false)
+  singleClickEdit?: boolean;             // Enter edit mode on single click (default: false)
+  renderCellEditor?: (ctx: {             // Host-supplied editor widget; null -> built-in input
+    column: any;
+    row: any;
+    value: any;
+    stage: (v: any) => void;
+    commit: (v?: any) => void;
+    cancel: () => void;
+  }) => ReactNode;
+
   // Styling
-  className?: string;                    // Tailwind CSS classes
+  className?: string;                    // Tailwind CSS classes on the table wrapper
+  cellClassName?: string;                // Tailwind CSS classes on EVERY body cell
   
   // Base properties
   id?: string;
@@ -53,6 +66,45 @@ interface DataTableSchema {
   testId?: string;
 }
 ```
+
+## Cell styling
+
+`className` styles the table wrapper; `cellClassName` is folded into **every body
+cell**, which is where per-cell padding has to go — row height is a property of the
+cells, not of the row element, so `rowClassName` cannot express it. A host rendering
+compact rows sets it once on the schema:
+
+```json
+{
+  "type": "data-table",
+  "cellClassName": "px-2 py-1 text-sm",
+  "columns": [
+    { "header": "Name", "accessorKey": "name" },
+    { "header": "Amount", "accessorKey": "amount", "cellClassName": "text-right" }
+  ],
+  "data": []
+}
+```
+
+The per-column `cellClassName` on `TableColumn` styles one column; both apply when
+both are present.
+
+## Inline editing
+
+With `editable: true` a cell enters edit mode on double-click (or on single click
+with `singleClickEdit: true`) and the table renders one of its built-in editors —
+text, number, date — chosen from the column's `type`.
+
+`renderCellEditor` lets the host supply a widget instead. The table calls it first
+for every cell it is about to edit; return a node to use it, or `null` to fall
+through to the built-in editor for that column. This is how `object-grid` gives a
+`select` or `lookup` cell the same dedicated control the form uses, without the
+component layer having to re-implement it.
+
+The returned node is wrapped by the table so it inherits the exit-edit
+affordances the built-in editors have: Enter commits from a single-line input,
+Escape cancels, and a click outside commits. Use `stage` to record a value while
+staying in edit mode, `commit` to save, and `cancel` to discard.
 
 ## Examples
 

--- a/content/docs/components/complex/data-table.mdx
+++ b/content/docs/components/complex/data-table.mdx
@@ -58,7 +58,8 @@ interface DataTableSchema {
 
   // Styling
   className?: string;                    // Tailwind CSS classes on the table wrapper
-  cellClassName?: string;                // Tailwind CSS classes on EVERY body cell
+  cellClassName?: string;                // Tailwind CSS classes on the utility cells only
+                                         // (select / row number / row actions)
   
   // Base properties
   id?: string;
@@ -69,25 +70,42 @@ interface DataTableSchema {
 
 ## Cell styling
 
-`className` styles the table wrapper; `cellClassName` is folded into **every body
-cell**, which is where per-cell padding has to go — row height is a property of the
-cells, not of the row element, so `rowClassName` cannot express it. A host rendering
-compact rows sets it once on the schema:
+`className` styles the table wrapper. Body cells have **two** class slots, and they
+reach **disjoint** cells — neither is a superset of the other, and no cell gets both:
+
+- `TableColumn.cellClassName` — the **data** cells of that one column.
+- `DataTableSchema.cellClassName` — the table's **utility** cells only: the leading
+  selection-checkbox cell (`selectable`), the row-number cell (`showRowNumbers`), and
+  the trailing row-actions cell (`rowActions`). It never reaches a data cell.
+
+(The empty-state cell and the add-record row take neither.)
+
+Row density is therefore a **pair** of settings, not one. Per-cell padding is where
+row height has to be expressed — height is a property of the cells, not of the row
+element, so `rowClassName` cannot express it — so a compact table sets the same
+density class on every column *and* on the schema, the second so the checkbox and
+row-number cells stay the same height as the data beside them. That is exactly what
+`object-grid` does for its `rowHeight` modes:
 
 ```json
 {
   "type": "data-table",
+  "selectable": true,
+  "showRowNumbers": true,
   "cellClassName": "px-2 py-1 text-sm",
   "columns": [
-    { "header": "Name", "accessorKey": "name" },
-    { "header": "Amount", "accessorKey": "amount", "cellClassName": "text-right" }
+    { "header": "Name", "accessorKey": "name", "cellClassName": "px-2 py-1 text-sm" },
+    { "header": "Amount", "accessorKey": "amount", "cellClassName": "px-2 py-1 text-sm text-right" }
   ],
-  "data": []
+  "data": [
+    { "name": "Ada Lovelace", "amount": 120 },
+    { "name": "Grace Hopper", "amount": 340 }
+  ]
 }
 ```
 
-The per-column `cellClassName` on `TableColumn` styles one column; both apply when
-both are present.
+Drop the per-column half and the data cells stay at the table primitive's default
+`p-4` — the schema-level key alone does not compact a row.
 
 ## Inline editing
 

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -2266,16 +2266,17 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                 // re-implement select/boolean/etc. down here in the
                                 // (fields-free) component layer. Returning null means "no
                                 // widget for this type" → fall through to the built-ins.
-                                const injectEditor = (schema as any).renderCellEditor as
-                                  | ((ctx: {
-                                      column: any;
-                                      row: any;
-                                      value: any;
-                                      stage: (v: any) => void;
-                                      commit: (v?: any) => void;
-                                      cancel: () => void;
-                                    }) => React.ReactNode)
-                                  | undefined;
+                                //
+                                // This used to be `(schema as any).renderCellEditor as
+                                // (…) => React.ReactNode` — a cast that existed for one
+                                // reason only: `DataTableSchema` did not declare the key
+                                // this renderer has always read, so the read had to
+                                // re-state the contract locally and the schema had to be
+                                // opened up to let it. objectui#6882 declared it (the
+                                // 2026-08-30 ruling), so the read is typed at its source
+                                // and the ctx shape below is checked against the
+                                // declaration instead of asserted against nothing.
+                                const injectEditor = schema.renderCellEditor;
                                 if (typeof injectEditor === 'function') {
                                   const node = injectEditor({
                                     column: col,

--- a/packages/types/src/__tests__/data-table-declared-keys-6882.test.ts
+++ b/packages/types/src/__tests__/data-table-declared-keys-6882.test.ts
@@ -1,0 +1,146 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6882 — `DataTableSchema` DECLARES the two schema-level keys
+ * `data-table.tsx` has always read: `renderCellEditor` and `cellClassName`
+ * (maintainer ruling 2026-08-30, option A).
+ *
+ * ## Why this pin is compile-time, and why a runtime pin would measure nothing
+ *
+ * The enforcement being added is a TYPE declaration. `data-table` behaves
+ * IDENTICALLY before and after it: both keys were already read on the
+ * production path — `renderCellEditor` through an `(schema as any)` cast,
+ * `cellClassName` by destructuring into every body cell's class — so no render
+ * changes, no runtime value changes, and a rendering test is blind to the whole
+ * change. What can fail is a COMPILE. Same reading as
+ * `plugin-grid/src/__tests__/dataTableSchemaSlot-6459.test.ts` next door.
+ *
+ * ## ⚠️ The index signature is what makes the naive pin vacuous
+ *
+ * `DataTableSchema extends BaseSchema`, and `BaseSchema` carries
+ * `[key: string]: any`. So `DataTableSchema['renderCellEditor']` resolves to
+ * `any` whether or not the key is declared, and every "is this key there?"
+ * spelling written over the raw type answers `true` for EVERY string —
+ * including `bogusKeyNobodyDeclared`. A pin written that way is green before
+ * the fix, green after it, and measures nothing.
+ *
+ * `Declared<>` below strips the signature so NON-MEMBERSHIP can exist, which is
+ * the only state in which a membership question has an answer.
+ *
+ * ## ⚠️ …and `extends` alone is vacuous a second way
+ *
+ * `Expect<X extends true ? true : false>` is satisfied by `never` (assignable
+ * to everything) and by `any`. `Equal<>` below is the invariant
+ * (function-parameter-identity) comparison instead, so neither passes.
+ *
+ * ## How the DIRECTION is proved, rather than asserted
+ *
+ * Four `@ts-expect-error` directives below are the load-bearing half. TypeScript
+ * reports an UNUSED `@ts-expect-error` as an error (TS2578), so each of them is
+ * a claim that the instrument REFUSES something:
+ *
+ *   - `Expect<false>` must be refused → the assertion helper has teeth;
+ *   - `Equal<never, true>` and `Equal<any, true>` must resolve `false` → the
+ *     comparison is invariant, not `extends`-shaped;
+ *   - `IsDeclaredOn<'…probe…'>` must resolve `false` → the strip really removed
+ *     the index signature, so a non-member is answerable.
+ *
+ * Break any part of the instrument — make `Expect` accept anything, make
+ * `Equal` bivariant, make `Declared` a no-op — and this file goes RED on the
+ * now-unused directive rather than quietly passing. That is the property the
+ * positive assertions borrow their meaning from.
+ */
+import { describe, it, expect } from 'vitest';
+import type { DataTableSchema } from '../data-display.js';
+
+/**
+ * `T` with its string/number index signatures removed — the same shape
+ * `plugin-grid`'s `RemoveIndexSignature` uses at the seam, restated here so
+ * this package's pin does not depend on a downstream package.
+ */
+type Declared<T> = {
+  [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
+};
+
+/** Invariant type equality. `A extends B` is NOT this: `never` and `any` pass that. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+/** The only assertion form used here — its constraint is what refuses `false`. */
+type Expect<T extends true> = T;
+
+/** Is `K` a DECLARED member of `DataTableSchema` (index signature stripped)? */
+type IsDeclaredOn<K extends PropertyKey> = K extends keyof Declared<DataTableSchema> ? true : false;
+
+/* ── Direction proofs: a broken instrument makes THIS file red ─────────────── */
+
+// @ts-expect-error objectui#6882 — `Expect` must refuse `false`. Widen its constraint and this directive goes unused (TS2578).
+type _ExpectRefusesFalse = Expect<false>;
+
+// @ts-expect-error objectui#6882 — `never` must NOT read as equal to `true`. An `extends`-shaped comparison would let it through.
+type _EqualRefusesNever = Expect<Equal<never, true>>;
+
+// @ts-expect-error objectui#6882 — `any` must NOT read as equal to `true`, for the same reason.
+type _EqualRefusesAny = Expect<Equal<any, true>>;
+
+// @ts-expect-error objectui#6882 — a key nothing declares must answer `false`. If `Declared<>` stopped stripping `[key: string]: any`, this would answer `true` and the directive would go unused.
+type _UndeclaredKeyIsRefused = Expect<IsDeclaredOn<'bogusKeyNobodyDeclares6882'>>;
+
+/* ── The assertions the card is about ─────────────────────────────────────── */
+
+/** RED before objectui#6882's declaration, green after. */
+type _RenderCellEditorIsDeclared = Expect<IsDeclaredOn<'renderCellEditor'>>;
+/** RED before objectui#6882's declaration, green after. */
+type _CellClassNameIsDeclared = Expect<IsDeclaredOn<'cellClassName'>>;
+
+/**
+ * The context object `data-table.tsx` actually passes to the injected editor,
+ * transcribed from its call site. Declaring the key with any other shape is a
+ * different (and false) statement about the renderer, so the shape is pinned,
+ * not just the membership.
+ */
+type CellEditorContext = {
+  column: any;
+  row: any;
+  value: any;
+  stage: (v: any) => void;
+  commit: (v?: any) => void;
+  cancel: () => void;
+};
+
+type _RenderCellEditorShape = Expect<
+  Equal<
+    Declared<DataTableSchema>['renderCellEditor'],
+    ((ctx: CellEditorContext) => React.ReactNode) | undefined
+  >
+>;
+
+/** Matches `TableColumn.cellClassName` and `BaseSchema.className` — both `string`. */
+type _CellClassNameShape = Expect<Equal<Declared<DataTableSchema>['cellClassName'], string | undefined>>;
+
+describe('objectui#6882 — DataTableSchema declares the two keys data-table reads', () => {
+  /**
+   * The runtime half exists only so the compile-time pins above have a file
+   * vitest also runs; the assertions that matter are erased before this runs.
+   * It does carry one honest statement: an author writing both keys produces an
+   * ordinary `DataTableSchema` value, no cast anywhere.
+   */
+  it('an author can write both keys on a plain DataTableSchema value', () => {
+    const authored: DataTableSchema = {
+      type: 'data-table',
+      columns: [{ header: 'Name', accessorKey: 'name' }],
+      data: [],
+      cellClassName: 'px-3 py-1',
+      renderCellEditor: ({ value }) => (value == null ? null : null),
+    };
+
+    expect(authored.cellClassName).toBe('px-3 py-1');
+    expect(typeof authored.renderCellEditor).toBe('function');
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -980,17 +980,32 @@ export interface DataTableSchema extends BaseSchema {
    */
   rowStyle?: (row: any, index: number) => React.CSSProperties | undefined;
   /**
-   * Extra CSS classes folded into EVERY body cell of the table
-   * (objectui#6882) — the table-level twin of {@link TableColumn.cellClassName},
-   * which styles one column. Both apply when both are present.
+   * Extra CSS classes folded into the table's UTILITY body cells
+   * (objectui#6882) — and ONLY those three, each rendered only when its
+   * feature is on: the leading selection-checkbox cell (`selectable`), the
+   * row-number cell (`showRowNumbers`), and the trailing row-actions cell
+   * (`rowActions`).
    *
-   * Its live use is row density: a host that renders compact / short / tall
-   * rows sets the per-cell padding here, because row height is a property of
-   * the cells, not of the `<tr>` — `rowClassName` cannot express it.
+   * ⚠️ It does NOT reach a data cell. A data cell folds
+   * {@link TableColumn.cellClassName} — the per-column key — and nothing else,
+   * so the two class slots style DISJOINT cells and never combine on one cell.
+   * (The empty-state cell and the add-record row cell take neither.) The
+   * population is checkable: `data-table.tsx` folds this key at exactly three
+   * `cn(cellClassName, …)` call sites, and the data-cell one folds
+   * `col.cellClassName`.
+   *
+   * Its live use is row density, and it is only half of that. Row height is a
+   * property of the cells, not of the `<tr>` — `rowClassName` cannot express
+   * it — so a host that renders compact / short / tall rows sets the per-cell
+   * padding on BOTH slots: `ObjectGrid` folds its density class into every
+   * column's `cellClassName` and passes the same class here, which is what
+   * keeps the checkbox and row-number cells the same height as the data beside
+   * them. Setting only this key leaves every data cell at the table
+   * primitive's default `p-4`.
    *
    * ⚠️ Declared as of objectui#6882 (maintainer ruling 2026-08-30). `data-table`
-   * has destructured this key off the schema and folded it into every body
-   * cell's class all along; only the declaration was missing. `string` matches
+   * has destructured this key off the schema and folded it into those three
+   * cells all along; only the declaration was missing. `string` matches
    * {@link BaseSchema.className} and {@link TableColumn.cellClassName} — the
    * renderer passes it through `cn()`, which would also swallow an array or an
    * object, but one authored spelling for a class slot is the contract.

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -920,6 +920,36 @@ export interface DataTableSchema extends BaseSchema {
    */
   singleClickEdit?: boolean;
   /**
+   * Host-supplied cell editor for inline editing (objectui#6882).
+   *
+   * When a cell enters edit mode the table calls this FIRST and renders what it
+   * returns; returning `null` means "no widget for this column" and the table
+   * falls through to its built-in text / number / date inputs. It exists so a
+   * higher layer (e.g. `ObjectGrid`) can hand a cell the SAME dedicated widget
+   * the form uses for that field type — select, lookup, boolean — without the
+   * component layer, which is deliberately `@object-ui/fields`-free, having to
+   * re-implement any of them.
+   *
+   * The returned node is wrapped by the table so it gains the exit-edit
+   * affordances the built-in editors have (Enter commits from a single-line
+   * input, Escape cancels, click-outside commits); `stage` records a value
+   * without leaving edit mode, `commit` saves, `cancel` discards.
+   *
+   * ⚠️ Declared as of objectui#6882 (maintainer ruling 2026-08-30). `data-table`
+   * has read this key on the production path since inline editing landed — it
+   * did so through a `(schema as any)` cast, which existed for no reason other
+   * than this declaration's absence and is gone with it. Nothing new runs; a
+   * misspelling is now caught at authoring time instead of failing silently.
+   */
+  renderCellEditor?: (ctx: {
+    column: any;
+    row: any;
+    value: any;
+    stage: (v: any) => void;
+    commit: (v?: any) => void;
+    cancel: () => void;
+  }) => React.ReactNode;
+  /**
    * Cell value change handler
    * Called when a cell value is edited
    */
@@ -949,6 +979,23 @@ export interface DataTableSchema extends BaseSchema {
    * Function that returns CSSProperties for each row (e.g., from conditionalFormatting).
    */
   rowStyle?: (row: any, index: number) => React.CSSProperties | undefined;
+  /**
+   * Extra CSS classes folded into EVERY body cell of the table
+   * (objectui#6882) — the table-level twin of {@link TableColumn.cellClassName},
+   * which styles one column. Both apply when both are present.
+   *
+   * Its live use is row density: a host that renders compact / short / tall
+   * rows sets the per-cell padding here, because row height is a property of
+   * the cells, not of the `<tr>` — `rowClassName` cannot express it.
+   *
+   * ⚠️ Declared as of objectui#6882 (maintainer ruling 2026-08-30). `data-table`
+   * has destructured this key off the schema and folded it into every body
+   * cell's class all along; only the declaration was missing. `string` matches
+   * {@link BaseSchema.className} and {@link TableColumn.cellClassName} — the
+   * renderer passes it through `cn()`, which would also swallow an array or an
+   * object, but one authored spelling for a class slot is the contract.
+   */
+  cellClassName?: string;
   /**
    * Number of columns to freeze (left-pin)
    * When set, the first N columns remain fixed while the rest scroll horizontally.

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -244,6 +244,8 @@ export const DataTableSchema = BaseSchema.extend({
   }).optional().describe('Per-record CEL predicates for the built-in row Delete item (objectui#2614)'),
   onSelectionChange: z.function().optional().describe('Selection change handler'),
   onColumnsReorder: z.function().optional().describe('Column reorder handler'),
+  cellClassName: z.string().optional().describe('Extra classes folded into every body cell — the table-level twin of the per-column `cellClassName`; carries row-density padding (objectui#6882)'),
+  renderCellEditor: z.function().optional().describe('Host-supplied inline cell editor; returning null falls through to the built-in text/number/date inputs (objectui#6882)'),
   frozenColumns: z.number().optional().describe('Number of frozen columns'),
   showRowNumbers: z.boolean().optional().describe('Show row numbers'),
   emptyAction: SchemaNodeSchema.optional().describe('Optional schema node rendered inside the empty-state, e.g. an "Add record" button. Lets the empty state become an actionable invitation rather than a dead end.'),

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -244,7 +244,7 @@ export const DataTableSchema = BaseSchema.extend({
   }).optional().describe('Per-record CEL predicates for the built-in row Delete item (objectui#2614)'),
   onSelectionChange: z.function().optional().describe('Selection change handler'),
   onColumnsReorder: z.function().optional().describe('Column reorder handler'),
-  cellClassName: z.string().optional().describe('Extra classes folded into every body cell — the table-level twin of the per-column `cellClassName`; carries row-density padding (objectui#6882)'),
+  cellClassName: z.string().optional().describe('Extra classes folded into the utility body cells only — the selection, row-number and row-actions cells; data cells fold the per-column `cellClassName` instead, so row density has to be set on both (objectui#6882)'),
   renderCellEditor: z.function().optional().describe('Host-supplied inline cell editor; returning null falls through to the built-in text/number/date inputs (objectui#6882)'),
   frozenColumns: z.number().optional().describe('Number of frozen columns'),
   showRowNumbers: z.boolean().optional().describe('Show row numbers'),


### PR DESCRIPTION
Fixes #6882

Executes the maintainer ruling of 2026-08-30 (batch #4, verbatim 「同意」), option **A**: declare `renderCellEditor` and schema-level `cellClassName` on `DataTableSchema`, document them, and drop the `(schema as any)` cast in `data-table.tsx`.

Clause ②: this **widens a published type face**, so it is opened as a draft on the `CONTRACT_REVIEW_TIER` review chain. ⛔ Not mine to mark ready or merge.

---

## What lands

| file | change |
|---|---|
| `packages/types/src/data-display.ts` | `DataTableSchema` declares `renderCellEditor` and `cellClassName` |
| `packages/types/src/zod/data-display.zod.ts` | the zod mirror gains both keys |
| `packages/components/src/renderers/complex/data-table.tsx` | the `(schema as any)` cast becomes `schema.renderCellEditor` |
| `content/docs/components/complex/data-table.mdx` | both keys documented, with a "Cell styling" and an "Inline editing" section |
| `packages/types/src/__tests__/data-table-declared-keys-6882.test.ts` | compile-time pin, new |
| `.changeset/6882-...md` | changeset |

The zod mirror is not a rider. `zod-mirror-parity.test.ts` reconciles every declared-but-unmirrored key against two ledgers, and its header states that adding to `UnmirroredDeclared` is **not a supported route** (shrink-only); the one exception routes callback-shaped keys to `RuntimeOnlyDeclared`, which `assertionRuntimeOnlyIsCallbackShapedOnly` restricts to `on` + uppercase spellings — `renderCellEditor` is not one. So **mirroring is the only supported route**, and it is the route #6639 took for `ObjectGridSchema.title`. Declaring the keys without mirroring reddens `assertionUnmirroredMatchesLedger`; that firing was observed and is quoted below. **Neither ledger is edited.**

## The widening, stated exactly

Two keys land on `DataTableSchema`:

```
renderCellEditor?: (ctx: {
  column: any;
  row: any;
  value: any;
  stage: (v: any) =. void;
  commit: (v?: any) =. void;
  cancel: () =. void;
}) =. React.ReactNode;

cellClassName?: string;
```

(The `=.` above is an arrow; see the diff for the real bytes.)

**What an author can write after this change that they could not write before: nothing new runs.** Both keys already worked, at any value at all, because `BaseSchema` carries an `[key: string]: any` index signature that `DataTableSchema` inherits — every string was already a member. `data-table` already read both on the production path: `renderCellEditor` through the cast being removed here, `cellClassName` by destructuring it into the `className` of the table's three utility cells — the selection checkbox, the row number, the row actions. (Corrected 2026-08-30: this line, and the docs that shipped with it, said "every body cell". Re-measured on the render, schema-level `cellClassName` reaches those three cells and no others; every data cell folds `TableColumn.cellClassName` and nothing else. Commit `4738f2727` fixes the docblock, the zod describe, the mdx section and its example, and the changeset.) Nothing in the renderer changed; no value flows anywhere it did not flow yesterday.

What changes is that the two keys are now **checked at authoring time** and **offered by completion**, and that the shape of `renderCellEditor`'s context is stated once, at its source, instead of being re-asserted locally by a cast that nothing verified.

The declared shapes are transcribed from the consumer, not invented: they are byte-identical to what the cast asserted and to the seam hold `ObjectGridDataTableSchemaHolds` in `plugin-grid`, and the context members match the list PR #6912 independently wrote into the comment at `injectedEditorElRef` while this branch was open (`{ column, row, value, stage, commit, cancel }`).

## The reject direction — it exists, and it was measured

Yes, there is one, and it is deliberate. Because the keys used to be absorbed as `any`, author code with a **wrong-shaped value** also compiled and then silently did nothing. Such code now fails to compile. Measured, not reasoned: a probe file asserting both shapes was compiled against this branch and against the same tree with both declarations ablated.

| probe | declarations present (this PR) | declarations ablated (pre-#6882 shape) |
|---|---|---|
| `cellClassName: ['px-2', 'py-1']` | TS2322 — `string[]` is not assignable to `string` | accepted, 0 diagnostics |
| `renderCellEditor: 'not-a-function'` | TS2322 — `string` is not assignable to the context function type | accepted, 0 diagnostics |

Both narrowings are the intended half of the ruling:

- `cellClassName` is declared `string`, matching `BaseSchema.className` and `TableColumn.cellClassName`. The renderer folds it through `cn()`, which would also swallow an array or an object — so the declaration is narrower than the *read*, on purpose. One authored spelling for a class slot is the contract (#0.1, contract-first).
- `renderCellEditor` is declared as the function the renderer actually calls. Its parameters stay `any` where the renderer passes `any`; narrowing `column` to `TableColumn` would be a reject-direction change the ruling did not authorise, and would break an author whose own handler declares a narrower context.

No key was retired, no existing declared key changed type, and no accepted *function* shape narrowed: every value that ran before still runs.

## The cast is gone, and nothing replaced it

```
- const injectEditor = (schema as any).renderCellEditor as
-   | ((ctx: { column: any; row: any; value: any; stage: ...; commit: ...; cancel: ... }) =. React.ReactNode)
-   | undefined;
+ const injectEditor = schema.renderCellEditor;
```

`grep -n 'schema as any' packages/components/src/renderers/complex/data-table.tsx` returns exactly one line on this branch — inside the replacement **comment**, which records why the cast existed. No second cast, no `any` annotation, no `@ts-expect-error`, no `eslint-disable`. The lint delta below is the mechanical confirmation.

## Verification

Final commit `4a9a4b37d` (a merge of `origin/main` `689ae3d13` into the work commit; PR #6912 landed on `data-table.tsx` mid-flight and merged without a textual conflict — its comment block is intact, `NOTHING EVER HANDS THE WIDGET ONE` and four `objectui#6859` references present).

**Red first, and the direction proved rather than asserted.** The pin was written *before* the declarations and compiled against the tree without them:

```
packages/types/src/__tests__/data-table-declared-keys-6882.test.ts(98,43): error TS2344: Type 'false' does not satisfy the constraint 'true'.
packages/types/src/__tests__/data-table-declared-keys-6882.test.ts(100,40): error TS2344: Type 'false' does not satisfy the constraint 'true'.
packages/types/src/__tests__/data-table-declared-keys-6882.test.ts(119,31): error TS2339: Property 'renderCellEditor' does not exist on type 'Declared[DataTableSchema]'.
packages/types/src/__tests__/data-table-declared-keys-6882.test.ts(125,67): error TS2339: Property 'cellClassName' does not exist on type 'Declared[DataTableSchema]'.
packages/types/src/__tests__/data-table-declared-keys-6882.test.ts(140,28): error TS7031: Binding element 'value' implicitly has an 'any' type.
```

⚠️ A naive membership pin here is **green and vacuous twice over**, and the file closes both holes:

1. `BaseSchema`'s index signature makes `DataTableSchema['anything']` resolve to `any`, so any question asked of the raw type answers "declared" for every string. The pin strips the index signature first, so non-membership can exist at all.
2. `Expect of (X extends true ? true : false)` is satisfied by `never` (assignable to everything) and by `any`. The pin compares with an invariant function-identity equality instead.

**The direction is proved mechanically, by four `@ts-expect-error` directives.** TypeScript reports an *unused* `@ts-expect-error` as TS2578, so each directive is a claim that the instrument really refuses something: the assertion helper must refuse `false`; the equality must refuse `never` and `any`; and the membership question must answer `false` for a key nothing declares (which it can only do if the strip really happened). Break any part of the instrument — widen the helper, make the equality `extends`-shaped, make the strip a no-op — and the file goes **red on the now-unused directive** instead of quietly passing. Both compilations above ran with all four directives satisfied.

**Ablation — predicted, then observed row by row.** Each leg: mutate, prove the mutation on disk (anchored counts plus `git hash-object`), rebuild `@object-ui/types` and prove the mutation reached `dist/*.d.ts` (which is what the components program reads — its `--listFiles` names `packages/types/dist/data-display.d.ts`, not `src`), measure, restore, prove the restore (`git hash-object` equal to the HEAD blob **and** `git diff HEAD` empty). `trap ... EXIT INT TERM` with absolute paths throughout.

| ablation | predicted | observed |
|---|---|---|
| **A** — remove the `renderCellEditor` declaration | types pin RED on both its `renderCellEditor` rows | RED: TS2344 at the membership row, TS2339 at the shape row, plus TS7031 in the runtime literal |
| **A**, components leg | GREEN — the read degrades to `any` through the index signature, it does not fail | GREEN, exit 0. ⭐ Recorded as a real limit: the components typecheck is **not** a detector of the declaration's absence |
| **B** — remove the `cellClassName` declaration | types pin RED on both its `cellClassName` rows only | RED: TS2344 at the membership row, TS2339 at the shape row; `renderCellEditor` rows untouched |
| **B**, components leg | GREEN, same reason as A | GREEN, exit 0 |
| **C** — keep the key, drop one member (`cancel`) from the declared context | components RED at the call site — this is what shows the removal is load-bearing | RED: `data-table.tsx(2287,37): error TS2353: Object literal may only specify known properties, and 'cancel' does not exist in type ...` |
| **C**, types pin | RED on the shape row only, not the membership row | RED: exactly one error, TS2344 at line 118 |

⭐ **C is the answer to "does the declaration match what the code actually reads".** With the cast gone, the call site is checked against the declaration; remove one context member and the renderer stops compiling, naming the member. Ablation A's green components leg is the same fact from the other side and is why the pin lives in `packages/types` and asks about **declared membership**, not about property access.

Anti-vacuity of the parity gate: declaring the keys without mirroring them produced `zod-mirror-parity.test.ts(1219,14): error TS2322: Type '"data-display.zod.ts#DataTableSchema"' is not assignable to type 'never'` — the gate naming the pair. Mirroring cleared it with no ledger edit.

**Program-input proof (a typecheck that excluded the files would read green and measure nothing).** `--listFiles` on both projects:

- `packages/types/tsconfig.test.json` — 524 inputs, including `src/__tests__/data-table-declared-keys-6882.test.ts`, `src/data-display.ts`, `src/zod/data-display.zod.ts` and `src/__tests__/zod-mirror-parity.test.ts`.
- `packages/components` `tsconfig.json` — 1367 inputs, including `src/renderers/complex/data-table.tsx` and `packages/types/dist/data-display.d.ts`.

**Builds and typechecks** (dependency closure built first — an unbuilt closure produces false TS2307 REDs):

| command | result |
|---|---|
| `turbo run build --filter='!@object-ui/site' --concurrency=2` | 43 successful, 43 total |
| `pnpm --filter @object-ui/types type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/components type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `pnpm --filter @object-ui/plugin-grid type-check` | exit 0 — the seam intersection still compiles |

**Tests, from the repo root with path filters** (the documented way; `pnpm --filter pkg test` is this repo's zero-match false-green trap):

| command | files | tests |
|---|---|---|
| `pnpm exec vitest run packages/types/` | 75 passed (75) | 858 passed (858) |
| `pnpm exec vitest run packages/components/` | 218 passed (218) | 2004 passed (2004) |
| `pnpm exec vitest run packages/plugin-grid/ packages/plugin-dashboard/` | 183 passed (183) | 1702 passed (1702) |

**Lint — the full farm, not a narrowing.** `pnpm lint` (`turbo run lint`, 47 tasks): **47 successful, 47 total**, exit 0, zero packages reporting a nonzero error count.

Per-file base-versus-head, base blob identity asserted **before** the base content was used (`git rev-parse BASE:path` non-empty and different from the HEAD blob; on-disk hash equal to the HEAD blob before mutating; restore proved by hash equality and an empty `git diff HEAD`):

| file | base | head | delta |
|---|---|---|---|
| `data-table.tsx` | 0 errors / 39 warnings | 0 / 33 | `no-explicit-any` 28 -. 22 |
| `data-display.ts` | 0 / 23 | 0 / 28 | `no-explicit-any` 23 -. 28 |
| `data-display.zod.ts` | 0 / 1 | 0 / 1 | unchanged |

That accounting is exact and worth reading: the cast contained **six** `any`s. Five of them were the context members, and they moved to the declaration verbatim — the same five, one package over. The sixth was `(schema as any)` itself, and it is simply gone. Across these three files: **total warnings 63 to 62**, and `no-explicit-any` specifically **52 to 51** — the same -1, but they are two different figures. (The per-file table above prints `no-explicit-any` for `data-table.tsx` and `data-display.ts`; `data-display.zod.ts` carries 1 on both sides, which is what makes the `no-explicit-any` totals 52 and 51.) Every other rule is unchanged, and errors are 0 on both sides. Corrected 2026-08-30 after the CONTRACT_REVIEW_TIER review: the earlier line labelled the total-warning delta as a `no-explicit-any` delta.

**Other gates re-derived from the actual diff and run on the final commit:** `check:doc-fences`, `check:doc-types`, `check:doc-snippets`, `docs:check-links`, `check:control-bytes`, `check:readme-exports`, `check:self-import`, `check:esm-specifiers`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:shell-escape-residue`, `check:docs-route-closure`, `lint:coverage`, `type-check:coverage`, `check-changeset-presence`, `changeset:check` — all exit 0.

## Not measured, on purpose

The ruling recorded a confidence gap before deciding: the **in-repo readers** were measured, the **external authoring surface** was not — nobody knows whether authors outside this repo already write these two keys. The maintainer ruled knowing that, and noted it cuts *toward* A. It is a recorded limitation of a decision already made, so this PR did **not** go measuring external consumers.

## One thing found and not fixed here

`scripts/__tests__/check-sdui-registration-pins.test.ts` fails on any tree where `packages/app-shell/dist` exists: that package's `sideEffects` array lists both `./dist/...ConnectAgentWidget.js` and `./src/...ConnectAgentWidget.tsx`, the dist spelling comes first, and the derivation records whichever it reads first. Probed by moving `dist` aside — the file then passes 11/11 — and restoring it. Unrelated to this diff, which touches no app-shell file and registers nothing. Already filed as #6893, so nothing new was filed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_

---
_Generated by [Claude Code](https://claude.ai/code)_