### PR TITLE
fix(plugin-detail): drop the two undeclared arms from RecordDetailDrawer's relationship-target chain

### DIFF
--- a/.changeset/6837-recorddrawer-invented-target-arms.md
+++ b/.changeset/6837-recorddrawer-invented-target-arms.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`RecordDetailDrawer` resolves a relationship target only from the two spellings
+a contract carries, dropping the two no contract declares (objectui#6837, first
+slice).
+
+The chain was `def.reference_to ?? def.reference ?? def.referenceTo ??
+def.target`; it is now `def.reference_to ?? def.reference`.
+
+**Accept-set move — a def carrying ONLY `referenceTo`, or ONLY `target`, stops
+resolving a target** and the field renders without one (the drawer already marks
+every reference-bearing field readonly, so nothing becomes editable that was
+not). Two things bound that:
+
+- Any def that entered through the ingestion choke point is unaffected.
+  `normalizeSchemaReferenceKeys` reads `reference_to ?? reference ??
+  referenceTo` and stamps both snake_case keys, so a `referenceTo`-only def
+  arriving via `MetadataProvider` or `ObjectStackAdapter.getObjectSchema`
+  already carries `reference_to` before the drawer sees it. Only a def that
+  bypassed that door entirely is affected.
+- `target` was never read anywhere else in the stack — not by the normalizer,
+  not by the spec. `@objectstack/spec`'s `FieldSchema` refuses both deleted
+  spellings by name with `unrecognized_keys`, each carrying its own "did you
+  mean `reference`" rename, and `referenceTo` is additionally stripped at the
+  designer read door (`RETIRED_FIELD_KEYS`, objectui#6041 / #6519).
+
+A repo-wide structure-walk producer census found **0** emitters of `target` and
+**0** reaching this seam for `referenceTo`, measured in the cell the drawer
+reads (a value inside an object schema's `fields` container) against controls
+`reference` (92 hits / 36 files) and `reference_to` (52 / 36) hot in the same
+pass over the same cells.
+
+Pinned by `RecordDetailDrawer.referenceArms-6837.test.tsx`, which keeps the live
+arms green beside a named refusal per deleted key.

--- a/packages/plugin-detail/src/RecordDetailDrawer.tsx
+++ b/packages/plugin-detail/src/RecordDetailDrawer.tsx
@@ -263,8 +263,32 @@ export function RecordDetailDrawer({
         format: def.format,
         // Served schemas key the target as `reference` (ObjectStack
         // convention, #2407); the drawer can receive a raw schema from any
-        // DataSource, so resolve every spelling.
-        reference_to: def.reference_to ?? def.reference ?? def.referenceTo ?? def.target,
+        // DataSource, so both snake_case spellings are resolved here.
+        //
+        // Two further arms stood here until objectui#6837 — `def.referenceTo`
+        // and `def.target` — and they were NOT redundant-but-harmless: no
+        // contract declares either spelling. `FieldSchema` refuses BOTH by name
+        // with `unrecognized_keys`, each carrying its own "did you mean
+        // `reference`" rename; `referenceTo` is additionally stripped at the
+        // designer read door (`RETIRED_FIELD_KEYS`, objectui#6041 / #6519), so
+        // that arm could never hit. A structure-walk producer census found ZERO
+        // emitters of either at THIS cell — a value inside an object schema's
+        // `fields` container, which is what `objectSchema.fields[name]` reads —
+        // while the controls `reference` (92 hits / 36 files) and `reference_to`
+        // (52 / 36) were hot in the same pass over the same cells. So the two
+        // arms were invented tolerance surface: a silent absorption point for a
+        // producer that should fail visibly (AGENTS.md #0.1).
+        //
+        // ⛔ Do not re-add a spelling arm here. A producer emitting a refused
+        // spelling is fixed AT THE PRODUCER, or canonicalised once at the
+        // ingestion choke point (`normalizeSchemaReferenceKeys`, which stamps
+        // both snake_case keys from whichever spelling arrived) — never by a
+        // renderer-side alias.
+        //
+        // The two remaining arms are deliberately left standing: deciding
+        // between them per reader is objectui#6837's OPEN scope (the
+        // classification table over ~20 more readers), not this slice's.
+        reference_to: def.reference_to ?? def.reference,
         reference_field: def.reference_field ?? def.referenceField,
         required: def.required,
         validation: def.validation,

--- a/packages/plugin-detail/src/__tests__/RecordDetailDrawer.referenceArms-6837.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RecordDetailDrawer.referenceArms-6837.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6837 (first slice) — the drawer's relationship-target chain drops the
+ * two arms NO CONTRACT DECLARES, and keeps the two that carry the value.
+ *
+ * Before:  `def.reference_to ?? def.reference ?? def.referenceTo ?? def.target`
+ * After:   `def.reference_to ?? def.reference`
+ *
+ * ## 1. The measurement this pin stands on (not just its conclusion)
+ *
+ * THE CELL: a value inside an object schema's `fields` container — literally
+ * what this component reads, `objectSchema.fields[name]`. Producer census by
+ * STRUCTURE WALK (TypeScript compiler API over every tracked `.ts`/`.tsx`, plus
+ * parsed JSON/YAML), recording each hit's ancestor property chain; EMIT
+ * positions only, so `def.target` (a read) is never counted as a producer.
+ * Subject and control terms were extracted BY THE SAME PASS, FROM THE SAME
+ * CELLS, IN THE SAME UNITS — the control sits on the JOIN, not merely on the
+ * terms.
+ *
+ *   | term           | role    | repo-wide emits | IN THE CELL   |
+ *   |----------------|---------|-----------------|---------------|
+ *   | `target`       | SUBJECT | 1329 / 366 files| **0** / 0     |
+ *   | `referenceTo`  | SUBJECT |   80 /  41 files| **2** / 2     |
+ *   | `reference`    | CONTROL |  194 /  75 files|  92 / 36      |
+ *   | `reference_to` | CONTROL |  136 /  87 files|  52 / 36      |
+ *
+ * A second, INDEPENDENT cell test that does not rely on a `fields` ancestor —
+ * "the enclosing object's own `type` is reference-bearing"
+ * (`EXPANDABLE_FIELD_TYPES`) — agrees: `target` 0, and every one of the 29
+ * `referenceTo` hits is a test fixture at OTHER seams (action params, the
+ * filter builder, the retirement machinery), none in `plugin-detail` and none
+ * reaching this drawer.
+ *
+ * The two in-cell `referenceTo` hits are NEGATIVE fixtures of the retirement
+ * machinery itself (`object-fields-io.spec-keys`, `MetadataFieldsPage
+ * .specKeyReference`): they poison a draft with the retired key precisely to
+ * assert the read door STRIPS it. A fixture asserting removal is not a producer.
+ *
+ * Why `target`'s repo-wide 1329 is not a counter-example: every one of those
+ * emits belongs to a DIFFERENT TIER. Attributed by the enclosing object's own
+ * `type` value they are `api` (137), `url` (35), `script` (32), `form` (16),
+ * `flow` (13), `back` (9), `modal` (6), `fault` (5) — action and navigation
+ * nodes — plus 1062 with no sibling `type` at all (DOM event targets, link
+ * targets). Not one lands on a field definition.
+ *
+ * ## 2. Why refusal is correct, not merely unused-today
+ *
+ * `@objectstack/spec`'s `FieldSchema` refuses BOTH deleted spellings BY NAME
+ * with `unrecognized_keys`, each carrying its own "did you mean `reference`"
+ * rename — measured two-directionally against the installed spec, alongside
+ * `reference` parsing clean. `referenceTo` is additionally in
+ * `RETIRED_FIELD_KEYS` (objectui#6041 / #6519), so the designer read door
+ * strips it before any draft round-trips. So these were not "redundant"
+ * fallbacks: they were INVENTED tolerance surface — a silent absorption point
+ * for a producer that ought to fail visibly (AGENTS.md #0.1).
+ *
+ * ## 3. No precedence inversion exists here — stated rather than fabricated
+ *
+ * Both deleted arms sat at the END of the chain
+ * (`reference_to ?? reference ?? referenceTo ?? target`), so neither could ever
+ * preempt a contract-carrying spelling. There is therefore NO inversion case to
+ * pin, and this file deliberately does not invent one: a
+ * `{ reference: 'a', target: 'b' }` case would resolve to `'a'` both before and
+ * after the change and would measure nothing. (Copied from PR #6916 / card
+ * #6840, which set this form and made the same call for `value`.)
+ *
+ * ## 4. THE FLOOR, restated where someone would try to re-widen it
+ *
+ * ⛔ Do not re-add a spelling arm to this chain. A producer emitting a refused
+ * spelling is fixed AT THE PRODUCER, or canonicalised ONCE at the ingestion
+ * choke point — `normalizeSchemaReferenceKeys`, which stamps both snake_case
+ * keys from whichever spelling arrived. Never a renderer-side alias: that is
+ * how twenty per-consumer dual-key fallbacks got written under a normalizer
+ * whose own docstring says it exists "so per-consumer dual-key fallbacks can't
+ * drift".
+ *
+ * ⛔ The two SURVIVING arms are out of this slice's scope. Deciding between
+ * `reference_to` and `reference` per reader is objectui#6837's OPEN scope (the
+ * classification table over ~20 more readers across eight other packages), and
+ * triage refused a single mechanical sweep because those readers are fed by
+ * different contracts. #6837 stays open.
+ *
+ * ## 5. Ablation direction, predicted before running
+ *
+ * Restore either deleted arm on the committed tree and the matching refusal
+ * goes RED while every live-arm control stays GREEN — that contrast is what
+ * makes the controls controls rather than duplicates of the pins. The pin
+ * imports the component by RELATIVE SOURCE PATH (`../RecordDetailDrawer`), so
+ * no package `exports` hop and no `dist` leg is involved.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { normalizeSchemaReferenceKeys } from '@object-ui/core';
+import { RecordDetailDrawer } from '../RecordDetailDrawer';
+
+/**
+ * The drawer hands its derived field list to `DetailView` as `schema.fields`.
+ * Standing in for `DetailView` captures that list without rendering the whole
+ * detail tree — the resolved `reference_to` under test is a property of the
+ * list, not of how DetailView paints it. (Same harness as
+ * `expandableFamily.identity-5874.test.tsx`, which pins the sibling rule
+ * derived from the very same `.map()`.)
+ */
+const capturedFields: { current: any[] } = { current: [] };
+vi.mock('../DetailView', () => ({
+  DetailView: ({ schema }: any) => {
+    capturedFields.current = schema?.fields ?? [];
+    return <div data-testid="detail-view-stub" />;
+  },
+}));
+
+/** Every probe is a `lookup`, so only the target SPELLING varies between them. */
+const FIELD_DEFS: Record<string, Record<string, unknown>> = {
+  // Live arms — the two spellings a contract actually carries at this seam.
+  canonical: { type: 'lookup', label: 'Canonical', reference_to: 'crm_account' },
+  spec_spelling: { type: 'lookup', label: 'Spec', reference: 'crm_account' },
+  // Deleted arms — refused by name, zero producers in the cell.
+  legacy_camel: { type: 'lookup', label: 'Legacy camel', referenceTo: 'crm_account' },
+  invented: { type: 'lookup', label: 'Invented', target: 'crm_account' },
+  // Non-relation control: carries no target spelling at all.
+  plain_text: { type: 'text', label: 'Plain' },
+};
+
+const RECORD: Record<string, unknown> = {
+  id: 'r1',
+  canonical: 'acc-1',
+  spec_spelling: 'acc-1',
+  legacy_camel: 'acc-1',
+  invented: 'acc-1',
+  plain_text: 'hello',
+};
+
+/** Render the drawer over `fields` and return the list handed to DetailView. */
+function resolveFields(fields: Record<string, unknown>) {
+  capturedFields.current = [];
+  render(
+    <RecordDetailDrawer
+      open
+      onClose={() => {}}
+      title="Probe"
+      record={RECORD}
+      recordId="r1"
+      objectName="probe"
+      objectSchema={{ name: 'probe', fields } as any}
+      onFieldSave={async () => {}}
+    />,
+  );
+  return capturedFields.current;
+}
+
+/** The `reference_to` the drawer resolved for one field name. */
+function resolvedTarget(name: string, fields: Record<string, unknown> = FIELD_DEFS) {
+  return resolveFields(fields).find((f: any) => f.name === name)?.reference_to;
+}
+
+describe('RecordDetailDrawer resolves only contract-declared target spellings (objectui#6837)', () => {
+  describe('live arms — the value still arrives (without these, a drawer that stopped resolving anything would pass the refusals too)', () => {
+    it("resolves `reference_to`, ObjectUI's own view/field key", () => {
+      expect(resolvedTarget('canonical')).toBe('crm_account');
+    });
+
+    it('resolves `reference`, the spelling `FieldSchema` accepts', () => {
+      expect(resolvedTarget('spec_spelling')).toBe('crm_account');
+    });
+
+    it('still derives the whole field list, relations and non-relations alike', () => {
+      // Guards the refusals below against the degenerate pass: a drawer that
+      // produced no fields at all would satisfy every `toBeUndefined()`.
+      const names = resolveFields(FIELD_DEFS).map((f: any) => f.name);
+      expect(names).toEqual(
+        expect.arrayContaining(['canonical', 'spec_spelling', 'legacy_camel', 'invented', 'plain_text']),
+      );
+    });
+
+    it('marks the relation fields readonly, so the list is genuinely populated', () => {
+      const f = resolveFields(FIELD_DEFS).find((x: any) => x.name === 'canonical');
+      expect(f?.readonly).toBe(true);
+    });
+  });
+
+  describe('refusals — one named case per deleted key', () => {
+    it("does NOT read `referenceTo` (RETIRED_FIELD_KEYS, objectui#6041/#6519; `FieldSchema` refuses it by name)", () => {
+      expect(resolvedTarget('legacy_camel')).toBeUndefined();
+    });
+
+    it("does NOT read `target` (no contract declares it; 0 producers in the cell against controls of 92 and 52)", () => {
+      expect(resolvedTarget('invented')).toBeUndefined();
+    });
+  });
+
+  describe('the ingestion choke point is what makes the `referenceTo` deletion lossless', () => {
+    it('a `referenceTo`-only def that came through `normalizeSchemaReferenceKeys` STILL resolves', () => {
+      // This is the mechanism, not a formality: the normalizer reads
+      // `reference_to ?? reference ?? referenceTo` and stamps both snake_case
+      // keys, so every def that entered through MetadataProvider or
+      // ObjectStackAdapter.getObjectSchema already carries `reference_to` by
+      // the time the drawer sees it. The deleted arm was dead weight for those.
+      const schema = { name: 'probe', fields: { legacy_camel: { ...FIELD_DEFS.legacy_camel } } };
+      normalizeSchemaReferenceKeys(schema);
+      expect(resolvedTarget('legacy_camel', schema.fields)).toBe('crm_account');
+    });
+
+    it('a `target`-only def does NOT resolve even through the normalizer — nothing in the stack ever declared it', () => {
+      // `normalizeFieldReferenceKeys` never read `target` either. So unlike
+      // `referenceTo`, `target` had no home anywhere in the stack: not in the
+      // spec, not at the choke point, not in the retirement registry.
+      const schema = { name: 'probe', fields: { invented: { ...FIELD_DEFS.invented } } };
+      normalizeSchemaReferenceKeys(schema);
+      expect(resolvedTarget('invented', schema.fields)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Refs #6837

⭐ **`Refs`, deliberately — not a closing keyword.** This is the **first slice only**
of #6837. The card's remaining scope is the per-reader classification table over ~20
more readers in eight other packages, and triage refused a single mechanical sweep for
them: *⛔ 不得开一个 PR 把二十处一起改掉*. #6584 already demonstrated what closing on the
first slice costs — a card that closes takes its deferred half with it, and that bucket
question lost its home for four days. **#6837 stays open after this lands.**

`RecordDetailDrawer` resolved a relationship target through four spellings:

```ts
def.reference_to ?? def.reference ?? def.referenceTo ?? def.target
```

Two of them are declared by no contract. This PR removes exactly those two, and leaves
the other two alone.

---

## 1. The producer census came first — it is a precondition, not a formality

Triage made it one, with a measured reason: *没有正对照的零,在本仓最近的卡里已经连翻
四次(objectstack#13293 / #13304 / #13305 / #13306)*.

**Method** — the one #6719 established and triage passed forward: a **structure walk**,
⛔ not text matching. The TypeScript compiler API over every tracked `.ts`/`.tsx`, plus
parsed JSON and YAML; each hit records its **ancestor property chain**, so a hit's cell
is established structurally rather than by a line window. 5851 tracked files, 1819 hit
records.

**EMIT positions only.** A `PropertyAssignment` is a producer; a `PropertyAccessExpression`
(`def.target`) is a *reader* and is never counted. `PropertySignature` — a type
declaration — is bucketed separately. Counting reads instead of emits is precisely the
wrong-question failure the control exists to catch.

**THE CELL** is a value inside an object schema's `fields` container — literally what
this component reads, `objectSchema.fields[name]`.

**Sweep A — repo-wide, every emit position, any depth**

| term | role | hits | files |
|---|---|---|---|
| `target` | **SUBJECT** | 1329 | 366 |
| `referenceTo` | **SUBJECT** | 80 | 41 |
| `reference` | CONTROL | 194 | 75 |
| `reference_to` | CONTROL | 136 | 87 |

**Sweep B — THE CELL (emit inside a `fields` container)**

| term | role | hits | files |
|---|---|---|---|
| `target` | **SUBJECT** | **0** | **0** |
| `referenceTo` | **SUBJECT** | **2** | 2 |
| `reference` | CONTROL | **92** | 36 |
| `reference_to` | CONTROL | **52** | 36 |

**The 2 in-cell `referenceTo` hits are negative fixtures of the retirement machinery
itself** — `object-fields-io.spec-keys.test.ts:235` and
`MetadataFieldsPage.specKeyReference.test.tsx:75` both poison a draft with the retired
key precisely to assert the read door **strips** it, so the body comes out
`ObjectSchema`-parseable. A fixture asserting removal is not a producer.

### A second, independent cell test — because one cell definition is not enough

The ancestor-chain test has a blind spot: a field def built in a variable and only later
assigned into `fields`. So a second test that does **not** rely on a `fields` ancestor was
run — the enclosing object's own `type` value being reference-bearing
(`EXPANDABLE_FIELD_TYPES` = `lookup` / `master_detail` / `tree` / `user`, the same family
the drawer's own `isExpandableFieldType` reads):

| term | role | hits | files |
|---|---|---|---|
| `target` | **SUBJECT** | **0** | **0** |
| `referenceTo` | **SUBJECT** | 29 | 13 |
| `reference` | CONTROL | 155 | 58 |
| `reference_to` | CONTROL | 100 | 64 |

The two tests agree on `target`: **zero, both ways.** All 29 `referenceTo` hits are test
fixtures at **other seams** — action params (`paramToField`, `resolveActionParams`,
`ActionParamDialog`), the filter builder, the retirement machinery — **none in
`plugin-detail`, and none reaching this drawer.** The one non-test emitter,
`resolveActionParams.ts:532`, writes `referenceTo` onto an `ActionParamDef`, which is the
action-parameter contract's own live key and a different tier; it never becomes a `fields`
container. (That reader is itself one of the ~20 named in the card body — out of fence
here.)

### ⭐ Both halves of the control discipline, stated separately

Triage required the control on the **join** — the cell the zero lives in — not merely on
the terms.

**Half 1 — the query ran.** The controls are hot *in the very cells where the subject zero
lives*: 92 and 52 hits, from the same pass.

**Half 2 — the question was right.** A hot control proves the query ran; it does not prove
the question was right. The second half is that subject and control terms were extracted
**by the same pass, from the same cells, in the same units** — emitted keys on a field
definition, which is exactly what `target` and `referenceTo` were counted as. Had the
question been wrong (scanning read positions instead of emit positions, or a cell
definition that excludes real field defs), the controls would have moved **together with**
the subjects rather than separating 92-to-0.

There is a third, unusually direct check available here: **the subject term `target` is
itself hot repo-wide** — 1329 emits — and collapses to 0 only when restricted to the cell.
So the zero is produced by the restriction, not by a scanner that cannot see the word.
Attributed by the enclosing object's own `type` value, all 1329 belong to a **different
tier**: `api` (137), `url` (35), `script` (32), `form` (16), `flow` (13), `back` (9),
`modal` (6), `fault` (5) — action and navigation nodes — plus 1062 with no sibling `type`
at all (DOM event targets, link targets). **Not one lands on a field definition.**

⭐ The recorded exclusion was honoured and not re-opened:
`examples/schema-catalog/src/schemas/fields-lookup/*.json` are
`{ type: 'form', fields: [...] }` **UI component schemas** — ObjectUI's own view/field
tier, not object metadata documents. They carry `reference_to`, are untouched by this PR,
and appear in the census only as context.

**The stop-and-report branch was not reached.** Had `target` shown a producer at this
seam, this would have gone back as a report rather than a deletion.

---

## 2. ⚠️ A correction to the card's stated premise — the conclusion survives, one supporting fact does not

The card and the dispatch both say `target` is *"not in the spec's alias table"*. **That is
not accurate, and the record should say so.** `target` **is** in the alias table — it sits
in `FieldSchema`'s own `aliases` map in `@objectstack/spec` as `target: "reference"`.

What the table does, however, is the opposite of declaring the key. Measured
two-directionally against the installed spec:

| probe | verdict |
|---|---|
| `reference: 'crm_account'` | **ACCEPT** |
| `reference_to: 'crm_account'` | REFUSE — `unrecognized_keys`, "Did you mean `reference_to` → `reference`?" |
| `referenceTo: 'crm_account'` | REFUSE — `unrecognized_keys`, "Did you mean `referenceTo` → `reference`?" |
| `target: 'crm_account'` | REFUSE — `unrecognized_keys`, "Did you mean `target` → `reference`?" |

So the alias entry is a **rename hint attached to a refusal**, not an acceptance. The
operative claim — *no contract declares these two spellings* — is therefore **stronger**
than the card put it: the spec names `target` explicitly, in order to refuse it. The
premise holds; only its supporting detail needed correcting.

---

## 3. Why these two were invented tolerance surface, not redundancy

- `referenceTo` — in `RETIRED_FIELD_KEYS` (objectui#6041, the card cites #6519), stripped
  at all three designer strip sites, so the read door removes it before a draft ever
  round-trips.
- `target` — refused by name, and **never read anywhere else in the stack**:
  `normalizeFieldReferenceKeys` reads `reference_to ?? reference ?? referenceTo` and does
  **not** read `target`. It has no home in the spec, none at the choke point, none in the
  retirement registry.

⇒ Each was a place where a producer emitting a refused spelling would be **silently
absorbed rather than failing visibly** (AGENTS.md #0.1) — the exact tension the card was
filed to record, under a normalizer whose own docstring says it runs at the choke point
*"so per-consumer dual-key fallbacks can't drift"*.

**Accept-set move, stated in the changeset:** a def carrying only `referenceTo`, or only
`target`, stops resolving a target. Bounded by the ingestion door — a `referenceTo`-only
def that came through `normalizeSchemaReferenceKeys` still resolves, because the choke
point stamps both snake_case keys before the drawer sees it. Only a def that bypassed that
door entirely is affected, and for `target` not even that door ever helped.

⚠️ **`reference_to` and `reference` are deliberately untouched.** Choosing between them per
reader is #6837's open scope.

---

## 4. ⭐ Pin form — copied from PR #6916 (card #6840), not invented

Per triage's family rule — *谁先落地谁把判据写成可复用的形制,后一张照抄,⛔ 不要各自发明
一套 refusal-pin 写法* — #6916 published the form first, in its section 5. All five
elements are adopted in
`packages/plugin-detail/src/__tests__/RecordDetailDrawer.referenceArms-6837.test.tsx`.
(#6916 is under clause-② review; as of this writing no review comment has changed the
form, so the published form governs.)

1. **A header stating the measurement, not just the conclusion** — the cell, the subject
   counts and the control counts side by side, so the pin carries its own evidence and a
   later reader can tell a measured zero from an assumed one.
2. **The live arms pinned in the same file as the dead ones** — `reference_to` and
   `reference` resolving, the full field list deriving, the relation still marked readonly.
   Without them, a drawer that simply stopped resolving anything would pass the refusals
   too.
3. **A named refusal case per deleted key** — `does NOT read 'referenceTo'` and
   `does NOT read 'target'`, each asserting the honest zero.
4. **A precedence-inversion case only where one exists — and here none does.** Both
   deleted arms sat at the **end** of the chain, so neither could ever preempt a
   contract-carrying spelling. The pin therefore **says so in prose rather than
   fabricating a case**: a `{ reference: 'a', target: 'b' }` case would resolve to `'a'`
   both before and after and would measure nothing. Copying the honesty matters more than
   copying the case list.
5. **The floor restated at the pin** — ⛔ do not re-add a spelling arm; a producer emitting
   a refused spelling is fixed at the producer or canonicalised once at the choke point,
   never by a renderer-side alias. And ⛔ the two surviving arms belong to #6837's open
   scope.

Two extra cases carry the *mechanism* rather than just the verdict: a `referenceTo`-only
def **through** `normalizeSchemaReferenceKeys` still resolves (so the deletion is lossless
at the ingestion door), while a `target`-only def does **not** resolve even through the
normalizer (nothing in the stack ever declared it).

---

## 5. Verification

**Module resolution path, stated first because the ablation stands on it:** the pin imports
the component by **relative source path** (`../RecordDetailDrawer`), and `@object-ui/core`
is aliased by the root vitest config to `packages/core/src`. Both legs resolve to
**source** — no package `exports` hop, no `dist/`, therefore **no rebuild leg** that could
leave the ablation measuring stale output.

### RED first — this change is behavioural, and the pin was red

A def carrying only `target` used to resolve and now does not, so the pin can be red and
was. The **fact was mutated, never the assertion** — the chain in the source was put back,
under a `trap ... EXIT INT TERM` with absolute paths resolved from
`git rev-parse --show-toplevel`, restore pinned to `git checkout HEAD -- path` (never the
bare form, which restores from a possibly-mutated index).

| leg | mutation (the fact) | predicted | measured |
|---|---|---|---|
| A | `?? def.referenceTo` restored | `referenceTo` refusal red, rest green | **1 failed / 7 passed** ✓ |
| B | `?? def.target` restored | `target` refusal **and** the through-the-normalizer case red | **2 failed / 6 passed** ✓ |
| C | the original **four-arm** chain restored | all 3 refusals red, all 5 live-arm controls green | **3 failed / 5 passed** ✓ |
| — | this branch, unmutated | all green | **8 passed** |

Leg C **is** the red-first reading against the pre-change source. Every prediction was
written down before the run and all three matched.

**Mutation proven on disk**, not by the editor's exit code — an anchor-miss aborts the leg
rather than reporting a silent no-op: anchored occurrence counts (live chain 1→0, mutated
chain 0→1) **and** `git hash-object` diverging from the HEAD blob
(`ec43039c…` → `6ebae4f5…` / `d75723ec…` / `f05f5819…`).

**Restore proven both ways, scoped to the mutated path only**, after every leg:
`git diff HEAD -- path` empty **and** `git hash-object` equal to the HEAD blob
(`ec43039c…`), with the whole tree clean at the end.

### The rest

| what | command | result |
|---|---|---|
| the new pin | `vitest run` the pin file | **8 passed** |
| `plugin-detail` full suite | `vitest run packages/plugin-detail/src/` | **115 files / 1053 tests passed** |
| every consumer that mounts the drawer | 12 explicit paths across `plugin-gantt`, `plugin-calendar`, `plugin-kanban`, `plugin-dashboard` | **12 files / 71 tests passed** |
| type-check | `--filter @object-ui/plugin-detail run type-check` | exit 0, script echoed: `tsc --noEmit && tsc -p tsconfig.test.json` |
| pin is a program input | `tsc -p tsconfig.test.json --listFiles` | **1 — measured, not assumed** |
| lint, the real gate | `--filter @object-ui/plugin-detail run lint` | exit 0, **0 errors** (880 pre-existing warnings) |
| gates | `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:self-import`, `check:esm-specifiers`, `check:phantom-deps`, `check:designer-field-key-parity`, `check:element-data-source-declaration`, `check:side-effects-array`, `check-changeset-no-major` | all exit 0, each quoted by its own verdict line |

**`--listFiles` was read carefully, because "type-check is clean" can be a true sentence
that says nothing about a new test file.** `tsconfig.json` **excludes** `**/*.test.tsx`, so
the build project sees the pin **0** times; `tsconfig.test.json` exists precisely to cover
tests and sees it **1** time. Both projects see the edited source once. So the pin *is*
type-checked — by the project that can.

**Lint compared against the BASE version of the same file, not a bare count.** The edited
file at base blob `da15724a…` and at this branch's blob `ec43039c…`, counts read from
`--format json`: **0 errors / 8 warnings, identical both ways.** Blob ids were verified in
both directions and the restore was proven by an empty `git status`. The new pin file has
no base version and is reported standalone: **0 errors / 6 warnings**, all
`@typescript-eslint/no-explicit-any` — the same rule and the same class as its closest
house analogue `expandableFamily.identity-5874.test.tsx` (5 of the same).

### NOT MEASURED — reported as such rather than as a colour

`check:spec-floors` exits 1 with **12 findings, all `[no-artifact]`**, zero of them naming
`plugin-detail`. The gate prints its own remedy: *"Build the workspace before running this
gate: `pnpm exec turbo run build --filter=!@object-ui/site`"*. This worktree built only
`plugin-detail`'s dependency closure, so 12 packages have no `dist/` to judge. This is a
**PREREQUISITE NOT MET**, not a red — and this diff adds no spec import and moves no
dependency range. Left to CI rather than reported as either colour.

### Scope of the local run, declared

The repo-wide `eslint .` and the remaining gate farm were **not** run locally; CI runs the
farm exactly once regardless. Type-aware linting is not enabled (no `projectService` /
`project:` in `eslint.config.js`), so this diff cannot move the verdict of any file it does
not touch.

**Tree provenance.** The ablation and its blob hashes were produced on commit `04cada79`.
`origin/main` then moved under this branch and #6915 landed, so `origin/main` was merged in
— see the next section — and the suite plus type-check were **re-run on the merged head
`7856fa8c`**, both green, with `git status` clean.

---

## 6. ⚠️ The flagged file overlap with #6915 — resolved, and nothing of theirs was touched

`RecordDetailDrawer.tsx` was flagged as also touched by then-unlanded PR #6915 (card
#6584). It landed first. `origin/main` was merged into this branch: **clean, no
conflict.** Their hunk is a comment-only addition to the `width` docblock at ~:77-87
recording the 2026-08-27 ruling; mine is the chain, which the merge moved from :267 to
:300. Disjoint hunks, no semantic overlap, and **nothing they added was reverted or
"fixed"** — their docblock and their changeset are present and untouched.

(For the record: the card's cited `:267` was still exact on `origin/main` at branch time —
re-located by text, not trusted as a line number.)

---

## 7. Out of scope — recorded, not fixed

⛔ **The ~20-reader sweep is not here.** The classification table — per reader, whether its
caller feeds an object metadata document or ObjectUI's own view/field contract
(`DetailViewFieldSchema`) — remains #6837's open scope, which is why this PR says `Refs`.

**One adjacent observation, and the census refused to license acting on it.** The very next
line is a two-spelling chain on a *different* key:

```ts
reference_field: def.reference_field ?? def.referenceField,
```

`FieldSchema` refuses both spellings by name, and `referenceField` has **0** in-cell
producers — but a first census pass returns **0 for the control `reference_field` as
well**. ⇒ **The control is cold, so that zero is not a measurement**, and no deletion is
justified on it. Recorded here rather than acted on or filed as a fresh card: it is the
same per-reader question #6837's classification table already owns, on a card that stays
open. Deleting an arm on a cold-control zero is exactly what the four-times-burned rule
exists to prevent.

Authored by Claude Code in session
`https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB` (recorded in prose because an
edited PR body drops the session form from the footer).

_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_