### PR TITLE
fix(plugin-gantt,plugin-tree): drop the undeclared `referenceTo` arm from both target chains

### DIFF
--- a/.changeset/6837-gantt-tree-referenceto-arms.md
+++ b/.changeset/6837-gantt-tree-referenceto-arms.md
@@ -1,0 +1,53 @@
+---
+'@object-ui/plugin-gantt': minor
+'@object-ui/plugin-tree': minor
+---
+
+`ObjectGantt` and `ObjectTree` resolve a relationship target only from the two
+spellings a contract carries, dropping the third one no contract declares
+(objectui#6837, second slice).
+
+- `ObjectGantt`'s quick-filter option fetch was
+  `fd?.reference_to ?? fd?.reference ?? fd?.referenceTo`; it is now
+  `fd?.reference_to ?? fd?.reference`.
+- `ObjectTree`'s `detectParentField` was
+  `def?.reference || def?.reference_to || def?.referenceTo`; it is now
+  `def?.reference || def?.reference_to`.
+
+**Accept-set move — a def carrying ONLY `referenceTo` stops resolving a target
+at these two seams.** Concretely: the gantt quick filter for that field falls
+back to the distinct values present in the loaded rows instead of fetching the
+referenced object's full domain, and the tree stops auto-detecting that field as
+its parent pointer, so records render as a flat forest unless `parentField` is
+configured explicitly. Nothing else changes; the two surviving arms are
+untouched.
+
+Two things bound that move:
+
+- Any def that entered through the ingestion choke point is unaffected.
+  `normalizeSchemaReferenceKeys` reads `reference_to ?? reference ??
+  referenceTo` and stamps both snake_case keys, so a `referenceTo`-only def
+  arriving via `MetadataProvider` or `ObjectStackAdapter.getObjectSchema`
+  already carries `reference_to` before either component sees it. Only a def
+  that bypassed that door entirely is affected — and that door is not total:
+  `getObjectSchema` is a required member of the published `DataSource`
+  interface, and both components call it on the generic `dataSource`.
+- No contract declares the deleted spelling. `@objectstack/spec` 17.2.0's
+  `FieldSchema` refuses `referenceTo` by name with `unrecognized_keys`, carrying
+  its own "Did you mean `referenceTo` -> `reference`?" rename, and `referenceTo`
+  is additionally a tombstone in `RETIRED_FIELD_KEY_TOMBSTONES` (objectui#6041)
+  at all three strip sites, so the designer read door removes it before a draft
+  round-trips.
+
+A repo-wide structure-walk producer census found **0** emitters of `referenceTo`
+reaching either seam, measured in the cell these components read (a value inside
+an object schema's `fields` container) against controls `reference` (92 hits / 36
+files) and `reference_to` (52 / 36) hot in the same pass over the same cells;
+the only two in-cell hits are negative fixtures of the retirement machinery,
+asserting the read door strips the key. Neither `plugin-gantt` nor `plugin-tree`
+emits `referenceTo` anywhere, while both packages' own fixtures are hot on the
+surviving spellings.
+
+Pinned by `ObjectGantt.referenceArms-6837.test.tsx` and
+`ObjectTree.referenceArms-6837.test.tsx`, which keep the live arms green beside a
+named refusal for the deleted key.

--- a/packages/plugin-gantt/src/ObjectGantt.referenceArms-6837.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.referenceArms-6837.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6837 (second slice) — the gantt quick-filter's relationship-target
+ * chain drops the arm NO CONTRACT DECLARES, and keeps the two that carry the
+ * value.
+ *
+ * Before:  `fd?.reference_to ?? fd?.reference ?? fd?.referenceTo`
+ * After:   `fd?.reference_to ?? fd?.reference`
+ *
+ * Form copied from `RecordDetailDrawer.referenceArms-6837.test.tsx` (PR #6920),
+ * which copied it from PR #6916 / card #6840. ⛔ Do not invent a second form.
+ *
+ * ## 1. The measurement this pin stands on (not just its conclusion)
+ *
+ * THE CELL: a value inside an object schema's `fields` container — literally
+ * what this component reads, `objectSchema.fields[name]`. Producer census by
+ * STRUCTURE WALK (TypeScript compiler API over every tracked `.ts`/`.tsx`, plus
+ * parsed JSON), recording each hit's ancestor property chain; EMIT positions
+ * only (`PropertyAssignment` / `ShorthandPropertyAssignment`), so `fd.referenceTo`
+ * — a `PropertyAccessExpression`, i.e. a READ — is never counted as a producer,
+ * and a `PropertySignature` is bucketed as a DECLARATION, never as one either.
+ * Subject and control were extracted BY THE SAME PASS, FROM THE SAME CELLS, IN
+ * THE SAME UNITS, so the control sits on the JOIN and not merely on the terms.
+ *
+ *   | term           | role    | repo-wide emits  | IN THE CELL |
+ *   |----------------|---------|------------------|-------------|
+ *   | `referenceTo`  | SUBJECT |  81 /  42 files  | **2** / 2   |
+ *   | `reference`    | CONTROL | 195 /  76 files  |  92 / 36    |
+ *   | `reference_to` | CONTROL | 137 /  88 files  |  52 / 36    |
+ *
+ * Both halves of the control discipline. (1) THE QUERY RAN: the controls are
+ * hot — 92 and 52 — in the very cells where the subject collapses to 2, from
+ * the same pass. (2) THE QUESTION WAS RIGHT: a mis-posed cell would have moved
+ * subject and control together; instead it separates 92-to-2. Third check, the
+ * one only this key affords: `referenceTo` is not a term the scanner cannot
+ * see — it is hot repo-wide at 81 emits across 42 files, and collapses to 2
+ * only under the cell restriction. The zero-ish is produced by the RESTRICTION,
+ * not by scanner blindness.
+ *
+ * The two surviving in-cell hits are NEGATIVE fixtures of the retirement
+ * machinery itself (`object-fields-io.spec-keys.test.ts:235`,
+ * `MetadataFieldsPage.specKeyReference.test.tsx:75`): they poison a draft with
+ * the retired key precisely to assert the read door STRIPS it before
+ * `ObjectSchema.safeParse` sees it. A fixture asserting removal is not a
+ * producer.
+ *
+ * SEAM-LOCAL control, the one this file owes over and above the repo-wide pass:
+ * `plugin-gantt` contains **zero** `referenceTo` emits at any position, in any
+ * cell — while its own fixture corpus is hot on both surviving spellings
+ * (`ObjectGantt.quickfilter.test.tsx:251` emits `reference_to`, `:306` emits
+ * `reference`, `demo/main.tsx:334-335` emit `reference_to`). So the corpus that
+ * actually feeds THIS reader is hot on what survives and empty on what goes.
+ *
+ * ## 2. Why refusal is correct, not merely unused-today
+ *
+ * `@objectstack/spec` 17.2.0's `FieldSchema` (`@objectstack/spec/data`), probed
+ * two-directionally on this branch's installed copy:
+ *
+ *   - `reference: 'crm_account'`     → ACCEPT
+ *   - `reference_to: 'crm_account'`  → REFUSE, `unrecognized_keys`
+ *   - `referenceTo: 'crm_account'`   → REFUSE, `unrecognized_keys`,
+ *     "Did you mean `referenceTo` → `reference`?"
+ *
+ * The alias entry is a RENAME HINT ATTACHED TO A REFUSAL, not an acceptance:
+ * the spec names `referenceTo` explicitly in order to refuse it. `referenceTo`
+ * is additionally a tombstone in `RETIRED_FIELD_KEY_TOMBSTONES`
+ * (`@object-ui/types/internal/retired-field-keys`, `retiredBy: 'objectui#6041'`,
+ * `specEquivalent: 'reference'`) at all three strip sites, so the designer read
+ * door removes it before a draft round-trips. So this arm was not a "redundant"
+ * fallback: it was INVENTED tolerance surface — a silent absorption point for a
+ * producer that ought to fail visibly (AGENTS.md #0.1).
+ *
+ * ⚠️ What this does NOT rest on: any claim that no production producer of
+ * `reference_to` exists. That question cannot be answered from inside this repo
+ * — restricting the cell to production files collapses the CONTROL too, and
+ * this repo is a UI library, not a metadata-app repo. `reference_to` and
+ * `reference` are therefore deliberately untouched here; see §4.
+ *
+ * ## 3. No precedence inversion exists here — stated rather than fabricated
+ *
+ * The deleted arm sat at the END of the chain
+ * (`reference_to ?? reference ?? referenceTo`), so it could never preempt a
+ * contract-carrying spelling. There is therefore NO inversion case to pin, and
+ * this file deliberately does not invent one: a
+ * `{ reference: 'projects', referenceTo: 'other' }` case resolves to
+ * `'projects'` both before and after the change and would measure nothing.
+ * (Same call, for the same reason, as PR #6916 and PR #6920.)
+ *
+ * ## 4. THE FLOOR, restated where someone would try to re-widen it
+ *
+ * ⛔ Do not re-add a spelling arm to this chain. A producer emitting a refused
+ * spelling is fixed AT THE PRODUCER, or canonicalised ONCE at the ingestion
+ * choke point — `normalizeSchemaReferenceKeys`, which stamps both snake_case
+ * keys from whichever spelling arrived. Never a renderer-side alias: that is
+ * how ~20 per-consumer dual-key fallbacks got written under a normalizer whose
+ * own docstring says it exists "so per-consumer dual-key fallbacks can't drift".
+ *
+ * ⛔ The two SURVIVING arms are out of this slice's scope. Choosing between
+ * `reference_to` and `reference` per reader is objectui#6837's OPEN scope, and
+ * its classification table measured why a mechanical sweep would be wrong: the
+ * ObjectUI-side contracts (`DetailViewFieldSchema`, `LookupFieldMetadata`,
+ * report columns, designer fields, related-list config) declare `reference_to`,
+ * `referenceTo` and `referenceField` but NONE of them declares `reference` —
+ * these readers sit on a TIER BOUNDARY rather than choosing between a legacy
+ * and a canonical spelling of one key. #6837 stays open.
+ *
+ * ## 5. Ablation direction, predicted before running
+ *
+ * Restore the deleted arm on the committed tree and the refusal below goes RED
+ * while every live-arm control stays GREEN — that contrast is what makes the
+ * controls controls rather than duplicates of the pins. MODULE RESOLUTION: this
+ * file imports the component by RELATIVE SOURCE PATH (`./ObjectGantt`) and
+ * `@object-ui/core` is aliased by the root `vitest.config.mts` to
+ * `packages/core/src`, so both legs resolve to SOURCE — no package `exports`
+ * hop, no `dist`, and therefore NO REBUILD LEG to get wrong.
+ */
+import React from 'react';
+import { render, fireEvent, waitFor, within, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { normalizeSchemaReferenceKeys } from '@object-ui/core';
+import { ObjectGantt } from './ObjectGantt';
+
+afterEach(cleanup);
+
+/**
+ * GanttView is mocked to a thin shell that surfaces the task count, exactly as
+ * `ObjectGantt.quickfilter.test.tsx` does — the resolved target is a property
+ * of the option fetch, not of how GanttView paints bars.
+ */
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks }: any) => (
+    <div data-testid="gantt-view" data-count={tasks.length} />
+  ),
+}));
+
+/** Both loaded rows point at `p1`, so `p2`/`p3` can only come from the lookup domain. */
+const TASKS = [
+  { id: '1', name: 'Alpha', start: '2024-01-01', end: '2024-01-05', project: 'p1' },
+  { id: '2', name: 'Beta', start: '2024-02-01', end: '2024-02-10', project: 'p1' },
+];
+
+/** The referenced object's full domain — reachable ONLY by resolving the target. */
+const PROJECTS = [
+  { id: 'p1', name: 'Apollo' },
+  { id: 'p2', name: 'Borealis' },
+  { id: 'p3', name: 'Cygnus' },
+];
+
+/** Every probe is a `lookup`, so only the target SPELLING varies between them. */
+const FIELD_DEFS: Record<string, Record<string, unknown>> = {
+  // Live arms — the two spellings a contract actually carries at this seam.
+  canonical: { type: 'lookup', reference_to: 'projects' },
+  spec_spelling: { type: 'lookup', reference: 'projects' },
+  // Deleted arm — refused by `FieldSchema` by name, retired at the read door.
+  legacy_camel: { type: 'lookup', referenceTo: 'projects' },
+};
+
+function makeDataSource(projectDef: Record<string, unknown>) {
+  return {
+    find: vi.fn(async (object: string) =>
+      object === 'projects' ? { data: PROJECTS } : { data: TASKS },
+    ),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'task',
+      fields: {
+        name: { type: 'text' },
+        start: { type: 'date' },
+        end: { type: 'date' },
+        project: projectDef,
+      },
+    }),
+  } as any;
+}
+
+const GANTT_SCHEMA = {
+  type: 'gantt',
+  objectName: 'task',
+  startDateField: 'start',
+  endDateField: 'end',
+  titleField: 'name',
+  quickFilters: [{ field: 'project', label: 'Project' }],
+} as any;
+
+/**
+ * Mount over one field def and wait for the SCHEMA-DEPENDENT commit to happen.
+ *
+ * The settle signal is deliberately spelling-INDEPENDENT: once `objectSchema`
+ * lands, the record query is re-issued carrying `$expand`, and
+ * `buildExpandFields` decides that from the field's `type` alone ("the
+ * `reference` / `reference_to` target is irrelevant to the decision"). So a
+ * `find('task', { $expand: [...] })` call proves the component consumed this
+ * schema — for the refusal probe just as much as for the live-arm ones. The
+ * option-fetch effect shares that commit and runs synchronously up to its own
+ * `find`, so by the time this resolves, a resolving arm has ALREADY recorded
+ * `find('projects', …)`.
+ */
+async function mount(projectDef: Record<string, unknown>) {
+  const ds = makeDataSource(projectDef);
+  const view = render(<ObjectGantt schema={GANTT_SCHEMA} dataSource={ds} />);
+  await waitFor(() =>
+    expect(
+      ds.find.mock.calls.some((c: any[]) => c[0] === 'task' && c[1]?.$expand?.includes('project')),
+    ).toBe(true),
+  );
+  return { ds, view };
+}
+
+/** Did the component resolve a target, i.e. fetch the referenced object's domain? */
+const fetchedDomain = (ds: any) =>
+  ds.find.mock.calls.some((c: any[]) => c[0] === 'projects');
+
+describe('ObjectGantt resolves only contract-declared target spellings (objectui#6837)', () => {
+  describe('live arms — the value still arrives (without these, a gantt that stopped resolving anything would pass the refusal too)', () => {
+    it("resolves `reference_to`, ObjectUI's own view/field key", async () => {
+      const { ds } = await mount(FIELD_DEFS.canonical);
+      await waitFor(() => expect(fetchedDomain(ds)).toBe(true));
+    });
+
+    it('resolves `reference`, the spelling `FieldSchema` accepts', async () => {
+      const { ds } = await mount(FIELD_DEFS.spec_spelling);
+      await waitFor(() => expect(fetchedDomain(ds)).toBe(true));
+    });
+
+    it('a resolved target widens the dropdown to the FULL domain, past the loaded rows', async () => {
+      // The user-visible half: `p2`/`p3` exist only on the referenced object.
+      const { ds, view } = await mount(FIELD_DEFS.canonical);
+      await waitFor(() => expect(fetchedDomain(ds)).toBe(true));
+      await waitFor(() => {
+        fireEvent.click(view.getByTestId('quick-filter-trigger-project'));
+        const panel = view.getByTestId('quick-filter-panel-project');
+        expect(within(panel).getByTestId('quick-filter-option-project-p3')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('refusal — one named case for the deleted key', () => {
+    it('does NOT read `referenceTo` (RETIRED_FIELD_KEY_TOMBSTONES, objectui#6041/#6519; `FieldSchema` refuses it by name)', async () => {
+      const { ds } = await mount(FIELD_DEFS.legacy_camel);
+      expect(fetchedDomain(ds)).toBe(false);
+    });
+
+    it('and degrades to the distinct loaded values rather than rendering nothing', async () => {
+      // Guards the refusal above against the degenerate pass: a gantt that
+      // rendered no quick filter at all would also never fetch `projects`.
+      const { ds, view } = await mount(FIELD_DEFS.legacy_camel);
+      expect(view.getByTestId('gantt-view').getAttribute('data-count')).toBe('2');
+      fireEvent.click(view.getByTestId('quick-filter-trigger-project'));
+      const panel = view.getByTestId('quick-filter-panel-project');
+      expect(within(panel).getByTestId('quick-filter-option-project-p1')).toBeTruthy();
+      expect(within(panel).queryByTestId('quick-filter-option-project-p3')).toBeNull();
+      expect(fetchedDomain(ds)).toBe(false);
+    });
+  });
+
+  describe('the ingestion choke point is what makes the deletion lossless', () => {
+    it('a `referenceTo`-only def that came through `normalizeSchemaReferenceKeys` STILL resolves', async () => {
+      // The mechanism, not a formality: the normalizer reads
+      // `reference_to ?? reference ?? referenceTo` and stamps BOTH snake_case
+      // keys, so every def that entered through `MetadataProvider` or
+      // `ObjectStackAdapter.getObjectSchema` already carries `reference_to` by
+      // the time this component sees it. The deleted arm was dead weight there.
+      //
+      // ⚠️ And this is exactly why the pin above still matters: the door is
+      // NOT total. `getObjectSchema` is a required member of the published
+      // `DataSource` interface and this component calls it on the generic
+      // `dataSource`, so a third-party implementation reaches this reader raw.
+      const def = { ...FIELD_DEFS.legacy_camel };
+      const schema = { name: 'task', fields: { project: def } };
+      normalizeSchemaReferenceKeys(schema);
+      const { ds } = await mount(schema.fields.project as Record<string, unknown>);
+      await waitFor(() => expect(fetchedDomain(ds)).toBe(true));
+    });
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -1123,9 +1123,16 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         const type: string | undefined = fd?.type;
         if (type !== 'lookup' && type !== 'master_detail') continue;
         // Served schemas key the target as `reference` (ObjectStack
-        // convention); reference_to/referenceTo cover ObjectUI-authored defs.
-        const refObject: string | undefined =
-          fd?.reference_to ?? fd?.reference ?? fd?.referenceTo;
+        // convention); `reference_to` covers ObjectUI-authored defs.
+        //
+        // A third arm, `referenceTo`, was deleted by objectui#6837: no contract
+        // declares that spelling — `@objectstack/spec`'s `FieldSchema` refuses
+        // it by name with `unrecognized_keys` ("Did you mean `referenceTo` ->
+        // `reference`?"), and it is a tombstone in `RETIRED_FIELD_KEY_TOMBSTONES`
+        // (objectui#6041), so the designer read door strips it. It was not a
+        // redundant fallback but invented tolerance surface. Pinned in
+        // `ObjectGantt.referenceArms-6837.test.tsx`.
+        const refObject: string | undefined = fd?.reference_to ?? fd?.reference;
         if (!refObject) continue;
         try {
           const result = await dataSource.find(refObject, { $top: 1000 });

--- a/packages/plugin-tree/src/ObjectTree.referenceArms-6837.test.tsx
+++ b/packages/plugin-tree/src/ObjectTree.referenceArms-6837.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6837 (second slice) — `detectParentField`'s relationship-target
+ * chain drops the arm NO CONTRACT DECLARES, and keeps the two that carry the
+ * value.
+ *
+ * Before:  `def?.reference || def?.reference_to || def?.referenceTo`
+ * After:   `def?.reference || def?.reference_to`
+ *
+ * Form copied from `RecordDetailDrawer.referenceArms-6837.test.tsx` (PR #6920),
+ * which copied it from PR #6916 / card #6840. ⛔ Do not invent a second form.
+ *
+ * ## 1. The measurement this pin stands on (not just its conclusion)
+ *
+ * THE CELL: a value inside an object schema's `fields` container — literally
+ * what this function reads, `objectSchema.fields[key]`. Producer census by
+ * STRUCTURE WALK (TypeScript compiler API over every tracked `.ts`/`.tsx`, plus
+ * parsed JSON), recording each hit's ancestor property chain; EMIT positions
+ * only (`PropertyAssignment` / `ShorthandPropertyAssignment`), so
+ * `def?.referenceTo` — a `PropertyAccessExpression`, i.e. a READ — is never
+ * counted as a producer, and a `PropertySignature` is bucketed as a
+ * DECLARATION, never as one either. Subject and control were extracted BY THE
+ * SAME PASS, FROM THE SAME CELLS, IN THE SAME UNITS, so the control sits on the
+ * JOIN and not merely on the terms.
+ *
+ *   | term           | role    | repo-wide emits  | IN THE CELL |
+ *   |----------------|---------|------------------|-------------|
+ *   | `referenceTo`  | SUBJECT |  81 /  42 files  | **2** / 2   |
+ *   | `reference`    | CONTROL | 195 /  76 files  |  92 / 36    |
+ *   | `reference_to` | CONTROL | 137 /  88 files  |  52 / 36    |
+ *
+ * Both halves of the control discipline. (1) THE QUERY RAN: the controls are
+ * hot — 92 and 52 — in the very cells where the subject collapses to 2, from
+ * the same pass. (2) THE QUESTION WAS RIGHT: a mis-posed cell would have moved
+ * subject and control together; instead it separates 92-to-2. Third check, the
+ * one only this key affords: `referenceTo` is not a term the scanner cannot
+ * see — it is hot repo-wide at 81 emits across 42 files, and collapses to 2
+ * only under the cell restriction. The zero-ish is produced by the RESTRICTION,
+ * not by scanner blindness.
+ *
+ * The two surviving in-cell hits are NEGATIVE fixtures of the retirement
+ * machinery itself (`object-fields-io.spec-keys.test.ts:235`,
+ * `MetadataFieldsPage.specKeyReference.test.tsx:75`): they poison a draft with
+ * the retired key precisely to assert the read door STRIPS it before
+ * `ObjectSchema.safeParse` sees it. A fixture asserting removal is not a
+ * producer.
+ *
+ * SEAM-LOCAL control, the one this file owes over and above the repo-wide pass:
+ * `plugin-tree` contains **zero** `referenceTo` emits at any position, in any
+ * cell — while its own fixture corpus is hot on a surviving spelling
+ * (`ObjectTree.fieldFormatting.test.tsx:51-52` and
+ * `ObjectTree.settledSchemaKeying-6481.test.tsx:62-71` emit `reference`, six
+ * hits in all, every one of them in a `fields` container feeding THIS
+ * component). So the corpus that actually feeds this reader is hot on what
+ * survives and empty on what goes.
+ *
+ * ## 2. Why refusal is correct, not merely unused-today
+ *
+ * `@objectstack/spec` 17.2.0's `FieldSchema` (`@objectstack/spec/data`), probed
+ * two-directionally on this branch's installed copy:
+ *
+ *   - `reference: 'crm_account'`     → ACCEPT
+ *   - `reference_to: 'crm_account'`  → REFUSE, `unrecognized_keys`
+ *   - `referenceTo: 'crm_account'`   → REFUSE, `unrecognized_keys`,
+ *     "Did you mean `referenceTo` → `reference`?"
+ *
+ * The alias entry is a RENAME HINT ATTACHED TO A REFUSAL, not an acceptance:
+ * the spec names `referenceTo` explicitly in order to refuse it. `referenceTo`
+ * is additionally a tombstone in `RETIRED_FIELD_KEY_TOMBSTONES`
+ * (`@object-ui/types/internal/retired-field-keys`, `retiredBy: 'objectui#6041'`,
+ * `specEquivalent: 'reference'`) at all three strip sites, so the designer read
+ * door removes it before a draft round-trips. So this arm was not a "redundant"
+ * fallback: it was INVENTED tolerance surface — a silent absorption point for a
+ * producer that ought to fail visibly (AGENTS.md #0.1).
+ *
+ * ⚠️ What this does NOT rest on: any claim that no production producer of
+ * `reference_to` exists. That question cannot be answered from inside this repo
+ * — restricting the cell to production files collapses the CONTROL too, and
+ * this repo is a UI library, not a metadata-app repo. `reference_to` and
+ * `reference` are therefore deliberately untouched here; see §4.
+ *
+ * ## 3. No precedence inversion exists here — stated rather than fabricated
+ *
+ * The deleted arm sat at the END of the chain, and this chain is already
+ * CANONICAL-FIRST (`reference || reference_to || referenceTo`), so it could
+ * never preempt a contract-carrying spelling. There is therefore NO inversion
+ * case to pin, and this file deliberately does not invent one: a
+ * `{ reference: 'business_unit', referenceTo: 'other' }` case resolves to
+ * `'business_unit'` both before and after the change and would measure nothing.
+ * (Same call, for the same reason, as PR #6916 and PR #6920.)
+ *
+ * ⚠️ One asymmetry worth naming rather than glossing: this chain uses `||`,
+ * not `??`, so it also skips the empty string. That is unchanged by this slice
+ * — the arms move, the operator does not.
+ *
+ * ## 4. THE FLOOR, restated where someone would try to re-widen it
+ *
+ * ⛔ Do not re-add a spelling arm to this chain. A producer emitting a refused
+ * spelling is fixed AT THE PRODUCER, or canonicalised ONCE at the ingestion
+ * choke point — `normalizeSchemaReferenceKeys`, which stamps both snake_case
+ * keys from whichever spelling arrived. Never a renderer-side alias: that is
+ * how ~20 per-consumer dual-key fallbacks got written under a normalizer whose
+ * own docstring says it exists "so per-consumer dual-key fallbacks can't drift".
+ *
+ * ⛔ The two SURVIVING arms are out of this slice's scope. Choosing between
+ * `reference_to` and `reference` per reader is objectui#6837's OPEN scope, and
+ * its classification table measured why a mechanical sweep would be wrong: the
+ * ObjectUI-side contracts (`DetailViewFieldSchema`, `LookupFieldMetadata`,
+ * report columns, designer fields, related-list config) declare `reference_to`,
+ * `referenceTo` and `referenceField` but NONE of them declares `reference` —
+ * these readers sit on a TIER BOUNDARY rather than choosing between a legacy
+ * and a canonical spelling of one key. #6837 stays open.
+ *
+ * ## 5. Ablation direction, predicted before running
+ *
+ * Restore the deleted arm on the committed tree and the refusal below goes RED
+ * while every live-arm control stays GREEN — that contrast is what makes the
+ * controls controls rather than duplicates of the pins. MODULE RESOLUTION: this
+ * file imports the component by RELATIVE SOURCE PATH (`./ObjectTree`) and
+ * `@object-ui/core` is aliased by the root `vitest.config.mts` to
+ * `packages/core/src`, so both legs resolve to SOURCE — no package `exports`
+ * hop, no `dist`, and therefore NO REBUILD LEG to get wrong.
+ */
+import React from 'react';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { normalizeSchemaReferenceKeys } from '@object-ui/core';
+import { ObjectTree } from './ObjectTree';
+
+afterEach(cleanup);
+
+/**
+ * A two-node self-referencing hierarchy. `Engineering` nests under `Acme` ONLY
+ * if the parent pointer is auto-detected — which is the whole observable here,
+ * because the schema below deliberately omits `parentField`.
+ */
+const RECORDS = [
+  { id: '1', name: 'Acme', parent_id: null },
+  { id: '2', name: 'Engineering', parent_id: '1' },
+];
+
+/**
+ * Every probe is a self-referencing `lookup`, so only the target SPELLING
+ * varies. ⚠️ `lookup` and not `tree`: `detectParentField` returns a `tree` field
+ * before it ever reads a target, which would make the chain unobservable.
+ */
+const FIELD_DEFS: Record<string, Record<string, unknown>> = {
+  // Live arms — the two spellings a contract actually carries at this seam.
+  canonical: { type: 'lookup', reference_to: 'business_unit' },
+  spec_spelling: { type: 'lookup', reference: 'business_unit' },
+  // Deleted arm — refused by `FieldSchema` by name, retired at the read door.
+  legacy_camel: { type: 'lookup', referenceTo: 'business_unit' },
+};
+
+function makeDataSource(parentDef: Record<string, unknown>) {
+  return {
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: 'business_unit',
+      fields: { name: { type: 'text' }, parent_id: parentDef },
+    }),
+    find: vi.fn(async () => RECORDS),
+  } as any;
+}
+
+/** No `parentField` — auto-detection is what is under test. */
+const TREE_SCHEMA = {
+  type: 'object-tree',
+  objectName: 'business_unit',
+  labelField: 'name',
+  fields: ['name'],
+} as any;
+
+/**
+ * Mount over one field def and wait for the SCHEMA-DEPENDENT commit to happen.
+ *
+ * The settle signal is deliberately spelling-INDEPENDENT: the record query is
+ * gated on the settled schema and carries `$expand`, and `buildExpandFields`
+ * decides that from the field's `type` alone ("the `reference` / `reference_to`
+ * target is irrelevant to the decision"). So a `find` carrying
+ * `$expand: ['parent_id']` proves the component consumed this schema — for the
+ * refusal probe just as much as for the live-arm ones, which is what stops the
+ * refusal from being satisfiable by a schema that never arrived.
+ */
+async function mount(parentDef: Record<string, unknown>) {
+  const ds = makeDataSource(parentDef);
+  const view = render(<ObjectTree schema={TREE_SCHEMA} dataSource={ds} />);
+  await waitFor(() =>
+    expect(
+      ds.find.mock.calls.some((c: any[]) => c[1]?.$expand?.includes('parent_id')),
+    ).toBe(true),
+  );
+  await waitFor(() => expect(view.getAllByTestId('object-tree-row').length).toBe(2));
+  return { ds, view };
+}
+
+/** The rendered depth of one node — 1 once the parent pointer is detected, 0 while it is not. */
+function depthOf(view: ReturnType<typeof render>, label: string) {
+  const row = view
+    .getAllByTestId('object-tree-row')
+    .find((r) => r.textContent?.includes(label));
+  return row?.getAttribute('data-depth');
+}
+
+describe('ObjectTree detects a parent pointer only through contract-declared target spellings (objectui#6837)', () => {
+  describe('live arms — the value still arrives (without these, a tree that stopped detecting anything would pass the refusal too)', () => {
+    it("resolves `reference_to`, ObjectUI's own view/field key", async () => {
+      const { view } = await mount(FIELD_DEFS.canonical);
+      expect(depthOf(view, 'Engineering')).toBe('1');
+    });
+
+    it('resolves `reference`, the spelling `FieldSchema` accepts', async () => {
+      const { view } = await mount(FIELD_DEFS.spec_spelling);
+      expect(depthOf(view, 'Engineering')).toBe('1');
+    });
+
+    it('the root stays a root either way, so depth is reading the hierarchy and not the row order', async () => {
+      const { view } = await mount(FIELD_DEFS.canonical);
+      expect(depthOf(view, 'Acme')).toBe('0');
+    });
+  });
+
+  describe('refusal — one named case for the deleted key', () => {
+    it('does NOT read `referenceTo` (RETIRED_FIELD_KEY_TOMBSTONES, objectui#6041/#6519; `FieldSchema` refuses it by name)', async () => {
+      const { view } = await mount(FIELD_DEFS.legacy_camel);
+      expect(depthOf(view, 'Engineering')).toBe('0');
+    });
+
+    it('and still renders every record as a root rather than rendering nothing', async () => {
+      // Guards the refusal above against the degenerate pass: a tree that
+      // rendered no rows at all would also report no nested child.
+      const { view } = await mount(FIELD_DEFS.legacy_camel);
+      expect(view.getAllByTestId('object-tree-row').length).toBe(2);
+      expect(depthOf(view, 'Acme')).toBe('0');
+      expect(view.getByText('Engineering')).toBeTruthy();
+    });
+  });
+
+  describe('the ingestion choke point is what makes the deletion lossless', () => {
+    it('a `referenceTo`-only def that came through `normalizeSchemaReferenceKeys` STILL resolves', async () => {
+      // The mechanism, not a formality: the normalizer reads
+      // `reference_to ?? reference ?? referenceTo` and stamps BOTH snake_case
+      // keys, so every def that entered through `MetadataProvider` or
+      // `ObjectStackAdapter.getObjectSchema` already carries `reference_to` by
+      // the time this component sees it. The deleted arm was dead weight there.
+      //
+      // ⚠️ And this is exactly why the pin above still matters: the door is
+      // NOT total. `getObjectSchema` is a required member of the published
+      // `DataSource` interface and `useSettledSchema` calls it on the generic
+      // `dataSource`, so a third-party implementation reaches this reader raw.
+      const schema = {
+        name: 'business_unit',
+        fields: { parent_id: { ...FIELD_DEFS.legacy_camel } },
+      };
+      normalizeSchemaReferenceKeys(schema);
+      const { view } = await mount(schema.fields.parent_id as Record<string, unknown>);
+      expect(depthOf(view, 'Engineering')).toBe('1');
+    });
+  });
+});

--- a/packages/plugin-tree/src/ObjectTree.tsx
+++ b/packages/plugin-tree/src/ObjectTree.tsx
@@ -129,7 +129,14 @@ function detectParentField(objectSchema: any, objectName?: string): string | und
   let firstSelfRef: string | undefined;
   for (const [key, def] of Object.entries<any>(fields)) {
     if (def?.type === 'tree') return key;
-    const ref = def?.reference || def?.reference_to || def?.referenceTo;
+    // A third arm, `def?.referenceTo`, was deleted by objectui#6837: no
+    // contract declares that spelling — `@objectstack/spec`'s `FieldSchema`
+    // refuses it by name with `unrecognized_keys` ("Did you mean `referenceTo`
+    // -> `reference`?"), and it is a tombstone in
+    // `RETIRED_FIELD_KEY_TOMBSTONES` (objectui#6041), so the designer read door
+    // strips it. It was not a redundant fallback but invented tolerance
+    // surface. Pinned in `ObjectTree.referenceArms-6837.test.tsx`.
+    const ref = def?.reference || def?.reference_to;
     if (
       !firstSelfRef &&
       (def?.type === 'lookup' || def?.type === 'master_detail') &&


### PR DESCRIPTION
Refs #6837

Second slice of the classification table's suggested slicing, item 1: the
`referenceTo` third arms at `ObjectGantt` and `ObjectTree`. ⛔ Nothing else — not
Class B, not the pass-through forwarders, not `reference_field`, not the other
~16 readers. **The card stays open.**

```
ObjectGantt.tsx:1128  fd?.reference_to ?? fd?.reference ?? fd?.referenceTo
                   →  fd?.reference_to ?? fd?.reference

ObjectTree.tsx:132    def?.reference || def?.reference_to || def?.referenceTo
                   →  def?.reference || def?.reference_to
```

Both readers were re-located **by text** on `bf97b98c8`; both were still at the
line numbers the card cites (the table had already found two other readers whose
numbers had shifted, so this was not assumed).

---

## 1. The accept/reject delta, stated so it does not have to be re-derived

**This is a reject-direction change reachable by third-party `DataSource`
implementations** — same clause-② routing as PR #6920, and for the same measured
reason: the ingestion door is **not total**. `normalizeSchemaReferenceKeys` has
two production call sites, making it a private property of two *implementations*,
while `getObjectSchema` is a **required, non-optional** member of the published
`DataSource` interface (`types/src/data.ts:519`) — and both components here call
it on the *generic* `dataSource`:

| component | how the def arrives | reachable raw? |
|---|---|---|
| `ObjectGantt` | `effectiveDataSource.getObjectSchema(resource)` at `:706` | **YES** |
| `ObjectTree` | `useSettledSchema(schemaKey, dataSource)` → `dataSource.getObjectSchema(key)` (`react/src/hooks/useSettledSchema.ts:141`) | **YES** |

**What stops being accepted:** a field def carrying **only** `referenceTo` — and
which did **not** pass the ingestion choke point — no longer resolves a
relationship target at these two seams.

**What that looks like, concretely, rather than abstractly:**

| seam | before | after |
|---|---|---|
| gantt quick filter | fetches the referenced object's **full option domain** | falls back to the **distinct values present in the loaded rows** |
| tree parent pointer | field is auto-detected as the single-parent pointer | not detected; records render as a **flat forest** unless `parentField` is set explicitly |

**What is NOT affected:**

- Any def that came through `MetadataProvider` or
  `ObjectStackAdapter.getObjectSchema`. The normalizer reads
  `reference_to ?? reference ?? referenceTo` and stamps **both** snake_case keys,
  so such a def already carries `reference_to` before either component sees it.
  This is pinned as a test, not asserted in prose.
- Both surviving arms. `reference_to` and `reference` are byte-identical to base.
- Every other reader named on #6837.

## 2. Why this arm, and only this arm, is licensed

`referenceTo` clears the same bar the first slice (PR #6920) cleared for
`RecordDetailDrawer`:

- **Refused by contract, by name.** Two-directional probe against this branch's
  installed `@objectstack/spec` 17.2.0, via `@objectstack/spec/data`:

  | probe | verdict |
  |---|---|
  | `reference: 'crm_account'` | **ACCEPT** |
  | `reference_to: 'crm_account'` | REFUSE — `unrecognized_keys`, "Did you mean `reference_to` → `reference`?" |
  | `referenceTo: 'crm_account'` | REFUSE — `unrecognized_keys`, "Did you mean `referenceTo` → `reference`?" |

  The alias entry is a **rename hint attached to a refusal**, not an acceptance:
  the spec names `referenceTo` explicitly *in order to refuse it*.

- **Stripped by the read door.** `referenceTo` is a tombstone in
  `RETIRED_FIELD_KEY_TOMBSTONES`
  (`types/src/internal/retired-field-keys.ts:146`, `retiredBy: 'objectui#6041'`,
  `specEquivalent: 'reference'`) with all three strip sites `true`.

- **Zero producers in the cell, against hot controls** — §3.

## 3. The producer census — re-derived at this base, not inherited

⛔ The table's numbers were **not** inherited. A separately written structure
walk was run at `bf97b98c8`: TypeScript compiler API over every tracked
`.ts`/`.tsx` plus parsed JSON, recording each hit's ancestor property chain,
counting **emit** positions only (`PropertyAssignment` /
`ShorthandPropertyAssignment`). A `PropertyAccessExpression` such as
`fd.referenceTo` is a **read** and is never counted as a producer; a
`PropertySignature` is a **declaration** and is bucketed separately (38 of those,
never counted as producers). Scanned 3808 TS/TSX + 754 JSON tracked files.

**THE CELL** = an emit inside a `fields` container — literally what these
components read, `objectSchema.fields[name]`.

| term | role | repo-wide emits | IN THE CELL | strict cell (field-def level) | independent cell (enclosing `type` is reference-bearing) |
|---|---|---|---|---|---|
| `referenceTo` | **SUBJECT** | 81 / 42 files | **2 / 2** | **2 / 2** | 30 / 14 |
| `reference` | CONTROL | 195 / 76 | 92 / 36 | 91 / 35 | 156 / 59 |
| `reference_to` | CONTROL | 137 / 88 | 52 / 36 | 52 / 36 | 101 / 65 |

**Control discipline, both halves.**
1. *The query ran.* The controls are hot — **92** and **52** — in the very cells
   where the subject collapses to 2, extracted by the same pass.
2. *The question was right.* Subject and control were extracted **by the same
   pass, from the same cells, in the same units** (emitted keys on a field
   definition), so a mis-posed cell would have moved subject and control
   together instead of separating 92-to-2. The cell was computed two ways
   (ancestor chain contains `fields`; and strictly at field-def level) and they
   agree on all three terms.

**Third check, the one this key affords:** `referenceTo` is not a term the
scanner cannot see — it is hot repo-wide at **81 emits across 42 files**, and
collapses to 2 only under the cell restriction. The near-zero is produced by the
**restriction**, not by scanner blindness. Attributing all 27 non-test emits:
action params (`resolveActionParams.ts`), designer drafts (`FieldDesigner.tsx`,
`MetadataFieldsPage.tsx`), dataset inspectors, the report field schema
(`reports.zod.ts:69`), list-view column meta and filter-condition meta, plus 10
i18n locale strings. **Not one is in the cell, and not one is in either package
this PR touches.**

**The 2 in-cell hits are negative fixtures of the retirement machinery**, read
and confirmed rather than assumed:
`app-shell/.../object-fields-io.spec-keys.test.ts:235` and
`plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx:75` both poison
a draft with the retired key precisely to assert `ObjectSchema.safeParse`
succeeds *after* the read door strips it. A fixture asserting removal is not a
producer.

### ⭐ Seam-local control — the half a repo-wide pass does not give you

The dispatch asked for confirmation that *these two readers* have no in-cell
`referenceTo` producer, so the census was also attributed per package:

| package | `referenceTo` emits (any position, any cell) | surviving spellings in its own fixtures |
|---|---|---|
| `plugin-gantt` | **0** | `reference_to` at `ObjectGantt.quickfilter.test.tsx:251`, `demo/main.tsx:334-335`; `reference` at `:306` |
| `plugin-tree` | **0** | `reference` ×6, all in a `fields` container: `ObjectTree.fieldFormatting.test.tsx:51-52`, `ObjectTree.settledSchemaKeying-6481.test.tsx:62,63,70,71` |

⇒ The corpus that actually feeds these two readers is **hot on what survives and
empty on what goes**. The zero here is a local measurement with a local control,
not an extrapolation from the repo-wide one.

### ⛔ The hard limitation, restated so this PR is not read as more than it is

This licence rests on the key being **contract-refused by name and actively
stripped by the read door** — ⛔ **not** on a production-only census. The
table's ceiling still stands and is not stepped over here:

> the census cannot distinguish "no production object-metadata producer of
> `reference_to` exists" from "this repo contains no production object-metadata
> documents at all" — restricting the cell to production files collapses the
> **control** too (in-cell non-test `reference` = 1, `reference_to` = 2; a
> 2-versus-1 comparison is not a measurement). **This repo is a UI library, not
> a metadata-app repo.**

⇒ That is exactly why `reference_to` is untouched here and `referenceTo` is not.
The argument does not carry to `reference_to`, and this PR does not extend it.

## 4. The pins — the published form, copied not invented

`ObjectGantt.referenceArms-6837.test.tsx` and
`ObjectTree.referenceArms-6837.test.tsx` follow the five-element form PR #6916
published and PR #6920 copied: header carrying the **measurement** rather than
the conclusion; the **live arms pinned in the same file as the dead one**; a
named refusal case per deleted key; the precedence-inversion element; and the
floor restated at the pin.

**Element 4 — no inversion case exists, and none was fabricated.** The deleted
arm sat at the **END** of both chains (the tree's is already canonical-first), so
it could never preempt a contract-carrying spelling. A
`{ reference: 'projects', referenceTo: 'other' }` case would resolve to
`'projects'` both before and after and would measure nothing. Stated in prose in
both files, per the form.

**Element 2 matters here and is load-bearing:** each file pins the live arms
beside the refusal, plus a degenerate-pass guard — otherwise a reader that simply
stopped resolving anything would pass the refusals too. The settle signal in both
harnesses is deliberately **spelling-independent**: `buildExpandFields` decides
`$expand` from the field's `type` alone ("the `reference` / `reference_to` target
is irrelevant to the decision"), so a `find` carrying `$expand` proves the
component consumed the schema — for the refusal probe just as much as for the
live-arm ones. A refusal that passed because the schema never arrived cannot hide
behind it.

## 5. Verification

**Module resolution, stated first:** both pins import their component by
**relative source path** (`./ObjectGantt`, `./ObjectTree`) and `@object-ui/core`
is aliased by the root `vitest.config.mts` to `packages/core/src`. Both legs
resolve to **SOURCE** — no package `exports` hop, no `dist`, and therefore **no
rebuild leg** to get wrong.

### Red first

| tree | tests | result |
|---|---|---|
| base source + the new pins | 12 | **3 failed / 9 passed** |
| after the change | 12 | **12 passed** |

The 3 failures were exactly the refusal assertions — gantt "does NOT read
`referenceTo`", gantt "degrades to the distinct loaded values", tree "does NOT
read `referenceTo`" — with all 9 live-arm, degenerate-guard and
through-the-normalizer cases green.

### Ablation — the FACT mutated, never the assertion

Run from the **committed** tree (`d812dadb8`), so the restore leg has a real
reference. Predictions were written before running; all four matched.

| leg | mutation | predicted | measured |
|---|---|---|---|
| control | none | 12 passed | **12 passed** |
| A | restore the third arm in gantt | 2 failed / 10 passed | **2 failed / 10 passed** |
| B | restore the third arm in tree | 1 failed / 11 passed | **1 failed / 11 passed** |
| C | restore both (= the pre-change source) | 3 failed / 9 passed | **3 failed / 9 passed** |

Leg B is the informative one: the tree's degenerate-pass guard stayed **green**
under the mutation, which is what makes it a control rather than a duplicate of
the pin.

**Mutation proven on disk per leg** — anchored counts (deleted-text 1→0,
injected-text 0→1; an anchor miss aborts the leg with exit 7 rather than silently
no-opping) **and** `git hash-object` diverging from the HEAD blob:
gantt `dc20b2f0` → `857b3324`, tree `568c4d35` → `beca27c1`.

**Restore proven both ways per leg, scoped to the mutated paths only** —
`git diff HEAD -- path` empty (measured in bytes, not by exit code) **and**
`git hash-object` equal to the HEAD blob. Restore is pinned to
`git checkout HEAD -- path`, never the bare form, which restores *from the index*
a path-scoped checkout has itself written. Whole-tree `git status --short` = **0
bytes** at the end. Absolute paths from `git rev-parse --show-toplevel`, under a
`trap ... EXIT INT TERM`.

### Suites, types, lint, gates

- **Package suites:** `plugin-gantt` + `plugin-tree` → **60 files / 462 tests
  passed**. Run from the repo root against explicit paths (a package-cwd run and
  a zero-match filter are both refused by `scripts/vitest-invocation-guard.mjs`).
- **Type-check, both packages, exit 0** with the script echoed
  (`tsc --noEmit && tsc -p tsconfig.test.json`) so it is not a zero-match false
  green. The dependency closure was built first (25 packages, exit 0) —
  `tsconfig.test.json` sets `paths: {}` so it resolves workspace deps through
  built `.d.ts`, and an unbuilt closure would have been a **false RED** (TS2307),
  not a finding.
- **`--listFiles`, MEASURED both halves:** each pin is a program input **1 time**
  under `tsconfig.test.json` and **0 times** under the build project — the build
  `tsconfig.json` excludes the test glob, so **only the test project can cover
  it**. Each edited component is an input **1 time in both** projects.
- **Lint, compared against the BASE version of the same files** — not a bare
  count. Base blobs `677650a2` / `94ba6dce` vs branch blobs `dc20b2f0` /
  `568c4d35`, counts from `--format json`: **0 errors / 113 warnings, identical
  in both directions**, with a byte-identical per-rule breakdown. Blob ids
  verified in both directions and the restore proven by an empty `git status`.
  The two new pins have no base version and are reported standalone: **0 errors /
  9 warnings**, all `@typescript-eslint/no-explicit-any` — the same rule and
  class as the drawer pin from PR #6920 (6 of the same).
- **The real package lint gates**, not a narrowing:
  `@object-ui/plugin-gantt` `eslint .` **exit 0** (0 errors, 309 warnings) and
  `@object-ui/plugin-tree` `eslint .` **exit 0** (0 errors, 53 warnings).
- **Gates, each quoted by its own verdict line, all exit 0:**
  `check:control-bytes` ("scanned 5777 tracked text file(s)"),
  `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:self-import`,
  `check:esm-specifiers`, `check:phantom-deps`, `check:designer-field-key-parity`,
  `check:element-data-source-declaration`, `check:side-effects-array`,
  `check-changeset-no-major`, `check-changeset-presence` ("4 source file(s) of 2
  released package(s) changed, and this change declares 1 changeset(s)"),
  `check-changeset-fixed`, `check-changeset-overwrite`, `check-lint-coverage`
  (46/46), `check-type-check-coverage` (45/46 + 41/41 test projects).

**NOT MEASURED — reported as neither red nor green:**

- `check:sdui-registration-pins` exits 2 and says so itself: *"This is exit 2,
  not a pass: ... a run with nothing to read has measured nothing. Build the
  console first"*. No console build exists in this worktree. The diff touches no
  registration array.
- `check:spec-floors` exits 1 with `no-artifact` and prints its own remedy
  (*"Build the workspace before running this gate"*). This worktree built a
  25-package closure, not the whole workspace. The diff adds no spec import and
  moves no dependency range.

**Declared narrowing:** repo-wide `eslint .` and the rest of the gate farm were
not run locally; CI runs the farm once regardless. The narrowing is bounded, not
assumed: `eslint.config.js` contains **no `projectService` and no `project:`
key**, so type-aware linting is not enabled and this diff cannot move the verdict
of any file it does not touch. Both packages it *does* touch were linted in full
by their own gate.

**Shared verify lock:** every acquisition waited **0s**; longest hold 88s (the
two package suites). Reported as a measurement, per the dispatch.

All figures above are from the final commit `d812dadb8`, with `git status`
clean.

## 6. Scope, and the boundary that was not reached

⛔ **`Refs`, never `Fixes`.** #6837 has ~18 readers of deferred scope and must
stay open; #6584 lost a decision's home for four days by closing on a first
slice.

The stop-and-report boundary — *"if either file's seam turns out to differ, STOP
AND REPORT rather than deleting"* — **was not reached**. Both seams matched the
table exactly: contract (a), fed by a generic `dataSource.getObjectSchema`,
reachable raw, three spellings read, only `reference` declared by the contract
fed. One refinement worth recording rather than silently correcting: the table
lists `ObjectTree`'s def provenance as an "`objectSchema` param". It is more
precisely `useSettledSchema(schemaKey, dataSource)`, which calls
`dataSource.getObjectSchema` itself. That makes it **more** clearly reachable
raw, not less — the classification is unchanged.

⛔ Deliberately untouched, and still #6837's open scope: the `reference_to` arms
across Class A (blocked on a corpus this repo cannot provide), Class B rows
18-20 (both spellings have named in-repo producers), the two pass-through
forwarders at `plugin-grid/ObjectGrid.tsx:465` and
`plugin-dashboard/recordFields.tsx:133`, and
`RecordDetailDrawer.tsx:301`'s `reference_field ?? referenceField` category
error.

_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_