### PR TITLE
test(plugin-detail): stop the record:highlights header narrating a parse mode

### DIFF
--- a/.changeset/issue-5881-record-highlights-header-prose.md
+++ b/.changeset/issue-5881-record-highlights-header-prose.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only comment change: the module header of
+`recordHighlightsInputs.spec-parity.test.ts` no longer narrates
+`RecordHighlightsProps` as a strip-mode `z.object`. It now states the
+pin-independent verdict and points at the file's own
+`specRefusesUnknownTopLevelKeys` probe for which way the installed
+`@objectstack/spec` states it. No assertion changed; nothing releases.

--- a/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts
@@ -19,11 +19,17 @@
  *     HeaderHighlight gate and honoured by the renderer, but the `fields`
  *     description still spelled the entry shape `{name,label?,icon?,type?}`);
  *   - a top-level input the spec does not declare is worse than undocumented,
- *     it is actively misleading. `RecordHighlightsProps` is a plain `z.object`,
- *     so an unknown top-level key is STRIPPED on parse with no error, the
- *     manifest gate only validates top-level props and raises no diagnostic,
- *     and the renderer never sees it. The manifest would be telling authors to
- *     write something the platform throws away.
+ *     it is actively misleading: the manifest would be publishing an authoring
+ *     surface the platform does not accept. That verdict holds on every pin —
+ *     an UNDECLARED top-level key is not an authoring surface — while the
+ *     contract states it two ways depending on the installed
+ *     `@objectstack/spec`: a closed `RecordHighlightsProps` refuses the key
+ *     with a named `unrecognized_keys`, where the older strip-mode `z.object`
+ *     dropped it from `data` with no error at all, which is exactly why this
+ *     gap could stay silent for as long as it did. Which way the installed pin
+ *     states it is probed behaviourally, below, by
+ *     `specRefusesUnknownTopLevelKeys` — never narrated here as a
+ *     present-tense fact about a mode.
  *
  * Both assertions derive their expectation from the spec at runtime rather than
  * restating today's key list, so a spec change fails here instead of quietly


### PR DESCRIPTION
Fixes #5881

`packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts` took the pin-aware disposition in its **body** but not in its **module header**. Forty lines above the file's own behavioural probe, the header still narrated a parse mode as a present-tense fact about the installed `@objectstack/spec`:

```
 *     it is actively misleading. `RecordHighlightsProps` is a plain `z.object`,
 *     so an unknown top-level key is STRIPPED on parse with no error, the
 *     manifest gate only validates top-level props and raises no diagnostic,
 *     and the renderer never sees it.
```

## Re-measured on this branch's merge-base — not copied from the card

The card's numbers were taken on `1939c9610`. This branch's merge-base is `e3d117ae1`, installed `@objectstack/spec` **17.2.0**. Measured with a declared-key control in the same run, so a red probe cannot be a rejection of `fields`:

```
installed @objectstack/spec = 17.2.0
=== RecordHighlightsProps ===
  control(declared keys only).success = true
  probe(+undeclared top-level key).success = false
  MODE = strict; issue codes = ["unrecognized_keys"]
  unrecognized_keys names = ["__objectui_5881_probe__"]
  specRefusesUnknownTopLevelKeys (as the file computes it) = true
```

Control green, probe red, exactly one `unrecognized_keys` naming exactly the probe key. **The premise holds**: "STRIPPED on parse with no error" is false as written on this pin.

## What changed

The paragraph's **verdict** was never falsified — publishing a top-level input the spec does not declare is actively misleading — only the mechanism it cited. So the verdict stays and the mechanism is replaced by a pin-independent statement that names both shapes as alternatives and hands the present-tense question to the file's own `specRefusesUnknownTopLevelKeys`. Narrating strict mode as fact would be the same defect with the sign flipped, so the new text asserts neither.

## Comment-only, proven rather than claimed

```
$ git diff -U0 -- packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts \
    | grep -E '^[+-]' | grep -v '^[+-][+-][+-]' | grep -vE '^[+-][[:space:]]*\*'
(no output)
NON_COMMENT_LINES_EXIT=1   # grep found none = zero non-comment +/- lines

$ ... | grep -cE '^[+-][[:space:]]*\*'
16                          # all 16 changed lines are comment lines (5 removed, 11 added)
```

No assertion added, changed or removed — that is deliberately #5887's separate work, not this branch's.

## Verification (exit codes captured before any pipe; verdict lines quoted from the tools themselves)

Run at `47c3da232`, the branch head this PR carries.

| check | result |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/src/__tests__/recordHighlightsInputs.spec-parity.test.ts` (repo root) **before** | `Test Files  1 passed (1)` / `Tests  5 passed (5)` — `VERDICT command-exit 0` |
| same, **after** | `Test Files  1 passed (1)` / `Tests  5 passed (5)` — `VERDICT command-exit 0` — identical, since nothing executable changed |
| `pnpm --filter @object-ui/plugin-detail type-check` | `> @object-ui/plugin-detail@17.6.0 type-check` / `> tsc --noEmit && tsc -p tsconfig.test.json` — `VERDICT command-exit 0` |
| `pnpm exec eslint .` in `packages/plugin-detail` (plain form) | `✖ 880 problems (0 errors, 880 warnings)`, exit 0 — all pre-existing; targeted `--format json` on the edited file reports `errors= 0 warnings= 0` |
| `node scripts/check-changeset-presence.mjs` | `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` … `Every one of them has an EMPTY frontmatter — declared as releasing nothing` |
| `node scripts/check-changeset-no-major.mjs` | `✅  No changeset declares a 'major' bump.` |

The first `type-check` read RED with `Cannot find module '@object-ui/react'` and friends — the unbuilt-closure false RED. `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail^...' build` then re-run gives the green above. The script name is echoed in both readings, so neither is a zero-match silent pass. `tsc -p tsconfig.test.json --listFiles` lists the edited file (1 hit), so the green is a measurement of it and not a coverage gap.

## Scope

Exactly one source file plus its "releases nothing" changeset. `recordDetailsInputs.spec-parity.test.ts` and `recordRelatedListInputs.spec-parity.test.ts` are untouched — they belong to #5887, which is in flight in parallel.

Out of scope, filed rather than fixed: #6925 — 11 files still call `17.0.0-rc.6` "the pinned" `@objectstack/spec` while no manifest in the workspace declares that range and the installed version is 17.2.0. Two of those files are #5887's, so it wants sequencing, not a drive-by here.

⛔ Draft on purpose. The PM lands it: do not mark ready, do not enqueue, do not enable auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_