### PR TITLE
test(plugin-detail): measure each top-level block's OWN schema strictness

### DIFF
--- a/.changeset/issue-5887-toplevel-strictness-probes.md
+++ b/.changeset/issue-5887-toplevel-strictness-probes.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only. The two `plugin-detail` top-level spec-parity blocks
+(`recordDetailsInputs`, `recordRelatedListInputs`) now measure their OWN
+schema's strictness against an undeclared top-level key, via a per-file
+`specRefusesUnknownTopLevelKeys` probe and a two-arm assertion, instead of
+citing the sibling `record:highlights` probe in prose — strictness is per
+schema. No published behaviour changes.

--- a/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
@@ -131,6 +131,31 @@ const specRefusesUnknownSectionKeys = !RecordDetailsProps.safeParse({
   sections: [{ label: 'Contact', fields: ['phone'], __objectui_4648_probe__: true }],
 }).success;
 
+/**
+ * The TOP-LEVEL twin of the probe above — does the installed spec refuse an
+ * undeclared key on the props object itself, or drop it in silence?
+ * (objectui#5887.)
+ *
+ * Both probes exist for the same reason and neither substitutes for the other:
+ * strictness is per SCHEMA, so the section-level reading above says nothing
+ * about `RecordDetailsProps` itself, and the sibling
+ * `recordHighlightsInputs.spec-parity.test.ts`'s top-level probe is a reading of
+ * `RecordHighlightsProps` — the shape to copy, not evidence about this one.
+ * Probed behaviourally rather than off a version string: the strictness IS the
+ * fact, and a probe cannot go stale against a pin it never reads.
+ *
+ * The probe key is a name no spec would ever declare — and if one ever did, the
+ * assertion below is what says so, rather than the probe quietly measuring a
+ * declared key and reporting strip mode.
+ */
+const TOP_LEVEL_BASELINE = { fields: ['phone'] };
+const UNDECLARED_TOP_LEVEL_KEY = '__objectui_5887_probe__';
+const unknownTopLevelParse = RecordDetailsProps.safeParse({
+  ...TOP_LEVEL_BASELINE,
+  [UNDECLARED_TOP_LEVEL_KEY]: true,
+});
+const specRefusesUnknownTopLevelKeys = !unknownTopLevelParse.success;
+
 const config = () => ComponentRegistry.getConfig('record:details');
 const inputs = () => config()?.inputs ?? [];
 const input = (name: string) => inputs().find((i) => i.name === name);
@@ -274,10 +299,11 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     // is exactly why the gap was silent. So "it is still there afterwards" is the
     // proof on both, and `success === true` is not — on a stripping pin an
     // undeclared key gets that too. Probed behaviourally rather than off a
-    // version string: `specRefusesUnknownTopLevelKeys` in the sibling
-    // `recordHighlightsInputs.spec-parity.test.ts` models the shape, and
-    // strictness is per schema, so it is the pattern rather than a reading of
-    // this one.
+    // version string, and measured on THIS schema:
+    // `specRefusesUnknownTopLevelKeys` above, asserted in the block that follows
+    // (objectui#5887). The sibling `recordHighlightsInputs.spec-parity.test.ts`
+    // models the shape, and strictness is per schema, so it was only ever the
+    // pattern rather than a reading of this one.
     expect(specTopLevelKeys()).toContain('hideFields');
     const parsed = RecordDetailsProps.safeParse({ hideFields: ['phone'] });
     expect(parsed.success).toBe(true);
@@ -285,6 +311,39 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
 
     expect(inputs().map((i) => i.name)).toContain('hideFields');
     expect(input('hideFields')?.description ?? '').not.toBe('');
+  });
+
+  it('refuses an undeclared top-level key, measured on THIS schema (#5887)', () => {
+    // The top-level counterpart of `publishes no section member key the spec
+    // refuses to carry` above, and the reading the block before this one used to
+    // borrow from a sibling. Both arms state the same verdict — an undeclared
+    // top-level key is not an authoring surface — because the contract states it
+    // two ways depending on the installed `@objectstack/spec`, and pinning the
+    // wrong one reds this file for a reason unrelated to what it guards.
+    //
+    // CONTROL FIRST, in this same assertion: the identical fixture WITHOUT the
+    // probe key parses green, so the probe's verdict below is attributable to the
+    // undeclared key and not to a malformed fixture. Without it, a probe that
+    // failed for any other reason would read as strictness.
+    expect(RecordDetailsProps.safeParse(TOP_LEVEL_BASELINE).success).toBe(true);
+
+    if (specRefusesUnknownTopLevelKeys) {
+      // A loud refusal. Asserted as an ENVELOPE — the code AND the key it names —
+      // because a bare "it failed" would also be satisfied by a rejection of
+      // `fields`, which is the half that must stay valid.
+      expect(unknownTopLevelParse.success).toBe(false);
+      expect(unknownTopLevelParse.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+      expect(
+        unknownTopLevelParse.error?.issues.flatMap(
+          (i) => (i as unknown as { keys?: string[] }).keys ?? [],
+        ),
+      ).toContain(UNDECLARED_TOP_LEVEL_KEY);
+    } else {
+      // Strip mode, and the concrete harm this family keeps re-paying for: no
+      // throw, no diagnostic, key gone, author handed a success receipt.
+      expect(unknownTopLevelParse.success).toBe(true);
+      expect(unknownTopLevelParse.data).not.toHaveProperty(UNDECLARED_TOP_LEVEL_KEY);
+    }
   });
 
   it('`hideFields` documents bare names only, because the spec rejects entry objects', () => {

--- a/packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts
@@ -103,6 +103,36 @@ const addDescription = () => input('add')?.description ?? '';
 /** A spec-valid related list, so a fixture only ever carries the key under test. */
 const baseline = { objectName: 'task', relationshipField: 'account', columns: ['name'] };
 
+/**
+ * Does the installed spec REFUSE an undeclared TOP-LEVEL key on this block, or
+ * drop it in silence? (objectui#5887.)
+ *
+ * `@objectstack/spec` 17.0.0 GA closed the props schemas under objectstack#4001
+ * batch A, so an undeclared key now raises `unrecognized_keys` with a named
+ * message; the older strip-mode `z.object`s parsed it green and dropped it from
+ * `data`. The VERDICT under test is identical either way — an undeclared
+ * top-level key is not an authoring surface — but the evidence differs, and
+ * asserting the wrong one turns this file red for a reason that has nothing to
+ * do with what it guards.
+ *
+ * Measured HERE rather than cited from the sibling: strictness is per schema, so
+ * `recordHighlightsInputs.spec-parity.test.ts`'s probe is a reading of
+ * `RecordHighlightsProps` and of nothing else — it is the shape to copy, not
+ * evidence about `RecordRelatedListProps`. Probed behaviourally rather than off
+ * a version string: the strictness IS the fact this file cares about, and a
+ * probe cannot go stale against a pin it never reads.
+ *
+ * The probe key is a name no spec would ever declare — and if one ever did, the
+ * assertion below is what says so, rather than the probe quietly measuring a
+ * declared key and reporting strip mode.
+ */
+const UNDECLARED_TOP_LEVEL_KEY = '__objectui_5887_probe__';
+const unknownTopLevelParse = RecordRelatedListProps.safeParse({
+  ...baseline,
+  [UNDECLARED_TOP_LEVEL_KEY]: true,
+});
+const specRefusesUnknownTopLevelKeys = !unknownTopLevelParse.success;
+
 describe('record:related_list — registry inputs vs @objectstack/spec', () => {
   it('is registered with a non-empty `inputs` surface', () => {
     expect(config()).toBeDefined();
@@ -135,16 +165,49 @@ describe('record:related_list — registry inputs vs @objectstack/spec', () => {
     // and dropped it from `data` in silence, which is exactly how this gap stayed
     // invisible for as long as it did. Key survival is the criterion that reads
     // the same either way; `success === true` does not, because on a stripping
-    // pin an undeclared key gets that too. For the behavioural probe of which way
-    // the installed pin says it, see `specRefusesUnknownTopLevelKeys` in the
-    // sibling `recordHighlightsInputs.spec-parity.test.ts` — strictness is per
-    // schema, so that probe is the shape to copy, not evidence about this one.
+    // pin an undeclared key gets that too. Which way the installed pin says it is
+    // measured on THIS schema by `specRefusesUnknownTopLevelKeys` above and
+    // asserted in the block that follows (objectui#5887) — strictness is per
+    // schema, so the sibling `recordHighlightsInputs.spec-parity.test.ts` probe
+    // was only ever the shape to copy, never evidence about this one.
     expect(specTopLevelKeys()).toContain('relationshipValueField');
     const parsed = RecordRelatedListProps.safeParse({ ...baseline, relationshipValueField: 'name' });
     expect(parsed.success).toBe(true);
     expect(parsed.data?.relationshipValueField).toBe('name');
 
     expect(inputNames()).toContain('relationshipValueField');
+  });
+
+  it('refuses an undeclared top-level key, measured on THIS schema (#5887)', () => {
+    // The reading the block above used to borrow from a sibling. Both arms state
+    // the same verdict — an undeclared top-level key is not an authoring surface
+    // — because the contract states it two ways depending on the installed
+    // `@objectstack/spec`, and pinning the wrong one reds this file for a reason
+    // unrelated to what it guards.
+    //
+    // CONTROL FIRST, in this same assertion: the identical fixture WITHOUT the
+    // probe key parses green, so the probe's verdict below is attributable to the
+    // undeclared key and not to a malformed fixture. Without it, a probe that
+    // failed for any other reason would read as strictness.
+    expect(RecordRelatedListProps.safeParse(baseline).success).toBe(true);
+
+    if (specRefusesUnknownTopLevelKeys) {
+      // A loud refusal. Asserted as an ENVELOPE — the code AND the key it names —
+      // because a bare "it failed" would also be satisfied by a rejection of
+      // `objectName`, which is the half that must stay valid.
+      expect(unknownTopLevelParse.success).toBe(false);
+      expect(unknownTopLevelParse.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+      expect(
+        unknownTopLevelParse.error?.issues.flatMap(
+          (i) => (i as unknown as { keys?: string[] }).keys ?? [],
+        ),
+      ).toContain(UNDECLARED_TOP_LEVEL_KEY);
+    } else {
+      // Strip mode, and the concrete harm this family keeps re-paying for: no
+      // throw, no diagnostic, key gone, author handed a success receipt.
+      expect(unknownTopLevelParse.success).toBe(true);
+      expect(unknownTopLevelParse.data).not.toHaveProperty(UNDECLARED_TOP_LEVEL_KEY);
+    }
   });
 
   it("`relationshipValueField` publishes the renderer's default, and it matches the read site", () => {


### PR DESCRIPTION
Fixes #5887

Both `plugin-detail` top-level spec-parity blocks narrated strictness in prose and pointed at the sibling `record:highlights` probe for the reading. Strictness is per SCHEMA, so that probe is evidence about `RecordHighlightsProps` and nothing else — the shape to copy, not a reading of `RecordDetailsProps` or `RecordRelatedListProps`. Each file now carries its own `specRefusesUnknownTopLevelKeys` probe plus a two-arm assertion, so the next `@objectstack/spec` pin change turns a test red instead of turning a comment false.

**Files (exactly the two in the card's fence, plus a changeset):**

- `packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts` — probe added as the TOP-LEVEL twin of the existing `specRefusesUnknownSectionKeys`, which the file's own prose already called it.
- `packages/plugin-detail/src/__tests__/recordRelatedListInputs.spec-parity.test.ts`
- `.changeset/issue-5887-toplevel-strictness-probes.md` — empty frontmatter: test-only, releases nothing.

`recordHighlightsInputs.spec-parity.test.ts` is **not** touched (read as the model only — #5881 is in flight on it in parallel). The SECTION-level block in `recordDetailsInputs` is not touched. No `.zod.ts` and no type declaration is touched.

In each edited block the now-stale sentence pointing readers at the sibling for the behavioural reading was repointed at the local probe. Leaving it would have recreated this card's own failure mode: a comment narrating a fact that is now measured a few lines away.

## The trap, and why a green run is not the evidence here

Both probes PASS on the installed pin, so green proves nothing on its own — an assertion that never runs is also green. Three things carry the claim instead.

**1. Premise re-measured on the merge-base (e3d117ae1, `@objectstack/spec` 17.2.0), each with a declared-key control that parses green.** The card's readings are from 2026-08-23; both still hold:

```
RecordDetailsProps      CONTROL {fields:['phone']}                                    success=true
                        PROBE   +__objectui_5887_probe__  success=false
                        codes=["unrecognized_keys"]  keys=["__objectui_5887_probe__"]  MODE=STRICT
RecordRelatedListProps  CONTROL {objectName,relationshipField,columns}                success=true
                        PROBE   +__objectui_5887_probe__  success=false
                        codes=["unrecognized_keys"]  keys=["__objectui_5887_probe__"]  MODE=STRICT
```

So `specRefusesUnknownTopLevelKeys === true` on both, and the strict arm is the one taken today.

**2. A declared-key control inside each new assertion**, run first: the identical fixture WITHOUT the probe key parses green, so the probe's red is attributable to the undeclared key and not to a malformed fixture.

**3. Liveness proven by ablation — the FACT mutated, never the assertion.** Direction predicted in writing before the run: change the probe key to a key the schema DECLARES and that accepts `true` (`inlineEdit` for details, `showViewAll` for related-list, both measured declared first) — the module probe then parses green, `specRefusesUnknownTopLevelKeys` flips true to false, the else (strip) arm is taken, `success` is still `true`, and `not.toHaveProperty` fails because a declared key survives in `data`. Predicted exactly 2 red tests, one per file, control still green.

Observed, matching the prediction:

```
Tests  2 failed | 24 passed (26)
recordDetailsInputs …:345  expected { columns: '2', …(2) } to not have property "inlineEdit"
recordRelatedListInputs …:209  expected { objectName: 'task', …(5) } to not have property "showViewAll"
```

Both reds land inside the new two-arm block, after the control passed. Mutation proven on disk before the run (anchored counts: removed spelling 0 hits, injected spelling 1 hit; `git hash-object` differing from the HEAD blob) and the diff over `expect(` lines was **0**, i.e. only the fact moved. Restore pinned to `git checkout HEAD -- ABSOLUTE_PATH` under `trap ... EXIT INT TERM`, proven both ways: `git diff HEAD` empty for both files AND both hashes equal to their HEAD blob. The implementation was committed BEFORE the mutation, so the restore leg had a real reference to restore to.

## Verification (all on b93bff959; exit codes captured before any pipe)

| check | result |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/` (root form) | BEFORE `115 files / 1053 tests`, AFTER `115 files / 1055 tests` — exit 0 |
| test delta | **+2**, exactly the two `it` blocks added (12 `expect` calls, 6 per file) |
| name-level diff | 2 additions, **0 removals** — a lost-one/gained-one swap could not hide behind the count |
| `pnpm --filter @object-ui/plugin-detail type-check` | green, script echoed as `type-check` running `tsc --noEmit && tsc -p tsconfig.test.json`; first read was the documented unbuilt-closure false RED, re-read after `pnpm --filter '@object-ui/plugin-detail^...' build` |
| type-check really covers the edits | `tsc -p tsconfig.test.json --listFiles` lists both edited files (2 hits) |
| `pnpm exec eslint .` in `packages/plugin-detail` (plain form) | exit 0 — `880 problems (0 errors, 880 warnings)`, all pre-existing, none in the edited files |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "Every one of them has an EMPTY frontmatter — declared as releasing nothing" |

The removed test names list is empty and the two added names are printed above, so the added-assertion count and the suite delta agree.

Draft on purpose: not marked ready, not enqueued, no auto-merge — the PM lands it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_