### PR TITLE
fix(types): one authority for `ActionSchema` and the Breadcrumb pair

### DIFF
--- a/.changeset/6349-types-internal-name-collisions-batch-1.md
+++ b/.changeset/6349-types-internal-name-collisions-batch-1.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/types': minor
+---
+
+Three exported type names inside `@object-ui/types` had two authorities each; each now has
+one (objectui#6349, first batch — the three intra-package collisions from the 46-name
+census on objectui#6273).
+
+**`ActionSchema` — renamed, because the two shapes are unrelated.** `crud.ts` and
+`ui-action.ts` both declared it. Measured member-by-member they share 9 keys out of 28 each:
+`crud.ts` `extends BaseSchema` and pins `type: 'action'` (a UI node — a button in a
+component tree), `ui-action.ts` extends nothing and types `type` as `ActionType` (a spec-v2
+action definition, with `name`, `locations`, `params`, `target`). Re-pointing either at the
+other would silently hand a consumer a different type, so this took the rename branch
+(objectui#5044 is the precedent for choosing the surviving name). `ui-action.ts`'s
+declaration is now spelled **`UIActionSchema`** — the name `src/index.ts` has always
+PUBLISHED it under, via `export type { ActionSchema as UIActionSchema }`, which is now a
+plain re-export. **The package's public surface is unchanged**: `ActionSchema` still means
+`crud.ts`'s legacy shape and `UIActionSchema` still means `ui-action.ts`'s, exactly as
+before. Nothing outside `ui-action.ts` imported the old spelling — there is no `./ui-action`
+subpath in `exports`, so the old name was never reachable from outside the package.
+
+**`BreadcrumbItem` / `BreadcrumbSchema` — re-pointed, because one copy was stale.** Both
+were declared in `data-display.ts` and in `navigation.ts`. The data-display pair was not a
+second dialect but a strict SUBSET: no key declared differently on either side, and missing
+`BreadcrumbItem.icon` / `onClick` / `siblings` and `BreadcrumbSchema.maxItems`. Everything
+that reads a breadcrumb was already on the navigation declaration — `registry.ts` maps the
+`'breadcrumb'` component type to it, `src/index.ts` re-exports it under the bare names,
+`zod/navigation.zod.ts` mirrors it (`icon`, `onClick`, `siblings`, `maxItems` included), the
+`ui:breadcrumb` renderer consumes it, and the component's own documentation page documents
+`icon` and `maxItems`. `data-display.ts` now re-exports the one authority.
+
+**What changes for a consumer.** The `@object-ui/types/data-display` subpath is published, so
+its `BreadcrumbItem` / `BreadcrumbSchema` and the `DataDisplaySchema` union's breadcrumb
+member widen to the navigation declaration — they gain the four keys above. Nothing narrows
+and no key changes type, so every value that type-checked before still does; what the subpath
+now declares is what the renderer already honoured and the docs already described. Graded
+`minor` because a published `.d.ts` member changes shape, per this repo's version-alignment
+rule (never `major`).
+
+The three `KNOWN_COLLISIONS` lines came down in the same change; that baseline
+(`scripts/__tests__/one-authority-per-exported-name-6273.test.ts`) is shrink-only and fails in
+both directions, so converging without deleting them would have been red too. 43 entries → 40.

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -17,6 +17,7 @@
 
 import type { ChartType as SpecChartType } from '@objectstack/spec/ui';
 import type { BaseSchema, SchemaNode } from './base.js';
+import type { BreadcrumbSchema } from './navigation.js';
 
 /**
  * Alert component
@@ -1644,34 +1645,27 @@ export interface TimelineSchema extends BaseSchema {
 }
 
 /**
- * Breadcrumb item
+ * Breadcrumb — ONE authority, and it lives in `./navigation.ts`.
+ *
+ * This module declared its own `BreadcrumbItem` / `BreadcrumbSchema` until
+ * objectui#6349. They were not a second dialect, they were a stale COPY: a
+ * strict subset of the navigation declarations, missing `BreadcrumbItem.icon` /
+ * `onClick` / `siblings` and `BreadcrumbSchema.maxItems`, with no key declared
+ * differently on either side. Everything that actually reads a breadcrumb was
+ * already on the navigation declaration — `registry.ts` maps the `'breadcrumb'`
+ * component type to it, `packages/types/src/index.ts` re-exports it under the
+ * bare names, `zod/navigation.zod.ts` mirrors it, and
+ * `content/docs/components/data-display/breadcrumb.mdx` documents `icon` and
+ * `maxItems` on THIS page. The copy's only reach was the
+ * `@object-ui/types/data-display` subpath and the {@link DataDisplaySchema}
+ * union below, both of which under-declared what the renderer honours.
+ *
+ * A re-export is one declaration with a second export site, which is exactly
+ * how this monorepo is meant to fan a type out; the recurrence guard
+ * (`scripts/__tests__/one-authority-per-exported-name-6273.test.ts`) does not
+ * count it. 2026-08-25 family ruling, objectui#6172 decision 甲/A1.
  */
-export interface BreadcrumbItem {
-  /**
-   * Item label
-   */
-  label: string;
-  /**
-   * Item href/link
-   */
-  href?: string;
-}
-
-/**
- * Breadcrumb component
- */
-export interface BreadcrumbSchema extends BaseSchema {
-  type: 'breadcrumb';
-  /**
-   * Breadcrumb items
-   */
-  items: BreadcrumbItem[];
-  /**
-   * Separator character
-   * @default '/'
-   */
-  separator?: string;
-}
+export type { BreadcrumbItem, BreadcrumbSchema } from './navigation.js';
 
 /**
  * Keyboard key component

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1034,7 +1034,7 @@ export type {
   ObjectUiLocalParamFieldType,
   ResolvableParamFieldType,
   ActionParam,
-  ActionSchema as UIActionSchema,
+  UIActionSchema,
   ActionGroup,
   ActionContext,
   ActionResult,

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -367,11 +367,23 @@ export interface ActionParam
 
 /**
  * Enhanced Action Schema (ObjectStack Spec v2.0.1)
- * 
- * This is the primary action schema that should be used for all new implementations.
- * The legacy ActionSchema in crud.ts is maintained for backward compatibility.
+ *
+ * This is the primary action schema that should be used for all new
+ * implementations. The legacy `ActionSchema` in `crud.ts` is maintained for
+ * backward compatibility.
+ *
+ * ⚠️ Named `UIActionSchema`, which is the name `packages/types/src/index.ts`
+ * has always PUBLISHED it under. It was declared as `ActionSchema` until
+ * objectui#6349 — a second authority for a name `crud.ts` also declares, so an
+ * IDE auto-import picked between two structurally unrelated types (9 shared
+ * keys out of 28 each; `type` is the literal `'action'` there and
+ * {@link ActionType} here) and the wrong pick surfaced as a remote `TS2322`.
+ * The declaration now spells the published name; nothing outside this file
+ * imported the old one, so the package's public surface is unchanged. See the
+ * 2026-08-25 family ruling (objectui#6172, decision 甲/A1) and the recurrence
+ * guard `scripts/__tests__/one-authority-per-exported-name-6273.test.ts`.
  */
-export interface ActionSchema {
+export interface UIActionSchema {
   /** Unique action identifier (snake_case) */
   name: string;
   
@@ -472,7 +484,7 @@ export interface ActionSchema {
    * `inline-action-api-params-to-body-extra` conversion (ADR-0087 D2).
    *
    * Declared here so the action renderers can forward it off a typed
-   * `ActionSchema` rather than through an `as any` cast — the renderers are the
+   * `UIActionSchema` rather than through an `as any` cast — the renderers are the
    * consumers this field exists for (objectstack#6837). Typed off the spec
    * rather than restated, so the shape cannot drift from the contract.
    */
@@ -491,7 +503,7 @@ export interface ActionSchema {
    * exactly that, so the key has one meaning everywhere it is honoured.
    *
    * Declared here for the same reason as {@link bodyExtra}: the action
-   * renderers forward it off a typed `ActionSchema` instead of an `as any`
+   * renderers forward it off a typed `UIActionSchema` instead of an `as any`
    * cast, and dropping it from those whitelists is what made a declared wrap
    * degrade silently to a flat body (objectstack#6938). Typed by derivation
    * from the spec so the union cannot drift from the contract.
@@ -583,7 +595,7 @@ export interface ActionGroup {
   icon?: string;
   
   /** Actions in this group */
-  actions: ActionSchema[];
+  actions: UIActionSchema[];
   
   /** Group visibility condition */
   visible?: string;
@@ -637,7 +649,7 @@ export interface ActionResult {
  * Action executor function type
  */
 export type ActionExecutor = (
-  action: ActionSchema,
+  action: UIActionSchema,
   context: ActionContext,
   params?: Record<string, any>
 ) => Promise<ActionResult>;
@@ -698,7 +710,7 @@ export interface TransactionConfig {
   /** Timeout in milliseconds */
   timeout?: number;
   /** Actions to execute within the transaction */
-  actions: ActionSchema[];
+  actions: UIActionSchema[];
   /** Rollback action on failure */
   rollbackAction?: string;
   /** Whether to auto-retry on conflict */

--- a/scripts/__tests__/check-action-forward-parity.test.ts
+++ b/scripts/__tests__/check-action-forward-parity.test.ts
@@ -98,7 +98,7 @@ function repoWith(
     files: {
       [UI_VIEW]:
         overrides.view ??
-        'export interface ActionSchema {\n  name?: string;\n  description?: string;\n}\n',
+        'export interface UIActionSchema {\n  name?: string;\n  description?: string;\n}\n',
       [KEYS_MODULE]:
         overrides.keys ?? "export const RETIRED_ACTION_KEYS = {\n  execute: 'renamed to target',\n};\n",
       [CONSUMER]:
@@ -388,7 +388,7 @@ describe('extraction failure throws rather than returning a clean verdict', () =
   });
 
   it('a renderer view with no properties is red', () => {
-    expect(() => judge(repoWith('{ target }', { view: 'export interface ActionSchema {}\n' }))).toThrow(
+    expect(() => judge(repoWith('{ target }', { view: 'export interface UIActionSchema {}\n' }))).toThrow(
       /declares no properties/,
     );
   });
@@ -409,7 +409,7 @@ describe('extraction failure throws rather than returning a clean verdict', () =
     // Authorable and runtime-read do not intersect at all: nothing would ever be
     // checked for this surface again.
     expect(() =>
-      judge(repoWith('{ target }', { view: 'export interface ActionSchema {\n  nothingReadsThis?: string;\n}\n' }), {
+      judge(repoWith('{ target }', { view: 'export interface UIActionSchema {\n  nothingReadsThis?: string;\n}\n' }), {
         spec: { declared: ['norThis'], inline: [] },
       }),
     ).toThrow(/owed set is empty/);

--- a/scripts/__tests__/one-authority-per-exported-name-6273.test.ts
+++ b/scripts/__tests__/one-authority-per-exported-name-6273.test.ts
@@ -349,11 +349,17 @@ const filesOf = (sites: readonly Located[]): string[] => [
 const KNOWN_COLLISIONS: ReadonlyMap<string, readonly string[]> = new Map([
   ['ActionContext', ['packages/core/src/actions/ActionRunner.ts', 'packages/types/src/ui-action.ts']],
   ['ActionResult', ['packages/core/src/actions/ActionRunner.ts', 'packages/types/src/ui-action.ts']],
-  ['ActionSchema', ['packages/types/src/crud.ts', 'packages/types/src/ui-action.ts']],
   ['AggregationConfig', ['packages/plugin-grid/src/useGroupedData.ts', 'packages/types/src/data-protocol.ts']],
   ['AppShellProps', ['packages/app-shell/src/types.ts', 'packages/layout/src/AppShell.tsx']],
-  ['BreadcrumbItem', ['packages/types/src/data-display.ts', 'packages/types/src/navigation.ts']],
-  ['BreadcrumbSchema', ['packages/types/src/data-display.ts', 'packages/types/src/navigation.ts']],
+  // `ActionSchema` sat here, colliding between `packages/types/src/crud.ts` and
+  // `packages/types/src/ui-action.ts`. Structurally unrelated types — 28 members
+  // each, 9 shared, `type` the literal `'action'` there and `ActionType` here — so
+  // the remedy was the RENAME branch: ui-action's declaration now spells
+  // `UIActionSchema`, the name `src/index.ts` always published it under
+  // (objectui#6349). `BreadcrumbItem` / `BreadcrumbSchema` sat here too, colliding
+  // between `packages/types/src/data-display.ts` and
+  // `packages/types/src/navigation.ts`; data-display's were a strict SUBSET copy, so
+  // that file re-points at navigation's one authority.
   ['CalendarEvent', ['packages/plugin-calendar/src/index.tsx', 'packages/types/src/complex.ts']], // the ruled-on objectui#5044 alias — see the header
   ['CalendarSchema', ['packages/plugin-calendar/src/ObjectCalendar.tsx', 'packages/types/src/form.ts']],
   ['ChatMessage', ['packages/plugin-chatbot/src/ChatbotEnhanced.tsx', 'packages/types/src/complex.ts']],

--- a/scripts/check-action-forward-parity.mjs
+++ b/scripts/check-action-forward-parity.mjs
@@ -392,7 +392,12 @@ export function loadSpecSchemas(require = createRequire(import.meta.url)) {
 }
 
 /**
- * `@object-ui/types`' renderer VIEW of an action.
+ * `@object-ui/types`' renderer VIEW of an action — `interface UIActionSchema`.
+ *
+ * ⚠️ It was `interface ActionSchema` until objectui#6349, a second authority for
+ * a name `packages/types/src/crud.ts` also declares. The declaration now spells
+ * the name the package always PUBLISHED it under (`UIActionSchema`); the type
+ * and the file are unchanged.
  *
  * Declared surfaces are typed against this, not against the spec schema
  * directly — it carries renderer-only fields the spec does not model
@@ -408,16 +413,16 @@ export function uiActionViewKeys(root, file = UI_ACTION_VIEW) {
   }
   const sf = parse(root, file);
   for (const stmt of sf.statements) {
-    if (!ts.isInterfaceDeclaration(stmt) || stmt.name.text !== "ActionSchema") continue;
+    if (!ts.isInterfaceDeclaration(stmt) || stmt.name.text !== "UIActionSchema") continue;
     const keys = stmt.members
       .filter(ts.isPropertySignature)
       .map((m) => (m.name && (ts.isIdentifier(m.name) || ts.isStringLiteral(m.name)) ? m.name.text : null))
       .filter((n) => n !== null);
-    if (keys.length === 0) fail(`\`ActionSchema\` in ${file} declares no properties — extraction failed.`);
+    if (keys.length === 0) fail(`\`UIActionSchema\` in ${file} declares no properties — extraction failed.`);
     return keys;
   }
   fail(
-    `\`interface ActionSchema\` not found in ${file}.\n` +
+    `\`interface UIActionSchema\` not found in ${file}.\n` +
       "    The renderer view moved or was renamed; re-point this gate at it."
   );
 }

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -243,11 +243,14 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const ALLOW = {
   "@object-ui/types:ActionSchema": {
     reason:
-      "Two deliberate objectui-side shapes, both documented at their declaration. " +
-      "`ui-action.ts` is a renderer VIEW over the spec's action — it carries renderer-only " +
-      "fields the spec does not model, while importing the spec-owned parts it does share " +
-      "(`ActionLocation`, `ActionType`). `crud.ts` is the explicitly @deprecated legacy " +
-      "shape kept for backward compatibility and slated for removal in a future major.",
+      "`crud.ts`'s explicitly @deprecated legacy action shape, kept for backward " +
+      "compatibility and slated for removal in a future major. ⚠️ This entry covered TWO " +
+      "objectui-side shapes until objectui#6349: `ui-action.ts` declared a same-named " +
+      "renderer VIEW over the spec's action (renderer-only fields the spec does not model, " +
+      "importing the spec-owned parts it shares — `ActionLocation`, `ActionType`). That one " +
+      "is now declared as `UIActionSchema`, the name the package always published it under, " +
+      "so it no longer shadows a spec export and no longer needs excusing here. This entry " +
+      "stays because `crud.ts` still carries the name.",
     issue: 4115,
   },
   "@object-ui/types:FormField": {


### PR DESCRIPTION
Refs #6349 — **first batch only**: the three collisions that live entirely inside `packages/types`, where a barrel consumer cannot disambiguate them. 43 of the 46 census names remain and #6349 stays their owner, so this is `Refs`, not `Fixes`.

Verified on `c7bc6155b`. ⛔ Do not mark ready / enqueue / auto-merge — draft by dispatch order.

## The batch, and the delta on the merge-base

The census table was measured on `79ebf30d1`. Re-derived on my merge-base `40c479af2` with the gate's own matcher (`scripts/js-comment-mask.mjs` + the same three regexes, same population bound): **43 colliding names, not 46** — `FormFieldSpec` / `FormSectionSpec` / `FormViewSpec` left the tree with the spec-bridge retirement (#6366) and `KNOWN_COLLISIONS` already records that in a comment. All three of my names still collided, at the same sites the table names, so none had to be dropped:

```
ActionSchema      packages/types/src/crud.ts:67          packages/types/src/ui-action.ts:374
BreadcrumbItem    packages/types/src/data-display.ts:1649 packages/types/src/navigation.ts:179
BreadcrumbSchema  packages/types/src/data-display.ts:1663 packages/types/src/navigation.ts:205
```

After: **40 collisions, 40 baseline entries.** Population floors intact — 38 published packages, 1,384 files, 2,201 authority sites (was 2,204: three declarations removed, one barrel alias became a plain re-export).

## Shapes compared structurally before choosing — the method

Not by reading. A TypeScript-AST probe over both declarations of each name, comparing heritage clause, member set, and each shared member's declared type and optionality:

| name | A | B | only in A | only in B | shared keys typed differently | verdict |
|---|---|---|---|---|---|---|
| `ActionSchema` | `crud.ts` (28 members, `extends BaseSchema`) | `ui-action.ts` (28 members, no heritage) | 19 | 19 | 3 — `type`: `'action'` vs `ActionType`; `variant`; `method` | **unrelated types** |
| `BreadcrumbItem` | `data-display.ts` (2) | `navigation.ts` (5) | 0 | 3 — `icon`, `onClick`, `siblings` | 0 | **strict subset copy** |
| `BreadcrumbSchema` | `data-display.ts` (3, `extends BaseSchema`) | `navigation.ts` (4, same) | 0 | 1 — `maxItems` | 0 | **strict subset copy** |

That split is what picks the remedy per name, and the two remedies are different.

### `ActionSchema` → rename, because the two are different things

9 shared keys out of 28 each; one is a UI node in a component tree (`type: 'action'`), the other a spec-v2 action definition (`name`, `locations`, `params`, `target`). Re-pointing either at the other would silently hand a consumer a different type — exactly the harm the ruling is about. #5044 is the precedent for choosing the surviving name, and here the tiebreak is already settled by the barrel: `src/index.ts` publishes `crud.ts`'s as `ActionSchema` and `ui-action.ts`'s as `UIActionSchema` (`export type { ActionSchema as UIActionSchema }`, line 1037). So **`ui-action.ts`'s declaration is renamed to the name the package has always published it under**, and the alias becomes a plain re-export. `packages/components`' own CHANGELOG already calls that type `UIActionSchema` in prose; only the declaration was out of step.

**Consumers.** Nothing outside `ui-action.ts` imported the old spelling: `exports` in `packages/types/package.json` has no `./ui-action` subpath, and the only three files importing that module by path take `ActionParam` and the value exports, never `ActionSchema`. Every `UIActionSchema` user in the repo goes through the barrel and is untouched.

### `BreadcrumbItem` / `BreadcrumbSchema` → re-point, because one copy was stale

Not a second dialect — a subset with nothing declared differently. Everything that actually reads a breadcrumb was already on **`navigation.ts`**: `registry.ts` maps the `'breadcrumb'` component type to it, `src/index.ts` re-exports it under the bare names, `zod/navigation.zod.ts` mirrors it (`icon`, `onClick`, `siblings`, `maxItems` all present), the `ui:breadcrumb` renderer consumes it and says so in a comment, and `content/docs/components/data-display/breadcrumb.mdx` documents `icon` and `maxItems`. `data-display.ts` now re-exports the one authority.

**Consumers, and one that imported the losing file directly.** Yes — `packages/types/src/__tests__/zod-mirror-parity.test.ts:138` imports `BreadcrumbItem` / `BreadcrumbSchema` from `../data-display` and pairs them against the **`navigation.zod.ts`** mirrors (lines 610–611). It was checking the navigation Zod schema against the data-display TS interface: a live instance of the defect, silent because the mirror is the wider side. After the re-point those pairs compare the mirror against the declaration it actually mirrors; the file is green either way, but it is honest now. No ledger entry (`KnownDrift` / `UnmirroredDeclared` / `RuntimeOnlyDeclared`) names either pair, so nothing went stale.

## Emitted `.d.ts` — what changed shape, and for whom

Built `@object-ui/types` on both sides (a second worktree at `40c479af2`, since removed) and diffed the emitted declarations:

| emitted file | result |
|---|---|
| `dist/index.d.ts` | **CHANGED, but only the spelling of one re-export clause** — `ActionSchema as UIActionSchema` → `UIActionSchema`. No exported name added, removed or reshaped. |
| `dist/crud.d.ts`, `dist/navigation.d.ts`, `dist/registry.d.ts` | **byte-identical** |
| `dist/ui-action.d.ts` | interface identifier `ActionSchema` → `UIActionSchema`; members unchanged. Not reachable — no `./ui-action` subpath. |
| `dist/data-display.d.ts` | the two `interface Breadcrumb*` declarations replaced by `export type { BreadcrumbItem, BreadcrumbSchema } from './navigation.js'` |
| `dist/zod/*.zod.d.ts` — **7 files** (data-display, form, index, layout, navigation, objectql, views) | **byte-differs, shape-identical.** Ordering jitter of inferred-type properties: the sorted line-multisets are identical for all seven, with `dist/data-display.d.ts` as a hot control that FAILS that same test, as a real change must; and two clean builds of the same head commit are byte-identical, so `tsc` is deterministic here and the reordering is attributable to this PR's module-graph change. The `./zod` subpath's declared types are unchanged in meaning. |

The first four rows are the complete **shape** statement; the zod row is what makes it complete as a **byte** statement too — my first enumeration listed only the shape changes and was incomplete on bytes.

**So exactly one audience sees a member change shape:** a consumer of the published `@object-ui/types/data-display` subpath, or of the `DataDisplaySchema` union. Their `BreadcrumbItem` gains `icon` / `onClick` / `siblings` and their `BreadcrumbSchema` gains `maxItems`. All four gained members are optional and nothing narrows, so **every _value_ that type-checked before still does**, in both directions — and what the subpath declares is now what the renderer already honoured and the docs already described. Graded `minor` per the version-alignment rule (direct precedent: #6574 added `bind` to `BaseSchema`, the same class, graded `minor`).

⚠️ **One caveat, and it is stated because an earlier draft of this sentence claimed the absolute (“everything that type-checked before still does”) and a probe refutes it.** Adding members moves `keyof`, so a consumer that EXHAUSTS it does break. Measured, direction predicted first: `Record<keyof BreadcrumbItem, string>` written with the two old keys compiles on base and fails on head — `TS2739: ... missing the following properties ...: icon, onClick, siblings`. In-repo consumers of that shape: **zero** (controlled grep for `keyof` over both names across `packages/` and `apps/`), and there is no in-repo, `examples/` or `skills/` importer of the `@object-ui/types/data-display` subpath at all. So this is a documented caveat for downstream, not a blocker — but it is a real class, and the landing record should not deny it. The changeset already carries the value-scoped wording.

## The baseline gate shown non-vacuous

The instrument is the two-way failure itself, so it is demonstrated rather than supplemented. **Direction predicted in writing first:** deleting a `KNOWN_COLLISIONS` line while the name still collides leaves the observed collision with no baseline entry, so `reconcile` puts it in **`fresh`** with the text `a NEW colliding name` — the `fresh` assertion fails, `stale` stays green.

Run on the clean merge-base tree, mutating the **fact** (the baseline line for `BreadcrumbItem`), never the assertion, under `trap … EXIT INT TERM` with absolute paths from `git rev-parse --show-toplevel`:

```
HEAD_BLOB=542a445903d56fb0e57fc176eda916bef7646e07
DISK_PRE  =542a445903d56fb0e57fc176eda916bef7646e07   (equal — tree was at HEAD before mutating)
ANCHOR_COUNT_BEFORE=1  →  ANCHOR_COUNT_AFTER=0
DISK_MUT  =7139a100bc8afe870b427d69b0246fd0175e7ff4   (≠ HEAD blob — mutation reached disk)
GATE_EXIT_ON_MUTATED_TREE=1
   BreadcrumbItem — a NEW colliding name
   Test Files 1 failed (1) · Tests 1 failed | 10 passed (11)
```

Observed direction matched the prediction. Restore proved **both** ways with `git checkout HEAD -- <abs path>` (never bare): `git diff HEAD` empty **and** disk hash back to `542a4459…`, `git status` clean.

## Gates

Exit codes captured **before any pipe**; every verdict below is the line the gate printed for itself.

| gate | result |
|---|---|
| `pnpm --filter @object-ui/types type-check` (hyphenated; `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`, so test files are covered) | exit 0, before **and** after |
| root-form vitest, same file set before and after | **before: 82 files / 1021 tests passed. after: 82 / 1021 passed.** Identical counts — no file or test silently dropped. Re-run on `c7bc6155b`: 82 / 1021. |
| `pnpm exec eslint .` (plain form, no `--no-inline-config`) | exit 0 — **full repo, not narrowed**: 4,022 files linted per `--format json`, **0 errors**, 11,516 pre-existing warnings. All seven changed files are in the population; every warning on them is `@typescript-eslint/no-explicit-any` on lines outside my hunks. |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 3 released-source files changed, 1 changeset declared |
| `check:action-forward-parity` | exit 0 — `5 surfaces checked against 39 runtime-read keys from 4 consumers` |
| `check:spec-symbols` | exit 0 — `16 declared dialects, 0 untriaged collisions in 0 packages` |
| `check:control-bytes` | exit 0 — 5,782 tracked text files |
| `check:doc-types`, `check:designer-field-key-parity`, `check:icon-record-names`, `check:self-import`, `check:esm-specifiers` | exit 0 (derived from the paths this diff actually touches) |
| `check:readme-exports` | **NOT MEASURED locally** — the gate prints `the population COLLAPSED -- this run proves nothing` without a full workspace build (388 complaints, all `dist/index.d.ts is not on disk`, across packages this diff never touches). `readme-exports.yml` builds first; this one is CI's. |

## Two touches outside `packages/types`, both declared

Neither is drive-by; both are the same defect and both are named here because the divide-line scan belongs in the PR body.

1. **`scripts/check-action-forward-parity.mjs`** extracts `interface ActionSchema` from `packages/types/src/ui-action.ts` by name, and its own failure message reads *"The renderer view moved or was renamed; re-point this gate at it."* — so it is re-pointed at `UIActionSchema`, together with the three fixtures in `scripts/__tests__/check-action-forward-parity.test.ts` that spell the old name (fixture triage: they merely used it; the negative control `interface Other` still proves a renamed view is red). That suite is owed because the gate script itself is edited — and it earned its keep: it went red first, 32 failures, before the fixtures were corrected.
2. **`scripts/check-spec-symbol-derivation.mjs`**'s `ALLOW["@object-ui/types:ActionSchema"]` reason said *"Two deliberate objectui-side shapes"*. After the rename only `crud.ts` carries the name, so the prose is corrected; that file's own header says such a comment is load-bearing rather than decorative. The entry stays (it is keyed `package:name` and `crud.ts` still matches), so the shrink-only ratchet does not fire.

## Scope

Exactly the three names the PM sized. Nothing else from the 46 — not while in the file. `KanbanCard` / `KanbanColumn` (#6155), `KanbanSchema` / `MarkdownSchema` (#6172) and `ComponentConfig` (#6298) are untouched. The #6298 fence held: `git diff --name-only -- packages/types/src/base.ts` is **empty**; the eight changed files are disjoint from `base.ts`.

## Amendment record

This body was amended once after the contract review (https://github.com/objectstack-ai/objectui/issues/6349#issuecomment-5473107460, verdict ACCEPT-WITH-CONDITIONS): the compatibility sentence is now value-scoped with the `keyof` caveat named, and the `.d.ts` table gained the seven `zod/*.zod.d.ts` byte-differences the reviewer measured as order-only. **Body only — no commit; the head is still `c7bc6155b`, the tree the gates above were run on.** Authored by Claude Code, session `https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB`.

_Generated by [Claude Code](https://claude.ai/code)_
