### PR TITLE
feat(types)!: retire ComponentInput's four inert constraint keys, and report the `inputType` fork

### DIFF
--- a/.changeset/5905-componentinput-retire-constraint-keys.md
+++ b/.changeset/5905-componentinput-retire-constraint-keys.md
@@ -1,0 +1,51 @@
+---
+'@object-ui/types': minor
+---
+
+Retire `ComponentInput`'s four inert constraint keys — `min`, `max`, `step` and
+`placeholder` (objectui#5905, ADR-0049 enforce-or-remove).
+
+All four were declared on `ComponentInput` and read by nothing, on either path. No consumer
+reads them off a `ComponentInput` value, and the manifest serializer
+(`packages/sdui-parser/src/index.ts`) forwards exactly six keys per input — `name`, `type`,
+`required`, `enum`, `binding`, `description` — so a value authored here could not reach the
+published `sdui.manifest.json` even in principle. Re-measured on this branch's merge-base
+rather than inherited from the card: a structural census over every `inputs:` array in the
+repository (219 regions, all tracked files) scores `min` **0**, `max` **0**, `step` **0**
+and `placeholder` **0**, against `name` 926, `type` 926, `description` 161, `enum` 114 and
+`required` 87 in the same pass over the same regions — the instrument was not blind.
+
+FROM → TO, per key:
+
+- `min: number` → **removed**. Spell the numeric domain out in `description`, which IS
+  published (`'A positive integer — the contract rejects 0 and fractional values'`).
+- `max: number` → **removed**. Same remedy.
+- `step: number` → **removed**. Same remedy.
+- `placeholder: string` → **removed**. Put the hint in `description`. ⚠️
+  `BaseSchema.placeholder` — the node-level prop a renderer does read — is a DIFFERENT key
+  and is unaffected.
+
+The retirement kit: `?: never` on the interface (`packages/types/src/base.ts`), so authoring
+one is a `tsc` error at the registration site; `retirementTombstone()` on the Zod mirror
+(`packages/types/src/zod/base.zod.ts`), so an authored value is REFUSED at parse time with
+`code: 'invalid_type'`, the key named in the issue `path`, and the migration note as the
+message. Deleting the members outright was the option NOT taken: `ComponentInputSchema` is
+a non-strict `z.object`, which strips an undeclared key silently — one silent no-op traded
+for another. Pinned in
+`packages/types/src/__tests__/component-input-retired-constraint-keys.test.ts`.
+
+Two limits worth stating rather than papering over:
+
+- The in-repo zero is what was measured. Whether anything OUTSIDE this repository writes
+  these keys is **not measurable from here** (the same limit objectui#5674 recorded for
+  `PluginComponentInput`). Converting such a write from a silent drop into a named refusal
+  is exactly what the tombstone buys.
+- The fifth key objectui#5905 named, `inputType`, is **NOT retired here**.
+  `packages/plugin-markdown` authors it (`inputType: 'textarea'`), so it is
+  declared-and-DROPPED — a different defect that needs a ruling, not a removal.
+
+This is not a verdict that constraint slots on `ComponentInput` were a mistake. The
+neighbouring `type` field carries a maintainer ruling of 2026-08-17 recording that giving
+`ComponentInput` real constraint slots was **deferred, not rejected** — `min`/`max`/`step`
+read exactly like the slots that ruling declined to add. What is retired is this inert
+spelling; the ruling's own reopen condition still stands.

--- a/packages/types/src/__tests__/component-input-retired-constraint-keys.test.ts
+++ b/packages/types/src/__tests__/component-input-retired-constraint-keys.test.ts
@@ -1,0 +1,197 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ComponentInput`'s four inert constraint keys are ADR-0049 RETIREMENT
+ * TOMBSTONES, and the refusal is LOUD (objectui#5905).
+ *
+ * ## What was measured
+ *
+ * `min` / `max` / `step` / `placeholder` were declared on `ComponentInput` and
+ * read by nothing, on either path:
+ *
+ *   - no consumer reads them off a `ComponentInput` value; and
+ *   - the manifest serializer (`packages/sdui-parser/src/index.ts`) forwards
+ *     exactly six keys per input — `name`, `type`, `required`, `enum`,
+ *     `binding`, `description` — so an authored value could not reach the
+ *     published `sdui.manifest.json` even in principle.
+ *
+ * A structural census over EVERY `inputs:` array in the repository found zero
+ * authoring sites for the four; the same pass, over the same regions, counted
+ * 926 `name`, 926 `type` and 161 `description` sites, so the instrument was
+ * demonstrably not blind. Authorship from OUTSIDE this repository is not
+ * measurable from here (the limit objectui#5674 recorded for
+ * `PluginComponentInput`) — and that unmeasurable half is precisely what the
+ * tombstone serves: an outside write becomes a NAMED REFUSAL carrying its own
+ * remedy instead of a silent drop.
+ *
+ * ## Why tombstones and not deletions
+ *
+ * `ComponentInputSchema` is a NON-STRICT `z.object`, so a deleted key would be
+ * silently STRIPPED — one silent no-op traded for another. The tombstone keeps
+ * the key declared and unwritable: `?: never` on the interface (a `tsc` error
+ * at the authoring site) and `retirementTombstone()` on the mirror (a parse
+ * refusal whose message IS the migration note). Both halves are pinned below,
+ * plus the CONTRAST against a genuinely undeclared key, so nobody can "simplify"
+ * the tombstones into deletions without this file going red.
+ *
+ * ## `inputType` is NOT here, deliberately
+ *
+ * The fifth key objectui#5905 named is still live and still writable, because
+ * the repository AUTHORS it: `packages/plugin-markdown/src/index.tsx` declares
+ * `inputType: 'textarea'` on its `content` input (pinned by that package's own
+ * test). That is declared-and-DROPPED — a different defect from the
+ * declared-and-unread four — and it needs a ruling, not a removal. Its liveness
+ * is pinned below so the fork stays visible and closing it stays a deliberate
+ * edit to this file.
+ *
+ * The `@ts-expect-error` directives are REAL enforcement: this package
+ * type-checks its tests through `tsconfig.test.json`, so re-widening the
+ * declaration fails the build on the unused directive.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ComponentInput } from '../base';
+import { ComponentInputSchema } from '../zod/base.zod';
+
+/** The four retired keys, with a value an author would plausibly have written. */
+const RETIRED = {
+  min: 0,
+  max: 100,
+  step: 1,
+  placeholder: 'Type here…',
+} as const;
+
+type RetiredKey = keyof typeof RETIRED;
+
+/** A fully live input — every key here is declared AND forwarded by the serializer. */
+const LIVE_INPUT = {
+  name: 'content',
+  type: 'string',
+  label: 'Markdown Content',
+  required: true,
+  description: 'A positive integer — the contract rejects 0 and fractional values',
+} as const;
+
+const shapeOf = (schema: unknown): Record<string, unknown> =>
+  (schema as { shape: Record<string, unknown> }).shape;
+
+const describeOf = (schema: unknown, key: string): string | undefined =>
+  (shapeOf(schema)[key] as { description?: string } | undefined)?.description;
+
+/* ── type-level pins: the `tsc` channel ──────────────────────────────────── */
+
+describe('the interface tombstones make authoring a `tsc` error', () => {
+  it('refuses each retired key at the authoring site', () => {
+    const input: ComponentInput = {
+      name: 'content',
+      type: 'string',
+      // @ts-expect-error `min` is a retirement tombstone (objectui#5905)
+      min: 0,
+      // @ts-expect-error `max` is a retirement tombstone (objectui#5905)
+      max: 100,
+      // @ts-expect-error `step` is a retirement tombstone (objectui#5905)
+      step: 1,
+      // @ts-expect-error `placeholder` is a retirement tombstone (objectui#5905)
+      placeholder: 'Type here…',
+    };
+    expect(input.name).toBe('content');
+  });
+
+  it('keeps `inputType` WRITABLE — the fork objectui#5905 reported, not an oversight', () => {
+    // No `@ts-expect-error`: `plugin-markdown` authors this key today, so
+    // retiring it is a ruling about that registration, not a cleanup. If this
+    // line ever needs a directive, the fork was closed — say so on the card.
+    const input: ComponentInput = { name: 'content', type: 'string', inputType: 'textarea' };
+    expect(input.inputType).toBe('textarea');
+  });
+});
+
+/* ── the mirror refuses, and the refusal carries its remedy ──────────────── */
+
+describe('the zod tombstones REFUSE, loudly (objectui#5905)', () => {
+  it('a fully live input still parses GREEN — the non-vacuity control, in this test', () => {
+    // Without this, a mirror that refused everything would satisfy every
+    // assertion below by accident.
+    const control = ComponentInputSchema.safeParse(LIVE_INPUT);
+    expect(control.success).toBe(true);
+    if (control.success) {
+      expect(control.data.name).toBe('content');
+      expect(control.data.description).toBe(LIVE_INPUT.description);
+    }
+  });
+
+  it('`inputType` still parses green — the fork half of the same control', () => {
+    const result = ComponentInputSchema.safeParse({ ...LIVE_INPUT, inputType: 'textarea' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.inputType).toBe('textarea');
+  });
+
+  for (const key of Object.keys(RETIRED) as RetiredKey[]) {
+    it(`refuses \`${key}\`, names it in the path, and answers with its own guidance`, () => {
+      const result = ComponentInputSchema.safeParse({ ...LIVE_INPUT, [key]: RETIRED[key] });
+      expect(result.success, key).toBe(false);
+      if (result.success) return;
+
+      const issue = result.error.issues.find((i) => String(i.path[0]) === key);
+      expect(issue, `no issue addressed to \`${key}\``).toBeDefined();
+
+      // The accept-set contract: same address, same code a bare `z.never()`
+      // reports. A `refine`-based spelling would report `custom` and was
+      // rejected for exactly that reason (objectui#6105).
+      expect(issue!.code, key).toBe('invalid_type');
+      expect(issue!.path, key).toEqual([key]);
+
+      // The message is the migration note, not zod's generic string.
+      expect(issue!.message, key).not.toContain('Invalid input: expected never, received ');
+      expect(issue!.message, key).toContain('RETIRED (objectui#5905)');
+      expect(issue!.message, key).toContain(`\`ComponentInput.${key}\``);
+      expect(issue!.message, key).toContain('`description`');
+
+      // ONE string, BOTH channels — the invariant `retirementTombstone()`
+      // exists to make unbreakable. Asserted derived (nothing hand-copied to
+      // rot), which is why the literal anchors above sit beside it: two empty
+      // strings are also equal.
+      expect(issue!.message, key).toBe(describeOf(ComponentInputSchema, key));
+    });
+  }
+
+  it('`placeholder` answers with the full string, including the `BaseSchema` disambiguation', () => {
+    // One member pinned as a LITERAL so the derived assertions above cannot all
+    // drift together. `BaseSchema.placeholder` is a different, live key — an
+    // author who trips this one must not read it as that one being retired.
+    const result = ComponentInputSchema.safeParse({ ...LIVE_INPUT, placeholder: 'Type here…' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'RETIRED (objectui#5905) — `ComponentInput.placeholder` was never read, and never published: '
+        + 'the manifest serializer forwards `name`/`type`/`required`/`enum`/`binding`/`description` and '
+        + 'this is not one of them, so an authored value was silently dropped. Delete the key; put the '
+        + 'hint in `description`, which IS published. `BaseSchema.placeholder`, the node-level prop, is '
+        + 'a DIFFERENT key and is unaffected.',
+      );
+    }
+  });
+});
+
+/* ── the contrast a deletion would have produced ─────────────────────────── */
+
+describe('a tombstone is not a deletion — the contrast, measured in one run', () => {
+  it('an UNDECLARED key is silently stripped, which is what deleting these four would have bought', () => {
+    const result = ComponentInputSchema.safeParse({ ...LIVE_INPUT, notAKeyAtAll: 'anything' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).not.toHaveProperty('notAKeyAtAll');
+  });
+
+  it('the four stay in the mirror\'s shape — a tombstone is DECLARED, just unwritable', () => {
+    for (const key of Object.keys(RETIRED)) {
+      expect(shapeOf(ComponentInputSchema)).toHaveProperty(key);
+      expect(describeOf(ComponentInputSchema, key)).toContain('RETIRED (objectui#5905)');
+    }
+  });
+});

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -544,28 +544,86 @@ export interface ComponentInput {
 
   /**
    * Specific input type (e.g., 'email', 'password' for string)
+   *
+   * ⚠️ NOT retired alongside the four tombstones below (objectui#5905), and the
+   * difference is measured rather than stylistic. `plugin-markdown`'s
+   * registration AUTHORS this key — `inputs: [{ name: 'content', …, inputType:
+   * 'textarea' }]` in `packages/plugin-markdown/src/index.tsx`, pinned by that
+   * package's own test — while the manifest serializer still drops it. That is
+   * declared-and-DROPPED, a different defect from the declared-and-unread four
+   * below: retiring it would convert one registration's silent no-op into a
+   * build failure without first deciding what that registration should say
+   * instead (delete the line, or teach the publication path to carry it). The
+   * fork is recorded on objectui#5905 for a ruling; until then this stays a
+   * live, writable key that nothing publishes.
    */
   inputType?: string;
 
   /**
-   * Minimum value (for number/date)
+   * ADR-0049 RETIREMENT TOMBSTONES — `min` / `max` / `step` / `placeholder`
+   * (objectui#5905).
+   *
+   * `?: never` is this package's tombstone convention (see `crud.ts` `confirm`
+   * and {@link StaticTableColumn} in `data-display.ts`): the key stays
+   * DECLARED and becomes UNWRITABLE, so authoring one is a `tsc` error here and
+   * a named parse refusal in the Zod twin (`zod/base.zod.ts`
+   * `ComponentInputSchema`, via `retirementTombstone()`). Deleting the members
+   * outright would have been the quiet option — an undeclared key is silently
+   * stripped by the non-strict mirror, which trades one silent no-op for
+   * another.
+   *
+   * What was measured (objectui#5905, re-measured on the merge-base of the
+   * retiring PR): no consumer reads any of the four, and the manifest
+   * serializer (`packages/sdui-parser/src/index.ts`) forwards exactly six keys
+   * per input — `name`, `type`, `required`, `enum`, `binding`, `description` —
+   * so a value authored here could not reach the published
+   * `sdui.manifest.json` even in principle. A structural census over every
+   * `inputs:` array in the repository found ZERO authoring sites for the four
+   * (the same pass counted 926 `name`, 926 `type` and 161 `description` sites,
+   * so the instrument was not blind). Authorship from OUTSIDE the repository is
+   * not measurable from here — the limit objectui#5674 recorded for
+   * `PluginComponentInput` — and converting such a write from a silent drop
+   * into a NAMED REFUSAL is exactly what these tombstones buy.
+   *
+   * ⚠️ Why a future reader must NOT read this as "these keys were a mistake":
+   * the neighbouring `type` field carries a maintainer ruling of 2026-08-17
+   * (quoted in full above) recording that giving `ComponentInput` real
+   * constraint slots was **DEFERRED, NOT REJECTED** — two sources of truth,
+   * free to drift, was the stated cost. `min` / `max` / `step` read exactly
+   * like the slots that ruling declined to add. What is retired is this inert
+   * spelling of them, not the idea; the ruling's own reopen condition (a
+   * measured case of an author shipping a spec-rejected value objectui's
+   * silence let through) is still the route back.
+   *
+   * RETIRED (objectui#5905, ADR-0049) — never read, and never published: the
+   * manifest serializer forwards six keys and this is not one of them. Spell
+   * the numeric domain out in `description`, which IS published.
+   * @deprecated Not part of `ComponentInput`'s contract — the value was inert.
    */
-  min?: number;
-
+  min?: never;
   /**
-   * Maximum value (for number/date)
+   * RETIRED (objectui#5905, ADR-0049) — never read, and never published: the
+   * manifest serializer forwards six keys and this is not one of them. Spell
+   * the numeric domain out in `description`, which IS published.
+   * @deprecated Not part of `ComponentInput`'s contract — the value was inert.
    */
-  max?: number;
-
+  max?: never;
   /**
-   * Step value (for number)
+   * RETIRED (objectui#5905, ADR-0049) — never read, and never published: the
+   * manifest serializer forwards six keys and this is not one of them. Spell
+   * the numeric domain out in `description`, which IS published.
+   * @deprecated Not part of `ComponentInput`'s contract — the value was inert.
    */
-  step?: number;
-
+  step?: never;
   /**
-   * Placeholder text
+   * RETIRED (objectui#5905, ADR-0049) — never read, and never published: the
+   * manifest serializer forwards six keys and this is not one of them. Put the
+   * hint in `description`, which IS published. `BaseSchema.placeholder` — the
+   * node-level prop a renderer does read — is a DIFFERENT key and is
+   * unaffected.
+   * @deprecated Not part of `ComponentInput`'s contract — the value was inert.
    */
-  placeholder?: string;
+  placeholder?: never;
 }
 
 /**

--- a/packages/types/src/widget.ts
+++ b/packages/types/src/widget.ts
@@ -219,6 +219,16 @@ export interface WidgetSourceRegistry {
  *    these. Copying them here would mirror surface that nothing reads on the
  *    face it already lives on.
  *
+ *    ⚠️ FOUR of those five are now ADR-0049 RETIREMENT TOMBSTONES on
+ *    `ComponentInput` (`min` / `max` / `step` / `placeholder` — `?: never` plus
+ *    a named Zod refusal, objectui#5905), so what this clause records is no
+ *    longer "five keys this face declines to copy" but ONE live key
+ *    (`inputType`) plus four unwritable ones. Copying any of them here is now
+ *    doubly wrong: the four are REFUSED on the face they already live on, and
+ *    `inputType` is the open fork objectui#5905 reported — `plugin-markdown`
+ *    authors it and the serializer still drops it, which is a ruling to make,
+ *    not a surface to mirror.
+ *
  * Pin: `__tests__/widget-input-control-vocabulary.test.ts`.
  */
 export interface WidgetInput {

--- a/packages/types/src/zod/base.zod.ts
+++ b/packages/types/src/zod/base.zod.ts
@@ -18,6 +18,7 @@
 
 import { z } from 'zod';
 import { I18nLabelSchema } from '@objectstack/spec/ui';
+import { retirementTombstone } from './tombstone.zod.js';
 
 /**
  * A KEYED i18n label — the runtime mirror of `KeyedI18nLabel` in `../base.ts`.
@@ -299,11 +300,55 @@ export const ComponentInputSchema = z.object({
   ]).optional().describe('Enum options'),
   description: z.string().optional().describe('Help text'),
   advanced: z.boolean().optional().describe('Advanced option flag'),
+  /**
+   * ⚠️ NOT retired with the four tombstones below (objectui#5905):
+   * `plugin-markdown`'s registration authors it, so it is declared-and-DROPPED
+   * rather than declared-and-unread. See `ComponentInput.inputType` in
+   * `../base.ts` for the fork and what a ruling on it has to decide.
+   */
   inputType: z.string().optional().describe('Specific input type'),
-  min: z.number().optional().describe('Minimum value'),
-  max: z.number().optional().describe('Maximum value'),
-  step: z.number().optional().describe('Step value'),
-  placeholder: z.string().optional().describe('Placeholder text'),
+  /**
+   * ADR-0049 RETIREMENT TOMBSTONES (objectui#5905) — `min` / `max` / `step` /
+   * `placeholder`, the four `ComponentInput` keys measured with no reader on
+   * either the consumption or the publication path.
+   *
+   * `retirementTombstone()` (`./tombstone.zod.ts`) writes each guidance string
+   * ONCE into both author-facing channels — the parse-time issue message and
+   * `.describe()`, which feeds generated JSON-Schema and docs — so the two
+   * cannot drift. Without a tombstone the non-strict mirror would SILENTLY
+   * STRIP an authored value, trading one silent no-op for another; with it, a
+   * write from outside this repository (the half objectui#5905 could not
+   * measure) arrives as a NAMED REFUSAL carrying its own remedy.
+   *
+   * The accept set is the point, not a side effect: issue `code` stays
+   * `invalid_type` and the issue `path` names the key. A `refine`-based
+   * spelling would report `custom` and was rejected for exactly that reason
+   * (objectui#6105).
+   */
+  min: retirementTombstone(
+    'RETIRED (objectui#5905) — `ComponentInput.min` was never read, and never published: the manifest '
+    + 'serializer forwards `name`/`type`/`required`/`enum`/`binding`/`description` and this is not one of them, '
+    + 'so an authored value was silently dropped. Delete the key; spell the numeric domain out in `description`, '
+    + 'which IS published.',
+  ),
+  max: retirementTombstone(
+    'RETIRED (objectui#5905) — `ComponentInput.max` was never read, and never published: the manifest '
+    + 'serializer forwards `name`/`type`/`required`/`enum`/`binding`/`description` and this is not one of them, '
+    + 'so an authored value was silently dropped. Delete the key; spell the numeric domain out in `description`, '
+    + 'which IS published.',
+  ),
+  step: retirementTombstone(
+    'RETIRED (objectui#5905) — `ComponentInput.step` was never read, and never published: the manifest '
+    + 'serializer forwards `name`/`type`/`required`/`enum`/`binding`/`description` and this is not one of them, '
+    + 'so an authored value was silently dropped. Delete the key; spell the numeric domain out in `description`, '
+    + 'which IS published.',
+  ),
+  placeholder: retirementTombstone(
+    'RETIRED (objectui#5905) — `ComponentInput.placeholder` was never read, and never published: the manifest '
+    + 'serializer forwards `name`/`type`/`required`/`enum`/`binding`/`description` and this is not one of them, '
+    + 'so an authored value was silently dropped. Delete the key; put the hint in `description`, which IS '
+    + 'published. `BaseSchema.placeholder`, the node-level prop, is a DIFFERENT key and is unaffected.',
+  ),
 });
 
 /**


### PR DESCRIPTION
Refs #5905. ⚠️ **`Refs`, not a closing keyword — the card asked for FIVE keys and this
retires FOUR.** The fifth, `inputType`, hit the fork condition triage set, and the card
stays open on that fork.

`needs:contract-review` tier: this changes members on a **published** type
(`@object-ui/types` → `ComponentInput`). ⛔ Draft on purpose — not ready, not enqueued, no
auto-merge.

Session: https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB

---

## 1. The fork, first — it is the point of the card, not a footnote

Triage: *"If any registration in the repo AUTHORS one of the five (declared-and-dropped is
a different defect), stop and report the fork with the site list."*

**One site authors one of the five.** The site list is one line long:

| key | site | what it writes |
|---|---|---|
| `inputType` | `packages/plugin-markdown/src/index.tsx:60` | `inputs: [{ name: 'content', type: 'string', label: 'Markdown Content', required: true, inputType: 'textarea' }]` |

It is a real `ComponentInput`: `ComponentRegistry.register(type, component, meta)` takes
`meta` as `ComponentMeta` (`packages/core/src/registry/Registry.ts:352`), whose `inputs` is
`ComponentInput[]`. It is also **pinned** — `packages/plugin-markdown/src/index.test.ts:51`
asserts `expect(contentInput?.inputType).toBe('textarea')`.

So `inputType` is **declared-and-DROPPED**, not declared-and-unread: something writes it,
and the serializer discards it. That is a different defect and a different remedy, and
retiring it here would turn one registration's silent no-op into a build failure without
anyone deciding what that registration should say instead. **`inputType` is left live and
writable**, with the fork recorded in its doc block, in the Zod mirror, and in the pin
test — so closing it later is a deliberate edit, not a drive-by.

The other four — `min`, `max`, `step`, `placeholder` — have **zero** authoring sites, and
are retired here.

## 2. What was measured, with its instrument and its bound

**Pathspec bound: every tracked file at the merge-base `b03ba3ad5` — 5,869 files, all
top-level directories, `packages/` and `apps/` and `examples/` and `e2e/` and `content/`
and `skills/` and `scripts/` included.** Not a package subset.

**Instrument (structural, not a bare grep):** bracket-match every `inputs:` array in every
tracked `.ts/.tsx/.js/.jsx/.mjs/.cjs/.json/.md/.mdx` file, then collect the top-level keys
of the object literals inside — i.e. the `ComponentInput`'s own keys. **219 regions**
scanned.

**The zero comes with a HOT CONTROL, from the same pass over the same regions** (not
merely repo-wide):

| retired candidate | sites | | control: a key the serializer DOES forward | sites |
|---|---|---|---|---|
| `inputType` | **1** | | `name` | 926 |
| `min` | **0** | | `type` | 926 |
| `max` | **0** | | `description` | 161 |
| `step` | **0** | | `enum` | 114 |
| `placeholder` | **0** | | `required` | 87 |

The instrument was demonstrably not blind: it found the one `inputType` site *and* four
digits of control hits in the same regions.

**Blind spot found and closed by hand.** The `inputs:` scan cannot see a `ComponentInput[]`
built as a named constant. All four such constants were read individually — the same
retired-five / forwarded-six pass inside each — and all four are clean:
`PAGE_CONTAINER_INPUTS` (`packages/components/src/renderers/layout/containers.tsx:85`),
`CHATTER_INPUTS` (`packages/plugin-detail/src/index.tsx:643`), `GRID_QUERY_INPUTS`
(`packages/plugin-grid/src/index.tsx:215`) and `ELEMENT_DATA_SOURCE_INPUT`
(`packages/core/src/data-scope/element-data-source.ts:327`).

**`placeholder` false positives, rejected BY HAND — and that rejection is a finding about
the instrument, not noise.** A plain `placeholder:` grep over the same file set returns 26
hits and **none** of them is a `ComponentInput` key:

- `packages/vscode-extension/src/providers/PreviewProvider.ts:180,193` — writes
  `input.placeholder` / `textarea.placeholder` on a **DOM element**, from
  `BaseSchema.placeholder`. Different type on both ends.
- `packages/app-shell/src/views/metadata-admin/previews/block-config.ts` — an **inspector
  field spec whose own key is named `placeholder`** (a `PlaceholderSpec`). Different type.
- Eight renderer registrations (`combobox`, `command`, `date-picker`, `select`, `textarea`,
  and three in `plugin-chatbot`) write `placeholder` in **`defaultProps`**, the element's
  own prop — while their `inputs:` array carries `{ name: 'placeholder', … }`, i.e.
  `placeholder` as the **value of `name`**, never as a `ComponentInput` key.
- `plugin-designer` / `ObjectManager` / `plugin-view` / `form.tsx` hits are **form field**
  descriptors (`type: 'text'`, `type: 'input'` — neither is a `ComponentInputControlType`).

**The publication path, re-read on the merge-base rather than trusted from the card.**
`packages/sdui-parser/src/index.ts:153-160` forwards exactly six keys per input:

```ts
inputs: (c.inputs ?? []).map((i) => ({
  name: i.name,
  type: canonicalizeInputType(i.type),
  required: i.required,
  enum: i.enum,
  binding: i.binding,
  description: i.description,
})),
```

None of the five is in it, so a value authored here could not reach the published
`sdui.manifest.json` even in principle.

**Reads: none.** A member-access census across the 71 files that consume `.inputs` returns
nothing for `min` / `max` / `step` / `placeholder` on a `ComponentInput` value (the hits are
i18n key strings, `sim.step()`, and `element:text_input.placeholder`, which is a different
surface). Same pass, same file set, control: `.name` 188, `.type` 302, `.description` 68,
`.enum` 28, `.required` 23.

## 3. ⚠️ The half that is NOT measurable from here — stated, not papered over

The in-repo zero is **all** that was measured. **Whether anything OUTSIDE this repository
writes these keys is out of reach from here** — the same limit objectui#5674 recorded for
`PluginComponentInput`, and the card names it explicitly as the thing that decides between
"remove" and "leave as published surface". Nothing in this PR establishes that no external
author writes them, and no sentence here should be read as claiming it.

That unmeasurable half is exactly **why this is a tombstone and not a deletion**:
`ComponentInputSchema` is a non-strict `z.object`, so a deleted key would be **silently
stripped** — one silent no-op traded for another. The tombstone converts an out-of-repo
write from a silent drop into a **NAMED REFUSAL** that carries its own remedy.

## 4. ⚠️ This is NOT a verdict that constraint slots were a mistake

The neighbouring `type` field carries a **maintainer ruling of 2026-08-17**, quoted in
`base.ts`:

> **Ruled (maintainer, 2026-08-17): the coarse arm plus `description` IS the publication
> face's expression ceiling today, and SPEC IS THE SOLE JUDGE OF VALUES.**
>
> Two directions were **deferred**, not rejected on merit: giving `ComponentInput` real
> constraint slots (two sources of truth, free to drift), and binding `checkType` to spec's
> Zod member when a `ComponentPropsMap` entry exists (one truth, but couples `sdui-parser`
> to spec). The ruling names the reopen condition: **a measured case of an author — human
> or agent — shipping a spec-rejected value that objectui's silence let through.**

`min` / `max` / `step` read **exactly like the slots that ruling declined to add**. What is
retired here is this inert spelling of them, not the idea — a future reader must not read
this PR as "these keys were a mistake". The ruling's own reopen condition still stands, and
the reopen route is a designed one, not a revert of this change.

## 5. What changed

- `packages/types/src/base.ts` — `min` / `max` / `step` / `placeholder` become
  `?: never` tombstones (this package's convention: `crud.ts` `confirm`,
  `StaticTableColumn`), each with its own guidance and `@deprecated`. `inputType` keeps its
  type and gains the fork note.
- `packages/types/src/zod/base.zod.ts` — the same four become
  **`retirementTombstone(guidance)`** from `zod/tombstone.zod.ts`.
  ⚠️ **The merged helper, NOT the older hand-written `z.never().optional().describe(...)`
  spelling** the retirement playbook and the #5942 precedent would have produced: both
  predate PR #6930 (card #6105). The helper carries the guidance string **once** into both
  channels — `z.never({ error })` for the runtime message and `.describe()` for
  JSON-Schema/docs — so they cannot drift. `.describe()` survives, and the `refine` route
  (which reports issue code `custom` instead of `invalid_type`) is not used.
- `packages/types/src/__tests__/component-input-retired-constraint-keys.test.ts` — new pin.
- `packages/types/src/widget.ts` — `WidgetInput`'s divergence block enumerated "five keys
  `ComponentInput` carries that this face does not". Four of them are now unwritable, so
  the block now says one live key plus four tombstones. Same declaration family, same
  package, same gate; its existing pin
  (`widget-input-control-vocabulary.test.ts`, which requires the block to name each of the
  five) still passes.
- `.changeset/5905-componentinput-retire-constraint-keys.md` — `minor`, states the removal
  in words with a FROM → TO line per key.

Considered and deliberately **not** touched: `packages/core/src/registry/Registry.ts`'s
doc block, which describes the same four keys **in the past tense as objectui#4972's
history** ("were missing from the copy every registration actually imports"). It stays true
as history, and editing it would pull a second package into this changeset.

Docs and skills need no edit: no `content/docs` page and no published skills file teaches
these four on `ComponentInput` — the skill's own `ComponentInput` type block
(`skills/objectui/guides/plugin-development.md:87`) already lists eight keys and none of the
five. **This diff does not touch the published skills directory at all.**

## 6. ⚠️ The emitted `.d.ts`, measured on BOTH sides — what the contract reviewer needs

Built with `pnpm --filter @object-ui/types build` on each side, then diffed.

**`packages/types/dist/base.d.ts` — `interface ComponentInput`** (comments stripped):

```diff
     description?: string;
     advanced?: boolean;
     inputType?: string;
-    min?: number;
-    max?: number;
-    step?: number;
-    placeholder?: string;
+    min?: never;
+    max?: never;
+    step?: never;
+    placeholder?: never;
 }
```

**Exact statement of what disappears:** *no member is removed from the emitted `.d.ts`.*
The four members stay **declared** and their **types** change from `number` / `number` /
`number` / `string` to `never`. That is the tombstone contract: the key stays visible so an
author who writes it meets a message, and unwritable so writing it fails. Member count is
13 before and 13 after.

**`packages/types/dist/zod/base.zod.d.ts` — the same four, before → after.**
⚠️ The angle-bracket generic spelling is written out **in words** below on purpose: this
body's sanitizer eats tag-shaped fragments, and on the first publish it ate exactly this
table — both columns came back reading `z.ZodOptional` and the diff was therefore
meaningless. Read "OPT of X" as `z.ZodOptional` parameterised by `X`.

| member | BEFORE | AFTER |
|---|---|---|
| `min` | OPT of `z.ZodNumber` | OPT of `z.ZodNever` |
| `max` | OPT of `z.ZodNumber` | OPT of `z.ZodNever` |
| `step` | OPT of `z.ZodNumber` | OPT of `z.ZodNever` |
| `placeholder` | OPT of `z.ZodString` | OPT of `z.ZodNever` |

That shape is inlined **three times** in that one file — `ComponentInputSchema`,
`ComponentMetaSchema` and `ComponentConfigSchema` all carry it.

**Which published subpaths carry the change** (from `package.json` `exports`):

| subpath | file | how it carries it |
|---|---|---|
| `@object-ui/types/base` | `dist/base.d.ts` | the declaration itself |
| `@object-ui/types` | `dist/index.d.ts` | re-exports the type by name (`ComponentInput`) |
| `@object-ui/types` | `dist/index.d.ts` | re-exports it again as the deprecated alias `PluginComponentInput` (via `dist/plugin-scope.d.ts`) |
| `@object-ui/types/zod` | `dist/zod/index.zod.d.ts` → `dist/zod/base.zod.d.ts` | `ComponentInputSchema`, `ComponentMetaSchema`, `ComponentConfigSchema` |

`dist/widget.d.ts` mentions `ComponentInput` only in prose and imports
`ComponentInputControlType`; `WidgetInput`'s own eight-key shape is unchanged.

## 7. The refusal is real — before/after `safeParse`, with a control both runs

Same probe, same document shape, run against the mirror before and after the change.
Control document: `{ name: 'content', type: 'string', label: …, required: true }`.

| key written | BEFORE | AFTER |
|---|---|---|
| `min: 0` | `success=true`, value KEPT | `success=false`, path `["min"]`, code `invalid_type` |
| `max: 100` | `success=true`, value KEPT | `success=false`, path `["max"]`, code `invalid_type` |
| `step: 1` | `success=true`, value KEPT | `success=false`, path `["step"]`, code `invalid_type` |
| `placeholder: 'Type here…'` | `success=true`, value KEPT | `success=false`, path `["placeholder"]`, code `invalid_type` |
| `inputType: 'textarea'` (the fork) | `success=true`, value KEPT | `success=true`, value KEPT — unchanged on purpose |
| CONTROL `description: 'Help text'` | `success=true` | `success=true` |
| CONTROL bare document | `success=true` | `success=true` |

`message` per key, AFTER (this is the `.describe()` text too — one string, both channels):

> RETIRED (objectui#5905) — `ComponentInput.min` was never read, and never published: the
> manifest serializer forwards `name`/`type`/`required`/`enum`/`binding`/`description` and
> this is not one of them, so an authored value was silently dropped. Delete the key; spell
> the numeric domain out in `description`, which IS published.

`max` and `step` are the same sentence with their own key. `placeholder`'s ends instead
with: *"Delete the key; put the hint in `description`, which IS published.
`BaseSchema.placeholder`, the node-level prop, is a DIFFERENT key and is unaffected."* —
because `BaseSchema.placeholder` (`zod/base.zod.ts:105`) is a live key an author must not
think was retired.

The refusal is a **narrowing that speaks**, not a silent narrowing: the pin test also
measures the contrast in the same run — a genuinely **undeclared** key
(`notAKeyAtAll: 'anything'`) still parses `success=true` and is silently stripped, which is
precisely what deleting these four members would have bought.

## 8. Ablation — direction predicted in writing BEFORE the run

**Predicted, before running:** replace `min: retirementTombstone(…)` with its exact
pre-change spelling `min: z.number().optional().describe('Minimum value')` — mutating the
**fact**, never an assertion — and the pin file goes **RED and NARROWLY**: exactly two
assertions, "refuses `min` …" (`expected true to be false`) and "the four stay in the
mirror's shape …" (describe reverts to `'Minimum value'`), with `max` / `step` /
`placeholder`, the live-input control, the `inputType` fork pin and the strip contrast all
staying GREEN.

**Rebuild question, answered rather than assumed:** no build is needed for this leg, and
the reason is the **resolution path**, not the suite's name — the pin test imports
`../zod/base.zod`, a **relative source specifier** (asserted mechanically in the script), so
vitest loads the mutated `src` directly and a stale `dist` cannot hide the mutation.

**Observed — matches the prediction:**

```
 × refuses `min`, names it in the path, and answers with its own guidance
 × the four stay in the mirror's shape — a tombstone is DECLARED, just unwritable
AssertionError: min: expected true to be false // Object.is equality
AssertionError: expected 'Minimum value' to contain 'RETIRED (objectui#5905)'
 Test Files  1 failed (1)
      Tests  2 failed | 9 passed (11)
```

(The one place the prediction was off: it said "2 failed | 8 passed" — the file has 11
tests, not 10, so 9 passed. The failure count and both named assertions matched exactly.)

**Mutation proven on disk** — anchored counts in both directions plus hashes, never an
editor's exit code: removed text `min: retirementTombstone(` count **0**, injected text
count **1**, remaining tombstone calls **4** (1 import + 3 keys), `git hash-object`
`c82523ed…` → `622c6d39…`.

**Restore proven BOTH ways**, under `trap … EXIT INT TERM`, absolute paths from
`git rev-parse --show-toplevel`, with `git checkout HEAD -- ABSOLUTE_PATH` (never the bare
form, which reads from the index): `git diff HEAD` empty **and** each file's
`git hash-object` equal to its `HEAD` blob, for all four touched paths. Then a
**post-restore control**: the same file green again, `Tests 11 passed (11)`.

## 9. Gates — exit codes captured before any pipe, on the final commit

Union re-run at `33846a77d`, worktree clean, after the last commit:

| gate | verdict line | exit |
|---|---|---|
| `pnpm --filter @object-ui/types build` | `tsc` | `BUILD_EXIT=0` |
| `pnpm --filter @object-ui/types type-check` (hyphenated) | `tsc --noEmit` then `tsc -p tsconfig.examples.json` then `tsc -p tsconfig.test.json` | `TYPECHECK_EXIT=0` |
| `pnpm exec vitest run packages/types/` (root form) | `Test Files 76 passed (76)` · `Tests 872 passed (872)` | `0` |
| `pnpm exec vitest run packages/core/src/registry/` | `Test Files 7 passed (7)` · `Tests 111 passed (111)` | `0` |
| `pnpm exec vitest run packages/sdui-parser/` | `Test Files 11 passed (11)` · `Tests 147 passed (147)` | `0` |
| `pnpm exec eslint .` (plain form, no `--no-inline-config`) | `✖ 11516 problems (0 errors, 11516 warnings)` | `ESLINT_EXIT=0` |
| `node scripts/check-changeset-presence.mjs` | `✅ 4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` | `0` |
| `zod-mirror-parity` | `Test Files 1 passed (1)` · `Tests 5 passed (5)` | `0` |

**vitest file/test counts, before → after** (the wrong-cwd false green this repo has been
bitten by would report `apps/console`'s 22 files instead):

| | Test Files | Tests |
|---|---|---|
| BEFORE (merge-base state of `packages/types`) | 75 | 861 |
| AFTER | **76** | **872** |
| delta | +1 | +11 |

Sanity-checked against the target's own count: `git ls-files 'packages/types/**'` matching
`*.test.ts(x)` is **76** — equal to what vitest reported — and **75** at `b03ba3ad5`. The
+1 file / +11 tests are exactly the new pin file.

`zod-mirror-parity` deserves its own note since this removes declarations it pairs: it
compares the mirror's `.shape` against the declaration over the INTERSECTION of the mirror's
keys and the declaration's, so the four **stay in the mirror** and **leave the declaration's
writable set** without entering any ledger. `base.zod.ts#ComponentInputSchema` has no
`KnownDrift` and no `UnmirroredDeclared` entry before or after — same precedent as
`DashboardComponentSchema.aria` (objectui#5855).

eslint reports **0 errors**; the 11,516 warnings are the repo's pre-existing
`no-explicit-any` population. The four files this PR touches contribute **zero new
findings** (the `base.ts` / `base.zod.ts` warnings are on untouched lines).

## 10. What is NOT claimed

- Not claimed: that nothing outside this repository writes these keys. Not measurable here.
- Not claimed: that `inputType` should stay. It needs a ruling; this PR does not make it.
- Not claimed: that constraint slots on `ComponentInput` are wrong. See §4.
- Not run locally: the full repo test farm and the rest of the `check:*` set — CI owns
  those and runs them exactly once on this branch.