### PR TITLE
feat(types): narrow DetailViewSection.headerColor to the ruled six-token enum

### DIFF
--- a/.changeset/6594-headercolor-mirror-enum.md
+++ b/.changeset/6594-headercolor-mirror-enum.md
@@ -1,0 +1,61 @@
+---
+'@object-ui/types': minor
+---
+
+`DetailViewSection.headerColor` is now the closed six-token vocabulary on both halves of
+the contract — the TypeScript declaration and the `@object-ui/types/zod` mirror — instead of
+`string` / `z.string()` (objectui#6594, maintainer ruling A of 2026-08-26 recorded at
+objectstack#12126). The six are `muted`, `muted/50`, `accent`, `primary/10`, `secondary/10`
+and `destructive/10`: exactly what `@object-ui/plugin-detail`'s `HEADER_COLOR_CLASSES`
+resolves (objectui#6178) and exactly what `@objectstack/spec` declares on its strict
+`record:details` section schema (objectstack PR #12616).
+
+## ⚠️ Accept-set narrowing — these spellings stop validating
+
+`DetailViewSectionSchema.headerColor` was `z.string().optional()`, so **any string parsed
+green** while the renderer contributed no class for most of them. It is now
+`z.enum([...]).optional()`: a value outside the six is refused at parse time with
+`headerColor` named in the error path, and is a `tsc` error at every authoring site typed
+against `DetailViewSection`.
+
+**Authored metadata in this repo needs no migration.** Measured before tightening, across
+the whole tracked tree: `headerColor` occurs in **ten files, none of them authored
+metadata** — the renderer and its tests, the two declaration files changed here, and two
+markdown notes. `examples/`, `content/`, `apps/`, `e2e/` and `docs/` contain **zero**
+occurrences (positive control: `sections` and `detail-view` both hit in those directories,
+so the census reached them). Nothing in the repo authors a value outside the six.
+
+## The renderer's `bg-*` pass-through is deliberately NOT declared
+
+`headerColorClass` also hands a value that is already a complete `bg-*` class through
+untouched. Ruling A rejected declaring that (option B, "the capability illusion"): whether
+such a class renders depends on the host app's Tailwind build, so declaring it would promise
+a capability the contract cannot keep. It stays a renderer affordance — still supported by
+the renderer, never invited by the contract. The three renderer tests that exercise
+off-contract values (`bg-accent`, `not-a-token`, `constructor`) now route them through a
+documented `offContract()` seam in `DetailSection.headerColor.test.tsx`, which is the visible
+consequence of the narrowing rather than a workaround for it: metadata still arrives as JSON
+over the wire, where no compiler was involved, so the renderer must keep behaving sanely.
+
+## The three ends cannot drift
+
+`packages/plugin-detail/src/__tests__/headerColor.contractPin-6594.test.ts` pins the resolver,
+the TypeScript declaration and the zod mirror against the ruled vocabulary — the resolver's
+key set one-to-one at runtime, the declaration by invariant type equality, the mirror by
+reading its own enum options. It fails in **both** directions: a seventh token on any one end,
+or one of the six dropped from any one end, turns it red, and the comparator itself is pinned
+against synthetic inputs so the guard has been shown to fail rather than only to pass.
+
+## Shape, and where it departs from the nearest precedent
+
+The nearest precedent is objectui#5853 (`.changeset/5853-tablecolumn-type-canonical-union.md`),
+which narrowed `TableColumn.type` on the same three-ends pattern and **exported** a
+`TABLE_COLUMN_TYPES` tuple for the zod mirror to build its enum from. That shape is not
+available here and the difference is structural, not a preference: `packages/types/src/views.ts`
+is a **type-only** module, so a tuple there would add a runtime export to the package barrel
+(a value export cannot ride the barrel's `export type` block) and a runtime import edge from
+the zod entry into `views.js`. #5853 had a second reason to export — producers needed its
+`normalizeTableColumnType()` at their emit seam — and `headerColor` has no producer that needs
+a runtime value. The literals are therefore written on each half and the anti-drift guarantee
+is carried by the pin above, which also covers the third end a shared tuple could not reach:
+the renderer, in a package `@object-ui/types` must not depend on.

--- a/packages/plugin-detail/src/__tests__/DetailSection.headerColor.test.tsx
+++ b/packages/plugin-detail/src/__tests__/DetailSection.headerColor.test.tsx
@@ -32,6 +32,28 @@ const baseSection = (extra: Partial<DetailViewSection>): DetailViewSection =>
   ({ title: TITLE, fields: [{ name: 'amount', label: 'Amount' }], ...extra }) as DetailViewSection;
 
 /**
+ * A `headerColor` value the CONTRACT does not declare, handed to the renderer
+ * anyway.
+ *
+ * ⚠️ The cast is the POINT of the three tests that use it, not a workaround for
+ * them. objectui#6594 narrowed `DetailViewSection.headerColor` to the six ruled
+ * tokens, so an off-vocabulary value is a compile error at every authoring site
+ * — which is the guarantee that card bought, and `headerColor.contractPin-6594
+ * .test.ts` is where it is pinned. The renderer still has to behave sanely when
+ * one reaches it anyway, because metadata arrives as JSON over the wire where
+ * no compiler was ever involved, and because the pass-through for a value that
+ * is already a complete `bg-*` class is a deliberate UNDECLARED affordance
+ * (objectstack#12126 ruling A rejected declaring it: whether the class renders
+ * depends on the host app's Tailwind build, so declaring it would promise a
+ * capability the contract cannot keep).
+ *
+ * ⛔ Do not widen the declaration to make these three compile without the cast.
+ * That deletes the distinction the ruling drew.
+ */
+const offContract = (value: string): DetailViewSection['headerColor'] =>
+  value as DetailViewSection['headerColor'];
+
+/**
  * The header element, located by the two padding classes `DetailSection`
  * passes to `CardHeader` on both render branches. `getBy`-style: it throws
  * when the header did not render at all, so a negative assertion below cannot
@@ -84,7 +106,7 @@ describe('DetailSection headerColor -> a class the stylesheet can carry (objectu
     it('a value that is already a `bg-*` class passes through, not doubled', () => {
       const { container } = render(
         <DetailSection
-          section={baseSection({ ...extra, headerColor: 'bg-accent' })}
+          section={baseSection({ ...extra, headerColor: offContract('bg-accent') })}
           data={{ amount: 1 }}
         />,
       );
@@ -97,7 +119,7 @@ describe('DetailSection headerColor -> a class the stylesheet can carry (objectu
     it('an unmapped value contributes no class at all — never a fabricated one', () => {
       const { container, getByText } = render(
         <DetailSection
-          section={baseSection({ ...extra, headerColor: 'not-a-token' })}
+          section={baseSection({ ...extra, headerColor: offContract('not-a-token') })}
           data={{ amount: 1 }}
         />,
       );
@@ -114,7 +136,7 @@ describe('DetailSection headerColor -> a class the stylesheet can carry (objectu
     it('an inherited Object.prototype key is not a vocabulary entry', () => {
       const { container } = render(
         <DetailSection
-          section={baseSection({ ...extra, headerColor: 'constructor' })}
+          section={baseSection({ ...extra, headerColor: offContract('constructor') })}
           data={{ amount: 1 }}
         />,
       );

--- a/packages/plugin-detail/src/__tests__/headerColor.contractPin-6594.test.ts
+++ b/packages/plugin-detail/src/__tests__/headerColor.contractPin-6594.test.ts
@@ -1,0 +1,254 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `headerColor` has ONE vocabulary across the three ends that declare it
+ * (objectui#6594, maintainer ruling A of 2026-08-26 recorded at
+ * objectstack#12126).
+ *
+ * ## The ends, and why a pin rather than a shared constant
+ *
+ *   1. `@object-ui/plugin-detail`'s `HEADER_COLOR_CLASSES` — the RESOLVER. It
+ *      decides which class reaches the DOM (objectui#6178).
+ *   2. `@object-ui/types`' `DetailViewSection.headerColor` — the TypeScript
+ *      declaration an author writes against.
+ *   3. `@object-ui/types/zod`'s `DetailViewSectionSchema.headerColor` — the
+ *      published validator that judges authored metadata at parse time.
+ *
+ * The three cannot share one constant. `@object-ui/types` is the protocol layer
+ * and carries no dependency on any renderer (AGENTS.md §3: "Zero deps"), so the
+ * arrow can only run plugin-detail -> types, never back; and `../views.ts` is a
+ * TYPE-ONLY module, so a tuple lifted into it to feed both halves of the mirror
+ * would add a runtime export to the package barrel and a runtime import edge
+ * from the zod entry into `views.js`. This file buys the same "cannot drift"
+ * property from the direction that is legal: this package already devDepends on
+ * `@object-ui/types`, so it can see all three ends at once.
+ *
+ * ## The oracle is the ruling, not today's tree
+ *
+ * {@link RULED_VOCABULARY} is the maintainer's six tokens, written out here so
+ * that all three ends are compared against a FIXED point rather than against
+ * each other. Comparing ends pairwise would go green on a coordinated edit that
+ * moved every end off the ruling together; comparing each end to the ruling
+ * cannot. That is the opposite of the hand-maintained key list
+ * `zod-mirror-parity.test.ts` warns about — a ledger there tracks drift that
+ * exists, this is a decision that has been made.
+ *
+ * ## What is deliberately NOT declared
+ *
+ * `headerColorClass` also hands a value that is ALREADY a complete `bg-*` class
+ * straight through. The ruling rejected declaring that pass-through: it renders
+ * only where the host app's Tailwind build happens to emit that class, so a
+ * declaration would promise a capability the contract cannot keep. `bg-accent`
+ * is therefore pinned below as a value the RESOLVER accepts and both halves of
+ * the contract refuse — the asymmetry is the ruling, not an oversight.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { DetailViewSection } from '@object-ui/types';
+import { DetailViewSectionSchema } from '@object-ui/types/zod';
+
+import { headerColorClass, headerColorVocabulary } from '../headerColor';
+
+/* ── Type-level helpers (the idiom of `zod-mirror-parity.test.ts`) ─────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+export type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+export type Expect<T extends true> = T;
+
+/* ── The oracle ───────────────────────────────────────────────────────────── */
+
+/**
+ * The ruled vocabulary, verbatim from objectstack#12126 comment 5419726057:
+ * `z.enum` over "the six tokens objectui#6294 ships … and the `@object-ui/types`
+ * mirror narrows to match."
+ */
+const RULED_VOCABULARY = [
+  'muted',
+  'muted/50',
+  'accent',
+  'primary/10',
+  'secondary/10',
+  'destructive/10',
+] as const;
+
+type RuledToken = (typeof RULED_VOCABULARY)[number];
+
+/* ── The comparator, shown to fail in both directions ─────────────────────── */
+
+/**
+ * Reconcile one end's vocabulary against another: what each side has and the
+ * other does not.
+ *
+ * Factored out and driven by synthetic inputs below rather than asserted inline,
+ * for the reason `zod-mirror-parity.test.ts` gives for exporting its own
+ * reconciler: a run over TODAY's tree can only ever show that today's tree is
+ * green, and a comparison that has never been shown to FAIL is indistinguishable
+ * from no comparison. The recognition suite pins both directions.
+ */
+export function reconcileVocabularies(
+  actual: readonly string[],
+  expected: readonly string[],
+): { missing: string[]; extra: string[]; duplicated: string[] } {
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+  return {
+    missing: expected.filter((token) => !actualSet.has(token)),
+    extra: actual.filter((token) => !expectedSet.has(token)),
+    duplicated: actual.filter((token, i) => actual.indexOf(token) !== i),
+  };
+}
+
+const AGREES = { missing: [], extra: [], duplicated: [] };
+
+describe('headerColor pin — recognition: the comparator fails in both directions', () => {
+  it('is silent when the two vocabularies agree', () => {
+    expect(reconcileVocabularies(['a', 'b'], ['b', 'a'])).toEqual(AGREES);
+  });
+
+  it('names a token the end is MISSING (a token added to the oracle alone)', () => {
+    expect(reconcileVocabularies(['a'], ['a', 'b'])).toEqual({
+      missing: ['b'],
+      extra: [],
+      duplicated: [],
+    });
+  });
+
+  it('names a token the end has EXTRA (a token added to that end alone)', () => {
+    expect(reconcileVocabularies(['a', 'b'], ['a'])).toEqual({
+      missing: [],
+      extra: ['b'],
+      duplicated: [],
+    });
+  });
+
+  it('names a token declared twice, which a set comparison alone would hide', () => {
+    expect(reconcileVocabularies(['a', 'a'], ['a'])).toEqual({
+      missing: [],
+      extra: [],
+      duplicated: ['a'],
+    });
+  });
+});
+
+/* ── End 1: the resolver ──────────────────────────────────────────────────── */
+
+describe('headerColor pin — the resolver carries exactly the ruled vocabulary', () => {
+  it('matches HEADER_COLOR_CLASSES one-to-one', () => {
+    expect(reconcileVocabularies(Object.keys(headerColorVocabulary), RULED_VOCABULARY)).toEqual(
+      AGREES,
+    );
+  });
+
+  it('resolves every ruled token to a class, and only complete literals', () => {
+    for (const token of RULED_VOCABULARY) {
+      const resolved = headerColorClass(token);
+      expect(resolved, `${token} should resolve to a class`).toBeDefined();
+      expect(resolved).toBe(`bg-${token}`);
+    }
+  });
+});
+
+/* ── End 2: the published TypeScript declaration ──────────────────────────── */
+
+/**
+ * The declaration accepts the ruled vocabulary and NOTHING else.
+ *
+ * Invariant equality, so this fails in both directions: a seventh token added to
+ * `views.ts` alone, or one of the six dropped from it, both stop the two sides
+ * being mutually assignable. A widening back to `string` fails here first.
+ */
+export type assertionDeclarationIsTheRuledVocabulary = Expect<
+  Equal<NonNullable<DetailViewSection['headerColor']>, RuledToken>
+>;
+
+/** …and the key stays optional, which the equality above deliberately strips. */
+export type assertionDeclarationStaysOptional = Expect<
+  Equal<DetailViewSection['headerColor'], RuledToken | undefined>
+>;
+
+/* ── End 3: the published validator ───────────────────────────────────────── */
+
+/** The mirror's declared options, read from its own shape — never restated. */
+function declaredEnumOptions(): string[] {
+  const member = DetailViewSectionSchema.shape.headerColor;
+  const unwrapped = (member as { unwrap?: () => unknown }).unwrap?.() ?? member;
+  const options = (unwrapped as { options?: unknown }).options;
+  expect(
+    Array.isArray(options),
+    'DetailViewSectionSchema.headerColor should be an enum with declared options — a widening back to z.string() lands here',
+  ).toBe(true);
+  return [...(options as string[])];
+}
+
+/** A section that is otherwise valid, so only `headerColor` decides the verdict. */
+function sectionWith(headerColor: unknown): Record<string, unknown> {
+  return { fields: [{ name: 'amount' }], headerColor };
+}
+
+describe('headerColor pin — the validator carries exactly the ruled vocabulary', () => {
+  it('declares the six as an enum, one-to-one with the ruling', () => {
+    expect(reconcileVocabularies(declaredEnumOptions(), RULED_VOCABULARY)).toEqual(AGREES);
+  });
+
+  it('parses every ruled token green', () => {
+    for (const token of RULED_VOCABULARY) {
+      const result = DetailViewSectionSchema.safeParse(sectionWith(token));
+      expect(result.success, `${token} should parse: ${JSON.stringify(result.error?.issues)}`).toBe(
+        true,
+      );
+    }
+  });
+
+  it('still accepts a section that omits the key', () => {
+    expect(DetailViewSectionSchema.safeParse({ fields: [{ name: 'amount' }] }).success).toBe(true);
+  });
+
+  it('refuses a string outside the vocabulary, naming `headerColor` in the path', () => {
+    const result = DetailViewSectionSchema.safeParse(sectionWith('blue-100'));
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path.join('.'))).toContain('headerColor');
+  });
+});
+
+/* ── The undeclared pass-through, pinned as an asymmetry on purpose ───────── */
+
+/**
+ * `bg-accent` is the shape of value the resolver hands through verbatim. Both
+ * halves of the contract refuse it, and that is the ruling: option B (declaring
+ * the pass-through) was rejected as a capability illusion, because whether the
+ * class renders depends on the host app's Tailwind build rather than on anything
+ * this workspace ships.
+ *
+ * If someone later declares it, the `@ts-expect-error` below becomes an unused
+ * directive and `tsc` fails — so the ruling cannot be reversed silently on the
+ * type side either.
+ */
+const passThroughSection: DetailViewSection = {
+  fields: [],
+  // @ts-expect-error — deliberately undeclared: the resolver's `bg-*` pass-through
+  // is a renderer affordance, not part of the contract (objectstack#12126 ruling A).
+  headerColor: 'bg-accent',
+};
+
+describe('headerColor pin — the `bg-*` pass-through stays UNDECLARED', () => {
+  it('is resolved by the renderer', () => {
+    expect(headerColorClass('bg-accent')).toBe('bg-accent');
+  });
+
+  it('is refused by the validator', () => {
+    const result = DetailViewSectionSchema.safeParse(passThroughSection);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path.join('.'))).toContain('headerColor');
+  });
+
+  it('is absent from the resolver vocabulary, so nothing offers it as a token', () => {
+    expect(Object.keys(headerColorVocabulary)).not.toContain('bg-accent');
+  });
+});

--- a/packages/types/src/views.ts
+++ b/packages/types/src/views.ts
@@ -198,10 +198,31 @@ export interface DetailViewSection {
    */
   showBorder?: boolean;
   /**
-   * Header background color (Tailwind class)
+   * Header background tint, as one of six design-system tokens.
+   *
+   * Closed vocabulary — the same six `@object-ui/plugin-detail`'s
+   * `HEADER_COLOR_CLASSES` resolves, and the same six `@objectstack/spec`
+   * declares on its strict `record:details` section schema (maintainer ruling
+   * A, 2026-08-26, objectstack#12126). A value outside them is refused by the
+   * `DetailViewSectionSchema` mirror in `./zod/views.zod.ts`, whose `z.enum`
+   * is pinned one-to-one against that renderer module.
+   *
+   * The renderer additionally hands a value that is ALREADY a complete `bg-*`
+   * class straight through to the DOM. That pass-through is deliberately NOT
+   * declared here: it renders on the same terms as any `className` a schema
+   * carries — only if the host app's Tailwind build happens to emit that class
+   * — so declaring it would promise a capability the contract cannot keep
+   * (the ruling rejected declaring it for exactly that reason).
+   *
    * @example 'muted', 'primary/10'
    */
-  headerColor?: string;
+  headerColor?:
+    | 'muted'
+    | 'muted/50'
+    | 'accent'
+    | 'primary/10'
+    | 'secondary/10'
+    | 'destructive/10';
   /**
    * When true, hide fields whose value is null, undefined, or empty string.
    * If all fields are hidden, the entire section is hidden.

--- a/packages/types/src/zod/views.zod.ts
+++ b/packages/types/src/zod/views.zod.ts
@@ -68,7 +68,20 @@ export const DetailViewSectionSchema = z.object({
   columns: z.number().optional().describe('Grid columns for field layout'),
   visible: z.union([z.boolean(), z.string()]).optional().describe('Section visibility condition'),
   showBorder: z.boolean().optional().describe('Show border around section'),
-  headerColor: z.string().optional().describe('Header background color (Tailwind class)'),
+  // Closed vocabulary — the six design-system tint tokens
+  // `@object-ui/plugin-detail`'s `HEADER_COLOR_CLASSES` resolves, and the six
+  // `@objectstack/spec` declares on its strict `record:details` section schema
+  // (maintainer ruling A, 2026-08-26, objectstack#12126). Pinned one-to-one
+  // against that renderer module by
+  // `packages/plugin-detail/src/__tests__/headerColor.contractPin-6594.test.ts`,
+  // which fails in BOTH directions — a token added to either side alone is red.
+  // The renderer's verbatim `bg-*` pass-through stays an UNDECLARED affordance:
+  // the ruling rejected declaring it, since it only renders where the host
+  // app's Tailwind build happens to emit that class.
+  headerColor: z
+    .enum(['muted', 'muted/50', 'accent', 'primary/10', 'secondary/10', 'destructive/10'])
+    .optional()
+    .describe('Header background tint (one of six design-system tokens)'),
 });
 
 /**


### PR DESCRIPTION
Fixes #6594

`DetailViewSection.headerColor` was `string` on the TypeScript declaration and `z.string()` on the `@object-ui/types/zod` mirror, so any string parsed green while the renderer contributed a class for only six values. Both halves are now the closed vocabulary maintainer ruling A of 2026-08-26 named (recorded at objectstack#12126 comment 5419726057, provenance 「其他接受你的建议」): `muted`, `muted/50`, `accent`, `primary/10`, `secondary/10`, `destructive/10` — exactly what `@object-ui/plugin-detail`'s `HEADER_COLOR_CLASSES` resolves, and exactly what `@objectstack/spec` declares on its strict `record:details` section schema.

**This PR stays DRAFT and carries `needs:contract-review`.** It changes a published contract face; the review chain owns any enqueue. Never ready, never auto-merge.

## What changed

| File | Change |
|---|---|
| `packages/types/src/views.ts` | the six-literal union replaces `string` |
| `packages/types/src/zod/views.zod.ts` | `z.enum([...])` replaces `z.string()` |
| `packages/plugin-detail/src/__tests__/headerColor.contractPin-6594.test.ts` | new — the three-end pin |
| `packages/plugin-detail/src/__tests__/DetailSection.headerColor.test.tsx` | fixture triage, forced by the narrowing — see below |
| `.changeset/6594-headercolor-mirror-enum.md` | `@object-ui/types: minor` |

`packages/plugin-detail/src/headerColor.ts` is untouched: the pin imports its exported vocabulary and never edits it.

## The `bg-*` pass-through is deliberately NOT declared

`headerColorClass` also hands a value that is already a complete `bg-*` class through untouched. Ruling A rejected declaring that (option B, the capability illusion): whether such a class renders depends on the host app's Tailwind build, so a declaration would promise a capability the contract cannot keep. It stays a renderer affordance the contract does not invite, and the pin holds that asymmetry explicitly — `bg-accent` is asserted to be resolved by the renderer and refused by both halves of the contract.

## The pin, and why it is not a shared constant

The three ends cannot share one tuple. `@object-ui/types` is the protocol layer and carries no dependency on any renderer (AGENTS.md section 3, "Zero deps"), so the arrow only runs plugin-detail to types. And `packages/types/src/views.ts` is a **type-only module**: a tuple lifted into it would add a runtime export to the package barrel — a value export cannot ride the barrel's `export type` block — and a runtime import edge from the zod entry into `views.js`. Measured, not assumed: `grep` for runtime exports in `views.ts` returns nothing, and `index.ts` re-exports it from inside an `export type` block.

So the pin lives in the package that may legally see all three ends. It compares each of them against the ruling itself rather than against each other, so a coordinated edit that moved every end off the ruling together cannot go green. Its comparator is itself pinned against synthetic inputs, so the guard has been shown to fail rather than only to pass.

### Ablations — the pin fails in BOTH directions

Each leg: mutate, prove the mutation landed on disk by grepping the text it was meant to change, measure, restore, prove the restore by comparing the disk hash to the HEAD blob. `git diff HEAD` empty at the end of both scripts.

| Leg | Mutation | Result |
|---|---|---|
| A | 7th token on the **TS declaration** only | `tsc -p tsconfig.test.json` EXIT=2 — `headerColor.contractPin-6594.test.ts(168,3): error TS2344: Type 'false' does not satisfy the constraint 'true'` and the same at (173,3) |
| B | 7th token on the **validator** only | vitest EXIT=1 — `× declares the six as an enum, one-to-one with the ruling` |
| C | 7th token on the **resolver** only | vitest EXIT=1 — `× matches HEADER_COLOR_CLASSES one-to-one` |
| baseline | none | EXIT=0, 13 passed |

Leg A rebuilds `@object-ui/types` on **both** legs and proves what reached `dist`. That is not ceremony: `packages/plugin-detail/tsconfig.test.json` sets `"paths": {}`, so `@object-ui/types` resolves through the built `.d.ts`, not the source tree — an unrebuilt mutation would read GREEN and credit a pin that never fired. Restore leg proved by absence: `ablation/7` occurrences in `views.ts` = 0 and in `dist/views.d.ts` = 0, restored type-check EXIT=0.

## Fixture triage — the third file, and why it is in this PR

The narrowing turned three existing assertions in `DetailSection.headerColor.test.tsx` into compile errors, because they author off-vocabulary values on purpose to prove **renderer** behaviour:

```
src/__tests__/DetailSection.headerColor.test.tsx(87,44): error TS2820: Type '"bg-accent"' is not assignable to ...
(100,44): error TS2322: Type '"not-a-token"' is not assignable to ...
(117,44): error TS2322: Type '"constructor"' is not assignable to ...
```

All three tests stay — they are the renderer's contract with metadata that arrives as JSON over the wire, where no compiler was involved. They now route their value through one documented `offContract()` seam that says why the value is off-contract and forbids widening the declaration to make them compile without it. Re-judged individually rather than batch-respelled: none of the three is a misspelling of a live token, and none of them pins a branch this change removes.

This is the only file outside the claimed surface, it is fallout of this change rather than a stray repair, and the claim comment on the card was amended to name it.

## Census before tightening

`headerColor` occurs in **ten tracked files, none of them authored metadata**: the renderer and its tests, the two declaration files changed here, and two markdown notes. `examples/`, `content/`, `apps/`, `e2e/` and `docs/` carry **zero** occurrences. Positive control for that census: `sections` and `detail-view` both hit in those directories, so the search reached them. Nothing in this repo authors a value outside the six, so no migration is owed.

## Changeset, graded against the nearest narrowing precedent

`@object-ui/types: minor` — the grade objectui#5853 took for the same class (`.changeset/5853-tablecolumn-type-canonical-union.md`, `TableColumn.type` from `z.string()` to `z.enum`, maintainer ruling 2026-08-25). `major` is barred by AGENTS.md's version-alignment rule. That precedent **exported** a `TABLE_COLUMN_TYPES` tuple; this one cannot, for the type-only-module reason above, and had no second motive to — #5853 also needed a runtime `normalizeTableColumnType()` for producers, and `headerColor` has no producer that needs a runtime value. The changeset states that departure rather than leaving it to be rediscovered.

## Verification

Union run on the final commit, `2ed0542`.

- `pnpm exec vitest run packages/types/ packages/plugin-detail/` — `Test Files 192 passed (192)`, `Tests 1946 passed (1946)`, EXIT=0. Includes `zod-mirror-parity.test.ts`, which is the guard that would have caught a one-sided narrowing.
- `pnpm --filter @object-ui/types --filter @object-ui/plugin-detail type-check` — both `Done`, EXIT=0. Proved to MEASURE the new pins: `tsc -p tsconfig.test.json --listFiles` resolves both edited test files into the program, and reads `packages/types/dist/*.d.ts` (rebuilt).
- `pnpm --filter @object-ui/types --filter @object-ui/plugin-detail lint` — EXIT=0, `0 errors` in both packages (259 and 880 pre-existing warnings, none on the files touched here). `check:lint-coverage`: `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total)`.
- Gates green: `check:changeset-presence` (`3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)`), `check:changeset-no-major`, `check:changeset-fixed`, `check:changeset-overwrite`, `check:control-bytes`, `check:spec-symbols`, `check:phantom-deps`, `check:self-import`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:side-effects-array`, `check:node-esm-load`, `check:doc-snippets` (`271 of 271 block(s) judged, 0 failed` — compiled against the built types, so a doc snippet authoring an off-vocabulary value would have failed here), `check:doc-types`, `check:designer-field-key-parity`.
- **Not measured locally, prerequisite not met** (not red — CI builds the workspace and owns these): `check:readme-exports` needs every package built; all 302 failures read `type entry ./dist/index.d.ts is not on disk -- run pnpm build first`, plus one `packagesRead: found 12, floor is 25`. Zero of those lines name `packages/types` — the half this diff could affect was judged and passed. `check:eager-closure` and `check:sdui-registration-pins` both need `apps/console` built and say so.

## Installability

The published `@objectstack/spec` this repo installs is **17.2.0**, and it contains **zero** occurrences of `headerColor` (positive controls `record:details` and `RecordDetailsProps` both hit in the same package). The spec-side enum lives only on objectstack main. This card's acceptance is therefore internal to objectui — six literal tokens pinned against the renderer — and no spec symbol is imported. No parity gate in this repo binds this mirror to the installed spec's declarations: the two tests that name `DetailViewSection` are `zod-mirror-parity.test.ts` (TS-to-zod, green) and `object-view-spec-parity.test.ts` (which names `record:details` only in prose). No fork to report.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_