### PR TITLE
test(types): check the `exportOptions` alignment claim against the installed spec (#4535)

### DIFF
--- a/.changeset/4535-export-options-spec-parity.md
+++ b/.changeset/4535-export-options-spec-parity.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/types': patch
+---
+
+`exportOptions`: the alignment claim is now checked against the installed spec,
+not asserted in prose
+
+`ListViewExportOptions` mirrors `@objectstack/spec`'s
+`ListViewSchema.exportOptions` object branch. The comment above it explained
+that the five keys were restated rather than derived "because objectui still
+pins `@objectstack/spec@17.0.0-rc.6`, whose `ListView.exportOptions` is the
+LEGACY bare format array".
+
+That is no longer true. objectui installs `@objectstack/spec@17.2.0`, which
+carries the object form: the bare format array lifts to `{ formats: [...] }` at
+parse and `'pdf'` has left the enum. Nobody edited the comment; the dependency
+moved underneath it. This is the second time this particular comment has gone
+false — objectui#4535 was filed for the first — and both times the mechanism was
+the same: a prose claim about another package's shape, with nothing that fails
+when that shape changes.
+
+So the reason is corrected and, more to the point, it stops being load-bearing.
+A new `export-options-spec-parity.test.ts` reads the object branch out of the
+spec package that is actually installed, at test time, and asserts against it:
+the key set, the format enum (`'pdf'` absent from both sides), upstream
+strictness, the migration prescription the `'pdf'` refusal carries, and the
+parse-time array lift. The key set is projected from `keyof
+ListViewExportOptions` through an exhaustive `Record`, so a local key added or
+dropped fails to compile rather than passing a comparison against a hand-copied
+list.
+
+The mirror itself is unchanged, and stays a mirror for a measured reason the
+test now pins: `ListViewExportOptionsSchema` is internal to the spec bundle and
+is not one of the package's public exports, so there is nothing to import. Only
+the enclosing `ListViewSchema` is exported, and its `exportOptions` is a
+two-branch union whose inferred type is not this interface. When upstream
+exports the symbol, the test says so by failing, and the mirror can go.
+
+Types are unchanged — no export added or removed, no key or union altered — so
+this is a patch. The shape change was the earlier minor that introduced
+`ListViewExportOptions`.

--- a/packages/types/src/__tests__/export-options-spec-parity.test.ts
+++ b/packages/types/src/__tests__/export-options-spec-parity.test.ts
@@ -1,0 +1,169 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `ListViewExportOptions` ↔ the INSTALLED `@objectstack/spec` (objectui#4535).
+ *
+ * The card this file closes was filed because a comment claimed alignment with
+ * `@objectstack/spec`'s `ListViewSchema.exportOptions` and was false in both
+ * directions. objectstack#8010 fixed the upstream half; objectui's half restated
+ * the spec's five keys locally, under a NOTE explaining that the object form was
+ * not importable from the pin.
+ *
+ * Both halves have since moved, and that is the hazard this file exists for. The
+ * pin bumped to `@objectstack/spec@17.2.0`, which DOES carry the object form —
+ * so the NOTE went stale, and the prose went false again, by nobody touching it.
+ * A comment that has already gone false twice is not the instrument to trust a
+ * third time.
+ *
+ * So the claim is made falsifiable instead: every assertion below reads the
+ * shape out of the spec package that is actually installed, at test time, and
+ * compares it to the local declaration. Nothing here restates the contract — a
+ * restatement is a third copy, and the copy is what drifts (the lesson
+ * `list-view-spec-parity.test.ts` already records for the enclosing schema).
+ *
+ * Why a mirror at all, rather than `z.infer` of the spec symbol:
+ * `ListViewExportOptionsSchema` is internal to the spec bundle and NOT among the
+ * package's public exports — measured, not assumed, by the floor test below.
+ * Only the enclosing `ListViewSchema` is exported, and its `exportOptions` is a
+ * two-branch union (legacy-array lift ∪ object), whose inferred type is a union
+ * and not this interface. When upstream exports the symbol, derive from it and
+ * delete both the mirror and this file's key-set tests.
+ *
+ * SCOPE, stated rather than implied: this covers the TypeScript declaration in
+ * `objectql.ts`. objectui's own Zod mirror of `ListViewSchema`
+ * (`src/zod/objectql.zod.ts`) declares `exportOptions` separately and is NOT
+ * measured here — deliberately, because it is a different seat's file surface.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ListViewSchema as SpecListViewSchema } from '@objectstack/spec/ui';
+import type { ListViewExportFormat, ListViewExportOptions } from '../index';
+
+/* ── The local declaration, as runtime-enumerable data ────────────────────── */
+
+/**
+ * `Record<keyof T, true>` is exhaustive BOTH ways at compile time: a key added
+ * to the interface and missing here is a TS2741, and a key here that the
+ * interface dropped is a TS2353. That makes this object a faithful runtime
+ * projection of the type — which the type itself, erased at runtime, cannot be.
+ */
+const LOCAL_OPTION_KEYS: Record<keyof ListViewExportOptions, true> = {
+  formats: true,
+  maxRecords: true,
+  includeHeaders: true,
+  fileNamePrefix: true,
+  streaming: true,
+};
+
+/** Same device for the format union, so the enum comparison is also exhaustive. */
+const LOCAL_FORMATS: Record<ListViewExportFormat, true> = {
+  csv: true,
+  xlsx: true,
+  json: true,
+};
+
+/* ── Reaching the spec's object branch ────────────────────────────────────── */
+
+type ZodLike = {
+  unwrap?: () => ZodLike;
+  options?: ZodLike[];
+  shape?: Record<string, ZodLike>;
+  element?: ZodLike;
+  safeParse: (v: unknown) => { success: boolean; data?: unknown; error?: { issues: { message: string }[] } };
+  _zod?: { def?: { type?: string; element?: ZodLike; entries?: Record<string, string> } };
+};
+
+const specExportOptions = (SpecListViewSchema as unknown as { shape: Record<string, ZodLike> })
+  .shape.exportOptions;
+
+/** Peel `.optional()` (and any further wrapper) until the union itself. */
+function toUnion(schema: ZodLike): ZodLike {
+  let cur = schema;
+  for (let i = 0; i < 5 && cur && !cur.options && typeof cur.unwrap === 'function'; i++) {
+    cur = cur.unwrap();
+  }
+  return cur;
+}
+
+const specUnion = toUnion(specExportOptions);
+/**
+ * The object branch — the one with a `shape`. The other branch is the legacy
+ * bare-format-array lift, which is a `ZodPipe` and has none.
+ */
+const specObjectBranch = specUnion.options?.find((o) => o.shape);
+
+function specFormatEnumValues(): string[] {
+  let f = specObjectBranch?.shape?.formats;
+  for (let i = 0; i < 5 && f && f._zod?.def?.type !== 'array' && typeof f.unwrap === 'function'; i++) {
+    f = f.unwrap();
+  }
+  const element = f?._zod?.def?.element ?? f?.element;
+  return Object.keys(element?._zod?.def?.entries ?? {});
+}
+
+/* ── Tests ───────────────────────────────────────────────────────────────── */
+
+describe('exportOptions ↔ installed @objectstack/spec (objectui#4535)', () => {
+  it('finds the spec shape it is about to compare against', () => {
+    // Non-vacuity floor. Every assertion below reads through `specObjectBranch`,
+    // and a spec refactor that moved the shape would otherwise turn each of them
+    // into a comparison against `undefined` — which some would pass.
+    expect(specExportOptions).toBeDefined();
+    expect(specUnion.options).toHaveLength(2);
+    expect(specObjectBranch).toBeDefined();
+    expect(Object.keys(specObjectBranch?.shape ?? {}).length).toBe(5);
+    expect(specFormatEnumValues().length).toBeGreaterThan(0);
+  });
+
+  it('records WHY the mirror exists: the spec does not export the symbol', async () => {
+    // The reason in the doc comment, measured. If this ever fails, the mirror is
+    // obsolete: derive `ListViewExportOptions` from the exported symbol and
+    // delete it, rather than leaving a hand copy beside an importable schema.
+    const specUi = (await import('@objectstack/spec/ui')) as unknown as Record<string, unknown>;
+    expect(specUi.ListViewSchema).toBeDefined();
+    expect(specUi.ListViewExportOptionsSchema).toBeUndefined();
+  });
+
+  it('declares exactly the keys the spec object branch declares', () => {
+    expect(Object.keys(LOCAL_OPTION_KEYS).sort())
+      .toEqual(Object.keys(specObjectBranch?.shape ?? {}).sort());
+  });
+
+  it('offers exactly the formats the spec enum offers — `pdf` is gone from both', () => {
+    expect(Object.keys(LOCAL_FORMATS).sort()).toEqual(specFormatEnumValues().sort());
+    expect(specFormatEnumValues()).not.toContain('pdf');
+  });
+
+  it('is strict upstream: a sixth key is refused, so declaring one here is unauthorable', () => {
+    // The other end of the local key-set assertion in `objectql.exportOptions.test.ts`.
+    // That one stops a sixth key being DECLARED locally; this one is the reason —
+    // the platform would refuse metadata carrying it.
+    expect(specExportOptions.safeParse({ formats: ['csv'], compression: 'gzip' }).success).toBe(false);
+    expect(specExportOptions.safeParse({
+      formats: ['csv'], maxRecords: 1, includeHeaders: true, fileNamePrefix: 'p', streaming: false,
+    }).success).toBe(true);
+  });
+
+  it('refuses a retired `pdf` format with a migration prescription, not a bare rejection', () => {
+    const refused = specExportOptions.safeParse(['csv', 'pdf']);
+    expect(refused.success).toBe(false);
+    // The prescription is the half that makes the refusal actionable for an
+    // author; asserting only `success === false` would stay green if it were
+    // reduced to "Invalid input".
+    const messages = (refused.error?.issues ?? []).map((i) => i.message).join('\n');
+    expect(messages).toMatch(/pdf/);
+    expect(messages).toMatch(/8010|1301/);
+  });
+
+  it('lifts a bare format array at PARSE — which is why the renderer still needs its own tolerance', () => {
+    // objectui#4535 item 4. The lift is real, but it only runs for whoever calls
+    // `.parse()`. Nothing on objectui's render path does: `normalizeListViewSchema`
+    // (@object-ui/core) does not touch `exportOptions`, and the ListView surface is
+    // typed `z.input` precisely because the renderer receives metadata as authored.
+    // So a stored bare array still arrives as an array, and `ListView`'s
+    // `resolvedExportOptions` fold is load-bearing rather than legacy.
+    const lifted = specExportOptions.safeParse(['csv', 'xlsx']);
+    expect(lifted.success).toBe(true);
+    expect(lifted.data).toEqual({ formats: ['csv', 'xlsx'] });
+  });
+});

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -587,12 +587,21 @@ export type ListViewExportFormat = 'csv' | 'xlsx' | 'json';
  *   `plugin-grid`'s `ObjectGrid.exportOptionsKeys.test.ts` reds.
  *
  * NOTE (objectui#4535): this restates the five keys rather than deriving them
- * from the spec symbol, because objectui still pins
- * `@objectstack/spec@17.0.0-rc.6`, whose `ListView.exportOptions` is the LEGACY
- * bare format array (`('csv' | 'xlsx' | 'json' | 'pdf')[]`) — the object form is
- * not importable from the pin yet. Deriving this type from the published spec
- * symbol becomes possible when the pin bumps; the shape below IS the new spec
- * shape, so nothing here changes when it does.
+ * from the spec symbol, and the reason is no longer the pin. objectui now
+ * installs `@objectstack/spec@17.2.0`, which DOES carry the object form — the
+ * bare format array lifts to `{ formats: [...] }` at parse and `'pdf'` is gone
+ * from the enum. What is missing is the SYMBOL: `ListViewExportOptionsSchema`
+ * is internal to the spec bundle and not among the package's public exports, so
+ * there is nothing to import. Only the enclosing `ListViewSchema` is exported,
+ * and its `exportOptions` is the two-branch union (legacy-array lift ∪ object),
+ * whose `z.infer` is a union — not this interface.
+ *
+ * So the mirror is restated but not unchecked: `export-options-spec-parity.test.ts`
+ * reads the object branch out of the INSTALLED spec at test time and asserts
+ * this key set, the format enum and the strictness against it. Prose claiming
+ * alignment is what went false last time; that test is what makes the claim
+ * falsifiable. When upstream exports the symbol, derive from it and delete the
+ * restatement — the shape below is already the spec's, so nothing else moves.
  */
 export interface ListViewExportOptions {
   /**


### PR DESCRIPTION
Fixes #4535

## The premise moved before I got here — measured first

The card lists four items against `origin/main@878140b`. Re-verified on `b03ba3a`, **three of them were already landed** by the change that shipped changeset `1f9b905`:

| card item | state on current main |
|---|---|
| 1. align the local `exportOptions` type, make the comment true | type landed as `ListViewExportOptions` (the five spec keys); comment **partly false again** — see below |
| 2. remove `'pdf'` | landed — `ListViewExportFormat = 'csv' \| 'xlsx' \| 'json'`, warn-drop path folded into the format-agnostic filter |
| 3. type `streaming`, delete the `as any` | landed in `ObjectGrid.tsx` — `:2563` and `:2605` read it uncast |
| 4. confirm the schema feed path, keep array tolerance only if raw metadata reaches the renderer | **unanswered** — measured here |

The card's constraint (no sixth undeclared-but-read key) was also already honoured as two guards: `objectql.exportOptions.test.ts` (type side) and `ObjectGrid.exportOptionsKeys.test.ts` (source scan).

So this PR is not a re-implementation. It closes the part of item 1 that came undone, answers item 4, and files the leg that sits outside this card's file surface.

## What this PR changes

### The alignment comment went false a second time — by nobody touching it

`ListViewExportOptions` (`packages/types/src/objectql.ts`) carried:

> NOTE (objectui#4535): this restates the five keys rather than deriving them from the spec symbol, because objectui still pins `@objectstack/spec@17.0.0-rc.6`, whose `ListView.exportOptions` is the LEGACY bare format array

That is no longer true. Measured from the lockfile and the installed package: objectui installs **`@objectstack/spec@17.2.0`**, and its `ListViewSchema.exportOptions` **is** the object form — a two-branch union where a bare format array lifts to `{ formats: [...] }` at parse, the object branch is a `strictObject` with exactly the five keys, and the enum is `["csv","xlsx","json"]`.

This is the same failure mode the card was filed for, one release later: a prose claim about another package's shape, with nothing that fails when that shape changes. A comment that has gone false twice is not the instrument to trust a third time.

### So the claim is made falsifiable

New `packages/types/src/__tests__/export-options-spec-parity.test.ts` reads the object branch **out of the spec package that is actually installed**, at test time, and asserts against it:

- the key set equals the spec object branch's key set;
- the format enum matches, and `'pdf'` is absent from both sides;
- upstream is strict — a sixth key is refused, which is *why* declaring one locally is unauthorable;
- the `'pdf'` refusal carries its migration prescription, not a bare "Invalid input";
- the bare format array lifts at parse (the fact item 4 turns on);
- a non-vacuity floor, because every assertion reads through the union branch and a spec refactor would otherwise compare against `undefined`.

The local key set is projected through `Record< keyof ListViewExportOptions, true >`, exhaustive in both directions, so a local key added or dropped **fails to compile** rather than passing a comparison against a hand-copied list. Nothing in the file restates the contract — a restatement is a third copy, and the copy is what drifts.

The comment now records the real reason the mirror exists, and the test pins that too: `ListViewExportOptionsSchema` is **internal to the spec bundle and not a public export** (measured: 222 exports on `@objectstack/spec/ui`, none matching `/Export/i`; only `ListViewSchema` is exported, and its `exportOptions` infers to a union, not this interface). When upstream exports the symbol, the test fails and says so, and the mirror can go.

## Item 4, answered: raw un-parsed metadata reaches the renderer — keep the tolerance

Three measurements, all on current main:

1. `normalizeListViewSchema` (`packages/core/src/utils/normalize-list-view.ts`) does **not** touch `exportOptions` — zero occurrences in the file.
2. Nothing on the render path runs `.parse()`/`.safeParse()` on a view schema; the only such calls in the repo are in tests. That is exactly why `ListViewInferred` is `z.input` and not `z.infer`, as its own doc comment already records.
3. `packages/app-shell/src/views/ObjectView.tsx:2116` forwards the stored value verbatim: `exportOptions: viewDef.allowExport === false ? undefined : (viewDef.exportOptions ?? listSchema.exportOptions)`.

**The spec's parse-time array lift therefore never runs before the renderer.** A stored bare-array declaration still arrives as an array, so the renderer's own tolerance is load-bearing and stays. It lives in `plugin-list/src/ListView.tsx:1299-1308` (`resolvedExportOptions`), on the component `ObjectView` actually renders. `ObjectGrid` carries none — a bare array reaching it degrades to the `['csv','json']` default, silently ignoring the author's declared formats. Left as-is here and recorded on the follow-up rather than changed on the way past.

## Out of this card's file surface — filed as #6956

The ListView leg of the same reconciliation never landed, and it is a live defect. It is outside this card's declared surface (`objectql.ts` + `ObjectGrid.tsx`), so it was measured and reported, not fixed here. #6956 remains open and carries the detail:

- `packages/types/src/zod/objectql.zod.ts:511-518` still declares the pre-#8010 shape — `'pdf'` accepted in both spellings, `streaming` declared nowhere, object branch not strict. This is not cosmetic: `ListViewSchema` (the TS type the ListView renderer is written against) derives from this zod, so it disagrees with its sibling `ObjectGridSchema` about the same spec key.
- `packages/plugin-list/src/ListView.tsx:1324` and `:2705` still read `streaming` through `as any` — item 3's exact defect in the other renderer, load-bearing precisely *because* of the zod gap.

The new test states this scope limit in its own docblock rather than implying it, so nobody reads it as covering the zod mirror.

## Verification

All gates below run on **`cac5aed`**, the final commit of this branch.

| gate | verdict (quoted) |
|---|---|
| `pnpm --filter @object-ui/types type-check` | exit 0 — `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json` |
| `pnpm exec vitest run packages/types/` | `Test Files  76 passed (76)` · `Tests  868 passed (868)` |
| `pnpm exec vitest run packages/plugin-grid/src/__tests__/ObjectGrid.exportOptionsKeys.test.ts` | `Test Files  1 passed (1)` · `Tests  5 passed (5)` |
| `pnpm --filter @object-ui/types lint` | exit 0 — `✖ 259 problems (0 errors, 259 warnings)`, all pre-existing |
| `node scripts/check-spec-symbol-derivation.mjs` | `✅  spec symbol derivation: 1325 files scanned against 4959 spec export names; 16 declared dialects, 0 untriaged collisions in 0 packages.` · `✅  spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages.` — unchanged count, so no new unbacked claim |
| `node scripts/check-control-bytes.mjs` | `✅  check-control-bytes: OK (scanned 5786 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-fixed.mjs` | `✅  All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | `✅  No changeset declares a `major` bump.` |

**Type-check coverage is measured, not assumed.** `tsc -p tsconfig.test.json --listFiles` names `packages/types/src/__tests__/export-options-spec-parity.test.ts` (1 hit), so "type-check is clean" is a statement about the new file rather than about a program that excluded it.

**Ablation — the guard reds on local drift.** Committed first, then mutated `ListViewExportFormat` back to include `'pdf'` (card item 2's defect), with an `EXIT INT TERM` trap restoring by absolute path.

- mutation confirmed on disk, anchored on the exact text: injected-form `1`, removed-form `0`; blob `46090c7` → `88ccf25`.
- `tsc -p tsconfig.test.json` exit **2**, naming this PR's guard first (angle brackets spaced out below — GitHub's body sanitizer silently eats short tag-shaped fragments, which is what happened to this quote on the first publish):
  ```
  src/__tests__/export-options-spec-parity.test.ts(59,7): error TS2741: Property 'pdf' is missing in type
    '{ csv: true; xlsx: true; json: true; }' but required in type 'Record< ListViewExportFormat, true >'.
  src/__tests__/objectql.exportOptions.test.ts(60,39): error TS2344: Type 'false' does not satisfy the constraint 'true'.
  src/__tests__/objectql.exportOptions.test.ts(80,7): error TS2578: Unused '@ts-expect-error' directive.
  ```
- restore confirmed by observed state, not by exit code: `git hash-object` back to `46090c7`, equal to `git rev-parse HEAD:packages/types/src/objectql.ts`; `git diff HEAD` empty; `git status` clean.

Stated honestly, because the template direction and the measured one differ: the **runtime** leg of the new test fires when the **spec** drifts, and the **compile** leg fires when the **local** declaration drifts. The ablation exercises the second. The first was not ablated — the only way to mutate the spec side is to edit `node_modules`, which is a pnpm store hardlink shared across worktrees on this box. The floor test (`finds the spec shape it is about to compare against`) is what stands in for it.

Scope narrowing, declared: the repo-wide `pnpm lint` and the full `check:*` farm were not run locally — CI runs them once regardless. The narrowing is bounded by measurement, not by assumption: the whole `@object-ui/types` package lint ran (not just changed files), and `eslint.config.js` enables no type-aware linting (no `projectService`, no `parserOptions.project`), so this diff cannot move the verdict on any file it does not touch.

## Changeset

`@object-ui/types` **patch**. No export added or removed, no key or union altered — the diff to shipped source is a doc comment. Precedent named: the earlier `1f9b905` graded this package **minor**, on the reasoning `ListViewExportFormat` and `ListViewExportOptions` are new exports, `streaming` is a new optional key, and `formats` no longer admits `'pdf'`. That was the shape change; this is not one. No `@object-ui/plugin-grid` changeset — nothing in that package changed.

## Review notes

- Opened **draft** and parked under `needs:contract-review`. Not for enqueue by me.
- `packages/plugin-grid/src/ObjectGrid.tsx` is **untouched** — regions owned by landed work (LinkCell #4531, date cells #4544/#4552, kebab menu) were never opened. Its guard test runs here only because it scans `packages/types/src/objectql.ts`, which this PR edits.
- One burn-down left on the table deliberately: `ListViewExportOptions` is entry 1 in the `@object-ui/types` list of `CLAIM_DEBT` in `scripts/check-spec-symbol-derivation.mjs:665`, the shrink-only ledger of unbacked spec-alignment claims. Its claim is now backed by a real parity test and the mirror's reason is measured, which makes it a clean move to `CLAIM_ALLOW` under the ledger's own route 2 — but `scripts/**` is outside this card's surface, and editing a gate script pulls in that script's own test suite. Recorded on #6956.
- Authored by Claude Code, session `session_01PBjwYLS6BciTQW3c9xQiD2` (https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2) — recorded in prose because a body edit rewrites the generated footer below to its bare form.