### PR TITLE
feat(app-shell): declare scim on RuntimeFeatures

### DIFF
--- a/.changeset/5869-runtime-features-scim.md
+++ b/.changeset/5869-runtime-features-scim.md
@@ -2,12 +2,14 @@
 '@object-ui/app-shell': patch
 ---
 
-Declare `scim?: boolean` on `RuntimeFeatures` (objectui#5869), mirroring its
-two commercial siblings `customDomain?` / `sso?` with the same
-server-derived, absent-on-vanilla doc comment.
+Declare `scim?: boolean` on `RuntimeFeatures` and map it through
+`initRuntimeConfig` (objectui#5869), mirroring its two commercial siblings
+`customDomain?` / `sso?` end to end: same doc-comment style
+(server-derived, absent-on-vanilla), same `false` default, same
+`body.features.scim === true` derivation.
 
-This documents the wire a shipped cloud producer already emits in the same
-`resolveFeatures` object literal as `customDomain` / `sso`; the key already
-arrives at the SPA today, untyped. Declaration only — this patch adds no
-read point, no gate, and no SCIM UI affordance. Any actual SCIM-gated UI is
-future work.
+This documents and now honestly carries the wire a shipped cloud producer
+already emits in the same `resolveFeatures` object literal as
+`customDomain` / `sso`; the key already arrives at the SPA today, untyped.
+Declaration plus plumbing only — this patch adds no read point, no gate,
+and no SCIM UI affordance. Any actual SCIM-gated UI is future work.

--- a/.changeset/5869-runtime-features-scim.md
+++ b/.changeset/5869-runtime-features-scim.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Declare `scim?: boolean` on `RuntimeFeatures` (objectui#5869), mirroring its
+two commercial siblings `customDomain?` / `sso?` with the same
+server-derived, absent-on-vanilla doc comment.
+
+This documents the wire a shipped cloud producer already emits in the same
+`resolveFeatures` object literal as `customDomain` / `sso`; the key already
+arrives at the SPA today, untyped. Declaration only — this patch adds no
+read point, no gate, and no SCIM UI affordance. Any actual SCIM-gated UI is
+future work.

--- a/packages/app-shell/src/runtime-config.test.ts
+++ b/packages/app-shell/src/runtime-config.test.ts
@@ -3,9 +3,9 @@
 /**
  * runtime-config commercial-feature parsing (cloud ADR-0011/0012).
  *
- * `customDomain` / `sso` are paid flags: they must default OFF and only turn on
- * when the server explicitly grants them, so an older/vanilla runtime that
- * omits them never surfaces a paid affordance.
+ * `customDomain` / `sso` / `scim` are paid flags: they must default OFF and
+ * only turn on when the server explicitly grants them, so an older/vanilla
+ * runtime that omits them never surfaces a paid affordance.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -24,31 +24,39 @@ afterEach(() => {
 });
 
 describe('runtime-config commercial features', () => {
-    it('defaults customDomain/sso OFF before init', () => {
+    it('defaults customDomain/sso/scim OFF before init', () => {
         resetRuntimeConfigForTesting();
         expect(getRuntimeConfig().features.customDomain).toBe(false);
         expect(getRuntimeConfig().features.sso).toBe(false);
+        expect(getRuntimeConfig().features.scim).toBe(false);
     });
 
-    it('grants customDomain/sso only when the server says true', async () => {
-        mockConfig({ customDomain: true, sso: false });
+    it('grants customDomain/sso only when the server says true (scim stays OFF when the server says false)', async () => {
+        mockConfig({ customDomain: true, sso: false, scim: false });
         await initRuntimeConfig();
         expect(getRuntimeConfig().features.customDomain).toBe(true);
         expect(getRuntimeConfig().features.sso).toBe(false);
+        // The negative leg that actually tests fail-closed: `scim: false` sits
+        // in the SAME payload as `customDomain: true`, so a hardcoded
+        // `scim: true` (or "any granted sibling flips scim on") would fail
+        // here even though it would pass the all-true case below.
+        expect(getRuntimeConfig().features.scim).toBe(false);
     });
 
-    it('business-tier grants both', async () => {
-        mockConfig({ customDomain: true, sso: true });
+    it('business-tier grants all three', async () => {
+        mockConfig({ customDomain: true, sso: true, scim: true });
         await initRuntimeConfig();
         expect(getRuntimeConfig().features.customDomain).toBe(true);
         expect(getRuntimeConfig().features.sso).toBe(true);
+        expect(getRuntimeConfig().features.scim).toBe(true);
     });
 
     it('older runtime omitting the flags keeps them OFF (no paid surface leak)', async () => {
-        mockConfig({ aiStudio: true }); // no customDomain/sso keys at all
+        mockConfig({ aiStudio: true }); // no customDomain/sso/scim keys at all
         await initRuntimeConfig();
         expect(getRuntimeConfig().features.customDomain).toBe(false);
         expect(getRuntimeConfig().features.sso).toBe(false);
+        expect(getRuntimeConfig().features.scim).toBe(false);
         // sanity: existing flags still parse
         expect(getRuntimeConfig().features.aiStudio).toBe(true);
     });

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -67,6 +67,16 @@ export interface RuntimeFeatures {
    * (treated as off). Server-derived from the plan entitlements.
    */
   sso?: boolean;
+  /**
+   * SCIM-based user/group provisioning is available on this environment's
+   * plan. Optional commercial flag — absent on self-hosted / vanilla
+   * runtimes (treated as off). Server-derived from the plan entitlements,
+   * the same producer object as `customDomain` / `sso`. Declaration only:
+   * this keeps the interface in sync with the wire the producer already
+   * emits — no SPA read point or gate consumes it yet (future work, not
+   * implied by this declaration).
+   */
+  scim?: boolean;
 }
 
 /**

--- a/packages/app-shell/src/runtime-config.ts
+++ b/packages/app-shell/src/runtime-config.ts
@@ -71,9 +71,10 @@ export interface RuntimeFeatures {
    * SCIM-based user/group provisioning is available on this environment's
    * plan. Optional commercial flag — absent on self-hosted / vanilla
    * runtimes (treated as off). Server-derived from the plan entitlements,
-   * the same producer object as `customDomain` / `sso`. Declaration only:
-   * this keeps the interface in sync with the wire the producer already
-   * emits — no SPA read point or gate consumes it yet (future work, not
+   * the same producer object as `customDomain` / `sso`. Mapped through by
+   * `initRuntimeConfig` alongside its two siblings so the typed value
+   * matches the wire the producer already emits — no SPA read point or
+   * gate consumes it yet (any actual SCIM UI gating is future work, not
    * implied by this declaration).
    */
   scim?: boolean;
@@ -288,7 +289,7 @@ const defaults: AppShellRuntimeConfig = {
   singleEnvironment: false,
   defaultOrgId: null,
   defaultEnvironmentId: null,
-  features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false },
+  features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false, scim: false },
   // `stage: 'preview'` while the whole platform is pre-GA, so the badge shows
   // out of the box on any runtime that hasn't sent an explicit stage yet.
   branding: { productName: 'ObjectOS', productShortName: 'ObjectOS', stage: 'preview', brandColor: '#4F46E5', pwaThemeColor: '#4f46e5' },
@@ -374,6 +375,7 @@ export async function initRuntimeConfig(baseUrl: string = ''): Promise<void> {
           // them — never show a paid surface on an unknown/older runtime.
           customDomain: body.features.customDomain === true,
           sso: body.features.sso === true,
+          scim: body.features.scim === true,
         }
         : current.features,
       // Read off the RAW body, not off `body.telemetry`: the mirrored reader


### PR DESCRIPTION
Fixes #5869

## What

Declares `scim?: boolean` on `RuntimeFeatures` in `packages/app-shell/src/runtime-config.ts`, maps it through `initRuntimeConfig`, and pins it into the existing commercial-flag test doctrine — mirroring its two commercial siblings `customDomain?` / `sso?` end to end: same doc-comment style, same `false` default, same `body.features.scim === true` derivation, same test coverage shape.

```ts
/**
 * SCIM-based user/group provisioning is available on this environment's
 * plan. Optional commercial flag — absent on self-hosted / vanilla
 * runtimes (treated as off). Server-derived from the plan entitlements,
 * the same producer object as `customDomain` / `sso`. Mapped through by
 * `initRuntimeConfig` alongside its two siblings so the typed value
 * matches the wire the producer already emits — no SPA read point or
 * gate consumes it yet (any actual SCIM UI gating is future work, not
 * implied by this declaration).
 */
scim?: boolean;
```

```ts
// defaults
features: { installLocal: false, marketplace: true, aiStudio: true, autoPublishAiBuilds: true, customDomain: false, sso: false, scim: false },

// initRuntimeConfig derivation
customDomain: body.features.customDomain === true,
sso: body.features.sso === true,
scim: body.features.scim === true,
```

Per the issue's own report (I did not verify this myself — the `cloud` repo is outside this session's scope): cloud's `resolveFeatures` (`packages/objectos-runtime/src/cloud-runtime-config-plugin.ts`) already returns `{ aiStudio, autoPublishAiBuilds, customDomain, sso, scim }` in one object literal, so the untyped key is already arriving at the SPA today.

**Declaration, plumbing, and test doctrine — nothing more.** No read point, no gate, no SCIM UI affordance, no derivation logic beyond the one-line mirror of its siblings, nothing under `packages/types/**`.

This PR went through two corrections during review, both recorded here for the trail:

1. An earlier revision declared the interface member without the defaults/derivation lines, leaving `getRuntimeConfig().features.scim` read `undefined` even when the server sent `scim: true` — true on the type face, false at runtime, the same divergence this card exists to record, just pointed the other way. Fixed by mirroring the two lines `customDomain`/`sso` already have.
2. A later revision left the mapping unpinned. `runtime-config.test.ts`'s own header doctrine ("`customDomain` / `sso` are paid flags: they must default OFF and only turn on when the server explicitly grants them") wasn't extended to `scim`, so nothing would have caught a future regression on that line. Fixed by extending all four existing "runtime-config commercial features" cases (defaults-off, grants-only-when-true, business-tier-grants-all, omitted-keys) with a `scim` assertion each — no new test cases, no parallel block.

## Premise re-verification (against current `origin/main`, before editing)

Both premises from the card still held:

1. `RuntimeFeatures` declares `customDomain?` / `sso?` and not `scim` — confirmed by reading the interface directly.
2. Zero in-repo consumption of `scim` — reconfirmed with a **seam-local control** (stronger than the card's repo-wide one), same file/interface:
   - `grep -n '\bscim\b' packages/app-shell/src/runtime-config.ts` → 0 hits
   - `grep -n '\bsso\b' packages/app-shell/src/runtime-config.ts` → 4 hits (header-comment producer list, interface declaration, defaults literal, `body.features.sso` derivation) — confirms the grep pattern isn't the reason for the `scim` zero.
   - Repeated the card's original repo-wide probe too: `grep -rn '\bscim\b' --include='*.ts' --include='*.tsx' packages/ apps/` → 0 hits (exit 1), matching the card's report.
   - One incidental case-insensitive hit worth noting: `packages/auth/src/types.ts:260` has a comment "*SCIM forces it on*" next to an unrelated `admin?: boolean` gate — not a `RuntimeFeatures.scim` reference, doesn't touch the premise.

## Scope

- File surface: `packages/app-shell/src/runtime-config.ts` and `packages/app-shell/src/runtime-config.test.ts` only.
- `packages/types/**` untouched.
- Test extension touches only the pre-existing "runtime-config commercial features" `describe` block — no new `it()` cases, sibling assertions' existing expectations (`customDomain`/`sso` values) unchanged.

## Reverse verification on the new test pins

Predicted before running: removing the `scim: body.features.scim === true,` derivation line would turn the "business-tier grants all three" (positive-leg, `scim: true → true`) assertion red, while the three negative-leg assertions (defaults-off, the `scim: false` leg in "grants...only when true", and the omitted-keys case) would stay green — because all three already expect `false`, and removing the line makes `current.features.scim` fall back to the untouched default (`false`) rather than genuinely measuring the mapping.

Observed, exactly as predicted:
- Mutation confirmed on disk: anchor line count `1 → 0`, file hash changed.
- Ablated run: `Tests 1 failed | 29 passed (30)` — only `business-tier grants all three` failed (`expected false to be true`).
- Restore proven both ways: `git hash-object` back to the pre-mutation hash, `git diff` empty.
- Restored run: `Tests 30 passed (30)`.

This confirms the positive leg (added even though not itself paid surface UI) was necessary for the pin to be load-bearing — a negative-leg-only extension would have stayed green through a silent regression on the mapping line.

## Tests

- `pnpm exec vitest run packages/app-shell/src/runtime-config.test.ts` (repo-root invocation, per AGENTS.md) — `Test Files 1 passed (1)`, `Tests 30 passed (30)`, both before and after the test-pin extension (no new `it()` blocks were added, only assertions within the four existing ones — `scim`-referencing assertions went from 0 to 4 in this file).
- `pnpm --filter '@object-ui/app-shell^...' build` (dependency closure) then `pnpm --filter '@object-ui/app-shell' run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — clean, exit 0, re-run after every commit.
- Full package suite, three times across the PR's revisions (declaration, plumbing fix, test-pin extension), identical result every time: `pnpm exec vitest run packages/app-shell/` — `Test Files 579 passed (579)`, `Tests 5690 passed | 1 skipped (5691)`.
- `node scripts/check-changeset-presence.mjs` — ✅ 1 changeset declared for the 2 released-package source files now touched.
- `node scripts/check-changeset-no-major.mjs` — ✅ no `major` bump declared.

## Changeset

`.changeset/5869-runtime-features-scim.md` — `@object-ui/app-shell: patch` (declaration + mirrored plumbing + mirrored test coverage, additive and inert — no read point, no gate, no behavior change for any existing consumer).

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_
