### PR TITLE
test(plugin-gantt): read the chart through an async query, not a race

### DIFF
--- a/.changeset/6959-gantt-lazy-read-flake.md
+++ b/.changeset/6959-gantt-lazy-read-flake.md
@@ -1,0 +1,28 @@
+---
+---
+
+Test-only: `ObjectGantt.referenceArms-6837.test.tsx` now reads the chart through an
+asynchronous query instead of racing it. No published behaviour changes; no runtime code
+was touched.
+
+The block at `:257` mounted through the file's `mount()` helper, whose gate settles a MOCK
+CALL — `find('task', { $expand })` was ISSUED — and then read the DOM synchronously with
+`getByTestId('gantt-view')`. Those are two different facts one promise-resolution apart:
+`ObjectGantt` flips `loading` false in the `finally` of `reload()`, i.e. after that find
+RESOLVES, so on return from `mount()` the component can still be painting its
+`Loading Gantt chart...` branch. The synchronous read raced it and lost twice in fifteen
+minutes in the merge queue — a heavier environment than PR CI — ejecting two pull requests
+that do not touch `plugin-gantt` at all, one of which passed and failed the queue on
+byte-identical content.
+
+The assertion is unchanged, and `mount()` keeps its find-call gate: the refusal probe above
+this block needs proof of the SCHEMA-dependent commit, which the chart's presence alone does
+not carry (`loading` flips false after the FIRST find resolves, before `objectSchema`
+lands). The two gates measure different facts, so the block now waits for both rather than
+trading one for the other.
+
+Measured rather than assumed: with the data source's resolution delayed 500ms — the timing
+FACT mutated, never the assertion — the old spelling throws
+`Unable to find an element by: [data-testid="gantt-view"]` against a DOM reading exactly
+`Loading Gantt chart...`, reproducing the queue failure, while the new spelling resolves
+through that fallback and reads `data-count=2`.

--- a/packages/plugin-gantt/src/ObjectGantt.referenceArms-6837.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.referenceArms-6837.test.tsx
@@ -253,9 +253,25 @@ describe('ObjectGantt resolves only contract-declared target spellings (objectui
     it('and degrades to the distinct loaded values rather than rendering nothing', async () => {
       // Guards the refusal above against the degenerate pass: a gantt that
       // rendered no quick filter at all would also never fetch `projects`.
+      //
+      // ⚠️ ASYNC reads, deliberately (objectui#6959). `mount()` settles on a
+      // MOCK CALL — `find('task', { $expand })` was ISSUED — and that is one
+      // promise resolution EARLIER than the `setLoading(false)` in `reload()`'s
+      // `finally`. So on return from `mount()` `ObjectGantt` may still be
+      // painting its `loading` branch (`Loading Gantt chart...`), and a
+      // SYNCHRONOUS `getByTestId` here races it. It lost that race twice in
+      // fifteen minutes in the merge queue — a heavier runner than PR CI —
+      // ejecting two PRs that do not touch `plugin-gantt` at all.
+      //
+      // `mount()`'s find-call gate STAYS: the refusal probe needs proof of the
+      // SCHEMA-dependent commit, and `gantt-view` alone does not carry it —
+      // `loading` flips false after the FIRST `find()` resolves, which happens
+      // before `objectSchema` lands. The two gates measure different facts, so
+      // this block waits for both rather than trading one for the other.
       const { ds, view } = await mount(FIELD_DEFS.legacy_camel);
-      expect(view.getByTestId('gantt-view').getAttribute('data-count')).toBe('2');
-      fireEvent.click(view.getByTestId('quick-filter-trigger-project'));
+      const chart = await view.findByTestId('gantt-view');
+      expect(chart.getAttribute('data-count')).toBe('2');
+      fireEvent.click(await view.findByTestId('quick-filter-trigger-project'));
       const panel = view.getByTestId('quick-filter-panel-project');
       expect(within(panel).getByTestId('quick-filter-option-project-p1')).toBeTruthy();
       expect(within(panel).queryByTestId('quick-filter-option-project-p3')).toBeNull();


### PR DESCRIPTION
Fixes #6959

`packages/plugin-gantt/src/ObjectGantt.referenceArms-6837.test.tsx:257` read the chart with a **synchronous** `getByTestId` and lost the race twice in fifteen minutes in the merge queue, ejecting two PRs that do not touch `plugin-gantt`. This converts that read — and the sibling read on the next line — to the house async form. **The assertion is unchanged.** Nothing is skipped, quarantined, or timeout-inflated, and `ObjectGantt` itself is untouched.

## One correction to the card's mechanism, stated rather than applied silently

The card attributes the fallback DOM to a `React.lazy` boundary. It is not one. `ObjectGantt.tsx:65` imports `GanttView` **statically**, and there is **no `React.lazy` anywhere in `packages/plugin-gantt`**. `Loading Gantt chart...` is the `if (loading)` early return at `ObjectGantt.tsx:1580-1587`, driven by `useState(true)` plus the async data/schema fetch.

Everything else in the card holds, and the remedy is identical — this is a synchronous read of an asynchronously-appearing surface either way. The correction matters only for *where* the window is, and that is what made the probe below constructible.

## The actual race

`mount()` gates on a **mock call** — `find('task', { $expand })` was ISSUED. `ObjectGantt` flips `loading` false in the `finally` of `reload()`, i.e. after that find **resolves**. Those are two facts one promise-resolution apart, so on return from `mount()` the component can still be painting its loading branch.

`mount()`'s find-call gate is **kept**, deliberately. The refusal probe above this block needs proof of the *schema-dependent* commit, and the chart's presence alone does not carry it: `loading` flips false after the **first** find resolves, before `objectSchema` lands. Swapping one gate for the other would have weakened the refusal pin. The block now waits for both facts.

## Measurement — the timing fact mutated, never the assertion

A throwaway probe copied the file's mocks, schema and `mount()` verbatim and changed exactly one thing: `find` resolves 500 ms late, as on a loaded queue runner. Both legs ran; the probe was deleted and is not in this PR.

- **Leg A, old spelling** — `DOM at read time: "Loading Gantt chart..."`, and the sync read threw ``Unable to find an element by: [data-testid="gantt-view"]``. That reproduces the queue failure in the card.
- **Leg B, new spelling** — `await findByTestId` resolved *through* that fallback; `data-count=2`.

At 25 ms the probe did **not** reproduce: the window closed before `waitFor`'s 50 ms poll observed the call. That negative reading is the point — locally the window is sub-50 ms, which is exactly why this passes on a quiet runner and fails on a loaded one.

## The census — is `:257` the only one?

**No.** Bound, stated: `git ls-files -- '*.test.tsx' '*.test.ts' '*.spec.tsx' '*.spec.ts'` = **2282 files**. **Hot control: every tier below reports `:257` itself.** Tier 1 initially did not — it required a literal `render(` in the block and `:257` mounts through a helper — the control caught that and the instrument was fixed rather than the corpus declared clean.

| tier | rule | hits |
|---|---|---|
| 1 | async block, first sync DOM read, no gate naming that surface | 1105 |
| 2 | + surface async-witnessed elsewhere in its own package | 413 |
| 3 | + **no** DOM-touching gate at all before the read, resolving awaited file-local helpers | **176** |

Tier 3 is the shape: the awaited settle never touches the DOM.

**In `packages/plugin-gantt` (in scope) tier 3 returns 3, and hand triage leaves exactly one real defect — `:257`.** The other two are false positives: `ObjectGantt.quickfilter.test.tsx:141` is gated at `:135` through the file-local `gv()` helper, and `GanttView.autoscheduledlg.test.tsx:63` has a synchronous mount with no async settle to race. The 10 tier-2 plugin-gantt hits triage the same way — every one has a real DOM gate, several hidden behind `gv()` / `renderSettled()`.

**173 tier-3 candidates sit outside `plugin-gantt` and are deliberately NOT touched here** — several of those packages have live PRs. Assume roughly the 2-in-3 false-positive rate measured in `plugin-gantt`; the concentrations are `app-shell` 58, `fields` 28, `apps/console` 25, `components` 16, `plugin-form` 11, `plugin-grid` 9. These are reported to the PM for separate dispatch, not filed as findings from this seat.

## Changeset

Owed, and added with **empty frontmatter**. `scripts/check-changeset-presence.mjs` guards all of each package's `src/` with **"No carve-out for test files under `src/`"** stated explicitly in its header, and `@object-ui/plugin-gantt` is in the `fixed` group. Verified in both directions: the gate exits **1** before the changeset and **0** after, quoting

> ✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.

The `skip-changeset` label is **not** used: in this repo it is an inert historical label that exempts nothing, and the empty-frontmatter changeset is the declaration mechanism.

## Verification — union run on the final commit, `6f5c01fb5`

Joined with `&&` so the verdict covers every part; run through the shared verify lock.

- `pnpm exec vitest run packages/plugin-gantt/` — **Test Files 53 passed (53), Tests 434 passed (434)**
- `pnpm --filter @object-ui/plugin-gantt run type-check` — clean. Measured, not assumed: `tsc --noEmit --listFiles` contains **0** hits for the edited file (the package tsconfig excludes tests); the `tsconfig.test.json` leg contains **1**. Coverage comes from the second leg.
- `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:shell-escape-residue` — all `✅ OK`
- `check-changeset-presence` / `-no-major` / `-fixed` / `-overwrite` — all `✅`

The vitest invocation matters: `pnpm --filter PKG exec vitest` is **refused** by this repo's guard, which reports that it silently runs `apps/console`'s 22 files and prints `Test Files 22 passed` while running none of this package's. The guard fired on my first attempt; the runs above are the root-level form it prescribes.

**Repo-wide `pnpm lint` was narrowed, and the narrowing is measured rather than asserted:**
1. Population read from eslint's own config, not guessed — `files: ['**/*.{ts,tsx}']` plus the config's `ignores`.
2. File count read from `--format json` — **1** file linted, **0 errors**, 6 warnings.
3. Invariance for untouched files — `languageOptions` declares only `ecmaVersion` and `globals`; there is **no `project` / `projectService`**, so type-aware linting is off and no rule's verdict on any file can depend on another file's contents.

The 6 warnings are pre-existing: linting the base blob of the same file gives **6 warnings / 0 errors**, all `@typescript-eslint/no-explicit-any` — identical before and after. CI deliberately sets no `--max-warnings`.

_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_