### PR TITLE
fix(hooks): print the --no-track worktree recipe in both guards' remediation text

### DIFF
--- a/.changeset/6977-hook-remediation-no-track.md
+++ b/.changeset/6977-hook-remediation-no-track.md
@@ -1,0 +1,42 @@
+---
+---
+
+PreToolUse-hook prose only: no published package's `src/` changed, so nothing ships.
+
+**Both worktree guards now print `--no-track` in the recipe they emit when they block.**
+`.claude/hooks/guard-main-checkout.sh` and `.claude/hooks/guard-main-checkout-bash.sh` each
+end their block message with the worktree recipe to run instead, and both created the branch
+with a plain `-b`. PR #6976 hardened the prescribed form in `CLAUDE.md` and `AGENTS.md`; the
+hooks' copy was left behind, and it is the higher-leverage one — it is delivered at the exact
+moment an agent is about to act, so it is the copy most likely to be run verbatim.
+
+The hazard is the one #6976 established: plain `-b` writes the new branch's upstream keys
+(`branch.NAME.remote`, `branch.NAME.merge`) into the one `.git/config` that every linked
+worktree of a repo shares. That write can fail *after* the branch is created, leaving a branch
+with no worktree — a half state the error text does not name. Read as "the worktree exists",
+the agent starts editing the shared primary checkout, which is the one thing these two guards
+exist to prevent. Measured on git 2.43.0 in #6976: `--no-track` removes the config write and
+still bases the worktree on `origin/main`, and `git push -u origin BRANCH` sets the upstream
+one command later.
+
+Additive, not a recipe rewrite: this repo's hooks already emitted the fetch-hardened base
+(`git fetch origin main && … origin/main`, landed for ui#6208), so the only surviving
+divergence from the prescribed form was the missing flag. One word added per file, net ±0
+lines in both.
+
+Deliberately unchanged, each for its own reason:
+
+- `.changeset/6208-worktree-recipe-fetch-base.md` quotes the pre-#6208 recipe as the record of
+  a past change. Editing a historical changeset would rewrite that record (adjudicated in
+  PR #6976).
+- The two `-cmp` comparison-tree lines in `CLAUDE.md` / `AGENTS.md` create no branch and take
+  an explicit ref from the caller, so there are no upstream keys to write and the flag does not
+  apply — the same reading #6208 recorded for them.
+- `.claude/hooks/guard-tree-enum.selftest.sh`'s allow-case is a command payload fed to a
+  different guard to assert that ordinary commands pass through it. It is test input, not text
+  any agent is told to run.
+
+Verified by re-running all three self-test matrices this repo ships (`guard-main-checkout-bash`
+121, `guard-shared-stash` 41, `guard-tree-enum` 36 — 0 failed each, unchanged from before the
+edit, because no case pins the remediation string), and by invoking both hooks directly and
+reading the text they emit.

--- a/.claude/hooks/guard-main-checkout-bash.sh
+++ b/.claude/hooks/guard-main-checkout-bash.sh
@@ -541,7 +541,7 @@ only, so the identical edit expressed as a shell command used to slip through in
 its HEAD switched and its tree reset under you, clobbering uncommitted work. A feature
 branch on the shared checkout is NOT enough; you need a dedicated worktree:
 
-  git fetch origin main && git worktree add ../${name}-<task> -b <branch> origin/main
+  git fetch origin main && git worktree add --no-track ../${name}-<task> -b <branch> origin/main
   cd ../${name}-<task> && pnpm install    # then re-run the command there
 
 Always fine, no flag needed:

--- a/.claude/hooks/guard-main-checkout.sh
+++ b/.claude/hooks/guard-main-checkout.sh
@@ -54,7 +54,7 @@ This repo is edited by multiple agents at once — the shared checkout gets its 
 switched and tree reset under you, silently clobbering uncommitted work. A feature
 branch on the shared checkout is NOT enough; you must be in a dedicated worktree:
 
-  git fetch origin main && git worktree add ../${name}-<task> -b <branch> origin/main
+  git fetch origin main && git worktree add --no-track ../${name}-<task> -b <branch> origin/main
   cd ../${name}-<task> && pnpm install    # then re-run your edits there
 
 This guard checks the edited file's OWN repo, so sibling repos are covered too.


### PR DESCRIPTION
Fixes #6977

## What changed

Both worktree guards print a remediation recipe when they block — the copy an agent reads
at the exact moment it is about to act, and therefore the copy most likely to be run
verbatim. Both printed the recipe with a plain `-b`. PR #6976 hardened the prescribed form
in `CLAUDE.md` and `AGENTS.md` with `--no-track`; the hooks' copy was left behind.

One word added per file, net ±0 lines in both:

- `.claude/hooks/guard-main-checkout.sh:57`
- `.claude/hooks/guard-main-checkout-bash.sh:544`

Both now emit exactly the prescribed form (verbatim from a live invocation of each hook,
with `$name` interpolated):

```
  git fetch origin main && git worktree add --no-track ../objectui-TASK -b BRANCH origin/main
  cd ../objectui-TASK && pnpm install    # then re-run your edits there
```

## Why

The hazard is the one PR #6976 established: plain `-b` writes the new branch's upstream
keys (`branch.NAME.remote`, `branch.NAME.merge`) into the one `.git/config` that every
linked worktree of a repo shares. That write can fail *after* the branch is created,
leaving a branch with no worktree — a half state the error text does not name. Read as
"the worktree exists", the agent starts editing the shared primary checkout, which is the
one thing these two guards exist to prevent.

## Scope — additive, not a recipe rewrite

The premise was re-verified on `origin/main` before the first edit and it is narrower than
the sibling card's. This repo's hooks **already** emitted the fetch-hardened base
(`git fetch origin main && … origin/main`, landed for ui#6208), so the missing flag was the
only surviving divergence from the prescribed form. Measured on the freshly fetched tree:
`grep -rc "no-track" .claude/hooks/` returned 0 across all seven files there (four guards,
three self-test matrices) before this change, and 1 in each of the two edited guards after.

## Not in this PR

Each of these was examined and deliberately left alone:

- `.changeset/6208-worktree-recipe-fetch-base.md` quotes the pre-ui#6208 recipe as the
  record of a past change. Editing a historical changeset rewrites that record —
  adjudicated in PR #6976, and restated on the card. `check-changeset-overwrite.mjs`
  confirms it mechanically: *0 modified, 0 deleted*.
- The two `-cmp` comparison-tree lines in `CLAUDE.md` / `AGENTS.md` create no branch and
  take an explicit ref from the caller, so there are no upstream keys to write and the flag
  does not apply. This is the same reading ui#6208 recorded for them.
- `.claude/hooks/guard-tree-enum.selftest.sh:99` is a command payload fed to a *different*
  guard, asserting that ordinary commands pass through it. It is test input, not text any
  agent is told to run, and adding the flag there would change no coverage.

## Verification

All at `efbfb15`, the head of this branch. Nine checks, joined with `&&` so one verdict
covers all of them — exit 0.

**Hook self-tests** — the only gate that targets `.claude/hooks/**`
(`.github/workflows/hook-selftests.yml`), all three matrices it runs:

| self-test | result |
| --- | --- |
| `guard-main-checkout-bash.selftest.sh` | 121 passed, 0 failed |
| `guard-shared-stash.selftest.sh` | 41 passed, 0 failed |
| `guard-tree-enum.selftest.sh` | 36 passed, 0 failed |

Identical to the pre-edit baseline, and that is the expected direction rather than a weak
result: **no self-test case pins the remediation string**, so none needed updating in this
change. Measured, not assumed — a `grep -rn` for four distinctive fragments of the two block
messages (`fetch origin main`, `dedicated worktree`, `Blocked: editing on the shared`,
`WRITES into the shared`) across `.claude/hooks/*.selftest.sh` and `scripts/` returns no
match in any self-test.

A second measurement, reported because its absence is the answer rather than an assumption:
this repo ships **no** `guard-main-checkout.selftest.sh`. `.claude/hooks/` holds four guards
and three matrices; `guard-main-checkout.sh` is the one guard without one — so for that hook
the direct invocation below is the whole of its coverage.

**Behavioural check** — both hooks invoked directly with a payload targeting the shared
primary checkout. Each exits 2 (blocked, as designed) and prints the hardened recipe shown
above. The recipe it now prints was then fed back through all three of this repo's Bash
guards (`guard-main-checkout-bash`, `guard-shared-stash`, `guard-tree-enum`): all three exit
0, so the text is runnable and not self-blocked.

**Repo gates that reach this diff** — `check-control-bytes` (5809 tracked text files
scanned), `check-changeset-presence`, `check-changeset-no-major`, `check-changeset-overwrite`,
`check-shell-escape-residue`, `check-governed-queue-guard --self-test` (132 cases). All ✅.
`bash -n` clean on both edited files.

**Measurement — nothing lints shell files' contents in this repo.** Verified on this tree
rather than taken from the workflow header that claims it: `eslint.config.js` scopes every
block to `**/*.{ts,tsx}`, and there is no `shellcheck` step anywhere (the three matches in
the repo are two prose mentions and one `# shellcheck source=` directive inside
`e2e/live/ci/start-backend.sh`). `check-shell-escape-residue` reads fenced blocks in
`AGENTS.md`, `CLAUDE.md`, `skills/` and `content/docs/` — it does not reach `.claude/hooks/`.
So the self-test matrices plus the direct invocation above are the whole of the coverage
available for this diff, by measurement.

## Changeset

`check-changeset-presence` reports **no changeset is owed** here (3 files changed, 0 of them
published source of a released package). One is included anyway, with **empty frontmatter**,
because that is this repo's verified convention for a diff of this shape — the same form as
`.changeset/6880-worktree-recipe-no-track.md` (PR #6976), `6208-worktree-recipe-fetch-base.md`
and `6089-hook-selftests-step-names-drop-counts.md`. The empty-frontmatter exemption is a
first-class pass in `scripts/check-changeset-presence.mjs`.

No `skip-changeset` label is applied: in this repo that label is a phantom.
`scripts/__tests__/ci-cd-pipeline-doc.test.ts` pins that **nothing** under `.github/` or
`scripts/` may mention it, so applying it would exempt nothing.

## Governed surface — draft, human merge

`.claude/**` is governed. `check-governed-queue-guard --test` on this diff returns
`⛔ GOVERNED — 2 of 3 path(s)`, and one governed path governs the whole pull request. This PR
stays a **draft**: not flipped ready, not enqueued, no auto-merge armed. The merge is the
maintainer's, and a human merge is the review record.

Refs: PR #6976 · ui#6880 · ui#6208 · objectstack#13052. The objectstack twin
(objectstack#13663) covers that repo's hooks and is not addressed here.

_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EnE7G31tqbxN1rqpQmzurT)_