### PR TITLE
docs(console-architecture): point Branding at the effective theme tokens, not the alias

### DIFF
--- a/.changeset/6871-branding-token-docs.md
+++ b/.changeset/6871-branding-token-docs.md
@@ -1,0 +1,37 @@
+---
+---
+
+Documentation-only: `content/docs/guide/console-architecture.md`'s Branding section now points
+readers at the tokens branding actually acts through, instead of at the backward-compat alias.
+
+The section's one closing sentence read "This sets CSS custom properties (`--brand-primary`,
+`--brand-primary-hsl`, etc.) on the document root" — naming only the `--brand-*` group. That
+group is an alias: `useAppShellBranding` writes it, nothing in this repository reads it, and no
+Tailwind utility is wired to it. The properties that make a brand colour visible are the Shadcn
+theme tokens the same hook writes — `--primary` / `--primary-foreground` / `--ring` /
+`--sidebar-primary` / `--sidebar-ring` from `primaryColor`, and `--accent` /
+`--accent-foreground` from `accentColor` — which reach rendered output through the Tailwind 4
+`@theme` block in `packages/components/src/index.css` (`--color-primary: hsl(var(--primary))`
+and siblings), and that is what generates the `bg-primary`, `text-primary-foreground`,
+`bg-accent` and `ring-ring` utilities the components already use. A reader following the old
+sentence would customize against a name nothing guarantees.
+
+The new copy states the mechanism, then describes the `--brand-*` group as what it is: a
+backward-compatibility alias. It also records a difference the old sentence hid — `--brand-*`
+carries the authored hex and its light-mode HSL triple and does not follow the light/dark
+toggle, while `--primary` / `--accent` carry the mode-adjusted value — so the two are not
+interchangeable for anyone theming against them.
+
+Deliberately **not** done here: the four alias properties are not removed and
+`packages/layout/src/AppShell.tsx` is not touched. CSS custom properties are consumed by
+definition from outside this repository — a customer stylesheet can write `var(--brand-primary)`
+directly — so the in-repo grep that found zero readers is structurally incapable of seeing the
+consumers that would make removal safe, and zero in-repo hits does not license deletion.
+Retiring them needs a measurement that reaches outside this repo (a release-surface
+announcement, a deprecation window, a survey of customer stylesheets); that is a separate card.
+The prose therefore neither promises removal nor promises permanence, matching the hedge the
+source comment already carries.
+
+Every token name and the `@theme` consumption path were checked against
+`packages/layout/src/AppShell.tsx` and `packages/components/src/index.css`. No published
+behaviour changes and no package source was touched.

--- a/content/docs/guide/console-architecture.md
+++ b/content/docs/guide/console-architecture.md
@@ -197,7 +197,25 @@ Per-app branding is applied via `AppShell`'s `branding` prop:
 }}>
 ```
 
-This sets CSS custom properties (`--brand-primary`, `--brand-primary-hsl`, etc.) on the document root.
+This writes CSS custom properties on the document root (`html`), and re-applies them whenever
+the `.dark` class on that element changes, so the brand stays readable across the theme toggle.
+
+**Branding acts through the Shadcn theme tokens.** `primaryColor` sets `--primary`,
+`--primary-foreground`, `--ring`, `--sidebar-primary` and `--sidebar-ring`; `accentColor` sets
+`--accent` and `--accent-foreground`. They reach rendered output through the Tailwind 4 `@theme`
+block in `packages/components/src/index.css`, which maps each one to a colour token
+(`--color-primary: hsl(var(--primary))`, `--color-accent: hsl(var(--accent))`, and so on) — and
+that is what generates the `bg-primary`, `text-primary-foreground`, `bg-accent` and `ring-ring`
+utilities the components already use. Overriding the token is therefore the whole mechanism:
+every existing consumer picks up the brand colour without a single component change.
+
+`AppShell` also writes `--brand-primary`, `--brand-primary-hsl`, `--brand-accent` and
+`--brand-accent-hsl`. These are **backward-compatibility aliases, not the branding surface** —
+no utility is wired to them, and nothing in this repository reads them. They are not
+interchangeable with the tokens above either: `--brand-*` carries the authored hex and its
+light-mode HSL triple and does not follow the light/dark toggle, whereas `--primary` /
+`--accent` carry the mode-adjusted value. Theme against the Shadcn tokens; treat the
+`--brand-*` names as an alias kept for whatever already consumes it.
 
 ## Development Mode
 


### PR DESCRIPTION
Fixes #6871

Documentation-only. The Branding section of `content/docs/guide/console-architecture.md` pointed
readers at the backward-compatibility alias instead of at the tokens branding actually acts
through. This rewrites that prose.

## The defect

The section closed with one sentence:

> This sets CSS custom properties (`--brand-primary`, `--brand-primary-hsl`, etc.) on the document root.

That names only the `--brand-*` group. `useAppShellBranding` writes it, nothing in this
repository reads it, and no Tailwind utility is wired to it. A reader customizing against that
sentence would target a name nothing guarantees, while the properties that make a brand colour
visible went unmentioned.

## What the docs now say

- **The effective tokens are named.** `primaryColor` sets `--primary`, `--primary-foreground`,
  `--ring`, `--sidebar-primary` and `--sidebar-ring`; `accentColor` sets `--accent` and
  `--accent-foreground`.
- **How they reach rendered output.** The Tailwind 4 `@theme` block in
  `packages/components/src/index.css` maps each to a colour token
  (`--color-primary: hsl(var(--primary))` and siblings), which generates the `bg-primary`,
  `text-primary-foreground`, `bg-accent` and `ring-ring` utilities the components already use.
- **The alias is described as an alias.** The `--brand-*` group is called a
  backward-compatibility alias, not the branding surface. The copy neither promises removal nor
  promises permanence — that hedge matches the source comment's own.
- **One difference the old sentence hid.** `--brand-*` carries the authored hex and its
  light-mode HSL triple and does not follow the light/dark toggle, whereas `--primary` /
  `--accent` carry the mode-adjusted value. The two are not interchangeable.

## Scope: pinned by the triage ruling, and held

The card was split in triage. Only the documentation half was released; the removal half was
explicitly refused and deferred to a separate card. This PR implements the released half and
nothing else.

**Not done here, deliberately:** the four alias properties are not removed, and
`packages/layout/src/AppShell.tsx` is not touched. CSS custom properties are consumed by
definition from outside this repository — a customer stylesheet can write `var(--brand-primary)`
directly — so the in-repo grep that found zero readers is structurally incapable of seeing the
consumers that would make removal safe. Zero in-repo hits does not license deletion. Retiring
these names needs a measurement that reaches outside this repo (a release-surface announcement,
a deprecation window, a survey of customer stylesheets), and that is separate work.

Verified mechanically against `ae85cb902`:

| Constraint | Evidence |
|:--|:--|
| No `setProperty` / `removeProperty` deleted or modified | count 33 at base, 33 at head |
| `AppShell.tsx` untouched | blob `12787bb2c621bcac31923abf9b8befb7ed0ef752` identical at base and head |
| `packages/components/src/index.css` untouched | not in the diff |
| `content/docs/releases/` untouched | not in the diff |
| Files changed | exactly 2 — the guide and the changeset |

## Verification

Every token name and the `@theme` consumption path in the new prose was read off
`packages/layout/src/AppShell.tsx` and `packages/components/src/index.css` rather than copied
from the card, and the four named utilities were confirmed to have real consumers in
`packages/components/src` and `packages/layout/src`. The alias grep was reproduced independently
and matches the card's reading: the only in-repo hits are `AppShell.tsx`'s own writes and
cleanups plus the one doc line this PR rewrites.

Gates run at `ae85cb902` with a clean working tree, quoting each gate's own verdict line:

| Gate | Result |
|:--|:--|
| `pnpm check:doc-types` | exit 0 — "Every documented component type is registered." |
| `pnpm check:doc-fences` | exit 0 — "every TypeScript block in 224 document(s) is fenced ts/tsx/typescript" |
| `pnpm check:control-bytes` | exit 0 — "OK (scanned 5819 tracked text file(s); skipped 85 binary)." |
| `pnpm docs:check-links` | exit 0 — "Links are valid across 17 scan roots." |
| `pnpm changeset:check` | exit 0 — "No changeset declares a `major` bump." |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "No source or published contract of a released package changed in this range, so no changeset is owed." |
| `node scripts/check-changeset-overwrite.mjs` | exit 0 — "No pre-existing changeset was modified or deleted." |

Exit codes were captured before any pipe (redirect to a file, then read), not from a `tail`.

**`check:doc-snippets` — declared narrowing, not a skip.** That gate's input is the fenced
`ts`/`tsx` blocks of covered documents plus a document-keyed coverage ledger; it does not read
prose. This diff adds and removes zero fence markers, leaves the fenced-block count at 8 on both
sides, and leaves the fenced-block content **byte-identical** — sha256
`ef87608b84c4b8f96acea91da2bd5cc926c546b42b8479b721d34f2f365da124` at base and at head. It adds
and removes no document, so the ledger's document set is unchanged. The gate's entire input
surface is therefore provably invariant under this change, and its 21-package filtered build was
not spent re-confirming a byte-identical input on a shared box. CI runs it regardless.

A changeset is not strictly owed here — the presence gate reports no released package source
changed — but one is included with empty frontmatter, the declaration form this repo uses for
docs-only changes and the form its sibling branding-prose changeset already took.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_