### PR TITLE
fix(plugin-grid): retire the FIELD-meta-dead `titleFormat` relational key

### DIFF
--- a/.changeset/6874-retire-titleformat.md
+++ b/.changeset/6874-retire-titleformat.md
@@ -1,0 +1,57 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+`ObjectGrid` no longer copies `titleFormat` onto a relational column's `fieldMeta`
+(objectui#6874).
+
+`RELATIONAL_META_KEYS` listed eight keys that `applyRelationalMeta` copies off the
+object-schema field def onto the built `fieldMeta`, at all three of `generateColumns`'s
+column-building call sites. `titleFormat` was one of them and had **zero FIELD-meta
+readers**.
+
+This is a zero of a different kind from objectui#6711's, and a stronger one: `titleFormat`
+is a real, live key with plenty of readers — it just has none on a field meta. The sweep
+did not fail to find readers. It found every member read of the identifier across
+`packages/` and `apps/` (tests included) and classified each by its receiver:
+
+- `objectDef` / `objectSchema` / `objSchema` — `core/utils/record-title.ts`,
+  `components/renderers/layout/containers.tsx`, `plugin-detail/DetailView.tsx`,
+  `plugin-kanban/ObjectKanban.tsx`, `plugin-calendar/ObjectCalendar.tsx`,
+  `react/hooks/useRecordSearch.ts`. An OBJECT schema, every one.
+- `refObjectSchema?.titleFormat` — `fields/widgets/LookupField.tsx`: the REFERENCED
+  object's schema, fetched by `getSchema(referenceTo)`. Also an OBJECT schema, and the one
+  that decides this case — it is what the grid's own inline picker reads.
+- `param.titleFormat` — `app-shell/utils/paramToField.ts`, off a resolved `ActionParamDef`.
+  The field-def read beside it is `field.title_format`, a different spelling on a different
+  surface.
+
+`RecordPickerDialog` and `lookupColumnDisplay` receive it as a PROP, and the repo's single
+`titleFormat=` pass is `titleFormat={refTitleFormat}` — object-schema sourced. So copying
+`reference_to` is what makes `titleFormat` work on this path, and copying `titleFormat`
+onto the meta reached nothing.
+
+Nothing renders differently, and the argument does not rest on the member sweep alone: the
+only computed access to the meta bag anywhere in `@object-ui/fields` or `plugin-grid` is
+`applyRelationalMeta`'s own write, so no consumer can pick the key up dynamically. The key
+is also not a member of any declared type on this path — `applyRelationalMeta` writes into
+a `Record<string, any>` and the bag reaches cell renderers through an `as any` cast.
+
+`plugin-dashboard/src/recordFields.tsx` had already recorded this exact measurement as its
+reason for not copying the key into that seam, so it was a measured no-op in two seams and
+retired from only one. Same defect class as objectui#6625 (`FieldMeta.decimals`),
+objectui#6597 (`FieldMeta.referenceTo`) and objectui#6711 (`reference_to_field`), and the
+same disposition as objectui#6711 on this very list.
+
+⚠️ **What the measurement bounds.** The sweep covers this repo and the producer repo. A
+host application outside them could still be reading `titleFormat` off the `fieldMeta` a
+cell renderer receives; that was never a declared promise this renderer made, and this
+repo's own contract is what the retirement is about — but the world was not measured, and a
+host reading the key off a field meta gets `undefined` after this change. The supported
+source is unchanged and unaffected: the referenced object's schema.
+
+Because the key had no readers on this path, the suite stays green whether or not the
+removal is correct, so the absence is pinned directly instead
+(`__tests__/relationalMetaCopySet-6874.test.tsx`): all three call sites, each with a
+presence assertion on the seven surviving keys as the control against a fixture that passes
+by never reaching the copy path.

--- a/packages/plugin-dashboard/src/__tests__/lookupRelationalMeta-6694.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/lookupRelationalMeta-6694.test.tsx
@@ -237,7 +237,10 @@ describe('objectui#6694 — RecordDetailDrawer lookup rows carry their reference
 /**
  * The copy-set boundary.
  *
- * `ObjectGrid`'s `applyRelationalMeta` copies NINE keys; this seam copies THREE,
+ * `ObjectGrid`'s `applyRelationalMeta` copies SEVEN keys — it copied NINE until
+ * objectui#6711 and objectui#6874 retired `reference_to_field` and `titleFormat`
+ * from its list, both on the reader measurement this seam had already recorded.
+ * This seam copies THREE,
  * and the difference is measured rather than preferred: the grid's cells are
  * EDITABLE, so its extra keys feed the inline picker (`LookupField` / `UserField`
  * read `id_field`, `description_field`, `lookup_filters`, `lookupFilters`).
@@ -245,7 +248,7 @@ describe('objectui#6694 — RecordDetailDrawer lookup rows carry their reference
  * renderer — and `packages/fields/src/index.tsx` reads exactly three relational
  * keys off a cell's `field` prop.
  *
- * ⛔ This is what stops the omitted six from being added back "for parity": a
+ * ⛔ This is what stops the omitted keys from being added back "for parity": a
  * `FieldMeta` member written on every call and read by nothing is precisely what
  * objectui#6625 (`decimals`) and objectui#6597 (`referenceTo`) retired from this
  * same file. If these widgets ever gain inline editing, that is the event that
@@ -257,7 +260,11 @@ describe('objectui#6694 — buildFieldMeta copies the cell-read relational keys 
     reference_to: 'project',
     reference: 'project',
     display_field: 'project_code',
-    // The six the grid also copies, which have no reader on this path:
+    // Six keys with no reader on this path. FOUR of them the grid still copies
+    // (its picker-only keys); the other two it has since retired as well —
+    // `reference_to_field` (objectui#6711) and `titleFormat` (objectui#6874).
+    // All six stay on the fixture on purpose: the assertion below pins THIS
+    // seam's boundary, which does not move when the grid's list does.
     reference_to_field: 'x',
     id_field: 'x',
     description_field: 'x',

--- a/packages/plugin-dashboard/src/recordFields.tsx
+++ b/packages/plugin-dashboard/src/recordFields.tsx
@@ -92,11 +92,15 @@ export const NUMERIC_FIELD_TYPES = new Set([
  * widgets funnel through, which is what this module exists for (see the file
  * header: the two surfaces must never drift).
  *
- * ## ⚠️ The copy set is DELIBERATELY 3 of the grid's 9 — measured, per key
+ * ## ⚠️ The copy set is DELIBERATELY 3 of the grid's 7 — measured, per key
  *
- * `RELATIONAL_META_KEYS` is `reference_to`, `reference`, `reference_to_field`,
- * `display_field`, `id_field`, `description_field`, `lookup_filters`,
- * `lookupFilters`, `titleFormat`. The grid needs all nine because its cells are
+ * `RELATIONAL_META_KEYS` is `reference_to`, `reference`, `display_field`,
+ * `id_field`, `description_field`, `lookup_filters`, `lookupFilters`. It listed
+ * NINE until the two keys this file had already measured as reader-less were
+ * retired from it as well — `reference_to_field` (objectui#6711) and
+ * `titleFormat` (objectui#6874).
+ *
+ * The grid needs the remaining seven because its cells are
  * EDITABLE — its own docblock says the extra keys "drive the inline picker's
  * query (LookupField reads reference_to/reference, display_field, id_field,
  * description_field, lookup_filters)", and the defect that earned them was an
@@ -114,15 +118,17 @@ export const NUMERIC_FIELD_TYPES = new Set([
  *    mentions in that module; read only by `fields/src/widgets/LookupField.tsx`
  *    and `UserField.tsx`, both EDITORS. ⛔ NOT copied.
  *  - `reference_to_field` — ZERO member reads anywhere in the repo. ⛔ NOT
- *    copied.
+ *    copied. ⭐ The grid has since retired it from its own list too
+ *    (objectui#6711); this measurement is what that retirement acted on.
  *  - `titleFormat` — never read off a FIELD meta at all; every reader takes it
  *    off the OBJECT schema (`getRecordDisplayName` in `@object-ui/core`,
  *    `containers.tsx`). On this path that object schema arrives through
  *    `useRefObjectSchema(reference_to)` — so copying `reference_to` is what
  *    makes `titleFormat` work, and copying `titleFormat` here would reach
- *    nothing. ⛔ NOT copied.
+ *    nothing. ⛔ NOT copied. ⭐ The grid has since retired it too
+ *    (objectui#6874), on exactly this reading.
  *
- * ⛔ Do not "restore parity" by widening this to the grid's nine. A member
+ * ⛔ Do not "restore parity" by widening this to the grid's seven. A member
  * written from the schema def on every call and read by nothing is exactly what
  * objectui#6625 (`decimals`) and objectui#6597 (`referenceTo`) retired from this
  * very file. Add a key when a reader on THIS path is measured, not before; if

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -430,42 +430,74 @@ function getDataConfig(schema: ObjectGridSchema): ViewData | null {
  * raw id after moving to another row. Copy them from the object-schema field
  * definition onto the built `fieldMeta` for every column-building path.
  *
- * ## ⛔ `reference_to_field` was in this list and is RETIRED (objectui#6711)
+ * ## ⛔ Two keys were in this list and are RETIRED
  *
  * Every key here has to have a measured reader on this grid's own render path —
  * the cell renderers and inline editors in `@object-ui/fields` that
- * `getCellRenderer` dispatches into. `reference_to_field` had none: swept across
- * `packages/` and `apps/` (and again across the producer repo), the only
- * occurrences of the identifier anywhere were this array literal — the write —
- * and prose recording that nothing reads it. No member access, no destructuring,
- * no bracket read. `@objectstack/spec`'s FieldSchema does not declare it either,
- * so nothing authorable produces it.
+ * `getCellRenderer` dispatches into. Two keys had none, for two different
+ * reasons, and each retirement was its own adjudication.
  *
- * The control that makes that zero a reading, not an artefact of how the sweep
- * was written: the same sweep over its list-mates finds real readers for each of
- * them — `reference_to` / `reference` / `display_field` in `LookupCellRenderer`,
- * `id_field` / `description_field` / `lookup_filters` / `lookupFilters` in
- * `LookupField` / `UserField`. ⚠️ One exception, measured and deliberately NOT
- * acted on here: `titleFormat` has no FIELD-meta reader either — every reader
- * takes it off the OBJECT schema, which reaches the picker through
- * `useRefObjectSchema(reference_to)` (`plugin-dashboard/src/recordFields.tsx`
- * records the same measurement). Retiring it is a separate adjudication.
+ * ### `reference_to_field` — objectui#6711
+ *
+ * Swept across `packages/` and `apps/` (and again across the producer repo), the
+ * only occurrences of the identifier anywhere were this array literal — the
+ * write — and prose recording that nothing reads it. No member access, no
+ * destructuring, no bracket read. `@objectstack/spec`'s FieldSchema does not
+ * declare it either, so nothing authorable produces it.
+ *
+ * ### `titleFormat` — objectui#6874
+ *
+ * A zero of a different kind, and a stronger one. `titleFormat` is a real, live
+ * key with plenty of readers — it simply has no FIELD-meta reader. The sweep did
+ * not fail to find readers; it found every member read of the identifier across
+ * `packages/` and `apps/` (tests included) and classified each one by receiver:
+ *
+ *  - `objectDef` / `objectSchema` / `objSchema` — `core/utils/record-title.ts`,
+ *    `components/.../containers.tsx`, `plugin-detail/DetailView.tsx`,
+ *    `ObjectKanban.tsx`, `ObjectCalendar.tsx`, `react/hooks/useRecordSearch.ts`.
+ *    OBJECT schema, every one.
+ *  - `refObjectSchema?.titleFormat` — `fields/widgets/LookupField.tsx`: the
+ *    REFERENCED object's schema, fetched by `getSchema(referenceTo)`. Also an
+ *    OBJECT schema, and the one that matters here — it is what this grid's own
+ *    inline picker reads.
+ *  - `param.titleFormat` — `app-shell/utils/paramToField.ts`, off a resolved
+ *    `ActionParamDef`; the field-def read next to it is `field.title_format`,
+ *    a different spelling on a different surface.
+ *
+ * `RecordPickerDialog` and `lookupColumnDisplay` receive it as a PROP, and the
+ * repo's single `titleFormat=` pass is `titleFormat={refTitleFormat}` —
+ * object-schema sourced. ⇒ copying `reference_to` is what makes `titleFormat`
+ * work on this path; copying `titleFormat` onto the meta reached nothing.
+ * `plugin-dashboard/src/recordFields.tsx` recorded this same measurement first
+ * and declined to copy the key, so it was a measured no-op in two seams and had
+ * been retired from only one.
+ *
+ * ### The control that makes both zeros a reading
+ *
+ * Not an artefact of how the sweep was written: the same sweep over the
+ * surviving list-mates finds a real FIELD-meta reader for every one of them —
+ * `reference_to` / `reference` / `display_field` off the cell's `field` prop in
+ * `LookupCellRenderer` (`fields/src/index.tsx`), and `id_field` /
+ * `description_field` / `lookup_filters` / `lookupFilters` off `fieldMeta?.…`
+ * in `LookupField` / `UserField`. There is no third reader-less key: all seven
+ * survivors are read off a field meta.
  *
  * ⚠️ The sweep bounds these two repos. A host application outside them could
- * still be reading the key off `fieldMeta`; the repo's own contract is what this
- * retirement is about.
+ * still be reading either key off `fieldMeta`; the repo's own contract is what
+ * these retirements are about.
  *
  * ⛔ Do not re-add a key for symmetry with the object-schema field def. A
  * member written from the def on every column build and read by nothing is
  * exactly what objectui#6625 (`decimals`) and objectui#6597 (`referenceTo`)
  * retired from the sibling producer. Add a key when a reader on THIS path is
- * measured, not before. The absence is pinned in
- * `__tests__/relationalMetaCopySet-6711.test.tsx`.
+ * measured, not before. Both absences are pinned, at all three call sites —
+ * `__tests__/relationalMetaCopySet-6711.test.tsx` and
+ * `__tests__/relationalMetaCopySet-6874.test.tsx`.
  */
 const RELATIONAL_META_KEYS = [
   'reference_to', 'reference',
   'display_field', 'id_field', 'description_field',
-  'lookup_filters', 'lookupFilters', 'titleFormat',
+  'lookup_filters', 'lookupFilters',
 ] as const;
 
 /**

--- a/packages/plugin-grid/src/__tests__/relationalMetaCopySet-6874.test.tsx
+++ b/packages/plugin-grid/src/__tests__/relationalMetaCopySet-6874.test.tsx
@@ -1,17 +1,25 @@
 /**
- * objectui#6711 — `ObjectGrid`'s relational copy set must NOT carry
- * `reference_to_field`.
+ * objectui#6874 — `ObjectGrid`'s relational copy set must NOT carry
+ * `titleFormat`.
  *
  * ## ⚠️ Why this is a pin and not a behaviour test
  *
- * The retired key had ZERO readers anywhere in the repo, so removing it changes
- * no rendering at all: every other test in this package stays green whether or
- * not the removal is correct. A green suite therefore proves nothing here. What
- * CAN be asserted is the thing that was actually measured — the key is no
- * longer WRITTEN onto the `fieldMeta` a cell renderer receives — so this file
- * asserts that absence directly, at all three of `generateColumns`'s
- * column-building call sites, and goes red the moment the key is re-added to
- * `RELATIONAL_META_KEYS`.
+ * `titleFormat` is a real, live key — but it has ZERO readers on a FIELD meta.
+ * Every read of the identifier in this repo takes it off an OBJECT schema
+ * (`objectDef` / `objectSchema` / `objSchema` in `record-title.ts`,
+ * `containers.tsx`, `DetailView.tsx`, `ObjectKanban.tsx`, `ObjectCalendar.tsx`,
+ * `useRecordSearch.ts`), and the one that this grid's own inline picker uses is
+ * `refObjectSchema?.titleFormat` in `LookupField` — the REFERENCED object's
+ * schema, fetched by `getSchema(referenceTo)`. So `reference_to` is what makes
+ * `titleFormat` work on this path, and the copy reached nothing.
+ *
+ * Removing it therefore changes no rendering at all: every other test in this
+ * package stays green whether or not the removal is correct. A green suite
+ * proves nothing here. What CAN be asserted is the thing that was actually
+ * measured — the key is no longer WRITTEN onto the `fieldMeta` a cell renderer
+ * receives — so this file asserts that absence directly, at all three of
+ * `generateColumns`'s column-building call sites, and goes red the moment the
+ * key is re-added to `RELATIONAL_META_KEYS`.
  *
  * ## The control against vacuity lives in the same assertions
  *
@@ -26,6 +34,10 @@
  * how the real `LookupCellRenderer` receives this bag — `getCellRenderer` checks
  * the registry first — so what it captures is the `field` prop the shipped
  * renderer would have been handed.
+ *
+ * Same disposition, same list, same author path as objectui#6711, which retired
+ * `reference_to_field` from this array; that absence is pinned in
+ * `relationalMetaCopySet-6711.test.tsx`.
  */
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
@@ -43,12 +55,12 @@ import { ActionProvider, SchemaRendererProvider } from '@object-ui/react';
 
 registerAllFields();
 
-const OBJECT = 'os_6711_report';
+const OBJECT = 'os_6874_report';
 
 /**
  * One field def carrying EVERY relational key the grid has ever copied,
- * including the retired one. A def that omitted `reference_to_field` could not
- * tell "the grid stopped copying it" apart from "the fixture never offered it".
+ * including both retired ones. A def that omitted `titleFormat` could not tell
+ * "the grid stopped copying it" apart from "the fixture never offered it".
  */
 const MANAGER_DEF = {
   type: 'lookup',
@@ -60,12 +72,11 @@ const MANAGER_DEF = {
   description_field: 'title',
   lookup_filters: [['active', '=', true]],
   lookupFilters: [['active', '=', true]],
-  // Also retired, in objectui#6874, and pinned in its own file
-  // (`relationalMetaCopySet-6874.test.tsx`). Kept on the fixture so this file's
-  // survivor control stays a list of keys the grid really does still copy.
-  titleFormat: '{name}',
-  // The retired key (objectui#6711). Kept on the fixture on purpose.
-  reference_to_field: 'MUST_NOT_BE_COPIED',
+  // The key this file pins as retired (objectui#6874). Kept on the fixture on
+  // purpose — a def without it would make the assertion vacuous.
+  titleFormat: 'MUST_NOT_BE_COPIED',
+  // Retired earlier, in objectui#6711. Kept for the same reason.
+  reference_to_field: 'x',
 };
 
 /** The seven keys that survive both retirements — the control. */
@@ -131,11 +142,11 @@ async function renderAndCaptureMeta(schemaExtra: Record<string, any>) {
   );
   // ⚠️ Wait for the ENRICHED meta, not merely the first one. The object schema
   // arrives from an async fetch, so the first paint hands the renderer a bare
-  // `{ name, type }` — on which `not.toHaveProperty('reference_to_field')`
-  // passes for the wrong reason. `label` is the signal because it is written
-  // from the same `objectDefField` block, immediately BEFORE
-  // `applyRelationalMeta`, and is not itself one of the keys under test — so
-  // the wait cannot manufacture the assertions below.
+  // `{ name, type }` — on which `not.toHaveProperty('titleFormat')` passes for
+  // the wrong reason. `label` is the signal because it is written from the same
+  // `objectDefField` block, immediately BEFORE `applyRelationalMeta`, and is not
+  // itself one of the keys under test — so the wait cannot manufacture the
+  // assertions below.
   await waitFor(() => {
     expect(captured.length).toBeGreaterThan(0);
     expect(captured[captured.length - 1]).toHaveProperty('label');
@@ -154,11 +165,11 @@ const CALL_SITES: Array<[string, Record<string, any>]> = [
   ['inline data + fields projection', { fields: ['manager'] }],
 ];
 
-describe('objectui#6711 — ObjectGrid no longer copies `reference_to_field` onto fieldMeta', () => {
+describe('objectui#6874 — ObjectGrid no longer copies `titleFormat` onto fieldMeta', () => {
   for (const [name, schemaExtra] of CALL_SITES) {
     it(`does not copy it (${name})`, async () => {
       const meta = await renderAndCaptureMeta(schemaExtra);
-      expect(meta).not.toHaveProperty('reference_to_field');
+      expect(meta).not.toHaveProperty('titleFormat');
     });
 
     it(`still copies the seven surviving relational keys (${name})`, async () => {


### PR DESCRIPTION
Fixes #6874

Retires `titleFormat` from `ObjectGrid`'s `RELATIONAL_META_KEYS`, in the same shape objectui#6711 used for `reference_to_field` on this same list: remove the key, record the measurement in the docblock beside the list, pin the absence at all three call sites, add a changeset.

## What was measured

`applyRelationalMeta` copied eight keys off the object-schema field def onto every relational column's `fieldMeta`, at all three of `generateColumns`'s column-building call sites. `titleFormat` was one of them and has **zero readers on a FIELD meta**.

This is a different kind of zero from objectui#6711's, and a stronger one. `titleFormat` is a real, live key with many readers — it simply has none on a field meta. The sweep did not fail to find readers; it found **every** member read of the identifier across `packages/` and `apps/` (tests included) and classified each one by its receiver:

| Receiver | Sites | Surface |
|---|---|---|
| `objectDef` / `objectSchema` / `objSchema` | `core/utils/record-title.ts`, `components/renderers/layout/containers.tsx`, `plugin-detail/DetailView.tsx`, `plugin-kanban/ObjectKanban.tsx`, `plugin-calendar/ObjectCalendar.tsx`, `react/hooks/useRecordSearch.ts` | OBJECT schema |
| `refObjectSchema?.titleFormat` | `fields/widgets/LookupField.tsx:377` | OBJECT schema (the **referenced** object's, via `getSchema(referenceTo)`) |
| `param.titleFormat` | `app-shell/utils/paramToField.ts:181` | resolved `ActionParamDef` |

Zero field metas. `RecordPickerDialog` and `lookupColumnDisplay` take it as a **prop**, and the repo's single `titleFormat=` pass is `titleFormat={refTitleFormat}` in `LookupField` — object-schema sourced. So copying `reference_to` is what makes `titleFormat` work on this path, and copying `titleFormat` onto the meta reached nothing.

Note `app-shell/utils/resolveActionParams.ts:536` reads `field.title_format` — snake_case, a different spelling on a different surface — and its line 249 `titleFormat` is a key in the `RESOLVED_ONLY_PARAM_KEYS` diagnostic-message table, not a read.

`plugin-dashboard/src/recordFields.tsx` had already recorded this exact measurement as its reason for not copying the key into that seam, so the key was a measured no-op in two seams and had been retired from only one.

## Must-answer: is there a THIRD reader-less key? Enumeration, not examples

**No.** All seven surviving keys have a measured FIELD-meta reader. For each key, the reader and the surface it reads from:

| Key | FIELD-meta readers | Reads from | Reader-less? |
|---|---|---|---|
| `reference_to` | `fields/src/index.tsx:1941` (`LookupCellRenderer`, off the cell's `field` prop); `LookupField.tsx:256` (`fieldMeta?.reference_to`); `UserField.tsx:48` (`meta?.reference_to`) | FIELD meta | No |
| `reference` | `fields/src/index.tsx:1942`; `LookupField.tsx:256`; `UserField.tsx:48` | FIELD meta | No |
| `display_field` | `fields/src/index.tsx:1948`; `LookupField.tsx:252`; `UserField.tsx:49` | FIELD meta | No |
| `id_field` | `LookupField.tsx:254` (`fieldMeta?.id_field \|\| 'id'`) | FIELD meta | No |
| `description_field` | `LookupField.tsx:253` (`fieldMeta?.description_field ?? fieldMeta?.descriptionField`) | FIELD meta | No |
| `lookup_filters` | `LookupField.tsx:270`; `UserField.tsx:53` | FIELD meta | No |
| `lookupFilters` | `LookupField.tsx:270`; `UserField.tsx:53` (second arm of the same `??`) | FIELD meta | No |

The first three are read on the **cell** path (`getCellRenderer` to `LookupCellRenderer`); the last four on the **inline editor** path, which is what makes them earn their place on this grid but not on the read-only dashboard seam.

The same sweep is the control against a blind instrument: it found a real reader for every surviving key, so its zero for `titleFormat` is a reading, not an artefact.

### Reported, not acted on

- `lookup_filters` **and** `lookupFilters` are both on the list — one concept, two spellings, read at the same two sites as the two arms of a single `??`. That is this repo's `field || schema` shape (objectui#3233). Left alone here per dispatch; flagging for triage.
- The converse of this finding — keys the grid's own cell and picker read but never receive (`displayField`, `reference_field`, `descriptionField`, `lookup_columns`) — is already tracked as objectui#6875. Not duplicated.

## Behaviour is provably unchanged

Not merely believed — three independent legs:

1. **Static:** every member read of the identifier is enumerated above; none is on a field meta.
2. **Dynamic:** the only computed access to the meta bag anywhere in `@object-ui/fields` or `plugin-grid` is `applyRelationalMeta`'s own write (`fieldMeta[key] = fieldDef[key]`). No consumer bracket-reads or enumerates the bag (`Object.keys/entries/values` over it: zero hits), so there is no dynamic path by which the key's presence could reach a renderer.
3. **Falsifiability:** because a reader-less key changes no rendering, a green suite proves nothing — so the pin was reverse-verified. Re-adding `titleFormat` to the array turned the new pin **red in exactly the predicted way**: 3 failed / 3 passed, one failure per call site, with the survivor-presence controls staying green. Mutation confirmed on disk before the run (injected-text count 1, original 0, blob hash moved off the HEAD blob); restore confirmed after (`git diff HEAD` empty **and** hash back to the HEAD blob).

## Second item: two stale descriptions re-synced

objectui#6711 falsified these when it landed; both are **comments only**.

- `plugin-dashboard/src/recordFields.tsx` — the docblock enumerating `RELATIONAL_META_KEYS` as nine keys including `reference_to_field`, and "the grid's nine".
- `plugin-dashboard/src/__tests__/lookupRelationalMeta-6694.test.tsx` — "copies NINE keys" and the fixture comment "The six the grid also copies".

⛔ The **assertions** in that test are untouched and still pin the dashboard's own three-key boundary — the diff on that file is comment lines only. All six keys stay on its fixture on purpose: that seam's boundary does not move when the grid's list does.

`plugin-grid`'s own `relationalMetaCopySet-6711.test.tsx` needed its survivor control narrowed from eight keys to seven — that is the control set legitimately shrinking with the list it controls, the same edit objectui#6711 would have made to a predecessor.

## Verification

Run from the repo root (canonical invocation; no `--` before paths), heavy runs serialized through the shared verify lock.

| Check | Command | Result |
|---|---|---|
| New pin + updated pin | `pnpm exec vitest run packages/plugin-grid/src/__tests__/relationalMetaCopySet-6874.test.tsx packages/plugin-grid/src/__tests__/relationalMetaCopySet-6711.test.tsx` | 2 files, **12 passed** |
| Reverse verification | key re-added, same pin re-run | **3 failed / 3 passed** — one failure per call site, as predicted; restored and confirmed |
| plugin-grid (full) | `pnpm exec vitest run packages/plugin-grid/` | 100 files, **920 passed** |
| plugin-dashboard (full) + every `titleFormat` reader test | `pnpm exec vitest run packages/plugin-dashboard/ core/record-title{,.stepNumbering} fields/lookupCellDisplay{Name,Field} components/page-header-title react/useRecordSearch plugin-map/ObjectMap.markerTitle app-shell/paramToField types/object-schema-metadata-spec-derivation` | 93 files, **935 passed** |
| type-check | `pnpm --filter @object-ui/plugin-grid --filter @object-ui/plugin-dashboard type-check` | both `Done`, exit 0 |
| lint | `pnpm --filter @object-ui/plugin-grid --filter @object-ui/plugin-dashboard lint` | exit 0 — **0 errors** (419 + 706 pre-existing warnings) |
| changeset guard | `pnpm changeset:check` | `No changeset declares a major bump`, exit 0 |
| control bytes | `pnpm check:control-bytes` | `OK (scanned 5822 tracked text files)`, exit 0 |

All results above are from the final commit `aa20ab010`.

**The type-check genuinely covers the new test file.** `packages/plugin-grid/tsconfig.json` excludes `**/__tests__/**`, so a green `tsc --noEmit` alone would say nothing about it; the `type-check` script chains `tsc -p tsconfig.test.json`, and `--listFiles` on that project reports the new file as a program input (1 hit, out of 1757 program files). Confirmed rather than assumed.

**Lint narrowing, declared.** The repo-wide `pnpm lint` was not run; the two packages holding every changed file were linted in full instead. The narrowing is measured, not assumed: (1) the population comes from the repo's own wiring — `git diff --name-only` puts all changed files in exactly these two packages, and each package's `lint` script is `eslint .`, the same command CI's `turbo run lint` runs for them; (2) the counts are from full-package runs (419 and 706 problems), not a file subset; (3) `eslint.config.js` configures no type-aware linting (no `project` / `projectService` / `parserOptions.project`), so no rule reads cross-file type information and this diff cannot move the verdict on any file outside these two packages. CI runs the full farm regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_