### PR TITLE
refactor(test-support): one shared home for the Zod wrapper-key list

### DIFF
--- a/.changeset/shared-zod-wrapper-keys-6923.md
+++ b/.changeset/shared-zod-wrapper-keys-6923.md
@@ -1,0 +1,10 @@
+---
+---
+
+Internal only — no user-visible change, nothing to release.
+
+objectui#6923: the Zod wrapper-key list that five test/gate sites each spelled
+out by hand now lives once, in `packages/test-support` (a `private: true`,
+never-published package), and is read by both the TypeScript suites and the
+`.mjs` CI gates. Only test files, CI gate scripts and the private
+`test-support` package change; no released package's runtime code is touched.

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   "devDependencies": {
     "@changesets/cli": "^3.0.0",
     "@eslint/js": "^10.0.1",
+    "@object-ui/test-support": "workspace:*",
     "@objectstack/spec": "^17.0.0",
     "@playwright/test": "^1.62.1",
     "@testing-library/dom": "^10.4.1",

--- a/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts
@@ -32,6 +32,9 @@
 
 import { describe, it, expect } from 'vitest';
 import * as Automation from '@objectstack/spec/automation';
+// The Zod wrapper-key vocabulary — one list, read by the `.mjs` CI gates that
+// walk the same internals (objectui#6923, ruled 2026-08-31).
+import { ZOD_WRAPPER_KEYS } from '@object-ui/test-support';
 import { fieldsForNodeType, type FlowConfigField } from './flow-node-config';
 
 // Feature-detected exports — absent on a spec that predates framework#4278.
@@ -105,7 +108,7 @@ function objectShape(schema: unknown, depth = 0): Record<string, unknown> | null
   const def = (s._def ?? s.def) as Record<string, unknown> | undefined;
   if (!def) return null;
   if (def.shape) return def.shape as Record<string, unknown>;
-  for (const key of ['in', 'out', 'innerType', 'schema', 'left', 'right']) {
+  for (const key of ZOD_WRAPPER_KEYS) {
     const found = def[key] ? objectShape(def[key], depth + 1) : null;
     if (found) return found;
   }

--- a/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx
@@ -47,6 +47,9 @@ import * as React from 'react';
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import * as Automation from '@objectstack/spec/automation';
+// The Zod wrapper-key vocabulary — one list, read by the `.mjs` CI gates that
+// walk the same internals (objectui#6923, ruled 2026-08-31).
+import { ZOD_WRAPPER_KEYS } from '@object-ui/test-support';
 import { FlowCanvas } from './FlowCanvas';
 import { NODE_PALETTE, defaultNodeExtras, defaultNodeLabel } from './flow-canvas-parts';
 
@@ -121,7 +124,7 @@ function objectShape(schema: unknown, depth = 0): Record<string, ZodLike | undef
   const def = (s._def ?? s.def) as Record<string, unknown> | undefined;
   if (!def) return null;
   if (def.shape) return def.shape as Record<string, ZodLike | undefined>;
-  for (const key of ['in', 'out', 'innerType', 'schema', 'left', 'right']) {
+  for (const key of ZOD_WRAPPER_KEYS) {
     const found = def[key] ? objectShape(def[key], depth + 1) : null;
     if (found) return found;
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@object-ui/test-support": "workspace:*",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   },

--- a/packages/core/src/actions/__tests__/actionKeys.pin.test.ts
+++ b/packages/core/src/actions/__tests__/actionKeys.pin.test.ts
@@ -20,6 +20,9 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import ts from 'typescript';
 import { ActionSchema as SpecActionSchema } from '@objectstack/spec/ui';
+// The Zod wrapper-key vocabulary — one list, read by the `.mjs` CI gates that
+// walk the same internals (objectui#6923, ruled 2026-08-31).
+import { ZOD_WRAPPER_KEYS } from '@object-ui/test-support';
 import {
   ACTION_DEF_KEYS,
   SPEC_ACTION_KEYS,
@@ -73,7 +76,7 @@ function specActionKeys(): string[] {
     const def = (s._def ?? s.def) as Record<string, unknown> | undefined;
     if (!def) return null;
     if (def.shape) return shapeOf(def.shape);
-    for (const key of ['in', 'out', 'innerType', 'schema', 'left', 'right']) {
+    for (const key of ZOD_WRAPPER_KEYS) {
       const found = def[key] ? walk(def[key], depth + 1) : null;
       if (found) return found;
     }

--- a/packages/test-support/README.md
+++ b/packages/test-support/README.md
@@ -69,10 +69,35 @@ code imports — nothing in `src/` of a released package may import this.
   `packages/plugin-list/src/__tests__/add-record-position-spec-parity.test.tsx`,
   `packages/plugin-list/src/__tests__/user-filter-arity-spec-parity.test.tsx`
   and `packages/plugin-timeline/src/__tests__/timeline-scale-spec-parity.test.ts`.
-  No copy of this reader is left in-tree. The other Zod-internals reader classes
-  the same card censused — array-element unwrapping, the wrapper-key walk — are
-  NOT confined here yet and are still hand-copied; converting them is a separate
-  round, one reader class at a time.
+  No copy of this reader is left in-tree. Of the other Zod-internals reader
+  classes the same card censused, the wrapper-key list is now shared as DATA
+  (below); array-element unwrapping is NOT confined here yet and is still
+  hand-copied — converting it is a separate round, one reader class at a time.
+- `src/zod-wrapper-keys.json` + `src/zod-wrapper-keys.ts` — the Zod wrapper-key
+  vocabulary, exported as `ZOD_WRAPPER_KEYS` (objectui#6923, ruled 2026-08-31 —
+  objectui#5872 class (3)). The `.json` holds the data and the `.ts` holds the
+  reasoning; read the `.ts` header before touching either.
+
+  This is the one class whose copies had grown OUT of tests and into `.mjs` CI
+  gate scripts, so the class-(1) pattern above was unavailable across it: this
+  package's `exports["."]` is TypeScript source and a bare
+  `node scripts/check-*.mjs` has no build artefact to reach. The ruling gave the
+  DATA a build-free home and a subpath of its own, and drew a boundary around
+  it — **the walks stay with their callers**. They are not identical
+  (`check-designer-field-key-parity.mjs` reads `node._def ?? node.def ??
+  node._zod?.def`; `check-action-forward-parity.mjs` reads `s._def ?? s.def`),
+  and sharing a FUNCTION across the language boundary is explicitly outside that
+  ruling. Consumed by those two gates plus
+  `packages/core/src/actions/__tests__/actionKeys.pin.test.ts`,
+  `packages/app-shell/src/views/metadata-admin/inspectors/flow-node-config.spec-reconciliation.test.ts`
+  and `packages/app-shell/src/views/metadata-admin/previews/flow-canvas-seeds.spec-parse.test.tsx`.
+  No copy of the list is left in-tree.
+- `src/__tests__/zod-wrapper-keys.test.ts` — the surface half: the module is the
+  JSON verbatim, it is non-empty, and it reaches consumers through the package
+  index rather than a deep path. The half that carries the discrimination is
+  `scripts/__tests__/zod-wrapper-keys.shared.test.ts`, which drives one fixture
+  per key through **both** `.mjs` gates' real entry points, so emptying the list
+  — or dropping a single entry — turns them red instead of quietly permissive.
 - `src/__tests__/spec-enum-options.test.ts` — the calibration for that reader:
   one synthetic fixture per wrapper spelling it claims to walk (bare enum,
   `.optional()`, `.default()`, a stack, and a `lazySchema()` thunk), the `[]`
@@ -87,7 +112,15 @@ code imports — nothing in `src/` of a released package may import this.
 
 - Consumers add `"@object-ui/test-support": "workspace:*"` to
   **`devDependencies`** — never `dependencies`, since no consumer ships it.
-- Import the package root (`@object-ui/test-support`), never a deep path.
+- Import the package root (`@object-ui/test-support`), never a deep path. The
+  single exception is `@object-ui/test-support/zod-wrapper-keys`, a declared
+  `exports` subpath pointing straight at a `.json` file. It exists because a
+  bare-node CI gate has no other way in, it carries DATA only, and it was ruled
+  (objectui#6923) rather than assumed. It does not license a second one — a
+  TypeScript consumer has the package root and must use it.
 - There is no build: consumers resolve the TypeScript source through the
   `exports` map. `pnpm --filter @object-ui/test-support type-check` reads both
   the modules and their tests in one program.
+- The workspace ROOT declares this package too, so that `node scripts/*.mjs`
+  can resolve the subpath above from `scripts/`. That root entry is what makes
+  the bare specifier work; a gate importing it without it fails at module load.

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -11,7 +11,8 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
-    }
+    },
+    "./zod-wrapper-keys": "./src/zod-wrapper-keys.json"
   },
   "scripts": {
     "type-check": "tsc --noEmit",

--- a/packages/test-support/src/__tests__/zod-wrapper-keys.test.ts
+++ b/packages/test-support/src/__tests__/zod-wrapper-keys.test.ts
@@ -1,0 +1,56 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { ZOD_WRAPPER_KEYS } from '../zod-wrapper-keys';
+import rawJson from '../zod-wrapper-keys.json';
+import * as surface from '../index';
+
+/**
+ * objectui#6923 — the TypeScript half of the two-language list.
+ *
+ * The `.mjs` half, and the counter-example that makes the whole thing worth
+ * having, live in `scripts/__tests__/zod-wrapper-keys.shared.test.ts`: this file
+ * cannot import a CI gate without dragging `typescript` and the repo root into a
+ * package's own suite. That file also owns the ON-DISK byte comparison, because
+ * this package's `tsc` program has no `@types/node` and so no `node:fs` — which
+ * is why the equality below is against the imported JSON rather than the file.
+ *
+ * What is pinned here is the surface: the re-export chain does not TRANSFORM the
+ * list on its way to a TypeScript consumer, and consumers reach it through the
+ * package index rather than a deep path.
+ */
+
+describe('ZOD_WRAPPER_KEYS', () => {
+  it('re-exports the JSON data file unchanged — one source, not a copy that agrees', () => {
+    // Not `toBe`: the assertion is about VALUE, so that a later decision to
+    // freeze or copy the array in `zod-wrapper-keys.ts` does not read as drift.
+    // What must never change is the content or the order.
+    expect([...ZOD_WRAPPER_KEYS]).toEqual(rawJson);
+  });
+
+  it('is non-empty — the one property an "both sides agree" test cannot see', () => {
+    // An empty list satisfies every equality assertion in this file. It is also
+    // the measured failure mode (PR #6047: three of four parity gates stayed
+    // GREEN on an empty vocabulary). The load-bearing half of this pin is in
+    // `scripts/__tests__/zod-wrapper-keys.shared.test.ts`, which drives one
+    // fixture per key through both gates; this is the cheap floor under it.
+    expect(ZOD_WRAPPER_KEYS.length).toBeGreaterThan(0);
+    expect(ZOD_WRAPPER_KEYS.every((k) => typeof k === 'string' && k.length > 0)).toBe(true);
+  });
+
+  it('is on the package surface, so consumers import the package and not a deep path', () => {
+    // objectui#4325: a deep subpath into another package resolved only through
+    // this repo's vitest alias, was TS2882 for `tsc`, and was ruled out rather
+    // than minted as permanent API. The `.json` subpath added for objectui#6923
+    // is the deliberate, narrow exception — it exists because bare `node` has no
+    // other way in — and it does not license a second one for TypeScript.
+    expect(surface.ZOD_WRAPPER_KEYS).toBe(ZOD_WRAPPER_KEYS);
+  });
+});

--- a/packages/test-support/src/index.ts
+++ b/packages/test-support/src/index.ts
@@ -42,3 +42,13 @@ export {
 } from './spec-tombstones';
 
 export { shapeEnumOptions } from './spec-enum-options';
+
+/**
+ * The Zod wrapper-key vocabulary (objectui#6923). The DATA lives in
+ * `zod-wrapper-keys.json` so that `node scripts/check-*.mjs` can read the same
+ * bytes through `@object-ui/test-support/zod-wrapper-keys` — the one thing this
+ * package's `.` entry, being TypeScript source, cannot offer a bare-node
+ * consumer. `zod-wrapper-keys.ts` carries the reasoning; read it before
+ * touching either side.
+ */
+export { ZOD_WRAPPER_KEYS } from './zod-wrapper-keys';

--- a/packages/test-support/src/zod-wrapper-keys.json
+++ b/packages/test-support/src/zod-wrapper-keys.json
@@ -1,0 +1,1 @@
+["in", "out", "innerType", "schema", "left", "right"]

--- a/packages/test-support/src/zod-wrapper-keys.ts
+++ b/packages/test-support/src/zod-wrapper-keys.ts
@@ -1,0 +1,92 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ZOD WRAPPER KEYS — the one literal list both language sides read
+ * (objectui#6923, ruled 2026-08-31; objectui#5872 class (3)).
+ *
+ * ## What the list is
+ *
+ * The `_def` / `def` member names a Zod node exposes for the schema it wraps.
+ * Walking them is how a reader gets from a wrapped node — a pipe, an effect, a
+ * refinement, an `.optional()` — down to the object `shape` underneath. Nothing
+ * here is a judgement: it is a vocabulary, transcribed from Zod's internals.
+ * The walk that consumes it stays with each caller (see the boundary below).
+ *
+ * ## Why it needed a home of its own, and not the usual one
+ *
+ * The copies had grown OUT of TypeScript and into `.mjs` CI gate scripts, so
+ * they now span a language boundary. `@object-ui/test-support` is `private:
+ * true` and its `exports["."]` resolves to `./src/index.ts` — TypeScript
+ * SOURCE — so a bare `node scripts/check-*.mjs` cannot import it and there is
+ * no build artefact for it to reach. That is the wall objectui#6923 was filed
+ * to get a ruling on, and the ruling's answer is this file's shape:
+ *
+ *   - the data lives in `zod-wrapper-keys.json`, which needs no build step and
+ *     no declaration file — `resolveJsonModule` types it for every TypeScript
+ *     consumer, and `node` reads it through the `exports` subpath directly;
+ *   - `@object-ui/test-support/zod-wrapper-keys` is that subpath, which is what
+ *     the two `.mjs` gates import (the workspace root declares the package as a
+ *     devDependency so the bare specifier resolves from `scripts/`);
+ *   - this module re-exports it for the TypeScript side, typed and documented,
+ *     and `index.ts` carries it onto the package surface.
+ *
+ * A `.mjs` data module was the other shape the ruling allowed, and was measured
+ * and rejected: `index.ts` re-exporting from a `.mjs` is TS7016 in every
+ * CONSUMER's program (the root config sets `allowJs: false`), so it would have
+ * cost either `allowJs` in each of the nine dependent packages or a hand-written
+ * `.d.mts` — the "second source of truth, free to drift silently" that
+ * `tsconfig.scripts.json`'s header already argues against. JSON has neither
+ * cost. The price JSON does charge is that it cannot carry its own prose, which
+ * is why this module exists rather than a bare re-export.
+ *
+ * ## The boundary — DATA only (part of the ruling, not a preference)
+ *
+ * The ruling covers the LIST. It deliberately does not open a door for sharing
+ * a function across the `.mjs` / TypeScript boundary: each caller keeps its own
+ * walk, and the walks are legitimately not identical — the designer gate reads
+ * `node._def ?? node.def ?? node._zod?.def` where the action gate reads
+ * `s._def ?? s.def`. Consolidating THOSE is a separate question that needs its
+ * own ruling on its own terms; do not fold it in here.
+ *
+ * ## Non-vacuity — the duty this list leaves with its callers
+ *
+ * The failure this list exists to prevent is not "the copies disagree", it is
+ * what a disagreeing copy DOES: a walk that stops matching returns no shape,
+ * the vocabulary derived from it becomes the empty set, and every "the renderer
+ * implements every name the spec accepts" assertion built on it passes over
+ * nothing. Measured on this exact family in PR #6047: on an empty vocabulary,
+ * three of four parity gates stayed GREEN.
+ *
+ * So a caller owes an assertion that separates "resolved a shape" from
+ * "resolved nothing". Both `.mjs` gates already pay it — they raise
+ * `ExtractionError` rather than return an empty key set — and
+ * `scripts/__tests__/zod-wrapper-keys.shared.test.ts` pins the other half: that
+ * EVERY entry here is load-bearing, one fixture per key, so emptying this list
+ * (or deleting a single entry) turns those gates red instead of quiet.
+ *
+ * ⚠️ That pin is deliberately driven from fixtures, not from whatever
+ * `@objectstack/spec` currently ships. Measured on `@objectstack/spec@17.2.0`:
+ * `ui.ActionSchema` and `automation.FlowNodeSchema` are reachable ONLY through
+ * a wrapper key, but `data.FieldSchema` and `data.ObjectSchema` expose `.shape`
+ * at depth 0 — so a counter-test anchored on the installed schemas would be
+ * vacuous for the designer gate today, and could go vacuous for the others the
+ * next time upstream unwraps something. Fixtures cannot rot that way.
+ */
+
+import keys from './zod-wrapper-keys.json';
+
+/**
+ * The `_def` / `def` member names to walk when unwrapping a Zod node, in the
+ * order every in-tree reader has always tried them.
+ *
+ * `readonly` because it is a vocabulary, not a working array: a caller that
+ * wants to filter or reorder should copy it. The `.mjs` gates read the same
+ * bytes through `@object-ui/test-support/zod-wrapper-keys`.
+ */
+export const ZOD_WRAPPER_KEYS: readonly string[] = keys;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.1(jiti@2.7.0))
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:packages/test-support
       '@objectstack/spec':
         specifier: ^17.0.0
         version: 17.2.0(ai@7.0.65(zod@4.4.3))
@@ -1202,6 +1205,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/scripts/__tests__/zod-wrapper-keys.shared.test.ts
+++ b/scripts/__tests__/zod-wrapper-keys.shared.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS CI helpers. Types are INFERRED from the .mjs sources by
+// `tsconfig.scripts.json` (`allowJs`) — see objectui#3494 and that file's header.
+import { specShapeKeys, ExtractionError } from '../check-action-forward-parity.mjs';
+import { schemaAcceptSet } from '../check-designer-field-key-parity.mjs';
+
+/**
+ * objectui#6923 — the counter-example the ruling asks for, in the shape it asks
+ * for it.
+ *
+ * ## What was consolidated, and what deliberately was not
+ *
+ * One literal Zod wrapper-key list — `['in', 'out', 'innerType', 'schema',
+ * 'left', 'right']` — had five copies: three TypeScript test files and two
+ * `.mjs` CI gates. The copies spanned a language boundary, so the
+ * objectui#5872 class-(1) pattern (consolidate onto `@object-ui/test-support`)
+ * was unavailable: that package's `exports["."]` is TypeScript SOURCE, and a
+ * bare `node scripts/check-*.mjs` cannot import it.
+ *
+ * The 2026-08-31 ruling gave the DATA a build-free home
+ * (`packages/test-support/src/zod-wrapper-keys.json`, reachable as
+ * `@object-ui/test-support/zod-wrapper-keys`) and drew an explicit boundary
+ * around it: the WALKS stay with their callers. They are not even identical —
+ * the designer gate reads `node._def ?? node.def ?? node._zod?.def` where the
+ * action gate reads `s._def ?? s.def` — and unifying THOSE needs its own ruling.
+ * So this file tests the two walks THROUGH THEIR OWN PUBLIC ENTRY POINTS rather
+ * than testing a shared function, because there is no shared function.
+ *
+ * ## Why "both sides import the same list" is not the test
+ *
+ * That assertion passes just as well when the list is EMPTY. And an empty list
+ * is precisely the failure this family has already been measured producing: on
+ * an empty vocabulary in PR #6047's ablation, the "spec accepts a name we do not
+ * implement" half of three of four parity gates stayed GREEN, because it filters
+ * an empty list. A gate that silently stops matching is that failure with CI's
+ * authority behind it.
+ *
+ * So the ruling's constraint 4 is what this file pays: **empty the list and the
+ * gate must go red.** Two halves, and the second is what makes it true:
+ *
+ *   1. every key in the list is LOAD-BEARING — one fixture per key, reachable
+ *      only through that key, driven through each gate's real entry point. Empty
+ *      the list, or delete any single entry, and these fail by name;
+ *   2. an unlisted wrapper spelling is LOUD — `ExtractionError`, never a clean
+ *      empty verdict. That is the drift scenario itself: Zod moves a spelling,
+ *      the list stops matching, and the gate must say so rather than derive an
+ *      empty vocabulary and pass everything.
+ *
+ * ## Why fixtures and not the installed spec
+ *
+ * Measured against `@objectstack/spec@17.2.0` while writing this: with the
+ * wrapper list emptied, `ui.ActionSchema` and `automation.FlowNodeSchema` become
+ * unreachable (the walk returns null — the gates raise), but `data.FieldSchema`
+ * and `data.ObjectSchema` still resolve 71 and 42 keys, because those two expose
+ * `.shape` at depth 0 and never need a wrapper hop at all.
+ *
+ * A counter-test anchored on the installed schemas would therefore be VACUOUS
+ * for the designer gate today, and could go vacuous for the others the next time
+ * upstream unwraps something — silently, which is the whole complaint. Fixtures
+ * cannot rot that way: this file constructs nodes whose shape is reachable ONLY
+ * through the wrapper key under test, so the discrimination is guaranteed by
+ * construction rather than borrowed from a dependency.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const DATA_FILE = path.join(repoRoot, 'packages/test-support/src/zod-wrapper-keys.json');
+
+/** The list as it sits on disk — the bytes both language sides resolve to. */
+const onDisk: string[] = JSON.parse(readFileSync(DATA_FILE, 'utf8'));
+
+/**
+ * A node whose object shape is reachable ONLY by stepping through `key`.
+ *
+ * `shape` is deliberately not at the top level and not on `_def` directly: both
+ * walks check those first and would answer without consulting the vocabulary at
+ * all, which would make every assertion below pass with the list emptied.
+ */
+const wrappedIn = (key: string) => ({ _def: { [key]: { shape: { alpha: 1, beta: 2 } } } });
+
+const SHAPE_KEYS = ['alpha', 'beta'];
+
+describe('the shared Zod wrapper-key list (objectui#6923)', () => {
+  it('is a non-empty list of strings', () => {
+    expect(Array.isArray(onDisk)).toBe(true);
+    expect(onDisk.length).toBeGreaterThan(0);
+    expect(onDisk.every((k) => typeof k === 'string' && k.length > 0)).toBe(true);
+  });
+
+  it('still carries every spelling the five former hand copies walked', () => {
+    // The membership the copies agreed on the day they were consolidated.
+    // Growing this list is expected; SHRINKING it is the drift, and the
+    // load-bearing tests below are what make a shrink fail rather than go quiet.
+    expect(onDisk).toEqual(['in', 'out', 'innerType', 'schema', 'left', 'right']);
+  });
+
+  it('is what the package `exports` subpath resolves to, so `node` reads these bytes', () => {
+    const manifest = JSON.parse(
+      readFileSync(path.join(repoRoot, 'packages/test-support/package.json'), 'utf8'),
+    );
+    // The mechanism the ruling named: a subpath pointing straight at the data
+    // file, so a bare-node gate resolves it without a build step. If this moves,
+    // the two `.mjs` gates stop resolving and CI says so — but it says so as a
+    // module-not-found deep in a gate run, which is a poor way to learn it.
+    expect(manifest.exports['./zod-wrapper-keys']).toBe('./src/zod-wrapper-keys.json');
+    expect(manifest.private).toBe(true);
+  });
+});
+
+describe('constraint 4 — emptying the list must turn the gates RED, not quiet', () => {
+  describe('check-action-forward-parity.mjs', () => {
+    it.each(onDisk)('resolves a shape reachable only through `%s`', (key) => {
+      expect(specShapeKeys(wrappedIn(key), 'fixture')).toEqual(SHAPE_KEYS);
+    });
+
+    it('raises on a wrapper spelling the list does not carry', () => {
+      // Not `toThrow()` alone: the gate's own error type is the contract, and a
+      // bare throw would be satisfied by any incidental TypeError.
+      expect(() => specShapeKeys(wrappedIn('bogusWrapper'), 'fixture')).toThrow(ExtractionError);
+      expect(() => specShapeKeys(wrappedIn('bogusWrapper'), 'fixture')).toThrow(
+        /could not resolve `fixture`'s shape/,
+      );
+    });
+  });
+
+  describe('check-designer-field-key-parity.mjs', () => {
+    // Reached through the gate's own `importSpec` seam, so the walk under test
+    // is the one the gate really runs — this gate keeps its walk module-private
+    // and the ruling's boundary says to leave it there.
+    const acceptSetFor = (node: unknown) =>
+      schemaAcceptSet('FieldSchema', async () => ({ FieldSchema: node }));
+
+    it.each(onDisk)('resolves a shape reachable only through `%s`', async (key) => {
+      const { accept } = await acceptSetFor(wrappedIn(key));
+      expect([...accept]).toEqual(SHAPE_KEYS);
+    });
+
+    it('raises on a wrapper spelling the list does not carry', async () => {
+      await expect(acceptSetFor(wrappedIn('bogusWrapper'))).rejects.toThrow(
+        /could not resolve `FieldSchema`'s shape/,
+      );
+    });
+  });
+});

--- a/scripts/__tests__/zod-wrapper-keys.shared.test.ts
+++ b/scripts/__tests__/zod-wrapper-keys.shared.test.ts
@@ -110,38 +110,60 @@ describe('the shared Zod wrapper-key list (objectui#6923)', () => {
   });
 });
 
+/**
+ * ⚠️ The per-key checks below are ONE test that loops, not `it.each(onDisk)`.
+ *
+ * That distinction was measured, not stylistic. `it.each` over the list under
+ * test generates its cases FROM that list, so with the list emptied it
+ * generates NONE — the suite reports fewer tests and stays green on the part
+ * that matters. Running this file's own ablation caught it: emptied, the
+ * `it.each` legs simply vanished and only the membership pins failed. That is
+ * this card's defect reproduced inside its own counter-example.
+ *
+ * A loop inside one test, with the non-vacuity floor asserted IN THE SAME TEST,
+ * cannot go quiet that way: no data, no cases, but the floor still fails.
+ */
 describe('constraint 4 — emptying the list must turn the gates RED, not quiet', () => {
-  describe('check-action-forward-parity.mjs', () => {
-    it.each(onDisk)('resolves a shape reachable only through `%s`', (key) => {
+  it('check-action-forward-parity: every entry in the list is load-bearing', () => {
+    expect(onDisk.length).toBeGreaterThan(0);
+    for (const key of onDisk) {
+      // A shape reachable ONLY by stepping through `key`. Drop `key` from the
+      // list and this throws instead of resolving.
       expect(specShapeKeys(wrappedIn(key), 'fixture')).toEqual(SHAPE_KEYS);
-    });
-
-    it('raises on a wrapper spelling the list does not carry', () => {
-      // Not `toThrow()` alone: the gate's own error type is the contract, and a
-      // bare throw would be satisfied by any incidental TypeError.
-      expect(() => specShapeKeys(wrappedIn('bogusWrapper'), 'fixture')).toThrow(ExtractionError);
-      expect(() => specShapeKeys(wrappedIn('bogusWrapper'), 'fixture')).toThrow(
-        /could not resolve `fixture`'s shape/,
-      );
-    });
+    }
   });
 
-  describe('check-designer-field-key-parity.mjs', () => {
-    // Reached through the gate's own `importSpec` seam, so the walk under test
-    // is the one the gate really runs — this gate keeps its walk module-private
-    // and the ruling's boundary says to leave it there.
-    const acceptSetFor = (node: unknown) =>
-      schemaAcceptSet('FieldSchema', async () => ({ FieldSchema: node }));
+  it('check-action-forward-parity: raises on a wrapper spelling the list does not carry', () => {
+    // Not `toThrow()` alone: the gate's own error type is the contract, and a
+    // bare throw would be satisfied by any incidental TypeError.
+    expect(() => specShapeKeys(wrappedIn('bogusWrapper'), 'fixture')).toThrow(ExtractionError);
+    expect(() => specShapeKeys(wrappedIn('bogusWrapper'), 'fixture')).toThrow(
+      /could not resolve `fixture`'s shape/,
+    );
+  });
 
-    it.each(onDisk)('resolves a shape reachable only through `%s`', async (key) => {
+  // The designer gate keeps its walk module-private, and the ruling's boundary
+  // says to leave it there — so it is reached through the gate's OWN
+  // `importSpec` seam, which means the walk under test is the one it really runs.
+  const acceptSetFor = (node: unknown) =>
+    schemaAcceptSet('FieldSchema', async () => ({ FieldSchema: node }));
+
+  it('check-designer-field-key-parity: every entry in the list is load-bearing', async () => {
+    expect(onDisk.length).toBeGreaterThan(0);
+    for (const key of onDisk) {
       const { accept } = await acceptSetFor(wrappedIn(key));
       expect([...accept]).toEqual(SHAPE_KEYS);
-    });
+    }
+  });
 
-    it('raises on a wrapper spelling the list does not carry', async () => {
-      await expect(acceptSetFor(wrappedIn('bogusWrapper'))).rejects.toThrow(
-        /could not resolve `FieldSchema`'s shape/,
-      );
-    });
+  it('check-designer-field-key-parity: raises on a wrapper spelling the list does not carry', async () => {
+    // ⭐ This gate is the reason the whole file uses fixtures. With the list
+    // emptied, the gate's REAL run stays GREEN — measured — because
+    // `data.FieldSchema` and `data.ObjectSchema` expose `.shape` at depth 0 and
+    // never need a wrapper hop. A counter-test anchored on the installed spec
+    // would therefore assert nothing here; this one still fails.
+    await expect(acceptSetFor(wrappedIn('bogusWrapper'))).rejects.toThrow(
+      /could not resolve `FieldSchema`'s shape/,
+    );
   });
 });

--- a/scripts/check-action-forward-parity.mjs
+++ b/scripts/check-action-forward-parity.mjs
@@ -129,6 +129,28 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { isEntrypoint } from "./invoked-as.mjs";
 
+/**
+ * The wrapper-key vocabulary, shared with the TypeScript readers that walk the
+ * same Zod internals (objectui#6923, ruled 2026-08-31 — objectui#5872 class (3)).
+ *
+ * A bare-node gate cannot import `@object-ui/test-support` itself: that entry is
+ * TypeScript source with no build artefact. `/zod-wrapper-keys` is the subpath
+ * the ruling gave the DATA — build-free JSON — so both language sides read the
+ * same bytes. The WALK stays local on purpose: sharing a FUNCTION across this
+ * boundary is explicitly outside that ruling.
+ *
+ * `createRequire` rather than `import ... with { type: "json" }`, and the
+ * difference is load-bearing: this module is imported BOTH by `node` (the gate
+ * run) and by Vite's SSR transform (its pin tests in `scripts/__tests__/`).
+ * Measured — under the SSR transform the attributed JSON import yields no
+ * default export, and the walk fails with "__vite_ssr_import_N__.default is not
+ * iterable" instead of reading the list. `createRequire` is the same idiom
+ * `loadSpecSchemas` below already uses, and behaves identically in both.
+ */
+const ZOD_WRAPPER_KEYS = createRequire(import.meta.url)(
+  "@object-ui/test-support/zod-wrapper-keys"
+);
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
 
@@ -354,7 +376,7 @@ export function specShapeKeys(schema, label) {
     const def = s._def ?? s.def;
     if (!def) return null;
     if (def.shape) return shapeOf(def.shape);
-    for (const key of ["in", "out", "innerType", "schema", "left", "right"]) {
+    for (const key of ZOD_WRAPPER_KEYS) {
       const found = def[key] ? walk(def[key], depth + 1) : null;
       if (found) return found;
     }

--- a/scripts/check-designer-field-key-parity.mjs
+++ b/scripts/check-designer-field-key-parity.mjs
@@ -135,6 +135,28 @@ import { resolve, dirname } from "path";
 import { fileURLToPath } from "url";
 import { isEntrypoint } from "./invoked-as.mjs";
 
+/**
+ * The wrapper-key vocabulary, shared with the TypeScript readers that walk the
+ * same Zod internals (objectui#6923, ruled 2026-08-31 — objectui#5872 class (3)).
+ *
+ * A bare-node gate cannot import `@object-ui/test-support` itself: that entry is
+ * TypeScript source with no build artefact. `/zod-wrapper-keys` is the subpath
+ * the ruling gave the DATA — build-free JSON — so both language sides read the
+ * same bytes. The WALK stays local on purpose: sharing a FUNCTION across this
+ * boundary is explicitly outside that ruling.
+ *
+ * `createRequire` rather than `import ... with { type: "json" }`, and the
+ * difference is load-bearing: this module is imported BOTH by `node` (the gate
+ * run) and by Vite's SSR transform (its pin tests in `scripts/__tests__/`).
+ * Measured — under the SSR transform the attributed JSON import yields no
+ * default export, and the walk fails with "__vite_ssr_import_N__.default is not
+ * iterable" instead of reading the list. `createRequire` is the same idiom
+ * `loadSpecSchemas` below already uses, and behaves identically in both.
+ */
+const ZOD_WRAPPER_KEYS = createRequire(import.meta.url)(
+  "@object-ui/test-support/zod-wrapper-keys"
+);
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
 
@@ -374,7 +396,7 @@ function shapeKeys(node, depth = 0, seen = new Set()) {
   const def = node._def ?? node.def ?? node._zod?.def;
   if (!def) return null;
   if (def.shape) return shapeOf(def.shape);
-  for (const key of ["in", "out", "innerType", "schema", "left", "right"]) {
+  for (const key of ZOD_WRAPPER_KEYS) {
     const found = def[key] ? shapeKeys(def[key], depth + 1, seen) : null;
     if (found) return found;
   }


### PR DESCRIPTION
Fixes #6923

Implements the 2026-08-31 ruling — option **B narrowed to data only**. The five numbered constraints are each answered below; constraint 4 is the one that carries the weight, and it changed the shape of the test twice.

## What the census actually found

The dispatch flagged its own census as incomplete and told me not to inherit it. Re-derived on `origin/main`, the literal list `['in','out','innerType','schema','left','right']` had **exactly five** copies:

| site | language |
|:--|:--|
| `scripts/check-action-forward-parity.mjs` | `.mjs` gate |
| `scripts/check-designer-field-key-parity.mjs` | `.mjs` gate |
| `packages/core/src/actions/__tests__/actionKeys.pin.test.ts` | TS |
| `packages/app-shell/.../inspectors/flow-node-config.spec-reconciliation.test.ts` | TS |
| `packages/app-shell/.../previews/flow-canvas-seeds.spec-parse.test.tsx` | TS |

The PM's zero-hit probe for single-quoted `'innerType'` is **falsified** — three of those sites spell it that way. The other `innerType` hits in the tree are single-spelling walks (`while (cur?._def?.innerType)`), not this list, and are deliberately left alone: they are a different reader class.

After this change the literal list exists in **one** place; a repo-wide grep for the pattern returns zero other hits.

## The shape

- `packages/test-support/src/zod-wrapper-keys.json` — the data. Zero build step.
- `packages/test-support/src/zod-wrapper-keys.ts` — the reasoning, and the typed `ZOD_WRAPPER_KEYS` the TypeScript side reads. `index.ts` re-exports it (constraint 3).
- `exports` gains `"./zod-wrapper-keys": "./src/zod-wrapper-keys.json"` (constraint 2). `private: true` unchanged.

### Two decisions the ruling left open, and why they went this way

**JSON, not `.mjs`.** Both were allowed. `.mjs` was rejected on a measurement: `index.ts` re-exporting from a `.mjs` is TS7016 in every **consumer's** program (the root config sets `allowJs: false`), so it would have cost either `allowJs` in each of the nine dependent packages or a hand-written `.d.mts` — the "second source of truth, free to drift silently" that `tsconfig.scripts.json`'s own header already argues against. `resolveJsonModule` is already on repo-wide, so JSON types itself with no declaration file and no build. Verified: `--listFiles` shows `zod-wrapper-keys.ts` inside both `@object-ui/core`'s and `@object-ui/app-shell`'s type-check programs, with no `allowJs` anywhere.

**⚠️ The ruling's parenthetical was not true yet, and this PR makes it true.** Constraint 2 says the subpath works because "pnpm workspace 链接使 `node scripts/check-*.mjs` 可直接解析". Measured: `@object-ui/test-support` was a devDependency of nine packages but **not of the workspace root**, so there was no `node_modules/@object-ui` at the root and the bare specifier resolved from nowhere in `scripts/`. Adding it to root `devDependencies` is what creates the link. That is the mechanism the ruling names, so it is in scope; flagging it because it is a manifest change the card did not anticipate. `check:phantom-deps` documents this exact root-declaration allowance for tooling imports and stays green. `packages/core` also had to declare the package (its sibling consumers already did).

**`createRequire`, not `import … with { type: "json" }`.** Load-bearing, and measured: these gate modules are imported both by `node` (the gate run) and by Vite's SSR transform (their own pin tests). Under the latter the attributed JSON import yields no default export and the walk dies with `__vite_ssr_import_N__.default is not iterable`. `createRequire` is the idiom `loadSpecSchemas` in the same file already uses.

## Constraint 4 — the counter-example, and the two things it caught

⭐ A test that only proves "both sides import the same list" passes just as well when the list is empty. `scripts/__tests__/zod-wrapper-keys.shared.test.ts` drives **one fixture per key** through each gate's real entry point (`specShapeKeys`; and `schemaAcceptSet`'s own `importSpec` seam, since that gate keeps its walk private and the ruling says to leave it there), plus a negative: an unlisted wrapper spelling must raise `ExtractionError`, never return a clean empty verdict.

**Why fixtures and not the installed spec — this is the finding that decided the design.** Measured against `@objectstack/spec@17.2.0`, walking with the list emptied:

| schema | real list | emptied | wrapper keys load-bearing? |
|:--|:--|:--|:--|
| `ui.ActionSchema` | 45 keys | `null` | **yes** |
| `automation.FlowNodeSchema` | 11 keys | `null` | **yes** |
| `data.FieldSchema` | 71 keys | 71 keys | **no** |
| `data.ObjectSchema` | 42 keys | 42 keys | **no** |

`FieldSchema`/`ObjectSchema` expose `.shape` at depth 0 and never need a wrapper hop. So a counter-test anchored on the installed schemas would be **vacuous for the designer gate today**, and could go vacuous for the others the next time upstream unwraps something — silently, which is the whole complaint. Fixtures cannot rot that way.

### The ablation, and the defect it found in the counter-test itself

Emptying `zod-wrapper-keys.json` to `[]` (mutation confirmed on disk: `innerType` count 0, `[]` count 1, blob `2aac729c` → `fe51488c`), on the committed implementation:

```
check:action-forward-parity      EXIT=1   ❌ could not resolve `ActionSchema`'s shape
check:designer-field-key-parity  EXIT=0   ← green, exactly as the table predicts
vitest (8 files)                 EXIT=1   5 files failed, 12 tests failed
```

Restore verified by observation, not exit code: `git hash-object` back to `2aac729c` (= the HEAD blob) and `git diff HEAD` empty.

**The first ablation run found a real defect in this PR's own test.** The per-key checks were written as `it.each(onDisk)` — which generates its cases *from the list under test*, so with the list emptied it generated **none**. The suite reported fewer tests and stayed green on precisely the part carrying the discrimination: this card's defect, reproduced inside its own counter-example. Fixed in `c83904d5b` — one looping test per gate, with the non-vacuity floor asserted *in the same test*, so no-data still fails. Re-ablated: 12 failing tests instead of 10, and both `every entry in the list is load-bearing` tests now among them, **including the designer one** — the leg the real designer gate cannot supply today.

## Constraint 5 — the boundary is respected

Only data moved. Each caller keeps its own walk, and they are legitimately **not identical**: the designer gate reads `node._def ?? node.def ?? node._zod?.def`, the action gate reads `s._def ?? s.def`. Unifying those is sharing a *function* across the language boundary, which the ruling explicitly does not open a door for. Both gate diffs are two lines: an import and a loop head.

## Verification

Union run after the final commit, at `c83904d5b`, tree clean.

```
pnpm exec vitest run scripts/ packages/test-support/ \
  packages/core/src/actions/__tests__/actionKeys.pin.test.ts \
  packages/app-shell/.../flow-node-config.spec-reconciliation.test.ts \
  packages/app-shell/.../flow-canvas-seeds.spec-parse.test.tsx
→ Test Files 98 passed (98) · Tests 2663 passed | 1 skipped (2664)
```

Gates, exit code captured before any pipe: `check-action-forward-parity`, `check-designer-field-key-parity`, `check-phantom-dependencies`, `check-pre-install-import-graph`, `check-control-bytes`, `check-changeset-presence` — all `EXIT=0`. Also green: `check-readme-exports` (on a built tree), `check-governed-queue-guard --test` over all 16 changed paths (NOT GOVERNED), `check-self-import`, `check-side-effects-array`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-changeset-{fixed,no-major,overwrite}`, `check-lint-coverage`, `check-type-check-coverage`.

Type-check: `type-check:scripts`, and `@object-ui/{test-support,core,app-shell}` — all `EXIT=0` (the last two only after building their dependency closures; unbuilt they fail on missing `packages/types/dist`, which is an unbuilt-tree condition, not this diff). `--listFiles` confirms all five edited/added test files are genuinely inside those programs rather than excluded.

**Lint — a declared narrowing, with its evidence.** `eslint --no-inline-config --format json` over all 9 changed lintable files: 9 linted, 0 ignored, **0 errors, 0 warnings**. The narrowing is measurable rather than a gap because `eslint.config.js` configures **no type-aware linting** (no `projectService`, no `parserOptions.project`), so a file's verdict depends only on its own text plus the flat config — this diff cannot move the verdict on any file it did not touch. The repo-wide sweep remains CI's run.

**Changeset:** empty frontmatter — test files, CI gate scripts and a `private: true` package only; nothing releases. `check-changeset-presence` confirms the exemption is complete.

### Two reds hit locally, neither from this diff, both already tracked

- `check:published-dist` — `@object-ui/fields` ships `dist/__tests__/numberInputBrowserReadings.d.ts`. Already filed twice: #6943, #6861.
- `check-sdui-registration-pins.test.ts` — fails on any tree where `packages/app-shell/dist` exists (my earlier build created it; removing it makes the test pass). Already filed: #6893.

⛔ No new issue filed: dedup ran against the 294 open issues via the repo-scoped REST list plus a local grep, with a control term that had to hit and did. #6699 is untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GgDDqh6YnkXqsnVTCa7wHk)_