### PR TITLE
docs(ci-cd-pipeline): drop the node-version claim off spelling, onto the version

### DIFF
--- a/.changeset/6448-ci-cd-pipeline-node-version-spelling.md
+++ b/.changeset/6448-ci-cd-pipeline-node-version-spelling.md
@@ -1,0 +1,25 @@
+---
+---
+
+Drops one prose sentence in `content/docs/guide/ci-cd-pipeline.md` off a spelling-level
+absolute (objectui#6448). The "adding a new workflow" steps used to say a fossilised
+example block pinned `node-version: 20` "where every workflow declares `'22.x'`" — but
+one lane, `.github/workflows/half-state-patrol.yml`, spells it `'22'` rather than
+`'22.x'`, so the quoted claim was false by exactly that one lane's quoting, even though
+every workflow agrees on the major.
+
+Re-measured on the branch point (`d3bf4fa6f`): 29 declarations spell `'22.x'`, 1 spells
+`'22'`, all 30 read major 22. The sentence now reads "where every workflow declares 22" —
+true today, and it stays true if `half-state-patrol.yml` is later normalised to `'22.x'`
+(a separate change, objectui#5986), because the sentence no longer asserts a spelling.
+
+This is disposition A from the finding, the one both the card and triage recommended:
+the paragraph is teaching "don't copy a fossilised pin", and the quote-mark spelling of
+the current value was never part of that lesson — asserting it was is exactly the
+count/spelling-shaped fact objectui#6400 and #6447 are open about elsewhere on this same
+page. No other part of the paragraph changed (the `@v7` and `pnpm/action-setup@v4` claims
+still measure true), and `scripts/__tests__/doc-version-claims.test.ts`'s ledger entry for
+this sentence (`node-version: 20`, landed by objectui#6409) needed no edit — its `why` was
+already phrased at the version level, not the spelling, so page and ledger now agree.
+
+Docs-only prose fix; no published behaviour changes, hence empty frontmatter.

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1891,7 +1891,7 @@ the runner. Removed by [#6436](https://github.com/objectstack-ai/objectui/issues
 2. Copy the pnpm + Turbo setup from a workflow that runs today, not from a snippet on this
    page. A copied YAML block is a fossil the moment it is pasted — this page used to keep
    one here, and every line of it had drifted: `actions/setup-node@v4` where every workflow
-   now uses `@v7`, a hardcoded `node-version: 20` where every workflow declares `'22.x'`
+   now uses `@v7`, a hardcoded `node-version: 20` where every workflow declares 22
    (and 20 sat below the floor the root `package.json`'s `engines` field now declares), and
    `pnpm/action-setup@v4`, which no workflow in this repository has ever used — pnpm comes
    from `corepack enable` plus the root `packageManager` field instead.


### PR DESCRIPTION
Fixes #6448

## What

`content/docs/guide/ci-cd-pipeline.md`'s "adding a new workflow" steps claimed a fossilised
example block pinned `node-version: 20` "where every workflow declares `'22.x'`" — a
spelling-level absolute that one lane, `.github/workflows/half-state-patrol.yml`, falsifies
(it spells the value `'22'`, not `'22.x'`). Disposition **A**, as the finding and triage both
recommended: drop the sentence to the version and off the spelling.

- Before: `...a hardcoded `node-version: 20` where every workflow declares `'22.x'``
- After: `...a hardcoded `node-version: 20` where every workflow declares 22`

One line changed. Nothing else in the paragraph moved (the `@v7` and
`pnpm/action-setup@v4` claims already measure true and are untouched).

## Premise re-verification (base `d3bf4fa6f`)

Both line numbers cited in the original finding and in the PM claim comment had already
rotted further by the time this landed; re-derived directly instead of trusting either:

```
$ grep -rhoP "node-version:\s*'22\.x'" .github/workflows/ | wc -l
29
$ grep -rhoP "node-version:\s*'22'"   .github/workflows/ | wc -l
1
$ grep -rnP "node-version:\s*'22'" .github/workflows/
.github/workflows/half-state-patrol.yml:257:          node-version: '22'
```

29 vs 1 — matches the claim comment's re-derivation exactly. The sentence itself was at
`ci-cd-pipeline.md:1894` at the branch point (not 1744 from the card, nor 1882 from the
claim comment — this hot file moved again in the interim). Premise holds.

**Control term** (zero-hit results need one — retaken, not inherited from the card):
the page's three `readme-exports.yml` references all resolve to a real workflow file
(`.github/workflows/readme-exports.yml` exists) — confirms this sweep isn't blind to
stale references wholesale.

**Invariance check** — the whole point of disposition A: every `node-version` declaration
in `.github/workflows` reads major 22 regardless of spelling (30 total: 29 as `'22.x'`, 1 as
`'22'`). So the new sentence is true today and stays true if `half-state-patrol.yml` is
later normalised to `'22.x'` — it no longer asserts anything about quoting.

## Ledger check (per the claim comment's DoD step 2)

Re-read `scripts/__tests__/doc-version-claims.test.ts:948-950` (the `node-version: 20`
entry, landed by #6409, anchor for this sentence): its `why` is phrased at the **version**
level ("every workflow declares 22 instead ... Deliberately phrased without a declaration
COUNT") and never quotes the `'22.x'` spelling. So this edit needs no ledger change — page
and ledger now agree instead of only the ledger being precise. No edit made to that file
(it is #6447's, per the boundary below).

## Verification

All run from the worktree root, repo-root-relative paths, no packages/`--` pitfall:

- `node scripts/check-doc-links.mjs` — PASS ("Links are valid across 17 scan roots.")
- `node scripts/check-doc-fence-languages.mjs` — PASS
- `node scripts/check-doc-snippet-types.mjs` — PASS after building the packages it
  resolves against (`pnpm exec turbo run build` over the 21 packages it names); "Every
  covered documentation snippet compiles against the built types." (271/271 blocks)
- `node scripts/check-control-bytes.mjs` — PASS (5833 tracked text files scanned)
- `pnpm exec vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` — PASS, 36/36
- `pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts` — PASS, 25/25

## Boundaries respected

- Did not touch `scripts/__tests__/doc-version-claims.test.ts` (owned by #6447, running in
  parallel) — confirmed no edit needed there (see ledger check above).
- One line only — did not widen into the surrounding paragraph or the `@v7` /
  `pnpm/action-setup@v4` claims.
- Did not normalise `half-state-patrol.yml`'s spelling — that stays the counter-example
  that makes this fix testable (separate card, #5986).
- No governed-surface files touched. No `content/docs/releases/` edit.

## Changeset

Docs-only, empty frontmatter (`.changeset/6448-ci-cd-pipeline-node-version-spelling.md`) —
no published package behaviour changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GgDDqh6YnkXqsnVTCa7wHk)_