### PR TITLE
fix(app-shell): an unrecognised activity kind fails open in ActivityFeed

### DIFF
--- a/.changeset/6816-activityfeed-unknown-kind-fails-open.md
+++ b/.changeset/6816-activityfeed-unknown-kind-fails-open.md
@@ -1,0 +1,25 @@
+---
+'@object-ui/app-shell': patch
+---
+
+`ActivityFeed` no longer drops a row whose activity kind it does not recognise
+(objectui#6816).
+
+The notification filter was `activities.filter(a => notificationPreferences[a.type])`
+— a truthiness test over a `Record<ActivityItemType, boolean>`, which answers the
+same falsy value to two unrelated questions: "the user toggled this kind off"
+(hide, which is the feature) and "this kind is not in the record at all". The
+second made the row **vanish** from the panel.
+
+In-repo `tsc` keeps that case out of reach — three exhaustive
+`Record<ActivityItemType, …>` tables force every member to be handled — but
+`ActivityFeed` is published API, and a host that mounts it passes rows whose
+`type` came from its own data. `sys_activity.type` is author-extensible and is
+not validated on write, so those kinds are real, and a missing row is the least
+detectable failure a feed can have.
+
+An unrecognised kind now fails **open**: the row renders, through the generic
+`system` presentation `activityItemType.ts` already declares for a value outside
+its mapping table (neutral on purpose, and in particular not `update`). A kind
+that is present and toggled off is still filtered out — presence, not
+truthiness, is now the question the filter asks.

--- a/packages/app-shell/src/layout/ActivityFeed.tsx
+++ b/packages/app-shell/src/layout/ActivityFeed.tsx
@@ -19,7 +19,8 @@ import {
 } from '@object-ui/components';
 import { Activity, Plus, Pencil, Trash2, MessageSquare, Filter, Info } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
-import type { ActivityItem } from './activityItemType.js';
+import { UNMAPPED_ACTIVITY_ITEM_TYPE } from './activityItemType.js';
+import type { ActivityItem, ActivityItemType } from './activityItemType.js';
 
 /**
  * The item shape and its kind union live in `activityItemType.ts` with the
@@ -49,6 +50,43 @@ const typeConfig: Record<
   // of the bucket is that it does not claim the row was an update.
   system: { icon: Info, color: 'text-muted-foreground' },
 };
+
+/**
+ * Is this activity kind allowed through the notification filter?
+ *
+ * ⚠️ The question is PRESENCE, not truthiness — that distinction is the fix
+ * (objectui#6816). A bare `preferences[type]` lookup answers the same falsy
+ * value to two unrelated questions:
+ *
+ *  - the kind is IN the record and the user toggled it OFF ⇒ hide the row.
+ *    That is the feature, and it still hides.
+ *  - the kind is ABSENT from the record ⇒ the row used to vanish from the
+ *    panel. It now fails OPEN and renders.
+ *
+ * The second case is unreachable inside this repo — the preferences record is
+ * `Record<ActivityItemType, boolean>` and `tsc` forces every member — but
+ * `ActivityFeed` is published API (the package barrel exports it), so a host
+ * can mount it and pass rows whose `type` came from its own data.
+ * `sys_activity.type` is author-extensible (objectstack#11507, ruled
+ * 2026-08-24) and is not validated on write, so those kinds are real. Reading
+ * one as "off" made the row stored, queryable and invisible — the
+ * objectui#5840 failure mode reached from the reader side, and the least
+ * detectable kind of failure a feed can have.
+ *
+ * Asking `hasOwnProperty` rather than defaulting a bracket read is the same
+ * choice `activityItemTypeOf` makes on the mapping side (layout/
+ * activityItemType.ts), for the same reason: the question is about the record's
+ * OWN entries. A consumer kind spelled `toString` or `constructor` is absent
+ * here, but a bracket read finds a truthy `Object.prototype` member — the same
+ * verdict today, reached by accident, through a value that is not a boolean.
+ */
+function isKindEnabled(
+  preferences: Partial<Record<ActivityItemType, boolean>>,
+  type: ActivityItemType,
+): boolean {
+  if (!Object.prototype.hasOwnProperty.call(preferences, type)) return true;
+  return preferences[type] === true;
+}
 
 /** Format an ISO timestamp as a localized relative string (e.g. "2m ago"). */
 function formatRelativeTime(iso: string, t: (key: string, vars?: Record<string, unknown>) => string): string {
@@ -81,7 +119,7 @@ export function ActivityFeed({ activities = [], className }: ActivityFeedProps) 
     setNotificationPreferences(prev => ({ ...prev, [type]: !prev[type] }));
   };
 
-  const filteredActivities = activities.filter(a => notificationPreferences[a.type]);
+  const filteredActivities = activities.filter(a => isKindEnabled(notificationPreferences, a.type));
 
   /** Localized labels for activity type badges. */
   const typeLabels: Record<ActivityItem['type'], string> = {
@@ -131,7 +169,12 @@ export function ActivityFeed({ activities = [], className }: ActivityFeedProps) 
           <div className="flex flex-wrap gap-1.5 mt-3 px-1">
             {(Object.keys(typeConfig) as ActivityItem['type'][]).map(type => {
               const { icon: Icon, color } = typeConfig[type];
-              const active = notificationPreferences[type];
+              // Same predicate as the filter above. Behaviour-neutral today (this
+              // strip iterates `typeConfig`'s own keys, all of which the record
+              // carries), so it is a de-duplication rather than a second fix: one
+              // reading of "is this kind on", which the badge and the list cannot
+              // drift apart on later.
+              const active = isKindEnabled(notificationPreferences, type);
               return (
                 <Badge
                   key={type}
@@ -155,7 +198,15 @@ export function ActivityFeed({ activities = [], className }: ActivityFeedProps) 
         ) : (
           <ul className="mt-4 space-y-1 overflow-y-auto max-h-[calc(100vh-8rem)]">
             {filteredActivities.map((item) => {
-              const { icon: Icon, color } = typeConfig[item.type];
+              // Fail-open's other half. The filter now lets an unrecognised kind
+              // through, so this lookup must have somewhere to land: destructuring
+              // `undefined` throws and takes the whole panel down with it, which is
+              // strictly worse than the row this card is here to stop losing.
+              // `UNMAPPED_ACTIVITY_ITEM_TYPE` is the presentation activityItemType.ts
+              // already declares for a value outside its table — neutral on purpose,
+              // and in particular not `update`.
+              const { icon: Icon, color } =
+                typeConfig[item.type] ?? typeConfig[UNMAPPED_ACTIVITY_ITEM_TYPE];
               return (
                 <li
                   key={item.id}

--- a/packages/app-shell/src/layout/__tests__/ActivityFeed.unknownKindFailsOpen-6816.test.tsx
+++ b/packages/app-shell/src/layout/__tests__/ActivityFeed.unknownKindFailsOpen-6816.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#6816 — `ActivityFeed`'s notification filter read an unrecognised
+ * kind as "off".
+ *
+ * `activities.filter(a => notificationPreferences[a.type])` is a truthiness
+ * test over a `Record<ActivityItemType, boolean>`, so it answers the same
+ * `false` to two different questions:
+ *
+ *  - the kind IS in the record and the user toggled it off — hide the row,
+ *    which is the feature;
+ *  - the kind is ABSENT from the record — which made the row VANISH.
+ *
+ * In-repo `tsc` keeps that second case out of reach (three exhaustive
+ * `Record<ActivityItemType, …>` tables), but `ActivityFeed` is published API
+ * — exported from the package barrel at `src/index.ts` — and a host that
+ * mounts it can pass a kind that came from its own data. `sys_activity.type`
+ * is author-extensible (objectstack#11507, ruled 2026-08-24), so those kinds
+ * exist. The failure mode was a missing row: stored, queryable, invisible.
+ *
+ * These pin BOTH directions, because either one alone is satisfiable by a
+ * broken filter: fail-open alone passes on a filter that shows everything,
+ * and still-filtered alone passes on the defect itself.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { ActivityFeed } from '../ActivityFeed.js';
+import type { ActivityItem, ActivityItemType } from '../activityItemType.js';
+
+// Key-echoing stub: the assertions below address the filter badges by their
+// i18n key, so a stub returning the key verbatim is what makes them legible.
+vi.mock('@object-ui/i18n', () => ({
+  useObjectTranslation: () => ({ language: 'en', t: (key: string) => key }),
+}));
+
+// Passthrough primitives so the Sheet body renders without driving Radix
+// open/close in happy-dom (the pattern InboxPopover's tests use). `variant`
+// is surfaced as `data-variant` rather than dropped: it is the only rendered
+// consequence of the SECOND preferences read (the toggle badge's own state),
+// so keeping it is what lets a test observe that read at all.
+vi.mock('@object-ui/components', () => ({
+  Button: ({ children, variant, size: _size, ...p }: Record<string, any>) => (
+    <button type="button" data-variant={variant} {...p}>{children}</button>
+  ),
+  Badge: ({ children, variant, ...p }: Record<string, any>) => (
+    <span data-variant={variant} {...p}>{children}</span>
+  ),
+  Sheet: ({ children }: Record<string, any>) => <div>{children}</div>,
+  SheetContent: ({ children }: Record<string, any>) => <div>{children}</div>,
+  SheetHeader: ({ children }: Record<string, any>) => <div>{children}</div>,
+  SheetTitle: ({ children }: Record<string, any>) => <div>{children}</div>,
+  SheetTrigger: ({ children }: Record<string, any>) => <div>{children}</div>,
+}));
+
+// Named test ids so a row's icon identifies WHICH presentation it rendered
+// through — "it did not throw" is a weaker claim than "it took the generic
+// bucket".
+vi.mock('lucide-react', () => {
+  const icon = (name: string) => (props: Record<string, unknown>) => (
+    <span data-testid={`icon-${name}`} {...props} />
+  );
+  return {
+    Activity: icon('Activity'),
+    Plus: icon('Plus'),
+    Pencil: icon('Pencil'),
+    Trash2: icon('Trash2'),
+    MessageSquare: icon('MessageSquare'),
+    Filter: icon('Filter'),
+    Info: icon('Info'),
+  };
+});
+
+/**
+ * A kind no `Record<ActivityItemType, …>` table in this repo has an entry for.
+ *
+ * The cast is the whole point and not a shortcut: `tsc` is exactly the
+ * protection a published consumer does NOT have, so reaching the defect from
+ * inside this repo means stepping around the compiler the way a JavaScript
+ * host does for free.
+ */
+const UNKNOWN_KIND = 'contract_countersigned' as ActivityItemType;
+
+const row = (id: string, type: ActivityItemType, description: string): ActivityItem => ({
+  id,
+  type,
+  objectName: 'accounts',
+  user: 'Ada Lovelace',
+  description,
+  timestamp: new Date().toISOString(),
+});
+
+const KNOWN_ROW = row('a1', 'create', 'Created the Acme account');
+const UNKNOWN_ROW = row('a2', UNKNOWN_KIND, 'Countersigned the Acme MSA');
+
+/** Open the filter strip (its badges are the notification toggles). */
+function openFilters() {
+  fireEvent.click(screen.getByText('layout.activityFeed.filter'));
+}
+
+describe('ActivityFeed — an unrecognised activity kind (objectui#6816)', () => {
+  it('renders the row rather than dropping it from the panel', () => {
+    render(<ActivityFeed activities={[KNOWN_ROW, UNKNOWN_ROW]} />);
+
+    // The defect: this row was absent from the panel entirely.
+    expect(screen.getByText('Countersigned the Acme MSA')).toBeInTheDocument();
+    expect(screen.getByText('Created the Acme account')).toBeInTheDocument();
+  });
+
+  it('renders it through the declared generic bucket, not a missing presentation', () => {
+    render(<ActivityFeed activities={[UNKNOWN_ROW]} />);
+
+    const item = screen.getByText('Countersigned the Acme MSA').closest('li');
+    expect(item).not.toBeNull();
+    // `UNMAPPED_ACTIVITY_ITEM_TYPE` is `system`, whose icon is `Info`.
+    expect(within(item as HTMLElement).getByTestId('icon-Info')).toBeInTheDocument();
+    // Not `update` — reading an unmapped kind as an update is the claim
+    // objectui#6730 removed from the mapping side.
+    expect(within(item as HTMLElement).queryByTestId('icon-Pencil')).toBeNull();
+  });
+
+  it('still filters a kind the user has toggled OFF, and leaves the unknown kind alone', () => {
+    render(<ActivityFeed activities={[KNOWN_ROW, UNKNOWN_ROW]} />);
+    openFilters();
+
+    // Both rows are in the panel before the toggle.
+    expect(screen.getByText('Created the Acme account')).toBeInTheDocument();
+    expect(screen.getByText('Countersigned the Acme MSA')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('layout.activityFeed.typeCreate'));
+
+    // Present-and-false is still a hide — fail-open must not degrade into
+    // "show everything", which would make the filter feature dead.
+    expect(screen.queryByText('Created the Acme account')).toBeNull();
+    // …and it did not take the unrecognised row with it.
+    expect(screen.getByText('Countersigned the Acme MSA')).toBeInTheDocument();
+  });
+
+  it('shows the toggle badge as off for a kind the user disabled', () => {
+    render(<ActivityFeed activities={[KNOWN_ROW]} />);
+    openFilters();
+
+    const badge = () => screen.getByText('layout.activityFeed.typeCreate');
+    expect(badge()).toHaveAttribute('data-variant', 'default');
+
+    fireEvent.click(badge());
+
+    // The second preferences read (the badge's own state) agrees with the
+    // first (the filter) — one predicate, so they cannot drift.
+    expect(badge()).toHaveAttribute('data-variant', 'outline');
+  });
+});


### PR DESCRIPTION
Fixes #6816

Session: https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB

> ⚠️ **Notation.** Square brackets below stand in for TypeScript's angle brackets — `Record[K, V]` means `Record` of `K` to `V`. This repo's GitHub body sanitizer **eats angle-bracket fragments**, code fences included: the first version of this description had every generic silently reduced to a bare `Record`, and an unterminated JSX tag near the end ate the entire remainder of the body along with the footer. Measured on this PR, verified by reading the body back.

## The defect

`packages/app-shell/src/layout/ActivityFeed.tsx:84` filtered the panel with

```ts
const filteredActivities = activities.filter(a => notificationPreferences[a.type]);
```

A truthiness test over a `Record[ActivityItemType, boolean]` gives the **same falsy answer to two unrelated questions**:

| the record says | what it means | what should happen | what happened |
|---|---|---|---|
| `false` | the user toggled this kind off | hide the row — this is the feature | hidden, correctly |
| *absent* | this kind is not in the record at all | show the row | **the row vanished** |

In-repo `tsc` keeps that second case out of reach — three exhaustive `Record[ActivityItemType, …]` tables force every member to be handled — but `ActivityFeed` is **published API**, exported from the package barrel at `src/index.ts:122`, and a host that mounts it passes rows whose `type` came from its own data. `sys_activity.type` is author-extensible (objectstack#11507, ruled 2026-08-24) and is not validated on write, so those kinds are real. The failure mode was a **missing row**: stored, queryable, invisible — the objectui#5840 shape reached from the reader side, and the least detectable failure a feed can have.

## The fix

One predicate, asking **presence** rather than truthiness:

```ts
function isKindEnabled(
  preferences: Partial[Record[ActivityItemType, boolean]],
  type: ActivityItemType,
): boolean {
  if (!Object.prototype.hasOwnProperty.call(preferences, type)) return true;
  return preferences[type] === true;
}
```

**Why `hasOwnProperty` and not `preferences[type] ?? true`.** Both draw the line in the right place — `??` defaults only on `undefined`, so a stored `false` survives it, and a truthiness test can do neither. `hasOwnProperty` was chosen for two reasons:

1. It is the same choice `activityItemTypeOf` already makes on the mapping side (`layout/activityItemType.ts`), whose own comment says why: *"which is why the lookup below asks `hasOwnProperty` rather than comparing the result to the bucket"*. One question — "does this record have its own entry?" — asked one way on both sides of the same feature.
2. A consumer kind spelled `toString` or `constructor` is genuinely **absent** here, but a bracket read finds a truthy `Object.prototype` member. `?? true` reaches the same verdict *by accident*, through a value that is not a boolean at all, returned from a function declared to return one. `hasOwnProperty` reaches it for the stated reason.

### The second call site — changed, deliberately, and it is not a second fix

`ActivityFeed.tsx:134` (`const active = notificationPreferences[type]`, the toggle badge's own state) now goes through the same predicate. **This is behaviour-neutral today, and provably so**: that strip iterates `Object.keys(typeConfig)`, and the preferences record is `Record[ActivityItemType, boolean]` — tsc-exhaustive over the same union — so `hasOwnProperty` is always true there and the new branch is never taken.

It is changed anyway because leaving it raw means *two different expressions* decide "is this kind on". Routing both through one predicate is a de-duplication, not a second guard: the badge and the list cannot answer differently later — which they would the first time the preferences record becomes partial (server-held preferences are the obvious next step for a panel whose own header still says *"Phase 17 L1 – local state only, no server integration"*).

### Fail-open's other half — required, not scope creep

`ActivityFeed.tsx:158` was a **third** unguarded lookup on the same record shape:

```ts
const { icon: Icon, color } = typeConfig[item.type];
```

Once the filter lets an unrecognised kind through, this destructures `undefined` and **throws**, taking the whole panel down — strictly worse than the disappearing row this PR exists to stop. The deliverable is not reachable without it.

It now falls back to `typeConfig[UNMAPPED_ACTIVITY_ITEM_TYPE]` — the presentation `activityItemType.ts` **already declares** for a value outside its mapping table, neutral on purpose and in particular *not* `update`. No new vocabulary is introduced: the reader side lands on the same generic bucket the mapping side does.

## The defect was reproduced before it was fixed

The test file was written and run **against the unmodified tree first**. Same file, same command, both runs:

| | `Test Files` | `Tests` |
|---|---|---|
| before the fix (tree = `main` content) | 1 failed | **3 failed**, 1 passed |
| after the fix | 1 passed | **4 passed** |

The before-run's failure is the defect itself, not a compile error:

```
× renders the row rather than dropping it from the panel
× renders it through the declared generic bucket, not a missing presentation
× still filters a kind the user has toggled OFF, and leaves the unknown kind alone

TestingLibraryElementError: Unable to find an element with the text: Countersigned the Acme MSA.
```

…and the dumped DOM showed exactly one list item: the `create` row rendered, the unrecognised row was absent from the panel entirely.

The fourth test (the toggle badge's state) **passed before the fix as well** — that is the reported reading of the second call site, confirmed as a measurement rather than an argument: it carried no defect.

## Both directions are asserted

A test that only checked fail-open would pass on a filter that shows everything, so the suite pins the other direction too:

- **fail open** — an absent kind renders, and renders through the generic bucket (the `Info` icon, not `Pencil`);
- **still filtered** — a kind that is present and toggled off is gone from the panel, *while the unrecognised row stays*;
- **the toggle still works** — the badge flips `default` to `outline`, which is the second call site's only rendered consequence.

The unknown kind reaches the component through a cast, and that is the point rather than a shortcut: `tsc` is exactly the protection a published consumer does not have, so reaching this defect from inside the repo means stepping around the compiler the way a JavaScript host does for free.

## Checks

All run from the repo root. The union was run on the final commit `88f14b62a`.

| check | command | result |
|---|---|---|
| the card's own suite | `pnpm exec vitest run packages/app-shell/src/layout/__tests__/ActivityFeed.unknownKindFailsOpen-6816.test.tsx` | `Tests 4 passed (4)` — was `3 failed, 1 passed` before the fix |
| the edited file's directory, on `88f14b62a` | `pnpm exec vitest run packages/app-shell/src/layout/` | `Test Files 33 passed (33)`, `Tests 221 passed (221)` |
| the whole affected package | `pnpm exec vitest run packages/app-shell/` | `Test Files 582 passed (582)`, `Tests 5709 passed, 1 skipped (5710)` |
| types, tests included | `pnpm --filter @object-ui/app-shell run type-check` (`tsc --noEmit` then `tsc -p tsconfig.test.json`) | exit 0 |
| lint, package scope | `pnpm --filter @object-ui/app-shell run lint` (`eslint .`) | exit 0 — **0 errors**, 2805 pre-existing warnings |
| dependency closure | `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` | exit 0 |
| `check:vi-mock-specifiers` | the new test carries `vi.mock` calls | `OK (… 507 carry a mock …)` |
| `check:vi-mock-inherit` | same | `OK (… 110 inherit, 0 auto-mocked …)` |
| `check:icon-record-names` | the diff touches a lucide icon record | `OK lucide icon names: 182 … are live icons keys` |
| `check:control-bytes` | any edit | `OK (scanned 5825 tracked text file(s))` |
| `check:i18n-keys` | `ActivityFeed.tsx` is an i18n call site | exit 0 |

Two notes on how to read that table, so it is checkable rather than merely reassuring:

- The **582-file package run** was measured on a tree identical to `88f14b62a` except for one token inside this PR's own new test file (an unused mock parameter renamed to clear a lint warning). Vitest isolates per file, and the directory containing that file was re-run on `88f14b62a` itself — the row above it.
- **`type-check` genuinely covers the new test.** `tsconfig.json` excludes tests, so "type-check is clean" could have said nothing at all about the file this PR adds. `tsc -p tsconfig.test.json --listFiles`, counted for `ActivityFeed.unknownKindFailsOpen-6816`, returns `1` — it is in the program.

Repo-wide gates (`pnpm lint` across every package, `pnpm check`) are CI's run and are not duplicated here.

## Scope

The three fences on the card are held:

- **No type icons were added to the bell or Home.** `InboxPopover.tsx` and `HomeRail.tsx` do not appear in this diff at all.
- **The product question of which surface owns the icon vocabulary is not answered here.** Triage deferred it deliberately and deliberately did not escalate it, on the grounds that `ActivityFeed` has zero in-repo call sites. That is re-measured rather than assumed: a repo-wide grep for the component's JSX opening tag returns nothing outside this PR's own test. Nobody is blocked, so the question stays open for whoever first mounts the component.
- **Not folded into #6730.** That card owned the *mapping*, and its PR (#6814, merged) deliberately did not touch the surfaces; this is the reader side. Nothing about #6730 is addressed here.

The diff is three files: the component, one new test, one changeset.