### PR TITLE
feat(app-shell,types,plugin-form): wizard view v1 objectui alignment + pins (Card R)

### DIFF
--- a/.changeset/6985-wizard-card-r-alignment.md
+++ b/.changeset/6985-wizard-card-r-alignment.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/types': patch
+'@object-ui/plugin-form': patch
+---
+
+Wizard view v1, the objectui half (Card R, objectui#6985) — alignment + pins for the
+ruled `type: 'wizard'` tightening (objectstack#13622 D1–D8, maintainer ruling
+2026-08-31; spec half objectstack PR #13733).
+
+The renderer was already aligned: `WizardStepConfig` carries no predicate/collapse
+keys (objectui#6237's ruled split), the wizard route drops-and-reports an authored
+step `visibleWhen`, and `allowSkip` has been navigation-freedom-not-validation-
+exemption since #2959. This card lands the residue:
+
+- **metadata-admin view create seeds one starter step for a wizard** (app-shell
+  `anchors.ts`): the create body used to emit `sections: []` for every form type,
+  which for `type: 'wizard'` is exactly the shape the tightened spec refuses at
+  parse (D7 — a stepless wizard silently rendered as a plain simple form). Same
+  seed-the-required-shape move the flow anchor makes for its `type` enum
+  (objectui#2326). Other form types keep the bare `[]` — only the wizard variant
+  refuses emptiness.
+- **`@object-ui/types` TSDoc states the ruled wizard boundary** where the shared
+  section/form types restate the form-view family: `ObjectFormSection.visibleWhen`
+  / `collapsible` / `collapsed` name the wizard drop + spec-door refusal;
+  `ObjectFormSchema.sections` states sections-ARE-steps and array-order-is-step-
+  order; `allowSkip` states the D4 semantics. Type SHAPES are unchanged — the
+  spec's own ruled mechanism is a parse-time refinement over the single shared
+  section schema (D2 option A), which these types mirror at the type level.
+- **Consumer-side behaviour pins** (`wizardRuledSemantics-6985.test.tsx`): the
+  wizard-inert step keys are dropped, never honoured (a denying `visibleWhen`
+  does not remove a step; `collapsible`/`collapsed: true` produce no collapse
+  affordance, with a positive control on the affordance probe); the empty-steps
+  wizard's measured degradation to a simple form is pinned as the shape the spec
+  door now refuses (one-step wizards stay legal — no arity floor); array order
+  is step order (with a reversed-array control).
+- **Installed-spec door pins** (`wizardSpecDoor-6985.test.ts`), gated on a
+  capability probe of the installed `FormViewSchema` rather than a version
+  string: the post-Card-S half (refusal messages, prescriptions, the authored-
+  `false` collapse boundary, the wizard-scoped control) activates by itself on
+  the lockfile bump that brings the tightening in; until then the pre-tightening
+  half records the 17.2.x accept-set it measured. `steps:` is pinned refused on
+  every spec line.
+
+No teaching material — the #13337/#13086 fence lifts only after both halves land;
+docs changes here are TSDoc/comments only.

--- a/packages/app-shell/src/views/metadata-admin/anchors.ts
+++ b/packages/app-shell/src/views/metadata-admin/anchors.ts
@@ -294,11 +294,24 @@ export function registerBuiltinAnchors(): void {
       const qualifiedName =
         key.includes('.') || !object ? key : `${object}.${key}`;
       const isForm = draft.viewKind === 'form';
+      const formType = (draft.formType as string) || 'simple';
       const config = isForm
         ? {
-            type: (draft.formType as string) || 'simple',
+            type: formType,
             data: { provider: 'object', object },
-            sections: [],
+            // A `type: 'wizard'` form view must declare its steps: the spec
+            // refuses absent/EMPTY `sections` on the wizard variant at parse
+            // (objectstack#13622 D7, ruled 2026-08-31 — before that refusal
+            // the shape silently rendered as a plain simple form). Seed one
+            // starter step so a create→save that never opens the designer
+            // can't 422 once the platform runs a spec carrying the refusal —
+            // the same seed-the-required-shape move the flow anchor makes for
+            // its `type` enum (objectui#2326). Other form types keep the bare
+            // `[]`: only the wizard variant refuses emptiness, and seeding
+            // where nothing demands it would put fabricated structure into
+            // every authored view.
+            sections:
+              formType === 'wizard' ? [{ label: 'Step 1', fields: [] }] : [],
           }
         : {
             type: (draft.kind as string) || 'grid',

--- a/packages/app-shell/src/views/metadata-admin/view-create-body.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/view-create-body.test.ts
@@ -101,6 +101,26 @@ describe('view createBuildBody — ViewItem family discrimination (objectui#2323
     }
   });
 
+  it('seeds one starter step for a wizard create — and ONLY for wizard (objectui#6985)', () => {
+    // A `type: 'wizard'` form view must declare its steps: the spec refuses
+    // absent/empty `sections` on the wizard variant at parse (objectstack#13622
+    // D7, ruled 2026-08-31). An empty-`sections` wizard body would 422 at
+    // create→save on a platform running a spec that carries the refusal — so
+    // the build seeds one starter step, exactly as the flow anchor seeds its
+    // required `type` enum (objectui#2326).
+    const wizard = build({ label: 'W', name: 'w', object: 'crm_lead', viewKind: 'form', formType: 'wizard' });
+    const sections = (wizard.config as Record<string, unknown>).sections as unknown[];
+    expect(sections.length).toBeGreaterThanOrEqual(1);
+    expectSpecValid(wizard);
+
+    // The boundary: only the wizard variant refuses emptiness, and fabricated
+    // structure must not leak into every authored view. A tabbed create keeps
+    // the bare `[]` it always had.
+    const tabbed = build({ label: 'T', name: 't', object: 'crm_lead', viewKind: 'form', formType: 'tabbed' });
+    expect((tabbed.config as Record<string, unknown>).sections).toEqual([]);
+    expectSpecValid(tabbed);
+  });
+
   it('qualifies the view name to <object>.<key> for both families', () => {
     expect(build({ label: 'All', name: 'all', object: 'crm_lead' }).name).toBe('crm_lead.all');
     expect(

--- a/packages/plugin-form/src/ObjectForm.tsx
+++ b/packages/plugin-form/src/ObjectForm.tsx
@@ -308,6 +308,14 @@ export const ObjectForm: React.FC<ObjectFormComponentProps> = ({
         schema={{
           ...schema,
           formType: 'wizard',
+          // Key-by-key rebuild into `WizardStepConfig`, the wizard's OWN step
+          // shape: `visibleWhen` / `collapsible` / `collapsed` are deliberately
+          // not copied — wizard steps carry no predicate slot and do not
+          // collapse (objectui#6237 split; upgraded to a spec-door parse
+          // refusal by objectstack#13622 D2, ruled 2026-08-31, so authored
+          // metadata carrying them never reaches this map). The predicate drop
+          // is additionally reported above for the callers the spec door
+          // cannot see (programmatic SDUI, pre-tightening metadata).
           sections: schema.sections.map(s => ({
             name: s.name,
             label: tSec(s),

--- a/packages/plugin-form/src/WizardForm.tsx
+++ b/packages/plugin-form/src/WizardForm.tsx
@@ -87,6 +87,15 @@ import { hasInlineFieldSource, noSubmitTargetError } from './submitTarget';
  * a FAMILY-level pin that fails the build if any `*When` key ever appears here,
  * not just the one this card was about.
  *
+ * Since the objectstack#13622 ruling (2026-08-31), the boundary is also an
+ * AUTHOR-door refusal: `@objectstack/spec` refuses `visibleWhen` (and
+ * `collapsible`/`collapsed: true`) on a wizard step at parse, so authored
+ * form-view metadata carrying them never reaches this renderer at all. This
+ * type and the runtime report remain the guard for what the spec door cannot
+ * see — programmatic SDUI callers and metadata published before the
+ * tightening. The step-predicate FUTURE contract stays tracked in
+ * objectui#6237; the spec-side refusal is its single opening point.
+ *
  * ⚠️ This changes nothing that used to work. The published surface is exactly
  * the key set `WizardStepConfig` already had — the derivation changed, not the
  * type — and `visibleWhen` was already a type error on a wizard step literal.

--- a/packages/plugin-form/src/__tests__/wizardRuledSemantics-6985.test.tsx
+++ b/packages/plugin-form/src/__tests__/wizardRuledSemantics-6985.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6985 (Card R) — consumer-side pins for the RULED wizard v1
+ * semantics (objectstack#13622 D2/D7/D8, maintainer ruling 2026-08-31; the
+ * spec half landed as objectstack PR #13733).
+ *
+ * ## Why BEHAVIOUR pins are sanctioned now
+ *
+ * `sectionPredicateLayoutDiagnostic-6237.test.tsx` deliberately pins REPORTING
+ * only — when it was written, the wizard step contract was interim and pinning
+ * behaviour would have declared a contract by the back door. The 2026-08-31
+ * ruling closed that: wizard steps carry no predicate slot (steps are entered
+ * in array order behind the step gate, never conditionally), wizard steps do
+ * not collapse, sections ARE the steps with array order as step order, and a
+ * wizard with absent/empty `sections` is refused at the spec door. Those are
+ * now the ruled semantics, so this file pins them as behaviour — from the
+ * consumer side, where the failure mode would be WizardForm quietly HONOURING
+ * a key the spec door refuses (a renderer dialect diverging from the
+ * contract), or quietly changing what the refused shapes degrade into.
+ *
+ * ## What is deliberately NOT here
+ *
+ * - D4 (`allowSkip` = navigation freedom, not a validation exemption) is
+ *   already pinned in `wizardSkipValidation.test.tsx` (#2959) — not re-pinned.
+ * - The warn wording for the dropped predicate stays pinned in
+ *   `sectionPredicateLayoutDiagnostic-6237.test.tsx` — not re-pinned.
+ * - The compile-time step-key refusals stay pinned in
+ *   `tabbedFormSectionPredicate-6237.test.tsx` (including the `*When` family
+ *   pin) — this file covers the UNTYPED path those cannot see: JSON reaching
+ *   `ObjectForm` from programmatic SDUI callers, which never pass the spec
+ *   door and never see the compiler.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { PredicateScopeProvider } from '@object-ui/react';
+import { registerAllFields } from '@object-ui/fields';
+import { ObjectForm } from '../ObjectForm';
+import { FormSectionContainer } from '../FormSection';
+
+registerAllFields();
+
+/** Canonical wire shape — same spelling the #6111 / #6237 pins use. */
+const cel = (source: string) => ({ dialect: 'cel', source });
+const GATE = cel("'sales_manager' in current_user.positions");
+
+/** A principal the GATE denies — the state where honouring the predicate
+ *  would REMOVE the step, i.e. where the drop is observable. */
+function deniedScope() {
+  const user = { id: 'u1', name: 'Kim', positions: ['sales'] };
+  return { current_user: user, user, ctx: { user }, os: { user }, app: {}, data: {}, features: {} };
+}
+
+const objectSchema = {
+  name: 'crm_case',
+  fields: {
+    subject: { type: 'text', label: 'Subject' },
+    salary: { type: 'text', label: 'Salary' },
+    notes: { type: 'text', label: 'Notes' },
+  },
+};
+
+let dataSource: any;
+
+beforeEach(() => {
+  dataSource = {
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  };
+  // The predicate drop on the wizard route REPORTS (pinned elsewhere); keep
+  // the console quiet here without asserting on it.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const renderWizard = async (
+  sections: unknown,
+  extra: Record<string, unknown> = {},
+) => {
+  const view = render(
+    <PredicateScopeProvider scope={deniedScope() as any}>
+      <ObjectForm
+        schema={{
+          type: 'object-form',
+          objectName: 'crm_case',
+          mode: 'create',
+          formType: 'wizard',
+          sections,
+          ...extra,
+        } as any}
+        dataSource={dataSource}
+      />
+    </PredicateScopeProvider>,
+  );
+  return view;
+};
+
+/** The wizard's step indicator buttons, in DOM order. */
+const indicatorSteps = () =>
+  Array.from(document.querySelectorAll('[data-testid^="wizard-step:"]')).map(
+    (el) => el.getAttribute('data-testid'),
+  );
+
+const progressNav = () => document.querySelector('nav[aria-label="Progress"]');
+
+describe('#6985 D2 — a wizard-inert step key is DROPPED, never honoured', () => {
+  it('a DENYING `visibleWhen` does not remove the step: it renders, first, unconditionally', async () => {
+    // The gated step is FIRST, so "honouring" the denied predicate would have
+    // to remove or skip the very step on screen — the observable direction.
+    await renderWizard([
+      { name: 'pay', label: 'Compensation', visibleWhen: GATE, fields: ['salary'] },
+      { name: 'always', label: 'Always', fields: ['subject'] },
+    ]);
+    // The gated step's own field is drawn as the current step.
+    await waitFor(() =>
+      expect(document.querySelector('input[name="salary"]')).toBeTruthy(),
+    );
+    // And the step stays on the indicator — both declared steps do.
+    expect(indicatorSteps()).toEqual(['wizard-step:pay', 'wizard-step:always']);
+  });
+
+  it('`collapsible`/`collapsed: true` produce NO collapse affordance on a step', async () => {
+    await renderWizard([
+      { name: 'only', label: 'Only', collapsible: true, collapsed: true, fields: ['subject'] },
+    ]);
+    // The step's field is drawn — an honoured `collapsed: true` would hide it.
+    await waitFor(() =>
+      expect(document.querySelector('input[name="subject"]')).toBeTruthy(),
+    );
+    // And no collapse trigger exists anywhere in the step chrome. The
+    // affordance `FormSectionContainer` renders for a collapsible section is a
+    // header with `role="button"` + `aria-expanded` (see the CONTROL below);
+    // the wizard's step container must not have grown one.
+    expect(document.querySelector('[aria-expanded]')).toBeNull();
+  });
+
+  it('CONTROL: the selector detects the affordance where a layout really honours it', () => {
+    // Not decoration: if `FormSectionContainer` ever changed how a collapse
+    // trigger is spelled in the DOM, the assertion above would pass vacuously.
+    // This row proves the probe finds the affordance on the component that
+    // renders it.
+    render(
+      <FormSectionContainer label="Collapsible" collapsible>
+        <div />
+      </FormSectionContainer>,
+    );
+    expect(document.querySelector('[role="button"][aria-expanded]')).toBeTruthy();
+  });
+});
+
+describe('#6985 D7 — the empty-steps wizard degrades to a plain simple form (the shape the spec door now refuses)', () => {
+  // `@objectstack/spec` refuses `type: 'wizard'` with absent/empty `sections`
+  // at parse for authored form views (objectstack#13622 D7) — PRECISELY
+  // because this renderer chain silently falls back to simple rendering.
+  // These rows pin that measured fallback: it is what the door protects
+  // authors from, and it is still the documented degradation for programmatic
+  // SDUI callers, which do not pass the door. If the fallback ever changes
+  // shape (e.g. starts throwing), that is a contract event, not a refactor.
+  it('`sections: []` renders the simple form — no step machinery', async () => {
+    await renderWizard([]);
+    await waitFor(() =>
+      expect(document.querySelector('input[name="subject"]')).toBeTruthy(),
+    );
+    expect(progressNav()).toBeNull();
+    expect(indicatorSteps()).toEqual([]);
+  });
+
+  it('absent `sections` renders the simple form — same fallback', async () => {
+    await renderWizard(undefined);
+    await waitFor(() =>
+      expect(document.querySelector('input[name="subject"]')).toBeTruthy(),
+    );
+    expect(progressNav()).toBeNull();
+  });
+
+  it('CONTROL: a ONE-step wizard is legal and renders AS a wizard — no "at least 2 steps" floor', async () => {
+    // D7's ruled boundary, from the consumer side: the refusal is about
+    // emptiness, never about arity. One declared step gets the full wizard
+    // (indicator included, since `showStepIndicator` defaults to shown).
+    await renderWizard([{ name: 'only', label: 'Only', fields: ['subject'] }]);
+    await waitFor(() =>
+      expect(document.querySelector('input[name="subject"]')).toBeTruthy(),
+    );
+    expect(progressNav()).toBeTruthy();
+    expect(indicatorSteps()).toEqual(['wizard-step:only']);
+  });
+});
+
+describe('#6985 D8 — array order IS step order', () => {
+  const forward = [
+    { name: 'a', label: 'Alpha', fields: ['subject'] },
+    { name: 'b', label: 'Beta', fields: ['salary'] },
+    { name: 'c', label: 'Gamma', fields: ['notes'] },
+  ];
+
+  it('the indicator lists steps in array order and step 1 is sections[0]', async () => {
+    await renderWizard(forward);
+    await waitFor(() =>
+      expect(document.querySelector('input[name="subject"]')).toBeTruthy(),
+    );
+    expect(indicatorSteps()).toEqual(['wizard-step:a', 'wizard-step:b', 'wizard-step:c']);
+    // Only sections[0]'s field is mounted — a wizard mounts one step at a time.
+    expect(document.querySelector('input[name="salary"]')).toBeNull();
+    expect(document.querySelector('input[name="notes"]')).toBeNull();
+  });
+
+  it('reversing the array reverses the wizard — order comes from the ARRAY, not names or labels', async () => {
+    // The control that makes the row above a measurement: identical steps,
+    // identical names and labels, one variable (array position) — and the
+    // wizard follows it. An `order` key or name-based sorting would make this
+    // row and the one above disagree.
+    await renderWizard([...forward].reverse());
+    await waitFor(() =>
+      expect(document.querySelector('input[name="notes"]')).toBeTruthy(),
+    );
+    expect(indicatorSteps()).toEqual(['wizard-step:c', 'wizard-step:b', 'wizard-step:a']);
+    expect(document.querySelector('input[name="subject"]')).toBeNull();
+  });
+});

--- a/packages/plugin-form/src/__tests__/wizardSpecDoor-6985.test.ts
+++ b/packages/plugin-form/src/__tests__/wizardSpecDoor-6985.test.ts
@@ -1,0 +1,148 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6985 (Card R) — pins on the INSTALLED `@objectstack/spec` wizard
+ * door, gated on the installed schema's own behaviour.
+ *
+ * The objectstack Card S tightening (objectstack#13622 D2/D3/D7, ruled
+ * 2026-08-31; landed as objectstack PR #13733) makes `FormViewSchema` refuse
+ * the wizard-inert step keys, refuse an absent/empty-`sections` wizard, and
+ * teach the `steps:` spelling at the point of refusal. That door is what keeps
+ * authored metadata from ever reaching WizardForm carrying keys it drops — so
+ * this repo wants pins on it. But the door ships with a spec RELEASE, and this
+ * repo's lockfile pins `@objectstack/spec` 17.2.0, which predates it
+ * (installability gate, objectui#6985: never assert against a contract the
+ * installed dependency does not carry).
+ *
+ * ## How the gate works (capability probe, not a version string)
+ *
+ * The file probes the installed `FormViewSchema` once — does it refuse a
+ * wizard step carrying `visibleWhen`? — and runs exactly ONE of the two
+ * describe halves:
+ *
+ *  - post-tightening half: pins the refusals and their prescriptions. Skipped
+ *    today; activates by itself on the lockfile bump that brings Card S in,
+ *    with zero edits here.
+ *  - pre-tightening half: pins TODAY's accept-set (17.2.x accepts the
+ *    wizard-inert step keys and the empty-sections wizard), so a run's output
+ *    records which regime it measured instead of silently skipping. It
+ *    deactivates by itself on the same bump.
+ *
+ * A version-string gate would encode a guess about WHICH release carries the
+ *  tightening; the behaviour probe measures the thing itself.
+ *
+ * Importing the spec's view schema here is the sanctioned drift-guard use —
+ * the same class as `sectionFields.spec-parity.test.ts` (this file exists to
+ * measure the installed contract, not to type a renderer against it).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { FormViewSchema } from '@objectstack/spec/ui';
+
+/** A clean wizard step — the shape the two real in-corpus wizards use. */
+const step = { name: 's1', label: 'Step 1', fields: ['subject'] };
+
+const wizard = (over: Record<string, unknown> = {}) => ({
+  type: 'wizard',
+  sections: [step],
+  ...over,
+});
+
+const parse = (view: unknown) => FormViewSchema.safeParse(view);
+
+/** One issue-list flattening for message asserts. */
+const messagesOf = (view: unknown): string => {
+  const res = parse(view);
+  return res.success ? '' : res.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('\n');
+};
+
+// ── The capability probe ────────────────────────────────────────────────────
+const stepWithPredicate = wizard({ sections: [{ ...step, visibleWhen: 'true' }] });
+const installedSpecCarriesWizardTightening = !parse(stepWithPredicate).success;
+
+describe('#6985 — the installed-spec wizard door, both regimes', () => {
+  it('POSITIVE CONTROL: the minimal stepped wizard parses on every spec line', () => {
+    // Every assertion below reads acceptance/refusal off fixtures derived from
+    // this one. If THIS fails, the fixtures are malformed for an unrelated
+    // reason and nothing else in the file is a measurement.
+    expect(parse(wizard()).success).toBe(true);
+  });
+
+  it('`steps:` is refused on the strict surface — on every spec line', () => {
+    // 17.2.0 already refuses it as an unknown key (strict object); the
+    // tightened spec refuses it WITH the ruled prescription (pinned below).
+    // Never an accepted alias, on either line (objectstack#13622 T1).
+    expect(parse(wizard({ steps: [step] })).success).toBe(false);
+  });
+});
+
+describe.runIf(installedSpecCarriesWizardTightening)(
+  '#6985 — post-Card-S: the door refuses what WizardForm drops (active once the lockfile carries the tightening)',
+  () => {
+    it('refuses `visibleWhen` on a wizard step, naming the ruled reason', () => {
+      const msgs = messagesOf(stepWithPredicate);
+      expect(msgs).toContain('visibleWhen');
+      expect(msgs).toContain('wizard steps carry no predicate slot');
+    });
+
+    it('refuses the deprecated `visibleOn` alias the same way (folded before the refinement)', () => {
+      expect(parse(wizard({ sections: [{ ...step, visibleOn: 'true' }] })).success).toBe(false);
+    });
+
+    it('refuses `collapsible: true` and `collapsed: true` on a wizard step', () => {
+      for (const key of ['collapsible', 'collapsed'] as const) {
+        const msgs = messagesOf(wizard({ sections: [{ ...step, [key]: true }] }));
+        expect(msgs, key).toContain(key);
+        expect(msgs, key).toContain('wizard steps do not collapse');
+      }
+    });
+
+    it('accepts an authored `false` for both collapse keys — it declares exactly what a wizard delivers', () => {
+      // The measured boundary Card S calls out: both keys carry
+      // `.default(false)`, so only `true` declares behaviour a step lacks.
+      expect(parse(wizard({ sections: [{ ...step, collapsible: false, collapsed: false }] })).success).toBe(true);
+    });
+
+    it('refuses the empty-`sections` wizard — the shape that silently rendered simple', () => {
+      const msgs = messagesOf(wizard({ sections: [] }));
+      expect(msgs).toContain('must declare its steps');
+    });
+
+    it('refuses the absent-`sections` wizard the same way', () => {
+      expect(parse({ type: 'wizard' }).success).toBe(false);
+    });
+
+    it('carries the `steps:` prescription — sections ARE the steps, in array order', () => {
+      const msgs = messagesOf(wizard({ steps: [step] }));
+      expect(msgs).toContain('steps');
+      expect(msgs).toContain('sections');
+    });
+
+    it('CONTROL: the refusal is wizard-scoped — a tabbed section keeps its predicate slot', () => {
+      expect(parse({ type: 'tabbed', sections: [{ ...step, visibleWhen: 'true' }] }).success).toBe(true);
+    });
+  },
+);
+
+describe.runIf(!installedSpecCarriesWizardTightening)(
+  '#6985 — pre-Card-S: the installed 17.2.x accept-set, recorded (deactivates on the lockfile bump)',
+  () => {
+    it('still accepts the wizard-inert step keys and the empty-sections wizard', () => {
+      // NOT an endorsement — this is the accept-set the Card S door closes,
+      // pinned so this suite's output states which spec line it measured.
+      // objectui's own guards for this regime are the renderer-side pins
+      // (`wizardRuledSemantics-6985.test.tsx`: the keys are dropped, the
+      // empty wizard degrades to simple) and the compile-time step type.
+      expect(parse(stepWithPredicate).success).toBe(true);
+      expect(parse(wizard({ sections: [{ ...step, collapsible: true, collapsed: true }] })).success).toBe(true);
+      expect(parse(wizard({ sections: [] })).success).toBe(true);
+      expect(parse({ type: 'wizard' }).success).toBe(true);
+    });
+  },
+);

--- a/packages/plugin-form/src/sectionPredicateDiagnostic.ts
+++ b/packages/plugin-form/src/sectionPredicateDiagnostic.ts
@@ -25,6 +25,13 @@
  * an author who writes the key on a wizard is told so rather than watching it do
  * nothing.
  *
+ * Since objectstack#13622 (ruled 2026-08-31) the boundary is ALSO enforced at
+ * the author door: `@objectstack/spec` refuses `visibleWhen` on a wizard step
+ * at parse, so authored form-view metadata can no longer arrive here carrying
+ * it. This report is deliberately KEPT (Card R of that ruling): programmatic
+ * SDUI callers do not pass the spec door, and metadata published before the
+ * tightening still round-trips — for both, this warning is the only signal.
+ *
  * Single-sourced so the runtime report and the pin that holds its wording cannot
  * drift apart.
  */

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -1050,12 +1050,23 @@ export interface ObjectFormSection {
   
   /**
    * Whether the section can be collapsed
+   *
+   * Wizard boundary (objectstack#13622 D2, ruled 2026-08-31): wizard steps do
+   * not collapse — the wizard shows exactly the current step. On a
+   * `formType: 'wizard'` form the renderer drops this key (ObjectForm's
+   * wizard map rebuilds each step key by key and does not copy it), and
+   * `@objectstack/spec` refuses an authored `true` on a wizard step at parse.
+   * An authored `false` stays accepted everywhere: it declares exactly the
+   * behavior a wizard delivers.
    * @default false
    */
   collapsible?: boolean;
-  
+
   /**
    * Whether the section is initially collapsed
+   *
+   * Same wizard boundary as {@link collapsible}: dropped by the wizard route,
+   * and `true` is refused on a wizard step at the spec door.
    * @default false
    */
   collapsed?: boolean;
@@ -1100,6 +1111,17 @@ export interface ObjectFormSection {
    * else (the console precedent, 2026-08-22 after #5594). Derived
    * `fieldGroups` sections carry no predicate slot, so their groups are
    * always drawn.
+   *
+   * Wizard boundary (objectstack#13622 D2, ruled 2026-08-31): wizard steps
+   * carry NO predicate slot — steps are entered in array order behind the
+   * step gate, never conditionally. On a `formType: 'wizard'` form the
+   * renderer drops this key (and reports the drop via console.warn — see
+   * `sectionPredicateUnsupportedWarning` in @object-ui/plugin-form), the
+   * wizard's own step type (`WizardStepConfig`) rejects it at compile time
+   * (objectui#6237's ruled split), and `@objectstack/spec` refuses it on a
+   * wizard step at parse. Put the predicate on the fields inside the step —
+   * field-level `visibleWhen` is evaluated on every layout. A step-level
+   * predicate is a future contract of its own, tracked in objectui#6237.
    */
   visibleWhen?: string | { dialect?: string; source: string };
 
@@ -1223,6 +1245,15 @@ export interface ObjectFormSchema extends BaseSchema {
    * Form sections for organized layout.
    * Used by tabbed/wizard/simple forms to group fields.
    * Aligns with @objectstack/spec FormView.sections
+   *
+   * Wizard semantics (objectstack#13622, ruled 2026-08-31): on a
+   * `formType: 'wizard'` form the sections ARE the steps — there is no
+   * `steps` key — and array order is step order (no `order` key; reordering
+   * the array reorders the wizard). A wizard with absent or empty `sections`
+   * is refused by `@objectstack/spec` at parse for authored form views; this
+   * renderer's own fallback for that shape (rendering as a plain simple
+   * form) is only reachable by programmatic SDUI callers, which do not pass
+   * the spec door.
    */
   sections?: ObjectFormSection[];
   
@@ -1277,6 +1308,13 @@ export interface ObjectFormSchema extends BaseSchema {
   
   /**
    * Allow skipping steps. Only used when formType is 'wizard'.
+   *
+   * This is navigation freedom, NOT a validation exemption (objectstack#13622
+   * D4, ruled 2026-08-31): the default (absent/`false`) is the step gate —
+   * the next step opens only after the current step's form submits and
+   * validates — and `true` merely lets the user enter any step. Either way
+   * the final submit re-checks every step's declared field set and returns
+   * the user to the first step with an outstanding required field.
    * @default false
    */
   allowSkip?: boolean;


### PR DESCRIPTION
Fixes #6985

Card R of the #13342 chain — the objectui **alignment + pins** for the ruled `type: 'wizard'` tightening (design of record objectstack#13622 D1–D8; maintainer ruling 2026-08-31, director batch #12, verbatim 「同意」; spec half landed as objectstack PR 13733, commit 4bc18e54 on objectstack main). Dispatched only after Card S landed, never co-batched. Together with Card S this finishes the #13342 chain's two halves; #13342 itself is the coordination node and remains open.

## Re-priced measurement (objectui main @ 7fc5c3c)

The card ordered a re-price at dispatch. Measured residue, item by item:

**Already landed, no work needed (cited, not re-built):**
- Leave-step gate, final full-set re-validation through the canonical rule engine, and the progress state machine — `WizardForm.tsx` (the proposal's own measurement, re-confirmed).
- D4 `allowSkip` semantics implemented AND pinned since #2959 — `wizardSkipValidation.test.tsx` ("refuses the submit and returns to the step holding the missing field" + sequential control). Deliberately not re-pinned here.
- D2 at the type level: `WizardStepConfig` is an independent 7-key interface with no predicate/collapse keys (objectui#6237 split, PR #6903), with the compile-time pin and the `*When` FAMILY pin in `tabbedFormSectionPredicate-6237.test.tsx`.
- The wizard route's key-by-key drop of `visibleWhen` with the scoped console.warn — kept, per the ruled Card R disposition (programmatic SDUI callers never pass the spec door; the warn is their only signal). Wording untouched; its pins untouched.
- objectui's type mirrors need NO accept-set change: `form-spec.ts` is DERIVED from the installed spec's own types, and the spec's ruled mechanism (D2 option A) is a parse-time refinement over the SINGLE shared section schema — invisible at the type level, so a type-level mirror that shares the section shape across variants is exactly aligned already.

**Residue landed in this PR:**
1. **metadata-admin view create seeded the D7-refused shape** — `anchors.ts` `createBuildBody` emitted `sections: []` for every form family, which for wizard is precisely the absent/empty-steps shape the tightened spec refuses at the ViewItem config door. Now seeds one starter step for wizard only (`sections: [{ label: 'Step 1', fields: [] }]`); tabbed/simple keep the bare `[]`. Same seed-the-required-shape move as the flow anchor's `type` enum (objectui#2326). Pinned in `view-create-body.test.ts` with the tabbed boundary control.
2. **TSDoc alignment in `@object-ui/types`** where `ObjectFormSection` / `ObjectFormSchema` restate the form-view family: `visibleWhen` / `collapsible` / `collapsed` now name the wizard drop + spec-door refusal; `sections` states sections-ARE-steps, array order = step order, and the D7 door; `allowSkip` states navigation-freedom-not-validation-exemption. Type shapes unchanged.
3. **Consumer-side behaviour pins** — `wizardRuledSemantics-6985.test.tsx`: a DENYING step `visibleWhen` does not remove the step (renders first, unconditionally, stays on the indicator); `collapsible`/`collapsed: true` produce no collapse affordance (with a positive control proving the affordance probe detects the real thing on `FormSectionContainer`); the empty/absent-sections wizard's measured degradation to a plain simple form is pinned AS the shape the spec door now refuses (still the documented path for programmatic SDUI callers); a one-step wizard renders as a wizard (no arity floor); array order is step order, with a reversed-array control.
4. **Installed-spec door pins** — `wizardSpecDoor-6985.test.ts`, see the installability gate below.
5. Comment alignment in `ObjectForm.tsx` / `sectionPredicateDiagnostic.ts` / `WizardStepConfig` docblock recording the author-door upgrade.

## ⚠️ Installability gate — the choice, stated

The lockfile pins `@objectstack/spec` **17.2.0**, which predates Card S (measured: 17.2.0 accepts a wizard step `visibleWhen`, `collapsible: true`, and the empty-sections wizard). Chosen handling: **capability-gated, not version-gated** — `wizardSpecDoor-6985.test.ts` probes the installed `FormViewSchema` once (does it refuse a wizard step predicate?) and runs exactly one of two halves:
- post-Card-S half (8 refusal/prescription pins): **skipped today**, self-activates on the lockfile bump with zero edits;
- pre-Card-S half: pins the 17.2.x accept-set so every run records which regime it measured; self-deactivates on the same bump.
- unconditional on both lines: the minimal stepped wizard parses (positive control) and `steps:` is refused (T1 — never an accepted alias).

No cross-repo workspace link, no lockfile bump here.

**Forward execution of the gated half** (so the pins are not a bet on a future release): replicated 1:1 against the REAL tightened spec — built `@objectstack/spec` in a detached objectstack worktree at origin/main (contains Card S 4bc18e54) and ran the same fixtures/assertions: **17/17 PASS**, including probe-flips-true, every refusal message fragment, the authored-false collapse boundary, the wizard-scoped control, and the regime flip (the pre-half's acceptance rows go red there). The anchors fix got the same treatment: the OLD `sections: []` wizard ViewItem is refused at `config.sections` on the tightened `ViewItemSchema` (predicted red, observed), the NEW seeded body parses on BOTH spec lines, tabbed empty stays accepted.

## Clause-② declaration (measured, against the claim's pre-read)

The claim pre-read "yes (mirror restates the tightening = accept-set narrowing)". The measured diff narrows **no accept surface in this repo**: the wizard-specific type (`WizardStepConfig`) already refused these keys (landed #6903), the shared section type mirrors the spec's own type-level shape (the ruled refusal is a runtime refinement), and there is no objectui-side zod door for form views (the client validator reads the installed spec and inherits Card S on bump). What changes behaviour is one producer emission (the wizard create seed — an emission WIDENING toward validity, not an acceptance change) plus docs and pins. Reported as **clause-② no on actuals**; parked draft + `needs:contract-review` per the dispatch regardless — the review chain owns that verdict.

## Evidence (all at head 397a40c, via the shared verify lock; verdict lines quoted from the gate)

- New + neighbour pins: `wizardRuledSemantics-6985` + `wizardSpecDoor-6985` + `sectionPredicateLayoutDiagnostic-6237` + `tabbedFormSectionPredicate-6237` + `wizardSkipValidation` + `WizardForm.regression` + `view-create-body` — **7 files, 59 passed, 8 skipped** (the 8 = the post-Card-S half, gated off on 17.2.0 by design), `VERDICT command-exit 0`.
- Whole `@object-ui/plugin-form` package: **80 files, 813 passed, 8 skipped**, `VERDICT command-exit 0` (pre-commit tree, only delta after was removing one unused import — re-covered by the head run above).
- `@object-ui/types` package + the anchors-affected app-shell suites (all anchors importers plus createBody/clientValidation/viewItemSpec): **90 files, 1113 passed**, `VERDICT command-exit 0`.
- `turbo run type-check` for types + plugin-form + app-shell (builds dependency closure first; includes each package's `tsconfig.test.json`, whose include globs match the new test files — checked, not assumed): **32 tasks successful**, exit 0.
- `turbo run lint` for the three packages: 4 tasks successful, exit 0. Narrowing declared: repo-wide `pnpm lint` (turbo across all packages) is CI's run; the three linted packages are the only ones this diff touches, and per-package eslint configs do not read sibling packages' sources, so untouched packages' verdicts cannot move.
- `node scripts/check-changeset-presence.mjs`: "6 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)". `check-changeset-no-major`: "No changeset declares a major bump." Changeset grade: patch across the three packages — the only behaviour change is the wizard create seed (a fix-shaped emission correction); the accept-set narrowing itself shipped with the spec (Card S carries the BREAKING narrative under the launch-window convention). Final grade is this review chain's call.
- Control-byte scan of every changed file: zero hits.

## Fences

- No teaching material: the #13337/#13086 fence stands until both halves land; every docs change here is TSDoc/code comment.
- The step-predicate FUTURE contract stays tracked in objectui#6237 — #6237 is not addressed here and remains open.
- Parked DRAFT with `needs:contract-review` per the dispatch — enqueue belongs to the in-seat review; never readied by this seat.

_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_