### PR TITLE
docs(scripts): re-derive the PER_CHUNK_BASELINE provenance against a live gate run

### DIFF
--- a/.changeset/6778-per-chunk-baseline-provenance.md
+++ b/.changeset/6778-per-chunk-baseline-provenance.md
@@ -1,0 +1,28 @@
+---
+---
+
+Build tooling only — the `PER_CHUNK_BASELINE` doc comment in
+`scripts/check-eager-closure-budget.mjs`. No constant, no verdict and no test
+changed; nothing ships from this change.
+
+The paragraph argued from a reading three aggregate re-baselines old. It said
+`BASELINE` "still carries `4c1623c0c`" (it carries `3d257c85a`), did its
+arithmetic against the retired 4,005,911 figure, and concluded that the
+aggregate ceiling sat far above the payload and that the per-chunk ceilings were
+therefore the only lines still holding the three biggest chunks in place. That
+conclusion was the reverse of what the same script prints in the same run: a
+full console build on `e33b44796` reports the aggregate at 3149.2 KB measured /
+3191.4 KB ceiling, headroom 42.2 KB = 0.47x the 89.0 KB regression — in range,
+and doing work. An author sizing a re-baseline off the comment would have read
+"this half is decorative" at the moment the tool was saying "this half is
+working".
+
+Rewritten against that live run. The provenance direction is now stated as
+unstable by construction — which side is the later reading flips every time
+either is re-baselined, so the comment tells the reader to read the commit names
+rather than trusting a direction written in prose. The aggregate-versus-per-chunk
+relationship is re-derived and narrowed to what is true: all four ceilings are
+inside one regression, and the per-chunk ceilings are the TIGHTER half
+(0.21x / 0.08x / 0.04x against the aggregate's 0.47x) that also says WHERE, not
+the only half that works. The quoted figures are labelled as one dated run, with
+the gate's own printed table named as the answer in force.

--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -387,18 +387,58 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
  * Exported so the ceilings are CHECKED against it instead of merely asserted
  * in this comment.
  *
- * ⚠️ This is a DIFFERENT and LATER reading than {@link BASELINE} above, which
- * still carries `4c1623c0c`. On `2c8474c04` the same build measures the closure
- * at 3,298,620 bytes — 707,291 BELOW that recorded aggregate baseline, almost
- * all of it in `vendor-objectstack` (1,493 KB in the objectui#5490 card, 926 KB
- * here). The aggregate ceiling and its baseline were deliberately NOT touched
- * by objectui#5490: objectui#5468 ruled that the aggregate line "stays as
- * shipped", and moving it — in either direction — is the maintainer's call, not
- * this card's. The consequence is recorded rather than quietly fixed: the
- * aggregate ceiling now sits ~787 KB above today's payload, which is far more
- * than the {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES} it was sized to catch,
- * and until that is re-decided these per-chunk ceilings are what actually holds
- * the three biggest chunks in place.
+ * ⚠️ These readings are on DIFFERENT commits from {@link BASELINE} above, and
+ * WHICH ONE IS LATER flips every time either side is re-baselined — so read the
+ * commit names, never a direction asserted here. As of objectui#6776 the
+ * AGGREGATE is the later reading: BASELINE's `3d257c85a` is dated 2026-08-30
+ * against `2c8474c04` on 2026-08-25 here, and `a64e96ca8` was recorded by
+ * objectui#6759, which landed 2026-08-29. This paragraph asserted the reverse,
+ * in the present tense, from objectui#5490 until objectui#6778 — true when it
+ * was written, then left standing while three aggregate re-baselines moved
+ * {@link BASELINE} out from under it.
+ *
+ * ⚠️ Do not expect `git show` to answer for all of these. Squash-merge keeps the
+ * landing commit and drops the PR branch, so of the three named above only
+ * `2c8474c04` is an ancestor of `main`; `3d257c85a` still resolves as an object
+ * but is not on `main` (it landed as `350509b53`), and `a64e96ca8` is not an
+ * object in this repository at all. That is why every hash here is cited WITH
+ * its issue: the issue outlives the hash.
+ *
+ * The aggregate ceiling and its baseline were deliberately NOT touched by
+ * objectui#5490: objectui#5468 had ruled that the aggregate line "stays as
+ * shipped", and moving it — in either direction — is the maintainer's call. That
+ * is why the provenance splits in the first place.
+ *
+ * ⛔ The stale direction is the cheap half. The expensive half is the CONCLUSION
+ * this paragraph used to draw from it: that the aggregate ceiling sat far above
+ * the payload — 4,086,000 over the 3,298,620 reading, 787,380 bytes of headroom,
+ * 8.64x {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES} — and that these per-chunk
+ * ceilings were therefore the only lines holding the three biggest chunks in
+ * place. That was accurate for objectui#5490 and is now false: objectui#5924,
+ * objectui#6683 and objectui#6776 lowered the aggregate ceiling three times,
+ * onto 3,268,000, and it is back in range and doing work.
+ *
+ * Checked rather than argued, which is the rule everywhere else in this file. A
+ * full console build on `e33b44796` and `pnpm check:eager-closure` printed:
+ *
+ *     ✅ aggregate closure          3149.2 KB measured / 3191.4 KB ceiling (headroom 42.2 KB = 0.47x)
+ *     ✅ chunk `vendor-objectstack`  925.7 KB measured /  944.3 KB ceiling (headroom 18.6 KB = 0.21x)
+ *     ✅ chunk `framework`           492.9 KB measured /  500.0 KB ceiling (headroom  7.1 KB = 0.08x)
+ *     ✅ chunk `ui-components`       386.2 KB measured /  389.6 KB ceiling (headroom  3.4 KB = 0.04x)
+ *
+ * All four sit inside one regression, which is the whole of what "in range"
+ * means here — {@link evaluateHeadroomSensitivity} calls 1.00x an error. So the
+ * relationship these ceilings have to the aggregate is no longer "we are the
+ * half that still works". It is narrower, and still worth having: they are the
+ * TIGHTER half — 0.21x, 0.08x, 0.04x against the aggregate's 0.47x — so growth
+ * in these three chunks reds the gate well before the aggregate would, and they
+ * say WHERE, which one total never can.
+ *
+ * ⛔ Do not size a re-baseline off the figures above. They are ONE dated run,
+ * recorded so this paragraph rests on a measurement instead of an argument; the
+ * answer in force is the table the gate prints on YOUR build. That this prose
+ * went three re-baselines stale while the numbers beside it could not
+ * (objectui#6778) is the reason to distrust the prose first.
  *
  * Keys must match {@link PER_CHUNK_GZIP_CEILINGS} exactly (a test enforces it):
  * a ceiling with no measurement behind it is a number someone guessed, and a


### PR DESCRIPTION
Fixes #6778

Comment-only change to `scripts/check-eager-closure-budget.mjs`: the doc comment on `PER_CHUNK_BASELINE`. No constant, no verdict and no test moved, and the gate prints an identical verdict before and after the edit.

## The live run this is written against

The card's third point is that the paragraph's conclusion contradicts a verdict the same script prints in the same run, so the new prose is validated against an actual run rather than a static recomputation. Full package build + console build on `e33b44796` (the branch point, clean tree), then `pnpm check:eager-closure`, exit 0:

```
✅ Console eager closure is 3149.2 KB gzipped across 48 of 517 chunks (budget: 3191.4 KB, headroom: 42.2 KB).
✅ Per-chunk eager budgets (3 chunks weighed):
  ✅ vendor-objectstack       925.7 KB / 944.3 KB ceiling (headroom 18.6 KB)
  ✅ framework                492.9 KB / 500.0 KB ceiling (headroom 7.1 KB)
  ✅ ui-components            386.2 KB / 389.6 KB ceiling (headroom 3.4 KB)
✅ Ceiling sensitivity (4 ceilings, each weighed against the report just read):
  ✅ aggregate closure               3149.2 KB measured / 3191.4 KB ceiling (headroom 42.2 KB = 0.47x the 89.0 KB regression)  [MAX_EAGER_CLOSURE_GZIP_BYTES]
  ✅ chunk `vendor-objectstack`       925.7 KB measured / 944.3 KB ceiling (headroom 18.6 KB = 0.21x the 89.0 KB regression)
  ✅ chunk `framework`                492.9 KB measured / 500.0 KB ceiling (headroom 7.1 KB = 0.08x the 89.0 KB regression)
  ✅ chunk `ui-components`            386.2 KB measured / 389.6 KB ceiling (headroom 3.4 KB = 0.04x the 89.0 KB regression)
```

Exact bytes from the same report: `eagerGzipBytes` 3,224,774 against a 3,268,000 ceiling — 43,226 bytes of headroom, 0.4743x the 91,136-byte regression.

## What the three points turned out to be

**1. `BASELINE` does not carry `4c1623c0c`.** It carries `3d257c85a` / `3_222_314`. The card said `bd2a7ec50` / `3_254_004`; that was correct on 2026-08-29 and objectui#6776 has since re-baselined again, so the card's own figure was one re-baseline stale by the time it was picked up. Re-derived on `e33b44796`, not inherited.

**2. The "707,291 BELOW" arithmetic.** Confirmed as 4,005,911 − 3,298,620 = 707,291 exactly, which is what pinned the provenance to the retired `4c1623c0c` reading. Removed from the present-tense paragraph. The two *historical* citations of `4c1623c0c` elsewhere in the file (in the "Why this number has moved" narrative and in the `MAX_EAGER_CLOSURE_GZIP_BYTES` re-baseline list) are correct as past-tense statements and are deliberately left alone.

While re-deriving it, one further error in the old text: "the aggregate ceiling now sits ~787 KB above today's payload" was a units slip. 4,086,000 − 3,298,620 = **787,380 bytes**, i.e. ~769 KB, not ~787 KB. The magnitude of the point (8.64x the regression, blind) was right; the unit was not. The replacement states bytes and the multiple.

**3. The sharp one — the conclusion is reversed.** It is. The paragraph said the aggregate ceiling is far wider than the regression it must catch, and therefore that the per-chunk ceilings are the only lines holding the three biggest chunks in place. The run above says the aggregate sits at 0.47x — in range, and `evaluateHeadroomSensitivity` errors at 1.00x. Three downward re-baselines closed the gap the old text described: objectui#5924 (4,086,000 → 3,345,000), objectui#6683 (→ 3,300,000), objectui#6776 (→ 3,268,000).

### What the relationship IS now

Not "the aggregate is decorative". All four ceilings are inside one regression. What survives is narrower and still worth stating: the per-chunk ceilings are the **tighter** half — 0.21x / 0.08x / 0.04x against the aggregate's 0.47x — so growth in those three chunks reds the gate well before the aggregate would, and they say *where*, which one total never can.

### A fourth thing, not in the card

The paragraph opened "This is a DIFFERENT and **LATER** reading than `BASELINE` above". That direction is now inverted: `BASELINE` is `3d257c85a` (2026-08-30), while the per-chunk readings are `2c8474c04` (2026-08-25) and `a64e96ca8` (recorded by objectui#6759, landed 2026-08-29). Rather than swap "LATER" for "EARLIER" — which would go stale on the next re-baseline in either direction — the comment now says the direction flips on every re-baseline and tells the reader to read the commit names.

Also verified and recorded, because it bears directly on objectui#6631's "nobody could establish which side moved": of the three commits the comment names, only `2c8474c04` is an ancestor of `main`. `3d257c85a` still resolves as an object but is not on `main` (it landed as `350509b53`), and `a64e96ca8` is not an object in this repository at all — squash-merge keeps the landing commit and drops the PR branch. That is why each hash is cited with its issue.

## Against staleness

The card's structural observation is that this file's guards cover the numbers and not the prose that explains them. This PR does not add a mechanism for that (that is a separate card), but it writes the prose so the same failure is harder: the direction claim is stated as unstable by construction, the figures are labelled as one dated run, and the gate's own printed table is named as the answer in force.

## Verification

Union re-run on the final commit `aebe09174`, clean tree:

| check | result |
|---|---|
| `pnpm check:eager-closure` | exit 0, verdict byte-identical to the pre-edit run |
| `vitest run` — `check-eager-closure-budget`, `check-side-effects-array`, `render-budget-comment`, `vite-declared-lazy-views`, `vite-ineffective-dynamic-imports` | 5 files, **191 tests passed** |
| `pnpm check:control-bytes` | exit 0 (5849 files scanned) |
| `pnpm lint:root` — the full root scope that owns `scripts/` | exit 0 (29 pre-existing warnings, none in this file) |
| `pnpm changeset:check`, `check-changeset-presence.mjs` | exit 0 |
| `pnpm check:entry-guard`, `check:esm-specifiers`, `check:doc-fences` | exit 0 |

The five test files are every file in the repo that names this script (`git grep -l check-eager-closure-budget`), not just its own suite.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GgDDqh6YnkXqsnVTCa7wHk)_