### PR TITLE
ci: bound the type-check Turbo cache save so bookkeeping cannot void a recorded verdict

### DIFF
--- a/.changeset/6577-bound-turbo-cache-save.md
+++ b/.changeset/6577-bound-turbo-cache-save.md
@@ -1,0 +1,45 @@
+---
+---
+
+Bounds the `.turbo/cache` save on `ci.yml`'s `type-check` job so cache bookkeeping can no
+longer discard a verdict the gate has already recorded (objectui#6577). CI-only; no package
+source, no published contract and no runtime behaviour is touched, hence the empty
+declaration.
+
+On 2026-08-26 a pull request whose every check was green was ejected from the merge queue
+with `CI_FAILURE`. All 21 real steps of its `Type Check` job succeeded — `Run type-check`
+reported success at 13:31:31Z — and then `Post Turbo Cache`, the save phase of
+`actions/cache@v6`, spent 13m09s inside the upload and was still there when the job's
+`timeout-minutes: 20` fired at 20m02s. The job went `cancelled`, the merge queue cannot tell
+`cancelled` from `failure`, and the pull request was dequeued. The bill lands on every lane:
+the queue is one shared serial resource, so that is 20 minutes of head-of-line blocking, an
+ejection, and a full re-run. It was transient, not structural — the same job on the same PR
+head thirteen minutes earlier went green in 5m53s with a cache save of **one second**.
+
+Same shape as the objectui#5304 `apt-get` fix already documented in `ci.yml`: an unbounded
+network call whose only backstop was the job ceiling, which converts a transient fault into a
+CANCELLED check — a gate that reports nothing at all. With one twist that makes it worse
+here, and it is the sentence the workflow now carries: **the verdict had already been
+recorded, and everything after it was bookkeeping.**
+
+The combined `actions/cache` action declares `main: dist/restore/index.js` and
+`post: dist/save/index.js`, so its save is a step the *runner* generates at job end. No
+workflow syntax attaches `timeout-minutes` or `continue-on-error` to a generated post step,
+which is why the step is split rather than annotated — the route `actions/cache`'s own
+`save-always` deprecation text points at:
+
+- `actions/cache/restore@v6` keeps the original position, path, key and restore-keys.
+- `actions/cache/save@v6` runs last, after the checking steps, which is exactly where the
+  post phase already ran — with `timeout-minutes: 5` (300x the measured healthy save, and
+  ~8 minutes clear of the job ceiling from the slowest verdict path on record) and
+  `continue-on-error: true`, so a cache that fails to upload costs the next run some time
+  instead of speaking for the code under test.
+
+Raising `timeout-minutes: 20` was ruled out: a larger ceiling only buys a longer hang, still
+ends in `cancelled`, and lifting a gate's ceiling weakens the gate.
+
+What the job accepts and rejects is unchanged — every command-bearing step in every job of
+`ci.yml` is byte-identical to `main`, and no job's `timeout-minutes` moved.
+`scripts/__tests__/turbo-cache-save-bound.test.ts` pins the contract, because reverting this
+fix is invisible: fold the split back into one step and the cache still works, every run
+still passes, and the next transient stall ejects the next green pull request.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,9 +420,53 @@ jobs:
         if: steps.relevant.outputs.should_run == 'true'
         run: pnpm type-check:scripts
 
-      - name: Turbo Cache
+      # ── Cache bookkeeping cannot void a recorded verdict (objectui#6577) ──
+      # THE ORDERING, because it is the only thing a future reader needs in
+      # order to judge whether this step may be touched: this job's verdict is
+      # recorded by the three checking steps below, the last of which is
+      # `Type-check repo-root vitest setup files`. EVERYTHING AFTER THAT POINT
+      # IS BOOKKEEPING — writing `.turbo/cache` back for the next run. It must
+      # never be able to discard an answer the gate has already produced.
+      #
+      # It could, and once did. On 2026-08-26 the merge-group build of #6571
+      # was ejected from the queue with `CI_FAILURE` while every substantive
+      # check passed: all 21 real steps of this job succeeded, the gate steps
+      # included, and then the runner-generated `Post Turbo Cache` step spent
+      # 13m09s (789s) inside the cache upload and was still there when this
+      # job's `timeout-minutes: 20` fired at 20m02s. The job went `cancelled`,
+      # the merge queue cannot tell `cancelled` from `failure`, and a pull
+      # request that had passed was dequeued — 20 minutes of head-of-line
+      # blocking for every lane, then a full re-run. Same shape as the
+      # objectui#5304 apt block in the `e2e` job below: an unbounded network
+      # call whose only backstop was the job ceiling, which converts a
+      # transient fault into a CANCELLED check — a gate that reports nothing.
+      #
+      # A transient, not a property of this workflow: the same job on the same
+      # PR head thirteen minutes earlier (job 98190108000) went green in 5m53s
+      # and its cache save took ONE SECOND. That 1s is what the bound on the
+      # save step at the end of this job is sized against.
+      #
+      # Why the restore/save SPLIT and not a timeout on a single cache step:
+      # combined `actions/cache` declares `main: dist/restore/index.js` plus
+      # `post: dist/save/index.js`, so the save is a step the RUNNER generates
+      # (`Post Turbo Cache`, step #40 in the incident) — not an authored step,
+      # and no workflow syntax attaches `timeout-minutes` or
+      # `continue-on-error` to it. Splitting moves the save into the main
+      # phase, where both are ordinary documented step keys. The action's own
+      # `save-always` deprecation text points at this same split.
+      #
+      # The restore half is deliberately left UNBOUNDED. A restore stall fails
+      # before any verdict exists — a gate that did not run, which is honest —
+      # rather than a recorded verdict discarded, and bounding it would force a
+      # cold check under this same 20-minute ceiling.
+      #
+      # ⛔ Raising `timeout-minutes: 20` is not the fix and was ruled out on the
+      # card: a larger ceiling only buys a longer hang, still ending in
+      # `cancelled`, and lifting a gate's ceiling weakens the gate.
+      - name: Restore Turbo Cache
+        id: turbo-cache
         if: steps.relevant.outputs.should_run == 'true'
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-type-check-${{ github.sha }}
@@ -462,6 +506,39 @@ jobs:
       - name: Type-check repo-root vitest setup files
         if: steps.relevant.outputs.should_run == 'true'
         run: pnpm type-check:vitest-setup
+
+      # The bookkeeping half of the split documented at the restore step above,
+      # placed HERE — after the last checking step — because that is exactly
+      # where the post phase it replaces already ran. Nothing about which
+      # commits this job accepts or rejects moves with it.
+      #
+      # `timeout-minutes: 5` is the bound the incident asked for: 300x the 1s a
+      # healthy save of this cache measured, so it cannot fire on a working
+      # runner, and even measured from the slowest verdict path on record
+      # (6m53s, the incident run) it lands roughly eight minutes clear of this
+      # job's 20-minute ceiling — this step can no longer reach that ceiling.
+      #
+      # `continue-on-error: true` is the other half, and without it the bound
+      # would only trade a `cancelled` gate for a red one. A cache that failed
+      # to upload costs the next run some time; it says nothing whatsoever
+      # about the code under test, so it must not be allowed to speak for it.
+      #
+      # Behaviour preserved, spelled out so the equivalence is checkable:
+      #   - `cache-hit != 'true'` reproduces the combined action's own "exact
+      #     hit on the primary key ⇒ do not save" skip.
+      #   - the condition names no status function, so the implicit `success()`
+      #     still applies — matching the combined action's `post-if: success()`.
+      #   - same `path` and same `key` as the restore step above.
+      - name: Save Turbo Cache
+        if: >-
+          steps.relevant.outputs.should_run == 'true'
+          && steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-type-check-${{ github.sha }}
 
   # PRs run the suite split across 4 runners. The suite is dominated by fixed
   # per-file cost rather than by the assertions: a PR run reported 495s wall

--- a/scripts/__tests__/turbo-cache-save-bound.test.ts
+++ b/scripts/__tests__/turbo-cache-save-bound.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+const CI = path.join(ROOT, '.github/workflows/ci.yml');
+
+/**
+ * objectui#6577 — cache bookkeeping voided a verdict the gate had already
+ * recorded.
+ *
+ * On 2026-08-26 the merge-group build of #6571 was ejected from the queue with
+ * `CI_FAILURE` while every substantive check passed. All 21 real steps of the
+ * `Type Check` job succeeded — `Run type-check` reported success at 13:31:31Z —
+ * and then `Post Turbo Cache`, the save phase of `actions/cache@v6`, spent
+ * 13m09s (789s) inside the upload and was still there when the job's
+ * `timeout-minutes: 20` fired at 20m02s. The job went `cancelled`, the merge
+ * queue cannot tell `cancelled` from `failure`, and a pull request that had
+ * passed was dequeued. It was transient, not structural: the same job on the
+ * same PR head thirteen minutes earlier went green in 5m53s with a cache save
+ * of ONE SECOND.
+ *
+ * The ordering is the whole point, and it is what this file exists to keep
+ * true: the verdict is recorded by the job's command steps; everything after
+ * them is bookkeeping. Bookkeeping must be bounded, and its failure must not
+ * be able to speak for the code.
+ *
+ * Why this needs a pin at all — the fix is invisible when reverted. Folding
+ * the split back into one `actions/cache` step, or dropping either key from
+ * the save, restores the defect with nothing going red: the cache still works,
+ * every run still passes, and the next transient upload stall ejects the next
+ * green pull request. That is this repository's recurring "looks like
+ * enforcement, isn't" class (objectui#3009, #3181, #3494), and it is why the
+ * sibling #5304 apt fix shipped with `ensure-chromium-ready.test.ts` beside it.
+ *
+ * Deliberately NOT asserted: that the restore half is bounded. A restore stall
+ * fails BEFORE any verdict exists — a gate that did not run, which is honest —
+ * rather than a recorded verdict discarded, and bounding it would force a cold
+ * check under the same job ceiling. That is a different card if it ever fires.
+ */
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  id?: string;
+  if?: string;
+  'timeout-minutes'?: number;
+  'continue-on-error'?: boolean;
+  with?: Record<string, string>;
+}
+interface Job {
+  'timeout-minutes'?: number;
+  steps: Step[];
+}
+
+const workflow = parseYaml(fs.readFileSync(CI, 'utf8')) as { jobs: Record<string, Job> };
+
+function typeCheckJob(): Job {
+  const job = workflow.jobs['type-check'];
+  expect(job, 'ci.yml must still define a `type-check:` job').toBeDefined();
+  // Non-vacuity: every assertion below scans this step list, so a parse that
+  // collapsed it to nothing would make all of them pass while reading nothing.
+  expect(
+    job.steps.length,
+    'the `type-check` job parsed to implausibly few steps — the scan below would be vacuous',
+  ).toBeGreaterThan(10);
+  return job;
+}
+
+const saveStep = (job: Job): Step => {
+  const found = job.steps.filter((s) => (s.uses ?? '').startsWith('actions/cache/save@'));
+  expect(
+    found.length,
+    'the `type-check` job must save `.turbo/cache` through exactly one `actions/cache/save` ' +
+      'step. That step is where the bound lives; without it there is nothing to bound.',
+  ).toBe(1);
+  return found[0];
+};
+
+describe('ci.yml — the type-check cache save is bounded and non-fatal (objectui#6577)', () => {
+  it('saves through a MAIN-phase step, never the combined action', () => {
+    // Combined `actions/cache` declares `main: dist/restore/index.js` and
+    // `post: dist/save/index.js`. Its save is therefore a step the RUNNER
+    // generates at job end (`Post Turbo Cache`, step #40 in the incident), and
+    // no workflow syntax attaches `timeout-minutes` or `continue-on-error` to a
+    // generated post step. Splitting is not a style preference — it is the only
+    // way the two keys below can exist at all. `actions/cache`'s own
+    // `save-always` deprecation text points at this same split.
+    const combined = typeCheckJob()
+      .steps.filter((s) => /^actions\/cache@/.test(s.uses ?? ''))
+      .map((s) => s.name ?? '(unnamed)');
+
+    expect(
+      combined,
+      'the `type-check` job is back on the combined `actions/cache` action:\n' +
+        combined.map((n) => `  - ${n}`).join('\n') +
+        '\n\nIts save runs as a runner-generated POST step, which cannot carry ' +
+        '`timeout-minutes` or `continue-on-error` — so an upload stall runs the job into its ' +
+        'ceiling and cancels a gate that had already passed (objectui#6577). Use ' +
+        '`actions/cache/restore` plus a bounded `actions/cache/save`.',
+    ).toEqual([]);
+  });
+
+  it('bounds the save, and does not let a failed save speak for the code', () => {
+    const save = saveStep(typeCheckJob());
+
+    expect(
+      typeof save['timeout-minutes'],
+      'the cache save step must declare `timeout-minutes`. It is the only thing standing ' +
+        'between a stalled upload and the job ceiling, and the job ceiling reports `cancelled` — ' +
+        'a gate that says nothing at all (objectui#6577).',
+    ).toBe('number');
+
+    expect(
+      save['continue-on-error'],
+      'the cache save step must declare `continue-on-error: true`. Without it the bound only ' +
+        'trades a `cancelled` gate for a red one: a cache that failed to upload costs the next ' +
+        'run some time and says nothing about the code under test.',
+    ).toBe(true);
+  });
+
+  it('leaves the verdict path at least as much ceiling as bookkeeping can consume', () => {
+    // Derived rather than hard-coded: whatever the two numbers become, the
+    // bookkeeping half must not be able to crowd out the half that produces the
+    // answer. At the values this landed with (5 of 20) the save cannot reach
+    // the ceiling from any verdict path yet observed — the slowest on record
+    // finished 6m53s in.
+    const job = typeCheckJob();
+    const ceiling = job['timeout-minutes'];
+    const bound = saveStep(job)['timeout-minutes'];
+
+    expect(typeof ceiling, 'the `type-check` job must still declare `timeout-minutes`').toBe('number');
+    expect(
+      (bound as number) * 2,
+      `the cache save may run for ${bound} of the job's ${ceiling} minutes. A bound that large ` +
+        'can still starve the checking steps of the ceiling and cancel the job — which is the ' +
+        'defect, not the fix.',
+    ).toBeLessThanOrEqual(ceiling as number);
+  });
+
+  it('runs the save AFTER every command step — bookkeeping follows the verdict', () => {
+    // The card's central sentence, made mechanical. A save hoisted above a
+    // checking step is bookkeeping that can still delay, and be blamed for, an
+    // answer that has not been produced yet.
+    const job = typeCheckJob();
+    const lastCommand = job.steps.map((s) => s.run !== undefined).lastIndexOf(true);
+    const saveAt = job.steps.indexOf(saveStep(job));
+
+    expect(lastCommand, 'the `type-check` job must still run commands').toBeGreaterThan(-1);
+    expect(
+      saveAt,
+      "the cache save must come after the job's last command step. The verdict is recorded by " +
+        `\`${job.steps[lastCommand].name}\`; everything after it is bookkeeping, and that ordering ` +
+        'is what makes the save safe to bound and safe to lose (objectui#6577).',
+    ).toBeGreaterThan(lastCommand);
+  });
+
+  it('still caches the same thing the combined step did', () => {
+    // The split must not quietly stop caching. Same path, same key, and the
+    // save guarded on the restore's `cache-hit` — which is how the combined
+    // action itself decided to skip a save after an exact primary-key hit.
+    const job = typeCheckJob();
+    const save = saveStep(job);
+    const restores = job.steps.filter((s) => (s.uses ?? '').startsWith('actions/cache/restore@'));
+
+    expect(restores.length, 'the `type-check` job must restore `.turbo/cache`').toBe(1);
+    const restore = restores[0];
+
+    expect(restore.with?.path, 'the restore step must still name `.turbo/cache`').toBe('.turbo/cache');
+    expect(
+      save.with?.path,
+      'the save step must write back the same path the restore step read, or the split has ' +
+        'silently stopped caching',
+    ).toBe(restore.with?.path);
+    expect(
+      save.with?.key,
+      'the save step must write the same key the restore step asked for, or every run misses',
+    ).toBe(restore.with?.key);
+
+    expect(
+      restore.id,
+      'the restore step needs an `id` so the save step can read its `cache-hit` output',
+    ).toBeTruthy();
+    expect(
+      save.if ?? '',
+      `the save step must skip on an exact hit of the primary key — ` +
+        `\`steps.${restore.id}.outputs.cache-hit != 'true'\`. The combined action did this ` +
+        `internally; after the split it is the workflow's job, and without it every re-run ` +
+        `re-uploads a cache that already exists.`,
+    ).toContain(`steps.${restore.id}.outputs.cache-hit != 'true'`);
+  });
+
+  it('does not raise the job ceiling, which is the ruled-out non-fix', () => {
+    // Ruled out on the card itself: a larger ceiling buys a longer hang and
+    // still ends in `cancelled`, and lifting a gate's ceiling weakens the gate.
+    // Raising this for some UNRELATED reason is a decision someone may well
+    // need to make — make it deliberately, and move this pin in the same
+    // commit, rather than discovering later that #6577's fix was undone by it.
+    expect(
+      typeCheckJob()['timeout-minutes'],
+      'the `type-check` job ceiling moved. Raising it does not fix a hung cache save — the hang ' +
+        'just runs longer and the gate still reports `cancelled` (objectui#6577).',
+    ).toBeLessThanOrEqual(20);
+  });
+});


### PR DESCRIPTION
Fixes #6577

## The defect

On 2026-08-26 a pull request whose every check was green was ejected from the merge queue with `CI_FAILURE`. Nothing in its diff failed. All 21 real steps of its `Type Check` job succeeded — `Run type-check` reported **success at 13:31:31Z** — and then `Post Turbo Cache`, the save phase of `actions/cache@v6`, spent **13m09s** inside the upload and was still there when the job's `timeout-minutes: 20` fired at 20m02s. The job went `cancelled`, the merge queue cannot tell `cancelled` from `failure`, and a pull request that had passed was dequeued.

**The verdict had already been recorded. Everything after 13:31:31Z was bookkeeping.** A transient upload stall discarded an answer that was already in hand — and the bill lands on every lane, because the queue is one shared serial resource: 20 minutes of head-of-line blocking, an ejection, then a full re-run.

Transient, not structural. I re-measured both jobs from the Actions API rather than inheriting the card's numbers:

| job | `Turbo Cache` (restore) | `Run type-check` | `Post Turbo Cache` (save) | outcome |
|:--|--:|--:|--:|:--|
| 98190108000 — same PR head, 13 min earlier | 2s | 287s | **1s** | success, 5m53s |
| 98194272759 — the ejected merge-group run | 16s | 332s | **789s** | cancelled at 20m02s |

A healthy save of this cache is **one second**. That measurement is what the bound below is sized against.

## Mechanism, and why this one

The charter's stated direction is this repo's own objectui#5304 `apt-get` precedent, already written into `ci.yml`: an unbounded network call whose only backstop was the job ceiling, which converts a transient fault into a CANCELLED check — a gate that reports nothing at all. Bound the call so the job survives it.

The obvious spelling — put `timeout-minutes` on the existing `Turbo Cache` step — **does not work, and I checked rather than assumed.** `actions/cache@v6`'s own `action.yml` declares:

```yaml
runs:
  main: 'dist/restore/index.js'
  post: 'dist/save/index.js'
  post-if: "success()"
```

The save is a step the **runner generates** at job end (`Post Turbo Cache`, step #40 in the incident), not the authored step. No workflow syntax attaches `timeout-minutes` or `continue-on-error` to a generated post step. So the step is **split**, which is the route `actions/cache`'s own `save-always` deprecation text points at:

- **`actions/cache/restore@v6`** — same position, same `path`, `key` and `restore-keys`.
- **`actions/cache/save@v6`** — runs **last**, which is exactly where the post phase already ran, carrying `timeout-minutes: 5` and `continue-on-error: true`.

Both sub-actions declare only `main:` (no `post:`), so both keys are ordinary documented step keys there.

**`timeout-minutes: 5`** — 300x the measured healthy save, so it cannot fire on a working runner; and measured from the slowest verdict path on record (6m53s, the incident run) it lands ~8 minutes clear of the 20-minute ceiling, so this step can no longer reach it.

**`continue-on-error: true`** — without it the bound would only trade a `cancelled` gate for a red one. A cache that failed to upload costs the next run some time; it says nothing about the code under test, so it must not speak for it.

### Rejected alternatives

- **Raise `timeout-minutes`** — ruled out on the card and by triage. A larger ceiling buys a longer hang and still ends in `cancelled`; lifting a gate's ceiling is gate-weakening. The job ceiling is unchanged at 20, and a pin now guards it.
- **`timeout-minutes` on the combined step** — cannot reach the post phase, per the `action.yml` above.
- **Disable the save on `merge_group`** — bounds nothing (a restore stall would still hang), and it removes cache warming from the very lane that is most expensive to re-run.
- **Bounding the restore half too** — deliberately not done, and the reason is in the comment: a restore stall fails *before* any verdict exists, which is a gate that honestly did not run rather than a recorded verdict discarded. Bounding it would force a cold check under this same ceiling.

## The ordering, written down

Per the dispatch, the sentence a future reader actually needs is now in `ci.yml` itself, at the restore step: **this job's verdict is recorded by its checking steps; everything after them is bookkeeping, and bookkeeping must never be able to discard an answer the gate has already produced.** That is the one thing needed to judge whether this step may be touched.

## The gate's verdict path is unchanged — evidence, not assertion

A step decides this job's verdict iff it runs a command and its failure is not swallowed. I compared that set between `origin/main` and this branch, for every job in `ci.yml`, by parsing both revisions:

```
IDENTICAL  job=changeset-check  verdict-steps=1   job-timeout=10->10
IDENTICAL  job=type-check       verdict-steps=19  job-timeout=20->20
IDENTICAL  job=test             verdict-steps=5   job-timeout=20->20
IDENTICAL  job=test-coverage    verdict-steps=4   job-timeout=40->40
IDENTICAL  job=coverage-report  verdict-steps=6   job-timeout=20->20
IDENTICAL  job=e2e              verdict-steps=10  job-timeout=30->30
IDENTICAL  job=docs             verdict-steps=5   job-timeout=15->15

CONTROL (must be "sees it"): planting a change in `Run type-check` -> sees it
VERDICT-PATH RESULT: UNCHANGED across all jobs, and the check is non-vacuous
```

Every command-bearing step in every job is byte-identical, including its `if:` and its own `timeout-minutes`, and no job's ceiling moved. The control run proves the comparison is not vacuous — it detects a planted change to `Run type-check`.

The only two behavioural deltas are on the cache steps themselves, and both preserve what the combined action did internally:

- `cache-hit != 'true'` reproduces the combined action's "exact hit on the primary key, do not save" skip.
- The save's condition names no status function, so the implicit `success()` still applies — matching the combined action's `post-if: success()`.

## The pin, and its teeth

Reverting this fix is invisible: fold the split back into one step and the cache still works, every run still passes, and the next transient stall ejects the next green pull request. That is this repo's recurring "looks like enforcement, isn't" class, and it is why objectui#5304 shipped with `ensure-chromium-ready.test.ts` beside it. `scripts/__tests__/turbo-cache-save-bound.test.ts` is the equivalent here (6 assertions).

Teeth proven by ablation against the committed tree. Each leg: mutate, prove the mutation on disk by counting both the removed and the injected text, run, then restore with `git checkout HEAD --` and prove the restore by **blob hash** plus an empty `git diff HEAD`.

| ablation | on-disk proof | result |
|:--|:--|:--|
| fold the split back to combined `actions/cache@v6` | save step gone (0), combined present (24) | **RED** — 5 of 6 assertions fail |
| drop `continue-on-error: true`, keep the bound | key-anchored count 1 -> 0, `timeout-minutes: 5` survives | **RED** — 1 assertion fails |
| hoist the save above `Run type-check` | renamed marker present (1), original gone (0) | **RED** — the ordering assertion fails |

HEAD blob of `ci.yml` `9402516686` before every leg and `9402516686` after every leg.

One honest note on method: the first attempt at the middle ablation was **rejected by its own on-disk check as a no-op** and its reading discarded — my anchor was the phrase `continue-on-error: true`, which also occurs in the comment this PR adds, so the count could not reach 0. Re-run with the anchor pinned to the YAML key at its exact indent (`^        continue-on-error: true$`); the table above is the re-run.

## Verified

Run on the final commit `1f1338fe0`, all through the shared verify lock:

- `pnpm exec vitest run scripts/__tests__/` — **92 files, 2593 tests passed**. This is the surface that pins `ci.yml`: 27 of those files read it. Baseline on `origin/main` before the change was 91/2587, so the delta is exactly the 6 new assertions.
- `pnpm exec tsc -p tsconfig.scripts.json --listFiles` — clean, and the new test file is confirmed **in** the program (1 hit), so this is a measurement rather than a silent skip.
- `pnpm exec eslint scripts/__tests__/turbo-cache-save-bound.test.ts` — clean. It caught a real `no-useless-escape` on the first pass, fixed before commit.
- `pnpm check:control-bytes` — OK, 5851 tracked text files; plus a manual sweep of the three changed files.
- `node scripts/check-changeset-presence.mjs` and `check-changeset-no-major.mjs` — both green.
- `node scripts/check-governed-queue-guard.mjs --test` on all three paths — **NOT GOVERNED**, ordinary route.

The workflow was also parsed with the `yaml` package and its step list inspected directly, rather than judged by eye.

## Scope

This card is **n=1** and stays that way — one measured occurrence, on the `type-check` job. Two other jobs in `ci.yml` (`e2e`, `docs`) still use the combined action and carry the same structural exposure, but neither has been observed to hang and generalising was not in the charter; that is a question for the PM, not a rider on this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GgDDqh6YnkXqsnVTCa7wHk)_