### PR TITLE
test(spec-parity): converge the non-optional enum-options casts onto the shared reader (#7025)

### DIFF
--- a/.changeset/7025-nonoptional-enum-cast.md
+++ b/.changeset/7025-nonoptional-enum-cast.md
@@ -1,0 +1,20 @@
+---
+---
+
+Internal test-only change, no user-visible behaviour (objectui#7025).
+
+The SIXTH spelling of the Zod-internals reader hazard objectui#5872 catalogues:
+9 spec-parity test files in 7 packages cast an enum node NON-optionally to an
+options-bearing shape and read `.options` straight off it. They converge onto
+`@object-ui/test-support`'s `enumOptions(node)` — the same walk objectui#6924
+converged the optional-cast family onto in PR #7024.
+
+Unlike that family, these sites failed LOUDLY (spreading `undefined` throws), and
+the shared reader deliberately answers `[]` rather than raising. So every site
+keeps its own non-vacuity duty: a throwing wrapper at the seven module-scope
+reads, and the suite's own pre-existing non-vacuity assertion at the two in-test
+reads. A bare conversion would have traded a loud failure for a silent empty
+vocabulary — a regression, not a convergence.
+
+Only test files, two `devDependencies` edges and the lockfile change; no
+package's shipped `dist/` and no public type moves.

--- a/packages/app-shell/src/utils/expandableFamily.identity-5874.test.ts
+++ b/packages/app-shell/src/utils/expandableFamily.identity-5874.test.ts
@@ -54,6 +54,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { EXPANDABLE_FIELD_TYPES } from '@object-ui/core';
 import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 import { ActionParamSchema } from '@objectstack/spec/ui';
 import {
   resolveActionParams,
@@ -61,9 +62,30 @@ import {
   type RawActionParam,
 } from './resolveActionParams';
 
-const SPEC_FIELD_TYPES: readonly string[] = [
-  ...(FieldType as unknown as { options: readonly string[] }).options,
-];
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. What it replaces was a NON-OPTIONAL
+ * cast of the enum node to an options-bearing shape, spread directly — which
+ * failed LOUDLY the moment the cast stopped holding (spreading `undefined`
+ * throws), so a bare `enumOptions` call here would have traded a loud failure
+ * for a silently empty vocabulary: every assertion below would then pass over
+ * nothing. That trade is the regression objectui#7025 exists to refuse. (The
+ * retired spelling is deliberately NOT quoted here: the card's enumeration
+ * instrument is a grep for it, and a comment carrying the literal text makes
+ * every future re-derivation of this population read a false positive.)
+ */
+const readSpecFieldTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+const SPEC_FIELD_TYPES: readonly string[] = readSpecFieldTypes();
 
 /** Every picker key `lookupExtras` copies off the resolved object field. */
 const PICKER_KEYS = [

--- a/packages/app-shell/src/views/richtextSurfaceParity.test.tsx
+++ b/packages/app-shell/src/views/richtextSurfaceParity.test.tsx
@@ -27,11 +27,35 @@
  */
 import { describe, it, expect } from 'vitest';
 import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 import { isWideFieldType as detailIsWide } from '@object-ui/plugin-detail';
 import { isWideFieldType as formIsWide } from '@object-ui/plugin-form';
 import { isSecondaryField } from './RecordDetailView';
 
-const SPEC_TYPES: readonly string[] = [...(FieldType as { options: readonly string[] }).options];
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. What it replaces was a NON-OPTIONAL
+ * cast of the enum node to an options-bearing shape, spread directly — which
+ * failed LOUDLY the moment the cast stopped holding (spreading `undefined`
+ * throws), so a bare `enumOptions` call here would have traded a loud failure
+ * for a silently empty vocabulary: the derived assertions below would then pass
+ * over nothing. That trade is the regression objectui#7025 exists to refuse.
+ * (The retired spelling is deliberately NOT quoted here: the card's enumeration
+ * instrument is a grep for it, and a comment carrying the literal text makes
+ * every future re-derivation of this population read a false positive.)
+ */
+const readSpecTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+const SPEC_TYPES: readonly string[] = readSpecTypes();
 
 /**
  * ONE fixture, read by all three rules. `body` is the field the card is about;

--- a/packages/plugin-dashboard/src/__tests__/expandableFamily.identity-5692.test.ts
+++ b/packages/plugin-dashboard/src/__tests__/expandableFamily.identity-5692.test.ts
@@ -71,12 +71,34 @@ import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi } from 'vitest';
 import { EXPANDABLE_FIELD_TYPES } from '@object-ui/core';
 import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 import { isLookupType } from '../recordFields';
 import { computeLookupExpand } from '../ObjectDataTable';
 
-const SPEC_FIELD_TYPES: readonly string[] = [
-  ...(FieldType as unknown as { options: readonly string[] }).options,
-];
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. What it replaces was a NON-OPTIONAL
+ * cast of the enum node to an options-bearing shape, spread directly — which
+ * failed LOUDLY the moment the cast stopped holding (spreading `undefined`
+ * throws), so a bare `enumOptions` call here would have traded a loud failure
+ * for a silently empty vocabulary: every assertion below would then pass over
+ * nothing. That trade is the regression objectui#7025 exists to refuse. (The
+ * retired spelling is deliberately NOT quoted here: the card's enumeration
+ * instrument is a grep for it, and a comment carrying the literal text makes
+ * every future re-derivation of this population read a false positive.)
+ */
+const readSpecFieldTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+const SPEC_FIELD_TYPES: readonly string[] = readSpecFieldTypes();
 
 /** The relations an ordinary dashboard table shows — the regression control. */
 const ORDINARY_RELATIONS = ['lookup', 'master_detail', 'user'] as const;

--- a/packages/plugin-detail/src/__tests__/autoLayout.wideSpelling.test.ts
+++ b/packages/plugin-detail/src/__tests__/autoLayout.wideSpelling.test.ts
@@ -20,10 +20,34 @@
  */
 import { describe, it, expect } from 'vitest';
 import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 import { mapFieldTypeToFormType } from '@object-ui/fields';
 import { isWideFieldType, applyAutoSpan } from '../autoLayout';
 
-const SPEC_TYPES: readonly string[] = [...(FieldType as { options: readonly string[] }).options];
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. What it replaces was a NON-OPTIONAL
+ * cast of the enum node to an options-bearing shape, spread directly — which
+ * failed LOUDLY the moment the cast stopped holding (spreading `undefined`
+ * throws), so a bare `enumOptions` call here would have traded a loud failure
+ * for a silently empty vocabulary: the derived assertions below would then pass
+ * over nothing. That trade is the regression objectui#7025 exists to refuse.
+ * (The retired spelling is deliberately NOT quoted here: the card's enumeration
+ * instrument is a grep for it, and a comment carrying the literal text makes
+ * every future re-derivation of this population read a false positive.)
+ */
+const readSpecTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+const SPEC_TYPES: readonly string[] = readSpecTypes();
 
 /**
  * The long-form / document family: the spec types whose value is a whole block

--- a/packages/plugin-detail/src/__tests__/expandableFamily.identity-5874.test.tsx
+++ b/packages/plugin-detail/src/__tests__/expandableFamily.identity-5874.test.tsx
@@ -66,12 +66,34 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { EXPANDABLE_FIELD_TYPES } from '@object-ui/core';
 import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 import { HeaderHighlight } from '../HeaderHighlight';
 import { RecordDetailDrawer } from '../RecordDetailDrawer';
 
-const SPEC_FIELD_TYPES: readonly string[] = [
-  ...(FieldType as unknown as { options: readonly string[] }).options,
-];
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. What it replaces was a NON-OPTIONAL
+ * cast of the enum node to an options-bearing shape, spread directly — which
+ * failed LOUDLY the moment the cast stopped holding (spreading `undefined`
+ * throws), so a bare `enumOptions` call here would have traded a loud failure
+ * for a silently empty vocabulary: every assertion below would then pass over
+ * nothing. That trade is the regression objectui#7025 exists to refuse. (The
+ * retired spelling is deliberately NOT quoted here: the card's enumeration
+ * instrument is a grep for it, and a comment carrying the literal text makes
+ * every future re-derivation of this population read a false positive.)
+ */
+const readSpecFieldTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+const SPEC_FIELD_TYPES: readonly string[] = readSpecFieldTypes();
 
 /**
  * The drawer hands its derived field list to `DetailView` as `schema.fields`.

--- a/packages/plugin-form/package.json
+++ b/packages/plugin-form/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@object-ui/data-objectstack": "workspace:*",
+    "@object-ui/test-support": "workspace:*",
     "@vitejs/plugin-react": "^6.0.5",
     "msw": "^2.15.0",
     "typescript": "^6.0.3",

--- a/packages/plugin-form/src/__tests__/autoLayout.wideSpelling.test.ts
+++ b/packages/plugin-form/src/__tests__/autoLayout.wideSpelling.test.ts
@@ -19,11 +19,35 @@
  */
 import { describe, it, expect } from 'vitest';
 import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 import { mapFieldTypeToFormType } from '@object-ui/fields';
 import { isWideFieldType, resolveColSpan } from '../autoLayout';
 import type { FormField } from '@object-ui/types';
 
-const SPEC_TYPES: readonly string[] = [...(FieldType as { options: readonly string[] }).options];
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. What it replaces was a NON-OPTIONAL
+ * cast of the enum node to an options-bearing shape, spread directly — which
+ * failed LOUDLY the moment the cast stopped holding (spreading `undefined`
+ * throws), so a bare `enumOptions` call here would have traded a loud failure
+ * for a silently empty vocabulary: the derived assertions below would then pass
+ * over nothing. That trade is the regression objectui#7025 exists to refuse.
+ * (The retired spelling is deliberately NOT quoted here: the card's enumeration
+ * instrument is a grep for it, and a comment carrying the literal text makes
+ * every future re-derivation of this population read a false positive.)
+ */
+const readSpecTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+const SPEC_TYPES: readonly string[] = readSpecTypes();
 
 /** The long-form / document family, spelled as the SPEC spells it. */
 const WIDE_SPEC_TYPES = ['textarea', 'markdown', 'html', 'richtext'] as const;

--- a/packages/plugin-grid/src/__tests__/spec-symbol-batch7.test.ts
+++ b/packages/plugin-grid/src/__tests__/spec-symbol-batch7.test.ts
@@ -36,15 +36,32 @@ import {
   MULTI_CAPABLE_TYPES,
   MULTI_OPTION_TYPES,
 } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 
 import { SUPPORTED_SUMMARY_TYPES, type ColumnSummarySetting, type ColumnSummaryType } from '../useColumnSummary';
 import { hasMultiValueShape } from '../hooks/multiValueFields';
 
-const specSummaryOptions = (ColumnSummarySchema as unknown as { options: readonly string[] }).options;
+/**
+ * The spec's column-summary vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924).
+ * No throw wrapper here — unlike the module-scope readers converted alongside it
+ * in objectui#7025, this suite already discharges the reader's non-vacuity duty
+ * with its OWN first assertion below, which is the sanctioned alternative. What
+ * it replaces was a NON-OPTIONAL cast of the enum node to an options-bearing
+ * shape; the loudness that cast provided is preserved by that assertion, not
+ * lost to `[]`.
+ */
+const specSummaryOptions: readonly string[] = enumOptions(ColumnSummarySchema);
 
 describe('the column-summary vocabulary comes from the spec', () => {
   it('reads a non-empty enum from the spec (the probe itself is not vacuous)', () => {
-    expect(Array.isArray(specSummaryOptions) && specSummaryOptions.length > 0).toBe(true);
+    // The reader answers `[]` when it cannot read the enum, so THIS is what
+    // keeps every assertion below from passing over an empty list.
+    expect(
+      specSummaryOptions,
+      'could not read ColumnSummarySchema.options from the spec',
+    ).not.toEqual([]);
   });
 
   it('every aggregation the spec accepts is one this renderer computes', () => {

--- a/packages/plugin-kanban/package.json
+++ b/packages/plugin-kanban/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@object-ui/data-objectstack": "workspace:*",
+    "@object-ui/test-support": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",

--- a/packages/plugin-kanban/src/__tests__/expandableFamily.identity-5874.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/expandableFamily.identity-5874.test.tsx
@@ -63,6 +63,7 @@ import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { EXPANDABLE_FIELD_TYPES } from '@object-ui/core';
 import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
 import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 // Registers `object-kanban`.
 import '../index';
@@ -73,9 +74,30 @@ import '../index';
 // so ESM's module cache makes that factory resolve immediately.
 import '../KanbanImpl';
 
-const SPEC_FIELD_TYPES: readonly string[] = [
-  ...(FieldType as unknown as { options: readonly string[] }).options,
-];
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. What it replaces was a NON-OPTIONAL
+ * cast of the enum node to an options-bearing shape, spread directly — which
+ * failed LOUDLY the moment the cast stopped holding (spreading `undefined`
+ * throws), so a bare `enumOptions` call here would have traded a loud failure
+ * for a silently empty vocabulary: every assertion below would then pass over
+ * nothing. That trade is the regression objectui#7025 exists to refuse. (The
+ * retired spelling is deliberately NOT quoted here: the card's enumeration
+ * instrument is a grep for it, and a comment carrying the literal text makes
+ * every future re-derivation of this population read a false positive.)
+ */
+const readSpecFieldTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+const SPEC_FIELD_TYPES: readonly string[] = readSpecFieldTypes();
 
 /**
  * A board with NO `cardFields` and NO `highlightFields`, so cards fall to the

--- a/packages/types/src/__tests__/spec-subschema-parity.test.ts
+++ b/packages/types/src/__tests__/spec-subschema-parity.test.ts
@@ -39,6 +39,7 @@ import {
   ChartTypeSchema as SpecChartTypeSchema,
   PageTypeSchema as SpecPageTypeSchema,
 } from '@objectstack/spec/ui';
+import { enumOptions } from '@object-ui/test-support';
 import {
   HttpMethodSchema,
   HttpRequestSchema,
@@ -175,7 +176,12 @@ describe('ListColumnSchema is the spec schema (the extension collapsed)', () => 
     // arm through `lazySchema`, whose Proxy resolves `.shape.type` to the inner
     // enum instead of the exported schema object, so a `toBe` check would test
     // the wrapper rather than the vocabulary it is meant to protect.
-    const vocabulary = (SpecColumnSummarySchema as unknown as { options: string[] }).options;
+    // The wrapper walk is `@object-ui/test-support`'s shared reader
+    // (objectui#6924). No throw wrapper: the assertion on the next line already
+    // discharges the reader's non-vacuity duty, which is what keeps the loop
+    // below from passing over an empty vocabulary now that a failed read
+    // answers `[]` instead of throwing (objectui#7025).
+    const vocabulary = enumOptions(SpecColumnSummarySchema);
     expect(vocabulary.length, 'spec ColumnSummarySchema should be a non-empty enum').toBeGreaterThan(0);
 
     for (const agg of vocabulary) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2043,6 +2043,9 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2244,6 +2247,9 @@ importers:
       '@object-ui/data-objectstack':
         specifier: workspace:*
         version: link:../data-objectstack
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3


### PR DESCRIPTION
Fixes #7025

The SIXTH spelling of the Zod-internals reader hazard #5872 catalogues: 9 spec-parity test files in 7 packages cast an enum node NON-optionally to an options-bearing shape and read `.options` straight off it. They converge onto `@object-ui/test-support`'s `enumOptions(node)` — the walk PR #7024 exported for #6924's family.

## The enumeration, re-derived (9, as the card predicted)

Instrument, run over `packages/`, `examples/`, `apps/` at branch base `e33b44796` (post-#7024 `main`):

```
grep -rnE 'as (unknown as )?\{ ?options: readonly string\[\] ?\}'   # 8 hits
```

That is the card's own instrument and it finds **8**. The 9th (`types/spec-subschema-parity.test.ts:178`) spells the same cast without `readonly`, so a second, wider instrument was run to catch it and to prove nothing else hides:

```
grep -rnPz -o '(?s)as [^;{]{0,80}\{[^;]{0,120}options[^;]{0,80}\}[^;]{0,40}\.options'
```

**Total: 9 files, 7 packages — matching the card's 9 and the triage comment's prediction that a post-#7024 tree measures 9, not 11.** The two files the triage flagged as the 11-vs-9 difference (`fields/FieldEditWidget.test.ts`, `plugin-detail/inlineEditTypeCoverage.test.tsx`) were confirmed already converted by PR #7024 and carry neither spelling now.

| file | node read |
|---|---|
| `packages/app-shell/src/utils/expandableFamily.identity-5874.test.ts` | `FieldType` |
| `packages/app-shell/src/views/richtextSurfaceParity.test.tsx` | `FieldType` |
| `packages/plugin-detail/src/__tests__/expandableFamily.identity-5874.test.tsx` | `FieldType` |
| `packages/plugin-detail/src/__tests__/autoLayout.wideSpelling.test.ts` | `FieldType` |
| `packages/plugin-form/src/__tests__/autoLayout.wideSpelling.test.ts` | `FieldType` |
| `packages/plugin-kanban/src/__tests__/expandableFamily.identity-5874.test.tsx` | `FieldType` |
| `packages/plugin-dashboard/src/__tests__/expandableFamily.identity-5692.test.ts` | `FieldType` |
| `packages/plugin-grid/src/__tests__/spec-symbol-batch7.test.ts` | `ColumnSummarySchema` |
| `packages/types/src/__tests__/spec-subschema-parity.test.ts` (line 178) | `ColumnSummarySchema` |

Both instruments return **zero** in-scope hits after this change.

## The constraint: a bare conversion would have been a regression

`enumOptions` deliberately answers `[]` rather than raising. These sites spread the cast result directly, so a failed cast THROWS — the opposite of #6924's family, which guarded with `Array.isArray(raw) ? [...raw] : []` and went quietly empty. Converting without preserving the loud failure would have turned this population into #6924's, backwards.

So every site keeps its own non-vacuity duty, in one of the two forms the card sanctions:

- **7 module-scope reads gain a throwing wrapper**, modelled on the two sites that already solved this in PR #7024 (`types/spec-derived-unions.test.ts` and `examples/schema-catalog/test/component-fixture-declared-keys.test.ts`, which both wrap `enumOptions` and keep their own `throw`). The throw stays at the call site because the read is module-scope: it reproduces the import-time failure the retired spread had.
- **2 in-test reads already carried an explicit non-vacuity assertion** and keep theirs — `plugin-grid/spec-symbol-batch7` (`reads a non-empty enum from the spec …`) and `types/spec-subschema-parity` (`spec ColumnSummarySchema should be a non-empty enum`). That is the sanctioned alternative, and it is also the idiom PR #7024 landed for the same shape in `plugin-grid/summary-spec-parity.test.ts`. Adding a module-scope throw to these two would have made their own probe unreachable.

Zero sites excluded: all 9 converted.

## The four identity files were treated as one unit

`expandableFamily.identity-5874` in `app-shell`, `plugin-detail`, `plugin-kanban` and `expandableFamily.identity-5692` in `plugin-dashboard` carry a textually identical read across four packages — #5872 class (1)'s sharpest shape, where a reviewer diffing one copy cannot see that the other three did not move. They were converted in one mechanical pass with one anchor, and the enumeration instrument returning zero afterwards is the check that all four moved.

## Ablation: the loud failure is preserved, and the wrapper is what preserves it

This is the one thing a reviewer cannot take on trust, so it was measured in two legs. `@object-ui/test-support` resolves to **source** (its `package.json` `exports` map points at `./src/index.ts`, and `vitest.config.mts` aliases the specifier to `packages/test-support/src`), so no `dist` rebuild is involved; the mutation reaches the run directly. Each leg proved the mutation on disk (injected marker counted, blob hash compared against the HEAD blob) before reading any result, and each restore was proved by `git diff HEAD` being empty and the file hash matching the HEAD blob exactly.

**Leg A — stub the shared reader to return `[]`, run all 9 suites.** Every one of the 9 goes red:

```
Test Files  9 failed (9)
Tests  3 failed | 17 passed (20)

Failed Suites 7  — each: Error: could not read FieldType.options from @objectstack/spec
Failed Tests  3  — plugin-grid: "could not read ColumnSummarySchema.options from the spec: expected [] to not deeply equal []"
                   plugin-grid: "expected [] to include 'none'"
                   types:       "spec ColumnSummarySchema should be a non-empty enum: expected 0 to be greater than 0"
```

The 7 wrapper sites fail at **import**, by name, before a single test runs (96 tests collected normally, 20 under ablation). The 2 assertion sites fail on their own probes.

**Leg B — the control: what a bare conversion would have done.** Stub the reader AND drop the throw wrapper from `richtextSurfaceParity.test.tsx`, then run that file:

```
Tests  1 failed | 5 passed (6)
  ×  the fixture is spelled the way the spec spells it
  ✓  the SAME richtext field is wide in the detail view and in the form
  ✓  the SAME richtext field is secondary on the record detail page
  ✓  markdown — the sibling the card asked about — is placed identically
  ✓  the detail and form auto-layouts agree on EVERY spec field type      ← GREEN over an empty set
  ✓  no surface answers to a spelling the spec rejects                    ← GREEN over an empty set
```

That file's whole reason to exist — the cross-surface parity control — passes **vacuously** without the wrapper. The wrapper is load-bearing, not decorative.

## Verdict preservation

Measured, not assumed. A temporary probe compared the retired reading against `enumOptions` for all 9 readings and asserted deep equality (order-sensitive): **identical array, identical order, 9/9**, against the installed pin — `FieldType` n=49 (`text, textarea, email, url, phone, password, …`), `ColumnSummarySchema` n=11 (`none, count, count_empty, count_filled, count_unique, percent_empty, …`). The probe was deleted before the commit; it is not in this diff.

## Checks run (all at `eab993075`, the commit this PR contains)

| check | command | result |
|---|---|---|
| the 9 converted suites | `pnpm exec vitest run [the 9 paths]` from the repo root | `Test Files 9 passed (9)` / `Tests 96 passed (96)` |
| typecheck, 8 packages | `pnpm --filter … run type-check` | all 8 `type-check: Done`, exit 0 |
| typecheck really covers the edits | `tsc -p tsconfig.test.json --listFiles` per package | all 9 edited files listed (1 hit each) — not excluded |
| lint | `pnpm exec eslint .` (plain form) | 4049 files, **0 errors**, 11581 pre-existing warnings; the 8 warnings on touched files are pre-existing `no-explicit-any` on untouched lines |
| `check:control-bytes` | `pnpm run check:control-bytes` | exit 0 |
| `check:phantom-deps` | `pnpm run check:phantom-deps` | exit 0 (covers the two new `devDependencies` edges) |
| `check:spec-symbols` | `pnpm run check:spec-symbols` | exit 0 |
| `check:vi-mock-specifiers`, `check:vi-mock-inherit` | `pnpm run …` | exit 0 |
| `check:action-forward-parity`, `check:designer-field-key-parity` | `pnpm run …` | exit 0 (both read enum vocabularies) |
| `check:readme-exports` | `pnpm run check:readme-exports` | `✅ check-readme-exports: OK` after building the 7 packages whose `dist/` this worktree lacked — its first exit 1 was that build prerequisite, in packages outside this diff, not a finding |

`plugin-form` and `plugin-kanban` gained `"@object-ui/test-support": "workspace:*"` in `devDependencies` (the other five packages already had the edge), with the lockfile updated — same pattern PR #7024 used for the five packages it added it to.

The retired spelling is deliberately **not quoted** in the new comments: the card's enumeration instrument is a grep for it, and a comment carrying the literal text would make every future re-derivation of this population read a false positive.

## Out of scope, measured and left alone

- `packages/types/src/__tests__/spec-subschema-parity.test.ts:161` — casts to an `unwrap()` / `def.options` shape. A further spelling and a #5872 class (2)/(4) shape rather than this one; the card and the triage comment both fence it out. **Untouched**, even though it sits 17 lines above a site this PR does convert.
- **Hand-written wrapper walks** (`unwrap()` then `def.innerType`, then `.options`) that duplicate `enumOptions`'s own walk — ~18 of them across 7 packages, including two that read `.options` off a bare `.unwrap()` with **no cast at all** (`app-shell/.../LayeredDiff.overlayScope.test.tsx:31`, `data-objectstack/src/metadata-client.overlayScope.test.ts:69`), which no cast-keyed instrument can see. **No new card filed** — this is already #5872's classes (2)/(4), and that card asks for a re-derived census, so the measurement was recorded there as a comment rather than duplicated into a fresh issue.
- `examples/schema-catalog/test/safe-validate-corpus-6318.test.ts:97` — matched by the wide instrument and excluded on reading: it reads the **authored** `options` array off a JSON fixture, not Zod internals. Not this population.

Session: https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB