### PR TITLE
feat(types,fields): declare rows (markdown/html) and select-option description; de-cast the widget reads (objectui half of the #6140/#6153 family)

### DIFF
--- a/.changeset/6140-field-metadata-rows-option-description.md
+++ b/.changeset/6140-field-metadata-rows-option-description.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/types': minor
+'@object-ui/fields': patch
+---
+
+Declare the two consumed-but-undeclared field-metadata keys ruled on
+objectui#6140 / objectui#6153 (maintainer 2026-08-25, Option A), and de-cast
+the widget reads they legalize:
+
+- `MarkdownFieldMetadata.rows` and `HtmlFieldMetadata.rows` (`@object-ui/types`)
+  — the inline-editor height `RichTextField` has always read through an
+  `as any` (default 8), aligned with the `TextareaFieldMetadata` precedent and
+  `@objectstack/spec` `FieldSchema.rows` (positive integer, multiline editor
+  types). The four inert editor keys (`toolbar`/`preview`/`minHeight`/
+  `maxHeight`) stay deliberately undeclared and are pinned so.
+- `SelectOptionMetadata.description` — secondary option text `LookupField`
+  searches on authored static options and emits from `recordToOption`,
+  aligned with `@objectstack/spec` `SelectOptionSchema.description`.
+- `RichTextField` and `TextAreaField` (`@object-ui/fields`) now read their
+  metadata through the declared types instead of `field as any` (the spec-face
+  `maxLength` dual-read in `TextAreaField` stays as a documented structural
+  read). Behaviour unchanged; `rows` and option `description` are now legal to
+  author with an annotated literal.

--- a/content/docs/fields/lookup.mdx
+++ b/content/docs/fields/lookup.mdx
@@ -61,9 +61,11 @@ const priority: LookupFieldMetadata = {
 };
 ```
 
-The picker also searches a `description` on a static option, but
-`SelectOptionMetadata` does not declare that key; the gap is tracked as
-[objectui#6153](https://github.com/objectstack-ai/objectui/issues/6153). The
+A static option may also carry a `description` — secondary text the picker's
+typeahead searches alongside the label. It is a declared `SelectOptionMetadata`
+member (declared for exactly that consumption —
+[objectui#6153](https://github.com/objectstack-ai/objectui/issues/6153) — and
+aligned with `@objectstack/spec`'s `SelectOptionSchema.description`). The
 `dataSource` a host injects and the `onCreateNew` callback it passes are widget props,
 not metadata.
 

--- a/content/docs/fields/rich-text.mdx
+++ b/content/docs/fields/rich-text.mdx
@@ -3,7 +3,7 @@ title: "Rich Text Field"
 description: "Rich text editor for formatted content"
 ---
 
-The Rich Text Field component provides a WYSIWYG editor for creating formatted text content with markdown or HTML support.
+The Rich Text Field component edits formatted text content with markdown or HTML support — a plain-textarea editor today, with the stored markup rendered formatted on every read surface.
 
 ## Basic Usage
 
@@ -16,8 +16,8 @@ The Rich Text Field component provides a WYSIWYG editor for creating formatted t
 
 `markdown` and `html` are two field types served by one widget, and each has its own
 exported metadata type — `MarkdownFieldMetadata` and `HtmlFieldMetadata`
-(`@object-ui/types`). Both extend `BaseFieldMetadata` and add a single length bound;
-there is no combined "rich text" metadata type.
+(`@object-ui/types`). Both extend `BaseFieldMetadata` and add a length bound and an
+inline-editor height; there is no combined "rich text" metadata type.
 
 ```ts
 import type { HtmlFieldMetadata, MarkdownFieldMetadata } from '@object-ui/types';
@@ -28,6 +28,9 @@ const releaseNotes: MarkdownFieldMetadata = {
   label: 'Release Notes',
   placeholder: 'Write the notes…',
   max_length: 20000,
+  // Inline editor height in text rows (positive integer; default 8). The
+  // fullscreen dialog sizes itself and ignores it.
+  rows: 12,
 };
 
 const emailBody: HtmlFieldMetadata = {
@@ -38,10 +41,13 @@ const emailBody: HtmlFieldMetadata = {
 };
 ```
 
+`rows` sizes the inline editor, in text rows — declared on both types (and on
+`@objectstack/spec`'s `FieldSchema` for the multiline editor types), matching the
+`textarea` field's key of the same name ([objectui#6140](https://github.com/objectstack-ai/objectui/issues/6140)).
 The editor is a plain textarea today — there is no formatting toolbar, no preview pane
-and no pixel height to configure, so neither metadata type declares one. The widget
-does size its inline editor from a `rows` key, but neither type declares that either;
-that gap is tracked as [objectui#6140](https://github.com/objectstack-ai/objectui/issues/6140).
+and no pixel height to configure, so neither metadata type declares one: `toolbar`,
+`preview`, `minHeight` and `maxHeight` are **not** metadata keys, and writing them
+does nothing.
 
 The value being edited, and the `className` / `disabled` a host supplies, are **not**
 metadata keys — they are runtime widget props. See [Field Widget Props](/docs/fields/widget-props).
@@ -85,13 +91,17 @@ import { TextCellRenderer } from '@object-ui/fields';
 
 ## Features
 
-- **WYSIWYG**: What you see is what you get editing
 - **Markdown Support**: For lightweight formatting
 - **HTML Support**: For advanced formatting
-- **Preview Mode**: See formatted output
-- **Syntax Highlighting**: For code blocks
-- **Image Upload**: Embed images (when configured)
-- **Auto-save**: Prevent data loss
+- **Formatted read surfaces**: Grids, detail pages and the readonly form branch
+  render the stored markup formatted (sanitized for HTML)
+- **Fullscreen editing**: An expand affordance when the form opts in
+  (`mobile.fullscreenLongText`)
+
+The editing surface itself is a plain textarea with a format indicator — a
+formatting toolbar, an edit-time preview pane and WYSIWYG editing are **not yet
+implemented** (whatever the editor grows into, both the inline and fullscreen
+surfaces gain it at once, since they share one editor component).
 
 ## Editor Modes
 

--- a/packages/fields/src/widgets/LookupField.optionDescription.test.tsx
+++ b/packages/fields/src/widgets/LookupField.optionDescription.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * A static lookup option's `description` is SEARCHED by the popover typeahead
+ * (objectui#6153, instance 2).
+ *
+ * The behaviour predates the card — `filteredOptions` has always matched
+ * `opt.description` alongside the label, and `recordToOption` emits the same
+ * key for fetched records. What the card changed is the CONTRACT:
+ * `SelectOptionMetadata` (the declared type of `LookupFieldMetadata.options`)
+ * now declares `description?: string`, aligned with `@objectstack/spec`'s
+ * `SelectOptionSchema.description`, so the fixture below is an ANNOTATED
+ * literal — the excess-property check that used to refuse this exact document
+ * is the compile half of the pin, and the search behaviour is the runtime
+ * half. Behaviour unchanged by design; the test would have passed before the
+ * declaration only with the literal laundered through a cast.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
+import type { LookupFieldMetadata } from '@object-ui/types';
+import { LookupField } from './LookupField';
+
+afterEach(cleanup);
+
+const priorityField: LookupFieldMetadata = {
+  type: 'lookup',
+  name: 'priority',
+  label: 'Priority',
+  reference_to: 'priorities',
+  options: [
+    { label: 'High', value: 'high', description: 'Blocks the release' },
+    { label: 'Normal', value: 'normal' },
+  ],
+};
+
+describe('LookupField — static option `description` search (#6153)', () => {
+  it('offers an option whose DESCRIPTION matches the query, and drops the rest', async () => {
+    render(<LookupField value={undefined} onChange={vi.fn()} field={priorityField as never} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+
+    // Both static options offered before any query.
+    expect(screen.getByText('High')).toBeInTheDocument();
+    expect(screen.getByText('Normal')).toBeInTheDocument();
+
+    // 'blocks' matches neither LABEL — only High's description.
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'blocks' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('High')).toBeInTheDocument();
+      expect(screen.queryByText('Normal')).not.toBeInTheDocument();
+    });
+  });
+
+  it('still matches on the label — description WIDENS the search, never replaces it', async () => {
+    render(<LookupField value={undefined} onChange={vi.fn()} field={priorityField as never} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /select/i }));
+    });
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'normal' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Normal')).toBeInTheDocument();
+      expect(screen.queryByText('High')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/fields/src/widgets/LookupField.tsx
+++ b/packages/fields/src/widgets/LookupField.tsx
@@ -38,6 +38,14 @@ import { useFieldTranslation } from './useFieldTranslation.js';
 export interface LookupOption {
   value: string | number;
   label: string;
+  /**
+   * Secondary text: searched by the popover typeahead alongside the label, and
+   * rendered as supporting text. For AUTHORED static options this is the
+   * declared `SelectOptionMetadata.description` (objectui#6153 — declared
+   * there, and on `@objectstack/spec`'s `SelectOptionSchema`, precisely
+   * because this widget consumes it); for fetched records `recordToOption`
+   * derives it from `description_field`.
+   */
   description?: string;
   [key: string]: any;
 }

--- a/packages/fields/src/widgets/RichTextField.tsx
+++ b/packages/fields/src/widgets/RichTextField.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { HtmlFieldMetadata, MarkdownFieldMetadata } from '@object-ui/types';
 import { cn, Textarea, EmptyValue, type FullscreenEditorAria } from '@object-ui/components';
 import { useObjectTranslation } from '@object-ui/react';
 import { FullscreenFieldEditor } from './FullscreenFieldEditor.js';
@@ -279,7 +280,14 @@ export function RichTextField({ value, onChange, field, readonly, error, ...prop
     return <Display value={value} field={field} />;
   }
 
-  const richField = field as any;
+  // The declared metadata face for this widget's registry keys. `markdown` and
+  // `html` each have an exported type; the third key, `richtext`, has no union
+  // member of its own and structurally matches the same three optional reads
+  // below — every key this widget consumes (`rows`, `mobile_fullscreen`,
+  // `placeholder`, `label`) is DECLARED on both members, `rows` since the
+  // objectui#6140 Option A ruling (which is what retired the `as any` that
+  // used to launder this carrier).
+  const richField = field as MarkdownFieldMetadata | HtmlFieldMetadata;
   const rows = richField?.rows || 8;
   // The stored syntax, DERIVED from the type's display pipeline rather than
   // read off a `format` key no rich-content type declares. Empty for a type

--- a/packages/fields/src/widgets/TextAreaField.tsx
+++ b/packages/fields/src/widgets/TextAreaField.tsx
@@ -1,4 +1,5 @@
 import React, { useId } from 'react';
+import type { TextareaFieldMetadata } from '@object-ui/types';
 import { Textarea, EmptyValue, CharacterCount } from '@object-ui/components';
 import { FullscreenFieldEditor } from './FullscreenFieldEditor.js';
 import { FieldWidgetComponentProps } from './types.js';
@@ -64,11 +65,19 @@ export function TextAreaField({ value, onChange, field, readonly, error, ...prop
   // the moment a field toggles readonly. `maxLength` is derived here for the
   // same reason the ids are — proximity to the hook, not because the readonly
   // branch wants it.
-  const textareaField = field as any;
+  // The declared metadata face — every key this widget reads off the carrier
+  // (`rows`, `max_length`, `mobile_fullscreen`, `placeholder`, `label`) is a
+  // `TextareaFieldMetadata` member, so the reads below are compiler-checked
+  // (objectui#6140's de-cast sweep; the sibling `RichTextField` got the same
+  // treatment when its types gained `rows`).
+  const textareaField = field as TextareaFieldMetadata;
   // Spec FieldSchema declares camelCase `maxLength`; `max_length` is the legacy
   // objectui spelling. Dual-read (framework#1878 §3 recheck) — without this a
-  // spec-authored maxLength gave neither the textarea cap nor the counter.
-  const maxLength = textareaField?.maxLength ?? textareaField?.max_length;
+  // spec-authored maxLength gave neither the textarea cap nor the counter. The
+  // camelCase half stays a narrow structural read because the objectui metadata
+  // type deliberately does not declare the spec spelling (that face alignment
+  // is objectui#4631's, not this widget's).
+  const maxLength = (field as { maxLength?: number }).maxLength ?? textareaField?.max_length;
 
   /**
    * Two description ids off one `useId()` — one per editing surface.

--- a/packages/fields/src/widgets/__tests__/RichTextField.rows.test.tsx
+++ b/packages/fields/src/widgets/__tests__/RichTextField.rows.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `rows` sizes the INLINE editor of both long-text widgets (objectui#6140).
+ *
+ * The read (`richField?.rows || 8` / `textareaField?.rows || 4`) predates this
+ * card; what the card changed is the CONTRACT — `rows` became a declared
+ * member of `MarkdownFieldMetadata` and `HtmlFieldMetadata` (maintainer
+ * 2026-08-25, Option A, aligning the `TextareaFieldMetadata` precedent), so
+ * the field literals below carry it under the excess-property check rather
+ * than through a cast. The `richtext` registry key resolves to the same
+ * widget (objectui#5498) with no union member of its own, so its case is the
+ * one deliberate `as` in this file.
+ *
+ * Direction of the DOM assertion: `rows` lands on the HTML `rows` attribute of
+ * the inline `<Textarea>`; the fullscreen dialog deliberately ignores it
+ * (`rows={fullHeight ? undefined : rows}`), pinned by the fullscreen tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { HtmlFieldMetadata, MarkdownFieldMetadata, TextareaFieldMetadata } from '@object-ui/types';
+
+import { RichTextField } from '../RichTextField';
+import { TextAreaField } from '../TextAreaField';
+
+describe('RichTextField — declared `rows` sizes the inline editor (#6140)', () => {
+  it('markdown: an authored rows lands on the textarea', () => {
+    const field: MarkdownFieldMetadata = { type: 'markdown', name: 'notes', rows: 12 };
+    render(<RichTextField value="# hi" onChange={() => {}} field={field} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '12');
+  });
+
+  it('html: an authored rows lands on the textarea', () => {
+    const field: HtmlFieldMetadata = { type: 'html', name: 'body', rows: 6 };
+    render(<RichTextField value="<p>hi</p>" onChange={() => {}} field={field} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '6');
+  });
+
+  it('richtext: the third registry key of the same widget honours rows too', () => {
+    // No `RichtextFieldMetadata` exists in the union — the runtime shape is
+    // structural. Cast, deliberately, at the one seam that has no declared type.
+    const field = { type: 'richtext', name: 'doc', rows: 10 } as unknown as MarkdownFieldMetadata;
+    render(<RichTextField value="<p>hi</p>" onChange={() => {}} field={field} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '10');
+  });
+
+  it('defaults to 8 rows when the key is omitted', () => {
+    const field: MarkdownFieldMetadata = { type: 'markdown', name: 'notes' };
+    render(<RichTextField value="" onChange={() => {}} field={field} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '8');
+  });
+});
+
+describe('TextAreaField — the precedent widget, same key, same channel', () => {
+  it('an authored rows lands on the textarea', () => {
+    const field: TextareaFieldMetadata = { type: 'textarea', name: 'summary', rows: 9 };
+    render(<TextAreaField value="" onChange={() => {}} field={field} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '9');
+  });
+
+  it('defaults to 4 rows when the key is omitted', () => {
+    const field: TextareaFieldMetadata = { type: 'textarea', name: 'summary' };
+    render(<TextAreaField value="" onChange={() => {}} field={field} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('rows', '4');
+  });
+});

--- a/packages/types/src/__tests__/field-metadata-rows-option-description-6140.test.ts
+++ b/packages/types/src/__tests__/field-metadata-rows-option-description-6140.test.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#6140 / objectui#6153 — the ruled declarations on the field-metadata
+ * face (maintainer 2026-08-25, Option A, verbatim ruling recorded on #6140):
+ *
+ *   1. `rows?: number` on `MarkdownFieldMetadata` AND `HtmlFieldMetadata`,
+ *      aligning the `TextareaFieldMetadata` precedent — `RichTextField` (the
+ *      one widget behind the `markdown`/`html`/`richtext` registry keys,
+ *      objectui#5498) has always read the key through an `as any` while no
+ *      rich-content type declared it.
+ *   2. `description?: string` on `SelectOptionMetadata` (objectui#6153
+ *      instance 2) — `LookupField` SEARCHES it on authored static options and
+ *      `recordToOption` emits it for fetched records, while the declared
+ *      option type refused it.
+ *
+ * And the ruling's fence, pinned as hard as the grants:
+ *
+ *   3. The four inert rich-text editor keys (`toolbar`/`preview`/`minHeight`/
+ *      `maxHeight`) stay UNDECLARED — "the capability expansion stops at
+ *      `rows`" is the ruling's own sentence. Nothing in `packages/fields/src`
+ *      reads any of them (measured on #6140).
+ *
+ * ## Why membership pins are type-level here
+ *
+ * These are plain interfaces with NO index signature and no zod mirror
+ * (`src/zod/` has no field-types mirror), so an undeclared member read is a
+ * compile error and `Equal<…>` cannot be satisfied by an index-signature
+ * fallback. The pins bite under `tsc -p tsconfig.test.json` (the package's
+ * `type-check` chain), not under the vitest RUNTIME — which is why each grant
+ * also carries a READ-SITE pin below (the house form of
+ * `undeclared-but-consumed-keys-6150.test.ts`): the declaration is worth its
+ * doc comment only while the consuming read exists.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import type {
+  HtmlFieldMetadata,
+  LookupFieldMetadata,
+  MarkdownFieldMetadata,
+  SelectFieldMetadata,
+  SelectOptionMetadata,
+  TextareaFieldMetadata,
+} from '../field-types';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+
+/* ── Type-level helpers (invariant equality, house form) ─────────────────── */
+
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/* ── 1+2. The declared members, pinned invariantly ───────────────────────── */
+
+export type _MarkdownRowsIsNumber = Expect< Equal< NonNullable< MarkdownFieldMetadata['rows'] >, number > >;
+export type _HtmlRowsIsNumber = Expect< Equal< NonNullable< HtmlFieldMetadata['rows'] >, number > >;
+// The precedent the ruling aligns to — pinned so the three multiline types
+// cannot drift apart again.
+export type _TextareaRowsIsNumber = Expect< Equal< NonNullable< TextareaFieldMetadata['rows'] >, number > >;
+export type _OptionDescriptionIsString = Expect< Equal< NonNullable< SelectOptionMetadata['description'] >, string > >;
+
+/* ── 3. The fence: the four inert editor keys stay undeclared ────────────── */
+
+type IsMember< T, K extends string > = K extends keyof T ? true : false;
+
+export type _NoToolbarOnMarkdown = Expect< Equal< IsMember< MarkdownFieldMetadata, 'toolbar' >, false > >;
+export type _NoPreviewOnMarkdown = Expect< Equal< IsMember< MarkdownFieldMetadata, 'preview' >, false > >;
+export type _NoMinHeightOnMarkdown = Expect< Equal< IsMember< MarkdownFieldMetadata, 'minHeight' >, false > >;
+export type _NoMaxHeightOnMarkdown = Expect< Equal< IsMember< MarkdownFieldMetadata, 'maxHeight' >, false > >;
+export type _NoToolbarOnHtml = Expect< Equal< IsMember< HtmlFieldMetadata, 'toolbar' >, false > >;
+export type _NoPreviewOnHtml = Expect< Equal< IsMember< HtmlFieldMetadata, 'preview' >, false > >;
+export type _NoMinHeightOnHtml = Expect< Equal< IsMember< HtmlFieldMetadata, 'minHeight' >, false > >;
+export type _NoMaxHeightOnHtml = Expect< Equal< IsMember< HtmlFieldMetadata, 'maxHeight' >, false > >;
+
+/* ── The authoring proof: annotated literals carry the keys ──────────────── */
+// These assignments are the excess-property check that FAILED before the
+// declarations landed — an author (human or AI) could not legally write what
+// the running widget honoured. Compiling at all is the assertion.
+
+export const _markdownWithRows: MarkdownFieldMetadata = {
+  type: 'markdown',
+  name: 'release_notes',
+  rows: 12,
+};
+
+export const _htmlWithRows: HtmlFieldMetadata = {
+  type: 'html',
+  name: 'email_body',
+  rows: 6,
+};
+
+export const _selectWithOptionDescription: SelectFieldMetadata = {
+  type: 'select',
+  name: 'status',
+  options: [{ label: 'Active', value: 'active', description: 'Currently being worked' }],
+};
+
+export const _lookupWithOptionDescription: LookupFieldMetadata = {
+  type: 'lookup',
+  name: 'priority',
+  reference_to: 'priorities',
+  options: [{ label: 'High', value: 'high', description: 'Blocks the release' }],
+};
+
+/* ── Read-site pins ──────────────────────────────────────────────────────── */
+
+const readSites: Array<{ file: string; text: string; why: string }> = [
+  {
+    file: 'packages/fields/src/widgets/RichTextField.tsx',
+    text: 'const richField = field as MarkdownFieldMetadata | HtmlFieldMetadata;',
+    why: 'the DECLARED carrier — the `as any` this card retired must not come back',
+  },
+  {
+    file: 'packages/fields/src/widgets/RichTextField.tsx',
+    text: 'const rows = richField?.rows || 8;',
+    why: 'the consuming read `rows` was declared FOR (objectui#6140)',
+  },
+  {
+    file: 'packages/fields/src/widgets/TextAreaField.tsx',
+    text: 'const rows = textareaField?.rows || 4;',
+    why: 'the precedent read the ruling aligns to',
+  },
+  {
+    file: 'packages/fields/src/widgets/TextAreaField.tsx',
+    text: 'const textareaField = field as TextareaFieldMetadata;',
+    why: 'the precedent widget reads through the declared type too',
+  },
+  {
+    file: 'packages/fields/src/widgets/LookupField.tsx',
+    text: '(opt.description && opt.description.toLowerCase().includes(q))',
+    why: 'the search consumption `description` was declared FOR (objectui#6153)',
+  },
+  {
+    file: 'packages/fields/src/widgets/LookupField.tsx',
+    text: 'return { value: val, label: String(label), description, ...record };',
+    why: 'recordToOption emits the same key for fetched records',
+  },
+];
+
+describe('objectui#6140/#6153 — declared field-metadata keys and their live reads', () => {
+  describe.each(readSites.map((s) => [`${s.file} — ${s.why}`, s] as const))('%s', (_title, s) => {
+    it('the read site still exists — the fact the declaration records', () => {
+      const src = readFileSync(join(REPO_ROOT, s.file), 'utf8');
+      expect(src, `${s.file} no longer contains \`${s.text}\``).toContain(s.text);
+    });
+  });
+
+  it('the retired cast is gone from both long-text widgets', () => {
+    for (const file of [
+      'packages/fields/src/widgets/RichTextField.tsx',
+      'packages/fields/src/widgets/TextAreaField.tsx',
+    ]) {
+      const src = readFileSync(join(REPO_ROOT, file), 'utf8');
+      expect(src, `${file} launders the metadata carrier through \`field as any\` again`).not.toContain(
+        'field as any',
+      );
+    }
+  });
+
+  it('the four inert editor keys have no read in packages/fields/src (the fence held)', () => {
+    // Same measurement #6140 recorded: `minHeight`/`maxHeight` have zero
+    // occurrences; `toolbar` and `preview` occur only in prose/JSDoc or on
+    // OTHER widgets. A new READ of one of these off rich-text field metadata
+    // is a capability expansion the ruling explicitly stopped short of.
+    for (const file of [
+      'packages/fields/src/widgets/RichTextField.tsx',
+      'packages/fields/src/widgets/TextAreaField.tsx',
+    ]) {
+      const src = readFileSync(join(REPO_ROOT, file), 'utf8');
+      for (const key of ['toolbar', 'preview', 'minHeight', 'maxHeight']) {
+        expect(src, `${file} reads \`${key}\` off the metadata carrier`).not.toMatch(
+          new RegExp(`(?:richField|textareaField)\\??\\.${key}\\b`),
+        );
+      }
+    }
+  });
+});

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -197,6 +197,21 @@ export interface TextareaFieldMetadata extends BaseFieldMetadata {
 export interface MarkdownFieldMetadata extends BaseFieldMetadata {
   type: 'markdown';
   max_length?: number;
+  /**
+   * Height of the INLINE editor, in text rows (the HTML textarea `rows`
+   * attribute; the fullscreen dialog sizes itself and ignores it).
+   *
+   * Declared by the objectui#6140 ruling (maintainer 2026-08-25, Option A):
+   * `RichTextField` — the one widget behind the `markdown`/`html`/`richtext`
+   * registry keys — has always read `rows` off this metadata (default 8) while
+   * no rich-content type declared it, so the running widget honoured a key an
+   * annotated literal rejected. Aligns the `TextareaFieldMetadata` precedent
+   * and `@objectstack/spec` `FieldSchema.rows` (a positive integer, authorable
+   * on exactly the multiline editor types textarea/markdown/html/richtext).
+   * The four inert editor keys the same ruling measured (`toolbar`/`preview`/
+   * `minHeight`/`maxHeight`) stay deliberately undeclared — nothing reads them.
+   */
+  rows?: number;
 }
 
 /**
@@ -205,6 +220,14 @@ export interface MarkdownFieldMetadata extends BaseFieldMetadata {
 export interface HtmlFieldMetadata extends BaseFieldMetadata {
   type: 'html';
   max_length?: number;
+  /**
+   * Height of the INLINE editor, in text rows. Same declaration as
+   * `MarkdownFieldMetadata.rows` (objectui#6140 Option A ruling — see the
+   * docblock there): `RichTextField` reads it for all three registry keys it
+   * serves, and `@objectstack/spec` `FieldSchema.rows` declares it for the
+   * multiline editor types.
+   */
+  rows?: number;
 }
 
 /**
@@ -290,6 +313,18 @@ export interface TimeFieldMetadata extends BaseFieldMetadata {
 export interface SelectOptionMetadata {
   label: string;
   value: string;
+  /**
+   * Optional secondary/help text for the option (objectui#6153, inheriting the
+   * objectui#6140 ruling frame — a key that is genuinely consumed gets
+   * declared). `LookupField` has always SEARCHED it on authored static options
+   * (`opt.description && opt.description.toLowerCase().includes(q)`) and its
+   * `recordToOption` emits the same key for fetched records — while this type
+   * never declared it, so the behaviour was real for a key no annotated
+   * literal could carry. Aligns `@objectstack/spec`
+   * `SelectOptionSchema.description`; renderers may show it as supporting
+   * text.
+   */
+  description?: string;
   color?: string;
   icon?: string;
   disabled?: boolean;


### PR DESCRIPTION
Fixes #6140
Part of #6153

The OBJECTUI HALF of the ruled two-card family (spec half: objectstack#13669, MERGED 2026-08-31 14:19Z). Maintainer ruling 2026-08-25 on #6140 (verbatim: 「就全部接受，然后继续下一批」) = **Option A**; #6153 inherited the frame per key. Clause-② is ruled yes on both cards, so this PR parks as DRAFT + `needs:contract-review`.

⚠️ **`Part of #6153`, not a close — a deliberate deviation from the dispatch** (which asked for a two-card close). Instance 2 of #6153 (`options[].description`) is fully delivered here; instance 1 (`dependsOn`) hit the inherited ruling's own **stop-and-fork clause** — see "The dependsOn fork" below. The card must stay open to carry that fork.

## What lands

- **`rows?: number` on `MarkdownFieldMetadata` and `HtmlFieldMetadata`** (`@object-ui/types`) — the ruling's literal sentence, aligning the `TextareaFieldMetadata` precedent and `@objectstack/spec` `FieldSchema.rows` (positive integer, declared for the multiline editor set textarea/markdown/html/richtext by the spec half). No `RichtextFieldMetadata` exists in the union (pre-existing; the `richtext` registry key resolves to the same widget and matches both members structurally) — declaring one would be a union expansion the ruling did not ask for, recorded as an observation, not folded.
- **`description?: string` on `SelectOptionMetadata`** (#6153 instance 2) — the key `LookupField` searches on authored static options (`opt.description && opt.description.toLowerCase().includes(q)`) and `recordToOption` emits for fetched records; aligned with the spec half's `SelectOptionSchema.description`.
- **De-casts** (behaviour unchanged, compiler-checked reads): `RichTextField` now reads through `MarkdownFieldMetadata | HtmlFieldMetadata` instead of `field as any`; `TextAreaField` through `TextareaFieldMetadata` (its spec-face `maxLength` dual-read stays as a documented one-key structural read — that face alignment is #4631's, not this widget's). `LookupField.LookupOption.description` documents its now-declared upstream source.
- **Pins** (`packages/types/src/__tests__/field-metadata-rows-option-description-6140.test.ts` + two widget test files): invariant type-level membership pins for `rows` (all three multiline types) and `description`; annotated-literal compile pins (the excess-property check that used to refuse these exact documents); read-site pins; **the ruling's fence pinned** — the four inert editor keys (`toolbar`/`preview`/`minHeight`/`maxHeight`) are asserted NOT declared on either type and NOT read by either widget; DOM behaviour pins (`rows` lands on the textarea for markdown/html/richtext, defaults 8/4; description search widens, never replaces, label search).
- **Docs rider** (`rich-text.mdx`): `rows` is now taught in the Field Schema block (declared key); the four inert keys are named as **not** metadata keys; the page's aspirational WYSIWYG/preview/auto-save feature claims are rewritten to describe the real plain-textarea editor ("not yet implemented" for toolbar/preview/WYSIWYG — the ruling's "remove or mark not-yet-implemented in docs"). `lookup.mdx`'s tracked-gap paragraph for option `description` becomes the declared-member paragraph. `select.mdx` is deliberately untouched — its #6153 gap paragraph is about the forked `dependsOn` instance and stays accurate while the card is open.
- **Changeset**: `@object-ui/types` minor, `@object-ui/fields` patch (fixed group; no major, per the version-alignment rule).

## The `dependsOn` fork (#6153 instance 1 — NOT implemented, needs a decision)

The dispatch (and the inherited ruling's preferred shape) asked: converge the widgets onto "canonical `depends_on`", keep/introduce no camelCase twin. The inherited ruling's own escape hatch is: *"stop and fork if reading the canonical spelling is not enough."* Measured against origin/main of BOTH repos, it is not enough — the premise "the parent already declares `depends_on`" holds only for objectui's legacy `BaseFieldMetadata`; the spec parent declares the OTHER spelling:

- `@objectstack/spec` `FieldSchema` declares **field-level `dependsOn`** (camelCase) — `packages/spec/src/data/field.zod.ts:1304` on today's objectstack main, declared 2026-06-21 (objectstack#2125), with a description that explicitly covers select/multiselect/radio gating AND lookup candidate scoping. The strict door refuses `depends_on` (alias probe folds separators; it renames nothing).
- The spec's liveness ledger classifies field-level `dependsOn` **live**, naming objectui `LookupField` as its consumer.
- Real published apps author it: `examples/app-showcase` `cascading-select.object.ts` (`province` declares `dependsOn: ['country']`) and `invoice`→`contact` dependent lookup. Spec-published field documents reach the widgets carrying `dependsOn`; the widgets' camelCase metadata arms (`SelectField`/`MultiSelectField`/`RadioField`/`CheckboxesField` `config?.dependsOn`, `LookupField`'s `?? fieldMeta?.dependsOn`) are the ONLY read path serving them (the form renderer copies no field-level cascade key onto object-driven form configs).
- What the spec half pinned refused is `dependsOn` **on the option shape** — a different declaration; the field-level spec key stands declared and live.

So deleting the camelCase arms would break the shipped cascade/dependent-lookup behaviour of every spec-published app, and would orphan a spec-declared, ledger-live key — manufacturing the same declared≠enforced split this family exists to end, on the spec's own canonical spelling. Which spelling the objectui METADATA face should declare (mirror the spec's `dependsOn`, or translate at the adapter, or rename the spec key) is a spec-shaping decision nobody has ruled; options and a recommendation are in the dev report on #6140/#6153. No `dependsOn`/`depends_on` read arm was touched in this PR.

## Installability gate

The lockfile installs `@objectstack/spec@17.2.0`, which predates objectstack#13669 — so this PR asserts **nothing about the installed spec's** acceptance of `rows`/`description`. All new pins are against `@object-ui/types`' own declarations and the widgets' behaviour (vitest aliases `@object-ui/types` to source; the doc-snippet gate compiles against this repo's built dist). Installed-spec acceptance pins belong to the future spec-version bump PR. `packages/types/src/zod/form.zod.ts`'s form-face `SelectOptionSchema` needs no edit at all: it spreads the installed `SpecSelectOptionSchema.shape` by reference, so the form face gains `description` mechanically when the dependency bumps.

## Evidence (local, at `10ff9ea`, via the shared verify lock; tree clean)

- **Both packages' full suites**: `pnpm exec vitest run packages/fields/ packages/types/` — "Test Files 208 passed (208) / Tests 3093 passed (3093)". The three new pin files re-run at HEAD `10ff9ea` after the final commit: 3 files / 16 tests passed.
- **Type-check (test layer included)**: `turbo run type-check --filter=@object-ui/types --filter=@object-ui/fields` — "Tasks: 12 successful, 12 total" (both packages chain `tsc -p tsconfig.test.json`, so the new test files are in the checked program — proven by the ablation below, whose reds land inside them).
- **Reverse verification, from the committed state**: `field-types.ts` checked out at base `e33b447` (mutation proven on disk: grep hits for the rows-member pattern 5→3, for the description pattern 2→1; no dist in the loop — the types package's own `tsc` reads src). Direction observed: `@object-ui/types#type-check` FAILED with TS2339/TS2353 naming exactly the new members at the new pins ("Property 'rows' does not exist on type 'MarkdownFieldMetadata'", ... 'HtmlFieldMetadata', "'description' does not exist in type 'SelectOptionMetadata'"). The `@object-ui/fields` red leg was NOT OBSERVED (turbo halted after the types failure — recorded honestly, not counted either way). Restore via `git checkout HEAD --`, proven by empty `git diff HEAD` and `git hash-object` == the HEAD blob (`29c9c8c9`).
- **Docs gates**: `check:doc-snippets` — "Semantic phase: 271 of 271 block(s) judged, 0 failed. Every covered documentation snippet compiles against the built types" (the rich-text.mdx literal carrying `rows: 12` is in that population, compiled against this branch's built dist); `check-doc-links` "Links are valid across 17 scan roots"; `check:doc-fences` OK; `check-doc-component-types` "Every documented component type is registered".
- **Hygiene gates**: `check-changeset-presence` ✅ (1 changeset, 2 released packages); `check-changeset-no-major` ✅; `check-control-bytes` OK (5849 files); `check-designer-field-key-parity` OK; self-import / phantom-deps / vi-mock-specifiers OK.
- **Lint**: targeted `eslint` over the 7 edited files — exit 0, "0 errors" (68 pre-existing warnings). Declared narrowing with its invariance argument: the repo config is NOT type-aware (no `parserOptions.project` in `eslint.config.js`), so verdicts are per-file and this diff cannot move any untouched file's verdict; the per-package `eslint .` farm is CI's run.
- NOT MEASURED here: the repo-wide CI farm (`ci.yml`/`lint.yml` shards) — CI runs it exactly once on this PR; and any assertion about the INSTALLED `@objectstack/spec` (see the installability section).

_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBjwYLS6BciTQW3c9xQiD2)_