### PR TITLE
feat(core,types,components)!: retire ActionRunner's legacy onSuccess chained-callback channel (#5934)

### DIFF
--- a/.changeset/5934-retire-onsuccess-callback-channel.md
+++ b/.changeset/5934-retire-onsuccess-callback-channel.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/core': major
+'@object-ui/core': minor
 '@object-ui/types': minor
 '@object-ui/components': patch
 ---
@@ -7,6 +7,11 @@
 BREAKING (`@object-ui/core`): `ActionRunner`'s legacy `ActionDef.onSuccess`
 chained-callback channel is retired — `onSuccess` now has exactly the meaning the
 contract declares (objectui#5934, maintainer ruling 2026-08-31).
+
+(The bump is `minor` by this repo's release model — objectui's major is pinned to
+the `@objectstack` family major, and its own breaking changes ship as `minor` with
+the break spelled out here, per `scripts/check-changeset-no-major.mjs`. This
+paragraph is that spelling-out: the break below is real and consumer-visible.)
 
 - **What breaks, by specifier**: `import type { ActionDef } from '@object-ui/core'` —
   `ActionDef['onSuccess']` was `ActionDef | ActionDef[]` (chained callbacks the runner

--- a/.changeset/5934-retire-onsuccess-callback-channel.md
+++ b/.changeset/5934-retire-onsuccess-callback-channel.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/core': major
+'@object-ui/types': minor
+'@object-ui/components': patch
+---
+
+BREAKING (`@object-ui/core`): `ActionRunner`'s legacy `ActionDef.onSuccess`
+chained-callback channel is retired — `onSuccess` now has exactly the meaning the
+contract declares (objectui#5934, maintainer ruling 2026-08-31).
+
+- **What breaks, by specifier**: `import type { ActionDef } from '@object-ui/core'` —
+  `ActionDef['onSuccess']` was `ActionDef | ActionDef[]` (chained callbacks the runner
+  dispatched through `executeChain` after a success). It is now derived from the pinned
+  spec: `ActionSchema.onSuccess`'s closed strict `{ navigate: string, openIn?: 'self' |
+  'newTab' }` block. Code that assigned a callback `ActionDef` (or an array of them) to
+  `onSuccess` no longer compiles, and at runtime a callback-shaped value gets NO reading —
+  no handler dispatch, no navigation, the action's own result untouched. `onFailure` is NOT
+  changed: the spec declares no such key, so it keeps its one runner-native meaning.
+- **Why this is safe to take**: the channel was unreachable from validated metadata —
+  `@objectstack/spec` (17.2.0 pin) strict-refuses a callback shape inside `onSuccess` at
+  parse (`invalid_type` on `navigate` + `unrecognized_keys`), so no published/saved
+  metadata could ever carry one — and a producer census with a positive control found zero
+  producers outside the channel's own test pins. Migration for an out-of-repo consumer that
+  drove the channel programmatically: put the follow-up actions in `chain` (the runner's
+  declared chaining key, unchanged), or author the spec's `onSuccess` navigation block.
+- `@object-ui/types` (minor): `UIActionSchema` now declares `onSuccess`, derived from the
+  spec's `ActionSchema.onSuccess` — the renderer view spells the key the four action
+  surfaces forward, so the forwards type-check.
+- `@object-ui/components` (patch): the four action renderers forward `onSuccess` without
+  the `as any` casts (no behavior change — same key, same value, now typed).

--- a/packages/app-shell/src/utils/__tests__/consoleServerAction.test.tsx
+++ b/packages/app-shell/src/utils/__tests__/consoleServerAction.test.tsx
@@ -399,8 +399,9 @@ describe('a declared onSuccess block defers to the runner (objectui#5221)', () =
   });
 
   it('a legacy chained-callback onSuccess is NOT mistaken for a declared hop', async () => {
-    // `{ type: 'notify' }` is the runner's older `ActionDef` callback channel,
-    // not the spec block. The redirectUrl convention must still run.
+    // `{ type: 'notify' }` was the runner's older `ActionDef` callback channel
+    // (retired by objectui#5934), not the spec block — an unparsed row can
+    // still carry the shape. The redirectUrl convention must still run.
     const openSpy = vi.spyOn(window, 'open').mockReturnValue(makeTab() as any);
     const navigate = vi.fn();
     const { handler } = makeHandler({

--- a/packages/components/src/renderers/action/action-button.tsx
+++ b/packages/components/src/renderers/action/action-button.tsx
@@ -198,9 +198,13 @@ const ActionButtonRenderer = forwardRef<
           // the app's own `navigationHandler`). Dropped here, the action
           // succeeded and the declared hop silently never happened —
           // objectui#5493, the same shape as `bodyShape` / `resultDialog`
-          // above. Cast because the key is spec-owned and not spelled on
-          // `@object-ui/types`' renderer view, exactly as `resultDialog` is.
-          onSuccess: (schema as any).onSuccess,
+          // above. Uncast since objectui#5934 retired the runner's legacy
+          // chained-callback meaning: both ends now derive the spec block
+          // (`UIActionSchema.onSuccess` on the read side,
+          // `ActionDef.onSuccess` on the write side), so the forward
+          // type-checks against the one declared meaning instead of hiding
+          // behind `as any`.
+          onSuccess: schema.onSuccess,
         };
 
         await execute({ ...forwarded, ...localContext });

--- a/packages/components/src/renderers/action/action-group.tsx
+++ b/packages/components/src/renderers/action/action-group.tsx
@@ -276,7 +276,8 @@ const ActionGroupRenderer = forwardRef<HTMLDivElement, { schema: ActionGroupSche
           // See action-button.tsx — the declared post-success hop
           // (objectui#5493). The runner reads it off the forwarded def; dropped
           // here the action succeeds and the authored navigation never runs.
-          onSuccess: (action as any).onSuccess,
+          // Uncast since objectui#5934 (legacy callback channel retired).
+          onSuccess: action.onSuccess,
         });
       },
       [execute],

--- a/packages/components/src/renderers/action/action-icon.tsx
+++ b/packages/components/src/renderers/action/action-icon.tsx
@@ -140,7 +140,8 @@ const ActionIconRenderer = forwardRef<
           // See action-button.tsx — the declared post-success hop
           // (objectui#5493). The runner reads it off the forwarded def; dropped
           // here the action succeeds and the authored navigation never runs.
-          onSuccess: (schema as any).onSuccess,
+          // Uncast since objectui#5934 (legacy callback channel retired).
+          onSuccess: schema.onSuccess,
         };
 
         await execute({ ...forwarded, ...localContext });

--- a/packages/components/src/renderers/action/action-menu.tsx
+++ b/packages/components/src/renderers/action/action-menu.tsx
@@ -256,7 +256,8 @@ const ActionMenuRenderer = forwardRef<HTMLButtonElement, { schema: ActionMenuSch
             // (objectui#5493). An overflow action must hop like its inline
             // twin, or the `action:bar` `maxVisible` split decides whether the
             // declared navigation runs.
-            onSuccess: (action as any).onSuccess,
+            // Uncast since objectui#5934 (legacy callback channel retired).
+            onSuccess: action.onSuccess,
           });
         } finally {
           setLoading(false);

--- a/packages/core/src/actions/ActionRunner.ts
+++ b/packages/core/src/actions/ActionRunner.ts
@@ -320,8 +320,6 @@ export interface ActionDef {
   chain?: ActionDef[];
   /** Chain execution mode */
   chainMode?: 'sequential' | 'parallel';
-  /** Callback on success */
-  onSuccess?: ActionDef | ActionDef[];
   /** Callback on failure */
   onFailure?: ActionDef | ActionDef[];
   /** When true, the runner pre-opens about:blank synchronously on click so the
@@ -422,6 +420,26 @@ export interface ActionDef {
   recordIdParam?: SpecActionInput['recordIdParam'];
   /** Auth/tenancy feature the action requires before it is offered. */
   requiresFeature?: SpecActionInput['requiresFeature'];
+  /**
+   * Declared post-success navigation — the spec's closed strict
+   * `{ navigate, openIn }` block (`ActionSchema.onSuccess`, authorable since
+   * `@objectstack/spec` 17.1.0, objectui#5328). Read by `handlePostExecution`
+   * → `readOnSuccessNavigation` → `navigateOnSuccess`.
+   *
+   * This key carried a SECOND, older meaning until objectui#5934: the runner's
+   * own chained-callback channel, `ActionDef | ActionDef[]`, dispatched through
+   * `executeChain`. The maintainer retired that channel on 2026-08-31 — the
+   * spec strict-refuses a callback shape here (`{ type: … }` fails parse with
+   * `unrecognized_keys`, so no validated metadata could ever reach it), and the
+   * census found zero producers outside the channel's own pins. `onSuccess`
+   * now means exactly what the contract declares, nothing else; a callback
+   * shape gets NO reading (not a fallback, not an error — the same "a shape
+   * the spec refuses gets no new reading here" rule the discrimination branch
+   * used to apply, now with nothing left to discriminate). `onFailure`, in the
+   * runner-native section above, is untouched: the spec declares no such key,
+   * so it has only ever had its one runner-native meaning.
+   */
+  onSuccess?: SpecActionInput['onSuccess'];
   /**
    * @deprecated Retired in `@objectstack/spec` 17 as a `retiredKey()` tombstone —
    * authoring it is a hard parse rejection, so this resolves to `undefined` and
@@ -1225,26 +1243,21 @@ export class ActionRunner {
     // `type: 'api'` and `type: 'script'` — the two types whose success event
     // carries a server response for `${result.*}` to read.
     //
-    // This runner's OWN `ActionDef.onSuccess` predates that key and means
-    // something else entirely: `ActionDef | ActionDef[]`, chained callbacks.
-    // The two are told apart by the spec's own declaration — a non-array object
-    // whose `navigate` is a STRING is the spec block and nothing else can be:
-    // `navigate` on a callback ActionDef is the deprecated nested navigation
-    // ENVELOPE (`executeNavigation` reads `navigate.to`), so a string there has
-    // never been runnable. This is a NARROWING to the declared contract, not a
-    // lenient fallback: a shape the spec refuses gets no new reading here.
+    // That declared meaning is the key's ONLY meaning. The runner's older
+    // chained-callback channel (`onSuccess?: ActionDef | ActionDef[]`,
+    // dispatched through `executeChain`) was retired by objectui#5934
+    // (maintainer ruling 2026-08-31): the spec strict-refuses a callback shape
+    // at parse, so no validated metadata could ever reach it, and the census
+    // found zero producers outside the channel's own pins.
     //
-    // Before this branch existed, the ruled shape fell into the callback path,
-    // dispatched `{ navigate: '<string>' }` as an action, and failed inside
-    // `executeNavigation` with "No URL provided for navigation action" — the
-    // author got a red toast and no hop.
+    // `readOnSuccessNavigation` stays as the shape guard, not as a
+    // discriminator: stored rows are rehydrated UNPARSED (#3903), so the value
+    // is still read as data, and a shape the spec refuses gets no reading —
+    // no navigation, no callback dispatch, no lenient fallback.
     if (result.success && action.onSuccess) {
       const navigation = readOnSuccessNavigation(action.onSuccess);
       if (navigation) {
         this.navigateOnSuccess(navigation, action, result);
-      } else {
-        const callbacks = Array.isArray(action.onSuccess) ? action.onSuccess : [action.onSuccess];
-        await this.executeChain(callbacks, 'sequential');
       }
     }
     if (!result.success && action.onFailure) {
@@ -1999,15 +2012,14 @@ export interface OnSuccessNavigation {
 }
 
 /**
- * Is this `onSuccess` the SPEC's navigation block, or this runner's older
- * chained-callback channel (`ActionDef | ActionDef[]`)?
+ * Is this `onSuccess` the spec's navigation block?
  *
  * The test IS the spec's declaration: a non-array object carrying a STRING
- * `navigate`. Nothing else can produce that shape — the spec object is strict
- * with `navigate: z.string()` required, and on a callback `ActionDef`,
- * `navigate` is the deprecated nested navigation ENVELOPE that
- * `executeNavigation` reads `to`/`target`/`redirect` off, so a bare string
- * there has never been runnable.
+ * `navigate`. Stored rows are rehydrated UNPARSED (#3903), so the runner reads
+ * the value as data and anything else gets NO reading — since objectui#5934
+ * retired the legacy chained-callback channel (`ActionDef | ActionDef[]`),
+ * there is no other channel for an off-contract shape to fall into. This is a
+ * shape GUARD on unparsed data, not a discriminator between two meanings.
  */
 export function readOnSuccessNavigation(value: unknown): OnSuccessNavigation | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;

--- a/packages/core/src/actions/__tests__/ActionRunner.onSuccessNavigation.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.onSuccessNavigation.test.ts
@@ -253,23 +253,30 @@ describe('ActionSchema.onSuccess — the two openIn spellings stay apart', () =>
   });
 });
 
-describe('ActionSchema.onSuccess — the legacy chained-callback channel is untouched', () => {
-  it('still runs an ActionDef callback, and does not treat it as navigation', async () => {
-    // `ActionDef.onSuccess?: ActionDef | ActionDef[]` predates the spec key and
-    // is a RUNTIME channel: `@objectstack/spec` strict-refuses `{ type: … }`
-    // inside `onSuccess`, so no validated metadata can reach it. Retiring it is
-    // its own card; this pins that implementing the spec key did not silently
-    // take it away.
+describe('ActionSchema.onSuccess — the retired chained-callback channel gets no reading', () => {
+  it('neither dispatches a callback-shaped onSuccess nor treats it as navigation', async () => {
+    // `ActionDef.onSuccess?: ActionDef | ActionDef[]` predated the spec key as
+    // the runner's own chained-callback channel. objectui#5934 (maintainer
+    // ruling 2026-08-31) retired it: the spec strict-refuses `{ type: … }`
+    // inside `onSuccess` at parse, so no validated metadata could ever reach
+    // it, and the census found zero producers outside the channel's own pins.
+    // Stored rows rehydrate UNPARSED (#3903), so this pins the RUNTIME half of
+    // the retirement — the shape still reaches the runner as data, and gets NO
+    // reading: no handler dispatch, no navigation, and the action's own result
+    // is untouched. (`as never` is the test reaching around the compile-time
+    // half: the declared type now derives the spec block and refuses this
+    // shape at the authoring site.)
     const { runner, nav } = makeRunner({ id: 'rec_42' });
     const cb = vi.fn(async () => ({ success: true }));
     runner.registerHandler('notify', cb as never);
 
-    await runner.execute({
+    const result = await runner.execute({
       type: 'api', name: 'clone_record', target: '/api/v1/records/clone',
       onSuccess: { type: 'notify', name: 'ping' },
     } as never);
 
-    expect(cb).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    expect(cb).not.toHaveBeenCalled();
     expect(nav).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/actions/__tests__/ActionRunner.test.ts
+++ b/packages/core/src/actions/__tests__/ActionRunner.test.ts
@@ -1019,17 +1019,29 @@ describe('ActionRunner', () => {
   // ==========================================================================
 
   describe('callbacks', () => {
-    it('should execute onSuccess callback after success', async () => {
+    // The `onSuccess` chained-callback channel (`ActionDef | ActionDef[]`) was
+    // retired by objectui#5934 (maintainer ruling 2026-08-31): the spec
+    // strict-refuses a callback shape inside `onSuccess` at parse, and the
+    // census found zero producers outside this file's own pins. The two tests
+    // that used to pin the channel now pin its ABSENCE — stored rows rehydrate
+    // UNPARSED (#3903), so the shapes still reach the runner as data, and must
+    // get no reading. `onFailure` is untouched: the spec declares no such key,
+    // so it keeps its one runner-native meaning.
+    it('a callback-shaped onSuccess is not dispatched — the channel is retired', async () => {
       const successHandler = vi.fn().mockResolvedValue({ success: true });
       runner.registerHandler('notify', successHandler);
 
-      await runner.execute({
+      const result = await runner.execute({
         onClick: vi.fn(),
+        // `as never`: since #5934 the declared type derives the spec's
+        // `{ navigate, openIn }` block, so the compiler refuses this shape at
+        // the authoring site — the cast reaches around it to pin the runtime.
         onSuccess: { type: 'notify', params: { msg: 'ok' } },
         toast: { showOnSuccess: false },
-      });
+      } as never);
 
-      expect(successHandler).toHaveBeenCalledOnce();
+      expect(result.success).toBe(true);
+      expect(successHandler).not.toHaveBeenCalled();
     });
 
     it('should execute onFailure callback after failure', async () => {
@@ -1045,20 +1057,21 @@ describe('ActionRunner', () => {
       expect(failureHandler).toHaveBeenCalledOnce();
     });
 
-    it('should support array of onSuccess callbacks', async () => {
+    it('an array of callback-shaped onSuccess entries is not dispatched either', async () => {
       const h1 = vi.fn().mockResolvedValue({ success: true });
       const h2 = vi.fn().mockResolvedValue({ success: true });
       runner.registerHandler('cb1', h1);
       runner.registerHandler('cb2', h2);
 
-      await runner.execute({
+      const result = await runner.execute({
         onClick: vi.fn(),
         onSuccess: [{ type: 'cb1' }, { type: 'cb2' }],
         toast: { showOnSuccess: false },
-      });
+      } as never);
 
-      expect(h1).toHaveBeenCalledOnce();
-      expect(h2).toHaveBeenCalledOnce();
+      expect(result.success).toBe(true);
+      expect(h1).not.toHaveBeenCalled();
+      expect(h2).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/actions/actionKeys.ts
+++ b/packages/core/src/actions/actionKeys.ts
@@ -75,10 +75,12 @@
  * rejection" into a compile error at no cost. Hand-copying would have quietly
  * re-legitimized two dead keys — which is why the types are derived.
  *
- * 17 keys `ActionDef` declares that the spec does not own — `actionType`, `api`,
+ * 16 keys `ActionDef` declares that the spec does not own — `actionType`, `api`,
  * `chain`, `chainMode`, `close`, `condition`, `confirm`, `endpoint`, `modal`,
- * `navigate`, `onClick`, `onFailure`, `onSuccess`, `redirect`, `reload`, `toast`,
- * `actionParams`. Step 2 marked `@deprecated`, with the spec spelling to use
+ * `navigate`, `onClick`, `onFailure`, `redirect`, `reload`, `toast`,
+ * `actionParams`. (`onSuccess` was the 17th until objectui#5934 retired the
+ * runner's chained-callback meaning; the key is now spec-owned and derived,
+ * like the 18 below.) Step 2 marked `@deprecated`, with the spec spelling to use
  * instead, ONLY the four the runner itself proves are aliases: `actionType` (→
  * `type`), `api` and `endpoint` (→ `target`; `executeAPI` resolves
  * `api || endpoint || target`), and `navigate` (→ flat `target`/`openIn`;
@@ -156,7 +158,6 @@ export const ACTION_DEF_KEYS = [
   'modal',
   'chain',
   'chainMode',
-  'onSuccess',
   'onFailure',
   'opensInNewTab',
   'newTabUrl',
@@ -181,6 +182,10 @@ export const ACTION_DEF_KEYS = [
   'recordIdField',
   'recordIdParam',
   'requiresFeature',
+  // Moved from the runner-native cluster above by objectui#5934: the legacy
+  // chained-callback meaning is retired and the key's type now derives the
+  // spec's `{ navigate, openIn }` block.
+  'onSuccess',
   'shortcut',
   'bulkEnabled',
 ] as const;
@@ -240,12 +245,9 @@ export const SPEC_ACTION_KEYS = [
   'newTabUrl',
   'objectName',
   // Declared by `ActionSchema` as of @objectstack/spec 17.1.0 (objectui#5328).
-  // Listing it here is a DIAGNOSTIC statement only — `KNOWN_ACTION_KEYS` feeds
-  // `warnOnUnknownActionKeys`, so without this row an author writing the key the
-  // spec now accepts would be warned it is unknown. It says nothing about the
-  // key being forwarded: the four declared action surfaces still drop it before
-  // the runner, tracked as KNOWN_GAPS in check-action-forward-parity.mjs and
-  // filed as objectui#5493.
+  // All four declared action surfaces forward it since objectui#5493/#6304, and
+  // `ActionDef` derives its type from the spec since objectui#5934 retired the
+  // runner's legacy chained-callback meaning for the same key.
   'onSuccess',
   'openIn',
   'opensInNewTab',

--- a/packages/types/src/ui-action.ts
+++ b/packages/types/src/ui-action.ts
@@ -451,6 +451,26 @@ export interface UIActionSchema {
    */
   openIn?: 'self' | 'new-tab';
 
+  /**
+   * Declared post-success navigation — the spec's closed strict
+   * `{ navigate, openIn }` block (`ActionSchema.onSuccess`, authorable since
+   * `@objectstack/spec` 17.1.0). All four declared action renderers forward it
+   * to the runner (objectui#5493/#6304), which performs the hop through the
+   * app's own `navigationHandler`.
+   *
+   * DERIVED from the spec, never hand-copied — a hand-written duplicate of a
+   * spec shape is a second contract that drifts silently. Declared on the
+   * renderer view since objectui#5934 retired `ActionRunner`'s legacy
+   * chained-callback meaning for the same key: with the spec block as the
+   * key's only meaning, the forward sites type-check without an `as any` cast.
+   *
+   * Note the inner `openIn` spelling is `'self' | 'newTab'` — NOT the
+   * top-level {@link openIn}'s `'self' | 'new-tab'`. The spec refuses each
+   * crossover spelling; the derivation keeps the two from ever being merged
+   * by hand.
+   */
+  onSuccess?: SpecAction['onSuccess'];
+
   /** API endpoint (for type: 'api') */
   endpoint?: string;
   


### PR DESCRIPTION
Fixes #5934

Implemented in session claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB (dev seat). Executes the verbatim maintainer ruling on the card (hotlong, 2026-08-31, director batch #5, item #1): 「退役 `ActionRunner` 的传统 `onSuccess` 回调通道(`ActionDef | ActionDef[]` 形),`onSuccess` 收敛为 spec 声明的唯一语义 `{ navigate, openIn }`」. All three must-answers were re-verified independently before any edit; both hold, so the BREAKING route applies (the ruling's downgrade clause was not triggered).

## Must-answer 1 — the member IS on the exported `ActionDef` (verified, holds)

Chain, measured on base `85b495795`:
- `packages/core/src/actions/ActionRunner.ts` — `export interface ActionDef` spans lines 113 to 441 and contains line 324 `onSuccess?: ActionDef | ActionDef[]` (the card said line 323; one line of drift on current main, same member).
- `src/actions/index.ts` line 9 `export * from './ActionRunner.js'` → `src/index.ts` line 45 `export * from './actions/index.js'` → package exports map `.` → `dist/index.d.ts` line 29 → `dist/actions/index.d.ts` line 8 → `dist/actions/ActionRunner.d.ts` line 104 `export interface ActionDef`, line 295 `onSuccess?: ActionDef | ActionDef[]`.

So the removal is a breaking change to the published surface of `@object-ui/core`. Per this repo's release model (`scripts/check-changeset-no-major.mjs`: objectui's major is pinned to the `@objectstack` family major, and the repo's own breaking changes ship as `minor` with the break spelled out in the changeset body), the changeset is `minor` and opens with the BREAKING declaration.

## Must-answer 2 — zero-producer census, re-run with a positive control

Procedure: repo-wide grep of every `onSuccess` occurrence outside dist (286 hits, 70 files), filtered to writer-shaped hits (`onSuccess:` with a value, excluding type declarations and property reads), then each writer classified by the ruling's discriminator — is the value an ActionDef-shaped object written onto an action object, as opposed to a React form callback on a different surface, a spec-shaped `{ navigate, openIn }` block, or a forward of a read value.

Producers of the retired callback shape found: exactly three, all test fixtures of the channel itself or of its discrimination —
- `packages/core/src/actions/__tests__/ActionRunner.test.ts` lines 1028 and 1056 — the channel's own pins (rewritten by this PR to pin the absence);
- `packages/app-shell/src/utils/__tests__/consoleServerAction.test.tsx` line 415 — a negative fixture proving the shape is NOT mistaken for the declared hop (still passes unchanged, because that behavior survives retirement).

Zero producers in app code, metadata, or examples. The many form-component `onSuccess:` writers (`handleFormSuccess`, arrow functions) are React callbacks on `ObjectFormSchema` and friends — a different surface, excluded exactly as triage instructed.

**Positive control**: the identical procedure run against `chain` (adjacent member, certainly produced) reports non-zero producers — `ActionRunner.test.ts` lines 970, 988, 1007 write ActionDef arrays onto action objects, among 50 writer-shaped hits. The instrument also distinguishes shapes on the same key: it found the spec-shaped `onSuccess: { navigate: ... }` producers (e.g. `consoleServerAction.test.tsx` line 390). The census is a live measurement, not a broken instrument reading zero everywhere.

Also re-measured on the installed `@objectstack/spec` 17.2.0 pin, with a valid-fixture control: a bare valid action parses; `onSuccess: { navigate: '/x', openIn: 'newTab' }` parses; `onSuccess: { navigate: '/x', bogus: 1 }` is refused with `unrecognized_keys`; `onSuccess: { type: 'notify' }` and `onSuccess: [{ type: 'cb1' }]` are refused. The channel was unreachable from validated metadata, exactly as the card claimed.

## Published-surface delta, by specifier

- `@object-ui/core` — **BREAKING** (`minor` bump by the pinned-major release model; the break is declared in the changeset body). `import type { ActionDef } from '@object-ui/core'`: `ActionDef['onSuccess']` was `ActionDef | ActionDef[]` (chained callbacks the runner dispatched through `executeChain` on success). After: derived from the spec — `SpecActionInput['onSuccess']`, the closed strict block `{ navigate: string, openIn?: 'self' | 'newTab' }`, following the interface's own derivation doctrine (never hand-copied). Runtime: a callback-shaped value now gets NO reading — no handler dispatch, no navigation, the action's own result untouched. Before, it was executed as a chain. Consumers who drove the channel programmatically migrate to `chain` (unchanged, declared) or author the spec block. `ActionDef['onFailure']` is NOT changed — the spec declares no such key, so it has only ever had its one runner-native meaning; the ruling covers `onSuccess` alone.
- `@object-ui/types` — **additive (minor)**. `import type { UIActionSchema } from '@object-ui/types'`: the renderer view now declares `onSuccess`, derived from the spec's `ActionSchema.onSuccess`. Before, the key reached renderers only through casts; nothing an existing consumer imported changes shape.
- `@object-ui/components` — **patch, no API change**. The four action renderers forward `onSuccess` without the `as any` casts the ruling ordered removed: `action-button.tsx`, `action-group.tsx`, `action-icon.tsx`, `action-menu.tsx`. Same key, same value, now type-checked. (Measured why the casts existed: `UIActionSchema` is a closed interface — the index signature at `ui-action.ts` line 625 belongs to `ActionContext`, not to it — so the read side needed the key declared; the types change above is the minimal enabler, and the write side is covered by the core retype.)

## Behaviour unchanged for every consumer that did not use the removed member

- The spec-path pins were NOT touched by this PR outside the retired-channel section and stay green: `ActionRunner.onSuccessNavigation.test.ts` (SPA hop, interpolation depth, openIn spelling isolation), `action-onSuccess-forward.test.tsx`, `action-forward-precedence.test.tsx`, `consoleServerAction.test.tsx` (declared-hop precedence, redirectUrl convention, legacy-shape non-confusion).
- Full targeted union at head `365f96c29`; the only later commit, `309ca3ec8`, changes a single `.changeset/*.md` file which none of those runs read (declared narrowing), and both changeset gates — `node scripts/check-changeset-no-major.mjs` and `pnpm changeset:check` — were re-run green at `309ca3ec8`: core actions suite + components action renderer suite + the whole `@object-ui/types` test dir + the app-shell server-action test — 117 files, 1677 tests, all passing. Type-checks green for `@object-ui/types`, `@object-ui/core`, `@object-ui/components`, `@object-ui/app-shell` (after building the dependency closure). Gates: `check:action-forward-parity`, `check:spec-symbols`, `check:control-bytes` all green. `pnpm exec eslint` on every touched file: 0 errors (135 pre-existing warnings, all `no-explicit-any`/style classes already present in those files).
- `check:readme-exports` is NOT MEASURED locally: it exits 1 in this worktree with 69 findings, every one of them "type entry dist/index.d.ts is not on disk — run pnpm build first" for packages outside this diff (app-shell, cli, plugin-ai, plugin-gantt, ...), zero findings for core/types/components READMEs. It needs the full workspace built, which CI does before running it.

## Reverse verification (both directions, from the committed state)

- Runtime leg: restored the BASE `ActionRunner.ts` (channel alive) while keeping the new pins — mutation proven on disk by marker count (the `executeChain` fall-through line: 0 before, 1 after mutation). Result: exactly the 3 retirement pins go red (3 failed, 91 passed), every spec-path pin stays green. Restoration proven three ways: empty `git diff HEAD` for the path, marker count back to 0, and `git hash-object` of the working file equal to the HEAD blob hash. The pinned tests import the runner by relative path, so this leg is source-compiled — no stale-dist hazard.
- Type leg, consumer eye: a probe file inside `@object-ui/components` importing `ActionDef` from `@object-ui/core` — `onSuccess: { type: 'notify' }` is refused (TS2353, and the error text quotes the new derived shape `{ navigate: string; openIn?: "self" | "newTab" }`, proving the REBUILT d.ts is what consumers resolve, not a cache); the array form is refused (TS2741, navigate missing); the spec block compiles. Zero non-probe errors; probe removed; tree clean.

## Retirement conventions

ADR-0087 registries / `retirementTombstone()` were judged NOT applicable and here is why: that machinery retires **authored spec metadata keys** (parse-level tombstones so authoring a retired key is a loud rejection). This card retires a **runtime channel on a published TypeScript type** — the authored key `onSuccess` is not retired, it converges on its declared spec meaning, which the spec already enforces at parse. The compile error for the callback shape (measured in the type leg above) is the analogous authoring-time loud rejection. The in-code documentation records the retirement at the declaration, the post-execution site, and the shape guard.

Follow-on note: this is the sequential follow-on to #5493, which remains closed (landed via #6304) — its four forward sites are exactly the cast sites this PR un-casts. #5493 is not re-opened or otherwise affected here.

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_