### PR TITLE
feat(types)!: retire DataTableSchema.toolbar — declared everywhere, read nowhere (objectui#6881)

### DIFF
--- a/.changeset/6881-retire-data-table-toolbar.md
+++ b/.changeset/6881-retire-data-table-toolbar.md
@@ -1,0 +1,60 @@
+---
+'@object-ui/types': minor
+---
+
+**Breaking for authored metadata:** `DataTableSchema.toolbar` is RETIRED
+(objectui#6881, maintainer ruling 2026-08-31). A `data-table` node that authors
+`toolbar` no longer validates — the parse fails loudly on the `toolbar` path
+with the remediation in the message — and the TS member is a `?: never`
+tombstone, so the same document is refused at compile time.
+
+**What was measured.** The key was declared on both published faces —
+`data-display.ts` (`toolbar?: SchemaNode[]`, "Table toolbar actions/content")
+and the Zod mirror (`SchemaNode | SchemaNode[]`) — documented, mirrored, and
+read by NOTHING: `data-table.tsx`, the registered renderer for
+`type: 'data-table'`, contains the word only in two prose comments and never
+reads `schema.toolbar`. The sibling `emptyAction` slot on the same interface IS
+mounted through `SchemaRenderer`, so the census zero is a reading, not a blind
+query. An author who wrote a toolbar got a green document and a blank result,
+with no signal anywhere that said so — the declared-vs-enforced failure mode
+that is worst for AI-authored metadata, which has nothing but the declaration
+to go on.
+
+**Who is affected — a `toolbar` authored directly onto a `data-table` node,
+in either spelling:**
+
+```json
+{ "type": "data-table",
+  "columns": [{ "header": "Name", "accessorKey": "name" }],
+  "data": [],
+  "toolbar": [{ "type": "button", "label": "Refresh" }] }   // ← was tolerated, rendered nothing
+```
+
+now fails validation with:
+
+> RETIRED (objectui#6881) — never mounted by the data-table renderer; use the
+> built-in toolbar chrome (searchable / exportable), or compose nodes beside
+> the table
+
+The single-node spelling `"toolbar": { … }` — which only the Zod mirror ever
+accepted; the TS face always refused it — is refused the same way, so the two
+faces now agree by refusing both.
+
+**Who is NOT affected.** A document that never wrote the key is untouched
+(`absent` stays valid), and every other `SchemaNode` slot — `emptyAction`
+included — is unchanged. No fixture, example, catalog entry, doc page or app
+in this repository authored the key (measured: all five
+`components-complex-data-table` catalog schemas are toolbar-free, and every
+other `toolbar` occurrence repo-wide is an i18n key, an ARIA role, or an
+unrelated React prop of the same name).
+
+**Migration:** use the built-in toolbar chrome (`searchable` / `exportable`),
+or compose your own nodes beside the table. Per the ruling, a real toolbar
+slot must arrive as a redesigned proposal WITH its enforcing reader — published
+zero-consumer capability gets no sunk-cost exemption.
+
+Graded `minor`, not `patch`: this narrows the accepted input set, which is
+breaking for any author who wrote the tolerated key. It is not `major` per
+this repo's fixed-group convention (objectui's own breaking changes ship as
+`minor`; the group's major tracks `@objectstack` — AGENTS.md 版本号策略,
+mechanically enforced by `scripts/check-changeset-no-major.mjs`).

--- a/packages/types/src/__tests__/data-table-toolbar-retired.test.ts
+++ b/packages/types/src/__tests__/data-table-toolbar-retired.test.ts
@@ -1,0 +1,194 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — `DataTableSchema.toolbar` is REFUSED, not silently ignored
+ * (objectui#6881, maintainer ruling 2026-08-31: retire, do NOT wire).
+ *
+ * ## The failure this pin exists to prevent
+ *
+ * `toolbar` was declared on both published faces — `data-display.ts` and the
+ * Zod mirror — documented, mirrored, and read by NOTHING: `data-table.tsx`
+ * never mounts it (the word appears there only in two prose comments), while
+ * the sibling `emptyAction` slot on the SAME interface is mounted through
+ * `SchemaRenderer`, so the census zero is a reading, not a blind query. An
+ * author who wrote a toolbar got a green document and a blank result, with no
+ * signal anywhere that said so — the declared-vs-enforced failure mode, worst
+ * for AI-authored metadata, which has nothing but the declaration to go on.
+ *
+ * So the deliverable is not "toolbar renders". It is: **an authored `toolbar`
+ * is refused loudly at the authoring boundary**, with the remediation in the
+ * refusal (the built-in chrome: `searchable` / `exportable`). The ruling
+ * records that a real toolbar slot must arrive as a redesigned proposal WITH
+ * its enforcing reader — not by reviving this key.
+ *
+ * ## Why the tombstone, and not simply deleting the key
+ *
+ * `BaseSchema` is `.passthrough()` on the Zod side and carries a
+ * `[key: string]: any` index signature on the TS side. An UNDECLARED key is
+ * accepted by both halves, unvalidated — deleting `toolbar` outright would
+ * hand the authored spelling exactly the silent no-op this card exists to
+ * close. `?: never` / `retirementTombstone()` is this package's convention —
+ * {@link StaticTableColumn} (objectui#5474), `crud.ts` `confirm`
+ * (objectui#4314), `TimelineSchema.timeScale` (objectui#6355) — and it is
+ * lockstep: both halves or neither.
+ *
+ * ## The rider the retirement settles by construction
+ *
+ * Before this card the two faces disagreed on the SHAPE: TS said
+ * `SchemaNode[]`, the mirror admitted `SchemaNode | SchemaNode[]` — a
+ * mirror-wider-than-declared drift no parity ledger watches. Retiring both
+ * faces in the same stroke makes them agree by refusing BOTH spellings, so
+ * this file pins the single-node spelling refused too — the half only the
+ * mirror ever accepted.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DataTableSchema } from '../zod/data-display.zod.js';
+import type { DataTableSchema as DataTableSchemaTS, TableColumn } from '../data-display.js';
+
+const GUIDANCE =
+  'RETIRED (objectui#6881) — never mounted by the data-table renderer; use the built-in toolbar chrome (searchable / exportable), or compose nodes beside the table';
+
+/** A minimal document that is valid TODAY and stays valid — the inside of the boundary. */
+const VALID_TABLE = {
+  type: 'data-table',
+  columns: [{ header: 'Name', accessorKey: 'name' }],
+  data: [],
+} as const;
+
+describe('DataTableSchema.toolbar is RETIRED — the Zod half of the tombstone (objectui#6881)', () => {
+  it('REFUSES the array spelling, naming the retired key', () => {
+    // The pin. Before the retirement this document parsed GREEN (`toolbar` was
+    // `z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()`),
+    // measured ACCEPTED on the retiring PR's base. Asserting the ENVELOPE —
+    // not merely `success:false` — so the pin cannot be satisfied by an
+    // unrelated rejection.
+    const result = DataTableSchema.safeParse({
+      ...VALID_TABLE,
+      toolbar: [{ type: 'button', label: 'Refresh' }],
+    });
+    expect(result.success, 'an authored toolbar was ACCEPTED — it will render as a blank result with no signal').toBe(false);
+    if (result.success) return;
+
+    const issue = result.error.issues.find((i) => i.path[0] === 'toolbar');
+    expect(issue, 'parse failed, but not on the `toolbar` path').toBeTruthy();
+    expect(issue?.code).toBe('invalid_type');
+    expect((issue as { expected?: string } | undefined)?.expected).toBe('never');
+  });
+
+  it('REFUSES the single-node spelling — the half only the mirror ever accepted', () => {
+    // Pre-retirement, TS refused this spelling while the mirror admitted it
+    // (the drift recorded on objectui#6881 as the secondary observation). The
+    // two faces now agree by refusing both.
+    const result = DataTableSchema.safeParse({
+      ...VALID_TABLE,
+      toolbar: { type: 'button', label: 'Refresh' },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => i.path[0] === 'toolbar');
+    expect(issue?.code).toBe('invalid_type');
+  });
+
+  it('the refusal CARRIES the remediation text, not zod\'s generic message', () => {
+    // `retirementTombstone()` writes the guidance once into the parse message
+    // and `.describe()` both (objectui#6931) — the author is told what to
+    // write instead: the built-in chrome.
+    const result = DataTableSchema.safeParse({
+      ...VALID_TABLE,
+      toolbar: [{ type: 'button', label: 'Refresh' }],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const issue = result.error.issues.find((i) => i.path[0] === 'toolbar');
+    expect(issue?.message).not.toContain('Invalid input: expected never, received ');
+    expect(issue?.message).toBe(GUIDANCE);
+    // ONE string, BOTH channels — asserted derived, so parse message and
+    // generated-docs metadata cannot drift apart.
+    expect(issue?.message).toBe(
+      (DataTableSchema.shape.toolbar as { description?: string }).description,
+    );
+  });
+
+  it('leaves a document that never wrote the key untouched — the inside of the boundary', () => {
+    // `absent` stays valid — `.optional()` on the tombstone. The retirement
+    // narrows exactly one key and nothing else.
+    expect(DataTableSchema.safeParse(VALID_TABLE).success).toBe(true);
+  });
+
+  it('still ACCEPTS the sibling `emptyAction` SchemaNode slot — the counter-probe', () => {
+    // `emptyAction` is the slot the census used as its positive control: same
+    // interface, same SchemaNode shape, actually mounted (data-table.tsx, via
+    // SchemaRenderer). Without this leg the refusals above would be satisfied
+    // by a schema that refuses every SchemaNode slot — a narrowing that
+    // refuses too much would pass a refusal-only test.
+    const result = DataTableSchema.safeParse({
+      ...VALID_TABLE,
+      emptyAction: { type: 'button', label: 'New' },
+    });
+    expect(result.success ? null : result.error.issues).toBe(null);
+  });
+
+  it('keeps `toolbar` DECLARED — a tombstone, not a deletion', () => {
+    // The route guard. `BaseSchema` is `.passthrough()`, so removing the key
+    // from the mirror would make the authored spelling parse green again and
+    // do nothing — the silent no-op reintroduced by the very edit meant to
+    // remove it.
+    expect(
+      Object.keys(DataTableSchema.shape),
+      'toolbar left the mirror — under .passthrough() the retired key becomes a SILENT no-op again',
+    ).toContain('toolbar');
+  });
+});
+
+describe('DataTableSchema.toolbar is RETIRED — the TS half of the tombstone (objectui#6881)', () => {
+  it('refuses the retired key at compile time', () => {
+    // On the pre-fix tree `toolbar` is `SchemaNode[] | undefined`, so the
+    // assignment is LEGAL, the directive below is unused, and `tsc` fails the
+    // build with TS2578 naming the key — this leg is red before the fix in
+    // `type-check`, not in vitest, which strips types.
+
+    // @ts-expect-error — `toolbar` is RETIRED (objectui#6881): declared `?: never`, so no value is authorable.
+    const retired: DataTableSchemaTS['toolbar'] = [{ type: 'button' }];
+
+    // Counter-probe on the same surface: the sibling SchemaNode slot still
+    // accepts a node, so the directive above pins the KEY's retirement and not
+    // a blanket narrowing of the interface.
+    const sibling: DataTableSchemaTS['emptyAction'] = { type: 'button' };
+
+    expect([retired, sibling]).toHaveLength(2);
+  });
+
+  it('refuses the retired key in the form authors actually write', () => {
+    // The leg that proves the tombstone survives `BaseSchema`'s
+    // `[key: string]: any`: if the index signature won, `toolbar` would widen
+    // back to `any` here and the directive would go unused (TS2578).
+    const columns: TableColumn[] = [{ header: 'Name', accessorKey: 'name' }];
+
+    const retiredDocument: DataTableSchemaTS = {
+      type: 'data-table',
+      columns,
+      data: [],
+      // @ts-expect-error — `toolbar` is RETIRED (objectui#6881); use the built-in chrome (`searchable` / `exportable`).
+      toolbar: [{ type: 'button', label: 'Refresh' }],
+    };
+
+    // The migrated document — built-in chrome instead — still type-checks.
+    const migratedDocument: DataTableSchemaTS = {
+      type: 'data-table',
+      columns,
+      data: [],
+      searchable: true,
+      exportable: true,
+    };
+
+    expect([retiredDocument, migratedDocument]).toHaveLength(2);
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -670,9 +670,31 @@ export interface DataTableSchema extends BaseSchema {
    */
   caption?: string;
   /**
-   * Table toolbar actions/content
+   * ADR-0049 RETIREMENT TOMBSTONE — `toolbar` (objectui#6881, maintainer
+   * ruling 2026-08-31: retire, do NOT wire).
+   *
+   * What was measured (objectui#6881, re-measured on the retiring PR's base):
+   * declared on both published faces, documented, mirrored — and read by
+   * NOTHING. `data-table.tsx`, the registered renderer for `type:
+   * 'data-table'`, contains the word only in two prose comments and never
+   * reads `schema.toolbar`; the sibling `emptyAction` slot on this same
+   * interface IS mounted through `SchemaRenderer`, so the zero is a reading,
+   * not a blind query. An author who wrote a toolbar got a green document and
+   * a blank result, with no signal anywhere that said so.
+   *
+   * `?: never` is this package's tombstone convention (see `crud.ts`
+   * `confirm`, {@link StaticTableColumn}, `TimelineSchema`'s `timeScale`), NOT
+   * a deletion: `BaseSchema`'s `[key: string]: any` would admit a deleted key
+   * as `any` again — the same silence one layer over. The Zod twin refuses it
+   * loudly via `retirementTombstone()` (`zod/data-display.zod.ts`).
+   *
+   * RETIRED (objectui#6881, ADR-0049) — never mounted by the data-table
+   * renderer. Use the built-in toolbar chrome instead (`searchable` /
+   * `exportable`), or compose your own nodes beside the table. A real
+   * toolbar slot must arrive as a redesigned proposal WITH its enforcing
+   * reader, per the ruling — not by reviving this key.
    */
-  toolbar?: SchemaNode[];
+  toolbar?: never;
   /**
    * Table columns
    */

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -241,7 +241,7 @@ export const DataTableSchema = BaseSchema.extend({
   type: z.literal('data-table'),
   caption: z.string().optional().describe('Table caption'),
   borderless: z.boolean().optional().describe('Render the table without its outer rounded border (for embedding inside grouped rows or other containers).'),
-  toolbar: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Toolbar content'),
+  toolbar: retirementTombstone('RETIRED (objectui#6881) — never mounted by the data-table renderer; use the built-in toolbar chrome (searchable / exportable), or compose nodes beside the table'),
   columns: z.array(TableColumnSchema).describe('Table columns'),
   data: z.array(z.any()).describe('Table data'),
   pagination: z.boolean().optional().describe('Enable pagination'),


### PR DESCRIPTION
Fixes #6881

Executes the maintainer ruling of 2026-08-31 (director batch 5, item 2), quoted verbatim from the card:

> **裁定:退役 `DataTableSchema.toolbar` —— 两个发布面(TS `data-display.ts:674` + zod 镜像)同笔墓碑化,⛔ 不接线。** 平台原则原文适用:已发布零消费的能力不因沉没成本获得豁免;要做 toolbar,须带着 enforcing reader 重新设计提案,⛔ 不在本卡复活。

CONTRACT REVIEW: this PR narrows a published validator's accept-set (ruling clause 4: "**条款②:yes**(收窄已发布接受集)——PR 建立时挂 `needs:contract-review` 走复审链;changeset 带 BREAKING 记号"). The label is applied at creation per that clause.

## Premises re-verified on this PR's base (85b495795), per the executor prerequisites

Line numbers re-located with git grep, not quoted from the card; the read-point census re-run with the card's positive control, not cited from it.

| Claim | Measured | Holds |
|---|---|---|
| TS face declares the key | `packages/types/src/data-display.ts:675` — `toolbar?: SchemaNode[]`, inside `DataTableSchema` (interface opens at line 650) | yes |
| Zod mirror declares it wider | `packages/types/src/zod/data-display.zod.ts:244` — union of one node or an array of nodes, `.optional()` | yes |
| Renderer reads it nowhere | `data-table.tsx` contains the word at lines 986 and 1211 only — both prose comments; no `schema.toolbar` read repo-wide (remaining hits are i18n keys such as `gantt.toolbar.refresh`, ARIA roles, and same-named React props: `PreviewShell` `toolbar`, `toolbarAddon`, `toolbarActions`) | yes |
| Positive control finds a real read | `emptyAction` — same interface, same SchemaNode shape — hits `data-table.tsx:2118-2119`, mounted through `SchemaRenderer`; the zero above is a reading, not a blind query | yes |
| No parity ledger watches it | `zod-mirror-parity.test.ts` — zero occurrences of the word across all four ledgers | yes |
| The key validates today | Measured before this change: array spelling ACCEPTED, single-node spelling ACCEPTED (see accept-set delta below) | yes |

## What changed — both faces, one stroke

- **TS face** (`data-display.ts`): the live member `toolbar?: SchemaNode[]` becomes the tombstone `toolbar?: never`, with the ADR-0049 docblock carrying the measurement and the ruling.
- **Zod face** (`data-display.zod.ts`): the union becomes `retirementTombstone(...)`, so the refusal carries its remediation in the parse message AND the `.describe()` metadata (one string, both channels — the objectui#6931 mechanism).
- **Pin test** (`packages/types/src/__tests__/data-table-toolbar-retired.test.ts`): envelope-asserted refusal on both spellings, remediation text asserted derived-equal with the describe text, boundary legs on both sides, route guard against softening the tombstone into a deletion, and the compile-time half via ts-expect-error directives verified present in the type-checked program (tsc listFiles count = 1 for the new file).

**On the ruling's "TS 成员删除" wording:** the live TS member is deleted and the house tombstone stands in its place, rather than the line being removed outright. Removing the line entirely would fall through to BaseSchema's string index signature and be admitted as `any` again — silently, even at fresh literals (measured and pinned by `dataTableSchemaSlot-6459.test.ts`: a bogus key on a bare `DataTableSchema` literal compiles). The ruling's own headline verb is 「同笔墓碑化」 and its pin ("authored toolbar flips to an authoring-time loud rejection") is only achievable through the tombstone; the same reasoning is already house law in `timeline-timescale-retired.test.ts` and the `StaticTableColumn` retirement.

## Accept-set delta — exactly what an author could write before and cannot after

Could write before (validated green, rendered nothing, no signal anywhere):

```json
{ "type": "data-table",
  "columns": [{ "header": "Name", "accessorKey": "name" }],
  "data": [],
  "toolbar": [{ "type": "button", "label": "Refresh" }] }
```

Also could write before — the spelling only the Zod mirror accepted (the TS face always refused it; this was the card's secondary observation, the mirror-wider-than-declared drift):

```json
{ "toolbar": { "type": "button", "label": "Refresh" } }
```

After this PR, both fail validation with the same envelope — code `invalid_type`, path `toolbar`, expected `never`, message:

> RETIRED (objectui#6881) — never mounted by the data-table renderer; use the built-in toolbar chrome (searchable / exportable), or compose nodes beside the table

Nothing else stops validating. That is the whole delta: one key, both spellings.

**Boundary proven on both sides** (a change that refuses too much would pass a refusal-only test):

- Just outside: the two documents above — REFUSED, measured, exact envelope asserted in the pin test.
- Just inside: the same document with the key absent — ACCEPTED; the same document with the sibling SchemaNode slot `emptyAction` (the census's positive control, actually mounted) — ACCEPTED. Both pinned.

**The rider settles by construction** (PM triage clause): retiring both faces in the same stroke makes them agree by refusing both spellings, so the TS-vs-mirror shape divergence dies with the key — it was deliberately not "fixed first". The pin test keeps the single-node leg so the agreement is measured, not assumed.

## Documents in this repo that would newly fail: NONE (enumerated, not assumed)

Swept fixtures, examples, catalog, docs and apps for authored `toolbar` on a data-table:

- All five `examples/schema-catalog/src/schemas/components-complex-data-table/*.json` — recursive key scan: zero `toolbar` keys at any depth.
- `content/docs/components/complex/data-table.mdx` — zero occurrences of the word.
- `content/docs/api/schema-reference.md` — two occurrences, both prose about ObjectGrid's own runtime chrome, not authored keys.
- Repo-wide sweep of `toolbar:` authoring spellings — every hit is an i18n locale key, an ARIA role in tests, or an unrelated React prop (`PreviewShell`, `toolbarAddon`, `toolbarActions`); the `catalog-meta.json` "toolbar buttons" description refers to a card that composes buttons by hand, not the retired key.
- `packages/types` examples and tests, the objectui#6882 declared-keys pin, and the objectui#6459 slot pin — zero references to the key.

## Changeset — BREAKING marker, graded per repo law

`.changeset/6881-retire-data-table-toolbar.md` bumps `@object-ui/types` **minor** and leads with **"Breaking for authored metadata:"**, enumerating the delta and migration. It is deliberately NOT a literal `major`: AGENTS.md 版本号策略 reserves the fixed group's major for tracking `@objectstack` across a major, spells out "objectui 自身的破坏性变更也标 `minor`(在正文里写清 breaking 语义即可)", and `scripts/check-changeset-no-major.mjs` (changeset-guard workflow) exits non-zero on any `major` changeset — a literal major cannot land. This matches the landed precedent for the closest cousin narrowing (`.changeset/5120-retire-data-table-name-alias.md`). The dispatch order's "(major)" gloss is thereby implemented as the ruling's actual requirement — a BREAKING-marked changeset — under the repo's mechanically-enforced grading; flagged here so the contract-review chain can veto.

## Verification (all on head 7511392ff unless noted)

- Before-reading (base 85b495795, pristine tree): both toolbar spellings ACCEPTED, controls ACCEPTED — the flip is measured, not asserted.
- `pnpm exec vitest run --maxWorkers=2 packages/types` (root-relative form): 80 files, 977 tests passed — includes the new pin file and the untouched parity ledgers staying green.
- `pnpm run type-check` in `packages/types` (all three tsconfigs): green, with the two ts-expect-error directives consumed — the compile-time refusal direction is proven by their being used, and `tsc -p tsconfig.test.json --listFiles` confirms the new test file is in the checked program.
- Cross-package reverse verification against rebuilt dist: `@object-ui/types` rebuilt (`toolbar?: never` confirmed present in `dist/data-display.d.ts:654`); a consumer-side probe in `packages/plugin-grid` importing the package by name goes RED on the toolbar write (TS2322 at the property) and GREEN with the key removed; probe deleted, tree clean.
- Gates: `check:control-bytes` green (5858 files); `check:doc-types` green (185 docs, 1068 blocks); changeset guard (`check-changeset-no-major.mjs`) green; targeted eslint (plain form) on the three changed source files: 0 errors.
- `check:doc-snippets`: exit 2 = PRECONDITION NOT MET locally (needs 20 packages built — the farm build CI owns). Declared narrowing in its place: the census above measured zero doc snippets authoring the key, and CI runs the full gate on this PR.

_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_