### PR TITLE
docs(components): publish button-group's shipped surface, in both directions

### DIFF
--- a/.changeset/6347-button-group-schema-block.md
+++ b/.changeset/6347-button-group-schema-block.md
@@ -5,7 +5,8 @@ Docs only, publishes nothing: `content/docs/components/basic/button-group.mdx`
 published a `ButtonGroupSchema` / `ButtonGroupButton` surface that disagreed
 with the shipped types in **both** directions. objectui#6347 named the two
 over-statements; re-measuring the whole fence against
-`packages/types/src/navigation.ts` and its Zod mirror found ten rows.
+`packages/types/src/navigation.ts`, `packages/types/src/base.ts` and their Zod
+mirrors found eleven rows.
 
 Over-stated — documented, never declared:
 
@@ -28,10 +29,22 @@ Under-stated — declared, never documented:
 | `ButtonGroupButton` had no `className` row | `className?: string` (`navigation.ts:329`, `.zod.ts:148`) | added |
 | `ButtonGroupSchema.variant?: 'default' \| 'outline' \| 'ghost'` | six members (`navigation.ts:345`, `.zod.ts:157`) | `secondary`, `destructive`, `link` restored |
 | `ButtonGroupSchema.size?: 'sm' \| 'default' \| 'lg'` | four members (`navigation.ts:350`, `.zod.ts:158`) | `icon` restored |
+| `disabled?: boolean` | `BaseSchema.disabled?: boolean \| string` (`base.ts`, `zod/base.zod.ts:190`) — `ButtonGroupSchema` does **not** redeclare it | `boolean \| string` |
 
 Both directions are one defect class with the sign flipped. Fixing only the
 direction a card happens to notice is what left these omissions sitting beside
 two earlier corrections to the same page (objectui#6132, objectui#6143).
+
+The `disabled` row deserves its own note, because it looks like a convention and
+is not. Fourteen `content/docs/components/**` pages spell a component schema's
+own `disabled` as `boolean` — but **thirteen of those fourteen schemas redeclare
+`disabled?: boolean` themselves** (`ButtonSchema`, `SelectSchema`,
+`SwitchSchema`, `ToggleGroupSchema` and nine more), so those pages are right.
+`ButtonGroupSchema` is the one that does not, so it inherits `BaseSchema`'s
+`boolean | string` and this page was the outlier rather than the convention.
+Whether `ButtonGroupSchema` *should* narrow it like its thirteen siblings is a
+types question, not a docs one, and is deliberately not answered here — the
+renderer reads neither spelling today.
 
 `onClick` is documented as declared and annotated as a runtime slot: it is
 `z.function()`, and objectui#4453 narrowed the runtime to

--- a/.changeset/6347-button-group-schema-block.md
+++ b/.changeset/6347-button-group-schema-block.md
@@ -1,0 +1,69 @@
+---
+---
+
+Docs only, publishes nothing: `content/docs/components/basic/button-group.mdx`
+published a `ButtonGroupSchema` / `ButtonGroupButton` surface that disagreed
+with the shipped types in **both** directions. objectui#6347 named the two
+over-statements; re-measuring the whole fence against
+`packages/types/src/navigation.ts` and its Zod mirror found ten rows.
+
+Over-stated — documented, never declared:
+
+| page before | shipped declaration | page after |
+| --- | --- | --- |
+| `ButtonGroupSchema.value?: string \| string[]` | not declared (`navigation.ts:335-351`, `zod/navigation.zod.ts:154-159`) | removed |
+| `ButtonGroupSchema.selectionMode?: 'single' \| 'multiple' \| 'none'` | not declared (same two blocks) | removed |
+| `ButtonGroupButton.value: string` (required) | not declared (`navigation.ts:305-330`, `zod/navigation.zod.ts:142-149`) | removed |
+| `ButtonGroupButton.icon?: string` | not declared (same two blocks) | removed |
+| `buttons: ButtonGroupButton[]` (required) | `buttons?: ButtonGroupButton[]` (`navigation.ts:340`, `.zod.ts:156`) | `buttons?:` |
+| `label?: string` | `label: string` — required (`navigation.ts:309`, `.zod.ts:143`) | `label:` |
+
+Under-stated — declared, never documented:
+
+| page before | shipped declaration | page after |
+| --- | --- | --- |
+| `ButtonGroupButton` had no `variant` row | `variant?: 'default' \| 'secondary' \| 'destructive' \| 'outline' \| 'ghost' \| 'link'` (`navigation.ts:313`, `.zod.ts:144`) | added |
+| `ButtonGroupButton` had no `size` row | `size?: 'default' \| 'sm' \| 'lg' \| 'icon'` (`navigation.ts:317`, `.zod.ts:145`) | added |
+| `ButtonGroupButton` had no `onClick` row | `onClick?: () => void` (`navigation.ts:325`, `.zod.ts:147`) | added, annotated as a runtime slot |
+| `ButtonGroupButton` had no `className` row | `className?: string` (`navigation.ts:329`, `.zod.ts:148`) | added |
+| `ButtonGroupSchema.variant?: 'default' \| 'outline' \| 'ghost'` | six members (`navigation.ts:345`, `.zod.ts:157`) | `secondary`, `destructive`, `link` restored |
+| `ButtonGroupSchema.size?: 'sm' \| 'default' \| 'lg'` | four members (`navigation.ts:350`, `.zod.ts:158`) | `icon` restored |
+
+Both directions are one defect class with the sign flipped. Fixing only the
+direction a card happens to notice is what left these omissions sitting beside
+two earlier corrections to the same page (objectui#6132, objectui#6143).
+
+`onClick` is documented as declared and annotated as a runtime slot: it is
+`z.function()`, and objectui#4453 narrowed the runtime to
+`typeof === 'function'`, so a JSON author cannot supply one.
+
+**`## Selection Mode` is deleted, not softened.**
+`packages/components/src/renderers/basic/button-group.tsx` implements no
+selection behaviour at all — no `selectionMode` read, no group-level `value`
+read, no state — and it does not wire the declared per-button `onClick` either.
+It maps `schema.buttons` to `Button` elements reading `variant`, `size`,
+`className` and `label` only. A heading over two inert demos taught a
+capability nothing draws. The capability question itself is filed separately
+rather than answered here.
+
+The two catalog fixtures the section rendered
+(`components-basic-button-group/single-selection`, `/multiple-selection`) are
+**kept**. Catalog entries are a separate verification population, fenced off by
+PR #6345; orphaning them from this page is the accepted cost, and no gate reads
+a catalog entry's page references (the index is generated from the schema
+directory by `scripts/regenerate-catalog-index.py`, path-keyed).
+
+`packages/types/src/__tests__/button-group-doc-surface-6347.test.ts` pins the
+result. Nothing in CI parses a `plaintext` fence — `check:doc-types` reads only
+the `type` string literals and `check:doc-snippets` compiles `ts`/`tsx` fences —
+so without it a green CI run would have said "nothing else broke", not "the
+correction is right". The pin reads membership off the mirror's `.shape` rather
+than off parse acceptance, because `BaseSchema` is `.passthrough()` and carries
+`[key: string]: any`: an undeclared `selectionMode` parses green and
+type-checks, so acceptance cannot tell "declared" from "admitted unexamined".
+
+No type was minted, no fence moved (the page holds one `plaintext` fence before
+and after, so objectui#5867's shrink-only declared population is unchanged), and
+no catalog fixture was edited.
+
+Part of objectui#6347.

--- a/content/docs/components/basic/button-group.mdx
+++ b/content/docs/components/basic/button-group.mdx
@@ -39,7 +39,7 @@ interface ButtonGroupSchema {
   size?: 'default' | 'sm' | 'lg' | 'icon';
 
   // States
-  disabled?: boolean;
+  disabled?: boolean | string;   // boolean, or a predicate expression
 
   // Styling
   className?: string;

--- a/content/docs/components/basic/button-group.mdx
+++ b/content/docs/components/basic/button-group.mdx
@@ -18,34 +18,29 @@ The Button Group component groups multiple buttons together with consistent styl
   <SchemaExample id="components-basic-button-group/with-icons" />
 </DemoGrid>
 
-## Selection Mode
-
-<DemoGrid>
-  <SchemaExample id="components-basic-button-group/single-selection" />
-  <SchemaExample id="components-basic-button-group/multiple-selection" />
-</DemoGrid>
-
 ## Schema
 
 ```plaintext
 interface ButtonGroupButton {
-  label?: string;
-  value: string;
-  icon?: string;
-  disabled?: boolean;
+  label: string;                  // Button label (required)
+  variant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link';
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+  disabled?: boolean;             // Whether this button is disabled
+  onClick?: () => void;           // Runtime handler; not authorable in JSON
+  className?: string;             // Per-button CSS class
 }
 
 interface ButtonGroupSchema {
   type: 'button-group';
-  buttons: ButtonGroupButton[];   // Button definitions
-  value?: string | string[];      // Selected value(s)
-  selectionMode?: 'single' | 'multiple' | 'none';
-  variant?: 'default' | 'outline' | 'ghost';
-  size?: 'sm' | 'default' | 'lg';
-  
+  buttons?: ButtonGroupButton[];  // Button definitions
+
+  // Defaults applied to every button that does not set its own
+  variant?: 'default' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link';
+  size?: 'default' | 'sm' | 'lg' | 'icon';
+
   // States
   disabled?: boolean;
-  
+
   // Styling
   className?: string;
 }

--- a/packages/types/src/__tests__/button-group-doc-surface-6347.test.ts
+++ b/packages/types/src/__tests__/button-group-doc-surface-6347.test.ts
@@ -167,12 +167,22 @@ const declaredOptional = (shape: ZodShape, key: string): boolean =>
  * and reading a union's option SCHEMAS out of it would be relying on a return
  * value its contract does not promise.
  */
-function unwrapWrappers(node: unknown): Record<string, any> | undefined {
-  let carrier = node as Record<string, any> | undefined;
+interface WrapperCarrier {
+  readonly options?: readonly unknown[];
+  readonly def?: {
+    readonly type?: string;
+    readonly innerType?: unknown;
+    readonly options?: readonly unknown[];
+  };
+  readonly _def?: { readonly innerType?: unknown };
+}
+
+function unwrapWrappers(node: unknown): WrapperCarrier | undefined {
+  let carrier = node as WrapperCarrier | undefined;
   for (let depth = 0; carrier && depth <= 8; depth += 1) {
     const inner = carrier.def?.innerType ?? carrier._def?.innerType;
     if (!inner) return carrier;
-    carrier = inner as Record<string, any>;
+    carrier = inner as WrapperCarrier;
   }
   return carrier;
 }
@@ -181,7 +191,7 @@ function unwrapWrappers(node: unknown): Record<string, any> | undefined {
 function declaredTypeText(node: unknown): string {
   const inner = unwrapWrappers(node);
   if (inner?.def?.type === 'union') {
-    const options = (inner.options ?? inner.def.options ?? []) as unknown[];
+    const options = inner.options ?? inner.def.options ?? [];
     return options.map((option) => unwrapWrappers(option)?.def?.type ?? 'unknown').join(' | ');
   }
   return String(inner?.def?.type ?? 'unknown');

--- a/packages/types/src/__tests__/button-group-doc-surface-6347.test.ts
+++ b/packages/types/src/__tests__/button-group-doc-surface-6347.test.ts
@@ -50,15 +50,23 @@
  * shared `enumOptions` reader rather than a hand-copied string list, so this
  * file follows the platform instead of asserting yesterday's vocabulary.
  *
- * ## Two BaseSchema-inherited rows are pinned for MEMBERSHIP only — deliberate
+ * ## The two BaseSchema-inherited rows are pinned too, and one of them was wrong
  *
  * The page also documents `disabled` and `className`, which `ButtonGroupSchema`
- * inherits. Their type TEXT is not pinned here: `BaseSchema` declares
- * `disabled?: boolean | string` (the string limb is the expression dialect),
- * while this page — and all 21 sibling `content/docs/components/**` pages that
- * document it, and the common-props table in `content/docs/api/schema-reference.md`
- * — spell it `boolean`. Correcting one page would make it the lone outlier of a
- * repo-wide convention, so it is measured and reported rather than guessed at.
+ * inherits rather than declares. `disabled` was spelled `boolean` against a
+ * declared `boolean | string` (`base.ts`; the mirror is
+ * `z.union([z.boolean(), z.string()])`, the string limb being the predicate
+ * dialect `disabledOn` also carries).
+ *
+ * That reads at first like a repo-wide convention worth leaving alone — 14
+ * `content/docs/components/**` pages spell a component schema's own `disabled`
+ * as `boolean`. It is not: 13 of those 14 component schemas REDECLARE
+ * `disabled?: boolean` themselves (`ButtonSchema`, `SelectSchema`,
+ * `SwitchSchema`, `ToggleGroupSchema` and nine more), so their pages are right.
+ * `ButtonGroupSchema` is the ONE that does not redeclare it, which makes this
+ * page the outlier rather than the convention. Measured, not assumed — and it
+ * is why the type TEXT of both inherited rows is asserted here rather than
+ * waved through as "documented centrally".
  *
  * ## `## Selection Mode` is gone because the renderer cannot draw it
  *
@@ -150,6 +158,36 @@ const declaredOptional = (shape: ZodShape, key: string): boolean =>
   shape[key].safeParse(undefined).success;
 
 /**
+ * Peel `.optional()` / `.default()` / `.nullable()` off a mirror member.
+ *
+ * Bounded rather than `while`, for the reason `@object-ui/test-support`'s
+ * `enumOptions` gives: the step is reached through `unknown`, so a node that
+ * unwraps to itself ends the walk instead of the process. That shared reader is
+ * deliberately NOT used here — it answers "which enum NAMES does this accept",
+ * and reading a union's option SCHEMAS out of it would be relying on a return
+ * value its contract does not promise.
+ */
+function unwrapWrappers(node: unknown): Record<string, any> | undefined {
+  let carrier = node as Record<string, any> | undefined;
+  for (let depth = 0; carrier && depth <= 8; depth += 1) {
+    const inner = carrier.def?.innerType ?? carrier._def?.innerType;
+    if (!inner) return carrier;
+    carrier = inner as Record<string, any>;
+  }
+  return carrier;
+}
+
+/** The declared type of a member, spelled the way the page writes it. */
+function declaredTypeText(node: unknown): string {
+  const inner = unwrapWrappers(node);
+  if (inner?.def?.type === 'union') {
+    const options = (inner.options ?? inner.def.options ?? []) as unknown[];
+    return options.map((option) => unwrapWrappers(option)?.def?.type ?? 'unknown').join(' | ');
+  }
+  return String(inner?.def?.type ?? 'unknown');
+}
+
+/**
  * The members this component declares in its OWN right.
  *
  * `type` is re-declared by `.extend()` as the discriminator literal, so it
@@ -214,12 +252,22 @@ describe('button-group.mdx: the `ButtonGroupSchema` block IS the shipped mirror 
   });
 
   it.each(['disabled', 'className'])(
-    'the inherited `%s` row it documents is a declared member (membership only — see header)',
+    'the inherited `%s` row it documents matches the declared member',
     (key) => {
       expect(BASE_KEYS.has(key)).toBe(true);
       expect(groupDoc.get(key)?.optional).toBe(declaredOptional(groupShape, key));
+      expect(groupDoc.get(key)?.typeText).toBe(declaredTypeText(groupShape[key]));
     },
   );
+
+  it('`ButtonGroupSchema` is the one component schema that does NOT narrow `disabled`', () => {
+    // The reason the row above says `boolean | string` while 13 sibling pages
+    // correctly say `boolean`: those 13 schemas redeclare it. This assertion is
+    // what stops a later `disabled?: boolean` narrowing on ButtonGroupSchema
+    // from leaving the page silently over-stating instead of under-stating.
+    expect(declaredTypeText(groupShape.disabled)).toBe('boolean | string');
+    expect(Object.keys(groupShape).includes('disabled')).toBe(true);
+  });
 });
 
 describe('button-group.mdx: no Selection Mode section, because the renderer has no selection (objectui#6347)', () => {
@@ -274,5 +322,15 @@ describe('counter-probes: the readers above can still fail (objectui#6347)', () 
     expect(documentedLiterals("'default' | 'outline' | 'ghost'")).not.toEqual(
       enumOptions(groupShape.variant),
     );
+  });
+
+  it('`declaredTypeText` reads the mirror, not a hard-coded string', () => {
+    // Non-vacuity for the union reader: it must distinguish the two inherited
+    // rows from each other, and must not answer `unknown` for either.
+    expect(declaredTypeText(groupShape.className)).toBe('string');
+    expect(declaredTypeText(groupShape.disabled)).not.toBe(
+      declaredTypeText(groupShape.className),
+    );
+    expect(declaredTypeText(groupShape.disabled)).not.toContain('unknown');
   });
 });

--- a/packages/types/src/__tests__/button-group-doc-surface-6347.test.ts
+++ b/packages/types/src/__tests__/button-group-doc-surface-6347.test.ts
@@ -1,0 +1,278 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `button-group.mdx` publishes the shipped surface, in BOTH directions (objectui#6347).
+ *
+ * ## Why this file exists rather than "the docs gates went green"
+ *
+ * Nothing in CI reads a component page's `plaintext` interface fence.
+ * `check-doc-component-types` reads the `type` STRING LITERALS out of docs code
+ * blocks and asks only "does something register this type";
+ * `check-doc-snippet-types` compiles `ts`/`tsx` fences and a `plaintext` fence is
+ * not one. So a member row in that fence can name any key at all and every gate
+ * stays green — the same hole `component-fixture-declared-keys.test.ts` records
+ * for catalog fixtures, one surface over. A green CI run on the docs correction
+ * this file accompanies would have meant "nothing else broke", NOT "the
+ * correction is right".
+ *
+ * ## What the page taught before, measured on this tree
+ *
+ * Ten rows disagreed with `packages/types/src/navigation.ts` and its Zod mirror,
+ * in BOTH directions — the card had noticed only the first direction:
+ *
+ *   OVER-stated (documented, never declared):  `ButtonGroupSchema.value`,
+ *     `ButtonGroupSchema.selectionMode`, `ButtonGroupButton.value`,
+ *     `ButtonGroupButton.icon`; `buttons` spelled REQUIRED against a declared
+ *     `buttons?`; `label?` spelled optional against a declared required `label`.
+ *   UNDER-stated (declared, never documented): `ButtonGroupButton.variant`,
+ *     `.size`, `.onClick`, `.className`; three `variant` members
+ *     (`secondary`, `destructive`, `link`) and one `size` member (`icon`).
+ *
+ * Both directions are one defect class with the sign flipped, which is why this
+ * file asserts SET EQUALITY on the component's own members rather than the
+ * subset the card enumerated. A one-directional pin is what let the omissions
+ * sit beside the corrections through two earlier passes over these pages.
+ *
+ * ## The authority is the mirror's `.shape`, never parse acceptance
+ *
+ * `BaseSchema` is `.passthrough()` and carries `[key: string]: any`, so an
+ * undeclared `selectionMode` PARSES GREEN and type-checks — acceptance cannot
+ * tell "declared" from "admitted unexamined" (the reading
+ * `undeclared-but-consumed-keys-6150.test.ts` and `object-grid-title-mirrored`
+ * established). Membership is therefore read off `.shape`, optionality off each
+ * member's own `safeParse(undefined)`, and the enum vocabularies through the
+ * shared `enumOptions` reader rather than a hand-copied string list, so this
+ * file follows the platform instead of asserting yesterday's vocabulary.
+ *
+ * ## Two BaseSchema-inherited rows are pinned for MEMBERSHIP only — deliberate
+ *
+ * The page also documents `disabled` and `className`, which `ButtonGroupSchema`
+ * inherits. Their type TEXT is not pinned here: `BaseSchema` declares
+ * `disabled?: boolean | string` (the string limb is the expression dialect),
+ * while this page — and all 21 sibling `content/docs/components/**` pages that
+ * document it, and the common-props table in `content/docs/api/schema-reference.md`
+ * — spell it `boolean`. Correcting one page would make it the lone outlier of a
+ * repo-wide convention, so it is measured and reported rather than guessed at.
+ *
+ * ## `## Selection Mode` is gone because the renderer cannot draw it
+ *
+ * `packages/components/src/renderers/basic/button-group.tsx` implements no
+ * selection behaviour at all — it maps `schema.buttons` to `Button` elements and
+ * reads `variant` / `size` / `className` / `label` only. The section's heading
+ * promised a capability nothing implements. The renderer half is asserted here
+ * too, so that whoever DOES implement selection sees this file go red and knows
+ * the page owes a section again; without it, the deletion would read as a
+ * permanent verdict rather than a statement about this tree.
+ *
+ * The two catalog fixtures the section used to render STAY (they are a different
+ * verification population, fenced off by PR #6345) and are asserted present.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { enumOptions } from '@object-ui/test-support';
+
+import { BaseSchema } from '../zod/base.zod';
+import { ButtonGroupButtonSchema, ButtonGroupSchema } from '../zod/navigation.zod';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+
+const DOC_PATH = 'content/docs/components/basic/button-group.mdx';
+const RENDERER_PATH = 'packages/components/src/renderers/basic/button-group.tsx';
+const FIXTURE_DIR = 'examples/schema-catalog/src/schemas/components-basic-button-group';
+
+const read = (relative: string): string => readFileSync(join(REPO_ROOT, relative), 'utf8');
+
+const doc = read(DOC_PATH);
+const renderer = read(RENDERER_PATH);
+
+/* ── The documented surface, parsed out of the page's `plaintext` fence ──── */
+
+interface DocumentedMember {
+  /** Spelled with a `?`. */
+  readonly optional: boolean;
+  /** Everything between the colon and the terminating semicolon, trimmed. */
+  readonly typeText: string;
+}
+
+/** The one `plaintext` fence that carries the page's interface blocks. */
+function schemaFence(): string {
+  const fences = [...doc.matchAll(/```plaintext\n([\s\S]*?)```/g)].map((match) => match[1]);
+  if (fences.length !== 1) {
+    throw new Error(`expected exactly one \`plaintext\` fence in ${DOC_PATH}, found ${fences.length}`);
+  }
+  return fences[0];
+}
+
+/** The body of one `interface <name> { … }` block, THROWING when absent. */
+function interfaceBody(source: string, name: string): string {
+  const opener = `interface ${name} {`;
+  const start = source.indexOf(opener);
+  if (start === -1) throw new Error(`no \`${opener}\` block in ${DOC_PATH}`);
+  const end = source.indexOf('\n}', start);
+  if (end === -1) throw new Error(`unterminated \`${opener}\` block in ${DOC_PATH}`);
+  return source.slice(start + opener.length, end);
+}
+
+/** Member rows of an interface body, keyed by name. */
+function documentedMembers(body: string): Map<string, DocumentedMember> {
+  const members = new Map<string, DocumentedMember>();
+  for (const match of body.matchAll(/^ {2}(\w+)(\?)?:\s*([^;]+);/gm)) {
+    members.set(match[1], { optional: match[2] === '?', typeText: match[3].trim() });
+  }
+  return members;
+}
+
+/** The single-quoted literals in a documented union, in source order. */
+const documentedLiterals = (typeText: string): string[] =>
+  [...typeText.matchAll(/'([^']*)'/g)].map((match) => match[1]);
+
+/* ── The declared surface, read off the shipped Zod mirrors ──────────────── */
+
+type ZodShape = Record<string, { safeParse(value: unknown): { success: boolean } }>;
+
+const buttonShape = ButtonGroupButtonSchema.shape as unknown as ZodShape;
+const groupShape = ButtonGroupSchema.shape as unknown as ZodShape;
+const BASE_KEYS = new Set(Object.keys(BaseSchema.shape));
+
+/** A member accepts `undefined`, i.e. the page should spell it with a `?`. */
+const declaredOptional = (shape: ZodShape, key: string): boolean =>
+  shape[key].safeParse(undefined).success;
+
+/**
+ * The members this component declares in its OWN right.
+ *
+ * `type` is re-declared by `.extend()` as the discriminator literal, so it
+ * belongs here even though `BaseSchema` carries a `type` too; every other
+ * inherited key is documented centrally, not on a component page.
+ */
+const groupOwnKeys = Object.keys(groupShape).filter((key) => key === 'type' || !BASE_KEYS.has(key));
+
+const buttonBody = interfaceBody(schemaFence(), 'ButtonGroupButton');
+const groupBody = interfaceBody(schemaFence(), 'ButtonGroupSchema');
+const buttonDoc = documentedMembers(buttonBody);
+const groupDoc = documentedMembers(groupBody);
+
+describe('button-group.mdx: the `ButtonGroupButton` block IS the shipped mirror (objectui#6347)', () => {
+  it('documents exactly the declared members — no more, no fewer', () => {
+    expect([...buttonDoc.keys()].sort()).toEqual(Object.keys(buttonShape).sort());
+  });
+
+  it.each([...Object.keys(buttonShape)])('spells `%s` with the declared optionality', (key) => {
+    expect(buttonDoc.get(key)?.optional).toBe(declaredOptional(buttonShape, key));
+  });
+
+  it.each(['variant', 'size'])('publishes the whole shipped `%s` vocabulary', (key) => {
+    const shipped = enumOptions(buttonShape[key]);
+    expect(shipped.length).toBeGreaterThan(0);
+    expect(documentedLiterals(buttonDoc.get(key)?.typeText ?? '')).toEqual(shipped);
+  });
+
+  it('documents `onClick` as a runtime slot, not something a JSON author supplies', () => {
+    // `onClick` is `() => void` / `z.function()`; objectui#4453 narrowed the
+    // runtime to `typeof === 'function'`, so an authored object is dropped.
+    expect(buttonDoc.get('onClick')?.typeText).toBe('() => void');
+    expect(buttonBody).toContain('not authorable in JSON');
+  });
+});
+
+describe('button-group.mdx: the `ButtonGroupSchema` block IS the shipped mirror (objectui#6347)', () => {
+  it('names no member the mirror does not declare', () => {
+    const undeclared = [...groupDoc.keys()].filter((key) => !(key in groupShape));
+    expect(undeclared).toEqual([]);
+  });
+
+  it('documents every member this component declares in its own right', () => {
+    const missing = groupOwnKeys.filter((key) => !groupDoc.has(key));
+    expect(missing).toEqual([]);
+    // Non-vacuity: the filter above is only worth something while it has
+    // something to filter.
+    expect([...groupOwnKeys].sort()).toEqual(['buttons', 'size', 'type', 'variant']);
+  });
+
+  it.each([...Object.keys(groupShape).filter((key) => !BASE_KEYS.has(key))])(
+    'spells `%s` with the declared optionality',
+    (key) => {
+      expect(groupDoc.get(key)?.optional).toBe(declaredOptional(groupShape, key));
+    },
+  );
+
+  it.each(['variant', 'size'])('publishes the whole shipped `%s` vocabulary', (key) => {
+    const shipped = enumOptions(groupShape[key]);
+    expect(shipped.length).toBeGreaterThan(0);
+    expect(documentedLiterals(groupDoc.get(key)?.typeText ?? '')).toEqual(shipped);
+  });
+
+  it.each(['disabled', 'className'])(
+    'the inherited `%s` row it documents is a declared member (membership only — see header)',
+    (key) => {
+      expect(BASE_KEYS.has(key)).toBe(true);
+      expect(groupDoc.get(key)?.optional).toBe(declaredOptional(groupShape, key));
+    },
+  );
+});
+
+describe('button-group.mdx: no Selection Mode section, because the renderer has no selection (objectui#6347)', () => {
+  it('the renderer reads neither `selectionMode` nor a group-level `value`', () => {
+    expect(renderer).not.toMatch(/selectionMode/);
+    expect(renderer).not.toMatch(/schema\.value/);
+    // Control: this IS the renderer, and the scan can find things in it.
+    expect(renderer).toContain('schema.buttons');
+    expect(renderer).toContain("ComponentRegistry.register('button-group'");
+  });
+
+  it('the page carries no heading promising selection', () => {
+    expect(doc).not.toMatch(/^#+ .*Selection/m);
+    expect(doc).not.toContain('single-selection');
+    expect(doc).not.toContain('multiple-selection');
+  });
+
+  it('the two catalog fixtures it used to render are still on disk', () => {
+    // Removing the section orphans them from this page; catalog entries are a
+    // separate verification population and are NOT deleted to tidy that up.
+    for (const slug of ['single-selection', 'multiple-selection']) {
+      expect(read(`${FIXTURE_DIR}/${slug}.json`)).toContain('"type": "button-group"');
+    }
+  });
+});
+
+describe('counter-probes: the readers above can still fail (objectui#6347)', () => {
+  it('`interfaceBody` throws rather than returning an empty body', () => {
+    expect(() => interfaceBody(schemaFence(), 'ButtonGroupSelectionSchema')).toThrow(
+      /no `interface ButtonGroupSelectionSchema \{` block/,
+    );
+  });
+
+  it('the extractor really parsed rows, not an empty match set', () => {
+    expect(buttonDoc.size).toBe(Object.keys(buttonShape).length);
+    expect(groupDoc.size).toBeGreaterThanOrEqual(groupOwnKeys.length);
+  });
+
+  it('an undeclared row would be caught — the shape the card reported', () => {
+    const regressed = documentedMembers(
+      "  buttons?: ButtonGroupButton[];\n  selectionMode?: 'single' | 'multiple' | 'none';",
+    );
+    expect([...regressed.keys()].filter((key) => !(key in groupShape))).toEqual(['selectionMode']);
+  });
+
+  it('an omitted declared row would be caught — the direction the card missed', () => {
+    const regressed = documentedMembers('  type: string;\n  buttons?: ButtonGroupButton[];');
+    expect(groupOwnKeys.filter((key) => !regressed.has(key))).toEqual(['variant', 'size']);
+  });
+
+  it('a truncated enum row would be caught', () => {
+    expect(documentedLiterals("'default' | 'outline' | 'ghost'")).not.toEqual(
+      enumOptions(groupShape.variant),
+    );
+  });
+});


### PR DESCRIPTION
Closes #6347

Docs only, publishes nothing. `content/docs/components/basic/button-group.mdx` published a `ButtonGroupSchema` / `ButtonGroupButton` surface that disagreed with the shipped types. The card named two rows; re-measuring the whole fence found **eleven**, in both directions.

The sonner half of #6347 was already landed under PR #6498 / #6250 and is not in this diff — no `components-feedback-sonner` file is touched. Re-verified before starting: the `duration` row is gone, the section is "With Description", and `toast-with-action.json` is a real `sonner` node.

## Every row changed

**Over-stated — documented, never declared:**

| page before | shipped declaration | page after |
| --- | --- | --- |
| `ButtonGroupSchema.value?: string \| string[]` | not declared — `navigation.ts:335-351` declares only `type`, `buttons`, `variant`, `size` (mirror `zod/navigation.zod.ts:154-159`) | removed |
| `ButtonGroupSchema.selectionMode?: 'single' \| 'multiple' \| 'none'` | not declared — same two blocks | removed |
| `ButtonGroupButton.value: string` (required) | not declared — `navigation.ts:305-330` (mirror `zod/navigation.zod.ts:142-149`) | removed |
| `ButtonGroupButton.icon?: string` | not declared — same two blocks | removed |
| `buttons: ButtonGroupButton[]` (required) | `buttons?: ButtonGroupButton[]` — `navigation.ts:340`, mirror `.zod.ts:156` | `buttons?:` |
| `label?: string` | `label: string` — required, `navigation.ts:309`, mirror `.zod.ts:143` | `label:` |

**Under-stated — declared, never documented:**

| page before | shipped declaration | page after |
| --- | --- | --- |
| no `ButtonGroupButton.variant` row | `variant?: 'default' \| 'secondary' \| 'destructive' \| 'outline' \| 'ghost' \| 'link'` — `navigation.ts:313`, `.zod.ts:144` | added |
| no `ButtonGroupButton.size` row | `size?: 'default' \| 'sm' \| 'lg' \| 'icon'` — `navigation.ts:317`, `.zod.ts:145` | added |
| no `ButtonGroupButton.onClick` row | `onClick?: () =` a void function — `navigation.ts:325`, `.zod.ts:147` (`z.function().optional()`) | added, annotated "not authorable in JSON" |
| no `ButtonGroupButton.className` row | `className?: string` — `navigation.ts:329`, `.zod.ts:148` | added |
| `ButtonGroupSchema.variant?: 'default' \| 'outline' \| 'ghost'` | six members — `navigation.ts:345`, `.zod.ts:157` | `secondary`, `destructive`, `link` restored |
| `ButtonGroupSchema.size?: 'sm' \| 'default' \| 'lg'` | four members — `navigation.ts:350`, `.zod.ts:158` | `icon` restored |
| `disabled?: boolean` | `BaseSchema.disabled?: boolean \| string` — `base.ts`, mirror `zod/base.zod.ts:190` (`z.union([z.boolean(), z.string()])`); `ButtonGroupSchema` does **not** redeclare it | `boolean \| string` |

`className?: string` was already correct and is unchanged.

### The `disabled` row is the one to look at twice

It reads at first like a repo-wide convention worth leaving alone: 14 `content/docs/components/**` pages spell a component schema's own `disabled` as `boolean`. It is not. **Thirteen of those fourteen schemas redeclare `disabled?: boolean` themselves** — `ButtonSchema`, `InputSchema`, `SelectSchema`, `SwitchSchema`, `TextareaSchema`, `CheckboxSchema`, `RadioGroupSchema`, `ComboboxSchema`, `CalendarSchema`, `DatePickerSchema`, `FileUploadSchema`, `InputOTPSchema`, `ToggleGroupSchema` — so their pages are right. `ButtonGroupSchema` is the one that does not, so it inherits `BaseSchema`'s `boolean | string` and this page was the outlier rather than the convention.

Whether `ButtonGroupSchema` *should* narrow it like its thirteen siblings is a types question, not a docs one, and is deliberately not answered here: the renderer reads neither spelling today.

## `## Selection Mode` is deleted — my independent verdict on the fork clause

Triage's ruling said a documented-but-undeclared key that a renderer nonetheless READS is a fork to report, not a docs fix. I measured it myself rather than inheriting the dispatch's reading. **Neither key is read, so no fork; the docs fix stands.**

What I measured in `packages/components/src/renderers/basic/button-group.tsx`:

- The renderer reads exactly: `schema.className`, `schema.buttons`, `schema.variant`, `schema.size`, `button.variant`, `button.size`, `button.className`, `button.label`. Nothing else reaches the DOM.
- `selectionMode` appears **nowhere** in the file. Repo-wide, the only other `selectionMode` occurrences are local variables in `data-table.tsx` and `plugin-grid/ObjectGrid.tsx` (computed from `selection.type` / `selectable`, a different schema surface), one retired-key list in `packages/i18n`, and the two catalog fixtures themselves.
- `schema.value` is never read here. Every `schema.value` read under `packages/components/src/renderers/**` belongs to a different component type (statistic, progress, textarea, input-otp, combobox, calendar, input, select, tabs, filter-builder, toggle-group, text, span).
- `button.icon` is never read either — the only `icon` token in the file is the `'icon'` member of the `size` enum.
- Only one registry entry exists for the type: `ComponentRegistry.register('button-group', ...)` in that file. `custom/button-group.tsx` and `plugin-chatbot/src/elements/ui/button-group.tsx` are Shadcn primitives taking a React `orientation` prop, not readers of this schema.

So the heading promised a capability nothing draws, over two demos that render as inert button rows. Per #6249's honesty precedent it is deleted rather than softened to a caveat.

## The two catalog fixtures stay — and the gate measurement that says they can

`components-basic-button-group/single-selection` and `/multiple-selection` are untouched. Removing the section orphans them from this page; measured, no gate fails on that:

- The catalog index is generated **from the schema directory**, keyed by `(category, slug)` — `scripts/regenerate-catalog-index.py`, pinned by `scripts/__tests__/catalog-index-regenerable-4633.test.ts`. It never reads a docs page.
- Nothing in `scripts/**`, `apps/**` or `packages/**` validates `SchemaExample id` references in either direction. `extract-mdx-demos.mjs` is a one-way migration tool run by hand.
- `examples/schema-catalog/test/catalog-gallery-render.test.tsx` renders every entry and fails only on an unregistered `type`; both fixtures are still `type: "button-group"`.
- No inbound link or anchor points at the removed section: `docs:check-links` is green, and the only other "Selection Mode" heading in the repo belongs to `form/calendar.mdx`.

The pin below asserts both fixtures are still on disk, so a later tidy-up cannot quietly delete them to silence something.

## The pin, and why a docs correction needs one

`packages/types/src/__tests__/button-group-doc-surface-6347.test.ts` — 29 assertions.

Nothing in CI reads a `plaintext` fence. `check:doc-types` reads only the `type` string literals out of docs code blocks; `check:doc-snippets` compiles `ts`/`tsx` fences and a `plaintext` block is not one. So a member row can name any key at all and every gate stays green — the same hole `component-fixture-declared-keys.test.ts` records one surface over. Without this file a green CI run would say "nothing else broke", not "the correction is right".

It asserts **set equality** on the component's own members, not the subset the card enumerated — a one-directional pin is precisely what left these omissions sitting beside two earlier corrections to this page (#6132, #6143). Membership is read off the mirror's `.shape`, never off parse acceptance: `BaseSchema` is `.passthrough()` and carries an index signature, so an undeclared `selectionMode` parses green and type-checks, and acceptance cannot tell "declared" from "admitted unexamined".

It also pins the renderer half of the deletion, so whoever implements selection sees this file go red and knows the page owes a section again.

## Verification

Union run on final commit `0f49c91c7`.

| command | result |
| --- | --- |
| `pnpm exec vitest run packages/types/` | `Test Files 80 passed (80)` · `Tests 998 passed (998)` |
| `pnpm --filter @object-ui/types type-check` | exit 0; `--listFiles` confirms the new test file is in the `tsconfig.test.json` program (1 hit) |
| `pnpm check:doc-types` | `Every documented component type is registered.` |
| `pnpm check:doc-fences` | `every TypeScript block in 224 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s)` — the page's declared entry is `1` and it still holds exactly 1 `plaintext` fence |
| `pnpm check:control-bytes` | `OK (scanned 5862 tracked text file(s); skipped 85 binary)` |
| `pnpm check:docs-route-closure` | `1360 modules crawled from 149 route roots (145 MDX), every specifier resolved` |
| `pnpm docs:check-links` | `Links are valid across 17 scan roots.` |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `node scripts/check-changeset-fixed.mjs` | `All workspace packages are in the changeset fixed group.` |
| `node scripts/check-type-check-coverage.mjs` | `45/46 via type-check` · `41/41 packages compile their tests` |
| `node scripts/check-lint-coverage.mjs` | `46/46 packages linted, 0 with outstanding errors` |
| `pnpm exec eslint <the new test file>` | 1 file, 0 errors, 0 warnings |

**Reverse verification, direction predicted before running.** With the fix committed and the page restored to `592acafbe`, the pin goes **15 failed / 12 passed** — set equality, both enum vocabularies on both blocks, `label` and `buttons` optionality, the `onClick` annotation, the undeclared-member check and the heading check all red, exactly as predicted; "documents every member declared in its own right" stayed green, because the old page did name `type`/`buttons`/`variant`/`size`. A targeted second ablation on the `disabled` row alone went **1 failed / 28 passed**, and the mutated blob hashed identically to the pre-fix commit's blob. Both restores were proven by `git diff HEAD` empty plus a blob-hash comparison against `HEAD`, not by an exit code.

**Two declared narrowings.**

`check:doc-snippets` was NOT run: it exits 2 `PRECONDITION NOT MET` until all 21 package dists are built, and that build is a repo-scale run. Evidence the narrowing costs nothing: (1) the gate's population is `ts`/`tsx`/`typescript` fences by its own contract, which `check:doc-fences` independently reports on and which ran green here; (2) counted with `grep -cE`, this page carries **0** ts/tsx/typescript fences before and after and exactly **1** `plaintext` fence before and after, matching its declared entry in `check-doc-fence-languages.mjs`; (3) `packages/types/tsconfig.json` excludes `**/*.test.ts` from the build, so `packages/types/dist` is byte-identical to `main`'s and no other document's compile input moved.

`pnpm lint` (repo-wide) was narrowed to the changed files. Evidence: (1) the population is eslint's own — asked directly, it reports `File ignored because no matching configuration was supplied.` for both the `.mdx` and the `.md` changeset, so the lintable population of this diff is one file; (2) counted from `--format json`: 1 file, 0 errors, 0 warnings; (3) `eslint.config.js` declares no `parserOptions.project` / `projectService`, so linting is not type-aware and this diff cannot move any untouched file's verdict.

## Filed, not fixed here

**#7077** — `button-group` implements no selection, and never wires the per-button `onClick` or `disabled` it *does* declare; the six catalog fixtures author 29 occurrences of four undeclared keys (`buttons[].value` 17, `buttons[].icon` 8, `value` 2, `selectionMode` 2). The card states the fork (implement, or retire the authored surface under ADR-0049) and does not choose. It cross-references #5931, which already covers `with-icons.json`'s `icon` pair for this component alongside `breadcrumb` and `command`.

## One correction to the dispatch's premises

The dispatch measured "the section's two fixtures ... five undeclared keys between them". Counted per fixture, it is **29 occurrences across all six**, including the three fixtures the sections that STAY still render. That does not change this diff — no fixture is edited — but it makes #7077 materially wider than "two demos".

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_