### PR TITLE
docs(api): state every declared BaseSchema member at its declared type

### DIFF
--- a/.changeset/7079-schema-reference-base-props.md
+++ b/.changeset/7079-schema-reference-base-props.md
@@ -1,0 +1,32 @@
+---
+---
+
+Docs only — the canonical `BaseSchema` "Common Properties" table in
+`content/docs/api/schema-reference.md` (objectui#7079). No package source, no
+published contract and no runtime behaviour is touched, hence the empty
+declaration; `apps/site` is `private: true` and sits in `.changeset/config.json`'s
+`ignore` list, so nothing under `content/` ships from this change.
+
+The table narrowed five declared unions to one limb each and omitted five declared
+members outright. Measured against `packages/types/src/base.ts` and its Zod mirror
+`packages/types/src/zod/base.zod.ts`, whose agreement is held by
+`base-schema-zod-mirror-parity.test.ts` reading the mirror's own `.shape`:
+`label` and `description` are `string | I18nLabel`, `ariaLabel` is
+`string | KeyedI18nLabel` (the KEYED form, not the inline locale map), and both
+`visible` and `disabled` take a predicate expression string as well as a boolean —
+the expression limb is on the base key itself, not only on the `visibleOn` /
+`disabledOn` siblings the paired cells implied. `placeholder`, `style`, `data`,
+`bind` and `visibleWhen` had no row at all.
+
+The three combined cells (`visible` / `visibleOn`, `hidden` / `hiddenOn`,
+`disabled` / `disabledOn`) are split into one row per member. Packing two members
+with different types into a single `boolean` / `string` cell is what made the
+error invisible: the pairing reads as a complete, ordered account, and that
+appearance of completeness is precisely what hid the third fact. One row per
+declared member, in declaration order, makes completeness checkable by reading the
+table against the interface.
+
+Nothing in CI reads this table — `check:doc-snippet-types` compiles only `ts` /
+`tsx` / `typescript` fences, `check:doc-component-types` judges `type` string
+literals and key tables anchored on a `Namespaced key | Bare-name fallback`
+header, and no script in the repository parses a Markdown property table.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -50,21 +50,36 @@ All schema types extend `BaseSchema`. These shared properties are available on e
 }
 ```
 
+One row per declared member, in declaration order, so the list can be checked against `BaseSchema` by reading the two side by side.
+
 | Property | Type | Description |
 |----------|------|-------------|
 | `type` | `string` | **Required.** Component type identifier (e.g. `"page"`, `"form"`, `"table"`). |
 | `id` | `string` | Unique instance identifier. |
 | `name` | `string` | Component name, used for form fields and data binding. |
-| `label` | `string` | Human-readable display label. |
-| `description` | `string` | Help text or tooltip content. |
+| `label` | `string \| I18nLabel` | Human-readable display label. `I18nLabel` is the spec's **inline locale map** (`string \| Record<string, string>`, keyed by BCP-47 locale tag such as `en` or `zh-CN`), resolved against the display locale by `resolveI18nLabel`. |
+| `description` | `string \| I18nLabel` | Help text or tooltip content. Same inline-locale-map vocabulary and resolver as `label`. |
+| `placeholder` | `string` | Hint text for input components. |
 | `className` | `string` | Tailwind CSS utility classes. |
+| `style` | `Record<string, string \| number>` | Inline CSS styles. Use sparingly — prefer `className`. |
+| `data` | `any` | Arbitrary data attached to the node. `any` because the shape is defined by the consuming component rather than by `BaseSchema`. |
+| `bind` | `string` | Data-scope path this node draws its rows or value from, resolved by `useDataScope()`. Honoured only by components that call it. |
 | `body` | `SchemaNode \| SchemaNode[]` | Child components rendered inside this component. |
 | `children` | `SchemaNode \| SchemaNode[]` | Alias for `body`. |
-| `visible` / `visibleOn` | `boolean` / `string` | Control visibility. `visibleOn` accepts expression strings. |
-| `hidden` / `hiddenOn` | `boolean` / `string` | Inverse of visible. |
-| `disabled` / `disabledOn` | `boolean` / `string` | Control disabled state. |
-| `testId` | `string` | Test identifier for automated testing. |
-| `ariaLabel` | `string` | Accessibility label. |
+| `visible` | `boolean \| string` | Visibility control. Accepts a boolean **or** a predicate expression string — the renderer evaluates this key rather than reading it as a boolean. |
+| `visibleWhen` | `string` | Canonical conditional-visibility predicate (ADR-0089); the element is shown when it evaluates truthy. Evaluated **before** `visible` and `visibleOn`, and outranks both. |
+| `visibleOn` | `string` | Expression for conditional visibility. **Deprecated** (ADR-0089) — use `visibleWhen`. |
+| `hidden` | `boolean` | Inverse of `visible`. Boolean only — unlike `visible`, this key takes no expression. |
+| `hiddenOn` | `string` | Expression for conditional hiding. |
+| `disabled` | `boolean \| string` | Disabled state. Accepts a boolean **or** a predicate expression string, on the same evaluated path as `visible`. |
+| `disabledOn` | `string` | Expression for conditional disabling. |
+| `testId` | `string` | Test identifier, rendered as `data-testid`. |
+| `ariaLabel` | `string \| KeyedI18nLabel` | Accessibility label, rendered as `aria-label`. `KeyedI18nLabel` is the **keyed** form (`{ key, defaultValue?, params? }`), resolved by `resolveKeyedI18nLabel` — **not** the `I18nLabel` that `label` and `description` carry. The two are structurally confusable and each returns nothing useful for the other's input. |
+
+Two things the table cannot show in a cell:
+
+- **A concrete schema may narrow an inherited member, and its own declaration wins.** Many component schemas restate `label`, `description` or `disabled` more narrowly than `BaseSchema` declares them, so the unions above are what a node gets when its own schema does not restate the key. Check the component's own property table before writing a predicate string or a locale map into an inherited slot.
+- **This list is exhaustive for *declared* members, not for *accepted* keys.** `BaseSchema` carries an index signature (`[key: string]: any`) and its Zod mirror is `.passthrough()`, so an undeclared key — a misspelling included — is still accepted by both halves. Absence from this table does not mean a key is rejected.
 
 ---
 


### PR DESCRIPTION
Closes #7079

The canonical "Common Properties" table in `content/docs/api/schema-reference.md` narrowed five declared unions to one limb each and omitted five declared members outright. It is the reference page every component page defers to for inherited props, so a reader who checked the authority for a `BaseSchema` key got a narrower answer than the type gives.

## Authority

Membership and per-key type are read off **`packages/types/src/base.ts`** and its Zod mirror **`packages/types/src/zod/base.zod.ts`** — not off parse acceptance. `BaseSchema` carries `[key: string]: any` and the mirror is `.passthrough()`, so an undeclared key parses green; acceptance cannot separate "declared" from "admitted unexamined".

The two faces are not assumed to agree — `packages/types/src/__tests__/base-schema-zod-mirror-parity.test.ts` reads the mirror's **own `.shape`** and compares each key against the declaration, and it is green on this branch.

Mechanical census of the interface body (extracted by matching declarations at the interface's own indentation, with `type` / `ariaLabel` / `disabled` / `[key: string]` as positive controls, all four HIT): **21 named members plus the index signature.** The old table had 13 rows covering 16 of the 21. Every one of the 21 has real readers in `packages/*/src` (see "A census I got wrong" below).

## Under-stated — row existed, type was narrower than declared

| Property | page before | authorising declaration | page after |
| --- | --- | --- | --- |
| `label` | `string` | `base.ts:139` · mirror `base.zod.ts:94` (`I18nLabelSchema`) | `string \| I18nLabel` |
| `description` | `string` | `base.ts:157` · mirror `base.zod.ts:101` | `string \| I18nLabel` |
| `ariaLabel` | `string` | `base.ts:376` · mirror `base.zod.ts:211` | `string \| KeyedI18nLabel` |
| `visible` | `boolean` (in a `boolean` / `string` cell shared with `visibleOn`) | `base.ts:278` · mirror `base.zod.ts:158` (`z.union([z.boolean(), z.string()])`) | `boolean \| string` |
| `disabled` | `boolean` (in a `boolean` / `string` cell shared with `disabledOn`) | `base.ts:327` · mirror `base.zod.ts:190` | `boolean \| string` |

## Omitted entirely — declared, no row at all

| Property | authorising declaration | page after |
| --- | --- | --- |
| `placeholder` | `base.ts:163` · mirror `base.zod.ts:106` | `string` |
| `style` | `base.ts:177` · mirror `base.zod.ts:116` | `Record<string, string \| number>` |
| `data` | `base.ts:183` · mirror `base.zod.ts:121` | `any` |
| `bind` | `base.ts:247` · mirror `base.zod.ts:135` | `string` |
| `visibleWhen` | `base.ts:286` · mirror `base.zod.ts:164` | `string` |

Correct before and unchanged in type: `type`, `id`, `name`, `className`, `body`, `children`, `hidden`, `hiddenOn`, `testId`, `visibleOn`, `disabledOn`. `hidden` really is boolean-only, so the divergence was never uniform and no blanket edit would have been right.

## Decision: the three combined cells are split, one row per member

`visible` / `visibleOn`, `hidden` / `hiddenOn` and `disabled` / `disabledOn` each packed two members with different types into one `boolean` / `string` cell. Annotating them in place was rejected; they are split. Four reasons:

1. **The pairing is what manufactured the error.** `boolean` / `string` reads as an ordered mapping — first member takes the first type — and that reading is exactly the false statement. A footnote would leave a Type cell that still cannot be read left to right.
2. **The same formatting would otherwise mean two different things.** `hidden` / `hiddenOn` genuinely is `boolean` / `string`. Keeping the paired form where it happens to be true and splitting it where it is false produces a table whose format carries no information.
3. **Completeness becomes checkable.** One row per declared member, in declaration order, makes "is this table complete" a straight zip against the interface. The paired form structurally denies that check, and that is how five members went missing without anyone noticing.
4. **`visibleWhen` gets the place a reader looks for it** — beside `visible` and `visibleOn`, which as a documented pair of two read as an exhaustive list of the visibility vocabulary.

## Verdict on `ariaLabel` (the row the dispatch did not check)

**The card is right, and the correct spelling is the one trap on this page.** `ariaLabel` is declared `string | KeyedI18nLabel` (`base.ts:376`), the **keyed** form `{ key, defaultValue?, params? }` resolved by `resolveKeyedI18nLabel` — **not** the `I18nLabel` inline locale map that `label` and `description` two rows up carry.

Copying the `label` / `description` pattern here would have manufactured a new defect rather than fixed one: `base.ts:352-362` records that PR #4593 measured `string | I18nLabel` wrong on this slot in three ways before ruling #4580 Q2-B withdrew it — the keyed fixture type-checked only vacuously, the same label carrying `params` was rejected outright, and a genuine `{ en: 'Owner' }` type-checked while the resolver returns `undefined` for it and renders an **empty** aria-label. The table now says which vocabulary this is and names the resolver, because the two are structurally confusable and each answers wrongly for the other's input.

Both type names are importable from the package the page's header names: `KeyedI18nLabel` at `packages/types/src/index.ts:101`, `I18nLabel` re-exported from `@objectstack/spec/ui` at `index.ts:1337`.

## Fence census, and why a green run would not have meant much

**This page carries no `plaintext` fence.** Before and after are identical: 27 fences — 24 `json`, 3 `typescript`. (A naive `^```` census reported 2 `typescript` and had to be corrected: one opener sits inside a blockquote at line 12.)

No gate in this repository reads a Markdown property table:

- `check:doc-snippets` compiles `ts` / `tsx` / `typescript` fences only. Proven invariant rather than asserted: this branch imports the gate's **own exported `scanFences`** and runs it over the before and after page — 2 collected blocks each side, bodies **byte-identical**. Content outside a fence is never collected, so this gate's verdict about this page cannot have moved. (2 collected, not 3 — see the finding below.)
- `check:doc-types` judges `type` string literals and key tables anchored on a `Namespaced key | Bare-name fallback` header (`scripts/check-doc-component-types.mjs:243`). The Property/Type/Description header does not match it.
- **`check:doc-key-tables` does not exist in this repository.** The card cites it as a separate gate; a controlled grep found 0 hits repo-wide for that name against 10 hits for a known-present control string. objectui#5106's key-table logic lives *inside* `check-doc-component-types.mjs`. The card's conclusion — nothing reads this table — holds, and holds more strongly than its citation.

So a green CI run here means "nothing else broke", not "the correction is right". The correction is carried by the declaration line numbers in the tables above, each of which a reviewer can open.

**No pin test is added, and that is deliberate.** #6347's pin was justified by a *type-level* claim a test could assert. The claim here is that a prose Type column matches a declaration — there is no assertion that reads a Markdown table without first building the table parser that objectui#5106 deliberately scoped to registration tables. Adding one reflexively would pin the table's *current text*, which reddens on every legitimate reword. If this class recurs, the right shape is a gate that parses property tables generally, not a pin on this page.

## Two notes added below the table

The corrected table newly invites a wrong inference that the visibly-incomplete old one did not: that 21 rows are the accepted key set. Two short notes carry what a cell cannot — that a concrete schema may narrow an inherited member and its own declaration wins, and that the list is exhaustive for *declared* members but not for *accepted* keys.

The narrowing note deliberately carries **no counts**. Publishing "18 schemas narrow `disabled`" in prose that nothing pins would reproduce the exact defect this PR fixes — a measured number going stale silently. The measurement is dated evidence and lives in the report, not in the page.

## A census I got wrong, recorded because the correction changed a row

My first reader census returned **zero** readers for `visibleWhen`, which would have made it a declared-but-never-read member and therefore a declaration question to file rather than a row to write. It was wrong: the pattern matched `schema.visibleWhen` and the actual reader is `newSchema.visibleWhen` (`packages/react/src/SchemaRenderer.tsx:1197`). My control passed while the census was broken, because the control keys happened to exist in the lowercase form.

Corrected, `visibleWhen` is not merely read — it is the **canonical** predicate under ADR-0089 and is evaluated **first**, ahead of `visible` and `visibleOn`, which the row now states. A separate CJK-precedent census hit the same class: `grep -P` errored out on this build and printed nothing, and only the control revealed that the zero was an error and not a measurement.

## Not changed, on purpose

- The `json` example above the table. It shows a valid subset and makes no type claim; adding keys to it would edit a fence this PR has proven it does not touch.
- The 14 component pages that spell inherited `disabled` as `boolean`. #6347 measured 13 of 14 as correct because those schemas redeclare the key themselves, and correcting `BaseSchema` does not make them wrong.
- `hidden`'s "Inverse of `visible`" wording, which is relocated unchanged. Correcting it toward `base.ts`'s own JSDoc would have made the page **less** accurate: filed separately, with the measurement.

## Verification

Run at `6dbef5210`, the branch head:

```
check:doc-types              exit=0  Every documented component type is registered.
check:doc-fences             exit=0  every TypeScript block in 224 document(s) is fenced ts/tsx/typescript
check:control-bytes          exit=0  scanned 5861 tracked text file(s); skipped 85 binary
check-changeset-presence     exit=0  no changeset is owed
check-changeset-no-major     exit=0  No changeset declares a `major` bump
check-doc-links              exit=0  Links are valid across 17 scan roots
vitest (5 BaseSchema pins)   exit=0  Test Files 5 passed (5) · Tests 29 passed (29)
```

Verdicts are quoted from each gate's own printed line; exit codes were captured before any pipe.

`check:doc-snippets` was **narrowed, not skipped** — its build closure is 21 packages, and the narrowing is measured with the gate's own collector as described above.

Changeset is the **empty-frontmatter** form. `@object-ui/site` is `private: true` and appears in `.changeset/config.json`'s `ignore` list, and the presence gate itself reports "no changeset is owed" both before and after, so a `patch` bump would falsely claim a released package changed. `skip-changeset` is **not** applied: measured on #7073 that no workflow or script in this repository reads it.

_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_

---
_Generated by [Claude Code](https://claude.ai/code/session_013hfmP9hoMd3dJwTh85J4yB)_