### PR TITLE
fix(plugin-grid): gate the server `$select` projection on field-level security

### DIFF
--- a/.changeset/6898-objectgrid-select-fls.md
+++ b/.changeset/6898-objectgrid-select-fls.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+ObjectGrid: field-level security on the server `$select` projection
+(objectui#6898) — the FETCH half of the gap objectui#6799 closed on the RENDER
+half.
+
+`getSelectFields()` built the projection from the authored `columns` / `fields`
+with no FLS gate, so after objectui#6799 hid the column the field name was still
+being ASKED for. `perms.checkField(object, field, 'read')` now gates the
+projection, on both authored arms and on the predicate-operand harvest.
+
+Measured, because the grade depended on it: ObjectStack's own server enforces
+FLS on the RECORD, not on the projection — `plugin-security`'s read middleware
+deletes an unreadable key from every returned row, and its `predicate-guard`
+says in terms that the projection is deliberately unguarded because the masker
+strips the value anyway (pinned over real HTTP by objectstack's
+`showcase-fls-read-mask-strip.dogfood.test.ts`, where `?select=name,<denied>`
+answers 200 with the key absent). So against ObjectStack this is
+defence-in-depth; it becomes load-bearing for any backend that does not strip.
+
+Two limits are deliberate and pinned:
+
+- Only keys the object DECLARES are judged. `checkField` answers `false` for a
+  field no policy mentions, so judging an undeclared key would strip a host's
+  derived or joined column out of its own query.
+- `id` survives even a policy that denies it, structurally — `ensureId` composes
+  after the gate — so row navigation cannot break. Readable predicate operands
+  are untouched, so objectui#3501 does not regress.
+
+The fetch effect now also depends on `perms.isLoaded`: `/me/permissions`
+resolves asynchronously, so without it nothing would rebuild the projection
+after the policy answered and the gate would never run on the only fetch most
+grids make.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -1469,6 +1469,75 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
               const names = list.map((f: any) => columnIdentity(f));
               return names.includes('id') ? list : ['id', ...list];
             };
+            // [objectui#6898] FIELD-LEVEL SECURITY ON THE PROJECTION — the FETCH
+            // half of the gap objectui#6799 closed on the RENDER half.
+            //
+            // objectui#6799 made `generateColumns()` drop a column naming a
+            // declared field the principal cannot read. That is what reaches the
+            // SCREEN. This is what goes on the WIRE: without this gate the same
+            // field name is still handed to the server in `$select`, so a
+            // backend that does not enforce FLS on the projection would return
+            // the value into `data` with no column on screen to reveal it.
+            //
+            // ⭐ MEASURED, not assumed (the escalation gate this card was graded
+            // on). ObjectStack's own server DOES enforce it — but on the RECORD,
+            // not on the projection. `plugin-security`'s read middleware runs
+            // `FieldMasker.maskResults`, whose `maskRecord` DELETES an unreadable
+            // key from every returned row, and `predicate-guard.ts` says in terms
+            // that the projection is deliberately NOT guarded because "selecting
+            // a hidden field is harmless because FieldMasker strips it from the
+            // result". Pinned end-to-end over real HTTP by objectstack's
+            // `showcase-fls-read-mask-strip.dogfood.test.ts`: an explicit
+            // `?select=name,<denied>` answers 200 with the denied key ABSENT.
+            // So against ObjectStack this gate is defence-in-depth (p2), exactly
+            // as triage graded it — it is NOT load-bearing for that backend, and
+            // this comment is what stops a future reader from concluding it is.
+            // It becomes load-bearing for any other backend, which is the same
+            // argument the objectui#6723 / objectui#6799 rulings accepted: the
+            // invariant must not rest on every future backend having enforced it.
+            //
+            // ⭐ THE DECLARED-KEY LIMIT IS THE SAME ONE, AND THE CARD IS RIGHT
+            // THAT THE REASONING DOES NOT TRANSFER AUTOMATICALLY — it has to be
+            // re-derived here, and it lands in the same place. On the render path
+            // an undeclared key is a legitimate derived / host-joined column. In
+            // a `$select` an undeclared key is what the host asked the SERVER
+            // for, so the question is genuinely different. It resolves the same
+            // way for a reason that is about `checkField`, not about drawing:
+            // `checkField` answers FALSE for a field the policy has never heard
+            // of, so judging an undeclared key is not a stricter reading of this
+            // rule — it is a different, wrong one, and it would strip a host's
+            // derived or joined column out of its own query. Undeclared ⇒ not
+            // this gate's business, on both halves.
+            //
+            // ⛔ NAVIGATION IS PRESERVED STRUCTURALLY, NOT BY A SPECIAL CASE:
+            // every call below composes `ensureId(...)` AFTER this gate, so `id`
+            // is re-added even in the pathological case where a policy marks it
+            // unreadable. A gate that filtered `id` out last would break row
+            // click / navigation for everyone — the naive-filter failure the
+            // card names by name. Keeping the restoration in the composition
+            // rather than in a branch here means it cannot drift out of one arm.
+            //
+            // Keyed on `objectName` (the object actually being FETCHED —
+            // `dataConfig.object` when a data block names one) rather than the
+            // render half's `schema.objectName`: the projection is judged against
+            // whatever object the server is about to read.
+            const passesProjectionGate = (entry: unknown): boolean => {
+              // Not loaded ⇒ nothing to ask yet; never filter on an unanswered
+              // policy. Same deferral as the render half — and the fetch effect
+              // re-runs on `perms.isLoaded` so the projection is rebuilt the
+              // moment the answer arrives (without that dep this gate would be
+              // dead on the first, and usually only, fetch).
+              if (!perms?.isLoaded || !objectName) return true;
+              const fieldName = columnIdentity(entry);
+              // No readable identity ⇒ nothing to ask the policy about.
+              if (!fieldName) return true;
+              // Undeclared ⇒ host-joined / derived / platform column ⇒ see above.
+              // `hasOwnProperty` rather than a truthiness read so an inherited
+              // name (`constructor`, `toString`) cannot be mistaken for a
+              // declared field and dropped out of the query.
+              if (!Object.prototype.hasOwnProperty.call(resolvedSchema?.fields ?? {}, fieldName)) return true;
+              return perms.checkField(objectName, fieldName, 'read');
+            };
             // Fields the view's PREDICATES read but no column shows
             // (objectui#3501). Without them the projection asks the
             // server for everything except the field a row action is gated on,
@@ -1529,6 +1598,18 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
                   // pinned by `__tests__/gridNonAuthorKeys.test.tsx`.
                   userActions: (resolvedSchema as any)?.userActions,
                 })).filter((f) => isProjectableField(f, declared as Record<string, unknown>))
+                  // [objectui#6898] A predicate operand the principal cannot read
+                  // is dropped from the projection too. This costs nothing that
+                  // was working: against ObjectStack the server already DELETES
+                  // that key from every row (measured above), so the operand was
+                  // never arriving and the CEL predicate was already faulting
+                  // `No such key` and failing CLOSED. Dropping it from `$select`
+                  // changes what we ASK for, not what we got. Against a
+                  // non-enforcing backend it converts "the button works, and the
+                  // denied value sits in memory" into "the button hides" — which
+                  // is the correct direction for a predicate gated on a field
+                  // this principal may not read.
+                  .filter((f) => passesProjectionGate(f))
               : [];
             const withPredicates = (list: any[]): any[] => {
               if (predicateFields.length === 0) return list;
@@ -1536,9 +1617,12 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
               const extra = predicateFields.filter((f) => !names.has(f));
               return extra.length > 0 ? [...list, ...extra] : list;
             };
-            if (schemaFields) return withPredicates(ensureId(schemaFields as any[]));
+            if (schemaFields) {
+              return withPredicates(ensureId((schemaFields as any[]).filter(passesProjectionGate)));
+            }
             if (schemaColumns && Array.isArray(schemaColumns)) {
               const fields = schemaColumns
+                .filter(passesProjectionGate)
                 .map((c: any) => columnIdentity(c))
                 .filter((v): v is string => !!v);
               return withPredicates(ensureId(fields));
@@ -1662,7 +1746,16 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [objectName, schemaFields, schemaColumns, schemaFilter, schemaSort, headerSort, searchTerm, schemaPagination, schemaPageSize, serverPage, serverPageSize, dataSource, hasInlineData, dataConfig, refreshKey]);
+  // `perms.isLoaded` (objectui#6898): the projection is FLS-gated above, and
+  // `/me/permissions` resolves asynchronously — on the first render it is still
+  // `false`, so the gate defers and the first request goes out ungated. Without
+  // this dep nothing would ever rebuild it and the gate would be dead on the
+  // only fetch most grids make. The boolean, not `perms` itself: it flips
+  // false -> true exactly once, so this costs at most one refetch, where the
+  // context object's identity would re-fetch the grid on every render.
+  // `PermissionProvider` reports `true` synchronously and the no-provider
+  // default stays `false` forever, so neither of those pays anything.
+  }, [objectName, schemaFields, schemaColumns, schemaFilter, schemaSort, headerSort, searchTerm, schemaPagination, schemaPageSize, serverPage, serverPageSize, dataSource, hasInlineData, dataConfig, refreshKey, perms.isLoaded]);
 
   // The same reset, for the path the loader above never runs on (objectui#4501
   // clause 2). "All N matching are selected" is a claim about ONE query, so it

--- a/packages/plugin-grid/src/__tests__/projectionFls-6898.test.tsx
+++ b/packages/plugin-grid/src/__tests__/projectionFls-6898.test.tsx
@@ -113,7 +113,10 @@ const OBJECT_FIELDS = {
 };
 
 const makeDataSource = (schemaExtra: Record<string, unknown> = {}) => ({
-  find: vi.fn(async () => ({ data: [], total: 0 })),
+  // `vi.fn().mockResolvedValue(...)` rather than `vi.fn(async () => ...)`: the
+  // inline implementation narrows the mock's ARG tuple to `[]`, and every
+  // assertion here reads `find.mock.calls.at(-1)?.[1].$select` — the second arg.
+  find: vi.fn().mockResolvedValue({ data: [], total: 0 }),
   findOne: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),

--- a/packages/plugin-grid/src/__tests__/projectionFls-6898.test.tsx
+++ b/packages/plugin-grid/src/__tests__/projectionFls-6898.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6898 — field-level security on the `$select` PROJECTION.
+ *
+ * ## The two halves
+ *
+ * objectui#6799 closed the RENDER half: `generateColumns()` drops a column
+ * naming a declared field the principal cannot read. This is the FETCH half —
+ * what `getSelectFields()` hands the server. Before this change the field name
+ * was still in `$select`, so the column was hidden while the value was still
+ * being ASKED for.
+ *
+ * ## What the escalation gate measured (why this file pins a p2, not a p1)
+ *
+ * ObjectStack's own server enforces FLS on the RECORD, not on the projection:
+ * `plugin-security`'s read middleware runs `FieldMasker.maskResults`, whose
+ * `maskRecord` DELETES an unreadable key from every returned row, and
+ * `predicate-guard.ts` states outright that the projection is deliberately not
+ * guarded because "selecting a hidden field is harmless because FieldMasker
+ * strips it from the result". Pinned end-to-end over real HTTP in objectstack's
+ * `showcase-fls-read-mask-strip.dogfood.test.ts`: `?select=name,<denied>`
+ * answers 200 with the denied key ABSENT.
+ *
+ * So against ObjectStack this gate is defence-in-depth and nothing here is
+ * load-bearing for that backend. It is load-bearing for any backend that does
+ * not strip — the same argument objectui#6723 / objectui#6799 accepted for the
+ * render half.
+ *
+ * ## The limit is the point (PIN 4 / PIN 5)
+ *
+ * Only keys the object DECLARES are judged. `checkField` answers `false` for a
+ * field no policy mentions, so judging an undeclared key would strip a host's
+ * derived or joined column out of its own query — a different, wrong rule. And
+ * the judged key is read through `columnIdentity`, never off a bare string, so
+ * the legacy `{ name }` spelling cannot walk a denied field through (PIN 5).
+ *
+ * ## `id` and the predicate operands (the card's decision point 2)
+ *
+ * `id` is force-added for row navigation and predicate operands are added
+ * though no column shows them, so a NAIVE filter breaks navigation or an action
+ * rather than closing a hole. PIN 3 pins that `id` survives even when the
+ * policy denies it — structurally, because `ensureId` composes AFTER the gate.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `authoredColumnsFls-6799.test.tsx` for the same reason:
+ * `PermissionProvider` answers `true` for a field no policy mentions, so under
+ * it the limit would be untestable and PIN 4 would be green in both worlds for
+ * the wrong reason. The stub models a server that ENUMERATES readable fields.
+ *
+ * ## ABLATION — see the PR body for the recorded run.
+ *
+ * This file imports `../ObjectGrid` relatively and the root vitest config
+ * aliases `@object-ui/*` to each package's `src`, so no build step stands
+ * between the edit and the run: the ablation reads source directly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import React from 'react';
+
+/** Stable stub identity — `ObjectGrid` carries `perms` in memo dep arrays. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = {
+    isLoaded: true,
+    readable: [],
+  };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+import { ObjectGrid } from '../ObjectGrid';
+import { ActionProvider } from '@object-ui/react';
+
+const OBJECT = 'opportunity';
+
+/**
+ * `salary` is DECLARED and denied — the field under test. `computed_score` is
+ * deliberately NOT declared: it is the derived / host-joined key the limit
+ * protects. `stage` is declared and readable, and is the predicate operand.
+ */
+const OBJECT_FIELDS = {
+  name: { type: 'text', label: 'Name' },
+  salary: { type: 'number', label: 'Salary' },
+  stage: { type: 'select', label: 'Stage' },
+};
+
+const makeDataSource = (schemaExtra: Record<string, unknown> = {}) => ({
+  find: vi.fn(async () => ({ data: [], total: 0 })),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn(async () => ({
+    name: OBJECT,
+    fields: OBJECT_FIELDS,
+    ...schemaExtra,
+  })),
+});
+
+/** Render a grid and return the `$select` it actually asked the server for. */
+const selectFor = async (
+  schemaExtra: Record<string, unknown>,
+  objectSchemaExtra: Record<string, unknown> = {},
+): Promise<string[]> => {
+  const ds = makeDataSource(objectSchemaExtra);
+  const schema: any = { type: 'object-grid', objectName: OBJECT, ...schemaExtra };
+  render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} dataSource={ds as never} />
+    </ActionProvider>,
+  );
+  await vi.waitFor(() => expect(ds.find).toHaveBeenCalled());
+  return (ds.find.mock.calls.at(-1)?.[1]?.$select ?? []) as string[];
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isLoaded = true;
+  state.readable = [];
+});
+afterEach(() => cleanup());
+
+describe('ObjectGrid — `$select` is FLS-gated (objectui#6898)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server for a declared column the principal cannot read', async () => {
+    state.readable = ['name', 'stage', 'id'];
+    const select = await selectFor({ columns: ['name', 'salary'] });
+    expect(
+      select,
+      'the denied declared field is still being REQUESTED — objectui#6799 hid the column, '
+        + 'this is the fetch half and the value would still arrive from a non-enforcing backend',
+    ).not.toContain('salary');
+  });
+
+  it('still asks for the readable columns — the gate narrows, it never empties', async () => {
+    state.readable = ['name', 'stage', 'id'];
+    const select = await selectFor({ columns: ['name', 'salary'] });
+    expect(select).toContain('name');
+  });
+
+  // ── PIN 2: the `fields` arm, not just `columns` ─────────────────────────
+  it('gates the `fields` arm too, not only the `columns` arm', async () => {
+    state.readable = ['name', 'id'];
+    const select = await selectFor({ fields: ['name', 'salary'] });
+    expect(select).not.toContain('salary');
+    expect(select).toContain('name');
+  });
+
+  // ── PIN 3: navigation survives (the card's decision point 2) ────────────
+  it('keeps `id` even when the policy denies it — row navigation must not break', async () => {
+    // `id` deliberately absent from `readable`: the pathological case.
+    state.readable = ['name'];
+    const select = await selectFor({ columns: ['id', 'name'] });
+    expect(
+      select,
+      'without `id` the record key is undefined and row click / the primary-field '
+        + 'link silently no-op — a naive filter breaks navigation rather than closing a hole',
+    ).toContain('id');
+  });
+
+  // ── PIN 4: THE LIMIT — undeclared keys are not this gate's business ─────
+  it('leaves an UNDECLARED (derived / host-joined) key in the projection', async () => {
+    state.readable = ['name', 'id'];
+    const select = await selectFor({ columns: ['name', 'computed_score'] });
+    expect(
+      select,
+      '`checkField` answers false for a field no policy mentions, so judging an undeclared '
+        + 'key is a different, wrong rule — it would strip a host derived column from its own query',
+    ).toContain('computed_score');
+  });
+
+  // ── PIN 5: the judged key is read through `columnIdentity` ──────────────
+  it('judges the legacy `{ name }` spelling — a bare-string read would wave it through', async () => {
+    state.readable = ['name', 'id'];
+    const select = await selectFor({ columns: [{ name: 'salary' }, { field: 'name' }] });
+    expect(select).not.toContain('salary');
+    expect(select).toContain('name');
+  });
+
+  // ── PIN 6/7: the predicate harvest is gated, readable operands survive ──
+  it('drops a denied predicate operand from the projection', async () => {
+    state.readable = ['name', 'id'];
+    const select = await selectFor({
+      columns: ['name'],
+      rowActionDefs: [{
+        name: 'raise', label: 'Raise', type: 'api', locations: ['list_item'],
+        target: '/x', visible: 'record.salary > 0',
+      }],
+    });
+    expect(
+      select,
+      'against ObjectStack the server already DELETES this key from every row, so the '
+        + 'operand never arrived and CEL already failed closed — dropping it changes what '
+        + 'we ASK for, not what we got',
+    ).not.toContain('salary');
+  });
+
+  it('keeps a READABLE predicate operand — objectui#3501 must not regress', async () => {
+    state.readable = ['name', 'stage', 'id'];
+    const select = await selectFor({
+      columns: ['name'],
+      rowActionDefs: [{
+        name: 'advance', label: 'Advance', type: 'api', locations: ['list_item'],
+        target: '/x', visible: 'record.stage == "open"',
+      }],
+    });
+    expect(
+      select,
+      'the operand of a predicate this principal CAN read must still be projected, or CEL '
+        + 'faults `No such key`, fails closed, and the row action vanishes for everyone',
+    ).toContain('stage');
+  });
+
+  // ── PIN 8: deferral — an unanswered policy filters nothing ──────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const select = await selectFor({ columns: ['name', 'salary'] });
+    expect(
+      select,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a grid with no PermissionProvider must keep working',
+    ).toEqual(expect.arrayContaining(['name', 'salary']));
+  });
+
+  // ── PIN 9: the gate is not DEAD — it must survive the async answer ──────
+  //
+  // `/me/permissions` resolves asynchronously, so on the first render
+  // `isLoaded` is false and the gate defers. If the fetch effect does not
+  // depend on `perms.isLoaded`, nothing ever rebuilds the projection and the
+  // gate never runs on the only fetch most grids make. This is the pin that
+  // fails if that dependency is dropped, and no other case here would notice.
+  it('re-projects once the policy answers — the gate is not dead on the first fetch', async () => {
+    state.isLoaded = false;
+    state.readable = ['name', 'id'];
+    const ds = makeDataSource();
+    const schema: any = { type: 'object-grid', objectName: OBJECT, columns: ['name', 'salary'] };
+    const { rerender } = render(
+      <ActionProvider>
+        <ObjectGrid schema={schema} dataSource={ds as never} />
+      </ActionProvider>,
+    );
+    await vi.waitFor(() => expect(ds.find).toHaveBeenCalled());
+    expect(
+      (ds.find.mock.calls.at(-1)?.[1]?.$select ?? []) as string[],
+      'baseline: while unanswered the denied field is still requested',
+    ).toContain('salary');
+
+    // The policy answers.
+    state.isLoaded = true;
+    rerender(
+      <ActionProvider>
+        <ObjectGrid schema={schema} dataSource={ds as never} />
+      </ActionProvider>,
+    );
+    await vi.waitFor(() => {
+      const latest = (ds.find.mock.calls.at(-1)?.[1]?.$select ?? []) as string[];
+      expect(
+        latest,
+        'the projection was never rebuilt after the policy answered — `perms.isLoaded` is '
+          + 'missing from the fetch effect deps and this gate is dead in practice',
+      ).not.toContain('salary');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6898

Field-level security on ObjectGrid's server `$select` projection — the FETCH half of the gap #6799 closed on the RENDER half.

## The escalation gate, answered first (this is what the grade rests on)

Triage made one measurement the first mandatory step: **does ObjectStack's own REST enforce FLS on the `$select` projection?** Answered by reading the enforcement path in the `objectstack` sibling checkout, not by assuming the server catches it.

**Answer: ENFORCED — but on the RECORD, not on the projection. Branch 1 of the ruling. p2 stands; this PR is defence-in-depth.**

Four independent readings, listed weakest to strongest:

1. `plugins/plugin-security/src/security-plugin.ts` step 4 (post-`next()`) runs `FieldMasker.maskResults` on every `find` / `findOne` / `insert` / `update` result.
2. `field-masker.ts`'s `maskRecord` does `delete result[field]` for each non-readable field — the key is **deleted**, not nulled.
3. `predicate-guard.ts` says so in terms, and explains why the projection is deliberately left unguarded:
   > `fields` (projection) is intentionally NOT collected — selecting a hidden field is harmless because FieldMasker strips it from the result; only predicates leak.
4. **An executed end-to-end HTTP pin**, `qa/dogfood/test/showcase-fls-read-mask-strip.dogfood.test.ts`:
   > `it('an explicit \`select\` of the denied field returns the record WITHOUT it (no error, no value)')`

   `GET /data/showcase_project/{id}?select=name,{denied}` answers **200** with the denied key **absent**, and the same projection serves an admin the real value.

That is precisely the ruling's first branch — *"a server that enforces FLS refuses or omits it — no exposure"*. ObjectStack **omits**. So nothing here is load-bearing for ObjectStack, and the code comment at the gate says so, to stop a future reader concluding otherwise. It becomes load-bearing for any backend that does not strip — the same argument the #6723 / #6799 rulings accepted for the render half.

## Mandatory question 2 — what else is concatenated into `$select`, as an enumeration

`getSelectFields()` (re-derived at **L1460**, not the card's day-old L1402) composes from **six** sources, not the two the card named:

| # | Source | Notes |
|---|---|---|
| 1 | `schemaFields` (the `fields` prop) | authored projection, arm A |
| 2 | `schemaColumns` (the `columns` prop) via `columnIdentity` | authored projection, arm B |
| 3 | `id`, force-added by `ensureId` | row navigation / record key |
| 4 | `conditionalFormatting` — `condition`, `expression`, and the native `{ field }` shape | predicate harvest |
| 5 | `rowActionDefs` / `bulkActionDefs` / object `actions` — `visible`, `disabled`, **and `recordIdField`** | predicate harvest |
| 6 | OBJECT-level `userActions` — `visibleWhen` / `disabledWhen` | predicate harvest (never the view-level block) |

Source 5's `recordIdField` (objectstack#8018) is the one the card did not name. All of 4–6 pass `isProjectableField`, which also admits the undeclared **platform columns** (`created_at`, `owner_id`, `organization_id`, …).

### The inference-leak trap — measured, and it is NOT a new card

The ruling flagged that a field the principal cannot read used as a **filter** may be an inference leak even when the value never returns. Measured: **already closed server-side, before this card existed.** `plugin-security`'s `assertReadableQueryFields` (anti filter-oracle, #2251) rejects with **403 PERMISSION_DENIED**, naming the offending field, when the caller's own `where` / `orderBy` / `groupBy` / `having` / `aggregations` reference an unreadable field — and it deliberately runs against the caller's verbatim AST, *before* RLS injection, so injected policy filters referencing `owner_id` are not caught by it. Pinned live in the same dogfood file: filtering **and** sorting on the denied field each answer 403, while the entitled caller still can. **No card filed** — the suspected gap does not exist.

## The change

`perms.checkField(object, field, 'read')` now gates the projection, on both authored arms and on the predicate harvest.

Two limits are deliberate, and both are pinned:

- **Only keys the object DECLARES are judged.** The card is right that this does not transfer automatically from the render path — on the render path an undeclared key is a derived column, in a `$select` it is what the host asked the *server* for, so it had to be re-derived. It lands in the same place for a reason about `checkField` rather than about drawing: `checkField` answers `false` for a field no policy mentions, so judging an undeclared key is not a stricter reading of this rule, it is a different and wrong one — it would strip a host's derived or joined column out of its own query.
- **`id` survives even a policy that denies it**, *structurally*: every arm composes `ensureId(...)` **after** the gate. Keeping the restoration in the composition rather than in a branch means it cannot drift out of one arm. This is the card's decision point 2 — a naive filter breaks navigation rather than closing a hole.

Denied **predicate operands** are dropped too, and this costs nothing that was working: against ObjectStack the server already deletes that key from every row, so the operand never arrived and the CEL predicate was already faulting `No such key` and failing closed. Dropping it changes what we *ask for*, not what we got. Against a non-enforcing backend it turns "the button works, and the denied value sits in memory" into "the button hides" — the correct direction for a predicate gated on a field this principal may not read. Readable operands are untouched, so #3501 does not regress (pinned).

### One non-obvious dependency, and why it is load-bearing

The fetch effect now also depends on **`perms.isLoaded`**. `/me/permissions` resolves asynchronously, so on the first render `isLoaded` is `false` and the gate correctly defers. Without this dependency nothing would ever rebuild the projection after the policy answered, and **the gate would be dead on the only fetch most grids make**. Ablation B below is the isolated proof. The boolean rather than `perms` itself: it flips false→true exactly once, so this costs at most one refetch, where the context object's identity would refetch on every render. `PermissionProvider` reports `true` synchronously and the no-provider default stays `false` forever, so neither pays anything.

### Known limit, stated rather than papered over

Under `MePermissionsProvider` the **first** request still goes out ungated, in the window before `/me/permissions` answers; the projection is corrected on the refetch. Closing that window entirely would mean blocking the grid's fetch on permissions, which would hang every host with no `PermissionProvider` (`isLoaded` is `false` there forever). Given the measured server behaviour the residual against ObjectStack is nil.

## Verification

All runs at final commit `91c67d2`, through the shared verification lock. Exit codes captured **before** any pipe.

| Run | Result |
|---|---|
| `vitest run packages/plugin-grid/` | **101 files / 930 tests passed**, exit 0 |
| `pnpm --filter @object-ui/plugin-grid run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0 |
| `eslint --no-inline-config` on both changed files | exit 0, **0 errors** |

The suite was first run from the package directory and the repo's own invocation guard **refused it** (#3378 — a package-cwd run silently executes the console package's 22 files and reports green). Re-run from the repo root as the guard prescribes; the numbers above are from the correct invocation.

**Lint narrowing, declared.** Repo-wide `pnpm lint` is CI's run. The narrowing to 2 files is a measurement, not a skip: the population comes from eslint's own config rather than my guess, the count (`2`) is read from `--format json`, and **type-aware linting is not enabled** in `eslint.config.js` (no `parserOptions.project` / `projectService`) — so this diff cannot move the verdict on any file it does not touch. Warning counts are byte-identical to `origin/main` rule-for-rule (213 → 213, `react-hooks/exhaustive-deps` unchanged at 10, so the new dependency satisfies the rule rather than suppressing it).

### Ablation — the gate can actually see the change

Both legs committed first, so the restore leg had a real reference. Each mutation was **proven on disk by blob hash** before the suite ran (an editor's exit code is not evidence — a zero-hit replace exits 0), and each restore proven by `git diff HEAD` empty **and** blob equality against `HEAD`.

**Ablation A — strip the gate from both authored arms.** HEAD blob `1de48053`, mutated blob `2c565d99`.
→ **4 of 10 red**: PIN 1 (denied column still requested), PIN 2 (`fields` arm), PIN 5 (legacy `{ name }` spelling), PIN 9.

**Ablation B — remove only the `perms.isLoaded` dependency.** HEAD blob `1de48053`, mutated blob `bdac2a69`.
→ **exactly 1 of 10 red**: PIN 9, "the gate is not dead on the first fetch". The other nine stayed green — which is the point: with a dead gate, nine pins would have reported success.

Restore verified after both: `git hash-object` = `1de48053` = `HEAD`, working tree clean.

## Scope

`packages/plugin-grid/src/` only — `ObjectGrid.tsx` plus its new test, and the changeset. `generateColumns()` is untouched: the maintainer's 2026-08-30 ruling deliberately scoped #6799 to that one function.

The **export** path was checked and needs nothing: it derives its `fields` from `generateColumns()`, so it already inherits the #6799 render-half gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_