### PR TITLE
docs(skills): correct 25 false facts in the published objectui skill package

### DIFF
--- a/skills/objectui/README.md
+++ b/skills/objectui/README.md
@@ -25,6 +25,8 @@ skills/objectui/
 │   ├── composition.md
 │   └── no-touch-zones.md
 ├── guides/       # Domain-specific deep dives
+│   ├── architecture.md
+│   ├── app-composition.md
 │   ├── page-builder.md
 │   ├── plugin-development.md
 │   ├── schema-expressions.md
@@ -78,8 +80,8 @@ The skill stays in sync with the `packages/` tree:
 
 - **Core renderer:** `@object-ui/types`, `core`, `components`, `fields`, `layout`, `react`
 - **Integration:** `@object-ui/app-shell`, `providers`, `runner`, `data-objectstack`
-- **Platform features:** `@object-ui/auth`, `permissions`, `tenant`, `i18n`, `mobile`, `collaboration`
-- **Plugins (19):** `plugin-{grid, list, detail, form, kanban, calendar, timeline, gantt, dashboard, report, charts, map, editor, markdown, view, designer, workflow, ai, chatbot}`
+- **Platform features:** `@object-ui/auth`, `permissions`, `i18n`, `mobile`, `collaboration`
+- **Plugins (19):** `plugin-{grid, list, detail, form, kanban, calendar, timeline, gantt, dashboard, report, charts, map, editor, markdown, view, tree, designer, ai, chatbot}`
 - **Tooling:** `@object-ui/cli`, `create-plugin`, `vscode-extension`
 
 ## Maintenance

--- a/skills/objectui/SKILL.md
+++ b/skills/objectui/SKILL.md
@@ -78,7 +78,7 @@ Actions are defined **as data**, not functions. Example:
 
 ### 6. Layout as Components
 
-Layouts are just components that render children. Treat `Grid`, `Stack`, `Container` as first-class citizens. Layout schemas declare responsive columns on the node as `columns` — a number, or a breakpoint object keyed `xs` / `sm` / `md` / `lg` / `xl`, with `xs` as the base (e.g. `columns: { xs: 1, md: 2, lg: 4 }`).
+Layouts are just components that render children. Treat `Grid`, `Stack`, `Container` as first-class citizens. Layout schemas declare responsive columns on the node as `columns` — a number, or a breakpoint object keyed `xs` / `sm` / `md` / `lg` / `xl`, with `xs` as the base (e.g. `columns: { xs: 1, md: 2, lg: 4 }`). The spec also accepts `2xl`, which the `grid` renderer never reads ([`rules/protocol.md`](./rules/protocol.md)).
 
 ### 7. Type Safety over Magic
 

--- a/skills/objectui/guides/app-composition.md
+++ b/skills/objectui/guides/app-composition.md
@@ -29,8 +29,10 @@ skip your app. Powerful constructs are escape hatches, not defaults.
 
 ## What Each Navigation Target Buys You
 
-The nav contract is a discriminated union on `type` (see `NavigationItemSchema`
-in `@object-ui/types`; aligned with `@objectstack/spec`). Runtime resolution is
+The nav contract is a discriminated union on `type` — nine members:
+`object`, `dashboard`, `page`, `report`, `url`, `component`, `group`,
+`separator`, `action` (see `NavigationItemSchema` in `@object-ui/types`;
+aligned with `@objectstack/spec`). Runtime resolution is
 `resolveHref` in `packages/layout/src/NavigationRenderer.tsx` — the single
 source of truth for nav → URL mapping.
 
@@ -44,7 +46,10 @@ source of truth for nav → URL mapping.
 | `{type:'report', reportName}` | `/report/:name` | Report renderer |
 | `{type:'page', pageName}` | `/page/:name` | **Bare SDUI rendering only.** No object shell — view switching, actions, and record routing must be hand-assembled in the page schema |
 | `{type:'url', url}` | external | External link (`target` controls tab) |
+| `{type:'component', componentRef, params?}` | `/component/:ns/:name?…` | A registered bespoke surface. `componentRef` is colon-joined (`metadata:resource`); `params` ride as querystring. `metadata:*` refs are special-cased onto the `/metadata[/:type[/:name]]` routes |
 | `{type:'group', children}` | — | Grouping only; no target |
+| `{type:'separator'}` | — | A rule in the sidebar; skipped by `resolveHref` and never pinnable |
+| `{type:'action'}` | — | Fires a host handler instead of navigating; **dropped entirely** when the host passes no action handler |
 
 ## Decision Rules (in priority order)
 

--- a/skills/objectui/guides/architecture.md
+++ b/skills/objectui/guides/architecture.md
@@ -30,7 +30,7 @@ ObjectUI is a strict PNPM Workspace. Pick a package by **role + dependency weigh
 
 | Package | Role | Responsibility |
 |---|---|---|
-| `@object-ui/app-shell` | Minimal Shell | Framework-agnostic `AppShell`, `ObjectRenderer`, `DashboardRenderer`, `PageRenderer`. Bring-your-own-router. |
+| `@object-ui/app-shell` | Minimal Shell | Framework-agnostic `AppShell`, `ObjectView`, `DashboardView`, `PageView`. Bring-your-own-router. |
 | `@object-ui/providers` | Context Stack | Reusable `DataSourceProvider`, `MetadataProvider`, `ThemeProvider`. Console-free. |
 | `@object-ui/runner` | Universal Runtime | Standalone runtime + dev server for schema-driven apps. Pre-wires popular plugins. |
 | `@object-ui/data-*` | Data Adapters | Connectors for REST, ObjectQL, GraphQL (e.g. `@object-ui/data-objectstack`). |
@@ -59,14 +59,14 @@ ObjectUI is a strict PNPM Workspace. Pick a package by **role + dependency weigh
 | `@object-ui/plugin-editor` / `plugin-markdown` | Rich text + markdown editors. |
 | `@object-ui/plugin-view` | View switcher / saved views. |
 | `@object-ui/plugin-designer` | Visual schema designer canvas. |
-| `@object-ui/plugin-workflow` | Workflow / process editor. |
+| `@object-ui/plugin-tree` | Hierarchy / tree views (`tree`, `object-tree`). |
 | `@object-ui/plugin-ai` / `plugin-chatbot` | AI assistant + chatbot UI. |
 
 ### Tooling
 
 | Package | Purpose |
 |---|---|
-| `@object-ui/cli` | `objectui` CLI: `init`, `dev`, `build`, `start`, `studio`, `validate`, `check`, `lint`, `test`, `generate`, `add`, `doctor`, `analyze`, `create plugin`. |
+| `@object-ui/cli` | `objectui` CLI: `init`, `serve`, `dev`, `build`, `start`, `studio`, `validate`, `check`, `lint`, `test`, `generate`, `add`, `doctor`, `analyze`, `create plugin`. |
 | `@object-ui/create-plugin` | `pnpm create-plugin <name>` scaffolder for new `plugin-*` packages. |
 | `@object-ui/vscode-extension` | VSCode extension: syntax highlighting, IntelliSense, validation for ObjectUI JSON schemas. |
 
@@ -131,18 +131,15 @@ See `rules/protocol.md` for which fields are expression-evaluated and which are 
 How users add their own components (e.g. a `Map` widget):
 
 ```typescript
-// packages/core/src/registry.ts
-export type ComponentImpl = React.FC<{ schema: any; ... }>;
+// packages/core/src/registry/Registry.ts — one shared instance, not free functions
+export const ComponentRegistry = new Registry<any>();
 
-const registry = new Map<string, ComponentImpl>();
+// register(type, component, meta?) — `meta.namespace` makes the key `namespace:type`
+ComponentRegistry.register('map', MapRenderer, { namespace: 'plugin-map' });
 
-export function registerComponent(type: string, impl: ComponentImpl) {
-  registry.set(type, impl);
-}
-
-export function resolveComponent(type: string) {
-  return registry.get(type) || FallbackComponent;
-}
+// get(type, namespace?) — undefined when nothing is registered; the caller
+// (SchemaRenderer) is what falls back, the registry does not.
+const impl = ComponentRegistry.get('map');
 ```
 
 ### Pattern B: The Renderer Loop (Recursion)

--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -46,18 +46,22 @@ interface DataSource<T = any> {
 
   // View support (optional)
   getView?(objectName: string, viewId: string): Promise<any | null>;
-  saveView?(objectName: string, viewId: string, config: any): Promise<any>;
+  createView?(...); updateView?(...); updateViewConfig?(...); deleteView?(...);
 
   // Analytics (optional)
   aggregate?(resource: string, params: AggregateParams): Promise<AggregateResult>;
-
-  // Custom actions (optional)
-  execute?(resource: string, action: string, params?: any): Promise<any>;
 
   // Real-time (optional)
   onMutation?(callback: (event: MutationEvent) => void): () => void;
 }
 ```
+
+Six members are **required**; the optional half is much larger than the excerpt
+above — **32** optional members at `origin/main`, covering bulk/transaction,
+views, apps & pages, file upload, and the export / import job lifecycles. Read
+`data.ts` before concluding a capability is missing, and note the two spellings
+that do **not** exist: there is no `saveView` (write through `updateViewConfig`
+/ `createView` / `updateView`) and no generic `execute`.
 
 ### QueryParams
 
@@ -69,6 +73,9 @@ interface QueryParams {
   $skip?: number;                 // OFFSET (for pagination)
   $top?: number;                  // LIMIT (page size)
   $expand?: string[];             // JOIN/expand related objects
+  $search?: string;               // free-text search term
+  $searchFields?: string[];       // fields the search term is matched against
+  $count?: boolean;               // ask the backend for `total`
   [key: string]: any;             // why an unprefixed `limit` type-checks — and is then dropped
 }
 ```

--- a/skills/objectui/guides/mobile.md
+++ b/skills/objectui/guides/mobile.md
@@ -22,7 +22,8 @@ function ResponsiveLayout() {
 }
 ```
 
-Breakpoint values follow Tailwind defaults:
+Breakpoint values (`BREAKPOINTS`, Tailwind-compatible):
+- `xs`: 0px  (the base — `useBreakpoint` reports it below `sm`)
 - `sm`: 640px
 - `md`: 768px
 - `lg`: 1024px
@@ -31,50 +32,54 @@ Breakpoint values follow Tailwind defaults:
 
 ## Touch gesture handling
 
+One hook, `useGesture`, per gesture. It takes a `type` plus one `onGesture`
+callback and returns a **ref** to attach — it does not return a spread-able
+handler bag.
+
 ```typescript
-import { useSwipe, useLongPress, usePinchZoom } from '@object-ui/mobile';
+import { useGesture, usePullToRefresh } from '@object-ui/mobile';
 
 function MobileCard() {
-  const swipeHandlers = useSwipe({
-    onSwipeLeft: () => showActions(),
-    onSwipeRight: () => dismiss(),
+  const swipeRef = useGesture<HTMLDivElement>({
+    type: 'swipe-left',            // threshold?: px (swipes)
+    onGesture: () => showActions(),
     threshold: 50,
   });
 
-  const longPressHandlers = useLongPress({
-    onLongPress: () => openContextMenu(),
-    delay: 500,
+  const listRef = usePullToRefresh<HTMLDivElement>({
+    onRefresh: async () => refetch(),   // threshold?: px, default 80
   });
 
-  return (
-    <div {...swipeHandlers} {...longPressHandlers}>
-      <CardContent />
-    </div>
-  );
+  return <div ref={swipeRef}><div ref={listRef}><CardContent /></div></div>;
 }
 ```
 
-## Bottom sheet and mobile navigation
+`type` is a `GestureType`: `tap`, `double-tap`, `long-press` (tune with
+`longPressDuration`, ms), `swipe-left` / `-right` / `-up` / `-down`, `pinch`,
+`rotate`, `pan`. `useSpecGesture` is the schema-driven twin, for gestures
+declared in metadata rather than in TSX.
+
+## Breakpoint-gated rendering and mobile navigation
+
+`@object-ui/mobile` ships **no** widgets — there is no `BottomSheet` and no
+`MobileNav` in it. What it ships is the gate: `ResponsiveContainer` renders its
+children only on the breakpoints you name.
 
 ```typescript
-import { BottomSheet, MobileNav } from '@object-ui/mobile';
+import { ResponsiveContainer, MobileProvider } from '@object-ui/mobile';
+import { Drawer, Sheet } from '@object-ui/components';   // the actual overlays
 
-function MobileApp() {
-  return (
-    <>
-      <MobileNav items={navItems} />
-      <MainContent />
-      <BottomSheet
-        open={showFilters}
-        onClose={() => setShowFilters(false)}
-        snapPoints={[0.5, 0.9]}
-      >
-        <FilterPanel />
-      </BottomSheet>
-    </>
-  );
-}
+<MobileProvider>
+  <ResponsiveContainer maxBreakpoint="sm" fallback={<DesktopFilters />}>
+    <Drawer>{/* the bottom sheet */}</Drawer>
+  </ResponsiveContainer>
+</MobileProvider>
 ```
+
+Props: `minBreakpoint` / `maxBreakpoint` / `showOn` / `hideOn` / `fallback`.
+Mobile navigation is an **app-shell** concern, not a package export: set
+`mobileNavMode` (`'drawer'` | `'bottom_nav'`) on the app schema that
+`AppSchemaRenderer` (`@object-ui/layout`) renders.
 
 ## Responsive schema layouts
 
@@ -96,7 +101,9 @@ Use responsive column configurations in grid layouts:
 
 `columns` takes a number or a breakpoint object (`xs` / `sm` / `md` / `lg` /
 `xl`), with `xs` as the base — the schema above renders
-`grid-cols-1 md:grid-cols-2 lg:grid-cols-4`. Keys belong on the node, not in a
+`grid-cols-1 md:grid-cols-2 lg:grid-cols-4`. The spec's map also declares
+`2xl`, but the `grid` renderer reads only those five: a `2xl` entry parses and
+is then silently dropped, so stop at `xl`. Keys belong on the node, not in a
 `props` wrapper: `"props": { "cols": … }` leaves both the columns *and* the card
 titles unread (objectui#4001).
 
@@ -111,12 +118,10 @@ titles unread (objectui#4001).
 
 ## Mobile-optimized form inputs
 
-```typescript
-import { MobileSelect, MobileDatePicker } from '@object-ui/mobile';
-
-// MobileSelect uses native <select> on mobile for better UX
-// MobileDatePicker uses native date input on mobile
-```
+There is no separate mobile widget set — no `MobileSelect`, no
+`MobileDatePicker`. Field widgets come from `@object-ui/fields` and adapt
+themselves; `useTouchTarget` is the hook for enforcing a minimum tap size on a
+custom control.
 
 ## Offline support
 
@@ -124,14 +129,14 @@ import { MobileSelect, MobileDatePicker } from '@object-ui/mobile';
 import { useOffline } from '@object-ui/react';
 
 function DataForm() {
-  const { isOnline, queue, syncState } = useOffline();
+  const { isOnline, pendingCount, syncState } = useOffline();
 
   // When offline, mutations are queued
   // When back online, queued mutations are synced automatically
 
   return (
     <div>
-      {!isOnline && <Banner>You are offline. Changes will sync when connected.</Banner>}
+      {!isOnline && <Banner>You are offline. {pendingCount} change(s) queued.</Banner>}
       {syncState === 'syncing' && <Spinner />}
       <FormContent />
     </div>
@@ -139,7 +144,10 @@ function DataForm() {
 }
 ```
 
-Sync states: `idle` → `syncing` → `synced` | `error`
+`SyncState` is `'idle' | 'syncing' | 'error' | 'offline'` — there is no
+`'synced'`; a drained queue returns to `'idle'`. The rest of `OfflineResult`:
+`enabled`, `strategy`, `pendingCount`, `queueMutation`, `sync`, `clearQueue`,
+`showIndicator`, `offlineMessage` — and no `queue` array is exposed.
 
 ## Viewport considerations
 

--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -476,7 +476,7 @@ Pick plugins by domain — each registers its own `type` strings in the Componen
 | Boards / Dashboards | `plugin-kanban`, `plugin-dashboard`, `plugin-report` |
 | Visualization | `plugin-charts`, `plugin-map` |
 | Editors | `plugin-editor`, `plugin-markdown` |
-| Views & Design | `plugin-view`, `plugin-designer`, `plugin-workflow` |
+| Views & Design | `plugin-view`, `plugin-tree`, `plugin-designer` |
 | AI | `plugin-ai`, `plugin-chatbot` |
 
 For lazy loading, use `LazyPluginLoader` from `@object-ui/react` rather than top-level imports.
@@ -486,10 +486,18 @@ For lazy loading, use `LazyPluginLoader` from `@object-ui/react` rather than top
 For host apps that need more than the raw renderer, prefer `@object-ui/app-shell`:
 
 ```tsx
-import { AppShell, ObjectRenderer, PageRenderer, DashboardRenderer } from '@object-ui/app-shell';
+import { AppShell, ObjectView, PageView, DashboardView } from '@object-ui/app-shell';
 ```
 
-It exposes `ObjectRenderer`, `PageRenderer`, `DashboardRenderer` and matching providers (`AdapterProvider`, `MetadataProvider`, `ExpressionProvider`). See `guides/project-setup.md` for the decision matrix.
+It exposes `ObjectView`, `RecordDetailView`, `PageView`, `DashboardView`,
+`ReportView` and matching providers (`AdapterProvider`, `MetadataProvider`,
+`ExpressionProvider`). ⚠️ Not `ObjectRenderer` / `PageRenderer` /
+`DashboardRenderer`. `ObjectRenderer` exists nowhere in the repo;
+`DashboardRenderer` is a public export of `@object-ui/plugin-dashboard`; and
+`PageRenderer` is an internal renderer inside `@object-ui/components`,
+reachable only through the `page` / `app` / `utility` / `home` / `record`
+registry keys it registers, never as an import. See
+`guides/project-setup.md` for the decision matrix.
 
 ## Common mistakes to avoid
 

--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -80,20 +80,38 @@ ComponentRegistry.register('my-widget', MyWidgetRenderer, {
 | `isContainer` | `boolean` | Accepts child components |
 | `resizable` | `boolean` | Designer allows resizing |
 | `resizeConstraints` | `object` | Min/max width/height |
+| `tier` | `'public' \| 'internal'` | Public contract tier (ADR-0080). Undefined = internal |
+| `labelling` | `'control' \| 'group' \| 'display'` | How a host associates its label; absent ⇒ `'control'` |
+| `deprecated` | `object` | Authoring-time deprecation (`surfaces`, `replacement`) |
+| `examples` | `array` | Sample schemas for the designer |
+| `tags` | `string[]` | Free-form grouping tags |
+| `description` | `string` | Longer description for the designer |
+
+Sixteen keys in total: the eleven on `ComponentMeta` (`@object-ui/types`
+`base.ts`) plus the five `RegistryComponentMetaExtras` the registry adds
+(`tier`, `namespace`, `skipFallback`, `labelling`, `deprecated`).
 
 ### ComponentInput types
 
 ```typescript
+type ComponentInputControlType =
+  | 'string' | 'number' | 'boolean' | 'enum' | 'array' | 'object'
+  | 'color' | 'date' | 'code' | 'file' | 'slot';
+
 type ComponentInput = {
   name: string;          // Maps to component prop
-  type: 'string' | 'number' | 'boolean' | 'enum' | 'array' | 'object'
-       | 'color' | 'date' | 'code' | 'file' | 'slot';
+  // ONE control type, or an ARRAY of them when the input accepts several
+  // shapes (objectui#3832). Widening the vocabulary is a contract change.
+  type: ComponentInputControlType | ComponentInputControlType[];
   label?: string;
   defaultValue?: any;
   required?: boolean;
   enum?: string[] | Array<{ label: string; value: string }>;
   description?: string;
   advanced?: boolean;    // Hide by default in designer
+  inputType?: string;    // Widget hint for the designer control
+  min?: number; max?: number; step?: number;   // numeric bounds
+  placeholder?: string;
 };
 ```
 
@@ -264,10 +282,12 @@ type FieldWidgetComponentProps<T = any> = {
 The slot is named `error` because that is what `FieldWidgetPropsSchema` in
 `@objectstack/spec/ui` — the published widget contract — calls it.
 
-The type is **closed**: it also declares the host plumbing and DOM/ARIA
-pass-through keys the renderer forwards (`dataSource`, `dependentValues`,
-`dependsOn`, `emptyHint`, `compact`, `id`, `name`, `aria-*`, `data-*`), and
-nothing else. A key it does not declare is a compile error rather than a silent
+The type is **closed**: it also declares the host plumbing
+(`dataSource`, `dependentValues`, `dependsOn`, `dependsOnLabels`, `emptyHint`,
+`compact`, `onUploadingChange`, `onSelectRecord`, `onCreateNew`) and, by
+intersection, the DOM/ARIA pass-through the renderer forwards
+(`FieldWidgetDomProps` → `id` / `name`, `AriaAttributes`, and a
+`data-${string}` index signature), and nothing else. A key it does not declare is a compile error rather than a silent
 `any`, so a typo like `readOnly` for `readonly` is caught at build time instead
 of being quietly `undefined` at runtime.
 

--- a/skills/objectui/guides/project-setup.md
+++ b/skills/objectui/guides/project-setup.md
@@ -73,8 +73,8 @@ Add plugins as needed (full plugin catalog):
   "@object-ui/plugin-editor": "latest",
   "@object-ui/plugin-markdown": "latest",
   "@object-ui/plugin-view": "latest",
+  "@object-ui/plugin-tree": "latest",
   "@object-ui/plugin-designer": "latest",
-  "@object-ui/plugin-workflow": "latest",
   "@object-ui/plugin-ai": "latest",
   "@object-ui/plugin-chatbot": "latest"
 }
@@ -312,7 +312,7 @@ by absolute path — still resolves. The run then executes console's 22 files, r
 `Test Files 22 passed (22)`, and never touches the package you asked for. A guard rejects
 those invocations with a non-zero exit and prints the correct form. It is wired into
 `vitest.config.mts` and into each standalone per-package config
-(`packages/plugin-grid/vitest.config.ts` and its ten siblings), since Vitest loads
+(`packages/plugin-grid/vitest.config.ts` and its sixteen siblings), since Vitest loads
 whichever config sits in the directory it was launched from (objectui#5406):
 
 ```
@@ -379,17 +379,22 @@ import { DataSourceProvider, MetadataProvider, ThemeProvider } from '@object-ui/
 Use when integrating ObjectUI into a host system (CRM, ERP, custom admin) and you want:
 
 - `AppShell` (sidebar + main split layout)
-- `ObjectRenderer`, `DashboardRenderer`, `PageRenderer`
+- `ObjectView`, `RecordDetailView`, `DashboardView`, `PageView`, `ReportView`
 - `AdapterProvider`, `MetadataProvider`, `ExpressionProvider`
 - `useObjectActions`, `useRecentItems`, `useAdapter`, `useMetadataItem`
 
+⚠️ These are `*View`, not `*Renderer`. `ObjectRenderer` exists nowhere in the
+repo; `DashboardRenderer` is `@object-ui/plugin-dashboard`'s; `PageRenderer` is
+internal to `@object-ui/components` and is reached through the registry, not by
+import. Importing any of the three from `app-shell` does not resolve.
+
 ```tsx
-import { AppShell, ObjectRenderer, AdapterProvider, MetadataProvider } from '@object-ui/app-shell';
+import { AppShell, ObjectView, AdapterProvider, MetadataProvider } from '@object-ui/app-shell';
 
 <AdapterProvider adapter={myAdapter}>
   <MetadataProvider value={metadata}>
     <AppShell sidebar={<MySidebar />}>
-      <ObjectRenderer objectName="contact" />
+      <ObjectView objectName="contact" />
     </AppShell>
   </MetadataProvider>
 </AdapterProvider>
@@ -413,7 +418,7 @@ Typical usage is via the `objectui dev` CLI (which wraps the same renderer).
 |------|-----|
 | Bare renderer in existing app | `@object-ui/react` |
 | Need shared providers (data/metadata/theme) | + `@object-ui/providers` |
-| Need shell + object/dashboard/page/form renderers | + `@object-ui/app-shell` |
+| Need shell + object/dashboard/page/record views | + `@object-ui/app-shell` |
 | Need full admin console (sidebar, system hub, navigation) | study `apps/console` patterns |
 | Need a CLI-driven dev server | `@object-ui/cli` (`objectui dev`) |
 | Need a standalone runtime bundle | `@object-ui/runner` |

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -22,7 +22,8 @@ Key files (for reference, not for editing):
 - `packages/core/src/evaluator/ExpressionContext.ts` — scope stacking
 - `packages/core/src/evaluator/FormulaFunctions.ts` — built-in functions
 - `packages/core/src/evaluator/ExpressionCache.ts` — LFU caching
-- `packages/react/src/SchemaRenderer.tsx` — integration layer (lines 117-175)
+- `packages/react/src/SchemaRenderer.tsx` — integration layer (the
+  `evaluatedSchema` memo; grep that name rather than a line number)
 
 ## What gets expression-evaluated
 
@@ -123,7 +124,10 @@ ${!isLocked}                    → boolean negation
 - Ternary: `condition ? trueVal : falseVal`
 - Nullish coalescing: `??`
 - Optional chaining: `?.`
+- Unary: `!`, unary `-` / `+`, `typeof`
 - Method calls: `.toUpperCase()`, `.includes()`, `.filter()`, `.map()`, `.length`
+- Primaries: literals, identifiers, `( … )`, array literals `[1, 2]`, and a
+  single-param arrow (`items.filter(i => i.active)`)
 
 ### Type preservation
 
@@ -171,11 +175,13 @@ ${AVG(scores)}                  → average
 ${COUNT(users)}                 → count
 ${MIN(values)}                  → minimum
 ${MAX(values)}                  → maximum
+${MEDIAN(values)}  ${PERCENTILE(90, values)}  ${STDEV(values)}  ${VARIANCE(values)}
 ```
 
 ### Logic
 ```
 ${IF(score > 90, "A", IF(score > 80, "B", "C"))}
+${SWITCH(tier, 1, "gold", 2, "silver", "other")}
 ${AND(isActive, hasPermission)}
 ${OR(isAdmin, isOwner)}
 ${NOT(isLocked)}
@@ -186,15 +192,25 @@ ${NOT(isLocked)}
 ${UPPER(name)}                  → "ALICE"
 ${LOWER(email)}                 → "alice@example.com"
 ${CONCAT(firstName, " ", lastName)}  → "Alice Smith"
+${TRIM(s)}  ${LEN(s)}  ${LEFT(s, 3)}  ${RIGHT(s, 3)}  ${SUBSTRING(s, 0, 3)}
+${FIND("@", s)}  ${REPLACE(s, "a", "b")}  ${REGEX(s, "^[0-9]+$")}
 ```
+
+`PERCENTILE` takes 0–100, not 0–1; `FIND(search, text)` puts the needle first
+and returns a **0-based** index (`-1` when absent).
 
 ### Date
 ```
 ${TODAY()}                      → current date
 ${NOW()}                        → current datetime
 ${DATEADD(startDate, 7, 'days')}
+${DATEDIFF(startDate, endDate, 'days')}
 ${DATEFORMAT(createdAt, 'YYYY-MM-DD')}
 ```
+
+That is the whole registry — **30 functions**, all of them registered by
+`FormulaFunctions.registerDefaults()`. `register(name, fn)` upper-cases the
+name, so calls are case-insensitive.
 
 ## Condition fields (visibility and disabled)
 
@@ -543,7 +559,10 @@ The expression parser blocks dangerous patterns to prevent injection:
 
 **Blocked:** `eval()`, `Function()`, `setTimeout()`, `setInterval()`, `import()`, `require()`, `process.*`, `global.*`, `window.*`, `document.*`, `__proto__`, `constructor`, `prototype`
 
-If a blocked pattern is detected, the expression throws an error at compile time.
+That list is `isDangerous`'s regex table, matched against the expression source
+before compilation. Property access has a second gate the list omits: the
+parser's `BLOCKED_PROPS` also rejects `__defineGetter__`, `__defineSetter__`,
+`__lookupGetter__` and `__lookupSetter__`.
 
 **Safe by design:** The recursive-descent parser never converts expression strings into executable JavaScript code. It tokenizes and evaluates each node directly.
 
@@ -586,16 +605,23 @@ Expressions are compiled once per unique `(expression, variableNames)` pair and 
 { "hidden": "${data.count > 0}" }
 ```
 
-### Cannot use constructor or `new Date()`
+### `new X()` — only `Date` and `RegExp`
 
-**Cause:** Security restriction blocks constructors.
+`parseNewExpression` permits exactly two constructors and throws
+`new X() is not supported in expressions` for every other name. `new Date(…)`
+is **not** blocked — measured through the schema path, it returns a real
+`Date`. Prefer a formula function anyway: a `Date` object stringifies into
+the DOM as a locale-dependent blob.
 
 ```json
-// ❌ Blocked
+// ✅ Works, but renders "Thu Jan 01 1970 …"
 { "type": "text", "content": "${new Date(data.timestamp)}" }
 
-// ✅ Use formula functions
+// ✅ Preferred — formatted, and stable across locales
 { "type": "text", "content": "${DATEFORMAT(data.timestamp, 'YYYY-MM-DD')}" }
+
+// ❌ Rejected — any constructor other than Date / RegExp
+{ "type": "text", "content": "${new Function('return 1')()}" }
 ```
 
 ### Object literal in expression

--- a/skills/objectui/guides/testing.md
+++ b/skills/objectui/guides/testing.md
@@ -26,19 +26,30 @@ pnpm test:e2e          # Playwright E2E tests
 
 ### Coverage thresholds
 
-Configured in `vitest.config.mts`:
-- Lines: 62% | Functions: 54% | Branches: 50% | Statements: 61%
+Configured in `vitest.config.mts` (`coverage.thresholds`):
+- Lines: 40% | Functions: 33% | Branches: 30% | Statements: 40%
 
 ## Vitest configuration
 
-Two test suites in `vitest.workspace.ts`:
+There is **no `vitest.workspace.ts`**. The projects are declared inline in
+`vitest.config.mts` under `test.projects`, and there are three of them plus
+`apps/console`'s own config. The split is by **file extension**, not by package
+— a `.test.ts` anywhere lands in `unit`, so a React test must be `.test.tsx`:
 
-1. **Unit tests** (`node` environment): `packages/core`, `packages/types`, `packages/cli`, `packages/data-objectstack`
-2. **UI tests** (`happy-dom` environment): All other packages, apps, examples
+| Project | Environment | Matches | Setup file |
+|---|---|---|---|
+| `unit` | `node` | `packages/**`, `examples/**` `*.test.ts` + `eslint-rules/**/*.test.js` + `scripts/**/*.test.ts` | `vitest.setup.base.ts` |
+| `dom` | `happy-dom` | `packages/**`, `examples/**` `*.test.tsx` | `vitest.setup.dom-light.tsx` |
+| `dom-heavy` | `happy-dom` | the registry-rendering files listed as `heavyDomTests` | `vitest.setup.dom.tsx` |
 
-### Setup file (`vitest.setup.tsx`)
+Run one with `--project unit` / `dom` / `dom-heavy` (`pnpm test:unit` is the
+first). `unit` also sets `isolate: false`; the DOM projects keep isolation.
 
-The setup file registers components globally before tests run:
+### Setup file (`vitest.setup.dom.tsx`)
+
+The `dom-heavy` setup registers components globally before tests run
+(`vitest.setup.tsx` is a legacy shim that re-exports it and is wired into no
+config):
 ```typescript
 import '@object-ui/components';     // Shadcn primitives
 import '@object-ui/fields';         // Field widgets
@@ -114,7 +125,7 @@ describe('schema validation', () => {
   it('rejects schema without type', () => {
     const result = validateSchema({} as any);
     expect(result.valid).toBe(false);
-    expect(formatValidationErrors(result.errors)).toContain('type');
+    expect(formatValidationErrors(result)).toContain('type');
   });
 
   it('validates nested children', () => {
@@ -137,27 +148,31 @@ import { describe, it, expect } from 'vitest';
 import { ExpressionEvaluator } from '@object-ui/core';
 
 describe('ExpressionEvaluator', () => {
-  const evaluator = new ExpressionEvaluator();
-  const context = {
+  // The CONTEXT is a constructor argument. `evaluate(expr, options)` and
+  // `evaluateExpression(expr, options)` take EvaluationOptions as their second
+  // argument — passing the context there is silently ignored, every `${…}`
+  // resolves against an empty scope, and the template part falls back to its
+  // own literal, so the test fails with the source string as `received`.
+  const evaluator = new ExpressionEvaluator({
     data: { name: 'Alice', count: 42, items: [1, 2, 3] },
     user: { role: 'admin' },
-  };
+  });
 
   it('evaluates template expressions', () => {
-    expect(evaluator.evaluate('Hello ${data.name}', context)).toBe('Hello Alice');
+    expect(evaluator.evaluate('Hello ${data.name}')).toBe('Hello Alice');
   });
 
   it('preserves type for single expressions', () => {
-    expect(evaluator.evaluate('${data.count}', context)).toBe(42);
+    expect(evaluator.evaluate('${data.count}')).toBe(42);
   });
 
   it('evaluates boolean conditions', () => {
-    expect(evaluator.evaluateExpression('user.role === "admin"', context)).toBe(true);
+    expect(evaluator.evaluateExpression('user.role === "admin"')).toBe(true);
   });
 
   it('handles missing variables safely', () => {
-    expect(evaluator.evaluate('${data.missing}', context)).toBeUndefined();
-    expect(evaluator.evaluate('${data.missing || "fallback"}', context)).toBe('fallback');
+    expect(evaluator.evaluate('${data.missing}')).toBeUndefined();
+    expect(evaluator.evaluate('${data.missing || "fallback"}')).toBe('fallback');
   });
 });
 ```

--- a/skills/objectui/rules/composition.md
+++ b/skills/objectui/rules/composition.md
@@ -152,21 +152,22 @@ Dialog, Sheet, and Drawer **always need a Title** for accessibility.
 </div>
 ```
 
-**Empty states use Empty:**
+**Empty states use Empty:** it composes like `Card`, it is not a props bag —
+`Empty` and its parts each take only `className` + children.
 ```typescript
 // ✅ Correct
-<Empty
-  icon={<InboxIcon />}
-  title="No results found"
-  description="Try adjusting your search"
-/>
+<Empty>
+  <EmptyMedia><InboxIcon /></EmptyMedia>
+  <EmptyTitle>No results found</EmptyTitle>
+  <EmptyDescription>Try adjusting your search</EmptyDescription>
+</Empty>
 
-// ❌ Wrong
-<div className="text-center p-8">
-  <InboxIcon className="mx-auto" />
-  <h3>No results found</h3>
-</div>
+// ❌ Wrong — `icon` / `title` / `description` are not props; they land on the
+//    underlying <div> as unknown attributes and nothing renders.
+<Empty icon={<InboxIcon />} title="No results found" />
 ```
+Parts: `EmptyHeader`, `EmptyMedia`, `EmptyTitle`, `EmptyDescription`,
+`EmptyContent`, `EmptyValue` (`@object-ui/components`).
 
 **Use Separator instead of hr:**
 ```typescript
@@ -218,7 +219,7 @@ showNotification({ type: 'success', message: 'Saved' });
 **✅ CORRECT:**
 ```typescript
 <Button disabled={isLoading}>
-  {isLoading && <Spinner data-icon="inline-start" />}
+  {isLoading && <Spinner />}
   {isLoading ? 'Saving...' : 'Save'}
 </Button>
 ```
@@ -229,51 +230,30 @@ showNotification({ type: 'success', message: 'Saved' });
 <Button isPending={isLoading}>Save</Button>
 ```
 
-## Rule: Icons in Buttons Use data-icon
+## Rule: Icons in Buttons Are Children — No Sizing, No Spacing, No `icon` Prop
+
+Put the icon where you want it in the children; leading or trailing is child
+order. `buttonVariants`' base string already carries `gap-2` and
+`[&_svg]:size-4 [&_svg]:shrink-0`, so the spacing and the sizing are done.
 
 **✅ CORRECT:**
 ```typescript
-<Button>
-  <SearchIcon data-icon="inline-start" />
-  Search
-</Button>
+import { SearchIcon, ChevronRightIcon } from 'lucide-react';
 
-<Button>
-  Save
-  <ChevronRightIcon data-icon="inline-end" />
-</Button>
+<Button><SearchIcon />Search</Button>
+<Button>Save<ChevronRightIcon /></Button>
 ```
 
 **❌ FORBIDDEN:**
 ```typescript
-// ❌ No data-icon attribute
-<Button>
-  <SearchIcon className="mr-2" />
-  Search
-</Button>
+// ❌ Manual sizing or spacing classes on the icon — the base string does both
+<Button><SearchIcon className="mr-2 size-4" />Search</Button>
 
-// ❌ Manual sizing classes on icons
-<Button>
-  <SearchIcon className="size-4" data-icon="inline-start" />
-  Search
-</Button>
-```
-
-**Why:** Components handle icon sizing via CSS. No manual `size-4` or `w-4 h-4` needed.
-
-## Rule: Pass Icons as Objects, Not String Keys
-
-**✅ CORRECT:**
-```typescript
-import { CheckIcon } from 'lucide-react';
-
+// ❌ There is no `icon` prop. `ButtonProps` is ButtonHTMLAttributes +
+//    variant/size + `asChild`, so this reaches the DOM as an unknown
+//    attribute and renders nothing. (`size="icon"` is the square-button
+//    SIZE variant — a different key with a confusingly similar name.)
 <Button icon={CheckIcon}>Save</Button>
-```
-
-**❌ FORBIDDEN:**
-```typescript
-// ❌ Don't use string lookups
-<Button icon="check">Save</Button>
 ```
 
 ## Rule: Registry-Based Component Resolution

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -280,6 +280,14 @@ A bare `"columns": 4` already gets a mobile-first ramp (1 column, 2 at `sm`,
 4 at `md`), so reach for the object form only when you need the breakpoints
 spelled out.
 
+**`2xl` is accepted and then dropped.** The spec's `BreakpointColumnMapSchema`
+declares six keys — `xs` … `xl` **plus `2xl`** — but the `grid` renderer reads
+only the first five, so `{ "xs": 1, "2xl": 6 }` validates, emits no `2xl:`
+class, and renders at the `xs` count forever. Measured: `{xs:1, xl:5}` →
+`grid grid-cols-1 xl:grid-cols-5 gap-4`; `{xs:1, "2xl":6}` →
+`grid grid-cols-1 gap-4`. Stop at `xl`, or carry the widest step in
+`className`.
+
 **❌ DO NOT** spell it `cols` — no schema, renderer or registry declares that
 key, so the value is dropped on the floor and the grid renders a flat two
 columns at *every* breakpoint (objectui#4001).


### PR DESCRIPTION
Fixes #7094
Part of objectstack-ai/objectstack#13658

Flight ⑫ of the published-skills factual sweep — `skills/objectui/**`, the program's last package. 18 files, 5,729 markdown lines at `origin/main@2c3cd1b`.

Session, for durable attribution: `https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2`

## ⛔ Governed surface — human merge, deliberately parked

`skills/**` is the published, customer-facing surface. This PR is a draft **on purpose**: not marked ready, auto-merge not armed, not enqueued, and the dispatching seat will not arm it. The repo's own guard agrees — `node scripts/check-governed-queue-guard.mjs --test` over this diff answers:

```
One governed path governs the WHOLE pull request — proportion is not a question.
⛔ Do not flip it ready, enqueue it, or arm auto-merge. Park it as a DRAFT and leave the merge
   to the maintainer; a human merge IS the review record for a governed surface.
```

## Method

Per behavioural claim: locate the **implementing code**, verify there — never against another document — and **execute** it where the claim is behaviour-bearing. Verdicts are VERIFIED / FALSE / NOT MEASURABLE, none silently skipped. Split by file (the package-size allowance), reported in the dev report on #7094.

Two mechanical sweeps ran over the whole package rather than by eye, both reproducible from the base tree: every backticked API identifier and every `@object-ui/*` import binding inside a fenced block, resolved against the real export surface of the package each names; and every in-repo path assertion. Deduplicated, that is **310 distinct (file, assertion) pairs**. Both sweeps are what surfaced the phantom-export class below — neither would have been caught by reading, because in every case the surrounding prose is coherent and only the name is dead.

**False density: 25 false claims / 340 adjudicated — 7.4%**, inside the program's 1.5–10% working range and at the top of it. The denominator is the 310 mechanical assertions plus the 30 enumerations probed against their schema's member set. A handful of the numerator (the coverage thresholds, the stale line range, the sibling count) are value claims that sit outside that mechanical substrate, so 7.4% is a **ceiling** on the density, not a point estimate.

The distribution is lopsided and worth naming: three guides carry 18 of the 25. `guides/mobile.md` alone documents an `@object-ui/mobile` that does not exist — seven phantom exports across three consecutive code blocks — and the `app-shell` sections of three more guides teach a `*Renderer` naming scheme the package never had.

## The corrections — 25 false facts, 34 landing sites

### Class 1 — phantom exports (10 facts, 13 sites)

| # | 落点 | before | after |
|---|---|---|---|
| F1 | `guides/mobile.md` — gesture block | `import { useSwipe, useLongPress, usePinchZoom } from '@object-ui/mobile'` | `useGesture` (one hook, `type` + `onGesture`, returns a **ref**), `usePullToRefresh`; `GestureType`'s ten values named |
| F2 | `guides/mobile.md` — overlay block | `import { BottomSheet, MobileNav }` | `ResponsiveContainer` (`minBreakpoint`/`maxBreakpoint`/`showOn`/`hideOn`/`fallback`) + the real overlays from `@object-ui/components`; mobile nav is app-shell's `mobileNavMode` |
| F3 | `guides/mobile.md` — inputs block | `import { MobileSelect, MobileDatePicker }` | no mobile widget set exists; `@object-ui/fields` + `useTouchTarget` |
| F4 | `guides/mobile.md` — offline block | `const { isOnline, queue, syncState } = useOffline()` | `pendingCount` — `OfflineResult` has no `queue` |
| F5 | `guides/mobile.md` — sync states | `idle → syncing → synced \| error` | `'idle' \| 'syncing' \| 'error' \| 'offline'` — there is no `'synced'` |
| F6 | `guides/page-builder.md`, `guides/project-setup.md`, `guides/architecture.md` (3 sites) | `ObjectRenderer`, `PageRenderer`, `DashboardRenderer` from `@object-ui/app-shell` | `ObjectView`, `RecordDetailView`, `PageView`, `DashboardView`, `ReportView`, with a note on where the two real `*Renderer` names actually live |
| F7 | `guides/architecture.md` Pattern A | `// packages/core/src/registry.ts` + `registerComponent()` / `resolveComponent()` | `packages/core/src/registry/Registry.ts`, the `ComponentRegistry` instance, `register(type, component, meta?)` / `get(type, namespace?)` |
| F8 | `rules/composition.md` | `Empty` taking `icon` / `title` / `description` props | the `Empty` / `EmptyMedia` / `EmptyTitle` / `EmptyDescription` composition family |
| F9 | `rules/composition.md` (2 sites) | the `data-icon="inline-start"` rule, and `Spinner` carrying that attribute | icons are children; `buttonVariants`' base already carries `gap-2 [&_svg]:size-4 [&_svg]:shrink-0` |
| F10 | `rules/composition.md` | `Button` taking an `icon` prop (`icon={CheckIcon}`) | `ButtonProps` has no `icon` prop — `icon` is the square-button **size** variant |

`data-icon` occurs **zero** times in `packages/`, `apps/`, `examples/`, `e2e/`, `scripts/`, `docs/` and `content/`. `ObjectRenderer` occurs six times repo-wide, all six in one example README — filed as #7095.

### Class 2 — an enumeration that stopped growing when the schema did (11 facts, 16 sites)

| # | 落点 | before | after |
|---|---|---|---|
| F11 | `guides/schema-expressions.md` — Formula functions | 16 named | **30** — added `MEDIAN` `PERCENTILE` `STDEV` `VARIANCE` `SWITCH` `TRIM` `LEN` `LEFT` `RIGHT` `SUBSTRING` `FIND` `REPLACE` `REGEX` `DATEDIFF`, with the two non-obvious argument orders spelled out |
| F12 | `guides/schema-expressions.md` — "Supported operators (full list)" | no `typeof`, no primaries | unary row (`!`, `-`, `+`, `typeof`) + primaries row (array literals, single-param arrow) |
| F13 | `guides/schema-expressions.md` — Security model | blocked list presented as the whole gate | names `isDangerous` as the source-level table and adds the four `BLOCKED_PROPS` members it omits |
| F14 | `guides/data-integration.md` — `DataSource` | `saveView?` and `execute?` shown as members | **neither exists** — replaced with the real `createView`/`updateView`/`updateViewConfig`/`deleteView`; the optional half is **32** members, not 6 |
| F15 | `guides/data-integration.md` — `QueryParams` | 6 `$` keys | 9 — added `$search`, `$searchFields`, `$count` |
| F16 | `guides/plugin-development.md` — "ComponentMeta options (full reference)" | 10 rows | **16** — added `tier`, `labelling`, `deprecated`, `examples`, `tags`, `description` |
| F17 | `guides/plugin-development.md` — `ComponentInput` | `type` a single literal; 8 keys | `ComponentInputControlType \| ComponentInputControlType[]` (objectui#3832); 13 keys — added `inputType`, `min`, `max`, `step`, `placeholder` |
| F18 | `guides/plugin-development.md` — `FieldWidgetComponentProps` "and nothing else" | 5 plumbing keys | adds `dependsOnLabels`, `onUploadingChange`, `onSelectRecord`, `onCreateNew`, and names the real intersection (`FieldWidgetDomProps` & `AriaAttributes` & `data-${string}`) |
| F19 | `guides/app-composition.md` — nav target table | 7 of 9 union members | all nine, with rows for `component` (`componentRef`, colon-joined), `separator` and `action` |
| F20 | `README.md`, `guides/architecture.md`, `guides/page-builder.md`, `guides/project-setup.md` (4 sites) | plugin catalogue lists `plugin-workflow`, omits `plugin-tree` | `@object-ui/plugin-workflow` **does not exist**; `@object-ui/plugin-tree` does, registering `tree` and `object-tree`. Count of 19 was right; one member was wrong |
| F21 | `guides/architecture.md` — CLI list | omits `serve` | `serve` added (`.command('serve')`; `dev` is described by the CLI as its alias) |

### Class 3 — accept surface vs read surface (1 fact, 3 sites)

| # | 落点 | before | after |
|---|---|---|---|
| F22 | `SKILL.md` §6, `rules/protocol.md`, `guides/mobile.md` | `columns` takes a breakpoint object keyed `xs`/`sm`/`md`/`lg`/`xl` | the spec's `BreakpointColumnMapSchema` accepts **six** keys including `2xl`; the `grid` renderer reads only five, so a `2xl` entry parses and is then silently dropped |

Measured through a real `SchemaRenderer` render, reading the emitted class: `{xs:1, xl:5}` → `grid grid-cols-1 xl:grid-cols-5 gap-4`; `{xs:1, "2xl":6}` → `grid grid-cols-1 gap-4`. The implementation half is filed as #7097 with both routes and the gate that generalizes.

### Class 4 — stale coordinates and self-description (3 facts, 6 sites)

| # | 落点 | before | after |
|---|---|---|---|
| F23 | `guides/testing.md` (3 sites) | "Two test suites in `vitest.workspace.ts`", split by package, setup `vitest.setup.tsx` | **no such file** — three projects (`unit`/`dom`/`dom-heavy`) declared in `vitest.config.mts`, split by **file extension**, each with its own setup file; `vitest.setup.tsx` is a legacy shim wired into no config |
| F24 | `guides/testing.md` | coverage `62 / 54 / 50 / 61` | `40 / 33 / 30 / 40`, the real `coverage.thresholds` |
| F25 | `guides/schema-expressions.md`, `guides/project-setup.md`, `README.md` | `SchemaRenderer.tsx` "(lines 117-175)" (that range is `resolveAriaProps`); "its ten siblings" (there are 17); layout tree listing 10 of 12 guides | the `evaluatedSchema` memo by name; "sixteen siblings"; `architecture.md` + `app-composition.md` restored |

Two test patterns in `guides/testing.md` were rewritten because, as published, **they cannot pass**: `new ExpressionEvaluator()` then `evaluate(expr, context)` puts the context where `EvaluationOptions` goes, so every `${…}` resolves against an empty scope and the template part falls back to its own literal (measured — `'Hello ${data.name}'` comes back verbatim); and `formatValidationErrors(result.errors)` passes the errors array to a function whose parameter is the whole result. Both are counted inside F23–F25's file rows.

## Executed evidence

Three probe files, written and run against the real modules, then deleted — this PR adds no test files.

**`unit` project, 13/13 pass.** The claims proven **TRUE by execution** (the non-vacuity control): the six safe globals resolve and evaluate; single-`${}` type preservation returns `42` / `true` and `"Count: 42"` for the mixed template; `${0 && "yes"}` returns number `0`; a missing variable returns `undefined` without throwing. And all 13 patterns in the published "Blocked" list really throw `Potentially dangerous expression detected: …`.

The FALSE ones, measured:

```
${new Date(data.timestamp)} => RETURNED a real Date: 1970-01-01T00:00:00.000Z
new Function()              => TypeError: new Function() is not supported in expressions
formula registry: registered=30 documented=16
  UNDOCUMENTED: DATEDIFF FIND LEFT LEN MEDIAN PERCENTILE REGEX REPLACE RIGHT
                STDEV SUBSTRING SWITCH TRIM VARIANCE
  PHANTOM (documented but not registered): (none)
evaluate(expr, context)     => "Hello ${data.name}"   (the source string, not "Hello Alice")
```

Every rewritten line re-executed: the 14 new formula calls with their real argument order (`FIND("@", s)` → `3`, `PERCENTILE(90, values)` → `8.6`, `SWITCH(…)` → `"silver"`, `TRIM` → `"hi"`, `DATEDIFF` → `7`), and both rewritten test patterns pass 5/5 and 3/3.

**`dom` project, 8/8 + 3/3 pass.** Export surfaces asserted against the real modules: the seven-part `Empty` family and `Spinner` present; `buttonVariants()` contains `gap-2` and `[&_svg]:size-4`; the ten real `@object-ui/mobile` exports present and all seven phantoms absent; `BREAKPOINTS` equals `{xs:0, sm:640, md:768, lg:1024, xl:1280, '2xl':1536}`; the thirteen real `app-shell` names present and all three `*Renderer` names absent; `PageRenderer` absent from `@object-ui/components`' public surface and `DashboardRenderer` present on `@object-ui/plugin-dashboard`. Plus the `2xl` grid measurements above.

## Budget — both readings, per the 2026-08-21 ruling

| reading | before | after | delta |
|:--|--:|--:|--:|
| `skills/objectui/**` package lines (all 18 `.md`) | 5,729 | 5,810 | **+81** |
| package bytes | 223,325 | 231,783 | **+8,458 (+3.8%)** |
| package tokens (`ceil(utf8 bytes / 4)`) | 55,832 | 57,946 | +2,114 |
| `guides/schema-expressions.md` | 628 | 654 | +26 |
| `guides/plugin-development.md` | 426 | 446 | +20 |
| `guides/testing.md` | 383 | 398 | +15 |
| `rules/composition.md` | 297 | 277 | **−20** |
| `guides/architecture.md` | 192 | 189 | **−3** |

**No token or line ratchet is in force in objectui — absence measured, not assumed.** The only `skills/**`-scoped gate is `scripts/check-skills-paths.mjs`, whose "ratchet" is its baseline *exemption list*, not a size budget; no script or workflow in the repo carries a skills token or line ceiling. So byte-neutral-or-shrinking does not bind here — which is stated so a reviewer can hold the growth to the ruling rather than to a gate.

The +3.8% is disclosed for that judgement. It is dominated by enumerations that were incomplete: 14 formula-function names, 6 `ComponentMeta` options, 5 `ComponentInput` keys, 3 `QueryParams` keys, 3 nav-union rows. Every added line carries a fact that was missing or wrong; nuance that did not correct a falsehood was cut rather than kept (the security-model paragraph was trimmed from 8 lines to 4 on that rule), and two files shrink.

## Gates — derived from objectui's own tooling, run at head `a3dc965`

`scripts/pm/dispatch-gates.mjs` lives only in objectstack and answers only about that tree, so the family was derived here from this repo's own `package.json` scripts and `.github/workflows/**` — every `check-*.mjs` whose scan surface names `skills/`, plus the unfiltered per-PR gates.

```
EXIT=0 :: node scripts/check-skills-paths.mjs
          ✅ 92/93 stated path(s) resolve across 18 guide file(s); 1 baselined
EXIT=0 :: pnpm check:shell-escape-residue      (skills: 18 files, 233 fences)
EXIT=0 :: pnpm check:control-bytes             (5,883 tracked text files)
EXIT=0 :: node scripts/check-changeset-presence.mjs
EXIT=0 :: node scripts/check-governed-queue-guard.mjs --self-test   (132 cases)
EXIT=0 :: pnpm check:doc-fences                (224 documents)
EXIT=0 :: pnpm docs:check-links                (17 scan roots)
```

Every exit code was captured before any pipe. Two gates are recorded honestly as **NOT MEASURED** rather than as passes:

- `node scripts/check-governed-queue-guard.mjs` (no flag) exits 1 with *"could not read GITHUB_EVENT_PATH"* — by its own text it reads the workflow event payload and nothing else, so it is a PREREQUISITE NOT MET locally. Its `--self-test` half is green above and the real run happens in CI.
- `pnpm check:readme-exports` exits 1 with 386 findings, every one of them *"its type entry `./dist/index.d.ts` is not on disk — run `pnpm build` first"*. Its population is the 43 READMEs under `packages/` (its own census line: "0 outside any package"); **zero** of its findings touch `skills/`, and this diff changes none of its inputs.

**ESLint was not run repo-wide, and that narrowing is measured, not skipped.** Its population, read from `eslint.config.js` itself, is `**/*.{ts,tsx}` (plus `**/*.tsx` and two test globs) — there is no markdown arm. `npx eslint skills --format json` reports **0 files linted, 0 messages**. And the config declares no `projectService` / `project`, so there is no cross-file type program through which a `.md`-only diff could move an untouched file's verdict in either direction.

## Changeset — none owed, and no label either

The repo's own gate decided it from the diff: *"13 file(s) changed, 0 of them published source of a package the release covers … ✅ No source or published contract of a released package changed in this range, so no changeset is owed."*

No `skip-changeset` label is applied, deliberately. In this repo that label is a **phantom**: `scripts/__tests__/ci-cd-pipeline-doc.test.ts` fails if any file under `.github/` or `scripts/` so much as mentions it (objectui#4912). Nothing reads it, so applying it would be theatre.

## Filed, not fixed — out of scope by file surface

- **#7095** — `examples/byo-backend-console/README.md` teaches `ObjectRenderer` at six sites. Same phantom as F6, different file surface.
- **#7096** — root `test:integration` runs `vitest run --project ui`; there is no project named `ui`. Measured: `Error: No projects matched the filter "ui"`, exit 1.
- **#7097** — the F22 implementation half: `BreakpointColumnMapSchema` accepts `2xl`, the `grid` renderer drops it. Carries both routes and the gate that generalizes past `columns` to every `Breakpoint*Map`.

All three are unassigned, deduped against the 274 open issues in this repo before filing, and link back to #7094.

## What is deliberately not here

- No gate binding this prose to behaviour. The sharpest candidate this flight found — comparing a presented-as-exhaustive enumeration against the schema member set it mirrors — is a new validation surface and belongs on its own card, not smuggled into a docs PR.
- `guides/console-development.md`, `guides/auth-permissions.md`, `guides/i18n.md`, `rules/styling.md` and `rules/no-touch-zones.md` are **unchanged**: every claim adjudicated in them came back VERIFIED. `console-development.md`'s retired-names table is right in both directions — all 16 symbols it declares nonexistent return zero hits repo-wide.
- `SKILL.md` carries one added clause (F22) and nothing else.

_Generated by [Claude Code](https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Msg17tAHJ3jVTYFgHydCm2)_