### PR TITLE
fix(scripts): collect TypeScript fences opened inside a blockquote

### DIFF
--- a/.changeset/7086-blockquoted-fence-collector.md
+++ b/.changeset/7086-blockquoted-fence-collector.md
@@ -1,0 +1,32 @@
+---
+---
+
+Doc-snippet gate tooling only, no published package source changed.
+
+`check-doc-snippet-types` collects blocks with `scanFences`, whose fence-opening
+anchor accepted a run of leading spaces and tabs and nothing else. A fence
+opened inside a Markdown blockquote carries a `> ` prefix, so the anchor never
+matched, the block was never collected, and the gate compiled nothing for it.
+There was no diagnostic: an uncollected block appears in no count, and its page
+still reports as covered. A callout is a natural home for an import example,
+which is exactly the snippet class that rots when an export is renamed — the one
+class this gate exists to catch.
+
+The opener now tolerates a blockquote prefix and carries the opener's quote
+DEPTH through the rest of the walk: the search for the closing fence reads
+candidate lines at that same depth, and every body line is stripped of that many
+markers before it reaches the compiler. Depth 0 — every unquoted fence in the
+corpus — takes an identity path that returns the line unchanged byte for byte,
+so the other 773 collected blocks scan exactly as they did before. Stripping
+consumes at most one space after each marker, per CommonMark, so indentation
+belonging to the snippet survives.
+
+Carrying the depth to the CLOSING fence is what makes this safe in both
+directions. Without it a blockquoted fence would find no close and swallow the
+rest of the file; and a plain fence would be closed early by any `> ` + backticks
+line quoted inside it as prose. Both directions are pinned.
+
+Measured over the gate's own 224-document population: collected blocks 773 → 774.
+The one newly-collected block is the import callout at
+`content/docs/api/schema-reference.md` line 12, and it compiles — the gate's
+semantic phase judges 272 of 272 with 0 failures. Nothing left the population.

--- a/scripts/__tests__/check-doc-snippet-types.test.ts
+++ b/scripts/__tests__/check-doc-snippet-types.test.ts
@@ -116,6 +116,73 @@ describe('fence scanning', () => {
     expect(blocks).toHaveLength(0);
   });
 
+  it('collects a fence opened inside a blockquote and strips the quoting from its body', () => {
+    // objectui#7086: the opening anchor allowed leading spaces and tabs only, so a
+    // fence inside a callout was never collected and the gate compiled nothing for
+    // it. Silently — an uncollected block appears in no count, and the page still
+    // reports as covered.
+    const { blocks } = scanFences(
+      [
+        '> **Import:** All types are available from `@object-ui/types`.',
+        '>',
+        `> ${FENCE}typescript`,
+        "> import type { PageNodeSchema } from '@object-ui/types';",
+        `> ${FENCE}`,
+        '',
+        'Prose after the callout.',
+      ].join('\n'),
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].language).toBe('typescript');
+    expect(blocks[0].body).toBe("import type { PageNodeSchema } from '@object-ui/types';");
+  });
+
+  it('closes a blockquoted fence at its own depth rather than running to end of file', () => {
+    const { blocks } = scanFences(
+      [
+        `> ${FENCE}ts`,
+        '> export const a = 1;',
+        `> ${FENCE}`,
+        '',
+        'export const notPartOfTheBlock = true;',
+      ].join('\n'),
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].body).toBe('export const a = 1;');
+  });
+
+  it('strips the opening depth only, so nesting and the snippet own indentation survive', () => {
+    const { blocks } = scanFences(
+      [
+        `> > ${FENCE}ts`,
+        '> > export const nested = {',
+        '> >   deep: true,',
+        '> > };',
+        `> > ${FENCE}`,
+      ].join('\n'),
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].body).toBe(['export const nested = {', '  deep: true,', '};'].join('\n'));
+  });
+
+  it('does not let a quoted backtick line close an unquoted fence', () => {
+    // Depth 0 takes the identity path. This is what keeps every unquoted fence in
+    // the corpus collecting exactly as it did before blockquotes were recognised.
+    const { blocks } = scanFences(
+      [
+        `${FENCE}ts`,
+        '// a quoted fence, as prose inside a snippet:',
+        `> ${FENCE}`,
+        'export const a = 1;',
+        FENCE,
+      ].join('\n'),
+    );
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].body).toBe(
+      ['// a quoted fence, as prose inside a snippet:', `> ${FENCE}`, 'export const a = 1;'].join('\n'),
+    );
+  });
+
   it('attaches a fragment marker only to the fence directly beneath it', () => {
     const { blocks } = scanFences(
       [

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -554,6 +554,31 @@ const UNGATED_DOCS = {
 
 // ── Fence scanning ───────────────────────────────────────────────────────────
 
+/**
+ * One level of blockquote marker: the `>` a Markdown blockquote puts in front of
+ * every line it contains — the fences and the code between them alike. At most one
+ * space after the marker is consumed, per CommonMark, so indentation that belongs
+ * to the snippet survives the strip.
+ */
+const QUOTE_MARKER = /^[ \t]*>[ \t]?/;
+
+/**
+ * `line` with `depth` levels of blockquote marker removed. `depth === 0` returns
+ * the line unchanged, byte for byte; that identity path is what keeps every
+ * unquoted fence in the corpus collecting exactly as it did before. A line that
+ * runs out of markers early is returned as far as it stripped, which bounds a
+ * lazily-continued blockquote instead of letting its fence run to end of file.
+ */
+function stripQuotePrefix(line, depth) {
+  let out = line;
+  for (let d = 0; d < depth; d++) {
+    const m = QUOTE_MARKER.exec(out);
+    if (!m) break;
+    out = out.slice(m[0].length);
+  }
+  return out;
+}
+
 /** The declaration a fragment carries; see FRAGMENT_MARKER_EXAMPLES. */
 const FRAGMENT_MARKER =
   /^[ \t]*(?:\{\/\*|<!--)[ \t]*doc-snippet:[ \t]*fragment[ \t]*(?:—|--|-|:)[ \t]*(.+?)[ \t]*(?:\*\/\}|-->)[ \t]*$/;
@@ -576,6 +601,12 @@ export const FRAGMENT_MARKER_EXAMPLES = [
  * Every fenced block in one document, with the ts/tsx ones marked. Fences are
  * matched by their own run length so a ```` ```` ```` wrapper containing ``` does
  * not confuse the walk, and a block's opening info string is kept verbatim.
+ *
+ * A fence opened inside a blockquote is collected too. Its opener's quote depth
+ * is carried to the search for its closing fence and stripped from every body
+ * line, so the compiler sees the snippet the reader sees and not the `>` around
+ * it. Depth 0 — every unquoted fence — takes the identity path and scans exactly
+ * as it did before blockquotes were recognised.
  */
 export function scanFences(source) {
   const lines = source.split('\n');
@@ -584,12 +615,13 @@ export function scanFences(source) {
   for (let i = 0; i < lines.length; i++) {
     const marker = FRAGMENT_MARKER.exec(lines[i]);
     if (marker) markers.push({ line: i + 1, reason: marker[1].trim(), consumed: false });
-    const open = /^([ \t]*)(`{3,})(.*)$/.exec(lines[i]);
+    const open = /^([ \t]*(?:>[ \t]*)*)(`{3,})(.*)$/.exec(lines[i]);
     if (!open) continue;
     const ticks = open[2];
+    const depth = (open[1].match(/>/g) ?? []).length;
     let close = lines.length;
     for (let j = i + 1; j < lines.length; j++) {
-      const c = /^[ \t]*(`{3,})[ \t]*$/.exec(lines[j]);
+      const c = /^[ \t]*(`{3,})[ \t]*$/.exec(stripQuotePrefix(lines[j], depth));
       if (c && c[1].length >= ticks.length) {
         close = j;
         break;
@@ -606,7 +638,10 @@ export function scanFences(source) {
       blocks.push({
         fenceLine: i + 1,
         language,
-        body: lines.slice(i + 1, close).join('\n'),
+        body: lines
+          .slice(i + 1, close)
+          .map((line) => stripQuotePrefix(line, depth))
+          .join('\n'),
         fragmentReason: above ? above.reason : null,
       });
     }


### PR DESCRIPTION
Fixes #7086

`check-doc-snippet-types` collects blocks with `scanFences`, whose fence-opening anchor accepted a run of leading spaces and tabs and nothing else. A fence opened inside a Markdown blockquote carries a `> ` prefix, so the anchor never matched, the block was never collected, and the gate compiled nothing for it. There was no diagnostic — an uncollected block appears in no count, and its page still reports as covered. A callout is a natural home for an import example, which is exactly the snippet class that rots when an export is renamed: the one class this gate exists to catch.

Took option (a) of the three the card left open, per the dispatching PM's ruling. This is gate strengthening — restoring declared-equals-enforced on a gate that claimed to compile the docs' TypeScript and silently did not.

## What changed

The opener now tolerates a blockquote prefix and carries the opener's quote **depth** through the rest of the walk:

- the search for the closing fence reads candidate lines at that same depth;
- every body line is stripped of that many markers before it reaches the compiler;
- `stripQuotePrefix` consumes at most one space after each marker, per CommonMark, so indentation belonging to the snippet survives.

**Depth 0 takes an identity path that returns the line unchanged byte for byte.** That is what keeps the other 773 collected blocks in the corpus scanning exactly as before, and it is pinned.

Carrying the depth to the *closing* fence is what makes this safe in both directions. Without it, a blockquoted fence would find no close and swallow the rest of the file; and a plain fence would be closed early by any quoted backtick line sitting inside it as prose. Both directions have a test.

## The ledger movement, measured

The card warned that widening the anchor "may pull previously-invisible blocks into the compiled population, which is a ledger movement rather than a one-line edit". It is, and it is exactly one block:

| | before | after |
| --- | --- | --- |
| collected blocks, whole 224-document population | 773 | **774** |
| gate's own covered blocks | 383 | **384** |
| of those, to compile | 271 | **272** |
| declared fragments | 112 | 112 |
| semantic phase failures | 0 | **0** |

Newly collected: **1** — the import callout at `content/docs/api/schema-reference.md` line 12. Its disposition: **compiles clean**. No longer collected: **0**; nothing left the population. Block identity was compared by document, fence line, language and a hash of the body, so a block whose body merely changed shape would have shown as one removal plus one addition rather than silently matching.

The card's sharpest handle reproduces and flips: importing the gate's own exported `scanFences` and running it over that page returned **2** collected blocks against 3 typescript fences before, and returns **3** now.

## Verification

Re-derived against `main` @ `2c3cd1b` before editing — every line number and count in the card still held: `TS_FENCE_LANGUAGES` at `:317`, the anchor at `:587`, acted on at `:600`; 224 documents; exactly 1 blockquoted ts/tsx/typescript fence, on the page the card named. The card's three controls all reproduce.

Gate and tests, run on the final commit `e463ae1`:

```
Scanned 224 document(s): 181 covered (80 of them hold a ts/tsx block), 43 ungated
Covered blocks: 384 — 272 to compile, 112 declared fragment(s).
Semantic phase: 272 of 272 block(s) judged, 0 failed.
Every covered documentation snippet compiles against the built types.

Test Files  1 passed (1)
     Tests  48 passed (48)
```

`eslint` on both changed files: exit 0. All four changeset gates: exit 0. `check-changeset-presence` verdict, quoted: `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` — so the changeset here is the **empty-frontmatter** form, not a `patch` bump that would falsely claim a released package moved.

**Ablation.** With the fix reverted to the `2c3cd1b` blob (mutation confirmed on disk by hash and by `stripQuotePrefix` dropping to 0 occurrences), 3 of the 4 new pins fail and the gate's covered count falls back to 383/271. The fourth — the depth-0 identity guard — passes in both trees, which is correct: it pins pre-existing behaviour that this change must not move. Restore was proved byte-identical to the `HEAD` blob, with a clean `git diff HEAD`. No rebuild leg is owed here: the gate runs as `node scripts/check-doc-snippet-types.mjs` and the test imports `'../check-doc-snippet-types.mjs'`, both source paths, neither resolved through a package `dist`.

## Scope

Confined to the collector's anchor and its prefix-stripping; the gate is not refactored. One bounded gap is deliberately left alone and filed separately as #7099: `FRAGMENT_MARKER` and the marker-attachment walk are still blockquote-unaware, so a blockquoted block that legitimately cannot compile has no reachable escape hatch. Population there is 0 today (measured, with controls at 2900 plain openers and 112 plain markers), and a correct fix needs a second mechanism — the blank-line walk — which was outside this card's dispatched scope.

_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_