### PR TITLE
fix(examples): drop the 21 inert `value` keys from the catalog overlay-menu fixtures

### DIFF
--- a/.changeset/7072-catalog-menu-value-keys.md
+++ b/.changeset/7072-catalog-menu-value-keys.md
@@ -1,0 +1,28 @@
+---
+---
+
+Internal only, no release: the four overlay-menu fixtures in
+`examples/schema-catalog` no longer author a `value` key on their menu items.
+
+Twenty-one menu items across `components-overlay-menubar/application-menubar`
+(11), `components-overlay-context-menu/basic-context-menu` (4),
+`components-overlay-dropdown-menu/basic-dropdown-menu` (3) and
+`components-overlay-dropdown-menu/with-icons` (3) carried `"value"`. No arm of
+the shipped `MenuItem` union declares it — `MenuCommandItem`
+(`packages/types/src/overlay.ts:363-401`) declares `label`, `icon`, `disabled`,
+`onClick`, `shortcut`, `children`, `separator?: false` and a `type?: never`
+tombstone; `MenuDividerItem` (`:409-419`) declares `separator: true` and the
+same tombstone. Neither declares `value`, and none of the three menu renderers
+under `packages/components/src/renderers/overlay/` reads one.
+
+Nothing rendered differently before or after, which is the point: `MenuItemSchema`
+(`packages/types/src/zod/overlay.zod.ts:147-168`) builds its union from bare,
+non-strict `z.object`s, so zod stripped the key and reported success. The key
+had been inert and invisible since it was authored, and the catalog is a
+declared AI few-shot retrieval source, so an inert key there is a spelling the
+next author copies.
+
+The keys are deleted rather than declared: nothing reads `value`, and
+objectui#6523 deliberately narrowed this union rather than widening it. No
+published package source, no schema, no renderer and no type was touched — the
+diff is four JSON fixtures in a `private: true` example package.

--- a/examples/schema-catalog/src/schemas/components-overlay-context-menu/basic-context-menu.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-context-menu/basic-context-menu.json
@@ -8,17 +8,14 @@
   "items": [
     {
       "label": "Copy",
-      "value": "copy",
       "icon": "copy"
     },
     {
       "label": "Cut",
-      "value": "cut",
       "icon": "scissors"
     },
     {
       "label": "Paste",
-      "value": "paste",
       "icon": "clipboard"
     },
     {
@@ -26,7 +23,6 @@
     },
     {
       "label": "Delete",
-      "value": "delete",
       "icon": "trash"
     }
   ]

--- a/examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/basic-dropdown-menu.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/basic-dropdown-menu.json
@@ -6,19 +6,16 @@
   },
   "items": [
     {
-      "label": "Profile",
-      "value": "profile"
+      "label": "Profile"
     },
     {
-      "label": "Settings",
-      "value": "settings"
+      "label": "Settings"
     },
     {
       "separator": true
     },
     {
-      "label": "Logout",
-      "value": "logout"
+      "label": "Logout"
     }
   ]
 }

--- a/examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/with-icons.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/with-icons.json
@@ -8,17 +8,14 @@
   "items": [
     {
       "label": "Edit",
-      "value": "edit",
       "icon": "square-pen"
     },
     {
       "label": "Copy",
-      "value": "copy",
       "icon": "copy"
     },
     {
       "label": "Delete",
-      "value": "delete",
       "icon": "trash",
       "variant": "destructive"
     }

--- a/examples/schema-catalog/src/schemas/components-overlay-menubar/application-menubar.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-menubar/application-menubar.json
@@ -5,19 +5,16 @@
       "label": "File",
       "items": [
         {
-          "label": "New Tab",
-          "value": "new"
+          "label": "New Tab"
         },
         {
-          "label": "New Window",
-          "value": "window"
+          "label": "New Window"
         },
         {
           "separator": true
         },
         {
-          "label": "Exit",
-          "value": "exit"
+          "label": "Exit"
         }
       ]
     },
@@ -25,27 +22,22 @@
       "label": "Edit",
       "items": [
         {
-          "label": "Undo",
-          "value": "undo"
+          "label": "Undo"
         },
         {
-          "label": "Redo",
-          "value": "redo"
+          "label": "Redo"
         },
         {
           "separator": true
         },
         {
-          "label": "Cut",
-          "value": "cut"
+          "label": "Cut"
         },
         {
-          "label": "Copy",
-          "value": "copy"
+          "label": "Copy"
         },
         {
-          "label": "Paste",
-          "value": "paste"
+          "label": "Paste"
         }
       ]
     },
@@ -53,16 +45,13 @@
       "label": "View",
       "items": [
         {
-          "label": "Zoom In",
-          "value": "zoom-in"
+          "label": "Zoom In"
         },
         {
-          "label": "Zoom Out",
-          "value": "zoom-out"
+          "label": "Zoom Out"
         },
         {
-          "label": "Reset Zoom",
-          "value": "reset"
+          "label": "Reset Zoom"
         }
       ]
     }

--- a/examples/schema-catalog/test/component-fixture-declared-keys.test.ts
+++ b/examples/schema-catalog/test/component-fixture-declared-keys.test.ts
@@ -661,3 +661,149 @@ describe('catalog corpus: every menubar item uses the declared MenuItem spelling
     expect(MenuItemSchema.safeParse({ label: 'Section', type: 'label' }).success).toBe(false);
   });
 });
+
+/**
+ * objectui#7072 — the four overlay-menu fixtures authored a `value` key on 21
+ * of their items. No arm of the shipped `MenuItem` union declares it
+ * (`MenuCommandItem` at `packages/types/src/overlay.ts:363-401`,
+ * `MenuDividerItem` at `:409-419`) and none of the three menu renderers reads
+ * one, so the key rendered nothing and cost nothing — it was simply a spelling
+ * the catalog taught. `MenuItemSchema` builds both arms from bare, non-strict
+ * `z.object`s, so zod STRIPS the key and reports success; that is the #5250
+ * blindness, and it is why nothing red ever covered these 21.
+ *
+ * ## Why this is a SEPARATE block from the `menubar` sweep above
+ *
+ * ⛔ This is deliberately not a widening of `objectui#6249`'s sweep, and the
+ * two must not be merged. That block walks ONE node shape (`{ type: 'menubar',
+ * menus: [{ items }] }`) and its header states on purpose that extending it to
+ * `dropdown-menu` / `context-menu` is "a separate verification surface this fix
+ * does not need". It is still scoped that way and still correct.
+ *
+ * But `value` was authored across all THREE containers, so a menubar-scoped pin
+ * would have covered 11 of the 21 while READING as though it covered the class
+ * — the failure mode that is worse than no pin at all. Hence a second, honestly
+ * named block whose population is the whole overlay-menu corpus.
+ *
+ * ## What this pins that the schema-level control above does NOT
+ *
+ * ⭐ The declared-key controls in the `menubar` block already feed
+ * `{ label, icon, disabled, shortcut, value }` to `MenuItemSchema` and assert
+ * only the first four survive. That pins the TYPE-LEVEL fact — `value` is not
+ * declared — and it was already green while all 21 keys sat in the corpus.
+ * A stripping schema cannot see an authored key, so the type-level probe is
+ * structurally incapable of catching this. The gap was only ever the CORPUS
+ * assertion, and that is exactly what this block adds.
+ *
+ * Per the objectui#6810 ruling (2026-08-30): no family-wide read-set extractor
+ * is being built here — this is the ruled `逐例修 + 补钉` shape, one named pin
+ * with its own counter-probe for a key the class has actually regenerated on.
+ */
+describe('catalog corpus: no overlay-menu item authors the undeclared `value` key (objectui#7072)', () => {
+  type Located = { where: string; item: Json };
+
+  /** The three containers that hold `MenuItem`s. They share one `MenuItem` type. */
+  const MENU_CONTAINER_TYPES = new Set(['menubar', 'dropdown-menu', 'context-menu']);
+
+  /** Depth-first over an items array, descending through submenu `children`. */
+  function collectFrom(items: unknown, where: string, acc: Located[]): void {
+    if (!Array.isArray(items)) return;
+    items.forEach((raw, i) => {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return;
+      const item = raw as Json;
+      acc.push({ where: `${where}[${i}]`, item });
+      collectFrom(item.children, `${where}[${i}].children`, acc);
+    });
+  }
+
+  /**
+   * Every `MenuItem` of every menu container in the corpus, at any depth.
+   * `menubar` nests its items one level deeper (`menus[].items[]`) than
+   * `dropdown-menu` / `context-menu` (`items[]`) — reading only one of the two
+   * shapes is how a sweep silently returns a short list, so both are walked
+   * here and the non-vacuity assertion below pins the resulting count.
+   */
+  function collectMenuItems(node: unknown, where: string, acc: Located[] = []): Located[] {
+    if (Array.isArray(node)) {
+      node.forEach((n, i) => collectMenuItems(n, `${where}[${i}]`, acc));
+      return acc;
+    }
+    if (!node || typeof node !== 'object') return acc;
+    const record = node as Json;
+    if (typeof record.type === 'string' && MENU_CONTAINER_TYPES.has(record.type)) {
+      if (record.type === 'menubar' && Array.isArray(record.menus)) {
+        (record.menus as Json[]).forEach((menu, m) => {
+          collectFrom((menu as Json)?.items, `${where}.menus[${m}].items`, acc);
+        });
+      } else {
+        collectFrom(record.items, `${where}.items`, acc);
+      }
+    }
+    for (const [key, value] of Object.entries(record)) {
+      collectMenuItems(value, `${where}.${key}`, acc);
+    }
+    return acc;
+  }
+
+  const authoredValueKeys = (items: Located[]) =>
+    items.filter(({ item }) => 'value' in item).map(({ where }) => `${where}.value`);
+
+  const items = allExamples().flatMap((e) => collectMenuItems(e.schema, e.id));
+
+  it('the sweep reaches all three container shapes and every one of their items — non-vacuity', () => {
+    // Pinned so a walker that silently stops matching one container shape (or
+    // one nesting depth) fails loudly here rather than reporting a clean zero
+    // below. 25 items = menubar 13 + basic-context-menu 5 + basic-dropdown-menu
+    // 4 + with-icons 3.
+    expect(items).toHaveLength(25);
+    expect(allExamples().length).toBeGreaterThan(400);
+
+    // One representative position per container shape, including the deeper
+    // `menus[].items[]` nesting only `menubar` has.
+    expect(items.map((i) => i.where)).toEqual(
+      expect.arrayContaining([
+        'components-overlay-menubar/application-menubar.menus[0].items[0]',
+        'components-overlay-context-menu/basic-context-menu.items[0]',
+        'components-overlay-dropdown-menu/basic-dropdown-menu.items[0]',
+        'components-overlay-dropdown-menu/with-icons.items[0]',
+      ]),
+    );
+  });
+
+  it('no overlay-menu item authors `value`', () => {
+    expect(authoredValueKeys(items)).toEqual([]);
+
+    // The zero above is only a reading if the same sweep still SEES the items
+    // it is judging: a corpus that stopped parsing, or a walker that returned
+    // nothing, would also report "no `value`". `label` is the comparable
+    // declared key and must stay non-zero.
+    const labelled = items.filter(({ item }) => 'label' in item);
+    expect(labelled).toHaveLength(21);
+    const dividers = items.filter(({ item }) => item.separator === true);
+    expect(dividers).toHaveLength(4);
+  });
+
+  it('counter-probe: the same sweep DOES flag a `value` key put back into a real fixture', () => {
+    // ⛔ Not a synthetic menu and NOT a `.safeParse` probe. `MenuItemSchema`
+    // strips `value` and returns success, so a schema-level probe is blind to
+    // the authored key by construction — it stayed green through all 21 of
+    // them. This re-authors the key into a REAL fixture, taken from the corpus
+    // the pin above judges, and asserts the identical sweep reports it.
+    const fixture = JSON.parse(
+      JSON.stringify(schemaOf('components-overlay-dropdown-menu/basic-dropdown-menu')),
+    ) as Json;
+    ((fixture.items as Json[])[0] as Json).value = 'profile';
+
+    const reintroduced = collectMenuItems(fixture, 'counter-probe');
+    expect(authoredValueKeys(reintroduced)).toEqual(['counter-probe.items[0].value']);
+
+    // ...and the untouched fixture at the same position is clean, so the probe
+    // is reading the mutation rather than always reporting a hit.
+    const pristine = collectMenuItems(
+      schemaOf('components-overlay-dropdown-menu/basic-dropdown-menu'),
+      'pristine',
+    );
+    expect(authoredValueKeys(pristine)).toEqual([]);
+    expect(reintroduced).toHaveLength(pristine.length);
+  });
+});


### PR DESCRIPTION
Fixes #7072

Twenty-one menu items in the four overlay-menu catalog fixtures authored a `value` key that no arm of the shipped `MenuItem` union declares and no menu renderer reads. This deletes them, and pins that they stay gone.

## Re-derived on current `main`, because the card's numbers were days old

The card measured at `592acafb`; `main` is now `2c3cd1b`. **The count has not moved** — 21, distributed exactly as the card's table claims:

| fixture | `value` keys |
|---|--:|
| `components-overlay-menubar/application-menubar.json` | 11 |
| `components-overlay-context-menu/basic-context-menu.json` | 4 |
| `components-overlay-dropdown-menu/basic-dropdown-menu.json` | 3 |
| `components-overlay-dropdown-menu/with-icons.json` | 3 |
| **total** | **21** |

Counted by a walker that classifies each `value` key **by its position in the tree** rather than by filename, so the neighbouring `buttons[].value` population (#7077, button-group) is separated by construction and cannot leak in. Catalog-wide the walker sees 288 objects carrying `value` before and 267 after — a delta of exactly 21, so nothing outside the four fixtures moved.

⚠️ One correction to the card: its cited line spans are slightly off. Re-derived, `MenuCommandItem` is `packages/types/src/overlay.ts:363-401` (card said `:363-400`) and `MenuDividerItem` is `:409-419` (card said `:409-421`).

## The authority, re-verified

- `MenuCommandItem` (`overlay.ts:363-401`) declares `label`, `icon`, `disabled`, `onClick`, `shortcut`, `children`, `separator?: false`, `type?: never`. No `value`.
- `MenuDividerItem` (`:409-419`) declares `separator: true`, `type?: never`. No `value`.
- The three renderers under `packages/components/src/renderers/overlay/` perform **zero `.value` reads**. Stated precisely, because it is not zero *occurrences of the token*: `context-menu.tsx:95` contains `{ type: 'text', value: "Right click here" }` — a **write** constructing a `text` node, whose renderer genuinely reads `value`. No menu item's `value` is ever read.
- `MenuItemSchema` (`packages/types/src/zod/overlay.zod.ts:147-168`) builds its union from bare, non-strict `z.object`s, so zod strips `value` and reports success — the #5250 blindness. Nothing red covered this.

Deleted rather than declared: nothing reads `value`, and #6523 deliberately narrowed this union rather than widening it.

## The pin — #6810's second half

#6810's ruling (2026-08-30, maintainer, verbatim「同意」) prescribes `逐例修 + 补钉` for a key this class has regenerated on: the case-by-case fix **plus** a named pin carrying its own counter-probe, in the existing `component-fixture-declared-keys.test.ts` ledger form. This PR now carries both halves.

⛔ **Not a widening of #6249's menubar sweep** — a new, separately named block. That sweep walks one node shape and its own header states that extending it to `dropdown-menu` / `context-menu` is *"a separate verification surface this fix does not need"*; it is untouched. `value` was authored across all three containers, so a menubar-scoped pin would have covered 11 of 21 **while reading as though it covered the class**, which is worse than no pin.

The new block sweeps the whole overlay-menu corpus — all three container shapes, including the deeper `menus[].items[]` nesting only `menubar` has, and submenu `children`:

- **non-vacuity**: 25 items (menubar 13 + context-menu 5 + dropdown 4 + with-icons 3), one representative position asserted per container shape, so a walker that stops matching a shape fails loudly instead of reporting a clean zero.
- **the assertion**: no overlay-menu item authors `value`, with `label` (21) and `separator` (4) as in-query controls, so an empty or unparsed corpus cannot masquerade as a pass.
- **the counter-probe**: ⛔ deliberately **corpus-level, not schema-level**. `MenuItemSchema` strips `value` and returns success, so a `.safeParse` probe is structurally blind here — it stayed green through all 21 authored keys. The probe re-authors `value` into a **real fixture** taken from the corpus and asserts the identical sweep reports it at the right position, with the untouched fixture clean alongside.

⭐ The pre-existing declared-key controls in the menubar block already fed `{label, icon, disabled, shortcut, value}` to `MenuItemSchema` and asserted only the first four survive. That pinned the **type-level** fact and was green the whole time the 21 keys sat in the corpus. The gap was only ever the **corpus** assertion.

**Ablation — the pin demonstrably goes red.** With `"value": "profile"` re-authored into `basic-dropdown-menu.json` on disk (mutation confirmed: `value` key count 0 → 1, injected text present, blob hash `7e72503b` → `ece5381c`, still valid JSON), the suite fails:

```
× ... > no overlay-menu item authors `value`
  AssertionError: expected [ Array(1) ] to deeply equal []
× ... > counter-probe: the same sweep DOES flag a `value` key put back into a real fixture
  AssertionError: expected [ 'pristine.items[0].value' ] to deeply equal []
Tests  2 failed | 34 passed (36)
```

The non-vacuity test stayed green throughout, correctly — a key was added, not an item. Restore leg proven rather than assumed: `git checkout HEAD -- <abs path>`, `value` count back to 0, blob hash matches the HEAD blob exactly, `git diff HEAD` empty.

## Evidence

**The diff is only what it claims.** Every changed fixture line is one of: a removed `"value": …` line (21), or a `"label"` line re-punctuated because `value` had been the last key on that item (14 removed / 14 added, identical but for the trailing comma). No content changed. All four files round-trip byte-identically through `JSON.stringify(…, null, 2)`, so the edit was made by parse-and-reserialise and the diff is minimal by construction.

**Zero-hit control.** After the deletion, `value` hits 0 in all four files while the control `label` still hits 14 / 4 / 4 / 4 in the same query — a zero for both would have meant the files were emptied, not fixed. Structure intact: menubar still has 13 items (2 separators, 11 labelled), matching the existing `expect(items).toHaveLength(13)` pin.

**Rendered output is unchanged — which is the correct expectation here**, the opposite of a fixture-*content* fix. The keys were inert, so the DOM must not move. Measured rather than assumed: a scratch harness rendered each dropdown fixture at `2c3cd1b` and at this branch with `defaultOpen: true` injected (a closed menu renders only its trigger, which never carried the key, and would have made the comparison vacuous), normalised Radix's per-instance generated ids, and asserted identical HTML, text and `[role="menuitem"]` counts. Its **control** — mutating a key the renderer *does* read (`label`) — was required to produce a difference, and did. Scratch-only; not part of this diff.

⚠️ **Coverage of that DOM measurement, stated honestly:** it directly covers the 6 items in the two `dropdown-menu` fixtures. `menubar` (11) and `context-menu` (4) cannot be forced open the same way — Radix opens them via a menubar `value` and a real right-click — so their inertness rests on the zero-read derivation above plus the corpus suites. My first attempt at this harness was discarded outright: without registering the renderers it fell back to a raw-JSON dump, and its control caught it.

**Suites**, on the final commit `8595e42`:

```
pnpm exec vitest run \
  examples/schema-catalog/test/component-fixture-declared-keys.test.ts \
  examples/schema-catalog/test/safe-validate-corpus-6318.test.ts \
  examples/schema-catalog/test/catalog-authored-key-6805-6806.test.tsx \
  examples/schema-catalog/test/catalog-gallery-render.test.tsx
=> Test Files 4 passed (4) · Tests 659 passed (659)   [RUN root: objectui-issue-7072]
```

659 = the prior 656 plus this PR's 3 new tests. Confirmed by name under `--reporter=verbose` rather than by an aggregate count:

```
✓ catalog corpus: no overlay-menu item authors the undeclared `value` key (objectui#7072) > the sweep reaches all three container shapes and every one of their items — non-vacuity
✓ catalog corpus: no overlay-menu item authors the undeclared `value` key (objectui#7072) > no overlay-menu item authors `value`
✓ catalog corpus: no overlay-menu item authors the undeclared `value` key (objectui#7072) > counter-probe: the same sweep DOES flag a `value` key put back into a real fixture
```

Run root-relative from the repo root, per #3378 — the `RUN v4.1.10 /home/user/objectui-issue-7072` banner confirms it did not silently re-root onto `apps/console`.

**Type-check.** `pnpm --filter @object-ui/example-schema-catalog type-check` (the package spells it hyphenated) => EXIT 0, 0 errors, with the script body echoed (`tsc --noEmit && tsc -p tsconfig.test.json`) so a zero-match filter cannot pass for a green. ⚠️ The package's main `tsconfig.json` **excludes `test/`**, so that green would say nothing about the new pin on its own; `--listFiles` confirms `component-fixture-declared-keys.test.ts` is really in the `tsconfig.test.json` program (889 files). The dependency closure was built first — before it, every test file in the package reported `Cannot find module '@object-ui/types/zod'`, including ones this PR never touches.

**Gates**, on `8595e42`, exit codes captured before any pipe:

| gate | exit |
|---|--:|
| `check:control-bytes` | 0 |
| `changeset:check` | 0 |
| `check:doc-types` | 0 |
| `check:icon-record-names` | 0 |
| `check:docs-route-closure` | 0 |
| `check-changeset-presence.mjs` | 0 |

Gate family derived by hand from this repo's own `package.json` and `.github/workflows/` — `scripts/pm/dispatch-gates.mjs` lives only in `objectstack` and would have answered about that tree.

**Changeset.** The presence gate's verdict line, verbatim:

> `✅  No source or published contract of a released package changed in this range, so no changeset is owed.`

`examples/schema-catalog` is `private: true`, so the artifact is an **empty-frontmatter** changeset (`.changeset/7072-catalog-menu-value-keys.md`) — ⛔ not a `patch` bump, which would falsely claim a released package changed. Adding a test does not change that. ⛔ No `skip-changeset` label: in this repo that label is a historical mis-mint that no workflow reads.

**Lint.** `pnpm exec eslint examples/schema-catalog/test/component-fixture-declared-keys.test.ts` => EXIT 0, and `--format json` confirms the file was **actually linted** (0 errors, 0 warnings, no "File ignored" message) rather than silently skipped. The four JSON fixtures and the changeset carry no eslint configuration and report as ignored. Plain form; ⛔ no `--no-inline-config`.

## Absorber check — #6810 is ruled, and it rules *for* this shape

The dispatch flagged #6810 as a possible absorber, expected to be undecided. It is not — it was ruled twice, and the second ruling adopted the middle state: **narrow ratchet, ⛔ no general extractor**, with option A (the family-wide sweep) `明确不采` and never-before-seen keys taking option C — `人手撞见、逐例修 + 补钉`. So this card is not a row of a sweep; it is exactly the hand fix that ruling prescribes, and the pin above is its second half.

## Filed, not fixed

- **#7101** — the same fixture authors `variant: "destructive"` on its Delete item; also undeclared on both arms and unread by all three renderers (`dropdown-menu.tsx` maps items with **no spread**). ⛔ Not a mechanical delete: shadcn's `DropdownMenuItem` really does ship a destructive variant, so "declare and render it" is a defensible opposite repair. That is the #6829 shape and needs a decision.
- **#7102** — `context-menu-item-icon.test.tsx:169-173` and `dropdown-menu-item-icon.test.tsx:122-124` transcribe these fixtures inline *including* `value`, so the phantom spelling survives this PR as copyable example code. Mechanical to fix, but in `packages/components` — a different package and gate family.

⛔ `#7077` is not addressed here; its `buttons[].value` population is a different component family.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_