### PR TITLE
feat(types)!: retire ChartDataSeries.data, correct categories' prose (#6896)

### DIFF
--- a/.changeset/6896-retire-chart-inline-data.md
+++ b/.changeset/6896-retire-chart-inline-data.md
@@ -1,0 +1,83 @@
+---
+'@object-ui/types': minor
+---
+
+Retire `ChartDataSeries.data`, and correct `ChartSchema.categories`' prose to the read it
+has always had (objectui#6896, ADR-0049 enforce-or-remove; maintainer ruling 2026-08-31).
+
+⚠️ **BREAKING for anyone authoring a static `ChartSchema` node**, shipped as `minor`
+because this repository's `major` is a cross-repo pin to `@objectstack`'s major rather than
+a severity dial. The break is announced here, which is the channel that carries it.
+
+## `ChartDataSeries.data` — RETIRED
+
+`data: number[]` was **required** on every authored series and read by nothing.
+`normalizeChartSchema`'s `normalizeSeries` (`@object-ui/plugin-charts`) reads `dataKey` /
+`name`, `label`, `chartType` / `type`, `variant`, `opacity`, `dashArray`, `stack`, `yAxis`
+and `color` — `data` is not among them. Rows come from the chart node's **chart-level**
+`data`, a key `ChartSchema` never declared at all, which survives only because `BaseSchema`
+carries an index signature and so suppresses excess-property checking on chart literals.
+The declaration therefore demanded numbers no reader consumed, and no author could omit
+them.
+
+FROM → TO:
+
+- `data: number[]` (required) → **`data?: never`**, an ADR-0049 retirement tombstone. Put
+  the rows on the chart node's chart-level `data`, name the column with the series' `name`
+  (or `dataKey`), and put the category axis on `xAxisKey`.
+
+The accept set moves in **both** directions, and both are deliberate:
+
+- **narrowing** — `{ name: 'Revenue', data: [1, 2, 3] }` was accepted and is now refused;
+- **widening** — `{ name: 'Revenue' }` was refused (`data` was required) and is now
+  accepted, which is the shape the renderer has always read.
+
+Deleting the member outright was the option **not** taken: `ChartDataSeriesSchema` is a
+non-strict `z.object`, which strips an undeclared key in silence — one silent no-op traded
+for another. The tombstone keeps the key declared and unwritable, so an authored value is a
+**named refusal carrying its own remedy**: `?: never` on the interface (a `tsc` error at the
+authoring site) and `retirementTombstone()` on the Zod mirror (`code: 'invalid_type'`, the
+key named in the issue `path`, the migration note as the message). Per the ruling —
+创业阶段不渐进 — the tombstone is immediate: there is no deprecation window and no
+dual-reading period.
+
+## `ChartSchema.categories` — NOT retired; its prose was wrong
+
+The key keeps its behaviour. It is read as an **alternative series list**, consulted only
+when `series` is absent, each entry normalized through the same series normalizer where a
+bare string means `{ dataKey }` — so the strings name **columns to plot**. The category axis
+comes from `xAxisKey` / `xAxis`. The docblock said "X-axis labels/categories", so an author
+following the documentation got a different chart from the documented one. Prose follows
+machine: the docblock, the `ChartDataSeries` header (which promised numbers "positionally
+aligned with the chart's `categories`", a model that never existed) and the Zod
+`.describe()` were corrected to the read. No behaviour changed, and `categories` remains
+writable.
+
+## The census behind the retirement, re-measured on this branch
+
+Re-measured at merge-base `2c3cd1b75` rather than inherited from the card, with a control
+that had to hit in the same query — the instrument was not blind: it scores
+`packages/types/src/__tests__/report-schema-authoring-face.test.ts` **4** authoring sites.
+
+⚠️ One correction to the record the ruling rests on. The ruling states *zero* authorship of
+a populated `series[].data` outside tests across `packages/` / `apps/` / `examples/`. The
+re-measurement finds **one such site inside those roots** —
+`packages/types/examples/data-display-examples.json` (2 series) — plus **four outside**
+them, in documentation: `content/docs/api/schema-reference.md` (3) and
+`content/docs/core/report-schema.mdx` (1).
+
+Every one of the five is documentation or an unreferenced example, **not a consumer**: none
+is imported, type-checked, parsed by a test or rendered anywhere, `packages/types` does not
+publish its `examples/` directory, and each authors the *documented* model — month names in
+`categories` next to inline `series[].data` — which renders an empty chart today, because
+`data` is dropped and `categories` is ignored whenever `series` is present. They are
+instances of the divergence this change closes rather than users of a working inline-data
+model, so the ruling's conclusion is unaffected. Their migration is filed separately; until
+it lands, an author copying them now trips the tombstone and reads the remedy instead of
+being silently dropped.
+
+Pinned in `packages/types/src/__tests__/chart-inline-data-retired.test.ts` — both channels,
+the announcement itself, and a counter-probe that builds the deletion this retirement did
+not choose and measures the contrast in the same run — and in
+`packages/plugin-charts/src/normalizeChartSchema.test.ts`, where the `categories` read now
+has behaviour coverage it never had.

--- a/packages/plugin-charts/src/normalizeChartSchema.test.ts
+++ b/packages/plugin-charts/src/normalizeChartSchema.test.ts
@@ -288,3 +288,68 @@ describe('domainFor', () => {
     expect(domainFor(undefined)).toBeUndefined();
   });
 });
+
+/**
+ * `categories` is an ALTERNATIVE SERIES LIST, not axis labels (objectui#6896).
+ *
+ * `@object-ui/types` declared this key as "X-axis labels/categories" while this
+ * normalizer read it as a fallback series list, so an author following the
+ * documentation got a different chart from the documented one. The maintainer
+ * ruled prose follows machine (2026-08-31): the declaration was corrected to
+ * this reading, and these are the pins that make the reading a contract instead
+ * of an accident. If any of these change, `ChartSchema.categories`' docblock and
+ * its zod `.describe()` are the other half of the edit.
+ */
+describe('normalizeChartSchema — `categories` is a series list (objectui#6896)', () => {
+  it('reads each category as a COLUMN NAME when `series` is absent', () => {
+    const out = normalizeChartSchema({
+      type: 'bar',
+      xAxisKey: 'month',
+      categories: ['revenue', 'expenses'],
+    });
+    // Bare strings go through `normalizeSeries`' shorthand branch as `{ dataKey }`.
+    expect(out.series).toEqual([{ dataKey: 'revenue' }, { dataKey: 'expenses' }]);
+  });
+
+  it('does NOT put categories on the category axis — that is `xAxisKey`/`xAxis`', () => {
+    const out = normalizeChartSchema({
+      type: 'bar',
+      xAxisKey: 'month',
+      categories: ['Jan', 'Feb', 'Mar'],
+    });
+    // The axis is untouched by `categories`; the month names became series.
+    expect(out.xAxisKey).toBe('month');
+    expect(out.series).toEqual([{ dataKey: 'Jan' }, { dataKey: 'Feb' }, { dataKey: 'Mar' }]);
+  });
+
+  it('leaves the axis unset when `categories` is the only axis-ish key present', () => {
+    // The shape an author following the OLD docblock would have written: month
+    // names in `categories`, expecting an x-axis. They get series bindings and
+    // no axis at all — the divergence objectui#6896 recorded, pinned so the
+    // corrected prose cannot drift back.
+    const out = normalizeChartSchema({ type: 'bar', categories: ['Jan', 'Feb'] });
+    expect(out.xAxisKey).toBeUndefined();
+    expect(out.series).toEqual([{ dataKey: 'Jan' }, { dataKey: 'Feb' }]);
+  });
+
+  it('IGNORES `categories` entirely when `series` is present', () => {
+    const out = normalizeChartSchema({
+      type: 'bar',
+      categories: ['Jan', 'Feb', 'Mar'],
+      series: [{ name: 'revenue' }],
+    });
+    expect(out.series).toEqual([{ dataKey: 'revenue' }]);
+  });
+
+  it('drops a series\' retired inline `data` — the read objectui#6896 retired', () => {
+    // The tombstone lives in `@object-ui/types`; this is the renderer-side fact
+    // that made it a tombstone rather than a missing feature. `data` reaches
+    // `normalizeSeries` and comes out nowhere.
+    const out = normalizeChartSchema({
+      type: 'bar',
+      series: [{ name: 'revenue', data: [1, 2, 3] }],
+    });
+    expect(out.series).toEqual([{ dataKey: 'revenue' }]);
+    expect(out.series?.[0]).not.toHaveProperty('data');
+  });
+});

--- a/packages/plugin-charts/src/normalizeChartSchema.ts
+++ b/packages/plugin-charts/src/normalizeChartSchema.ts
@@ -298,6 +298,17 @@ export function normalizeChartSchema(schema: unknown): NormalizedChartSchema {
   if (yAxes.length) out.yAxes = yAxes;
 
   // ── series ──────────────────────────────────────────────────────────────
+  // ⚠️ `categories` is an ALTERNATIVE SERIES LIST here, not axis labels, and
+  // this branch is the whole of its meaning: it is consulted only when `series`
+  // is absent, and each entry then goes through `normalizeSeries`, whose bare-
+  // string branch reads it as `{ dataKey }` — a COLUMN NAME. The category axis
+  // is resolved separately, from `xAxisKey` / `xAxis` above.
+  //
+  // `@object-ui/types` documented this key as "X-axis labels/categories" until
+  // objectui#6896; the declaration was corrected to this reading rather than
+  // this reading to the declaration (maintainer ruling 2026-08-31 — prose
+  // follows machine). Pinned in `normalizeChartSchema.test.ts`; if you change
+  // what `categories` means here, that docblock is the other half of the edit.
   const rawSeries = Array.isArray(schema.series)
     ? schema.series
     : Array.isArray(schema.categories)

--- a/packages/types/src/__tests__/chart-inline-data-retired.test.ts
+++ b/packages/types/src/__tests__/chart-inline-data-retired.test.ts
@@ -1,0 +1,254 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ChartDataSeries.data` is an ADR-0049 RETIREMENT TOMBSTONE, and `categories`
+ * is NOT retired — it is live with corrected prose (objectui#6896, maintainer
+ * ruling 2026-08-31, decision batch #20 ③).
+ *
+ * ## What was measured
+ *
+ * The static `ChartSchema` node declared two data keys that its renderer does
+ * not implement the way the declaration said:
+ *
+ *   1. `data: number[]` was REQUIRED on every authored series and read by
+ *      nothing. `normalizeChartSchema`'s `normalizeSeries`
+ *      (`@object-ui/plugin-charts`) reads `dataKey`/`name`, `label`,
+ *      `chartType`/`type`, `variant`, `opacity`, `dashArray`, `stack`, `yAxis`
+ *      and `color` — `data` is not among them. Rows come from the chart-level
+ *      `data`, a key `ChartSchema` never declared at all, which survives only
+ *      because `BaseSchema` carries an index signature.
+ *   2. `categories` was documented as "X-axis labels/categories" and is read as
+ *      an ALTERNATIVE SERIES LIST — consulted only when `series` is absent, each
+ *      entry normalized as `{ dataKey }`. The category axis comes from
+ *      `xAxisKey` / `xAxis`.
+ *
+ * The ruling split them: (1) is retired, immediately and without a dual-reading
+ * window; (2) keeps its behaviour and its prose was corrected to match — prose
+ * follows machine. Fixing only (1) was named as NOT a valid landing, so both
+ * halves are pinned here.
+ *
+ * ## Why a tombstone and not a deletion
+ *
+ * `ChartDataSeriesSchema` is a NON-STRICT `z.object`, so a deleted key is
+ * silently STRIPPED — one silent no-op traded for another. The tombstone keeps
+ * the key DECLARED and unwritable: `?: never` on the interface (a `tsc` error at
+ * the authoring site) and `retirementTombstone()` on the mirror (a parse refusal
+ * whose message IS the migration note). The COUNTER-PROBE below builds the
+ * deletion that was not chosen, in this same run, and measures the difference —
+ * so "simplifying" the tombstone into a deletion turns this file red instead of
+ * quietly restoring the silence.
+ *
+ * The `@ts-expect-error` directives are REAL enforcement: this package
+ * type-checks its tests through `tsconfig.test.json`, so re-widening the
+ * declaration fails the build on the unused directive.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { ChartDataSeries, ChartSchema } from '../data-display';
+import { ChartDataSeriesSchema, ChartSchema as ChartZodSchema } from '../zod/data-display.zod';
+
+/** A series authored the way the renderer actually reads one. */
+const LIVE_SERIES = { name: 'Revenue', type: 'line', color: '#3b82f6' } as const;
+
+/** The value an author following the old declaration would have written. */
+const RETIRED_VALUE = [12000, 15000, 18000] as const;
+
+const shapeOf = (schema: unknown): Record<string, unknown> =>
+  (schema as { shape: Record<string, unknown> }).shape;
+
+const describeOf = (schema: unknown, key: string): string | undefined =>
+  (shapeOf(schema)[key] as { description?: string } | undefined)?.description;
+
+/* ── (a) the tombstone: the `tsc` channel ────────────────────────────────── */
+
+describe('objectui#6896 — `ChartDataSeries.data` is a tombstone at the type level', () => {
+  it('refuses an authored `data` at the authoring site', () => {
+    const series: ChartDataSeries = {
+      name: 'Revenue',
+      // @ts-expect-error `data` is a retirement tombstone (objectui#6896)
+      data: [12000, 15000, 18000],
+    };
+    expect(series.name).toBe('Revenue');
+  });
+
+  it('no longer REQUIRES anything beyond `name` — the other half of the move', () => {
+    // Before the retirement this did not compile: `data` was required, so every
+    // author had to supply numbers that were then dropped. The accept set moves
+    // in BOTH directions here, and this is the widening half.
+    const series: ChartDataSeries = { name: 'Revenue' };
+    expect(series.name).toBe('Revenue');
+  });
+
+  it('keeps `categories` LIVE and writable — it was NOT retired', () => {
+    // No `@ts-expect-error`: the ruling kept this key's behaviour and corrected
+    // its prose. If this line ever needs a directive, half (b) was undone.
+    const chart: ChartSchema = {
+      type: 'chart',
+      chartType: 'bar',
+      categories: ['revenue', 'expenses'],
+      series: [],
+    };
+    expect(chart.categories).toEqual(['revenue', 'expenses']);
+  });
+});
+
+/* ── (a) the tombstone: the parse channel, refusing loudly ───────────────── */
+
+describe('objectui#6896 — the mirror REFUSES `data`, and the refusal carries its remedy', () => {
+  it('a live series still parses GREEN — the non-vacuity control, in this test', () => {
+    // Without this, a mirror that refused everything would satisfy every
+    // assertion below by accident.
+    const control = ChartDataSeriesSchema.safeParse(LIVE_SERIES);
+    expect(control.success).toBe(true);
+    if (control.success) {
+      expect(control.data.name).toBe('Revenue');
+      expect(control.data.type).toBe('line');
+    }
+  });
+
+  it('a bare `{ name }` series parses green — `data` is no longer required', () => {
+    const result = ChartDataSeriesSchema.safeParse({ name: 'Revenue' });
+    expect(result.success).toBe(true);
+  });
+
+  it('refuses `data`, names it in the path, and answers with its own guidance', () => {
+    const result = ChartDataSeriesSchema.safeParse({ ...LIVE_SERIES, data: [...RETIRED_VALUE] });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const issue = result.error.issues.find((i) => String(i.path[0]) === 'data');
+    expect(issue, 'no issue addressed to `data`').toBeDefined();
+
+    // The accept-set contract: the same address and the same code a bare
+    // `z.never()` reports. A `refine`-based spelling would report `custom`.
+    expect(issue!.code).toBe('invalid_type');
+    expect(issue!.path).toEqual(['data']);
+
+    // The message is the migration note, not zod's generic string.
+    expect(issue!.message).not.toContain('Invalid input: expected never, received ');
+    expect(issue!.message).toContain('RETIRED (objectui#6896)');
+    expect(issue!.message).toContain('`xAxisKey`');
+
+    // ONE string, BOTH channels — the invariant `retirementTombstone()` exists
+    // to make unbreakable. Asserted derived, which is why the literal anchors
+    // above sit beside it: two empty strings are also equal.
+    expect(issue!.message).toBe(describeOf(ChartDataSeriesSchema, 'data'));
+  });
+
+  it('refuses it through the whole chart node, not just the bare series', () => {
+    const result = ChartZodSchema.safeParse({
+      type: 'chart',
+      chartType: 'bar',
+      series: [{ name: 'Revenue', data: [...RETIRED_VALUE] }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.join('.') === 'series.0.data');
+      expect(issue, 'no issue addressed to `series.0.data`').toBeDefined();
+      expect(issue!.message).toContain('RETIRED (objectui#6896)');
+    }
+  });
+});
+
+/* ── ANNOUNCED, not merely gone ──────────────────────────────────────────── */
+
+describe('objectui#6896 — the retirement is ANNOUNCED', () => {
+  it('`data` stays in the mirror\'s shape — a tombstone is DECLARED, just unwritable', () => {
+    expect(shapeOf(ChartDataSeriesSchema)).toHaveProperty('data');
+    const text = describeOf(ChartDataSeriesSchema, 'data');
+    expect(text).toBeDefined();
+    expect(text).toContain('RETIRED (objectui#6896)');
+    // The announcement names a REMEDY, not just a removal. This is the half a
+    // silent deletion cannot carry at all.
+    expect(text).toContain('chart-level `data`');
+    expect(text).toContain('`xAxisKey`');
+  });
+});
+
+/* ── THE COUNTER-PROBE: the deletion this retirement did not choose ──────── */
+
+describe('objectui#6896 — the counter-probe: a deletion would restore the silence', () => {
+  /**
+   * The same series schema with `data` simply ABSENT — non-strict, exactly as
+   * `ChartDataSeriesSchema` is. Built here so the contrast is measured in this
+   * run rather than recalled from a comment.
+   */
+  const DELETION_SHAPED = z.object({
+    name: z.string(),
+    type: z.enum(['bar', 'line', 'area']).optional(),
+    color: z.string().optional(),
+  });
+
+  it('the deletion ACCEPTS an authored `data` and strips it in silence', () => {
+    const result = DELETION_SHAPED.safeParse({ ...LIVE_SERIES, data: [...RETIRED_VALUE] });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).not.toHaveProperty('data');
+  });
+
+  it('the deletion announces NOTHING — no shape entry, no guidance', () => {
+    expect(shapeOf(DELETION_SHAPED)).not.toHaveProperty('data');
+    expect(describeOf(DELETION_SHAPED, 'data')).toBeUndefined();
+  });
+
+  it('the shipped schema does the OPPOSITE on the same input — refuses, and says why', () => {
+    // This is the probe. If the tombstone is ever "simplified" into a deletion,
+    // the shipped schema starts behaving like DELETION_SHAPED above and this
+    // assertion goes red — which is the whole reason the contrast is built here
+    // instead of being asserted about the shipped schema alone.
+    const shipped = ChartDataSeriesSchema.safeParse({ ...LIVE_SERIES, data: [...RETIRED_VALUE] });
+    const deleted = DELETION_SHAPED.safeParse({ ...LIVE_SERIES, data: [...RETIRED_VALUE] });
+    expect(deleted.success).toBe(true);
+    expect(shipped.success).toBe(false);
+    expect(describeOf(ChartDataSeriesSchema, 'data')).toBeDefined();
+  });
+
+  it('an UNDECLARED key still rides through — the silence a tombstone is measured against', () => {
+    const result = ChartDataSeriesSchema.safeParse({ ...LIVE_SERIES, notAKeyAtAll: 'anything' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).not.toHaveProperty('notAKeyAtAll');
+  });
+});
+
+/* ── (b) `categories`: prose follows machine ─────────────────────────────── */
+
+describe('objectui#6896 — `categories` is live, and its prose now states the read', () => {
+  it('still parses a list of strings — the behaviour is untouched', () => {
+    const result = ChartZodSchema.safeParse({
+      type: 'chart',
+      chartType: 'bar',
+      categories: ['revenue', 'expenses'],
+      series: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('the published description says SERIES LIST, and denies the axis reading', () => {
+    // The docblock in `../data-display.ts` is the other half of this pair; the
+    // behaviour itself is pinned in `@object-ui/plugin-charts`'
+    // `normalizeChartSchema.test.ts`, which is where the read lives.
+    const text = describeOf(ChartZodSchema, 'categories');
+    expect(text).toBeDefined();
+    expect(text).toContain('series list');
+    expect(text).toContain('`series` is absent');
+    expect(text).toContain('NOT axis labels');
+    // The correction is the point: the old text must not survive anywhere in
+    // the published metadata.
+    expect(text).not.toContain('X-axis categories');
+  });
+
+  it('is NOT a tombstone — writing it is accepted, unlike `data`', () => {
+    const written = ChartDataSeriesSchema.safeParse({ ...LIVE_SERIES, data: [1] });
+    const live = ChartZodSchema.safeParse({
+      type: 'chart', chartType: 'bar', categories: ['a'], series: [],
+    });
+    expect(written.success).toBe(false);
+    expect(live.success).toBe(true);
+  });
+});

--- a/packages/types/src/__tests__/report-schema-authoring-face.test.ts
+++ b/packages/types/src/__tests__/report-schema-authoring-face.test.ts
@@ -135,10 +135,11 @@ describe('objectui#6121 — ChartDataSeries declares the per-series family overr
   >;
 
   it('accepts the series shape the documentation authors', () => {
+    // `data` was authored here until objectui#6896 retired it — the series
+    // NAMES a column on the chart-level `data`, it does not carry numbers.
     const series: ChartDataSeries = {
       name: 'Revenue',
       type: 'line',
-      data: [120000, 145000, 132000],
     };
     expect(series.type).toBe('line');
     // The zod twin moves in lockstep — an unmirrored key is what
@@ -148,14 +149,16 @@ describe('objectui#6121 — ChartDataSeries declares the per-series family overr
 
   it('rejects a family the normalizer would silently drop', () => {
     // @ts-expect-error 'pie' is not a per-series override the renderer performs
-    const bad: ChartDataSeries = { name: 'Revenue', type: 'pie', data: [1] };
+    const bad: ChartDataSeries = { name: 'Revenue', type: 'pie' };
     expect(bad).toBeTruthy();
-    expect(ChartDataSeriesSchema.safeParse({ name: 'Revenue', type: 'pie', data: [1] }).success)
+    // No `data` here: it would make this refusal ambiguous between the family
+    // union and objectui#6896's tombstone, and this pin is about the union.
+    expect(ChartDataSeriesSchema.safeParse({ name: 'Revenue', type: 'pie' }).success)
       .toBe(false);
   });
 
   it('leaves the override optional — a plain inline series still parses', () => {
-    const plain: ChartDataSeries = { name: 'Revenue', data: [1, 2, 3] };
+    const plain: ChartDataSeries = { name: 'Revenue' };
     expect(ChartDataSeriesSchema.parse(plain).type).toBeUndefined();
   });
 });

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -1205,9 +1205,16 @@ export interface TreeViewSchema extends BaseSchema {
 export type ChartType = SpecChartType;
 
 /**
- * One inline-data series of the objectui `ChartSchema` node — a display name
- * plus the literal numbers to plot, positionally aligned with the chart's
- * `categories`.
+ * One series of the objectui `ChartSchema` node — a display name that also
+ * NAMES THE COLUMN to plot, plus that column's presentation options.
+ *
+ * ⚠️ It carries no numbers of its own. Rows come from the chart node's
+ * chart-level `data`, `name` (or `dataKey`) selects the column within each row,
+ * and the category axis comes from `xAxisKey` / `xAxis`. That is the model
+ * `normalizeChartSchema` in `@object-ui/plugin-charts` implements, and the only
+ * one it has ever implemented. This header described an inline `data` array
+ * indexed by the chart's `categories` until objectui#6896 measured that no such
+ * reader exists; `data` is now a retirement tombstone — see the member below.
  *
  * Renamed off `ChartSeries` (objectstack#4115): `@objectstack/spec/ui` owns that
  * name for a **dataset-bound series descriptor** — `{ name, label?, type?,
@@ -1223,9 +1230,20 @@ export interface ChartDataSeries {
    */
   name: string;
   /**
-   * Series data points
+   * RETIRED (objectui#6896, ADR-0049 enforce-or-remove) — the inline-data model
+   * this key belonged to was never implemented. `normalizeChartSchema`'s
+   * `normalizeSeries` reads `dataKey`/`name`, `label`, `chartType`/`type`,
+   * `variant`, `opacity`, `dashArray`, `stack`, `yAxis` and `color`; `data` is
+   * not among them, so an authored array was dropped in silence — while the
+   * declaration made it REQUIRED, so no author could leave it out.
+   *
+   * Put the rows on the chart node's own chart-level `data`, name the column
+   * with this series' `name` (or `dataKey`), and put the category axis on
+   * `xAxisKey`. Maintainer ruling 2026-08-31: immediate tombstone, no
+   * dual-reading window.
+   * @deprecated Not part of `ChartDataSeries`' contract — the value was inert.
    */
-  data: number[];
+  data?: never;
   /**
    * Per-series chart family override, for a combo chart: this series draws as a
    * line (or bar, or area) on a chart whose own `chartType` is something else.
@@ -1273,7 +1291,17 @@ export interface ChartSchema extends BaseSchema {
    */
   description?: string;
   /**
-   * X-axis labels/categories
+   * An ALTERNATIVE SERIES LIST — not axis labels.
+   *
+   * ⚠️ Read this before authoring. `normalizeChartSchema` consumes `categories`
+   * only when `series` is absent, and then runs each entry through the same
+   * series normalizer, where a bare string means `{ dataKey }`. So these strings
+   * name COLUMNS TO PLOT, exactly as `series` does — they do not label the
+   * category axis, and when `series` IS present they are ignored outright.
+   *
+   * The category axis comes from `xAxisKey` / `xAxis`. This docblock read
+   * "X-axis labels/categories" until objectui#6896 measured the read that has
+   * always been there (maintainer ruling 2026-08-31 — prose follows machine).
    */
   categories?: string[];
   /**

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -338,10 +338,25 @@ export const ChartTypeSchema = SpecChartTypeSchema;
  * dataset-bound series (no `data`, plus `type`/`stack`/`yAxis`/`variant`), so a
  * consumer importing `ChartSeriesSchema` from `@object-ui/types` could not tell
  * which contract they had.
+ *
+ * ⚠️ Since objectui#6896 this twin carries no inline numbers either: `data` is a
+ * retirement tombstone. The distinction the rename drew is now one of ROLE, not
+ * of payload — this is the STATIC SDUI node's series, the spec's is the
+ * dataset-bound one, and neither carries values.
  */
 export const ChartDataSeriesSchema = z.object({
   name: z.string().describe('Series name'),
-  data: z.array(z.number()).describe('Series data points'),
+  // ADR-0049 RETIREMENT TOMBSTONE (objectui#6896). Deleting the member was the
+  // option NOT taken: `ChartDataSeriesSchema` is a non-strict `z.object`, which
+  // STRIPS an undeclared key in silence — the same silent no-op the retirement
+  // exists to end. Kept declared and unwritable, so an authored value is a
+  // NAMED refusal carrying its own remedy.
+  data: retirementTombstone(
+    'RETIRED (objectui#6896) — `ChartDataSeries.data` was never read: '
+    + '`normalizeChartSchema` takes rows from the chart node\'s chart-level `data` and picks a '
+    + 'column with the series\' `name`/`dataKey`, so an authored array was dropped in silence. '
+    + 'Delete the key; put the rows on the chart-level `data` and the category axis on `xAxisKey`.',
+  ),
   // Mirrors `ChartDataSeries.type` (objectui#6121). The three families are the
   // ones `normalizeChartSchema` actually honours as a per-series override; see
   // the TS declaration for the read this narrowness is taken from.
@@ -357,7 +372,15 @@ export const ChartSchema = BaseSchema.extend({
   chartType: ChartTypeSchema.describe('Chart type'),
   title: z.string().optional().describe('Chart title'),
   description: z.string().optional().describe('Chart description'),
-  categories: z.array(z.string()).optional().describe('X-axis categories'),
+  // NOT axis labels — `normalizeChartSchema` reads `categories` as an
+  // ALTERNATIVE SERIES LIST, used only when `series` is absent (objectui#6896).
+  categories: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Alternative series list — column names to plot, used only when `series` is absent. '
+      + 'NOT axis labels: the category axis comes from `xAxisKey`/`xAxis`.',
+    ),
   series: z.array(ChartDataSeriesSchema).describe('Chart data series'),
   height: z.union([z.string(), z.number()]).optional().describe('Chart height'),
   width: z.union([z.string(), z.number()]).optional().describe('Chart width'),


### PR DESCRIPTION
Fixes #6896

⛔ **Draft, and it stops here.** Clause ② applies: this narrows the accept set of a published
`@object-ui/types` surface, so it waits on contract review. Not ready, not enqueued, no
auto-merge — and the dispatch tier for this build was **opus** under the maintainer's standing
quota exemption (2026-08-13) after fable returned HTTP 429, so the merge-queue prohibition is
unchanged. `needs:contract-review` attached with this PR, not before it.

Implements the maintainer's ruling of 2026-08-31 (决裁批 #20 ③, 「其他同意」). Both halves land;
the ruling named half (a) alone as not a valid landing.

## (a) `ChartDataSeries.data` — RETIRED, announced

`data: number[]` was **required** on every authored series and read by nothing.
`normalizeSeries` (`packages/plugin-charts/src/normalizeChartSchema.ts:232`) reads
`dataKey`/`name`, `label`, `chartType`/`type`, `variant`, `opacity`, `dashArray`, `stack`,
`yAxis`, `color`. `data` is not among them. Rows come from the chart-level `data` — a key
`ChartSchema` never declared at all, surviving only because `BaseSchema` carries an index
signature, which is why no gate ever saw this.

`data: number[]` → **`data?: never`** plus `retirementTombstone()` on the Zod mirror. Deleting
the member was the option not taken: `ChartDataSeriesSchema` is a non-strict `z.object`, so a
deletion strips an authored value in silence — one silent no-op traded for another. Immediate
tombstone, no dual-reading window.

The accept set moves in **both** directions, both deliberate:

| | before | after |
|---|---|---|
| `{ name: 'Revenue', data: [1,2,3] }` | accepted | **refused**, named, with the remedy |
| `{ name: 'Revenue' }` | refused (`data` required) | **accepted** — the shape the renderer reads |

## (b) `categories` — live, with corrected prose

Not retired. It is read as an **alternative series list**, consulted only when `series` is
absent, each entry normalized as `{ dataKey }` — so the strings name columns to plot. The
category axis comes from `xAxisKey` / `xAxis` (`:290-292`). The docblock said "X-axis
labels/categories", so an author following the documentation got a different chart from the
documented one. Prose follows machine: the `ChartSchema.categories` docblock, the
`ChartDataSeries` header (which promised numbers "positionally aligned with the chart's
`categories`", a model that never existed) and the Zod `.describe()` now state the read.
Behaviour is byte-identical; `categories` stays writable.

## The census, re-measured — with a correction to the record

Re-measured at merge-base `2c3cd1b75`, with a control that had to hit in the same query. The
instrument was **not blind**: it scores 4 authoring sites in
`packages/types/src/__tests__/report-schema-authoring-face.test.ts`.

⚠️ The ruling states *zero* authorship of a populated `series[].data` outside tests across
`packages/` / `apps/` / `examples/`. That is **off by one site inside those roots**:

- `packages/types/examples/data-display-examples.json` — 2 series (inside `packages/`)
- `content/docs/api/schema-reference.md` — 3 series (outside the scanned roots)
- `content/docs/core/report-schema.mdx` — 1 series (outside the scanned roots)

**The ruling's conclusion is unaffected, and these strengthen it.** None is a consumer: nothing
imports, type-checks, parses or renders any of them (`packages/types` ships only `dist`,
`README.md`, `CHANGELOG.md`, `LICENSE`, so `examples/` is not published; the mdx site sits in a
`plaintext` fence, so no doc gate covers it). Each authors the *documented* model — month names
in `categories` beside inline `series[].data` — which renders an **empty chart today**, because
`data` is dropped and `categories` is ignored whenever `series` is present. They are instances
of the divergence this PR closes, not users of a working inline-data model.

They are **out of scope here by file surface** and filed separately; until that lands, an author
copying them trips the tombstone and reads the remedy instead of being dropped in silence.

## Mechanism note for the reviewer

The dispatch expected an "ADR-0087 retirement registry and its generated baselines". objectui has
**no such files**: neither ADR-0049 nor ADR-0087 exists under `docs/adr/` here — both are
upstream `@objectstack` ADRs referenced by convention, and the retirement "registry" in this repo
*is* the declaration pair (`?: never` + `retirementTombstone()`) plus its pin test. That is the
shape #6949 landed (changeset, pin test, interface, Zod mirror — no registry file, no generated
baselines), and this PR follows it. Nothing was skipped; the artifacts do not exist.

## Verification

Run on the exact commit under review, `9d53bee5d`. Exit codes captured before any pipe.

| check | exit | verdict line |
|---|---|---|
| `vitest` (4 affected files) | 0 | `Test Files 4 passed (4) · Tests 70 passed (70)` |
| `vitest` full `types` + `plugin-charts` | 0 | `Test Files 117 passed (117) · Tests 1266 passed (1266)` |
| `@object-ui/types` `type-check` | 0 | `Done` — `tsc --noEmit && tsconfig.examples.json && tsconfig.test.json` |
| `@object-ui/plugin-charts` `type-check` | 0 | clean, after building its closure |
| `lint` (both packages) | 0 | `0 errors` (260 + 267 pre-existing warnings) |
| `check:changeset-no-major` | 0 | `No changeset declares a major bump.` |
| `check:changeset-presence` | 0 | `5 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check:doc-snippets` | 0 | `271 of 271 block(s) judged, 0 failed` (sentinel controls fired) |
| `check:doc-types` | 0 | `Every documented component type is registered.` |
| `check:spec-symbol-derivation` | 0 | `1329 files scanned … 0 untriaged collisions` |
| `check:readme-exports` | 0 | `386 self-imports judged (386 real, 0 wrong-path, 0 fabricated)` |
| `check:control-bytes` | 0 | `OK (scanned 5883 tracked text file(s))` |
| `check:phantom-deps` / `self-import` / `vi-mock-specifiers` / `esm-specifiers` | 0 | clean |

Two gates first returned **NOT MEASURED**, and neither is reported as a pass: `check:doc-snippets`
answered `PRECONDITION NOT MET (exit 2)` and `check:readme-exports` exit 1 with
`type entry not on disk` — both the unbuilt dependency closure. Both were re-run to exit 0 after
building what they name. `plugin-charts` `type-check` failed the same way (TS2307 on
`@object-ui/core` / `components` / `react`) before its closure was built.

`@ts-expect-error` enforcement is real here and was verified rather than assumed: `tsc -p
tsconfig.test.json --listFiles` confirms both the new pin and the edited pin are inside the
project, so a re-widened declaration fails the build on the unused directive.

### The counter-probe, and the ablation that proves it fires

`chart-inline-data-retired.test.ts` builds the **deletion this retirement did not choose** — the
same series schema with `data` simply absent — and measures the contrast in the same run: the
deletion accepts an authored `data` and strips it silently, the shipped schema refuses and says
why. Announcement is pinned separately (`data` stays in `.shape`; the description names both the
remedy and `xAxisKey`), so "gone" cannot pass as "retired".

Ablated to prove it is not vacuous. The tombstone was removed from the Zod mirror; the mutation
was confirmed **on disk** — `data: retirementTombstone(` occurrences dropped to 0 and the blob
hash moved from `71a1b768` — and the pin then went **red: 5 failed / 10 passed**, the failures
being exactly the refusal, the whole-node refusal, the shape/announcement pin, the counter-probe
and the `categories`-contrast pin. No rebuild leg applies: the pin imports the mirror by relative
source path (`../zod/data-display.zod`), not through `dist`, so nothing stale can answer for it.
Restore was proven the same way rather than by exit code — blob hash back to `71a1b768`, `git
diff HEAD` empty, tombstone present again — and the pin re-run green (70/70) on that restored
tree, which is the commit under review. The mutation ran under a `trap ... EXIT INT TERM` with
absolute paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_