### PR TITLE
docs: teach `content` as text's expression channel, not `value` (29 occurrences, not 23)

### DIFF
--- a/.changeset/7015-text-expression-content-channel.md
+++ b/.changeset/7015-text-expression-content-channel.md
@@ -1,0 +1,12 @@
+---
+---
+
+Docs only: the expression guides taught `"value": "${...}"` on `type: "text"`
+nodes, which the renderer reads back but never evaluates, so the reader saw the
+literal `${...}` on screen. All 29 authored occurrences now spell the carriage
+`content`, the ruled sole evaluation channel for `text` (objectui#7015,
+maintainer ruling 2026-08-31 on objectstack#13670, option 2).
+
+No package source changed, so this ships nothing — `check-changeset-presence`
+independently reports "no changeset is owed" for this diff. The declaration is
+here to state the release intent explicitly rather than to bump anything.

--- a/content/docs/blocks/block-schema.mdx
+++ b/content/docs/blocks/block-schema.mdx
@@ -303,12 +303,12 @@ const cardBlock: BlockSchema = {
           {
             type: 'text',
             variant: 'h3',
-            value: '${title}',
+            content: '${title}',
             className: 'card-title'
           },
           {
             type: 'text',
-            value: '${description}',
+            content: '${description}',
             className: 'card-description'
           },
           {

--- a/content/docs/guide/architecture.md
+++ b/content/docs/guide/architecture.md
@@ -123,7 +123,7 @@ A backend system sends a JSON schema:
   "title": "Welcome",
   "body": {
     "type": "text",
-    "value": "Hello, ${user.name}!"
+    "content": "Hello, ${user.name}!"
   }
 }
 ```
@@ -148,7 +148,7 @@ const schema: BaseSchema = {
   title: 'Welcome',
   body: {
     type: 'text',
-    value: 'Hello, ${user.name}!',
+    content: 'Hello, ${user.name}!',
   },
 }
 
@@ -180,7 +180,7 @@ The registered component renders with evaluated props:
 <!-- doc-snippet: fragment — the JSX the registry produces for step 1's schema; CardComponent and TextComponent are the placeholder components registered in the block above -->
 ```tsx
 <CardComponent title="Welcome">
-  <TextComponent value="Hello, Alice!" />
+  <TextComponent content="Hello, Alice!" />
 </CardComponent>
 ```
 
@@ -234,7 +234,7 @@ ObjectUI includes a powerful expression engine for dynamic UIs:
 ```json
 {
   "type": "text",
-  "value": "Welcome, ${user.firstName} ${user.lastName}!"
+  "content": "Welcome, ${user.firstName} ${user.lastName}!"
 }
 ```
 

--- a/content/docs/guide/dashboard-filters.md
+++ b/content/docs/guide/dashboard-filters.md
@@ -267,7 +267,7 @@ read them under the `page.` scope, keyed by the filter's `name`:
 ```json
 {
   "type": "text",
-  "value": "Region: ${page.region || 'All'}"
+  "content": "Region: ${page.region || 'All'}"
 }
 ```
 

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -588,12 +588,12 @@ language's own. A membership test is written with the array method:
 ```json
 // ❌ Bad: Too complex
 {
-  "value": "${users.filter(u => u.age > 18).map(u => ({...u, isAdult: true})).reduce((acc, u) => acc + u.score, 0)}"
+  "content": "${users.filter(u => u.age > 18).map(u => ({...u, isAdult: true})).reduce((acc, u) => acc + u.score, 0)}"
 }
 
 // ✅ Good: Pre-compute complex logic
 {
-  "value": "${adultUsersScore}"
+  "content": "${adultUsersScore}"
 }
 ```
 
@@ -616,12 +616,12 @@ language's own. A membership test is written with the array method:
 ```json
 // ❌ Bad: Might throw error
 {
-  "value": "${user.address.city}"
+  "content": "${user.address.city}"
 }
 
 // ✅ Good: Safe access
 {
-  "value": "${user.address?.city || 'N/A'}"
+  "content": "${user.address?.city || 'N/A'}"
 }
 ```
 

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -11,7 +11,7 @@ Expressions are JavaScript-like code snippets embedded in schemas using the `${}
 ```json
 {
   "type": "text",
-  "value": "Hello, ${user.name}!"
+  "content": "Hello, ${user.name}!"
 }
 ```
 
@@ -31,7 +31,7 @@ Access data properties using dot notation:
 ```json
 {
   "type": "text",
-  "value": "${user.firstName}"
+  "content": "${user.firstName}"
 }
 ```
 
@@ -42,7 +42,7 @@ Access nested objects:
 ```json
 {
   "type": "text",
-  "value": "${user.address.city}"
+  "content": "${user.address.city}"
 }
 ```
 
@@ -53,7 +53,7 @@ Access array elements:
 ```json
 {
   "type": "text",
-  "value": "${users[0].name}"
+  "content": "${users[0].name}"
 }
 ```
 
@@ -64,7 +64,7 @@ Mix expressions with static text:
 ```json
 {
   "type": "text",
-  "value": "Welcome, ${user.firstName} ${user.lastName}!"
+  "content": "Welcome, ${user.firstName} ${user.lastName}!"
 }
 ```
 
@@ -75,7 +75,7 @@ Mix expressions with static text:
 ```json
 {
   "type": "text",
-  "value": "Total: ${price * quantity}"
+  "content": "Total: ${price * quantity}"
 }
 ```
 
@@ -108,7 +108,7 @@ Supported: `&&`, `||`, `!`
 ```json
 {
   "type": "text",
-  "value": "${count > 0 ? count + ' items' : 'No items'}"
+  "content": "${count > 0 ? count + ' items' : 'No items'}"
 }
 ```
 
@@ -169,7 +169,7 @@ const data = {
 ```json
 {
   "type": "text",
-  "value": "Theme: ${settings.theme}"
+  "content": "Theme: ${settings.theme}"
 }
 ```
 
@@ -199,7 +199,7 @@ Access the current index in loops:
   "items": "${users}",
   "itemTemplate": {
     "type": "text",
-    "value": "#${index + 1}: ${item.name}"
+    "content": "#${index + 1}: ${item.name}"
   }
 }
 ```
@@ -211,7 +211,7 @@ Access the current index in loops:
 ```json
 {
   "type": "text",
-  "value": "${user.name.toUpperCase()}"
+  "content": "${user.name.toUpperCase()}"
 }
 ```
 
@@ -229,14 +229,14 @@ Available:
 ```json
 {
   "type": "text",
-  "value": "Total users: ${users.length}"
+  "content": "Total users: ${users.length}"
 }
 ```
 
 ```json
 {
   "type": "text",
-  "value": "${users.map(u => u.name).join(', ')}"
+  "content": "${users.map(u => u.name).join(', ')}"
 }
 ```
 
@@ -254,7 +254,7 @@ Available:
 ```json
 {
   "type": "text",
-  "value": "Price: ${price.toFixed(2)}"
+  "content": "Price: ${price.toFixed(2)}"
 }
 ```
 
@@ -268,7 +268,7 @@ Available:
 ```json
 {
   "type": "text",
-  "value": "${Math.round(average)}"
+  "content": "${Math.round(average)}"
 }
 ```
 
@@ -283,7 +283,7 @@ Available: All standard `Math` functions
 ```json
 {
   "type": "text",
-  "value": "${new Date().toLocaleDateString()}"
+  "content": "${new Date().toLocaleDateString()}"
 }
 ```
 
@@ -321,7 +321,7 @@ Available: All standard `Math` functions
 ```json
 {
   "type": "text",
-  "value": "${
+  "content": "${
     users
       .filter(u => u.isActive)
       .map(u => u.name)
@@ -337,7 +337,7 @@ Available: All standard `Math` functions
 ```json
 {
   "type": "text",
-  "value": "${
+  "content": "${
     new Date().getHours() < 12 ? 'Good morning' :
     new Date().getHours() < 18 ? 'Good afternoon' :
     'Good evening'
@@ -365,7 +365,7 @@ Available: All standard `Math` functions
 ```json
 {
   "type": "text",
-  "value": "$${(price * quantity).toFixed(2)}"
+  "content": "$${(price * quantity).toFixed(2)}"
 }
 ```
 
@@ -465,7 +465,7 @@ Expressions are re-evaluated when data changes. Avoid expensive operations:
 // ❌ Bad: Complex computation in expression
 {
   "type": "text",
-  "value": "${users.map(u => expensiveOperation(u)).join(', ')}"
+  "content": "${users.map(u => expensiveOperation(u)).join(', ')}"
 }
 
 // ✅ Good: Pre-compute in data
@@ -510,7 +510,7 @@ Invalid expressions show helpful error messages:
 ```json
 {
   "type": "text",
-  "value": "${user.invalidProperty}"
+  "content": "${user.invalidProperty}"
 }
 ```
 

--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -67,7 +67,7 @@ interface BaseSchema {
   "visibleOn": "${user.role === 'admin'}",
   "body": {
     "type": "text",
-    "value": "Total Users: ${stats.totalUsers}"
+    "content": "Total Users: ${stats.totalUsers}"
   }
 }
 ```
@@ -93,7 +93,7 @@ Use expression syntax `${}` to reference data:
 ```json
 {
   "type": "text",
-  "value": "Welcome, ${user.name}!"
+  "content": "Welcome, ${user.name}!"
 }
 ```
 
@@ -174,7 +174,7 @@ Object UI includes a powerful expression system for dynamic behavior:
 ```json
 {
   "type": "text",
-  "value": "${user.firstName} ${user.lastName}"
+  "content": "${user.firstName} ${user.lastName}"
 }
 ```
 


### PR DESCRIPTION
Fixes #7015

Docs-only. Switches authored examples that carry an expression in a `text` node's
`value` over to `content`, the ruled sole evaluation channel (maintainer ruling
2026-08-31, decision batch #17, option 2 on objectstack#13670).

## Why the spelling matters (measured, not assumed)

`packages/components/src/renderers/basic/text.tsx:51` renders
`{schema.content || schema.value}` — so `value` **is** read back. What it never
gets is evaluated: `SchemaRenderer` evaluates the spec-declared carriage keys via
`expressionBindableTextKeysFor(type)`, and `text` has no `value` row (the map's
answer for an unlisted type is the empty set). Net effect: the reader sees the
literal `${...}` on screen. `content` is evaluated **unconditionally on every
component type** — its leg in `SchemaRenderer` carries no type gate at all.

That asymmetry is what makes the edit safe as well as correct, and it decided the
one judgment call below.

## Census — the assumed 23 was low; the real ruled-scope number is 29

Re-measured across the whole authored corpus, not the two named files. The card's
23 is exactly `expressions.md` (20) + `architecture.md` (3) — i.e. the two files
it names. **"Concentrated in" was not "only in": three more files carry six more.**

| File | In scope | Fence |
|---|---|---|
| `content/docs/guide/expressions.md` | 20 | json |
| `content/docs/guide/architecture.md` | 3 | json x2, **tsx x1** |
| `content/docs/guide/schema-rendering.md` | 3 | json |
| `content/docs/blocks/block-schema.mdx` | 2 | **ts x2** |
| `content/docs/guide/dashboard-filters.md` | 1 | json |
| **Total** | **29** | |

Before: 29 `text`-node value-with-expression. After: **0**.
Control for that zero — the identical query in the same run still returns the two
non-`text` hits below, so the zero is a measurement, not a dead query.
`content`-with-expression rose to 33 (29 + the 4 judgment-call fragments).

## Excluded, with reasons

- `expressions.md:388` — `type: "progress"`, and `:453` — `type: "input"`. Not
  `text` nodes; retargeting their `value` would be an unruled behaviour edit.
  Both are *also* outside the carriage map, so they likely render literals too —
  reported rather than touched.
- **The published skills surface — 7 hits, all correct as written, and changing
  them would be destructive.** `schema-expressions.md` and `page-builder.md` use
  `text` + `value` as deliberate counter-examples teaching this exact rule, each
  paired with its ✅ `content` fix; the rest are `statistic`, which genuinely
  declares a `value` row. Zero files under the skills directory are touched here.
- `packages/plugin-dashboard/README.md` (`metric-card`), `packages/react/README.md`
  (`input`) — non-`text` nodes. Root `README.md` teaches `stat-card`, which nothing
  registers — a different defect class, reported separately.
- `schema-rendering.md:34` — `text` + `value` with **no** expression; renders fine
  through the fallback. Out of scope by the card's own rule.
- One false positive: an `examples/` editor fixture whose `${name}` is JavaScript
  template-literal source being edited, not an ObjectUI expression.

## The one judgment call, isolated so it can be dropped

Commit 2 (`39d3eb151`) switches **four typeless fragments** in `expressions.md`
"Best Practices". They declare no `type`, so they sit outside the ruling's literal
wording, but both halves of both ✅/❌ pairs used `value` — and since the carriage
map answers the empty set for an absent type, the ✅ halves were teaching a
spelling that evaluates for nothing. `content` is right whatever type the reader
substitutes. To keep strict ruling scope: `git revert 39d3eb151`.

## Gates — all run at final HEAD `3476c2c25`

| Gate | Exit | Verdict |
|---|---|---|
| `check-doc-snippet-types` | 0 | green — "Every covered documentation snippet compiles against the built types"; 272/272 blocks judged, 0 failed |
| `check-doc-component-types` | 0 | green — every documented component type is registered |
| `check-doc-fence-languages` | 0 | green |
| `check-doc-links` | 0 | green — valid across 17 scan roots |
| `check-control-bytes` | 0 | green — 5893 files scanned |
| `check-changeset-presence` | 0 | green — **"no changeset is owed"** |
| `check-changeset-no-major` | 0 | green |
| vitest x6 gate suites | 0 | 266/266 passed |

`check-doc-snippet-types` needed the built closure and first returned
`PRECONDITION NOT MET (exit 2)` on the unbuilt tree — recorded as NOT MEASURED,
then the 21-package closure was built (32/32 tasks) and it was re-run for the real
green above. Its own self-controls fired in that run (sentinel produced TS2305,
undeclared produced TS2307), so the harness demonstrably can detect errors.

Three of the 29 edits live in **compiled** ts/tsx snippets, not prose — the risk
the card did not anticipate. It resolves to nil: all three reach `BaseSchema`,
whose `[key: string]: any` index signature accepts both spellings identically.
That is reasoning, and `check-doc-snippet-types` green above is the measurement.

## Changeset

Empty frontmatter — this ships nothing. Worth flagging that the gate says a
changeset was **not owed** here at all (0 files of published source changed); it
is included as an explicit statement of release intent, which is a first-class
form in this repo. Not `patch`, and not `major` (the guard refuses that outright).

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_