### PR TITLE
test(app-shell): pin the metadata advisory sink seam — an emitted event reaches the toast, both doors

### DIFF
--- a/.changeset/pin-advisory-sink-seam-6969.md
+++ b/.changeset/pin-advisory-sink-seam-6969.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only change: pins the metadata advisory sink seam (`useMetadataClient` ->
+`createConsoleMetadataClient` -> `MetadataClient`), so an advisory the server
+returns on a save or a publish is asserted to actually reach the toast. No
+published behaviour changes.

--- a/packages/app-shell/src/views/metadata-admin/useMetadataClient.advisorySink.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/useMetadataClient.advisorySink.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The advisory chain's MIDDLE link: an emitted event actually REACHES the sink
+ * (objectui#6969).
+ *
+ * ## What was missing, and why nothing red said so
+ *
+ * The chain has three links, and before this file only its two ends were
+ * pinned:
+ *
+ *   producer  MetadataClient.save / .publishDraft emit the event
+ *             -> pinned by metadata-client.saveAdvisories.test.ts and
+ *                metadata-client.publishAdvisories.test.ts
+ *   MIDDLE    useMetadataClient hands its toast sink to the client factory,
+ *             which hands it to the MetadataClient constructor
+ *             -> pinned by NOTHING
+ *   renderer  emitSaveAdvisories turns an event into the warning
+ *             -> pinned by saveAdvisoryToast.test.ts
+ *
+ * The producer suites assert the event is EMITTED, into a sink they construct
+ * themselves. The renderer suite asserts the message is BUILT, over an event it
+ * writes by hand. Neither one ever asserts that the thing emitted and the thing
+ * rendered are connected — so cutting the middle silenced BOTH doors, save and
+ * publish, with every named suite green. Measured before writing this file:
+ * with the `onSaveAdvisory` hand-off deleted from the factory call in
+ * `useMetadata.ts`, 226 test files / 2369 tests stayed green.
+ *
+ * The mechanism of the blind spot is worth naming, because it is not an
+ * oversight anyone could have spotted by reading a coverage number: 51 suites
+ * `vi.mock('./useMetadata')` — legitimately, they are testing pages, not
+ * plumbing — and, before this file, exactly ZERO imported the real
+ * `useMetadataClient`. The seam was mocked away everywhere it appeared.
+ *
+ * ## What is real here, and what is not
+ *
+ * Real: the hook, its `useCallback` sink, the i18n `t` it closes over, the
+ * PreviewModeContext read, `createConsoleMetadataClient`, the authenticated
+ * fetch wrapper, the `MetadataClient` instance, its response parsing, its
+ * `readSaveAdvisories` filter, and `emitSaveAdvisories`.
+ *
+ * Stubbed, and only these two:
+ *   - `sonner` — the terminal sink. It is imported directly by the hook (not
+ *     injected), so intercepting the module is the only way to observe what
+ *     arrives. Everything BETWEEN the producer and it is the real thing, which
+ *     is the whole point.
+ *   - `globalThis.fetch` — the server. It answers with the response body the
+ *     framework's runtime authoring gate actually sends.
+ *
+ * ## Scope — deliberately NOT a bigger test at either end
+ *
+ * This asserts the CONNECTION and nothing else. The tier (warning, never
+ * error), the per-finding formatting and the empty-list drop are the renderer
+ * suite's; `withEnvironment` clone survival and the response-shape filtering
+ * are the producer suites'. Duplicating any of them here would grow the suite
+ * without closing the hole this file exists to close.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, cleanup } from '@testing-library/react';
+
+// The one stub in the middle of the chain — see the module doc. `toast` is
+// imported by `useMetadata.ts` as a module binding, so it cannot be handed over
+// the way `saveAdvisoryToast.test.ts` hands over its sink.
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+import { useMetadataClient } from './useMetadata';
+
+/**
+ * The measured `nightly_purge` finding, in the gate's D3 shape. All six keys
+ * are required — `readSaveAdvisories` drops anything half-shaped, so a fixture
+ * missing one would make this file pass for the wrong reason.
+ */
+const PURGE_ADVISORY = {
+  severity: 'warning' as const,
+  rule: 'flow/delete-without-filter',
+  where: 'flow "nightly_purge" · node "purge old rows"',
+  path: 'flows[0].nodes[2].config.filters',
+  message: 'this delete_record node sets multi: true with no filter, so it deletes every row',
+  hint: 'add a filter, or set multi: false to delete a single record',
+};
+
+/** A committed write the gate had something to say about. */
+const ADVISED_BODY = {
+  success: true,
+  version: 'sha256:0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0',
+  seq: 7,
+  advisories: [PURGE_ADVISORY],
+};
+
+/** The same write, clean. The server omits `advisories` entirely. */
+const CLEAN_BODY = {
+  success: true,
+  version: 'sha256:0f1e2d3c4b5a69788796a5b4c3d2e1f00f1e2d3c4b5a69788796a5b4c3d2e1f0',
+  seq: 7,
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function serverAnswers(body: unknown) {
+  fetchMock = vi.fn(async () => jsonResponse(body));
+  vi.stubGlobal('fetch', fetchMock);
+}
+
+beforeEach(() => {
+  vi.mocked(toast.warning).mockClear();
+  serverAnswers(ADVISED_BODY);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+/** The `(title, options)` pair the sink was called with. */
+function warningCall(): [string, { description?: string; duration?: number } | undefined] {
+  const calls = vi.mocked(toast.warning).mock.calls;
+  expect(calls).toHaveLength(1);
+  return calls[0] as [string, { description?: string; duration?: number } | undefined];
+}
+
+describe('useMetadataClient — an emitted advisory reaches the toast sink', () => {
+  it('SAVE door: a save whose response carries findings renders them', async () => {
+    const { result } = renderHook(() => useMetadataClient());
+
+    await result.current.save('flow', 'nightly_purge', { name: 'nightly_purge' });
+
+    const [title, options] = warningCall();
+    // The verb proves the DOOR discriminator survived the whole seam: it is set
+    // by the producer and read by the renderer, and nothing in between may lose
+    // or rewrite it.
+    expect(title).toMatch(/^Saved\b/);
+    // The finding itself arrived — not merely "something was toasted".
+    expect(options?.description).toContain(PURGE_ADVISORY.message);
+    expect(options?.description).toContain(PURGE_ADVISORY.rule);
+  });
+
+  it('PUBLISH door: the same client, the same sink, the published verb', async () => {
+    const { result } = renderHook(() => useMetadataClient());
+
+    // `publishDraft` rather than `publish` because it is what the console's own
+    // publish path (`usePublishAllDrafts`) calls through THIS hook.
+    await result.current.publishDraft('flow', 'nightly_purge');
+
+    const [title, options] = warningCall();
+    expect(title).toMatch(/^Published\b/);
+    expect(options?.description).toContain(PURGE_ADVISORY.message);
+  });
+
+  it('CONTROL: a clean write says nothing at either door', async () => {
+    serverAnswers(CLEAN_BODY);
+    const { result } = renderHook(() => useMetadataClient());
+
+    await result.current.save('flow', 'nightly_purge', { name: 'nightly_purge' });
+    await result.current.publishDraft('flow', 'nightly_purge');
+
+    // The zero above is only a reading beside a control that MUST hit: both
+    // writes really did travel the chain, so "the sink stayed quiet" is about
+    // the empty advisory list and not about a chain that never ran.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #6969

One pin over the advisory chain's **middle link**, asserting the CONNECTION rather than either end of it: a server-sent advisory travels the real hook, the real client factory and the real `MetadataClient`, and arrives at the toast — for the save door and for the publish door.

## Leg 0 — the card's precondition, re-measured on current `main`

The card required the claimant to re-measure that the gap is still real. It is.

**Seam location — assumption falsified.** The card and the dispatch both name `packages/app-shell/src/hooks/useMetadata.ts`. **That file does not exist.** The real seam is `packages/app-shell/src/views/metadata-admin/useMetadata.ts` — the *line numbers* 130-135 were right, the directory was not. `packages/app-shell/src/hooks/useMetadataService.ts` is a different thing (it mints a `MetadataService` from the adapter) and carries no advisory wiring.

**Ablation** — predicted direction stated before running: every named suite stays GREEN, and that green IS the finding.

Cut, at the seam the card names:

```
-    () => createConsoleMetadataClient({ previewDrafts, environmentId, onSaveAdvisory }),
+    () => createConsoleMetadataClient({ previewDrafts, environmentId }),
```

| | value |
|---|---|
| predicted | all named suites stay green |
| observed | all named suites stayed green — **226 files / 2369 tests, zero reds** |
| blob before | `4bbebbf78439ca088ba313a7a708d8a007535a32` (identical to the HEAD blob) |
| blob after | `7d2ade859f42f27f76723fea95c3d4810243b7f1` |
| mutation proven | anchor count for the deleted text 1 to 0, for the injected text 0 to 1, **and** the blob hash moved |
| restore proven | by STATE: blob back to `4bbebbf78...` **and** `git diff HEAD` 0 bytes |

Green suites through the cut (reported because a suite that survives an ablation tells you which layer it does NOT cover):

- `metadata-client.saveAdvisories.test.ts`, `metadata-client.publishAdvisories.test.ts`, `onSaveAdvisory.test.ts` — producer end, green
- `saveAdvisoryToast.test.ts` — renderer end, green
- `MetadataService.saveAdvisories.test.ts`, `metadata-client-auth.ratchet.test.ts` — green
- all 220 suites in `views/metadata-admin/` — green, 2299 passed / 1 skipped, byte-identical to the baseline

Red suites through the cut: **none.**

**Why nothing could see it**, measured: 51 suites `vi.mock('./useMetadata')` — legitimately, they test pages, not plumbing — and, before this PR, **exactly 0** imported the real `useMetadataClient`. Control: 76 suites name `useMetadataClient` at all, so the zero is a reading, not a dead query. The seam was mocked away everywhere it appeared.

## The pin

`packages/app-shell/src/views/metadata-admin/useMetadataClient.advisorySink.test.tsx` — 3 cases:

1. **SAVE door** — `save()` through the hook's client; the toast title matches `/^Saved\b/` and carries the finding's message and rule.
2. **PUBLISH door** — `publishDraft()` through the same client (the method the console's own `usePublishAllDrafts` calls through this hook); title matches `/^Published\b/`.
3. **CONTROL** — a clean 200 with no advisories says nothing at either door, and `fetch` is asserted to have been called twice, so the silence is about the empty advisory list and not about a chain that never ran.

The door verb is the load-bearing assertion: it is set by the producer and read by the renderer, so it only reads correctly if the discriminator survived the whole seam.

Real: the hook, its `useCallback` sink, the i18n `t`, the PreviewModeContext read, `createConsoleMetadataClient`, the authenticated fetch wrapper, the `MetadataClient`, its response parsing, `readSaveAdvisories`, `emitSaveAdvisories`. Stubbed, only these two: `sonner` (the terminal sink — the hook imports it as a module binding, so it cannot be handed over the way the renderer suite hands over its own) and `globalThis.fetch` (the server).

**Scope** — deliberately not a bigger test at either end. The warning tier, the per-finding formatting and the empty-list drop stay the renderer suite's; `withEnvironment` clone survival and response-shape filtering stay the producer suites' (both already pin them, both doors).

## Pin ablation — it fails when the middle is cut, and passes when it is intact

Both halves of the middle link were cut, separately. Predicted before running: the two door cases go RED and the CONTROL case stays GREEN, because a severed chain also satisfies "the sink was not called" — which is exactly why the control alone could never have caught this.

| leg | file | blob before to after | observed |
|---|---|---|---|
| A | `useMetadata.ts` (the hand-off) | `4bbebbf78` to `7d2ade859` | **2 failed / 1 passed** — as predicted |
| B | `metadataClientFactory.ts` (the pass-through into the constructor) | `e0f04f9a4` to `fddd1d555` | **2 failed / 1 passed** — as predicted |

Both legs: mutation proven on disk by anchor counts **and** blob-hash movement; restore proven by state — blob back to the HEAD blob and `git diff HEAD` 0 bytes.

⚠️ Leg B was run twice and the first run is reported as **VOID, not as a result**: the verification used `grep -c -F` with a newline inside the pattern, which degenerates to matching every line (92 of them), so the guard refused the reading. The mutation had in fact landed; the *check* was broken. Re-run with a single-line anchor, which is the row above.

## Gates

Run at final HEAD `b5a989f0c`. Verdict lines quoted from the gates themselves, never a bare exit code.

| gate | verdict |
|---|---|
| union regression | `Test Files 227 passed (227)` · `Tests 2372 passed \| 1 skipped (2373)` |
| `check-changeset-presence` | `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` |
| `check-changeset-no-major` | `No changeset declares a major bump.` |
| `check-vi-mock-specifiers` | `OK (4074 tracked source file(s), 2349 test-named; 516 carry a mock; ...)` |
| `check-vi-mock-inherit` | `OK (... 114 call site(s) on @object-ui/react judged (114 inherit, 0 auto-mocked) ...)` |
| `check-control-bytes` | `OK (scanned 5893 tracked text file(s); skipped 85 binary).` |
| `check-shell-escape-residue` | `OK (4/4 root(s) resolved ...)` |
| `check-lint-coverage` | `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `check-type-check-coverage` | `test type-check coverage: 41/41 packages compile their tests, 0 declared debt` |
| `eslint` (plain form) | exit 0, no output |
| `pnpm --filter @object-ui/app-shell run type-check` | exit 0; output echoed `tsc --noEmit && tsc -p tsconfig.test.json`, so it was not a zero-match |

**The typecheck actually covers the new file**, proven rather than assumed: `tsc -p tsconfig.test.json --listFiles` names it (1 hit) out of 4504 program files, with a control that must hit — the sibling `providers/saveAdvisoryToast.test.ts`, also 1 hit. That config sets `paths: {}`, so it resolves through built `.d.ts`; the 29-package dependency closure was built first, otherwise the result would have been NOT MEASURED rather than green.

The changeset carries an EMPTY frontmatter — the presence gate's own named exemption for a test-only change, quoted above. No `skip-changeset` label was applied: in this repo that label is a phantom (the object exists from a historical mislabel, but nothing reads it, and `scripts/__tests__/ci-cd-pipeline-doc.test.ts` fails if anything under `.github/` or `scripts/` ever wires it in).

## Out of scope, filed separately

#7116 — the SIBLING advisory wiring in `AdapterProvider.tsx` (the `ObjectStackAdapter` channel, built by #4237) has the same unpinned middle link. Measured by grep with a control, not by ablation, and said so on the card. Not touched here.

## Notes for review

- This gap is inherited from #4236, which built the save door on this shape. It is not a regression in #5026's publish wiring — cutting the seam silences **both** doors at once, which is what shows the shape predates the publish door.
- No production code changed. The seam needed no new hook or injection point to be testable.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_