### PR TITLE
fix(app-shell): reword the `app:launcher` palette-exclusion reason so a renderer cannot falsify it

### DIFF
--- a/.changeset/7092-launcher-exclusion-reason.md
+++ b/.changeset/7092-launcher-exclusion-reason.md
@@ -1,0 +1,17 @@
+---
+---
+
+Corrects the `PALETTE_EXCLUSIONS` reason string for `app:launcher` in the Studio
+page-palette ledger. It read "shell singleton — the app shell renders it, not a page",
+and objectui#7091 registered a real `app:launcher` renderer, so a page can now render it
+and the "not a page" clause became false. The reason now reads "shell singleton — lives
+in the app shell chrome", mirroring the neutral form its sibling `global:notifications`
+has carried since objectui#6757 shipped that type a renderer without its wording rotting:
+the entry describes WHERE the thing lives, not whether a renderer exists, so a later
+renderer cannot falsify it.
+
+The exclusion itself is an unchanged decision — `app:launcher` stays out of the page
+palette, and its key and position in the ledger are untouched. Whether it should become
+palette-authorable is a separate product question this does not answer. No published
+behaviour moves: the reason strings are developer-facing ledger prose, read by no runtime
+code path, and `PALETTE_EXCLUSIONS` is not exported from `@object-ui/app-shell`'s entry.

--- a/packages/app-shell/src/views/metadata-admin/previews/block-types.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/block-types.ts
@@ -148,7 +148,7 @@ export const BLOCK_TYPE_META: Record<BlockTypeId, Omit<BlockTypeMeta, 'id'>> = {
  */
 export const PALETTE_EXCLUSIONS: Record<string, string> = {
   // Shell singletons — chrome the app shell owns, not page content.
-  'app:launcher': 'shell singleton — the app shell renders it, not a page',
+  'app:launcher': 'shell singleton — lives in the app shell chrome',
   'global:notifications': 'shell singleton — lives in the app shell header',
   'user:profile': 'shell singleton — lives in the app shell header',
   // No renderer, by decision — and these two are the ones that MEASURE that way.


### PR DESCRIPTION
Fixes #7092

One line of source. `PALETTE_EXCLUSIONS['app:launcher']` read `'shell singleton — the app shell renders it, not a page'`. PR #7091 landed on `main` as `969ba84f4`, registering a real `app:launcher` renderer, so a page **can** now render it and the "not a page" clause is false today.

```diff
-  'app:launcher': 'shell singleton — the app shell renders it, not a page',
+  'app:launcher': 'shell singleton — lives in the app shell chrome',
```

The wording is the defect, not the decision. `app:launcher` stays out of the Studio page palette; **the entry, its key and its position are unchanged**. Whether it should become palette-authorable is a live product question, and moving the entry rather than rewording it would have answered that silently — so the entry did not move. Direct precedent: #6071 corrected two reasons on this same ledger in place.

The new text mirrors the sibling `'global:notifications': 'shell singleton — lives in the app shell header'`, which carries the identical shell-singleton marker and did **not** rot when #6757 shipped it a real renderer — because it describes *where the thing lives*, not *whether a renderer exists*. #7091's own docblock reaches the same conclusion independently:

> This does NOT put the block in the Studio page palette: `PALETTE_EXCLUSIONS` still records `app:launcher` as a shell singleton, and that is a palette decision about authoring ergonomics, independent of whether a declared type renders — exactly as objectui#6757 left `global:notifications`.

## Measurements

All runs below are on `ab85b515e` with a clean tree.

| Gate | Exit | Verdict |
|---|---|---|
| `vitest packages/app-shell/.../previews/__tests__/` | 0 | **green** — 7 files, 73 tests passed |
| `check-changeset-presence.mjs` | 0 | **green** |
| `check-changeset-no-major.mjs` | 0 | **green** |
| `check-changeset-overwrite.mjs` | 0 | **green** |
| `check-changeset-fixed.mjs` | 0 | **green** |
| `check:control-bytes` | 0 | **green** — 5893 tracked text files |
| `check:doc-fences` | 0 | **green** |
| `pnpm lint` (full farm, plain form) | 0 | **green** — 47/47 tasks, 0 errors |
| `pnpm --filter @object-ui/app-shell run type-check` | 0 | **green** — after building the closure |

Exit codes were captured by redirecting to a file first, never read across a pipe.

**`type-check` was NOT MEASURED on the first attempt** and is recorded as such rather than as a failure: it exited 2 with `TS2307: Cannot find module '@object-ui/components'` (and `@object-ui/react`, `@object-ui/fields`, `@object-ui/data-objectstack`) — an unbuilt dependency closure. After `pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build` (exit 0) it re-ran at **exit 0 with 0 remaining TS2307**. Both passes run (`tsc --noEmit && tsc -p tsconfig.test.json`), so test sources are in the population too.

Population proof for the typecheck: `tsc --listFiles` lists 2421 files and `previews/block-types.ts` is among them (1 hit), so the green covers the edited file rather than merely omitting it.

### The truthfulness test: what it actually judges

`exclusion-reason-truthfulness.test.ts` judges only reasons matching `/\bno\s+(?:\w+\s+){0,2}renderer\b/i`. Neither the old text (which says "renders", not "renderer") nor the new text matches, so this entry was never in that guard's population — it stays green, and its non-vacuity assertion is still satisfied by `ai:chat_window` and `element:form`. All 4 of its assertions pass, including both anti-vacuity guards.

### Reverse verification

Predicted directions were fixed before running. Each leg confirmed the mutation on disk (injected/removed text counts plus a blob-hash move off the HEAD blob) and verified the restore by hash match plus an empty `git diff HEAD`.

- **Leg A — predicted RED, got RED.** Shortening the reason to a 7-char marker fails `block-config.test.ts`: `AssertionError: 'app:launcher' needs a reason: expected 7 to be greater than 10`. This proves the suite reads the edited file, so the green above is a measurement and not a vacuous pass.
- **Leg B — predicted GREEN, got GREEN.** Setting the reason to `'no renderer ZZMUTZZ'`, which *does* match the guard's regex, still passes 4/4. That is a real blind spot rather than a property of this change, and it is filed separately as #7117: the guard's import set never grew to include app-shell, which now registers four page blocks (#6757, #7091), so a false "no renderer" on any of the five shell singletons would pass green. Latent today — no shell singleton's reason makes that claim, and this reword keeps it that way. Not touched here.

## Changeset

Empty frontmatter, following #6071's changeset on this same ledger. The presence gate certifies the route explicitly:

> Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.

That matches the measurement: `PALETTE_EXCLUSIONS` is not exported from `@object-ui/app-shell`'s entry (the package exposes only `.` and `./styles.css`), nothing re-exports `block-types` anywhere in app-shell `src`, and no runtime code path reads the reason strings — they are developer-facing ledger prose. This corrects the dispatch's assumption that a `patch` was owed.

## Swept and deliberately left

- **`nav:menu`** — #7091's other renderer. It is in `BLOCK_TYPE_META` (offered by the palette), **not** in `PALETTE_EXCLUSIONS`, so it falsified no reason. Zero hits inside the exclusion table, against a control (`app:launcher`) that hits in the same query.
- **The `BlockTypeId` docblock**, which calls shell singletons "intentionally NOT page blocks" — a claim about membership of that local palette union, still exactly true, and it covers `global:notifications` identically, which #6757 deliberately left untouched. Rewording it would apply a standard the sibling precedent rejects.
- **`user:profile` / `global:notifications`** — already neutral location wording; nothing falsified them.
- **`core/src/registry/public-blocks.ts`** — zero hits for all four shell-singleton keys, against controls `record:chatter` and `element:text_input` that hit in the same sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_