### PR TITLE
fix(app-shell): say what is true when the studio-design designer registries are empty (#6795 part C)

### DIFF
--- a/.changeset/6795-studio-design-consumer-states.md
+++ b/.changeset/6795-studio-design-consumer-states.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Studio design: say what is true when the metadata designer registries are
+unpopulated (objectui#6795 part C).
+
+The three registries (`preview-registry`, `inspector-registry`,
+`default-inspector-registry`) are plain `Map`s filled by a module-scope side
+effect, and every studio-design consumer reads them **during render with no
+subscription**. A consumer that reads an empty registry therefore gets
+`undefined` and never recovers — measured: registering afterwards leaves the
+consumer in its fallback forever. Four consumer states lied about that, and
+one was silent:
+
+- **Data pillar field rail** — the guard was
+  `fieldSel && (fieldSel.kind === 'group' || inspector)`, so selecting a
+  **field** with no inspector registered dropped the whole rail: clicking a
+  field did literally nothing while the designer above it went on saying
+  "click a field to edit its properties". A selection now always opens its
+  rail, and the rail names the missing inspector.
+- **Interfaces canvas** — "{type} shows a read-only preview for now; design
+  support is in progress" was false twice: the branch renders no preview at
+  all, and page design support exists. It is split by
+  `listMetadataPreviewTypes()` into the two causes that are actually
+  distinguishable — this type has no designer, or none are registered at all.
+- **Interfaces rail** — no longer tells the author to click a canvas that is
+  not rendered.
+- **Automations pillar** — the canvas chip and the rail both said "click a
+  node" while the canvas was a raw JSON dump.
+- **`ObjectActionsPanel`** — rendered only the action's own label, which read
+  as "this action has no properties"; the label now carries the reason there
+  is no editor under it.
+
+⛔ None of these messages promises recovery ("loading…", "try again", a
+spinner): that would replace one false statement with another. Making the
+registries observable so recovery is real is part A of #6795, which the ruling
+deferred. `ObjectSettingsPanel` and `ObjectHooksPanel` are deliberately
+untouched — the measurement found both already correct.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -1748,7 +1748,26 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.if.tabCanvas': 'Canvas',
   'engine.studio.if.noAppTitle': 'This package has no app yet',
   'engine.studio.if.noAppHint': 'Create an app to design its navigation and interfaces.',
-  'engine.studio.if.readonlyPreview': '{type} shows a read-only preview for now; design support is in progress.',
+  /* objectui#6795 part C — the three designer registries (`preview-registry`,
+   * `inspector-registry`, `default-inspector-registry`) are plain `Map`s filled
+   * by a module-scope side effect, with no change notification. A consumer that
+   * reads one before that registration has landed gets `undefined` and NEVER
+   * recovers — measured on this card: `fallback before registration: true |
+   * still fallback after registration: true | late inspector rendered: false`.
+   * So every string in this family states what is TRUE and must NOT promise
+   * recovery: no "loading…", no "try again", no spinner. That would replace one
+   * false statement with another; making recovery real is part A of #6795.
+   *
+   * The retired `engine.studio.if.readonlyPreview` ("{type} shows a read-only
+   * preview for now; design support is in progress.") was false twice over: this
+   * branch renders NO preview at all, and page design support exists — the
+   * sentence blamed the platform's roadmap for a chunk that did not load. It is
+   * split in two because the two causes are genuinely different and
+   * `listMetadataPreviewTypes()` tells them apart. */
+  'engine.studio.if.designersMissing':
+    'No metadata designers are registered in this session, so {type} cannot be previewed or designed here.',
+  'engine.studio.if.noDesigner':
+    'No designer is registered for {type}, so it cannot be previewed or designed here.',
   'engine.studio.if.objectHintPre': 'Runtime list preview · edit fields / structure in the ',
   'engine.studio.if.objectHintPost': ' pillar',
   'engine.studio.inspector.props': 'Properties',
@@ -1758,6 +1777,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.inspector.tabSource': 'Source',
   'engine.studio.inspector.emptyLine1': 'Click a block on the canvas,',
   'engine.studio.inspector.emptyLine2': 'and edit its properties right here.',
+  'engine.studio.inspector.designersMissing':
+    'No metadata designers are registered in this session, so there is nothing to edit here.',
   'engine.studio.inspector.noPageSchema': 'Page settings are unavailable — the page schema could not be loaded.',
   'engine.studio.inspector.sourcePageLine1': 'This page is {kind} source, not a block tree —',
   'engine.studio.inspector.sourcePageLine2': 'edit it in the Source tab; the canvas shows the live preview.',
@@ -1792,6 +1813,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   // Actions view
   'engine.studio.actions.none': 'No actions on this object.',
   'engine.studio.actions.pick': 'Select an action to edit its properties.',
+  'engine.studio.actions.editorMissing':
+    'No action editor is registered in this session, so this action’s properties cannot be edited here.',
   'engine.studio.actions.newLabel': 'New action',
   'engine.studio.actions.delete': 'Delete',
   // API view
@@ -1835,6 +1858,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
     '“Preview” renders the published runtime form, but this object isn’t published yet. Confirm the draft in “Layout”, then click “Publish” in the top bar to preview.',
   'engine.studio.data.fieldProps': 'Field properties',
   'engine.studio.data.groupProps': 'Group properties',
+  'engine.studio.data.fieldInspectorMissing':
+    'No field inspector is registered in this session, so this field’s properties cannot be edited here.',
   'engine.studio.designer.group.kind': 'Group',
   'engine.studio.designer.group.settings': 'Group settings',
   'engine.studio.designer.group.nameLabel': 'Group name',
@@ -1870,6 +1895,8 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.auto.config': 'Configuration',
   'engine.studio.auto.emptyLine1': 'Click a node on the canvas,',
   'engine.studio.auto.emptyLine2': 'and its configuration appears here.',
+  'engine.studio.auto.designersMissing':
+    'No metadata designers are registered in this session, so this flow cannot be designed here.',
   // Access pillar
   'engine.studio.access.created': 'Permission set “{label}” created',
   'engine.studio.access.title': 'Permission matrix',
@@ -3601,7 +3628,8 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.if.tabCanvas': '画布',
   'engine.studio.if.noAppTitle': '这个软件包还没有应用',
   'engine.studio.if.noAppHint': '创建一个应用来设计它的导航与界面。',
-  'engine.studio.if.readonlyPreview': '{type} 暂用只读预览,设计能力建设中。',
+  'engine.studio.if.designersMissing': '本次会话没有注册任何元数据设计器,因此无法在这里预览或设计 {type}。',
+  'engine.studio.if.noDesigner': '没有为 {type} 注册设计器,因此无法在这里预览或设计。',
   'engine.studio.if.objectHintPre': '运行态列表预览 · 改字段 / 结构请到 ',
   'engine.studio.if.objectHintPost': ' 支柱',
   'engine.studio.inspector.props': '属性',
@@ -3611,6 +3639,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.inspector.tabSource': '源码',
   'engine.studio.inspector.emptyLine1': '在画布里点选一个积木,',
   'engine.studio.inspector.emptyLine2': '它的属性会在这里直接编辑。',
+  'engine.studio.inspector.designersMissing': '本次会话没有注册任何元数据设计器,这里没有可编辑的内容。',
   'engine.studio.inspector.noPageSchema': '页面设置不可用——无法加载页面 schema。',
   'engine.studio.inspector.sourcePageLine1': '这个页面是 {kind} 源码,不是积木树 ——',
   'engine.studio.inspector.sourcePageLine2': '请在「源码」标签页里编辑,画布展示实时预览。',
@@ -3644,6 +3673,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   // Actions view
   'engine.studio.actions.none': '该对象没有操作。',
   'engine.studio.actions.pick': '选择一个操作以编辑其属性。',
+  'engine.studio.actions.editorMissing': '本次会话没有注册操作编辑器,因此无法在这里编辑该操作的属性。',
   'engine.studio.actions.newLabel': '新操作',
   'engine.studio.actions.delete': '删除',
   // API view
@@ -3683,6 +3713,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
     '「预览」渲染已发布的运行态表单,而这个对象还未发布。在「布局」里确认草稿,点顶栏「发布」后即可预览。',
   'engine.studio.data.fieldProps': '字段属性',
   'engine.studio.data.groupProps': '分组属性',
+  'engine.studio.data.fieldInspectorMissing': '本次会话没有注册字段检查器,因此无法在这里编辑该字段的属性。',
   'engine.studio.designer.group.kind': '分组',
   'engine.studio.designer.group.settings': '分组设置',
   'engine.studio.designer.group.nameLabel': '分组名称',
@@ -3718,6 +3749,7 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.auto.config': '配置',
   'engine.studio.auto.emptyLine1': '在画布里点选一个节点,',
   'engine.studio.auto.emptyLine2': '它的配置会在这里显示。',
+  'engine.studio.auto.designersMissing': '本次会话没有注册任何元数据设计器,因此无法在这里设计该流程。',
   // Access pillar
   'engine.studio.access.created': '权限集「{label}」已创建',
   'engine.studio.access.title': '权限矩阵',

--- a/packages/app-shell/src/views/studio-design/ObjectActionsPanel.designerRegistryMissing.test.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectActionsPanel.designerRegistryMissing.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#6795 part C, site 3 — the actions detail pane must not read as
+ * "this action has no properties".
+ *
+ * With `getMetadataDefaultInspector('action')` undefined the pane rendered the
+ * action's own label and nothing else ("Send Email"), which looks like a
+ * finished answer rather than a missing editor. The repair keeps the label (it
+ * says WHICH action is selected) and adds the reason there is no form under it.
+ *
+ * ⛔ The message must not promise recovery. That read is a plain `Map` lookup
+ * during render with no subscription, and the card measured that a registration
+ * landing later never reaches the component (`late inspector rendered: false`).
+ * "Loading…" / "try again" would swap one false statement for another; making
+ * recovery real is part A of #6795.
+ *
+ * ⚠️ Sibling panels in this pillar are deliberately NOT pinned here, because the
+ * measurement found them already correct and the ruling put them out of scope:
+ * `ObjectSettingsPanel` already prints "No default object inspector
+ * registered.", and `ObjectHooksPanel` already falls back to a working generic
+ * `SchemaForm`. Both were "silently empty" on the card and neither is.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { ObjectActionsPanel } from './ObjectActionsPanel';
+import { getMetadataDefaultInspector } from '../metadata-admin/default-inspector-registry';
+import { getStudioCanvasPreview } from './studio-canvas-preview';
+
+const draft = {
+  name: 'showcase_task',
+  label: 'Task',
+  actions: [{ name: 'send_email', label: 'Send Email', type: 'quick' }],
+};
+
+afterEach(cleanup);
+
+describe('ObjectActionsPanel — no action editor registered (#6795 C, site 3)', () => {
+  it('names the missing editor beside the action label', async () => {
+    // CONTROL — `studio-canvas-preview` self-registers `object` at module scope,
+    // so this MUST hit. It proves the module graph loaded and the lookup works;
+    // only then is the `undefined` below a reading rather than a failed import.
+    expect(getStudioCanvasPreview('object')).toBeTypeOf('function');
+    expect(getMetadataDefaultInspector('action')).toBeUndefined();
+
+    render(<ObjectActionsPanel draft={draft as Record<string, unknown>} onPatch={() => {}} />);
+
+    // The label survives — it is the only thing identifying the selection.
+    expect(await screen.findAllByText('Send Email')).not.toHaveLength(0);
+    // ...and no longer stands alone, which is what read as "no properties".
+    await screen.findByText(
+      'No action editor is registered in this session, so this action’s properties cannot be edited here.',
+    );
+    expect(document.body.textContent ?? '').not.toMatch(/loading|try again/i);
+  });
+});

--- a/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
+++ b/packages/app-shell/src/views/studio-design/ObjectActionsPanel.tsx
@@ -23,7 +23,7 @@
  */
 
 import React from 'react';
-import { Zap, Plus, Trash2 } from 'lucide-react';
+import { Ban, Zap, Plus, Trash2 } from 'lucide-react';
 import { getIcon } from '../../utils/getIcon.js';
 import { getMetadataDefaultInspector } from '../metadata-admin/default-inspector-registry.js';
 import { t, useMetadataLocale } from '../metadata-admin/i18n.js';
@@ -266,8 +266,23 @@ export function ObjectActionsPanel({
             />
           </>
         ) : (
-          <div className="flex flex-1 items-center justify-center p-6 text-center text-[12px] text-muted-foreground">
-            {labelText(sel.label, String(sel.name ?? ''))}
+          /* objectui#6795 part C — this branch used to render the action's own
+           * label and nothing else, which reads as "this action has no
+           * properties": the pane looked like a finished answer rather than a
+           * missing editor. Keep the label (it says WHICH action is selected)
+           * and add the reason there is no form under it.
+           *
+           * ⛔ Not "loading…" / "try again". `getMetadataDefaultInspector` reads
+           * a plain `Map` with no change notification, during render, with no
+           * subscription — measured on #6795, a registration that lands later
+           * never reaches this component, so promising recovery would just swap
+           * one false statement for another. Making recovery real is part A. */
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center text-[12px] text-muted-foreground">
+            <Ban className="h-5 w-5" />
+            <span className="font-medium text-foreground">
+              {labelText(sel.label, String(sel.name ?? ''))}
+            </span>
+            <span>{t('engine.studio.actions.editorMissing', locale)}</span>
           </div>
         )}
       </div>

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx
@@ -1,0 +1,241 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#6795 part C — what the studio-design pillars SAY when the designer
+ * registries are unpopulated (维护者 2026-08-30, 第 5 场总监席决裁批 #4:「同意」).
+ *
+ * ## The mechanism these pins exist to hold
+ *
+ * `preview-registry` / `inspector-registry` / `default-inspector-registry` are
+ * plain `Map`s filled by a module-scope side effect in
+ * `views/metadata-admin/index.ts`, reached statically through the package
+ * barrel. Every consumer reads them **during render, with no subscription** and
+ * gets `undefined` when the registration has not run. Measured on the card:
+ *
+ *     fallback before registration: true
+ *     still fallback after registration: true
+ *     late inspector rendered: false
+ *
+ * ⇒ a consumer that reads an empty registry **never recovers**. That is why
+ * every message pinned here states a fact and ⛔ never promises recovery — no
+ * "loading…", no "try again", no spinner. Promising recovery would replace one
+ * false statement with another. Making recovery real is part A of #6795, which
+ * the ruling deferred to the maintainer's sequencing surface.
+ *
+ * ⛔ `Suspense` cannot repair any of this and must not be proposed: these are
+ * synchronous reads returning `undefined`, and Suspense catches a *thrown
+ * promise*. Triage fenced this explicitly; it is mechanical, not stylistic.
+ *
+ * ## Why the states are reachable at all
+ *
+ * They are unreachable in production **only by accident** — the eager
+ * registration part A wants to remove is what keeps them so. That is precisely
+ * why they can silently re-rot, and why they are pinned here rather than left
+ * to the browser.
+ *
+ * ## ⚠️ This file must never register a designer
+ *
+ * Its whole subject is the empty-registry branch, so every test below asserts
+ * the registries are empty FIRST — a zero that is not asserted is not a
+ * reading. The populated-registry contrast lives in
+ * {@link file://./StudioDesignSurface.designerRegistryPartial.test.tsx}, a
+ * separate file because these `Map`s are module state shared by a whole file.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const objectDef = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: [{ name: 'title', label: 'Title', type: 'text' }],
+};
+
+const NAV = [{ id: 'nav_page', type: 'page', label: 'Home', pageName: 'home_page' }];
+
+const mockClient = {
+  save: vi.fn(async () => ({})),
+  list: vi.fn(async (type: string) => {
+    if (type === 'app') return [{ name: 'acme_app', label: 'Acme' }];
+    if (type === 'object') return [{ name: 'showcase_task', label: 'Task' }];
+    if (type === 'flow') return [{ name: 'nightly', label: 'Nightly' }];
+    return [];
+  }),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async (type: string, name: string) => {
+    if (type === 'app') return { effective: { name: 'acme_app', label: 'Acme', navigation: NAV } };
+    if (type === 'object') return { effective: objectDef, code: objectDef };
+    if (type === 'page') return { effective: { name: 'home_page', label: 'Home' } };
+    if (type === 'flow') return { effective: { name: 'nightly', label: 'Nightly', steps: [] } };
+    return { effective: { name } };
+  }),
+  getDraft: vi.fn(async () => null),
+  get: vi.fn(async () => undefined),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return { ...mod, useMetadataClient: () => mockClient, useMetadataTypes: () => ({ entries: [] }) };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+import { AutomationsPillar, DataPillar, InterfacesPillar } from './StudioDesignSurface';
+import { listMetadataPreviewTypes } from '../metadata-admin/preview-registry';
+import { listMetadataInspectorTypes, getMetadataInspector } from '../metadata-admin/inspector-registry';
+import { getMetadataDefaultInspector } from '../metadata-admin/default-inspector-registry';
+import { getStudioCanvasPreview } from './studio-canvas-preview';
+
+afterEach(cleanup);
+
+/**
+ * Assert the registries really are empty — **with a control that MUST hit**.
+ *
+ * `studio-canvas-preview` registers `object` at module scope in the very file
+ * the control reads from, so a defined control proves the module graph loaded
+ * and the query mechanism works. Without it the three zeros below would be
+ * indistinguishable from a failed import, and a probe that renders a consumer
+ * without proving the registry is empty has measured nothing.
+ */
+function assertRegistriesEmptyWithControl(): void {
+  expect(getStudioCanvasPreview('object')).toBeTypeOf('function'); // control — MUST hit
+  expect(listMetadataPreviewTypes()).toEqual([]);
+  expect(listMetadataInspectorTypes()).toEqual([]);
+  expect(getMetadataInspector('object')).toBeUndefined();
+  expect(getMetadataInspector('flow')).toBeUndefined();
+  expect(getMetadataDefaultInspector('object')).toBeUndefined();
+}
+
+describe('Data pillar field rail — a field click must never be a no-op (#6795 C, site 1)', () => {
+  /**
+   * ⭐ The site the card never listed, and the real silent failure. The rail's
+   * guard read `(fieldSel.kind === 'group' || inspector)`, so a selected FIELD
+   * with `getMetadataInspector('object')` undefined dropped the whole `aside`:
+   * measured count **0**. Clicking a field did literally nothing while the
+   * designer above went on saying "click a field to edit its properties".
+   */
+  it('opens the rail and names the missing inspector instead of swallowing the click', async () => {
+    assertRegistriesEmptyWithControl();
+
+    render(
+      <MemoryRouter initialEntries={['/studio/com.example.showcase/data']}>
+        <DataPillar packageId="com.example.showcase" />
+      </MemoryRouter>,
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Form' }));
+    const card = (await screen.findByText('Title')).closest('.cursor-grab') as HTMLElement;
+    expect(card).toBeTruthy();
+    fireEvent.click(card);
+
+    // The regression this pin exists for: the aside used to be absent entirely.
+    const rail = await waitFor(() => {
+      const el = document.querySelector('aside');
+      expect(el).toBeTruthy();
+      return el as HTMLElement;
+    });
+    expect(rail).toHaveTextContent('Field properties');
+    expect(rail).toHaveTextContent(
+      'No field inspector is registered in this session, so this field’s properties cannot be edited here.',
+    );
+    // ⛔ The measured mechanism forbids promising recovery.
+    expect(rail.textContent ?? '').not.toMatch(/loading|try again/i);
+  });
+});
+
+describe('Interfaces pillar — the canvas must not blame the roadmap (#6795 C, site 2)', () => {
+  /**
+   * The retired copy — "{type} shows a read-only preview for now; design support
+   * is in progress." — was false twice over: this branch renders **no** preview
+   * at all, and page design support **exists**. It blamed the platform's roadmap
+   * for a chunk that did not load.
+   */
+  it('says the designers are unregistered, not that design support is in progress', async () => {
+    assertRegistriesEmptyWithControl();
+
+    render(
+      <MemoryRouter initialEntries={['/studio/com.acme.app/interfaces']}>
+        <InterfacesPillar packageId="com.acme.app" />
+      </MemoryRouter>,
+    );
+    fireEvent.click(await screen.findByTitle('page · home_page'));
+    await waitFor(() => expect(screen.getByTestId('canvas-mode-toggle')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    await screen.findByText(
+      'No metadata designers are registered in this session, so page cannot be previewed or designed here.',
+    );
+    expect(document.body.textContent ?? '').not.toContain('design support is in progress');
+    expect(document.body.textContent ?? '').not.toContain('read-only preview');
+  });
+
+  /**
+   * The other half of the same tableau: the rail told the author to click a
+   * canvas that is not rendered. An instruction that cannot be followed is a
+   * worse empty state than no instruction.
+   */
+  it('does not tell the author to click a canvas that is not there', async () => {
+    assertRegistriesEmptyWithControl();
+
+    render(
+      <MemoryRouter initialEntries={['/studio/com.acme.app/interfaces']}>
+        <InterfacesPillar packageId="com.acme.app" />
+      </MemoryRouter>,
+    );
+    fireEvent.click(await screen.findByTitle('page · home_page'));
+    await waitFor(() => expect(screen.getByTestId('canvas-mode-toggle')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    await screen.findByText(
+      'No metadata designers are registered in this session, so there is nothing to edit here.',
+    );
+    expect(document.body.textContent ?? '').not.toContain('Click a block on the canvas');
+  });
+});
+
+describe('Automations pillar — the fourth site, found by sweeping (#6795 C, site 4)', () => {
+  /**
+   * Not on the card and not in the ruling's list of three: found by sweeping
+   * every studio-design consumer that reads a metadata registry during render.
+   * Same class as the Interfaces rail — with the registries unpopulated the
+   * canvas degrades to a raw JSON dump, and BOTH the header chip ("Visual
+   * orchestration · click a node to configure") and the rail ("Click a node on
+   * the canvas, and its configuration appears here") went on instructing the
+   * author to click nodes that are not rendered.
+   */
+  it('replaces both "click a node" instructions with the reason there are no nodes', async () => {
+    assertRegistriesEmptyWithControl();
+
+    render(
+      <MemoryRouter initialEntries={['/studio/com.acme.app/automations']}>
+        <AutomationsPillar packageId="com.acme.app" />
+      </MemoryRouter>,
+    );
+    fireEvent.click(await screen.findByText('Nightly'));
+
+    await waitFor(
+      async () => {
+        const hits = await screen.findAllByText(
+          'No metadata designers are registered in this session, so this flow cannot be designed here.',
+        );
+        // Both the canvas header chip AND the rail — the two false instructions.
+        expect(hits.length).toBe(2);
+      },
+      { timeout: 4000 },
+    );
+    expect(document.body.textContent ?? '').not.toContain('click a node to configure');
+    expect(document.body.textContent ?? '').not.toContain('Click a node on the canvas');
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryPartial.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryPartial.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#6795 part C — the CONTRAST half of
+ * {@link file://./StudioDesignSurface.designerRegistryMissing.test.tsx}.
+ *
+ * `Preview === undefined` has exactly two causes and the Interfaces canvas must
+ * not confuse them:
+ *
+ *   1. **this type** has no designer while others do — a product fact;
+ *   2. the registries are empty **wholesale** because the module-scope
+ *      registration never ran — an environment fact.
+ *
+ * The retired single message asserted (2)'s cause in (1)'s words ("design
+ * support is in progress"), which is why it was wrong for pages. The repair
+ * tells them apart with `listMetadataPreviewTypes()` — a read of the same
+ * already-imported registry module, inventing no state.
+ *
+ * This file pins branch (1), so it DOES register a designer — for an unrelated
+ * type. It lives apart from the empty-registry pins because these registries are
+ * plain `Map`s: module state shared by every test in a file. Splitting them is
+ * what lets each file assert its own precondition instead of depending on test
+ * order.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const NAV = [{ id: 'nav_page', type: 'page', label: 'Home', pageName: 'home_page' }];
+
+const mockClient = {
+  save: vi.fn(async () => ({})),
+  list: vi.fn(async (type: string) => (type === 'app' ? [{ name: 'acme_app', label: 'Acme' }] : [])),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async (type: string, name: string) => {
+    if (type === 'app') return { effective: { name: 'acme_app', label: 'Acme', navigation: NAV } };
+    if (type === 'page') return { effective: { name: 'home_page', label: 'Home' } };
+    return { effective: { name } };
+  }),
+  getDraft: vi.fn(async () => null),
+  get: vi.fn(async () => undefined),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return { ...mod, useMetadataClient: () => mockClient, useMetadataTypes: () => ({ entries: [] }) };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+import { InterfacesPillar } from './StudioDesignSurface';
+import { listMetadataPreviewTypes, registerMetadataPreview } from '../metadata-admin/preview-registry';
+
+/**
+ * A designer for an unrelated type. The registry is now demonstrably populated,
+ * so a `page` leaf reaching the same fallback branch is reaching it for reason
+ * (1), not reason (2).
+ */
+function StubDashboardPreview(): React.ReactElement {
+  return <div data-testid="stub-dashboard-preview" />;
+}
+registerMetadataPreview('dashboard', StubDashboardPreview as never);
+
+afterEach(cleanup);
+
+describe('Interfaces canvas — a POPULATED registry still names the right cause (#6795 C)', () => {
+  it('says no designer is registered for this type, not that none loaded at all', async () => {
+    // Precondition, stated rather than assumed: the registry is non-empty, and
+    // this leaf's own type is not in it. Without this the assertion below could
+    // pass for the wrong reason.
+    expect(listMetadataPreviewTypes()).toEqual(['dashboard']);
+    expect(listMetadataPreviewTypes()).not.toContain('page');
+
+    render(
+      <MemoryRouter initialEntries={['/studio/com.acme.app/interfaces']}>
+        <InterfacesPillar packageId="com.acme.app" />
+      </MemoryRouter>,
+    );
+    fireEvent.click(await screen.findByTitle('page · home_page'));
+    await waitFor(() => expect(screen.getByTestId('canvas-mode-toggle')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    await screen.findByText(
+      'No designer is registered for page, so it cannot be previewed or designed here.',
+    );
+    // ⛔ Must NOT claim the whole registry is missing — it demonstrably is not.
+    expect(document.body.textContent ?? '').not.toContain(
+      'No metadata designers are registered in this session',
+    );
+    // ⛔ And must not resurrect the retired roadmap claim either.
+    expect(document.body.textContent ?? '').not.toContain('design support is in progress');
+  });
+
+  it('keeps the ordinary "click a block" empty state when designers ARE registered', async () => {
+    expect(listMetadataPreviewTypes()).toEqual(['dashboard']);
+
+    render(
+      <MemoryRouter initialEntries={['/studio/com.acme.app/interfaces']}>
+        <InterfacesPillar packageId="com.acme.app" />
+      </MemoryRouter>,
+    );
+    fireEvent.click(await screen.findByTitle('page · home_page'));
+    await waitFor(() => expect(screen.getByTestId('canvas-mode-toggle')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    // The repair must not over-fire: with the registry populated the rail keeps
+    // its normal invitation. Asserted on `textContent` rather than `findByText`
+    // because the two lines are split by a `<br />`, so no single element's text
+    // equals either line on its own.
+    await waitFor(() =>
+      expect(document.body.textContent ?? '').toContain(
+        'Click a block on the canvas,and edit its properties right here.',
+      ),
+    );
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -40,6 +40,7 @@ import { ObjectView as PluginObjectView } from '@object-ui/plugin-view';
 import { ListView } from '@object-ui/plugin-list';
 import { ObjectForm } from '@object-ui/plugin-form';
 import {
+  Ban,
   Boxes,
   FileText,
   Database,
@@ -73,11 +74,18 @@ import {
   PanelRightOpen,
   type LucideIcon,
 } from 'lucide-react';
-import { getMetadataPreview, type MetadataSelection } from '../metadata-admin/preview-registry.js';
+import {
+  getMetadataPreview,
+  listMetadataPreviewTypes,
+  type MetadataSelection,
+} from '../metadata-admin/preview-registry.js';
 import { getStudioCanvasPreview } from './studio-canvas-preview.js';
 import { PermissionMatrixEditPage } from '../metadata-admin/PermissionMatrixEditor.js';
 import { AccessExplainPanel } from '../metadata-admin/AccessExplainPanel.js';
-import { getMetadataInspector } from '../metadata-admin/inspector-registry.js';
+import {
+  getMetadataInspector,
+  listMetadataInspectorTypes,
+} from '../metadata-admin/inspector-registry.js';
 import { getMetadataDefaultInspector } from '../metadata-admin/default-inspector-registry.js';
 import { useMetadataClient, useMetadataTypes } from '../metadata-admin/useMetadata.js';
 import {
@@ -1400,6 +1408,25 @@ export function InterfacesPillar({
   // block tree, so `selection` never populates; without this the panel would
   // sit permanently on the "click a block" empty state.
   const DefaultInspector = getMetadataDefaultInspector(current?.type ?? '');
+  // objectui#6795 part C — WHY the three reads above can be `undefined` decides
+  // what this pillar may truthfully say, and there are exactly two causes:
+  //   1. no designer is registered for THIS type (others are) — a product fact;
+  //   2. the registries are empty wholesale, because the module-scope
+  //      registration side effect has not run — an environment fact.
+  // The retired copy asserted (2)'s cause with (1)'s wording ("design support is
+  // in progress") on a branch that renders no preview at all, so it was false
+  // either way. `list*Types()` is a read of the SAME already-imported registry
+  // module, so telling the two apart costs nothing and invents no state.
+  //
+  // ⛔ Neither branch may promise recovery. These registries are plain `Map`s
+  // with no change notification and every read here happens during render with
+  // no subscription, so a consumer that reads an empty registry never recovers
+  // when registration lands later (measured on #6795: "still fallback after
+  // registration: true | late inspector rendered: false"). "Loading…" / "try
+  // again" would swap one false statement for another; making recovery real is
+  // part A of that card.
+  const designersUnregistered =
+    listMetadataPreviewTypes().length === 0 && listMetadataInspectorTypes().length === 0;
   // Blocking author-time issues the right-rail inspector is showing — a CEL
   // predicate that does not parse must not be saveable here either
   // (objectui#4527). #4306 wired the Data pillar only, which left the SAME
@@ -1643,7 +1670,13 @@ export function InterfacesPillar({
           />
         ) : (
           <div className="py-12 text-center text-xs text-muted-foreground">
-            {tFormat('engine.studio.if.readonlyPreview', locale, { type: current.type })}
+            {tFormat(
+              designersUnregistered
+                ? 'engine.studio.if.designersMissing'
+                : 'engine.studio.if.noDesigner',
+              locale,
+              { type: current.type },
+            )}
           </div>
         )}
       </div>
@@ -1783,6 +1816,18 @@ export function InterfacesPillar({
           readOnly={false}
           locale={locale}
         />
+      </div>
+    ) : designersUnregistered ? (
+      // ⭐ #6795 part C. "Click a block on the canvas, and edit its properties
+      // right here" instructs the author to do something impossible: with the
+      // registries unpopulated the canvas beside this rail is the
+      // designers-missing notice, not a block tree, so there is nothing to
+      // click and nothing this rail could open if they did.
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
+          <Ban className="h-5 w-5" />
+          {t('engine.studio.inspector.designersMissing', locale)}
+        </div>
       </div>
     ) : (
       <div className="min-h-0 flex-1 overflow-auto p-3">
@@ -3073,7 +3118,17 @@ export function DataPillar({
         {/* Right rail — property inspector. Fields reuse the shared
           * ObjectFieldInspector; a selected group opens ObjectGroupInspector
           * (label + collapse behaviour). */}
-        {current && fieldSel && (fieldSel.kind === 'group' || inspector) && (
+        {/* ⭐ objectui#6795 part C — this guard used to read
+          * `(fieldSel.kind === 'group' || inspector)`, so with
+          * `getMetadataInspector('object')` undefined and a FIELD selected the
+          * whole rail was dropped: measured `aside` count 0, i.e. clicking a
+          * field did literally nothing while the designer above it went on
+          * saying "click a field to edit its properties". A selection the author
+          * just made must always open its rail; whether an EDITOR exists for it
+          * is a question the rail body answers, not a reason to swallow the
+          * click. (Unreachable in production today only because registration is
+          * eager — the very thing part A wants to make lazy.) */}
+        {current && fieldSel && (
           <aside className="flex w-80 shrink-0 flex-col border-l">
             <header className="sticky top-0 z-10 flex items-center gap-2 border-b bg-background/95 px-3 py-2 backdrop-blur">
               <SlidersHorizontal className="h-3.5 w-3.5" />
@@ -3099,8 +3154,7 @@ export function DataPillar({
                   readOnly={readOnly}
                   locale={locale}
                 />
-              ) : (
-                inspector &&
+              ) : inspector ? (
                 React.createElement(inspector, {
                   type: 'object',
                   name: current.name,
@@ -3114,6 +3168,16 @@ export function DataPillar({
                   readOnly,
                   locale,
                 })
+              ) : (
+                /* No field inspector registered. ⛔ Not "loading…" — these
+                 * registries have no change notification and this read happens
+                 * during render with no subscription, so a late registration
+                 * never reaches this component (measured on #6795). State the
+                 * fact; recovery is part A. */
+                <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
+                  <Ban className="h-5 w-5" />
+                  {t('engine.studio.data.fieldInspectorMissing', locale)}
+                </div>
               )}
             </div>
           </aside>
@@ -3206,7 +3270,7 @@ export function FlowStatusDot({ state, locale }: { state?: { enabled: boolean; b
   );
 }
 
-function AutomationsPillar({
+export function AutomationsPillar({
   packageId,
   publishNonce = 0,
   onDraftSaved,
@@ -3245,6 +3309,15 @@ function AutomationsPillar({
   const Preview = getMetadataPreview(current?.type ?? '');
   const inspector = getMetadataInspector('flow');
   const isEditable = !!Preview;
+  // objectui#6795 part C — the FOURTH site, found by sweeping past the three the
+  // ruling named. Same class as the Interfaces rail: with the registries
+  // unpopulated the canvas below degrades to a raw JSON dump, and both the
+  // header chip ("click a node to configure") and the rail ("Click a node on the
+  // canvas, and its configuration appears here") went on instructing the author
+  // to click nodes that are not rendered. Same constraint on the wording — ⛔ no
+  // "loading…"/"try again": a late registration never reaches this render.
+  const designersUnregistered =
+    listMetadataPreviewTypes().length === 0 && listMetadataInspectorTypes().length === 0;
 
   // Runtime enable/bound state per flow (GET /automation/_status). Persisted
   // `status` is intent; this is what's actually live in the engine — the truth
@@ -3517,7 +3590,10 @@ function AutomationsPillar({
         <main className="flex min-w-0 flex-1 flex-col overflow-auto bg-muted/30 p-4">
           <div className="mb-3 flex shrink-0 items-center gap-2">
             <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
-              <Workflow className="h-3 w-3" /> {t('engine.studio.auto.canvasHint', locale)}
+              <Workflow className="h-3 w-3" />{' '}
+              {isEditable
+                ? t('engine.studio.auto.canvasHint', locale)
+                : t('engine.studio.auto.designersMissing', locale)}
             </span>
             {current && <span className="text-[11px] text-muted-foreground">flow · {current.name}</span>}
           </div>
@@ -3583,6 +3659,11 @@ function AutomationsPillar({
                 readOnly: false,
                 locale,
               })
+            ) : designersUnregistered ? (
+              <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
+                <Ban className="h-5 w-5" />
+                {t('engine.studio.auto.designersMissing', locale)}
+              </div>
             ) : (
               <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
                 <MousePointer2 className="h-5 w-5" />


### PR DESCRIPTION
Part of #6795 — part **C** only, exactly as ruled (维护者, 2026-08-30, 第 5 场总监席决裁批 #4, verbatim「同意」): repair the misleading/silent consumer states now, defer part A (registry observability → lazy conversion) to the maintainer's sequencing surface.

⛔ Part A is untouched. No lazy conversion, no subscribe/notify, no `useSyncExternalStore`, no change to `MAX_EAGER_CLOSURE_GZIP_BYTES`, the #6683 `sideEffects` array, or `preview-gallery.tsx`. No registry module is in this diff.

## The mechanism that constrains what these messages may say

The three registries are plain `Map`s filled by a module-scope side effect, and every studio-design consumer reads them **during render with no subscription**. The card measured that a consumer which reads an empty registry **never recovers** when registration lands later:

```
fallback before registration: true | still fallback after registration: true | late inspector rendered: false
```

So every message here states a fact and **never promises recovery** — no "loading…", no "try again", no spinner. That would swap one false statement for another. Making recovery real is part A.

`Suspense` cannot repair any of this: these are *synchronous* reads returning `undefined`, and Suspense catches a thrown promise. Triage fenced this explicitly; it is mechanical, not stylistic.

## Sites — actual locations on this base (`03380aa14`)

The card's line numbers came from `26896c689` and were stale. Re-located:

| site | card said | actual location now | status |
|:--|:--|:--|:--|
| ⭐ Data pillar field rail | `StudioDesignSurface.tsx:3076` | **`:3076`** (unchanged), read at `:2564` | fixed |
| Interfaces canvas + rail | not line-numbered | canvas `:1646`, rail `:1786`, reads at `:1391`/`:1397`/`:1402` | fixed |
| `ObjectActionsPanel` | `:101` | **`:101`** (unchanged), render at `:266` | fixed |
| ⭐ **Automations pillar** | **not on the card at all** | reads at `:3245`/`:3246`, chip `:3520`, rail `:3574` | fixed (fourth site) |
| `ObjectSettingsPanel` | `:75` "silently empty" | `:75` | ⛔ untouched — already correct |
| `ObjectHooksPanel` | `:88` "silently empty" | `:88` | ⛔ untouched — already correct |

## Fourth-site sweep — result, with its control

Swept every registry read in `views/studio-design/`. The set is closed at six read sites (three in `StudioDesignSurface`, one each in the three panels); nothing else in the directory reads a metadata registry during render.

**Found a fourth site the card and the ruling both missed: the Automations pillar.** With the registries unpopulated it printed *two* false instructions at once — the canvas header chip *"Visual orchestration · click a node to configure"* and the rail *"Click a node on the canvas, and its configuration appears here."* — while the canvas below was a raw JSON dump with no nodes to click. Same class as the Interfaces rail, so it is repaired here.

**Control for the zero:** `getStudioCanvasPreview('object')` — registered at module scope inside the file the read comes from, so it **must** hit. Measured `function` in every probe while `listMetadataPreviewTypes()` and `listMetadataInspectorTypes()` were both `[]`. Without that control the zeros would be indistinguishable from a failed import.

**Deliberately NOT repaired, and why:** `studio-canvas-preview.tsx` reads its own registry but self-registers `object` in the same module, so it cannot be empty in this way — not in the class.

## Measured before / after (registries asserted empty first, every time)

| site | before | after |
|:--|:--|:--|
| Data pillar field rail | **`aside` count 0** — clicking a field did literally nothing, while the designer above it kept saying "click a field to edit its properties" | `aside` count **1**; rail opens with "Field properties" and names the missing inspector |
| Interfaces canvas | "page shows a read-only preview for now; design support is in progress." | "No metadata designers are registered in this session, so page cannot be previewed or designed here." |
| Interfaces rail | "Click a block on the canvas, and edit its properties right here." (no canvas) | "No metadata designers are registered in this session, so there is nothing to edit here." |
| Automations chip + rail | "click a node to configure" / "Click a node on the canvas…" (canvas was a JSON dump) | both replaced with "No metadata designers are registered in this session, so this flow cannot be designed here." |
| `ObjectActionsPanel` | "Send Email" alone — reads as *"this action has no properties"* | "Send Email" **plus** "No action editor is registered in this session, so this action's properties cannot be edited here." |

The Interfaces canvas message is **split into the two genuinely different causes**, because `Preview === undefined` has two of them and the retired sentence asserted one cause in the other's words. `listMetadataPreviewTypes()` tells them apart — a read of the same already-imported registry module, inventing no state:

- registry empty wholesale → `engine.studio.if.designersMissing`
- registry populated, this type has no designer → `engine.studio.if.noDesigner`

The retired `engine.studio.if.readonlyPreview` was false **twice over**: this branch renders no preview at all, *and* page design support exists.

## Pins

Three new files, 7 tests. Every empty-registry test asserts its own precondition (both `list*Types()` empty, the `get*` reads `undefined`) with the control above — a zero that is not asserted is not a reading.

- `StudioDesignSurface.designerRegistryMissing.test.tsx` — sites 1, 2, 4. Never registers a designer.
- `StudioDesignSurface.designerRegistryPartial.test.tsx` — the contrast: registry **populated**, this type has none. Separate file because these `Map`s are module state shared by a whole file, so splitting is what lets each file assert its own precondition instead of depending on test order.
- `ObjectActionsPanel.designerRegistryMissing.test.tsx` — site 3.

## Ablation

Predicted directions recorded **before** running. Mutation: revert the three repaired source files to `HEAD~1`, keeping the pins at `HEAD`. `i18n.ts` is included on purpose — reverting only the `.tsx` files would leave the reverted call site asking for a key the pack no longer defines, so the "must not contain the old text" half of each assertion would pass **vacuously**.

**Proven on disk, not by an editor exit code** — blob hashes and marker counts both:

| file | HEAD blob | mutated blob | markers |
|:--|:--|:--|:--|
| `StudioDesignSurface.tsx` | `d5abcd2d` | `77ca4ff3` | `designersUnregistered` 5→0, `fieldInspectorMissing` 1→0, `auto.designersMissing` 2→0 |
| `ObjectActionsPanel.tsx` | `37fd92ab` | `f58da0fe` | `actions.editorMissing` 1→0 |
| `i18n.ts` | `b04271c7` | `604b7487` | `if.designersMissing` 2→0; `readonlyPreview` 1→2 (old string restored) |

Pre-flight asserted each target pristine first, and an **empty** hash was treated as FAILURE, not as "nothing to compare". Restore leg used `git checkout HEAD --` (never a bare `git checkout --`, which reads from the polluted index), with absolute paths in an EXIT/INT/TERM trap.

**Predicted vs observed — 6 red, 1 green, exactly as predicted:**

| test | predicted | observed |
|:--|:--|:--|
| site 1, field rail | RED | **RED** |
| site 2, canvas | RED | **RED** |
| site 2, rail | RED | **RED** |
| site 4, automations | RED | **RED** |
| site 3, actions panel | RED | **RED** |
| contrast: "no designer for this type" | RED | **RED** |
| contrast: "click a block" survives with a populated registry | **GREEN, predicted** | **GREEN** |

That last green is reported because it is informative, not because it is a pass: it pins the **must-not-change** half, so it is expected to survive the ablation and tells me which layer it does *not* cover.

**Restore proven by state:** `git diff HEAD` = 0 lines, `git diff --cached` = 0 lines (the index too — path-scoped checkout stages what it writes), and all three blob hashes back to their HEAD values. No number in this PR was taken on a mutated tree.

## Gates — all run on the final commit `9ad81e0f1`

Exit codes captured **before** any pipe (`cmd > out 2>&1; EXIT=$?`), and each verdict quoted from the gate's own printed line.

| gate | exit | verdict |
|:--|:--|:--|
| `vitest run packages/app-shell/src/views/studio-design/` | 0 | **41 files / 218 tests passed** — the 3 new pins plus every pre-existing studio-design suite |
| `@object-ui/app-shell type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json` |
| `@object-ui/app-shell lint` (whole package, unnarrowed) | 0 | `2852 problems (0 errors, 2852 warnings)` |
| `check:i18n-keys` | 0 | "Every in-scope call-site key resolves against the en pack (2842 keys)…" |
| `check:i18n-drift` | 0 | "No en value changed in this range." |
| `check:i18n-dead-keys` | 0 | report-only; none of the six new keys appears (control `workspace.createFailed` hit twice) |
| `check:control-bytes` | 0 | "OK (scanned 5898 tracked text file(s))" |
| `check:eager-closure` | 0 | "Console eager closure is 3151.9 KB gzipped across 48 of 517 chunks (budget: 3191.4 KB, headroom: 39.5 KB)" — ceiling **untouched**, sensitivity green at 0.44x |
| `check:side-effects-array` | 0 | "names exactly the 14 module(s) that register at load time" |
| `check:sdui-registration-pins` | 0 | "All 16 registration(s) … present in the built console (517 chunks weighed)" |
| `check:readme-exports` | 0 | "OK (43 tracked README(s) … 0 unbuilt)" |
| `check:entry-guard` · `check:designer-field-key-parity` · `check:self-import` · `check:esm-specifiers` | 0 | green |
| `lint:coverage` · `type-check:coverage` | 0 | "46/46 packages linted, 0 with outstanding errors"; "41/41 packages compile their tests" |
| `check-changeset-presence` · `-no-major` · `-fixed` · `-overwrite` | 0 | "3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)" |

`check:readme-exports` and `check:sdui-registration-pins` are the two known to need a full build; both ran **after** `pnpm turbo run build --filter='./packages/*'` (39/39) and `apps/console build`, so they are real greens, not NOT MEASURED.

Two measurements worth naming precisely:

- **Lint is not a claim, it is a comparison.** The 20 warnings on `StudioDesignSurface.tsx` are **pre-existing**: linting the `HEAD~1` version of the same file under the same config gives the same **20 warnings / 0 errors**. My diff adds zero findings. Type-aware linting is not enabled in `eslint.config.js` (no `project` / `projectService`), so this diff cannot move the verdict on any file it does not itself contain.
- **The new test files really are typechecked.** `tsc -p tsconfig.test.json --listFiles` lists all three (control: `DataPillar.celGate.test.tsx` also listed; 4506 files in the program). The package `tsconfig.json` excludes `**/*.test.tsx`, so a green `tsc --noEmit` alone would have said nothing about them.

**Not re-measured:** the eager closure on the *base* tree — that needs a second full build. What is measured is that the gate is green with `MAX_EAGER_CLOSURE_GZIP_BYTES` untouched by this diff, which is what part C owes. (This diff can only *add* bytes, so the headroom-sensitivity gauge error the dispatch warned about — a byte *removal* — is not reachable from here.)

## One thing deliberately left

The Interfaces "Design" button is still offered when there is nothing designable. Repairing it means gating the Design/Run toggle on `isEditable`, which also reaches the `StudioCanvas` (object) leaves — where the registry is *populated* and the misleading state has a different cause. That is outside the registry-emptiness class this card is about, so it is filed rather than fixed; see the report comment on #6795.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_