### PR TITLE
fix(plugin-detail): let DetailSection's heuristic own the empty-section default

### DIFF
--- a/.changeset/7064-empty-section-default.md
+++ b/.changeset/7064-empty-section-default.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+**Behaviour change.** `record:details` no longer forces `hideEmpty` on the
+sections it synthesizes, so a sparse record keeps its section skeleton instead
+of collapsing. Applications relying on the old auto-hide of *unauthored*
+sections will now see headings, field labels and empty-value placeholders where
+rows used to vanish. This is the loud-over-silent direction, ruled by the
+maintainer on 2026-08-31: an empty detail body is a platform concern, and a
+metadata application should not have to author its way out of one.
+
+`RecordDetailsRenderer` mapped every authored section with
+`hideEmpty: s.hideEmpty ?? true`. `DetailSection` already states the correct
+rule in its own heuristic — *"If a section is entirely empty (e.g., loading
+state, brand-new record), do NOT auto-hide — the labels themselves are useful
+as a structural skeleton"* — and the forced default overrode exactly the case
+that sentence reserves. On a hand-created record whole sections disappeared and
+the body collapsed to a couple of rows; seeded demo data hid it. Every
+application then had to hand-write `hideEmpty: false` per section to stop
+looking broken, which is per-app tax for a platform defect. The renderer now
+passes the authored value through untouched and lets the heuristic own the
+default.
+
+What changes, precisely:
+
+- an **all-empty** section renders its heading, every field label and one
+  empty-value placeholder per field (it used to render nothing at all);
+- a **small** partly-empty section — below `DetailSection`'s auto-hide
+  threshold of 4 fields / 25% empty (3 / 20% on mobile) — now shows its empty
+  rows;
+- a **large** mostly-empty section with at least one filled row still
+  auto-hides, with the "Show N empty fields" toggle unchanged: the
+  label-graveyard guard is intact and this is not a return to dense-by-default;
+- empty rows are now visible while inline-editing a section, so an unwritten
+  field can be filled in place.
+
+What does **not** change: an authored `hideEmpty` keeps its exact former
+meaning. `hideEmpty: true` remains the explicit opt-in to hiding, and
+`hideEmpty: false` remains what it always was — "not `true`", not an override
+of the auto-hide heuristic (measured, and pinned as pre-existing).
+
+Reference-app hit inside this repo: the Studio metadata-admin page preview
+(`PagePreview`) binds a real sample record, so a `record:details` block over a
+sparse sample now previews the skeleton rather than a collapsed body. No
+application metadata needs editing — that is the point of the change.

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `record:details` — who owns the empty-section default (objectui#7064).
+ *
+ * `RecordDetailsRenderer` used to map every authored section with
+ * `hideEmpty: s.hideEmpty ?? true`. That forced default overrode the one case
+ * `DetailSection`'s own heuristic explicitly reserves:
+ *
+ *   "If a section is entirely empty (e.g., loading state, brand-new record),
+ *    do NOT auto-hide — the labels themselves are useful as a structural
+ *    skeleton."
+ *
+ * With the force in place an all-empty section took `DetailSection`'s
+ * all-fields-hidden early return instead, so a hand-created record lost whole
+ * sections and collapsed to a two-row body, and every application had to
+ * hand-write `hideEmpty: false` per section to stop looking broken — per-app
+ * tax for a platform concern (maintainer ruling 2026-08-31).
+ *
+ * The renderer now passes the authored value through untouched. These pins
+ * hold both halves of that contract:
+ *   - the UNAUTHORED default is the heuristic's, not the renderer's;
+ *   - an AUTHORED value keeps its exact former meaning.
+ *
+ * Deliberately no i18n provider: `fieldLabel` falls back to the value the
+ * renderer hands it, which for the spec's bare-string section fields is the
+ * field NAME. So the "labels" a skeleton shows here read as field names — the
+ * same DOM nodes a translated app fills with translated labels.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { RecordContextProvider } from '@object-ui/react';
+import { RecordDetailsRenderer } from '../record-details';
+
+/**
+ * No `name` / `title` / `subject` / `display_name` key anywhere: the renderer
+ * drops the page-H1 title field from the body (`titleCandidates`), which would
+ * make an absence assertion below pass for the wrong reason.
+ */
+const objectSchema = {
+  fields: {
+    industry: { type: 'text', label: 'Industry' },
+    stage: { type: 'text', label: 'Stage' },
+    amount: { type: 'text', label: 'Amount' },
+    close_date: { type: 'text', label: 'Close Date' },
+    next_step: { type: 'text', label: 'Next Step' },
+  },
+};
+
+/** A hand-created sparse record: one filled field, everything else unwritten. */
+const sparseData = { industry: 'Manufacturing' };
+
+const renderDetails = (schema: Record<string, unknown>, data: Record<string, unknown> = sparseData) =>
+  render(
+    <RecordContextProvider
+      objectName="crm_opportunity"
+      recordId="O1"
+      data={data}
+      objectSchema={objectSchema}
+    >
+      <RecordDetailsRenderer schema={schema as any} />
+    </RecordContextProvider>,
+  );
+
+/** The empty-value placeholder `DetailSection` draws for a field with no value. */
+const emptyPlaceholders = () => screen.queryAllByTitle('No value');
+
+describe('record:details — the UNAUTHORED empty-section default is DetailSection\'s heuristic (#7064)', () => {
+  it('an ALL-empty section renders its skeleton: heading, every field label, an empty placeholder each', () => {
+    renderDetails({
+      sections: [
+        { name: 'deal_terms', label: 'Deal Terms', fields: ['stage', 'amount', 'close_date', 'next_step'] },
+      ],
+    });
+
+    // The heading survives — the whole section used to disappear here.
+    expect(screen.getByText('Deal Terms')).toBeInTheDocument();
+
+    // Every field keeps its row, so the record reads as a structure waiting to
+    // be filled rather than as a blank page.
+    for (const label of ['stage', 'amount', 'close_date', 'next_step']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(emptyPlaceholders()).toHaveLength(4);
+  });
+
+  it('a SMALL partly-empty section (below the auto-hide threshold) now shows its empty row', () => {
+    // 2 fields, 1 empty: under DetailSection's minimum field count in both the
+    // desktop (4) and mobile (3) variant, so the auto-hide heuristic never
+    // fires and the empty row is shown. Under the old forced default this row
+    // was hidden. This is the second half of the user-visible behaviour change
+    // the changeset names — it is not limited to all-empty sections.
+    renderDetails({
+      sections: [
+        { name: 'summary', label: 'Summary', fields: ['industry', 'stage'] },
+      ],
+    });
+
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+    expect(screen.getByText('stage')).toBeInTheDocument();
+    expect(emptyPlaceholders()).toHaveLength(1);
+  });
+
+  it('the label-graveyard guard is INTACT: a large mostly-empty section still auto-hides', () => {
+    // 4 fields, 3 empty, 1 filled — at/above both threshold variants
+    // (min fields 4/3, empty ratio 25%/20%) with at least one filled row, so
+    // `shouldAutoHideEmpty` still fires exactly as before. Flipping the
+    // unauthored default did NOT turn populated pages into label graveyards;
+    // it only stopped overriding the all-empty case the heuristic reserves.
+    renderDetails({
+      sections: [
+        {
+          name: 'deal_terms',
+          label: 'Deal Terms',
+          fields: ['industry', 'stage', 'amount', 'close_date'],
+        },
+      ],
+    });
+
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+    expect(screen.queryByText('stage')).not.toBeInTheDocument();
+    expect(emptyPlaceholders()).toHaveLength(0);
+    // …and the user-facing escape hatch is offered for the rows it hid.
+    expect(screen.getByRole('button', { name: /empty fields/i })).toBeInTheDocument();
+  });
+});
+
+describe('record:details — an AUTHORED `hideEmpty` keeps its exact former meaning (#7064)', () => {
+  it('`hideEmpty: true` still hides an all-empty section entirely', () => {
+    renderDetails({
+      sections: [
+        { name: 'deal_terms', label: 'Deal Terms', fields: ['stage', 'amount', 'close_date', 'next_step'], hideEmpty: true },
+        // CONTROL: a sibling section that MUST render, so the absences below
+        // are a decision by `hideEmpty` and not a render that never happened.
+        { name: 'firmographics', label: 'Firmographics', fields: ['industry'] },
+      ],
+    });
+
+    expect(screen.getByText('Firmographics')).toBeInTheDocument();
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+
+    expect(screen.queryByText('Deal Terms')).not.toBeInTheDocument();
+    expect(screen.queryByText('stage')).not.toBeInTheDocument();
+    expect(emptyPlaceholders()).toHaveLength(0);
+  });
+
+  it('`hideEmpty: true` still hides the empty rows of a partly-filled section', () => {
+    renderDetails({
+      sections: [
+        { name: 'summary', label: 'Summary', fields: ['industry', 'stage'], hideEmpty: true },
+      ],
+    });
+
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+    expect(screen.queryByText('stage')).not.toBeInTheDocument();
+    expect(emptyPlaceholders()).toHaveLength(0);
+  });
+
+  it('`hideEmpty: false` shows the empty rows the heuristic would not have hidden anyway', () => {
+    renderDetails({
+      sections: [
+        { name: 'summary', label: 'Summary', fields: ['industry', 'stage'], hideEmpty: false },
+      ],
+    });
+
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+    expect(screen.getByText('stage')).toBeInTheDocument();
+    expect(emptyPlaceholders()).toHaveLength(1);
+  });
+
+  it('MEASURED, not endorsed: `hideEmpty: false` is "not true", NOT an override of the auto-hide heuristic', () => {
+    // `DetailSection` computes `shouldAutoHideEmpty` from `!section.hideEmpty`,
+    // so an authored `false` is indistinguishable from an unauthored section
+    // and the heuristic still hides empty rows once the thresholds are met.
+    // This is PRE-EXISTING and is NOT changed by #7064 — under the old forced
+    // default the same fixture took the same path, because `?? true` preserved
+    // an authored `false` too. Pinned so a future reader can see that the flip
+    // left this precedence exactly where it found it; whether `false` SHOULD
+    // become a hard override is a separate contract question.
+    renderDetails({
+      sections: [
+        {
+          name: 'deal_terms',
+          label: 'Deal Terms',
+          fields: ['industry', 'stage', 'amount', 'close_date'],
+          hideEmpty: false,
+        },
+      ],
+    });
+
+    expect(screen.getByText('Manufacturing')).toBeInTheDocument();
+    expect(screen.queryByText('stage')).not.toBeInTheDocument();
+    expect(emptyPlaceholders()).toHaveLength(0);
+  });
+});

--- a/packages/plugin-detail/src/renderers/record-details.tsx
+++ b/packages/plugin-detail/src/renderers/record-details.tsx
@@ -202,12 +202,27 @@ export const RecordDetailsRenderer: React.FC<RecordDetailsRendererProps> = ({
         // flat sections stay borderless so the page chrome alone provides
         // containment. Authors can override explicitly via `showBorder`.
         showBorder: s.showBorder ?? (translatedTitle ? true : false),
-        // Phase N: default to hide-empty so pages don't render as label
-        // graveyards on first load. Authors can opt back in to showing
-        // empty rows by setting `hideEmpty: false` explicitly. The
-        // "显示 N 个空字段" toggle in DetailSection still works as the
-        // user-facing escape hatch.
-        hideEmpty: s.hideEmpty ?? true,
+        // Deliberately NOT defaulted. The authored value passes through
+        // verbatim, so an UNAUTHORED section reaches DetailSection as
+        // `undefined` and that component's own stated heuristic decides:
+        // auto-hide empty rows only while the section still has at least one
+        // filled row, and never on an all-empty section — there the labels
+        // ARE the structural skeleton a sparse or brand-new record needs.
+        //
+        // This slot used to force `s.hideEmpty ?? true`, which overrode
+        // exactly the case that heuristic reserves: a hand-created record
+        // collapsed to a two-row body and whole sections vanished, and every
+        // app had to hand-write `hideEmpty: false` per section to stop looking
+        // broken. That is per-app tax for a platform concern (maintainer
+        // ruling 2026-08-31: this is a platform problem; metadata
+        // applications should not have to think about these details).
+        //
+        // An AUTHORED value is still honoured exactly as before —
+        // `hideEmpty: true` remains the explicit opt-in to hiding, and
+        // `hideEmpty: false` the explicit opt-out. Only the unauthored
+        // default flips. DetailSection's "Show N empty fields" toggle remains
+        // the user-facing escape hatch wherever the heuristic does hide rows.
+        hideEmpty: s.hideEmpty,
         fields: dropHidden(normaliseList(filterList(s.fields))),
       });
       })


### PR DESCRIPTION
Fixes #7064

Stops `RecordDetailsRenderer` forcing `hideEmpty: s.hideEmpty ?? true` onto every
section it synthesizes, so `DetailSection`'s own stated heuristic owns the
unauthored case. Maintainer ruling 2026-08-31 (hotcrm#1247 adjudication).

The one-line diff is `hideEmpty: s.hideEmpty ?? true,` becoming
`hideEmpty: s.hideEmpty,` — the authored value now passes through untouched.

## Force sites swept

`hideEmpty` occurs in 5 source files across the repo. Exactly **one** site
defaulted a `record:details` section's `hideEmpty`, and it is the one this PR
changes:

| site | verdict |
|---|---|
| `packages/plugin-detail/src/renderers/record-details.tsx:210` | **fixed** — the ruled site |
| `packages/plugin-detail/src/DetailSection.tsx` (heuristic + `hideEmptyEffective` + toggle) | left alone — this is the heuristic the ruling hands the case to |
| `packages/plugin-detail/src/renderers/record-reference-rail.tsx:232` (`schema.hideEmpty !== false`) | **left alone, reported** — different surface (`record:reference_rail`), a component-level key that folds rail *entries* whose related count is 0, not detail-section rows. Its default is spec-documented (`renderer default: on`). Outside the ruled class; same family as the sibling card objectui#7063 (dashboard widget empty state), which the ruling explicitly treats as a separate surface. |
| `packages/plugin-detail/src/index.tsx:731` | the rail's registered input (`defaultValue: true`) — belongs to the row above |
| `packages/types/src/views.ts:230` | the type declaration; unchanged |

No other renderer or mapper independently drops empty sections. `DetailView`
renders `schema.sections.map(...)` unconditionally — every section-hiding
decision is `DetailSection`'s single early return.

## Heuristic verified by rendering, not inferred from the comment

Rendered `RecordDetailsRenderer` over a sparse record inside a real
`RecordContextProvider` and dumped the DOM. `container.textContent` for an
all-empty 4-field section:

```
Deal Termsstage—amount—close_date—next_step—
```

The Card heading survives, a 2-column grid carries one row per field, each row
is a label plus the em-dash placeholder
(`aria-label="No value" title="No value"`). The heuristic is fully implemented;
the forced default was the only thing suppressing it.

## Precedence chain

`hideEmpty` is **per section only** — there is no page-level or view-level
`hideEmpty` with competing precedence. The effective chain inside
`DetailSection` is:

1. the user's per-session toggle (`showEmptyOverride`) wins over everything;
2. otherwise empties hide when `section.hideEmpty` is truthy **or**
   `shouldAutoHideEmpty` fires;
3. `shouldAutoHideEmpty` requires `!section.hideEmpty`, not editing, at least 4
   fields (3 on mobile), at least 25% empty (20% on mobile), **and at least one
   filled row** — that last clause is what reserves the all-empty case;
4. the whole section returns `null` only when every field is empty *and* all of
   them got filtered out.

⚠️ **Measured, and worth a decision:** `hideEmpty: false` is **not** an
override. Step 3 reads `!section.hideEmpty`, so an authored `false` is
indistinguishable from an unauthored section and the auto-hide heuristic still
fires above the thresholds. This is **pre-existing and unchanged by this PR** —
`?? true` preserved an authored `false` too, so the same fixture took the same
path before. Pinned as-is with a comment saying it records the measurement
rather than endorsing it.

## Behaviour delta (named in the changeset)

- an all-empty section renders heading, labels and placeholders — it used to
  render nothing;
- a **small** partly-empty section (below the 4-field / 25% thresholds) now
  shows its empty rows;
- a **large** mostly-empty section with a filled row still auto-hides, toggle
  and all — the label-graveyard guard is intact;
- empty rows are now visible while inline-editing, so an unwritten field can be
  filled in place (`shouldAutoHideEmpty` already excluded `isEditing`; the
  forced default overrode that too).

**Reference-app hit inside this repo:** the Studio metadata-admin page preview
(`packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx`) binds a
real sample record, so a `record:details` block over a sparse sample now
previews the skeleton instead of a collapsed body. Display-only; no file in
`packages/app-shell` was touched. No application metadata anywhere needs
editing — that is the point of the ruling.

## Tests

New pin file `packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx`
(7 cases): the all-empty skeleton, the below-threshold empty row, the intact
label-graveyard guard plus its toggle, `hideEmpty: true` hiding an all-empty
section (with a sibling section as the render control), `hideEmpty: true` hiding
rows in a partly-filled section, `hideEmpty: false` showing them, and the
measured `false`-is-not-an-override case.

**No existing test went red.** The PM's expectation that the suite encoded the
old default is falsified: baseline `packages/plugin-detail/` was 119 files /
1100 tests passing, and after the change it is 120 files / 1107 tests passing —
the delta is exactly this PR's new file. Nothing pinned `?? true`.

All runs below went through the shared heavy-verify lock; verdict lines are the
tools' own.

| run | verdict |
|---|---|
| `pnpm exec vitest run packages/plugin-detail/` **at `1895c0965`** | `Test Files 120 passed (120)` · `Tests 1107 passed (1107)` · lock `VERDICT command-exit 0` |
| baseline, same command at `71d83a6b1` | `Test Files 119 passed (119)` · `Tests 1100 passed (1100)` |
| 15 consumer test files referencing `record:details` in `apps/console`, `packages/app-shell`, `packages/core`, `packages/types` | `Test Files 15 passed (15)` · `Tests 329 passed (329)` |
| `pnpm --filter "@object-ui/plugin-detail" type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | exit 0 |
| `pnpm --filter "@object-ui/plugin-detail" lint` (`eslint .`) | `894 problems (0 errors, 894 warnings)`, exit 0 — all warnings pre-existing |
| `node scripts/check-changeset-presence.mjs` | `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/7064-empty-section-default.md.` |
| `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 5895 tracked text file(s); skipped 85 binary).` |
| `pnpm check:vi-mock-specifiers` | `✅ check-vi-mock-specifiers: OK` |
| `pnpm check:vi-mock-inherit` | `✅ check-vi-mock-inherit: OK` |
| `pnpm check:i18n-keys` | `Every in-scope call-site key resolves against the en pack (2842 keys)…`, exit 0 |
| `pnpm check:spec-symbols` | `✅ spec symbol derivation: … 0 untriaged collisions in 0 packages.` |
| `pnpm check:sdui-registration-pins` | first run **exit 2, NOT MEASURED** (`a run with nothing to read has measured nothing. Build the console first`); after building the console closure and the console: `✅ All 16 registration(s) a sideEffects array promises are present in the built console` |

Typecheck coverage is proven rather than assumed: `tsc -p tsconfig.test.json
--listFiles` lists the new pin file (1 hit) alongside the existing
`renderers/__tests__/record-details.test.tsx` control (1 hit) out of 1712 files,
so the "typecheck is clean" claim really covers the new tests.

Lint was narrowed to the affected package rather than the repo, and the
narrowing is a measurement: `eslint.config.js` declares no `project` /
`projectService` / `parserOptions`, so type-aware linting is off and a change in
these two files cannot move any verdict on an untouched file; `--format json`
over the two changed files reports 2 files, `0 errors`, and 32 warnings all of
the pre-existing `no-explicit-any` / `react-refresh` families the package
already carries 894 of. The repo-wide run stays CI's.

## Ablation

**Predicted before running:** restoring `?? true` turns exactly 2 of the 7 pins
red — the all-empty skeleton and the below-threshold empty row — and leaves the
other 5 green, because `?? true` is a no-op on an authored value and produces an
identical DOM on the auto-hide path.

**Observed:** `Tests 2 failed | 5 passed (7)`, and the two failures are exactly
the two predicted. The mutated DOM for the first is the failure mode the issue
describes — the section container renders completely empty:

```
TestingLibraryElementError: Unable to find an element with the text: Deal Terms.
```

…and the body printed by that failure is a `div.space-y-6` wrapping a single
self-closed `div.space-y-3 sm:space-y-4` — the section list element with no
section inside it. (Rendered here as prose: angle-bracket fragments do not
survive this repo's body sanitizer.)

No rebuild leg is owed: `vitest.config.mts` aliases every `@object-ui/*`
specifier to that package's `src`, and the pin file imports `../record-details`
relatively, so the mutation runs from source with no `dist` in the path.

Mutation proven on disk before the run — injected-line count 1, removed-line
count 0, control line (`showBorder: s.showBorder`) 1, blob
`bee9ec88115d566c98ba314ca665ddd0f426f5c1` to
`4b5d8813361ca109018c6ab312d6a37942d7270b`. Restore proven by state, not by exit
code: `git checkout HEAD --` against an absolute path (with an `EXIT INT TERM`
trap as the crash-path backstop), then blob back to
`bee9ec88115d566c98ba314ca665ddd0f426f5c1` and `git diff HEAD` empty. The final
suite run above is on the restored tree.

## Falsified assumptions, reported not fixed

1. **`hideEmpty` is not authorable on a `record:details` section at
   `@objectstack/spec` 17.2.0 — it is refused.** The issue and the dispatch both
   describe authored `hideEmpty` as a declared opt-out. Measured against the
   installed spec: `RecordDetailsProps.safeParse` on a section carrying
   `hideEmpty: true` returns `success: false` with
   `unrecognized_keys: ["hideEmpty"]`, message *"Unrecognized key(s) on this
   `record:details` section"*. Control in the same probe: a section carrying
   `columns: 2` parses and the value survives. So for any spec-validated page the
   key never reaches this renderer at all, and the old `?? true` was an
   unconditional platform policy with no author escape hatch. This PR is
   unaffected — the renderer still honours an authored value for the schemas that
   carry one (`@object-ui/types` declares `DetailViewSection.hideEmpty`), and the
   flip is what actually gives spec-validated pages the right behaviour with zero
   authoring. Flagged because the ruling's second clause reads differently once
   you know this.
2. **Stale comment, left alone.** `packages/plugin-detail/src/index.tsx:426-431`
   says the spec's section object "STRIPS" undeclared keys on parse. Since the
   `#4001` batch A work it refuses them loudly instead, per the measurement
   above. Not in this card's class and in a file this PR does not otherwise
   touch, so it is reported rather than fixed.
3. **No existing test encoded the old default** (detail above).

## hotcrm acceptance is unverified by me

The acceptance scenario names hotcrm `opportunity_detail_page` and
`case_detail_page` on hand-created records. **hotcrm is not in this session's
repo scope** and I did not reach it, so I claim nothing about those pages. The
evidence here is entirely objectui-side: component-level renders of
`RecordDetailsRenderer` through the real `DetailView` and `DetailSection` with
sparse fixtures. The hotcrm scenario needs a run by someone with that repo.

## Open question for the maintainer

Should `hideEmpty: false` become a hard override of the auto-hide heuristic?
Today it means "not `true`" (see Precedence chain). Left exactly as found and
pinned as measured, because changing it is a contract decision beyond this
ruling — but an author who writes `false` on a large sparse section today gets
no change in behaviour, which is its own quiet surprise.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_