### PR TITLE
fix(plugin-dashboard,i18n): a self-explaining default empty state for dashboard widgets

### DIFF
--- a/.changeset/7063-widget-empty-state-default.md
+++ b/.changeset/7063-widget-empty-state-default.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/plugin-dashboard': minor
+'@object-ui/i18n': minor
+---
+
+Dashboard/analytics widgets get a self-explaining DEFAULT empty state, stated
+once for the surface (objectui#7063).
+
+Maintainer ruling 2026-08-31 (hotcrm#1212, following hotcrm#1203): a widget that
+renders a bare row-placeholder on an empty result is the PLATFORM's defect and
+must be fixed uniformly — apps must not compensate widget by widget
+(objectstack#13848). The measured scenario is a fresh flagship-demo install:
+eleven populated tiles and one reading exactly `暂无数据行` mid-page, which reads
+as "the dashboard failed to load" even though the widget, its declaration and
+its (not yet produced) data are all legitimate.
+
+- New `WidgetEmptyState` is the seam the three dashboard surfaces now share.
+  There was no shared placeholder to fix: `DatasetWidget` wrote
+  `dashboard.noRows`, while `ObjectDataTable` and `PivotTable` wrote
+  `dashboard.noDataAvailable` — three renders, two strings, no common code.
+- The default now reads as a STATE, not a failure: `role="status"` (the empty
+  branches previously carried no role at all, while the failure branches beside
+  them are `role="alert"`), muted treatment with an inbox glyph rather than a
+  warning triangle, and a title plus an explanation where the placeholder was a
+  single terse fragment.
+- It names WHAT is empty with zero authored copy — the widget's data source,
+  which is the half the reader cannot already see (the tile's title is rendered
+  by the card header directly above). That is `widget.dataset` on the dataset
+  path and `schema.objectName` on the object-bound table/pivot; `PivotTable`
+  takes it as a new optional `sourceLabel` prop, which `ObjectPivotTable`
+  forwards.
+- Copy is platform i18n: `dashboard.empty.title` / `.message` / `.sourceLabel`
+  added to `en` and all nine sibling packs. No inline `defaultValue` and no
+  interpolation — the source renders as a labelled value, so no separator is
+  concatenated in code and every pack spells its own punctuation.
+
+No new authoring obligation and no new spec key. Note that the `emptyState`
+override the card assumes for this surface does not exist: `emptyState` is a
+LIST-view contract, and `@objectstack/spec`'s `DashboardWidgetSchema` declares no
+such key — so there is nothing here for an author to override, and adding one
+would be a contract question rather than a rider.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1053,6 +1053,17 @@ const ar = {
   },
   dashboard: {
     noRows: "لا توجد صفوف",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "لا توجد بيانات بعد",
+      message: "تم تحميل هذه الأداة بنجاح، لكن الاستعلام لم يُرجع أي سجلات بعد.",
+      sourceLabel: "مصدر البيانات:",
+    },
     loading: "جارٍ التحميل…",
     pickMeasures: "اختر المقاييس (القيم) لأداة مجموعة البيانات هذه.",
     datasetUnsupported: "مصدر البيانات هذا لا يدعم استعلامات مجموعات البيانات.",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1046,6 +1046,17 @@ const de = {
   },
   dashboard: {
     noRows: "Keine Zeilen",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "Noch keine Daten",
+      message: "Dieses Widget wurde erfolgreich geladen, die Abfrage hat aber noch keine Datensätze zurückgegeben.",
+      sourceLabel: "Datenquelle:",
+    },
     loading: "Wird geladen…",
     pickMeasures: "Wählen Sie Kennzahlen (Werte) für dieses Dataset-Widget.",
     datasetUnsupported: "Diese Datenquelle unterstützt keine Dataset-Abfragen.",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1248,6 +1248,17 @@ const en = {
     noDataAvailable: 'No data available',
     noDataSourceFor: 'No data source available for',
     noRows: 'No rows',
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: 'No data yet',
+      message: 'This widget loaded successfully and its query returned no records yet.',
+      sourceLabel: 'Source:',
+    },
     loading: 'Loading…',
     pickMeasures: 'Pick measures (values) for this dataset widget.',
     datasetUnsupported: 'This data source does not support dataset queries.',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1050,6 +1050,17 @@ const es = {
   },
   dashboard: {
     noRows: "Sin filas",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "Aún no hay datos",
+      message: "Este widget se cargó correctamente, pero la consulta todavía no ha devuelto ningún registro.",
+      sourceLabel: "Origen de datos:",
+    },
     loading: "Cargando…",
     pickMeasures: "Elija medidas (valores) para este widget de dataset.",
     datasetUnsupported: "Esta fuente de datos no admite consultas de dataset.",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1048,6 +1048,17 @@ const fr = {
   },
   dashboard: {
     noRows: "Aucune ligne",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "Pas encore de données",
+      message: "Ce widget s'est chargé correctement, mais la requête n'a encore renvoyé aucun enregistrement.",
+      sourceLabel: "Source de données :",
+    },
     loading: "Chargement…",
     pickMeasures: "Choisissez des mesures (valeurs) pour ce widget de dataset.",
     datasetUnsupported: "Cette source de données ne prend pas en charge les requêtes de dataset.",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1046,6 +1046,17 @@ const ja = {
   },
   dashboard: {
     noRows: "行がありません",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "まだデータがありません",
+      message: "このウィジェットは正常に読み込まれましたが、クエリはまだレコードを返していません。",
+      sourceLabel: "データソース:",
+    },
     loading: "読み込み中…",
     pickMeasures: "このデータセットウィジェットの指標（値）を選択してください。",
     datasetUnsupported: "このデータソースはデータセットクエリに対応していません。",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1046,6 +1046,17 @@ const ko = {
   },
   dashboard: {
     noRows: "행 없음",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "아직 데이터가 없습니다",
+      message: "이 위젯은 정상적으로 로드되었지만 쿼리가 아직 레코드를 반환하지 않았습니다.",
+      sourceLabel: "데이터 소스:",
+    },
     loading: "로딩 중…",
     pickMeasures: "이 데이터셋 위젯의 측정값(값)을 선택하세요.",
     datasetUnsupported: "이 데이터 소스는 데이터셋 쿼리를 지원하지 않습니다.",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1045,6 +1045,17 @@ const pt = {
   },
   dashboard: {
     noRows: "Sem linhas",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "Ainda sem dados",
+      message: "Este widget foi carregado com sucesso, mas a consulta ainda não retornou nenhum registro.",
+      sourceLabel: "Fonte de dados:",
+    },
     loading: "Carregando…",
     pickMeasures: "Escolha medidas (valores) para este widget de dataset.",
     datasetUnsupported: "Esta fonte de dados não oferece suporte a consultas de dataset.",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1056,6 +1056,17 @@ const ru = {
   },
   dashboard: {
     noRows: "Нет строк",
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: "Данных пока нет",
+      message: "Виджет успешно загружен, но запрос пока не вернул ни одной записи.",
+      sourceLabel: "Источник данных:",
+    },
     loading: "Загрузка…",
     pickMeasures: "Выберите меры (значения) для этого виджета набора данных.",
     datasetUnsupported: "Этот источник данных не поддерживает запросы к наборам данных.",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1119,6 +1119,17 @@ const zh = {
     noDataAvailable: '暂无数据',
     noDataSourceFor: '没有可用的数据源：',
     noRows: '暂无数据行',
+    // objectui#7063 — the DEFAULT empty state every dashboard widget renders
+    // when its query SUCCEEDED and returned nothing. `noRows` above is the
+    // terse fragment it replaces at the render site; the copy here has to
+    // read as a state rather than a failure, which is why it says the widget
+    // loaded. `sourceLabel` carries its own punctuation so the call site
+    // concatenates no separator (see `WidgetEmptyState`).
+    empty: {
+      title: '暂时还没有数据',
+      message: '该组件已成功加载，只是查询目前没有返回任何记录。',
+      sourceLabel: '数据源：',
+    },
     loading: '加载中…',
     pickMeasures: '请为该数据集组件选择度量（值）。',
     datasetUnsupported: '当前数据源不支持数据集查询。',

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -77,7 +77,10 @@ import {
 } from '@object-ui/core';
 import { cn, Skeleton, ChartSkeleton, GridSkeleton } from '@object-ui/components';
 import { useSafeFieldLabel, useSafeTranslate, useDisplayLocale } from '@object-ui/i18n';
-import { BarChart3, AlertTriangle, Download, ArrowUpIcon, ArrowDownIcon, MinusIcon, ChevronsUpDown, ChevronUp, ChevronDown } from 'lucide-react';
+import { AlertTriangle, Download, ArrowUpIcon, ArrowDownIcon, MinusIcon, ChevronsUpDown, ChevronUp, ChevronDown } from 'lucide-react';
+// objectui#7063 — the default empty state is stated ONCE for the dashboard
+// surface (see that component's header for why it is dashboard-local).
+import { WidgetEmptyState } from './WidgetEmptyState';
 import { useFilterScope } from '@object-ui/react';
 import { resolveFilterPlaceholders, computeMetricDelta } from './utils';
 import { metricAccentTextClass } from './colorVariants';
@@ -720,11 +723,26 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
       </div>
     );
   }
-  // A metric (single value) over an empty dataset is 0, not "No rows" — the
-  // latter reads as broken for KPIs like "Total Books" on a fresh app. Charts
-  // and tables keep the empty state (there is genuinely nothing to plot).
+  // A metric (single value) over an empty dataset is 0, not an empty state —
+  // the latter reads as broken for KPIs like "Total Books" on a fresh app.
+  // Charts and tables keep the empty state (there is genuinely nothing to
+  // plot).
+  //
+  // objectui#7063: this used to be a one-line `dashboard.noRows` fragment in a
+  // dashed box — 'No rows' / `暂无数据行` — with no role, no explanation and no
+  // mention of WHAT was empty, which is why a legitimately young tile read as
+  // "the dashboard failed to load" beside eleven populated ones. `datasetName`
+  // is `widget.dataset` and is non-empty on every path that reaches here (a
+  // widget with no dataset never mounts this component), but it is passed
+  // defensively so a blank binding degrades to the un-sourced copy rather than
+  // printing an empty label.
   if (state.rows.length === 0 && !isMetric) {
-    return <div className="flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-xs text-muted-foreground"><BarChart3 className="mr-2 h-4 w-4" />{tt('dashboard.noRows', 'No rows')}</div>;
+    return (
+      <WidgetEmptyState
+        className="rounded border border-dashed bg-muted/20"
+        source={datasetName || undefined}
+      />
+    );
   }
 
   // Measure metadata (label + format + currency) + header-label resolution,

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -30,6 +30,7 @@ import {
   isLookupType,
 } from './recordFields';
 import { RecordDetailDrawer } from './RecordDetailDrawer';
+import { WidgetEmptyState } from './WidgetEmptyState';
 
 export interface ObjectDataTableProps {
   schema: {
@@ -612,15 +613,18 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
   const dataSource = propDataSource || context?.dataSource;
   const boundData = useDataScope(schema.bind);
   const { fieldLabel, fieldOptionLabel } = useSafeFieldLabel();
-  let noDataLabel = 'No data available';
   let noDataSourceLabel = 'No data source available for';
   // useObjectTranslation is provider-safe (react-i18next falls back to the
   // global instance and never throws), so call it directly — no try/catch,
-  // which would make the hook conditional. The English defaults above stand
+  // which would make the hook conditional. The English default above stands
   // until a translation resolves.
+  //
+  // objectui#7063 removed this surface's second lookup (`noDataLabel` /
+  // `dashboard.noDataAvailable`): the empty branch now renders the shared
+  // `WidgetEmptyState`, which resolves its own copy. The no-data-SOURCE label
+  // below is a different state — a misconfigured binding, not an empty result
+  // — and keeps its own string.
   const { t } = useObjectTranslation();
-  const a = t('dashboard.noDataAvailable');
-  if (a && a !== 'dashboard.noDataAvailable') noDataLabel = a;
   const b = t('dashboard.noDataSourceFor');
   if (b && b !== 'dashboard.noDataSourceFor') noDataSourceLabel = b;
 
@@ -928,18 +932,19 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
     );
   }
 
-  // Empty state
+  // Empty state — the shared dashboard default (objectui#7063). It used to be a
+  // grid glyph over a bare `dashboard.noDataAvailable` line ('No data
+  // available' / `暂无数据`) with no role and no explanation, which is the
+  // same "reads as a load failure" shape the ruling is about — and it sat
+  // directly above an error block that DOES announce itself (`role="alert"`,
+  // destructive colours). `schema.objectName` is what this surface can name:
+  // the object the table is bound to. The wrapper keeps `table-empty-state`,
+  // which `ObjectDataTable.stableEmptyRows` and app-shell's widget DOM leak
+  // sweep both select on.
   if (finalData.length === 0) {
     return (
       <div className={cn('overflow-auto', className)} data-testid="table-empty-state">
-        <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 mb-2 opacity-40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-            <line x1="3" y1="9" x2="21" y2="9" />
-            <line x1="9" y1="21" x2="9" y2="9" />
-          </svg>
-          <p className="text-xs">{noDataLabel}</p>
-        </div>
+        <WidgetEmptyState source={schema.objectName || undefined} className="py-8" />
       </div>
     );
   }

--- a/packages/plugin-dashboard/src/ObjectPivotTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectPivotTable.tsx
@@ -286,12 +286,18 @@ export const ObjectPivotTable: React.FC<ObjectPivotTableProps> = ({ schema, data
 
   return (
     <>
+      {/* objectui#7063 — `sourceLabel` is the object this pivot is bound to,
+          named by the shared default empty state. Passed as a PROP because
+          `finalSchema` is a `PivotTableSchema`, which declares no
+          `objectName`; it survives the spread above only by accident and
+          reading it there would be reading a key the type denies. */}
       <PivotTable
         schema={finalSchema}
         className={className}
         rowLabels={rowLabels}
         columnLabels={colLabels}
         rowFieldLabel={rowFieldLabel}
+        sourceLabel={schema.objectName}
         onDrillDown={handleDrillDown}
       />
       {renderDrillDrawer()}

--- a/packages/plugin-dashboard/src/PivotTable.tsx
+++ b/packages/plugin-dashboard/src/PivotTable.tsx
@@ -8,16 +8,13 @@
 
 import React, { useMemo } from 'react';
 import type { PivotTableSchema, PivotAggregation } from '@object-ui/types';
-import { cn, DataEmptyState } from '@object-ui/components';
+import { cn } from '@object-ui/components';
 import { isDrillEnabled, type DrillEvent } from '@object-ui/core';
 import { useSafeTranslate } from '@object-ui/i18n';
+import { WidgetEmptyState } from './WidgetEmptyState';
 
 function useTotalLabel(): string {
   return useSafeTranslate()('dashboard.total', 'Total');
-}
-
-function useNoDataLabel(): string {
-  return useSafeTranslate()('dashboard.noDataAvailable', 'No data available');
 }
 
 export interface PivotTableProps {
@@ -34,6 +31,15 @@ export interface PivotTableProps {
   columnLabels?: Record<string, string>;
   /** Optional display label for the row field name (e.g. "Stage" for "stage"). */
   rowFieldLabel?: string;
+  /**
+   * What this pivot is bound to, named in the default empty state
+   * (objectui#7063). `ObjectPivotTable` passes its `schema.objectName`; a pivot
+   * over inline `schema.data` has no source to name and omits it. NOT read off
+   * `schema`: `PivotTableSchema` declares no `objectName`, so reading one would
+   * be reading a key the type says cannot be there — it survives
+   * `ObjectPivotTable`'s spread only by accident.
+   */
+  sourceLabel?: string;
   /**
    * Drill-down click handler. When provided **and** `schema.drillDown` is
    * enabled, cells / row & column headers / totals become interactive.
@@ -160,7 +166,7 @@ function aggregate(values: number[], fn: PivotAggregation): number {
  * Renders a matrix where rows correspond to `rowField`, columns to
  * `columnField`, and cells show the aggregated `valueField`.
  */
-export const PivotTable: React.FC<PivotTableProps> = ({ schema, className, rowLabels, columnLabels, rowFieldLabel, onDrillDown }) => {
+export const PivotTable: React.FC<PivotTableProps> = ({ schema, className, rowLabels, columnLabels, rowFieldLabel, sourceLabel, onDrillDown }) => {
   const {
     title,
     rowField,
@@ -176,7 +182,6 @@ export const PivotTable: React.FC<PivotTableProps> = ({ schema, className, rowLa
     drillDown,
   } = schema;
   const totalLabel = useTotalLabel();
-  const noDataLabel = useNoDataLabel();
 
   const drillEnabled = isDrillEnabled(drillDown) && typeof onDrillDown === 'function';
   const fireDrill = (ev: DrillEvent) => {
@@ -296,21 +301,11 @@ export const PivotTable: React.FC<PivotTableProps> = ({ schema, className, rowLa
         {title && (
           <h3 className="text-sm font-semibold mb-2">{title}</h3>
         )}
-        <DataEmptyState
-          data-testid="pivot-empty-state"
-          className="py-8 gap-2 [&>h3]:hidden"
-          icon={
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8 opacity-40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-              <rect x="3" y="3" width="7" height="7" />
-              <rect x="14" y="3" width="7" height="7" />
-              <rect x="3" y="14" width="7" height="7" />
-              <rect x="14" y="14" width="7" height="7" />
-            </svg>
-          }
-          iconWrapperClassName=""
-          title=""
-          description={noDataLabel}
-        />
+        {/* objectui#7063 — the shared dashboard default. The title used to be
+            suppressed outright (`title=""` plus `[&>h3]:hidden`), leaving a
+            grid glyph over a bare `dashboard.noDataAvailable` line: exactly
+            the "reads as a load failure" shape the ruling is about. */}
+        <WidgetEmptyState testId="pivot-empty-state" source={sourceLabel} className="py-8" />
       </div>
     );
   }

--- a/packages/plugin-dashboard/src/WidgetEmptyState.tsx
+++ b/packages/plugin-dashboard/src/WidgetEmptyState.tsx
@@ -1,0 +1,127 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * WidgetEmptyState — the DEFAULT empty state every dashboard/analytics widget
+ * renders when its query succeeded and returned nothing.
+ *
+ * ## Why this exists (objectui#7063)
+ *
+ * Maintainer ruling 2026-08-31 (hotcrm#1212, following hotcrm#1203): a widget
+ * that renders a bare row-placeholder on an empty result is the PLATFORM's
+ * defect, not the app's. The measured scenario is a fresh flagship-demo
+ * install: eleven populated tiles and one reading exactly `暂无数据行`
+ * (`dashboard.noRows`, 'No rows') mid-page. Nothing on screen says whether the
+ * dashboard failed or is simply young, so the tile reads as a load failure —
+ * and the only app-side remedy was authoring per-widget prose, which is the
+ * per-app tax objectstack#13848 rules against.
+ *
+ * Three widget surfaces had written that placeholder independently, in two
+ * different strings — `DatasetWidget` (`dashboard.noRows`), `ObjectDataTable`
+ * and `PivotTable` (both `dashboard.noDataAvailable`). There was no shared
+ * seam to fix; this component IS the seam, stated once for the dashboard
+ * surface so "uniformly" is a property of the code and not of three copies
+ * agreeing by hand.
+ *
+ * ## What makes it distinguishable from a load failure — the three properties
+ *
+ * 1. **`role="status"`, never `role="alert"`.** The failure paths beside each
+ *    call site (`DatasetWidget`'s `state.status === 'error'` box, the table's
+ *    error block) are `role="alert"` on destructive colours. Before this, the
+ *    empty branches carried NO role at all, so assistive tech got a bare
+ *    fragment with no state either way. The two roles are now the machine
+ *    check that the states are distinct, which is why no invented
+ *    `data-empty-*` attribute is added: the semantics already carry it.
+ * 2. **Muted treatment + an inbox glyph**, never destructive colour + a
+ *    warning triangle.
+ * 3. **A title AND an explanation**, where the placeholder used to be a single
+ *    terse fragment. The copy says the widget LOADED SUCCESSFULLY — the one
+ *    fact the reader of a blank tile cannot otherwise get.
+ *
+ * ## `source` names what is empty, and it is a raw identifier on purpose
+ *
+ * The card asks the default to name the widget's label and/or its data source
+ * rather than the bare placeholder. The widget's own title is already rendered
+ * by the `CardHeader` directly above every tile (`DashboardRenderer`), so
+ * repeating it here says nothing new; the DATA SOURCE is the half the reader
+ * cannot see. What is reachable at each render site is the authored binding —
+ * `widget.dataset` for the dataset path, `schema.objectName` for the
+ * object-bound table/pivot — i.e. a raw metadata name (`crm_forecast`), not a
+ * localized label. It is rendered as a labelled monospace value rather than
+ * folded into a sentence for exactly that reason: a truthful narrow statement
+ * beats an invented friendly one, and a label/value pair translates cleanly in
+ * every pack (including RTL) where a concatenated sentence would not.
+ *
+ * That is also why the copy carries no `{{interpolation}}`. `useSafeTranslate`
+ * takes a positional fallback and no options bag, so an interpolated key would
+ * have to come from a raw `useObjectTranslation` `t()` — and with no
+ * `I18nProvider` mounted (the standalone-host and test configuration) that
+ * renders the raw KEY unless the call site also carries an inline
+ * `defaultValue`, which objectui#3517 rules out. Label + value needs neither.
+ *
+ * ⚠️ NOT a cross-surface abstraction. `packages/plugin-detail`'s empty SECTION
+ * default (objectui#7064) is a sibling card on the same maintainer principle,
+ * dispatched in parallel; this component is deliberately dashboard-local and
+ * `DataEmptyState` — the presentational primitive both surfaces already use —
+ * is consumed here UNCHANGED. Converging the two is its own sequenced card,
+ * not a rider on either.
+ */
+
+import { cn, DataEmptyState } from '@object-ui/components';
+import { useSafeTranslate } from '@object-ui/i18n';
+import { Inbox } from 'lucide-react';
+
+export interface WidgetEmptyStateProps {
+  /**
+   * The authored binding this widget is empty FOR — `widget.dataset` on the
+   * dataset path, `schema.objectName` on the object-bound one. Omitted when the
+   * render site genuinely has no source to name (an inline-data pivot), in
+   * which case the title and explanation still stand on their own.
+   */
+  source?: string;
+  /** Layout classes for the surrounding tile; the muted/centred look is fixed. */
+  className?: string;
+  /**
+   * Test id for the root. Defaults to `widget-empty-state`; the table and pivot
+   * surfaces pass the ids their existing pins already select on
+   * (`table-empty-state` / `pivot-empty-state`, read by
+   * `ObjectDataTable.stableEmptyRows` and app-shell's widget DOM leak sweep).
+   */
+  testId?: string;
+}
+
+export function WidgetEmptyState({ source, className, testId }: WidgetEmptyStateProps) {
+  const tt = useSafeTranslate();
+  return (
+    <DataEmptyState
+      role="status"
+      data-testid={testId ?? 'widget-empty-state'}
+      className={cn(
+        'h-full w-full gap-2 p-4 [&>h3]:text-sm [&>h3]:font-medium [&>p]:text-xs',
+        className,
+      )}
+      icon={<Inbox className="h-5 w-5 text-muted-foreground/70" />}
+      iconWrapperClassName="flex size-9 items-center justify-center rounded-lg bg-muted"
+      title={tt('dashboard.empty.title', 'No data yet')}
+      description={tt(
+        'dashboard.empty.message',
+        'This widget loaded successfully and its query returned no records yet.',
+      )}
+    >
+      {source ? (
+        <p className="text-xs text-muted-foreground/80" data-testid="widget-empty-source">
+          {/* The label carries its own punctuation so no separator is
+              concatenated in code — `Source:` / `数据源：` / `:المصدر` each
+              spell it the way their language does. */}
+          <span>{tt('dashboard.empty.sourceLabel', 'Source:')}</span>{' '}
+          <span className="font-mono">{source}</span>
+        </p>
+      ) : null}
+    </DataEmptyState>
+  );
+}

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.test.tsx
@@ -253,13 +253,16 @@ describe('DatasetWidget', () => {
   // as empty/0 (a 0-value axis / blank table) instead of "loading".
   const pendingSource = () => ({ queryDataset: vi.fn(() => new Promise<{ rows: any[] }>(() => {})) });
 
-  it('shows a chart skeleton (not "No rows", not a 0-axis) while a chart query is pending', () => {
+  it('shows a chart skeleton (not the empty state, not a 0-axis) while a chart query is pending', () => {
     const src = pendingSource();
     const { container } = render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
     expect(screen.getByTestId('dataset-loading')).toBeInTheDocument();
     expect(container.querySelector('[data-slot="chart-skeleton"]')).toBeInTheDocument();
     // The empty state must NOT show while loading — that was the bug.
-    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+    // Selected by test id, not by the copy: objectui#7063 replaced the bare
+    // 'No rows' string, and a `queryByText` for a string that no longer exists
+    // anywhere passes for the wrong reason.
+    expect(screen.queryByTestId('widget-empty-state')).not.toBeInTheDocument();
   });
 
   it('shows a row (grid) skeleton while a table query is pending', () => {
@@ -284,14 +287,14 @@ describe('DatasetWidget', () => {
     expect(screen.getByTestId('dataset-loading')).toBeInTheDocument();
     // …then it clears once data arrives (status → ok, rows present).
     await waitFor(() => expect(screen.queryByTestId('dataset-loading')).not.toBeInTheDocument());
-    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('widget-empty-state')).not.toBeInTheDocument();
   });
 
-  it('shows 0 (not "No rows") for a metric over an empty dataset', async () => {
+  it('shows 0 (not an empty state) for a metric over an empty dataset', async () => {
     const src = makeSource(async () => ({ rows: [] }));
     render(<DatasetWidget widget={{ type: 'metric', dataset: 'books', values: ['count'] }} dataSource={src} />);
     expect(await screen.findByText('0')).toBeInTheDocument();
-    expect(screen.queryByText('No rows')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('widget-empty-state')).not.toBeInTheDocument();
   });
 
   it('formats the empty-metric zero (e.g. $0) using the measure format', async () => {
@@ -303,10 +306,52 @@ describe('DatasetWidget', () => {
     expect(await screen.findByText('$0')).toBeInTheDocument();
   });
 
-  it('still shows "No rows" for a dimensioned chart over an empty dataset', async () => {
+  // ── objectui#7063: the DEFAULT empty state is self-explaining ────────────
+  // Maintainer ruling 2026-08-31 (hotcrm#1212): a legitimately young widget
+  // must not read as a load failure, and it must say what is empty without any
+  // authored copy. The measured shape was a bare `暂无数据行` / 'No rows'
+  // fragment mid-dashboard beside eleven populated tiles.
+  //
+  // These pin the three properties the ruling fixes, NOT the exact sentence
+  // (copy is review's to move): the state announces itself as a STATUS rather
+  // than an alert, it carries an explanation as well as a title, and it names
+  // the widget's data source.
+  it('renders a self-explaining empty state for a dimensioned chart over an empty dataset', async () => {
     const src = makeSource(async () => ({ rows: [] }));
-    render(<DatasetWidget widget={{ type: 'bar', dataset: 'sales', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
-    expect(await screen.findByText('No rows')).toBeInTheDocument();
+    render(<DatasetWidget widget={{ type: 'bar', dataset: 'crm_forecast', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
+    const panel = await screen.findByTestId('widget-empty-state');
+    // (1) a state, not a failure. The error branch of this same component is
+    // `role="alert"`; before this card the empty branch carried NO role at all,
+    // so assistive tech could not tell the two apart either.
+    expect(panel).toHaveAttribute('role', 'status');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    // (2) title AND explanation — the placeholder was a single fragment.
+    expect(panel.textContent).toContain('No data yet');
+    expect(panel.textContent).toContain('loaded successfully');
+    // (3) it names WHAT is empty, with zero authored copy on the widget.
+    expect(screen.getByTestId('widget-empty-source').textContent).toContain('crm_forecast');
+  });
+
+  it('the empty state degrades to un-sourced copy rather than printing a blank source', async () => {
+    // `dataset` is what every path into this component carries, so this is the
+    // defensive half: a blank binding must drop the source LINE, not render
+    // "Source:" with nothing after it.
+    const src = makeSource(async () => ({ rows: [] }));
+    render(<DatasetWidget widget={{ type: 'bar', dataset: '', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
+    const panel = await screen.findByTestId('widget-empty-state');
+    expect(panel.textContent).toContain('No data yet');
+    expect(screen.queryByTestId('widget-empty-source')).not.toBeInTheDocument();
+  });
+
+  it('a load FAILURE still reads as a failure, not as an empty state', async () => {
+    // The other half of property (1), measured on the same component: the card
+    // is only satisfied if empty and failed remain distinguishable, so a fix
+    // that softened the error path would defeat it.
+    const src = { queryDataset: vi.fn(async () => { throw new Error('dataset service unreachable'); }) };
+    render(<DatasetWidget widget={{ type: 'bar', dataset: 'crm_forecast', dimensions: ['stage'], values: ['revenue'] }} dataSource={src} />);
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toContain('dataset service unreachable');
+    expect(screen.queryByTestId('widget-empty-state')).not.toBeInTheDocument();
   });
 
   // ── #2 header labels ────────────────────────────────────────────────────

--- a/packages/plugin-dashboard/src/__tests__/WidgetEmptyState.uniformDefault.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/WidgetEmptyState.uniformDefault.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7063 — the dashboard/analytics DEFAULT empty state, pinned at the
+ * SEAM rather than once per widget.
+ *
+ * Maintainer ruling 2026-08-31 (hotcrm#1212, following hotcrm#1203): a widget
+ * that renders a bare row-placeholder on an empty result is the platform's
+ * defect and must be fixed UNIFORMLY — apps must not compensate widget by
+ * widget (objectstack#13848).
+ *
+ * ## What "uniformly" had to mean here, measured
+ *
+ * The card's premise was that `暂无数据行` is ONE shared placeholder every
+ * affected widget reaches. It is not. Three dashboard surfaces wrote their own,
+ * in two different strings:
+ *
+ *   - `DatasetWidget`   -> `dashboard.noRows`          ('No rows' / `暂无数据行`)
+ *   - `ObjectDataTable` -> `dashboard.noDataAvailable` ('No data available')
+ *   - `PivotTable`      -> `dashboard.noDataAvailable`
+ *
+ * `emptyState` — the authored override the card assumes exists — appears ZERO
+ * times in `packages/plugin-dashboard` and `packages/plugin-charts` (control in
+ * the same sweep: `widget`, 1154 hits). It is a LIST-view contract
+ * (`ObjectGridSchema` / `NamedListView`, honoured in `plugin-list`), and
+ * `@objectstack/spec`'s `DashboardWidgetSchema` declares no such key at all.
+ *
+ * So there was no seam to fix; `WidgetEmptyState` IS the seam. This file pins
+ * that all three surfaces reach it, which is the property that decays first: a
+ * fourth widget added later can quietly write a fourth placeholder, and every
+ * per-widget test stays green while "uniformly" stops being true.
+ *
+ * ## It pins PROPERTIES, not the sentence
+ *
+ * The ruling fixes what the state must DO — read as a state and not a failure,
+ * describe itself with no authored copy, name what is empty, translate through
+ * the platform packs. Exact copy is review's to move, so the assertions here
+ * are the role, the presence of an explanation beside the title, and the source
+ * name — never a full-string equality.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { I18nProvider } from '@object-ui/i18n';
+import React from 'react';
+
+import { DatasetWidget } from '../DatasetWidget';
+import { ObjectDataTable } from '../ObjectDataTable';
+import { PivotTable } from '../PivotTable';
+import { ObjectPivotTable } from '../ObjectPivotTable';
+
+afterEach(cleanup);
+
+/** A dataSource whose every read succeeds and returns nothing. */
+const emptySource = () => ({
+  queryDataset: vi.fn(async () => ({ rows: [] })),
+  find: vi.fn(async () => []),
+  getObject: vi.fn(async () => ({ name: 'crm_forecast', fields: {} })),
+});
+
+describe('objectui#7063 — one self-explaining default across the dashboard surface', () => {
+  it('DatasetWidget (the measured surface) names its dataset', async () => {
+    render(
+      <DatasetWidget
+        widget={{ type: 'table', dataset: 'crm_forecast', dimensions: ['owner'], values: ['attainment'] }}
+        dataSource={emptySource()}
+      />,
+    );
+    const panel = await screen.findByTestId('widget-empty-state');
+    expect(panel).toHaveAttribute('role', 'status');
+    expect(panel.textContent).toContain('No data yet');
+    expect(screen.getByTestId('widget-empty-source').textContent).toContain('crm_forecast');
+  });
+
+  it('ObjectDataTable reaches the same default and names its object', async () => {
+    render(<ObjectDataTable schema={{ type: 'object-data-table', objectName: 'quota_attainment' } as any} dataSource={emptySource() as any} />);
+    // The wrapper keeps the id the pre-existing pins select on…
+    await waitFor(() => expect(screen.getByTestId('table-empty-state')).toBeInTheDocument());
+    // …and the shared default renders inside it.
+    const panel = screen.getByTestId('widget-empty-state');
+    expect(panel).toHaveAttribute('role', 'status');
+    expect(screen.getByTestId('widget-empty-source').textContent).toContain('quota_attainment');
+  });
+
+  it('PivotTable reaches the same default (id preserved for the app-shell sweep)', () => {
+    render(
+      <PivotTable
+        schema={{ type: 'pivot', rowField: 'stage', columnField: 'quarter', valueField: 'amount', data: [] }}
+        sourceLabel="crm_forecast"
+      />,
+    );
+    const panel = screen.getByTestId('pivot-empty-state');
+    expect(panel).toHaveAttribute('role', 'status');
+    // The pivot used to suppress its title outright (`title=""` plus a
+    // `[&>h3]:hidden` rule), leaving only the terse description.
+    expect(panel.textContent).toContain('No data yet');
+    expect(screen.getByTestId('widget-empty-source').textContent).toContain('crm_forecast');
+  });
+
+  it('ObjectPivotTable forwards its objectName as the source', async () => {
+    render(
+      <ObjectPivotTable
+        schema={{ type: 'object-pivot', objectName: 'crm_forecast', rowField: 'stage', columnField: 'quarter', valueField: 'amount' } as any}
+        dataSource={emptySource() as any}
+      />,
+    );
+    await waitFor(() => expect(screen.getByTestId('pivot-empty-state')).toBeInTheDocument());
+    expect(screen.getByTestId('widget-empty-source').textContent).toContain('crm_forecast');
+  });
+
+  it('the copy comes from the platform packs, not from an inline English default', async () => {
+    // The i18n half of the ruling: mounting a zh provider must move the whole
+    // default, title and explanation alike. An inline `defaultValue` (or a
+    // hard-coded string) renders English here and is untranslatable everywhere
+    // else — objectui#3517's exact failure, which is why this asserts on a
+    // MOUNTED provider rather than on the pack file's contents.
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <DatasetWidget
+          widget={{ type: 'table', dataset: 'crm_forecast', dimensions: ['owner'], values: ['attainment'] }}
+          dataSource={emptySource()}
+        />
+      </I18nProvider>,
+    );
+    const panel = await screen.findByTestId('widget-empty-state');
+    await waitFor(() => expect(panel.textContent).toContain('暂时还没有数据'));
+    expect(panel.textContent).toContain('已成功加载');
+    // The bare placeholder this card replaces must be gone from the rendered
+    // output — not merely joined by better copy.
+    expect(panel.textContent).not.toContain('暂无数据行');
+    // The source line keeps its own punctuation from the pack (`数据源：`), so
+    // no separator is concatenated in code.
+    expect(screen.getByTestId('widget-empty-source').textContent).toContain('数据源：');
+  });
+});


### PR DESCRIPTION
Fixes #7063

Maintainer ruling 2026-08-31 (hotcrm#1212 adjudication, verbatim 「1212 也是」, following 「hotcrm#1203 …这种也是平台的问题啊」): this class is the platform's to fix uniformly; apps must not compensate widget by widget (objectstack#13848 — apps are simplified business implementations, uniform behaviour belongs to the platform).

All evidence below was measured at **79accd66f** (the final commit on this branch).

---

## The card's premise was half wrong, and that changed the shape of the fix

Two of the dispatch's stated assumptions did not survive measurement. Both are reported here rather than worked around.

### 1. `暂无数据行` is NOT one shared placeholder — there was no seam to fix

Three dashboard surfaces wrote their own empty state, in **two different strings**, with no common code:

| surface | key | en | zh |
|---|---|---|---|
| `DatasetWidget` (the measured one) | `dashboard.noRows` | `No rows` | `暂无数据行` |
| `ObjectDataTable` | `dashboard.noDataAvailable` | `No data available` | `暂无数据` |
| `PivotTable` | `dashboard.noDataAvailable` | `No data available` | `暂无数据` |

`dashboard.noRows` had exactly **one** call site repo-wide (`DatasetWidget.tsx:727`), so the measured `暂无数据行` came from the dataset-bound path only — which is the ADR-0021 governed path the hotcrm quota-attainment tile takes.

So "uniformly" could not mean "fix the shared placeholder". The new `WidgetEmptyState` **is** the seam: it is added, and the three surfaces are routed through it.

### 2. The authored `emptyState` override does not exist on this surface

Clause 3 assumes an existing authored `emptyState` contract that always overrides. Measured:

- `emptyState` occurs **0 times** in `packages/plugin-dashboard/src` and `packages/plugin-charts/src`. Control in the same sweep, same paths: `widget`, **1154** hits — so the zero is a reading, not a broken query.
- `emptyState` is a **list-view** contract (`ObjectGridSchema`, `NamedListView` in `packages/types/src/objectql.ts`), honoured in `packages/plugin-list/src/ListView.tsx`.
- `@objectstack/spec@17.2.0`'s `DashboardWidgetSchema` declares no such key. Its full key set, read from the built package at runtime rather than recalled:

  `id, title, description, type, chartConfig, colorVariant, requiresObject, requiresService, actionUrl, actionType, actionIcon, filter, compareTo, dataset, dimensions, values, layout, options, filterBindings, suppressWarnings, responsive, aria`

**Consequence, and why this is not the stop-and-report case.** Clause 3 is satisfied here vacuously: there is no authored override on dashboard widgets for the default to lose to, so improving the default cannot displace one. **No spec key was added and none is needed** to deliver this card — the deliverable is a better DEFAULT, and defaults need no authoring surface. Making clause 3 non-vacuous (i.e. giving dashboard widgets a real authored override) *would* require a new spec key, which is the contract question the card fences off. That is flagged for the seat, not taken.

---

## What changed

**New:** `packages/plugin-dashboard/src/WidgetEmptyState.tsx` — the dashboard-local seam.

The ruling's four properties, and how each is delivered:

1. **Distinguishable from a load failure at a glance.** `role="status"`, where the failure branches sitting beside these call sites are `role="alert"` on destructive colours. The empty branches previously carried **no role at all**, so assistive tech got a bare fragment with no state either way. Visually: muted treatment and an inbox glyph, never destructive colour and a warning triangle.
2. **Self-describing without authored copy.** A title *and* an explanation where the placeholder was one terse fragment, plus the name of the widget's data source. The copy states that the widget **loaded successfully** — the one fact a reader of a blank tile cannot otherwise get.
3. **No new authoring obligation, no new spec key.** Nothing was added to any schema. `PivotTable` gains one optional *component* prop (`sourceLabel`), which is React-side only.
4. **Platform i18n.** `dashboard.empty.title` / `.message` / `.sourceLabel` in `en` and all nine sibling packs.

**What `source` names, and why it is a raw identifier.** The card allows the widget's label and/or its data source. The widget's title is already rendered by the card header directly above every tile (`DashboardRenderer`), so repeating it says nothing new; the data source is the half the reader cannot see. What is reachable at each render site is the authored binding — `widget.dataset` on the dataset path, `schema.objectName` on the object-bound table/pivot — i.e. a raw metadata name such as `crm_forecast`, not a localized label. It is rendered as a labelled monospace value rather than folded into a sentence: a truthful narrow statement beats an invented friendly one.

**Why the copy carries no interpolation.** `useSafeTranslate` takes a positional fallback and no options bag, so an interpolated key would have to come from a raw `useObjectTranslation` `t()` — and with no `I18nProvider` mounted (the standalone-host and test configuration, which `vitest.setup.i18n-global.ts` deliberately preserves) that renders the raw KEY unless the call site also carries an inline `defaultValue`, which #3517 rules out. A label that carries its own punctuation (`Source:` / `数据源：` / `مصدر البيانات:`) needs neither, and concatenates no separator in code.

**Files:** `WidgetEmptyState.tsx` (new) · `DatasetWidget.tsx` · `ObjectDataTable.tsx` · `PivotTable.tsx` · `ObjectPivotTable.tsx` · ten locale packs · one new test file · `DatasetWidget.test.tsx` · one changeset.

---

## Evidence

### Tests

`pnpm exec vitest run packages/plugin-dashboard packages/i18n packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx --maxWorkers=2` at 79accd66f:

```
 Test Files  144 passed (144)
      Tests  1924 passed (1924)
```

New pin: `packages/plugin-dashboard/src/__tests__/WidgetEmptyState.uniformDefault.test.tsx` (5 cases). It pins the ruling's **properties**, never the sentence — copy is review's to move. It also pins that all four dashboard entry points reach the one seam, which is the property that decays first: a fourth widget can quietly write a fifth placeholder while every per-widget test stays green.

Four pins in `DatasetWidget.test.tsx` were rewritten rather than left passing. Three of them asserted `queryByText('No rows')).not.toBeInTheDocument()` — after this change that string exists nowhere, so they would have passed for the wrong reason. They now select the empty state by test id.

### Ablation — two legs, direction predicted before running

**Leg 1** — revert `DatasetWidget`'s empty branch to the pre-card `dashboard.noRows` one-liner. *Predicted: RED, and only on the DatasetWidget surface.*

- mutation proven on disk: removed-marker `WidgetEmptyState` (as a JSX open tag) 1 to 0; injected-marker `tt('dashboard.noRows'` 0 to 1; blob `f8f61e71...` to `951c8251...`
- observed: `Tests 4 failed | 59 passed`, vitest exit 1 (read from the run's own printed `ABLATED_VITEST_EXIT=1`, not a bare `$?` behind a pipe). All four failures on the DatasetWidget surface; the `ObjectDataTable`, `PivotTable` and `ObjectPivotTable` cases stayed **green**, so the pins resolve per surface rather than firing as a block.
- restore proven by state: `git diff HEAD` empty, `git status --porcelain` empty, blob back to `f8f61e712947e3cdf3dacf3cdab3e6a8cccd25ba` = its HEAD blob.

**Leg 2** — delete `role="status"` from the shared component, i.e. ablate property (1) itself. *Predicted: RED on the role assertions; the load-failure test stays green.*

- mutation proven on disk: marker `role="status"` 2 to 1 (the second occurrence is in the file's doc comment; the python anchor asserted exactly one match on the JSX line); blob `a62aaa96...` to `39a46faf...`
- observed: `Tests 4 failed | 59 passed`, exit 1 — the three seam cases plus the `DatasetWidget.test.tsx` role case. **`a load FAILURE still reads as a failure` stayed green**, so the two halves of property (1) are independent.
- restore proven by state: `git diff HEAD` empty, blob back to `a62aaa96ec88cede54f96579451a6922b3aceb3a`.

Both legs used an `EXIT INT TERM` trap with an absolute `REPO_ROOT` path, and restored with `git checkout HEAD -- path` (never a bare `git checkout -- path`, which restores from the index and would hand back the mutation).

**No rebuild leg, stated rather than skipped.** This repo's vitest resolves `@object-ui/*` to `packages/*/src` via `resolve.alias` in `vitest.config.mts`, and the pins import the components by relative path, so no `dist` can shadow the mutation. A stale build cannot make an ablation falsely green here.

### Gates

| gate | exit | verdict |
|---|---|---|
| `vitest` (plugin-dashboard, i18n, widget-dom-leak-sweep) | 0 | green — 144 files, 1924 tests |
| `pnpm --filter @object-ui/plugin-dashboard --filter @object-ui/i18n run type-check` | 0 | green — both ran `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test file was type-checked, not merely excluded |
| `pnpm --filter @object-ui/plugin-dashboard --filter @object-ui/i18n run lint` | 0 | green — 0 errors (423 + 34 pre-existing warnings; 4 of them `no-explicit-any` on the new test file, the same schema-cast shape its sibling suites use) |
| `check:i18n-keys` | 0 | green — "Every in-scope call-site key resolves against the en pack (2845 keys)…" |
| `check:i18n-drift` | 0 | green — "0 en value(s) changed (3 key(s) added, 0 removed…)" — strictly additive |
| `check:control-bytes` | 0 | green — "OK (scanned 5898 tracked text file(s); skipped 85 binary)" |
| `check-changeset-presence` | 0 | green — "17 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)" |
| `check:changeset-fixed` | 0 | green — "All workspace packages are in the changeset fixed group." |
| `check:changeset-no-major` | 0 | green — "No changeset declares a `major` bump." |
| `check:phantom-deps` / `check:self-import` / `check:side-effects-array` / `check:vi-mock-specifiers` / `check:vi-mock-inherit` / `check:esm-specifiers` | 0 | green |
| `check:readme-exports` | 1 | **NOT MEASURED** — "the population COLLAPSED -- this run proves nothing / packagesRead: found 12, floor is 25". Local tree has most packages unbuilt; CI runs `turbo run build` first. Narrowing argument: `packages/plugin-dashboard/src/index.tsx` is untouched and does not export `WidgetEmptyState` (control in the same query: `PivotTable`, which it does export, hits), so the package's published export surface is unchanged and no README moved. |
| `check:eager-closure` | 2 | **NOT MEASURED** — "No eager-closure report at apps/console/dist/eager-closure.json … This is a broken gauge, not a sensitive gate." Needs a built `apps/console`; produced by `performance-budget.yml` in CI. |

Changeset verdicts are quoted verbatim above rather than predicted; both gates were run.

### Zero-hit readings, each with its control

| query | scope | hits | control | control hits |
|---|---|---|---|---|
| `emptyState` | `plugin-dashboard/src` + `plugin-charts/src` | **0** | `widget`, same scope | 1154 |
| `WidgetEmptyState` | `plugin-dashboard/src/index.tsx` | **0** | `PivotTable`, same file | 1 |

---

## What is NOT verified here, and why

**The hotcrm acceptance scenario is unverified by me.** The card's acceptance is a hotcrm `sales_dashboard` fresh install. **hotcrm is outside this session's repo scope** — it is not attached and I did not try to reach it. What I can state is the objectui-side mechanism: the quota-attainment tile is a dataset-bound table widget, which renders through `DatasetWidget`, whose empty branch is the one call site of the `暂无数据行` string this PR replaces. The end-to-end confirmation on a fresh hotcrm install still needs to be run by someone with that repo.

**Shared-abstraction temptation, reported rather than taken.** `DataEmptyState` in `@object-ui/components` is the presentational primitive already used by `plugin-list`, `plugin-kanban`, `plugin-dashboard` **and `plugin-detail`** — the surface of the parallel card #7064. Changing its defaults would have been a smaller diff that repaired both surfaces at once. It is deliberately consumed **unchanged** here: a shared empty-state abstraction designed twice in parallel by two agents is worse than two honest local fixes, and converging the two is its own sequenced card. Nothing under `packages/plugin-detail` is touched by this PR.

**Residue this creates, not fixed here.** `dashboard.noRows` and `dashboard.noDataAvailable` now have no call site. `check:i18n-dead-keys` (report-only, exit 0, not wired into CI) lists both as `needs-review` after this change. They are left in all ten packs deliberately: the dispatch asks locale edits to stay additive so parallel merges stay trivial, and the dead-key sweep is its own tracked workstream (objectui#4658). Filed as a follow-up rather than ridden on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_