### PR TITLE
fix(fields): FieldEditWidget delivers the declared NON-DOM host-plumbing block

### DIFF
--- a/.changeset/7008-field-edit-widget-host-plumbing.md
+++ b/.changeset/7008-field-edit-widget-host-plumbing.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/fields': minor
+'@object-ui/plugin-kanban': patch
+---
+
+`FieldEditWidget` now delivers the NON-DOM half of the contract it declares (objectui#7008).
+
+objectui#7009 made the factory forward its declared DOM pass-through block. The rest of
+`FieldWidgetComponentProps` was still dropped: `error`, `onUploadingChange`, and the whole
+"Host plumbing" block (`dataSource`, `dependentValues`, `dependsOn`, `dependsOnLabels`,
+`emptyHint`, `onSelectRecord`, `onCreateNew`). A host could pass any of them with no type
+error and the widget never received it — the "declared but not delivered" class this
+package treats as first-class.
+
+`error` was the live one. `InlineFieldInput` has passed `error` into this factory since
+PR #7109 and the factory dropped it, so an inline-edit control that had failed validation
+never reported `aria-invalid`: a sighted user saw the red hint, a screen-reader user was
+told nothing. The kanban `RequiredFieldsDialog` had the same hole from the other side — it
+computes the validation state and could not hand it over — and now passes `error`, so its
+controls are marked. Delivering `error` buys the a11y MARKING only; the message text stays
+with the host, per the objectui#3222 contract.
+
+The keys travel through a new sibling executor, `toHostProps` (exported alongside
+`toDomProps`), never through the DOM whitelist — none of them is DOM-legal, and routing a
+`dataSource` adapter there is the `[object Object]` leak that whitelist exists to stop.
+Three compile-time assertions make the two executors partition the contract, so a future
+declared key cannot go undelivered silently.
+
+`dataSource` precedence is stated rather than left to emerge: a host's explicit
+`dataSource` prop WINS over `SchemaRendererContext`. That is the order `LookupField`
+already implements; the factory is a conduit and resolves nothing. A host that passes no
+`dataSource` keeps reading the context exactly as before, so no in-repo host changes
+behaviour.

--- a/packages/fields/src/FieldEditWidget.tsx
+++ b/packages/fields/src/FieldEditWidget.tsx
@@ -11,6 +11,9 @@ import type { FieldWidgetComponentProps } from './widgets/types.js';
 // The package's own executor of the DOM pass-through declaration, reused here
 // rather than re-listed — see the note on this component's return statement.
 import { toDomProps } from './widgets/toDomProps.js';
+// The package's own executor of the NON-DOM half of the same declaration
+// (objectui#7008) — a separate function because those keys are not DOM-legal.
+import { toHostProps } from './widgets/toHostProps.js';
 
 // The SAME dedicated widgets the form renders — reused for in-place editing
 // (e.g. the data grid's inline cell editor) so a select edits as a dropdown, a
@@ -271,6 +274,40 @@ const COMPACT_EDIT_TYPES = new Set<string>(['lookup', 'master_detail', 'user']);
  * each widget's own whitelist carries these onto the real focusable control, so
  * nothing here needs to know which element that is. A host that passes nothing
  * is unaffected.
+ *
+ * The host's NON-DOM set is forwarded WHOLE too (objectui#7008), through the
+ * sibling executor `toHostProps`. The DOM fix left the other half of the
+ * contract undelivered: `error`, `onUploadingChange` and the "Host plumbing"
+ * block (`dataSource`, `dependentValues`, `dependsOn`, `dependsOnLabels`,
+ * `emptyHint`, `onSelectRecord`, `onCreateNew`) still type-checked, read as
+ * supported, and never reached the widget. `error` was the live one:
+ * `InlineFieldInput` has passed `error={error}` since PR #7109 and this factory
+ * dropped it, so a control that had failed validation never reported
+ * `aria-invalid`. Forwarding is not a widening — every one of those keys is
+ * already declared on `FieldWidgetComponentProps`, the same argument #7009
+ * landed on in this file.
+ *
+ * ⛔ They do NOT go through `toDomProps`. None of them is DOM-legal, and that
+ * whitelist is closed for exactly this reason — a `dataSource` adapter routed
+ * there becomes `dataSource="[object Object]"` on an `<input>`, the leak the
+ * helper exists to prevent. `toHostProps`' direction-3 assertion makes the two
+ * sets provably disjoint, so the order of the two spreads below is not a
+ * question anyone has to answer again.
+ *
+ * ## `dataSource` precedence: the explicit prop WINS
+ *
+ * Delivering `dataSource` can change behaviour where before it could not
+ * arrive, because the relational widgets fall back to `SchemaRendererContext`
+ * (which the grid already provides). The precedence is therefore STATED rather
+ * than left to emerge: **a host's explicit `dataSource` prop wins over the
+ * context**. That is not a new decision — `LookupField` already resolves
+ * `props.dataSource ?? lookupField?.dataSource ?? fieldMeta?.dataSource ??
+ * contextDataSource` and documents that order on the line that does it. This
+ * factory is a CONDUIT and resolves nothing: adding a resolution here would
+ * give `dataSource` a second author, the `field || schema` shape objectui#3233
+ * removed. A host that passes no `dataSource` keeps reading the context exactly
+ * as before, so no in-repo host changes behaviour. The full per-key precedence
+ * table lives on `toHostProps`, next to the list it governs.
  */
 export function FieldEditWidget(
   props: FieldWidgetComponentProps<any>,
@@ -324,9 +361,17 @@ export function FieldEditWidget(
   // The semantic props stay explicit and come AFTER the spread. They are not in
   // the whitelist, so there is no collision to resolve; ordering them this way
   // states that this component OWNS them and a host cannot displace them.
+  //
+  // `toHostProps` is the same reuse argument applied to the other half of the
+  // declaration (objectui#7008): the declared NON-DOM keys — `error` and the
+  // "Host plumbing" block — travel as COMPONENT props, never through the DOM
+  // whitelist, which is closed against exactly them. The two executors are
+  // asserted disjoint at compile time, so neither spread can shadow the other,
+  // and `compact` below still wins because the factory owns it.
   return (
     <Widget
       {...toDomProps(props)}
+      {...toHostProps(props)}
       field={field}
       value={value}
       onChange={onChange}

--- a/packages/fields/src/__tests__/FieldEditWidget.hostPlumbing-7008.test.tsx
+++ b/packages/fields/src/__tests__/FieldEditWidget.hostPlumbing-7008.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `FieldEditWidget` DELIVERS the NON-DOM half of the contract it DECLARES
+ * (objectui#7008) — the other half of objectui#6909 / #7009.
+ *
+ * ## The defect this pins closed
+ *
+ * #7009 made the factory forward `toDomProps(props)`, so the declared DOM block
+ * finally arrived. `FieldWidgetComponentProps` also declares `error`,
+ * `onUploadingChange`, and a whole "Host plumbing" block (`dataSource`,
+ * `dependentValues`, `dependsOn`, `dependsOnLabels`, `emptyHint`,
+ * `onSelectRecord`, `onCreateNew`) — and nothing carried any of it. A host
+ * passed them with no type error and the widget never received them.
+ *
+ * `error` was the LIVE one, and measurably so on `main` at `71d83a6b1`:
+ * `InlineFieldInput` (`@object-ui/plugin-detail`, since PR #7109) already
+ * passes `error={error}` into this factory, which dropped it — so a control
+ * that had failed validation never reported `aria-invalid`. A sighted user saw
+ * the red hint; a screen-reader user was told nothing. That is the class
+ * objectui#3222 / #3290 exist to close, and the one #7002 closed for
+ * `NumberField` one layer down.
+ *
+ * ## What binds it, and what this file adds
+ *
+ * The fix hands the widget `toHostProps(props)` — a SIBLING executor, not more
+ * entries in `DOM_PASS_THROUGH_KEYS`, because none of these keys is DOM-legal
+ * and that whitelist is closed against exactly them. Three compile-time
+ * assertions in `toHostProps.ts` make the two executors PARTITION the contract,
+ * so a future declared key cannot go undelivered without a red build.
+ *
+ * A type cannot see the two things this file pins: that the keys ARRIVE at
+ * runtime, and that arriving actually changes what assistive tech is told.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { SchemaRendererContext } from '@object-ui/react';
+
+import { FieldEditWidget } from '../FieldEditWidget';
+import type { FieldWidgetComponentProps } from '../widgets/types';
+
+afterEach(() => cleanup());
+
+/** `select` resolves to `SelectField`, whose trigger carries `aria-invalid`. */
+const SELECT_FIELD = {
+  name: 'stage',
+  type: 'select',
+  label: 'Stage',
+  options: [{ label: 'New', value: 'new' }],
+} as never;
+
+/** `text` resolves to `TextField` — used only where the widget is irrelevant. */
+const TEXT_FIELD = { name: 'f', type: 'text', label: 'F' } as never;
+
+describe('FieldEditWidget delivers its declared NON-DOM block (objectui#7008)', () => {
+  it('forwards every declared host-plumbing key it is handed, at the factory boundary', () => {
+    const onUploadingChange = vi.fn();
+    const onSelectRecord = vi.fn();
+    const onCreateNew = vi.fn();
+    const dataSource = { find: vi.fn() };
+
+    // `zzcanary` is the control, carried over from the #7009 pin: NOT declared
+    // on `FieldWidgetComponentProps` (passing it is a compile error, hence the
+    // cast), but an SDUI node or a field config can carry exactly such a key at
+    // runtime. Without it, "everything forwards now" would be
+    // indistinguishable from having reopened the bare `{...props}` spread.
+    const props = {
+      field: TEXT_FIELD,
+      value: '',
+      onChange: () => {},
+      readonly: false,
+      // the two declared controlled-input keys the factory neither owns nor
+      // routes to the DOM
+      error: 'Required',
+      onUploadingChange,
+      // the declared "Host plumbing" block, minus `compact` (factory-owned)
+      dataSource,
+      dependentValues: { account: 'a1' },
+      dependsOn: 'account',
+      dependsOnLabels: { account: 'Account' },
+      emptyHint: 'Pick an account first',
+      onSelectRecord,
+      onCreateNew,
+      zzcanary: 'CANARY-STR',
+    } as unknown as FieldWidgetComponentProps<string>;
+
+    // Called as a plain function rather than rendered: it uses no hooks and its
+    // return value IS the widget element, so this reads the handoff itself.
+    const element = FieldEditWidget(props);
+    expect(element).not.toBeNull();
+    const forwarded = element!.props as Record<string, unknown>;
+
+    // Exact set, not a subset — a subset check cannot see the control key, and
+    // an extra key appearing here is the leak this guards.
+    expect(Object.keys(forwarded).sort()).toEqual(
+      [
+        // rendered by the factory itself
+        'field',
+        'value',
+        'onChange',
+        'readonly',
+        // the declared NON-DOM keys, via `toHostProps`
+        'error',
+        'onUploadingChange',
+        'dataSource',
+        'dependentValues',
+        'dependsOn',
+        'dependsOnLabels',
+        'emptyHint',
+        'onSelectRecord',
+        'onCreateNew',
+      ].sort(),
+    );
+
+    // Identity, not just presence: a conduit hands over the host's own object.
+    expect(forwarded.dataSource).toBe(dataSource);
+    expect(forwarded.onSelectRecord).toBe(onSelectRecord);
+    expect(forwarded.onCreateNew).toBe(onCreateNew);
+    expect(forwarded.onUploadingChange).toBe(onUploadingChange);
+    expect(forwarded.error).toBe('Required');
+
+    // CONTROL: the undeclared authored key is still dropped.
+    expect(forwarded).not.toHaveProperty('zzcanary');
+  });
+
+  it('CONTROL: a key the host did not pass stays ABSENT, not `undefined`', () => {
+    // The #7009 pin asserts an exact boundary set for a host that passes only
+    // DOM keys. Forwarding the non-DOM block as nine always-present
+    // `undefined`s would have broken that pin AND made the boundary unreadable
+    // — "what the host supplied" is the claim, so absence must survive.
+    const element = FieldEditWidget({
+      field: TEXT_FIELD,
+      value: '',
+      onChange: () => {},
+    } as FieldWidgetComponentProps<string>);
+    expect(element).not.toBeNull();
+    const forwarded = element!.props as Record<string, unknown>;
+
+    for (const key of [
+      'error',
+      'onUploadingChange',
+      'dataSource',
+      'dependentValues',
+      'dependsOn',
+      'dependsOnLabels',
+      'emptyHint',
+      'onSelectRecord',
+      'onCreateNew',
+    ]) {
+      expect(forwarded).not.toHaveProperty(key);
+    }
+    // CONTROL: the factory's own props are still there, so the assertion above
+    // is not passing because the handoff is empty.
+    expect(forwarded).toHaveProperty('field');
+    expect(forwarded).toHaveProperty('value');
+  });
+
+  it('`error` reaches a real control as `aria-invalid` — the live a11y defect', async () => {
+    const { getByTestId, rerender } = render(
+      <FieldEditWidget field={SELECT_FIELD} value="" onChange={() => {}} error="Required" />,
+    );
+    // `SelectField` puts the DOM pass-through and `aria-invalid` on
+    // `SelectTrigger` — the focusable `button role="combobox"` the user and
+    // their screen reader actually meet (objectui#3306) — not on Radix `Root`,
+    // which renders no element.
+    const trigger = getByTestId('select-trigger-stage');
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('aria-invalid', 'true');
+
+    // CONTROL: the same widget, same host, no `error`. `SelectField` computes
+    // `!!error`, so a valid field SAYS "false" rather than staying mute — which
+    // makes this a real two-state reading and not "the attribute exists".
+    rerender(<FieldEditWidget field={SELECT_FIELD} value="" onChange={() => {}} />);
+    expect(getByTestId('select-trigger-stage')).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('`dataSource`: the explicit prop WINS over SchemaRendererContext', async () => {
+    // The one delivered key that can CHANGE behaviour rather than only add it:
+    // the relational widgets fall back to `SchemaRendererContext` (which the
+    // grid already provides), so delivering the prop creates a precedence
+    // question. `LookupField` already resolves "explicit prop > field-level >
+    // wrapper field > SchemaRendererContext > none"; the factory is a conduit
+    // and adds no second authority. This pins that the delivered prop is what
+    // the widget ends up querying.
+    const LOOKUP_FIELD = { name: 'account', type: 'lookup', reference_to: 'accounts' } as never;
+    const makeSource = () => ({
+      find: vi.fn().mockResolvedValue([]),
+      getObjectSchema: vi.fn().mockResolvedValue({ name: 'accounts' }),
+    });
+
+    const fromProp = makeSource();
+    const fromContext = makeSource();
+
+    render(
+      <SchemaRendererContext.Provider value={{ dataSource: fromContext } as never}>
+        <FieldEditWidget
+          field={LOOKUP_FIELD}
+          value={undefined}
+          onChange={() => {}}
+          dataSource={fromProp}
+        />
+      </SchemaRendererContext.Provider>,
+    );
+
+    await waitFor(() => expect(fromProp.getObjectSchema).toHaveBeenCalledWith('accounts'));
+    expect(fromContext.getObjectSchema).not.toHaveBeenCalled();
+
+    cleanup();
+
+    // CONTROL: drop the prop and the SAME context source IS queried. Without
+    // this, "the context was not called" would be indistinguishable from a
+    // context that was never wired up in this test at all.
+    const contextOnly = makeSource();
+    render(
+      <SchemaRendererContext.Provider value={{ dataSource: contextOnly } as never}>
+        <FieldEditWidget field={LOOKUP_FIELD} value={undefined} onChange={() => {}} />
+      </SchemaRendererContext.Provider>,
+    );
+    await waitFor(() => expect(contextOnly.getObjectSchema).toHaveBeenCalledWith('accounts'));
+  });
+});

--- a/packages/fields/src/index.tsx
+++ b/packages/fields/src/index.tsx
@@ -3347,6 +3347,15 @@ export { withFieldCarrier } from './withFieldCarrier.js';
 export { toDomProps } from './widgets/toDomProps.js';
 export type { DomProps } from './widgets/toDomProps.js';
 
+// The sibling executor for the NON-DOM half of the same declaration
+// (objectui#7008): `error` plus the "Host plumbing" block, forwarded as
+// COMPONENT props because none of them is DOM-legal. Exported alongside
+// `toDomProps` because a host factory authored outside this repo needs the
+// pair — reaching for only the first one is how `FieldEditWidget` came to
+// deliver half the contract it declares.
+export { toHostProps } from './widgets/toHostProps.js';
+export type { HostProps } from './widgets/toHostProps.js';
+
 // The native date/time control value adapters (objectui#3127). `DateTimeField`
 // is ISO-canonical on BOTH sides — it takes the record's ISO instant and hands
 // an ISO instant back, which is also the wire form the platform's `datetime`

--- a/packages/fields/src/widgets/toDomProps.ts
+++ b/packages/fields/src/widgets/toDomProps.ts
@@ -123,7 +123,16 @@ const DOM_PASS_THROUGH_KEYS = [
   'disabled',
 ] as const;
 
-type DomPassThroughKey = (typeof DOM_PASS_THROUGH_KEYS)[number];
+/**
+ * The keys this helper forwards.
+ *
+ * Exported so the SIBLING executor — `toHostProps`, which carries the declared
+ * NON-DOM keys (objectui#7008) — can subtract this set from the contract and
+ * assert that the two together cover every declared key exactly once. Without
+ * that subtraction there is no way to state "these keys are handled elsewhere"
+ * as a compile-time fact rather than as a comment.
+ */
+export type DomPassThroughKey = (typeof DOM_PASS_THROUGH_KEYS)[number];
 
 /**
  * Compile-time link to the declaration, direction 1 of 2: every key forwarded

--- a/packages/fields/src/widgets/toHostProps.ts
+++ b/packages/fields/src/widgets/toHostProps.ts
@@ -1,0 +1,208 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type { AriaAttributes } from 'react';
+import type { DomPassThroughKey } from './toDomProps.js';
+import type { FieldWidgetComponentProps } from './types.js';
+
+/**
+ * The RUNTIME EXECUTOR of the NON-DOM half of {@link FieldWidgetComponentProps}
+ * (objectui#7008) — the sibling of `toDomProps`, and deliberately a SEPARATE
+ * function rather than more entries in that whitelist.
+ *
+ * ## The defect
+ *
+ * objectui#6909 / #7009 closed the DOM half at `FieldEditWidget`: the factory
+ * hands the widget `toDomProps(props)`, so `id` / `name` / `tabIndex` /
+ * `aria-*` / `data-*` and friends finally arrive. The contract also declares a
+ * "Host plumbing" block plus two controlled-input keys the factory neither owns
+ * nor routes to the DOM, and NOTHING carried those. A host could pass any of
+ * them with no type error and the widget never received it — this package's own
+ * first-class defect class, named in `toDomProps.ts`: "a key that type-checks,
+ * reads as supported, and silently never reaches the element" (objectui#3290's
+ * `aria-required`, objectui#3222's validation slot).
+ *
+ * Measured on `main` at `71d83a6b1`, the live victim was `error`:
+ * `InlineFieldInput` (`@object-ui/plugin-detail`, since PR #7109) already
+ * passes `error={error}` to `FieldEditWidget`, and the factory dropped it on
+ * the floor — so a control that had failed validation never reported
+ * `aria-invalid` and a screen-reader user was never told. The kanban
+ * `RequiredFieldsDialog` had the same hole from the other side: it computes the
+ * validation state, renders it in red text, and had no way to hand it over.
+ *
+ * ## Why NOT more keys in `DOM_PASS_THROUGH_KEYS`
+ *
+ * Because none of them is DOM-legal. That whitelist is deliberately closed and
+ * exists precisely to stop renderer plumbing reaching an element — its own
+ * header names `error`, `emptyHint`, `dataSource`, `dependentValues` and
+ * `dependsOn` as examples of what a blacklist would have failed to catch. Put
+ * them there and a `dataSource` adapter becomes `dataSource="[object Object]"`
+ * on an `<input>`. They travel as COMPONENT props, which is what they are.
+ *
+ * ## Declared = enforced, in both directions
+ *
+ * The three assertions below make the two executors PARTITION the contract:
+ * every declared key is DOM-handled, forwarded here, or named as one the
+ * factory itself owns. A key added to `FieldWidgetComponentProps` that is none
+ * of those is a compile error, so the next non-DOM key cannot repeat this bug.
+ *
+ * ## Precedence: this is a CONDUIT, and never a second authority
+ *
+ * Several of these keys have a context-based fallback inside the widget that
+ * reads them, so DELIVERING one can change behaviour where before it could not
+ * arrive at all. The rule is stated once, here, and this function implements it
+ * by doing nothing: it forwards what the host passed and resolves NOTHING.
+ * Each key's precedence stays where its single reader already implements and
+ * documents it —
+ *
+ *  - `dataSource`: **the explicit prop WINS** over `SchemaRendererContext`.
+ *    `LookupField` already resolves exactly that order and says so on the line
+ *    that does it: "explicit prop > field-level > wrapper field >
+ *    SchemaRendererContext > none". Hosts that pass nothing keep reading the
+ *    context, so the grid's inline editor is unaffected.
+ *  - `dependentValues`: the explicit prop wins, then `ctx.formValues`, then
+ *    `ctx.data` (`useCascadingOptions`, and `LookupField`'s own resolver).
+ *  - `dependsOn`: the FIELD METADATA wins over the prop — the one documented
+ *    inversion, stated on the key's own doc comment and implemented as
+ *    `config?.dependsOn ?? dependsOnProp` in all four option widgets.
+ *  - `emptyHint`: the host's value wins when supplied (objectui#3231).
+ *  - `onCreateNew`: the prop wins over `field.onCreateNew`; `onSelectRecord`
+ *    has no metadata carrier at all, so the prop is its ONLY one.
+ *
+ * Resolving any of that HERE would give each key a second author — the
+ * `field || schema` shape objectui#3233 spent a release removing. One key, one
+ * resolver, in the widget that reads it.
+ */
+const HOST_PLUMBING_KEYS = [
+  /* ── Declared on the controlled-input block, but neither DOM-legal nor
+     owned by the factory ─────────────────────────────────────────────────── */
+  //
+  // `error` is the published validation slot (`@objectstack/spec/ui`'s
+  // `FieldWidgetPropsSchema`). Its single documented consumer contract is
+  // "drive `aria-invalid` on the control"; the message TEXT stays with the
+  // host, so forwarding this cannot double-display anything.
+  'error',
+  // `onUploadingChange` is forwarded for completeness of the declaration, not
+  // for a reachable consumer: its only readers are `FileField` / `ImageField`,
+  // and `file` / `image` are both in `INLINE_EXCLUDED_FIELD_TYPES`, so no
+  // widget reachable through `FieldEditWidget` reads it today. Delivering a
+  // declared key that happens to have no reader is the correct half of
+  // enforce-or-remove; withholding it would leave the contract lying.
+  'onUploadingChange',
+
+  /* ── The contract's own "Host plumbing" block, verbatim ────────────────── */
+  //
+  // `compact` is the ONE member of that block deliberately absent here: the
+  // factory OWNS it, deriving it from the resolved field type
+  // (`COMPACT_EDIT_TYPES`) so a cell-sized relational picker renders as a
+  // single-line trigger. Forwarding it would give the sizing two authors, and
+  // the exclusion is named in the `FactoryOwnedKey` list below so the compiler
+  // treats it as a decision rather than an omission.
+  'dataSource',
+  'dependentValues',
+  'dependsOn',
+  'dependsOnLabels',
+  'emptyHint',
+  'onSelectRecord',
+  'onCreateNew',
+] as const;
+
+type HostPlumbingKey = (typeof HOST_PLUMBING_KEYS)[number];
+
+/**
+ * The keys `FieldEditWidget` computes or renders ITSELF, and therefore neither
+ * executor forwards.
+ *
+ * `field` / `value` / `onChange` / `readonly` are the controlled-input contract
+ * the factory writes out explicitly; `compact` is derived from the resolved
+ * field type (see the note in the list above). Naming them here is what lets
+ * the partition assertion below be exact rather than a subset check.
+ */
+type FactoryOwnedKey = 'field' | 'value' | 'onChange' | 'readonly' | 'compact';
+
+/**
+ * Every declared key that is NOT handled by the DOM executor, NOT one of the
+ * open attribute families, and NOT owned by the factory.
+ *
+ * Derived from the contract rather than typed out, so it tracks
+ * {@link FieldWidgetComponentProps} automatically.
+ */
+type NonDomDeclaredKey = Exclude<
+  keyof FieldWidgetComponentProps,
+  DomPassThroughKey | keyof AriaAttributes | `data-${string}` | FactoryOwnedKey
+>;
+
+/**
+ * Direction 1 of 3: every key forwarded at runtime is declared on the contract.
+ *
+ * Catches: this helper forwards something the contract no longer declares.
+ */
+type EveryForwardedKeyIsDeclared =
+  HostPlumbingKey extends keyof FieldWidgetComponentProps ? true : never;
+const _everyForwardedKeyIsDeclared: EveryForwardedKeyIsDeclared = true;
+void _everyForwardedKeyIsDeclared;
+
+/**
+ * Direction 2 of 3: every declared non-DOM, non-factory-owned key is forwarded
+ * here. Adding a key to `FieldWidgetComponentProps` without adding it to
+ * {@link HOST_PLUMBING_KEYS} — or to {@link FactoryOwnedKey} — is a compile
+ * error.
+ *
+ * Catches: DECLARED BUT NOT DELIVERED, the failure this whole file exists to
+ * close. It is the direction no runtime test can see, because a test looks for
+ * props that ARRIVE, not for ones that go missing.
+ */
+type EveryDeclaredHostKeyIsForwarded =
+  NonDomDeclaredKey extends HostPlumbingKey ? true : never;
+const _everyDeclaredHostKeyIsForwarded: EveryDeclaredHostKeyIsForwarded = true;
+void _everyDeclaredHostKeyIsForwarded;
+
+/**
+ * Direction 3 of 3: the two executors are DISJOINT — nothing forwarded here is
+ * also a DOM pass-through key.
+ *
+ * Catches the specific mistake objectui#7008's ruling fences off: "route the
+ * host-plumbing keys through `toDomProps`". Add `error` or `dataSource` to
+ * `DOM_PASS_THROUGH_KEYS` and that file's own two assertions stay green (the
+ * keys ARE declared) — this one is what goes red, because the key would leave
+ * `NonDomDeclaredKey` while still being listed above. It is also what keeps the
+ * order of the two spreads at the call site a non-question.
+ */
+type EveryForwardedKeyIsNonDom = HostPlumbingKey extends NonDomDeclaredKey ? true : never;
+const _everyForwardedKeyIsNonDom: EveryForwardedKeyIsNonDom = true;
+void _everyForwardedKeyIsNonDom;
+
+/** The subset of `P` this helper forwards, with each key's declared type. */
+export type HostProps<P> = Pick<P, Extract<keyof P, HostPlumbingKey>>;
+
+/**
+ * Keep only the declared NON-DOM keys — the host plumbing a widget interprets
+ * as component props — and drop everything else.
+ *
+ * The companion to `toDomProps`, and used the same way. A host that passes
+ * nothing gets an empty object, so the widget's prop set is unchanged:
+ *
+ * ```tsx
+ * <Widget {...toDomProps(props)} {...toHostProps(props)} field={field} … />
+ * ```
+ *
+ * Iterating the props (rather than the key list) mirrors `pickDomProps`, so a
+ * key the host did not mention stays ABSENT rather than arriving as
+ * `undefined` — which keeps the factory-boundary prop set readable as "what the
+ * host actually supplied".
+ */
+export function toHostProps<P extends object>(props: P): HostProps<P> {
+  const allowed: ReadonlySet<string> = new Set<string>(HOST_PLUMBING_KEYS);
+  const hostProps: Record<string, unknown> = {};
+  for (const key of Object.keys(props)) {
+    if (allowed.has(key)) {
+      hostProps[key] = (props as Record<string, unknown>)[key];
+    }
+  }
+  return hostProps as HostProps<P>;
+}

--- a/packages/plugin-kanban/src/RequiredFieldsDialog.tsx
+++ b/packages/plugin-kanban/src/RequiredFieldsDialog.tsx
@@ -114,9 +114,23 @@ export function RequiredFieldsDialog({
             const isMissing = isMissingForRequired(values[f.name]);
             return (
               // A wrapping `label` gives the control its accessible name
-              // implicitly — `FieldEditWidget` renders the widget itself and
-              // takes no `id` to associate with, and widening its contract
-              // belongs to `@object-ui/fields`, not to a caller.
+              // implicitly. This used to be justified with "`FieldEditWidget`
+              // renders the widget itself and takes no `id` to associate with,
+              // and widening its contract belongs to `@object-ui/fields`" —
+              // FALSE since objectui#7009 put `id` in `DOM_PASS_THROUGH_KEYS`:
+              // the factory takes an `id` and lands it on the real control.
+              // The reason is corrected rather than the markup changed
+              // (objectui#7008), because a dead constraint left in a comment is
+              // how the next reader concludes it still binds.
+              //
+              // The wrapping form is still the right choice here, for a reason
+              // that IS still true: this dialog renders whatever field types the
+              // target column made required, and several of them resolve to
+              // COMPOSITE controls with no single labelable element for a
+              // `htmlFor` to point at — `RadioField` renders `<div
+              // role="radiogroup">`, `CheckboxesField` `<div role="group">`,
+              // `AddressField` a set of sibling inputs. One wrapping `label`
+              // covers every type uniformly and mints no ids.
               <label key={f.name} className="flex flex-col gap-1.5">
                 <span className="text-sm font-medium">
                   {f.label}
@@ -129,6 +143,17 @@ export function RequiredFieldsDialog({
                     setValues((prev) => ({ ...prev, [f.name]: v }))
                   }
                   readonly={submitting}
+                  // The a11y half of the red text below (objectui#7008). The
+                  // dialog has always COMPUTED this state and shown it to a
+                  // sighted user; until `FieldEditWidget` forwarded the declared
+                  // `error` key there was no way to hand it to the control, so
+                  // `aria-invalid` was never set and a screen-reader user was
+                  // told nothing. Same string as the visible hint, deliberately:
+                  // a widget reads `error` ONLY to drive `aria-invalid` (the
+                  // #3222 contract — the message TEXT stays with the host), so
+                  // this cannot double-display, and one definition of the
+                  // message cannot drift from the other.
+                  error={showErrors && isMissing ? tt('common.required', 'Required') : undefined}
                 />
                 {showErrors && isMissing && (
                   <span className="text-xs text-destructive">

--- a/packages/plugin-kanban/src/__tests__/RequiredFieldsDialog.ariaInvalid-7008.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/RequiredFieldsDialog.ariaInvalid-7008.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7008, end to end: a control in the required-fields dialog that has
+ * FAILED required-validation reports `aria-invalid` to assistive tech.
+ *
+ * ## The defect
+ *
+ * The dialog has always computed the validation state (`isMissingForRequired`,
+ * the presence contract it shares with the form and the server) and rendered it
+ * in red text. It could not hand that state to the control: `FieldEditWidget`
+ * declared `error` and dropped it, so `aria-invalid` was never set. A sighted
+ * user saw "Required"; a screen-reader user was told nothing.
+ *
+ * ## Why this test lives HERE and not only in `@object-ui/fields`
+ *
+ * The fields package pins that the factory forwards the key and that a widget
+ * turns it into `aria-invalid`. Neither of those would have caught THIS bug,
+ * because the missing link was a host that had the error and no way to pass it.
+ * The two halves — forwarding in the factory, producing at the host — only add
+ * up at this seam, so the seam is where the claim is measured.
+ *
+ * ## Why a `select` field
+ *
+ * `SelectField` computes `aria-invalid={!!error}`, so it reports an explicit
+ * `"false"` when valid: the pin reads a two-state signal rather than the mere
+ * presence of an attribute. NOT every inline widget reads `error` — `TextField`,
+ * `BooleanField`, `DateField`, `DateTimeField` and `TimeField` do not, so for
+ * those types delivering the key is inert today. That is a separate, reported
+ * gap one layer down in `@object-ui/fields`, not something this dialog can fix.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { RequiredFieldsDialog } from '../RequiredFieldsDialog';
+
+afterEach(() => cleanup());
+
+const SELECT_FIELD = {
+  name: 'stage',
+  label: 'Stage',
+  def: {
+    name: 'stage',
+    type: 'select',
+    label: 'Stage',
+    options: [{ label: 'Won', value: 'won' }],
+  },
+};
+
+function renderDialog(onSubmit = vi.fn()) {
+  render(
+    <RequiredFieldsDialog
+      open
+      fields={[SELECT_FIELD]}
+      onCancel={() => {}}
+      onSubmit={onSubmit}
+    />,
+  );
+  return onSubmit;
+}
+
+describe('RequiredFieldsDialog tells assistive tech about a failed required field (objectui#7008)', () => {
+  it('marks the control `aria-invalid` once a submit attempt finds it empty', () => {
+    const onSubmit = renderDialog();
+
+    // CONTROL, and the reason this is a two-state reading: the dialog opens
+    // clean — it does not shout at fields the user has not reached yet — so the
+    // control must say "false" here. If this line read "true", the assertion
+    // after the click would prove nothing.
+    expect(screen.getByTestId('select-trigger-stage')).toHaveAttribute('aria-invalid', 'false');
+
+    fireEvent.click(screen.getByText('Move card'));
+
+    // The submit is refused (that half already worked) …
+    expect(onSubmit).not.toHaveBeenCalled();
+    // … the visible hint appears (that half already worked too) …
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    // … and NOW the control says so to a screen reader. This is the assertion
+    // that was red before the fix.
+    expect(screen.getByTestId('select-trigger-stage')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('CONTROL: the marking is PER FIELD — a filled control is not marked invalid', () => {
+    // Without this, "the control says true after submit" would be satisfied by
+    // a dialog-wide flag that lights up every control, valid ones included.
+    // `textarea` is the second type because `TextAreaField` also computes
+    // `aria-invalid={!!error}` AND renders a real `<textarea>` that synthetic
+    // events can fill — Radix's select trigger cannot be driven that way.
+    const onSubmit = vi.fn();
+    render(
+      <RequiredFieldsDialog
+        open
+        fields={[
+          SELECT_FIELD,
+          { name: 'notes', label: 'Notes', def: { name: 'notes', type: 'textarea', label: 'Notes' } },
+        ]}
+        onCancel={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const notes = screen.getByRole('textbox');
+    fireEvent.change(notes, { target: { value: 'ready to move' } });
+
+    fireEvent.click(screen.getByText('Move card'));
+
+    // Still refused, because the select is still empty.
+    expect(onSubmit).not.toHaveBeenCalled();
+    // The empty one is marked …
+    expect(screen.getByTestId('select-trigger-stage')).toHaveAttribute('aria-invalid', 'true');
+    // … and the filled one is NOT.
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'false');
+    // One hint, not two — the same per-field split, read on the visible side.
+    expect(screen.getAllByText('Required')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #7008

`FieldEditWidget` now delivers the **NON-DOM** half of the contract it declares — the other half of objectui#6909 / #7009.

## Re-derived the declared block, and the seven-key list was wrong: it is **nine**

The dispatch and the card both named seven undelivered keys. Re-derived from `FieldWidgetComponentProps`' own blocks on `origin/main` at `71d83a6b1`, the set of DECLARED keys that neither `toDomProps` nor the factory itself delivered is **nine**:

| block | key | delivered before |
|---|---|---|
| controlled-input | `error` | no |
| controlled-input | `onUploadingChange` | no |
| Host plumbing | `dataSource` | no |
| Host plumbing | `dependentValues` | no |
| Host plumbing | `dependsOn` | no |
| Host plumbing | `dependsOnLabels` | no |
| Host plumbing | `emptyHint` | no |
| Host plumbing | `onSelectRecord` | **no — not in the card's list** |
| Host plumbing | `onCreateNew` | **no — not in the card's list** |
| Host plumbing | `compact` | yes, factory-owned |

The card's own TITLE names all nine; its re-measurement comment narrowed to seven. The two extra keys are forwarded here, on measurement rather than symmetry:

- `LookupField` reads `props.onSelectRecord` and **has no metadata fallback at all** — the prop is its ONLY carrier.
- `LookupField` reads `props.onCreateNew ?? lookupField?.onCreateNew` — the prop is the PREFERRED carrier.

So the card body's speculation that "field metadata may be the intended single carrier" for those two is falsified: withholding them leaves a hole the widget explicitly expects a host to fill. `compact` stays factory-owned (derived from the resolved field type) and is named in the exclusion list so the compiler treats it as a decision, not an omission.

## The card understated the live victim: there are **two** hosts, and one was already wired

The card and the dispatch both state that none of the three in-repo hosts passes any host-plumbing key. That is **false on current `main`**:

`packages/plugin-detail/src/InlineFieldInput.tsx:486` passes `error={error}` into this factory, and has since `03380aa14` (PR #7109, `git log origin/main`). The producer was already wired and the factory dropped it on the floor — so an inline-edit control that had failed server validation never reported `aria-invalid`. That is a live, already-shipping defect, not a latent one.

The second victim is the one the card names: `RequiredFieldsDialog` (kanban) computes the required-validation state, renders it in red text, and had no way to hand it over. It does now.

- **keys with a live victim**: `error` (two hosts).
- **latent, no in-repo victim**: `dataSource`, `dependentValues`, `dependsOn`, `dependsOnLabels`, `emptyHint`, `onSelectRecord`, `onCreateNew`.
- **structurally inert through this factory**: `onUploadingChange` — its only readers are `FileField` / `ImageField`, and `file` / `image` are both in `INLINE_EXCLUDED_FIELD_TYPES`, so no widget reachable here can read it. Forwarded anyway, because a declared key that is withheld leaves the contract lying; measured zero readers among `EDIT_WIDGETS`, with a control (the same query hits `FileField` 2, `ImageField` 2, `useUploadingSignal` 3).

## What this buys, stated exactly

**The a11y MARKING, and not a visible message.** The objectui#3222 `error` slot drives `aria-invalid` on the control; the message TEXT stays with the host. Nothing here makes an error message appear that did not appear before. The marking is the defect being closed.

## `toDomProps` is untouched — and that fence is now mechanical

None of these keys is DOM-legal, so they travel through a **sibling executor**, `toHostProps`, as component props. `DOM_PASS_THROUGH_KEYS` is unchanged; routing a `dataSource` adapter through it is the `dataSource="[object Object]"` leak that whitelist exists to stop.

Three compile-time assertions in `toHostProps.ts` make the two executors **partition** the contract:

1. every key forwarded here is declared on `FieldWidgetComponentProps`;
2. every declared key that is not DOM-handled, not an open `aria-` / `data-` family member and not factory-owned **is** forwarded here — so the next declared key cannot go undelivered silently;
3. the two sets are **disjoint**. This one is the fence made mechanical: add `error` to `DOM_PASS_THROUGH_KEYS` and `toDomProps.ts`' own two assertions stay green (the key IS declared) — assertion 3 is what goes red.

## `dataSource` precedence: the explicit prop WINS

Stated in code (on `toHostProps`, next to the list it governs, and on the factory's own doc comment) and here.

This is **not a new decision**. `LookupField` already resolves, and documents on the line that does it:

```
// Resolve DataSource: explicit prop > field-level > wrapper field > SchemaRendererContext > none
const dataSource = props.dataSource ?? lookupField?.dataSource ?? fieldMeta?.dataSource ?? contextDataSource;
```

The factory is a **conduit** and resolves nothing — adding a resolution here would give `dataSource` a second author, the `field || schema` shape objectui#3233 spent a release removing. A host that passes no `dataSource` keeps reading `SchemaRendererContext` exactly as before, so **no in-repo host changes behaviour**. Verified: no host passes both today.

The same conduit rule covers the rest, each documented next to its single resolver: `dependentValues` prop then `ctx.formValues` then `ctx.data`; `emptyHint` host-wins-when-supplied; and `dependsOn` is the one documented **inversion** — field metadata wins over the prop (`config?.dependsOn ?? dependsOnProp`, in all four option widgets).

## Consumer readiness re-measured, with a control — and a real gap found

Census of the 27 distinct components in `EDIT_WIDGETS`, read from `origin/main` at `71d83a6b1` with `git grep` against an explicit ref (never the shared checkout):

- **21 of 27 read `error`.**
- **CONTROL for the regex**: the same query returns 5 on `NumberField`, 11 on `LookupField` — a zero is a reading, not a broken instrument.
- **CONTROL for the zeroes**: of the 6 zeroes, `UserField` is a FALSE zero — it renders `LookupField` with `{...props}`, so it delivers `error` transitively and does mark. A naive census would have reported six and been wrong about one.

That leaves **five widgets that genuinely do not read `error`** — `TextField`, `BooleanField`, `DateField`, `DateTimeField`, `TimeField` — so for inline `text` / `boolean` / `toggle` / `date` / `datetime` / `time` the delivered key is **inert today**. Reported rather than glossed, and filed separately as objectui#7126: it is one layer down, in the widgets, and outside this card's ruling. `text` being among them matters, because the kanban dialog renders whatever types the column made required.

## Stale comment corrected (fold, not file)

`RequiredFieldsDialog.tsx` justified its wrapping-`label` with *"`FieldEditWidget` renders the widget itself and takes no `id` to associate with"*. False since #7009 put `id` in `DOM_PASS_THROUGH_KEYS`. The **markup is unchanged** — the wrapping form is still right — but the reason is replaced with one that is still true and was measured here: this dialog renders whatever types the column made required, and several resolve to COMPOSITE controls with no single labelable element for a `htmlFor` to point at (`RadioField` renders `div role="radiogroup"`, `CheckboxesField` `div role="group"`, `AddressField` a set of sibling inputs).

## Pins, and the ablation that proves they can fail

Six new pins. `@object-ui/fields` is aliased to `packages/fields/src` in the root `vitest.config.mts`, so both suites execute SOURCE — no `dist` staleness can fake a green.

**Predicted before running**: removing the single `{...toHostProps(props)}` call site turns 5 of the 6 red; the sixth ("a key the host did not pass stays ABSENT") stays GREEN, because it asserts absence, which holds trivially without delivery.

**Observed**: `Tests  5 failed | 1 passed (6)` — exactly as predicted, with the expected green being exactly that test.

Mutation proven on disk, not by an editor exit code:

```
BLOB_BEFORE=7d8556abc1ec4dcec18958eb34b1a3840328cc8b   (== HEAD blob)
BLOB_AFTER =d8b7991e8e8afe379e251e928c8e8fbd02c8bcbc
deleted-text marker count: 1 -> 0     LINES 382 -> 381
```

Restore proven by STATE, not by an exit code: `git diff HEAD` empty, `git diff --cached` empty (a path-scoped checkout stages what it writes), blob hash back to `7d8556abc1...`, marker back to 1, `git status --porcelain` empty. Restored re-run: `Test Files 2 passed (2) / Tests 6 passed (6)`.

**A first ablation attempt was NOT MEASURED and is reported as such**: it injected a JSX expression-container comment in **attribute** position, which is a syntax error, so both suites failed to parse and vitest printed `Tests  no tests`. Caught by reading the output rather than the exit code. Re-run as a pure deletion.

## Gates — all run at `d77aacf1c`, the final commit

| gate | exit | verdict | the tool's own line |
|---|---|---|---|
| `pnpm exec vitest run packages/fields/ packages/plugin-kanban/` | 0 | green | `Test Files  149 passed (149)` / `Tests  2228 passed (2228)` |
| `type-check` (fields + plugin-kanban) | 0 | green | `packages/fields type-check: Done` / `packages/plugin-kanban type-check: Done` |
| `lint` (fields + plugin-kanban) | 0 | green | `0 errors`; the new files contribute no warning |
| `node scripts/check-changeset-presence.mjs` | 0 | green | `4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | 0 | green | `No changeset declares a major bump.` |
| `pnpm check:control-bytes` | 0 | green | `check-control-bytes: OK (scanned 5899 tracked text file(s); skipped 85 binary).` |
| `pnpm check:esm-specifiers` | 0 | green | `no un-ledgered package emits an extensionless relative specifier.` |
| `pnpm check:self-import` | 0 | green | `No package names itself inside its own src/.` |
| `pnpm check:phantom-deps` | 0 | green | `Every in-scope import is declared by the package that publishes it.` |
| `pnpm check:readme-exports` | 1 | **NOT MEASURED** | `the population COLLAPSED -- this run proves nothing` / `packagesRead: found 13, floor is 25` |

`check:readme-exports` reads exports from BUILT type declarations; this worktree built only the dependency closure of the two touched packages, so 24 of 40 packages are unbuilt and the run collapses below its own floor. That is a build-state artifact, not a finding: the gate asserts that a README's self-imports name real exports, and this change adds no README import. CI builds the whole tree and runs it for real.

`type-check` really covers the new files, not just the old ones: `tsc -p tsconfig.test.json --listFiles` lists `FieldEditWidget.hostPlumbing-7008.test.tsx` (1), `toHostProps.ts` (1) and `RequiredFieldsDialog.ariaInvalid-7008.test.tsx` (1), with `RequiredFieldsDialog.tsx` (1) as the must-hit control.

No README or `content/docs` change, following the precedent of #7009 (`b458300ca`), which was changeset plus source plus test: `FieldEditWidget`'s prop delivery is not documented in either place, and `toDomProps` has zero README mentions.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_