### PR TITLE
test(app-shell): pin the adapter advisory sink seam — an emitted advisory reaches the toast

### DIFF
--- a/.changeset/adapter-advisory-sink-pin.md
+++ b/.changeset/adapter-advisory-sink-pin.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: pins that a metadata-save advisory emitted by the `ObjectStackAdapter` actually reaches the toast sink `AdapterProvider` wires to it. No published behaviour changes.

--- a/packages/app-shell/src/providers/AdapterProvider.advisorySink.test.tsx
+++ b/packages/app-shell/src/providers/AdapterProvider.advisorySink.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The ADAPTER channel's advisory chain: an emitted event actually REACHES the
+ * sink (objectui#7116).
+ *
+ * Sibling of `views/metadata-admin/useMetadataClient.advisorySink.test.tsx`
+ * (objectui#6969), which pins the same middle link on the OTHER client class.
+ * These are two channels, not one — #6969 covers `MetadataClient`, minted per
+ * component by `useMetadataClient`, whose sink rides the factory config; this
+ * one covers `ObjectStackAdapter`, the long-lived instance every data surface
+ * shares, whose sink is a `subscribe → unsubscribe` registration that
+ * `AdapterProvider` wires once (#4237). Cutting either leaves the other green.
+ *
+ * ## What was missing, and why nothing red said so
+ *
+ * The chain has three links, and before this file only its two ends were
+ * pinned:
+ *
+ *   producer  ObjectStackClient.meta.saveItem, wrapped by the adapter's
+ *             installSaveAdvisoryInterceptor, emits the event
+ *             -> pinned by data-objectstack/src/onSaveAdvisory.test.ts
+ *   MIDDLE    AdapterProvider subscribes with a.onSaveAdvisory and renders
+ *             through emitSaveAdvisories into sonner
+ *             -> pinned by NOTHING
+ *   renderer  emitSaveAdvisories turns an event into the warning
+ *             -> pinned by saveAdvisoryToast.test.ts
+ *
+ * The producer suite asserts the event is EMITTED, into a sink it constructs
+ * itself. The renderer suite asserts the message is BUILT, over an event it
+ * writes by hand. Neither ever asserts the thing emitted and the thing rendered
+ * are connected. Measured before writing this file, on the 45 suites that name
+ * `AdapterProvider` plus the producer and renderer suites (633 tests): with the
+ * `a.onSaveAdvisory` subscription deleted outright, all 45 stayed GREEN; with
+ * the subscription kept but its `emitSaveAdvisories` call cut, all 45 stayed
+ * GREEN; with the unsubscribe cut, all 45 stayed GREEN.
+ *
+ * The mechanism of the blind spot is the same one #6969 named, and starker
+ * here: 38 of those 41 `AdapterProvider` suites `vi.mock` the module away —
+ * legitimately, they are testing pages, not plumbing — and, before this file,
+ * exactly ZERO imported the real one. (Control for that zero: the same query
+ * shape against `saveAdvisoryToast` returns 2.) The seam was mocked away
+ * everywhere it appeared.
+ *
+ * ## Why the provider must build its own adapter here
+ *
+ * `AdapterProvider` takes an optional `adapter` prop, and passing it makes the
+ * effect return EARLY — before the subscription is installed. So a test that
+ * hands in a ready-made adapter cannot see this seam at all: it would be green
+ * against every ablation above. Nothing is passed here; the provider runs its
+ * real `init()`, constructs the real `ObjectStackAdapter`, and the child reads
+ * that instance back out of the context the provider publishes.
+ *
+ * ## What is real here, and what is not
+ *
+ * Real: the provider, its effect, the `ObjectStackAdapter` it constructs, that
+ * adapter's `installSaveAdvisoryInterceptor`, the real SDK `ObjectStackClient`
+ * and its response parsing, `createAuthenticatedFetch`, `withSettleSignal`, the
+ * `onSaveAdvisory` registration and its unsubscribe, the i18n `t` read through
+ * the provider's ref, `readSaveAdvisories`, and `emitSaveAdvisories`.
+ *
+ * Stubbed, and only these two:
+ *   - `sonner` — the terminal sink. `AdapterProvider` imports `toast` as a
+ *     module binding rather than taking it as a parameter, so intercepting the
+ *     module is the only way to observe what arrives. Everything BETWEEN the
+ *     producer and it is the real thing, which is the whole point.
+ *   - `globalThis.fetch` — the server. It answers discovery, and answers the
+ *     metadata PUT with the body the framework's runtime authoring gate
+ *     actually sends.
+ *
+ * ## Scope — deliberately NOT a bigger test at either end
+ *
+ * This asserts the CONNECTION and nothing else. The tier, the per-finding
+ * formatting, the door verbs and the empty-list drop are the renderer suite's;
+ * the response-shape filtering, the `mode` derivation and listener isolation
+ * are the producer suite's. Duplicating any of them here would grow the suite
+ * without closing the hole this file exists to close.
+ */
+
+import { useEffect } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+
+// The one stub in the middle of the chain — see the module doc.
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+import { AdapterProvider, useAdapter } from './AdapterProvider';
+
+/** The measured `nightly_purge` finding, in the gate's D3 shape. */
+const PURGE_ADVISORY = {
+  severity: 'warning' as const,
+  rule: 'flow/delete-without-filter',
+  where: 'flow "nightly_purge" · node "purge old rows"',
+  path: 'flows[0].nodes[2].config.filters',
+  message: 'this delete_record node sets multi: true with no filter, so it deletes every row',
+  hint: 'add a filter, or set multi: false to delete a single record',
+};
+
+/**
+ * The clean part of a real save response. `success`/`version`/`seq`/`state` are
+ * REQUIRED by `SaveMetaItemResponseSchema` (#5745); `readSaveAdvisories` drops
+ * anything half-shaped, so a fixture missing one would make this file pass for
+ * the wrong reason.
+ */
+const CLEAN_BODY = { success: true, version: 'v2', seq: 4, state: 'active' as const };
+
+/** A committed write the gate had something to say about. */
+const ADVISED_BODY = { ...CLEAN_BODY, advisories: [PURGE_ADVISORY] };
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+/** URLs of the metadata writes that actually left — the control for any zero. */
+function metaWriteCount(): number {
+  return fetchMock.mock.calls.filter(([input]) =>
+    String(typeof input === 'string' ? input : (input as Request).url).includes('/meta/'),
+  ).length;
+}
+
+/**
+ * A `fetch` that answers discovery, and answers every metadata write with
+ * `saveBody`. Discovery is served because the provider's `init()` awaits
+ * `connect()` before it publishes the adapter to children.
+ */
+function serverAnswers(saveBody: unknown) {
+  fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+    if (url.includes('/discovery')) return jsonResponse({ success: true, data: {} });
+    return jsonResponse(saveBody);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+}
+
+/** Reads the adapter back out of the context the provider publishes. */
+let captured: { getClient(): { meta: { saveItem(t: string, n: string, i: unknown): Promise<unknown> } } } | null = null;
+
+function CaptureAdapter() {
+  const adapter = useAdapter();
+  // Recorded in an effect rather than during render: reassigning a
+  // module-scope binding mid-render is a side effect (react-hooks/globals),
+  // and the mount helper awaits this anyway.
+  useEffect(() => {
+    captured = adapter as unknown as typeof captured;
+  }, [adapter]);
+  return null;
+}
+
+/** Mounts the real provider and waits until it has published its adapter. */
+async function mountProvider() {
+  const view = render(
+    <AdapterProvider>
+      <CaptureAdapter />
+    </AdapterProvider>,
+  );
+  await waitFor(() => expect(captured).not.toBeNull());
+  return view;
+}
+
+async function save() {
+  await captured!.getClient().meta.saveItem('flow', 'nightly_purge', { name: 'nightly_purge' });
+}
+
+/** The `(title, options)` pair the sink was called with. */
+function warningCall(): [string, { description?: string; duration?: number } | undefined] {
+  const calls = vi.mocked(toast.warning).mock.calls;
+  expect(calls).toHaveLength(1);
+  return calls[0] as [string, { description?: string; duration?: number } | undefined];
+}
+
+beforeEach(() => {
+  captured = null;
+  vi.mocked(toast.warning).mockClear();
+  serverAnswers(ADVISED_BODY);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('AdapterProvider — an emitted adapter advisory reaches the toast sink (#7116)', () => {
+  it('a save through the provider-built adapter renders the gate findings', async () => {
+    await mountProvider();
+
+    await save();
+
+    const [title, options] = warningCall();
+    // The verb proves the DOOR discriminator survived the whole seam: it is set
+    // by the adapter's interceptor and read by the renderer, and nothing in
+    // between may lose or rewrite it.
+    expect(title).toMatch(/^Saved\b/);
+    // The finding itself arrived — not merely "something was toasted".
+    expect(options?.description).toContain(PURGE_ADVISORY.message);
+    expect(options?.description).toContain(PURGE_ADVISORY.rule);
+  });
+
+  it('CONTROL: a clean save says nothing', async () => {
+    serverAnswers(CLEAN_BODY);
+    await mountProvider();
+
+    await save();
+
+    // The zero below is only a reading beside a control that MUST hit: the
+    // write really did travel the chain, so "the sink stayed quiet" is about
+    // the absent advisory list and not about a chain that never ran.
+    expect(metaWriteCount()).toBe(1);
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it('the subscription is released on unmount', async () => {
+    const { unmount } = await mountProvider();
+
+    // Control: the channel is live BEFORE unmount, so the silence asserted
+    // after it is about the unsubscribe and not about a chain that never ran.
+    await save();
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+
+    unmount();
+    vi.mocked(toast.warning).mockClear();
+
+    // The adapter outlives the provider that built it, so its interceptor still
+    // emits here — only the provider's listener should be gone.
+    await save();
+
+    expect(metaWriteCount()).toBe(2);
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #7116

The `ObjectStackAdapter` advisory chain had both ends pinned and its middle link pinned by nothing. This adds one pin that asserts the CONNECTION.

## Precondition — the card was filed as grep-measured, so it was re-measured by ablation

The card said so itself, and it was right to. Its grep reading reproduced, with the denominator moved by one since filing:

| reading | card | re-derived here |
|---|---|---|
| suites naming `AdapterProvider` | 40 | **41** (one landed since) |
| of those, naming `dvisor` | 1 | **1** (same file) |
| CONTROL: of those, naming `expect` | 40/40 | **41/41** |

A sharper census explains the blind spot, and it is starker than the sibling card's: **38 of the 41 mock the module away** with `vi.mock`, and **exactly 0 imported the real `AdapterProvider`**. Control for that zero, same query shape against `saveAdvisoryToast`: **2 hits**, so the zero is a reading and not a dead query.

### The ablation that settles it

Baseline: the 41 suites naming `AdapterProvider` plus the producer and renderer suites — **45 files / 633 tests, green**. Then, three separate cuts, each proven on disk by blob-hash change plus a marker count, each restored by state (`git diff HEAD` empty, `git diff --cached` empty, blob hash back):

| cut | what was removed | result |
|---|---|---|
| H1 | the `a.onSaveAdvisory` subscription, outright | **45/45 files green, 0 red** |
| H2 | the `emitSaveAdvisories` call inside it | **45/45 files green, 0 red** |
| H3 | the unsubscribe in the effect cleanup | **45/45 files green, 0 red** |

Predicted green before running, on the strength of the 0-real-imports census; observed green. The gap is real, and it has three independently cuttable points rather than the one the card assumed.

### It is NOT covered transitively by the sibling pin

Measured, not assumed. With this channel's seam cut (H1), the pin that landed as `7e2e6f42c` stays **green, 3/3**. They are sibling channels: that one is `MetadataClient`, minted per component, sink riding the factory config; this one is `ObjectStackAdapter`, the long-lived shared instance whose sink is a subscribe/unsubscribe registration wired once by the provider (built by #4237).

## The pin

`packages/app-shell/src/providers/AdapterProvider.advisorySink.test.tsx` — three cases: the save renders the finding, a clean save says nothing (with a control that the write really travelled), and the subscription is released on unmount.

The load-bearing design point: **the provider must build its own adapter.** `AdapterProvider` takes an optional `adapter` prop, and passing it makes the effect return early — before the subscription is installed. A test that hands in a ready-made adapter is green against all three ablations above and sees nothing. So nothing is passed; the provider runs its real `init()`.

Real: the provider and its effect, the `ObjectStackAdapter` it constructs, that adapter's save interceptor, the real SDK client and its response parsing, `createAuthenticatedFetch`, `withSettleSignal`, the registration and its unsubscribe, the i18n `t` read through the provider's ref, `readSaveAdvisories`, and `emitSaveAdvisories`. Stubbed, and only these two: `sonner` (the terminal sink, imported as a module binding so it cannot be handed over) and `globalThis.fetch` (the server).

### Red-first evidence

The pin goes red at each cut point, each for the right reason — and H3 discriminates, failing only its unmount case:

| cut | pin result | assertion that fired |
|---|---|---|
| H1 | 2 failed, 1 passed | `expected [] to have a length of 1` |
| H2 | 2 failed, 1 passed | `expected [] to have a length of 1` |
| H3 | **1 failed**, 2 passed | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |

Ablation validity: this lane is **source-resolved** — the root vitest config aliases every `@object-ui/*` to that package's `src`, so no `dist` rebuild stands between the mutation and the run, and a stale build cannot manufacture a false green here.

## Scope

Deliberately not a bigger test at either end — both ends are already covered, and adding to either would grow the suite without closing the hole. The tier, per-finding formatting, door verbs and empty-list drop stay the renderer suite's; response-shape filtering, `mode` derivation and listener isolation stay the producer suite's. No production code changed.

## Verification, at `ad32812de`

- 46 files / 636 tests green (the 45 named suites plus the new pin)
- `type-check` for app-shell: exit 0, 0 errors — re-run after building the dependency closure, since the first attempt failed only on unresolved workspace modules and was NOT MEASURED rather than red
- `check-changeset-presence`: exit 0. Its verdict was quoted rather than predicted — it demanded a declaration, and names an empty frontmatter as "a pass, not a workaround" for a change that releases nothing, which is what the changeset carries
- `changeset:check` (fixed + no-major), `check-changeset-overwrite`, `check-control-bytes`, `lint:coverage`, `type-check:coverage`: all exit 0
- eslint on the new file: exit 0

Declared narrowing: the repo-wide lint scan is CI's and was not run here. Evidence the narrowing excludes nothing — population read from eslint's own config rather than guessed (1038 files under `packages/app-shell`, counted from `--format json`, 0 errors), the new file confirmed present in that population, and no type-aware linting configured (no `projectService`, no `parserOptions.project`; control: the config file reads back `rules` 10 times, `export default` once), so this diff cannot move the verdict of any untouched file.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_