### PR TITLE
test(app-shell): widen the exclusion-reason truthfulness guard's import set so a false "no renderer" cannot pass

### DIFF
--- a/.changeset/truthfulness-guard-import-set-7117.md
+++ b/.changeset/truthfulness-guard-import-set-7117.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change (objectui#7117): `exclusion-reason-truthfulness.test.ts` now imports the six `views/*-renderer.tsx` leaves and `@object-ui/plugin-detail`, so the three `PALETTE_EXCLUSIONS` keys that have a renderer outside the old import set (`app:launcher`, `global:notifications`, `record:chatter`) are actually visible to the guard, and a new renderer leaf that is not imported reds the suite instead of shrinking its coverage silently. No published behaviour changes.

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/exclusion-reason-truthfulness.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/exclusion-reason-truthfulness.test.ts
@@ -21,7 +21,7 @@
  *
  * ## Why the assertion is shaped this way
  *
- * The interesting direction is cheap to get wrong. Three hazards, each with its
+ * The interesting direction is cheap to get wrong. Four hazards, each with its
  * own guard below:
  *
  *  1. **A degenerate (empty) registry passes every negative assertion.** If the
@@ -38,14 +38,58 @@
  *     contains a no-renderer claim to check` fails in that case.
  *  3. **Scope is bounded by the import set.** A renderer registered in a
  *     package NOT imported here reads as unregistered, which would let a false
- *     "no renderer" pass. The imports below are therefore the packages that
- *     could plausibly register a page block for the excluded types
- *     (`@object-ui/components` for `element:*`, `@object-ui/plugin-chatbot` for
- *     the AI surface, `@object-ui/plugin-form` for the form family). Widen the
- *     set — and its positive probes — when a new package starts registering
- *     page blocks.
+ *     "no renderer" pass.
+ *  4. **The import set drifting behind the registrations** — hazard 3 coming
+ *     true silently, which is what objectui#7117 measured and what the last
+ *     guard below now refuses. See the next section.
+ *
+ * ## objectui#7117 — the import set had already drifted, and nothing said so
+ *
+ * Hazard 3 was stated in prose here ("widen the set when a new package starts
+ * registering page blocks") and prose was not enough. `app-shell` became such a
+ * package twice — #6757 (`global:search`, `global:notifications`) and #7091
+ * (`app:launcher`, `nav:menu`) — and the set was not widened either time, so
+ * for two ledger keys this file could not see a renderer that exists. Measured
+ * on `44ea62d29`: setting `PALETTE_EXCLUSIONS['app:launcher']` to
+ * `'no renderer ZZMUTZZ'` — a string that DOES match {@link CLAIMS_NO_RENDERER}
+ * — still passed 4/4, while `views/app-launcher-renderer.tsx` registers a
+ * renderer for it. A guard passing the exact false claim it exists to refuse.
+ *
+ * Two things follow, and the second is the one that keeps this from recurring:
+ *
+ *  - The set is widened to every package that registers a renderer for a
+ *    CURRENT ledger key: the six `views/*-renderer.tsx` leaves of this package,
+ *    and `@object-ui/plugin-detail` (which registers `record:chatter` — blind
+ *    here for the same reason, measured the same way).
+ *  - The app-shell half of the import set is CHECKED rather than trusted. `the
+ *    import set covers every page block app-shell registers` derives the leaf
+ *    list from the directory and fails when a leaf is not imported here — so
+ *    the seventh renderer leaf reds this file instead of quietly shrinking its
+ *    coverage. A hand-maintained list is exactly what drifted; deriving it is
+ *    the point.
+ *
+ * Why the leaves and not the package barrel: `../../../../index.js` would track
+ * the package automatically, but it costs 6105ms to load against 553ms for the
+ * leaves (measured on `44ea62d29`, same harness) because it drags the console,
+ * marketplace, cloud and diagnostics graphs in with it. This file is a
+ * pure-logic gate in the cheap `unit` project, whose whole design point is not
+ * paying for graphs it does not touch (`vitest.config.mts`). The derived guard
+ * buys the barrel's one real advantage — tracking the package — for 0ms.
+ *
+ * ## What is deliberately NOT imported
+ *
+ * `registerPlaceholders()`. It registers the whole `PROTOCOL_COMPONENTS`
+ * vocabulary against `PlaceholderRenderer` under `namespace:
+ * 'protocol-placeholder'`, which would make this file answer "has a renderer"
+ * for types that have only the dashed "Component Placeholder" scaffold —
+ * `user:profile` is one (measured). This repo's own language is clear that the
+ * scaffold is not a renderer: `views/app-launcher-renderer.tsx` describes the
+ * state before it existed as "nothing rendered it, so a page that authored it
+ * drew a dashed box", with placeholders registered the whole time. Opting in
+ * would make the guard assert a falsehood in the opposite direction.
  */
 
+import { readdirSync, readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { ComponentRegistry } from '@object-ui/core';
 // Side-effect imports: these register the components under test. The app-shell
@@ -54,6 +98,21 @@ import { ComponentRegistry } from '@object-ui/core';
 import '@object-ui/components';
 import '@object-ui/plugin-chatbot';
 import '@object-ui/plugin-form';
+// `record:chatter` is a ledger key whose renderer lives here (registered
+// alongside `record:discussion` against the same component). Both sibling
+// suites in this directory already import it for the same reason.
+import '@object-ui/plugin-detail';
+// This package's own page-block registrations (#6757, #7091). All six
+// `views/*-renderer.tsx` leaves, not just the two currently in the ledger:
+// which of them the ledger names is a palette decision that has moved before,
+// and `the import set covers every page block app-shell registers` below holds
+// this list to the directory.
+import '../../../app-launcher-renderer.js';
+import '../../../global-notifications-renderer.js';
+import '../../../global-search-renderer.js';
+import '../../../nav-menu-renderer.js';
+import '../../../record-approvals-renderer.js';
+import '../../../record-attachments-renderer.js';
 import { PALETTE_EXCLUSIONS } from '../block-types';
 
 /**
@@ -67,11 +126,29 @@ const claimingNoRenderer = Object.entries(PALETTE_EXCLUSIONS).filter(([, reason]
   CLAIMS_NO_RENDERER.test(reason),
 );
 
+/** Where this package keeps its page-block registrations, one block per file. */
+const VIEWS_DIR = new URL('../../../', import.meta.url);
+
+/**
+ * The page blocks this package registers, derived from the leaf files rather
+ * than restated — see the header. `register('menu', C, { namespace: 'nav' })`
+ * writes the key `nav:menu`, so the two captures spell the key the ledger and
+ * the registry both use.
+ */
+const appShellRegistrations = readdirSync(VIEWS_DIR)
+  .filter((f) => f.endsWith('-renderer.tsx'))
+  .map((file) => {
+    const src = readFileSync(new URL(file, VIEWS_DIR), 'utf8');
+    const m = /ComponentRegistry\.register\(\s*'([^']+)'[\s\S]{0,400}?namespace:\s*'([^']+)'/.exec(src);
+    return { file, key: m ? `${m[2]}:${m[1]}` : null };
+  });
+
 describe('objectui#6071 — PALETTE_EXCLUSIONS reasons that claim "no renderer"', () => {
   it('the registry under test is actually populated (guards a vacuous green)', () => {
     // One probe per side-effect import above. If any of these is falsy the
     // negative assertion below proves nothing, so it must fail LOUDLY here
-    // rather than passing quietly there.
+    // rather than passing quietly there. (The six app-shell leaves get their
+    // probes from the derived guard below, which cannot be forgotten.)
     expect(
       ComponentRegistry.get('element:text'),
       '@object-ui/components did not register — every "not registered" check below would pass vacuously',
@@ -84,6 +161,46 @@ describe('objectui#6071 — PALETTE_EXCLUSIONS reasons that claim "no renderer"'
       ComponentRegistry.get('object-form'),
       '@object-ui/plugin-form did not register — the form family is not actually covered',
     ).toBeTruthy();
+    expect(
+      ComponentRegistry.get('record:chatter'),
+      '@object-ui/plugin-detail did not register — `record:chatter` is a ledger key and would read as unregistered',
+    ).toBeTruthy();
+  });
+
+  it('the import set covers every page block app-shell registers (objectui#7117)', () => {
+    // The guard the prose maintenance rule failed to be. A new
+    // `views/<block>-renderer.tsx` that this file does not import reads as
+    // unregistered, which is precisely how #6757 and #7091 left two ledger keys
+    // unguarded for two releases.
+    //
+    // Control first: a derivation that finds nothing would pass every check
+    // under it vacuously, and this file's whole subject is a guard that stopped
+    // seeing its population.
+    expect(
+      appShellRegistrations.length,
+      'no views/*-renderer.tsx leaves were found — this coverage check has stopped checking',
+    ).toBeGreaterThan(0);
+    expect(
+      appShellRegistrations.filter((r) => r.key === null).map((r) => r.file),
+      'a renderer leaf whose ComponentRegistry.register(...) call could not be read — the key below cannot be derived',
+    ).toEqual([]);
+    // Anchor the derivation on the two keys objectui#7117 measured, so a
+    // regex that silently stops matching cannot leave this green.
+    expect(
+      appShellRegistrations.map((r) => r.key),
+      'the derived registration list no longer contains the keys #7117 was filed about',
+    ).toEqual(expect.arrayContaining(['app:launcher', 'global:notifications']));
+
+    for (const { file, key } of appShellRegistrations) {
+      expect(
+        ComponentRegistry.get(key as string),
+        `views/${file} registers '${key}' and this file does not import it, so '${key}' reads as UNREGISTERED here. ` +
+          "Add `import '../../../" +
+          file.replace(/\.tsx$/, '.js') +
+          "';` to the side-effect imports above. Until then, an exclusion reason claiming " +
+          `'no renderer' over '${key}' would pass this suite — the defect objectui#7117 filed.`,
+      ).toBeTruthy();
+    }
   });
 
   it('the ledger still contains a no-renderer claim to check (guards a vacuous loop)', () => {


### PR DESCRIPTION
Fixes #7117

`exclusion-reason-truthfulness.test.ts` asks the runtime `ComponentRegistry` whether a `PALETTE_EXCLUSIONS` reason claiming "no renderer" is true, so its coverage is bounded by its own side-effect import set. That set never grew to include this package — which has registered page blocks since #6757 and #7091 — nor `@object-ui/plugin-detail`.

All measurements below were taken on this branch; the union of gates was run at `778fb78b4` (the final commit).

## Leg 0 — the blindness, reproduced before any fix

Predicted GREEN (the guard is blind), observed GREEN. On `44ea62d29`, `PALETTE_EXCLUSIONS['app:launcher']` set to `'no renderer ZZMUTZZ'` — a string that DOES match the guard's `CLAIMS_NO_RENDERER` regex — while `views/app-launcher-renderer.tsx` registers a renderer for it:

```
ANCHOR_BEFORE=1 INJECTED_BEFORE=0      blob 186b4a2de89fcc150474b5861ee1e2d56bdc50a3
ANCHOR_AFTER=0  INJECTED_AFTER=1       blob 1734fcd9888fd864b379f4ab0b9e6b2d71fe95bd
=== MUTATION CONFIRMED ON DISK ===
 Test Files  1 passed (1)
      Tests  4 passed (4)
VITEST_EXIT=0
```

Restore proven by state, not by an exit code: `blob_restored=186b4a2d…` (back to the HEAD blob), `git diff HEAD` 0 bytes, `git diff --cached` 0 bytes, injected-marker count back to 0.

## The at-risk population, re-derived

Measured with a throwaway probe that snapshots `ComponentRegistry.getConfig(key)` after each import step, rather than argued from source. All eight `PALETTE_EXCLUSIONS` keys:

| ledger key | renderer? | registered by | visible to the OLD import set |
|---|---|---|---|
| `app:launcher` | yes, real (`ns=app`) | app-shell `views/app-launcher-renderer.tsx`, eager at module load | **no — blind** |
| `global:notifications` | yes, real (`ns=global`) | app-shell `views/global-notifications-renderer.tsx`, eager | **no — blind** |
| `record:chatter` | yes, real (`ns=record`) | `@object-ui/plugin-detail`, eager | **no — blind** |
| `element:record_picker` | yes (`ns=element`) | `@object-ui/components` | yes |
| `element:text_input` | yes (`ns=element`) | `@object-ui/components` | yes |
| `user:profile` | no real renderer; placeholder scaffold only under opt-in `registerPlaceholders()` (`ns=protocol-placeholder`) | — | n/a |
| `ai:chat_window` | none anywhere | — | n/a |
| `element:form` | none anywhere | — | n/a |

Three corrections to what the card assumed, all measured:

1. **It is three keys, not "five shell singletons".** `PALETTE_EXCLUSIONS` carries exactly three shell-singleton entries (`app:launcher`, `global:notifications`, `user:profile`); `nav:menu` and `global:search` are not excluded at all, so they never enter this guard's loop. The blind set is `app:launcher`, `global:notifications` and — outside app-shell — `record:chatter`.
2. **`app:launcher` does not need an opt-in probe.** It is opt-in-only *in `@object-ui/components`*, but since #7091 app-shell registers the real renderer eagerly at module load. The probe finds it with no `registerPlaceholders()` call: `app:launcher REG ns=app label=App Launcher`.
3. **No live false claim exists.** The only reasons matching `CLAIMS_NO_RENDERER` today are `ai:chat_window` and `element:form`, and a repo-wide grep for a registration of either (control: `namespace: 'element'`, which returns many hits) returns zero. The defect was latent, as filed.

`registerPlaceholders()` is deliberately NOT called: it would make the file answer "has a renderer" for types that have only the dashed "Component Placeholder" scaffold (`user:profile` is one, measured). This repo's own language says the scaffold is not a renderer — `views/app-launcher-renderer.tsx` describes the state before it existed as "nothing rendered it, so a page that authored it drew a dashed box", with placeholders registered the whole time.

## Mechanism chosen, and the cost that chose it

Marginal import cost, same harness and same baseline (after `@object-ui/components` + `plugin-chatbot` + `plugin-form` are loaded):

| mechanism | marginal cost | file duration end to end |
|---|---|---|
| the four app-shell renderer leaves | **553ms** (251 + 164 + 128 + 10) | 9.4s |
| the package barrel `../../../../index.js` | **6105ms** | 15.1s |

The barrel would track the package automatically, but it drags the console, marketplace, cloud and diagnostics graphs into a pure-logic gate in the cheap `unit` project — whose entire design point (`vitest.config.mts`) is not paying for graphs it does not touch. So: **leaves, plus a derived guard that buys the barrel's one real advantage for 0ms.**

`the import set covers every page block app-shell registers` reads the `views/*-renderer.tsx` leaf list from the directory, derives each leaf's registered key from its own `ComponentRegistry.register(...)` call, and requires every one to resolve. A seventh renderer leaf that is not imported here reds this file instead of silently shrinking its coverage. A hand-maintained list is exactly what drifted — deriving it is the point. It carries three controls of its own, because a derivation that finds nothing would pass vacuously and that is this file's whole subject: the leaf list must be non-empty, every leaf's key must be extractable, and the derived list must still contain `app:launcher` and `global:notifications`.

The barrel remains viable and cycle-free — it loaded and registered correctly in the probe — so this is a cost decision, not a feasibility one.

## Positive probes — one per import, each shown hitting

Required by the finding's own text: *"it needs one positive probe per new import or it guards vacuously."*

| import | probe | result |
|---|---|---|
| `@object-ui/components` (pre-existing) | `element:text` | hits |
| `@object-ui/plugin-chatbot` (pre-existing) | `chatbot` | hits |
| `@object-ui/plugin-form` (pre-existing) | `object-form` | hits |
| `@object-ui/plugin-detail` (new) | `record:chatter` | hits |
| `views/app-launcher-renderer.js` (new) | `app:launcher`, derived | hits |
| `views/global-notifications-renderer.js` (new) | `global:notifications`, derived | hits |
| `views/global-search-renderer.js` (new) | `global:search`, derived | hits |
| `views/nav-menu-renderer.js` (new) | `nav:menu`, derived | hits |
| `views/record-approvals-renderer.js` (new) | `record:approvals`, derived | hits |
| `views/record-attachments-renderer.js` (new) | `record:attachments`, derived | hits |

All ten hit — the suite is green at 5/5, and every derived probe is an assertion inside the coverage test, so a miss is a red rather than a silent skip. Ablation A3 below proves that is true and not merely stated.

Both pre-existing anti-vacuity guards are preserved verbatim and neither is weakened: `the registry under test is actually populated (guards a vacuous green)` keeps its three probes and gains a fourth, and `the ledger still contains a no-renderer claim to check (guards a vacuous loop)` is untouched.

## Post-fix ablations — all three predicted RED, all three observed RED

Run against the committed fix, so each restore is `git checkout HEAD -- (absolute path)` against a HEAD that already contains the implementation. Every leg proved its mutation on disk (anchor count moved, marker count moved, blob hash moved) and its restore by state (blob back to the HEAD blob, `git diff HEAD` and `git diff --cached` both 0 bytes).

**A1 — the card's own false claim, the one that passed 4/4 in leg 0:**

```
AssertionError: PALETTE_EXCLUSIONS['app:launcher'] says "no renderer ZZMUTZZ", but a renderer IS
registered for it. ... : expected [Function AppLauncherRenderer] to be falsy
 Tests  1 failed | 4 passed (5)
```

**A2 — the same false claim on `record:chatter`, proving the plugin-detail import is not decorative:**

```
AssertionError: PALETTE_EXCLUSIONS['record:chatter'] says "no renderer ZZMUTBB", but a renderer IS
registered for it. ... : expected [Function RecordChatterRenderer] to be falsy
 Tests  1 failed | 4 passed (5)
```

**A3 — one renderer-leaf import deleted, proving the derived coverage guard bites:**

```
AssertionError: views/record-attachments-renderer.tsx registers 'record:attachments' and this file
does not import it, so 'record:attachments' reads as UNREGISTERED here. Add
`import '../../../record-attachments-renderer.js';` to the side-effect imports above. ...
: expected undefined to be truthy
 Tests  1 failed | 4 passed (5)
```

Each leg reports `Tests 1 failed | 4 passed (5)`, so the suite really executed rather than collapsing to "no tests" behind a plausible exit 1.

## Scope note — one bounded in-place addition, named

`@object-ui/plugin-detail` is outside the card's title ("excludes app-shell"), and it is included deliberately: `record:chatter` is a *current* ledger key, blind in the same loop, in the same file, for the same reason, and measured the same way (A2). The correct shape was already pinned by the two sibling suites in this same directory — `palette-discussion-alias.test.tsx:50` and `canvas-display-meta.test.tsx:44` both carry `import '@object-ui/plugin-detail';` for exactly this question. Closing the app-shell half while leaving a known, measured blind key in the loop this PR certifies would reproduce the defect the card is about.

## Gates

| gate | exit | verdict | evidence |
|---|---|---|---|
| `vitest run` on the guard file | 0 | green | `Test Files 1 passed (1)` / `Tests 5 passed (5)` |
| `vitest run --project unit` (whole project) | 0 | green | `Test Files 801 passed (801)` / `Tests 12489 passed \| 9 skipped (12498)` |
| `vitest run packages/app-shell/src/views/metadata-admin/previews/` | 0 | green | `Test Files 45 passed (45)` / `Tests 521 passed (521)` |
| `turbo run type-check --filter=@object-ui/app-shell` | 0 | green | `Tasks: 30 successful, 30 total`; the package script is `tsc --noEmit && tsc -p tsconfig.test.json` |
| `eslint` on the changed file | 0 | green | no output |
| `check-changeset-presence` | 0 | green | "declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate" |
| `check-changeset-no-major` | 0 | green | "No changeset declares a `major` bump." |
| `check-control-bytes` | 0 | green | "OK (scanned 5899 tracked text file(s); skipped 85 binary)" |

The whole-`unit`-project run is not incidental: the `unit` project runs with `isolate: false`, so the added side-effect registrations are visible to every other unit file sharing a worker. 801/801 green is the measurement that they leak into nothing.

Two notes on reading the evidence honestly:

- The typecheck is a real measurement, not an assumed one. A first attempt reported `Cannot find module '@object-ui/*'` across files this PR never touches — an unbuilt workspace closure, which is NOT MEASURED rather than red. Routing through turbo builds the closure first, and `--listFiles` confirmed the edited file is actually in the `tsconfig.test.json` program (6 hits) rather than excluded like it is from `tsconfig.json`.
- Every exit code above was captured by redirect-then-read, never through a pipe.

## Not changed

No production code. The ledger text, the palette decisions and `CLAIMS_NO_RENDERER` are all untouched — this PR changes only what the guard can see. The changeset declares an empty frontmatter: nothing is released.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_