### PR TITLE
docs(plugin-detail): the record:* registration comments say REFUSES, not STRIPS

### DIFF
--- a/.changeset/7127-record-details-refuses-not-strips.md
+++ b/.changeset/7127-record-details-refuses-not-strips.md
@@ -1,0 +1,10 @@
+---
+---
+
+Comment-only. The `record:details` and `record:highlights` registration comments in
+`@object-ui/plugin-detail` stated that the spec STRIPS an undeclared key on parse.
+Measured against the installed `@objectstack/spec` 17.2.0, it REFUSES it — `safeParse`
+returns `success: false` with `unrecognized_keys` naming the key — so both comments now
+state the mechanism they actually rely on. No published behaviour changes: the decision
+both comments record (do not publish those keys as authorable inputs) is unchanged, and
+no declaration, type or renderer was touched.

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -425,10 +425,18 @@ ComponentRegistry.register('details', RecordDetailsRenderer, {
   // Documented member keys are exactly the spec's four (`name`, `label`,
   // `columns`, `fields`) — deliberately NOT the extras `RecordDetailsRenderer`
   // also honours on a section (`title`, `showBorder`, `hideEmpty`). Those are
-  // undeclared upstream, so the spec's section object STRIPS them on parse:
-  // publishing them here would advertise keys the contract throws away, the
-  // same trap as declaring a top-level `readonly` on `record:highlights`
-  // below. The renderer tolerating them is not a licence to teach them.
+  // undeclared upstream, and the spec's section object REFUSES them on parse
+  // rather than stripping them: `RecordDetailsProps.safeParse` on a section
+  // carrying any of the three returns `success: false` with
+  // `unrecognized_keys` naming the key (measured on the installed pin, 17.2.0,
+  // against a control — `columns: 2` — that parses and whose value survives).
+  // So publishing them here would advertise keys that make the whole document
+  // fail to validate, not keys the contract quietly throws away — the same
+  // trap as declaring a top-level `readonly` on `record:highlights` below. The
+  // renderer tolerating them is not a licence to teach them. (This said
+  // "STRIPS" until objectui#7127: that was the pre-#4001-batch-A behaviour the
+  // spec's own refusal message still recounts, and the `layout` paragraph
+  // above already said `rejects`.)
   inputs: [
     { name: 'columns', type: 'enum', label: 'Columns', enum: ['1', '2', '3', '4'], defaultValue: '2', description: 'Number of columns for field layout (1-4)' },
     { name: 'sections', type: 'array', label: 'Sections', description: 'Field groups rendered as the detail body, in order. Every entry is an OBJECT — `{ name?, label?, columns?, fields }` — a bare section-id string is NOT accepted (the spec retired that spelling in objectstack#5611, and the renderer reads name/label/fields off each entry, so a string entry renders no fields at all). `fields` (required) are the field names shown in this section, in order. `label` is the section heading; omit it for an untitled, borderless section. `name` is a stable snake_case identifier and the i18n anchor — the heading resolves through objects.<object>._sections.<name>.label, so a section without a name shows its authored label in every locale. `columns` (1-4) is THIS section\'s field-grid width; omit it and the renderer derives the width. Authoring `sections` at all makes it the only source of the detail body; omit it and the body falls back to the object\'s highlightFields.' },
@@ -556,17 +564,23 @@ ComponentRegistry.register('highlights', RecordHighlightsRenderer, {
   // `RecordHighlightsProps` has exactly three top-level keys (fields, layout,
   // aria). A top-level `{ name: 'readonly', type: 'boolean' }` here would look
   // like the fix for "the manifest never mentions readonly" and would instead
-  // publish a key the platform silently discards: the generated
+  // publish a key the platform does not accept: the generated
   // `sdui.manifest.json` and `sdui-intrinsics.d.ts` would advertise
   // `<RecordHighlights readonly>`, the manifest gate validates top-level props
-  // only and would raise no diagnostic, the spec strips the unknown key on
-  // parse without error, and the renderer — which reads `field.readonly` per
-  // entry — would never see it. An author who trusted that surface would be
-  // left with the machine-owned column still hand-editable and nothing
-  // anywhere saying why. `ComponentInput` is flat by design (`name` = "must
-  // match schema property"), so an array-of-objects input publishes its member
-  // keys in prose, the same way `record:path.stages` and `record:alert.action`
-  // do. objectui#3407 / objectstack#5176.
+  // only and would raise no diagnostic, the spec REFUSES the unknown key on
+  // parse rather than stripping it — `RecordHighlightsProps.safeParse` returns
+  // `success: false` with `unrecognized_keys: ['readonly']` (measured on the
+  // installed pin, 17.2.0, against a control — `layout: 'vertical'` — that
+  // parses and whose value survives) — and the renderer, which reads
+  // `field.readonly` per entry, would never see it either. An author who
+  // trusted that surface would be left with the machine-owned column still
+  // hand-editable and their page refused by the contract wherever it is
+  // parsed. (This said "strips the unknown key on parse without error" until
+  // objectui#7127: the pre-#4001-batch-A behaviour, the same stale claim the
+  // `record:details` block above carried.) `ComponentInput` is flat by design
+  // (`name` = "must match schema property"), so an array-of-objects input
+  // publishes its member keys in prose, the same way `record:path.stages` and
+  // `record:alert.action` do. objectui#3407 / objectstack#5176.
   inputs: [
     { name: 'fields', type: 'array', label: 'Fields', required: true, description: 'Key fields to highlight (1-7), bare names or {name,label?,icon?,type?,readonly?}. Set readonly: true on an entry to render that chip read-only — it suppresses the inline-edit affordance and the HeaderHighlight editability gate enforces it. Use it for hook/automation-maintained columns that must not be hand-edited from the record header; marking the OBJECT field readonly instead would also strip the hook\'s own write-back.' },
     { name: 'layout', type: 'enum', label: 'Layout', enum: ['horizontal', 'vertical'], defaultValue: 'horizontal', description: 'Layout orientation for highlight fields' },


### PR DESCRIPTION
Fixes #7127

Comment-only. Every changed line in `packages/plugin-detail/src/index.tsx` is a `//` line — mechanically checked: `git diff -U0` produces 40 changed lines and **0** that do not match `^[+-]  // `. No declaration, type, renderer, input or decision moved.

## 1. Re-measured at the version installed now — not quoted from the card

`@objectstack/spec` **17.2.0** (root and `packages/plugin-detail/node_modules` both resolve to 17.2.0; declared range `^17.1.0`). Probe run from the worktree against `dist/ui/index.mjs`:

| probe | verdict |
|---|---|
| `RecordDetailsProps.safeParse({ sections: [{ label, fields, title: 'T' }] })` | **REFUSED** — `unrecognized_keys: ['title']` at path `sections.0` |
| same with `showBorder: true` | **REFUSED** — `unrecognized_keys: ['showBorder']` |
| same with `hideEmpty: true` | **REFUSED** — `unrecognized_keys: ['hideEmpty']` |
| **control** — same with `columns: 2` | **PARSED**, and the value survives: `data.sections[0].columns === 2` |
| **control 2** — bare `{ label, fields }` section | **PARSED**, `fields` survives |

Verbatim refusal message (it recounts the very history the card points at):

> Unrecognized key(s) on this `record:details` section: `hideEmpty`. Until #4001 batch A an undeclared prop was dropped in silence: the props schema stripped it and `PageComponent.properties` is an open bag, so the key reached objectui's renderer, was not read there, and the author got a success receipt for configuration that did nothing.

So the comment's mechanism was wrong in the direction that matters: a stripped key is dropped in silence and the page still renders; a refused key fails the parse and the document does not validate. The decision the block records — do **not** publish `title` / `showBorder` / `hideEmpty` as authorable inputs — is unchanged and is now carried by the stronger reason.

## 2. The self-contradiction: CONFIRMED, with one correction to the card

**Confirmed.** Both sentences live in the same contiguous `//` block on the `record:details` registration, six lines apart:

- line 422 — "Re-adding it here would republish a key the spec now **rejects** on parse" (about the retired `layout`)
- line 428 — "so the spec's section object **STRIPS** them on parse"

**Corrected.** The card also says the block "even records why the behaviour changed — *Until #4001 batch A an undeclared prop was dropped in silence…*". That sentence is **not in `index.tsx`**: it is the spec's own refusal message, quoted above, and it is echoed in the sibling test files' header comments (`recordDetailsInputs.spec-parity.test.ts:257`, `recordHighlightsInputs.spec-parity.test.ts:80`). Control for that zero: `grep -i silence` on `index.tsx` does hit — lines 74, 209, 265 — just not that sentence.

Git-history provenance for "STRIPS is pre-#4001 wording" is **NOT MEASURED**: this checkout is shallow (`git rev-parse --is-shallow-repository` = true; deepened to 525 commits and `index.tsx` still shows only 3 touching commits), so `git log -S` collapses every one of the three phrases onto the graft-boundary commit. The pre-#4001 reading rests on the spec's own message ("the props schema stripped it"), not on history here.

## 3. The sweep — what else in the block asserts spec parse behaviour

All other parse claims in this file were probed at 17.2.0. Three are **true and untouched**:

| claim (line) | probe | verdict |
|---|---|---|
| 422 — `layout` is a tombstone the spec "rejects on parse" | `{ layout: 'auto' }` | REFUSED, `invalid_type`, "removed in @objectstack/spec 17.0.0 (#6946, ADR-0087 D2)" — **claim true** |
| 447 — `hideFields` is `z.array(z.string())`, rejects `{name}` entries | `{ hideFields: [{ name: 'phone' }] }` | REFUSED, expected string received object; control `['phone']` parses — **claim true** |
| 469 — `inlineEdit` / `showHeader` plain booleans, `1` / `'true'` / `null` rejected by value | all three | REFUSED, `invalid_type`; control `false` parses — **claim true** |

One is **the same defect, and is fixed here too** — the neighbouring `record:highlights` registration comment (line 562) said the spec "strips the unknown key on parse without error" for a top-level `readonly`:

| probe | verdict |
|---|---|
| `RecordHighlightsProps.safeParse({ fields: ['phone'], readonly: true })` | **REFUSED** — `unrecognized_keys: ['readonly']` |
| **control** — `{ fields: ['phone'], layout: 'vertical' }` | **PARSED**, `layout` survives |

Same class (a comment certifying spec parse behaviour the spec no longer has), same file, same measurement, and the card's dispatch asked for the sweep to fix same-class staleness and say which was fixed and which was left. Its decision — `readonly` is documented inside the `fields` description, never declared as a top-level input — is unchanged.

**Left alone deliberately:** every declaration. The four-party divergence about `hideEmpty` (spec refuses / `@object-ui/types` `views.ts:230` declares / the zod mirror omits / `RecordDetailsRenderer` honours) is a maintainer decision routed on #7129 and is not resolved here.

## 4. Does any test pin the old wording? No — measured

No test reads `packages/plugin-detail/src/index.tsx` as text. The only `readFileSync(join(SRC_DIR, …))` in `plugin-detail`'s tests targets `renderers/record-details.tsx`. Controls for those zeros: 7 test files in that directory do side-effect-import `'../index'` (so the edited module is loaded and executed by the green run below), and 204 test files repo-wide use `readFileSync`.

## 5. Gates — all run at the final commit `783f04300`

| gate | exit | verdict line |
|---|---|---|
| `pnpm exec vitest run` on the two `plugin-detail` spec-parity files + `apps/console/src/__tests__/registry-inputs-spec-parity.test.ts` | 0 | `Test Files  3 passed (3)` / `Tests  131 passed (131)`; lock `VERDICT command-exit 0` |
| `pnpm exec eslint packages/plugin-detail/src/index.tsx` | 0 | `✖ 31 problems (0 errors, 31 warnings)` — all 31 pre-existing, on lines 148-243, none touched here |
| `node scripts/check-changeset-presence.mjs` (staged first) | 0 | `✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `✅  No changeset declares a 'major' bump.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅  check-control-bytes: OK (scanned 5908 tracked text file(s); skipped 85 binary).` |

**Declared narrowing — `pnpm --filter @object-ui/plugin-detail run type-check` is NOT MEASURED, not green.** It exits 2 with 21 diagnostics that are all `TS2307 Cannot find module '@object-ui/components' / '@object-ui/core' / …` plus the implicit-`any` cascade behind them — an unbuilt dependency closure in a fresh worktree, present before this change and unrelated to it. Rather than spend a shared-box closure build on a diff that changes zero non-comment lines, it is declared unrun: the file is proven to still parse and register by the vitest run above, which imports it.

The changeset is empty-frontmatter — this releases nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_