### PR TITLE
fix(app-shell): no Design mode or block-canvas rail on studio-canvas leaves

### DIFF
--- a/.changeset/7121-studio-canvas-leaf-affordances.md
+++ b/.changeset/7121-studio-canvas-leaf-affordances.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Studio Interfaces: no Design mode and no "click a block" rail on leaves that have
+no block canvas (objectui#7121).
+
+`registerStudioCanvasPreview(type, …)` opts a type into a surface-specific canvas
+that renders the running app rather than an editable draft — a contract, not a
+habit: `StudioCanvasPreviewProps` carries no `selection`, `onSelectionChange`,
+`onPatch` or `editing`. Two affordances beside such a leaf ignored that.
+
+- The Design/Run switch (objectui#5800) was still offered, though `editing` is
+  handed to exactly one canvas branch (`Preview`). On a studio-canvas leaf the
+  switch moved `canvasMode` and reached no renderer — a live-looking control
+  wired to nothing. It is now gated.
+- The right rail fell through to "Click a block on the canvas, and edit its
+  properties right here." beside a canvas that has no blocks, so the instruction
+  could not be followed. It now states what the canvas is, and — because this
+  canvas has no blocks by contract — promises no recovery.
+- The rail's new branch is ordered ahead of the selection branch, so a block
+  selected on a *different* leaf no longer opens a scoped inspector for a block
+  this canvas does not contain; the header's "clear selection" button is gated
+  with it.
+
+The discriminator is `StudioCanvas`, not `isEditable`. `isEditable` is
+`!!Preview && !StudioCanvas` — a conjunction of two independent causes — so
+gating on it would also strip these affordances from leaves whose only fault is
+that their own type has no designer, the state objectui#6795 part C pinned as
+still deserving the ordinary rail. Behaviour on every leaf with a block canvas
+is unchanged.

--- a/packages/app-shell/src/views/metadata-admin/i18n.ts
+++ b/packages/app-shell/src/views/metadata-admin/i18n.ts
@@ -1777,6 +1777,12 @@ const ENGINE_STRINGS_EN: Record<string, string> = {
   'engine.studio.inspector.tabSource': 'Source',
   'engine.studio.inspector.emptyLine1': 'Click a block on the canvas,',
   'engine.studio.inspector.emptyLine2': 'and edit its properties right here.',
+  // objectui#7121 — the rail beside a studio-canvas leaf (a
+  // `registerStudioCanvasPreview` type: the running app, not a block tree).
+  // States what the canvas IS; promises no recovery, because there is nothing
+  // to wait for — `StudioCanvasPreviewProps` carries no selection by contract.
+  'engine.studio.inspector.studioCanvasNoBlocks':
+    'This canvas renders the running app, not a block tree — it has no blocks to select, and nothing here is edited from this panel.',
   'engine.studio.inspector.designersMissing':
     'No metadata designers are registered in this session, so there is nothing to edit here.',
   'engine.studio.inspector.noPageSchema': 'Page settings are unavailable — the page schema could not be loaded.',
@@ -3639,6 +3645,8 @@ const ENGINE_STRINGS_ZH: Record<string, string> = {
   'engine.studio.inspector.tabSource': '源码',
   'engine.studio.inspector.emptyLine1': '在画布里点选一个积木,',
   'engine.studio.inspector.emptyLine2': '它的属性会在这里直接编辑。',
+  'engine.studio.inspector.studioCanvasNoBlocks':
+    '此画布渲染的是运行态应用，而不是积木树 —— 这里没有可选中的积木，也没有可在本面板编辑的内容。',
   'engine.studio.inspector.designersMissing': '本次会话没有注册任何元数据设计器,这里没有可编辑的内容。',
   'engine.studio.inspector.noPageSchema': '页面设置不可用——无法加载页面 schema。',
   'engine.studio.inspector.sourcePageLine1': '这个页面是 {kind} 源码,不是积木树 ——',

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.studioCanvasLeaf.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.studioCanvasLeaf.test.tsx
@@ -1,0 +1,300 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7121 — what the Interfaces pillar may OFFER beside a studio-canvas
+ * leaf.
+ *
+ * ## The mechanism
+ *
+ * `registerStudioCanvasPreview(type, …)` opts a type into a surface-specific
+ * canvas: the running app, not an editable draft. That is a contract, not a
+ * habit — `StudioCanvasPreviewProps` is deliberately a small read-only subset
+ * of `MetadataPreviewProps` with **no `selection`, no `onSelectionChange`, no
+ * `onPatch`, no `editing`**. So a studio-canvas leaf:
+ *
+ *   - can never produce a block selection (there is no block tree), and
+ *   - can never read the design/run mode (nothing is handed `editing`).
+ *
+ * Two affordances beside it ignored both facts: the Design/Run switch (#5800)
+ * was still offered though `canvasMode` reached no renderer, and the rail fell
+ * through to *"Click a block on the canvas, and edit its properties right
+ * here."* — an instruction that cannot be followed.
+ *
+ * ## ⚠️ This is NOT #6795 part C's cause, and the precondition says so
+ *
+ * Part C repaired what the pillar says when the designer registries are
+ * **empty**. Every test here asserts a **POPULATED** registry first
+ * (`listMetadataPreviewTypes()` non-empty), because a zero-registry reading
+ * would measure that other card instead. The cause here is an ungated
+ * affordance, not a missing registration.
+ *
+ * ## ⛔ The message promises no recovery
+ *
+ * Part C established by measurement that these registries are plain `Map`s read
+ * during render with no subscription, so a consumer that read an empty one
+ * never recovers ("late inspector rendered: false") — no "loading…", no "try
+ * again". Here the constraint is even stricter: the statement is not about
+ * registration at all. This canvas has no blocks **by contract**, so there is
+ * nothing to wait for, and the last test pins the absence of recovery language.
+ *
+ * ## ⚠️ The discriminator is `StudioCanvas`, NOT `isEditable`
+ *
+ * `isEditable = !!Preview && !StudioCanvas` is a conjunction of two independent
+ * causes. Gating on it would also strip these affordances from leaves whose
+ * only fault is that **their own type** has no designer — the exact state
+ * `StudioDesignSurface.designerRegistryPartial.test.tsx` pins as still deserving
+ * the ordinary "click a block" rail. That file is the live fence: gate on
+ * `isEditable` and it goes red.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const objectDef = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: [{ name: 'title', label: 'Title', type: 'text' }],
+};
+
+/**
+ * One leaf of each kind, in one app: `object` opts into the studio canvas,
+ * `dashboard` does not (it is an ordinary block-canvas designer). The contrast
+ * is the point — the second leaf is the regression fence.
+ */
+const NAV = [
+  { id: 'nav_obj', type: 'object', label: 'Tasks', objectName: 'showcase_task' },
+  { id: 'nav_dash', type: 'dashboard', label: 'Overview', dashboardName: 'sales_overview' },
+];
+
+const mockClient = {
+  save: vi.fn(async () => ({})),
+  list: vi.fn(async (type: string) => {
+    if (type === 'app') return [{ name: 'acme_app', label: 'Acme' }];
+    if (type === 'object') return [{ name: 'showcase_task', label: 'Task' }];
+    return [];
+  }),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async (type: string, name: string) => {
+    if (type === 'app') return { effective: { name: 'acme_app', label: 'Acme', navigation: NAV } };
+    if (type === 'object') return { effective: objectDef, code: objectDef };
+    if (type === 'dashboard') return { effective: { name: 'sales_overview', label: 'Sales' } };
+    return { effective: { name } };
+  }),
+  getDraft: vi.fn(async () => null),
+  get: vi.fn(async () => undefined),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return { ...mod, useMetadataClient: () => mockClient, useMetadataTypes: () => ({ entries: [] }) };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+import { InterfacesPillar } from './StudioDesignSurface';
+import { listMetadataPreviewTypes, registerMetadataPreview } from '../metadata-admin/preview-registry';
+import { listMetadataInspectorTypes, registerMetadataInspector } from '../metadata-admin/inspector-registry';
+import { listStudioCanvasPreviewTypes } from './studio-canvas-preview';
+
+const CLICK_A_BLOCK = 'Click a block on the canvas,';
+
+/**
+ * A block-canvas designer for an unrelated type. Two jobs: it makes the
+ * designer registry demonstrably POPULATED (the card's precondition), and it
+ * is the regression fence's leaf. It reports the `editing` prop it was handed,
+ * so the Design/Run round trip is measured at the seam that actually carries
+ * the mode rather than through any one renderer's overlay internals.
+ */
+function StubDashboardPreview(props: Record<string, unknown>): React.ReactElement {
+  const onSel = props.onSelectionChange as ((s: unknown) => void) | undefined;
+  return (
+    <div data-testid="stub-dash" data-editing={String(props.editing)}>
+      <button
+        type="button"
+        data-testid="pick-block"
+        onClick={() => onSel?.({ kind: 'block', id: 'blk_1' })}
+      >
+        pick
+      </button>
+    </div>
+  );
+}
+registerMetadataPreview('dashboard', StubDashboardPreview as never);
+
+/**
+ * Production registers `ObjectFieldInspector` for `object`
+ * (`metadata-admin/inspectors/index.ts`), so the scoped-inspector branch is
+ * reachable on the studio-canvas leaf whenever a `selection` survives a leaf
+ * change. Registering a stand-in here is what makes the last pin a measurement
+ * of that branch rather than of an accidentally-empty registry.
+ */
+function StubObjectInspector(props: Record<string, unknown>): React.ReactElement {
+  const sel = props.selection as { kind?: string; id?: string } | null;
+  return (
+    <div
+      data-testid="stub-object-inspector"
+      data-for={`${String(props.type)}:${String(props.name)}:${sel?.kind}:${sel?.id}`}
+    />
+  );
+}
+registerMetadataInspector('object', StubObjectInspector as never);
+
+afterEach(cleanup);
+
+function mountPillar() {
+  return render(
+    <MemoryRouter initialEntries={['/studio/com.acme.app/interfaces']}>
+      <InterfacesPillar packageId="com.acme.app" />
+    </MemoryRouter>,
+  );
+}
+
+/** The precondition every test here shares, stated rather than assumed. */
+function expectPopulatedRegistries() {
+  expect(listMetadataPreviewTypes()).toContain('dashboard');
+  expect(listMetadataPreviewTypes().length).toBeGreaterThan(0);
+  expect(listMetadataInspectorTypes()).toContain('object');
+  // ...and the leaf under test really is a studio-canvas leaf.
+  expect(listStudioCanvasPreviewTypes()).toContain('object');
+}
+
+async function openLeaf(title: string) {
+  mountPillar();
+  fireEvent.click(await screen.findByTitle(title));
+}
+
+const bodyText = () => (document.body.textContent ?? '').replace(/\s+/g, ' ');
+
+describe('Interfaces pillar — affordances beside a studio-canvas leaf (#7121)', () => {
+  it('offers no Design/Run switch on a leaf whose canvas cannot read the mode', async () => {
+    expectPopulatedRegistries();
+    await openLeaf('object · showcase_task');
+
+    // Wait on the canvas itself, not on the toggle — the toggle's ABSENCE is
+    // the assertion, so waiting for it would deadlock the pin by construction.
+    await waitFor(() => expect(bodyText()).toContain('Runtime list preview'), { timeout: 4000 });
+
+    expect(screen.queryByTestId('canvas-mode-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Design' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Run' })).not.toBeInTheDocument();
+  });
+
+  it('replaces the impossible "click a block" invitation with what is true', async () => {
+    expectPopulatedRegistries();
+    await openLeaf('object · showcase_task');
+    await waitFor(() => expect(bodyText()).toContain('Runtime list preview'), { timeout: 4000 });
+
+    await waitFor(() =>
+      expect(bodyText()).toContain('This canvas renders the running app, not a block tree'),
+    );
+    // ⛔ The invitation that cannot be followed must be gone.
+    expect(bodyText()).not.toContain(CLICK_A_BLOCK);
+    // ⛔ And this must not be mistaken for #6795 part C's empty-registry state,
+    // which is demonstrably not the cause here.
+    expect(bodyText()).not.toContain('No metadata designers are registered');
+  });
+
+  it('promises no recovery — there is nothing to wait for', async () => {
+    expectPopulatedRegistries();
+    await openLeaf('object · showcase_task');
+    await waitFor(() => expect(bodyText()).toContain('This canvas renders the running app'), {
+      timeout: 4000,
+    });
+
+    // Scoped to the RAIL, not the document: the canvas beside it renders the
+    // real records grid, which in jsdom (no data source) says "Error loading
+    // grid" — its own honest state, and nothing this card may speak for. A
+    // document-wide scan would read that as the rail promising recovery.
+    const railBlock = screen.getByText(/This canvas renders the running app/).closest('div');
+    const rail = railBlock?.textContent ?? '';
+    // Control: the scoped read must actually have found the message.
+    expect(rail).toContain('This canvas renders the running app');
+
+    for (const promise of ['Loading', 'loading', 'try again', 'Try again', 'not yet', 'in progress']) {
+      expect(rail).not.toContain(promise);
+    }
+  });
+
+  it('does not open a scoped inspector for a block selected on a DIFFERENT leaf', async () => {
+    expectPopulatedRegistries();
+
+    // Select a block on the dashboard leaf — a real selection, made through the
+    // pillar's own `onSelectionChange`.
+    await openLeaf('dashboard · sales_overview');
+    await waitFor(() => expect(screen.getByTestId('stub-dash')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+    fireEvent.click(screen.getByTestId('pick-block'));
+    await waitFor(() => expect(screen.getByLabelText('Clear selection')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    // ...then walk to the studio-canvas leaf. The pillar's load effect clears
+    // `selection` only on the editable path, so the selection is still live.
+    fireEvent.click(screen.getByTitle('object · showcase_task'));
+    await waitFor(() => expect(bodyText()).toContain('Runtime list preview'), { timeout: 4000 });
+
+    // The block belongs to another leaf's canvas and does not exist on this one.
+    expect(screen.queryByTestId('stub-object-inspector')).not.toBeInTheDocument();
+    expect(bodyText()).toContain('This canvas renders the running app, not a block tree');
+    // ...and the rail must not contradict itself by offering to clear a
+    // selection it just said cannot exist here.
+    expect(screen.queryByLabelText('Clear selection')).not.toBeInTheDocument();
+  });
+});
+
+describe('REGRESSION FENCE — a leaf WITH a block canvas is untouched (#7121)', () => {
+  it('still offers the Design/Run switch, and it still round-trips', async () => {
+    expectPopulatedRegistries();
+    await openLeaf('dashboard · sales_overview');
+    await waitFor(() => expect(screen.getByTestId('canvas-mode-toggle')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    // #5800's acceptance: 设计⇄运行 is a round trip on the SAME renderer, and
+    // `editing` is the mode the renderer actually reads.
+    expect(screen.getByTestId('stub-dash')).toHaveAttribute('data-editing', 'true');
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('stub-dash')).toHaveAttribute('data-editing', 'false'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Design' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('stub-dash')).toHaveAttribute('data-editing', 'true'),
+    );
+  });
+
+  it('keeps the ordinary "click a block" rail where a block canvas exists', async () => {
+    expectPopulatedRegistries();
+    await openLeaf('dashboard · sales_overview');
+    await waitFor(() => expect(screen.getByTestId('stub-dash')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    // The repair must not over-fire: this leaf HAS blocks to click.
+    await waitFor(() => expect(bodyText()).toContain(CLICK_A_BLOCK));
+    expect(bodyText()).not.toContain('This canvas renders the running app');
+  });
+
+  it('keeps the selection affordances where a block canvas exists', async () => {
+    expectPopulatedRegistries();
+    await openLeaf('dashboard · sales_overview');
+    await waitFor(() => expect(screen.getByTestId('stub-dash')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    fireEvent.click(screen.getByTestId('pick-block'));
+    await waitFor(() => expect(screen.getByLabelText('Clear selection')).toBeInTheDocument());
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -1576,7 +1576,19 @@ export function InterfacesPillar({
       <div className="mb-3 flex shrink-0 items-center gap-2">
         {/* objectui#5800 — the 设计⇄运行 switch replaces the static 实时预览
             chip: same renderer either way, the switch only adds/removes the
-            design affordances. */}
+            design affordances.
+
+            objectui#7121 — ...but only where a renderer READS the mode. `editing`
+            is handed to exactly one canvas branch (`Preview`, below); a
+            studio-canvas leaf renders `StudioCanvas`, whose props
+            (`StudioCanvasPreviewProps`) carry no `editing` by contract — it is
+            the running app, not an editable draft. So on those leaves the
+            switch moved `canvasMode` and nothing else: a live-looking control
+            wired to nothing. Gated on `StudioCanvas` — the SAME value that
+            selects the canvas branch — and deliberately NOT on `isEditable`,
+            which is `!!Preview && !StudioCanvas` and would also strip the
+            switch from the no-designer leaves that #6795 part C pinned. */}
+        {!StudioCanvas && (
         <div className="inline-flex items-center gap-0.5 rounded-lg bg-muted p-1" data-testid="canvas-mode-toggle">
           <button
             type="button"
@@ -1601,6 +1613,7 @@ export function InterfacesPillar({
             {t('engine.studio.if.modeRun', locale)}
           </button>
         </div>
+        )}
         {current && (
           <span className="text-[11px] text-muted-foreground">
             {current.type} · {current.name}
@@ -1693,7 +1706,13 @@ export function InterfacesPillar({
       <SlidersHorizontal className="h-3.5 w-3.5" />
       <span className="text-[13px] font-medium">{t('engine.studio.inspector.props', locale)}</span>
       <div className="ml-auto flex items-center gap-0.5">
-        {selection && (
+        {/* objectui#7121 — same gate as the rail branch: on a studio-canvas
+            leaf `selection` can only be a leftover from the previous leaf, so
+            offering "clear selection" here would contradict the rail beside it,
+            which states this canvas has no blocks. (The leftover STATE itself
+            outlives every non-editable leaf change, not just these — filed
+            separately rather than swept in here.) */}
+        {selection && !StudioCanvas && (
           <button
             type="button"
             onClick={() => setSelection(null)}
@@ -1745,6 +1764,34 @@ export function InterfacesPillar({
           onNavPatch={onNavPatch}
           onClear={() => setNavSel(null)}
         />
+      </div>
+    ) : StudioCanvas && current ? (
+      // ⭐ objectui#7121 — a studio-canvas leaf has no block tree, so the
+      // generic "click a block on the canvas" invitation below instructs the
+      // author to do something impossible: `StudioCanvasPreviewProps` carries
+      // no `selection`/`onSelectionChange` by contract, so this canvas can
+      // never produce one. Measured with the designer registry POPULATED
+      // (`listMetadataPreviewTypes() === ['dashboard']`), which is what makes
+      // this a different cause from #6795 part C's empty-registry states.
+      //
+      // Ordered BEFORE the `selection` branch on purpose. `selection` is state
+      // that outlives a leaf change (the load effect clears it only on the
+      // editable path), so arriving here with a block selected on the PREVIOUS
+      // leaf otherwise opens the scoped inspector for a block this canvas does
+      // not contain — measured: `ObjectFieldInspector` handed
+      // `object:showcase_task:block:blk_1`. This ordering mirrors the canvas
+      // chain, where `StudioCanvas` also wins.
+      //
+      // ⛔ Says what is true and promises no recovery — no "loading…", no "try
+      // again". Same constraint part C established: these registries are plain
+      // `Map`s read during render with no subscription. Here the statement is
+      // not even about registration — this canvas has no blocks by contract,
+      // so there is nothing to wait for.
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        <div className="flex flex-col items-center gap-2 px-2 py-10 text-center text-xs text-muted-foreground">
+          <Eye className="h-5 w-5" />
+          {t('engine.studio.inspector.studioCanvasNoBlocks', locale)}
+        </div>
       </div>
     ) : selection && Inspector && current ? (
       <div className="min-h-0 flex-1 overflow-auto p-3">


### PR DESCRIPTION
Fixes #7121

The Interfaces pillar offered **Design mode** and a *"Click a block on the canvas, and edit its properties right here."* rail beside studio-canvas leaves that have no block canvas at all. Both instructions are impossible to follow there.

## Leg 0 — reproduced on current `origin/main`, NOT already repaired by #7120

Measured on `220c18d05` (which contains #7120 as `994b73696`), with the designer registry **populated** — the card's precondition:

```
[A] preview types now: ["dashboard"]
[A] studio-canvas types: ["object"]
[A] toggle present: true
[A] rail says click-a-block: true
[A] canvas hint present: true
```

The canvas beside that rail is honest — it carries *"Runtime list preview · edit fields / structure in the Data pillar"* — while the rail contradicts it. So this is the ungated affordance, not the empty-registry class #6795 part C repaired.

## Leaf population — enumerated before editing

`registerStudioCanvasPreview` call sites across the whole repo:

| site | type | has a block canvas? |
| --- | --- | --- |
| `studio-canvas-preview.tsx:97` (built-in default) | `object` | no — runtime records grid |
| `studio-canvas-preview.test.tsx:43,48` | `object` (override, restored) | test-only |

**Population: one** (`object`), confirmed at runtime by `listStudioCanvasPreviewTypes() === ["object"]`. The registry is a public extension point, so the gate is written against the registry, not against the string `object`.

## ⚠️ `isEditable` is a proxy, and gating on it would have broken a landed pin

The card sketched gating on `isEditable`. That is **not** the right discriminator, and this is measured rather than argued.

`isEditable = !!Preview && !StudioCanvas` — a conjunction of two independent causes. It is false both for a studio-canvas leaf *and* for a leaf whose own type simply has no designer. The second is the state #6795 part C **pinned as still deserving the ordinary rail**, in `StudioDesignSurface.designerRegistryPartial.test.tsx`.

Ablation, direction predicted before running — swap `StudioCanvas` for `isEditable` at both gates, then run that landed pin. Predicted RED, observed RED:

```
MUTATED: 5209c038d421b8410c2ed7049d70eaf610afcda3 -> a80d71a6dc06e2f3200dfab970ad47b496821e16
grep proof -> !StudioCanvas remaining: 0 | isEditable gate: 1
 × says no designer is registered for this type, not that none loaded at all
 × keeps the ordinary "click a block" empty state when designers ARE registered
TestingLibraryElementError: Unable to find an element by: [data-testid="canvas-mode-toggle"]
 Tests  2 failed (2)
```

Restore proven by state: blob hash back to `5209c038d…`, `git diff HEAD` empty, `git diff --cached` empty, `!StudioCanvas` gate count back to 1.

⇒ the gate is `StudioCanvas` — the same value that selects the canvas branch. Blast radius is exactly the studio-canvas leaves.

## The repair

Three surfaces in `StudioDesignSurface.tsx` (`InterfacesPillar`), all reached through the shared `canvasEl` / `inspectorBodyEl`, so all three layouts — classic, folded-wide, folded-tabs — are covered by one change.

1. **Design/Run switch** gated on `!StudioCanvas`. `editing` is handed to exactly one canvas branch (`Preview`); `StudioCanvasPreviewProps` carries no `editing` by contract, so the switch moved `canvasMode` and reached no renderer.
2. **The rail** gets a studio-canvas branch stating what the canvas is. It promises no recovery — and here the constraint is stricter than part C's: the statement is not about registration at all, so there is nothing to wait for.
3. **Ordering + the header button** — a bounded in-place addition, declared rather than slipped in. The new rail branch is ordered **ahead of** the `selection` branch, and the header's "clear selection" button is gated with it. Without this, my own repair would have left the rail saying "no blocks here" beside a button offering to clear a selection.

That third item is a fix for a defect I measured while here:

```
[D] scoped inspector rendered on studio-canvas leaf: true
[D] inspector was handed type/name: object:showcase_task:block:blk_1
```

`blk_1` is a block on a *different* leaf's canvas — `selection` outlives a leaf change because the load effect's `setSelection(null)` sits inside the `isEditable` early-return. The rail symptom is closed here; the **underlying state leak reaches every non-editable leaf**, so it is filed separately as #7137 rather than swept in.

## New string

`engine.studio.inspector.studioCanvasNoBlocks`, added to `en` and `zh`.

⚠️ Worth recording: `engine.*` strings do **not** live in `packages/i18n/src/locales/` and are not covered by `all-locales-key-parity`. They are a flat dotted-key table with `en` and `zh` only, in `views/metadata-admin/i18n.ts`, whose header states the carve-out and which `check-i18n-call-site-keys.mjs` skips by declaration. `check:i18n-drift` confirms the packs did not move: *"0 en value(s) changed"*.

## Pins

`StudioDesignSurface.studioCanvasLeaf.test.tsx` — 7 tests. Four pin the studio-canvas leaf; **three are the regression fence** on a leaf that does have a block canvas, which matters more: the switch is still offered and still round-trips (`editing` true → false → true, #5800's acceptance), the ordinary "click a block" rail is untouched, and the selection affordances still work.

Ablation, direction predicted before running — revert the source fix, keep the tests. Predicted RED on the four, green on the fence:

```
MUTATED: 5209c038d421b8410c2ed7049d70eaf610afcda3 -> d5abcd2d3ab77e08c91ba811283d1d28d46cd383  (markers now: 0)
 × offers no Design/Run switch on a leaf whose canvas cannot read the mode
 × replaces the impossible "click a block" invitation with what is true
 × promises no recovery — there is nothing to wait for
 × does not open a scoped inspector for a block selected on a DIFFERENT leaf
 Tests  4 failed | 3 passed (7)
```

Restore proven by state: blob back to `5209c038d…`, `git diff HEAD` and `git diff --cached` both empty, markers back to 3 / 1.

## Gates — all run on `e462194d7`, the final commit

| gate | exit | verdict |
| --- | --- | --- |
| `vitest packages/app-shell/src/views/studio-design/` + locale parity | 0 | `Test Files 43 passed (43) · Tests 257 passed (257)` |
| `pnpm --filter @object-ui/app-shell run type-check` | 0 | `tsc --noEmit && tsc -p tsconfig.test.json`, 0 `error TS` |
| `eslint` (plain form, 3 changed files) | 0 | 0 errors, 20 warnings — **identical to the 20 on the same file at `220c18d05`**, none inside my hunks; new test file and `i18n.ts` contribute 0 |
| `check-changeset-presence` | 0 | `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `check-changeset-no-major` | 0 | `✅ No changeset declares a major bump.` |
| `check:i18n-keys` | 0 | `Every in-scope call-site key resolves against the en pack (2845 keys)` |
| `check:i18n-drift` | 0 | `No en value changed in this range.` |
| `check:control-bytes` | 0 | `✅ OK (scanned 5909 tracked text file(s))` |
| `check-vi-mock-specifiers` | 0 | `✅ OK (771 relative specifier(s) resolved)` |
| `vitest-invocation-guard` | 0 | clean |
| `check-designer-field-key-parity` | 0 | `designer-field-key-parity: OK` |
| `check-lucide-icon-record-names` | 0 | `OK lucide icon names: 182 …` |

Gate set derived from the repo, not guessed: only `check-i18n-call-site-keys.mjs` references `studio-design` / `StudioDesignSurface` / `metadata-admin/i18n` among `scripts/*.mjs` (control: 5 scripts do reference `packages/app-shell`, so that zero is a reading). The remaining rows are the app-shell-reading gates plausibly touched by a JSX + i18n diff.

`typecheck` genuinely covers the new test: `tsc -p tsconfig.test.json --listFiles` lists `studioCanvasLeaf.test.tsx` (1 hit; control `StudioDesignSurface.tsx` also 1; 4508 files total) — so the second `tsc` invocation is not excluding tests.

## Observation, not changed here

The canvas hint below the grid is gated `!isEditable && current?.type === 'object'` — hardcoded to the type rather than to the registry. A second `registerStudioCanvasPreview` leaf would get the gating in this PR but no hint, because the hint's wording ("edit fields / structure in the Data pillar") is object-specific and generalising it is a wording decision. Latent only: population is 1 today. Left for triage.

## Base

Branched from `220c18d05`; `origin/main` has since moved to `2b3964aff`. All measurements above are on `e462194d7`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_