### PR TITLE
fix(fields): the last five inline widgets read the delivered `error` slot

### DIFF
--- a/.changeset/7126-inline-widgets-read-error.md
+++ b/.changeset/7126-inline-widgets-read-error.md
@@ -1,0 +1,41 @@
+---
+'@object-ui/fields': patch
+---
+
+The last five inline edit widgets read the delivered `error` slot, so a failed
+required `text` / `boolean` / `date` / `datetime` / `time` control finally
+reports `aria-invalid` (objectui#7126).
+
+objectui#7008 made `FieldEditWidget` DELIVER the declared `error` key to
+whichever widget it resolves. Of the 27 distinct components in `EDIT_WIDGETS`,
+21 read it; five did not — `TextField`, `BooleanField` (serving both `boolean`
+and `toggle`), `DateField`, `DateTimeField` and `TimeField` — so for their field
+types the delivery was inert and the attribute was still never set.
+
+`text` being in that set is what made this a live defect rather than tidiness.
+It is the most common field type in any object, so it is the likeliest thing a
+kanban column makes required: `RequiredFieldsDialog` computed the failure, drew
+the red "Required" hint, handed the state to the control, and the control said
+nothing to assistive tech. The grid's inline cell editor and the detail page's
+inline edit (`InlineFieldInput`) compose the same seam.
+
+Each of the five now computes `aria-invalid={!!error}` **after** its DOM
+pass-through spread — one existing idiom, the objectui#3222 discipline the other
+21 already share, so a valid field says an explicit `"false"` rather than staying
+mute. Two judgements worth stating:
+
+- **The FORM path was never broken and is unchanged.** `<FormControl>` is a
+  Radix `Slot` whose `aria-invalid` reached each control through the props
+  spread; the form also produces `error`, so the widget's own computation now
+  agrees with the value it replaces. The gap was every host WITHOUT that Slot.
+- **`BooleanField` is the one composite here, and the mark goes on the
+  control.** Its Radix `Checkbox` / `Switch` renders a real
+  `button[role=checkbox]` / `button[role=switch]`; the wrapping flex `div` is
+  deliberately not the target, because a wrapper mark satisfies a subtree query
+  while telling a screen-reader user nothing (objectui#5223). The three
+  date/time widgets each render one native input, so the browser's picker raises
+  no second-element question.
+
+This buys the MARKING only. The objectui#3222 slot drives `aria-invalid` and
+renders no text: the visible message stays with the host, and nothing that was
+invisible becomes visible.

--- a/packages/fields/src/__tests__/inline-widget-aria-invalid-7126.test.tsx
+++ b/packages/fields/src/__tests__/inline-widget-aria-invalid-7126.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The five widgets that never read the delivered `error` now report
+ * `aria-invalid` on a FOCUSABLE control, through the real inline seam
+ * (objectui#7126).
+ *
+ * ## The defect
+ *
+ * objectui#7008 made `FieldEditWidget` DELIVER the declared `error` key
+ * (`toHostProps`, landed as f08bcd9af). Of the 27 distinct components in
+ * `EDIT_WIDGETS`, 21 read it; five did not — `TextField`, `BooleanField`
+ * (`boolean` + `toggle`), `DateField`, `DateTimeField`, `TimeField` — so for
+ * their field types the delivery was inert and `aria-invalid` was still never
+ * set. `text` being in that set is what made it live rather than tidy: it is
+ * the most common type in any object, and the kanban `RequiredFieldsDialog`
+ * renders whatever types the target column made required.
+ *
+ * ## Why the FACTORY and not the widgets directly
+ *
+ * In the FORM these five were already announced correctly and always had been:
+ * `<FormControl>` is a Radix `Slot`, its `aria-invalid` reached the control
+ * through each widget's props spread untouched, and
+ * `widget-aria-invalid-registry-e2e.test.tsx` sweeps exactly that path with an
+ * EMPTY `NOT_YET_DELIVERED` ledger. So a form-based test would have been green
+ * before this change and proves nothing about it.
+ *
+ * `FieldEditWidget` renders no Slot. It is the seam every NON-form host
+ * composes — the grid's inline cell editor, the detail page's inline edit
+ * (`InlineFieldInput`), the kanban required-fields dialog — and the only way
+ * the state reaches the control there is the declared `error` prop. That is
+ * the path that was broken, so that is the path measured here.
+ *
+ * ## What is NOT claimed
+ *
+ * The marking only. objectui#3222's slot drives `aria-invalid` and renders no
+ * text; the visible message stays with the host. Nothing here becomes visible
+ * that was not visible before.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { FieldEditWidget } from '../FieldEditWidget';
+
+afterEach(() => cleanup());
+
+/**
+ * HTML's own focusability rules, as a selector — copied from
+ * `widget-aria-invalid-registry-e2e.test.tsx` on purpose, so both sweeps judge
+ * "the control a keyboard user can land on" by one definition.
+ *
+ * This is the objectui#5223 line: a mark on a non-focusable wrapper satisfies a
+ * subtree query while telling a screen-reader user nothing, and it is the
+ * cheapest way to make an assertion like the ones below go green without
+ * helping anyone.
+ */
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable="true"]',
+].join(',');
+
+function describeEl(el: Element): string {
+  const role = el.getAttribute('role');
+  const type = el.getAttribute('type');
+  return `${el.tagName.toLowerCase()}${type ? `[type=${type}]` : ''}${role ? `[role=${role}]` : ''}`;
+}
+
+function renderInline(field: Record<string, unknown>, error?: string) {
+  const { container } = render(
+    <FieldEditWidget
+      field={field as never}
+      value={undefined as never}
+      onChange={() => {}}
+      error={error}
+    />,
+  );
+  return container;
+}
+
+/**
+ * The population of objectui#7126, by the field TYPE each widget serves inline
+ * — six types, five widgets (`boolean` and `toggle` both resolve to
+ * `BooleanField`), plus the two branch variants that a type key alone does not
+ * reach: `TextField`'s textarea branch (`rows > 1`) and `BooleanField`'s
+ * checkbox branch (`widget: 'checkbox'`). Both are real authored configs, and
+ * each renders a DIFFERENT element, so a fix applied to only one branch of
+ * either widget still fails here.
+ */
+const CASES: ReadonlyArray<readonly [label: string, field: Record<string, unknown>]> = [
+  ['text', { name: 'f', type: 'text', label: 'F' }],
+  ['text (rows > 1 -> textarea branch)', { name: 'f', type: 'text', label: 'F', rows: 4 }],
+  ['boolean (switch branch)', { name: 'f', type: 'boolean', label: 'F' }],
+  ['boolean (widget: checkbox branch)', { name: 'f', type: 'boolean', label: 'F', widget: 'checkbox' }],
+  ['toggle', { name: 'f', type: 'toggle', label: 'F' }],
+  ['date', { name: 'f', type: 'date', label: 'F' }],
+  ['datetime', { name: 'f', type: 'datetime', label: 'F' }],
+  ['time', { name: 'f', type: 'time', label: 'F' }],
+];
+
+describe('inline field widgets announce a delivered `error` (objectui#7126)', () => {
+  it.each(CASES)(
+    '%s — carries aria-invalid="true" on a FOCUSABLE control when the host delivers `error`',
+    (_label, field) => {
+      const container = renderInline(field, 'Required');
+
+      const carriers = Array.from(container.querySelectorAll('[aria-invalid="true"]'));
+      expect(
+        carriers.map(describeEl),
+        'the host delivered `error` and nothing in the rendered widget says so — assistive tech is never told the field failed',
+      ).not.toEqual([]);
+
+      // THE WRAPPER-MARK HOLE (objectui#5223). `BooleanField` is the case this
+      // exists for: it renders its control inside a flex `div`, and marking
+      // that `div` would satisfy the query above while the switch the user
+      // actually operates announces nothing.
+      expect(
+        carriers.filter((el) => el.matches(FOCUSABLE)).map(describeEl),
+        `aria-invalid sits ONLY on non-focusable element(s) [${carriers.map(describeEl).join(', ')}] — that is a wrapper mark, not a control mark`,
+      ).not.toEqual([]);
+    },
+  );
+
+  it.each(CASES)(
+    '%s — says an explicit aria-invalid="false" when the host delivers no `error`',
+    (_label, field) => {
+      // The load-bearing half, and the reason this is a two-state reading
+      // rather than "the attribute exists": `!!undefined` must yield `"false"`,
+      // so a valid field SAYS it is valid instead of staying mute (the
+      // objectui#3222 discipline). Without this, an unconditional
+      // `aria-invalid="true"` would pass the case above.
+      const container = renderInline(field);
+
+      const control = container.querySelector(FOCUSABLE);
+      expect(control, 'no focusable control rendered at all').not.toBeNull();
+      expect(control).toHaveAttribute('aria-invalid', 'false');
+      expect(container.querySelector('[aria-invalid="true"]')).toBeNull();
+    },
+  );
+
+  it('CONTROL: a widget that ALREADY read `error` reports the same way through the same harness', () => {
+    // Without this, a green sweep above could not be distinguished from a
+    // harness that marks everything it renders. `select` -> `SelectField` was
+    // one of the 21 readers before this change (objectui#3306 / #7008's pin),
+    // so it must read `true`/`false` here for exactly the reasons the five now
+    // do — same factory, same delivery, same assertion.
+    const SELECT_FIELD = {
+      name: 'stage',
+      type: 'select',
+      label: 'Stage',
+      options: [{ label: 'New', value: 'new' }],
+    };
+
+    const invalid = renderInline(SELECT_FIELD, 'Required');
+    const trigger = invalid.querySelector('[role="combobox"]')!;
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('aria-invalid', 'true');
+
+    cleanup();
+
+    const valid = renderInline(SELECT_FIELD);
+    expect(valid.querySelector('[role="combobox"]')).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('CONTROL: `user` was a FALSE zero in the census and is NOT in the population', () => {
+    // The one trap in the measurement that produced this card. A word-boundary
+    // `error` grep over the 27 `EDIT_WIDGETS` components returns SIX zeroes,
+    // and `UserField` is one of them — but it renders `LookupField` with a
+    // props spread, so it delivers `error` transitively and has always marked.
+    // A naive census reports six and is wrong about one; this pins the sixth so
+    // the next reader does not "fix" a widget that was never broken (and so a
+    // future refactor that flattens the delegation cannot silently drop it).
+    const container = renderInline(
+      { name: 'owner_id', type: 'user', label: 'Owner', reference_to: 'sys_user' },
+      'Required',
+    );
+
+    const carriers = Array.from(container.querySelectorAll('[aria-invalid="true"]'));
+    expect(carriers.filter((el) => el.matches(FOCUSABLE)).map(describeEl)).not.toEqual([]);
+  });
+});

--- a/packages/fields/src/widgets/BooleanField.tsx
+++ b/packages/fields/src/widgets/BooleanField.tsx
@@ -7,7 +7,7 @@ import { toDomProps } from './toDomProps.js';
  * BooleanField - Toggle input supporting switch and checkbox variants
  * Renders as Switch or Checkbox based on field widget configuration
  */
-export function BooleanField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<boolean>) {
+export function BooleanField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<boolean>) {
   const config = field as any;
   // Use simple type assertion for arbitrary custom properties not in BaseFieldMetadata
   const widget = config?.widget;
@@ -56,6 +56,26 @@ export function BooleanField({ value, onChange, field, readonly, ...props }: Fie
 
   const domProps = toDomProps(props);
 
+  /**
+   * WHICH ELEMENT carries `aria-invalid`, since this widget is the one of the
+   * five in objectui#7126 that renders a composite: a control plus its
+   * `sr-only` label inside a flex `div`.
+   *
+   * It goes on the Radix `Checkbox` / `Switch` -- each renders a real
+   * `<button role="checkbox">` / `<button role="switch">`, which is the
+   * focusable element a keyboard user lands on and the one assistive tech
+   * reads control state from. `aria-invalid` is a GLOBAL ARIA attribute, valid
+   * on both roles. The wrapper `div` is deliberately NOT the target: marking it
+   * satisfies a row-wide query while telling a screen-reader user nothing,
+   * which is exactly the hole objectui#5223 closed in the registry sweep and
+   * the move that sweep now forbids by requiring a FOCUSABLE carrier.
+   *
+   * Written AFTER the DOM spread in both branches so this widget's own
+   * computation wins (the objectui#3222 idiom, shared with `SelectField` /
+   * `EmailField` / `NumberField`), and `!!undefined` yields an explicit
+   * `"false"` so a valid field says so rather than staying mute. MARKING only:
+   * the message TEXT stays with the host.
+   */
   if (widget === 'checkbox') {
      return (
         <div className="flex items-center space-x-2">
@@ -65,6 +85,7 @@ export function BooleanField({ value, onChange, field, readonly, ...props }: Fie
                 checked={!!value}
                 onCheckedChange={(checked) => onChange(!!checked)}
                 disabled={readonly || domProps.disabled}
+                aria-invalid={!!error}
             />
             {emitOwnLabel && <Label htmlFor={id} className="sr-only">{label}</Label>}
         </div>
@@ -79,6 +100,7 @@ export function BooleanField({ value, onChange, field, readonly, ...props }: Fie
             checked={!!value}
             onCheckedChange={onChange}
             disabled={readonly || domProps.disabled}
+            aria-invalid={!!error}
         />
         {emitOwnLabel && <Label htmlFor={id} className="sr-only">{label}</Label>}
     </div>

--- a/packages/fields/src/widgets/DateField.tsx
+++ b/packages/fields/src/widgets/DateField.tsx
@@ -10,7 +10,7 @@ import { toDateInputValue } from './nativeDateValue.js';
  * DateField - Date picker input widget
  * Uses native date input and displays locale-formatted date in readonly mode
  */
-export function DateField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
+export function DateField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   // Before the readonly early return: the hook count must not depend on a prop
   // (objectui#4468). A bare `toLocaleDateString()` reads the MACHINE's locale,
   // which is how a Chinese form ended up with an `8/11/2026` value in it.
@@ -21,6 +21,29 @@ export function DateField({ value, onChange, field, readonly, ...props }: FieldW
 
   const domProps = toDomProps(props);
 
+  /**
+   * `aria-invalid` after the DOM spread below, the objectui#3222 idiom shared
+   * with the other readers (`SelectField`, `EmailField`, `NumberField`):
+   * `error` is the published validation slot
+   * (`@objectstack/spec/ui`'s `FieldWidgetPropsSchema`) and `!!undefined`
+   * yields an explicit `"false"`, so a valid field SAYS it is valid rather
+   * than staying mute.
+   *
+   * There is no composite-target question here despite the name "picker": the
+   * widget renders ONE `<input type="date">`, and the browser's date
+   * picker is that same element's own UI, not a second element. So the
+   * focusable control a keyboard user lands on IS the carrier -- no wrapper is
+   * marked (the objectui#5223 line).
+   *
+   * Reading it here is what makes the delivery non-inert for `date`
+   * (objectui#7126). The FORM path already announced correctly, because
+   * `<FormControl>`'s Radix `Slot` value reached the input through the spread
+   * untouched; every host WITHOUT that Slot -- `FieldEditWidget`, i.e. the
+   * kanban required-fields dialog and the grid / detail inline editors --
+   * hands the state over as the declared `error` prop (delivered since
+   * objectui#7008) and nothing read it. MARKING only: the message TEXT stays
+   * with the host.
+   */
   return (
     <Input
       {...domProps}
@@ -35,6 +58,7 @@ export function DateField({ value, onChange, field, readonly, ...props }: FieldW
         domProps.onClick?.(e);
       }}
       disabled={readonly || domProps.disabled}
+      aria-invalid={!!error}
     />
   );
 }

--- a/packages/fields/src/widgets/DateTimeField.tsx
+++ b/packages/fields/src/widgets/DateTimeField.tsx
@@ -10,7 +10,7 @@ import { toDateTimeInputValue, fromDateTimeInputValue } from './nativeDateValue.
  * DateTimeField - Combined date and time picker widget
  * Displays both date and time in locale format when readonly
  */
-export function DateTimeField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
+export function DateTimeField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   // Before the readonly early return — the hook count must not depend on a
   // prop. See DateField for why the bare `toLocale*` calls were wrong
   // (objectui#4468).
@@ -27,6 +27,29 @@ export function DateTimeField({ value, onChange, field, readonly, ...props }: Fi
 
   const domProps = toDomProps(props);
 
+  /**
+   * `aria-invalid` after the DOM spread below, the objectui#3222 idiom shared
+   * with the other readers (`SelectField`, `EmailField`, `NumberField`):
+   * `error` is the published validation slot
+   * (`@objectstack/spec/ui`'s `FieldWidgetPropsSchema`) and `!!undefined`
+   * yields an explicit `"false"`, so a valid field SAYS it is valid rather
+   * than staying mute.
+   *
+   * There is no composite-target question here despite the name "picker": the
+   * widget renders ONE `<input type="datetime-local">`, and the browser's date-and-time
+   * picker is that same element's own UI, not a second element. So the
+   * focusable control a keyboard user lands on IS the carrier -- no wrapper is
+   * marked (the objectui#5223 line).
+   *
+   * Reading it here is what makes the delivery non-inert for `datetime-local`
+   * (objectui#7126). The FORM path already announced correctly, because
+   * `<FormControl>`'s Radix `Slot` value reached the input through the spread
+   * untouched; every host WITHOUT that Slot -- `FieldEditWidget`, i.e. the
+   * kanban required-fields dialog and the grid / detail inline editors --
+   * hands the state over as the declared `error` prop (delivered since
+   * objectui#7008) and nothing read it. MARKING only: the message TEXT stays
+   * with the host.
+   */
   return (
     <Input
       {...domProps}
@@ -41,6 +64,7 @@ export function DateTimeField({ value, onChange, field, readonly, ...props }: Fi
         domProps.onClick?.(e);
       }}
       disabled={readonly || domProps.disabled}
+      aria-invalid={!!error}
     />
   );
 }

--- a/packages/fields/src/widgets/TextField.tsx
+++ b/packages/fields/src/widgets/TextField.tsx
@@ -8,7 +8,7 @@ import { toDomProps } from './toDomProps.js';
  * TextField - Standard single-line or multi-line text input
  * Automatically renders as a textarea when rows are configured in field metadata
  */
-export function TextField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
+export function TextField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   const fieldData = field;
 
   if (readonly) {
@@ -20,6 +20,27 @@ export function TextField({ value, onChange, field, readonly, ...props }: FieldW
 
   const domProps = toDomProps(props);
 
+  /**
+   * `aria-invalid` is written AFTER the DOM spread in both branches below, the
+   * objectui#3222 idiom the other readers already share (`SelectField`,
+   * `EmailField`, `NumberField`): `error` is the published validation slot
+   * (`@objectstack/spec/ui`'s `FieldWidgetPropsSchema`), and `!!undefined`
+   * yields an explicit `"false"` so a valid field SAYS it is valid rather than
+   * staying mute.
+   *
+   * Reading it here is what makes the delivery non-inert for `text`
+   * (objectui#7126). In the FORM this widget was already announced correctly —
+   * `<FormControl>` is a Radix `Slot` and its `aria-invalid` reached the input
+   * through the spread untouched. Every OTHER host of this widget was not:
+   * `FieldEditWidget` renders no Slot, so the kanban required-fields dialog and
+   * the grid / detail inline editors hand the state over as the declared
+   * `error` prop (delivered since objectui#7008) and nothing read it — the red
+   * "Required" hint was on screen while assistive tech was told nothing.
+   *
+   * MARKING only. The message TEXT stays with the host (`<FormMessage/>` in the
+   * form, the red hint in the dialog); a widget that printed it too would show
+   * the user the same sentence twice.
+   */
   if (rows && rows > 1) {
     return (
       <Textarea
@@ -28,6 +49,7 @@ export function TextField({ value, onChange, field, readonly, ...props }: FieldW
         onChange={(e) => onChange(e.target.value)}
         placeholder={fieldData?.placeholder}
         disabled={readonly || domProps.disabled}
+        aria-invalid={!!error}
       />
     );
   }
@@ -40,6 +62,7 @@ export function TextField({ value, onChange, field, readonly, ...props }: FieldW
       onChange={(e) => onChange(e.target.value)}
       placeholder={fieldData?.placeholder}
       disabled={readonly || domProps.disabled}
+      aria-invalid={!!error}
     />
   );
 }

--- a/packages/fields/src/widgets/TimeField.tsx
+++ b/packages/fields/src/widgets/TimeField.tsx
@@ -8,13 +8,36 @@ import { openNativePicker } from './openNativePicker.js';
  * TimeField - Time picker input widget
  * Uses native time input for hour and minute selection
  */
-export function TimeField({ value, onChange, field, readonly, ...props }: FieldWidgetComponentProps<string>) {
+export function TimeField({ value, onChange, field, readonly, error, ...props }: FieldWidgetComponentProps<string>) {
   if (readonly) {
     return <span className="text-sm">{value || <EmptyValue />}</span>;
   }
 
   const domProps = toDomProps(props);
 
+  /**
+   * `aria-invalid` after the DOM spread below, the objectui#3222 idiom shared
+   * with the other readers (`SelectField`, `EmailField`, `NumberField`):
+   * `error` is the published validation slot
+   * (`@objectstack/spec/ui`'s `FieldWidgetPropsSchema`) and `!!undefined`
+   * yields an explicit `"false"`, so a valid field SAYS it is valid rather
+   * than staying mute.
+   *
+   * There is no composite-target question here despite the name "picker": the
+   * widget renders ONE `<input type="time">`, and the browser's time
+   * picker is that same element's own UI, not a second element. So the
+   * focusable control a keyboard user lands on IS the carrier -- no wrapper is
+   * marked (the objectui#5223 line).
+   *
+   * Reading it here is what makes the delivery non-inert for `time`
+   * (objectui#7126). The FORM path already announced correctly, because
+   * `<FormControl>`'s Radix `Slot` value reached the input through the spread
+   * untouched; every host WITHOUT that Slot -- `FieldEditWidget`, i.e. the
+   * kanban required-fields dialog and the grid / detail inline editors --
+   * hands the state over as the declared `error` prop (delivered since
+   * objectui#7008) and nothing read it. MARKING only: the message TEXT stays
+   * with the host.
+   */
   return (
     <Input
       {...domProps}
@@ -26,6 +49,7 @@ export function TimeField({ value, onChange, field, readonly, ...props }: FieldW
         domProps.onClick?.(e);
       }}
       disabled={readonly || domProps.disabled}
+      aria-invalid={!!error}
     />
   );
 }

--- a/packages/plugin-kanban/src/__tests__/RequiredFieldsDialog.ariaInvalid-7008.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/RequiredFieldsDialog.ariaInvalid-7008.test.tsx
@@ -30,10 +30,17 @@
  *
  * `SelectField` computes `aria-invalid={!!error}`, so it reports an explicit
  * `"false"` when valid: the pin reads a two-state signal rather than the mere
- * presence of an attribute. NOT every inline widget reads `error` — `TextField`,
- * `BooleanField`, `DateField`, `DateTimeField` and `TimeField` do not, so for
- * those types delivering the key is inert today. That is a separate, reported
- * gap one layer down in `@object-ui/fields`, not something this dialog can fix.
+ * presence of an attribute.
+ *
+ * ⚠️ This paragraph used to continue: "NOT every inline widget reads `error` —
+ * `TextField`, `BooleanField`, `DateField`, `DateTimeField` and `TimeField` do
+ * not, so for those types delivering the key is inert today." That was true
+ * when this file landed and is NOT true any more — objectui#7126 made all five
+ * read it. The sentence is corrected here rather than deleted, because it is
+ * the reason `select` was chosen and a reader who finds the choice unexplained
+ * will assume the other types still cannot be pinned. They can: the `text`
+ * case, and the whole population, are pinned next door in
+ * `RequiredFieldsDialog.ariaInvalidText-7126.test.tsx`.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup } from '@testing-library/react';

--- a/packages/plugin-kanban/src/__tests__/RequiredFieldsDialog.ariaInvalidText-7126.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/RequiredFieldsDialog.ariaInvalidText-7126.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7126, end to end: a required **text** field in the required-fields
+ * dialog reports `aria-invalid` once its validation fails — and so do the other
+ * four types whose widgets did not read the delivered key.
+ *
+ * ## Why this file exists next to the #7008 one
+ *
+ * `RequiredFieldsDialog.ariaInvalid-7008.test.tsx` pinned the same claim for
+ * `select` and `textarea`, and its own header recorded WHY it could not use
+ * `text`: `TextField`, `BooleanField`, `DateField`, `DateTimeField` and
+ * `TimeField` did not read `error`, so for their types the dialog's delivery
+ * was inert. That was the gap objectui#7126 closed, and this is the same
+ * measurement taken again at the same seam now that the widgets read it.
+ *
+ * ⭐ `text` is why the gap was p2 rather than tidiness. It is the most common
+ * field type in any object, so it is the likeliest thing a column makes
+ * required — the live case in which a sighted user saw the red "Required" and a
+ * screen-reader user was told nothing.
+ *
+ * ## What is NOT claimed
+ *
+ * Only the MARKING. The objectui#3222 slot drives `aria-invalid` and renders no
+ * text; the visible hint is still the dialog's own red span, exactly as before.
+ * Nothing became visible here that was not visible before.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { RequiredFieldsDialog } from '../RequiredFieldsDialog';
+
+afterEach(() => cleanup());
+
+const TEXT_FIELD = {
+  name: 'title',
+  label: 'Title',
+  def: { name: 'title', type: 'text', label: 'Title' },
+};
+
+/** The control `TextField` renders for a single-line `text` field. */
+function textControl(name = 'title'): Element {
+  const el = document.querySelector(`input[type="text"][name="${name}"], input[type="text"]`);
+  if (!el) throw new Error('no text control rendered');
+  return el;
+}
+
+const moveCard = () => fireEvent.click(screen.getByText('Move card'));
+
+describe('RequiredFieldsDialog marks a failed required TEXT field (objectui#7126)', () => {
+  it('a required text field reports aria-invalid once a submit attempt finds it empty', () => {
+    const onSubmit = vi.fn();
+    render(
+      <RequiredFieldsDialog open fields={[TEXT_FIELD]} onCancel={() => {}} onSubmit={onSubmit} />,
+    );
+
+    // CONTROL, and what makes this a two-state reading: the dialog opens clean
+    // (`showErrors` is false until a submit attempt), so the control must say
+    // "false" here. If this line read "true" the assertion after the click
+    // would prove nothing — and if it read *nothing at all*, that is the
+    // pre-#7126 state, in which `TextField` set no `aria-invalid` whatsoever.
+    expect(textControl()).toHaveAttribute('aria-invalid', 'false');
+
+    moveCard();
+
+    // The submit is refused (that half already worked) …
+    expect(onSubmit).not.toHaveBeenCalled();
+    // … the visible hint appears (that half already worked too — and it is the
+    // ONLY thing that renders the message; the widget renders none) …
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    // … and NOW the control says so to a screen reader. This is the assertion
+    // that was red before objectui#7126.
+    expect(textControl()).toHaveAttribute('aria-invalid', 'true');
+    // On the control itself — an `<input>` is focusable, so this is not a
+    // wrapper mark (the objectui#5223 line).
+    expect(textControl().tagName).toBe('INPUT');
+  });
+
+  it('CONTROL: the marking is PER FIELD — a filled text field is not marked invalid', () => {
+    // Without this, "the control says true after submit" would be satisfied by
+    // a dialog-wide flag that lights up every control, valid ones included.
+    const onSubmit = vi.fn();
+    render(
+      <RequiredFieldsDialog
+        open
+        fields={[
+          TEXT_FIELD,
+          { name: 'stage', label: 'Stage', def: { name: 'stage', type: 'select', label: 'Stage', options: [{ label: 'Won', value: 'won' }] } },
+        ]}
+        onCancel={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(textControl(), { target: { value: 'Ship it' } });
+
+    moveCard();
+
+    // Still refused, because the select is still empty.
+    expect(onSubmit).not.toHaveBeenCalled();
+    // The empty one is marked …
+    expect(screen.getByTestId('select-trigger-stage')).toHaveAttribute('aria-invalid', 'true');
+    // … and the filled TEXT one is NOT.
+    expect(textControl()).toHaveAttribute('aria-invalid', 'false');
+    // One hint, not two — the same per-field split, read on the visible side.
+    expect(screen.getAllByText('Required')).toHaveLength(1);
+  });
+
+  it('the whole objectui#7126 population reports through this dialog, on focusable controls', () => {
+    // The five widgets serve six inline types between them. The dialog renders
+    // whatever the target column made required, so all of them are reachable
+    // here — and each renders a DIFFERENT element, which is what makes this
+    // more than a repeat of the `text` case above.
+    const onSubmit = vi.fn();
+    render(
+      <RequiredFieldsDialog
+        open
+        fields={[
+          TEXT_FIELD,
+          { name: 'active', label: 'Active', def: { name: 'active', type: 'boolean', label: 'Active' } },
+          { name: 'flagged', label: 'Flagged', def: { name: 'flagged', type: 'toggle', label: 'Flagged' } },
+          { name: 'due', label: 'Due', def: { name: 'due', type: 'date', label: 'Due' } },
+          { name: 'at', label: 'At', def: { name: 'at', type: 'datetime', label: 'At' } },
+          { name: 'start', label: 'Start', def: { name: 'start', type: 'time', label: 'Start' } },
+        ]}
+        onCancel={() => {}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Prove the failure actually happened before reading aria off anything — a
+    // dialog that silently submitted would leave every control valid and this
+    // whole case would read as a pass over nothing.
+    moveCard();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getAllByText('Required')).toHaveLength(6);
+
+    // `boolean` and `toggle` both resolve to `BooleanField`, whose control is a
+    // Radix `<button role="switch">`; the three date/time types each render one
+    // native input. Selected by their OWN element so a mark that landed on
+    // BooleanField's wrapper `div` instead cannot satisfy this.
+    const carriers: ReadonlyArray<readonly [string, string]> = [
+      ['text', 'input[type="text"]'],
+      ['boolean', 'button[role="switch"]'],
+      ['date', 'input[type="date"]'],
+      ['datetime', 'input[type="datetime-local"]'],
+      ['time', 'input[type="time"]'],
+    ];
+
+    for (const [label, selector] of carriers) {
+      const found = Array.from(document.querySelectorAll(selector));
+      expect(found.length, `${label}: no control matched ${selector}`).toBeGreaterThan(0);
+      for (const el of found) {
+        expect(el, `${label} (${selector}) was not marked invalid`).toHaveAttribute(
+          'aria-invalid',
+          'true',
+        );
+      }
+    }
+    // `boolean` + `toggle` are two fields sharing one widget — both switches
+    // must be there, or the loop above would have passed on a single one.
+    expect(document.querySelectorAll('button[role="switch"]')).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Fixes #7126

The last five widgets in `EDIT_WIDGETS` now read the `error` slot that objectui#7008 delivers, so an inline `text` / `boolean` / `toggle` / `date` / `datetime` / `time` control that failed validation finally reports `aria-invalid`.

## Leg 0 — the population, re-derived on `origin/main` AFTER its blocker landed

The census in the card was taken before PR #7128 landed. Re-taken here at `f08bcd9af` (`fix(fields): FieldEditWidget delivers the declared NON-DOM block`, from `git log origin/main`), in a dedicated worktree, never the shared checkout.

Word-boundary `error` match over the **27 distinct components** in `EDIT_WIDGETS`:

- **21 read it**, **6 return zero** — unchanged from the pre-#7128 census.
- **CONTROL for the instrument**: `NumberField` returns 5, `LookupField` 11, so a zero is a reading and not a broken query.
- **CONTROL for the zeroes — each apparent zero was opened and read, not counted.** `UserField` is a **FALSE zero**: its whole body is `return LookupField {...(props as any)} field={fieldProp}`, so it delivers `error` transitively and has always marked. Independently corroborated in-repo by `data-table.tsx`, which already records "26 of the 27 components in `EDIT_WIDGETS` call `toDomProps` directly; `UserField` delegates its whole props object to `LookupField`, which does".

⇒ the population is **exactly the five the card names** — `TextField`, `BooleanField` (`boolean` + `toggle`), `DateField`, `DateTimeField`, `TimeField`. Nothing shrank, nothing grew.

## What changed

One idiom, five widgets — the objectui#3222 shape the other 21 already share (`SelectField`, `EmailField`, `NumberField`): destructure `error`, then write `aria-invalid={!!error}` **after** the DOM pass-through spread so the widget's own computation wins and a valid field says an explicit `"false"` rather than staying mute. Seven call sites, because two widgets have two render branches each.

**⛔ This buys the a11y MARKING only.** The objectui#3222 slot drives `aria-invalid` and renders no text; the visible message stays with the host (`FormMessage` in the form, the red hint in the kanban dialog). Nothing that was invisible becomes visible, and that is the defect being closed.

## The composite judgement, stated per widget

| widget | markable control? | what was marked | why |
|---|---|---|---|
| `TextField` | yes (x2) | the `input[type=text]` **and** the `textarea` of the `rows > 1` branch | two render branches, two real single controls; marking only one would leave authored `rows` configs silent |
| `BooleanField` | yes (x2) | the Radix `Checkbox` / `Switch`, i.e. `button[role=checkbox]` / `button[role=switch]` | **the one composite here.** The control sits inside a flex `div` with an `sr-only` label. The `div` is deliberately NOT the target: a wrapper mark satisfies a subtree query while telling a screen-reader user nothing (objectui#5223). `aria-invalid` is a global ARIA attribute, valid on both roles, and both Radix roots forward unknown props to the real button |
| `DateField` | yes | the `input[type=date]` | no composite question despite the name "picker": the browser picker is that same element's own UI, not a second element |
| `DateTimeField` | yes | the `input[type=datetime-local]` | as above |
| `TimeField` | yes | the `input[type=time]` | as above |

None of the five turned out to lack a markable control.

## The end-to-end case — the deliverable

`packages/plugin-kanban/src/__tests__/RequiredFieldsDialog.ariaInvalidText-7126.test.tsx`, following the shape of #7128's `RequiredFieldsDialog.ariaInvalid-7008.test.tsx` rather than inventing a harness:

1. a required **`text`** field reports `aria-invalid="false"` on a clean open and `"true"` after a submit attempt finds it empty — with the submit refusal and the visible `Required` hint asserted first, so a dialog that silently submitted could not pass;
2. **CONTROL, per-field**: with a `text` filled and a `select` empty, the select is `"true"` and the filled text is `"false"`, and there is exactly one `Required` hint — a dialog-wide flag would fail this;
3. the whole population through the same dialog: `text`, `boolean`, `toggle`, `date`, `datetime`, `time` in one dialog, each read off **its own** element selector, so a mark that landed on `BooleanField`'s wrapper could not satisfy it.

Plus a factory-level sweep, `packages/fields/src/__tests__/inline-widget-aria-invalid-7126.test.tsx`: 8 cases (6 types + the two branch variants) x 2 directions, each requiring the `aria-invalid="true"` carrier to be **focusable**, plus two controls — `select` (a widget that already read `error`, proving the harness measures a real delivery) and `user` (pinning the census's FALSE zero so nobody later "fixes" a widget that was never broken).

**Why the factory and not the form.** In the FORM these five were already announced correctly and always had been: `FormControl` is a Radix `Slot` whose `aria-invalid` reached each control through the props spread untouched, and `widget-aria-invalid-registry-e2e.test.tsx` sweeps that path with an **empty** `NOT_YET_DELIVERED` ledger. A form-based test would have been green before this change. `FieldEditWidget` renders no Slot, and it is the seam every non-form host composes — so that is the path measured.

## Ablation — the pins fail without the change

Direction predicted **before** the run and recorded in the script header. Mutation: delete all 7 `aria-invalid={!!error}` lines.

- **Mutation proven on disk**, not by an editor exit code: marker count 2/2/1/1/1 -> 0 for all five, and every blob hash moved off its `HEAD` blob (e.g. `TextField.tsx` `a9a17e42f` -> `b919aa64d`, `BooleanField.tsx` `c8325fff6` -> `d2adecc4c`, `TimeField.tsx` `239728047` -> `762385d77`). No rebuild leg is claimed and none is owed: `vitest.config.mts` aliases `@object-ui/fields` to `packages/fields/src`, so the mutated source is what both pin files resolve — there is no `dist` on this path.
- **PREDICTED**: `Tests 19 failed | 2 passed (21)`.
- **OBSERVED**: `Tests 19 failed | 2 passed (21)` — and the 2 that stayed green are exactly the two CONTROL cases (`select`, `user`), which do not depend on the five widgets. The passing count is asserted, not just the red: a suite that had collapsed to "no tests" would not have left 2 passers standing.
- **Restore proven by state**, with `git checkout HEAD -- ABSOLUTE_PATH` (never a bare `git checkout --`, which reads the index a path-scoped checkout also writes): all five blobs back to their `HEAD` values, marker counts back to 2/2/1/1/1, and `git diff HEAD`, `git diff --cached` and `git status --short` all empty.

## Measurements

All at `323f2c381`, the head of this branch.

| check | verdict |
|---|---|
| `pnpm exec vitest run packages/fields/ packages/plugin-kanban/ --maxWorkers=2` | `Test Files 151 passed (151)` / `Tests 2249 passed (2249)` — includes the form-path registry sweep and #7128's own dialog pin |
| `pnpm exec vitest run` (the 2 components-side negative-assertion files) | `Test Files 2 passed (2)` / `Tests 24 passed (24)` |
| `pnpm --filter @object-ui/fields --filter @object-ui/plugin-kanban run type-check` | exit 0, `Scope: 2 of 47 workspace projects`, both `Done`. Its `tsconfig.test.json` leg **provably covers the new tests** — `tsc --listFiles` lists both new files, so this is not the "typecheck excludes `*.test.tsx`" non-reading |
| `pnpm --filter @object-ui/fields --filter @object-ui/plugin-kanban run lint` | exit 0, `0 errors` (warnings are pre-existing repo-wide; no `--max-warnings` in the gate). Plain `eslint .` per package, no `--no-inline-config` |
| `pnpm check:control-bytes` | `check-control-bytes: OK (scanned 5914 tracked text file(s); skipped 85 binary)` — plus a self-scan of the 9 changed files with a probe control that hits |
| `pnpm check:vi-mock-specifiers` / `check:vi-mock-inherit` / `check:i18n-keys` | all exit 0 |
| `pnpm changeset:check` | `All workspace packages are in the changeset fixed group.` / `No changeset declares a major bump.` |
| `node scripts/check-changeset-presence.mjs` | `8 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-overwrite.mjs` | `No pre-existing changeset was modified or deleted.` |
| `pnpm check:sdui-registration-pins` | **NOT MEASURED**, not red — exit 2 with its own `PREREQUISITE NOT MET` text: "the registrations this gate pins are dropped by a WRONG ARRAY at BUNDLE time, so a run with nothing to read has measured nothing. Build the console first". This change registers nothing; CI builds the console and runs it |

`type-check` first came back with a wall of `TS2307: Cannot find module '@object-ui/components'` across files this branch never touched — an unbuilt closure, i.e. NOT MEASURED. `pnpm --workspace-concurrency=2 --filter '@object-ui/fields^...' --filter '@object-ui/plugin-kanban^...' build` (exit 0) fixed it, and the verdict above is from the re-run.

## PM assumptions, checked

- **"The five are exactly right post-#7128."** Confirmed, with the false-zero trap re-caught rather than re-introduced.
- **"Each of the five has a markable control."** Confirmed, per widget, in the table above.
- **"`EDIT_WIDGETS` is the right population boundary."** **Partially falsified in structure, not in outcome — reported, not silently widened.** `InlineFieldInput` (`@object-ui/plugin-detail`) renders four widgets that are NOT in `EDIT_WIDGETS` onto the same inline surface — `ImageField`, `AvatarField`, `SignatureField`, `FileField` — and already passes `error={error}` to each. Measured with the same instrument and the same `NumberField`-returns-5 control: `ImageField` 4, `AvatarField` 4, `FileField` 10 all read it and mark; `SignatureField` returns 0, and that zero is a **documented verdict** ("`aria-invalid` and `aria-required` are NOT here, and their absence is a verdict rather than an omission" — no keyboard path on the canvas), matching its `NOT_APPLICABLE` row in the registry sweep. ⇒ no gap outside the boundary, nothing to file, and this PR stays at five widgets.
- **"No test asserts these widgets do NOT mark."** No *assertion* does — the registry sweep's `NOT_YET_DELIVERED` ledger is empty, and it exercises the form path where these five always marked via the Slot. One *doc comment* did: #7128's dialog test explained its choice of `select` with "NOT every inline widget reads `error` — `TextField`, `BooleanField`, `DateField`, `DateTimeField` and `TimeField` do not". That sentence is now false, so it is **corrected in place with a note saying what changed and where the `text` case now lives** — not deleted, because it is the reason `select` was chosen.

## Fences honoured

`toDomProps.ts`, `toHostProps.ts` and `FieldEditWidget.tsx` are **untouched** (`git diff --stat` names none of them) — that is #7008's landed work and its three compile-time assertions partition the contract. No `content/docs/releases/` edit. Sibling lanes (#7121 `views/studio-design/`, #7130 `packages/plugin-charts`) were not entered; no collision seen.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_