### PR TITLE
fix(components,plugin-list): let DataEmptyState declare role="status", so an empty result is not shaped like a failed one

### DIFF
--- a/.changeset/7132-empty-state-role-default.md
+++ b/.changeset/7132-empty-state-role-default.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/components': minor
+'@object-ui/plugin-list': patch
+---
+
+`DataEmptyState` now declares `role="status"` by default, so an empty result is
+distinguishable from a failed one on every surface that renders it
+(objectui#7132).
+
+This is the convergence half of the two rulings that landed as objectui#7063 and
+objectui#7064, both resting on objectstack#13848: uniform behaviour belongs to
+the platform, and per-surface compensation is the per-app tax being ruled
+against. Those two fixed their own surfaces deliberately and locally; this card
+measured whether the shared primitive should carry the property. It did not.
+
+**Measured, not assumed.** All the surfaces were rendered and their empty boxes
+read directly:
+
+| surface | `role` before |
+|---|---|
+| `DataEmptyState` bare default | *none* |
+| `plugin-list` empty list | *none* |
+| `plugin-list` load-error panel | *none* |
+| `plugin-detail` activity timelines | *none* |
+| `ui:empty` schema renderer | *none* |
+| `plugin-dashboard` `WidgetEmptyState` (#7063) | `status`, typed at the call site |
+| `plugin-kanban` empty board | `status`, typed at the call site |
+
+The sibling states in the same file had always declared themselves —
+`DataLoadingState` is `role="status"`, `DataErrorState` is `role="alert"` — and
+the empty state alone declared nothing. So the surfaces were not legitimately
+differing: the ones that wanted the property had each hand-typed the same line,
+and the ones that had not yet done so were silently missing it. That is one
+platform default, copied by hand, at package level.
+
+**It is a default, not a fixed attribute** — `role` is spread from props, so a
+call site keeps the last word. That is what makes this inert for the two ruled
+surfaces: both already pass `role="status"` explicitly and receive the identical
+attribute with or without it. Neither surface's behaviour changes.
+
+**One real defect fell out of the measurement.** `plugin-list` renders its load
+FAILURE through `DataEmptyState`, borrowing it for layout — so a 403 saying "You
+don't have access" and a young object saying "Nothing here yet" were the same
+node shape, with no role on either. That panel now declares `role="alert"`,
+which both fixes the pre-existing indistinguishability and stops the new default
+from announcing an outage as a routine status.
+
+Metric/KPI widgets are untouched: their carve-out (`rows.length === 0 &&
+!isMetric`) gates whether an empty state is rendered *at all*, upstream of this
+component, so a KPI still reads `0` rather than "no data".

--- a/packages/components/src/__tests__/data-empty-state-role-7132.test.tsx
+++ b/packages/components/src/__tests__/data-empty-state-role-7132.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7132 — the empty state must declare what it is.
+ *
+ * `DataLoadingState` has always been `role="status"` and `DataErrorState`
+ * `role="alert"`; `DataEmptyState` alone declared nothing, so "this list is
+ * young" and "this list failed to load" were the same node shape. Both the
+ * hotcrm#1212 (#7063) and hotcrm#1247 (#7064) rulings name *distinguishable
+ * from a load failure* as the first property an empty state owes, and four
+ * separate call sites had each hand-typed `role="status"` to get it.
+ *
+ * SUITE DIRECTION, predicted before running: the DEFAULT arm is red against
+ * `origin/main` and green after. The OVERRIDE arms and the two SIBLING arms are
+ * green in both worlds — they are the negative controls proving the default is
+ * a default (a call site keeps the last word, which is why the two already-ruled
+ * surfaces are inert under this change) and that the contrast it is measured
+ * against is real.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DataEmptyState, DataErrorState, DataLoadingState } from '../custom/view-states';
+
+const emptyBox = (c: HTMLElement) => c.querySelector('[data-slot="data-empty-state"]');
+
+describe('DataEmptyState — role default (#7132)', () => {
+  it('DEFAULT: declares role="status" with no call-site prop', () => {
+    const { container } = render(<DataEmptyState />);
+    const box = emptyBox(container);
+    expect(box).not.toBeNull();
+    expect(box!.getAttribute('role')).toBe('status');
+  });
+
+  it('DEFAULT survives the props a real call site passes alongside it', () => {
+    const { container } = render(
+      <DataEmptyState title="Nothing here yet" description="Create your first record." />,
+    );
+    expect(emptyBox(container)!.getAttribute('role')).toBe('status');
+    // The default must not have displaced the rest of the render.
+    expect(container.textContent).toContain('Nothing here yet');
+  });
+
+  it('OVERRIDE: a call site passing role="alert" keeps it (the load-error borrow)', () => {
+    const { container } = render(<DataEmptyState role="alert" title="You don’t have access" />);
+    expect(emptyBox(container)!.getAttribute('role')).toBe('alert');
+  });
+
+  it('OVERRIDE: the already-ruled surfaces pass role="status" explicitly and are unchanged', () => {
+    // plugin-dashboard's WidgetEmptyState (#7063) and plugin-kanban both spell
+    // this out. They must receive the identical attribute with or without the
+    // default, which is what makes #7132 inert for them.
+    const { container } = render(<DataEmptyState role="status" aria-live="polite" />);
+    const box = emptyBox(container)!;
+    expect(box.getAttribute('role')).toBe('status');
+    expect(box.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('SIBLING CONTRAST: the error state is an alert and the loading state a status', () => {
+    const { container: err } = render(<DataErrorState />);
+    expect(err.querySelector('[data-slot="data-error-state"]')!.getAttribute('role')).toBe('alert');
+    const { container: load } = render(<DataLoadingState />);
+    expect(load.querySelector('[data-slot="data-loading-state"]')!.getAttribute('role')).toBe('status');
+  });
+});

--- a/packages/components/src/custom/view-states.tsx
+++ b/packages/components/src/custom/view-states.tsx
@@ -83,6 +83,31 @@ interface DataEmptyStateProps extends React.ComponentProps<"div"> {
   action?: React.ReactNode
 }
 
+/**
+ * `role` defaults to `"status"` (objectui#7132).
+ *
+ * The sibling states in this file each declare what they are — `DataLoadingState`
+ * is `role="status"`, `DataErrorState` is `role="alert"` — and the empty state
+ * alone declared nothing, so an empty box and a failed box were the same node
+ * shape to a screen reader and to any structural test. That is the exact
+ * property both the hotcrm#1212 (objectui#7063) and hotcrm#1247 (objectui#7064)
+ * rulings named first: an empty state must be *distinguishable from a load
+ * failure at a glance*.
+ *
+ * With no default, every surface that wanted the property had to type it at its
+ * own call site, and four independently did — `plugin-kanban`'s empty board,
+ * `plugin-dashboard`'s `WidgetEmptyState`, and `plugin-charts`' `ObjectChart` —
+ * while `plugin-list`, `plugin-detail`'s two timelines and the `ui:empty`
+ * renderer silently did not. Four hand-copies of one line is the per-app tax
+ * objectstack#13848 rules against, paid at the package level.
+ *
+ * It is a DEFAULT, not a fixed attribute: `role` is spread from `props` below,
+ * so a call site keeps the last word. That is what makes this change inert for
+ * the two ruled surfaces — both already pass `role="status"` explicitly and
+ * receive the identical attribute either way — and it is what lets a call site
+ * rendering something that is NOT empty say so (`plugin-list`'s load-error
+ * panel borrows this component and declares `role="alert"`).
+ */
 function DataEmptyState({
   className,
   icon,
@@ -102,6 +127,7 @@ function DataEmptyState({
 
   return (
     <div
+      role="status"
       data-slot="data-empty-state"
       className={cn(
         "flex flex-col items-center justify-center gap-3 p-6 text-center",

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -3582,6 +3582,14 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
             empty state on slow networks. */}
         {loadError && data.length === 0 ? (
           <DataEmptyState
+            // This panel is NOT an empty state — it is the load FAILURE, and it
+            // borrows `DataEmptyState` only for its layout. Since objectui#7132
+            // that component defaults to `role="status"`, which would announce a
+            // 403 or an outage as a routine status update, so this call site
+            // declares what it actually is. (Measured: before #7132 neither this
+            // panel nor the empty state below carried any role, so "you don't
+            // have access" and "nothing here yet" were the same node shape.)
+            role="alert"
             data-testid="list-error-state"
             data-error-kind={loadErrorKind}
             className="h-full min-h-[200px] p-8 gap-1 [&>h3]:text-lg [&>h3]:font-medium [&>h3]:text-foreground [&>p]:max-w-md"

--- a/packages/plugin-list/src/__tests__/ListView.emptyVsErrorRole-7132.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.emptyVsErrorRole-7132.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7132 — a list that is EMPTY and a list that FAILED TO LOAD must not
+ * be the same node shape.
+ *
+ * Measured on `origin/main` by rendering both branches: each one is a
+ * `data-slot="data-empty-state"` div with **no `role` at all**. A 403 telling
+ * the user "You don't have access" and a young object telling them "Nothing
+ * here yet" were structurally indistinguishable — the precise failure the
+ * #7063 / #7064 rulings put first, and the reason `ListView` was the
+ * "unmeasured" row on #7132's own table.
+ *
+ * Two things are pinned here because they are separable and either can regress
+ * alone: the empty branch takes the platform default (#7132), and the error
+ * branch — which borrows `DataEmptyState` purely for its layout — overrides it
+ * back to `alert` so the default cannot mislabel a failure as a status.
+ *
+ * SUITE DIRECTION, predicted before running: the EMPTY arm is red against
+ * `origin/main`; the ERROR arm is green in both worlds (its `role="alert"` is
+ * typed at the call site, not inherited), and is here as the negative control
+ * that keeps a suite collapsed to "no tests" from reading as the fix.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { ListView } from '../ListView';
+import { SchemaRendererProvider } from '@object-ui/react';
+import type { ListViewSchema } from '@object-ui/types';
+
+const schema: ListViewSchema = {
+  type: 'list-view',
+  objectName: 'work_order',
+  fields: ['name'],
+};
+
+function renderWith(find: () => Promise<unknown>) {
+  const ds = {
+    find: vi.fn().mockImplementation(find),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  return render(
+    <SchemaRendererProvider dataSource={ds as any}>
+      <ListView schema={schema} dataSource={ds as any} />
+    </SchemaRendererProvider>,
+  );
+}
+
+async function panel(container: HTMLElement, testId: string): Promise<HTMLElement> {
+  await waitFor(() => {
+    expect(container.querySelector(`[data-testid="${testId}"]`)).not.toBeNull();
+  });
+  return container.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+}
+
+describe('ListView — an empty list is not a failed list (#7132)', () => {
+  it('EMPTY: the empty state is announced as role="status"', async () => {
+    const { container } = renderWith(() => Promise.resolve([]));
+    const box = await panel(container, 'empty-state');
+    expect(box.getAttribute('role')).toBe('status');
+    // Guard against the arm passing over a collapsed render: the empty copy
+    // must actually be present in the box being measured.
+    expect(box.textContent).toMatch(/nothing here yet/i);
+  });
+
+  it('ERROR: the load-failure panel is announced as role="alert"', async () => {
+    const { container } = renderWith(() =>
+      Promise.reject(Object.assign(new Error('Forbidden'), { httpStatus: 403 })),
+    );
+    const box = await panel(container, 'list-error-state');
+    expect(box.getAttribute('role')).toBe('alert');
+    expect(box.getAttribute('data-error-kind')).toBe('forbidden');
+  });
+
+  it('the two branches carry DIFFERENT roles, by exact value', async () => {
+    const { container: emptyC } = renderWith(() => Promise.resolve([]));
+    const emptyRole = (await panel(emptyC, 'empty-state')).getAttribute('role');
+    const { container: errC } = renderWith(() =>
+      Promise.reject(Object.assign(new Error('Forbidden'), { httpStatus: 403 })),
+    );
+    const errorRole = (await panel(errC, 'list-error-state')).getAttribute('role');
+    // Asserted by exact value, not by inequality: on `origin/main` the roles
+    // were `null` and `null`, but a partial fix leaving the empty branch at
+    // `null` would still satisfy `null !== 'alert'` and pass a mere-difference
+    // assertion. Both values must be named for this arm to be able to fail.
+    expect(emptyRole).toBe('status');
+    expect(errorRole).toBe('alert');
+  });
+});


### PR DESCRIPTION
Fixes #7132

## The card asked for a measurement first, so here is the measurement

Every surface was rendered and its empty box read directly — `role`, `aria-live`, `data-slot`, non-blank text-node count and text — at `2b3964aff`. Not read off the source; rendered.

| surface | `role` | text | self-describing | distinguishable from a failure |
|---|---|---|---|---|
| `DataEmptyState` bare default | **none** | `No data` | no — terse, names nothing | **no** |
| `plugin-list` empty list | **none** | `Nothing here yet` + `Create your first record…` | yes | **no** |
| `plugin-list` load ERROR (403) | **none** | `You don't have access…` + `Retry` | yes | **no** |
| `plugin-detail` `ActivityTimeline` | **none** | `No activity recorded` | partly | **no** |
| `ui:empty` schema renderer | **none** | authored | authored | **no** |
| `plugin-dashboard` `WidgetEmptyState` (#7063) | `status` | `No data yet` + explanation + `Source: work_order` | yes | yes |
| `plugin-kanban` empty board | `status` + `aria-live=polite` | `No cards` + `2 columns` | yes | yes |
| `plugin-charts` `ObjectChart` (PR #7139) | `status` | `No data yet` + explanation | yes | yes |

## The answer: they do NOT legitimately differ

The two properties the rulings name are not in tension across these surfaces — one surface had simply never been given the platform default, and the rest had each bought it retail.

`DataLoadingState` has always been `role="status"` and `DataErrorState` `role="alert"`. **`DataEmptyState`, in the same file, declared nothing.** So every surface that wanted the property typed it at its own call site, and **three independently did** — kanban, dashboard, and the in-flight `ObjectChart` — while `plugin-list`, `plugin-detail`'s two timelines and the `ui:empty` renderer silently did not.

Three hand-copies of one line, paid per package, is the per-app tax objectstack#13848 rules against, and the spread was not principled divergence but the presence or absence of one attribute nobody owned.

⇒ The primitive carries **property 1** now. It still does not carry property 2 and deliberately is not given it: every shipped surface already supplies its own self-describing copy, and changing the `'No data'` title default would be a copy change reaching all consumers plus an i18n project in a component that currently has no translation hook. That half is measured-and-declined, recorded here rather than done quietly.

## The fences, each checked rather than asserted

**#7063 and #7064 are not re-litigated — neither surface's behaviour changes, structurally.**
- #7064's fix is in `packages/plugin-detail/src/renderers/record-details.tsx`, which does **not** consume `DataEmptyState` at all (census below). It cannot be reached by a change to this component.
- #7063's `WidgetEmptyState` passes `role="status"` **explicitly**. `role` is spread from `props` *after* the default, so that call site keeps the last word and receives the identical attribute with or without this change. Pinned as a negative control, and proven by ablation: removing the default leaves both override arms green.

**No authoring surface is widened.** No new prop, no new schema key, no new i18n key. `ListView` already read `schema.emptyState?.title` / `.message` before this change and still does, untouched. Clause ② is not engaged, so the blocked Fable 5 quota is not in the path.

**The KPI datum does not generalise, and the code says why.** `DatasetWidget`'s carve-out is `if (state.rows.length === 0 && !isMetric)` — a branch gate on *whether an empty state is rendered at all*, upstream of this component. A metric widget never reaches `DataEmptyState`, so a KPI still reads `0`. That decision and this one are about different questions: *whether to show an empty state* vs *what structure the empty state has*. Untouched either way.

## One real defect fell out of the measurement

`plugin-list` renders its load **failure** through `DataEmptyState`, borrowing it for layout. With no role on either branch, "You don't have access" and "Nothing here yet" were the same node shape — and a `role="status"` default alone would have made it worse, announcing a 403 as a routine status update. That call site now declares `role="alert"`.

This is why naive hoisting was not safe, and it is the one thing the card's hypothesis did not anticipate. The deeper structural question — that `DataErrorState` sits unused next to it — is filed as #7143 rather than refactored here.

## Consumer census, re-derived with controls

Both exported names were swept, not just the canonical one:

- `DataEmptyState` — **6 call sites in 4 packages** on `main`, not the four the card assumed: `plugin-list` (**two** — empty *and* error), `plugin-kanban`, `plugin-detail` (**two** — `ActivityTimeline` and `RecordActivityTimeline`), and `packages/components`' own `ui:empty` renderer, which the card did not list at all. PR #7139 adds `ObjectChart` as a seventh.
- `EmptyState` — the alias re-export has **zero** consumers. Real zero: the control (`git grep -nw` against the alias line itself) hits at `view-states.tsx:199`. It is public API of a published package, so this is an observation, not a defect.
- **Outside `packages/*`: zero** code consumers — one changeset mentions the name in prose. Control: 238 files outside `packages/*` reference `@object-ui/components`, so the channel reads.
- **PM assumption falsified:** `DataEmptyState` is *not* the only shared empty-state primitive in `packages/components`. `custom/empty.tsx` carries a second, independent family — `Empty` / `EmptyHeader` / `EmptyMedia` / `EmptyTitle` / `EmptyDescription` / `EmptyContent` / `EmptyValue` — plus `BuiltinSelectEmptyState` and `CommandEmpty` elsewhere. None of them is a view-level data empty state and none is touched here, but "the only shared primitive" was not true.

## Blast radius, measured before proposing it

`packages/components` is broad-blast, so the whole consumer graph was run, not sampled.

| scope | result |
|---|---|
| direct consumers — `components`, `plugin-list`, `plugin-kanban`, `plugin-detail`, `plugin-dashboard` | `Test Files 504 passed (504)` · `Tests 4780 passed (4780)` |
| indirect — `app-shell`, `apps/console`, `fields`, `plugin-gantt`, `plugin-timeline`, `i18n`, `plugin-charts`, `plugin-view` | `Test Files 1003 passed (1003)` · `Tests 10939 passed \| 1 skipped (10940)` |

Zero snapshot exposure: no snapshot file contains a `DataEmptyState` render (control: 10 `data-slot` hits in `snapshot.test.tsx.snap` prove the grep reads).

## Evidence

**The pins can fail — ablation, direction predicted before running.** Predicted: removing the `role="status"` default reddens the two DEFAULT arms and the two ListView arms that name `status`, and leaves the two OVERRIDE arms, the SIBLING CONTRAST arm and the ERROR arm green.

- mutation proven on disk **before** the run: blob `294d845a` to `9e24fccf`, guard-line count 2 to 1, `git diff --stat` non-empty
- result: **`Tests 4 failed | 4 passed (8)`** — exactly the four predicted arms, with the passing count asserted so a collapsed suite could not masquerade as the red
- restore proven by state: blob back to `294d845a`, guard-lines back to 2, `git diff HEAD` **and** `git diff --cached` both empty

The three-value arm is asserted **by exact value**, not by inequality: on `main` both roles were `null`, and a partial fix leaving the empty branch at `null` would still satisfy `null !== 'alert'` and pass a mere-difference assertion. Naming both values is what makes that arm able to fail.

**Gates, at final commit `ff43f39f7`** — each verdict quoted from the gate's own output, exit captured before any pipe.

| gate | exit | verdict |
|---|---|---|
| `vitest run` (the two new pins) | 0 | `Test Files 2 passed (2)` · `Tests 8 passed (8)` |
| `vitest run` (5 direct consumer packages) | 0 | `Test Files 504 passed (504)` · `Tests 4780 passed (4780)` |
| `vitest run` (8 indirect packages) | 0 | `Test Files 1003 passed (1003)` · `Tests 10939 passed \| 1 skipped` |
| `tsc --noEmit` + `tsc -p tsconfig.test.json` (components) | 0 / 0 | clean |
| `tsc --noEmit` + `tsc -p tsconfig.test.json` (plugin-list) | 0 / 0 | clean |
| `eslint` (plain form, 4 changed files) | 0 | `184 problems (0 errors, 184 warnings)` — all pre-existing `no-explicit-any`; the new pin's 2 match `ListView.loadErrorKind.test.tsx`'s own profile exactly |
| `check-changeset-presence` | 0 | `4 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` | 0 | `All workspace packages are in the changeset fixed group.` |
| `check-changeset-no-major` | 0 | `No changeset declares a major bump.` |
| `check-changeset-overwrite` | 0 | `No pre-existing changeset was modified or deleted.` |
| `check-control-bytes` | 0 | `OK (scanned 5917 tracked text file(s); skipped 85 binary)` |
| `check-i18n-call-site-keys` | 0 | `2845 keys` — every in-scope call-site key resolves |
| `check-i18n-en-drift` | 0 | `No en value changed in this range.` |
| `check-phantom-dependencies` | 0 | `Every in-scope import is declared by the package that publishes it.` |

⚠️ **`typecheck` clean would have been a false green on its own** — `packages/components/tsconfig.json` excludes `src/__tests__` and `**/*.test.tsx`. Proven covered by the second pass instead: `--listFiles` puts the components pin at **1 of 1895** checked files and the plugin-list pin at **1 of 1625**; both edited sources are in the src pass (1 of 1367, 1 of 1334); control — the src pass contains **0** `.test.tsx`, confirming the two-pass split is what covers them.

**Declared narrowing:** repo-wide `pnpm lint` and the full `check:*` farm were not run locally; CI runs them regardless. `pnpm install`, the closure build (`turbo run build --filter='@object-ui/plugin-list^...'`, `12 successful`) and every run above happened in a dedicated worktree off `2b3964aff`.

**On PR #7139:** measured on `main` as instructed; it is still open and based on the same `2b3964aff`. It hand-types `role="status"` at its call site, so it is unaffected by this default whichever order the two land in — and afterwards that line becomes removable, which is the collapse its author placed it for. No file in `packages/plugin-charts` is touched here.

## Out-of-scope findings

- #7142 — `ActivityTimeline`'s empty title is a hardcoded English literal while its sibling uses `t('detail.noActivity')`
- #7143 — `[finding]` `ListView` renders its load failure through `DataEmptyState` while `DataErrorState` sits unused beside it

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_