### PR TITLE
fix(app-shell): scope the Interfaces block selection to its leaf

### DIFF
--- a/.changeset/7137-selection-expires-with-leaf.md
+++ b/.changeset/7137-selection-expires-with-leaf.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Studio Interfaces pillar: a canvas block selection no longer outlives the leaf
+it was made on (objectui#7137).
+
+`InterfacesPillar`'s only clear of `selection` sat inside the draft-load effect,
+*after* its `if (!current || !isEditable) … return` guard, so it never ran on the
+early-return path. Since `isEditable = !!Preview && !StudioCanvas` is a
+conjunction, that is two populations of leaf: a studio-canvas leaf (`object`),
+and a leaf whose own type has no registered designer. Walking to either from a
+leaf with a block selected carried the selection across, still describing a block
+on the previous leaf's canvas.
+
+Two symptoms, both measured before and after:
+
+- the scoped inspector opened for a foreign block — recorded three renders as
+  `page:home_page:block:blk_1`, with `blk_1` a dashboard block — and the header
+  offered to clear a selection belonging to another leaf;
+- in the folded (chat-dock) layout, `hasInspectorTarget` stayed true across the
+  leaf change, so `nextCenterTab` saw no edge and stranded the author on the
+  Properties tab of a leaf with no properties to show.
+
+The selection is now stamped with its leaf and read back through that key — the
+same "expires by construction" shape `blockingReport` already uses against
+`inspectorKey` in this component. It goes null in the *same* render as the leaf
+change rather than one committed render later, and there is no imperative clear
+left for a future guard to strand. Within a leaf nothing changes: the Design/Run
+round trip still keeps its selection, and a same-leaf reload (`publishNonce`)
+still clears it.
+
+objectui#7121's gating of the rail and the Design/Run switch is untouched, and
+its discriminator remains `StudioCanvas` — not `isEditable`.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.selectionLeafScope.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.selectionLeafScope.test.tsx
@@ -1,0 +1,381 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7137 — the Interfaces pillar's block `selection` must not outlive a
+ * leaf change.
+ *
+ * ## The mechanism it pins
+ *
+ * `InterfacesPillar`'s draft-load effect used to be the only thing that cleared
+ * the selection, and its clear sat AFTER the guard:
+ *
+ *     if (!current || !isEditable) { setDraft({}); setHasDraft(false); return; }
+ *     …
+ *     setSelection(null);   // never reached on the early-return path
+ *
+ * So walking from a leaf with a block selected to any leaf where
+ * `isEditable === false` carried the selection across, and it then described a
+ * block on the PREVIOUS leaf's canvas.
+ *
+ * The repair keys the selection to the leaf it was made on — the same
+ * "expires by construction" shape `blockingReport` already uses against
+ * `inspectorKey` in this component — so a leaf change nulls it in the SAME
+ * render rather than one committed render later.
+ *
+ * ## Two populations, two different observables — both are pinned here
+ *
+ * `isEditable = !!Preview && !StudioCanvas` is a conjunction, so it is false
+ * for two disjoint reasons, and #7121's landed gating covers only one of them:
+ *
+ *   (a) **studio-canvas leaves** (`object`). #7121 gates the rail and the
+ *       header's clear button on `StudioCanvas`, so both of those symptoms are
+ *       already unreachable here. What it did NOT gate is `hasInspectorTarget`,
+ *       which feeds `nextCenterTab` — so in the folded layout the ONLY
+ *       surviving observable of the leak is the center tab, and that is what
+ *       the folded-layout test below measures.
+ *
+ *   (b) **leaves whose own type has no registered designer**. Nothing gates
+ *       this population: the stale selection reaches the
+ *       `selection && Inspector && current` rail branch directly and opens the
+ *       scoped inspector for a foreign block. Pinned via a mount LEDGER rather
+ *       than a point-in-time query, because the defect being excluded is a
+ *       mount that is torn down again a render later.
+ *
+ * ## ⚠️ The registry is POPULATED on purpose
+ *
+ * Same precondition as `StudioDesignSurface.designerRegistryPartial.test.tsx`:
+ * a designer is registered for an unrelated type, so a `page` leaf lands in the
+ * no-designer branch for reason (1) "this type has none" — a product fact — and
+ * not for #6795 part C's reason (2) "the registries never loaded". A
+ * zero-registry reading would measure that other card instead.
+ *
+ * ## ⛔ Do NOT re-fence this on `isEditable`
+ *
+ * The discriminator for #7121's rail / Design-mode gating is `StudioCanvas`,
+ * never `isEditable` — `StudioDesignSurface.designerRegistryPartial.test.tsx`
+ * is the live fence for that and goes red on the substitution. This card is the
+ * opposite direction: the STATE lifecycle, which is correctly keyed to the leaf
+ * and not to either discriminator.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// jsdom has no matchMedia — `useIsMobile` (rail overlay) and
+// `useIsWideViewport` (the folded layout's side-by-side threshold) both need a
+// stub. `innerWidth` stays at jsdom's 1024 default, i.e. BELOW the 1280 `xl`
+// breakpoint, so `foldInspector` really does produce the center-tabs layout
+// rather than the wide side-by-side one.
+window.matchMedia = ((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: () => {},
+  removeListener: () => {},
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => false,
+})) as unknown as typeof window.matchMedia;
+
+/**
+ * Three leaves, one app — one of each population plus the editable leaf the
+ * selection is made on:
+ *   - `dashboard` → a registered designer, so it is editable and can emit a
+ *     selection (the ONLY leaf here that can);
+ *   - `object`    → population (a), a studio-canvas leaf;
+ *   - `page`      → population (b), no designer registered for its own type.
+ */
+const NAV = [
+  { id: 'nav_dash', type: 'dashboard', label: 'Overview', dashboardName: 'sales_overview' },
+  { id: 'nav_obj', type: 'object', label: 'Tasks', objectName: 'showcase_task' },
+  { id: 'nav_page', type: 'page', label: 'Home', pageName: 'home_page' },
+];
+
+const objectDef = {
+  name: 'showcase_task',
+  label: 'Task',
+  fields: [{ name: 'title', label: 'Title', type: 'text' }],
+};
+
+const mockClient = {
+  save: vi.fn(async () => ({})),
+  list: vi.fn(async (type: string) => {
+    if (type === 'app') return [{ name: 'acme_app', label: 'Acme' }];
+    if (type === 'object') return [{ name: 'showcase_task', label: 'Task' }];
+    return [];
+  }),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async (type: string, name: string) => {
+    if (type === 'app') return { effective: { name: 'acme_app', label: 'Acme', navigation: NAV } };
+    if (type === 'object') return { effective: objectDef, code: objectDef };
+    if (type === 'dashboard') return { effective: { name: 'sales_overview', label: 'Sales' } };
+    if (type === 'page') return { effective: { name: 'home_page', label: 'Home' } };
+    return { effective: { name } };
+  }),
+  getDraft: vi.fn(async () => null),
+  get: vi.fn(async () => undefined),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return { ...mod, useMetadataClient: () => mockClient, useMetadataTypes: () => ({ entries: [] }) };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+import { InterfacesPillar } from './StudioDesignSurface';
+import { listMetadataPreviewTypes, registerMetadataPreview } from '../metadata-admin/preview-registry';
+import { listMetadataInspectorTypes, registerMetadataInspector } from '../metadata-admin/inspector-registry';
+import { listStudioCanvasPreviewTypes } from './studio-canvas-preview';
+
+/**
+ * Every `{type, name, selection}` a scoped inspector was EVER mounted with.
+ *
+ * A ledger rather than a `queryBy…` at the end of the test, because the defect
+ * under exclusion is short-lived by nature: an imperative clear that runs in an
+ * effect leaves the stale selection live for one committed render, so the
+ * foreign-block inspector mounts, runs its effects, and is torn down before any
+ * settled assertion could see it. The ledger catches that frame; a final query
+ * cannot.
+ */
+const mounts: string[] = [];
+
+function StubInspector(props: Record<string, unknown>): React.ReactElement {
+  const sel = props.selection as { kind?: string; id?: string } | null;
+  const stamp = `${String(props.type)}:${String(props.name)}:${sel?.kind}:${sel?.id}`;
+  // Recorded during render (not in an effect) so a mount that is discarded
+  // before commit is still counted — the strictest reading available.
+  mounts.push(stamp);
+  return <div data-testid="stub-inspector" data-for={stamp} />;
+}
+
+/**
+ * The only leaf here that can produce a selection. Its `pick` button goes
+ * through the pillar's own `onSelectionChange`, so the selection under test is
+ * made the way the product makes one.
+ */
+function StubDashboardPreview(props: Record<string, unknown>): React.ReactElement {
+  const onSel = props.onSelectionChange as ((s: unknown) => void) | undefined;
+  return (
+    <div data-testid="stub-dash" data-editing={String(props.editing)}>
+      <button
+        type="button"
+        data-testid="pick-block"
+        onClick={() => onSel?.({ kind: 'block', id: 'blk_1' })}
+      >
+        pick
+      </button>
+    </div>
+  );
+}
+
+registerMetadataPreview('dashboard', StubDashboardPreview as never);
+// Inspectors for all three types. `object` mirrors production, which registers
+// `ObjectFieldInspector` (`metadata-admin/inspectors/index.ts`); `page` is what
+// makes population (b)'s scoped-inspector branch reachable rather than
+// accidentally empty.
+registerMetadataInspector('dashboard', StubInspector as never);
+registerMetadataInspector('object', StubInspector as never);
+registerMetadataInspector('page', StubInspector as never);
+
+beforeEach(() => {
+  mounts.length = 0;
+});
+afterEach(cleanup);
+
+/** The precondition every test here shares, stated rather than assumed. */
+function expectPopulatedRegistries() {
+  // Populated — so a `page` leaf reaching the no-designer branch is reaching it
+  // because ITS type has none, not because none loaded (#6795 part C).
+  expect(listMetadataPreviewTypes()).toEqual(['dashboard']);
+  expect(listMetadataPreviewTypes()).not.toContain('page');
+  expect(listMetadataInspectorTypes()).toEqual(
+    expect.arrayContaining(['dashboard', 'object', 'page']),
+  );
+  // ...and the two populations really are what this file says they are.
+  expect(listStudioCanvasPreviewTypes()).toContain('object');
+  expect(listStudioCanvasPreviewTypes()).not.toContain('page');
+}
+
+function mountPillar(props: { foldInspector?: boolean } = {}) {
+  return render(
+    <MemoryRouter initialEntries={['/studio/com.acme.app/interfaces']}>
+      <InterfacesPillar packageId="com.acme.app" {...props} />
+    </MemoryRouter>,
+  );
+}
+
+const bodyText = () => (document.body.textContent ?? '').replace(/\s+/g, ' ');
+
+/** Select `blk_1` on the dashboard leaf, through the pillar's own callback. */
+async function selectBlockOnDashboardLeaf() {
+  fireEvent.click(await screen.findByTitle('dashboard · sales_overview'));
+  await waitFor(() => expect(screen.getByTestId('stub-dash')).toBeInTheDocument(), {
+    timeout: 4000,
+  });
+  fireEvent.click(screen.getByTestId('pick-block'));
+  // Control: the selection really was made. Without this the "it is gone
+  // afterwards" assertions below could pass because it never existed.
+  await waitFor(() => expect(screen.getByLabelText('Clear selection')).toBeInTheDocument(), {
+    timeout: 4000,
+  });
+  expect(screen.getByTestId('stub-inspector')).toHaveAttribute(
+    'data-for',
+    'dashboard:sales_overview:block:blk_1',
+  );
+}
+
+/** Which center tab is active, read from the DOM rather than from state. */
+function activeCenterTab(): string | null {
+  const tabs = screen.getByTestId('studio-center-tabs');
+  const active = tabs.querySelector('[role="tab"][data-state="active"]');
+  return active?.textContent?.trim() ?? null;
+}
+
+describe('Interfaces pillar — a block selection expires with its leaf (#7137)', () => {
+  it('does not carry the selection onto a leaf whose type has no designer', async () => {
+    expectPopulatedRegistries();
+    mountPillar();
+    await selectBlockOnDashboardLeaf();
+
+    // Walk to population (b). Nothing in #7121 gates this branch.
+    fireEvent.click(screen.getByTitle('page · home_page'));
+    await waitFor(
+      () =>
+        expect(bodyText()).toContain(
+          'No designer is registered for page, so it cannot be previewed or designed here.',
+        ),
+      { timeout: 4000 },
+    );
+
+    // The scoped inspector must never have been handed a block from the
+    // dashboard leaf — not at the end, and not for a single render either.
+    const foreign = mounts.filter((m) => m.startsWith('page:') && m.includes('blk_1'));
+    expect(foreign).toEqual([]);
+    // Control on the same instrument: the ledger is demonstrably live and does
+    // record real mounts, so the empty result above is a measurement and not a
+    // broken probe.
+    expect(mounts).toContain('dashboard:sales_overview:block:blk_1');
+
+    // ...and the settled state agrees: no scoped inspector, and no offer to
+    // clear a selection that no longer exists.
+    expect(screen.queryByTestId('stub-inspector')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Clear selection')).not.toBeInTheDocument();
+  });
+
+  /**
+   * ⚠️ Green on BOTH sides of the repair, and deliberately kept anyway.
+   *
+   * Measured on the unfixed tree, this test passed while the other four in this
+   * file split 3-failed / 2-passed — because #7121 already orders the
+   * studio-canvas rail branch ahead of the `selection` branch, so the foreign
+   * block never reached an inspector here even with the leak live. That is the
+   * finding, not a defect in the test: on population (a) the scoped-inspector
+   * symptom is ALREADY unreachable, which is why the folded-tab test below is
+   * the one that actually measures this population's leak.
+   *
+   * It stays as the fence for the combination — state lifecycle and rail gating
+   * agreeing — which nothing else asserts.
+   */
+  it('does not carry the selection onto a studio-canvas leaf', async () => {
+    expectPopulatedRegistries();
+    mountPillar();
+    await selectBlockOnDashboardLeaf();
+
+    // Walk to population (a).
+    fireEvent.click(screen.getByTitle('object · showcase_task'));
+    await waitFor(
+      () => expect(bodyText()).toContain('This canvas renders the running app, not a block tree'),
+      { timeout: 4000 },
+    );
+
+    const foreign = mounts.filter((m) => m.startsWith('object:') && m.includes('blk_1'));
+    expect(foreign).toEqual([]);
+    expect(mounts).toContain('dashboard:sales_overview:block:blk_1');
+    expect(screen.queryByTestId('stub-inspector')).not.toBeInTheDocument();
+  });
+
+  it('returns the folded center tab to Canvas instead of stranding it on Properties', async () => {
+    expectPopulatedRegistries();
+    mountPillar({ foldInspector: true });
+    await selectBlockOnDashboardLeaf();
+
+    // Control on the same instrument: selecting a block DOES drive this tab, so
+    // the "back to Canvas" reading below is a measurement of the auto-switch and
+    // not of a tab strip that never moves.
+    await waitFor(() => expect(activeCenterTab()).toBe('Properties'), { timeout: 4000 });
+
+    // ⭐ The card's `centerTab` sub-claim, measured. A surviving selection keeps
+    // `hasInspectorTarget` true across the leaf change, so `nextCenterTab` sees
+    // no edge and the author lands on Properties — on a leaf whose Properties
+    // panel can only say the canvas has no blocks. With the selection scoped to
+    // its leaf the target CLEARS, and the folded layout returns to the canvas
+    // that actually has something to show.
+    fireEvent.click(screen.getByTitle('object · showcase_task'));
+    await waitFor(() => expect(activeCenterTab()).toBe('Canvas'), { timeout: 4000 });
+  });
+});
+
+describe('REGRESSION FENCE — the repair must not over-fire (#7137)', () => {
+  it('keeps the selection while the leaf stays the same', async () => {
+    expectPopulatedRegistries();
+    mountPillar();
+    await selectBlockOnDashboardLeaf();
+
+    // #5800's contract, quoted in the component: "Selection state is retained
+    // so switching back to design keeps context." A repair that cleared on any
+    // re-render rather than on a LEAF CHANGE would break this round trip.
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('stub-dash')).toHaveAttribute('data-editing', 'false'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Design' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('stub-dash')).toHaveAttribute('data-editing', 'true'),
+    );
+
+    expect(screen.getByTestId('stub-inspector')).toHaveAttribute(
+      'data-for',
+      'dashboard:sales_overview:block:blk_1',
+    );
+    expect(screen.getByLabelText('Clear selection')).toBeInTheDocument();
+  });
+
+  it('restores a selection made again on the leaf it was cleared by leaving', async () => {
+    expectPopulatedRegistries();
+    mountPillar();
+    await selectBlockOnDashboardLeaf();
+
+    fireEvent.click(screen.getByTitle('page · home_page'));
+    await waitFor(() => expect(screen.queryByTestId('stub-inspector')).not.toBeInTheDocument(), {
+      timeout: 4000,
+    });
+
+    // Coming BACK must not resurrect the old selection (the leaf starts clean)…
+    fireEvent.click(screen.getByTitle('dashboard · sales_overview'));
+    await waitFor(() => expect(screen.getByTestId('stub-dash')).toBeInTheDocument(), {
+      timeout: 4000,
+    });
+    expect(screen.queryByLabelText('Clear selection')).not.toBeInTheDocument();
+
+    // …and selecting again on it must still work.
+    fireEvent.click(screen.getByTestId('pick-block'));
+    await waitFor(() =>
+      expect(screen.getByTestId('stub-inspector')).toHaveAttribute(
+        'data-for',
+        'dashboard:sales_overview:block:blk_1',
+      ),
+    );
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.studioCanvasLeaf.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.studioCanvasLeaf.test.tsx
@@ -240,8 +240,19 @@ describe('Interfaces pillar — affordances beside a studio-canvas leaf (#7121)'
       timeout: 4000,
     });
 
-    // ...then walk to the studio-canvas leaf. The pillar's load effect clears
-    // `selection` only on the editable path, so the selection is still live.
+    // ...then walk to the studio-canvas leaf.
+    //
+    // ⚠️ This step's premise CHANGED under objectui#7137. When this test landed,
+    // the pillar's load effect cleared `selection` only on the editable path, so
+    // the selection was still live here and the two absences below measured
+    // #7121's gating against it. #7137 keyed `selection` to its leaf, so it is
+    // now already null on arrival and those two absences hold for that stronger
+    // reason instead — belt-and-braces rather than the sole guard. Kept as-is
+    // (it is still the end-to-end statement "a block picked on another leaf
+    // opens nothing here"), but #7121's gating is independently pinned by the
+    // three tests ABOVE, which assert it with no selection in play at all —
+    // those are the ones that go red if the gate is removed or re-fenced on
+    // `isEditable`.
     fireEvent.click(screen.getByTitle('object · showcase_task'));
     await waitFor(() => expect(bodyText()).toContain('Runtime list preview'), { timeout: 4000 });
 

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -1253,7 +1253,40 @@ export function InterfacesPillar({
   // blocks to inspect). Non-source surfaces never show the tab strip.
   const [inspectorTab, setInspectorTab] = React.useState<'props' | 'source'>('source');
   const [draft, setDraft] = React.useState<Record<string, unknown>>({});
-  const [selection, setSelection] = React.useState<MetadataSelection | null>(null);
+  // objectui#7137 — the block selection is STAMPED with the leaf it was made
+  // on, so it expires BY CONSTRUCTION when the leaf changes — the same shape
+  // `blockingReport` already uses against `inspectorKey` below, and the reason
+  // that one cannot be stranded either.
+  //
+  // The previous shape was a bare `MetadataSelection | null` whose ONLY clear
+  // lived inside the draft-load effect, *after* its
+  // `if (!current || !isEditable) … return` guard. So the clear never ran on any
+  // leaf where `isEditable` is false, and `isEditable = !!Preview && !StudioCanvas`
+  // is a conjunction — that is a studio-canvas leaf OR a leaf whose own type has
+  // no registered designer. Walking to either carried a selection describing a
+  // block on the PREVIOUS leaf's canvas. Measured before the repair: the scoped
+  // inspector mounted three times as `page:home_page:block:blk_1` with `blk_1` a
+  // dashboard block, and in the folded layout `hasInspectorTarget` stayed true
+  // across the leaf change so `nextCenterTab` saw no edge and stranded the author
+  // on Properties ("expected 'Properties' to be 'Canvas'").
+  //
+  // ⛔ Deliberately NOT repaired by hoisting that imperative clear above the
+  // guard. Two reasons, the first measured: a clear in an effect runs one
+  // COMMITTED render after the leaf change, so the foreign-block inspector still
+  // mounts and runs its effects before being torn down — keying it to the leaf
+  // makes `selection` null in the SAME render. And an imperative clear is what
+  // this defect was: a guard added later stranded it, and the next guard could
+  // strand it again.
+  const leafKey = `${current?.type ?? ''}:${current?.name ?? ''}`;
+  const [selectionState, setSelectionState] = React.useState<{
+    key: string;
+    value: MetadataSelection | null;
+  }>({ key: '', value: null });
+  const selection = selectionState.key === leafKey ? selectionState.value : null;
+  const setSelection = React.useCallback(
+    (next: MetadataSelection | null) => setSelectionState({ key: leafKey, value: next }),
+    [leafKey],
+  );
   // ADR-0057 P3c — the folded-layout center tab (canvas | properties). The
   // auto-switch below reacts to inspector-target EDGES (select a block → jump
   // to Properties; deselect → back to Canvas) while preserving a manual choice
@@ -1437,9 +1470,7 @@ export function InterfacesPillar({
   // selection changes, when the rail swaps scoped for default, or when the leaf
   // changes — an unmounted inspector can never retract its last verdict.
   const [blockingReport, setBlockingReport] = React.useState({ key: '', count: 0 });
-  const inspectorKey = `${current?.type ?? ''}:${current?.name ?? ''}:${
-    selection ? `${selection.kind}:${selection.id}` : 'default'
-  }`;
+  const inspectorKey = `${leafKey}:${selection ? `${selection.kind}:${selection.id}` : 'default'}`;
   const inspectorBlocking = blockingReport.key === inspectorKey ? blockingReport.count : 0;
   // A studio-canvas surface (e.g. object → runtime records grid) renders the
   // running app, not an editable draft — schema editing is the Data pillar's
@@ -1470,6 +1501,12 @@ export function InterfacesPillar({
     let cancelled = false;
     setLoading(true);
     setError(null);
+    // A LEAF CHANGE no longer needs this — `selection` is keyed to the leaf and
+    // is already null by the time this runs (objectui#7137). What is left is the
+    // narrower case this effect also fires for: a RELOAD of the same leaf
+    // (`publishNonce` bumped, or a new `client`), where the leaf key is unchanged
+    // and a block selected against the pre-publish draft should not carry into
+    // the reloaded one.
     setSelection(null);
     (async () => {
       try {
@@ -1706,12 +1743,14 @@ export function InterfacesPillar({
       <SlidersHorizontal className="h-3.5 w-3.5" />
       <span className="text-[13px] font-medium">{t('engine.studio.inspector.props', locale)}</span>
       <div className="ml-auto flex items-center gap-0.5">
-        {/* objectui#7121 — same gate as the rail branch: on a studio-canvas
-            leaf `selection` can only be a leftover from the previous leaf, so
-            offering "clear selection" here would contradict the rail beside it,
-            which states this canvas has no blocks. (The leftover STATE itself
-            outlives every non-editable leaf change, not just these — filed
-            separately rather than swept in here.) */}
+        {/* objectui#7121 — same gate as the rail branch: offering "clear
+            selection" on a studio-canvas leaf would contradict the rail beside
+            it, which states this canvas has no blocks. (The leftover STATE that
+            once reached here is gone since objectui#7137 keyed `selection` to
+            its leaf; this gate stays because it is the RAIL's consistency rule,
+            and a studio-canvas leaf can never produce a selection to clear
+            either way — `StudioCanvasPreviewProps` carries no
+            `onSelectionChange` by contract.) */}
         {selection && !StudioCanvas && (
           <button
             type="button"
@@ -1774,13 +1813,18 @@ export function InterfacesPillar({
       // (`listMetadataPreviewTypes() === ['dashboard']`), which is what makes
       // this a different cause from #6795 part C's empty-registry states.
       //
-      // Ordered BEFORE the `selection` branch on purpose. `selection` is state
-      // that outlives a leaf change (the load effect clears it only on the
-      // editable path), so arriving here with a block selected on the PREVIOUS
-      // leaf otherwise opens the scoped inspector for a block this canvas does
-      // not contain — measured: `ObjectFieldInspector` handed
-      // `object:showcase_task:block:blk_1`. This ordering mirrors the canvas
-      // chain, where `StudioCanvas` also wins.
+      // Ordered BEFORE the `selection` branch on purpose, mirroring the canvas
+      // chain where `StudioCanvas` also wins. When this ordering landed it was
+      // also load-bearing against a second defect: `selection` outlived a leaf
+      // change (the load effect cleared it only on the editable path), so
+      // arriving here with a block selected on the PREVIOUS leaf opened the
+      // scoped inspector for a block this canvas does not contain — measured,
+      // `ObjectFieldInspector` handed `object:showcase_task:block:blk_1`.
+      // objectui#7137 fixed that at the source by keying `selection` to its
+      // leaf, so this branch is no longer the thing standing between an author
+      // and a foreign block. Keep the order anyway: it states which branch is
+      // TRUE for this leaf, and it does not depend on the state lifecycle
+      // staying correct.
       //
       // ⛔ Says what is true and promises no recovery — no "loading…", no "try
       // again". Same constraint part C established: these registries are plain


### PR DESCRIPTION
Fixes #7137

The Interfaces pillar's block `selection` outlived a leaf change on every leaf
where `isEditable === false`, because the only clear sat *after* the draft-load
effect's early return:

```
React.useEffect(() => {
  if (!current || !isEditable) { setDraft({}); setHasDraft(false); return; }
  ...
  setSelection(null);   // never reached on the early-return path
}, [client, current, isEditable, publishNonce]);
```

`isEditable = !!Preview && !StudioCanvas` is a conjunction, so that early return
covers two disjoint populations, and the surviving selection then described a
block on the *previous* leaf's canvas.

## Premise re-derived on the current head

Verified in a fresh worktree at `origin/main` = `0d4c7890d` — the commit that
landed #7121, i.e. after the card was filed. The guard's shape and the stranded
clear are both still exactly as the card quotes them. Premise holds.

## Populations, measured

| population | in-repo count | live symptoms after #7121 |
| --- | --- | --- |
| (a) studio-canvas leaves | **1** (`object`, `studio-canvas-preview.tsx:97`) | folded-layout center tab only |
| (b) leaf whose own type has no designer | **0 under the shipped registration** | scoped inspector + clear button |

The pillar's leaves come from `resolveSurface`, which can produce exactly five
types (`page` / `object` / `dashboard` / `report` / `action`), and
`registerBuiltinPreviews()` registers a preview for all five. So population (b)
is **empty** when `register-builtins` has run. It is reachable only in a host
that registers a partial set — which is the state
`StudioDesignSurface.designerRegistryPartial.test.tsx` already treats as a
supported product fact, and which this PR's pin constructs.

On population (a) the rail and header symptoms are already unreachable, because
#7121 gates both on `StudioCanvas`. What that card did **not** gate is
`hasInspectorTarget`, which feeds `nextCenterTab` — so the folded center tab is
the one surviving observable there, and it is measured below.

## The repair, chosen by measurement

The selection is now stamped with the leaf it was made on and read back through
that key — the same shape `blockingReport` already uses against `inspectorKey`
in this component.

The card offered three candidates. Candidate 1, hoisting `setSelection(null)`
above the guard, was **implemented and measured** rather than reasoned about: it
closes the center-tab symptom, but the clear runs in an effect, i.e. one
committed render after the leaf change, so the foreign-block inspector still
mounts. Against the same pin:

- unfixed tree: ledger `[ 'page:home_page:block:blk_1', ...(2) ]` — 3 stale renders
- candidate 1 (hoist): ledger `[ 'page:home_page:block:blk_1' ]` — **1** stale render, `1 failed | 4 passed (5)`
- this PR (leaf-keyed): ledger `[]` — `5 passed (5)`

That single surviving render is what decided it. Keying also leaves no
imperative clear for a future guard to strand, which is how this defect arose.

Within a leaf nothing changes: the Design/Run round trip keeps its selection
(#5800's stated contract), and a same-leaf reload via `publishNonce` still
clears it — both pinned.

## Both symptoms are closed, and the card's NOT MEASURED sub-claim is now measured

The card flagged the `centerTab` symptom as *"read from the code path, not
measured in a browser."* It is measured here, in the folded layout with
`foldInspector`, reading the active tab from the DOM:

- control on the same instrument: picking a block **does** drive the tab to
  Properties, so the reading below is of a live auto-switch, not a static strip;
- unfixed: `expected 'Properties' to be 'Canvas'` — the stale target suppresses
  the return-to-Canvas edge;
- fixed: the tab returns to Canvas.

One refinement to the card's wording: the mechanism is not an auto-switch *to*
Properties on arrival. `hasInspectorTarget` never changes across the leaf walk,
so `nextCenterTab` sees no edge at all and the author is **stranded** on the
Properties tab they were already on. Same defect, same repair, more precise
cause.

## Not done here

- #7121's rail / Design-mode gating is untouched, and its discriminator remains
  `StudioCanvas`. It was never substituted with `isEditable`; its live fence
  `StudioDesignSurface.designerRegistryPartial.test.tsx` is green.
- `AutomationsPillar` in the same file was checked and does **not** share the
  defect — its guard is `if (!current) return`, with no `isEditable` term, so
  its clear runs on every leaf change.
- No public surface change: `InterfacesPillar` is a module export that
  `packages/app-shell/src/index.ts` does not re-export, and no exported type
  moved.

## Verification

All runs below are at `db22d18b0`, on a clean tree.

- `pnpm exec vitest run .../StudioDesignSurface.selectionLeafScope.test.tsx` —
  new pin. Before: `3 failed | 2 passed (5)`. After: `5 passed (5)`.
  The 2 that passed before are named and explained in the file: one is the
  over-fire fence (green on both sides by design), the other is the
  studio-canvas leaf, green because #7121 already blocks that path — the
  finding that made the center-tab test the real measurement for population (a).
- `pnpm exec vitest run packages/app-shell/src/views/studio-design/` —
  `43 passed (43)` files, `230 passed (230)` tests.
- `pnpm exec vitest run packages/app-shell/src/views/metadata-admin/` —
  `221 passed (221)` files, `2303 passed | 1 skipped (2304)`.
- `pnpm --filter '@object-ui/app-shell' type-check` — exit 0
  (`tsc --noEmit && tsc -p tsconfig.test.json`). Confirmed to actually cover the
  new file: `--listFiles` lists it, alongside a known-covered sibling as control.
- `pnpm --filter '@object-ui/app-shell' lint` — exit 0, `0 errors`
  (2853 pre-existing warnings package-wide, none in the changed files).
- `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`,
  `check:i18n-keys`, `check:shell-escape-residue` — all exit 0.
- `scripts/check-changeset-no-major.mjs` — `No changeset declares a major bump.`

The ablation restore was verified by state, not by the trap firing:
`git diff HEAD`, `git diff --cached` and `git status --short` all empty, and the
worktree blob back to HEAD's `f4c98092438320bba6469a3e886d21b2779cc2d8`.

Repo-wide `pnpm lint` and the full gate farm are left to CI, which runs them
once regardless.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_