### PR TITLE
fix(plugin-charts): a sankey with no positive flow says so instead of rendering an empty div

### DIFF
--- a/.changeset/7140-sankey-no-positive-flow.md
+++ b/.changeset/7140-sankey-no-positive-flow.md
@@ -1,0 +1,36 @@
+---
+'@object-ui/plugin-charts': minor
+---
+
+A sankey with no positive flow says so, instead of rendering an empty div
+(objectui#7140).
+
+`AdvancedChartImpl`'s sankey arm keeps only strictly positive measures, so a
+chart handed **real rows** whose measure is all `0`, all `null`, all negative,
+or unparseable built no links and returned a bare `<div>`. Measured in Chromium
+against a populated control: the control drew 1 `<svg>` / 7 `<path>` /
+26 descendants; each of those four tiles rendered `descendantCount: 1`,
+`svgCount: 0`, `textContent: ''`, and their screenshots hashed identical to one
+another. No marks, no text, no `role` — a tile indistinguishable from a widget
+that had crashed, which is the one distinction the file's other refusals exist
+to make.
+
+It now renders through the `ChartRefusal` shell those refusals already use —
+same box, same `role="status"`, and a new `data-chart-error="no-positive-flow"`
+— reading *"This chart has no flow to draw: no row's `<measure>` is above
+zero."*
+
+Two boundaries are deliberate and pinned:
+
+- **No rows at all is untouched.** That is the empty-result question, answered
+  upstream in `ObjectChart` where the query outcome is known; a sentence about
+  what the rows contain would be false about a dataset with no rows in it.
+- **One positive row among zeros still draws.** The refusal fires on an empty
+  link set, never on a thin one.
+
+One code and one sentence for three causes (a genuinely all-zero flow, values a
+flow cannot represent because they are negative, and measures `Number(…) || 0`
+folds to zero): naming any single cause would be false for the other two, so
+the copy names the predicate the filter actually applies, which is true for all
+three. No recovery is promised. Every other chart family is byte-identical —
+eight of the twelve tiles in the browser sweep hashed unchanged.

--- a/packages/plugin-charts/src/AdvancedChartImpl.sankeyNoPositiveFlow.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.sankeyNoPositiveFlow.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Sankey — rows arrived, none of them is a positive number (objectui#7140).
+ *
+ * The sankey arm keeps only strictly positive measures
+ * (`data.filter((r) => (Number(r?.[dataKey]) || 0) > 0)`), so a chart handed
+ * REAL rows whose measure is all `0`, all `null`, all negative, or unparseable
+ * built no links and returned a bare `<div className={className} />`.
+ *
+ * Measured in Chromium against a populated control before the fix, at
+ * `origin/main` e8e4c4df5: the control drew 1 `<svg>` / 7 `<path>` /
+ * 26 descendants; each of the four blank tiles rendered `descendantCount: 1`,
+ * `svgCount: 0`, `textContent: ''`, and their screenshots hashed identical to
+ * one another. Nothing was on the page — no marks, no text, no `role` — so the
+ * tile was indistinguishable from a widget that had crashed, which is the one
+ * distinction every other refusal in that file exists to make.
+ *
+ * The two boundaries this pins are the ones that make the message TRUE rather
+ * than merely present:
+ *
+ *   - **no rows at all still returns the bare div.** That is the empty-RESULT
+ *     question (objectui#7130), answered upstream in `ObjectChart` where the
+ *     query outcome is known. "No row's measure is above zero" would be a false
+ *     sentence about a dataset with no rows in it.
+ *   - **one positive row among zeros still DRAWS.** The refusal fires on an
+ *     empty link set, never on a thin one; a sankey that can draw anything is
+ *     never replaced by prose.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+const SERIES = [{ dataKey: 'amount', label: 'Amount' }];
+
+const renderSankey = (data: Array<Record<string, unknown>>) =>
+  render(
+    <AdvancedChartImpl
+      chartType="sankey"
+      xAxisKey="stage"
+      series={SERIES as any}
+      data={data as any}
+    />,
+  );
+
+const refusalOf = (container: HTMLElement) =>
+  container.querySelector('[data-chart-error="no-positive-flow"]');
+
+/**
+ * The four row shapes that reach the empty link set. They are NOT the same
+ * situation — a genuinely all-zero flow, values a flow cannot represent because
+ * they are negative, and measures `Number(…) || 0` folds to zero — but the
+ * predicate the filter applies is the one thing true of all of them, so one
+ * message serves all four without saying anything false about any of them.
+ */
+const NO_POSITIVE_ROWS: Array<[string, Array<Record<string, unknown>>]> = [
+  ['every measure is 0', [{ stage: 'Prospecting', amount: 0 }, { stage: 'Won', amount: 0 }]],
+  ['every measure is null', [{ stage: 'Prospecting', amount: null }, { stage: 'Won', amount: null }]],
+  ['every measure is negative', [{ stage: 'Refunds', amount: -40 }, { stage: 'Credits', amount: -12 }]],
+  ['every measure is unparseable', [{ stage: 'A', amount: 'n/a' }, { stage: 'B', amount: 'n/a' }]],
+];
+
+describe('AdvancedChartImpl — sankey with no positive flow (objectui#7140)', () => {
+  it.each(NO_POSITIVE_ROWS)('says so instead of rendering nothing when %s', (_label, rows) => {
+    const { container } = renderSankey(rows);
+
+    const refusal = refusalOf(container);
+    expect(refusal, 'renders the explanatory placeholder').not.toBeNull();
+    // A refusal is a STATE, not an alert — the shell the other two refusals in
+    // this file render through.
+    expect(refusal?.getAttribute('role')).toBe('status');
+    // Names the measure it tested, so the author knows WHICH column was all
+    // zero rather than being told the chart is empty.
+    expect(refusal?.textContent).toContain('amount');
+    expect(refusal?.textContent).toContain('above zero');
+    // The old behaviour was a bare `<div>` with nothing in it. Anything that
+    // paints a plot here would be a sankey drawn from links that do not exist.
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('leaves the no-rows case alone — that is the empty-result question, answered upstream', () => {
+    const { container } = renderSankey([]);
+
+    expect(refusalOf(container), 'no refusal without rows to refuse over').toBeNull();
+    expect(container.querySelector('svg')).toBeNull();
+    // Byte-for-byte what this arm returned before objectui#7140: an empty div,
+    // carrying only the className it was handed.
+    expect(container.textContent).toBe('');
+  });
+
+  it('still draws when ONE row is positive among zeros', () => {
+    const { container } = renderSankey([
+      { stage: 'Prospecting', amount: 0 },
+      { stage: 'Proposal', amount: 7 },
+      { stage: 'Won', amount: 0 },
+    ]);
+
+    expect(refusalOf(container), 'a drawable sankey is never replaced by prose').toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('CONTROL — an all-positive sankey draws, and carries no refusal', () => {
+    const { container } = renderSankey([
+      { stage: 'Prospecting', amount: 40 },
+      { stage: 'Proposal', amount: 25 },
+      { stage: 'Won', amount: 12 },
+    ]);
+
+    expect(refusalOf(container)).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('does not fire for other chart families handed the same all-zero rows', () => {
+    // The guard lives inside the sankey arm and reads the sankey filter's own
+    // result, so it cannot reach a family that has no such filter. Pinned
+    // because a hoisted copy of the predicate is the obvious refactor and would
+    // blank four working charts: bar/pie/funnel/treemap all render an all-zero
+    // dataset today (measured in Chromium — axes, labels and legend).
+    for (const chartType of ['bar', 'pie', 'funnel', 'treemap'] as const) {
+      const { container } = render(
+        <AdvancedChartImpl
+          chartType={chartType}
+          xAxisKey="stage"
+          series={SERIES as any}
+          data={[{ stage: 'A', amount: 0 }, { stage: 'B', amount: 0 }] as any}
+        />,
+      );
+      expect(refusalOf(container), `${chartType} must be untouched`).toBeNull();
+      cleanup();
+    }
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -1048,7 +1048,45 @@ function AdvancedChartImplInner({
     const nodes = [{ name: rootName }, ...rows.map((r) => ({ name: String(r?.[xAxisKey] ?? '') }))];
     const links = rows.map((r, i) => ({ source: 0, target: i + 1, value: Number(r?.[dataKey]) || 0 }));
     if (links.length === 0) {
-      return <div className={className} />;
+      // Rows ARRIVED and the filter above kept none of them, so there is no
+      // flow to draw. This used to return a bare `<div>` — objectui#7140.
+      //
+      // Measured in Chromium before it was changed, against a populated
+      // control that drew 1 `<svg>` / 7 `<path>`: the all-zero, all-null,
+      // all-negative and unparseable-measure tiles each rendered ONE element
+      // and nothing else (`descendantCount: 1`, `svg: 0`, `textContent: ''`),
+      // and their screenshots were byte-identical to each other. No marks, no
+      // text, no `role` — the one path in this file that put nothing at all on
+      // the page, and pixel-identical to a render that crashed. A reader could
+      // not tell a genuinely all-zero flow from a broken widget, which is the
+      // distinction every other refusal here exists to make.
+      //
+      // Gated on rows being present for the same reason `hasNoCategoryKey` and
+      // `hasNoPlottableSeries` are: handed NO rows the sentence below would be
+      // false — there is no row whose measure could be anything. That is the
+      // empty-RESULT question (objectui#7130), answered upstream in
+      // `ObjectChart` where the query outcome is known, so this arm leaves the
+      // no-rows case byte-for-byte as it was.
+      //
+      // ONE code and ONE sentence, for the reason `hasNoPlottableSeries`'
+      // docstring gives: three causes reach here — a genuinely all-zero flow,
+      // values a flow cannot represent because they are negative, and
+      // unparseable measures that `Number(…) || 0` folds to zero — and naming
+      // any ONE of them is a sentence that is false for the other two. The
+      // predicate the filter actually applies is true for all three, so the
+      // copy names THAT. No console warning either, unlike the two refusals
+      // below: those carry a diagnostic pair that does not fit on screen,
+      // whereas this message already names the key and the exact test it
+      // failed.
+      if (data.length === 0) {
+        return <div className={className} />;
+      }
+      return (
+        <ChartRefusal code="no-positive-flow" className={className}>
+          This chart has no flow to draw: no row&apos;s{' '}
+          <code className="font-mono">{dataKey}</code> is above zero.
+        </ChartRefusal>
+      );
     }
     return (
       <ChartContainer config={config} className={className} {...containerProps}>


### PR DESCRIPTION
Fixes #7140

## What was measured, before anything was written

The card asked for the blank to be **rendered and looked at first**, and said
closing it measured-and-declined would be a full success. So it was rendered
first, in a real Chromium, at `origin/main` **e8e4c4df5**, in a 520x240 tile
against a populated control — twelve tiles, one page.

| tile | descendants | svg | path | role | on screen |
|---|---|---|---|---|---|
| sankey, all values positive (CONTROL) | 26 | 1 | 7 | — | a sankey |
| sankey, every measure `0` | **1** | 0 | 0 | none | **nothing** |
| sankey, every measure `null` | **1** | 0 | 0 | none | **nothing** |
| sankey, every measure negative | **1** | 0 | 0 | none | **nothing** |
| sankey, every measure unparseable | **1** | 0 | 0 | none | **nothing** |
| sankey, one positive among zeros | 18 | 1 | 3 | — | a sankey |
| sankey, no rows at all | 1 | 0 | 0 | none | nothing |
| bar / treemap, all zero | 104 / 25 | 1 | — | — | axes, labels, legend |
| existing refusal (CONTROL) | 3 | 0 | 0 | `status` | its message |

The four blank sankey tiles hashed **byte-identical screenshots** to one
another (`b53cc8c4…`), and the control hashed differently — so the control
returns non-zero on the same instrument and the zeros are real.

**The decision this produced: fix, not decline.** Not because a blank is the
wrong picture of an empty flow, but because of what the DOM says: one element,
no marks, no text, **no `role`** — the only path in this file that puts nothing
at all on the page. A reader cannot tell a genuinely all-zero flow from a
widget that crashed, and a screen-reader user is handed literally nothing. That
is the exact distinction the file's two existing refusals exist to make, three
lines away.

## The change

`AdvancedChartImpl.tsx`, the sankey arm only. When the filter keeps no rows,
it now renders through the **`ChartRefusal` shell already in this file** — same
box, same `role="status"`, new `data-chart-error="no-positive-flow"`:

> This chart has no flow to draw: no row's `amount` is above zero.

Two boundaries are deliberate, and each is pinned by a test:

- **No rows at all still returns the bare div.** That is the empty-RESULT
  question, answered upstream in `ObjectChart` where the query outcome is
  known. "No row's measure is above zero" would be a false sentence about a
  dataset with no rows in it — measured: that tile hits the same branch today.
- **One positive row among zeros still draws.** The refusal fires on an empty
  link set, never on a thin one.

**One code, one sentence, three causes.** A genuinely all-zero flow, values a
flow cannot represent because they are negative, and measures `Number(...) || 0`
folds to zero all arrive at the same branch. The causes differ — an all-zero
pipeline is a young dataset, an all-negative one is a data-modelling mistake —
but naming any single one is a sentence that is false for the other two, so the
copy names the predicate the filter actually applies, which is true for all
three. This is the same reasoning `hasNoPlottableSeries`' own docstring gives
for its single code and two causes. No recovery is promised.

**No console warning**, unlike the two refusals below it: those carry a
diagnostic pair (`xAxisKey` plus the keys the rows carry) that does not fit on
screen. This message already names the key and the exact test it failed, and
the guard sits inside the arm — beside the filter it reads — where no hook can
be added and where it cannot drift from that filter.

## Blast radius, measured the same way

Re-rendered the same twelve tiles after the change and hashed every screenshot
against its before image:

- **CHANGED — exactly 4**: the all-zero, all-null, all-negative and
  unparseable sankey tiles.
- **UNCHANGED — the other 8, pixel-identical**: the populated control, the
  one-positive-among-zeros sankey, the no-rows sankey, bar / pie / funnel /
  treemap all-zero, and the existing `missing-category-key` refusal.

## Ablation

Direction predicted **before** the run: reverting the guard turns the four
no-positive-flow cases red and leaves the four boundary cases green.

Mutation proven on disk by **blob hash and marker count**, not by an editor's
exit code: `3105af33…` -> `baf47ce1…`, guard marker `1` -> `0`.

```
FAIL  ... when every measure is 0 / null / negative / unparseable
AssertionError: renders the explanatory placeholder: expected null not to be null
Test Files  1 failed (1)
     Tests  4 failed | 4 passed (8)
```

`4 failed | 4 passed (8)` — matching the prediction exactly. The 4 survivors
are the boundary tests, which assert behaviour the change does **not** touch;
a run that collapsed to "4 failed, 0 passed" would have meant the file stopped
loading rather than that the guard was doing the work.

Restore proven by **state**: `git diff HEAD`, `git diff --cached` and
`git status --short` all empty afterwards, worktree blob back to
`3105af33…`, marker back to `1`. No dist leg applies here — the test imports
`./AdvancedChartImpl` relatively inside its own package, so vitest reads the
mutated source directly, which the red/green flip itself demonstrates.

## Verification — union run at `c14d945b6`

| check | verdict |
|---|---|
| `pnpm exec vitest run packages/plugin-charts/` | `Test Files 36 passed (36)` / `Tests 248 passed (248)` |
| the new file alone | `Test Files 1 passed (1)` / `Tests 8 passed (8)` |
| `pnpm --filter '@object-ui/plugin-charts' run type-check` | exit 0 — and `tsc --listFiles` puts **both** changed files in the program, so this reading covers the new test file |
| `npx eslint .` in `packages/plugin-charts` | exit 0 — 0 errors, 273 warnings, all pre-existing `no-explicit-any` / `react-refresh`; 49 files linted, both changed files among them, 6 warnings on the new test (siblings carry 2-17 of the same) |
| `pnpm changeset:check` | `All workspace packages are in the changeset fixed group.` / `privatePackages declared: version=true, tag=false.` / `No changeset declares a 'major' bump.` |
| `check-control-bytes` | `OK (scanned 5922 tracked text file(s); skipped 85 binary)` |
| `check-vi-mock-specifiers` | `OK (4089 tracked source file(s), 2362 test-named; 521 carry a mock ...)` |
| `check-vi-mock-inherit` | `OK (... 117 inherit, 0 auto-mocked ...)` |
| `check-lint-coverage` | `lint coverage: 46/46 packages linted, 0 with outstanding errors` |
| `check-i18n-call-site-keys` | exit 0 |
| `check-i18n-en-drift` | `No en value changed in this range.` |
| `check-i18n-dead-keys` | exit 0 |
| `check-phantom-dependencies` | `Every in-scope import is declared by the package that publishes it.` |
| `check-package-self-import` | `No package names itself inside its own src/.` |
| `check-sdui-registration-pins` | **NOT MEASURED** — exit 2, `No console build to weigh at apps/console/dist/assets`; the gate itself says "This is exit 2, not a pass ... a run with nothing to read has measured nothing". CI builds the console and owns this reading. Declared narrowing: this diff adds no registration and touches no registration array. |

The whole-repo `pnpm lint` and the rest of the gate farm are CI's run, not
duplicated here.

## Scope

- **No i18n key added.** `AdvancedChartImpl.tsx` has no i18n call sites at all
  — both existing refusals are hardcoded English — and `check-i18n-drift`
  confirms no `en` value moved. Adding a translation hook here would be a new
  subsystem in a component whose hook count is deliberately fixed, not this
  card.
- **No shared abstraction built, promoted or extended.** The seam used is the
  `ChartRefusal` shell in this same file, which took this case **without
  modification** — it already accepts a `code`, a `className` and children.
- **#4695 is not addressed here** and its path is not touched: it is a
  cartesian chart handed no series binding, which never reaches the sankey arm.
- No public export widened, no parse accept/reject behaviour changed.

Files: `packages/plugin-charts/src/AdvancedChartImpl.tsx`,
`packages/plugin-charts/src/AdvancedChartImpl.sankeyNoPositiveFlow.test.tsx`
(new), `.changeset/7140-sankey-no-positive-flow.md` (new).

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_