### PR TITLE
fix(plugin-detail): ActivityTimeline's empty state resolves from the locale packs

### DIFF
--- a/.changeset/7142-activity-timeline-empty-i18n.md
+++ b/.changeset/7142-activity-timeline-empty-i18n.md
@@ -1,0 +1,23 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+`ActivityTimeline`'s empty state speaks the session locale (objectui#7142).
+
+The title was a raw English JSX literal — `title="No activity recorded"`, not a
+`t()` call and not an inline `defaultValue` — so it never reached the pack
+system and stayed English in all ten locales. Measured before the fix by
+rendering `activities={[]}` under a zh `I18nProvider`: the card read
+`"Activity(0)No activity recorded"`, while its sibling `RecordActivityTimeline`
+rendered `"活动(0)全部动态暂无活动记录"` from the same packs.
+
+The call site now reads `detail.noActivity`, the key the sibling already uses.
+Reusing it rather than minting a second key is a measured decision: the `en`
+pack value for that key is `'No activity recorded'`, byte-identical to the
+literal it replaces, so both surfaces were already saying the same words in
+English and a new key would have forked one sentence across ten packs for no
+copy difference. No pack was edited — the key is already translated in all ten,
+verified by reading `detail.noActivity` out of each pack object.
+
+Both routes to the box are covered: an empty `activities` array, and a
+populated timeline filtered down to a type with no entries.

--- a/packages/plugin-detail/src/ActivityTimeline.i18n.test.tsx
+++ b/packages/plugin-detail/src/ActivityTimeline.i18n.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ActivityTimeline`'s empty state speaks the session locale — objectui#7142.
+ *
+ * The title was the raw English literal `"No activity recorded"`, written
+ * straight into the JSX. It was not a `t()` call and not an inline
+ * `defaultValue`, so it never reached the pack system at all and a zh session
+ * read English. Measured before the fix by rendering `activities={[]}` under a
+ * zh `I18nProvider`: the card came out `"Activity(0)No activity recorded"`,
+ * while its sibling `RecordActivityTimeline` rendered `"活动(0)全部动态暂无活动记录"`
+ * from the same packs.
+ *
+ * The call site now reads `detail.noActivity` — the key the sibling already
+ * uses (`RecordActivityTimeline.tsx`), reused rather than forked. That reuse is
+ * a measured decision, not an assumption: the `en` pack value for the key is
+ * `'No activity recorded'`, **byte-identical** to the literal being replaced,
+ * so both surfaces were already saying the same words in English and a second
+ * key would have forked one sentence across ten packs for no copy difference.
+ *
+ * `zh` and `ar` are the load-bearing assertions. An `en`-only test would have
+ * been green *before* the fix too — the literal and the `en` pack value are the
+ * same string — so English proves nothing here. Non-Latin locales are what
+ * discriminate the pack lookup from the hardcoded literal.
+ *
+ * The provider-less case is asserted alongside them because
+ * `useDetailTranslation` is a `createSafeTranslation` hook: a host with no
+ * `I18nProvider` must get the English default from
+ * `DETAIL_DEFAULT_TRANSLATIONS`, never the raw key `detail.noActivity` in the
+ * empty box. No inline `defaultValue` is used anywhere here (objectui#3517) —
+ * the key resolves from the packs or from that defaults map.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import type { ActivityEntry } from '@object-ui/types';
+import { ActivityTimeline } from './ActivityTimeline';
+
+afterEach(() => cleanup());
+
+/** The pack values for `detail.noActivity`, read from the packs themselves. */
+const EN = 'No activity recorded';
+const ZH = '暂无活动记录';
+const AR = 'لا يوجد نشاط مسجل';
+const RAW_KEY = 'detail.noActivity';
+
+function renderEmptyIn(language: string) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <ActivityTimeline activities={[]} />
+    </I18nProvider>,
+  );
+}
+
+describe('ActivityTimeline empty state — locale resolution (objectui#7142)', () => {
+  it('reads the zh pack value under a zh session', () => {
+    renderEmptyIn('zh');
+
+    expect(screen.getByText(ZH)).toBeTruthy();
+    // The regression itself: English must not survive into a zh session.
+    expect(screen.queryByText(EN)).toBeNull();
+  });
+
+  it('reads the ar pack value under an ar session', () => {
+    renderEmptyIn('ar');
+
+    expect(screen.getByText(AR)).toBeTruthy();
+    expect(screen.queryByText(EN)).toBeNull();
+  });
+
+  it('still reads English under an en session', () => {
+    renderEmptyIn('en');
+
+    expect(screen.getByText(EN)).toBeTruthy();
+  });
+
+  it('falls back to the English default with no provider mounted', () => {
+    render(<ActivityTimeline activities={[]} />);
+
+    expect(screen.getByText(EN)).toBeTruthy();
+  });
+
+  it('never renders the raw key, provider or not', () => {
+    renderEmptyIn('zh');
+    expect(screen.queryByText(RAW_KEY)).toBeNull();
+    cleanup();
+
+    render(<ActivityTimeline activities={[]} />);
+    expect(screen.queryByText(RAW_KEY)).toBeNull();
+  });
+
+  it('translates the empty state reached by filtering, not just by an empty list', () => {
+    // The other route to this box: a non-empty timeline filtered down to a type
+    // that has no entries. Same call site, but it is the only one a host reaches
+    // with `activities` actually populated.
+    const activities: ActivityEntry[] = [
+      {
+        id: 'a1',
+        type: 'comment',
+        user: 'Ada',
+        timestamp: '2026-01-02T00:00:00.000Z',
+      } as ActivityEntry,
+    ];
+
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <ActivityTimeline activities={activities} filterable defaultFilter="delete" />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText(ZH)).toBeTruthy();
+    expect(screen.queryByText(EN)).toBeNull();
+  });
+});

--- a/packages/plugin-detail/src/ActivityTimeline.tsx
+++ b/packages/plugin-detail/src/ActivityTimeline.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { cn, Card, CardHeader, CardTitle, CardContent, DataEmptyState } from '@object-ui/components';
 import { Activity, Edit, PlusCircle, Trash2, MessageSquare, ArrowRightLeft, Filter } from 'lucide-react';
 import type { ActivityEntry } from '@object-ui/types';
+import { useDetailTranslation } from './useDetailTranslation';
 
 export type ActivityFilterType = ActivityEntry['type'] | 'all';
 
@@ -92,6 +93,7 @@ export const ActivityTimeline: React.FC<ActivityTimelineProps> = ({
   defaultFilter = 'all',
   className,
 }) => {
+  const { t } = useDetailTranslation();
   const [activeFilter, setActiveFilter] = React.useState<ActivityFilterType>(defaultFilter);
 
   const filteredActivities = React.useMemo(() => {
@@ -135,7 +137,7 @@ export const ActivityTimeline: React.FC<ActivityTimelineProps> = ({
         )}
 
         {filteredActivities.length === 0 ? (
-          <DataEmptyState title="No activity recorded" className="py-6" />
+          <DataEmptyState title={t('detail.noActivity')} className="py-6" />
         ) : (
           <div className="relative">
             {/* Timeline line */}


### PR DESCRIPTION
Fixes #7142

`ActivityTimeline`'s empty-state title was a raw English JSX literal — `title="No activity recorded"`, not a `t()` call and not an inline `defaultValue` — so it never reached the pack system and stayed English in all ten locales. It now reads `detail.noActivity` through `useDetailTranslation`, the hook its sibling already uses.

Three lines of production change: the hook import, the `const { t } = useDetailTranslation();` call, and the title expression. No pack was edited.

## The key-reuse decision was measured, not assumed

The card and the dispatch both flagged this as the thing to settle first: `RecordActivityTimeline.tsx:415` already renders `title={emptyLabel ?? t('detail.noActivity')}`, but that proves a key **exists**, not that the two surfaces want the same words. So both were rendered empty and read.

```
[en] ActivityTimeline       => "Activity(0)No activity recorded"
[en] RecordActivityTimeline => "Activity(0)All ActivityNo activity recorded"
[zh] ActivityTimeline       => "Activity(0)No activity recorded"      <- the defect
[zh] RecordActivityTimeline => "活动(0)全部动态暂无活动记录"
```

The `en` pack value for `detail.noActivity` is `'No activity recorded'` — **byte-identical** to the literal being replaced. The two surfaces were already saying exactly the same words in English, so reuse changes no copy in any locale, while a second key would fork one sentence across ten packs for zero copy difference. Reuse it is.

## The key is genuinely translated in all ten packs

Read out of the pack objects directly rather than grepped — the packs are nested (`detail: {` … `noActivity:`), so a dotted-key grep for `detail.noActivity` returns **zero** against a pack that defines it. Two controls ran on the same instrument: `detail.noRelatedRecords` and `detail.loading` returned present in all ten (positive), and `detail.zzzNotAKeyEver` returned absent in all ten (negative, proving the probe can report absence).

```
en  "No activity recorded"          zh  "暂无活动记录"
ja  "アクティビティの記録なし"          ko  "기록된 활동 없음"
de  "Keine Aktivitäten aufgezeichnet" fr  "Aucune activité enregistrée"
es  "Sin actividad registrada"      pt  "Nenhuma atividade registrada"
ru  "Нет зарегистрированной активности"  ar  "لا يوجد نشاط مسجل"
```

`DETAIL_DEFAULT_TRANSLATIONS` already carries the byte-identical English row, so the provider-less path is unchanged and `defaults-maps-mirror-en-pack` stays green. No inline `defaultValue` anywhere (#3517).

## Test

`packages/plugin-detail/src/ActivityTimeline.i18n.test.tsx`, six cases: zh, ar, en, no-provider, never-the-raw-key, and the second route into the box — a populated timeline filtered down to a type with no entries.

`zh` and `ar` are the load-bearing half. An `en`-only assertion would have been **green before the fix too**, since the literal and the `en` pack value are the same string; only a non-Latin locale discriminates a pack lookup from a hardcoded literal.

### Ablation

Predicted before running: restoring the literal turns exactly the three locale-discriminating cases red and leaves the other three green. Observed `Tests 3 failed | 3 passed (6)` — the passing count is quoted deliberately, since a suite collapsed to zero survivors also shows red and would look stronger.

Mutation proven on disk by marker count in both directions (`t('detail.noActivity')` 1 to 0, `title="No activity recorded"` 0 to 1) and by blob hash (`6bb6ce32` to `678d2e03`), never by an editor's exit code. Restore proven by state — `git diff HEAD`, `git diff --cached` and `git status --short` all empty, and the blob back to `6bb6ce32` — never by a trap firing. No rebuild leg applies: the test imports `./ActivityTimeline` relatively and the root vitest config aliases `@object-ui/i18n` to `packages/i18n/src`, so nothing in the closure resolves through `dist/`.

## Verification

All readings below are on `0e210de56`, the final commit.

Green:

- `pnpm exec vitest run packages/plugin-detail/ packages/i18n/src/__tests__/all-locales-key-parity.test.ts packages/app-shell/src/__tests__/defaults-maps-mirror-en-pack.test.tsx` — `Test Files 123 passed (123)`, `Tests 1157 passed (1157)`
- `check:i18n-keys` — "Every in-scope call-site key resolves against the en pack (2845 keys) … no call site carries a literal fallback beside itself" (2604/2604 literal keys resolve)
- `check:i18n-drift` — "No en value changed in this range."
- `check:i18n-dead-keys` — report, not a gate; `detail.noActivity` gains a call site here rather than losing one
- `check-changeset-presence` — "1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"
- `check-changeset-no-major` — "No changeset declares a `major` bump." (quoted rather than predicted)
- `type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — exit 0. Confirmed it actually covers the diff: `--listFiles` puts `ActivityTimeline.tsx` in the main pass and `ActivityTimeline.i18n.test.tsx` in the `tsconfig.test.json` pass, with a present-file control and a nonexistent-path control both behaving.
- `eslint .` in `packages/plugin-detail` — 0 errors. The one warning on `ActivityTimeline.tsx` (`Filter` imported unused, line 11) is pre-existing on `origin/main` and untouched here.
- `check:control-bytes`, `check:self-import`, `check:esm-specifiers`, `check:phantom-deps`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:dist-completeness`, `check:side-effects-array`

NOT MEASURED — recorded as the absence of a reading, not as passes:

- `check:sdui-registration-pins` — exit 2, "a run with nothing to read has measured nothing. Build the console first". The console build needs 28 unbuilt packages; that full-monorepo build is CI's, and this diff registers no SDUI component.
- `check:eager-closure` — exit 2, "a broken gauge, not a sensitive gate": no `apps/console/dist/eager-closure.json` locally. Same cause.
- `check:readme-exports` — the gate declares its own run void ("the population COLLAPSED — this run proves nothing") while packages are unbuilt. Narrowed and declared: after building `@object-ui/plugin-detail`, its README dropped out of the unjudged list (1 hit to 0), so this package's slice is judged; the residual collapse is the other 24 unbuilt packages.

`type-check` first came back exit 2 with TS2307 across every `@object-ui/*` — an unbuilt dependency closure, which is a non-reading rather than a red. The closure was built (`pnpm --filter '@object-ui/plugin-detail^...' build`) and it was re-run to get the exit 0 above.

## Scope

Only the empty-state title, per the dispatch ruling. Sweeping the file found the component uses **no** translation hook at all on `origin/main` — 18 further hardcoded English literals (relative timestamps, the six filter chips, the `Activity` card title, the filter `aria-label`, the six activity-description sentences), 12 of which already have pack keys sitting unused. That inventory is filed as #7149, unassigned, rather than folded in here.

No public export added, no accept/reject behaviour changed — contract clause 2 stays disengaged. No `role` was added, removed or aligned on the `DataEmptyState` call site; that is #7132's decision and it is already made.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_