### PR TITLE
test(components): drop the undeclared `value` key from the two menu icon transcriptions

### DIFF
--- a/.changeset/menu-icon-test-phantom-value.md
+++ b/.changeset/menu-icon-test-phantom-value.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only change: the two overlay-menu icon suites (`context-menu-item-icon`,
+`dropdown-menu-item-icon`) no longer transcribe the undeclared `value` key from
+the catalog fixtures objectui#7072 cleaned, and each block now records why the
+key is absent. No published source and no rendered behaviour changes.

--- a/packages/components/src/__tests__/context-menu-item-icon.test.tsx
+++ b/packages/components/src/__tests__/context-menu-item-icon.test.tsx
@@ -164,13 +164,23 @@ describe('ui:context-menu item icon resolution (objectui#6278)', () => {
     // specimen AND a declared AI few-shot retrieval source, so every name it
     // ships must draw. Spelling drift is the gate's job (see the header);
     // this row is the renderer's half of that contract.
+    //
+    // ⛔ No `value` key here, and its absence is deliberate. These items are a
+    // TRANSCRIPTION of the fixture, so a key the fixture does not carry is a
+    // spelling the next author copies out of here. No arm of the `MenuItem`
+    // union declares `value` — objectui#6523 narrowed that union on purpose —
+    // and no menu renderer reads it; objectui#7072 deleted it from the four
+    // catalog fixtures and objectui#7102 from these copies. Re-adding it would
+    // NOT go red: `MenuItemSchema`'s arms are non-strict `z.object`s, so zod
+    // strips the key and reports success. Hence this note rather than a pin —
+    // a parse-based pin here could not fail.
     it('draws a distinct glyph for each of the four authored names', () => {
       renderMenu([
-        { label: 'Copy', value: 'copy', icon: 'copy' },
-        { label: 'Cut', value: 'cut', icon: 'scissors' },
-        { label: 'Paste', value: 'paste', icon: 'clipboard' },
+        { label: 'Copy', icon: 'copy' },
+        { label: 'Cut', icon: 'scissors' },
+        { label: 'Paste', icon: 'clipboard' },
         { separator: true },
-        { label: 'Delete', value: 'delete', icon: 'trash' },
+        { label: 'Delete', icon: 'trash' },
       ]);
       for (const [label, name] of [
         ['Copy', 'copy'],

--- a/packages/components/src/__tests__/dropdown-menu-item-icon.test.tsx
+++ b/packages/components/src/__tests__/dropdown-menu-item-icon.test.tsx
@@ -117,11 +117,19 @@ describe('ui:dropdown-menu item icon resolution (objectui#5930)', () => {
     // The fixture is a live specimen AND a declared AI few-shot retrieval
     // source, so every name it ships must actually draw. `square-pen` is the
     // identity-derived live key for the retired `edit` this fixture carried.
+    //
+    // ⛔ No `value` key here, and its absence is deliberate — same reason as
+    // the twin block in `context-menu-item-icon.test.tsx`, which carries the
+    // long form. In short: no arm of the `MenuItem` union declares `value`
+    // (objectui#6523), no menu renderer reads it, objectui#7072 removed it
+    // from the fixtures and objectui#7102 from these copies — and re-adding
+    // it could not go red, because `MenuItemSchema` is non-strict and strips
+    // the key while reporting success.
     it('draws a glyph for every icon name it declares', () => {
       renderMenu([
-        { label: 'Edit', value: 'edit', icon: 'square-pen' },
-        { label: 'Copy', value: 'copy', icon: 'copy' },
-        { label: 'Delete', value: 'delete', icon: 'trash' },
+        { label: 'Edit', icon: 'square-pen' },
+        { label: 'Copy', icon: 'copy' },
+        { label: 'Delete', icon: 'trash' },
       ]);
       for (const label of ['Edit', 'Copy', 'Delete']) {
         expect(glyphFor(label), `${label} should draw a glyph`).not.toBeNull();


### PR DESCRIPTION
Fixes #7102

Two overlay-menu icon suites each carry an inline transcription of a catalog fixture, and both copies still spelled `value` — a key **no arm of the `MenuItem` union declares** (#6523 narrowed that union deliberately) and **no menu renderer reads**. #7072 removed the key from the four catalog fixtures; these copies sat outside that card's fenced surface, so the phantom spelling survived right next to the renderer as copyable example code.

## What changed

Deleted the 4 + 3 `value` entries, and gave each block a note recording why the key is absent.

| file | entries dropped |
|---|--:|
| `packages/components/src/__tests__/context-menu-item-icon.test.tsx` | 4 |
| `packages/components/src/__tests__/dropdown-menu-item-icon.test.tsx` | 3 |

The context-menu literal is now **key-for-key identical** to `basic-context-menu.json`'s `items` — checked mechanically, not by eye:

```
fixture items : ["icon,label","icon,label","icon,label","separator","icon,label"]
test    items : ["icon,label","icon,label","icon,label","separator","icon,label"]
IDENTICAL     : true
```

## Premise re-derived on today's `main`

The card measured at `2c3cd1b`. Re-measured on `origin/main` **`e8e4c4df5f51fc3a1d5ffc678881d3480f97a70e`**: the two blocks are still at lines 169-173 and 122-124, unmoved.

**#7072 has landed** — closed as completed by PR #7103, merged. Verified against the tree rather than the card: all four overlay-menu fixtures now grep to `0` occurrences of `"value"`, against a live control of `4` for `"label"` in the same two files. So the card's future tense is now past tense: the comments were **already** false on arrival, not prospectively. The PR description says so rather than repeating the card's framing.

## Nothing was red, and nothing is red now — stated, not assumed

The literals go to a local `renderMenu(items: any[])` helper. Neither file imports `MenuItem` or `MenuItemSchema` (zero occurrences; control — sibling suites in the same directory *do* import from `@object-ui/types`). Both suites pass identically:

```
before:  Test Files  2 passed (2)   Tests  15 passed (15)
after:   Test Files  2 passed (2)   Tests  15 passed (15)
```

Same passing count, not merely "green" — a suite collapsed to zero tests also reports no failures.

## Why a pin was considered and rejected — decided by measurement

The obvious guard is "parse these literals against `MenuItemSchema`". **Measured: that pin could never fail.** Both arms are bare, non-strict `z.object`s, so zod strips the excess key and reports success:

```
SUBJECT  {label,value,icon}        success=true   parsed={"label":"Copy","icon":"copy"}
CONTROL+ {label,icon} declared     success=true   parsed={"label":"Copy","icon":"copy"}
CONTROL- {label,type:"separator"}  success=false
CONTROL- {label:42} wrong type     success=false
```

The subject and the clean shape are **indistinguishable after parse**, while the two negative controls prove the instrument can say no — so this is a real reading, not a dead probe. A parse-based pin would be a phantom check: green before the fix, green after, green again if `value` came back.

The remaining options were a string-absence assertion over the test's own literal (self-referential — its only failure mode is an edit to the very lines it guards) or deriving the literal from the fixture at test time. The latter is the genuinely load-bearing guard, but it is a different shape in a different package: the repo's own precedent, `packages/types/src/__tests__/timeline-catalog-fixture-migrated.test.ts`, reads a catalog fixture from `packages/types` precisely because *"this package's test tsconfig carries no node types"*. That is its own card, not this one.

So the guard here is a **comment**, which is the honest instrument for a defect nothing mechanical can catch: the deletion alone is invisible, and a note naming the refusal is what stops the next author (or model) from helpfully adding the key back.

## The census the card asked for

The card flagged its own count as *"bounded by that query, not a census."* Widened, with live controls throughout. Across `packages/`, **exactly two** test files transcribe a catalog fixture inline while carrying a key undeclared for that node type — the two in this PR.

Two independent instruments, both non-zero:

- **Naming instrument** — all 405 catalog fixture basenames grepped against every test under `packages/`: **28 hits across 9 files**, not a broken query.
- **Shape instrument**, which does not need a test to name its fixture — all 16 files under `packages/` referencing a menu renderer, grepped for a `value:` key: only these same two files carry it on a menu item. The other hits are `{ type: 'text', value: ... }`, already declared and pinned by #6150.

The discriminating controls are what make the count trustworthy:

| file | transcribes a fixture | verdict |
|---|---|---|
| `components/command-item-icon.test.tsx` | yes, 2 fixtures, **carrying `value`** | **clean** — `CommandItem` *declares* `value` (`types/src/form.ts:1409`, `zod/form.zod.ts:84`) |
| `components/breadcrumb-item-icon.test.tsx` | yes, exactly | clean — every key declared |
| `cli/check-validity-recogniser.test.ts` | yes, 2 fixtures | clean — the invalid `variant: 'small'` is the subject under test, and says so |
| `plugin-timeline/timeline-object-bound-gantt-refusal.test.tsx` | yes, honestly labelled "Trimmed" | clean — `variant` is documented on gantt rows |
| `types/timeline-catalog-fixture-migrated.test.ts` | **reads the real file** | clean — the pattern that has no drift class |

The `command` row is the control that matters: the **same key spelling**, opposite verdict. The instrument distinguishes a phantom key from a declared one rather than pattern-matching on the string.

## Surfaced, and deliberately left alone

- **#7151** — filed from this census. `DashboardGridLayout.legacyRetired.test.tsx:52` claims a row is *"Byte-for-byte `filtered-dashboard.json` → `widgets[0]`"*; that fixture's `widgets[0]` is the ADR-0021 `options` shape and carries none of the three keys the row names. Different package, and the repair needs a choice between three routes, so it is a card and not a rider here.
- **#7101** — the `variant: "destructive"` sibling on `with-icons.json` stays open and untouched; the card records it as needing a decision. Out of scope for this PR by dispatch.
- `examples/schema-catalog/src/schemas/` — #7072's fenced surface, not entered.

## Verification

Union re-run **after** the final commit, at `0883c0fc3`:

- `pnpm exec vitest run packages/components/` → **221 files, 2027 tests, all passing** (vitest project **`dom`** — these are `.tsx` under `packages/**` and not in `heavyDomTests`). Run from the repo root with root-relative paths; a package-directory invocation is refused outright by this repo's own guard for #3378, which caught one attempt here — recorded as *not measured*, not as a pass.
- `type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) and `lint` (plain per-package `eslint .`) → exit 0; `0 errors, 934 warnings`, all pre-existing. Coverage confirmed rather than assumed: `tsc -p tsconfig.test.json --listFiles` puts **both** edited files in a 1894-file program (control: another package's tests, 0).
- 11 gates green, each quoting its own verdict line: `check-changeset-presence` · `-no-major` · `-fixed` · `-overwrite` · `check-control-bytes` · `check-lucide-icon-record-names` · `check-vi-mock-specifiers` · `check-vi-mock-inherit` · `check-shell-escape-residue` · `check-type-check-coverage` · `check-lint-coverage`.

**Changeset:** the gate was run, not predicted. It refused the change, and its own text names empty frontmatter as *"the explicit exemption and a complete answer to this gate"* for a release-nothing change. Added on that basis, and re-run:

```
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s).
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_