### PR TITLE
docs(plugin-timeline): scope `spellGanttDateValue`'s totality claim to what is exercised

### DIFF
--- a/.changeset/spellgantt-revoked-proxy-exclusion.md
+++ b/.changeset/spellgantt-revoked-proxy-exclusion.md
@@ -1,0 +1,11 @@
+---
+---
+
+Docs and tests only for `@object-ui/plugin-timeline`. `spellGanttDateValue`'s
+docblock claimed every branch was total; measured in-render, `Array.isArray`
+throws on a revoked `Proxy`, so the claim is now scoped to the input set that
+is actually exercised and the exclusion is pinned as rows in the existing
+adversarial set. The same measurement falsified the wider claim that
+`Array.isArray` is the last non-total operation on the gantt date path — five
+reads upstream of the helper throw first, recorded in objectui#7153. No
+published behaviour changes.

--- a/packages/plugin-timeline/src/__tests__/timeline-gantt-date-brand-7027.test.tsx
+++ b/packages/plugin-timeline/src/__tests__/timeline-gantt-date-brand-7027.test.tsx
@@ -30,6 +30,17 @@
  * about being a Date, each one asserted to reach a DEFINED outcome. That is
  * what #7026 gave the speller and what the gate did not have.
  *
+ *   5. objectui#7036: the gate's repair held, and the SPELLER still was not
+ *      total — `Array.isArray` throws on a revoked `Proxy`. That card did not
+ *      repair it; it ruled the exclusion STATED AND EXERCISED, which is what
+ *      `pin 4` at the foot of this file is. It also measured that the card's
+ *      own headline was wrong: `Array.isArray` is not the last non-total
+ *      operation on the PATH, only inside that function (objectui#7153).
+ *
+ * ⚠️ So this file's input set is not a claim of totality either. It is the
+ * boundary that has actually been exercised, and the sixth card will be the
+ * one that says where it ends.
+ *
  * ## What "a defined outcome" means here — two kinds, and never a third
  *
  * ⚠️ Not every row below is a refusal, and forcing them all to be one would
@@ -180,6 +191,17 @@ class HijackedGetTime extends Date {
     throw new Error('getTime hijacked by the authored document');
   }
 }
+
+/**
+ * A REVOKED proxy — the one input `spellGanttDateValue` is documented NOT to
+ * survive (objectui#7036). `Proxy.revocable` is the only way to spell it, and
+ * nothing in any package `src/` calls it: this is a test-only value.
+ */
+const revokedProxy = (target: object = {}) => {
+  const { proxy, revoke } = Proxy.revocable(target, {});
+  revoke();
+  return proxy as unknown;
+};
 
 /** An object whose `Symbol.toStringTag` is a throwing getter. */
 const throwingToStringTag = () =>
@@ -345,5 +367,76 @@ describe('pin 3 — the ACCEPT SET is unchanged: #6781’s ruling does not move 
       expect(diagnosticOf(container) ?? '', `${label} was accepted`).toContain(PATH);
       expect(barCountOf(container), `${label} drew a bar`).toBe(0);
     }
+  });
+});
+
+describe('pin 4 — the ONE documented EXCLUSION, exercised not asserted (objectui#7036)', () => {
+  /**
+   * `spellGanttDateValue`'s `Array.isArray` is not total: `IsArray` recurses
+   * into `[[ProxyTarget]]` and a REVOKED proxy has none, so it throws while
+   * naming the value. objectui#7036 adjudicated this as STATED-AND-EXERCISED
+   * rather than repaired, on three grounds recorded in that function's
+   * docblock: it is unreachable from an authored document (JSON cannot spell
+   * a proxy), a `catch` here would SUBSTITUTE `an object` for a failure
+   * rather than read anything the way `isDate`'s catch does, and it would not
+   * make the PATH total anyway — five reads that FETCH the date throw first
+   * (objectui#7153).
+   *
+   * ## Why a THROW is pinned here, and why not with a bare `toThrow()`
+   *
+   * This file exists because four prose totality claims on this path were
+   * each falsified by the next card's measurement. A docblock sentence saying
+   * "except a revoked proxy" would be a fifth claim of the same species. The
+   * rows below make the exclusion a MEASUREMENT instead, and they assert the
+   * throw's own MESSAGE: a bare `toThrow()` passes for any error from any
+   * line, so it would stay green if the crash moved to `instanceof`, to
+   * `Object.prototype.toString`, or upstream into the row walk — which is
+   * precisely what has happened on this path four times. The message names
+   * both the operation (`IsArray`) and the cause (`revoked`), so the pin
+   * fails if the site moves and fails if the exclusion is ever repaired,
+   * either of which must come with a docblock edit.
+   */
+
+  const REVOKED_ISARRAY = /Cannot perform 'IsArray' on a proxy that has been revoked/;
+
+  // Every target shape: the throw is about revocation, not about the target.
+  const targets: [string, () => object][] = [
+    ['{}', () => ({})],
+    ['[]', () => []],
+    ['a function', () => function noop() {}],
+    ['a real Date', () => new Date('2024-03-01')],
+  ];
+
+  for (const [label, makeTarget] of targets) {
+    it(`a revoked Proxy over ${label} throws at \`Array.isArray\`, by design`, () => {
+      expect(() =>
+        gantt({ items: rowWith({ startDate: '2024-01-01', endDate: revokedProxy(makeTarget()) }) }),
+      ).toThrow(REVOKED_ISARRAY);
+    });
+  }
+
+  it('a revoked Proxy pinned as `minDate` reaches the same site', () => {
+    // The pinned limb takes the same speller, so the exclusion is not
+    // confined to a row item. `value &&` is ToBoolean and does not throw.
+    expect(() =>
+      gantt({
+        items: rowWith({ startDate: '2024-01-01', endDate: '2024-03-01' }),
+        minDate: revokedProxy(),
+      }),
+    ).toThrow(REVOKED_ISARRAY);
+  });
+
+  it('CONTROL — a LIVE Proxy is still NAMED `an object`, so the rows above are about REVOCATION', () => {
+    // Without this the four rows above would also pass if the whole gantt
+    // branch had broken. `typeof` does not separate a revoked proxy out
+    // either: it answers `'object'` for one, exactly as it does here.
+    const { container } = gantt({
+      items: rowWith({ startDate: '2024-01-01', endDate: new Proxy({}, {}) }),
+    });
+
+    const text = diagnosticOf(container) ?? '';
+    expect(text).toContain(PATH);
+    expect(text).toContain('is an object');
+    expect(barCountOf(container)).toBe(0);
   });
 });

--- a/packages/plugin-timeline/src/renderer.tsx
+++ b/packages/plugin-timeline/src/renderer.tsx
@@ -427,7 +427,7 @@ const isDate = (value: unknown): value is Date => {
  * worse than naming a category: it costs the author a search for a fault that
  * is not there.
  *
- * ## The branches, and why each is total
+ * ## The branches, and how far each one's totality reaches
  *
  * - `string` -> quoted (#6759's pin; empty and space-padded stay visible).
  * - `undefined` / `null` -> themselves (#6759 / #6770's pins; how an author
@@ -455,7 +455,10 @@ const isDate = (value: unknown): value is Date => {
  *   `Array.isArray` and `typeof`, which read no author-controlled property.
  *   Deliberately NOT `Object.prototype.toString.call`: that consults
  *   `Symbol.toStringTag`, which can be a throwing getter (measured), so the
- *   more informative spelling is the non-total one.
+ *   more informative spelling is the non-total one. `Array.isArray` reads no
+ *   property and is STILL not total — on a revoked `Proxy` it throws. That is
+ *   the one exclusion this docblock claims, and it is stated and exercised
+ *   rather than repaired: see the objectui#7036 note below.
  *
  * All eight `typeof` results are covered and no branch falls through to author
  * code. The single reflective operation it performs is the Date test, which is
@@ -470,6 +473,69 @@ const isDate = (value: unknown): value is Date => {
  * 7fc5c3c12). Both sites now ask `isDate`, which is total, so the shared
  * operation adds no throw site because it HAS none — not because the gate
  * absorbed it first.
+ *
+ * ⚠️ objectui#7036 — READ THE TWO PARAGRAPHS ABOVE AS A SEQUENCE, NOT AS A
+ * CONCLUSION. Each was written as the settled answer and the next card's
+ * measurement moved it (#6759 -> #6905 -> #6907 -> #7027). This is the fifth
+ * entry and it is deliberately NOT a fifth claim of totality. The sentence it
+ * falsifies is the one directly above the #7027 note: this function DOES add
+ * a throw site the accept gate does not have, and it is `Array.isArray`.
+ *
+ * THE EXCLUSION, measured in-render on dd35800af through `TimelineRenderer`
+ * itself — not a replica of these branch bodies:
+ *
+ *     endDate: <a revoked Proxy, over any target>
+ *         -> THREW TypeError: Cannot perform 'IsArray' on a proxy that has
+ *            been revoked                     (here, at `Array.isArray`)
+ *
+ * `IsArray` recurses into `[[ProxyTarget]]`, which a revoked proxy does not
+ * have, so this throws on an INTERNAL condition while still reading no
+ * author-controlled property. All four target shapes throw (`{}`, `[]`, a
+ * function, a real `Date`), and so does a revoked proxy pinned as
+ * `schema.minDate` / `maxDate`. `typeof` does not separate it out — it
+ * answers `'object'` (or `'function'`) without throwing.
+ *
+ * WHY IT IS LEFT, and none of the three reasons is cost:
+ *
+ * 1. It is not reachable from an authored document — ObjectUI metadata is
+ *    JSON and JSON cannot spell a proxy. Re-swept on dd35800af: zero
+ *    `Proxy.revocable` in the repo, zero `Object.setPrototypeOf` calls in
+ *    any package `src/`, each read beside a live control on the same
+ *    instrument
+ *    (52 `Proxy` mentions, 19 `Object.assign` calls) so the zeros are
+ *    readings and not a broken query. The `__proto__` hits are denylists.
+ * 2. A `catch` here would be SUBSTITUTION, not a read — the opposite of
+ *    `isDate`'s. `isDate` catches because the language exposes the
+ *    `[[DateValue]]` bit ONLY by throwing, so its catch IS the read. A
+ *    revoked proxy has no array-ness to read, so catching would discard a
+ *    failure and substitute `an object`: consumer-side tolerance, which is
+ *    what #6750 and #6759 both refused. A second `catch` beside `isDate`'s
+ *    would erase the distinction this file is built on.
+ * 3. It would buy no invariant, because of the paragraph below.
+ *
+ * ⛔ `Array.isArray` IS NOT THE LAST NON-TOTAL OPERATION ON THE GANTT DATE
+ * PATH, and this function cannot make the path total. Measured in the same
+ * run: five further crash sites, every one of them reached BEFORE this
+ * function is entered, in the property reads that FETCH the date out of the
+ * authored document (`findUnusableGanttDate`'s `items[i]?.items` and
+ * `rowItems[j]?.[key]`) —
+ *
+ *     items[0].items[0] with a throwing `endDate` getter -> THREW
+ *     items[0].items[0] is a revoked Proxy               -> THREW
+ *     items[0]          is a revoked Proxy               -> THREW
+ *     items[0].items    is a revoked Proxy               -> THREW
+ *     items[0] with a throwing `items` getter            -> THREW
+ *
+ * They are the same reachability class (JSON spells neither a getter nor a
+ * proxy) and they are enumerated in objectui#7153 rather than repaired here —
+ * they are a different function's surface. The true and much narrower
+ * sentence is that `Array.isArray` is the last non-total operation INSIDE
+ * THIS FUNCTION.
+ *
+ * ⚠️ Whatever totality this docblock claims is bounded by an EXERCISED input
+ * set — the rows in `__tests__/timeline-gantt-date-brand-7027.test.tsx`,
+ * which now include the revoked proxy — and by nothing else. On this path
+ * prose has been a hypothesis four times running.
  *
  * ## What this deliberately does NOT do
  *


### PR DESCRIPTION
Fixes #7036

Took the card's **second** branch: the docblock overclaimed, so the claim is corrected and the exclusion is exercised. `Array.isArray` is left exactly as #6907 chose it. Measured on `dd35800af`; verified on `e615be490`.

## Why not "make the array test total"

Three reasons, none of them cost. A `try`/`catch` around `Array.isArray` would be four lines.

1. **Unreachable from an authored document.** ObjectUI metadata is JSON, and JSON cannot spell a proxy. Re-swept on `dd35800af`, each zero beside a live control on the same instrument: zero `Proxy.revocable` in the repo (control: 52 `Proxy` mentions in package sources), zero `Object.setPrototypeOf` calls in package sources (control: 19 `Object.assign` calls). The three non-comment `__proto__` hits are denylists that block it.
2. **The catch would be substitution, not a read.** `isDate`'s catch is argued in its own docblock as *the read* — the language exposes the `[[DateValue]]` bit only by throwing, so there is no other way to ask. A revoked proxy has no array-ness to read: catching would discard a failure and substitute `an object`. That is the consumer-side tolerance #6750 and #6759 both refused, and a second `catch` sitting beside `isDate`'s would erase the distinction this file is built on.
3. **It would buy no invariant** — see the next section.

## The card's headline is false as measured

#7036's title says `Array.isArray` is *the last non-total operation on the gantt date path*. It is not. It is the last one **inside `spellGanttDateValue`**. Measured in-render through the real `TimelineRenderer`, five further crash sites exist and every one runs **before** that helper is entered — in the property reads that fetch the date out of the document (`findUnusableGanttDate`'s `items[i]?.items` and `rowItems[j]?.[key]`; `calculateDateRange` repeats both):

| input | outcome |
|---|---|
| `items[0].items[0]` with a throwing `endDate` getter | THREW `Error: endDate getter throws` |
| `items[0].items[0]` is a revoked `Proxy` | THREW `TypeError: Cannot perform 'get' on a proxy that has been revoked` |
| `items[0]` is a revoked `Proxy` | THREW same |
| `items[0].items` is a revoked `Proxy` | THREW same |
| `items[0]` with a throwing `items` getter | THREW `Error: items getter throws` |
| CONTROL — an ordinary row/item | drew 1 bar |

Enumerated in #7153 (p3, same reachability class), not repaired here — different function, outside this card's ruled scope.

## What was measured, and how

The card measured with *"a node probe replicating both functions' branch bodies verbatim (not measured in-render)"*. This PR did not use a replica: every reading below comes from `render(<TimelineRenderer …>)` driving the real code.

```
endDate: <a revoked Proxy over {} / [] / a function / a real Date>
    -> THREW TypeError: Cannot perform 'IsArray' on a proxy
                        that has been revoked        (at Array.isArray)
schema.minDate: <a revoked Proxy>   -> THREW, same site
CONTROL  endDate: new Proxy({}, {}) -> NAMED "is an object"
CONTROL  endDate: ['2024-01-01']    -> NAMED "is an array"
CONTROL  endDate: new Date(...)     -> drew 1 bar
```

Two facts the card did not have: a revoked proxy over a **real `Date`** also lands here (`isDate` refuses it first, so it falls through to `Array.isArray`), and the **pinned `minDate` / `maxDate`** limb reaches the same site.

**Not a regression, confirmed.** On `7fc5c3c12` the value crashed at `isGanttDateType`'s `value instanceof Date` (`instanceof` walks `[[GetPrototypeOf]]`, which throws on a revoked proxy — measured), and that tree's `spellGanttDateValue` carried a second `instanceof` plus the same `Array.isArray`. #7027 did not introduce anything: it cut this input's throw sites from three to one.

## The change

- `packages/plugin-timeline/src/renderer.tsx` — docblock only, no executable line moved. The section heading no longer says every branch is total; the "everything else" bullet carries the exclusion inline; a `⚠️ #7036` note follows #7027's, naming the sentence it falsifies, the measurement, the three reasons, and the five upstream sites. The falsified sentences above it are kept verbatim — the file's own idiom (#7027 did the same), so the chain stays readable.
- `packages/plugin-timeline/src/__tests__/timeline-gantt-date-brand-7027.test.tsx` — `pin 4`, six rows in the **existing** set (no new file), plus a header entry for the fifth claim.

**No new confident totality sentence.** Everything the docblock now claims is explicitly bounded by the exercised input set, because prose has been the failure mode on this path four times running. That is also why the exclusion is pinned rather than merely written: a sentence would be a fifth claim of the same species.

## Tests

`pnpm exec vitest run packages/plugin-timeline/` on `e615be490` — **19 files, 226 passed** (220 before; `pin 4` adds 6). The two source blobs are byte-identical between the tested commit and the head above.

Rows assert the throw's **message**, never a bare `toThrow()`: a bare one passes for any error from any line, so it would stay green if the crash moved to `instanceof`, to `Object.prototype.toString`, or upstream into the row walk — which is exactly what has happened here four times. A live-proxy CONTROL row keeps the four throw rows from passing on a wholly broken gantt branch.

**Ablation.** Predicted before running: applying the repair this card declined (wrapping `Array.isArray` in `try`/`catch`) turns the 5 throw rows red and leaves the CONTROL green — 10 passed / 5 failed of 15. Observed exactly that. Mutation proven on disk by injected-marker count (0 → 1) and blob hash (`5acd179b…` → `bcd53d6a…`), never by an editor's exit code. No rebuild was needed: the suite imports `../renderer` by relative path, so it resolves to source, not through the package's `exports` into `dist/`. Restore proven by state — `git diff HEAD`, `git diff --cached` and `git status --short` all empty, the on-disk blob back to `5acd179b…`, marker count 0.

## Gates run locally (union, on `e615be490`)

`check-changeset-presence` · `check-changeset-no-major` · `check-changeset-fixed` · `check-control-bytes` · `check-lint-coverage` · `check-type-check-coverage` · `check-i18n-call-site-keys` · `check-i18n-en-drift` — all exit 0.

Changeset gate verdict, verbatim and not predicted:

```
✅  2 source file(s) of 1 released package(s) changed, and this change declares 1
    changeset(s): .changeset/spellgantt-revoked-proxy-exclusion.md.
    Every one of them has an EMPTY frontmatter — declared as releasing nothing,
    which is the explicit exemption and a complete answer to this gate.
```

`eslint .` in `packages/plugin-timeline` — exit 0, 0 errors (97 warnings, all pre-existing and none on added lines). `pnpm --filter @object-ui/plugin-timeline run type-check` — exit 0, and `tsc --listFiles` confirms both edited files are actually in the program (1369 files), so that green is a reading rather than an exclusion.

Repo-wide `pnpm lint` was **not** run locally; CI owns that farm.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_