### PR TITLE
test(plugin-dashboard): the legacy-retired rows say what they really are, and the fixture claim becomes a read

### DIFF
--- a/.changeset/7151-legacy-retired-provenance.md
+++ b/.changeset/7151-legacy-retired-provenance.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only change to `plugin-dashboard`'s legacy-retired suite; no published behaviour changes.
+
+The two annotated `it.each` rows in `DashboardGridLayout.legacyRetired.test.tsx` introduced their literals with provenance comments naming a schema-catalog fixture. Both were true when written and were invalidated 66 minutes later by the catalog migration off the retired shape (objectui#4600). The annotations now state the measured history and say plainly that the rows no longer carry the independent-corpus property, and the relationship they assert is derived at test time from the fixture instead of restated in prose.

--- a/packages/plugin-dashboard/src/__tests__/DashboardGridLayout.legacyRetired.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DashboardGridLayout.legacyRetired.test.tsx
@@ -31,6 +31,9 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
 import type { DashboardComponentSchema } from '@object-ui/types';
@@ -46,16 +49,46 @@ afterEach(cleanup);
 const dash = (widget: Record<string, unknown>): DashboardComponentSchema =>
   ({ type: 'dashboard', widgets: [widget] }) as unknown as DashboardComponentSchema;
 
+/**
+ * The catalog entry the two annotated rows below were transcribed from, named
+ * once so the prose and the derived block at the bottom cannot drift apart.
+ */
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const CATALOG_FIXTURE = path.join(
+  REPO_ROOT,
+  'examples/schema-catalog/src/schemas/plugin-dashboard/filtered-dashboard.json',
+);
+const catalogWidgets = (
+  JSON.parse(fs.readFileSync(CATALOG_FIXTURE, 'utf8')) as { widgets: Record<string, unknown>[] }
+).widgets;
+
 describe('DashboardGridLayout retired legacy widgets (#4612)', () => {
   it.each([
     ['chart', { id: 'w1', type: 'bar', object: 'invoices', categoryField: 'month', valueField: 'amount', aggregate: 'sum' }],
-    // Byte-for-byte `examples/schema-catalog/src/schemas/plugin-dashboard/
-    // filtered-dashboard.json` → `widgets[0]`: the real stored shape, not a
-    // fixture invented to match the detector.
+    // Transcribed from `filtered-dashboard.json` → `widgets[0]` as that fixture
+    // stood at `8640cec19`, the commit that added this file. It was byte-for-byte
+    // then — same keys, same order, same values — and it is NOT byte-for-byte
+    // now: `e028dfcd8` (objectui#4600, PR #4615) migrated the `filtered-*`
+    // entries off the retired shape 66 minutes later, so `widgets[0]` on disk is
+    // `{ id, title, type, options: { xField, yField, data } }` today.
+    //
+    // ⚠️ This row therefore does NOT carry the independent-corpus property the
+    // original annotation claimed for it. It is a HISTORICAL specimen of stored
+    // metadata, not a live transcription — which is the right thing to pin (a
+    // renderer cannot refuse to receive stored metadata) but is worth strictly
+    // less as evidence, so it is stated rather than left to be re-derived. No
+    // live specimen can replace it; the derived block at the bottom measures
+    // that, instead of asserting it here in prose the way this comment once did.
     ['catalog bar', { id: 'invoices_by_status', title: 'Invoices by Status', type: 'bar', object: 'invoices', categoryField: 'status', aggregate: 'count' }],
     // The pivot family, whose legacy spelling names `rowField`/`columnField`.
     ['pivot', { id: 'w1', type: 'pivot', object: 'invoices', rowField: 'region', valueField: 'amount' }],
-    // `widgets[2]` of the same catalog entry.
+    // The same fixture's `widgets[2]` at that same commit, and a LOOSER claim
+    // than the row above ever made: its retired binding verbatim (`type`,
+    // `object`, `aggregate`), with `id` genericised to `w1` and `title` /
+    // `filterBindings` dropped. So this row was never byte-for-byte and never
+    // said it was. `e028dfcd8` retired that widget's shape too — `widgets[2]` is
+    // `{ id, title, type, options: { value }, filterBindings }` today — so the
+    // same ⚠️ above applies to it.
     ['metric', { id: 'w1', type: 'metric', object: 'invoices', aggregate: 'count' }],
   ])('renders the visible placeholder for a legacy %s widget', (_kind, widget) => {
     render(<DashboardGridLayout schema={dash(widget)} />);
@@ -115,5 +148,65 @@ describe('DashboardGridLayout retired legacy widgets (#4612)', () => {
     // would have retired a working branch.
     renderOne({ id: 'w1', type: 'pivot', options: { data: [{ region: 'EMEA', amount: 1 }] } });
     expect(screen.queryByText(/retired data format/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * The corpus half — DERIVED from the fixture, not transcribed from it
+   * (objectui#7151).
+   *
+   * Two of the rows above are hand-written literals introduced by comments
+   * naming a fixture. Those comments were TRUE when written and stopped being
+   * true 66 minutes later, and nothing noticed for months: a comment cannot
+   * detect the file it names changing, which is exactly what a test can do. So
+   * the relationship stops being prose here and becomes a read.
+   *
+   * It reads the file off disk rather than importing it because this package's
+   * `tsconfig.test.json` declares `"types": ["node"]` — the precondition
+   * `packages/types/src/__tests__/timeline-catalog-fixture-migrated.test.ts`
+   * could not meet in `packages/plugin-timeline` and had to relocate for. The
+   * root Vitest config aliases `@object-ui/*` to sibling `src/`, so this file
+   * needs no built dependency closure to resolve either half.
+   *
+   * What this block deliberately does NOT do is restore the independent-corpus
+   * property the annotations above lost, because that property is no longer
+   * obtainable. Measured across every JSON document in the repo: 28 dashboard
+   * widgets, ZERO carrying the retired top-level binding, against live controls
+   * of 15 `options`-shaped and 2 `dataset`-shaped widgets. That zero is by
+   * DESIGN, not by accident — the retirement's whole content is that no
+   * authoring surface emits the shape (`WidgetConfigPanel` scrubs it on save via
+   * `LEGACY_ANALYTICS_KEYS`), and the catalog is an authoring corpus. A specimen
+   * reappearing there is therefore a catalog regression, which is the second
+   * thing this block catches.
+   */
+  describe('the catalog entry those two rows name (objectui#7151)', () => {
+    it('is on disk, and holds the widgets the derived rows below iterate', () => {
+      // Asserted before anything consumes `catalogWidgets`: an emptied or
+      // renamed `widgets` array turns the `it.each` below into ZERO tests and a
+      // green run — the vacuous pass this whole block exists to end.
+      expect(fs.existsSync(CATALOG_FIXTURE), `fixture not found at ${CATALOG_FIXTURE}`).toBe(true);
+      expect(catalogWidgets.length).toBeGreaterThan(0);
+    });
+
+    it('carries NO widget in the retired shape — which is why those rows are hand-written', () => {
+      expect(catalogWidgets.length).toBeGreaterThan(0);
+      const retired = catalogWidgets.filter(
+        (w) => 'object' in w || 'categoryField' in w || 'valueField' in w || 'aggregate' in w,
+      );
+      expect(
+        retired,
+        'a shipped catalog widget authors the retired pre-ADR-0021 binding again — either the catalog regressed, or there is finally a live corpus specimen to transcribe into the annotated rows above',
+      ).toEqual([]);
+    });
+
+    // The independent-corpus property, restored on the side where the corpus
+    // still HAS specimens: these are the real shipped documents, and the
+    // detector must fire on none of them.
+    it.each(catalogWidgets.map((w, i) => [`widgets[${i}]`, w] as [string, Record<string, unknown>]))(
+      'does NOT show the placeholder for shipped catalog %s',
+      (_where, widget) => {
+        renderOne(widget);
+        expect(screen.queryByText(/retired data format/i)).not.toBeInTheDocument();
+      },
+    );
   });
 });


### PR DESCRIPTION
Fixes #7151

Measured on `origin/main` **`dd35800af`**; shipped at **`81b5da034`**.

## The routing tree landed on route 3, and both gates were measurements

**Route 2 gate — is there a live corpus specimen of the pre-ADR-0021 shape?** No. Two independent instruments, each with a live non-zero control on the same instrument:

| instrument | subject | live control |
|---|---|---|
| structural walk of every `widgets[]` element in **all 628 tracked JSON files** | **0** widgets carry `object` / `categoryField` / `valueField` / `aggregate` / `rowField` / `columnField` at top level; **0** the shipped detector would flag | population **28** widgets; **15** `options`-shaped, **2** `dataset`-shaped |
| `git grep -c` over tracked `*.json` | `categoryField` **0**, `rowField` **0**, `columnField` **0**, `aggregate` **0** | `xField` **11**, `dataset` **2** |

The only two structural hits anywhere were `globalFilters[N].optionsFrom` nodes — a filter's option source, not a widget, and a live surface.

**A3.4 checked directly rather than inherited:** objectui#4600's "all the dashboard catalog examples were migrated" holds against the fixtures, measured, not taken from another card's summary.

**Route 1-vs-3 gate — can this package's test tsconfig read a fixture at test time?** Yes. `packages/plugin-dashboard/tsconfig.test.json` declares `"types": ["node"]`, and its own comment records that as load-bearing and measured. Independently confirmed after the fact: the test program loads 82 `@types/node` files. This is exactly the precondition `packages/types/src/__tests__/timeline-catalog-fixture-migrated.test.ts` could not meet in `plugin-timeline` and relocated for. **So: route 3.**

## The card's premise is half falsified — the claim was TRUE when written

The card's title says the fixture "has never carried" the shape, and its "It was never true" section rests on `git log` returning exactly one commit for both paths. That reading is an artifact.

`ad0f5f11f` **is the shallow clone's graft boundary** — the oldest commit present. Every file alive at the boundary reports as added there. Control: of 40 randomly sampled tracked files, **35 return exactly that same one commit**, and the boundary commit also reports adding `legacyRetiredWidget.ts`, which this suite's own header attributes to objectui#4612 — a lower number than the boundary commit's own PR. The instrument can distinguish (`package.json` returns 18 commits, `packages/types/src/complex.ts` returns 3); it simply has nothing to say about paths untouched since the boundary.

Recovered the real history from the public commit log without deepening the shared `.git` (zero-quota, no shared-state mutation), and it inverts the finding:

| commit | when | what |
|---|---|---|
| `8640cec19` | **2026-08-14T01:05:19Z** | added this suite, with the annotated literal |
| `e028dfcd8` | **2026-08-14T02:11:37Z** | migrated the `filtered-*` catalog entries off the retired shape (objectui#4600, PR objectui#4615) |

**66 minutes apart.** The fixture as it stood at `8640cec19` has `widgets[0]` equal to the test literal **byte-for-byte — same keys, same order, same values** (checked mechanically, with a self-comparison control returning true on the same comparator). So the row was a genuine independent corpus specimen; it was not "a fixture invented to match the detector". This is drift, and the migration that caused it is named in the card's own Refs.

The second row's comment made the looser claim "`widgets[2]` of the same catalog entry" and was never byte-for-byte; its retired binding was verbatim, with `id` genericised to `w1` and `title` / `filterBindings` dropped. Substantially true then, false now.

Both are false against today's fixture — that part of the card stands, mechanically confirmed key-for-key.

## What changed

Both annotations now state the measured history and say **explicitly that the rows no longer carry the independent-corpus property** — they are historical specimens of stored metadata, which is still the right thing to pin, but is weaker evidence and now says so rather than leaving the next reader to re-derive the confidence.

Route 3's half: the relationship stops being prose. A derived block reads the same fixture at test time and

- pins that **no** shipped catalog widget authors the retired binding — the executable form of the sentence that used to be a false comment, and a catalog-regression guard in the other direction;
- runs the **three real shipped widgets** through the surface as corpus-derived negative controls. That restores the independent-corpus property on the side where the corpus still has specimens.

The property cannot be restored for the legacy rows themselves, and the block says why: the zero is by design. The retirement's whole content is that no authoring surface emits the shape — `WidgetConfigPanel` scrubs it on save via `LEGACY_ANALYTICS_KEYS` — and the catalog is an authoring corpus.

## A3.3 sweep — no third false claim

Swept every remaining provenance claim in the file and checked each mechanically. All hold:

- `object` / `categoryField` / `aggregate` are not on `DashboardWidgetSchema` — enumerated the spec Zod schema's 22 top-level keys plus objectui's own additions; controls `dataset` / `dimensions` / `values` / `options` all present.
- `DashboardGridLayout` is separately exported and registered as `dashboard-grid`.
- One detector module, two consumers; one shared placeholder constant, one wording.
- Pivot's legacy spelling really is `rowField` / `columnField` — both in `LEGACY_ANALYTICS_KEYS`.
- `DashboardRenderer` really does return the placeholder family-wide for pivot, and this surface really does have a pivot renderer.
- The `provider: 'object'` config really is read off `widgetData`, never the widget top level.

## Tests, at `81b5da034`

Whole package, from the repo root: **85 files, 800 tests, all passing.** This suite alone went 9 passing to **14**.

Ablation, direction predicted before running, on the committed tree:

| leg | mutation | predicted | observed |
|---|---|---|---|
| A | add top-level `object` to `widgets[0]`, keep `options.data` | shape pin red, render control green | **1 failed / 13 passed** — only the shape pin |
| B | revert `widgets[0]` to its `8640cec19` retired form | both red | **2 failed / 12 passed** — shape pin and the derived `widgets[0]` control |

Mutation proved on disk by blob hash change plus injected-marker count, never an editor's exit code; restore proved by state — blob hash back to the HEAD blob and `git diff HEAD`, `git diff --cached`, `git status --short` all empty; absolute paths and an `EXIT INT TERM` trap throughout. The restored tree re-measured at 14 passing. One caveat reported rather than quoted as evidence: leg B's "removed marker" check used `xField`, which is not unique to `widgets[0]`, so it carries no information; the hash and the injected-marker count are what prove that leg.

So this is **not** the objectui#7102 situation where no available pin could fail — both new pins are independently falsifiable, shown two different ways.

Gates: `check:control-bytes`, `check:phantom-deps` (green on the new `node:` builtin imports), `check:esm-specifiers`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `type-check:coverage` all exit 0. `pnpm --filter @object-ui/plugin-dashboard type-check` exits 0, and `--listFiles` confirms the edited file is genuinely in the test program rather than silently excluded. `eslint .` for the package: 0 errors, and 0 findings on the edited file (control: sibling files do appear).

Changeset verdict quoted rather than predicted — empty frontmatter, per the gate's own named exemption:

> 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/7151-legacy-retired-provenance.md.
> Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.

## Scope

One test file plus one changeset. No published type, export, or parse behaviour is touched, so the contract-review tier is not engaged. Nothing under `content/docs/releases/`, and the schema-catalog fixture is unmodified in the diff — it was read, and temporarily mutated only inside the ablation, which restored it provably.

Stayed clear of the objectui#6875 lane: no relational-meta file and no `CELL_RELATIONAL_META_KEYS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_