### PR TITLE
fix(data-objectstack): parse a dropped-fields entry's `fields` elements and `object` instead of asserting them

### DIFF
--- a/.changeset/wire-dropped-fields-shape-6889.md
+++ b/.changeset/wire-dropped-fields-shape-6889.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+Parse a `droppedFields` wire entry's `fields` elements and its `object` at the
+write-warning boundary instead of asserting them.
+
+The structural gate checked `Array.isArray(fields) && fields.length > 0` and then
+asserted the entry into a type declaring `fields: string[]` and a required
+`object: string` — reading neither. A response carrying `fields: [42]` reached
+`onWriteWarning` subscribers typed as a field name (the shell rendered it as the
+label `42`), and an entry that omitted `object` arrived claiming a string that was
+not there.
+
+Now the wire type declares only what the gate establishes, and the notice is
+parsed: non-string `fields` elements are refused, an entry naming no field at all
+is dropped as `fields: []` already was, and a missing or non-string `object` is
+healed from the object the write targeted. Warnings are never silenced for a
+field the server really did name. No published type changes — `WriteWarningEvent`
+and `DroppedFieldsNotice` keep their shapes, and a subscriber's `fields: string[]`
+is now true rather than asserted.

--- a/packages/data-objectstack/src/droppedFieldsShape.boundary.test.ts
+++ b/packages/data-objectstack/src/droppedFieldsShape.boundary.test.ts
@@ -1,0 +1,201 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The write-warning boundary must PARSE a wire entry's `fields` elements and its
+ * `object`, not assert them into the spec type on array-shape alone
+ * (objectui#6889).
+ *
+ * Sibling to `droppedFieldsReason.boundary.test.ts`, which pinned the same
+ * discipline for `reason` (objectui#4934). That fix left two smaller
+ * over-claims behind, and they are independent of each other:
+ *
+ *  - **`fields` elements.** The gate read `Array.isArray(fields) && length > 0`
+ *    and asserted the entry into a type whose `fields` is `string[]`, so
+ *    `fields: [42]` reached every subscriber typed as a field name.
+ *  - **`object`.** `Omit<DroppedFieldsEvent, 'reason'>` carries the spec's
+ *    REQUIRED `object: string`, and nothing in the gate read `object` at all —
+ *    so an entry that omitted it arrived claiming a string that was not there.
+ *    Required is what MAKES this a gap; an optional `object` would have had
+ *    nothing to over-claim.
+ *
+ * What these tests pin is the DISCRIMINATION, not a population: nothing in
+ * these two repos is known to emit either shape, and whether a real server does
+ * is unanswerable from here. Each was measured red against the pre-fix boundary
+ * (see the PR's ablation), and each keeps a live positive control beside it so a
+ * green run cannot be a silently-empty one.
+ *
+ * The repair is deliberately asymmetric with `reason`'s. A reason from the
+ * future is the EXPECTED direction of version skew, so it earns an explicit
+ * skew arm carrying the wire value verbatim. `fields` is `z.array(z.string())`
+ * in the spec and cannot grow a non-string element without a breaking change,
+ * so a non-string element is off-spec input: refused here, fixed at the
+ * producer (AGENTS.md #0.1). `object` is neither — the adapter already KNOWS
+ * which object it wrote to, so a missing one is healed rather than dropped.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackAdapter, UNRECOGNIZED_DROP_REASON } from './index';
+import type { WriteWarningEvent } from './index';
+
+function makeDS(stub: Record<string, any>) {
+  const ds: any = new ObjectStackAdapter({
+    baseUrl: 'http://test.local',
+    fetch: vi.fn(async () =>
+      new Response(JSON.stringify({ success: true, data: { capabilities: {}, routes: {} } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  });
+  ds.connected = true;
+  ds.connectionState = 'connected';
+  ds.client = { data: stub };
+  return ds;
+}
+
+/** Drive one create on `andon` whose response carries `droppedFields`. */
+async function emitOnCreate(droppedFields: unknown[]): Promise<WriteWarningEvent[]> {
+  const create = vi.fn().mockResolvedValue({ record: { id: 'r1' }, droppedFields });
+  const ds = makeDS({ create });
+  const events: WriteWarningEvent[] = [];
+  ds.onWriteWarning((e: WriteWarningEvent) => events.push(e));
+  await ds.create('andon', { title: 'T' });
+  return events;
+}
+
+/** Drive one two-op batch whose response carries a top-level `droppedFields`. */
+async function emitOnBatch(droppedFields: unknown[]): Promise<WriteWarningEvent[]> {
+  const batchTransaction = vi.fn().mockResolvedValue({
+    results: [{ id: 'acc1' }, { id: 'inv1' }],
+    droppedFields,
+  });
+  const ds = makeDS({ batchTransaction });
+  ds.atomicBatchCapability = true;
+  const events: WriteWarningEvent[] = [];
+  ds.onWriteWarning((e: WriteWarningEvent) => events.push(e));
+  await ds.batchTransaction([
+    { object: 'account', action: 'create', data: { name: 'Acme' } },
+    { object: 'invoice', action: 'update', id: 'inv1', data: { status: 'paid' } },
+  ]);
+  return events;
+}
+
+describe('dropped-fields `fields` elements are parsed at the boundary (#6889)', () => {
+  it('refuses the non-string elements and KEEPS the string ones', async () => {
+    const events = await emitOnCreate([
+      { object: 'andon', fields: ['type', 42, { name: 'salary' }, null, true], reason: 'readonly' },
+    ]);
+
+    expect(events).toHaveLength(1);
+    const [notice] = events[0].droppedFields;
+    // The lie this card exists to delete: a subscriber's `string[]` must not be
+    // handed anything that is not a string.
+    expect(notice.fields).toEqual(['type']);
+    for (const f of notice.fields) expect(typeof f).toBe('string');
+    // The entry itself survives — refusing an element must not silence the
+    // warning about the field that WAS named (objectui#3484).
+    expect(notice.reason).toBe('readonly');
+  });
+
+  it('drops an entry that names no field at all, and keeps one that does', async () => {
+    // Nothing in `[42, {}]` is a field name, so there is nothing truthful to
+    // tell the user — same disposition the boundary already gave `fields: []`.
+    expect(await emitOnCreate([{ object: 'andon', fields: [42, {}], reason: 'readonly' }])).toEqual(
+      [],
+    );
+
+    // CONTROL on the same instrument: one string element is enough to emit, so
+    // the zero above is a reading and not a broken harness.
+    const control = await emitOnCreate([
+      { object: 'andon', fields: ['type'], reason: 'readonly' },
+    ]);
+    expect(control).toHaveLength(1);
+    expect(control[0].droppedFields[0].fields).toEqual(['type']);
+  });
+
+  it('never silences a sibling entry that is well-formed', async () => {
+    const events = await emitOnCreate([
+      { object: 'andon', fields: [42], reason: 'readonly' },
+      { object: 'andon', fields: ['source_method'], reason: 'readonly_when' },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].droppedFields).toHaveLength(1);
+    expect(events[0].droppedFields[0]).toEqual({
+      object: 'andon',
+      fields: ['source_method'],
+      reason: 'readonly_when',
+    });
+  });
+
+  it('applies the same parse on the batch path', async () => {
+    const events = await emitOnBatch([
+      { object: 'invoice', fields: ['tax_rate', 42], reason: 'readonly_when', index: 1 },
+    ]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].droppedFields[0].fields).toEqual(['tax_rate']);
+
+    // CONTROL: an all-non-string batch entry emits nothing, on the same driver.
+    expect(
+      await emitOnBatch([{ object: 'invoice', fields: [42], reason: 'readonly_when', index: 1 }]),
+    ).toEqual([]);
+  });
+
+  it('composes with the `reason` skew arm rather than replacing it (#4934)', async () => {
+    const events = await emitOnCreate([
+      { object: 'andon', fields: ['type', 42], reason: 'some_future_reason' },
+    ]);
+
+    expect(events[0].droppedFields[0]).toEqual({
+      object: 'andon',
+      fields: ['type'],
+      reason: UNRECOGNIZED_DROP_REASON,
+      unrecognizedReason: 'some_future_reason',
+    });
+  });
+});
+
+describe('dropped-fields `object` is parsed at the boundary (#6889)', () => {
+  it('heals a missing `object` from the resource the write targeted', async () => {
+    const events = await emitOnCreate([{ fields: ['type'], reason: 'readonly' }]);
+
+    expect(events).toHaveLength(1);
+    const [notice] = events[0].droppedFields;
+    // Declared `object: string` on the spec arm — so it must BE a string, and
+    // the only truthful one available is the object this create wrote to.
+    expect(typeof notice.object).toBe('string');
+    expect(notice.object).toBe('andon');
+  });
+
+  it('heals a non-string `object` the same way', async () => {
+    const events = await emitOnCreate([{ object: 42, fields: ['type'], reason: 'readonly' }]);
+
+    expect(events[0].droppedFields[0].object).toBe('andon');
+  });
+
+  it('CONTROL — a string `object` on the wire is passed through, not overwritten', async () => {
+    // The write targets `andon`; the wire says the strip is about `andon_line`.
+    // Healing must never overrule what the server actually said.
+    const events = await emitOnCreate([
+      { object: 'andon_line', fields: ['type'], reason: 'readonly' },
+    ]);
+
+    expect(events[0].droppedFields[0].object).toBe('andon_line');
+  });
+
+  it('heals a missing `object` from the originating op on the batch path', async () => {
+    const events = await emitOnBatch([{ fields: ['tax_rate'], reason: 'readonly_when', index: 1 }]);
+
+    expect(events).toHaveLength(1);
+    // The notice and the event describing it must name the SAME object — they
+    // used to be computed by two separate expressions.
+    expect(events[0].droppedFields[0].object).toBe('invoice');
+    expect(events[0].resource).toBe('invoice');
+  });
+});

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -1513,11 +1513,26 @@ export type DroppedFieldsNotice = DroppedFieldsEvent | UnrecognizedDropReasonEve
 
 /**
  * A `droppedFields` entry as it comes OFF THE WIRE: everything a structural
- * check can honestly claim about it, and no more. `reason` is `unknown` because
- * nothing has parsed it yet — writing `DroppedFieldsEvent` here is the exact
- * assertion objectui#4934 exists to delete.
+ * check can honestly claim about it, and no more. Every field is `unknown`
+ * until something parses it — writing `DroppedFieldsEvent` for any of them here
+ * is the exact assertion objectui#4934 exists to delete.
+ *
+ * It used to be `Omit<DroppedFieldsEvent, 'reason'> & { reason?: unknown }`,
+ * which was honest about `reason` and dishonest about the other two
+ * (objectui#6889). `Omit` carried the spec's `fields: string[]` and its
+ * REQUIRED `object: string` through untouched, while the structural gate below
+ * read neither: `fields: [42]` and an entry with no `object` at all both passed
+ * and reached subscribers typed as if they had been checked. Required is what
+ * makes `object` a gap here, not what closes it — an optional `object` would
+ * have had nothing to over-claim.
+ *
+ * So the declaration now states exactly what {@link isWireDroppedFieldsEntry}
+ * establishes and nothing else, and {@link asDroppedFieldsNotice} PARSES the
+ * rest. The published surface — {@link DroppedFieldsNotice},
+ * {@link WriteWarningEvent} — is unchanged: a subscriber's `fields: string[]`
+ * stays `string[]` and is now TRUE rather than asserted.
  */
-type WireDroppedFieldsEntry = Omit<DroppedFieldsEvent, 'reason'> & { reason?: unknown };
+type WireDroppedFieldsEntry = { object?: unknown; fields: unknown[]; reason?: unknown };
 
 /** Whether the wire's `reason` is an arm the installed spec pin declares. */
 function isRecognizedDropReason(reason: unknown): reason is DroppedFieldsEvent['reason'] {
@@ -1525,19 +1540,73 @@ function isRecognizedDropReason(reason: unknown): reason is DroppedFieldsEvent['
 }
 
 /**
- * Classify ONE wire entry by parsing its `reason` against the spec enum
- * (objectui#4934).
+ * The structural gate: is this wire value an entry that names at least one
+ * field?
  *
- * A recognized entry is passed through by reference — unchanged, extra
- * server-sent keys and all — so this is a classification, not a rewrite; only
- * the skew case builds a new object. The cast on that path is the one kind this
- * seam may still make: `reason` has just been PARSED, so the claim is proven
- * rather than assumed.
+ * `fields` must be an array (so `unknown[]` is established) carrying at least
+ * one string (so the parsed notice below names something). An array holding no
+ * string at all — `fields: [42]`, `fields: []` — reports no field name, and an
+ * entry that names no field has nothing truthful to tell the user; the
+ * pre-objectui#6889 gate already dropped the empty case for exactly that
+ * reason, and this is the same rule one level deeper.
+ *
+ * `object` and `reason` are deliberately NOT gated on. Nothing is dropped for
+ * them: both are parsed afterwards, so a missing `object` or an unnameable
+ * `reason` still reaches the user as the warning it is (objectui#3484's
+ * silence is the worse failure).
  */
-function asDroppedFieldsNotice(entry: WireDroppedFieldsEntry): DroppedFieldsNotice {
-  if (isRecognizedDropReason(entry.reason)) return entry as DroppedFieldsEvent;
+function isWireDroppedFieldsEntry(e: unknown): e is WireDroppedFieldsEntry {
+  return (
+    !!e &&
+    typeof e === 'object' &&
+    Array.isArray((e as { fields?: unknown }).fields) &&
+    ((e as { fields: unknown[] }).fields).some((f) => typeof f === 'string')
+  );
+}
+
+/**
+ * Parse ONE wire entry into a notice (objectui#4934, objectui#6889).
+ *
+ * Three parses, one per field the gate above does not establish, and the
+ * result is built rather than asserted — so the last cast in this seam is gone:
+ *
+ * - **`reason`** — checked against the spec enum; anything the installed pin
+ *   cannot name goes to the explicit skew arm with the wire value preserved
+ *   verbatim in `unrecognizedReason` (objectui#4934).
+ * - **`fields`** — narrowed to its string elements. Deliberately NOT given a
+ *   skew arm like `reason`: a reason from the future is the EXPECTED direction
+ *   of version skew, whereas `fields` is `z.array(z.string())` in the spec and
+ *   cannot grow a non-string element without a breaking change. A non-string
+ *   element is off-spec input, so the contract-first answer (AGENTS.md #0.1) is
+ *   to refuse it here and fix the producer — not to invent a rendering for it.
+ *   Measured on the one reader (`app-shell`'s `writeWarningToast`): today such
+ *   an element degrades to a wrong label — `42`, `[object Object]`, `true`, or
+ *   an empty entry for `null` — never a throw, which is why this is repaired as
+ *   an honesty defect rather than a crash.
+ * - **`object`** — taken from the wire when it is a string, otherwise from
+ *   `fallbackObject`, which is the object the adapter just wrote to. That is
+ *   not a lenient alias: the caller KNOWS the resource, and the batch path has
+ *   always healed the same hole this way for the event's `resource`. Narrowing
+ *   the gate on `object` instead would drop the entry — and no reader depends
+ *   on it (`writeWarningToast` names fields off `WriteWarningEvent.resource`),
+ *   so dropping would trade a silent user-facing warning for nothing.
+ *
+ * Extra server-sent keys still ride along: the spread preserves them, and only
+ * the three parsed keys are rewritten.
+ */
+function asDroppedFieldsNotice(
+  entry: WireDroppedFieldsEntry,
+  fallbackObject: string,
+): DroppedFieldsNotice {
+  const fields = entry.fields.filter((f): f is string => typeof f === 'string');
+  const object = typeof entry.object === 'string' ? entry.object : fallbackObject;
+  if (isRecognizedDropReason(entry.reason)) {
+    return { ...entry, object, fields, reason: entry.reason };
+  }
   return {
     ...entry,
+    object,
+    fields,
     reason: UNRECOGNIZED_DROP_REASON,
     unrecognizedReason: entry.reason,
   };
@@ -2549,10 +2618,11 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
    * whose response type predates `droppedFields`: the field is read structurally
    * and validated, so an older client (or a backend that never drops) is a no-op.
    *
-   * SHAPE decides whether an entry is an event at all (it must carry a non-empty
-   * `fields`); `reason` is then PARSED against the spec enum and an unrecognized
-   * one routed to the skew arm — never asserted into the union, and never
-   * dropped (objectui#4934).
+   * SHAPE decides whether an entry is an event at all (it must name at least one
+   * field); `object`, `fields` and `reason` are then PARSED — an unrecognized
+   * reason routed to the skew arm, a non-string field element refused, a missing
+   * `object` healed from `resource` — never asserted into the union, and the
+   * entry itself never dropped for them (objectui#4934, objectui#6889).
    */
   private notifyDroppedFields(
     operation: 'create' | 'update',
@@ -2564,14 +2634,8 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     const dropped = (result as { droppedFields?: unknown } | null | undefined)?.droppedFields;
     if (!Array.isArray(dropped) || dropped.length === 0) return;
     const valid = dropped
-      .filter(
-        (e): e is WireDroppedFieldsEntry =>
-          !!e &&
-          typeof e === 'object' &&
-          Array.isArray((e as WireDroppedFieldsEntry).fields) &&
-          (e as WireDroppedFieldsEntry).fields.length > 0,
-      )
-      .map(asDroppedFieldsNotice);
+      .filter(isWireDroppedFieldsEntry)
+      .map((e) => asDroppedFieldsNotice(e, resource));
     // A strip that changed nothing is not news — see withoutNoOpDrops (#3484).
     const stored = (result as { record?: Record<string, unknown> } | null | undefined)?.record;
     const droppedFields = withoutNoOpDrops(valid, sent, stored);
@@ -2599,12 +2663,24 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
     if (!Array.isArray(dropped) || dropped.length === 0) return;
     const results = (payload as { results?: unknown[] } | null | undefined)?.results;
     for (const entry of dropped) {
-      if (!entry || typeof entry !== 'object') continue;
-      // The cast claims only the structure this loop checks; `reason` stays
-      // unparsed until `asDroppedFieldsNotice` below (objectui#4934).
+      // Same gate as the single-record path, so the two agree on what an entry
+      // even is. The remaining cast adds only `index`, which this loop reads
+      // and the gate has no opinion about (objectui#4934, objectui#6889).
+      if (!isWireDroppedFieldsEntry(entry)) continue;
       const e = entry as WireDroppedFieldsEntry & { index?: number };
-      if (!Array.isArray(e.fields) || e.fields.length === 0) continue;
       const op = typeof e.index === 'number' ? operations[e.index] : undefined;
+      // Which object this strip is about. The wire's own `object` wins; the
+      // originating op is the fallback when the wire omitted it or sent a
+      // non-string. ONE spelling, used for both the notice and the event's
+      // `resource` — they used to be computed separately, so a wire entry with
+      // a non-string `object` could put one value on the notice and another on
+      // the event describing it.
+      const object =
+        typeof e.object === 'string'
+          ? e.object
+          : typeof op?.object === 'string'
+            ? op.object
+            : '';
       // Same no-op suppression as the single-record path (#3484). The echoed
       // row for the originating op is the "stored" side; when the batch echoed
       // nothing usable, `withoutNoOpDrops` keeps every field.
@@ -2612,12 +2688,13 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         typeof e.index === 'number' && Array.isArray(results)
           ? (results[e.index] as Record<string, unknown> | undefined)
           : undefined;
-      // `reason` is parsed against the spec enum here too — the batch path used
-      // to re-assert the wire value into the union via the cast above
-      // (objectui#4934). `index` is deliberately not carried onto the notice:
-      // it addresses an operation in THIS response, not the strip.
+      // `object`, `fields` and `reason` are parsed here too — the batch path
+      // used to re-assert all three into the union via the cast above
+      // (objectui#4934, objectui#6889). `index` is deliberately not carried onto
+      // the notice: it addresses an operation in THIS response, not the strip,
+      // which is why the entry is rebuilt rather than spread.
       const [live] = withoutNoOpDrops(
-        [asDroppedFieldsNotice({ object: e.object, fields: e.fields, reason: e.reason })],
+        [asDroppedFieldsNotice({ fields: e.fields, reason: e.reason }, object)],
         op?.data as Record<string, unknown> | undefined,
         stored,
       );
@@ -2627,7 +2704,7 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       const operation: 'create' | 'update' = (op?.action ?? 'create') === 'create' ? 'create' : 'update';
       this.emitWriteWarning({
         operation,
-        resource: e.object ?? op?.object ?? '',
+        resource: object,
         ...(op?.id !== undefined && op?.id !== null ? { id: op.id } : {}),
         droppedFields: [live],
       });


### PR DESCRIPTION
Fixes #6889

Measured on `origin/main` at **`fd11e1644`** (`fd11e1644601d261ec00e371f8bf0b4ce8a7455a`). The card is from 2026-08-30 and its snippets were not trusted; the filter, the type and the reader were all re-derived at that head.

## 1. The gating measurement — driven, not reasoned

The card left the severity question open and pointed at the one reader. That reader was **executed**, not read: a scratch probe drove the real production chain end to end — `ObjectStackAdapter.create()` to `onWriteWarning` to `app-shell`'s `emitWriteWarning`, with the real `t` from `useObjectTranslation()` and the real `fieldLabel` from `useSafeFieldLabel()` (exactly what `AdapterProvider` passes) and a recording sink.

| wire `fields` | reader outcome | rendered description |
| --- | --- | --- |
| `['type','source_method']` (control) | resolved | `... : Andon type, Source method` |
| `[42]` | resolved | `... : 42` |
| `[{ name: 'salary' }]` | resolved | `... : [object Object]` |
| `[null, 'type']` | resolved | `... : , Andon type` |
| `[['type','source_method']]` | resolved | `... : type,source_method` |
| `[true]` | resolved | `... : true` |
| `['type', 42, {}]` | resolved | `... : Andon type, 42, [object Object]` |
| `object` key absent | resolved | unaffected — the reader names fields off `WriteWarningEvent.resource` |

**No throw on any JSON-representable non-string element.** The reader degrades to a wrong label, or to an empty entry for `null`. Nothing a user would act on as a real field name.

The one throw observed came from a deliberately **non-JSON** probe (an element whose `toString` throws), and it did not reach the reader at all — it threw inside the adapter, in `withoutNoOpDrops`, on `Object.prototype.hasOwnProperty.call(sent, f)`. `droppedFields` arrives as parsed JSON, so that value is not reachable from the wire. Reported as a curiosity, not as evidence of a defect.

**Verdict: severity is cosmetic.** Per the card's own ruling that licenses the cheaper honest repair — never *no* repair.

## 2. Which branch that selected, and why it is the opposite of the cheap one

The card offered two shapes: narrow the filter to check element types, or keep the filter permissive and let the declared type say `unknown`.

The second one — the "cheaper" branch — **cannot be taken without moving a published type.** `WireDroppedFieldsEntry` feeds `asDroppedFieldsNotice`, which returns `DroppedFieldsNotice`, whose `fields` is `string[]` on both arms and which IS re-exported. Declaring the wire `fields` as `unknown[]` and stopping there only relocates the split one call down, into the cast; carried to its honest conclusion it makes a subscriber's declared `string[]` become `unknown[]`. That is the contract tier, and it is not what this PR does.

So this PR takes the **filter-narrowing** branch, and additionally makes the internal wire type honest — which is free, because `WireDroppedFieldsEntry` is not published (evidence below). The two together give the shape the card asked for: what the code establishes and what the declaration claims are now the same thing at every step.

## 3. Both over-claims held, independently

- **`fields` elements** — the gate read `Array.isArray(fields) && fields.length > 0` and nothing about the elements, while the asserted type declares `string[]`. Real.
- **`object`** — the installed spec pin (`@objectstack/spec@17.2.0`) declares `object: z.ZodString`, i.e. **required**. `Omit` carried that required `string` through, and the gate never read `object`. Real, and independent of the first.

This **falsifies the dispatch's A2.3 hypothesis**, which guessed that a required `object` might mean "no gap". Required is precisely what makes it a gap — an *optional* `object` would have had nothing to over-claim. The adapter's own batch path already knew this: it wrote `e.object ?? op?.object ?? ''`, a runtime defence against an absence the type denied.

## 4. What changed

- `WireDroppedFieldsEntry` now declares only what the gate establishes: `{ object?: unknown; fields: unknown[]; reason?: unknown }`.
- The gate is named (`isWireDroppedFieldsEntry`) and **shared** by the single-record and batch paths, which previously spelled it twice. It requires at least one string element: an entry naming no field has nothing truthful to tell the user, which is the same disposition the boundary already gave `fields: []`.
- `asDroppedFieldsNotice` narrows `fields` to its string elements, and takes `object` from the wire when it is a string, else from the object the write targeted. It now **builds** the notice, so the last cast in this seam is gone.
- The batch path computes the object name **once**, for both the notice and the event's `resource`; those were two separate expressions that could disagree.

The repair is deliberately **asymmetric with `reason`'s**, and the code says why: a reason from the future is the expected direction of version skew, so it earns an explicit skew arm carrying the wire value verbatim. `fields` is `z.array(z.string())` in the spec and cannot grow a non-string element without a breaking change, so a non-string element is off-spec input — refused here, fixed at the producer (AGENTS.md #0.1), never given an invented rendering. `object` is neither: the adapter knows which object it wrote to, so a missing one is healed rather than dropped, and no entry is ever silenced for it (objectui#3484).

### Bounded, per the card's own scope

No widening into PR #6884's territory (`reason` untouched) or objectui#4934's. objectui#3160's canonical arm is not widened to `string`. `app-shell`'s `writeWarningToast.ts` was read only — it is unchanged, and the probe that drove it was scratch and is not in this diff.

## 5. Evidence

**Published-surface probe — the claim that no published type moved.** Built the package at `fd11e1644` and at this branch's head and compared the emitted `dist/index.d.ts`:

- declaration lines (comments and blanks stripped): **570 vs 570, identical, diff exit 0**
- control on the same instrument: the **full** files DO differ (diff exit 1) — the delta is comment text only, carried in from a `private` method's JSDoc. So the zero is a reading, not a broken comparison.
- `git diff fd11e1644` over the source adds and removes **zero** lines beginning with `export`.
- `WireDroppedFieldsEntry` appears **0** times in the built `dist/index.d.ts`; positive control `DroppedFieldsNotice` appears **4** times on the same grep. The two private methods emit signature-less (`private notifyDroppedFields;`).

**Reader census.** Repo-wide grep for `onWriteWarning`, `WriteWarningEvent` and `DroppedFieldsNotice`: exactly one non-test subscriber, `packages/app-shell/src/providers/AdapterProvider.tsx:78`, which calls `emitWriteWarning` in `writeWarningToast.ts`. Nothing in `apps/`. Control: the same instrument returned dozens of hits across the test suites, so the single production hit is a reading.

**No test pinned the permissive behaviour.** Every `fields:` array in the write-warning suites is all-strings or empty; none pins a non-string element or a missing `object`. So the fix's shape was not constrained by an existing pin.

**Ablation.** Direction predicted before running: reverting only `index.ts` to `fd11e1644`, keeping the new test file, turns 8 of the 9 new tests red and leaves exactly one green — the `object` pass-through control — while the sibling suites stay green.

Mutation proven on disk by blob hash, not by an editor's exit code: worktree `c48540398871a4a9bb4e4e4a049598f267080aff` equals the base blob and differs from the HEAD blob; marker counts `isWireDroppedFieldsEntry` 4 to 0 and `fallbackObject` 3 to 0, with `fields.length > 0` back at 2. Observed: **8 failed, 34 passed** across 4 files — exactly the predicted split, including the single green control. Restore proven by state: `git diff HEAD`, `git diff --cached` and `git status --short` all empty, and the worktree blob hash back to `1b93160c80b2d6ebd3a01366a2d05ba5a48c5d14`.

No rebuild was needed for the ablation to be valid: `vitest.config.mts` aliases every workspace package to its `src`, and the suites import `./index` relatively, so the mutation reached the run from source rather than from a stale `dist`.

**Gate union, re-run after the final commit, at `e268018b4`** (exit code captured by redirect-then-capture, never across a pipe; verdicts quoted from each gate's own line):

| gate | exit | verdict |
| --- | --- | --- |
| `pnpm --filter @object-ui/data-objectstack type-check` | 0 | `tsc --noEmit` clean |
| `pnpm exec vitest run` (5 files, from the repo root) | 0 | `Test Files 5 passed (5)` / `Tests 56 passed (56)` |
| `pnpm --filter @object-ui/data-objectstack lint` | 0 | `419 problems (0 errors, 419 warnings)` |
| `check-changeset-presence.mjs` | 0 | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `pnpm changeset:check` | 0 | `No changeset declares a major bump.` |
| `pnpm check:control-bytes` | 0 | `OK (scanned 5931 tracked text file(s); skipped 85 binary)` |
| `pnpm check:self-import` | 0 | `No package names itself inside its own src/.` |
| `pnpm check:phantom-deps` | 0 | `Every in-scope import is declared by the package that publishes it.` |
| `pnpm check:vi-mock-specifiers` | 0 | `OK` |
| `pnpm check:vi-mock-inherit` | 0 | `OK` |

The package `type-check` really does cover the new test file: `tsc --listFiles` names `droppedFieldsShape.boundary.test.ts` once, with `src/index.ts` as the control.

**Declared narrowing.** The repo-wide `pnpm lint` is CI's run; this branch ran the per-package form instead, and the narrowing is measured rather than skipped: the population came from eslint's own config resolution (`eslint .` in the package dir, not a hand-picked list); `--format json` reports **58 files linted, 0 errors**, and both touched files are in that list; and `eslint.config.js` declares no `projectService` and no `parserOptions` (control: `rules` matches 10 times on the same grep), so type-aware linting is off and this diff cannot move the verdict on any file it did not touch.

**Not measured.** Whether any real server emits a non-string `fields` element or omits `object`. That is unanswerable from these two repos — a host application outside them is invisible to any measurement runnable here — and no inference about it was made.


---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_