### PR TITLE
fix(plugin-charts): a sankey that drew only some of its rows says how many

### DIFF
--- a/.changeset/7148-sankey-omitted-rows-note.md
+++ b/.changeset/7148-sankey-omitted-rows-note.md
@@ -1,0 +1,34 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+A sankey that drew only SOME of its rows now says how many (objectui#7148).
+
+The sankey arm keeps strictly positive measures
+(`data.filter((r) => (Number(r?.[dataKey]) || 0) > 0)`), so a mixed dataset
+drew a normal, healthy, confident chart of a fraction of itself and nothing
+anywhere recorded that the other rows existed. Measured in Chromium across 27
+tiles: `[{New business: 40}, {Refunds: -25}, {Chargebacks: -12}]` rendered
+`svg: 1`, `path: 3`, 18 descendants, no `role`, no text, and — against a live
+console control that did fire on the same instrument — zero console output.
+Its screenshot hashed byte-identical to five other datasets, one of which
+genuinely had a single row. Six datasets, one image: a reader had no bit of
+information separating a complete flow from a third of one.
+
+The discard itself stands — a flow has no negative width, so it is the only
+thing that arm can do with those rows. What is added is a footnote under the
+plot naming the ratio and the predicate the filter applies:
+
+> Showing 1 of 3 rows — 2 rows have no `amount` above zero, which a flow
+> cannot draw.
+
+It names the predicate rather than a cause because `Number(…) || 0` folds
+negatives, zeros, `null`, unparseable strings and a missing key into one
+discard, and all five were measured reaching this branch beside a survivor;
+naming any one of them is a sentence that is false for the other four.
+
+A complete flow is byte-for-byte unchanged and gains no wrapper element, and a
+drawable sankey is never replaced by prose: the `no-positive-flow` refusal
+still owns the case where NOTHING survives the filter, and the "one positive
+among zeros still draws" boundary still draws — that fixture is itself a
+thinned dataset, so it now draws *and* says so.

--- a/packages/plugin-charts/src/AdvancedChartImpl.sankeyOmittedRows.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.sankeyOmittedRows.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * Sankey — SOME rows survive the positive filter and the rest are dropped
+ * silently (objectui#7148). The branch next door to objectui#7140's refusal,
+ * and the more dangerous of the two.
+ *
+ * The sankey arm keeps only strictly positive measures
+ * (`data.filter((r) => (Number(r?.[dataKey]) || 0) > 0)`). When that filter
+ * keeps NOTHING, objectui#7146 now says so. When it keeps SOME, the chart drew
+ * a normal, healthy, confident sankey of a fraction of its dataset and nothing
+ * anywhere recorded that the other rows existed.
+ *
+ * ## The measurement that decided fix-over-decline
+ *
+ * 27 tiles in real Chromium (`/opt/pw-browsers/chromium`) at `origin/main`
+ * fd11e1644, each tile screenshotted and SHA-256'd. The card's own dataset
+ * (`New business 40 / Refunds -25 / Chargebacks -12`) rendered `svg: 1`,
+ * `path: 3`, 18 descendants, no `role`, no text — and, against a live console
+ * control that DID fire on the same instrument (`missing-category-key`), zero
+ * console output. Its screenshot hashed `13237e6e19a7072a`, byte-identical to
+ * FIVE other tiles including a genuinely one-row dataset
+ * `[{ stage: 'New business', amount: 40 }]`. Six datasets, one image: the
+ * reader had no bit of information separating a complete flow from a third of
+ * one. That is why "discarding is all a flow CAN do" does not settle the card —
+ * the drop is fine, the silence is not.
+ *
+ * ## Why a note and not a refusal
+ *
+ * objectui#7146 pins "one positive row among zeros still draws". That fixture
+ * (`0 / 7 / 0`) is itself a THINNED dataset — it lands in this branch and
+ * hashed identical to the mixed-sign tile — so a refusal here would blank a
+ * chart that pin requires drawn. The two cards meet exactly at
+ * `rows.length === 0`: none survive → refusal (objectui#7146); some survive and
+ * some do not → this note; all survive → untouched.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+const SERIES = [{ dataKey: 'amount', label: 'Amount' }];
+
+const renderSankey = (data: Array<Record<string, unknown>>) =>
+  render(
+    <AdvancedChartImpl
+      chartType="sankey"
+      xAxisKey="stage"
+      series={SERIES as any}
+      data={data as any}
+    />,
+  );
+
+const noteOf = (container: HTMLElement) =>
+  container.querySelector('[data-chart-note="omitted-rows"]');
+const refusalOf = (container: HTMLElement) =>
+  container.querySelector('[data-chart-error="no-positive-flow"]');
+
+/**
+ * Every shape `Number(…) || 0` folds to zero, each one BESIDE a survivor.
+ *
+ * They are not the same situation and the copy deliberately names none of them:
+ * a message that said "negative" would be false of the null row, and the card
+ * itself notes that `null` and unparseable measures vanish through the very
+ * same filter. All five were measured reaching this branch in Chromium.
+ */
+const THINNED: Array<[string, Array<Record<string, unknown>>, number, number]> = [
+  ['negative rows (the card\'s own dataset)', [
+    { stage: 'New business', amount: 40 },
+    { stage: 'Refunds', amount: -25 },
+    { stage: 'Chargebacks', amount: -12 },
+  ], 1, 3],
+  ['zero rows (objectui#7146\'s pinned boundary)', [
+    { stage: 'Prospecting', amount: 0 },
+    { stage: 'Proposal', amount: 7 },
+    { stage: 'Won', amount: 0 },
+  ], 1, 3],
+  ['null measures', [
+    { stage: 'New business', amount: 40 },
+    { stage: 'Refunds', amount: null },
+    { stage: 'Credits', amount: null },
+  ], 1, 3],
+  ['unparseable measures', [
+    { stage: 'New business', amount: 40 },
+    { stage: 'Refunds', amount: 'n/a' },
+  ], 1, 2],
+  ['a row missing the measure key entirely', [
+    { stage: 'New business', amount: 40 },
+    { stage: 'Refunds' },
+  ], 1, 2],
+  ['a mix that keeps more than one row', [
+    { stage: 'New business', amount: 40 },
+    { stage: 'Expansion', amount: 25 },
+    { stage: 'Chargebacks', amount: -12 },
+  ], 2, 3],
+];
+
+describe('AdvancedChartImpl — sankey that drew only SOME of its rows (objectui#7148)', () => {
+  it.each(THINNED)('says how many rows it drew when handed %s', (_label, rows, kept, total) => {
+    const { container } = renderSankey(rows);
+
+    const note = noteOf(container);
+    expect(note, 'a partial flow states that it is partial').not.toBeNull();
+
+    // BOTH halves of the count. "Some rows were dropped" would still leave a
+    // thinned flow indistinguishable from a complete one; the ratio is the bit
+    // the picture cannot carry.
+    expect(note?.textContent).toContain(`Showing ${kept} of ${total} rows`);
+    // Names the measure it tested and the exact test it failed, so the author
+    // knows WHICH column decided it — the same diagnosis the refusal gives.
+    expect(note?.textContent).toContain('amount');
+    expect(note?.textContent).toContain('above zero');
+    // A note annotates; it is not a state change and not an alert.
+    expect(note?.getAttribute('role')).toBe('note');
+
+    // ⛔ The chart is still DRAWN. The drop is not the defect — a flow has no
+    // negative width — so nothing here may replace a drawable sankey with
+    // prose. This is objectui#7146's boundary restated from the other side.
+    expect(container.querySelector('svg'), 'a drawable sankey still draws').not.toBeNull();
+    expect(refusalOf(container), 'a drawn chart is never also a refusal').toBeNull();
+  });
+
+  it('agrees with itself in the singular', () => {
+    const { container } = renderSankey([
+      { stage: 'New business', amount: 40 },
+      { stage: 'Refunds', amount: -25 },
+    ]);
+    expect(noteOf(container)?.textContent).toContain('1 row has no');
+  });
+
+  it('agrees with itself in the plural', () => {
+    const { container } = renderSankey([
+      { stage: 'New business', amount: 40 },
+      { stage: 'Refunds', amount: -25 },
+      { stage: 'Chargebacks', amount: -12 },
+    ]);
+    expect(noteOf(container)?.textContent).toContain('2 rows have no');
+  });
+
+  it('CONTROL — an all-positive sankey carries no note, and gains no wrapper', () => {
+    const { container } = renderSankey([
+      { stage: 'New business', amount: 40 },
+      { stage: 'Expansion', amount: 25 },
+      { stage: 'Renewal', amount: 12 },
+    ]);
+
+    expect(noteOf(container), 'nothing was omitted, so nothing is claimed').toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+    // The complete-flow path returns the container it always returned. The
+    // footnote's flex wrapper would take over the height chain (see
+    // `ChartFootnote`), so a chart with nothing to say must not get one.
+    expect(
+      container.firstElementChild?.getAttribute('data-slot'),
+      'the chart container is still the root element',
+    ).toBe('chart');
+  });
+
+  // ---- the seam with objectui#7146 -------------------------------------
+  //
+  // `rows.length` is the whole boundary: 0 survivors is that card, 1-or-more
+  // survivors alongside a casualty is this one, and no casualties at all is
+  // neither. Pinned from both sides so neither answer can drift into the
+  // other's branch.
+
+  it('SEAM — no row survives: objectui#7146 refuses, and this note stays out of it', () => {
+    const { container } = renderSankey([
+      { stage: 'A', amount: 0 },
+      { stage: 'B', amount: 0 },
+      { stage: 'C', amount: -5 },
+    ]);
+
+    expect(refusalOf(container), 'all-non-positive is still the refusal branch').not.toBeNull();
+    expect(noteOf(container), 'a chart that drew nothing has no partial draw to annotate').toBeNull();
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('SEAM — no rows at all: still the bare div, untouched by both cards', () => {
+    const { container } = renderSankey([]);
+
+    expect(refusalOf(container)).toBeNull();
+    expect(noteOf(container)).toBeNull();
+    // The empty-RESULT question (objectui#7130), answered upstream in
+    // ObjectChart where the query outcome is known.
+    expect(container.textContent).toBe('');
+  });
+
+  it('does not reach other chart families handed the same mixed-sign rows', () => {
+    // The note reads the sankey filter's own result and no other family has
+    // such a filter — measured in Chromium, bar/pie/donut/funnel/treemap all
+    // keep every row of this dataset in their data array. Pinned because
+    // hoisting the count out of this arm is the obvious refactor and would
+    // annotate four charts that omitted nothing.
+    for (const chartType of ['bar', 'pie', 'donut', 'funnel', 'treemap'] as const) {
+      const { container } = render(
+        <AdvancedChartImpl
+          chartType={chartType}
+          xAxisKey="stage"
+          series={SERIES as any}
+          data={[
+            { stage: 'New business', amount: 40 },
+            { stage: 'Refunds', amount: -25 },
+          ] as any}
+        />,
+      );
+      expect(noteOf(container), `${chartType} omitted nothing and must say nothing`).toBeNull();
+      cleanup();
+    }
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -374,6 +374,40 @@ function ChartFrame({ title, subtitle, children }: { title?: string; subtitle?: 
 }
 
 /**
+ * `ChartFrame`'s mirror image: chrome BELOW the plot, for a chart that drew
+ * something but did not draw all of it (objectui#7148).
+ *
+ * Same construction, and deliberately so, because the construction is the whole
+ * difficulty. A footnote cannot simply be rendered as a SIBLING of
+ * `ChartContainer`: measured in Chromium in the dashboard shape — a fixed,
+ * clipping card whose chart carries `h-full` — the container takes the card's
+ * full height and a following `<p>` lands at y=327 in a box that ends at y=316,
+ * i.e. entirely outside the clip. A note invisible in dashboards is no note at
+ * all, and dashboards are where these charts live.
+ *
+ * Nor can it be a plain wrapper `<div className={className}>` around the
+ * container: the consumer's className is the chart's height contract and it has
+ * to keep reaching the element Recharts measures (see `CHART_MIN_HEIGHT` in
+ * `ChartContainerImpl` for the measurement of what happens when it does not —
+ * a permanently zero box and an invisible chart, with no refusal and no empty
+ * state).
+ *
+ * So the plot keeps its own `className` and gains a definite height through the
+ * flex chain instead: `h-full` outer, `min-h-0 flex-1` around the plot,
+ * `shrink-0` under it. With no footnote this returns the chart untouched, so no
+ * existing caller gains a wrapper element — the same gate `ChartFrame` uses.
+ */
+function ChartFootnote({ note, children }: { note?: React.ReactNode; children: React.ReactNode }) {
+  if (!note) return <>{children}</>;
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div className="min-h-0 flex-1">{children}</div>
+      <div className="mt-1 shrink-0">{note}</div>
+    </div>
+  );
+}
+
+/**
  * AdvancedChartImpl - The heavy implementation that imports Recharts with full features
  * This component is lazy-loaded to avoid including Recharts in the initial bundle
  */
@@ -1088,18 +1122,84 @@ function AdvancedChartImplInner({
         </ChartRefusal>
       );
     }
+    // A PARTIAL flow SAYS it is partial — objectui#7148, the branch next door
+    // to the refusal above.
+    //
+    // The filter is unconditional, so a dataset where only SOME rows survive it
+    // draws a normal, healthy, confident sankey of a fraction of itself, and
+    // nothing in the output carried that fact. Measured in Chromium at
+    // origin/main fd11e1644 across 27 tiles: the card's own dataset
+    // (`New business 40 / Refunds -25 / Chargebacks -12`) rendered `svg: 1`,
+    // `path: 3`, 18 descendants, no `role`, no text, and — against a live
+    // console control that did fire on the same instrument — ZERO console
+    // output. Its screenshot hashed `13237e6e19a7072a`, BYTE-IDENTICAL to a
+    // genuinely one-row dataset `[{ New business: 40 }]` and to three other
+    // thinned shapes (one positive among zeros, positive + nulls, positive +
+    // unparseable). Six datasets, one image. A reader had no bit of information
+    // distinguishing a complete flow from a third of one, and nobody re-reads a
+    // dataset that renders fine.
+    //
+    // ## Why a note beside the chart, and not a refusal
+    //
+    // Not a style preference — a refusal is unavailable here. objectui#7146
+    // pins "one positive row among zeros still draws", and that fixture
+    // (`0 / 7 / 0`) is ITSELF a thinned dataset: it lands in this branch, and
+    // hashes identical to the mixed-sign tile above. Refusing on a thinned flow
+    // would blank the chart that pin requires drawn.
+    //
+    // The drop is also not the defect. A flow has no negative width, so
+    // discarding those rows is the only thing this arm CAN do with them. What
+    // was missing was saying so — which is the whole change: the plot is the
+    // element this arm already returned, unchanged, with one line of prose
+    // under it.
+    //
+    // ## Why the copy names the PREDICATE and a COUNT, not a cause
+    //
+    // The reason the refusal above gives, and this branch is where that family
+    // actually lives: `Number(…) || 0` folds negatives, zeros, `null`,
+    // unparseable strings and a missing key into ONE discard, and all five were
+    // measured reaching here beside a survivor. Naming any one of them is a
+    // sentence that is false for the other four, so the copy names the
+    // predicate the filter actually applies, which is true of all of them.
+    //
+    // The COUNT is the half a reader cannot recover from the picture. "Some
+    // rows were dropped" still leaves a thinned flow indistinguishable from a
+    // complete one; `1 of 3` is the bit that was missing.
+    //
+    // No console warning, matching the refusal above and unlike the two guards
+    // at the bottom of this file: those carry a diagnostic PAIR that does not
+    // fit on screen, whereas this sentence already names the key, the test it
+    // failed, and how many rows failed it.
+    const omittedRowCount = data.length - rows.length;
     return (
-      <ChartContainer config={config} className={className} {...containerProps}>
-        <Sankey
-          data={{ nodes, links }}
-          nodePadding={24}
-          link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.25 }}
-          node={{ fill: 'hsl(var(--chart-1))' } as any}
-          {...sankeyClickProps}
-        >
-          <Tooltip />
-        </Sankey>
-      </ChartContainer>
+      <ChartFootnote
+        note={
+          omittedRowCount > 0 ? (
+            <p
+              role="note"
+              data-chart-note="omitted-rows"
+              className="px-1 text-xs text-muted-foreground"
+            >
+              Showing {rows.length} of {data.length} rows &mdash; {omittedRowCount}{' '}
+              {omittedRowCount === 1 ? 'row has' : 'rows have'} no{' '}
+              <code className="font-mono">{dataKey}</code> above zero, which a flow cannot
+              draw.
+            </p>
+          ) : null
+        }
+      >
+        <ChartContainer config={config} className={className} {...containerProps}>
+          <Sankey
+            data={{ nodes, links }}
+            nodePadding={24}
+            link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.25 }}
+            node={{ fill: 'hsl(var(--chart-1))' } as any}
+            {...sankeyClickProps}
+          >
+            <Tooltip />
+          </Sankey>
+        </ChartContainer>
+      </ChartFootnote>
     );
   }
 


### PR DESCRIPTION
Fixes #7148

The sankey arm keeps only strictly positive measures, so a mixed dataset drew a
normal, healthy, confident chart of a fraction of itself and nothing anywhere
recorded that the other rows existed. This adds one line of prose under the plot
saying how many rows it drew. The chart itself is unchanged.

## The measurement that decided fix-over-decline

The card deliberately does not assert the drop is wrong, so this was settled the
way #7140 was: 27 tiles rendered in real Chromium (`/opt/pw-browsers/chromium`)
at `origin/main` **fd11e1644**, each screenshotted and SHA-256'd.

At base, six different datasets produced **one byte-identical image**
(`13237e6e19a7072a`):

| tile | dataset | rows drawn |
|---|---|---|
| `sankey-card-mixed-sign` | `New business 40 / Refunds -25 / Chargebacks -12` | 1 of 3 |
| `sankey-pin-one-pos-among-zeros` | `0 / 7 / 0` | 1 of 3 |
| `sankey-pos-plus-nulls` | `40 / null / null` | 1 of 3 |
| `sankey-pos-plus-unparseable` | `40 / 'n/a'` | 1 of 2 |
| `sankey-pos-plus-missing-key` | `40 / (no measure key)` | 1 of 2 |
| `sankey-genuine-1row-40` | `40` | **1 of 1** |

That last row is the finding. A chart showing a third of its dataset was
pixel-for-pixel the chart of a dataset that genuinely had one row — `svg: 1`,
`path: 3`, 18 descendants, no `role`, no text, and **zero console output**,
measured against a live console control on the same instrument
(`missing-category-key`, which did fire). A reader had no bit of information
separating a complete flow from a partial one. `measured-and-declined` was
available and is not what the evidence supports.

## What ships, and why this shape

- **Not a refusal.** #7146 pins *"one positive row among zeros still draws"* —
  and that fixture (`0 / 7 / 0`) is itself a **thinned** dataset. It lands in
  this branch and hashed identical to the mixed-sign tile. Refusing on a thinned
  flow would blank the chart that pin requires drawn. It now draws *and* says so.
- **Not a change to the drop.** A flow has no negative width, so discarding is
  the only thing this arm can do with those rows. The silence was the defect.
- **Names the predicate, not a cause.** `Number(…) || 0` folds negatives, zeros,
  `null`, unparseable strings and a missing key into one discard, and all five
  were measured reaching this branch beside a survivor. Naming any one of them is
  a sentence that is false for the other four — the same doctrine the
  `no-positive-flow` copy follows.
- **Carries the count.** "Some rows were dropped" still leaves a thinned flow
  indistinguishable from a complete one; the ratio is the bit the picture cannot
  carry.

> Showing 1 of 3 rows — 2 rows have no `amount` above zero, which a flow cannot draw.

No console warning, matching the sibling refusal: the sentence already names the
key, the test it failed and how many rows failed it.

### The footnote could not be a plain sibling — that was measured too

A bare paragraph element rendered after `ChartContainer` is **invisible in dashboards**. In the
dashboard shape — a fixed, clipping card whose chart carries `h-full` — the
container takes the card's full height and the note landed at `y=327` in a box
ending at `y=316`, entirely outside the clip. A wrapper div carrying `className`
is equally unavailable: the consumer's className is the chart's height contract
and has to keep reaching the element Recharts measures (see `CHART_MIN_HEIGHT`
in `ChartContainerImpl` for what a broken chain costs — a permanently zero box
and an invisible chart, with no refusal and no empty state).

So the plot keeps its own `className` and the note hangs off a flex chain, in
`ChartFootnote` — deliberately the mirror image of this file's existing
`ChartFrame`, including its gate: with nothing to say, the chart is returned
untouched and **gains no wrapper element**.

## Reverse verification (controlled)

The implementation was committed first, then the pre-fix file was restored onto
disk (mutation proven by blob hash `3105af33…` matching the base blob, marker
count `omitted-rows` 0, and the marker confirmed absent from the rebuilt bundle),
the harness rebuilt with **identical CSS**, and all 31 tiles re-measured.
Restore proven by state: `git diff HEAD`, `git diff --cached` and
`git status --short` all clean, on-disk blob back to `5e2486b8…`.

- **8 tiles changed. All 8 are thinned sankeys.**
- **23 tiles byte-identical**, including `sankey-control-all-positive`,
  `chain-clip-all-positive`, `chain-auto-all-positive` (the complete-flow path is
  unchanged in all three height chains), both `no-positive-flow` refusal tiles,
  the no-rows tile, and every other chart family.
- The collision with `sankey-genuine-1row-40` is broken: that tile keeps
  `13237e6e19a7072a` (nothing was omitted) while the five thinned tiles move away.

Residual collisions are correct: tiles sharing a ratio share a sentence, because
the copy deliberately does not distinguish *why* a row was dropped.

## The seam with #7146

`rows.length` is the whole boundary, and it is now pinned from both sides:

| dataset | branch | measured |
|---|---|---|
| no rows at all | bare div — the empty-**result** question (#7130), answered upstream | `svg: 0`, `textContent: ''` |
| all zeros + one negative | `no-positive-flow` refusal (#7146) | `data-chart-error="no-positive-flow"` |
| one positive + nulls | **this note** | `svg: 1`, note present |
| `0 / 7 / 0` (#7146's own pin) | **this note** — and still draws | `svg: 1`, note present |
| all positive | untouched | byte-identical to base |

## Gates

Run at `f2df89144` (the head this PR points at), repo root:

- `pnpm vitest run packages/plugin-charts/` — **38 files, 265 tests passed**,
  including #7146's `sankeyNoPositiveFlow` pin unmodified.
- `pnpm --filter @object-ui/plugin-charts type-check` — exit 0. `--listFiles`
  confirms the new test file is inside the program (not an excluded-tests
  false green).
- `pnpm --filter @object-ui/plugin-charts lint` — 51 files judged, **0 errors**,
  282 warnings (`--max-warnings` is deliberately unset repo-wide, per
  `lint.yml`). The 6 warnings on the new test file are the `as any` /
  `importActual` type-argument shape every sibling test in this package already uses.
- `pnpm check:control-bytes` — `✅ OK (scanned 5931 tracked text file(s))`
- `pnpm check:vi-mock-specifiers`, `check:vi-mock-inherit` — both `✅ OK`
- `pnpm check:i18n-keys` — `✅` (no i18n call site added; this file is
  hardcoded English throughout and both existing refusals are too)
- `pnpm changeset:check` — `✅ All workspace packages are in the changeset fixed
  group.` / `✅ No changeset declares a major bump.`
- `pnpm check:sdui-registration-pins` — first returned **exit 2, "No console
  build to weigh"**, which is NOT MEASURED rather than a pass. Built the console
  and its closure and re-ran: `✅ All 16 registration(s) … present in the built
  console (517 chunks weighed)`.

Repo-wide `pnpm lint` is CI's run. The narrowing above is measured, not assumed:
the universe (51 files) is eslint's own config resolution, the counts come from
`--format json`, and `eslint.config.js` configures **no** type-aware linting
(no `parserOptions.project` / `projectService`), so a change under
`packages/plugin-charts/src/` cannot move the verdict on any untouched file.

## Out of scope, reported not fixed

Measured in the same sweep, for **#7147**, which owns that family:
`treemap` drew 2 rects / 2 labels for the mixed-sign dataset against a control's
4 / 4; `funnel` with a `null` measure drew **0** segment paths against a
control's 2; `pie` drew 1 slice against a control's 2. Those rows are never
filtered — they stay in the data and the layout gives them no area — so this is
degenerate geometry, a different mechanism from the row drop fixed here, and
untouched by this PR. It widens #7147 beyond all-zero datasets to mixed ones.

`AdvancedChartImpl.tsx` line 1047 is the only row-dropping `filter` in the file
(the other two filter *series*), which is why the note cannot reach another
family — pinned in the tests.

_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_