### PR TITLE
docs(plugin-timeline): the gantt row walk's non-total reads become a measured enumeration, and the class claim is corrected

### DIFF
--- a/.changeset/gantt-row-walk-nontotal-reads.md
+++ b/.changeset/gantt-row-walk-nontotal-reads.md
@@ -1,0 +1,4 @@
+---
+---
+
+Documentation and pinned tests only; no published behaviour changes. `plugin-timeline`'s gantt row walk now carries the measured enumeration of its non-total reads — six in `findUnusableGanttDate`, three in `calculateDateRange` — in place of the prose count that was short, and the adversarial set exercises both classes instead of asserting them.

--- a/packages/plugin-timeline/src/__tests__/timeline-gantt-date-brand-7027.test.tsx
+++ b/packages/plugin-timeline/src/__tests__/timeline-gantt-date-brand-7027.test.tsx
@@ -37,9 +37,20 @@
  *      own headline was wrong: `Array.isArray` is not the last non-total
  *      operation on the PATH, only inside that function (objectui#7153).
  *
+ *   6. objectui#7153: the UPSTREAM reads. That card said five sites; driven in
+ *      render there are six in `findUnusableGanttDate` and three more in
+ *      `calculateDateRange`, and a tenth is NOT MEASURED. It took the same
+ *      stated-and-exercised branch for the six (`pin 5`) after re-testing the
+ *      `catch` argument rather than inheriting it — measured, a `catch`
+ *      upstream reads the PATH half and still substitutes the VALUE half, and
+ *      buys 3 of 9. And it falsified the class claim as well as the count: the
+ *      three in `calculateDateRange` are plain JSON, not exotica, so they are
+ *      pinned as a DEFECT (`pin 6`, objectui#7164) and not as an exclusion.
+ *
  * ⚠️ So this file's input set is not a claim of totality either. It is the
- * boundary that has actually been exercised, and the sixth card will be the
- * one that says where it ends.
+ * boundary that has actually been exercised, and the seventh card will be the
+ * one that says where it ends. Every entry above was written as the settled
+ * answer; five of the six were moved by the next card's measurement.
  *
  * ## What "a defined outcome" means here — two kinds, and never a third
  *
@@ -437,6 +448,235 @@ describe('pin 4 — the ONE documented EXCLUSION, exercised not asserted (object
     const text = diagnosticOf(container) ?? '';
     expect(text).toContain(PATH);
     expect(text).toContain('is an object');
+    expect(barCountOf(container)).toBe(0);
+  });
+});
+
+/**
+ * A proxy that refuses ONE named operation and is honest about the rest, so
+ * the thrown message identifies WHICH read died. `Reflect.get` for everything
+ * else keeps the value ordinary right up to the site under test.
+ */
+const trapOn = (target: object, key: string, message: string) =>
+  new Proxy(target, {
+    get(t, p, r) {
+      if (p === key) throw new Error(message);
+      return Reflect.get(t, p, r);
+    },
+  }) as any;
+
+/** One ordinary gantt row, as the hostile rows' non-hostile twin. */
+const GOOD_ITEM = { title: 'T', startDate: '2024-01-01', endDate: '2024-03-01' };
+const goodRow = () => ({ label: 'R', items: [{ ...GOOD_ITEM }] });
+
+const REVOKED_GET = /Cannot perform 'get' on a proxy that has been revoked/;
+
+describe('pin 5 — the SIX non-total reads UPSTREAM of the speller (objectui#7153)', () => {
+  /**
+   * objectui#7036 documented `spellGanttDateValue`'s `Array.isArray` as the
+   * one exclusion on the gantt date path and pointed at this card for the
+   * reads that run BEFORE the speller is entered. objectui#7153's card named
+   * five of them; driven in render on 51449a043 there are SIX in
+   * `findUnusableGanttDate` alone, and three more in `calculateDateRange`
+   * (pin 6 below, a different reachability class entirely).
+   *
+   * ## Why these are PINNED AS THROWS rather than repaired
+   *
+   * Same three grounds objectui#7036 recorded for its own site, and the middle
+   * one was RE-TESTED here rather than inherited, because upstream is not the
+   * same shape as the speller:
+   *
+   * 1. Unreachable from an authored document — JSON spells neither a getter
+   *    nor a proxy. Re-swept on 51449a043 with a comment-stripped instrument:
+   *    `Proxy.revocable`, `new Proxy`, the bare word `Proxy` and
+   *    `Object.setPrototypeOf` are each 0 across every package `src/` outside
+   *    tests, beside live controls of `Object.assign` 19 and `JSON.parse` 105
+   *    on that same instrument; the SAME query widened to the whole repo returns 1, 21
+   *    and 105 (tests only), which is what makes the narrow zeros readings.
+   * 2. A `catch` upstream reads HALF of what it would need, which is more than
+   *    the speller's `catch` reads and still not enough. Measured by ablation:
+   *    a `try` around U6 reporting the path from the loop counters came back
+   *    NAMED `items[0].items[0].endDate` — exact, because the path is built
+   *    from indices and never touches the value, unlike at the speller where
+   *    the `catch` holds only the value it cannot read. But the VALUE half is
+   *    still substitution (the diagnostic read `is "UNREADABLE"`), so a real
+   *    repair needs a value-less diagnostic and therefore a new i18n key
+   *    across ten locale packs.
+   * 3. It would buy 3 of 9. That same ablation converted U5, U6 and the
+   *    throwing-getter item and left U1 through U4 throwing upstream of it and
+   *    `calculateDateRange`'s three throwing downstream — the "1 of 6" trade
+   *    objectui#7036's triage refused, at a different site.
+   *
+   * ## The assertions name the MESSAGE, and the messages name the SITE
+   *
+   * A bare `toThrow()` passes for any error from any line, so it would stay
+   * green through exactly the relocation this path has performed four times.
+   * Four of the six rows drive a proxy that refuses ONE named operation, so
+   * the message identifies the read that died. A row goes red both if its site
+   * is repaired and if the crash moves — either of which must come with a
+   * docblock edit.
+   */
+
+  const sites: [string, () => Record<string, unknown>, RegExp][] = [
+    [
+      'U1 `items.length` — the row loop condition',
+      () => ({ items: trapOn([goodRow()], 'length', 'U1: items.length trap') }),
+      /U1: items\.length trap/,
+    ],
+    [
+      'U2 `items[rowIndex]` — the row index get',
+      () => ({ items: trapOn([goodRow()], '0', 'U2: items[0] trap') }),
+      /U2: items\[0\] trap/,
+    ],
+    [
+      'U3 `items[rowIndex]?.items` — reading `items` off the row',
+      () => ({ items: [trapOn(goodRow(), 'items', 'U3: row.items getter trap')] }),
+      /U3: row\.items getter trap/,
+    ],
+    [
+      'U4 `rowItems.length` — the item loop condition',
+      () => ({ items: [{ label: 'R', items: trapOn([{ ...GOOD_ITEM }], 'length', 'U4: rowItems.length trap') }] }),
+      /U4: rowItems\.length trap/,
+    ],
+    [
+      'U5 `rowItems[itemIndex]` — the item index get',
+      () => ({ items: [{ label: 'R', items: trapOn([{ ...GOOD_ITEM }], '0', 'U5: rowItems[0] trap') }] }),
+      /U5: rowItems\[0\] trap/,
+    ],
+    [
+      'U6 `rowItems[itemIndex]?.[key]` — the date read itself',
+      () => ({ items: [{ label: 'R', items: [trapOn({ ...GOOD_ITEM }, 'endDate', 'U6: endDate getter trap')] }] }),
+      /U6: endDate getter trap/,
+    ],
+  ];
+
+  for (const [label, make, message] of sites) {
+    it(`${label} is NOT total — it throws, by design`, () => {
+      expect(() => gantt(make())).toThrow(message);
+    });
+  }
+
+  /**
+   * The revoked `Proxy` reaches four of those six sites depending on WHERE it
+   * is pinned, and all four share one message because the language writes it.
+   * They are separate rows so that repairing one site turns exactly one red.
+   */
+  const revokedPositions: [string, () => Record<string, unknown>][] = [
+    ['as `items` itself (dies at U1)', () => ({ items: revokedProxy([]) })],
+    ['as a ROW (dies at U3)', () => ({ items: [revokedProxy()] })],
+    ["as a row's `items` (dies at U4)", () => ({ items: [{ label: 'R', items: revokedProxy([]) }] })],
+    ['as an ITEM (dies at U6)', () => ({ items: [{ label: 'R', items: [revokedProxy()] }] })],
+  ];
+
+  for (const [label, make] of revokedPositions) {
+    it(`a revoked Proxy ${label}`, () => {
+      expect(() => gantt(make())).toThrow(REVOKED_GET);
+    });
+  }
+
+  it('CONTROL — a LIVE Proxy at every one of those positions still DRAWS', () => {
+    // Without this the ten rows above would also pass if the gantt branch had
+    // simply broken. These are the same positions, proxied and not hostile, so
+    // the rows above are about REVOCATION and THROWING TRAPS and nothing else.
+    const live: [string, Record<string, unknown>][] = [
+      ['items', { items: new Proxy([goodRow()], {}) }],
+      ['a row', { items: [new Proxy(goodRow(), {})] }],
+      ["a row's items", { items: [{ label: 'R', items: new Proxy([{ ...GOOD_ITEM }], {}) }] }],
+      ['an item', { items: [{ label: 'R', items: [new Proxy({ ...GOOD_ITEM }, {})] }] }],
+    ];
+    for (const [where, schema] of live) {
+      const { container } = gantt(schema);
+      expect(diagnosticOf(container), `a live Proxy at ${where} was refused`).toBeNull();
+      expect(barCountOf(container), `a live Proxy at ${where} drew no bar`).toBe(1);
+      expect(axisOf(container)).toEqual(['Jan 2024', 'Feb 2024', 'Mar 2024']);
+    }
+  });
+});
+
+describe('pin 6 — `calculateDateRange`’s three reads: a DEFECT, pinned (objectui#7164)', () => {
+  /**
+   * ⛔ READ THIS BEFORE READING THE ROWS. Unlike pin 4 and pin 5, these throws
+   * are NOT adjudicated as acceptable and are NOT an excluded exotic class.
+   * They are a live defect, objectui#7164, and they are pinned here so the
+   * class is EXERCISED rather than asserted — because on this path an
+   * enumeration written only in prose has been wrong five times running.
+   *
+   * These rows are expected to go RED when objectui#7164 is repaired. That is
+   * their purpose: the repair cannot land quietly, and whoever lands it has to
+   * come back and rewrite this block and the two docblocks it points at.
+   *
+   * ## Why they are a different class from pin 5
+   *
+   * `findUnusableGanttDate` reads the row walk with `?.` and `|| []` and SKIPS
+   * a row it cannot index. `calculateDateRange` re-walks the same rows BARE.
+   * Everything in the gap crashes, and all of it is ordinary JSON:
+   *
+   *     items: [null]                 -> TypeError, at `row.items`
+   *     items: [{ items: 5 }]         -> TypeError, at `(row.items || []).flatMap`
+   *     items: {}                     -> TypeError, at `items.flatMap`
+   *
+   * `items: [null]` and `items: [{ items: 5 }]` also PASS the declared zod
+   * mirror, whose element type is `z.any()`, and `ObjectTimeline` hands
+   * authored rows through on a truthiness check alone. So "JSON cannot spell
+   * this", the argument that excuses pin 4 and pin 5, is simply false here.
+   *
+   * ## And why the repair is not attempted in this file's card
+   *
+   * Measured by ablation on 51449a043: making `calculateDateRange` tolerant
+   * closes none of the three and MOVES all three into the render loop
+   * (`items.map`, `row.label`, `(row.items || []).map`), with the ordinary-row
+   * control drawing its single bar on both sides of the mutation. The real
+   * repair spans three sites and first has to decide what a malformed ROW
+   * means — refuse the chart through a new i18n key, or skip the row, which is
+   * the consumer-side tolerance #6750 and #6759 both refused.
+   */
+
+  const defects: [string, Record<string, unknown>, RegExp][] = [
+    ['a `null` ROW', { items: [null] }, /Cannot read properties of null \(reading 'items'\)/],
+    ['a `null` row BESIDE a good one', { items: [goodRow(), null] }, /Cannot read properties of null \(reading 'items'\)/],
+    ["a row whose `items` is a number", { items: [{ label: 'R', items: 5 }] }, /flatMap is not a function/],
+    ["a row whose `items` is a plain object", { items: [{ label: 'R', items: {} }] }, /flatMap is not a function/],
+    ["a row whose `items` is `true`", { items: [{ label: 'R', items: true }] }, /flatMap is not a function/],
+    [
+      "a row whose `items` is ARRAY-LIKE — judged USABLE, then dies",
+      { items: [{ label: 'R', items: { length: 1, 0: { ...GOOD_ITEM } } }] },
+      /flatMap is not a function/,
+    ],
+    ['`items` itself a plain object', { items: {} }, /items\.flatMap is not a function/],
+    ['`items` itself a string', { items: 'x' }, /items\.flatMap is not a function/],
+    ['`items` itself a number', { items: 5 }, /items\.flatMap is not a function/],
+  ];
+
+  for (const [label, schema, message] of defects) {
+    it(`DEFECT — ${label} crashes the render`, () => {
+      expect(() => gantt(schema)).toThrow(message);
+    });
+  }
+
+  it('CONTROL — the row shapes NEXT TO the defect all still reach a defined outcome', () => {
+    // The live controls that make the nine rows above readings rather than a
+    // broken harness, and that fence the defect: these are the neighbouring
+    // shapes, and every one of them DRAWS or is NAMED.
+    const drawn: [string, Record<string, unknown>][] = [
+      ['an ordinary row', { items: [goodRow()] }],
+      ['an empty items list', { items: [] }],
+      ['a row with no `items` key', { items: [{ label: 'R' }] }],
+      ['a row whose `items` is null', { items: [{ label: 'R', items: null }] }],
+      ['a row whose `items` is an empty array', { items: [{ label: 'R', items: [] }] }],
+      ['a row that is the number 0', { items: [0] }],
+      ['a row that is an empty array', { items: [[]] }],
+    ];
+    for (const [label, schema] of drawn) {
+      const { container } = gantt(schema);
+      expect(diagnosticOf(container), `${label} was refused`).toBeNull();
+      expect(axisOf(container).length, `${label} drew no axis`).toBeGreaterThan(0);
+    }
+
+    // The one non-array `items` that does NOT crash: a string is
+    // index-readable, so the walk reaches `'x'[0]?.startDate`, reads
+    // `undefined`, and takes the ordinary refusal. Nobody designed that.
+    const { container } = gantt({ items: [{ label: 'R', items: 'x' }] });
+    expect(diagnosticOf(container) ?? '').toContain('items[0].items[0].startDate');
     expect(barCountOf(container)).toBe(0);
   });
 });

--- a/packages/plugin-timeline/src/renderer.tsx
+++ b/packages/plugin-timeline/src/renderer.tsx
@@ -238,7 +238,50 @@ function emptyGanttDateRange(): { minDate: string; maxDate: string } {
   return { minDate: today, maxDate: today };
 }
 
-// Helper function to calculate date range from items
+/**
+ * THE ROW WALK, READ A SECOND TIME AND READ DIFFERENTLY — objectui#7153.
+ *
+ * This function re-walks exactly what `findUnusableGanttDate` just walked, and
+ * the two do not agree about how to read it. That function uses `?.` and
+ * `|| []` and SKIPS a row it cannot index; this one assumes an array at every
+ * level. Every input in the gap between them reaches a `TypeError`:
+ *
+ *     D1  items.flatMap                  243   items is a truthy non-array
+ *     D2  row.items          (bare, no ?.) 244   items: [null]
+ *     D3  (row.items || []).flatMap      244   row.items is a truthy non-array
+ *                                              (5, true, {}, or array-LIKE)
+ *
+ * ⛔ THESE THREE ARE NOT THE EXCLUDED EXOTIC CLASS. The revoked proxies and
+ * throwing getters enumerated on `findUnusableGanttDate` are unreachable from
+ * an authored document because JSON cannot spell them. `items: [null]` is
+ * JSON. So is `items: [{ label: 'R', items: 5 }]`, and both PASS the declared
+ * zod mirror, whose element type is `z.any()`. `ObjectTimeline` hands authored
+ * rows through on a truthiness check alone. Measured in render on
+ * `51449a043`, beside five live drawing controls.
+ *
+ * The array-LIKE row is the sharpest reading of the disagreement:
+ * `findUnusableGanttDate` walks `{ length: 1, 0: { startDate, endDate } }`
+ * happily, JUDGES both dates USABLE, and the very next line dies on
+ * `.flatMap`. And `items: [{ items: 'x' }]` does NOT crash, because a string
+ * is index-readable and takes the ordinary refusal — an asymmetry nobody
+ * designed.
+ *
+ * ⛔ AND DO NOT REPAIR IT HERE, which is the part worth reading twice.
+ * Measured by ablation on `51449a043`: making this function tolerant
+ * (`Array.isArray(items) ? items : []` plus `row?.items`) closes ZERO of the
+ * three. It MOVES all three into the render loop below — `items.map` at 1235,
+ * `row.label` at 1237, `(row.items || []).map` at 1246 — with the ordinary-row
+ * control still drawing its 1 bar over a 3-cell axis on both sides of the
+ * mutation. Relocating a crash class while a docblock reports it closed is the
+ * mistake this code path has now made four times, so it is written down here
+ * rather than repeated.
+ *
+ * The repair spans this function, `findUnusableGanttDate` AND the render loop,
+ * and it first has to decide what a malformed ROW means — refuse the chart
+ * through a new diagnostic key (ten locale packs), or skip the row (the
+ * consumer-side tolerance #6750 and #6759 both refused). That adjudication is
+ * objectui#7164; it is not made here, and no code below pretends it was.
+ */
 function calculateDateRange(items: any[]): { minDate: string; maxDate: string } {
   const allDates = items.flatMap((row: any) =>
     (row.items || []).flatMap((item: any) => [item.startDate, item.endDate])
@@ -514,23 +557,33 @@ const isDate = (value: unknown): value is Date => {
  * 3. It would buy no invariant, because of the paragraph below.
  *
  * ⛔ `Array.isArray` IS NOT THE LAST NON-TOTAL OPERATION ON THE GANTT DATE
- * PATH, and this function cannot make the path total. Measured in the same
- * run: five further crash sites, every one of them reached BEFORE this
- * function is entered, in the property reads that FETCH the date out of the
- * authored document (`findUnusableGanttDate`'s `items[i]?.items` and
- * `rowItems[j]?.[key]`) —
+ * PATH, and this function cannot make the path total. The true and much
+ * narrower sentence is that `Array.isArray` is the last non-total operation
+ * INSIDE THIS FUNCTION. Everything upstream of it — the property reads that
+ * FETCH the date out of the authored document — is enumerated on
+ * `findUnusableGanttDate` and on `calculateDateRange`, which is where a reader
+ * asking "how far does this go?" should go next.
  *
- *     items[0].items[0] with a throwing `endDate` getter -> THREW
- *     items[0].items[0] is a revoked Proxy               -> THREW
- *     items[0]          is a revoked Proxy               -> THREW
- *     items[0].items    is a revoked Proxy               -> THREW
- *     items[0] with a throwing `items` getter            -> THREW
+ * ⚠️ objectui#7153 — TWO CORRECTIONS to the paragraph that used to stand here,
+ * both of them measurements, and the second one matters much more than the
+ * first.
  *
- * They are the same reachability class (JSON spells neither a getter nor a
- * proxy) and they are enumerated in objectui#7153 rather than repaired here —
- * they are a different function's surface. The true and much narrower
- * sentence is that `Array.isArray` is the last non-total operation INSIDE
- * THIS FUNCTION.
+ * It said FIVE upstream crash sites. Driven in render on `51449a043` the count
+ * is NINE: six in `findUnusableGanttDate` (its `items.length`, `items[i]`,
+ * `items[i]?.items`, `rowItems.length`, `rowItems[j]` and `rowItems[j]?.[key]`)
+ * and three in `calculateDateRange`. A tenth is identified by reading and
+ * recorded as NOT MEASURED. Five was written after a real measurement, and it
+ * was short — which is the fifth time prose on this path has been.
+ *
+ * It also said the upstream sites "are the same reachability class (JSON
+ * spells neither a getter nor a proxy)". That is TRUE of the six and FALSE of
+ * the three. `calculateDateRange` reads the same walk BARE — `items.flatMap`
+ * and `row.items` with no optional chaining — so an authored `items: [null]`,
+ * or a row whose `items` is a truthy non-array, crashes the render from
+ * ordinary JSON that the declared zod mirror accepts. That is a live defect,
+ * objectui#7164, not an excluded exotic. The exclusion argument this docblock
+ * makes for its own `Array.isArray` covers the six and must not be borrowed
+ * for the three.
  *
  * ⚠️ Whatever totality this docblock claims is bounded by an EXERCISED input
  * set — the rows in `__tests__/timeline-gantt-date-brand-7027.test.tsx`,
@@ -791,6 +844,113 @@ const isGanttDateType = (value: unknown): value is string | number | Date =>
   (typeof value === 'number' && Number.isFinite(value)) ||
   isDate(value);
 
+/**
+ * WHAT THE ROW WALK BELOW READS, AND WHERE THAT READING IS NOT TOTAL —
+ * objectui#7153, the enumeration objectui#7036's docblock pointed at.
+ *
+ * ## Read this as a BOUNDED READING, not as a totality claim
+ *
+ * Five cards before this one made a totality claim about this code path
+ * (#6759 -> #6905 -> #6907 -> #7027 -> #7036) and FOUR were falsified by the
+ * next card's measurement. #7153 is the fourth falsification: it measured that
+ * `spellGanttDateValue`'s `Array.isArray` is not "the last non-total operation
+ * on the gantt date path", only the last one inside that function.
+ *
+ * So this block does not say the walk is total, and it does not say the list
+ * below is complete. It says: these are the operations that were DRIVEN, in
+ * render, through `TimelineRenderer` on `51449a043`, and this is what each one
+ * did. Everything outside that input set is unmeasured, which is a third thing
+ * and not a quiet green.
+ *
+ * ## THE SITES, each with the input that drove it and the frame it threw from
+ *
+ * `?.` guards `null` and `undefined`. It does not guard a getter that throws
+ * or a revoked `Proxy`: those crash INSIDE the read, before any value exists
+ * to judge, so the type gate above never sees them.
+ *
+ *     U1  items.length                 818  items is a revoked Proxy;
+ *                                           items has a throwing length trap
+ *     U2  items[rowIndex]              819  items has a throwing index trap
+ *     U3  items[rowIndex]?.items       819  the ROW is a revoked Proxy;
+ *                                           the row has a throwing items getter
+ *     U4  rowItems.length              820  row.items is a revoked Proxy;
+ *                                           row.items has a throwing length trap
+ *     U5  rowItems[itemIndex]          822  row.items has a throwing index trap
+ *     U6  rowItems[itemIndex]?.[key]   822  the ITEM is a revoked Proxy;
+ *                                           the item has a throwing date getter
+ *
+ * SIX here, and THREE more in `calculateDateRange` (see that function). NINE
+ * measured, where #7153's card said five and #7036's docblock repeated it. The
+ * count was never the point, but it is the evidence that prose counting on
+ * this path is a hypothesis: both numbers were written after a real
+ * measurement, and both were short.
+ *
+ * A tenth read — `item.startDate` / `item.endDate` inside
+ * `calculateDateRange`'s inner `flatMap` — is bare and would throw on a `null`
+ * item, but it is SHADOWED here: U6's `?.` turns a `null` item into
+ * `undefined`, which the type gate refuses, so the render never reaches it.
+ * That shadow is an accident of two functions written apart, not a guard, and
+ * it is recorded as NOT MEASURED: no input was found that reaches it.
+ *
+ * ## TWO REACHABILITY CLASSES, and they must not be merged
+ *
+ * 1. THE SIX ABOVE — unreachable from an authored document. ObjectUI metadata
+ *    is JSON and JSON spells neither a getter nor a proxy. Re-swept on
+ *    `51449a043` with the comment-stripped instrument, each zero beside a live
+ *    control on that same instrument: across every package `src/` excluding
+ *    tests, `Proxy.revocable` 0, `new Proxy` 0, the bare word `Proxy` 0, and
+ *    `Object.setPrototypeOf` 0 — against `Object.assign` 19 and `JSON.parse`
+ *    105. Widened to the whole repo the SAME query returns `Proxy.revocable`
+ *    1, `new Proxy` 21 and `Proxy` 105 (all in tests, one of them this file's
+ *    own factory), which is what makes the narrow zeros readings rather than a
+ *    broken query.
+ *
+ * 2. `calculateDateRange`'s THREE — ordinary JSON, and a live defect
+ *    (objectui#7164). They are NOT this class, they are not p3, and the note
+ *    on that function carries them. Do not let the paragraph above be read as
+ *    covering them: the sentence "JSON cannot spell this" is true of the six
+ *    and false of the three, and collapsing the two is how this docblock would
+ *    start overclaiming again.
+ *
+ * ## WHY A `catch` IS NOT PUT HERE — re-tested, not inherited from #7036
+ *
+ * #7036 refused a `catch` at the speller because it would SUBSTITUTE `an
+ * object` for a failure rather than read anything, the opposite of `isDate`'s
+ * `catch` (which IS the read, because the language exposes `[[DateValue]]`
+ * only by throwing). #7153's dispatch required that argument to be re-tested
+ * upstream rather than assumed, because upstream is not the same shape. It was
+ * tested, by ablation, and it comes out DIFFERENTLY — in half:
+ *
+ * A `try` around U6 alone, reporting the path built from the loop counters,
+ * was measured in-render. The PATH half is a genuine READ: the throwing-getter
+ * input came back NAMED as `items[0].items[0].endDate`, exact, including the
+ * key whose getter threw — because the path is built from `rowIndex`,
+ * `itemIndex` and `key` and never touches the value. The speller's `catch` has
+ * no such thing; it holds only the value it cannot read.
+ *
+ * The VALUE half is still substitution. The measured diagnostic read `...
+ * endDate is "UNREADABLE", which is not a valid date` — a placeholder standing
+ * in the `{value}` hole of `timeline.gantt.unusableRange.malformedDate`. There
+ * is no true spelling for a value that cannot be touched, so a real repair
+ * needs a value-less diagnostic, which is a new i18n key across ten locale
+ * packs: the file surface #7036 deferred as a separate decision.
+ *
+ * And the coverage is the same shape of error #7036's triage caught. That
+ * `catch` converted THREE of the nine measured sites (U5, U6, and the
+ * throwing-getter item) and left the other six throwing — U1 through U4 are
+ * upstream of it, and `calculateDateRange`'s three are downstream. The PASSING
+ * control held either way: an ordinary row drew 1 bar over a 3-cell axis
+ * before and after. One `catch` here would buy 3 of 9 while a docblock went on
+ * implying the walk was safe, which is exactly the "1 of 6" trade #7036 was
+ * stopped from making.
+ *
+ * ## So this is STATED AND EXERCISED, on #7036's terms
+ *
+ * The rows are in `./__tests__/timeline-gantt-date-brand-7027.test.tsx`, pin
+ * 5, asserting each throw's own MESSAGE so the pin fails if a site MOVES as
+ * well as if it is repaired — a bare `toThrow()` would stay green through
+ * exactly the relocation this path has performed four times.
+ */
 function findUnusableGanttDate(
   items: any[],
   pinnedMinDate: unknown,


### PR DESCRIPTION
Fixes #7153

Re-derived on `51449a043`, which already carries #7157 (`869b876c8`) — the docblock this card was filed against.

Documentation and pinned tests only. No behaviour changes, no export changes, no i18n keys.

## The headline: the card's own count and class were both wrong

#7153 said FIVE non-total operations upstream of the speller, all of them the same p3 reachability class. Driven in render through the real `TimelineRenderer` on `51449a043`:

- **NINE**, not five. Six in `findUnusableGanttDate` (`items.length`, `items[i]`, `items[i]?.items`, `rowItems.length`, `rowItems[j]`, `rowItems[j]?.[key]`), three in `calculateDateRange`. A tenth is identified by reading and recorded as NOT MEASURED — `item.startDate` / `item.endDate` are bare, but U6's `?.` shadows them and no input was found that reaches them.
- **Two classes, not one.** The six are unreachable from an authored document. The three in `calculateDateRange` are **ordinary JSON**, and they are a live defect: filed as #7164, not addressed in this PR.

Each site is attributed by the stack frame it threw from, per site:

```
U1  items.length                818:43   revoked Proxy as items; throwing length trap
U2  items[rowIndex]             819:23   throwing index trap
U3  items[rowIndex]?.items      819:38   revoked Proxy as the ROW; throwing `items` getter
U4  rowItems.length             820:50   revoked Proxy as row.items; throwing length trap
U5  rowItems[itemIndex]         822:23   throwing index trap
U6  rowItems[itemIndex]?.[key]  822:42   revoked Proxy as the ITEM; throwing date getter
D1  items.flatMap               243:26   items is a truthy non-array          <- JSON
D2  row.items      (bare)       244:10   items: [null]                        <- JSON
D3  (row.items || []).flatMap   244:23   row.items is a truthy non-array      <- JSON
CONTROL  an ordinary row                 DREW bars=1 axisCells=3
```

## Which branch of the either/or, and the measurement that chose it

The **docblock branch** (#7036's precedent, `869b876c8`), on three measurements rather than on inheritance.

**1. Repairing inside the ruled scope closes nothing.** Ablation: making `calculateDateRange` tolerant (`Array.isArray(items) ? items : []` plus `row?.items`) closes ZERO of the three JSON-reachable crashes. It MOVES all three into the render loop — `items.map` at 1235, `row.label` at 1237, `(row.items || []).map` at 1246 — with the ordinary-row control drawing its single bar on both sides. Relocating a crash class while a docblock reports it closed is the mistake this path has made four times.

**2. A `catch` upstream DOES read something — half of it.** #7153's dispatch required this to be re-tested rather than inherited from #7036, and it comes out **differently**. Ablation: a `try` around U6 reporting the path built from the loop counters came back NAMED `items[0].items[0].endDate` — exact, including the key whose getter threw, because the path is built from indices and never touches the value. The speller's `catch` has no such thing; it holds only the value it cannot read. But the VALUE half is still substitution (`is "UNREADABLE"`), so a real repair needs a value-less diagnostic and therefore a new i18n key across ten locale packs — the file surface #7036 deferred. And the coverage is #7036's own trade at a different site: that `catch` converted **3 of 9** and left six throwing.

**3. The reachability sweep still holds for the six.** Re-run on `51449a043` with a comment-stripped instrument. Across every package `src/` outside tests: `Proxy.revocable` 0, `new Proxy` 0, the bare word `Proxy` 0, `Object.setPrototypeOf` 0 — beside live controls `Object.assign` 19 and `JSON.parse` 105 on that same instrument. The SAME query widened to the whole repo returns `Proxy.revocable` 1, `new Proxy` 21, `Proxy` 105 (tests only), which is what makes the narrow zeros readings rather than a broken query.

## What is in the diff

- `renderer.tsx` — a docblock on `findUnusableGanttDate` enumerating U1..U6 with the input that drove each, separating the two reachability classes, and recording the re-tested `catch` result; a docblock on `calculateDateRange` carrying D1..D3, the ablation, and the deferral to #7164; and a correction to `spellGanttDateValue`'s block, whose "five further crash sites, the same reachability class" paragraph was wrong twice.
- `timeline-gantt-date-brand-7027.test.tsx` — **pin 5** (the six, stated-and-exercised on #7036's terms, each assertion naming the throw's own MESSAGE so a row fails if the site MOVES as well as if it is repaired, plus a live-Proxy control at all four positions) and **pin 6** (the three, pinned explicitly as a DEFECT and not as behaviour, with seven drawing controls).

⚠️ No claim here is a totality claim. Every statement in both docblocks is bounded to the input set in that file and says so.

## Verification — all on `5213e66d3`

```
pnpm exec vitest run packages/plugin-timeline/          Test Files 19 passed (19)   Tests 247 passed (247)
  (brand-7027 alone: 36 passed, was 15 — pin 5 adds 11, pin 6 adds 10)
pnpm --filter @object-ui/plugin-timeline run type-check  exit 0, script echoed
pnpm --filter @object-ui/plugin-timeline run lint        exit 0 — 0 errors (98 pre-existing warnings)
node scripts/check-changeset-presence.mjs
  "✅  2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
   ... Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
   is the explicit exemption and a complete answer to this gate."
node scripts/check-changeset-no-major.mjs   "✅  No changeset declares a `major` bump."
check:control-bytes ✅ · check:vi-mock-specifiers ✅ · check:vi-mock-inherit ✅ · check:i18n-keys ✅
check:i18n-dead-keys ✅ · check:shell-escape-residue ✅ · check:self-import ✅ · check:phantom-deps ✅
check:element-data-source-declaration ✅
check:sdui-registration-pins — NOT MEASURED, exit 2 on a prerequisite ("No console build to weigh
  at apps/console/dist/assets"), unrelated to this diff, which touches no registration.
```

**Both new pins were proved able to move**, since a pin that cannot fail measures nothing:

| ablation (mutation proved on disk by marker counts and a moved blob hash; restore proved by blob equality with HEAD and an empty `git diff HEAD`) | predicted | measured |
|---|---|---|
| tolerant `calculateDateRange` | pin 6's 9 rows red, rest green | **9 failed, 27 passed** |
| `try` around the whole row walk | pin 5's 10 throw-rows red, its control green | **10 failed, 26 passed** |

**Declared narrowing**: lint was run per-package rather than repo-wide. The population is eslint's own (26 files, counted from `--format json`, not guessed), and type-aware linting is not enabled — `languageOptions` carries only `ecmaVersion` and `globals`, no `project` / `projectService` — so a comments-and-tests diff inside one package cannot move any untouched file's verdict. CI runs the repo-wide scan regardless.

## Out of scope

#7164 is not addressed here and remains open. #7036's `Array.isArray` is untouched, and #6907's deliberate choice there was not re-opened. #6781's accept set does not move.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_