### PR TITLE
fix(plugin-charts): pie, funnel and treemap say when rows carry no magnitude they can draw

### DIFF
--- a/.changeset/degenerate-magnitude-charts.md
+++ b/.changeset/degenerate-magnitude-charts.md
@@ -1,0 +1,20 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+Pie, donut, funnel and treemap now say when rows carry no magnitude they can draw.
+
+These four families size a mark BY its measure, so a row whose value is zero,
+negative, `null` or unparseable stays in the data and is given no area. Measured
+in Chromium across 74 tiles: an all-zero pie put ZERO non-white pixels on the
+page while its DOM carried 31 descendants and a real `svg`; a treemap handed
+`40 / null`, `40 / 0` or `40 / -25 / -12` rendered one full-bleed leaf that was
+byte-identical to a genuinely one-row treemap; and a funnel handed `40` beside a
+`null` drew no segments at all and labelled the tile with the row that had no
+value.
+
+When no row can be sized, these charts now render the file's refusal shell
+(`no-positive-magnitude`) instead of a blank tile. When only some rows can be
+sized, the chart still draws and carries a note counting the ones it could not.
+All-positive charts, charts handed no rows at all, bar charts, and both sankey
+answers are unchanged.

--- a/packages/plugin-charts/src/AdvancedChartImpl.degenerateMagnitude.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.degenerateMagnitude.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Pie / donut / funnel / treemap — rows that are NEVER filtered and are given
+ * no area anyway (objectui#7147). The third mechanism on this surface, and the
+ * one neither landed answer reaches.
+ *
+ * ## Three mechanisms, one reader-facing symptom
+ *
+ *   - objectui#7140 / objectui#7146 — an early return emitting a bare `div`
+ *   - objectui#7148 — a silent row DROP before the plot
+ *   - objectui#7147 — DEGENERATE GEOMETRY, pinned here
+ *
+ * objectui#7148's footnote counts dropped rows (`data.length - rows.length`).
+ * Against these four families that count is exactly ZERO — the sankey arm holds
+ * the only row-dropping filter in the file — so hoisting it here would have
+ * rendered nothing at all while looking like coverage. The rows stay in `data`
+ * and the LAYOUT gives them no area. Zero area is not zero elements, and
+ * neither is a dropped row.
+ *
+ * ## The measurement that decided fix-over-decline, per family
+ *
+ * 74 tiles in real Chromium (`/opt/pw-browsers/chromium`) at `origin/main`
+ * 40c4711d6, each screenshotted, MD5'd and pixel-diffed against a literally
+ * empty `div` of the same box. `measured-and-declined` was on the table for
+ * every family, as the card says, and survived for none of the four:
+ *
+ *   - pie / donut all-zero, all-null, all-negative: ZERO non-white pixels out
+ *     of 124,800 — byte-identical to the empty div, with 31 descendants and a
+ *     real `svg` in the DOM.
+ *   - pie / donut `40` beside a `null`: a FULL circle in the first category's
+ *     colour, 99.35% pixel-identical to a legitimately one-row dataset (the
+ *     0.654% residue is the `paddingAngle` hairline, not information).
+ *   - funnel `40` beside a `null`: 178 ink pixels — ZERO segments, ONE label,
+ *     and the label reads "Beta", the row with NO value. The row carrying 40
+ *     drew nothing at all.
+ *   - funnel all-negative: a confident two-band funnel whose mark area
+ *     (220,320) EXCEEDS the all-positive control's (111,881).
+ *   - treemap `40 / null`, `40 / 0` and `40 / -25 / -12`: all three
+ *     BYTE-IDENTICAL (diff 0.000%) to a genuinely one-row treemap. Four
+ *     datasets, one image.
+ *   - treemap all-zero: ONE full-bleed leaf labelled with the LAST category.
+ *
+ * The controls are what make those zeros mean anything: an all-zero BAR drew
+ * 5,128 ink pixels of axes and ticks on the same instrument — which is why bar
+ * is deliberately untouched and pinned that way below — a two-row pie differed
+ * from a one-row pie by 9.683% of its pixels, and a two-row treemap from a
+ * one-row treemap by 38.301%.
+ *
+ * ## What this file pins, and why the passing cases are the discriminating half
+ *
+ * The refusal and the note are only half the pin. The other half is everything
+ * that must NOT have moved: the all-positive control of every family keeps its
+ * exact DOM (no wrapper element), the no-rows case stays byte-for-byte as it
+ * was (that is the empty-RESULT question, objectui#7130, answered upstream in
+ * `ObjectChart`), bar keeps its axes, and BOTH landed sankey answers keep
+ * firing on their own datasets under their own codes. Measured across the same
+ * 74 tiles: every sankey tile and every bar tile hashed IDENTICALLY before and
+ * after this change.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+const SERIES = [{ dataKey: 'amount', label: 'Amount' }];
+
+type Row = Record<string, unknown>;
+
+const renderChart = (chartType: string, data: Row[]) =>
+  render(
+    <AdvancedChartImpl
+      chartType={chartType as any}
+      xAxisKey="stage"
+      series={SERIES as any}
+      data={data as any}
+    />,
+  );
+
+const refusalOf = (c: HTMLElement) => c.querySelector('[data-chart-error="no-positive-magnitude"]');
+const noteOf = (c: HTMLElement) => c.querySelector('[data-chart-note="unsized-rows"]');
+const plotOf = (c: HTMLElement) => c.querySelector('[data-slot="chart"]');
+
+/** The four families whose layout sizes a mark BY its measure. */
+const MAGNITUDE_FAMILIES = ['pie', 'donut', 'funnel', 'treemap'] as const;
+
+/**
+ * Every shape that reaches the layout carrying no positive magnitude.
+ *
+ * The copy deliberately names NONE of them, for the reason `no-positive-flow`'s
+ * docstring gives: a message saying "negative" is false of the `null` row, one
+ * saying "zero" is false of the unparseable string, and one naming a missing key
+ * is false of all four others. The predicate is true of every one of them, so
+ * the predicate is what the sentence names.
+ */
+const UNSIZABLE: Array<[string, unknown]> = [
+  ['a genuine zero', 0],
+  ['a negative', -25],
+  ['null', null],
+  ['undefined', undefined],
+  ['an unparseable string', 'n/a'],
+  ['Infinity, which `Number(x) || 0` would let through', 'Infinity'],
+];
+
+describe('objectui#7147 — no row can be sized: the chart refuses instead of drawing nothing', () => {
+  for (const family of MAGNITUDE_FAMILIES) {
+    for (const [label, value] of UNSIZABLE) {
+      it(`${family}: every row carrying ${label} gets a refusal, not a blank tile`, () => {
+        const { container } = renderChart(family, [
+          { stage: 'Alpha', amount: value },
+          { stage: 'Beta', amount: value },
+        ]);
+        const refusal = refusalOf(container);
+        expect(refusal).not.toBeNull();
+        // The message names the KEY and the exact test it failed — the same
+        // diagnostic pair `no-positive-flow` carries, which is why neither
+        // needs a console warning.
+        expect(refusal!.textContent).toContain('amount');
+        expect(refusal!.textContent).toContain('above zero');
+        // A refusal REPLACES the plot; it does not sit beside one.
+        expect(plotOf(container)).toBeNull();
+        expect(noteOf(container)).toBeNull();
+      });
+    }
+  }
+
+  it('a missing measure key on every row refuses too', () => {
+    const { container } = renderChart('pie', [{ stage: 'Alpha' }, { stage: 'Beta' }]);
+    expect(refusalOf(container)).not.toBeNull();
+  });
+
+  it('the refusal uses its OWN code, never the sankey arm\'s', () => {
+    const { container } = renderChart('funnel', [
+      { stage: 'Alpha', amount: 0 },
+      { stage: 'Beta', amount: 0 },
+    ]);
+    expect(refusalOf(container)).not.toBeNull();
+    expect(container.querySelector('[data-chart-error="no-positive-flow"]')).toBeNull();
+  });
+});
+
+describe('objectui#7147 — SOME rows can be sized: the chart still draws, and says how many it could not', () => {
+  for (const family of MAGNITUDE_FAMILIES) {
+    for (const [label, value] of UNSIZABLE) {
+      it(`${family}: one good row beside ${label} still DRAWS, with a note`, () => {
+        const { container } = renderChart(family, [
+          { stage: 'Alpha', amount: 40 },
+          { stage: 'Beta', amount: value },
+        ]);
+        // The plot is not blanked — objectui#7146 pins the analogous "one
+        // positive row among zeros still draws" for the sankey arm, and the
+        // same must hold here or a fix becomes a regression.
+        expect(plotOf(container)).not.toBeNull();
+        expect(refusalOf(container)).toBeNull();
+        const note = noteOf(container);
+        expect(note).not.toBeNull();
+        expect(note!.getAttribute('role')).toBe('note');
+        expect(note!.textContent).toContain('1 of 2 rows has');
+        expect(note!.textContent).toContain('amount');
+      });
+    }
+  }
+
+  it('the COUNT is the half a reader cannot recover from the picture', () => {
+    const { container } = renderChart('treemap', [
+      { stage: 'Alpha', amount: 40 },
+      { stage: 'Beta', amount: -25 },
+      { stage: 'Gamma', amount: -12 },
+    ]);
+    // Measured: this dataset rendered ONE full-bleed leaf, byte-identical to a
+    // genuinely one-row treemap. "Some rows" would leave those two images
+    // identical in meaning; "2 of 3" is the bit that was missing.
+    expect(noteOf(container)!.textContent).toContain('2 of 3 rows have');
+  });
+
+  it('the note uses its OWN attribute, never objectui#7148\'s', () => {
+    const { container } = renderChart('pie', [
+      { stage: 'Alpha', amount: 40 },
+      { stage: 'Beta', amount: 0 },
+    ]);
+    expect(noteOf(container)).not.toBeNull();
+    expect(container.querySelector('[data-chart-note="omitted-rows"]')).toBeNull();
+  });
+});
+
+describe('objectui#7147 — the cases that must NOT have moved', () => {
+  for (const family of MAGNITUDE_FAMILIES) {
+    it(`${family}: an all-positive chart gains no note, no refusal and NO WRAPPER`, () => {
+      const { container } = renderChart(family, [
+        { stage: 'Alpha', amount: 40 },
+        { stage: 'Beta', amount: 25 },
+      ]);
+      expect(refusalOf(container)).toBeNull();
+      expect(noteOf(container)).toBeNull();
+      // `ChartFootnote` with a null note returns its children untouched, so the
+      // plot stays the FIRST element — no existing caller gains a wrapper.
+      expect(container.firstElementChild?.getAttribute('data-slot')).toBe('chart');
+    });
+
+    it(`${family}: handed NO rows at all, nothing is said`, () => {
+      // The empty-RESULT question (objectui#7130) is answered upstream in
+      // `ObjectChart`, where the query outcome is actually known. "No row's
+      // measure is above zero" would be a sentence about rows that do not
+      // exist.
+      const { container } = renderChart(family, []);
+      expect(refusalOf(container)).toBeNull();
+      expect(noteOf(container)).toBeNull();
+    });
+  }
+
+  it('bar is untouched: an all-zero bar chart still draws its axes and says nothing', () => {
+    // Deliberate, and measured: an all-zero bar drew 5,128 ink pixels of axes
+    // and ticks against a blank tile's 0. Its reader can already tell a zero
+    // dataset from a broken widget, so bar is outside this card.
+    const { container } = renderChart('bar', [
+      { stage: 'Alpha', amount: 0 },
+      { stage: 'Beta', amount: 0 },
+    ]);
+    expect(refusalOf(container)).toBeNull();
+    expect(noteOf(container)).toBeNull();
+    expect(plotOf(container)).not.toBeNull();
+  });
+});
+
+describe('objectui#7147 — the seam with the two landed sankey answers, pinned from both sides', () => {
+  it('an all-zero SANKEY keeps objectui#7146\'s refusal and never gets this one', () => {
+    const { container } = renderChart('sankey', [
+      { stage: 'Alpha', amount: 0 },
+      { stage: 'Beta', amount: 0 },
+    ]);
+    expect(container.querySelector('[data-chart-error="no-positive-flow"]')).not.toBeNull();
+    expect(refusalOf(container)).toBeNull();
+  });
+
+  it('a thinned SANKEY keeps objectui#7148\'s footnote and never gets this note', () => {
+    const { container } = renderChart('sankey', [
+      { stage: 'Alpha', amount: 40 },
+      { stage: 'Beta', amount: -25 },
+    ]);
+    expect(container.querySelector('[data-chart-note="omitted-rows"]')).not.toBeNull();
+    expect(noteOf(container)).toBeNull();
+  });
+
+  it('the three codes are mutually exclusive on every dataset in the sweep', () => {
+    const datasets: Row[][] = [
+      [{ stage: 'Alpha', amount: 0 }, { stage: 'Beta', amount: 0 }],
+      [{ stage: 'Alpha', amount: 40 }, { stage: 'Beta', amount: null }],
+      [{ stage: 'Alpha', amount: 40 }, { stage: 'Beta', amount: 25 }],
+      [],
+    ];
+    for (const family of [...MAGNITUDE_FAMILIES, 'sankey', 'bar']) {
+      for (const data of datasets) {
+        const { container } = renderChart(family, data);
+        const codes = [
+          container.querySelector('[data-chart-error="no-positive-flow"]'),
+          container.querySelector('[data-chart-error="no-positive-magnitude"]'),
+          container.querySelector('[data-chart-note="omitted-rows"]'),
+          container.querySelector('[data-chart-note="unsized-rows"]'),
+        ].filter(Boolean).length;
+        expect(codes).toBeLessThanOrEqual(1);
+        cleanup();
+      }
+    }
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -408,6 +408,146 @@ function ChartFootnote({ note, children }: { note?: React.ReactNode; children: R
 }
 
 /**
+ * How many rows a MAGNITUDE chart can actually give area to (objectui#7147).
+ *
+ * ## The third mechanism, and why neither landed answer reaches it
+ *
+ * Three distinct mechanisms on this surface produce ONE reader-facing symptom —
+ * a tile that says nothing, or says something false, about rows it was handed:
+ *
+ *   - an early return that emits a bare `div`  — objectui#7140 / objectui#7146
+ *   - a silent row DROP before the plot        — objectui#7148
+ *   - DEGENERATE GEOMETRY, which is this one   — objectui#7147
+ *
+ * The rows here are never filtered. `data` reaches `<Pie>`, `<Funnel>` and
+ * `<Treemap>` whole — the sankey arm's is the only row-dropping filter in this
+ * file — and what happens instead is that a row whose measure is not above zero
+ * is given no area. objectui#7148's count (`data.length - rows.length`) is
+ * therefore exactly ZERO against these three families, so hoisting that
+ * footnote here would render nothing at all while looking like coverage. Zero
+ * area is not zero elements, and neither is a dropped row.
+ *
+ * ## The measurement that decided fix-over-decline, per family
+ *
+ * 56 tiles in real Chromium (`/opt/pw-browsers/chromium`) at `origin/main`
+ * 40c4711d6 — six families x nine datasets — each tile screenshotted, MD5'd,
+ * and pixel-diffed against a literally empty `div` of the same 520x240 box.
+ * `measured-and-declined` was genuinely on the table for all three families,
+ * as the card says, and survived for none of them:
+ *
+ *   - pie / donut, all-zero, all-null, all-negative: ZERO non-white pixels out
+ *     of 124,800. Not blank-LOOKING — byte-identical to the empty div, while
+ *     the DOM carried 31 descendants and a real `svg`.
+ *   - pie / donut, `40` beside a `null`: a FULL circle in the first category's
+ *     colour, 99.35% pixel-identical to a legitimately one-row dataset (diff
+ *     0.654%, and that residue is the `paddingAngle` hairline, not
+ *     information). The picture asserts "Alpha is 100%" of a dataset in which
+ *     Beta was never measured at all.
+ *   - funnel, `40` beside a `null`: 178 ink pixels — ZERO segments and ONE
+ *     label, and the label is "Beta", the row with NO value. The row carrying
+ *     40 draws nothing whatsoever.
+ *   - funnel, all-negative: a large, healthy-looking two-band funnel whose mark
+ *     area (220,320) EXCEEDS the all-positive control's (111,881).
+ *   - treemap, `40` beside a `null`, `40` beside a `0`, and mixed-sign
+ *     `40 / -25 / -12`: all three BYTE-IDENTICAL (diff 0.000%) to a genuinely
+ *     one-row treemap — one full-bleed leaf labelled "Alpha". Four datasets,
+ *     one image.
+ *   - treemap, all-zero: one full-bleed leaf labelled "Beta" — the LAST
+ *     category — asserting that one of two equal-zero categories is the entire
+ *     composition.
+ *
+ * The controls are what make those zeros readable. On the same instrument an
+ * all-zero BAR drew 5,128 ink pixels of axes and ticks — which is why bar is
+ * deliberately NOT touched here: its reader can already tell. A two-row pie
+ * differed from a one-row pie by 9.683% of its pixels and a two-row treemap
+ * from a one-row treemap by 38.301%, so the instrument separates these datasets
+ * easily whenever the renderer does.
+ *
+ * ## Why the predicate is `> 0`, and why the copy names it
+ *
+ * The reason `no-positive-flow`'s docstring gives. Five shapes reach here — a
+ * genuine zero, a negative, `null`, an unparseable string, and a missing key —
+ * and naming any ONE of them is a sentence that is false for the other four.
+ * A strictly positive, finite measure is the single test all three families'
+ * layouts effectively apply, so the copy names THAT.
+ *
+ * `Number.isFinite(v) && v > 0` rather than the sankey arm's `Number(...) || 0`
+ * idiom: this predicate must also reject `Infinity`, which has no finite area
+ * to occupy anywhere and which `|| 0` lets straight through.
+ */
+function countSizableRows(rows: unknown[], dataKey: string): { sizable: number; total: number } {
+  let sizable = 0;
+  for (const row of rows) {
+    const v = Number((row as Record<string, unknown> | null | undefined)?.[dataKey]);
+    if (Number.isFinite(v) && v > 0) sizable += 1;
+  }
+  return { sizable, total: rows.length };
+}
+
+/**
+ * The refusal a magnitude chart renders when NO row can be sized.
+ *
+ * The same shell and the same shape of sentence as `no-positive-flow`, and
+ * deliberately a DIFFERENT code: that one is the sankey arm's and answers rows
+ * being DROPPED, this one answers geometry that collapses with every row still
+ * present. Sharing a code would make the two indistinguishable to the pins that
+ * exist to keep them apart.
+ *
+ * Callers gate it on `total > 0`, for the reason objectui#7146 gives: handed NO
+ * rows, "no row's measure is above zero" is a sentence about rows that do not
+ * exist. That is the empty-RESULT question (objectui#7130), answered upstream in
+ * `ObjectChart` where the query outcome is known — so every no-rows tile is left
+ * byte-for-byte as it was.
+ */
+function MagnitudeRefusal({ dataKey, className }: { dataKey: string; className?: string }) {
+  return (
+    <ChartRefusal code="no-positive-magnitude" className={className}>
+      This chart has nothing to size: no row&apos;s{' '}
+      <code className="font-mono">{dataKey}</code> is above zero.
+    </ChartRefusal>
+  );
+}
+
+/**
+ * The note a magnitude chart carries when SOME rows can be sized and some cannot.
+ *
+ * Returns `null` when every row is sizable, and that is the gate which keeps
+ * healthy charts byte-identical: `ChartFootnote` with no note renders its
+ * children untouched, so no existing caller gains a wrapper element.
+ *
+ * ## Why it does NOT say "showing N of M rows"
+ *
+ * objectui#7148's sankey note can say that, because there the missing rows are
+ * genuinely absent from the plot. Here they are not. A mixed-sign pie PAINTS a
+ * sector for every row — measured: `40 / -25 / -12` drew 3 sectors — it just
+ * paints them at a scale that means nothing, and a funnel handed the same rows
+ * drew 3 trapezoids. "Showing 1 of 3" would be a false statement about what is
+ * on the screen. What IS true of every one of them is that the chart sizes by
+ * value and these rows carry no value it can size, so that is what the copy
+ * says.
+ *
+ * `rows` is an unconditional plural because the note cannot render with fewer
+ * than two: reaching it at all means at least one row was sized (otherwise the
+ * refusal returned first) and at least one was not.
+ *
+ * No console warning, matching the two sankey answers and unlike the two guards
+ * at the bottom of this file: those carry a diagnostic PAIR that does not fit on
+ * screen, whereas this sentence already names the key, the test it failed, and
+ * how many rows failed it.
+ */
+function unsizedRowsNote(sizable: number, total: number, dataKey: string): React.ReactNode {
+  const unsized = total - sizable;
+  if (unsized <= 0) return null;
+  return (
+    <p role="note" data-chart-note="unsized-rows" className="px-1 text-xs text-muted-foreground">
+      {unsized} of {total} rows {unsized === 1 ? 'has' : 'have'} no{' '}
+      <code className="font-mono">{dataKey}</code> above zero &mdash; this chart sizes by value, so{' '}
+      {unsized === 1 ? 'that row is' : 'those rows are'} not drawn to scale.
+    </p>
+  );
+}
+
+/**
  * AdvancedChartImpl - The heavy implementation that imports Recharts with full features
  * This component is lazy-loaded to avoid including Recharts in the initial bundle
  */
@@ -937,6 +1077,16 @@ function AdvancedChartImplInner({
   if (chartType === 'pie' || chartType === 'donut') {
     const innerRadius = chartType === 'donut' ? '52%' : 0;
     const palette = getPalette();
+    // objectui#7147 — see `countSizableRows`. A slice's angle is its share of
+    // the positive total, so a row that is zero, negative, null or unparseable
+    // is drawn as nothing at all while staying in `data`. Measured: all-zero,
+    // all-null and all-negative pies each put ZERO non-white pixels on a
+    // 520x240 tile, byte-identical to an empty div.
+    const pieDataKey = series[0]?.dataKey || 'value';
+    const pieSizable = countSizableRows(data, pieDataKey);
+    if (pieSizable.total > 0 && pieSizable.sizable === 0) {
+      return <MagnitudeRefusal dataKey={pieDataKey} className={className} />;
+    }
     // Augment the chart config with one entry per category value so that
     // `ChartLegendContent` (which resolves item labels via `config[key]`)
     // can render the slice labels next to the color swatches. Without
@@ -954,13 +1104,13 @@ function AdvancedChartImplInner({
         };
       }
     });
-    return (
+    const pieChart = (
       <ChartContainer config={pieConfig} className={className} {...containerProps}>
         <PieChart>
           <ChartTooltip cursor={false} content={<ChartTooltipContent hideLabel />} />
           <Pie
             data={data}
-            dataKey={series[0]?.dataKey || 'value'}
+            dataKey={pieDataKey}
             nameKey={xAxisKey || 'name'}
             innerRadius={innerRadius}
             strokeWidth={5}
@@ -986,12 +1136,31 @@ function AdvancedChartImplInner({
         </PieChart>
       </ChartContainer>
     );
+    // A pie that drew SOME of its rows says how many it could not size. With
+    // every row sizable the note is `null` and `ChartFootnote` returns the
+    // container untouched, so healthy pies keep their exact DOM.
+    return (
+      <ChartFootnote note={unsizedRowsNote(pieSizable.sizable, pieSizable.total, pieDataKey)}>
+        {pieChart}
+      </ChartFootnote>
+    );
   }
 
   // Funnel chart — uses recharts FunnelChart (single series only)
   if (chartType === 'funnel') {
     const dataKey = series[0]?.dataKey || 'value';
     const palette = getPalette();
+    // objectui#7147 — see `countSizableRows`. Recharts derives each segment's
+    // upper and lower width from ITS value and the NEXT one, so a single
+    // unsizable row does not merely omit itself: measured, `40` beside a `null`
+    // drew ZERO segments and one label reading "Beta" — the row with no value —
+    // while the row carrying 40 drew nothing at all. All-negative is the mirror
+    // image: a confident two-band funnel with MORE mark area than the
+    // all-positive control.
+    const funnelSizable = countSizableRows(data, dataKey);
+    if (funnelSizable.total > 0 && funnelSizable.sizable === 0) {
+      return <MagnitudeRefusal dataKey={dataKey} className={className} />;
+    }
     const handleFunnelClick = onChartClick
       ? (entry: any) => {
           if (!entry) return;
@@ -1031,7 +1200,7 @@ function AdvancedChartImplInner({
           const bv = Number(b?.[dataKey] ?? 0);
           return bv - av;
         });
-    return (
+    const funnelChart = (
       <ChartContainer config={config} className={className} {...containerProps}>
         <FunnelChart>
           <ChartTooltip content={<ChartTooltipContent />} />
@@ -1050,6 +1219,11 @@ function AdvancedChartImplInner({
         </FunnelChart>
       </ChartContainer>
     );
+    return (
+      <ChartFootnote note={unsizedRowsNote(funnelSizable.sizable, funnelSizable.total, dataKey)}>
+        {funnelChart}
+      </ChartFootnote>
+    );
   }
 
   // Treemap — composition by relative size. Recharts <Treemap> is itself the
@@ -1058,17 +1232,32 @@ function AdvancedChartImplInner({
   if (chartType === 'treemap') {
     const dataKey = series[0]?.dataKey || 'value';
     const palette = getPalette();
+    // objectui#7147 — see `countSizableRows`. A treemap's leaf area IS its
+    // value, so an unsizable row collapses to nothing and its neighbours expand
+    // to fill the box. Measured: `40 / null`, `40 / 0` and `40 / -25 / -12` all
+    // rendered ONE full-bleed leaf labelled "Alpha", byte-identical to each
+    // other AND to a genuinely one-row treemap. All-zero rows paint one
+    // full-bleed leaf labelled with the LAST category.
+    const treemapSizable = countSizableRows(data, dataKey);
+    if (treemapSizable.total > 0 && treemapSizable.sizable === 0) {
+      return <MagnitudeRefusal dataKey={dataKey} className={className} />;
+    }
     const tmData = data.map((row, idx) => ({
       name: String(row?.[xAxisKey] ?? ''),
       size: Number(row?.[dataKey]) || 0,
       fill: resolveColor(palette[idx % palette.length]),
     }));
-    return (
+    const treemapChart = (
       <ChartContainer config={config} className={className} {...containerProps}>
         <Treemap data={tmData} dataKey="size" nameKey="name" {...animProps} content={<TreemapCell />} {...treemapClickProps}>
           <Tooltip />
         </Treemap>
       </ChartContainer>
+    );
+    return (
+      <ChartFootnote note={unsizedRowsNote(treemapSizable.sizable, treemapSizable.total, dataKey)}>
+        {treemapChart}
+      </ChartFootnote>
     );
   }
 


### PR DESCRIPTION
Fixes #7147

Re-derived on `origin/main` **40c4711d6** (the head this branch forks from; it already carries PR #7146's `no-positive-flow` refusal and PR #7161's `ChartFootnote`). The card's snippets and line numbers were stale, as PM assumed.

## Rendered it and looked first

74 tiles in real Chromium (`/opt/pw-browsers/chromium`) — 8 chart families x 9 datasets, plus a blank reference and a live console control. Every tile screenshotted, MD5'd, and **pixel-diffed** against a literally empty `div` of the same box. `measured-and-declined` was genuinely on the table for each family separately. It survived for **radar** and **bar**, and for none of pie / donut / funnel / treemap.

The instrument's discriminating power, from its own controls: a two-row pie differs from a one-row pie by **9.683%** of its pixels, a two-row treemap from a one-row treemap by **38.301%**, and an all-zero **bar** puts **5,128** ink pixels (axes and ticks) against a blank tile's 0.

### Per-family verdict

| family | dataset | what a reader saw at 40c4711d6 | verdict |
|---|---|---|---|
| pie / donut | all-zero, all-null, all-negative | **0 non-white pixels of 124,800** — byte-identical to an empty `div`, while the DOM carried 31 descendants and a real `svg` | **fix** |
| pie / donut | `40` beside a `null` | a **full circle** in the first category's colour — 99.35% pixel-identical to a legitimately one-row dataset (the 0.654% residue is the `paddingAngle` hairline, not information). The picture asserts "Alpha is 100%" of a dataset where Beta was never measured | **fix** |
| funnel | `40` beside a `null` | **178** ink pixels: **zero** segments, **one** label — and the label reads "Beta", the row with **no** value. The row carrying 40 drew nothing at all | **fix** |
| funnel | all-negative | a confident two-band funnel whose mark area (**220,320**) *exceeds* the all-positive control's (**111,881**) | **fix** |
| treemap | `40 / null`, `40 / 0`, `40 / -25 / -12` | all three **byte-identical** (diff `0.000%`) to a genuinely one-row treemap — one full-bleed leaf labelled "Alpha". Four datasets, one image | **fix** |
| treemap | all-zero | one full-bleed leaf labelled with the **last** category — as the card's adjacent observation recorded | **fix** |
| bar | all-zero | 5,128 ink pixels of axes, ticks and a zero-labelled scale | **declined** — its reader can already tell |
| radar | all-zero | grid and axes drawn, and hashes distinct from both its all-positive and its one-row control | **declined** |

## The mechanism is the same across all three families, and it is neither landed answer

The rows are **never filtered**. `data` reaches the pie, funnel and treemap elements whole — PR #7161 pinned that the sankey arm holds the only row-dropping filter in this file, and that still reads true at this head (`AdvancedChartImpl.tsx:1081`, the other two `.filter(` sites filter *series*). What happens instead is that the **layout gives a non-positive row no area**.

So PR #7161's count (`data.length - rows.length`) is **exactly zero** against these families. A hoisted copy of that footnote would have rendered nothing while looking like coverage. Confirmed rather than assumed: the sankey tiles are the only ones in the sweep carrying `omitted-rows`.

**A2.3 was falsified in one respect and it changed nothing.** Pie and funnel are *not* the same failure at the Recharts level — an unsizable pie row produces **no sector element at all** (`path.recharts-sector` = 0), whereas an unsizable funnel row produces a **NaN-width trapezoid that also poisons its neighbour** (which is why `40` beside a `null` loses the row worth 40, not the `null` one). Treemap is a third: the leaf collapses and its neighbours expand to fill the box. Three different Recharts behaviours, **one** authoring-side predicate — a row can only occupy area if its measure is a positive finite number — so one answer serves all three.

## What changed

Three helpers, stated once so the arms cannot drift, and wired into the pie/donut, funnel and treemap arms:

- `countSizableRows(rows, dataKey)` — `Number.isFinite(v) && v > 0`. `Number.isFinite` rather than the sankey arm's `Number(x) || 0` idiom, because this predicate must also reject `Infinity`, which `|| 0` lets straight through.
- **No row sizable** and at least one row present: the file's existing refusal shell under its **own** code, `data-chart-error="no-positive-magnitude"`.
- **Some rows sizable**: the plot renders unchanged, wrapped in the existing `ChartFootnote` with `data-chart-note="unsized-rows"`, carrying the count.

Copy names the **predicate**, not a cause — the reason `no-positive-flow`'s docstring already gives: five shapes reach here (a genuine zero, a negative, `null`, an unparseable string, a missing key) and naming any one is a sentence false for the other four.

The note deliberately does **not** say "showing N of M". PR #7161's sankey note can, because there the missing rows are genuinely absent from the plot. Here they are not: a mixed-sign pie *paints* a sector for every row (measured: `40 / -25 / -12` drew 3 sectors) — it just paints them at a scale that means nothing. "Showing 1 of 3" would be a false statement about what is on the screen.

**No console warning**, matching both sankey answers and unlike the two guards at the bottom of the file: those carry a diagnostic pair that does not fit on screen, whereas these sentences already name the key, the test it failed, and how many rows failed it.

**i18n**: none added. This file has no i18n call sites at all and both landed refusals plus PR #7161's footnote are hardcoded English; this matches the file.

## Before / after, and the 50 tiles that did not move

Measured at a tile taller than the chart's own `CHART_MIN_HEIGHT` floor of 280 (see "assumption falsified" below). The pre-fix renderer was reproduced by double ablation and **verified** against the true pre-fix run: **56/56 tiles byte-identical**, so the "before" column is the real thing rather than a stand-in.

**24 tiles changed. 50 did not.** The 50 are what make the 24 discriminating:

- every all-positive control of all 8 families — unchanged
- every one-row control — unchanged (so a thinned chart is now distinguishable from a legitimately small one; the four-way treemap collision `be719ec4d968` is broken)
- every no-rows tile — unchanged. That is the empty-RESULT question (#7130), answered upstream in `ObjectChart` where the query outcome is known, so the refusal is gated on `total > 0`
- **all 9 bar tiles and all 9 sankey tiles — byte-identical**, including `no-positive-flow` on all-zero/null/negative and `omitted-rows` on all three thinned datasets. Both landed answers keep firing under their own codes.

`treemap--posNull` and `treemap--posZero` still share an image after the fix, and that is correct: to a chart that sizes by value a `null` and a `0` are the same fact, and the copy names the predicate rather than the cause.

## Seam map, pinned from both sides

| dataset | sankey | pie / donut / funnel / treemap |
|---|---|---|
| no rows at all | untouched (#7130, upstream) | untouched (#7130, upstream) |
| no row above zero | `no-positive-flow` (#7146) | `no-positive-magnitude` (this PR) |
| some rows above zero | `omitted-rows` (#7161) | `unsized-rows` (this PR) |
| all rows above zero | untouched | untouched, **no wrapper element added** |

A test asserts the four codes are **mutually exclusive** across every family x dataset pair in the sweep, and two more assert a sankey never receives this PR's code or attribute and vice versa.

## Console diagnostic, with its control

Across all 72 chart tiles: **zero** console output. That zero is readable only because the same instrument's positive control **did** fire on the same run — a rows-carry-no-category-key tile printed `[chart] no row has the category key "name" ...`. A2.4 confirmed on the widened population.

## Assumptions falsified

1. **The card's "funnel all-zero is pixel-identical to a blank tile" does not reproduce at this head on this instrument.** It draws its two category labels (412 ink pixels) and zero segments. The likely difference is that this probe compiles the real Tailwind theme, so `hsl(var(--foreground))` resolves and the labels are visible. The finding stands regardless — 0 of 2 segments — but the specific pixel-identity claim is not what I measured, so I am not repeating it.
2. **A 520x240 tile — the box the card's own sweep used — is 40px shorter than the chart's own `CHART_MIN_HEIGHT` of 280, so no footnote can be seen in it.** Measured with the landed footnote as the control: `sankey--posNull` is **byte-identical** before and after this change at 240 (`2b123b92769b`), i.e. **PR #7161's shipped note is equally invisible there**. This is a pre-existing property of sub-280 boxes that this PR inherits and does not worsen, not something introduced here. All before/after numbers above are therefore quoted at a box that fits the floor.
3. **A2.3** — see above; the mechanism differs per family at the Recharts level while the authoring-side predicate does not.

## Tests

`AdvancedChartImpl.degenerateMagnitude.test.tsx`, 64 tests. Run from the repo root with root-relative paths.

```
pnpm exec vitest run packages/plugin-charts/src/AdvancedChartImpl.degenerateMagnitude.test.tsx
  Test Files  1 passed (1)
       Tests  64 passed (64)

pnpm exec vitest run packages/plugin-charts/
  Test Files  39 passed (39)
       Tests  329 passed (329)
```

### Ablation, direction predicted before running

Two legs, each proving mutation on disk by **marker count and blob hash** and restore by **state**, both with an absolute-path `trap`:

| leg | mutation | predicted | observed |
|---|---|---|---|
| A | refusal guard neutered (`sizable === 0` to `sizable === -1`, 3 sites) | refusal block red, note block green | **26 failed / 38 passed** — all 26 in the refusal block |
| B | note guard neutered (`unsized <= 0` to `unsized >= 0`, 1 site) | note block red, refusal block green | **26 failed / 38 passed** — all 26 in the note block |

The two red sets are **disjoint**, and each leg left the other 38 green — which is what makes them discriminating rather than a blanket break. Blob hashes: `433eb895...` mutated to `328319dd...` (A) and `5d9ad41a...` (B); both restored to `433eb895...` with `git diff HEAD` empty.

## Gates

All run on the committed head **`dd79defc7`**, after the final commit.

| gate | verdict, as the gate printed it |
|---|---|
| `vitest packages/plugin-charts/` | `Test Files 39 passed (39)` / `Tests 329 passed (329)` |
| `type-check` | exit 0, `tsc --noEmit`, script name echoed |
| `lint` | `287 problems (0 errors, 287 warnings)` — exit 0, all warnings pre-existing |
| `check-changeset-presence` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major` | `No changeset declares a major bump.` |
| `check-control-bytes` | `OK (scanned 5942 tracked text file(s); skipped 85 binary).` |
| `check-vi-mock-specifiers` | `OK (4099 tracked source file(s), 2371 test-named; 525 carry a mock; ...)` |
| `check-vi-mock-inherit` | `OK (4099 tracked source file(s), ... 118 inherit, 0 auto-mocked ...)` |
| `check-lint-coverage` | `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `check-type-check-coverage` | `type-check coverage: 45/46 via type-check, ... 1 not compiled.` |

The three tracked-file gates were re-run **after** `git add`; their own counts moved (5940 to 5942 text files, 524 to 525 files carrying a mock), which is how I know they actually saw the new test rather than skipping it as untracked.

`type-check` was `NOT MEASURED` on first attempt — 16 `Cannot find module '@object-ui/*'` errors because the dependency closure was unbuilt. Built with `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-charts^...' build` and re-run to a real verdict. `tsc --listFiles` confirms both edited files are in the compiled set (1 hit each), so the green covers them.

**Declared narrowing**: repo-wide `pnpm lint` was not run locally; CI owns it. The per-package run is a measurement, not a guess — eslint's *own* config selected **52** files in this package (`--format json` count), both edited files are in that set with 0 errors, and this package's eslint config enables no type-aware linting, so nothing in this diff can move a verdict in a file it does not touch.

## Out of scope, reported not fixed

- **`scatter` is `NOT MEASURED`, not clean.** Its all-positive control drew **zero** marks on this instrument (`markN: 0` on every scatter tile including the control), so its zeros say nothing — a control that returns zero is no control. Scatter takes two measures and this sweep's single-measure fixture does not bind it. Worth a proper sweep with a correct fixture; I did not file a card, per the report-do-not-duplicate fence.
- **`radar` measured and clean** for this defect class: grid and axes survive an all-zero dataset and its hashes are distinct from both its all-positive and its one-row control.


---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_