### PR TITLE
fix(plugin-detail,i18n): RecordComments and PointInTimeRestore resolve their copy from the packs

### DIFF
--- a/.changeset/7163-detail-timestamp-i18n.md
+++ b/.changeset/7163-detail-timestamp-i18n.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-detail': patch
+'@object-ui/i18n': patch
+---
+
+`RecordComments` and `PointInTimeRestore` resolve their copy from the locale
+packs instead of hardcoded English (objectui#7163).
+
+Both files carried their own `formatTimestamp` whose relative-time branches
+returned English literals, so a zh/ja/ar session read `5m ago` next to
+otherwise translated chrome — the defect objectui#7142/#7149 fixed one file
+over in `ActivityTimeline`.
+
+- **`RecordComments`** was already wired to the packs (11 `t('detail.…')`
+  references), so this is a pure lookup swap onto `detail.justNow` /
+  `minutesAgo` / `hoursAgo` / `daysAgo` — keys already present in all ten packs,
+  each `en` value byte-identical to the literal it replaces. **No new key, no
+  copy change.**
+- **`PointInTimeRestore`** used no translation hook at all, so it is swept
+  WHOLE rather than having only its timestamps converted: card title, empty
+  state, field-count line, preview panel, snapshot heading, restore
+  confirmation and all three buttons. Wiring one string into an otherwise
+  untranslated component is what shipped objectui#7142's visibly half-done zh
+  card; that is not repeated here.
+
+Ten new `detail.*` keys land in all ten packs and in
+`DETAIL_DEFAULT_TRANSLATIONS`: `revisionHistory`, `noRevisions`,
+`revisionFieldsChanged`, `revisionFieldsChangedOne`, `revisionPreview`,
+`revisionSnapshot`, `restoreConfirm`, `restoring`, `confirmRestore`,
+`restoreToPoint`. `detail.cancel`, `detail.activityEmptyValue` and
+`detail.emptyValue` are **reused**, not forked.
+
+The restore confirmation becomes one key with a `{{when}}` hole rather than a
+sentence assembled around a JSX expression, and the field-count line uses the
+repo's two-key plural convention selected by a static ternary over two literal
+keys — never `t(KEYS[n])`, which objectui#7149 measured as invisible to the
+i18n scanners.
+
+One deliberate copy change: the snapshot panel's null placeholder was an EN
+DASH (`–`, U+2013) written inline and now resolves `detail.emptyValue`, which
+is an EM DASH (`—`, U+2014) in all ten packs — the glyph the rest of the detail
+package already uses for an empty value.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1059,6 +1059,21 @@ const ar = {
     showEmptyFields: "إظهار {{count}} حقل(حقول) فارغة",
     hideEmptyFields: "إخفاء الحقول الفارغة",
     noValue: "لا قيمة",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'سجل المراجعات',
+    noRevisions: 'لا توجد مراجعات مسجلة',
+    revisionFieldsChanged: 'تم تغيير {{count}} حقول',
+    revisionFieldsChangedOne: 'تم تغيير {{count}} حقل',
+    revisionPreview: 'معاينة المراجعة',
+    revisionSnapshot: 'حالة السجل في هذه النقطة',
+    restoreConfirm: 'سيؤدي هذا إلى استعادة السجل إلى حالته في {{when}}. هل تريد المتابعة؟',
+    restoring: 'جارٍ الاستعادة…',
+    confirmRestore: 'تأكيد الاستعادة',
+    restoreToPoint: 'الاستعادة إلى هذه النقطة',
   },
   chart: {
     loading: "جارٍ تحميل الرسم البياني…",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1052,6 +1052,21 @@ const de = {
     showEmptyFields: "{{count}} leere Felder anzeigen",
     hideEmptyFields: "Leere Felder ausblenden",
     noValue: "Kein Wert",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'Versionsverlauf',
+    noRevisions: 'Keine Versionen aufgezeichnet',
+    revisionFieldsChanged: '{{count}} Felder geändert',
+    revisionFieldsChangedOne: '{{count}} Feld geändert',
+    revisionPreview: 'Versionsvorschau',
+    revisionSnapshot: 'Datensatzstand zu diesem Zeitpunkt',
+    restoreConfirm: 'Dadurch wird der Datensatz auf seinen Stand von {{when}} zurückgesetzt. Fortfahren?',
+    restoring: 'Wird wiederhergestellt…',
+    confirmRestore: 'Wiederherstellung bestätigen',
+    restoreToPoint: 'Auf diesen Zeitpunkt zurücksetzen',
   },
   chart: {
     loading: "Diagramm wird geladen…",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1202,6 +1202,21 @@ const en = {
     showEmptyFields: 'Show {{count}} empty fields',
     hideEmptyFields: 'Hide empty fields',
     noValue: 'No value',
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'Revision History',
+    noRevisions: 'No revisions recorded',
+    revisionFieldsChanged: '{{count}} fields changed',
+    revisionFieldsChangedOne: '{{count}} field changed',
+    revisionPreview: 'Revision Preview',
+    revisionSnapshot: 'Record state at this point',
+    restoreConfirm: 'This will restore the record to its state at {{when}}. Continue?',
+    restoring: 'Restoring…',
+    confirmRestore: 'Confirm Restore',
+    restoreToPoint: 'Restore to this point',
   },
   chart: {
     loading: 'Loading chart…',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1056,6 +1056,21 @@ const es = {
     showEmptyFields: "Mostrar {{count}} campos vacíos",
     hideEmptyFields: "Ocultar campos vacíos",
     noValue: "Sin valor",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'Historial de revisiones',
+    noRevisions: 'Sin revisiones registradas',
+    revisionFieldsChanged: '{{count}} campos modificados',
+    revisionFieldsChangedOne: '{{count}} campo modificado',
+    revisionPreview: 'Vista previa de la revisión',
+    revisionSnapshot: 'Estado del registro en este punto',
+    restoreConfirm: 'Esto restaurará el registro a su estado del {{when}}. ¿Continuar?',
+    restoring: 'Restaurando…',
+    confirmRestore: 'Confirmar restauración',
+    restoreToPoint: 'Restaurar a este punto',
   },
   chart: {
     loading: "Cargando gráfico…",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1054,6 +1054,21 @@ const fr = {
     showEmptyFields: "Afficher {{count}} champs vides",
     hideEmptyFields: "Masquer les champs vides",
     noValue: "Aucune valeur",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'Historique des révisions',
+    noRevisions: 'Aucune révision enregistrée',
+    revisionFieldsChanged: '{{count}} champs modifiés',
+    revisionFieldsChangedOne: '{{count}} champ modifié',
+    revisionPreview: 'Aperçu de la révision',
+    revisionSnapshot: "État de l'enregistrement à ce moment",
+    restoreConfirm: "Cela restaurera l'enregistrement à son état du {{when}}. Continuer ?",
+    restoring: 'Restauration…',
+    confirmRestore: 'Confirmer la restauration',
+    restoreToPoint: 'Restaurer à ce point',
   },
   chart: {
     loading: "Chargement du graphique…",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1052,6 +1052,21 @@ const ja = {
     showEmptyFields: "{{count}} 件の空フィールドを表示",
     hideEmptyFields: "空フィールドを非表示",
     noValue: "値なし",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'リビジョン履歴',
+    noRevisions: 'リビジョンの記録なし',
+    revisionFieldsChanged: '{{count}} 件のフィールドを変更',
+    revisionFieldsChangedOne: '{{count}} 件のフィールドを変更',
+    revisionPreview: 'リビジョンのプレビュー',
+    revisionSnapshot: 'この時点のレコード状態',
+    restoreConfirm: 'レコードを {{when}} の状態に復元します。続行しますか?',
+    restoring: '復元中…',
+    confirmRestore: '復元を確認',
+    restoreToPoint: 'この時点に復元',
   },
   chart: {
     loading: "チャート読み込み中…",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1052,6 +1052,21 @@ const ko = {
     showEmptyFields: "{{count}}개의 빈 필드 표시",
     hideEmptyFields: "빈 필드 숨기기",
     noValue: "값 없음",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: '수정 기록',
+    noRevisions: '기록된 수정 없음',
+    revisionFieldsChanged: '필드 {{count}}개 변경됨',
+    revisionFieldsChangedOne: '필드 {{count}}개 변경됨',
+    revisionPreview: '수정 미리보기',
+    revisionSnapshot: '이 시점의 레코드 상태',
+    restoreConfirm: '레코드를 {{when}} 시점의 상태로 복원합니다. 계속하시겠습니까?',
+    restoring: '복원 중…',
+    confirmRestore: '복원 확인',
+    restoreToPoint: '이 시점으로 복원',
   },
   chart: {
     loading: "차트 로딩 중…",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1051,6 +1051,21 @@ const pt = {
     showEmptyFields: "Mostrar {{count}} campos vazios",
     hideEmptyFields: "Ocultar campos vazios",
     noValue: "Sem valor",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'Histórico de revisões',
+    noRevisions: 'Nenhuma revisão registrada',
+    revisionFieldsChanged: '{{count}} campos alterados',
+    revisionFieldsChangedOne: '{{count}} campo alterado',
+    revisionPreview: 'Pré-visualização da revisão',
+    revisionSnapshot: 'Estado do registro neste ponto',
+    restoreConfirm: 'Isto restaurará o registro ao seu estado de {{when}}. Continuar?',
+    restoring: 'Restaurando…',
+    confirmRestore: 'Confirmar restauração',
+    restoreToPoint: 'Restaurar para este ponto',
   },
   chart: {
     loading: "Carregando gráfico…",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1062,6 +1062,21 @@ const ru = {
     showEmptyFields: "Показать {{count}} пустых полей",
     hideEmptyFields: "Скрыть пустые поля",
     noValue: "Нет значения",
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: 'История версий',
+    noRevisions: 'Нет зарегистрированных версий',
+    revisionFieldsChanged: 'Изменено полей: {{count}}',
+    revisionFieldsChangedOne: 'Изменено полей: {{count}}',
+    revisionPreview: 'Предпросмотр версии',
+    revisionSnapshot: 'Состояние записи на этот момент',
+    restoreConfirm: 'Запись будет восстановлена до состояния на {{when}}. Продолжить?',
+    restoring: 'Восстановление…',
+    confirmRestore: 'Подтвердить восстановление',
+    restoreToPoint: 'Восстановить до этого момента',
   },
   chart: {
     loading: "Загрузка графика…",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1091,6 +1091,21 @@ const zh = {
     showEmptyFields: '显示 {{count}} 个空字段',
     hideEmptyFields: '隐藏空字段',
     noValue: '无',
+    // objectui#7163 — PointInTimeRestore's revision-history chrome. The file
+    // used no translation hook at all, so every one of these read English in
+    // every session; swept in one pass rather than converting the timestamps
+    // alone. `Cancel`, `(empty)` and the empty-value dash reuse the keys this
+    // namespace already has, so only these ten are new.
+    revisionHistory: '修订历史',
+    noRevisions: '暂无修订记录',
+    revisionFieldsChanged: '已更改 {{count}} 个字段',
+    revisionFieldsChangedOne: '已更改 {{count}} 个字段',
+    revisionPreview: '修订预览',
+    revisionSnapshot: '此时间点的记录状态',
+    restoreConfirm: '这会将记录恢复到 {{when}} 时的状态。是否继续?',
+    restoring: '正在恢复…',
+    confirmRestore: '确认恢复',
+    restoreToPoint: '恢复到此时间点',
   },
   chart: {
     loading: '图表加载中…',

--- a/packages/plugin-detail/src/PointInTimeRestore.i18n.test.tsx
+++ b/packages/plugin-detail/src/PointInTimeRestore.i18n.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `PointInTimeRestore` speaks the session locale — objectui#7163.
+ *
+ * Unlike its sibling `RecordComments`, this file used **no translation hook at
+ * all** (0 references), so every string in it — the card title, the empty
+ * state, the field-count line, the preview panel, the restore confirmation and
+ * all three buttons — rendered English in every session. It is therefore swept
+ * WHOLE here rather than having only its timestamps converted: objectui#7142
+ * wired one string into an otherwise untranslated component and shipped a zh
+ * card reading `"Activity(0)No activity recorded"`, and objectui#7149 is what
+ * finishing that afterwards cost. Ten keys are new; `detail.cancel`,
+ * `detail.activityEmptyValue` and `detail.emptyValue` are reused rather than
+ * forked, and the four relative-time keys were already present in all ten packs.
+ *
+ * The relative-time branches are the load-bearing zh/ar assertions for the same
+ * reason as the sibling suite: each `en` pack value is byte-identical to the
+ * literal it replaced, so an `en`-only test is green before the fix too. The
+ * ten NEW keys are different — those literals had no pack value at all, so
+ * their provider-less leg (`DETAIL_DEFAULT_TRANSLATIONS`) is a real assertion
+ * rather than a tautology: before this change there was no English to fall back
+ * TO, and a raw key would have rendered.
+ *
+ * `{{count}}` and `{{when}}` are spelled with no inner spaces — the one
+ * spelling BOTH paths resolve (i18next on the provider path,
+ * `interpolateFallback` on the provider-less one — objectui#3512 / #6219). The
+ * provider-less leg is asserted because that is where a wrong spelling renders
+ * a raw `{{when}}` silently. No inline `defaultValue` anywhere (objectui#3517).
+ *
+ * The field-count pair is selected by a **static ternary over two literal
+ * keys**, never `t(KEYS[n])` — objectui#7149 measured that a key visible only
+ * as a map value has no call site the i18n scanners can resolve and reads as
+ * unreferenced.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import { PointInTimeRestore, type RevisionEntry } from './PointInTimeRestore';
+
+afterEach(() => cleanup());
+
+const MIN = 60_000;
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+function revisions(): RevisionEntry[] {
+  return [
+    {
+      id: 'r1',
+      timestamp: ago(5 * MIN),
+      user: 'Grace',
+      changes: [
+        { field: 'stage', oldValue: null, newValue: 'won' },
+        { field: 'amount', oldValue: 10, newValue: 20 },
+      ],
+      snapshot: { stage: 'won', owner: null },
+    },
+    {
+      id: 'r2',
+      timestamp: ago(3 * 60 * MIN),
+      user: 'Alan',
+      changes: [{ field: 'name', oldValue: 'a', newValue: 'b' }],
+    },
+  ];
+}
+
+function renderIn(language: string, props: Partial<React.ComponentProps<typeof PointInTimeRestore>> = {}) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <PointInTimeRestore recordId="rec_1" revisions={revisions()} {...props} />
+    </I18nProvider>,
+  );
+}
+
+const EN = {
+  title: 'Revision History',
+  empty: 'No revisions recorded',
+  preview: 'Revision Preview',
+  snapshot: 'Record state at this point',
+  restoreBtn: 'Restore to this point',
+  confirmBtn: 'Confirm Restore',
+  cancelBtn: 'Cancel',
+  emptyValue: '(empty)',
+  minutes: '5m ago',
+  hours: '3h ago',
+  twoFields: '2 fields changed',
+  oneField: '1 field changed',
+  confirm: 'This will restore the record to its state at 5m ago. Continue?',
+};
+const ZH = {
+  title: '修订历史',
+  empty: '暂无修订记录',
+  preview: '修订预览',
+  snapshot: '此时间点的记录状态',
+  restoreBtn: '恢复到此时间点',
+  confirmBtn: '确认恢复',
+  cancelBtn: '取消',
+  emptyValue: '(空)',
+  minutes: '5分钟前',
+  hours: '3小时前',
+  twoFields: '已更改 2 个字段',
+  oneField: '已更改 1 个字段',
+  confirm: '这会将记录恢复到 5分钟前 时的状态。是否继续?',
+};
+const AR = {
+  title: 'سجل المراجعات',
+  empty: 'لا توجد مراجعات مسجلة',
+  restoreBtn: 'الاستعادة إلى هذه النقطة',
+};
+
+describe('PointInTimeRestore — locale resolution (objectui#7163)', () => {
+  it('renders its whole chrome from the zh pack under a zh session', () => {
+    renderIn('zh', { onRestore: () => {} });
+
+    expect(screen.getByText(ZH.title)).toBeTruthy();
+    expect(screen.getByText(ZH.minutes)).toBeTruthy();
+    expect(screen.getByText(ZH.hours)).toBeTruthy();
+    expect(screen.getByText(ZH.twoFields)).toBeTruthy();
+    expect(screen.getByText(ZH.oneField)).toBeTruthy();
+  });
+
+  it('leaves no English chrome behind in a zh session', () => {
+    // The defect. A partial conversion passes the assertion above and fails this.
+    renderIn('zh', { onRestore: () => {} });
+
+    for (const en of [EN.title, EN.minutes, EN.hours, EN.twoFields, EN.oneField]) {
+      expect(screen.queryByText(en)).toBeNull();
+    }
+  });
+
+  it('translates the selected-revision preview panel and its restore flow in zh', () => {
+    renderIn('zh', { onRestore: () => {} });
+
+    fireEvent.click(screen.getByText('Grace'));
+
+    expect(screen.getByText(ZH.preview)).toBeTruthy();
+    expect(screen.getByText(ZH.snapshot)).toBeTruthy();
+    // `oldValue: null` and the null snapshot entry — both reuse existing keys.
+    expect(screen.getAllByText(ZH.emptyValue).length).toBeGreaterThan(0);
+    expect(screen.queryByText(EN.emptyValue)).toBeNull();
+
+    const restore = screen.getByText(ZH.restoreBtn);
+    expect(restore).toBeTruthy();
+    fireEvent.click(restore);
+
+    // The confirmation is ONE key with a `{{when}}` hole, not an assembled
+    // sentence — the interpolated value is the localized relative time.
+    expect(screen.getByText(ZH.confirm)).toBeTruthy();
+    expect(screen.getByText(ZH.confirmBtn)).toBeTruthy();
+    expect(screen.getByText(ZH.cancelBtn)).toBeTruthy();
+    expect(screen.queryByText(EN.confirm)).toBeNull();
+  });
+
+  it('translates the empty state in zh', () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'zh', detectBrowserLanguage: false }}>
+        <PointInTimeRestore recordId="rec_1" revisions={[]} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText(ZH.empty)).toBeTruthy();
+    expect(screen.queryByText(EN.empty)).toBeNull();
+  });
+
+  it('reads the ar pack under an ar session', () => {
+    renderIn('ar', { onRestore: () => {} });
+
+    expect(screen.getByText(AR.title)).toBeTruthy();
+    fireEvent.click(screen.getByText('Grace'));
+    expect(screen.getByText(AR.restoreBtn)).toBeTruthy();
+    expect(screen.queryByText(EN.title)).toBeNull();
+    expect(screen.queryByText(EN.restoreBtn)).toBeNull();
+  });
+
+  it('translates the ar empty state', () => {
+    render(
+      <I18nProvider config={{ defaultLanguage: 'ar', detectBrowserLanguage: false }}>
+        <PointInTimeRestore recordId="rec_1" revisions={[]} />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText(AR.empty)).toBeTruthy();
+    expect(screen.queryByText(EN.empty)).toBeNull();
+  });
+
+  it('still reads English under an en session', () => {
+    // For the four relative-time keys this is green by construction (their `en`
+    // values are byte-identical to the old literals). For the ten NEW keys it
+    // is a real copy assertion: it pins that the pack rows say exactly what the
+    // literals said.
+    renderIn('en', { onRestore: () => {} });
+
+    expect(screen.getByText(EN.title)).toBeTruthy();
+    expect(screen.getByText(EN.minutes)).toBeTruthy();
+    expect(screen.getByText(EN.twoFields)).toBeTruthy();
+    expect(screen.getByText(EN.oneField)).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Grace'));
+    expect(screen.getByText(EN.preview)).toBeTruthy();
+    expect(screen.getByText(EN.snapshot)).toBeTruthy();
+    fireEvent.click(screen.getByText(EN.restoreBtn));
+    expect(screen.getByText(EN.confirm)).toBeTruthy();
+  });
+
+  it('falls back to the English defaults map with no provider mounted', () => {
+    // Before this change the file had no hook, so there was no defaults map
+    // entry to fall back to at all — a raw key would render here.
+    render(<PointInTimeRestore recordId="rec_1" revisions={revisions()} onRestore={() => {}} />);
+
+    expect(screen.getByText(EN.title)).toBeTruthy();
+    expect(screen.getByText(EN.minutes)).toBeTruthy();
+    expect(screen.getByText(EN.twoFields)).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Grace'));
+    expect(screen.getByText(EN.preview)).toBeTruthy();
+    fireEvent.click(screen.getByText(EN.restoreBtn));
+    // `{{when}}` filled by `interpolateFallback`, not left raw.
+    expect(screen.getByText(EN.confirm)).toBeTruthy();
+    expect(screen.getByText(EN.cancelBtn)).toBeTruthy();
+  });
+
+  it('never renders a raw key or a raw interpolation hole, provider or not', () => {
+    const KEYS = [
+      'detail.revisionHistory', 'detail.noRevisions', 'detail.revisionFieldsChanged',
+      'detail.revisionFieldsChangedOne', 'detail.revisionPreview', 'detail.revisionSnapshot',
+      'detail.restoreConfirm', 'detail.restoring', 'detail.confirmRestore',
+      'detail.restoreToPoint', 'detail.cancel', 'detail.emptyValue',
+      'detail.activityEmptyValue', 'detail.justNow', 'detail.minutesAgo', 'detail.hoursAgo',
+    ];
+
+    for (const mount of [() => renderIn('zh', { onRestore: () => {} }),
+                         () => render(<PointInTimeRestore recordId="rec_1" revisions={revisions()} onRestore={() => {}} />)]) {
+      mount();
+      fireEvent.click(screen.getByText('Grace'));
+      fireEvent.click(screen.getByText(screen.queryByText(ZH.restoreBtn) ? ZH.restoreBtn : EN.restoreBtn));
+      for (const k of KEYS) expect(screen.queryByText(k)).toBeNull();
+      expect(screen.queryByText(/\{\{(count|when)\}\}/)).toBeNull();
+      cleanup();
+    }
+  });
+});

--- a/packages/plugin-detail/src/PointInTimeRestore.tsx
+++ b/packages/plugin-detail/src/PointInTimeRestore.tsx
@@ -16,6 +16,7 @@ import {
   CardContent,
 } from '@object-ui/components';
 import { History, RotateCcw, Eye, ChevronRight } from 'lucide-react';
+import { useDetailTranslation } from './useDetailTranslation';
 
 export interface RevisionEntry {
   id: string;
@@ -33,17 +34,36 @@ export interface PointInTimeRestoreProps {
   className?: string;
 }
 
-function formatTimestamp(timestamp: string): string {
+type RestoreTranslate = (key: string, options?: Record<string, unknown>) => string;
+
+/**
+ * Format a revision timestamp as a relative phrase, falling through to an
+ * absolute date-time once it is more than a day old.
+ *
+ * objectui#7163 — the three relative branches were hardcoded English. They now
+ * resolve from the packs through the same keys the rest of this package already
+ * uses; each key's `en` value is byte-identical to the literal it replaced.
+ *
+ * ⚠️ This is NOT the same helper `RecordComments`/`ActivityTimeline` carry, and
+ * the card's "byte-identical copy" premise is false for this file: those two
+ * have a fourth `d ago` branch and fall through to `toLocaleDateString()`,
+ * while this one stops at hours and falls through to `toLocaleString()` —
+ * a revision list wants the time of day, a comment list does not. Keeping the
+ * tails apart is deliberate; unifying them would silently restyle one surface.
+ */
+function formatTimestamp(timestamp: string, t: RestoreTranslate): string {
   try {
     const date = new Date(timestamp);
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / 60000);
 
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffMins < 1) return t('detail.justNow');
+    if (diffMins < 60) return t('detail.minutesAgo', { count: diffMins });
     const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffHours < 24) return t('detail.hoursAgo', { count: diffHours });
+    // Past a day this is a DATE-TIME, not a relative phrase: `toLocaleString`
+    // already localizes it, so there is no literal here to key.
     return date.toLocaleString();
   } catch {
     return timestamp;
@@ -56,6 +76,7 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
   onRestore,
   className,
 }) => {
+  const { t } = useDetailTranslation();
   const [selectedRevisionId, setSelectedRevisionId] = React.useState<string | null>(null);
   const [isConfirming, setIsConfirming] = React.useState(false);
   const [isRestoring, setIsRestoring] = React.useState(false);
@@ -93,7 +114,7 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-base">
           <History className="h-4 w-4" />
-          Revision History
+          {t('detail.revisionHistory')}
           <span className="text-sm font-normal text-muted-foreground">
             ({revisions.length})
           </span>
@@ -102,7 +123,7 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
       <CardContent>
         {revisions.length === 0 ? (
           <p className="text-sm text-muted-foreground text-center py-4">
-            No revisions recorded
+            {t('detail.noRevisions')}
           </p>
         ) : (
           <div className="flex flex-col lg:flex-row gap-4">
@@ -146,12 +167,13 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
                           <div className="flex items-center gap-2">
                             <span className="text-sm font-medium">{revision.user}</span>
                             <span className="text-xs text-muted-foreground">
-                              {formatTimestamp(revision.timestamp)}
+                              {formatTimestamp(revision.timestamp, t)}
                             </span>
                           </div>
                           <p className="text-xs text-muted-foreground mt-0.5">
-                            {revision.changes.length} field{revision.changes.length !== 1 ? 's' : ''}{' '}
-                            changed
+                            {revision.changes.length === 1
+                              ? t('detail.revisionFieldsChangedOne', { count: revision.changes.length })
+                              : t('detail.revisionFieldsChanged', { count: revision.changes.length })}
                           </p>
                         </div>
                       </button>
@@ -166,7 +188,7 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
               <div className="lg:w-80 border rounded-md p-3 space-y-3">
                 <div className="flex items-center gap-2 text-sm font-medium">
                   <Eye className="h-4 w-4 text-muted-foreground" />
-                  Revision Preview
+                  {t('detail.revisionPreview')}
                 </div>
 
                 {/* Field changes */}
@@ -178,11 +200,11 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
                       </span>
                       <div className="flex items-center gap-1.5 mt-0.5">
                         <span className="line-through text-red-600 dark:text-red-400 truncate max-w-[120px]">
-                          {change.oldValue != null ? String(change.oldValue) : '(empty)'}
+                          {change.oldValue != null ? String(change.oldValue) : t('detail.activityEmptyValue')}
                         </span>
                         <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />
                         <span className="text-green-600 dark:text-green-400 truncate max-w-[120px]">
-                          {change.newValue != null ? String(change.newValue) : '(empty)'}
+                          {change.newValue != null ? String(change.newValue) : t('detail.activityEmptyValue')}
                         </span>
                       </div>
                     </div>
@@ -193,14 +215,14 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
                 {selectedRevision.snapshot && (
                   <div className="border-t pt-2 space-y-1">
                     <p className="text-xs font-medium text-muted-foreground">
-                      Record state at this point
+                      {t('detail.revisionSnapshot')}
                     </p>
                     <div className="max-h-40 overflow-y-auto space-y-1">
                       {Object.entries(selectedRevision.snapshot).map(([key, val]) => (
                         <div key={key} className="flex justify-between text-xs gap-2">
                           <span className="text-muted-foreground truncate">{key}</span>
                           <span className="font-mono truncate max-w-[140px]">
-                            {val != null ? String(val) : '–'}
+                            {val != null ? String(val) : t('detail.emptyValue')}
                           </span>
                         </div>
                       ))}
@@ -214,8 +236,9 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
                     {isConfirming ? (
                       <>
                         <p className="text-xs text-amber-600 dark:text-amber-400">
-                          This will restore the record to its state at{' '}
-                          {formatTimestamp(selectedRevision.timestamp)}. Continue?
+                          {t('detail.restoreConfirm', {
+                            when: formatTimestamp(selectedRevision.timestamp, t),
+                          })}
                         </p>
                         <div className="flex gap-2">
                           <Button
@@ -226,7 +249,7 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
                             disabled={isRestoring}
                           >
                             <RotateCcw className="h-3.5 w-3.5" />
-                            {isRestoring ? 'Restoring…' : 'Confirm Restore'}
+                            {isRestoring ? t('detail.restoring') : t('detail.confirmRestore')}
                           </Button>
                           <Button
                             variant="ghost"
@@ -234,7 +257,7 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
                             onClick={handleCancelConfirm}
                             disabled={isRestoring}
                           >
-                            Cancel
+                            {t('detail.cancel')}
                           </Button>
                         </div>
                       </>
@@ -246,7 +269,7 @@ export const PointInTimeRestore: React.FC<PointInTimeRestoreProps> = ({
                         onClick={handleRestore}
                       >
                         <RotateCcw className="h-3.5 w-3.5" />
-                        Restore to this point
+                        {t('detail.restoreToPoint')}
                       </Button>
                     )}
                   </div>

--- a/packages/plugin-detail/src/RecordComments.i18n.test.tsx
+++ b/packages/plugin-detail/src/RecordComments.i18n.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `RecordComments`' relative timestamps speak the session locale — objectui#7163.
+ *
+ * The component was already wired to the packs (11 `t('detail.…')` references),
+ * but its module-local `formatTimestamp` returned four hardcoded English
+ * strings, so a zh session read translated comment chrome with an English
+ * `5m ago` sitting inside it. Exactly the shape objectui#7142/#7149 fixed one
+ * file over, in `ActivityTimeline`.
+ *
+ * The fix adds no key to any pack: `detail.justNow` / `minutesAgo` / `hoursAgo`
+ * / `daysAgo` are already present in all ten (verified by reading the pack
+ * OBJECTS, never a dotted-key grep — the packs are nested, so a grep for
+ * `detail.justNow` returns a false zero against the `en` pack that defines it;
+ * positive control `detail.back` = 10/10, negative control
+ * `detail.zzzAbsentControl7163` = 0/10), and each `en` value is
+ * **byte-identical** to the literal it replaces.
+ *
+ * That byte-identity is why **zh and ar are the load-bearing assertions**. An
+ * `en`-only test is green *before* the fix too — the literal and the `en` pack
+ * value are the same string — so English cannot discriminate a pack lookup from
+ * a hardcoded literal. It is kept anyway, as a no-copy-change guard.
+ *
+ * The provider-less leg is asserted separately because `useDetailTranslation`
+ * is a `createSafeTranslation` hook: a host with no `I18nProvider` must get the
+ * English default from `DETAIL_DEFAULT_TRANSLATIONS`, and — the part that fails
+ * silently — must **interpolate** `{{count}}`, never render it raw. No inline
+ * `defaultValue` is used anywhere (objectui#3517).
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { I18nProvider } from '@object-ui/i18n';
+import type { CommentEntry } from '@object-ui/types';
+import { RecordComments } from './RecordComments';
+
+afterEach(() => cleanup());
+
+const MIN = 60_000;
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+/** One comment per relative-time branch the helper can take. */
+function comments(): CommentEntry[] {
+  return [
+    { id: 'c0', author: 'Ada', text: 'zero', createdAt: ago(0) },
+    { id: 'c1', author: 'Grace', text: 'five minutes', createdAt: ago(5 * MIN) },
+    { id: 'c2', author: 'Alan', text: 'three hours', createdAt: ago(3 * 60 * MIN) },
+    { id: 'c3', author: 'Edsger', text: 'two days', createdAt: ago(2 * 24 * 60 * MIN) },
+  ];
+}
+
+function renderIn(language: string) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false }}>
+      <RecordComments comments={comments()} />
+    </I18nProvider>,
+  );
+}
+
+/** Pack values read out of the pack objects, not transcribed from the card. */
+const EN = { just: 'just now', min: '5m ago', hour: '3h ago', day: '2d ago' };
+const ZH = { just: '刚刚', min: '5分钟前', hour: '3小时前', day: '2天前' };
+const AR = { just: 'الآن', min: 'منذ 5 دقيقة', hour: 'منذ 3 ساعة', day: 'منذ 2 يوم' };
+
+describe('RecordComments relative timestamps — locale resolution (objectui#7163)', () => {
+  it('reads all four branches from the zh pack under a zh session', () => {
+    renderIn('zh');
+
+    expect(screen.getByText(ZH.just)).toBeTruthy();
+    expect(screen.getByText(ZH.min)).toBeTruthy();
+    expect(screen.getByText(ZH.hour)).toBeTruthy();
+    expect(screen.getByText(ZH.day)).toBeTruthy();
+  });
+
+  it('leaves no English relative time behind in a zh session', () => {
+    // The defect itself. Separated from the assertion above because a partial
+    // conversion passes that one and fails this one.
+    renderIn('zh');
+
+    expect(screen.queryByText(EN.just)).toBeNull();
+    expect(screen.queryByText(EN.min)).toBeNull();
+    expect(screen.queryByText(EN.hour)).toBeNull();
+    expect(screen.queryByText(EN.day)).toBeNull();
+  });
+
+  it('reads all four branches from the ar pack under an ar session', () => {
+    renderIn('ar');
+
+    expect(screen.getByText(AR.just)).toBeTruthy();
+    expect(screen.getByText(AR.min)).toBeTruthy();
+    expect(screen.getByText(AR.hour)).toBeTruthy();
+    expect(screen.getByText(AR.day)).toBeTruthy();
+  });
+
+  it('interpolates {{count}} on the provider path rather than rendering it raw', () => {
+    renderIn('zh');
+
+    expect(screen.queryByText('{{count}}分钟前')).toBeNull();
+    expect(screen.queryByText(/\{\{count\}\}/)).toBeNull();
+  });
+
+  it('still reads English under an en session', () => {
+    // Green by construction before the fix too — each `en` pack value is
+    // byte-identical to the literal it replaced. Kept as the guard that this
+    // was a lookup swap and NOT a copy change.
+    renderIn('en');
+
+    expect(screen.getByText(EN.just)).toBeTruthy();
+    expect(screen.getByText(EN.min)).toBeTruthy();
+    expect(screen.getByText(EN.hour)).toBeTruthy();
+    expect(screen.getByText(EN.day)).toBeTruthy();
+  });
+
+  it('falls back to the English defaults map with no provider mounted', () => {
+    render(<RecordComments comments={comments()} />);
+
+    expect(screen.getByText(EN.just)).toBeTruthy();
+    expect(screen.getByText(EN.min)).toBeTruthy();
+    expect(screen.getByText(EN.hour)).toBeTruthy();
+    expect(screen.getByText(EN.day)).toBeTruthy();
+  });
+
+  it('interpolates {{count}} on the provider-LESS path too', () => {
+    // `interpolateFallback` fills only the `{{name}}` spelling with no inner
+    // spaces (objectui#3512 / #6219). This is the leg where a wrong spelling
+    // renders a raw `{{count}}` silently.
+    render(<RecordComments comments={comments()} />);
+
+    expect(screen.queryByText(/\{\{count\}\}/)).toBeNull();
+    expect(screen.queryByText('{{count}}m ago')).toBeNull();
+  });
+
+  it('never renders a raw key, provider or not', () => {
+    renderIn('zh');
+    for (const k of ['detail.justNow', 'detail.minutesAgo', 'detail.hoursAgo', 'detail.daysAgo']) {
+      expect(screen.queryByText(k)).toBeNull();
+    }
+    cleanup();
+
+    render(<RecordComments comments={comments()} />);
+    for (const k of ['detail.justNow', 'detail.minutesAgo', 'detail.hoursAgo', 'detail.daysAgo']) {
+      expect(screen.queryByText(k)).toBeNull();
+    }
+  });
+});

--- a/packages/plugin-detail/src/RecordComments.tsx
+++ b/packages/plugin-detail/src/RecordComments.tsx
@@ -22,22 +22,37 @@ export interface RecordCommentsProps {
   className?: string;
 }
 
+type CommentsTranslate = (key: string, options?: Record<string, unknown>) => string;
+
 /**
  * Format a timestamp string into a human-readable relative time or date string.
+ *
+ * objectui#7163 — the four relative-time branches were hardcoded English, so a
+ * zh session read a translated comment card with an English `5m ago` inside it.
+ * They now resolve from the packs through the same four keys the siblings in
+ * this package already use (`RecordActivityTimeline`, `RecordMetaFooter`,
+ * `ThreadedReplies`, and `ActivityTimeline` since objectui#7162) — reused, not
+ * forked: each key's `en` value is byte-identical to the literal it replaces,
+ * so this is a lookup swap with no copy change and no new key in any pack.
+ *
+ * `t` is threaded in as a parameter rather than the helper being made a hook:
+ * it is called from inside a `.map()` over the comment list.
  */
-function formatTimestamp(timestamp: string): string {
+function formatTimestamp(timestamp: string, t: CommentsTranslate): string {
   try {
     const date = new Date(timestamp);
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(diffMs / 60000);
 
-    if (diffMins < 1) return 'just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffMins < 1) return t('detail.justNow');
+    if (diffMins < 60) return t('detail.minutesAgo', { count: diffMins });
     const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffHours < 24) return t('detail.hoursAgo', { count: diffHours });
     const diffDays = Math.floor(diffHours / 24);
-    if (diffDays < 7) return `${diffDays}d ago`;
+    if (diffDays < 7) return t('detail.daysAgo', { count: diffDays });
+    // Past a week this is a DATE, not a relative phrase: `toLocaleDateString`
+    // already localizes it, so there is no literal here to key.
     return date.toLocaleDateString();
   } catch {
     return timestamp;
@@ -184,7 +199,7 @@ export const RecordComments: React.FC<RecordCommentsProps> = ({
                   <div className="flex items-center gap-2 mb-0.5">
                     <span className="text-sm font-medium truncate">{comment.author}</span>
                     <span className="text-xs text-muted-foreground">
-                      {formatTimestamp(comment.createdAt)}
+                      {formatTimestamp(comment.createdAt, t)}
                     </span>
                     {comment.pinned && (
                       <span className="text-xs text-amber-600 flex items-center gap-0.5">

--- a/packages/plugin-detail/src/useDetailTranslation.ts
+++ b/packages/plugin-detail/src/useDetailTranslation.ts
@@ -266,6 +266,22 @@ export const DETAIL_DEFAULT_TRANSLATIONS: Record<string, string> = {
   // any other current/completed stage, so naming it apart would hand a screen
   // reader a distinction the screen does not make.
   'detail.pathStageWonUpcoming': '{{stage}}, goal stage, not reached',
+  // objectui#7163 — `PointInTimeRestore`'s chrome. That file used no hook at
+  // all, so a provider-less host had no English to fall back TO; these rows are
+  // byte-identical to the `en` pack (`defaults-maps-mirror-en-pack` enforces
+  // it). The field-count pair follows the repo's two-key plural convention
+  // (`reactionCount`/`reactionCountOne`), never an i18next `_one` suffix —
+  // `fallbackT` resolves `defaults[key]` literally and appends no suffix.
+  'detail.revisionHistory': 'Revision History',
+  'detail.noRevisions': 'No revisions recorded',
+  'detail.revisionFieldsChanged': '{{count}} fields changed',
+  'detail.revisionFieldsChangedOne': '{{count}} field changed',
+  'detail.revisionPreview': 'Revision Preview',
+  'detail.revisionSnapshot': 'Record state at this point',
+  'detail.restoreConfirm': 'This will restore the record to its state at {{when}}. Continue?',
+  'detail.restoring': 'Restoring…',
+  'detail.confirmRestore': 'Confirm Restore',
+  'detail.restoreToPoint': 'Restore to this point',
 };
 
 /**


### PR DESCRIPTION
Fixes #7163

Measured on `origin/main` head **`d8ec8d6d4`** (PR #7162's landing sha — the card's line numbers predate it, so everything below was re-derived, not inherited). Final commit **`42f6c1480`**; every gate result quoted here was run on that tree with `git status --porcelain` empty.

## The card's "byte-identical" premise is FALSE — verified mechanically

The title and both PM comments say the two `formatTimestamp` copies are byte-identical. They are not:

```
md5  b36edffbf4d6719482f17e1743ac2a4a  RecordComments::formatTimestamp     (18 lines, 597 bytes)
md5  846a6b780ea858ee9650f7a0eadf6f6c  PointInTimeRestore::formatTimestamp (16 lines, 495 bytes)
diff exit=1 — 3 lines differ
```

`RecordComments` has a fourth `d ago` branch and falls through to `toLocaleDateString()`; `PointInTimeRestore` stops at hours and falls through to `toLocaleString()`. A revision list wants the time of day; a comment list does not. (The card *body* said as much — "the same, minus the days branch"; only the title and the dispatch generalised it.)

**This decides the sharing question by measurement**, per the scope ruling. Sharing is declined on two independent grounds: the two helpers have genuinely different tails, so unifying them would silently restyle one surface; and a shared helper needs a new export, which is Clause ② with the quota exhausted. Reported rather than routed around. The duplication is now three-way (`ActivityTimeline`, `RecordComments`, and this near-copy) and is filed separately as a finding.

## What shipped

**`RecordComments.tsx` — pure lookup swap, no new key, no copy change.** The file was already wired to the packs (11 `t('detail.…')` refs); only its helper was hardcoded. It now resolves `detail.justNow` / `minutesAgo` / `hoursAgo` / `daysAgo`. Each mapping was checked for **exactness**, not adopted on the card's word:

| literal | key | `en` pack value | verdict |
|---|---|---|---|
| `'just now'` | `detail.justNow` | `just now` | exact |
| `` `${diffMins}m ago` `` | `detail.minutesAgo` | `{{count}}m ago` | exact |
| `` `${diffHours}h ago` `` | `detail.hoursAgo` | `{{count}}h ago` | exact |
| `` `${diffDays}d ago` `` | `detail.daysAgo` | `{{count}}d ago` | exact |

**`PointInTimeRestore.tsx` — swept WHOLE, not partially wired.** It used no translation hook at all (0 refs), so per the ruling it was finished in one pass rather than becoming a third half-done component: card title, empty state, field-count line, preview heading, snapshot heading, both `(empty)` placeholders, the snapshot dash, the restore confirmation, and all three buttons. 17 static `t()` call sites; zero English literals remain (each removed anchor greps to 0).

Ten new keys land in **all ten packs** and in `DETAIL_DEFAULT_TRANSLATIONS`. Three existing keys are **reused rather than forked**: `detail.cancel`, `detail.activityEmptyValue` (the key `ActivityTimeline` already uses for an absent old/new value in a field-change diff — the same concept), and `detail.emptyValue`.

Two shape rules observed:
- The restore confirmation is **one key with a `{{when}}` hole**, not a sentence assembled around a JSX expression.
- The field-count plural is selected by a **static ternary over two literal keys**, never `t(KEYS[n])` — #7149 measured that a key visible only as a map value reads as unreferenced to the i18n scanners.

**One deliberate copy change, called out rather than quietly adopted:** the snapshot panel's null placeholder was an EN DASH (`–`, U+2013) written inline; it now resolves `detail.emptyValue`, which is an EM DASH (`—`, U+2014) in all ten packs — the glyph the rest of the detail package already uses.

## Pack verification method, with both controls

Read out of the **pack objects** by walking the nested path (`packages/i18n/src/locales/index.ts` -> `builtInLocales`), never a dotted-key grep — a grep for `detail.justNow` returns a false zero against the `en` pack that defines it, and the `detail` namespace is one of five in these packs that carry a `justNow` row.

- Loader liveness: `locales loaded: en,zh,ja,ko,de,fr,es,pt,ru,ar (count=10)`
- Positive controls: `detail.back` 10/10, `detail.noActivity` 10/10
- Negative control: `detail.zzzAbsentControl7163` **0/10**
- The four existing relative-time keys: **10/10 each**
- The ten new keys after the change: **10/10 each**, controls re-run in the same invocation and unchanged

## Reachability finding (this splits the card, as #7149's did)

`PointInTimeRestore` has **zero in-repo consumers**. Repo-wide, excluding `node_modules` and `dist`, it appears only in its own file and twice in the package barrel (`index.tsx:126` export, `:154` type export). Nothing renders it — not `DetailView`, not `apps/console`. `RecordComments`, by contrast, is rendered by `DetailView` at two call sites (`:1479`, `:1705`).

So the user-visible defect today is `RecordComments`; `PointInTimeRestore` is public API a downstream consumer can mount but nothing in this repo does. It was still swept whole rather than deferred: it is exported, so it is shippable surface, and finishing it now is what stops the #7142 shape from recurring.

## Nothing pinned the old literals — attributed, not counted

Repo-wide `grep -F` on `'just now'` and `'m ago'` returns hits across five packages. **Attributed** rather than counted: every test assertion among them belongs to `packages/collaboration` (a different package and namespace, `useCollaborationTranslation`) or to `ActivityTimeline.remainingLiterals.i18n.test.tsx` (#7162's suite, asserting on a different component). The two `plugin-detail` hits in `RecordMetaFooter.tsx` are **comments**, not literals — that file is already a correct `t()` call site. The `PointInTimeRestore` copy has exactly **one** hit per literal: the file itself. No test pinned either file's English.

## Evidence

**Ablation — direction predicted before running, mutation proven on disk, restore proven by state.**

Predicted: reverting only the two `.tsx` files to `d8ec8d6d4` (packs, defaults map and the new suites kept) turns the zh/ar assertions red while every `en` and provider-less assertion stays green **by construction**, since each `en` pack value is byte-identical to the literal being restored. Predicted 9 red / 8 green.

Observed, exactly:

```
Test Files  2 failed (2)
     Tests  9 failed | 8 passed (17)
```

- Mutation proven by **blob hash AND marker count**: `A(HEAD)=49c08e56…` vs `A(disk)=b5ce3ad9…`, `B(HEAD)=0db4d714…` vs `B(disk)=cac43cf7…`; injected marker `t('detail.justNow')` 0 in both, restored marker `return 'just now';` 1 in both, `Revision History` literal back to 1.
- Restore proven by **state**, not exit code: `git diff HEAD` produced **0 lines**, `git status --porcelain` **0 lines**, and both on-disk hashes match their HEAD blobs exactly. The script carried `trap restore EXIT INT TERM` with absolute paths resolved from `git rev-parse --show-toplevel`, and the restore leg names `HEAD` explicitly (a bare `git checkout -- path` restores *from the index*, which the mutation had already written).
- The 8 greens are green-by-construction and are kept deliberately: they guard that this was a lookup swap and **not** a copy change. Naming them: the `en` and provider-less legs of both suites, the two `{{count}}`-interpolation guards, and the two raw-key guards (a reverted file renders literals, not keys, so those cannot discriminate).

**Resolution path stated, since an ablation is only valid if it is measured:** the suites resolve **source**, not `dist/`. The components are same-package relative imports, and the root vitest config aliases `@object-ui/i18n` to `packages/i18n/src` (`vitest.config.mts:275`). No rebuild leg is required for this ablation, and the green run was measured against source too. The dependency closure was built anyway before the first run (`pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail^...' build`, exit 0).

**Green runs** (vitest paths root-relative per #3378, canonical invocation through the root config):

```
packages/plugin-detail/src/RecordComments.i18n.test.tsx
packages/plugin-detail/src/PointInTimeRestore.i18n.test.tsx
  Test Files  2 passed (2)       Tests  17 passed (17)

packages/plugin-detail/ packages/i18n/          (affected packages, whole)
  Test Files  182 passed (182)   Tests  2071 passed (2071)

all-locales-key-parity + de-quote-pairing-3876 + defaults-maps-mirror-en-pack
  Test Files  3 passed (3)       Tests  53 passed (53)
```

**Gates** — exit codes captured by redirect-then-capture, never read across a pipe; each verdict is the gate's own printed line:

- `check:i18n-keys` **exit 0** — *"Every in-scope call-site key resolves against the en pack (2865 keys), every literal inline defaultValue matches the value the pack serves, every call site passes exactly the arguments that value has holes for…"*
- `check:i18n-drift` **exit 0** — *"Compared the ten locale packs at d8ec8d6d4 (merge-base with origin/main) with the working tree: 0 en value(s) changed (10 key(s) added, 0 removed…)"*
- `check:i18n-dead-keys` **exit 0** (report, not a gate)
- `changeset:check` **exit 0** — *"All workspace packages are in the changeset fixed group."* / *"No changeset declares a `major` bump."*
- `check-changeset-presence.mjs` **exit 0** — *"15 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)"*
- `check-changeset-overwrite.mjs` **exit 0** — *"No pre-existing changeset was modified or deleted."*
- `check:control-bytes` **exit 0** — *"OK (scanned 5947 tracked text file(s); skipped 85 binary)"*; plus a direct `grep -naP` control-char scan over all 16 changed files: **0 hits**
- `type-check` (plugin-detail + i18n) **exit 0** — *"Scope: 2 of 47 workspace projects"* with both script names echoed, so not a zero-match silent pass
- `lint` (plugin-detail + i18n, plain per-package `eslint .`, no `--no-inline-config`) **exit 0** — warnings only, all pre-existing; the three on `PointInTimeRestore.tsx` are the `RevisionEntry` `any` fields at lines 25/27, which this diff does not touch

**Not NOT-MEASURED:** `type-check` runs `tsc -p tsconfig.test.json`, and `--listFiles` confirms both new suites are actually in that program (1 hit each; control `zzzNoSuchFile.tsx` = 0) — so the green genuinely covers the new test files rather than excluding them.

**The `de` quote-pairing census did not move.** The ⚠ carried forward from #7149 (a pack value with a quoted span shifts `de-quote-pairing-3876.test.ts`, 55 -> 58) does not apply: the German values added here contain no quote characters by construction, the census stays at **58**, and that file is untouched — verified by running it green rather than by assuming.

## Scope

Lane held: `packages/plugin-detail/src/{RecordComments,PointInTimeRestore}.tsx`, their new suites, and the ten locale packs. `ActivityTimeline.tsx` was read-only reference and is unmodified. No fenced package was entered. `content/docs/releases/` untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_