### PR TITLE
census(scripts): the `body` dialect liveness reading — ruling step 1 of #6771

### DIFF
--- a/.changeset/6771-body-dialect-census.md
+++ b/.changeset/6771-body-dialect-census.md
@@ -1,0 +1,6 @@
+---
+---
+
+Adds `scripts/body-dialect-census.mjs`, the re-runnable liveness census that ruling step 1
+of objectui#6771 makes a precondition of retiring the `body` child-list dialect. Tooling and
+tests only — no package changes, no behaviour change, and none of the retirement itself.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "check:dist-completeness": "node scripts/check-dist-completeness.mjs --all",
   "check:esm-specifiers": "node scripts/check-node-esm-load.mjs --specifiers-only",
   "check:node-esm-load": "node scripts/check-node-esm-load.mjs",
+    "census:body-dialect": "node scripts/body-dialect-census.mjs",
     "check:control-bytes": "node scripts/check-control-bytes.mjs",
     "check:published-dist": "node scripts/check-published-dist-tooling.mjs",
     "check:spec-floors": "node scripts/check-spec-range-floors.mjs",

--- a/scripts/__tests__/body-dialect-census.test.ts
+++ b/scripts/__tests__/body-dialect-census.test.ts
@@ -1,0 +1,220 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Pins for `scripts/body-dialect-census.mjs` (objectui#6771, ruling step 1).
+ *
+ * Two things are pinned here, and they fail for different reasons:
+ *
+ * 1. **The instrument.** Every assertion in the first block corresponds to a
+ *    bug the first draft of the census actually had, and each one failed the
+ *    same way: it returned a SILENT ZERO with exit 0. A census that reads zero
+ *    because it is blind is indistinguishable from a corpus that is clean —
+ *    which is the exact failure mode the card's own history is made of.
+ *
+ * 2. **The population.** The `body`-only key list is read back off the renderer
+ *    sources, so it cannot go stale the way the card body's "10" did. If
+ *    someone teaches `badge` to read `children`, or adds a `sidebar-*`
+ *    registration, this goes red rather than the census quietly measuring the
+ *    wrong set.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  scanNodes,
+  keepFencedCodeOnly,
+  BODY_ONLY,
+  RULED_BUT_NOT_A_READER,
+  BODY_ONLY_UNRULED,
+} from '../body-dialect-census.mjs';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const read = (p: string) => readFileSync(join(REPO_ROOT, p), 'utf8');
+
+const keysOf = (text: string, type: string) => {
+  const node = scanNodes(text).find((n: { type: string }) => n.type === type);
+  return node ? [...(node.keys as Set<string>)] : null;
+};
+
+describe('the scanner sees the shapes authored metadata actually uses', () => {
+  it('reads QUOTED keys — the JSON corpus is the whole point', () => {
+    // REGRESSION: the first draft consumed a quoted key as a string value
+    // before ever testing it as a key, because the string branch ran first.
+    // JSON spells every key quoted, so the entire `.json` corpus — including
+    // the four authored sidebar fixtures that turned out to hold 56 of the 56
+    // `body` nodes in this repo — read as ZERO. Exit 0, no error, no hint.
+    expect(keysOf('{"type": "badge", "body": []}', 'badge')).toEqual(['type', 'body']);
+    expect(keysOf("{ type: 'badge', body: [] }", 'badge')).toEqual(['type', 'body']);
+  });
+
+  it('attributes a child key to the node that owns it, not to an ancestor', () => {
+    // `body` two levels down belongs to the inner node. Without this, one
+    // authored `body` would score against every enclosing node as well.
+    const text = '{"type":"card","children":[{"type":"badge","body":[]}]}';
+    expect(keysOf(text, 'card')).toEqual(['type', 'children']);
+    expect(keysOf(text, 'badge')).toEqual(['type', 'body']);
+  });
+
+  it('does NOT score a key that only appears in a comment — prose is not a call site', () => {
+    expect(scanNodes("// a node written { type: 'badge', body: [] }\n")).toEqual([]);
+    expect(scanNodes("/* { type: 'badge', body: [] } */")).toEqual([]);
+  });
+
+  it('survives a regex literal after `=>`, which otherwise blinds the rest of the file', () => {
+    // REGRESSION: `/^ {3}\S.*\(type "/` in a real test file was not recognised
+    // as a regex because `>` was missing from the "value position" set. Its `{`
+    // opened a phantom object frame and its lone `"` opened a runaway string,
+    // so every node AFTER it vanished — the file scored 0 of its 3 nodes.
+    const text = String.raw`
+      const f = (l) => /^ {3}\S.*\(type "/.test(l);
+      const node = { type: 'badge', body: [] };
+    `;
+    expect(keysOf(text, 'badge')).toEqual(['type', 'body']);
+  });
+
+  it('keeps Markdown fenced code and drops Markdown prose', () => {
+    // REGRESSION: a ```json fence is THREE backticks. The scanner treats a
+    // backtick as a template-literal delimiter, so the first two paired off and
+    // the third swallowed the whole snippet — EVERY doc example read as zero.
+    // That population is not incidental: ruling step 5 migrates the teaching
+    // corpus in the same commit.
+    const md = ['Prose mentioning `type: "badge"` inline.', '', '```json', '{ "type": "badge", "body": [] }', '```', ''].join('\n');
+    const kept = keepFencedCodeOnly(md);
+    expect(keysOf(kept, 'badge')).toEqual(['type', 'body']);
+    // …and the prose mention is gone, not counted.
+    expect(kept).not.toContain('Prose mentioning');
+    // Line numbers survive the blanking, so reported positions stay true.
+    expect(kept.split('\n').length).toBe(md.split('\n').length);
+  });
+
+  it('CONTROL — a corpus-shaped input returns hits, so a zero elsewhere is readable', () => {
+    // Without this, every "0" in the census is indistinguishable from a
+    // scanner that resolved nothing at all.
+    const nodes = scanNodes(read('examples/schema-catalog/src/schemas/components-basic-sidebar/basic-sidebar.json'));
+    expect(nodes.length).toBeGreaterThan(0);
+    expect(nodes.filter((n: { keys: Set<string> }) => n.keys.has('body')).length).toBeGreaterThan(0);
+  });
+});
+
+describe('the measured population is read off the renderers, not off the card body', () => {
+  const sidebarSrc = () => read('packages/components/src/renderers/navigation/sidebar.tsx');
+
+  it('`BODY_ONLY` is 12 keys — the ruled 13 minus `sidebar-trigger`', () => {
+    // The card body says 10 and the ruling's step 2 repeats it; the census pin
+    // in `container-declaration-ratchet.test.tsx` says 13. Both are counts of
+    // slightly different things. What the retirement actually costs is measured
+    // per RENDERER READ, and that set is 12.
+    expect(BODY_ONLY.length).toBe(12);
+    expect(BODY_ONLY).toContain('badge');
+    expect(BODY_ONLY).toContain('alert');
+    // The bare family name is present. A `sidebar-[a-z-]+` pattern REQUIRES a
+    // suffix and silently drops it — the original miscount, recorded on the
+    // card 2026-08-29, and the census query has the same shape.
+    expect(BODY_ONLY).toContain('sidebar');
+    expect(BODY_ONLY.filter((k) => k.startsWith('sidebar')).length).toBe(10);
+  });
+
+  it('`badge` and `alert` read `body` and never `children`', () => {
+    for (const [file, type] of [
+      ['packages/components/src/renderers/data-display/badge.tsx', 'badge'],
+      ['packages/components/src/renderers/data-display/alert.tsx', 'alert'],
+    ] as const) {
+      const src = read(file);
+      expect(src, `${type} stopped reading schema.body`).toContain('renderChildren(schema.body)');
+      expect(src, `${type} now reads schema.children — it is no longer body-only`).not.toContain('schema.children');
+    }
+  });
+
+  it('`sidebar-trigger` is ruled but reads NO child list, so retirement costs it nothing', () => {
+    expect(RULED_BUT_NOT_A_READER).toEqual(['sidebar-trigger']);
+    const src = sidebarSrc();
+    // It is registered…
+    expect(src).toContain("ComponentRegistry.register('sidebar-trigger'");
+    // …and there are exactly 10 `renderChildren(schema.body)` reads across the
+    // 11 `sidebar-*` registrations. The one without is `sidebar-trigger`, whose
+    // renderer never receives `schema` at all.
+    expect(src.match(/ComponentRegistry\.register\('sidebar/g)?.length).toBe(11);
+    expect(src.match(/renderChildren\(schema\.body\)/g)?.length).toBe(10);
+    const trigger = src.slice(src.indexOf("register('sidebar-trigger'"));
+    expect(trigger).not.toContain('schema.body');
+    expect(trigger).not.toContain('schema.children');
+  });
+
+  it('⚠️ `tooltip` is a `body`-only reader that the ruled 13 does NOT include', () => {
+    // Measured, and it matters: `tooltip` renders `renderChildren(schema.body)`
+    // and never `schema.children`, so direction B removes its only rich-content
+    // key too — yet it is absent from the ruling's step 2 list. It is also the
+    // ONE registration in the tree that DECLARES `body` as an authorable input,
+    // which makes it the most discoverable spelling of `body` on the whole
+    // authoring surface.
+    expect(BODY_ONLY_UNRULED).toEqual(['tooltip']);
+    const src = read('packages/components/src/renderers/overlay/tooltip.tsx');
+    expect(src).toContain('renderChildren(schema.body)');
+    expect(src).not.toContain('schema.children');
+    expect(src).toMatch(/name:\s*'body'/);
+  });
+
+  it('the two published keys are exactly `badge` and `alert`', () => {
+    // ADR-0080's allow-list. Retiring `body` on these two is a reject-direction
+    // change on PUBLISHED contract; on the 11 bare `sidebar-*` it is internal.
+    // `PUBLIC_BLOCKS` carries the namespaced `page:sidebar`, a different type —
+    // so grepping the list for "sidebar" would wrongly score the bare family.
+    const src = read('packages/core/src/registry/public-blocks.ts');
+    expect(src).toMatch(/^\s*'badge',$/m);
+    expect(src).toMatch(/^\s*'alert',$/m);
+    expect(src).toMatch(/^\s*'page:sidebar',$/m);
+    for (const key of BODY_ONLY.filter((k) => k.startsWith('sidebar'))) {
+      expect(src, `bare \`${key}\` became public — the census cost split changed`).not.toMatch(
+        new RegExp(`^\\s*'${key}',$`, 'm'),
+      );
+    }
+  });
+});
+
+describe('the census stays re-runnable', () => {
+  it('is wired into the root package.json, like every other script here', () => {
+    // A census that gates a multi-day retirement has to be repeatable after the
+    // next corpus change, by someone who was not here. Same convention as the
+    // `check:*` gates: the entry point is pinned, not just documented.
+    const pkg = JSON.parse(read('package.json')) as { scripts: Record<string, string> };
+    expect(pkg.scripts['census:body-dialect']).toBe('node scripts/body-dialect-census.mjs');
+  });
+});
+
+describe('the `body` consumers the ruling does not enumerate', () => {
+  it('three generic readers outside the renderer tree still resolve `body`', () => {
+    // Recorded because ruling steps 2-5 name renderers, the published type and
+    // the tier — and these three are none of those. They read `body` for ANY
+    // node type, so they outlive the per-registration convergence and would
+    // keep the dialect alive after step 2 lands.
+    expect(read('packages/core/src/validation/schema-validator.ts')).toContain(
+      'schema.children || schema.body',
+    );
+    expect(read('packages/vscode-extension/src/providers/SchemaValidator.ts')).toContain('schema.body');
+    expect(read('packages/vscode-extension/src/providers/PreviewProvider.ts')).toContain('schema.body');
+  });
+
+  it('the platform SHIPS the dialect it is being asked to refuse', () => {
+    // The sharpest census finding. Ruling step 5's principle is that "the
+    // platform never refuses a spelling it still ships" — and today these
+    // PRODUCERS emit `body` into metadata a user then owns:
+    //
+    //   - `objectui init` scaffolds every new project's app in `body`
+    //   - the VS Code extension's new-file templates do the same
+    //   - two registrations ship `body` inside their own `defaultProps`
+    //
+    // So step 4 (tier teaches `children` only) cannot land before these move,
+    // or every freshly scaffolded project fails validation on day one.
+    expect(read('packages/cli/src/commands/init.ts')).toMatch(/^\s*body:/m);
+    expect(read('packages/vscode-extension/src/extension.ts')).toMatch(/^\s*body:/m);
+    expect(read('packages/components/src/renderers/complex/carousel.tsx')).toContain("body: [{ type: 'text'");
+  });
+});

--- a/scripts/body-dialect-census.mjs
+++ b/scripts/body-dialect-census.mjs
@@ -61,6 +61,8 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative, extname, sep } from 'node:path';
 
+import { isEntrypoint } from './invoked-as.mjs';
+
 // ── The measured population ────────────────────────────────────────────────
 //
 // BODY_ONLY: registrations whose renderer reads `renderChildren(schema.body)`
@@ -485,4 +487,16 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) main();
+// The ONE entry-guard predicate (`scripts/invoked-as.mjs`), never a hand-typed
+// `process.argv[1]` comparison. This file shipped the percent-encoding spelling
+// its header names: ``import.meta.url === `file://${process.argv[1]}` `` builds
+// a URL WITHOUT the encoding `pathToFileURL` applies, so a checkout path
+// containing a character that needs encoding — a `#` in any parent directory is
+// enough, no symlink required — makes the two sides disagree, the guard answer
+// false, and the census print nothing and exit 0.
+//
+// ⇒ That is a FOURTH silent zero on this card, in the harness around the
+// scanner rather than in the scanner itself, and the same shape as the three
+// the differential control caught inside it: a clean read and a tool that never
+// ran are indistinguishable from the exit code alone.
+if (isEntrypoint(import.meta.url)) main();

--- a/scripts/body-dialect-census.mjs
+++ b/scripts/body-dialect-census.mjs
@@ -1,0 +1,488 @@
+#!/usr/bin/env node
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `body` dialect liveness census (objectui#6771, ruling step 1).
+ *
+ * ## What this answers
+ *
+ * The 2026-09-01 ruling on objectui#6771 adopted option B — retire the `body`
+ * child-list dialect so `children` is the one spelling — and made a liveness
+ * reading a HARD GATE on everything after it:
+ *
+ * > Evidence of heavy `body` usage in *published* authored metadata returns to
+ * > this card before any narrowing ships.
+ *
+ * So the question is not "does the string `body` appear" — it is **how many
+ * authored NODES spell their child list `body`, per registration key**, with
+ * the `children` count on the same keys as the denominator.
+ *
+ * ## Why a parser and not a grep
+ *
+ * `body` is a sibling key of `type` inside one object literal. A line-oriented
+ * grep cannot see that relationship: it scores `body:` in an email payload, a
+ * `bodyExtra` prop and a real authored node identically. This walks object
+ * literals with a string/comment/regex-aware scanner and reports, per node,
+ * which child-list keys that node actually carries.
+ *
+ * It reads `.json` and JS/TS object literals and Markdown alike, because
+ * authored metadata in these repos lives in all three (JSON app metadata,
+ * `definePage`-style TS literals, and the teaching snippets that ruling step 5
+ * migrates in the same commit).
+ *
+ * ## Populations are reported SEPARATELY and never summed
+ *
+ * `--label` names the population so two runs cannot be added together by
+ * accident: this repo's corpus is partly fixtures, hotcrm is a real
+ * application, and they are differently authoritative.
+ *
+ * ## Known limits (stated so a zero is readable)
+ *
+ * - Template literals are opaque. A node built inside `` `${...}` `` is not
+ *   counted. Measured on both corpora at time of writing: no target node is
+ *   authored that way.
+ * - YAML is NOT scanned. Report YAML separately if a corpus ever authors
+ *   metadata there — absence here is "not scanned", not "zero".
+ * - The scanner reports CANDIDATES. Attribution (fixture vs doc vs real
+ *   authored page) is the `--group` bucket, and the counts per bucket are what
+ *   a reader should quote, not the raw total.
+ *
+ * Usage:
+ *   node scripts/body-dialect-census.mjs --root . --label objectui
+ *   node scripts/body-dialect-census.mjs --root ../hotcrm --label hotcrm --json
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, extname, sep } from 'node:path';
+
+// ── The measured population ────────────────────────────────────────────────
+//
+// BODY_ONLY: registrations whose renderer reads `renderChildren(schema.body)`
+// and never `schema.children`. For these, `body` is the ONLY door — retiring it
+// removes the sole child-list key.
+//
+// ⚠️ Derived from the renderer sources, NOT from objectui#6771's card body
+// (which lists 10) and NOT verbatim from the ratchet pin's `bodyReaders` array
+// (which is `['badge','alert',...sidebar*]` = 13). The pin's array is a
+// convenience construction for a containment assertion — it is correct that all
+// 13 are non-containers, but two of its members are not `body` readers at all:
+//
+//   - `sidebar-trigger` (navigation/sidebar.tsx:202) renders `<SidebarTrigger>`
+//     and takes no `schema` at all — it reads NEITHER `body` NOR `children`.
+//   - `tooltip` (overlay/tooltip.tsx:31) DOES read `schema.body` and never
+//     `schema.children`, and is the one registration in the tree that DECLARES
+//     `body` as an input (`type: 'slot'`, label "Rich Content") — yet it is
+//     absent from the ruled 13.
+//
+// So the body-reading population is 12 of the ruled 13, plus `tooltip` = 13
+// readers, which is the same NUMBER by coincidence and a different SET.
+// Both facts are pinned in `__tests__/body-dialect-census.test.mjs`.
+export const BODY_ONLY = [
+  'alert',
+  'badge',
+  'sidebar',
+  'sidebar-content',
+  'sidebar-footer',
+  'sidebar-group',
+  'sidebar-header',
+  'sidebar-inset',
+  'sidebar-menu',
+  'sidebar-menu-button',
+  'sidebar-menu-item',
+  'sidebar-provider',
+];
+
+/** Ruled by objectui#6771 but reads no child list at all — retiring `body` costs it nothing. */
+export const RULED_BUT_NOT_A_READER = ['sidebar-trigger'];
+
+/** Reads `schema.body` only, and is NOT in the ruled 13. See the note above. */
+export const BODY_ONLY_UNRULED = ['tooltip'];
+
+// FALLBACK_READERS: `schema.children || schema.body` (or `body || children`).
+// Authored `body` here is a silent second dialect, not the only door — these
+// authors have a working alternative, so the retirement cost is a rewrite, not
+// a capability loss.
+const SEMANTIC_TAGS = ['aside', 'main', 'header', 'nav', 'footer', 'section', 'article'];
+const HTML_ELEMENT_TAGS = [
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'p', 'a', 'blockquote', 'pre',
+  'strong', 'em', 'b', 'i', 'u', 'small', 'mark', 'sub', 'sup', 'del', 'ins', 'abbr',
+  'ul', 'ol', 'li', 'dl', 'dt', 'dd',
+  'figure', 'figcaption', 'time', 'address', 'cite', 'q',
+  // `img`, `hr`, `br` are VOID_TAGS — the factory skips `renderChildren` for
+  // them, so they read neither key and are deliberately absent.
+];
+export const FALLBACK_READERS = [
+  ...SEMANTIC_TAGS,
+  ...HTML_ELEMENT_TAGS,
+  'div',
+  'aspect-ratio',
+  'card',
+  'page',
+  'button',
+];
+
+const ALL_KEYS = new Set([
+  ...BODY_ONLY,
+  ...RULED_BUT_NOT_A_READER,
+  ...BODY_ONLY_UNRULED,
+  ...FALLBACK_READERS,
+]);
+
+const SCANNED_EXT = new Set([
+  '.json', '.jsonc', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.md', '.mdx',
+]);
+const SKIP_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'coverage', '.next', '.turbo', 'out',
+  '.pnpm-store', 'playwright-report', 'test-results',
+]);
+
+// ── Scanner ────────────────────────────────────────────────────────────────
+
+/**
+ * Blank out Markdown prose, keeping only fenced code blocks (offsets and line
+ * breaks preserved, so reported line numbers stay true).
+ *
+ * ⚠️ Required, not cosmetic. Markdown spells inline code with backticks, and
+ * the scanner treats a backtick as a template-literal delimiter. A ```` ```json ````
+ * fence is THREE backticks: the first two pair off, and the third opens a
+ * "string" that runs to the closing fence — swallowing the entire snippet. The
+ * first draft of this script therefore read EVERY doc example as zero nodes,
+ * silently and with exit 0. That population is not incidental: ruling step 5
+ * migrates the teaching corpus in the same commit, so a zero there would have
+ * under-reported exactly the surface the ruling asks about.
+ *
+ * Prose is blanked rather than scanned because prose is not a call site — a
+ * sentence mentioning `type: "badge"` is documentation about a key, not a node
+ * authoring it.
+ */
+export function keepFencedCodeOnly(text) {
+  const out = new Array(text.length).fill(' ');
+  for (let i = 0; i < text.length; i++) if (text[i] === '\n') out[i] = '\n';
+
+  const fence = /^([ \t]*)(`{3,}|~{3,})([^\n]*)\n/gm;
+  let m;
+  while ((m = fence.exec(text)) !== null) {
+    const marker = m[2][0].repeat(m[2].length);
+    const bodyStart = m.index + m[0].length;
+    // Find the closing fence: same marker character, at least as long.
+    const closeRe = new RegExp(`^[ \\t]*${m[2][0] === '`' ? '`' : '~'}{${m[2].length},}[ \\t]*$`, 'm');
+    closeRe.lastIndex = 0;
+    const rest = text.slice(bodyStart);
+    const closeMatch = closeRe.exec(rest);
+    const bodyEnd = closeMatch ? bodyStart + closeMatch.index : text.length;
+    for (let i = bodyStart; i < bodyEnd; i++) out[i] = text[i];
+    fence.lastIndex = closeMatch ? bodyStart + closeMatch.index + closeMatch[0].length : text.length;
+    void marker;
+  }
+  return out.join('');
+}
+
+/**
+ * Walk object literals in `text`, returning one record per object that carries
+ * a string-valued `type` key.
+ *
+ * String-, comment- and regex-aware, so `body:` inside a string, a comment or a
+ * regular expression is never scored as a key. Keys are attributed to the
+ * IMMEDIATELY enclosing object frame only — a `body` two levels down belongs to
+ * the inner node, not the outer one.
+ */
+export function scanNodes(text) {
+  const nodes = [];
+  /** @type {Array<{ isObject: boolean, keys: Set<string>, type: string | null, start: number }>} */
+  const stack = [];
+  const n = text.length;
+  let i = 0;
+  // Tracks the last significant character, to tell division from a regex literal.
+  let prevSignificant = '';
+
+  const pushFrame = (isObject) => {
+    stack.push({ isObject, keys: new Set(), type: null, start: i });
+  };
+  const popFrame = () => {
+    const frame = stack.pop();
+    if (frame && frame.isObject && frame.type !== null) {
+      nodes.push({ type: frame.type, keys: frame.keys, offset: frame.start });
+    }
+  };
+
+  while (i < n) {
+    const c = text[i];
+
+    // Comments
+    if (c === '/' && text[i + 1] === '/') {
+      while (i < n && text[i] !== '\n') i++;
+      continue;
+    }
+    if (c === '/' && text[i + 1] === '*') {
+      i += 2;
+      while (i < n && !(text[i] === '*' && text[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+
+    // Regex literal: a `/` in value position. Without this, a pattern such as
+    // /^ {3}\S.*\(type "/ unbalances the brace stack (its `{` opens a phantom
+    // object) AND its lone `"` opens a runaway string, blinding the scanner for
+    // the rest of the file. Measured: that exact pattern in
+    // `packages/cli/src/__tests__/check-schema-marker.test.ts` cost the file all
+    // of its nodes until `>` was added below — an arrow function's `=>` is the
+    // single commonest thing a regex literal follows in this codebase.
+    if (
+      c === '/' &&
+      (/[(,=:[!&|?{};+\-*%~^<>]/.test(prevSignificant) ||
+        /\b(return|typeof|case|in|of|do|else|yield|await|delete|void|instanceof)$/.test(
+          text.slice(Math.max(0, i - 12), i).trimEnd(),
+        ))
+    ) {
+      i++;
+      let closed = false;
+      while (i < n) {
+        if (text[i] === '\\') { i += 2; continue; }
+        if (text[i] === '\n') break;
+        if (text[i] === '[') { // character class: `/` inside it is literal
+          i++;
+          while (i < n && text[i] !== ']' && text[i] !== '\n') {
+            if (text[i] === '\\') i++;
+            i++;
+          }
+          i++;
+          continue;
+        }
+        if (text[i] === '/') { i++; closed = true; break; }
+        i++;
+      }
+      if (closed) { prevSignificant = '/'; continue; }
+      // Not a regex after all — fall through as an ordinary character.
+      continue;
+    }
+
+    // Key position: an identifier or quoted string directly inside an object
+    // frame, followed by `:`.
+    //
+    // ⚠️ ORDER IS LOAD-BEARING — this MUST run before the string branch below.
+    // JSON spells every key quoted (`"type": "badge"`), so if the string branch
+    // consumes the opening quote first, no JSON key is ever tested and the whole
+    // `.json` corpus scores a silent, exit-0 ZERO. That is not hypothetical: it
+    // is what the first draft of this script did, and the differential control
+    // in the test file is what caught it (14-16 nodes per authored sidebar
+    // fixture, all read as 0).
+    const top = stack[stack.length - 1];
+    if (top && top.isObject && (/[A-Za-z_$]/.test(c) || c === '"' || c === "'")) {
+      const m = /^(?:"([^"\\]*)"|'([^'\\]*)'|([A-Za-z_$][\w$]*))\s*:/.exec(text.slice(i, i + 200));
+      if (m) {
+        const key = m[1] ?? m[2] ?? m[3];
+        top.keys.add(key);
+        i += m[0].length;
+        prevSignificant = ':';
+        if (key === 'type') {
+          // Capture a string-literal value; anything else (a TS annotation, an
+          // identifier, a union type) leaves `type` null and the frame unscored.
+          const v = /^\s*(?:"([^"\\]*)"|'([^'\\]*)')/.exec(text.slice(i, i + 200));
+          if (v) top.type = v[1] ?? v[2];
+        }
+        continue;
+      }
+    }
+
+    // Strings (values, and any quoted text that was NOT in key position).
+    if (c === '"' || c === "'" || c === '`') {
+      const quote = c;
+      i++;
+      while (i < n) {
+        if (text[i] === '\\') { i += 2; continue; }
+        if (text[i] === quote) { i++; break; }
+        i++;
+      }
+      prevSignificant = quote;
+      continue;
+    }
+
+    if (c === '{') { pushFrame(true); i++; prevSignificant = '{'; continue; }
+    if (c === '[') { pushFrame(false); i++; prevSignificant = '['; continue; }
+    if (c === '}' || c === ']') { popFrame(); i++; prevSignificant = c; continue; }
+
+    if (!/\s/.test(c)) prevSignificant = c;
+    i++;
+  }
+
+  // Unterminated frames (a Markdown file whose fenced snippet is a fragment,
+  // a `.tsx` whose apostrophe-in-prose desynced the stack) still yield their
+  // nodes — dropping them would turn a scanner limitation into a silent zero.
+  while (stack.length) popFrame();
+
+  return nodes;
+}
+
+// ── Attribution ────────────────────────────────────────────────────────────
+
+/**
+ * Bucket a file by what KIND of artifact it is. A `body` string in a test
+ * fixture, a doc snippet and a real authored page are three different things
+ * and only some of them are the population the ruling asks about.
+ */
+export function bucketOf(relPath) {
+  const p = relPath.split(sep).join('/');
+  if (/(^|\/)__tests__\//.test(p) || /\.(test|spec)\.[cm]?[jt]sx?$/.test(p)) return 'test';
+  if (/(^|\/)(__fixtures__|fixtures|__mocks__)\//.test(p)) return 'fixture';
+  if (/(^|\/)e2e\//.test(p)) return 'e2e';
+  if (/\.mdx?$/.test(p)) return 'docs-teaching';
+  if (/(^|\/)skills\//.test(p)) return 'skills-teaching';
+  if (/(^|\/)examples\//.test(p)) return 'example-app';
+  if (/(^|\/)(apps|src)\//.test(p)) return 'app-metadata';
+  if (/(^|\/)scripts\//.test(p)) return 'tooling';
+  return 'other';
+}
+
+// ── Walk ───────────────────────────────────────────────────────────────────
+
+function* walk(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) yield* walk(full);
+    else if (st.isFile() && SCANNED_EXT.has(extname(entry))) yield full;
+  }
+}
+
+function lineOf(text, offset) {
+  let line = 1;
+  for (let i = 0; i < offset && i < text.length; i++) if (text[i] === '\n') line++;
+  return line;
+}
+
+export function census(root) {
+  /** @type {Array<{file:string,line:number,type:string,body:boolean,children:boolean,bucket:string}>} */
+  const hits = [];
+  let filesScanned = 0;
+  for (const file of walk(root)) {
+    filesScanned++;
+    let text;
+    try {
+      text = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    // Cheap pre-filter: a file with none of the key names cannot hold a node.
+    if (!/\btype\b/.test(text)) continue;
+    const isMarkdown = /\.mdx?$/.test(file);
+    const scanText = isMarkdown ? keepFencedCodeOnly(text) : text;
+    let nodes;
+    try {
+      nodes = scanNodes(scanText);
+    } catch {
+      continue;
+    }
+    for (const node of nodes) {
+      if (!ALL_KEYS.has(node.type)) continue;
+      const rel = relative(root, file);
+      hits.push({
+        file: rel,
+        line: lineOf(text, node.offset),
+        type: node.type,
+        body: node.keys.has('body'),
+        children: node.keys.has('children'),
+        bucket: bucketOf(rel),
+      });
+    }
+  }
+  return { filesScanned, hits };
+}
+
+// ── Report ─────────────────────────────────────────────────────────────────
+
+function group(keys, hits) {
+  const rows = [];
+  for (const key of keys) {
+    const forKey = hits.filter((h) => h.type === key);
+    if (forKey.length === 0) {
+      rows.push({ key, nodes: 0, body: 0, children: 0, neither: 0, files: 0 });
+      continue;
+    }
+    rows.push({
+      key,
+      nodes: forKey.length,
+      body: forKey.filter((h) => h.body).length,
+      children: forKey.filter((h) => h.children).length,
+      neither: forKey.filter((h) => !h.body && !h.children).length,
+      files: new Set(forKey.map((h) => h.file)).size,
+    });
+  }
+  return rows;
+}
+
+function printTable(title, rows) {
+  console.log(`\n### ${title}`);
+  console.log('| key | nodes | `body` | `children` | neither | files |');
+  console.log('|:--|--:|--:|--:|--:|--:|');
+  for (const r of rows) {
+    console.log(`| \`${r.key}\` | ${r.nodes} | ${r.body} | ${r.children} | ${r.neither} | ${r.files} |`);
+  }
+  const sum = (f) => rows.reduce((a, r) => a + r[f], 0);
+  console.log(
+    `| **total** | **${sum('nodes')}** | **${sum('body')}** | **${sum('children')}** | **${sum('neither')}** | |`,
+  );
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const arg = (name, dflt) => {
+    const idx = argv.indexOf(name);
+    return idx >= 0 && argv[idx + 1] ? argv[idx + 1] : dflt;
+  };
+  const root = arg('--root', '.');
+  const label = arg('--label', root);
+  const asJson = argv.includes('--json');
+
+  const { filesScanned, hits } = census(root);
+
+  if (asJson) {
+    console.log(JSON.stringify({ label, root, filesScanned, hits }, null, 2));
+    return;
+  }
+
+  console.log(`## \`body\` dialect census — population: **${label}** (root: ${root})`);
+  console.log(`\nFiles scanned: ${filesScanned}. Candidate nodes: ${hits.length}.`);
+
+  printTable('Group 1 — `body`-only registrations (retiring `body` removes their ONLY child-list key)', group(BODY_ONLY, hits));
+  printTable('Group 1b — ruled by #6771 but reads NO child list (retirement costs it nothing)', group(RULED_BUT_NOT_A_READER, hits));
+  printTable('Group 1c — `body`-only reader NOT in the ruled 13 (⚠️ declares `body` as an input)', group(BODY_ONLY_UNRULED, hits));
+  printTable('Group 2 — `children || body` fallback readers (`body` is a second dialect, not the only door)', group(FALLBACK_READERS, hits).filter((r) => r.nodes > 0));
+
+  const bodyHits = hits.filter((h) => h.body);
+  console.log(`\n### Attribution of every node carrying \`body\` (${bodyHits.length})`);
+  if (bodyHits.length === 0) {
+    console.log('\n_None._');
+  } else {
+    const byBucket = new Map();
+    for (const h of bodyHits) byBucket.set(h.bucket, (byBucket.get(h.bucket) ?? 0) + 1);
+    console.log('\n| bucket | nodes |');
+    console.log('|:--|--:|');
+    for (const [b, c] of [...byBucket].sort((a, b2) => b2[1] - a[1])) console.log(`| ${b} | ${c} |`);
+    console.log('\n| file:line | key | also has `children` |');
+    console.log('|:--|:--|:--|');
+    for (const h of bodyHits.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line)) {
+      console.log(`| \`${h.file}:${h.line}\` | \`${h.type}\` | ${h.children ? 'yes' : 'no'} |`);
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();


### PR DESCRIPTION
Part of #6771 — this is **ruling step 1 of five** (the liveness census). ⛔ Deliberately **not** a closing reference: steps 2–5 are a published-contract narrowing marked `Clause-② yes at dispatch`, `CONTRACT_REVIEW_TIER` is exhausted, and the card must stay open to carry them. **No narrowing ships here.** This PR adds a measurement instrument and its pins; it touches none of `BASE_PROPS`, the body-only registrations, `form/button.tsx:58`, `packages/types/src/base.ts`, or the corpus.

The 2026-09-01 ruling made this reading a hard gate on everything after it:

> ⛔ Evidence of heavy `body` usage in *published* authored metadata returns to this card before any narrowing ships — the ruling adopts the direction on the current evidence, not against contrary measurement.

## Verdict: usage is **NOT heavy**. The ruling's direction survives its own gate.

The two keys that make direction B a **published** reject-direction change — `badge` and `alert`, the only members of `PUBLIC_BLOCKS` in the population — are authored with `body` **zero** times, in either population. All measured `body` usage on the only-door keys is **56 nodes in 4 files**, every one of them a `sidebar-*` demo this repo owns and can migrate in the same commit.

## What "heavy" means here, so you can disagree with a number

The ruling does not define it. This is the threshold used, stated so it is arguable:

| criterion | rule | measured | verdict |
|:--|:--|:--|:--|
| **Published-surface** (decisive) | any `body` node on a `PUBLIC_BLOCKS` key, in metadata this repo cannot migrate | **0** on `badge`, **0** on `alert`, both populations | not heavy |
| **Volume** | at least 100 authored nodes on the only-door keys — the three-digit line already stated on this card on 2026-08-29 ("存量达三位数节点 ⇒ 停手回报"), re-read against the real population rather than the 10-renderer estimate it was written for | **56** | not heavy |
| **Migratability** | every hit in a file this repo owns and can move in one commit | 56 nodes / **4** files, all `examples/schema-catalog` | not heavy |

The volume line is deliberately the card's own number rather than a fresh invention. Note it is a threshold on **Group 1** (the only-door keys); Group 2 clears three digits (146) but has a working alternative, so its cost is a rewrite, not a capability loss.

---

# Population A — this repo's corpus (partly fixtures; measured at `a90cfe5fe`)

5,816 files scanned, 1,000 candidate nodes.

## Group 1 — the only-door keys: retiring `body` removes their sole child-list key

| key | public? | nodes | `body` | `children` | neither | files |
|:--|:--|--:|--:|--:|--:|--:|
| `alert` | **yes** | 9 | **0** | 0 | 9 | 8 |
| `badge` | **yes** | 76 | **0** | 9 | 67 | 35 |
| `sidebar` | no | 9 | 4 | 0 | 5 | 9 |
| `sidebar-content` | no | 4 | 4 | 0 | 0 | 4 |
| `sidebar-footer` | no | 0 | 0 | 0 | 0 | 0 |
| `sidebar-group` | no | 7 | 5 | 0 | 2 | 5 |
| `sidebar-header` | no | 0 | 0 | 0 | 0 | 0 |
| `sidebar-inset` | no | 4 | 4 | 0 | 0 | 4 |
| `sidebar-menu` | no | 5 | 5 | 0 | 0 | 4 |
| `sidebar-menu-button` | no | 15 | 15 | 0 | 0 | 4 |
| `sidebar-menu-item` | no | 15 | 15 | 0 | 0 | 4 |
| `sidebar-provider` | no | 4 | 4 | 0 | 0 | 4 |
| **total** | | **148** | **56** | **9** | **83** | |

⭐ **The two published keys carry zero `body`.** That is the whole cost question for direction B, and it answers in the ruling's favour. Every one of the 56 is a `sidebar-*` key, which `PUBLIC_BLOCKS` does not carry (it carries the namespaced `page:sidebar`, a different type).

All 56 live in four files:

```
examples/schema-catalog/src/schemas/components-basic-sidebar/basic-sidebar.json
examples/schema-catalog/src/schemas/components-basic-sidebar/collapsible-sidebar.json
examples/schema-catalog/src/schemas/components-basic-sidebar/grouped-sidebar.json
examples/schema-catalog/src/schemas/components-basic-sidebar/sidebar-with-badges.json
```

⚠️ The 9 `badge` nodes in the `children` column are **not** this card's population — they are #6829 (content authored under a key `badge` never reads, so the pill draws empty). This census independently reproduces that card's count: 7 authored nodes in its four named files, plus 2 deliberate cases inside its own pin test. Recorded because it is corroboration, not a new finding.

## Group 1b — ruled by #6771 but reads no child list at all

| key | nodes | `body` | `children` |
|:--|--:|--:|--:|
| `sidebar-trigger` | 1 | 0 | 0 |

## Group 1c — ⚠️ a `body`-only reader the ruled 13 does **not** include

| key | nodes | `body` | `children` |
|:--|--:|--:|--:|
| `tooltip` | 3 | 0 | 2 |

## Group 2 — the `children || body` fallback readers (a second dialect, not the only door)

| key | nodes | `body` | `children` | neither | files |
|:--|--:|--:|--:|--:|--:|
| `div` | 194 | 69 | 96 | 29 | 32 |
| `card` | 229 | 43 | 121 | 65 | 112 |
| `page` | 101 | 33 | 4 | 64 | 63 |
| `button` | 228 | 1 | 3 | 224 | 128 |
| `aspect-ratio` | 10 | 0 | 5 | 5 | 8 |
| `address` | 18 | 0 | 0 | 18 | 13 |
| `time` | 13 | 0 | 0 | 13 | 13 |
| `header` | 8 | 0 | 3 | 5 | 7 |
| `nav` | 8 | 0 | 2 | 6 | 6 |
| `a` | 8 | 0 | 0 | 8 | 4 |
| `b` | 6 | 0 | 0 | 6 | 2 |
| `main` | 4 | 0 | 3 | 1 | 4 |
| `footer` | 4 | 0 | 3 | 1 | 4 |
| `section` | 4 | 0 | 3 | 1 | 4 |
| `article` | 3 | 0 | 3 | 0 | 3 |
| `h1` | 3 | 0 | 2 | 1 | 3 |
| `p` | 2 | 0 | 1 | 1 | 2 |
| `li` | 2 | 0 | 2 | 0 | 1 |
| `aside` | 1 | 0 | 1 | 0 | 1 |
| `ul` | 1 | 0 | 0 | 1 | 1 |
| `ol` | 1 | 0 | 0 | 1 | 1 |
| **total** | **848** | **146** | **252** | **450** | |

**No node anywhere carries both keys** (measured: 0). That matters because `page` and `button` read `body` **first** (`schema.body || schema.children`) — had any node carried both, retiring the `body` arm would silently change which content renders. None does, so the Group 2 migration is a pure rewrite.

## Attribution of all 202 `body` nodes in population A

A `body` in a fixture, a doc snippet and a real authored page are three different things. Every hit is attributed, not just counted:

| bucket | nodes | of which Group 1 |
|:--|--:|--:|
| app-metadata | 76 | 0 |
| example-app | 61 | 56 |
| docs-teaching | 58 | 0 |
| test | 7 | 0 |

---

# Population B — hotcrm, a real application (**kept separate, never summed**)

Read at `a6be39a3d5d3ce5cc8b8852b48e7de4f326c3d1b`, committed 2026-09-01T03:02:59Z. 765 files scanned, 4 candidate nodes.

**`body` usage on every key in this retirement: 0.** Group 1: zero nodes of any of the 12 keys. Group 2: 4 nodes (`time` twice, `page`, `button`), none carrying `body`.

### The channel was measured, not assumed

The ruling states hotcrm "is publicly readable"; this seat has repeatedly measured **HTTP 403** on it via unauthenticated REST. Both are true about different channels. Measured this run: an **anonymous shallow `git clone` through the session proxy succeeded**, exit `0` captured before any pipe, against a same-shape control clone of `objectui` that also succeeded. So this half is **MEASURED**, not inferred and not a reported zero.

### …and the zero is a reading, because the control fires

A zero is only a reading if the instrument returns hits on the same corpus. The same scanner, same run:

- resolves **1,517 nodes across 177 hotcrm files** (`text`, `grid`, `metric`, `modal`, `screen`, flow steps and so on);
- finds **21 nodes carrying a `body` key** — all attributed, none in scope: **15 on `script`** (action script bodies, a different `body` entirely) and **6 on `modal`** (doc snippets). Neither type is a reader in this retirement.

⇒ hotcrm authors ObjectUI-shaped metadata, the scanner sees it, and none of it uses the `body` dialect.

---

# ⚠️ Three corrections the ruling's own text needs

## 1. The only-door population is **12 keys, not 13** — and it is a different *set*

The card body says 10; the ratchet pin says 13; the ruling's step 2 repeats the stale 10. Measured off the renderer sources:

- **`sidebar-trigger` is not a `body` reader at all.** `navigation/sidebar.tsx:202` renders `SidebarTrigger` and never receives `schema` — it reads neither key, so retiring `body` costs it nothing. There are exactly **10** `renderChildren(schema.body)` reads across the **11** `sidebar-*` registrations.
- ⭐ **`tooltip` IS a `body`-only reader, and is absent from the ruled 13.** `overlay/tooltip.tsx:31` renders `schema.content || renderChildren(schema.body)` and never reads `children` — the identical shape to `badge.tsx:32`. It is also **the one registration in the whole tree that declares `body` as an authorable input** (`name: 'body'`, `type: 'slot'`, label "Rich Content"), which makes it the most discoverable spelling of `body` on the entire authoring surface. Under direction B it loses its only rich-content key while sitting outside the migration list.

⇒ 12 of the ruled 13 are readers, plus `tooltip` — the same *number* by coincidence, a different *set*. Both facts are pinned so they cannot go stale again.

## 2. The dialect has consumers **and producers** outside the enumerated population — filed as #7181

Steps 2–5 name renderers, the published type and the tier. The census found neither of these classes named anywhere:

- **Producers.** `packages/cli/src/commands/init.ts` scaffolds **53** `body` nodes — every project created by `objectui init` is authored in the dialect. The VS Code extension's new-file templates add **14**. `carousel`/`resizable`/`scroll-area` ship `body` inside their own `defaultProps`. Step 5's own principle ("the platform never refuses a spelling it still ships") therefore reaches further than step 5 lists: step 4 cannot land before these move.
- **Generic readers.** `packages/core/src/validation/schema-validator.ts:419` (`schema.children || schema.body`) and two VS Code providers resolve `body` for *any* node type, so they outlive step 2's per-registration convergence.

## 3. Nothing recorded that the census was blocked — it was not

Stated explicitly because this card has already taken four label flips over unwritten preconditions: **no undeclared blocker was found.** Both populations were readable, both were measured.

---

# The instrument, and why it is committed

`scripts/body-dialect-census.mjs` (`pnpm census:body-dialect`). A retirement that will take more than one day needs a census that can be repeated after the next corpus change, so it ships rather than living in a transcript.

It parses object literals — string-, comment- and regex-aware — and reports, per node, which child-list keys that node **actually carries as a sibling of `type`**. A line grep cannot see that relationship: it scores `bodyExtra`, an email payload and a real authored node identically.

## Three silent zeros it had first, each now pinned

Every one returned **exit 0 with no error**, which is the failure mode this card's own history is made of — a blind instrument and a clean corpus read identically.

1. **Quoted keys were consumed as strings before being tested as keys.** JSON spells every key quoted, so the entire `.json` corpus read as zero — including the four files that turned out to hold **all 56** Group 1 hits.
2. **Markdown fences swallowed every snippet.** A ` ```json ` fence is three backticks: two pair off and the third opens a template-string that runs to the closing fence. Every doc example read as zero — the population ruling step 5 migrates.
3. **A regex literal after an arrow desynced the rest of the file.** `/^ {3}\S.*\(type "/` was not recognised as a regex, so its `{` opened a phantom object frame and its lone `"` opened a runaway string, blinding the scanner from that point on.

## ⭐ A fourth silent zero — in the harness, not the scanner

Caught by CI, not by me: `check:entry-guard` failed on this file's hand-typed guard.

```
if (import.meta.url === `file://${process.argv[1]}`) main();
```

That is the **percent-encoding** spelling `scripts/invoked-as.mjs` names in its own header: it builds a file URL *without* the encoding `pathToFileURL` applies, so on any checkout path containing a character that needs encoding — a `#` in any parent directory is enough, **no symlink required** — the two sides disagree, the guard answers `false`, and the census prints nothing and exits `0`.

⇒ **the same failure class this whole card is about, one layer out.** Three silent zeros inside the scanner, and a fourth in the harness deciding whether the scanner runs at all. A clean corpus and a tool that never ran are indistinguishable from the exit code, wherever the blindness sits. Now `if (isEntrypoint(import.meta.url)) main();`, the one predicate.

Proven in both directions rather than asserted: before the fix `node scripts/check-entry-guard.mjs` exits `1` naming this line; after it, exit `0` with `0 file(s) still hand-type one`. And reached through a real symlink the script now emits **18,126 bytes** where the old guard would have emitted none.

⚠️ **Why my own gate union missed it:** I picked the union from the diff's *content* (a script plus a test plus a changeset) rather than its *file kind* — and `check:entry-guard` is the gate a newly added `scripts/**.mjs` file is most likely to trip. Recorded because it is the generalisable half of the mistake.

## How the counts were checked

A **differential control** compares, per file, a naive regex count against the scanner's node count. It is what caught all three scanner bugs. Final state on the Group 1 keys: **1 disagreement in the whole repo**, and it is the scanner being *right* — a `type: 'sidebar'` mention inside a comment in `navigation/sidebar.tsx:14`, which is prose, not a call site.

On the Group 2 keys, 39 naive hits are unmatched, of which 25 sit on comment lines; the rest are string literals in test expectations. Direction is one-way — the scanner is stricter than the grep, never blinder — so Group 2's `body` counts are a **lower bound with at most 14 nodes' uncertainty**, and Group 1 is exact. Stated rather than smoothed over.

**Known limits, so a zero stays readable:** template literals are opaque (no target node is built that way in either corpus); YAML is not scanned — absence there is "not scanned", not zero.

---

# Tests

All at `a90cfe5fe`, the final commit (`origin/main` merged in, never rebased), re-run after it.

```
pnpm exec vitest run scripts/__tests__/body-dialect-census.test.ts \
                    scripts/__tests__/entry-guard-wiring.test.ts
  Test Files  2 passed (2)
       Tests  21 passed (21)      # 14 census + 7 entry-guard wiring
```

The entry guard is how the script decides to run at all, so `entry-guard-wiring` is in the set deliberately rather than assumed unaffected. Re-measured after the fix and after the `origin/main` merge: **every census figure above is unchanged** — Group 1 `148 / 56 / 9 / 83`, Group 2 `848 / 146 / 252 / 450`, attribution `202`. Only the scanned-file count moved (5,803 to 5,816), because `main` brought new files into the corpus.

Gate union, each exit code captured before any pipe:

```
check:entry-guard           EXIT=0    check:control-bytes        EXIT=0
check:esm-specifiers        EXIT=0    check:self-import          EXIT=0
check:phantom-deps          EXIT=0    check:shell-escape-residue EXIT=0
check:vi-mock-specifiers    EXIT=0    check-changeset-no-major   EXIT=0
check-changeset-overwrite   EXIT=0    check-changeset-presence   EXIT=0

check-entry-guard.mjs --self-test   EXIT=0   (63 cases)
invoked-as.mjs        --self-test   EXIT=0   (12 cases, real symlinks)
```

`check:control-bytes`: `OK (scanned 5947 tracked text file(s); skipped 85 binary)`, plus a direct control-character scan of the three added files — 0 hits.

**Lint is a declared narrowing, not a full run**, with the three things that make it a measurement rather than a skip: (1) the receiving population is read from eslint's own config — `isPathIgnored` returns `false` for both added files, so neither is excluded; (2) the file count comes from `--format json`: **2 files linted, 0 errors, 0 warnings**, exit `0`; (3) this repo does **not** enable type-aware linting (no `projectService`, no `parserOptions.project` in `eslint.config.js`), so this diff cannot move the verdict on any untouched file. The repo-wide run is CI's.

Session, kept in prose so it survives edits to this body: `https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM`