### PR TITLE
docs(plugin-grid): re-derive ObjectGrid's held-key censuses — 16 claims checked, 7 corrected

### DIFF
--- a/.changeset/7196-plugin-grid-held-key-census.md
+++ b/.changeset/7196-plugin-grid-held-key-census.md
@@ -1,0 +1,47 @@
+---
+---
+
+Re-derives the held-key censuses in `packages/plugin-grid/src/ObjectGrid.tsx` and corrects
+the seven claims that no longer match the tree. Comments and one test docblock only — no
+runtime code, no exported type, no declared member moves, so nothing publishes.
+
+The card (objectui#7196) was filed on ONE measured entry: the schema-level census still
+listed `renderCellEditor` as an undeclared-but-live HELD key and called the `packages/types`
+ruling on it "pending", when objectui#6882 had declared it on 2026-08-30. The card
+deliberately did not claim the other entries were correct, only that nobody had checked, so
+all sixteen claims across both censuses in the file were re-derived against `origin/main`
+rather than read. Seven were defective:
+
+Stale — correct when written, drifted since:
+
+- `renderCellEditor` — declared by objectui#6882 on three surfaces (the member, the Zod
+  mirror, an `Equal` exact-shape pin). The `(schema as any)` cast the census cites went
+  with the declaration.
+- `cellClassName` — declared by the SAME ruling. The card did not name this one; the
+  re-derivation did. The census called it a hold with a "pending ruling" too.
+- "leaves exactly TWO undeclared keys" — diffing the 46 flat-literal keys plus the 8
+  group-literal keys against `DataTableSchema`'s declared members now leaves ZERO.
+- the consumer read set listed fourteen `col.<key>` reads in `data-table.tsx` including
+  `name`; objectui#6963 retired that alias on 2026-08-31, so it is thirteen.
+
+Wrong when written, not drift:
+
+- the schema-level `cellClassName` was described as folded "into every body cell's
+  `className`". It reaches exactly three UTILITY cells (selection, row-number,
+  row-actions) and never a data cell, which folds the per-column twin. The failure mode
+  the census names is wrong in the same way. objectui#6882's declaration carries the
+  correct version upstream; this makes the local copy agree with it.
+- "the 7-literal union `TableColumn` declares" — it has been eight since objectui#6370
+  (2026-08-25), a day before the docblock was written; that commit's own subject says
+  "8-literal".
+- the downstream read list omitted four keys the chrome passes read to re-express
+  (`className`, `cellClassName`, `sortable`, `cell`). All three passes predate the list.
+
+Nine claims re-derived clean and are recorded as such, including every column-level
+verdict (`headerIcon`, `pinned`, `wrap`, `options`, `essential`, `name`) and the
+`FieldType` count of 49.
+
+The holds type is left in place, with its docblock rewritten to record that it is now
+redundant rather than load-bearing and what was measured toward removing it. Deleting a
+member of an exported type is a different kind of change and gets its own card, the way
+objectui#6615 was followed by objectui#6424 for `headerIcon`.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -527,12 +527,24 @@ function normalizeColumns(
  * Consumers measured for THIS producer — two of them, because the array is read
  * twice before it reaches the slot:
  *
- *   - `data-table.tsx`, comments stripped, every `col.<key>` read: `accessorKey`,
- *     `width`, `align`, `header`, `className`, `cellClassName`, `sortable`,
- *     `resizable`, `editable`, `type`, `cell`, `headerIcon`, `fitContent`, `name`.
+ *   - `data-table.tsx`, comments stripped, every `col.<key>` read — THIRTEEN:
+ *     `accessorKey`, `width`, `align`, `header`, `className`, `cellClassName`,
+ *     `sortable`, `resizable`, `editable`, `type`, `cell`, `headerIcon`,
+ *     `fitContent`. ⚠️ This said fourteen until objectui#7196 re-derived it:
+ *     `name` was the fourteenth and was correct when written, but objectui#6963
+ *     (2026-08-31) retired the `col.name` alias — the last undeclared spelling
+ *     the adapter accepted — so the key left the consumer's read set that day.
  *   - THIS FILE's own downstream passes, which read the array before handing it
- *     on: `pinned` (the left/right reorder + the frozen-column verdict),
- *     `accessorKey`, `header`, `width`, `type`, `fitContent`.
+ *     on — TEN: `pinned` (the left/right reorder + the frozen-column verdict),
+ *     `accessorKey`, `header`, `width`, `type`, `fitContent`, plus the four the
+ *     chrome passes read in order to RE-EXPRESS them: `className` and
+ *     `cellClassName` (`applyDensity`, and again in the right-pinned literal),
+ *     `sortable` (`withSortability`), `cell` (the mobile card renderer).
+ *     ⚠️ Those four were missing from this list from the day it was written —
+ *     all three passes already existed at that commit — so this is an
+ *     incompleteness, not drift. They change no verdict: each is declared on
+ *     `TableColumn` and read by `data-table.tsx` as well. Recorded because a
+ *     list presented as MEASURED has to be one.
  *
  * Verdicts, each with the read-count behind it:
  *
@@ -567,7 +579,10 @@ function normalizeColumns(
  *     fold still stands. It is the one member whose vocabulary differs between
  *     the two types below.
  *   - `name` — not emitted by this producer at all, so objectui#5120's alias
- *     needs no hold here. Tombstoned only in the sense that nothing writes it.
+ *     never needed a hold here. Tombstoned only in the sense that nothing writes
+ *     it — and since objectui#6963 (2026-08-31) nothing READS it either: the
+ *     consumer-side alias is retired, so the key is absent from BOTH ends of
+ *     this seam and the verdict now rests on two measurements, not one.
  *
  * `essential` is absent from both types on purpose: objectui#6004's suggested
  * key list named it, but it was READ off the authored column and turned into a
@@ -627,10 +642,19 @@ export interface ObjectGridColumnHolds {
 /**
  * What `generateColumns()` returns: everything final EXCEPT `type`, which is
  * still the producer's raw inference vocabulary (`@objectstack/spec`'s
- * `FieldType`, 49 values) rather than the 7-literal union `TableColumn`
- * declares. objectui#5853 folds it downstream, in a pass that is deliberately
- * separate from the enrichment map — so the pre-fold shape needs a name, and
- * this is it.
+ * `FieldType`, 49 values) rather than the EIGHT-literal union `TableColumn`
+ * declares (`TABLE_COLUMN_TYPES`: `text`, `number`, `date`, `datetime`,
+ * `currency`, `percent`, `boolean`, `action`). objectui#5853 folds it
+ * downstream, in a pass that is deliberately separate from the enrichment map —
+ * so the pre-fold shape needs a name, and this is it.
+ *
+ * ⚠️ This said "7-literal" until objectui#7196 re-derived it. `action` joined
+ * the union at objectui#6370 on 2026-08-25 — a day BEFORE this docblock was
+ * written, and that commit's own subject line reads "make the 8-literal union
+ * the one canonical TableColumn.type" — so the count was never right here; it
+ * was mis-copied, not drifted. Both numbers are now measured rather than
+ * recited: `TABLE_COLUMN_TYPES` in `@object-ui/types` has 8 members and
+ * `@objectstack/spec`'s `FieldType` enum has 49.
  */
 /**
  * ⭐ `options` — RETIRED at this emit (objectui#6004), and this explicit
@@ -720,30 +744,62 @@ export type ObjectGridColumn =
  * tombstones remain the instrument for a key RETIRED by ruling, but an open
  * census cannot be tombstoned, because a tombstone needs the key's name.
  *
- * ## The census this annotation surfaced (the substance, per the card)
+ * ## The census this annotation surfaced — CLOSED, re-derived by objectui#7196
  *
  * Diffing the 46 keys the flat literal writes (plus the 8 the group literal
- * re-writes) against `DataTableSchema` + `BaseSchema` declared members leaves
- * exactly TWO undeclared keys — the card's speculative list (`pagination`,
- * `manualPagination`, `rowCount`, `frozenColumns`, `singleClickEdit`,
- * `selectionResetKey`, `disableInnerScroll`, `borderless`) has since been
- * declared on `DataTableSchema`, and only these survive:
+ * re-writes) against `DataTableSchema` + `BaseSchema` declared members left
+ * exactly TWO undeclared keys when this was written. Re-derived on 2026-09-01
+ * against the same two literals (still 46 and 8), it now leaves **ZERO**. Both
+ * halves closed:
  *
- *   - `renderCellEditor` — HELD. Live: `data-table.tsx` reads it via its own
- *     `(schema as any).renderCellEditor` cast and hands cell editing to the
- *     returned widget; absent, cells fall back to the built-in text/number/date
- *     inputs. Undocumented at schema level. Whether `DataTableSchema` should
- *     declare it is a `packages/types` (human-floor) ruling, not this card's —
- *     declared here at the seam meanwhile, so the hold is visible.
- *   - `cellClassName` — HELD. Live: `data-table.tsx` destructures it off the
- *     schema and folds it into every body cell's `className` (this is the
- *     SCHEMA-level key; the column-level twin IS declared, on `TableColumn`).
- *     Absent, the grid's row-height density styling stops reaching cells.
- *     Undocumented at schema level; same pending ruling as above.
+ *   - the card's speculative list (`pagination`, `manualPagination`, `rowCount`,
+ *     `frozenColumns`, `singleClickEdit`, `selectionResetKey`,
+ *     `disableInnerScroll`, `borderless`) was already declared then, and is
+ *     still declared now;
+ *   - the two keys that survived that diff, `renderCellEditor` and
+ *     `cellClassName`, were DECLARED by objectui#6882 (maintainer ruling
+ *     2026-08-30) on three surfaces:
+ *       · `packages/types/src/data-display.ts` — the members themselves
+ *       · `packages/types/src/zod/data-display.zod.ts` — the Zod mirror
+ *       · `packages/types/src/__tests__/data-table-declared-keys-6882.test.ts`
+ *         — an `Equal` (not `extends`) exact-shape pin
  *
- * ⛔ Do not "fix" either hold by declaring the key on `DataTableSchema` as a
- * rider — that package is published surface with its own review floor, and the
- * census above is filed for a ruling on exactly that question.
+ * ⇒ The ruling this census was filed for HAPPENED, and it went the declare way.
+ * `ObjectGridDataTableSchemaHolds` below is therefore redundant rather than
+ * load-bearing — the position `headerIcon` reached at objectui#6615 — and
+ * removing it is the same separate, MEASURED step objectui#6424 took there. Its
+ * docblock carries what #7196 measured toward that.
+ *
+ * ### What the two entries used to say, and what is true instead
+ *
+ *   - `renderCellEditor` — said HELD, read "via its own `(schema as any)`
+ *     cast", and called the `packages/types` ruling still open. All three are
+ *     over: the key is declared, the cast went with the declaration
+ *     (`data-table.tsx` reads `schema.renderCellEditor` directly; the line where
+ *     the cast stood still spells it, as a quotation inside its own
+ *     correction), and the ruling landed. BEHAVIOUR is unchanged and always
+ *     was — a returned widget takes the cell, `null` falls through to the
+ *     built-in text / number / date inputs.
+ *   - `cellClassName` — said HELD, and described the key as folded "into every
+ *     body cell's `className`". The hold is over (declared by the same #6882);
+ *     the DESCRIPTION was wrong from the day it was written, which is the more
+ *     useful half of this correction. Measured: `data-table.tsx` folds the
+ *     SCHEMA-level key at exactly three sites and every one is a UTILITY cell —
+ *     the selection checkbox, the row-number cell, the row-actions cell. It
+ *     never reaches a data cell; a data cell folds `col.cellClassName`, the
+ *     per-column twin declared on `TableColumn`. The two class slots style
+ *     DISJOINT cells and never combine on one. So what breaks when the schema
+ *     key is absent is NOT "density stops reaching cells": data cells keep
+ *     their density, because `applyDensity` below puts the same class on every
+ *     column. What breaks is the checkbox / row-number / row-actions cells
+ *     falling out of height alignment with the data beside them, which is why
+ *     this grid sets BOTH slots. #6882's declaration is where the authoritative
+ *     version of this now lives; this is the local copy agreeing with it.
+ *
+ * ⛔ The old closing note ("do not fix either hold by declaring the key on
+ * `DataTableSchema` as a rider — that package is published surface with its own
+ * review floor") governs nothing now. It was asking for the ruling to be taken
+ * deliberately at that package's floor, and that is exactly how #6882 took it.
  */
 type RemoveIndexSignature<T> = {
   [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
@@ -753,12 +809,50 @@ type RemoveIndexSignature<T> = {
 export type DeclaredDataTableSchema = RemoveIndexSignature<DataTableSchema>;
 
 /**
- * The undeclared-but-live SCHEMA-level keys this grid holds at the seam — the
- * schema-slot sibling of `ObjectGridColumnHolds`. Shapes mirror the CONSUMER's
- * reads in `data-table.tsx`, not what this file happens to pass.
+ * The SCHEMA-level keys this grid holds at the seam — the schema-slot sibling
+ * of `ObjectGridColumnHolds`. Shapes mirror the CONSUMER's reads in
+ * `data-table.tsx`, not what this file happens to pass.
+ *
+ * ⚠️ "Undeclared by `DataTableSchema`" was this type's ENTRY CONDITION, and —
+ * exactly as `ObjectGridColumnHolds` warns about its own — it is a claim about
+ * ANOTHER package that can stop being true with nothing going red here. It
+ * stopped being true on 2026-08-30: objectui#6882 declared BOTH members. As of
+ * objectui#7196 this type holds nothing; every member is redundant with
+ * `DeclaredDataTableSchema`.
+ *
+ * ⛔ Kept rather than deleted, because deleting a member of an EXPORTED type is
+ * a change of a different kind and gets its own card — the order objectui#6615
+ * → #6424 took for `headerIcon`. What #7196 measured, so that card can start
+ * from a reading instead of a guess:
+ *
+ *   - each member's shape is `Equal` (not merely assignable) to the upstream
+ *     declared member, so removing it cannot narrow or widen the seam;
+ *   - the seam's `cellClassName` is already reduced (`string & string` is
+ *     `string`), while its `renderCellEditor` resolves to the SAME signature
+ *     intersected with itself. That is inert — mutually assignable with the
+ *     declared member, measured in both directions — but it is the one visible
+ *     trace the redundant hold leaves, and it is what the exact-shape pin in
+ *     `packages/types` would report if pointed at the seam type;
+ *   - unlike `ObjectGridColumnHolds.pinned`, neither member is its own ONLY
+ *     declaration on the emitted type, so deleting them deletes nothing from
+ *     it. That is precisely the ⛔ contrast `ObjectGridColumnHolds` spells out,
+ *     and this type is now on the other side of it.
+ *
+ * ⛔ Nothing above is mechanically checked, which is how it went stale unseen.
+ * `dataTableSchemaSlot-6459.test.ts` pins that the seam ACCEPTS both keys — an
+ * assertion that stays green whether they are held HERE or declared THERE, so
+ * it could not have caught this. The column-level twin IS guarded
+ * (`columnHoldsExpiry-6424.test.ts` asserts `TableColumn` does NOT declare
+ * `pinned`), and that is the shape a guard for this type would take. #7196
+ * files it as a separate finding; ⛔ do not add it as a rider here.
  */
 export type ObjectGridDataTableSchemaHolds = {
-  /** HELD (objectui#6459) — `data-table` calls it to render a host cell editor. */
+  /**
+   * REDUNDANT since objectui#6882 (2026-08-30) — `DataTableSchema` declares this
+   * key itself now, with a shape measured `Equal` to this one. `data-table`
+   * calls it to render a host cell editor; returning `null` falls through to the
+   * built-in text / number / date inputs.
+   */
   renderCellEditor?: (ctx: {
     column: any;
     row: any;
@@ -767,7 +861,13 @@ export type ObjectGridDataTableSchemaHolds = {
     commit: (v?: any) => void;
     cancel: () => void;
   }) => React.ReactNode;
-  /** HELD (objectui#6459) — `data-table` folds it into every body cell's class. */
+  /**
+   * REDUNDANT since objectui#6882 (2026-08-30) — `DataTableSchema` declares this
+   * key itself now, with a shape measured `Equal` to this one. `data-table`
+   * folds it into the three UTILITY body cells (selection, row-number,
+   * row-actions) and never into a data cell, which folds
+   * `TableColumn.cellClassName` instead.
+   */
   cellClassName?: string;
 };
 

--- a/packages/plugin-grid/src/__tests__/dataTableSchemaSlot-6459.test.ts
+++ b/packages/plugin-grid/src/__tests__/dataTableSchemaSlot-6459.test.ts
@@ -130,15 +130,26 @@ describe('objectui#6459 — the schema slot annotation is an instrument, not a d
   });
 
   /**
-   * The two HELD schema-level keys — the whole census, measured on `38a123cac`
-   * by diffing the 46 flat-literal keys (+ the 8 group-literal keys) against
-   * `DataTableSchema` + `BaseSchema` declared members. Each has a live reader
-   * in `data-table.tsx` (`renderCellEditor` via its `(schema as any)` cast,
-   * `cellClassName` via destructuring into every body cell's class), so the
-   * seam must ACCEPT them; whether `DataTableSchema` should DECLARE them is
-   * the ruling this card files, not this suite's call.
+   * The two schema-level keys that were the whole census, measured on
+   * `38a123cac` by diffing the 46 flat-literal keys (+ the 8 group-literal
+   * keys) against `DataTableSchema` + `BaseSchema` declared members.
+   *
+   * ⚠️ They are no longer HELD, and this assertion is why nobody noticed:
+   * objectui#6882 (2026-08-30) DECLARED both on `DataTableSchema`, and the
+   * assertion below stays green either way. It pins that the seam ACCEPTS the
+   * two keys — true while they are held here, equally true once they arrive
+   * through `DeclaredDataTableSchema`. An acceptance pin cannot express a hold's
+   * ENTRY CONDITION, so this suite could never have gone red at the moment of
+   * loss. Re-derived by objectui#7196; the diff now leaves ZERO undeclared keys,
+   * and `ObjectGrid.tsx`'s `ObjectGridDataTableSchemaHolds` carries the full
+   * record. The guard that WOULD have caught it is the column-level twin's:
+   * `columnHoldsExpiry-6424.test.ts` asserts `TableColumn` does not declare
+   * `pinned`. Filed by #7196 as a separate finding, ⛔ deliberately not a rider.
+   *
+   * The assertion itself keeps its value unchanged: both keys must remain
+   * writable at this seam, whichever side declares them.
    */
-  it('accepts the two held keys — renderCellEditor and cellClassName', () => {
+  it('accepts both schema-level keys — renderCellEditor and cellClassName', () => {
     const held: ObjectGridDataTableSchema = {
       type: 'data-table',
       columns,


### PR DESCRIPTION
Fixes #7196

Comments and one test docblock/title only. No runtime code, no exported type, no declared member moves. Clause ② is not engaged and was not approached — `packages/types` is untouched.

## The headline number

**Sixteen census claims re-derived; seven were defective.** The card was filed on ONE measured entry and explicitly did not assert the others were correct, only that nobody had checked. The re-derivation is what produced the other six.

Four had drifted since they were written. Three were wrong on the day they were written — which the card could not have predicted, and which is the more interesting half.

## The card's entry, re-measured (A2.1)

`ObjectGridDataTableSchemaHolds` listed `renderCellEditor` as an undeclared-but-live HELD key and called the `packages/types` ruling on it **pending**. #6882 landed that ruling on 2026-08-30. Verified against `origin/main` at `c97752d2f`, each with a live control in the same query shape:

| surface | location |
|---|---|
| the member | `packages/types/src/data-display.ts:945` |
| Zod mirror | `packages/types/src/zod/data-display.zod.ts:270` |
| `Equal` exact-shape pin | `packages/types/src/__tests__/data-table-declared-keys-6882.test.ts:119` |

The `(schema as any).renderCellEditor` cast the census cites went with the declaration: `data-table.tsx:2318` reads `schema.renderCellEditor` directly. (Probed for the **presence of the replacement**, not the absence of the removed token — the line above it still spells the old cast as a quotation inside its own correction, which is exactly the false negative that probe order avoids.)

## A2.2 — behaviour and soundness, verified rather than inherited

Confirmed, and it holds. Measured with a type-level probe carrying a **must-fail control** (the control was the only diagnostic where one was expected):

- each hold's shape is `Equal` — not merely `extends` — to the upstream declared member;
- the seam member and the declared member are **mutually assignable**, measured in both directions;
- the printed types differ only in that the seam's `renderCellEditor` is the identical signature intersected with itself (`cellClassName` reduces outright, `string & string` being `string`). Inert, and the one visible trace the now-redundant hold leaves.

⇒ Nothing mis-renders, no type is unsound. This stayed a documentation card.

## A2.3 — the rest of the census, which nobody had checked

**Stale (correct when written, drifted since):**

1. `renderCellEditor` — above.
2. **`cellClassName` — declared by the SAME ruling.** The card named only the first key; this one carried "same pending ruling as above" and is false twice over. Not asserted by the card, found by re-deriving.
3. **"leaves exactly TWO undeclared keys" — now ZERO.** Re-derived with the TypeScript checker: the flat literal writes 46 keys and the group literal 8 (both counts still exact), diffed against `DataTableSchema`'s 75 declared members with the index signature excluded. Control: a bogus key returns absent on the same instrument that returns present for `columns`.
4. the consumer read set named **fourteen** `col.` reads in `data-table.tsx` including `name`; #6963 retired that alias on 2026-08-31, so it is **thirteen**. Measured by AST over the whole file, not by grep.

**Wrong when written, not drift** — each dated against the commit that wrote the prose:

5. **the schema-level `cellClassName` was described as folded "into every body cell's `className`".** It reaches exactly **three UTILITY cells** — the selection checkbox, the row-number cell, the row-actions cell — and **never a data cell**, which folds `col.cellClassName` instead. The two class slots style disjoint cells. So the stated failure mode is wrong too: data cells keep their density (`applyDensity` puts it on every column); what breaks without the schema key is the utility cells falling out of height alignment. Verified at `beccf1c6b`, the commit that wrote the sentence: the same three sites, already utility-only. #6882's declaration carries the authoritative version; this makes the local copy agree with it.
6. **"the 7-literal union `TableColumn` declares"** — eight since #6370 on 2026-08-25, one day **before** the docblock was written, and that commit's own subject line reads "make the 8-literal union the one canonical TableColumn.type". Both numbers are now measured: `TABLE_COLUMN_TYPES` has 8 members, `@objectstack/spec`'s `FieldType` enum has 49 (that one was right).
7. the downstream read list omitted four keys the chrome passes read in order to re-express them — `className` and `cellClassName` (`applyDensity`), `sortable` (`withSortability`), `cell` (the mobile card renderer). All three passes already existed at the census commit, so this is incompleteness, not drift. No verdict moves: each is declared on `TableColumn` and read by `data-table.tsx` too.

**Re-derived clean (9)** — recorded because "the others are correct" is a real result: the 46/8 literal counts · the eight already-declared keys from the card's speculative list · `BaseSchema`'s index signature · `headerIcon` DECLARED with its 2 syntactic reads · `pinned` HELD (undeclared by `TableColumn`, 5 reads here, 0 in `data-table.tsx` against a 28-hit control) · `wrap` RETIRED with no wrap affordance and no `density`/`rowHeight` read · `options` RETIRED and declared on `TableColumn` · `name` emitted by nothing here · `essential` a member of neither type.

## A2.4 — is any of it mechanically derived? Partly, and that is the finding

`RetiredListColumnKey` **is** derived (`Exclude` over `keyof ListColumn`), and it re-derives correctly. But the censuses themselves are hand-maintained, and the two are guarded asymmetrically:

- the **column-level** hold's entry condition is pinned — `columnHoldsExpiry-6424.test.ts` asserts `TableColumn` does NOT declare `pinned`;
- the **schema-level** one is not. `dataTableSchemaSlot-6459.test.ts` pins that the seam **ACCEPTS** both keys — green whether they are held here or declared upstream. An acceptance pin cannot express an entry condition, so it could never have gone red at the moment of loss.

That asymmetry is why this census rotted and its twin did not. Recorded in both docblocks, and filed as #7201. ⛔ Not built here, per the order.

## What is deliberately NOT done

The holds type is **kept**. Both members are redundant with `DeclaredDataTableSchema` now, but deleting a member of an exported type is a different kind of change and gets its own card — the order #6615 → #6424 took for `headerIcon`, which measured before it deleted. The docblock now states why it survives and carries the three measurements that card would start from.

⚠️ **Overlap for triage, not acted on here:** #6919 is open and covers this same type. Its scope is (1) retire the seam hold *or state in its docblock why it survives as a deliberate redundancy*, and (2) correct the docblock either way — the standing prohibition against declaring these keys had to go regardless. This PR does both in the "keep and state why" branch: the ⛔ prohibition is gone and the deliberate redundancy is recorded. Whether #6919 stays open for the hold's actual removal is triage's call — ⛔ this PR does not touch its state, and no keyword here acts on it. Refs: #6919.

## Verification

Everything below ran on `d20267a93`, the branch head, and `git diff HEAD` was empty at that point — so the tree measured is byte-identical to the tree committed.

| gate | result |
|---|---|
| `pnpm --filter '@object-ui/plugin-grid^...' build` | exit 0 — dependency closure built first |
| `pnpm --filter @object-ui/plugin-grid type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json`) |
| `tsc -p tsconfig.test.json --listFiles` | both edited files ARE program inputs — 1 hit each, control 0. The package's own `tsconfig.json` excludes `__tests__`, so without this the green would say nothing about the test file |
| `pnpm exec vitest run packages/plugin-grid/` | **105 files, 952 tests, all passed** |
| the census suite, verbose | 7/7, including the renamed `accepts both schema-level keys` |
| `pnpm --filter @object-ui/plugin-grid lint` | eslint exit 0 — **0 errors**, 749 pre-existing warnings |
| `node scripts/check-control-bytes.mjs` | ✅ OK (5964 tracked text files scanned) |
| `node scripts/check-changeset-presence.mjs` | ✅ empty frontmatter accepted as the explicit exemption |
| `node scripts/check-changeset-no-major.mjs` | ✅ no changeset declares `major` |
| `node scripts/check-shell-escape-residue.mjs` | ✅ OK |

Exit codes were captured **before** any pipe, and each row quotes the gate's own verdict line rather than a bare `$?`.

**Declared narrowing.** Repo-wide `pnpm lint` was not run; the affected package's own `eslint .` was, which is a strict superset of the diff. Three pieces of evidence, not two: (1) the population came from eslint's own config resolution, not a guess about which files count; (2) `--format json` reports exactly 2 files for the diff — `ObjectGrid.tsx` 0 errors / 209 pre-existing warnings, the test file 0 / 0; (3) type-aware linting is **not** enabled — `eslint.config.js` declares no `projectService` and no `parserOptions.project`, against a control confirming the same grep reads that file — so every verdict is per-file and a comment-only diff in two files cannot move a verdict on an untouched file. The farm runs in full on CI regardless.

**No ablation was run and none is owed.** Nothing here can fail differently: the diff adds no assertion and removes none. The one assertion touched keeps its exact shape and only its name and docblock change.

## Changeset

`.changeset/7196-plugin-grid-held-key-census.md`, **empty frontmatter** — the explicit "releases nothing" declaration this repo's gate accepts, since the diff is comments in `src/` and publishes no behaviour. ⛔ The `skip-changeset` label is not this repo's mechanism and was not applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_