### PR TITLE
fix(fields): exclude tooling DIRECTORIES from the emitting program, not just the `*.test.*` name

### DIFF
--- a/.changeset/6943-fields-tooling-dirs-out-of-emit.md
+++ b/.changeset/6943-fields-tooling-dirs-out-of-emit.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/fields': patch
+---
+
+Stop shipping `dist/__tests__/numberInputBrowserReadings.d.ts` in the published tarball
+(objectui#6943). `packages/fields/tsconfig.json` now excludes the tooling DIRECTORIES
+(`__tests__`, `__mocks__`, `__benchmarks__`), not just the `*.test.*` NAME.
+
+`numberInputBrowserReadings.ts` holds the measured Chromium/happy-dom readings the number
+widget suites share. It is deliberately not a `*.test.ts` — it carries no assertions — so
+the name-only exclude list did not catch it, and it was emitted into `dist` and published
+while its 79 neighbours in the same directory were kept out. That made
+`check:published-dist` red on `main`, and because the same script is the first link in
+`changeset:publish`, it also failed the publish command at its first step.
+
+This is the third instance of the same name-versus-directory mismatch (objectui#4006 here,
+objectui#4836 in plugin-grid / plugin-view / plugin-designer), so the exclude table is now
+the directory convention itself rather than a list of names to extend.
+
+Which program had to be fixed was measured rather than assumed, because this package's
+build is `tsc && vite build` and the `tsc` leg inherits the root's `noEmit`: run alone the
+`tsc` leg exited 0 and wrote zero files, while `vite build` alone produced the whole
+81-file output including the offending declaration. vite-plugin-dts is the emitting
+program, and it builds its declaration program from this package's `tsconfig.json`, so
+that is where the exclude belongs.
+
+No type coverage moves with the change and no API surface moves: `numberInputBrowserReadings.ts`
+is the only file the directory patterns newly remove from the build program, and the
+`tsconfig.test.json` chained off `type-check` already reads it as a transitive input of the
+three suites that import it. The name patterns stay, because 52 `*.test.ts(x)` files in this
+package sit outside any `__tests__/` directory.

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -30,5 +30,42 @@
   // Their type coverage did not go away with them: it moved to the
   // `tsconfig.test.json` chained off this package's `type-check` script, which
   // is what scripts/check-type-check-coverage.mjs verifies.
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test.tsx"]
+  //
+  // The exclusions cover TOOLING DIRECTORIES, not just the `*.test.*` name
+  // (objectui#6943 — the THIRD instance of that mismatch, after objectui#4006
+  // here and objectui#4836 in plugin-{grid,view,designer}). Which program the
+  // directories have to be excluded FROM was measured on 56453410f rather than
+  // assumed, because the comment above says `tsc` here only checks: run alone,
+  // the `tsc` leg of `build` exited 0 and wrote ZERO files, while `vite build`
+  // alone produced the whole 81-file output — including
+  // `dist/__tests__/numberInputBrowserReadings.d.ts`. So vite-plugin-dts is the
+  // emitting program, and it builds its declaration program from THIS config
+  // (`dts()` in `vite.config.ts` passes no `exclude` of its own), which is why
+  // the fix belongs here and not in the plugin options.
+  //
+  // That file is not a `*.test.ts` by NAME, so the name-only list let it ship in
+  // the tarball while its 79 neighbours in the same directory were caught.
+  //
+  // The name patterns stay: 52 `*.test.ts(x)` files in this package sit outside
+  // any `__tests__/` directory, so the directory patterns do not subsume them.
+  // `__mocks__` / `__benchmarks__` match nothing here today and are listed so
+  // the table is the directory convention itself — exactly as `TOOLING_FILE` in
+  // scripts/check-phantom-dependencies.mjs spells it — rather than a list that
+  // has to be extended the next time such a directory appears.
+  //
+  // No type coverage moves with this change. `numberInputBrowserReadings.ts` is
+  // the only file the directory patterns newly remove from this program, and the
+  // `tsconfig.test.json` chained off `type-check` already reads it as a
+  // transitive input of the three suites that import it (measured with
+  // `tsc -p tsconfig.test.json --listFiles`, before and after), so it needs no
+  // entry there — the same reason plugin-grid's `explainDouble.ts` needed none.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__benchmarks__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
Fixes #6943

`@object-ui/fields` shipped `dist/__tests__/numberInputBrowserReadings.d.ts` inside its published tarball. That made `check:published-dist` red on `main` since 2026-08-31, and because the same script is the first link in `changeset:publish`, it also failed the publish command at its first step — surfacing only to the one actor who cannot hand it off.

## Which program emits `dist` — measured, not assumed

This is the question the card was really buying, because `packages/fields/tsconfig.json` carries a comment warning that `tsc` there only CHECKS. Editing its `exclude` could have changed the check program and left the emit untouched: a fix that looks right, reviews clean, and leaves the gate red.

So both legs of `build` (`tsc && vite build && node scripts/build-css.mjs`) were run in isolation against a cleaned `dist`:

| leg | exit | files written to `dist` |
|---|---|---|
| `pnpm exec tsc` alone | 0 | **0 — wrote nothing** |
| `pnpm exec vite build` alone | 0 | **81, including `dist/__tests__/numberInputBrowserReadings.d.ts`** |

**vite-plugin-dts is the emitting program.** It builds its declaration program from this package's own `tsconfig.json` — the `dts()` call in `vite.config.ts` passes no `exclude` of its own — so the exclude belongs in that tsconfig, and not in the plugin options. The fix is therefore one file plus a changeset.

## The change

`packages/fields/tsconfig.json` now excludes the tooling DIRECTORIES, matching the shape objectui#4836 landed in plugin-grid / plugin-view / plugin-designer:

```
"exclude": [
  "node_modules", "dist",
  "**/__tests__/**", "**/__mocks__/**", "**/__benchmarks__/**",
  "**/*.test.ts", "**/*.test.tsx"
]
```

`numberInputBrowserReadings.ts` holds the measured Chromium/happy-dom readings the number-widget suites share. It carries no assertions, so it is deliberately not a `*.test.ts`, which is exactly why the name-only list let it through while its 79 neighbours in the same directory were caught.

The name patterns stay — 52 `*.test.ts(x)` files in this package sit outside any `__tests__/` directory, so the directory patterns do not subsume them. `__mocks__` and `__benchmarks__` match nothing here today and are listed so the table is the directory convention itself, exactly as `TOOLING_FILE` in `scripts/check-phantom-dependencies.mjs` spells it, rather than a list to extend next time.

⛔ Not done: adding a fourth NAME pattern such as a `BrowserReadings` glob. That would have been the same mistake a fourth time.

## Gate evidence — red first, then green

Exit codes captured before any pipe, on a full 43-task build. Verdict lines are the gate's own.

**BEFORE** (`pnpm check:published-dist`, exit **1**):

```
Inspected 39 published package(s) after a 1s build: 5886 tarball file(s), 5730 of them build output, 1 tooling artifact(s) in build output.
❌  1 finding(s) across 1 published package(s):
      @object-ui/fields  [tooling-in-published-output]  packages/fields/dist/__tests__/numberInputBrowserReadings.d.ts
```

**AFTER** (exit **0**):

```
Inspected 39 published package(s) after a 1s build: 5885 tarball file(s), 5729 of them build output, 0 tooling artifact(s) in build output.
✅  No published package's build output carries tooling material.
```

The counts moved by exactly one on each axis (5886 to 5885 tarball, 5730 to 5729 build output, 1 to 0 tooling), which is what shows the change reached the emit rather than merely the check. The narrower ablation says the same thing directly: rebuilding the `vite build` leg alone after the edit produced **80** files instead of 81, **0** tooling artifacts, with `dist/index.d.ts` still present as a live control that the exclude did not overshoot.

## No second gate traded for the first

The likeliest way this repair goes wrong is trading one red gate for another, since `scripts/check-type-check-coverage.mjs` verifies that tests excluded from a build program are still checked somewhere.

`node scripts/check-type-check-coverage.mjs` exits **0** both before and after, and its two verdict lines are **byte-identical** across the change (`diff` of the two runs is empty):

```
✅  type-check coverage: 45/46 via `type-check`, 0 via their own build, 0 known-broken (0 errors outstanding), 1 not compiled.
✅  test type-check coverage: 41/41 packages compile their tests, 0 declared debt (0 errors outstanding), 0 with a narrow type-assertion project.
```

That holds because no coverage actually moves, measured with `tsc --listFiles` on both programs, each zero carrying a live control in the same query shape:

| program | before | after | control |
|---|---|---|---|
| build (`tsc --noEmit`) | reads the file | **0 — now excluded** | `src/widgets/numberBadInput.tsx` still read (1) |
| test (`tsc -p tsconfig.test.json`) | reads the file | **1 — still read** | importing suite still read (1) |

`numberInputBrowserReadings.ts` is the only file the directory patterns newly remove from the build program, and `tsconfig.test.json` already reads it as a transitive input of the three suites that import it. So it needs no entry there — the same reason plugin-grid's `explainDouble.ts` needed none, and the reason the `tsconfig.test.json` half of the remedy (PR #4845's shape) is not owed on this card.

## Everything else run

Union re-run on the final commit `81b778ce3`, after the last commit rather than before it:

| gate | exit |
|---|---|
| `check:published-dist` | 0 |
| `check-type-check-coverage.mjs` | 0 |
| `check-changeset-presence.mjs` | 0 |
| `check-changeset-overwrite.mjs` | 0 (1 added, 0 modified, 0 deleted) |
| `check-changeset-fixed.mjs` | 0 |
| `check-changeset-no-major.mjs` | 0 |
| `check-control-bytes.mjs` | 0 (5972 files) |
| `check-dist-completeness.mjs --all` | 0 |
| `check-phantom-dependencies.mjs` | 0 |
| `check-package-self-import.mjs` | 0 |
| `pnpm --filter @object-ui/fields type-check` | 0 |
| `pnpm exec vitest run packages/fields/` | 0 — **130 files, 2138 tests passed** |

The vitest run is from the repo ROOT deliberately: `pnpm --filter @object-ui/fields test` is refused by this repo's own guard (objectui#3378), which exists because running vitest from a package directory silently runs `@object-ui/console`'s 22 files and reports them as green. The 130-file count is the control that this package's suites actually ran.

A changeset is included — a published package's tarball contents change.

## Reported, deliberately not ridden

The card raised generalising this into a shared emitting-program exclude, and the dispatch ruled that out of scope. Swept it anyway and filed the reading as #7212: **29 published packages still exclude tooling by NAME only**, all with zero offending files today, so each is one shared `__tests__/` helper away from the same red. Three rounds of correct per-package repair have left the same trap armed everywhere else, which is the argument that the altitude is wrong — but a cross-package build-config change is its own card with its own review, and no part of it is in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_