### PR TITLE
fix(plugin-list): a gantt view no longer shows a record-count bar that describes a request it does not draw

### DIFF
--- a/.changeset/7210-gantt-paging-chrome.md
+++ b/.changeset/7210-gantt-paging-chrome.md
@@ -1,0 +1,32 @@
+---
+'@object-ui/plugin-list': patch
+---
+
+A gantt list view no longer shows the record-count bar, because the bar describes a
+request that view does not draw (objectui#7210, half 1).
+
+`ListView` renders one record-count bar for every `viewType`: the row count, the
+"Showing first N records. More data may be available." warning that goes with its own
+`$top: pageSize` query, and a rows-per-page selector that re-issues that query. On grid,
+kanban, calendar, gallery, timeline and map the bar is accurate — those renderers draw
+the `data` `ListView` hands down.
+
+On `gantt` it is not. Measured, not inferred: the registered `object-gantt` renderer
+forwards no prop but `schema`, so the `data` prop never reaches the chart and
+`ObjectGantt` issues its own query — one that carries no `$top` at all. In a harness of
+18 rows with `pagination.pageSize: 6`, the chart drew all 18 while the bar under it read
+"6 records · Showing first 6 records. More data may be available." Because it is the
+only paging disclosure on the screen, a reader takes it as describing the chart; that
+reading already produced a wrong finding in an application repo, which cost a browser
+session to disprove. Authoring `pagination.pageSize` could not have fixed it either —
+the chart's request never carried a page size to begin with.
+
+Scoped to `gantt` alone. Every other surface keeps its bar unchanged, warning included;
+a kanban over the same result set still reports its page honestly.
+
+Not changed here, deliberately: the gantt's query still has no ceiling, and `ListView`
+still issues its own paged query for that view (its rows still drive the loading
+skeleton and load-error panel, `UserFilters`' option counts, and the client-side CSV /
+JSON export). Capping a non-grid view's fetch is an open maintainer decision — adding
+one would turn a complete schedule into a quietly truncated one — and this correction is
+right whichever way that lands.

--- a/packages/plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7210 — the registered `object-gantt` renderer draws its OWN query,
+ * not the host's rows.
+ *
+ * This is the measured basis for the paging-chrome correction one package over
+ * (`plugin-list/src/ListView.tsx`, `surfaceDrawsFetchedRows`): a host that
+ * fetches a page and hands it down as `data` — `ListView` does exactly that,
+ * for every view type — does not thereby feed the chart. `ObjectGanttRenderer`
+ * (`./index`) destructures `{ schema }` and renders
+ * `< ObjectGantt schema={bound} dataSource={dataSource} / >`, forwarding no
+ * other prop, so `ObjectGantt.reload`'s `rest.data` short-circuit is never
+ * reached from the registry path and the component queries for itself. The
+ * sibling wrappers (`object-grid`, `object-kanban`, `object-calendar`,
+ * `object-map`, `object-tree`) all spread `{...props}`; this one is the outlier.
+ *
+ * Two facts are pinned, because the footer correction rests on both:
+ *
+ *   1. the rows drawn are the ADAPTER's, not the host `data` prop's;
+ *   2. the query carries no `$top` — so its row count is not the host's page
+ *      size and cannot be made to be by authoring `pagination.pageSize`.
+ *
+ * ⛔ Do not "fix" (1) by spreading `{...props}` in the renderer. That caps the
+ * chart at the host's page — a complete schedule silently becomes a truncated
+ * one that still looks like a schedule. Whether a non-grid view may fetch
+ * unbounded at all is an open maintainer decision (objectui#7210, half 2) and
+ * is not settled here; this file only records what the code does today, which
+ * is what the footer has to stop contradicting either way.
+ *
+ * REVERSE VERIFICATION — direction and counts predicted before running: add
+ * `{...props}` to the `ObjectGanttRenderer` children callback and BOTH
+ * assertions in the first case flip (5 rows → 2, host rows drawn), while the
+ * `$top` case stays green because the component never gets as far as querying.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SchemaRendererProvider, SchemaRenderer } from '@object-ui/react';
+import './index';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks }: any) => (
+    <div data-testid="gantt-view" data-task-count={String(tasks.length)}>
+      {tasks.map((t: any) => (
+        <div key={t.id} data-testid={`gv-task-${t.id}`}>{t.title}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@object-ui/plugin-detail', () => ({
+  RecordDetailDrawer: () => null,
+  deriveRecordPageHref: () => null,
+}));
+
+/** What the adapter answers with — the whole result set. */
+const ADAPTER_ROWS = Array.from({ length: 5 }, (_, i) => ({
+  id: String(i + 1),
+  subject: `Adapter task ${i + 1}`,
+  visible_from: '2026-01-01',
+  due_date: '2026-01-10',
+}));
+
+/** What a paging host hands down as `data` — one page of it. */
+const HOST_PAGE = ADAPTER_ROWS.slice(0, 2).map(r => ({ ...r, subject: `Host task ${r.id}` }));
+
+const schema: any = {
+  type: 'object-gantt',
+  objectName: 'duly_task',
+  gantt: {
+    titleField: 'subject',
+    startDateField: 'visible_from',
+    endDateField: 'due_date',
+  },
+};
+
+let calls: Array<Record<string, any>> = [];
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async (_resource: string, params: any) => {
+      calls.push({ ...(params ?? {}) });
+      return { data: ADAPTER_ROWS, total: ADAPTER_ROWS.length };
+    }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => ({
+      name: 'duly_task',
+      fields: {
+        id: { name: 'id', type: 'text' },
+        subject: { name: 'subject', type: 'text' },
+        visible_from: { name: 'visible_from', type: 'date' },
+        due_date: { name: 'due_date', type: 'date' },
+      },
+    })),
+  } as any;
+}
+
+describe('objectui#7210 — object-gantt ignores a host `data` prop', () => {
+  beforeEach(() => {
+    calls = [];
+  });
+
+  it('draws the adapter rows, not the page the host handed down', async () => {
+    const dataSource = makeDataSource();
+
+    render(
+      <SchemaRendererProvider dataSource={dataSource}>
+        <SchemaRenderer schema={schema} data={HOST_PAGE} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeTruthy());
+    await waitFor(() =>
+      expect(screen.getByTestId('gantt-view').getAttribute('data-task-count')).toBe('5'),
+    );
+
+    // The host's two rows are nowhere on screen; all five adapter rows are.
+    expect(screen.queryByText('Host task 1')).toBeNull();
+    expect(screen.getByText('Adapter task 5')).toBeTruthy();
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it('issues its query with no `$top` — the host page size cannot bound it', async () => {
+    const dataSource = makeDataSource();
+
+    render(
+      <SchemaRendererProvider dataSource={dataSource}>
+        <SchemaRenderer schema={schema} data={HOST_PAGE} pagination={{ pageSize: 2 }} />
+      </SchemaRendererProvider>,
+    );
+
+    await waitFor(() => expect(calls.length).toBeGreaterThan(0));
+
+    for (const params of calls) {
+      expect(params.$top).toBeUndefined();
+      expect(params.$skip).toBeUndefined();
+    }
+  });
+});

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1507,6 +1507,47 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
     !Array.isArray(schema.data) &&
     (schema.data as any).provider === 'api';
 
+  /**
+   * Does the surface rendered below draw the rows THIS component fetched?
+   *
+   * objectui#7210. The record-count bar at the foot of this component reports
+   * this component's own paged query — `data.length` (or `serverTotal`), the
+   * `dataLimitReached` warning that goes with `$top: effectivePageSize`, and a
+   * rows-per-page selector that re-issues it. It is the only paging disclosure
+   * on the screen, so a reader takes it as describing whatever is drawn above
+   * it.
+   *
+   * On `gantt` that reading is false, and the bar is then worse than no bar.
+   * MEASURED rather than inferred: the registered `object-gantt` renderer
+   * (`plugin-gantt/src/index.tsx`) resolves to
+   * `< ObjectGantt schema={bound} dataSource={dataSource} / >` and forwards no
+   * other prop — unlike `object-grid` / `object-kanban` / `object-calendar` /
+   * `object-map` / `object-tree`, whose wrappers all spread `{...props}`. The
+   * `data` handed to the SchemaRenderer below therefore never reaches the
+   * chart, `ObjectGantt.reload` issues its OWN query, and that query carries no
+   * `$top` at all. Harness: 18 rows, `pagination.pageSize: 6` — the chart drew
+   * 18 rows while this bar read "6 records · Showing first 6 records. More data
+   * may be available." The same harness on `grid` ("18 records", the server
+   * total, no warning) and on `kanban` ("6 records …", and the board really is
+   * drawing those 6) is why this is scoped to `gantt` alone: everywhere else
+   * the bar is telling the truth and must keep telling it.
+   *
+   * ⛔ The correction is NOT to forward `data` to the chart. That would cap a
+   * gantt at one page, turning a complete schedule into a quietly truncated one
+   * that still looks like a schedule. Whether a non-grid view may fetch
+   * unbounded is an open maintainer decision (objectui#7210, half 2) — this
+   * line is correct whichever way that lands, which is why it did not wait for
+   * it.
+   *
+   * ⛔ Nor does suppressing the bar make this component's query dead: `data`
+   * still gates the loading skeleton and the load-error panel (so it decides
+   * whether the chart mounts at all), feeds `UserFilters`' option counts, and
+   * is what the client-side CSV/JSON export writes out. Measured with the paged
+   * response delayed: while it was in flight the skeleton was up and the chart
+   * had 0 rows, though its own unbounded response had already arrived.
+   */
+  const surfaceDrawsFetchedRows = currentView !== 'gantt';
+
   // Fetch data effect — supports schema.data (ViewDataSchema) provider modes
   React.useEffect(() => {
     let isMounted = true;
@@ -3838,7 +3879,7 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
       )}
 
       {/* Record count status bar (Airtable-style) */}
-      {!loading && data.length > 0 && schema.showRecordCount !== false && (
+      {!loading && data.length > 0 && surfaceDrawsFetchedRows && schema.showRecordCount !== false && (
         <div
           className="border-t px-4 py-2 flex items-center gap-3 text-xs text-muted-foreground bg-background shrink-0"
           data-testid="record-count-bar"

--- a/packages/plugin-list/src/__tests__/ListView.ganttPagingChrome-7210.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.ganttPagingChrome-7210.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7210 — the record-count bar describes THIS component's paged query,
+ * so it is suppressed on the one surface that does not draw those rows.
+ *
+ * The bar is shared chrome: one block at the foot of `ListView`, rendered for
+ * every `viewType`. On grid, kanban, calendar, gallery, timeline and map it is
+ * accurate — those renderers consume the `data` this component hands down. On
+ * `gantt` it is not: the registered `object-gantt` renderer forwards no props
+ * but `schema`, so the chart queries for itself, with no `$top`
+ * (`plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx` pins that half).
+ * The bar then reports one request under a chart drawn from another — and it is
+ * the only paging disclosure on the screen, so a reader takes it as describing
+ * the chart. It cost a browser session and a wrong finding in an application
+ * repo before it was disproved.
+ *
+ * The two controls are the point of this file as much as the gantt case is: a
+ * naive edit deletes shared chrome and takes a TRUE footer down with the false
+ * one. `kanban` is the load-bearing control — a non-grid, page-scoped surface
+ * whose limit warning is correct and must survive.
+ *
+ * REVERSE VERIFICATION — direction and counts predicted before running: drop
+ * `surfaceDrawsFetchedRows` from the bar's render condition and exactly the two
+ * gantt cases go RED (the bar and its warning reappear) while both control
+ * cases stay GREEN. Observed: 2 failed / 2 passed, as predicted.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRendererProvider } from '@object-ui/react';
+import { ListView } from '../ListView';
+
+/** Total rows in the store; the view is authored with a smaller page. */
+const TOTAL = 18;
+const PAGE_SIZE = 6;
+
+const rows = Array.from({ length: TOTAL }, (_, i) => ({
+  id: String(i + 1),
+  subject: `Task ${i + 1}`,
+  status: i < PAGE_SIZE ? 'open' : 'done',
+  visible_from: `2026-01-0${(i % 9) + 1}`,
+  due_date: `2026-01-1${(i % 9) + 1}`,
+}));
+
+const objectDef = {
+  name: 'duly_task',
+  label: 'Task',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    subject: { name: 'subject', type: 'text', label: 'Subject' },
+    status: { name: 'status', type: 'select', label: 'Status' },
+    visible_from: { name: 'visible_from', type: 'date', label: 'Visible From' },
+    due_date: { name: 'due_date', type: 'date', label: 'Due' },
+  },
+};
+
+/**
+ * Stand-ins for the three child renderers. The bar under test is `ListView`'s
+ * own and is independent of what the child draws, so a spy keeps this file free
+ * of a dependency on `plugin-grid` / `plugin-kanban` / `plugin-gantt` — and the
+ * gantt spy deliberately does NOT consume `data`, which is what the real
+ * renderer does too.
+ */
+for (const type of ['object-grid', 'object-kanban', 'object-gantt'] as const) {
+  ComponentRegistry.register(
+    type,
+    () => <div data-testid={`${type}-spy`} />,
+    { namespace: 'test', label: `${type} spy`, category: 'view' },
+  );
+}
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async (_resource: string, params: any) => {
+      const top = params?.$top;
+      const slice = typeof top === 'number' ? rows.slice(0, top) : rows;
+      return { data: slice, total: TOTAL, hasMore: typeof top === 'number' && top < TOTAL };
+    }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => objectDef),
+  } as any;
+}
+
+function baseSchema(viewType: string): any {
+  return {
+    type: 'list-view',
+    objectName: 'duly_task',
+    viewType,
+    columns: ['subject', 'status', 'visible_from', 'due_date'],
+    filter: [['visible_from', 'is_not_null'], ['due_date', 'is_not_null']],
+    sort: [{ field: 'visible_from', order: 'asc' }],
+    pagination: { pageSize: PAGE_SIZE },
+    gantt: {
+      startDateField: 'visible_from',
+      endDateField: 'due_date',
+      titleField: 'subject',
+    },
+    kanban: { groupByField: 'status' },
+  };
+}
+
+async function renderView(viewType: string) {
+  const dataSource = makeDataSource();
+  render(
+    <SchemaRendererProvider dataSource={dataSource}>
+      <ListView schema={baseSchema(viewType)} dataSource={dataSource} />
+    </SchemaRendererProvider>,
+  );
+  // Wait for the child surface, so every case is asserted on a settled render
+  // rather than on a still-loading one (where the bar is absent for a reason
+  // that has nothing to do with this change).
+  await waitFor(() => expect(screen.getByTestId(`object-${viewType}-spy`)).toBeTruthy());
+  return dataSource;
+}
+
+describe('objectui#7210 — paging chrome on a surface it does not describe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('gantt: no record-count bar, because the chart is not drawn from the paged query', async () => {
+    await renderView('gantt');
+    await waitFor(() => expect(screen.queryByTestId('record-count-bar')).toBeNull());
+    expect(screen.queryByTestId('record-count-bar')).toBeNull();
+  });
+
+  it('gantt: no "showing first N records" warning either', async () => {
+    await renderView('gantt');
+    await waitFor(() => expect(screen.queryByTestId('record-count-bar')).toBeNull());
+    expect(screen.queryByTestId('data-limit-warning')).toBeNull();
+  });
+
+  it('CONTROL grid: the paging footer is unchanged', async () => {
+    await renderView('grid');
+    const bar = await screen.findByTestId('record-count-bar');
+    // Server pagination is live here, so the honest figure is the grand total.
+    expect(bar.textContent).toContain(String(TOTAL));
+  });
+
+  it('CONTROL kanban: a correctly page-scoped non-grid surface keeps its warning', async () => {
+    await renderView('kanban');
+    const bar = await screen.findByTestId('record-count-bar');
+    expect(bar.textContent).toContain(String(PAGE_SIZE));
+    const warning = await screen.findByTestId('data-limit-warning');
+    expect(warning.textContent).toContain(String(PAGE_SIZE));
+  });
+});


### PR DESCRIPTION
Part of #7210 — half 1 only. Halves 2 and 3 stay open on that card, deliberately; see "Half 3" below.

## What changed

`ListView` renders one record-count bar for every `viewType`: the row count, the "Showing first N records. More data may be available." warning tied to its own `$top: pageSize` query, and a rows-per-page selector that re-issues that query. It is now suppressed on `gantt` alone, behind a named constant (`surfaceDrawsFetchedRows`) whose doc comment carries the measurement and the reason.

One line of behaviour, one guard, two controls, plus a pin in `plugin-gantt` for the fact the guard rests on.

## Why suppression rather than "make it describe the chart"

The ruling allowed either. `ListView` cannot report the chart's row count without a new upward channel from `ObjectGantt` — more published surface, and a channel whose meaning changes if a ceiling is ever added. Suppression is invariant to that decision, which is the property the split was made for. None of the bar's three parts describes the chart: not the count, not the warning, and not the page-size selector, which re-issues a query the chart ignores.

## Measured, not inherited

Everything below was measured in this branch. Nothing was copied from the report.

**Request count — the order said "count them yourself", and the answer is not two.** Harness: one `list-view` of `viewType: 'gantt'`, 18 rows in the store, `pagination.pageSize: 6`, instrumented adapter recording every `find`.

```
3 find calls
  1. $top: 6, $select: [...], authored filter array   -- ListView's own paged query
  2. no $top, no $select, no $expand                  -- ObjectGantt, before its schema read settles
  3. no $top, no $select, $expand: [owner]            -- ObjectGantt, after it settles
```

Calls 2 and 3 are one defect the reporter's browser capture read as one request: the second/third split is the "two queries, the first unexpanded" regime already recorded for `ObjectGantt` on #6482, which is no longer open; re-confirmed here. Only call 1 has a `$top` at all.

**The chart consumes the unbounded fetch.** The DOM reading reproduced in the harness's own terms: the paged query answered 6 rows, and the chart rendered 18 `gantt-task-row-*` rows while the bar under it read `6 records - Showing first 6 records. More data may be available.` That is the defect in miniature, one screen, both halves visible.

**The chrome is shared, so the change is scoped.** Same harness, same store, only `viewType` differing:

| viewType | find calls | record-count bar | honest? |
|---|---|---|---|
| `gantt` | 3 | `6 records - Showing first 6 records...` while the chart drew 18 | no |
| `grid` | 1 | `18 records` (server total, no warning) | yes |
| `kanban` | 1 | `6 records - Showing first 6 records...`, and the board drew 6 | yes |

`kanban` is the load-bearing control: a non-grid, page-scoped surface whose warning is correct and had to survive.

**The mechanism.** `plugin-gantt/src/index.tsx`'s `ObjectGanttRenderer` destructures `{ schema }` and hands its child only `schema` and `dataSource`. Every sibling wrapper — grid, kanban, calendar, map, tree — spreads `{...props}`. So the `data` `ListView` passes never reaches the chart, `ObjectGantt.reload`'s `rest.data` short-circuit is unreachable from the registry path, and the component queries for itself with no `$top`. Pinned in `packages/plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx`.

## Half 3 — condition FAILED, so both requests stay

The order was explicit: measure whether the paged request has any consumer other than the footer; if it does, stop and report rather than pick a dialect. It does. Reads of `ListView`'s `data` on the gantt surface:

| line | consumer |
|---|---|
| `ListView.tsx:2801` | client-side CSV / JSON export slices `data` |
| `ListView.tsx:2938` | `UserFilters data={data}` — option counts (`showCount`) |
| `ListView.tsx:3573` | refresh indicator |
| `ListView.tsx:3583` | load-error panel vs. rendering the view |
| `ListView.tsx:3630` | loading skeleton vs. rendering the view |
| `ListView.tsx:3841` | the record-count bar (this PR) |

The last two are behavioural, not cosmetic, and one of them was measured directly: with the paged response delayed 600ms and the unbounded one immediate, at t=250ms the skeleton was up and the chart had **0 rows on screen** although its own data had already arrived. The paged query decides whether the chart mounts at all. Removing it is not a no-op, so no dialect was picked and nothing was deduped.

## Falsified ZONE 2 assumptions

- **"exactly two requests"** — three (see above). One paged, two unbounded.
- **"the fetch path is `ObjectView`'s non-grid list-view path"** — the paged request in the report is `ListView`'s (`plugin-list`), identified by its `$select` projection and `$top`, which `ObjectView`'s non-grid fetch does not emit. `ObjectView` (`plugin-view`) delegates to `ListView` through `renderListView` and skips its own fetch when it does. The unbounded one is `ObjectGantt.reload`.
- **"the footer is rendered by shared paging chrome"** — CONFIRMED, and it decided the width: one block in `ListView`, rendered for every view type, correct on all of them but `gantt`.
- **"`@objectstack/rest` applies no cap when `limit` is absent"** — NOT MEASURED here. Out of reach from this repo; nothing in this change depends on it. What is measured is one layer up: the request carries no `$top`, so no page size authored on the view can bound it.
- **"the chart consumes the unbounded one"** — CONFIRMED, reproduced as row counts in the harness rather than inferred.

## Not touched, deliberately

- **No cap, ceiling or `$top` on the gantt's query.** Half 2 is a maintainer decision (escalated on #5560) and adding one would turn a complete schedule into a quietly truncated one that still looks like a schedule.
- **The filter-dialect disagreement** is recorded, not repaired — #7221.
- **`ObjectGanttRenderer` dropping every host prop**, the inert `data` clause it makes of `ListView`'s `ganttOwnsData`, and a live comment that states the opposite — #7222. ⛔ That card explicitly does not propose spreading `{...props}`: forwarding `data` would cap the chart at one page, which is half 2's decision arriving through the back door.
- **`plugin-view`'s own non-grid path** double-fetches for a gantt in the same way (its `$top: 100` query plus the chart's unbounded one). No paging chrome renders there, so half 1 has nothing to correct on it; it belongs to #7210's still-open half 3.
- **`ObjectGantt`'s two unbounded queries per load** — already recorded as `plugin-gantt` in the table on #6482, which is no longer open. Re-confirmed here rather than re-filed; worth reopening that card rather than duplicating it.

## Reverse verification

Direction and counts predicted before running: drop `surfaceDrawsFetchedRows` from the bar's render condition and exactly the two gantt cases go red while both controls stay green — **2 failed / 2 passed**. Observed exactly that, then 4 passed after restore.

Mutation proved on disk: removed-token count 2 to 1, mutated-line count 0 to 1, blob hash `4a1ce3c1` to `7f55c73b`. Restore proved by state: `git diff HEAD`, `git diff --cached` and `git status --short` all empty, and the blob hash back to `4a1ce3c1`, the HEAD blob.

## Verification (all at `f3d7b3cd3`)

- `pnpm exec vitest run packages/plugin-list/ packages/plugin-gantt/` — **113 files passed, 1183 tests passed**.
- `pnpm --filter @object-ui/plugin-list run type-check` and the same for `@object-ui/plugin-gantt` — both exit 0, over a freshly built dependency closure. Both new test files proved present in the `tsconfig.test.json` program via `tsc --listFiles` (1 hit each), so "typecheck is clean" actually covers them.
- Gates: `check:control-bytes`, `check:phantom-deps`, `check:self-import`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:i18n-keys`, `check:i18n-dead-keys`, `check:element-data-source-declaration`, `check:side-effects-array`, `lint:coverage` (46/46 packages, 0 errors), and all four changeset guards — every one exit 0. `check:sdui-registration-pins` returned **exit 2, PRECONDITION NOT MET** (no `apps/console` build to weigh) — recorded as NOT MEASURED, not as a pass; this diff adds no registration and moves no entry array. Left to CI.
- ESLint, narrowed and declared: 3 changed files, 0 errors (`--format json`, file count read from that output, not guessed). The narrowing is a measurement rather than a skip because `eslint.config.js` enables no type-aware linting (no `project` / `projectService` in its `languageOptions`), so no untouched file's verdict can move because of this diff, and the diff adds no config and no inline directive.

_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_


---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_