### PR TITLE
feat(grid,i18n): a grouped grid states, beside the group counts, that it grouped a page

### DIFF
--- a/.changeset/7189-grouped-grid-partial-disclosure.md
+++ b/.changeset/7189-grouped-grid-partial-disclosure.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/plugin-grid': minor
+'@object-ui/i18n': minor
+---
+
+A grouped grid now says, where the group counts are, that it grouped a **page**
+(objectui#7189).
+
+`useGroupedData` buckets the rows the browser already holds and computes every
+per-group aggregate from that same array, so both the set of groups and every
+number in a group header are properties of the fetched page, not of the query.
+That is a correct implementation of client-side grouping and is **unchanged**
+here — what was missing is any statement that client-side grouping is what you
+are looking at. Measured on a 186-record store distributed 86 / 61 / 31 / 7 / 1
+across five business units with a 100-row page: with contiguous rows the grid
+rendered **two** group headers (`86`, `14`) and three units were absent from
+the screen entirely; with interleaved rows all five resolved but every count
+was a page slice (31 / 31 / 30 / 1 / 7). Nothing on screen said either.
+
+The paging footer is not a statement about what was grouped, and it
+demonstrably did not prevent the wrong reading — a wrong number invites a
+second look, an absent row invites none. So the disclosure goes where the
+authoritative-looking number is:
+
+- a short `Partial` marker beside **every** group count, at every nesting
+  depth, carrying the full sentence as its `title` and its accessible name;
+- one line directly above the group list, inside the grouped region rather
+  than in the footer: *"Grouped over the first 100 of 186 records. Group counts
+  are page-scoped, and a group whose records all fall beyond the loaded rows is
+  missing here."*
+
+The trigger is the strongest thing the component can actually know, and the
+wording never outruns it. With a real match total to compare against
+(`resolvedTotalMatching` — the one derived value the pager and both bulk-bar
+sites already read, reached either from the grid's own fetch or from a host's
+`rowCount`) it states the fact with both numbers. With no total but a window
+that came back full it may only say *"more may match"* — the same inference
+`plugin-list`'s own footer draws when no total is known. Rows handed in inline
+are not a page and are never marked, and **a grouped grid whose result set fits
+in one page shows nothing at all**: the marker is conditional, which is what
+makes it worth reading.
+
+Server-side grouping — the durable fix — is deliberately NOT part of this. It
+is an API-surface decision still open on objectui#5560, and nothing here builds
+toward it or changes the fetch.
+
+`@object-ui/i18n` carries the three new `grid.grouping.*` strings across all
+ten locale packs; `GroupRow` gains two optional props (`partialLabel`,
+`partialTitle`) and is otherwise unchanged. No metadata schema key was added:
+the condition is derived from data the grid already has.

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -746,7 +746,7 @@ A data grid that auto-fetches from an ObjectQL object definition. Includes searc
 | `operations` | `object` | Enabled CRUD operations. |
 | `rowActions` / `bulkActions` | `string[]` | Action identifiers for rows and batch selection. `bulkActions` is the spec-aligned key; `batchActions` is a legacy alias that takes precedence when both are set. |
 | `editable` | `boolean` | Enable inline cell editing. |
-| `grouping` | `GroupingConfig` | Row grouping configuration. |
+| `grouping` | `GroupingConfig` | Row grouping configuration. **Page-scoped**: the grid groups the rows it has fetched, so group counts are page slices and a group beyond the page is absent — the grid marks the grouping partial when it can tell. |
 | `frozenColumns` | `number` | Number of columns frozen on scroll. |
 | `navigation` | `ViewNavigationConfig` | SPA navigation configuration. |
 

--- a/content/docs/plugins/plugin-grid.mdx
+++ b/content/docs/plugins/plugin-grid.mdx
@@ -94,7 +94,8 @@ below for why this plugin deliberately does not claim it.
 | `editable` / `singleClickEdit` | `boolean` | Inline editing — see [Inline Editing](#inline-editing). |
 | `navigation` | `NavigationConfig` | What a row click does: `{ mode: 'page' \| 'drawer' \| 'modal' \| 'split' \| 'none', … }`. |
 | `operations` | `object` | Toggles the built-in CRUD/export/import affordances, e.g. `{ delete: false }`. |
-| `rowHeight`, `frozenColumns`, `resizable`, `reorderableColumns`, `showColumnTypeIcons`, `rowColor`, `conditionalFormatting`, `grouping`, `aggregations`, `exportOptions`, `className` | | The rest of the declared surface. |
+| `rowHeight`, `frozenColumns`, `resizable`, `reorderableColumns`, `showColumnTypeIcons`, `rowColor`, `conditionalFormatting`, `aggregations`, `exportOptions`, `className` | | The rest of the declared surface. |
+| `grouping` | `GroupingConfig` | Row grouping — **page-scoped**, see [Grouping is page-scoped](#grouping-is-page-scoped). |
 
 **There is no `sortable`, `filterable`, `onRowClick`, `onSelectionChange`,
 `onCellChange`, `onRowSave`, `onBatchSave` or `object` on this schema.** The two
@@ -333,6 +334,38 @@ see [Row callbacks are component props](#row-callbacks-are-component-props).
 `pageSizeOptions` — there is no `showSizeChanger`, and none is needed: the pager
 always carries a rows-per-page picker, and `pageSizeOptions` only replaces the
 choices it offers with your own.
+
+### Grouping is page-scoped
+
+`grouping` groups **the records the browser has already fetched** — one page —
+not the whole result set. The grid buckets the rows in hand and computes every
+per-group count and aggregation from that same array, so both the set of groups
+and every number in a group header are properties of the page, not of the query.
+
+Two consequences, and the second is the one to decide against before you ship
+the view:
+
+- Every group count is a page slice, so it can be lower than the group's real
+  size.
+- **A group whose records all fall beyond the page does not appear at all.** On
+  a grid read as an org lens ("what is outstanding, per business unit"), a unit
+  that is silently absent is a wrong answer that looks like good news.
+
+Since objectui#7189 the grid says so on screen rather than leaving it silent.
+When the result set is larger than the rows loaded, a short `Partial` marker
+appears beside **every group count** — where the authoritative-looking number
+is — and a line above the group list carries the whole sentence, e.g.
+*"Grouped over the first 100 of 186 records…"*. When no match total is
+reachable the wording weakens honestly to *"Grouped over the 100 records
+loaded. More may match this view…"*. A grouped grid whose result set fits in
+one page shows neither: the marker is conditional, which is what makes it worth
+reading.
+
+The disclosure is not a fix for the scoping — it makes it visible. If a view
+needs true totals per group today, the working options are to narrow the query
+until the result set fits one page (a `filter` that scopes the lens), to raise
+`pagination.pageSize` past the result set, or to compute the aggregation server
+side and render it from a dataset rather than from grid grouping.
 
 ### ObjectQL Integration
 

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -367,6 +367,14 @@ const ar = {
     yes: "نعم",
     no: "لا",
     systemFields: "النظام",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "جزئي",
+      partialNotice:
+        "تم التجميع على أول {{loaded}} سجل من أصل {{total}}. أعداد المجموعات تخص الصفحة المحمَّلة فقط، وأي مجموعة تقع كل سجلاتها خارج الصفوف المحمَّلة لا تظهر هنا.",
+      partialNoticeUnknownTotal:
+        "تم التجميع على {{loaded}} سجل محمَّل. قد تتطابق سجلات أخرى مع هذا العرض، لذا قد تكون أعداد المجموعات جزئية وقد لا تظهر إحدى المجموعات هنا.",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -363,6 +363,14 @@ const de = {
     yes: "Ja",
     no: "Nein",
     systemFields: "System",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "Teilweise",
+      partialNotice:
+        "Gruppiert über die ersten {{loaded}} von {{total}} Datensätzen. Gruppenanzahlen gelten nur für die geladene Seite; eine Gruppe, deren Datensätze alle jenseits der geladenen Zeilen liegen, fehlt hier.",
+      partialNoticeUnknownTotal:
+        "Gruppiert über die {{loaded}} geladenen Datensätze. Möglicherweise passen weitere Datensätze zu dieser Ansicht, daher können Gruppenanzahlen unvollständig sein und eine Gruppe kann hier fehlen.",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -435,6 +435,20 @@ const en = {
     yes: 'Yes',
     no: 'No',
     systemFields: 'System',
+    // objectui#7189 — the grouped grid says, where the group counts are, that
+    // it grouped a PAGE. `useGroupedData` buckets only the rows the browser
+    // holds, so a group beyond the page boundary is absent entirely and every
+    // count is a page slice. The paging footer is not a statement about what
+    // was grouped, and it demonstrably did not prevent the wrong reading.
+    // Two sentences because two conditions: a known total states the fact
+    // with both numbers; a full window with no total can only say "may".
+    grouping: {
+      partialBadge: 'Partial',
+      partialNotice:
+        'Grouped over the first {{loaded}} of {{total}} records. Group counts are page-scoped, and a group whose records all fall beyond the loaded rows is missing here.',
+      partialNoticeUnknownTotal:
+        'Grouped over the {{loaded}} records loaded. More may match this view, so group counts may be partial and a group may be missing here.',
+    },
     // Column-footer aggregate prefixes, keyed by the spec's `ColumnSummary`
     // vocabulary (objectui#4024). The footer already formatted its NUMBER
     // through the locale-aware formatter and then put a hardcoded English

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -367,6 +367,14 @@ const es = {
     yes: "Sí",
     no: "No",
     systemFields: "Sistema",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "Parcial",
+      partialNotice:
+        "Agrupado sobre los primeros {{loaded}} de {{total}} registros. Los recuentos por grupo se limitan a la página cargada y un grupo cuyos registros quedan todos fuera de las filas cargadas no aparece aquí.",
+      partialNoticeUnknownTotal:
+        "Agrupado sobre los {{loaded}} registros cargados. Puede haber más registros que coincidan con esta vista, por lo que los recuentos por grupo pueden ser parciales y puede faltar algún grupo.",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -363,6 +363,14 @@ const fr = {
     yes: "Oui",
     no: "Non",
     systemFields: "Système",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "Partiel",
+      partialNotice:
+        "Regroupement effectué sur les {{loaded}} premiers enregistrements sur {{total}}. Les décomptes par groupe ne portent que sur la page chargée, et un groupe dont tous les enregistrements se trouvent au-delà des lignes chargées est absent ici.",
+      partialNoticeUnknownTotal:
+        "Regroupement effectué sur les {{loaded}} enregistrements chargés. D'autres enregistrements peuvent correspondre à cette vue : les décomptes par groupe peuvent donc être partiels et un groupe peut manquer ici.",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -363,6 +363,14 @@ const ja = {
     yes: "はい",
     no: "いいえ",
     systemFields: "システム",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "一部",
+      partialNotice:
+        "{{total}} 件中、読み込み済みの先頭 {{loaded}} 件のみでグループ化しています。グループの件数は読み込み済みのページだけの集計で、レコードがすべて読み込み範囲の外にあるグループはここに表示されません。",
+      partialNoticeUnknownTotal:
+        "読み込み済みの {{loaded}} 件のみでグループ化しています。このビューに該当するレコードはさらに存在する可能性があるため、グループの件数が不完全であったり、グループが表示されないことがあります。",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -363,6 +363,14 @@ const ko = {
     yes: "예",
     no: "아니요",
     systemFields: "시스템",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "일부",
+      partialNotice:
+        "전체 {{total}}개 중 불러온 처음 {{loaded}}개 레코드만으로 그룹화했습니다. 그룹 개수는 불러온 페이지 기준이며, 레코드가 모두 불러온 행 밖에 있는 그룹은 여기에 표시되지 않습니다.",
+      partialNoticeUnknownTotal:
+        "불러온 {{loaded}}개 레코드만으로 그룹화했습니다. 이 뷰에 해당하는 레코드가 더 있을 수 있으므로 그룹 개수가 일부일 수 있고 일부 그룹이 표시되지 않을 수 있습니다.",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -362,6 +362,14 @@ const pt = {
     yes: "Sim",
     no: "Não",
     systemFields: "Sistema",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "Parcial",
+      partialNotice:
+        "Agrupado sobre os primeiros {{loaded}} de {{total}} registros. As contagens por grupo referem-se apenas à página carregada, e um grupo cujos registros estão todos além das linhas carregadas não aparece aqui.",
+      partialNoticeUnknownTotal:
+        "Agrupado sobre os {{loaded}} registros carregados. Pode haver mais registros correspondentes a esta visão, portanto as contagens por grupo podem estar incompletas e um grupo pode não aparecer aqui.",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -369,6 +369,14 @@ const ru = {
     yes: "Да",
     no: "Нет",
     systemFields: "Система",
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: "Частично",
+      partialNotice:
+        "Группировка выполнена по первым {{loaded}} из {{total}} записей. Счётчики групп относятся только к загруженной странице, а группа, все записи которой находятся за пределами загруженных строк, здесь отсутствует.",
+      partialNoticeUnknownTotal:
+        "Группировка выполнена по {{loaded}} загруженным записям. Этому представлению могут соответствовать и другие записи, поэтому счётчики групп могут быть неполными, а какая-либо группа может здесь отсутствовать.",
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -349,6 +349,14 @@ const zh = {
     yes: '是',
     no: '否',
     systemFields: '系统字段',
+    // objectui#7189 — partial-grouping disclosure for the grouped grid.
+    grouping: {
+      partialBadge: '部分',
+      partialNotice:
+        '仅按已加载的前 {{loaded}} 条(共 {{total}} 条)记录分组。分组计数只统计当前页,记录全部落在已加载行之外的分组不会出现在这里。',
+      partialNoticeUnknownTotal:
+        '仅按已加载的 {{loaded}} 条记录分组。可能还有更多记录符合此视图,因此分组计数可能不完整,某个分组也可能不会出现在这里。',
+    },
     // objectui#4024 — column-footer aggregate prefixes, keyed by the spec's
     // `ColumnSummary` vocabulary. `pattern` owns the label/value join so this
     // pack controls its own separator and word order.

--- a/packages/plugin-grid/README.md
+++ b/packages/plugin-grid/README.md
@@ -193,7 +193,8 @@ const grid: ObjectGridSchema = {
 | `editable` / `singleClickEdit` | `boolean` | Inline editing — see [Inline Editing](#inline-editing). |
 | `navigation` | `NavigationConfig` | What a row click does, `{ mode: 'page' \| 'drawer' \| 'modal' \| 'split' \| 'none', … }`. |
 | `operations` | `object` | Toggles the built-in CRUD/export/import affordances, e.g. `{ delete: false }`. |
-| `rowHeight`, `frozenColumns`, `resizable`, `reorderableColumns`, `showColumnTypeIcons`, `rowColor`, `conditionalFormatting`, `grouping`, `aggregations`, `exportOptions`, `className` | | The rest of the declared surface. |
+| `rowHeight`, `frozenColumns`, `resizable`, `reorderableColumns`, `showColumnTypeIcons`, `rowColor`, `conditionalFormatting`, `aggregations`, `exportOptions`, `className` | | The rest of the declared surface. |
+| `grouping` | `GroupingConfig` | Row grouping — **page-scoped**, see [Grouping is page-scoped](#grouping-is-page-scoped). |
 
 **There is no `sortable`, `filterable`, `onRowClick`, `onSelectionChange`,
 `onCellChange`, `onRowSave`, `onBatchSave` or `object` on this schema.** The
@@ -405,6 +406,38 @@ const schema: ObjectGridSchema = {
 `pageSizeOptions` — there is no `showSizeChanger`, and none is needed: the pager
 always carries a rows-per-page picker, and `pageSizeOptions` only replaces the
 choices it offers with your own.
+
+### Grouping is page-scoped
+
+`grouping` groups **the records the browser has already fetched** — one page —
+not the whole result set. The grid buckets the rows in hand and computes every
+per-group count and aggregation from that same array, so both the set of groups
+and every number in a group header are properties of the page, not of the query.
+
+Two consequences, and the second is the one to decide against before you ship
+the view:
+
+- Every group count is a page slice, so it can be lower than the group's real
+  size.
+- **A group whose records all fall beyond the page does not appear at all.** On
+  a grid read as an org lens ("what is outstanding, per business unit"), a unit
+  that is silently absent is a wrong answer that looks like good news.
+
+Since objectui#7189 the grid says so on screen rather than leaving it silent.
+When the result set is larger than the rows loaded, a short `Partial` marker
+appears beside **every group count** — where the authoritative-looking number
+is — and a line above the group list carries the whole sentence, e.g.
+*"Grouped over the first 100 of 186 records…"*. When no match total is
+reachable the wording weakens honestly to *"Grouped over the 100 records
+loaded. More may match this view…"*. A grouped grid whose result set fits in
+one page shows neither: the marker is conditional, which is what makes it worth
+reading.
+
+The disclosure is not a fix for the scoping — it makes it visible. If a view
+needs true totals per group today, the working options are to narrow the query
+until the result set fits one page (a `filter` that scopes the lens), to raise
+`pagination.pageSize` past the result set, or to compute the aggregation server
+side and render it from a dataset rather than from grid grouping.
 
 ## Integration with Data Sources
 

--- a/packages/plugin-grid/src/GroupRow.tsx
+++ b/packages/plugin-grid/src/GroupRow.tsx
@@ -47,6 +47,27 @@ export interface GroupRowProps {
    * `style` verbatim; leave unset on the palette-family path.
    */
   labelColorStyle?: React.CSSProperties;
+  /**
+   * Short marker rendered beside `count` when the grouping was computed over
+   * a PAGE of the result set rather than the whole of it (objectui#7189).
+   *
+   * `count` is then a page slice, not the group's size, and a group whose
+   * records all fall beyond the loaded rows is absent from the list entirely.
+   * The marker lives here, next to the number, because that is the number a
+   * reader treats as authoritative — the paging footer says nothing about
+   * what was grouped, and demonstrably does not prevent the wrong reading.
+   *
+   * Presence is the switch: leave it unset and no marker renders. The host
+   * owns the wording (this package's translation bundle), so this component
+   * stays free of i18n wiring like the rest of its props.
+   */
+  partialLabel?: string;
+  /**
+   * Full sentence behind `partialLabel` — the marker's `title` and its
+   * accessible name. Carries the numbers when the host can support them.
+   * Ignored unless `partialLabel` is set.
+   */
+  partialTitle?: string;
   /** Callback when the group header is clicked to toggle collapse */
   onToggle: (key: string) => void;
   /** Children to render when not collapsed (the group content) */
@@ -71,6 +92,8 @@ export const GroupRow: React.FC<GroupRowProps> = ({
   fieldLabel,
   labelColorClass,
   labelColorStyle,
+  partialLabel,
+  partialTitle,
   onToggle,
   children,
 }) => {
@@ -96,6 +119,16 @@ export const GroupRow: React.FC<GroupRowProps> = ({
           : <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
         <span className={cn(pillClass, 'group-label')} style={labelColorStyle}>{label}</span>
         <span className="text-xs text-muted-foreground tabular-nums group-count">{count}</span>
+        {partialLabel && (
+          <span
+            data-testid={`group-count-partial-${groupKey}`}
+            className="rounded-sm bg-muted px-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground group-count-partial"
+            title={partialTitle}
+            aria-label={partialTitle}
+          >
+            {partialLabel}
+          </span>
+        )}
         {aggregations && aggregations.length > 0 && (
           <span className="ml-2 text-xs text-muted-foreground group-aggregations">
             {aggregations.map((agg) => (

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -221,6 +221,15 @@ const GRID_DEFAULT_TRANSLATIONS: Record<string, string> = {
   'grid.yes': 'Yes',
   'grid.no': 'No',
   'grid.systemFields': 'System',
+  // Grouped-view partial-grouping disclosure (objectui#7189). Both sentences
+  // must exist HERE as well as in the locale packs: a provider-less host (a
+  // standalone grid, this package's own tests) never reaches them, and this
+  // is a statement about whether the numbers on screen are true.
+  'grid.grouping.partialBadge': 'Partial',
+  'grid.grouping.partialNotice':
+    'Grouped over the first {{loaded}} of {{total}} records. Group counts are page-scoped, and a group whose records all fall beyond the loaded rows is missing here.',
+  'grid.grouping.partialNoticeUnknownTotal':
+    'Grouped over the {{loaded}} records loaded. More may match this view, so group counts may be partial and a group may be missing here.',
   // Reused by the grouped-view pager (falls back here when no I18nProvider).
   'table.rowsPerPage': 'Rows per page',
   'table.pageInfo': 'Page {{current}} of {{total}}',
@@ -3778,6 +3787,55 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
     ? hostOnPageSizeChange
     : (size: number) => { setServerPageSize(size); setServerPage(1); };
 
+  // ── Is the grouping on screen page-scoped? (objectui#7189) ───────────────
+  //
+  // `useGroupedData` buckets the rows THIS COMPONENT HOLDS and computes every
+  // per-group aggregate from that same array, so both the set of groups and
+  // every number in a group header are properties of the fetched page rather
+  // than of the query. That is a correct implementation of client-side
+  // grouping and is deliberately untouched here; what was missing is any
+  // statement that client-side grouping is what you are looking at. A group
+  // whose records all fall beyond the page does not appear AT ALL — and a
+  // wrong number invites a second look where an absent row invites none.
+  //
+  // Two knowable conditions, deliberately different in strength, because the
+  // wording each one can honestly support differs with it:
+  //
+  //  1. A real match total to compare against — `resolvedTotalMatching`, the
+  //     same ONE derived value the pager and both bulk-bar sites read (do not
+  //     re-spell the `externalManualPagination` conditional here; two copies
+  //     of it is how one of them got missed in #4464). Exceeding the rows in
+  //     hand makes the grouping partial as a FACT, with both numbers.
+  //  2. No total, but we asked the server for a window and it came back full.
+  //     `plugin-list`'s own footer draws exactly this inference when no total
+  //     is known (`items.length >= effectivePageSize`), and it can only ever
+  //     say "may": a result set that exactly fills the window trips it too.
+  //
+  // Rows handed to us inline are NOT a page — nothing was asked for and
+  // nothing was withheld — so `hasInlineData` gates condition 2 out. The
+  // host-driven paging mode still reaches condition 1, through `hostRowCount`.
+  // A result set that fits leaves the grid silent, and that silence is what
+  // makes the marker mean something when it does appear.
+  const groupingRowsLoaded = data.length;
+  const groupingTotalKnown = typeof resolvedTotalMatching === 'number';
+  const groupingPartialWithTotal =
+    groupingTotalKnown && (resolvedTotalMatching as number) > groupingRowsLoaded;
+  const groupingPartialWindowFull =
+    !groupingTotalKnown && !hasInlineData && groupingRowsLoaded >= serverPageSize;
+  const groupingIsPartial =
+    isGrouped && (groupingPartialWithTotal || groupingPartialWindowFull);
+  // ONE sentence, used in both places it belongs: the notice above the group
+  // list, and the accessible name of the marker beside every group count.
+  const groupingPartialNotice = groupingIsPartial
+    ? (groupingPartialWithTotal
+      ? t('grid.grouping.partialNotice', {
+        loaded: groupingRowsLoaded,
+        total: resolvedTotalMatching,
+      })
+      : t('grid.grouping.partialNoticeUnknownTotal', { loaded: groupingRowsLoaded }))
+    : undefined;
+  const groupingPartialLabel = groupingIsPartial ? t('grid.grouping.partialBadge') : undefined;
+
   // Before anyone clicks, the headers show the sort the view was authored with
   // — read with the same `schemaSort` → `defaultSort` precedence the fetch path
   // above uses, so the arrow on screen and the `$orderby` on the wire are the
@@ -4630,6 +4688,8 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
           fieldLabel={group.depth === 0 ? fieldLabel : undefined}
           labelColorClass={labelColorClass}
           labelColorStyle={labelColorStyle}
+          partialLabel={groupingPartialLabel}
+          partialTitle={groupingPartialNotice}
           onToggle={toggleGroup}
         >
           {group.subgroups.length > 0 ? (
@@ -4695,6 +4755,19 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // bottom of an overflow-hidden ancestor and clips it.
   const gridContent = isGrouped ? (
     <div className="flex flex-col flex-1 min-h-0">
+      {/* The partial-grouping disclosure sits INSIDE the grouped region,
+          directly above the first group header — not in the paging footer.
+          The footer is paging chrome and says nothing about what was
+          grouped; the number a reader trusts is the one next to the group's
+          name, so the statement has to be where that number is. */}
+      {groupingIsPartial && (
+        <div
+          data-testid="grouping-partial-notice"
+          className="border-b bg-muted/30 px-3 sm:px-4 py-1.5 text-xs text-muted-foreground grouping-partial-notice"
+        >
+          {groupingPartialNotice}
+        </div>
+      )}
       {/* Single shared horizontal scroll container: every group's sub-table
           overflows into this one scroller (disableInnerScroll), so columns
           stay aligned and there is exactly one x-axis scrollbar. */}

--- a/packages/plugin-grid/src/__tests__/groupedPartialDisclosure-7189.test.tsx
+++ b/packages/plugin-grid/src/__tests__/groupedPartialDisclosure-7189.test.tsx
@@ -1,0 +1,392 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7189 — a grouped grid says, WHERE THE GROUP COUNTS ARE, that it
+ * grouped a page.
+ *
+ * ## The defect this discloses (measured on `main` at a6d8b8d44)
+ *
+ * `useGroupedData` buckets the rows the browser already holds and computes
+ * every per-group aggregate from that same array, so both the set of groups
+ * and every number in a group header are properties of the FETCHED PAGE, not
+ * of the query. Over a 186-row store distributed 86/61/31/7/1 across five
+ * units with `$top: 100`, `main` rendered:
+ *
+ *   - contiguous rows  → TWO group headers, `86` and `14`. Three of the five
+ *     units were absent from the screen entirely.
+ *   - interleaved rows → five headers reading 31/31/30/1/7 — every count a
+ *     page slice of the real 86/61/31/7/1.
+ *
+ * and in both cases the document contained no "186", no "partial", no
+ * "loaded". A wrong number invites a second look; an absent row invites none.
+ *
+ * ## What is under test here, and what is NOT
+ *
+ * The grouping and aggregation algorithm is CORRECT for what it does and is
+ * untouched — the counts asserted below are still page slices afterwards.
+ * These pins are about the *statement*: the grid now says so beside the
+ * numbers a reader treats as authoritative, and stays silent when the result
+ * set genuinely fits. Server-side grouping is a separate, undecided question
+ * (escalated on #5560) and nothing here anticipates it.
+ *
+ * The conditional half is as load-bearing as the disclosure half. A marker
+ * that is simply always on says nothing, so every positive pin below is
+ * paired with a control that must NOT show it.
+ *
+ * ## Why jsdom is a measurement here and not a guess
+ *
+ * jsdom applies CSS media-query rules irrespective of `innerWidth`, so a
+ * width-dependent reading taken in it is not a measurement. Nothing in this
+ * disclosure is width-dependent: it carries no `hidden`/`md:` visibility
+ * utility, and the grouped render path is the only one grouping can reach —
+ * ObjectGrid's mobile card view is gated `useCardView && … && !isGrouped`.
+ * The last pin in this file asserts that gate directly rather than trusting
+ * the reading.
+ *
+ * ## Test-source note
+ *
+ * This file imports `../ObjectGrid` relatively and the root vitest config
+ * aliases `@object-ui/*` to each package's `src`, so no build step stands
+ * between the edit and the run (the same standing arrangement
+ * `groupingProjection-7179.test.tsx` records).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { ActionProvider } from '@object-ui/react';
+
+const OBJECT = 'duly_task';
+
+const OBJECT_FIELDS = {
+  id: { type: 'text', label: 'Id' },
+  subject: { type: 'text', label: 'Subject' },
+  business_unit: { type: 'text', label: 'Business Unit' },
+  region: { type: 'text', label: 'Region' },
+};
+
+/**
+ * The card's own distribution: 186 records over five business units, sized
+ * 86 / 61 / 31 / 7 / 1. Ordering is a parameter because it decides WHICH
+ * shape of the defect you see — contiguous hides whole groups, interleaved
+ * shrinks every count — and the disclosure has to be true of both.
+ */
+const UNITS: Array<[string, number]> = [
+  ['Northgate Operations', 86],
+  ['Northgate Plant', 61],
+  ['Northgate Quality', 31],
+  ['Riverside Plant', 7],
+  ['Riverside Depot', 1],
+];
+
+const buildRows = (interleaved: boolean): any[] => {
+  const buckets = UNITS.map(([unit, n]) =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `${unit}-${i}`,
+      subject: `${unit} #${i}`,
+      business_unit: unit,
+      region: unit.startsWith('Northgate') ? 'North' : 'River',
+    })),
+  );
+  if (!interleaved) return buckets.flat();
+  const out: any[] = [];
+  for (let i = 0; ; i++) {
+    let took = false;
+    for (const b of buckets) {
+      if (i < b.length) { out.push(b[i]); took = true; }
+    }
+    if (!took) return out;
+  }
+};
+
+const ALL_186 = buildRows(true);
+expect(ALL_186).toHaveLength(186);
+
+/**
+ * A data source that honours `$top`/`$skip`. `total` is optional so the
+ * "no total is reachable" branch can be measured rather than assumed.
+ */
+const makeDataSource = (rows: any[], opts?: { withTotal?: boolean }) => ({
+  find: vi.fn(async (_object: string, params: any) => {
+    const skip = params.$skip ?? 0;
+    const top = params.$top ?? rows.length;
+    const page = rows.slice(skip, skip + top);
+    return opts?.withTotal === false
+      ? { data: page }
+      : { data: page, total: rows.length };
+  }),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn(async () => ({ name: OBJECT, fields: OBJECT_FIELDS })),
+});
+
+const groupRows = () => [...document.querySelectorAll('[data-testid^="group-row-"]')];
+const groupHeaders = () =>
+  groupRows().map((r) => ({
+    label: r.querySelector('.group-label')?.textContent,
+    count: r.querySelector('.group-count')?.textContent,
+  }));
+const partialMarkers = () => [...document.querySelectorAll('.group-count-partial')];
+const notice = () => screen.queryByTestId('grouping-partial-notice');
+
+const renderGrid = async (props: Record<string, unknown>) => {
+  const result = render(
+    <ActionProvider>
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <ObjectGrid {...(props as any)} />
+    </ActionProvider>,
+  );
+  await vi.waitFor(() => expect(document.querySelector('[data-testid]')).toBeTruthy());
+  return result;
+};
+
+const groupedSchema = (extra: Record<string, unknown> = {}) => ({
+  type: 'object-grid',
+  objectName: OBJECT,
+  columns: ['subject'],
+  grouping: { fields: [{ field: 'business_unit' }] },
+  ...extra,
+});
+
+afterEach(() => cleanup());
+
+describe('ObjectGrid — a grouped grid discloses that it grouped a page (objectui#7189)', () => {
+  // ── PIN 1: THE DISCLOSURE, WHERE THE COUNTS ARE ─────────────────────────
+  it('marks every group count when the result set exceeds the rows in hand', async () => {
+    const ds = makeDataSource(ALL_186);
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(groupRows().length).toBeGreaterThan(0));
+
+    // The counts are STILL page slices — the algorithm is untouched. What
+    // changed is that each of them now carries the marker.
+    expect(
+      partialMarkers().length,
+      'every group header count is a page slice, so every one of them is marked',
+    ).toBe(groupRows().length);
+    expect(partialMarkers().length).toBeGreaterThan(0);
+  });
+
+  it('states the partial-ness above the group list, with both real numbers', async () => {
+    const ds = makeDataSource(ALL_186);
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(notice()).toBeInTheDocument());
+    const text = notice()!.textContent ?? '';
+    // 100 rows loaded of a 186-row result set. Both numbers are measured
+    // here, not copied: 100 is the `$top` the grid sent, 186 the fixture.
+    expect(text).toContain('100');
+    expect(text).toContain('186');
+    expect(text).toMatch(/missing/i);
+  });
+
+  it('is reached by the group-count marker as its accessible name', async () => {
+    const ds = makeDataSource(ALL_186);
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(partialMarkers().length).toBeGreaterThan(0));
+    const marker = partialMarkers()[0];
+    // The marker beside the number is not a bare glyph: the whole sentence,
+    // numbers included, is its `title` AND its accessible name, so the
+    // disclosure is not lost to a reader who never sees the banner.
+    expect(marker.getAttribute('title')).toContain('186');
+    expect(marker.getAttribute('aria-label')).toContain('186');
+  });
+
+  // ── PIN 2: THE DEFECT IT DISCLOSES IS REAL, IN BOTH SHAPES ──────────────
+  it('discloses the shape where whole groups are missing (contiguous rows)', async () => {
+    const ds = makeDataSource(buildRows(false));
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(groupRows().length).toBeGreaterThan(0));
+    // Measured on `main` before the disclosure existed, and unchanged by it:
+    // the first 100 of these rows hold only two of the five units.
+    expect(groupHeaders()).toEqual([
+      { label: 'Northgate Operations', count: '86' },
+      { label: 'Northgate Plant', count: '14' },
+    ]);
+    expect(screen.queryByText('Riverside Depot')).not.toBeInTheDocument();
+    // Three units are absent from the screen. THAT is what the notice is for.
+    expect(notice()).toBeInTheDocument();
+  });
+
+  it('discloses the shape where every count is a slice (interleaved rows)', async () => {
+    const ds = makeDataSource(ALL_186);
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(groupRows().length).toBe(5));
+    // All five units resolve (that is objectui#7179's fix, live here), and
+    // every count is short of the store's 86/61/31/7/1.
+    expect(groupHeaders().map((g) => g.count)).toEqual(['31', '31', '30', '1', '7']);
+    expect(partialMarkers().length).toBe(5);
+  });
+
+  // ── PIN 3: THE CONTROLS — the marker is CONDITIONAL ─────────────────────
+  it('stays silent when the whole result set fits in the page', async () => {
+    const fits = ALL_186.slice(0, 40);
+    const ds = makeDataSource(fits);
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(groupRows().length).toBe(5));
+    // 40 of 40: every group is whole and every count is the truth.
+    const counts = groupHeaders().map((g) => Number(g.count));
+    expect(counts.reduce((a, b) => a + b, 0)).toBe(40);
+    expect(
+      notice(),
+      'a marker that is always on says nothing — silence here is what makes it mean something',
+    ).not.toBeInTheDocument();
+    expect(partialMarkers()).toHaveLength(0);
+  });
+
+  it('leaves an UNGROUPED grid untouched, however short of the total it is', async () => {
+    const ds = makeDataSource(ALL_186);
+    await renderGrid({
+      schema: {
+        type: 'object-grid',
+        objectName: OBJECT,
+        columns: ['subject'],
+        pagination: { pageSize: 100 },
+      },
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(ds.find).toHaveBeenCalled());
+    await vi.waitFor(() => expect(screen.queryAllByText(/Northgate Operations #0/).length).toBeGreaterThan(0));
+    expect(groupRows()).toHaveLength(0);
+    expect(notice()).not.toBeInTheDocument();
+    expect(partialMarkers()).toHaveLength(0);
+  });
+
+  it('does not mark rows handed to it inline — nothing was asked for, nothing withheld', async () => {
+    await renderGrid({
+      schema: groupedSchema({
+        data: { provider: 'value', items: ALL_186 },
+        pagination: { pageSize: 100 },
+      }),
+    });
+
+    await vi.waitFor(() => expect(groupRows().length).toBeGreaterThan(0));
+    expect(notice()).not.toBeInTheDocument();
+    expect(partialMarkers()).toHaveLength(0);
+  });
+
+  // ── PIN 4: WHERE THE TOTAL COMES FROM ───────────────────────────────────
+  it('reads the total a HOST supplies (the ListView paging shape)', async () => {
+    const ds = makeDataSource(ALL_186);
+    await renderGrid({
+      schema: groupedSchema(),
+      dataSource: ds,
+      data: ALL_186.slice(0, 100),
+      manualPagination: true,
+      rowCount: 186,
+      page: 1,
+      pageSize: 100,
+      onPageChange: () => {},
+    });
+
+    await vi.waitFor(() => expect(notice()).toBeInTheDocument());
+    // The host owns the fetch here, so the grid's own `totalMatching` is
+    // never written; the number has to come from `rowCount`.
+    expect(notice()!.textContent).toContain('186');
+    expect(partialMarkers().length).toBe(groupRows().length);
+  });
+
+  it('falls back to the weaker, honest sentence when NO total is reachable', async () => {
+    const ds = makeDataSource(ALL_186, { withTotal: false });
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(notice()).toBeInTheDocument());
+    const text = notice()!.textContent ?? '';
+    // The window came back full, which is the same inference `plugin-list`'s
+    // own footer draws with no total — so it may only say "may", and it must
+    // not invent a figure it does not have.
+    expect(text).toContain('100');
+    expect(text).toMatch(/\bmay\b/i);
+    expect(text).not.toContain('186');
+    expect(text).not.toMatch(/of \d+ records/i);
+  });
+
+  it('stays silent with no total when the window came back SHORT', async () => {
+    const ds = makeDataSource(ALL_186.slice(0, 40), { withTotal: false });
+    await renderGrid({
+      schema: groupedSchema({ pagination: { pageSize: 100 } }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(groupRows().length).toBe(5));
+    // 40 rows came back against a 100-row window: nothing was withheld.
+    expect(notice()).not.toBeInTheDocument();
+    expect(partialMarkers()).toHaveLength(0);
+  });
+
+  // ── PIN 5: EVERY LEVEL, not just the top one ────────────────────────────
+  it('marks nested subgroup counts too — they are page slices at every depth', async () => {
+    const ds = makeDataSource(ALL_186);
+    await renderGrid({
+      schema: groupedSchema({
+        pagination: { pageSize: 100 },
+        grouping: { fields: [{ field: 'region' }, { field: 'business_unit' }] },
+      }),
+      dataSource: ds,
+    });
+
+    await vi.waitFor(() => expect(groupRows().length).toBeGreaterThan(2));
+    const depths = new Set(
+      groupRows().map((r) => (r.getAttribute('data-testid') ?? '').includes('__') ? 'nested' : 'top'),
+    );
+    expect(depths.has('nested'), 'the fixture must actually produce a second level').toBe(true);
+    expect(partialMarkers().length).toBe(groupRows().length);
+  });
+
+  // ── PIN 6: the jsdom caveat, closed by source rather than by reading ────
+  it('is not width-conditional: grouping never reaches the mobile card view', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    // The repo root: this repo's vitest guard refuses any invocation whose
+    // root is not it (objectui#3378), so `process.cwd()` is that root by
+    // construction and needs no walking up.
+    const src = fs.readFileSync(
+      path.join(process.cwd(), 'packages/plugin-grid/src/ObjectGrid.tsx'),
+      'utf8',
+    );
+    // The one width-driven branch in this component excludes grouping, so the
+    // grouped render path — and therefore this disclosure — is the same at
+    // every viewport. Pinned in source because jsdom cannot measure it:
+    // it applies media-query rules irrespective of `innerWidth`.
+    expect(src).toContain('if (useCardView && data.length > 0 && !isGrouped) {');
+    // And the disclosure itself carries no responsive visibility utility.
+    const noticeMarkup = src.slice(src.indexOf('data-testid="grouping-partial-notice"'));
+    expect(noticeMarkup.slice(0, 400)).not.toMatch(/\b(hidden|sm:hidden|md:hidden|md:block|lg:block)\b/);
+  });
+});

--- a/packages/plugin-grid/src/__tests__/groupedPartialDisclosure-7189.test.tsx
+++ b/packages/plugin-grid/src/__tests__/groupedPartialDisclosure-7189.test.tsx
@@ -87,7 +87,14 @@ const UNITS: Array<[string, number]> = [
   ['Riverside Depot', 1],
 ];
 
-const buildRows = (interleaved: boolean): any[] => {
+interface Row {
+  id: string;
+  subject: string;
+  business_unit: string;
+  region: string;
+}
+
+const buildRows = (interleaved: boolean): Row[] => {
   const buckets = UNITS.map(([unit, n]) =>
     Array.from({ length: n }, (_, i) => ({
       id: `${unit}-${i}`,
@@ -97,7 +104,7 @@ const buildRows = (interleaved: boolean): any[] => {
     })),
   );
   if (!interleaved) return buckets.flat();
-  const out: any[] = [];
+  const out: Row[] = [];
   for (let i = 0; ; i++) {
     let took = false;
     for (const b of buckets) {
@@ -114,10 +121,10 @@ expect(ALL_186).toHaveLength(186);
  * A data source that honours `$top`/`$skip`. `total` is optional so the
  * "no total is reachable" branch can be measured rather than assumed.
  */
-const makeDataSource = (rows: any[], opts?: { withTotal?: boolean }) => ({
-  find: vi.fn(async (_object: string, params: any) => {
-    const skip = params.$skip ?? 0;
-    const top = params.$top ?? rows.length;
+const makeDataSource = (rows: Row[], opts?: { withTotal?: boolean }) => ({
+  find: vi.fn(async (_object: string, params: Record<string, unknown>) => {
+    const skip = (params.$skip as number | undefined) ?? 0;
+    const top = (params.$top as number | undefined) ?? rows.length;
     const page = rows.slice(skip, skip + top);
     return opts?.withTotal === false
       ? { data: page }


### PR DESCRIPTION
Part of #7189 — the **disclosure** half only.

A grouped grid now states, where the group counts are, that it grouped a **page**.

## The card's numbers were stale, so here is today's `main`

objectui#7179 landed as `a6d8b8d44` after the card was written, and it changed
what the card measures: the projection now carries the grouping field, so the
groups resolve and the `(empty)` collapse is gone. The card's table (four
groups for five units, 33 / 3 / 46 / 18) **cannot be reproduced** and nothing
here was built against it.

Re-measured on `a6d8b8d44` — 186 records over five business units sized
86 / 61 / 31 / 7 / 1, `$top: 100`, `$select` confirmed to carry
`business_unit`:

| fixture ordering | group headers rendered | counts | store holds |
| --- | --- | --- | --- |
| contiguous | **2 of 5** | 86, 14 | 86, 61, 31, 7, 1 |
| interleaved | 5 of 5 | 31, 31, 30, 1, 7 | 86, 61, 31, 7, 1 |

In both, the document contained no `186`, no "partial", no "loaded". Which
shape you see is a property of row ordering, not of the tree — the defect is
the same one either way, and the disclosure has to be true of both.

The paging footer the card quotes is **not the grid's**: `Showing first N
records. More data may be available.` lives in
`packages/plugin-list/src/ListView.tsx` (`list.dataLimitReached`), a different
component in a different package. A standalone grouped grid renders no footer
at all.

## What this adds

`useGroupedData`'s grouping and aggregation algorithm is **untouched** — it is
correct for what it does, and the counts above are still page slices
afterwards. What was missing is any statement that client-side grouping is
what you are looking at.

- a short `Partial` marker beside **every group count, at every nesting
  depth**, carrying the whole sentence as its `title` and its accessible name;
- one line directly above the group list, **inside the grouped region** rather
  than in the paging footer, which is not a statement about what was grouped.

## Is a result-set total reachable where the group headers render? Yes

`resolvedTotalMatching` (ObjectGrid.tsx:3769) is in scope at the grouped render
site (~4688 / ~4755), and it is the same ONE derived value the pager and both
bulk-bar sites already read — deliberately not re-spelled here, per the note
objectui#4464 left on it. It resolves from the grid's own `result.total` when
the grid owns the fetch, and from a host's `rowCount` when a host does. Both
paths are pinned.

So the strong wording is supported, and the trigger never outruns what the
component knows:

| condition | wording |
| --- | --- |
| total known and greater than rows in hand | *"Grouped over the first 100 of 186 records. Group counts are page-scoped, and a group whose records all fall beyond the loaded rows is missing here."* |
| no total, window came back full | *"Grouped over the 100 records loaded. More may match this view…"* — may only say **may**, the same inference `plugin-list`'s own footer draws when no total is known |
| rows handed in inline | nothing — nothing was asked for and nothing was withheld |
| result set fits the page | **nothing** |

That last row is the point of the whole thing: a marker that is always on says
nothing.

## Deliberately NOT here

Server-side grouping. It is the card's own preferred durable fix, an
API-surface decision open on #5560, and out of scope for this branch: nothing
builds toward it, no flag anticipates it, the fetch is unchanged. That half of
#7189 stays open.

## No metadata contract was widened

No schema key was added — the condition is derived from data the grid already
holds. `GroupRow` (exported from this package) gains two **optional** props,
`partialLabel` and `partialTitle`; `@objectstack/spec` is untouched.

## Tests — 13 new pins, and an ablation in both directions

`packages/plugin-grid/src/__tests__/groupedPartialDisclosure-7189.test.tsx`.
Prediction was written before either leg ran and both matched exactly.

| leg | mutation | predicted | observed |
| --- | --- | --- | --- |
| A | `groupingIsPartial = false` (disclosure removed) | 8 failed / 5 passed | **8 failed / 5 passed** |
| B | `groupingIsPartial = isGrouped` (marker unconditional) | 3 failed / 10 passed | **3 failed / 10 passed** |

Leg B goes red on the **controls only** — fits-in-one-page, inline rows,
short window — which is what makes the eight positive pins worth anything.

Each leg: mutation proved on disk by injected-marker line count (1) **and**
removed-expression line count (0) **and** a blob hash moved off
`HEAD:packages/plugin-grid/src/ObjectGrid.tsx`
(`eaab121121273aea4e6304d96d82f6fa0da6b06d`); restore by
`git checkout HEAD -- ABSOLUTE_PATH` and proved by **state** — `git diff HEAD`,
`git diff --cached` and `git status --short` all empty and the blob hash back
to HEAD's — with the restore trapped on `EXIT INT TERM`. No rebuild was needed
or performed: `vitest.config.mts:288` aliases `@object-ui/plugin-grid` to
`packages/plugin-grid/src`, verified by reading the alias table.

**jsdom caveat, closed rather than assumed.** jsdom applies CSS media-query
rules irrespective of `innerWidth`, so a width-dependent reading in it is not a
measurement. This disclosure is not width-dependent: it carries no responsive
visibility utility, and grouping never reaches the width-driven branch —
`if (useCardView && data.length &gt; 0 && !isGrouped)`. The last pin asserts
that gate in source rather than trusting the reading.

## Verification, all at `1d8fd9e65` (the final commit)

- `pnpm exec vitest run packages/i18n/ packages/plugin-grid/` — **166 files,
  1912 tests, all passed**. Includes `all-locales-key-parity`, which owns the
  ten-pack key sets the three new `grid.grouping.*` strings had to satisfy.
- `turbo run type-check --filter @object-ui/plugin-grid --filter
  @object-ui/i18n` — 15/15 tasks. `tsc -p tsconfig.test.json --listFiles`
  confirms the new test file and both edited sources are in that program, so
  "typecheck clean" actually covers them.
- Consumer sweep, direction **dependents** of `@object-ui/plugin-grid` (named
  explicitly, because the `...` prefix means opposite things in pnpm and
  turbo): app-shell, console, plugin-designer, plugin-report, plugin-view,
  plugin-list — `turbo run type-check`, 41/41 tasks.
- `check:i18n-keys`, `check:i18n-drift` (0 en values changed, 3 keys added),
  `check:control-bytes`, `check:doc-types`, `check:doc-fences`,
  `check:changeset-presence` — all exit 0 at `1d8fd9e65`.
- eslint, plain form, on all 13 changed `.ts`/`.tsx` files: **0 errors**; the
  new test file is 0 errors / 0 warnings. Type-aware linting is not enabled in
  `eslint.config.js` (no `parserOptions.project`), so this diff cannot move a
  verdict in a file it did not touch — the narrowing is a measurement, not a
  skip. The repo-wide scan is CI's.
- **NOT MEASURED locally, declared:** `check:doc-snippets` and
  `check:readme-exports`. Both exit on an explicit *precondition* — 21
  packages unbuilt in a fresh worktree — and both judge only **fenced** code
  blocks. This diff adds **zero** fenced blocks to any document (measured:
  zero added lines carrying a fence). CI builds and runs them.

## Changeset

`@object-ui/plugin-grid` and `@object-ui/i18n`, both `minor`. The docs edits
ride along in the same PR, so no separate empty-frontmatter changeset is owed —
that form is for a docs-**only** change, where a `patch` would falsely claim a
released package moved.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_