### PR TITLE
fix(plugin-gantt): derive the toolbar period label from the visible window, and wire the period steppers

### DIFF
--- a/.changeset/7203-gantt-toolbar-period-label.md
+++ b/.changeset/7203-gantt-toolbar-period-label.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/plugin-gantt': patch
+---
+
+Gantt toolbar: the period label names the visible window, and the prev/next
+buttons step it (objectui#7203).
+
+The label formatted `timelineRange.start` — the memo spanning the whole dataset
+— so it named the first unit of the entire result set and could not change while
+the chart was scrolled, because it was not derived from scroll position at all.
+On a dataset running January to December it therefore read "January 2026" at
+every scroll position, four pixels above a band header correctly reading
+"Aug 2026". Measured on the demo fixture in Chromium at 1440x900: on first paint,
+after the chart auto-scrolls to Today, the label read `December 2025` over
+columns `28F 29S 30S 31M 1T 2W 3T` with the band beneath them reading `Aug 2026`.
+Two month labels four pixels apart, disagreeing — and the wrong one is the
+prominent one, so the chart reads as if the columns were mislabelled.
+
+The label now names the period at the left edge of the viewport, snapped to the
+same tier `headerGroups` bands the timeline by: a month under day and week view,
+a year under month and quarter view, a decade under year view, the shift-day
+under shift-segmented day view. The toolbar and the band header therefore agree
+by construction rather than by two derivations that can drift. Wording is
+unchanged for the month tier — the toolbar still spells the month out
+("August 2026" beside the header's "Aug 2026").
+
+The `‹` / `›` buttons rendered an `aria-label` and an icon and carried no
+`onClick`. They now scroll the visible window one period backwards/forwards at
+that same tier, clamped to the ends of the timeline (ADR-0049 enforce-or-remove:
+wiring is the branch the label change makes available). They step the label's
+tier rather than one column, so a click always changes what the label says.
+
+The band header is untouched. It was already correct; it is the reference here.

--- a/packages/plugin-gantt/README.md
+++ b/packages/plugin-gantt/README.md
@@ -444,6 +444,21 @@ Drag snapping follows the active scale: bars snap to days in day view, weeks
 in week view, and whole calendar months/quarters (duration preserved) in the
 coarse views.
 
+### The toolbar period label and its steppers
+
+The label between the `‹` / `›` buttons names the period **currently on screen**,
+not the extent of the data: it reads the date at the left edge of the viewport
+and snaps it to the same tier the band header groups by — a month under day and
+week view, a year under month and quarter view, a decade under year view, and
+the shift-day under shift-segmented day view. So the label and the band header
+directly beneath it always name the same period, and the label moves as the
+chart is scrolled.
+
+`‹` / `›` step the visible window by one of those periods (one month in day and
+week view, one year in month and quarter view, a decade in year view), clamped
+to the ends of the timeline. They step the *label's* tier rather than a single
+column, so one click always changes what the label says.
+
 Set the initial scale with `viewMode`. It is read through the gantt config, so
 it needs the field mapping beside it (or a `gantt` block of its own):
 

--- a/packages/plugin-gantt/src/GanttView.toolbarPeriod-7203.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.toolbarPeriod-7203.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * objectui#7203 — the toolbar period label and its prev/next steppers.
+ *
+ * The label used to format `timelineRange.start`, the memo spanning the WHOLE
+ * dataset, so it named the first month of the result set and could not change
+ * at any scroll position — it was not a function of scroll position at all. On
+ * a dataset running Jan–Dec it therefore read "January 2026" four pixels above
+ * a band header correctly reading "Aug 2026". The two stepper buttons beside it
+ * rendered an aria-label and an icon and carried no onClick.
+ *
+ * The band header (`data-testid="gantt-header-groups"`) is the REFERENCE here,
+ * never the thing under test: these tests read the header cell that owns the
+ * pixel at the left edge of the viewport and require the toolbar to name the
+ * same month. Comparison is by month identity (`monthKey`), not by wording, so
+ * the toolbar staying on the fuller "August 2026" beside the header's compact
+ * "Aug 2026" is not what is being asserted either way.
+ *
+ * Scroll is honestly modelled in this environment: `GanttView.virtual.test.tsx`
+ * already pins that `timeline.scrollLeft = N` + `fireEvent.scroll` moves the
+ * column window to N (its assertion reads a rendered `style.left` back). The
+ * label derives from the same `scrollPos.left`, so these readings are real.
+ * Client sizes ARE 0 here, so the component falls back to a 4000px virtual
+ * viewport — every fixture below is wider than that, which is what makes the
+ * stepper's clamp non-trivial and the window genuinely scrollable.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  // >=1024 → columnWidth 110 (deterministic), matching the sibling suites.
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+  window.localStorage.clear();
+});
+
+function toolbarLabel(container: HTMLElement): string {
+  const el = container.querySelector('[data-testid="gantt-toolbar-period"]');
+  expect(el, 'toolbar period label is missing').toBeTruthy();
+  return el!.textContent!.trim();
+}
+
+function groupCells(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll('[data-testid="gantt-header-groups"] > div'),
+  ).map((node) => {
+    const el = node as HTMLElement;
+    return {
+      label: el.textContent!.trim(),
+      left: parseFloat(el.style.left),
+      width: parseFloat(el.style.width),
+    };
+  });
+}
+
+/** The band-header cell that owns pixel `x` — what the user reads at the left
+ *  edge of the viewport, and the reference the toolbar has to agree with. */
+function bandAt(container: HTMLElement, x: number) {
+  const hit = groupCells(container).find((c) => c.left <= x && x < c.left + c.width);
+  expect(hit, `no band-header cell owns x=${x}`).toBeTruthy();
+  return hit!;
+}
+
+/** `year-monthIndex` of a rendered month label, so "August 2026" (toolbar) and
+ *  "Aug 2026" (band header) compare as the same month without either one's
+ *  exact wording being asserted. */
+function monthKey(label: string): string {
+  const d = new Date(label);
+  expect(Number.isNaN(d.getTime()), `unparseable month label: "${label}"`).toBe(false);
+  return `${d.getFullYear()}-${d.getMonth()}`;
+}
+
+function timelineOf(container: HTMLElement): HTMLElement {
+  return container.querySelector('[data-testid="gantt-timeline"]') as HTMLElement;
+}
+
+function scrollTo(container: HTMLElement, x: number) {
+  const timeline = timelineOf(container);
+  timeline.scrollLeft = x;
+  fireEvent.scroll(timeline);
+  return timeline;
+}
+
+function click(container: HTMLElement, testid: string) {
+  const btn = container.querySelector(`[data-testid="${testid}"]`);
+  expect(btn, `${testid} is missing`).toBeTruthy();
+  fireEvent.click(btn!);
+}
+
+/** The reporter's shape: a year of history, no explicit window, so
+ *  `timelineRange` spans the whole dataset and starts in January. */
+function yearOfTasks(): GanttTask[] {
+  return [
+    { id: 'a', title: 'Task a', start: new Date(2026, 0, 31), end: new Date(2026, 1, 20), progress: 0 },
+    { id: 'b', title: 'Task b', start: new Date(2026, 7, 26), end: new Date(2026, 8, 6), progress: 0 },
+    { id: 'c', title: 'Task c', start: new Date(2026, 11, 1), end: new Date(2026, 11, 31), progress: 0 },
+  ];
+}
+
+function renderView(props: Partial<React.ComponentProps<typeof GanttView>> = {}) {
+  return render(
+    <div style={{ width: 1280, height: 600 }}>
+      <GanttView tasks={yearOfTasks()} {...props} />
+    </div>,
+  );
+}
+
+describe('GanttView toolbar period label (objectui#7203)', () => {
+  it('names the month the band header names, at a scrolled position', () => {
+    const { container } = renderView();
+    // The dataset really does start in January — which is precisely why the old
+    // `timelineRange.start` label read January at EVERY scroll position.
+    expect(monthKey(toolbarLabel(container))).toBe('2026-0');
+
+    const x = 23430; // ~7 months in at 110px/day; anywhere past January will do
+    scrollTo(container, x);
+
+    const band = bandAt(container, x);
+    expect(monthKey(band.label), 'fixture did not actually leave January').not.toBe('2026-0');
+    expect(monthKey(toolbarLabel(container))).toBe(monthKey(band.label));
+  });
+
+  it('changes as the chart scrolls, and comes back', () => {
+    // The assertion that fails if the label is ever wired back to a whole-range
+    // memo: a static string passes any single-position check.
+    const { container } = renderView();
+    const atStart = toolbarLabel(container);
+
+    scrollTo(container, 23430);
+    expect(toolbarLabel(container)).not.toBe(atStart);
+
+    scrollTo(container, 0);
+    expect(toolbarLabel(container)).toBe(atStart);
+  });
+
+  it('agrees with the band header at every scroll position, week view included', () => {
+    // Week view is the straddle case: a week column can start in one month and
+    // end in the next. The header keys such a column by the month its START
+    // falls in, so the label has to snap the COLUMN, not the instant under the
+    // pixel — otherwise the two disagree for part of every straddling week.
+    const { container } = renderView({ viewMode: 'week' });
+    for (const x of [0, 300, 777, 1234, 2000, 3111, 4200]) {
+      scrollTo(container, x);
+      expect(monthKey(toolbarLabel(container)), `at x=${x}`).toBe(monthKey(bandAt(container, x).label));
+    }
+  });
+
+  it('still labels a single-month dataset correctly (control)', () => {
+    // The fix is not "read whatever the header says": with one band and no
+    // scrolling, the label is still derived, and still right.
+    const { container } = render(
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={[{ id: 'a', title: 'Task a', start: new Date(2026, 5, 5), end: new Date(2026, 5, 20), progress: 0 }]}
+          startDate={new Date(2026, 5, 1)}
+          endDate={new Date(2026, 5, 30)}
+        />
+      </div>,
+    );
+    const bands = groupCells(container);
+    expect(bands.length).toBe(1);
+    expect(monthKey(toolbarLabel(container))).toBe('2026-5');
+    expect(monthKey(bands[0].label)).toBe('2026-5');
+  });
+});
+
+describe('GanttView toolbar period steppers (objectui#7203)', () => {
+  it('steps the visible window one period per click, and the label follows', () => {
+    const { container } = renderView();
+    const timeline = timelineOf(container);
+    expect(monthKey(toolbarLabel(container))).toBe('2026-0');
+    expect(timeline.scrollLeft).toBe(0);
+
+    click(container, 'gantt-toolbar-next-period');
+    expect(monthKey(toolbarLabel(container))).toBe('2026-1');
+    const afterNext = timeline.scrollLeft;
+    expect(afterNext).toBeGreaterThan(0);
+    expect(monthKey(bandAt(container, afterNext).label)).toBe('2026-1');
+
+    click(container, 'gantt-toolbar-next-period');
+    expect(monthKey(toolbarLabel(container))).toBe('2026-2');
+    expect(timeline.scrollLeft).toBeGreaterThan(afterNext);
+
+    click(container, 'gantt-toolbar-prev-period');
+    expect(monthKey(toolbarLabel(container))).toBe('2026-1');
+    expect(timeline.scrollLeft).toBe(afterNext);
+  });
+
+  it('clamps at the left edge instead of scrolling out of the range', () => {
+    const { container } = renderView();
+    const timeline = timelineOf(container);
+    // January is the first period; the timeline itself starts on 24 Jan, so the
+    // period start is off-grid to the left. Stepping back parks at 0.
+    click(container, 'gantt-toolbar-prev-period');
+    expect(timeline.scrollLeft).toBe(0);
+    expect(monthKey(toolbarLabel(container))).toBe('2026-0');
+  });
+
+  it('bands by year in month view, and steps one year per click', () => {
+    // "One unit of the current granularity" is the tier the band header groups
+    // by, not the column unit: day/week band by month, month/quarter by year,
+    // year by decade. Stepping a single month column in month view would leave
+    // the toolbar's own label unchanged for eleven clicks out of twelve.
+    const { container } = render(
+      <div style={{ width: 1280, height: 600 }}>
+        <GanttView
+          tasks={[{ id: 'a', title: 'Task a', start: new Date(2024, 0, 10), end: new Date(2028, 11, 20), progress: 0 }]}
+          startDate={new Date(2024, 0, 1)}
+          endDate={new Date(2028, 11, 31)}
+          viewMode="month"
+        />
+      </div>,
+    );
+    expect(toolbarLabel(container)).toBe('2024');
+    expect(bandAt(container, 0).label).toBe('2024');
+
+    const timeline = timelineOf(container);
+    click(container, 'gantt-toolbar-next-period');
+    expect(toolbarLabel(container)).toBe('2025');
+    expect(timeline.scrollLeft).toBeGreaterThan(0);
+    expect(bandAt(container, timeline.scrollLeft).label).toBe('2025');
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -308,6 +308,68 @@ export function addUnits(date: Date, units: number, mode: GanttViewMode): Date {
   return d;
 }
 
+/**
+ * The tier the toolbar's period label and its prev/next steppers work in.
+ *
+ * It is deliberately the SAME tier `headerGroups` bands the timeline by, so the
+ * toolbar and the band header four pixels below it can never name different
+ * periods (objectui#7203: the toolbar formatted `timelineRange.start` — the memo
+ * spanning the whole dataset — and so read "January 2026" over columns the band
+ * header correctly called "Aug 2026", and could not change at any scroll
+ * position because it was not derived from scroll position at all).
+ *
+ * Every `GanttViewMode` has a natural unit here, so "step one period" is always
+ * defined: day/week band by month, month/quarter by year, year by decade, and
+ * shift-segmented day mode by shift-day (the tier its bands group into).
+ */
+export type GanttPeriodTier = 'shiftDay' | 'month' | 'year' | 'decade';
+
+/** Mirror of the `groupBy` choice inside `headerGroups` — keep the two in step. */
+export function periodTierFor(mode: GanttViewMode, segmenting: boolean): GanttPeriodTier {
+  if (segmenting) return 'shiftDay';
+  if (mode === 'year') return 'decade';
+  if (mode === 'month' || mode === 'quarter') return 'year';
+  return 'month';
+}
+
+/** Start of the period `date` falls in, at `tier`. */
+export function startOfPeriod(date: Date, tier: GanttPeriodTier, dayStartMin = 0): Date {
+  if (tier === 'shiftDay') return shiftDayStart(date, dayStartMin);
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  if (tier === 'month') {
+    d.setDate(1);
+  } else if (tier === 'year') {
+    d.setMonth(0, 1);
+  } else {
+    d.setMonth(0, 1);
+    d.setFullYear(Math.floor(d.getFullYear() / 10) * 10);
+  }
+  return d;
+}
+
+/** Step whole periods at `tier` — one unit of the toolbar's granularity. */
+export function addPeriods(date: Date, n: number, tier: GanttPeriodTier): Date {
+  if (tier === 'shiftDay') return addUnits(date, n, 'day');
+  if (tier === 'month') return addUnits(date, n, 'month');
+  return addUnits(date, n * (tier === 'decade' ? 10 : 1), 'year');
+}
+
+/**
+ * Toolbar wording for a period start. The year and decade tiers reuse the band
+ * header's exact strings; the month tier spells the month out ("August 2026"
+ * beside the header's "Aug 2026") — a fuller form of the same month, never a
+ * different one.
+ */
+export function formatPeriodLabel(date: Date, tier: GanttPeriodTier, locale?: string): string {
+  if (tier === 'decade') return `${Math.floor(date.getFullYear() / 10) * 10}s`;
+  if (tier === 'year') return String(date.getFullYear());
+  if (tier === 'shiftDay') {
+    return date.toLocaleDateString(locale, { year: 'numeric', month: 'long', day: 'numeric' });
+  }
+  return date.toLocaleDateString(locale, { month: 'long', year: 'numeric' });
+}
+
 /** Custom vertical timeline marker (deadline, sprint boundary, release…). */
 export interface GanttMarker {
   date: Date | string
@@ -1984,12 +2046,15 @@ export function GanttView({
     [timeColumns, colStartMs, colRealMs, colOffsets, folding, segmenting],
   );
 
-  // x (px) → date. Inverse of dateToX, used by drag/resize to read the date
-  // under the pointer. Never returns a folded (non-working) instant.
-  const xToDate = React.useCallback(
-    (x: number): Date => {
+  // Index of the column that OWNS pixel x — the largest i with
+  // colOffsets[i] <= x. Shared by `xToDate` (which then interpolates inside the
+  // column) and by the toolbar's visible-period label (which must not
+  // interpolate: a week column straddling a month boundary belongs, header-group
+  // and label alike, to the month its START falls in).
+  const colIndexAtX = React.useCallback(
+    (x: number): number => {
       const n = timeColumns.length;
-      if (n === 0) return new Date(timelineRange.start);
+      if (n === 0) return -1;
       let lo = 0;
       let hi = n - 1;
       let i = 0;
@@ -2002,11 +2067,22 @@ export function GanttView({
           hi = m - 1;
         }
       }
+      return i;
+    },
+    [timeColumns, colOffsets],
+  );
+
+  // x (px) → date. Inverse of dateToX, used by drag/resize to read the date
+  // under the pointer. Never returns a folded (non-working) instant.
+  const xToDate = React.useCallback(
+    (x: number): Date => {
+      const i = colIndexAtX(x);
+      if (i < 0) return new Date(timelineRange.start);
       const w = timeColumns[i].width || 1;
       const frac = (x - colOffsets[i]) / w;
       return new Date(colStartMs[i] + frac * (colRealMs[i] || MS_PER_DAY));
     },
-    [timeColumns, colStartMs, colRealMs, colOffsets, timelineRange],
+    [colIndexAtX, timeColumns, colStartMs, colRealMs, colOffsets, timelineRange],
   );
 
   // Switch granularity *without* the date window jumping. The scroll container
@@ -2266,6 +2342,51 @@ export function GanttView({
     return { startIdx, endIdx };
   }, [scrollPos.top, viewport.height, rowHeight, rows.length]);
   const totalRowsHeight = rows.length * rowHeight;
+
+  // --- Toolbar period: label + prev/next steppers ---------------------------
+  // Both are derived from the VISIBLE WINDOW, never from `timelineRange` — the
+  // whole-dataset memo, whose start is the first unit of the entire result set
+  // and does not move when the chart is scrolled, because it is not a function
+  // of scroll position at all (objectui#7203). The left edge of the viewport
+  // picks the owning column; that column's own start date, snapped to the tier
+  // `headerGroups` bands by, is the period on screen — so the toolbar label and
+  // the band header four pixels below it agree by construction rather than by
+  // two parallel derivations that can drift apart.
+  const periodTier = periodTierFor(viewMode, segmenting);
+  const visiblePeriodStart = React.useMemo(() => {
+    const i = colIndexAtX(scrollPos.left);
+    // Snap the COLUMN's start, not the interpolated instant under the pixel: a
+    // week column straddling a month boundary belongs to the month its start
+    // falls in, which is exactly how `headerGroups` keys it.
+    const anchor = i >= 0 ? timeColumns[i].date : timelineRange.start;
+    return startOfPeriod(anchor, periodTier, shiftSegments?.dayStartMin ?? 0);
+  }, [colIndexAtX, scrollPos.left, timeColumns, timelineRange, periodTier, shiftSegments]);
+
+  const periodLabel = React.useMemo(
+    () => formatPeriodLabel(visiblePeriodStart, periodTier, dateLocale),
+    [visiblePeriodStart, periodTier, dateLocale],
+  );
+
+  // Scroll the visible window one period backwards/forwards — what the toolbar's
+  // ChevronLeft/ChevronRight drive. Clamped against the same totalWidth/viewport
+  // pair the virtualization windows use, so the two never disagree about where
+  // the content ends. `scrollPos` is pushed here as well as from the scroll
+  // event because that event is queued (async) and a clamped assignment at
+  // either end of the range fires none at all — the label has to follow the
+  // move either way. Same "drive virtualization directly" reason as
+  // `handleListScroll` below.
+  const stepPeriod = React.useCallback(
+    (delta: number) => {
+      const el = scrollAreaRef.current;
+      if (!el) return;
+      const target = addPeriods(visiblePeriodStart, delta, periodTier);
+      const maxLeft = Math.max(0, totalWidth - viewport.width);
+      const left = Math.max(0, Math.min(Math.round(dateToX(target)), maxLeft));
+      el.scrollLeft = left;
+      setScrollPos((prev) => (prev.left === left ? prev : { ...prev, left }));
+    },
+    [visiblePeriodStart, periodTier, totalWidth, viewport.width, dateToX],
+  );
 
   // --- Fullscreen -----------------------------------------------------------
   const [isFullscreen, setIsFullscreen] = React.useState(false);
@@ -3178,14 +3299,30 @@ export function GanttView({
               already exposes a fully-fielded create form for this
               object, and the toolbar's quick-create only set 3 fields
               which was confusing for required-field-heavy schemas. */}
-          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label={t('gantt.toolbar.prevPeriod')}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={t('gantt.toolbar.prevPeriod')}
+            data-testid="gantt-toolbar-prev-period"
+            onClick={() => stepPeriod(-1)}
+          >
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <Button variant="ghost" size="icon" className="h-8 w-8" aria-label={t('gantt.toolbar.nextPeriod')}>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label={t('gantt.toolbar.nextPeriod')}
+            data-testid="gantt-toolbar-next-period"
+            onClick={() => stepPeriod(1)}
+          >
             <ChevronRight className="h-4 w-4" />
           </Button>
-          <span className="font-semibold text-xs sm:text-sm">
-            {timelineRange.start.toLocaleDateString(dateLocale, { month: 'long', year: 'numeric' })}
+          {/* The period ON SCREEN, not the start of the dataset — see
+              `visiblePeriodStart`. */}
+          <span className="font-semibold text-xs sm:text-sm" data-testid="gantt-toolbar-period">
+            {periodLabel}
           </span>
           {effectiveReadOnly && (
             <span

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -322,10 +322,10 @@ export function addUnits(date: Date, units: number, mode: GanttViewMode): Date {
  * defined: day/week band by month, month/quarter by year, year by decade, and
  * shift-segmented day mode by shift-day (the tier its bands group into).
  */
-export type GanttPeriodTier = 'shiftDay' | 'month' | 'year' | 'decade';
+type GanttPeriodTier = 'shiftDay' | 'month' | 'year' | 'decade';
 
 /** Mirror of the `groupBy` choice inside `headerGroups` — keep the two in step. */
-export function periodTierFor(mode: GanttViewMode, segmenting: boolean): GanttPeriodTier {
+function periodTierFor(mode: GanttViewMode, segmenting: boolean): GanttPeriodTier {
   if (segmenting) return 'shiftDay';
   if (mode === 'year') return 'decade';
   if (mode === 'month' || mode === 'quarter') return 'year';
@@ -333,7 +333,7 @@ export function periodTierFor(mode: GanttViewMode, segmenting: boolean): GanttPe
 }
 
 /** Start of the period `date` falls in, at `tier`. */
-export function startOfPeriod(date: Date, tier: GanttPeriodTier, dayStartMin = 0): Date {
+function startOfPeriod(date: Date, tier: GanttPeriodTier, dayStartMin = 0): Date {
   if (tier === 'shiftDay') return shiftDayStart(date, dayStartMin);
   const d = new Date(date);
   d.setHours(0, 0, 0, 0);
@@ -349,7 +349,7 @@ export function startOfPeriod(date: Date, tier: GanttPeriodTier, dayStartMin = 0
 }
 
 /** Step whole periods at `tier` — one unit of the toolbar's granularity. */
-export function addPeriods(date: Date, n: number, tier: GanttPeriodTier): Date {
+function addPeriods(date: Date, n: number, tier: GanttPeriodTier): Date {
   if (tier === 'shiftDay') return addUnits(date, n, 'day');
   if (tier === 'month') return addUnits(date, n, 'month');
   return addUnits(date, n * (tier === 'decade' ? 10 : 1), 'year');
@@ -361,7 +361,7 @@ export function addPeriods(date: Date, n: number, tier: GanttPeriodTier): Date {
  * beside the header's "Aug 2026") — a fuller form of the same month, never a
  * different one.
  */
-export function formatPeriodLabel(date: Date, tier: GanttPeriodTier, locale?: string): string {
+function formatPeriodLabel(date: Date, tier: GanttPeriodTier, locale?: string): string {
   if (tier === 'decade') return `${Math.floor(date.getFullYear() / 10) * 10}s`;
   if (tier === 'year') return String(date.getFullYear());
   if (tier === 'shiftDay') {


### PR DESCRIPTION
Fixes #7203

## What was wrong

The toolbar span formatted `timelineRange.start` — the memo spanning the whole
dataset — so it named the first unit of the entire result set and **could not
change while the chart was scrolled, because it was not derived from scroll
position at all**. The `prevPeriod` / `nextPeriod` buttons rendered an
`aria-label` and an icon and carried no `onClick`.

## What changed

`packages/plugin-gantt/src/GanttView.tsx` only.

- **The label names the period on screen.** The left edge of the viewport picks
  the owning column (`colIndexAtX`, extracted from the binary search `xToDate`
  already ran, and now shared by both); that column's own start date, snapped to
  the tier `headerGroups` bands by, is the visible period. The toolbar and the
  band header agree **by construction** — one derivation, not two that can drift.
- **The steppers scroll that window** one period back/forward at the same tier,
  clamped against the same `totalWidth` / viewport pair the virtualization uses.
- **The band header is untouched.** It is the reference, not the defect. Its
  memo, its rendering and its grouping are byte-identical to `origin/main`.

### Granularity: what "one unit" is, per view mode

The stepped unit is the **label's tier**, not the column unit — stepping one
month column in month view would leave the toolbar's own label unchanged for
eleven clicks out of twelve, which is not a control that drives the label
beside it. Every view mode has a natural unit at that tier, so nothing had to
be invented:

| view mode | band tier | one step |
| :-- | :-- | :-- |
| day, week | month | 1 month |
| month, quarter | year | 1 year |
| year | decade | 10 years |
| day + shift segments | shift-day | 1 shift-day |

## Evidence

### Real browser — preinstalled Chromium at `/opt/pw-browsers`, 1440x900

jsdom/happy-dom reports `clientWidth` 0, so the chart's **auto-scroll to Today**
never fires there — which is precisely the card's first-paint reproduction. It
was measured in a real browser instead, against the package demo's `?perf=2000`
fixture (tasks from Jan 2026, `timelineRange.start` 29 Dec 2025, Today 1 Sep
2026). The "before" column is the same page with the label expression reverted
in place, mutation proven on disk by marker count and blob hash, restored under
a trap:

| state | toolbar, before | toolbar, after | band header at the left edge | first visible unit columns |
| :-- | :-- | :-- | :-- | :-- |
| first paint (auto-scrolled to Today, scrollLeft 26576) | `December 2025` | `August 2026` | `Aug 2026` | 28F 29S 30S 31M 1T 2W 3T |
| after one next-period click (scrollLeft 27060) | `December 2025` | `September 2026` | `Sep 2026` | 1T 2W 3T 4F 5S 6S 7M |
| after one prev-period click (scrollLeft 23650) | `December 2025` | `August 2026` | `Aug 2026` | 1S 2S 3M 4T 5W 6T 7F |
| scrolled to 0 | `December 2025` | `December 2025` | `Dec 2025` | 29M 30T 31W 1T 2F 3S 4S |

Agreement with the band header: **false / false / false / true** before, **true
at all four** after. The label moved across positions: **no** before, **yes**
after. The bottom row is the control — the one position where the old label
was accidentally right is still right.

### Unit tests — `GanttView.toolbarPeriod-7203.test.tsx`, 7 new

Scroll is honestly modelled in this environment: `GanttView.virtual.test.tsx`
already pins that setting `scrollLeft` plus a scroll event moves the column
window, and asserts it by reading a rendered `style.left` back. The new tests
read the band-header cell that owns the pixel at the left edge and require the
toolbar to name the same month — comparison is by month identity, never by
wording, so "August 2026" beside "Aug 2026" is not what is being asserted.

Two ablations, each with the direction and the counts predicted first, the
mutation proven on disk by marker count both ways plus a changed blob hash, and
the restore proven by state (`git diff HEAD`, `git diff --cached`,
`git status --short` all empty via `git checkout HEAD -- ABSOLUTE_PATH`):

- **Label reverted** to `timelineRange.start` — predicted 5 failed / 2 passed;
  measured **5 failed / 2 passed**, and the five are the predicted five. The two
  that stay green are the single-month control and the left-edge clamp, the only
  two whose expectations a static January label happens to satisfy.
- **Both `onClick` handlers removed** — predicted 2 failed / 5 passed; measured
  **2 failed / 5 passed**.

### Gates, all at `e1facd916` (the pushed head)

- `pnpm exec vitest run packages/plugin-gantt/` — **56 files / 448 tests passed**
- `pnpm --filter @object-ui/plugin-gantt run type-check` — **exit 0** (both
  `tsc --noEmit` and `tsc -p tsconfig.test.json`, so the new test file is
  type-checked too)
- `check:control-bytes` — OK, 5988 tracked text files
- `check:changeset-presence` — OK, 1 changeset for 2 changed published sources
- `check:i18n-keys`, `check:doc-fences`, `check:vi-mock-specifiers`,
  `check:vi-mock-inherit` — exit 0
- `check:governed-queue-guard --test` on the 4 changed paths — NOT GOVERNED
- Cross-package suites that read `GanttView` (3 in `@object-ui/i18n`, 1 in
  `@object-ui/plugin-view`) — 4 files / 83 tests passed
- `git merge-tree --write-tree --name-only origin/main HEAD` — exit 0 against
  `f626808d4`

**eslint — declared narrowing.** Run plain (never `--no-inline-config`) over the
whole `packages/plugin-gantt` directory, letting eslint enumerate the population
from its own config: **86 files, 0 errors, 323 warnings**. `GanttView.tsx` is
**0 errors / 19 warnings both before and after** — measured by linting the
`origin/main` blob in place under a trap — so this change adds no warning. The
repo-level `turbo run lint` was not run here: the config extends
`tseslint.configs.recommended` with no `parserOptions.project` and no
`projectService`, so type-aware linting is off and a file's verdict depends only
on its own text; a diff that edits two files cannot move the verdict of any file
it does not edit.

**`check:readme-exports` — NOT MEASURED, not red.** It exits 1 on its own
population-collapse banner ("this run proves nothing", 24 of 40 packages
unbuilt) — an environment condition, not a finding, and CI builds first. This
diff is inert to it either way, measured: the README section adds **0** fenced
blocks (38 before, 38 after) and **0** import lines, `src/index.tsx` is
byte-identical to `origin/main`, and `GanttView.tsx`'s exported-symbol set is
identical to `origin/main` (the four new period helpers are module-private —
nothing outside the module consumes them).

`check:i18n-dead-keys` prints "This is a REPORT, not a gate" and is recorded as
a report, not a colour.

## Scope

Nothing outside the toolbar. `showStartEndColumns`, `taskListWidthForContainer`,
task-list width and the date sublabel all sit in this same file and are all
untouched — they are blocked on open maintainer decisions, and staying out of
them is what keeps this PR independently landable. Also untouched:
`content/docs/releases/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wwHa4aaFybxXrfmfHioDM)_