### PR TITLE
fix(plugin-gantt): guard `reload()`'s `finally` so a superseded run cannot clear the loading state

### DIFF
--- a/.changeset/7231-gantt-stale-reload-finally.md
+++ b/.changeset/7231-gantt-stale-reload-finally.md
@@ -1,0 +1,22 @@
+---
+'@object-ui/plugin-gantt': patch
+---
+
+`ObjectGantt` no longer blanks the chart when one reload supersedes another
+
+`reload()` already sequenced concurrent runs with `reloadSeqRef` and guarded every
+result write with `isCurrent()`, but its `finally` was unguarded — so a **superseded**
+reload still flipped `loading` / `refreshing` off. The stale run only had to finish
+first, which is the ordinary case whenever a second reload is issued while the first
+is still in flight: the placeholder was released, no rows had arrived, and the user
+saw an empty chart until the fresh response landed.
+
+The `finally` now clears the flags only when the run reaching it is still the current
+one. It clears **both** flags rather than only the one its own `silent` mode set:
+being current at that point means nothing is in flight any more, so clearing only its
+own mode would strand the other flag whenever the superseded run used the other mode
+— a silent toolbar refresh overtaken by a filter-change reload would have left the
+refresh button busy for the life of the component.
+
+This is the reload guard alone. Nothing about which queries are issued, how they are
+projected or how they page changes.

--- a/packages/plugin-gantt/src/ObjectGantt.staleReloadFinally-7231.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.staleReloadFinally-7231.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7231 — `reload()`'s `finally` must belong to the CURRENT reload.
+ *
+ * `reload()` sequences concurrent runs with `reloadSeqRef` and guards every
+ * result write with `isCurrent()` (`setData` on three branches, `setError` on
+ * the error branch). The `finally` used to carry no guard, so a SUPERSEDED
+ * reload still flipped `loading` / `refreshing` off — clearing the loading
+ * placeholder while the fresh query was still in flight. The user saw an
+ * empty chart: placeholder gone, no rows arrived yet.
+ *
+ * Note which ordering produces it: NOT an exotic out-of-order response, but
+ * the plain in-issue-order one. The stale reload merely has to FINISH FIRST,
+ * which is the ordinary case whenever a second reload is issued while the
+ * first is still in flight. The out-of-order case (fresh finishes first) is
+ * the one the pre-existing `setData` guard already covered, and it is kept
+ * below as the control.
+ *
+ * The guard shape matters, hence the third case. The flags are per-MODE
+ * (`silent` → `refreshing`, otherwise `loading`), so a `finally` that clears
+ * only its own mode's flag when current leaks the other one: a silent reload
+ * superseded by a non-silent one would never clear `refreshing`, leaving the
+ * toolbar's refresh button stuck busy for the life of the component. What
+ * makes clearing BOTH correct is that "I am current AND I am finishing"
+ * means nothing is in flight any more — a newer reload would have made this
+ * one stale, and an older one has no claim on the flags.
+ *
+ * Scope: this is the reload guard only. The overlapping-reload pairs it
+ * covers include the toolbar refresh and the write-readback paths, where two
+ * reloads legitimately overlap and no schema gating is involved — see the
+ * card for why this must not be folded into the gating work.
+ */
+
+import React from 'react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectGantt } from './ObjectGantt';
+import type { DataSource } from '@object-ui/types';
+
+// Probe stand-in: the real chart is irrelevant here, but `refreshing` is not —
+// case 3 reads it back off the DOM.
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks, onRefresh, refreshing }: any) => (
+    <div data-testid="gantt-view" data-refreshing={String(!!refreshing)}>
+      {tasks.map((t: any) => (
+        <div key={t.id} data-testid="gantt-task">{t.title}</div>
+      ))}
+      <button data-testid="gv-refresh" onClick={() => onRefresh?.()}>refresh</button>
+    </div>
+  ),
+}));
+
+const PLACEHOLDER = 'Loading Gantt chart...';
+
+const ROWS_A = [
+  { id: '1', name: 'From the stale query', start_date: '2024-01-01', end_date: '2024-01-05' },
+];
+const ROWS_B = [
+  { id: '2', name: 'From the fresh query', start_date: '2024-02-01', end_date: '2024-02-05' },
+];
+
+const OBJECT_SCHEMA = {
+  fields: {
+    name: { type: 'text' },
+    start_date: { type: 'date' },
+    end_date: { type: 'date' },
+  },
+};
+
+const GANTT_CONFIG = {
+  titleField: 'name',
+  startDateField: 'start_date',
+  endDateField: 'end_date',
+};
+
+function schemaWith(filter?: unknown): any {
+  return {
+    type: 'gantt',
+    gantt: GANTT_CONFIG,
+    data: { provider: 'object', object: 'tasks' },
+    ...(filter === undefined ? {} : { filter }),
+  };
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * A data source whose every `find()` hands back a promise the test resolves
+ * by hand, so reload N and reload N+1 can be held in flight together and
+ * completed in either order. `getObjectSchema` resolves immediately — that is
+ * what issues the second reload (`objectSchema` is a `reload` dependency)
+ * while the first `find()` is still pending.
+ */
+function makeDeferredDataSource() {
+  const finds: Deferred<any>[] = [];
+  const dataSource = {
+    find: vi.fn(() => {
+      const d = deferred<any>();
+      finds.push(d);
+      return d.promise;
+    }),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn().mockResolvedValue({}),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn().mockResolvedValue(OBJECT_SCHEMA),
+  } as unknown as DataSource;
+  return { dataSource, finds };
+}
+
+/** Settle one held `find()` and let React flush the resulting commits. */
+async function settle(d: Deferred<any>, rows: unknown[]) {
+  await act(async () => {
+    d.resolve({ data: rows });
+    await Promise.resolve();
+  });
+}
+
+/** Let pending microtasks/effects run without resolving anything. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('ObjectGantt — a superseded reload must not clear the loading state (objectui#7231)', () => {
+  it('keeps the placeholder up when the STALE reload finishes first and the fresh one is still in flight', async () => {
+    const { dataSource, finds } = makeDeferredDataSource();
+
+    render(<ObjectGantt schema={schemaWith()} dataSource={dataSource} />);
+
+    // Reload #1 (mount) is in flight; the object schema resolves and re-keys
+    // `reload`, issuing reload #2 before #1 has answered.
+    await waitFor(() => expect((dataSource.find as any).mock.calls.length).toBe(2));
+    expect(screen.getByText(PLACEHOLDER)).toBeTruthy();
+
+    // The superseded reload #1 answers first — the ordinary ordering.
+    await settle(finds[0], ROWS_A);
+
+    // Its `finally` must NOT clear `loading`: the fresh query has not answered,
+    // so releasing the placeholder here paints an empty chart.
+    expect(screen.getByText(PLACEHOLDER)).toBeTruthy();
+    expect(screen.queryByTestId('gantt-view')).toBeNull();
+
+    // The current reload #2 answers and owns the transition out of loading.
+    await settle(finds[1], ROWS_B);
+
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeTruthy());
+    expect(screen.getByText('From the fresh query')).toBeTruthy();
+    expect(screen.queryByText('From the stale query')).toBeNull();
+  });
+
+  it('control — the fresh reload finishing FIRST paints its rows, and the late stale answer changes nothing', async () => {
+    const { dataSource, finds } = makeDeferredDataSource();
+
+    render(<ObjectGantt schema={schemaWith()} dataSource={dataSource} />);
+
+    await waitFor(() => expect((dataSource.find as any).mock.calls.length).toBe(2));
+
+    // Out-of-order: the current reload #2 answers before the superseded #1.
+    await settle(finds[1], ROWS_B);
+
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeTruthy());
+    expect(screen.getByText('From the fresh query')).toBeTruthy();
+
+    // The late stale answer must neither clobber the data (the pre-existing
+    // `setData` guard) nor put the placeholder back.
+    await settle(finds[0], ROWS_A);
+    await flush();
+
+    expect(screen.getByTestId('gantt-view')).toBeTruthy();
+    expect(screen.getByText('From the fresh query')).toBeTruthy();
+    expect(screen.queryByText('From the stale query')).toBeNull();
+    expect(screen.queryByText(PLACEHOLDER)).toBeNull();
+  });
+
+  it('does not strand `refreshing` when a SILENT reload is superseded by a non-silent one', async () => {
+    const { dataSource, finds } = makeDeferredDataSource();
+
+    const { rerender } = render(<ObjectGantt schema={schemaWith()} dataSource={dataSource} />);
+
+    await waitFor(() => expect((dataSource.find as any).mock.calls.length).toBe(2));
+    await settle(finds[0], ROWS_A);
+    await settle(finds[1], ROWS_A);
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeTruthy());
+    expect(screen.getByTestId('gantt-view').getAttribute('data-refreshing')).toBe('false');
+
+    // Toolbar refresh → reload #3, silent: it owns `refreshing`, not `loading`.
+    fireEvent.click(screen.getByTestId('gv-refresh'));
+    await waitFor(() =>
+      expect(screen.getByTestId('gantt-view').getAttribute('data-refreshing')).toBe('true'),
+    );
+
+    // A filter change re-keys `reload` → reload #4, non-silent, superseding the
+    // silent one while it is still in flight. Different flag, same sequence.
+    rerender(<ObjectGantt schema={schemaWith({ status: 'open' })} dataSource={dataSource} />);
+    await waitFor(() => expect((dataSource.find as any).mock.calls.length).toBe(4));
+    expect(screen.getByText(PLACEHOLDER)).toBeTruthy();
+
+    // The superseded silent reload answers: it must touch neither flag.
+    await settle(finds[2], ROWS_A);
+    expect(screen.getByText(PLACEHOLDER)).toBeTruthy();
+
+    // The current reload answers. Nothing is in flight any more, so BOTH flags
+    // must be honest — a guard that only cleared `loading` here would leave the
+    // refresh button spinning forever.
+    await settle(finds[3], ROWS_B);
+
+    await waitFor(() => expect(screen.getByTestId('gantt-view')).toBeTruthy());
+    expect(screen.getByTestId('gantt-view').getAttribute('data-refreshing')).toBe('false');
+    expect(screen.getByText('From the fresh query')).toBeTruthy();
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -686,8 +686,24 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
         setError(err as Error);
       }
     } finally {
-      if (silent) setRefreshing(false);
-      else setLoading(false);
+      // Only the NEWEST reload owns the loading flags, for the same reason
+      // the result writes above are guarded. An unguarded clear here let a
+      // SUPERSEDED reload release the placeholder while the fresh query was
+      // still in flight, so the chart painted empty in between
+      // (objectui#7231).
+      //
+      // The current reload clears BOTH flags, not just the one its own
+      // `silent` mode set: reaching this point as the current run means
+      // nothing is in flight any more — a newer reload would have made this
+      // one stale, and an older one has no claim on the flags. Clearing only
+      // this run's own mode would strand the other one whenever the
+      // superseded reload ran in the OTHER mode (a silent toolbar refresh
+      // overtaken by a filter-change reload would leave `refreshing` on for
+      // the life of the component).
+      if (isCurrent()) {
+        setRefreshing(false);
+        setLoading(false);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- (rest as any).data intentionally untracked, matching the original effect
   }, [effectiveDataSource, resource, hasInlineData, dataProvider, dataItems, schema.filter, schema.sort, objectSchema]);


### PR DESCRIPTION
Fixes #7231

## The defect

`ObjectGantt`'s `reload()` sequences concurrent runs with `reloadSeqRef` and guards every result write with `isCurrent()` — `setData` on all three branches, `setError` on the error branch. Its `finally` carried no guard, so a **superseded** reload still flipped `loading` / `refreshing` off.

Note which ordering produces the symptom: not an exotic out-of-order response, but the plain one. The stale run only has to **finish first**, which is the ordinary case whenever a second reload is issued while the first is still in flight. The placeholder was released before any rows arrived and the chart painted empty until the fresh response landed. (The out-of-order case — fresh finishes first — is what the pre-existing `setData` guard already covered; it is kept below as a control.)

## The caller measurement the card asked for

The card's "Not measured" paragraph was the first task. Enumerating `reload()`'s call sites in `packages/plugin-gantt/src/ObjectGantt.tsx` (line numbers on this branch):

| Call site | Mode | What triggers it |
| --- | --- | --- |
| `:712` `useEffect(() => { reload(); }, [reload])` | non-silent | mount; and any change of `reload`'s identity — its deps at `:707` are `effectiveDataSource, resource, hasInlineData, dataProvider, dataItems, schema.filter, schema.sort, objectSchema`. So this one site is the card's *initial load*, *schema-resolution refire* and *view/filter change* callers. |
| `:1440` | silent | write-readback after a drag / resize / progress update |
| `:1484` | silent | write-readback after a dependency-link write |
| `:1585` | silent | write-readback after a delete |
| `:1753` | silent | toolbar refresh button (`onRefresh` on `GanttView`) |
| `:1820` | silent | write-readback after an inline edit in the record drawer |

Which pairs can actually overlap:

- **non-silent + non-silent — reachable, and the visible one.** `:712` re-fires against itself: `objectSchema` resolving mid-flight re-keys `reload`, and so does a host changing `schema.filter` / `schema.sort` / the bound object. `loading` is the flag that gates the placeholder at `:1596`, so this is the pair that blanks the chart. Reproduced in the harness (case 1 below). It is **not** confined to the two-queries regime: the filter/sort/object route re-keys `reload` with no schema read involved.
- **silent + silent — reachable.** Nothing serializes the write-readbacks and the toolbar refresh. Two quick inline edits, or a drag followed by a refresh click, overlap. No blanking here (they never touch `loading`), but the stale run used to drop `refreshing` while the fresh read was still outstanding, so the toolbar's `disabled` / `aria-busy` (`GanttView.tsx:3449`, `:3451`) went honest-to-lying mid-flight and the button accepted another click.
- **silent superseded by non-silent — reachable, and it decides the guard shape.** Every silent caller runs with the chart mounted (`loading === false`), and a filter/sort change or a late `objectSchema` can re-key `reload` at any moment.
- **non-silent superseded by silent — not reachable from this component.** Every silent caller sits behind the `if (loading) return placeholder` early return at `:1596`, so while a non-silent reload holds `loading` true there is no toolbar and no row handler mounted to fire one. Worth recording that the unguarded `finally` was itself the thing that opened this window: it released `loading` early and re-mounted the toolbar while the fresh query was still running.

So the defect is live on three distinct pairs, only one of which passes through schema resolution — which is the card's scoping fence, measured rather than assumed.

## The fix, and why it clears both flags

```ts
} finally {
  if (isCurrent()) {
    setRefreshing(false);
    setLoading(false);
  }
}
```

The obvious form — clear only the flag this run's own `silent` mode set — is wrong on the third pair above. The superseded silent run correctly skips its clear; the current non-silent run clears only `loading`; nobody ever clears `refreshing`, and the refresh button stays busy for the life of the component. Clearing both is the honest form because reaching this point *as the current run* means nothing is in flight any more: a newer reload would have made this one stale, and an older one has no claim on the flags. Case 3 pins that shape.

Checked, per the card's warning, that the fresh run always reaches its own `finally`:

- **error path** — `catch` then `finally`, both modes, always.
- **early `return` inside `try`** (host `data` prop at `:658`, inline `value` items at `:663`) — `finally` still runs.
- **abort** — no `AbortSignal` is passed to `effectiveDataSource.find()` anywhere in this file, so there is no cancel path whose promise never settles. A `find()` that never settles would strand `loading`, identically before and after this change.
- **unmount** — a `setState` after unmount is a no-op on this repo's React; unchanged here.

No path relied on the stale `finally` doing the clearing: `reload` increments `reloadSeqRef` as its first statement, so a newer sequence number always implies a newer run already inside its own `try`.

## Tests

New file `packages/plugin-gantt/src/ObjectGantt.staleReloadFinally-7231.test.tsx`. A data source hands back deferred `find()` promises so two reloads can be held in flight and completed in either order; `getObjectSchema` resolves immediately, which is what issues the second reload while the first is pending.

1. **the defect** — stale run finishes first: the placeholder must stay and no chart may render.
2. **control** — fresh run finishes first: its rows paint, and the late stale answer neither clobbers the data nor puts the placeholder back. Green on the unmodified tree, so case 1's failure is a measurement rather than a broken harness.
3. **guard shape** — a silent toolbar refresh superseded by a filter-change reload must not strand `refreshing`.

**Ablation** (run on the committed tree, guard reverted then restored):

- resolution path: the test reaches the subject through a **relative** import (`import { ObjectGantt } from './ObjectGantt'`), so the subject is the source module and no `dist/` is in the path — no rebuild leg applies.
- mutation proven on disk before measuring: anchor `if (isCurrent()) {` 2 occurrences to 1, injected `if (silent) setRefreshing(false);` 0 to 1, blob `c063fb2` to `cb81262`.
- ablated run: `Tests 1 failed | 2 passed (3)` — exactly case 1 red, both controls green.
- restore proven: blob back to `c063fb2` (byte-identical to the `HEAD` blob), `git diff HEAD` empty, anchor counts back to 2 / 0.

## Gates

All run on `529d546`, the final commit, with the worktree clean:

| Gate | Verdict line |
| --- | --- |
| `pnpm exec vitest run packages/plugin-gantt/` | `Test Files 57 passed (57)` · `Tests 451 passed (451)` |
| `pnpm --filter @object-ui/plugin-gantt run type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.test.json` — the second leg is what type-checks the new test file) |
| `check:control-bytes` | `check-control-bytes: OK (scanned 5998 tracked text file(s); skipped 85 binary).` |
| `check:vi-mock-specifiers` | `check-vi-mock-specifiers: OK (4128 tracked source file(s), 2398 test-named; 533 carry a mock; 782 relative specifier(s) resolved...)` |
| `check:vi-mock-inherit` | `check-vi-mock-inherit: OK (... 118 call site(s) on @object-ui/react judged (118 inherit, 0 auto-mocked) ...)` |
| `check:self-import` | `No package names itself inside its own src/.` |
| `check:phantom-deps` | `Every in-scope import is declared by the package that publishes it.` |
| `check-changeset-presence.mjs` | `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/7231-gantt-stale-reload-finally.md.` |
| `check-changeset-no-major.mjs` | `No changeset declares a major bump.` |

**Declared narrowing — eslint.** The repo-wide `pnpm lint` (`turbo run lint` over the 42 packages that define a `lint` script) is CI's run. Locally eslint ran over the touched package only — `eslint .` inside `packages/plugin-gantt`, which is exactly the unit turbo invokes for it. Three readings, so the narrowing is a measurement and not a skip:

1. **population** read from eslint's own resolution of `eslint.config.js` (its own walk and its own ignores), not from a guess about which files count;
2. **count** read from `--format json`: **87 files, 0 errors, 333 warnings** (the new test file contributes 10 warnings, in line with its siblings — `.github/workflows/lint.yml` deliberately sets no `--max-warnings`, so this gate is about errors);
3. **invariance for untouched files**: `eslint.config.js` declares no `parserOptions`, no `project` and no `projectService` anywhere, so no rule reads type information across files — every verdict is single-file. Every config block matches `**/*.{ts,tsx}` only, so the added `.changeset/*.md` is outside the linted set entirely. This diff therefore cannot move the verdict on any file it does not contain.

## Scope

Reload guard only. `packages/plugin-gantt/src/ObjectGantt.tsx` (the `finally` in the `reload()` closure), one new test beside it, one changeset. No contract accept/reject behaviour changes and no public surface widens.

Deliberately untouched, each queued or owned elsewhere: the `buildExpandFields(objectSchema?.fields)` projection site in this same file (that is #7230, which remains open and is queued behind this card); the paging / `$top` shape of the gantt fetch (#7210 remains open — its half 2 is a maintainer decision); and the schema-gating regime (#7225 and #6482 both remain open). Per the card, this is deliberately not folded into that gating work: a gate would hide the schema-resolution instance and leave the guard broken on the toolbar-refresh and write-readback pairs measured above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho

_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_