### PR TITLE
feat(types,components,plugin-grid): carry the staged row across the renderCellEditor seam as pendingRow

### DIFF
--- a/.changeset/7188-components-data-table-pending-row.md
+++ b/.changeset/7188-components-data-table-pending-row.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/components': minor
+---
+
+feat(data-table): pass `pendingRow` to the host cell editor — the row with its staged edits merged over it (#7188)
+
+`data-table` already computed each row's `pendingChanges` entry in the row loop that
+renders the editor; it now hands the injected editor that row merged with those staged
+values as `pendingRow`, next to the persisted `row`. Nothing about `row`, `value`,
+`stage`, `commit` or `cancel` changed. A host editor that scopes itself by a sibling
+field can read `pendingRow` and follow an edit the user has made but not yet saved.

--- a/.changeset/7188-plugin-grid-staged-parent-rescopes-child.md
+++ b/.changeset/7188-plugin-grid-staged-parent-rescopes-child.md
@@ -1,0 +1,14 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+Fix: a `dependsOn` lookup edited inline follows a parent edited in the same row **before**
+it is saved (#7188, finishing #7165).
+
+#7165 shipped an explicitly-labelled interim: the grid's inline editor scoped a
+`dependsOn` picker by `ctx.row`, the **saved** record. Edit the parent cell, do not save,
+open the child — and the child still listed candidates for the parent's persisted value
+(or stayed gated if that value was empty). The grid now scopes by `ctx.pendingRow ?? ctx.row`,
+where `pendingRow` is the row merged with its staged, unsaved edits, so picking a parent
+re-scopes the child immediately — the form's live-record semantics from #2216. The interim
+marker that named #7188 is gone with the interim.

--- a/.changeset/7188-types-render-cell-editor-pending-row.md
+++ b/.changeset/7188-types-render-cell-editor-pending-row.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/types': minor
+---
+
+feat(types): `renderCellEditor`'s context gains `pendingRow` — the persisted row merged with its staged, unsaved edits (#7188)
+
+The inline cell editor's context on `DataTableSchema` (declared by #6882) carried the row
+once, as `row` — the **persisted** record. A widget that scopes itself by a sibling field
+(a `dependsOn` lookup) had no way to see a parent that was edited in the same row but not
+yet saved, so it kept listing candidates for the old parent.
+
+The context now carries the row twice, deliberately:
+
+- `row` — unchanged: the persisted record, what the data source last returned.
+- `pendingRow` — **new**: `row` shallow-merged with the row's staged, unsaved edits. The
+  same object as `row` when nothing is staged.
+
+`row` was **not** redefined to mean the merged record — that would silently change an
+already-published member, and a host that needs the persisted value would have lost its
+only source. Both are addressable. The zod mirror's `renderCellEditor` is `z.function()`
+and encodes no parameter shape; its description records the delta and names the member
+on `DataTableSchema` as the authority. The #6882 exact-shape pin was extended (not
+weakened) in the same change, with a control proving the pin can tell the seventh member's
+presence from its absence.

--- a/content/docs/components/complex/data-table.mdx
+++ b/content/docs/components/complex/data-table.mdx
@@ -49,7 +49,8 @@ interface DataTableSchema {
   singleClickEdit?: boolean;             // Enter edit mode on single click (default: false)
   renderCellEditor?: (ctx: {             // Host-supplied editor widget; null -> built-in input
     column: any;
-    row: any;
+    row: any;                            // the persisted record
+    pendingRow: any;                     // row + this row's staged, unsaved edits (#7188)
     value: any;
     stage: (v: any) => void;
     commit: (v?: any) => void;
@@ -123,6 +124,13 @@ The returned node is wrapped by the table so it inherits the exit-edit
 affordances the built-in editors have: Enter commits from a single-line input,
 Escape cancels, and a click outside commits. Use `stage` to record a value while
 staying in edit mode, `commit` to save, and `cancel` to discard.
+
+The context carries the row twice, on purpose: `row` is the persisted record, and
+`pendingRow` is that record with the row's staged, unsaved edits merged over it
+(the same object as `row` when nothing is staged). A widget that scopes itself by
+a sibling field — a `dependsOn` lookup — should read `pendingRow`, so a parent
+edited in the same row re-scopes the child before anything is saved; `row` stays
+the place to read what the data source last returned.
 
 ## Examples
 

--- a/packages/components/src/renderers/complex/data-table.tsx
+++ b/packages/components/src/renderers/complex/data-table.tsx
@@ -981,6 +981,33 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   const [editValue, setEditValue] = useState<any>('');
   // Track pending changes for multi-cell editing: rowIndex -> { columnKey -> newValue }
   const [pendingChanges, setPendingChanges] = useState<Map<number, Record<string, any>>>(new Map());
+
+  // objectui#7188 — the row merged with its STAGED edits, handed to the host
+  // editor as `pendingRow` next to the persisted `row`. Cached per row object
+  // and rebuilt whenever `pendingChanges` is replaced (every stage / save /
+  // cancel builds a new Map), so the merged record keeps its IDENTITY across
+  // renders that stage nothing. That matters: `LookupField` keys its
+  // `dependentFilter` / `popoverFilter` memos on the identity of the record it
+  // is handed, and its recent-ids effect keys on `popoverFilter`, so a fresh
+  // object per render would re-issue that query on every table re-render while
+  // the picker is open (`useRecordQuery` itself is immune — it keys on a JSON
+  // signature). `row` is identity-stable for the same reason; a row with
+  // nothing staged is handed `row` itself.
+  const pendingRows = useMemo(() => {
+    const byRow = new WeakMap<object, any>();
+    return {
+      /** `row` merged with its staged edits — or `row` itself when it has none. */
+      of(row: any, rowIndex: number): any {
+        const changes = pendingChanges.get(rowIndex);
+        if (!changes || row === null || typeof row !== 'object') return row;
+        const hit = byRow.get(row);
+        if (hit !== undefined) return hit;
+        const merged = { ...row, ...changes };
+        byRow.set(row, merged);
+        return merged;
+      },
+    };
+  }, [pendingChanges]);
   const [isSaving, setIsSaving] = useState(false);
   // Last save failure message (server validation text, etc.) shown in the
   // toolbar; null when the last save attempt succeeded or nothing's been saved.
@@ -1025,8 +1052,8 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
   //
   // The listener is still needed, for a different reason: NOTHING EVER HANDS
   // THE WIDGET ONE. The wrapper below carries `onKeyDown` alone, and the
-  // context object `renderCellEditor` receives — `{ column, row, value, stage,
-  // commit, cancel }` — has no DOM-props slot to put an `onBlur` in.
+  // context object `renderCellEditor` receives — `{ column, row, pendingRow,
+  // value, stage, commit, cancel }` — has no DOM-props slot to put an `onBlur` in.
   //
   // ⚠️ The second half of that reason is GONE (objectui#6909). The in-repo
   // factory behind the seam, `@object-ui/fields`' `FieldEditWidget`, used to
@@ -2320,6 +2347,12 @@ const DataTableRenderer = ({ schema }: { schema: DataTableSchema }) => {
                                   const node = injectEditor({
                                     column: col,
                                     row,
+                                    // The persisted row with this row's staged,
+                                    // unsaved edits merged over it (objectui#7188);
+                                    // the SAME object as `row` when nothing is
+                                    // staged, so `row === pendingRow` reads as
+                                    // "clean" on the host side.
+                                    pendingRow: rowHasChanges ? pendingRows.of(row, rowIndex) : row,
                                     value: editValue,
                                     stage: stageEdit,
                                     commit: (v?: any) => saveEdit(true, v),

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -860,11 +860,16 @@ export type ObjectGridDataTableSchemaHolds = {
    * REDUNDANT since objectui#6882 (2026-08-30) — `DataTableSchema` declares this
    * key itself now, with a shape measured `Equal` to this one. `data-table`
    * calls it to render a host cell editor; returning `null` falls through to the
-   * built-in text / number / date inputs.
+   * built-in text / number / date inputs. objectui#7188 added `pendingRow` (the
+   * persisted `row` merged with the row's staged, unsaved edits) upstream, and
+   * this copy carries it too so the seam's intersection stays INERT — `Equal`
+   * in both directions, as #7196 measured — rather than becoming a second,
+   * narrower signature that a `pendingRow`-reading host would trip on.
    */
   renderCellEditor?: (ctx: {
     column: any;
     row: any;
+    pendingRow: any;
     value: any;
     stage: (v: any) => void;
     commit: (v?: any) => void;
@@ -4015,7 +4020,7 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
     // handing DataTable an editor factory would leave the built-in fallback
     // editors as the only reachable ones if any future path re-opened the mode.
     renderCellEditor: inlineEditable
-      ? (ctx: { column: any; row: any; value: any; stage: (v: any) => void; commit: (v?: any) => void }) => {
+      ? (ctx: { column: any; row: any; pendingRow: any; value: any; stage: (v: any) => void; commit: (v?: any) => void }) => {
           const fieldDef = (objectSchema as any)?.fields?.[ctx.column?.accessorKey];
           if (!fieldDef || !hasFieldEditWidget(fieldDef.type)) return null;
           const discrete = DISCRETE_EDIT_TYPES.has(fieldDef.type);
@@ -4035,50 +4040,35 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
               field={field}
               value={ctx.value}
               onChange={(v: any) => (discrete ? ctx.commit(v) : ctx.stage(v))}
-              // ⚠️ INTERIM (objectui#7165) — the SAVED row, not the staged one.
+              // The record a dependent widget scopes itself by (objectui#7165,
+              // finished by objectui#7188). `LookupField` resolves
+              // `dependentValues ?? ctx.formValues ?? ctx.data ?? {}`, and only
+              // the FIRST link is suppliable by any host: `SchemaRendererContextType`
+              // declares exactly `dataSource` / `debug` / `debugFlags` / `apiFetch`,
+              // so the tail is unconditionally empty repo-wide (objectui#7206) —
+              // which is why the repair is this prop and could not have been a
+              // provider. A grid that supplied none of the three rendered every
+              // `dependsOn` column as a permanently gated, disabled trigger
+              // ("Select region first") even when the row carried the parent —
+              // a field that could never be filled, with no diagnostic. PR
+              // objectui#2216 gave the FORM renderer exactly this injection (its
+              // LIVE watched record); the other half — every picker taking the
+              // `dependsOn` chain as a hard `baseFilter` — is host-independent
+              // and was already live here, so this line supplies a missing INPUT
+              // and re-implements no cascade.
               //
-              // The record a dependent widget scopes itself by. `LookupField`
-              // resolves `dependentValues ?? ctx.formValues ?? ctx.data ?? {}`
-              // and this grid supplied NONE of the three, so the resolved record
-              // was `{}` for every row. ⚠️ Only the FIRST link was ever
-              // suppliable, by this host or any other:
-              // `SchemaRendererContextType` declares exactly `dataSource` /
-              // `debug` / `debugFlags` / `apiFetch`, so the tail is
-              // unconditionally empty repo-wide (objectui#7206). That is why the
-              // repair has to be this prop and could not have been a provider. A column declaring `dependsOn` therefore
-              // rendered a permanently gated, disabled trigger ("Select region
-              // first") even when the row carried the parent value — a field
-              // that could never be filled, with no diagnostic. PR objectui#2216
-              // gave the FORM renderer exactly this injection (its live watched
-              // record); only that half was per-host, and the grid never got it.
-              // The other half — every picker taking the `dependsOn` chain as a
-              // hard `baseFilter` — is host-independent and was already live
-              // here, so this line supplies a missing INPUT and re-implements no
-              // cascade.
-              //
-              // ⛔ WHAT IS STILL WRONG, precisely: `ctx.row` is the PERSISTED
-              // record. A parent edited but NOT YET SAVED in this same row does
-              // not re-scope the child — the picker keeps listing candidates for
-              // the parent's saved value, and stays gated if that saved value is
-              // empty. objectui#2215's form fix was explicitly the LIVE record,
-              // so picking a parent re-scopes the child immediately. Matching
-              // that is objectui#7188, and it is the finished shape.
-              //
-              // Why the interim ships instead of the finished shape: the staged
-              // values live in `data-table`'s `pendingChanges` — in scope at the
-              // call site, so this is not a plumbing problem — and carrying them
-              // across needs a SEVENTH member on `renderCellEditor`'s context.
-              // `@object-ui/types` declares that context (objectui#6882,
-              // maintainer ruling 2026-08-30, replacing a `(schema as any)` cast)
-              // and pins its shape by EXACT type equality. That is a
-              // published-surface contract change with its own review floor, so
-              // it belongs to objectui#7188, not to this line.
-              //
-              // ⛔ Do NOT read this as settled. "Never fillable" → "scoped by
-              // the saved parent" is strictly better and strictly not finished;
-              // whether the user should be TOLD the scope came from the saved row
-              // is an OPEN question on objectui#7188, not a closed one.
-              dependentValues={ctx.row}
+              // `pendingRow` is the PERSISTED row shallow-merged with this row's
+              // STAGED, unsaved edits (`data-table` builds it from its
+              // `pendingChanges`), so a parent edited in the same row re-scopes
+              // the child before anything is saved — the form's semantics.
+              // `ctx.row` alone was #7165's interim and scoped by the SAVED
+              // parent. `pendingRow` is a REQUIRED member of the declared
+              // context (`@object-ui/types`, objectui#6882 + #7188), so the
+              // `?? ctx.row` never selects for a conforming host; it is spelled
+              // so a context handed to this factory WITHOUT it degrades to the
+              // saved-row scoping rather than to `{}` — gated forever — and it
+              // is the spelling objectui#7188's ruling chose.
+              dependentValues={ctx.pendingRow ?? ctx.row}
             />
           );
         }

--- a/packages/plugin-grid/src/__tests__/gridDependentValues-7165.test.tsx
+++ b/packages/plugin-grid/src/__tests__/gridDependentValues-7165.test.tsx
@@ -29,21 +29,22 @@
  * re-implements no cascade, and `test 2` below is what proves that distinction
  * rather than asserting it.
  *
- * ## ⚠️ INTERIM — this ships option A, and option A is not the conclusion
+ * ## objectui#7188 — the STAGED record crosses the seam too (option B)
  *
- * `renderCellEditor` now passes `dependentValues={ctx.row}`, and `ctx.row` is
- * the SAVED record. A parent edited but not yet saved in the same row does not
- * re-scope the child. That is strictly better than a field that can never be
- * filled and strictly not finished — the form's answer to objectui#2215 was the
- * LIVE record. Carrying the staged record needs a seventh member on
- * `renderCellEditor`'s context, which `@object-ui/types` declares (objectui#6882,
- * maintainer ruling 2026-08-30) and pins by EXACT type equality — a
- * published-surface contract change, filed as objectui#7188.
+ * objectui#7165 shipped option A as a labelled interim: `dependentValues={ctx.row}`,
+ * the SAVED record, so a parent edited but not yet saved in the same row did
+ * not re-scope the child — strictly better than never fillable, strictly not
+ * the form's answer to objectui#2215 (the LIVE record). objectui#7188 finished
+ * it: `renderCellEditor`'s context (declared by objectui#6882, pinned by exact
+ * type equality in `@object-ui/types`) gained a seventh member, `pendingRow` —
+ * the persisted row shallow-merged with the row's `pendingChanges` entry — and
+ * the grid scopes by `ctx.pendingRow ?? ctx.row`.
  *
- * ⭐ `test 4` pins that staleness AS CURRENT BEHAVIOUR, with its own proof that
- * the staging actually happened (otherwise "still scoped by north" is true for
- * the trivial reason that nothing was ever staged). objectui#7188 flips it, and
- * it is the assertion that fails if someone later "simplifies" B back to A.
+ * ⭐ `test 4` is the assertion only B can pass and tests 1–3 cannot see: their
+ * rows carry no staged edits, so `pendingRow` and `row` coincide there. It
+ * carries its own proof that the staging happened AND that nothing was saved
+ * (otherwise "scoped by south" could be true because the parent was persisted),
+ * and it is the test that goes RED if anyone later "simplifies" B back to A.
  *
  * ## Why every test carries a live control
  *
@@ -245,12 +246,16 @@ describe('objectui#7165 — the grid feeds the inline editor its row as dependen
     expect(openTrigger.disabled).toBe(false);
   });
 
-  it('4 — ⚠️ INTERIM (objectui#7188): a STAGED parent does NOT re-scope the child', async () => {
-    // ⛔ This pins what option A gets WRONG, as current behaviour. `ctx.row` is
-    // the SAVED record, so staging `region: 'south'` in this same row leaves the
-    // child scoped by the persisted `'north'`. objectui#7188 carries the staged
-    // record across the `renderCellEditor` seam and flips this test; until then
-    // the staleness is written down rather than left to be discovered.
+  it('4 — ⭐ objectui#7188: a STAGED parent re-scopes the child before anything is saved', async () => {
+    // Under option A (objectui#7165) this test pinned the OPPOSITE as current
+    // behaviour: `dependentValues={ctx.row}` is the SAVED record, so staging
+    // `region: 'south'` in this same row left the child scoped by the persisted
+    // 'north'. objectui#7188 carries the staged record across the seam —
+    // `data-table` passes `pendingRow` (the row merged with its `pendingChanges`
+    // entry) and the grid scopes by `ctx.pendingRow ?? ctx.row` — so this is
+    // the assertion that goes RED if anyone "simplifies" B back to A. Tests 1–3
+    // cannot see that regression: their rows carry no staged edits, so
+    // `pendingRow` and `row` coincide there.
     const rows = [ROW_NORTH];
     const ds = makeDataSource(rows);
     const { container } = renderGrid(ds, rows);
@@ -271,20 +276,25 @@ describe('objectui#7165 — the grid feeds the inline editor its row as dependen
     // Open the child. Clicking another cell moves the edit; the staged value
     // stays in `pendingChanges`.
     fireEvent.click(await openEditor(cellAt(container, 0, 3)));
-    await waitFor(() => expect(screen.getByText('Person 01')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Person 07')).toBeInTheDocument());
 
-    // ⭐ PROOF THE STAGING LANDED — without it this test passes for the trivial
-    // reason that nothing was ever staged. The region cell renders its PENDING
-    // value ('south') while the saved record still says 'north'.
+    // ⭐ PROOF THE STAGING LANDED AND NOTHING WAS SAVED. Without the first half
+    // this test could pass for a trivial reason (nothing staged, the saved
+    // parent honoured as in test 2); without the second, a save would make the
+    // staged and persisted parents coincide and the test could not tell A from
+    // B. The region cell renders its PENDING value ('south') while the saved
+    // record still says 'north' and the data source saw no write.
     await waitFor(() => {
       expect(cellAt(container, 0, 1).textContent).toMatch(/south/);
     });
     expect(rows[0].region).toBe('north');
+    expect(ds.update).not.toHaveBeenCalled();
 
-    // The interim's staleness: scoped by the SAVED 'north', not the staged
-    // 'south'. Person 01 is north (offered); Person 07 is south (not offered).
-    expect(screen.queryByText('Person 07')).not.toBeInTheDocument();
-    expect(ds.refQueries.some((q: any) => q?.$filter?.region === 'north')).toBe(true);
-    expect(ds.refQueries.some((q: any) => q?.$filter?.region === 'south')).toBe(false);
+    // Scoped by the STAGED 'south', not the saved 'north': Person 07 is south
+    // (offered); Person 01 is north (not offered). The query carried the staged
+    // value as its hard `$filter`, and the persisted value never reached it.
+    expect(screen.queryByText('Person 01')).not.toBeInTheDocument();
+    expect(ds.refQueries.some((q: any) => q?.$filter?.region === 'south')).toBe(true);
+    expect(ds.refQueries.some((q: any) => q?.$filter?.region === 'north')).toBe(false);
   });
 });

--- a/packages/plugin-grid/src/__tests__/lookupPickerKeys-7154.test.tsx
+++ b/packages/plugin-grid/src/__tests__/lookupPickerKeys-7154.test.tsx
@@ -74,15 +74,17 @@
  * editor supplied none of the three, so the resolved record was `{}` for every
  * row and the gate never lifted — a field that could never be filled.
  *
- * objectui#7165 supplies the missing input: `renderCellEditor` now passes
- * `dependentValues={ctx.row}`. The cascade itself is unchanged (half 2 was
- * always live here), which is why this case needs no new data source.
+ * objectui#7165 supplied the missing input: `renderCellEditor` passes the row as
+ * `dependentValues`. The cascade itself is unchanged (half 2 was always live
+ * here), which is why this case needs no new data source.
  *
- * ⚠️ INTERIM — `ctx.row` is the SAVED record, so a parent edited but not yet
- * saved in the same row does not re-scope the child. Carrying the staged record
- * needs a seventh member on `renderCellEditor`'s published context type, which
- * is objectui#7188. That staleness is pinned — deliberately, as the current
- * behaviour — in `gridDependentValues-7165.test.tsx`, not here.
+ * objectui#7188 then carried the STAGED record across the seam too: the context
+ * gained `pendingRow` (the persisted row merged with the row's unsaved edits)
+ * and the grid scopes by `ctx.pendingRow ?? ctx.row`, so a parent edited but
+ * not yet saved in the same row re-scopes the child. That case is pinned in
+ * `gridDependentValues-7165.test.tsx` (test 4), not here: this file's rows
+ * carry no staged edits, so `pendingRow` and `row` are the same object for
+ * every assertion below.
  */
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
@@ -334,9 +336,10 @@ describe('objectui#7154 — the four picker keys reach the grid’s inline picke
     // Declared `dependsOn: ['region']`. ⭐ UPDATED BY objectui#7165 — this used
     // to assert `lookup-trigger-gated` / `disabled === true`, which pinned the
     // defect: the grid fed the widget NO dependent values, so the gate could
-    // never lift however the row was filled. The grid now passes
-    // `dependentValues={ctx.row}`, the row carries `region: 'north'`, so the
-    // dependency is satisfied and the picker is an ordinary usable trigger.
+    // never lift however the row was filled. The grid now passes the row as
+    // `dependentValues` (`ctx.pendingRow ?? ctx.row` since objectui#7188; nothing
+    // is staged here, so that IS the row), the row carries `region: 'north'`, so
+    // the dependency is satisfied and the picker is an ordinary usable trigger.
     //
     // The key still ARRIVES off the field def — which is this file's whole
     // claim — and the proof is no longer the gate but the SCOPING asserted

--- a/packages/types/src/__tests__/data-table-declared-keys-6882.test.ts
+++ b/packages/types/src/__tests__/data-table-declared-keys-6882.test.ts
@@ -104,10 +104,19 @@ type _CellClassNameIsDeclared = Expect<IsDeclaredOn<'cellClassName'>>;
  * transcribed from its call site. Declaring the key with any other shape is a
  * different (and false) statement about the renderer, so the shape is pinned,
  * not just the membership.
+ *
+ * objectui#7188 added a SEVENTH member, `pendingRow` — the persisted `row`
+ * shallow-merged with the row's staged, unsaved edits — so a `dependsOn`
+ * widget can scope itself by a parent edited in the same row before it is
+ * saved. `row` keeps meaning the persisted record. This pin went red on that
+ * change by design (it is an `Equal`, not an `extends`) and was EXTENDED in the
+ * same change, not weakened; `_SixMemberShapeIsRefused` below is the proof that
+ * the instrument can tell the seventh member's presence from its absence.
  */
 type CellEditorContext = {
   column: any;
   row: any;
+  pendingRow: any;
   value: any;
   stage: (v: any) => void;
   commit: (v?: any) => void;
@@ -120,6 +129,19 @@ type _RenderCellEditorShape = Expect<
     ((ctx: CellEditorContext) => React.ReactNode) | undefined
   >
 >;
+
+/** The six-member context objectui#6882 pinned — a CONTROL now, not the shape. */
+type CellEditorContextBefore7188 = {
+  column: any;
+  row: any;
+  value: any;
+  stage: (v: any) => void;
+  commit: (v?: any) => void;
+  cancel: () => void;
+};
+
+// @ts-expect-error objectui#7188 — the pre-#7188 six-member context must NOT read as equal to the declared shape. If it did, `Equal` could not see the seventh member and the pin above would be vacuous for exactly the change it was extended for. (One line: the directive covers only the next line, and `tsc` reports the constraint failure on the `Expect<…>` argument.)
+type _SixMemberShapeIsRefused = Expect<Equal<Declared<DataTableSchema>['renderCellEditor'], ((ctx: CellEditorContextBefore7188) => React.ReactNode) | undefined>>;
 
 /** Matches `TableColumn.cellClassName` and `BaseSchema.className` — both `string`. */
 type _CellClassNameShape = Expect<Equal<Declared<DataTableSchema>['cellClassName'], string | undefined>>;
@@ -137,7 +159,9 @@ describe('objectui#6882 — DataTableSchema declares the two keys data-table rea
       columns: [{ header: 'Name', accessorKey: 'name' }],
       data: [],
       cellClassName: 'px-3 py-1',
-      renderCellEditor: ({ value }) => (value == null ? null : null),
+      // `pendingRow` is addressable next to `row` (objectui#7188) — destructured
+      // here so an author reaching for it compiles against the declaration.
+      renderCellEditor: ({ value, row, pendingRow }) => (value == null && row === pendingRow ? null : null),
     };
 
     expect(authored.cellClassName).toBe('px-3 py-1');

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -963,10 +963,26 @@ export interface DataTableSchema extends BaseSchema {
    * did so through a `(schema as any)` cast, which existed for no reason other
    * than this declaration's absence and is gone with it. Nothing new runs; a
    * misspelling is now caught at authoring time instead of failing silently.
+   *
+   * The context carries the row TWICE, deliberately (objectui#7188): `row` is
+   * the PERSISTED record and `pendingRow` is that record with the row's
+   * staged-but-unsaved edits merged over it. A widget that scopes itself by a
+   * sibling field (a `dependsOn` lookup) wants the staged one, so picking a
+   * parent re-scopes the child before anything is saved — the form's
+   * live-record semantics (PR objectui#2216). `row` was NOT redefined to mean
+   * the merged record: that would silently change an already-published member,
+   * and a host that needs the persisted value would have lost its only source.
    */
   renderCellEditor?: (ctx: {
     column: any;
+    /** The PERSISTED record — what the data source last returned for this row. */
     row: any;
+    /**
+     * `row` shallow-merged with this row's staged, unsaved edits (the table's
+     * `pendingChanges` entry). The same object as `row` when nothing is staged.
+     * The record a dependent widget should scope itself by (objectui#7188).
+     */
+    pendingRow: any;
     value: any;
     stage: (v: any) => void;
     commit: (v?: any) => void;

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -267,7 +267,7 @@ export const DataTableSchema = BaseSchema.extend({
   onSelectionChange: z.function().optional().describe('Selection change handler'),
   onColumnsReorder: z.function().optional().describe('Column reorder handler'),
   cellClassName: z.string().optional().describe('Extra classes folded into the utility body cells only — the selection, row-number and row-actions cells; data cells fold the per-column `cellClassName` instead, so row density has to be set on both (objectui#6882)'),
-  renderCellEditor: z.function().optional().describe('Host-supplied inline cell editor; returning null falls through to the built-in text/number/date inputs (objectui#6882)'),
+  renderCellEditor: z.function().optional().describe('Host-supplied inline cell editor; returning null falls through to the built-in text/number/date inputs (objectui#6882). Its context carries `row` (the persisted record) and `pendingRow` (that record with the row\'s staged, unsaved edits merged over it — objectui#7188); `z.function()` encodes no parameter shape, so the member on `DataTableSchema` is the authority for it'),
   frozenColumns: z.number().optional().describe('Number of frozen columns'),
   showRowNumbers: z.boolean().optional().describe('Show row numbers'),
   emptyAction: SchemaNodeSchema.optional().describe('Optional schema node rendered inside the empty-state, e.g. an "Add record" button. Lets the empty state become an actionable invitation rather than a dead end.'),


### PR DESCRIPTION
Fixes #7188

Option B of the A/B split ruled on #7165 (comment 5491922231); #7165 remains open — its closure is the PM's, after landing. **Clause-②**: this widens a published, exactly-pinned context on `DataTableSchema` (`@object-ui/types`), ruled at tier in #7188 comment 5502616875 and carried unchanged.

## The contract delta

`DataTableSchema.renderCellEditor`'s context, `packages/types/src/data-display.ts`:

| | before | after |
|---|---|---|
| members | `column`, `row`, `value`, `stage`, `commit`, `cancel` | `column`, `row`, **`pendingRow`**, `value`, `stage`, `commit`, `cancel` |
| `row` | the persisted record | **unchanged** — the persisted record |
| `pendingRow` | — | `row` shallow-merged with the row's staged, unsaved edits (its `pendingChanges` entry); the SAME object as `row` when nothing is staged |

- **Why `row` was not redefined.** Making `row` mean the merged record would be a silent semantic change to an already-published member — the option that passes review by looking smaller — and a host that needs the persisted value would lose its only source. Both are addressable; neither is redefined. (The card's reasoning; the tier ruling adopted it.)
- **`pendingRow` is required, not optional**, because `data-table` always passes it — the pin's principle is "transcribed from the call site".
- **Zod mirror** (`packages/types/src/zod/data-display.zod.ts:270`): `renderCellEditor: z.function().optional()` — it encodes no parameter shape, so there is no ctx member to mirror. The only zod-side delta is the `.describe()` text, which now records the two-row semantics and names the member on `DataTableSchema` as the authority. `zod-mirror-parity` is about key membership and is unaffected.
- **The #6882 exact-shape pin** (`data-table-declared-keys-6882.test.ts`) went red on the seventh member by design and was **extended**, not weakened: `CellEditorContext` gains `pendingRow`; the `Equal` (not `extends`) form and the stated reason are kept; a new direction proof `_SixMemberShapeIsRefused` (`@ts-expect-error` on the six-member shape) proves the instrument can tell the seventh member's presence from its absence. Leg B of the ablation shows the exact red.

## Producer — `packages/components/src/renderers/complex/data-table.tsx`

`injectEditor({ column, row, pendingRow: rowHasChanges ? pendingRows.of(row, rowIndex) : row, value, stage, commit, cancel })`. The ruled expression was `rowHasChanges ? { ...row, ...rowChanges } : row`; the values are identical, but the merged object is **cached per row object and rebuilt only when `pendingChanges` is replaced** (every stage / save / cancel builds a new Map). Measured reason: `LookupField` keys its `dependentFilter` → `popoverFilter` memos on the identity of the record it is handed, and its recent-ids `useEffect` keys on `popoverFilter`, so a fresh object per render would re-issue that query on every table re-render while the picker is open (`useRecordQuery` itself is immune — it keys on a JSON `filterSignature`). `row` is identity-stable for the same reason. Implementation detail beneath the contract; the member and its semantics are exactly as ruled.

## Consumer — `packages/plugin-grid/src/ObjectGrid.tsx`

- `dependentValues={ctx.pendingRow ?? ctx.row}` (the ruled spelling). `pendingRow` is a required member, so the `??` never selects for a conforming host; it is spelled so a context handed to this factory without it degrades to #7165's saved-row scoping rather than to `{}` (gated forever). Not a second contract — the comment on the line says so.
- **#7165's interim block is deleted** (44 lines, from the INTERIM header to the prop). The facts it carried that are still load-bearing — why the repair is a prop and could not have been a provider (#7206); half 1 / half 2 of PR #2216 — are kept in a shorter comment with no INTERIM / open-question language.
- The callback's explicit ctx annotation gains `pendingRow: any`.
- `ObjectGridDataTableSchemaHolds.renderCellEditor` (the local copy #7196 measured as redundant and `Equal` to upstream) carries `pendingRow` too, so the seam's intersection stays inert — `Equal` in both directions — instead of becoming a second, narrower signature. Its deletion remains #7196's separate card. Nothing here touches grouping (#7217 is queued behind this on the same file).

## The assertion B adds — `gridDependentValues-7165.test.tsx`, test 4

Edit the parent cell (`region` → `south`), do **not** save, open the child picker. Asserts: Person 07 (south) offered, Person 01 (north) not; the query carried `$filter.region === 'south'` and never `'north'`; the region cell renders the pending `south` while `rows[0].region` is still `north` and `ds.update` was never called (so the staged and persisted parents cannot coincide). Tests 1–3 and the `lookupPickerKeys-7154` suite are the live controls — their rows carry no staged edits, so `pendingRow` and `row` coincide there; they stay green under both A and B, which is why they cannot see the regression and test 4 can.

## Ablation — after commit `d20e5c4`; both legs restored via `git checkout HEAD --`, proven by blob hash = HEAD blob and empty `git diff HEAD`

- **Leg A** — `ObjectGrid.tsx` back to `dependentValues={ctx.row}` (mutation proven on disk: B-line count 1→0, A-line 0→1, blob hash ≠ HEAD): `Tests 1 failed | 8 passed (9)` — exactly test 4 (`× 4 — ⭐ objectui#7188: a STAGED parent re-scopes the child…`) red; tests 1–3 and all 7154 tests green. No dist rebuild is involved: the root `vitest.config.mts` aliases `@object-ui/types` / `components` / `fields` / `react` / `plugin-grid` to `src` (lines 281–288), so the suite reads the mutated source directly.
- **Leg B** — remove `pendingRow: any;` from the declared ctx (member count 1→0, blob hash ≠ HEAD): `tsc -p tsconfig.test.json` in `packages/types` exits 2 with `(127,3) TS2344` on `_RenderCellEditorShape`, `(143,1) TS2578: Unused '@ts-expect-error' directive` on `_SixMemberShapeIsRefused`, and `(164,40) TS2339: Property 'pendingRow' does not exist` on the authoring example. Direction: red, as predicted; the control directive flips exactly as designed.

## Census of `renderCellEditor` ctx readers

Grep over the whole tree excluding `node_modules` / `dist`, control term `ctx.row` hit (in `app-shell/resolveActionParams.ts` — a different ctx — and in `plugin-grid`). `examples/`, `apps/`, `plugin-dashboard`, `plugin-detail`, `app-shell`: **no reader**.

| reader | members read | effect of the additive member |
|---|---|---|
| `packages/plugin-grid/src/ObjectGrid.tsx` — the only production consumer | `column`, `row`, `value`, `stage`, `commit`, now `pendingRow` | updated here |
| `packages/components/src/renderers/complex/data-table.tsx` | producer of the ctx | updated here |
| `packages/components/src/__tests__/data-table-injected-editor-focus-6859.test.tsx` — `stagingEditor({ column, value, stage })` | three | unaffected, green |
| `packages/components/src/__tests__/data-table-inline-edit.test.tsx:192` — `({ column, stage })` | two | unaffected, green |
| `packages/plugin-grid/src/__tests__/dataTableSchemaSlot-6459.test.ts:158` — `(ctx) => ctx.column` | one, contextually typed from the seam intersection | unaffected, compiles (the hold copy kept `Equal`) |
| `packages/types/src/__tests__/data-table-declared-keys-6882.test.ts` | the pin | extended here |
| `content/docs/components/complex/data-table.mdx:50` | the documented ctx | updated here |

## One file outside the dispatched surface — declared

`content/docs/components/complex/data-table.mdx` (+9/−1): the published documentation of exactly this ctx listed six members. AGENTS.md Commandment #2 (docs reflect the code) is binding, and leaving it would ship documentation that contradicts the type it documents. Drop the hunk if the PM prefers it filed separately.

## Verification on `d20e5c4` (the pushed head)

- build: `pnpm --filter @object-ui/components --filter @object-ui/plugin-grid build` (prebuild rebuilt `types` / `core` / `react`) — green; `type-check` for `@object-ui/types`, `@object-ui/components`, `@object-ui/plugin-grid` (each `tsc --noEmit && tsc -p tsconfig.test.json`; types also `tsconfig.examples.json`) — zero diagnostics; `--listFiles` confirms the 6882 pin (1) and the 6459 + 7165 files (2) are in their `tsconfig.test.json` programs. Lock verdict line: `os-verify-lock: VERDICT command-exit 0`.
- vitest, root-relative, 7 files (the two grid fixtures, the 6882 pin, the 6459 slot pin, `data-table-inline-edit`, `data-table-injected-editor-focus-6859`, `inlineEditLookupRepro`): `Test Files 7 passed (7)` / `Tests 31 passed (31)`.
- gates green: `check-changeset-presence` (3 changesets for 3 released packages), `check-changeset-no-major`, `check:control-bytes`, `check:spec-symbols`, `check:doc-types`, `check:doc-fences`, `check-doc-links`, `check:dist-completeness`; eslint on the seven changed ts/tsx files — 0 errors.
- NOT measured locally (precondition exit 2 — they need the full-farm / console build; CI owns them): `check:sdui-registration-pins`, `check:eager-closure`, `check:doc-snippets`, `check:readme-exports`. This diff touches no registration and no README, and the `data-table.mdx` snippet is a `plaintext` fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_