### PR TITLE
docs(types): widget.ts anchors describe the retired spec WidgetManifest/WidgetSource as history

### DIFF
--- a/.changeset/5213-widget-ts-retired-spec-anchor-history.md
+++ b/.changeset/5213-widget-ts-retired-spec-anchor-history.md
@@ -1,0 +1,46 @@
+---
+'@object-ui/types': patch
+---
+
+`RuntimeWidgetManifest` / `RuntimeWidgetSource` document the spec's retired
+`WidgetManifest` / `WidgetSource` as HISTORY, instead of describing them as a
+live schema (objectui#5213).
+
+Both JSDoc blocks were written while `@objectstack/spec/ui` still exported a
+field-widget-plugin `WidgetManifest` and a `WidgetSource` union — they said the
+local types were "renamed off the spec's name", in the present tense, and the
+manifest block enumerated the spec shape key by key (`fieldTypes`, `category`,
+`lifecycle`, `events`, `properties`, `implementation`, `screenshots`, `license`,
+`aria`, `performance`). Protocol 17 retired that entire widget-registration
+vocabulary under ADR-0049 enforce-or-remove (objectstack#5055): the installed
+`@objectstack/spec` 17.2.0 exports none of those names, and its own tombstone
+records why there is nothing to migrate — no schema ever declared a carrier key
+of a widget shape, so the record is the D3 `SemanticMigration`
+`ui-widget-i18n-family-retired` plus `ui/WidgetManifest` in
+`RETIRED_DEFS_BY_MAJOR` for major 17.
+
+A per-key description of a schema that no longer exists is the ADR-0033 failure:
+an AI author reads a published docblock as present-tense fact and builds on it.
+The enumeration is dropped rather than re-dated, and the blocks now say what is
+true today — the bare names are owned by NOBODY, `RuntimeWidgetManifest` is
+objectui's only widget-registration contract, and the `Runtime` prefix is kept
+BY CHOICE (objectstack#4988's precedent: a freed word is not a reason to spend a
+second breaking rename taking it back; the unlock is recorded, not taken, in
+objectui#4164). The `inline` collision that made the `WidgetSource` rename
+urgent is kept, in the past tense, because it is the reason the prefix exists.
+Both blocks now point at the live assertion instead of restating it: the "the
+spec no longer owns" rows in
+`packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts`, which are what
+goes red if the spec ever re-publishes either name.
+
+Comments only. No type, signature, member or test changed, and the parity test
+that owns this fact was already correct — it moved both rows to its "spec no
+longer owns" table on the 17.0.0-rc.6 bump.
+
+Declared a `patch` for `@object-ui/types` alone because the emit was measured,
+not assumed: both blocks sit on EXPORTED declarations, so they publish. Rebuilt
+from a cleared `dist` and `tsconfig.tsbuildinfo` on both sides and compared by
+SHA-256 — `dist/widget.d.ts` `bb4f2fd702cac02a…` -> `db1d5fbd53d305f5…`
+(a consumer reads this text on hover and in the API docs), while
+`dist/widget.js` is byte-identical across the rebuild
+(`a3de34c54213a269…` both sides), so nothing runtime moved.

--- a/packages/types/src/widget.ts
+++ b/packages/types/src/widget.ts
@@ -27,17 +27,37 @@ import type { ComponentInputControlType } from './base.js';
  * A manifest provides all metadata needed to discover, load, and render
  * a widget without requiring an upfront import of its code.
  *
- * Renamed off the spec's `WidgetManifest` name (objectstack#4115): the spec's
- * is the **field-widget plugin** manifest that sits beside its
- * `FieldWidgetProps` — `{ fieldTypes, category: input|display|picker|editor,
- * lifecycle: { onMount, onValidate, … }, events, properties, implementation,
- * screenshots, license, aria, performance }`. This one is the **SDUI component**
- * manifest: `type` is a schema-renderer component key, and it carries `source`,
- * `defaultProps`, `inputs`, `isContainer` and `capabilities`, none of which the
- * spec's models. The only keys the two share are `name`/`label`/`version`/
- * `icon`/`description`.
+ * Today this is objectui's ONLY widget-registration contract: no published
+ * `@objectstack/spec` schema models one.
  *
- * Tripwire: `__tests__/page-nav-misc-spec-parity.test.ts`.
+ * HISTORY — why the `Runtime` prefix exists, and why it stays.
+ * `@objectstack/spec/ui` ONCE exported a **field-widget plugin**
+ * `WidgetManifest` (beside its `FieldWidgetProps`), and this interface was
+ * renamed off that name to end the collision (objectstack#4115). ⚠️ That schema
+ * is GONE — its keys are deliberately no longer enumerated here, and the
+ * prefix is not evidence that a spec twin exists: protocol 17 retired the whole
+ * widget-registration vocabulary — `WidgetManifest`, `WidgetLifecycle`,
+ * `WidgetEvent`, `WidgetProperty`, `WidgetSource` — under ADR-0049
+ * enforce-or-remove (objectstack#5055, maintainer ruling 2026-08-06). There is
+ * no tombstone key to migrate, because there was never a carrier key: the
+ * record is the D3 `SemanticMigration` `ui-widget-i18n-family-retired` plus
+ * `ui/WidgetManifest` in the spec's `RETIRED_DEFS_BY_MAJOR` for 17. That entry
+ * states the relationship these two types always had, verbatim: "objectui's
+ * registry has always carried its own runtime manifest for that
+ * (`RuntimeWidgetManifest` / `RuntimeWidgetSource` in `@object-ui/types`,
+ * objectui#3161 / #4115), which models different keys and never derived from
+ * these". `field.widget` is still what it always was — a `z.string()` naming a
+ * component the RENDERER has registered.
+ *
+ * So the bare name is now owned by NOBODY, and the prefix is kept BY CHOICE: a
+ * freed word is not a reason to spend a second breaking rename taking it back
+ * (objectstack#4988 precedent; the unlock is recorded, not taken —
+ * objectui#4164).
+ *
+ * Tripwire: `__tests__/page-nav-misc-spec-parity.test.ts`. Its "the spec no
+ * longer owns `WidgetManifest`" row is the LIVE assertion of that vacancy —
+ * read it, not this comment, for what the spec owns today; it goes red if the
+ * spec ever re-publishes the name while this package holds it.
  *
  * @example
  * ```ts
@@ -106,20 +126,25 @@ export interface RuntimeWidgetManifest {
 /**
  * Describes how to load the widget's code at runtime.
  *
- * Renamed off the spec's `WidgetSource` name (objectstack#4115). Both are
- * discriminated unions on `type`, which is what makes the collision dangerous:
- * they share the member name `inline` and mean opposite things by it. The
- * spec's `inline` carries source **code** to evaluate (`{ type: 'inline', code:
- * string }`), objectui's carries an **already-resolved component**
- * ({@link WidgetSourceInline}). The other members do not overlap at all — the
- * spec has `npm`/`remote`, objectui has `module`/`registry` — so a value of one
- * union is never a valid value of the other.
+ * HISTORY — the same rename as {@link RuntimeWidgetManifest}, and the more
+ * dangerous half of the collision it ended. `@objectstack/spec/ui` ONCE
+ * exported a `WidgetSource` union too (objectstack#4115). Both WERE
+ * discriminated unions on `type` that shared the member name `inline` and meant
+ * opposite things by it:
+ * the spec's `inline` carried source **code** to evaluate (`{ type: 'inline',
+ * code: string }`), objectui's carries an **already-resolved component**
+ * ({@link WidgetSourceInline}). The other members never overlapped — the spec
+ * had `npm`/`remote`, objectui has `module`/`registry` — so a value of one
+ * union was never a valid value of the other. ⚠️ The spec's union was retired
+ * with the rest of the widget-registration vocabulary (objectstack#5055): the
+ * union declared below is objectui's own, and never derived from it.
  *
- * The variant interfaces keep their `WidgetSource…` names: the spec does not
- * export those, and renaming them would churn the public surface without
+ * The variant interfaces keep their `WidgetSource…` names: the spec never
+ * exported those, and renaming them would churn the public surface without
  * removing a collision.
  *
- * Tripwire: `__tests__/page-nav-misc-spec-parity.test.ts`.
+ * Tripwire: `__tests__/page-nav-misc-spec-parity.test.ts` — its "the spec no
+ * longer owns `WidgetSource`" row pins the vacancy.
  */
 export type RuntimeWidgetSource =
   | WidgetSourceModule


### PR DESCRIPTION
Fixes #5213

Comment-only change to `packages/types/src/widget.ts`, plus the changeset that declares it. No type, member, signature, export or test moved.

## What was wrong

The two JSDoc blocks on `RuntimeWidgetManifest` (`:30`) and `RuntimeWidgetSource` (`:109`) were written while `@objectstack/spec/ui` still exported a field-widget-plugin `WidgetManifest` and a `WidgetSource` union. They said the local types were "Renamed off the spec's `WidgetManifest` name (objectstack#4115)", in the **present tense**, and the manifest block enumerated the spec's shape key by key — `{ fieldTypes, category, lifecycle, events, properties, implementation, screenshots, license, aria, performance }`.

None of that exists any more. That is the ADR-0033 failure the card names: an AI author reads a published docblock as present-tense fact, and a per-key description of a deleted schema is a planted premise, not stale documentation.

## Installed-spec probe (measured in this worktree, not on the platform repo's main)

`@objectstack/spec` resolves to **17.2.0** here (`node_modules/@objectstack/spec/package.json`).

- `grep -rn "WidgetManifest\|WidgetSource" node_modules/@objectstack/spec/dist --include=*.d.ts --include=*.d.mts` — **zero hits**. Nothing is exported under either name.
- `grep -rn "WidgetManifestSchema\|WidgetSourceSchema" dist --include=*.js --include=*.mjs` — **zero hits**. The only occurrences anywhere in the tarball are inside `sourcesContent` of `dist/ui/index.js.map`, i.e. the retired file's own tombstone comment.
- The retirement **is** declared in the installed dist, so this PR quotes it rather than inventing history: the D3 `SemanticMigration` `ui-widget-i18n-family-retired` (surface `ui.widgetManifest / ui.widgetLifecycle / ui.widgetEvent / ui.widgetProperty / ui.widgetSource …`), and `ui/WidgetManifest` / `ui/WidgetSource` listed in `RETIRED_DEFS_BY_MAJOR` under the `retired-def:17` block.

The sentence the new JSDoc quotes verbatim is that entry's own `replacement` text: "objectui's registry has always carried its own runtime manifest for that (`RuntimeWidgetManifest` / `RuntimeWidgetSource` in `@object-ui/types`, objectui#3161 / #4115), which models different keys and never derived from these". The same entry's `acceptanceCriteria` prescribes exactly this change: "`packages/types/src/widget.ts`'s 'Renamed off the spec's `WidgetManifest` name' comments now point at names that no longer exist. Both are prescribed responses to this removal, not collateral damage."

## What changed

Both blocks are now **historical statements**, and each says what is true today:

- The spec **ONCE** exported those names; protocol 17 retired the whole widget-registration vocabulary under ADR-0049 enforce-or-remove (objectstack#5055, maintainer ruling 2026-08-06). There is no tombstone key to migrate because there was never a carrier key — `field.widget` is a `z.string()` naming a registered component and never referenced `WidgetManifest`.
- The per-key enumeration of the retired schema is **dropped**, not re-dated. What is enumerated now is objectui's own key set, which is present-tense true.
- `RuntimeWidgetManifest` is stated to be objectui's **only** widget-registration contract.
- The bare names are owned by **nobody**, and the `Runtime` prefix is kept **by choice** — objectstack#4988's precedent, a freed word is not a reason to spend a second breaking rename taking it back. The unlock is recorded, not taken (objectui#4164).
- The `inline` collision that made the `WidgetSource` rename urgent is **kept, in the past tense** — it is the reason the prefix exists, so deleting it would lose the reason while keeping the workaround.
- Both blocks now **point at** the live assertion instead of restating it: the "the spec no longer owns …" rows in `packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts:652-653`. A comment cannot go red; that table can.

## Half 1 was already landed — verified on the ref, not assumed

`page-nav-misc-spec-parity.test.ts` already carries both names in its "spec no longer owns" table (`:652-653`) with the `RuntimeXxx` names kept — the card's option B — and the reverse assertions at `:750-751` are intact. Nothing in that file is touched by this PR. `packages/fields/src/__tests__/spec-symbol-batch7.test.ts` and its `FieldWidgetProps` import are likewise untouched: `FieldWidgetPropsSchema` deliberately survived the retirement.

## Changeset: `@object-ui/types: patch`, and the emit was measured

Both blocks sit on **exported** declarations, so they publish. Rebuilt from a cleared `dist` and `tsconfig.tsbuildinfo` on both sides and compared by SHA-256:

- `dist/widget.d.ts` — `bb4f2fd702cac02a327b2bb498d01259313f6dc6004a99018b6ed036df9bba15` to `db1d5fbd53d305f5c82bf634e76d3f17ac4a59f53bf6448420b49c5f148f1f62` — **changed**. A consumer reads this text on hover and in the API docs.
- `dist/widget.js` — `a3de34c54213a269074b1858248c0f26d689957dda18410443972f90e879b3e1` on **both** sides — byte-identical. Nothing runtime moved.

So a `patch` is the honest declaration and an empty-frontmatter "no release" changeset would not be. Never `major`.

Reverse-verification hygiene for that measurement: the implementation was committed **first**, the baseline text was restored with `git checkout HEAD~1 -- "$REPO_ROOT/packages/types/src/widget.ts"` (absolute path) under a `trap … EXIT INT TERM`, the mutation was proved on disk before measuring (`grep -c "Renamed off the spec's"` = 2, new-marker count = 0, `git hash-object` equal to the `HEAD~1` blob), and the restore was proved by `git diff HEAD --name-only` being empty with the working blob hash back to the `HEAD` blob.

## Gates — all run at the final commit `015bec4`, tree clean

| gate | verdict |
| --- | --- |
| `pnpm --filter @object-ui/types type-check` | exit 0 — the script is `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`, so the test project is included and the test sources really were checked |
| `pnpm exec vitest run packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts` | Test Files 1 passed (1) · Tests 45 passed (45) |
| `pnpm exec eslint packages/types/src/widget.ts` | exit 0, no output |
| `pnpm check:control-bytes` | ✅ check-control-bytes: OK (scanned 5997 tracked text file(s); skipped 85 binary). |
| `pnpm check:spec-symbols` | ✅ spec symbol derivation: 1333 files scanned against 4959 spec export names; 16 declared dialects, 0 untriaged collisions in 0 packages. — ✅ spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages. |
| `node scripts/check-changeset-presence.mjs` | ✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s). |
| `node scripts/check-changeset-no-major.mjs` | ✅ No changeset declares a major bump. |
| `node scripts/check-changeset-overwrite.mjs` | ✅ No pre-existing changeset was modified or deleted. |
| `node scripts/check-changeset-fixed.mjs` | ✅ All workspace packages are in the changeset fixed group. |

Every heavy step ran through the shared verify lock (`os-verify-lock.sh`, slot `issue-5213-objectui`), each returning `VERDICT command-exit 0`. Exit codes were captured before any pipe.

**Declared narrowing:** the repo-wide farm (`pnpm lint`, the other 30-odd `check:*` scripts) was **not** run locally — CI runs it exactly once anyway. The targeted set above is derived from the change surface: one comment-only edit to `packages/types/src/widget.ts` plus one `.changeset/*.md`. `check:spec-symbols` is included because it is the gate that reads spec-symbol names and spec-alignment claims out of objectui source, which is precisely what this diff rewrites.

One non-gate note: `pnpm --filter '@object-ui/types^...' build` reports `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT — None of the selected packages has a "build" script` and exits 1. That is an **empty dependency closure**, not a failure: `@object-ui/types` is the base package with zero workspace dependencies. `pnpm --filter @object-ui/types build` itself exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3hPr7riucnMfhcHY86Msd