### PR TITLE
fix(console): stop retrying /api/v1/dev/metadata-events after the first 404

### DIFF
--- a/.changeset/7257-metadata-hmr-give-up-after-404.md
+++ b/.changeset/7257-metadata-hmr-give-up-after-404.md
@@ -1,0 +1,30 @@
+---
+'@object-ui/console': patch
+---
+
+`MetadataHmrReloader` stops flooding a production-posture deployment with
+`GET /api/v1/dev/metadata-events` 404s (objectui#7257).
+
+The dev-only HMR component subscribes via `EventSource`, gated on
+`import.meta.env.DEV`. That gate is not airtight against every rig: a
+"prod-like" build/serve setup that forces `NODE_ENV=development` for the
+*build tooling* while running the server itself in production posture can
+bake `DEV === true` into the shipped bundle even though the server never
+mounts the dev route there — and the old reconnect loop treated every closed
+connection as transient, retrying on a fixed `reconnectDelayMs` (2s)
+forever. On an env host that is ~30 requests/minute of 404s per open
+record/list page, drowning out the legitimate `sys_inbox_message` /
+`sys_notification_receipt` polling in the same console.
+
+The first `connect()` attempt now doubles as the real capability probe: if
+the stream closes before it ever reaches `open`, the component gives up for
+good instead of retrying (and specifically not a longer interval either —
+that would still spam 404s, just slower). A stream that DID open at least
+once and later drops — a real dev-server restart or network blip — keeps
+reconnecting exactly as before.
+
+No production-side replacement is introduced here: this component's only
+job is turning "a metadata file changed on disk" into a full reload, and
+production deployments have no such file-system event to watch. The
+separate Studio-left-nav-doesn't-refresh caching issue does not go through
+this SSE stream and needs its own fix.

--- a/apps/console/src/components/MetadataHmrReloader.test.tsx
+++ b/apps/console/src/components/MetadataHmrReloader.test.tsx
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7257 — a production-posture console kept polling
+ * `GET /api/v1/dev/metadata-events` every `reconnectDelayMs` forever, each
+ * attempt landing on a 404 because the server doesn't mount this dev-only
+ * route there (~30 requests/min, flooding the console and drowning out the
+ * legitimate `sys_inbox_message` / `sys_notification_receipt` polling).
+ *
+ * `enabled` (default `import.meta.env.DEV`) is the primary gate, but it is
+ * not airtight: a build can end up with `DEV === true` baked in even while
+ * the server it talks to is in production posture (a "prod-like" rig that
+ * forces `NODE_ENV=development` for the *build tooling* is one concrete way
+ * this happens — see the file header of `MetadataHmrReloader.tsx`). So the
+ * fix under test lives one layer down, in the reconnect loop itself: the
+ * first `connect()` attempt doubles as a capability probe. A stream that
+ * closes before ever reaching `open` is read as "the server doesn't support
+ * this", and the component gives up for good — no retry, and specifically
+ * NOT a longer retry interval (that would still spam 404s, just slower). A
+ * stream that DID open at least once and later drops is a different case —
+ * that proves the route exists, so ordinary reconnect-on-drop keeps working
+ * for real dev-server restarts / network blips.
+ *
+ * A fake `EventSource` drives both branches directly (this repo's jsdom-ish
+ * `happy-dom` test environment does not implement `EventSource`), so each
+ * case controls exactly which lifecycle events fire and in what order.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MetadataHmrReloader } from './MetadataHmrReloader';
+
+type Listener = (event: unknown) => void;
+
+/** Minimal, test-controlled stand-in for the browser `EventSource`. */
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  /** Every instance constructed across the whole test file, in order. */
+  static instances: FakeEventSource[] = [];
+
+  readyState = FakeEventSource.CONNECTING;
+  private readonly listeners = new Map<string, Listener[]>();
+
+  constructor(public readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  removeEventListener() {
+    /* not exercised — the component never calls this */
+  }
+
+  close() {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  private emit(type: string, event: unknown = {}) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  /** The 404 case: the connection never reaches `open` before it closes. */
+  failWithoutOpening() {
+    this.readyState = FakeEventSource.CLOSED;
+    this.emit('error');
+  }
+
+  /** The dev-server-restart case: a real connection that later drops. */
+  openThenDrop() {
+    this.readyState = FakeEventSource.OPEN;
+    this.emit('open');
+    this.readyState = FakeEventSource.CLOSED;
+    this.emit('error');
+  }
+}
+
+describe('MetadataHmrReloader — give up after the first connection fails without opening', () => {
+  const originalEventSource = (globalThis as { EventSource?: unknown }).EventSource;
+
+  beforeEach(() => {
+    FakeEventSource.instances = [];
+    (globalThis as { EventSource?: unknown }).EventSource = FakeEventSource;
+  });
+
+  afterEach(() => {
+    cleanup();
+    (globalThis as { EventSource?: unknown }).EventSource = originalEventSource;
+    vi.useRealTimers();
+  });
+
+  it('THE FIX: a 404-shaped failure (closed before `open`) is not retried at all', () => {
+    vi.useFakeTimers();
+
+    render(
+      <MetadataHmrReloader
+        enabled
+        url="/api/v1/dev/metadata-events"
+        reconnectDelayMs={2000}
+      />,
+    );
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    FakeEventSource.instances[0].failWithoutOpening();
+
+    // Advance well past what would have been ~15 reconnect attempts under
+    // the old fixed-interval retry — the regression this pins is "polls
+    // forever", not "polls a little less".
+    vi.advanceTimersByTime(2000 * 15);
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('⛔ does not fall back to a longer interval either — zero further attempts, not a slower loop', () => {
+    vi.useFakeTimers();
+
+    render(
+      <MetadataHmrReloader
+        enabled
+        url="/api/v1/dev/metadata-events"
+        reconnectDelayMs={2000}
+      />,
+    );
+
+    FakeEventSource.instances[0].failWithoutOpening();
+
+    // Even an interval an order of magnitude longer than the configured one
+    // must not produce a second attempt.
+    vi.advanceTimersByTime(2000 * 100);
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+  });
+
+  it('CONTROL: a stream that opened once and then drops keeps reconnecting (real dev-server churn)', () => {
+    vi.useFakeTimers();
+
+    render(
+      <MetadataHmrReloader
+        enabled
+        url="/api/v1/dev/metadata-events"
+        reconnectDelayMs={2000}
+      />,
+    );
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    FakeEventSource.instances[0].openThenDrop();
+
+    vi.advanceTimersByTime(2000);
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    // The reconnect is itself a fresh probe: if it also opens and later
+    // drops, the loop keeps going — this is the behavior the fix must NOT
+    // disturb for a route that genuinely exists.
+    FakeEventSource.instances[1].openThenDrop();
+    vi.advanceTimersByTime(2000);
+    expect(FakeEventSource.instances).toHaveLength(3);
+  });
+
+  it('does not subscribe at all when disabled (unaffected by this change)', () => {
+    render(<MetadataHmrReloader enabled={false} url="/api/v1/dev/metadata-events" />);
+
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+});

--- a/apps/console/src/components/MetadataHmrReloader.tsx
+++ b/apps/console/src/components/MetadataHmrReloader.tsx
@@ -19,6 +19,31 @@
  *   - `enabled` defaults to `import.meta.env.DEV` so production builds
  *     never run this component.
  *   - SSR-safe: no-op when `window`/`EventSource` are unavailable.
+ *
+ * Give-up-after-first-failure (objectui#7257)
+ *   `enabled` alone is not a hard guarantee that the server actually mounts
+ *   `/api/v1/dev/metadata-events` — a build can end up with
+ *   `import.meta.env.DEV === true` baked in (e.g. a "prod-like" rig that
+ *   forces `NODE_ENV=development` for the *build tooling* while running the
+ *   server itself in production posture) even though the route is absent
+ *   there. Treat the very first `connect()` attempt as the real capability
+ *   probe: if the stream is closed before it ever reaches `open`, the server
+ *   doesn't support it (a 404, most likely), and retrying on a fixed
+ *   interval would just recreate that 404 every `reconnectDelayMs` forever —
+ *   so this gives up permanently instead of retrying or backing off. A
+ *   stream that HAS opened at least once and later drops (dev server
+ *   restart, network blip) keeps reconnecting as before — that scenario
+ *   means the route genuinely exists, so it is ordinary dev-time churn, not
+ *   a production posture mismatch.
+ *
+ * No production-posture substitute
+ *   This component's only job is dev-time "a metadata file changed on disk"
+ *   -> full reload. Production deployments never have metadata files
+ *   changing on the server's disk after a publish, so there is nothing for
+ *   an equivalent production channel to watch — this card intentionally
+ *   ships no replacement. A separate, unrelated caching bug (the Studio left
+ *   nav not refreshing after a metadata change) needs its own fix elsewhere;
+ *   it does not go through this SSE stream today either way.
  */
 
 import { useEffect, useRef } from 'react';
@@ -50,6 +75,11 @@ export function MetadataHmrReloader({
     let es: EventSource | null = null;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let cancelled = false;
+    // Set once the stream has ever reached `open`. Until then, a closed
+    // connection is read as "this server doesn't mount the route" rather
+    // than "a transient drop" — see the give-up-after-first-failure note
+    // in the file header (objectui#7257).
+    let hasOpenedOnce = false;
 
     const scheduleReload = (reason: string) => {
       if (reloadTimerRef.current) clearTimeout(reloadTimerRef.current);
@@ -92,16 +122,28 @@ export function MetadataHmrReloader({
       if (cancelled) return;
       try {
         es = new EventSource(url);
+        es.addEventListener('open', () => {
+          hasOpenedOnce = true;
+        });
         es.addEventListener('metadata-change', onChange as EventListener);
         es.addEventListener('reload', onReload as EventListener);
         es.addEventListener('error', () => {
           if (cancelled) return;
           if (es?.readyState === EventSource.CLOSED) {
             es = null;
+            if (!hasOpenedOnce) {
+              // Never got past the first attempt — most likely a 404
+              // (production posture doesn't mount this dev-only route).
+              // Retrying on a timer would just recreate the same 404 every
+              // `reconnectDelayMs` forever; give up instead of extending
+              // the interval.
+              return;
+            }
             retryTimer = setTimeout(connect, reconnectDelayMs);
           }
         });
       } catch {
+        if (!hasOpenedOnce) return;
         retryTimer = setTimeout(connect, reconnectDelayMs);
       }
     };


### PR DESCRIPTION
Fixes #7257

## File-surface note

The PM's claim comment scoped this to `packages/app-shell/src/**`. Verified against `origin/main`: nothing under `packages/app-shell` references `metadata-events` at all. The actual subscription is `MetadataHmrReloader` at `apps/console/src/components/MetadataHmrReloader.tsx`, mounted once from `apps/console/src/App.tsx`. This PR's diff is confined to that one component + its new test + a changeset — it does not touch `packages/app-shell`, nor `#7253`'s marketplace files or `#7254`'s studio/i18n files.

## Root cause

`MetadataHmrReloader` is dev-only HMR tooling: an `EventSource` subscribed to `/api/v1/dev/metadata-events`, gated on `enabled = import.meta.env.DEV`. Its own `error` handler unconditionally scheduled a reconnect on a fixed `reconnectDelayMs` (2s) whenever `readyState === CLOSED` — with no distinction between "the stream dropped after being open" (worth retrying) and "the very first connection attempt failed" (a route that isn't mounted, i.e. production posture — retrying just recreates the same 404 forever, ~30/min while a record/list page stays open, drowning out the legitimate `sys_inbox_message` / `sys_notification_receipt` polling).

Separately, and worth recording even though it isn't fixed in this PR: `enabled`'s `import.meta.env.DEV` gate is not airtight against every rig. Traced through Vite 8's `resolveConfig` (`node_modules/vite/dist/node/chunks/node.js`): for `vite build`, `mode` defaults to `'production'` regardless of `NODE_ENV`, but `import.meta.env.DEV`/`PROD` are derived from a *separate* `isProduction = process.env.NODE_ENV === 'production'` check. `scripts/dev-local/run-stack.sh --with-ui` in the `cloud` repo builds the console with `NODE_ENV=development` forced ("vite/tsc misbehave under NODE_ENV=production" per its own comment) while the server itself runs `--prod-like` (`NODE_ENV=production`). That combination bakes `import.meta.env.DEV === true` into the shipped console bundle even though the server is in production posture — which is one concrete way `enabled` ends up `true` where it shouldn't. That's a `cloud`-repo rig concern, out of scope here; this PR's fix is deliberately layered underneath the `enabled` gate so the component is safe regardless of *why* it ended up enabled.

## Fix

The first `connect()` attempt now doubles as the real capability probe (`apps/console/src/components/MetadataHmrReloader.tsx`): a `hasOpenedOnce` flag is set on the stream's `open` event. If the connection closes (or throws) before ever reaching `open`, the component gives up permanently — no retry, and specifically **not** a longer backoff interval either, per the fix requirement. A stream that opened at least once and later drops (dev server restart, network blip) keeps reconnecting exactly as before, since that proves the route genuinely exists.

## Alternative channel for production metadata refresh — none needed

Per the ruling, no replacement channel is implemented in this card. Explaining why none is needed: `MetadataHmrReloader`'s only job is dev-time "a metadata file changed on disk" → full reload. Production deployments never have metadata files changing on the server's disk after a publish — there is no equivalent event for a production channel to watch. The referenced "Studio left nav doesn't refresh" issue is a separate, unrelated caching bug (Studio has its own `useMetadataHmr` + `subscribe(...)` invalidation layer per this file's docstring) and does not go through this SSE stream either way — it needs its own fix, tracked separately.

## Tests

`apps/console/src/components/MetadataHmrReloader.test.tsx` (new), against a hand-rolled `FakeEventSource` (this repo's `happy-dom` test env has no real `EventSource`):
- **THE FIX**: a connection that closes before `open` (404-shaped) produces exactly one `EventSource` instance even after advancing fake timers 15x past `reconnectDelayMs`.
- A second case pins "not a longer interval either" — 100x the interval, still zero further attempts.
- **CONTROL**: a stream that opens once and then drops keeps reconnecting (2 more instances across 2 drops) — proves the fix doesn't regress genuine dev-time reconnect.
- **CONTROL**: `enabled={false}` subscribes to nothing (unaffected by this change).

Reverse-verified: reverted `MetadataHmrReloader.tsx` to `origin/main` (`git diff` confirmed byte-identical), re-ran the new test file — the two "give up" tests went red (2 `EventSource` instances instead of 1) while both controls stayed green; restored the fix (`git checkout HEAD --`, `git diff HEAD` empty) and confirmed green again.

```
pnpm exec vitest run apps/console/src/components/MetadataHmrReloader.test.tsx
 Test Files  1 passed (1)
      Tests  4 passed (4)

pnpm exec vitest run apps/console/                 # full package, unaffected suites
 Test Files  86 passed (86)
      Tests  952 passed (952)

pnpm --filter @object-ui/console type-check        # clean, no errors
pnpm --filter @object-ui/console build              # exit 0
node scripts/check-changeset-presence.mjs           # ✅ 1 changeset declared
node scripts/check-changeset-no-major.mjs           # ✅
node scripts/check-control-bytes.mjs                # ✅
```

All at `a32a727bd`.

## Changeset

`.changeset/7257-metadata-hmr-give-up-after-404.md` — `@object-ui/console` patch.

_Generated by [Claude Code](https://claude.ai/code/session_c5c0ce54-bb9c-478c-9e5b-cf44b80d4569)_