### PR TITLE
ci: bound the seven remaining cache saves so bookkeeping cannot void a verdict

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -572,8 +572,38 @@ jobs:
       # comment here trips it — deliberately the safe direction (a false red, never
       # a false green), which is why this comment spells the attribute form.
 
-      - name: Turbo Cache
-        uses: actions/cache@v6
+      # ── Cache bookkeeping cannot void a recorded verdict (objectui#7048) ──
+      # THE ORDERING, carried here from the type-check split in `ci.yml`
+      # (objectui#6577, PR #7047) because it is what a future reader needs in
+      # order to judge whether these steps may be touched: the verdict is
+      # recorded by the checking steps; everything after them is bookkeeping,
+      # and bookkeeping must never discard an answer the gate already produced.
+      # In this job the answer at stake is the publish/refresh outcome and the
+      # post-version tree validation below it.
+      #
+      # Why the SPLIT rather than a timeout on one step: combined
+      # `actions/cache` declares `main: dist/restore/index.js` plus
+      # `post: dist/save/index.js`, so its save is a step the RUNNER generates
+      # at job end (`Post Turbo Cache`). No workflow syntax attaches
+      # `timeout-minutes` or `continue-on-error` to a generated post step.
+      # Measured once, on `ci.yml`'s type-check cache: a 1-second save took
+      # 789s and ran that job into its ceiling (objectui#6577).
+      # `actions/cache`'s own `save-always` deprecation text points at this
+      # same split.
+      #
+      # ⚠️ This job declares NO `timeout-minutes`, so its ceiling is GitHub's
+      # default of 360 minutes — and this is the PUBLISH lane, where a job that
+      # hangs after `Publish to npm` has already shipped and the concurrency
+      # note above records what a long-running release job does to the pushes
+      # behind it. ⛔ Adding a ceiling is NOT the fix and is not attempted here:
+      # the release act must never be truncated by a clock. The bound below is
+      # on the bookkeeping step alone, which runs after every release step.
+      #
+      # The restore half is deliberately left UNBOUNDED: a restore stall fails
+      # BEFORE anything is published, which is the honest failure.
+      - name: Restore Turbo Cache
+        id: turbo-cache
+        uses: actions/cache/restore@v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -1116,3 +1146,46 @@ jobs:
           commit: 'chore: release packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The bookkeeping half of the split documented at the restore step above,
+      # placed HERE — last in the job, after publish, after the post-version
+      # tree validation and after the refresh — because that is exactly where
+      # the post phase it replaces already ran. Nothing this job publishes,
+      # validates or restores moves with it, and no step above it is touched.
+      #
+      # `timeout-minutes: 5` is DERIVED, and the derivation is weaker here than
+      # at the other six sites — said plainly rather than dressed up.
+      # objectui#7048 fences inheriting PR #7047's 5, so: this cache is
+      # `.turbo/cache` under the same `turbo-${{ runner.os }}-${{ github.sha }}`
+      # key shape as `lint.yml` and `performance-budget.yml`, and the saves of
+      # THAT cache measured 1s, 2s, 5s and 6s across four jobs on 2026-09-02
+      # (`Bundle Analysis` 100096569559, `Type Check` 100096569872,
+      # `Build Docs` 100094597253, `Lint` 100097466846). A same-SITE save was
+      # not observable in the sampled runs: this job runs on `push` to `main`
+      # only when the version is not yet on npm, and on the 6-hourly `schedule`
+      # the primary key is an exact hit, so `Post Turbo Cache` measured 0s on
+      # the sampled scheduled run (job 99021319583, 2026-08-29) with its
+      # restore at 4s. 5 minutes is 50x the slowest of the four same-cache
+      # saves; if a directly measured save of this site ever lands and lies
+      # outside that range, re-derive rather than defend this number.
+      #
+      # `continue-on-error: true` is the other half. A cache that failed to
+      # upload costs the next run some build time; it says nothing about
+      # whether the release succeeded, so it must not be able to redden a job
+      # that has already published.
+      #
+      # Behaviour preserved, spelled out so the equivalence is checkable:
+      #   - `cache-hit != 'true'` reproduces the combined action's own "exact
+      #     hit on the primary key ⇒ do not save" skip — which is precisely the
+      #     path the scheduled run above took.
+      #   - the condition names no status function, so the implicit `success()`
+      #     still applies — matching the combined action's `post-if: success()`.
+      #   - same `path` and same `key` as the restore step above.
+      - name: Save Turbo Cache
+        if: steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1141,9 +1141,37 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Cache Playwright browsers
+      # ── Cache bookkeeping cannot void a recorded verdict (objectui#7048) ──
+      # THE ORDERING, carried here from the type-check split (objectui#6577,
+      # PR #7047) because it is what a future reader needs in order to judge
+      # whether these steps may be touched: the verdict is recorded by the
+      # checking steps; everything after them is bookkeeping, and bookkeeping
+      # must never discard an answer the gate already produced.
+      #
+      # Why the SPLIT rather than a timeout on one step: combined
+      # `actions/cache` declares `main: dist/restore/index.js` plus
+      # `post: dist/save/index.js`, so its save is a step the RUNNER generates
+      # at job end (`Post Cache Playwright browsers`). No workflow syntax
+      # attaches `timeout-minutes` or `continue-on-error` to a generated post
+      # step, so an upload stall runs the job into `timeout-minutes: 30`, the
+      # job goes `cancelled`, and the merge queue cannot tell `cancelled` from
+      # `failure` — an all-green pull request is ejected and every lane pays
+      # the ceiling in head-of-line blocking. Measured once, on the type-check
+      # cache: a 1-second save took 789s (objectui#6577). Splitting moves the
+      # save into the main phase, where both keys are ordinary documented step
+      # keys; `actions/cache`'s own `save-always` deprecation text points at
+      # this same split.
+      #
+      # ⛔ Raising `timeout-minutes: 30` is the ruled-out non-fix: a larger
+      # ceiling only buys a longer hang, still ends in `cancelled`, and lifting
+      # a gate's ceiling weakens the gate.
+      #
+      # The restore half is deliberately left UNBOUNDED, as at the type-check
+      # site: a restore stall fails BEFORE any verdict exists — a gate that did
+      # not run, which is honest — rather than a recorded verdict discarded.
+      - name: Restore Playwright browsers
         if: steps.relevant.outputs.should_run == 'true'
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -1217,6 +1245,54 @@ jobs:
             playwright-report/
             test-results/
           retention-days: 14
+
+      # The bookkeeping half of the split documented at the restore step above,
+      # placed HERE — last in the job — because that is exactly where the post
+      # phase it replaces already ran. Nothing about which commits this job
+      # accepts or rejects moves with it.
+      #
+      # `timeout-minutes: 8` is DERIVED FOR THIS CACHE, not inherited from the
+      # type-check site's 5 (objectui#7048 fences that explicitly). This cache
+      # is Playwright's browser binaries — ~269 MB, two orders of magnitude
+      # larger than `.turbo/cache` — and upload time scales with size, so the
+      # bound has to be sized against a measurement of THIS artefact:
+      #   - restores of this exact archive, same runner class: 3s (job
+      #     100096569775) and 3s (job 100094597323) here, 5s in `live-e2e.yml`
+      #     (job 100097466897) ⇒ the cache service moves it at ~54-90 MB/s.
+      #   - a save is only observable after a Playwright version bump (an exact
+      #     key hit skips it, and `Post Cache Playwright browsers` measured 0s
+      #     on every sampled run), so the honest save is bounded from the
+      #     restore rather than read directly — stated plainly rather than
+      #     dressed up as a direct measurement.
+      #   - taking a deliberately pessimistic 20x penalty on the slowest
+      #     observed restore gives ~1m40s for an honest save. 8 minutes is
+      #     ~4.8x that, and demands only 0.56 MB/s sustained to finish.
+      # And it stays clear of the ceiling in both directions: 8 x 2 = 16 <= 30,
+      # so bookkeeping cannot crowd out the checking steps, whose whole verdict
+      # path measured 56s wall clock end to end on job 100096569775.
+      #
+      # `continue-on-error: true` is the other half, and without it the bound
+      # would only trade a `cancelled` gate for a red one. A cache that failed
+      # to upload costs the next run a re-download from Playwright's CDN — a
+      # path this job already takes on a miss — and says nothing whatsoever
+      # about the code under test, so it must not be allowed to speak for it.
+      #
+      # Behaviour preserved, spelled out so the equivalence is checkable:
+      #   - `cache-hit != 'true'` reproduces the combined action's own "exact
+      #     hit on the primary key ⇒ do not save" skip.
+      #   - the condition names no status function, so the implicit `success()`
+      #     still applies — matching the combined action's `post-if: success()`.
+      #   - same `path` and same `key` as the restore step above.
+      - name: Save Playwright browsers
+        if: >-
+          steps.relevant.outputs.should_run == 'true'
+          && steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 8
+        continue-on-error: true
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
   docs:
     name: Build Docs
@@ -1306,9 +1382,37 @@ jobs:
       # `scripts/__tests__/docs-links-workflow.test.ts` pins the gate to exactly
       # one home.
 
-      - name: Turbo Cache
+      # ── Cache bookkeeping cannot void a recorded verdict (objectui#7048) ──
+      # THE ORDERING, carried here from the type-check split (objectui#6577,
+      # PR #7047) because it is what a future reader needs in order to judge
+      # whether these steps may be touched: the verdict is recorded by the
+      # checking steps; everything after them is bookkeeping, and bookkeeping
+      # must never discard an answer the gate already produced.
+      #
+      # Why the SPLIT rather than a timeout on one step: combined
+      # `actions/cache` declares `main: dist/restore/index.js` plus
+      # `post: dist/save/index.js`, so its save is a step the RUNNER generates
+      # at job end (`Post Turbo Cache`). No workflow syntax attaches
+      # `timeout-minutes` or `continue-on-error` to a generated post step, so
+      # an upload stall runs the job into `timeout-minutes: 15` — the TIGHTEST
+      # ceiling of this workflow's three cached jobs — the job goes
+      # `cancelled`, and the merge queue cannot tell `cancelled` from
+      # `failure`. Measured once, on the type-check cache: a 1-second save took
+      # 789s and ejected an all-green pull request (objectui#6577).
+      # `actions/cache`'s own `save-always` deprecation text points at this
+      # same split.
+      #
+      # ⛔ Raising `timeout-minutes: 15` is the ruled-out non-fix: a larger
+      # ceiling only buys a longer hang, still ends in `cancelled`, and lifting
+      # a gate's ceiling weakens the gate.
+      #
+      # The restore half is deliberately left UNBOUNDED: a restore stall fails
+      # BEFORE any verdict exists — a gate that did not run, which is honest —
+      # rather than a recorded verdict discarded.
+      - name: Restore Turbo Cache
+        id: turbo-cache
         if: steps.docs-changes.outputs.should_run == 'true'
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-docs-${{ github.sha }}
@@ -1323,3 +1427,44 @@ jobs:
       - name: Build Site
         if: steps.docs-changes.outputs.should_run == 'true'
         run: pnpm turbo run build --filter='@object-ui/site'
+
+      # The bookkeeping half of the split documented at the restore step above,
+      # placed HERE — after `Build Site`, the step that records this job's
+      # verdict — because that is exactly where the post phase it replaces
+      # already ran. Nothing about which commits this job accepts or rejects
+      # moves with it.
+      #
+      # `timeout-minutes: 5` is DERIVED FOR THIS SITE, and landing on the same
+      # number PR #7047 chose is a result rather than a copy — objectui#7048
+      # fences inheriting that 5, so here is this site's own arithmetic. This
+      # cache is `.turbo/cache`, and this job's own save of it measured 5s on
+      # 2026-09-02 (`Post Turbo Cache`, job 100094597253, a `merge_group` build
+      # where this job's steps actually run — on a pull request without
+      # `apps/site/` or `content/` changes they all skip). 5 minutes is 60x
+      # that, so it cannot fire on a working runner.
+      # Ceiling check: 5 x 2 = 10 <= 15, so bookkeeping cannot crowd out the
+      # checking steps — whose whole verdict path measured 4m26s on that job.
+      #
+      # `continue-on-error: true` is the other half, and without it the bound
+      # would only trade a `cancelled` gate for a red one. A cache that failed
+      # to upload costs the next run some time; it says nothing whatsoever
+      # about the code under test, so it must not be allowed to speak for it.
+      #
+      # Behaviour preserved, spelled out so the equivalence is checkable:
+      #   - `cache-hit != 'true'` reproduces the combined action's own "exact
+      #     hit on the primary key ⇒ do not save" skip. Note this is the EXACT
+      #     hit only: a `restore-keys` prefix match leaves `cache-hit` false
+      #     and the save still runs, which is what the combined action did.
+      #   - the condition names no status function, so the implicit `success()`
+      #     still applies — matching the combined action's `post-if: success()`.
+      #   - same `path` and same `key` as the restore step above.
+      - name: Save Turbo Cache
+        if: >-
+          steps.docs-changes.outputs.should_run == 'true'
+          && steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-docs-${{ github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -239,9 +239,39 @@ jobs:
           node scripts/check-upstream-port-parity.mjs --self-test
           node scripts/check-upstream-port-parity.mjs
 
-      - name: Turbo Cache
+      # ── Cache bookkeeping cannot void a recorded verdict (objectui#7048) ──
+      # THE ORDERING, carried here from the type-check split in `ci.yml`
+      # (objectui#6577, PR #7047) because it is what a future reader needs in
+      # order to judge whether these steps may be touched: the verdict is
+      # recorded by the checking steps; everything after them is bookkeeping,
+      # and bookkeeping must never discard an answer the gate already produced.
+      #
+      # Why the SPLIT rather than a timeout on one step: combined
+      # `actions/cache` declares `main: dist/restore/index.js` plus
+      # `post: dist/save/index.js`, so its save is a step the RUNNER generates
+      # at job end (`Post Turbo Cache`). No workflow syntax attaches
+      # `timeout-minutes` or `continue-on-error` to a generated post step.
+      # Measured once, on `ci.yml`'s type-check cache: a 1-second save took
+      # 789s, ran that job into its ceiling, and the resulting `cancelled` —
+      # which the merge queue cannot tell from `failure` — ejected an all-green
+      # pull request (objectui#6577). `actions/cache`'s own `save-always`
+      # deprecation text points at this same split.
+      #
+      # ⚠️ This job declares NO `timeout-minutes`, so its ceiling is GitHub's
+      # default of 360 minutes. That makes the exposure worse here, not better:
+      # `Lint` is a required context on `pull_request` and `merge_group` alike,
+      # so a stalled save would hold the shared serial queue for up to six
+      # hours before reporting `cancelled`. ⛔ Adding a ceiling is NOT the fix
+      # and is not attempted here — it would change what this gate rejects. The
+      # bound below is on the bookkeeping step alone.
+      #
+      # The restore half is deliberately left UNBOUNDED: a restore stall fails
+      # BEFORE any verdict exists — a gate that did not run, which is honest —
+      # rather than a recorded verdict discarded.
+      - name: Restore Turbo Cache
+        id: turbo-cache
         if: steps.relevant.outputs.should_run == 'true'
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -354,3 +384,41 @@ jobs:
       - name: Verify the CLI's own check command passes on this repository
         if: steps.relevant.outputs.should_run == 'true'
         run: pnpm check
+
+      # The bookkeeping half of the split documented at the restore step above,
+      # placed HERE — after the last checking step — because that is exactly
+      # where the post phase it replaces already ran. Nothing about which
+      # commits this job accepts or rejects moves with it.
+      #
+      # `timeout-minutes: 5` is DERIVED FOR THIS SITE, and landing on the same
+      # number PR #7047 chose is a result rather than a copy — objectui#7048
+      # fences inheriting that 5, so here is this site's own arithmetic. This
+      # job's own save of this cache measured 6s on 2026-09-02 (`Post Turbo
+      # Cache`, job 100097466846); the whole job was 5m14s. 5 minutes is 50x
+      # the measured save, so it cannot fire on a working runner, and it is a
+      # bound on a step whose only alternative backstop is a 360-minute default
+      # ceiling.
+      #
+      # `continue-on-error: true` is the other half, and without it the bound
+      # would only trade a `cancelled` gate for a red one. A cache that failed
+      # to upload costs the next run some time; it says nothing whatsoever
+      # about the code under test, so it must not be allowed to speak for it.
+      #
+      # Behaviour preserved, spelled out so the equivalence is checkable:
+      #   - `cache-hit != 'true'` reproduces the combined action's own "exact
+      #     hit on the primary key ⇒ do not save" skip. A `restore-keys` prefix
+      #     match leaves `cache-hit` false and the save still runs, exactly as
+      #     the combined action behaved.
+      #   - the condition names no status function, so the implicit `success()`
+      #     still applies — matching the combined action's `post-if: success()`.
+      #   - same `path` and same `key` as the restore step above.
+      - name: Save Turbo Cache
+        if: >-
+          steps.relevant.outputs.should_run == 'true'
+          && steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -94,8 +94,40 @@ jobs:
       # The backend fixture (showcase metadata + published @objectstack/*
       # node_modules) only changes when the pins do — cache it on the pin file.
       # start-backend.sh's stamp check makes a cache hit skip clone + install.
-      - name: Cache live backend fixture
-        uses: actions/cache@v6
+      #
+      # ── Cache bookkeeping cannot void a recorded verdict (objectui#7048) ──
+      # THE ORDERING, carried here from the type-check split in `ci.yml`
+      # (objectui#6577, PR #7047) because it is what a future reader needs in
+      # order to judge whether these steps may be touched: the verdict is
+      # recorded by the checking steps; everything after them is bookkeeping,
+      # and bookkeeping must never discard an answer the gate already produced.
+      #
+      # Why the SPLIT rather than a timeout on one step: combined
+      # `actions/cache` declares `main: dist/restore/index.js` plus
+      # `post: dist/save/index.js`, so its save is a step the RUNNER generates
+      # at job end (`Post Cache live backend fixture`). No workflow syntax
+      # attaches `timeout-minutes` or `continue-on-error` to a generated post
+      # step, so an upload stall runs this job into `timeout-minutes: 40` and
+      # it reports `cancelled` — a lane that says nothing at all, which for an
+      # informational lane whose only product is a stability record is the
+      # worst outcome available. Measured once, on `ci.yml`'s type-check cache:
+      # a 1-second save took 789s (objectui#6577). `actions/cache`'s own
+      # `save-always` deprecation text points at this same split.
+      #
+      # ⛔ Raising `timeout-minutes: 40` is the ruled-out non-fix: a larger
+      # ceiling only buys a longer hang and still ends in `cancelled`.
+      #
+      # This job has TWO caches, so it gets two bounds. Together they can
+      # consume at most 5 + 8 = 13 minutes of the 40-minute ceiling, against a
+      # verdict path that measured 2m25s end to end (job 100097466897) — so
+      # even both bookkeeping halves stalling at once cannot reach the ceiling.
+      #
+      # The restore halves are deliberately left UNBOUNDED: a restore stall
+      # fails BEFORE any verdict exists — a lane that did not run, which is
+      # honest — rather than a recorded verdict discarded.
+      - name: Restore live backend fixture
+        id: live-backend-cache
+        uses: actions/cache/restore@v6
         with:
           path: ${{ runner.temp }}/live-backend
           key: live-backend-${{ runner.os }}-${{ hashFiles('e2e/live/ci/backend.env') }}
@@ -159,8 +191,12 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v6
+      # The second of this job's two caches; the split, the ordering sentence
+      # and the ruled-out non-fix are all documented at `Restore live backend
+      # fixture` above (objectui#7048). Same shape here: restore in place and
+      # unbounded, save last and bounded.
+      - name: Restore Playwright browsers
+        uses: actions/cache/restore@v6
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -206,6 +242,64 @@ jobs:
             ${{ runner.temp }}/live-backend/backend.log
             ${{ runner.temp }}/console-preview.log
           retention-days: 14
+
+      # The bookkeeping halves of the two splits documented at the restore
+      # steps above, placed HERE — last in the job — because that is exactly
+      # where the post phases they replace already ran. They are ordered
+      # Playwright-then-fixture to preserve the observed post-phase order
+      # (post steps run in reverse registration order, so `Post Cache
+      # Playwright browsers` ran before `Post Cache live backend fixture` —
+      # job 100097466897). Nothing about what this lane reports moves with them.
+      #
+      # `timeout-minutes: 8` on the browser cache is DERIVED FOR THIS CACHE,
+      # not inherited from the type-check site's 5 (objectui#7048 fences that
+      # explicitly): it is Playwright's browser binaries at ~269 MB. Restores
+      # of that exact archive measured 5s here (job 100097466897) and 3s in
+      # `ci.yml`'s `Build & E2E` (jobs 100096569775, 100094597323) ⇒ ~54-90
+      # MB/s in the download direction; a save is only observable after a
+      # version bump (an exact key hit skips it, and `Post Cache Playwright
+      # browsers` measured 0s on every sampled run), so the honest save is
+      # bounded from the restore rather than read directly — said plainly
+      # rather than dressed up as a direct measurement. A deliberately
+      # pessimistic 20x penalty on the slowest observed restore gives ~1m40s;
+      # 8 minutes is ~4.8x that and demands only 0.56 MB/s sustained.
+      #
+      # `timeout-minutes: 5` on the fixture cache is derived from THIS site's
+      # own measurement: its save measured 8s on 2026-09-02 (`Post Cache live
+      # backend fixture`, job 100097466897 — a real save, not a skip: the
+      # restore missed, which is why `Start ObjectStack backend` did the full
+      # clone + install). 5 minutes is ~37x that.
+      #
+      # `continue-on-error: true` on both is the other half, and without it the
+      # bounds would only trade a `cancelled` lane for a red one. A cache that
+      # failed to upload costs the next run some time; it says nothing about
+      # the console-x-backend integration this lane exists to observe.
+      #
+      # Behaviour preserved, spelled out so the equivalence is checkable:
+      #   - `cache-hit != 'true'` reproduces the combined action's own "exact
+      #     hit on the primary key ⇒ do not save" skip.
+      #   - neither condition names a status function, so the implicit
+      #     `success()` still applies — matching `post-if: success()`. In
+      #     particular a failed `Run live E2E allowlist` skips both saves, just
+      #     as the post phases skipped.
+      #   - same `path` and same `key` as the matching restore step.
+      - name: Save Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 8
+        continue-on-error: true
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Save live backend fixture
+        if: steps.live-backend-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/live-backend
+          key: live-backend-${{ runner.os }}-${{ hashFiles('e2e/live/ci/backend.env') }}
 
       # Ephemeral runner — no teardown needed; stop-backend.sh exists for
       # local runs of the same scripts.

--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -134,8 +134,37 @@ jobs:
           node-version: '22.x'
           cache: 'pnpm'
 
-      - name: Turbo Cache
-        uses: actions/cache@v6
+      # ── Cache bookkeeping cannot void a recorded verdict (objectui#7048) ──
+      # THE ORDERING, carried here from the type-check split in `ci.yml`
+      # (objectui#6577, PR #7047) because it is what a future reader needs in
+      # order to judge whether these steps may be touched: the verdict is
+      # recorded by the checking steps; everything after them is bookkeeping,
+      # and bookkeeping must never discard an answer the gate already produced.
+      #
+      # Why the SPLIT rather than a timeout on one step: combined
+      # `actions/cache` declares `main: dist/restore/index.js` plus
+      # `post: dist/save/index.js`, so its save is a step the RUNNER generates
+      # at job end (`Post Turbo Cache`). No workflow syntax attaches
+      # `timeout-minutes` or `continue-on-error` to a generated post step.
+      # Measured once, on `ci.yml`'s type-check cache: a 1-second save took
+      # 789s, ran that job into its ceiling, and the resulting `cancelled` —
+      # which the merge queue cannot tell from `failure` — ejected an all-green
+      # pull request (objectui#6577). `actions/cache`'s own `save-always`
+      # deprecation text points at this same split.
+      #
+      # ⚠️ This job declares NO `timeout-minutes`, so its ceiling is GitHub's
+      # default of 360 minutes, and `Bundle Analysis` is a required context
+      # (objectui#6245). A stalled save would therefore hold a required check
+      # open for up to six hours before reporting `cancelled`. ⛔ Adding a
+      # ceiling is NOT the fix and is not attempted here — it would change what
+      # this gate rejects. The bound below is on the bookkeeping step alone.
+      #
+      # The restore half is deliberately left UNBOUNDED: a restore stall fails
+      # BEFORE any verdict exists — a gate that did not run, which is honest —
+      # rather than a recorded verdict discarded.
+      - name: Restore Turbo Cache
+        id: turbo-cache
+        uses: actions/cache/restore@v6
         with:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -470,3 +499,39 @@ jobs:
               core.warning(`Could not comment on PR: ${error.message}`);
               await core.summary.addRaw(body).write();
             }
+
+      # The bookkeeping half of the split documented at the restore step above,
+      # placed HERE — last in the job, after the budget verdict AND after the
+      # comment that reports it — because that is exactly where the post phase
+      # it replaces already ran. Nothing about which commits this gate accepts
+      # or rejects moves with it.
+      #
+      # `timeout-minutes: 5` is DERIVED FOR THIS SITE, and landing on the same
+      # number PR #7047 chose is a result rather than a copy — objectui#7048
+      # fences inheriting that 5, so here is this site's own arithmetic. This
+      # job's own save of this cache measured 1s on 2026-09-02 (`Post Turbo
+      # Cache`, job 100096569559); the whole job was 4m07s. 5 minutes is 300x
+      # the measured save — the same ratio #7047 sized its bound at, arrived at
+      # from this job's own number.
+      #
+      # `continue-on-error: true` is the other half, and without it the bound
+      # would only trade a `cancelled` gate for a red one. A cache that failed
+      # to upload costs the next run some time; it says nothing whatsoever
+      # about the bundle sizes under test, so it must not speak for them.
+      #
+      # Behaviour preserved, spelled out so the equivalence is checkable:
+      #   - `cache-hit != 'true'` reproduces the combined action's own "exact
+      #     hit on the primary key ⇒ do not save" skip. A `restore-keys` prefix
+      #     match leaves `cache-hit` false and the save still runs, exactly as
+      #     the combined action behaved.
+      #   - the condition names no status function, so the implicit `success()`
+      #     still applies — matching the combined action's `post-if: success()`.
+      #   - same `path` and same `key` as the restore step above.
+      - name: Save Turbo Cache
+        if: steps.turbo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-${{ github.sha }}

--- a/scripts/__tests__/workflow-cache-save-bound.test.ts
+++ b/scripts/__tests__/workflow-cache-save-bound.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+/**
+ * objectui#7048 — every cache save in this repository is bounded and non-fatal,
+ * not just `ci.yml`'s `type-check` one.
+ *
+ * ## Why a second file beside `turbo-cache-save-bound.test.ts`
+ *
+ * That file is about ONE INCIDENT and one job: the 2026-08-26 merge-group build
+ * of #6571, where all 21 real steps of `Type Check` passed and then the
+ * runner-generated `Post Turbo Cache` spent 13m09s (789s) in the upload, hit the
+ * job's `timeout-minutes: 20`, and turned an all-green pull request into a
+ * `cancelled` check the merge queue could not tell from a failure. Its
+ * assertions are sized against that job's numbers and it should stay that way.
+ *
+ * This file is about the POPULATION. When #6577's fix landed, seven more
+ * combined `actions/cache@v6` uses across five workflows carried the identical
+ * exposure — that was the repository's DEFAULT SPELLING for caching, not an edge
+ * case on one job — and nothing in the tree noticed. So the subject here is the
+ * rule rather than the site: enumerate every workflow file, and require of every
+ * cache save what #6577 proved a cache save must have.
+ *
+ * ## The ordering, which is the whole point
+ *
+ * The verdict is recorded by the checking steps; everything after them is
+ * bookkeeping, and bookkeeping must never discard an answer the gate already
+ * produced. Combined `actions/cache` declares `main: dist/restore/index.js` plus
+ * `post: dist/save/index.js`, so its save is a step the RUNNER generates at job
+ * end and NO workflow syntax attaches `timeout-minutes` or `continue-on-error`
+ * to it. Splitting into `actions/cache/restore` + a trailing
+ * `actions/cache/save` is not a style preference — it is the only way those two
+ * keys can exist at all, and it is the route `actions/cache`'s own `save-always`
+ * deprecation text points at.
+ *
+ * ## Why it needs a pin: reverting is invisible
+ *
+ * Fold any split back into one `actions/cache` step and nothing goes red. The
+ * cache still works, every run still passes, and the next transient upload stall
+ * ejects the next green pull request — or, in the three jobs here that declare
+ * no `timeout-minutes` at all, holds a required context open against GitHub's
+ * 360-minute default. That is this repository's recurring "looks like
+ * enforcement, isn't" class (objectui#3009, #3181, #3494).
+ *
+ * ## Deliberately NOT asserted
+ *
+ * - That the RESTORE halves are bounded. A restore stall fails BEFORE any
+ *   verdict exists — a gate that did not run, which is honest — rather than a
+ *   recorded verdict discarded, and bounding it would force a cold check under
+ *   the same ceiling.
+ * - Any specific bound. Each site's number is derived from that site's own
+ *   measured healthy save and written into the workflow comment beside it;
+ *   objectui#7048 fences copying one site's number to another. What is asserted
+ *   is that a bound EXISTS and that it cannot crowd out the checking steps.
+ */
+
+const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
+const WORKFLOW_DIR = path.join(ROOT, '.github/workflows');
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  id?: string;
+  if?: string;
+  'timeout-minutes'?: number;
+  'continue-on-error'?: boolean;
+  with?: Record<string, string>;
+}
+interface Job {
+  'timeout-minutes'?: number;
+  steps?: Step[];
+}
+
+const workflowFiles = fs
+  .readdirSync(WORKFLOW_DIR)
+  .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+  .sort();
+
+interface JobEntry {
+  file: string;
+  jobKey: string;
+  job: Job;
+  steps: Step[];
+}
+
+const allJobs: JobEntry[] = workflowFiles.flatMap((file) => {
+  const parsed = parseYaml(fs.readFileSync(path.join(WORKFLOW_DIR, file), 'utf8')) as {
+    jobs?: Record<string, Job>;
+  };
+  return Object.entries(parsed?.jobs ?? {}).map(([jobKey, job]) => ({
+    file,
+    jobKey,
+    job,
+    steps: job.steps ?? [],
+  }));
+});
+
+const usesPrefix = (step: Step, prefix: string) => (step.uses ?? '').startsWith(prefix);
+const where = (e: JobEntry, s: Step) => `${e.file} :: job \`${e.jobKey}\` :: step \`${s.name ?? '(unnamed)'}\``;
+
+describe('every workflow cache save is bounded and non-fatal (objectui#7048)', () => {
+  it('reads a plausible population — the scan below is not vacuous', () => {
+    // The enumeration is the axis that failed when this card was first filed:
+    // the population was inherited from one file's grep instead of derived
+    // across the directory, and undercounted by more than 3x. A control that
+    // only proves the PROBE works cannot catch that; this one is on the
+    // population itself.
+    expect(
+      workflowFiles.length,
+      `implausibly few workflow files found under ${WORKFLOW_DIR} — every assertion below would ` +
+        'pass while reading nothing',
+    ).toBeGreaterThan(20);
+    expect(allJobs.length, 'implausibly few jobs parsed out of those workflow files').toBeGreaterThan(20);
+  });
+
+  it('caches through the split form only — never the combined action', () => {
+    const offenders = allJobs.flatMap((e) =>
+      e.steps.filter((s) => /^actions\/cache@/.test(s.uses ?? '')).map((s) => where(e, s)),
+    );
+
+    expect(
+      offenders,
+      'these steps use the COMBINED `actions/cache` action:\n' +
+        offenders.map((o) => `  - ${o}`).join('\n') +
+        '\n\nIts save runs as a runner-generated POST step, which cannot carry `timeout-minutes` ' +
+        'or `continue-on-error` — so an upload stall runs the job into its ceiling and cancels a ' +
+        'gate that had already passed (objectui#6577), or, in a job with no declared ceiling, ' +
+        "holds it against GitHub's 360-minute default. Use `actions/cache/restore` plus a bounded, " +
+        '`continue-on-error` `actions/cache/save` placed after the last command step.',
+    ).toEqual([]);
+  });
+
+  it('actually caches something — the rule above is not passing on an empty set', () => {
+    // Without this, deleting every cache step in the repository would make the
+    // assertion above green. The rule is "saves are bounded", not "there are no
+    // saves".
+    const saves = allJobs.flatMap((e) => e.steps.filter((s) => usesPrefix(s, 'actions/cache/save@')));
+    expect(
+      saves.length,
+      'no workflow in this repository saves a cache any more. If that is deliberate, this whole ' +
+        'file is obsolete and should be deleted with the reason recorded — not left passing on an ' +
+        'empty set.',
+    ).toBeGreaterThan(5);
+  });
+
+  it('bounds every save, and lets none of them speak for the code', () => {
+    const unbounded: string[] = [];
+    const fatal: string[] = [];
+
+    for (const e of allJobs) {
+      for (const s of e.steps.filter((x) => usesPrefix(x, 'actions/cache/save@'))) {
+        if (typeof s['timeout-minutes'] !== 'number') unbounded.push(where(e, s));
+        if (s['continue-on-error'] !== true) fatal.push(where(e, s));
+      }
+    }
+
+    expect(
+      unbounded,
+      'these cache saves declare no `timeout-minutes`:\n' +
+        unbounded.map((o) => `  - ${o}`).join('\n') +
+        '\n\nThe bound is the only thing standing between a stalled upload and the job ceiling, ' +
+        'and the job ceiling reports `cancelled` — a gate that says nothing at all (objectui#6577). ' +
+        "Derive the number from that site's own measured healthy save; do not copy another site's.",
+    ).toEqual([]);
+
+    expect(
+      fatal,
+      'these cache saves do not declare `continue-on-error: true`:\n' +
+        fatal.map((o) => `  - ${o}`).join('\n') +
+        '\n\nWithout it the bound only trades a `cancelled` gate for a red one. A cache that ' +
+        'failed to upload costs the next run some time and says nothing whatsoever about the code ' +
+        'under test, so it must not be allowed to speak for it.',
+    ).toEqual([]);
+  });
+
+  it('runs every save AFTER its job’s last command step — bookkeeping follows the verdict', () => {
+    const hoisted: string[] = [];
+
+    for (const e of allJobs) {
+      const lastCommand = e.steps.map((s) => s.run !== undefined).lastIndexOf(true);
+      if (lastCommand === -1) continue; // no commands in this job: nothing to protect
+      for (const s of e.steps.filter((x) => usesPrefix(x, 'actions/cache/save@'))) {
+        if (e.steps.indexOf(s) < lastCommand) {
+          hoisted.push(`${where(e, s)} (runs before \`${e.steps[lastCommand].name ?? '(unnamed)'}\`)`);
+        }
+      }
+    }
+
+    expect(
+      hoisted,
+      'these cache saves run BEFORE their job’s last command step:\n' +
+        hoisted.map((o) => `  - ${o}`).join('\n') +
+        '\n\nThe verdict is recorded by the command steps; everything after them is bookkeeping, ' +
+        'and that ordering is what makes a save safe to bound and safe to lose. A save hoisted ' +
+        'above a checking step is bookkeeping that can still delay, and be blamed for, an answer ' +
+        'that has not been produced yet (objectui#6577).',
+    ).toEqual([]);
+  });
+
+  it('still caches the same thing the combined step did', () => {
+    const broken: string[] = [];
+
+    for (const e of allJobs) {
+      const restores = e.steps.filter((s) => usesPrefix(s, 'actions/cache/restore@'));
+      for (const save of e.steps.filter((s) => usesPrefix(s, 'actions/cache/save@'))) {
+        const restore = restores.find((r) => r.with?.path === save.with?.path);
+        if (!restore) {
+          broken.push(`${where(e, save)}: no \`actions/cache/restore\` in this job reads path \`${save.with?.path}\``);
+          continue;
+        }
+        if (save.with?.key !== restore.with?.key) {
+          broken.push(`${where(e, save)}: writes key \`${save.with?.key}\` but the restore asks for \`${restore.with?.key}\` — every run would miss`);
+        }
+        if (!restore.id) {
+          broken.push(`${where(e, restore)}: needs an \`id\` so the save can read its \`cache-hit\` output`);
+          continue;
+        }
+        const guard = `steps.${restore.id}.outputs.cache-hit != 'true'`;
+        if (!(save.if ?? '').includes(guard)) {
+          broken.push(`${where(e, save)}: must skip on an exact primary-key hit — \`${guard}\`. The combined action did this internally; after the split it is the workflow’s job, and without it every re-run re-uploads a cache that already exists.`);
+        }
+      }
+    }
+
+    expect(broken, 'the split has silently changed what gets cached:\n' + broken.map((o) => `  - ${o}`).join('\n')).toEqual([]);
+  });
+
+  it('never lets bookkeeping crowd out the checking steps under a declared ceiling', () => {
+    // Generalises the type-check pin's invariant to jobs with more than one
+    // cache: it is the SUM of a job's save bounds that competes with its
+    // verdict path for the ceiling, not any single bound.
+    const crowded: string[] = [];
+
+    for (const e of allJobs) {
+      const ceiling = e.job['timeout-minutes'];
+      if (typeof ceiling !== 'number') continue;
+      const bounds = e.steps
+        .filter((s) => usesPrefix(s, 'actions/cache/save@'))
+        .map((s) => s['timeout-minutes'] ?? 0);
+      if (bounds.length === 0) continue;
+      const total = bounds.reduce((a, b) => a + b, 0);
+      if (total * 2 > ceiling) {
+        crowded.push(
+          `${e.file} :: job \`${e.jobKey}\`: cache saves may run for ${total} of the job's ${ceiling} minutes (bounds: ${bounds.join(' + ')})`,
+        );
+      }
+    }
+
+    expect(
+      crowded,
+      'bookkeeping can starve the verdict path of its ceiling here:\n' +
+        crowded.map((o) => `  - ${o}`).join('\n') +
+        '\n\nA bound that large can still cancel the job — which is the defect, not the fix.',
+    ).toEqual([]);
+  });
+
+  it('does not raise the ceilings of the jobs this card bounded — the ruled-out non-fix', () => {
+    // Ruled out on objectui#6577 and again on #7048: a larger ceiling buys a
+    // longer hang and still ends in `cancelled`, and lifting a gate's ceiling
+    // weakens the gate. Raising one for some UNRELATED reason is a decision
+    // someone may need to make — make it deliberately, and move this pin in the
+    // same commit, rather than discovering later that the fix was undone by it.
+    const ceilings: Record<string, number> = {
+      'ci.yml::e2e': 30,
+      'ci.yml::docs': 15,
+      'live-e2e.yml::live-e2e': 40,
+    };
+
+    for (const [key, max] of Object.entries(ceilings)) {
+      const [file, jobKey] = key.split('::');
+      const entry = allJobs.find((e) => e.file === file && e.jobKey === jobKey);
+      expect(entry, `${file} must still define a \`${jobKey}:\` job`).toBeDefined();
+      expect(
+        entry!.job['timeout-minutes'],
+        `the \`${jobKey}\` job ceiling in ${file} moved. Raising it does not fix a hung cache save — ` +
+          'the hang just runs longer and the gate still reports `cancelled` (objectui#6577).',
+      ).toBeLessThanOrEqual(max);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #7048

Every remaining combined `actions/cache@v6` use in this repository is split into `actions/cache/restore@v6` (in place, unbounded) plus a trailing `actions/cache/save@v6` carrying `timeout-minutes` and `continue-on-error: true`. Seven sites across five workflows — which, as the card's correction comment recorded, was the repository's **default spelling for caching**, not an edge case on one job.

The mechanism is #6577's, pinned by PR #7047 and not re-argued here: the combined action declares `main: dist/restore/index.js` plus `post: dist/save/index.js`, so its save is a step the *runner* generates at job end and **no workflow syntax attaches `timeout-minutes` or `continue-on-error` to it**. An upload stall therefore runs the job into its ceiling, the job goes `cancelled`, and the merge queue cannot tell `cancelled` from `failure`. The ordering sentence is carried verbatim into all seven comments: *the verdict is recorded by the checking steps; everything after them is bookkeeping, and bookkeeping must never discard an answer the gate already produced.*

⛔ No job's `timeout-minutes` is raised, and none is added. ⛔ No verdict-bearing step is touched.

## Population — re-derived, not inherited

Enumeration and content read from the same source (`git ls-tree -r`, then `git show`) at `adbda1bed`:

| | before | after |
|:--|--:|--:|
| workflow files enumerated | 31 | 31 |
| combined `actions/cache@v6` sites | 7 | **0** |
| split-form `restore`/`save` lines | 2 (the PR #7047 site) | 16 (8 sites) |
| control: `uses: actions/` lines across those files | 88 | 95 (+7, one per split) |

## The seven sites, each with its own bound

⭐ The card fences copying PR #7047's `timeout-minutes: 5` across. Every number below is derived from that site's own measurement; the four `.turbo/cache` sites landing on 5 is a *result* of their own arithmetic, not a copy — each comment carries its own working.

| workflow:line (at `adbda1bed`) | cache content | job ceiling | measured healthy save | bound | live run on this PR |
|:--|:--|:--|:--|--:|:--|
| `ci.yml:1146` — `e2e` | Playwright browsers, ~269 MB | 30 min | not directly observable (saves only after a version bump; post = 0s on every sampled run). Restores of the same archive: **3s** (jobs 100096569775, 100094597323), 5s in `live-e2e.yml` | **8 min** | ✅ yes |
| `ci.yml:1311` — `docs` | `.turbo/cache` | 15 min | **5s** (`Post Turbo Cache`, job 100094597253) | **5 min** | ⚠️ partial — steps skip on a PR without `apps/site/`/`content/` changes; the job's real run is the `merge_group` build |
| `lint.yml:244` | `.turbo/cache` | **none** (360 default) | **6s** (job 100097466846) | **5 min** | ✅ yes |
| `live-e2e.yml:98` | live backend fixture | 40 min | **8s** (job 100097466897 — a real save; the restore missed) | **5 min** | ✅ yes |
| `live-e2e.yml:163` | Playwright browsers, ~269 MB | 40 min | as `ci.yml:1146`; restore **5s** here | **8 min** | ✅ yes |
| `performance-budget.yml:138` | `.turbo/cache` | **none** (360 default) | **1s** (job 100096569559) | **5 min** | ✅ yes (self-included in its own `paths:`) |
| `changeset-release.yml:576` | `.turbo/cache` | **none** (360 default) | ⚠️ **not observable at this site** — see below | **5 min** | ⛔ no (`push` to `main` / `schedule` only) |

**Bound arithmetic, stated so it is checkable**

- **Playwright (8 min).** Restores of that exact 269 MB archive measured 3s/3s/5s on this runner class ⇒ the cache service moves it at ~54–90 MB/s downward. Taking a deliberately pessimistic **20x** penalty for the upload direction on the *slowest* observed restore gives ~1m40s for an honest save; 8 minutes is ~4.8x that and demands only **0.56 MB/s** sustained to finish. Ceiling check: 8 × 2 = 16 ≤ 30 (and ≤ 40).
- **`.turbo/cache` (5 min).** Same cache, four independent same-day measurements: 1s, 2s, 5s, 6s. 5 minutes is 50x the slowest and 300x the fastest. Ceiling check where one exists: 5 × 2 = 10 ≤ 15.
- **`live-e2e.yml` has two caches under one ceiling**, so what matters is the *sum*: 5 + 8 = 13 min against a verdict path measured at 2m25s end to end — both bookkeeping halves stalling at once still cannot reach 40.

**⚠️ Where the derivation is weaker, said plainly rather than dressed up**

`changeset-release.yml` is the only site with no same-site save measurement. Its `release` job runs on `push` to `main` only when the version is not yet on npm, and on the 6-hourly `schedule` the primary key is an exact hit — the sampled scheduled run's `Post Turbo Cache` measured **0s** with its restore at 4s (job 99021319583, 2026-08-29). Its bound is therefore derived from the **same cache at four sibling sites**. It is included rather than left out because the diff there is strictly the cache step plus its comment, the save is appended after publish, after the post-version tree validation and after the refresh, and it carries `continue-on-error: true` — so nothing the release lane does can be affected by it. The workflow still parses (below). If a directly measured save of that site ever lands outside the 1–6s range, the comment says to re-derive rather than defend the number.

## No verdict-bearing step changed — comparison parser output

PR #7047's approach, re-implemented over all five files: parse both revisions with a real YAML parser and compare, per job, every command-bearing (`run:`) step plus each job's `timeout-minutes`.

```
compared .github/workflows/ci.yml: 7 job(s), 50 command-bearing step(s); ceilings: changeset-check=10, type-check=20, test=20, test-coverage=40, coverage-report=20, e2e=30, docs=15
compared .github/workflows/lint.yml: 1 job(s), 11 command-bearing step(s); ceilings: lint=none
compared .github/workflows/live-e2e.yml: 1 job(s), 10 command-bearing step(s); ceilings: live-e2e=40
compared .github/workflows/performance-budget.yml: 1 job(s), 10 command-bearing step(s); ceilings: bundle-analysis=none
compared .github/workflows/changeset-release.yml: 2 job(s), 12 command-bearing step(s); ceilings: lane=none, release=none

TOTAL COMPARED: 12 jobs, 93 command-bearing steps across 5 files

RESULT: no command-bearing step and no job ceiling differs between the two revisions.

CONTROL (BASE vs BASE with one `run:` body mutated — "node scripts/check-changeset-fixed.mjs"):
  - ci.yml[CONTROL] :: job changeset-check: command step GONE or CHANGED: Verify all packages are in changeset fixed group
  - ci.yml[CONTROL] :: job changeset-check: command step NEW or CHANGED: Verify all packages are in changeset fixed group
CONTROL PASSED: the comparator does notice a changed command step, so the RESULT above is non-vacuous.
```

⭐ **The control earned its keep, and the way it did is worth recording.** Its first spelling appended ` # CONTROL-MUTATION` to a `run:` line — YAML reads that as a trailing comment, the parsed scalar never changed, and the control came back **clean while the comparator was working perfectly**. Exactly the class of trap PR #7047 recorded for its own ablation anchor, caught here only because the control was asserted rather than assumed. The mutation now changes the scalar itself.

## Ablation — 21 of them, each proven on disk and each restore proven by blob hash

Three mutations × seven sites, run against the pin: fold the split back, drop `continue-on-error`, hoist the save above the checking steps. **21 red, 0 green.** Every mutation is confirmed on disk before the reading is trusted, anchored on the **YAML key at its exact indent** — never the phrase, because `continue-on-error: true` also appears in the comments this change adds (the trap #7047 recorded, inherited deliberately). Every restore is proven by comparing `git hash-object` against the file's HEAD blob, with an empty hash read as failure.

| mutation | on-disk proof | assertion that caught it |
|:--|:--|:--|
| fold split back | `uses: actions/cache@v6` +1, `restore@v6` −1, `save@v6` −1 | *caches through the split form only — never the combined action* |
| drop `continue-on-error` | exact-indent key −1 | *bounds every save, and lets none of them speak for the code* |
| hoist above checks | ⭐ counts are **+0 by construction** for a move, so this leg measures **position** instead: save line 260 → last `run:` 193 before (after: true) vs save 153 → last `run:` 204 after (after: false) | *runs every save AFTER its job's last command step* |

Sample restore proof: `restored; blob fed6ab4ad671edbce5d5d271c35f61474cc09c68 == HEAD fed6ab4ad671edbce5d5d271c35f61474cc09c68`. Final line: `all 5 touched workflow files match their HEAD blobs.`

## Gates — all run at the final commit `4c67aeddb`, verdict lines quoted

| gate | verdict line |
|:--|:--|
| changeset presence | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` (6 files changed, 0 published source) — **none owed** |
| `check:control-bytes` | `✅  check-control-bytes: OK (scanned 6002 tracked text file(s); skipped 85 binary).` |
| `check:shell-escape-residue` | `✅  check-shell-escape-residue: OK (4/4 root(s) resolved … 205 file(s) and 1318 fenced block(s) examined)` — its roots are AGENTS/CLAUDE/skills/content, so it does not scan workflows |
| `check:governed-queue-guard` | `OK check-governed-queue-guard self-test: 132 cases pass`; and for this diff's paths: `✅ NOT GOVERNED — 6 path(s) checked against 5 governed surface(s); none matched.` |
| `check:lint-coverage` | `✅  lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| YAML parse, all workflows | `parsed 31 workflow file(s), 39 job(s) total, 0 problem(s)` — this is the "`changeset-release.yml` still parses" evidence; `actionlint` is neither installed in this container nor referenced anywhere in the repo (`git grep actionlint` exits 1) |
| `scripts/` vitest suite (every test that reads these workflow files) | `Test Files  94 passed (94)` / `Tests  2625 passed (2625)` |
| `turbo-cache-save-bound` + `workflow-cache-save-bound` | `Test Files  2 passed (2)` / `Tests  14 passed (14)` |
| `type-check:scripts` | exit 0, and `--listFiles` confirms the new test file **is** in the program (1 occurrence; #7047's pin as positive control, also 1) — so this is a measurement, not a vacuous pass |
| eslint | root scope in full: **226 files, 0 errors, 29 pre-existing warnings**, exit 0, my file present in eslint's own resolved population |

**Declared narrowing:** `pnpm lint` (`turbo run lint`, 46 packages) was not run locally. Evidence the narrowing excludes nothing: (1) population read from eslint's own resolution, not a guess — 226 files in the root scope, 46/46 packages reported by `check-lint-coverage.mjs`; (2) file count read from `--format json`; (3) `eslint.config.js` declares no `project`/`projectService`/`parserOptions` (`grep` exits 1), so it is **not type-aware** and this diff cannot move any untouched file's verdict — and the diff contains zero files under `packages/`, `apps/` or `examples/`, so the package farm has no changed input at all. CI runs the farm regardless.

## Deviation from the declared file surface — one file, declared not hidden

The card fenced the file surface to the five workflow files. This PR adds one more: `scripts/__tests__/workflow-cache-save-bound.test.ts`.

The reason is the card's own requirement. *"Prove each pin has teeth by ablation"* is unanswerable without something that can go red — and reverting any of these seven splits is **invisible**: the cache still works, every run still passes, and the next transient stall ejects the next green pull request. PR #7047 shipped its split with a pin beside it for exactly this reason and said so in its own body. Without this file the ablation section above would read "21 mutations applied, nothing noticed."

It is a second file rather than an edit to `turbo-cache-save-bound.test.ts` because the two have different subjects: that one is about **one incident** and is sized against `type-check`'s numbers; this one is about the **population**, and asserts its non-vacuity on the population axis — which is precisely the axis that failed when this card was first filed 3.5x low, and which a probe-side control structurally cannot catch.

## Live-run coverage on this PR

`ci.yml`, `lint.yml` and `live-e2e.yml` are `pull_request`-triggered and `performance-budget.yml` lists its own file in its `paths:`, so **six of the seven sites get a live run on this PR**. Two caveats stated rather than glossed: `ci.yml`'s `docs` job skips its steps on a PR with no `apps/site/`/`content/` change, so that site's live proof arrives at the `merge_group` build; and `changeset-release.yml` runs only on `push` to `main` and on its schedule, so that site gets **no live run before merge** — the YAML parse and the pin are its whole local evidence.

## Not claimed

- ⛔ **No second occurrence has been observed.** #6577 stays n=1. This is exposure, not a defect, and nothing here upgrades it.
- ⛔ #7010 is **not** cited as corroboration — different fault shape, and the card says so.
- ⛔ Restore halves are deliberately left unbounded: a restore stall fails *before* any verdict exists, which is honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b)_