### PR TITLE
feat(gates): cover the permission authoring shapes in designer-field-key-parity

### DIFF
--- a/scripts/__tests__/check-designer-field-key-parity.test.ts
+++ b/scripts/__tests__/check-designer-field-key-parity.test.ts
@@ -3,17 +3,23 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { FieldSchema, ObjectSchema } from '@objectstack/spec/data';
+// The permission oracles are NOT on `/data` (objectui#6606) — the identity
+// proof below has to import them from the subpath the gate reads them from.
+import { ObjectPermissionSchema, PermissionSetSchema } from '@objectstack/spec/security';
 
 // Plain-JS CI helper. Its types are INFERRED from the .mjs source by
 // `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here.
 import {
   ExtractionError,
   KNOWN_UNPARSEABLE_KEYS,
+  ORACLES,
+  ORACLE_SPECIFIERS,
   PAYLOAD_SHAPES,
   analyze,
   declaredKeys,
   fieldSchemaAcceptSet,
   objectSchemaAcceptSet,
+  schemaAcceptSet,
 } from '../check-designer-field-key-parity.mjs';
 
 /**
@@ -370,6 +376,174 @@ describe('the second oracle — objectui#6223', () => {
   });
 });
 
+describe('the permission oracles — objectui#6606', () => {
+  // The permission matrix is the SECOND authoring surface with both of this
+  // gate's ingredients, and it was in none of the six original shapes.
+  // objectui#6595 (retired `allowRestore` / `allowPurge` checkboxes) is an
+  // instance of exactly this gate's class that reached the repo as a
+  // hand-written card rather than as a red gate.
+  const PERM_ROW_WIRE = {
+    id: 'FixturePermRow',
+    file: 'perm-row.ts',
+    interface: 'FixturePermRow',
+    schema: 'ObjectPermissionSchema' as const,
+    reach: 'wire' as const,
+    writer: 'fixture',
+  };
+  const PERM_SET_WIRE = {
+    id: 'FixturePermSet',
+    file: 'perm-set.ts',
+    interface: 'FixturePermSet',
+    schema: 'PermissionSetSchema' as const,
+    reach: 'wire' as const,
+    writer: 'fixture',
+  };
+
+  it('resolves the very same schema objects `@objectstack/spec/security` exports', async () => {
+    // Reference identity, as for the other two oracles: a structural check
+    // could not tell the installed schema from a look-alike, `===` can, and it
+    // is also what pins these to the ESM build for the dual-package reason.
+    expect((await schemaAcceptSet('ObjectPermissionSchema')).schema).toBe(ObjectPermissionSchema);
+    expect((await schemaAcceptSet('PermissionSetSchema')).schema).toBe(PermissionSetSchema);
+  });
+
+  it('reads them from `/security`, because `/data` does not export them', async () => {
+    // The subpath decides WHICH MODULE judges a save, so the measurement the
+    // map records is asserted rather than trusted. If these ever move onto
+    // `/data`, `ORACLE_SPECIFIERS` has to move with them and this fails first.
+    const data = await import('@objectstack/spec/data');
+    expect(data).not.toHaveProperty('ObjectPermissionSchema');
+    expect(data).not.toHaveProperty('PermissionSetSchema');
+    expect(ORACLE_SPECIFIERS.ObjectPermissionSchema).toBe('@objectstack/spec/security');
+    expect(ORACLE_SPECIFIERS.PermissionSetSchema).toBe('@objectstack/spec/security');
+  });
+
+  it('reads accept sets that are REAL and DIFFERENT from each other', async () => {
+    // Two oracles that resolved to the same schema would make one of the two
+    // checks vacuous while looking like it ran.
+    const { accept: rowKeys } = await schemaAcceptSet('ObjectPermissionSchema');
+    const { accept: setKeys } = await schemaAcceptSet('PermissionSetSchema');
+    const { accept: fieldKeys } = await fieldSchemaAcceptSet();
+    expect(rowKeys.has('allowRead')).toBe(true);
+    expect(rowKeys.has('objects')).toBe(false);
+    expect(setKeys.has('objects')).toBe(true);
+    expect(setKeys.has('allowRead')).toBe(false);
+    expect(rowKeys.has('zzzDefinitelyNotAKey')).toBe(false);
+    expect(rowKeys.size).not.toBe(setKeys.size);
+    expect(setKeys.size).not.toBe(fieldKeys.size);
+  });
+
+  it('both are STRICT — an unknown key is refused, not stripped', () => {
+    const row = ObjectPermissionSchema.safeParse({ allowRead: true, zzzDefinitelyNotAKey: 1 });
+    expect(row.success).toBe(false);
+    expect(row.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+    const set = PermissionSetSchema.safeParse({ name: 'admin', objects: {}, zzzDefinitelyNotAKey: 1 });
+    expect(set.success).toBe(false);
+    expect(set.error?.issues.map((i) => i.code)).toContain('unrecognized_keys');
+    // The same body without the extra key parses, so the failure above is the
+    // unknown key and not an unrelated invalid base.
+    expect(PermissionSetSchema.safeParse({ name: 'admin', objects: {} }).success).toBe(true);
+  });
+
+  it('goes red on a field-permission key sitting on an object-permission row', async () => {
+    // Realistic rather than bogus: `readable` / `editable` are the `FieldPerm`
+    // facets one level over, and an object row refuses them by name.
+    await withFixture(
+      { 'perm-row.ts': 'export interface FixturePermRow {\n  allowRead?: boolean;\n  readable?: boolean;\n}\n' },
+      async (dir) => {
+        const { violations } = await analyze(dir, { shapes: [PERM_ROW_WIRE], ledger: {} });
+        expect(violations.map((v) => `${v.key}:${v.oracle}`)).toEqual(['readable:ObjectPermissionSchema']);
+      },
+    );
+  });
+
+  it('the same key really is refused by the real schema, with `unrecognized_keys`', () => {
+    const parsed = ObjectPermissionSchema.safeParse({ allowRead: true, readable: true });
+    expect(parsed.success).toBe(false);
+    const issue = parsed.error?.issues.find((i) => i.code === 'unrecognized_keys');
+    expect((issue as { keys: string[] }).keys).toContain('readable');
+  });
+
+  it('routes each shape to ITS OWN oracle — `objects` is legal on the record and refused on a row', async () => {
+    // The record/row pair is the same trap the field/object pair carries:
+    // a pooled accept set would let a row-level key hide behind the record
+    // shape that legitimately declares that spelling.
+    await withFixture(
+      {
+        'perm-set.ts': 'export interface FixturePermSet {\n  name?: string;\n  objects?: unknown;\n}\n',
+        'perm-row.ts': 'export interface FixturePermRow {\n  allowRead?: boolean;\n  objects?: unknown;\n}\n',
+      },
+      async (dir) => {
+        const { violations } = await analyze(dir, {
+          shapes: [PERM_SET_WIRE, PERM_ROW_WIRE],
+          ledger: {},
+        });
+        expect(violations.map((v) => `${v.key}:${v.oracle}`)).toEqual(['objects:ObjectPermissionSchema']);
+      },
+    );
+  });
+
+  it('throws when a permission oracle cannot be resolved — a missing schema is never a pass', async () => {
+    await expect(
+      analyze(repoRoot, { shapes: [PERM_ROW_WIRE], ledger: {}, importSpec: async () => ({}) }),
+    ).rejects.toThrow(/no longer exports `ObjectPermissionSchema`/);
+  });
+
+  it('throws when a shape names an oracle no subpath is declared for', async () => {
+    // The failure mode the per-oracle subpath map introduces. Defaulting an
+    // unknown oracle to `/data` would resolve the wrong module — or nothing —
+    // and hand back the confident green this file exists to prevent.
+    const unmapped = { ...PERM_ROW_WIRE, schema: 'NotAnOracleSchema' as const };
+    await expect(analyze(repoRoot, { shapes: [unmapped], ledger: {} })).rejects.toThrow(ExtractionError);
+    await expect(analyze(repoRoot, { shapes: [unmapped], ledger: {} })).rejects.toThrow(
+      /no spec subpath is declared for the oracle `NotAnOracleSchema`/,
+    );
+  });
+
+  it('carries both permission shapes on the real tree, each judged by its own oracle', () => {
+    const perm = PAYLOAD_SHAPES.filter((s) => s.file.endsWith('permission-slice.ts'));
+    expect(perm.map((s) => `${s.id}:${s.schema}:${s.reach}`).sort()).toEqual([
+      'ObjectPerm:ObjectPermissionSchema:wire',
+      'PermissionSetDraft:PermissionSetSchema:wire',
+    ]);
+  });
+
+  it('sees the index signature on `PermissionSetDraft` — coverage note 2 applies here too', () => {
+    // `[extra: string]: unknown` is this shape's stated contract (a key the
+    // editor does not model is carried through save untouched), which is
+    // precisely the hole the gate records rather than hides.
+    const draft = PAYLOAD_SHAPES.find((s) => s.id === 'PermissionSetDraft')!;
+    expect(declaredKeys(repoRoot, draft).indexSignature).toBe(true);
+  });
+
+  it('every key the permission shapes can EMIT is accepted, on the real tree', async () => {
+    for (const id of ['PermissionSetDraft', 'ObjectPerm']) {
+      const shape = PAYLOAD_SHAPES.find((s) => s.id === id)!;
+      const { accept } = await schemaAcceptSet(shape.schema);
+      const { keys } = declaredKeys(repoRoot, shape);
+      expect(keys.filter((k: string) => !accept.has(k)), `${id} emits a refused key`).toEqual([]);
+    }
+  });
+
+  it('stays EMIT-SIDE — a spec key the shape omits is not reported', async () => {
+    // objectui#6605: `ObjectPerm` is a hand-written SUBSET of the spec's
+    // `ObjectPermission`. Under-coverage is a different question from the one
+    // this gate answers and stays a separate card, so the gate must be silent
+    // about the omissions. If that charter ever widens, this is the assertion
+    // that has to argue for it rather than be quietly deleted.
+    const { accept } = await schemaAcceptSet('ObjectPermissionSchema');
+    const shape = PAYLOAD_SHAPES.find((s) => s.id === 'ObjectPerm')!;
+    const { keys } = declaredKeys(repoRoot, shape);
+    const omitted = [...accept].filter((k) => !keys.includes(k));
+    expect(omitted).toContain('allowExport');
+    const { violations, uiOnly } = await analyze(repoRoot);
+    for (const key of omitted) {
+      expect(violations.map((v) => v.key), `${key} reported as a violation`).not.toContain(key);
+      expect(uiOnly.map((u) => u.key), `${key} reported as uiOnly`).not.toContain(key);
+    }
+  });
+});
+
 describe('the ledger ratchets in both directions', () => {
   const LEDGER = { zzzLedgeredKey: { card: 'objectui#0000', spec: null, note: 'fixture' } };
 
@@ -431,11 +605,33 @@ describe('extraction failure is an error, never a silent pass', () => {
 });
 
 describe('the real shapes, on the real tree', () => {
+  /**
+   * One key per shape that identifies THE INTERFACE, not merely some interface
+   * — the non-vacuity guard this file used to spell as a literal `label` on
+   * every shape. `label` cannot carry it everywhere: an authorization row
+   * (`ObjectPerm`, objectui#6606) has no label, while a walk that silently read
+   * some other seven-key interface would still have to miss `allowRead`. Every
+   * entry in `PAYLOAD_SHAPES` must appear here, so a shape cannot be added
+   * unwitnessed and read as verified.
+   */
+  const SHAPE_WITNESS: Record<string, string> = {
+    FieldMetadataPayload: 'label',
+    ServerFieldSchema: 'label',
+    DesignerFieldDefinition: 'label',
+    ObjectMetadataPayload: 'label',
+    ServerObjectSchema: 'label',
+    ObjectDefinition: 'label',
+    PermissionSetDraft: 'objects',
+    ObjectPerm: 'allowRead',
+  };
+
   it('finds every declared shape and reads a non-trivial key set from each', async () => {
     for (const shape of PAYLOAD_SHAPES) {
       const { keys } = declaredKeys(repoRoot, shape);
       expect(keys.length, `${shape.id} declared no keys`).toBeGreaterThan(5);
-      expect(keys, `${shape.id} is missing \`label\``).toContain('label');
+      const witness = SHAPE_WITNESS[shape.id];
+      expect(witness, `${shape.id} has no witness key in SHAPE_WITNESS`).toBeTruthy();
+      expect(keys, `${shape.id} is missing \`${witness}\``).toContain(witness);
     }
   });
 
@@ -515,9 +711,11 @@ describe('the real shapes, on the real tree', () => {
     const validate = (key: string, entry: { card?: string; note?: string; oracle?: string }) => {
       expect(entry.card, `${key} has no card`).toMatch(/^objectui#\d+$/);
       expect(entry.note, `${key} has no note`).toBeTruthy();
-      // objectui#6223: with two oracles, an entry that names none silently
-      // defaults to the field one and can absorb an object-level key.
-      expect(['FieldSchema', 'ObjectSchema'], `${key} names no oracle`).toContain(entry.oracle);
+      // objectui#6223: with more than one oracle, an entry that names none
+      // silently defaults to the field one and can absorb another level's key.
+      // Read from `ORACLES` rather than re-listed, so adding an oracle
+      // (objectui#6606 added two) cannot leave this list behind.
+      expect(ORACLES, `${key} names no oracle`).toContain(entry.oracle);
     };
 
     // Non-vacuity, on a fixture rather than on the real tree: the loop body

--- a/scripts/check-designer-field-key-parity.mjs
+++ b/scripts/check-designer-field-key-parity.mjs
@@ -11,6 +11,26 @@
  * object-level keys (`group`, `sortOrder`, `relationships`) that `ObjectSchema`
  * refuses by name, sitting on the wire the whole time the gate was green.
  *
+ * A THIRD and FOURTH oracle, because the permission matrix is a SECOND
+ * authoring surface carrying the same two ingredients (objectui#6606). Its
+ * statically declared shapes are in
+ * `packages/app-shell/src/views/metadata-admin/permission-slice.ts`:
+ * `PermissionSetDraft` is the record `PermissionMatrixEditor.doSave` hands to
+ * `client.save`, and `ObjectPerm` is one authorization row inside that
+ * record's `objects` map — nested exactly as a field shape is nested in the
+ * object document. They are judged by `PermissionSetSchema` and
+ * `ObjectPermissionSchema`. Nothing in this repo watched that surface before:
+ * objectui#6595 (the retired `allowRestore` / `allowPurge` checkboxes) is an
+ * instance of precisely this gate's class, and it arrived as a hand-written
+ * card from the upstream retirement (objectstack#12497) rather than from CI.
+ *
+ * The permission entries are the same EMIT-SIDE check as everywhere else, and
+ * deliberately so: `ObjectPerm` is a hand-written SUBSET of the spec's
+ * `ObjectPermission` (it omits `allowExport`, `readScope`, `writeScope` —
+ * objectui#6605). Under-coverage is a different question from the one this gate
+ * answers and stays a separate card; a key the shape can EMIT that the schema
+ * refuses is this one.
+ *
  * The failure class (objectui#5761): a designer offers a control that
  * writes a key the spec refuses BY NAME. The author sees the control work
  * — and, in metadata-admin, sees the preview render it — then
@@ -54,6 +74,9 @@
  * one of those interfaces. That is enough to have caught all three instances
  * above: `indexed` was a declared property of the designer field definition,
  * `distance_metric` a declared property, `placeholder` a declared property.
+ * On the permission surface it is what will show `allowRestore` / `allowPurge`
+ * on `ObjectPerm` the moment the spec bump carrying their retirement lands —
+ * the return direction the filing card named.
  *
  * NOT COVERED — four ways a key can reach the payload without ever appearing as
  * a declared property:
@@ -81,19 +104,30 @@
  *      refinement) is green here and still a 422 in production.
  *
  * ── The accept set is read from the schema, never listed here ───────────────
- * `FieldSchema` and `ObjectSchema` are strict zod objects: they refuse unknown
- * keys with `unrecognized_keys` rather than stripping them (objectstack#4001
- * closed the silent-drop shape). Each accept set is read off the schema's own
- * `shape` at run time.
+ * All four oracles are strict zod objects: they refuse unknown keys with
+ * `unrecognized_keys` rather than stripping them (objectstack#4001 closed the
+ * silent-drop shape). Each accept set is read off the schema's own `shape` at
+ * run time.
+ *
+ * WHICH SUBPATH each is read from is itself declared, in
+ * {@link ORACLE_SPECIFIERS}, because it is not one subpath: measured against
+ * `@objectstack/spec` 17.2.0, `/data` exports `FieldSchema` / `ObjectSchema`
+ * and neither permission schema, while `/security` exports both permission
+ * schemas. An oracle that map does not carry is an extraction ERROR —
+ * defaulting to `/data` would silently read the wrong module and pass over
+ * everything.
  *
  * It is read through a dynamic `import()`, NOT `createRequire`, and that is
  * load-bearing rather than stylistic. `@objectstack/spec` is a dual-package
  * build: `require` lands on `dist/data/index.js`, `import` on
- * `dist/data/index.mjs`. Those are two different module instances of the same
+ * `dist/data/index.mjs`, and `/security` carries the identical export map
+ * (`dist/security/index.js` vs `dist/security/index.mjs`), so this reasoning
+ * applies to the permission oracles unchanged. Those are two different module instances of the same
  * schema, so a CJS-resolving gate cannot be proven — by identity — to be
  * reading the build the app bundles against, and the two could drift with
  * nothing to notice. Importing makes the self-test's `===` against a plain
- * `import { FieldSchema } from '@objectstack/spec/data'` a real proof of
+ * `import { FieldSchema } from '@objectstack/spec/data'` — and, for the
+ * permission oracles, from `@objectstack/spec/security` — a real proof of
  * provenance, which is the assertion that rules out the whole
  * wrong-symbol failure mode. This is why the exported functions are async. A hardcoded copy would be the stale second definition this whole
  * family of gates exists to prevent, and — worse for a parity check — a wrongly
@@ -254,6 +288,33 @@ export const PAYLOAD_SHAPES = [
     reach: "ui",
     writer: "ObjectManager (in-memory model)",
   },
+  {
+    id: "PermissionSetDraft",
+    file: "packages/app-shell/src/views/metadata-admin/permission-slice.ts",
+    interface: "PermissionSetDraft",
+    schema: "PermissionSetSchema",
+    reach: "wire",
+    // `PermissionMatrixEditor.doSave` writes it with
+    // `client.save(type, name, toSave)`. At package scope `mergePermissionSlice`
+    // first rebuilds it from a freshly-read base (ADR-0086 P0) — the merged
+    // result is still this shape, so the declared keys are the same body either
+    // way. Carries an index signature (coverage note 2), which here is a stated
+    // contract rather than an oversight: a key this editor does not model is
+    // carried through save untouched.
+    writer: "PermissionMatrixEditor.doSave",
+  },
+  {
+    id: "ObjectPerm",
+    file: "packages/app-shell/src/views/metadata-admin/permission-slice.ts",
+    interface: "ObjectPerm",
+    schema: "ObjectPermissionSchema",
+    reach: "wire",
+    // One authorization row inside `PermissionSetDraft.objects`, so it reaches
+    // the very same saved body one level down — the field-in-object nesting
+    // again, which is why it needs its own oracle rather than riding on the
+    // record's.
+    writer: "PermissionMatrixEditor.doSave (objects[name] row)",
+  },
 ];
 
 /**
@@ -324,24 +385,58 @@ export const KNOWN_UNPARSEABLE_KEYS = {
   // gate still reports below.
 };
 
+/**
+ * Oracle name -> the PUBLISHED SUBPATH its schema is exported from.
+ *
+ * Declared here rather than inlined at the import because it is the seam that
+ * decides WHICH MODULE INSTANCE judges a payload, and it is not one subpath:
+ * the permission schemas are not on `/data` (measured, `@objectstack/spec`
+ * 17.2.0). `/security` has the same dual-package export map as `/data`, so the
+ * header's provenance argument carries over verbatim and the self-test pins
+ * each of the four by reference identity against a plain `import` from the
+ * subpath named here.
+ *
+ * An oracle a shape names and this map does not carry is an
+ * {@link ExtractionError} — never a default. Falling back to `/data` for an
+ * unknown oracle is the confident-green failure this whole file exists to
+ * prevent.
+ */
+export const ORACLE_SPECIFIERS = {
+  FieldSchema: "@objectstack/spec/data",
+  ObjectSchema: "@objectstack/spec/data",
+  PermissionSetSchema: "@objectstack/spec/security",
+  ObjectPermissionSchema: "@objectstack/spec/security",
+};
+
 /** The oracle names a shape may name, in the order they are reported. */
-export const ORACLES = ["FieldSchema", "ObjectSchema"];
+export const ORACLES = Object.keys(ORACLE_SPECIFIERS);
 
 /**
  * The keys the INSTALLED schema named by `exportName` accepts, read off the
  * schema itself.
  *
- * Resolved through `@objectstack/spec/data` — the published subpath, the same
- * one the runtime parses with — so this is the schema that actually judges a
- * `PUT`, not a local look-alike. Extraction failure throws; see the header.
+ * Resolved through the published subpath {@link ORACLE_SPECIFIERS} names for
+ * that oracle — the same entry point the runtime parses with — so this is the
+ * schema that actually judges a save, not a local look-alike. Extraction
+ * failure throws; see the header.
  */
 export async function schemaAcceptSet(exportName, importSpec = (id) => import(id)) {
+  const specifier = Object.prototype.hasOwnProperty.call(ORACLE_SPECIFIERS, exportName)
+    ? ORACLE_SPECIFIERS[exportName]
+    : null;
+  if (!specifier) {
+    fail(
+      `no spec subpath is declared for the oracle \`${exportName}\` — add it to ORACLE_SPECIFIERS.\n` +
+        "    Falling back to another subpath would resolve the wrong module (or nothing) and\n" +
+        "    pass over every key the real schema refuses."
+    );
+  }
   let data;
   try {
-    data = await importSpec("@objectstack/spec/data");
+    data = await importSpec(specifier);
   } catch (err) {
     fail(
-      "cannot resolve @objectstack/spec/data — run `pnpm install` first.\n" +
+      `cannot resolve ${specifier} — run \`pnpm install\` first.\n` +
         "    This gate reads the spec's own schema; it has no hardcoded fallback by design.\n" +
         `    (${err && err.message})`
     );
@@ -349,14 +444,14 @@ export async function schemaAcceptSet(exportName, importSpec = (id) => import(id
   const schema = data[exportName];
   if (!schema) {
     fail(
-      `@objectstack/spec/data no longer exports \`${exportName}\` — the accept set cannot be derived.\n` +
+      `${specifier} no longer exports \`${exportName}\` — the accept set cannot be derived.\n` +
         "    Re-point this gate at the schema that judges that payload; do NOT hardcode a key list."
     );
   }
   const keys = shapeKeys(schema);
   if (!keys || keys.length === 0) {
     fail(
-      `could not resolve \`${exportName}\`'s shape from @objectstack/spec/data.\n` +
+      `could not resolve \`${exportName}\`'s shape from ${specifier}.\n` +
         "    The schema's internal representation changed. Fix the walk — falling back to a\n" +
         "    hardcoded key list would make this gate the stale copy it exists to prevent."
     );
@@ -586,7 +681,7 @@ async function main() {
   console.log(`  oracle: ${origin}`);
   for (const { shape, keys, indexSignature } of shapes) {
     console.log(
-      `  ${shape.id.padEnd(24)} ${String(keys.length).padStart(2)} declared  [${shape.reach}] vs ${(shape.schema ?? "FieldSchema").padEnd(12)}` +
+      `  ${shape.id.padEnd(24)} ${String(keys.length).padStart(2)} declared  [${shape.reach}] vs ${(shape.schema ?? "FieldSchema").padEnd(22)}` +
         (indexSignature ? "  (+ index signature — see coverage note 2)" : "")
     );
   }


### PR DESCRIPTION
Fixes #6606

`scripts/check-designer-field-key-parity.mjs` watched exactly one authoring
surface. Its six `PAYLOAD_SHAPES` are all the object/field designer path, judged
by `FieldSchema` / `ObjectSchema`. The permission matrix is a **second** surface
carrying both of the gate's ingredients — statically declared payload shapes,
and strict zod schemas that refuse unknown keys by name — and it was in none of
them, so the retired-key class the gate exists to catch was invisible there.
objectui#6595 (the retired `allowRestore` / `allowPurge` checkboxes) is an
instance of precisely that class, and it reached this repo as a hand-written
card from the upstream retirement (objectstack#12497) rather than from CI.

## What this adds

Two entries in `PAYLOAD_SHAPES`, both in
`packages/app-shell/src/views/metadata-admin/permission-slice.ts`:

| shape | oracle | subpath | reach |
|---|---|---|---|
| `PermissionSetDraft` | `PermissionSetSchema` | `@objectstack/spec/security` | wire |
| `ObjectPerm` | `ObjectPermissionSchema` | `@objectstack/spec/security` | wire |

`PermissionSetDraft` is the record `PermissionMatrixEditor.doSave` hands to
`client.save(type, name, toSave)`; `ObjectPerm` is one authorization row inside
that record's `objects` map, so it reaches the same saved body one level down —
the field-in-object nesting again, which is why it needs its own oracle rather
than riding on the record's.

## The subpath is per-oracle now, and that was a measurement

The permission schemas are **not** on `/data`. Measured against the installed
`@objectstack/spec` 17.2.0: `/data` exports neither `ObjectPermissionSchema` nor
`PermissionSetSchema`; `/security` exports both. So the hardcoded
`import("@objectstack/spec/data")` becomes a declared map, `ORACLE_SPECIFIERS`,
and `ORACLES` is derived from it (`Object.keys`) so the two cannot drift.

The two header constraints are kept, not worked around:

- **Extraction failure is an ERROR, never a pass.** An oracle the map does not
  carry throws `ExtractionError` rather than defaulting to `/data` — a silent
  default there would resolve the wrong module (or nothing) and produce the
  confident green the file exists to prevent. There is no silent-skip path on
  either new entry.
- **The accept set is read from the installed schema, never listed in the
  file.** No permission key list is hardcoded; resolution stays through the
  dynamic `import()`. `/security` carries the identical dual-package export map
  (`dist/security/index.js` for `require`, `dist/security/index.mjs` for
  `import`), so the provenance argument the header spells out applies to it
  unchanged — and the self-test pins all four oracles by reference identity
  against a plain static import from the subpath named in the map.

## Emit-side, deliberately

`ObjectPerm` is a hand-written **subset** of the spec's `ObjectPermission` (it
omits `allowExport`, `readScope`, `writeScope` — objectui#6605). Surfacing that
under-coverage stays a separate card, so this is the same emit-side check as
every other entry. A test asserts the gate stays silent about the omitted keys,
so widening the charter has to argue for itself rather than happen by drift.

## Gate verdict lines

Before (on `67dadd6`, two oracles, six shapes):

```
designer-field-key-parity: FieldSchema accepts 71 keys
designer-field-key-parity: ObjectSchema accepts 42 keys
...
designer-field-key-parity: OK
```

After (`18c3f61`, four oracles, eight shapes):

```
designer-field-key-parity: FieldSchema accepts 71 keys
designer-field-key-parity: ObjectSchema accepts 42 keys
designer-field-key-parity: PermissionSetSchema accepts 20 keys
designer-field-key-parity: ObjectPermissionSchema accepts 12 keys
  PermissionSetDraft       10 declared  [wire] vs PermissionSetSchema     (+ index signature — see coverage note 2)
  ObjectPerm                7 declared  [wire] vs ObjectPermissionSchema

designer-field-key-parity: OK
```

Green on today's tree, as the filing card predicted it would be once
objectui#6595 had landed: every key both shapes declare is accepted by the
schema that judges it.

## Teeth, proven by ablation

The card is fenced against editing `permission-slice.ts`, so the mutation was
applied to a **copy** of that file in a throwaway root and the **real**
`PAYLOAD_SHAPES` entries — real `interface`, real `schema`, real `reach` — were
run against it. The thing under test is the entry that ships, not a fixture
look-alike.

```
fenced file at HEAD before: dd14740b589865816440e03bb652535ed8c978b8
real entries under test: PermissionSetDraft -> PermissionSetSchema [wire] | ObjectPerm -> ObjectPermissionSchema [wire]
mutation on disk: injected counts=[1,1] (source counts=[0,0])
MUTATED  violations: ["allowResurrect:ObjectPermissionSchema:ObjectPerm","zzzRetiredRecordKey:PermissionSetSchema:PermissionSetDraft"]
restore on disk: injected counts=[0,0]
RESTORED violations: []
fenced file at HEAD after:  dd14740b589865816440e03bb652535ed8c978b8
ABLATION VERDICT: teeth proven on both new entries; fenced file byte-identical to HEAD throughout
```

Both legs prove they landed on disk by counting the injected and the original
text, not by reading an editor's exit code, and the fenced file is shown
byte-identical to its `HEAD` blob before and after.

## Self-test

The per-shape non-vacuity guard was a literal `label` on **every** shape. An
authorization row does not have one, so that assertion is now a witness key per
shape (`ObjectPerm` -> `allowRead`, `PermissionSetDraft` -> `objects`), with
every entry in `PAYLOAD_SHAPES` required to appear in the table — a shape cannot
land unwitnessed and read as verified. The ledger's oracle validation now reads
`ORACLES` instead of re-listing `['FieldSchema', 'ObjectSchema']`, so adding an
oracle cannot leave it behind.

Thirteen new cases (`it()` count in this file goes 32 -> 45, and 45 + 7 in
`zod-wrapper-keys.shared.test.ts` is exactly the 52 vitest reports as passing, so
none of them was skipped): reference identity for both permission oracles; the
`/data`-exports-neither measurement asserted rather than trusted; both accept sets
real and different; strictness with a parsing control body; a realistic negative
control (`readable`, a `FieldPerm` facet, on an object-permission row); per-shape
oracle routing (`objects` legal on the record, refused on a row); the
unresolvable-schema throw; the unmapped-oracle throw; both real entries present
and wire-bound; the index signature on `PermissionSetDraft`; every emitted key
accepted on the real tree; and the emit-side charter assertion.

## Verification

| command | verdict |
|---|---|
| `pnpm check:designer-field-key-parity` (before, `67dadd6`) | `designer-field-key-parity: OK` |
| `pnpm check:designer-field-key-parity` (after, `18c3f61`) | `designer-field-key-parity: OK` |
| `pnpm exec vitest run scripts/__tests__/check-designer-field-key-parity.test.ts scripts/__tests__/zod-wrapper-keys.shared.test.ts --maxWorkers=2` | `Test Files 2 passed (2) · Tests 52 passed (52)` |
| `pnpm type-check:scripts` | exit 0, no diagnostics |
| `pnpm check:control-bytes` | `check-control-bytes: OK (scanned 5996 tracked text file(s); skipped 85 binary)` |
| `pnpm check:entry-guard` | `check:entry-guard: 58 scripts/ file(s) — no entry guard outside the baseline` |
| `pnpm check:esm-specifiers` | `no un-ledgered package emits an extensionless relative specifier` |
| `node scripts/check-changeset-presence.mjs` | `No source or published contract of a released package changed in this range, so no changeset is owed.` |

`pnpm check:node-esm-load` (the full two-leg form) is **not** run here and the
narrowing is declared rather than implied: its subject is published packages and
its load leg builds them, which exceeds this container's foreground limit. Its
cheap specifier leg — the one that reads source — ran green above, and the
changeset-presence gate measured the population independently: of the 2 changed
files, **0** are published source of a package the release covers and **0** are a
manifest whose published contract moved. Nothing under `scripts/` is a published
package entry, so this diff cannot move any package's emitted specifiers. CI runs
the full farm regardless.

Every row above was run on `18c3f61` with a clean working tree (`git status
--porcelain` empty), so the greens describe the tree this PR proposes and not an
earlier one. The two test files are the complete set that names this script —
`git grep -l check-designer-field-key-parity -- 'scripts/__tests__/*'` returns
exactly those two — and `ci.yml:359` is the only workflow line that runs the
gate itself.

No changeset: `scripts/`-only, per the presence gate's own verdict quoted above.
No `packages/` source touched; `permission-slice.ts` is untouched, as the card
required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b)_