### PR TITLE
fix(tooling): drop the derivation gate's export filter — rule 2 as a one-liner, rule 1 scoped

### DIFF
--- a/scripts/__tests__/check-spec-symbol-derivation.test.ts
+++ b/scripts/__tests__/check-spec-symbol-derivation.test.ts
@@ -310,7 +310,23 @@ export interface UnrelatedLocalShape {
     );
   });
 
-  it('an unexported declaration — it publishes no surface to be mistaken for the spec', () => {
+  // ── Rewritten deliberately, not deleted (objectui#6291) ──────────────────
+  // This slot held the INVERSE pin — *"an unexported declaration — it publishes
+  // no surface to be mistaken for the spec"* — asserting `scan()` returns `[]`
+  // for the fixture below. It was a designed assertion, and its premise was
+  // measured false (objectui#5899, census in PR #6284): a spec-alignment claim
+  // is read by the next agent editing the FILE, not by an importer, so the
+  // package boundary was never what made it dangerous. The three module-local
+  // mirrors in `packages/react/src/spec-bridge/bridges/form-view.ts`
+  // (objectui#5652) had drifted on three keys and INVERTED one arm — admitting
+  // only the value the contract rejects — with this gate green throughout.
+  //
+  // The old fixture is kept verbatim below because it makes the point sharper
+  // than any new one could: it re-exported the declaration on the very next
+  // line (`export type { InternalNavigationConfig }`), so it DID publish a
+  // surface. `hasExportModifier` never saw it, because the export was a
+  // separate statement. The pin's own fixture contradicted the pin's own name.
+  it('a module-local declaration carrying a claim IS flagged (objectui#6291)', () => {
     withFixture(
       {
         'internal.ts': `
@@ -323,7 +339,44 @@ export const NAVIGATION_MODES = ['page', 'drawer'] as const;
 export type { InternalNavigationConfig };
 `,
       },
-      ({ 'internal.ts': file }) => expect(scan(file)).toEqual([])
+      ({ 'internal.ts': file }) => {
+        const found = scan(file);
+        expect(found.map((f: { name: string }) => f.name)).toEqual(['InternalNavigationConfig']);
+        expect(found[0].phrase.toLowerCase()).toContain('aligned with');
+      }
+    );
+  });
+
+  // The half the retired pin was really holding: rule 2 must stay quiet on
+  // module-local shapes, but for its OWN reasons — the renderer skip, the tie
+  // test, and the absence of a claim — never because of an `export` keyword.
+  // Each of the three below is module-local, and each is green on a different
+  // precision rule. If dropping the export filter had widened the rule beyond
+  // its stated boundary, these would have turned red with it.
+  it('…and the precision rules, not the export keyword, are what keep locals green', () => {
+    withFixture(
+      {
+        'locals.tsx': `
+import type { NavigationConfig } from '@objectstack/spec/ui';
+
+/** Local nav row. Aligned with @objectstack/spec ListView. */
+interface LocalTiedShape {
+  navigation?: NavigationConfig;
+}
+
+/** Local picker. Aligned with @objectstack/spec ReactionSchema. */
+const LocalReactionPicker = () => null;
+
+/** Fully resolved navigation state after defaults are applied. */
+interface LocalNoClaim {
+  mode: 'page' | 'drawer';
+}
+
+export type { LocalTiedShape, LocalNoClaim };
+export { LocalReactionPicker };
+`,
+      },
+      ({ 'locals.tsx': file }) => expect(scan(file)).toEqual([])
     );
   });
 });

--- a/scripts/__tests__/check-spec-symbol-derivation.test.ts
+++ b/scripts/__tests__/check-spec-symbol-derivation.test.ts
@@ -12,6 +12,7 @@ import {
   CLAIM_WINDOW,
   findClaim,
   normalizeDoc,
+  scanFile,
   scanFileForClaims,
 } from '../check-spec-symbol-derivation.mjs';
 
@@ -706,5 +707,136 @@ describe('the guard file itself', () => {
     for (const fragment of ['aligned with', 'mirrors', 'canonical', 'source of truth', 'conforms to']) {
       expect(header.toLowerCase(), fragment).toContain(fragment);
     }
+  });
+});
+
+
+// ── Rule 1's module-local boundary and its two narrowings (objectui#6291) ────
+
+/**
+ * Rule 1 skipped every non-exported declaration until objectui#6291. The
+ * measured cost of that filter (objectui#5899's census, PR #6284, re-taken on
+ * the implementing commit): 25 module-local declarations under spec export
+ * names, of which the four different-concept collisions got reasoned ALLOW
+ * entries and 15 findings under 14 names went to the DEBT ledger.
+ *
+ * Dropping it is only safe because two structural narrowings landed with it, and
+ * a narrowing is a statement about what this guard may NOT see. These cases are
+ * that statement's proof — one red per widening, and one green per narrowing,
+ * with the RED case for each narrowing's near neighbour sitting beside it. The
+ * No fixture below re-exports its declaration. That is deliberate and worth a
+ * line: a bare `export { X }` over a local import carries no module specifier,
+ * so the barrel skip in `scanFile` (which fires only on
+ * `export { X } from './x'`) misses it and records a SECOND finding at the
+ * barrel. That hole predates objectui#6291 — it is why
+ * `@object-ui/plugin-list:ListView` still matches an ALLOW entry while its two
+ * renderer siblings' entries were deleted — and it is filed, not fixed here.
+ * Re-exporting in a fixture would measure that hole instead of these narrowings.
+ *
+ * The near neighbours are the point: `rendersJsx` must not become "functions are
+ * exempt" (that would silence `isContextToken` and `normalizeFilterOperator`,
+ * both real mirrors), and `isPureAlias` must not become "type aliases are
+ * exempt" (that would silence every hand-written union under a spec name).
+ */
+describe("rule 1 sees module-local declarations, and the narrowings say which it may not", () => {
+  const RULE1_SPEC_NAMES = new Map<string, Set<string>>([
+    ['ListView', new Set(['@objectstack/spec/ui'])],
+    ['NavigationConfig', new Set(['@objectstack/spec/ui'])],
+    ['isContextToken', new Set(['@objectstack/spec/data'])],
+  ]);
+  const scan1 = (file: string) =>
+    (scanFile(file, RULE1_SPEC_NAMES) as { name: string; kind: string }[]).map((f) => ({
+      name: f.name,
+      kind: f.kind,
+    }));
+
+  it('a module-local hand-written declaration under a spec export name IS flagged', () => {
+    // The objectui#5652 shape: an `interface` the spec owns the name of, never
+    // exported, read by the next agent editing the file and drifting there.
+    withFixture(
+      {
+        'local.ts': `
+interface NavigationConfig {
+  mode: string;
+  view?: string;
+}
+`,
+      },
+      ({ 'local.ts': file }) =>
+        expect(scan1(file)).toEqual([{ name: 'NavigationConfig', kind: 'interface' }])
+    );
+  });
+
+  it('a module-local component that RENDERS the spec shape is not a second declaration of it', () => {
+    withFixture(
+      {
+        'renderer.tsx': `
+function ListView({ schema }: { schema: unknown }) {
+  return <div data-schema={String(schema)} />;
+}
+const NavigationConfig = () => <span />;
+`,
+      },
+      ({ 'renderer.tsx': file }) => expect(scan1(file)).toEqual([])
+    );
+  });
+
+  it('…but a module-local FUNCTION that renders nothing is still a fork', () => {
+    // The near neighbour that keeps `rendersJsx` from decaying into
+    // `isRendererLike`. `isContextToken` (@object-ui/core) and
+    // `normalizeFilterOperator` (@object-ui/data-objectstack) are the live
+    // instances: non-exported functions under spec export names, both real
+    // mirrors, both DEBT entries today. A blanket "functions are renderers"
+    // would have made them invisible instead — silently, and for good.
+    withFixture(
+      {
+        'predicate.ts': `
+function isContextToken(token: string): boolean {
+  return ['current_user_id', 'current_org_id'].includes(token);
+}
+`,
+      },
+      ({ 'predicate.ts': file }) =>
+        expect(scan1(file)).toEqual([{ name: 'isContextToken', kind: 'function' }])
+    );
+  });
+
+  it('a pure alias to a single identifier is derivation by delegation', () => {
+    // `type FlowNode = FlowDesignerNode` restates nothing, and whatever it names
+    // is judged at its own declaration site — the judgement this scanner already
+    // makes for barrels, and the change the tree made in objectui#3202.
+    withFixture(
+      {
+        'alias.ts': `
+import type { CanvasNavigation } from './canvas.js';
+
+type NavigationConfig = CanvasNavigation;
+`,
+      },
+      ({ 'alias.ts': file }) => expect(scan1(file)).toEqual([])
+    );
+  });
+
+  it('…but an alias that WIDENS, or restates anything, is not', () => {
+    // The near neighbour that keeps `isPureAlias` from decaying into "type
+    // aliases are exempt". `DashboardWidget = DashboardWidgetSchema & { id }`
+    // (app-shell) is the live widening — it carries an ALLOW entry with its
+    // reason rather than a structural pass, which is the governance this map
+    // exists for.
+    withFixture(
+      {
+        'widen.ts': `
+import type { CanvasNavigation } from './canvas.js';
+
+type NavigationConfig = CanvasNavigation & { id: string };
+type ListView = 'table' | 'kanban' | 'calendar';
+`,
+      },
+      ({ 'widen.ts': file }) =>
+        expect(scan1(file)).toEqual([
+          { name: 'NavigationConfig', kind: 'type' },
+          { name: 'ListView', kind: 'type' },
+        ])
+    );
   });
 });

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -143,8 +143,8 @@
  * `export` modifier (`hasExportModifier`, once per scanner). The class was
  * therefore NOT fully covered by rule 1 plus rule 2. A module-local declaration
  * sat outside the jurisdiction of both, whatever it was named and whatever its
- * doc comment claimed. Rule 2's half of that filter is gone as of
- * objectui#6291; read on for what it cost.
+ * doc comment claimed. BOTH halves of that filter are gone as of objectui#6291;
+ * read on for what each cost.
  *
  * The filter was defensible on this script's own terms: an unexported type
  * cannot be imported by another package under the spec's name, so it cannot
@@ -222,6 +222,56 @@
  * rather than deleted: it now asserts that a module-local claim IS flagged,
  * beside a second case proving the precision rules — not the `export` keyword
  * — are what keep module-local shapes green.
+ *
+ * ── Rule 1's half of the split: SHIPPED (objectui#6291) ────────────────────
+ * `scanFile` no longer filters on `export` either, and the population it
+ * surfaces was scoped first by the two structural narrowings the ruling
+ * required. Re-measured on the implementing commit against
+ * `@objectstack/spec@17.2.0`:
+ *
+ *   rule 1, filter dropped, NO narrowings   0 untriaged → 25   (+25)
+ *   rule 1, filter dropped, narrowings on   0 untriaged → 19   (+19)
+ *
+ * 25, not the 29 measured at a76b18cf2. Four sites left the population in the
+ * interval, and reading why is the whole argument for re-taking rather than
+ * transcribing: `ActionParam` twice (b84dc18 consolidated the two copies that
+ * already disagreed with each other), `SelectOption`, and
+ * `EXPLAIN_BATCH_MAX_RECORD_IDS` (objectui#6286 — the one whose own comment
+ * said it existed only until the spec pin exported the constant).
+ *
+ * The two narrowings, and what each measurably retires:
+ *
+ *   `rendersJsx`   — 2 module-local React `Field` components (metadata-admin
+ *                    inspectors). ⚠️ NOT `isRendererLike`, which rule 2 uses;
+ *                    see that function's own comment for the two REAL MIRRORS a
+ *                    blanket "functions are renderers" would have silenced.
+ *   `isPureAlias`  — 4 aliases: the `FlowNode`/`FlowEdge` pair in FlowPreview,
+ *                    and the pair in FlowNodeInspector, which became aliases in
+ *                    the interval too (the census had them as real mirrors, one
+ *                    of them declaring a `description` key the spec's `.strict()`
+ *                    schema rejects; that is fixed at the site now).
+ *
+ * The remaining 19 split 4 / 15:
+ *
+ *   4 are different-concept name collisions and got reasoned ALLOW entries —
+ *   `SearchResult` (a result ROW, where the spec's is the search RESPONSE),
+ *   `Dimension` (the spec's cube dimension REQUIRES `sql` and REJECTS this
+ *   shape's own `field`/`dateGranularity` — probed, not guessed), `ModelConfig`
+ *   (a model SELECTION against a model REGISTRY RECORD), and `DashboardWidget`
+ *   (already derived one hop out, deliberately widened).
+ *
+ *   15 findings under 14 names are real mirrors and were seeded into DEBT
+ *   mechanically by `--ledger`, anchored on objectui#7265.
+ *
+ * Two ALLOW entries were DELETED by the same commit, and this is the part that
+ * exceeded what the ruling predicted: `@object-ui/auth:AuthProvider` and
+ * `@object-ui/plugin-list:UserFilters` stopped matching anything, because
+ * `rendersJsx` now makes structurally the judgement those entries made by hand.
+ * Ratchet 3 requires deleting an entry that excuses nothing — a stale entry
+ * reserves the name for a future fork under it — so the narrowing SHRANK the
+ * hand-written part of the map while the collisions grew it. Both deletions are
+ * documented in place, with what each entry carried beyond the waiver. Net:
+ * 16 declared dialects → 18.
  *
  * These figures are a SNAPSHOT. When they move, re-take them and re-name the
  * commit and the spec version — never edit the numbers in place under the old
@@ -348,29 +398,24 @@ const ALLOW = {
       "is imported from the spec at its declaration in objectql.ts.",
     issue: 3334,
   },
-  "@object-ui/auth:AuthProvider": {
-    reason:
-      "A REACT CONTEXT PROVIDER COMPONENT, not a type — `<AuthProvider authUrl=…>` is the " +
-      "documented entry point of this package and of every app that mounts it. The spec's " +
-      "`AuthProvider` is a `z.ZodEnum` of provider IDENTIFIERS (local | google | github | " +
-      "microsoft | ldap | saml); nothing about a JSX element could be mistaken for it, which " +
-      "is why this one collision is excused where its own config type was NOT — that config " +
-      "was renamed to `AuthProviderOptions` because `AuthProviderConfig` names the spec's " +
-      "OAuth registration shape `{ id, clientId, clientSecret, scope? }`, the same domain and " +
-      "the same words, and IS readable as canonical by the next session. Renaming the " +
-      "component would break the React `<XProvider>` convention and every consumer's JSX for " +
-      "no defect. Pinned by packages/auth/src/__tests__/auth-spec-parity.test.ts, which fails " +
-      "if the spec's `AuthProvider` ever stops being an enum of provider ids.",
-    issue: 4115,
-  },
-  // ── objectstack#4115 batch 8/8 (objectui#3162) ───────────────────────────────
-  // These three were the last DEBT entries. The ledger filed them as "blocked on
-  // objectstack#4171, burn down when the upstream `any` erasure lifts"; #4171
-  // closed completed 2026-07-30, and the re-measurement it licensed found none of
-  // them burnable — for reasons that are NOT the one the ledger recorded. They are
-  // deliberate dialects, so they belong here with the reason written down, rather
-  // than in a debt bucket implying work that measurement says must not happen.
-  // Every verdict below was measured in the BUILT dist at spec 17.2.0.
+  // `@object-ui/auth:AuthProvider` sat here until objectui#6291. It is gone
+  // because the guard now makes its judgement STRUCTURALLY, not because the
+  // judgement changed: `rendersJsx` skips a declaration that literally contains
+  // JSX, so `export function AuthProvider(…) { return <Ctx.Provider …/> }` is no
+  // longer a finding to excuse. The entry's own reason said as much — "a REACT
+  // CONTEXT PROVIDER COMPONENT, not a type … nothing about a JSX element could
+  // be mistaken for [a `z.ZodEnum` of provider identifiers]". Ratchet 3 requires
+  // deleting an entry that excuses nothing; leaving it would reserve the name
+  // for a future non-component fork under it.
+  //
+  // ⚠️ What the entry carried beyond the waiver is NOT lost, and must not be:
+  // packages/auth/src/__tests__/auth-spec-parity.test.ts still fails if the
+  // spec's `AuthProvider` stops being an enum of provider ids, and
+  // `AuthProviderConfig` is still RENAMED to `AuthProviderOptions` rather than
+  // excused, because that one names the spec's OAuth registration shape and IS
+  // readable as canonical by the next session. A structural skip covers the
+  // component; it does not cover the config, and nothing here should be read as
+  // saying components are exempt in general.
   "@object-ui/types:NavigationItem": {
     reason:
       "Precise upstream, still not bindable — guard header case 2c. objectstack#4171 landed and " +
@@ -466,16 +511,72 @@ const ALLOW = {
       "component that consumes it.",
     issue: 4115,
   },
-  "@object-ui/plugin-list:UserFilters": {
+  // `@object-ui/plugin-list:UserFilters` sat here, on the same judgement, until
+  // objectui#6291 — `export function UserFilters(…)` returns JSX, so
+  // `rendersJsx` skips it and ratchet 3 required the entry's deletion. Its pin
+  // (the same spec-symbol-batch6.test.tsx) still asserts
+  // `UserFiltersProps['config']` accepts the spec's authored `UserFilters`.
+  //
+  // `ListView` above SURVIVED the same narrowing, and the asymmetry is worth
+  // reading before anyone "tidies" it: the finding it now matches is not the
+  // component at ListView.tsx:747 (that one is skipped too) but the bare
+  // `export { ListView, … }` in packages/plugin-list/src/index.tsx. The barrel
+  // skip a dozen lines into `scanFile` only fires when the re-export carries a
+  // module specifier (`export { X } from './x'`); a bare `export { X }` over a
+  // local import has none, so it is recorded at the barrel rather than at the
+  // declaration. That is a pre-existing hole, not something objectui#6291
+  // opened, and it is filed rather than fixed here.
+  // ── Different-concept name collisions, module-local (objectui#6291) ───────
+  // The four the export-filter drop surfaced that are NOT mirrors. Each was
+  // read at its site and, where the spec's symbol is a schema, probed with
+  // `safeParse` on this commit rather than judged by name.
+  "@object-ui/app-shell:SearchResult": {
     reason:
-      "Same judgement as `ListView` directly above, and the same package. The spec's " +
-      "`UserFilters` is the ADR-0047 quick-filter CONFIG (`{ element, fields, tabs, … }`, " +
-      "type-only); this is the filter bar that renders it, and it takes that config as a prop " +
-      "— `UserFiltersProps.config` is `NonNullable<ListViewSchema['userFilters']>`, so the " +
-      "spec's shape is what this component is typed against rather than something it restates. " +
-      "Nothing here declares a filter shape, so nothing here can drift from one. Pinned by the " +
-      "same test file, which asserts `UserFiltersProps['config']` still accepts the spec's " +
-      "authored `UserFilters`.",
+      "A ROW is not a RESPONSE — the `InboxNotification` judgement above, one layer over. " +
+      "`@objectstack/spec/contracts`' `SearchResult` is what `ISearchService.search()` " +
+      "RESOLVES TO: `{ hits: SearchHit[], totalHits, processingTimeMs?, facets? }`. This is one " +
+      "rendered result row in the search page's flat list — `{ id, label, href, type: " +
+      "'object'|'dashboard'|'page'|'report', description? }` — built from the navigation tree, " +
+      "not from a search service at all. The two share no key. Deriving one from the other " +
+      "would be a type error, not a tightening.",
+    issue: 4115,
+  },
+  "@object-ui/app-shell:Dimension": {
+    reason:
+      "Different vocabularies, measured. `@objectstack/spec/data`'s `DimensionSchema` is the " +
+      "semantic-layer CUBE dimension — keys `{name, label, description, type, sql, " +
+      "granularities}` — and it REQUIRES `sql`. The dataset inspector's local shape is the " +
+      "authored dataset field `{name?, label?, field?, type?, dateGranularity?}`. Probed on " +
+      "this commit: the local instance fails the spec schema with `invalid_type` on `sql` and " +
+      "`unrecognized_keys: [\"field\", \"dateGranularity\"]` — the two keys that carry this " +
+      "shape's whole meaning are the two the spec rejects. The spec exports no `DatasetSchema` " +
+      "for the inspector to bind against, so there is nothing to derive from either.",
+    issue: 4115,
+  },
+  "@object-ui/app-shell:ModelConfig": {
+    reason:
+      "A model SELECTION is not a model REGISTRY RECORD. `@objectstack/spec/ai`'s " +
+      "`ModelConfigSchema` describes a model the platform offers — `{id, name, version, " +
+      "provider, capabilities, limits, pricing, endpoint, apiKey, secretRef, region, …}`, with " +
+      "`id`/`name`/`version`/`capabilities`/`limits` all REQUIRED. `AgentPreview`'s local " +
+      "shape is an agent's CHOICE among them, `{provider?, model?, temperature?, maxTokens?}`, " +
+      "read off a draft for a preview panel. Probed on this commit: the local instance fails " +
+      "the spec schema on all five required keys, and `model`/`temperature`/`maxTokens` are " +
+      "not registry keys at all.",
+    issue: 4115,
+  },
+  "@object-ui/app-shell:DashboardWidget": {
+    reason:
+      "ALREADY derived, one hop outside where rule 1 looks, and deliberately wider. " +
+      "`type DashboardWidget = DashboardWidgetSchema & { id: string }` where " +
+      "`DashboardWidgetSchema` is `@object-ui/types`' interface, itself declared " +
+      "`extends Omit<Partial<SpecDashboardWidget>, …>` — so every spec key flows in through " +
+      "that `extends` and tracks the protocol. The intersection restores `id` to REQUIRED, " +
+      "which the `Partial<>` had relaxed for stored legacy widgets that omit it; the inspector " +
+      "only ever handles widgets it has already keyed. Deliberately NOT covered by the " +
+      "`isPureAlias` narrowing — that one is the narrowest possible reading (a bare type " +
+      "reference, nothing else), and an intersection that WIDENS a spec shape is exactly the " +
+      "case this map exists to make someone write a reason for.",
     issue: 4115,
   },
   // The three theme document types (`Theme`, `ThemeMode`, `ColorPalette`,
@@ -569,13 +670,58 @@ const ALLOW = {
 // AUTHORING input. `FormFieldSchema` is exactly that — identical `_output`,
 // divergent `_input` — so re-exporting it would silently change what parses.
 // Compare `_input` too before touching a schema const.
-const DEBT_ISSUE = 4115;
-// EMPTY since objectui#3162 (objectstack#4115 batch 8/8). The last three entries
-// were not burned down — they were MEASURED not-burnable and moved to ALLOW as
-// declared dialects, each carrying its own release condition as a pin. Re-adding
-// a name here means "collides, not yet triaged"; a name whose triage concluded
-// "deliberate divergence" belongs in ALLOW instead.
-const DEBT = {};
+// Re-anchored at objectui#6291. It was `4115` (objectstack#4115) while the block
+// was EMPTY — burned down in objectui#3162, and objectstack#4115 itself closed by
+// objectstack#6883. A ledger whose anchor is CLOSED makes the stale-entry message
+// below ("…and close #N once the ledger is empty") a dead instruction, and #6291
+// could not serve either, being the card its own PR closes. objectui#7265 is the
+// open burn-down card for the population seeded here.
+// ⚠️ `CLAIM_DEBT_ISSUE` a few screens down has the same defect — objectui#4592 is
+// closed while its 19-entry block is live — and is deliberately NOT changed here,
+// because rule 2's ledger is not what objectui#6291 widened.
+const DEBT_ISSUE = 7265;
+// Re-seeded at objectui#6291, mechanically (`--ledger`), when rule 1 stopped
+// skipping module-local declarations. ⚠️ The block is SHRINK-ONLY and this is the
+// one sanctioned way it grows: the rule's JURISDICTION widened, so these are
+// pre-existing mirrors it could not previously SEE, not forks anybody wrote. A
+// name may not be added here for any other reason.
+//
+// All 13 are real mirrors, classified by reading each site — the four
+// different-concept collisions the same widening surfaced went to ALLOW with
+// reasons instead, and the two carrying standalone defects beyond the mirroring
+// already have cards (objectui#6286, objectui#6287). Re-adding a name here still
+// means "collides, not yet triaged"; a name whose triage concluded "deliberate
+// divergence" belongs in ALLOW instead.
+const DEBT = {
+  "@object-ui/app-shell": [
+    "AdminScope",
+    "AppLike",
+    "FlowEdge",
+    "FlowRuntimeState",
+    "ObjectLike",
+    "RemoteTable",
+  ],
+  "@object-ui/core": [
+    "CONTEXT_TOKEN_SUGGESTIONS",
+    "isContextToken",
+  ],
+  "@object-ui/types": [
+    "UserFilterFieldSchema",
+    "UserFiltersSchema",
+  ],
+  "@object-ui/components": [
+    "SortDirection",
+  ],
+  "@object-ui/data-objectstack": [
+    "normalizeFilterOperator",
+  ],
+  "@object-ui/plugin-detail": [
+    "RecordAlertProps",
+  ],
+  "@object-ui/plugin-tree": [
+    "TreeConfig",
+  ],
+};
 
 // Files under these paths are not objectui's own authored surface.
 //   - `ui/` is the Shadcn no-touch zone (AGENTS.md #7): upstream 3rd-party files
@@ -968,6 +1114,78 @@ function isRendererLike(stmt) {
 }
 
 /**
+ * Rule 1's narrower cousin: does this declaration actually RENDER? (objectui#6291)
+ *
+ * `isRendererLike` above is rule 2's, and rule 2 can afford it: that scanner
+ * drops function and class declarations one line earlier (`if (!nameNode)
+ * continue`), so the predicate only ever judges a `const` initialised with a
+ * call or a function. Rule 1 has no such pre-filter — it RECORDS every exported
+ * function with `derived: false` — so reusing `isRendererLike` verbatim would
+ * skip every spec-named function in the tree.
+ *
+ * Measured, that is not the same set. On the objectui#6291 commit, dropping
+ * rule 1's export filter surfaces four module-local functions: two React
+ * components named `Field` (metadata-admin inspectors, wrapping a child in a
+ * `<div>` with a hint line), and `isContextToken` / `normalizeFilterOperator` —
+ * a type-guard predicate and an alias-table normalizer, both classified REAL
+ * MIRRORS by the census and both carrying the drift this guard exists to catch
+ * (`normalizeFilterOperator` is a SECOND normalizer over the spec's, and two
+ * normalizers disagreeing about filter operators is the silent over-fetch class
+ * of objectstack#3948). A blanket "functions are renderers" would have made
+ * those two invisible rather than DEBT entries — silently, and for good.
+ *
+ * So the narrowing here tests the judgement the header actually states — "a
+ * component that RENDERS the spec's shape is not a second declaration of it" —
+ * literally: the declaration must contain JSX. A predicate returning `boolean`
+ * does not; a component returning `<div>` does. Nested functions are not
+ * excluded from the walk on purpose: a helper that builds JSX inside a
+ * non-rendering function is vanishingly rarer than the false negative that
+ * excluding it would buy, and the fallback for a genuine miss is an ALLOW entry
+ * with a reason — which is the governance this file wants anyway.
+ */
+function rendersJsx(node) {
+  let found = false;
+  const visit = (n) => {
+    if (found || !n) return;
+    if (
+      ts.isJsxElement(n) ||
+      ts.isJsxSelfClosingElement(n) ||
+      ts.isJsxFragment(n)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return found;
+}
+
+/**
+ * A pure alias to a single identifier is derivation BY DELEGATION (objectui#6291).
+ *
+ * `type FlowNode = FlowDesignerNode` restates nothing. It names one thing, and
+ * whatever that thing is gets judged at its own declaration site — which is the
+ * judgement this scanner already makes one screen down for barrels: a re-export
+ * through a relative path or an `@object-ui/*` sibling "is not a second
+ * finding … reporting the barrel too would just make one fork look like four,
+ * and would make the fix land in the barrel rather than at the declaration".
+ * The same sentence is true of an alias, and it is the change the tree itself
+ * made in objectui#3202 when it deleted two restated copies of the flow shapes
+ * in favour of exactly this form.
+ *
+ * Deliberately the narrowest possible reading — a bare `TypeReferenceNode`,
+ * one identifier, no type arguments, no qualified name. `A & { id: string }`
+ * is NOT this (it is a deliberate widening, which belongs in ALLOW with its
+ * reason written down), and neither is `A<B>` or a union.
+ */
+function isPureAlias(stmt) {
+  if (!ts.isTypeAliasDeclaration(stmt)) return false;
+  const t = stmt.type;
+  return ts.isTypeReferenceNode(t) && ts.isIdentifier(t.typeName) && !t.typeArguments;
+}
+
+/**
  * Rule 2's scan: exported declarations whose doc comment claims spec alignment
  * while the declaration itself references nothing spec-bound.
  */
@@ -1046,7 +1264,13 @@ export function scanFileForClaims(file, specNames = new Map()) {
   return findings;
 }
 
-function scanFile(file, specNames) {
+/**
+ * Rule 1's scan. Exported for the same reason `scanFileForClaims` is — the two
+ * structural narrowings above (`rendersJsx`, `isPureAlias`) are judgement calls
+ * about what this rule may NOT see, and a narrowing with no discrimination
+ * proof is how a guard quietly stops guarding (objectui#6291).
+ */
+export function scanFile(file, specNames) {
   const text = readFileSync(file, "utf8");
   const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, /\.tsx$/.test(file) ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
 
@@ -1095,10 +1319,21 @@ function scanFile(file, specNames) {
       continue;
     }
 
-    if (!hasExportModifier(stmt)) continue;
+    // No export filter (objectui#6291). A module-local declaration under a spec
+    // export's name is still READ by the next agent editing that file, and it
+    // still drifts — objectui#5652's three mirrors were all module-local
+    // `interface`s. Two structural narrowings above (`rendersJsx`, `isPureAlias`)
+    // carry the judgement this widening needs; the header records the measured
+    // population.
+
+    // A component that RENDERS the spec's shape is not a second declaration of
+    // it — the judgement rule 2 and three ALLOW entries already make, applied
+    // here to declarations that literally contain JSX. See `rendersJsx`.
+    if ((ts.isFunctionDeclaration(stmt) || ts.isClassDeclaration(stmt) || ts.isVariableStatement(stmt)) && rendersJsx(stmt))
+      continue;
 
     if (ts.isTypeAliasDeclaration(stmt)) {
-      record(stmt.name.text, "type", referencesSpec(stmt, specBindings, true, stmt.name), stmt);
+      record(stmt.name.text, "type", isPureAlias(stmt) || referencesSpec(stmt, specBindings, true, stmt.name), stmt);
     } else if (ts.isInterfaceDeclaration(stmt)) {
       // Only `extends` counts — see the header.
       const extendsSpec = (stmt.heritageClauses ?? []).some((h) => referencesSpec(h, specBindings, false));

--- a/scripts/check-spec-symbol-derivation.mjs
+++ b/scripts/check-spec-symbol-derivation.mjs
@@ -137,15 +137,16 @@
  *     and this rule stays out of the way entirely. A verdict fabricated from
  *     ignorance of the spec would flag every citation in the repo at once.
  *
- * ── The boundary BOTH rules share: exported declarations only (objectui#5899) ─
- * Everything above is scoped by one filter that neither rule's account of its
- * own failure class mentions: each scanner skips any statement without an
- * `export` modifier (`hasExportModifier`, once per scanner). The class is
+ * ── The boundary the rules USED to share: exported only (objectui#5899) ─────
+ * Everything above was once scoped by one filter that neither rule's account of
+ * its own failure class mentions: each scanner skipped any statement without an
+ * `export` modifier (`hasExportModifier`, once per scanner). The class was
  * therefore NOT fully covered by rule 1 plus rule 2. A module-local declaration
- * is outside the jurisdiction of both, whatever it is named and whatever its
- * doc comment claims.
+ * sat outside the jurisdiction of both, whatever it was named and whatever its
+ * doc comment claimed. Rule 2's half of that filter is gone as of
+ * objectui#6291; read on for what it cost.
  *
- * The filter is defensible on this script's own terms: an unexported type
+ * The filter was defensible on this script's own terms: an unexported type
  * cannot be imported by another package under the spec's name, so it cannot
  * become a planted premise through the package's public surface. objectui#5652
  * measured the other half. Three hand-written mirrors of the `FormViewSchema`
@@ -192,17 +193,35 @@
  *   `DashboardWidget` aliases an `@object-ui/types` schema that is itself
  *   spec-derived.
  *
- * So the hole is real rather than theoretical, and it is not a one-line change
- * for RULE 1: dropping the filter there turns the gate red on 29 sites at once,
- * against this header's own standard that an ALLOW map with dozens of entries
- * is not a guard. It IS a clean one-liner for RULE 2, whose entire additional
- * population is two declarations, both real mirrors, one with measured drift.
- * Which of those lands — and whether rule 1 instead gets the two structural
- * narrowings that would retire half the false positives (apply `isRendererLike`
- * to rule 1 too; count a pure alias to one identifier as derivation) — is
- * objectui#5899's decision to make, not this script's. What is corrected here
- * is only the account above, which read as though rule 1 plus rule 2 covered
- * the class.
+ * That census forced the split ruled in objectui#6291: rule 2's filter is a
+ * clean one-liner, rule 1's is a scoped change, and doing both at once would
+ * land 29 reds and four avoidable waivers against this header's own standard
+ * that an ALLOW map with dozens of entries is not a guard.
+ *
+ * ── Rule 2's half of the split: SHIPPED (objectui#6291) ─────────────────────
+ * `scanFileForClaims` no longer filters on `export`. Re-measured on the
+ * implementing commit against `@objectstack/spec@17.2.0` — the a76b18cf2
+ * figures above had already moved, which is exactly why they are re-taken
+ * rather than transcribed:
+ *
+ *   rule 2   18 unbacked claims → 19   (+1 module-local declaration)
+ *
+ * ONE, not the two measured at a76b18cf2. `CURATED_CAPABILITY_LABELS`
+ * (packages/fields) was the other, and objectui#6285 fixed it in the interval:
+ * its comment no longer claims alignment in prose, because
+ * `CapabilityMultiSelectField.specParity-6285.test.tsx` now CHECKS the equality
+ * against `PLATFORM_CAPABILITIES` in both directions. That is the burn-down
+ * this rule exists to provoke, and it took the site out of the population
+ * before this change could reach it.
+ *
+ * The one that remains, `CONTEXT_TOKEN_SUGGESTIONS` (@object-ui/core), is a
+ * real mirror and goes to CLAIM_DEBT — see the note there for why a
+ * shrink-only block is allowed to grow on a jurisdiction widening. Zero
+ * legitimate-local fallout, zero CLAIM_ALLOW entries, and the named pin in
+ * `scripts/__tests__/check-spec-symbol-derivation.test.ts` was REWRITTEN
+ * rather than deleted: it now asserts that a module-local claim IS flagged,
+ * beside a second case proving the precision rules — not the `export` keyword
+ * — are what keep module-local shapes green.
  *
  * These figures are a SNAPSHOT. When they move, re-take them and re-name the
  * commit and the spec version — never edit the numbers in place under the old
@@ -645,6 +664,19 @@ export const CLAIM_ALLOW = {
 //   - keep the copy and move it to CLAIM_ALLOW with the reason it exists;
 //   - or delete the claim from the comment, because it is not true here.
 //
+// The block GREW once, at objectui#6291, and that is not a ratchet failure: rule
+// 2 stopped skipping module-local declarations in the same commit, so
+// `CONTEXT_TOKEN_SUGGESTIONS` (@object-ui/core) is a pre-existing claim the rule
+// could not previously SEE, not a new one somebody wrote. It is a real mirror —
+// byte-identical to `@objectstack/spec/data`'s nine-entry map — and 25 lines
+// above it the same file explains that its neighbour `CONTEXT_TOKENS` became a
+// re-export precisely because "the copy was byte-identical, so every value
+// comparison and every behavioural test passed while it sat here". Burning it
+// down is the same edit that fixed the neighbour; it is listed rather than
+// excused because nothing about it is deliberate. Widening a rule's
+// jurisdiction is the ONLY sanctioned way this block grows, and it must be
+// mechanically regenerated (`--claim-ledger`) in that same commit.
+//
 // Eight entries left by that last route in objectui#4597 — the i18n formatters'
 // four and views.ts's four, which cited `DateFormatSchema`, `NumberFormatSchema`,
 // `PluralRuleSchema`, `LocaleConfigSchema`, `FieldChangeEntrySchema`,
@@ -679,10 +711,20 @@ const CLAIM_DEBT = {
     "RecordRelatedListComponentProps",
     "SubmitBehavior",
   ],
-  "@object-ui/core": ["ResultDialogFieldSpec", "ViewDataConfig"],
-  "@object-ui/app-shell": ["RecordLookupBinding"],
-  "@object-ui/plugin-view": ["ROW_HEIGHT_OPTIONS"],
-  "@object-ui/react": ["DensityModeValue"],
+  "@object-ui/core": [
+    "CONTEXT_TOKEN_SUGGESTIONS",
+    "ResultDialogFieldSpec",
+    "ViewDataConfig",
+  ],
+  "@object-ui/app-shell": [
+    "RecordLookupBinding",
+  ],
+  "@object-ui/plugin-view": [
+    "ROW_HEIGHT_OPTIONS",
+  ],
+  "@object-ui/react": [
+    "DensityModeValue",
+  ],
 };
 
 // ── 1. Enumerate every `@objectstack/spec` export name, per subpath ──────────
@@ -953,7 +995,11 @@ export function scanFileForClaims(file, specNames = new Map()) {
 
   const findings = [];
   for (const stmt of sf.statements) {
-    if (!hasExportModifier(stmt)) continue;
+    // No export filter: a module-local declaration carrying a spec-alignment
+    // claim is the same planted premise as an exported one (objectui#6291).
+    // The claim is read by the next agent editing the FILE, not by an importer,
+    // so the package boundary was never what made it dangerous. Measured cost of
+    // dropping it here: see the header's rule-2 line.
 
     let nameNode = null;
     if (


### PR DESCRIPTION
Fixes #6291

Ruling **A (split)**, implemented in the order it sets: half 1 is rule 2's filter drop, half 2 is the two structural narrowings, then rule 1's filter drop, then a mechanically regenerated DEBT block, then the reasoned ALLOW entries. One branch, two commits, each independently green.

Every figure below is re-taken on `3612110ff` against `@objectstack/spec@17.2.0`. PR #6284's census is the evidence base, not a list to transcribe — and it had moved.

## The population, re-taken

| | PR #6284 (`a76b18cf2`) | this commit (`3612110ff`) |
|---|---|---|
| rule 1, filter dropped, no narrowings | +29 | **+25** |
| rule 1, filter dropped, narrowings on | (projected) | **+19** |
| rule 2, filter dropped | +2 | **+1** |

Four rule-1 sites left the population in the interval: `ActionParam` twice (`b84dc18`, "one authority for ActionSchema and the Breadcrumb pair", consolidated the pair that already disagreed with itself), `SelectOption`, and `EXPLAIN_BATCH_MAX_RECORD_IDS` — the one whose own comment said it existed only until the spec pin exported the constant (#6286). Rule 2's second site was `CURATED_CAPABILITY_LABELS`; #6285 replaced its prose claim with a two-directional parity test, so the burn-down this rule exists to provoke took the site out of the population before this change could reach it.

Two sites the census classified as real mirrors — the `FlowNode` / `FlowEdge` pair in `FlowNodeInspector.tsx` — became pure aliases in the interval, so the narrowing retires them rather than the ledger carrying them.

### Where the 19 went

**4 different-concept collisions → reasoned ALLOW entries.** Each read at its site; where the spec's symbol is a schema, probed with `safeParse` on this commit rather than judged by name.

| symbol | why it is not a mirror |
|---|---|
| `app-shell:SearchResult` | A ROW is not a RESPONSE. The spec's is what `ISearchService.search()` resolves to — `{hits, totalHits, processingTimeMs?, facets?}`. This is one rendered result row `{id, label, href, type, description?}`, built from the navigation tree. The two share no key. |
| `app-shell:Dimension` | The spec's `DimensionSchema` is the semantic-layer cube dimension and REQUIRES `sql`. Probed: the local instance fails with `invalid_type` on `sql` and `unrecognized_keys: ["field","dateGranularity"]` — the two keys carrying this shape's whole meaning are the two the spec rejects. The spec exports no `DatasetSchema` to bind against. |
| `app-shell:ModelConfig` | A model SELECTION against a model REGISTRY RECORD. Probed: the local instance fails on all five of the spec's required keys (`id`, `name`, `version`, `capabilities`, `limits`), and `model`/`temperature`/`maxTokens` are not registry keys at all. |
| `app-shell:DashboardWidget` | Already derived one hop out and deliberately wider: `DashboardWidgetSchema & { id: string }`, where `@object-ui/types`' interface is declared `extends Omit of Partial-of-SpecDashboardWidget` (minus four re-typed keys). The intersection restores `id` to required. Deliberately NOT covered by `isPureAlias` — an intersection that widens a spec shape is exactly what this map exists to make someone write a reason for. |

**15 findings under 14 names → DEBT**, regenerated by `--ledger`, never hand-written. `@object-ui/app-shell` (`AdminScope`, `AppLike`, `FlowEdge`, `FlowRuntimeState`, `ObjectLike` ×2 sites, `RemoteTable`), `@object-ui/core` (`CONTEXT_TOKEN_SUGGESTIONS`, `isContextToken`), `@object-ui/types` (`UserFilterFieldSchema`, `UserFiltersSchema`), `@object-ui/components` (`SortDirection`), `@object-ui/data-objectstack` (`normalizeFilterOperator`), `@object-ui/plugin-detail` (`RecordAlertProps`), `@object-ui/plugin-tree` (`TreeConfig`).

Rule 2's one addition, `CONTEXT_TOKEN_SUGGESTIONS`, went to `CLAIM_DEBT` the same way.

## The DEBT anchor is a new issue, and that is deliberate

`DEBT_ISSUE` was `4115`. That block had been empty since #3162 and objectstack#4115 was itself retired by objectstack#6883, so the gate's own stale-entry message — *"delete them … (and close #N once the ledger is empty)"* — pointed at an issue nobody can act on. #6291 could not serve either, being the card this PR retires. **#7265** is the open burn-down anchor, with the seeded population and its provenance in the body.

Noted there and **not** changed here: `CLAIM_DEBT_ISSUE = 4592` has the same dead-anchor defect with a live 19-entry block. Rule 2's ledger is not what this card widened, so it is filed rather than ridden.

## The narrowings, and one deviation from the ruling's literal wording

The ruling says "extend `isRendererLike` to rule 1". Implemented as a **new, narrower predicate**, `rendersJsx`, and the reason is measured rather than stylistic.

Rule 2 can afford `isRendererLike` because it drops function and class declarations one line earlier (`if (!nameNode) continue`), so that predicate only ever judges a `const` initialised with a call or a function. **Rule 1 records every function with `derived: false`.** Reusing `isRendererLike` verbatim would therefore skip every spec-named function in the tree — and measured, that is four declarations, not two: the two local React `Field` components the ruling names, plus `isContextToken` and `normalizeFilterOperator`, **both classified real mirrors by the census**, both DEBT entries today. `normalizeFilterOperator` is a second normalizer over the spec's own, and two normalizers disagreeing about filter operators is the silent over-fetch class of objectstack#3948. A blanket "functions are renderers" would have made those two invisible instead of tracked — silently, and for good.

So `rendersJsx` tests the judgement the header actually states — *"a component that RENDERS the spec's shape is not a second declaration of it"* — literally: the declaration must contain JSX. A predicate returning `boolean` does not; a component returning a JSX element does. This retires exactly the sites the ruling predicted and no others.

`isPureAlias` is the narrowest possible reading of the second narrowing: a bare `TypeReferenceNode`, one identifier, no type arguments, no qualified name. A generic reference `A of B`, a union, and `A & { … }` are all still forks. It generalises the judgement `scanFile` already makes for barrels — *"whatever it points at gets judged at its own declaration site"*.

## Two ALLOW entries were DELETED — the one place this exceeded the ruling

`@object-ui/auth:AuthProvider` and `@object-ui/plugin-list:UserFilters` stopped matching anything once `rendersJsx` made their judgement structurally, and ratchet 3 requires deleting an entry that excuses nothing (a stale entry reserves the name for a future fork under it). So the narrowing **shrank** the hand-written part of the map while the collisions grew it: 16 declared dialects → 18.

Both deletions are documented in place with what each entry carried **beyond** the waiver — `auth-spec-parity.test.ts` still fails if the spec's `AuthProvider` stops being an enum of provider ids, and `AuthProviderConfig` is still renamed rather than excused, because that one really does name the spec's OAuth registration shape.

`@object-ui/plugin-list:ListView` survived the same narrowing, and the asymmetry is documented rather than tidied: the finding it now matches is not the component but the bare `export { ListView, … }` in `packages/plugin-list/src/index.tsx`. `scanFile`'s barrel skip fires only when the re-export carries a module specifier, so a bare `export { X }` over a local import is recorded at the barrel. That hole predates this card; it is filed, not fixed here.

## The named pin was rewritten, not deleted

`scripts/__tests__/check-spec-symbol-derivation.test.ts` › *"an unexported declaration — it publishes no surface to be mistaken for the spec"* now asserts the inverse, **on the same fixture** — which makes the point better than a new one could, because that fixture re-exported the declaration on the very next line (`export type { InternalNavigationConfig }`) and so always did publish a surface. `hasExportModifier` never saw it, because the export was a separate statement. The pin's own fixture contradicted the pin's own name.

Beside it, the half the pin was really holding: rule 2 stays quiet on module-local shapes for its OWN reasons — renderer skip, tie test, absent claim — never because of an `export` keyword.

`scanFile` is now exported (as `scanFileForClaims` already was) so the narrowings carry a discrimination proof: one red per widening, one green per narrowing, and the **red near neighbour** beside each — a non-rendering function is still a fork, an alias that widens is still a fork. Those two are what keep `rendersJsx` from decaying into `isRendererLike` and `isPureAlias` into "type aliases are exempt". 35 cases → 40.

## Ablation evidence

Each ablation ran against the **committed** implementation, with the mutation confirmed on disk by injected-marker count before the run, an `EXIT`-trapped restore, and the restore proven by comparing `git hash-object` against the HEAD blob (not by a trap firing).

| ablated | gate/tests | what turned red |
|---|---|---|
| `rendersJsx` skip removed | gate exit **1** | exactly 4: `Field` ×2 (the retired false positives) plus `AuthProvider` and `UserFilters` — which is also the independent confirmation that the two deleted ALLOW entries are accounted for by the narrowing and nothing else |
| `isPureAlias` removed | gate exit **1** | `FlowNode` at `FlowNodeInspector.tsx:87` and `FlowPreview.tsx:57`. The two `FlowEdge` aliases stay green because `FlowEdge` is already a DEBT-declared name for that package — the ledger absorbing them is correct behaviour, not a miss |
| both export filters restored | tests exit **1** | 4 failed / 36 passed — the rewritten rule-2 pin, rule 1's widening pin, and both red near neighbours. The green narrowing cases stay green, as they must: they are green under the filter too |

Marker counts, exit codes and restore proofs: `on-disk injected-marker count: 1` / `1` / `2 (expect 2)`; `RESTORE_OK` after each, with `git diff HEAD --name-only` empty.

## Verification — all on `3612110ff`

| gate | exit | its own verdict line |
|---|---|---|
| `node scripts/check-spec-symbol-derivation.mjs` **before** (`67dadd602`) | 0 | `✅  spec symbol derivation: 1333 files scanned against 4959 spec export names; 16 declared dialects, 0 untriaged collisions in 0 packages.` / `✅  spec alignment claims: 2 declared deliberate copies, 18 unbacked claims in 5 packages.` |
| `pnpm check:spec-symbols` **after** | 0 | `✅  spec symbol derivation: 1333 files scanned against 4959 spec export names; 18 declared dialects, 14 untriaged collisions in 7 packages.` / `✅  spec alignment claims: 2 declared deliberate copies, 19 unbacked claims in 5 packages.` |
| `pnpm exec vitest run scripts/__tests__/check-spec-symbol-derivation.test.ts scripts/__tests__/check-doc-component-types.test.ts --maxWorkers=2` | 0 | `Test Files  2 passed (2)` / `Tests  89 passed (89)` — the second file is the only other suite in `scripts/__tests__` naming this script |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, no diagnostics |
| `pnpm lint:root` (**unnarrowed**) | 0 | `✖ 29 problems (0 errors, 29 warnings)` — all pre-existing, none in either edited file (verified by name against the report) |
| `pnpm check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 5996 tracked text file(s); skipped 85 binary).` |
| own control-byte scan of both edited files | — | `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → no hits |
| `pnpm check:entry-guard` | 0 | `✓ check:entry-guard: 58 scripts/ file(s) — no entry guard outside the baseline; 0 file(s) still hand-type one …; 52 export bindings, 52 of them inert on import (0 known-unsafe, ⛔ SHRINK-ONLY).` — the new `scanFile` export is inert on import |
| `pnpm check:esm-specifiers` | 0 | `Specifier leg: no un-ledgered package emits an extensionless relative specifier.` |
| `pnpm check:shell-escape-residue` | 0 | `✅  check-shell-escape-residue: OK (4/4 root(s) resolved … 0 occurrence(s) outside a fence).` |
| `pnpm check:self-import` | 0 | `✅  No package names itself inside its own src/.` |
| `pnpm check:node-esm-load` | 1 | **NOT MEASURED, not a red.** Its build leg replayed turbo cache entries from a *sibling agent's worktree* on this container (`@object-ui/example-byo-backend-console:build: cache hit … /home/user/objectui-issue-6606/…`), and it then reported `✗ @object-ui/console: no-build-output`. This diff is `scripts/`-only — 2 files, 0 under `packages/`— and that gate grades built package artifacts, which this change cannot reach. Filed separately; CI's clean checkout is the authority. |

Every exit code was captured by redirect **before** any pipe.

**Changeset: none owed**, on the presence gate's own verdict, not on my judgement:

```
Compared the working tree with 67dadd602 (merge-base with origin/main): 2 file(s) changed,
0 of them published source of a package the release covers, 0 of them a manifest whose
published contract moved, 0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no
changeset is owed.
```

There is no `skip-changeset` label in this repo — confirmed by PR #6284 and not created here.

## Scope fence

Two files, both under `scripts/`: `check-spec-symbol-derivation.mjs` and `check-spec-symbol-derivation.test.ts`. **Zero package-source edits** — none of the 14 mirror sites was fixed; they are ledger entries, per the ruling. #6286 and #6287 remain open on their own merits and are untouched by this branch.

Heavy runs were serialised through the container-global lock at `/home/user/objectstack/scripts/pm/os-verify-lock.sh` (objectui carries no copy), slot `dev-6291`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b)_