### PR TITLE
docs(changeset): write the naming convention into .changeset/README.md

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -44,6 +44,30 @@ $ pnpm changeset
 Add support for custom validators in form components
 ```
 
+### ⚠️ Rename the generated file — don't ship the `adjective-animal-verb` name
+
+`pnpm changeset` writes the file above under a randomly generated name like
+`olive-donkeys-smile.md`. **Before committing it, rename it to
+`.changeset/<issue>-<slug>.md`** — the issue number the change settles, a short
+slug, `.md` (e.g. `6439-changeset-naming-readme.md`).
+
+**Why this matters, not just style:** `pnpm changeset` allocates its
+`adjective-animal-verb` names against the files *already present* in this
+directory, so it cannot collide. A hand-picked or copy-pasted name has no such
+guarantee — pick one that another pending changeset already uses and you
+**overwrite that file**, silently deleting a third party's release
+declaration. The cost lands on them, not you, and nothing catches it at the
+time: `git status` shows ` M` (modified) rather than `??` (untracked), so it
+reads like your own new file landing, and a deleted release declaration is
+flagged by nothing downstream — the affected package simply never gets
+bumped (objectui#6336). An issue-number-prefixed name cannot collide with
+another pending changeset, because no two open issues share a number.
+
+A report-only gate (`scripts/check-changeset-overwrite.mjs`, wired into
+`changeset-guard.yml`) flags it after the fact if this still happens — but by
+then the damage (a silently dropped release declaration) is already done.
+Renaming the file before you commit is what actually prevents it.
+
 ### When to Create a Changeset
 
 ✅ **DO** create a changeset for:


### PR DESCRIPTION
Fixes #6439

## What

`.changeset/README.md` was the stock `changesets` boilerplate and said nothing about how the generated file should be named. Adds a section right after the existing "Example" walkthrough: rename the `pnpm changeset`-generated `adjective-animal-verb.md` to the numbered form `NNNN-slug.md` (issue number, short slug, `.md` — e.g. `6439-changeset-naming-readme.md`) before committing, and why — the generated name is allocated against files already present so it cannot collide, while a hand-picked name can, and the collision overwrites a third party's pending release declaration silently (`git status` shows ` M`, not `??`; nothing downstream flags the lost declaration).

This is triage's ruled option 2 from #6439 (verbatim, 2026-08-26):

> land option **2 now** — write the naming convention into `.changeset/README.md`, the file sitting in the directory where the mistake is made, replacing/extending the stock boilerplate with the collision-proof rationale this card already states.

## Wording agreement with the gate

The new section's core sentence mirrors what `scripts/check-changeset-overwrite.mjs` already prints in its report-only output, so the README and the gate agree instead of drifting apart (quoting the gate's own output, angle brackets spelled out to survive GitHub's body sanitizer):

> Name a changeset after the issue it settles — `.changeset/` + issue number + `-` + slug + `.md` — and case 1 (the overwrite) cannot happen.

## Scope

- File surface: `.changeset/README.md` only.
- Not touching `AGENTS.md` (option 1 — governed surface, triage explicitly ruled it must be its own draft PR for human merge, never a rider here).
- Not touching `scripts/check-changeset-overwrite.mjs` or its report-only posture (out of scope per the #6336 ruling; this card is docs-only).

## Re-measured adherence (on `main` @ `64d624ded`, this PR's merge base)

Counting `.changeset/*.md` excluding `README.md` (matching `NOT_A_CHANGESET` in `scripts/check-changeset-presence.mjs`):

- **419 of 758** (55.3%) already use the numbered form.
- (The issue's original filing measured 133/424 = 31%. PM's dispatch-time control read measured 425/765. This PR's own re-measurement, run fresh against the same merge-base commit with the exact `NOT_A_CHANGESET` exclusion, is 419/758.)

No existing changesets were renamed — this PR only documents the convention going forward.

## Gates run (docs-only surface; no `dispatch-gates.mjs` in this repo)

- `node scripts/check-control-bytes.mjs` → `OK (scanned 6004 tracked text file(s); skipped 85 binary)`.
- `node scripts/check-shell-escape-residue.mjs` → `OK (4/4 root(s) resolved ...)`.
- `node scripts/check-doc-fence-languages.mjs` (`check:doc-fences`) → `every TypeScript block ... is fenced ...` — confirmed its roots are `content/docs/**` + `packages/*/README.md`; `.changeset/README.md` is out of its scope, unaffected either way.
- `node scripts/check-changeset-presence.mjs` → `No source or published contract of a released package changed in this range, so no changeset is owed.` — docs-only, no changeset added for this PR (correct per its own verdict), and no `skip-changeset` label used (not a mechanism in this repo).
- `node scripts/check-changeset-overwrite.mjs` (informational only — script untouched) → `No pre-existing changeset was modified or deleted.`
- `scripts/__tests__/` search for tests naming the real README content: none found — `check-changeset-overwrite.test.ts` / `check-changeset-presence.test.ts` only write a synthetic `.changeset/README.md` inside disposable fixture repos, not the real file, so this edit doesn't need a pin update.

Session: https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b

🤖 Generated with [Claude Code](https://claude.com/claude-code)