### PR TITLE
fix(core,app-shell,plugin-grid): lead the synthesized default list view with the object's name field

### DIFF
--- a/.changeset/7245-default-view-namefield-lead.md
+++ b/.changeset/7245-default-view-namefield-lead.md
@@ -1,0 +1,50 @@
+---
+'@object-ui/core': patch
+'@object-ui/app-shell': patch
+'@object-ui/plugin-grid': patch
+---
+
+A synthesized default list view now always leads with the object's name field
+(objectui#7245).
+
+**The defect.** An object that declares no list view gets its default grid columns
+synthesized from `highlightFields`, taken verbatim. But `highlightFields` is ADR-0085's
+*"most important fields"* role, not a column list — and its first consumer, the
+detail-page highlight strip, **deliberately removes the title field**, because the page
+H1 directly above it already shows one. So metadata that is entirely correct routinely
+omits the record's name from `highlightFields`. The showcase `showcase_account` declares
+`nameField: "name"` and `highlightFields: ["status", "industry", "annual_revenue"]`, and
+its default `所有记录` grid rendered 14 rows whose columns were `#` / Lifecycle / Industry
+/ Annual Revenue / actions — no name column, and no way to tell one account from another.
+
+A list has no H1 to lean on, so the same declaration needs the opposite treatment here.
+This is not a new convention: `deriveLookupColumns` in `@object-ui/fields` already leads
+its record-picker columns with the display field and filters it out of the declared list.
+The list faces now agree with it.
+
+**What changed.** `@object-ui/core` gains two exports on the ADR-0079 title ladder:
+
+- `resolveNameField(objectDef)` — *which field* titles an object: the declared
+  `nameField` (then its deprecated `displayNameField` / `NAME_FIELD_KEY` aliases), else
+  the type-aware derivation. The name-space twin of `getRecordDisplayName`, which answers
+  what that field *says* on one record. Both now read one spelling of the declared
+  pointer, so they cannot drift into naming different fields.
+- `leadWithNameField(objectDef, columns)` — moves that field to the front of a
+  **synthesized** column list.
+
+All three faces that synthesize default list columns call it: `ObjectView`
+(`defaultListColumnsFromObject`), `InterfaceListPage` (`defaultColumnsFromObject`) and
+`ObjectGrid`'s own derivation. The name field is **moved**, not merely appended, so an
+author who lists it third still gets it first — "the column that identifies the row"
+means first. On the two capped faces the lead is applied *before* the 5 / 6-column slice,
+so an object declaring its name field late no longer loses it off the end.
+
+**Scope, deliberately narrow.** Author-declared column lists are untouched — a view or
+grid that declares `columns` / `fields` said what it wants, and reordering it would be
+renderer-side second-guessing of metadata. Three cases also decline to lead: a name field
+the object carries no field def for (never fabricate a column), one marked
+`hidden: true` (the author said don't show it), and a *derived* pick that lands on a
+system-managed column — `deriveTitleField` filters by type only, and leading a default
+list with a raw id is the regression objectui#2702 / #2777 fixed. A *declared*
+`nameField` pointing at a system field still leads: `sys_migration` really does point at
+`id`, and an explicit designation is not a heuristic misfire.

--- a/packages/app-shell/src/views/InterfaceListPage.defaults.test.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.defaults.test.tsx
@@ -96,6 +96,58 @@ describe('defaultColumnsFromObject', () => {
     expect(cols).toEqual(['name', 'owner_id']);
   });
 
+  // objectui#7245 — the same fix as `ObjectView.defaultListColumnsFromObject`.
+  // These two are documented mirrors of one another, so the pin is mirrored too:
+  // a curated `highlightFields` that (correctly) omits the title field left an
+  // interface page's rows with no column identifying them.
+  describe('#7245: the synthesized default always leads with the name field', () => {
+    const showcaseAccount = {
+      nameField: 'name',
+      highlightFields: ['status', 'industry', 'annual_revenue'],
+      fields: {
+        name: { type: 'text', label: 'Account Name' },
+        industry: { type: 'select' },
+        annual_revenue: { type: 'currency' },
+        status: { type: 'select' },
+        organization_id: { type: 'lookup', system: true, hidden: true },
+      },
+    };
+
+    it('THE REPRO: prepends nameField to a curated list that omits it', () => {
+      expect(defaultColumnsFromObject(showcaseAccount)).toEqual([
+        'name',
+        'status',
+        'industry',
+        'annual_revenue',
+      ]);
+    });
+
+    it('does not duplicate, and moves a late-listed nameField to the front', () => {
+      expect(
+        defaultColumnsFromObject({ ...showcaseAccount, highlightFields: ['status', 'name'] }),
+      ).toEqual(['name', 'status']);
+    });
+
+    it('leads the derived walk BEFORE the six-column cap', () => {
+      const fields: Record<string, any> = {};
+      for (let i = 0; i < 9; i++) fields[`b_${i}`] = { type: 'text' };
+      fields.headline = { type: 'text' };
+      const cols = defaultColumnsFromObject({ nameField: 'headline', fields });
+      expect(cols).toHaveLength(6);
+      expect(cols[0]).toBe('headline');
+    });
+
+    it('still appends the org attribution column last', () => {
+      expect(defaultColumnsFromObject(showcaseAccount, { orgAttribution: true })).toEqual([
+        'name',
+        'status',
+        'industry',
+        'annual_revenue',
+        'organization_id',
+      ]);
+    });
+  });
+
   it('caps the auto-derived business columns at six', () => {
     const fields: Record<string, any> = { owner_id: { type: 'lookup', system: true } };
     for (let i = 0; i < 10; i++) fields[`b_${i}`] = { type: 'text' };

--- a/packages/app-shell/src/views/InterfaceListPage.tsx
+++ b/packages/app-shell/src/views/InterfaceListPage.tsx
@@ -23,6 +23,7 @@ import { Empty, EmptyTitle, EmptyDescription, NavigationOverlay } from '@object-
 import { Database } from 'lucide-react';
 import { useObjectTranslation } from '@object-ui/i18n';
 import { isSystemManagedField } from '@object-ui/types';
+import { leadWithNameField } from '@object-ui/core';
 import type { ListViewSchema } from '@object-ui/types';
 import { useMetadata } from '../providers/MetadataProvider.js';
 import { useTenancyPosture } from '../hooks/useTenancyPosture.js';
@@ -75,10 +76,19 @@ function resolveSourceView(objectDef: any, sourceView?: string): any | undefined
 /**
  * Default column set when the resolved view carries none — mirrors
  * ObjectView's data-mode fallback so an interface page never renders a
- * column-less grid. Priority: the `highlightFields` semantic role
- * (ADR-0085), else the first business fields — framework-managed
- * system/audit/ownership columns (including the injected, editable `owner_id`)
- * are excluded via the shared `isSystemManagedField` classifier.
+ * column-less grid. Priority: the object's name field always leads
+ * (`leadWithNameField`, objectui#7245 — `highlightFields` is ADR-0085's
+ * "most important fields" role, which the detail highlight strip deliberately
+ * strips the title out of, so well-authored metadata often omits it and the
+ * synthesized list had no column identifying the row); then the
+ * `highlightFields` semantic role (ADR-0085), else the first business fields —
+ * framework-managed system/audit/ownership columns (including the injected,
+ * editable `owner_id`) are excluded via the shared `isSystemManagedField`
+ * classifier.
+ *
+ * The lead is applied on BOTH branches, and before the slice on the fallback
+ * walk, exactly as in `ObjectView.defaultListColumnsFromObject` — the two are
+ * documented as mirrors, so they must not drift on this.
  *
  * `opts.orgAttribution` (ADR-0105 group posture): reads span every
  * organization the member belongs to, so cross-org rows need attribution —
@@ -95,15 +105,19 @@ export function defaultColumnsFromObject(
       : cols;
   const curated = objectDef?.highlightFields;
   if (Array.isArray(curated) && curated.length > 0) {
-    return withOrgAttribution(curated.filter((n: string) => objectDef.fields?.[n]));
+    return withOrgAttribution(
+      leadWithNameField(objectDef, curated.filter((n: string) => objectDef.fields?.[n])),
+    );
   }
   const fields = objectDef?.fields;
   if (fields && typeof fields === 'object') {
     return withOrgAttribution(
-      Object.entries(fields)
-        .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
-        .map(([name]) => name)
-        .slice(0, 6),
+      leadWithNameField(
+        objectDef,
+        Object.entries(fields)
+          .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
+          .map(([name]) => name),
+      ).slice(0, 6),
     );
   }
   return [];

--- a/packages/app-shell/src/views/ObjectView.defaultColumns.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.defaultColumns.test.tsx
@@ -56,6 +56,78 @@ describe('defaultListColumnsFromObject', () => {
     expect(cols).toEqual(['invoice_no', 'owner_id']);
   });
 
+  // objectui#7245. `highlightFields` is ADR-0085's "most important fields", not
+  // a column list — the detail highlight strip, its first consumer, strips the
+  // title field out because the page H1 above it already shows one. A grid has
+  // no H1, so a curated list that (correctly) omits the name left every row
+  // unidentifiable. The synthesized default therefore always leads with the
+  // object's name field.
+  describe('#7245: the synthesized default always leads with the name field', () => {
+    // The served `showcase_account`: `nameField: "name"`, three curated
+    // highlight fields that do not include it, and no list views at all.
+    const showcaseAccount = {
+      nameField: 'name',
+      highlightFields: ['status', 'industry', 'annual_revenue'],
+      fields: {
+        name: { type: 'text', label: 'Account Name', required: true },
+        industry: { type: 'select', label: 'Industry' },
+        annual_revenue: { type: 'currency', label: 'Annual Revenue' },
+        status: { type: 'select', label: 'Lifecycle' },
+        organization_id: { type: 'lookup', system: true, hidden: true },
+      },
+    };
+
+    it('THE REPRO: prepends nameField to a curated list that omits it', () => {
+      expect(defaultListColumnsFromObject(showcaseAccount, 5)).toEqual([
+        'name',
+        'status',
+        'industry',
+        'annual_revenue',
+      ]);
+    });
+
+    it('does not duplicate a nameField the curated list already carries', () => {
+      const cols = defaultListColumnsFromObject(
+        { ...showcaseAccount, highlightFields: ['name', 'status'] },
+        5,
+      );
+      expect(cols).toEqual(['name', 'status']);
+    });
+
+    it('moves a late-listed nameField to the front', () => {
+      const cols = defaultListColumnsFromObject(
+        { ...showcaseAccount, highlightFields: ['status', 'name', 'industry'] },
+        5,
+      );
+      expect(cols).toEqual(['name', 'status', 'industry']);
+    });
+
+    it('still appends the org attribution column last', () => {
+      const cols = defaultListColumnsFromObject(showcaseAccount, 5, { orgAttribution: true });
+      expect(cols).toEqual(['name', 'status', 'industry', 'annual_revenue', 'organization_id']);
+    });
+
+    it('leads the derived walk too, and BEFORE the limit slice', () => {
+      // The walk is declaration-ordered, so a nameField declared after `limit`
+      // other fields used to fall off the end of the slice entirely.
+      const fields: Record<string, any> = {};
+      for (let i = 0; i < 8; i++) fields[`b_${i}`] = { type: 'text' };
+      fields.headline = { type: 'text' };
+      const cols = defaultListColumnsFromObject({ nameField: 'headline', fields }, 5);
+      expect(cols).toHaveLength(5);
+      expect(cols[0]).toBe('headline');
+      expect(cols).toEqual(['headline', 'b_0', 'b_1', 'b_2', 'b_3']);
+    });
+
+    it('does not lead with a nameField the object has no field def for', () => {
+      const cols = defaultListColumnsFromObject(
+        { nameField: 'ghost', highlightFields: ['status'], fields: showcaseAccount.fields },
+        5,
+      );
+      expect(cols).toEqual(['status']);
+    });
+  });
+
   it('caps the auto-derived business columns at the requested limit', () => {
     const fields: Record<string, any> = { owner_id: { type: 'lookup', system: true } };
     for (let i = 0; i < 10; i++) fields[`b_${i}`] = { type: 'text' };

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -11,7 +11,7 @@
 
 import { useMemo, useState, useCallback, useEffect, useRef, lazy, Suspense, type ComponentType } from 'react';
 import { useParams, useSearchParams, useNavigate, useLocation } from 'react-router-dom';
-import { resolveFilterPlaceholders, DENSITY_MODE_TO_ROW_HEIGHT, normalizeListViewSchema, type FilterTokenScope } from '@object-ui/core';
+import { resolveFilterPlaceholders, DENSITY_MODE_TO_ROW_HEIGHT, normalizeListViewSchema, leadWithNameField, type FilterTokenScope } from '@object-ui/core';
 import { parseUserFilterParams, applyUserFilterParams } from './userFilterUrlState.js';
 import { buildListFilterKey, readListFilterState, writeListFilterState } from './listFilterStorage.js';
 import { VALUELESS_FILTER_OPERATORS } from './viewFilterFold.js';
@@ -119,15 +119,27 @@ function substituteFilterTokens(filter: any, scope: FilterTokenScope): any {
 /**
  * Default list columns for an object that declares no explicit list view.
  *
- * Priority: the `highlightFields` semantic role (ADR-0085) wins verbatim
- * (only dropping names with no field def); otherwise the first `limit`
- * business fields in declared order. Framework-injected system / audit /
- * ownership columns are excluded via the shared `isSystemManagedField`
- * classifier — its single source of truth is the spec `system` flag stamped
- * by `applySystemFields`, with a name-set fallback covering the injected,
- * non-hidden / non-readonly `owner_id` and `organization_id`. Without this,
- * `applySystemFields` (which spreads injected fields to the FRONT of the field
- * map) would surface `owner_id` as a leading raw-id column (#2702, #2777).
+ * Priority: the object's name field ALWAYS leads (see below); then the
+ * `highlightFields` semantic role (ADR-0085) verbatim (only dropping names with
+ * no field def); otherwise the first `limit` business fields in declared order.
+ * Framework-injected system / audit / ownership columns are excluded via the
+ * shared `isSystemManagedField` classifier — its single source of truth is the
+ * spec `system` flag stamped by `applySystemFields`, with a name-set fallback
+ * covering the injected, non-hidden / non-readonly `owner_id` and
+ * `organization_id`. Without this, `applySystemFields` (which spreads injected
+ * fields to the FRONT of the field map) would surface `owner_id` as a leading
+ * raw-id column (#2702, #2777).
+ *
+ * The name-field lead is `leadWithNameField` from `@object-ui/core`
+ * (objectui#7245). `highlightFields` is NOT a column list — it is ADR-0085's
+ * "most important fields", and its first consumer, the detail highlight strip,
+ * deliberately DROPS the title field because the page H1 above it already shows
+ * one. So metadata that is entirely well-authored routinely omits the name:
+ * `showcase_account` declares `["status", "industry", "annual_revenue"]` and its
+ * default grid rendered 14 rows a user could not tell apart. A list has no H1,
+ * so the same role needs the opposite treatment here. Applied to BOTH branches:
+ * the fallback walk is declaration-ordered, so an object whose name field is
+ * declared late lost it off the end of the `limit` slice.
  *
  * `opts.orgAttribution` (ADR-0105 group posture): reads span every
  * organization the member belongs to, so cross-org rows need attribution —
@@ -365,15 +377,22 @@ export function defaultListColumnsFromObject(
             : cols;
     const curated = objectDef?.highlightFields;
     if (Array.isArray(curated) && curated.length > 0) {
-        return withOrgAttribution(curated.filter((n: string) => objectDef?.fields?.[n]));
+        return withOrgAttribution(
+            leadWithNameField(objectDef, curated.filter((n: string) => objectDef?.fields?.[n])),
+        );
     }
     const fields = objectDef?.fields;
     if (fields && typeof fields === 'object') {
         return withOrgAttribution(
-            Object.entries(fields)
-                .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
-                .map(([name]) => name)
-                .slice(0, limit),
+            // Lead BEFORE the slice: slicing first could drop the very column
+            // the lead exists to guarantee, on an object that declares its name
+            // field after `limit` others.
+            leadWithNameField(
+                objectDef,
+                Object.entries(fields)
+                    .filter(([name, f]: [string, any]) => f && !f.hidden && !isSystemManagedField(name, f))
+                    .map(([name]) => name),
+            ).slice(0, limit),
         );
     }
     return [];

--- a/packages/core/src/utils/__tests__/name-field-columns.test.ts
+++ b/packages/core/src/utils/__tests__/name-field-columns.test.ts
@@ -1,0 +1,176 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7245 — the name-space half of the ADR-0079 title ladder, and the
+ * column-list helper the three default-list synthesis faces share.
+ *
+ * The reported defect: `showcase_account` declares
+ * `highlightFields: ["status", "industry", "annual_revenue"]` against
+ * `nameField: "name"` and no list views, so every face that synthesized a
+ * default grid from `highlightFields` alone rendered 14 rows with no column
+ * identifying any of them.
+ *
+ * `highlightFields` is not a column list — it is ADR-0085's "most important
+ * fields", and its first consumer (the detail highlight strip) deliberately
+ * REMOVES the title field because the page H1 already shows it. So the metadata
+ * is correct and the synthesis was wrong.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveNameField, leadWithNameField, getRecordDisplayName } from '../record-title';
+
+/** The served `showcase_account` shape, abridged to the keys under test. */
+const showcaseAccount = {
+  name: 'showcase_account',
+  nameField: 'name',
+  highlightFields: ['status', 'industry', 'annual_revenue'],
+  fields: {
+    name: { type: 'text', label: 'Account Name', required: true },
+    industry: { type: 'select', label: 'Industry' },
+    annual_revenue: { type: 'currency', label: 'Annual Revenue' },
+    status: { type: 'select', label: 'Lifecycle' },
+    organization_id: { type: 'lookup', system: true, hidden: true },
+  },
+};
+
+describe('resolveNameField — which FIELD titles an object', () => {
+  it('returns the declared canonical `nameField`', () => {
+    expect(resolveNameField(showcaseAccount)).toBe('name');
+  });
+
+  it('honours the deprecated `displayNameField` alias when `nameField` is absent', () => {
+    expect(
+      resolveNameField({ displayNameField: 'activity_name', fields: { activity_name: { type: 'text' } } }),
+    ).toBe('activity_name');
+  });
+
+  it('prefers the canonical pointer over the deprecated alias', () => {
+    expect(resolveNameField({ nameField: 'subject', displayNameField: 'legacy' })).toBe('subject');
+  });
+
+  it('falls back to the type-aware derivation when nothing is declared', () => {
+    // Same ladder `getRecordDisplayName` step 4 runs: name-ish exact beats
+    // declaration order, and the date field is not title-eligible.
+    expect(
+      resolveNameField({ fields: { due_at: { type: 'datetime' }, title: { type: 'text' } } }),
+    ).toBe('title');
+  });
+
+  it('does NOT read the render-only `titleFormat` — a template is not a field name', () => {
+    // Deliberate omission, not a gap: there is no column, sort key or `$select`
+    // entry to be had from a template. Value-space still renders it.
+    const def = { titleFormat: '{a} · {b}', fields: { a: { type: 'text' }, b: { type: 'text' } } };
+    expect(resolveNameField(def)).toBe('a'); // the derivation, not the template
+    expect(getRecordDisplayName(def, { a: 'x', b: 'y' })).toBe('x · y');
+  });
+
+  it('returns undefined when nothing declares or derives a name field', () => {
+    expect(resolveNameField({ fields: { when: { type: 'datetime' } } })).toBeUndefined();
+    expect(resolveNameField(undefined)).toBeUndefined();
+  });
+
+  it('reads the SAME declared ladder value-space reads', () => {
+    // The `??` chain has one spelling (`declaredNameField`). If the two ever
+    // disagree, an object's list column and its record title name different
+    // fields — the divergence ADR-0079 collapsed in the first place.
+    const def = { nameField: 'activity_name', fields: { activity_name: { type: 'text' } } };
+    expect(getRecordDisplayName(def, { activity_name: 'Kickoff' })).toBe('Kickoff');
+    expect(resolveNameField(def)).toBe('activity_name');
+  });
+});
+
+describe('leadWithNameField — the synthesized default column list', () => {
+  it('THE REPRO: prepends the name column to a curated highlightFields list', () => {
+    expect(leadWithNameField(showcaseAccount, ['status', 'industry', 'annual_revenue'])).toEqual([
+      'name',
+      'status',
+      'industry',
+      'annual_revenue',
+    ]);
+  });
+
+  it('does not duplicate a name field the curated list already contains', () => {
+    expect(leadWithNameField(showcaseAccount, ['name', 'status'])).toEqual(['name', 'status']);
+  });
+
+  it('MOVES the name field to the front when it is listed later', () => {
+    // "The column that identifies the row" means first, not merely present.
+    // Same treatment `deriveLookupColumns` gives the picker's display field.
+    expect(leadWithNameField(showcaseAccount, ['status', 'name', 'industry'])).toEqual([
+      'name',
+      'status',
+      'industry',
+    ]);
+  });
+
+  it('leaves the order of the remaining columns untouched', () => {
+    expect(leadWithNameField(showcaseAccount, ['annual_revenue', 'status', 'industry'])).toEqual([
+      'name',
+      'annual_revenue',
+      'status',
+      'industry',
+    ]);
+  });
+
+  it('leads via the DERIVED name field when the object declares none', () => {
+    const def = {
+      highlightFields: ['stage'],
+      fields: { stage: { type: 'select' }, title: { type: 'text' } },
+    };
+    expect(leadWithNameField(def, ['stage'])).toEqual(['title', 'stage']);
+  });
+
+  describe('cases that must NOT lead', () => {
+    it('a name field the object carries no field def for — never fabricate a column', () => {
+      const def = { nameField: 'ghost', fields: { status: { type: 'select' } } };
+      expect(leadWithNameField(def, ['status'])).toEqual(['status']);
+    });
+
+    it('a `hidden: true` name field — the author said do not show it', () => {
+      const def = {
+        nameField: 'secret_name',
+        fields: { secret_name: { type: 'text', hidden: true }, status: { type: 'select' } },
+      };
+      expect(leadWithNameField(def, ['status'])).toEqual(['status']);
+    });
+
+    it('a DERIVED pick that lands on a system-managed column (#2702 / #2777)', () => {
+      // `deriveTitleField` filters by TYPE only, so with no name-ish business
+      // field it can pick an injected column. Leading a default list with a raw
+      // id is exactly the regression those two issues fixed.
+      const def = {
+        fields: {
+          owner_id: { type: 'text', system: true },
+          amount: { type: 'currency' },
+        },
+      };
+      expect(resolveNameField(def)).toBe('owner_id'); // the derivation does pick it…
+      expect(leadWithNameField(def, ['amount'])).toEqual(['amount']); // …and the guard refuses it
+    });
+
+    it('but a DECLARED system field still leads — `sys_migration` really points at `id`', () => {
+      // An author's explicit designation is not a heuristic misfire.
+      const def = {
+        nameField: 'id',
+        fields: { id: { type: 'text', system: true }, applied_at: { type: 'datetime' } },
+      };
+      expect(leadWithNameField(def, ['applied_at'])).toEqual(['id', 'applied_at']);
+    });
+
+    it('an object with no resolvable name field at all', () => {
+      const def = { fields: { when: { type: 'datetime' }, amount: { type: 'currency' } } };
+      expect(leadWithNameField(def, ['when', 'amount'])).toEqual(['when', 'amount']);
+    });
+
+    it('an absent / empty object definition', () => {
+      expect(leadWithNameField(undefined, ['a'])).toEqual(['a']);
+      expect(leadWithNameField({}, ['a'])).toEqual(['a']);
+    });
+  });
+});

--- a/packages/core/src/utils/record-title.ts
+++ b/packages/core/src/utils/record-title.ts
@@ -44,6 +44,8 @@
  * `percentDisplayValue` / `formatMeasure`.
  */
 
+import { isSystemManagedField } from '@object-ui/types';
+
 // Sentinel marking an empty-placeholder position inside a titleFormat render,
 // so adjacent separators can be stripped in a second pass.
 //
@@ -306,6 +308,104 @@ export function deriveTitleField(objectDef: any): string | undefined {
 }
 
 /**
+ * The declared name-field pointer, read exactly as {@link getRecordDisplayName}
+ * reads it: the canonical `nameField` (ADR-0079 Phase 2), then its deprecated
+ * `displayNameField` / `NAME_FIELD_KEY` aliases.
+ *
+ * One spelling, two readers — the value-space resolver and the name-space
+ * {@link resolveNameField}. Re-typing the `??` chain at the second reader is
+ * how the two would drift into disagreeing about which field titles an object.
+ * No new alias is read here; this is the existing ladder, extracted.
+ */
+function declaredNameField(objectDef: any): any {
+  return objectDef?.nameField ?? objectDef?.displayNameField ?? objectDef?.NAME_FIELD_KEY;
+}
+
+/**
+ * WHICH FIELD titles this object — the name-space twin of
+ * {@link getRecordDisplayName}, which answers what that field SAYS on one
+ * record. Same ladder, minus the rungs that only exist per record:
+ *
+ *   1+2. the declared pointer ({@link declaredNameField});
+ *   4.   else the type-aware derivation ({@link deriveTitleField}).
+ *
+ * The two omissions are deliberate, not oversights. `options.titleField`
+ * (step 0) belongs to one view, not to the object. `titleFormat` (step 3) is a
+ * render-only template, not a field name — there is no column, no sort key and
+ * no `$select` entry to be had from it, which is the same reason ADR-0079
+ * demoted it. A caller that wants a title for a `titleFormat`-only object wants
+ * {@link getRecordDisplayName}, per record.
+ *
+ * Deliberately does NOT require the answer to exist in `objectDef.fields`: in
+ * value-space the declared pointer is read off the RECORD, so demanding a field
+ * def here would make the two resolvers disagree. A caller that needs a
+ * RENDERABLE column checks presence itself — see {@link leadWithNameField}.
+ *
+ * Returns `undefined` when nothing declares or derives a name field.
+ */
+export function resolveNameField(objectDef: any): string | undefined {
+  const declared = declaredNameField(objectDef);
+  if (typeof declared === 'string' && declared.length > 0) return declared;
+  return deriveTitleField(objectDef);
+}
+
+/**
+ * Put the object's name field at the FRONT of a **synthesized** default column
+ * list, so a list no author ever configured still lets you tell its rows apart.
+ *
+ * Why this exists (objectui#7245): the three faces that synthesize default list
+ * columns each took a declared `highlightFields` verbatim. `highlightFields` is
+ * the ADR-0085 "most important fields" role, and its canonical consumer — the
+ * detail-page highlight strip — deliberately *excludes* the title field,
+ * because the strip sits directly under the page H1 that already shows it. So
+ * well-authored metadata routinely omits the name from `highlightFields`: the
+ * showcase `showcase_account` declares `["status", "industry", "annual_revenue"]`
+ * against `nameField: "name"`, and its default grid rendered 14 rows with no
+ * name column and nothing to distinguish them.
+ *
+ * A list has no H1 to lean on, so the same role needs the opposite treatment
+ * here. This is not a new convention: `deriveLookupColumns` in `@object-ui/fields`
+ * already leads its picker columns with the display field and filters it out of
+ * the declared list — the record-picker equivalent of this problem, solved the
+ * same way. This makes the list faces agree with it.
+ *
+ * MOVES the name field rather than only prepending a missing one: an author who
+ * lists it third still gets it first, which is what "the column that identifies
+ * the row" means. Order among the remaining columns is untouched.
+ *
+ * NOT for author-declared column lists. A view that declares `columns` said what
+ * it wants; overriding that would be exactly the renderer-side second-guessing
+ * AGENTS.md Commandment #0.1 rules out. Every caller passes a list it
+ * synthesized itself.
+ *
+ * Three cases return `columns` untouched, each guarding a rule that already
+ * governs these column lists:
+ *
+ *  - **No field def** (nothing resolved, or the pointer names a field the object
+ *    does not carry) — a synthesized list must never fabricate a column the
+ *    object cannot render.
+ *  - **`hidden: true`** — the author said don't show this field. That outranks
+ *    the fact that it also titles the record; every one of these faces already
+ *    drops hidden fields from its own walk.
+ *  - **DERIVED onto a system-managed field.** {@link deriveTitleField} filters
+ *    by TYPE only, so on an object with no name-ish business field it can land
+ *    on a framework-injected column — and leading a default list with a raw id
+ *    is precisely the regression objectui#2702 / #2777 fixed. A *declared*
+ *    `nameField` is exempt: `sys_migration` really does point at `id`, and an
+ *    author's explicit designation is not a heuristic misfire.
+ */
+export function leadWithNameField(objectDef: any, columns: string[]): string[] {
+  const declared = declaredNameField(objectDef);
+  const isDeclared = typeof declared === 'string' && declared.length > 0;
+  const lead = isDeclared ? declared : deriveTitleField(objectDef);
+  const def = lead ? objectDef?.fields?.[lead] : undefined;
+  if (!lead || !def) return columns;
+  if (def.hidden) return columns;
+  if (!isDeclared && isSystemManagedField(lead, def)) return columns;
+  return [lead, ...columns.filter((c) => c !== lead)];
+}
+
+/**
  * Standard name-ish keys probed directly on a *record* as a last resort before
  * the `Record #<id>` floor — used when `objectDef.fields` is absent so
  * {@link deriveTitleField} can't run (loosely-typed metadata, the lightweight
@@ -417,10 +517,9 @@ export function getRecordDisplayName(
   //      explicitly-declared field now wins over the legacy `titleFormat`
   //      template (step 3): an object that sets `nameField` resolves via it even
   //      if it also carries a stale `titleFormat`.
-  const declared = valueAt(
-    record,
-    objectDef?.nameField ?? objectDef?.displayNameField ?? objectDef?.NAME_FIELD_KEY,
-  );
+  //      The `??` chain itself lives in {@link declaredNameField} so the
+  //      name-space {@link resolveNameField} reads the identical ladder.
+  const declared = valueAt(record, declaredNameField(objectDef));
   if (declared) return declared;
 
   // 3. titleFormat (LEGACY, render-only template). DEPRECATED by ADR-0079: the

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -36,7 +36,7 @@ import {
   RefreshIndicator,
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, ROW_HEIGHT_TO_DENSITY_MODE } from '@object-ui/core';
+import { resolveConditionalFormatting, leadWithNameField, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, ROW_HEIGHT_TO_DENSITY_MODE } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { ChevronRight, ChevronDown, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
@@ -2788,8 +2788,30 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
     if (schemaFields) {
       fieldsToShow = schemaFields;
     } else if (highlightFields?.length) {
-      fieldsToShow = highlightFields.filter((n) => objectSchema.fields?.[n]);
+      // Lead with the object's name field (objectui#7245). `highlightFields` is
+      // ADR-0085's "most important fields" role, not a column list — the detail
+      // highlight strip, its first consumer, deliberately drops the title field
+      // because the page H1 above it already shows one. A grid has no H1, so a
+      // declared list like `["status", "industry", "annual_revenue"]` left rows
+      // with nothing to tell them apart. `leadWithNameField` is the shared
+      // helper the two app-shell synthesis faces use, so all three agree.
+      //
+      // Only the SYNTHESIZED branch. `schemaFields` above is author-declared and
+      // is never reordered — that would be the renderer second-guessing metadata
+      // (AGENTS.md Commandment #0.1).
+      fieldsToShow = leadWithNameField(
+        objectSchema,
+        highlightFields.filter((n) => objectSchema.fields?.[n]),
+      );
     } else {
+      // No name-field lead here, and that is measured, not an oversight: this
+      // branch takes EVERY visible field with no cap, so — unlike the two
+      // app-shell faces, which slice to 5 / 6 — the name field cannot fall off
+      // the end. It is already present; only its position could differ, and a
+      // row that carries its name column somewhere is still identifiable. The
+      // objectui#7245 defect is "no name column at all", which is unreachable
+      // from here.
+      //
       // Drop hidden + readonly system-managed fields, then push the remaining
       // system/audit/ownership columns (e.g. the injected, editable `owner_id`)
       // to the end as a fallback so business fields lead.

--- a/packages/plugin-grid/src/__tests__/defaultColumnsNameFieldLead-7245.test.tsx
+++ b/packages/plugin-grid/src/__tests__/defaultColumnsNameFieldLead-7245.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7245 — ObjectGrid's own default-column synthesis is the third face
+ * that took a declared `highlightFields` verbatim, and it needs the same
+ * name-field lead as the two app-shell faces.
+ *
+ * `highlightFields` is ADR-0085's "most important fields" role, NOT a column
+ * list. Its first consumer — the detail-page highlight strip — deliberately
+ * removes the title field, because the page H1 directly above it already shows
+ * one. So metadata that is entirely correct routinely omits the name, and the
+ * showcase `showcase_account` (`nameField: "name"`,
+ * `highlightFields: ["status", "industry", "annual_revenue"]`, no list views)
+ * rendered 14 rows with nothing to tell them apart.
+ *
+ * ## What discriminates
+ *
+ * Asserting only "the name column is present" would pass on the broken build
+ * for the object below, because `name` would appear once the author listed it.
+ * The load-bearing assertion is the FULL header list in ORDER — on the
+ * unfixed synthesis the curated three come through with no `Account Name` at
+ * all.
+ *
+ * The controls hold the boundaries the lead must not cross: an authored
+ * `fields` projection is never reordered (that is the author's declaration, and
+ * reordering it would be the renderer second-guessing metadata — AGENTS.md
+ * Commandment #0.1), and the no-`highlightFields` walk is untouched.
+ */
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+
+registerAllFields();
+
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = vi.fn(() => false) as any;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn() as any;
+  }
+});
+
+/**
+ * The served `showcase_account`, abridged. Field declaration order deliberately
+ * does NOT match `highlightFields` order, so the assertion below cannot pass by
+ * accident through the declaration-order walk.
+ */
+const ACCOUNT_SCHEMA = {
+  name: 'showcase_account',
+  label: 'Account',
+  nameField: 'name',
+  highlightFields: ['status', 'industry', 'annual_revenue'],
+  fields: {
+    name: { type: 'text', label: 'Account Name' },
+    industry: { type: 'text', label: 'Industry' },
+    annual_revenue: { type: 'number', label: 'Annual Revenue' },
+    status: { type: 'text', label: 'Lifecycle' },
+    created_at: { type: 'datetime', label: 'Created At', system: true, readonly: true },
+  },
+};
+
+const ROWS = [
+  {
+    id: 'acct-1',
+    name: 'Northwind Traders',
+    industry: 'Retail',
+    annual_revenue: 25000000,
+    status: 'active',
+    created_at: '2026-08-01T10:00:00Z',
+  },
+];
+
+function makeDataSource(schema: Record<string, unknown> = ACCOUNT_SCHEMA) {
+  return {
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    getObjectSchema: vi.fn(async () => schema),
+  } as any;
+}
+
+/** Data-column header labels in render order (drops furniture + the `#` index). */
+function dataHeaders(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('thead th'))
+    .map((th) => (th.textContent ?? '').trim())
+    .filter((text) => text.length > 0 && text !== '#');
+}
+
+function renderGrid(schemaOverrides: Record<string, unknown> = {}, objectSchema = ACCOUNT_SCHEMA) {
+  const ds = makeDataSource(objectSchema);
+  const utils = render(
+    <ActionProvider>
+      <ObjectGrid
+        schema={{ type: 'object-grid', objectName: 'showcase_account', ...schemaOverrides }}
+        dataSource={ds}
+        data={ROWS}
+      />
+    </ActionProvider>,
+  );
+  return { ...utils, ds };
+}
+
+describe('ObjectGrid default columns lead with the name field (#7245)', () => {
+  it('THE REPRO: a curated highlightFields that omits the name still gets a name column, first', async () => {
+    const { container } = renderGrid();
+    await waitFor(() =>
+      expect(dataHeaders(container)).toEqual([
+        'Account Name',
+        'Lifecycle',
+        'Industry',
+        'Annual Revenue',
+      ]),
+    );
+  });
+
+  it('does not duplicate a name field the curated list already carries', async () => {
+    const { container } = renderGrid(
+      {},
+      { ...ACCOUNT_SCHEMA, highlightFields: ['name', 'status'] },
+    );
+    await waitFor(() => expect(dataHeaders(container)).toEqual(['Account Name', 'Lifecycle']));
+  });
+
+  it('moves a late-listed name field to the front', async () => {
+    const { container } = renderGrid(
+      {},
+      { ...ACCOUNT_SCHEMA, highlightFields: ['status', 'name', 'industry'] },
+    );
+    await waitFor(() =>
+      expect(dataHeaders(container)).toEqual(['Account Name', 'Lifecycle', 'Industry']),
+    );
+  });
+
+  // CONTROL — an author who declares a projection gets it verbatim, in their
+  // order. The lead applies only to what the renderer synthesized itself.
+  it('never reorders an authored `fields` projection', async () => {
+    const { container } = renderGrid({ fields: ['status', 'name'] });
+    await waitFor(() => expect(dataHeaders(container)).toEqual(['Lifecycle', 'Account Name']));
+  });
+
+  // CONTROL — no `highlightFields`, so the walk runs. It takes every visible
+  // field with no cap, so the name cannot fall off the end; that branch is
+  // deliberately left alone and must stay declaration-ordered.
+  it('leaves the no-highlightFields walk untouched', async () => {
+    const { highlightFields: _dropped, ...noHighlights } = ACCOUNT_SCHEMA;
+    const { container } = renderGrid({}, noHighlights as typeof ACCOUNT_SCHEMA);
+    await waitFor(() =>
+      expect(dataHeaders(container)).toEqual([
+        'Account Name',
+        'Industry',
+        'Annual Revenue',
+        'Lifecycle',
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #7245

## The defect

An object that declares no list view gets its default grid columns **synthesized** from `highlightFields`, taken verbatim. But `highlightFields` is ADR-0085's *"most important fields"* role, **not a column list** — and its first consumer, the detail-page highlight strip, *deliberately removes* the title field, because the page H1 directly above it already shows one.

So metadata that is entirely correct routinely omits the record's name from `highlightFields`, and the list faces had nothing to identify a row with. Confirmed against the running showcase backend rather than from the card:

    GET /api/v1/meta/object/showcase_account
      nameField        = "name"
      highlightFields  = ["status", "industry", "annual_revenue"]
      listViews / list_views / list  → all ABSENT

    GET /api/v1/meta/view
      35 views total, 0 of them bound to showcase_account

One correction to the card's wording, for the record: `showcase_account` does **not** *declare* `nameField` in its source (`examples/app-showcase/src/data/objects/account.object.ts` has no such key) — the platform stamps it onto the served metadata. The served reading the console actually consumes is exactly as reported, so the diagnosis is unaffected.

A list has no H1 to lean on, so the same declaration needs the opposite treatment here. This is **not a new convention**: `deriveLookupColumns` in `@object-ui/fields` already leads its record-picker columns with the display field and filters it out of the declared list. The list faces now agree with it.

## Column lists, before and after

`showcase_account`, default `所有记录` view:

| | data columns |
|---|---|
| before | 生命周期, 行业, 年收入 |
| after | **Account Name**, 生命周期, 行业, 年收入 |

(furniture columns `#` and 操作 unchanged). Measured as rendered DOM headers in `defaultColumnsNameFieldLead-7245.test.tsx`, which drives a real `ObjectGrid` against the served schema shape.

Both halves are measured, not inferred. The *before* row is the card's reading. The *after* row was read out of the **live console** driven against the running showcase backend — this branch's source served by a Vite dev server on :5181 proxying to :3911, at `/apps/showcase_app/showcase_account`, view `所有记录`:

    thead th  → ["", "#", "客户名称", "生命周期", "行业", "年收入", "操作"]
    tbody tr  → 14
    row 1     → ["", "1", "Vandelay Industries", "Active", "Finance", "6,700,000"]

The 14 rows the card reports as indistinguishable now lead with the account name. The same column set is pinned headlessly in `defaultColumnsNameFieldLead-7245.test.tsx`, which drives a real `ObjectGrid` against the served schema shape, so the fix does not depend on a live backend to stay pinned.

## Three faces, not one

The card's dispatch anticipated more than one synthesis point, and there are three. Each read `highlightFields` verbatim:

| face | file | cap |
|---|---|---|
| console object view (the reported one) | `packages/app-shell/src/views/ObjectView.tsx` — `defaultListColumnsFromObject` | 5 |
| interface pages | `packages/app-shell/src/views/InterfaceListPage.tsx` — `defaultColumnsFromObject` | 6 |
| the grid's own derivation | `packages/plugin-grid/src/ObjectGrid.tsx` — `fieldsToShow` | none |

## Fixed at the producer, not the consumer

`@object-ui/core` gains two exports on the existing ADR-0079 title ladder:

- **`resolveNameField(objectDef)`** — *which field* titles an object: the declared `nameField`, then its deprecated `displayNameField` / `NAME_FIELD_KEY` aliases, else the type-aware derivation. The name-space twin of `getRecordDisplayName`, which answers what that field *says* on one record. The `??` chain now has **one spelling** (`declaredNameField`), read by both, so the two cannot drift into naming different fields — the divergence ADR-0079 collapsed in the first place. No new alias is read; this is the existing ladder, extracted.
- **`leadWithNameField(objectDef, columns)`** — moves that field to the front of a **synthesized** column list.

Core was chosen over the other two existing name-field spellings deliberately. `plugin-detail`'s `resolveTitleField` runs a different ladder (`primaryField` first, a different fallback name set) and is not a dependency of `plugin-grid`; core's is the one documented as *the* unified ADR-0079 resolver, and both app-shell and plugin-grid already depend on it.

The name field is **moved**, not merely appended when missing — an author who lists it third still gets it first, because "the column that identifies the row" means first. On the two capped faces the lead is applied *before* the 5 / 6-column slice, so an object declaring its name field late no longer loses it off the end.

## What is deliberately NOT changed

- **Author-declared column lists.** A view or grid that declares `columns` / `fields` said what it wants; reordering it would be renderer-side second-guessing of metadata (AGENTS.md Commandment #0.1). Pinned as a control test.
- **`ObjectGrid`'s no-`highlightFields` walk.** It takes every visible field with no cap, so the name field cannot fall off the end — it is already present, only its position could differ. The defect this card reports is unreachable from there. Stated in the code as a measured decision, and pinned as a second control.
- **The showcase app.** Adding a list view over in `objectstack` would have hidden the defect rather than fixed it; the synthesis rule itself was wrong.

Three cases decline to lead, each guarding an existing rule: a name field the object carries no field def for (never fabricate a column), one marked `hidden: true` (the author said don't show it), and a **derived** pick that lands on a system-managed column — `deriveTitleField` filters by type only, and leading a default list with a raw id is the objectui#2702 / #2777 regression. A **declared** `nameField` on a system field still leads: `sys_migration` really does point at `id`, and an explicit designation is not a heuristic misfire.

## Verification

Union re-run on the final merged head **34b307b38**.

**Reverse verification (ablation).** The three call sites were reverted to `origin/main` with the core helper and every test kept, so the faces fail on *assertions* rather than on a missing import. Predicted direction: red. Measured: **10 failed / 46 passed** — every failure inside a `#7245` block, every pre-existing assertion in those same files still green. The mutation was proven on disk before measuring (`leadWithNameField` occurrences 4/4/3 → 0/0/0, and each file's blob hash equal to its `origin/main` blob); the restore was proven by observation afterwards, not by an exit code — `git diff HEAD` empty, `git status` clean, and all three blob hashes byte-identical to the pre-ablation reading. No rebuild leg was needed and none is claimed: the root vitest config aliases `@object-ui/core` to `packages/core/src` (`vitest.config.mts:277`), so nothing resolves through `dist` and there is no stale-artifact surface for the ablation to hide behind.

| gate | result |
|---|---|
| targeted vitest, 14 files (both new suites, both edited suites, the blast radius, plus `hostFetchedDefaultColumns-6677` and the just-landed `ListView.speculativeFls-7216`) | `Test Files 14 passed (14)` / `Tests 207 passed (207)` |
| `packages/core/` + `packages/plugin-grid/` full suites | `Test Files 1 failed \| 217 passed (218)` / `Tests 1 failed \| 3139 passed (3140)` — see the flake note below |
| `type-check` (core, app-shell, plugin-grid) | all three `Done`; each echoed `tsc --noEmit && tsc -p tsconfig.test.json`, so the new test files are type-checked too |
| eslint over the three packages | **0 errors** across **1397** files processed |
| `check-changeset-presence.mjs` | `✅ 8 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-no-major.mjs` | `✅ No changeset declares a major bump.` |

**The one red, and why it is not this change.** `plugin-grid/src/__tests__/rowRecordCrudVerdict.test.tsx > paginates under the server's cap` failed with `Error: Test timed out in 15000ms` at 16471ms — a timeout, not an assertion, and the signature AGENTS.md documents for unbounded module loading charged to a bounded window under a saturated parallel run. Re-run alone: `Test Files 1 passed (1)` / `Tests 15 passed (15)`. The file covers batched CRUD verdicts and touches no part of column synthesis.

### Declared narrowing 1 — verification ran UNLOCKED

The official wording from `scripts/pm/os-verify-lock.sh`, pasted as it asks:

**Declared narrowing — verification ran UNLOCKED.** `scripts/pm/os-verify-lock.sh` could not take the shared verify lock on this host: no usable `flock`. The shared verify lock is declared Linux-only (`flock` is util-linux, and a stock macOS does not ship it), so the command below was run directly, without the lock — a declared narrowing, not a silent one. No serialization guarantee held for this run, nor for any sibling agent in this container while it ran.

This applies to every command in the table above.

### Declared narrowing 2 — the app-shell suite was scoped, not run whole

`pnpm exec vitest run packages/app-shell/` was killed by the container's ~10-minute foreground cap (`exit 143`) before producing any verdict. It was replaced by the 10-file blast radius — every app-shell test that references `defaultListColumnsFromObject`, `defaultColumnsFromObject`, `getRecordDisplayName` or `deriveTitleField`, plus the `ObjectView.*` / `InterfaceListPage.*` suites: `Test Files 10 passed (10)` / `Tests 110 passed (110)`. The rest of `app-shell` is left to CI, which runs the farm regardless. This is a scoped run, not a claim of full-package coverage.

### On the lint scope

Three pieces of evidence, so the scoping is a measurement rather than an omission:

1. **Population** — read from eslint's own resolution of the three package directories under the root flat config, not from a hand-listed file set.
2. **Count** — **1397** files, read from `--format json` output, 0 errors (4154 pre-existing warnings, all `warn`-level rules such as `@typescript-eslint/no-explicit-any`; the repo has no formatting gate).
3. **Invariance** — `eslint.config.js` declares no `parserOptions.project` and no `projectService`, so **type-aware linting is not enabled**: every file's verdict depends only on its own source plus the shared config. This diff changes no config file, so it cannot move the verdict of any file it did not touch.

## Overlap with in-flight work

Re-checked after merging `origin/main`. PR #7261 (`plugin-list` speculative `$select` FLS gating) landed as ac257b31f while this was in progress; its file surface is `packages/plugin-list/src/ListView.tsx` plus its own test — **zero overlap** with the four files here, and it gates *which fields are fetched*, not *which columns are synthesized*. Its suite is included in the union above and is green on this head.

_Generated by [Claude Code](https://claude.ai/code/session_62849a16-0144-4728-8942-9f60bb3a73f1)_
