### PR TITLE
test(scripts): pin the published stylesheet banner per subject (#7044)

### DIFF
--- a/scripts/__tests__/plugin-published-stylesheet.test.ts
+++ b/scripts/__tests__/plugin-published-stylesheet.test.ts
@@ -202,12 +202,27 @@ describe('published supplement stylesheets (objectui#4929, objectui#6438)', () =
     /**
      * objectui#7044: the emitted sheet's banner is part of the published
      * artifact (objectui#6405's acceptance gate was byte-identity of that
-     * file), yet nothing here read it. The expected value is read from the
-     * subject's OWN build script export — `mod.buildOptions.header` for the
-     * package that declares one (`fields`, objectui#4059/#6405), else the
-     * shared `defaultHeader(mod.PACKAGE_NAME)` this module now exports for
-     * exactly this — never a second, hand-spelled copy of either wording,
-     * which would be free to drift from the real one while staying green.
+     * file), yet nothing here read it. Two checks, deliberately independent
+     * of each other, because the obvious single check is vacuous: recomputing
+     * "expected" by calling the very function that ALSO produced "actual"
+     * (`defaultHeader`, or fields' own `buildOptions.header`) can never be
+     * surprised by a mutation to that function's wording — both sides move
+     * together. Neither check below has that shape:
+     *
+     *   1. the emitted sheet starts with the header this subject is
+     *      CONFIGURED to use — its own declared `buildOptions.header` when it
+     *      has one (`fields`, objectui#4059/#6405), else the shared
+     *      `defaultHeader(PACKAGE_NAME)` this module now exports for exactly
+     *      this. Catches the ASSEMBLY breaking (`header` no longer prepended,
+     *      or some third, unrelated value used) — never a second hand-spelled
+     *      copy of either wording, which would be free to drift from the real
+     *      one while staying green.
+     *   2. that header actually NAMES this package: `mod.PACKAGE_NAME` is a
+     *      plain string constant each build script declares independently
+     *      (never derived from `defaultHeader`), so a broken interpolation
+     *      inside `defaultHeader` cannot hide behind (1)'s self-consistent
+     *      recomputation — this is what gives (1) teeth against a mutation to
+     *      `defaultHeader` itself, for the two subjects that inherit it.
      */
     it('opens the emitted sheet with the banner it declares', () => {
       const { css } = built.get(name) as Built;
@@ -215,7 +230,22 @@ describe('published supplement stylesheets (objectui#4929, objectui#6438)', () =
       const declaredHeader = (mod.buildOptions as { header?: string }).header;
       const expectedHeader = declaredHeader ?? defaultHeader(mod.PACKAGE_NAME);
       expect(css.startsWith(`${expectedHeader}\n`)).toBe(true);
+      expect(css.slice(0, expectedHeader.length)).toContain(mod.PACKAGE_NAME);
     });
+
+    // fields-only: the control that (1) above cannot provide, because
+    // dropping fields' `header` override moves both its "expected" and
+    // "actual" to the shared default IN LOCKSTEP — exactly the failure mode
+    // objectui#7044 was filed over ("an accidental drop of fields' per-package
+    // `header`, would ship silently"). This checks the emitted sheet against
+    // the OTHER branch's value, independent of whichever branch (1) took.
+    if (name === 'fields') {
+      it('does not fall back to the shared default banner', () => {
+        const { css } = built.get('fields') as Built;
+        const { mod } = SUBJECTS.find((s) => s.name === 'fields')!;
+        expect(css.startsWith(`${defaultHeader(mod.PACKAGE_NAME)}\n`)).toBe(false);
+      });
+    }
 
     it('emits the themed utilities only this build can produce', () => {
       const { classes } = built.get(name) as Built;

--- a/scripts/__tests__/plugin-published-stylesheet.test.ts
+++ b/scripts/__tests__/plugin-published-stylesheet.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import * as gridStylesheet from '../../packages/plugin-grid/scripts/build-css.mjs';
 import * as kanbanStylesheet from '../../packages/plugin-kanban/scripts/build-css.mjs';
 import * as fieldsStylesheet from '../../packages/fields/scripts/build-css.mjs';
-import { classesOf, COMPONENTS_ENTRY, REPO_ROOT } from '../build-plugin-stylesheet.mjs';
+import { classesOf, COMPONENTS_ENTRY, REPO_ROOT, defaultHeader } from '../build-plugin-stylesheet.mjs';
 
 /**
  * objectui#4929: `@object-ui/plugin-grid` and `@object-ui/plugin-kanban` now
@@ -198,6 +198,24 @@ describe('published supplement stylesheets (objectui#4929, objectui#6438)', () =
 
   describe.each(SUBJECTS.map(({ name }) => name))('%s', (name) => {
     const themed = CARD_THEMED[name];
+
+    /**
+     * objectui#7044: the emitted sheet's banner is part of the published
+     * artifact (objectui#6405's acceptance gate was byte-identity of that
+     * file), yet nothing here read it. The expected value is read from the
+     * subject's OWN build script export — `mod.buildOptions.header` for the
+     * package that declares one (`fields`, objectui#4059/#6405), else the
+     * shared `defaultHeader(mod.PACKAGE_NAME)` this module now exports for
+     * exactly this — never a second, hand-spelled copy of either wording,
+     * which would be free to drift from the real one while staying green.
+     */
+    it('opens the emitted sheet with the banner it declares', () => {
+      const { css } = built.get(name) as Built;
+      const { mod } = SUBJECTS.find((s) => s.name === name)!;
+      const declaredHeader = (mod.buildOptions as { header?: string }).header;
+      const expectedHeader = declaredHeader ?? defaultHeader(mod.PACKAGE_NAME);
+      expect(css.startsWith(`${expectedHeader}\n`)).toBe(true);
+    });
 
     it('emits the themed utilities only this build can produce', () => {
       const { classes } = built.get(name) as Built;

--- a/scripts/build-plugin-stylesheet.mjs
+++ b/scripts/build-plugin-stylesheet.mjs
@@ -214,8 +214,12 @@ export function indexSheet(rootNode) {
  * those exact bytes are part of a published artifact (objectui#6405). Wording
  * that would be an improvement everywhere else is a diff in a published file
  * there. A package with no such history passes no `header` and inherits this.
+ *
+ * Exported (objectui#7044) so `scripts/__tests__/plugin-published-stylesheet.test.ts`
+ * can pin the emitted banner against the real default instead of a second,
+ * hand-spelled copy that would be free to drift from it while staying green.
  */
-function defaultHeader(packageName) {
+export function defaultHeader(packageName) {
   return [
     `/*! ${packageName} — utilities this package adds on top of @object-ui/components.`,
     ' *',


### PR DESCRIPTION
Fixes #7044

## What

Three packages ship a supplement stylesheet whose emitted bytes open with a
banner comment that is part of the published artifact (`@object-ui/fields`,
`@object-ui/plugin-grid`, `@object-ui/plugin-kanban`). Nothing in the suite
read that banner, so a change to the shared `defaultHeader`, or an accidental
drop of fields' own per-package `header` override, would ship silently — the
second case being a diff in a published file that #6405's acceptance gate
(byte-identity of the emitted sheet) was explicitly meant to prevent.

This PR:

- Exports `defaultHeader` from `scripts/build-plugin-stylesheet.mjs` (was
  module-private; one-line change, function body untouched, plus a doc-comment
  note on why it's exported now).
- Adds a per-subject assertion in
  `scripts/__tests__/plugin-published-stylesheet.test.ts` that the emitted
  sheet opens with the header the subject is actually configured to use —
  its own declared `buildOptions.header` for `fields`, else the shared
  `defaultHeader(PACKAGE_NAME)` this module now exports for `plugin-grid` /
  `plugin-kanban` — never a second, hand-spelled copy of either wording (the
  route ruled out on the issue as the "assertion that inspects nothing"
  shape).

## Why two checks, not one

The obvious single assertion — recompute "expected" by calling the very
function (`defaultHeader`, or `buildOptions.header`) that also produced
"actual" — is vacuous: since both sides call the same pure function on the
same input, no mutation to that function's own wording can ever make it
disagree with itself. Ablating confirmed this (see Testing below), so the
assertion adds two independent checks that don't have that shape:

1. **Assembly check** (all 3 subjects): the emitted sheet must start with
   `expectedHeader`, where `expectedHeader` is read from the subject's own
   build script export. Catches the header not being prepended at all, or
   some unrelated value being used.
2. **Name-presence check** (all 3 subjects): the banner region contains the
   subject's own `PACKAGE_NAME` — a plain string constant each build script
   declares independently, never derived from `defaultHeader`. This is what
   gives check 1 teeth against a broken interpolation inside `defaultHeader`
   itself, for the two packages that inherit it.
3. **fields-only control**: fields' emitted sheet must NOT start with the
   shared default banner. This is the check that actually catches "an
   accidental drop of fields' `header` override" — the scenario named in the
   issue — because dropping it moves fields' "expected" (check 1's fallback)
   and "actual" to the shared default in lockstep, so check 1 alone can't see
   it.

## Testing

```
pnpm exec vitest run scripts/__tests__/plugin-published-stylesheet.test.ts --maxWorkers=2
# Test Files  1 passed (1) / Tests  24 passed (24)

pnpm type-check:scripts   # clean
pnpm check:control-bytes  # OK, 6004 tracked text files scanned
pnpm check:entry-guard    # 52 export bindings, 52 inert on import (0 known-unsafe)
pnpm check:esm-specifiers # unaffected (no ESM specifier surface touched)
node scripts/check-changeset-presence.mjs  # no changeset owed (scripts/-only diff)
```

**Ablation 1** — mutated `defaultHeader()` in
`scripts/build-plugin-stylesheet.mjs` to hardcode a wrong package name
(breaking its package-name interpolation), confirmed the mutation landed on
disk (`git diff`, byte count), reran the suite:

```
FAIL plugin-grid   > opens the emitted sheet with the banner it declares
FAIL plugin-kanban > opens the emitted sheet with the banner it declares
PASS fields        > opens the emitted sheet with the banner it declares
PASS fields        > does not fall back to the shared default banner
Tests  2 failed | 22 passed (24)
```

Restored the mutated file from `HEAD` (`git checkout HEAD` on that one path);
`git hash-object` on the restored file matched the pre-mutation blob exactly.

**Ablation 2** — mutated `packages/fields/scripts/build-css.mjs` to drop its
`header: HEADER,` line from `buildOptions` (simulating the exact "accidental
drop" defect named in the issue), confirmed on disk, reran the suite:

```
PASS plugin-grid   > opens the emitted sheet with the banner it declares
PASS plugin-kanban > opens the emitted sheet with the banner it declares
PASS fields        > opens the emitted sheet with the banner it declares   (self-consistent — expected)
FAIL fields        > does not fall back to the shared default banner
Tests  1 failed | 23 passed (24)
```

Restored the mutated file from `HEAD` the same way; `git hash-object` matched
the pre-mutation blob exactly.

**Byte-identity of the published artifact** (objectui#6405's acceptance
gate): built all three subjects' emitted sheets against this branch's
`scripts/build-plugin-stylesheet.mjs` and, separately, against the pre-PR
version at `64d624ded` (temporarily checked out, restored by blob hash
afterward). SHA-256 of all three emitted sheets is identical before/after —
the `export` keyword and doc-comment addition change zero published bytes.

## Scope

Touches only `scripts/build-plugin-stylesheet.mjs` (the one-line `export` +
a doc-comment) and `scripts/__tests__/plugin-published-stylesheet.test.ts`.
The three `build-css.mjs` consumers are untouched in the committed diff (they
were only mutated transiently, on disk, during the two ablations above, and
restored by verified blob hash — never part of any commit).

No changeset: scripts-only diff, nothing published moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b