### PR TITLE
fix(components): give the record header title a width floor the action tail cannot take

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,18 @@
+---
+'@object-ui/components': patch
+---
+
+Stop the record header title from collapsing when the action tail is wide
+
+The `page:header` record header laid the title column and the action tail out
+in a `flex-nowrap` row. The tail is `shrink-0`, so the title column — the only
+flexible item — absorbed the entire width deficit. On a record carrying three
+labelled `record_header` actions plus the `⋯` and `⟳` chrome, a 799px viewport
+left the title column 29.5px of a 687px header and the `h1` rendered as a
+single character and an ellipsis, while the breadcrumb above it still showed
+the full record name.
+
+The title column now carries a 12rem floor and the header may wrap at `sm` and
+up, so a tail that cannot fit alongside a readable title drops to its own line
+instead of starving it. Below `sm` the header is already a column and is
+unchanged. Headers whose tail already fits keep their single-line layout.

--- a/packages/components/src/__tests__/page-header-title-width.test.tsx
+++ b/packages/components/src/__tests__/page-header-title-width.test.tsx
@@ -56,7 +56,9 @@ function renderRecordHeader(actions: any[] = WIDE_ACTIONS) {
         recordId="rec-1"
         data={{ id: 'rec-1', name: 'Specimen — Full' }}
         objectSchema={{ name: 'showcase_field_zoo', label: 'Field Zoo' }}
-        onRefresh={vi.fn()}
+        // A host `refresh` puts the `⟳` chrome in the tail, which is part of
+        // what made the measured tail 641.5px wide.
+        refresh={vi.fn()}
       >
         <PageHeader schema={{ type: 'page:header', actions }} />
       </RecordContextProvider>

--- a/packages/components/src/__tests__/page-header-title-width.test.tsx
+++ b/packages/components/src/__tests__/page-header-title-width.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Tests for the PageHeaderRenderer record header's WIDTH ARBITRATION between
+ * the title column and the trailing action row (objectui#7244).
+ *
+ * The bug: the action tail is `shrink-0` (correct — buttons must not be
+ * squeezed into unreadable slivers), and in a `flex-nowrap` row the title
+ * column was the only flexible item, so it absorbed the entire width deficit.
+ * With three labelled `record_header` actions plus `⋯` and `⟳`, the h1 was
+ * driven to ~30px and rendered as a single character + ellipsis, while the
+ * breadcrumb above it still showed the full record name.
+ *
+ * ⚠️ These assertions are CLASS-SHAPE assertions, deliberately. jsdom has no
+ * layout engine — every `getBoundingClientRect()` here is 0×0 — so a width
+ * regression CANNOT be caught by measuring in this suite. What is pinned is
+ * the structural precondition that made the collapse possible, so that
+ * removing either half of the fix turns this file red. The actual widths were
+ * measured in a real browser (Chromium, showcase `showcase_field_zoo` record,
+ * console dev server) and are recorded in the PR body:
+ *
+ *   viewport 799px, header 687px, tail 641.5px, gap-4 16px
+ *     before: h1 =  29.5px (scrollWidth 180px → rendered "S…")
+ *     after:  h1 = 180.0px (not clipped; tail wrapped to its own line)
+ *   control — Account record (edit + `⋯` + `⟳`, tail 135.6px) at the same
+ *   799px: h1 = 217.4px on ONE line, before and after alike.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { ActionProvider, RecordContextProvider } from '@object-ui/react';
+// Registers `page:header` at module scope, NOT inside a `beforeAll` — there the
+// cold transform is billed to `hookTimeout`
+// (object-ui/no-dynamic-import-in-test-hook, objectui#3010). This keeps the
+// file in the light `dom` project instead of adding it to `heavyDomTests`.
+import '../renderers';
+
+function PageHeader({ schema }: { schema: any }) {
+  const Component = ComponentRegistry.get('page:header');
+  if (!Component) throw new Error('page:header not registered');
+  // eslint-disable-next-line react-hooks/static-components -- ComponentRegistry.get returns a registered component (stable), not one created during render
+  return <Component schema={schema} />;
+}
+
+/** The Field Zoo shape from the report: three labelled record-header actions. */
+const WIDE_ACTIONS = [
+  { name: 'gallery', locations: ['record_header'], label: 'Action Param Gallery' },
+  { name: 'lookup_first', locations: ['record_header'], label: 'Lookup == first of many' },
+  { name: 'assign_me', locations: ['record_header'], label: 'Assign to me (owner_id)' },
+];
+
+function renderRecordHeader(actions: any[] = WIDE_ACTIONS) {
+  const utils = render(
+    <ActionProvider>
+      <RecordContextProvider
+        objectName="showcase_field_zoo"
+        recordId="rec-1"
+        data={{ id: 'rec-1', name: 'Specimen — Full' }}
+        objectSchema={{ name: 'showcase_field_zoo', label: 'Field Zoo' }}
+        onRefresh={vi.fn()}
+      >
+        <PageHeader schema={{ type: 'page:header', actions }} />
+      </RecordContextProvider>
+    </ActionProvider>
+  );
+  const header = utils.container.querySelector('header');
+  if (!header) throw new Error('record header did not render');
+  const h1 = header.querySelector('h1');
+  if (!h1) throw new Error('record title h1 did not render');
+  // The title column is the direct child of <header> that owns the h1.
+  const titleColumn = Array.from(header.children).find((child) =>
+    child.contains(h1)
+  ) as HTMLElement;
+  return { ...utils, header, h1, titleColumn };
+}
+
+describe('PageHeaderRenderer — record title width arbitration (#7244)', () => {
+  it('lets the header wrap so the deficit has somewhere to go', () => {
+    const { header } = renderRecordHeader();
+    // Pre-fix this was `flex flex-col sm:flex-row …` with no wrap at all: the
+    // row could not break, so the only way to fit the tail was to starve the
+    // title. Scoped to `sm:` — below 640px the header is already a column.
+    expect(header.className).toContain('sm:flex-wrap');
+    expect(header.className).toContain('sm:flex-row');
+  });
+
+  it('gives the title column a width floor it will not yield at sm and up', () => {
+    const { titleColumn } = renderRecordHeader();
+    // The heart of the fix. Without a floor, `flex-1` + `min-w-0` means
+    // "shrink me to zero before you shrink anything else".
+    expect(titleColumn.className).toMatch(/\bsm:min-w-(?!0\b)\S+/);
+    expect(titleColumn.className).toContain('flex-1');
+  });
+
+  it('keeps min-w-0 below sm so the h1 can still ellipsise', () => {
+    const { titleColumn } = renderRecordHeader();
+    // The floor must be ADDITIVE, not a replacement: `min-w-0` is what allows
+    // `truncate` to clip at all. Dropping it would make a long title overflow
+    // the header instead of ellipsising.
+    expect(titleColumn.className).toContain('min-w-0');
+  });
+
+  it('still truncates rather than wrapping the title text itself', () => {
+    const { h1 } = renderRecordHeader();
+    expect(h1.className).toContain('truncate');
+    expect(h1.textContent).toBe('Specimen — Full');
+  });
+
+  it('leaves the action tail unshrinkable', () => {
+    const { header, titleColumn } = renderRecordHeader();
+    const tail = header.lastElementChild as HTMLElement;
+    expect(tail).not.toBe(titleColumn);
+    // The tail keeping `shrink-0` is intentional and is why the title needed a
+    // floor: squeezing the buttons instead would just move the illegibility.
+    expect(tail.className).toContain('shrink-0');
+  });
+
+  it('applies the same arbitration to a light action tail', () => {
+    // The Account-record control: one labelled action. The classes are
+    // unconditional, so a header that already fits is unaffected at runtime —
+    // 192px floor + 16px gap + a ~136px tail leaves the row uncrowded.
+    const { header, titleColumn } = renderRecordHeader([
+      { name: 'edit', locations: ['record_header'], label: 'Edit' },
+    ]);
+    expect(header.className).toContain('sm:flex-wrap');
+    expect(titleColumn.className).toMatch(/\bsm:min-w-(?!0\b)\S+/);
+  });
+});

--- a/packages/components/src/renderers/layout/containers.tsx
+++ b/packages/components/src/renderers/layout/containers.tsx
@@ -1896,15 +1896,40 @@ const PageHeaderRenderer: React.FC<any> = ({ schema, className, ...props }) => {
       (objectLabel && data?.id ? `${objectLabel} ${String(data.id).slice(0, 8)}` : '') ||
       objectLabel ||
       '';
+    // Width arbitration between the title column and the action tail
+    // (objectui#7244). The tail is `shrink-0` — correct, buttons must not be
+    // squeezed into unreadable slivers — so in a `nowrap` row it takes what it
+    // needs and the title column, being the only flexible item, absorbs the
+    // entire deficit. Measured at a 799px viewport on a Field Zoo record
+    // (3 labelled record_header actions + `⋯` + `⟳`): header 687px, tail
+    // 641.5px, `gap-4` 16px, leaving the title column **29.5px** for an h1
+    // whose `scrollWidth` was 180px — the title rendered as "S…" while the
+    // breadcrumb still showed the full "Specimen — Full".
+    //
+    // Two utilities settle it, both scoped to `sm:` so the sub-640px column
+    // layout stays byte-for-byte what it was:
+    //   - `sm:min-w-48` gives the title column a 12rem floor it will not
+    //     yield, so the deficit has nowhere to go but the tail;
+    //   - `sm:flex-wrap` gives the deficit somewhere to go — the tail drops to
+    //     its own line instead of overflowing the header.
+    // The h1 still ellipsises, but now at a width you can read a name from.
+    //
+    // The floor is deliberately NOT a `min-w-0` removal: `min-w-0` is what lets
+    // `truncate` clip at all, and the chip's own inner column keeps it. This
+    // only stops the OUTER column from being driven below a readable width.
+    //
+    // Headers whose tail already fits are unaffected — an Account record
+    // (edit + `⋯` + `⟳`) needs 192 + 16 + ~180px of a 687px header, so it stays
+    // on one line exactly as before.
     return (
       <header
         className={cn(
-          'flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-4 pb-4 border-b',
+          'flex flex-col sm:flex-row sm:flex-wrap items-start sm:items-center justify-between gap-3 sm:gap-4 pb-4 border-b',
           className,
         )}
         {...designer}
       >
-        <div className="flex flex-col min-w-0 flex-1">
+        <div className="flex flex-col min-w-0 sm:min-w-48 flex-1">
           {breadcrumb && (
             <div
               className="text-xs text-muted-foreground mb-1"


### PR DESCRIPTION
Fixes #7244

## The mechanism, measured

The `page:header` record header laid its title column and action tail out in a `flex-nowrap` row. The tail is `shrink-0` — correct, buttons must not be squeezed into unreadable slivers — which left the title column, the only flexible item, absorbing the entire width deficit.

Measured in Chromium against the showcase `showcase_field_zoo` record (three labelled `record_header` actions plus the `...` and refresh chrome), console dev server proxied to a running showcase backend:

| | header | tail | gap | title column | h1 width | h1 scrollWidth | clipped |
|---|---|---|---|---|---|---|---|
| before | 687px | 641.5px | 16px | 29.5px | **29.5px** | 180px | yes — rendered `S...` |
| after | 687px | 641.5px | 16px | 687px | **180px** | 180px | no |

687 − 641.5 − 16 = 29.5, exactly the width the h1 was left with. The breadcrumb above it still showed the full "Specimen — Full", which is how the blank header gets noticed.

## The fix

The producer is `packages/components/src/renderers/layout/containers.tsx` (`PageHeaderRenderer`), **not** `RecordTitleChip.tsx`, which the issue pointed at. The chip is the victim: its own `min-w-0` + `truncate` are right for a chip handed a fair width. Two `sm:`-scoped utilities settle the arbitration in the header that owns both columns:

- `sm:min-w-48` on the title column — a 12rem floor it will not yield, so the deficit has nowhere to go but the tail;
- `sm:flex-wrap` on the header — so the deficit has somewhere to go: the tail drops to its own line rather than overflowing.

`min-w-0` is deliberately kept alongside the floor: it is what lets `truncate` clip at all. The h1 still ellipsises, now at a width you can read a name from.

## Regression readings (same session, same browser)

| case | viewport | h1 | layout |
|---|---|---|---|
| Field Zoo (3 wide actions) | 799px | 180px, not clipped | tail wraps to line 2 |
| Field Zoo | 1000px | 180px, not clipped | single line (title column 230.5px) |
| Field Zoo | 1440px | 180px, not clipped | single line |
| **Account control** (edit + more + refresh, tail 135.6px) | 799px | **217.4px**, single line | unchanged |
| Field Zoo | 375px (mobile) | 150.9px, not clipped | `flex-wrap: nowrap`, `min-width: 0px` — both utilities inert below `sm`; no document overflow |

The Account reading reproduces the 217px the issue quoted as the healthy baseline, to the decimal — light-tail headers are untouched.

## Tests

`packages/components/src/__tests__/page-header-title-width.test.tsx` (6 tests). jsdom has no layout engine, so these are **class-shape assertions by necessity**, and the file says so: they pin the structural precondition that made the collapse possible, with the browser numbers recorded in the docblock. Registration uses the module-scope `import '../renderers'` the sibling `page-header-refresh` test uses, which keeps the file in the light `dom` project instead of growing `heavyDomTests`.

**Reverse verification** (run from the committed state, per AGENTS.md): reverting `containers.tsx` to `origin/main` while keeping the test turned it **3 failed / 3 passed** — red exactly on the three assertions that name the fix, green on the three that pin pre-existing behaviour (`min-w-0`, `truncate`, tail `shrink-0`). Predicted before running. The mutation was proven on disk (marker count 2 → 0, blob hash changed) and the restore proven by blob hash equality against the HEAD blob plus an empty `git diff HEAD` — not by any exit code.

### Gate results, at commit `95f6062e8`

- `pnpm exec vitest run` on the 12-file `page-header-*` + `page-single-h1` family: **12 files / 133 tests passed**
- `pnpm exec vitest run` on the 13 files outside `components` that render `page:header` (app-shell, layout, plugin-grid, react): **13 files / 339 tests passed**
- `pnpm --filter @object-ui/components type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`): **pass**. This gate does cover test files — it caught a real error in the new test (`onRefresh` is not on `RecordContextProviderProps`), fixed in the second commit.
- `pnpm exec eslint .` in `packages/components`: **exit 0, 0 errors** over 442 files. `containers.tsx` holds 91 warnings both before and after the change (measured by linting the file in both states, with the restore verified by blob hash) — this diff adds no lint findings.
- `node scripts/check-changeset-presence.mjs` and `node scripts/check-changeset-no-major.mjs`: **pass**.
- Earlier, on the same tree apart from the test's `refresh` prop rename: full `packages/components/` suite **224 files / 2046 tests passed**.

## Declared narrowings

Two, both declared rather than silent:

1. **Verification ran UNLOCKED.** `scripts/pm/os-verify-lock.sh` could not take the shared verify lock on this host: no usable `flock` (it is util-linux; stock macOS does not ship it). The wrapper reports this itself and instructs that it be declared here. No serialization guarantee held for these runs, nor for any sibling agent in this container while they ran.
2. **The final union run is the affected surface, not the whole package.** Two attempts to re-run all of `packages/components/` at `95f6062e8` were killed by the 10-minute foreground command cap under container contention (`exit 143`). The delta between the green 2046-test run and final HEAD is only this PR's own test file's prop rename, and that file plus its whole `page-header` family plus every out-of-package `page:header` consumer were re-run green at `95f6062e8`. CI runs the full farm regardless.

Lint scope evidence: the population (442 files) is eslint's own resolution from its config rather than a guessed file list, the count comes from `--format json`, and `eslint.config.js` configures no type-aware linting (no `projectService` / `project:`), so this diff cannot move the verdict on any file it does not touch.

## Out of scope

Two sibling record headers share the same width-arbitration shape — `packages/plugin-detail/src/DetailView.tsx:919` (no wrap, no floor) and `packages/layout/src/PageHeader.tsx:236` (wraps already, still no floor). Identified statically, not measured, and each needs its own browser repro in its own package. Filed separately as #7281 rather than fixed here; that card is not addressed by this PR.

_Generated by [Claude Code](https://claude.ai/code/session_62849a16-0144-4728-8942-9f60bb3a73f1)_