### PR TITLE
fix(scripts): pin the retired-field-key tombstone registry as the designer parity gate's single source

### DIFF
--- a/scripts/__tests__/check-designer-field-key-parity.test.ts
+++ b/scripts/__tests__/check-designer-field-key-parity.test.ts
@@ -15,10 +15,13 @@ import {
   ORACLES,
   ORACLE_SPECIFIERS,
   PAYLOAD_SHAPES,
+  RETIRED_KEY_REGISTRY_FILE,
+  SITES_WITH_NO_DECLARED_SHAPE,
   analyze,
   declaredKeys,
   fieldSchemaAcceptSet,
   objectSchemaAcceptSet,
+  readRetiredKeyRegistry,
   schemaAcceptSet,
 } from '../check-designer-field-key-parity.mjs';
 
@@ -46,11 +49,67 @@ import {
 const here = path.dirname(new URL(import.meta.url).pathname);
 const repoRoot = path.resolve(here, '..', '..');
 
-/** Writes fixture sources to a throwaway dir and runs the REAL extractor over them. */
-async function withFixture<T>(files: Record<string, string>, run: (dir: string) => Promise<T>): Promise<T> {
+/** One fixture tombstone. `key`/`retiredBy` are optional so the malformed cases can omit them. */
+type FixtureTombstone = { key?: string; retiredBy?: string; sites: Record<string, boolean> };
+
+/**
+ * A synthetic registry source, in the shape `readRetiredKeyRegistry` walks
+ * (`as const satisfies …` and all). Fixture registries name sites from the REAL
+ * site vocabulary, because the gate's site-coverage check is a statement about
+ * the gate's own declared surface rather than about the fixture tree.
+ */
+function registrySource(sites: string[], tombstones: FixtureTombstone[]): string {
+  const entries = tombstones.map((t) => {
+    const columns = Object.entries(t.sites)
+      .map(([site, on]) => `      ${site}: ${on},`)
+      .join('\n');
+    return [
+      '  {',
+      t.key === undefined ? '' : `    key: '${t.key}',\n`,
+      t.retiredBy === undefined ? '' : `    retiredBy: '${t.retiredBy}',\n`,
+      '    sites: {\n',
+      `${columns}\n`,
+      '    },\n',
+      '  }',
+    ].join('');
+  });
+  return [
+    `export const RETIRED_FIELD_KEY_SITES = [\n${sites.map((s) => `  '${s}',`).join('\n')}\n] as const;\n`,
+    `\nexport const RETIRED_FIELD_KEY_TOMBSTONES = [\n${entries.join(',\n')},\n] as const satisfies readonly unknown[];\n`,
+  ].join('');
+}
+
+/**
+ * The registry every fixture tree gets unless it writes its own.
+ *
+ * The gate now REQUIRES a registry to run (objectui#6699 — an unreadable one is
+ * an ExtractionError, never a pass), so a fixture tree has to carry one. This
+ * default is deliberately inert: its one tombstone names a key no fixture shape
+ * declares, at the one site that has no payload shape, so it cannot change any
+ * verdict the other cases in this file measure.
+ */
+const DEFAULT_FIXTURE_REGISTRY = registrySource(
+  ['metadataAdminFieldsReadDoor'],
+  [{ key: 'zzzFixtureRetiredKey', retiredBy: 'objectui#0000', sites: { metadataAdminFieldsReadDoor: true } }],
+);
+
+/**
+ * Writes fixture sources to a throwaway dir and runs the REAL extractor over them.
+ *
+ * `options.registry` overrides the default registry source; `null` writes none
+ * at all, which is how the missing-registry extraction failure is probed.
+ */
+async function withFixture<T>(
+  files: Record<string, string>,
+  run: (dir: string) => Promise<T>,
+  options: { registry?: string | null } = {},
+): Promise<T> {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'designer-field-parity-'));
+  const registry = options.registry === undefined ? DEFAULT_FIXTURE_REGISTRY : options.registry;
+  const withRegistry =
+    registry === null ? files : { [RETIRED_KEY_REGISTRY_FILE]: registry, ...files };
   try {
-    for (const [name, contents] of Object.entries(files)) {
+    for (const [name, contents] of Object.entries(withRegistry)) {
       const full = path.join(dir, name);
       fs.mkdirSync(path.dirname(full), { recursive: true });
       fs.writeFileSync(full, contents);
@@ -580,6 +639,387 @@ describe('the ledger ratchets in both directions', () => {
         ledger: { placeholder: { card: 'objectui#4676', spec: null, note: 'fixture' } },
       });
       expect(staleLedger).toEqual([{ key: 'placeholder', reason: '`FieldSchema` now accepts it' }]);
+    });
+  });
+});
+
+describe('the tombstone registry is the single source for retirement — objectui#6699', () => {
+  // objectui#6527 converged three drifted per-site retired-key literals into
+  // one registry. A registry with no gate pinning it is a convention, so this
+  // block is the mechanical half: the gate READS it, and the per-site asymmetry
+  // the registry deliberately encodes survives every step of that read.
+  //
+  // The registry file and the three strip sites are NOT edited by these cases:
+  // the fixtures either synthesise a registry or copy the real one into a
+  // throwaway tree, so the ablation never touches a shipped strip site.
+
+  /** The real registry's own source, copied into fixture trees verbatim. */
+  const REAL_REGISTRY = fs.readFileSync(path.join(repoRoot, RETIRED_KEY_REGISTRY_FILE), 'utf8');
+
+  /** A fixture wire shape that IS one of the registry's strip sites. */
+  const atSite = (stripSite: string) => ({ ...WIRE_SHAPE, id: `Fixture@${stripSite}`, stripSite });
+
+  const fieldRow = { card: 'objectui#0000', oracle: 'FieldSchema', spec: null, note: 'fixture' };
+  const declaring = (key: string) =>
+    `export interface FixturePayload {\n  type?: string;\n  label?: string;\n  ${key}?: string;\n}\n`;
+
+  describe('extraction — a registry this gate cannot read is never a pass', () => {
+    it('reads every tombstone key and every site NAME off the real registry', () => {
+      // The non-vacuity floor. A walk that silently returned nothing would make
+      // every retirement rule below trivially satisfied while reading green —
+      // "nothing is retired" is exactly the drift objectui#6527 closed.
+      const registry = readRetiredKeyRegistry(repoRoot);
+      expect(registry.file).toBe(RETIRED_KEY_REGISTRY_FILE);
+      // Sites EXACTLY: the gate's coverage of them is exact by construction (a
+      // site accounted for nowhere is an ExtractionError), so this is the same
+      // statement, said where a reader will see it.
+      expect(registry.sites).toEqual([
+        'metadataAdminFieldsReadDoor',
+        'metadataServiceCarryOver',
+        'metadataFieldsPageCarryOver',
+      ]);
+      // Keys as a FLOOR rather than a census — the census is the registry's own
+      // test's to keep; what must not happen here is a key going missing.
+      const keys = registry.tombstones.map((t) => t.key);
+      expect(keys).toEqual(
+        expect.arrayContaining(['indexed', 'referenceTo', 'formula', 'isSystem', 'sortOrder']),
+      );
+      // Control terms: a walk that scooped up every string literal, or every
+      // property name, would pass the floor above and fail here.
+      expect(keys).not.toContain('label');
+      expect(keys).not.toContain('specEquivalent');
+      expect(registry.sites).not.toContain('zzzNotASite');
+      for (const t of registry.tombstones) expect(t.retiredBy).toMatch(/^objectui#\d+$/);
+    });
+
+    it('throws when the registry file is gone', async () => {
+      await withFixture(
+        { 'payload.ts': 'export interface FixturePayload {\n  label?: string;\n}\n' },
+        async (dir) => {
+          await expect(analyze(dir, { shapes: [WIRE_SHAPE], ledger: {} })).rejects.toThrow(
+            /retired-field-key registry .* does not exist/,
+          );
+        },
+        { registry: null },
+      );
+    });
+
+    it('throws when the tombstone constant is gone — an empty read is not "nothing is retired"', async () => {
+      await withFixture(
+        { 'payload.ts': 'export interface FixturePayload {\n  label?: string;\n}\n' },
+        async (dir) => {
+          await expect(analyze(dir, { shapes: [WIRE_SHAPE], ledger: {} })).rejects.toThrow(
+            /`RETIRED_FIELD_KEY_TOMBSTONES` is not an array literal/,
+          );
+        },
+        { registry: "export const RETIRED_FIELD_KEY_SITES = ['metadataAdminFieldsReadDoor'] as const;\n" },
+      );
+    });
+
+    it('throws on a tombstone with no `key` — a nameless tombstone retires nothing', async () => {
+      await withFixture(
+        { 'payload.ts': 'export interface FixturePayload {\n  label?: string;\n}\n' },
+        async (dir) => {
+          await expect(analyze(dir, { shapes: [WIRE_SHAPE], ledger: {} })).rejects.toThrow(
+            /declares no string `key`/,
+          );
+        },
+        {
+          registry: registrySource(
+            ['metadataAdminFieldsReadDoor'],
+            [{ retiredBy: 'objectui#0000', sites: { metadataAdminFieldsReadDoor: true } }],
+          ),
+        },
+      );
+    });
+
+    it('throws when a `sites` record names a site the registry does not declare', async () => {
+      // The two halves of the registry drifting apart. Reading past it would
+      // evaluate a retirement against a site that does not exist — a column
+      // that can never be `true`, i.e. a silently disabled rule.
+      await withFixture(
+        { 'payload.ts': 'export interface FixturePayload {\n  label?: string;\n}\n' },
+        async (dir) => {
+          await expect(analyze(dir, { shapes: [WIRE_SHAPE], ledger: {} })).rejects.toThrow(
+            /names the site `zzzGhostSite`, which `RETIRED_FIELD_KEY_SITES` does not declare/,
+          );
+        },
+        {
+          registry: registrySource(
+            ['metadataAdminFieldsReadDoor'],
+            [
+              {
+                key: 'zzzGhostSited',
+                retiredBy: 'objectui#0000',
+                sites: { metadataAdminFieldsReadDoor: true, zzzGhostSite: true },
+              },
+            ],
+          ),
+        },
+      );
+    });
+
+    it('⭐ throws when the registry grows a site this gate accounts for nowhere', async () => {
+      // This is what makes the registry the single SOURCE rather than a single
+      // copy: it cannot gain a strip site while the gate goes on judging only
+      // the sites it already knew, in silence.
+      await withFixture(
+        { 'payload.ts': 'export interface FixturePayload {\n  label?: string;\n}\n' },
+        async (dir) => {
+          await expect(analyze(dir, { shapes: [WIRE_SHAPE], ledger: {} })).rejects.toThrow(
+            /declares strip site\(s\) `zzzUnadjudicatedSite` this gate accounts for nowhere/,
+          );
+        },
+        {
+          registry: registrySource(
+            ['metadataServiceCarryOver', 'zzzUnadjudicatedSite'],
+            [
+              {
+                key: 'zzzSomeKey',
+                retiredBy: 'objectui#0000',
+                sites: { metadataServiceCarryOver: true, zzzUnadjudicatedSite: true },
+              },
+            ],
+          ),
+        },
+      );
+    });
+
+    it('throws when a shape names a strip site the registry does not declare', async () => {
+      // The other direction of the same link: a renamed site must not leave a
+      // shape quietly enforcing nothing.
+      await withFixture(
+        { 'payload.ts': declaring('indexed') },
+        async (dir) => {
+          await expect(
+            analyze(dir, { shapes: [atSite('metadataFieldsPageCarryOver')], ledger: {} }),
+          ).rejects.toThrow(/names the strip site `metadataFieldsPageCarryOver`, which .* does not declare/);
+        },
+        {
+          registry: registrySource(
+            ['metadataServiceCarryOver'],
+            [{ key: 'indexed', retiredBy: 'objectui#4644', sites: { metadataServiceCarryOver: true } }],
+          ),
+        },
+      );
+    });
+  });
+
+  describe('a retirement is not waivable at a site that strips the key', () => {
+    it('⭐ refuses the ledger row, and cites the registry entry instead', async () => {
+      // The rule with teeth, measured against the REAL registry: `formula` is
+      // retired (objectui#6043) and `metadataServiceCarryOver` strips it, so a
+      // KNOWN_UNPARSEABLE_KEYS row cannot quiet a re-declaration there. Its
+      // resolution already happened, on the card the tombstone names; a fresh
+      // ledger row would re-open a settled retirement in silence.
+      await withFixture(
+        { [RETIRED_KEY_REGISTRY_FILE]: REAL_REGISTRY, 'payload.ts': declaring('formula') },
+        async (dir) => {
+          const { violations, staleLedger } = await analyze(dir, {
+            shapes: [atSite('metadataServiceCarryOver')],
+            ledger: { formula: fieldRow },
+          });
+          expect(violations.map((v) => `${v.key}:${v.waiverRefused}`)).toEqual(['formula:true']);
+          expect(violations[0].retired!.retiredBy).toBe('objectui#6043');
+          expect(violations[0].retired!.inForce).toBe(true);
+          // ...and the row itself is reported, with the registry's reason
+          // rather than the generic "unreachable" one.
+          expect(staleLedger.map((s) => s.key)).toEqual(['formula']);
+          expect(staleLedger[0].reason).toContain('objectui#6043');
+          expect(staleLedger[0].reason).toContain('a retirement cannot be waived by a ledger row');
+        },
+      );
+    });
+
+    it('the citation carries the per-site columns VERBATIM, never flattened', async () => {
+      // `formula`'s read-door column is `false` — RULED, objectui#6526 option B
+      // (`ObjectFieldInspector` seeds its CEL editor from
+      // `def.expression ?? def.formula`, and stripping on read destroys the
+      // authored text). The gate reproduces that column on the NOT-stripped
+      // side; it never inverts it into a claim that the read door strips it.
+      await withFixture(
+        { [RETIRED_KEY_REGISTRY_FILE]: REAL_REGISTRY, 'payload.ts': declaring('formula') },
+        async (dir) => {
+          const { violations } = await analyze(dir, {
+            shapes: [atSite('metadataServiceCarryOver')],
+            ledger: {},
+          });
+          expect(violations[0].retired!.strippedAt).toEqual([
+            'metadataServiceCarryOver',
+            'metadataFieldsPageCarryOver',
+          ]);
+          expect(violations[0].retired!.notStrippedAt).toEqual(['metadataAdminFieldsReadDoor']);
+        },
+      );
+    });
+
+    it('⭐ the SAME key at a site whose column is `false` stays an ordinary, ledgerable violation', async () => {
+      // The anti-flattening proof, on the real registry: `sortOrder` is `true`
+      // at `metadataServiceCarryOver` and `false` at
+      // `metadataFieldsPageCarryOver` (objectui#6045's recorded verdict — the
+      // registry's one defensive, single-site entry). One key, one ledger row,
+      // two sites, two different verdicts. A gate holding one flat "retired"
+      // set could not produce this pair.
+      const files = { [RETIRED_KEY_REGISTRY_FILE]: REAL_REGISTRY, 'payload.ts': declaring('sortOrder') };
+
+      await withFixture(files, async (dir) => {
+        const strips = await analyze(dir, {
+          shapes: [atSite('metadataServiceCarryOver')],
+          ledger: { sortOrder: fieldRow },
+        });
+        expect(strips.violations.map((v) => `${v.key}:${v.waiverRefused}`)).toEqual(['sortOrder:true']);
+        expect(strips.staleLedger.map((s) => s.key)).toEqual(['sortOrder']);
+      });
+
+      await withFixture(files, async (dir) => {
+        const doesNotStrip = await analyze(dir, {
+          shapes: [atSite('metadataFieldsPageCarryOver')],
+          ledger: { sortOrder: fieldRow },
+        });
+        // The registry makes no claim to enforce the retirement at THIS site,
+        // so the ordinary ledger path applies and the row is honoured.
+        expect(doesNotStrip.violations).toEqual([]);
+        expect(doesNotStrip.staleLedger).toEqual([]);
+      });
+    });
+
+    it('still cites a tombstone at a site that does not strip it, marked not-in-force', async () => {
+      // Not silence: the reader is told the key is retired and which sites
+      // strip it, so an unledgered re-declaration is adjudicated with the
+      // registry in hand rather than from scratch.
+      await withFixture(
+        { [RETIRED_KEY_REGISTRY_FILE]: REAL_REGISTRY, 'payload.ts': declaring('sortOrder') },
+        async (dir) => {
+          const { violations } = await analyze(dir, {
+            shapes: [atSite('metadataFieldsPageCarryOver')],
+            ledger: {},
+          });
+          expect(violations.map((v) => v.key)).toEqual(['sortOrder']);
+          expect(violations[0].retired!.retiredBy).toBe('objectui#6045');
+          expect(violations[0].retired!.inForce).toBe(false);
+          expect(violations[0].waiverRefused).toBe(false);
+        },
+      );
+    });
+
+    it('a shape that is no strip site at all carries the citation but never the ban', async () => {
+      await withFixture(
+        { [RETIRED_KEY_REGISTRY_FILE]: REAL_REGISTRY, 'payload.ts': declaring('indexed') },
+        async (dir) => {
+          const { violations } = await analyze(dir, {
+            shapes: [WIRE_SHAPE],
+            ledger: { indexed: fieldRow },
+          });
+          expect(violations).toEqual([]);
+        },
+      );
+    });
+
+    it('⭐ the FIELD registry never reaches the OBJECT oracle — same spelling, two cards', async () => {
+      // `sortOrder` is refused at BOTH levels by two different schemas and is
+      // two different cards (objectui#6045 field-level, objectui#6223
+      // object-level, still the Object Manager's display order). A registry of
+      // FIELD tombstones that leaked across the oracle boundary would refuse
+      // the object-level card's own ledger row.
+      const OBJECT_AT_SITE = {
+        id: 'FixtureObjectPayload',
+        file: 'object-payload.ts',
+        interface: 'FixtureObjectPayload',
+        schema: 'ObjectSchema' as const,
+        reach: 'wire' as const,
+        writer: 'fixture',
+        stripSite: 'metadataServiceCarryOver',
+      };
+      await withFixture(
+        {
+          [RETIRED_KEY_REGISTRY_FILE]: REAL_REGISTRY,
+          'object-payload.ts':
+            'export interface FixtureObjectPayload {\n  name?: string;\n  label?: string;\n  sortOrder?: number;\n}\n',
+        },
+        async (dir) => {
+          const ledgered = await analyze(dir, {
+            shapes: [OBJECT_AT_SITE],
+            ledger: {
+              sortOrder: { card: 'objectui#6223', oracle: 'ObjectSchema', spec: null, note: 'fixture' },
+            },
+          });
+          expect(ledgered.violations).toEqual([]);
+          expect(ledgered.staleLedger).toEqual([]);
+          const bare = await analyze(dir, { shapes: [OBJECT_AT_SITE], ledger: {} });
+          expect(bare.violations.map((v) => `${v.key}:${v.oracle}`)).toEqual(['sortOrder:ObjectSchema']);
+          expect(bare.violations[0].retired).toBeNull();
+        },
+      );
+    });
+  });
+
+  describe('the per-site map, on the real tree', () => {
+    it('accounts for every registry site exactly once — shaped or declared shapeless', async () => {
+      const registry = readRetiredKeyRegistry(repoRoot);
+      const shaped = PAYLOAD_SHAPES.map((s) => s.stripSite).filter(Boolean);
+      expect(shaped).toEqual(['metadataServiceCarryOver', 'metadataFieldsPageCarryOver']);
+      expect(Object.keys(SITES_WITH_NO_DECLARED_SHAPE)).toEqual(['metadataAdminFieldsReadDoor']);
+      expect([...shaped, ...Object.keys(SITES_WITH_NO_DECLARED_SHAPE)].sort()).toEqual(
+        [...registry.sites].sort(),
+      );
+      // Every shape answers the column — an omitted one would opt out of the
+      // retirement rule in silence, the way an unnamed oracle used to fall back
+      // to the field schema (objectui#6223).
+      for (const shape of PAYLOAD_SHAPES) {
+        expect(Object.prototype.hasOwnProperty.call(shape, 'stripSite'), `${shape.id} omits stripSite`).toBe(
+          true,
+        );
+      }
+    });
+
+    it('maps each site onto the file the registry says it is — a crossed map applies the wrong column', () => {
+      // The paths come from the registry's own site docblock. Swapping the two
+      // `stripSite` values would leave every other assertion here green while
+      // each site was judged by the other's columns.
+      const siteFiles: Record<string, string> = {
+        metadataServiceCarryOver: 'packages/app-shell/src/services/MetadataService.ts',
+        metadataFieldsPageCarryOver: 'packages/plugin-designer/src/MetadataFieldsPage.tsx',
+      };
+      for (const shape of PAYLOAD_SHAPES.filter((s) => s.stripSite)) {
+        expect(shape.file, `${shape.id} is mapped to the wrong site`).toBe(siteFiles[shape.stripSite!]);
+      }
+    });
+
+    it('⭐ judges NOTHING at the read door — objectui#6526 option B, kept structural', async () => {
+      // The ruling: `formula` must NOT be stripped at the read door, because
+      // `ObjectFieldInspector` seeds its CEL editor from
+      // `def.expression ?? def.formula` and the first edit migrates it. The
+      // read door also declares no payload shape at all (coverage note 3), so
+      // this gate has nothing there to judge — and that is recorded rather than
+      // left to chance. If a shape ever names the read door as its strip site,
+      // this is what says so before the gate starts asserting strips there.
+      expect(PAYLOAD_SHAPES.map((s) => s.stripSite)).not.toContain('metadataAdminFieldsReadDoor');
+      expect(SITES_WITH_NO_DECLARED_SHAPE.metadataAdminFieldsReadDoor).toContain(
+        'no statically declared payload shape',
+      );
+      const { violations, uiOnly } = await analyze(repoRoot);
+      for (const entry of [...violations, ...uiOnly]) {
+        expect(entry.retired?.site ?? null, `${entry.key} judged at the read door`).not.toBe(
+          'metadataAdminFieldsReadDoor',
+        );
+      }
+    });
+
+    it('annotates the retired keys still declared on the UI model, and stays green', async () => {
+      // `isSystem` (objectui#6044) and `referenceTo` (objectui#6041) are
+      // tombstoned keys the designer's in-memory model still declares; the
+      // converters strip them, so they are `uiOnly` and NOT violations. The
+      // citation makes that visible in the run log instead of leaving two
+      // retired spellings looking like ordinary UI keys.
+      const { uiOnly, violations } = await analyze(repoRoot);
+      const cited = uiOnly.filter((u) => u.retired).map((u) => `${u.key}:${u.retired!.retiredBy}`);
+      expect(cited).toEqual(
+        expect.arrayContaining(['isSystem:objectui#6044', 'referenceTo:objectui#6041']),
+      );
+      // The object-level `sortOrder` on `ObjectDefinition` is a DIFFERENT card
+      // and must not be annotated with the field registry's tombstone.
+      expect(uiOnly.find((u) => u.key === 'sortOrder' && u.oracle === 'ObjectSchema')?.retired).toBeNull();
+      expect(violations).toEqual([]);
     });
   });
 });

--- a/scripts/check-designer-field-key-parity.mjs
+++ b/scripts/check-designer-field-key-parity.mjs
@@ -160,6 +160,73 @@
  *   - a ledger entry whose key is no longer refused, or no longer declared, is
  *     ALSO red, so a fixed key cannot leave a stale entry behind that would
  *     silently re-admit the same spelling later.
+ *
+ * ── The tombstone registry is this gate's single source for RETIREMENT ──────
+ * objectui#6699. The three drifted per-site retired-key literals converged into
+ * one registry (objectui#6527, maintainer option B):
+ * {@link RETIRED_KEY_REGISTRY_FILE}. A registry with no gate pinning it is a
+ * convention, and conventions drift — the three literals it replaced are the
+ * proof, each written AFTER an instance was found in production.
+ *
+ * So the retirement facts this gate uses are READ FROM THAT FILE, never copied
+ * here. It is read from the TRACKED SOURCE with the same TypeScript AST walk
+ * {@link PAYLOAD_SHAPES} are read with — deliberately NOT through the built
+ * `@object-ui/types/internal/retired-field-keys` subpath, so this gate gains no
+ * build precondition and keeps running on a cold cache. Extraction failure is
+ * an {@link ExtractionError}, never a pass: a missing registry, a missing
+ * constant, a tombstone with no `key`, or a `sites` record naming a site the
+ * registry does not declare all stop the run.
+ *
+ * WHAT IS DERIVED — one rule, and it is the one the ledger could not state:
+ *
+ *   A RETIREMENT IS NOT WAIVABLE AT A SITE THAT STRIPS THE KEY. Where a wire
+ *   shape IS one of the registry's strip sites (`stripSite` below) and the
+ *   tombstone marks that site `true`, a {@link KNOWN_UNPARSEABLE_KEYS} row
+ *   cannot quiet the key. The ledger is for keys whose resolution is still
+ *   OPEN; a tombstoned key's resolution already happened, on the card the
+ *   tombstone names. Re-declaring one and filing a fresh ledger row would
+ *   re-open a settled retirement in silence — the ledger becoming the hiding
+ *   place the ratchet note says it must never be. Such a violation is reported
+ *   with the registry entry (key, retiring card, per-site columns) INSTEAD of
+ *   the "file a card and record it" invitation the other violations carry.
+ *
+ * THE PER-SITE ASYMMETRY SURVIVES AS DATA, and that is load-bearing rather than
+ * tidy. The registry is deliberately not nested, so this gate must never
+ * flatten it into one "retired everywhere" key set:
+ *
+ *   - the rule above is evaluated PER (key, site) — the same key with a `false`
+ *     column at the shape's own site stays an ordinary, ledgerable violation,
+ *     because at that site the registry makes no claim to enforce. Measured on
+ *     the registry as it stands: `sortOrder` is `true` at
+ *     `metadataServiceCarryOver` and `false` at `metadataFieldsPageCarryOver`,
+ *     one key with two verdicts.
+ *   - `formula`'s READ-DOOR column is `false` — RULED, objectui#6526 option B:
+ *     `ObjectFieldInspector` seeds its CEL editor from
+ *     `def.expression ?? def.formula` and the first edit migrates it, so
+ *     stripping on read destroys authored expression text. This gate never
+ *     asserts, and never implies, that `formula` is stripped there: the read
+ *     door has no statically declared payload shape at all (coverage note 3),
+ *     so it is declared in {@link SITES_WITH_NO_DECLARED_SHAPE} and NOTHING is
+ *     judged against it. Its column is reproduced verbatim in the citation, on
+ *     the NOT-stripped side, which is the registry's own word for it.
+ *   - a registry site accounted for NOWHERE — named by no shape and not
+ *     declared shapeless — is an {@link ExtractionError}. That is what makes
+ *     the registry the single SOURCE rather than a single copy: it cannot grow
+ *     a site while this gate goes on judging the old three in silence.
+ *
+ * COLUMNS CONSUMED: `key`, `retiredBy`, `sites`. Columns deliberately NOT read
+ * — `specEquivalent` is documentation and never an instruction to rename
+ * (objectui#6043 refused exactly that rename for `formula`), and `defensive`
+ * records how strong the EVIDENCE for a strip is, which is the registry's
+ * verdict to keep and no input to a key-name parity comparison. Neither is
+ * extracted, so neither can quietly acquire a meaning here.
+ *
+ * The registry's OWN contract — every tombstoned key being refused by the
+ * installed `FieldSchema`, `formula`'s read-door column, `sortOrder`'s
+ * single-site defensive verdict, per-site list parity — is pinned by
+ * `packages/types/src/__tests__/retired-field-key-tombstones.test.ts` and is
+ * deliberately NOT duplicated here. A second copy of an assertion is a second
+ * thing to keep honest, which is the defect this whole family closes.
  */
 
 import ts from "typescript";
@@ -228,6 +295,13 @@ const parse = (root, rel) =>
  *          visible, but not a violation. The moment one of them is added to a
  *          `wire` shape the `wire` scan catches it, so the classification is
  *          computed on every run rather than asserted once.
+ *
+ * `stripSite` is the retired-key registry's strip site this shape's FILE is, or
+ * `null`. It is what lets the retirement rule be evaluated per (key, site)
+ * instead of over a flattened key set — see the header. Every entry answers it
+ * explicitly, no column left implicit: a shape that simply omitted it would opt
+ * out of that rule in silence, which is the shape of every defect in this file's
+ * history.
  */
 export const PAYLOAD_SHAPES = [
   {
@@ -239,6 +313,10 @@ export const PAYLOAD_SHAPES = [
     // `toFieldPayload` builds it; `saveFields` PUTs `fields.map(toFieldPayload)`
     // and `saveObject` PUTs it through `toObjectPayload`.
     writer: "MetadataService.saveFields / saveObject",
+    // This file is ALSO the registry's `metadataServiceCarryOver` strip site
+    // (`carryOver`, objectui#6488), which is why the retirement rule can be
+    // evaluated per site here rather than over a flattened key set.
+    stripSite: "metadataServiceCarryOver",
   },
   {
     id: "ServerFieldSchema",
@@ -249,6 +327,8 @@ export const PAYLOAD_SHAPES = [
     // `fromDesignerField` builds it; `MetadataFieldsPage` PUTs the assembled
     // `fields` map. Carries an index signature — see coverage note 2.
     writer: "MetadataFieldsPage.handleFieldsChange",
+    // ALSO the registry's `metadataFieldsPageCarryOver` strip site.
+    stripSite: "metadataFieldsPageCarryOver",
   },
   {
     id: "DesignerFieldDefinition",
@@ -257,6 +337,7 @@ export const PAYLOAD_SHAPES = [
     schema: "FieldSchema",
     reach: "ui",
     writer: "FieldDesigner (in-memory model)",
+    stripSite: null,
   },
   {
     id: "ObjectMetadataPayload",
@@ -267,6 +348,7 @@ export const PAYLOAD_SHAPES = [
     // `toObjectPayload` builds it; `saveObject` PUTs it whole to
     // `PUT /api/v1/meta/object/:name`, fields nested inside.
     writer: "MetadataService.saveObject",
+    stripSite: null,
   },
   {
     id: "ServerObjectSchema",
@@ -279,6 +361,7 @@ export const PAYLOAD_SHAPES = [
     // note 2 applies here too, and with more force: this shape is BUILT by
     // spreading the server's own document.
     writer: "MetadataObjectsPage.handleObjectsChange",
+    stripSite: null,
   },
   {
     id: "ObjectDefinition",
@@ -287,6 +370,7 @@ export const PAYLOAD_SHAPES = [
     schema: "ObjectSchema",
     reach: "ui",
     writer: "ObjectManager (in-memory model)",
+    stripSite: null,
   },
   {
     id: "PermissionSetDraft",
@@ -302,6 +386,7 @@ export const PAYLOAD_SHAPES = [
     // contract rather than an oversight: a key this editor does not model is
     // carried through save untouched.
     writer: "PermissionMatrixEditor.doSave",
+    stripSite: null,
   },
   {
     id: "ObjectPerm",
@@ -314,6 +399,7 @@ export const PAYLOAD_SHAPES = [
     // again, which is why it needs its own oracle rather than riding on the
     // record's.
     writer: "PermissionMatrixEditor.doSave (objects[name] row)",
+    stripSite: null,
   },
 ];
 
@@ -384,6 +470,204 @@ export const KNOWN_UNPARSEABLE_KEYS = {
   // spelling is unrelated to `ObjectDefinition.isSystem` / the UI-only keys the
   // gate still reports below.
 };
+
+/**
+ * The retired-field-key tombstone registry — this gate's single source for
+ * WHICH KEYS ARE RETIRED and WHERE (objectui#6527, pinned here by
+ * objectui#6699). See the header section for what is derived from it.
+ *
+ * The TRACKED SOURCE, not the built `@object-ui/types/internal/…` subpath: a
+ * gate that needed `packages/types` built first would be unrunnable on a cold
+ * cache, and this file already reads every other input off the AST.
+ */
+export const RETIRED_KEY_REGISTRY_FILE = "packages/types/src/internal/retired-field-keys.ts";
+
+/**
+ * Registry strip sites that deliberately have NO statically declared payload
+ * shape, with the reason — the value is printed in the run log.
+ *
+ * `metadataAdminFieldsReadDoor` is `object-fields-io.ts`'s `readFields`, which
+ * carries raw `Record<string, unknown>` field defs and declares no interface at
+ * all: coverage note 3, the hole this gate states rather than hides (its
+ * round-trip is pinned executably by `object-fields-io.field-schema-parity`
+ * and `object-fields-io.retiredKeys`). So this gate judges NOTHING at that
+ * site — which is also what keeps it clear of objectui#6526 option B: the read
+ * door must NOT strip `formula`, and a gate with no assertion there cannot
+ * drift into implying that it does.
+ *
+ * A registry site that is neither named by a shape's `stripSite` nor listed
+ * here is an {@link ExtractionError}. Being shapeless is a recorded decision,
+ * never a default.
+ */
+export const SITES_WITH_NO_DECLARED_SHAPE = {
+  metadataAdminFieldsReadDoor:
+    "no statically declared payload shape (coverage note 3) — nothing is judged at this site",
+};
+
+/** Peel `as const`, `satisfies T` and parentheses off an initializer. */
+const unwrapExpression = (node) => {
+  let current = node;
+  while (
+    current &&
+    (ts.isAsExpression(current) ||
+      ts.isSatisfiesExpression(current) ||
+      ts.isParenthesizedExpression(current))
+  ) {
+    current = current.expression;
+  }
+  return current;
+};
+
+/** The initializer of `const <name> = …`, found anywhere in the file. */
+const constInitializer = (sf, name) => {
+  let found = null;
+  const visit = (node) => {
+    if (ts.isVariableStatement(node)) {
+      for (const d of node.declarationList.declarations) {
+        if (ts.isIdentifier(d.name) && d.name.text === name && d.initializer) {
+          found = unwrapExpression(d.initializer);
+        }
+      }
+    }
+    if (!found) ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+};
+
+/** The declared name of an object-literal property, or null. */
+const propertyName = (prop) =>
+  prop.name && (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) ? prop.name.text : null;
+
+/**
+ * Read the tombstone registry off {@link RETIRED_KEY_REGISTRY_FILE}'s AST.
+ *
+ * Returns `{ file, sites, tombstones }` where each tombstone is
+ * `{ key, retiredBy, sites: Record<site, boolean> }` — the three columns this
+ * gate consumes. `specEquivalent` and `defensive` are deliberately not read;
+ * see the header.
+ *
+ * Every failure here is an {@link ExtractionError}. A registry this gate cannot
+ * read is the confident-green case: "no tombstones" would read as "nothing is
+ * retired", which is precisely the drift objectui#6527 closed.
+ *
+ * The return type is spelled out because `tsconfig.scripts.json` INFERS this
+ * file's types for the pin tests (`allowJs`, `checkJs: false`): the walk's
+ * `ts.Node` narrowing is invisible to that inference, so without this the tests
+ * would consume an `any` and their assertions would stop being checked.
+ *
+ * @param {string} [root]
+ * @param {string} [rel]
+ * @returns {{
+ *   file: string,
+ *   sites: string[],
+ *   tombstones: { key: string, retiredBy: string, sites: Record<string, boolean> }[],
+ * }}
+ */
+export function readRetiredKeyRegistry(root = REPO_ROOT, rel = RETIRED_KEY_REGISTRY_FILE) {
+  if (!existsSync(resolve(root, rel))) {
+    fail(
+      `the retired-field-key registry ${rel} does not exist — it moved, or was deleted.\n` +
+        "    Re-point this gate at it (objectui#6527 made it the single source for retirement);\n" +
+        "    an unreadable registry is never a pass, and a copied key list here is the drift it closed."
+    );
+  }
+  const sf = parse(root, rel);
+
+  const sitesNode = constInitializer(sf, "RETIRED_FIELD_KEY_SITES");
+  if (!sitesNode || !ts.isArrayLiteralExpression(sitesNode)) {
+    fail(
+      `\`RETIRED_FIELD_KEY_SITES\` is not an array literal in ${rel} — the registry's shape changed.\n` +
+        "    Fix the walk; do NOT hardcode the site list here."
+    );
+  }
+  const sites = sitesNode.elements.map((el) => {
+    if (!ts.isStringLiteral(el)) {
+      fail(`\`RETIRED_FIELD_KEY_SITES\` in ${rel} holds a non-string element — the walk cannot read it.`);
+    }
+    return el.text;
+  });
+  if (sites.length === 0) {
+    fail(`\`RETIRED_FIELD_KEY_SITES\` in ${rel} is empty — a registry with no sites cannot be checked against.`);
+  }
+
+  const tombstonesNode = constInitializer(sf, "RETIRED_FIELD_KEY_TOMBSTONES");
+  if (!tombstonesNode || !ts.isArrayLiteralExpression(tombstonesNode)) {
+    fail(
+      `\`RETIRED_FIELD_KEY_TOMBSTONES\` is not an array literal in ${rel} — the registry's shape changed.\n` +
+        "    Fix the walk; an empty read would report every retired key as un-retired."
+    );
+  }
+  if (tombstonesNode.elements.length === 0) {
+    fail(
+      `\`RETIRED_FIELD_KEY_TOMBSTONES\` in ${rel} is empty — read as "nothing is retired", which is the\n` +
+        "    silent-green case this gate exists to prevent. If the last tombstone really was retired,\n" +
+        "    that is a decision to record, not to infer from an empty array."
+    );
+  }
+
+  const tombstones = tombstonesNode.elements.map((element, index) => {
+    const obj = unwrapExpression(element);
+    if (!obj || !ts.isObjectLiteralExpression(obj)) {
+      fail(`tombstone #${index + 1} in ${rel} is not an object literal — the walk cannot read it.`);
+    }
+    const props = obj.properties.filter((p) => ts.isPropertyAssignment(p));
+    const valueOf = (name) => props.find((p) => propertyName(p) === name)?.initializer ?? null;
+
+    const keyNode = valueOf("key");
+    if (!keyNode || !ts.isStringLiteral(keyNode)) {
+      fail(
+        `tombstone #${index + 1} in ${rel} declares no string \`key\` — a nameless tombstone retires nothing,\n` +
+          "    and reading past it would drop a retirement this gate is supposed to hold."
+      );
+    }
+    const key = keyNode.text;
+
+    const retiredByNode = valueOf("retiredBy");
+    if (!retiredByNode || !ts.isStringLiteral(retiredByNode)) {
+      fail(
+        `the \`${key}\` tombstone in ${rel} declares no string \`retiredBy\` — the citation this gate prints\n` +
+          "    instead of inviting a ledger row would name no card, which is worse than no citation."
+      );
+    }
+
+    const sitesValue = valueOf("sites");
+    if (!sitesValue || !ts.isObjectLiteralExpression(sitesValue)) {
+      fail(
+        `the \`${key}\` tombstone in ${rel} declares no \`sites\` record — per-site applicability is the\n` +
+          "    registry's load-bearing half (objectui#6526 / objectui#6527); it must never be inferred."
+      );
+    }
+    /** @type {Record<string, boolean>} */
+    const siteFlags = {};
+    for (const prop of sitesValue.properties) {
+      if (!ts.isPropertyAssignment(prop)) {
+        fail(`the \`${key}\` tombstone's \`sites\` record in ${rel} holds an entry the walk cannot read.`);
+      }
+      const site = propertyName(prop);
+      if (site === null) {
+        fail(`the \`${key}\` tombstone's \`sites\` record in ${rel} holds a computed key — it cannot be read statically.`);
+      }
+      if (!sites.includes(site)) {
+        fail(
+          `the \`${key}\` tombstone in ${rel} names the site \`${site}\`, which \`RETIRED_FIELD_KEY_SITES\` does not declare.\n` +
+            "    One of the two is stale; reading past it would evaluate the retirement against a site that does not exist."
+        );
+      }
+      const value = prop.initializer;
+      if (value.kind !== ts.SyntaxKind.TrueKeyword && value.kind !== ts.SyntaxKind.FalseKeyword) {
+        fail(
+          `the \`${key}\` tombstone's \`${site}\` column in ${rel} is not a boolean literal.\n` +
+            "    A column this gate cannot read is a column it must not guess at."
+        );
+      }
+      siteFlags[site] = value.kind === ts.SyntaxKind.TrueKeyword;
+    }
+    return { key, retiredBy: retiredByNode.text, sites: siteFlags };
+  });
+
+  return { file: rel, sites, tombstones };
+}
 
 /**
  * Oracle name -> the PUBLISHED SUBPATH its schema is exported from.
@@ -546,10 +830,19 @@ const oracleOf = (shape) => shape.schema ?? "FieldSchema";
  * Compare every declared payload key against the accept set OF THE ORACLE THAT
  * JUDGES ITS SHAPE.
  *
- * Returns `{ accept, accepts, origin, shapes, violations, uiOnly, staleLedger }`.
+ * Returns
+ * `{ accept, accepts, origin, registry, shapes, violations, uiOnly, staleLedger }`.
  * `violations` is what makes the gate red; `uiOnly` and `staleLedger` are
  * reported too — `staleLedger` is red as well (see the header's
  * both-directions ratchet).
+ *
+ * `registry` is the tombstone registry read from `root`
+ * ({@link readRetiredKeyRegistry}). A violation or `uiOnly` entry whose key is
+ * a FIELD tombstone carries a `retired` citation, and a violation the registry
+ * retires AT THAT SHAPE'S OWN STRIP SITE additionally carries
+ * `waiverRefused: true` — the ledger row that would have quieted it is refused
+ * and reported as stale. See the header for why the rule is per (key, site) and
+ * never over a flattened key set.
  *
  * Reach is resolved WITHIN an oracle, never across one. A key is `uiOnly` when
  * no wire shape *judged by the same schema* declares it: `group` is a legal
@@ -577,6 +870,61 @@ export async function analyze(root = REPO_ROOT, options = {}) {
     }
   }
 
+  const registry = readRetiredKeyRegistry(root);
+
+  // The gate's link to the registry, checked in BOTH directions before a
+  // single key is compared — a link that has silently come apart would leave
+  // the retirement rule applying to nothing while the run still reads green.
+  for (const shape of shapes) {
+    if (shape.stripSite && !registry.sites.includes(shape.stripSite)) {
+      fail(
+        `\`${shape.id}\` names the strip site \`${shape.stripSite}\`, which ${registry.file} does not declare.\n` +
+          "    The site was renamed or removed; re-point the shape at the registry's own name. Reading past\n" +
+          "    it would silently stop enforcing that site's retirements."
+      );
+    }
+  }
+  // Scoped to this gate's OWN declared surface, never to `options.shapes`: it
+  // is a statement about which sites this gate has adjudicated, which a fixture
+  // tree cannot answer.
+  const shapedSites = new Set(PAYLOAD_SHAPES.map((s) => s.stripSite).filter(Boolean));
+  const unaccounted = registry.sites.filter(
+    (site) => !shapedSites.has(site) && !Object.prototype.hasOwnProperty.call(SITES_WITH_NO_DECLARED_SHAPE, site)
+  );
+  if (unaccounted.length > 0) {
+    fail(
+      `${registry.file} declares strip site(s) \`${unaccounted.join("`, `")}\` this gate accounts for nowhere.\n` +
+        "    Either a payload shape at that site names it via `stripSite`, or it is recorded in\n" +
+        "    SITES_WITH_NO_DECLARED_SHAPE with the reason. Silence would let the registry grow a site\n" +
+        "    while this gate went on judging only the old ones."
+    );
+  }
+
+  /** key -> its FIELD tombstone. The registry is a field-key registry. */
+  const tombstones = new Map(registry.tombstones.map((t) => [t.key, t]));
+
+  /**
+   * The registry's word on `key` AT `shape`, or null.
+   *
+   * `inForce` is the per-site half: true only where the shape IS a strip site
+   * and the tombstone's column for THAT site is `true`. A flattened "is
+   * retired anywhere" test would decide `sortOrder` at `MetadataFieldsPage`
+   * and `formula` at the read door in the direction the registry refused.
+   */
+  const retirementAt = (shape, key) => {
+    if (oracleOf(shape) !== "FieldSchema") return null;
+    const tombstone = tombstones.get(key);
+    if (!tombstone) return null;
+    const site = shape.stripSite ?? null;
+    return {
+      retiredBy: tombstone.retiredBy,
+      site,
+      inForce: site !== null && tombstone.sites[site] === true,
+      strippedAt: registry.sites.filter((s) => tombstone.sites[s] === true),
+      notStrippedAt: registry.sites.filter((s) => tombstone.sites[s] !== true),
+    };
+  };
+
   const read = shapes.map((shape) => ({ shape, ...declaredKeys(root, shape) }));
 
   /** oracle name -> every key declared on a wire shape judged by that oracle. */
@@ -591,21 +939,38 @@ export async function analyze(root = REPO_ROOT, options = {}) {
   const uiOnly = [];
   const ledgered = new Set();
 
+  /** key -> the retirement that refused a ledger row for it, with its oracle. */
+  const refusedWaivers = new Map();
+
   for (const { shape, keys } of read) {
     const oracle = oracleOf(shape);
     const accept = accepts.get(oracle);
     for (const key of keys) {
       if (accept.has(key)) continue;
+      const retired = retirementAt(shape, key);
       if (shape.reach === "ui" && !wireKeysByOracle.get(oracle).has(key)) {
-        uiOnly.push({ shape: shape.id, file: shape.file, key, oracle });
+        uiOnly.push({ shape: shape.id, file: shape.file, key, oracle, retired });
         continue;
       }
       const entry = Object.prototype.hasOwnProperty.call(ledger, key) ? ledger[key] : null;
-      if (entry && (entry.oracle ?? "FieldSchema") === oracle) {
+      const waivable = Boolean(entry) && (entry.oracle ?? "FieldSchema") === oracle;
+      // A retirement IN FORCE at this shape's own strip site is not waivable —
+      // its resolution already happened, on the card the tombstone names, and a
+      // fresh ledger row would re-open it in silence.
+      if (waivable && !(retired && retired.inForce)) {
         ledgered.add(`${key}\u0000${oracle}`);
         continue;
       }
-      violations.push({ shape: shape.id, file: shape.file, writer: shape.writer, key, oracle });
+      if (waivable) refusedWaivers.set(key, { oracle, retired });
+      violations.push({
+        shape: shape.id,
+        file: shape.file,
+        writer: shape.writer,
+        key,
+        oracle,
+        retired,
+        waiverRefused: waivable,
+      });
     }
   }
 
@@ -627,6 +992,19 @@ export async function analyze(root = REPO_ROOT, options = {}) {
   const staleLedger = Object.keys(ledger)
     .filter((key) => !ledgered.has(`${key}\u0000${ledgerOracle(key)}`))
     .map((key) => {
+      // The registry's answer comes first and is the most specific: this row
+      // was not honoured because the key is RETIRED at the site that declares
+      // it. Reporting it as merely "unreachable" would send the reader looking
+      // for a shape that is right there.
+      const refused = refusedWaivers.get(key);
+      if (refused && refused.oracle === ledgerOracle(key)) {
+        return {
+          key,
+          reason:
+            `the registry retires it (${refused.retired.retiredBy}) and \`${refused.retired.site}\` strips it — ` +
+            "a retirement cannot be waived by a ledger row",
+        };
+      }
       // Scoped to the entry's own oracle: a key still declared somewhere, but
       // no longer on any shape THIS entry could apply to, is exactly as stale
       // as one nothing declares at all.
@@ -654,6 +1032,7 @@ export async function analyze(root = REPO_ROOT, options = {}) {
     accept: accepts.get("FieldSchema") ?? accepts.get(needed[0]),
     accepts,
     origin,
+    registry,
     shapes: read,
     violations,
     uiOnly,
@@ -674,7 +1053,7 @@ async function main() {
     throw err;
   }
 
-  const { accepts, origin, shapes, violations, uiOnly, staleLedger } = result;
+  const { accepts, origin, registry, shapes, violations, uiOnly, staleLedger } = result;
   for (const [name, accept] of accepts) {
     console.log(`designer-field-key-parity: ${name} accepts ${accept.size} keys`);
   }
@@ -685,9 +1064,27 @@ async function main() {
         (indexSignature ? "  (+ index signature — see coverage note 2)" : "")
     );
   }
+  // The registry, and the per-site map this gate judges it through. Printed
+  // every run so a silently empty extraction cannot read as "nothing is
+  // retired" in a green log.
+  console.log(
+    `\n  Retired-key registry: ${registry.file} — ${registry.tombstones.length} tombstones over ${registry.sites.length} sites`
+  );
+  for (const site of registry.sites) {
+    const shape = PAYLOAD_SHAPES.find((s) => s.stripSite === site);
+    console.log(
+      `    ${site.padEnd(28)} ${shape ? `-> ${shape.id} (${shape.file})` : `-- ${SITES_WITH_NO_DECLARED_SHAPE[site]}`}`
+    );
+  }
+
   if (uiOnly.length) {
     console.log("\n  UI-only keys (declared on no wire-bound shape of the same oracle, so out of reach of a PUT):");
-    for (const u of uiOnly) console.log(`    ${u.key.padEnd(16)} (${u.shape}, vs ${u.oracle})`);
+    for (const u of uiOnly) {
+      console.log(
+        `    ${u.key.padEnd(16)} (${u.shape}, vs ${u.oracle})` +
+          (u.retired ? `  [retired ${u.retired.retiredBy}]` : "")
+      );
+    }
   }
   const ledgerKeys = Object.keys(KNOWN_UNPARSEABLE_KEYS);
   if (ledgerKeys.length) {
@@ -727,6 +1124,18 @@ async function main() {
         console.error(`        declared on ${v.shape} (${v.file})`);
         console.error(`        written by  ${v.writer}`);
         console.error(`        refused by  ${v.oracle}`);
+        if (!v.retired) continue;
+        // The registry's own words, per site — never flattened to "retired".
+        console.error(`        RETIRED by  ${v.retired.retiredBy} (${registry.file})`);
+        console.error(`          stripped at      ${v.retired.strippedAt.join(", ") || "(no site)"}`);
+        console.error(`          NOT stripped at  ${v.retired.notStrippedAt.join(", ") || "(none)"}`);
+        if (v.retired.inForce) {
+          console.error(
+            `          this shape IS the \`${v.retired.site}\` strip site, which strips this key:\n` +
+              "          the retirement is in force here and a KNOWN_UNPARSEABLE_KEYS row cannot waive it." +
+              (v.waiverRefused ? " The row present for it is reported as stale above." : "")
+          );
+        }
       }
     }
     console.error(
@@ -734,7 +1143,11 @@ async function main() {
         "    which blocks EVERY subsequent save of the object until the key is cleared.\n" +
         "    The three prior instances took three different correct resolutions (retire the\n" +
         "    control, delete the declaration, move the producer upstream) — so file a card and\n" +
-        "    record it in KNOWN_UNPARSEABLE_KEYS rather than picking one here.\n"
+        "    record it in KNOWN_UNPARSEABLE_KEYS rather than picking one here.\n" +
+        "\n    EXCEPT where a key is printed as RETIRED and in force above: that adjudication is\n" +
+        "    already made, on the card the tombstone names. The resolution there is to remove the\n" +
+        "    declaration (or to overturn the tombstone in the registry, with a ruling) — never to\n" +
+        "    add a ledger row, which would re-open a settled retirement in silence.\n"
     );
   }
 


### PR DESCRIPTION
Fixes #6699

Makes the objectui#6527 tombstone registry the parity gate's single source for **retirement**. A registry with no gate pinning it is a convention, and conventions drift — this repo's own history is the proof the card cites.

File surface, as dispatched: `scripts/check-designer-field-key-parity.mjs` and `scripts/__tests__/check-designer-field-key-parity.test.ts` **only**. The registry, its test, the three strip sites and `permission-slice.ts` are untouched.

## Measured premise (re-measured on this base, `eb33a8d4c`)

The gate carried **no retired-key set of its own** — the card's "derive what it checks from the registry" had no existing copy to delete:

- `KNOWN_UNPARSEABLE_KEYS` is `{}` at run time (`node -e "... Object.keys(m.KNOWN_UNPARSEABLE_KEYS)"` prints `[]`). It is a different ledger anyway: card-anchored keys whose resolution is still OPEN, with the `formula` / `sortOrder` rows already resolved and removed.
- `git grep -n "RETIRED\|retired\|tombstone"` over the gate returned only prose — the header's `RETIRED_FIELD_KEYS = ['indexed']` sentence is history (lines 51-58), plus one comment.

So the deliverable had to be a concrete, non-vacuous derivation, proven by ablation. It is; the ablation table below is the proof.

## The derivation shipped

**A retirement is not waivable at a site that strips the key.** Where a wire shape IS one of the registry's strip sites (`stripSite`) and the tombstone marks that site `true`, a `KNOWN_UNPARSEABLE_KEYS` row can no longer quiet the key. The ledger is for keys whose resolution is still open; a tombstoned key's resolution already happened, on the card the tombstone names, so a fresh row would re-open a settled retirement in silence — the ledger becoming the hiding place the header's ratchet note says it must never be. The violation cites the registry entry instead of the "file a card and record it in `KNOWN_UNPARSEABLE_KEYS`" invitation, and the row itself is reported as stale with the registry's reason.

Two `ExtractionError` link checks come with it, in both directions:

- a shape naming a `stripSite` the registry does not declare (a renamed site must not leave a shape enforcing nothing);
- a registry site this gate accounts for **nowhere** — named by no shape and not recorded shapeless. This is what makes the registry the single SOURCE rather than a single copy: it cannot grow a strip site while the gate goes on judging only the old three.

The registry is read from the **tracked source** `packages/types/src/internal/retired-field-keys.ts` through the TypeScript AST — the same walk `PAYLOAD_SHAPES` already use — not through the built `@object-ui/types/internal/retired-field-keys` subpath, so the gate gains no build precondition and still runs on a cold cache. Extraction failure is an `ExtractionError`, never a pass and never a silent skip: missing file, missing constant, empty tombstone array, a tombstone with no `key` or no `retiredBy`, a non-boolean column, or a `sites` record naming a site outside `RETIRED_FIELD_KEY_SITES`. The header's two standing constraints are kept as they were: extraction failure is an ERROR, and the accept set is still read from the installed schema and never listed in the file.

### Rejected, with the measurement

- **Registry/oracle agreement in the gate** (route (ii) — "every tombstone key must be refused by the installed `FieldSchema`"). **Rejected as a duplicate.** `packages/types/src/__tests__/retired-field-key-tombstones.test.ts` already pins exactly this, per key, with `unrecognized_keys` asserted and a positive control: *"every registry key is refused BY NAME by the installed FieldSchema"* (lines 104-113). A second copy of an assertion is a second thing to keep honest. The gate leans on route (i) instead, and its header says so.
- **A flat "retired everywhere" key set.** Rejected on the card's own terms, and the rejection is measured rather than asserted: ablation **A3** flattens `inForce` to `Object.values(sites).some(Boolean)` and two pins go red. A flat set decides `sortOrder` at `MetadataFieldsPage` and `formula` at the read door in the direction the registry refused.
- **Widening the charter to make a tombstoned key on a UI-only shape a violation.** Rejected as a policy change with no ruling behind it: `isSystem` and `referenceTo` are tombstoned keys the in-memory model still declares, the converters strip them, and `uiOnly` is the correct verdict. They are now *annotated* with their retiring card in the run log instead — visible, not red.

## Per-site columns: consumed vs deliberately not

| Column | Consumed? | Why |
| --- | --- | --- |
| `key` | yes | the identity the rule is keyed on |
| `retiredBy` | yes | the citation the gate prints in place of inviting a ledger row |
| `sites` | yes, **per site** | `inForce` is `sites[thisShape.stripSite] === true`; the whole record is reproduced verbatim in the citation, on both the stripped and NOT-stripped sides |
| `specEquivalent` | **no** — not even extracted | documentation, never an instruction to rename. objectui#6043 refused exactly that rename for `formula` (`FieldSchema` validates the key, not the language, so a blind rename launders non-CEL text into a formula that parses green and evaluates to null). A gate that read it would sooner or later suggest it. |
| `defensive` | **no** — not even extracted | it records how strong the EVIDENCE for a strip is (objectui#6045's recorded verdict). That is the registry's verdict to keep; it is no input to a key-NAME parity comparison, and consuming it would let the gate silently treat a defensive strip as weaker than the registry says. |

**The asymmetry survives as data, and is measured:**

- **`formula` at the read door.** The gate asserts **nothing** at `metadataAdminFieldsReadDoor` and cannot: the read door declares no payload shape at all (coverage note 3 — `readFields` carries raw `Record` defs), so it is recorded in `SITES_WITH_NO_DECLARED_SHAPE` with that reason and no shape can name it. Where `formula` IS cited, the read door appears only on the **NOT stripped at** side — the registry's own word for it, never inverted. This keeps objectui#6526 option B structurally out of the gate's reach: *"the READ door must NOT strip it (`false`) — RULED, objectui#6526 option B … Flipping this `false` is overturning a maintainer ruling, not tidying an inconsistency."*
- **`sortOrder`'s single site.** Treated exactly as the registry states it — `true` at `metadataServiceCarryOver`, `false` at `metadataFieldsPageCarryOver`. One key, one ledger row, two sites, **two different verdicts**: at the stripping site the row is refused; at the other the ordinary ledger path applies and the row is honoured, because there the registry makes no claim to enforce. That pair is a test (`⭐ the SAME key at a site whose column is false …`) and it is what a flattened set cannot produce.
- **The FIELD registry never reaches the OBJECT oracle.** `sortOrder` is refused at both levels by two different schemas and is two different cards (objectui#6045 field-level, objectui#6223 object-level). The citation is scoped to `FieldSchema`, so the object-level card's own ledger row still works — pinned, and visible in the run log where `ObjectDefinition`'s `sortOrder` is the one uiOnly entry carrying no citation.

## Ablation table

Every leg: mutate, prove the mutation ON DISK by text count and by `git hash-object` differing from the HEAD blob, measure, restore, prove the restore by blob hash **equal** to HEAD and an empty `git diff HEAD` — never by an exit code. The harness carries `trap ... EXIT INT TERM` with absolute paths, so a mid-run kill cannot leave the tree mutated. A1-A5 mutate the gate (mine to mutate, in my worktree); A6 mutates a **copy** of a real wire-shape file, because the strip sites are fenced.

| # | Mutation | Disk proof | Result |
| --- | --- | --- | --- |
| A1 | remove the waiver ban (`waivable && !(retired && retired.inForce)` to `!(false && …)`) | anchor-gone=0 injected=1, blob `3b2062f3` vs HEAD `93a13cf5` | **RED** — 2 failed / 60 passed: `expected [] to deeply equal [ 'formula:true' ]`, `[ 'sortOrder:true' ]` |
| A2 | extraction returns no tombstones (`tombstones: []`) — the silently-empty read | anchor-gone=0 injected=1, blob `ed705770` | **RED** — 6 failed / 56 passed, starting with the non-vacuity floor: `expected [] to deeply equal ArrayContaining` |
| A3 | **flatten** the registry: `inForce` ignores the per-site column | anchor-gone=0 injected=1, blob `5fdf7abc` | **RED** — 2 failed: the `false`-column case starts refusing the waiver (`expected [ {…} ] to deeply equal []`) and `inForce` flips (`expected true to be false`) |
| A4 | drop the read door from `SITES_WITH_NO_DECLARED_SHAPE` | anchor-gone=0 injected=1, blob `bb3c5cc7` | **RED** — gate exit 1: `EXTRACTION FAILED … declares strip site(s) 'metadataAdminFieldsReadDoor' this gate accounts for nowhere`; 30 test failures |
| A5 | cross the site map (swap the two `stripSite` values) | order on disk swapped to `[metadataFieldsPageCarryOver, metadataServiceCarryOver]`, blob `deb1e32f` | **RED** — 2 failed: `FieldMetadataPayload is mapped to the wrong site` |
| A6 | re-declare `formula` on a **copy** of `MetadataService.ts` + a matching ledger row | injected=1 delta=1, copy blob `57277b29` vs original HEAD blob `e41a23fa`; original blob after the run `e41a23fa` (untouched), `git diff HEAD` empty | **RED**, naming the tombstone: `waiverRefused: true`, `retiredBy: objectui#6043`, `inForce: true`, `strippedAt: [metadataServiceCarryOver, metadataFieldsPageCarryOver]`, `notStrippedAt: [metadataAdminFieldsReadDoor]`; stale row: *"the registry retires it (objectui#6043) and `metadataServiceCarryOver` strips it — a retirement cannot be waived by a ledger row"* |

Every restore leg printed `blob == HEAD` and `git diff HEAD: ''`; the harness's final line confirms a clean tree.

## Gate verdict lines, before and after

Before (`eb33a8d4c`, exit 0) and after (`2c9a1ec26`, exit 0) both end in `designer-field-key-parity: OK`. The run gained the registry block, so a silently empty extraction cannot read as "nothing is retired" in a green log:

```
  Retired-key registry: packages/types/src/internal/retired-field-keys.ts — 5 tombstones over 3 sites
    metadataAdminFieldsReadDoor  -- no statically declared payload shape (coverage note 3) — nothing is judged at this site
    metadataServiceCarryOver     -> FieldMetadataPayload (packages/app-shell/src/services/MetadataService.ts)
    metadataFieldsPageCarryOver  -> ServerFieldSchema (packages/plugin-designer/src/MetadataFieldsPage.tsx)
```

and the two retired spellings still on the UI model are now annotated rather than reading as ordinary UI keys:

```
    isSystem         (DesignerFieldDefinition, vs FieldSchema)  [retired objectui#6044]
    referenceTo      (DesignerFieldDefinition, vs FieldSchema)  [retired objectui#6041]
    sortOrder        (ObjectDefinition, vs ObjectSchema)
```

(the object-level `sortOrder` deliberately carries none — different oracle, different card.)

## Gates run, with their own verdict lines — all at `2c9a1ec26`, the final commit

Exit codes captured by redirect-then-`$?`, never through a pipe.

| Command | Exit | Verdict line |
| --- | --- | --- |
| `pnpm exec vitest run scripts/__tests__/check-designer-field-key-parity.test.ts scripts/__tests__/zod-wrapper-keys.shared.test.ts --maxWorkers=2` | 0 | `Test Files 2 passed (2)` / `Tests 69 passed (69)` — the parity file went 45 to 62 cases |
| `pnpm check:designer-field-key-parity` | 0 | `designer-field-key-parity: OK` |
| `pnpm type-check:scripts` | 0 | (clean `tsc -p tsconfig.scripts.json`) |
| `pnpm check:control-bytes` | 0 | `check-control-bytes: OK (scanned 6008 tracked text file(s); skipped 85 binary).` |
| `pnpm check:entry-guard` | 0 | `check:entry-guard: 58 scripts/ file(s) — no entry guard outside the baseline; … 52 export bindings, 52 of them inert on import` |
| `pnpm check:esm-specifiers` | 0 | `no un-ledgered package emits an extensionless relative specifier` |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` (2 files changed, 0 published source) |

**Declared narrowing — lint.** Repo-wide `pnpm lint` was NOT run; it is a repo scan CI owns, and it is not in this card's gate list. `eslint --no-inline-config` was run on the two changed files: 0 errors, 0 warnings, and the narrowing is measured rather than assumed — (1) the universe read from ESLint's OWN config via its API (`isPathIgnored` + `calculateConfigForFile` over every tracked file): 4024 of 6093 tracked files carry rules, 1964 are ignored by eslint's own config, 105 match no rule-carrying entry; (2) files actually linted, from `--format json`: 2; (3) `eslint.config.js` declares no `parserOptions.project` and no `projectService`, so type-aware linting is off and no rule's verdict on an untouched file can move with this diff — the only cross-file rule configured is `no-restricted-imports`, which is per-file, and the only file importing the gate is its own test, which was linted.

No console build was needed and no heavy verify was run, so the shared verify lock was not taken.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b)_