### PR TITLE
test(config): state the unit project's real `isolate: false` invariant, and enforce it

### DIFF
--- a/scripts/__tests__/unit-registry-absence-collision.test.ts
+++ b/scripts/__tests__/unit-registry-absence-collision.test.ts
@@ -1,0 +1,350 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS shared helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
+// re-adding one is itself an error (TS2578). See objectui#3494.
+import {
+  FLOORS,
+  checkFloors,
+  findCollisions,
+  formatCollisions,
+  readAbsenceAssertions,
+  readImportSpecifiers,
+  readOwnRegistrations,
+  readUnitProjectShape,
+  resolveSpecifier,
+  unitProjectFiles,
+} from '../unit-registry-collision.mjs';
+
+/**
+ * objectui#7134 — the `unit` project's `isolate: false` is safe only while a
+ * key one file asserts ABSENT from the `ComponentRegistry` is registered by no
+ * other file in the project. This gate is what makes that a fact rather than a
+ * sentence in `vitest.config.mts`.
+ *
+ * ## Why a comment was not enough
+ *
+ * The config used to justify `isolate: false` with "no ComponentRegistry ... state
+ * to leak across files". That premise was false in BOTH directions and had been
+ * for some time: the project holds files whose import closure registers into the
+ * singleton, and files that assert a key is absent from it. Measured here on
+ * every run — on `eb33a8d4c` the project's 810 files import 600 distinct
+ * specifiers whose closures register 502 keys into the shared singleton.
+ *
+ * Nothing was red, and that is the point: a collision is ORDER-DEPENDENT, so it
+ * arrives as a failure in a file that did nothing wrong, in whichever worker
+ * happened to run the writer first. A comment is the only thing a future author
+ * consults before adding a registering import to this project, and this one had
+ * already gone false without anyone noticing.
+ *
+ * ## Why the writers' keys are EXECUTED and not read off the source
+ *
+ * They cannot be read off the source. The live field path registers from data —
+ * `registerAllFields()` walks a map — so `field:multiselect` exists at runtime
+ * and appears in no `register('field:multiselect')` call site anywhere in the
+ * repo. A static reader would report "nothing registers it" and this gate would
+ * be green for the empty reason. So the writer half is measured by running the
+ * project's import closures in a FRESH module graph and diffing the registry;
+ * only what genuinely cannot be executed (a file's own in-body `register` calls,
+ * which happen when the test runs, not when it is imported) is read off the AST.
+ *
+ * ## Why this file does not itself pollute the project it measures
+ *
+ * It runs in the very project it is about, so its own imports would otherwise be
+ * the largest registry write in it. `vi.resetModules()` before the measurement
+ * gives it a private module graph — a fresh `@object-ui/core`, therefore a fresh
+ * singleton, not the one its worker's other files hold — and a second reset
+ * afterwards drops that graph so files running later re-import their own.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const configPath = path.join(repoRoot, 'vitest.config.mts');
+
+/** Where a future author reads the justification, and what it must point at. */
+const GUARD_PATH = 'scripts/__tests__/unit-registry-absence-collision.test.ts';
+
+type Population = {
+  files: string[];
+  readers: Array<{ file: string; keys: string[]; sites: Array<{ key: string | null; line: number; matcher: string; text: string }> }>;
+  ownWriters: Array<{ file: string; keys: string[] }>;
+  unresolvedAbsenceSites: Array<{ file: string; line: number; text: string }>;
+  specsByFile: Map<string, string[]>;
+  importIds: string[];
+  workspaceIds: Set<string>;
+  filesBySpecId: Map<string, string[]>;
+  unresolvedSpecifiers: Array<{ file: string; spec: string }>;
+  isolateFalse: boolean;
+  configText: string;
+};
+
+function derive(): Population {
+  const configText = fs.readFileSync(configPath, 'utf8');
+  const shape = readUnitProjectShape(configText);
+  const files: string[] = unitProjectFiles(repoRoot, shape);
+
+  const readers: Population['readers'] = [];
+  const ownWriters: Population['ownWriters'] = [];
+  const unresolvedAbsenceSites: Population['unresolvedAbsenceSites'] = [];
+  const specsByFile = new Map<string, string[]>();
+  const filesBySpecId = new Map<string, string[]>();
+  const workspaceIds = new Set<string>();
+  const unresolvedSpecifiers: Population['unresolvedSpecifiers'] = [];
+  const importIds: string[] = [];
+
+  for (const file of files) {
+    const source = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+
+    const sites = readAbsenceAssertions(source, file);
+    if (sites.length > 0) {
+      const keys = [...new Set(sites.map((s) => s.key).filter((k): k is string => k !== null))];
+      readers.push({ file, keys, sites });
+      for (const site of sites) {
+        if (site.key === null) unresolvedAbsenceSites.push({ file, line: site.line, text: site.text });
+      }
+    }
+
+    const own = readOwnRegistrations(source, file);
+    if (own.keys.length > 0) ownWriters.push({ file, keys: own.keys });
+
+    const specs = readImportSpecifiers(source, file);
+    specsByFile.set(file, specs);
+    for (const spec of specs) {
+      const resolved = resolveSpecifier(repoRoot, file, spec);
+      if (resolved.kind === 'unresolved') {
+        unresolvedSpecifiers.push({ file, spec });
+        continue;
+      }
+      if (resolved.kind === 'workspace') workspaceIds.add(resolved.id);
+      if (!filesBySpecId.has(resolved.id)) {
+        filesBySpecId.set(resolved.id, []);
+        importIds.push(resolved.id);
+      }
+      filesBySpecId.get(resolved.id)!.push(file);
+    }
+  }
+
+  return {
+    files, readers, ownWriters, unresolvedAbsenceSites, specsByFile, importIds,
+    workspaceIds, filesBySpecId, unresolvedSpecifiers, isolateFalse: shape.isolateFalse, configText,
+  };
+}
+
+/** Import `ids` into a private module graph and report what they registered. */
+async function registryAfterImporting(ids: string[]) {
+  vi.resetModules();
+  const { ComponentRegistry } = await import('@object-ui/core');
+  const before = new Set<string>(ComponentRegistry.getAllTypes());
+  const failures: Array<{ id: string; message: string }> = [];
+  let imported = 0;
+  for (const id of ids) {
+    try {
+      await import(/* @vite-ignore */ id);
+      imported += 1;
+    } catch (error) {
+      failures.push({ id, message: String((error as Error)?.message ?? error).split('\n')[0].slice(0, 160) });
+    }
+  }
+  const added = ComponentRegistry.getAllTypes().filter((k: string) => !before.has(k));
+  return { added, failures, imported, startedEmpty: before.size === 0 };
+}
+
+let population: Population;
+let measurement: Awaited<ReturnType<typeof registryAfterImporting>>;
+
+beforeAll(async () => {
+  population = derive();
+  measurement = await registryAfterImporting(population.importIds);
+}, 600_000);
+
+// Drop the private graph so files running later in this worker re-import their
+// own rather than inheriting the one this file built.
+afterAll(() => {
+  vi.resetModules();
+});
+
+describe('the unit project shares one ComponentRegistry, and this gate is what keeps that safe (objectui#7134)', () => {
+  it('is measuring the project it claims to (population, readers, writers, modules)', () => {
+    const counts = {
+      populationFiles: population.files.length,
+      readerFiles: population.readers.length,
+      resolvedAbsentKeys: new Set(population.readers.flatMap((r) => r.keys)).size,
+      distinctSpecifiers: population.importIds.length,
+      registeredKeys: measurement.added.length,
+    };
+    expect(
+      checkFloors(counts),
+      'a population COLLAPSED — this run proves nothing:\n' +
+        JSON.stringify(counts, null, 2) +
+        '\nFix the derivation. If a floor is genuinely too high because the tree changed shape, ' +
+        'move it in `FLOORS` deliberately and say why — never to make a red run green.',
+    ).toEqual([]);
+    // The private graph must really be private: a non-empty starting registry
+    // means `vi.resetModules()` did not give this file its own `@object-ui/core`,
+    // and every number above would be about its worker's leftovers instead.
+    expect(measurement.startedEmpty, 'the measurement did not start from a fresh registry').toBe(true);
+  });
+
+  it('imports every module this repo owns (a module that fails to load registers nothing)', () => {
+    const ours = measurement.failures.filter((f) => population.workspaceIds.has(f.id));
+    expect(
+      ours.map((f) => `${path.relative(repoRoot, f.id)}: ${f.message}`),
+      'a workspace module the unit project imports could not be imported here, so its registrations ' +
+        'were not measured and this gate is blind to them',
+    ).toEqual([]);
+    expect(
+      population.unresolvedSpecifiers.length,
+      `relative import specifiers with no file behind them: ${JSON.stringify(population.unresolvedSpecifiers.slice(0, 5))}`,
+    ).toBeLessThanOrEqual(2);
+  });
+
+  it('no key asserted ABSENT by one file is registered by another', async () => {
+    const absentKeys = new Set(population.readers.flatMap((r) => r.keys));
+    const registered = new Set(measurement.added);
+
+    // Cheap path first: the whole project's closures registered `measurement.added`,
+    // so if no asserted-absent key is in there, no closure can collide with one.
+    const suspects = [...absentKeys].filter((k) => registered.has(k));
+
+    const writers: Array<{ file: string; keys: string[] }> = [...population.ownWriters];
+    for (const key of suspects) {
+      // Only now — on the expensive path — pay for attribution: bisect the
+      // specifier list for the one that registers this key, then name the files
+      // that import it. The message has to name a file an author can go and edit.
+      const specId = await bisectForKey(key, population.importIds);
+      const importers = specId ? (population.filesBySpecId.get(specId) ?? []) : [];
+      const via = specId ? ` (via ${path.relative(repoRoot, specId)})` : '';
+      for (const importer of importers) writers.push({ file: `${importer}${via}`, keys: [key] });
+    }
+
+    const collisions = findCollisions(
+      population.readers.map((r) => ({ file: r.file, keys: r.keys })),
+      writers,
+    );
+    expect(
+      collisions,
+      'REGISTRY COLLISION in the `unit` project. `vitest.config.mts` runs it with `isolate: false`, so ' +
+        'these files share one module graph — and one ComponentRegistry — per worker. Whether the ' +
+        'absence assertion sees the registration depends on which file the worker ran first, so the ' +
+        'outcome is not information about the code under test:\n' +
+        formatCollisions(collisions) +
+        '\n\nClose it by making the absence assertion hermetic (reset the module graph and re-import ' +
+        'only what it means to measure), or by keeping the registration out of this project.',
+    ).toEqual([]);
+  }, 600_000);
+
+  it('reports every absence assertion whose key it could not resolve, rather than dropping it', () => {
+    // An unresolvable key is a place this gate is blind. Today there is exactly
+    // one — `exclusion-reason-truthfulness.test.ts` asserts over a key set
+    // derived at runtime from `PALETTE_EXCLUSIONS`. Dropping such a site
+    // silently is how a gate shrinks to nothing while staying green, so the
+    // count is pinned: a NEW one is a decision, not a default.
+    expect(
+      population.unresolvedAbsenceSites.map((s) => `${s.file}:${s.line} ${s.text}`),
+      'a new registry-absence assertion names a key this gate cannot resolve statically, so it cannot ' +
+        'check it. Either spell the key as a literal (or a local const), or make the assertion hermetic ' +
+        'and record why here.',
+    ).toHaveLength(1);
+  });
+
+  it('the config justification still points at this gate', () => {
+    // Rule of the card: the justification is the only thing a future author
+    // consults. It has to name where the constraint is enforced, and that name
+    // has to still be true.
+    expect(
+      population.configText.includes(GUARD_PATH),
+      `vitest.config.mts no longer names ${GUARD_PATH} in the \`unit\` project's \`isolate: false\` ` +
+        'justification. Point it back at the gate, or move the gate and update the comment.',
+    ).toBe(true);
+    expect(population.isolateFalse, "the `unit` project no longer sets `isolate: false`").toBe(true);
+  });
+});
+
+/** Which single specifier registers `key`? Bisection — the red path only. */
+async function bisectForKey(key: string, ids: string[]): Promise<string | null> {
+  let pool = ids;
+  const registers = async (subset: string[]) => (await registryAfterImporting(subset)).added.includes(key);
+  if (!(await registers(pool))) return null;
+  while (pool.length > 1) {
+    const mid = Math.floor(pool.length / 2);
+    const head = pool.slice(0, mid);
+    pool = (await registers(head)) ? head : pool.slice(mid);
+  }
+  return pool[0] ?? null;
+}
+
+describe('the judgement, on planted populations (this gate must be able to go red)', () => {
+  it('names both files and the key when a writer registers what a reader asserts absent', () => {
+    const collisions = findCollisions(
+      [{ file: 'a.test.ts', keys: ['field:retired'] }],
+      [{ file: 'b.test.ts', keys: ['field:retired', 'field:kept'] }],
+    );
+    expect(collisions).toEqual([{ key: 'field:retired', reader: 'a.test.ts', writer: 'b.test.ts' }]);
+    expect(formatCollisions(collisions)).toContain('a.test.ts');
+    expect(formatCollisions(collisions)).toContain('b.test.ts');
+    expect(formatCollisions(collisions)).toContain('field:retired');
+  });
+
+  it('does not report a file colliding with itself — that file is hermetic either way', () => {
+    expect(
+      findCollisions([{ file: 'a.test.ts', keys: ['k'] }], [{ file: 'a.test.ts', keys: ['k'] }]),
+    ).toEqual([]);
+  });
+
+  it('an empty population FAILS instead of passing (every floor is one a zero would satisfy)', () => {
+    expect(checkFloors({ populationFiles: 0, readerFiles: 0, resolvedAbsentKeys: 0, distinctSpecifiers: 0, registeredKeys: 0 }))
+      .toHaveLength(Object.keys(FLOORS).length);
+    // A population that was never measured is not "zero", and must not read as one.
+    expect(checkFloors({}).every((line: string) => line.includes('NOT MEASURED'))).toBe(true);
+    // The control's control: a healthy census clears every floor.
+    expect(checkFloors({ populationFiles: 810, readerFiles: 2, resolvedAbsentKeys: 2, distinctSpecifiers: 600, registeredKeys: 502 }))
+      .toEqual([]);
+  });
+});
+
+describe('the readers read the AST, not the text (this repo embeds fixture sources in strings)', () => {
+  const absence = (src: string) => readAbsenceAssertions(src, 'f.test.ts');
+
+  it('finds a literal-key absence assertion', () => {
+    expect(absence("expect(ComponentRegistry.get('field:x')).toBeUndefined();")[0]).toMatchObject({
+      key: 'field:x', matcher: 'toBeUndefined',
+    });
+  });
+
+  it('resolves a template key through a local const, the way a retirement pin spells it', () => {
+    const src = "const RETIRED = 'multiselect';\nexpect(ComponentRegistry.get(`field:${RETIRED}`)).toBeUndefined();";
+    expect(absence(src)[0].key).toBe('field:multiselect');
+  });
+
+  it('counts `.not.toBeDefined()` as absence and plain `.toBeDefined()` as presence', () => {
+    expect(absence("expect(ComponentRegistry.get('k')).not.toBeDefined();")).toHaveLength(1);
+    expect(absence("expect(ComponentRegistry.get('k')).toBeDefined();")).toHaveLength(0);
+    expect(absence("expect(ComponentRegistry.get('k')).not.toBeUndefined();")).toHaveLength(0);
+  });
+
+  it('reports an unresolvable key as a site with key null, never as no site at all', () => {
+    expect(absence('expect(ComponentRegistry.get(type)).toBeFalsy();')).toMatchObject([{ key: null }]);
+  });
+
+  it('ignores a registration written inside a fixture string — source to a regex, not a registration', () => {
+    const src = 'const fixture = `ComponentRegistry.register("ui:ghost", C, { namespace: "ui" });`;\n';
+    expect(readOwnRegistrations(src, 'f.test.ts').keys).toEqual([]);
+    expect(readImportSpecifiers("const f = `import '@object-ui/components';`;\n", 'f.test.ts')).toEqual([]);
+  });
+
+  it('reads a real in-body registration, with the bare-name fallback `register` also writes', () => {
+    const one = readOwnRegistrations("ComponentRegistry.register('grid', C, { namespace: 'view' });", 'f.test.ts');
+    expect(one.keys).toEqual(['view:grid', 'grid']);
+    const skipped = readOwnRegistrations(
+      "ComponentRegistry.register('grid', C, { namespace: 'view', skipFallback: true });", 'f.test.ts');
+    expect(skipped.keys).toEqual(['view:grid']);
+  });
+
+  it('reports a dynamic registration key rather than dropping the call', () => {
+    expect(readOwnRegistrations('ComponentRegistry.register(type, C);', 'f.test.ts')).toMatchObject({
+      keys: [], unresolved: [{ line: 1 }],
+    });
+  });
+});

--- a/scripts/__tests__/unit-registry-absence-collision.test.ts
+++ b/scripts/__tests__/unit-registry-absence-collision.test.ts
@@ -210,13 +210,21 @@ describe('the unit project shares one ComponentRegistry, and this gate is what k
 
     const writers: Array<{ file: string; keys: string[] }> = [...population.ownWriters];
     for (const key of suspects) {
-      // Only now — on the expensive path — pay for attribution: bisect the
-      // specifier list for the one that registers this key, then name the files
-      // that import it. The message has to name a file an author can go and edit.
-      const specId = await bisectForKey(key, population.importIds);
-      const importers = specId ? (population.filesBySpecId.get(specId) ?? []) : [];
-      const via = specId ? ` (via ${path.relative(repoRoot, specId)})` : '';
-      for (const importer of importers) writers.push({ file: `${importer}${via}`, keys: [key] });
+      for (const reader of population.readers.filter((r) => r.keys.includes(key))) {
+        // Attribution runs only on this expensive path, and it runs over the
+        // specifiers SOME OTHER file imports. Measuring the whole union instead
+        // would let the reader's own closure answer for the key — a file that
+        // registers what it then asserts absent is hermetic, not a collision,
+        // and reporting one would be a false red.
+        const othersIds = population.importIds.filter((id) =>
+          (population.filesBySpecId.get(id) ?? []).some((f) => f !== reader.file),
+        );
+        const specId = await bisectForKey(key, othersIds);
+        if (!specId) continue;
+        const importers = (population.filesBySpecId.get(specId) ?? []).filter((f) => f !== reader.file);
+        const via = ` (via ${path.relative(repoRoot, specId)})`;
+        for (const importer of importers) writers.push({ file: `${importer}${via}`, keys: [key] });
+      }
     }
 
     const collisions = findCollisions(

--- a/scripts/__tests__/unit-registry-absence-collision.test.ts
+++ b/scripts/__tests__/unit-registry-absence-collision.test.ts
@@ -31,8 +31,8 @@ import {
  * to leak across files". That premise was false in BOTH directions and had been
  * for some time: the project holds files whose import closure registers into the
  * singleton, and files that assert a key is absent from it. Measured here on
- * every run — on `eb33a8d4c` the project's 810 files import 600 distinct
- * specifiers whose closures register 502 keys into the shared singleton.
+ * every run — over `ec0a7b846` the project's 811 files import 551 distinct
+ * modules whose closures register 505 keys into the shared singleton.
  *
  * Nothing was red, and that is the point: a collision is ORDER-DEPENDENT, so it
  * arrives as a failure in a file that did nothing wrong, in whichever worker

--- a/scripts/__tests__/unit-registry-absence-collision.test.ts
+++ b/scripts/__tests__/unit-registry-absence-collision.test.ts
@@ -132,10 +132,21 @@ function derive(): Population {
   };
 }
 
+/**
+ * `@object-ui/core` by computed specifier, like every other import below it.
+ * `tsconfig.scripts.json` has no path mapping into the workspace packages, and
+ * adding one to type ONE line would put every `scripts/` file on a different
+ * module resolution than the one CI type-checks them with.
+ */
+const CORE_SPECIFIER = '@object-ui/core';
+type Singleton = { getAllTypes(): string[] };
+
 /** Import `ids` into a private module graph and report what they registered. */
 async function registryAfterImporting(ids: string[]) {
   vi.resetModules();
-  const { ComponentRegistry } = await import('@object-ui/core');
+  const { ComponentRegistry } = (await import(/* @vite-ignore */ CORE_SPECIFIER)) as {
+    ComponentRegistry: Singleton;
+  };
   const before = new Set<string>(ComponentRegistry.getAllTypes());
   const failures: Array<{ id: string; message: string }> = [];
   let imported = 0;
@@ -147,7 +158,7 @@ async function registryAfterImporting(ids: string[]) {
       failures.push({ id, message: String((error as Error)?.message ?? error).split('\n')[0].slice(0, 160) });
     }
   }
-  const added = ComponentRegistry.getAllTypes().filter((k: string) => !before.has(k));
+  const added = ComponentRegistry.getAllTypes().filter((k) => !before.has(k));
   return { added, failures, imported, startedEmpty: before.size === 0 };
 }
 

--- a/scripts/unit-registry-collision.mjs
+++ b/scripts/unit-registry-collision.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * Static half of the `unit`-project registry-collision guard (objectui#7134).
+ *
+ * ## The invariant this exists to keep true
+ *
+ * `vitest.config.mts` runs the `unit` project with `isolate: false`, so every
+ * file in a worker shares ONE module graph — and therefore one
+ * `ComponentRegistry`, which is a module-level singleton
+ * (`packages/core/src/registry/Registry.ts`). Registrations performed by one
+ * file's import closure are visible to every other file in that worker.
+ *
+ * The project's justification comment used to state the opposite ("no
+ * ComponentRegistry ... state to leak across files"). Measured on
+ * `eb33a8d4c`: the union of the project's import closures registers 502 keys.
+ * The premise was false in both directions — the project holds files that
+ * WRITE to the singleton and files that assert a key is ABSENT from it — and a
+ * comment is the only thing a future author consults before adding either.
+ *
+ * A collision between the two is order-dependent, which is the reason it needs
+ * a gate rather than a rule: whether the absent-asserting file runs before or
+ * after the writer in its worker decides the outcome, and neither outcome is
+ * information about the code under test.
+ *
+ * ## What is static here and what is NOT
+ *
+ * This module holds only the parts that can be read off the SOURCE, all of
+ * them off the TypeScript AST rather than raw text — a registration written
+ * inside a fixture string (this repo has several, e.g.
+ * `scripts/__tests__/component-registrations.test.ts`) is source to a regex and
+ * is not a registration:
+ *
+ *   - the `unit` project's file population, derived from `vitest.config.mts`;
+ *   - each file's import specifiers;
+ *   - each file's registry-ABSENCE assertions and the keys they name;
+ *   - each file's OWN `ComponentRegistry.register` / `registerLazy` calls.
+ *
+ * The other half — which keys a file's import CLOSURE registers — is not
+ * derivable from source at all: the live path registers from data
+ * (`registerAllFields()` walks a map, so `field:*` keys appear in no
+ * `register('field:...')` call site anywhere). It is measured by EXECUTION in
+ * `scripts/__tests__/unit-registry-absence-collision.test.ts`: fresh module
+ * graph, import `@object-ui/core`, snapshot `getAllTypes()`, import the
+ * specifiers, diff.
+ *
+ * Every reader below reports what it could NOT resolve instead of dropping it,
+ * because each of these populations is one a silent zero would make green.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+/** Matchers that assert the subject is absent / not there. */
+export const ABSENCE_MATCHERS = new Set(['toBeUndefined', 'toBeNull', 'toBeFalsy']);
+/** Matchers that assert absence only under a `.not` in the chain. */
+export const NEGATED_PRESENCE_MATCHERS = new Set(['toBeDefined', 'toBeTruthy']);
+/** Registry reads whose result an absence assertion can be made about. */
+export const REGISTRY_READERS = new Set(['get', 'has']);
+/** The singleton this guard is about. A local `new Registry()` is not it. */
+export const SINGLETON = 'ComponentRegistry';
+
+/** Directory names never walked when collecting the project population. */
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.git', 'cypress', 'e2e']);
+
+function parse(sourceText, fileName = 'file.ts') {
+  return ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function lineOf(sf, node) {
+  return sf.getLineAndCharacterOfPosition(node.getStart(sf)).line + 1;
+}
+
+/**
+ * The `unit` project's include roots and `domTsTests` exclusions, read out of
+ * `vitest.config.mts` rather than duplicated here. Duplicating them is how the
+ * population silently stops matching the project it claims to describe.
+ */
+export function readUnitProjectShape(configText) {
+  const domMatch = configText.match(/const domTsTests = \[([\s\S]*?)\n\];/);
+  if (!domMatch) throw new Error('unit-registry-collision: could not find `domTsTests` in vitest.config.mts');
+  const domTsTests = domMatch[1]
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith("'") || l.startsWith('"'))
+    .map((l) => l.replace(/^['"]/, '').replace(/['"],?$/, ''));
+
+  const unitBlock = configText.match(/name: 'unit'[\s\S]*?include: \[([\s\S]*?)\],/);
+  if (!unitBlock) throw new Error("unit-registry-collision: could not find the `unit` project's `include` list");
+  const include = unitBlock[1]
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith("'") || l.startsWith('"'))
+    .map((l) => l.replace(/^['"]/, '').replace(/['"],?$/, ''));
+
+  const isolateFalse = /name: 'unit'[\s\S]*?isolate: false/.test(configText);
+  return { domTsTests, include, isolateFalse };
+}
+
+/** Walk `root` for files whose path matches one of the simple `dir/**\/*.ext` globs. */
+export function collectFiles(root, includeGlobs) {
+  const specs = includeGlobs.map((g) => {
+    const m = g.match(/^([^*]+)\/\*\*\/\*(\.[A-Za-z.]+)$/);
+    if (!m) throw new Error(`unit-registry-collision: unsupported include glob ${JSON.stringify(g)}`);
+    return { dir: m[1], ext: m[2] };
+  });
+  const out = [];
+  for (const { dir, ext } of specs) {
+    const start = path.join(root, dir);
+    if (!fs.existsSync(start)) continue;
+    const stack = [start];
+    while (stack.length) {
+      const cur = stack.pop();
+      for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+        const full = path.join(cur, entry.name);
+        if (entry.isDirectory()) {
+          if (SKIP_DIRS.has(entry.name) || entry.name.startsWith('.wt-')) continue;
+          stack.push(full);
+        } else if (entry.isFile() && entry.name.endsWith(ext)) {
+          out.push(path.relative(root, full).split(path.sep).join('/'));
+        }
+      }
+    }
+  }
+  return [...new Set(out)].sort();
+}
+
+/** The `unit` project's files: the include globs minus the `domTsTests` opt-outs. */
+export function unitProjectFiles(root, shape) {
+  const dom = new Set(shape.domTsTests);
+  return collectFiles(root, shape.include).filter((f) => !dom.has(f));
+}
+
+/**
+ * Every import specifier the file names — static `import`/`export ... from`
+ * and the dynamic `import('...')` form. Read off the AST, so the several
+ * fixture sources this repo embeds in template literals are not counted.
+ */
+export function readImportSpecifiers(sourceText, fileName = 'file.ts') {
+  const sf = parse(sourceText, fileName);
+  const out = [];
+  const visit = (node) => {
+    if ((ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) && node.moduleSpecifier
+        && ts.isStringLiteral(node.moduleSpecifier)) {
+      out.push(node.moduleSpecifier.text);
+    } else if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword
+        && node.arguments.length && ts.isStringLiteralLike(node.arguments[0])) {
+      out.push(node.arguments[0].text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return [...new Set(out)];
+}
+
+/** `const X = 'literal'` declarations in the file, for resolving key expressions. */
+function localStringConsts(sf) {
+  const consts = new Map();
+  const visit = (node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer
+        && ts.isStringLiteralLike(node.initializer)) {
+      consts.set(node.name.text, node.initializer.text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return consts;
+}
+
+/** Resolve a key expression to a literal string, or `null` when it is not static. */
+function resolveKeyExpression(node, consts) {
+  if (!node) return null;
+  if (ts.isStringLiteralLike(node)) return node.text;
+  if (ts.isIdentifier(node)) return consts.has(node.text) ? consts.get(node.text) : null;
+  if (ts.isTemplateExpression(node)) {
+    let out = node.head.text;
+    for (const span of node.templateSpans) {
+      const piece = resolveKeyExpression(span.expression, consts);
+      if (piece === null) return null;
+      out += piece + span.literal.text;
+    }
+    return out;
+  }
+  return null;
+}
+
+/** Does `node`'s subtree read the singleton, and with which key expression? */
+function findSingletonRead(node) {
+  let found = null;
+  const visit = (n) => {
+    if (found) return;
+    if (ts.isCallExpression(n) && ts.isPropertyAccessExpression(n.expression)
+        && ts.isIdentifier(n.expression.expression) && n.expression.expression.text === SINGLETON
+        && REGISTRY_READERS.has(n.expression.name.text)) {
+      found = { method: n.expression.name.text, keyExpr: n.arguments[0] ?? null };
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return found;
+}
+
+/**
+ * Registry-ABSENCE assertions in the file: `expect(<read of the singleton>)`
+ * followed by a matcher that asserts the subject is not there.
+ *
+ * Sites whose key is not statically resolvable are returned with `key: null`
+ * rather than dropped — `unit-registry-absence-collision.test.ts` floors them,
+ * so a new unresolvable one is a decision rather than a silent shrink in what
+ * the gate can see.
+ */
+export function readAbsenceAssertions(sourceText, fileName = 'file.ts') {
+  const sf = parse(sourceText, fileName);
+  const consts = localStringConsts(sf);
+  const sites = [];
+  const visit = (node) => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+      const matcher = node.expression.name.text;
+      const plainAbsence = ABSENCE_MATCHERS.has(matcher);
+      const negatable = NEGATED_PRESENCE_MATCHERS.has(matcher);
+      if (plainAbsence || negatable) {
+        // Walk the property-access chain back to its `expect(...)` root,
+        // remembering whether a `.not` inverted it on the way.
+        let cur = node.expression.expression;
+        let negated = false;
+        while (ts.isPropertyAccessExpression(cur)) {
+          if (cur.name.text === 'not') negated = !negated;
+          cur = cur.expression;
+        }
+        const isAbsence = negatable ? negated : !negated;
+        if (isAbsence && ts.isCallExpression(cur) && ts.isIdentifier(cur.expression)
+            && cur.expression.text === 'expect' && cur.arguments.length) {
+          const read = findSingletonRead(cur.arguments[0]);
+          if (read) {
+            sites.push({
+              key: resolveKeyExpression(read.keyExpr, consts),
+              method: read.method,
+              matcher: (negated ? 'not.' : '') + matcher,
+              line: lineOf(sf, node),
+              text: cur.arguments[0].getText(sf).replace(/\s+/g, ' ').slice(0, 120),
+            });
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return sites;
+}
+
+/**
+ * Keys the file itself writes into the singleton from a test body — the
+ * registrations no import-closure measurement can see, because they only
+ * happen when the test runs.
+ *
+ * `register(type, c, { namespace: n })` writes `n:type` AND the bare `type`
+ * fallback unless `skipFallback` is set (`Registry.register`), so both are
+ * reported.
+ */
+export function readOwnRegistrations(sourceText, fileName = 'file.ts') {
+  const sf = parse(sourceText, fileName);
+  const consts = localStringConsts(sf);
+  const keys = [];
+  const unresolved = [];
+  const visit = (node) => {
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)
+        && ts.isIdentifier(node.expression.expression) && node.expression.expression.text === SINGLETON
+        && (node.expression.name.text === 'register' || node.expression.name.text === 'registerLazy')) {
+      const type = resolveKeyExpression(node.arguments[0], consts);
+      if (type === null) {
+        unresolved.push({ line: lineOf(sf, node), text: node.getText(sf).replace(/\s+/g, ' ').slice(0, 100) });
+      } else {
+        const meta = node.arguments.find((a) => ts.isObjectLiteralExpression(a));
+        let namespace = null;
+        let skipFallback = false;
+        if (meta) {
+          for (const prop of meta.properties) {
+            if (!ts.isPropertyAssignment(prop) || !prop.name) continue;
+            const name = ts.isIdentifier(prop.name) || ts.isStringLiteralLike(prop.name) ? prop.name.text : null;
+            if (name === 'namespace') namespace = resolveKeyExpression(prop.initializer, consts);
+            if (name === 'skipFallback') skipFallback = prop.initializer.kind === ts.SyntaxKind.TrueKeyword;
+          }
+        }
+        if (namespace) {
+          keys.push(`${namespace}:${type}`);
+          if (!skipFallback) keys.push(type);
+        } else {
+          keys.push(type);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return { keys: [...new Set(keys)], unresolved };
+}
+
+/**
+ * The judgement, kept pure so it can be exercised on planted populations.
+ *
+ * `readers`: [{ file, keys }] — keys asserted ABSENT.
+ * `writers`: [{ file, keys }] — keys the file (or its closure) registers.
+ * A file colliding with ITSELF is not a finding: it is hermetic either way.
+ */
+export function findCollisions(readers, writers) {
+  const out = [];
+  for (const reader of readers) {
+    for (const key of reader.keys) {
+      for (const writer of writers) {
+        if (writer.file === reader.file) continue;
+        if (writer.keys.includes(key)) out.push({ key, reader: reader.file, writer: writer.file });
+      }
+    }
+  }
+  return out;
+}
+
+export function formatCollisions(collisions) {
+  return collisions
+    .map(
+      (c) =>
+        `  ${JSON.stringify(c.key)}\n` +
+        `      asserted ABSENT by: ${c.reader}\n` +
+        `      registered by:      ${c.writer}`,
+    )
+    .join('\n');
+}
+
+/**
+ * Floors for every population this gate derives. Each one is a population a
+ * silent zero would make GREEN — no readers, no keys, no modules imported —
+ * which is the failure mode the gate exists to refuse one level down, so it is
+ * refused here too. Move one deliberately, never to make a red run green.
+ */
+export const FLOORS = {
+  populationFiles: 500,
+  readerFiles: 1,
+  resolvedAbsentKeys: 2,
+  distinctSpecifiers: 200,
+  registeredKeys: 100,
+};
+
+/** Floors that were not met, as human-readable lines. Empty means non-vacuous. */
+export function checkFloors(counts, floors = FLOORS) {
+  const out = [];
+  for (const [name, floor] of Object.entries(floors)) {
+    const got = counts[name];
+    if (typeof got !== 'number') out.push(`${name}: NOT MEASURED (floor ${floor})`);
+    else if (got < floor) out.push(`${name}: found ${got}, floor is ${floor}`);
+  }
+  return out;
+}
+
+const MODULE_EXTENSIONS = ['.ts', '.tsx', '.mts', '.js', '.jsx', '.mjs', '.json', ''];
+
+/**
+ * Where an import specifier points. `workspace` ids are absolute paths this
+ * repo owns and MUST import; `bare` ids are package specifiers left to the
+ * resolver; `unresolved` is a relative specifier with no file behind it, which
+ * is reported rather than dropped.
+ */
+export function resolveSpecifier(root, fromFile, spec) {
+  if (!spec.startsWith('.')) return { kind: 'bare', id: spec };
+  const dir = path.dirname(path.join(root, fromFile));
+  const base = path.resolve(dir, spec.replace(/\.js$/, ''));
+  for (const ext of MODULE_EXTENSIONS) {
+    const candidate = base + ext;
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return { kind: 'workspace', id: candidate };
+  }
+  for (const ext of MODULE_EXTENSIONS) {
+    if (ext === '') continue;
+    const candidate = path.join(base, 'index' + ext);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) return { kind: 'workspace', id: candidate };
+  }
+  const asWritten = path.resolve(dir, spec);
+  if (fs.existsSync(asWritten) && fs.statSync(asWritten).isFile()) return { kind: 'workspace', id: asWritten };
+  return { kind: 'unresolved', id: spec };
+}

--- a/scripts/unit-registry-collision.mjs
+++ b/scripts/unit-registry-collision.mjs
@@ -12,7 +12,7 @@
  *
  * The project's justification comment used to state the opposite ("no
  * ComponentRegistry ... state to leak across files"). Measured on
- * `eb33a8d4c`: the union of the project's import closures registers 502 keys.
+ * `ec0a7b846`: the union of the project's import closures registers 505 keys.
  * The premise was false in both directions — the project holds files that
  * WRITE to the singleton and files that assert a key is ABSENT from it — and a
  * comment is the only thing a future author consults before adding either.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -192,8 +192,9 @@ export default defineConfig({
           // "node-env pure logic with no ComponentRegistry or DOM state to leak
           // across files". It was false in both directions and had been for
           // some time: this project holds files whose import closure REGISTERS
-          // into the `ComponentRegistry` singleton — measured, its 810 files
-          // import 600 distinct specifiers whose closures register 502 keys —
+          // into the `ComponentRegistry` singleton — measured over `ec0a7b846`,
+          // its 811 files import 551 distinct modules whose closures register
+          // 505 keys into it —
           // and files that assert a key is ABSENT from it. A shared graph makes
           // each visible to the other, so the constraint that actually has to
           // hold is:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -183,14 +183,48 @@ export default defineConfig({
         test: {
           name: 'unit',
           environment: 'node',
-          // The unit project is node-env pure logic with no ComponentRegistry
-          // or DOM state to leak across files, so it can share a module graph
-          // per worker instead of re-executing it per file. Measured 3.2x
-          // faster (38s -> 12s for the project) with zero failures, holding
-          // green across repeated and shuffled runs. The `dom`/`dom-heavy`
-          // projects keep `isolate: true` — they DO leak (registry overrides,
-          // happy-dom nodes); relaxing them needs the hermeticity fixes tracked
-          // separately.
+          // Share a module graph per worker instead of re-executing it per
+          // file. Measured 3.2x faster (38s -> 12s for the project) with zero
+          // failures, holding green across repeated and shuffled runs.
+          //
+          // What that buys is paid for by an INVARIANT, not by a property of
+          // the files (objectui#7134). The premise written here used to be
+          // "node-env pure logic with no ComponentRegistry or DOM state to leak
+          // across files". It was false in both directions and had been for
+          // some time: this project holds files whose import closure REGISTERS
+          // into the `ComponentRegistry` singleton — measured, its 810 files
+          // import 600 distinct specifiers whose closures register 502 keys —
+          // and files that assert a key is ABSENT from it. A shared graph makes
+          // each visible to the other, so the constraint that actually has to
+          // hold is:
+          //
+          //     a key one file asserts ABSENT from the ComponentRegistry must
+          //     be registered by no other file in this project.
+          //
+          // Nothing about a breach of it fails safe. The outcome is ORDER
+          // dependent — whether the absence assertion runs before or after the
+          // writer in its worker decides it — so a collision surfaces as a
+          // failure in a file that did nothing wrong, in some shards and not
+          // others, and says nothing about the code under test.
+          //
+          // So it is ENFORCED rather than left written down here, because this
+          // comment is the only thing a future author consults before adding a
+          // registering import to this project, and it had already gone false
+          // without anyone noticing:
+          //
+          //     scripts/__tests__/unit-registry-absence-collision.test.ts
+          //
+          // That gate derives both populations from this file's own `include`
+          // and `domTsTests` on every run and fails naming both files and the
+          // key. It EXECUTES the closures in a fresh module graph to learn what
+          // they register, because the writers' keys cannot be read off the
+          // source: the live field path registers from data (`registerAllFields()`
+          // walks a map), so `field:multiselect` exists at runtime and appears
+          // in no `register('field:multiselect')` call site anywhere.
+          //
+          // The `dom`/`dom-heavy` projects keep `isolate: true` — they DO leak
+          // in ways nothing checks (registry overrides, happy-dom nodes);
+          // relaxing them needs the hermeticity fixes tracked separately.
           isolate: false,
           setupFiles: [path.resolve(__dirname, 'vitest.setup.base.ts')],
           // `eslint-rules/**` holds the local ESLint plugin's RuleTester specs.


### PR DESCRIPTION
Fixes #7134

The `unit` project's `isolate: false` was justified by a premise that is false: "node-env pure logic with **no ComponentRegistry or DOM state to leak across files**". This PR replaces that justification with the constraint that actually has to hold, and ships the gate that enforces it.

## Both populations, re-derived on this branch

Derived from `vitest.config.mts` itself — the project's own `include` list minus its own `domTsTests` — so the population is the project, not a hand-copied guess. It reconciles exactly with what Vitest collects: **811 files**, against `Test Files 811 passed (811)` from the full run below.

**WRITERS — measured by EXECUTION, not by grep.** Fresh module graph (`vi.resetModules()`), import `@object-ui/core`, snapshot `ComponentRegistry.getAllTypes()`, import the project's import specifiers, diff. Over `ec0a7b846` the population's **551 distinct resolved modules register 505 keys** into the shared singleton, across 28 namespaces (`ui` 133, bare 215, `field` 47, `view` 14, `record` 13, `element` 10, ...).

Grep cannot answer this half, and that is why the gate executes. The live field path registers **from data** — `registerAllFields()` walks a map — so `field:multiselect` exists at runtime and appears in **no** `register('field:multiselect')` call site anywhere in the repo. A static reader would report "nothing registers it" and the gate would be green for the empty reason.

The one thing execution cannot see is a registration made in a test BODY (it happens when the test runs, not when it is imported). Those are read off the TypeScript AST: **1 file**, `packages/runner/src/plugin-integration.test.ts` (`test-kanban-manual`, `test-bar-chart-manual`). The AST matters here — a raw-text scan reported **12** such files, 11 of them registrations written inside fixture template literals, which are source to a regex and not registrations.

**READERS — files asserting a key ABSENT.** Also off the AST: an `expect(...)` whose argument reads the singleton, followed by a matcher that asserts the subject is not there (`toBeUndefined` / `toBeFalsy` / `toBeNull`, and `.not.toBeDefined` / `.not.toBeTruthy`), with template keys resolved through local string consts.

| Reader | Site | Key |
|---|---|---|
| `packages/fields/src/__tests__/capability-multiselect-retired.test.ts` | `:81` `toBeUndefined` | `field:capability-multiselect` |
| `packages/fields/src/__tests__/capability-multiselect-retired.test.ts` | `:82` `toBeUndefined` | `capability-multiselect` |
| `packages/app-shell/src/views/metadata-admin/previews/__tests__/exclusion-reason-truthfulness.test.ts` | `:222` `toBeFalsy` | UNRESOLVED — `ComponentRegistry.get(type)`, a key set derived at runtime from `PALETTE_EXCLUSIONS` |

**2 readers, 2 statically resolved keys, 1 unresolvable site.** The unresolvable one is reported and PINNED rather than dropped: a new one fails the gate, so a place it goes blind is a decision instead of a silent shrink.

The seat's grep found 7 candidate files. Five are not readers of this singleton: `app-generator.test.ts` mentions it only in a comment, `component-deprecation-declaration.test.ts` and `report-bare-key-ownership.test.ts` assert over a LOCAL `Registry` instance, `plugin-editor/index.test.ts`'s absence matchers are about `readOnly` defaults, and `timeline-bare-key-ownership.test.ts` asserts a meta FLAG (`getMeta(...)?.skipFallback`), not key absence.

**Latent, not live — confirmed.** Neither `field:capability-multiselect` nor `capability-multiselect` is among the 505 registered keys, and neither is written by the one in-body writer. The absence assertion is also non-vacuous under the shared graph: the live path registers **47** `field:*` keys, including `field:multiselect` and the `field:owner` tombstone, with the retired one absent.

### One correction to the card

The card reads the hazard as a silent green ("if some other file registers that key first, this one goes green while proving nothing"). Measured, `toBeUndefined()` goes **red** when the key is registered — the ablation below shows exactly that. The defect is not a direction, it is ORDER DEPENDENCE: which of the two files the worker ran first decides the outcome, and neither outcome is information about the code under test. The invariant, and the fix, are unchanged.

## The gate: chosen shape, and the one rejected

**Chosen (A): a collision gate.** `scripts/__tests__/unit-registry-absence-collision.test.ts` computes both populations on every run and fails when a key asserted absent by one file is registered by another, naming both files and the key. It satisfies the dispatch's criterion (i) literally: it goes red on a planted collision.

**Rejected (B): an isolation-proof pattern plus a style gate** (every absence assertion resets the module graph and re-imports only its own subject; a gate fails when one does not). Rejected for three measured reasons, not for taste:

1. It does **not** go red on a planted collision — it is a gate about a PATTERN, so it cannot satisfy criterion (i). It answers "is this file written the approved way", not "is the invariant true".
2. Its cost is not the one that matters. Static, so ~0 s — but it buys that by requiring a rewrite of the two readers, and one of them (`exclusion-reason-truthfulness.test.ts`) deliberately imports six renderer leaves instead of the package barrel because the barrel costs 6105 ms against 553 ms (its own measurement, #7117). Making its dynamic-key absence loop hermetic means re-importing ten specifiers after each reset.
3. A style gate is satisfiable vacuously: the pattern present but pointed at the wrong module still passes.

**And (A) turned out to be nearly free**, which is the measurement that decided it. Its cold standalone cost is ~43 s, but the modules it loads are overwhelmingly the ones the project it measures already loads into the same worker under `isolate: false`. Full-project wall clock: **173.52 s before, 182.16 s after — +8.6 s, about +5%** (shared-box seconds; four sibling agents build in this container, so this is an upper-ish bound).

Moving registry-touching files out of the shared-graph project — the dispatch's fallback — was not needed and is not done: the gate is non-vacuous, so the 3.2x is kept on every file.

### Why the gate does not pollute the project it measures

It runs inside the very project it is about, so its own imports would otherwise be the single largest registry write in it. `vi.resetModules()` before the measurement gives it a **private** module graph — a fresh `@object-ui/core`, therefore a fresh singleton, not the one its worker's other files hold — and this is asserted, not assumed (`startedEmpty`). A second reset afterwards drops that graph so files running later re-import their own. Evidence it works: the full project is green with the gate in it, all 811 files.

Attribution runs only on the red path, and only over the specifiers **some other file** imports — a file that registers what it then asserts absent is hermetic, not a collision, and reporting one would be a false red.

## The corrected comment

`vitest.config.mts`, the `unit` project. The perf measurement is kept (it is still true); the false premise is replaced by the invariant, the order-dependence is named, and the justification points at where the constraint is enforced:

    // Share a module graph per worker instead of re-executing it per
    // file. Measured 3.2x faster (38s -> 12s for the project) with zero
    // failures, holding green across repeated and shuffled runs.
    //
    // What that buys is paid for by an INVARIANT, not by a property of
    // the files (objectui#7134). The premise written here used to be
    // "node-env pure logic with no ComponentRegistry or DOM state to leak
    // across files". It was false in both directions and had been for
    // some time: this project holds files whose import closure REGISTERS
    // into the `ComponentRegistry` singleton - measured over `ec0a7b846`,
    // its 811 files import 551 distinct modules whose closures register
    // 505 keys into it - and files that assert a key is ABSENT from it. A
    // shared graph makes each visible to the other, so the constraint that
    // actually has to hold is:
    //
    //     a key one file asserts ABSENT from the ComponentRegistry must
    //     be registered by no other file in this project.
    //
    // Nothing about a breach of it fails safe. The outcome is ORDER
    // dependent - whether the absence assertion runs before or after the
    // writer in its worker decides it - so a collision surfaces as a
    // failure in a file that did nothing wrong, in some shards and not
    // others, and says nothing about the code under test.
    //
    // So it is ENFORCED rather than left written down here, because this
    // comment is the only thing a future author consults before adding a
    // registering import to this project, and it had already gone false
    // without anyone noticing:
    //
    //     scripts/__tests__/unit-registry-absence-collision.test.ts
    //
    // [...] It EXECUTES the closures in a fresh module graph to learn what
    // they register, because the writers' keys cannot be read off the
    // source [...]

`isolate` itself is untouched. The gate asserts that this comment still names it, so the justification and its enforcement cannot drift apart silently.

## Ablation

Every mutation is proven ON DISK by marker count **and** `git hash-object` before the run; every restore is proven by blob hash equal to the HEAD blob, marker count back to 0, and an empty `git diff HEAD` — never by an exit code. Each leg carries a `trap ... EXIT INT TERM` restoring by ABSOLUTE path.

| # | Planted | Proof it landed | Gate | What it named |
|---|---|---|---|---|
| A1 | `'capability-multiselect'` added to `RETIRED_FIELD_TYPES` in `packages/core/src/utils/retired-field-types.ts` — a DATA-driven registration, invisible to any static reader | marker 0 to 1; blob `bb80173b` to `e9d313de` | **RED**, exit 1 (1 failed / 14 passed) | key `"field:capability-multiselect"`, asserted absent by `capability-multiselect-retired.test.ts`, registered by `packages/app-shell/src/__tests__/spec-symbol-parity.test.ts` (via `packages/app-shell/src/views/ScreenView.tsx`) |
| A2 | `ComponentRegistry.register('capability-multiselect', ...)` in the body of `packages/runner/src/plugin-integration.test.ts` | marker 0 to 1; blob `3273700b` to `b70843a5` | **RED**, exit 1 (1 failed / 14 passed) | key `"capability-multiselect"`, asserted absent by `capability-multiselect-retired.test.ts`, registered by `packages/runner/src/plugin-integration.test.ts` |
| A3 | non-vacuity control: `collectFiles` forced to return `[]` in `scripts/unit-registry-collision.mjs` | marker 0 to 1; blob `0dbb587b` to `ed0c4f98` | **RED**, exit 1 (2 failed / 13 passed) | `a population COLLAPSED - this run proves nothing:` with all five census counts at 0 |

Restores: A1 `bb80173b` = HEAD blob; A2 `3273700b` = HEAD blob; A3 `0dbb587b` = HEAD blob, `git diff HEAD` **0 bytes**, `git status --porcelain` empty.

A1 is the leg that proves the EXECUTION half is load-bearing: the planted key is registered from a frozen data table, so a grep-based gate would have stayed green on it. A3 is the gate's own control — an empty population must FAIL, not pass — and the file also carries the pure-function form of it (`checkFloors({})` reports `NOT MEASURED`, never zero).

The gate additionally carries fixture controls for its readers: a registration written inside a template literal is NOT counted as a registration, `.not.toBeDefined()` counts as absence while plain `.toBeDefined()` does not, a dynamic registration key is reported rather than dropped, and `register(type, C, { namespace: n })` yields both `n:type` and the bare fallback (only `n:type` under `skipFallback`), matching `Registry.register`.

One honest property of the red message: attribution bisects for **a** specifier whose closure registers the key, so in A1 it named `ScreenView.tsx` rather than the more obvious `@object-ui/fields`. Both statements are true; the message names a file and a module an author can act on, which is what it is for.

## Verification

Full unit project, from the repo root, both runs under the shared verify lock (`os-verify-lock`, VERDICT `command-exit 0` for each):

The controlled pair — same tree, with and without this gate:

| | Summary line | Duration |
|---|---|---|
| before, `eb33a8d4c` (no gate) | `Test Files 810 passed (810)` / `Tests 12610 passed \| 9 skipped (12619)` | 173.52 s |
| after, `e41a20cc8` (gate in) | `Test Files 811 passed (811)` / `Tests 12625 passed \| 9 skipped (12634)` | 182.16 s |

The delta is +1 file and +15 tests, which is exactly this gate, and +8.6 s of wall clock.

And the final head, after merging `origin/main` at `9bf0abfec` — not a controlled comparison, since the sibling work merged in brings its own tests:

| | Summary line | Duration |
|---|---|---|
| final, `6044abb9f` | `Test Files 811 passed (811)` / `Tests 12652 passed \| 9 skipped (12661)` | 177.99 s |

Gates, re-run on the final head `6044abb9f`; every exit code captured by redirect-then-`$?`, never through a pipe:

| Gate | Verdict |
|---|---|
| `pnpm exec vitest run --project unit --maxWorkers=2` (under the lock, at `6044abb9f`) | VERDICT `command-exit 0` — `Test Files 811 passed (811)` |
| `pnpm exec vitest run --project unit ... unit-registry-absence-collision.test.ts` | exit 0 — `Test Files 1 passed (1)` / `Tests 15 passed (15)` |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm check:control-bytes` | exit 0 — *"OK (scanned 6010 tracked text file(s); skipped 85 binary)"* |
| `pnpm check:entry-guard` | exit 0 — *"59 scripts/ file(s) — no entry guard outside the baseline"* |
| `node scripts/check-changeset-presence.mjs` | exit 0 — *"No source or published contract of a released package changed in this range, so no changeset is owed."* |
| `eslint --no-inline-config --format json` on the changed files | exit 0 — 0 errors |

`type-check:scripts` was red on the first attempt (`TS2307: Cannot find module '@object-ui/core'` — `tsconfig.scripts.json` has no path mapping into the workspace packages) and is fixed in the gate rather than in the tsconfig: `@object-ui/core` is imported by computed specifier, like every other import in that file. Changing the scripts tsconfig to type one line would have put every `scripts/` file on a different module resolution than the one CI type-checks them with.

**Declared narrowing.** The repo-wide `pnpm lint` is CI's run; the lint here is narrowed to the diff, and the narrowing is measured rather than asserted: (1) the population comes from ESLint's own configuration, which reports `vitest.config.mts` as *"File ignored because no matching configuration was supplied"* — it is outside the configured population, not skipped by me; (2) the count comes from `--format json`: 3 paths requested, 2 linted, 0 errors, 1 warning (that ignore notice); (3) `eslint.config.js` contains **0** occurrences of `projectService` / `parserOptions` / `project:` — type-aware linting is not enabled, so this diff cannot move the verdict on any untouched file.

**Changeset:** none owed, and the gate says so in its own words (quoted above). No package's published source or contract changed — the diff is one config comment plus two new files under `scripts/`. No `skip-changeset` label: in this repo that label is inert.

## Serial constraint (#7291 / #7183)

`origin/main` is merged (`9bf0abfec`, no conflict; the final head is `6044abb9f`). PR #7291 appends a `dist` project and two constants to the same file and had **not** landed within the dispatch's 20-minute poll budget (14 polls of `git ls-remote origin refs/heads/main` from 05:03Z to 05:22Z; main moved once, to #7294, which is docs-only). It is still an open DRAFT, `mergeable_state: behind`. Its hunks and this one are disjoint (its constants sit above `defineConfig`, its project appends to the end of `projects`; this change is inside the `unit` project block), and that was verified rather than assumed: `git merge-tree --write-tree` against its head `857c8afc5` produced a **clean tree, exit 0**, and this gate's config reader parses that merged config correctly (`isolateFalse: true`, the same four `include` globs, the same 18 `domTsTests`, and both changes present). No hunk of another PR was resolved by hand.

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b)_