### PR TITLE
test(console): take the app-shell barrel out of three vi.mock factories (#6580)

### DIFF
--- a/.changeset/six-donkeys-shake.md
+++ b/.changeset/six-donkeys-shake.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only change to three `apps/console` test files: the `vi.mock('@object-ui/app-shell', …)`
+factories no longer call `importOriginal()`, which was transforming the whole source-aliased
+barrel graph (measured 10019 ms per file) to reach a handful of real exports. They now spread
+only the app-shell submodules those exports live in. No published behaviour changes.

--- a/apps/console/src/components/FormPage.predicateScope.test.tsx
+++ b/apps/console/src/components/FormPage.predicateScope.test.tsx
@@ -73,14 +73,16 @@ import { FormPage } from './FormPage';
  *
  * This module's graph is the first VALUE request for `@object-ui/app-shell` in
  * the file (`FormPage` only `import type`s it), so it is what runs the
- * `vi.mock('@object-ui/app-shell')` factory's `importOriginal()` below — and
- * that specifier is aliased to `packages/app-shell/src`
- * (`apps/console/vite.config.ts`), a barrel carrying eight side-effect imports,
- * transformed on demand. Measured on an IDLE machine it cost **10204ms** of
- * `hop1SessionPrincipal`'s 15000ms budget; the render and the assertions cost
- * ~12ms, the same as the seven cases above. Nothing was wrong with the test —
- * it was racing the module loader, and lost whenever the transform pipeline was
- * saturated by a full-project run.
+ * `vi.mock('@object-ui/app-shell')` factory below — and that specifier is
+ * aliased to `packages/app-shell/src` (`apps/console/vite.config.ts`), a barrel
+ * carrying thirteen side-effect imports, transformed on demand. While that
+ * factory still called `importOriginal()` the load cost **10204ms** of
+ * `hop1SessionPrincipal`'s 15000ms budget on an IDLE machine, against ~12ms for
+ * the render and the assertions. Nothing was wrong with the test — it was
+ * racing the module loader, and lost whenever the transform pipeline was
+ * saturated by a full-project run. objectui#6580 took the barrel out of the
+ * factory; the module-scope import below is what keeps the remaining load out
+ * of a bounded window.
  *
  * Module scope moves that cost into the IMPORT phase, which no test or hook
  * timeout bounds. `beforeAll` would not do: it is bounded by `hookTimeout`
@@ -342,10 +344,23 @@ describe('#6110 controls — green before AND after the fix, by construction', (
  * `vi.mock` calls are hoisted above every import in the file, so the factories
  * are registered before that import executes.
  */
-vi.mock('@object-ui/app-shell', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
+// The barrel is aliased to `packages/app-shell/src`, so an `importOriginal()`
+// on it transforms that whole graph on demand — 10204ms when objectui#6567
+// instrumented it, 10019ms re-measured for objectui#6580. The three submodules
+// below carry every name this file's graph reads from the barrel and cost a few
+// ms together: `ExpressionProvider`, `buildExpressionUser` (`expressionUser`)
+// and `resolveHostAppSegment` (`utils/`).
+vi.mock('@object-ui/app-shell', async () => {
   return {
-    ...actual,
+    ...(await vi.importActual<Record<string, unknown>>(
+      '../../../../packages/app-shell/src/providers/ExpressionProvider'
+    )),
+    ...(await vi.importActual<Record<string, unknown>>(
+      '../../../../packages/app-shell/src/providers/expressionUser'
+    )),
+    ...(await vi.importActual<Record<string, unknown>>(
+      '../../../../packages/app-shell/src/utils/index'
+    )),
     useMetadata: () => ({ apps: [] }),
     useNavigationContext: () => ({ currentAppName: undefined }),
     DefaultHomeLayout: ({ children }: { children?: unknown }) => children as never,

--- a/apps/console/src/components/SetupRoute.test.tsx
+++ b/apps/console/src/components/SetupRoute.test.tsx
@@ -68,8 +68,26 @@ vi.mock('../../../../packages/app-shell/src/providers/MetadataProvider', async (
   useMetadata: () => ({ apps, objects: [], loading: false, error: null, refresh: async () => {} }),
 }));
 
-vi.mock('@object-ui/app-shell', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
+// `@object-ui/app-shell` is aliased to `packages/app-shell/src`
+// (`apps/console/vite.config.ts`), so an `importOriginal()` on it transforms the
+// whole barrel graph on demand — measured on this tree at **10019ms**
+// (objectui#6580). The three submodules below carry every name this file's graph
+// reads from the barrel and cost ~2.0s together: `chrome/` has
+// `RedirectWithSplash`, `console/ConsoleShell` has `SetupRedirect`,
+// `SETUP_APP_PACKAGE_ID` and `SETUP_APP_NAME`.
+vi.mock('@object-ui/app-shell', async () => ({
+  ...(await vi.importActual<Record<string, unknown>>(
+    '../../../../packages/app-shell/src/chrome/index'
+  )),
+  ...(await vi.importActual<Record<string, unknown>>(
+    '../../../../packages/app-shell/src/console/ConsoleShell'
+  )),
+  // `RootLandingRedirect` reads `useMetadata` through the BARREL, so the
+  // provider mock above — which only reaches importers of the provider module
+  // itself — does not cover it. The whole-barrel spread this factory used to do
+  // covered it by re-exporting the already-mocked provider; spelling the same
+  // stub out here keeps that, and is why the two must stay in step.
+  useMetadata: () => ({ apps, objects: [], loading: false, error: null, refresh: async () => {} }),
   // Pass-through: the provider stack is not what decides this question.
   ConnectedShell: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   RequireOrganization: ({ children }: { children?: React.ReactNode }) => <>{children}</>,

--- a/apps/console/src/components/StudioRoute.test.tsx
+++ b/apps/console/src/components/StudioRoute.test.tsx
@@ -90,8 +90,18 @@ vi.mock('../../../../packages/auth/src/useAuth', async (importOriginal) => ({
 const builderLanding = vi.fn();
 const designSurface = vi.fn();
 
-vi.mock('@object-ui/app-shell', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
+// `@object-ui/app-shell` is aliased to `packages/app-shell/src`
+// (`apps/console/vite.config.ts`), so an `importOriginal()` on it transforms the
+// whole barrel graph on demand: measured on this tree at **10019ms**, against
+// 237ms for `@object-ui/auth` in this same file (objectui#6580). Every name this
+// file's graph reads from the barrel is either overridden below or lives in
+// `chrome/`, so the factory pulls that ONE submodule (**549ms**) instead.
+// `RedirectWithSplash` is the only real export left standing: `ProtectedRoute`
+// renders it for the unauthenticated case, which this file asserts.
+vi.mock('@object-ui/app-shell', async () => ({
+  ...(await vi.importActual<Record<string, unknown>>(
+    '../../../../packages/app-shell/src/chrome/index'
+  )),
   // Pass-through: the provider stack is not what decides this question.
   ConnectedShell: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
   RequireOrganization: ({ children }: { children?: React.ReactNode }) => <>{children}</>,


### PR DESCRIPTION
Fixes #6580

## 1. Measurement first — the population is 3, not 12

The card was explicit that 12 was a path-intersection **upper bound**, because a file
lands in it if it mocks `@object-ui/app-shell` **and** uses `importOriginal` anywhere.
Attributing each `importOriginal` call to the factory it actually sits in (paren-balanced
scan over every `vi.mock` call, then confirmed by reading the three survivors):

Ripgrep over `apps/console` finds **22** files mocking the package — one more than the
card's GitHub code-search figure of 21, so the index was indeed lagging.

| file | `importOriginal` belongs to | affected |
| --- | --- | --- |
| `components/FormPage.predicateScope.test.tsx` | **`@object-ui/app-shell`**, `@object-ui/auth` | **YES** |
| `components/SetupRoute.test.tsx` | **`@object-ui/app-shell`**, `@object-ui/auth`, `packages/auth/src/useAuth`, `packages/app-shell/src/providers/MetadataProvider` | **YES** |
| `components/StudioRoute.test.tsx` | **`@object-ui/app-shell`**, `@object-ui/auth`, `packages/auth/src/useAuth` | **YES** |
| `pages/system/ApprovalsInboxPage.cellIdentity.test.tsx` | `../../services/approvalsApi` | no |
| `pages/system/ApprovalsInboxPage.characterizationPins.test.tsx` | `../../services/approvalsApi` | no |
| `pages/system/ApprovalsInboxPage.hiddenFieldTrim.test.tsx` | `../../services/approvalsApi` | no |
| `pages/system/ApprovalsInboxPage.queueHiddenAmount.test.tsx` | `../../services/approvalsApi` | no |
| `pages/system/ApprovalsInboxPage.rawPayloadGate.test.tsx` | `../../services/approvalsApi` | no |
| `pages/system/ApprovalsInboxPage.recordLink.test.tsx` | `../../services/approvalsApi` | no |
| `pages/system/ApprovalsInboxPage.stepProgressVertical.test.tsx` | `../../services/approvalsApi` | no |
| `pages/system/__tests__/AppManagementPage.i18n.test.tsx` | `@object-ui/i18n` | no |
| `pages/system/__tests__/AppManagementPage.mutations.test.tsx` | `@object-ui/i18n` | no |
| `pages/system/__tests__/AppManagementPage.search.test.tsx` | `@object-ui/i18n` | no |
| the remaining 9 files | no `importOriginal` at all | no |

**N = 3.** The card's own caveat was right: nine of the twelve candidates carry an
`importOriginal` that belongs to `approvalsApi` or `@object-ui/i18n`, not to the barrel.

## 2. Cost, re-measured on this tree

`performance.now()` around the call, in a throwaway probe file that was deleted before
the commit (a `vi.hoisted` holder carries the number out of the hoisted factory):

```
PROBE6580 app-shell=10019ms auth=237ms
```

That reproduces the card's 10204ms / 240ms independently. Two of the card's structural
numbers have grown since it was filed and are corrected here: the barrel is **447 lines**
carrying **13** bare side-effect imports, not 385 and 8.

## 3. Which lever, and why the other two are not it

**(a) alias the test build to built output — not viable.** `.github/workflows/ci.yml`
runs `pnpm install --frozen-lockfile` and then `pnpm test --shard=N/4` with **no build
step**, and `packages/app-shell/dist` does not exist at test time. The alias table in
`apps/console/vite.config.ts` points every `@object-ui/*` entry at source, so this would
also be a single inconsistent entry.

**(b) trim the barrel's side-effect imports — stopped, per the dispatch ruling.** Those
13 imports are registration side effects of the published package; removing or deferring
them changes what a consumer gets from importing the barrel. Making only the test alias
avoid them requires a second entry point, which is lever (a) wearing a different hat.
Not landed here.

**(c) drop `importOriginal` for this package in the factories — chosen.** Confined to the
three test files, no published surface touched.

What decided it: each submodule these factories actually need was timed individually, and
then the barrel was timed **after** all of them were already loaded.

| module | cold cost |
| --- | --- |
| `chrome/index` | 549 ms |
| `console/ConsoleShell` | 1477 ms |
| `providers/ExpressionProvider` | 0 ms |
| `providers/expressionUser` | 4 ms |
| `utils/index` | 0 ms |
| `providers/MetadataProvider` | 0 ms |
| **the barrel, with all six already loaded** | **7828 ms** |

So ~7.8 s of the ~10 s is graph these three files never touch. The factories now spread
the submodules the real exports live in.

## 4. Why this is not fragile — a static coverage proof

Dropping the whole-barrel spread risks a name silently becoming `undefined` on a path no
test exercises. So the covering set was derived **statically**, over the full transitive
module graph of each test file (~1237 modules once NodeNext `.js` specifiers resolve to
their TypeScript sources), not from the paths the tests happen to run. Every name any
module in the graph imports from `@object-ui/app-shell` must be an override, a type-only
barrel export, or an export of a spread submodule:

| file | union of names read from the barrel | uncovered |
| --- | --- | --- |
| `SetupRoute.test.tsx` | ConnectedShell, LoadingFallback, MetadataTypeStatus, RedirectWithSplash, RequireOrganization, SETUP_APP_NAME, SETUP_APP_PACKAGE_ID, SetupRedirect, useMetadata | **0** |
| `StudioRoute.test.tsx` | BuilderLanding, ConnectedShell, LoadingFallback, LoadingScreen, RedirectWithSplash, RequireOrganization, StudioDesignSurface, getProductName | **0** |
| `FormPage.predicateScope.test.tsx` | DefaultHomeLayout, ExpressionProvider, FormFieldSpec, FormSectionSpec, FormViewSpec, buildExpressionUser, resolveHostAppSegment, useMetadata, useNavigationContext | **0** |

The same scan confirms no module inside any workspace package imports the barrel by its
package name, so the consumer set is exactly those console files.

One subtlety worth flagging for review: `SetupRoute.test.tsx` mocks
`packages/app-shell/src/providers/MetadataProvider` separately, but `RootLandingRedirect`
reads `useMetadata` through the **barrel**. The old whole-barrel spread covered that by
re-exporting the already-mocked provider. The replacement spells the same stub out in the
app-shell factory rather than importing the provider module, so console's tsc program
gains no new cross-package source edge; the comment there says the two must stay in step.

## 5. Before / after

Same three files, same flags, same command, from the repo root:

```
pnpm exec vitest run --project @object-ui/console --no-file-parallelism --reporter=verbose \
  apps/console/src/components/SetupRoute.test.tsx \
  apps/console/src/components/StudioRoute.test.tsx \
  apps/console/src/components/FormPage.predicateScope.test.tsx
```

| | before | after |
| --- | --- | --- |
| **import** | **13.07 s** | **2.64 s** |
| transform | 17.09 s | 11.27 s |
| tests | 560 ms | 473 ms |
| total duration | 40.21 s | 30.52 s |
| result | 3 files / 37 tests passed | 3 files / 37 tests passed |

These are shared-box seconds — the runs went through the shared verification lock, which
excludes other locked runs but not unlocked sibling work, so read the ratio (import phase
down ~5x) rather than the absolutes.

## 6. Verification

All from the repo root of the task worktree, exit codes captured before any pipe.

- tests, final tree: `Test Files 3 passed (3)` / `Tests 37 passed (37)`, lock `VERDICT command-exit 0`
- `pnpm --filter @object-ui/console run type-check` -> exit **0**, 0 `error TS`. Run after
  `pnpm --workspace-concurrency=4 --filter "@object-ui/console^..." run build` so the
  dependency closure was real; `tsc --noEmit --listFiles` confirms all three edited files
  are in the program (1 hit each), so "type-check clean" actually covers them.
- `pnpm exec eslint` on the three changed files -> exit **0**. One pre-existing
  `no-explicit-any` warning at line 188 of `FormPage.predicateScope.test.tsx`, outside
  every hunk in this diff.
- `pnpm check:control-bytes` -> exit **0**, `scanned 6009 tracked text file(s)`.
- `node scripts/check-changeset-presence.mjs` -> exit **0**: "Every one of them has an
  EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption".
  `pnpm changeset:check` -> exit **0**.
- `pnpm lint:coverage` -> exit **0** (46/46). `pnpm type-check:coverage` -> exit **0**.

Not run locally, left to CI: the full `apps/console` project and the repo-wide lint farm.
This is a declared narrowing — the diff is three test files plus an empty-frontmatter
changeset, and CI runs the farm exactly once regardless.

## 7. Not touched

`apps/console/vitest.config.ts`, root `vitest.config.mts` and root `vitest.setup.*` are
owned by in-flight PRs #7291 and #7304. No timeout was raised, nothing was added to
`heavyDomTests`, and nothing was skipped or quarantined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b)_