### PR TITLE
docs(data-objectstack,plugin-form,plugin-view): clear three package READMEs off the doc-snippet ledger (#5174 batch 8)

### DIFF
--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -23,6 +23,9 @@ npm install @object-ui/data-objectstack
 ```typescript
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 import { SchemaRenderer } from '@object-ui/react';
+import type { ComponentSchema } from '@object-ui/types';
+
+declare const mySchema: ComponentSchema;
 
 // 1. Create the adapter
 const dataSource = createObjectStackAdapter({
@@ -44,6 +47,8 @@ function App() {
 ### Advanced Configuration
 
 ```typescript
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+
 const dataSource = createObjectStackAdapter({
   baseUrl: 'https://api.example.com',
   token: 'your-api-token',
@@ -78,6 +83,10 @@ ObjectStack's native query format, so a schema never has to be written in the
 protocol's own shape:
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // Query with filters (MongoDB-like operators)
 const result = await dataSource.find('tasks', {
   $filter: {
@@ -92,7 +101,7 @@ const result = await dataSource.find('tasks', {
 // Escape hatch: reach the underlying ObjectStack client for anything
 // the DataSource interface does not cover
 const client = dataSource.getClient();
-const metadata = await client.meta.getObject('task');
+const metadata = await client.meta.getItem('object', 'task');
 ```
 
 ### Query Parameter Mapping
@@ -186,6 +195,10 @@ array that the spec's own `isFilterAST` gate rejects is refused here rather
 than shipped:
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // ✅ lowered — reaches the wire unchanged
 await dataSource.aggregate('opportunity', {
   groupBy: ['stage'],
@@ -215,6 +228,10 @@ declares), and an empty array (`[]` means "no filter").
 ### Sorting
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // OData-style
 await dataSource.find('users', {
   $orderby: {
@@ -231,6 +248,10 @@ await dataSource.find('users', {
 The adapter includes built-in metadata caching to improve performance when fetching schemas:
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // Get cache statistics
 const stats = dataSource.getCacheStats();
 console.log(`Cache hit rate: ${stats.hitRate * 100}%`);
@@ -257,6 +278,10 @@ dataSource.clearCache();
 The adapter provides real-time connection state monitoring with automatic reconnection:
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // Monitor connection state changes
 const unsubscribe = dataSource.onConnectionStateChange((event) => {
   console.log('Connection state:', event.state);
@@ -301,6 +326,12 @@ The adapter automatically attempts to reconnect on connection failures:
 Track progress of bulk operations in real-time:
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
+declare const largeDataset: Array<Record<string, unknown>>;
+
 // Monitor batch operation progress
 const unsubscribe = dataSource.onBatchProgress((event) => {
   console.log(`${event.operation}: ${event.percentage.toFixed(1)}%`);
@@ -358,24 +389,36 @@ import {
 ### Error Handling Example
 
 ```typescript
+import {
+  ObjectStackError,
+  MetadataNotFoundError,
+  ConnectionError,
+  AuthenticationError,
+  type ObjectStackAdapter,
+} from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 try {
   const schema = await dataSource.getObjectSchema('users');
 } catch (error) {
   if (error instanceof MetadataNotFoundError) {
-    console.error(`Schema not found: ${error.details.objectName}`);
+    console.error(`Schema not found: ${error.details?.objectName}`);
   } else if (error instanceof ConnectionError) {
     console.error(`Connection failed to: ${error.url}`);
   } else if (error instanceof AuthenticationError) {
     console.error('Authentication required');
   }
-  
-  // All errors have consistent structure
-  console.error({
-    code: error.code,
-    message: error.message,
-    statusCode: error.statusCode,
-    details: error.details
-  });
+
+  // Every error this adapter throws carries the same shape
+  if (error instanceof ObjectStackError) {
+    console.error({
+      code: error.code,
+      message: error.message,
+      statusCode: error.statusCode,
+      details: error.details,
+    });
+  }
 }
 ```
 
@@ -384,6 +427,12 @@ try {
 Bulk operations provide detailed error reporting with partial success information:
 
 ```typescript
+import { BulkOperationError, type ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
+declare const records: Array<Record<string, unknown>>;
+
 try {
   await dataSource.bulk('users', 'update', records);
 } catch (error) {
@@ -420,6 +469,10 @@ All errors include unique error codes for programmatic handling:
 The adapter supports optimized batch operations with automatic fallback:
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // Batch create
 const newUsers = await dataSource.bulk('users', 'create', [
   { name: 'Alice', email: 'alice@example.com' },
@@ -453,6 +506,10 @@ writes as a single all-or-nothing unit — the master-detail case, where a paren
 and its children must commit or roll back together — use `batchTransaction`:
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // Create a parent and a child that references it, atomically.
 // `{ $ref: 0 }` resolves to the id minted by operation 0 (the parent).
 await dataSource.batchTransaction([
@@ -515,8 +572,11 @@ In addition to the main `DataSource` adapter, this package ships
 persist per-user UI state (favorites, recent items) into ObjectStack.
 
 ```typescript
-import { createObjectStackUserStateAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackUserStateAdapter, type ObjectStackAdapter } from '@object-ui/data-objectstack';
 import { useAttachUserStateAdapters } from '@object-ui/app-shell';
+
+declare const dataSource: ObjectStackAdapter;
+declare const user: { id: string };
 
 const favoritesAdapter = createObjectStackUserStateAdapter({
   dataSource,             // the ObjectStack DataSource
@@ -525,6 +585,8 @@ const favoritesAdapter = createObjectStackUserStateAdapter({
   // resource: 'sys_user_preference',  // default — the unified per-user KV store
   // onError: (op, err) => console.warn(`[user-state] ${op} failed`, err),
 });
+
+const attach = useAttachUserStateAdapters();
 
 attach('favorites', favoritesAdapter);
 ```
@@ -559,6 +621,8 @@ for the full design.
 ### ObjectStackAdapter
 
 #### Constructor
+
+<!-- doc-snippet: fragment — the constructor SIGNATURE in prose notation, not a statement: `new ObjectStackAdapter(config: { ... })` names the parameter type where a call would carry a value. Measured TS1005x10. -->
 
 ```typescript
 new ObjectStackAdapter(config: {
@@ -613,6 +677,10 @@ new ObjectStackAdapter(config: {
 #### Schema Not Found
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // Error: MetadataNotFoundError
 // Solution: Verify object name and ensure schema exists on server
 const schema = await dataSource.getObjectSchema('correct_object_name');
@@ -621,6 +689,8 @@ const schema = await dataSource.getObjectSchema('correct_object_name');
 #### Connection Errors
 
 ```typescript
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+
 // Error: ConnectionError
 // Solution: Check baseUrl and network connectivity
 const dataSource = createObjectStackAdapter({
@@ -632,6 +702,10 @@ const dataSource = createObjectStackAdapter({
 #### Cache Issues
 
 ```typescript
+import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+
+declare const dataSource: ObjectStackAdapter;
+
 // Clear cache if stale data is being returned
 dataSource.clearCache();
 

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -44,6 +44,16 @@ function App() {
 }
 ```
 
+> **Reaching the adapter-only API from TypeScript.** `createObjectStackAdapter`
+> declares `DataSource` as its return type, so the members below that belong to the
+> adapter rather than to every data source — `getClient`, the cache methods, the
+> connection-state and batch-progress subscriptions — are not on the type the factory
+> hands back, even though they are on the object it hands back. Until
+> [#7323](https://github.com/objectstack-ai/objectui/issues/7323) is settled, hold the
+> adapter as `ObjectStackAdapter` (the exported class, whose constructor is documented
+> under **API Reference** below) wherever you use those members; the examples in this
+> README do exactly that.
+
 ### Advanced Configuration
 
 ```typescript

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -294,6 +294,8 @@ field.
 A field may declare both, and it is coherent authoring — storage-level required,
 with the value guaranteed by the producer:
 
+<!-- doc-snippet: fragment — one object-literal PROPERTY quoted out of a field map — `remind_at: Field.datetime(...)` is a key/value pair, not a statement. Measured TS1109x1. -->
+
 ```ts
 remind_at: Field.datetime({ required: true, defaultValue: 'NOW()' }),
 ```
@@ -309,6 +311,8 @@ The **conditional** spelling reaches the same verdict. A `requiredWhen`
 predicate says "required in this state", but `NOW()` / `current_user` resolve
 at insert regardless of state, so the producer's guarantee covers the
 conditional claim exactly as it covers the unconditional one:
+
+<!-- doc-snippet: fragment — one object-literal PROPERTY quoted out of a field map — `remind_at: Field.datetime(...)` is a key/value pair, not a statement. Measured TS1109x1. -->
 
 ```ts
 remind_at: Field.datetime({ requiredWhen: 'record.status == "scheduled"', defaultValue: 'NOW()' }),
@@ -331,6 +335,11 @@ The two halves of that verdict are importable, so a host with its own form
 renderer applies the same rule rather than re-deriving it (objectui#6059):
 
 ```typescript
+declare const field: { required?: unknown; defaultValue?: unknown };
+declare const isCreateForm: boolean;
+declare const values: Record<string, unknown>;
+declare const objectSchema: { fields?: Record<string, { defaultValue?: unknown }> };
+
 import { isRequiredInForm, omitServerResolvedDefaults } from '@object-ui/plugin-form';
 
 // Should this create form enforce `required` on the field?
@@ -418,6 +427,8 @@ A sectioned form is **one** form. Instead of rendering a form per section — wh
 strands every section but the first outside the submit, and (in tabs) lets the
 inactive panel unmount with its values — declare tabs on the single form and let
 the renderer distribute the fields:
+
+<!-- doc-snippet: fragment — a `fieldTabs` key list in prose notation, not a statement: the trailing `defaultFieldTab?:` / `fieldTabsPosition?:` entries mark OPTIONAL keys, which no object literal can spell. Measured TS1005x2 TS1109x3. -->
 
 ```typescript
 {
@@ -550,6 +561,8 @@ saying so (#2959's validation half, in a wizard).
 The same rule for side-by-side panels: the `<form>` wraps the whole panel group
 and each pane holds only fields, so one react-hook-form instance spans the
 divider.
+
+<!-- doc-snippet: fragment — a `fieldPanes` key list in prose notation, not a statement: the trailing `fieldPanesOrientation?:` / `fieldPanesResizable?:` entries mark OPTIONAL keys, which no object literal can spell. Measured TS1005x2 TS1109x3. -->
 
 ```typescript
 {
@@ -853,6 +866,7 @@ and hands them to your `onSubmit`, which the renderer awaits
 whatever that function does:
 
 ```typescript
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 import type { FormSchema } from '@object-ui/types';
 
 const dataSource = createObjectStackAdapter({

--- a/packages/plugin-view/README.md
+++ b/packages/plugin-view/README.md
@@ -229,6 +229,8 @@ schema.pageSize`; `if (schema.selection?.type) … else if (schema.selectable
 the pair itself:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'products',
@@ -259,7 +261,9 @@ from `table.fields` (objectui#5269, open).
 Toggle between multiple view configurations:
 
 ```typescript
-{
+import type { ViewSwitcherSchema } from '@object-ui/types';
+
+const viewSwitcher: ViewSwitcherSchema = {
   type: 'view-switcher',
   views: [
     { type: 'grid', label: 'Grid', schema: { type: 'text', content: 'Grid content' } },
@@ -270,7 +274,7 @@ Toggle between multiple view configurations:
   position: 'top',
   persistPreference: true,
   storageKey: 'my-view-switcher'
-}
+};
 ```
 
 ### FilterUI
@@ -278,7 +282,9 @@ Toggle between multiple view configurations:
 Render a filter toolbar with multiple field types:
 
 ```typescript
-{
+import type { FilterUISchema } from '@object-ui/types';
+
+const filterUi: FilterUISchema = {
   type: 'filter-ui',
   layout: 'popover',
   showApply: true,
@@ -291,7 +297,7 @@ Render a filter toolbar with multiple field types:
     ] },
     { field: 'created_at', label: 'Created', type: 'date-range' }
   ]
-}
+};
 ```
 
 ### SortUI
@@ -299,7 +305,9 @@ Render a filter toolbar with multiple field types:
 Configure sorting with dropdowns or buttons:
 
 ```typescript
-{
+import type { SortUISchema } from '@object-ui/types';
+
+const sortUi: SortUISchema = {
   type: 'sort-ui',
   variant: 'dropdown',
   multiple: true,
@@ -308,7 +316,7 @@ Configure sorting with dropdowns or buttons:
     { field: 'created_at', label: 'Created At' }
   ],
   sort: [{ field: 'name', direction: 'asc' }]
-}
+};
 ```
 
 ## Examples
@@ -319,6 +327,8 @@ The list is always rendered; `defaultViewType` picks which renderer draws it,
 and `table` configures the grid:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'users',
@@ -341,6 +351,8 @@ Create and edit share one record surface. `layout` chooses where it opens and
 no authored `mode`:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'users',
@@ -364,6 +376,11 @@ row. `navigation.mode` decides how, and `onNavigate` is what hands a page-mode
 record off to your router:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
+// your application's router
+declare const router: { push: (href: string) => void };
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'users',
@@ -392,6 +409,8 @@ not wire handlers for them — you switch them on or off with `operations`, and
 Both default to on, and the new-record form opens on the `layout` surface:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'products',
@@ -411,6 +430,8 @@ Search, filter and sort are toolbar toggles; column set, filter, sort and page
 size live in `table`:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'products',
@@ -430,6 +451,8 @@ Saved views are `listViews`, keyed by view name, with `defaultListView`
 selecting which opens first:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'products',
@@ -451,6 +474,8 @@ Editing is reached from a row's edit action; `operations.update` is what gates
 it. The edited record is chosen by the click, never by an authored `recordId`:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'products',
@@ -468,6 +493,8 @@ Under `layout: 'page'` this becomes `onNavigate(recordId, 'edit')`.
 no `enableDelete` key and no `onDelete` callback:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'products',
@@ -518,6 +545,8 @@ that is what makes the view "automatic". What the schema node chooses is
 **which** fields appear and how they are grouped:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'users',
@@ -547,6 +576,8 @@ There is no `nestedFields` key. A child collection is declared as a **subform**
 on the record form, which is where an order's line items belong:
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'orders',
@@ -576,6 +607,8 @@ the **saved-view** tab bar: declare the views and render `<ViewTabBar>` (or let
 a host such as `@object-ui/app-shell` do it):
 
 ```typescript
+import type { ObjectViewSchema } from '@object-ui/types';
+
 const schema: ObjectViewSchema = {
   type: 'object-view',
   objectName: 'users',

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -481,8 +481,6 @@ const UNGATED_DOCS = {
     'the documented override flow did not compile. It now returns `DeepMutable<T>` and that ' +
     'diagnostic is gone. Covering this page still needs the 5 undefined-name blocks made ' +
     'self-contained or declared, plus a way to declare a block whose rejection IS the point.',
-  'packages/data-objectstack/README.md':
-    '10 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 41 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/fields/README.md':
     '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
   'packages/i18n/README.md':
@@ -509,8 +507,6 @@ const UNGATED_DOCS = {
     '5 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 15 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/plugin-editor/README.md':
     '6 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
-  'packages/plugin-form/README.md':
-    '12 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 1 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/plugin-gantt/README.md':
     '9 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 12 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/plugin-kanban/README.md':
@@ -525,8 +521,6 @@ const UNGATED_DOCS = {
     '16 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS1108x1 — candidate real defects, un-triaged',
   'packages/plugin-tree/README.md':
     '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
-  'packages/plugin-view/README.md':
-    '14 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 14 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/providers/README.md':
     '7 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2741x1 — candidate real defects, un-triaged',
   'packages/react-runtime/README.md':


### PR DESCRIPTION
Part of #5174

Batch 8 of the `UNGATED_DOCS` burn-down, and the first one that takes **package READMEs** rather than `content/docs` pages. Takes the next three README entries by fence density and delivers all three whole: **57 blocks, 52 compile against the built `dist`, 5 carry a `FRAGMENT_MARKER` with a written, measured reason. 104 diagnostics cleared.** Nothing about the gate's strictness moved.

Batch 6 (#7314) landed while this was in flight; `origin/main` was merged (never rebased) and the two ledger hunks are disjoint removals, as predicted. Batch 7 is still open on `.mdx` entries and is disjoint by construction — this batch touches no `.mdx` page at all.

Angle-bracketed generics are spelled in words throughout: the GitHub body sanitizer eats tag-shaped fragments, including inside backticks.

## Selection

All counts produced with the gate's own `scanFences`, never a hand grep. The top of the 31-entry README population by ts/tsx block count:

| rank | README | ts/tsx blocks | taken |
|--:|:--|--:|:--|
| 1 | `packages/data-objectstack/README.md` | 21 | ✅ |
| 2 | `packages/plugin-view/README.md` | 21 | ✅ |
| 3 | `packages/plugin-gantt/README.md` | 18 | ⛔ excluded — #7306 pins `PARTIAL_EXCERPTS` entries on it and #7302 owns its content |
| 4 | `packages/plugin-form/README.md` | 15 | ✅ |
| 5 | `packages/plugin-report/README.md` | 13 | — next batch |

`packages/plugin-kanban/README.md` (5 blocks) is excluded on the same grounds. No other open PR on this lane (#7291, #7304, #7306, #7314, #7315) touches any `packages/*/README.md` — checked by fetching each PR head over git and diffing it against its own merge-base, so the check cost no API quota.

⛔ The gate's non-recursive package-README walk (#7308) was left alone: only `packages/NAME/README.md` entries the gate already collects were taken.

## Pages taken, and how each block reached zero

| README | blocks | compile | declared | diagnostics cleared | real defects found, and the shipped declaration each was checked against |
|:--|--:|--:|--:|--:|:--|
| `packages/data-objectstack/README.md` | 21 | 20 | 1 | 56 (10 syntax, 46 semantic) | **`client.meta.getObject('task')` does not exist.** The escape-hatch example's metadata read is not a member of the `meta` surface `@objectstack/client` ships; the read is `client.meta.getItem('object', 'task')` (`packages/data-objectstack/node_modules/@objectstack/client/dist/index.d.ts:697`). **The error-handling example read `code` / `message` / `statusCode` / `details` off an un-narrowed `unknown`**, and `error.details.objectName` off an optional member — both now narrow through the exported `ObjectStackError` and use `details?.objectName`. **The user-state example imported `useAttachUserStateAdapters` and then called a bare `attach`** it never obtained from the hook. Thirteen further blocks were unrunnable as written (`Cannot find name 'dataSource'` / `'mySchema'` / `'records'` / `'largeDataset'` / `'createObjectStackAdapter'`) and were made self-contained. |
| `packages/plugin-view/README.md` | 21 | 21 | 0 | 29 (14 syntax, 15 semantic) | No fabricated key. **Twelve blocks annotated `ObjectViewSchema` without importing it** — a reader copying any one of them was broken on line 1 (`TS2304`), and every downstream `TS7006` on `onNavigate`'s parameters was a consequence of the annotation being an error type rather than a real gap. **Three bare object literals (`view-switcher`, `filter-ui`, `sort-ui`) became annotated declarations** against `ViewSwitcherSchema` / `FilterUISchema` / `SortUISchema`, which `@object-ui/types` exports and the page never named; that puts 26 previously unchecked keys under a declared type. |
| `packages/plugin-form/README.md` | 15 | 11 | 4 | 19 (12 syntax, 7 semantic) | No fabricated key. The `isRequiredInForm` / `omitServerResolvedDefaults` example named four host variables it never declared, and the `onSubmit` closure example built an adapter without importing `createObjectStackAdapter`. The four declared fragments are prose notation, not defects: two single object-literal *properties* quoted out of a field map, and two key lists whose trailing entries carry a `?` to mark the key optional — which no object literal can spell. |

Ledger **37 → 34** (6 `.mdx` + 28 README). Covered documents **187 → 190** — strictly grows. Covered blocks 481 → 538; compiled 345 → 397; declared fragments 136 → 141. The per-page splits (20+21+11 = 52 compile, 1+0+4 = 5 declared) reconcile exactly with those deltas.

## Invariants, each measured rather than asserted

Measured by importing `origin/main`'s copy of the gate alongside this branch's and evaluating both over the same working tree, so the covered-set delta is attributable to the ledger alone:

- **The ledger hunk is removals only** — `git diff --numstat origin/main...HEAD -- scripts/check-doc-snippet-types.mjs` is **`0	6`**: zero additions, six deletions.
- `ADDED ledger entries: []` · `REMOVED ledger entries: [data-objectstack, plugin-form, plugin-view READMEs]` and nothing else · `surviving entries whose REASON TEXT changed: []` across all 34.
- `covered documents: 187 -> 190` · `previously-covered docs now UNGATED: []`.
- **Gate strictness byte-identical**, from the fence-scanning banner to EOF, `origin/main` vs this branch: **764 lines, `sha256 b87e347626a6cbab30b904eaf7d3eb72f6804122505bdf9ec8f2f2c8136e95a3`** — the same value on both sides, and the same value batches 5 and 6 recorded. `DOC_EXTENSIONS`, `TS_FENCE_LANGUAGES` and `MIN_REASON_LENGTH` each hash identical too. ⛔ The ledger docblock's own prose was **not** touched — batch 7 owns the header count fix.
- **Build cost: zero.** `--build-filter` re-measured on the merged head with and without the three removals: **25 filters both ways, packages ADDED `[]`, REMOVED `[]`**. Covering these three READMEs pulls nothing new into the gate's build closure.

Before / after, both at a fully built tree, exit codes captured by redirect before any pipe:

```
BEFORE (origin/main ad3d4029a's ledger, applied to this working tree)
  Scanned 224 document(s): 187 covered, 37 ungated
  Covered blocks: 481 — 345 to compile, 136 declared fragment(s)

AFTER (777e0dbac)
  Scanned 224 document(s): 190 covered (89 hold a ts/tsx block), 34 ungated
  Covered blocks: 538 — 397 to compile, 141 declared fragment(s)
  Syntax phase:   every block parsed, so every one of them reached the semantic phase.
  Semantic phase: 397 of 397 block(s) judged, 0 failed          exit 0
```

At the branch point (`d717e8bc3`, before #7314 landed) the same measurement read 184 covered / 40 ungated / 440 blocks — i.e. the dispatch's stated 187/37/481 was batch 6's *after*-census and only became reproducible here once #7314 merged. Reported rather than assumed.

## The lid check, per README — including the negative results

- **`plugin-view` — NEGATIVE.** Resolving `ObjectViewSchema` in twelve blocks removed both `TS7006`s with it and exposed nothing underneath; the re-run was clean.
- **`data-objectstack` — POSITIVE, twice.** Narrowing the catch clause exposed `error.details.objectName` on an optional member, and typing `dataSource` exposed `client.meta.getObject`. Both fixed on the page. A third positive was producer-side and is filed, not cast around (below).
- **`plugin-form` — NEGATIVE, and measured rather than assumed.** The two declared `fieldTabs` / `fieldPanes` fragments were re-run through the gate's own compiler as parseable statements: **clean**, and all six keys (`fieldTabs`, `fieldPanes`, `defaultFieldTab`, `fieldTabsPosition`, `fieldPanesOrientation`, `fieldPanesResizable`) are declared members of `FormSchema` in `packages/types/dist/form.d.ts`, so the green is a real check and not index-signature blindness. Nothing hides behind those markers.

## The read-site check — what the compiler structurally cannot see

`BaseSchema` carries `[key: string]: any`, so a wrong TOP-LEVEL key on any schema literal is invisible to this gate. Every top-level key on every annotated literal added here was therefore checked against the shipped declaration by name: **all 32 are declared members** of `ObjectViewSchema` / `ViewSwitcherSchema` / `FilterUISchema` / `SortUISchema`, so nothing on these pages is riding the index signature. `WizardFormSchema` on the plugin-form page is a sealed interface with no `BaseSchema` base at all, so that block is checked including excess properties.

## What the green does not mean

Each limit below was **measured on a taken README** by planting a probe, running the real gate, and restoring from `HEAD` under an `EXIT INT TERM` trap. Mutations proved on disk by blob hash before each run; restores proved by an empty `git diff HEAD` and the blob hash back at its `HEAD` value — never by the trap's own exit.

1. **A misspelled TOP-LEVEL key on a schema literal is not caught.** Probe: `thisKeyDoesNotExistAnywhere: 123` beside `objectName` on the annotated `ObjectViewSchema` literal at `plugin-view/README.md:232`. Predicted exit 0, no diagnostic. **Observed exit 0**, `Semantic phase: 364 of 364 block(s) judged, 0 failed` — `BaseSchema`'s index signature absorbs it.
2. **The same key one level down IS caught.** Probe: the same key inside that literal's `table: { … }`. Predicted exit 1 with `TS2353`. **Observed exit 1**: `packages/plugin-view/README.md:239:5 TS2353: Object literal may only specify known properties, and 'thisKeyDoesNotExistAnywhere' does not exist in type 'Partial of Pick of ObjectGridSchema over ObjectGridSlotKey'` (generic spelled in words here; the gate prints it in brackets). `Semantic phase: 364 of 364 block(s) judged, 1 failed`. The annotations are live, not no-ops: `Pick` drops the index signature, so every `table` block on that page is now strictly checked for the first time.
3. The gate answers only "does this snippet compile against the published types". Whether a `type` literal names a registered component, whether a schema key survives `safeParse`, and whether the shell examples run are three other questions with three other answers.

## Type gaps found and filed, not fixed here

`packages/*/src` is out of this PR's surface. Both filed unassigned after a targeted dedupe search — with a known-hitting control query run in the same session first, so an empty result is a reading and not a broken search.

- **#7323** — `createObjectStackAdapter` declares `DataSource` as its return type, so `getClient`, the cache methods and the connection-state / batch-progress subscriptions — the members four whole sections of that README are built around, and which its own API Reference lists — are not on the type the factory hands back. Measured: four `TS2339`s against the built `dist`.
  **Deviation from the standing disposition, flagged deliberately:** the affected blocks ship **compiling**, holding the adapter as the exported `ObjectStackAdapter` class, rather than shipping as declared fragments. The class is exported and its constructor is documented in that README, so the annotation is a truthful statement about the object and about the one cast-free way to obtain that type today; and because no block now asserts the factory's return, nothing on the page is papered over. To keep the page from being silently inconsistent with its own setup step, a short note under **Basic Setup** states the narrowing and names #7323; the note comes out when the card is settled. If the reviewer prefers the literal disposition, converting those thirteen blocks to `FRAGMENT_MARKER` is a mechanical follow-up.
- **#7324** — `ObjectSchemaLike` is the second parameter type of three functions `@object-ui/plugin-form` exports (`omitServerResolvedDefaults`, `schemaDefaultValues`, `seedCreateValues`) and is not itself exported, so a consumer cannot name what it must pass. `SeedContext`, on the same signatures, is exported. The README block documenting the #6059 pair declares its input as a hand-written structural literal for exactly this reason — that literal is the duplication the card is about.

## Gate verdict lines

Everything below at **`777e0dbac`**, the final commit, working tree clean at union time. The closure was built first under the shared verify lock (`VERDICT command-exit 0`) and `dist/index.d.ts` presence was confirmed on disk **in this worktree** for all 25 packages before any gate result was trusted — turbo replayed cached logs naming `objectui-issue-5174-b6`'s paths, so the log alone proves nothing.

```
check:doc-snippets       exit 0  Semantic phase: 397 of 397 block(s) judged, 0 failed.
                                 Every covered documentation snippet compiles against the built types.
check:readme-exports     exit 0  406 self-imports judged (406 real, 0 wrong-path, 0 fabricated);
                                 52 key(s) compared both ways (0 fabricated, 0 stale omission(s))
check:doc-fences         exit 0  every TypeScript block in 224 document(s) is fenced ts/tsx/typescript …
check:doc-types          exit 0  Every documented component type is registered.
docs:check-links         exit 0  Links are valid across 17 scan roots.
check:control-bytes      exit 0  scanned 6015 tracked text file(s); skipped 85 binary
check-changeset-presence exit 0  No source or published contract of a released package changed in
                                 this range, so no changeset is owed.
vitest (repo root)       exit 0  Test Files 8 passed (8) · Tests 264 passed (264)
lint:root                exit 0  33 problems (0 errors, 33 warnings) — all pre-existing
```

The changeset verdict was **followed, not overridden**: none added. No `skip-changeset` label — in this repo that label is a historical mis-mount that no workflow reads, and a pin test forbids applying it.

The eight vitest files are every file `git grep -l check-doc-snippet-types -- '*.test.ts' '*.test.tsx'` names, plus `scripts/__tests__/check-readme-exports.test.ts`, which #7306 landed on `main` mid-run and which reads the very READMEs this diff edits. Run from the repo root with `--maxWorkers=2`, never through `pnpm --filter`.

`check:readme-exports` first read **NOT MEASURED**, not red: it exited 1 with 45 findings, every one the string `its type entry ./dist/index.d.ts is not on disk -- run pnpm build first` for `plugin-ai` / `plugin-gantt`, and none naming a file in this diff. Building those three packages made it a real measurement, and it is genuinely green.

## Lint: run whole, not narrowed

1. **Population read from ESLint's own config**, not from a guess: the root task judges **230 files**, of which **0** are `.md`; the three edited packages' own lint tasks judge 59 / 112 / 47 files, of which **0** are `.md`. All three edited READMEs are outside ESLint's population by its own configuration.
2. **File count read from `--format json`**: the one changed file inside a population, `scripts/check-doc-snippet-types.mjs`, reports `errorCount 0`, `warningCount 0`.
3. **Config invariance for untouched files**: `eslint.config.js` sets no `project`, `projectService` or `tsconfigRootDir`, so type-aware linting is not enabled and nothing in this diff can move the verdict on a file it does not touch.

A control-byte self-scan (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) over the four changed files returns no hits, beside the repo-wide gate above.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b


---
_Generated by [Claude Code](https://claude.ai/code/session_01BGMDbrVa8JjZcCQ7DWYH1b)_