### PR TITLE
fix(app-shell): Studio package switcher reads the server's writable verdict, heuristic only as fallback (#7177)

### DIFF
--- a/.changeset/7177-studio-switcher-server-writable-verdict.md
+++ b/.changeset/7177-studio-switcher-server-writable-verdict.md
@@ -1,0 +1,26 @@
+---
+'@object-ui/app-shell': patch
+---
+
+Studio's package switcher reads the server's `writable` verdict instead of guessing
+from `manifest.scope` (objectui#7177, ADR-0130 Consequences row 6, server half in
+objectstack#14375).
+
+`GET /api/v1/packages` now stamps every row with `writable: boolean`, computed by
+`isWritablePackage` (ADR-0070 D2) — the same predicate the server's authoring and
+lifecycle gates enforce. `parsePackages` uses it when the row carries one, so the
+lock badge and the gate cannot disagree.
+
+The old `scope !== 'project'` expression stays as the fallback for servers that
+predate the field, and its output is pinned byte-identical. It is wrong for exactly
+one row, which is why the verdict had to move server-side: a `type: module`
+sub-package of a multi-package artifact (ADR-0130 D4) is served with no `scope` key
+at all — the schema default is applied at parse time, while the artifact load path
+hands the raw manifest body to `registerApp`. The heuristic reads that as a writable
+database base, while the server refuses every write to it. Nothing in the raw row
+separates it from a scope-less Studio-created base, which really is writable — only
+the server's `engine.manifests` does, so a client-side "missing scope means
+read-only" rule would have flipped every Studio base read-only instead.
+
+Kernel packages (`scope: system` / `cloud`) stay hidden whatever verdict they carry:
+that filter is about visibility, not writability.

--- a/packages/app-shell/src/views/studio-design/packages-io.ts
+++ b/packages/app-shell/src/views/studio-design/packages-io.ts
@@ -4,11 +4,27 @@
  * Package-list helpers shared by the Studio package switcher and the builder
  * landing page.
  *
- * Writability is a DISPLAY heuristic — kernel packages (scope system/cloud)
- * are hidden, `scope: 'project'` marks a read-only code package (authoring is
- * refused server-side by the ADR-0070 D4 gate), and a scope-less entry is a
- * database base package (writable). The gate stays the authority; this only
- * sets expectations up front.
+ * Writability is the SERVER's verdict, not a shape we derive. Every row of
+ * `GET /api/v1/packages` carries a top-level `writable: boolean` computed by
+ * `isWritablePackage` (ADR-0070 D2, objectstack#14375) — the same predicate the
+ * server's authoring (`saveMetaItem`) and lifecycle (`DELETE` / `disable`) gates
+ * enforce, so the badge and the gate cannot disagree. Read it; do not re-derive
+ * it.
+ *
+ * The `scope !== 'project'` expression below is ONLY the fallback for servers
+ * that predate that field, and it is WRONG for one row: a `type: module`
+ * sub-package of a multi-package artifact (ADR-0130 D4) normally omits `scope`
+ * — the schema default is applied at PARSE time, while the artifact load path
+ * deliberately hands the RAW manifest body to `registerApp`, so the served row
+ * has no `scope` key at all. The heuristic reads that as a writable database
+ * base, yet the server refuses every write to it (it is in `engine.manifests`).
+ * Nothing in the raw row separates it from a scope-less Studio-created base,
+ * which really is writable — only the server's `engine.manifests` does, which is
+ * why the client cannot compute this and a "missing scope means read-only" rule
+ * would have flipped every Studio base read-only.
+ *
+ * Kernel packages (scope `system` / `cloud`) are hidden here whatever their
+ * verdict says: that filter is about visibility, not writability.
  */
 
 import { deriveNamespaceFromPackageId, validateObjectNamespacePrefix } from '@objectstack/spec/kernel';
@@ -39,7 +55,10 @@ export function parsePackages(payload: unknown): PkgEntry[] {
     if (scope === 'system' || scope === 'cloud') continue; // kernel — not app packages
     const namespace =
       typeof m.namespace === 'string' && m.namespace ? m.namespace : deriveNamespaceFromPackageId(id);
-    out.push({ id, name: String(m.name ?? id), writable: scope !== 'project', namespace });
+    // Server first, heuristic only when the key is absent (see the module doc).
+    // A non-boolean value is not a verdict, so it falls back too.
+    const writable = typeof p.writable === 'boolean' ? p.writable : scope !== 'project';
+    out.push({ id, name: String(m.name ?? id), writable, namespace });
   }
   return out;
 }

--- a/packages/app-shell/src/views/studio-design/packages-io.writableVerdict.test.ts
+++ b/packages/app-shell/src/views/studio-design/packages-io.writableVerdict.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Guards WHO decides a package is writable (objectui#7177 · ADR-0130
+ * Consequences row 6 · objectstack#14375).
+ *
+ * The server computes `writable` with `isWritablePackage` (ADR-0070 D2) and
+ * stamps it on every `GET /api/v1/packages` row. `parsePackages` must READ that
+ * verdict, because the client cannot derive it: the signal that separates a
+ * booted multi-package module (read-only, `engine.manifests`) from a
+ * Studio-created database base (writable) lives only on the server, and BOTH of
+ * those rows arrive with no `scope` key.
+ *
+ * The old `scope !== 'project'` expression survives as the fallback for servers
+ * that predate the field — pinned here as byte-identical output, so the
+ * compatibility arm cannot rot unnoticed.
+ */
+import { describe, expect, it } from 'vitest';
+import { parsePackages } from './packages-io';
+
+function wrap(packages: Array<Record<string, unknown>>) {
+  return { data: { packages } };
+}
+
+/** A registry row as the runtime dispatcher serves it (`InstalledPackage` + the verdict). */
+function row(manifest: Record<string, unknown>, extra: Record<string, unknown> = {}) {
+  return {
+    manifest,
+    status: 'installed',
+    enabled: true,
+    installedAt: '2026-09-01T00:00:00.000Z',
+    updatedAt: '2026-09-01T00:00:00.000Z',
+    ...extra,
+  };
+}
+
+describe('parsePackages — the server owns the writable verdict', () => {
+  it('honours writable:false on a scope-less row (the ADR-0130 module sub-package)', () => {
+    const [pkg] = parsePackages(
+      wrap([row({ id: 'com.example.leave', name: 'Leave', type: 'module' }, { writable: false })]),
+    );
+    // The row really has no scope — the verdict cannot be leaking out of one.
+    expect(pkg.writable).toBe(false);
+    expect(pkg.id).toBe('com.example.leave');
+  });
+
+  it('honours writable:true on a scope-less row (a Studio-created database base)', () => {
+    const [pkg] = parsePackages(
+      wrap([row({ id: 'com.example.my_base', name: 'My Base' }, { writable: true })]),
+    );
+    expect(pkg.writable).toBe(true);
+  });
+
+  it('lets the server win over the heuristic in BOTH directions on scope:project', () => {
+    const [readOnly] = parsePackages(
+      wrap([row({ id: 'app.objectstack.hotcrm', name: 'HotCRM', scope: 'project' }, { writable: false })]),
+    );
+    expect(readOnly.writable).toBe(false);
+
+    // The heuristic would say false here; the server says true and is obeyed.
+    const [writable] = parsePackages(
+      wrap([row({ id: 'com.example.promoted', name: 'Promoted', scope: 'project' }, { writable: true })]),
+    );
+    expect(writable.writable).toBe(true);
+  });
+
+  it('ignores a non-boolean writable and falls back to the heuristic', () => {
+    // A string is not a verdict. `Boolean('false')` is `true`, so a coercing
+    // read would have made this row writable *and* agreed with the fallback by
+    // accident — the scope:project row is what tells the two apart.
+    const [scopeless] = parsePackages(
+      wrap([row({ id: 'com.example.leave', name: 'Leave' }, { writable: 'false' })]),
+    );
+    expect(scopeless.writable).toBe(true); // fallback: no scope → not 'project'
+
+    const [project] = parsePackages(
+      wrap([row({ id: 'app.objectstack.hotcrm', name: 'HotCRM', scope: 'project' }, { writable: 'true' })]),
+    );
+    expect(project.writable).toBe(false); // fallback: scope 'project' → read-only
+  });
+
+  it('hides kernel packages whatever verdict they carry (visibility is not writability)', () => {
+    const out = parsePackages(
+      wrap([
+        row({ id: 'objectstack.core', name: 'Core', scope: 'system' }, { writable: true }),
+        row({ id: 'com.objectstack.cloud.billing', name: 'Billing', scope: 'cloud' }, { writable: true }),
+        row({ id: 'com.example.leave', name: 'Leave' }, { writable: false }),
+      ]),
+    );
+    expect(out.map((p) => p.id)).toEqual(['com.example.leave']);
+  });
+});
+
+describe('parsePackages — a server with no writable field is unchanged', () => {
+  /**
+   * A realistic single-package install as an older server serves it: kernel
+   * packages, the `scope: 'project'` app package, a scope-less database base and
+   * a scope-less module. No `writable` key anywhere.
+   */
+  const LEGACY_PAYLOAD = {
+    success: true,
+    data: {
+      packages: [
+        row({ id: 'objectstack.core', name: 'ObjectStack Core', version: '1.0.0', scope: 'system' }),
+        row({ id: 'com.objectstack.cloud.billing', name: 'Billing', version: '1.0.0', scope: 'cloud' }),
+        row({
+          id: 'app.objectstack.hotcrm',
+          name: 'HotCRM',
+          version: '1.0.0',
+          type: 'app',
+          scope: 'project',
+        }),
+        row({ id: 'com.example.my_base', name: 'My Base', version: '0.1.0' }),
+        row({ id: 'com.example.leave', name: 'Leave', version: '0.1.0', type: 'module', namespace: 'leave' }),
+      ],
+      total: 5,
+    },
+  };
+
+  /**
+   * Captured by running `parsePackages` against LEGACY_PAYLOAD on the UNTOUCHED
+   * tree (`ad3d4029abb949cb41815b6ce38d5e0ecad1486a`), before the verdict read
+   * existed. Pasted, never re-derived — a re-derived expectation would agree
+   * with any regression this pin exists to catch.
+   */
+  const OUTPUT_BEFORE_THIS_CHANGE = [
+    { id: 'app.objectstack.hotcrm', name: 'HotCRM', writable: false, namespace: 'hotcrm' },
+    { id: 'com.example.my_base', name: 'My Base', writable: true, namespace: 'my_base' },
+    { id: 'com.example.leave', name: 'Leave', writable: true, namespace: 'leave' },
+  ];
+
+  it('produces exactly the output it produced before the verdict read landed', () => {
+    expect(parsePackages(LEGACY_PAYLOAD)).toEqual(OUTPUT_BEFORE_THIS_CHANGE);
+  });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectui#7177
Part of objectstack-ai/objectstack#14122 — ADR-0130 Consequences row 6, the **client half**. Server half: objectstack-ai/objectstack#14375 (PR objectstack-ai/objectstack#14430).

## Why

`parsePackages` derived "writable" from `manifest.scope` alone (`scope !== 'project'`). That is not the rule the server enforces. `isWritablePackage` (ADR-0070 D2) reads **`engine.manifests` first** — a package booted from an artifact through `registerApp` is read-only whatever its scope says — and only then the `system` / `cloud` scopes. The two rules split on exactly the row ADR-0130 introduces:

| row | `manifest.scope` | in `engine.manifests` | server | old client heuristic |
| --- | --- | --- | --- | --- |
| `type: module` sub-package of a multi-package artifact (D4/D7 raw body) | absent | yes | read-only | writable — wrong |
| Studio-created database base | absent | no | writable | writable |

Nothing in the raw row separates those two; only the server's `engine.manifests` does. A client-side "missing scope means read-only" rule (the first fix proposed on the card, since withdrawn) would have flipped **every Studio base** read-only. So the verdict moved server-side and this PR consumes it.

**Measured on a live server** (see Verification): the scope default is applied at PARSE time, while the artifact load path hands the RAW manifest body to `registerApp` — so the served row has no `scope` key at all, and the heuristic reads it as a writable database base.

## What changed

`packages/app-shell/src/views/studio-design/packages-io.ts`:

- `parsePackages` uses the row's own `writable` when the server states one (`typeof p.writable === 'boolean'`), and falls back to the unchanged `scope !== 'project'` expression when the key is absent (older servers). A non-boolean value is not a verdict and falls back too.
- The module doc comment is rewritten: it used to state the heuristic as the rule. It now says the server is the authority, the heuristic is only the pre-objectstack-14375 fallback, and it is wrong for the scope-less booted module row — with the mechanism (parse-time default vs raw body) written down.
- The `system` / `cloud` hide filter is untouched, and now says in writing that it is about visibility, not writability.

Changeset: `.changeset/7177-studio-switcher-server-writable-verdict.md` (`@object-ui/app-shell`: patch).

## Pins

`packages/app-shell/src/views/studio-design/packages-io.writableVerdict.test.ts` — 5 tests:

1. `writable: false` on a scope-less row (the ADR-0130 module) is honoured, and the test asserts the row really carries no scope so the verdict cannot be leaking out of one.
2. `writable: true` on a scope-less row (a Studio base) is honoured.
3. `scope: 'project'` is overridden in BOTH directions — server `false` stays false, server `true` wins over the heuristic.
4. A non-boolean `writable` (the string `"false"`) is ignored. `Boolean('false')` is `true`, so a coercing read would have agreed with the fallback by accident on the scope-less row; the `scope: 'project'` row is what tells the two apart.
5. Kernel packages stay hidden whatever verdict they carry.

Negative pin (same file): a payload with no `writable` key anywhere produces output **deep-equal to the pre-change capture**. The expected value was captured by running `parsePackages` against that payload on the UNTOUCHED tree at `ad3d4029abb949cb41815b6ce38d5e0ecad1486a` and pasted in, never re-derived.

## Reverse verification — ablation, prediction stated first

Subject: `packages-io.ts` restored to its pre-change bytes from the pinned base commit, with the fix committed first so the restore leg has a real restore point.

- Mutation proved on disk before the run: removed text count 0, injected text count 1, `git hash-object` differs from the HEAD blob.
- Predicted: only the two pins that DISCRIMINATE go red — pin 1 and pin 3 — while pins 2, 4, 5 and the negative stay green, because those agree with the heuristic by construction.
- Observed: `Tests 2 failed | 13 passed (15)`, failing exactly `honours writable:false on a scope-less row` and `lets the server win over the heuristic in BOTH directions on scope:project`.
- Restore leg: on-disk blob `c94002e170b25bc7a2d40500e7adfef3a7328393` equal to the HEAD blob, `git diff HEAD` empty, 15/15 green again.

No rebuild step applies: the pins import the subject by a relative specifier inside the same package, so nothing resolves through `dist`.

## Verification at `dcef834`

- `pnpm exec vitest run packages/app-shell/src/views/studio-design/packages-io.writableVerdict.test.ts packages/app-shell/src/views/studio-design/packages-io.test.ts packages/app-shell/src/views/studio-design/packages-io.duplicateEnvelope.test.ts` — `Test Files 3 passed (3)`, `Tests 23 passed (23)`, exit 0.
- Whole directory: `pnpm exec vitest run packages/app-shell/src/views/studio-design/` — `Test Files 44 passed (44)`, `Tests 236 passed (236)`, exit 0.
- `pnpm --filter @object-ui/app-shell run type-check` — exit 0 (dependency closure built first; the chained `tsconfig.test.json` project includes `src/**/*.test.ts`, so the new pins are type-checked).
- eslint on the two changed files with `--no-inline-config` — 0 errors, 0 warnings. **Narrowing declared:** the repo-wide population is `eslint .`; the file count (2) is read from `--format json`; `eslint.config.js` configures no type-aware linting (0 occurrences of `projectService` / `parserOptions` / `project:` / `TypeChecked`), so this diff cannot move any untouched file's verdict. CI runs the full farm regardless.
- `node scripts/check-changeset-presence.mjs` — exit 0, 1 changeset declared for 1 released package.
- `pnpm check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:i18n-keys` — all green.
- `node scripts/check-governed-queue-guard.mjs --test` on the three changed paths — `NOT GOVERNED`.

## Live server verification

Booted from objectstack commit `bd0ee2fbb634e7cdcd3c2afffb6258fd8f3a0942` — the head of PR objectstack-ai/objectstack#14430, which is **not yet in objectstack `main`** (checked: `withWritableVerdict` has 0 occurrences in `origin/main`'s `packages/runtime/src/domains/packages.ts`). The squash content is identical.

### Single-package boot — the negative check

`examples/app-todo` on its own port with a fresh `file:` DB (the showcase app was tried first and is unusable for this: its `GET /api/v1/packages` answers HTTP 500 `Converting circular structure to JSON … '_ObjectQL' … property 'engine'`, a pre-existing platform defect the PM is filing, unrelated to this change).

`GET /api/v1/packages`: 23 rows, **all 23 carrying `writable`**. The one row the switcher keeps:

    com.example.todo | type=app | scope="project" | writable=false

Identical to what the heuristic said, so the switcher is unchanged for existing single-package apps.

Then `POST /api/v1/packages/com.example.todo/duplicate` created a Studio base, giving the pair that matters:

    com.example.todo      | type=app | scope="project"  | writable=false
    com.example.todo_copy | type=app | scope=ABSENT     | writable=true

The Studio switcher, driven through the objectui HMR console pointed at that server (`VITE_SERVER_URL` / `DEV_PROXY_TARGET`, so this branch's code is what rendered — the vendored `/_console` bundle is stale by construction), lists `Todo Manager` as **Read-only** and `Todo Copy (writable base)` as **Writable**. That second row is the one a client-side "missing scope means read-only" rule would have broken, and it is scope-less on the wire.

### Multi-package boot — BLOCKED

**BLOCKED-BY objectstack-ai/objectstack#14439.** The card's second acceptance line — switcher shows both packages, the module marked read-only, and the three Studio sections filtering by package — cannot be verified end to end yet, because no producer emits a `packages[]` artifact. One honest attempt, a two-package `packages[]` config booted through `os dev` from `bd0ee2fb`, refused at the producer door:

    ◆ Compile
    ────────────────────────────────────────
      → Loading configuration...

      ✗ defineStack validation failed (2 issues):

      ✗ packages.0.manifest.objects.0: Expected string but received object.
      ✗ packages.1.manifest.objects.0: Expected string but received object.
     ›   Error: defineStack validation failed (2 issues):
      ✗ Compile failed — fix errors above before starting dev server

`ArtifactPackageEntrySchema.manifest` is the AUTHORING `ManifestSchema`, whose `objects` is `z.array(z.string())` — glob patterns — so object DEFINITIONS in a sub-package body are refused before compile finishes.

A second, independent door refuses the same shape after compile, recorded here because it is a separate seam and objectstack-ai/objectstack#14439 will meet both: `MetadataPlugin._parseAndRegisterArtifact` hard-parses the whole artifact with `ObjectStackDefinitionSchema` before ADR-0130 D4's load path (which deliberately does not judge bodies) is ever reached, so an assembled `packages[i].manifest.objects` fails with `expected string, received object` and `packages[i].manifest.permissions` fails its union. Measured by parsing artifact variants directly: bodies with `objects` + `permissions` fail 4 ways; with `permissions` removed, 2 ways; with both removed, the parse passes. `flows`, `apps` and the other collections are simply undeclared on `ManifestSchema`, so they are stripped from the parsed copy and survive in the raw body — which is why `objects` (Data pillar) and `permissions` (Access pillar) are precisely the two the D4 seam cannot carry today.

This verification will be re-run against that card's `examples/app-multi-package` fixture once it lands. Nothing was worked around in objectui.

## Boundaries

No new authorable key, no spec change, no lenient alias. The fallback is version compatibility with servers that predate the field, not tolerance of a second dialect: the field is either a boolean or it is absent.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHvF5hyiZjnCyExFnfQB8m)_