### PR TITLE
docs(plugin-list): correct the `ganttOwnsData` note — no host prop reaches the chart

### DIFF
--- a/.changeset/gantt-owns-data-comment-7222.md
+++ b/.changeset/gantt-owns-data-comment-7222.md
@@ -1,0 +1,4 @@
+---
+---
+
+Comment-only correction in `@object-ui/plugin-list` (objectui#7222): the note above `ganttOwnsData` in `ListView.tsx` claimed the rows `data` prop "short-circuits the renderer's own fetch". It does not — no host prop reaches `ObjectGantt` at all, because the registered `object-gantt` renderer forwards nothing but `schema`. No published behaviour changes.

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -1555,9 +1555,31 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
   // A gantt view whose `data` names the api provider is fed by a composite
   // endpoint that ObjectGantt resolves itself (resolveDataSource →
   // ApiDataSource, reads AND write-backs). ListView must neither fetch
-  // schema.objectName rows for it nor pass its `data` prop down — the prop
-  // short-circuits the renderer's own fetch, so stale object rows would
-  // replace the endpoint's tree.
+  // schema.objectName rows for it nor hand its rows `data` prop down.
+  //
+  // ⛔ What the second half does NOT do (objectui#7222). It does not
+  // "short-circuit the renderer's own fetch" — an earlier version of this
+  // comment said it did, and believing that is exactly what made objectui#7210's
+  // double fetch invisible on a read-through. No host prop reaches the chart at
+  // all: the registered `object-gantt` renderer (`plugin-gantt/src/index.tsx`)
+  // destructures `({ schema })` and hands `ObjectGantt` exactly `schema` and
+  // `dataSource`, so `data`, `onRowClick`, `rowHeight` and the rest of
+  // `baseProps` are dropped one layer up, and the chart queries for itself
+  // whichever branch the render below takes. It is the one view wrapper that
+  // forwards nothing — `object-grid`, `object-kanban`, `object-calendar`,
+  // `object-map` and `object-tree` all spread `{...props}`. Pinned
+  // behaviourally, one package over, in
+  // `plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx`.
+  //
+  // The withholding is kept anyway: it is unreachable, not wrong, and it stops
+  // being unreachable the moment that wrapper forwards host props — whether a
+  // non-grid view may fetch unbounded at all is an open maintainer decision
+  // (objectui#7210, half 2). `ObjectGantt.reload` takes its `rest.data`
+  // short-circuit on `data && Array.isArray(data)`, and `[]` satisfies both,
+  // while this view's rows array is never filled (the fetch effect below
+  // returns early for it). Forwarding it would therefore replace the endpoint's
+  // tree with an EMPTY chart — not with the stale object rows the old comment
+  // warned about.
   const ganttOwnsData =
     currentView === 'gantt' &&
     !!schema.data &&
@@ -3895,7 +3917,12 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
           <SchemaRenderer
             schema={viewComponentSchema}
             {...props}
-            {...(ganttOwnsData ? {} : { data })}
+            {...(ganttOwnsData
+              // Withheld, not dropped. See `ganttOwnsData` above for why this
+              // branch cannot be observed at the chart today (objectui#7222)
+              // and why it is still the correct value to hand down.
+              ? {}
+              : { data })}
             loading={loading}
             onRowSelect={setSelectedRows}
             {...(currentView === 'grid' && !(groupingConfig?.fields?.length) && serverTotal != null

--- a/packages/plugin-list/src/__tests__/ListView.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.test.tsx
@@ -2656,8 +2656,19 @@ describe('ListView — gantt view fed by an api-provider ViewData', () => {
   // a composite endpoint that ObjectGantt resolves itself (resolveDataSource →
   // ApiDataSource). ListView must (a) forward schema.data into the gantt
   // component schema, (b) NOT fetch schema.objectName rows itself, and (c) NOT
-  // pass its rows `data` prop down — an array prop short-circuits the
-  // renderer's own fetch, replacing the endpoint's tree with raw object rows.
+  // pass its rows `data` prop down.
+  //
+  // (c) is asserted against the props-recording STUB below, which is the only
+  // place it is observable at all: the real `object-gantt` renderer forwards no
+  // host prop but `schema`, so nothing ListView puts on this element reaches
+  // the chart today (objectui#7222; pinned one package over in
+  // `plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx`). That makes (c)
+  // a guard on a path the registry does not currently reach — keep it. The day
+  // that wrapper forwards host props (objectui#7210, half 2, an open maintainer
+  // decision) it becomes load-bearing: `ObjectGantt.reload` short-circuits on
+  // `data && Array.isArray(data)`, and this view's rows array is a truthy `[]`
+  // forever, so handing it down would paint an EMPTY chart in place of the
+  // endpoint's tree.
   let prevObjectGantt: ReturnType<typeof ComponentRegistry.get>;
   let ganttCalls: any[];
 
@@ -2705,7 +2716,8 @@ describe('ListView — gantt view fed by an api-provider ViewData', () => {
     // (b) ListView did not query the bound object itself
     expect(mockDataSource.find).not.toHaveBeenCalled();
     // (c) no rows array prop — the schema-spread `data` (the ViewData object)
-    // must be what arrives, so ObjectGantt's own api fetch is not bypassed
+    // must be what arrives. Not observable through the real renderer today
+    // (see the note on this describe block); this pins ListView's own output.
     expect(Array.isArray(last?.data)).toBe(false);
   });
 


### PR DESCRIPTION
Part of #7222 — the half that is certain. #7222 remains open on purpose; see "What is deliberately NOT done" below, which is a maintainer decision this PR must not settle as a side effect.

## What changed

Comments only. No behaviour changes, and the changeset says so with an empty frontmatter.

**`packages/plugin-list/src/ListView.tsx`** — the note above `ganttOwnsData` said the rows `data` prop "short-circuits the renderer's own fetch, so stale object rows would replace the endpoint's tree". Measured on today's tree, that is false in its premise: the prop never reaches `ObjectGantt` at all. The registered `object-gantt` renderer (`plugin-gantt/src/index.tsx`) destructures `({ schema })` and hands the chart exactly `schema` and `dataSource`, so `data`, `onRowClick`, `rowHeight` and `onRowSelect` are all dropped one layer up. It is the only view wrapper that forwards nothing — grid, kanban, calendar, map and tree all spread the host props. Already pinned behaviourally one package over, in `packages/plugin-gantt/src/ObjectGantt.hostDataProp-7210.test.tsx`, so the corrected note cites that file rather than duplicating the pin.

The rewritten note states the mechanism, names what the old sentence got wrong and why believing it mattered (it says the host feeds the chart; the host does not — which is what made the double fetch invisible on a read-through), and records the one thing that keeps the withholding clause worth having.

A four-line note was also added at the clause itself (around the `SchemaRenderer` call), because it sits ~2300 lines below the flag it reads.

**`packages/plugin-list/src/__tests__/ListView.test.tsx`** — bounded in-place fix, declared here rather than left as unreviewable drift. The **same false sentence** was repeated verbatim on the `ListView — gantt view fed by an api-provider ViewData` describe block, one clause after the assertion it justifies. Same defect class as the card's Consequence 2, mechanical, and the correct form is pinned by the same evidence. Comments only; the assertions are untouched. The replacement also states what assertion (c) actually observes — a props-recording **stub**, which is the only place ListView's output on that element is observable at all.

## What is deliberately NOT done, and the measurement behind that

The card names two safe pieces: the false comment and the inert `ganttOwnsData ? {} : { data }` clause. The comment is corrected. **The clause is left in place**, against the card's suggestion, because verifying the premise turned up two facts the card did not have:

1. **It is not observationally inert.** `ListView.test.tsx` registers a props-recording stub for `object-gantt` and asserts `expect(Array.isArray(last?.data)).toBe(false)` — a live, currently-correct pin on ListView's own output. "The prop is dropped either way" is true at the *chart*, not at this component's boundary.

2. **Removing it arms a trap that the sibling card would spring.** `ObjectGantt.reload` takes its host-rows short-circuit on `data && Array.isArray(data)`. An empty array satisfies both halves, and this view's rows array is a truthy `[]` forever (the fetch effect returns early for it). So the moment `ObjectGanttRenderer` is made to forward host props — the shape objectui#7210 half 2 weighs — an api-provider gantt handed that array would short-circuit its own endpoint fetch and paint an EMPTY chart. Not the stale rows the old comment predicted; worse, and silent.

**Ablation, direction predicted before running:** apply the deletion exactly as suggested (replace the clause with an unconditional `data={data}`) and expect the api-provider case in `ListView.test.tsx` to go red on that one assertion, with the rest of the file green. Observed: `Tests 1 failed | 145 passed (146)`, the failure being `ListView — gantt view fed by an api-provider ViewData > forwards schema.data to the gantt schema, skips its own fetch, and withholds the rows prop` with `AssertionError: expected true to be false`. Mutation confirmed on disk before the run by anchored `grep -c` in both directions (removed anchor 0, injected anchor 1) and by a blob hash differing from the HEAD blob; restored with `git checkout HEAD -- ABSOLUTE_PATH` and proved byte-identical afterwards (`git hash-object` equal to the HEAD blob, `git diff HEAD` empty, removed anchor back to 1). No rebuild is involved: the root vitest config aliases every workspace specifier to `src`, and the subject is imported relatively.

So the delete/keep call is escalated rather than taken. It interacts with an open maintainer decision, and the deletion is not the no-op the card assumed.

## Tests — all at 2198b91b6

Run through the container's shared verify lock (`OS_VERIFY_LOCK_SLOT=dev-7222`); the verdict line is quoted, never a bare exit code. Shared-box seconds.

- `pnpm exec vitest run packages/plugin-list/` — `Test Files 62 passed (62)` / `Tests 787 passed (787)`; `VERDICT command-exit 0`.
- `pnpm exec vitest run` on the three gantt-touching files (`ListView.test.tsx`, `ListView.ganttPagingChrome-7210.test.tsx`, `ListView.gantt-binding-7070.test.tsx`) — `Test Files 3 passed (3)` / `Tests 160 passed (160)`; `VERDICT command-exit 0`. Re-run on the final commit.
- `pnpm --filter @object-ui/plugin-list run type-check` — `VERDICT command-exit 0`. Both `tsc --noEmit` and `tsc -p tsconfig.test.json` ran (script name echoed, so this was not a zero-match run), and `--listFiles` confirms the test program actually contains both edited files (1 hit each) — the edited test file is measured, not merely adjacent.
- `pnpm lint` (repo-wide `eslint .`, 47 tasks, no narrowing) — `VERDICT command-exit 0`.
- `node scripts/check-control-bytes.mjs` — `check-control-bytes: OK (scanned 6019 tracked text file(s))`, plus a direct control-byte scan of both edited files: no hits.
- `node scripts/check-changeset-presence.mjs` — exit 0: "Every one of them has an EMPTY frontmatter — declared as releasing nothing". This falsified the dispatch's assumption that no changeset would be owed: the gate does ask, because `plugin-list/src` is published source.
- `node scripts/check-changeset-no-major.mjs`, `check-changeset-fixed.mjs`, `check-changeset-overwrite.mjs` — all exit 0.
- `pnpm check:element-data-source-declaration` — exit 0 (13 gate-consuming files checked).
- `pnpm check:sdui-registration-pins` — **NOT MEASURED**, not red: it refuses without an `@object-ui/console` bundle ("Build the console first"). A comments-only diff cannot move registration pins; CI owns this one.

## Findings filed alongside (unassigned, `finding`)

- #7333 — `ObjectGantt.reload`'s host-`data` short-circuit fires on an empty array; the latent half of point 2 above, recorded where it lives.
- #7334 — a gantt view's authored view-level `navigation` reaches nothing: `baseProps` declares no `navigation` key and the `case 'gantt'` branch of `viewComponentSchema` adds none, so `ObjectGantt` always falls back to its own `mode: 'drawer'`. This sharpens the card's Consequence 3 without settling it — still not browser-verified. The half that card guessed at is confirmed: `ObjectGantt` does own a record drawer (`RecordDetailDrawer`, `schema.navigation ?? { mode: 'drawer' }`).

`packages/plugin-gantt/src/index.tsx` was not touched; out of scope: #7210 half 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho

_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_