### PR TITLE
fix(gantt,calendar,timeline): resolve `colorField` through one shared ladder

### DIFF
--- a/.changeset/7243-colorfield-shared-ladder.md
+++ b/.changeset/7243-colorfield-shared-ladder.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/core': patch
+'@object-ui/plugin-gantt': patch
+'@object-ui/plugin-calendar': patch
+'@object-ui/plugin-timeline': patch
+---
+
+`colorField` now means the same thing in the gantt, the calendar and the timeline
+(objectui#7243).
+
+**The inversion this fixes.** `gantt.colorField` is documented as "field that drives the
+bar color", and the renderer passed the stored value straight into the bar's
+`backgroundColor`. Pointing the key at a select field therefore emitted
+`backgroundColor: "open"` — not a colour, so the browser dropped the declaration and
+every bar rendered identically. OMITTING the key was strictly better: the absent-key
+branch derived a real colour per status. Declaring the documented key was worse than not
+declaring it, with no error, warning or console message either way.
+
+The same key also meant three different things across the three lenses: the timeline
+resolved the field's authored option `color`, the calendar hashed the raw value onto a
+fixed palette, and the gantt emitted the raw value. An author colouring three views by
+one field got three unrelated results, one of which was no colour at all.
+
+**The ladder.** `@object-ui/core` gains `createFieldColorResolver` — the timeline's
+resolver, lifted so all three call it:
+
+1. the field's own option `color` for the record's value;
+2. else the value itself when it already IS a colour literal (`#rgb`, `#rrggbb`,
+   `#rrggbbaa`, `rgb(...)`, `hsl(...)`);
+3. else each renderer's own last rung, which is deliberately NOT shared — the gantt
+   derives a semantic-token hex (a bar must be painted), the calendar keeps its
+   theme-aware 8-stop hash (a soft tint, not a solid fill), the timeline draws its
+   default marker.
+
+**What changes for authors.** A gantt or calendar whose `colorField` points at a select
+field with authored option colours now paints those colours. A gantt value that is
+neither an option colour nor a colour literal now derives a colour instead of emitting
+an invalid CSS value — including a palette NAME (`red`), which now resolves to that
+palette's hex, the behaviour the key's own contract has always promised ("hex or
+semantic name") and the one `borderColorField` already had. `gantt.borderColorField`
+takes rung 1 as well, so an authored option colour reaches the alert stroke; it keeps
+today's behaviour otherwise and deliberately gains no derivation rung, since the stroke
+is opt-in and deriving one for every record would draw an alert on records that have
+none.
+
+Calendars whose `colorField` points at a plain categorical field are unchanged: that
+value still reaches `CalendarView`'s deterministic hash exactly as before. The timeline
+is unchanged apart from accepting the 8-digit `#rrggbbaa` hex spelling the calendar
+already accepted.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,10 @@ export * from './utils/dataset-format.js';
 // (objectstack#5473 / objectstack#5665).
 export * from './utils/dataset-pivot.js';
 export * from './utils/record-title.js';
+// The one `colorField` ladder every record view shares (objectui#7243) — the
+// gantt, calendar and timeline all resolve an authored option colour here
+// instead of each guessing at the raw stored value.
+export * from './utils/record-color.js';
 export * from './utils/export-filename.js';
 export * from './utils/reference-keys.js';
 // Binds a fetched record into an expression scope the way the SERVER binds it

--- a/packages/core/src/utils/__tests__/record-color.test.ts
+++ b/packages/core/src/utils/__tests__/record-color.test.ts
@@ -1,0 +1,142 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7243 — the one `colorField` ladder gantt / calendar / timeline share.
+ *
+ * Rungs 1 and 2 live here; the last rung stays with each caller because each
+ * has a different right answer for "neither an option colour nor a literal"
+ * (gantt derives a semantic hex, calendar hashes onto its class palette,
+ * timeline draws its default marker). The renderer-side fixtures pinning that
+ * split are `ObjectGantt.colorFieldLadder-7243.test.tsx`,
+ * `ObjectCalendar.colorFieldLadder-7243.test.tsx` and
+ * `ObjectTimeline.colorFieldLadder-7243.test.tsx`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildFieldColorMap,
+  createFieldColorResolver,
+  isColorLiteral,
+} from '../record-color.js';
+
+const STATUS_FIELD = {
+  name: 'status',
+  type: 'select',
+  options: [
+    { value: 'open', label: 'Open', color: '#7c3aed' },
+    { value: 'done', label: 'Done', color: '#059669' },
+    { value: 'archived', label: 'Archived' },
+  ],
+};
+
+describe('buildFieldColorMap', () => {
+  it('keys by the option VALUE only', () => {
+    expect(buildFieldColorMap(STATUS_FIELD)).toEqual({ open: '#7c3aed', done: '#059669' });
+  });
+
+  it('is empty for a field with no options, and for no field at all', () => {
+    expect(buildFieldColorMap({ name: 'accent', type: 'text' } as any)).toEqual({});
+    expect(buildFieldColorMap(undefined)).toEqual({});
+    expect(buildFieldColorMap(null)).toEqual({});
+    expect(buildFieldColorMap({ options: 'nope' } as any)).toEqual({});
+  });
+
+  it('skips options with no colour, no value, or a non-string colour', () => {
+    expect(
+      buildFieldColorMap({
+        options: [
+          { value: 'a' },
+          { value: 'b', color: '' },
+          { value: 'c', color: 123 },
+          { color: '#fff' },
+          null,
+          'plain',
+          { value: 'd', color: '#fff' },
+        ],
+      } as any),
+    ).toEqual({ d: '#fff' });
+  });
+
+  it('stringifies non-string option values so a numeric picklist still resolves', () => {
+    expect(buildFieldColorMap({ options: [{ value: 1, color: '#111' }] } as any)).toEqual({
+      '1': '#111',
+    });
+  });
+});
+
+describe('isColorLiteral', () => {
+  it('accepts 3-, 6- and 8-digit hex', () => {
+    expect(isColorLiteral('#abc')).toBe(true);
+    expect(isColorLiteral('#AABBCC')).toBe(true);
+    // The deliberate widening: `plugin-calendar` already accepted this
+    // spelling, `plugin-timeline` did not. The narrow spelling was the only
+    // one under which a valid CSS colour could fall through to a DERIVED
+    // colour in the gantt.
+    expect(isColorLiteral('#aabbccdd')).toBe(true);
+  });
+
+  it('accepts rgb() and hsl() forms', () => {
+    expect(isColorLiteral('rgb(1, 2, 3)')).toBe(true);
+    expect(isColorLiteral('rgba(1, 2, 3, 0.5)')).toBe(true);
+    expect(isColorLiteral('hsl(1 2% 3%)')).toBe(true);
+  });
+
+  it('rejects stored values that merely look like words', () => {
+    expect(isColorLiteral('open')).toBe(false);
+    expect(isColorLiteral('in_progress')).toBe(false);
+    expect(isColorLiteral('#12')).toBe(false);
+    expect(isColorLiteral('#1234567')).toBe(false);
+    expect(isColorLiteral('bg-blue-500')).toBe(false);
+  });
+});
+
+describe('createFieldColorResolver', () => {
+  const resolve = createFieldColorResolver(STATUS_FIELD);
+
+  it('rung 1: the value takes its own option colour', () => {
+    expect(resolve('open')).toBe('#7c3aed');
+    expect(resolve('done')).toBe('#059669');
+  });
+
+  it('rung 1 wins over rung 2 — an option colour is never re-derived', () => {
+    const r = createFieldColorResolver({ options: [{ value: '#000000', color: '#7c3aed' }] });
+    expect(r('#000000')).toBe('#7c3aed');
+  });
+
+  it('rung 2: a colour literal in a plain field passes through', () => {
+    const r = createFieldColorResolver({ name: 'accent', type: 'text' } as any);
+    expect(r('#123456')).toBe('#123456');
+    expect(r('rgb(1, 2, 3)')).toBe('rgb(1, 2, 3)');
+  });
+
+  it('returns undefined for a value the field does not colour — the caller owns the last rung', () => {
+    // An option with no `color` is exactly as unresolved as an unknown value:
+    // both hand the decision back to the caller.
+    expect(resolve('archived')).toBeUndefined();
+    expect(resolve('nonesuch')).toBeUndefined();
+  });
+
+  it('returns undefined for empty values rather than a colour for ""', () => {
+    expect(resolve(undefined)).toBeUndefined();
+    expect(resolve(null)).toBeUndefined();
+    expect(resolve('')).toBeUndefined();
+  });
+
+  it('resolves a numeric stored value against a numeric picklist', () => {
+    const r = createFieldColorResolver({ options: [{ value: 1, color: '#111' }] });
+    expect(r(1)).toBe('#111');
+    expect(r('1')).toBe('#111');
+  });
+
+  it('works with no field definition at all — literals still resolve, options cannot', () => {
+    const r = createFieldColorResolver(undefined);
+    expect(r('#abc')).toBe('#abc');
+    expect(r('open')).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/record-color.ts
+++ b/packages/core/src/utils/record-color.ts
@@ -1,0 +1,116 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Resolve the colour a record's value stands for, off the field's own metadata.
+ *
+ * ## Why this is shared (objectui#7243)
+ *
+ * `colorField` is one authored key — `gantt.colorField`, `calendar.colorField`,
+ * `timeline.colorField` — and it used to mean three different things:
+ *
+ *   - `plugin-timeline` resolved the field's option `color` (correct);
+ *   - `plugin-calendar` passed the raw value on to a deterministic hash, so the
+ *     colour the author declared on the option was never consulted;
+ *   - `plugin-gantt` passed the raw value straight into `backgroundColor`, so
+ *     `colorField: 'status'` emitted `backgroundColor: "open"` — not a colour.
+ *     The browser dropped the declaration and every bar rendered identically,
+ *     which made DECLARING the documented key strictly worse than omitting it.
+ *
+ * The timeline's resolver is lifted here verbatim so all three answer the same
+ * question the same way. What lives here is the part that is genuinely common —
+ * the two rungs that depend only on the field metadata and the stored value:
+ *
+ *   1. the field's own option `color` for that value;
+ *   2. the value itself when it already IS a CSS colour literal.
+ *
+ * The LAST rung deliberately stays with each caller, because each one has a
+ * different right answer for "a value that is neither": the gantt derives a
+ * semantic token hex (a bar must be painted), the calendar hashes onto its
+ * theme-aware 8-stop class palette (a soft tint, not a solid fill), and the
+ * timeline draws its default marker variant. Pulling those together would be a
+ * repaint of existing views, not a bug fix.
+ *
+ * ## Keyed by option `value` only
+ *
+ * Deliberately NOT `buildOptionColorMap` (`./chart-series.ts`), which keys by
+ * value AND display label: that one reads dataset ROWS, where the server may
+ * have resolved a select dimension to its label. These callers read RECORDS,
+ * where `record[colorField]` is the stored value. Keying by label as well would
+ * colour a record whose stored value happens to collide with another option's
+ * label — a tolerance nothing here needs, and one the timeline never had.
+ */
+
+/** One entry of a select-like field's `options`, as far as colour is concerned. */
+export interface FieldColorOption {
+  value?: unknown;
+  color?: unknown;
+}
+
+/** The slice of a field definition this resolver reads. */
+export interface FieldColorDefinition {
+  options?: unknown;
+}
+
+/**
+ * Colour literals the renderers accept as-is.
+ *
+ * Hex accepts 3, 6 and 8 digits. The timeline's private regex accepted 3 and 6;
+ * `plugin-calendar`'s accepted 3, 6 and 8 — two in-repo spellings of the same
+ * question, and the narrow one is the only one under which a VALID CSS colour
+ * (`#rrggbbaa`) could fall past this rung and be replaced by a derived colour.
+ * Widening can only turn "not recognised" into "the author's colour"; it can
+ * never turn a colour into something else. So the wider spelling wins.
+ */
+const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+/** Does this string already name a colour the DOM can paint? */
+export function isColorLiteral(value: string): boolean {
+  return HEX_COLOR_RE.test(value) || value.startsWith('rgb') || value.startsWith('hsl');
+}
+
+/**
+ * Build a `value -> option colour` lookup from a field definition's `options`.
+ * Returns an empty map for a field with no options, so callers need no guard.
+ */
+export function buildFieldColorMap(fieldDef: FieldColorDefinition | undefined | null): Record<string, string> {
+  const options = fieldDef?.options;
+  if (!Array.isArray(options)) return {};
+  const map: Record<string, string> = {};
+  for (const opt of options as FieldColorOption[]) {
+    if (!opt || typeof opt !== 'object') continue;
+    if (opt.value == null) continue;
+    if (typeof opt.color === 'string' && opt.color) map[String(opt.value)] = opt.color;
+  }
+  return map;
+}
+
+/**
+ * Build the per-field colour resolver: rung 1 (option colour) then rung 2 (the
+ * value is already a colour literal), else `undefined` so the caller runs its
+ * own last rung.
+ *
+ * A factory rather than a plain function because callers resolve one field
+ * across every row of a view — the option map is built once, not per record.
+ *
+ * @param fieldDef `objectSchema.fields[colorField]`, or `undefined` when the
+ *   view has no schema in hand (an inline-data or `api`-provider view). With no
+ *   options, rung 1 is a no-op and rung 2 still answers for literal colours.
+ */
+export function createFieldColorResolver(
+  fieldDef: FieldColorDefinition | undefined | null,
+): (value: unknown) => string | undefined {
+  const colorByValue = buildFieldColorMap(fieldDef);
+  return (value: unknown): string | undefined => {
+    if (value == null || value === '') return undefined;
+    const key = String(value);
+    const optionColor = colorByValue[key];
+    if (optionColor) return optionColor;
+    return isColorLiteral(key) ? key : undefined;
+  };
+}

--- a/packages/plugin-calendar/src/ObjectCalendar.colorFieldLadder-7243.test.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.colorFieldLadder-7243.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7243 — the same `colorField` used to mean three different things
+ * across gantt / calendar / timeline. This file pins the calendar's half.
+ *
+ * BEFORE: `ObjectCalendar` handed `CalendarView` the RAW record value, so an
+ * authored option colour never reached the event — `"open"` fell through to
+ * `resolveEventColor`'s deterministic 8-stop hash and produced a palette class
+ * unrelated to the colour the author declared on the field's option.
+ *
+ * AFTER: the shared ladder (`@object-ui/core#createFieldColorResolver`) runs
+ * first, so a select field's option colour arrives as a hex and
+ * `resolveEventColor` paints THAT.
+ *
+ * The hash is NOT retired — it stays as the last rung, unchanged, for values
+ * no option colours it (a category label on a schemaless / inline-data
+ * calendar). That is deliberate: retiring it would repaint every existing
+ * calendar whose `colorField` points at a plain categorical field, which is a
+ * behaviour change well beyond this card, and `CalendarView`'s soft-tint class
+ * pairs are theme-aware where a derived solid hex would not be.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectCalendar } from './ObjectCalendar';
+import { __resolveEventColorForTest as resolveEventColor } from './CalendarView';
+
+vi.mock('@object-ui/plugin-detail', () => ({
+  RecordDetailDrawer: () => null,
+  deriveRecordPageHref: () => null,
+}));
+
+let lastEvents: any[] = [];
+
+vi.mock('./CalendarView', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    CalendarView: ({ events }: any) => {
+      lastEvents = events;
+      return <div data-testid="calendar-view" data-event-count={String(events.length)} />;
+    },
+  };
+});
+
+/** The authored option colours — identical to the gantt and timeline fixtures. */
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open', color: '#7c3aed' },
+  { value: 'done', label: 'Done', color: '#059669' },
+];
+
+const OBJECT_SCHEMA = {
+  name: 'duly_task',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    subject: { name: 'subject', type: 'text' },
+    starts_at: { name: 'starts_at', type: 'datetime' },
+    ends_at: { name: 'ends_at', type: 'datetime' },
+    status: { name: 'status', type: 'select', options: STATUS_OPTIONS },
+    category: { name: 'category', type: 'text' },
+  },
+};
+
+const ROWS = [
+  {
+    id: '1',
+    subject: 'Ship it',
+    status: 'open',
+    category: 'email',
+    starts_at: '2026-01-01T09:00:00Z',
+    ends_at: '2026-01-01T10:00:00Z',
+  },
+];
+
+function makeDataSource(rows: any[] = ROWS, objectSchema: any = OBJECT_SCHEMA) {
+  return {
+    find: vi.fn(async () => ({ data: rows, total: rows.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => objectSchema),
+  } as any;
+}
+
+async function colorsFor(colorField: string, rows: any[] = ROWS, objectSchema: any = OBJECT_SCHEMA) {
+  lastEvents = [];
+  const schema: any = {
+    type: 'object-calendar',
+    objectName: 'duly_task',
+    calendar: {
+      startDateField: 'starts_at',
+      endDateField: 'ends_at',
+      titleField: 'subject',
+      colorField,
+    },
+  };
+  render(<ObjectCalendar schema={schema} dataSource={makeDataSource(rows, objectSchema)} />);
+  await waitFor(() => expect(lastEvents.length).toBe(rows.length));
+  return lastEvents.map((e) => e.color);
+}
+
+describe('objectui#7243 — calendar colorField ladder', () => {
+  it('rung 1: a select field paints the AUTHORED option colour', async () => {
+    expect(await colorsFor('status')).toEqual(['#7c3aed']);
+  });
+
+  it('the authored colour reaches the DOM as a real colour, not a hashed class', () => {
+    expect(resolveEventColor('#7c3aed')).toEqual({ className: 'text-white', inlineColor: '#7c3aed' });
+    // What the pre-fix raw value produced instead: a palette class, no colour.
+    expect(resolveEventColor('open').inlineColor).toBeUndefined();
+  });
+
+  it('last rung: a value no option colours still reaches the hash unchanged', async () => {
+    expect(await colorsFor('category')).toEqual(['email']);
+    expect(resolveEventColor('email').className).toMatch(/^bg-/);
+  });
+});

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -52,6 +52,7 @@ import {
   buildExpandFields,
   convertSortToQueryParams,
   getRecordDisplayName,
+  createFieldColorResolver,
 } from '@object-ui/core';
 
 export interface CalendarSchema {
@@ -418,6 +419,14 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
     }
 
     const { startDateField, endDateField, titleField, colorField } = calendarConfig;
+    // `colorField` NAMES A FIELD to derive a colour from (objectui#7243). The
+    // shared ladder answers the two rungs that depend only on the field's own
+    // metadata — the option `color` the author declared for this value, then
+    // the value itself when it already IS a colour literal. Built once for the
+    // whole dataset, not per record.
+    const resolveColorFieldValue = createFieldColorResolver(
+      (objectSchema?.fields as Record<string, any> | undefined)?.[colorField ?? ''],
+    );
     const resolveTitle = (record: Record<string, any>): string => {
       // 1. Explicit titleField wins when present on the record.
       if (titleField) {
@@ -437,7 +446,14 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
       const startDate = record[startDateField];
       const endDate = endDateField ? record[endDateField] : null;
       const title = resolveTitle(record);
-      const color = colorField ? record[colorField] : undefined;
+      // Last rung stays where it was: a value no option colours is handed on
+      // RAW, so `CalendarView.resolveEventColor` still recognises a Tailwind
+      // utility string and still hashes a plain category label onto its
+      // theme-aware 8-stop palette. Retiring that would repaint every existing
+      // calendar whose `colorField` points at a plain categorical field, which
+      // is well beyond this fix.
+      const colorRaw = colorField ? record[colorField] : undefined;
+      const color = resolveColorFieldValue(colorRaw) ?? colorRaw;
 
       return {
         id: record.id || record._id || `event-${index}`,

--- a/packages/plugin-gantt/src/ObjectGantt.colorFieldLadder-7243.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.colorFieldLadder-7243.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7243 — `gantt.colorField` used to be passed RAW into the bar's
+ * `backgroundColor`.
+ *
+ * Pointing the documented key at a select field therefore produced
+ * `backgroundColor: "open"` — not a colour, so the browser dropped the
+ * declaration and every bar rendered identically. OMITTING the key was
+ * strictly better: the absent-key branch derived a real colour per status.
+ *
+ * The ladder this file pins (the triage ruling on #7243, shared with
+ * `plugin-timeline` and `plugin-calendar` through
+ * `@object-ui/core#createFieldColorResolver`):
+ *
+ *   1. the field's own option `color` for the record's value;
+ *   2. else the value when it already IS a colour literal (#hex / rgb / hsl);
+ *   3. else the existing semantic-token derivation — never a raw value.
+ *
+ * The assertions read the `tasks` prop `ObjectGantt` hands `GanttView` rather
+ * than the painted bar: that prop IS the colour contract between the two
+ * (`GanttView` writes `backgroundColor: task.color || '#3b82f6'` at four
+ * sites), and reading it keeps the fixture from depending on which of those
+ * four sites a given row happens to take.
+ *
+ * REVERSE VERIFICATION — direction predicted before running: on the
+ * unmodified tree the first case reports `color: 'open'` instead of the
+ * authored `#7c3aed`, and the palette-token case reports `'red'` instead of
+ * that palette's hex. Both are the pre-fix values, not a crash.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectGantt } from './ObjectGantt';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+vi.mock('@object-ui/plugin-detail', () => ({
+  RecordDetailDrawer: () => null,
+  deriveRecordPageHref: () => null,
+}));
+
+let lastTasks: any[] = [];
+
+vi.mock('./GanttView', () => ({
+  GanttView: ({ tasks }: any) => {
+    lastTasks = tasks;
+    return <div data-testid="gantt-view" data-task-count={String(tasks.length)} />;
+  },
+}));
+
+/** The authored option colours — the single fact all three renderers must agree on. */
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open', color: '#7c3aed' },
+  { value: 'done', label: 'Done', color: '#059669' },
+];
+
+const OBJECT_SCHEMA = {
+  name: 'duly_task',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    subject: { name: 'subject', type: 'text' },
+    visible_from: { name: 'visible_from', type: 'date' },
+    due_date: { name: 'due_date', type: 'date' },
+    status: { name: 'status', type: 'select', options: STATUS_OPTIONS },
+    // No `options` — a plain text field an author may use to store a literal
+    // colour, which is the only shape rung 2 exists for.
+    accent: { name: 'accent', type: 'text' },
+  },
+};
+
+const ROWS = [
+  {
+    id: '1',
+    subject: 'Ship it',
+    status: 'open',
+    accent: '#123456',
+    visible_from: '2026-01-01',
+    due_date: '2026-01-10',
+  },
+];
+
+function makeDataSource(rows: any[] = ROWS) {
+  return {
+    find: vi.fn(async () => ({ data: rows, total: rows.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+  } as any;
+}
+
+async function colorsFor(colorField: string, rows: any[] = ROWS) {
+  lastTasks = [];
+  const schema: any = {
+    type: 'object-gantt',
+    objectName: 'duly_task',
+    gantt: {
+      titleField: 'subject',
+      startDateField: 'visible_from',
+      endDateField: 'due_date',
+      colorField,
+    },
+  };
+  render(<ObjectGantt schema={schema} dataSource={makeDataSource(rows)} />);
+  await waitFor(() => expect(lastTasks.length).toBe(rows.length));
+  return lastTasks.map((t) => t.color);
+}
+
+describe('objectui#7243 — gantt colorField ladder', () => {
+  it('rung 1: a select field paints the AUTHORED option colour', async () => {
+    expect(await colorsFor('status')).toEqual(['#7c3aed']);
+  });
+
+  it('rung 2: a literal hex in a plain field still passes through untouched', async () => {
+    expect(await colorsFor('accent')).toEqual(['#123456']);
+  });
+
+  it('rung 3: a value with no option colour derives a colour, never the raw value', async () => {
+    const rows = [{ ...ROWS[0], status: 'in_progress' }];
+    const schemaless = {
+      ...OBJECT_SCHEMA,
+      fields: { ...OBJECT_SCHEMA.fields, status: { name: 'status', type: 'text' } },
+    };
+    lastTasks = [];
+    const ds = {
+      find: vi.fn(async () => ({ data: rows, total: rows.length })),
+      findOne: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      getObjectSchema: vi.fn(async () => schemaless),
+    } as any;
+    render(
+      <ObjectGantt
+        schema={{
+          type: 'object-gantt',
+          objectName: 'duly_task',
+          gantt: {
+            titleField: 'subject',
+            startDateField: 'visible_from',
+            endDateField: 'due_date',
+            colorField: 'status',
+          },
+        } as any}
+        dataSource={ds}
+      />,
+    );
+    await waitFor(() => expect(lastTasks.length).toBe(1));
+    // `in_progress` is a SEMANTIC_COLOR_MAP key -> blue -> that palette's hex.
+    expect(lastTasks[0].color).toBe('#3b82f6');
+    expect(lastTasks[0].color).not.toBe('in_progress');
+  });
+
+  it('rung 3: a palette token resolves to that palette colour, not a raw CSS name', async () => {
+    const rows = [{ ...ROWS[0], accent: 'red' }];
+    expect(await colorsFor('accent', rows)).toEqual(['#ef4444']);
+  });
+
+  it('an empty colorField value still falls back to the record status story', async () => {
+    const rows = [{ ...ROWS[0], accent: '' }];
+    // `status: 'open'` -> SEMANTIC_COLOR_MAP blue.
+    expect(await colorsFor('accent', rows)).toEqual(['#3b82f6']);
+  });
+
+  it('borderColorField takes rung 1 too — the alert stroke honours option colours', async () => {
+    lastTasks = [];
+    render(
+      <ObjectGantt
+        schema={{
+          type: 'object-gantt',
+          objectName: 'duly_task',
+          gantt: {
+            titleField: 'subject',
+            startDateField: 'visible_from',
+            endDateField: 'due_date',
+            borderColorField: 'status',
+          },
+        } as any}
+        dataSource={makeDataSource()}
+      />,
+    );
+    await waitFor(() => expect(lastTasks.length).toBe(1));
+    expect(lastTasks[0].borderColor).toBe('#7c3aed');
+  });
+});

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -51,6 +51,7 @@ import {
   convertSortToQueryParams,
   getRecordDisplayName,
   resolveDataSource,
+  createFieldColorResolver,
 } from '@object-ui/core';
 import {
   getSemanticColorName,
@@ -742,6 +743,12 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
 
     const { startDateField, endDateField, titleField, progressField, dependenciesField, colorField, borderColorField, parentField, typeField, lockField, tooltipFields, baselineStartField, baselineEndField, quickFilters } = ganttConfig;
     const fieldDefs: Record<string, any> = objectSchema?.fields ?? {};
+    // One resolver per declared colour field, built once for the whole
+    // dataset rather than per row: rung 1 (the field's own option colour)
+    // plus rung 2 (the value already IS a colour literal). See
+    // `@object-ui/core#createFieldColorResolver` (objectui#7243).
+    const resolveColorFieldValue = createFieldColorResolver(fieldDefs[colorField ?? '']);
+    const resolveBorderColorFieldValue = createFieldColorResolver(fieldDefs[borderColorField ?? '']);
 
     // Fallback value→label maps from the view's quickFilters config. When the
     // data comes from an `api` provider there is no object schema, so select
@@ -929,12 +936,33 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
       const title = resolveTitle(record);
       const progress = progressField ? record[progressField] : 0;
       const dependencies = dependenciesField ? record[dependenciesField] : [];
-      // Bar color resolution:
-      //   1. explicit `colorField` value (hex or semantic name) — metadata wins.
-      //   2. fall back to the record's status / state / priority field so
-      //      the timeline reflects the same color story as list/kanban.
-      //   3. if neither exists, GanttView paints the platform default blue.
-      let color = colorField ? record[colorField] : undefined;
+      // Bar color resolution (objectui#7243). `colorField` NAMES A FIELD to
+      // derive a colour from — it is not itself a colour, and the value stored
+      // in that field usually isn't one either. The rungs, shared with
+      // plugin-timeline and plugin-calendar via `createFieldColorResolver`:
+      //   1. the field's own option `color` for this record's value —
+      //      the colour the author actually declared;
+      //   2. the value itself when it already IS a colour literal;
+      //   3. the semantic-token derivation, which also maps a palette NAME
+      //      ('red') to that palette's hex — what the key's contract has always
+      //      promised ("hex or semantic name").
+      // Only when `colorField` is absent or its value is empty do we fall back
+      // to the record's status / state / priority so the chart reflects the
+      // same colour story as list/kanban; if neither exists GanttView paints
+      // the platform default blue.
+      //
+      // ⛔ The raw value must never reach `color` again. That was this card's
+      // defect: `backgroundColor: "open"` is not a colour, so the browser
+      // dropped the declaration and every bar rendered identically — DECLARING
+      // the documented key was strictly worse than omitting it, silently.
+      const colorValue = colorField ? record[colorField] : undefined;
+      let color = resolveColorFieldValue(colorValue);
+      if (!color && colorValue != null && colorValue !== '') {
+        // Rung 3 for the declared field's own value. `getSemanticColorName`
+        // always answers for a non-empty value (semantic map, else its stable
+        // hash), so a declared `colorField` always paints something real.
+        color = getSemanticHex(getSemanticColorName(String(colorValue), colorValue));
+      }
       if (!color) {
         const fallbackVal =
           record.status ?? record.state ?? record.priority ?? record.severity;
@@ -943,12 +971,19 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
           if (name) color = getSemanticHex(name);
         }
       }
-      // Alert stroke: semantic palette names map to their hex;
-      // anything else (hex, css color) passes through untouched.
+      // Alert stroke: the option colour first (same rung 1 as the bar — an
+      // authored option colour is an authored option colour whichever slot it
+      // paints), then today's behaviour: semantic palette names map to their
+      // hex, anything else (hex, css color) passes through untouched.
+      //
+      // Deliberately NO rung 3 here. The stroke is opt-in and exceptional —
+      // deriving one for every record would draw an alert on records that have
+      // none, which is a repaint, not a fix.
       const borderColorRaw = borderColorField ? record[borderColorField] : undefined;
       const borderColor =
         borderColorRaw != null && borderColorRaw !== ''
-          ? getSemanticHex(String(borderColorRaw), String(borderColorRaw))
+          ? resolveBorderColorFieldValue(borderColorRaw)
+            ?? getSemanticHex(String(borderColorRaw), String(borderColorRaw))
           : undefined;
 
       return {

--- a/packages/plugin-timeline/src/ObjectTimeline.colorFieldLadder-7243.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.colorFieldLadder-7243.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7243 — the CONTROL of the three-renderer fixture set.
+ *
+ * `plugin-timeline` was already the reference implementation: it built a
+ * value -> option map off `objectSchema.fields[colorField].options` and read
+ * `option.color`. This file pins that observable behaviour so the resolver can
+ * be LIFTED into `@object-ui/core#createFieldColorResolver` without moving it
+ * — every case below is green BEFORE the lift and green AFTER, which is what
+ * makes gantt's and calendar's red-to-green readings mean something.
+ *
+ * The one deliberate widening the lift carries is recorded here too: the hex
+ * literal test accepts the 8-digit `#rrggbbaa` spelling, which the timeline's
+ * private regex (3 or 6 digits) did not. `plugin-calendar`'s own hex test
+ * already accepted 8 digits, so the two in-repo spellings disagreed; the
+ * shared rung takes the wider one because the narrow one is the only spelling
+ * under which a VALID CSS colour could fall through to a derived colour in
+ * gantt. It can only turn "no colour" into the author's colour — never the
+ * reverse.
+ *
+ * The assertions read the items `ObjectTimeline` composes for
+ * `TimelineRenderer`; that `color` is what the renderer turns into the
+ * marker's `borderColor` / translucent `backgroundColor`.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectTimeline } from './ObjectTimeline';
+
+let lastItems: any[] = [];
+
+vi.mock('./renderer', () => ({
+  TimelineRenderer: ({ schema }: any) => {
+    lastItems = schema.items ?? [];
+    return <div data-testid="timeline-renderer" data-item-count={String(lastItems.length)} />;
+  },
+}));
+
+/** The authored option colours — identical to the gantt and calendar fixtures. */
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open', color: '#7c3aed' },
+  { value: 'done', label: 'Done', color: '#059669' },
+];
+
+const OBJECT_SCHEMA = {
+  name: 'duly_task',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    subject: { name: 'subject', type: 'text' },
+    starts_at: { name: 'starts_at', type: 'datetime' },
+    status: { name: 'status', type: 'select', options: STATUS_OPTIONS },
+    accent: { name: 'accent', type: 'text' },
+  },
+};
+
+const ROW = {
+  id: '1',
+  subject: 'Ship it',
+  status: 'open',
+  accent: '#123456',
+  starts_at: '2026-01-01T09:00:00Z',
+};
+
+function makeDataSource(rows: any[]) {
+  return {
+    find: vi.fn(async () => ({ data: rows, total: rows.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+  } as any;
+}
+
+async function colorsFor(colorField: string, rows: any[] = [ROW]) {
+  lastItems = [];
+  const schema: any = {
+    type: 'timeline',
+    objectName: 'duly_task',
+    titleField: 'subject',
+    startDateField: 'starts_at',
+    colorField,
+  };
+  render(<ObjectTimeline schema={schema} dataSource={makeDataSource(rows)} />);
+  await waitFor(() => expect(lastItems.length).toBe(rows.length));
+  return lastItems.map((i) => i.color);
+}
+
+describe('objectui#7243 — timeline colorField ladder (control: green before and after)', () => {
+  it('rung 1: a select field paints the AUTHORED option colour', async () => {
+    expect(await colorsFor('status')).toEqual(['#7c3aed']);
+  });
+
+  it('rung 1: an unmatched value in an optioned field takes no option colour', async () => {
+    const rows = [{ ...ROW, status: 'archived' }];
+    expect(await colorsFor('status', rows)).toEqual([undefined]);
+  });
+
+  it('rung 2: 3- and 6-digit hex literals pass through', async () => {
+    expect(await colorsFor('accent', [{ ...ROW, accent: '#abc' }])).toEqual(['#abc']);
+    expect(await colorsFor('accent', [{ ...ROW, accent: '#123456' }])).toEqual(['#123456']);
+  });
+
+  it('rung 2: rgb() and hsl() literals pass through', async () => {
+    expect(await colorsFor('accent', [{ ...ROW, accent: 'rgb(1, 2, 3)' }])).toEqual(['rgb(1, 2, 3)']);
+    expect(await colorsFor('accent', [{ ...ROW, accent: 'hsl(1 2% 3%)' }])).toEqual(['hsl(1 2% 3%)']);
+  });
+
+  it('a value that is neither an option nor a colour literal yields no colour', async () => {
+    expect(await colorsFor('accent', [{ ...ROW, accent: 'in_progress' }])).toEqual([undefined]);
+  });
+
+  it('an empty value yields no colour', async () => {
+    expect(await colorsFor('accent', [{ ...ROW, accent: '' }])).toEqual([undefined]);
+  });
+});
+
+/**
+ * The ONE case in this file that is not a control: it was red before the lift
+ * and is green after. Kept separate so the block above can be read as the pure
+ * before/after control it is.
+ */
+describe('objectui#7243 — the lift widens the hex spelling by one form', () => {
+  it('rung 2: an 8-digit #rrggbbaa literal now passes through too', async () => {
+    expect(await colorsFor('accent', [{ ...ROW, accent: '#aabbccdd' }])).toEqual(['#aabbccdd']);
+  });
+});

--- a/packages/plugin-timeline/src/ObjectTimeline.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { DataSource, TimelineSchema, ListViewTimelineConfig } from '@object-ui/types';
 import { useDataScope, useNavigationOverlay, useSafeFieldLabel } from '@object-ui/react';
 import { NavigationOverlay } from '@object-ui/components';
-import { extractRecords, buildExpandFields, convertSortToQueryParams } from '@object-ui/core';
+import { extractRecords, buildExpandFields, convertSortToQueryParams, createFieldColorResolver } from '@object-ui/core';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { z } from 'zod';
 import { TimelineRenderer } from './renderer';
@@ -274,8 +274,6 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
       return map;
     };
 
-    const colorOptions = optionMap(colorField);
-
     /** Which fields appear as inline chips beside the title.
      *  Spec config: `timeline.metaFields: string[]`.
      *  Heuristic default: `['status', 'priority']` — limited to fields that
@@ -290,14 +288,15 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
     // Resolve the marker color for an item: prefer the explicit `color`
     // attribute on the matching select option, else use the raw value if
     // it already looks like a CSS color.
-    const resolveColor = (value: any): string | undefined => {
-      if (value == null || value === '') return undefined;
-      const opt = colorOptions[String(value)];
-      if (opt?.color) return String(opt.color);
-      const s = String(value);
-      if (/^#([0-9a-f]{3}){1,2}$/i.test(s) || s.startsWith('rgb') || s.startsWith('hsl')) return s;
-      return undefined;
-    };
+    //
+    // This resolver used to be private to this file. It is now
+    // `@object-ui/core#createFieldColorResolver`, LIFTED unchanged so the
+    // gantt and the calendar answer `colorField` the same way this one always
+    // did (objectui#7243) — the same authored option colour, on the same
+    // record, in all three lenses. Its one widening is the hex spelling (3, 6
+    // or 8 digits, where this copy took 3 or 6); the shared module carries the
+    // reasoning.
+    const resolveColor = createFieldColorResolver(fields[colorField ?? '']);
 
     // Resolve the localized label (and color, when known) for a select
     // field. Used for both the explicit groupBy label and the inline


### PR DESCRIPTION
Fixes #7243

`gantt.colorField` is documented as "field that drives the bar color", and the renderer passed the stored value straight into the bar's `backgroundColor`. Pointing the documented key at a select field emitted `backgroundColor: "open"` — not a colour, so the browser dropped the declaration and every bar rendered identically. **Omitting** the key was strictly better, because the absent-key branch derived a real colour per status. And the same key meant three different things across the three lenses: the timeline resolved the field's authored option colour, the calendar hashed the raw value onto a fixed palette, the gantt emitted the raw value.

## The ladder

`@object-ui/core` gains `createFieldColorResolver` (`packages/core/src/utils/record-color.ts`) — `plugin-timeline`'s resolver, **lifted, not rewritten**, so all three call one thing:

1. the field's own option `color` for the record's value;
2. else the value itself when it already IS a colour literal (`#rgb`, `#rrggbb`, `#rrggbbaa`, `rgb(...)`, `hsl(...)`);
3. else **each caller's own last rung**, deliberately NOT shared — the gantt derives a semantic-token hex (a bar must be painted), the calendar keeps its theme-aware 8-stop hash (a soft tint, not a solid fill), the timeline draws its default marker. Sharing those would repaint existing views, which is not what this card asks for.

Keyed by the option `value` only. Deliberately not `buildOptionColorMap` (`chart-series.ts`), which also keys by display **label**: that one reads dataset ROWS, where the server may have resolved a dimension to its label. These callers read RECORDS, where the stored value is the contract — and label-keying would be a tolerance the timeline never had.

## Falsified PM assumptions, and the two judgement calls

- **Shared home.** `@object-ui/core` confirmed by reading all three manifests, not assumed: `core`, `components`, `i18n`, `react`, `types` are the packages all three already depend on. **No new workspace dependency edge** — `check:phantom-deps` green. `@object-ui/fields` was rejected as the home: `plugin-timeline` does not depend on it, and `fields` depends on `core`, so hosting the ladder there would either add an edge or make a cycle. That is also why rung 3 stays at the callers — it needs `fields`' semantic-token helpers, which `core` may not reach.
- **`borderColorField` — bounded in-place fix, named here as it must be.** The stroke had the same defect from the same line shape (`getSemanticHex(raw, raw)` passes any unrecognised string through, so a select value reached `borderColor` raw). It takes **rung 1 only**: an authored option colour now reaches the stroke, and everything else keeps today's behaviour byte for byte. It deliberately gains **no** rung 3 — the alert stroke is opt-in, and deriving one for every record would draw an alert on records that have none. Pinned by the last case in the gantt fixture (pre-fix reading `'open'`, post-fix `'#7c3aed'`).
- **A palette NAME now resolves to that palette's hex.** `colorField` pointing at a field holding `red` used to paint CSS `red`; it now paints `#ef4444`. That is the behaviour the site's own contract has always promised ("hex or semantic name") and the one `borderColorField` already had one line below. Pinned.
- **One deliberate widening: the hex spelling.** The timeline's private regex took 3 or 6 digits; `plugin-calendar`'s took 3, 6 or 8. Two in-repo spellings of one question, and the narrow one is the only one under which a **valid** CSS colour (`#rrggbbaa`) could fall past rung 2 and be replaced by a derived colour in the gantt. Widening can only turn "not recognised" into the author's colour, never the reverse. Pinned separately from the control block in the timeline fixture, because it is the one case there that was red before the lift.
- **Calendar's hash is NOT retired — it is the last rung.** A `colorField` pointing at a plain categorical field still reaches `CalendarView.resolveEventColor` with the raw value and still hashes, unchanged. Retiring it would repaint every existing authored calendar of that shape and would trade a theme-aware class pair for a solid inline fill; that is a behaviour change beyond this card, so it was not made. `CalendarView.test.tsx`'s five hash pins are untouched and green.
- **Out of scope, deliberately:** `calendar-view-renderer.tsx`'s plain `calendar` block resolves `record[colorField]` with no object schema in hand, so there are no options to resolve there — the raw pass-through is correct on that surface and is left alone.

## Proof — one fixture per renderer, same `status` value, same authored colour

Three fixtures share one shape: field `status` with options `open` -> `#7c3aed`, `done` -> `#059669`; record `status: 'open'`; `colorField: 'status'`.

Pre-fix, on the unmodified tree:

- gantt `ObjectGantt.colorFieldLadder-7243.test.tsx` — **RED**, `Tests 4 failed | 2 passed (6)`, rung 1 reporting `expected [ 'open' ] to deeply equal [ '#7c3aed' ]` — the card's inversion, measured.
- calendar `ObjectCalendar.colorFieldLadder-7243.test.tsx` — **RED**, `Tests 1 failed | 8 passed`, same `[ 'open' ]` vs `[ '#7c3aed' ]`.
- timeline `ObjectTimeline.colorFieldLadder-7243.test.tsx` — **GREEN 6/6** before the lift (the control), green after.

Post-fix the four suites (three fixtures plus `packages/core/src/utils/__tests__/record-color.test.ts`) report `Test Files 4 passed (4)` / `Tests 30 passed (30)`.

**Ablation** — rung 1 removed from the shared resolver at `399891d1a`, mutation proven on disk before measuring (anchor count 1 -> 0, injected marker 1, blob `0af3a0a0` -> `a51561b9`), restore via `git checkout HEAD -- ABSOLUTE_PATH` proven by blob hash back to `0af3a0a0`, marker count 0, `git diff HEAD` empty. Result: `Tests 4 failed | 12 passed (16)` — gantt 2 red (bar and stroke rung 1), calendar 1 red, **and timeline 1 red**. That last one is *not* the predicted direction and is reported as observed: it is the proof that the timeline is genuinely on the shared rung rather than keeping a private copy. Its other six cases stayed green, so exactly rung 1 was ablated. No rebuild was needed and none would have helped: the root vitest config aliases `@object-ui/core` to `packages/core/src`, and the ablation going red on a tree whose `dist` still holds the fixed build is itself the evidence that the mutated source is what ran.

## Verification

Union re-run **after** the final commit, at `399891d1a`:

- `pnpm exec vitest run packages/plugin-gantt --maxWorkers=2` -> `Test Files 58 passed (58)` / `Tests 457 passed (457)`
- `pnpm exec vitest run packages/plugin-calendar packages/plugin-timeline packages/core --maxWorkers=2` -> `Test Files 146 passed (146)` / `Tests 2505 passed (2505)`
- `pnpm --filter @object-ui/core --filter @object-ui/plugin-gantt --filter @object-ui/plugin-calendar --filter @object-ui/plugin-timeline run type-check` -> all four `Done`. Each package's `type-check` is `tsc --noEmit && tsc -p tsconfig.test.json`, and `--listFiles` confirms all four new test files are program inputs (2 hits per package), so the tests are type-checked, not merely excluded-and-clean.
- Gates green: `check:phantom-deps`, `check:self-import`, `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:esm-specifiers`, `check:side-effects-array`, `check:changeset-presence` (`9 source file(s) of 4 released package(s) changed, and this change declares 1 changeset(s)`), `check:changeset-no-major`.
- **Lint, full repo, not narrowed:** `pnpm exec eslint . --no-inline-config --format json` visited **4141** files; **0 errors in the 9 files this PR changes**. The 91 errors it reports are pre-existing and in untouched files, and `--no-inline-config` is stricter than the per-package `eslint .` CI runs.
- **Not measured locally, prerequisite unmet, left to CI:** `check:readme-exports` and `check:eager-closure` both need a full-repo build (`300` of its `303` complaints are literally "type entry not on disk — run `pnpm build` first", and the three others are ratchet floors that fall for the same reason; after building this PR's four packages, **zero** complaints name any of them). These are not red readings about this diff.

One changeset, `patch` for all four released packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho

_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_