### PR TITLE
fix(types): the 58 `on*` handler keys declared `z.function()` refuse BY NAME (objectui#6124)

### DIFF
--- a/.changeset/6124-handler-keys-json-refusal.md
+++ b/.changeset/6124-handler-keys-json-refusal.md
@@ -1,0 +1,15 @@
+---
+"@object-ui/types": minor
+---
+
+`@object-ui/types/zod`: the 58 `on*` handler keys declared `z.function()` now refuse BY NAME (objectui#6124)
+
+The zod mirrors declared 58 `on*` keys (26 distinct — `onClick`, `onChange`, `onOpenChange`, `onValueChange`, `onCardMove`, …) across `complex`, `data-display`, `disclosure`, `feedback`, `form`, `layout`, `navigation` and `overlay` as `z.function()`, a declaration no JSON document can satisfy on a JSON-authored vocabulary. A JSON author who wrote `onClick: { "action": "toast" }` was already refused, with zod's bare `invalid_type … expected function, received object` naming the key and nothing else.
+
+Every one of the 58 sites is now a named refusal arm in the shape #5099 landed for `FieldConstraintsSchema.pattern.value` (`z.custom` + guidance, via `handlerKeyRefusal()` in `zod/tombstone.zod.ts`): the message names the key, says why JSON cannot author it, and points at the node-type spelling PR #6498 established (`{ "type": "toast" }`, an `action:button` node with a declared action). The same text is the key's `.describe()` metadata — one string, two channels. Deleting the keys was measured and refused: under `BaseSchema.passthrough()` an undeclared key is not refused, it is KEPT, and `onClick` rides `SDUI_DOM_PASS_THROUGH_KEYS` into the DOM listener slot where React throws at click.
+
+**Accept-set change (Clause ②).** A live function value — which parsed green before — is now refused on the JSON mirror too. The programmatic face reaches renderers through the TypeScript interface and React props, never through `safeParse`; on this tree the only runtime `safeParse` doors into these mirrors are the CLI validators and the exported `validateSchema` / `safeValidateSchema` helpers, none of which is fed a function-bearing object. Code that ran a host-supplied function through one of these mirrors must stop doing so.
+
+**TypeScript face, measured per key.** 36 keys whose function value reaches a renderer at runtime (read off `schema.*`, called as a React prop after `SchemaRenderer`'s spread, or spread onto a Radix root / DOM listener slot) keep their function type. 22 keys nothing reads carry the `?: never` tombstone (ADR-0049): `KanbanSchema.onColumnAdd` / `onCardAdd`, `CarouselSchema.onSlideChange`, `ChatbotSchema.onSendMessage`, `AlertSchema.onDismiss`, `ListItem.onClick`, `TreeViewSchema.onSelectChange` / `onExpandChange`, `ToastSchema.onDismiss`, `RadioGroupSchema` / `SwitchSchema` / `ToggleSchema` / `SliderSchema` / `CalendarSchema` / `ComboboxSchema` / `CommandSchema` `.onChange`, `InputOTPSchema.onComplete`, `BreadcrumbItem.onClick`, `SidebarSchema.onCollapsedChange`, `ButtonGroupButton.onClick`, `AlertDialogSchema.onConfirm` / `onCancel`. Assigning one of those is now a `tsc` error naming the key.
+
+Out of scope, per the ruling: the four non-`on*` `z.function()` keys (`cell`, `custom`, `validate`, `renderCellEditor`) stay as they are; `EventHandlersSchema` is objectui#6910's card.

--- a/examples/schema-catalog/test/component-fixture-declared-keys.test.ts
+++ b/examples/schema-catalog/test/component-fixture-declared-keys.test.ts
@@ -136,7 +136,14 @@ describe('toast fixtures: the registered spelling, not an action object off `onC
     const result = ButtonSchema.safeParse(retired);
     expect(result.success).toBe(false);
     expect(result.error?.issues[0]?.path).toEqual(['onClick']);
-    expect(result.error?.issues[0]?.message).toContain('expected function, received object');
+    // Still RED, and now BY NAME: objectui#6124 replaced `ButtonSchema.onClick`'s
+    // bare `z.function()` (zod's "expected function, received object") with a
+    // named refusal arm that points at the node-type spelling this block's
+    // fixtures already use. The verdict this block leans on did not move; the
+    // message an author reads did.
+    expect(result.error?.issues[0]?.code).toBe('custom');
+    expect(result.error?.issues[0]?.message).toContain('`onClick` is a RUNTIME SLOT');
+    expect(result.error?.issues[0]?.message).toContain('{ "type": "toast"');
   });
 });
 

--- a/packages/types/src/__tests__/chatbot-authoring-face-keys.test.ts
+++ b/packages/types/src/__tests__/chatbot-authoring-face-keys.test.ts
@@ -125,10 +125,26 @@ describe('ChatbotSchema: the ten local-display/legacy keys are declared, not ano
       autoResponse: true,
       autoResponseText: 'Thanks!',
       autoResponseDelay: 1000,
-      onSend: () => {},
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('`onSend` is a RUNTIME SLOT the Zod mirror refuses by name; the TypeScript face above is its channel (objectui#6124)', () => {
+    // `onSend: () => {}` used to sit in the green fixture above. objectui#6124
+    // replaced every `on*: z.function()` arm with a named refusal: a JSON face
+    // has no function value, and `plugin-chatbot` reads `schema.onSend` through
+    // the TypeScript interface (which keeps the callable member — see the first
+    // `it` in this file), never through `safeParse`.
+    const result = ChatbotZodSchema.safeParse({
+      type: 'chatbot',
+      messages: [{ id: '1', role: 'user', content: 'hi' }],
+      onSend: () => {},
+    });
+    expect(result.success).toBe(false);
+    const issue = result.error?.issues.find((i) => String(i.path[0]) === 'onSend');
+    expect(issue?.code).toBe('custom');
+    expect(issue?.message).toContain('`onSend` is a RUNTIME SLOT');
   });
 
   it('refuses a wrong-typed value on a declared key through the Zod mirror (was silently passed through before)', () => {

--- a/packages/types/src/__tests__/handler-keys-json-refusal-6124.test.ts
+++ b/packages/types/src/__tests__/handler-keys-json-refusal-6124.test.ts
@@ -1,0 +1,535 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The 58 `on*` handler keys that the zod mirrors declared as `z.function()`
+ * now REFUSE BY NAME (objectui#6124, maintainer ruling 2026-08-30, batch #8:
+ * Q1 → A, Q2 → A with C, Q3 → A, Q4 → B).
+ *
+ * ## The defect, and why deletion was not the fix
+ *
+ * `z.function()` is a declaration NO JSON document can satisfy — `null`, `{}`,
+ * `1`, `[]`, `"x"` and `true` are all refused; only a live function parses —
+ * on the protocol layer of a JSON-authored vocabulary. Authors who learned
+ * `onClick: { action: 'toast' }` from the corpus got a bare
+ * `invalid_type … expected function` that named the key and nothing else.
+ *
+ * The obvious remedy, "the key leaves the mirror", was measured and refused:
+ * `BaseSchema` is `.passthrough()`, so an UNDECLARED key is not refused — it
+ * stops being judged and the value is KEPT. `onClick` is a member of
+ * `SDUI_DOM_PASS_THROUGH_KEYS`, so the kept object reached the DOM listener
+ * slot and React threw at click. A deletion converts a clear parse error into
+ * silence plus a runtime throw. The counter-probe below pins that hazard so
+ * nobody "simplifies" a refusal arm into a deletion.
+ *
+ * ## The ruled shape — two faces, one measurement per key
+ *
+ *   - zod face (all 58): the #5099 `z.custom` + guidance shape
+ *     (`form.zod.ts` `FieldConstraintsSchema.pattern.value`), via
+ *     `handlerKeyRefusal()` in `../zod/tombstone.zod.ts`. The predicate refuses
+ *     EVERYTHING — an authored object AND a live function — because a JSON
+ *     face has no function value and the programmatic face reaches renderers
+ *     through the TypeScript interface / React props, never through
+ *     `safeParse`. Measured on this tree: the only runtime `safeParse` doors
+ *     into these mirrors are the CLI file validators and the exported
+ *     `validateSchema` / `safeValidateSchema` helpers; `SchemaRenderer`
+ *     validates through `@object-ui/core`'s structural validator, which never
+ *     reads a handler key. The message names the key, says why JSON cannot
+ *     author it, and points at the node-type spelling PR #6498 established
+ *     (Q1 → A, option C).
+ *   - TypeScript face (per key, measured): a key whose function value reaches
+ *     a renderer at runtime keeps its function type — `SchemaRenderer` spreads
+ *     every non-metadata schema key as a React prop, so a renderer that reads
+ *     `schema.onX`, calls `props.onX`, or spreads leftover props onto a Radix
+ *     root / DOM listener slot is a live channel (36 sites, `RUNTIME_SLOT`
+ *     below). A key nothing reads gets the `?: never` tombstone (22 sites,
+ *     `RETIRED` below; the `crud.ts` `confirm` / `base.ts` convention).
+ *
+ * ## Predictions, written before the first run (red-first)
+ *
+ * On the unmodified tree (`origin/main` @ `c93b4d5f3`):
+ *   - the source census finds 58 `on*: z.function(` sites, not 0;
+ *   - an authored object is refused with `invalid_type` (zod's bare message),
+ *     not `custom` with the named guidance;
+ *   - a live function parses GREEN on every one of the 58 (the accept-set
+ *     change this card declares in its changeset);
+ *   - `tsc -p tsconfig.test.json` reports TS2344 on every `RetiredIsNever`
+ *     line (the member is still a function type).
+ * The non-`on*` census (`cell` / `custom` / `renderCellEditor` / `validate`)
+ * and the passthrough counter-probe are GREEN before and after — they pin the
+ * ruling's scope (Q4 → B) and the reason for the arm, not this change.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { z } from 'zod';
+
+import { retirementTombstone } from '../zod/tombstone.zod';
+import {
+  CalendarViewSchema as CalendarViewZod,
+  CarouselSchema as CarouselZod,
+  ChatbotSchema as ChatbotZod,
+  FilterBuilderSchema as FilterBuilderZod,
+  KanbanSchema as KanbanZod,
+} from '../zod/complex.zod';
+import {
+  AlertSchema as AlertZod,
+  DataTableSchema as DataTableZod,
+  ListItemSchema as ListItemZod,
+  TreeViewSchema as TreeViewZod,
+} from '../zod/data-display.zod';
+import {
+  AccordionSchema as AccordionZod,
+  CollapsibleSchema as CollapsibleZod,
+  ToggleGroupSchema as ToggleGroupZod,
+} from '../zod/disclosure.zod';
+import { ToastSchema as ToastZod } from '../zod/feedback.zod';
+import {
+  ButtonSchema as ButtonZod,
+  CalendarSchema as CalendarZod,
+  CheckboxSchema as CheckboxZod,
+  CodeEditorSchema as CodeEditorZod,
+  ComboboxSchema as ComboboxZod,
+  CommandSchema as CommandZod,
+  DatePickerSchema as DatePickerZod,
+  FileUploadSchema as FileUploadZod,
+  FormSchema as FormZod,
+  InputOTPSchema as InputOTPZod,
+  InputSchema as InputZod,
+  RadioGroupSchema as RadioGroupZod,
+  SelectSchema as SelectZod,
+  SliderSchema as SliderZod,
+  SwitchSchema as SwitchZod,
+  TextareaSchema as TextareaZod,
+  ToggleSchema as ToggleZod,
+} from '../zod/form.zod';
+import { CardSchema as CardZod, TabsSchema as TabsZod } from '../zod/layout.zod';
+import {
+  BreadcrumbItemSchema as BreadcrumbItemZod,
+  ButtonGroupButtonSchema as ButtonGroupButtonZod,
+  PaginationSchema as PaginationZod,
+  SidebarSchema as SidebarZod,
+} from '../zod/navigation.zod';
+import {
+  AlertDialogSchema as AlertDialogZod,
+  DialogSchema as DialogZod,
+  DrawerSchema as DrawerZod,
+  DropdownMenuSchema as DropdownMenuZod,
+  HoverCardSchema as HoverCardZod,
+  MenuItemSchema as MenuItemZod,
+  PopoverSchema as PopoverZod,
+  SheetSchema as SheetZod,
+} from '../zod/overlay.zod';
+
+import type {
+  CalendarViewSchema,
+  CarouselSchema,
+  ChatbotSchema,
+  FilterBuilderSchema,
+  KanbanSchema,
+} from '../complex';
+import type { AlertSchema, DataTableSchema, ListItem, TreeViewSchema } from '../data-display';
+import type { AccordionSchema, CollapsibleSchema, ToggleGroupSchema } from '../disclosure';
+import type { ToastSchema } from '../feedback';
+import type {
+  ButtonSchema,
+  CalendarSchema,
+  CheckboxSchema,
+  CodeEditorSchema,
+  ComboboxSchema,
+  CommandSchema,
+  DatePickerSchema,
+  FileUploadSchema,
+  FormSchema,
+  InputOTPSchema,
+  InputSchema,
+  RadioGroupSchema,
+  SelectSchema,
+  SliderSchema,
+  SwitchSchema,
+  TextareaSchema,
+  ToggleSchema,
+} from '../form';
+import type { CardSchema, TabsSchema } from '../layout';
+import type {
+  BreadcrumbItem,
+  ButtonGroupButton,
+  PaginationSchema,
+  SidebarSchema,
+} from '../navigation';
+import type {
+  AlertDialogSchema,
+  DialogSchema,
+  DrawerSchema,
+  DropdownMenuSchema,
+  HoverCardSchema,
+  MenuCommandItem,
+  PopoverSchema,
+  SheetSchema,
+} from '../overlay';
+
+/* ── The census, as data ─────────────────────────────────────────────────── */
+
+type Site = readonly [file: string, schema: string, key: string, mirror: z.ZodType];
+
+/** The object that DECLARES `key` behind a mirror. Every mirror here IS the
+ *  object except `overlay.zod.ts#MenuItemSchema`: a `z.lazy` (its `children`
+ *  recurse) over a discriminated UNION (command item | divider, objectui#6523),
+ *  so the member lives on the command arm one `unwrap()` down. Typed loosely
+ *  on purpose: the census is about members, not shapes. */
+const objectOf = (mirror: z.ZodType, key: string): z.ZodObject<z.ZodRawShape> => {
+  const inner = mirror instanceof z.ZodLazy ? mirror.unwrap() : mirror;
+  if (inner instanceof z.ZodUnion) {
+    const arm = (inner.options as z.ZodType[]).find(
+      (o) => o instanceof z.ZodObject && key in (o as z.ZodObject<z.ZodRawShape>).shape,
+    );
+    if (!arm) throw new Error(`no union arm declares \`${key}\``);
+    return arm as z.ZodObject<z.ZodRawShape>;
+  }
+  return inner as z.ZodObject<z.ZodRawShape>;
+};
+
+/**
+ * 36 keys whose function value REACHES a renderer at runtime — the TypeScript
+ * interface keeps the function type. Channel measured per key on this tree:
+ * `schema.onX` read/forwarded (kanban, chatbot, data-table, form, code-editor,
+ * menu items), `props.onX` called after `SchemaRenderer`'s spread (input,
+ * textarea, select, checkbox, file-upload, date-picker, input-otp, pagination,
+ * filter-builder, calendar-view's `pickHostCallbacks`), or leftover props
+ * spread onto a Radix root / DOM listener slot (accordion, collapsible,
+ * toggle-group, tabs, the seven `onOpenChange` overlays, button's
+ * `toFormControlDomProps` whitelist, card's `<Card {...cardProps}>`).
+ */
+const RUNTIME_SLOT: readonly Site[] = [
+  ['complex.zod.ts', 'KanbanSchema', 'onCardMove', KanbanZod],
+  ['complex.zod.ts', 'KanbanSchema', 'onCardClick', KanbanZod],
+  ['complex.zod.ts', 'CalendarViewSchema', 'onViewChange', CalendarViewZod],
+  ['complex.zod.ts', 'FilterBuilderSchema', 'onChange', FilterBuilderZod],
+  ['complex.zod.ts', 'ChatbotSchema', 'onError', ChatbotZod],
+  ['complex.zod.ts', 'ChatbotSchema', 'onSend', ChatbotZod],
+  ['data-display.zod.ts', 'DataTableSchema', 'onRowEdit', DataTableZod],
+  ['data-display.zod.ts', 'DataTableSchema', 'onRowDelete', DataTableZod],
+  ['data-display.zod.ts', 'DataTableSchema', 'onSelectionChange', DataTableZod],
+  ['data-display.zod.ts', 'DataTableSchema', 'onColumnsReorder', DataTableZod],
+  ['disclosure.zod.ts', 'AccordionSchema', 'onValueChange', AccordionZod],
+  ['disclosure.zod.ts', 'CollapsibleSchema', 'onOpenChange', CollapsibleZod],
+  ['disclosure.zod.ts', 'ToggleGroupSchema', 'onValueChange', ToggleGroupZod],
+  ['form.zod.ts', 'ButtonSchema', 'onClick', ButtonZod],
+  ['form.zod.ts', 'InputSchema', 'onChange', InputZod],
+  ['form.zod.ts', 'TextareaSchema', 'onChange', TextareaZod],
+  ['form.zod.ts', 'SelectSchema', 'onChange', SelectZod],
+  ['form.zod.ts', 'CheckboxSchema', 'onChange', CheckboxZod],
+  ['form.zod.ts', 'FileUploadSchema', 'onChange', FileUploadZod],
+  ['form.zod.ts', 'DatePickerSchema', 'onChange', DatePickerZod],
+  ['form.zod.ts', 'InputOTPSchema', 'onChange', InputOTPZod],
+  ['form.zod.ts', 'FormSchema', 'onSubmit', FormZod],
+  ['form.zod.ts', 'FormSchema', 'onChange', FormZod],
+  ['form.zod.ts', 'FormSchema', 'onCancel', FormZod],
+  ['form.zod.ts', 'CodeEditorSchema', 'onChange', CodeEditorZod],
+  ['layout.zod.ts', 'CardSchema', 'onClick', CardZod],
+  ['layout.zod.ts', 'TabsSchema', 'onValueChange', TabsZod],
+  ['navigation.zod.ts', 'PaginationSchema', 'onPageChange', PaginationZod],
+  ['overlay.zod.ts', 'DialogSchema', 'onOpenChange', DialogZod],
+  ['overlay.zod.ts', 'AlertDialogSchema', 'onOpenChange', AlertDialogZod],
+  ['overlay.zod.ts', 'SheetSchema', 'onOpenChange', SheetZod],
+  ['overlay.zod.ts', 'DrawerSchema', 'onOpenChange', DrawerZod],
+  ['overlay.zod.ts', 'PopoverSchema', 'onOpenChange', PopoverZod],
+  ['overlay.zod.ts', 'HoverCardSchema', 'onOpenChange', HoverCardZod],
+  ['overlay.zod.ts', 'MenuItemSchema', 'onClick', MenuItemZod],
+  ['overlay.zod.ts', 'DropdownMenuSchema', 'onOpenChange', DropdownMenuZod],
+];
+
+/**
+ * 22 keys NO renderer reads — the TypeScript interface carries the `?: never`
+ * tombstone. Measured per key: the renderer takes `({ schema })` only, or
+ * strips the key through a `toFormControlDomProps` whitelist, or spreads it
+ * onto a DOM element / primitive that has no such prop (React warns about an
+ * unknown event handler and attaches nothing). `CommandSchema.onChange` is the
+ * one that lands somewhere at all — cmdk's root `div`, where React fires it
+ * with a SyntheticEvent on every keystroke — which is a DIFFERENT contract
+ * from the declared `(value: string) => void`, not a consumer of it.
+ */
+const RETIRED: readonly Site[] = [
+  ['complex.zod.ts', 'KanbanSchema', 'onColumnAdd', KanbanZod],
+  ['complex.zod.ts', 'KanbanSchema', 'onCardAdd', KanbanZod],
+  ['complex.zod.ts', 'CarouselSchema', 'onSlideChange', CarouselZod],
+  ['complex.zod.ts', 'ChatbotSchema', 'onSendMessage', ChatbotZod],
+  ['data-display.zod.ts', 'AlertSchema', 'onDismiss', AlertZod],
+  ['data-display.zod.ts', 'ListItemSchema', 'onClick', ListItemZod],
+  ['data-display.zod.ts', 'TreeViewSchema', 'onSelectChange', TreeViewZod],
+  ['data-display.zod.ts', 'TreeViewSchema', 'onExpandChange', TreeViewZod],
+  ['feedback.zod.ts', 'ToastSchema', 'onDismiss', ToastZod],
+  ['form.zod.ts', 'RadioGroupSchema', 'onChange', RadioGroupZod],
+  ['form.zod.ts', 'SwitchSchema', 'onChange', SwitchZod],
+  ['form.zod.ts', 'ToggleSchema', 'onChange', ToggleZod],
+  ['form.zod.ts', 'SliderSchema', 'onChange', SliderZod],
+  ['form.zod.ts', 'CalendarSchema', 'onChange', CalendarZod],
+  ['form.zod.ts', 'InputOTPSchema', 'onComplete', InputOTPZod],
+  ['form.zod.ts', 'ComboboxSchema', 'onChange', ComboboxZod],
+  ['form.zod.ts', 'CommandSchema', 'onChange', CommandZod],
+  ['navigation.zod.ts', 'BreadcrumbItemSchema', 'onClick', BreadcrumbItemZod],
+  ['navigation.zod.ts', 'SidebarSchema', 'onCollapsedChange', SidebarZod],
+  ['navigation.zod.ts', 'ButtonGroupButtonSchema', 'onClick', ButtonGroupButtonZod],
+  ['overlay.zod.ts', 'AlertDialogSchema', 'onConfirm', AlertDialogZod],
+  ['overlay.zod.ts', 'AlertDialogSchema', 'onCancel', AlertDialogZod],
+];
+
+const ALL_SITES: readonly Site[] = [...RUNTIME_SLOT, ...RETIRED];
+
+/** The eight mirror files the census covers; `base.zod.ts` holds only
+ *  `EventHandlersSchema` (a record, objectui#6910's card) and no named key. */
+const MIRROR_FILES = [
+  'complex.zod.ts',
+  'data-display.zod.ts',
+  'disclosure.zod.ts',
+  'feedback.zod.ts',
+  'form.zod.ts',
+  'layout.zod.ts',
+  'navigation.zod.ts',
+  'overlay.zod.ts',
+] as const;
+
+const ZOD_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'zod');
+const readMirror = (file: string) => readFileSync(join(ZOD_DIR, file), 'utf8');
+
+/** The card's ANCHORED census — the unanchored `on[A-Z]…` spelling matches
+ *  mid-identifier (`buttonLabel`, `actionUrl`, …) and over-reports. */
+const ON_KEY_FUNCTION = /^\s*on[A-Z][A-Za-z]*: z\.function\(/gm;
+const NON_ON_FUNCTION = /^\s*(cell|custom|renderCellEditor|validate): z\.function\(/gm;
+
+const describeOf = (mirror: z.ZodType, key: string): string | undefined =>
+  (objectOf(mirror, key).shape[key] as { description?: string } | undefined)?.description;
+
+/** One key, isolated: `.pick()` keeps the member's own declaration and drops
+ *  the rest of the object, so the probe needs no per-schema fixture and a
+ *  refusal can only be about the key under test. */
+const pickKey = (mirror: z.ZodType, key: string) =>
+  objectOf(mirror, key).pick({ [key]: true } as Record<string, true>);
+
+const AUTHORED_ACTION_OBJECT = { action: 'toast', title: 'Saved', variant: 'success' };
+const LIVE_FUNCTION = () => undefined;
+
+/* ── Census ──────────────────────────────────────────────────────────────── */
+
+describe('census: no on* key in the eight mirrors is declared z.function() (objectui#6124)', () => {
+  it('the anchored source census finds 0 `on*: z.function(` sites', () => {
+    const hits = MIRROR_FILES.flatMap((file) =>
+      [...readMirror(file).matchAll(ON_KEY_FUNCTION)].map((m) => `${file}: ${m[0].trim()}`),
+    );
+    expect(hits).toEqual([]);
+  });
+
+  it('the four non-on* z.function() sites stay exactly as they are (Q4 → B — cell/custom/validate/renderCellEditor are out of scope)', () => {
+    // Positive control for the census instrument as well: the same regex
+    // family, anchored the same way, still finds the sites it should.
+    const hits = MIRROR_FILES.flatMap((file) =>
+      [...readMirror(file).matchAll(NON_ON_FUNCTION)].map((m) => `${file}#${m[1]}`),
+    );
+    expect(hits.sort()).toEqual([
+      'data-display.zod.ts#cell',
+      'data-display.zod.ts#renderCellEditor',
+      'form.zod.ts#custom',
+      'form.zod.ts#validate',
+    ]);
+  });
+
+  it('58 sites are ledgered, 36 runtime slots + 22 retired, with no key filed twice', () => {
+    expect(RUNTIME_SLOT).toHaveLength(36);
+    expect(RETIRED).toHaveLength(22);
+    const ids = ALL_SITES.map(([file, schema, key]) => `${file}#${schema}.${key}`);
+    expect(new Set(ids).size).toBe(58);
+  });
+
+  it.each(ALL_SITES)('%s %s.%s is DECLARED on the mirror shape, with the objectui#6124 guidance as its description', (_file, _schema, key, mirror) => {
+    // Deliberately `.shape`, not `safeParse`: under `.passthrough()` a DELETED
+    // key still parses green and the value rides through, so a parse-based
+    // declaration pin stays green through the very deletion it exists to
+    // catch (the same reading PR #6899's pin recorded for the event-name keys).
+    expect(objectOf(mirror, key).shape[key]).toBeDefined();
+    expect(describeOf(mirror, key)).toContain('objectui#6124');
+  });
+});
+
+/* ── Behaviour: the refusal, by name, with the remedy ─────────────────────── */
+
+describe('a JSON author is refused BY NAME and pointed at the node-type spelling (objectui#6124, Q2 → A)', () => {
+  it.each(ALL_SITES)('%s %s.%s refuses an authored action object with its own guidance, not zod\'s bare invalid_type', (_file, _schema, key, mirror) => {
+    const result = pickKey(mirror, key).safeParse({ [key]: AUTHORED_ACTION_OBJECT });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => String(i.path[0]) === key);
+    expect(issue, `no issue addressed to \`${key}\``).toBeDefined();
+    // The #5099 shape: a `z.custom` predicate, so the code is `custom` — the
+    // bare `z.function()` reported `invalid_type` with "expected function".
+    expect(issue!.code).toBe('custom');
+    expect(issue!.path).toEqual([key]);
+    expect(issue!.message).toContain(`\`${key}\``);
+    expect(issue!.message).not.toContain('expected function');
+    // The remedy: the node-type spelling PR #6498 established (Q1, option C).
+    expect(issue!.message).toContain('"type"');
+    expect(issue!.message).toContain('action:button');
+    // BOTH channels, one string — the runtime message and the `.describe()`
+    // metadata cannot drift apart (the `retirementTombstone()` invariant).
+    expect(issue!.message).toBe(describeOf(mirror, key));
+  });
+
+  it.each(ALL_SITES)('%s %s.%s refuses a LIVE FUNCTION too — the JSON mirror is not the programmatic channel', (_file, _schema, key, mirror) => {
+    // This is the accept-set change the changeset declares. The ruling: the
+    // programmatic face goes through the TypeScript interface / React props
+    // and never through `safeParse`; a function that parsed green here was
+    // the instrument's positive control, never an authoring form.
+    const result = pickKey(mirror, key).safeParse({ [key]: LIVE_FUNCTION });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.map((i) => [i.code, String(i.path[0])])).toEqual([['custom', key]]);
+  });
+
+  it.each(ALL_SITES)('%s %s.%s — the same isolated shape parses GREEN without the key (the arm is optional; the refusal is about the key)', (_file, _schema, key, mirror) => {
+    expect(pickKey(mirror, key).safeParse({}).success).toBe(true);
+  });
+
+  it('the guidance wording distinguishes a runtime slot from a retired key', () => {
+    for (const [, , key, mirror] of RUNTIME_SLOT) {
+      expect(describeOf(mirror, key), key).toContain('RUNTIME SLOT');
+      expect(describeOf(mirror, key), key).not.toContain('RETIRED');
+    }
+    for (const [, , key, mirror] of RETIRED) {
+      expect(describeOf(mirror, key), key).toContain('RETIRED (objectui#6124');
+      expect(describeOf(mirror, key), key).not.toContain('RUNTIME SLOT');
+    }
+  });
+
+  it('a whole document still parses green once the handler key is spelled as a node type', () => {
+    // The corpus flip PR #6498 landed: `{ "type": "toast" }` is the authorable
+    // spelling; a button without a handler key is a plain green button.
+    expect(ButtonZod.safeParse({ type: 'button', label: 'Save' }).success).toBe(true);
+    expect(ToastZod.safeParse({ type: 'toast', title: 'Saved' }).success).toBe(true);
+    expect(DialogZod.safeParse({ type: 'dialog', title: 'Confirm' }).success).toBe(true);
+  });
+});
+
+/* ── Counter-probe: why the arm, and not a deletion ───────────────────────── */
+
+describe('counter-probe: deleting the key instead would be a SILENT accept that KEEPS the value (the ruling\'s ⛔ 不裸删)', () => {
+  const retiredEnvelope = {
+    type: 'button',
+    label: 'Destructive Toast',
+    variant: 'destructive',
+    onClick: AUTHORED_ACTION_OBJECT,
+  };
+
+  it('with the arm: refused at path onClick', () => {
+    const result = ButtonZod.safeParse(retiredEnvelope);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['onClick']);
+  });
+
+  it('the deletion, simulated: `BaseSchema.passthrough()` parses it GREEN and the object rides through to the DOM listener slot', () => {
+    const result = ButtonZod.omit({ onClick: true }).safeParse(retiredEnvelope);
+    expect(result.success).toBe(true);
+    expect((result.data as Record<string, unknown>).onClick).toEqual(AUTHORED_ACTION_OBJECT);
+  });
+
+  it('the refusal arm is not a retirement tombstone: it reports `custom`, the tombstone reports `invalid_type`', () => {
+    // Two helpers, two meanings — `retirementTombstone()` retires a key from
+    // the contract on BOTH faces; the handler refusal keeps 36 of these keys
+    // live on the TypeScript face. Pinned so the two are not merged into one.
+    const tombstone = retirementTombstone('RETIRED (fixture)').safeParse('x');
+    expect(tombstone.success).toBe(false);
+    expect(tombstone.error?.issues[0]?.code).toBe('invalid_type');
+    const arm = pickKey(ButtonZod, 'onClick').safeParse({ onClick: 'x' });
+    expect(arm.error?.issues[0]?.code).toBe('custom');
+  });
+});
+
+/* ── The TypeScript face, judged by `tsc -p tsconfig.test.json` ──────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+/** `?: never` reads as exactly `undefined` off the interface. `Equal`, not
+ *  `extends`: `BaseSchema`'s `[key: string]: any` means a DELETED member reads
+ *  `any`, which a one-way check would accept (the disabled-twin lesson). */
+type RetiredIsNever<T> = Equal<T, undefined>;
+
+/** A runtime slot keeps a callable member: some function type survives the
+ *  `Extract`. Written over `NonNullable` so `undefined` cannot satisfy it. */
+type KeepsFunction<T> = [Extract<NonNullable<T>, (...args: never[]) => unknown>] extends [never]
+  ? false
+  : true;
+
+export type assertionRetiredKeysAreTombstoned = [
+  Expect<RetiredIsNever<KanbanSchema['onColumnAdd']>>,
+  Expect<RetiredIsNever<KanbanSchema['onCardAdd']>>,
+  Expect<RetiredIsNever<CarouselSchema['onSlideChange']>>,
+  Expect<RetiredIsNever<ChatbotSchema['onSendMessage']>>,
+  Expect<RetiredIsNever<AlertSchema['onDismiss']>>,
+  Expect<RetiredIsNever<ListItem['onClick']>>,
+  Expect<RetiredIsNever<TreeViewSchema['onSelectChange']>>,
+  Expect<RetiredIsNever<TreeViewSchema['onExpandChange']>>,
+  Expect<RetiredIsNever<ToastSchema['onDismiss']>>,
+  Expect<RetiredIsNever<RadioGroupSchema['onChange']>>,
+  Expect<RetiredIsNever<SwitchSchema['onChange']>>,
+  Expect<RetiredIsNever<ToggleSchema['onChange']>>,
+  Expect<RetiredIsNever<SliderSchema['onChange']>>,
+  Expect<RetiredIsNever<CalendarSchema['onChange']>>,
+  Expect<RetiredIsNever<InputOTPSchema['onComplete']>>,
+  Expect<RetiredIsNever<ComboboxSchema['onChange']>>,
+  Expect<RetiredIsNever<CommandSchema['onChange']>>,
+  Expect<RetiredIsNever<BreadcrumbItem['onClick']>>,
+  Expect<RetiredIsNever<SidebarSchema['onCollapsedChange']>>,
+  Expect<RetiredIsNever<ButtonGroupButton['onClick']>>,
+  Expect<RetiredIsNever<AlertDialogSchema['onConfirm']>>,
+  Expect<RetiredIsNever<AlertDialogSchema['onCancel']>>,
+];
+
+export type assertionRuntimeSlotsKeepTheirFunctionType = [
+  Expect<KeepsFunction<KanbanSchema['onCardMove']>>,
+  Expect<KeepsFunction<KanbanSchema['onCardClick']>>,
+  Expect<KeepsFunction<CalendarViewSchema['onViewChange']>>,
+  Expect<KeepsFunction<FilterBuilderSchema['onChange']>>,
+  Expect<KeepsFunction<ChatbotSchema['onError']>>,
+  Expect<KeepsFunction<ChatbotSchema['onSend']>>,
+  Expect<KeepsFunction<DataTableSchema['onRowEdit']>>,
+  Expect<KeepsFunction<DataTableSchema['onRowDelete']>>,
+  Expect<KeepsFunction<DataTableSchema['onSelectionChange']>>,
+  Expect<KeepsFunction<DataTableSchema['onColumnsReorder']>>,
+  Expect<KeepsFunction<AccordionSchema['onValueChange']>>,
+  Expect<KeepsFunction<CollapsibleSchema['onOpenChange']>>,
+  Expect<KeepsFunction<ToggleGroupSchema['onValueChange']>>,
+  Expect<KeepsFunction<ButtonSchema['onClick']>>,
+  Expect<KeepsFunction<InputSchema['onChange']>>,
+  Expect<KeepsFunction<TextareaSchema['onChange']>>,
+  Expect<KeepsFunction<SelectSchema['onChange']>>,
+  Expect<KeepsFunction<CheckboxSchema['onChange']>>,
+  Expect<KeepsFunction<FileUploadSchema['onChange']>>,
+  Expect<KeepsFunction<DatePickerSchema['onChange']>>,
+  Expect<KeepsFunction<InputOTPSchema['onChange']>>,
+  Expect<KeepsFunction<FormSchema['onSubmit']>>,
+  Expect<KeepsFunction<FormSchema['onChange']>>,
+  Expect<KeepsFunction<FormSchema['onCancel']>>,
+  Expect<KeepsFunction<CodeEditorSchema['onChange']>>,
+  Expect<KeepsFunction<CardSchema['onClick']>>,
+  Expect<KeepsFunction<TabsSchema['onValueChange']>>,
+  Expect<KeepsFunction<PaginationSchema['onPageChange']>>,
+  Expect<KeepsFunction<DialogSchema['onOpenChange']>>,
+  Expect<KeepsFunction<AlertDialogSchema['onOpenChange']>>,
+  Expect<KeepsFunction<SheetSchema['onOpenChange']>>,
+  Expect<KeepsFunction<DrawerSchema['onOpenChange']>>,
+  Expect<KeepsFunction<PopoverSchema['onOpenChange']>>,
+  Expect<KeepsFunction<HoverCardSchema['onOpenChange']>>,
+  Expect<KeepsFunction<MenuCommandItem['onClick']>>,
+  Expect<KeepsFunction<DropdownMenuSchema['onOpenChange']>>,
+];
+
+// The two helpers must be able to FAIL — synthetic controls, both directions.
+export type assertionRetiredIsNeverCanFail = Expect<Equal<RetiredIsNever<(() => void) | undefined>, false>>;
+export type assertionKeepsFunctionCanFail = Expect<Equal<KeepsFunction<undefined>, false>>;

--- a/packages/types/src/__tests__/menu-item-union.test.ts
+++ b/packages/types/src/__tests__/menu-item-union.test.ts
@@ -215,13 +215,45 @@ describe('MenuItemSchema — the zod mirror agrees with the TS union (objectui#6
     expect(MenuItemSchema.safeParse({ separator: true }).success).toBe(true);
   });
 
-  it('a live command item — label, icon, shortcut, onClick — still parses green', () => {
+  it('a live command item — label, icon, shortcut — still parses green', () => {
+    const result = MenuItemSchema.safeParse({
+      label: 'New Tab',
+      icon: 'plus',
+      shortcut: 'Ctrl+T',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('`onClick` is a RUNTIME SLOT the mirror refuses by name — the function still parses on the TS face only (objectui#6124)', () => {
+    // This case used to parse a live function GREEN. objectui#6124 replaced
+    // every `on*: z.function()` arm with a named refusal: the JSON face has no
+    // function value, and the renderers reach `item.onClick?.()` through the
+    // TypeScript `MenuCommandItem` — which keeps the callable member, pinned
+    // in `handler-keys-json-refusal-6124.test.ts` — never through `safeParse`.
     const result = MenuItemSchema.safeParse({
       label: 'New Tab',
       icon: 'plus',
       shortcut: 'Ctrl+T',
       onClick: () => {},
     });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    // A UNION reports `invalid_union` at the top; the named refusal lives in
+    // the command arm's errors (the same reading the `type` tombstone case
+    // above records for objectui#6931).
+    const top = result.error.issues[0]!;
+    expect(top.code).toBe('invalid_union');
+    const armIssues = (
+      (top as unknown as { errors?: { path: PropertyKey[]; code: string; message: string }[][] }).errors ?? []
+    )
+      .flat()
+      .filter((i) => String(i.path[0]) === 'onClick');
+    expect(armIssues.length, 'no arm reported an issue addressed to `onClick`').toBeGreaterThan(0);
+    for (const issue of armIssues) {
+      expect(issue.code).toBe('custom');
+      expect(issue.message).toContain('`onClick` is a RUNTIME SLOT');
+    }
+    const onClick: MenuCommandItem['onClick'] = () => {};
+    expect(typeof onClick).toBe('function');
   });
 });

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -57,7 +57,9 @@
  *     already pins equal to `keyof Declared`. Nothing asserts it against a written
  *     number, so this line is prose and can rot; the pin that cannot is the one
  *     comparing the two halves to each other.
- *   - **12 entries** in `KnownDrift`, **17 keys** across them.
+ *   - **36 entries** in `KnownDrift`, **52 keys** across them. It was 12 / 17 until
+ *     objectui#6124 added the RUNTIME-SLOT class (28 pairs touched, 35 keys) — see
+ *     the class note inside the ledger, above `ButtonSchema`.
  *   - **16 entries** in `UnmirroredDeclared`, **97 keys** across them. ⚠️ It was
  *     **121** when objectui#6058 seeded it; objectui#6152 moved 23 callback-shaped
  *     keys to the ledger below by RECLASSIFICATION, not by fixing them, and
@@ -70,7 +72,7 @@
  *     the first pair whose ONLY ledger entry is a runtime-only one
  *     (objectui#6150 declared `onNodeClick` on an otherwise clean pair), so the
  *     "no entry in either" population dropped by one to 141.
- *   - 158 − 12 = **146**, the "pairs with no entry" `LedgerMismatch` speaks of.
+ *   - 158 − 36 = **122**, the "pairs with no entry" `LedgerMismatch` speaks of.
  *
  * ## Two ratchets, because the forward comparison has two halves
  *
@@ -91,7 +93,7 @@
  *
  * ## KNOWN_DRIFT is a ratchet, not a waiver
  *
- * 12 of the 158 pairs carry TYPE drift TODAY (measured, not assumed). Each is
+ * 36 of the 158 pairs carry TYPE drift TODAY (measured, not assumed). Each is
  * pinned to its EXACT drifted key set, so the entry fails when new drift appears on
  * that mirror AND when the recorded drift is fixed — a stale entry cannot rot
  * quietly. Correcting them is not one change: the pairs below split into DISJOINT
@@ -107,6 +109,13 @@
  * `ViewSwitcherSchema`) and two shrank to the keys that are NOT widenings
  * (`DataTableSchema` kept `rowActions`, `FormSchema` kept `fields`/`mode`). The
  * remaining classes are rulings, not edits, and are deliberately still here.
+ *
+ * Then 12 became 36 with objectui#6124, which is the opposite movement from #5927's
+ * and must not be read as regression: 24 pairs ENTERED (and 4 grew) because the
+ * ruling put a NAMED REFUSAL on the mirror side of 35 runtime-slot handler keys while
+ * their TypeScript twins stay callable. That drift is the ruling's intended shape,
+ * ledgered so the ratchet holds it exactly — a pair leaving this class means either
+ * the mirror accepts a function again or a renderer lost its callback.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -679,8 +688,18 @@ export type UnmirroredOf< K extends MirrorKey > = UnmirroredDeclaredKeys< (typeo
  * new drift on a listed mirror fails, and so does a listed key that has been fixed.
  */
 interface KnownDrift {
-  /** TS declares `SchemaNode | SchemaNode[]` (a rendered slot); the mirror declares `Record<string, unknown>` ("additional API body params"). Two different meanings of one key — a naming collision to rule on, not a widening. */
-  'complex.zod.ts#ChatbotSchema': 'body';
+  /** RUNTIME SLOT (objectui#6124): `calendar-view`'s `pickHostCallbacks` reads `onViewChange` off the spread props (function values only) and hands it to `CalendarView`. */
+  'complex.zod.ts#CalendarViewSchema': 'onViewChange';
+  /**
+   * `body` — TS declares `SchemaNode | SchemaNode[]` (a rendered slot); the mirror
+   * declares `Record<string, unknown>` ("additional API body params"). Two different
+   * meanings of one key — a naming collision to rule on, not a widening.
+   *
+   * `onError` / `onSend` — RUNTIME SLOT (objectui#6124): `plugin-chatbot` forwards both off
+   * `schema.*` into `useObjectChat`, so the TS side keeps the callables; the mirror
+   * refuses them by name (`handlerKeyRefusal`). See the class note above `ButtonSchema`.
+   */
+  'complex.zod.ts#ChatbotSchema': 'body' | 'onError' | 'onSend';
   /**
    * spec-derived shape (`SpecDashboardFields`) measured against a hand-written
    * local declaration. Needs the spec-unification triage of #2231 rather than a
@@ -694,24 +713,122 @@ interface KnownDrift {
   'complex.zod.ts#DashboardComponentSchema': 'header' | 'widgets' | 'globalFilters';
   /** TS declares `unknown`; the mirror declares a structured options object. The mirror is the STRICTER side here — narrowing the check would be wrong, widening the TS declaration is the ADR-0049 question. */
   'complex.zod.ts#DashboardWidgetSchema': 'options';
-  /** inherited from `FilterFieldSchema.operators` below — the element type is the drifted one. */
-  'complex.zod.ts#FilterBuilderSchema': 'fields';
+  /**
+   * `fields` — inherited from `FilterFieldSchema.operators` below; the element type is
+   * the drifted one. `onChange` — RUNTIME SLOT (objectui#6124): the `filter-builder` renderer
+   * calls it as `props.onChange` after `SchemaRenderer`'s spread.
+   */
+  'complex.zod.ts#FilterBuilderSchema': 'fields' | 'onChange';
   /** DISJOINT vocabularies: TS declares `is_empty`/`is_not_empty`, the mirror declares `is_null`/`is_not_null`. One of the two is dead; which one is a ruling. */
   'complex.zod.ts#FilterFieldSchema': 'operators';
-  /** DISJOINT: TS declares `rowActions?: boolean` (show the column or not), the mirror declares `any[]` (the actions themselves). One of the two is dead; which is a ruling. (`selectable` was a second drifted key here until objectui#5927 widened the mirror to `boolean | 'single' | 'multiple'` — `resolveSelectionMode` in `renderers/complex/data-table.tsx` implements `'single'` as a real mode.) */
-  'data-display.zod.ts#DataTableSchema': 'rowActions';
-  /** DISJOINT: TS `Date | Date[]`, mirror `string | Date`. The mirror refuses `Date[]`; the TS side refuses the ISO string the mirror accepts. */
+  /** RUNTIME SLOT (objectui#6124) ×2: `plugin-kanban` forwards `onCardMove` / `onCardClick` off `schema.*` into the board. (`onColumnAdd` / `onCardAdd` are NOT here: nothing reads them, so both faces retire them — `?: never` meets the refusal arm and the pair does not drift on those keys.) */
+  'complex.zod.ts#KanbanSchema': 'onCardMove' | 'onCardClick';
+  /**
+   * `rowActions` — DISJOINT: TS declares `rowActions?: boolean` (show the column or
+   * not), the mirror declares `any[]` (the actions themselves). One of the two is
+   * dead; which is a ruling. (`selectable` was a second drifted key here until
+   * objectui#5927 widened the mirror to `boolean | 'single' | 'multiple'` —
+   * `resolveSelectionMode` in `renderers/complex/data-table.tsx` implements
+   * `'single'` as a real mode.)
+   *
+   * The four callbacks — RUNTIME SLOT (objectui#6124) ×4: `renderers/complex/data-table.tsx`
+   * CALLS every one of them off `schema.*` (`schema.onRowEdit?.(r)`,
+   * `schema.onSelectionChange(selectedData)`, …), so the TS side keeps them callable
+   * and the mirror refuses them by name.
+   */
+  'data-display.zod.ts#DataTableSchema': 'rowActions' | 'onRowEdit' | 'onRowDelete' | 'onSelectionChange' | 'onColumnsReorder';
+  /** RUNTIME SLOT (objectui#6124): the `accordion` renderer spreads leftover props onto the Radix `Accordion` root, where `onValueChange` is a real prop. */
+  'disclosure.zod.ts#AccordionSchema': 'onValueChange';
+  /** RUNTIME SLOT (objectui#6124): the `collapsible` renderer spreads leftover props onto the Radix `Collapsible` root. */
+  'disclosure.zod.ts#CollapsibleSchema': 'onOpenChange';
+  /** RUNTIME SLOT (objectui#6124): the `toggle-group` renderer spreads `toggleGroupProps` onto the Radix `ToggleGroup` root. */
+  'disclosure.zod.ts#ToggleGroupSchema': 'onValueChange';
+  /**
+   * ## The objectui#6124 class — a RUNTIME SLOT on the TS face, a NAMED REFUSAL on the mirror
+   *
+   * Maintainer ruling 2026-08-30 (batch #8, Q2 → A with C): the 58 `on*` keys the
+   * mirrors declared as `z.function()` — a type NO JSON document can satisfy — keep
+   * their declaration and REFUSE BY NAME (`handlerKeyRefusal()` in
+   * `../zod/tombstone.zod.ts`, the #5099 `z.custom` + guidance shape), because under
+   * `BaseSchema.passthrough()` deleting a key is a SILENT accept that keeps the value
+   * and forwards it to the DOM. The mirror's `z.input` for such a key is therefore
+   * `undefined` — a JSON author cannot write it — while the TypeScript twin of a key
+   * whose function value REACHES a renderer stays callable, because that is the
+   * programmatic channel (`SchemaRenderer` spreads every non-metadata schema key as a
+   * React prop; renderers read `schema.onX`, call `props.onX`, or spread leftovers onto
+   * a Radix root / DOM listener slot). Two faces of one key, both true, measured per
+   * key — a DELIBERATE divergence like `PageNodeSchema.pageType`, not debt to widen
+   * away. ⛔ Do not "fix" one of these by making the mirror accept a function again
+   * (that re-opens the JSON lie) or by deleting the TS member (that breaks the shipped
+   * renderer that reads it).
+   *
+   * The 22 keys NOTHING reads are not in this ledger at all: their TS twin is a
+   * `?: never` tombstone, so `undefined` meets `undefined` and the pair does not drift
+   * on them. Every one of the 58 is pinned member-by-member, both faces, in
+   * `handler-keys-json-refusal-6124.test.ts`; this ledger records the 35 that drift.
+   *
+   * `ButtonSchema.onClick` — RUNTIME SLOT (objectui#6124): `toFormControlDomProps` forwards it
+   * to the DOM `<button>` (`onClick` is on `SDUI_DOM_PASS_THROUGH_KEYS`).
+   */
+  'form.zod.ts#ButtonSchema': 'onClick';
+  /** DISJOINT: TS `Date | Date[]`, mirror `string | Date`. The mirror refuses `Date[]`; the TS side refuses the ISO string the mirror accepts. (`onChange` is NOT here: the `calendar` renderer spreads it onto `DayPicker`, whose callback is `onSelect`, so nothing reads it — both faces retire it.) */
   'form.zod.ts#CalendarSchema': 'defaultValue' | 'value';
+  /** RUNTIME SLOT (objectui#6124): the `checkbox` renderer calls `props.onChange(checked)` after `SchemaRenderer`'s spread. */
+  'form.zod.ts#CheckboxSchema': 'onChange';
+  /** RUNTIME SLOT (objectui#6124): `plugin-editor` reads `onChange ?? schema.onChange`. */
+  'form.zod.ts#CodeEditorSchema': 'onChange';
   /** OPTIONALITY: TS declares `options?`, the mirror REQUIRES it. Whether authoring a combobox without options is legal is a ruling. */
   'form.zod.ts#ComboboxSchema': 'options';
-  /** OPTIONALITY: TS declares `groups?`, the mirror REQUIRES it. */
+  /** OPTIONALITY: TS declares `groups?`, the mirror REQUIRES it. (`onChange` is NOT here: the `command` renderer spreads it onto cmdk's root `div`, where React fires it with a SyntheticEvent — a different contract from the declared `(value: string) => void`, so both faces retire it.) */
   'form.zod.ts#CommandSchema': 'groups';
-  /** DISJOINT on `mode`: TS `disabled|read|edit`, mirror `create|edit|view`. `fields` is inherited element drift. (`validationMode` was a third drifted key until objectui#5927 widened it to react-hook-form's full `mode` vocabulary — `useForm({ mode })` in `renderers/form/form.tsx` forwards it verbatim and RHF implements `onTouched`/`all` as real branches.) */
-  'form.zod.ts#FormSchema': 'fields' | 'mode';
+  /** RUNTIME SLOT (objectui#6124): the `date-picker` renderer calls `props.onChange(date)` after `SchemaRenderer`'s spread. */
+  'form.zod.ts#DatePickerSchema': 'onChange';
+  /** RUNTIME SLOT (objectui#6124): the `file-upload` renderer calls `props.onChange(files)` after `SchemaRenderer`'s spread. */
+  'form.zod.ts#FileUploadSchema': 'onChange';
+  /**
+   * `mode` — DISJOINT: TS `disabled|read|edit`, mirror `create|edit|view`. `fields` is
+   * inherited element drift. (`validationMode` was a third drifted key until
+   * objectui#5927 widened it to react-hook-form's full `mode` vocabulary —
+   * `useForm({ mode })` in `renderers/form/form.tsx` forwards it verbatim and RHF
+   * implements `onTouched`/`all` as real branches.)
+   *
+   * `onSubmit` / `onChange` / `onCancel` — RUNTIME SLOT (objectui#6124) ×3: `renderers/form/form.tsx`
+   * destructures all three off `schema` and calls them (`await onSubmitProp(formData)`,
+   * the objectui#4259 `onChangeProp` subscription, `onCancelProp()`).
+   */
+  'form.zod.ts#FormSchema': 'fields' | 'mode' | 'onSubmit' | 'onChange' | 'onCancel';
+  /** RUNTIME SLOT (objectui#6124): the `input-otp` renderer calls `props.onChange(val)` after `SchemaRenderer`'s spread. (`onComplete` is NOT here: the `toFormControlDomProps` whitelist drops it — both faces retire it.) */
+  'form.zod.ts#InputOTPSchema': 'onChange';
+  /** RUNTIME SLOT (objectui#6124): the `input` renderer calls `props.onChange(e.target.value)` after `SchemaRenderer`'s spread. */
+  'form.zod.ts#InputSchema': 'onChange';
+  /** RUNTIME SLOT (objectui#6124): the `select` renderer calls `props.onChange(matchOptionValue(…))` after `SchemaRenderer`'s spread. (This pair LEFT the ledger with objectui#5927's widenings and re-enters on a different key for a different reason.) */
+  'form.zod.ts#SelectSchema': 'onChange';
+  /** RUNTIME SLOT (objectui#6124): the `textarea` renderer calls `props.onChange(e.target.value)` after `SchemaRenderer`'s spread. */
+  'form.zod.ts#TextareaSchema': 'onChange';
+  /** RUNTIME SLOT (objectui#6124): the `card` renderer spreads `cardProps` onto the `<Card>` element (a DOM `onClick`) and reads it for `isClickable`. */
+  'layout.zod.ts#CardSchema': 'onClick';
   /** `pageType` is a DELIBERATE divergence, documented at `PageVisualizationAlias` (`../layout.ts`): the TS side retains five visualization names as a sanctioned local extension while the mirror takes the spec's vocabulary by reference, which repudiates them. Widening the mirror would re-add spellings the spec rejects. */
   'layout.zod.ts#PageNodeSchema': 'slots' | 'pageType';
+  /** RUNTIME SLOT (objectui#6124): the `tabs` renderer spreads `tabsProps` onto the Radix `Tabs` root AFTER its own `onValueChange`, so the authored function wins. */
+  'layout.zod.ts#TabsSchema': 'onValueChange';
   /** DISJOINT: TS declares `floating`, the mirror declares `transparent`. One of the two renders nothing. */
   'navigation.zod.ts#HeaderBarSchema': 'variant';
+  /** RUNTIME SLOT (objectui#6124): the `pagination` renderer calls `props.onPageChange(page)` after `SchemaRenderer`'s spread. */
+  'navigation.zod.ts#PaginationSchema': 'onPageChange';
+  /** RUNTIME SLOT (objectui#6124): the `alert-dialog` renderer spreads leftover props onto the Radix `AlertDialog` root. (`onConfirm` / `onCancel` are NOT here: the footer is wired to `schema.onAction` and `AlertDialogCancel`, so nothing reads them — both faces retire them.) */
+  'overlay.zod.ts#AlertDialogSchema': 'onOpenChange';
+  /** RUNTIME SLOT (objectui#6124): the `dialog` renderer spreads leftover props onto the Radix `Dialog` root. */
+  'overlay.zod.ts#DialogSchema': 'onOpenChange';
+  /** RUNTIME SLOT (objectui#6124): the `drawer` renderer spreads leftover props onto the vaul `Drawer` root. */
+  'overlay.zod.ts#DrawerSchema': 'onOpenChange';
+  /** RUNTIME SLOT (objectui#6124): the `dropdown-menu` renderer spreads leftover props onto the Radix `DropdownMenu` root. (`MenuItemSchema.onClick`, the 36th runtime slot, is not a pair here — that mirror is a lazy union and sits in `EXCLUSIONS`.) */
+  'overlay.zod.ts#DropdownMenuSchema': 'onOpenChange';
+  /** RUNTIME SLOT (objectui#6124): the `hover-card` renderer spreads leftover props onto the Radix `HoverCard` root. */
+  'overlay.zod.ts#HoverCardSchema': 'onOpenChange';
+  /** RUNTIME SLOT (objectui#6124): the `popover` renderer spreads leftover props onto the Radix `Popover` root. */
+  'overlay.zod.ts#PopoverSchema': 'onOpenChange';
+  /** RUNTIME SLOT (objectui#6124): the `sheet` renderer spreads leftover props onto the Radix `Sheet` (Dialog) root. */
+  'overlay.zod.ts#SheetSchema': 'onOpenChange';
 }
 
 /* ── The measured unmirrored-declared ledger (objectui#6058) ────────────────── */
@@ -1154,7 +1271,7 @@ export type assertionLedgerHalvesAreDisjoint = Expect< Equal< DoubleFiledKey, ne
 
 /**
  * Every pair's TYPE drift equals what `KnownDrift` records for it — `never` for the
- * 146 pairs with no entry (158 − 12).
+ * 122 pairs with no entry (158 − 36).
  *
  * Routed through `ReconcileAgainstLedger` rather than spelling the conditional
  * inline. That is a semantics-preserving refactor and nothing else — the type is

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -110,20 +110,38 @@ export interface KanbanSchema extends BaseSchema {
   draggable?: boolean;
   /**
    * Card move handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * forwarded by `plugin-kanban` (`onCardMove={schema.onCardMove}`).
    */
   onCardMove?: (cardId: string, fromColumn: string, toColumn: string, position: number) => void;
   /**
    * Card click handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * forwarded by `plugin-kanban` (`onCardClick={schema.onCardClick}`).
    */
   onCardClick?: (card: KanbanCard) => void;
   /**
-   * Column add handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `kanban` renderer takes `({ schema })` and never reads it. The zod twin
+   * refuses it by name; author behaviour as a node type (`{ "type": "toast" }`,
+   * an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onColumnAdd?: (column: KanbanColumn) => void;
+  onColumnAdd?: never;
   /**
-   * Card add handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `kanban` renderer takes `({ schema })` and never reads it. The zod twin
+   * refuses it by name; author behaviour as a node type (`{ "type": "toast" }`,
+   * an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onCardAdd?: (columnId: string, card: KanbanCard) => void;
+  onCardAdd?: never;
 }
 
 /**
@@ -259,7 +277,14 @@ export interface CalendarViewSchema extends BaseSchema {
    */
   onEventClick?: (event: CalendarEvent) => void;
   /**
-   * View change handler — HOST-ONLY, same rule as {@link CalendarViewSchema.onEventClick}.
+   * View change handler — HOST-ONLY, same rule as {@link
+   * CalendarViewSchema.onEventClick}.
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * read by `calendar-view`'s `pickHostCallbacks` off the spread props
+   * (function values only).
    */
   onViewChange?: (view: CalendarViewMode) => void;
 }
@@ -335,6 +360,12 @@ export interface FilterBuilderSchema extends BaseSchema {
   value?: FilterGroup;
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `filter-builder` renderer as `props.onChange` after
+   * `SchemaRenderer` spreads it.
    */
   onChange?: (filter: FilterGroup) => void;
   /**
@@ -470,9 +501,13 @@ export interface CarouselSchema extends BaseSchema {
    */
   gap?: number;
   /**
-   * Slide change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `carousel` renderer spreads it onto a `<div>` that has no such event (React
+   * attaches nothing). The zod twin refuses it by name; author behaviour as a
+   * node type (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onSlideChange?: (index: number) => void;
+  onSlideChange?: never;
 }
 
 /**
@@ -595,9 +630,13 @@ export interface ChatbotSchema extends BaseSchema {
    */
   loading?: boolean;
   /**
-   * Message send handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `chatbot` renderer wires its own `handleSendMessage` and `toDomProps` drops
+   * the key. The zod twin refuses it by name; author behaviour as a node type
+   * (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onSendMessage?: (message: string) => void | Promise<void>;
+  onSendMessage?: never;
   /**
    * Show avatars
    * @default true
@@ -681,6 +720,11 @@ export interface ChatbotSchema extends BaseSchema {
   maxToolRoundtrips?: number;
   /**
    * Callback when an error occurs during streaming or API calls.
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * forwarded by `plugin-chatbot` into `useObjectChat({ onError })`.
    */
   onError?: (error: Error) => void;
 
@@ -740,12 +784,17 @@ export interface ChatbotSchema extends BaseSchema {
    */
   autoResponseDelay?: number;
   /**
-   * Called after a message is sent, in both API and local auto-response
-   * mode, with the trimmed content and the full message list at that
-   * point. `messages` here is the same authoring-side {@link ChatMessage}
-   * shape as the `messages` field above; the plugin's own runtime message
-   * type is a structural superset (objectui#4424) and still satisfies a
-   * handler typed against this narrower, published shape.
+   * Called after a message is sent, in both API and local auto-response mode,
+   * with the trimmed content and the full message list at that point.
+   * `messages` here is the same authoring-side {@link ChatMessage} shape as the
+   * `messages` field above; the plugin's own runtime message type is a
+   * structural superset (objectui#4424) and still satisfies a handler typed
+   * against this narrower, published shape.
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * forwarded by `plugin-chatbot` into `useObjectChat({ onSend })`.
    */
   onSend?: (content: string, messages: ChatMessage[]) => void;
 

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -46,9 +46,14 @@ export interface AlertSchema extends BaseSchema {
    */
   dismissible?: boolean;
   /**
-   * Dismiss handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `alert` renderer spreads it onto the `<Alert>` element, which has no such
+   * event (React attaches nothing). The zod twin refuses it by name; author
+   * behaviour as a node type (`{ "type": "toast" }`, an `action:button` node)
+   * instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onDismiss?: () => void;
+  onDismiss?: never;
   /**
    * Child content
    */
@@ -190,9 +195,13 @@ export interface ListItem {
    */
   disabled?: boolean;
   /**
-   * Click handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `list` renderer renders each item as `<li>{content}</li>` and never reads
+   * it. The zod twin refuses it by name; author behaviour as a node type (`{
+   * "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onClick?: () => void;
+  onClick?: never;
   /**
    * Item content (schema nodes)
    */
@@ -883,10 +892,20 @@ export interface DataTableSchema extends BaseSchema {
   reorderableColumns?: boolean;
   /**
    * Row edit handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by `renderers/complex/data-table.tsx` (`schema.onRowEdit?.(row)`).
    */
   onRowEdit?: (row: any) => void;
   /**
    * Row delete handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by `renderers/complex/data-table.tsx` (`schema.onRowDelete?.(row)`).
    */
   onRowDelete?: (row: any) => void;
   /**
@@ -917,6 +936,12 @@ export interface DataTableSchema extends BaseSchema {
   onRowActionDef?: (action: DataTableRowAction, row: any) => void | Promise<void>;
   /**
    * Selection change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by `renderers/complex/data-table.tsx`
+   * (`schema.onSelectionChange(selectedData)`).
    */
   onSelectionChange?: (selectedRows: any[]) => void;
   /**
@@ -928,6 +953,12 @@ export interface DataTableSchema extends BaseSchema {
   selectionResetKey?: string | number;
   /**
    * Columns reorder handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by `renderers/complex/data-table.tsx`
+   * (`schema.onColumnsReorder(newColumns)`).
    */
   onColumnsReorder?: (columns: TableColumn[]) => void;
   /**
@@ -1206,13 +1237,23 @@ export interface TreeViewSchema extends BaseSchema {
    */
   showLines?: boolean;
   /**
-   * Node select handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `tree-view` renderer spreads it onto a `<div>` that has no such event;
+   * nodes receive only `onNodeClick`. The zod twin refuses it by name; author
+   * behaviour as a node type (`{ "type": "toast" }`, an `action:button` node)
+   * instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onSelectChange?: (selectedIds: string[]) => void;
+  onSelectChange?: never;
   /**
-   * Node expand handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `tree-view` renderer spreads it onto a `<div>` that has no such event;
+   * nodes receive only `onNodeClick`. The zod twin refuses it by name; author
+   * behaviour as a node type (`{ "type": "toast" }`, an `action:button` node)
+   * instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onExpandChange?: (expandedIds: string[]) => void;
+  onExpandChange?: never;
   /**
    * Node click handler — INVOKED, not merely read, so this is a call
    * signature and not a value shape.

--- a/packages/types/src/disclosure.ts
+++ b/packages/types/src/disclosure.ts
@@ -72,6 +72,11 @@ export interface AccordionSchema extends BaseSchema {
   value?: string | string[];
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `Accordion` root by the renderer's `{...props}`.
    */
   onValueChange?: (value: string | string[]) => void;
   /**
@@ -105,6 +110,11 @@ export interface CollapsibleSchema extends BaseSchema {
   open?: boolean;
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `Collapsible` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -165,6 +175,12 @@ export interface ToggleGroupSchema extends BaseSchema {
   value?: string | string[];
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `ToggleGroup` root by the renderer's
+   * `{...toggleGroupProps}`.
    */
   onValueChange?: (value: string | string[]) => void;
 }

--- a/packages/types/src/feedback.ts
+++ b/packages/types/src/feedback.ts
@@ -145,9 +145,13 @@ export interface ToastSchema extends BaseSchema {
     onClick: () => void;
   };
   /**
-   * Dismiss handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `toast` renderer takes `({ schema })` and never reads it. The zod twin
+   * refuses it by name; author behaviour as a node type (`{ "type": "toast" }`,
+   * an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onDismiss?: () => void;
+  onDismiss?: never;
   /**
    * Label for the trigger button this component renders in place.
    *

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -51,6 +51,12 @@ export interface ButtonSchema extends BaseSchema {
   iconPosition?: 'left' | 'right';
   /**
    * Click handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * forwarded to the DOM `<button>` by `toFormControlDomProps` (`onClick` is on
+   * `SDUI_DOM_PASS_THROUGH_KEYS`).
    */
   onClick?: () => void | Promise<void>;
   /**
@@ -112,6 +118,12 @@ export interface InputSchema extends BaseSchema {
   error?: string;
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `input` renderer as `props.onChange(e.target.value)` after
+   * `SchemaRenderer` spreads it.
    */
   onChange?: (value: string | number) => void;
   /**
@@ -187,6 +199,12 @@ export interface TextareaSchema extends BaseSchema {
   error?: string;
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `textarea` renderer as `props.onChange(e.target.value)` after
+   * `SchemaRenderer` spreads it.
    */
   onChange?: (value: string) => void;
   /**
@@ -240,6 +258,12 @@ export interface SelectSchema extends BaseSchema {
    * Change handler. Receives the AUTHORED option value — a numeric/boolean
    * option arrives with its type intact (#3090), not stringified by the
    * underlying control.
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `select` renderer as `props.onChange(matchOptionValue(…))`
+   * after `SchemaRenderer` spreads it.
    */
   onChange?: (value: string | number | boolean) => void;
 }
@@ -339,6 +363,12 @@ export interface CheckboxSchema extends BaseSchema {
   required?: boolean;
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `checkbox` renderer as `props.onChange(checked)` after
+   * `SchemaRenderer` spreads it.
    */
   onChange?: (checked: boolean) => void;
 }
@@ -382,10 +412,13 @@ export interface RadioGroupSchema extends BaseSchema {
    */
   error?: string;
   /**
-   * Change handler. Receives the AUTHORED option value — a numeric option
-   * arrives with its type intact (#3090).
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `radio-group` renderer forwards only `toFormControlDomProps`'s whitelist,
+   * which drops it. The zod twin refuses it by name; author behaviour as a node
+   * type (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onChange?: (value: string | number) => void;
+  onChange?: never;
 }
 
 /**
@@ -437,9 +470,13 @@ export interface SwitchSchema extends BaseSchema {
    */
   description?: string;
   /**
-   * Change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `switch` renderer forwards only `toFormControlDomProps`'s whitelist, which
+   * drops it. The zod twin refuses it by name; author behaviour as a node type
+   * (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onChange?: (checked: boolean) => void;
+  onChange?: never;
 }
 
 /**
@@ -470,9 +507,13 @@ export interface ToggleSchema extends BaseSchema {
    */
   size?: 'default' | 'sm' | 'lg';
   /**
-   * Change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `toggle` renderer forwards only `toFormControlDomProps`'s whitelist, which
+   * drops it. The zod twin refuses it by name; author behaviour as a node type
+   * (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onChange?: (pressed: boolean) => void;
+  onChange?: never;
   /**
    * Child content
    */
@@ -520,9 +561,13 @@ export interface SliderSchema extends BaseSchema {
    */
   description?: string;
   /**
-   * Change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `slider` renderer forwards only `toFormControlDomProps`'s whitelist, which
+   * drops it. The zod twin refuses it by name; author behaviour as a node type
+   * (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onChange?: (value: number[]) => void;
+  onChange?: never;
 }
 
 /**
@@ -581,6 +626,12 @@ export interface FileUploadSchema extends BaseSchema {
   wrapperClass?: string;
   /**
    * Change handler (receives FileList or File[])
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `file-upload` renderer as `props.onChange(files)` after
+   * `SchemaRenderer` spreads it.
    */
   onChange?: (files: FileList | File[]) => void;
 }
@@ -633,6 +684,12 @@ export interface DatePickerSchema extends BaseSchema {
   error?: string;
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `date-picker` renderer as `props.onChange(date)` after
+   * `SchemaRenderer` spreads it.
    */
   onChange?: (date: Date | undefined) => void;
 }
@@ -664,9 +721,14 @@ export interface CalendarSchema extends BaseSchema {
    */
   maxDate?: Date | string;
   /**
-   * Change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `calendar` renderer spreads it onto `DayPicker`, whose selection callback
+   * is `onSelect`; nothing calls it. The zod twin refuses it by name; author
+   * behaviour as a node type (`{ "type": "toast" }`, an `action:button` node)
+   * instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onChange?: (date: Date | Date[] | undefined) => void;
+  onChange?: never;
 }
 
 /**
@@ -705,12 +767,22 @@ export interface InputOTPSchema extends BaseSchema {
   error?: string;
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `input-otp` renderer as `props.onChange(val)` after
+   * `SchemaRenderer` spreads it.
    */
   onChange?: (value: string) => void;
   /**
-   * Complete handler (called when all digits filled)
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `input-otp` renderer forwards only `toFormControlDomProps`'s whitelist,
+   * which drops it. The zod twin refuses it by name; author behaviour as a node
+   * type (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onComplete?: (value: string) => void;
+  onComplete?: never;
 }
 
 /**
@@ -1170,10 +1242,22 @@ export interface FormSchema extends BaseSchema {
   actions?: SchemaNode[];
   /**
    * Submit handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * destructured off `schema` by `renderers/form/form.tsx` and awaited from
+   * `handleSubmit`.
    */
   onSubmit?: (data: Record<string, any>) => void | Promise<void>;
   /**
    * Change handler (called on any field change)
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * destructured off `schema` by `renderers/form/form.tsx` and subscribed to
+   * the form values (objectui#4259).
    */
   onChange?: (data: Record<string, any>) => void;
   /**
@@ -1186,6 +1270,12 @@ export interface FormSchema extends BaseSchema {
   onDirtyChange?: (isDirty: boolean) => void;
   /**
    * Cancel handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * destructured off `schema` by `renderers/form/form.tsx` and called from the
+   * cancel action.
    */
   onCancel?: () => void;
   /**
@@ -1334,9 +1424,13 @@ export interface ComboboxSchema extends BaseSchema {
    */
   error?: string;
   /**
-   * Change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `combobox` renderer forwards only `toFormControlDomProps`'s whitelist,
+   * which drops it. The zod twin refuses it by name; author behaviour as a node
+   * type (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onChange?: (value: string) => void;
+  onChange?: never;
 }
 
 /**
@@ -1389,9 +1483,15 @@ export interface CommandSchema extends BaseSchema {
    */
   groups?: CommandGroup[];
   /**
-   * Change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `command` renderer spreads it onto cmdk's root `<div>`, where React fires
+   * it with a SyntheticEvent on keystrokes — a different contract from `(value:
+   * string) => void`, not a consumer of it. The zod twin refuses it by name;
+   * author behaviour as a node type (`{ "type": "toast" }`, an `action:button`
+   * node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onChange?: (value: string) => void;
+  onChange?: never;
 }
 
 /**
@@ -1457,6 +1557,11 @@ export interface CodeEditorSchema extends BaseSchema {
   /**
    * Change handler. A runtime slot, not an authorable key — no JSON document
    * can carry a function.
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * read by `plugin-editor` (`onChange ?? schema.onChange`).
    */
   onChange?: (value: string | undefined) => void;
 }

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -389,6 +389,12 @@ export interface CardSchema extends BaseSchema {
   clickable?: boolean;
   /**
    * Click handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the `<Card>` element by the renderer's `{...cardProps}` (it
+   * also drives `isClickable`).
    */
   onClick?: () => void;
 }
@@ -417,6 +423,12 @@ export interface TabsSchema extends BaseSchema {
   items: TabItem[];
   /**
    * Change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `Tabs` root by the renderer's `{...tabsProps}`, after
+   * its own `onValueChange`.
    */
   onValueChange?: (value: string) => void;
 }

--- a/packages/types/src/navigation.ts
+++ b/packages/types/src/navigation.ts
@@ -163,9 +163,13 @@ export interface SidebarSchema extends BaseSchema {
    */
   collapsedWidth?: string | number;
   /**
-   * Collapsed state change handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `sidebar` renderer spreads it onto `<Sidebar>`, which has no such prop
+   * (React attaches nothing). The zod twin refuses it by name; author behaviour
+   * as a node type (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onCollapsedChange?: (collapsed: boolean) => void;
+  onCollapsedChange?: never;
   /**
    * Sidebar variant
    * @default 'default'
@@ -190,9 +194,13 @@ export interface BreadcrumbItem {
    */
   icon?: string;
   /**
-   * Click handler (if not using href)
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `breadcrumb` renderer renders items as links and never reads it. The zod
+   * twin refuses it by name; author behaviour as a node type (`{ "type":
+   * "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onClick?: () => void;
+  onClick?: never;
   /**
    * Sibling items for dropdown navigation (e.g., quick-switch between objects)
    */
@@ -253,6 +261,12 @@ export interface PaginationSchema extends BaseSchema {
   showPrevNext?: boolean;
   /**
    * Page change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `pagination` renderer as `props.onPageChange(page)` after
+   * `SchemaRenderer` spreads it.
    */
   onPageChange?: (page: number) => void;
 }
@@ -320,9 +334,13 @@ export interface ButtonGroupButton {
    */
   disabled?: boolean;
   /**
-   * Click handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `button-group` renderer renders each `<Button>` without a click handler and
+   * never reads it. The zod twin refuses it by name; author behaviour as a node
+   * type (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onClick?: () => void;
+  onClick?: never;
   /**
    * Button CSS class
    */

--- a/packages/types/src/overlay.ts
+++ b/packages/types/src/overlay.ts
@@ -68,6 +68,11 @@ export interface DialogSchema extends BaseSchema {
   modal?: boolean;
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `Dialog` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -114,15 +119,29 @@ export interface AlertDialogSchema extends BaseSchema {
    */
   confirmVariant?: 'default' | 'destructive';
   /**
-   * Confirm handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `alert-dialog` renderer wires its action button to `schema.onAction` and
+   * never reads it. The zod twin refuses it by name; author behaviour as a node
+   * type (`{ "type": "toast" }`, an `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onConfirm?: () => void | Promise<void>;
+  onConfirm?: never;
   /**
-   * Cancel handler
+   * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
+   * `alert-dialog` renderer spreads it onto the Radix root, which has no such
+   * prop; the cancel button is `AlertDialogCancel`. The zod twin refuses it by
+   * name; author behaviour as a node type (`{ "type": "toast" }`, an
+   * `action:button` node) instead.
+   * @deprecated Not part of this contract — the value was inert.
    */
-  onCancel?: () => void;
+  onCancel?: never;
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `AlertDialog` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -168,6 +187,11 @@ export interface SheetSchema extends BaseSchema {
   footer?: SchemaNode | SchemaNode[];
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `Sheet` (Dialog) root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -209,6 +233,11 @@ export interface DrawerSchema extends BaseSchema {
   direction?: OverlayPosition;
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the vaul `Drawer` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -247,6 +276,11 @@ export interface PopoverSchema extends BaseSchema {
   align?: OverlayAlignment;
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `Popover` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -331,6 +365,11 @@ export interface HoverCardSchema extends BaseSchema {
   align?: OverlayAlignment;
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `HoverCard` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }
@@ -375,6 +414,12 @@ export interface MenuCommandItem {
   disabled?: boolean;
   /**
    * Click handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * called by the `dropdown-menu` / `context-menu` / `menubar` renderers
+   * (`item.onClick?.()`).
    */
   onClick?: () => void;
   /**
@@ -452,6 +497,11 @@ export interface DropdownMenuSchema extends BaseSchema {
   align?: OverlayAlignment;
   /**
    * Open state change handler
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because it is
+   * spread onto the Radix `DropdownMenu` root by the renderer's `{...props}`.
    */
   onOpenChange?: (open: boolean) => void;
 }

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from 'zod';
+import { handlerKeyRefusal } from './tombstone.zod.js';
 import {
   ChartTypeSchema as SpecChartTypeSchema,
   DashboardSchema as SpecDashboardSchema,
@@ -64,10 +65,10 @@ export const KanbanSchema = BaseSchema.extend({
   type: z.literal('kanban'),
   columns: z.array(KanbanColumnSchema).describe('Kanban columns'),
   draggable: z.boolean().optional().describe('Whether cards are draggable'),
-  onCardMove: z.function().optional().describe('Card move handler'),
-  onCardClick: z.function().optional().describe('Card click handler'),
-  onColumnAdd: z.function().optional().describe('Column add handler'),
-  onCardAdd: z.function().optional().describe('Card add handler'),
+  onCardMove: handlerKeyRefusal('onCardMove', 'runtime-slot', 'Card move handler'),
+  onCardClick: handlerKeyRefusal('onCardClick', 'runtime-slot', 'Card click handler'),
+  onColumnAdd: handlerKeyRefusal('onColumnAdd', 'retired', 'Column add handler'),
+  onCardAdd: handlerKeyRefusal('onCardAdd', 'retired', 'Card add handler'),
 });
 
 /**
@@ -145,7 +146,7 @@ export const CalendarViewSchema = BaseSchema.extend({
     .function()
     .optional()
     .describe('Host-only event click handler (authored JSON cannot produce a function)'),
-  onViewChange: z.function().optional().describe('Host-only view change handler'),
+  onViewChange: handlerKeyRefusal('onViewChange', 'runtime-slot', 'Host-only view change handler'),
 });
 
 /**
@@ -211,7 +212,7 @@ export const FilterBuilderSchema = BaseSchema.extend({
   fields: z.array(FilterFieldSchema).describe('Available filter fields'),
   defaultValue: z.union([FilterBuilderConditionSchema, FilterGroupSchema]).optional().describe('Default filter value'),
   value: z.union([FilterBuilderConditionSchema, FilterGroupSchema]).optional().describe('Controlled filter value'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
   allowGroups: z.boolean().optional().describe('Allow grouped conditions'),
   maxDepth: z.number().optional().describe('Maximum nesting depth'),
   wrapperClass: z.string().optional()
@@ -244,7 +245,7 @@ export const CarouselSchema = BaseSchema.extend({
   loop: z.boolean().optional().describe('Enable infinite loop'),
   itemsPerView: z.number().optional().describe('Items per view'),
   gap: z.number().optional().describe('Gap between items'),
-  onSlideChange: z.function().optional().describe('Slide change handler'),
+  onSlideChange: handlerKeyRefusal('onSlideChange', 'retired', 'Slide change handler'),
 });
 
 /**
@@ -300,7 +301,7 @@ export const ChatbotSchema = BaseSchema.extend({
   messages: z.array(ChatMessageSchema).describe('Chat messages'),
   placeholder: z.string().optional().describe('Input placeholder'),
   loading: z.boolean().optional().describe('Whether chat is loading'),
-  onSendMessage: z.function().optional().describe('Send message handler'),
+  onSendMessage: handlerKeyRefusal('onSendMessage', 'retired', 'Send message handler'),
   showAvatars: z.boolean().optional().describe('Show user avatars'),
   userAvatar: z.string().optional().describe('User avatar URL'),
   assistantAvatar: z.string().optional().describe('Assistant avatar URL'),
@@ -317,7 +318,7 @@ export const ChatbotSchema = BaseSchema.extend({
   /** @deprecated objectui#5605 — inert; nothing reads it. Cap loops on the agent (`planning.maxIterations`). Slated for removal. */
   maxToolRoundtrips: z.number().optional()
     .describe('DEPRECATED (inert, slated for removal) — Max tool-calling round-trips. Nothing reads this; cap tool loops on the agent via planning.maxIterations'),
-  onError: z.function().optional().describe('Error callback'),
+  onError: handlerKeyRefusal('onError', 'runtime-slot', 'Error callback'),
   // --- Local display + legacy auto-response fields (objectui#6169) ---
   // Mirrors the TS declaration added at ../complex.ts in lockstep, so these
   // ten keys move from the pre-existing "declared but unmirrored, rides
@@ -332,7 +333,7 @@ export const ChatbotSchema = BaseSchema.extend({
   autoResponse: z.boolean().optional().describe('Enable local auto-response (demo/playground) mode'),
   autoResponseText: z.string().optional().describe('Text of the local auto-response'),
   autoResponseDelay: z.number().optional().describe('Delay in milliseconds before the local auto-response is sent'),
-  onSend: z.function().optional().describe('Called after a message is sent, in both API and local auto-response mode'),
+  onSend: handlerKeyRefusal('onSend', 'runtime-slot', 'Called after a message is sent, in both API and local auto-response mode'),
 });
 
 /**

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -19,7 +19,7 @@
 import { z } from 'zod';
 import { ChartTypeSchema as SpecChartTypeSchema } from '@objectstack/spec/ui';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
-import { retirementTombstone } from './tombstone.zod.js';
+import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 import { TABLE_COLUMN_TYPES } from '../data-display.js';
 
 /**
@@ -32,7 +32,7 @@ export const AlertSchema = BaseSchema.extend({
   variant: z.enum(['default', 'destructive']).optional().describe('Alert variant'),
   icon: z.string().optional().describe('Alert icon'),
   dismissible: z.boolean().optional().describe('Whether alert can be dismissed'),
-  onDismiss: z.function().optional().describe('Dismiss handler'),
+  onDismiss: handlerKeyRefusal('onDismiss', 'retired', 'Dismiss handler'),
   children: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional(),
 });
 
@@ -81,7 +81,7 @@ export const ListItemSchema = z.object({
   icon: z.string().optional().describe('Item icon'),
   avatar: z.string().optional().describe('Item avatar URL'),
   disabled: z.boolean().optional().describe('Whether item is disabled'),
-  onClick: z.function().optional().describe('Click handler'),
+  onClick: handlerKeyRefusal('onClick', 'retired', 'Click handler'),
   content: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Custom content'),
 });
 
@@ -254,8 +254,8 @@ export const DataTableSchema = BaseSchema.extend({
   rowActions: z.array(z.any()).optional().describe('Row action buttons'),
   resizableColumns: z.boolean().optional().describe('Allow column resizing'),
   reorderableColumns: z.boolean().optional().describe('Allow column reordering'),
-  onRowEdit: z.function().optional().describe('Row edit handler'),
-  onRowDelete: z.function().optional().describe('Row delete handler'),
+  onRowEdit: handlerKeyRefusal('onRowEdit', 'runtime-slot', 'Row edit handler'),
+  onRowDelete: handlerKeyRefusal('onRowDelete', 'runtime-slot', 'Row delete handler'),
   rowEditPredicates: z.object({
     visibleWhen: z.unknown().optional(),
     disabledWhen: z.unknown().optional(),
@@ -264,8 +264,8 @@ export const DataTableSchema = BaseSchema.extend({
     visibleWhen: z.unknown().optional(),
     disabledWhen: z.unknown().optional(),
   }).optional().describe('Per-record CEL predicates for the built-in row Delete item (objectui#2614)'),
-  onSelectionChange: z.function().optional().describe('Selection change handler'),
-  onColumnsReorder: z.function().optional().describe('Column reorder handler'),
+  onSelectionChange: handlerKeyRefusal('onSelectionChange', 'runtime-slot', 'Selection change handler'),
+  onColumnsReorder: handlerKeyRefusal('onColumnsReorder', 'runtime-slot', 'Column reorder handler'),
   cellClassName: z.string().optional().describe('Extra classes folded into the utility body cells only — the selection, row-number and row-actions cells; data cells fold the per-column `cellClassName` instead, so row density has to be set on both (objectui#6882)'),
   renderCellEditor: z.function().optional().describe('Host-supplied inline cell editor; returning null falls through to the built-in text/number/date inputs (objectui#6882). Its context carries `row` (the persisted record) and `pendingRow` (that record with the row\'s staged, unsaved edits merged over it — objectui#7188); `z.function()` encodes no parameter shape, so the member on `DataTableSchema` is the authority for it'),
   frozenColumns: z.number().optional().describe('Number of frozen columns'),
@@ -315,8 +315,8 @@ export const TreeViewSchema = BaseSchema.extend({
   selectedIds: z.array(z.string()).optional().describe('Controlled selected node IDs'),
   multiSelect: z.boolean().optional().describe('Allow multiple selection'),
   showLines: z.boolean().optional().describe('Show connecting lines'),
-  onSelectChange: z.function().optional().describe('Selection change handler'),
-  onExpandChange: z.function().optional().describe('Expand change handler'),
+  onSelectChange: handlerKeyRefusal('onSelectChange', 'retired', 'Selection change handler'),
+  onExpandChange: handlerKeyRefusal('onExpandChange', 'retired', 'Expand change handler'),
 });
 
 /**

--- a/packages/types/src/zod/disclosure.zod.ts
+++ b/packages/types/src/zod/disclosure.zod.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from 'zod';
+import { handlerKeyRefusal } from './tombstone.zod.js';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 
 /**
@@ -39,7 +40,7 @@ export const AccordionSchema = BaseSchema.extend({
   collapsible: z.boolean().optional().describe('Whether items can be collapsed'),
   defaultValue: z.union([z.string(), z.array(z.string())]).optional().describe('Default open item(s)'),
   value: z.union([z.string(), z.array(z.string())]).optional().describe('Controlled open item(s)'),
-  onValueChange: z.function().optional().describe('Value change handler'),
+  onValueChange: handlerKeyRefusal('onValueChange', 'runtime-slot', 'Value change handler'),
   variant: z.enum(['default', 'bordered', 'separated']).optional().describe('Accordion variant'),
 });
 
@@ -52,7 +53,7 @@ export const CollapsibleSchema = BaseSchema.extend({
   content: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).describe('Collapsible content'),
   defaultOpen: z.boolean().optional().describe('Default open state'),
   open: z.boolean().optional().describe('Controlled open state'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**
@@ -75,7 +76,7 @@ export const ToggleGroupSchema = BaseSchema.extend({
   items: z.array(ToggleGroupItemSchema).optional().describe('Toggle group items'),
   defaultValue: z.union([z.string(), z.array(z.string())]).optional().describe('Default value(s)'),
   value: z.union([z.string(), z.array(z.string())]).optional().describe('Controlled value(s)'),
-  onValueChange: z.function().optional().describe('Value change handler'),
+  onValueChange: handlerKeyRefusal('onValueChange', 'runtime-slot', 'Value change handler'),
 });
 
 /**

--- a/packages/types/src/zod/feedback.zod.ts
+++ b/packages/types/src/zod/feedback.zod.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from 'zod';
+import { handlerKeyRefusal } from './tombstone.zod.js';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 
 /**
@@ -73,7 +74,7 @@ export const ToastSchema = BaseSchema.extend({
     'bottom-right',
   ]).optional().describe('Toast position'),
   action: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Action button'),
-  onDismiss: z.function().optional().describe('Dismiss handler'),
+  onDismiss: handlerKeyRefusal('onDismiss', 'retired', 'Dismiss handler'),
   // The trigger button the `toast` renderer draws in place. `buttonVariant`
   // is an ENUM and not `z.string()`: the renderer hands the value straight to
   // `<Button variant={…}>`, whose vocabulary is the six keys of

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from 'zod';
+import { handlerKeyRefusal } from './tombstone.zod.js';
 import { SelectOptionSchema as SpecSelectOptionSchema } from '@objectstack/spec/data';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 
@@ -175,9 +176,7 @@ export const ButtonSchema = BaseSchema.extend({
   loading: z.boolean().optional().describe('Whether button is in loading state'),
   icon: z.string().optional().describe('Icon to display (lucide-react icon name)'),
   iconPosition: z.enum(['left', 'right']).optional().default('left').describe('Icon position'),
-  onClick: z.function()
-    .optional()
-    .describe('Click handler'),
+  onClick: handlerKeyRefusal('onClick', 'runtime-slot', 'Click handler'),
   buttonType: z.enum(['button', 'submit', 'reset'])
     .optional()
     .default('button')
@@ -206,7 +205,7 @@ export const InputSchema = BaseSchema.extend({
   readOnly: z.boolean().optional().describe('Whether field is read-only'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
   min: z.number().optional().describe('Minimum value (for number type)'),
   max: z.number().optional().describe('Maximum value (for number type)'),
   step: z.number().optional().describe('Step value (for number type)'),
@@ -229,7 +228,7 @@ export const TextareaSchema = BaseSchema.extend({
   readOnly: z.boolean().optional().describe('Whether field is read-only'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
   maxLength: z.number().optional().describe('Maximum length'),
 });
 
@@ -247,7 +246,7 @@ export const SelectSchema = BaseSchema.extend({
   required: z.boolean().optional().describe('Whether field is required'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
 /**
@@ -263,7 +262,7 @@ export const CheckboxSchema = BaseSchema.extend({
     .describe("Required affordance, read at renderers/form/checkbox.tsx:45 (`required=` on the Radix Checkbox) and :49 (gates the label's `*` marker) (objectui#6150)"),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
 /**
@@ -279,7 +278,7 @@ export const RadioGroupSchema = BaseSchema.extend({
   orientation: z.enum(['horizontal', 'vertical']).optional().describe('Layout orientation'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
 /**
@@ -292,7 +291,7 @@ export const SwitchSchema = BaseSchema.extend({
   defaultChecked: z.boolean().optional().describe('Default checked state'),
   checked: z.boolean().optional().describe('Controlled checked state'),
   description: z.string().optional().describe('Help text'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
 /**
@@ -305,7 +304,7 @@ export const ToggleSchema = BaseSchema.extend({
   pressed: z.boolean().optional().describe('Controlled pressed state'),
   variant: z.enum(['default', 'outline']).optional().describe('Toggle variant'),
   size: z.enum(['default', 'sm', 'lg']).optional().describe('Toggle size'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
   children: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional(),
 });
 
@@ -322,7 +321,7 @@ export const SliderSchema = BaseSchema.extend({
   max: z.number().optional().describe('Maximum value'),
   step: z.number().optional().describe('Step value'),
   description: z.string().optional().describe('Help text'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
 /**
@@ -342,7 +341,7 @@ export const FileUploadSchema = BaseSchema.extend({
   maxFiles: z.number().optional().describe('Maximum number of files'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
 /**
@@ -360,7 +359,7 @@ export const DatePickerSchema = BaseSchema.extend({
   format: z.string().optional().describe('Date format string'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
 /**
@@ -373,7 +372,7 @@ export const CalendarSchema = BaseSchema.extend({
   mode: z.enum(['single', 'multiple', 'range']).optional().describe('Selection mode'),
   minDate: z.union([z.string(), z.date()]).optional().describe('Minimum date'),
   maxDate: z.union([z.string(), z.date()]).optional().describe('Maximum date'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
 /**
@@ -388,8 +387,8 @@ export const InputOTPSchema = BaseSchema.extend({
   value: z.string().optional().describe('Controlled value'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
-  onComplete: z.function().optional().describe('Complete handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
+  onComplete: handlerKeyRefusal('onComplete', 'retired', 'Complete handler'),
 });
 
 /**
@@ -405,7 +404,7 @@ export const ComboboxSchema = BaseSchema.extend({
   value: z.string().optional().describe('Controlled value'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
 /**
@@ -426,7 +425,7 @@ export const CommandSchema = BaseSchema.extend({
   placeholder: z.string().optional().describe('Search placeholder'),
   emptyText: z.string().optional().describe('Empty state text'),
   groups: z.array(CommandGroupSchema).describe('Command groups'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
 /**
@@ -634,9 +633,9 @@ export const FormSchema = BaseSchema.extend({
   resetOnSubmit: z.boolean().optional().describe('Reset form on successful submit'),
   mode: z.enum(['create', 'edit', 'view']).optional().describe('Form mode'),
   actions: z.array(z.any()).optional().describe('Custom actions'),
-  onSubmit: z.function().optional().describe('Submit handler'),
-  onChange: z.function().optional().describe('Change handler'),
-  onCancel: z.function().optional().describe('Cancel handler'),
+  onSubmit: handlerKeyRefusal('onSubmit', 'runtime-slot', 'Submit handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
+  onCancel: handlerKeyRefusal('onCancel', 'runtime-slot', 'Cancel handler'),
   showActions: z.boolean().optional().describe('Show action buttons'),
 });
 
@@ -665,7 +664,7 @@ export const CodeEditorSchema = BaseSchema.extend({
   theme: z.enum(['vs-dark', 'light']).optional().describe('Editor colour theme'),
   height: z.string().optional().describe('Editor height as a CSS length'),
   readOnly: z.boolean().optional().describe('Whether the editor refuses edits'),
-  onChange: z.function().optional().describe('Change handler'),
+  onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
 export const FormComponentSchema = z.discriminatedUnion('type', [

--- a/packages/types/src/zod/layout.zod.ts
+++ b/packages/types/src/zod/layout.zod.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from 'zod';
+import { handlerKeyRefusal } from './tombstone.zod.js';
 import {
   PageSchema as SpecPageSchema,
   PageTypeSchema as SpecPageTypeSchema,
@@ -234,7 +235,7 @@ export const CardSchema = BaseSchema.extend({
   variant: z.enum(['default', 'outline', 'ghost']).optional().default('default').describe('Card variant style'),
   hoverable: z.boolean().optional().default(false).describe('Whether the card is hoverable'),
   clickable: z.boolean().optional().default(false).describe('Whether the card is clickable'),
-  onClick: z.function().optional().describe('Click handler'),
+  onClick: handlerKeyRefusal('onClick', 'runtime-slot', 'Click handler'),
 });
 
 /**
@@ -257,7 +258,7 @@ export const TabsSchema = BaseSchema.extend({
   value: z.string().optional().describe('Controlled active tab value'),
   orientation: z.enum(['horizontal', 'vertical']).optional().default('horizontal').describe('Tabs orientation'),
   items: z.array(TabItemSchema).describe('Tab items configuration'),
-  onValueChange: z.function().optional().describe('Change handler'),
+  onValueChange: handlerKeyRefusal('onValueChange', 'runtime-slot', 'Change handler'),
 });
 
 /**

--- a/packages/types/src/zod/navigation.zod.ts
+++ b/packages/types/src/zod/navigation.zod.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from 'zod';
+import { handlerKeyRefusal } from './tombstone.zod.js';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 
 /**
@@ -41,7 +42,7 @@ export const BreadcrumbItemSchema = z.object({
   label: z.string().describe('Breadcrumb label'),
   href: z.string().optional().describe('Link URL'),
   icon: z.string().optional().describe('Breadcrumb icon'),
-  onClick: z.function().optional().describe('Click handler'),
+  onClick: handlerKeyRefusal('onClick', 'retired', 'Click handler'),
   siblings: z.array(z.object({
     label: z.string().describe('Sibling label'),
     href: z.string().describe('Sibling URL'),
@@ -87,7 +88,7 @@ export const SidebarSchema = BaseSchema.extend({
   collapsed: z.boolean().optional().describe('Controlled collapsed state'),
   width: z.union([z.string(), z.number()]).optional().describe('Sidebar width'),
   collapsedWidth: z.union([z.string(), z.number()]).optional().describe('Collapsed width'),
-  onCollapsedChange: z.function().optional().describe('Collapsed change handler'),
+  onCollapsedChange: handlerKeyRefusal('onCollapsedChange', 'retired', 'Collapsed change handler'),
   variant: z.enum(['default', 'bordered', 'floating']).optional().describe('Sidebar variant'),
 });
 
@@ -111,7 +112,7 @@ export const PaginationSchema = BaseSchema.extend({
   siblings: z.number().optional().describe('Number of sibling pages to show'),
   showFirstLast: z.boolean().optional().describe('Show first/last page buttons'),
   showPrevNext: z.boolean().optional().describe('Show previous/next buttons'),
-  onPageChange: z.function().optional().describe('Page change handler'),
+  onPageChange: handlerKeyRefusal('onPageChange', 'runtime-slot', 'Page change handler'),
 });
 
 /**
@@ -144,7 +145,7 @@ export const ButtonGroupButtonSchema = z.object({
   variant: z.enum(['default', 'secondary', 'destructive', 'outline', 'ghost', 'link']).optional(),
   size: z.enum(['default', 'sm', 'lg', 'icon']).optional(),
   disabled: z.boolean().optional().describe('Whether button is disabled'),
-  onClick: z.function().optional().describe('Click handler'),
+  onClick: handlerKeyRefusal('onClick', 'retired', 'Click handler'),
   className: z.string().optional().describe('Button class name'),
 });
 

--- a/packages/types/src/zod/overlay.zod.ts
+++ b/packages/types/src/zod/overlay.zod.ts
@@ -18,7 +18,7 @@
 
 import { z } from 'zod';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
-import { retirementTombstone } from './tombstone.zod.js';
+import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 
 /**
  * Dialog Schema - Dialog/modal component
@@ -33,7 +33,7 @@ export const DialogSchema = BaseSchema.extend({
   open: z.boolean().optional().describe('Controlled open state'),
   footer: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Dialog footer'),
   modal: z.boolean().optional().describe('Whether dialog is modal'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**
@@ -49,9 +49,9 @@ export const AlertDialogSchema = BaseSchema.extend({
   cancelLabel: z.string().optional().describe('Cancel button label'),
   confirmLabel: z.string().optional().describe('Confirm button label'),
   confirmVariant: z.enum(['default', 'destructive']).optional().describe('Confirm button variant'),
-  onConfirm: z.function().optional().describe('Confirm handler'),
-  onCancel: z.function().optional().describe('Cancel handler'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onConfirm: handlerKeyRefusal('onConfirm', 'retired', 'Confirm handler'),
+  onCancel: handlerKeyRefusal('onCancel', 'retired', 'Cancel handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**
@@ -67,7 +67,7 @@ export const SheetSchema = BaseSchema.extend({
   open: z.boolean().optional().describe('Controlled open state'),
   side: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Sheet position'),
   footer: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional().describe('Sheet footer'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**
@@ -82,7 +82,7 @@ export const DrawerSchema = BaseSchema.extend({
   defaultOpen: z.boolean().optional().describe('Default open state'),
   open: z.boolean().optional().describe('Controlled open state'),
   direction: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Drawer direction'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**
@@ -96,7 +96,7 @@ export const PopoverSchema = BaseSchema.extend({
   open: z.boolean().optional().describe('Controlled open state'),
   side: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Popover side'),
   align: z.enum(['start', 'center', 'end']).optional().describe('Popover alignment'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**
@@ -125,7 +125,7 @@ export const HoverCardSchema = BaseSchema.extend({
     .describe('Alignment against the trigger, read at renderers/overlay/hover-card.tsx:24 — `align={schema.align}` on HoverCardContent, beside the already-declared `side` (objectui#6150)'),
   openDelay: z.number().optional().describe('Delay before opening (ms)'),
   closeDelay: z.number().optional().describe('Delay before closing (ms)'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**
@@ -150,7 +150,7 @@ export const MenuItemSchema: z.ZodType<any> = z.lazy(() =>
       label: z.string().describe('Menu item label'),
       icon: z.string().optional().describe('Menu item icon'),
       disabled: z.boolean().optional().describe('Whether item is disabled'),
-      onClick: z.function().optional().describe('Click handler'),
+      onClick: handlerKeyRefusal('onClick', 'runtime-slot', 'Click handler'),
       shortcut: z.string().optional().describe('Keyboard shortcut'),
       children: z.array(MenuItemSchema).optional().describe('Submenu items'),
       separator: z.literal(false).optional().describe('Not a divider'),
@@ -178,7 +178,7 @@ export const DropdownMenuSchema = BaseSchema.extend({
   open: z.boolean().optional().describe('Controlled open state'),
   side: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Menu side'),
   align: z.enum(['start', 'center', 'end']).optional().describe('Menu alignment'),
-  onOpenChange: z.function().optional().describe('Open change handler'),
+  onOpenChange: handlerKeyRefusal('onOpenChange', 'runtime-slot', 'Open change handler'),
 });
 
 /**

--- a/packages/types/src/zod/tombstone.zod.ts
+++ b/packages/types/src/zod/tombstone.zod.ts
@@ -63,3 +63,60 @@ import { z } from 'zod';
 export function retirementTombstone(guidance: string) {
   return z.never({ error: guidance }).optional().describe(guidance);
 }
+
+/** How a handler key sits on the TypeScript face (objectui#6124, measured per key). */
+export type HandlerKeyDisposition =
+  /** A host-supplied function REACHES a renderer at runtime — the TS twin keeps its function type. */
+  | 'runtime-slot'
+  /** Nothing reads the key — the TS twin is a `?: never` tombstone. */
+  | 'retired';
+
+/**
+ * Declare a NAMED REFUSAL ARM for an `on*` handler key (objectui#6124,
+ * maintainer ruling 2026-08-30: Q2 → A with C).
+ *
+ * The mirrors declared 58 handler keys as `z.function()` — a declaration no
+ * JSON document can satisfy on a JSON-authored vocabulary. Deleting them was
+ * measured and refused: `BaseSchema` is `.passthrough()`, so an undeclared key
+ * is not refused, it is KEPT, and `onClick` rides `SDUI_DOM_PASS_THROUGH_KEYS`
+ * into the DOM listener slot where React throws at click. So the key stays
+ * DECLARED and refuses BY NAME, in the shape #5099 landed for
+ * `FieldConstraintsSchema.pattern.value` (`form.zod.ts`): a `z.custom`
+ * predicate whose message names the key, says why JSON cannot author it, and
+ * points at the spelling that runs — the node-type form PR #6498 established.
+ *
+ * The predicate refuses EVERYTHING, a live function included. The JSON face
+ * has no function value, and the programmatic face reaches renderers through
+ * the TypeScript interface and React props, never through `safeParse`; a
+ * function that parsed green here was only ever the instrument's positive
+ * control. That is the accept-set change objectui#6124's changeset declares.
+ *
+ * Same discipline as {@link retirementTombstone}: ONE string feeds BOTH
+ * author-facing channels — the parse-time issue message and the `.describe()`
+ * metadata — so they cannot drift apart. Deliberately NOT that helper: a
+ * tombstone retires a key from the contract on both faces and reports
+ * `invalid_type`; this arm reports `custom` (the #5099 code) and, for a
+ * `'runtime-slot'` key, the TypeScript twin stays callable. The two are pinned
+ * apart in `../__tests__/handler-keys-json-refusal-6124.test.ts`.
+ *
+ * @param key         the member name, spelled into the message so the issue is
+ *                    addressed even when read without its path
+ * @param disposition what the TypeScript twin does — see {@link HandlerKeyDisposition}
+ * @param label       the human label the site carried before (`'Click handler'`),
+ *                    kept as the message's lead so docs surfaces keep their noun
+ */
+export function handlerKeyRefusal(key: string, disposition: HandlerKeyDisposition, label?: string) {
+  const what =
+    disposition === 'runtime-slot'
+      ? `\`${key}\` is a RUNTIME SLOT for a host-supplied function, not authorable metadata ` +
+        '(objectui#6124): JSON has no function value, and no handler key consumes a declarative ' +
+        'action object. A React host supplies it through the TypeScript interface / props, never ' +
+        'through this validator, which refuses it by name.'
+      : `\`${key}\` is RETIRED (objectui#6124, ADR-0049): JSON has no function value, and no ` +
+        'renderer reads this key, so nothing could ever run it.';
+  const remedy =
+    'Author behaviour as a NODE TYPE instead — e.g. { "type": "toast", ... } or an action:button ' +
+    'node with a declared action, the spelling PR #6498 established.';
+  const guidance = `${label ? `${label} — ` : ''}${what} ${remedy}`;
+  return z.custom<never>(() => false, { error: guidance }).optional().describe(guidance);
+}


### PR DESCRIPTION
Fixes #6124

## What this PR does

The `@object-ui/types` zod mirrors declared **58 `on*` handler keys (26 distinct) across 8 files as `z.function()`** — a declaration no JSON document can satisfy on a JSON-authored vocabulary. A JSON author who wrote `onClick: { "action": "toast" }` was refused with zod's bare `invalid_type … expected function, received object`, which names the key and nothing else.

This PR executes the maintainer ruling of 2026-08-30 (director seat, batch #8, verbatim 「批次 #8 同意」, comment 5469346437 on #6124): **Q1 → A, Q2 → A with C, Q3 → A, Q4 → B.**

- **Q2 → A (zod face, all 58 sites):** every key keeps its declaration and becomes a **named refusal arm** in the #5099 shape (`FieldConstraintsSchema.pattern.value`, `z.custom` + guidance) — `handlerKeyRefusal(key, disposition, label)` in `packages/types/src/zod/tombstone.zod.ts`. The message names the key, says why JSON cannot author it, and points at the node-type spelling PR #6498 established (`{ "type": "toast", ... }` / an `action:button` node with a declared action — Q1's option C). One string feeds both channels: the parse-time issue message and the key's `.describe()` metadata. ⛔ No bare deletion: under `BaseSchema.passthrough()` an undeclared key is KEPT, and `onClick` rides `SDUI_DOM_PASS_THROUGH_KEYS` into the DOM listener slot where React throws at click — the counter-probe in the new pin holds that hazard.
- **The arm refuses a live function too** (the ruling: 「zod JSON 镜像的拒绝臂对函数值一并拒绝」). Stop condition measured and NOT fired: on this tree the only runtime `safeParse` doors into these mirrors are `packages/cli` `check`/`validate` (JSON files) and the exported `validateSchema` / `safeValidateSchema`; `SchemaRenderer` validates through `@object-ui/core`'s structural `validateSchema`, which never reads a handler key. No in-repo path feeds a function-bearing object through these mirrors.
- **Q2's C (TypeScript face), measured per key:** `SchemaRenderer` spreads every non-metadata schema key as a React prop (`...componentProps`, `SchemaRenderer.tsx:1576`), so a function placed on a schema key reaches the renderer. **36 keys** whose value is then read off `schema.*`, called as `props.onX`, or spread onto a Radix root / DOM listener slot **keep their function type** (JSDoc says why). **22 keys** nothing reads carry the **`?: never` tombstone** (ADR-0049; the `crud.ts` `confirm` / `base.ts` convention).
- **Q1 → A / Q3 → A:** no declarative-object arm, no hooks-ref arm. **Q4 → B:** `cell` / `custom` / `validate` / `renderCellEditor` stay `z.function()` (pinned by name). `EventHandlersSchema` (`base.zod.ts:394`) is #6910's, untouched. The three CustomEvent-name keys (`z.string()`, PR #6899) are not in the population.

Clause ②: **yes** — the published validators' accept set moves (a function value that parsed green is now refused). Contract-review tier: this PR stays **draft** and carries `needs:contract-review`.

## Census on the base (`c93b4d5f3`, re-run, not copied)

Anchored `^\s*on[A-Z][A-Za-z]*: z\.function\(` over `packages/types/src/zod/*.ts`: **58 sites, 26 distinct keys, 8 files** (complex 10, data-display 8, disclosure 3, feedback 1, form 20, layout 2, navigation 4, overlay 10). All `key: z.function(` sites: 62 = 58 + the four non-`on*` (`cell`, `custom`, `renderCellEditor`, `validate`). Raw `z.function(` occurrences: 64 = 62 + `EventHandlersSchema` + one mention inside a `describe` string. The card's 28/60 and the ruling's 29/61 are both stale; the close condition is this table.

| Schema (`file`) | Key | TS twin | Runtime consumer measured | Disposition |
|---|---|---|---|---|
| `KanbanSchema` (complex) | `onCardMove`, `onCardClick` | `complex.ts` | `plugin-kanban/index.tsx:193-194` forwards `schema.onCardMove` / `schema.onCardClick` | runtime slot |
| `KanbanSchema` (complex) | `onColumnAdd`, `onCardAdd` | `complex.ts` | renderer takes `({ schema })`, never reads them | retired → `?: never` |
| `CalendarViewSchema` (complex) | `onViewChange` | `complex.ts` | `calendar-view-renderer.tsx:319` `pickHostCallbacks(rest)` (function values only) → `CalendarView` | runtime slot |
| `FilterBuilderSchema` (complex) | `onChange` | `complex.ts` | `filter-builder.tsx:26` calls `props.onChange` | runtime slot |
| `CarouselSchema` (complex) | `onSlideChange` | `complex.ts` | `{...props}` onto a `div`; `CarouselProps` has no such prop | retired |
| `ChatbotSchema` (complex) | `onError`, `onSend` | `complex.ts` | `plugin-chatbot/renderer.tsx:89,94` → `useObjectChat` | runtime slot |
| `ChatbotSchema` (complex) | `onSendMessage` | `complex.ts` | renderer wires its own `handleSendMessage`; `toDomProps` drops the key | retired |
| `AlertSchema` (data-display) | `onDismiss` | `data-display.ts` | `{...props}` spread onto the `Alert` element (no such event) | retired |
| `ListItemSchema` (data-display) | `onClick` | `ListItem` | `list.tsx` renders each item as a plain `li` with its content | retired |
| `DataTableSchema` (data-display) | `onRowEdit`, `onRowDelete`, `onSelectionChange`, `onColumnsReorder` | `data-display.ts` | `data-table.tsx:551,576,1341,1494` call them off `schema.*` | runtime slot |
| `TreeViewSchema` (data-display) | `onSelectChange`, `onExpandChange` | `data-display.ts` | `{...props}` onto a `div`; nodes get only `onNodeClick` | retired |
| `AccordionSchema` / `CollapsibleSchema` / `ToggleGroupSchema` (disclosure) | `onValueChange` / `onOpenChange` / `onValueChange` | `disclosure.ts` | leftover props spread onto the Radix root, where the prop is real | runtime slot |
| `ToastSchema` (feedback) | `onDismiss` | `feedback.ts` | `toast.tsx` takes `({ schema })`, never reads it | retired |
| `ButtonSchema` (form) | `onClick` | `form.ts` | `button.tsx:67` `toFormControlDomProps` forwards it (`onClick` ∈ `SDUI_DOM_PASS_THROUGH_KEYS`) | runtime slot |
| `InputSchema`, `TextareaSchema`, `SelectSchema`, `CheckboxSchema`, `FileUploadSchema`, `DatePickerSchema`, `InputOTPSchema` (form) | `onChange` | `form.ts` | each renderer destructures `onChange` from props and calls it | runtime slot |
| `RadioGroupSchema`, `SwitchSchema`, `ToggleSchema`, `SliderSchema`, `ComboboxSchema` (form) | `onChange` | `form.ts` | only `toFormControlDomProps`'s whitelist is forwarded; no by-name read | retired |
| `CalendarSchema` (form) | `onChange` | `form.ts` | `{...props}` onto `DayPicker`, whose callback is `onSelect` | retired |
| `CommandSchema` (form) | `onChange` | `form.ts` | lands on cmdk's root `div` as a DOM change listener (SyntheticEvent) — not the declared `(value: string) => void` | retired (leak noted) |
| `InputOTPSchema` (form) | `onComplete` | `form.ts` | whitelist drops it | retired |
| `FormSchema` (form) | `onSubmit`, `onChange`, `onCancel` | `form.ts` | `form.tsx:1002-1005` destructures off `schema`; called at `:2008`, `:1869`, `:2096` | runtime slot |
| `CodeEditorSchema` (form) | `onChange` | `form.ts` | `plugin-editor/index.tsx:48` `onChange ?? schema.onChange` | runtime slot |
| `CardSchema` (layout) | `onClick` | `layout.ts` | `card.tsx:35,46` reads `props.onClick`, spreads onto the `Card` element | runtime slot |
| `TabsSchema` (layout) | `onValueChange` | `layout.ts` | `tabs.tsx:45` `{...tabsProps}` after its own `onValueChange` | runtime slot |
| `BreadcrumbItemSchema` (navigation) | `onClick` | `BreadcrumbItem` | `breadcrumb.tsx` renders links; never reads it | retired |
| `SidebarSchema` (navigation) | `onCollapsedChange` | `navigation.ts` | `{...props}` spread onto the `Sidebar` component; no such prop | retired |
| `PaginationSchema` (navigation) | `onPageChange` | `navigation.ts` | `pagination.tsx:32` calls `props.onPageChange` | runtime slot |
| `ButtonGroupButtonSchema` (navigation) | `onClick` | `ButtonGroupButton` | `button-group.tsx` renders each `Button` without a click handler | retired |
| `DialogSchema`, `SheetSchema`, `DrawerSchema`, `PopoverSchema`, `HoverCardSchema`, `DropdownMenuSchema`, `AlertDialogSchema` (overlay) | `onOpenChange` | `overlay.ts` | `{...props}` onto the Radix / vaul root, where `onOpenChange` is real | runtime slot |
| `AlertDialogSchema` (overlay) | `onConfirm`, `onCancel` | `overlay.ts` | footer wired to `schema.onAction` and `AlertDialogCancel`; never read | retired |
| `MenuItemSchema` (overlay) | `onClick` | `MenuCommandItem` | `dropdown-menu.tsx:77`, `context-menu.tsx:75`, `menubar.tsx:53,67` call `item.onClick?.()` | runtime slot |

Totals: **36 runtime slots + 22 retired = 58.**

## Parity ledger (`zod-mirror-parity.test.ts`) — every changed row

The mirror's `z.input` for a refusal arm is `undefined`, so a runtime-slot key (TS keeps the function) is a measured TYPE drift and lands in `KnownDrift`; a retired key (`?: never`) meets `undefined` on both sides and does not drift. 28 pairs, 35 keys (the 36th, `MenuItemSchema.onClick`, is a lazy union in `EXCLUSIONS`). Header counts re-read: **12 → 36 entries, 17 → 52 keys, 146 → 122 pairs with no entry**; a class note above `ButtonSchema` explains the deliberate two-face divergence.

Extended (4): `complex.zod.ts#ChatbotSchema: 'body' | 'onError' | 'onSend'` · `complex.zod.ts#FilterBuilderSchema: 'fields' | 'onChange'` · `data-display.zod.ts#DataTableSchema: 'rowActions' | 'onRowEdit' | 'onRowDelete' | 'onSelectionChange' | 'onColumnsReorder'` · `form.zod.ts#FormSchema: 'fields' | 'mode' | 'onSubmit' | 'onChange' | 'onCancel'`.

New (24): `complex.zod.ts#CalendarViewSchema: 'onViewChange'` · `complex.zod.ts#KanbanSchema: 'onCardMove' | 'onCardClick'` · `disclosure.zod.ts#AccordionSchema: 'onValueChange'` · `disclosure.zod.ts#CollapsibleSchema: 'onOpenChange'` · `disclosure.zod.ts#ToggleGroupSchema: 'onValueChange'` · `form.zod.ts#ButtonSchema: 'onClick'` · `form.zod.ts#CheckboxSchema: 'onChange'` · `form.zod.ts#CodeEditorSchema: 'onChange'` · `form.zod.ts#DatePickerSchema: 'onChange'` · `form.zod.ts#FileUploadSchema: 'onChange'` · `form.zod.ts#InputOTPSchema: 'onChange'` · `form.zod.ts#InputSchema: 'onChange'` · `form.zod.ts#SelectSchema: 'onChange'` · `form.zod.ts#TextareaSchema: 'onChange'` · `layout.zod.ts#CardSchema: 'onClick'` · `layout.zod.ts#TabsSchema: 'onValueChange'` · `navigation.zod.ts#PaginationSchema: 'onPageChange'` · `overlay.zod.ts#AlertDialogSchema: 'onOpenChange'` · `overlay.zod.ts#DialogSchema: 'onOpenChange'` · `overlay.zod.ts#DrawerSchema: 'onOpenChange'` · `overlay.zod.ts#DropdownMenuSchema: 'onOpenChange'` · `overlay.zod.ts#HoverCardSchema: 'onOpenChange'` · `overlay.zod.ts#PopoverSchema: 'onOpenChange'` · `overlay.zod.ts#SheetSchema: 'onOpenChange'`.

## Tests

New pin `packages/types/src/__tests__/handler-keys-json-refusal-6124.test.ts` (240 cases): anchored source census (0 `on*` sites; the 4 non-`on*` sites pinned by name), 58 × {declared on the shape with the #6124 guidance · authored object refused with `code: 'custom'`, path `[key]`, message naming the key, `"type"` and `action:button`, message === describe · live function refused · isolated shape green without the key}, wording split (RUNTIME SLOT vs RETIRED), the passthrough counter-probe (`omit` → green with the object kept), arm ≠ tombstone (`custom` vs `invalid_type`), and type-level pins: 22 × `RetiredIsNever`, 36 × `KeepsFunction`, both helpers shown able to fail. Compiled by `tsconfig.test.json` — `tsc --listFiles` lists the file (544 files).

Three existing tests restated for the accept-set change (verdicts unchanged, messages moved): `component-fixture-declared-keys.test.ts` counter-probe (still RED, now `custom` + named guidance), `menu-item-union.test.ts` (function parses on the TS face only; union arm errors dug), `chatbot-authoring-face-keys.test.ts` (`onSend` refused by name on the mirror).

**Red-first on the unmodified tree** (`c93b4d5f3`, pin file only): vitest `Tests 178 failed | 62 passed (240)` — census found 58 sites; object refused with `invalid_type` not `custom`; functions parsed GREEN; `tsc -p tsconfig.test.json`: 22 × TS2344 on `RetiredIsNever` exactly as predicted.

**Union on the final commit `11fd53500`** (all through `os-verify-lock.sh`, verdict lines quoted): `pnpm --filter @object-ui/types run type-check` (echoed `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`) `type-check-exit=0` · `pnpm exec vitest run packages/types/ examples/schema-catalog/test/component-fixture-declared-keys.test.ts --maxWorkers=2` → `Test Files 88 passed (88) / Tests 1455 passed (1455)` · `pnpm --filter @object-ui/types build` → `✓ dist completeness: 1 package(s) complete (118 emitted files verified)` · downstream `pnpm --filter @object-ui/core run type-check` against the rebuilt dist (core's only workspace dep is `@object-ui/types`) → exit 0.

**Ablation** (after the commit; `trap … EXIT INT TERM`; absolute paths): `ButtonSchema.onClick` reverted to `z.function().optional().describe('Click handler')` — on-disk proof `arm-before=1 mut-before=0 → arm-after=0 mut-after=1`, `git diff --stat` 1/1; no build needed (the pin imports `../zod/form.zod` from SOURCE). Result: `Tests 6 failed | 234 passed (240)` — census (1 site), Button declared/describe, Button object (`invalid_type`), Button function (GREEN), wording, arm-vs-tombstone — exactly the Button rows. Restore: `git checkout HEAD -- ABS_PATH`, `git diff HEAD` empty, `git hash-object` = `git rev-parse HEAD:…` = `23a63abe…`, `git status` clean.

**Gates** (unlocked `check:*`, verdict lines): `check-changeset-presence` `✅ 21 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` · `check-changeset-no-major` `✅ No changeset declares a major bump` · `check:control-bytes` `✅ OK (scanned 6023 tracked text file(s))` · `check:spec-symbols` `✅ spec symbol derivation: 1333 files scanned` · `check:doc-types` `✅ Every documented component type is registered` · `check:vi-mock-inherit` / `check:vi-mock-specifiers` `✅ OK`.

**Lint, narrowed and measured:** `eslint --no-inline-config --format json` over the 22 staged `.ts` files → population from eslint's own json output = 22 files, **0 errors**, 54 warnings; every warning is `@typescript-eslint/no-explicit-any` and each warned file's merge-base blob lints to the identical E/W count (`complex.ts` 0/8, `data-display.ts` 0/30, `form.ts` 0/10, `complex.zod.ts` 0/2, `data-display.zod.ts` 0/1, `navigation.zod.ts` 0/2, `overlay.zod.ts` 0/1) — pre-existing; config invariance: `eslint.config.js` has no `projectService` / `parserOptions.project`, so this diff cannot move an untouched file's verdict. Repo-wide `pnpm lint` left to CI.

**Downstream type-check, narrowed and declared:** the only breaking TS change is the 22 `?: never` members. A read census over `packages/*/src`, `apps/*/src`, `examples`, `scripts` for files naming both an affected interface and its retired key found three, none of which assigns the key on that type (`AppHeader.tsx` builds `BreadcrumbItem[]` segments without `onClick`; `ObjectCalendar.tsx` declares its own local `CalendarSchema`; chatbot `renderer.tsx` intersects `ChatbotSchema` with `onSend`/`onClear`, and `onSendMessage` there is the `Chatbot` component's own prop). `@object-ui/core` was type-checked for real against the rebuilt dist; the full `turbo run type-check --filter='...@object-ui/types'` needs the whole repo built and exceeds the foreground cap on a shared box — CI runs it.

## Changeset

`.changeset/6124-handler-keys-json-refusal.md` — `@object-ui/types: minor` (objectui refuses `major`); states the accept-set change plainly.

## Not in this PR (for the PM)

- Docs that teach retired keys as authorable props: `content/docs/api/schema-reference.md:926-927` (`onColumnAdd`, `onCardAdd`), `content/docs/components/data-display/tree-view.mdx:46-47` (`onSelectChange`, `onExpandChange`), `content/docs/components/form/input-otp.mdx:36` (`onComplete`). Docs are outside the dispatched file surface; listed for triage, not edited.
- `EventHandlersSchema` → #6910. `#6182` stays blocked on this card; its close condition is restated by the PM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_