### PR TITLE
fix(form): a later submit outcome supersedes this form's earlier one

### DIFF
--- a/.changeset/7252-form-outcome-toast-supersede.md
+++ b/.changeset/7252-form-outcome-toast-supersede.md
@@ -1,0 +1,28 @@
+---
+'@object-ui/components': patch
+'@object-ui/console': patch
+---
+
+A form no longer ends on a screen asserting both a failure and a success (objectui#7252).
+
+A refused submit raised an error toast that nothing ever retired, so when the user
+fixed the input and submitted again the confirmation of that second attempt appeared
+*beside* the refusal of the first — a wizard's last step showing "Invalid project
+status transition." and "Your new project is ready…" at the same time.
+
+Every outcome toast a form raises now travels under one stable per-form id, so the
+later outcome supersedes the earlier one instead of stacking beside it:
+
+- `@object-ui/components`' form renderer publishes its three outcome toasts (the
+  field-level rejection, an `onAction` error, and a rejected write) under that id, and
+  retires the previous attempt's toast in the same place it already cleared the
+  previous attempt's in-form banner. This is what fixes the reported wizard flow: the
+  refusal comes from this renderer while the success toast is raised by the host
+  (`WizardForm` / `ObjectForm`), so no single raiser could supersede the other before.
+- the console's own `FormPage` publishes its confirmation and its submit failure under
+  one id, for the same reason.
+
+Toast durations are unchanged — this is about supersession, not lifetime. The
+objectui#4190 arm is deliberately excluded: a refused redirect *destination* still gets
+its own toast, because the write succeeded and that refusal has to stay readable beside
+the confirmation it qualifies.

--- a/apps/console/src/components/FormPage.outcomeToast.test.tsx
+++ b/apps/console/src/components/FormPage.outcomeToast.test.tsx
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7252 — a form never ends on a screen that asserts BOTH outcomes.
+ *
+ * The card was filed against the console's WIZARD path, where the refusal and
+ * the confirmation are raised by two different modules (`@object-ui/components`'
+ * form renderer and `@object-ui/plugin-form`'s `WizardForm`); that end-to-end
+ * flow is pinned in
+ * `packages/plugin-form/src/WizardForm.outcomeToastSupersede.test.tsx`.
+ *
+ * This page carried the SAME defect in a single function. `handleSubmit` clears
+ * the `error` banner at the top of every attempt but published its toast under
+ * sonner's auto-generated id, so nothing here could retire it: a refused submit
+ * left its toast up, and the confirmation of the retry landed beside it. Both
+ * outcomes now travel under one per-form id, so the later one supersedes the
+ * earlier in place.
+ *
+ * ## Why the assertion is a registry rather than a call count
+ *
+ * `toast.error` was called and `toast.success` was called is true both before
+ * and after the fix — it is exactly the reading under which the defect looks
+ * fine. What the card is about is what remains ON SCREEN, so `sonner` is
+ * replaced by a registry modelling the one behaviour the fix relies on: raising
+ * a toast under an id the registry already holds REPLACES that entry.
+ *
+ * ## Reverse verification — predicted, then measured
+ *
+ * Dropping `{ id: outcomeToastId }` from the two submit-outcome toasts turns
+ * the first test RED (two entries on screen: the refusal and the confirmation)
+ * and leaves the second one — which asserts that the redirect refusal is NOT
+ * folded into that id — green, since it never depended on the id at all.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { FormPage } from './FormPage';
+
+type ToastEntry = { type: string; message: string };
+
+const { toastRegistry, fakeToast } = vi.hoisted(() => {
+  const toastRegistry = new Map<string | number, { type: string; message: string }>();
+  let auto = 0;
+  const raise =
+    (type: string) =>
+    (message: unknown, options?: { id?: string | number }) => {
+      // No id is sonner's auto-id — a NEW toast every time, which is precisely
+      // the pre-fix behaviour that let two outcomes share the screen.
+      const id = options?.id ?? `auto:${(auto += 1)}`;
+      toastRegistry.set(id, { type, message: String(message) });
+      return id;
+    };
+  const fakeToast = {
+    success: raise('success'),
+    error: raise('error'),
+    info: raise('info'),
+    warning: raise('warning'),
+    dismiss: (id?: string | number) => {
+      if (id === undefined) toastRegistry.clear();
+      else toastRegistry.delete(id);
+      return id;
+    },
+  };
+  return { toastRegistry, fakeToast };
+});
+
+vi.mock('sonner', () => ({ toast: fakeToast }));
+
+/** What the submitter can actually see, in the order sonner holds it. */
+const onScreen = (): ToastEntry[] => [...toastRegistry.values()];
+
+const publicPayload = (submitBehavior?: unknown) => ({
+  slug: 'contact-us',
+  object: 'showcase_inquiry',
+  label: 'Contact us',
+  form: {
+    type: 'simple',
+    sections: [{ fields: ['title'] }],
+    ...(submitBehavior ? { submitBehavior } : {}),
+  },
+  objectSchema: { name: 'showcase_inquiry', fields: { title: { type: 'text', label: 'Title' } } },
+});
+
+/**
+ * Answers the form resolver, then refuses the first N submits with a 400 the
+ * way the reported flow was refused, and accepts every one after that.
+ */
+function stubFetchRefusingFirst(refusals: number, payload: Record<string, unknown>) {
+  let posts = 0;
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    if (init?.method === 'POST') {
+      posts += 1;
+      if (posts <= refusals) {
+        return {
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          text: async () => 'Invalid project status transition.',
+          json: async () => ({ error: 'Invalid project status transition.' }),
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 201,
+        statusText: 'Created',
+        json: async () => ({ object: 'showcase_inquiry', id: 'inq-1', record: { id: 'inq-1' } }),
+        text: async () => '{}',
+      } as unknown as Response;
+    }
+    if (!String(url).includes('/forms/')) throw new Error(`unstubbed fetch: ${url}`);
+    return {
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => payload,
+      text: async () => JSON.stringify(payload),
+    } as unknown as Response;
+  });
+}
+
+const renderPublic = () =>
+  render(
+    <MemoryRouter initialEntries={['/f/contact-us']}>
+      <Routes>
+        <Route path="/f/:slug" element={<FormPage mode="public" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  toastRegistry.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('FormPage — the later submit outcome supersedes the earlier one', () => {
+  it('leaves only the confirmation after a refused submit is retried and accepted', async () => {
+    vi.stubGlobal('fetch', stubFetchRefusingFirst(1, publicPayload()));
+    renderPublic();
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.type(screen.getByLabelText(/Title/), 'Ship it');
+
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+    await waitFor(() => expect(onScreen()).toHaveLength(1));
+    expect(onScreen()[0].type).toBe('error');
+    expect(onScreen()[0].message).toContain('Invalid project status transition.');
+
+    // The retry the card describes: same form, same page, and it is accepted.
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+    expect(await screen.findByText('Your submission has been received.')).toBeInTheDocument();
+
+    await waitFor(() => expect(onScreen()).toEqual([{ type: 'success', message: 'Submitted' }]));
+  });
+
+  /**
+   * The objectui#4190 arm is NOT a submit outcome: the write succeeded and only
+   * the declared destination is out of contract, so its refusal has to stay
+   * readable BESIDE the confirmation. It therefore keeps its own toast — folding
+   * it into the shared id would silently delete the confirmation of a write that
+   * really happened.
+   */
+  it('keeps a refused redirect destination beside the confirmation it qualifies', async () => {
+    vi.stubGlobal(
+      'fetch',
+      stubFetchRefusingFirst(0, publicPayload({ kind: 'redirect', url: 'https://evil.example/x' })),
+    );
+    renderPublic();
+
+    await screen.findByLabelText(/Title/);
+    await userEvent.click(screen.getByRole('button', { name: /Submit/ }));
+
+    await waitFor(() => expect(onScreen()).toHaveLength(2));
+    expect(onScreen().map((e) => e.type)).toEqual(['success', 'error']);
+  });
+});

--- a/apps/console/src/components/FormPage.tsx
+++ b/apps/console/src/components/FormPage.tsx
@@ -103,7 +103,7 @@
  * sibling of `@object-ui/plugin-form`'s `omitServerResolvedDefaults`.
  */
 
-import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useEffect, useId, useMemo, useState, type FormEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import {
@@ -1578,6 +1578,23 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
   const [loaded, setLoaded] = useState<LoadedForm | null>(null);
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [submitting, setSubmitting] = useState(false);
+  /**
+   * The sonner id this form's submit OUTCOME is published under — one id for
+   * the confirmation and for the refusal, so the later of the two SUPERSEDES
+   * the earlier instead of stacking beside it (objectui#7252).
+   *
+   * The `error` banner above is already cleared at the top of every attempt;
+   * its toast was not, because it went out under sonner's auto-generated id and
+   * nothing here held a handle on it. A refused submit therefore left its toast
+   * on screen, and the success toast of the retry landed next to it — the form
+   * ending on a screen that asserted both outcomes at once.
+   *
+   * ⚠️ The redirect REFUSAL below deliberately does NOT share this id. That one
+   * is not a submit outcome: the write succeeded and only the declared
+   * destination is out of contract, so it has to be readable BESIDE the
+   * confirmation this id carries, exactly as objectui#4190 ruled.
+   */
+  const outcomeToastId = `form-outcome:${useId()}`;
   const [submitted, setSubmitted] = useState(false);
   /**
    * The outcome of a `redirect` submit behaviour: the in-app route to go to
@@ -1681,7 +1698,7 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
         mode === 'public'
           ? await submitPublic(identifier, payload)
           : await submitInternal(loaded.object, payload, editingId);
-      toast.success('Submitted');
+      toast.success('Submitted', { id: outcomeToastId });
       // Behaviour after submit
       switch (behavior.kind) {
         case 'created-record': {
@@ -1766,7 +1783,7 @@ export function FormPage({ mode, recordPath }: FormPageProps) {
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       setError(msg);
-      toast.error(msg);
+      toast.error(msg, { id: outcomeToastId });
     } finally {
       setSubmitting(false);
     }

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -1130,6 +1130,29 @@ ComponentRegistry.register('form',
 
     const [isSubmitting, setIsSubmitting] = React.useState(false);
     const [submitError, setSubmitError] = React.useState<string | null>(null);
+    /**
+     * The sonner id every OUTCOME toast of THIS form is published under.
+     *
+     * The in-form banner (`submitError`) and its toast are raised together at
+     * each of the three points below, but only the banner was ever retired
+     * together: the toast went out under sonner's auto-generated id, so nothing
+     * here held a handle on it and a refused submit's toast outlived the
+     * attempt that raised it. A later SUCCESSFUL submit — whose success toast a
+     * host raises (`WizardForm`, `ObjectForm`), not this renderer — then landed
+     * BESIDE that stale refusal, and the form ended on a screen asserting both
+     * outcomes at once (objectui#7252).
+     *
+     * One stable id closes both halves. Reusing an id sonner already holds
+     * UPDATES that toast rather than stacking a second one, so every outcome
+     * this form reports supersedes the one before it; and the dismissal beside
+     * `setSubmitError(null)` retires it the moment a new attempt starts, so by
+     * the time any host can confirm a success this form's last refusal is gone.
+     *
+     * Scoped to this form instance (`React.useId()`) on purpose: a blanket
+     * `toast.dismiss()` would take unrelated toasts down with it.
+     */
+    const formInstanceId = React.useId();
+    const outcomeToastId = `form-outcome:${formInstanceId}`;
     // Active `fieldTabs` panel. Undefined until something picks one — the
     // effective tab falls back to `defaultFieldTab`, then to the first tab.
     // Which tab of an in-progress form is showing is presentational and dies
@@ -1912,7 +1935,7 @@ ComponentRegistry.register('form',
       const fieldsText =
         labels.slice(0, MAX).join(t('validation.formInvalidJoiner')) +
         (labels.length > MAX ? '…' : '');
-      toast.error(t('validation.formInvalid', { fields: fieldsText }));
+      toast.error(t('validation.formInvalid', { fields: fieldsText }), { id: outcomeToastId });
 
       const errored = new Set(names);
       const firstName =
@@ -1948,6 +1971,10 @@ ComponentRegistry.register('form',
     const handleSubmit = form.handleSubmit(async (data) => {
       setIsSubmitting(true);
       setSubmitError(null);
+      // …and the toast twin of that banner (objectui#7252). Both belong to the
+      // previous attempt and both are stale now; the toast outliving it is what
+      // let an earlier refusal share the screen with the success that followed.
+      toast.dismiss(outcomeToastId);
       // This attempt cleared client validation — drop the previous attempt's
       // tab markers (the server may re-add its own below).
       setRejectedFieldNames([]);
@@ -1999,7 +2026,7 @@ ComponentRegistry.register('form',
             setSubmitError(result.error);
             // Also surface as a toast so the message is visible even when the
             // in-form banner has scrolled out of view (long forms in modals/drawers).
-            toast.error(result.error);
+            toast.error(result.error, { id: outcomeToastId });
             return;
           }
         }
@@ -2069,7 +2096,7 @@ ComponentRegistry.register('form',
         setSubmitError(errorMessage);
         // Also surface as a toast so the message is visible even when the
         // in-form banner has scrolled out of view (long forms in modals/drawers).
-        toast.error(errorMessage);
+        toast.error(errorMessage, { id: outcomeToastId });
 
         // Log errors for debugging (dev environment only)
         // process may not be defined in all environments

--- a/packages/plugin-form/src/WizardForm.outcomeToastSupersede.test.tsx
+++ b/packages/plugin-form/src/WizardForm.outcomeToastSupersede.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * A form never ends on a screen that asserts BOTH outcomes (objectui#7252).
+ *
+ * ## The reported flow, and where the two toasts actually come from
+ *
+ * Showcase -> Workspace -> New Project (wizard): the last step's Create was
+ * refused (400 `VALIDATION_FAILED`, "Invalid project status transition."), the
+ * user went back a step, changed the status, hit Create again and got a 201 —
+ * and the refusal was STILL on screen beside the success.
+ *
+ * The two toasts are raised by two different modules, which is why neither
+ * could supersede the other on its own:
+ *
+ *  - the REFUSAL comes from the step form renderer, `@object-ui/components`'s
+ *    `renderers/form/form.tsx`. `WizardForm` hands it `onSubmit:
+ *    handleStepSubmit`; that handler rethrows a rejected write after calling
+ *    `schema.onError`, so the rejection surfaces in the renderer's own catch,
+ *    which sets the in-form banner AND toasts;
+ *  - the SUCCESS comes from `WizardForm` itself (`toast.success(successMessage
+ *    || 'Created')`).
+ *
+ * ## What was actually measured, not assumed
+ *
+ * The refusal toast is NOT sticky by configuration. `ConsoleToaster` sets
+ * `toastOptions.duration: 4000` for every severity, `@object-ui/components`'
+ * own `Toaster` sets none (sonner's default `TOAST_LIFETIME` is also 4000), and
+ * `duration: Infinity` appears nowhere on any form path in this repo. So the
+ * durations are left exactly as they are here: the defect this file pins is
+ * SUPERSESSION, and it is reproducible inside any lifetime — the two toasts are
+ * simply unrelated, so nothing retires the first when the second arrives.
+ *
+ * ## Why the pin models sonner rather than counting calls
+ *
+ * Asserting `toast.error` was called and `toast.success` was called says
+ * nothing about what is on SCREEN — that is exactly the reading under which the
+ * defect looks fine. So the module is replaced by a registry modelling the one
+ * sonner behaviour the fix relies on: a toast raised under an id the registry
+ * already holds REPLACES that entry, and `dismiss(id)` removes exactly that
+ * one. The assertion is then the card's own sentence — what remains on screen.
+ *
+ * ⚠️ The mock target is `@object-ui/components/ui/sonner`, NOT bare `'sonner'`.
+ * That wrapper is the single module BOTH raisers reach — the renderer imports
+ * it as `../../ui/sonner`, and the `toast` `WizardForm` pulls from
+ * `@object-ui/components` is this module's re-export — and it is the only one
+ * of the two spellings that resolves from here: `plugin-form` does not depend
+ * on `sonner`, so `vi.mock('sonner')` in this package registers against an id
+ * nothing resolves to and intercepts NOTHING (measured: the run went red with
+ * an EMPTY registry while the in-form banner rendered the refusal, i.e. the
+ * real sonner had taken both toasts). A green run here is therefore also the
+ * proof that the mock is in the graph at all.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+
+type ToastEntry = { type: string; message: string };
+
+const { toastRegistry, fakeToast } = vi.hoisted(() => {
+  const toastRegistry = new Map<string | number, { type: string; message: string }>();
+  let auto = 0;
+  const raise =
+    (type: string) =>
+    (message: unknown, options?: { id?: string | number }) => {
+      // No id supplied is sonner's auto-id: a NEW toast every time, which is
+      // precisely the pre-fix behaviour that let two outcomes coexist.
+      const id = options?.id ?? `auto:${(auto += 1)}`;
+      toastRegistry.set(id, { type, message: String(message) });
+      return id;
+    };
+  const fakeToast: any = Object.assign(raise('message'), {
+    success: raise('success'),
+    error: raise('error'),
+    info: raise('info'),
+    warning: raise('warning'),
+    loading: raise('loading'),
+    custom: raise('custom'),
+    promise: (p: unknown) => p,
+    dismiss: (id?: string | number) => {
+      if (id === undefined) toastRegistry.clear();
+      else toastRegistry.delete(id);
+      return id;
+    },
+  });
+  return { toastRegistry, fakeToast };
+});
+
+vi.mock('@object-ui/components/ui/sonner', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, toast: fakeToast };
+});
+
+import { registerAllFields } from '@object-ui/fields';
+import { WizardForm } from './WizardForm';
+
+registerAllFields();
+
+const REFUSAL = 'Invalid project status transition.';
+const SUCCESS = 'Your new project is ready.';
+
+const objectSchema = {
+  name: 'showcase_project',
+  fields: {
+    name: { type: 'text', label: 'Name' },
+    status: { type: 'text', label: 'Status' },
+  },
+};
+
+/** Refuses the first create the way the server did, accepts the second. */
+const makeDataSource = () => {
+  let creates = 0;
+  return {
+    getObjectSchema: vi.fn().mockResolvedValue(objectSchema),
+    create: vi.fn(async (_object: string, data: Record<string, unknown>) => {
+      creates += 1;
+      if (creates === 1) {
+        throw Object.assign(new Error(REFUSAL), { status: 400, code: 'VALIDATION_FAILED' });
+      }
+      return { id: 'proj-1', ...data };
+    }),
+    update: vi.fn(),
+    findOne: vi.fn(),
+  };
+};
+
+const wizard = (dataSource: any) =>
+  render(
+    <WizardForm
+      schema={
+        {
+          type: 'object-form',
+          formType: 'wizard',
+          objectName: 'showcase_project',
+          mode: 'create',
+          successMessage: SUCCESS,
+          sections: [
+            { label: 'Basics', fields: ['name'] },
+            { label: 'Status', fields: ['status'] },
+          ],
+        } as any
+      }
+      dataSource={dataSource as any}
+    />,
+  );
+
+const inputNamed = (container: HTMLElement, name: string) =>
+  waitFor(() => {
+    const el = container.querySelector(`input[name="${name}"]`) as HTMLInputElement | null;
+    if (!el) throw new Error(`input ${name} not ready`);
+    return el;
+  });
+
+const submitStep = (container: HTMLElement) =>
+  fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+/** What the user can actually see, in the order sonner holds it. */
+const onScreen = (): ToastEntry[] => [...toastRegistry.values()];
+
+beforeEach(() => {
+  toastRegistry.clear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('WizardForm — a later outcome supersedes this form’s earlier one', () => {
+  it('leaves only the success toast after a refused submit is retried and accepted', async () => {
+    const ds = makeDataSource();
+    const { container } = wizard(ds);
+
+    // Step 1 -> Step 2.
+    fireEvent.change(await inputNamed(container, 'name'), { target: { value: 'Apollo' } });
+    submitStep(container);
+
+    // Step 2: Create, refused.
+    fireEvent.change(await inputNamed(container, 'status'), { target: { value: 'archived' } });
+    submitStep(container);
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onScreen()).toEqual([{ type: 'error', message: REFUSAL }]));
+
+    // Back to step 2 of the reported flow, change the status, and Create again.
+    // The navigation matters: it is what proves the id survives step changes —
+    // the renderer instance is reused across steps, so the attempt that
+    // succeeds is the one that must retire the refusal.
+    fireEvent.click(screen.getByRole('button', { name: /Back/i }));
+    await inputNamed(container, 'name');
+    submitStep(container);
+    fireEvent.change(await inputNamed(container, 'status'), { target: { value: 'active' } });
+    submitStep(container);
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(2));
+
+    // The card's own sentence: one form, one outcome on screen.
+    await waitFor(() => expect(onScreen()).toEqual([{ type: 'success', message: SUCCESS }]));
+  });
+
+  it('does not stack a second refusal when the retry is refused too', async () => {
+    const ds = makeDataSource();
+    // Refuse every attempt this time.
+    ds.create = vi.fn(async () => {
+      throw Object.assign(new Error(REFUSAL), { status: 400, code: 'VALIDATION_FAILED' });
+    });
+    const { container } = wizard(ds);
+
+    fireEvent.change(await inputNamed(container, 'name'), { target: { value: 'Apollo' } });
+    submitStep(container);
+    fireEvent.change(await inputNamed(container, 'status'), { target: { value: 'archived' } });
+
+    submitStep(container);
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onScreen()).toHaveLength(1));
+
+    submitStep(container);
+    await waitFor(() => expect(ds.create).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(onScreen()).toEqual([{ type: 'error', message: REFUSAL }]));
+  });
+});


### PR DESCRIPTION
Fixes #7252

A refused submit raised an error toast that nothing ever retired, so the confirmation of a later, successful submit of the *same* form appeared beside the refusal of the earlier one. Every outcome toast a form raises now travels under one stable per-form id, so the later outcome supersedes the earlier one instead of stacking beside it.

## Where the two toasts actually come from

The card's premise named `apps/console/src/components/FormPage.tsx` as the source of both toasts. That is **not** the reported flow, and reading the whole submit path is what showed it:

- `FormPage` renders a **flat** form — its own sections and its own bare form element, no step machinery — and its success toast is the literal `toast.success('Submitted')`. It is the `/f/:slug` public-form and internal-form route, not the wizard the card describes (whose success toast read "Your new project is ready…", i.e. an authored `successMessage`).
- The reported wizard runs `ObjectForm` → `WizardForm` (`packages/plugin-form/src/WizardForm.tsx`). `WizardForm` renders each step through the SDUI `form` renderer in `@object-ui/components` and hands it `onSubmit: handleStepSubmit`. That handler calls `schema.onError` and **rethrows** a rejected write, so the rejection surfaces in the *renderer's* catch — which sets the in-form banner **and** toasts (`packages/components/src/renderers/form/form.tsx`). The success toast is `WizardForm`'s own.

So the refusal and the confirmation are raised by two different modules, which is exactly why neither could supersede the other on its own, and why the fix lands in the renderer rather than in `WizardForm`.

## What was measured rather than assumed

**The refusal toast is not sticky by configuration.** `ConsoleToaster` sets `toastOptions.duration: 4000` for every severity, `@object-ui/components`' own `Toaster` sets none (sonner 2.0.8's `TOAST_LIFETIME` is also 4000), and `duration: Infinity` appears nowhere on any form path in this repo — the only match in the tree is a test fixture in `app-shell`. Durations are therefore left exactly as they are: the defect is **supersession**, and it reproduces inside any lifetime, because the two toasts are simply unrelated.

## The change

- `packages/components/src/renderers/form/form.tsx` — one stable per-form id (`React.useId()`, scoped to this form instance so nothing takes unrelated toasts down with it). All three of this renderer's outcome toasts publish under it (the field-level rejection, an `onAction` error, a rejected write), and the previous attempt's toast is retired in the same place the previous attempt's in-form banner was already cleared. By the time a host can confirm a success, this form's last refusal is gone.
- `apps/console/src/components/FormPage.tsx` — **a bounded in-place fix of the same defect class**, in the file the claim named. `handleSubmit` there already cleared its `error` banner at the top of every attempt but published its toast under sonner's auto-generated id, so a refused submit's toast survived into the confirmation of the retry — the card's Expected, violated in a single function. Its confirmation and its submit failure now share one id. Evidence that this is the same class and not a drive-by: the two toasts sit 85 lines apart in one handler whose first statements are `setSubmitting(true); setError(null);`, i.e. the identical banner-cleared/toast-not asymmetry. Scan boundary: every other `toast.error` call site in the repo was read; the only other member of this class found is `MasterDetailForm.tsx` (a separate renderer with its own submit path), reported to the PM rather than fixed here.

**Deliberately excluded:** the refused redirect *destination* (objectui#4190) keeps its own toast. The write succeeded there and only the declared destination is out of contract, so that refusal has to stay readable beside the confirmation it qualifies — folding it into the shared id would silently delete the confirmation of a write that really happened. The second FormPage test pins that.

Out of scope by the card's own text and untouched here: the state-machine refusal and its localisation (objectstack-ai/objectstack#14311 remains open), and deriving a create form's allowed initial values from `stateMachine`.

## Does this need a rebase? Checked, not assumed — no

`origin/main` moved from this branch's fork point `ebc05b4d6` to `2956d7af8` (11 commits) while the work was in flight. **Neither file this PR edits moved.** `git diff --name-only ebc05b4d6..origin/main` restricted to `packages/components/src`, `packages/plugin-form/src` and `apps/console/src` returns exactly four files, none of them mine:

```
apps/console/src/components/MetadataHmrReloader.tsx
apps/console/src/components/MetadataHmrReloader.test.tsx
packages/components/src/__tests__/page-header-title-width.test.tsx
packages/components/src/renderers/layout/containers.tsx
```

`packages/plugin-form/src` is untouched on main across that range, and `git merge-tree` against the current `origin/main` reports zero conflict markers. Deliberately **not** rebased or merged here — the merge queue rebuilds.

## Tests

Both pins assert **what remains on screen**, not call counts — `toast.error` was called *and* `toast.success` was called is true before and after the fix, which is precisely the reading under which the defect looks fine. Each replaces the toast module with a registry modelling the one sonner behaviour the fix relies on: raising a toast under an id the registry already holds replaces that entry, and `dismiss(id)` removes exactly that one.

- `packages/plugin-form/src/WizardForm.outcomeToastSupersede.test.tsx` — the card's flow end to end: last step Create refused with a 400, **Back a step**, forward, Create accepted; the assertion is that only the success toast remains. The navigation is load-bearing — it is what proves the renderer instance (and therefore the id) survives a step change. Plus: two consecutive refusals leave one toast, not two.
- `apps/console/src/components/FormPage.outcomeToast.test.tsx` — refuse-then-accept on the public form path, and the guard that a refused redirect destination still shows beside the confirmation.

Run at `dbed63dd3`:

```
pnpm exec vitest run packages/plugin-form/           -> Test Files 82 passed (82) | Tests 823 passed | 8 skipped (831)
pnpm exec vitest run packages/components/src/renderers/form/  -> Test Files 57 passed (57) | Tests 386 passed (386)
pnpm exec vitest run apps/console/src/               -> Test Files 86 passed (86) | Tests 950 passed (950)
pnpm --filter @object-ui/components --filter @object-ui/console --filter @object-ui/plugin-form run type-check  -> exit 0
```

`type-check` covers the new tests, not just the sources: `tsc --listFilesOnly` on `packages/plugin-form/tsconfig.test.json` and on `apps/console/tsconfig.json` each resolve the new file (1 hit apiece).

Gate union re-run at `dbed63dd3`, each quoted from the gate's own verdict line:

```
check-changeset-presence  OK  4 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)
check-changeset-no-major  OK  No changeset declares a `major` bump.
check-changeset-fixed     OK  All workspace packages are in the changeset fixed group.
check-changeset-overwrite OK  No pre-existing changeset was modified or deleted.
check:control-bytes       OK  check-control-bytes: OK (scanned 6027 tracked text file(s); skipped 85 binary).
check:vi-mock-specifiers  OK  check-vi-mock-specifiers: OK (4143 tracked source file(s) …)
check:vi-mock-inherit     OK  check-vi-mock-inherit: OK (4143 tracked source file(s) …)
check:phantom-deps        OK  Every in-scope import is declared by the package that publishes it.
```

### Ablation (after the commit; both legs proved on disk, both restored by blob hash)

No `dist` is involved: the root `vitest.config.mts` aliases `@object-ui/components` to `packages/components/src` (line 415), so the pins resolve the edited source directly — which the red legs below confirm, since mutating `src` alone turned them red.

- **Leg A**, dropping the id and the dismissal from the renderer: both wizard tests RED, and the failure is literally the card — `expected [ { type: 'error', … }, …(1) ] to deeply equal [ { type: 'success', … } ]`, i.e. two outcomes on screen at once. Mutation proved by grep on the removed text (`id: outcomeToastId` → 0 occurrences, `toast.dismiss(outcomeToastId)` → 0, injected `toast.error(errorMessage);` → 1). Restored with `git checkout HEAD -- ABSOLUTE_PATH`; `git diff HEAD` empty and `git hash-object` back to the HEAD blob `5d01245f79d3418ff41c07d30e9f4eb15476f85b`.
- **Leg B**, dropping the shared id from `FormPage`: the supersession test RED (`expected [ { type: 'error', … }, …(1) ] to deeply equal [ { type: 'success', … } ]`) and the redirect-refusal guard GREEN — the predicted narrow change detector, since that guard never depended on the id. Restored the same way; blob back to `2de9ac81934deafcf6db36de4bc3ad32057c18a0`, `git status` clean.

### Narrowed lint, declared

Repo-wide `eslint .` is CI's run. Locally this was narrowed to the four changed `.ts`/`.tsx` files: `0 errors, 98 warnings`, every warning a pre-existing pattern in these files (`@typescript-eslint/no-explicit-any`, `react-refresh/only-export-components`, one pre-existing unused type import) and no package here sets `--max-warnings`. The narrowing is safe to read as a measurement because (1) the linted population is `**/*.{ts,tsx}` minus `**/dist`, `**/.next`, `**/node_modules`, `**/public`, `**/.source`, read from `eslint.config.js` itself rather than guessed; (2) the file count is `4`, read from `--format json`; (3) `eslint.config.js` configures **no** type-aware linting — no `parserOptions.project` and no `projectService` — so every rule is single-file and this diff cannot move the verdict of any file it did not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho