### PR TITLE
fix(plugin-grid): a null entry in `grouping.fields[]` no longer crashes the grid

### DIFF
--- a/.changeset/7217-grouping-null-entry-guard.md
+++ b/.changeset/7217-grouping-null-entry-guard.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/plugin-grid': patch
+---
+
+Grid: a malformed entry in `grouping.fields[]` no longer crashes the whole grid.
+
+A `null` (or `undefined`) hole in the array was dereferenced with no guard at
+two places — `ObjectGrid`'s `groupValueFormatter` memo and `useGroupedData`'s
+`buildLevel` — throwing `TypeError: Cannot read properties of null (reading
+'field')` during render, before any projection was built. Both sites now read
+one normalized entry list, admitting exactly the entries `collectGroupingFieldRefs`
+harvests into the query projection, so the usable grouping levels still group
+and an unusable entry is simply dropped rather than taking the view down.

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -40,7 +40,7 @@ import { resolveConditionalFormatting, buildExpandFields, buildExportFileName, c
 import { usePermissions } from '@object-ui/permissions';
 import { ChevronRight, ChevronDown, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
-import { useGroupedData } from './useGroupedData';
+import { useGroupedData, usableGroupingFields } from './useGroupedData';
 import { GroupRow } from './GroupRow';
 import { useColumnSummary } from './useColumnSummary';
 import { resolveRowCrudAffordances, resolveRowRecordCrudAffordance } from './rowCrudAffordances';
@@ -2034,14 +2034,21 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // readable label for select/boolean fields rather than the raw value
   // (e.g. "In Progress" instead of "in_progress", "Yes" instead of "true").
   const groupValueFormatter = React.useMemo(() => {
-    const grouping = schema.grouping;
-    if (!grouping?.fields?.length) return undefined;
+    // [objectui#7217] ONE normalized entry list, shared with the
+    // `useGroupedData` call below. Reading `grouping.fields` raw here threw
+    // `TypeError: Cannot read properties of null (reading 'field')` on a null
+    // hole — the whole grid gone, during render, before any projection was
+    // built. `usableGroupingFields` admits exactly the entries
+    // `collectGroupingFieldRefs` harvests into the projection, so the grid can
+    // never group by an entry the query never asked for.
+    const groupingFields = usableGroupingFields(schema.grouping?.fields);
+    if (!groupingFields.length) return undefined;
 
     // Per-field { value -> label } lookup, plus a per-field type so we can
     // handle booleans / dates / users without dedicated option lists.
     const lookup = new Map<string, { type?: string; options?: Map<string, string> }>();
 
-    for (const gf of grouping.fields) {
+    for (const gf of groupingFields) {
       const fieldName = gf.field;
       const objectDefField = objectSchema?.fields?.[fieldName];
       // Try to find a column override matching this field for type/options

--- a/packages/plugin-grid/src/__tests__/groupingNullEntry-7217.test.tsx
+++ b/packages/plugin-grid/src/__tests__/groupingNullEntry-7217.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7217 — a `null` entry in `grouping.fields[]` must not take the grid
+ * down.
+ *
+ * ## The defect
+ *
+ * `ObjectGrid`'s `groupValueFormatter` memo walked `grouping.fields` and read
+ * `gf.field` off every entry with no guard, so a single `null` hole threw
+ * `TypeError: Cannot read properties of null (reading 'field')` during render
+ * — the whole grid, gone, before any projection was built.
+ *
+ * `useGroupedData` is a SECOND dereference site of the same list (`const f =
+ * fields[depth]` then `f.field` / `f.order` / `f.collapsed`), so guarding the
+ * memo alone only moves the crash one call downstream. Both sites now read one
+ * normalized entry list — `usableGroupingFields` — and this file pins both:
+ * ablating either guard on its own turns these tests red.
+ *
+ * ## Why a guard, not a schema change (the reachability measurement)
+ *
+ * Author-time validation ALREADY refuses a null entry — `GroupingConfigSchema`
+ * types `fields` as an array of `$strict` objects, so `{ fields: [null] }`
+ * fails with `invalid_type` at `fields.0`, and objectui's own `ListViewSchema`
+ * inherits that by reference. The last two `it`s below measure exactly that,
+ * so the claim is checked rather than asserted in prose.
+ *
+ * That makes this a defensive guard rather than a validation gap — but the
+ * crash is still live, because NOTHING ON THE RENDER PATH RUNS THAT VALIDATOR.
+ * `ObjectGrid` reads `schema.grouping` straight off its props; `@object-ui/core`'s
+ * `validateSchema` is structural and never looks at the `grouping` key. A
+ * runtime-composed or generated schema therefore reaches the memo unparsed,
+ * which is the reachable path this pin closes.
+ *
+ * ## Test-source note
+ *
+ * The root vitest config aliases `@object-ui/*` to each package's `src`, and
+ * this file imports `../ObjectGrid` relatively, so no build step stands
+ * between the edit and the run — the ablation recorded in the PR body reads
+ * source directly.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { ObjectGrid } from '../ObjectGrid';
+import { registerAllFields } from '@object-ui/fields';
+import { ActionProvider } from '@object-ui/react';
+import { GroupingConfigSchema } from '@objectstack/spec/ui';
+import { ListViewSchema } from '@object-ui/types/zod';
+
+registerAllFields();
+
+const ROWS = [
+  { id: '1', name: 'Row 1', active: true },
+  { id: '2', name: 'Row 2', active: false },
+  { id: '3', name: 'Row 3', active: true },
+];
+
+/**
+ * Mount a grid whose `grouping.fields` is exactly `fields`.
+ *
+ * `data.provider: 'value'` keeps the rows inline, so `useGroupedData` runs over
+ * a NON-EMPTY array: the hook's dereference is only reached once there is a row
+ * to bucket, and a pin mounted on empty data would leave that half unmeasured.
+ */
+function renderGrid(fields: unknown[]) {
+  const schema: any = {
+    type: 'object-grid',
+    objectName: 'test_object',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'active', label: 'Active', type: 'boolean' },
+    ],
+    data: { provider: 'value', items: ROWS },
+    grouping: { fields },
+  };
+  return render(
+    <ActionProvider>
+      <ObjectGrid schema={schema} />
+    </ActionProvider>,
+  );
+}
+
+const groupLabels = () =>
+  Array.from(document.querySelectorAll('.group-label')).map((el) => el.textContent);
+
+afterEach(() => cleanup());
+
+describe('ObjectGrid — a null `grouping.fields[]` entry never crashes the grid (objectui#7217)', () => {
+  // ── PIN 1: THE DEFECT ───────────────────────────────────────────────────
+  it('renders instead of throwing when the only grouping entry is null', async () => {
+    expect(
+      () => renderGrid([null]),
+      'a null hole in `grouping.fields[]` threw a TypeError out of render and '
+        + 'took the whole grid down before any projection was built',
+    ).not.toThrow();
+    await waitFor(() => expect(document.body.textContent).toContain('Row 1'));
+    expect(document.body.textContent).toContain('Row 2');
+    expect(document.body.textContent).toContain('Row 3');
+  });
+
+  it('renders instead of throwing when the only grouping entry is undefined', async () => {
+    // Same defect class as `null`: a hole a trailing comma or a sparse
+    // generator leaves behind, which no dereference can survive.
+    expect(() => renderGrid([undefined])).not.toThrow();
+    await waitFor(() => expect(document.body.textContent).toContain('Row 1'));
+  });
+
+  // ── PIN 2: THE SURVIVING ENTRY STILL GROUPS ─────────────────────────────
+  // The guard must DROP the unusable entry, not abandon grouping altogether —
+  // otherwise a single hole silently degrades a working grouped view into a
+  // flat one, which is the objectui#7179 class of silent wrong answer.
+  it('still groups by the usable entry when a null precedes it', async () => {
+    expect(() => renderGrid([null, { field: 'active' }])).not.toThrow();
+    await waitFor(() => expect(groupLabels().length).toBeGreaterThan(0));
+    expect(groupLabels()).toEqual(expect.arrayContaining(['Yes', 'No']));
+  });
+
+  it('still groups by the usable entry when a null follows it at a deeper level', async () => {
+    // The second entry is the NESTED level, so this reaches `buildLevel`'s
+    // recursion rather than only its depth-0 call.
+    expect(() => renderGrid([{ field: 'active' }, null])).not.toThrow();
+    await waitFor(() => expect(groupLabels().length).toBeGreaterThan(0));
+    expect(groupLabels()).toEqual(expect.arrayContaining(['Yes', 'No']));
+  });
+
+  // ── PIN 3: REACHABILITY — the validator refuses it, the render path never runs one ──
+  it('author-time validation already refuses a null entry (`@objectstack/spec`)', () => {
+    const refused = GroupingConfigSchema.safeParse({ fields: [null] });
+    expect(refused.success).toBe(false);
+    expect(refused.success === false && refused.error.issues[0]).toMatchObject({
+      code: 'invalid_type',
+      path: ['fields', 0],
+    });
+    // Positive control: the well-formed entry the same schema accepts, so a
+    // schema that refused EVERYTHING could not pass the assertion above.
+    expect(GroupingConfigSchema.safeParse({ fields: [{ field: 'active' }] }).success).toBe(true);
+  });
+
+  it("objectui's own `ListViewSchema` inherits that refusal by reference", () => {
+    const refused = ListViewSchema.safeParse({
+      type: 'list-view',
+      objectName: 'test_object',
+      grouping: { fields: [null] },
+    });
+    expect(refused.success).toBe(false);
+    expect(
+      refused.success === false
+        && refused.error.issues.some((i) => i.path.join('.') === 'grouping.fields.0'),
+      '`grouping` is imported into `ListViewSchema` from the spec by reference, so '
+        + 'the entry-shape refusal must arrive with it',
+    ).toBe(true);
+    // Positive control: the same payload with a well-formed entry is accepted,
+    // so the refusal above is about the null entry and not about the envelope.
+    expect(
+      ListViewSchema.safeParse({
+        type: 'list-view',
+        objectName: 'test_object',
+        grouping: { fields: [{ field: 'active' }] },
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/plugin-grid/src/useGroupedData.ts
+++ b/packages/plugin-grid/src/useGroupedData.ts
@@ -208,6 +208,55 @@ function compareGroups(a: string, b: string, order: 'asc' | 'desc'): number {
 }
 
 /**
+ * One entry of the spec's `grouping.fields[]` — `{ field, order?, collapsed? }`.
+ */
+export type GroupingFieldEntry = NonNullable<GroupingConfig['fields']>[number];
+
+/**
+ * The `grouping.fields[]` entries a grid can actually group by (objectui#7217).
+ *
+ * ## Why this exists
+ *
+ * `grouping` is authored JSON and reaches the renderer unparsed — `ObjectGrid`
+ * reads `schema.grouping` straight off its props and `@object-ui/core`'s
+ * `validateSchema` is structural and never looks at the key. A `null` hole in
+ * the array (a trailing comma, a sparse generator, an agent-written block) was
+ * therefore dereferenced twice with no guard: once by `ObjectGrid`'s
+ * `groupValueFormatter` memo and once by this hook's `buildLevel`. Both threw
+ * `TypeError: Cannot read properties of null (reading 'field')` and took the
+ * whole grid down during render.
+ *
+ * ## The admission rule is the harvester's, deliberately
+ *
+ * An entry is usable when it is an object carrying a non-empty string `field`
+ * — exactly the entries `collectGroupingFieldRefs` (`@object-ui/core`) harvests
+ * into the projection. Keeping the two sets equal is the point: an entry the
+ * grid grouped by but the projection ignored would be fetched as `undefined`
+ * on every row and bucket every record into one `(empty)` group, which is the
+ * silent wrong answer objectui#7179 closed. This is a defensive normalizer,
+ * NOT a lenient alias — no off-spec spelling is taught to mean anything here;
+ * unusable entries are dropped, never coerced.
+ *
+ * ## Dropping the entry, not the grouping
+ *
+ * One bad entry must not flatten a working grouped view: the usable entries
+ * still group, at the levels they still occupy.
+ *
+ * @param fields - `grouping.fields` in any authored state.
+ * @returns The usable entries, in order, with their `order` / `collapsed`
+ *   intact — the harvester answers with field NAMES, which is why this cannot
+ *   simply route through it.
+ */
+export function usableGroupingFields(fields: unknown): GroupingFieldEntry[] {
+  if (!Array.isArray(fields)) return [];
+  return fields.filter((entry): entry is GroupingFieldEntry => {
+    if (entry === null || typeof entry !== 'object') return false;
+    const name = (entry as { field?: unknown }).field;
+    return typeof name === 'string' && name.trim() !== '';
+  });
+}
+
+/**
  * Hook that groups a flat data array by the fields specified in GroupingConfig.
  *
  * Supports multi-level grouping, per-field sort order, and per-field default
@@ -227,14 +276,19 @@ export function useGroupedData(
   aggregations?: AggregationConfig[],
   formatValue?: GroupValueFormatter,
 ): UseGroupedDataResult {
-  const fields = config?.fields;
-  const isGrouped = !!(fields && fields.length > 0);
+  // [objectui#7217] The SAME normalized list `ObjectGrid`'s formatter memo
+  // reads. Memoized on the raw array rather than on `config`: hosts rebuild
+  // the `{ grouping }` object literal every render, so keying on `config`
+  // would hand `groups` a fresh array identity on every render.
+  const rawFields = config?.fields;
+  const fields = useMemo(() => usableGroupingFields(rawFields), [rawFields]);
+  const isGrouped = fields.length > 0;
 
   // Track which group keys have been explicitly toggled by the user.
   const [toggledKeys, setToggledKeys] = useState<Record<string, boolean>>({});
 
   const groups: GroupEntry[] = useMemo(() => {
-    if (!isGrouped || !fields) return [];
+    if (!isGrouped) return [];
 
     /**
      * Recursively build a tree of groups for the slice of rows at the current
@@ -308,7 +362,7 @@ export function useGroupedData(
       const lastSegment = key.split('__').pop() || '';
       const depthMatch = /^(\d+):/.exec(lastSegment);
       const depth = depthMatch ? Number(depthMatch[1]) : 0;
-      const fieldDefault = !!fields?.[depth]?.collapsed;
+      const fieldDefault = !!fields[depth]?.collapsed;
       return {
         ...prev,
         [key]: prev[key] !== undefined ? !prev[key] : !fieldDefault,

--- a/packages/plugin-grid/src/useGroupedData.ts
+++ b/packages/plugin-grid/src/useGroupedData.ts
@@ -208,9 +208,18 @@ function compareGroups(a: string, b: string, order: 'asc' | 'desc'): number {
 }
 
 /**
- * One entry of the spec's `grouping.fields[]` — `{ field, order?, collapsed? }`.
+ * One entry of the spec's `grouping.fields[]` as AUTHORED — `field` plus the
+ * optional `order` / `collapsed`.
+ *
+ * ⚠️ NOT the same type as `@object-ui/components`' `GroupingFieldEntry`, which
+ * is the grouping EDITOR's fully-populated value shape and requires `order`
+ * and `collapsed`. This one is `z.input` of the spec schema, where both carry
+ * defaults and are therefore optional, so the two are structurally different
+ * and each keeps its own name (objectui#6273 — one authority per exported
+ * name; a shared spelling for two shapes is the collision that gate exists to
+ * catch).
  */
-export type GroupingFieldEntry = NonNullable<GroupingConfig['fields']>[number];
+export type UsableGroupingField = NonNullable<GroupingConfig['fields']>[number];
 
 /**
  * The `grouping.fields[]` entries a grid can actually group by (objectui#7217).
@@ -247,9 +256,9 @@ export type GroupingFieldEntry = NonNullable<GroupingConfig['fields']>[number];
  *   intact — the harvester answers with field NAMES, which is why this cannot
  *   simply route through it.
  */
-export function usableGroupingFields(fields: unknown): GroupingFieldEntry[] {
+export function usableGroupingFields(fields: unknown): UsableGroupingField[] {
   if (!Array.isArray(fields)) return [];
-  return fields.filter((entry): entry is GroupingFieldEntry => {
+  return fields.filter((entry): entry is UsableGroupingField => {
     if (entry === null || typeof entry !== 'object') return false;
     const name = (entry as { field?: unknown }).field;
     return typeof name === 'string' && name.trim() !== '';


### PR DESCRIPTION
Fixes #7217

Branch forked from `origin/main` at `e75f4c986`. Round-1 numbers were measured on `5eb7a8138`; the **Round 2** section at the end records the CI fix and what was re-run on the final commit `410823207`.

## Premise re-verified on the base sha

The card's claim holds, unchanged, at the fork point and on current `origin/main`:

- `packages/plugin-grid/src/ObjectGrid.tsx:2044-2045` — `for (const gf of grouping.fields) { const fieldName = gf.field;` with no guard.
- `packages/plugin-grid/src/useGroupedData.ts:251,257,260,268,278,290` — the SECOND dereference site: `const f = fields[depth]` and then `f.field` / `f.order` / `f.collapsed`.

`origin/main` moved to `2956d7af8` while this ran. `git log e75f4c986..origin/main -- packages/plugin-grid packages/core packages/types` shows PR #7284 and PR #7339 landed there, but both target lines are byte-identical and at the same line numbers on current `origin/main`, so the fork point was kept and the merge queue rebuilds.

## The fix

Both sites now read ONE normalized entry list, `usableGroupingFields`, exported from `useGroupedData.ts`. An entry is usable when it is an object carrying a non-empty string `field`.

That admission rule is deliberately the harvester's — exactly what `collectGroupingFieldRefs` (`packages/core/src/utils/grouping-fields.ts`) contributes to the query projection. Keeping the two sets equal is load-bearing, not tidiness: an entry the grid grouped by but the projection ignored would read `undefined` on every row and bucket every record into one `(empty)` group, which is the silent wrong answer objectui#7179 addressed. This is a defensive normalizer, not a lenient alias — no off-spec spelling is taught to mean anything; unusable entries are dropped, never coerced. And one bad entry drops the entry, not the grouping: the usable levels still group.

Routing the memo through `collectGroupingFieldRefs` itself was measured and rejected — see the table below.

## Reachability measurement (the card's "Measure which before fixing")

| Question | Answer | Evidence |
|---|---|---|
| Does author-time validation reject a null entry? | **YES** | `GroupingConfigSchema` types `fields` as an array of `$strict` objects. `safeParse({ fields: [null] })` fails with `invalid_type` at path `fields.0`. Declared in `@objectstack/spec` (`view.zod` d.ts lines 388-409); reached in this repo as `@objectstack/spec/ui`. |
| Does objectui's own `ListViewSchema` inherit that refusal? | **YES** | `packages/types/src/zod/objectql.zod.ts:427` imports the spec fields by reference via `specFieldsExcept(SpecListViewSchema.shape, LIST_VIEW_LOCAL_OVERRIDES)`, and `grouping` is NOT in `LIST_VIEW_LOCAL_OVERRIDES` (`objectql.zod.ts:310-325`), so the entry shape arrives with it. |
| Does any zod mirror *in this repo* re-declare the entry shape? | **NO** | `git grep -n grouping packages/types/src/zod/` hits only comments (`objectql.zod.ts:382,410`). The shape arrives by reference, never restated. The PM's assumption 4 is therefore half right: nothing is re-declared locally, but a refusing validator does exist. |
| Does the plugin-grid render path run any validator over `schema.grouping`? | **NO** | No `safeParse` / `validateSchema` call anywhere in `packages/plugin-grid/src/**` outside tests. `@object-ui/core`'s `validateSchema` (`packages/core/src/validation/schema-validator.ts:458`) runs base + retired-node-type + form + children only; `packages/core/src/validation/` contains zero occurrences of `grouping` — matching PR #7339's finding for this key too. `ObjectGrid` reads `schema.grouping` straight off its props. |
| Can the grouping toolbar popover write a hole? | **NO** | `GroupingEditor.writeFields` (`packages/components/src/custom/grouping-editor.tsx:76-158`) only ever builds object literals (`{ ...g, field: e.target.value }`, `{ field, order, collapsed }`) and removes with `.filter()`, which cannot leave a hole. `useGroupReorder.ts` reorders rendered GROUP KEYS, never `grouping.fields[]` entries, so it is not a writer at all. |
| Is `collectGroupingFieldRefs` the whole fix? | **NO** | A `GroupingFieldSchema` entry carries `order` and `collapsed` besides `field`. The harvester answers with field NAMES, so routing the memo through it would lose exactly the two properties `useGroupedData` needs for sort order and default-collapsed state. Hence an entry-level normalizer that keeps the entry object. |

⇒ **This is a defensive guard, not a validation gap** — but the crash stays live, because nothing on the render path runs the validator that refuses it. A runtime-composed, generated, or agent-written schema reaches the memo unparsed. Both halves of this measurement are pinned in the new test file rather than left as prose.

### Not in this PR (for the PM)

There is nothing to file on the accept set: author-time validation already refuses a null entry, so no published validator's accept set needs to move and Clause-② stays "no". `packages/types/src/**` is untouched.

The measurement did surface one separate defect, filed as objectui#7347 and deliberately not touched here: a grouping field name with **surrounding whitespace** is accepted by `GroupingFieldSchema` (a bare `z.ZodString`), is **trimmed** by `collectGroupingFieldRefs` on its way into `$select`, but is used **untrimmed** as the bucket key by both grid sites — so every row reads `undefined` and lands in one `(empty)` group. Measured: spec `safeParse` accepts `{ field: "  business_unit  " }`; the harvester yields `["business_unit"]`; the grid buckets by the raw padded key. It is the same silent-wrong-answer class as objectui#7179, and unlike the null entry it survives validation. The guard in this PR admits such an entry (its `field` is a non-empty string), leaving today's behaviour exactly as it is on `main`; normalizing the value as well as the admission set would be a behaviour change beyond this card, on a hot file.

## Test evidence

New pin: `packages/plugin-grid/src/__tests__/groupingNullEntry-7217.test.tsx` (6 tests — 4 crash pins, 2 reachability measurements). The 7179 pin's narrowed malformed-block fixture was left exactly as it is.

RED first, on the unmodified tree:

```
× renders instead of throwing when the only grouping entry is null
× renders instead of throwing when the only grouping entry is undefined
× still groups by the usable entry when a null precedes it
× still groups by the usable entry when a null follows it at a deeper level
AssertionError: expected [Function] to not throw an error but
  "TypeError: Cannot read properties of null (reading 'field')" was thrown
Tests  4 failed | 2 passed (6)
```

The 2 that passed on the unmodified tree are the reachability measurements — they are about the schema, not the guard, and are expected green in both directions.

### Ablation, one site at a time

Each leg: mutate; prove the mutation landed on disk by counting the injected and the removed text (an edit tool's exit code proves nothing); run; restore with `git checkout HEAD --` naming the file by ABSOLUTE path; prove the restore by blob hash against the HEAD blob plus an empty `git diff HEAD`. The script carried `trap restore EXIT INT TERM` throughout.

No build leg applies: the pin imports `../ObjectGrid` relatively and the root vitest config aliases `@object-ui/*` to each package's `src`, so both mutation targets are read from source with no `dist/` in the path.

| Ablation | Mutation proven on disk | Result | Restore proven |
|---|---|---|---|
| A — remove ONLY the `ObjectGrid` memo guard (hook guard stays) | injected `for (const gf of grouping.fields) {` x1, removed `for (const gf of groupingFields) {` x0 | **RED**, exit 1, `Tests 4 failed \| 2 passed (6)`, first error `TypeError: Cannot read properties of null (reading 'field')` | hash `b8053e5e91d98da07cd30525417411b1c57c0d93` == HEAD blob, `git diff HEAD` empty |
| B — remove ONLY the `useGroupedData` guard (memo guard stays) | injected `const fields = config?.fields;` x1, removed the `useMemo(() => usableGroupingFields(rawFields), …)` line x0 | **RED**, exit 1, `Tests 4 failed \| 2 passed (6)`, first error `TypeError: Cannot read properties of null (reading 'field')` | hash `98d98f05bdcf27510ff6d9c9f70229a13630b2f5` == HEAD blob, `git diff HEAD` empty |

Both sites are independently load-bearing: guarding either one alone leaves all four crash pins red.

## Verification table (round 1, on `5eb7a8138`)

Every heavy run went through the shared verification lock (`os-verify-lock.sh`, slot `dev-7217`); the verdict quoted is the line the gate or the lock printed, never a bare `$?`.

| What | Command | Verdict line |
|---|---|---|
| New pin | `pnpm exec vitest run packages/plugin-grid/src/__tests__/groupingNullEntry-7217.test.tsx` | `Test Files 1 passed (1)` / `Tests 6 passed (6)` · `VERDICT command-exit 0` |
| plugin-grid suite | `pnpm exec vitest run packages/plugin-grid/` | `Test Files 110 passed (110)` / `Tests 999 passed (999)` · `VERDICT command-exit 0` |
| plugin-list suite (downstream grouping composer) | `pnpm exec vitest run packages/plugin-list/` | `Test Files 62 passed (62)` / `Tests 787 passed (787)` · `VERDICT command-exit 0` |
| Dependency closure build | `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-grid^...' build` | `VERDICT command-exit 0` |
| Type-check | `pnpm --filter @object-ui/plugin-grid run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0` |
| Lint, whole package (the CI-identical `eslint .`) | `pnpm exec eslint . --format json` in `packages/plugin-grid` | 148 files, **E=0**, W=777 · `VERDICT command-exit 0` |
| Changeset presence | `node scripts/check-changeset-presence.mjs` | `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/7217-grouping-null-entry-guard.md.` |
| Changeset no-major | `node scripts/check-changeset-no-major.mjs` | `✅ No changeset declares a 'major' bump.` |
| Control bytes | `node scripts/check-control-bytes.mjs` | `✅ check-control-bytes: OK (scanned 6037 tracked text file(s); skipped 85 binary).` |
| Phantom deps | `node scripts/check-phantom-dependencies.mjs` | exit 0 — 40 released packages, 3736 source files, 18810 specifiers checked |
| Package self-import | `node scripts/check-package-self-import.mjs` | `✅ No package names itself inside its own src/.` |
| vi.mock specifiers | `node scripts/check-vi-mock-specifiers.mjs` | `✅ check-vi-mock-specifiers: OK` |
| vi.mock inherit | `node scripts/check-vi-mock-inherit.mjs` | `✅ check-vi-mock-inherit: OK` |
| Governed surface | `node scripts/pm/check-governed-merges.mjs --test …` (final file list) | `✅ NOT governed — ordinary queue landing applies to a PR with exactly this file list.` (0 of 4 paths hit the register) |

### Type-check actually covers the new test file

`tsc --noEmit` alone would have said nothing about it. `tsc -p tsconfig.test.json --listFiles | grep -c groupingNullEntry-7217` = **1**, so the new test file is genuinely inside the type-check program rather than excluded and silently unmeasured.

### Lint delta, against the fork-point blobs

Baseline taken by checking the two modified files out at `e75f4c986` into the same paths (so eslint's config resolution is identical), proven landed on disk before measuring (`usableGroupingFields` occurrences = 0), then restored and proven by blob hash:

| File | Base (`e75f4c986`) | Final | Delta |
|---|---|---|---|
| `ObjectGrid.tsx` | E=0 W=213 | E=0 W=213 | 0 / 0 |
| `useGroupedData.ts` | E=0 W=26 | E=0 W=26 | 0 / 0 |
| `groupingNullEntry-7217.test.tsx` | new file | E=0 W=1 | +1 warning |

The one added warning is `@typescript-eslint/no-explicit-any` on `const schema: any = {` — the same idiom every sibling grid test uses (`groupedBooleanLabel.test.tsx`, `groupingProjection-7179.test.tsx`), and deliberate here: the fixture is intentionally off-spec, so a typed shape would refuse the null entry the test exists to feed in.

## Round 2 — the CI gate this missed, and the fix

`Test (shard 4/4)` went red on `5eb7a8138` in `scripts/__tests__/one-authority-per-exported-name-6273.test.ts` (objectui#6273, ruling objectui#6172). Verbatim:

```
GroupingFieldEntry — a NEW colliding name
    packages/components/src/custom/grouping-editor.tsx:14 — interface declaration
    packages/plugin-grid/src/useGroupedData.ts:213 — type declaration
```

Round 1's alias published `GroupingFieldEntry`, a name `@object-ui/components` already owns.

**The two are genuinely different shapes**, so this took the gate's rename branch rather than re-pointing one at the other:

| | `@object-ui/components` `GroupingFieldEntry` | this alias |
|---|---|---|
| What it is | the grouping EDITOR's fully-populated value | the AUTHORED spec entry (`z.input` of `GroupingConfig`) |
| `order` | **required** `'asc' \| 'desc'` | optional (schema default) |
| `collapsed` | **required** `boolean` | optional (schema default) |

Collapsing them would have made one of the two lie, so each keeps its own name. Renamed to **`UsableGroupingField`** — verified free across `packages`, `apps` and `scripts` before choosing — which also says what it is: an entry that passed `usableGroupingFields`. The components interface is untouched and keeps the name it already owned; nothing outside `useGroupedData.ts` referenced the alias. A comment at the declaration records why the two names differ, so the next reader does not "unify" them. `KNOWN_COLLISIONS` was NOT touched — it is shrink-only.

Type-level only, no behaviour change.

Reproduced RED locally first, then green, on the final commit `410823207`:

| What | Verdict line |
|---|---|
| The failing gate, before the rename | `Tests 1 failed \| 10 passed (11)` · `VERDICT command-exit 1` — same `GroupingFieldEntry — a NEW colliding name` message as CI |
| The gate + the pin, after the rename | `Test Files 2 passed (2)` / `Tests 17 passed (17)` · `VERDICT command-exit 0` |
| **The whole `scripts/` meta-gate family** | `Test Files 97 passed (97)` / `Tests 2738 passed (2738)` · `VERDICT command-exit 0` |
| plugin-grid suite | `Test Files 110 passed (110)` / `Tests 999 passed (999)` · `VERDICT command-exit 0` |
| Closure build + type-check | `VERDICT command-exit 0` |
| Lint, `useGroupedData.ts` | E=0 W=26 — unchanged from base · `VERDICT command-exit 0` |
| Control bytes | `✅ check-control-bytes: OK (scanned 6037 tracked text file(s); skipped 85 binary).` |

Round 1's local gate derivation was package-scoped — the touched package's suites, type-check and `eslint .`, plus the `check:*` scripts whose subject matter the diff touched. It never asked whether a **repo-wide** gate in `scripts/__tests__/` reads the diff, and this one does: it scans every exported type name in the monorepo, so adding one exported type anywhere can redden it. Round 2 therefore ran all 97 of those files rather than only the one that failed, which is the derivation round 1 should have made.

## Hot-file constraint (PR #7284)

Honoured. `git diff -U0` on `ObjectGrid.tsx` reports exactly three hunk headers: `@@ -43 +43 @@`, `@@ -2037,2 +2037,9 @@` and `@@ -2044 +2051 @@` — the import line 43 plus the grouping memo region. Line 39 (the `@object-ui/core` import) and the `fieldsToShow` default-column synthesis at roughly 2788-2810 are untouched — no new `@object-ui/core` export was needed, because `usableGroupingFields` lives in `plugin-grid`'s own `useGroupedData.ts` and rides the existing line-43 `./useGroupedData` import. Round 2 touched only `useGroupedData.ts`.

`packages/core/src/utils/grouping-fields.ts` was READ as the route candidate and deliberately not edited: the harvester is already correct, and its name-only return is why it cannot be the whole fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho