### PR TITLE
test(core,data-objectstack): measure the two filter dialects one authored view filter reaches the wire in

### DIFF
--- a/.changeset/7221-filter-dialect-equivalence.md
+++ b/.changeset/7221-filter-dialect-equivalence.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: pin the measured behaviour of the two filter dialects one authored view filter reaches the wire in (objectui#7221). Records the lowering `mergeFilterNodes` produces, the row sets each dialect selects through `ValueDataSource`, and the wire strings and server-side reading of each through the ObjectStack adapter. No published behaviour changes.

--- a/packages/core/src/utils/__tests__/filter-dialect-equivalence-7221.test.ts
+++ b/packages/core/src/utils/__tests__/filter-dialect-equivalence-7221.test.ts
@@ -1,0 +1,275 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One authored view filter, two lowered dialects — do they select the same rows?
+ * The MEASUREMENT objectui#7221 asked for, recorded so the answer cannot drift.
+ *
+ * objectui#7210 watched one page load of a `type: 'gantt'` list view put two
+ * filters on the wire from one authored filter:
+ *
+ * ```
+ * paged      [["visible_from","is_not_null"],["due_date","is_not_null"]]
+ * unbounded  ["and",["visible_from","isnotnull",null],["due_date","isnotnull",null]]
+ * ```
+ *
+ * objectui#7221 filed the obvious question — nobody had checked that
+ * `['and', A, B]` and `[A, B]` select the same rows through every adapter — and
+ * asked for a measurement rather than a repair. This file is the `ValueDataSource`
+ * half of that measurement; `data-objectstack/src/filter-dialect-wire-7221.test.ts`
+ * is the wire half.
+ *
+ * ## The answer, in one line
+ *
+ * On the card's own filter the two dialects agree — and they agree because
+ * `matchesASTFilter` evaluates NEITHER of them. Change the operator to one the
+ * in-memory matcher implements and they part: the flat dialect applies no filter
+ * at all while the `and`-wrapped one filters correctly. So the equivalence the
+ * card hoped to establish does NOT hold in general, and the case it was observed
+ * on is the accidentally-benign one.
+ *
+ * ## Why the flat dialect is inert here
+ *
+ * `matchesASTFilter` (`../../adapters/ValueDataSource.ts`) recognises exactly two
+ * node shapes: a logical `['and'|'or', ...children]` head, and a THREE-element
+ * comparison `[field, operator, value]`. A legacy flat array of condition nodes —
+ * `[[…], […]]`, the implicit-AND shape `toFilterNode` returns for a lone source —
+ * matches neither, so it reaches the closing `return true` and every row passes.
+ * The same fall-through swallows it as a CHILD of an `and`, which is the shape
+ * `ElementDataSourceGate` produces from two surviving sources.
+ *
+ * Two separate reasons the card's own filter is inert, and both are recorded
+ * below: the flat shape is unread AS A SHAPE, and `is_not_null` / `isnotnull` are
+ * unimplemented AS OPERATORS (the `switch` has no null-ness arm, so its `default`
+ * returns true for the wrapped dialect too).
+ *
+ * ## Reading a red in this file
+ *
+ * - An `it.fails` case going RED means the divergence was repaired — the two
+ *   dialects now agree. That is the good day; delete the `.fails` and keep the
+ *   assertion.
+ * - A plain case going red means the measured behaviour moved. Re-measure before
+ *   changing the expectation: these numbers are the evidence objectui#7221's
+ *   severity was graded on.
+ *
+ * ⛔ No product code is changed by this card. Which dialect wins is a ruling, not
+ * a test's decision.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { toFilterNode, mergeFilterNodes } from '../filter-converter';
+import { ValueDataSource } from '../../adapters/ValueDataSource';
+
+/** The authored view filter of the card, as a spec `ViewFilterRule[]`. */
+const AUTHORED_RULES = [
+  { field: 'visible_from', operator: 'is_not_null' },
+  { field: 'due_date', operator: 'is_not_null' },
+];
+
+/**
+ * Dialect A — the flat, implicit-AND array. What `buildEffectiveFilter` forwards
+ * when the authored filter is the only surviving source, and byte-for-byte the
+ * `paged` filter objectui#7210 saw.
+ */
+const DIALECT_A = [
+  ['visible_from', 'is_not_null'],
+  ['due_date', 'is_not_null'],
+];
+
+/**
+ * Dialect B — the `and`-wrapped, 3-tuple form, byte-for-byte the `unbounded`
+ * filter objectui#7210 saw. Measured provenance (see the wire pin): this is what
+ * `@object-ui/data-objectstack` produces from an UNLOWERED `ViewFilterRule[]`,
+ * not what `mergeFilterNodes` produces — the `null` slot is `entry.value` being
+ * `undefined` and surviving `JSON.stringify` as `null`.
+ */
+const DIALECT_B = [
+  'and',
+  ['visible_from', 'isnotnull', null],
+  ['due_date', 'isnotnull', null],
+];
+
+// ---------------------------------------------------------------------------
+// 1. Lowering — what `mergeFilterNodes` actually produces
+// ---------------------------------------------------------------------------
+
+describe('objectui#7221 — the lowering, measured rather than assumed', () => {
+  it('lowers a ViewFilterRule[] to 2-tuples, inventing no value slot', () => {
+    // The card guessed the rules might become 3-tuples with a `null` value slot.
+    // They do not: `viewFilterRuleToNode` emits a value only when the rule
+    // carries one, and the spec's own canonical spelling `is_not_null` survives.
+    expect(toFilterNode(AUTHORED_RULES)).toEqual(DIALECT_A);
+  });
+
+  it('passes the already-lowered array through unchanged', () => {
+    expect(toFilterNode(DIALECT_A)).toEqual(DIALECT_A);
+  });
+
+  it('returns a lone surviving source as-is, so one source reaches the wire FLAT', () => {
+    expect(mergeFilterNodes(AUTHORED_RULES)).toEqual(DIALECT_A);
+    expect(mergeFilterNodes(undefined, AUTHORED_RULES)).toEqual(DIALECT_A);
+    expect(mergeFilterNodes(DIALECT_A, undefined)).toEqual(DIALECT_A);
+  });
+
+  it('wraps the authored array WHOLE as one child — one source, not one per rule', () => {
+    // This is the shape `ElementDataSourceGate` hands the gantt when both the
+    // element's own filter and the composed view/binding filter survive. The
+    // authored array stays a single nested child; it is NOT spread.
+    expect(mergeFilterNodes(DIALECT_A, ['owner', '=', 'me'])).toEqual([
+      'and',
+      DIALECT_A,
+      ['owner', '=', 'me'],
+    ]);
+  });
+
+  it('never produces dialect B — that spelling is not this function’s', () => {
+    // Two surviving sources or one, the `isnotnull` spelling and the `null` value
+    // slot never appear. The card attributed dialect B to `mergeFilterNodes`;
+    // the measurement puts it at the adapter instead.
+    const twoSources = JSON.stringify(mergeFilterNodes(AUTHORED_RULES, ['owner', '=', 'me']));
+    const oneSource = JSON.stringify(mergeFilterNodes(AUTHORED_RULES));
+    expect(twoSources).not.toContain('isnotnull');
+    expect(oneSource).not.toContain('isnotnull');
+    expect(JSON.stringify(DIALECT_B)).toContain('isnotnull');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Row sets — the card's own filter, every edge value
+// ---------------------------------------------------------------------------
+
+/** One row per edge value, plus a row that carries no keys at all. */
+const EDGE_VALUES: Array<readonly [string, unknown]> = [
+  ['null', null],
+  ['undefined', undefined],
+  ['empty-string', ''],
+  ['zero', 0],
+  ['false', false],
+  ['NaN', NaN],
+  ['array', []],
+  ['object', {}],
+  ['real', '2026-01-01'],
+];
+
+const EDGE_ROWS: Array<Record<string, unknown>> = [
+  ...EDGE_VALUES.map(([id, value]) => ({ id, visible_from: value, due_date: value })),
+  { id: 'missing-key' },
+];
+
+const ALL_EDGE_IDS = EDGE_ROWS.map((r) => r.id as string);
+
+async function selectedIds(
+  filter: unknown,
+  rows: Array<Record<string, unknown>> = EDGE_ROWS,
+): Promise<string[]> {
+  const ds = new ValueDataSource({ items: rows });
+  const result = await ds.find('tasks', { $filter: filter as any });
+  return result.data.map((r) => r.id as string);
+}
+
+describe('objectui#7221 — row sets through ValueDataSource, the card’s filter', () => {
+  it('dialect A selects EVERY row, including the ones the filter exists to exclude', async () => {
+    // The measured behaviour of path A, on its own. A flat array is not a shape
+    // `matchesASTFilter` reads, so nothing is excluded — not the null row, not
+    // the row that has no such key.
+    expect(await selectedIds(DIALECT_A)).toEqual(ALL_EDGE_IDS);
+  });
+
+  it('dialect B selects EVERY row too — for a different reason', async () => {
+    // Path B's shape IS read: `and` recurses, each child is a 3-element
+    // comparison node. It is the OPERATOR that is unimplemented — the `switch`
+    // has no `isnotnull` arm and its `default` returns true.
+    expect(await selectedIds(DIALECT_B)).toEqual(ALL_EDGE_IDS);
+  });
+
+  it('so the two dialects agree here — at "no filter applied", on both sides', async () => {
+    expect(await selectedIds(DIALECT_A)).toEqual(await selectedIds(DIALECT_B));
+  });
+
+  it('the null-ness operators never read their value slot, in any spelling', async () => {
+    // The card asked specifically whether the matcher reads the value slot for
+    // the null-ness operators. It does not — but only because it does not reach
+    // the value at all. Filler, `null`, or an absent slot: same rows.
+    const rows = [
+      { id: 'null-row', visible_from: null },
+      { id: 'real-row', visible_from: '2026-01-01' },
+    ];
+    const both = ['null-row', 'real-row'];
+    expect(await selectedIds(['visible_from', 'isnotnull', null], rows)).toEqual(both);
+    expect(await selectedIds(['visible_from', 'isnotnull', 'FILLER'], rows)).toEqual(both);
+    expect(await selectedIds(['visible_from', 'is_not_null'], rows)).toEqual(both);
+    expect(await selectedIds(['and', ['visible_from', 'isnotnull', null]], rows)).toEqual(both);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Row sets — where the two dialects part
+// ---------------------------------------------------------------------------
+
+/** Three rows and an operator pair `matchesASTFilter` genuinely implements. */
+const CONTROL_ROWS = [
+  { id: 'a', role: 'admin', age: 30 },
+  { id: 'b', role: 'user', age: 25 },
+  { id: 'c', role: 'admin', age: 20 },
+];
+
+/** Dialect A's shape, carrying operators the matcher implements. */
+const CONTROL_A = [
+  ['role', '=', 'admin'],
+  ['age', '>', 24],
+];
+
+/** Dialect B's shape, same two conditions. */
+const CONTROL_B = ['and', ['role', '=', 'admin'], ['age', '>', 24]];
+
+/** The gate's two-source output: an authored array nested inside an `and`. */
+const CONTROL_GATE_TWO_SOURCE = ['and', CONTROL_A, ['id', '!=', 'zzz']];
+
+/** The same three conditions with nothing nested — what the gate would emit if it spread. */
+const CONTROL_GATE_FLATTENED = ['and', ['role', '=', 'admin'], ['age', '>', 24], ['id', '!=', 'zzz']];
+
+describe('objectui#7221 — the dialects on an operator the matcher implements', () => {
+  it('dialect A’s shape applies NO filter — every row comes back', async () => {
+    expect(await selectedIds(CONTROL_A, CONTROL_ROWS)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('a single-rule flat array is inert too — it is the SHAPE, not the count', async () => {
+    expect(await selectedIds([['role', '=', 'admin']], CONTROL_ROWS)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('dialect B’s shape filters correctly — one row of three', async () => {
+    expect(await selectedIds(CONTROL_B, CONTROL_ROWS)).toEqual(['a']);
+  });
+
+  it('the gate’s two-source shape loses its nested authored rules', async () => {
+    // Only the sibling tuple child is evaluated; the nested flat child is
+    // swallowed by the same fall-through.
+    expect(await selectedIds(CONTROL_GATE_TWO_SOURCE, CONTROL_ROWS)).toEqual(['a', 'b', 'c']);
+    expect(await selectedIds(CONTROL_GATE_FLATTENED, CONTROL_ROWS)).toEqual(['a']);
+  });
+
+  it.fails(
+    'the two dialects select the same rows — diverges — objectui#7221',
+    async () => {
+      // GREEN today BECAUSE IT FAILS: dialect A returns a,b,c and dialect B
+      // returns a. Remove the `.fails` the day one lowered form is agreed on and
+      // `matchesASTFilter` reads it.
+      expect(await selectedIds(CONTROL_A, CONTROL_ROWS))
+        .toEqual(await selectedIds(CONTROL_B, CONTROL_ROWS));
+    },
+  );
+
+  it.fails(
+    'nesting an authored array under `and` preserves its rules — diverges — objectui#7221',
+    async () => {
+      // The gate's own output versus the same conditions unnested.
+      expect(await selectedIds(CONTROL_GATE_TWO_SOURCE, CONTROL_ROWS))
+        .toEqual(await selectedIds(CONTROL_GATE_FLATTENED, CONTROL_ROWS));
+    },
+  );
+});

--- a/packages/data-objectstack/src/filter-dialect-wire-7221.test.ts
+++ b/packages/data-objectstack/src/filter-dialect-wire-7221.test.ts
@@ -1,0 +1,166 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * One authored view filter, two lowered dialects — the WIRE half of the
+ * objectui#7221 measurement. (`@object-ui/core`'s
+ * `filter-dialect-equivalence-7221.test.ts` is the row-set half.)
+ *
+ * objectui#7210 saw one page load of a `type: 'gantt'` list view put two filters
+ * on the wire from one authored filter. This file reproduces BOTH strings from
+ * named inputs, and then asks the only question that decides the severity: does
+ * the server read them as the same query?
+ *
+ * ## The answer
+ *
+ * Yes. Both are accepted by `isFilterAST` and both lower, through the shipped
+ * `@objectstack/spec` the adapter already depends on, to the identical
+ * `FilterCondition`:
+ *
+ * ```
+ * {"$and":[{"visible_from":{"$null":false}},{"due_date":{"$null":false}}]}
+ * ```
+ *
+ * Two spellings, one meaning — the null-ness direction comes from the operator
+ * NAME on the server (`data/filter.zod.ts`), so the `null` value slot in the
+ * second dialect is filler that is never read, and `is_not_null` / `isnotnull`
+ * are both members of `VALID_AST_OPERATORS` with the same lowering.
+ *
+ * ## Where dialect B actually comes from — measured, not assumed
+ *
+ * objectui#7221 attributed the `and`-wrapped 3-tuple form to `mergeFilterNodes`.
+ * It is not that function's shape (the core pin measures what that produces). It
+ * is THIS package's `objectFilterEntriesToAST`, reached when an UNLOWERED
+ * `ViewFilterRule[]` arrives at the adapter: it emits `[field, op, entry.value]`
+ * always three long, normalizes `is_not_null` to `isnotnull` through
+ * `FILTER_OPERATOR_ALIASES`, and wraps 2+ entries in `and`. The `null` slot is
+ * `entry.value` being `undefined` and surviving `JSON.stringify` as `null`.
+ *
+ * A tuple, by contrast, is passed through untouched — operators in an already-AST
+ * node are never normalized — which is why the lowered path keeps the authored
+ * `is_not_null` spelling all the way to the wire.
+ *
+ * ⛔ No product code is changed by this card; it records what today does.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { isFilterAST, parseFilterAST } from '@objectstack/spec/data';
+import { ObjectStackAdapter } from './index';
+
+function makeAdapter() {
+  const calls: string[] = [];
+  const fetchImpl = vi.fn(async (url: any) => {
+    const u = String(url);
+    calls.push(u);
+    if (u.includes('/api/v1/discovery')) {
+      return {
+        ok: true, status: 200, statusText: 'OK',
+        json: async () => ({ success: true, data: { version: 'v1', routes: {} } }),
+      } as any;
+    }
+    return {
+      ok: true, status: 200, statusText: 'OK',
+      json: async () => ({ success: true, data: { object: 'task', records: [], total: 0 } }),
+    } as any;
+  });
+  const adapter = new ObjectStackAdapter({
+    baseUrl: 'http://localhost:3000', token: 't', autoReconnect: false, fetch: fetchImpl as any,
+  });
+  return { adapter, calls };
+}
+
+/** The raw `filter=` string this `$filter` produced, exactly as it left the client. */
+async function filterOnWire($filter: unknown, route: 'plain' | 'expand' = 'plain'): Promise<string | undefined> {
+  const { adapter, calls } = makeAdapter();
+  await adapter.find('task', {
+    $filter,
+    ...(route === 'expand' ? { $expand: ['owner'] } : {}),
+  } as any);
+  const dataCall = calls.filter((u) => u.includes('/data/task')).pop();
+  const raw = dataCall ? new URL(dataCall).searchParams.get('filter') : null;
+  return raw === null ? undefined : raw;
+}
+
+/** The authored view filter, unlowered — a spec `ViewFilterRule[]`. */
+const AUTHORED_RULES = [
+  { field: 'visible_from', operator: 'is_not_null' },
+  { field: 'due_date', operator: 'is_not_null' },
+];
+
+/** The same filter, lowered by `@object-ui/core` first. */
+const LOWERED_FLAT = [
+  ['visible_from', 'is_not_null'],
+  ['due_date', 'is_not_null'],
+];
+
+/** The two strings objectui#7210 observed, verbatim. */
+const WIRE_A = '[["visible_from","is_not_null"],["due_date","is_not_null"]]';
+const WIRE_B = '["and",["visible_from","isnotnull",null],["due_date","isnotnull",null]]';
+
+describe('objectui#7221 — both observed wire strings, reproduced from named inputs', () => {
+  it('the lowered flat array reaches the wire verbatim — dialect A', async () => {
+    expect(await filterOnWire(LOWERED_FLAT)).toBe(WIRE_A);
+  });
+
+  it('the UNLOWERED rules reach the wire as dialect B — the adapter lowers them', async () => {
+    // Where the `and`, the third slot and the `isnotnull` spelling all come from.
+    expect(await filterOnWire(AUTHORED_RULES)).toBe(WIRE_B);
+  });
+
+  it('dialect B travels unchanged when it is already dialect B', async () => {
+    expect(await filterOnWire(JSON.parse(WIRE_B))).toBe(WIRE_B);
+  });
+
+  it('both routes through find() agree — plain and $expand', async () => {
+    expect(await filterOnWire(LOWERED_FLAT, 'expand')).toBe(WIRE_A);
+    expect(await filterOnWire(AUTHORED_RULES, 'expand')).toBe(WIRE_B);
+  });
+
+  it('the gate’s two-source shape keeps its nested child on the wire', async () => {
+    // `mergeFilterNodes(authored, composed)` output, serialized. The authored
+    // array stays one nested child; the adapter does not flatten it.
+    expect(await filterOnWire(['and', LOWERED_FLAT, ['owner', '=', 'me']]))
+      .toBe('["and",[["visible_from","is_not_null"],["due_date","is_not_null"]],["owner","=","me"]]');
+  });
+});
+
+describe('objectui#7221 — what the server makes of each dialect', () => {
+  /** The one `FilterCondition` both dialects lower to. */
+  const MEANING = {
+    $and: [{ visible_from: { $null: false } }, { due_date: { $null: false } }],
+  };
+
+  it('accepts both dialects — neither is a 400 INVALID_FILTER', () => {
+    expect(isFilterAST(JSON.parse(WIRE_A))).toBe(true);
+    expect(isFilterAST(JSON.parse(WIRE_B))).toBe(true);
+  });
+
+  it('reads both dialects as the SAME query', () => {
+    expect(parseFilterAST(JSON.parse(WIRE_A))).toEqual(MEANING);
+    expect(parseFilterAST(JSON.parse(WIRE_B))).toEqual(MEANING);
+    expect(parseFilterAST(JSON.parse(WIRE_A))).toEqual(parseFilterAST(JSON.parse(WIRE_B)));
+  });
+
+  it('takes the null-ness direction from the operator NAME, never the value slot', () => {
+    // Why the `null` third element is harmless: 2-tuple, 3-tuple with `null`, and
+    // either spelling all mean "this column is not null".
+    const expected = { visible_from: { $null: false } };
+    expect(parseFilterAST(['visible_from', 'isnotnull'])).toEqual(expected);
+    expect(parseFilterAST(['visible_from', 'isnotnull', null])).toEqual(expected);
+    expect(parseFilterAST(['visible_from', 'is_not_null'])).toEqual(expected);
+    expect(parseFilterAST(['visible_from', 'is_not_null', null])).toEqual(expected);
+  });
+
+  it('accepts the gate’s nested shape too, as a nested $and of the same conditions', () => {
+    const gateShape = ['and', LOWERED_FLAT, ['owner', '=', 'me']];
+    expect(isFilterAST(gateShape)).toBe(true);
+    expect(parseFilterAST(gateShape)).toEqual({
+      $and: [MEANING, { owner: 'me' }],
+    });
+  });
+});


### PR DESCRIPTION
Refs #7221

The measurement objectui#7221 asked for, and nothing else. **No product code changes** — not `ListView.tsx`, not `ObjectGantt.tsx`, not `filter-converter.ts`, not `ElementDataSourceGate.tsx`, not the adapter. Which dialect wins is a ruling; this PR only establishes what today does, as two test-only pins so the answer cannot silently drift.

## The answer in one line

**The two dialects are NOT equivalent.** They agree on the card's own filter — and they agree because `ValueDataSource` evaluates neither of them. Swap in an operator its matcher implements and they part: the flat dialect selects every row, the `and`-wrapped one filters. On the wire they are genuinely equivalent: the server reads both as the same query. So the row-set half is a correctness finding, the wire half is tidiness.

## Premise, re-verified on the base commit `2956d7af8`

Holds, with two refinements worth recording because both change the attribution.

1. `ElementDataSourceGate.tsx:224` still runs `mergeFilterNodes(base.filter, composed.filter)` for a mapping declaring `filter: true`, and `plugin-gantt/src/index.tsx:77-78` declares it. Unchanged.
2. **`plugin-list` declares it too** — `ListViewBlock.tsx:31`, `LIST_VIEW_DATA_SOURCE`. So `ListView` sits behind the same gate, and `ListView.tsx:1696` then calls `buildEffectiveFilter`, which is itself `mergeFilterNodes`. The two paths do not differ by "one lowers, one forwards"; they differ by **how many sources survive**, and a lone surviving source comes back unchanged from both.
3. **The `and` + 3-tuple + `isnotnull` dialect is not `mergeFilterNodes`' output.** Measured: it is this repo's own adapter lowering an **unlowered** `ViewFilterRule[]` — `objectFilterEntriesToAST` emits `[field, op, entry.value]` always three long, maps `is_not_null` to `isnotnull`, and wraps two or more entries in `and`. The `null` slot is `entry.value` being `undefined` and surviving `JSON.stringify`. The wire pin reproduces the card's exact string from that input.

## 1. The lowering, quoted

```
toFilterNode(rules)               [["visible_from","is_not_null"],["due_date","is_not_null"]]
mergeFilterNodes(rules)           [["visible_from","is_not_null"],["due_date","is_not_null"]]
mergeFilterNodes(undefined, rules)[["visible_from","is_not_null"],["due_date","is_not_null"]]
mergeFilterNodes(flat, owner=me)  ["and",[["visible_from","is_not_null"],["due_date","is_not_null"]],["owner","=","me"]]
```

Two answers to the open questions the dispatch raised: the authored array is **one source, wrapped whole** (never split per rule), and the rules stay **2-tuples** — no invented `null` value slot, and the spec's canonical `is_not_null` spelling survives. `isnotnull` never appears anywhere in this function's output.

## 2. Row sets through `ValueDataSource`

Ten rows, one per edge value, `visible_from` and `due_date` both set to it; `missing-key` carries no keys at all.

| edge value | dialect A `[[f,"is_not_null"],[g,"is_not_null"]]` | dialect B `["and",[f,"isnotnull",null],...]` |
| --- | --- | --- |
| `null` | selected | selected |
| `undefined` | selected | selected |
| missing key | selected | selected |
| `''` | selected | selected |
| `0` | selected | selected |
| `false` | selected | selected |
| `NaN` | selected | selected |
| `[]` | selected | selected |
| `{}` | selected | selected |
| real date | selected | selected |

Every row, both dialects, including the rows the filter exists to exclude. **They agree at "no filter applied", for two different reasons**, and the pin records each separately:

- Dialect A's **shape** is unread. `matchesASTFilter` recognises an `and`/`or` head or a three-element comparison node; a flat implicit-AND array is neither, so it reaches the closing `return true`.
- Dialect B's **operator** is unimplemented. The shape is read fine, but the `switch` has no null-ness arm and its `default` returns true. The value slot is never reached, so filler, `null` and an absent slot behave identically — the card's specific question about the value slot, answered.

Change the operator to one the matcher does implement and the dialects part (three rows, `role = admin AND age > 24`):

| filter | rows selected |
| --- | --- |
| `[["role","=","admin"],["age",">",24]]` (A's shape) | a, b, c — no filtering |
| `[["role","=","admin"]]` (A's shape, one rule) | a, b, c — no filtering |
| `["and",["role","=","admin"],["age",">",24]]` (B's shape) | a |
| `["and",[[...A...]],["id","!=","zzz"]]` (the gate's two-source output) | a, b, c — the nested child is swallowed too |

Reachable, not theoretical: `resolveDataSource.ts:70` builds a `ValueDataSource` for `provider: 'value'` (inline rows), and `ListView.tsx` sends `$filter: finalFilter` — the flat array — to whatever data source it resolved.

## 3. The wire, and what the server makes of it

Both strings objectui#7210 observed, reproduced from named inputs through `ObjectStackAdapter.find` (both the plain and the `$expand` route):

```
lowered flat array   -> [["visible_from","is_not_null"],["due_date","is_not_null"]]
unlowered rules      -> ["and",["visible_from","isnotnull",null],["due_date","isnotnull",null]]
gate two-source      -> ["and",[["visible_from","is_not_null"],["due_date","is_not_null"]],["owner","=","me"]]
```

Read back through the shipped `@objectstack/spec` 17.2.0 the adapter already depends on:

```
isFilterAST(A) = true          isFilterAST(B) = true
parseFilterAST(A) = {"$and":[{"visible_from":{"$null":false}},{"due_date":{"$null":false}}]}
parseFilterAST(B) = {"$and":[{"visible_from":{"$null":false}},{"due_date":{"$null":false}}]}
```

Identical. The server takes the null-ness direction from the operator NAME, not the value — objectstack `packages/spec/src/data/filter.zod.ts:1911-1922` at `origin/main` `53d3689` — so the `null` slot is filler either way, and both spellings are `VALID_AST_OPERATORS` members with the same lowering (`:1728`, `:1730`). A 2-tuple comparison node is accepted: `isFilterAST` requires `length >= 2`, not 3 (`:1824`). The gate's nested shape is accepted too, as a nested `$and` of the same conditions.

## What this means for severity

- **Wire path (what objectui#7210 actually watched): tidiness.** Two spellings, one meaning, no wrong answer reaches the server. One authored filter should still have one lowered form, but nothing is broken today.
- **In-memory path: correctness.** A flat implicit-AND filter is silently a no-op in `ValueDataSource`, at the top level and nested under an `and`. Both dialects reach that matcher from real authoring paths, and they disagree there for every operator it implements. A ruling on which lowered form is canonical will also decide whether `matchesASTFilter` is the thing that must learn to read the other one.

The two diverging cases are pinned as `it.fails` named "diverges — objectui#7221": green today because they fail, red the day someone makes the dialects agree.

## Tests

All on the final commit `b02bad53d`.

```
pnpm exec vitest run packages/core/ --maxWorkers=2
  Test Files  110 passed (110) · Tests  2169 passed | 2 expected fail (2171)
pnpm exec vitest run packages/data-objectstack/ --maxWorkers=2
  Test Files  54 passed (54) · Tests  733 passed (733)
pnpm --filter @object-ui/core run type-check          exit 0
pnpm --filter @object-ui/data-objectstack run type-check   exit 0
eslint on both new files                              0 errors, 6 warnings (no-explicit-any, matching the sibling harness on main, which has 8)
```

Both new files are proved to be inside their type-check file sets, not merely adjacent to them: `tsc --listFiles` names each exactly once.

Gates derived from the changed paths and run locally, all green: `check-changeset-presence` ("2 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)"), `check-changeset-no-major` ("No changeset declares a major bump"), `check-changeset-fixed`, `check-control-bytes`, `check-vi-mock-specifiers`, `check-vi-mock-inherit`, `check-type-check-coverage` ("41/41 packages compile their tests"), `check-lint-coverage` ("46/46 packages linted"). The changeset carries empty frontmatter — the presence gate's own text calls that a pass for a change that should release nothing.

### Ablation

Test-only pins, so the mutation is of the test INPUT, never of product code. No build step is involved — both files import their subject from source in the same package. Three input mutations, each proved on disk before the run (injected text present, replaced text gone, `git diff --numstat HEAD` non-empty):

1. typo the authored operator spelling — 2 lowering assertions went red;
2. un-wrap `CONTROL_B` so the two dialects coincide — the `it.fails` divergence pin went **red**, which is the behaviour that matters: it detects the fixed state;
3. drop the `null` slot from the expected dialect-B wire string — 2 wire assertions went red.

`6 failed | 17 passed | 1 expected fail`. Restoration is byte-proven, not assumed: `git checkout HEAD --` on both files, then `git hash-object` equals the HEAD blob for each (`56487c133...`, `986a64418...`) and `git diff HEAD` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_