### PR TITLE
fix(types): anchor ObjectGalleryProps / ObjectDataTableProps schema to exported schema types that extend BaseSchema (#6576, #6914)

### DIFF
--- a/.changeset/6576-widget-schema-anchors.md
+++ b/.changeset/6576-widget-schema-anchors.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-list': minor
+'@object-ui/plugin-dashboard': patch
+---
+
+Two widget prop types anchor their `schema` to exported schema types that extend
+`BaseSchema`, instead of hand-rolled inline literals with no `BaseSchema` in
+their ancestry (objectui#6576, maintainer ruling 2026-08-31 option A; folds
+objectui#6914).
+
+- `@object-ui/types` exports `ObjectGallerySchema` (`type: 'object-gallery'`)
+  and `ObjectDataTableSchema` (`type: 'object-data-table'`), each `extends
+  BaseSchema`, beside the other `Object*Schema` declarations, with zod mirrors
+  of the same names under `@object-ui/types/zod`. `ObjectDataTableSchema`
+  declares the two keys the widget was reading behind casts — `drillDown`
+  (`DrillDownConfig`) and `onRowClick` — which no declaration carried before.
+- `@object-ui/plugin-list`: the published `ObjectGalleryProps.schema` is
+  `ObjectGallerySchema`. Its accept set WIDENS — every `BaseSchema` member is
+  writable (`visibleWhen`, a real base member, was a compile error on the
+  literal) — and NARROWS in one place: `type` is now required and pinned to
+  `'object-gallery'`. `data` stays `Record<string, unknown>[]`.
+- `@object-ui/plugin-dashboard`: `ObjectDataTableProps.schema` (not exported
+  from the plugin index) is `ObjectDataTableSchema`. The literal's own
+  `[key: string]: any` is gone, so a wrong-typed base member (`visible: 42`) and
+  a wrong-shaped `drillDown` are refused, and `type` is pinned to
+  `'object-data-table'` instead of bare `string`.
+
+Unchanged on both, stated plainly: an UNKNOWN key still compiles, because
+`BaseSchema`'s index signature is inherited (objectui#5155, open). No runtime
+behaviour changes; the widgets render exactly as before.

--- a/packages/plugin-dashboard/src/ObjectDataTable.tsx
+++ b/packages/plugin-dashboard/src/ObjectDataTable.tsx
@@ -14,7 +14,7 @@ import {
   columnIdentity,
   columnHeader,
 } from '@object-ui/core';
-import type { DrillDownConfig, TableColumn } from '@object-ui/types';
+import type { ObjectDataTableSchema, TableColumn } from '@object-ui/types';
 import { normalizeTableColumnType } from '@object-ui/types';
 import { Skeleton, RefreshIndicator, cn } from '@object-ui/components';
 import { useSafeFieldLabel, useObjectTranslation, useLocalization, useDisplayLocale } from '@object-ui/i18n';
@@ -33,19 +33,14 @@ import { RecordDetailDrawer } from './RecordDetailDrawer';
 import { WidgetEmptyState } from './WidgetEmptyState';
 
 export interface ObjectDataTableProps {
-  schema: {
-    type: string;
-    objectName?: string;
-    dataProvider?: { provider: string; object?: string };
-    bind?: string;
-    filter?: any;
-    data?: any[];
-    columns?: any[];
-    searchable?: boolean;
-    pagination?: boolean;
-    className?: string;
-    [key: string]: any;
-  };
+  /**
+   * The `object-data-table` node — anchored to the exported schema type
+   * (objectui#6576 / #6914). The hand-rolled literal that stood here carried
+   * its own string index signature and had drifted: `drillDown` and
+   * `onRowClick` were read behind casts and declared nowhere. Both are declared
+   * on the schema type now; `bind` / `className` are inherited from `BaseSchema`.
+   */
+  schema: ObjectDataTableSchema;
   dataSource?: any;
   className?: string;
 }
@@ -644,7 +639,7 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
   // record in a detail drawer (the row already IS a record, so there is no
   // filter to derive). Opt-in via `schema.drillDown` — DashboardRenderer
   // defaults object-backed table/list widgets to `{ enabled: true }`.
-  const drillDown = schema.drillDown as DrillDownConfig | undefined;
+  const drillDown = schema.drillDown;
   const recordDrillEnabled = isDrillEnabled(drillDown) && (drillDown?.mode ?? 'record') === 'record';
   const [drillRecord, setDrillRecord] = useState<Record<string, any> | null>(null);
   const handleRowClick = useCallback((row: Record<string, any>) => {
@@ -970,7 +965,7 @@ export const ObjectDataTable: React.FC<ObjectDataTableProps> = ({ schema, dataSo
     type: 'data-table',
     data: finalData,
     columns: derivedColumns,
-    onRowClick: (schema as any).onRowClick ?? (recordDrillEnabled ? handleRowClick : undefined),
+    onRowClick: schema.onRowClick ?? (recordDrillEnabled ? handleRowClick : undefined),
   };
 
   // A `${event.*}` template (filter-mode title) is meaningless for a single

--- a/packages/plugin-dashboard/src/__tests__/ObjectDataTable.schemaAnchor-6576.test.ts
+++ b/packages/plugin-dashboard/src/__tests__/ObjectDataTable.schemaAnchor-6576.test.ts
@@ -1,0 +1,105 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6576 / #6914 — `ObjectDataTableProps.schema` is anchored to the
+ * exported `ObjectDataTableSchema` (`extends BaseSchema`); the literal's own
+ * `[key: string]: any` is gone, and the two keys the widget reads behind casts
+ * (`drillDown`, `onRowClick`) are declared.
+ *
+ * ## Why this pin is compile-time
+ *
+ * Same reading as `ObjectDataTable.emitBoundary-6373.test.tsx` next door: the
+ * widget renders identically before and after a type declaration, so only a
+ * COMPILE can fail. `tsconfig.test.json` compiles this file.
+ *
+ * ## Direction of the move, stated (Clause ②)
+ *
+ * `ObjectDataTableProps` is NOT exported from `plugin-dashboard/src/index.tsx`
+ * — it reaches consumers only structurally, as the prop type of the exported
+ * component — so the breakage surface is the in-repo call sites.
+ *
+ *   - NARROWS: a wrong-typed base member is refused (`visible: 42` used to be
+ *     absorbed by the literal's index signature); `type` is pinned to the
+ *     registry key (it used to be bare `string`).
+ *   - WIDENS, in declaration only: `drillDown` / `onRowClick` are now DECLARED
+ *     with real types — before, they compiled through the index signature as
+ *     `any`, which is why a wrong-shaped `drillDown` compiled too.
+ *   - UNCHANGED, pinned honestly: an unknown key still compiles, because
+ *     `BaseSchema`'s `[key: string]: any` is inherited (objectui#5155).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ObjectDataTableProps } from '../ObjectDataTable';
+import type { BaseSchema, DrillDownConfig, ObjectDataTableSchema } from '@object-ui/types';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+type Schema = ObjectDataTableProps['schema'];
+
+/** The anchor itself — invariant equality, so a second literal cannot creep back. */
+export type assertionSchemaIsAnchored = Expect<Equal<Schema, ObjectDataTableSchema>>;
+export type assertionSchemaExtendsBase = Expect<[Schema] extends [BaseSchema] ? true : false>;
+/**
+ * objectui#6914 — `Equal`, not `extends`: before the declaration both keys
+ * resolved to `any` through the literal's index signature, and `any` satisfies
+ * a one-way check. These were RED on the unmodified tree for exactly that reason.
+ */
+export type assertionDrillDownDeclared = Expect<Equal<Schema['drillDown'], DrillDownConfig | undefined>>;
+export type assertionOnRowClickDeclared = Expect<Equal<Schema['onRowClick'], ((row: any) => void) | undefined>>;
+export type assertionTypeIsRegistryKey = Expect<Equal<Schema['type'], 'object-data-table'>>;
+/** The pin can fail: the pre-#6576 literal shape is NOT the anchor. */
+export type assertionAnchorPinCanFail = Expect<Equal<Equal<{ type: string; [key: string]: any }, ObjectDataTableSchema>, false>>;
+
+describe('ObjectDataTableProps.schema — anchored to ObjectDataTableSchema (objectui#6576, #6914)', () => {
+  it('NARROWS: refuses a wrong-typed base member the literal used to absorb', () => {
+    // Before this card this directive was UNUSED (TS2578): the literal's own
+    // `[key: string]: any` typed `visible` as `any` and 42 compiled.
+    // @ts-expect-error — `visible` is `boolean | string` through BaseSchema.
+    const node: Schema = { type: 'object-data-table', objectName: 'account', visible: 42 };
+    expect(node.visible).toBe(42);
+  });
+
+  it('NARROWS: `type` is the registry key, not bare `string`', () => {
+    // Before this card `type: string` accepted any spelling, including the
+    // `data-table` key of a DIFFERENT node.
+    // @ts-expect-error — the only spelling is the key `ObjectDataTable.tsx` registers.
+    const node: Schema = { type: 'data-table', objectName: 'account' };
+    expect(node.type).toBe('data-table');
+  });
+
+  it('declares the two keys the widget reads (objectui#6914) — typed, so a wrong shape is refused', () => {
+    const node: Schema = {
+      type: 'object-data-table',
+      objectName: 'account',
+      drillDown: { enabled: true, mode: 'record', target: 'dialog' },
+      // `row` is contextually typed from the declaration; it used to sit behind `(schema as any)`.
+      onRowClick: (row) => { void row; },
+    };
+    expect(node.drillDown?.mode).toBe('record');
+
+    // @ts-expect-error — `enabled` is a boolean on DrillDownConfig; the index signature used to hide this.
+    const wrongShape: Schema = { type: 'object-data-table', drillDown: { enabled: 'yes' } };
+    // @ts-expect-error — `onRowClick` is a function.
+    const notAFunction: Schema = { type: 'object-data-table', onRowClick: 'toast' };
+    expect([wrongShape.drillDown, notAFunction.onRowClick]).toEqual([{ enabled: 'yes' }, 'toast']);
+  });
+
+  it('keeps `data` typed as `any[]` — a non-array is still refused, as before', () => {
+    // @ts-expect-error — `data` is `any[]`; the interface member overrides BaseSchema's `data?: any`.
+    const node: Schema = { type: 'object-data-table', data: 'not-an-array' };
+    expect(node.data).toBe('not-an-array');
+  });
+
+  it('the ceiling, stated: an UNKNOWN key still compiles (inherited index signature, objectui#5155)', () => {
+    const node: Schema = { type: 'object-data-table', bogusKey: 1 };
+    expect(node.bogusKey).toBe(1);
+  });
+});

--- a/packages/plugin-list/src/ObjectGallery.tsx
+++ b/packages/plugin-list/src/ObjectGallery.tsx
@@ -10,27 +10,17 @@ import React, { useState, useEffect, useCallback, useMemo, useContext } from 're
 import { useDataScope, SchemaRendererContext, useNavigationOverlay, useSafeFieldLabel } from '@object-ui/react';
 import { ComponentRegistry, buildExpandFields, getRecordDisplayName } from '@object-ui/core';
 import { cn, Card, CardContent, NavigationOverlay } from '@object-ui/components';
-import type { GalleryConfig, ViewNavigationConfig, GroupingConfig } from '@object-ui/types';
+import type { GalleryConfig, ObjectGallerySchema } from '@object-ui/types';
 import { ChevronRight, ChevronDown } from 'lucide-react';
 import { getCellRenderer, resolveCellRendererType, readFileValues } from '@object-ui/fields';
 
 export interface ObjectGalleryProps {
-    schema: {
-        objectName?: string;
-        bind?: string;
-        filter?: unknown;
-        data?: Record<string, unknown>[];
-        className?: string;
-        gallery?: GalleryConfig;
-        /** Navigation config for item click behavior */
-        navigation?: ViewNavigationConfig;
-        /** Grouping configuration for sectioned display */
-        grouping?: GroupingConfig;
-        /** @deprecated Use gallery.coverField instead */
-        imageField?: string;
-        /** @deprecated Use gallery.titleField instead */
-        titleField?: string;
-    };
+    /**
+     * The `object-gallery` node — anchored to the exported schema type
+     * (objectui#6576). Every `BaseSchema` member is writable, `bind` and
+     * `className` included; the widget's own keys are declared there.
+     */
+    schema: ObjectGallerySchema;
     data?: Record<string, unknown>[];
     dataSource?: { find: (name: string, query: unknown) => Promise<unknown> };
     onCardClick?: (record: Record<string, unknown>) => void;

--- a/packages/plugin-list/src/__tests__/ObjectGallery.cells.test.tsx
+++ b/packages/plugin-list/src/__tests__/ObjectGallery.cells.test.tsx
@@ -59,6 +59,7 @@ const renderGallery = (visibleFields: string[]) =>
     <SchemaRendererProvider dataSource={mockDataSource as any}>
       <ObjectGallery
         schema={{
+          type: 'object-gallery',
           objectName: 'account',
           gallery: {
             titleField: 'name',

--- a/packages/plugin-list/src/__tests__/ObjectGallery.coverValue.test.tsx
+++ b/packages/plugin-list/src/__tests__/ObjectGallery.coverValue.test.tsx
@@ -49,6 +49,7 @@ const renderGallery = (data: Record<string, unknown>[]) => {
     <SchemaRendererProvider dataSource={dataSource as any}>
       <ObjectGallery
         schema={{
+          type: 'object-gallery',
           objectName: 'showcase_task',
           gallery: { titleField: 'name', coverField: 'cover' },
         }}

--- a/packages/plugin-list/src/__tests__/ObjectGallery.schemaAnchor-6576.test.ts
+++ b/packages/plugin-list/src/__tests__/ObjectGallery.schemaAnchor-6576.test.ts
@@ -42,8 +42,13 @@ type Expect<T extends true> = T;
 /** The anchor itself — invariant equality, so a second literal cannot creep back. */
 export type assertionSchemaIsAnchored = Expect<Equal<ObjectGalleryProps['schema'], ObjectGallerySchema>>;
 export type assertionSchemaExtendsBase = Expect<[ObjectGalleryProps['schema']] extends [BaseSchema] ? true : false>;
-/** The pin can fail: the pre-#6576 literal shape is NOT the anchor. */
-export type assertionAnchorPinCanFail = Expect<Equal<Equal<{ objectName?: string; bind?: string }, ObjectGallerySchema>, false>>;
+/**
+ * The pin can fail: the pre-#6576 literal shape is NOT the anchor. (Spelled with
+ * `className`, not the literal's `bind` member: `base-bind-declared.test.ts`
+ * scans every tracked file for a schema-side `bind` re-declaration, and a
+ * synthetic control must not read as one.)
+ */
+export type assertionAnchorPinCanFail = Expect<Equal<Equal<{ objectName?: string; className?: string }, ObjectGallerySchema>, false>>;
 
 describe('ObjectGalleryProps.schema — anchored to ObjectGallerySchema (objectui#6576)', () => {
   it('WIDENS: accepts a real BaseSchema member the literal refused', () => {

--- a/packages/plugin-list/src/__tests__/ObjectGallery.schemaAnchor-6576.test.ts
+++ b/packages/plugin-list/src/__tests__/ObjectGallery.schemaAnchor-6576.test.ts
@@ -1,0 +1,87 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6576 — `ObjectGalleryProps.schema` is anchored to the exported
+ * `ObjectGallerySchema` (`extends BaseSchema`), not a hand-rolled literal.
+ *
+ * ## Why this pin is compile-time
+ *
+ * The change is a TYPE declaration; the widget renders identically before and
+ * after it, so a rendering test is blind to the whole change. What moves is the
+ * ACCEPT SET of a published prop type (`ObjectGalleryProps` is exported from
+ * `plugin-list/src/index.tsx`), and `tsconfig.test.json` compiles this file, so
+ * each statement below is real enforcement.
+ *
+ * ## Direction of the move, stated (Clause ②)
+ *
+ *   - WIDENS: every `BaseSchema` member is now writable. `visibleWhen` — a real
+ *     base member — was a compile error on the literal.
+ *   - NARROWS: `type` is now required, and pinned to the registry key.
+ *   - UNCHANGED, pinned honestly: an unknown key still compiles, because
+ *     `BaseSchema`'s `[key: string]: any` is inherited (objectui#5155). The
+ *     ruling accepted that cost; the counter-probe below keeps it visible.
+ *
+ * The schema type's own members and the widget's read census are pinned in
+ * `packages/types/src/__tests__/widget-schema-anchors-6576.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ObjectGalleryProps } from '../ObjectGallery';
+import type { BaseSchema, ObjectGallerySchema } from '@object-ui/types';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+/** The anchor itself — invariant equality, so a second literal cannot creep back. */
+export type assertionSchemaIsAnchored = Expect<Equal<ObjectGalleryProps['schema'], ObjectGallerySchema>>;
+export type assertionSchemaExtendsBase = Expect<[ObjectGalleryProps['schema']] extends [BaseSchema] ? true : false>;
+/** The pin can fail: the pre-#6576 literal shape is NOT the anchor. */
+export type assertionAnchorPinCanFail = Expect<Equal<Equal<{ objectName?: string; bind?: string }, ObjectGallerySchema>, false>>;
+
+describe('ObjectGalleryProps.schema — anchored to ObjectGallerySchema (objectui#6576)', () => {
+  it('WIDENS: accepts a real BaseSchema member the literal refused', () => {
+    // RED before this card (TS2353 — `visibleWhen` did not exist on the literal).
+    const node: ObjectGalleryProps['schema'] = {
+      type: 'object-gallery',
+      objectName: 'account',
+      visibleWhen: '${data.ready}',
+      gallery: { titleField: 'name' },
+    };
+    expect(node.visibleWhen).toBe('${data.ready}');
+  });
+
+  it('NARROWS: `type` is required and is the registry key', () => {
+    // @ts-expect-error — `type` is required now; the minimal `{ objectName }` literal no longer compiles.
+    const missing: ObjectGalleryProps['schema'] = { objectName: 'account' };
+    // @ts-expect-error — the only spelling is the key `ObjectGallery.tsx` registers.
+    const wrong: ObjectGalleryProps['schema'] = { type: 'gallery', objectName: 'account' };
+    expect([missing.objectName, wrong.objectName]).toEqual(['account', 'account']);
+  });
+
+  it('refuses a wrong-typed base member for the DECLARED reason', () => {
+    // @ts-expect-error — `visible` is `boolean | string` through BaseSchema.
+    const node: ObjectGalleryProps['schema'] = { type: 'object-gallery', visible: 42 };
+    expect(node.visible).toBe(42);
+  });
+
+  it('keeps the widget-local `data` typed — an interface member overrides, it does not intersect', () => {
+    // The prior probe predicted `data` would collapse to `any` under a
+    // `BaseSchema & {…}` INTERSECTION. `extends` is not an intersection: the
+    // derived member wins, so a non-array is still refused.
+    // @ts-expect-error — `data` is `Record<string, unknown>[]`.
+    const node: ObjectGalleryProps['schema'] = { type: 'object-gallery', data: 'not-an-array' };
+    expect(node.data).toBe('not-an-array');
+  });
+
+  it('the ceiling, stated: an UNKNOWN key still compiles (inherited index signature, objectui#5155)', () => {
+    const node: ObjectGalleryProps['schema'] = { type: 'object-gallery', visibleWhn: 'typo' };
+    expect(node.visibleWhn).toBe('typo');
+  });
+});

--- a/packages/types/src/__tests__/base-bind-declared.test.ts
+++ b/packages/types/src/__tests__/base-bind-declared.test.ts
@@ -43,9 +43,15 @@
  * hazard: "two copies of one key list is how a list becomes two disagreeing
  * lists". Exactly ONE of the four was a true duplicate of a base member —
  * `ObjectPivotTable`'s, whose `PivotTableSchema & {…}` intersection does extend
- * `BaseSchema`; it is removed by this card. The other three are load-bearing:
- * their containing types never reference `BaseSchema`, so deleting the member
- * deletes the declaration rather than inheriting it. They are ratcheted below.
+ * `BaseSchema`; it is removed by this card. The other three were load-bearing
+ * at the time: their containing types never referenced `BaseSchema`, so
+ * deleting the member would have deleted the declaration rather than
+ * inheriting it. Two of them — the hand-rolled `schema` prop literals of
+ * `ObjectGallery` and `ObjectDataTable` — were ratcheted here until
+ * objectui#6576 anchored both to exported schema types that extend
+ * `BaseSchema` (ruling 2026-08-31), at which point their local members became
+ * true duplicates and were removed exactly as `ObjectPivotTable`'s was. The one
+ * that remains is ratcheted below.
  *
  * `placeholder` is the standing precedent for a cross-cutting key declared here
  * and honoured by a subset: every node may write it, only inputs read it.
@@ -166,13 +172,21 @@ describe('BaseSchema (TS) — compile-time pin on `bind`', () => {
  */
 describe('`bind` is declared in exactly one place (objectui#6357)', () => {
   /**
-   * Every allowed non-home declaration, WITH ITS REASON.
+   * The one allowed non-home declaration, WITH ITS REASON.
    *
-   * None of the three is a schema shape, which is why none of them inherits the
-   * declaration and none could simply be deleted. Two are hand-rolled inline
-   * `schema` prop types with no `BaseSchema` in their ancestry — a real defect,
-   * but objectui#5155 / objectui#6269's, filed and not fixed here. The third is
-   * a DOM-strip props type. An entry here is a declared decision; a file that is
+   * It is not a schema shape, which is why it does not inherit the declaration
+   * and could not simply be deleted. Two more entries stood here from
+   * objectui#6357 to objectui#6576 — the hand-rolled inline `schema` prop
+   * literals of `ObjectGallery` and `ObjectDataTable`, RATCHETED because their
+   * containing types never reached `BaseSchema`, so dropping the member would
+   * have deleted the declaration instead of inheriting it. Those entries
+   * attributed the defect to objectui#5155 / objectui#6269; that was wrong —
+   * #5155 is about `BaseSchema`'s index signature leaving EXTENDERS open to
+   * misspellings, and these two types never extended it at all. The defect was
+   * objectui#6576's, and its 2026-08-31 ruling closed it by anchoring both to
+   * `ObjectGallerySchema` / `ObjectDataTableSchema` (each `extends BaseSchema`),
+   * so `bind` is inherited there now and the scan below is what keeps a local
+   * copy from coming back. An entry here is a declared decision; a file that is
    * in neither this map nor the home fails the scan.
    */
   const ALLOWED = new Map<string, string>([
@@ -180,19 +194,6 @@ describe('`bind` is declared in exactly one place (objectui#6357)', () => {
       'packages/plugin-dashboard/src/schemaHostProps.ts',
       'DOM-strip props type, not a schema shape — all seven members are `unknown` by design, '
         + 'because the type exists to be destructured out and never read (objectui#4357).',
-    ],
-    [
-      'packages/plugin-dashboard/src/ObjectDataTable.tsx',
-      'RATCHET, not an endorsement. `ObjectDataTableProps.schema` is an inline object type that '
-        + 'never references `BaseSchema`, so this member is load-bearing rather than duplicated — '
-        + 'removing it would not inherit the declaration, it would delete it. The disconnected '
-        + 'hand-rolled schema prop type is objectui#5155 / objectui#6269 territory, not this card.',
-    ],
-    [
-      'packages/plugin-list/src/ObjectGallery.tsx',
-      'RATCHET, same shape as the entry above — `ObjectGalleryProps.schema` is a hand-rolled inline '
-        + 'type with no `BaseSchema` in its ancestry and (unlike that one) no index signature, so '
-        + 'dropping the member is a compile error rather than an inheritance.',
     ],
   ]);
 

--- a/packages/types/src/__tests__/handler-keys-json-refusal-6124.test.ts
+++ b/packages/types/src/__tests__/handler-keys-json-refusal-6124.test.ts
@@ -47,8 +47,10 @@
  *     every non-metadata schema key as a React prop, so a renderer that reads
  *     `schema.onX`, calls `props.onX`, or spreads leftover props onto a Radix
  *     root / DOM listener slot is a live channel (36 sites, `RUNTIME_SLOT`
- *     below). A key nothing reads gets the `?: never` tombstone (22 sites,
- *     `RETIRED` below; the `crud.ts` `confirm` / `base.ts` convention).
+ *     below — 37 since objectui#6576 minted `ObjectDataTableSchema` with an
+ *     `onRowClick` arm, the first on an `objectql` mirror). A key nothing reads
+ *     gets the `?: never` tombstone (22 sites, `RETIRED` below; the `crud.ts`
+ *     `confirm` / `base.ts` convention).
  *
  * ## Predictions, written before the first run (red-first)
  *
@@ -72,6 +74,10 @@ import { dirname, join } from 'node:path';
 import { z } from 'zod';
 
 import { retirementTombstone } from '../zod/tombstone.zod';
+// objectui#6576 — the first handler arm on an `objectql` mirror, ledgered here
+// like the 58 it joins.
+import { ObjectDataTableSchema as ObjectDataTableZod } from '../zod/objectql.zod';
+import type { ObjectDataTableSchema } from '../objectql';
 import {
   CalendarViewSchema as CalendarViewZod,
   CarouselSchema as CarouselZod,
@@ -236,6 +242,8 @@ const RUNTIME_SLOT: readonly Site[] = [
   ['layout.zod.ts', 'CardSchema', 'onClick', CardZod],
   ['layout.zod.ts', 'TabsSchema', 'onValueChange', TabsZod],
   ['navigation.zod.ts', 'PaginationSchema', 'onPageChange', PaginationZod],
+  // objectui#6576 / #6914 — `ObjectDataTable.tsx` forwards `schema.onRowClick` into the `data-table` it renders.
+  ['objectql.zod.ts', 'ObjectDataTableSchema', 'onRowClick', ObjectDataTableZod],
   ['overlay.zod.ts', 'DialogSchema', 'onOpenChange', DialogZod],
   ['overlay.zod.ts', 'AlertDialogSchema', 'onOpenChange', AlertDialogZod],
   ['overlay.zod.ts', 'SheetSchema', 'onOpenChange', SheetZod],
@@ -283,8 +291,10 @@ const RETIRED: readonly Site[] = [
 
 const ALL_SITES: readonly Site[] = [...RUNTIME_SLOT, ...RETIRED];
 
-/** The eight mirror files the census covers; `base.zod.ts` holds only
- *  `EventHandlersSchema` (a record, objectui#6910's card) and no named key. */
+/** The nine mirror files the census covers; `base.zod.ts` holds only
+ *  `EventHandlersSchema` (a record, objectui#6910's card) and no named key.
+ *  `objectql.zod.ts` joined with objectui#6576 — it declared no handler key
+ *  at all until `ObjectDataTableSchema.onRowClick`. */
 const MIRROR_FILES = [
   'complex.zod.ts',
   'data-display.zod.ts',
@@ -293,6 +303,7 @@ const MIRROR_FILES = [
   'form.zod.ts',
   'layout.zod.ts',
   'navigation.zod.ts',
+  'objectql.zod.ts',
   'overlay.zod.ts',
 ] as const;
 
@@ -340,11 +351,13 @@ describe('census: no on* key in the eight mirrors is declared z.function() (obje
     ]);
   });
 
-  it('58 sites are ledgered, 36 runtime slots + 22 retired, with no key filed twice', () => {
-    expect(RUNTIME_SLOT).toHaveLength(36);
+  it('59 sites are ledgered, 37 runtime slots + 22 retired, with no key filed twice', () => {
+    // 58 from objectui#6124; the 59th is `ObjectDataTableSchema.onRowClick`,
+    // minted with its arm by objectui#6576 / #6914.
+    expect(RUNTIME_SLOT).toHaveLength(37);
     expect(RETIRED).toHaveLength(22);
     const ids = ALL_SITES.map(([file, schema, key]) => `${file}#${schema}.${key}`);
-    expect(new Set(ids).size).toBe(58);
+    expect(new Set(ids).size).toBe(59);
   });
 
   it.each(ALL_SITES)('%s %s.%s is DECLARED on the mirror shape, with the objectui#6124 guidance as its description', (_file, _schema, key, mirror) => {
@@ -520,6 +533,7 @@ export type assertionRuntimeSlotsKeepTheirFunctionType = [
   Expect<KeepsFunction<CardSchema['onClick']>>,
   Expect<KeepsFunction<TabsSchema['onValueChange']>>,
   Expect<KeepsFunction<PaginationSchema['onPageChange']>>,
+  Expect<KeepsFunction<ObjectDataTableSchema['onRowClick']>>,
   Expect<KeepsFunction<DialogSchema['onOpenChange']>>,
   Expect<KeepsFunction<AlertDialogSchema['onOpenChange']>>,
   Expect<KeepsFunction<SheetSchema['onOpenChange']>>,

--- a/packages/types/src/__tests__/widget-schema-anchors-6576.test.ts
+++ b/packages/types/src/__tests__/widget-schema-anchors-6576.test.ts
@@ -1,0 +1,243 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6576 — the two widget prop types that declared their `schema` as a
+ * hand-rolled inline object literal are anchored to NAMED schema types that
+ * `extends BaseSchema` (maintainer ruling 2026-08-31, option A). Folds
+ * objectui#6914: `ObjectDataTableSchema` declares the two keys the widget was
+ * reading behind casts.
+ *
+ * ## What was wrong
+ *
+ * `ObjectGalleryProps.schema` (plugin-list) and `ObjectDataTableProps.schema`
+ * (plugin-dashboard) were the ONLY two `Object*Props` in the repo whose
+ * `schema` member anchored to no named type at all. Because nothing in their
+ * ancestry reached `BaseSchema`, none of its declared members existed on them —
+ * every base key an author may legitimately write had to be hand-copied into
+ * the literal (`bind`, `className` were), and the two literals disagreed on
+ * strictness: the gallery had no index signature and REJECTED `visibleWhen`,
+ * a real base member, as an unknown key; the data-table carried its own
+ * `[key: string]: any` and had already drifted — it read `drillDown` and
+ * `onRowClick` and declared neither (objectui#6914).
+ *
+ * ## What this file pins, and where the rest lives
+ *
+ * 1. TYPE-LEVEL, on the two new declarations in this package: both extend
+ *    `BaseSchema`, carry the widget's registry key as their `type` literal,
+ *    inherit the base members with their DECLARED types (not `any`), and
+ *    `ObjectDataTableSchema` declares `drillDown` / `onRowClick` with the exact
+ *    types measured where they were declared before (`DrillDownConfig` on
+ *    `ChartSchema` / `PivotTableSchema`; `onRowClick` on `DataTableSchema`).
+ *    `tsconfig.test.json` compiles this file, so these are real enforcement.
+ * 2. SOURCE-LEVEL, on the two widget files: `schema:` anchors to the named type,
+ *    no inline `schema: {` literal remains, the local `bind` re-declaration and
+ *    the data-table's own index signature are gone, and the two #6914 casts are
+ *    gone with them. Read off disk the way `base-bind-declared.test.ts` reads
+ *    its readers — this package cannot import the plugins.
+ * 3. DRIFT, the objectui#6170 / #6357 class the inline shape invited: every key
+ *    a widget reads off `schema` is a key its zod mirror declares — both
+ *    widgets in ONE run so each is the other's control. The single deliberate
+ *    exception is ledgered by name below and in `zod-mirror-parity.test.ts`.
+ *
+ * The anchoring of each PROP type to its schema type is pinned where it can be
+ * compiled — beside the widget:
+ * `plugin-list/src/__tests__/ObjectGallery.schemaAnchor-6576.test.ts` and
+ * `plugin-dashboard/src/__tests__/ObjectDataTable.schemaAnchor-6576.test.ts`.
+ *
+ * ## The ceiling, stated rather than assumed (objectui#5155)
+ *
+ * `BaseSchema` still carries `[key: string]: any`, so anchoring buys DECLARED
+ * members their declared types (`visible: 42` is refused on both widgets now)
+ * but does NOT buy rejection of a misspelling: `visibleWhn` compiles on both.
+ * The ruling accepted that cost knowingly; the counter-probe below pins it
+ * honestly so nobody reads the anchor as more than it is. When objectui#5155
+ * lands, that expectation is the one to revisit deliberately.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import type { BaseSchema } from '../base.js';
+import type { DrillDownConfig } from '../data-display.js';
+import type { ObjectGallerySchema, ObjectDataTableSchema } from '../objectql.js';
+import {
+  ObjectGallerySchema as ObjectGalleryMirror,
+  ObjectDataTableSchema as ObjectDataTableMirror,
+} from '../zod/objectql.zod.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+
+/* ── Type-level pins (compiled by `tsc -p tsconfig.test.json`) ─────────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+/** Tuple-wrapped so a union declared type is judged whole, not limb by limb. */
+type ExtendsBase<T> = [T] extends [BaseSchema] ? true : false;
+
+export type assertionGalleryExtendsBase = Expect<ExtendsBase<ObjectGallerySchema>>;
+export type assertionDataTableExtendsBase = Expect<ExtendsBase<ObjectDataTableSchema>>;
+export type assertionGalleryTypeIsRegistryKey = Expect<Equal<ObjectGallerySchema['type'], 'object-gallery'>>;
+export type assertionDataTableTypeIsRegistryKey = Expect<Equal<ObjectDataTableSchema['type'], 'object-data-table'>>;
+/** objectui#6914 — declared with the types measured at their prior homes. */
+export type assertionDrillDownDeclared = Expect<Equal<ObjectDataTableSchema['drillDown'], DrillDownConfig | undefined>>;
+export type assertionOnRowClickDeclared = Expect<Equal<ObjectDataTableSchema['onRowClick'], ((row: any) => void) | undefined>>;
+/**
+ * Inherited members resolve to their DECLARED types. `Equal`, not `extends`:
+ * through the index signature a missing member reads `any`, which a one-way
+ * check would accept (the objectui#7087 disabled-twin lesson).
+ */
+export type assertionGalleryInheritsVisibleWhen = Expect<Equal<ObjectGallerySchema['visibleWhen'], string | undefined>>;
+export type assertionGalleryInheritsBind = Expect<Equal<ObjectGallerySchema['bind'], string | undefined>>;
+export type assertionDataTableInheritsVisible = Expect<Equal<ObjectDataTableSchema['visible'], boolean | string | undefined>>;
+export type assertionDataTableInheritsBind = Expect<Equal<ObjectDataTableSchema['bind'], string | undefined>>;
+/** The widget-local members keep their measured spellings. */
+export type assertionGalleryDataStaysTyped = Expect<Equal<ObjectGallerySchema['data'], Record<string, unknown>[] | undefined>>;
+export type assertionDataTableDataStaysTyped = Expect<Equal<ObjectDataTableSchema['data'], any[] | undefined>>;
+/** The helpers can FAIL — synthetic controls. */
+export type assertionExtendsBaseCanFail = Expect<Equal<ExtendsBase<{ objectName: string }>, false>>;
+export type assertionEqualCanFail = Expect<Equal<Equal<any, string | undefined>, false>>;
+
+describe('ObjectGallerySchema / ObjectDataTableSchema — compile-time pins (objectui#6576)', () => {
+  it('refuses a wrong-typed inherited base member on BOTH new types', () => {
+    // Before this card: the gallery literal had no `visible` key at all (an
+    // unknown-key error, for the wrong reason); the data-table literal's own
+    // index signature typed it `any` and ACCEPTED 42. Now both refuse it for
+    // the declared reason. Each directive fails the build (TS2578) the moment
+    // the member stops being declared.
+
+    // @ts-expect-error — `visible` is `boolean | string | undefined` through `BaseSchema`.
+    const gallery: ObjectGallerySchema = { type: 'object-gallery', visible: 42 };
+    // @ts-expect-error — same member, same reason, on the type that used to absorb it.
+    const table: ObjectDataTableSchema = { type: 'object-data-table', visible: 42 };
+
+    expect([gallery.visible, table.visible]).toEqual([42, 42]);
+  });
+
+  it('accepts a real base member the gallery literal used to refuse', () => {
+    const gallery: ObjectGallerySchema = { type: 'object-gallery', objectName: 'account', visibleWhen: '${data.ready}' };
+    expect(gallery.visibleWhen).toBe('${data.ready}');
+  });
+
+  it('declares the two keys the data-table reads (objectui#6914) — the row is contextually typed, no cast', () => {
+    const table: ObjectDataTableSchema = {
+      type: 'object-data-table',
+      objectName: 'account',
+      drillDown: { enabled: true, mode: 'record', target: 'dialog' },
+      onRowClick: (row) => { void row; },
+    };
+    expect(table.drillDown?.mode).toBe('record');
+    expect(typeof table.onRowClick).toBe('function');
+  });
+
+  it('still accepts a MISSPELLING — the ceiling, pinned honestly (objectui#5155)', () => {
+    // Counter-probe against reading the anchor as more than it is. `BaseSchema`'s
+    // `[key: string]: any` is inherited, so `visibleWhn` compiles on both. The
+    // ruling accepted this cost; closing it is objectui#5155, not this card.
+    const gallery: ObjectGallerySchema = { type: 'object-gallery', visibleWhn: 'typo' };
+    const table: ObjectDataTableSchema = { type: 'object-data-table', visibleWhn: 'typo' };
+    expect([gallery.visibleWhn, table.visibleWhn]).toEqual(['typo', 'typo']);
+  });
+});
+
+/* ── Source-level pins on the two widget files ─────────────────────────────── */
+
+const WIDGETS = [
+  {
+    file: 'packages/plugin-list/src/ObjectGallery.tsx',
+    props: 'ObjectGalleryProps',
+    anchor: 'ObjectGallerySchema',
+    registryKey: 'object-gallery' satisfies ObjectGallerySchema['type'],
+    /** Where `ComponentRegistry.register(...)` for this widget lives. */
+    registrationFile: 'packages/plugin-list/src/ObjectGallery.tsx',
+    mirror: ObjectGalleryMirror,
+    /** Keys read off `schema` that the mirror deliberately does not declare. */
+    unmirroredReads: [] as readonly string[],
+    retiredCasts: [] as readonly string[],
+  },
+  {
+    file: 'packages/plugin-dashboard/src/ObjectDataTable.tsx',
+    props: 'ObjectDataTableProps',
+    anchor: 'ObjectDataTableSchema',
+    registryKey: 'object-data-table' satisfies ObjectDataTableSchema['type'],
+    /** The dashboard plugin registers its widgets from the barrel, not the widget file. */
+    registrationFile: 'packages/plugin-dashboard/src/index.tsx',
+    mirror: ObjectDataTableMirror,
+    // `drillDown` is declared on the TS face and ledgered as unmirrored in
+    // `zod-mirror-parity.test.ts` (`UnmirroredDeclared`, LOCAL — the same
+    // reading as `ChartSchema.drillDown`): `DrillDownConfig` has no zod mirror
+    // in this package, and minting one is a new export outside #6576's ruling.
+    unmirroredReads: ['drillDown'] as readonly string[],
+    /** The two objectui#6914 casts the declaration makes unnecessary. */
+    retiredCasts: ['schema.drillDown as DrillDownConfig', '(schema as any).onRowClick'] as readonly string[],
+  },
+] as const;
+
+/** The `export interface <Props> { … }` block, up to its column-0 closing brace. */
+function propsInterface(src: string, props: string): string {
+  const start = src.indexOf(`export interface ${props} {`);
+  if (start < 0) return '';
+  const end = src.indexOf('\n}', start);
+  return end < 0 ? '' : src.slice(start, end + 2);
+}
+
+/** Every key read off `schema`, cast-aware: `schema.x`, `schema?.x`, `(schema as any).x`, `schema['x']`. */
+function schemaReads(src: string): Set<string> {
+  const re = /\bschema(?:\?)?\.([A-Za-z_$][\w$]*)|\(schema as any\)\.([A-Za-z_$][\w$]*)|\bschema\[['"]([A-Za-z_$][\w$]*)['"]\]/g;
+  const out = new Set<string>();
+  for (const m of src.matchAll(re)) out.add(m[1] ?? m[2] ?? m[3]);
+  return out;
+}
+
+describe('the two widget prop types anchor `schema` to the named type (objectui#6576)', () => {
+  it.each(WIDGETS)('$file — the `schema` member of $props is `$anchor`, with no inline literal, local `bind` or index signature left', ({ file, props, anchor }) => {
+    const iface = propsInterface(readFileSync(join(REPO_ROOT, file), 'utf8'), props);
+    // Non-vacuity: the block must exist and must still declare a `schema` member.
+    expect(iface, `${file} no longer declares \`export interface ${props}\``).not.toBe('');
+    expect(iface).toMatch(/\bschema:/);
+
+    expect(iface).toMatch(new RegExp(`\\bschema:\\s*${anchor};`));
+    expect(iface, 'the hand-rolled inline literal is back').not.toMatch(/\bschema:\s*\{/);
+    expect(iface, 'a local `bind` re-declaration is back — it is inherited from BaseSchema (objectui#6357)').not.toMatch(/\bbind\?:/);
+    expect(iface, 'a local index signature is back').not.toMatch(/\[key: string\]: any/);
+  });
+
+  it.each(WIDGETS)('$registrationFile — the `type` literal on $anchor is the key the widget registers', ({ registrationFile, registryKey }) => {
+    const src = readFileSync(join(REPO_ROOT, registrationFile), 'utf8');
+    // `register(` is split across lines in plugin-dashboard; a line-anchored grep misses it.
+    expect(src).toMatch(new RegExp(`ComponentRegistry\\.register\\(\\s*'${registryKey}'`));
+  });
+
+  it.each(WIDGETS)('$file — every key read off `schema` is declared by the mirror (or ledgered), and the #6914 casts are gone', ({ file, mirror, unmirroredReads, retiredCasts }) => {
+    const src = readFileSync(join(REPO_ROOT, file), 'utf8');
+    const reads = schemaReads(src);
+    // Non-vacuity: a widget that reads nothing off `schema` would pass vacuously.
+    expect(reads.size).toBeGreaterThan(3);
+    expect(reads.has('objectName')).toBe(true);
+
+    const declared = new Set([...Object.keys(mirror.shape), ...unmirroredReads]);
+    const readNotDeclared = [...reads].filter((k) => !declared.has(k)).sort();
+    expect(readNotDeclared, `${file} reads keys its schema type does not declare (objectui#6914 class)`).toEqual([]);
+
+    // Each ledgered exception must still be READ — a stale exception is a hole.
+    for (const key of unmirroredReads) expect(reads.has(key), `${key} is ledgered as unmirrored but no longer read`).toBe(true);
+    for (const cast of retiredCasts) expect(src, `${cast} — the declaration made this cast unnecessary`).not.toContain(cast);
+  });
+
+  it('the read census can see a drifted key (non-vacuity control)', () => {
+    // A census that returned an empty set for any input would pass the pin above
+    // while measuring nothing. Feed it a source with one undeclared read.
+    const reads = schemaReads("const a = schema.objectName; const b = (schema as any).drillDwon; const c = schema?.filter; const d = schema['data'];");
+    expect([...reads].sort()).toEqual(['data', 'drillDwon', 'filter', 'objectName']);
+    const declared = new Set(Object.keys(ObjectDataTableMirror.shape));
+    expect([...reads].filter((k) => !declared.has(k))).toEqual(['drillDwon']);
+  });
+});

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -28,7 +28,7 @@
  *
  * It reads `.shape` and not `keyof z.input<typeof Mirror>` because that spelling is
  * vacuous — `.passthrough()` collapses the inferred key union to bare `string`.
- * `assertionNoVacuousEntry` below pins that for all 158 entries at once.
+ * `assertionNoVacuousEntry` below pins that for all 160 entries at once.
  *
  * ## What is registered
  *
@@ -53,14 +53,17 @@
  * framing, and objectui#6058's own dispatch, both inherited "163"). On a file whose
  * entire subject is measurement that is worth stating explicitly:
  *
- *   - **158 pairs** — `Object.keys(MIRRORS).length`, which `assertionRegistryHalvesAgree`
+ *   - **160 pairs** — `Object.keys(MIRRORS).length`, which `assertionRegistryHalvesAgree`
  *     already pins equal to `keyof Declared`. Nothing asserts it against a written
  *     number, so this line is prose and can rot; the pin that cannot is the one
  *     comparing the two halves to each other.
- *   - **36 entries** in `KnownDrift`, **52 keys** across them. It was 12 / 17 until
+ *   - **37 entries** in `KnownDrift`, **53 keys** across them. It was 12 / 17 until
  *     objectui#6124 added the RUNTIME-SLOT class (28 pairs touched, 35 keys) — see
- *     the class note inside the ledger, above `ButtonSchema`.
- *   - **16 entries** in `UnmirroredDeclared`, **97 keys** across them. ⚠️ It was
+ *     the class note inside the ledger, above `ButtonSchema` — and 36 / 52 until
+ *     objectui#6576 minted `ObjectDataTableSchema` with one such arm (`onRowClick`).
+ *   - **17 entries** in `UnmirroredDeclared`, **98 keys** across them (16 / 97 until
+ *     objectui#6576 SEEDED the new `ObjectDataTableSchema` pair with its one measured
+ *     key, `drillDown` — a pair born ledgered, not growth on an existing one). ⚠️ It was
  *     **121** when objectui#6058 seeded it; objectui#6152 moved 23 callback-shaped
  *     keys to the ledger below by RECLASSIFICATION, not by fixing them, and
  *     objectui#6639 MIRRORED `ObjectGridSchema.title` — one key actually repaired.
@@ -71,8 +74,9 @@
  *     seven are a subset of the 16 pairs above; `TreeViewSchema` is NOT — it is
  *     the first pair whose ONLY ledger entry is a runtime-only one
  *     (objectui#6150 declared `onNodeClick` on an otherwise clean pair), so the
- *     "no entry in either" population dropped by one to 141.
- *   - 158 − 36 = **122**, the "pairs with no entry" `LedgerMismatch` speaks of.
+ *     "no entry in either" population dropped by one to 141 — and stands at 142
+ *     since objectui#6576 added two pairs, one of them ledgered.
+ *   - 160 − 37 = **123**, the "pairs with no entry" `LedgerMismatch` speaks of.
  *
  * ## Two ratchets, because the forward comparison has two halves
  *
@@ -93,7 +97,7 @@
  *
  * ## KNOWN_DRIFT is a ratchet, not a waiver
  *
- * 36 of the 158 pairs carry TYPE drift TODAY (measured, not assumed). Each is
+ * 37 of the 160 pairs carry TYPE drift TODAY (measured, not assumed). Each is
  * pinned to its EXACT drifted key set, so the entry fails when new drift appears on
  * that mirror AND when the recorded drift is fixed — a stale entry cannot rot
  * quietly. Correcting them is not one change: the pairs below split into DISJOINT
@@ -136,7 +140,7 @@ import { EmptySchema, LoadingSchema, ProgressSchema, SkeletonSchema, SonnerSchem
 import { ButtonSchema, CalendarSchema, CheckboxSchema, CodeEditorSchema, ComboboxOptionSchema, ComboboxSchema, CommandGroupSchema, CommandItemSchema, CommandSchema, DatePickerSchema, FieldConditionSchema, FieldConstraintsSchema, FileUploadSchema, FormFieldSchema, FormSchema, InputOTPSchema, InputSchema, LabelSchema, RadioGroupSchema, RadioOptionSchema, SelectOptionSchema, SelectSchema, SliderSchema, SwitchSchema, TextareaSchema, ToggleSchema } from '../zod/form.zod.js';
 import { AspectRatioSchema, BoxSchema, CardSchema, ContainerSchema, DivSchema, FlexSchema, GridSchema, IconSchema, ImageSchema, PageNodeRegionSchema, PageNodeSchema, ResizablePanelSchema, ResizableSchema, ScrollAreaSchema, SeparatorSchema, StackSchema, TabItemSchema, TabsSchema, TextSchema, TextSpanSchema } from '../zod/layout.zod.js';
 import { BreadcrumbItemSchema, BreadcrumbSchema, ButtonGroupButtonSchema, ButtonGroupSchema, HeaderBarSchema, NavigationMenuSchema, PaginationSchema, SidebarSchema } from '../zod/navigation.zod.js';
-import { ObjectCalendarSchema, ObjectChartSchema, ObjectFormSchema, ObjectGanttSchema, ObjectGridSchema, ObjectKanbanSchema, ObjectMapConfigSchema, ObjectMapSchema, ObjectTreeSchema, ObjectViewSchema, SortConfigSchema } from '../zod/objectql.zod.js';
+import { ObjectCalendarSchema, ObjectChartSchema, ObjectDataTableSchema, ObjectFormSchema, ObjectGallerySchema, ObjectGanttSchema, ObjectGridSchema, ObjectKanbanSchema, ObjectMapConfigSchema, ObjectMapSchema, ObjectTreeSchema, ObjectViewSchema, SortConfigSchema } from '../zod/objectql.zod.js';
 import { AlertDialogSchema, ContextMenuSchema, DialogSchema, DrawerSchema, DropdownMenuSchema, HoverCardSchema, MenubarMenuSchema, MenubarSchema, PopoverSchema, SheetSchema, TooltipSchema } from '../zod/overlay.zod.js';
 import { ReportBuilderSchema, ReportComponentSchema, ReportExportConfigSchema, ReportFieldSchema, ReportFilterSchema, ReportGroupBySchema, ReportSectionSchema, ReportViewerSchema } from '../zod/reports.zod.js';
 import { DetailViewFieldSchema, DetailViewSchema, DetailViewSectionSchema, DetailViewTabSchema, FilterUISchema, SortUISchema, ViewSwitcherSchema } from '../zod/views.zod.js';
@@ -153,7 +157,7 @@ import type { EmptySchema as Ts_EmptySchema, LoadingSchema as Ts_LoadingSchema, 
 import type { ButtonSchema as Ts_ButtonSchema, CalendarSchema as Ts_CalendarSchema, CheckboxSchema as Ts_CheckboxSchema, CodeEditorSchema as Ts_CodeEditorSchema, ComboboxOption as Ts_ComboboxOption, ComboboxSchema as Ts_ComboboxSchema, CommandGroup as Ts_CommandGroup, CommandItem as Ts_CommandItem, CommandSchema as Ts_CommandSchema, DatePickerSchema as Ts_DatePickerSchema, FieldCondition as Ts_FieldCondition, FieldValidationRules as Ts_FieldValidationRules, FileUploadSchema as Ts_FileUploadSchema, FormField as Ts_FormField, FormSchema as Ts_FormSchema, InputOTPSchema as Ts_InputOTPSchema, InputSchema as Ts_InputSchema, LabelSchema as Ts_LabelSchema, RadioGroupSchema as Ts_RadioGroupSchema, RadioOption as Ts_RadioOption, SelectOption as Ts_SelectOption, SelectSchema as Ts_SelectSchema, SliderSchema as Ts_SliderSchema, SwitchSchema as Ts_SwitchSchema, TextareaSchema as Ts_TextareaSchema, ToggleSchema as Ts_ToggleSchema } from '../form';
 import type { AspectRatioSchema as Ts_AspectRatioSchema, BoxSchema as Ts_BoxSchema, CardSchema as Ts_CardSchema, ContainerSchema as Ts_ContainerSchema, DivSchema as Ts_DivSchema, FlexSchema as Ts_FlexSchema, GridSchema as Ts_GridSchema, IconSchema as Ts_IconSchema, ImageSchema as Ts_ImageSchema, PageNodeRegion as Ts_PageNodeRegion, PageNodeSchema as Ts_PageNodeSchema, ResizablePanel as Ts_ResizablePanel, ResizableSchema as Ts_ResizableSchema, ScrollAreaSchema as Ts_ScrollAreaSchema, SeparatorSchema as Ts_SeparatorSchema, StackSchema as Ts_StackSchema, TabItem as Ts_TabItem, TabsSchema as Ts_TabsSchema, TextSchema as Ts_TextSchema, TextSpanSchema as Ts_TextSpanSchema } from '../layout';
 import type { ButtonGroupButton as Ts_ButtonGroupButton, ButtonGroupSchema as Ts_ButtonGroupSchema, HeaderBarSchema as Ts_HeaderBarSchema, NavigationMenuSchema as Ts_NavigationMenuSchema, PaginationSchema as Ts_PaginationSchema, SidebarSchema as Ts_SidebarSchema } from '../navigation';
-import type { ObjectCalendarSchema as Ts_ObjectCalendarSchema, ObjectChartSchema as Ts_ObjectChartSchema, ObjectFormSchema as Ts_ObjectFormSchema, ObjectGanttSchema as Ts_ObjectGanttSchema, ObjectGridSchema as Ts_ObjectGridSchema, ObjectKanbanSchema as Ts_ObjectKanbanSchema, ObjectMapConfig as Ts_ObjectMapConfig, ObjectMapSchema as Ts_ObjectMapSchema, ObjectTreeSchema as Ts_ObjectTreeSchema, ObjectViewSchema as Ts_ObjectViewSchema, SortConfig as Ts_SortConfig } from '../objectql';
+import type { ObjectCalendarSchema as Ts_ObjectCalendarSchema, ObjectChartSchema as Ts_ObjectChartSchema, ObjectDataTableSchema as Ts_ObjectDataTableSchema, ObjectFormSchema as Ts_ObjectFormSchema, ObjectGallerySchema as Ts_ObjectGallerySchema, ObjectGanttSchema as Ts_ObjectGanttSchema, ObjectGridSchema as Ts_ObjectGridSchema, ObjectKanbanSchema as Ts_ObjectKanbanSchema, ObjectMapConfig as Ts_ObjectMapConfig, ObjectMapSchema as Ts_ObjectMapSchema, ObjectTreeSchema as Ts_ObjectTreeSchema, ObjectViewSchema as Ts_ObjectViewSchema, SortConfig as Ts_SortConfig } from '../objectql';
 import type { AlertDialogSchema as Ts_AlertDialogSchema, ContextMenuSchema as Ts_ContextMenuSchema, DialogSchema as Ts_DialogSchema, DrawerSchema as Ts_DrawerSchema, DropdownMenuSchema as Ts_DropdownMenuSchema, HoverCardSchema as Ts_HoverCardSchema, MenubarMenu as Ts_MenubarMenu, MenubarSchema as Ts_MenubarSchema, PopoverSchema as Ts_PopoverSchema, SheetSchema as Ts_SheetSchema, TooltipSchema as Ts_TooltipSchema } from '../overlay';
 import type { ReportBuilderSchema as Ts_ReportBuilderSchema, ReportComponentSchema as Ts_ReportComponentSchema, ReportExportConfig as Ts_ReportExportConfig, ReportField as Ts_ReportField, ReportFilter as Ts_ReportFilter, ReportGroupBy as Ts_ReportGroupBy, ReportSection as Ts_ReportSection, ReportViewerSchema as Ts_ReportViewerSchema } from '../reports';
 import type { DetailViewField as Ts_DetailViewField, DetailViewSchema as Ts_DetailViewSchema, DetailViewSection as Ts_DetailViewSection, DetailViewTab as Ts_DetailViewTab, FilterUISchema as Ts_FilterUISchema, SortUISchema as Ts_SortUISchema, ViewSwitcherSchema as Ts_ViewSwitcherSchema } from '../views';
@@ -260,7 +264,7 @@ export type ReconcileAgainstLedger< K, Measured, Recorded > =
 export type assertionRatchetAcceptsAgreement =
   Expect< Equal< ReconcileAgainstLedger< 'p', 'a', 'a' >, never > >;
 
-/** …and so does a clean pair with no entry, which is the case for 141 of the 158. */
+/** …and so does a clean pair with no entry, which is the case for 142 of the 160. */
 export type assertionRatchetAcceptsCleanPair =
   Expect< Equal< ReconcileAgainstLedger< 'p', never, never >, never > >;
 
@@ -468,7 +472,9 @@ const MIRRORS = {
   'navigation.zod.ts#SidebarSchema': SidebarSchema,
   'objectql.zod.ts#ObjectCalendarSchema': ObjectCalendarSchema,
   'objectql.zod.ts#ObjectChartSchema': ObjectChartSchema,
+  'objectql.zod.ts#ObjectDataTableSchema': ObjectDataTableSchema,
   'objectql.zod.ts#ObjectFormSchema': ObjectFormSchema,
+  'objectql.zod.ts#ObjectGallerySchema': ObjectGallerySchema,
   'objectql.zod.ts#ObjectGanttSchema': ObjectGanttSchema,
   'objectql.zod.ts#ObjectGridSchema': ObjectGridSchema,
   'objectql.zod.ts#ObjectKanbanSchema': ObjectKanbanSchema,
@@ -633,7 +639,9 @@ interface Declared {
   'navigation.zod.ts#SidebarSchema': Ts_SidebarSchema;
   'objectql.zod.ts#ObjectCalendarSchema': Ts_ObjectCalendarSchema;
   'objectql.zod.ts#ObjectChartSchema': Ts_ObjectChartSchema;
+  'objectql.zod.ts#ObjectDataTableSchema': Ts_ObjectDataTableSchema;
   'objectql.zod.ts#ObjectFormSchema': Ts_ObjectFormSchema;
+  'objectql.zod.ts#ObjectGallerySchema': Ts_ObjectGallerySchema;
   'objectql.zod.ts#ObjectGanttSchema': Ts_ObjectGanttSchema;
   'objectql.zod.ts#ObjectGridSchema': Ts_ObjectGridSchema;
   'objectql.zod.ts#ObjectKanbanSchema': Ts_ObjectKanbanSchema;
@@ -815,6 +823,16 @@ interface KnownDrift {
   'navigation.zod.ts#HeaderBarSchema': 'variant';
   /** RUNTIME SLOT (objectui#6124): the `pagination` renderer calls `props.onPageChange(page)` after `SchemaRenderer`'s spread. */
   'navigation.zod.ts#PaginationSchema': 'onPageChange';
+  /**
+   * RUNTIME SLOT (objectui#6124 shape, minted by objectui#6576 / #6914): the pair
+   * was born with this entry. `ObjectDataTable.tsx` forwards `schema.onRowClick`
+   * into the `data-table` it renders (it used to read it through an
+   * `(schema as any)` cast — #6914's drift), so the TS side keeps the callable
+   * and the mirror refuses it by name. The FIRST handler arm on an `objectql`
+   * mirror: the POLICY-group entries in `RuntimeOnlyDeclared` below record the
+   * pre-#6124 state of that file, not a rule for new mirrors.
+   */
+  'objectql.zod.ts#ObjectDataTableSchema': 'onRowClick';
   /** RUNTIME SLOT (objectui#6124): the `alert-dialog` renderer spreads leftover props onto the Radix `AlertDialog` root. (`onConfirm` / `onCancel` are NOT here: the footer is wired to `schema.onAction` and `AlertDialogCancel`, so nothing reads them — both faces retire them.) */
   'overlay.zod.ts#AlertDialogSchema': 'onOpenChange';
   /** RUNTIME SLOT (objectui#6124): the `dialog` renderer spreads leftover props onto the Radix `Dialog` root. */
@@ -865,7 +883,7 @@ interface KnownDrift {
  * is being let through, because there was no such thing. Seeding takes the count of
  * VISIBLE, RATCHETED facts from 0 to 121 and installs a floor: the problem cannot
  * grow while they are worked off, and a new declared-but-unmirrored key on any of
- * the 158 pairs reddens immediately (`assertionRatchetRejectsFreshDrift`) —
+ * the 160 pairs reddens immediately (`assertionRatchetRejectsFreshDrift`) —
  * including a callback-shaped one, which reddens until it is filed in
  * `RuntimeOnlyDeclared` (`assertionSplitLedgerRejectsFreshCallback`).
  *
@@ -901,7 +919,8 @@ interface KnownDrift {
  * `ObjectViewSchema.onNavigate` (14 → 13) and the local side lost the other 22
  * (107 → 85; 84 since objectui#6639 mirrored `ObjectGridSchema.title`). The pair
  * COUNTS did not move — every affected pair kept keys here — which is why 16
- * entries still hold 97 keys.
+ * entries still hold 97 keys. (17 entries / 98 keys since objectui#6576 seeded the
+ * `ObjectDataTableSchema` pair with `drillDown` — see that entry.)
  *
  * ## How this was measured, and the trap that makes the number hard to get
  *
@@ -975,6 +994,18 @@ interface UnmirroredDeclared {
   'form.zod.ts#LabelSchema': 'content';
   /** LOCAL. */
   'navigation.zod.ts#PaginationSchema': 'currentPage';
+  /**
+   * LOCAL — a SEED, not growth. This pair was minted by objectui#6576 (folding
+   * #6914, which found the widget reading `drillDown` behind a cast and declaring
+   * it nowhere); the declaration now carries it, and the mirror does not, for the
+   * same reason `ChartSchema.drillDown` above is here: `DrillDownConfig` has no
+   * zod mirror in this package, and minting one is a new export outside that
+   * ruling. The shrink-only rule governs keys that APPEAR on registered pairs;
+   * a pair born with its measured debt written down is the seeding discipline
+   * objectui#6058 established, applied once. Remedy when ruled: a paired
+   * `DrillDownConfigSchema` mirror, which shrinks THIS entry and `ChartSchema`'s.
+   */
+  'objectql.zod.ts#ObjectDataTableSchema': 'drillDown';
   /**
    * LOCAL, and still the second-largest at 21. It was 26: the five `on*` keys are in
    * `RuntimeOnlyDeclared` below (objectui#6152). ⚠️ `submitHandler` is NOT among them
@@ -1271,7 +1302,7 @@ export type assertionLedgerHalvesAreDisjoint = Expect< Equal< DoubleFiledKey, ne
 
 /**
  * Every pair's TYPE drift equals what `KnownDrift` records for it — `never` for the
- * 122 pairs with no entry (158 − 36).
+ * 123 pairs with no entry (160 − 37).
  *
  * Routed through `ReconcileAgainstLedger` rather than spelling the conditional
  * inline. That is a semantics-preserving refactor and nothing else — the type is
@@ -1319,8 +1350,8 @@ export const assertionDriftMatchesLedger: never = 0 as unknown as LedgerMismatch
 
 /**
  * The SECOND half of the forward comparison: every pair's declared-but-unmirrored
- * key set equals what the two ledgers TOGETHER record for it — `never` for the 141
- * pairs with no entry in either (158 − 17). Six of `RuntimeOnlyDeclared`'s seven
+ * key set equals what the two ledgers TOGETHER record for it — `never` for the 142
+ * pairs with no entry in either (160 − 18). Six of `RuntimeOnlyDeclared`'s seven
  * pairs are a measured subset of `UnmirroredDeclared`'s 16, so objectui#6152's
  * reclassification left the clean population unchanged; objectui#6150 then added
  * `TreeViewSchema`, whose only entry is runtime-only, which is why the union is 17
@@ -1374,7 +1405,7 @@ export const assertionUnmirroredMatchesLedger: never = 0 as unknown as {
 }[MirrorKey];
 
 /**
- * Non-vacuity for all 158 entries at once.
+ * Non-vacuity for all 160 entries at once.
  *
  * `NarrowerThanDeclared` is `never` — green — for an entry whose mirror exposes no
  * `.shape`, and also for one whose key union has degenerated to bare `string` (the
@@ -1580,6 +1611,7 @@ const SPEC_DERIVED_PAIRS: readonly string[] = [
   'complex.zod.ts#DashboardWidgetSchema',
   'form.zod.ts#SelectOptionSchema',
   'layout.zod.ts#PageNodeSchema',
+  'objectql.zod.ts#ObjectGallerySchema',
   'objectql.zod.ts#ObjectGanttSchema',
   'objectql.zod.ts#ObjectMapSchema',
 ];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -401,6 +401,8 @@ export type {
   KanbanConditionalFormattingRule,
   KanbanNativeConditionalFormattingRule,
   ObjectChartSchema,
+  ObjectGallerySchema,
+  ObjectDataTableSchema,
   ListViewSchema,
   ListViewExportFormat,
   ListViewExportOptions,

--- a/packages/types/src/objectql.ts
+++ b/packages/types/src/objectql.ts
@@ -19,6 +19,7 @@
  */
 
 import type { BaseSchema } from './base.js';
+import type { DrillDownConfig } from './data-display.js';
 import type { BulkActionOperation } from '@objectstack/spec/ui';
 import type { FormField } from './form.js';
 // ListView type is now derived from the zod schema (issue #2231) — see ListViewSchema below.
@@ -2744,6 +2745,89 @@ export interface ObjectChartSchema extends BaseSchema {
   dimensions?: string[];
   /** Dataset measure names */
   values?: string[];
+}
+
+/**
+ * Object Gallery Component Schema (objectui#6576)
+ *
+ * The node `plugin-list`'s `ObjectGallery` renders — registered as
+ * `object-gallery` — and the anchor of the published `ObjectGalleryProps.schema`.
+ * Minted by the 2026-08-31 ruling on objectui#6576 (option A): the prop type
+ * used to declare this shape as a hand-rolled inline literal with no
+ * `BaseSchema` in its ancestry, so every base member had to be hand-copied in
+ * (`bind`, `className` were) and a real base key such as `visibleWhen` was a
+ * compile error. Anchoring here WIDENS that published accept set to every
+ * `BaseSchema` member and makes `type` required.
+ *
+ * Every key below has a read site in `plugin-list/src/ObjectGallery.tsx` (the
+ * read census is pinned in `__tests__/widget-schema-anchors-6576.test.ts`);
+ * `bind` and `className` are inherited, not restated.
+ */
+export interface ObjectGallerySchema extends BaseSchema {
+  type: 'object-gallery';
+  /** ObjectQL object name; omitted when the records arrive through `bind` or `data` */
+  objectName?: string;
+  /** Query filter, forwarded verbatim as `$filter` */
+  filter?: unknown;
+  /** Inline records — rendered ahead of a fetch when present */
+  data?: Record<string, unknown>[];
+  /** Gallery configuration — aligned with @objectstack/spec `GalleryConfig` */
+  gallery?: GalleryConfig;
+  /** Navigation config for item click behavior */
+  navigation?: ViewNavigationConfig;
+  /** Grouping configuration for sectioned display */
+  grouping?: GroupingConfig;
+  /** @deprecated Use `gallery.coverField` instead */
+  imageField?: string;
+  /** @deprecated Use `gallery.titleField` instead */
+  titleField?: string;
+}
+
+/**
+ * Object Data Table Component Schema (objectui#6576 / objectui#6914)
+ *
+ * The node `plugin-dashboard`'s `ObjectDataTable` renders — registered as
+ * `object-data-table` — and the anchor of `ObjectDataTableProps.schema`. That
+ * prop type used to be a hand-rolled inline literal carrying its own
+ * `[key: string]: any`, which is how it drifted: the widget read `drillDown`
+ * and `onRowClick` behind casts and declared neither (objectui#6914). Both are
+ * declared here with the types measured where they were declared before
+ * (`DrillDownConfig` on `ChartSchema` / `PivotTableSchema`, `onRowClick` on
+ * `DataTableSchema`), and the literal's index signature is gone — a NARROWING
+ * of a prop type the plugin index does not export.
+ *
+ * `bind` and `className` are inherited from `BaseSchema`, not restated. The
+ * widget spreads this node into the `data-table` it renders (overwriting
+ * `type`, `data`, `columns` and `onRowClick`), so `searchable` / `pagination`
+ * reach `DataTableSchema` unchanged.
+ */
+export interface ObjectDataTableSchema extends BaseSchema {
+  type: 'object-data-table';
+  /** ObjectQL object name; omitted when the rows arrive through `bind` or `data` */
+  objectName?: string;
+  /** Data-provider binding, carried from the dashboard widget definition */
+  dataProvider?: { provider: string; object?: string };
+  /** Query filter, resolved through the filter scope and forwarded as `$filter` */
+  filter?: any;
+  /** Inline rows — rendered ahead of a fetch when non-empty */
+  data?: any[];
+  /** Column definitions (names or column objects), normalized by the widget */
+  columns?: any[];
+  /** Forwarded to the rendered `data-table` */
+  searchable?: boolean;
+  /** Forwarded to the rendered `data-table` */
+  pagination?: boolean;
+  /**
+   * Drill-to-record: clicking a row opens that record in a detail drawer.
+   * `DashboardRenderer` defaults object-backed table widgets to `{ enabled: true }`.
+   */
+  drillDown?: DrillDownConfig;
+  /**
+   * Row click handler — a RUNTIME SLOT a React host supplies through this
+   * interface, never through authored JSON (objectui#6124; the zod mirror
+   * refuses the key by name). When present it overrides drill-to-record.
+   */
+  onRowClick?: (row: any) => void;
 }
 
 /**

--- a/packages/types/src/zod/index.zod.ts
+++ b/packages/types/src/zod/index.zod.ts
@@ -263,6 +263,8 @@ export {
   ObjectCalendarSchema,
   ObjectKanbanSchema,
   ObjectChartSchema,
+  ObjectGallerySchema,
+  ObjectDataTableSchema,
   ListViewSchema,
   ObjectQLComponentSchema,
 } from './objectql.zod.js';

--- a/packages/types/src/zod/objectql.zod.ts
+++ b/packages/types/src/zod/objectql.zod.ts
@@ -23,6 +23,7 @@ import {
   GanttConfigSchema as SpecGanttConfigSchema,
   CalendarConfigSchema as SpecCalendarConfigSchema,
   GalleryConfigSchema as SpecGalleryConfigSchema,
+  GroupingConfigSchema as SpecGroupingConfigSchema,
   TimelineConfigSchema as SpecTimelineConfigSchema,
   HttpMethodSubsetSchema as SpecHttpMethodSubsetSchema,
   HttpRequestSchema as SpecHttpRequestSchema,
@@ -35,6 +36,7 @@ import {
   NavigationConfigSchema as SpecNavigationConfigSchema,
 } from '@objectstack/spec/ui';
 import { BaseSchema, specFieldsExcept } from './base.zod.js';
+import { handlerKeyRefusal } from './tombstone.zod.js';
 
 /**
  * HTTP Method Schema — `@objectstack/spec/ui` schema re-exported by reference
@@ -840,6 +842,55 @@ export const ObjectChartSchema = BaseSchema.extend({
     z.array(z.string()),
     z.record(z.string(), z.string()),
   ]).optional().describe('Positional palette (string[]) OR a value→color map ({ value: color }, kanban-style). Select/lookup option colors and explicit maps win over the palette per category.'),
+});
+
+/**
+ * ObjectGallery Schema (objectui#6576)
+ *
+ * Mirrors the `ObjectGallerySchema` interface in `objectql.ts` key for key;
+ * every key has a read site in `plugin-list/src/ObjectGallery.tsx`. `gallery`,
+ * `navigation` and `grouping` are the spec's own schemas by reference, which is
+ * how the TS declaration types them.
+ */
+export const ObjectGallerySchema = BaseSchema.extend({
+  type: z.literal('object-gallery'),
+  objectName: z.string().optional().describe('ObjectQL object name'),
+  filter: z.unknown().optional().describe('Query filter, forwarded verbatim as $filter'),
+  data: z.array(z.record(z.string(), z.unknown())).optional().describe('Inline records'),
+  gallery: SpecGalleryConfigSchema.optional().describe('Gallery configuration (@objectstack/spec GalleryConfig)'),
+  navigation: SpecNavigationConfigSchema.optional().describe('Record navigation behaviour (drawer/dialog/page)'),
+  grouping: SpecGroupingConfigSchema.optional().describe('Grouping configuration for sectioned display'),
+  imageField: z.string().optional().describe('DEPRECATED — use gallery.coverField'),
+  titleField: z.string().optional().describe('DEPRECATED — use gallery.titleField'),
+});
+
+/**
+ * ObjectDataTable Schema (objectui#6576 / objectui#6914)
+ *
+ * Mirrors the `ObjectDataTableSchema` interface in `objectql.ts`. Two keys
+ * follow the parity ledger's discipline rather than the literal shape:
+ *
+ *   - `onRowClick` is a RUNTIME SLOT — a host-supplied function the widget
+ *     forwards into `data-table` — so the mirror refuses it BY NAME
+ *     (`handlerKeyRefusal`, the objectui#6124 shape) while the TS twin stays
+ *     callable; `KnownDrift` in `zod-mirror-parity.test.ts` records the
+ *     divergence.
+ *   - `drillDown` is declared on the TS face and deliberately NOT mirrored:
+ *     `DrillDownConfig` has no zod mirror in this package (`ChartSchema.drillDown`
+ *     is in the same state), and minting one is a new export outside the
+ *     objectui#6576 ruling. `UnmirroredDeclared` records it.
+ */
+export const ObjectDataTableSchema = BaseSchema.extend({
+  type: z.literal('object-data-table'),
+  objectName: z.string().optional().describe('ObjectQL object name'),
+  dataProvider: z.object({ provider: z.string(), object: z.string().optional() }).optional()
+    .describe('Data-provider binding carried from the dashboard widget definition'),
+  filter: z.any().optional().describe('Query filter, resolved through the filter scope and forwarded as $filter'),
+  data: z.array(z.any()).optional().describe('Inline rows'),
+  columns: z.array(z.any()).optional().describe('Column definitions (names or column objects)'),
+  searchable: z.boolean().optional().describe('Forwarded to the rendered data-table'),
+  pagination: z.boolean().optional().describe('Forwarded to the rendered data-table'),
+  onRowClick: handlerKeyRefusal('onRowClick', 'runtime-slot', 'Row click handler (overrides drill-to-record)'),
 });
 
 /**


### PR DESCRIPTION
Fixes #6576
Fixes #6914
Clause-②: yes — contract review required before release

Maintainer ruling 2026-08-31 (director seat, batch #10, option A, verbatim 「同意」), executed as written: two new exported schema types in `@object-ui/types`, each `extends BaseSchema`, and the two widget prop types that declared their `schema` as a hand-rolled inline literal are anchored to them. #6914 (the two keys the data-table reads and declared nowhere) is closed in the same stroke, per the erratum: `drillDown` and `onRowClick`.

Session for this implementation: `https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho` (kept in prose because a PR body edit strips the footer form).

## What changed

- `packages/types/src/objectql.ts` — `ObjectGallerySchema` (`type: 'object-gallery'`) and `ObjectDataTableSchema` (`type: 'object-data-table'`), beside `ObjectKanbanSchema` / `ObjectChartSchema`. Members are the measured read sets of each widget; `bind` and `className` are inherited, not restated. `ObjectDataTableSchema` declares `drillDown` as `DrillDownConfig` (the type it carries on `ChartSchema` / `PivotTableSchema`) and `onRowClick` as a function of one row (the type on `DataTableSchema`). Exported from `index.ts`.
- `packages/types/src/zod/objectql.zod.ts` — mirrors of both, exported from `index.zod.ts`. `onRowClick` is a `handlerKeyRefusal` runtime-slot arm (the PR #7339 shape) — the first handler arm on an `objectql` mirror. `drillDown` is NOT mirrored: `DrillDownConfig` has no zod mirror in this package and minting one is a third new export outside the ruling; it is ledgered (see Deviations) and filed as #7352.
- `zod-mirror-parity.test.ts` — both pairs registered (`MIRRORS` / `Declared`), `KnownDrift` gains `ObjectDataTableSchema: onRowClick`, `UnmirroredDeclared` gains the seed `ObjectDataTableSchema: drillDown`, `SPEC_DERIVED_PAIRS` gains the gallery pair (it references three spec schemas). Header counts re-read, not restated: 160 pairs (was 158), `KnownDrift` 37 entries / 53 keys (was 36 / 52), `UnmirroredDeclared` 17 entries / 98 keys (was 16 / 97), clean population 142 (was 141), `LedgerMismatch` population 123 (was 122). `RuntimeOnlyDeclared` unchanged at 7 / 24.
- `handler-keys-json-refusal-6124.test.ts` — the census covers nine mirror files (objectql joins), `RUNTIME_SLOT` is 37 (was 36), 59 sites ledgered (was 58), and `ObjectDataTableSchema.onRowClick` keeps its function type on the TS face.
- `packages/plugin-list/src/ObjectGallery.tsx` — `ObjectGalleryProps.schema: ObjectGallerySchema` (the bare-named-type shape `ObjectMapProps` uses for a dedicated schema type); the inline literal, its local `bind` / `className`, and two now-unused type imports are gone.
- `packages/plugin-dashboard/src/ObjectDataTable.tsx` — `ObjectDataTableProps.schema: ObjectDataTableSchema`; the literal with its own string index signature is gone, and the two #6914 casts with it (`schema.drillDown` no longer cast to `DrillDownConfig`; `onRowClick` no longer read through a cast to `any`).
- `base-bind-declared.test.ts` — the two #6574 `ALLOWED` ratchet entries for these files are removed and the prose rewritten deliberately: the defect was #6576's, not #5155 / #6269's (those entries said the opposite); the scan is now what keeps a local `bind` copy from returning. `ObjectPivotTable` is the precedent named.
- Pins (red-first, all three RED on `origin/main`, GREEN here): `packages/types/src/__tests__/widget-schema-anchors-6576.test.ts` (type-level pins on the two new types, source-level pins on both widget files, and a read census against each mirror with the one ledgered exception); `plugin-list/src/__tests__/ObjectGallery.schemaAnchor-6576.test.ts` and `plugin-dashboard/src/__tests__/ObjectDataTable.schemaAnchor-6576.test.ts` (compile-time: the prop's `schema` equals the schema type, extends `BaseSchema`, and each direction of the accept-set move is a literal that must or must not compile).
- Two gallery test literals gain the now-required `type: 'object-gallery'` (`ObjectGallery.cells.test.tsx`, `ObjectGallery.coverValue.test.tsx`).
- `.changeset/6576-widget-schema-anchors.md` — `@object-ui/types: minor`, `@object-ui/plugin-list: minor`, `@object-ui/plugin-dashboard: patch`.

No runtime behaviour changes; both widgets render exactly as before (792 plugin-list and 805 plugin-dashboard tests unchanged and green).

## Contract-review pack — accept-set before / after

Real `tsc --noEmit` against the real prop types, one labelled statement per line, diagnostics mapped by line number (`origin/main` at `2956d7af8`, then this head). Each row is the exact literal assigned to the prop's `schema` type. The `origin/main` column repeats the prior report's probe and re-measures it on the same instrument.

### `ObjectGalleryProps.schema` — PUBLISHED (`plugin-list/src/index.tsx` exports the type)

| case | literal | origin/main | this head | movement |
|---|---|---|---|---|
| G1 | `{ objectName, visibleWhen }` (no `type`) | REJECTED — TS2353 `visibleWhen` does not exist | REJECTED — TS2741 `type` is missing | reason changed, see G6 |
| G6 | `{ type: 'object-gallery', objectName, visibleWhen }` | REJECTED — TS2353 `type` does not exist | ACCEPTED | WIDENS — a real base member is writable |
| G2 | `{ type: 'object-gallery', objectName }` | REJECTED — TS2353 `type` does not exist | ACCEPTED | WIDENS — the node's own `type` key can be spelled |
| G4 | `{ objectName }` (minimal) | ACCEPTED | REJECTED — TS2741 `type` is missing | NARROWS — `type` is required (the prior report's G6) |
| G12 | `{ type: 'gallery', objectName }` | REJECTED — TS2353 `type` does not exist | REJECTED — TS2322 `"gallery"` not assignable to `"object-gallery"` | NARROWS for the right reason — the literal is the registry key |
| G3 / G7 | `{ [type,] objectName, data: 'not-an-array' }` | REJECTED — TS2322 string not assignable to array of records | REJECTED — same TS2322 | UNCHANGED — the prior report predicted `data` would collapse to `any` under a `BaseSchema` INTERSECTION; `extends` overrides the member instead, so the widening does not happen |
| G11 | `{ type, objectName, data: [{ id: 1 }] }` | REJECTED — TS2353 `type` | ACCEPTED | WIDENS (via `type`) |
| G9 | `{ objectName, visible: 42 }` (no `type`) | REJECTED — TS2353 `visible` does not exist | REJECTED — TS2322 number not assignable to string or boolean | reason changed: unknown key → wrong-typed declared member |
| G8 | `{ type, objectName, visible: 42 }` | REJECTED — TS2353 `type` | REJECTED — TS2322 | same as G9 with `type` present |
| G10 | `{ type, objectName, bind: 42 }` | REJECTED — TS2322 (local `bind?: string`) | REJECTED — TS2322 (inherited `bind?: string`) | UNCHANGED — inherited now |
| G5 | `{ type, objectName, visibleWhn: 'typo' }` | REJECTED — TS2353 `type` (the unknown key would also have been refused) | ACCEPTED | WIDENS — the ceiling below |

Net for the published type: WIDENS to every `BaseSchema` member (21 members gained; `visibleWhen`, `visible`, `id`, `hidden`, `disabled`, `testId`, `ariaLabel`, `label`, `style`, … are writable and type-checked), NARROWS in one place (`type` required and pinned to `'object-gallery'`). `data`, `bind`, `filter`, `gallery`, `navigation`, `grouping`, `imageField`, `titleField` keep their exact types.

### `ObjectDataTableProps.schema` — NOT exported from `plugin-dashboard/src/index.tsx` (reaches consumers structurally as the exported component's prop)

| case | literal | origin/main | this head | movement |
|---|---|---|---|---|
| D1 | `{ type: 'object-data-table', objectName, bogusKey: 1 }` | ACCEPTED | ACCEPTED | UNCHANGED — the ceiling below |
| D2 | `{ type, objectName, visible: 42 }` | ACCEPTED (absorbed by the literal's index signature) | REJECTED — TS2322 number not assignable to string or boolean | NARROWS — a wrong-typed base member is refused |
| D3 | `{ type, objectName, drillDown: { enabled: true, mode: 'record' } }` | ACCEPTED (as `any`) | ACCEPTED (as `DrillDownConfig`) | UNCHANGED in verdict; DECLARED now (#6914) |
| D4 | `{ type, objectName, drillDown: { enabled: 'yes' } }` | ACCEPTED (absorbed) | REJECTED — TS2322 string not assignable to boolean | NARROWS — a wrong-shaped `drillDown` is refused |
| D5 | `{ type, objectName, onRowClick: an arrow function of one untyped parameter }` | REJECTED — TS7006 `row` implicitly `any` (the key resolved to `any`, so nothing typed the parameter) | ACCEPTED — `row` is contextually typed | WIDENS in declaration — the handler can be written without an annotation (#6914) |
| D10 | `{ type, objectName, onRowClick: 'not-a-function' }` | ACCEPTED (absorbed) | REJECTED — TS2322 | NARROWS |
| D6 | `{ type, objectName, data: 'not-an-array' }` | REJECTED — TS2322 string not assignable to `any[]` | REJECTED — same | UNCHANGED |
| D7 | `{ type: 'data-table', objectName }` | ACCEPTED (`type: string`) | REJECTED — TS2322 `"data-table"` not assignable to `"object-data-table"` | NARROWS — the literal is the registry key |
| D8 | `{ type: 'object-data-table' }` | ACCEPTED | ACCEPTED | UNCHANGED |
| D9 | `{ objectName }` (no `type`) | REJECTED — TS2741 `type` missing | REJECTED — TS2741 | UNCHANGED (`type` was already required) |
| D11 | `{ type, objectName, bind: 42 }` | REJECTED — TS2322 (local `bind?: string`) | REJECTED — TS2322 (inherited) | UNCHANGED |
| D12 | `{ type, objectName, visibleWhen: 'ready' }` | ACCEPTED (absorbed as `any`) | ACCEPTED (declared `string`) | UNCHANGED in verdict; typed now |

Net for the unpublished type: NARROWS (the literal's own index signature is gone, so declared base members and the two #6914 keys are type-checked; `type` is the registry key). In-repo call sites re-checked: every `plugin-dashboard` test and `DrillDownDrawer.tsx` compile unchanged — the tests that write other spellings already carry `as any`.

### The ceiling, stated plainly

`BaseSchema` still carries `[key: string]: any` (#5155 remains open). Anchoring inherits it, so an UNKNOWN key (`visibleWhn`, `bogusKey`) remains ACCEPTED on BOTH prop types after this PR — on the data-table it always was; on the gallery it is new (G5). The ruling accepted that cost; the pins record it as a counter-probe rather than hiding it.

## Verification (on the committed heads `f84c14c17` — the implementation — and the final head named below, tree clean)

Every heavy command ran under `scripts/pm/os-verify-lock.sh` (slot `dev-6576`); verdict lines quoted from the tools, not from a bare exit status.

- Dependency closure built first (`turbo run build` for the three plugins' dependency closures, then every `packages/*`: `Tasks: 39 successful, 39 total`).
- `pnpm --filter @object-ui/types run build` → `tsc && node ../../scripts/check-dist-completeness.mjs`, exit 0; `dist/index.d.ts` carries both new names.
- `pnpm --filter … run type-check` — script echoed for each: `@object-ui/types@17.6.0 type-check`, `@object-ui/plugin-list@17.6.0 type-check`, `@object-ui/plugin-dashboard@17.6.0 type-check`, `@object-ui/plugin-view@17.6.0 type-check` — 0 errors each (each script is `tsc --noEmit` plus the package's test project, so every pin and both ledgers are compiled). `plugin-view` is the other producer of `object-gallery` nodes; it builds a plain node and never passes through `ObjectGalleryProps`, so nothing there moved.
- `pnpm --filter … run lint` (types / plugin-list / plugin-dashboard): 0 errors each (warnings only, pre-existing `no-explicit-any` in files that already carried it; the new `ObjectDataTableSchema` transcribes the literal's `any` spellings unchanged).
- Vitest (root-relative paths, no `--`), on the final head `e5b24a3bb`: `packages/types/` → `Test Files 88 passed (88)`, `Tests 1434 passed (1434)`; `packages/plugin-list/` → `Test Files 63 passed (63)`, `Tests 792 passed (792)`; the six ledger and pin files together (`zod-mirror-parity`, `handler-keys-json-refusal-6124`, `base-bind-declared`, `widget-schema-anchors-6576`, both `schemaAnchor-6576` pins) → `Test Files 6 passed (6)`, `Tests 286 passed (286)`. `packages/plugin-dashboard/` on `f84c14c17` (the second commit touches only a plugin-list test file) → `Test Files 86 passed (86)`, `Tests 805 passed (805)`. The second commit exists because the first post-commit run of `base-bind-declared` went RED: its `git grep` scan covers tracked files, and the plugin-list pin's synthetic control spelled the pre-#6576 literal with a `bind` member — the ratchet did exactly its job; the control now uses `className`.
- Red-first, on `origin/main` with the pins added and nothing else: `tsc -p tsconfig.test.json` — types 17 errors (all in the new pin: TS2724 the two names do not exist, TS2344 on every type assertion), plugin-list 9 errors, plugin-dashboard 10 errors (TS2724, TS2344, four TS2578 unused directives where the literal absorbed the wrong value); vitest on the types pin: 6 failed. GREEN here on all three.
- Ablation (each leg on the committed tree; mutation proven by blob hash equal to the `origin/main` blob, restore proven by blob hash equal to `HEAD` and `git diff HEAD` empty; a `trap` restored both files on every exit path): reverting only `ObjectGallery.tsx` → the types pin fails exactly one test naming `packages/plugin-list/src/ObjectGallery.tsx`, and plugin-list's test project reports 8 errors in `ObjectGallery.schemaAnchor-6576.test.ts` (plus the two gallery test literals); reverting only `ObjectDataTable.tsx` → the types pin fails exactly two tests naming `packages/plugin-dashboard/src/ObjectDataTable.tsx` (anchor shape; the #6914 casts are back), and plugin-dashboard's test project reports 9 errors, all in `ObjectDataTable.schemaAnchor-6576.test.ts`.
- Drift census on this head (read keys off `schema`, cast-aware, minus the members the checker resolves on the built `dist` declaration; both widgets in one run): `ObjectGallery` read-not-declared `[]` (10 reads, 28 declared), `ObjectDataTable` read-not-declared `[]` (7 reads, 29 declared); synthetic control with `drillDown` removed from the declared set reports `["drillDown"]`, so the instrument sees a missing key. On `origin/main` the same census read `['drillDown','onRowClick']` for the data-table (prior report).
- Gates: `check-changeset-presence` (11 published source files changed, changeset present), `check-changeset-no-major` (`✅ No changeset declares a major bump`), `check-changeset-fixed` (`✅ All workspace packages are in the changeset fixed group`), `check:readme-exports` (`✅ OK … 406 self-imports judged (406 real, 0 wrong-path, 0 fabricated)` — the `@object-ui/types` README lists no object-* schema types, so no README edit is required by the gate), `check:spec-symbols` (exit 0 — neither new name is a spec export; control `GalleryConfigSchema` found in the spec api-surface), `check:control-bytes` OK, `check:phantom-deps` OK, `check:self-import` OK, `check:esm-specifiers` OK, `check:published-dist` OK, `check:side-effects-array` OK, `check:element-data-source-declaration` OK, `check:spec-floors` OK, `check:doc-types` OK. NOT MEASURED locally: `check:sdui-registration-pins` (`❌ No console build to weigh at apps/console/dist/assets` — a prerequisite, not a verdict; registrations are untouched) and `check:eager-closure` (needs the console bundle). CI owns the repo-wide farm.
- Governed-surface check (from `../objectstack`, final file list): `governed-surface predicate: 0 of 15 path(s) hit the register` → `✅ NOT governed`.

## Deviations from the dispatch, declared

1. `drillDown` on the zod mirror: ledgered instead of mirrored. The ruling admits either route (「新类型入镜或按台账既有词表申报」); mirroring it needs a paired `DrillDownConfigSchema` — a third new export the ruling did not name, whose wiring into `ChartSchema` would move that published validator — and an inline unpaired restatement would strip nested keys silently (`z.object` drops unknown keys), the very drift class the ledger exists for. So the new pair is SEEDED in `UnmirroredDeclared` with the `ChartSchema.drillDown` vocabulary (LOCAL), its doc states why this is a seed and not growth on an existing pair, and the repair is filed as #7352. The reviewer should weigh this: the ledger's shrink-only rule is written for keys that appear on registered pairs.
2. `onRowClick` on the mirror is a `handlerKeyRefusal` arm (as the dispatch said), which also means the 6124 census and its 36 / 58 pins moved to 37 / 59 and its file list to nine. The alternative — no arm, `RuntimeOnlyDeclared` (the pre-#6124 objectql policy group) — was not taken because the 2026-08-30 ruling's rationale (an undeclared key is a silent accept that forwards the value) applies to a new mirror exactly as to an old one.
3. Fresh gallery literals: TWO test files needed the `type` key (`cells` and `coverValue`), not one — the dispatch assumed only `cells`. Both are tests; no producer changed.
4. `ObjectDataTableProps.schema` is the bare named type, not `NamedSchema & {…}`: with a dedicated schema type there are no widget-only extras to intersect, which is the `ObjectMapProps` shape; `PivotTable` / `Timeline` intersect because their schemas are generic nodes.
5. The prior report's G7 prediction (gallery `data` collapses to `any`) did not hold: it was measured on a `BaseSchema & {…}` intersection; an `extends` member overrides. Reported as UNCHANGED above and pinned.
6. Not extended: the `ObjectQLComponentSchema` unions (TS and zod) and `AnyComponentSchema` do not include the two new types. Adding them changes what `validateSchema` accepts for `object-gallery` / `object-data-table` nodes — a third published surface the ruling did not name. Flagged for the reviewer rather than decided.

## Not in this PR (for the PM)

- #7352 — `DrillDownConfig` has no zod mirror; `drillDown` is validated on no node (filed, unassigned).
- #7353 — `dataProvider` is declared on `ObjectDataTableSchema` (transcribed) and `ObjectPivotTableProps.schema`, written by `DashboardRenderer` / `DashboardGridLayout`, read by nothing (filed, unassigned).
- `ObjectTreeProps.schema: any` — reported by the prior dev, outside this fence, not re-filed here.
- Docs: `content/docs/plugins/plugin-dashboard.mdx` and `packages/plugin-dashboard/README.md` only carry the registry table for `object-data-table` (no interface shape); the two `skills/objectui/guides` pages name both widgets only in the list of `bind`-honouring nodes. Nothing teaches a stale shape, so no docs page is edited or flagged.
- #5155 remains open; the unknown-key ceiling above is its territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRRumy89BYdW9ogbcdHTho)_