### PR TITLE
docs(skills): verify — prescribe the stable Chromium alias instead of the versioned path

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -24,13 +24,15 @@ their hardcoded defaults — that IS the offline path, not an error.
 ## Driving it headlessly
 
 The chrome-devtools MCP may lack a Chrome binary in remote sessions. Use the
-repo's own Playwright instead — the pre-installed executable is at
-`/opt/pw-browsers/chromium-1194/chrome-linux/chrome` (probe with
-`find /opt/pw-browsers -name chrome` if the version moved):
+repo's own Playwright instead — the pre-installed executable is the stable
+alias `/opt/pw-browsers/chromium`. ⛔ Never copy the versioned
+`chromium-NNNN/chrome-linux/chrome` spelling out of a probe: the alias is what
+survives an image bump, and a dead versioned path reads as "no browser here"
+when the browser is in fact present.
 
 ```js
 import { chromium } from '@playwright/test';
-const browser = await chromium.launch({ executablePath: '<probed path>' });
+const browser = await chromium.launch({ executablePath: '/opt/pw-browsers/chromium' });
 ```
 
 Gotcha: a driver script must live **inside** the repo (e.g.


### PR DESCRIPTION
Part of objectstack-ai/objectstack#14317 — the objectui half of the internal-small skills flight (one finding). The objectstack half is objectstack-ai/objectstack#14598.

## Per-finding record

| id | 落点 | before | after |
|---|---|---|---|
| **VFY-C-01** | `.claude/skills/verify/SKILL.md:26-33` | prescribes the versioned literal `/opt/pw-browsers/chromium-1194/chrome-linux/chrome`, tells the reader to re-probe with `find` when the version moves, and leaves the launch snippet holding a placeholder the reader must resolve | prescribes the stable alias `/opt/pw-browsers/chromium` in both the prose and the snippet, and warns against copying the versioned spelling back out of a probe |

**Why the alias and not the probe.** Both sibling repos already prescribe the alias and warn against exactly this spelling: the platform-checklist runner doc calls a dead versioned path copied out of a section "the absence-inference trap", and the dev-agent definition prescribes the alias for `executablePath`. The versioned literal works today and stops working at the next image bump — and its failure mode is the expensive one, because a missing path reads as "no browser in this container" when the browser is in fact installed, which is the same wrong conclusion the runner doc records someone reaching from a blocked CDN download.

**Positive control, measured on this container:** `/opt/pw-browsers/chromium` is a live symlink onto `/opt/pw-browsers/chromium-1194/chrome-linux/chrome` and is executable. The fix names the same binary by a name that survives.

Line delta: `.claude/skills/verify/SKILL.md` 44 → 46. This repo prices no ceiling on it — its only skills gate scans the published `skills/` root, so this file is unpriced and unguarded (measured during the audit, reported for the corpus record, not acted on here).

## Gates

All at head `81e6308`, which equals the pushed remote head. Exit codes captured by redirect before any pipe.

| command | exit | its own verdict |
|---|---|---|
| `node scripts/check-control-bytes.mjs` | 0 | `OK (scanned 6066 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `OK (4/4 root(s) resolved … 205 file(s) and 1319 fenced block(s) examined)` |
| `node scripts/check-skills-paths.mjs` | 0 | `OK (92/93 stated path(s) resolve across 18 guide file(s); 1 baselined)` |
| `node scripts/check-changeset-presence.mjs` | 0 | `1 file(s) changed, 0 of them published source of a package the release covers … No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `No changeset declares a major bump.` |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `132 cases pass` |
| `node scripts/check-governed-queue-guard.mjs --test .claude/skills/verify/SKILL.md` | 3 | the governed verdict, not a red: `GOVERNED — 1 of 1 path(s) are on a governed surface … Park it as a DRAFT and leave the merge to the maintainer` |

**No changeset**, and it is the repo's own gate that says so rather than a judgment call: the path is not published source of any released package, so none is owed. ⛔ No label is requested from this seat.

Governed surface ⇒ this PR stays a **draft** for human merge; review requests are the dispatching seat's step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_