### PR TITLE
fix(app-shell): Studio rails converge on an AI copilot apply without a page reload

### DIFF
--- a/.changeset/nervous-donkeys-tap.md
+++ b/.changeset/nervous-donkeys-tap.md
@@ -1,0 +1,15 @@
+---
+'@object-ui/app-shell': minor
+---
+
+Studio workbench rails converge on an AI copilot apply without a page reload (objectui#7255)
+
+The copilot is the right dock of the Studio document and already announces
+every authoring turn on the assistant bus (`emitMetadataRefresh`), but the
+four pillar rails never subscribed: a just-applied object or nav item stayed
+invisible until the author reloaded the page. The Interfaces / Data /
+Automations / Access rails now list that pulse as a load dependency and refetch
+their package-scoped reads in place. The Interfaces rail holds the pulse while
+the nav editor has unsaved edits (its load rehydrates the nav edit buffer) and
+releases it once they settle, and re-reading the same package no longer flaps
+the app status back through `loading`.

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.aiApplyRefresh.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.aiApplyRefresh.test.tsx
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7255 — the Studio workbench converges on an AI copilot apply
+ * WITHOUT a page reload.
+ *
+ * Measured symptom: the copilot staged/published a new object and pushed a nav
+ * item into the app's `navigation`; the tenant registry had both (object
+ * `active`, item present in `sys_metadata`) — and the workbench's left rail
+ * still showed the pre-apply tree until the author reloaded the page.
+ *
+ * The channel was already there and already production-safe: the copilot is
+ * the RIGHT DOCK of this same document (ADR-0057 P3c), and `ChatPane`
+ * announces every authoring turn on the assistant bus (`emitMetadataRefresh`,
+ * the same pulse `usePendingDrafts` / `MetadataProvider` already converge on).
+ * What was missing was a subscriber on the rails. These tests pin that the
+ * rails now re-read on the pulse — the SAME mounted tree, so the assertion
+ * would still fail if someone "fixed" it by remounting or reloading.
+ *
+ * Deliberately NOT asserted here: which tool result emits the pulse. That
+ * predicate is `ChatPane`'s and is covered where it lives; duplicating it
+ * would pin two producers to one test.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import * as React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, act, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import type { NavNode } from './navSurface.js';
+
+/** The nav BEFORE the copilot turn — the two blueprint items the card names. */
+const NAV_BEFORE: NavNode[] = [
+  { id: 'nav_dashboard', type: 'page', label: '首页仪表盘', pageName: 'home', icon: 'layout_dashboard' },
+  { id: 'nav_customer', type: 'object', label: '客户', objectName: 'b2r4_customer', icon: 'building_2' },
+];
+
+/** …and AFTER: the copilot's follow-up table, already live in the registry. */
+const NAV_AFTER: NavNode[] = [
+  ...NAV_BEFORE,
+  { id: 'nav_b2r4_follow_up_record', type: 'object', label: '跟进记录', objectName: 'b2r4_follow_up_record' },
+];
+
+/**
+ * One mutable world both pillars read, flipped by `applyCopilotTurn()` — the
+ * server-side half of the scenario. The client itself is uncached
+ * (`cache: 'no-store'` on every `/meta/*` GET), so a re-read is all it takes.
+ */
+let world = { nav: NAV_BEFORE, objects: [{ name: 'b2r4_customer', label: '客户' }] };
+
+function applyCopilotTurn(): void {
+  world = {
+    nav: NAV_AFTER,
+    objects: [
+      { name: 'b2r4_customer', label: '客户' },
+      { name: 'b2r4_follow_up_record', label: '跟进记录' },
+    ],
+  };
+}
+
+const mockClient = {
+  list: vi.fn(async (type: string) => {
+    if (type === 'app') return [{ name: 'b2r4_app', label: '客户管理' }];
+    if (type === 'object') return world.objects;
+    return [];
+  }),
+  listDrafts: vi.fn(async () => []),
+  layered: vi.fn(async (type: string, name: string) => {
+    if (type === 'app') {
+      return { effective: { name: 'b2r4_app', label: '客户管理', navigation: world.nav } };
+    }
+    return { effective: { name, label: name, fields: [] }, code: { name, label: name, fields: [] } };
+  }),
+  getDraft: vi.fn(async () => null),
+  save: vi.fn(async () => ({})),
+  get: vi.fn(async () => undefined),
+};
+
+vi.mock('../metadata-admin/useMetadata', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('../metadata-admin/useMetadata')>();
+  return {
+    ...mod,
+    useMetadataClient: () => mockClient,
+    useMetadataTypes: () => ({ entries: [] }),
+  };
+});
+
+vi.mock('./packages-io', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('./packages-io')>();
+  return { ...mod, fetchPackages: vi.fn(async () => []) };
+});
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@object-ui/react')>();
+  return { ...mod, useAdapter: () => ({}) };
+});
+
+// The Data pillar's canvas is the runtime records grid; this test is about the
+// RAIL, so the grid is stubbed exactly as `DataPillar.gridProjection.test.tsx`
+// stubs it — same seam, no plugin-view tree dragged into this file's graph.
+vi.mock('@object-ui/plugin-view', async (importOriginal) => {
+  const mod = await importOriginal<Record<string, unknown>>();
+  return { ...mod, ObjectView: () => <div data-testid="grid-stub" /> };
+});
+
+import { emitMetadataRefresh } from '../../assistant/assistantBus.js';
+import { DataPillar, InterfacesPillar } from './StudioDesignSurface';
+import { SurfaceDeepLinkProvider } from './surfaceDeepLinkChannel';
+
+afterEach(() => {
+  cleanup();
+  world = { nav: NAV_BEFORE, objects: [{ name: 'b2r4_customer', label: '客户' }] };
+  vi.clearAllMocks();
+});
+
+describe('Studio rails converge on an AI copilot apply (objectui#7255)', () => {
+  it('Interfaces rail grows the new nav item on the pulse, in place', async () => {
+    render(
+      <MemoryRouter initialEntries={['/studio/b2r4/interfaces']}>
+        <InterfacesPillar packageId="b2r4" />
+      </MemoryRouter>,
+    );
+
+    // Baseline: the two blueprint items, and NOT the copilot's.
+    await screen.findByTitle('object · b2r4_customer');
+    expect(screen.queryByTitle('object · b2r4_follow_up_record')).toBeNull();
+
+    // The copilot turn lands server-side …
+    applyCopilotTurn();
+    // … and is still invisible until something tells this tree to re-read:
+    // the bug was that nothing did.
+    expect(screen.queryByTitle('object · b2r4_follow_up_record')).toBeNull();
+
+    await act(async () => {
+      emitMetadataRefresh();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTitle('object · b2r4_follow_up_record')).toBeInTheDocument(),
+    );
+    // Refresh, don't rebuild (AGENTS.md #8): the pre-existing entries are the
+    // same tree, not a remounted one — a `key=` bump would have blown away the
+    // rail and re-run the mount-time first-leaf selection.
+    expect(screen.getByTitle('object · b2r4_customer')).toBeInTheDocument();
+  });
+
+  it('Data rail grows the new object on the pulse', async () => {
+    render(
+      <MemoryRouter initialEntries={['/studio/b2r4/data']}>
+        <SurfaceDeepLinkProvider>
+          <DataPillar packageId="b2r4" />
+        </SurfaceDeepLinkProvider>
+      </MemoryRouter>,
+    );
+
+    // The objects rail lists labels (no title attribute), and the selected
+    // object's label also titles the canvas — so `getAllByText`, scoped by the
+    // assertion that the NEW label appears at all (it has no canvas presence
+    // until it is selected, which this test never does).
+    await screen.findAllByText('客户');
+    expect(screen.queryByText('跟进记录')).toBeNull();
+
+    applyCopilotTurn();
+    await act(async () => {
+      emitMetadataRefresh();
+    });
+
+    await waitFor(() => expect(screen.getAllByText('跟进记录').length).toBeGreaterThan(0));
+  });
+});

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.tsx
@@ -102,6 +102,7 @@ import { usePendingDrafts } from '../../preview/usePendingDrafts.js';
 import { emitMetadataRefresh, subscribeMetadataRefresh } from '../../assistant/assistantBus.js';
 import { formatMetadataError, formatPublishFailures, type PublishFailure } from './metadataError.js';
 import { loadPackageSurfaces } from './packageSurfaces.js';
+import { useMetadataRefreshNonce } from './useMetadataRefreshNonce.js';
 import { resolveSurface, findSurfaceInTree, type NavNode, type Surface } from './navSurface.js';
 import { useSurfaceDeepLink, resolveSurfaceDeepLink, type SurfaceTarget } from './useSurfaceDeepLink.js';
 import { SurfaceDeepLinkProvider, useRequestedSurface } from './surfaceDeepLinkChannel.js';
@@ -1253,6 +1254,14 @@ export function InterfacesPillar({
   );
   const [navHasDraft, setNavHasDraft] = React.useState(false);
   const [navSaving, setNavSaving] = React.useState<false | 'draft' | 'publish'>(false);
+  // objectui#7255 — the copilot dock shares this document, so a turn that
+  // staged/published metadata converges the rail here instead of waiting for a
+  // page reload. HELD while the nav editor has unsaved (or in-flight) edits:
+  // this pillar's load rehydrates `appDraft`, which IS the nav edit buffer, so
+  // an unheld pulse would overwrite the author mid-drag. The hold defers, it
+  // does not drop — autosave clears `navDirty` within a beat and the pulse
+  // lands then.
+  const metadataRefreshNonce = useMetadataRefreshNonce(navDirty || !!navSaving);
   const [current, setCurrent] = React.useState<Surface | null>(null);
   // `?surface=` capture + mirror — shared plumbing (see useSurfaceDeepLink).
   const initialSurface = useSurfaceDeepLink(current);
@@ -1359,16 +1368,26 @@ export function InterfacesPillar({
     return () => {
       cancelled = true;
     };
-  }, [client, packageId, publishNonce, draftNonce]);
+  }, [client, packageId, publishNonce, draftNonce, metadataRefreshNonce]);
 
   // Resolve THIS package's App → load its navigation tree. The query is scoped
   // to the package (`list('app', { packageId })`) so a design surface only ever
   // shows the current package's app — never another package's. `list()` sees
   // published metadata only, so a freshly-created (unpublished) app is found via
   // `listDrafts()` instead, keeping it designable before its first publish.
+  //
+  // objectui#7255 — which package we are resolving, so a RE-read of the same
+  // package (a publish, a draft save, a copilot pulse) refreshes in place while
+  // a genuine package switch still shows the loading state. Without this the
+  // status flapped `ready → loading → ready` on every pulse and the nav
+  // toolbar (gated on `ready`) blinked once per copilot turn: rebuilding UI for
+  // a data refresh, which is exactly what AGENTS.md Commandment #8 forbids.
+  const appIdentityRef = React.useRef<string | null>(null);
   React.useEffect(() => {
     let cancelled = false;
-    setAppStatus('loading');
+    const isSameApp = appIdentityRef.current === packageId;
+    appIdentityRef.current = packageId;
+    if (!isSameApp) setAppStatus('loading');
     (async () => {
       try {
         const published = (await client.list('app', { packageId })) as Array<Record<string, unknown>>;
@@ -1435,7 +1454,7 @@ export function InterfacesPillar({
     return () => {
       cancelled = true;
     };
-  }, [client, packageId, publishNonce, draftNonce]);
+  }, [client, packageId, publishNonce, draftNonce, metadataRefreshNonce]);
 
   const Preview = getMetadataPreview(current?.type ?? '');
   // Studio-canvas surface override: the SAME type can render as a different
@@ -2310,6 +2329,11 @@ export function DataPillar({
   const [railOpen, setRailOpen] = React.useState(false);
   const [objects, setObjects] = React.useState<Surface[]>([]);
   const [objectsLoaded, setObjectsLoaded] = React.useState(false);
+  // objectui#7255 — the copilot dock shares this document; a turn that staged
+  // or published metadata re-reads this rail in place. No hold is needed: the
+  // rail load only replaces the LIST (the per-object edit buffer is loaded by
+  // its own `loadedNameRef`-guarded effect and is never touched here).
+  const metadataRefreshNonce = useMetadataRefreshNonce();
   const [current, setCurrent] = React.useState<Surface | null>(null);
   // `?surface=object:<name>` capture + mirror — the app→Studio bridge
   // (ADR-0080, `appStudioObjectPath`) lands here with a specific object;
@@ -2478,7 +2502,7 @@ export function DataPillar({
     return () => {
       cancelled = true;
     };
-  }, [client, packageId, readOnly]);
+  }, [client, packageId, readOnly, metadataRefreshNonce]);
 
   React.useEffect(() => {
     if (!current) return;
@@ -3408,6 +3432,9 @@ export function AutomationsPillar({
   const isMobile = useIsMobile();
   const [railOpen, setRailOpen] = React.useState(false);
   const [flows, setFlows] = React.useState<Surface[]>([]);
+  // objectui#7255 — same live-pulse subscription as the sibling rails; this
+  // one only replaces the flow LIST, so it needs no edit-buffer hold either.
+  const metadataRefreshNonce = useMetadataRefreshNonce();
   const [current, setCurrent] = React.useState<Surface | null>(null);
   // `?surface=flow:<name>` capture + mirror — shared plumbing (see
   // useSurfaceDeepLink). No producer emits this link yet; honoring it keeps
@@ -3490,7 +3517,7 @@ export function AutomationsPillar({
     return () => {
       cancelled = true;
     };
-  }, [client, packageId, publishNonce]);
+  }, [client, packageId, publishNonce, metadataRefreshNonce]);
 
   const doCreateFlow = React.useCallback(
     async (label: string, name: string) => {
@@ -3855,6 +3882,9 @@ export function AccessPillar({
   // See DataPillar's rail — same mobile-overlay treatment for the permission-set list.
   const isMobile = useIsMobile();
   const [railOpen, setRailOpen] = React.useState(false);
+  // objectui#7255 — same live-pulse subscription as the sibling rails; this
+  // one only replaces the permission-set LIST, so no edit-buffer hold.
+  const metadataRefreshNonce = useMetadataRefreshNonce();
   const [perms, setPerms] = React.useState<
     Array<{ name: string; label: string; isDefault?: boolean }>
   >([]);
@@ -3977,8 +4007,9 @@ export function AccessPillar({
   React.useEffect(() => {
     void load();
     // Re-read after a package publish so drafts that went live collapse into
-    // the published rail (ADR-0086 P2).
-  }, [load, publishNonce]);
+    // the published rail (ADR-0086 P2), and on the live-metadata pulse so a
+    // copilot turn's permission set appears without a page reload (#7255).
+  }, [load, publishNonce, metadataRefreshNonce]);
 
   const doCreate = React.useCallback(
     async (label: string, name: string) => {

--- a/packages/app-shell/src/views/studio-design/useMetadataRefreshNonce.test.tsx
+++ b/packages/app-shell/src/views/studio-design/useMetadataRefreshNonce.test.tsx
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7255 — the pulse→dependency adapter the Studio rails read.
+ *
+ * Two properties are load-bearing and neither is visible from the pillar
+ * tests: a pulse must reach a consumer that is NOT holding, and a pulse that
+ * arrives DURING a hold must be deferred rather than dropped — the Interfaces
+ * pillar's load rehydrates the nav edit buffer, so the hold is the only thing
+ * standing between a background refresh and the author's unsaved drag.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, act, cleanup } from '@testing-library/react';
+
+import { emitMetadataRefresh } from '../../assistant/assistantBus.js';
+import { useMetadataRefreshNonce } from './useMetadataRefreshNonce.js';
+
+afterEach(cleanup);
+
+function Probe({ hold }: { hold: boolean }): React.ReactElement {
+  const nonce = useMetadataRefreshNonce(hold);
+  return <span data-testid="nonce">{nonce}</span>;
+}
+
+function nonce(): string {
+  return screen.getByTestId('nonce').textContent ?? '';
+}
+
+describe('useMetadataRefreshNonce', () => {
+  it('starts at 0 and advances on every pulse', () => {
+    render(<Probe hold={false} />);
+    expect(nonce()).toBe('0');
+
+    act(() => emitMetadataRefresh());
+    expect(nonce()).toBe('1');
+
+    act(() => emitMetadataRefresh());
+    expect(nonce()).toBe('2');
+  });
+
+  it('holds pulses back, then releases them coalesced when the hold lifts', () => {
+    const { rerender } = render(<Probe hold />);
+    expect(nonce()).toBe('0');
+
+    act(() => emitMetadataRefresh());
+    act(() => emitMetadataRefresh());
+    // Held: the consumer's dependency has not moved, so nothing refetched and
+    // nothing overwrote the edit buffer.
+    expect(nonce()).toBe('0');
+
+    rerender(<Probe hold={false} />);
+    // Deferred, not dropped — and two held pulses release as ONE refetch.
+    expect(nonce()).toBe('2');
+  });
+
+  it('stops advancing once unmounted', () => {
+    const { unmount } = render(<Probe hold={false} />);
+    unmount();
+    // No listener left behind: emitting after unmount must not throw or warn
+    // about setting state on an unmounted component.
+    expect(() => act(() => emitMetadataRefresh())).not.toThrow();
+  });
+});

--- a/packages/app-shell/src/views/studio-design/useMetadataRefreshNonce.ts
+++ b/packages/app-shell/src/views/studio-design/useMetadataRefreshNonce.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7255 — turn the assistant bus's live-metadata pulse into a render
+ * dependency the Studio pillars can list next to `publishNonce` / `draftNonce`.
+ *
+ * Why this exists: the Studio workbench and the AI copilot are the SAME
+ * document (the copilot is the right dock, ADR-0057 P3c). When a copilot turn
+ * stages or publishes metadata, `ChatPane` already announces it on the
+ * assistant bus (`emitMetadataRefresh()` — the same pulse `usePendingDrafts`
+ * and `MetadataProvider` converge on). The pillars' rails never listened, so a
+ * just-applied object / nav item stayed invisible until a full page reload.
+ * This hook is the missing half: the pulse becomes a number, the rails' load
+ * effects list it, and each refetch is exactly the package-scoped read that
+ * went stale — no polling, no remount, no `location.reload()`.
+ *
+ * `hold` is the edit-buffer guard. A pillar whose rail load also rehydrates an
+ * EDIT BUFFER (the Interfaces pillar re-reads `app` into `appDraft`, which the
+ * nav editor patches in place) must not let a background pulse overwrite
+ * unsaved work. Passing `hold` while the buffer is dirty defers the pulse
+ * rather than dropping it: the nonce advances the moment the hold lifts, so
+ * the rail still converges once the author's edits are saved. Coalescing is
+ * deliberate — several pulses during one hold release as a single refetch.
+ */
+
+import { useEffect, useState } from 'react';
+import { subscribeMetadataRefresh } from '../../assistant/assistantBus.js';
+
+/**
+ * A monotonic counter that advances on every live-metadata pulse.
+ *
+ * @param hold - while true, pulses are recorded but not released to consumers.
+ * @returns the released nonce — stable across renders until a pulse lands.
+ */
+export function useMetadataRefreshNonce(hold = false): number {
+  // Two counters, not one: `received` advances the instant the bus fires (a
+  // pulse is never lost to a hold), `released` is what consumers depend on.
+  const [received, setReceived] = useState(0);
+  const [released, setReleased] = useState(0);
+
+  useEffect(() => subscribeMetadataRefresh(() => setReceived((n) => n + 1)), []);
+
+  useEffect(() => {
+    if (hold) return;
+    // React bails out when the reducer returns the current value, so this is a
+    // no-op render-wise while no pulse is outstanding.
+    setReleased((cur) => (cur === received ? cur : received));
+  }, [hold, received]);
+
+  return released;
+}


### PR DESCRIPTION
Fixes #7255

## The bug

The Studio copilot is the RIGHT DOCK of the same document as the workbench (ADR-0057 P3c). When a copilot turn applied a new object and pushed a nav item into the app's `navigation`, the tenant registry had both — the object `active`, the item present in `sys_metadata` — and the workbench's left rail still showed the pre-apply tree. Only a full page reload surfaced it.

The channel was already there. `ChatPane` announces every authoring turn on the assistant bus (`emitMetadataRefresh()` — `AiChatPage.tsx`, both the "turn carried an authoring envelope" effect and the chat-card publish handler). What was missing was a subscriber: the four Studio pillar rails keyed their loads on `publishNonce` / `draftNonce` only, both of which are bumped by the workbench's OWN publish / draft-save buttons and by nothing the copilot does.

## The refresh channel, and why this one

The card requires a production-available channel and forbids a global poll. Of the three sanctioned options — same-page event, tool-result callback, existing query invalidation — this PR takes **the existing invalidation mechanism**, which happens to also be the same-page event:

- **It is production-safe by construction.** The assistant bus is an in-process module singleton; no route, no posture gate. Nothing here touches `/api/v1/dev/metadata-events`, the dev-only SSE stream #7257 taught to stop retrying once it 404s in production posture — that stream watches metadata FILES on the server's disk and has no production equivalent, which is exactly why that card shipped no replacement and named this bug as needing its own fix.
- **It is precise, not a poll.** The pulse fires only on turns whose tool results carried an authoring envelope (`draftReview` / `replayOutcome`) — an ordinary Q&A turn emits nothing. Each subscriber then re-reads exactly its own package-scoped queries (`list('app', { packageId })`, `list('object', { packageId })`, `listDrafts({ packageId, type })`). There is no timer anywhere in this diff.
- **It is already the convergence contract in this repo.** `usePendingDrafts` states it in writing: "every successful publish path calls `emitMetadataRefresh()` — that pulse, plus this hook, is the whole unification mechanism." `MetadataProvider` subscribes for the same reason. The rails were the outlier.

**A packageId payload on the pulse was considered and deliberately not added.** It would only pay off when Studio is open on package A while a pulse concerns package B — but the Studio dock's copilot is always scoped to the open package (`editPackageId={packageId}`), and the only cross-package producers (marketplace install, the full-page `/ai` console route) are not mounted alongside a Studio pillar. That is a declaration surface with no measured pull, against six call sites that could silently drift back to coarse. Contract-first cuts the other way here: the pulse is a producer-side fact ("the live registry changed"), and widening it to carry scope belongs in a card that has a consumer asking for the scope.

## The change

`useMetadataRefreshNonce(hold?)` turns the pulse into a load dependency the rails list beside `publishNonce` / `draftNonce`. Wired into all four pillars — Interfaces (nav tree + the nav inspector's object picker), Data (objects rail), Automations (flows rail), Access (permission-set rail). The card's acceptance is the nav rail; the other three are the same one-line subscription against the same producer, and leaving them out would reproduce this exact bug on the next object / flow / permission set an author asks the copilot for.

Two things the naive version gets wrong, both handled:

1. **The Interfaces load rehydrates an edit buffer.** It reads the app into `appDraft`, which IS what the nav editor patches. An unheld pulse would overwrite an author mid-drag. The hook therefore takes `hold` — passed as `navDirty || !!navSaving` — and **defers rather than drops**: the nonce advances the moment the hold lifts, so the rail still converges once autosave settles. Several pulses during one hold release as one refetch.
2. **Refresh data, don't rebuild UI (AGENTS.md #8).** That effect used to set `appStatus` back to `'loading'` on every run. With the pulse added, the nav toolbar (gated on `'ready'`) would have blinked once per copilot turn. It now only shows loading when the package identity actually changed; a re-read of the same package refreshes in place. Rail selection was already preserved (`setCurrent((cur) => cur ?? …)`), and nothing here bumps a `key=`.

## Out of scope, filed instead: the missing icon

Requirement 2 of the card ("AI-generated nav items have no icon") is a **producer** defect, filed as objectstack-ai/cloud#1858 with no assignee. Both objectui consumers already have a default-icon convention — `resolveIcon` falls back to `FileText` in the runtime sidebar, and the Studio `NavTree` falls back node icon → the object's own metadata icon → a type-generic glyph — so this is not "no icon renders", it is "a generic glyph next to two semantic ones". Picking a meaningful icon needs to know what the table is FOR, which only the blueprint / apply chain has; guessing from the label in the renderer would fossilize a second de-facto contract (Commandment #0.1). Not touched here.

## Verification

Ran at `c8534ddce` (the final commit).

**Targeted tests** — `pnpm exec vitest run packages/app-shell/src/views/studio-design/ packages/app-shell/src/assistant/` → `Test Files 48 passed (48) / Tests 257 passed (257)`. The wider first pass including `packages/app-shell/src/preview/` was `Test Files 60 passed (60) / Tests 353 passed (353)`.

New coverage:
- `StudioDesignSurface.aiApplyRefresh.test.tsx` — the card's scenario against a mutable server world: the Interfaces rail grows `跟进记录` and the Data rail grows the new object after `emitMetadataRefresh()`, in the SAME mounted tree (the pre-existing entries are asserted to survive, so a remount-based "fix" would not pass).
- `useMetadataRefreshNonce.test.tsx` — the hold semantics, which no pillar test can see: pulses during a hold are deferred and coalesced, not dropped.

**Reverse verification (ablation).** Committed first, then stripped `metadataRefreshNonce` from the two dep arrays under test. Mutation confirmed on disk before measuring, not by an editor exit code: the `metadataRefreshNonce]` occurrence count went 5 → 2 and the file hash moved `b2522f25` → `ba30689f`. Predicted direction was RED, and that is what happened — both acceptance tests failed (`Tests 2 failed | 3 passed`), while the three hook unit tests stayed green, which is the correct split: they measure the adapter, not the wiring. No rebuild leg is claimed or needed — the test imports `./StudioDesignSurface` as a sibling source module, so the mutated bytes ARE what ran. Restore was `git checkout HEAD -- <path>` under an EXIT/INT/TERM trap with an absolute repo root, and is proven by state, not exit code: `git diff HEAD` empty, working tree clean, on-disk hash back to `b2522f25d375f1b7b3fc08309c3acd133a66e0c2` = the HEAD blob, occurrence count back to 5. The suites above were then re-run on the restored tree.

**Type-check** — `pnpm --filter @object-ui/app-shell type-check` → exit 0, after building the dependency closure (`pnpm --filter '@object-ui/app-shell^...' build`, exit 0); without it the run was 20+ phantom `TS2307 Cannot find module '@object-ui/*'`. Both new test files are genuinely covered rather than excluded: `tsc -p tsconfig.test.json --listFiles` names them, and the first run actually caught a real widening error in the nav fixture.

**Lint** — full repo `pnpm lint` (`eslint . --no-inline-config`), not a narrowed run: `Tasks: 47 successful, 47 total` / `Cached: 0 cached, 47 total`, `0 errors` (2877 pre-existing `no-explicit-any` warnings, none in this diff).

**Gates**, each read from its own verdict line with the exit code captured before any pipe:
- `check:control-bytes` — `OK (scanned 6075 tracked text file(s); skipped 85 binary)`
- `check:i18n-keys` — every in-scope call-site key resolves against the en pack; no new keys added
- `check:i18n-drift` — `0 en value(s) changed` in this range
- `check:vi-mock-specifiers` / `check:vi-mock-inherit` — OK (this diff adds `vi.mock` call sites, so both apply)
- `check:self-import`, `check:phantom-deps`, `check:side-effects-array`, `check:entry-guard`, `check:icon-record-names` — OK
- `check-changeset-presence` — `1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`; `check-changeset-no-major` — OK (`minor`)
- `check:eager-closure` — NOT MEASURED locally: it needs `apps/console/dist/eager-closure.json`, which a local run has no build for; it reports itself as a broken gauge rather than a verdict. CI has the artifact.

`packages/i18n` and the marketplace surfaces are untouched; the file surface is disjoint from #7372 and #7371.

_Generated by [Claude Code](https://claude.ai/code/session_c5c0ce54-bb9c-478c-9e5b-cf44b80d4569)_