### PR TITLE
fix(plugin-charts): draw every categorical x-axis label on short axes

### DIFF
--- a/.changeset/khaki-rocks-shout.md
+++ b/.changeset/khaki-rocks-shout.md
@@ -1,0 +1,22 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+Draw every categorical x-axis label on short axes
+
+A vertical bar chart in a dashboard-width widget dropped most of its x-axis
+labels — three bars drew one label, five bars drew two — leaving the bars
+unnamed, with no legend to fall back on because a single-series bar chart has
+none.
+
+The x axis applied one tick policy to time and category alike (`preserveStartEnd`
+with a 48px `minTickGap`), which is right for hundreds of dates and wrong for a
+band axis, where a dropped tick is an identity the reader cannot recover rather
+than a sample they can interpolate. It was also keyed to the viewport rather
+than the widget, so a 200px chart inside an 800px console was treated as a wide
+one.
+
+Bar, column, line, area and combo charts now draw every label on a categorical
+x axis of five buckets or fewer — rotating, and ellipsising an over-long name
+rather than clipping it. Longer axes keep the existing measured thinning, and
+horizontal bars are unchanged.

--- a/packages/plugin-charts/src/AdvancedChartImpl.categoricalAxisDensity.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.categoricalAxisDensity.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#7247 — a vertical bar chart in a dashboard-width widget dropped most
+ * of its categorical x-axis labels: 3 bars drew 1 label, 5 bars drew 2, so the
+ * bars had no names and a single-series bar chart has no legend to fall back
+ * on. The x axis carried a TIME-series thinning policy (`preserveStartEnd` +
+ * `minTickGap: 48`) that is correct for hundreds of dates and wrong for a band
+ * axis, where a dropped tick is an unrecoverable identity rather than a
+ * skippable sample.
+ *
+ * The width is injected the way the sibling axis test does it — recharts'
+ * `ResponsiveContainer` measures a real box, and happy-dom has no layout — so
+ * these render at the exact widget widths the report names.
+ */
+import React from 'react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+/** Widget width under test, in px. Read at render time by the mock below. */
+let containerWidth = 200;
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: containerWidth, height: 260 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(() => {
+  cleanup();
+  containerWidth = 200;
+});
+
+/**
+ * The drawn tick labels of one axis. Recharts renders tick text into a
+ * z-index layer OUTSIDE the `.recharts-xAxis` group, so this selects by the
+ * per-axis `*-tick-labels` class rather than by descent from the axis.
+ */
+function tickLabels(container: HTMLElement, axis: 'x' | 'y'): string[] {
+  return Array.from(
+    container.querySelectorAll(
+      `.recharts-${axis}Axis-tick-labels .recharts-cartesian-axis-tick-value`,
+    ),
+  ).map((n) => (n.textContent || '').trim());
+}
+
+const STATUSES = ['Backlog', 'To Do', 'In Progress', 'In Review', 'Done'];
+const TASKS_BY_STATUS = STATUSES.map((status, i) => ({ status, count: 5 - i }));
+const PROJECTS_BY_HEALTH = ['Green', 'Yellow', 'Red'].map((health, i) => ({ health, count: 4 - i }));
+const TASKS_BY_PRIORITY = ['Low', 'Normal', 'High', 'Urgent'].map((priority, i) => ({ priority, count: i + 1 }));
+
+function renderBar(data: any[], xAxisKey: string, chartType: 'bar' | 'horizontal-bar' = 'bar') {
+  return render(
+    <AdvancedChartImpl
+      chartType={chartType}
+      data={data}
+      xAxisKey={xAxisKey}
+      series={[{ dataKey: 'count', label: 'Count' }]}
+    />,
+  );
+}
+
+describe('AdvancedChartImpl — categorical x-axis label density (objectui#7247)', () => {
+  it('names every bar of a 5-bucket chart at a 200px dashboard widget width', () => {
+    const { container } = renderBar(TASKS_BY_STATUS, 'status');
+    expect(tickLabels(container, 'x')).toEqual(STATUSES);
+  });
+
+  it('names every bar of a 3-bucket chart at a 200px dashboard widget width', () => {
+    const { container } = renderBar(PROJECTS_BY_HEALTH, 'health');
+    expect(tickLabels(container, 'x')).toEqual(['Green', 'Yellow', 'Red']);
+  });
+
+  it('names every bar of a 4-bucket chart at a 200px dashboard widget width', () => {
+    const { container } = renderBar(TASKS_BY_PRIORITY, 'priority');
+    expect(tickLabels(container, 'x')).toEqual(['Low', 'Normal', 'High', 'Urgent']);
+  });
+
+  it('keeps every label for line and area charts on the same short categorical axis', () => {
+    for (const chartType of ['line', 'area'] as const) {
+      const { container } = render(
+        <AdvancedChartImpl
+          chartType={chartType}
+          data={TASKS_BY_STATUS}
+          xAxisKey="status"
+          series={[{ dataKey: 'count', label: 'Count' }]}
+        />,
+      );
+      expect(tickLabels(container, 'x')).toEqual(STATUSES);
+      cleanup();
+    }
+  });
+
+  it('ellipsises a rotated label instead of letting it overrun the axis height', () => {
+    const { container } = renderBar(
+      [
+        { status: 'Waiting on customer', count: 3 },
+        { status: 'Done', count: 1 },
+      ],
+      'status',
+    );
+    // 12 chars kept, the 12th replaced by the ellipsis (see
+    // ROTATED_X_LABEL_MAX_CHARS) — a shortened name, never a missing one.
+    expect(tickLabels(container, 'x')).toEqual(['Waiting on …', 'Done']);
+  });
+
+  it('still thins a high-cardinality axis, so hundreds of buckets cannot pile up', () => {
+    const many = Array.from({ length: 24 }, (_, i) => ({
+      day: `2026-01-${String(i + 1).padStart(2, '0')}`,
+      count: i,
+    }));
+    const { container } = render(
+      <AdvancedChartImpl
+        chartType="line"
+        data={many}
+        xAxisKey="day"
+        series={[{ dataKey: 'count', label: 'Count' }]}
+      />,
+    );
+    const drawn = tickLabels(container, 'x');
+    expect(drawn.length).toBeGreaterThan(0);
+    expect(drawn.length).toBeLessThan(many.length);
+  });
+
+  it('does not regress the horizontal bar family, whose category axis is y', () => {
+    const { container } = renderBar(TASKS_BY_STATUS, 'status', 'horizontal-bar');
+    expect(tickLabels(container, 'y')).toEqual(STATUSES);
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -1046,6 +1046,49 @@ function AdvancedChartImplInner({
     [data, xAxisKey],
   );
 
+  // objectui#7247 — a CATEGORICAL x axis with few buckets draws every label.
+  //
+  // On a band (categorical) axis a tick is the bar's NAME, not a sample of a
+  // continuum: drop it and the reader cannot recover it, because there is
+  // nothing to interpolate between neighbours and a single-series bar chart has
+  // no legend to fall back on. On a time axis the opposite holds — a reader
+  // reconstructs the skipped dates — which is why the thinning policy below is
+  // right there and wrong here. Measured in the dashboard shape (3-column grid
+  // in an ~800px console, widget ≈200px): 3 bars drew 1 label, 5 bars drew 2.
+  //
+  // Where the bound comes from (so it is a derivation, not a taste):
+  //
+  //   plot width at the narrowest shipped widget
+  //     = 200 (widget) − 48 (`YAxis width`, below) − 5 − 5 (chart margins) = 142px
+  //   rotated tick labels are PARALLEL lines, so adjacent ones collide only
+  //   when their perpendicular separation drops under one line box:
+  //     separation = bandWidth · sin(35°) = 0.574 · (142 / buckets)
+  //   one 12px line box ≈ 14px  ⇒  buckets ≤ 5.8
+  //
+  // So at 5 buckets or fewer every label is guaranteed to fit at the narrowest
+  // width the product ships, with no measurement — which is why `interval={0}`
+  // is safe HERE and was not safe as the blanket setting it used to be (a
+  // hundreds-of-points series painted a dense black bar). Above the bound
+  // nothing changes: recharts keeps thinning against its own measured text.
+  const X_AXIS_ALL_LABELS_MAX_BUCKETS = 5;
+
+  /**
+   * Longest rotated x label kept before it is ellipsised, so a label this
+   * branch newly forces into view cannot overrun the 60px the axis reserves:
+   * 12 chars ≈ 78px of text, × sin(35°) ≈ 45px of height, inside 60 − 10
+   * (`tickMargin`). Scoped to the forced branch — charts above the bound keep
+   * rendering their labels exactly as before.
+   */
+  const ROTATED_X_LABEL_MAX_CHARS = 12;
+
+  /** Every bucket gets a name (see the derivation above). */
+  const labelEveryBucket = data.length > 0 && data.length <= X_AXIS_ALL_LABELS_MAX_BUCKETS;
+
+  // Rotation is what BUYS the complete axis, so in the forced branch it applies
+  // on mobile too: drawing every label without rotating is the horizontal
+  // overlap the old thinning avoided. Above the bound the trigger is unchanged.
+  const rotateXLabels = labelEveryBucket ? hasLongLabels : (!isMobile && hasLongLabels);
+
   // Helper function to get color palette. An explicit `colors` prop (set by the
   // page/dashboard) wins; otherwise fall back to the theme's --chart-1..5 vars.
   const getPalette = () => (Array.isArray(colors) && colors.length > 0 ? colors : [

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -334,6 +334,46 @@ const CATEGORY_AXIS_CHART_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Bucket count at or below which a CATEGORICAL x axis draws EVERY label
+ * (objectui#7247).
+ *
+ * On a band axis a tick is the bar's NAME, not a sample of a continuum: drop it
+ * and the reader cannot recover it — there is nothing to interpolate between
+ * neighbours, and a single-series bar chart has no legend to fall back on. On a
+ * time axis the opposite holds (a reader reconstructs the skipped dates), which
+ * is why `xAxisCommonProps`' thinning is right there and wrong here. Measured
+ * in the dashboard shape — a 3-column grid in an ~800px console, so a widget
+ * ≈200px wide: 3 bars drew 1 label, 5 bars drew 2, and the bars had no names.
+ *
+ * Where the bound comes from, so it is a derivation and not a taste:
+ *
+ *   plot width at the narrowest shipped widget
+ *     = 200 (widget) − 48 (the `YAxis width` this file sets) − 5 − 5 (recharts'
+ *       default left/right chart margin) = 142px
+ *   rotated tick labels are PARALLEL lines, so two adjacent ones collide only
+ *   once their PERPENDICULAR separation drops below one line box:
+ *     separation = bandWidth · sin(35°) = 0.574 · (142 / buckets)
+ *   a 12px line box ≈ 14px tall  ⇒  buckets ≤ 5.8
+ *
+ * At 5 buckets or fewer every label therefore fits at the narrowest width the
+ * product ships, with nothing measured at runtime — which is what makes
+ * `interval={0}` safe HERE though it was not safe as the blanket setting it
+ * used to be (a hundreds-of-points series painted a dense black bar). Above the
+ * bound nothing changes: recharts goes on thinning against its own measured
+ * text widths, using the real rendered width rather than this worst case.
+ */
+const X_AXIS_ALL_LABELS_MAX_BUCKETS = 5;
+
+/**
+ * Longest rotated x-axis label kept before it is ellipsised, so a label the
+ * bound above newly forces into view cannot overrun the 60px the axis reserves:
+ * 12 chars ≈ 78px of text, × sin(35°) ≈ 45px of height, inside 60 − 10
+ * (`tickMargin`). Deliberately scoped to that branch — charts above the bound
+ * render their labels exactly as they did before.
+ */
+const ROTATED_X_LABEL_MAX_CHARS = 12;
+
+/**
  * Treemap leaf cell — paints each leaf rect with its palette fill + label.
  * Hoisted to module scope so it is a stable component reference rather than one
  * re-created on every AdvancedChartImpl render (react-hooks/static-components).
@@ -1046,42 +1086,8 @@ function AdvancedChartImplInner({
     [data, xAxisKey],
   );
 
-  // objectui#7247 — a CATEGORICAL x axis with few buckets draws every label.
-  //
-  // On a band (categorical) axis a tick is the bar's NAME, not a sample of a
-  // continuum: drop it and the reader cannot recover it, because there is
-  // nothing to interpolate between neighbours and a single-series bar chart has
-  // no legend to fall back on. On a time axis the opposite holds — a reader
-  // reconstructs the skipped dates — which is why the thinning policy below is
-  // right there and wrong here. Measured in the dashboard shape (3-column grid
-  // in an ~800px console, widget ≈200px): 3 bars drew 1 label, 5 bars drew 2.
-  //
-  // Where the bound comes from (so it is a derivation, not a taste):
-  //
-  //   plot width at the narrowest shipped widget
-  //     = 200 (widget) − 48 (`YAxis width`, below) − 5 − 5 (chart margins) = 142px
-  //   rotated tick labels are PARALLEL lines, so adjacent ones collide only
-  //   when their perpendicular separation drops under one line box:
-  //     separation = bandWidth · sin(35°) = 0.574 · (142 / buckets)
-  //   one 12px line box ≈ 14px  ⇒  buckets ≤ 5.8
-  //
-  // So at 5 buckets or fewer every label is guaranteed to fit at the narrowest
-  // width the product ships, with no measurement — which is why `interval={0}`
-  // is safe HERE and was not safe as the blanket setting it used to be (a
-  // hundreds-of-points series painted a dense black bar). Above the bound
-  // nothing changes: recharts keeps thinning against its own measured text.
-  const X_AXIS_ALL_LABELS_MAX_BUCKETS = 5;
-
-  /**
-   * Longest rotated x label kept before it is ellipsised, so a label this
-   * branch newly forces into view cannot overrun the 60px the axis reserves:
-   * 12 chars ≈ 78px of text, × sin(35°) ≈ 45px of height, inside 60 − 10
-   * (`tickMargin`). Scoped to the forced branch — charts above the bound keep
-   * rendering their labels exactly as before.
-   */
-  const ROTATED_X_LABEL_MAX_CHARS = 12;
-
-  /** Every bucket gets a name (see the derivation above). */
+  // objectui#7247 — see X_AXIS_ALL_LABELS_MAX_BUCKETS for why a short
+  // categorical axis draws every label instead of thinning like a time axis.
   const labelEveryBucket = data.length > 0 && data.length <= X_AXIS_ALL_LABELS_MAX_BUCKETS;
 
   // Rotation is what BUYS the complete axis, so in the forced branch it applies
@@ -1132,6 +1138,26 @@ function AdvancedChartImplInner({
     () => formatterFor(xAxisSpec?.format) ?? formatTick,
     [xAxisSpec?.format, formatTick],
   );
+
+  /**
+   * The x-axis formatter, plus the ellipsis step objectui#7247's label policy
+   * owes: once every bucket is drawn, a long rotated name would run past the
+   * 60px the axis reserves and be clipped mid-word. A shortened name is still
+   * a name; a clipped one reads as a different category.
+   *
+   * Kept separate from `xTickFormatter` on purpose — that one also formats the
+   * horizontal-bar family's CATEGORY axis, which is the y axis, sizes its own
+   * width from the longest label, and already draws all of them.
+   */
+  const xAxisTickFormatter = React.useMemo(() => {
+    if (!labelEveryBucket || !rotateXLabels) return xTickFormatter;
+    return (value: any): string => {
+      const label = String(xTickFormatter(value) ?? '');
+      return label.length > ROTATED_X_LABEL_MAX_CHARS
+        ? `${label.slice(0, ROTATED_X_LABEL_MAX_CHARS - 1)}…`
+        : label;
+    };
+  }, [labelEveryBucket, rotateXLabels, xTickFormatter]);
   const yTickFormatter = React.useMemo(
     () => formatterFor(primaryY?.format) ?? formatYTick,
     [primaryY?.format, formatYTick],
@@ -1244,20 +1270,27 @@ function AdvancedChartImplInner({
       ? <LabelList position="top" className="fill-foreground" fontSize={11} {...(formatter ? { formatter } : {})} />
       : null;
 
-  // Shared X-axis props for time/categorical axes. Recharts' `minTickGap`
-  // automatically thins ticks that would otherwise overlap, so we no
-  // longer hard-code `interval={0}` (which forced every label and
-  // produced a dense black bar when data spanned hundreds of points).
+  // Shared X-axis props for time/categorical axes, in two branches.
+  //
+  // Above X_AXIS_ALL_LABELS_MAX_BUCKETS, recharts' `minTickGap` thins ticks
+  // that would otherwise overlap — `interval={0}` is NOT hard-coded there,
+  // because forcing every label painted a dense black bar when the data spanned
+  // hundreds of points. At or below the bound the reverse is true and thinning
+  // is the bug (objectui#7247): the axis is short enough that every label is
+  // provably drawable, and each one is a bar's only name.
   const xAxisCommonProps = React.useMemo(() => ({
     tickLine: false as const,
     tickMargin: 10,
     axisLine: false as const,
-    interval: 'preserveStartEnd' as const,
-    minTickGap: isMobile ? 32 : 48,
-    tickFormatter: xTickFormatter,
+    // A short categorical axis names every bucket; everything above the bound
+    // keeps the time-series thinning, which is what `minTickGap` is for.
+    ...(labelEveryBucket
+      ? { interval: 0 as const }
+      : { interval: 'preserveStartEnd' as const, minTickGap: isMobile ? 32 : 48 }),
+    tickFormatter: xAxisTickFormatter,
     ...(xAxisSpec?.title ? { label: { value: xAxisSpec.title, position: 'insideBottom' as const, offset: -4 } } : {}),
-    ...(!isMobile && hasLongLabels && { angle: -35, textAnchor: 'end' as const, height: 60 }),
-  }), [isMobile, hasLongLabels, xTickFormatter, xAxisSpec?.title]);
+    ...(rotateXLabels && { angle: -35, textAnchor: 'end' as const, height: 60 }),
+  }), [isMobile, labelEveryBucket, rotateXLabels, xAxisTickFormatter, xAxisSpec?.title]);
 
   // #2942 — the non-series spec families used to fall through the component
   // map's `|| BarChart` into a bar shell whose series marks all returned


### PR DESCRIPTION
Fixes #7247

## The defect

`AdvancedChartImpl`'s shared x-axis props applied one tick policy to time and
category axes alike — `interval: 'preserveStartEnd'` with `minTickGap: 48` —
which is correct for hundreds of dates and wrong for a band axis. On a
categorical axis a tick is the bar's **name**: drop it and the reader cannot
recover it, because there is nothing to interpolate between neighbours and a
single-series bar chart has no legend to fall back on.

Two aggravating details found while reproducing it:

- the policy is keyed to the **viewport** (`isMobile = window.innerWidth < 640`),
  never to the widget, so a 174px chart inside an 800px console was treated as a
  wide desktop chart and charged the full 48px inter-label gap;
- the horizontal-bar family escapes precisely because its category axis is the
  **y** axis, which uses recharts' defaults (`minTickGap` 5) and keeps every
  label — the same data, the same widget, a complete axis.

## The change

A categorical x axis of `X_AXIS_ALL_LABELS_MAX_BUCKETS` (5) buckets or fewer now
draws every label (`interval={0}`), rotating so they fit and ellipsising an
over-long name rather than letting it clip. Above the bound nothing changes:
recharts keeps thinning against its own measured text widths.

The bound is derived rather than chosen, and the derivation is in the code:

```
plot width at the narrowest shipped widget
  = 200 (widget) - 48 (the YAxis width this file sets) - 5 - 5 (chart margins)
  = 142px
rotated tick labels are PARALLEL lines, so two adjacent ones collide only once
their PERPENDICULAR separation drops below one line box:
  separation = bandWidth * sin(35deg) = 0.574 * (142 / buckets)
a 12px line box is about 14px tall  =>  buckets <= 5.8
```

So at 5 buckets or fewer every label is guaranteed to fit at the narrowest width
the product ships, with nothing measured at runtime — which is what makes
`interval={0}` safe here though it was not safe as the blanket setting it used
to be (a hundreds-of-points series painted a dense black bar). That guard is
pinned by a test.

## Change surface, declared

- **Changed** — `xAxisCommonProps` in `packages/plugin-charts/src/AdvancedChartImpl.tsx`,
  which is the x axis of the **bar / column, line, area and combo** families
  (its two call sites). The new truncating formatter is deliberately a separate
  memo from `xTickFormatter`, because that one also formats the horizontal-bar
  family's category axis.
- **Already compliant** — `packages/plugin-charts/src/ChartImpl.tsx`, the simpler
  bar renderer, already hard-codes `interval={0}` with an angled tick and says
  why in a comment. Untouched.
- **Already compliant** — the horizontal-bar category axis (the `YAxis type="category"`
  branch), which sizes its own width from the longest label and draws all of
  them. Untouched, and pinned by a no-regression test.
- **Out of scope** — the scatter axes (numeric on both sides; #7248 covers that
  family and is deliberately not part of this change), and the three polish items
  the issue lists as ride-along candidates: fractional ticks on integer count
  y-axes, radar and funnel label clipping, and the sankey's missing node labels.
  None is the same defect, and each needs its own evidence.
- **Deliberately NOT done here** — relaxing `minTickGap: 48` for categorical axes
  **above** the bound. It is the same root cause and would help a 6-plus bucket
  chart at 290px, but the right replacement value is a judgement call rather
  than something existing evidence pins, and its effect is not measurable in
  this repo's DOM test environment (happy-dom reports zero text metrics, so
  recharts' size-based thinning cannot be observed there — any test asserting it
  would be a phantom). Filed separately instead.

## Browser verification

ObjectUI console dev server against the showcase runtime on :3911, Chromium at
an 800px viewport — the three-column dashboard grid, so each chart's measured
plot box is **174px** wide. Counted from the DOM
(`.recharts-xAxis-tick-labels .recharts-cartesian-axis-tick-value`), not by eye.

Before was measured by checking the one changed file back out to `origin/main`
in the same worktree, with the fix already committed, and letting HMR reload;
the file was then restored from `HEAD` and the restore proven by hash (see
Verification below).

| widget | bars | x labels BEFORE | x labels AFTER |
|---|---|---|---|
| Delivery Operations -> Projects by Health | 3 | 1 — `Yellow` | **3** — `Green`, `Red`, `Yellow` |
| Delivery Operations -> Tasks by Status | 5 | 2 — `Backlog`, `To Do` | **5** — `Backlog`, `Done`, `In Progress`, `In Review`, `To Do` |
| Chart Gallery -> Tasks by Status | 5 | 2 — `Backlog`, `To Do` | **5** — all |
| Chart Gallery -> Tasks by Priority | 4 | 2 — `High`, `Urgent` | **4** — `High`, `Low`, `Medium`, `Urgent` |
| Chart Gallery -> Hours by Status (horizontal) | 5 | 5 — all | 5 — all (unchanged) |
| Chart Gallery -> report chart at 654px | 3 | 3 — all | 3 — all (unchanged) |

The BEFORE column reproduces the issue's table exactly, at the same widths.

## Verification

Everything below ran on the final commit, `git rev-parse --short HEAD` =
`200063bc9`.

- `pnpm exec vitest run packages/plugin-charts/` — `Test Files 41 passed (41)`,
  `Tests 383 passed (383)`
- `pnpm --filter @object-ui/plugin-charts type-check` — exit 0 (`tsc --noEmit`
  echoed, so this is a real run and not a zero-match filter). Confirmed with
  `tsc --listFiles` that the new test file **is** in the type-check's file set.
- `pnpm --filter @object-ui/plugin-charts lint` — exit 0,
  `303 problems (0 errors, 303 warnings)`, all pre-existing
- `node scripts/check-control-bytes.mjs` — `OK (scanned 6044 tracked text file(s))`
- `node scripts/check-vi-mock-specifiers.mjs`, `check-vi-mock-inherit.mjs` — both OK
  (this PR adds a `vi.mock('recharts')` call site)
- `node scripts/check-changeset-fixed.mjs`, `check-changeset-no-major.mjs` — both OK

**Reverse verification.** The regression test was written and run *against the
unfixed source*, before the policy existed: 5 of its 7 cases failed, with the
received values naming the missing labels —

```
expected [ 'Green', 'Red' ]                        to deeply equal [ 'Green', 'Yellow', 'Red' ]
expected [ 'Low', 'Urgent' ]                       to deeply equal [ 'Low', 'Normal', 'High', 'Urgent' ]
expected [ 'Backlog', 'In Progress', 'Done' ]      to deeply equal [ 'Backlog', 'To Do', ...(3) ]
expected [ 'Waiting on customer', 'Done' ]         to deeply equal [ 'Waiting on ...', 'Done' ]
```

The other 2 cases — high-cardinality thinning, and the horizontal family —
passed **both** before and after, which is the point of them: they pin behaviour
this change must not move. The dependency closure
(`pnpm --filter '@object-ui/plugin-charts^...' build`) was built once before the
red run and not rebuilt between red and green, and the subject under test is
imported from source, so both runs read the same tree.

The browser before/after used the sanctioned mutate-then-restore shape: the fix
was committed first, the mutation was `git checkout origin/main -- FILE` and was
confirmed on disk by blob hash (`2acc581d3` to `aceb44fcb`) plus a zero count of
the new policy identifier, and the restore was `git checkout HEAD -- FILE`,
proven by the on-disk hash matching the HEAD blob exactly and `git diff HEAD`
being empty.

**Declared narrowing — verification ran UNLOCKED.** `scripts/pm/os-verify-lock.sh`
could not take the shared verify lock on this host: no usable `flock`. The shared
verify lock is declared Linux-only (`flock` is util-linux, and a stock macOS does
not ship it), so the command below was run directly, without the lock —
a declared narrowing, not a silent one. No serialization guarantee held for this
run, nor for any sibling agent in this container while it ran.

**Declared deviation — the dispatched test command does not work in this repo.**
`pnpm --filter @object-ui/plugin-charts exec vitest run FILE` is *refused* by
this repo's own invocation guard (objectui#3378): a package-cwd vitest run
resolves the root projects to nothing, runs `@object-ui/console`'s 22 files
instead, and reports them green. Every run above was therefore started from the
repository root, which is what CI does.

**Lint scope.** Lint here is `turbo run lint`, i.e. a per-package `eslint .`, and
this diff touches exactly one package — so the package's own lint run above is
the whole lint surface of the change, not a narrowing. No cross-package or
type-aware rule is configured that could move another package's verdict from a
file in this one.

_Generated by [Claude Code](https://claude.ai/code/session_62849a16-0144-4728-8942-9f60bb3a73f1)_
