### PR TITLE
test(app-shell): pin the shared inbox feed's one declared cadence (#7249)

### DIFF
--- a/.changeset/tidy-pugs-invent.md
+++ b/.changeset/tidy-pugs-invent.md
@@ -1,0 +1,4 @@
+---
+---
+
+Pin the shared inbox feed's cadence (objectui#7249): one declared poll interval owned by the feed, however many consumers mount, plus the hidden-tab throttle and the return-to-tab refresh. Tests only — no runtime change, nothing to release.

--- a/packages/app-shell/src/hooks/__tests__/sharedInboxFeed.cadence-7249.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/sharedInboxFeed.cadence-7249.test.tsx
@@ -47,10 +47,17 @@
  * ## Reverse verification (prediction first, measured in this PR)
  *
  *   - set `INBOX_POLL_MS` to 2_000 — the cadence the card reported — and the
- *     two counting cases go RED (25 reads against the bound of 7) while every
- *     other inbox pin, `twoSurfaces` included, stays GREEN. That asymmetry is
- *     the point: it is the exact defect the card described, and the existing
- *     suite cannot see it.
+ *     three counting cases go RED (`expected 31 to be 7`, and `expected 32 to
+ *     be 8` for the return-to-tab window) while every other inbox pin,
+ *     `twoSurfaces` included, stays GREEN: 1 file failed, 1 passed, 3 tests
+ *     failed of 18. That asymmetry is the point — it is the exact defect the
+ *     card described, and the existing suite cannot see it. Predicted two red
+ *     cases and measured three: the return-to-tab case counts a window too, so
+ *     it fails on the same arithmetic.
+ *   - the hidden-tab case stays GREEN under that same mutation, correctly: the
+ *     backgrounded delay is `max(HIDDEN_POLL_MS, backoff)`, which a faster
+ *     FOREGROUND constant cannot move. It pins a different clock, which is why
+ *     it is a separate case.
  *   - give `useHomeInbox` a second scheduler of its own and
  *     "one feed's cadence, not one per consumer" goes RED while the single-
  *     consumer case stays green — a second scheduler is not a faster one.

--- a/packages/app-shell/src/hooks/__tests__/sharedInboxFeed.cadence-7249.test.tsx
+++ b/packages/app-shell/src/hooks/__tests__/sharedInboxFeed.cadence-7249.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * objectui#7249 — ONE cadence, owned by the shared feed, however many consumers
+ * mount.
+ *
+ * ## What the card reported, and what was actually measured
+ *
+ * The card reported the console HOME issuing the inbox pair
+ * (`sys_inbox_message?top=20` + `sys_notification_receipt?top=200`) every
+ * **2000 ms** — five times `INBOX_POLL_MS` — against ~10 s on an app page, and
+ * read that asymmetry as a second scheduler on Home racing the shared feed.
+ *
+ * Re-measured against the same backend (showcase, objectstack `main`), signed in
+ * as the same seeded admin, in a controlled Playwright context — 60 s idle,
+ * every request to the two reads recorded:
+ *
+ *   | surface                                   | inbox pairs / 60 s | gaps (ms)     |
+ *   | ----------------------------------------- | ------------------ | ------------- |
+ *   | `/_console/home` (the card's own URL)     | 6                  | 10054-10077   |
+ *   | `/home` on this package's dev build       | 6                  | 10042-10089   |
+ *   | `/home`, after 4x home<->app route churn  | 6                  | 10074-10091   |
+ *   | `/home`, tab hidden                       | 1                  | (60 s)        |
+ *
+ * The 2 s cadence did not reproduce on any of them, and `approvals/requests`
+ * held its own 30 s. There is no second scheduler: `useHomeInbox` and
+ * `useInboxBell` both fetch nothing, and `useClientNotifications` — the other
+ * candidate — has no call sites in this repo at all.
+ *
+ * ## Why a pin, then, if nothing is broken
+ *
+ * Because "one cadence, owned by the shared feed" was true only by measurement,
+ * and nothing in the suite said so. The neighbouring pins
+ * (`sharedInboxFeed.twoSurfaces`) assert the MOUNT-time dedupe — one read for
+ * the bell and Home together, a late consumer served without re-reading — which
+ * is a different claim: it is satisfied by any number of schedulers that happen
+ * to agree on the first tick. Nothing advanced a clock and counted, so a
+ * consumer that grew its own `setInterval` would have kept every existing pin
+ * green and cost a browser dogfood to find. It cost one here.
+ *
+ * That is the whole content of this file: the cadence is a property of the FEED,
+ * not of how many consumers mount or which page they mount on, and it is now
+ * enforced rather than measured. #4197 / #4225 / #4316 each fought for one read
+ * feeding both surfaces; this is the clock-domain half of that invariant.
+ *
+ * ## Reverse verification (prediction first, measured in this PR)
+ *
+ *   - set `INBOX_POLL_MS` to 2_000 — the cadence the card reported — and the
+ *     two counting cases go RED (25 reads against the bound of 7) while every
+ *     other inbox pin, `twoSurfaces` included, stays GREEN. That asymmetry is
+ *     the point: it is the exact defect the card described, and the existing
+ *     suite cannot see it.
+ *   - give `useHomeInbox` a second scheduler of its own and
+ *     "one feed's cadence, not one per consumer" goes RED while the single-
+ *     consumer case stays green — a second scheduler is not a faster one.
+ */
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+let userFixture: { id: string } | null = { id: 'u1' };
+vi.mock('@object-ui/auth', () => ({ useAuth: () => ({ user: userFixture }) }));
+
+const findCalls: Array<{ object: string }> = [];
+const fakeAdapter = {
+  find: (object: string) => {
+    findCalls.push({ object });
+    return Promise.resolve({ data: [] });
+  },
+  getClient: () => undefined,
+};
+vi.mock('../../providers/AdapterProvider', () => ({ useAdapter: () => fakeAdapter }));
+
+import { useSharedInboxFeed, __resetSharedUserFeeds } from '../sharedUserFeeds';
+import { useHomeInbox } from '../useHomeInbox';
+
+/** The declared foreground cadence (`INBOX_POLL_MS`), restated as the pin's unit. */
+const INBOX_POLL_MS = 10_000;
+/** The declared backgrounded cadence (`HIDDEN_POLL_MS`). */
+const HIDDEN_POLL_MS = 60_000;
+/** The measurement window both counting cases use. */
+const WINDOW_MS = 60_000;
+/**
+ * Reads a 60 s window may contain at the declared cadence: the attach-time read
+ * plus one per tick. Written as the arithmetic rather than as `7` so the bound
+ * moves with the cadence instead of having to be re-derived by hand.
+ */
+const READS_IN_WINDOW = 1 + WINDOW_MS / INBOX_POLL_MS;
+
+const inboxReads = () => findCalls.filter((c) => c.object === 'sys_inbox_message').length;
+const receiptReads = () =>
+  findCalls.filter((c) => c.object === 'sys_notification_receipt').length;
+
+const settle = () => act(async () => { await vi.advanceTimersByTimeAsync(0); });
+const advance = (ms: number) => act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+
+/** Drive `document.hidden`, which is the only input the scheduler reads. */
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => (hidden ? 'hidden' : 'visible'),
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  userFixture = { id: 'u1' };
+  findCalls.length = 0;
+  setHidden(false);
+  // Module-scoped stores outlive any one render tree.
+  __resetSharedUserFeeds();
+  // Approvals degrade to 0 (404) so the REST feed is not this suite's subject.
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(new Response('{}', { status: 404 }))));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('objectui#7249 — the inbox feed holds ONE declared cadence', () => {
+  it('polls at INBOX_POLL_MS with the bell and Home mounted together', async () => {
+    // The card's surface: on `/home` the bell (`useSharedInboxFeed`, mounted by
+    // the header) and the action centre (`useHomeInbox`) are both up. The read
+    // count over the window is the whole assertion — a second scheduler, or a
+    // cadence quietly faster than the declared one, can only make it larger.
+    renderHook(() => {
+      useSharedInboxFeed();
+      useHomeInbox();
+    });
+    await settle();
+
+    expect(inboxReads()).toBe(1);
+
+    await advance(WINDOW_MS);
+
+    expect(inboxReads()).toBe(READS_IN_WINDOW);
+    // The join travels with the rows: the receipt read is issued by the same
+    // runner, so it can neither lag the message read nor double it. The card's
+    // `top=200` receipt read is exactly as frequent as the pair, no more.
+    expect(receiptReads()).toBe(inboxReads());
+  });
+
+  it('is one FEED cadence, not one per consumer', async () => {
+    // Three consumers on one page must cost what one costs. This is the claim
+    // the mount-time dedupe pins cannot make: they stop at the first tick,
+    // where N schedulers still look like one.
+    renderHook(() => {
+      useSharedInboxFeed();
+      useSharedInboxFeed();
+      useHomeInbox();
+    });
+    await settle();
+    await advance(WINDOW_MS);
+
+    const withThree = inboxReads();
+
+    __resetSharedUserFeeds();
+    findCalls.length = 0;
+
+    renderHook(() => useSharedInboxFeed());
+    await settle();
+    await advance(WINDOW_MS);
+
+    expect(withThree).toBe(inboxReads());
+    expect(withThree).toBe(READS_IN_WINDOW);
+  });
+
+  it('throttles to HIDDEN_POLL_MS while the tab is backgrounded', async () => {
+    // The hidden cadence measured on the real page (1 pair per 60 s), pinned so
+    // a future change cannot let a backgrounded tab poll at the foreground rate
+    // — the regression #4225 explicitly refused to let ride along.
+    setHidden(true);
+
+    renderHook(() => useSharedInboxFeed());
+    await settle();
+    expect(inboxReads()).toBe(1);
+
+    await advance(HIDDEN_POLL_MS);
+
+    expect(inboxReads()).toBe(2);
+  });
+
+  it('coming back to the tab refreshes once, and does not leave a faster loop behind', async () => {
+    // The visibility handler refreshes immediately so the bell is current when
+    // the user looks at it. That is one extra read at the moment of return —
+    // not a cadence change, which is the failure this case exists to exclude.
+    setHidden(true);
+    renderHook(() => useSharedInboxFeed());
+    await settle();
+    expect(inboxReads()).toBe(1);
+
+    setHidden(false);
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(inboxReads()).toBe(2);
+
+    await advance(WINDOW_MS);
+
+    // One window at the foreground cadence after the return read — the return
+    // does not compound into a second scheduler.
+    expect(inboxReads()).toBe(2 + WINDOW_MS / INBOX_POLL_MS);
+  });
+});


### PR DESCRIPTION
Part of #7249.

Not `Fixes`: the card's headline defect did not reproduce, and its second half
(realtime for the bell) is blocked on a transport the server does not mount, so
merging this must not close the card. It needs maintainer triage — details below.

## What the card reported

The console HOME issuing the inbox pair (`sys_inbox_message?top=20` +
`sys_notification_receipt?top=200`) every **2000 ms** — five times
`INBOX_POLL_MS` — against ~10 s on an app page, read as a second scheduler on
Home racing the shared feed.

## What was measured

Same backend (showcase on objectstack `main`, `:3911`), signed in as the same
seeded admin, in a controlled Playwright context. 60 s idle per row, every
request to the two reads recorded off `page.on('request')`:

| surface | inbox pairs / 60 s | measured gaps (ms) |
|---|---|---|
| `/_console/home` — **the card's own URL**, published console bundle | 6 | 10054, 10055, 10070, 10074, 10075, 10077 |
| `/home` on this package's dev build | 6 | 10042, 10043, 10080, 10080, 10088 |
| `/home`, after 4x home↔app route churn + bell popover open | 6 | 10074, 10080, 10084, 10087, 10091 |
| `/home`, tab hidden | 1 | one read per 60 s |

`approvals/requests` held its own declared 30 s throughout (measured gap 30010-30017 ms).

**The 2 s cadence did not reproduce on any of them**, including the card's exact
URL. There is no second scheduler: `useHomeInbox` and `useInboxBell` both fetch
nothing — every read comes from `sharedUserFeeds` — and `useClientNotifications`,
the other candidate the card names, has **no call sites in this repo** (it is
exported and never mounted).

The card's own figures are also internally inconsistent: 24 pairs at a 2000 ms
gap spans 46 s, not the 85 s reported, and 85 s at the declared cadence is ~8
pairs. That points at the sampling rather than at a second scheduler, though this
PR does not claim to have reproduced whatever the reporter's window actually held.

## What this PR changes

Tests only. No runtime change — nothing about the cadence was wrong.

What *was* wrong is that "one cadence, owned by the shared feed" was true only by
measurement. The neighbouring pins (`sharedInboxFeed.twoSurfaces`) assert the
**mount-time** dedupe — one read for the bell and Home together, a late consumer
served without re-reading. That is a different claim, and it is satisfied by any
number of schedulers that happen to agree on the first tick. Nothing advanced a
clock and counted, so a consumer that grew its own interval would have kept every
existing pin green and cost a browser dogfood to find. It cost one here.

Four cases now make the cadence a property of the **feed** — not of how many
consumers mount, nor of which page they mount on — plus the hidden-tab throttle
and the return-to-tab refresh.

## Reverse verification

Prediction written first, then measured. Fix committed before the mutation, so
the restore had a real commit to return to.

Set `INBOX_POLL_MS` to `2_000` — the cadence the card reported:

- **three** counting cases go RED (`expected 31 to be 7`; `expected 32 to be 8`
  for the return-to-tab window), `Test Files 1 failed | 1 passed`,
  `Tests 3 failed | 15 passed (18)`;
- **`sharedInboxFeed.twoSurfaces` stays entirely GREEN** — the asymmetry is the
  point: the mutation is the exact defect the card described, and the existing
  suite cannot see it;
- the hidden-tab case correctly stays green, because the backgrounded delay is
  `max(HIDDEN_POLL_MS, backoff)`, which a faster *foreground* constant cannot
  move. It pins a different clock, which is why it is its own case.

Predicted two red cases and measured three — the return-to-tab case counts a
window too, so it fails on the same arithmetic. The file's own note records the
measured numbers, not the predicted ones.

Mutation confirmed on disk before the run (removed-text `grep -c` = 0, injected-text
= 1, blob hash moved `687fd012` -> `6ecf7303`). Restore proved after it, not
assumed from the trap: text counts back to 1/0, `git hash-object` equal to the
HEAD blob `687fd012`, `git diff HEAD` empty, `git status --porcelain` empty. No
`dist` step is involved — these tests import `../sharedUserFeeds` as a relative
source path, so no build stands between the mutation and the assertion.

## Realtime — the card's second Expected, and why it is not here

The card asks to prefer the realtime channel for the bell "when the server
advertises it". Measured on the running showcase, `GET /api/v1/discovery`:

```json
"realtime": {
  "enabled": true,
  "status": "degraded",
  "provider": "@objectstack/service-realtime",
  "handlerReady": false,
  "message": "In-process event bus only — no HTTP/WS realtime surface is mounted"
}
```

and the `routes` map carries no realtime entry at all (`data`, `metadata`,
`analytics`, `auth`, `automation`, `notifications`, `i18n`, `storage`, `ui`,
`mcp`, `datasources`, `email`).

So the server does **not** advertise a channel a client could subscribe to: the
plugin is loaded, but its surface is in-process only. Subscribing would mean
inventing a transport, which is out of scope for this card and for this repo.
Note the trap for whoever picks this up: `enabled: true` is not the predicate —
a client reading that key alone would subscribe to nothing. The honest predicate
is `handlerReady === true` **and** a route to connect to.

What the realtime half needs before it can be built here: an advertised realtime
route (WS or SSE) in `discovery`, a subscribe primitive in
`@objectstack/client` / `@object-ui/data-objectstack` (this repo has none today —
no `EventSource`/`WebSocket` subscription path exists in either), and a defined
event shape for inbox/receipt changes. That is objectstack-side work.

## Not addressed here (deliberately out of scope for this card)

The ⌘K palette firing its search three times per query, and the kanban's
double mount fetch, are both noted in the card's closing paragraph. Neither is
touched by this PR and neither is claimed fixed. `#7249` remains open.

## Verification

Union re-run on the final commit `1ab3ad61d`:

- `pnpm exec vitest run packages/app-shell/src/hooks packages/app-shell/src/console/home`
  -> `Test Files 47 passed (47)`, `Tests 366 passed (366)`, exit 0
- `pnpm --filter @object-ui/app-shell type-check` -> exit 0. Confirmed the new
  file is actually in that file set rather than assumed: `tsc -p
  tsconfig.test.json --listFiles | grep -c` the new test = **1**.
- `pnpm exec eslint --no-inline-config --format json <changed file>` -> exit 0,
  `files linted: 1`, 0 errors, 0 warnings.
- `node scripts/check-changeset-presence.mjs` -> exit 0, and it names the empty
  frontmatter as "the explicit exemption and a complete answer to this gate".
  `node scripts/check-changeset-no-major.mjs` -> exit 0.

**Declared narrowing — the repo-wide `pnpm lint` was not run; lint was narrowed to
the changed file.** Three pieces of evidence that the narrowing excluded nothing:
(1) the population comes from eslint's own config, not a guess — `eslint.config.js`
declares no `projectService` and no `parserOptions.project`, so type-aware linting
is off; (2) the file count is read from `--format json` — 1 file, the only lintable
file in the diff (the changeset is `.md`); (3) with no type-aware linting each file
is judged from its own source text, so a diff that adds one new test file cannot
move the verdict on any file it did not touch.

**Declared narrowing — verification ran UNLOCKED.** `scripts/pm/os-verify-lock.sh`
could not take the shared verify lock on this host: no usable `flock`. The shared
verify lock is declared Linux-only (`flock` is util-linux, and a stock macOS does
not ship it), so the command below was run directly, without the lock —
a declared narrowing, not a silent one. No serialization guarantee held for this
run, nor for any sibling agent in this container while it ran.

One measurement caveat, stated so it is not read as stronger than it is: the
browser probe signs in fresh each run, so it does not reproduce a long-lived
session with accumulated local state. Every other axis the card named — the URL,
the backend, the account, foreground and hidden, route churn — was covered.

_Generated by [Claude Code](https://claude.ai/code)_