### PR TITLE
fix(plugin-charts): name the scatter legend's series so its swatch stops reading as a stray point

### DIFF
--- a/.changeset/7248-scatter-legend-names-its-series.md
+++ b/.changeset/7248-scatter-legend-names-its-series.md
@@ -1,0 +1,31 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+Name the scatter legend's series, so its swatch stops reading as a stray data point
+(objectui#7248).
+
+The Chart Gallery scatter ("Estimate vs Progress") appeared to draw a seventh point
+below the x-axis, outside the plot area. It was not a point. `ChartLegendContent`
+resolves a label as `config[nameKey || item.dataKey || 'value']`, and a `<Scatter>`
+carries **no `dataKey`** — scatter's keys live on the XAxis/YAxis, not on the mark — so
+the key collapsed to the literal string `'value'`, missed a config keyed by measure
+name, and the legend entry rendered its colour swatch with no text beside it. An 8x8
+square in `--chart-1`, the same colour as the marks, sitting under the x-axis.
+
+Measured on the running showcase in real Chromium: the swatch sat at cy 341 against a
+plot area ending at cy 295, on a y scale of 4.835 px per unit — y = -9.5, at x ≈ 45.
+That is the "x≈40, y≈-10" the report described, to the pixel, and all six real marks
+were inside the plot area at every viewport width swept from 1440 down to 480.
+
+**The y domain was not the defect and is unchanged.** Clamping it — the fix the report
+asked for — would have created the bug it described: mixed-sign and all-negative
+fixtures are pinned here drawing every mark, because recharts already extends the
+domain to cover negative values.
+
+Two changes. The scatter now passes `nameKey` so its legend resolves the measure's
+label, and `ChartLegendContent` falls back to the series `name` recharts itself put on
+the legend item when the config lookup misses. The second closes the class rather than
+this one instance: the swatch renders unconditionally, so a config miss must never
+leave it anonymous. Charts whose config already resolves are unaffected — only a
+currently-empty label changes.

--- a/packages/plugin-charts/src/AdvancedChartImpl.scatterLegendLabel.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.scatterLegendLabel.test.tsx
@@ -121,6 +121,21 @@ describe('objectui#7248 — the scatter legend names its series', () => {
     expect(legendEntries(container)).toEqual([{ hasSwatch: true, text: 'avg_estimate' }]);
   });
 
+  it('resolves the legend entry through the CONFIG, not just the series name', () => {
+    // What `nameKey` buys, pinned separately because the `item.value` fallback
+    // masks it on the label: with the key collapsed to `'value'` the config
+    // lookup can never hit, so `itemConfig.icon` is dead for scatter and a
+    // config-declared legend icon is silently ignored — while every other
+    // family honours it. Measured via the icon because that is the one branch
+    // the fallback cannot stand in for.
+    const Icon = () => <svg data-testid="legend-icon" />;
+    const { container } = renderScatter({
+      config: { progress: { label: 'Progress' }, avg_estimate: { label: 'Avg Estimate', icon: Icon } },
+    });
+    expect(container.querySelector('[data-testid="legend-icon"]')).not.toBeNull();
+    expect(legendEntries(container)).toEqual([{ hasSwatch: false, text: 'Avg Estimate' }]);
+  });
+
   it('never paints a swatch with no text — the invariant, across families', () => {
     // The class this card belongs to, not just its one instance. A legend entry
     // that cannot be named is worse than no legend: it adds an anonymous mark

--- a/packages/plugin-charts/src/AdvancedChartImpl.scatterLegendLabel.test.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.scatterLegendLabel.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * objectui#7248 — the scatter legend rendered a colour swatch with NO label,
+ * and that anonymous dot read as a DATA POINT drawn outside the plot area.
+ *
+ * ## The card said "y domain", and the y domain was innocent
+ *
+ * The card reported the Chart Gallery scatter ("Estimate vs Progress") drawing
+ * "a seventh point below the x-axis at x≈40, y≈-10" and asked for the y domain
+ * to include every plotted value. Measured on the running showcase in real
+ * Chromium (viewport 1440, widget svg 510x350) that diagnosis is FALSE and the
+ * fix would have been in the wrong place:
+ *
+ *   - all SIX marks sat inside the plot area (y 5..295): cy 215.3, 101.7, 5,
+ *     179, 150, 237. Nothing was outside it, at any viewport width swept from
+ *     1440 down to 480.
+ *   - the seventh "point" was the LEGEND swatch — an 8x8 `--chart-1` square,
+ *     the same colour as the marks, at cx 255 / cy 341, with `innerText === ""`.
+ *   - the arithmetic closes it: the plot bottom (y=0) is cy 295 and the scale
+ *     is 4.835 px per unit, so cy 341 is y = -9.5 and cx 255 is x ≈ 45 —
+ *     the card's "x≈40, y≈-10", to the pixel.
+ *
+ * The domain is therefore NOT touched, and the two fixtures that would expose a
+ * real domain bug are pinned below instead: mixed-sign and all-negative data
+ * both draw every mark, because recharts extends the domain to cover negatives.
+ *
+ * ## Why the label was empty
+ *
+ * `ChartLegendContent` resolves a label as `config[nameKey || item.dataKey ||
+ * 'value']`. A `<Scatter>` carries NO `dataKey` — scatter's keys live on the
+ * XAxis/YAxis, not on the mark — so the key collapsed to the literal string
+ * `'value'` and missed a config keyed by measure name. Captured from recharts
+ * 3.10.1 rather than assumed, the scatter's legend payload item is:
+ *
+ *     { color: '#3b82f6', type: 'circle', value: 'Avg Estimate',
+ *       payload: { name: 'Avg Estimate', ... } }        // NO `dataKey`
+ *
+ * The name was right there in `value` the whole time; the legend just never
+ * read it. Both halves of the fix are pinned here: the scatter now passes
+ * `nameKey`, and `ChartLegendContent` falls back to `item.value` so that NO
+ * family can render a nameless swatch again.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import AdvancedChartImpl from './AdvancedChartImpl';
+
+afterEach(cleanup);
+
+type Row = Record<string, unknown>;
+
+/** The six aggregate rows the Chart Gallery scatter actually plots, read from
+ *  the running showcase API: progress buckets x avg estimate_hours. */
+const GALLERY: Row[] = [
+  { progress: 0, avg_estimate: 16.5 },
+  { progress: 45, avg_estimate: 40 },
+  { progress: 55, avg_estimate: 60 },
+  { progress: 80, avg_estimate: 24 },
+  { progress: 90, avg_estimate: 30 },
+  { progress: 100, avg_estimate: 12 },
+];
+
+const CONFIG = { progress: { label: 'Progress' }, avg_estimate: { label: 'Avg Estimate' } };
+
+const renderScatter = (props: Record<string, unknown> = {}) =>
+  render(
+    <AdvancedChartImpl
+      chartType="scatter"
+      xAxisKey="progress"
+      series={[{ dataKey: 'avg_estimate', label: 'Avg Estimate' }] as any}
+      config={CONFIG as any}
+      data={GALLERY as any}
+      isAnimationActive={false}
+      {...(props as any)}
+    />,
+  );
+
+/**
+ * One entry per legend item: does it paint a swatch, and what text sits beside
+ * it. The swatch is the `h-2 w-2` div `ChartLegendContent` renders when the
+ * config carries no icon — the exact element measured at cy 341 on screen.
+ */
+const legendEntries = (c: HTMLElement) => {
+  const wrapper = c.querySelector('.recharts-legend-wrapper');
+  const row = wrapper?.firstElementChild;
+  return [...(row?.children ?? [])].map((el) => ({
+    hasSwatch: !!el.querySelector('div.h-2.w-2'),
+    text: (el.textContent ?? '').trim(),
+  }));
+};
+
+const marksOf = (c: HTMLElement) => c.querySelectorAll('path.recharts-symbols').length;
+
+describe('objectui#7248 — the scatter legend names its series', () => {
+  it('renders the measure label beside the swatch, not a bare dot', () => {
+    // The defect, stated as the reader sees it: a swatch with nothing next to
+    // it is indistinguishable from a data point, and this one was painted
+    // below the x-axis in the marks' own colour.
+    const { container } = renderScatter();
+    expect(legendEntries(container)).toEqual([{ hasSwatch: true, text: 'Avg Estimate' }]);
+  });
+
+  it('falls back to the series name when the config has no entry for the measure', () => {
+    // `nameKey` alone would leave the hole open one config-miss away, which is
+    // how this bug survived the pie fix that closed the same shape in #3135.
+    //
+    // The fallback lands on the RAW measure key, not a prose label, because
+    // with no config entry the scatter's own `name` is `s.dataKey` — that is
+    // the honest reading and it is still the point: `avg_estimate` identifies
+    // the series, an unlabelled dot does not.
+    const { container } = renderScatter({ config: { progress: { label: 'Progress' } } });
+    expect(legendEntries(container)).toEqual([{ hasSwatch: true, text: 'avg_estimate' }]);
+  });
+
+  it('never paints a swatch with no text — the invariant, across families', () => {
+    // The class this card belongs to, not just its one instance. A legend entry
+    // that cannot be named is worse than no legend: it adds an anonymous mark
+    // to a picture whose whole job is to be read.
+    for (const chartType of ['scatter', 'bar', 'line', 'area'] as const) {
+      const { container } = render(
+        <AdvancedChartImpl
+          chartType={chartType}
+          xAxisKey="progress"
+          series={[{ dataKey: 'avg_estimate', label: 'Avg Estimate' }] as any}
+          config={{} as any}
+          data={GALLERY as any}
+          isAnimationActive={false}
+        />,
+      );
+      const nameless = legendEntries(container).filter((e) => e.hasSwatch && e.text === '');
+      expect(nameless, `${chartType} painted an unlabelled legend swatch`).toEqual([]);
+      cleanup();
+    }
+  });
+});
+
+describe('objectui#7248 — the y domain was NOT the defect, and stays untouched', () => {
+  it('draws every gallery row', () => {
+    // The control. Six aggregate rows, six marks — measured in Chromium as six
+    // marks all inside the plot area, so there is no missing/expelled point.
+    expect(marksOf(renderScatter().container)).toBe(6);
+  });
+
+  it('draws every mark for mixed-sign and all-negative data', () => {
+    // The two fixtures a real y-domain bug would fail. Recharts extends the
+    // domain to cover negatives, so clamping it to `[0, 'auto']` here — the fix
+    // the card asked for — would have CREATED the defect it described.
+    const mixed = render(
+      <AdvancedChartImpl chartType="scatter" xAxisKey="xm"
+        series={[{ dataKey: 'ym', label: 'Y' }] as any} config={CONFIG as any}
+        data={[{ xm: 10, ym: 40 }, { xm: 20, ym: -15 }, { xm: 30, ym: 25 }] as any}
+        isAnimationActive={false} />,
+    );
+    expect(marksOf(mixed.container)).toBe(3);
+    cleanup();
+
+    const allNeg = render(
+      <AdvancedChartImpl chartType="scatter" xAxisKey="xm"
+        series={[{ dataKey: 'ym', label: 'Y' }] as any} config={CONFIG as any}
+        data={[{ xm: 10, ym: -40 }, { xm: 20, ym: -15 }] as any}
+        isAnimationActive={false} />,
+    );
+    expect(marksOf(allNeg.container)).toBe(2);
+  });
+
+  it('leaves the #7197 unplaceable-row notice alone', () => {
+    // The card asked whether this was #7197's job. It is not: that notice
+    // answers rows with NO number, and every gallery row has two.
+    const { container } = renderScatter();
+    expect(container.querySelector('[data-chart-note="unplotted-points"]')).toBeNull();
+    expect(container.querySelector('[data-chart-error="no-plottable-points"]')).toBeNull();
+  });
+});

--- a/packages/plugin-charts/src/AdvancedChartImpl.tsx
+++ b/packages/plugin-charts/src/AdvancedChartImpl.tsx
@@ -1728,8 +1728,28 @@ function AdvancedChartImplInner({
           />
           <ZAxis type="number" range={[60, 400]} />
           <ChartTooltip content={<ChartTooltipContent />} />
+          {/* `nameKey` is REQUIRED here, for a reason unique to scatter
+              (objectui#7248). `ChartLegendContent` resolves a label as
+              `config[nameKey || item.dataKey || 'value']`, and a `<Scatter>`
+              carries NO `dataKey` — scatter's keys live on the two axes, not on
+              the mark. So the key collapsed to the literal `'value'`, missed a
+              config keyed by measure name, and the entry rendered its colour
+              swatch with NO TEXT beside it.
+
+              What that looks like on screen is the whole card: an 8x8 dot in
+              `--chart-1` — the SAME colour as the marks — sitting under the
+              x-axis, which reads as a seventh data point plotted outside the
+              plot area. Measured on the showcase Chart Gallery in real
+              Chromium: swatch at cy 341 against a plot area ending at cy 295,
+              on a y scale of 4.835 px per unit, i.e. y = -9.5 — which is
+              exactly the "x≈40, y≈-10" the card reported as a stray point.
+
+              The y DOMAIN was never the defect and is deliberately not touched:
+              the same run measured all six marks inside the plot area, and
+              mixed-sign and all-negative fixtures draw every mark inside too,
+              because recharts extends the domain to cover negatives. */}
           <ChartLegend
-            content={<ChartLegendContent />}
+            content={<ChartLegendContent nameKey={scatterYKey} />}
             {...(isMobile && { verticalAlign: "bottom", wrapperStyle: { fontSize: '11px', paddingTop: '8px' } })}
           />
           {series.map((s: any, index: number) => {

--- a/packages/plugin-charts/src/ChartContainerImpl.tsx
+++ b/packages/plugin-charts/src/ChartContainerImpl.tsx
@@ -484,7 +484,21 @@ function ChartLegendContent({
                   }}
                 />
               )}
-              {itemConfig?.label}
+              {/* Fall back to the series name recharts itself put on the
+                  legend item (objectui#7248). The config lookup above is an
+                  OVERRIDE layer, so a miss must not erase the label: the
+                  swatch renders unconditionally, and a swatch with no text is
+                  an unidentifiable coloured dot — on a scatter it read as a
+                  stray data point plotted outside the plot area.
+
+                  This is the general form of the pie bug the helper below
+                  documents ("legend swatches with NO text at all"). That one
+                  was closed by making one family's key resolve; this closes
+                  the class, because `item.value` IS the `name` the mark
+                  declared and is the last thing standing between a reader and
+                  an anonymous dot. Charts whose config already resolves are
+                  unaffected — only a currently-EMPTY label changes. */}
+              {itemConfig?.label ?? item.value}
             </div>
           )
         })}


### PR DESCRIPTION
Fixes #7248

## The reported point is not a point — it is the legend swatch

The card reported the Chart Gallery scatter ("Estimate vs Progress") drawing a seventh
point below the x-axis at "x≈40, y≈-10", and asked for the y domain to include every
plotted value. Measured on the running showcase in real Chromium, that diagnosis is
false and the requested fix would have been in the wrong place.

`ChartLegendContent` resolves a label as `config[nameKey || item.dataKey || 'value']`.
A `Scatter` carries **no `dataKey`** — scatter's keys live on the XAxis/YAxis, not on
the mark — so the key collapsed to the literal string `'value'`, missed a config keyed
by measure name, and the legend entry rendered its colour swatch with no text beside
it. An 8x8 square in `--chart-1`, the same colour as the marks, sitting under the
x-axis.

Captured from recharts 3.10.1 rather than assumed, the scatter's legend payload item is:

```
{ color: '#3b82f6', type: 'circle', value: 'Avg Estimate',
  payload: { name: 'Avg Estimate', ... } }          // no `dataKey`
```

The series name was in `value` the whole time; the legend never read it.

## Browser measurement — before and after

Showcase Chart Gallery, `/apps/com.example.showcase/dashboard/showcase_chart_gallery`,
real Chromium (Playwright 1.62.1), viewport 1440x1000, widget svg 510x350.

**Before** — plot area y 5..295, six marks, all inside it:

| progress (x) | avg_estimate (y) | cx | cy | inside plot? |
|---|---|---|---|---|
| 0 | 16.5 | 53 | 215.3 | yes |
| 45 | 40 | 256.4 | 101.7 | yes |
| 55 | 60 | 301.6 | 5 | yes |
| 80 | 24 | 414.6 | 179 | yes |
| 90 | 30 | 459.8 | 150 | yes |
| 100 | 12 | 505 | 237 | yes |

The seventh "point" was the legend swatch: cx 255, cy 341, `innerText === ""`. The
arithmetic closes the identification — the plot bottom (y=0) is cy 295 and the y scale
is 4.835 px per unit, so cy 341 is **y = -9.5**, at **x ≈ 45**. That is the card's
"x≈40, y≈-10", to the pixel.

Swept viewport widths 1440, 1100, 980, 900, 820, 760, 700, 640, 560, 480: **zero marks
outside the plot area at any width**, so the symptom was never width-dependent either.

**After** — plot area y 5..287, same six marks all inside (cy 209.5, 99, 5, 174.2, 146,
230.6), and the legend now reads `Avg Estimate` beside its swatch instead of painting an
anonymous dot.

## The y domain was not the defect and is unchanged

Clamping the y domain — the fix the card asked for — would have **created** the bug it
described. Two adversarial fixtures are pinned in this PR: mixed-sign data
(`ym: 40, -15, 25`) draws 3 of 3 marks and all-negative data (`ym: -40, -15`) draws 2 of
2, because recharts already extends the domain to cover negative values. Forcing
`[0, 'auto']` is exactly what would push a negative point below the baseline.

The live data was read from the running showcase API and rules out the "bad row"
hypothesis independently: 10 seeded tasks, every `progress` a finite non-negative
number, no null / negative / string values, aggregating to the six buckets above.

## Two changes

1. **`AdvancedChartImpl.tsx`, scatter branch** — pass `nameKey={scatterYKey}` so the
   legend resolves the measure's config entry, the same way the pie branch already
   passes `nameKey={xAxisKey}`.

2. **`ChartContainerImpl.tsx`, `ChartLegendContent`** — fall back to `item.value`, the
   series name recharts itself put on the legend item, when the config lookup misses.

The second is a deliberate bounded in-place fix rather than a drive-by: it is the same
defect class, at the layer that decides whether a swatch gets a name, and it closes the
**class** instead of this one instance. The swatch renders unconditionally, so a config
miss must never leave it anonymous. The helper directly below it already documents the
pie form of this same bug ("legend swatches with NO text at all"); that one was closed
by making one family's key resolve, this closes the general case. Charts whose config
already resolves are unaffected — only a currently-empty label can change.

## Reverse verification (ablation)

Each half was ablated independently from the committed state, with a restore trap on
absolute paths, the mutation proved on disk by HEAD-blob-hash comparison plus an anchor
count, and the tree confirmed clean (`git diff HEAD` empty) after every leg. No `dist`
is involved — the test imports `./AdvancedChartImpl`, which imports
`./ChartContainerImpl`, both relative source paths — so no rebuild leg applies.

| ablation | mutation landed | result |
|---|---|---|
| baseline (both halves) | — | 7 passed |
| remove `nameKey` only | `640e2290 → 52a84b18`, anchor count 0 | **1 red** — the config-resolution pin |
| remove `?? item.value` only | `117306ba → 525ac855`, anchor count 0 | **2 red** |
| remove both (origin/main behaviour) | both, anchor counts 0 | **4 red**, incl. the headline assertion |

The first run of this ablation found a real problem and changed the PR: removing
`nameKey` alone left **all assertions green**, because the `item.value` fallback masks
it on the label. Rather than ship an unenforced change, a pin was added for the one
branch the fallback cannot stand in for — `itemConfig.icon`, which only resolves when
the config lookup hits, so a config-declared legend icon is silently ignored for scatter
without `nameKey` while every other family honours it. That pin is the single red in
ablation 1 above.

## Per-facet answers to the dispatch

- **#7197 (the "cannot place a row" notice)** — **not the mechanism, unchanged.** That
  notice answers rows carrying no number; every gallery row has two. Pinned here: no
  note and no refusal on this fixture. Note also that #7197 was already an *ancestor* of
  the build the card was filed against (`67dadd602a3a`), so it was never the missing
  piece.
- **#7194 (multi-series scatter y values)** — **real, distinct root cause, out of scope.**
  The `YAxis` binds `dataKey={series[0].dataKey}` for every series and each `Scatter`
  receives the same unprojected `data`, so every series does plot at the first series'
  y values. That is an axis-binding defect, not label resolution, and this card's chart
  is single-series. Left to its own card.
- **#7385 (categorical x-axis labels)** — no interaction, as predicted. Scatter uses
  `type="number"` axes and never reaches the categorical thinning path. Not reverted,
  not touched.

## Gates

Run on the final commit `d2537532b`:

- `pnpm exec vitest run packages/plugin-charts/ --maxWorkers=2` — **42 files, 390 tests
  passed** (run from the repo root; the package-scoped `pnpm --filter ... test` form is
  the silent-green trap AGENTS.md bans)
- `pnpm --filter @object-ui/plugin-charts type-check` — exit 0. `tsc --listFiles`
  confirms both edited files and the new test are inside the program, so this green
  actually covers the diff rather than excluding the test file
- `pnpm exec eslint .` in `packages/plugin-charts` — exit 0, 0 errors, 318 pre-existing
  warnings, **55 files** linted (count read from `--format json`), all three touched
  files present in the linted set
- changeset: `.changeset/7248-scatter-legend-names-its-series.md`, `@object-ui/plugin-charts` patch

**Declared narrowing.** Lint was run at package scope rather than repo-wide. The
population comes from eslint's own config resolution, the count from `--format json`
(55 files), and the config is **not type-aware** (no `parserOptions.project` /
`projectService`), so this diff cannot move the verdict on any untouched file. CI runs
the full farm regardless.

**Verify-lock declaration**, verbatim from the tool on every heavy run:

```
os-verify-lock: VERDICT command-exit 0 · UNLOCKED (declared) · no usable `flock` on this
host, so the shared verify lock was NEVER taken and NOTHING was serialized
```

## Out-of-scope findings filed

- objectui#7396 — a scatter's extreme points are half-clipped by the plot edge (the
  numeric axes get no domain padding). Measured here: plot x 53..505 with marks at
  cx 53 and cx 505, so about half of each extreme symbol paints outside the plot area.
  Real, different mechanism, and changing it would alter every scatter's appearance.
- objectui#7397 — `packages/components/src/ui/chart.tsx` is an unreferenced duplicate of
  the plugin-charts chart primitives carrying this same legend hole. Imported by
  nothing and absent from the barrel, so it is currently unreachable; left untouched
  here rather than widening this PR across a second published package.

_Generated by [Claude Code](https://claude.ai/code/session_62849a16-0144-4728-8942-9f60bb3a73f1)_
