### PR TITLE
chore(scripts): check-skills-paths scans .claude/skills too — 27 to 88 stated paths under the gate, the #7251 pins restored (#7358)

### DIFF
--- a/scripts/__tests__/check-skills-paths.test.ts
+++ b/scripts/__tests__/check-skills-paths.test.ts
@@ -8,20 +8,31 @@ import { fileURLToPath } from 'node:url';
 // Plain-JS CI helper. Its types are INFERRED from the .mjs source by
 // `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
 // re-adding one is now itself an error (TS2578). See objectui#3494.
-import { extractPathTokens, scan, PATH_PREFIXES, readBaseline, BASELINE_FILE } from '../check-skills-paths.mjs';
+import {
+  extractPathTokens,
+  scan,
+  PATH_PREFIXES,
+  SCAN_ROOTS,
+  readBaseline,
+  BASELINE_FILE,
+} from '../check-skills-paths.mjs';
 
 /**
  * objectui#3735 — the test for `scripts/check-skills-paths.mjs`.
  *
- * The guides under `skills/objectui/` are read by every agent that writes code
- * here, and they give in-repo paths as coordinates. Nothing checked those paths
- * existed, so two rounds of dead ones (#3713 / PR #3729 and #3730 / PR #3734,
- * 13+ in one guide) were found by eye while reading. This suite holds the gate
- * that makes the third round mechanical.
+ * The guides under `skills/objectui/` and `.claude/skills/` are read by every
+ * agent that writes code here, and they give in-repo paths as coordinates.
+ * Nothing checked those paths existed, so two rounds of dead ones (#3713 /
+ * PR #3729 and #3730 / PR #3734, 13+ in one guide) were found by eye while
+ * reading. This suite holds the gate that makes the third round mechanical.
  *
- * The fixtures are temporary trees built here, never the real `skills/`
- * directory: a committed fixture guide would have to contain a deliberately dead
- * path, and something else in the repo would eventually scan it.
+ * The second root is objectui#7358. objectui#7251 moved the two contributor-only
+ * guides out of `skills/` and 55 of 93 assertions left the gate with nothing
+ * turning red; the pins that move had to weaken are restored below, and marked.
+ *
+ * The fixtures are temporary trees built here, never the real guide
+ * directories: a committed fixture guide would have to contain a deliberately
+ * dead path, and something else in the repo would eventually scan it.
  */
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
@@ -218,6 +229,94 @@ describe('scan — a seeded dead path turns the gate red and gets named', () => 
   });
 });
 
+describe('scan — both roots are read, and each is accounted for on its own', () => {
+  // objectui#7358. The gate scanned one root until objectui#7251 moved the two
+  // contributor-only guides into `.claude/skills/` — 55 of 93 assertions left
+  // the checked surface and nothing turned red, because a total cannot say
+  // which root it came from.
+
+  it('declares exactly the two roots, in order', () => {
+    // The widening itself, pinned in one place. `.claude/skills` is not
+    // incidental: it is where this repo keeps the guides that address a
+    // maintainer rather than a customer of the published bundle.
+    expect(SCAN_ROOTS).toEqual(['skills', '.claude/skills']);
+  });
+
+  it('finds a dead path stated under `.claude/skills`, not only under `skills`', () => {
+    const result = withTree(
+      (write) => {
+        write('skills/objectui/SKILL.md', 'Entry: `packages/core/src/index.ts`.\n');
+        write('packages/core/src/index.ts', 'export {};\n');
+        write(
+          '.claude/skills/objectui-contributor/guides/console-development.md',
+          'The sidebar lives in `packages/app-shell/src/layout/Gone.tsx`.\n',
+        );
+      },
+      (dir) => scan(dir, NO_BASELINE),
+    );
+    expect(result.missing).toEqual([
+      {
+        file: '.claude/skills/objectui-contributor/guides/console-development.md',
+        line: 1,
+        token: 'packages/app-shell/src/layout/Gone.tsx',
+      },
+    ]);
+    expect(result.files).toBe(2);
+    expect(result.checked).toBe(2);
+  });
+
+  it('breaks the totals down per root, in declaration order', () => {
+    const result = withTree(
+      (write) => {
+        write('packages/core/src/index.ts', 'export {};\n');
+        write('skills/objectui/SKILL.md', 'Entry: `packages/core/src/index.ts`.\n');
+        write('skills/objectui/rules/protocol.md', 'Also `packages/core/src/index.ts`.\n');
+        write('.claude/skills/verify/SKILL.md', 'Gone: `packages/app-shell/src/Gone.tsx`.\n');
+      },
+      (dir) => scan(dir, NO_BASELINE),
+    );
+    expect(result.perRoot).toEqual([
+      { root: 'skills', files: 2, checked: 2, resolved: 2 },
+      { root: '.claude/skills', files: 1, checked: 1, resolved: 0 },
+    ]);
+    expect(result.files).toBe(3);
+    expect(result.checked).toBe(3);
+    expect(result.resolved).toBe(2);
+  });
+
+  it('reports a root that reads nothing as a zero row, not as an absence', () => {
+    // The mechanism `main()` trips on. Summed, this tree reads 1 file and 1
+    // healthy assertion and looks entirely fine; per root, the second root
+    // announces that it judged nothing — which is exactly what objectui#7251's
+    // move looked like from inside this gate.
+    const result = withTree(
+      (write) => {
+        write('packages/core/src/index.ts', 'export {};\n');
+        write('skills/objectui/SKILL.md', 'Entry: `packages/core/src/index.ts`.\n');
+      },
+      (dir) => scan(dir, NO_BASELINE),
+    );
+    expect(result.missing).toEqual([]);
+    expect(result.perRoot).toEqual([
+      { root: 'skills', files: 1, checked: 1, resolved: 1 },
+      { root: '.claude/skills', files: 0, checked: 0, resolved: 0 },
+    ]);
+  });
+
+  it('keeps a baseline entry keyed to a file under the second root', () => {
+    const GUIDE = '.claude/skills/objectui-contributor/guides/console-development.md';
+    const TOKEN = 'apps/console/src/context/';
+    const result = withTree(
+      (write) => write(GUIDE, `There is no \`${TOKEN}\` directory at all.\n`),
+      (dir) => scan(dir, baselineFor(GUIDE, TOKEN, 'deliberate negative statement')),
+    );
+    expect(result.missing).toEqual([]);
+    expect(result.exempt).toHaveLength(1);
+    expect(result.exempt[0].file).toBe(GUIDE);
+    expect(result.staleUnseen).toEqual([]);
+  });
+});
+
 describe('scan — the baseline is a ratchet, red in both directions', () => {
   const GUIDE = 'skills/objectui/guides/console-development.md';
   const TOKEN = 'apps/console/src/context/';
@@ -317,20 +416,28 @@ describe('repo state — the gate is green on this tree', () => {
     // both assertions above by finding nothing. Floors, not exact counts, so
     // ordinary guide edits do not touch this file — measured at 18 files and
     // 86 assertions on main@6422aa891, then at 16 files and 27 assertions after
-    // objectui#7251 moved the contributor-only guides out of `skills/`.
+    // objectui#7251 moved the contributor-only guides out of `skills/`, and now
+    // at 20 files and 88 assertions with `.claude/skills` under the gate
+    // (main@0614b6df1, objectui#7358).
     //
-    // The `checked` floor dropped from 50 to 20 because that move took 55 of
-    // the 93 assertions with it: 49 in `console-development.md` and 6 in
-    // `no-touch-zones.md`, both now under `.claude/skills/`, which SCAN_ROOT
-    // does not reach. Lowering a floor is normally how a gate rots, so the
-    // reason is recorded here and the follow-up is named: widening SCAN_ROOT to
-    // cover `.claude/skills` would bring those 55 back under the gate, and that
-    // is a deliberate decision with its own measurement (see the docblock's
-    // "The prefix allow-list is a decision, not an accident"), not a rider on
-    // the move.
+    // The `checked` floor is back to 50, the value objectui#7251 had to drop to
+    // 20 when that move took 55 of the 93 assertions with it. The arithmetic it
+    // left behind, restored: 88 checked today, of which the two moved guides
+    // carry 55 (49 in `console-development.md`, 6 in `no-touch-zones.md`). If
+    // `.claude/skills` ever falls out of SCAN_ROOTS again the reading drops to
+    // 33 and this floor is red — which is the assertion objectui#7251 could not
+    // make and had to record as a follow-up instead.
     expect(result.files).toBeGreaterThanOrEqual(15);
-    expect(result.checked).toBeGreaterThan(20);
+    expect(result.checked).toBeGreaterThan(50);
     expect(result.resolved).toBe(result.checked - result.exempt.length);
+
+    // Per root, because the floor above is a TOTAL and a total cannot see one
+    // root go quiet: 27 under `skills` alone would clear a floor of 20, which
+    // is precisely how the 55 left unnoticed.
+    for (const row of result.perRoot as { root: string; files: number; checked: number }[]) {
+      expect(row.files, `${row.root}/ read no markdown at all`).toBeGreaterThan(0);
+      expect(row.checked, `${row.root}/ stated no path at all`).toBeGreaterThan(0);
+    }
   });
 
   it('keeps every baseline entry attached to a reason and an issue', () => {
@@ -355,39 +462,47 @@ describe('repo state — the gate is green on this tree', () => {
 });
 
 describe('objectui#3713 / #3730 — the guide those two rounds corrected by hand', () => {
-  // That guide is `console-development.md`, and objectui#7251 moved it out of
-  // the scan root to `.claude/skills/objectui-contributor/guides/` because it
-  // addresses a maintainer of this repo, not a customer of the published
-  // bundle. So the three pins this block used to carry cannot be restated as
-  // they were: `scan(repoRoot)` no longer sees the file, and a filter on its
-  // old path would pass by finding nothing — the exact empty-verdict failure
-  // the block above exists to catch.
-  //
-  // What survives is the half that never needed the scan: the file still
-  // states path coordinates, `extractPathTokens` still reads them, and #3730
-  // alone corrected 13 of them by hand. Pinning the count keeps that fact
-  // visible, and keeps the follow-up honest — the day SCAN_ROOT covers
-  // `.claude/skills`, these coordinates come back under the gate and this
-  // block can go back to asserting `result.missing` on them.
-  const MOVED_GUIDE = '.claude/skills/objectui-contributor/guides/console-development.md';
+  // objectui#7251 moved this guide to `.claude/skills/objectui-contributor/`
+  // because it addresses a maintainer of this repo, not a customer of the
+  // published bundle, and the gate stopped seeing it. objectui#7358 widened
+  // SCAN_ROOTS, so the three pins are back on `scan(repoRoot)` — only the
+  // path is new. The "NOT covered by the gate" assertion that stood here in
+  // between was written to be deleted on this day, and is deleted.
+  const GUIDE = '.claude/skills/objectui-contributor/guides/console-development.md';
+  const result = scan(repoRoot);
+  const inGuide = <T extends { file: string }>(rows: T[]) => rows.filter((r) => r.file === GUIDE);
 
-  it('still lives where the move put it', () => {
-    expect(fs.existsSync(path.join(repoRoot, MOVED_GUIDE))).toBe(true);
+  it('states no dead path any more', () => {
+    expect(inGuide(result.missing).map((m: { line: number; token: string }) => `${m.line} ${m.token}`)).toEqual([]);
   });
 
-  it('is still dense in stated paths, which is why it needed a gate', () => {
-    const stated = extractPathTokens(fs.readFileSync(path.join(repoRoot, MOVED_GUIDE), 'utf8')).filter(
+  it('is still the densest guide, so the assertion above is not vacuous', () => {
+    // #3730 alone corrected 13 coordinates in this one file. If its path-bearing
+    // prose ever collapses to nothing, the pin above would pass for the wrong
+    // reason.
+    const stated = extractPathTokens(fs.readFileSync(path.join(repoRoot, GUIDE), 'utf8')).filter(
       (h: Hit) => !h.pattern,
     );
     expect(stated.length).toBeGreaterThan(40);
   });
 
-  it('is NOT covered by the gate today, and that is the open follow-up', () => {
-    // Red the day someone widens SCAN_ROOT: delete this and restore the
-    // `result.missing` assertion above it.
-    const result = scan(repoRoot);
-    expect(result.missing.map((m: { file: string }) => m.file)).not.toContain(MOVED_GUIDE);
-    expect(result.exempt.map((e: { file: string }) => e.file)).not.toContain(MOVED_GUIDE);
+  it('is actually inside the scanned surface, not merely absent from the red', () => {
+    // The inverse of the assertion this block carried between #7251 and #7358,
+    // and the reason that one had to go: `inGuide(result.missing)` is empty
+    // both when the guide is clean and when nothing scans it at all. Tie the
+    // file's own density to the root's count and the two stop being confusable.
+    const stated = extractPathTokens(fs.readFileSync(path.join(repoRoot, GUIDE), 'utf8')).filter(
+      (h: Hit) => !h.pattern,
+    );
+    const row = (result.perRoot as { root: string; checked: number }[]).find((r) => r.root === '.claude/skills');
+    expect(row, '`.claude/skills` is not among the scan roots').toBeDefined();
+    expect(row!.checked, 'the guide states more paths than its whole root reports checking').toBeGreaterThanOrEqual(
+      stated.length,
+    );
+  });
+
+  it('carries exactly the one exemption, the deliberate negative sentence', () => {
+    expect(inGuide(result.exempt).map((e: { token: string }) => e.token)).toEqual(['apps/console/src/context/']);
   });
 });
 

--- a/scripts/check-skills-paths.mjs
+++ b/scripts/check-skills-paths.mjs
@@ -48,6 +48,13 @@
  * sentence (the sole baseline entry). So the signal-to-noise ratio is what makes
  * this checkable at all: one exemption for 86 assertions.
  *
+ * Re-measured on `main@0614b6df1` across both roots (objectui#7358): 20 files,
+ * 92 tokens, 4 patterns, 88 literal assertions — 87 resolve, 1 does not, and it
+ * is the SAME deliberate negative sentence, now stated from
+ * `.claude/skills/objectui-contributor/guides/console-development.md`. The ratio
+ * held across a 3.3x widening of the checked surface: one exemption for 88
+ * assertions.
+ *
  * Three exclusions, each a rule rather than a baseline entry, because none of
  * them is a claim that a file exists:
  *
@@ -67,6 +74,40 @@
  *      tree, so it buys nothing yet and is a scope statement for later — the
  *      inverse boundary `check-doc-links.mjs` draws for itself, and for the same
  *      reason (that file's `stripCode` section spells it out).
+ *
+ * ## The scan surface is a decision too (objectui#7358)
+ *
+ * `SCAN_ROOTS` holds `skills` and `.claude/skills`. It was one string, `skills`,
+ * until objectui#7251 moved the two contributor-only files — the 49-coordinate
+ * `console-development.md` and `no-touch-zones.md` — into
+ * `.claude/skills/objectui-contributor/`, because they address a maintainer of
+ * this repo rather than a customer of the published bundle. The move was
+ * correct and the gate did not notice it: 55 of 93 assertions, 59%, left the
+ * checked surface in one commit with nothing turning red, because the gate
+ * simply stopped looking. Both files stayed green the whole time.
+ *
+ * Widening it was its own change, with the measurement re-run as this docblock
+ * demands below:
+ *
+ *   |                         | before | after |
+ *   |-------------------------|--------|-------|
+ *   | files scanned           | 16     | 20    |
+ *   | stated paths checked    | 27     | 88    |
+ *   | `console-development.md`| —      | 49    |
+ *   | `no-touch-zones.md`     | —      | 6     |
+ *   | `objectui-contributor/SKILL.md` | — | 5 |
+ *   | `verify/SKILL.md`       | —      | 1     |
+ *
+ * The batch of red it brought was exactly one token, and it was not rot: the
+ * deliberate negative sentence in `console-development.md`'s Key contexts
+ * section ("there is no `apps/console/src/context/` directory at all"), which
+ * held the sole baseline entry before the move and holds it again under its new
+ * key. The other 60 coordinates in the two moved guides all resolved on
+ * arrival — they were maintained by hand through #3713 and #3730 and had not
+ * yet gone stale, which is the case FOR gating them, not against.
+ *
+ * The lesson the widening itself taught is in `main()`: a whole-surface floor
+ * cannot see a root that stopped being read. Emptiness is judged per root now.
  *
  * ## The prefix allow-list is a decision, not an accident
  *
@@ -101,8 +142,16 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isEntrypoint } from './invoked-as.mjs';
 
-/** The scan surface, relative to the repo root: markdown under this directory. */
-export const SCAN_ROOT = 'skills';
+/**
+ * The scan surface: markdown under each of these directories, relative to the
+ * repo root.
+ *
+ * A LIST since objectui#7358, and the list is the point — see "The scan surface
+ * is a decision too" above for the widening's measurement. `main()` judges each
+ * root SEPARATELY for emptiness, so a root that stops matching is red on its own
+ * rather than hidden behind the other root's healthy count.
+ */
+export const SCAN_ROOTS = ['skills', '.claude/skills'];
 
 /** Where the exemptions live. A ratchet — see `readBaseline`. */
 export const BASELINE_FILE = 'scripts/skills-path-baseline.json';
@@ -221,15 +270,20 @@ export function baselineKeys(baseline) {
  * The one scan. `main()`, `--list` and the test suite all go through here, so
  * the tests exercise the real code path rather than a parallel imitation.
  *
- * Reads the directory, not `git ls-files`: the surface is "markdown on disk
- * under `skills`", which lets the tests run the real `scan()` over a fixture
- * tree with no git repository in it.
+ * Reads the directories, not `git ls-files`: the surface is "markdown on disk
+ * under each of `SCAN_ROOTS`", which lets the tests run the real `scan()` over a
+ * fixture tree with no git repository in it.
+ *
+ * `perRoot` carries the same three numbers per scan root. The totals alone
+ * cannot answer "is every root still being read?" — the reading that motivated
+ * objectui#7358 was a comfortable 27/27 across 16 files while a second tree of
+ * 55 assertions sat unscanned — so the breakdown is part of the result, not a
+ * `--list` nicety.
  *
  * @param root      directory to treat as the repository root
  * @param baseline  `{ allowedMissing: { [file]: { [token]: { reason, issue } } } }`
  */
 export function scan(root, baseline = readBaseline(root)) {
-  const files = markdownFiles(path.join(root, SCAN_ROOT));
 
   /** Dead paths nobody declared. Red. */
   const missing = [];
@@ -239,40 +293,57 @@ export function scan(root, baseline = readBaseline(root)) {
   const staleNowExists = [];
   /** Tokens rule 2 excluded. Reported by `--list` only. */
   const patterns = [];
+  /** One `{ root, files, checked, resolved }` row per scan root. */
+  const perRoot = [];
   const seen = new Set();
+  let files = 0;
   let checked = 0;
   let resolved = 0;
 
-  for (const full of files) {
-    const file = path.relative(root, full);
-    for (const hit of extractPathTokens(readFileSync(full, 'utf8'))) {
-      if (hit.pattern) {
-        patterns.push({ file, ...hit });
-        continue;
-      }
-      checked++;
+  for (const scanRoot of SCAN_ROOTS) {
+    const rootFiles = markdownFiles(path.join(root, scanRoot));
+    const checkedBefore = checked;
+    const resolvedBefore = resolved;
 
-      const entry = baseline.allowedMissing[file]?.[hit.token];
-      if (entry) seen.add(keyOf(file, hit.token));
-      const record = { file, line: hit.line, token: hit.token };
+    for (const full of rootFiles) {
+      const file = path.relative(root, full);
+      for (const hit of extractPathTokens(readFileSync(full, 'utf8'))) {
+        if (hit.pattern) {
+          patterns.push({ file, ...hit });
+          continue;
+        }
+        checked++;
 
-      if (existsSync(path.join(root, hit.token))) {
-        resolved++;
-        if (entry) staleNowExists.push({ ...record, ...entry });
-        continue;
+        const entry = baseline.allowedMissing[file]?.[hit.token];
+        if (entry) seen.add(keyOf(file, hit.token));
+        const record = { file, line: hit.line, token: hit.token };
+
+        if (existsSync(path.join(root, hit.token))) {
+          resolved++;
+          if (entry) staleNowExists.push({ ...record, ...entry });
+          continue;
+        }
+        if (entry) {
+          exempt.push({ ...record, ...entry });
+          continue;
+        }
+        missing.push(record);
       }
-      if (entry) {
-        exempt.push({ ...record, ...entry });
-        continue;
-      }
-      missing.push(record);
     }
+
+    files += rootFiles.length;
+    perRoot.push({
+      root: scanRoot,
+      files: rootFiles.length,
+      checked: checked - checkedBefore,
+      resolved: resolved - resolvedBefore,
+    });
   }
 
   /** Declared exemptions the scan never met. Red. */
   const staleUnseen = baselineKeys(baseline).filter((key) => !seen.has(key));
 
-  return { missing, exempt, staleNowExists, staleUnseen, patterns, files: files.length, checked, resolved };
+  return { missing, exempt, staleNowExists, staleUnseen, patterns, perRoot, files, checked, resolved };
 }
 
 function repoRoot() {
@@ -289,14 +360,28 @@ function main() {
   // The empty-verdict trap: a broken extractor, a renamed scan root or a moved
   // guide tree would satisfy every assertion above by finding nothing at all.
   // A gate that passes because it looked at zero files is not a gate.
-  if (result.files === 0 || result.checked === 0) {
+  //
+  // PER ROOT since objectui#7358, which is the failure that made the widening
+  // worth its own change: the contributor guides left `skills/` for
+  // `.claude/skills/`, and a whole-surface test stayed green on the 16 files
+  // still under `skills` while 55 of 93 assertions had quietly stopped being
+  // checked. Summed over roots, "one root reads nothing" is invisible; per root
+  // it is the loudest line in the output. A root that scans nothing is either a
+  // move nobody threaded through here or a root that should be deleted from
+  // SCAN_ROOTS — both are decisions, neither is a pass.
+  const emptyRoots = result.perRoot.filter((r) => r.files === 0 || r.checked === 0);
+  if (emptyRoots.length > 0) {
+    const rows = emptyRoots
+      .map((r) => `    • ${r.root}/ — ${r.files} markdown file(s), ${r.checked} path assertion(s)`)
+      .join('\n');
     console.error(
-      `❌  check-skills-paths: scanned ${result.files} markdown file(s) under ${SCAN_ROOT}/ and found ${result.checked} path assertion(s).\n\n` +
-        `Nothing to judge means this gate reports OK for the wrong reason. Either the\n` +
-        `scan surface moved (see SCAN_ROOT) or the extractor stopped matching (see\n` +
+      `❌  check-skills-paths: ${emptyRoots.length} of ${result.perRoot.length} scan root(s) judged nothing:\n\n${rows}\n\n` +
+        `Nothing to judge means this gate reports OK for the wrong reason. Either that\n` +
+        `surface moved (see SCAN_ROOTS) or the extractor stopped matching (see\n` +
         `extractPathTokens and PATH_PREFIXES). objectui#3735 measured 18 files and\n` +
-        `86 assertions on main@6422aa891, so a reading of zero is a broken gate, not\n` +
-        `a clean tree.`,
+        `86 assertions under skills/ on main@6422aa891, and objectui#7358 measured\n` +
+        `20 files and 88 assertions across both roots, so a reading of zero for any\n` +
+        `root is a broken gate, not a clean tree.`,
     );
     process.exit(1);
   }
@@ -307,6 +392,10 @@ function main() {
       `✅  check-skills-paths: OK (${result.resolved}/${result.checked} stated path(s) resolve across ` +
         `${result.files} guide file(s)${waived}).`,
     );
+    // Per root, always — a total is not evidence that every root was read.
+    for (const r of result.perRoot) {
+      console.log(`    ${r.root}/ — ${r.resolved}/${r.checked} resolve across ${r.files} file(s)`);
+    }
     process.exit(0);
   }
 
@@ -365,6 +454,9 @@ if (invokedDirectly) {
         `(${result.resolved} resolve, ${result.exempt.length} baselined), ` +
         `${result.patterns.length} pattern(s) excluded.`,
     );
+    for (const r of result.perRoot) {
+      console.log(`  ${r.root}/ — ${r.files} file(s), ${r.checked} checked, ${r.resolved} resolve`);
+    }
   } else {
     main();
   }

--- a/scripts/skills-path-baseline.json
+++ b/scripts/skills-path-baseline.json
@@ -3,7 +3,10 @@
     "Exemptions for scripts/check-skills-paths.mjs: in-repo paths a guide states in a",
     "backtick code span that deliberately do NOT exist on disk. Measured on",
     "main@6422aa891: 86 stated paths across the 18 guide files, 85 resolve, and this",
-    "is the one that does not.",
+    "is the one that does not. Re-measured on main@0614b6df1 after objectui#7358",
+    "widened SCAN_ROOTS to cover .claude/skills: 88 stated paths across 20 files, 87",
+    "resolve, and it is still this same one -- stated now from the path objectui#7251",
+    "moved the guide to.",
     "",
     "A RATCHET, not an allowlist, red in BOTH directions (scan() in that script):",
     "  - the path APPEARS on disk    -> red. The sentence built around 'there is no",
@@ -15,19 +18,25 @@
     "constantly (PR #3856 moved this very file's paragraphs) and a line-keyed",
     "exemption would go stale on every unrelated edit.",
     "",
+    "The file key is a real coordinate, so a MOVE retires the entry the same way a",
+    "rewrite does -- that is the second direction working, not a bug. objectui#7251",
+    "moved this guide out of the scan root and the gate demanded the entry's deletion",
+    "in its own words ('1 baseline entry the scan never met ... Delete the entry');",
+    "it was deleted, and objectui#7358 re-added it under the new key once the widened",
+    "SCAN_ROOTS met the same sentence again.",
+    "",
     "Not everything unresolvable needs an entry. A token containing whitespace, a",
     "glob metacharacter or a placeholder segment is excluded by RULE, because it is",
     "not a claim that a file exists -- see the script's docblock. Reach for this file",
-    "only when the prose really does assert the absence of a real coordinate.",
-    "",
-    "EMPTY as of objectui#7251. The one entry was the negative sentence in",
-    "skills/objectui/guides/console-development.md, and that guide moved out of the",
-    "scan root to .claude/skills/objectui-contributor/ -- contributor-only content that",
-    "a customer install has no use for. The gate demanded the deletion in its own",
-    "words: \"1 baseline entry the scan never met ... Delete the entry from",
-    "scripts/skills-path-baseline.json\". An empty map is the correct resting state",
-    "for a ratchet with nothing to exempt, not a missing file."
+    "only when the prose really does assert the absence of a real coordinate."
   ],
 
-  "allowedMissing": {}
+  "allowedMissing": {
+    ".claude/skills/objectui-contributor/guides/console-development.md": {
+      "apps/console/src/context/": {
+        "reason": "Deliberate negative statement. The Key contexts section exists to correct the recurring wrong guess that the five contexts live in the console app: 'there is no apps/console/src/context/ directory at all'. If this directory is ever created, that sentence must be rewritten before the entry is removed. Granted against the gate's own prescription for this case: 'If the path is deliberately named as NOT existing -- a sentence whose whole point is \"there is no such directory\" -- add it to scripts/skills-path-baseline.json with a reason, and expect the gate to go red again the day that path appears on disk.'",
+        "issue": "objectui#3735 (re-keyed under the moved guide path by objectui#7358, 2026-09-02)"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes #7358

`SCAN_ROOT` was one string, `skills`. #7251 moved the two contributor-only guides into `.claude/skills/objectui-contributor/` and 55 of 93 stated paths left the checked surface in one commit with nothing turning red — the gate simply stopped looking. This makes it a list, `['skills', '.claude/skills']`, clears the red the wider surface brings, and restores the pins #7251 had to weaken.

Head: `471589f`. Every number below was measured on that commit unless it names another.

## The measurement the docblock asks for

The script's own header requires this: *"Widen it on purpose, with the measurement re-run, not as a rider."* Re-run, before and after, with `node scripts/check-skills-paths.mjs` and `--list`:

| | before (`0614b6df1`) | after (`471589f`) |
|---|---|---|
| files scanned | 16 | **20** |
| stated paths checked | 27 | **88** |
| resolve | 27 | 87 (+1 baselined) |
| pattern tokens excluded | 1 | 4 |
| `console-development.md` | — (unscanned) | **49** |
| `no-touch-zones.md` | — (unscanned) | **6** |
| `objectui-contributor/SKILL.md` | — (unscanned) | **5** |
| `verify/SKILL.md` | — (unscanned) | **1** |

Per root, which the gate now prints on every green run:

```
✅  check-skills-paths: OK (87/88 stated path(s) resolve across 20 guide file(s); 1 baselined).
    skills/ — 27/27 resolve across 16 file(s)
    .claude/skills/ — 60/61 resolve across 4 file(s)
```

**The card's headline number is 93, and the honest re-measurement is 88.** Both the card's own figures cannot hold at once: it records 18 to 16 files and 93 to 27 assertions, a loss of 66, while the two moved guides carry 55 between them. The missing 11 are assertions #7251 also removed when it rewrote the published guides it kept. So widening restores 61 assertions under the new root — the 55 that left, plus 6 in two files that were never under `skills` at all — for 88, not 93. The PR title carries the measured number rather than the card's.

## The red the widened surface brought: exactly one, and it is not rot

```
❌  check-skills-paths: 1 stated path does not exist

    • .claude/skills/objectui-contributor/guides/console-development.md:381 — apps/console/src/context/
```

**Coordinates corrected at source: zero.** Not for want of looking — the other 60 in the two moved guides all resolved on arrival. They were maintained by hand through #3713 and #3730 and had not yet gone stale, which is the case *for* gating them, not against.

The one non-resolver is the deliberate negative sentence in the Key contexts section, which exists to correct the recurring wrong guess that the five contexts live in the console app:

> All five live in `@object-ui/app-shell`; there is no `apps/console/src/context/` directory at all.

Evidence it is a true statement and not a stale coordinate:

```
$ ls -d apps/console/src/context/
ls: cannot access 'apps/console/src/context/': No such file or directory
```

This is the entry #7251 was forced to delete. The baseline is keyed by guide file, so the move retired it through the ratchet's second direction — the gate demanded it in its own words, *"1 baseline entry the scan never met ... Delete the entry"*. Widening the root makes the scan meet the same sentence again, so the entry returns under the new key, granted against the gate's own prescription, quoted verbatim in the entry's `reason`:

> If the path is deliberately named as NOT existing — a sentence whose whole point is "there is no such directory" — add it to `scripts/skills-path-baseline.json` with a reason, and expect the gate to go red again the day that path appears on disk.

Dated `objectui#3735 (re-keyed under the moved guide path by objectui#7358, 2026-09-02)`. It is the only entry in the file, as it was before the move: one exemption for 88 assertions.

## The lesson the miss itself taught: emptiness is judged per root

The empty-verdict trap in `main()` used to ask whether the *whole surface* read zero. That question could not have caught #7251: 16 files and 27 assertions still under `skills` is a healthy-looking total while a second tree of 55 sits unscanned. It now asks per root, and a root that judges nothing is named and red — either a move nobody threaded through, or a root that should be deleted from `SCAN_ROOTS`, and both are decisions rather than a pass. `scan()` returns a `perRoot` row per root to make that answerable at all.

## The pins #7251 left to be reversed

All three were named in advance by the comments beside them.

1. **The `checked` floor, 20 back to 50.** With the arithmetic restored, as #7251 left it: 88 checked today, of which the two moved guides carry 55 (49 + 6). If `.claude/skills` ever falls out of `SCAN_ROOTS` the reading drops to 33 and the floor is red — the assertion #7251 could not make.
2. **A per-root floor beside it**, because the one above is a total: 27 under `skills` alone clears a floor of 20, which is exactly how the 55 left unnoticed.
3. **The #3713 / #3730 block asserts `result.missing` through `scan(repoRoot)` again**, on the guide's current path, and carries its exemption pin again.
4. **The "is NOT covered by the gate today" assertion is DELETED**, as it was written to be. Its replacement is the *inverse* claim rather than nothing: `inGuide(result.missing)` is empty both when the guide is clean and when nothing scans it, so the guide's own stated-path density is now tied to its root's `checked` count and the two stop being confusable.

Five fixture cases cover the two-root surface: the declared roots, a dead path found under `.claude/skills`, the `perRoot` breakdown, a root that reads nothing showing as a zero row rather than an absence, and a baseline entry keyed under the second root. 31 to 37 cases.

## Ablation — the widened root really is checked

One coordinate in the newly covered guide, mutated on the committed tree and restored, both legs proved on disk. No build or `dist` is involved: the gate is a `node` script reading markdown, so there is no artifact between the edit and the reading.

**Mutation landed** (`packages/app-shell/src/layout/UnifiedSidebar.tsx` to `...SidebarGONE.tsx`, injected-token count 1, original-token count 0, on-disk hash `0cd9feb` against HEAD blob `27e5f46`), gate exit **1**:

```
❌  check-skills-paths: 1 stated path does not exist

    • .claude/skills/objectui-contributor/guides/console-development.md:268 — packages/app-shell/src/layout/UnifiedSidebarGONE.tsx
```

**Restore proved**, not assumed — `git checkout HEAD -- ABSOLUTE_PATH` under a `trap ... EXIT INT TERM`, then on-disk hash `27e5f46` equal to the HEAD blob, `git diff HEAD --name-only` empty, injected-token count 0, original-token count 1. Gate exit **0**:

```
✅  check-skills-paths: OK (87/88 stated path(s) resolve across 20 guide file(s); 1 baselined).
```

## Premises that did not hold

- `premise_false: the gate has a --self-test mode` — the dispatch expected `node scripts/check-skills-paths.mjs` to run "self-test + live". It has no such flag; `grep -n 'self-test\|selfTest'` over the script returns nothing, and its only mode besides the live run is `--list`. The self-test is the vitest suite, and that is where the two-root cases were added.
- `premise_false: 93 stated paths come back under the gate` — 88, for the arithmetic given above.
- `premise_false: the queue guard returns exit 3 GOVERNED` — it does so when `.claude/skills/**` is in the diff, and nothing there needed correcting, so the diff is three files under `scripts/`. Its own verdict: `✅ NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.` Draft and human-merged either way, as the dispatch asks.
- `premise_false: the widened surface brings stale coordinates to correct at source` — 60 of 61 resolve; the single non-resolver is the deliberate negative sentence.

## Gates, at `471589f`

Exit codes captured by redirecting first (`cmd > file 2>&1; EXIT=$?`), never read across a pipe. Each row quotes the gate's own verdict line.

| gate | exit | its own verdict |
|---|---|---|
| `node scripts/check-skills-paths.mjs` | 0 | `✅  check-skills-paths: OK (87/88 stated path(s) resolve across 20 guide file(s); 1 baselined).` |
| `pnpm exec vitest run scripts/__tests__/check-skills-paths.test.ts` | 0 | `Test Files  1 passed (1)` / `Tests  37 passed (37)` |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, silent |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅  check-control-bytes: OK (scanned 6103 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `✅  check-shell-escape-residue: OK (4/4 root(s) resolved ...)` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `OK check-governed-queue-guard self-test: 132 cases pass` |
| `node scripts/check-governed-queue-guard.mjs --test` (3 changed paths) | 0 | `✅ NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.` |
| `pnpm exec eslint` (changed files) | 0 | 1 file linted, 0 errors, 0 warnings |

**No changeset**, on the gate's own verdict, not on judgement: `3 file(s) changed, 0 of them published source of a package the release covers`. No `skip-changeset` label, which this repo does not use as a mechanism, and no empty-frontmatter changeset either — the gate says none is owed.

**`type-check:scripts` genuinely covers the edited test file**, rather than excluding it and reporting a clean run about other files: `tsc -p tsconfig.scripts.json --listFiles` lists both `scripts/check-skills-paths.mjs` and `scripts/__tests__/check-skills-paths.test.ts`, one occurrence each.

**eslint was narrowed, and the narrowing is measured rather than assumed.** Population, read from `eslint.config.js` and not guessed: every rule block is scoped `files: ['**/*.{ts,tsx}']`, and no block declares an `.mjs`, `.cjs` or `.json` glob — so of the three changed files only the `.ts` test is inside the linted population at all. File count read from `--format json`: 1 result object, `errorCount` 0, `warningCount` 0. Invariance: the config declares neither `parserOptions.project` nor `projectService`, so linting is not type-aware and nothing in this diff can move the verdict on a file it did not touch. The full-repo `pnpm lint` is CI's run.

## Scope

Three files, all under `scripts/`. Nothing under `skills/objectui/**`, nothing under `packages/**`, no other gate touched, and — because nothing needed correcting — nothing under `.claude/skills/**` either.

Two findings of the same class were filed unassigned rather than ridden in here; neither is addressed by this PR:

- #7403 — `check-shell-escape-residue`'s `skills` directory root lost the same two files in the same move: 18 fenced blocks off its surface, invisible to its `minFiles: 5` floor because 16 files still satisfy it.
- #7404 — this gate's own workflow header still states the surface as `skills/**` over 18 files. Prose only; the workflow has no path filter and still runs correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_