### PR TITLE
skills(objectui): evals grade what the guides teach — six assertions re-pointed or dropped, two substring accidents fixed, registerComponent taught (#7360)

### DIFF
--- a/skills/objectui/evals/mobile.json
+++ b/skills/objectui/evals/mobile.json
@@ -4,14 +4,14 @@
     {
       "id": 1,
       "prompt": "My ObjectUI dashboard looks broken on mobile phones — cards stack but the sidebar takes up the whole screen. How do I make it responsive?",
-      "expected_output": "Provides responsive grid schema with Tailwind mobile-first classes, useBreakpoint hook usage, and sidebar responsive pattern.",
+      "expected_output": "Provides responsive grid schema with Tailwind mobile-first classes, useBreakpoint hook usage, and the ResponsiveContainer breakpoint gate for the sidebar — @object-ui/mobile ships no mobile widgets, only that gate.",
       "files": [],
       "assertions": {
         "must_contain": [
           "useBreakpoint",
           "grid-cols-1",
           "md:",
-          "sidebar"
+          "ResponsiveContainer"
         ],
         "must_not_contain": [
           "window.innerWidth <"

--- a/skills/objectui/evals/page-builder.json
+++ b/skills/objectui/evals/page-builder.json
@@ -29,7 +29,7 @@
         "must_contain": [
           "visible",
           "admin",
-          "section"
+          "card"
         ],
         "must_not_contain": [
           "role === 'admin' ? <Button",
@@ -47,8 +47,7 @@
           "dashboard",
           "chart",
           "action",
-          "navigate",
-          "refresh"
+          "navigate"
         ],
         "must_not_contain": []
       }

--- a/skills/objectui/evals/plugin-development.json
+++ b/skills/objectui/evals/plugin-development.json
@@ -11,7 +11,7 @@
           "registerComponent",
           "namespace",
           "useDataScope",
-          "FieldWidgetProps",
+          "FieldWidgetComponentProps",
           "vitest"
         ],
         "must_not_contain": [
@@ -36,11 +36,11 @@
     {
       "id": 3,
       "prompt": "How do I create a custom field widget that renders a star rating input (1-5 stars) and integrates with ObjectUI forms?",
-      "expected_output": "Shows FieldWidgetProps implementation with value/onChange, star rendering logic, proper readonly/disabled handling, and registration pattern.",
+      "expected_output": "Shows FieldWidgetComponentProps implementation with value/onChange, star rendering logic, proper readonly/disabled handling, and registration pattern.",
       "files": [],
       "assertions": {
         "must_contain": [
-          "FieldWidgetProps",
+          "FieldWidgetComponentProps",
           "value",
           "onChange",
           "readonly",

--- a/skills/objectui/evals/project-setup.json
+++ b/skills/objectui/evals/project-setup.json
@@ -46,8 +46,7 @@
         "must_contain": [
           "@object-ui/plugin-grid",
           "@object-ui/plugin-kanban",
-          "import",
-          "ComponentRegistry"
+          "import"
         ],
         "must_not_contain": [
           "node_modules/@object-ui",

--- a/skills/objectui/evals/testing.json
+++ b/skills/objectui/evals/testing.json
@@ -29,7 +29,6 @@
           "React Testing Library",
           "SchemaRendererProvider",
           "create",
-          "edit",
           "view"
         ],
         "must_not_contain": []

--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -47,17 +47,17 @@ The registry maps JSON `type` strings to React component implementations.
 import { ComponentRegistry } from '@object-ui/core';
 
 ComponentRegistry.register('my-widget', MyWidgetRenderer, {
-  namespace: 'plugin-my-widget',   // Registers as "plugin-my-widget:my-widget"
-  label: 'My Widget',              // Display name in designer
-  icon: 'layout-grid',            // Lucide icon name
+  namespace: 'plugin-my-widget',
+  label: 'My Widget',
+  icon: 'layout-grid',
   category: 'plugin',             // Grouping: 'plugin' | 'view' | 'field' | 'layout'
-  isContainer: false,              // Accepts child components?
-  inputs: [                        // Designer configuration inputs
+  isContainer: false,
+  inputs: [
     { name: 'title', type: 'string', label: 'Title' },
     { name: 'columns', type: 'array', label: 'Columns', required: true },
     { name: 'mode', type: 'enum', label: 'Mode', enum: ['compact', 'full'] },
   ],
-  defaultProps: { mode: 'full' },  // Defaults when dropped in designer
+  defaultProps: { mode: 'full' },
 });
 ```
 
@@ -137,6 +137,12 @@ When registering with a namespace:
 
 **Use `skipFallback: true`** when multiple plugins register the same base type (e.g., both `plugin-form` and `plugin-grid` registering `'form'`).
 
+**A plugin handed a `PluginScope` registers through it instead** —
+`scope.registerComponent(type, component, meta?)`
+(`packages/types/src/plugin-scope.ts`) applies the scope's own name, storing
+`pluginName:type`, so it takes no `namespace`. `ComponentRegistry.register` is
+the global registry, where the namespace is yours to pass.
+
 ## Implementing a plugin component
 
 ### Entry point pattern (`index.tsx`)
@@ -164,14 +170,9 @@ const MyWidgetRenderer: React.FC<{ schema: any }> = ({ schema }) => {
   );
 };
 
-// Register in ComponentRegistry
+// Register in ComponentRegistry — meta options as above
 ComponentRegistry.register('my-widget', MyWidgetRenderer, {
   namespace: 'plugin-my-widget',
-  label: 'My Widget',
-  category: 'plugin',
-  inputs: [
-    { name: 'title', type: 'string', label: 'Title' },
-  ],
 });
 ```
 


### PR DESCRIPTION
Fixes #7360

Governed surface (`skills/**`): this stays a **draft** and a human merge is the review record. `check-governed-queue-guard --test` returns exit 3 over the change set, which is the correct verdict, not a red.

Six commits at `f6c2f1b`, one per eval file plus one for the guide, so any one can be dropped. Every count below is `grep -c` against the guide the eval actually scores (`guides/BASENAME.md` for `evals/BASENAME.json`), measured at the branch point `0614b6d`.

## Landing map — 落点 | before | after

### Fix the assertion (the eval tests a real decision with the wrong token)

| 落点 | before | after | evidence |
|---|---|---|---|
| `evals/plugin-development.json` evals 1 and 3 | `FieldWidgetProps` — 1 occurrence in `guides/plugin-development.md`, and it is the head of `FieldWidgetPropsSchema` (the published spec schema, line 277). Substring accident: the assertion passed on a name the guide never teaches | `FieldWidgetComponentProps` | the guide uses the long name 6 times, including its own `FieldWidgetComponentProps interface` section and the `@object-ui/fields` import in the worked example; the implementation exports it (`packages/fields/src/index.tsx`, `packages/fields/src/FieldEditWidget.tsx`). `packages/fields/src/__tests__/spec-symbol-batch7.test.ts:22` records the rename in its own words: "`FieldWidgetProps` is now `FieldWidgetComponentProps`" |
| `evals/mobile.json` eval 1 | `sidebar` — **0** in `guides/mobile.md` | `ResponsiveContainer` — 4 in that guide | re-pointed, not dropped, because the eval tests something real. The guide answers the prompt under "Breakpoint-gated rendering and mobile navigation": `@object-ui/mobile` ships no widgets — no `BottomSheet`, no `MobileNav` — "what it ships is the gate: `ResponsiveContainer` renders its children only on the breakpoints you name". Real export at `packages/mobile/src/index.ts:30`. Alternative considered and rejected: `mobileNavMode` (1 occurrence), the app-shell key for drawer / bottom-nav — narrower than a dashboard-layout prompt |
| `evals/page-builder.json` eval 2 | `section` — **0** in `guides/page-builder.md` | `card` — 4 in that guide | re-pointed. The guide's node-shape example is literally a titled detail-page block, `{ "type": "card", "id": "customer_summary", "title": "Customer Summary", "hidden": "${data.userRole !== 'admin'}" }`, and its layout-primitive table describes `card` beside the five structural types as the one that "adds a border, a shadow and a `CardContent` wrapper around the children" |

### Drop the token (nothing in the guide corresponds)

| 落点 | before | after | why dropped rather than re-pointed |
|---|---|---|---|
| `evals/project-setup.json` eval 3 | `ComponentRegistry` — **0** in `guides/project-setup.md` | removed from `must_contain` | same file measures `registration` 0, `side-effect` 0, `Unknown component type` 0, and `register` 1 — that one being "`PageRenderer` ... is reached through the registry, not by import", a sentence about app-shell's `*View` exports. The guide's entire plugin surface is two dependency lines in its `package.json` block and a decision-matrix row; it never states the side-effect import. The three surviving tokens (`@object-ui/plugin-grid`, `@object-ui/plugin-kanban`, `import`) are all taught and still grade the real decision |
| `evals/testing.json` eval 2 | `edit` — **0** in `guides/testing.md` | removed from `must_contain` | `mode` also counts 0 there; the guide teaches nothing about form modes. The key is real but taught in a different guide (`guides/page-builder.md` writes `"mode": "edit"` on an `object-form` node), and this eval is scored against `guides/testing.md`. What the guide does teach is already graded by `SchemaRendererProvider` (5 occurrences) |
| `evals/page-builder.json` eval 3 | `refresh` — **0** in `guides/page-builder.md` | removed from `must_contain` | `refresh` is real, but it is registered by `@object-ui/app-shell` (`packages/app-shell/src/hooks/useObjectActions.ts:193`, `runner.registerHandler('refresh', ...)`), not by the core action vocabulary this guide teaches — its action section shows `validate`, `submit`, `navigate` and nothing else. The assertion still grades the decision through `action` (15) and `navigate` (1) |

In all three, only the mechanically graded literal changed. Prompts keep their wording, and `project-setup.json` eval 3 keeps its `expected_output` sentence about `ComponentRegistry`: it is a true statement about the runtime, it just is not gradeable against a guide that does not teach it.

### Teach the thing

| 落点 | before | after |
|---|---|---|
| `guides/plugin-development.md`, "Namespace system" | `registerComponent` occurred **0 times anywhere in the published skill**, while three assertions required it — `evals/plugin-development.json` evals 1 and 2, `evals/page-builder.json` eval 1 | one bullet, no new section, naming `scope.registerComponent(type, component, meta?)` beside `ComponentRegistry.register` |

Signature verified at source, not carried from the card: `registerComponent(type: string, component: any, meta?: ComponentMeta): void` on the `PluginScope` interface, `packages/types/src/plugin-scope.ts:54`.

The one distinguishing fact is the docblock's own — "Components will be registered as `pluginName:type` to prevent conflicts", so the scope owns the namespace. That is checkable rather than merely quoted: the `ComponentMeta` `plugin-scope.ts` imports is `@object-ui/types`' (`base.ts`), which declares **no** `namespace` key, whereas `ComponentRegistry.register` takes core's `ComponentMeta = CanonicalComponentMeta & RegistryComponentMetaExtras` (`packages/core/src/registry/Registry.ts:260`), where `namespace` lives.

**Honest limit on the fix, so it is not mistaken for complete.** The row makes `registerComponent` taught **package-wide** (0 to 1). It does not change the count in `guides/page-builder.md`, which still measures 0 — so `evals/page-builder.json` eval 1 is honest under a bundle-wide oracle and still untaught under a per-guide one. Which oracle applies is a design input to #7359's structural check, recorded on that card rather than decided here.

## `premise_false` — one funded row skipped, no edit forced

**`useOffline` in `evals/mobile.json` eval 2.** The card reads this as a second substring accident, on the ground that `packages/mobile/src/index.ts` exports `useOfflineSync` rather than `useOffline`. That is true of `@object-ui/mobile` and irrelevant here: the guide does not import the hook from that package.

Three legs, all at `0614b6d`:

- `packages/react/src/hooks/useOffline.ts:256` declares `export function useOffline(config: OfflineConfig = {}): OfflineResult`
- it reaches the public entry point: `packages/react/src/hooks/index.ts:30` re-exports it, and `packages/react/src/index.ts:11` is `export * from './hooks/index.js'` — so `@object-ui/react` really does export `useOffline`
- `guides/mobile.md:123` teaches exactly `import { useOffline } from '@object-ui/react';` and line 126 destructures `{ isOnline, pendingCount, syncState }`, which matches the implementation (`isOnline` and `syncState` are declared in the function body; `pendingCount` is the docblock's own example)

The token counts **2** in the guide it scores, not 0. `useOfflineSync` is a different hook in a different package. Nothing to fix, and the assertion is left exactly as it was.

## Token deltas — `ceil(utf8_bytes / 4)`

The programme's rule is shrink-or-neutral per file for the guide that gained content. `guides/plugin-development.md` pays for its bullet in the same file:

| file | before | after | Δ |
|---|---|---|---|
| `guides/plugin-development.md` | 14,335 B / 3,584 tok | 14,325 B / 3,582 tok | **−2 tok** |

Both deletions are duplication the file already carries twice: six trailing comments in the canonical registration example that the "ComponentMeta options (full reference)" table two lines below restates ("Lucide icon name" and "Accepts child components" verbatim; the `namespace` one a triple, since the "Namespace system" section states the same `plugin-my-widget:my-widget` key as its point 1), and the meta object in the entry-point example's second `register` call, a subset of the canonical block 120 lines above. The `category` comment stays — its enum is the one fact the table omits.

The eval fixtures, reported for completeness rather than because the rule binds them:

| file | before | after | Δ |
|---|---|---|---|
| `evals/mobile.json` | 426 tok | 452 tok | +26 |
| `evals/page-builder.json` | 566 tok | 560 tok | −6 |
| `evals/plugin-development.json` | 485 tok | 492 tok | +7 |
| `evals/project-setup.json` | 794 tok | 786 tok | −8 |
| `evals/testing.json` | 486 tok | 481 tok | −5 |
| **edited files, total** | 6,339 tok | 6,351 tok | **+12** |

`mobile.json` carries the whole increase: its `expected_output` now names the gate the assertion grades and the fact that `@object-ui/mobile` ships no mobile widgets, so a grader cannot accept a `MobileNav` answer. The published prose bundle (every `.md` under `skills/objectui/`) is **37,582 to 37,579 tokens, −3**.

## Gates — all at head `f6c2f1b`, exit codes captured before any pipe

| gate | exit | its own verdict line |
|---|---|---|
| `node scripts/check-skills-paths.mjs` | 0 | `✅  check-skills-paths: OK (28/28 stated path(s) resolve across 16 guide file(s)).` — `--list` confirms the newly stated `packages/types/src/plugin-scope.ts` is among the 28 checked, so the row's coordinate is gated, not merely written |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅  check-control-bytes: OK (scanned 6103 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `✅  check-shell-escape-residue: OK (4/4 root(s) resolved -- ... skills: 16 file(s), 196 fence(s) ...).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` — its own verdict, so none is added |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `OK check-governed-queue-guard self-test: 132 cases pass` |
| `... --test` over the six changed paths | **3** | `One governed path governs the WHOLE pull request` — GOVERNED, the correct verdict; the PR is parked as a draft accordingly |
| `pnpm exec vitest run` over 4 files (below) | 0 | `Test Files  4 passed (4)` / `Tests  91 passed (91)` |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, no diagnostics |
| `JSON.parse` on all 11 `evals/*.json` | 0 | all 11 parse, including the 5 edited |

The vitest set is the dispatched pair plus two the dispatch did not name and the diff earns — see below: `scripts/__tests__/doc-version-claims.test.ts`, `scripts/__tests__/check-skills-paths.test.ts`, `packages/components/src/__tests__/skill-guide-provider-envelope.test.tsx`, `packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx`.

### Two dispatch premises measured false, and the gates they add

The dispatch stated that `evals/*.json` is read by no gate or test. `git grep -ln "skills/objectui/evals"` over `scripts/ packages/ apps/` does return nothing, as it says — but that spelling is not how the reader finds them. `packages/components/src/__tests__/skill-guide-provider-envelope.test.tsx:248` globs the published tree and filters `/evals/`, then asserts over **every** `must_contain` array in the package that no entry matches `/^props\./`, with a counter-probe (`expect(graded).toBeGreaterThan(0)`) so an emptied assertion list cannot pass vacuously. Editing five eval files without running it would have been unmeasured. It is green.

The dispatch also stated that `guides/plugin-development.md` is read by no executable-fixture test. Correct as to fixtures — `skill-guide-data-table-binding.test.tsx` binds `schema-expressions.md` and `data-integration.md` — but the file is pinned twice in `scripts/__tests__/doc-version-claims.test.ts` (`KNOWN_CLAIMS` entries at lines 1167 and 1173, for the skeleton's `react` peer range and the `lucide-react` tail). That test was already on the dispatched list; the reason it matters is that the added bullet deliberately states **no** version literal, which is what keeps those entries the only two.

### Repo-wide lint, narrowed with the narrowing proven

`pnpm lint` (`eslint . --no-inline-config`) is a repository-wide scan that CI runs once regardless. It is not run here, and the narrowing is a measurement rather than an omission: asked about the two edited file types, eslint's **own configuration** answers `File ignored because no matching configuration was supplied` for both `skills/objectui/guides/plugin-development.md` and `skills/objectui/evals/mobile.json` (read from `--format json`, 2 files, 0 configured). A configuration that matches neither `.md` nor `.json` cannot have its verdict on any untouched file moved by this diff.

## Out-of-scope findings, filed unassigned rather than fixed here

- **#7405** — three more assertions that grade nothing. Two are accidental substring matches a `grep -c == 0` audit cannot see by construction: in the same `evals/testing.json` eval 2 array this PR edits, `create` counts 1 in `guides/testing.md` because of a mocked dataSource method (`create: vi.fn()...`) and `view` counts 1 because of the comment `// vite preview`. The third, `visible` in `evals/page-builder.json` eval 2, is untaught outright (0) where the guide teaches `hidden`. Not folded in: choosing between re-pointing and dropping is the per-row judgement #7360 funds by row, and none of these rows was funded.
- **#7406** — `guides/page-builder.md` states "Five registered types do all the structural work" and omits `section`, which is registered at `packages/components/src/renderers/layout/containers.tsx:988` and authored in the schema catalogue. This is why the `section` row above was re-pointed rather than closed by teaching: teaching it is an addition to a second guide, outside this card.

Both are recorded on the branch's commit messages as well, so the reasoning survives independently of the cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_