### PR TITLE
docs(ci): skills-paths header names both scan roots and drops the file count

### DIFF
--- a/.github/workflows/skills-paths.yml
+++ b/.github/workflows/skills-paths.yml
@@ -1,8 +1,9 @@
 name: Skills Paths
 
 # Why this is its own workflow instead of a step in `ci.yml` or `lint.yml`: this
-# gate's ENTIRE scan surface is markdown (`skills/**`, guide prose), and both of
-# those workflows list `'**/*.md'`, `content/**` and `docs/**` under the
+# gate's ENTIRE scan surface is markdown (`skills/**` and `.claude/skills/**`,
+# guide prose — the roots are `SCAN_ROOTS` in the script), and both of those
+# workflows list `'**/*.md'`, `content/**` and `docs/**` under the
 # `paths-ignore` of their `push` trigger, with no per-job path filter available in
 # GitHub Actions. A push that only edits a guide would therefore start neither —
 # and editing only a guide is the single most likely way a stated path goes dead.
@@ -19,9 +20,10 @@ name: Skills Paths
 # and fails too if a second workflow starts running the same script — one gate,
 # one home.
 #
-# It needs no install and no build — a checkout plus one `node` call over 18
-# markdown files, a couple of seconds — so keep it that way if you add checks to
-# it.
+# It needs no install and no build — a checkout plus one `node` call over the
+# markdown under those roots, a couple of seconds — so keep it that way if you
+# add checks to it. No file count is stated on purpose: it goes stale on every
+# guide added, which is how the previous one drifted.
 
 on:
   pull_request:


### PR DESCRIPTION
Fixes #7404

The header comment of `.github/workflows/skills-paths.yml` stated the gate's scan surface as `skills/**` over 18 markdown files. Both halves were stale, and they drifted in two separate steps. Prose only: the parsed workflow document is byte-identical before and after (proof in the gate table).

A reader who took the old parenthetical literally would conclude `.claude/skills` is ungated — the exact failure mode the widening exists to remove.

## Before / after

```diff
 # Why this is its own workflow instead of a step in `ci.yml` or `lint.yml`: this
-# gate's ENTIRE scan surface is markdown (`skills/**`, guide prose), and both of
-# those workflows list `'**/*.md'`, `content/**` and `docs/**` under the
+# gate's ENTIRE scan surface is markdown (`skills/**` and `.claude/skills/**`,
+# guide prose — the roots are `SCAN_ROOTS` in the script), and both of those
+# workflows list `'**/*.md'`, `content/**` and `docs/**` under the
 # `paths-ignore` of their `push` trigger, with no per-job path filter available in
```

```diff
-# It needs no install and no build — a checkout plus one `node` call over 18
-# markdown files, a couple of seconds — so keep it that way if you add checks to
-# it.
+# It needs no install and no build — a checkout plus one `node` call over the
+# markdown under those roots, a couple of seconds — so keep it that way if you
+# add checks to it. No file count is stated on purpose: it goes stale on every
+# guide added, which is how the previous one drifted.
```

The enumeration now names both roots and points at the declaration rather than copying a list; the count is dropped rather than restated at 20.

## The roots, as the script declares them

`scripts/check-skills-paths.mjs:154`, verbatim:

```js
export const SCAN_ROOTS = ['skills', '.claude/skills'];
```

Landed in `7c77298` — *"chore(scripts): check-skills-paths scans .claude/skills too — 27 to 88 stated paths under the gate, the #7251 pins restored (#7358) (#7407)"*. It replaced `export const SCAN_ROOT = 'skills'`.

The gate's own run at this head prints the surface, which is where the 18/16/20 arithmetic resolves:

```
✅  check-skills-paths: OK (87/88 stated path(s) resolve across 20 guide file(s); 1 baselined).
    skills/ — 27/27 resolve across 16 file(s)
    .claude/skills/ — 60/61 resolve across 4 file(s)
```

16 under `skills/` (was 18 before the guide move) plus 4 under `.claude/skills/` = the 20 the card names.

## The three claims kept, each verified on `main` at `6aeba67`

**1. The scan surface is entirely markdown.** `scripts/check-skills-paths.mjs:202` — the walker admits nothing else:

```js
else if (entry.name.endsWith('.md')) files.push(full);
```

Worth stating precisely, because it is a claim about what the gate *reads*, not about what the directories *hold*: the roots also contain 11 non-markdown files (`skills/objectui/evals/*.json`), which the gate never opens. The comment's wording ("scan surface") is already the accurate one, so it is kept as-is.

**2. `ci.yml` and `lint.yml` both list `'**/*.md'` under the `paths-ignore` of their `push` trigger.** `ci.yml:6-11`:

```yaml
  push:
    branches: [main, develop]
    paths-ignore:
      - '**/*.md'
      - 'content/**'
      - 'docs/**'
      - 'apps/site/**'
      - '.changeset/**'
```

`lint.yml:32-36` carries the same list minus `apps/site/**`. The header's scoping to the **push** trigger is exact and still required: both files removed `paths-ignore` from their `pull_request` trigger (`ci.yml:12`, `lint.yml:37` — "No `paths-ignore` here any more (objectui#3523, step 2)") and moved that decision into the jobs. Unchanged.

**3. This workflow carries no `paths` or `paths-ignore` of its own.** After comment-stripping there is no such key at all — the YAML parse below enumerates the whole `on:` block, and `scripts/__tests__/check-skills-paths.test.ts:552-555` pins it in both directions.

That pin is also why a comment edit cannot move anything in it. `scripts/__tests__/check-skills-paths.test.ts:517-526`, the `yamlOf` helper, drops whole-line comments before every assertion:

```ts
.filter((line) => !/^\s*#/.test(line))
```

Its own doc comment gives the reason: *"this file's own header discusses `paths` and `paths-ignore` in prose ... A scan that counted comments would report filters and duplicate homes that no file has."*

## Why the count is dropped, not restated

`lint.yml:26-28` records the same lesson from the other side, about a number that went stale on its own clock: *"The order of magnitude is the whole argument; the integer never was."* Restating 20 would re-arm the same drift on the next guide added.

## Gates — all at head `54d5db8`, exit code captured by redirect before any pipe

| Gate | Exit | Its own verdict line |
| --- | --- | --- |
| `vitest run scripts/__tests__/check-skills-paths.test.ts` (+ 2 derived, below) | 0 | `Test Files 3 passed (3)` · `Tests 88 passed (88)`; lock: `VERDICT command-exit 0` |
| `node scripts/check-skills-paths.mjs` | 0 | `✅  check-skills-paths: OK (87/88 stated path(s) resolve across 20 guide file(s); 1 baselined).` |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅  check-control-bytes: OK (scanned 6108 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --test .github/workflows/skills-paths.yml` | 0 | `✅ NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched.` |
| YAML parse, `yaml@2.9.0` from `node_modules` | 0 | `VERDICT: PARSED DOCUMENT IDENTICAL before/after — comment-only change confirmed` |

The changeset gate's verdict decides, and it says none is owed: one file changed, zero of them published source.

The YAML check parses both revisions with the repo's own `yaml@2.9.0` and compares the parsed documents, so "comment-only" is measured rather than asserted. It also re-prints `on:` (`pull_request`, `push`, `merge_group`, `workflow_dispatch` — no `paths` key), `permissions: contents: read`, and the three steps unchanged.

**Two suites beyond the dispatched list**, derived from the actual diff — both assert on this file, so a header edit is in their blast radius:

- `scripts/__tests__/check-pre-install-import-graph.test.ts:262` pins `'skills-paths.yml : skills-paths -> scripts/check-skills-paths.mjs'`
- `scripts/__tests__/merge-queue-reporting.test.ts:91` pins `skills-paths.yml` among the workflows that must subscribe `merge_group`

Both are in the 3-file, 88-test run above.

## Premise notes

Everything in the card held. Three deviations from the dispatch brief, none of them blocking:

- **The `workflow`-scope push refusal did not occur.** Both pushes (empty-branch probe, then the commit touching `.github/workflows/**`) returned exit 0.
- **The verify lock does not exist in this repo.** `scripts/pm/os-verify-lock.sh` is an objectstack script; there is no lock script under `objectui/scripts/`. The vitest run was serialized through the objectstack copy by absolute path, since the lock guards the shared container rather than a repo. Slot `objectui-7404`, acquired after 0s, held 6s.
- **Attribution of the widening.** The brief credits PR #7407, the card credits #7358; they are the same landed commit `7c77298`, whose title carries both numbers (issue and PR). Not a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_