### PR TITLE
chore(scripts): check-shell-escape-residue scans .claude/skills too — the 18 fenced blocks #7251 moved, back on its surface (#7403)

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -882,8 +882,19 @@ markdown-only change is exactly the shape `ci.yml` and `lint.yml` skip their exp
 appears in the checks list as **Shell Escape Residue Scan**.
 
 Runs `scripts/check-shell-escape-residue.mjs`. It walks `AGENTS.md`, `CLAUDE.md`, every `.md`/`.mdx`
-under `skills/` and every one under `content/docs/`, and fails when a **fenced code block** contains
-one of the enumerated machine-produced shell-quote escape runs.
+under `skills/`, every one under `.claude/skills/` and every one under `content/docs/`, and fails when
+a **fenced code block** contains one of the enumerated machine-produced shell-quote escape runs.
+
+The contributor tree `.claude/skills/` joined that list in
+[#7403](https://github.com/objectstack-ai/objectui/issues/7403). It is not published, but it is
+agent-**written** and agent-**read**, which is both halves of the mechanism this gate exists for — and
+[#7251](https://github.com/objectstack-ai/objectui/issues/7251) had moved two contributor guides there
+out of `skills/objectui/`, taking 18 fenced blocks off the surface in one commit with nothing turning
+red. Nothing could have turned red: the `skills` row's file floor is a **collapse** detector, and 16
+files stayed behind to satisfy it while the two that left went unmeasured. A floor measures the roots
+that are declared, never the tree that walked out of them, so a move and its `SCAN_ROOTS` row belong
+in one change. The sibling gate `check-skills-paths` lost 55 stated paths to the same move and was
+widened the same way in [#7358](https://github.com/objectstack-ai/objectui/issues/7358).
 
 **Why it needed a gate.** In [#5150](https://github.com/objectstack-ai/objectui/issues/5150) the
 `git commit -F -` example in `AGENTS.md` §9 shipped with its heredoc terminator wrapped in the
@@ -912,9 +923,12 @@ required — rather than pinned as a sentence, so the claim cannot rot into a fa
 **It is green at rest, so its census is part of the verdict.** There are zero occurrences in the tree
 and there should stay zero, which means the run's output alone cannot distinguish a working gate from
 one that matches nothing. The verdict line therefore prints the **per-root population** — files and
-fenced blocks for each of the four roots — rather than a bare `OK`, and the scan **fails when that
+fenced blocks for each of the five roots — rather than a bare `OK`, and the scan **fails when that
 population collapses**: a root that does not resolve, a root that walks to fewer documents than its
-floor, or a total fence count under the floor is a broken walk, not a clean tree. A scan root that has
+floor, or a total fence count under the floor is a broken walk, not a clean tree. The document floors
+are **per root** and deliberately never a whole-surface total: on a day the four-file `.claude/skills`
+root reads zero, the other four still return 203 of today's 207 files, so a total floor stays green
+through the entire outage. A scan root that has
 moved or been mistyped is reported **by name**, because a mistyped root and a clean root produce
 identical output otherwise. The evidence that the gate works is the ablation in its test suite, which
 replants #5150's exact line in each root on a fixture tree.
@@ -924,8 +938,9 @@ census and not judged**, because documentation about this defect class has to be
 literal. That is a known narrowing, and the census figure is what keeps it visible.
 
 **If it fails:** it names the file, line and column, the fence language and the line the fence opened
-on. Note that `AGENTS.md`, `CLAUDE.md` and `skills/**` are **governed surface** — a finding in one of
-those is reported for a human to fix in its own change, not folded into an unrelated pull request. A
+on. Note that `AGENTS.md`, `CLAUDE.md`, `skills/**` and `.claude/**` are **governed surface** — a finding
+in one of those is reported for a human to fix in its own change, not folded into an unrelated pull
+request. A
 finding under `content/docs/**` is an ordinary docs fix. Run it locally with
 `pnpm check:shell-escape-residue`, or `node scripts/check-shell-escape-residue.mjs --list` to see the
 per-root census. It needs no install and no build.

--- a/scripts/__tests__/check-shell-escape-residue.test.ts
+++ b/scripts/__tests__/check-shell-escape-residue.test.ts
@@ -13,6 +13,7 @@ import {
   RESIDUE_PATTERNS,
   SCAN_ROOTS,
   findResidue,
+  listDocuments,
   resolveRoot,
   scan,
   summarise,
@@ -47,6 +48,16 @@ import { REQUIRED_CONTEXTS } from '../dependabot-merge-gate.mjs';
  * is the correct amount of friction for changing what a gate promises.
  *
  * ## Fixture discipline
+ *
+ * ## The second skills root (objectui#7403)
+ *
+ * `SCAN_ROOTS` carries TWO skills trees: the published `skills/` and the
+ * contributor tree `.claude/skills/`, which objectui#7251 moved two guides into
+ * while nothing reached the new location. The fixtures below therefore declare
+ * both, and three cases exist only for the second one: the declared roots, a
+ * residue planted under `.claude/skills`, and — the case the miss itself asks
+ * for — a root that walks to ZERO documents while every other root is healthy,
+ * which must be NAMED AND RED rather than absorbed by a healthy total.
  *
  * `scripts/` is not in `SCAN_ROOTS`, so this file could carry the literal
  * plainly. It builds it from code points anyway — belt and braces against a
@@ -90,11 +101,16 @@ const FIXTURE_ROOTS = [
   { spec: 'AGENTS.md', kind: 'file', minFiles: 1 },
   { spec: 'CLAUDE.md', kind: 'file', minFiles: 1 },
   { spec: 'skills', kind: 'dir', minFiles: 1 },
+  { spec: '.claude/skills', kind: 'dir', minFiles: 1 },
   { spec: 'content/docs', kind: 'dir', minFiles: 1 },
 ];
 
 const scanFixture = (root: string, roots = FIXTURE_ROOTS) => scan(root, { roots, fenceFloor: 0 });
 
+/** One `SCAN_ROOTS` entry, as declared. */
+type DeclaredRoot = { spec: string; kind: string; minFiles: number };
+/** One `census.perRoot` row, as `scan` returns it. */
+type RootRow = { spec: string; files: number; fences: number; minFiles: number; resolved: boolean };
 /** A finding as `findResidue` returns it — no file, because it scans one source. */
 type Hit = { line: number; column: number; language: string; fenceLine: number; patternId: string };
 /** The same finding as `scan` returns it, carrying the document it came from. */
@@ -223,8 +239,12 @@ describe('⛔ what this gate does NOT do — asserted by behaviour, not by prose
       'AGENTS.md': fence('bash', 'echo ok'),
       'CLAUDE.md': fence('bash', 'echo ok'),
       'skills/s/SKILL.md': fence('bash', 'echo ok'),
+      '.claude/skills/s/SKILL.md': fence('bash', 'echo ok'),
       'content/docs/a.md': fence('bash', 'echo ok'),
-      // Out of scope by construction: not under any declared root.
+      // Out of scope by construction: not under any declared root. `.claude/`
+      // is only on the surface BELOW `skills/` — the rest of the agent tree
+      // (hooks, settings, agent definitions) is not markdown this gate reads.
+      '.claude/hooks/notes.md': fence('bash', HISTORICAL_LINE),
       'packages/thing/README.md': fence('bash', HISTORICAL_LINE),
     });
     expect(scanFixture(root).hits).toEqual([]);
@@ -240,6 +260,12 @@ describe('⭐ ablation — objectui#5150 replanted in every scan root', () => {
     'AGENTS.md': ['# AGENTS', '', fence('bash', `git commit -F - <<${SQ}EOF${SQ}`, 'msg', 'EOF')].join('\n'),
     'CLAUDE.md': ['# CLAUDE', '', fence('bash', 'pnpm install')].join('\n'),
     'skills/objectui/SKILL.md': ['# Skill', '', fence('bash', 'pnpm build')].join('\n'),
+    // objectui#7403 — the tree objectui#7251 moved the contributor guides into.
+    '.claude/skills/objectui-contributor/guides/console-development.md': [
+      '# Console development',
+      '',
+      fence('bash', 'pnpm dev'),
+    ].join('\n'),
     'content/docs/guide/a.md': ['# Guide', '', fence('bash', 'pnpm test')].join('\n'),
   };
 
@@ -248,7 +274,7 @@ describe('⭐ ablation — objectui#5150 replanted in every scan root', () => {
     expect(result.hits).toEqual([]);
     expect(result.unresolved).toEqual([]);
     expect(result.vacuous).toEqual([]);
-    expect(result.census.fences).toBe(4);
+    expect(result.census.fences).toBe(5);
   });
 
   it('goes RED in each root separately, naming the file and the line', () => {
@@ -269,13 +295,13 @@ describe('⭐ ablation — objectui#5150 replanted in every scan root', () => {
     }
   });
 
-  it('finds all four at once, and is loud about none of the roots collapsing', () => {
+  it('finds all five at once, and is loud about none of the roots collapsing', () => {
     const planted = Object.fromEntries(
       Object.entries(clean).map(([rel, body]) => [rel, `${body}\n\n${fence('bash', HISTORICAL_LINE)}\n`]),
     );
     const result = scanFixture(fixtureTree(planted));
-    expect(result.hits).toHaveLength(8);
-    expect(result.census.rootsResolved).toBe(4);
+    expect(result.hits).toHaveLength(10);
+    expect(result.census.rootsResolved).toBe(5);
     expect(result.census.outsideFences).toBe(0);
   });
 });
@@ -290,7 +316,12 @@ describe('non-vacuity — zero roots or zero files is a failure, not a green', (
     // the mistyped one reads as coverage for as long as nobody checks.
     const root = fixtureTree({ 'AGENTS.md': fence('bash', 'echo ok') });
     const result = scan(root, { roots: FIXTURE_ROOTS, fenceFloor: 0 });
-    expect(result.unresolved.map((u: { spec: string }) => u.spec)).toEqual(['CLAUDE.md', 'skills', 'content/docs']);
+    expect(result.unresolved.map((u: { spec: string }) => u.spec)).toEqual([
+      'CLAUDE.md',
+      'skills',
+      '.claude/skills',
+      'content/docs',
+    ]);
     expect(result.census.rootsResolved).toBe(1);
   });
 
@@ -304,10 +335,20 @@ describe('non-vacuity — zero roots or zero files is a failure, not a green', (
   });
 
   it('reports a resolved-but-empty root as a COLLAPSE, not as clean', () => {
-    const root = fixtureTree({ 'AGENTS.md': '', 'CLAUDE.md': '', 'skills/.keep': '', 'content/docs/.keep': '' });
+    const root = fixtureTree({
+      'AGENTS.md': '',
+      'CLAUDE.md': '',
+      'skills/.keep': '',
+      '.claude/skills/.keep': '',
+      'content/docs/.keep': '',
+    });
     const result = scan(root, { roots: FIXTURE_ROOTS, fenceFloor: 0 });
-    // `.keep` is not a document, so both directory roots resolve and walk to nothing.
-    expect(result.vacuous.map((v: { what: string }) => v.what)).toEqual(['files under skills', 'files under content/docs']);
+    // `.keep` is not a document, so all three directory roots resolve and walk to nothing.
+    expect(result.vacuous.map((v: { what: string }) => v.what)).toEqual([
+      'files under skills',
+      'files under .claude/skills',
+      'files under content/docs',
+    ]);
   });
 
   it('treats a fence count under the floor as a collapse of the walk', () => {
@@ -315,10 +356,39 @@ describe('non-vacuity — zero roots or zero files is a failure, not a green', (
       'AGENTS.md': fence('bash', 'echo ok'),
       'CLAUDE.md': '# no fences',
       'skills/s/SKILL.md': '# no fences',
+      '.claude/skills/s/SKILL.md': '# no fences',
       'content/docs/a.md': '# no fences',
     });
     const result = scan(root, { roots: FIXTURE_ROOTS, fenceFloor: 400 });
     expect(result.vacuous).toEqual([{ what: 'fenced blocks examined', value: 1, floor: 400 }]);
+  });
+
+  it('⭐ NAMES a root that reads nothing instead of passing on a healthy total (objectui#7403)', () => {
+    // This is objectui#7251's miss as a fixture, and the reason the floors are
+    // per root. Every other root is healthy, so a whole-surface floor — files,
+    // or the global fence floor — is green through the entire outage while the
+    // widened root walks to zero documents. The per-root floor is what turns it
+    // red, and it names the root rather than reporting a total.
+    const root = fixtureTree({
+      'AGENTS.md': fence('bash', 'echo ok'),
+      'CLAUDE.md': fence('bash', 'echo ok'),
+      'skills/objectui/SKILL.md': fence('bash', 'echo ok'),
+      'skills/objectui/guides/a.md': fence('bash', 'echo ok'),
+      '.claude/skills/.keep': '', // resolves, walks to no document at all
+      'content/docs/a.md': fence('bash', 'echo ok'),
+    });
+    const result = scan(root, { roots: FIXTURE_ROOTS, fenceFloor: 0 });
+
+    expect(result.unresolved, 'the root EXISTS — this is emptiness, not absence').toEqual([]);
+    expect(result.vacuous).toEqual([{ what: 'files under .claude/skills', value: 0, floor: 1 }]);
+    // The reading that hid it for a whole move: the totals look healthy.
+    expect(result.census.files).toBe(5);
+    expect(result.census.fences).toBe(5);
+    expect(result.census.perRoot.find((r: RootRow) => r.spec === '.claude/skills')).toMatchObject({
+      files: 0,
+      fences: 0,
+      resolved: true,
+    });
   });
 
   it('exits 1 for a collapsed population even with nothing to report', () => {
@@ -337,13 +407,38 @@ describe('non-vacuity — zero roots or zero files is a failure, not a green', (
 describe('repo state — the gate is green on this tree, over a real population', () => {
   const result = scan(repoRoot);
 
-  it('scans exactly the four roots objectui#5151 ruled', () => {
-    expect(SCAN_ROOTS.map((r: { spec: string }) => r.spec)).toEqual([
+  it('scans the five roots — objectui#5151 ruled four, objectui#7403 added the contributor tree', () => {
+    expect(SCAN_ROOTS.map((r: DeclaredRoot) => r.spec)).toEqual([
       'AGENTS.md',
       'CLAUDE.md',
       'skills',
+      '.claude/skills',
       'content/docs',
     ]);
+    // Every floor is PER ROOT. A whole-surface floor is the shape that let
+    // objectui#7251's move through, so there is deliberately no such row here.
+    expect(SCAN_ROOTS.every((r: DeclaredRoot) => Number.isInteger(r.minFiles) && r.minFiles >= 1)).toBe(true);
+    expect(SCAN_ROOTS.find((r: DeclaredRoot) => r.spec === '.claude/skills')).toEqual({
+      spec: '.claude/skills',
+      kind: 'dir',
+      minFiles: 3,
+    });
+  });
+
+  it('⭐ actually reads the two guides objectui#7251 moved — asserted on the POPULATION', () => {
+    // `hits` being empty is true both when these guides are clean and when
+    // nothing scans them at all; that ambiguity is how 18 fenced blocks left
+    // this surface unnoticed. So the claim is made against the population the
+    // walk returns, which is false in exactly one of those two worlds.
+    const docs: string[] = listDocuments(repoRoot, '.claude/skills', 'dir');
+    expect(docs).toContain('.claude/skills/objectui-contributor/guides/console-development.md');
+    expect(docs).toContain('.claude/skills/objectui-contributor/rules/no-touch-zones.md');
+
+    const row: RootRow | undefined = result.census.perRoot.find((r: RootRow) => r.spec === '.claude/skills');
+    expect(row?.resolved).toBe(true);
+    expect(row?.files).toBeGreaterThanOrEqual(3);
+    // Floors, not exact counts: 4 files / 20 fences measured when this landed.
+    expect(row?.fences).toBeGreaterThan(0);
   });
 
   it('has no residue in any fenced block', () => {

--- a/scripts/check-shell-escape-residue.mjs
+++ b/scripts/check-shell-escape-residue.mjs
@@ -230,6 +230,14 @@ const DOC_EXTENSIONS = ['.mdx', '.md'];
  * card -- the `objectui-contributor` tree leaving reads 1, the two guides alone
  * leaving reads 2.
  *
+ * ⚠️ The row is `.claude/skills`, not `.claude` -- and the difference is only
+ * about files that do not exist yet. Every `.md`/`.mdx` under `.claude/` today
+ * is under `.claude/skills/` (4 of 4), so the two specs read the same tree; the
+ * narrower one was declared because it is the subtree whose contents are
+ * agent-read prose by construction. ⛔ It therefore does NOT reach a future
+ * `.claude/agents/*.md` or `.claude/commands/*.md` -- which is this card's own
+ * class one step out, and is objectui#7413 rather than pre-solved here.
+ *
  * ⚠️ `AGENTS.md`, `CLAUDE.md`, `skills/**` and `.claude/**` are GOVERNED SURFACE
  * (AGENTS.md §受管面). This gate READS them and never writes: a finding in one of
  * those is reported for a human to act on, and fixing it is a separate,

--- a/scripts/check-shell-escape-residue.mjs
+++ b/scripts/check-shell-escape-residue.mjs
@@ -13,7 +13,7 @@
  * ## ⛔ WHAT THIS GATE DOES NOT DO -- read this before citing it as coverage
  *
  * It checks ONE ENUMERATED LITERAL (`RESIDUE_PATTERNS`, currently a single
- * entry) inside fenced blocks in four roots. That is the whole of it.
+ * entry) inside fenced blocks in five roots. That is the whole of it.
  *
  *   ⛔ It does NOT make fenced shell examples executable-by-construction, and
  *      nothing in this repository does. A ```bash block may be syntactically
@@ -64,9 +64,13 @@
  *      HANGS. A reader will not attribute a hung terminal to the document, and
  *      will fall back to exactly the workaround the clause argues against.
  *   2. **Agent-facing text is re-read once per session.** `AGENTS.md`,
- *      `CLAUDE.md` and `skills/**` are inputs to every seat, so a bad example is
- *      not paid once -- it is paid by every reader. Those three are also where
- *      this repository does most of its shell demonstrating.
+ *      `CLAUDE.md`, `skills/**` and `.claude/skills/**` are inputs to every
+ *      seat, so a bad example is not paid once -- it is paid by every reader.
+ *      Those are also where this repository does most of its shell
+ *      demonstrating. ⭐ The contributor tree under `.claude/skills/**` is on
+ *      this surface for exactly that reason and no other (objectui#7403): it is
+ *      not published, but it is agent-WRITTEN and agent-READ, which is both
+ *      halves of the generating mechanism below.
  *
  * And the GENERATING MECHANISM IS FIXED AND REPRODUCIBLE: an agent writing a
  * file through a shell heredoc that is itself nested inside a single-quoted
@@ -123,15 +127,17 @@
  * and the first speculative entry spends that.
  *
  * The measured population of the current entry across the four roots, at the
- * commit this landed on, is ZERO inside fences and ZERO outside them.
+ * commit this landed on, is ZERO inside fences and ZERO outside them. Still
+ * ZERO on both counts across five roots when objectui#7403 added
+ * `.claude/skills` -- 20 fences in 4 files arrived clean.
  *
  * ## ⚠️ The literal is legitimate shell -- so the claim here is narrower
  *
  * `'` + `"` + `'` + `"` + `'` is the standard way to put a literal single quote
  * inside a single-quoted string, and a hand-written one-liner may use it
  * correctly. This gate does not claim otherwise. It claims something smaller and
- * checkable: in THESE FOUR ROOTS the sequence has never once been intentional,
- * and every occurrence so far was a write-path leak.
+ * checkable: in THESE ROOTS the sequence has never once been intentional, and
+ * every occurrence so far was a write-path leak.
  *
  * If a deliberate instance is ever genuinely needed in a documented example, the
  * equivalent `'\''` spelling is not matched here and is the documented remedy.
@@ -184,22 +190,56 @@ const DOC_EXTENSIONS = ['.mdx', '.md'];
 
 /**
  * The scan surface, declared -- objectui#5151's dispatch ruling, verbatim:
- * `AGENTS.md`, `CLAUDE.md`, `skills/**`, `content/docs/**`.
+ * `AGENTS.md`, `CLAUDE.md`, `skills/**`, `content/docs/**`; widened to
+ * `.claude/skills/**` by objectui#7403, for the reason recorded below.
  *
  * `kind` and `minFiles` exist for the "loud, never a silent zero" rule above.
  * `minFiles` is a COLLAPSE floor set with room, not today's count: the point is
  * to catch a walk that broke, not to pin figures that move every day. Measured
  * when this landed: 1 / 1 / 18 / 184 files, 12 / 2 / 235 / 1056 fences.
  *
- * ⚠️ `AGENTS.md`, `CLAUDE.md` and `skills/**` are GOVERNED SURFACE (AGENTS.md
- * §受管面). This gate READS them and never writes: a finding in one of those is
- * reported for a human to act on, and fixing it is a separate, human-merged
- * change. That is a property of the remedy, not of the scan.
+ * ## ⭐ objectui#7403 -- a per-root floor measures the roots that are DECLARED,
+ * never the tree that walked out of them
+ *
+ * objectui#7251 moved two contributor guides from `skills/objectui/` into
+ * `.claude/skills/objectui-contributor/`. No row reached the new location, so 18
+ * fenced blocks left this gate's surface in one commit and NOTHING WENT RED: the
+ * `skills` row carries `minFiles: 5` and 16 files stayed behind it, so the floor
+ * was satisfied by the tree that REMAINED while the tree that LEFT went
+ * unmeasured. A floor is a collapse detector, not a coverage detector, and no
+ * floor can be made to do the second job -- the only thing that catches a move
+ * is declaring the new location, which is why a move and its `SCAN_ROOTS` row
+ * belong in one change (the unresolved-root text in `main()` says the same for a
+ * root that vanishes; this is its blind side). The sibling gate
+ * `check-skills-paths.mjs` lost 55 stated paths to the same move and was widened
+ * the same way in objectui#7358.
+ *
+ * Measured for the widening (objectui#7403, `6aeba67`): 4 files, 20 fences under
+ * `.claude/skills` --
+ * `objectui-contributor/guides/console-development.md` 9,
+ * `objectui-contributor/rules/no-touch-zones.md` 9, `verify/SKILL.md` 2,
+ * `objectui-contributor/SKILL.md` 0. The first two carry the 18 blocks
+ * objectui#7251 moved; the other two had never been on this surface at all. All
+ * four arrived with zero residue, inside fences and outside them.
+ *
+ * ⛔ `minFiles: 3` for that row -- PER ROOT, never a whole-surface floor, which
+ * is the shape that failed: on a day this four-file root reads ZERO the other
+ * four roots still return 203 of today's 207 files, so any total floor is green
+ * through the whole outage. Seeded the way the others were, under today's count
+ * with room for ordinary movement, and still red for the shape that caused this
+ * card -- the `objectui-contributor` tree leaving reads 1, the two guides alone
+ * leaving reads 2.
+ *
+ * ⚠️ `AGENTS.md`, `CLAUDE.md`, `skills/**` and `.claude/**` are GOVERNED SURFACE
+ * (AGENTS.md §受管面). This gate READS them and never writes: a finding in one of
+ * those is reported for a human to act on, and fixing it is a separate,
+ * human-merged change. That is a property of the remedy, not of the scan.
  */
 export const SCAN_ROOTS = Object.freeze([
   { spec: 'AGENTS.md', kind: 'file', minFiles: 1 },
   { spec: 'CLAUDE.md', kind: 'file', minFiles: 1 },
   { spec: 'skills', kind: 'dir', minFiles: 5 },
+  { spec: '.claude/skills', kind: 'dir', minFiles: 3 },
   { spec: 'content/docs', kind: 'dir', minFiles: 100 },
 ]);
 
@@ -430,10 +470,10 @@ function main() {
     const remedies = [...new Set(hits.map((h) => RESIDUE_PATTERNS.find((p) => p.id === h.patternId).remedy))];
     console.error(`\n${remedies.map((r) => `  ${r}`).join('\n\n')}`);
     console.error(`
-⚠️  AGENTS.md, CLAUDE.md and skills/** are GOVERNED SURFACE. A finding in one of
-those is for a human to fix in its own change -- report it, do not fold the fix
-into an unrelated pull request. A finding under content/docs/** is an ordinary
-docs fix.
+⚠️  AGENTS.md, CLAUDE.md, skills/** and .claude/** are GOVERNED SURFACE. A
+finding in one of those is for a human to fix in its own change -- report it, do
+not fold the fix into an unrelated pull request. A finding under content/docs/**
+is an ordinary docs fix.
 
 ⛔ This gate checks an enumerated literal. It does NOT check that fenced shell
 examples are executable -- nothing does. See this script's header.`);


### PR DESCRIPTION
Fixes #7403

`SCAN_ROOTS` reached `skills` but not `.claude/skills`. #7251 moved two contributor guides into `.claude/skills/objectui-contributor/` and 18 fenced blocks left this gate's surface in one commit with nothing turning red — the `skills` row's `minFiles: 5` was satisfied by the 16 files that stayed while the two that left went unmeasured. This adds a `.claude/skills` row with its own per-root floor, extends the gate's own suite for the second root, and records the lesson beside the row.

Head: `239edb1`. Every number below was measured on that commit unless it names another.

## The measurement, before and after

Re-run with `node scripts/check-shell-escape-residue.mjs` and `--list`, per root, from the gate's own verdict line.

| root | before (`6aeba67`) | after (`239edb1`) |
|---|---|---|
| `AGENTS.md` | 1 file, 15 fences | 1 file, 15 fences |
| `CLAUDE.md` | 1 file, 2 fences | 1 file, 2 fences |
| `skills` | 16 files, 196 fences | 16 files, 196 fences |
| `.claude/skills` | — (unscanned) | **4 files, 20 fences** |
| `content/docs` | 185 files, 1071 fences | 185 files, 1071 fences |
| **roots resolved** | 4/4 | **5/5** |
| **total** | 203 files, 1284 fences | **207 files, 1304 fences** |
| occurrences outside a fence | 0 | 0 |

**The card's before-reading re-measured identically on today's `main`.** It was taken on `0614b6df1`; `6aeba67` gives the same 4/4, the same 16/196 and 185/1071, and the same per-file fence counts below. No drift to reconcile.

What the widening brings in, per file — counted with the gate's own `findResidue`, not by eye:

| file | fenced blocks | was under `skills` before #7251 |
|---|---|---|
| `.claude/skills/objectui-contributor/guides/console-development.md` | 9 | yes |
| `.claude/skills/objectui-contributor/rules/no-touch-zones.md` | 9 | yes |
| `.claude/skills/verify/SKILL.md` | 2 | no — never covered |
| `.claude/skills/objectui-contributor/SKILL.md` | 0 | no — never covered |

18 blocks restored, 2 newly covered, 20 in total.

## The floor, and its arithmetic

```js
{ spec: '.claude/skills', kind: 'dir', minFiles: 3 },
```

Seeded the way the others were — under today's count, with room, a collapse detector rather than a pin on today's figures (`AGENTS.md` 1 of 1, `CLAUDE.md` 1 of 1, `skills` 5 of 16, `content/docs` 100 of 185).

- Reads **4** files today, floor **3**: one file of ordinary movement stays green.
- The #7251-shaped move is **red**: the two guides leaving reads 2, the whole `objectui-contributor` tree leaving reads 1.
- **Per root, never a whole-surface floor** — that is the shape that failed. On a day this four-file root reads zero, the other four still return **203 of today's 207** files, so a total floor is green through the entire outage. The same reasoning is why #7358 added a per-root floor beside `check-skills-paths`' total.

## Disposition of what the widened surface reported: nothing, and no mechanism invented

**Zero residue in the four newly covered files** — inside fences and outside them:

```
✅  check-shell-escape-residue: OK (5/5 root(s) resolved -- AGENTS.md: 1 file(s), 15 fence(s);
CLAUDE.md: 1 file(s), 2 fence(s); skills: 16 file(s), 196 fence(s); .claude/skills: 4 file(s),
20 fence(s); content/docs: 185 file(s), 1071 fence(s); 207 file(s) and 1304 fenced block(s)
examined in total; 0 occurrence(s) outside a fence (counted, not judged)).
```

So there is no coordinate to correct at source and nothing to exempt. That is the right outcome to state rather than to work around: **this gate has no baseline mechanism and refuses one on purpose**, in its own words —

> ⛔ There is deliberately no allowlist, baseline or inline opt-out: with a measured population of zero, a permit mechanism would be the only thing in this file anyone ever reached for.

Nothing under `.claude/skills/**` is edited by this PR, so it is not GOVERNED (verdict in the table below).

## The lesson, recorded beside the row

A `minFiles` floor is a **collapse** detector, not a **coverage** detector, and no floor can be made to do the second job: it measures the roots that are declared, never the tree that walked out of them. The only thing that catches a move is declaring the new location — which is why a move and its `SCAN_ROOTS` row belong in one change. That is now written next to the row, together with the measurement, and asserted as a test rather than left as a sentence.

## The gate's own test: 33 to 35 cases

`scripts/__tests__/check-shell-escape-residue.test.ts`, all five roots in the fixtures:

1. **The declared roots** — the list is five and pins the new row whole (`spec` / `kind` / `minFiles`), plus that every floor is per root.
2. **A residue planted under `.claude/skills`** — the ablation fixture gains a `.claude/skills/objectui-contributor/guides/` document, so the "goes RED in each root separately" loop covers the new root, and the all-roots case moves 8 hits to 10 across 5 resolved roots.
3. **A root that reads nothing is NAMED and red, not absorbed by the total** (the case this miss asks for): every other root is healthy, the totals read 5 files and 5 fences, and the widened root walks to zero — `vacuous` is exactly `files under .claude/skills`, with `unresolved` empty because the root **exists**. Emptiness and absence stay distinguishable.
4. **The moved guides are asserted on the POPULATION, not on an empty `hits` list** — `hits` being empty is true both when the guides are clean and when nothing scans them, which is precisely how 18 blocks left unnoticed. So `listDocuments` is required to contain both moved guide paths and the per-root row is required to have read them.

The pre-existing non-vacuity cases were extended rather than duplicated: the missing-root list, the resolved-but-empty collapse and the "nothing outside SCAN_ROOTS" fixture all carry the second skills root now, and the last one also pins that `.claude/hooks/` markdown is **not** on the surface.

## Ablation — the widened root really is judged

One residue injected into a fenced block of a newly covered guide, on the **committed** tree, both legs proved on disk. No build or `dist` is involved: the gate is a `node` script reading markdown, so nothing sits between the edit and the reading.

**Mutation landed** — `#5150`'s shape written into the info-string-less fence opened at line 324 of `.claude/skills/objectui-contributor/guides/console-development.md`; on-disk hash moved `27e5f46` to `c8be76c`, residue count on disk 0 to 1, anchor count 1 throughout. Gate exit **1**:

```
❌  check-shell-escape-residue: 1 fenced block carries machine-produced shell-escape residue

    - .claude/skills/objectui-contributor/guides/console-development.md:326:19 -- the
      single-quote-inside-single-quote shell escape
      in the `(no info string)` fence opened at line 324:
        git commit -F - <<'"'"'EOF
```

That coordinate did not exist on this gate's surface before this PR, which is the whole claim.

**Restore proved, not assumed** — `git checkout HEAD -- ABSOLUTE_PATH` under a `trap ... EXIT INT TERM` (the trap is the crash-path convenience; the proof is the comparison): on-disk hash back to `27e5f46`, **equal to the HEAD blob** and checked for emptiness first, `git diff HEAD --name-only` **empty**, residue count on disk **0**. Gate exit **0**:

```
✅  check-shell-escape-residue: OK (5/5 root(s) resolved -- ... .claude/skills: 4 file(s), 20 fence(s); ...).
```

## Gates, at `239edb1`

Exit codes captured by redirecting first (`cmd  file 2 and 1; EXIT=$?`), never read across a pipe. Each row quotes the gate's own verdict line.

| gate | exit | its own verdict |
|---|---|---|
| `node scripts/check-shell-escape-residue.mjs` | 0 | `✅  check-shell-escape-residue: OK (5/5 root(s) resolved -- ... 207 file(s) and 1304 fenced block(s) examined in total; 0 occurrence(s) outside a fence)` |
| `pnpm exec vitest run` (its test + `ci-cd-pipeline-doc` + `scripts-type-check`) | 0 | `Test Files  3 passed (3)` / `Tests  86 passed (86)` |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, silent |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅  check-control-bytes: OK (scanned 6108 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `OK check-governed-queue-guard self-test: 132 cases pass` |
| `node scripts/check-governed-queue-guard.mjs --test` (3 changed paths) | 0 | `✅ NOT GOVERNED — 3 path(s) checked against 5 governed surface(s); none matched.` |
| `node scripts/check-doc-fence-languages.mjs` | 0 | `✅  check:doc-fences — every TypeScript block in 224 document(s) is fenced ts/tsx/typescript ...` |
| `node scripts/check-pre-install-import-graph.mjs` | 0 | `✅  check-pre-install-import-graph: OK — 21 pre-install step(s) in 17 job(s) run 20 scripts/ gate(s); 22 module(s) walked, every non-relative leaf a node builtin.` |
| `pnpm exec eslint` (changed files) | 0 | 1 file linted, 0 errors, 0 warnings |

The vitest run went through the shared verify lock (`VERDICT command-exit 0 · held the lock 3s · waited 1s`), so the exit code is the command's own and not the lock's 99.

**No changeset**, on the gate's own verdict rather than on judgement: `3 file(s) changed, 0 of them published source of a package the release covers, 0 of them a manifest whose published contract moved`. No `skip-changeset` label — this repo does not use that as a mechanism.

**`type-check:scripts` genuinely covers the edited files** rather than excluding them and reporting a clean run about others: `tsc -p tsconfig.scripts.json --listFiles` lists `scripts/check-shell-escape-residue.mjs` and `scripts/__tests__/check-shell-escape-residue.test.ts`, one occurrence each.

**eslint was narrowed, and the narrowing is measured rather than assumed.** Population read from `eslint.config.js`: every `files:` block is scoped to `.ts`/`.tsx` globs and no block declares an `.mjs`, `.cjs`, `.md` or `.json` glob, so of the three changed files only the `.ts` test is inside the linted population at all. File count read from `--format json`: 1 result object, `errorCount` 0, `warningCount` 0. Invariance: the config declares neither `parserOptions.project` nor `projectService`, so linting is not type-aware and nothing in this diff can move the verdict on a file it did not touch. The repo-wide `pnpm lint` is CI's run.

## Premises that did not hold

- `premise_false: the widened surface reports residue to clear or baseline` — it reports **zero**, so step 3's branch never fired. Nothing was cleared at source and no exemption was granted.
- `premise_false: the gate may have a baseline mechanism to use` — it has none, and its header rules one out explicitly. None was invented, which the brief also required.
- `premise_false: the PR may become GOVERNED (queue guard exit 3)` — that is conditional on a fix under `.claude/skills/**`, and none was needed. The guard's own verdict over the three changed paths is `NOT GOVERNED`, exit 0. Draft either way, as dispatched.
- `premise_held: the card's measurement table is the before-reading` — re-measured on today's `main` and identical, per-root and per-file.

## Scope, and the third file

Three files. Two under `scripts/`, plus **`content/docs/guide/ci-cd-pipeline.md`**, which states this gate's surface in prose:

> It walks `AGENTS.md`, `CLAUDE.md`, every `.md`/`.mdx` under `skills/` and every one under `content/docs/` ... the per-root population — files and fenced blocks for each of the **four** roots

Both sentences become **false** the moment the row lands, so updating them is completing this change rather than extending it — a widening that leaves the docs stating the old surface ships a known-wrong statement, which is the stale-surface-prose defect #7404 was filed for on the sibling gate. The page now names the fifth root, carries the per-root-floor reasoning and its arithmetic, and adds `.claude/**` to the governed-surface note. The same governed-surface line inside the gate's own failure output was updated with it.

One finding of the same class was filed unassigned rather than ridden in here, and is **not** addressed by this PR:

- #7413 — the row is `.claude/skills`, while the ruling behind it was stated about `.claude/**`. Today the difference is zero files (all 4 markdown documents under `.claude/` are under `.claude/skills/`), but a future `.claude/agents/*.md` would repeat this card's own miss. The boundary is written down beside the row and pointed at that card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_