### PR TITLE
skills(objectui): page-builder teaches `section`, and stops claiming a closed set of five

### DIFF
--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -70,10 +70,10 @@ branching in component code.
 
 ### 3b. Pick the right layout primitive
 
-Five registered types do all the structural work. By volume in the schema
+These are the structural types to reach for. By volume in the schema
 catalogue, `flex`, `stack` and `box` are the three most-used layout nodes, so
-reach for them before anything heavier. All five take `children` and read every
-key off the node.
+reach for them before anything heavier. All take `children` and read every key
+off the node.
 
 | `type` | Renders | Key props (renderer defaults) | Reach for it when |
 |---|---|---|---|
@@ -82,16 +82,14 @@ key off the node.
 | `grid` | a CSS grid | `columns` (number, or a breakpoint object), `gap` (`4`) | a fixed number of equal cells that must reflow by breakpoint — KPI cards, a tile wall |
 | `container` | a centred, width-capped block | `maxWidth` (`xl`; `false` cancels the cap), `centered` (`true`), `padding` (`4`) | you want page gutters and a reading width, once, near the root |
 | `box` | a bare `div` | none — `className` passes through **verbatim**, and the renderer injects nothing | you want a wrapper that adds no layout of its own: a Tailwind-only block, a positioning anchor |
+| `section` | a semantic `<section>` | none — `className` passes through **verbatim**, exactly like `box` | you want `box` with an outline landmark: a thematic grouping that carries its own heading |
 
-`stack` is `flex` with a different default direction and alignment — the two
-declare the same members. Use whichever names your intent; do not set
+Use whichever of `flex` / `stack` names your intent; do not set
 `direction: "col"` on a `flex`.
 
-`box` exists because every other option injects layout: `container` adds width,
-centering and padding, `flex` / `stack` add a display mode and a gap, `grid`
-adds `grid-cols-*`, and `card` adds a border, a shadow and a `CardContent`
-wrapper around the children. When you want none of that, `box` is the one that
-gives you none of it.
+`box` and `section` exist because every other option injects layout — the props
+column above, plus `card`'s border, shadow and `CardContent` wrapper. When you
+want none of that, those two are the ones that give you none of it.
 
 ### 4. Wire renderer and registry cleanly
 


### PR DESCRIPTION
Fixes #7406

`guides/page-builder.md` section "3b. Pick the right layout primitive" opened with a closed-set claim that was measurably false, and the token `section` occurred **0 times in the whole guide** (verified at the branch point `24d4a21`). An author reading the guide had no way to reach a registered structural type, and the sentence told them the set was complete.

## The change

**Sentence, before** (line 73):

> Five registered types do all the structural work. By volume in the schema catalogue, `flex`, `stack` and `box` are the three most-used layout nodes, so reach for them before anything heavier. All five take `children` and read every key off the node.

**Sentence, after:**

> These are the structural types to reach for. By volume in the schema catalogue, `flex`, `stack` and `box` are the three most-used layout nodes, so reach for them before anything heavier. All take `children` and read every key off the node.

The card offered "corrected count" or "reworded so it stops claiming a closed set". **The reword is the only one that stays true** — see premise ③ below: a corrected count of six would have been false again on the next reading.

**Row added**, in the table's own shape, after `box`:

| `type` | Renders | Key props (renderer defaults) | Reach for it when |
|---|---|---|---|
| `section` | a semantic `section` element | none — `className` passes through **verbatim**, exactly like `box` | you want `box` with an outline landmark: a thematic grouping that carries its own heading |

## Every claim in the row, traced to a source line

The authorable key `section` resolves to `SemanticSection`, registered by the tag factory in `packages/components/src/renderers/layout/semantic.tsx`:

- line 13 — `const tags = ['aside', 'main', 'header', 'nav', 'footer', 'section', 'article'] as const;`
- line 46 — `ComponentRegistry.register(tag, Component, { namespace: 'ui', ... })`, with **no** `skipFallback`, so `Registry.register` also writes the bare-name fallback (`packages/core/src/registry/Registry.ts:468` — `if (meta?.namespace && !meta?.skipFallback)`).
- line 31/34/36 — `const Tag = tag;` then `Tag ... className={className}`: it renders the semantic element and passes `className` through **verbatim**, injecting nothing. That is the row's "Key props" cell.
- line 40 — `renderChildren(schema.children || schema.body)`, so it takes `children` like every other row.
- line 70-72 — its only declared input is `className`.

Measured at runtime rather than inferred, with a throwaway probe against the real registry (removed before commit):

```
bare_type    = "ui:section"   bare_display = "SemanticSection"
page_type    = "page:section" page_display = "PageSectionRenderer"
bare_is_ui   = true           bare_is_page = false
bare_inputs  = [{ name: "className", type: "string", label: "CSS Class" }]
```

Catalogue usage, all three authoring the **bare** key:

- `examples/schema-catalog/src/schemas/components-layout-semantic/section.json:2` — `"type": "section"`
- `.../blog-article.json:22` and `.../complete-layout.json:68` — same spelling.

## premise_false — what the card and the dispatch asserted that did not hold

**① The registration behind the catalogue's `section` is NOT `containers.tsx:988`.** The card and the dispatch both attribute it there. That call is `ComponentRegistry.register('section', PageSectionRenderer, { namespace: 'page', skipFallback: true, ... })` — and `skipFallback: true` means it registers **only** `page:section` and deliberately never claims the bare `section` key. The two are different renderers: `PageSectionRenderer` injects `space-y-4` (`containers.tsx:979`), `SemanticSection` injects nothing. `bare_is_page = false` above is the measurement.

**② So the row's props/defaults could not be read from `containers.tsx`.** The dispatch directed me to read them there. Doing so would have published a false row — `space-y-4` and a `children` slot input belong to a namespaced key the guide does not teach and authors do not write. They are read from `semantic.tsx` instead, which is the renderer the authorable spelling actually reaches.

**③ A corrected count of "six" would have been false again.** The same factory line 13 registers `aside`, `main`, `nav` and `article` as bare structural types on identical terms (plus `header`/`footer`, whose bare keys the page-namespace siblings do not claim either). Any closed-set number is falsifiable here, which is why the sentence became a recommendation rather than a census.

**④ `check:doc-snippets` is not owed by this diff.** It exits 2 = `PRECONDITION NOT MET` on an unbuilt worktree ("This is 'I could not run', NOT 'I ran and found errors'"). Its declared scan surface is `content/docs/**` plus `packages/*/README.md` (`scripts/check-doc-snippet-types.mjs:301`, and `check-doc-component-types.mjs:212` names it as the gate for "not `skills/**`"). A `skills/**`-only diff is outside its surface; CI builds before running it.

## Budget — shrink-or-neutral, `ceil(utf8_bytes / 4)`

| | bytes | tokens |
|---|---|---|
| before (`24d4a21`) | 12,245 | **3,062** |
| after | 12,248 | **3,062** |
| delta | +3 | **0 — neutral** |

Paid inside the same file, from two strict restatements of the table (not a re-wrap):

1. **The `stack` sentence.** "`stack` is `flex` with a different default direction and alignment — the two declare the same members" restates its own row's props cell verbatim ("same props; `direction` defaults to `col` and `align` to `stretch`"). Kept the part the table does not carry: the imperative not to set `direction: "col"` on a `flex`.
2. **The `box` paragraph's enumeration.** "`container` adds width, centering and padding, `flex` / `stack` add a display mode and a gap, `grid` adds `grid-cols-*`" is the props column re-typed as prose. Kept `card`'s border/shadow/`CardContent` wrapper, which the table does **not** carry, and folded `section` into the same sentence.

Deletions measured and **rejected** as load-bearing: the `props` / `properties` envelope block (lines 52-66, the only statement of why a key under `props` is never read); the two expression-boundary examples; the grid-`field` / form-`name` callout.

## Gates at the final head `42eea12`

Every exit code captured by redirect **before** any pipe; each gate's own verdict line quoted.

| Gate | Exit | Verdict line |
|---|---|---|
| `check-skills-paths.mjs` | 0 | `✅ check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined)` — `skills/` 28/28. `--list` shows the row states no path, so it adds no assertion. |
| `check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 6108 tracked text file(s); skipped 85 binary).` |
| `check-shell-escape-residue.mjs` | 0 | `✅ check-shell-escape-residue: OK (5/5 root(s) resolved ... skills: 16 file(s), 196 fence(s) ...)` |
| `check-changeset-presence.mjs` | 0 | `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` — **its verdict decides: no changeset.** |
| `check-governed-queue-guard.mjs --test skills/objectui/guides/page-builder.md` | **3** | GOVERNED, the correct verdict: `Park it as a DRAFT and leave the merge to the maintainer`. |
| `check-doc-fence-languages.mjs` | 0 | `✅ check:doc-fences — every TypeScript block in 224 document(s) is fenced ts/tsx/typescript` |
| `check-doc-component-types.mjs` | 0 | `✅ Every documented component type is registered.` (derived, then measured out of scope: it walks `content/docs` and nothing else, `:214`) |
| `check-doc-snippet-types.mjs` | 2 | `PRECONDITION NOT MET (exit 2) — The snippet program was NOT run` — see premise ④. Not measured, not red, not owed. |
| vitest — `doc-version-claims`, `check-skills-paths`, `skill-guide-provider-envelope`, `skill-guide-data-table-binding`, `skill-guide-permission-config` | 0 | `Test Files 5 passed (5)` · `Tests 105 passed (105)` |

Suite selection was derived, not assumed: `git grep -l "page-builder.md" scripts packages` returns **nothing** — no gate or suite reads this guide by name — so the `skill-guide-*` family was enumerated by filename and run whole.

**eslint — narrowing measured, all three pieces:**
1. *Population from eslint's own config, not a guess:* every `files` entry in `eslint.config.js` is `.ts`/`.tsx` (lines 28, 176, 196, 218, 232, 262). The single `markdown|mdx` match in that file is a comment on line 22.
2. *Count from `--format json`:* running eslint on the changed file yields `errorCount: 0` with eslint's own message `"File ignored because no matching configuration was supplied."` — the file is outside the linted population entirely.
3. *Invariance for untouched files:* no markdown processor is configured and no `.ts`/`.tsx` file is touched by this diff, so it cannot move the verdict of any file eslint does lint.

## Scope

One row and one sentence in one file. No new section, no other guide, no eval file touched — the `section` eval row that #7408 re-pointed to `card` stays as landed, and `card` remains present in this guide (the schema example and the `box` paragraph both carry it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_