### PR TITLE
fix(docs,gates): the root README joins both doc gates' scan surface, and stops teaching `stat-card`

### DIFF
--- a/.changeset/7115-root-readme-doc-gate-surface.md
+++ b/.changeset/7115-root-readme-doc-gate-surface.md
@@ -1,0 +1,19 @@
+---
+---
+
+Docs and gates only: the root `README.md` — the repository's landing page and the
+most-read authored file in it — was outside the scan surface of every doc gate,
+and had been teaching `stat-card` four times in its flagship "dashboard in JSON"
+example. Nothing registers `stat-card`, so a reader who copied the headline
+snippet got four OBJUI-001 "Unknown component type" panels.
+
+The file now joins the scan surface of `check-doc-component-types` and
+`check-doc-snippet-types`, and the four widgets are retargeted onto `statistic`,
+which is registered and declares a `value` carriage row, so the example keeps its
+expressions. Per the maintainer's 2026-09-01 ruling on the (A)/(B) fork —
+option (B), no new carriage rows — four documentation sites that authored `${…}`
+in keys with no carriage row now teach what actually renders instead.
+
+No package source changed, so this ships nothing: `check-changeset-presence`
+independently reports "no changeset is owed" for this diff. The declaration
+states the release intent rather than bumping anything.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ function UserForm() {
 
 // Object UI: 20 lines
 const schema = {
-  type: "crud",
-  api: "/api/users",
-  columns: [...]
+  type: "object-form",
+  objectName: "user",
+  mode: "create",
+  fields: ["name", "email", "role"]
 }
 ```
 
@@ -217,9 +218,9 @@ const schema = {
     type: "grid",
     columns: 3,
     items: [
-      { type: "card", title: "Total Users", value: "${stats.users}" },
-      { type: "card", title: "Revenue", value: "${stats.revenue}" },
-      { type: "card", title: "Orders", value: "${stats.orders}" }
+      { type: "statistic", label: "Total Users", value: "${stats.users}" },
+      { type: "statistic", label: "Revenue", value: "${stats.revenue}" },
+      { type: "statistic", label: "Orders", value: "${stats.orders}" }
     ]
   }
 }
@@ -253,7 +254,7 @@ export default App
     ]},
     { "name": "message", "type": "textarea", "label": "Message", "required": true }
   ],
-  "actions": [{ "type": "submit", "label": "Send Message" }]
+  "submitLabel": "Send Message"
 }
 ```
 
@@ -261,22 +262,19 @@ export default App
 
 ```json
 {
-  "type": "crud",
-  "api": "/api/users",
+  "type": "object-grid",
+  "objectName": "user",
+  "title": "Users",
   "columns": [
-    { "name": "name", "label": "Name", "sortable": true },
-    { "name": "email", "label": "Email" },
-    { "name": "role", "label": "Role", "type": "select", "options": ["Admin", "User", "Viewer"] },
-    { "name": "status", "label": "Status", "type": "badge" },
-    { "name": "created_at", "label": "Joined", "type": "date" }
-  ],
-  "filters": [
-    { "name": "role", "type": "select", "label": "Filter by Role" },
-    { "name": "status", "type": "select", "label": "Filter by Status" }
+    { "field": "name", "label": "Name", "sortable": true },
+    { "field": "email", "label": "Email" },
+    { "field": "role", "label": "Role" },
+    { "field": "status", "label": "Status" },
+    { "field": "created_at", "label": "Joined" }
   ],
   "showSearch": true,
-  "showCreate": true,
-  "showExport": true
+  "showFilters": true,
+  "operations": { "create": true, "read": true, "update": true, "delete": true, "export": true }
 }
 ```
 
@@ -287,10 +285,10 @@ export default App
   "type": "dashboard",
   "title": "Sales Dashboard",
   "widgets": [
-    { "type": "stat-card", "title": "Revenue", "value": "${stats.revenue}", "trend": "+12%", "w": 3, "h": 1 },
-    { "type": "stat-card", "title": "Orders", "value": "${stats.orders}", "trend": "+8%", "w": 3, "h": 1 },
-    { "type": "stat-card", "title": "Customers", "value": "${stats.customers}", "trend": "+5%", "w": 3, "h": 1 },
-    { "type": "stat-card", "title": "Conversion", "value": "${stats.conversion}", "trend": "-2%", "w": 3, "h": 1 },
+    { "type": "statistic", "label": "Revenue", "value": "${stats.revenue}", "trend": "up", "description": "+12%", "w": 3, "h": 1 },
+    { "type": "statistic", "label": "Orders", "value": "${stats.orders}", "trend": "up", "description": "+8%", "w": 3, "h": 1 },
+    { "type": "statistic", "label": "Customers", "value": "${stats.customers}", "trend": "up", "description": "+5%", "w": 3, "h": 1 },
+    { "type": "statistic", "label": "Conversion", "value": "${stats.conversion}", "trend": "down", "description": "-2%", "w": 3, "h": 1 },
     { "type": "chart", "chartType": "line", "title": "Revenue Over Time", "w": 8, "h": 3 },
     { "type": "chart", "chartType": "pie", "title": "Sales by Region", "w": 4, "h": 3 }
   ]

--- a/content/docs/guide/expressions.md
+++ b/content/docs/guide/expressions.md
@@ -382,11 +382,17 @@ Available: All standard `Math` functions
 
 ### Percentage Bar
 
+`progress` has no row in the expression carriage map, so its `value` and `label`
+are read off the node exactly as written — a `${…}` in either reaches the screen
+as those characters. Compute the percentage in the data you hand the renderer;
+the condition keys are evaluated on every type and stay expressions:
+
 ```json
 {
   "type": "progress",
-  "value": "${(completed / total) * 100}",
-  "label": "${completed} of ${total} completed"
+  "value": 75,
+  "label": "75% complete",
+  "visibleOn": "${total > 0}"
 }
 ```
 
@@ -445,13 +451,14 @@ Available: All standard `Math` functions
 
 ### Computed Fields
 
+`input` has no row in the expression carriage map either, so a computed total
+cannot be carried by its `value`. Show it with a `text` node, whose `content` is
+evaluated on every component type:
+
 ```json
 {
-  "type": "input",
-  "name": "total",
-  "label": "Total",
-  "value": "${form.price * form.quantity}",
-  "disabled": true
+  "type": "text",
+  "content": "Total: ${form.price * form.quantity}"
 }
 ```
 

--- a/packages/plugin-dashboard/README.md
+++ b/packages/plugin-dashboard/README.md
@@ -239,7 +239,11 @@ const schema = {
 
 ## Integration with Data Sources
 
-Connect dashboard to live data:
+Connect dashboard to live data. `metric-card` renders the `value` it is handed:
+it has no row in the spec's expression carriage map, so a `${…}` written in
+`value` or `trend` reaches the screen as those characters. A widget that should
+read live data is one of the `object-*` types above — they resolve the spec's
+per-element `dataSource` binding and query the object themselves.
 
 ```typescript
 import { createObjectStackAdapter } from '@object-ui/data-objectstack';
@@ -256,8 +260,8 @@ const schema = {
     {
       type: 'metric-card',
       title: 'Total Users',
-      value: '${data.metrics.totalUsers}',
-      trend: '${data.metrics.userTrend}'
+      value: 12480,
+      trend: 'up'
     }
   ]
 };

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,10 +45,16 @@ const schema = {
   type: 'form',
   body: [
     {
+      // `content` is evaluated on every component type. `input` has no row in
+      // the spec's expression carriage map, so a `${…}` in ITS `value` would be
+      // rendered as those characters rather than resolved.
+      type: 'text',
+      content: 'Editing ${user.name}'
+    },
+    {
       type: 'input',
       name: 'name',
-      label: 'Name',
-      value: '${user.name}'
+      label: 'Name'
     }
   ]
 }

--- a/scripts/__tests__/check-doc-component-types.test.ts
+++ b/scripts/__tests__/check-doc-component-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -712,6 +712,77 @@ describe('objectui#5342 — the key errors the widened collector found stay fixe
     const body = read('content/docs/api/schema-reference.md');
     expect(body).not.toContain('"label": "Email", "type": "link"');
     expect(body).toContain('"label": "Email", "type": "email"');
+  });
+});
+
+// ── objectui#7115: the root README joined the scan surface ───────────────────
+
+/**
+ * objectui#7115 — the root `README.md` sat outside EVERY doc gate's scan
+ * surface. This gate walked `content/docs`; `check-doc-snippet-types.mjs` walked
+ * `content/docs` plus the package READMEs; the most-read authored file in the
+ * repository fell between the two. It taught the unregistered type `stat-card`
+ * four times, in the flagship "dashboard in JSON" example, for as long as the
+ * example existed — four OBJUI-001 panels for anyone who copied the headline
+ * snippet.
+ *
+ * ⚠️ Widening a scan surface is the change that can be GREEN ABOUT NOTHING, so
+ * what is pinned here is the three ways it can quietly stop being real: the walk
+ * stops reaching the file, the JUDGEMENT stops applying to what it finds there,
+ * or the content regresses under a surface that still technically covers it.
+ * The fourth — the name in `ROOT_PAGES` going dangling — is the one that would
+ * look healthiest, since every count this gate prints stays plausible while the
+ * surface shrinks back to what objectui#7115 found.
+ */
+describe('objectui#7115 — the root README is inside the scan surface', () => {
+  it('the walk really reaches it — the widening, pinned', () => {
+    const { sites } = scanDocs(repoRoot);
+    const files = new Set(sites.map((s: { file: string }) => s.file));
+    expect(
+      files.has('README.md'),
+      'no `type` literal was scanned in the root README — the collector narrowed back to content/docs',
+    ).toBe(true);
+  });
+
+  it('judges a root page by the same rule, so an unregistered type there is a finding', () => {
+    // The mechanism, over a throwaway tree: reaching the file and JUDGING it are
+    // two different things, and a widening that only did the first would pass
+    // the assertion above.
+    const findings = withTree((write) => {
+      write(
+        'packages/demo/src/index.tsx',
+        "ComponentRegistry.register('statistic', S, { namespace: 'ui' });\n",
+      );
+      write('README.md', ['```json', '{ "type": "stat-card" }', '```'].join('\n'));
+    }, (dir) => analyze(dir, BARE).findings as Finding[]);
+    expect(findings.map((f) => `${f.reason} :: ${f.site} :: ${f.value ?? ''}`)).toEqual([
+      'unregistered-doc-type :: README.md:2 :: stat-card',
+    ]);
+  });
+
+  it('the flagship dashboard example teaches `statistic`, and keeps its expressions', () => {
+    const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
+    expect(readme, 'the defect objectui#7115 was filed for is back').not.toContain('stat-card');
+    const widgets = readme.split('\n').filter((line) => line.includes('"type": "statistic"'));
+    expect(widgets).toHaveLength(4);
+    // A retarget, not a downgrade to literals: `statistic` declares a `value`
+    // carriage row in the spec's expression map, which is precisely why the
+    // 2026-09-01 ruling picked it over spelling the numbers out.
+    for (const widget of widgets) expect(widget).toMatch(/"value": "\$\{stats\./);
+  });
+
+  it('refuses to run when a ROOT_PAGES name does not resolve — the silent shrink', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-doc-component-types-rootpages-'));
+    try {
+      const run = spawnSync(process.execPath, [path.join(repoRoot, SCRIPT), '--root', dir], {
+        encoding: 'utf8',
+      });
+      expect(run.status, 'a dangling root page must fail the run, not shrink the surface').toBe(1);
+      expect(run.stderr).toContain('ROOT_PAGES');
+      expect(run.stderr).toContain('README.md');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/__tests__/check-doc-fence-languages.test.ts
+++ b/scripts/__tests__/check-doc-fence-languages.test.ts
@@ -5,8 +5,18 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 
-import { census, listDocuments as fenceDocuments, TS_FENCE_LANGUAGES as GUARD_TS_FENCES } from '../check-doc-fence-languages.mjs';
-import { listDocuments as snippetDocuments, TS_FENCE_LANGUAGES as GATE_TS_FENCES } from '../check-doc-snippet-types.mjs';
+import {
+  census,
+  listDocuments as fenceDocuments,
+  ROOT_PAGES as FENCE_ROOT_PAGES,
+  TS_FENCE_LANGUAGES as GUARD_TS_FENCES,
+} from '../check-doc-fence-languages.mjs';
+import {
+  listDocuments as snippetDocuments,
+  ROOT_PAGES as SNIPPET_ROOT_PAGES,
+  TS_FENCE_LANGUAGES as GATE_TS_FENCES,
+} from '../check-doc-snippet-types.mjs';
+import { ROOT_PAGES as COMPONENT_ROOT_PAGES } from '../check-doc-component-types.mjs';
 
 const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 const GUARD = 'scripts/check-doc-fence-languages.mjs';
@@ -52,6 +62,32 @@ describe('check-doc-fence-languages: the scan surface is check-doc-snippet-types
 
   it('treats exactly the snippet gate’s fence languages as already-covered', () => {
     expect([...GUARD_TS_FENCES].sort()).toEqual([...GATE_TS_FENCES].sort());
+  });
+
+  /**
+   * objectui#7115 — the ROOT_PAGES half of the surface, pinned across ALL THREE
+   * doc gates rather than two.
+   *
+   * The document-list assertion above is what caught this: objectui#7115 widened
+   * `check-doc-component-types` and `check-doc-snippet-types` onto the root
+   * `README.md` — the two gates its ruling named — and this file went red,
+   * because a third gate is coupled to that surface by construction. The lists
+   * are equal again, but list equality alone would not have said WHERE they
+   * diverged, and `check-doc-component-types`'s surface is deliberately narrower
+   * (it does not walk the package READMEs), so it cannot join that comparison.
+   *
+   * This is the piece all three DO share. Each carries its own copy for its own
+   * install-free reason; comparing the copies is what keeps "copy freely" honest.
+   */
+  it('all three doc gates carry the same ROOT_PAGES — the surface objectui#7115 widened', () => {
+    expect([...FENCE_ROOT_PAGES]).toEqual(['README.md']);
+    expect([...SNIPPET_ROOT_PAGES]).toEqual([...FENCE_ROOT_PAGES]);
+    expect([...COMPONENT_ROOT_PAGES]).toEqual([...FENCE_ROOT_PAGES]);
+  });
+
+  it('the root README is really in this gate’s walk — the widening, pinned', () => {
+    // Not implied by the equality above: both lists could lose it together.
+    expect(fenceDocuments(ROOT)).toContain('README.md');
   });
 });
 

--- a/scripts/__tests__/check-doc-snippet-types.test.ts
+++ b/scripts/__tests__/check-doc-snippet-types.test.ts
@@ -299,6 +299,52 @@ describe('this repository', () => {
   });
 });
 
+/**
+ * objectui#7115 — the root `README.md` was in NO doc gate's scan set: this gate
+ * walked `content/docs` plus the package READMEs, its sibling
+ * `check-doc-component-types.mjs` walked `content/docs`, and the repository's
+ * landing page fell between them.
+ *
+ * ⚠️ Read the second assertion carefully. Being ON the ungated ledger is NOT a
+ * claim that this file compiles — it does not; objectui#7417 carries its nine
+ * measured diagnostics. It is the objectui#5174 distinction, which this script's
+ * own header states: a document outside the walk is "neither covered NOR
+ * declared ungated", invisible to the gate's own accounting, while a ledgered
+ * one is named, counted, re-derived every run and shrink-only.
+ */
+describe('objectui#7115 — the root README is in the scan set', () => {
+  it('listDocuments reaches it', () => {
+    expect(listDocuments(repoRoot)).toContain('README.md');
+  });
+
+  it('is DECLARED debt rather than absent, and its reason names the card that carries it', () => {
+    expect(Object.keys(UNGATED_DOCS as Record<string, string>)).toContain('README.md');
+    expect((UNGATED_DOCS as Record<string, string>)['README.md']).toContain('objectui#7417');
+  });
+
+  it('root pages are collected BY NAME, not by the packages walk', () => {
+    // The mechanism, isolated: a tree with no `content/docs` and no `packages`
+    // still lists its root page, which is what makes the entry independent of
+    // the two walks it sits between.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-doc-snippet-types-rootpages-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'README.md'), '# root\n');
+      expect(listDocuments(dir)).toEqual(['README.md']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('states in its own source that a dangling root page fails the run', () => {
+    // The guard lives in `main()`, which takes no `--root`, so it cannot be
+    // driven from a fixture. Pinned against the source for the same reason the
+    // exit-code contract is: a silently narrowed surface is this card's defect.
+    const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-doc-snippet-types.mjs'), 'utf8');
+    expect(source).toContain('ROOT_PAGES');
+    expect(source).toMatch(/for \(const name of ROOT_PAGES\) \{\n\s*if \(!existsSync\(join\(repoRoot, name\)\)\)/);
+  });
+});
+
 describe('third-party resolution reaches exactly as far as the imported packages declare', () => {
   /** A workspace package with its own `node_modules`, the way pnpm links one. */
   function treeWithDependency(files: Record<string, string> = {}): string {

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -239,8 +239,12 @@ const DOCS_ROOT = 'content/docs';
  * A name here that does not resolve is a FAILED run, not a quiet skip — see the
  * check beside `FLOORS` in the CLI block. Without it, renaming or moving the
  * file would silently return the surface to what objectui#7115 found.
+ *
+ * Exported so the equality is checked rather than hoped for: three gates now
+ * carry this array, and `check-doc-fence-languages.test.ts` pins all three
+ * against each other.
  */
-const ROOT_PAGES = ['README.md'];
+export const ROOT_PAGES = ['README.md'];
 
 /** Page extensions collected under `DOCS_ROOT`. BOTH are collected, and that is
  *  the whole content of the scan surface: `content/docs` is authored in a mix of

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Every `type` string literal in a `content/docs/**` code block — `.mdx` and
- * `.md` alike — must name a component the repository actually registers, or be
- * declared, per file, as belonging to some other vocabulary. Since objectui#5106
+ * `.md` alike — and in the root `README.md` (objectui#7115), must name a
+ * component the repository actually registers, or be declared, per file, as
+ * belonging to some other vocabulary. Since objectui#5106
  * the same question is also asked of the KEY TABLES that document a plugin's
  * registrations, on BOTH halves of the row: the namespaced key and the bare-name
  * fallback (see "The second surface" below).
@@ -199,7 +200,7 @@
  * that is not a key table), and both are worth fixing rather than silencing.
  */
 
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isEntrypoint } from './invoked-as.mjs';
@@ -208,10 +209,38 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 
 // ── Configuration ────────────────────────────────────────────────────────────
 
-/** Where the teaching prose lives. This gate walks `content/docs` and nothing
- *  else: not `skills/**`, not the package READMEs (`check-doc-snippet-types.mjs`
- *  covers those for its own question), not `docs/**`. */
+/** Where the teaching prose lives. This gate walks `content/docs` plus the root
+ *  pages named below, and nothing else: not `skills/**`, not the package READMEs
+ *  (`check-doc-snippet-types.mjs` covers those for its own question), not
+ *  `docs/**`. */
 const DOCS_ROOT = 'content/docs';
+
+/**
+ * Pages at the repository ROOT that join the walk by name.
+ *
+ * objectui#7115. The root `README.md` is the most-read authored file in the
+ * repository — the GitHub landing page and the npm package page — and it was the
+ * one teaching surface NO doc gate read. This gate walked `content/docs`; its
+ * sibling `check-doc-snippet-types.mjs` walked `content/docs` plus the package
+ * READMEs; the root README fell between the two. It taught `stat-card` four
+ * times, in the flagship "dashboard in JSON" example, and `stat-card` is
+ * registered nowhere — four `OBJUI-001` "Unknown component type" panels for
+ * anyone who copied the headline snippet. The defect survived for exactly one
+ * reason: nothing read the file. That is objectui#5174's shape (40 `.md` guides
+ * outside the ledger) and objectui#5342's, one directory up.
+ *
+ * ⚠️ Widening a scan surface is the change that can be GREEN ABOUT NOTHING, so
+ * this entry landed RED FIRST: with the name added and the content still saying
+ * `stat-card`, this gate failed on `README.md:290`-`:293` with
+ * `unregistered-doc-type`. That failure is the evidence the walk reaches the
+ * file; the content fix then turned it green. Anything added here later is owed
+ * the same proof, in that order.
+ *
+ * A name here that does not resolve is a FAILED run, not a quiet skip — see the
+ * check beside `FLOORS` in the CLI block. Without it, renaming or moving the
+ * file would silently return the surface to what objectui#7115 found.
+ */
+const ROOT_PAGES = ['README.md'];
 
 /** Page extensions collected under `DOCS_ROOT`. BOTH are collected, and that is
  *  the whole content of the scan surface: `content/docs` is authored in a mix of
@@ -967,6 +996,10 @@ export function deriveRegistryKeys(root, options = {}) {
 export function scanDocs(root) {
   const docsDir = join(root, DOCS_ROOT);
   const files = walkFiles(docsDir, (f) => DOC_EXTENSIONS.some((ext) => f.endsWith(ext))).sort();
+  // Root pages join by name rather than by walk. An absent one is dropped here so
+  // a throwaway fixture tree stays scannable; the CLI refuses to publish a
+  // verdict when one is missing from a real run, which is where that must bite.
+  files.push(...ROOT_PAGES.map((name) => join(root, name)).filter((abs) => existsSync(abs)));
   const sites = [];
   const tableRows = [];
   const counters = { files: files.length, codeBlocks: 0, typeSites: 0, keyTables: 0, keyTableRows: 0 };
@@ -1223,6 +1256,21 @@ if (invokedDirectly) {
     return index > -1 ? process.argv[index + 1] : null;
   };
   const root = resolve(argOf('--root') ?? resolve(scriptDir, '..'));
+
+  // Checked BEFORE the scan, because a missing root page produces a smaller
+  // number rather than an error, and `FLOORS` below cannot tell a shrunken
+  // surface from an ordinary docs edit.
+  for (const name of ROOT_PAGES) {
+    if (!existsSync(resolve(root, name))) {
+      console.error(
+        `ROOT_PAGES names \`${name}\`, which does not exist under ${root}. That name is part of this ` +
+          "gate's scan surface (objectui#7115), so a dangling entry means the surface is quietly " +
+          'smaller than this file says it is — which is the whole defect objectui#7115 was filed for. ' +
+          'Re-point the entry at the page\'s new path, or remove it deliberately.',
+      );
+      process.exit(1);
+    }
+  }
 
   let result;
   try {

--- a/scripts/check-doc-fence-languages.mjs
+++ b/scripts/check-doc-fence-languages.mjs
@@ -118,14 +118,22 @@
  * ## What it reads, and what it deliberately does not
  *
  * The scan surface is `check-doc-snippet-types`'s, exactly: every `.mdx` and
- * `.md` under `content/docs`, plus every `packages/<name>/README.md`. It is
- * re-implemented here rather than imported so this gate needs NO install — that
- * gate imports `typescript`, and an install-gated docs check is one that a
- * docs-only pull request skips, which is the shape objectui#5174 and
- * `doc-component-types.yml`'s header both record as the hole. The copy is not
- * left to drift: `scripts/__tests__/check-doc-fence-languages.test.ts` imports
- * BOTH walks and fails if they ever return different document lists, and pins
- * this file's TypeScript-fence set against the gate's own `TS_FENCE_LANGUAGES`.
+ * `.md` under `content/docs`, every `packages/<name>/README.md`, and the root
+ * `README.md` (objectui#7115). It is re-implemented here rather than imported so
+ * this gate needs NO install — that gate imports `typescript`, and an
+ * install-gated docs check is one that a docs-only pull request skips, which is
+ * the shape objectui#5174 and `doc-component-types.yml`'s header both record as
+ * the hole. The copy is not left to drift:
+ * `scripts/__tests__/check-doc-fence-languages.test.ts` imports BOTH walks and
+ * fails if they ever return different document lists, and pins this file's
+ * TypeScript-fence set against the gate's own `TS_FENCE_LANGUAGES`.
+ *
+ * ⭐ That coupling pin is not decoration — it is what CAUGHT objectui#7115.
+ * That card widened the two gates its ruling named onto the root `README.md`
+ * and this one, the third, went red on `walks exactly the documents the snippet
+ * gate walks` before anybody had thought to look for a third. The install-free
+ * copy is deliberate; the pin is what makes a deliberate copy safe, and it did
+ * the job it was written for.
  *
  * ⛔ It compiles nothing. Whether a block that reaches a `ts` fence then passes
  * `--strict` is `check-doc-snippet-types`'s question; this gate only makes sure
@@ -145,6 +153,20 @@ const DOCS_ROOT = 'content/docs';
 const PACKAGES_DIR = 'packages';
 const DOC_EXTENSIONS = ['.mdx', '.md'];
 
+/**
+ * Pages at the repository ROOT that join the scan set by name (objectui#7115).
+ *
+ * ⛔ Deliberately a COPY of `check-doc-snippet-types.mjs`'s constant rather than
+ * an import of it, for the reason stated in the header: importing anything from
+ * that module pulls in its `import ts from 'typescript'` at load, and this gate's
+ * whole value is that it runs with no install, in the unfiltered workflow a
+ * docs-only pull request starts. Exported so the equality is checked rather than
+ * hoped for — `check-doc-fence-languages.test.ts` pins this array against the
+ * other two gates', which is the same bargain `TS_FENCE_LANGUAGES` and the
+ * document walk already make: copy freely, compare always.
+ */
+export const ROOT_PAGES = ['README.md'];
+
 /** Every document in the scan set, in a stable order. */
 export function listDocuments(root = repoRoot) {
   const out = [];
@@ -163,6 +185,11 @@ export function listDocuments(root = repoRoot) {
       const readme = join(pkgDir, entry, 'README.md');
       if (existsSync(readme)) out.push(relative(root, readme).split(sep).join('/'));
     }
+  }
+  // Root pages last, by name — the same order the snippet gate appends them in,
+  // because the coupling pin compares the lists element by element.
+  for (const name of ROOT_PAGES) {
+    if (existsSync(join(root, name))) out.push(name);
   }
   return out;
 }

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -259,8 +259,8 @@
  * SURFACE is stated in the same breath as the coverage rule rather than left to
  * be read off the collector:
  *
- *     every `.mdx` and `.md` page under `content/docs`, plus every
- *     `packages/<name>/README.md`.
+ *     every `.mdx` and `.md` page under `content/docs`, every
+ *     `packages/<name>/README.md`, and the root `README.md`.
  *
  * Stating it here is objectui#5174's finding, and the finding was not the missing
  * extension — it was that a reader had to open `listDocuments` to learn that
@@ -300,6 +300,28 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
  *  package README (which ships to npm inside the package's `files`). */
 const DOCS_ROOT = 'content/docs';
 const PACKAGES_DIR = 'packages';
+
+/**
+ * Pages at the repository ROOT that join the scan set by name.
+ *
+ * objectui#7115. Between this gate's surface (`content/docs` + the package
+ * READMEs) and `check-doc-component-types.mjs`'s (`content/docs` alone), the
+ * root `README.md` fell through: the most-read authored file in the repository —
+ * the GitHub landing page and the npm page for the workspace — was read by NO
+ * doc gate at all. It taught the unregistered type `stat-card` four times in its
+ * flagship example for as long as the example existed.
+ *
+ * Adding the name here is what makes the file VISIBLE to this gate's accounting.
+ * Whether its snippets compile is a separate question answered, as for every
+ * other document, by `UNGATED_DOCS` below: covered by default, and opted out
+ * only with a written, re-derived reason. That distinction is objectui#5174's,
+ * quoted in the header — a document outside the walk is "neither covered NOR
+ * declared ungated", which is strictly worse than a named debt.
+ *
+ * A name here that does not resolve is a failed run, not a quiet skip: see the
+ * check in `main`.
+ */
+const ROOT_PAGES = ['README.md'];
 
 /** Page extensions collected under `DOCS_ROOT`. BOTH are collected, and that is
  *  the whole content of the scan surface: `content/docs` is authored in a mix of
@@ -450,6 +472,23 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * @type {Record<string, string>}
  */
 const UNGATED_DOCS = {
+  // objectui#7115 put the root README into the scan surface; this entry is what
+  // that bought on THIS gate's question. The file is now VISIBLE to the ledger
+  // instead of invisible to the walk — the objectui#5174 distinction quoted in
+  // the header — and the debt below is measured, not estimated. ⚠️ Read as debt,
+  // never as a pass: these 9 diagnostics are real and objectui#7417 carries them.
+  // The three TS2305s are the ones that matter; the other six are fragment shape.
+  'README.md':
+    '4 undefined-name diagnostic(s) — blocks use ambient names the page never defines (`myAPI`, ' +
+    '`MySidebar`) or continue an earlier block (`SchemaRenderer`, `schema`); 2 elided-body ' +
+    'diagnostic(s) (TS2420, TS2355) — a `DataSource` implementation written as `// ... other ' +
+    'methods`; plus TS2305x3 — REAL defects, measured against the built `dist/index.d.ts` of each ' +
+    'package and filed as objectui#7417: `ObjectRenderer` is on no export of @object-ui/app-shell ' +
+    '(the same phantom objectui#7095 recorded in examples/byo-backend-console/README.md), ' +
+    '`registerDefaultRenderers` is on no export of @object-ui/components (only ' +
+    '`registerPlaceholders` is) and is taught in no other authored file, and ' +
+    '`createObjectStackAdapter` is imported from @object-ui/core, which does not ship it — ' +
+    '@object-ui/data-objectstack does, as packages/plugin-dashboard/README.md already writes it.',
   'content/docs/plugins/plugin-calendar-view.mdx':
     '2 unresolved-module diagnostic(s) — and NOT a defect: the page is a migration guide whose ' +
     '"Before" blocks quote the retired `@object-ui/plugin-calendar-view` import on purpose. Covering ' +
@@ -642,6 +681,12 @@ export function listDocuments(root = repoRoot) {
       const readme = join(pkgDir, entry, 'README.md');
       if (existsSync(readme)) out.push(relative(root, readme).split(sep).join('/'));
     }
+  }
+  // Root pages last, by name. An absent one is dropped here so a throwaway
+  // fixture tree stays listable; `main` refuses to publish a verdict when one is
+  // missing from a real run, which is the only place that can bite.
+  for (const name of ROOT_PAGES) {
+    if (existsSync(join(root, name))) out.push(name);
   }
   return out;
 }
@@ -1129,6 +1174,22 @@ export function buildFilterArgs(packages) {
 
 function main() {
   const argv = process.argv.slice(2);
+
+  // Checked before anything else: a ROOT_PAGES name that does not resolve makes
+  // the scan set quietly SMALLER, and every count this gate prints would still
+  // look healthy. That silent shrink is the defect objectui#7115 was filed for.
+  for (const name of ROOT_PAGES) {
+    if (!existsSync(join(repoRoot, name))) {
+      console.error(
+        `ROOT_PAGES names \`${name}\`, which does not exist under ${repoRoot}. That name is part of ` +
+          "this gate's stated scan surface (objectui#7115), so a dangling entry silently narrows the " +
+          "surface back to what objectui#7115 found. Re-point it at the page's new path, or remove " +
+          'it deliberately.',
+      );
+      return EXIT_CODES.couldNotRun;
+    }
+  }
+
   const state = analyze({});
 
   if (argv.includes('--build-filter')) {

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -320,8 +320,12 @@ const PACKAGES_DIR = 'packages';
  *
  * A name here that does not resolve is a failed run, not a quiet skip: see the
  * check in `main`.
+ *
+ * Exported so the equality is checked rather than hoped for: three gates now
+ * carry this array, and `check-doc-fence-languages.test.ts` pins all three
+ * against each other.
  */
-const ROOT_PAGES = ['README.md'];
+export const ROOT_PAGES = ['README.md'];
 
 /** Page extensions collected under `DOCS_ROOT`. BOTH are collected, and that is
  *  the whole content of the scan surface: `content/docs` is authored in a mix of


### PR DESCRIPTION
Fixes #7115

The root `README.md` — the repository's GitHub landing page and the npm page for the workspace, the most-read authored file in it — was outside the scan surface of **every** doc gate. `check-doc-component-types` walked `content/docs`. `check-doc-snippet-types` walked `content/docs` plus the package READMEs. The root README fell between the two, and taught `stat-card` four times in its flagship "dashboard in JSON" example. Nothing registers `stat-card`, so a reader who copied the headline snippet got four `OBJUI-001` "Unknown component type" panels.

## The ruling this implements

Maintainer, 2026-09-01, verbatim 「同意」 (comment 5494799307), quoted in the ruled order:

> 1. **门禁盲区**:根 `README.md` 加进 `check-doc-component-types` 与 `check-doc-snippet-types` 的扫描面(最高价值半边,先落——内容修了不加面就会再烂);
> 2. **内容修**:四个 `stat-card` widget 改 **`statistic`**(真实注册且有 `value` 运送行,`"${…}"` 照常求值,示例保持表达力);
> 3. **叉裁 B**:非 text 类型不加运送行 —— 停止在无运送行的键上编写 `${…}`(文档教现实);真实应用要哪个键求值 ⇒ 带消费者立 carriage-row 卡,届时按条款②扩

All three parts, one PR (lane's choice, as the ruling permits).

## Part 1 — the gate blind spot, proved red-then-green

Widening a scan surface is exactly the change that can be **green about nothing**, so the widening was landed red first and the evidence is here rather than asserted.

**`check-doc-component-types`** (`ROOT_PAGES = ['README.md']`, joined to `scanDocs`'s file list):

| state | files scanned | exit | what it said |
|---|---|---|---|
| before, unwidened | 185 | 0 | green — the README was not in the walk |
| **widened, content untouched** | **186** | **1** | **7 findings, 4 of them the ruled ones** |
| widened + content fixed | 186 | 0 | green |

The failure that proves the walk reaches the file, verbatim from the run:

```
      README.md:290  [unregistered-doc-type]  type 'stat-card' (json)
          { "type": "stat-card", "title": "Revenue", "value": "${stats.revenue}", "trend": "+12%", "w": 3, "h": 1 },
      README.md:291  [unregistered-doc-type]  type 'stat-card' (json)
      README.md:292  [unregistered-doc-type]  type 'stat-card' (json)
      README.md:293  [unregistered-doc-type]  type 'stat-card' (json)
```

**Ablation, to show the pins can fail.** With the implementation committed, the `files.push(...ROOT_PAGES…)` line was deleted (anchored grep `1` to `0`, blob `6688e098` to `d0441c22` — confirmed on disk before the run, not asserted). The gate went back to **185 files and printed `✅ Every documented component type is registered`** — the exact "green about nothing" state — and both new pins went red with the intended message. Restored with `git checkout HEAD -- ABSOLUTE_PATH` under a `trap … EXIT INT TERM`, and the restore is verified by state: `git diff HEAD` empty and the blob equal to the HEAD blob, not by an exit code.

**`check-doc-snippet-types`** — the root README **does** carry snippets its rules cover (five `tsx`/`typescript` blocks), so the same proof applies and is not hand-waved. Widening it took the scan set from 224 to 225 documents, and the build closure the gate computes for itself grew by exactly `@object-ui/providers` — a second, independent signal that the walk now reaches the file. It went red with 9 semantic diagnostics.

⚠️ **Read this half honestly: those diagnostics are declared debt, not fixed.** `README.md` is now named in `UNGATED_DOCS` with a measured reason, which is that gate's own designed mechanism and the objectui#5174 distinction its header states — a document outside the walk is *"neither covered NOR declared ungated"*, invisible to the gate's own accounting, whereas a ledgered one is named, counted, re-derived every run and shrink-only. Three of the nine are real defects (`ObjectRenderer`, `registerDefaultRenderers`, `createObjectStackAdapter` attributed to the wrong package) and are filed as **#7417**, with the reason string in the ledger naming that card. Making those blocks compile means resolving two phantom APIs, which is authoring work with an API question inside it — not this card.

### The third gate — `check-doc-fence-languages`, found by its own coupling pin

⭐ **The ruling named two gates. There are four.** `check-doc-fence-languages` re-implements the snippet gate's walk (deliberately, so it needs no install — the snippet gate imports `typescript`, and an install-gated docs check is one a docs-only PR skips), and `check-doc-fence-languages.test.ts` asserts `fenceDocuments(ROOT)` **equals** `snippetDocuments(ROOT)`. Widening one surface without the other breaks that coupling by construction, and it did: the pin went red at 223 vs 224 documents.

The pin was **not** touched — it is doing precisely the job it was written for, and it is the only reason the third gate was found at all. The fence guard's surface is widened instead, and its header now *states* the surface where a reader will find it, as objectui#5174's own finding requires.

`ROOT_PAGES` **cannot** be shared by import: anything imported from `check-doc-snippet-types.mjs` pulls in its `import ts from 'typescript'` at load, which would install-gate the one gate whose value is running install-free. So it stays a copy, on the bargain the document walk and `TS_FENCE_LANGUAGES` already make — copy freely, compare always. All three now **export** `ROOT_PAGES` and a new pin compares all three, so the shared half cannot drift even where the full surfaces legitimately differ (component-types deliberately does not walk the package READMEs, so it cannot join the list-equality comparison).

**The root README needed no fence fix, and that green is not vacuous.** With it in the walk the guard reports **225 documents and zero findings for it**; the objectui#5867 shrink-only baseline is untouched, with no entry added. Control, through the shipped `census()`: un-fencing one of the README's `tsx` blocks produces `{ rel: 'README.md', line: 206, language: '', mode: 'synonym' }`, so the file is genuinely parsed and genuinely judged.

### Four gates, measured rather than assumed

The card's thesis was that the most-read authored file in the repository was checked by nothing. The true number turned out to be **larger than the ruling enumerated**, which is the thesis proving itself a second time:

| gate | status |
|---|---|
| `check-doc-component-types` | widened here |
| `check-doc-snippet-types` | widened here |
| `check-readme-exports` | same blind spot, surface is `packages/NAME/README.md` only — filed as #7417 |
| `check-doc-fence-languages` | widened here, **found by its own coupling pin** rather than by anyone looking |

## Part 2 — the content fix

The four widgets become `statistic`, registered at `packages/components/src/renderers/data-display/statistic.tsx:64`. ⭐ **A retarget, not a downgrade to literals**: measured from the built artifact (`expressionBindableTextKeysFor` out of `@objectstack/spec@17.2.0`'s `dist/ui/index.mjs`, the same lookup `SchemaRenderer.tsx:1139` consumes), `statistic` carries `[label, value, description]`, so `"value": "${stats.revenue}"` keeps evaluating.

Two keys moved with the type, because the renderer's real shape is not `stat-card`'s: it reads `schema.label` (not `title`), and its `trend` is the enum `up`/`down`/`neutral` with the delta text in `description`. `"trend": "+12%"` would have rendered no arrow and no text — 文档教现实 applies to the retarget too.

## Part 3 — fork ruled B, and no carriage row was added

⛔ **Zero carriage rows added.** The map lives in `@objectstack/spec` (a dependency), and this PR touches neither it nor `SchemaRenderer.tsx`.

Every `${…}` rewritten, with the measured row set for its node type:

| file | node type | key | carriage rows for that type | now |
|---|---|---|---|---|
| `content/docs/guide/expressions.md` (Percentage Bar) | `progress` | `value` | none | literal `75`, with `visibleOn` carrying the expression |
| `content/docs/guide/expressions.md` (Percentage Bar) | `progress` | `label` | none | literal — same node, same defect, named on the card as `:388` |
| `content/docs/guide/expressions.md` (Computed Fields) | `input` | `value` | none | shown by a `text` node's `content`, which is evaluated on every type |
| `packages/plugin-dashboard/README.md` | `metric-card` | `value` | none | literal, with a sentence pointing at the `object-*` widgets that do read live data |
| `packages/plugin-dashboard/README.md` | `metric-card` | `trend` | none | literal `'up'` |
| `packages/react/README.md` | `input` | `value` | none | moved to a sibling `text` node's `content` |

On the card's own second-order note: it recorded, **unmeasured**, that `metric-card` and `input` "likely render the literal `${...}`". That is now **measured** — both carry the empty set — but the rendering claim itself was never put in a browser and is not restated here as one.

## ⚠️ Deviations — flagged, not folded in silently

Widening a surface finds what the surface was hiding. Four things surfaced that the ruling's enumeration does not name, because the census behind it was taken **before** any gate had read this file. Each is stated so a reviewer can drop it on its own.

1. **`crud` × 2 — a RETIRED type.** The widened gate found `README.md:137` and `:264` teaching `crud`. `CRUDSchema` and the `crud` node type were **removed in objectui#5373** under ADR-0049; `content/docs/api/schema-reference.md:541`-`:563` carries the retirement and an explicit "what to author instead" table, and `validateSchema` already returns `RETIRED_TYPE` for the name. The README was teaching a type the platform refuses by name. Retargeted per that table: the `UserForm` comparison onto `object-form`, the "Data Grid" example onto `object-grid` with that schema's real keys (`field`, not `name`, as its own doc row insists).
2. **`submit` — not a node type.** `README.md:256` authored `"actions": [{ "type": "submit" }]` under a form. `FormSchema.actions` is `SchemaNode[]`, so this is a *rendered node* position, and `ActionSchema.type` is `'action'` — the `authentication.mdx` exemption for `submit` does not reach here. The declared key for the built-in submit button is `submitLabel`, which is what it now says.
3. **`card.value` × 3 — ruling B, in a site the ruling's census never read.** The "Basic Usage" snippet bound `${stats.*}` in `card.value`; `card` carries `[title, description]`, so `value` there is a literal. Retargeted onto `statistic` — the same move part 2 ordered, for the same reason.
4. Findings left alone and filed rather than fixed: **#7417** (the root README's snippet debt, plus `check-readme-exports`' identical blind spot) and **#7418** (six more non-carriage `${…}` in `guide/expressions.md` beyond the two the ruling enumerated).

Items 1-3 are the card's own defect classes in the card's own file, and 1-2 are structurally forced: part 1 cannot land green while the file it now reads is red. They are bounded, and each correct form is pinned by evidence already in the tree — nothing here is a judgement call about an API.

## Verification

All runs at `02efff4ba`, the final commit, with a clean tree.

| check | result |
|---|---|
| `check:doc-types` | ✅ 186 files, 922 `type` literals, 787 registered |
| `check:doc-snippets` | ✅ 225 documents, 193 covered, 32 ungated, 417/417 blocks judged |
| `check:doc-fences` | ✅ **225** documents, root README contributing 0 findings (control fires — see above) |
| `docs:check-links` | ✅ 17 scan roots |
| `check:readme-exports` | ✅ 406 self-imports judged, 0 fabricated |
| `check:control-bytes` | ✅ 6109 files |
| `check:pre-install-import-graph` | ✅ 22 modules walked, every non-relative leaf a node builtin — the fence guard stays install-free |
| `changeset:check` + `check-changeset-presence` | ✅ — "no changeset is owed"; an empty-frontmatter declaration is here anyway, per the objectui#7114 precedent |
| the three gate suites + 7 derived tests | ✅ 10 files, 226 tests (the three gate suites carry **+10 new pins**) |
| `eslint --no-inline-config` over the changed lintable files | ✅ 0 errors, 0 warnings |

**On the eslint narrowing**, stated so it reads as a measurement rather than a skip: ① the receiving population is read from `eslint.config.js` itself (`files: ['**/*.{ts,tsx}']` plus narrower overrides; `scripts/` is not in `ignores`) — the `.mjs` files are outside it and were passed explicitly, so this over-covers; ② the count comes from `--format json`: 0 errors, 0 warnings; ③ `eslint.config.js` has **zero** occurrences of `projectService` / `parserOptions` / `project:` (control: `languageOptions` matches once), so type-aware linting is off and no untouched file's verdict can depend on this diff.

**`check:eager-closure` is unmoved, and this is structural rather than a byte reading.** Locally the gate reports its own precondition — *"No eager-closure report at `apps/console/dist/eager-closure.json` … a broken gauge, not a passing budget"* — so it is **NOT MEASURED** here, not green. What is measured: **0** files in this diff are under `apps/**` or `packages/*/src/**`; the rest are `scripts/` CI tooling and markdown. No source imports a README or a `scripts/` file (the only `?raw` imports in the tree are `apps/console/index.html` inside console *tests*; control: the same probe over `d4c6a86a1` lists four real `src/` files). Nothing here is a bundler input. CI confirms it: `Bundle Analysis` is green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC