### PR TITLE
fix(plugin-gantt): one container-driven predicate for a row's dates, and a task list sized from the container

### DIFF
--- a/.changeset/7204-gantt-tasklist-width-and-date-predicate.md
+++ b/.changeset/7204-gantt-tasklist-width-and-date-predicate.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/plugin-gantt': minor
+---
+
+Size the gantt task list from its container, and give a row's dates ONE predicate
+(objectui#7204, objectui#7224; maintainer ruling 2026-09-02, option Y).
+
+**A row could show no dates at all.** Two gates decided whether a row's dates were
+painted, and they read two different widths. The Start/End columns were gated on the
+container-derived task-list width; the `8/26 → 9/2` sublabel under the title was gated
+by the component's own `@media (min-width: 640px) { .gantt-sm-hidden { display: none } }`
+rule, which reads the viewport. Between a 640px and a 1023px container both were shut,
+so the row's dates existed in the DOM twice and were painted zero times. The same hole
+opened at any width once the splitter was dragged under the threshold.
+
+The sublabel now renders on exactly the complement of the Start/End columns, both from
+the same container-derived width, and the media rule is gone. A row always carries its
+dates one way or the other.
+
+**And the task list no longer caps at 320px.** From a 1024px container up, the pane
+takes 3/8 of the container clamped to `[320, 560]` instead of a flat 320. At 1440 that
+is 540px, which leaves the title 287px with the Start/End columns still painted — a
+40-character title measures 262px in the row's font, so real-world task names stop
+truncating to about seven characters while several hundred pixels of chart sit empty.
+Measured in Chromium at a 1440px container: title 53px before, 287px after.
+
+The Start/End threshold moves from an estimated 280 to a derived **412** — 32 row
+padding + 160 for the two columns + 28 for the open-details slot + 32 of title
+furniture + 160 minimum title, each term traced to the markup that spends it. Below it
+the sublabel carries the dates. One consequence worth stating: between a 1024px and a
+1097px container the columns are now off and the dates ride the sublabel, which trades
+two 80px date cells for a title that grows from 67px to 291px.
+
+Not fixed here, and unchanged: a row's `depth * 14` indent is unbounded, so no single
+default keeps a deeply nested row legible.

--- a/packages/plugin-gantt/src/GanttView.tasklistDates-7204.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.tasklistDates-7204.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * #7204 / #7224 — ONE container-driven predicate for a row's dates, and a
+ * task-list default sized from the container instead of capped at 320px.
+ *
+ * ⚠️ Every assertion here is about the DOM, never about computed style, and
+ * that is deliberate. jsdom applies `@media` rules irrespective of
+ * `window.innerWidth`: while the old `@media (min-width: 640px) {
+ * .gantt-sm-hidden { display: none } }` rule was live, `getComputedStyle(
+ * sublabel).display` read `none` at 500, 800 and 1440 alike — including at
+ * widths where a real browser painted the sublabel. A computed-style assertion
+ * in this file would confirm the wrong answer in the reassuring direction. The
+ * predicate under test is a RENDER decision, which jsdom answers exactly; the
+ * pixel readings that go with it were taken in real Chromium and are recorded
+ * on the PR.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function tasks(): GanttTask[] {
+  return [
+    {
+      id: 'a',
+      title: 'Site environmental audit — Northgate',
+      start: new Date('2026-08-26T00:00:00.000Z'),
+      end: new Date('2026-09-02T00:00:00.000Z'),
+      progress: 0,
+    },
+  ];
+}
+
+/**
+ * `effectiveWidth = containerWidth || window.innerWidth`, and jsdom's
+ * ResizeObserver reports 0, so `innerWidth` IS the container width here — the
+ * same convention the rest of this suite uses.
+ */
+function renderAt(width: number, props: Partial<React.ComponentProps<typeof GanttView>> = {}) {
+  Object.defineProperty(window, 'innerWidth', { value: width, configurable: true });
+  return render(
+    <div style={{ width, height: 600 }}>
+      <GanttView
+        tasks={tasks()}
+        startDate={new Date('2026-08-17T00:00:00.000Z')}
+        endDate={new Date('2026-10-30T00:00:00.000Z')}
+        onTaskClick={vi.fn()}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function gates(container: HTMLElement) {
+  const headerCells = Array.from(container.querySelectorAll('.gantt-sm-w20')).filter(
+    (el) => !el.closest('[data-testid^="gantt-task-row-"]')
+  );
+  const panel = container.querySelector('.gantt-task-list') as HTMLElement | null;
+  return {
+    sublabel: !!container.querySelector('[data-testid="gantt-row-dates-a"]'),
+    startCell: !!container.querySelector('[data-testid="gantt-row-start-a"]'),
+    endCell: !!container.querySelector('[data-testid="gantt-row-end-a"]'),
+    headerCaptions: headerCells.length,
+    panelWidth: panel ? parseFloat(panel.style.width) : null,
+  };
+}
+
+/**
+ * The #7224 table. `columns` is what the Start/End cells do; the sublabel is
+ * asserted to be its exact complement at every row, which is the property that
+ * goes red the moment the two gates start reading different widths again.
+ * 640–1023 is the band that showed NO dates at all before this change.
+ */
+const TABLE: Array<{ width: number; panelWidth: number; columns: boolean }> = [
+  { width: 500, panelWidth: 0, columns: false },
+  { width: 639, panelWidth: 0, columns: false },
+  { width: 640, panelWidth: 220, columns: false },
+  { width: 800, panelWidth: 220, columns: false },
+  { width: 1024, panelWidth: 384, columns: false },
+  { width: 1280, panelWidth: 480, columns: true },
+  { width: 1440, panelWidth: 540, columns: true },
+  { width: 1920, panelWidth: 560, columns: true },
+];
+
+describe('GanttView row dates — one predicate, container-driven (#7224)', () => {
+  it.each(TABLE)(
+    'at a $width px container the sublabel renders on exactly the complement of the Start/End columns',
+    ({ width, panelWidth, columns }) => {
+      const { container } = renderAt(width);
+      const g = gates(container);
+      expect(g.panelWidth).toBe(panelWidth);
+      expect(g.startCell).toBe(columns);
+      expect(g.endCell).toBe(columns);
+      // The complement — not "both off" (the 640–1023 hole) and not "both on".
+      expect(g.sublabel).toBe(!columns);
+      // The header captions follow the same single predicate as the cells they
+      // caption, so a row can never be captioned by a column it does not have.
+      expect(g.headerCaptions).toBe(columns ? 2 : 0);
+    }
+  );
+
+  it('never leaves a row with no dates at any width in the table', () => {
+    for (const { width } of TABLE) {
+      const { container, unmount } = renderAt(width);
+      const g = gates(container);
+      expect(
+        g.sublabel !== g.startCell,
+        `width ${width}: sublabel=${g.sublabel} startCell=${g.startCell}`
+      ).toBe(true);
+      unmount();
+    }
+  });
+
+  it('a splitter drag under the threshold moves the dates to the sublabel, at a desktop width too', () => {
+    // The #7224 second hole: a persisted drag below the threshold at 1440,
+    // where the old viewport rule kept the sublabel hidden as well.
+    window.localStorage.setItem(
+      'gantt-layout:drag-narrow',
+      JSON.stringify({ viewMode: 'day', columnWidth: null, taskListCollapsed: false, taskListWidth: 200 })
+    );
+    const { container } = renderAt(1440, { persistLayoutKey: 'drag-narrow' });
+    const g = gates(container);
+    expect(g.panelWidth).toBe(200);
+    expect(g.startCell).toBe(false);
+    expect(g.sublabel).toBe(true);
+  });
+
+  it('carries no viewport rule in its own stylesheet that can hide a row date', () => {
+    const { container } = renderAt(1440);
+    const css = Array.from(container.querySelectorAll('style'))
+      .map((s) => s.textContent ?? '')
+      .join('\n');
+    expect(css.length).toBeGreaterThan(0);
+    // The class the media rule used to hide is gone from the component entirely.
+    expect(css).not.toContain('gantt-sm-hidden');
+    expect(container.querySelector('.gantt-sm-hidden')).toBeNull();
+    // And no surviving media block hides anything — re-adding a viewport gate
+    // on a row's dates has to fail here, whatever it gets called next time.
+    const mediaBlocks = css.match(/@media[^{]*\{[\s\S]*?\}\s*\}/g) ?? [];
+    expect(mediaBlocks.length).toBeGreaterThan(0);
+    for (const block of mediaBlocks) expect(block).not.toMatch(/display:\s*none/);
+  });
+});
+
+describe('GanttView task-list default sized from the container (#7204)', () => {
+  it('spends the extra desktop width on the task list, clearing the 412px threshold', () => {
+    // 412 = 32 padding + 160 columns + 28 open-details slot + 32 title
+    // furniture + 160 minimum title. Each of 1280 / 1440 / 1920 must clear it,
+    // otherwise the threshold would only ever be reached by a manual drag.
+    for (const [width, expected] of [[1280, 480], [1440, 540], [1920, 560]] as const) {
+      const { container, unmount } = renderAt(width);
+      const g = gates(container);
+      expect(g.panelWidth, `container ${width}`).toBe(expected);
+      expect(g.panelWidth!, `container ${width} clears 412`).toBeGreaterThanOrEqual(412);
+      expect(g.startCell).toBe(true);
+      unmount();
+    }
+  });
+
+  it('pins the exact width at which the Start/End columns switch on', () => {
+    const below = renderAt(1097);
+    expect(gates(below.container).panelWidth).toBe(411);
+    expect(gates(below.container).startCell).toBe(false);
+    expect(gates(below.container).sublabel).toBe(true);
+    below.unmount();
+
+    const at = renderAt(1098);
+    expect(gates(at.container).panelWidth).toBe(412);
+    expect(gates(at.container).startCell).toBe(true);
+    expect(gates(at.container).sublabel).toBe(false);
+  });
+
+  it('clamps the share to the 320px floor and the 560px ceiling', () => {
+    // Floor: the share is 3/8, so it cannot bind above 1024 — the floor guards
+    // the bottom of the branch and keeps the old default as the minimum.
+    const floor = renderAt(1024);
+    expect(gates(floor.container).panelWidth).toBe(384);
+    floor.unmount();
+
+    const wide = renderAt(3000);
+    expect(gates(wide.container).panelWidth).toBe(560);
+    wide.unmount();
+
+    const ultra = renderAt(5120);
+    expect(gates(ultra.container).panelWidth).toBe(560);
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -88,17 +88,89 @@ function columnWidthForContainer(width: number) {
   return 110;
 }
 
+/**
+ * Task-list geometry, in px. Every term below is traced to the markup that
+ * spends it, so the Start/End threshold is DERIVED rather than estimated.
+ */
+/** Row and header horizontal padding: `px-2 sm:px-4` — 16px a side from 640px up. */
+const TASK_LIST_ROW_PADDING_W = 32;
+/** The two date cells: `w-16 gantt-sm-w20` — 80px each from 640px up. */
+const START_END_COLUMNS_W = 160;
+/** The trailing `→` open-details slot: `w-6` (24px) plus its 4px `marginLeft`. */
+const OPEN_DETAILS_SLOT_W = 28;
+/**
+ * Fixed furniture inside the name cell, ahead of the title: the collapse
+ * spacer (`w-3` 12px, pulled back 4px), the `w-2` colour dot, and the two
+ * `gap-2` gaps → 8 + 8 + 8 + 8. (A summary row's `w-4` toggle costs 4 more.)
+ */
+const TITLE_FURNITURE_W = 32;
+/**
+ * Task-list pane floor — the narrowest a drag may leave the pane, and reused
+ * below as the least title width worth keeping the Start/End columns for.
+ */
+const TASK_LIST_MIN_W = 160;
+
+/**
+ * Task-list default width, sized from the CONTAINER instead of capped at a
+ * fixed 320px. Below 1024 the two stepped defaults are unchanged; from 1024 up
+ * the pane takes a share of the container, clamped:
+ *
+ * - floor 320 — the previous fixed default, so nothing gets narrower;
+ * - share 3/8 — 3/8 of 1440 is 540, which leaves the title 287px once the
+ *   row's fixed cost is paid (`START_END_COLUMNS_MIN_W` minus its title term).
+ *   A 40-character title measures 262px in the row's 14px `sm:text-sm` font
+ *   (measured in Chromium), so the top of the 25-to-40 character band is
+ *   legible at 1440 and wider WITH the Start/End columns still painted;
+ * - ceiling 560 — leaves the title 307px, still clearing 262px after one level
+ *   of the row's `depth * 14` indent. Past that, more pane width buys no
+ *   legibility and the timeline — the view's primary content — pays for it.
+ *   The ceiling binds from a 1494px container up.
+ *
+ * ⚠️ `depth * 14` is unbounded, so no single default keeps a DEEPLY nested row
+ * legible; that is a known limit of this sizing, not something a threshold can
+ * fix.
+ */
+const TASK_LIST_DEFAULT_SHARE = 0.375;
+const TASK_LIST_DEFAULT_MIN_W = 320;
+const TASK_LIST_DEFAULT_MAX_W = 560;
+
 function taskListWidthForContainer(width: number) {
   if (width < 640) return 140;
   if (width < 1024) return 220;
-  return 320;
+  return Math.round(
+    Math.min(
+      TASK_LIST_DEFAULT_MAX_W,
+      Math.max(TASK_LIST_DEFAULT_MIN_W, width * TASK_LIST_DEFAULT_SHARE)
+    )
+  );
 }
 
-// Show the Start/End sub-columns only when the task list is wide enough that
-// the title still has room. Below this threshold the title would collapse to
-// a few pixels (issue: bars rendered but names invisible).
+/**
+ * The pane width at which the Start/End sub-columns start paying for
+ * themselves: everything the row spends before the title, plus the least title
+ * worth leaving. 32 + 160 + 28 + 32 + 160 = 412.
+ */
+const START_END_COLUMNS_MIN_W =
+  TASK_LIST_ROW_PADDING_W +
+  START_END_COLUMNS_W +
+  OPEN_DETAILS_SLOT_W +
+  TITLE_FURNITURE_W +
+  TASK_LIST_MIN_W;
+
+/**
+ * The single predicate for a row's dates. It reads ONLY the container-derived
+ * task-list width, and the date sublabel under the title renders on exactly
+ * its complement — so a row always shows its dates one way or the other.
+ *
+ * Previously the columns were gated by this test AND a `sm:` viewport test
+ * while the sublabel was gated by a `(min-width: 640px)` media rule alone. Two
+ * gates on two different widths are not complements: between a 640px and a
+ * 1023px container both were shut and the row showed no dates at all, and the
+ * same hole opened at any width once the splitter was dragged under the
+ * threshold.
+ */
 function showStartEndColumns(taskListWidth: number) {
-  return taskListWidth >= 280;
+  return taskListWidth >= START_END_COLUMNS_MIN_W;
 }
 
 function rowHeightForContainer(width: number) {
@@ -907,7 +979,8 @@ export function GanttView({
   }, [isNarrow]);
   // Task-list pane width. A user drag (taskListWidthOverride) wins over the
   // auto-size, clamped so it can't collapse to nothing or swallow the timeline.
-  const TASK_LIST_MIN_W = 160;
+  // The floor is the module-level TASK_LIST_MIN_W, shared with the Start/End
+  // threshold so the two cannot drift apart.
   const taskListMaxW = Math.max(TASK_LIST_MIN_W, effectiveWidth - 200);
   const taskListWidth = taskListCollapsed
     ? 0
@@ -3273,7 +3346,6 @@ export function GanttView({
         @media (min-width: 640px) {
           .gantt-sm-h50 { height: 50px; }
           .gantt-sm-w20 { width: 80px; }
-          .gantt-sm-hidden { display: none; }
         }
         /* The timeline's NATIVE scrollbars are fully hidden — both axes are
            replaced by the self-drawn bars (horizontal at the bottom, vertical
@@ -3799,14 +3871,31 @@ export function GanttView({
                     />
                   ) : (
                     <span className="flex flex-col min-w-0">
-                      <span className={cn("truncate", row.isSummary && "font-semibold")}>{task.title}</span>
-                      <span className="text-[10px] text-muted-foreground gantt-sm-hidden">
-                        {row.start.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })} → {row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })}
-                      </span>
+                      <span
+                        className={cn("truncate", row.isSummary && "font-semibold")}
+                        data-testid={`gantt-row-title-${task.id}`}
+                      >{task.title}</span>
+                      {/* The row's dates, on exactly the complement of the
+                          Start/End columns — same container-derived width, one
+                          predicate, so a row is never left with neither. */}
+                      {!showSEColumns && (
+                        <span
+                          className="text-[10px] text-muted-foreground"
+                          data-testid={`gantt-row-dates-${task.id}`}
+                        >
+                          {row.start.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })} → {row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })}
+                        </span>
+                      )}
                     </span>
                   )}
                 </div>
-                <div className="w-16 gantt-sm-w20 text-right text-xs text-muted-foreground hidden sm:block" hidden={!showSEColumns} style={!showSEColumns ? { display: 'none' } : undefined}>
+                {/* Start/End, rendered on the same single predicate as the
+                    header's captions — and never on a viewport test, which is
+                    what let the columns and the date sublabel disagree about
+                    how wide the task list is. */}
+                {showSEColumns && (
+                  <>
+                <div className="w-16 gantt-sm-w20 text-right text-xs text-muted-foreground" data-testid={`gantt-row-start-${task.id}`}>
                   {isEditing ? (
                     <input
                       type="date"
@@ -3819,7 +3908,7 @@ export function GanttView({
                     row.start.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })
                   )}
                 </div>
-                <div className="w-16 gantt-sm-w20 text-right text-xs text-muted-foreground hidden sm:block" hidden={!showSEColumns} style={!showSEColumns ? { display: 'none' } : undefined}>
+                <div className="w-16 gantt-sm-w20 text-right text-xs text-muted-foreground" data-testid={`gantt-row-end-${task.id}`}>
                   {isEditing ? (
                     <input
                       type="date"
@@ -3832,6 +3921,8 @@ export function GanttView({
                     row.end.toLocaleDateString(dateLocale, { month: 'numeric', day: 'numeric' })
                   )}
                 </div>
+                  </>
+                )}
                 {/* Open details `→`: opens the detail drawer / page — the row click
                     itself is reserved for Focus-locate, so detail needs its own
                     always-reachable affordance besides double-click. A dedicated


### PR DESCRIPTION
Fixes #7204
Fixes #7224

## The ruling this implements

Maintainer, 2026-09-02, replying to decision batch #5 where these two cards were items 2 and 3, presented as one ruling with recommendation Y. Verbatim reply: 「同意」 (recorded on #7204, comment 5507936333). Option C (an authorable width key) is **not** taken — no new key. Option X (predicate + threshold, without part 2) was the recorded fallback, not the plan.

> 1. **One predicate, container-driven.** The date sublabel renders exactly when the Start/End columns are not painted, and both read the same container width — the viewport media rule on `gantt-sm-hidden` goes; "the columns are painted" stops being the conjunction of a container test and a viewport test. This closes #7224's 640–1023 band (and the dragged-narrow case at any width) at the root.
> 2. **The task-list default is sized from the container**, a clamped share rather than the 320px cap: at 1440 and wider the panel takes enough of the extra width that a 25–40 character title is legible while the Start/End columns stay on; the exact share and clamp bounds are the dev's to derive and pin at 1280 / 1440 / 1920, with 320 as the floor.
> 3. **The Start/End threshold is the derived 412** (32 padding + 160 columns + 28 open-details slot + 32 title furniture + 160 minimum title, each term traced to source), not the estimated 440.

All three parts are in this PR. The `gantt`-block passthrough defect (an invented `gantt.taskListWidth` validates and is silently ignored) is, per the ruling, **not** repaired here.

---

## Part 1 — one predicate

Before, two gates decided whether a row's dates were painted and they read two different widths:

| gate | what it read | where |
| --- | --- | --- |
| Start/End columns | `showStartEndColumns(taskListWidth)`, container-derived — **and** Tailwind `hidden sm:block`, viewport | JS + class |
| date sublabel | `@media (min-width: 640px) { .gantt-sm-hidden { display: none } }`, viewport | the component's own injected style element |

Two gates on two different widths are not complements. Between a 640px and a 1023px **container** both were shut: the row's dates were in the DOM twice and painted zero times. The same hole opened at any width once the splitter was dragged under the threshold.

Now the sublabel renders on exactly `!showSEColumns`, the media rule and the class it hid are gone, and the two date cells lose their `hidden sm:block` so the columns are painted on the same single predicate as the header captions above them. A row always carries its dates one way or the other.

Two smaller things fall out of that, unasked for but not separable: the header captions and the data cells now agree (before, a viewport under 640px with a task list over the threshold printed `Start` / `End` captions over cells that were not painted), and the cells' `hidden` attribute plus inline `display: none` are replaced by conditional rendering, which removes an inline style.

## Part 2 — the default, sized from the container

From a 1024px container up the pane takes **3/8 of the container, clamped to [320, 560]**, rounded to a whole pixel. Below 1024 the two stepped defaults (140 / 220) are unchanged.

- **floor 320** — the ruling's floor, and the previous fixed default, so nothing gets narrower.
- **share 3/8** — 3/8 of 1440 is 540, which leaves the title **287px** once the row's fixed cost is paid. A 40-character title measures **262px** in the row's `sm:text-sm` font (measured in Chromium, below), so the top of the ruling's 25-to-40 character band is legible at 1440 and wider **with the columns still painted**. 3/8 is the smallest clean fraction that does it: 515/1440 = 0.3576 is the bare requirement.
- **ceiling 560** — leaves the title 307px, still clearing 262px after one level of the row's `depth * 14` indent (262 + 14 = 276). Past that, more pane width buys no legibility the ruling asked for and the timeline — the view's primary content — pays for it. The ceiling binds from a 1494px container up.

Resulting pane widths and title space, all three desktop widths clearing 412:

| container | pane | columns painted | title space | 25-char title (154px) | 40-char title (262px) |
| --: | --: | --- | --: | --- | --- |
| 1280 | 480 | yes | 227 | fits | truncates (~35 chars shown) |
| 1440 | 540 | yes | 287 | fits | **fits** |
| 1920 | 560 | yes | 307 | fits | **fits** |

Before this change all three were pane 320 / title 67.

## Part 3 — the threshold is the derived 412

`START_END_COLUMNS_MIN_W = TASK_LIST_ROW_PADDING_W + START_END_COLUMNS_W + OPEN_DETAILS_SLOT_W + TITLE_FURNITURE_W + TASK_LIST_MIN_W`, each term named in the source and traced to the markup that spends it:

| term | px | traced to |
| --- | --: | --- |
| row padding | 32 | the row and header carry `px-2 sm:px-4` — 16px a side from 640px up |
| the two date cells | 160 | each is `w-16 gantt-sm-w20`, and the injected rule sets `.gantt-sm-w20 { width: 80px }` from 640px up |
| open-details slot | 28 | the trailing `w-6` (24px) with its `marginLeft: 4` |
| title furniture | 32 | inside the name cell, ahead of the title: the `w-3` collapse spacer pulled back 4px (8), `gap-2` (8), the `w-2` colour dot (8), `gap-2` (8) |
| minimum title | 160 | `TASK_LIST_MIN_W`, the pane's own drag floor, reused |

**32 + 160 + 28 + 32 + 160 = 412.** Not the card's estimated 440, which is derived from nothing.

The derivation was checked against the real thing rather than asserted. For a flat leaf row at a 640px-or-wider viewport with `onTaskClick` live, the title's space is

```
pane − 1 (the pane's own border-r, inside its border-box width)
     − 32 (sm:px-4)
     − 160 (the two date cells, when painted)
     − 28 (open-details slot)
     − 32 (title furniture)
```

which reproduces #7204's reported numbers exactly, in Chromium: at pane 320 that is **67px** for a flat leaf and **53px** at depth 1 (67 − 14) — the card measured 53. A summary row's `w-4` toggle costs 4 more, giving 63, which is what the harness read for the summary row. No term is off by a pixel.

---

## Measurements — real Chromium, and why that matters here

⚠️ **jsdom confirms the wrong answer on this card.** jsdom applies `@media` rules irrespective of `window.innerWidth`, so while the old rule was live `getComputedStyle(sublabel).display` read `none` at 500, 800 and 1440 alike — including widths where a real browser painted the sublabel. Taken at face value that reads "the sublabel is never visible", which is false and sends the fix somewhere else. Every viewport-dependent number in this PR comes from **Chromium 1194** (`/opt/pw-browsers/chromium`, preinstalled — no `playwright install`), driving the real component through a Vite dev server with the repo's own Tailwind build and the component's own injected style element, at real viewports.

**#7224's table, before and after** (`sub` = date sublabel painted, `cols` = both Start/End cells painted; container equals viewport):

| viewport | pane before | sub before | cols before | pane after | sub after | cols after |
| --: | --: | --- | --- | --: | --- | --- |
| 500 | 140 | yes | no | 140 | yes | no |
| 639 | 140 | yes | no | 140 | yes | no |
| 640 | 220 | **no** | **no** | 220 | **yes** | no |
| 800 | 220 | **no** | **no** | 220 | **yes** | no |
| 1024 | 320 | no | yes | 384 | **yes** | **no** |
| 1280 | 320 | no | yes | 480 | no | yes |
| 1440 | 320 | no | yes | 540 | no | yes |
| 1920 | 320 | no | yes | 560 | no | yes |

Before: **2 rows where sublabel and columns are both off** — 640 and 800, the #7224 hole. After: **0**. At every row exactly one of the two is painted.

The same run, with the container decoupled from the viewport — the case the two gates could never agree on:

| viewport | container | pane | sub | cols |
| --: | --: | --: | --- | --- |
| 1440 | 800 | 220 | yes | no |
| 1920 | 700 | 220 | yes | no |
| 500 | 700 | 220 | yes | no |
| 800 | 1440 | 540 | no | yes |
| 1024 | 1097 | 411 | yes | no |
| 1024 | 1098 | 412 | no | yes |

Zero violations of the complement, and the crossover is pinned to the pixel: a 1097px container gives pane 411 and the sublabel; 1098 gives pane 412 and the columns.

**Title width, measured** (flat leaf, columns painted): name cell 259 / 319 / 339 at 1280 / 1440 / 1920, which is exactly `pane − 1 − 32 − 160 − 28`; minus the 32px of furniture that gives 227 / 287 / 307. A 25-character title measures 154px and a 40-character title 262px in that font, so 1440 and 1920 paint a 40-character name in full and 1280 paints about 35 characters of it. Before: 67px at all three.

## Verification

- **Red-then-green.** The new pins were run against the pre-fix source by restoring `origin/main`'s `GanttView.tsx` over the committed fix. The mutation was proved on disk by blob hash (`8e7b4d8b…` = `origin/main` blob, ≠ the `HEAD` blob `e0cca573…`) plus two anchored controls (`gantt-sm-hidden` back, `START_END_COLUMNS_MIN_W` gone); the run came back **14 failed / 14** with the #7224 complement red at 500 / 639 / 640 / 800 and every width pin red at 1024–1920. The restore was proved by state — `git diff HEAD` empty and blob equality — not by an exit code, under a `trap ... EXIT INT TERM` with absolute paths.
- `packages/plugin-gantt` suite after the fix: **59 files, 471 tests, all passing** (the 14 new ones included).
- `type-check` for the package: exit 0, after building its dependency closure first (a stale `dist/*.d.ts` lies in both directions).
- `lint` for the package: exit 0, 0 errors. `GanttView.tsx` carries **19 warnings before and 19 after, identical rule multiset** — measured the same way, by linting the restored pre-fix blob. The new test file adds 0.
- Repo-wide lint is CI's run; the narrowing here is declared and measured, not skipped: eslint's own config resolved **89 files** for this package (count read from `--format json`), it is the only package the diff touches (the other changed path is a `.changeset/*.md`, which eslint does not lint), and the config enables **no type-aware linting** (no `parserOptions.project`, no `projectService`, no `recommendedTypeChecked`), so this diff cannot move a verdict on a file it does not contain.
- Gate family derived from the touched paths, all exit 0: `check:control-bytes`, `check:i18n-keys`, `check:i18n-drift`, `check:i18n-dead-keys`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:readme-exports`, `check:shell-escape-residue`, `check:sdui-registration-pins`, `check:element-data-source-declaration`.
- Every reading above was taken at `b5f659e72`.

### Bytes — measured, not inferred

`check:eager-closure` is **green**: framework 511.5 KB / 511.7 KB ceiling (headroom 0.2 KB), vendor-objectstack 926.1 / 944.3, ui-components 387.3 / 389.6, aggregate 3178.3 KB / 3191.4 KB. No ceiling was touched.

Byte-neutrality was measured rather than argued from "plugin-gantt should be lazy". The console was built on this branch and again with `GanttView.tsx` restored to `origin/main` (both builds exited 0 — a failed ablation build reads a stale artifact and reports a stripped input as free):

| | branch | pre-fix baseline | delta |
| --- | --: | --: | --: |
| `eagerGzipBytes` | 3254545 | 3254545 | **0** |
| `eagerRawBytes` | 11175307 | 11175307 | **0** |
| eager chunks | 48 | 48 | 0 |

Every one of the 48 eager chunks is identical in gzip bytes; no chunk appears on one side only. The zero is a reading, not a stale artifact: the **entry chunk hash differs between the two builds** (`index-DUp49asL.js` vs `index-XRCMG0Ou.js`), so the two builds genuinely produced different bundles and the eager closure still weighed the same. No gantt chunk appears in the eager set at all.

## Deviations and notes, flagged rather than folded in

1. **The ruling's 412 does not count the pane's own 1px `border-r`.** The pane's width is set inline under `box-sizing: border-box`, so the true break-even is 413. 412 is implemented **as ruled**; the effect is that at exactly pane 412 the title gets 159px rather than the 160 the term names. One pixel, stated rather than silently corrected.
2. **New behaviour between a 1024px and a 1097px container**: the columns are now **off** there where they used to be on, and the dates ride the sublabel. This is the ruled design working (`0.375 × 1024 = 384 < 412`), and it is a net gain — the title goes from 67px to 291px and the dates stay visible — but it is a change #7204's table never visits, so it is called out. The crossover is pinned in the tests at 1097/1098.
3. **The 412 terms are viewport-conditional below 640px.** `.gantt-sm-w20` (80px) and the open-details slot (`hidden sm:block`) only apply from 640px up, so below that the columns cost 128 and the slot 0 — the threshold is conservative there, never permissive. Left alone: making those unconditional is a narrow-layout change nobody asked for.
4. **`depth * 14` is unbounded**, so no single default keeps a deeply nested row legible. Stated as a known limit of container-based sizing, per the dispatch — not chased here. The tests and the source comment both say so.

## Test surface

`packages/plugin-gantt/src/GanttView.tasklistDates-7204.test.tsx`, 14 pins. Every assertion is about the **DOM**, never about computed style, and the file says why: the predicate under test is a render decision, which jsdom answers exactly, whereas a computed-style assertion there would confirm the wrong answer in the reassuring direction. The pixel readings that go with it were taken in Chromium and live in this PR. The suite also pins that the component's own stylesheet contains no `gantt-sm-hidden` and that **no surviving media block hides anything**, so re-adding a viewport gate on a row's dates has to fail here whatever it gets called next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_