### PR TITLE
skills(objectui): two eval assertions stop grading accidental substrings, one re-points to the taught spelling (#7405)

### DIFF
--- a/skills/objectui/evals/page-builder.json
+++ b/skills/objectui/evals/page-builder.json
@@ -27,7 +27,7 @@
       "files": [],
       "assertions": {
         "must_contain": [
-          "visible",
+          "hidden",
           "admin",
           "card"
         ],

--- a/skills/objectui/evals/testing.json
+++ b/skills/objectui/evals/testing.json
@@ -22,14 +22,12 @@
     {
       "id": 2,
       "prompt": "Write RTL component tests for an ObjectUI form plugin that has create, edit, and view modes.",
-      "expected_output": "Provides Vitest + React Testing Library tests with SchemaRendererProvider wrapping, mock dataSource, and a test case per form mode (create / edit / view) asserting fields render and submit behavior matches the mode.",
+      "expected_output": "Provides Vitest + React Testing Library tests with SchemaRendererProvider wrapping, mock dataSource, and a test case per form mode asserting fields render and submit behavior matches the mode.",
       "files": [],
       "assertions": {
         "must_contain": [
           "React Testing Library",
-          "SchemaRendererProvider",
-          "create",
-          "view"
+          "SchemaRendererProvider"
         ],
         "must_not_contain": []
       }


### PR DESCRIPTION
Fixes #7405

Governed surface (`skills/**`): this stays a **draft** and a human merge is the review record. `check-governed-queue-guard --test` returns exit 3 over the change set, which is the correct verdict, not a red.

Three commits at `0f8c312`, one per eval file plus a retraction (see the last section). Every count below is `grep -c` against the guide the eval actually scores — `guides/BASENAME.md` for `evals/BASENAME.json` — re-measured at this branch point `a37600b`, not carried from the card's `0614b6d`. Occurrence counts (`grep -o | wc -l`) were taken beside every line count and agree with all of them, so no `1` hides a second match.

## Landing map — 落点 | before | after

### Drop the token (nothing in the guide corresponds)

| 落点 | before | after | evidence |
|---|---|---|---|
| `evals/testing.json` eval 2 | `create` — 1 in `guides/testing.md` | removed from `must_contain` | line 216, `create: vi.fn().mockResolvedValue({ id: '1', name: 'New' })` — a mocked dataSource method in the provider example, not the form mode the prompt asks about |
| `evals/testing.json` eval 2 | `view` — 1 in `guides/testing.md` | removed from `must_contain` | line 238, `const BASE_URL = 'http://localhost:4173'; // vite preview` — the tail of `preview` |

Dropped rather than re-pointed because there is no form-mode spelling in this guide to re-point to: `mode` counts **0** in `guides/testing.md`, which is the same measurement that removed `edit` from this identical array in #7360. The guide teaches nothing about form modes at all.

The row still grades a real decision. `SchemaRendererProvider` counts **5** there and survives beside `React Testing Library`, so `must_contain` goes from four entries to two rather than to zero.

### Fix the assertion (the eval tests a real decision with the wrong token)

| 落点 | before | after | evidence |
|---|---|---|---|
| `evals/page-builder.json` eval 2 | `visible` — **0** in `guides/page-builder.md` | `hidden` — 2 in that guide | re-pointed, not dropped: the eval tests a real decision and the guide teaches that decision twice, under the other spelling. Line 42, the node-shape example: `"hidden": "${data.userRole !== 'admin'}"`. Line 68, the prose: "Prefer expression-based behavior (`hidden`, `disabled`) over imperative branching in component code" |

The two tokens that keep this row honest are unmoved and were re-measured: `admin` 1 (line 42, the same expression) and `card` 4. `card` is the token #7360 re-pointed into this array, and #7416 has since edited this guide — the count is unchanged, so that landing did not disturb it.

### What did not change

`prompt` text is untouched in both rows. `evals/page-builder.json` eval 2 still says "must be visible only to admins" in its prompt — that is English prose describing the requirement, not the graded literal, and its `expected_output` says "expression-based visibility", which does not contain the token `visible` at all (`visibility` is not a superstring of `visible`). So that file's prose is byte-identical; only the one literal moved.

`evals/testing.json` eval 2's `expected_output` loses exactly one parenthetical:

- before: "… and a test case per form mode **(create / edit / view)** asserting fields render and submit behavior matches the mode."
- after: "… and a test case per form mode asserting fields render and submit behavior matches the mode."

That parenthetical enumerated the three tokens this array no longer grades — `edit` since #7360, `create` and `view` here. The sentence still requires a test case per form mode, and the prompt is the thing that names which three. This is a deliberate departure from #7360's handling of `ComponentRegistry`, where the `expected_output` sentence was kept: there the prose stated a true fact about the runtime that simply was not gradeable, whereas here the parenthetical is a list of graded literals that is no longer a list of graded literals. Flagged rather than buried, since a reviewer may prefer the other convention.

**No guide was edited**, as the card requires. That is measured rather than asserted: the published prose bundle (every `.md` under `skills/objectui/`) is 150,318 bytes / 37,580 tokens before and after, byte-identical.

## Token deltas — `ceil(utf8_bytes / 4)`

| file | before | after | Δ |
|---|---|---|---|
| `evals/testing.json` | 1,923 B / 481 tok | 1,862 B / 466 tok | **−15 tok** |
| `evals/page-builder.json` | 2,239 B / 560 tok | 2,238 B / 560 tok | **0 tok** |
| sum of the per-file figures | 1,041 tok | 1,026 tok | **−15 tok** |
| published `.md` prose bundle | 37,580 tok | 37,580 tok | **0** |

Net negative, so the skills net-increase budget is not engaged.

## Gates — all at head `0f8c312`, every exit code captured by redirect before any pipe

| gate | exit | its own verdict line |
|---|---|---|
| `JSON.parse` over all `evals/*.json` | 0 | all 11 parse, including the 2 edited |
| `node scripts/check-skills-paths.mjs` | 0 | `✅  check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).` — `skills/ — 28/28 resolve across 16 file(s)` |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-control-bytes.mjs` | 0 | `✅  check-control-bytes: OK (scanned 6108 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `✅  check-shell-escape-residue: OK (5/5 root(s) resolved -- … skills: 16 file(s), 196 fence(s) …).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` — its own verdict, so none is added |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `OK check-governed-queue-guard self-test: 132 cases pass` |
| `… --test` over the two changed paths | **3** | `⛔ GOVERNED — 2 of 2 path(s) are on a governed surface` / `One governed path governs the WHOLE pull request` — the correct verdict; the PR is parked as a draft accordingly |
| `node scripts/check-doc-fence-languages.mjs` | 0 | `✅  check:doc-fences — every TypeScript block in 224 document(s) is fenced ts/tsx/typescript …` — derived, not dispatched; `skills/` is in its roots |
| `pnpm exec vitest run` over 13 files (below) | 0 | `Test Files  13 passed (13)` / `Tests  251 passed (251)` |

Heavy runs went through the shared verify lock, slot `objectui-7405` (`os-verify-lock: VERDICT command-exit 0 · held the lock 25s · waited 121s`).

### The test set is derived, not copied from the dispatch

The dispatch named three test files. `git grep -ln` for the skills tree across `*.test.ts` / `*.test.tsx` returns **13**, and all 13 were run: the three dispatched (`skill-guide-provider-envelope`, `skill-guide-data-table-binding`, `doc-version-claims`) plus `preview-samples-spec-valid`, `data-table-node-data-diagnostic`, `data-table-bind-diagnostic`, `skill-guide-permission-config`, `ObjectDataTable.columnIdentity`, `headerColor`, `base-bind-declared`, `check-shell-escape-residue`, `check-skills-paths`, `layered-read-declared-path-4016`.

Only one of the 13 reads the **eval** files rather than the guides: `packages/components/src/__tests__/skill-guide-provider-envelope.test.tsx:248` globs the published tree, filters `/evals/`, and asserts over every `must_contain` array that no entry matches `/^props\./`, with a counter-probe (`expect(graded).toBeGreaterThan(0)`) so an emptied assertion list cannot pass vacuously. That counter-probe is the reason this diff needed it: it shrinks two `must_contain` arrays.

### Ablation — proving that test actually reads the edited file

Green is only evidence if the test can go red for this file. Measured, with the implementation committed first so the restore leg has a real reference:

- the test resolves `repoRoot` as `path.resolve(here, '../../../..')` and reads the working tree directly — no `dist/`, so there is no build leg and no unbuilt-ablation false green available here
- **mutation leg**, confirmed on disk before running anything: injected `"props.ABLATION_MARKER"` into `evals/testing.json` eval 2's `must_contain`; injected-marker `grep -c` = 1, and `git hash-object` moved from `f165600…` to `98e159a…`, so the edit is not a no-op
- result: **red**, naming the file — `AssertionError: skills/objectui/evals/testing.json requires a dead 'props.*' spelling: expected [ 'props.ABLATION_MARKER' ] to deeply equal []`, `Test Files 1 failed (1)`
- **restore leg**, proven by observed state rather than by an exit code: `git checkout HEAD --` against an absolute path from `git rev-parse --show-toplevel`, then `git hash-object` = `f16560093e511df1a0db41b659f8f8cd4c0318bd` = the HEAD blob, marker `grep -c` = 0, `git diff HEAD` empty, `git status` clean

The mutation script carried `trap … EXIT INT TERM`, and it fired: a first run that ended after the on-disk proof restored the file without being asked, which is why the run above is the second one.

### Repo-wide lint, narrowed with the narrowing measured

Three legs, none of them a guess about which files "count":

1. **Population, read from eslint's own configuration.** Every `files:` glob in `eslint.config.js` is `**/*.{ts,tsx}`, `**/*.tsx`, or a specific `.ts` path (lines 28, 176–179, 196, 218, 232, 262). No glob matches `.json` or `.md`.
2. **Count, read from `--format json`.** Asked about the two edited files directly, eslint answers for 2 files, 0 errors, and the message `File ignored because no matching configuration was supplied.` for each — 0 configured.
3. **Invariance for untouched files.** This diff contains zero `.ts`/`.tsx` files, so its intersection with eslint's population is empty; a diff that adds no file to the linted population cannot move a verdict on any file already in it, type-aware linting or not.

## `premise_false` — one dispatch premise did not hold

**The lint command.** The dispatch (carrying the spelling forward from #7360's PR body) describes `pnpm lint` as `eslint . --no-inline-config`. At `a37600b` that is not what it is: the root `lint` script is `turbo run lint`, which fans out to per-package `eslint .` / `eslint src`, and `git grep -- "--no-inline-config"` over the whole tree exits 1 — the flag appears nowhere in the repository.

This makes the narrowing **stronger**, not weaker, which is why it is recorded rather than escalated: `skills/` contains no `package.json`, so it is inside no workspace package, so no `turbo run lint` task has it in scope at all — on top of leg 1 above, where no eslint configuration matches `.json` in the first place. Two independent reasons the edited files are outside the lint population.

Nothing else in the dispatch or the card measured false. All three token counts the card reported at `0614b6d` still hold at `a37600b`, including in `guides/page-builder.md`, which #7416 has edited since.

## A false sentence in commit `f72743a`, retracted in `0f8c312`

Commit `f72743a`'s message added an editorial claim that is wrong, and this repo squash-merges, so the retraction had to travel as a commit rather than a force-push. Repeated here because the PR body is what gets read:

Retracted: "`hidden` is also the key the protocol actually reads … while `visible` is not a node key at all — so the previous token could not have been satisfied by a correct answer that followed the guide."

The second half is false. `visible` is real and evaluated:

- `packages/types/src/base.ts:278` declares `visible?: boolean | string` on `BaseSchema`, widened from `boolean` precisely so the predicate string is authorable (objectui#4581, pinned by `packages/types/src/__tests__/base-schema-visible-predicate.test.ts`)
- `packages/react/src/SchemaRenderer.tsx:245` lists it among the keys it evaluates — `VISIBILITY_SHOW_KEYS = ['visibleWhen', 'visible', 'visibleOn', 'visibility']` — consumed by the visibility block at line 1176
- the action renderers read it directly (`packages/components/src/renderers/action/action-button.tsx:89` and `:231`, plus the `action-bar`, `action-group`, `action-icon`, `action-menu` siblings), which is the node kind this very prompt is about — "the 'Edit Customer' button"

None of that moves the change. The row is re-pointed for the reason the card and the disposition give, which stands alone: an eval is scored against the guide named by its filename, `guides/page-builder.md` measures `visible` 0 and `hidden` 2, and a token the guide never writes grades nothing. A dropped spelling being real elsewhere in the codebase is the same situation as `refresh` and `ComponentRegistry` in #7360 — real API, wrong guide. The narrower true statement, if one is wanted: `visibleWhen` is the canonical ADR-0089 predicate and short-circuits ahead of `visible`, so `visible` is neither canonical nor absent; it is simply not what this guide teaches.

## Scope

No guide edits, and no other eval rows touched. The whole-token-versus-substring oracle — the structural check that would catch this class mechanically instead of one funded row at a time — remains #7359's, and nothing here prejudges which oracle it should use.

No out-of-scope findings to file: the two candidate observations both resolved to "not a defect" on inspection. `guides/page-builder.md` teaching `hidden` rather than the canonical `visibleWhen` is not wrong, since `hidden` is itself a real declared and evaluated node key; and the wider derived test set was a gap in the dispatch's list, not in the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_