### PR TITLE
test(test-support,app-shell,plugin-detail,data-objectstack): one array-element reader for three disagreeing walks

### DIFF
--- a/.changeset/zod-array-element-reader-5872.md
+++ b/.changeset/zod-array-element-reader-5872.md
@@ -1,0 +1,10 @@
+---
+---
+
+Internal test-support only: `@object-ui/test-support` gains `arrayElementSchema`
+(objectui#5872 class (2)), and the three disagreeing hand-written array-element
+walks in `plugin-detail`, `app-shell` (previews) and `app-shell`
+(clientValidation) converge onto it, along with one `.unwrap().options` read in
+`data-objectstack`. No published runtime source changes: the diff is test files
+plus a `private: true` workspace package that ships in no bundle, so this
+declaration carries an EMPTY frontmatter — nothing to version.

--- a/packages/app-shell/src/views/metadata-admin/clientValidation.optOuts.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/clientValidation.optOuts.test.ts
@@ -36,6 +36,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { arrayElementSchema } from '@object-ui/test-support';
 import { validateMetadataDraft, hasClientValidator } from './clientValidation';
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
@@ -342,23 +343,23 @@ describe('binding parity — the wired schema is the one the platform binds', ()
   const isStrict = (s: unknown): boolean =>
     (s as ZodInternals)?._zod?.def?.catchall?._zod?.def?.type === 'never';
 
-  /** Unwrap optional/default/lazy wrappers down to the schema that carries a shape. */
-  const unwrap = (s: unknown, depth = 0): unknown => {
-    const def = (s as { _zod?: { def?: Record<string, unknown> } })?._zod?.def;
-    if (!def || depth > 6) return s;
-    const kind = def.type as string | undefined;
-    if (kind && ['optional', 'nullable', 'default', 'readonly', 'lazy'].includes(kind)) {
-      const inner = def.innerType ?? (typeof def.getter === 'function' ? def.getter() : undefined);
-      return unwrap(inner, depth + 1);
-    }
-    return s;
-  };
-
-  /** The element schema of an `z.array(X)` collection on the stack schema. */
-  const arrayElement = (s: unknown): unknown => {
-    const outer = unwrap(s) as { _zod?: { def?: { type?: string; element?: unknown } } };
-    return outer?._zod?.def?.type === 'array' ? unwrap(outer._zod.def.element) : undefined;
-  };
+  /**
+   * The element schema of a `z.array(X)` collection on the stack schema —
+   * `@object-ui/test-support`'s reader, not a fourth local copy of the walk
+   * (objectui#5872 class (2)). This file carried the strictest of the three
+   * censused spellings, and the strictness is what the shared reader adopted:
+   * `undefined` for a node that is not an array, so the
+   * `expect(element, '… must be an array collection').toBeDefined()` assertions
+   * below stay discriminating instead of passing for every input.
+   *
+   * The one limb NOT carried over is this copy's second unwrap of the element
+   * itself. Measured on the installed pin: of the 35 array members of
+   * `ObjectStackSchema`, ZERO have a wrapped element, so the limb never fired;
+   * and it cannot be added safely, because `zod@4.4.3` puts `unwrap()` on
+   * `ZodArray` itself, so "unwrap the element too" would descend into an
+   * array-of-arrays and answer with the wrong entry shape. A wrapped element
+   * now fails loudly at the `shapeKeys` comparison instead.
+   */
 
   it('translation → the schema the kernel metadata-type registry binds', async () => {
     const { getMetadataTypeSchema } = await import('@objectstack/spec/kernel');
@@ -375,7 +376,7 @@ describe('binding parity — the wired schema is the one the platform binds', ()
   it('sharing_rule → the schema `ObjectStackSchema.sharingRules` binds', async () => {
     const { ObjectStackSchema } = await import('@objectstack/spec');
     const { SharingRuleSchema } = await import('@objectstack/spec/security');
-    const element = arrayElement(ObjectStackSchema.shape.sharingRules);
+    const element = arrayElementSchema(ObjectStackSchema.shape.sharingRules);
     expect(element, 'sharingRules must be an array collection').toBeDefined();
     expect(shapeKeys(element)).toEqual(shapeKeys(SharingRuleSchema));
     expect(isStrict(element)).toBe(isStrict(SharingRuleSchema));
@@ -389,7 +390,7 @@ describe('binding parity — the wired schema is the one the platform binds', ()
     const { DeclarativeConnectorEntrySchema, ConnectorSchema } = await import(
       '@objectstack/spec/integration'
     );
-    const element = arrayElement(ObjectStackSchema.shape.connectors);
+    const element = arrayElementSchema(ObjectStackSchema.shape.connectors);
     expect(element, 'connectors must be an array collection').toBeDefined();
     expect(shapeKeys(element)).toEqual(shapeKeys(DeclarativeConnectorEntrySchema));
 

--- a/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
+++ b/packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts
@@ -7,9 +7,11 @@ import {
   RecordDetailsProps,
 } from '@objectstack/spec/ui';
 import {
+  arrayElementSchema,
   enumOptions,
   isShapeKeyTombstoned,
   listedShapeKeys,
+  resolvePropsShape,
   shapeMemberTypeName,
 } from '@object-ui/test-support';
 import { BLOCK_CONFIG, blockHasConfig, type PlaceholderSpec } from '../block-config';
@@ -81,21 +83,20 @@ describe('block-config', () => {
  * time the spec grows a section key the inspector never learns to author.
  */
 describe('record:details sections ↔ spec section-entry coverage (#3819)', () => {
-  /** The spec's authorable keys for one `sections[]` entry, read off the Zod shape. */
-  const specSectionKeys: string[] = (() => {
-    const props = RecordDetailsProps as unknown as { shape?: Record<string, unknown> };
-    const sections = props.shape?.sections as { _def?: Record<string, any> } | undefined;
-    // sections: ZodOptional< ZodArray< ZodObject > > — unwrap to the element object.
-    let node: any = sections;
-    for (let i = 0; i < 6 && node; i++) {
-      const def = node._def ?? {};
-      if (def.innerType) { node = def.innerType; continue; }
-      if (def.element) { node = def.element; continue; }
-      break;
-    }
-    const shape = node?.shape;
-    return shape ? Object.keys(shape) : [];
-  })();
+  /**
+   * The spec's authorable keys for one `sections[]` entry, read off the Zod shape.
+   *
+   * `sections` is `ZodOptional< ZodArray< ZodObject > >`, so this needs both a
+   * wrapper walk and an array-element read. Both are `@object-ui/test-support`'s
+   * (objectui#5872 class (2)); the six-iteration `_def.innerType` / `_def.element`
+   * loop that used to stand here was one of the three disagreeing copies that
+   * card censused. `arrayElementSchema` answers `undefined` for a non-array,
+   * which `listedShapeKeys` turns into `[]` — the case the non-vacuity
+   * assertion below exists to catch.
+   */
+  const specSectionKeys: string[] = listedShapeKeys(
+    arrayElementSchema(resolvePropsShape(RecordDetailsProps)?.sections),
+  );
 
   /** The inspector's item editors for one section. */
   const sectionsField = BLOCK_CONFIG['record:details'].find((f) => f.name === 'sections') as

--- a/packages/data-objectstack/package.json
+++ b/packages/data-objectstack/package.json
@@ -35,6 +35,7 @@
     "@objectstack/spec": "^17.2.0"
   },
   "devDependencies": {
+    "@object-ui/test-support": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/data-objectstack/src/metadata-client.overlayScope.test.ts
+++ b/packages/data-objectstack/src/metadata-client.overlayScope.test.ts
@@ -38,6 +38,7 @@
  *      user-visible half of this bug.
  */
 import { describe, it, expect } from 'vitest';
+import { enumOptions } from '@object-ui/test-support';
 import { GetMetaItemLayeredResponseSchema } from '@objectstack/spec/api';
 import type { MetadataLayered, MetadataOverlayScope } from './metadata-client';
 
@@ -66,7 +67,14 @@ const specOverlayScope = GetMetaItemLayeredResponseSchema.shape.overlayScope;
 
 describe('MetadataLayered.overlayScope tracks the spec enum (objectui#4982)', () => {
   it('the producer vocabulary is exactly org | env, plus null', () => {
-    expect(specOverlayScope.unwrap().options).toEqual(['org', 'env']);
+    // Read through `@object-ui/test-support` rather than `.unwrap().options`
+    // (objectui#5872 class (4)). The bare spelling was a SEVENTH way to ask this
+    // question and the only one with neither a cast nor a guard: it answered
+    // correctly only while `overlayScope` stayed wrapped exactly once and Zod
+    // kept `.options` where it is. `enumOptions` walks the wrappers and answers
+    // `[]` when it cannot read — and `[]` fails this assertion, which is the
+    // non-vacuity duty that reader's docblock leaves with every caller.
+    expect(enumOptions(specOverlayScope)).toEqual(['org', 'env']);
     expect(specOverlayScope.safeParse(null).success).toBe(true);
   });
 

--- a/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
+++ b/packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts
@@ -48,6 +48,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { ComponentRegistry } from '@object-ui/core';
 import {
+  arrayElementSchema,
   authorableShapeKeys,
   isShapeKeyTombstoned,
   listedShapeKeys,
@@ -58,21 +59,21 @@ import '../index';
 
 const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-/** One entry of `.shape`, unwrapped past `.optional()`. */
-function shapeMember(schema: unknown, key: string): unknown {
-  const member = resolvePropsShape(schema)?.[key] as { unwrap?: () => unknown } | undefined;
-  return typeof member?.unwrap === 'function' ? member.unwrap() : member;
-}
-
-/** The element schema of a `z.array(...)`, through both spellings. */
-function arrayElement(schema: unknown): unknown {
-  const arr = schema as {
-    element?: unknown;
-    def?: { element?: unknown };
-    _def?: { type?: unknown; element?: unknown };
-  } | undefined;
-  return arr?.element ?? arr?.def?.element ?? arr?._def?.element ?? arr?._def?.type;
-}
+/**
+ * The element schema of `RecordDetailsProps.<key>`, a `z.array(...)`.
+ *
+ * The wrapper walk and the element read are `@object-ui/test-support`'s
+ * (objectui#5872 class (2)), not this file's. What stood here was one of three
+ * disagreeing hand copies, and its last limb — `arr?._def?.type`, Zod 3's
+ * spelling for a `ZodArray`'s element — is a landmine on the installed
+ * `zod@4.4.3`, where `_def.type` is the type-name STRING `'array'`: had the
+ * three limbs before it ever missed, this would have handed `listedShapeKeys`
+ * a string and derived the empty set in silence. `arrayElementSchema` keeps
+ * that Zod 3 spelling behind the `_def.typeName === 'ZodArray'` discriminator
+ * so it can only answer where it is actually right.
+ */
+const specArrayElement = (key: string): unknown =>
+  arrayElementSchema(resolvePropsShape(RecordDetailsProps)?.[key]);
 
 /** Top-level keys of the spec's `RecordDetailsProps`, INCLUDING tombstones. */
 const specTopLevelKeys = (): string[] => listedShapeKeys(RecordDetailsProps);
@@ -103,7 +104,7 @@ const specAcceptedTopLevelKeys = (): string[] => authorableShapeKeys(RecordDetai
 
 /** Member keys of one `sections[]` entry, per the spec. */
 const specSectionKeys = (): string[] =>
-  listedShapeKeys(arrayElement(shapeMember(RecordDetailsProps, 'sections')));
+  listedShapeKeys(specArrayElement('sections'));
 
 /**
  * Section keys the `sections` description may NOT teach. Read off
@@ -364,7 +365,7 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     // contract to advertise. Every in-repo producer passes strings
     // (`synth/buildDefaultPageSchema.ts:557-562` types it `string[]`), so the
     // tolerant arm is unexercised drift rather than a live dialect.
-    const element = arrayElement(shapeMember(RecordDetailsProps, 'hideFields'));
+    const element = specArrayElement('hideFields');
     expect(listedShapeKeys(element)).toEqual([]);
     expect(RecordDetailsProps.safeParse({ hideFields: ['phone'] }).success).toBe(true);
 
@@ -442,7 +443,7 @@ describe('record:details — registry inputs vs @objectstack/spec', () => {
     // Top-level `fields` is `z.array(z.string())`: there is no member shape to
     // publish, and the renderer's tolerance for `{name}` / `{field}` entries is
     // not a second contract to advertise — the spec rejects those values.
-    const element = arrayElement(shapeMember(RecordDetailsProps, 'fields'));
+    const element = specArrayElement('fields');
     expect(listedShapeKeys(element)).toEqual([]);
     expect(RecordDetailsProps.safeParse({ fields: ['phone'] }).success).toBe(true);
     expect(RecordDetailsProps.safeParse({ fields: [{ name: 'phone' }] }).success).toBe(false);

--- a/packages/test-support/README.md
+++ b/packages/test-support/README.md
@@ -83,9 +83,30 @@ code imports — nothing in `src/` of a released package may import this.
     exactly one wrapper walk in this repository and a third entry point must not
     change that.
   - Of the other Zod-internals reader classes #5872 censused, the wrapper-key
-    list is now shared as DATA (below, objectui#6923); array-element unwrapping
-    is NOT confined here yet and is still hand-copied — converting it is a
-    separate round, one reader class at a time.
+    list is now shared as DATA (below, objectui#6923) and array-element
+    unwrapping is `src/spec-array-element.ts` (below). What is still hand-copied
+    are the readers that ask a DIFFERENT question — union arms, walk-until-a-
+    shape-is-reachable, and the deliberately one-level-deep reads that carry
+    their reason in a comment. Those are not copies of these walks and must not
+    be swept onto them.
+- `src/spec-zod-wrappers.ts` — THE wrapper walk, `firstInWrapperChain`, and the
+  `MAX_WRAPPER_DEPTH` bound. Not exported from the package index: it is plumbing
+  between the two readers below, not something a gate should hold. It exists
+  because a second reader class arrived that needed the same steps with a
+  different question asked at each one, and writing that walk out again inside
+  the new reader would have been this package's own failure mode reintroduced by
+  the package that exists to end it.
+- `src/spec-array-element.ts` — the array-element reader, `arrayElementSchema`
+  (objectui#5872 class (2)). Answers "what shape does ONE entry of this array
+  have?", past `.optional()` / `.default()` / `.nullable()` / `.readonly()` /
+  `z.lazy()`, and `undefined` when the node is not an array. Unlike class (1)'s
+  four byte-identical copies, this class's three copies DISAGREED — about
+  whether to walk at all, which `def` spelling to read, and whether a non-array
+  answers `undefined` — so the module records which site each choice came from
+  and what was measured before it was made. Consumed by
+  `packages/plugin-detail/src/__tests__/recordDetailsInputs.spec-parity.test.ts`,
+  `packages/app-shell/src/views/metadata-admin/previews/__tests__/block-config.test.ts`
+  and `packages/app-shell/src/views/metadata-admin/clientValidation.optOuts.test.ts`.
 - `src/zod-wrapper-keys.json` + `src/zod-wrapper-keys.ts` — the Zod wrapper-key
   vocabulary, exported as `ZOD_WRAPPER_KEYS` (objectui#6923, ruled 2026-08-31 —
   objectui#5872 class (3)). The `.json` holds the data and the `.ts` holds the
@@ -118,6 +139,12 @@ code imports — nothing in `src/` of a released package may import this.
   stamp, a non-empty check against the four real `@objectstack/spec` pairs, and
   the same three halves again for `enumOptions` — including the pin that the two
   entry points agree, which is what makes the delegation observable.
+- `src/__tests__/spec-array-element.test.ts` — the calibration for the
+  array-element reader: one synthetic fixture per wrapper spelling it walks, the
+  `undefined` cases that keep a consuming suite's `toBeDefined()` from being a
+  rubber stamp, the three choices made between the disagreeing copies pinned one
+  by one (including that Zod 4's `_def.type` STRING is never returned as a
+  schema), and the non-empty check against the real `RecordDetailsProps.sections`.
 - `src/__tests__/spec-tombstones.test.ts` — the calibration for that judge: one
   synthetic fixture per recognition channel (so neither can quietly stop
   working), plus a cross-check of the structural verdict against what the

--- a/packages/test-support/src/__tests__/spec-array-element.test.ts
+++ b/packages/test-support/src/__tests__/spec-array-element.test.ts
@@ -1,0 +1,144 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * THE ARRAY-ELEMENT READER PROVES ITSELF — once, for the three gates that used
+ * to write this walk out by hand (objectui#5872 class (2)).
+ *
+ * Same two halves as `spec-enum-options.test.ts`, and the same reason: the
+ * value of a shared reader is the spellings it adds to whichever one copy a
+ * given site happened to carry, so every added spelling is pinned ALONE.
+ *
+ * What is different here is that this class's three copies DISAGREED, so this
+ * file also has to pin the choices made between them — each of which could
+ * change a verdict rather than preserve one:
+ *
+ *   - `undefined` for a node that is not an array. `clientValidation.optOuts`
+ *     asserts `expect(element, '… must be an array collection').toBeDefined()`;
+ *     a reader that answered with the node itself would make that assertion
+ *     pass for every input, deleting a non-vacuity check in silence.
+ *   - the element is returned AS FOUND. `zod@4.4.3` puts `unwrap()` on
+ *     `ZodArray` itself, so a reader that unwrapped its own answer would
+ *     descend into an array-of-arrays and report the wrong entry shape.
+ *   - Zod 3's `_def.type` is read only behind `_def.typeName === 'ZodArray'`.
+ *     On Zod 4 `_def.type` is the type-name STRING, and the hand copy in
+ *     `recordDetailsInputs.spec-parity.test.ts` ended its chain with an
+ *     unguarded read of it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { RecordDetailsProps } from '@objectstack/spec/ui';
+import { arrayElementSchema } from '../spec-array-element';
+import { listedShapeKeys, resolvePropsShape } from '../spec-tombstones';
+import { MAX_WRAPPER_DEPTH } from '../spec-zod-wrappers';
+
+const Entry = z.object({ name: z.string(), label: z.string() });
+const entryKeys = ['name', 'label'];
+
+describe('arrayElementSchema — the wrapper spellings it walks', () => {
+  it('reads a bare `z.array()`', () => {
+    expect(listedShapeKeys(arrayElementSchema(z.array(Entry)))).toEqual(entryKeys);
+  });
+
+  it.each([
+    ['.optional()', z.array(Entry).optional()],
+    ['.nullable()', z.array(Entry).nullable()],
+    ['.default([])', z.array(Entry).default([])],
+    ['.readonly()', z.array(Entry).readonly()],
+    ['z.lazy()', z.lazy(() => z.array(Entry))],
+  ])('walks past %s', (_spelling, schema) => {
+    expect(listedShapeKeys(arrayElementSchema(schema))).toEqual(entryKeys);
+  });
+
+  it('walks a STACK of wrappers, not just one level', () => {
+    // The copy in `recordDetailsInputs` did no walk at all; the one in
+    // `block-config` stopped at six. Both answered only because their input
+    // happened to be shallow.
+    const stacked = z.array(Entry).optional().nullable().readonly();
+    expect(listedShapeKeys(arrayElementSchema(stacked))).toEqual(entryKeys);
+  });
+
+  it('gives up at the declared depth instead of hanging on a self-unwrapping node', () => {
+    // Reached through `unknown`, so this shape cannot be ruled out. The bound
+    // is imported rather than restated — a restated `8` is one more copy.
+    const looping: { unwrap: () => unknown } = { unwrap: () => looping };
+    expect(MAX_WRAPPER_DEPTH).toBe(8);
+    expect(arrayElementSchema(looping)).toBeUndefined();
+  });
+});
+
+describe('arrayElementSchema — `undefined` is the "could not read" answer', () => {
+  it.each([
+    ['a plain object schema', z.object({ a: z.string() })],
+    ['an enum', z.enum(['a', 'b'])],
+    ['a string', z.string()],
+    ['an optional object', z.object({ a: z.string() }).optional()],
+  ])('answers `undefined` for %s — it is not an array', (_what, schema) => {
+    expect(arrayElementSchema(schema)).toBeUndefined();
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['a non-schema object', { nope: true }],
+    ['a string', 'array'],
+  ])('answers `undefined` for %s', (_what, node) => {
+    expect(arrayElementSchema(node)).toBeUndefined();
+  });
+});
+
+describe('arrayElementSchema — the choices made between three disagreeing copies', () => {
+  it('returns the element AS FOUND, without unwrapping it again', () => {
+    // `zod@4.4.3` puts `unwrap()` on `ZodArray`, so a reader that unwrapped its
+    // own answer would return `Entry` here instead of the inner array.
+    const nested = z.array(z.array(Entry));
+    const element = arrayElementSchema(nested);
+    expect(element).toBe(nested.element);
+    expect(listedShapeKeys(element)).toEqual([]);
+    expect(listedShapeKeys(arrayElementSchema(element))).toEqual(entryKeys);
+  });
+
+  it('reads Zod 3’s `_def.type` element ONLY behind the `ZodArray` type name', () => {
+    const zod3Array = { _def: { typeName: 'ZodArray', type: Entry } };
+    expect(arrayElementSchema(zod3Array)).toBe(Entry);
+  });
+
+  it('never returns Zod 4’s `_def.type` STRING as if it were a schema', () => {
+    // The unguarded limb this reader replaces: on the installed pin
+    // `_def.type` is `'array'`, and `listedShapeKeys('array')` is `[]` — the
+    // quiet empty set this card family exists to stop.
+    const zod4Shaped = { _def: { type: 'array' } };
+    expect(arrayElementSchema(zod4Shaped)).toBeUndefined();
+    expect(z.array(Entry)._def.type).toBe('array');
+  });
+});
+
+describe('arrayElementSchema — against the real installed contract', () => {
+  it('reads a NON-EMPTY entry shape for `RecordDetailsProps.sections`', () => {
+    // The non-vacuity half, stated here once for the same reason the enum
+    // reader states it: `undefined` and "this array has no entry shape" are
+    // different facts, and every consuming suite owes its own version of this.
+    const element = arrayElementSchema(resolvePropsShape(RecordDetailsProps)?.sections);
+    expect(element, 'could not read RecordDetailsProps.sections[] element').toBeDefined();
+    expect(listedShapeKeys(element)).not.toEqual([]);
+  });
+
+  it('discriminates: `RecordDetailsProps` itself is not an array', () => {
+    expect(arrayElementSchema(RecordDetailsProps)).toBeUndefined();
+  });
+
+  it('reads the element of an array-of-strings, which simply has no shape', () => {
+    // `fields` / `hideFields` in the converged suite: the element is real, and
+    // `[]` there means "no entry shape", not "the reader broke". Both facts are
+    // needed, which is why the assertion above is `toBeDefined` and not `!= []`.
+    const element = arrayElementSchema(resolvePropsShape(RecordDetailsProps)?.fields);
+    expect(element).toBeDefined();
+    expect(listedShapeKeys(element)).toEqual([]);
+  });
+});

--- a/packages/test-support/src/index.ts
+++ b/packages/test-support/src/index.ts
@@ -44,6 +44,14 @@ export {
 export { enumOptions, shapeEnumOptions } from './spec-enum-options';
 
 /**
+ * The array-element reader (objectui#5872 class (2)). Stands on the same
+ * `spec-zod-wrappers.ts` walk `enumOptions` does; the walk itself is NOT
+ * exported, because it is plumbing between the two readers rather than
+ * something a gate should hold.
+ */
+export { arrayElementSchema } from './spec-array-element';
+
+/**
  * The Zod wrapper-key vocabulary (objectui#6923). The DATA lives in
  * `zod-wrapper-keys.json` so that `node scripts/check-*.mjs` can read the same
  * bytes through `@object-ui/test-support/zod-wrapper-keys` — the one thing this

--- a/packages/test-support/src/spec-array-element.ts
+++ b/packages/test-support/src/spec-array-element.ts
@@ -1,0 +1,110 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * ARRAY-ELEMENT UNWRAPPING — one reader for every gate that asks "what shape
+ * does ONE entry of this array have?" (objectui#5872 class (2)).
+ *
+ * ## The three readers this replaces, and why they were not one
+ *
+ * Unlike class (1) — four byte-identical copies — this class was THREE
+ * DIFFERENT spellings of one question, in three packages, disagreeing about
+ * every choice a reader has to make:
+ *
+ * 1. `plugin-detail/.../recordDetailsInputs.spec-parity.test.ts` — no walk at
+ *    all (its caller did one `.unwrap()` first), four element spellings tried
+ *    in a row, ending in `_def.type`;
+ * 2. `app-shell/.../previews/__tests__/block-config.test.ts` — a bounded
+ *    6-iteration loop alternating `_def.innerType` / `_def.element`, reading
+ *    `_def` and nothing else;
+ * 3. `app-shell/.../clientValidation.optOuts.test.ts` — a recursive walk
+ *    through `_zod.def`, gated on `def.type` naming a known wrapper, and the
+ *    only one of the three that answers `undefined` when the node is NOT an
+ *    array.
+ *
+ * A shared reader has to pick, and on this class picking can change a VERDICT
+ * rather than preserve one. Every choice below is recorded with the site it
+ * came from and what was measured before it was made.
+ *
+ * ## Choice 1 — `undefined` when the node is not an array (from (3))
+ *
+ * (3) is the only site whose assertion depends on it:
+ * `expect(element, 'sharingRules must be an array collection').toBeDefined()`.
+ * A reader that answered with the node itself for a non-array would make that
+ * assertion pass for every input, which is a non-vacuity check deleted in
+ * silence. (1) and (2) cannot tell the difference — their inputs are arrays —
+ * so (3)'s stricter answer is the one that costs nothing and guards something.
+ *
+ * ## Choice 2 — the element is returned AS FOUND, not unwrapped again
+ *
+ * (3) unwrapped the element a second time; (1) and (2) did not. Measured on the
+ * installed pin (`@objectstack/spec@17.2.0`), the element at all four converted
+ * call sites is a bare `ZodObject` / `ZodString`, so the second unwrap is a
+ * no-op and no verdict moves either way. The narrower answer is taken because
+ * the wider one cannot be given safely: the walk steps through `.unwrap()`, and
+ * on `zod@4.4.3` `ZodArray` HAS an `unwrap()` that returns its element — so
+ * "unwrap the element too" would silently descend into an array-of-arrays and
+ * answer with the wrong entry shape. A wrapped element instead fails LOUDLY at
+ * the caller's shape read, which is the direction this package prefers.
+ *
+ * ## Choice 3 — Zod 3's `_def.type` is read only behind `typeName`
+ *
+ * (1) ended its chain with `arr?._def?.type`. On Zod 3 that IS the element of a
+ * `ZodArray`. On the installed `zod@4.4.3` it is the type-name STRING
+ * `'array'` — measured — so (1)'s last limb was a live landmine: had the three
+ * limbs before it ever missed, it would have handed its caller the string
+ * `'array'`, and `listedShapeKeys('array')` is `[]`, which is exactly the quiet
+ * empty set this card family exists to stop. It is kept here, because a Zod 3
+ * consumer is a real thing, but only when `_def.typeName === 'ZodArray'` says
+ * so — the discriminator Zod 3 carries and Zod 4 does not.
+ *
+ * ## `undefined` and the non-vacuity duty it leaves with the caller
+ *
+ * Same duty `spec-enum-options.ts` states, for the same reason: `undefined`
+ * means "no element could be read", NOT "this array has no entry shape". A
+ * caller that derives a key set from the element and asserts over it owes an
+ * assertion that the set is non-empty — without one, a reader that stopped
+ * working and a satisfied parity check look exactly alike.
+ */
+
+import { firstInWrapperChain, type ZodWrapperCarrier } from './spec-zod-wrappers';
+
+/** The element of an array node, under whichever spelling the build uses. */
+function readArrayElement(carrier: ZodWrapperCarrier): unknown {
+  if (carrier.element !== undefined) return carrier.element;
+  if (carrier.def?.element !== undefined) return carrier.def.element;
+  if (carrier._def?.element !== undefined) return carrier._def.element;
+  // Zod 3 only — see "Choice 3" above. `typeName` is the discriminator that
+  // keeps Zod 4's `_def.type` STRING from ever being returned as a schema.
+  const legacy = carrier._def;
+  if (legacy?.typeName === 'ZodArray' && typeof legacy.type === 'object' && legacy.type !== null) {
+    return legacy.type;
+  }
+  return undefined;
+}
+
+/**
+ * The element schema of a `z.array(...)`, reached past `.optional()` /
+ * `.default()` / `.nullable()` / `.readonly()` / `z.lazy()` — `undefined` when
+ * the node is not an array, or when no element could be read.
+ *
+ * Takes the node itself, the way `enumOptions` does, so it answers for a shape
+ * member the caller already holds and for a top-level `z.array` imported
+ * straight from `@objectstack/spec`. Compose it with `resolvePropsShape` when
+ * the caller has a schema and a key:
+ *
+ *     arrayElementSchema(resolvePropsShape(RecordDetailsProps)?.sections)
+ *
+ * There is no `shapeArrayElement(schema, key)` entry point: no in-tree call
+ * site needs one, and this package does not mint surface ahead of a consumer.
+ *
+ * `undefined` carries the non-vacuity duty described in this module's docblock.
+ */
+export function arrayElementSchema(node: unknown): unknown {
+  return firstInWrapperChain(node, readArrayElement);
+}

--- a/packages/test-support/src/spec-enum-options.ts
+++ b/packages/test-support/src/spec-enum-options.ts
@@ -10,10 +10,17 @@
  * SPEC ENUM VOCABULARY — one reader for every parity gate that asks
  * "which names does this contract accept?" (objectui#5872, objectui#6924).
  *
- * Two exports, ONE walk. `enumOptions(node)` is the walk; `shapeEnumOptions`
- * is that walk entered through a shape member. See "Two entry points, one
- * walk" below for why the second family needed an entry point and not a
- * second reader.
+ * Two exports, ONE walk. `enumOptions(node)` reads the vocabulary at each level
+ * of that walk; `shapeEnumOptions` is the same reader entered through a shape
+ * member. See "Two entry points, one walk" below for why the second family
+ * needed an entry point and not a second reader.
+ *
+ * The walk ITSELF now lives in `spec-zod-wrappers.ts` — `firstInWrapperChain`
+ * — because objectui#5872 class (2) brought a SECOND reader (array elements)
+ * that needs the same steps and a different question at each one. That move is
+ * the promise below ("exactly one wrapper-walk in this repository") kept, not
+ * abandoned: the step is unchanged in order and tries one more spelling only
+ * where it previously gave up. `spec-zod-wrappers.ts` carries the measurement.
  *
  * ## The reader this replaces
  *
@@ -71,9 +78,9 @@
  * `shapeEnumOptions` could not answer for them — it opens with
  * `resolvePropsShape` and then indexes `shape[key]`, so a node that is already
  * the enum has no shape to resolve and no key to index, and it returns `[]`.
- * That is a missing ENTRY POINT, not a missing reader: the loop below already
- * reads `.options` before unwrapping, so it answers a bare enum correctly the
- * moment it is handed one. So the walk is exported as `enumOptions(node)` and
+ * That is a missing ENTRY POINT, not a missing reader: the walk reads
+ * `.options` before unwrapping, so it answers a bare enum correctly the moment
+ * it is handed one. So the reader is exported as `enumOptions(node)` and
  * `shapeEnumOptions` delegates to it. There is exactly one wrapper-walk in this
  * repository, and adding a third entry point later must not change that.
  *
@@ -88,25 +95,7 @@
  */
 
 import { resolvePropsShape } from './spec-tombstones';
-
-/** A Zod node, as far as unwrapping to an enum needs to see it. */
-interface EnumCarrier {
-  options?: unknown;
-  unwrap?: () => unknown;
-  def?: { innerType?: unknown };
-  _def?: { innerType?: unknown };
-}
-
-/**
- * How many wrappers deep to look before giving up.
- *
- * Bounded rather than `while (node)`: the step below is reached through
- * `unknown`, so a node that unwraps to itself — a shape this reader cannot
- * rule out and should not hang on — ends the walk instead of the process. Eight
- * is far past anything the contract stacks today (the deepest in-tree member is
- * one wrapper: `.default()` or `.optional()`).
- */
-const MAX_WRAPPER_DEPTH = 8;
+import { firstInWrapperChain } from './spec-zod-wrappers';
 
 /**
  * The enum names a node ACCEPTS, unwrapped past `.optional()` / `.default()` /
@@ -120,22 +109,23 @@ const MAX_WRAPPER_DEPTH = 8;
  * `[]` carries the non-vacuity duty described in this module's docblock: it
  * means "no vocabulary could be read", and a caller that does not assert
  * against it cannot tell a broken reader from a satisfied parity check.
+ *
+ * ⚠️ NOT a union reader. On `zod@4.4.3` a `ZodUnion` also carries
+ * `.options` — an array of its ARM SCHEMAS, not of names — so pointing this at
+ * a union returns schema objects behind a `string[]` annotation. The censused
+ * union-arm sites (`types/spec-subschema-parity.test.ts`,
+ * `plugin-detail/.../recordHighlightsInputs.spec-parity.test.ts`) ask a
+ * different question and are deliberately left with their own readers.
  */
 export function enumOptions(node: unknown): string[] {
-  let carrier = node as EnumCarrier | undefined;
-  for (let depth = 0; carrier && depth <= MAX_WRAPPER_DEPTH; depth += 1) {
-    const options = carrier.options;
-    // Not filtered to strings: the converging call sites did not filter
-    // either, and dropping a non-string member here would narrow a vocabulary
-    // silently — the one thing this module exists to stop.
-    if (Array.isArray(options)) return [...options] as string[];
-    const inner =
-      typeof carrier.unwrap === 'function'
-        ? carrier.unwrap()
-        : (carrier.def?.innerType ?? carrier._def?.innerType);
-    carrier = inner as EnumCarrier | undefined;
-  }
-  return [];
+  return (
+    firstInWrapperChain(node, (carrier) =>
+      // Not filtered to strings: the converging call sites did not filter
+      // either, and dropping a non-string member here would narrow a vocabulary
+      // silently — the one thing this module exists to stop.
+      Array.isArray(carrier.options) ? ([...carrier.options] as string[]) : undefined,
+    ) ?? []
+  );
 }
 
 /**

--- a/packages/test-support/src/spec-zod-wrappers.ts
+++ b/packages/test-support/src/spec-zod-wrappers.ts
@@ -1,0 +1,129 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * THE ZOD WRAPPER WALK — one implementation, every reader in this package that
+ * has to look past `.optional()` / `.default()` / `.nullable()` / `.readonly()`
+ * / `z.lazy()` before it can answer (objectui#5872).
+ *
+ * ## Why this module exists at all
+ *
+ * `spec-enum-options.ts` closed with a promise: "There is exactly one
+ * wrapper-walk in this repository, and adding a third entry point later must
+ * not change that." A SECOND reader class — array-element unwrapping, this
+ * card's class (2) — arrived, and it needed the same walk with a different
+ * question asked at each step. Writing that walk out again inside the new
+ * reader would have been this package's own failure mode reintroduced by the
+ * package that exists to end it. So the walk moved HERE and both readers stand
+ * on it; `enumOptions` and `arrayElementSchema` differ only in what they read.
+ *
+ * ## What a "step" is, and why it is a superset rather than a rewrite
+ *
+ * The step is the one `enumOptions` carried, unchanged in the order it tried
+ * things — `unwrap()`, then `def.innerType`, then `_def.innerType` — plus one
+ * limb: a `def.getter()` / `_def.getter()` thunk, which is how `z.lazy()`
+ * spells its inner schema on a build that does not put `unwrap()` on
+ * `ZodLazy`. That limb is a WIDENING in the only safe direction: it can fire
+ * only where every earlier limb already yielded `undefined`, i.e. where the
+ * walk used to stop and the caller used to get the empty answer.
+ *
+ * ⚠️ Measured against the installed pin (`zod@4.4.3`, `@objectstack/spec@17.2.0`)
+ * the new limb is UNREACHABLE: the only class carrying `def.getter` is
+ * `ZodLazy`, and on this pin `ZodLazy` also exposes `unwrap()`, which the first
+ * limb takes. So `enumOptions` is bit-for-bit the same walk it was before this
+ * module existed, and the limb is there for the build where it is not.
+ *
+ * ## `def`, `_def` and `_zod.def` are the SAME OBJECT on this pin
+ *
+ * Measured, not assumed: on `zod@4.4.3` every node satisfies
+ * `node.def === node._def === node._zod.def`. The three spellings the censused
+ * hand copies disagreed about are one object, so a reader that tries `def`
+ * before `_def` cannot answer differently from one that tries the reverse —
+ * TODAY. Both are tried anyway, in `enumOptions`'s original order, because the
+ * whole point of confining the walk is that the day they stop being the same
+ * object, ONE place has to move.
+ *
+ * ⚠️ The same measurement is what makes Zod 3's `_def.type` spelling a trap
+ * rather than a fallback: on Zod 3 `_def.type` IS the element schema of a
+ * `ZodArray`, and on Zod 4 `_def.type` is the type-name STRING `'array'`.
+ * `spec-array-element.ts` documents how it is guarded; nothing here may read
+ * `type` as a schema.
+ *
+ * ## Bounded, not `while (node)`
+ *
+ * Same reason and same bound as the loop this replaces: the step is reached
+ * through `unknown`, so a node that unwraps to itself ends the walk instead of
+ * the process. Eight is far past anything the contract stacks today (the
+ * deepest in-tree member is one wrapper).
+ */
+
+/** A Zod node, as far as walking past its wrappers needs to see it. */
+export interface ZodWrapperCarrier {
+  readonly options?: unknown;
+  readonly element?: unknown;
+  readonly unwrap?: () => unknown;
+  readonly def?: ZodDefView;
+  readonly _def?: ZodDefView;
+}
+
+/** The `def` bag, under whichever of its three names a build exposes. */
+export interface ZodDefView {
+  readonly type?: unknown;
+  readonly typeName?: unknown;
+  readonly innerType?: unknown;
+  readonly element?: unknown;
+  readonly getter?: unknown;
+}
+
+/**
+ * How many wrappers deep to look before giving up.
+ *
+ * Exported so a reader's own calibration can assert the bound rather than
+ * restate the number — a restated `8` is one more copy of the kind this
+ * package exists to end.
+ */
+export const MAX_WRAPPER_DEPTH = 8;
+
+/** `z.lazy()`'s inner schema, on a build that spells it as a thunk. */
+function callGetter(def: ZodDefView | undefined): unknown {
+  return typeof def?.getter === 'function' ? (def.getter as () => unknown)() : undefined;
+}
+
+/**
+ * Ask `read` of a node and of each node inside its wrappers, outermost first,
+ * and answer with the FIRST non-`undefined` result — `undefined` when no level
+ * answers.
+ *
+ * The walk is lazy in the way that matters: `read` is asked BEFORE the next
+ * `unwrap()` is called, so a reader that answers at the top never triggers the
+ * step. That is the property the loop this replaced had, kept deliberately.
+ *
+ * `undefined` is the not-here signal, so a reader must not use it as a value.
+ * Both readers in this package answer with `[]` / `undefined` at their own
+ * surface instead, and both document what that means for their caller's
+ * non-vacuity duty.
+ */
+export function firstInWrapperChain<T>(
+  node: unknown,
+  read: (carrier: ZodWrapperCarrier) => T | undefined,
+): T | undefined {
+  let carrier = node as ZodWrapperCarrier | undefined;
+  for (let depth = 0; carrier && depth <= MAX_WRAPPER_DEPTH; depth += 1) {
+    const answer = read(carrier);
+    if (answer !== undefined) return answer;
+    const inner =
+      typeof carrier.unwrap === 'function'
+        ? carrier.unwrap()
+        : (carrier.def?.innerType ??
+          carrier._def?.innerType ??
+          callGetter(carrier.def) ??
+          callGetter(carrier._def));
+    carrier = inner as ZodWrapperCarrier | undefined;
+  }
+  return undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,7 +912,7 @@ importers:
         version: 9.0.0
       '@vitejs/plugin-react':
         specifier: ^6.0.5
-        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.5.4
         version: 10.5.4(postcss@8.5.26)
@@ -939,7 +939,7 @@ importers:
         version: 3.3.1
       vite:
         specifier: ^8.2.1
-        version: 8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@types/express':
         specifier: ^4.17.25
@@ -958,7 +958,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/collaboration:
     dependencies:
@@ -1264,6 +1264,9 @@ importers:
         specifier: ^17.2.0
         version: 17.2.0(ai@7.0.65(zod@4.4.3))
     devDependencies:
+      '@object-ui/test-support':
+        specifier: workspace:*
+        version: link:../test-support
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(@microsoft/api-extractor@7.58.2(@types/node@26.2.0))(@swc/core@1.15.33(@swc/helpers@0.5.23))(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(typescript@6.0.3)(yaml@2.9.0)
@@ -1272,7 +1275,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/fields:
     dependencies:
@@ -14584,11 +14587,6 @@ snapshots:
     optionalDependencies:
       maplibre-gl: 6.3.0
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
-    dependencies:
-      '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
-
   '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -14606,7 +14604,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -14617,15 +14615,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -14634,6 +14623,15 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
+      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -14671,7 +14669,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -20172,21 +20170,6 @@ snapshots:
       - typescript
       - webpack
 
-  vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.33.0
-      picomatch: 4.0.5
-      postcss: 8.5.26
-      rolldown: 1.2.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.2.0
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.23.12
-      yaml: 2.9.0
-
   vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -20197,6 +20180,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
       esbuild: 0.28.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.12
+      yaml: 2.9.0
+
+  vite@8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rolldown: 1.2.7
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.23.12
@@ -20227,38 +20225,6 @@ snapshots:
       redent: 3.0.0
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 26.2.0
-      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      '@vitest/ui': 4.1.10(vitest@4.1.10)
-      happy-dom: 20.11.2
-      jsdom: 30.0.1(@noble/hashes@2.3.0)
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -20280,6 +20246,38 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.2.0
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.2
+      jsdom: 30.0.1(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.3.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
Part of #5872 — classes (2) and (4) only. Class (1) landed in PR #6047; class (3) was ruled on 2026-08-31 (objectui#6923) and is untouched here. The card stays open.

Verified at `3f06af818`.

## Re-derived census first, because the card says to

The card's own instrument, re-run on `main@24d4a21ff` over `packages/ apps/ examples/`:

```
grep -rnE "unwrap\?*\(\)|def\?*\.innerType|_def\?*\.innerType" --include=*.ts --include=*.tsx packages/ examples/ apps/ | grep -v packages/test-support/src/
```

**31 matching lines in 23 files across 7 packages** — `types` x11, `app-shell` x5, `plugin-detail` x2, `components` x2, `plugin-gantt` x1, `data-objectstack` x1, `core` x1. The 2026-08-31 census recorded roughly 18 across 7 packages with `types` x8 and `app-shell` x5. `app-shell` held; `types` grew from 8 to 11. The premise holds — this population is real and it is still growing — so the round proceeded.

## What converged, and the measurement behind each choice

Class (2) was three *different* spellings of one question, and they disagreed about every choice a shared reader has to make. So the reader records which site each choice came from:

| choice | taken from | why the other answer was rejected |
|---|---|---|
| `undefined` for a node that is not an array | `clientValidation.optOuts` | it is the only site whose `toBeDefined()` assertion depends on the discrimination; answering with the node itself deletes a non-vacuity check in silence |
| element returned **as found**, not unwrapped again | `recordDetailsInputs` / `block-config` | `zod@4.4.3` puts `unwrap()` on `ZodArray` itself, so a reader that unwrapped its own answer would descend into an array-of-arrays and report the wrong entry shape |
| Zod 3's `_def.type` read only behind `_def.typeName === 'ZodArray'` | `recordDetailsInputs`, guarded | on the installed pin `_def.type` is the type-name STRING `'array'`, so the hand copy's last limb was a landmine: `listedShapeKeys('array')` is `[]`, the exact quiet empty set this card family exists to stop |

Per-site set identity, measured against the installed pin (`@objectstack/spec@17.2.0`, `zod@4.4.3`) — every element compared by **reference identity**, not just by derived keys:

| site | old walk depth | new | evidence |
|---|---|---|---|
| `plugin-detail/.../recordDetailsInputs.spec-parity.test.ts` | 0 (caller did one `unwrap()`), 4 element spellings | up to 8 | `sections` / `hideFields` / `fields` elements identical by reference; derived key sets identical (`["name","label","columns","fields"]`, `[]`, `[]`) |
| `app-shell/.../previews/__tests__/block-config.test.ts` | bounded 6, `_def` only | up to 8, all spellings | `specSectionKeys` identical: `["name","label","columns","fields"]` |
| `app-shell/.../clientValidation.optOuts.test.ts` | recursive 6, `_zod.def`, type-gated | up to 8 | `sharingRules` / `connectors` elements identical by reference; 16- and 30-key shapes identical; `checks()` counts identical (0 / 1); **array-vs-not discrimination swept over all 43 `ObjectStackSchema` members with zero divergence** |
| `data-objectstack/.../metadata-client.overlayScope.test.ts` (class 4) | exactly 1, no cast, no guard | up to 8 | `["org","env"]` both ways |

The dropped limb from `clientValidation.optOuts` — its second unwrap of the element — is a measured no-op: of the 35 array members of `ObjectStackSchema`, **zero** have a wrapped element, and a wrapped one now fails loudly at the `shapeKeys` comparison rather than quietly.

## `enumOptions` is unchanged, and that was measured rather than argued

The walk moved into `spec-zod-wrappers.ts` so the new reader is not a second copy of it. A differential harness ran the pre-change `enumOptions` and the post-change one over **1386 nodes** reachable from all 12 `@objectstack/spec` subpath modules (334 of which answer non-empty):

```
enumOptions OLD vs NEW differences: 0
new getter() limb fired: 0 times
```

The one added limb (a `def.getter()` thunk for `z.lazy()`) is unreachable on this pin, because `ZodLazy` also exposes `unwrap()`, which the first limb takes. All 33 in-tree `enumOptions` consumers were run.

## The site deliberately NOT converted, with the measurement

`app-shell/.../LayeredDiff.overlayScope.test.tsx:31` is one of the two "seventh spelling" sites the census flagged — `Schema.shape.key.unwrap().options`, no cast, no guard. **Converting it would delete a live compile-time guard**, and this is the reverse verification that says so. Predicted direction recorded before the run: turns red. Applying the conversion and running `app-shell`'s `tsconfig.test.json`:

```
src/views/metadata-admin/LayeredDiff.overlayScope.test.tsx(57,46): error TS2345:
  Argument of type 'string' is not assignable to parameter of type '"org" | "env" | null'.
```

At that site the *absence* of a cast is the guard: `SPEC_SCOPES` inherits its element type from the spec schema, so the day the spec adds a scope, `layeredWith(scope)` stops compiling and someone has to add the zh-CN label. A shared reader returns `string[]`, and any cast that silences today's error silences that future one too. The mutation was proven on disk by anchored token counts and the restore by state (`git diff HEAD` empty, blob hash equal to `HEAD`), under a `trap` with absolute paths.

Other sites left alone, each for a reason rather than for budget: the union-arm readers (`types/spec-subschema-parity.test.ts`, `plugin-detail/.../recordHighlightsInputs.spec-parity.test.ts`) ask a different question — `ZodUnion.options` is an array of arm *schemas*, so `enumOptions` would hand them schema objects behind a `string[]` annotation, and the reader's docblock now says so; `components/.../toast-button-variant-parity.test.ts` deliberately **throws** where the shared reader answers `[]`; `plugin-detail/.../recordRelatedListInputs.spec-parity.test.ts` walks *until a shape is reachable*, which no shared reader expresses and which a walk-to-the-end reader would overshoot on an array; `types/object-view-spec-parity.test.ts:78` says "Deliberately ONE unwrap, not a loop" in its own comment; the `flow-*` sites belong to class (3).

## Non-vacuity

The duty `spec-enum-options.ts` names is carried into the new reader's docblock and checked per site. `block-config` already had `expect(specSectionKeys, 'could not read ...').not.toEqual([])`; `recordDetailsInputs` already had `expect(specSectionKeys().length).toBeGreaterThan(0)`; `clientValidation.optOuts` already had `expect(element, '... must be an array collection').toBeDefined()`; `metadata-client.overlayScope` already had `toEqual(['org','env'])`, which an empty array fails. **None was dropped and none had to be added.** `LayeredDiff.overlayScope` has none — its module-scope `.unwrap().options` fails loudly instead — which is a second reason converting it as-is would have been a regression.

## Ablation — the new calibration suite can actually fail

Both legs proven on disk by anchored token counts before the run and restored by state afterwards, under `trap ... EXIT INT TERM` with absolute paths. `@object-ui/test-support` has no build step and its `exports` map points at `./src/index.ts`, so the mutated bytes are the bytes that ran; there is no `dist` that could serve a stale copy.

| leg | mutation | result |
|---|---|---|
| 1 | drop the `_def.typeName === 'ZodArray'` guard | 13 failed / 9 passed |
| 2 | answer with the node itself instead of `undefined` | 10 failed / 12 passed, including "never returns Zod 4's `_def.type` STRING as if it were a schema" |

Restore proof both legs: `git diff HEAD` reports 0 changed paths and `git hash-object` equals the `HEAD` blob `83e125a6e...`.

## Gates

`check:eager-closure` is **unmoved**, measured on a real console build rather than asserted: `framework` is 523,823 bytes against a 524,000 ceiling — **177 bytes of headroom**, the exact repo-wide figure the lane is blocked on. The diff is test files plus `@object-ui/test-support`, which is `private: true`, has no build, and is imported by nothing outside test files and `scripts/*.mjs` gates.

Green: `check:control-bytes`, `check:phantom-deps`, `check:self-import`, `check:readme-exports`, `check:eager-closure`, `check:spec-symbols`, `check:dist-completeness`, `check:published-dist`, `check:published-tsconfig-exclude`, `check:esm-specifiers`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:side-effects-array`, `check:doc-fences`, `check:spec-floors`, `check-changeset-presence`. The repo-wide lint farm ran in full — `turbo run lint`, 47 of 47 tasks successful, 0 errors. `type-check` green for all four affected packages, and `tsc --listFiles` confirms every edited file is inside the program that reported clean.

The changeset carries an EMPTY frontmatter, which the presence gate names as the explicit exemption for a diff that releases nothing: "4 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s) ... declared as releasing nothing".

Test evidence: `vitest run`, 37 files / 538 tests passed at `3f06af818`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_