### PR TITLE
docs(console): correct the ResizablePanelGroup prop and declare every fragment block under apps/console/docs

### DIFF
--- a/.changeset/7282-console-docs-fragment-markers.md
+++ b/.changeset/7282-console-docs-fragment-markers.md
@@ -1,0 +1,24 @@
+---
+---
+
+Console documentation only (`apps/console/docs/**`) — nothing published moves, so no version bump.
+
+`UI_IMPROVEMENT_PROPOSAL.md` section 3.1 taught `<ResizablePanelGroup direction="horizontal">`.
+The exported component takes `orientation`, not `direction`
+(`packages/components/src/ui/resizable.tsx:44`, pinned by
+`packages/components/src/__tests__/resizable-orientation.test.tsx` and used in-tree at
+`packages/components/src/custom/navigation-overlay.tsx:520`), so a reader who copied the guide's
+first prop got a type error. The prop is corrected in place.
+
+The other ten red `ts` / `tsx` blocks across that tree are excerpt fragments rather than defects,
+and each now carries `check-doc-snippet-types.mjs`'s per-block fragment declaration with a written
+reason naming the identifiers the excerpt leaves to its host. No `UNGATED_DOCS` entry was added:
+the 2026-09-02 ruling on objectui#6600 rejects whole-file exemptions, and this card is that
+ruling's step 1 — content first, then the gate roots move (objectui#6600 step 2).
+
+Why the empty frontmatter rather than a bump: `apps/console/docs/**` is not in `@object-ui/console`'s
+`files` (`dist`, `plugin.ts`, `plugin.js`, `plugin.d.ts`, `README.md`), so no published artifact
+changes. `scripts/check-changeset-presence.mjs` agrees — it reports no changeset owed for this
+range. Note for the record that `@object-ui/console` is **not** `private: true`: it is a published
+member of the 40-package `fixed` group at 17.6.0, so the "no release" declaration rests on the
+unshipped path, not on privacy.

--- a/.changeset/7282-console-docs-fragment-markers.md
+++ b/.changeset/7282-console-docs-fragment-markers.md
@@ -7,7 +7,7 @@ Console documentation only (`apps/console/docs/**`) — nothing published moves,
 The exported component takes `orientation`, not `direction`
 (`packages/components/src/ui/resizable.tsx:44`, pinned by
 `packages/components/src/__tests__/resizable-orientation.test.tsx` and used in-tree at
-`packages/components/src/custom/navigation-overlay.tsx:520`), so a reader who copied the guide's
+`packages/components/src/custom/navigation-overlay.tsx:519`), so a reader who copied the guide's
 first prop got a type error. The prop is corrected in place.
 
 The other ten red `ts` / `tsx` blocks across that tree are excerpt fragments rather than defects,

--- a/apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md
+++ b/apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md
@@ -49,6 +49,7 @@ The current Metadata Inspector panel on the console list page is overly verbose 
 ### Phase 1: Quick Wins (Minimal Changes)
 
 #### 1.1 **Default to Closed**
+<!-- doc-snippet: fragment — the body of `useMetadataInspector` as it would be edited in place; `useState` is the reader's own React import, which this excerpt omits -->
 ```typescript
 // Change default state in useMetadataInspector
 export function useMetadataInspector() {
@@ -61,12 +62,14 @@ export function useMetadataInspector() {
 ```
 
 #### 1.2 **Reduce Width**
+<!-- doc-snippet: fragment — a single opening `<div>` tag, quoted to show the one className change; it has no closing tag and no surrounding component by design -->
 ```tsx
 // MetadataPanel.tsx - Change from w-100 to w-80
 <div className="w-80 border-l bg-muted/20 ...">
 ```
 
 #### 1.3 **Add Collapsible Sections**
+<!-- doc-snippet: fragment — JSX for the panel body: `Accordion`, `AccordionItem`, `AccordionTrigger`, `AccordionContent` and `JsonCodeBlock` are the host component's own imports, and `viewConfig` and `objectDef` its own state -->
 ```tsx
 <Accordion type="multiple" defaultValue={["view"]}>
   <AccordionItem value="view">
@@ -94,6 +97,7 @@ export function useMetadataInspector() {
 #### 2.1 **Smart Summary View**
 Instead of showing raw JSON first, show a structured summary:
 
+<!-- doc-snippet: fragment — the summary view's JSX only: `Label`, `Badge`, `Separator`, `Button` and `Code` are the host component's imports, and `columns`, `showRawJson` and `setShowRawJson` its own state -->
 ```tsx
 // View Summary Component
 <div className="space-y-3 p-4">
@@ -125,6 +129,7 @@ Instead of showing raw JSON first, show a structured summary:
 ```
 
 #### 2.2 **Copy Utilities**
+<!-- doc-snippet: fragment — a header-row excerpt: `Button` and `Copy` are the host component's imports, and `copyToClipboard` and `data` its own helper and state -->
 ```tsx
 <div className="flex items-center justify-between px-3 py-2 border-b">
   <span className="text-xs font-semibold">View Configuration</span>
@@ -140,6 +145,7 @@ Instead of showing raw JSON first, show a structured summary:
 ```
 
 #### 2.3 **Tabbed Interface**
+<!-- doc-snippet: fragment — the tabbed shell's JSX: `Tabs`, `TabsList`, `TabsTrigger` and `TabsContent` are the host component's imports, and `StructuredSummary`, `JsonViewer`, `DataPreview` and `schema` are the components and data it supplies -->
 ```tsx
 <Tabs defaultValue="summary" className="w-full">
   <TabsList className="grid w-full grid-cols-3 h-9">
@@ -165,7 +171,7 @@ Instead of showing raw JSON first, show a structured summary:
 ```tsx
 import { ResizablePanel, ResizablePanelGroup } from '@object-ui/components';
 
-<ResizablePanelGroup direction="horizontal">
+<ResizablePanelGroup orientation="horizontal">
   <ResizablePanel defaultSize={75} minSize={50}>
     {/* Main content */}
   </ResizablePanel>
@@ -176,12 +182,14 @@ import { ResizablePanel, ResizablePanelGroup } from '@object-ui/components';
 ```
 
 #### 3.2 **Persist User Preference**
+<!-- doc-snippet: fragment — a one-line replacement for the `useState` call in 1.1; `useLocalStorage` is the reader's own hook and is not exported by any package here -->
 ```tsx
 // Store in localStorage
 const [showDebug, setShowDebug] = useLocalStorage('console:metadata-panel', false);
 ```
 
 #### 3.3 **Command Palette Integration**
+<!-- doc-snippet: fragment — one entry of the command-palette array, quoted as a bare object literal so it can be spliced into `CommandPalette.tsx`; `Code2` and `toggleDebug` come from that file -->
 ```tsx
 // Add to CommandPalette.tsx
 {

--- a/apps/console/docs/error-tracking.md
+++ b/apps/console/docs/error-tracking.md
@@ -51,6 +51,7 @@ That single variable enables reporting. The rest are optional and inert without 
 
 …or, from a host that composes the plugin directly:
 
+<!-- doc-snippet: fragment — `RuntimeConfigPlugin` is the host runtime's own class, shipped by `@objectstack/cloud-connection` or `@objectstack/objectos-runtime`; neither is a dependency of any package in this workspace, so the specifier does not resolve here -->
 ```ts
 new RuntimeConfigPlugin({
   clientErrorReporting: { dsn: 'https://PUBLIC_KEY@HOST/PROJECT_ID', sendDefaultPii: true },
@@ -142,6 +143,7 @@ first paint (and on that path no sink arrived, so the failure direction is silen
 Use the built-in helpers from `@object-ui/app-shell` — they route through the same gate
 and no-op when it withheld, so they cannot become a second ungated path:
 
+<!-- doc-snippet: fragment — the two calls a host makes; `err` and `user` are the caller's own values, supplied by the surrounding catch block and the signed-in session -->
 ```ts
 import { captureError, setSentryUser } from '@object-ui/app-shell';
 


### PR DESCRIPTION
Fixes #7282

Step 1 of maintainer ruling **D** on #6600 (decision batch #8, 2026-09-02, verbatim 「同意」): fix the content first, then move the documentation gates' roots. No gate script is touched and no gate root moves — that is #6600's step 2, which this unblocks.

## Step 1 — is `UI_IMPROVEMENT_PROPOSAL.md` still live?

**Verdict: live. The fix branch was taken, not retirement.** The evidence, recorded either way as the dispatch requires:

**For liveness**

- **Inbound reference.** `apps/console/README.md:134` links it from the app's "Documentation" table — one of the four documents listed there, alongside the repo ROADMAP and two `content/docs` guides.
- **Its subject is live code.** The Metadata Inspector it proposes to improve exists today as `packages/app-shell/src/views/MetadataInspector.tsx` (`useMetadataInspector`, `MetadataPanel`), and the console consumes it at `apps/console/src/preview-gallery.tsx:51,110` via `getMetadataInspector`.
- **The API it teaches is current.** `ResizablePanelGroup` is a real export of `@object-ui/components` (`packages/components/src/ui/resizable.tsx:44`), pinned by `packages/components/src/__tests__/resizable-orientation.test.tsx:52` and called in-tree at `packages/components/src/custom/navigation-overlay.tsx:519`.
- **The tree is deliberately gated.** objectui#4938 bought `apps/*/docs/**` into `check-doc-links`, and `scripts/__tests__/check-doc-links.test.ts:1507` names this exact path when pinning that.

**Against (recorded, and not decisive)**

- **Never revised.** Created 2026-02-11 in `366775d42` (`copilot-swe-agent[bot]`, PR #444, merged as `65901a5ed`) and **not modified since** — the only commit that touches it. ⚠️ The container's clone is shallow; `git log -- path` there attributes the file to `835a2cebe` (a repo-wide lint-directive fix, PR #5978), which in full history does **not** touch it at all. This branch's figure comes from an unshallowed clone.
- **One stale path.** The component it names, `apps/console/src/components/MetadataInspector.tsx`, no longer exists — it moved to `packages/app-shell/src/views/`.

Neither strand is decisive: an unrevised design proposal is not thereby dead, its subject is demonstrably live, and it is linked from the app's own documentation index. Retirement would have deleted a linked document to close a one-word prop defect. Per the dispatch, anything short of decisive goes to the fix branch.

## Step 1 — the defect

Section 3.1 taught `ResizablePanelGroup` with a `direction="horizontal"` prop. The exported component takes **`orientation`**. A reader copying the block got `TS2322` on its first prop. Corrected in place; nothing else in that block changed.

## Step 2 — fragment markers

Ten blocks now carry `check-doc-snippet-types.mjs`'s per-block `doc-snippet: fragment` declaration (HTML-comment spelling, the one the gate's `FRAGMENT_MARKER_EXAMPLES` gives for `.md`), each with a written reason naming the identifiers the excerpt leaves to its host. **No `UNGATED_DOCS` entry was added** — the ruling rejects whole-file exemptions.

## Re-derived census (the card's numbers were measured earlier; these are this tree's)

Measured on `bf244f400` with the gate's own `scanFences` and `compileSnippets`:

| | blocks |
|:--|--:|
| `ts` / `tsx` blocks under `apps/*/docs/**` | **14** |
| red before this change | **11** (2 syntax + 9 semantic) |
| of those, defects in what the prose claims | **1** (the `TS2322`) |
| of those, excerpt fragments | **10** |
| already green | **3** |

Exactly matching the card's 14/11. Per document: `UI_IMPROVEMENT_PROPOSAL.md` 12 blocks (9 red), `error-tracking.md` 2 blocks (2 red), `deployment.md` 0 blocks.

**The three already-green blocks are deliberately left undeclared.** They are the design-token lists under "Visual Design Specs" (`background:`, `title:`, `panel:` …), which parse as labelled statements and compile clean. Declaring them would assert they cannot compile — false — and would remove three blocks from real semantic coverage. See "Out of scope" below.

**The card's three source references were verified exact** on the base this branch was cut from: `resizable.tsx:44`, `resizable-orientation.test.tsx:52` and `navigation-overlay.tsx:519`.

## Acceptance — the ruling's own criterion

A scratch harness imports the gate's exported functions and replays `analyze()`'s glue over `apps/*/docs/**` instead of `content/docs`. Nothing in the repo is modified. All four controls held:

```
resolution   '@object-ui/types' resolved to packages/types/dist/index.d.ts
sentinel     produced 1 diagnostic (TS2305)
positive     produced 0 diagnostics
undeclared   '@floating-ui/react-dom' produced 1 diagnostic (TS2307)

Scanned 3 document(s): 3 covered (2 of them hold a ts/tsx block), 0 ungated.
Covered blocks: 14 - 4 to compile, 10 declared fragment(s).
Syntax phase:   every block parsed, so every one of them reached the semantic phase.
Semantic phase: 4 of 4 block(s) judged, 0 failed.
```

**`check:doc-snippets` reports 0 failed for this tree.** That is #6600 step 2's precondition.

## Reverse verification

Predicted direction stated before running: red on both legs. The fix was committed first, so each leg restores from `HEAD`; each mutation was proven on disk by counting the injected and removed text, and each restore proven by hash equality with the `HEAD` blob plus an empty `git diff HEAD`.

- **Leg A — revert the fix** (`orientation=` back to `direction=`): red, 1 failed, `TS2322` on that block. The green is caused by this change.
- **Leg B — plant a wrong prop** (`orientationX=`): red, 1 failed, and TypeScript's own diagnostic ends *"Did you mean 'orientation'?"*. The block's props are genuinely excess-checked, so accepting `orientation` is a real judgement rather than a widened `any`.
- **Restored control:** 4 of 4 judged, 0 failed; tree byte-identical to `HEAD`.

## Gates run — union at `3b067b9b0`, clean tree

Each exit code captured before any pipe; each verdict quoted from the gate's own line.

| gate | exit | verdict |
|:--|--:|:--|
| `pnpm docs:check-links` | 0 | Links are valid across 17 scan roots. |
| `pnpm check:doc-snippets` | 0 | Every covered documentation snippet compiles against the built types. (417 of 417 judged, 0 failed) |
| `pnpm check:doc-types` | 0 | Every documented component type is registered. |
| `pnpm check:doc-fences` | 0 | every TypeScript block in 224 document(s) is fenced ts/tsx/typescript |
| `pnpm check:control-bytes` | 0 | OK (6111 tracked text files) |
| `check-changeset-presence.mjs` | 0 | no changeset is owed |
| `check-changeset-no-major.mjs` | 0 | No changeset declares a `major` bump. |
| scratch `apps/*/docs` run | 0 | 4 of 4 judged, 0 failed |

`check:doc-snippets` first returned **exit 2** — `PRECONDITION NOT MET`, the gate's "could not run" code, not a documents verdict. Its own `--build-filter` closure (25 packages) was built and it was re-run; the 0 above is that run.

Follow-up commit `56fab342e` changes two tokens of changeset prose and nothing else (`git diff --stat 3b067b9b0 HEAD` = 1 file, 1 insertion, 1 deletion). At the reviewer's direction the full union was not re-run for it; `pnpm check:control-bytes` (exit 0) and `check-changeset-presence.mjs` (exit 0) were, on the new head.

`pnpm lint` is a repo-wide scan CI owns. The narrowing here is a measurement, not a skip: eslint's **own** config resolution reports all three changed files as `File ignored because no matching configuration was supplied` (0 errors, `--format json`), the flat config carries no `.md` matcher, and the diff adds no config, no `files` pattern and no source file — so no untouched file's verdict can move.

## Step 3 — changeset

Empty-frontmatter form, declaring "no release".

⚠️ **The grading's premise for that form does not hold, and the form is still right.** The grading said to confirm `apps/console` is `private: true`. It is **not** — `@object-ui/console` has no `private` key and is a published member of the 40-package `fixed` group at `17.6.0`. The declaration instead rests on a verified fact: `apps/console/docs/**` is not in the package's `files` (`dist`, `plugin.ts`, `plugin.js`, `plugin.d.ts`, `README.md`), so no published artifact moves. `check-changeset-presence.mjs` agrees independently — it reports no changeset owed for this range.

## Out of scope — declined, not done

- **Gate scripts and gate roots.** Untouched, per the dispatch. #6600 step 2.
- **The three token-list blocks' fence language.** `background: "bg-background"` inside a `tsx` fence compiles only because it parses as a labelled statement — green about nothing. The honest repair is the fence language, which is a `check:doc-fences` question about document shape rather than this card's defect class, and `check:doc-fences` is currently green on them. Reported rather than changed, as #7426.
- **The proposal's one stale path** (`apps/console/src/components/MetadataInspector.tsx`, now under `packages/app-shell/src/views/`). Rewriting a design proposal's prose is not this card's scope; recorded here so the next reader of that file has it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC