### PR TITLE
feat(gates): check the marked fenced examples in the skill guides

### DIFF
--- a/.github/workflows/skill-examples.yml
+++ b/.github/workflows/skill-examples.yml
@@ -1,0 +1,141 @@
+name: Skill Examples
+
+# Compiles every MARKED `ts` / `tsx` / `typescript` fence under `skills/`,
+# `--strict`, against the packages' BUILT `dist/*.d.ts`, and parses every marked
+# `json` / `jsonc` fence. The opt-in marker convention, the adjacency rule, the
+# inherited harness controls and the declared exit codes are documented at length
+# in `scripts/check-skill-examples.mjs`.
+#
+# ── Why this is its own workflow, with NO path filter ───────────────────────
+#
+# Same reason `skills-paths.yml`, `docs-links.yml`, `control-bytes.yml` and
+# `doc-snippet-types.yml` are theirs, and their headers say it best: this gate's
+# entire scan surface is markdown under `skills/`, and both `ci.yml` and
+# `lint.yml` list `'**/*.md'`, `content/**` and `docs/**` under the `paths-ignore`
+# of their `push` trigger. GitHub has no per-job path filter, so a push that only
+# edits a guide would start neither — and editing only a guide is the single most
+# likely way a worked example goes stale. `control-bytes.yml`'s header names the
+# consequence: a gate that cannot see a markdown-only change "rebuilds the hole
+# it exists to close".
+#
+# Hence: no `paths` and no `paths-ignore` here, deliberately.
+# `scripts/__tests__/check-skill-examples.test.ts` fails if either is ever added,
+# and fails too if a second workflow starts running the same script — one gate,
+# one home.
+#
+# ── Why it builds, unlike its install-free sibling `skills-paths.yml` ───────
+#
+# `skills-paths.yml`'s header asks that it stay a checkout plus one `node` call,
+# and this gate cannot be that: its whole criterion is the PUBLISHED type
+# surface, so the packages the marked fences import have to exist as `dist/*.d.ts`
+# first. That is why this is a separate workflow rather than a second step there.
+# Resolving against `src/` instead would be a weaker check the root
+# `tsconfig.json` makes one inherited config away, and the script's RESOLUTION
+# control fails the run rather than letting it pass quietly.
+#
+# The build is FILTERED to the packages the MARKED fences import, emitted by the
+# gate itself (`--build-filter`) rather than hand-maintained here, so it grows
+# only as the marked population grows and the growth is visible in this job's log
+# rather than hidden in a workflow edit. That is what keeps this inside the
+# 2026-08-16 ruling on objectui#4846 (recorded in `published-dist-gate.yml`),
+# which rejected a per-PR FULL-REPO build.
+#
+# ⛔ Do not replace the filtered build with `pnpm build`. The filter is the reason
+# this job is allowed to run on every pull request at all.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  # Merge queue (objectui#3523 — see `ci.yml`'s trigger block for the full note
+  # and the measurements behind it). A required check that does not report on a
+  # queue build stalls the queue until the ruleset's 60-minute timeout fails it,
+  # so an unfiltered gate that could become required subscribes here from the
+  # start. `types:` is named although `checks_requested` is currently the only
+  # activity type GitHub defines for `merge_group`.
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: skill-examples-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  skill-examples:
+    name: Skill Example Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.x'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The filter comes from the gate, so it can never drift from what the
+      # marked fences import.
+      #
+      # ⛔ Do not fold this back into `echo "args=$(node …)" >> "$GITHUB_OUTPUT"`
+      # (objectui#6221). A command substitution contributes its STDOUT to the
+      # surrounding word and nothing else — the step's status is `echo`'s — so a
+      # gate that failed reads as a gate that named no packages, `args` is
+      # silently empty, and the step below expands to a bare `turbo run build`
+      # over the whole workspace: the one thing this workflow's header forbids,
+      # with no signal anywhere. Capture the status, then write the output.
+      - name: Derive the packages the marked examples import
+        id: filter
+        run: |
+          status=0
+          args="$(node scripts/check-skill-examples.mjs --build-filter)" || status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Could not derive the build filter: \`node scripts/check-skill-examples.mjs --build-filter\` exited $status. Refusing to continue — carrying on would build every package in the workspace instead of the ones the marked examples import." >&2
+            exit "$status"
+          fi
+          echo "args=$args" >> "$GITHUB_OUTPUT"
+
+      # The empty-filter refusal is the second half, deliberately kept HERE
+      # rather than beside the status check above: it holds for every route to an
+      # empty filter, including a gate that exits 0 while naming nothing. The
+      # gate's own empty-population floor already refuses a run in which nothing
+      # is marked, and an unfiltered `turbo run build` is a far worse answer than
+      # a red step. `args` arrives through the environment so the check has a
+      # value to test; it stays unquoted on the `turbo` line because it is a LIST
+      # of `--filter=` words that must word-split.
+      - name: Build those packages
+        env:
+          FILTER_ARGS: ${{ steps.filter.outputs.args }}
+        run: |
+          case "$FILTER_ARGS" in
+            *--filter=*) ;;
+            *)
+              echo "::error::The derived build filter names no package (got: '$FILTER_ARGS'). Refusing to run an unfiltered build — see this workflow's header." >&2
+              exit 1
+              ;;
+          esac
+          pnpm exec turbo run build $FILTER_ARGS --concurrency=2
+
+      # The self-test runs BEFORE the corpus, and after the build because its
+      # compiler legs need the same built tree. A probe that cannot fail is not a
+      # probe: it plants a fence that must go red and a marker that must be
+      # reported, so a harness broken into permanent green is caught here rather
+      # than by nobody.
+      - name: Self-test the marker convention, both directions
+        run: node scripts/check-skill-examples.mjs --self-test
+
+      - name: Check the marked skill examples against the built types
+        run: node scripts/check-skill-examples.mjs

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -30,6 +30,7 @@ one has its own section below.
 | `control-bytes.yml` | Control Byte Scan | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** |
 | `docs-links.yml` | Internal Docs Link Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** |
 | `skills-paths.yml` | Skill Guide Path Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a path stated in a `skills/` guide does not exist |
+| `skill-examples.yml` | Skill Example Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a MARKED fenced example in a `skills/` guide no longer compiles against the packages' built types, no longer parses as JSON, or carries a marker that opts nothing in |
 | `doc-component-types.yml` | Doc Component Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a `content/docs/**.mdx` snippet teaches a `type` nothing registers |
 | `doc-snippet-types.yml` | Doc Snippet Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a covered documentation snippet no longer compiles against the packages' built types |
 | `doc-fence-languages.yml` | Doc Fence Language Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a TypeScript block sits under a fence the snippet gate does not read |
@@ -593,6 +594,59 @@ deliberate rather than assumed.
 the sentence's whole point is that the path does not exist. Run it locally with
 `pnpm check:skills-paths`, or `node scripts/check-skills-paths.mjs --list` to see every candidate and
 how it was classified.
+
+## Skill Examples (`skill-examples.yml`)
+
+**Triggers:** Push and PR to `main`/`develop`, merge-queue builds, plus manual dispatch — with **no
+path filter at all**, for the same reason as the section above: the scan surface is markdown under
+`skills/`, and both `ci.yml` and `lint.yml` list `'**/*.md'` under the `paths-ignore` of their `push`
+trigger. It appears in the checks list as **Skill Example Check**.
+
+Runs `scripts/check-skill-examples.mjs`. Where the section above checks the *paths* a guide states in
+prose, this one checks the *worked examples* themselves: a marked `ts` / `tsx` / `typescript` fence
+must compile `--strict` against the packages' built `dist/*.d.ts`, and a marked `json` / `jsonc`
+fence must parse.
+
+**Why it was needed:** at the time it landed, `skills/objectui/` carried 112 TypeScript fences and 56
+JSON fences and **not one gate in the repository read inside any of them**
+([#7359](https://github.com/objectstack-ai/objectui/issues/7359)). Every gate that could have is
+scoped elsewhere by construction — `check-skills-paths.mjs` deliberately reads inline code spans in
+prose only, the three `content/docs` gates say so in their own headers. So a fence could import a
+symbol that does not exist and stay green forever, and two rounds of exactly that had already been
+cleaned by hand.
+
+**Opt-in, and why:** a fence is checked only when the line **immediately above** it is
+`<!-- os:check -->`. Most skill fences are fragments by construction — a `columns: [...]` subtree, a
+block that continues the one above it — so compiling all of them at once would red on prose that is
+not wrong, and a gate that reds on correct code gets deleted by the first person who hits it. The
+marker is an inert HTML comment and leaves the fence info string bare, so the three gates that key on
+the info string still see the block. The convention is ported byte-for-byte from objectstack's
+`packages/spec/scripts/check-skill-examples.ts`.
+
+**Adjacency is strict:** a marker that is not directly above a checkable fence — separated by a blank
+line, above a `bash` fence, or left behind when its example was deleted — is an **orphan** and fails
+the run. A lenient rule would opt in nothing while its author believed otherwise, which is this
+repository's recurring "looks like enforcement, isn't" class. A marker shown as *example text* inside
+another fence is neither an opt-in nor an orphan: it is not at top level, so it claims nothing.
+
+**It builds, unlike `skills-paths.yml`:** the criterion is the *published* type surface, so the
+packages the marked fences import must exist as `dist/*.d.ts` first. The build is filtered to exactly
+those packages, and the filter is emitted by the gate itself
+(`node scripts/check-skill-examples.mjs --build-filter`) rather than hand-maintained in the workflow,
+so it grows only as the marked population grows.
+
+**Three exit codes, not two.** `0` = every marked example held up. `1` = the gate ran and found
+errors — a verdict about a guide. `2` = the gate **could not run**: the packages are unbuilt or typed
+from source, a harness control failed, or nothing is marked at all. Nothing printed under exit 2 is a
+verdict about any guide, and it is never a pass — zero with nothing run reads as coverage, which is
+the failure shape this gate family exists to prevent
+([#4846](https://github.com/objectstack-ai/objectui/issues/4846)).
+
+**If it fails:** it prints `file:line` for every failing fence with the compiler's own diagnostic, or
+the JSON parser's message, or the orphan marker's line. Fix the example — or, if it was never meant
+to stand alone, remove its marker rather than weakening the gate. Run it locally with
+`pnpm check:skill-examples`, `node scripts/check-skill-examples.mjs --list` to see every candidate
+fence and its verdict, and `--measure` to judge every candidate whether marked or not.
 
 ## Documented Component Types (`doc-component-types.yml`)
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "check:i18n-drift": "node scripts/check-i18n-en-drift.mjs",
     "check:i18n-dead-keys": "node scripts/check-i18n-dead-keys.mjs",
     "check:skills-paths": "node scripts/check-skills-paths.mjs",
+    "check:skill-examples": "node scripts/check-skill-examples.mjs",
     "check:doc-types": "node scripts/check-doc-component-types.mjs",
     "check:doc-snippets": "node scripts/check-doc-snippet-types.mjs",
     "check:doc-fences": "node scripts/check-doc-fence-languages.mjs",

--- a/scripts/__tests__/check-skill-examples.test.ts
+++ b/scripts/__tests__/check-skill-examples.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS CI helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
+// re-adding one is now itself an error (TS2578). See objectui#3494.
+import {
+  EXIT_CODES,
+  JSON_FENCE_LANGUAGES,
+  MARKER,
+  SCAN_ROOTS,
+  TS_FENCE_LANGUAGES,
+  buildFilterArgs,
+  fenceSpans,
+  listGuides,
+  parseJsonFence,
+  scanSkillFences,
+  stripJsonComments,
+} from '../check-skill-examples.mjs';
+
+/**
+ * objectui#7359 — the test for `scripts/check-skill-examples.mjs`.
+ *
+ * ## What this file covers, and what it deliberately leaves to `--self-test`
+ *
+ * Everything here runs on an UNBUILT tree: the fence scanner, the marker
+ * convention, the JSON dialects, and the wiring. That boundary is not tidiness —
+ * this suite runs inside `ci.yml`'s `Test (shard N/4)` jobs, which do not build
+ * the workspace, and a test that needed `dist/*.d.ts` would either be flaky or
+ * would quietly assert nothing there.
+ *
+ * The compiler half — a marked fence that holds up is clean, a marked fence with
+ * a type error is red, an unparseable one is a SYNTAX failure and does not blind
+ * the semantic phase for the rest — lives in the script's own `--self-test`,
+ * which the workflow runs AFTER the build, and which refuses with
+ * `PRECONDITION NOT MET` (exit 2) rather than skipping if the tree is not built.
+ * `wiring` below pins that the workflow really runs it, because a probe nobody
+ * runs is indistinguishable from a probe that passes.
+ *
+ * The fixtures are strings and throwaway trees, never the real guides: a
+ * committed fixture guide would have to contain a deliberately broken example,
+ * and something else in this repository would eventually scan it — the reasoning
+ * `check-skills-paths.test.ts` states for its own trees.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** Builds a throwaway tree and hands the caller its root. */
+function withTree<T>(
+  build: (write: (rel: string, contents: string) => void) => void,
+  run: (dir: string) => T,
+): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-skill-examples-'));
+  const write = (rel: string, contents: string) => {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+  };
+  try {
+    build(write);
+    return run(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+type Fence = { kind: string; language: string; fenceLine: number; body: string; marked: boolean };
+type Scan = { fences: Fence[]; orphans: number[] };
+
+describe('the marker, and what it opts in', () => {
+  it('is the exact spelling objectstack uses — the convention is one convention', () => {
+    // Byte-for-byte. A near-spelling would be a second convention that looks
+    // like the first, and the orphan scan below is what makes the difference
+    // loud instead of silent.
+    expect(MARKER).toBe('<!-- os:check -->');
+  });
+
+  it('opts in the fence on the line DIRECTLY below it', () => {
+    const scan: Scan = scanSkillFences([MARKER, '```typescript', 'export const a = 1;', '```'].join('\n'));
+    expect(scan.fences).toHaveLength(1);
+    expect(scan.fences[0].marked).toBe(true);
+    expect(scan.fences[0].fenceLine).toBe(2);
+    expect(scan.fences[0].body).toBe('export const a = 1;');
+    expect(scan.orphans).toEqual([]);
+  });
+
+  it('does NOT reach across a blank line — that marker is an orphan', () => {
+    // The rule that costs nothing to keep strict and everything to relax. A
+    // marker one blank line away opts in NOTHING, and under a lenient
+    // "nearest non-blank line above" rule the author would never learn that.
+    const scan: Scan = scanSkillFences([MARKER, '', '```typescript', 'export const a = 1;', '```'].join('\n'));
+    expect(scan.fences[0].marked).toBe(false);
+    expect(scan.orphans).toEqual([1]);
+  });
+
+  it('reports a marker above a fence it cannot judge as an orphan', () => {
+    const scan: Scan = scanSkillFences([MARKER, '```bash', 'pnpm install', '```'].join('\n'));
+    expect(scan.fences).toEqual([]);
+    expect(scan.orphans).toEqual([1]);
+  });
+
+  it('reports a marker left behind above prose', () => {
+    const scan: Scan = scanSkillFences(['# Guide', '', MARKER, '', 'Some prose.'].join('\n'));
+    expect(scan.orphans).toEqual([3]);
+  });
+
+  it('ignores leading and trailing whitespace on the marker line', () => {
+    const scan: Scan = scanSkillFences([`  ${MARKER}  `, '```json', '{"a":1}', '```'].join('\n'));
+    expect(scan.fences[0].marked).toBe(true);
+    expect(scan.orphans).toEqual([]);
+  });
+
+  it('does not accept a marker with anything else on its line', () => {
+    const scan: Scan = scanSkillFences([`${MARKER} and more`, '```json', '{"a":1}', '```'].join('\n'));
+    expect(scan.fences[0].marked).toBe(false);
+    // ...and it is not an orphan either: it is not the marker, it is prose that
+    // contains it. Only the exact line makes a claim.
+    expect(scan.orphans).toEqual([]);
+  });
+});
+
+describe('fence-awareness — a marker shown as example text claims nothing', () => {
+  /**
+   * This gate's convention has to be documentable in the very guides it
+   * governs, and in this file. So the two questions the walk answers — "is this
+   * marker at top level?" and "does this line open a fence?" — read one array,
+   * and a nested illustration is neither an opt-in nor an orphan.
+   */
+  it('extracts nothing from a fully worked illustration inside a wrapper fence', () => {
+    const scan: Scan = scanSkillFences(
+      ['````markdown', MARKER, '```typescript', 'const illustrative = 1;', '```', '````'].join('\n'),
+    );
+    expect(scan.fences).toEqual([]);
+    expect(scan.orphans).toEqual([]);
+  });
+
+  it('extracts everything from the identical payload when it is NOT nested', () => {
+    // The control on the case above: without it, a walk that extracted nothing
+    // for the wrong reason would pass.
+    const scan: Scan = scanSkillFences([MARKER, '```typescript', 'const illustrative = 1;', '```'].join('\n'));
+    expect(scan.fences).toHaveLength(1);
+    expect(scan.fences[0].marked).toBe(true);
+  });
+
+  it('reads the fence body to the closing line the SAME walk chose', () => {
+    const { owners, closeOf } = fenceSpans(['```ts', 'a', '```', 'top level'].join('\n').split('\n'));
+    expect(owners).toEqual([0, 0, 0, -1]);
+    expect(closeOf.get(0)).toBe(2);
+  });
+
+  it('lets an unclosed fence run to end of file rather than throwing', () => {
+    const scan: Scan = scanSkillFences(['```typescript', 'const a = 1;', '', '# still inside'].join('\n'));
+    expect(scan.fences).toHaveLength(1);
+    expect(scan.fences[0].body).toBe('const a = 1;\n\n# still inside');
+  });
+
+  it('normalises CRLF, so no regex has to decide whether \\s matches a carriage return', () => {
+    const scan: Scan = scanSkillFences([MARKER, '```json', '{"a":1}', '```'].join('\r\n'));
+    expect(scan.fences).toHaveLength(1);
+    expect(scan.fences[0].marked).toBe(true);
+    expect(scan.fences[0].body).toBe('{"a":1}');
+  });
+});
+
+describe('languages', () => {
+  it('recognises the three TypeScript spellings and the two JSON ones', () => {
+    expect([...TS_FENCE_LANGUAGES].sort()).toEqual(['ts', 'tsx', 'typescript']);
+    expect([...JSON_FENCE_LANGUAGES].sort()).toEqual(['json', 'jsonc']);
+  });
+
+  it('classifies each candidate by kind', () => {
+    const scan: Scan = scanSkillFences(
+      ['```tsx', 'const a = <div />;', '```', '', '```jsonc', '{}', '```'].join('\n'),
+    );
+    expect(scan.fences.map((f) => [f.language, f.kind])).toEqual([
+      ['tsx', 'ts'],
+      ['jsonc', 'json'],
+    ]);
+  });
+
+  it('ignores a language it cannot judge', () => {
+    const scan: Scan = scanSkillFences(['```css', '.a { color: red }', '```'].join('\n'));
+    expect(scan.fences).toEqual([]);
+  });
+});
+
+describe('JSON fences — `json` is strict, `jsonc` is exactly two things looser', () => {
+  it('accepts valid JSON', () => {
+    expect(parseJsonFence('{"a": 1}', 'json')).toBeNull();
+  });
+
+  it('rejects a trailing comma under `json`', () => {
+    // A `json` fence is a claim about what a real `.json` file may contain, so a
+    // tolerant parser here would bless a file no `JSON.parse` in the product
+    // would accept.
+    expect(parseJsonFence('{"a": 1,}', 'json')).not.toBeNull();
+  });
+
+  it('rejects a comment under `json`', () => {
+    expect(parseJsonFence('{\n  // nope\n  "a": 1\n}', 'json')).not.toBeNull();
+  });
+
+  it('accepts both under `jsonc`', () => {
+    expect(parseJsonFence('{"a": 1,}', 'jsonc')).toBeNull();
+    expect(parseJsonFence('{\n  /* fine */\n  "a": 1\n}', 'jsonc')).toBeNull();
+  });
+
+  it('does not mistake a `//` inside a string for a comment', () => {
+    // Written as a scanner rather than a regex for exactly this: a URL in a
+    // guide example is not hypothetical.
+    expect(stripJsonComments('{"url": "https://example.com/x"}')).toBe('{"url": "https://example.com/x"}');
+    expect(parseJsonFence('{"url": "https://example.com/x"}', 'jsonc')).toBeNull();
+  });
+
+  it('does not mistake an escaped quote for the end of a string', () => {
+    expect(stripJsonComments('{"a": "he said \\"//\\" here"}')).toBe('{"a": "he said \\"//\\" here"}');
+  });
+
+  it('keeps line count stable when it blanks a block comment', () => {
+    // Diagnostics quote line numbers; a stripper that collapsed lines would
+    // point at the wrong one.
+    const source = '{\n/* one\n   two */\n"a": 1\n}';
+    expect(stripJsonComments(source).split('\n')).toHaveLength(source.split('\n').length);
+  });
+
+  it('reports a truncated object rather than accepting it', () => {
+    expect(parseJsonFence('{"a": 1', 'json')).not.toBeNull();
+  });
+});
+
+describe('the scan surface is a decision, stated here rather than read off the walker', () => {
+  it('walks `skills` and, today, nothing else', () => {
+    // `.claude/skills/**` is deliberately outside this gate for now, the way
+    // `check-skills-paths.mjs`'s prefix allow-list was: widening it is a
+    // separate, visible edit with its own measurement, not a silent drift.
+    expect(SCAN_ROOTS).toEqual(['skills']);
+  });
+
+  it('collects every `.md` under the roots, recursively and in a stable order', () => {
+    withTree(
+      (write) => {
+        write('skills/objectui/guides/b.md', '# b\n');
+        write('skills/objectui/guides/a.md', '# a\n');
+        write('skills/objectui/SKILL.md', '# skill\n');
+        write('skills/objectui/notes.txt', 'not markdown\n');
+        write('content/docs/elsewhere.md', '# not in scope\n');
+      },
+      (dir) => {
+        expect(listGuides(dir)).toEqual([
+          'skills/objectui/SKILL.md',
+          'skills/objectui/guides/a.md',
+          'skills/objectui/guides/b.md',
+        ]);
+      },
+    );
+  });
+
+  it('returns an empty list rather than throwing when a root is absent', () => {
+    withTree(
+      (write) => write('README.md', '# nothing here\n'),
+      (dir) => expect(listGuides(dir)).toEqual([]),
+    );
+  });
+
+  it('really does read the published bundle in this checkout', () => {
+    // Non-vacuity: every assertion above is about fixtures, and a gate pointed
+    // at a root that does not exist would satisfy all of them while judging
+    // nothing at all.
+    const guides = listGuides(repoRoot) as string[];
+    expect(guides.length).toBeGreaterThan(5);
+    expect(guides.every((g) => g.startsWith('skills/'))).toBe(true);
+  });
+});
+
+describe('the corpus this gate governs', () => {
+  const guides = listGuides(repoRoot) as string[];
+  const scans = guides.map((g) => ({
+    guide: g,
+    scan: scanSkillFences(fs.readFileSync(path.join(repoRoot, g), 'utf8')) as Scan,
+  }));
+
+  it('carries no orphan marker', () => {
+    // The same verdict the gate reaches, asserted here too because this half
+    // needs no build — so a stale marker is caught by the cheap job as well as
+    // by the one that installs and builds.
+    const orphans = scans.flatMap(({ guide, scan }) => scan.orphans.map((line) => `${guide}:${line}`));
+    expect(
+      orphans,
+      `\`${MARKER}\` must be the line IMMEDIATELY above a ts/tsx/typescript/json/jsonc fence. ` +
+        `At these sites it opts nothing in, so the example below reads as gated and is not:\n` +
+        orphans.map((o) => `  - ${o}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('has a non-empty marked population — a gate that checks nothing must not report success', () => {
+    const marked = scans.flatMap(({ scan }) => scan.fences.filter((f) => f.marked));
+    expect(marked.length).toBeGreaterThan(0);
+    // Both languages are really exercised. Without this the population could
+    // collapse to one kind and the other half of the gate would be dead code
+    // nobody noticed.
+    expect(marked.some((f) => f.kind === 'ts')).toBe(true);
+    expect(marked.some((f) => f.kind === 'json')).toBe(true);
+  });
+
+  it('leaves the majority unmarked — opt-in is the design, not a migration halfway done', () => {
+    // Stated as a RATIO rather than a count on purpose. objectui#7359 explicitly
+    // did NOT decide whether the marked population becomes shrink-only, and a
+    // count pinned here would be that decision taken by accident, red on the
+    // next guide anyone edits.
+    const all = scans.flatMap(({ scan }) => scan.fences);
+    const marked = all.filter((f) => f.marked);
+    expect(marked.length).toBeLessThan(all.length);
+  });
+
+  it('spells every marker byte-identically', () => {
+    // A near-spelling (`<!--os:check-->`, a smart dash, a stray space inside)
+    // reads as a marker and claims nothing. It would surface as an orphan only
+    // if it matched the orphan scan's own literal — which it does not.
+    for (const guide of guides) {
+      const source = fs.readFileSync(path.join(repoRoot, guide), 'utf8');
+      for (const [index, line] of source.split('\n').entries()) {
+        if (!/os:check/.test(line)) continue;
+        expect(line, `${guide}:${index + 1} carries a near-spelling of the marker`).toBe(MARKER);
+      }
+    }
+  });
+});
+
+describe('exit codes — "could not run" is not "ran and found errors"', () => {
+  it('names all three, and keeps them distinct', () => {
+    expect(EXIT_CODES.verified).toBe(0);
+    expect(EXIT_CODES.examplesFailed).toBe(1);
+    expect(EXIT_CODES.couldNotRun).toBe(2);
+  });
+});
+
+describe('the build filter carries the dependency closure', () => {
+  it('emits sorted `--filter=<pkg>...` words', () => {
+    expect(buildFilterArgs(['@object-ui/react', '@object-ui/core'])).toBe(
+      '--filter=@object-ui/core... --filter=@object-ui/react...',
+    );
+  });
+
+  it('emits nothing for an empty set, which the workflow refuses rather than expands', () => {
+    // A bare `turbo run build` over the whole workspace is the one thing the
+    // workflow's header forbids, so the empty case must be visibly empty here.
+    expect(buildFilterArgs([])).toBe('');
+  });
+});
+
+describe('wiring — the gate is reachable and a markdown-only PR starts it', () => {
+  const SCRIPT = 'scripts/check-skill-examples.mjs';
+  const workflowDir = path.join(repoRoot, '.github/workflows');
+  const workflowPath = path.join(workflowDir, 'skill-examples.yml');
+  const workflowFiles = fs.readdirSync(workflowDir).filter((f) => f.endsWith('.yml'));
+
+  /**
+   * A workflow's YAML with whole-line comments removed. Every workflow in this
+   * repository discusses `paths`, `paths-ignore` and its neighbours' scripts in
+   * prose; a scan that counted comments would report filters and duplicate homes
+   * that no file has.
+   */
+  const yamlOf = (file: string) =>
+    fs
+      .readFileSync(path.join(workflowDir, file), 'utf8')
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n');
+
+  it('is exposed as a root package script', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    expect(pkg.scripts['check:skill-examples']).toBe(`node ${SCRIPT}`);
+  });
+
+  it('has a workflow that gates pull requests, not just pushes', () => {
+    expect(fs.existsSync(workflowPath), 'a check nothing runs is not a gate').toBe(true);
+    const yaml = yamlOf('skill-examples.yml');
+    expect(yaml).toMatch(new RegExp(`run:\\s*node\\s+${SCRIPT.replace(/[.]/g, '\\.')}\\s*$`, 'm'));
+    expect(yaml).toMatch(/^\s*pull_request:/m);
+    expect(yaml).toMatch(/^\s*push:/m);
+    expect(yaml).toMatch(/^\s*merge_group:/m);
+  });
+
+  it('runs the self-test too — a probe nobody runs is a probe that passes', () => {
+    expect(yamlOf('skill-examples.yml')).toMatch(
+      new RegExp(`run:\\s*node\\s+${SCRIPT.replace(/[.]/g, '\\.')}\\s+--self-test`),
+    );
+  });
+
+  it('derives its build filter from the gate rather than hand-maintaining one', () => {
+    const yaml = yamlOf('skill-examples.yml');
+    expect(yaml).toContain('--build-filter');
+    // ⛔ The one thing the header forbids: an unfiltered workspace build.
+    expect(yaml).not.toMatch(/turbo run build\s*$/m);
+    expect(yaml).not.toMatch(/pnpm build/);
+  });
+
+  it('runs it in NO path-filtered workflow — the scan surface is entirely markdown', () => {
+    // The whole reason this is its own workflow. `ci.yml` and `lint.yml` list
+    // `'**/*.md'` under the `paths-ignore` of their `push` trigger and GitHub
+    // has no per-job path filter, so a push that only edits a guide would never
+    // start them. That is exactly the hole #3448 (docs links), control-bytes.yml
+    // and skills-paths.yml were split out to close.
+    expect(workflowFiles.length, 'the workflow directory scan returned implausibly few files').toBeGreaterThan(5);
+    for (const file of workflowFiles) {
+      const yaml = yamlOf(file);
+      if (!yaml.includes(SCRIPT)) continue;
+      expect(yaml, `${file} runs ${SCRIPT} behind a paths-ignore — a guide-only change would not start it`).not.toMatch(
+        /paths-ignore:/,
+      );
+      expect(yaml, `${file} runs ${SCRIPT} behind a paths filter — see objectui#3448`).not.toMatch(/^\s+paths:/m);
+    }
+  });
+
+  it('has exactly one home', () => {
+    // A second copy in a path-filtered workflow is how a gate ends up looking
+    // covered while the change it exists for still slips past.
+    expect(workflowFiles.filter((f) => yamlOf(f).includes(SCRIPT))).toEqual(['skill-examples.yml']);
+  });
+
+  it('does not run a NEIGHBOUR gate from this workflow', () => {
+    // `check-doc-snippet-types.test.ts` pins that its own script lives in
+    // exactly one workflow. This gate imports that script's harness as a MODULE,
+    // which is the intended reuse; invoking it from this YAML would break that
+    // pin and give one gate two homes.
+    expect(yamlOf('skill-examples.yml')).not.toContain('scripts/check-doc-snippet-types.mjs');
+  });
+
+  it('is classified as a blocking context rather than defaulting into silence', () => {
+    // `dependabot-merge-gate.test.ts` asserts its three buckets partition the
+    // produced check-run set exactly, and `merge-queue-reporting.test.ts`
+    // derives the `merge_group` floor from the required bucket. Asserted here
+    // too, in this gate's own file, so the reason travels with the gate.
+    const gate = fs.readFileSync(path.join(repoRoot, 'scripts/dependabot-merge-gate.mjs'), 'utf8');
+    expect(gate).toContain("'Skill Example Check'");
+  });
+
+  it('has a section on the CI page, named by heading', () => {
+    // `ci-cd-pipeline-doc.test.ts` enforces this repo-wide; restated here
+    // because objectui#3212's lesson is that the omission happens at the moment
+    // the workflow is added, not later.
+    const doc = fs.readFileSync(path.join(repoRoot, 'content/docs/guide/ci-cd-pipeline.md'), 'utf8');
+    const headings = doc.split('\n').filter((line) => /^#{1,6}\s/.test(line));
+    expect(headings.some((h) => h.includes('skill-examples.yml'))).toBe(true);
+  });
+});
+
+describe('the harness is imported, not re-rolled', () => {
+  /**
+   * `check-doc-snippet-types.mjs` had its type-check harness hand-rolled three
+   * separate times before it was consolidated, and its header records that one
+   * of those three produced a FALSE GREEN. The harness carries the
+   * syntax/semantics split and the four self-controls; a second copy here would
+   * be a second answer to the same question, free to drift.
+   *
+   * Pinned as a source-level fact because it is invisible in behaviour: a forked
+   * harness would pass every other assertion in this file.
+   */
+  it('imports the compiler and resolution helpers from the docs gate', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-skill-examples.mjs'), 'utf8');
+    const importBlock = source.match(/import\s*\{[^}]*\}\s*from\s*'\.\/check-doc-snippet-types\.mjs';/);
+    expect(importBlock, 'the shared harness import is gone — has it been forked?').not.toBeNull();
+    for (const name of ['compileSnippets', 'derivePackageTypePaths', 'deriveDeclaredDependencyPaths']) {
+      expect(importBlock![0]).toContain(name);
+    }
+  });
+
+  it('does not build a TypeScript Program of its own', () => {
+    const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-skill-examples.mjs'), 'utf8');
+    expect(source).not.toContain('ts.createProgram');
+    expect(source).not.toContain('ts.createCompilerHost');
+  });
+});

--- a/scripts/__tests__/merge-queue-reporting.test.ts
+++ b/scripts/__tests__/merge-queue-reporting.test.ts
@@ -94,6 +94,14 @@ const MUST_SUBSCRIBE_MERGE_GROUP = new Map<string, string>([
       'request, and is therefore requirable',
   ],
   [
+    'skill-examples.yml',
+    'produces Skill Example Check — added by objectui#7359. Its scan surface is the markdown under ' +
+      '`skills/`, the shape `ci.yml` and `lint.yml` structurally cannot see (both list `**/*.md` ' +
+      'under the `paths-ignore` of their `push` trigger), so it carries no path filter, reports on ' +
+      'every pull request, and is therefore requirable; `scripts/dependabot-merge-gate.mjs` ' +
+      'classifies it as a required context',
+  ],
+  [
     'pre-install-import-graph.yml',
     'produces Pre-Install Import Graph Check — added by objectui#6148. What it judges is the ' +
       'arrangement of the workflows themselves, so it carries no path filter, reports on every ' +

--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -1,0 +1,1055 @@
+#!/usr/bin/env node
+/**
+ * Every fenced example in `skills/` that carries the opt-in marker must still be
+ * REAL: a `ts` / `tsx` / `typescript` block must compile against the packages'
+ * BUILT `dist/*.d.ts`, and a `json` / `jsonc` block must parse.
+ *
+ * Run:  node scripts/check-skill-examples.mjs        (also `pnpm check:skill-examples`)
+ *       node scripts/check-skill-examples.mjs --list          # every candidate fence + verdict
+ *       node scripts/check-skill-examples.mjs --measure       # judge EVERY candidate, marked or not
+ *       node scripts/check-skill-examples.mjs --build-filter  # filter args for turbo/pnpm
+ *       node scripts/check-skill-examples.mjs --self-test     # fixtures, both directions
+ * Exit: 0 = every MARKED fence holds up, and the marked population is non-empty.
+ *       1 = THE GATE RAN AND FOUND ERRORS. A marked fence failed to parse, failed
+ *           to type-check, or a marker is not adjacent to a fence it can opt in.
+ *           Everything printed above the summary is a verdict about a guide.
+ *       2 = THE GATE COULD NOT RUN, so nothing printed above is a verdict about
+ *           any guide: the packages the marked fences import are not built (or
+ *           are typed from source), a harness control failed, or the marked
+ *           population is empty. Fix the tree and re-run. Never read this as a
+ *           guide defect, and never as a pass.
+ *
+ * ## The gap this closes (objectui#7359)
+ *
+ * The guides under `skills/objectui/` are the first thing an AI reads when it
+ * writes ObjectUI code, and at the branch point they carried 112 `ts` / `tsx` /
+ * `typescript` fences and 56 `json` fences. NOT ONE of them was read by any gate
+ * in this repository, and every gate that could have reached them excludes the
+ * surface by construction rather than by accident:
+ *
+ *   | gate                          | why it does not reach a fence in `skills/`   |
+ *   |-------------------------------|----------------------------------------------|
+ *   | `check-skills-paths.mjs`      | deliberately reads inline code spans in PROSE only — "a fence is a worked example", and a tutorial fence may name a file the reader is about to create |
+ *   | `check-doc-links.mjs`         | its `SCAN_ROOTS` has no `skills` row          |
+ *   | `check-doc-component-types.mjs` | `DOCS_ROOT = 'content/docs'`, and its header says "not `skills/**`" verbatim |
+ *   | `check-doc-snippet-types.mjs` | `content/docs` + the package READMEs + `README.md` |
+ *   | `check-doc-fence-languages.mjs` | same surface, and it judges the fence LANGUAGE TAG, never the contents |
+ *
+ * So this repository enforced path existence in skill prose and nothing else. A
+ * fence could import a symbol that does not exist, spell a key the renderer never
+ * reads, or restate a shape the spec had changed, and stay green forever. Two
+ * rounds of exactly that were already cleaned BY HAND (objectui#3658 / #7094's
+ * truth sweep, and #7251's correctness items — which included an eval asserting a
+ * mobile hook API with zero occurrences repo-wide), which is precisely the
+ * economics `check-skills-paths.mjs` was created to end for paths.
+ *
+ * ## Opt-in, and why that is the only shape that can start
+ *
+ * `check-doc-snippet-types.mjs` is opt-OUT: every `ts` fence in a covered
+ * document is compiled unless a marker declares it a fragment. That rule is right
+ * there and wrong here, and the difference is measurable rather than a matter of
+ * taste. The docs corpus was curated into that shape over several cards; the
+ * skills corpus never has been. Most of its fences are FRAGMENTS by construction
+ * — a `columns: [...]` subtree, a `plugins: [...]` literal, a hook body that
+ * continues the block above it, a `vitest` test that imports a dev-only package
+ * no consumer of `@object-ui/*` can resolve. Turning all 112 on at once would
+ * produce a wall of red on prose that is not wrong, and the reliable outcome of a
+ * gate that reds on correct code is that someone deletes it.
+ *
+ * Hence the convention this file PORTS from objectstack's
+ * `packages/spec/scripts/check-skill-examples.ts`: a self-contained,
+ * should-hold-up block is opted in by an HTML comment on the line DIRECTLY ABOVE
+ * its fence. The marker's exact spelling is in `MARKER` below (a JavaScript block
+ * comment cannot quote an HTML comment's closer without confusing a reader
+ * grepping for it, so it lives in code, the way
+ * `check-doc-snippet-types.mjs` puts its own marker in
+ * `FRAGMENT_MARKER_EXAMPLES`).
+ *
+ * Two properties make the marker safe on this surface, and both are the reason
+ * objectstack chose this spelling over a fence-meta tag like ` ```ts check `:
+ *
+ *   1. It is an HTML comment, so it renders to nothing. A skill guide is read by
+ *      an agent as raw markdown and by a human as rendered markdown; neither sees
+ *      it.
+ *   2. It leaves the fence info string a BARE ` ```typescript `. Three gates in
+ *      this repository key on the info string — `check-doc-fence-languages.mjs`
+ *      most directly — and a fence-meta tag would have punched a hole in every
+ *      one of them.
+ *
+ * Opt-in also makes the starting population an honest, stated number rather than
+ * a wall of exemptions: see "The starting population" below.
+ *
+ * ## Marker ADJACENCY is strict, and an orphan is a failure
+ *
+ * The marker must be the line IMMEDIATELY above the fence-open line — not the
+ * nearest non-blank line above it. A marker anywhere else is an ORPHAN and fails
+ * the run.
+ *
+ * This is the one rule where being strict costs nothing and being lenient costs
+ * everything. A marker separated from its fence by a blank line, or left behind
+ * when its fence was deleted or rewritten, is a claim that nothing checks: under
+ * a lenient rule it silently opts in NOTHING, and the author who wrote it
+ * believes their example is gated. That is the "looks like enforcement, isn't"
+ * class this repository has now measured five separate times (objectui#3009,
+ * #3181, #3494, #4846, #7115). A stale marker is reported, loudly, with its line
+ * number.
+ *
+ * ## Fence-awareness: a marker shown as EXAMPLE TEXT claims nothing
+ *
+ * This gate's own convention has to be documentable in the very guides it
+ * governs, and in this file's own tests. So a marker line that sits INSIDE some
+ * other fenced block — a ```markdown illustration showing what the marker looks
+ * like — is at once not an opt-in and not an orphan: it is not at top level, so
+ * it claims nothing. `fenceSpans()` answers "which top-level fence owns this
+ * line?" for BOTH questions, so the two readings cannot drift apart. The same
+ * walk also supplies each fence's CLOSING line, so the body's end is decided by
+ * exactly the predicate that decided the fence opened — never by a second,
+ * looser closer re-derived at the extraction site (objectstack measured that
+ * pair disagreeing on an indented closer and on a CRLF file, in opposite
+ * directions).
+ *
+ * ## How imports resolve: the BUILT dist, exactly like the docs gate
+ *
+ * A marked `ts` fence is compiled `--strict` against each package's built
+ * `dist/*.d.ts`, resolved through the same `paths` map
+ * `check-doc-snippet-types.mjs` derives from every package's own `exports` /
+ * `types` field, plus that gate's declared-dependency rule for third-party
+ * specifiers (a snippet importing `@object-ui/layout` may import `lucide-react`
+ * because that package declares it — and may not import a package nothing
+ * declares).
+ *
+ * ⛔ The alternative was mapping `@object-ui/*` to `src/` through
+ * `tsconfig.base.json`, and it is rejected for the reason that gate's header
+ * states in as many words: the root config maps the workspace to SOURCE, so a
+ * harness that inherited it would judge the guides against code no reader
+ * resolves — green while the published surface is broken. The reader of a skill
+ * guide is a consumer who installs `@object-ui/react` from npm. That is the
+ * surface, so that is what is compiled against.
+ *
+ * ⚠️ The honest edge of that resolution, measured rather than assumed, and
+ * printed on every run as `Unmapped specifiers`: a bare specifier that neither
+ * the workspace map nor the declared-dependency map covers still resolves if the
+ * REPOSITORY ROOT declares it, because pnpm symlinks the root's own dependency
+ * set into `/node_modules`. `vitest`, `react` and `@testing-library/react` are
+ * root devDependencies here, so a marked fence importing them is verified
+ * against THIS workspace's copy — not against anything a reader of the guide is
+ * told to install. The guides do tell that reader to install vitest, so the
+ * examples are not wrong; the GATE simply is not the thing that proves it. The
+ * inherited UNDECLARED control does not close this: it bounds resolution against
+ * TRANSITIVE packages (which pnpm leaves only under `.pnpm/`), a different leak.
+ * Naming the specifiers in the run output is what stops that from being a silent
+ * property of a green — tightening it is recorded as a follow-up, not done here.
+ *
+ * The cost of that decision is the PRECONDITION, and it is a declared exit code
+ * rather than a silent green: if a package a marked fence imports has no `dist`,
+ * this gate prints `PRECONDITION NOT MET` and exits 2 (`couldNotRun`), never 0
+ * and never 1. Zero with nothing run reads as coverage, which is the exact
+ * failure shape this whole gate family exists to prevent (objectui#4846). The 1
+ * vs 2 split is this repository's convention, not a new one — see
+ * `check-eager-closure-budget.mjs` (1 = over budget, 2 = the gauge produced
+ * nothing) and `check-doc-snippet-types.mjs`, whose header records three separate
+ * agents in one evening each having to notice a printed message before their exit
+ * code meant anything.
+ *
+ * ## What is REUSED, and what is deliberately local
+ *
+ * The type-check HARNESS is imported from `check-doc-snippet-types.mjs`:
+ * `derivePackageTypePaths`, `deriveDeclaredDependencyPaths` and
+ * `compileSnippets`. That is not convenience — that harness carries the
+ * syntax/semantics split (a `tsc` program with ONE parse error reports no
+ * semantic diagnostics at all, program-wide, so an unparseable block must never
+ * blind the rest) and the three self-controls (RESOLUTION lands on a built
+ * artifact, a planted SENTINEL import must produce TS2305, a POSITIVE control
+ * must be clean, and an UNDECLARED specifier must still fail to resolve). A
+ * second hand-rolled harness would be a second answer to the same question, and
+ * that gate's own header records what hand-rolling it three times cost.
+ *
+ * What is local is the READING of those controls (`evaluateControls` below) and
+ * everything about the marker convention. `scripts/__tests__/check-skill-examples.test.ts`
+ * pins that this file imports the shared harness rather than growing its own.
+ *
+ * ## The starting population (objectui#7359 step 2)
+ *
+ * `--measure` judges EVERY candidate fence, marked or not, and prints the
+ * pass/fail split per language. That is how the marker was landed on exactly the
+ * fences that already held up at the branch point, and it stays in the file so
+ * the number is re-derivable rather than a claim in a merged PR body.
+ *
+ * ⛔ There is deliberately NO ratchet and NO count pin. Whether the marked
+ * population becomes shrink-only — the way `check-doc-fence-languages.mjs`
+ * treats its declared-file population — is a separate decision, recorded as a
+ * follow-up rather than taken here. What IS enforced is a floor: a run in which
+ * NOTHING is marked exits 2, because a gate that checks nothing must not report
+ * success.
+ *
+ * ## Deliberately NOT answered here
+ *
+ *   1. **Whether a marked JSON fence is VALID METADATA.** It is parsed, not
+ *      validated against `@object-ui/types`' schemas. Parsing catches the
+ *      trailing comma, the smart quote and the truncated object; deciding which
+ *      fences are complete documents rather than prose fragments is the same
+ *      boundary `check-doc-snippet-types.mjs` left unruled for the same reason,
+ *      and guessing it is what produces a gate people learn to ignore.
+ *   2. **Bare `any` inside a marked block.** objectstack's runner treats it as a
+ *      third assertion — a marker is the author's claim "this compiles", and
+ *      every property access on an `any` proves nothing. Worth porting; it is a
+ *      new assertion rather than the convention, so it is recorded as a
+ *      follow-up.
+ *   3. **`.claude/skills/**`.** `check-skills-paths.mjs` scans it too
+ *      (objectui#7358 widened it there). This gate's root is the PUBLISHED
+ *      bundle, which is the governed surface objectui#7359 was filed about;
+ *      widening is a separate, visible edit with its own measurement — the
+ *      discipline that file's own "prefix allow-list is a decision, not an
+ *      accident" section records.
+ *   4. **Whether an eval's `must_contain` token is taught by the guides.** A
+ *      different oracle over a different corpus, discussed at length on
+ *      objectui#7359 and explicitly not this check.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+import {
+  compileSnippets,
+  deriveDeclaredDependencyPaths,
+  derivePackageTypePaths,
+} from './check-doc-snippet-types.mjs';
+import { isEntrypoint } from './invoked-as.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/**
+ * The prose roots this gate walks. One entry today: the PUBLISHED skill bundle.
+ *
+ * Stated here as a decision rather than left to be read off the walker, which is
+ * objectui#5174's finding restated — a reader had to open the collector to learn
+ * that "covered by default" meant "covered if the filename ends in `.mdx`". See
+ * "Deliberately NOT answered here" item 3 for why `.claude/skills` is not in it.
+ */
+export const SCAN_ROOTS = ['skills'];
+
+/** Fence languages compiled as TypeScript. */
+export const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
+
+/** Fence languages parsed as JSON. `jsonc` additionally tolerates comments. */
+export const JSON_FENCE_LANGUAGES = new Set(['json', 'jsonc']);
+
+/**
+ * The opt-in marker, spelled out. It lives in code rather than in the header for
+ * the reason `check-doc-snippet-types.mjs` gives for its own: a JavaScript block
+ * comment cannot carry these delimiters without a reader having to reconstruct
+ * them. Byte-for-byte identical to objectstack's, so the convention is one
+ * convention across the two repositories rather than two that look alike.
+ */
+export const MARKER = '<!-- os:check -->';
+
+/**
+ * This gate's exit codes, named so callers and tests can talk about them.
+ * `couldNotRun` is deliberately distinct from `examplesFailed`; see the header.
+ * The numbers are `check-doc-snippet-types.mjs`'s and
+ * `check-eager-closure-budget.mjs`'s — this repository's convention — and each
+ * gate names them for itself so that no gate's exit contract is a side effect of
+ * importing another one.
+ */
+export const EXIT_CODES = {
+  /** Every marked fence held up, the controls held, something was marked. */
+  verified: 0,
+  /** The gate RAN. A marked fence or a marker is at fault — a verdict was read. */
+  examplesFailed: 1,
+  /** The gate COULD NOT RUN. Nothing it printed is a verdict about a guide. */
+  couldNotRun: 2,
+};
+
+// ── Fence scanning ───────────────────────────────────────────────────────────
+
+/**
+ * ANY CommonMark-shaped opening code fence — every language, not just the ones
+ * this gate compiles or parses: up to three spaces of indent, a run of three or
+ * more backticks, and an info string that cannot itself contain a backtick.
+ */
+const ANY_FENCE_OPEN_RE = /^ {0,3}(`{3,})([^`]*)$/;
+
+/** A closing fence: indent, at least as long a backtick run, nothing else. */
+const FENCE_CLOSE_RE = /^ {0,3}(`{3,})[ \t]*$/;
+
+/**
+ * Which TOP-LEVEL fenced block owns each line — of ANY language, spanning both
+ * the opening and closing fence lines. `owners[i]` is the index of the line that
+ * OPENED the block, or `-1` for a line at true top level; a line that opens a
+ * top-level fence owns itself, which is what makes this one array answer both of
+ * this file's questions:
+ *
+ *   - "is this marker at top level?"    `owners[m] === -1`
+ *   - "does this line open a fence?"    `owners[i] === i`
+ *
+ * `closeOf` carries each opener's closing line, so the body's end is read from
+ * the same walk that decided the fence opened — never from a second, looser
+ * closer re-derived at the extraction site. An unclosed fence runs to END OF
+ * FILE per CommonMark, and `closeOf` records `lines.length` for it: one past the
+ * last line, so the body slice reaches the end instead of dropping it. The two
+ * cases have to be distinguishable, because "closed on the last line" and "never
+ * closed" differ by exactly that line.
+ */
+export function fenceSpans(lines) {
+  const owners = new Array(lines.length).fill(-1);
+  const closeOf = new Map();
+  let i = 0;
+  while (i < lines.length) {
+    const open = ANY_FENCE_OPEN_RE.exec(lines[i]);
+    if (!open) {
+      i += 1;
+      continue;
+    }
+    const ticks = open[1];
+    let close = -1;
+    for (let j = i + 1; j < lines.length; j++) {
+      const c = FENCE_CLOSE_RE.exec(lines[j]);
+      if (c && c[1].length >= ticks.length) {
+        close = j;
+        break;
+      }
+    }
+    const end = close === -1 ? lines.length : close;
+    for (let k = i; k <= end && k < lines.length; k++) owners[k] = i;
+    closeOf.set(i, end);
+    i = end + 1;
+  }
+  return { owners, closeOf };
+}
+
+/**
+ * Every candidate fence in one document, plus every orphan marker.
+ *
+ * A candidate is a TOP-LEVEL fence whose language this gate can judge. `marked`
+ * is true when the line immediately above the fence-open line is exactly the
+ * marker (ignoring surrounding whitespace) and is itself at top level.
+ *
+ * An orphan is a top-level marker line that did not opt a candidate in — a
+ * marker above a blank line, above prose, above a ```bash fence, or left behind
+ * by a deleted example. A marker inside another fence is example text and is
+ * neither: see the header.
+ *
+ * CRLF is normalised on the way in, so no regex here has to decide whether `\s`
+ * should match a carriage return.
+ */
+export function scanSkillFences(source) {
+  const lines = source.replace(/\r\n/g, '\n').split('\n');
+  const { owners, closeOf } = fenceSpans(lines);
+
+  const fences = [];
+  const claimed = new Set();
+  for (let i = 0; i < lines.length; i++) {
+    if (owners[i] !== i) continue; // not a top-level fence opener
+    const open = ANY_FENCE_OPEN_RE.exec(lines[i]);
+    if (!open) continue;
+    const language = (open[2].trim().split(/\s+/)[0] || '').toLowerCase();
+    const kind = TS_FENCE_LANGUAGES.has(language)
+      ? 'ts'
+      : JSON_FENCE_LANGUAGES.has(language)
+        ? 'json'
+        : null;
+    if (kind === null) continue;
+
+    const markerLine = i - 1;
+    const marked =
+      markerLine >= 0 && owners[markerLine] === -1 && lines[markerLine].trim() === MARKER;
+    if (marked) claimed.add(markerLine);
+
+    const close = closeOf.get(i) ?? lines.length;
+    fences.push({
+      kind,
+      language,
+      /** 1-based line of the fence-open line itself. */
+      fenceLine: i + 1,
+      body: lines.slice(i + 1, close).join('\n'),
+      marked,
+    });
+  }
+
+  const orphans = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (owners[i] !== -1) continue; // example text inside another fence
+    if (lines[i].trim() !== MARKER) continue;
+    if (!claimed.has(i)) orphans.push(i + 1); // 1-based
+  }
+
+  return { fences, orphans };
+}
+
+/** Every guide in the scan set, repo-relative, in a stable order. */
+export function listGuides(root = repoRoot) {
+  const out = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir).sort()) {
+      const p = join(dir, entry);
+      if (statSync(p).isDirectory()) walk(p);
+      else if (entry.endsWith('.md')) out.push(relative(root, p).split(sep).join('/'));
+    }
+  };
+  for (const rootName of SCAN_ROOTS) {
+    const dir = join(root, rootName);
+    if (existsSync(dir)) walk(dir);
+  }
+  return out;
+}
+
+// ── JSON fences ──────────────────────────────────────────────────────────────
+
+/**
+ * `source` with `//` and block comments blanked, outside string literals.
+ *
+ * Only used for `jsonc`. Written as a scanner rather than a regex because a
+ * regex cannot tell a `//` inside `"https://..."` from a comment — and a URL in
+ * a `json` example is not hypothetical.
+ */
+export function stripJsonComments(source) {
+  let out = '';
+  let i = 0;
+  let inString = false;
+  while (i < source.length) {
+    const c = source[i];
+    if (inString) {
+      out += c;
+      if (c === '\\' && i + 1 < source.length) {
+        out += source[i + 1];
+        i += 2;
+        continue;
+      }
+      if (c === '"') inString = false;
+      i += 1;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === '/' && source[i + 1] === '/') {
+      while (i < source.length && source[i] !== '\n') i += 1;
+      continue;
+    }
+    if (c === '/' && source[i + 1] === '*') {
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        if (source[i] === '\n') out += '\n'; // keep line numbers honest
+        i += 1;
+      }
+      i += 2;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
+/** `source` with trailing commas before `}` / `]` removed. `jsonc` only. */
+function stripTrailingCommas(source) {
+  return source.replace(/,(?=\s*[}\]])/g, '');
+}
+
+/**
+ * Parse one marked JSON fence. Returns `null` when it parses, or the parser's
+ * own message when it does not.
+ *
+ * `json` is parsed STRICTLY — `JSON.parse` and nothing else — because a `json`
+ * fence in a guide is a claim about what a real `.json` file may contain, and a
+ * tolerant parser here would bless a file no `JSON.parse` in the product would
+ * accept. `jsonc` gets comments and trailing commas removed first, and nothing
+ * else: that is the whole of what the `jsonc` dialect adds over `json` for the
+ * shapes a guide writes. There are zero `jsonc` fences in the corpus today; the
+ * language is recognised so that adding one is not a silent no-op.
+ */
+export function parseJsonFence(body, language) {
+  const text = language === 'jsonc' ? stripTrailingCommas(stripJsonComments(body)) : body;
+  try {
+    JSON.parse(text);
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+// ── Collection ───────────────────────────────────────────────────────────────
+
+/** Workspace package specifiers a block imports (bare specifier root only). */
+function importedSpecifiers(body) {
+  const out = new Set();
+  const patterns = [
+    /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/g,
+    /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+  for (const re of patterns) {
+    let m;
+    while ((m = re.exec(body)) !== null) out.add(m[1]);
+  }
+  return out;
+}
+
+/**
+ * Everything this run knows before any compiler is started.
+ *
+ * `measure: true` treats EVERY candidate fence as opted in. That is the
+ * measurement mode behind step 2 of objectui#7359, and it is the only difference
+ * between the two modes — one predicate, so a fence cannot be measured under one
+ * set of rules and gated under another.
+ */
+export function analyze({ root = repoRoot, measure = false } = {}) {
+  const guides = listGuides(root);
+  const scans = new Map();
+  for (const guide of guides) {
+    scans.set(guide, scanSkillFences(readFileSync(join(root, guide), 'utf8')));
+  }
+
+  const findings = [];
+  const candidates = [];
+  for (const guide of guides) {
+    const { fences, orphans } = scans.get(guide);
+    for (const line of orphans) {
+      findings.push({
+        reason: 'orphan-marker',
+        site: `${guide}:${line}`,
+        detail:
+          `\`${MARKER}\` must be the line IMMEDIATELY above a ts/tsx/typescript/json/jsonc fence. ` +
+          'Here it opts nothing in, so the example below it is unchecked while reading as gated.',
+      });
+    }
+    for (const fence of fences) {
+      candidates.push({ doc: guide, ...fence, selected: measure || fence.marked });
+    }
+  }
+
+  const selected = candidates.filter((c) => c.selected);
+  const tsBlocks = selected.filter((c) => c.kind === 'ts');
+  const jsonBlocks = selected.filter((c) => c.kind === 'json');
+
+  // ── the packages those blocks import must be BUILT ────────────────────────
+  const { paths, packageDirOf, sourceTyped } = derivePackageTypePaths(root);
+  const neededPackages = new Set();
+  for (const block of tsBlocks) {
+    for (const specifier of importedSpecifiers(block.body)) {
+      const owner = Object.keys(packageDirOf).find(
+        (name) => specifier === name || specifier.startsWith(`${name}/`),
+      );
+      if (owner) neededPackages.add(owner);
+    }
+  }
+  for (const name of [...neededPackages].sort()) {
+    if (sourceTyped[name]) {
+      findings.push({
+        reason: 'source-typed-package',
+        site: packageDirOf[name],
+        detail: `${name} declares its types at ${sourceTyped[name]} — source, not a built artifact. A marked example may not be judged against it.`,
+      });
+      continue;
+    }
+    const entry = paths[name];
+    if (!entry || !existsSync(entry[0])) {
+      findings.push({
+        reason: 'unbuilt-package',
+        site: packageDirOf[name],
+        detail: `${name} declares types at ${entry ? relative(root, entry[0]) : '(none)'} and it is not on disk — run the build first`,
+      });
+    }
+  }
+
+  const {
+    paths: dependencyPaths,
+    untyped: untypedDependencies,
+    declared: declaredSpecifiers,
+  } = deriveDeclaredDependencyPaths(root, neededPackages, packageDirOf);
+  // Workspace entries win every collision, exactly as in the docs gate.
+  const mergedPaths = { ...dependencyPaths, ...paths };
+
+  // Bare specifiers the selected fences import that NOTHING in the map covers.
+  // See `unmappedSpecifiers` in the header: these are the ones that resolve, if
+  // at all, out of the repository root's own `node_modules`, so naming them in
+  // every run is what keeps a green honest about what backed it.
+  const mapped = new Set(Object.keys(mergedPaths));
+  const unmappedSpecifiers = new Set();
+  for (const block of tsBlocks) {
+    for (const specifier of importedSpecifiers(block.body)) {
+      if (specifier.startsWith('.') || specifier.startsWith('/')) continue;
+      const root2 = specifier.startsWith('@') ? specifier.split('/').slice(0, 2).join('/') : specifier.split('/')[0];
+      if (mapped.has(root2) || mapped.has(specifier)) continue;
+      unmappedSpecifiers.add(root2);
+    }
+  }
+
+  return {
+    unmappedSpecifiers,
+    guides,
+    scans,
+    candidates,
+    tsBlocks,
+    jsonBlocks,
+    findings,
+    paths: mergedPaths,
+    dependencyPaths,
+    untypedDependencies,
+    declaredSpecifiers,
+    neededPackages,
+  };
+}
+
+/**
+ * The findings that stop the program from being built at all, so no verdict
+ * about any guide can be read from the run. Kept apart from the findings that
+ * ARE verdicts (an orphan marker) because the two leave through different exit
+ * codes.
+ */
+export function blockingPreconditions(findings) {
+  return findings.filter((f) => f.reason === 'unbuilt-package' || f.reason === 'source-typed-package');
+}
+
+/**
+ * The filter arguments naming the packages the selected fences import, each
+ * carrying pnpm/turbo's DEPENDENCY-CLOSURE suffix `...`. Identical in shape and
+ * in reasoning to `check-doc-snippet-types.mjs`'s `buildFilterArgs`: the set this
+ * gate computes is the packages the GUIDES import, which is not a buildable unit
+ * on its own, and emitting bare names left that gap to be closed by accident by
+ * whichever tool the reader reached for.
+ */
+export function buildFilterArgs(packages) {
+  return [...packages]
+    .sort()
+    .map((n) => `--filter=${n}...`)
+    .join(' ');
+}
+
+// ── Reporting ────────────────────────────────────────────────────────────────
+
+function formatDiagnostic(diagnostic, block) {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+  if (diagnostic.file && typeof diagnostic.start === 'number') {
+    const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+    // The block body starts on the line after its fence.
+    return `${block.doc}:${block.fenceLine + 1 + line}:${character + 1}  TS${diagnostic.code}: ${message}`;
+  }
+  return `${block.doc}:${block.fenceLine}  TS${diagnostic.code}: ${message}`;
+}
+
+/**
+ * Read the shared harness's controls. The harness is
+ * `check-doc-snippet-types.mjs`'s; the READING is local, so this gate's exit
+ * contract is its own rather than a side effect of importing another gate.
+ *
+ * Returns the lines to print (a control that is not printed cannot be audited)
+ * and the failures. Any failure means the harness is broken, which is a verdict
+ * about the harness and never about a guide — so it leaves through
+ * `couldNotRun`.
+ */
+export function evaluateControls(run) {
+  const lines = [];
+  const failures = [];
+
+  lines.push(`  resolution   resolved to '${run.resolvedFileName ?? '(unresolved)'}'`);
+  if (!run.resolvedFileName || !/[\\/]dist[\\/].*\.d\.ts$/.test(run.resolvedFileName)) {
+    failures.push(
+      `resolution did not land on a built artifact (${run.resolvedFileName ?? 'unresolved'}) — the examples would be judged against source, or against nothing`,
+    );
+  }
+  if (run.srcLeaks.length > 0) {
+    failures.push(
+      `${run.srcLeaks.length} source file(s) under a package's src/ entered the program, e.g. ${run.srcLeaks[0]}`,
+    );
+  }
+
+  const sentinelCodes = run.sentinelDiagnostics.map((d) => d.code);
+  lines.push(
+    `  sentinel     a planted missing export produced ${run.sentinelDiagnostics.length} diagnostic(s)${sentinelCodes.length ? ` (TS${sentinelCodes.join(', TS')})` : ''}`,
+  );
+  if (!sentinelCodes.includes(2305)) {
+    failures.push(
+      "the planted sentinel produced no TS2305 — the program is resolving everything to 'any' and would report green forever",
+    );
+  }
+
+  lines.push(`  positive     a real export produced ${run.positiveDiagnostics.length} diagnostic(s)`);
+  if (run.positiveDiagnostics.length > 0) {
+    failures.push(
+      `the positive control failed (${ts.flattenDiagnosticMessageText(run.positiveDiagnostics[0].messageText, ' ')}) — the harness is broken, not the guides`,
+    );
+  }
+
+  const undeclaredCodes = run.undeclaredDiagnostics.map((d) => d.code);
+  lines.push(
+    `  undeclared   a specifier no imported package declares (installed at ${run.undeclaredInstalledAt ?? '(NOT INSTALLED)'}) produced ${run.undeclaredDiagnostics.length} diagnostic(s)${undeclaredCodes.length ? ` (TS${undeclaredCodes.join(', TS')})` : ''}`,
+  );
+  if (run.undeclaredDeclared) {
+    failures.push(
+      'the undeclared control specifier is now a DECLARED dependency of an imported package, so it can no longer show that resolution stayed narrow — pick another',
+    );
+  } else if (!run.undeclaredInstalledAt) {
+    failures.push(
+      'the undeclared control specifier is not installed, so its failure to resolve proves nothing about how far resolution reaches — pick another',
+    );
+  } else if (!undeclaredCodes.includes(2307)) {
+    failures.push(
+      'a specifier NO imported package declares now resolves — third-party resolution has widened past the imported packages\' own dependencies, and every guide would stay green while it does',
+    );
+  }
+
+  return { lines, failures };
+}
+
+/**
+ * Judge the selected fences. Returns everything the caller needs to print a
+ * verdict, with the type-check and JSON halves kept apart.
+ */
+export function judge(state) {
+  const run = compileSnippets({
+    root: repoRoot,
+    compiled: state.tsBlocks,
+    paths: state.paths,
+    declaredSpecifiers: state.declaredSpecifiers,
+  });
+
+  const failedTs = new Set();
+  for (const { block } of run.parseFailures) failedTs.add(block);
+  for (const { block } of run.semanticFailures) failedTs.add(block);
+
+  const jsonFailures = [];
+  for (const block of state.jsonBlocks) {
+    const message = parseJsonFence(block.body, block.language);
+    if (message !== null) jsonFailures.push({ block, message });
+  }
+
+  return { run, failedTs, jsonFailures };
+}
+
+// ── The run ──────────────────────────────────────────────────────────────────
+
+function main() {
+  const argv = process.argv.slice(2);
+  const measure = argv.includes('--measure');
+  const state = analyze({ root: repoRoot, measure });
+
+  if (argv.includes('--build-filter')) {
+    // ⛔ This query answers from an UNBUILT tree by design and must keep exiting
+    // 0 there: it is what the workflow runs to learn what to build, one step
+    // BEFORE the build. Sharing the precondition exit would deadlock the gate
+    // against its own build step (the reasoning, and the wording, are
+    // `check-doc-snippet-types.mjs`'s).
+    process.stdout.write(`${buildFilterArgs(state.neededPackages)}\n`);
+    return EXIT_CODES.verified;
+  }
+
+  const marked = state.candidates.filter((c) => c.marked);
+
+  // ── the anti-idle floor, checked before anything expensive ────────────────
+  // A gate that checks nothing must not report success. Under `--measure` the
+  // selected population is every candidate, so the floor is about that instead.
+  if (!measure && marked.length === 0) {
+    console.error(
+      `No fence under ${SCAN_ROOTS.join(', ')} carries \`${MARKER}\`, so this run judged nothing.`,
+    );
+    console.error(
+      `\nPRECONDITION NOT MET (exit ${EXIT_CODES.couldNotRun}) — the marked population is EMPTY. ` +
+        'This is "I could not run", NOT "I ran and everything held up": a gate that checks nothing ' +
+        'must not report success (objectui#4846). Either the markers were removed, or this gate is ' +
+        'reading the wrong root — see SCAN_ROOTS in this script.',
+    );
+    return EXIT_CODES.couldNotRun;
+  }
+
+  const blocking = blockingPreconditions(state.findings);
+  if (blocking.length > 0) {
+    for (const f of state.findings) console.error(`  ${f.site}  [${f.reason}]  ${f.detail}`);
+    console.error(
+      `\nPRECONDITION NOT MET (exit ${EXIT_CODES.couldNotRun}) — the example program was NOT run: ` +
+        'the packages it resolves against are not built, or are typed from source.',
+    );
+    console.error(
+      `This is "I could not run", NOT "I ran and found errors" (exit ${EXIT_CODES.examplesFailed}). ` +
+        'No line above is a verdict about any guide. Build what the gate needs, then re-run:',
+    );
+    console.error(
+      '  pnpm exec turbo run build $(node scripts/check-skill-examples.mjs --build-filter) --concurrency=2\n' +
+        '  pnpm check:skill-examples',
+    );
+    return EXIT_CODES.couldNotRun;
+  }
+
+  const { run, failedTs, jsonFailures } = judge(state);
+
+  const { lines: controlLines, failures: controlFailures } = evaluateControls(run);
+  console.log(
+    `Third-party resolution: ${Object.keys(state.dependencyPaths).length} specifier(s) mapped from the declared dependencies of ${state.neededPackages.size} imported package(s); ${state.untypedDependencies.length} declared specifier(s) ship no types here and stay unresolvable.`,
+  );
+  console.log(
+    state.unmappedSpecifiers.size === 0
+      ? 'Unmapped specifiers: none — every bare import of a selected fence is covered by the map above.'
+      : `Unmapped specifiers (resolve, if at all, from the repository ROOT's own node_modules — this workspace's devDependency set, NOT what a reader of the guide installs): ${[...state.unmappedSpecifiers].sort().join(', ')}`,
+  );
+  console.log('Controls:');
+  for (const line of controlLines) console.log(line);
+  console.log('');
+
+  if (argv.includes('--list') || measure) {
+    for (const block of state.candidates) {
+      let verdict;
+      if (!block.selected) verdict = 'unmarked — ignored';
+      else if (block.kind === 'json')
+        verdict = jsonFailures.some((f) => f.block === block) ? 'FAIL' : 'pass';
+      else verdict = failedTs.has(block) ? 'FAIL' : 'pass';
+      console.log(
+        `  ${block.doc}:${block.fenceLine}  [${block.language}]  ${block.marked ? 'marked' : '      '}  ${verdict}`,
+      );
+    }
+    console.log('');
+  }
+
+  for (const f of state.findings) console.error(`  ${f.site}  [${f.reason}]  ${f.detail}`);
+  for (const { block, diagnostics } of run.parseFailures) {
+    for (const d of diagnostics) console.error(`  [syntax]    ${formatDiagnostic(d, block)}`);
+  }
+  for (const { block, diagnostics } of run.semanticFailures) {
+    for (const d of diagnostics) console.error(`  [semantic]  ${formatDiagnostic(d, block)}`);
+  }
+  for (const { block, message } of jsonFailures) {
+    console.error(`  [json]      ${block.doc}:${block.fenceLine}  ${message}`);
+  }
+
+  // ── the summary always states COVERAGE, never just a verdict ──────────────
+  const tsCandidates = state.candidates.filter((c) => c.kind === 'ts');
+  const jsonCandidates = state.candidates.filter((c) => c.kind === 'json');
+  const parseFailedBlocks = run.parseFailures.length;
+  console.log(
+    `Scanned ${state.guides.length} guide(s) under ${SCAN_ROOTS.join(', ')}: ` +
+      `${tsCandidates.length} ts/tsx/typescript fence(s), ${jsonCandidates.length} json/jsonc fence(s).`,
+  );
+  console.log(
+    measure
+      ? `MEASURE MODE: every candidate judged, marked or not — ${marked.length} of them carry the marker today.`
+      : `Marked: ${state.tsBlocks.length} ts fence(s) and ${state.jsonBlocks.length} json fence(s). Unmarked fences are ignored by design (opt-in).`,
+  );
+  console.log(
+    parseFailedBlocks === 0
+      ? 'Syntax phase:   every selected ts fence parsed, so every one of them reached the semantic phase.'
+      : `Syntax phase:   ${parseFailedBlocks} ts fence(s) failed to parse and were NOT semantically checked.`,
+  );
+  console.log(
+    `Semantic phase: ${run.semanticallyJudged} of ${state.tsBlocks.length} ts fence(s) judged, ${run.semanticFailures.length} failed.`,
+  );
+  console.log(
+    `JSON phase:     ${state.jsonBlocks.length} fence(s) parsed, ${jsonFailures.length} failed.`,
+  );
+  if (parseFailedBlocks > 0) {
+    console.log(
+      `NOTE: this run's semantic result covers ${run.semanticallyJudged} fence(s) only. A syntax failure is not a semantic pass.`,
+    );
+  }
+
+  if (measure) {
+    const tsPass = tsCandidates.length - [...failedTs].filter((b) => b.kind === 'ts').length;
+    const jsonPass = jsonCandidates.length - jsonFailures.length;
+    console.log(
+      `\nStarting population — ts: ${tsPass}/${tsCandidates.length} pass; json: ${jsonPass}/${jsonCandidates.length} pass.`,
+    );
+  }
+
+  if (controlFailures.length > 0) {
+    console.error('\nHARNESS CONTROL FAILED — no verdict about the guides can be read from this run:');
+    for (const c of controlFailures) console.error(`  - ${c}`);
+    console.error(
+      `\nThe gate COULD NOT RUN (exit ${EXIT_CODES.couldNotRun}). A broken harness is a verdict about ` +
+        'the harness, never about the guides.',
+    );
+    return EXIT_CODES.couldNotRun;
+  }
+
+  // `--measure` reports; it does not gate. It exists to produce the number the
+  // marker was landed on, and every candidate fence is selected in it, so its
+  // failures are the UNMARKED population by construction — a verdict about what
+  // is not yet opted in, which is not a defect.
+  if (measure) return EXIT_CODES.verified;
+
+  const failed =
+    state.findings.length > 0 ||
+    parseFailedBlocks > 0 ||
+    run.semanticFailures.length > 0 ||
+    jsonFailures.length > 0;
+
+  if (failed) {
+    console.error(
+      `\nA marked example in ${SCAN_ROOTS.join(', ')} no longer holds up. Fix the example, or — if it ` +
+        'was never meant to compile on its own — remove its marker rather than weakening this gate.',
+    );
+    return EXIT_CODES.examplesFailed;
+  }
+  console.log('\nEvery marked skill example holds up against the built types.');
+  return EXIT_CODES.verified;
+}
+
+// ── Self-test ────────────────────────────────────────────────────────────────
+
+/**
+ * The marker convention, pinned in BOTH directions on fixtures rather than on
+ * the real guides. A committed fixture guide would have to contain a
+ * deliberately broken example, and something else in this repository would
+ * eventually scan it — the reasoning `check-skills-paths.test.ts` states for its
+ * own throwaway trees.
+ *
+ * The four cases objectui#7359 asks for are all here, and each one is a
+ * direction this gate could fail in silently:
+ *
+ *   - a marked fence that HOLDS UP must pass (a harness broken the other way
+ *     reds every guide at once and reads as "the guides are full of defects");
+ *   - a marked fence that is BROKEN must fail (without it the gate is a rubber
+ *     stamp);
+ *   - a marker NOT adjacent to a fence must be reported (the stale-marker case:
+ *     lenient adjacency opts in nothing while the author believes otherwise);
+ *   - an UNMARKED broken fence must be ignored (opt-in is the whole design; if
+ *     this leaks the gate reds on day one on prose that is not wrong).
+ *
+ * Plus the two the design turns on and nobody would think to write down: a
+ * marker shown as EXAMPLE TEXT inside another fence claims nothing and is not an
+ * orphan either, and a marker above a ```bash fence IS an orphan.
+ */
+export function selfTest() {
+  const cases = [];
+  const t = (name, ok, detail) => cases.push({ name, ok: Boolean(ok), detail });
+
+  // ── scanner: what a marker opts in ────────────────────────────────────────
+  const guide = [
+    '# Guide',
+    '',
+    MARKER,
+    '```typescript',
+    "export const one: number = 1;",
+    '```',
+    '',
+    '```typescript',
+    'const broken: number = "not a number";',
+    '```',
+    '',
+    MARKER,
+    '',
+    '```typescript',
+    'export const two = 2;',
+    '```',
+    '',
+    MARKER,
+    '```bash',
+    'pnpm install',
+    '```',
+    '',
+    MARKER,
+    '```json',
+    '{ "ok": true }',
+    '```',
+    '',
+    '````markdown',
+    MARKER,
+    '```typescript',
+    'this is an illustration, not an example',
+    '```',
+    '````',
+    '',
+  ].join('\n');
+
+  const scan = scanSkillFences(guide);
+  const marked = scan.fences.filter((f) => f.marked);
+  t('a marker directly above a fence opts exactly that fence in', marked.length === 2, JSON.stringify(marked.map((f) => f.fenceLine)));
+  t('the opted-in ts fence is the FIRST one, not the unmarked broken one', marked.some((f) => f.kind === 'ts' && f.body.includes('export const one')));
+  t('the opted-in json fence is recognised as json', marked.some((f) => f.kind === 'json' && f.language === 'json'));
+  t('an unmarked broken fence is a candidate but NOT selected', scan.fences.some((f) => !f.marked && f.body.includes('not a number')));
+  t(
+    'a marker separated from its fence by a blank line is an ORPHAN',
+    scan.orphans.includes(12),
+    `orphans=${JSON.stringify(scan.orphans)}`,
+  );
+  t('a marker above a ```bash fence is an ORPHAN', scan.orphans.includes(18), `orphans=${JSON.stringify(scan.orphans)}`);
+  t(
+    'a marker shown as example text inside another fence is neither opt-in nor orphan',
+    scan.orphans.length === 2 && !scan.fences.some((f) => f.body.includes('illustration')),
+    `orphans=${JSON.stringify(scan.orphans)} fences=${scan.fences.length}`,
+  );
+
+  // ── an unclosed fence must not swallow the rest of the file ───────────────
+  const unclosed = scanSkillFences(['```typescript', 'const a = 1;', '', '# still inside, per CommonMark'].join('\n'));
+  t('an unclosed fence runs to end of file rather than throwing', unclosed.fences.length === 1, JSON.stringify(unclosed.fences.map((f) => f.fenceLine)));
+
+  // ── JSON fences ──────────────────────────────────────────────────────────
+  t('valid json parses', parseJsonFence('{"a": 1}', 'json') === null);
+  t('a trailing comma fails under `json`', parseJsonFence('{"a": 1,}', 'json') !== null);
+  t('a comment fails under `json`', parseJsonFence('{\n  // nope\n  "a": 1\n}', 'json') !== null);
+  t('a trailing comma passes under `jsonc`', parseJsonFence('{"a": 1,}', 'jsonc') === null);
+  t('a comment passes under `jsonc`', parseJsonFence('{\n  // fine\n  "a": 1\n}', 'jsonc') === null);
+  t(
+    'a `//` inside a string is not a comment',
+    parseJsonFence('{"url": "https://example.com/x"}', 'jsonc') === null,
+  );
+  t('a truncated object fails', parseJsonFence('{"a": 1', 'json') !== null);
+
+  // ── the type-check half, through the REAL harness ─────────────────────────
+  // Two fixture blocks that need no package types at all, so this leg measures
+  // the harness rather than the workspace. The CONTROLS still need the built
+  // tree; when it is not built they fail, and that is reported as PRECONDITION
+  // NOT MET rather than as a passing or failing self-test — the same rule the
+  // real run follows.
+  const holds = { doc: 'fixture/holds.md', fenceLine: 1, kind: 'ts', body: 'export const one: number = 1;\n' };
+  const broken = { doc: 'fixture/broken.md', fenceLine: 1, kind: 'ts', body: 'export const two: number = "no";\n' };
+  const unparseable = { doc: 'fixture/unparseable.md', fenceLine: 1, kind: 'ts', body: 'export const three: = ;\n' };
+  const state = analyze({ root: repoRoot, measure: false });
+  const blocking = blockingPreconditions(state.findings);
+  const run = compileSnippets({
+    root: repoRoot,
+    compiled: [holds, broken, unparseable],
+    paths: state.paths,
+    declaredSpecifiers: state.declaredSpecifiers,
+  });
+  const { failures: controlFailures } = evaluateControls(run);
+
+  if (blocking.length > 0 || controlFailures.length > 0) {
+    for (const f of blocking) console.error(`  ${f.site}  [${f.reason}]  ${f.detail}`);
+    for (const c of controlFailures) console.error(`  - ${c}`);
+    console.error(
+      `\nPRECONDITION NOT MET (exit ${EXIT_CODES.couldNotRun}) — the self-test's type-check leg needs ` +
+        'the workspace built, and this tree is not. The scanner cases above did run; the compiler ' +
+        'cases did NOT, and a self-test that quietly skipped them would be the exact silent-green ' +
+        'this gate exists to prevent. Build, then re-run:',
+    );
+    console.error(
+      '  pnpm exec turbo run build $(node scripts/check-skill-examples.mjs --build-filter) --concurrency=2\n' +
+        '  node scripts/check-skill-examples.mjs --self-test',
+    );
+    for (const c of cases.filter((c2) => !c2.ok)) console.error(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+    return EXIT_CODES.couldNotRun;
+  }
+
+  const semanticallyFailed = new Set(run.semanticFailures.map((f) => f.block));
+  const parseFailed = new Set(run.parseFailures.map((f) => f.block));
+  t('a marked fence that holds up is CLEAN', !semanticallyFailed.has(holds) && !parseFailed.has(holds));
+  t('a marked fence with a type error is RED', semanticallyFailed.has(broken));
+  t('a marked fence that does not parse is a SYNTAX failure, never a skip', parseFailed.has(unparseable));
+  t(
+    'one unparseable fence does not blind the semantic phase for the rest',
+    run.semanticallyJudged === 2,
+    `semanticallyJudged=${run.semanticallyJudged}`,
+  );
+
+  const failed = cases.filter((c) => !c.ok);
+  for (const c of failed) console.error(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+  if (failed.length) {
+    console.error(`✗ check-skill-examples self-test: ${failed.length} of ${cases.length} case(s) failed.`);
+    return EXIT_CODES.examplesFailed;
+  }
+  console.log(
+    `✓ check-skill-examples self-test: ${cases.length} cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, and the compiler legs through the real harness).`,
+  );
+  return EXIT_CODES.verified;
+}
+
+if (isEntrypoint(import.meta.url)) {
+  process.exit(process.argv.includes('--self-test') ? selfTest() : main());
+}
+
+export { main };

--- a/scripts/dependabot-merge-gate.mjs
+++ b/scripts/dependabot-merge-gate.mjs
@@ -122,6 +122,7 @@ import { isEntrypoint } from './invoked-as.mjs';
  *   control-bytes.yml Control Byte Scan
  *   docs-links.yml    Internal Docs Link Check
  *   skills-paths.yml  Skill Guide Path Check
+ *   skill-examples.yml  Skill Example Check
  *   changeset-presence.yml   Changeset Declaration
  *   doc-component-types.yml  Doc Component Type Check
  *   doc-snippet-types.yml    Doc Snippet Type Check
@@ -162,6 +163,7 @@ export const REQUIRED_CONTEXTS = Object.freeze([
   'Control Byte Scan',
   'Internal Docs Link Check',
   'Skill Guide Path Check',
+  'Skill Example Check',
   'Changeset Declaration',
   'Doc Component Type Check',
   'Doc Snippet Type Check',

--- a/skills/objectui/SKILL.md
+++ b/skills/objectui/SKILL.md
@@ -84,6 +84,7 @@ styles can be overridden from JSON.
 
 Actions are data, not functions:
 
+<!-- os:check -->
 ```json
 {
   "events": {

--- a/skills/objectui/guides/auth-permissions.md
+++ b/skills/objectui/guides/auth-permissions.md
@@ -55,6 +55,7 @@ function UserBadge() {
 
 ### AuthUser type
 
+<!-- os:check -->
 ```typescript
 interface AuthUser {
   id: string;
@@ -249,6 +250,7 @@ function AdminPanel() {
 
 Combine permissions with expression-based visibility:
 
+<!-- os:check -->
 ```json
 {
   "type": "button",
@@ -273,6 +275,7 @@ const dataSource = {
 ```
 
 Then in schema — note the `data.` root:
+<!-- os:check -->
 ```json
 {
   "type": "button",

--- a/skills/objectui/guides/data-integration.md
+++ b/skills/objectui/guides/data-integration.md
@@ -77,6 +77,7 @@ interface QueryParams {
 
 ### QueryResult
 
+<!-- os:check -->
 ```typescript
 interface QueryResult<T = any> {
   data: T[];                      // Returned data array — required, and NOT named `records`
@@ -185,6 +186,7 @@ adapter.onBatchProgress((event) => {
 
 A component reads the `bind` field only if it calls `useDataScope`:
 
+<!-- os:check -->
 ```json
 {
   "type": "list",
@@ -211,6 +213,7 @@ node**, as below. The one spelling that does carry a provider expression
 through is measured, with its open-question caveat, in
 [`../rules/protocol.md`](../rules/protocol.md).
 
+<!-- os:check -->
 ```json
 {
   "type": "data-table",
@@ -231,6 +234,7 @@ Computed values go through the expression system. `content` is the text key that
 is both expression-evaluated and read back by the renderer, and the provider's
 `dataSource` is reachable under the `data` root:
 
+<!-- os:check -->
 ```json
 {
   "type": "card",
@@ -245,6 +249,7 @@ A `statistic` declares `label` / `value` / `description` as expression-bindable
 (objectui#4795), so these are evaluated on the node and read back. Host-resolved
 literals work exactly as before:
 
+<!-- os:check -->
 ```json
 {
   "type": "statistic",
@@ -265,6 +270,7 @@ different envelope and behaves differently; see
 
 Plugin components that need CRUD operations access the DataSource from context:
 
+<!-- os:check -->
 ```typescript
 import { useSchemaContext } from '@object-ui/react';
 
@@ -343,6 +349,7 @@ bootstrap();
 
 ### Test DataSource helper
 
+<!-- os:check -->
 ```typescript
 import { ObjectStackAdapter } from '@object-ui/data-objectstack';
 
@@ -355,6 +362,7 @@ export function createTestDataSource() {
 
 If your backend isn't ObjectStack-compatible, implement the DataSource interface:
 
+<!-- os:check -->
 ```typescript
 import type { DataSource, QueryParams, QueryResult } from '@object-ui/types';
 

--- a/skills/objectui/guides/i18n.md
+++ b/skills/objectui/guides/i18n.md
@@ -35,6 +35,7 @@ The package includes translations for:
 
 ## useObjectTranslation hook
 
+<!-- os:check -->
 ```typescript
 import { useObjectTranslation } from '@object-ui/i18n';
 
@@ -135,6 +136,7 @@ const localizedSchema = {
 (`en`, `zh-CN`, `ja-JP`) or `default`. The renderer picks the entry for the active language
 at display time via `pickLocalized`, so there is no bundle key and no `t()` pass:
 
+<!-- os:check -->
 ```typescript
 const localizedSchema = {
   type: 'card',

--- a/skills/objectui/guides/mobile.md
+++ b/skills/objectui/guides/mobile.md
@@ -80,6 +80,7 @@ Mobile navigation is an **app-shell** concern, not a package export: set
 
 Use responsive column configurations in grid layouts:
 
+<!-- os:check -->
 ```json
 {
   "type": "grid",
@@ -103,6 +104,7 @@ Responsiveness".
 
 ## Mobile-first Tailwind classes in schemas
 
+<!-- os:check -->
 ```json
 {
   "type": "grid",

--- a/skills/objectui/guides/page-builder.md
+++ b/skills/objectui/guides/page-builder.md
@@ -33,6 +33,7 @@ When helping third-party apps, consume these packages; avoid duplicating core ru
 
 Use a strict component schema shape similar to:
 
+<!-- os:check -->
 ```json
 {
   "type": "card",
@@ -106,6 +107,7 @@ Keep custom component registrations namespaced to avoid collisions.
 
 Represent interactions as data where possible:
 
+<!-- os:check -->
 ```json
 {
   "events": {
@@ -169,6 +171,7 @@ page:
 **A `statistic` carries its own text keys**, so both static values and
 expressions work on the node (`statistic` declares `label` / `value` /
 `description`):
+<!-- os:check -->
 ```json
 {
   "type": "statistic",
@@ -181,6 +184,7 @@ expressions work on the node (`statistic` declares `label` / `value` /
 
 **A type that does not declare the key needs a `text` child**, because `content`
 is evaluated on every component type:
+<!-- os:check -->
 ```json
 {
   "type": "card",
@@ -212,6 +216,7 @@ renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
 `schema.gantt`) — the `props` envelope is not read here either.
 
 **Grid plugin example:**
+<!-- os:check -->
 ```json
 {
   "type": "object-grid",
@@ -232,6 +237,7 @@ renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
 > names no field, so `ObjectGrid` drops it.
 
 **Form plugin example:**
+<!-- os:check -->
 ```json
 {
   "type": "object-form",
@@ -245,6 +251,7 @@ renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
 ```
 
 **Kanban plugin example:**
+<!-- os:check -->
 ```json
 {
   "type": "kanban",
@@ -255,6 +262,7 @@ renderers do (`schema.objectName`, `schema.columns`, `schema.fields`,
 ```
 
 **Gantt plugin example:**
+<!-- os:check -->
 ```json
 {
   "type": "gantt",
@@ -279,6 +287,7 @@ carrying both renders the block and warns about the ignored top-level keys.
 Author the `gantt` block.
 
 Import plugins in your app entry point to trigger registration:
+<!-- os:check -->
 ```typescript
 import '@object-ui/plugin-grid';
 import '@object-ui/plugin-form';
@@ -306,6 +315,7 @@ For lazy loading, use `LazyPluginLoader` from `@object-ui/react` rather than top
 
 For host apps that need more than the raw renderer, prefer `@object-ui/app-shell`:
 
+<!-- os:check -->
 ```tsx
 import { AppShell, ObjectView, PageView, DashboardView } from '@object-ui/app-shell';
 ```

--- a/skills/objectui/guides/plugin-development.md
+++ b/skills/objectui/guides/plugin-development.md
@@ -88,6 +88,7 @@ Sixteen keys in total: the eleven on `ComponentMeta` (`@object-ui/types`
 
 ### ComponentInput types
 
+<!-- os:check -->
 ```typescript
 type ComponentInputControlType =
   | 'string' | 'number' | 'boolean' | 'enum' | 'array' | 'object'
@@ -232,6 +233,7 @@ export interface MyWidgetProps {
 
 Field widgets are simpler plugins that render form inputs. They implement `FieldWidgetComponentProps`:
 
+<!-- os:check -->
 ```typescript
 import { type FieldWidgetComponentProps } from '@object-ui/fields';
 import { Input } from '@object-ui/components';
@@ -321,6 +323,7 @@ double-displays it.
 
 ### package.json essentials
 
+<!-- os:check -->
 ```json
 {
   "name": "@object-ui/plugin-my-widget",
@@ -356,6 +359,7 @@ double-displays it.
 
 ### tsconfig.json
 
+<!-- os:check -->
 ```json
 {
   "extends": "../../tsconfig.react.json",

--- a/skills/objectui/guides/project-setup.md
+++ b/skills/objectui/guides/project-setup.md
@@ -30,6 +30,7 @@ Then configure the required files (see "Essential configuration files" below).
 
 ### package.json (minimum dependencies)
 
+<!-- os:check -->
 ```json
 {
   "dependencies": {
@@ -51,6 +52,7 @@ Then configure the required files (see "Essential configuration files" below).
 ```
 
 Add plugins as needed (full plugin catalog):
+<!-- os:check -->
 ```json
 {
   "@object-ui/plugin-grid": "latest",
@@ -76,6 +78,7 @@ Add plugins as needed (full plugin catalog):
 ```
 
 Opt-in platform packages (auth, i18n, mobile, realtime):
+<!-- os:check -->
 ```json
 {
   "@object-ui/auth": "latest",
@@ -87,6 +90,7 @@ Opt-in platform packages (auth, i18n, mobile, realtime):
 ```
 
 Embedding shell + provider stack into a third-party app:
+<!-- os:check -->
 ```json
 {
   "@object-ui/app-shell": "latest",
@@ -134,6 +138,7 @@ overriding the token values: [`rules/styling.md`](../rules/styling.md).
 
 ### tsconfig.json
 
+<!-- os:check -->
 ```json
 {
   "compilerOptions": {

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -178,21 +178,25 @@ The `On` variants accept raw expressions without `${}` wrapping — the entire s
 ### Visibility patterns
 
 **Role-based:**
+<!-- os:check -->
 ```json
 { "hidden": "${data.userRole !== 'admin'}" }
 ```
 
 **Status-based:**
+<!-- os:check -->
 ```json
 { "visible": "${data.record.status === 'active'}" }
 ```
 
 **Data-dependent:**
+<!-- os:check -->
 ```json
 { "hidden": "${!data.items || data.items.length === 0}" }
 ```
 
 **Combined conditions:**
+<!-- os:check -->
 ```json
 { "visibleOn": "data.isAuthenticated && data.permissions.canEdit" }
 ```
@@ -262,6 +266,7 @@ Three renderer-side facts that live nowhere else:
 The `bind` field is NOT expression-evaluated. It's a path string resolved by
 `useDataScope()` — and **only a component that calls that hook reads it**.
 
+<!-- os:check -->
 ```json
 {
   "type": "list",
@@ -289,6 +294,7 @@ it resolves nothing: the table renders its header over the "No results found"
 empty state. Nothing is thrown and nothing is logged — a table that looks built
 and is blank is the whole failure.
 
+<!-- os:check -->
 ```json
 {
   "type": "data-table",
@@ -495,6 +501,7 @@ the DOM as a locale-dependent blob.
 
 Expressions don't throw on missing variables — they return `undefined`. Use fallback patterns:
 
+<!-- os:check -->
 ```json
 { "type": "text", "content": "${data.user?.name || 'Unknown'}" }
 ```

--- a/skills/objectui/guides/testing.md
+++ b/skills/objectui/guides/testing.md
@@ -56,6 +56,7 @@ describe('plugin-kanban registration', () => {
 
 ### Pattern 3: Schema validation testing
 
+<!-- os:check -->
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { validateSchema, isValidSchema, formatValidationErrors } from '@object-ui/core';
@@ -86,6 +87,7 @@ describe('schema validation', () => {
 
 ### Pattern 4: Expression evaluation testing
 
+<!-- os:check -->
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { ExpressionEvaluator } from '@object-ui/core';
@@ -202,6 +204,7 @@ describe('AuthProvider', () => {
 
 ### Pattern 7: DataSource adapter testing
 
+<!-- os:check -->
 ```typescript
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ObjectStackAdapter } from '@object-ui/data-objectstack';
@@ -232,6 +235,7 @@ describe('ObjectStackAdapter', () => {
 
 ### Smoke test
 
+<!-- os:check -->
 ```typescript
 import { test, expect } from '@playwright/test';
 

--- a/skills/objectui/rules/composition.md
+++ b/skills/objectui/rules/composition.md
@@ -200,6 +200,7 @@ Parts: `EmptyHeader`, `EmptyMedia`, `EmptyTitle`, `EmptyDescription`,
 ## Rule: Toast via Sonner
 
 **✅ CORRECT:**
+<!-- os:check -->
 ```typescript
 import { toast } from 'sonner';
 

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -77,6 +77,7 @@ declaration rather than keeping its own copy.
 | `button` | `label` |
 
 **✅ CORRECT — a dashboard number that moves with the data:**
+<!-- os:check -->
 ```json
 {
   "type": "statistic",
@@ -102,6 +103,7 @@ renders an empty frame, and the envelope itself lands in the DOM as the invalid
 attribute `props="[object Object]"`.
 
 **❌ WRONG — renders an empty card:**
+<!-- os:check -->
 ```json
 {
   "type": "card",
@@ -110,6 +112,7 @@ attribute `props="[object Object]"`.
 ```
 
 **✅ CORRECT:**
+<!-- os:check -->
 ```json
 {
   "type": "card",
@@ -215,6 +218,7 @@ channel is objectui#4795's open question, not a taught surface.
 
 Events must be defined as arrays of action definitions:
 
+<!-- os:check -->
 ```json
 {
   "events": {
@@ -237,6 +241,7 @@ through the **same field-widget renderer the object form uses** — so any
 form-supported type (`select`, `lookup`, `date`, `file`, `image`, `richtext`,
 `color`, …) gets its real widget, never a text-box fallback (ADR-0059):
 
+<!-- os:check -->
 ```json
 {
   "name": "approve",
@@ -267,6 +272,7 @@ param support ⊇ form support).
 breakpoint object keyed `xs` / `sm` / `md` / `lg` / `xl` (`GridSchema` in
 `packages/types/src/layout.ts`):
 
+<!-- os:check -->
 ```json
 {
   "type": "grid",

--- a/skills/objectui/rules/styling.md
+++ b/skills/objectui/rules/styling.md
@@ -7,6 +7,7 @@
 ## Rule: Use Tailwind Utility Classes Only
 
 **✅ CORRECT:**
+<!-- os:check -->
 ```json
 {
   "type": "card",
@@ -135,6 +136,7 @@ are published as custom properties and consumed by the static utility pair above
 
 For component variations, use `class-variance-authority`:
 
+<!-- os:check -->
 ```typescript
 import { cva } from 'class-variance-authority';
 
@@ -177,6 +179,7 @@ const buttonVariants = cva(
 
 Use Tailwind's responsive prefixes in schemas:
 
+<!-- os:check -->
 ```json
 {
   "type": "grid",


### PR DESCRIPTION
Fixes #7359

Nothing in this repository read inside a code fence under `skills/`. At the branch point, `skills/objectui/` carried **112** `ts`/`tsx`/`typescript` fences and **56** `json` fences, and `os:check` occurred **0** times. Every gate that could have reached them is scoped elsewhere by construction — `check-skills-paths.mjs` deliberately reads inline code spans in prose only ("a fence is a worked example"), `check-doc-links.mjs` has no `skills` row in `SCAN_ROOTS`, and the three `content/docs` gates say so in their own headers. So a fence could import a symbol that does not exist and stay green forever, and two rounds of exactly that had already been cleaned by hand.

This ports objectstack's opt-in marker convention from `packages/spec/scripts/check-skill-examples.ts`, adds an objectui runner, wires it into CI, and lands the marker on exactly the fences that already hold up.

Branch point: `75e7436`. Head at the readings below: `70fdb0e`.

## Design

**The marker, and adjacency.** A fence is checked only when the line **immediately above** it is the marker: an HTML comment whose entire content is `os:check`. (The exact spelling is `MARKER` in `scripts/check-skill-examples.mjs` and is not reproduced in this body — GitHub's body sanitizer eats angle-bracket fragments, backticked ones included.) Two properties make that spelling the right one, both inherited from objectstack's reasoning: it renders to nothing, and it leaves the fence info string a bare ` ```typescript `, so the three gates in this repo that key on the info string still see the block. A fence-meta tag like ` ```ts check ` would have punched a hole in every one of them.

Adjacency is **strict** — not "the nearest non-blank line above". A marker anywhere else is an **orphan** and fails the run. This is the one rule where lenience costs everything: a marker separated from its fence by a blank line, or left behind when its example was rewritten, opts in *nothing* while its author believes their example is gated. That is this repository's recurring "looks like enforcement, isn't" class (#3009, #3181, #3494, #4846, #7115).

**Fence-awareness.** A marker that sits inside some *other* fenced block — a ```` ```markdown ```` illustration of the convention — is at once not an opt-in and not an orphan: it is not at top level, so it claims nothing. One walk (`fenceSpans`) answers both "is this marker at top level?" and "does this line open a fence?", and it also supplies each fence's **closing** line, so the body's end is decided by exactly the predicate that decided it opened. objectstack measured a second, looser closer disagreeing with the walk's in both directions (an indented closer; a CRLF file), so there is deliberately only one here.

**How imports resolve: the BUILT `dist/*.d.ts`.** A marked `ts` fence compiles `--strict` against each package's built declarations, resolved through the `paths` map `check-doc-snippet-types.mjs` derives from every package's own `exports`/`types`, plus that gate's declared-dependency rule for third-party specifiers. The alternative — mapping `@object-ui/*` to `src/` through `tsconfig.base.json` — is rejected for the reason that gate's header already states: the root config maps the workspace to source, so a harness that inherited it would judge the guides against code no reader resolves. The reader of a skill guide is a consumer who installs `@object-ui/react` from npm; that is the surface, so that is what is compiled against.

**The declared precondition.** The cost of that decision is an exit code, never a silent green:

| exit | meaning |
|---|---|
| `0` | every marked fence held up, the controls held, and something was marked |
| `1` | the gate **ran and found errors** — a verdict about a guide |
| `2` | the gate **could not run**: packages unbuilt or typed from source, a harness control failed, or the marked population is empty |

Exit 2 prints `PRECONDITION NOT MET` and is never a pass — zero with nothing run reads as coverage, the failure shape this gate family exists to prevent (#4846). The 1-vs-2 split is this repository's convention, not a new one (`check-eager-closure-budget.mjs`, `check-doc-snippet-types.mjs`).

**The harness is imported, not re-rolled.** `derivePackageTypePaths`, `deriveDeclaredDependencyPaths` and `compileSnippets` come from `check-doc-snippet-types.mjs`, so the syntax/semantics split (one parse error suppresses *every* semantic diagnostic in a `tsc` program) and its four self-controls — RESOLUTION lands on a built artifact, a planted SENTINEL must produce TS2305, a POSITIVE control must be clean, an UNDECLARED specifier must still fail — are shared rather than duplicated. That gate's header records what hand-rolling the harness three times cost, including one false green. `scripts/__tests__/check-skill-examples.test.ts` pins the import and pins that this script builds no `ts.createProgram` of its own.

**One honest edge, printed on every run.** A bare specifier that neither map covers still resolves if the **repository root** declares it, because pnpm symlinks the root's own dependency set into `/node_modules`. In the marked population that is `vitest` and `@playwright/test`. The guides do tell the reader to install vitest, so the examples are not wrong — but the gate is not what proves it. The inherited UNDECLARED control does not close this: it bounds resolution against *transitive* packages, a different leak. So every run prints an `Unmapped specifiers:` line naming them, rather than letting it be a silent property of a green. Tightening it is a follow-up below.

## Starting population

Measured by the gate's own `--measure` (which judges every candidate, marked or not) at the branch point, and re-measured at head:

| language | passing | total | marked |
|---|---|---|---|
| `ts` / `tsx` / `typescript` | **17** | 112 | 17 |
| `json` / `jsonc` | **39** | 56 | 39 |
| **total** | **56** | **168** | **56** |

The 95 unmarked TypeScript fences and 17 unmarked JSON fences are fragments by construction — a `columns: [...]` subtree, a block continuing the one above it, a `json` fence carrying `//` comments and `...` elisions. ⛔ **No fence's content was edited to make it pass.** The only edit inside `skills/objectui/**` is marker lines: 56 insertions, 0 deletions, every added line byte-identical.

Files that gained markers:

| file | markers | lines before | after |
|---|---|---|---|
| `skills/objectui/SKILL.md` | 1 | 136 | 137 |
| `skills/objectui/guides/auth-permissions.md` | 3 | 345 | 348 |
| `skills/objectui/guides/data-integration.md` | 8 | 443 | 451 |
| `skills/objectui/guides/i18n.md` | 2 | 185 | 187 |
| `skills/objectui/guides/mobile.md` | 2 | 166 | 168 |
| `skills/objectui/guides/page-builder.md` | 10 | 321 | 331 |
| `skills/objectui/guides/plugin-development.md` | 4 | 442 | 446 |
| `skills/objectui/guides/project-setup.md` | 5 | 340 | 345 |
| `skills/objectui/guides/schema-expressions.md` | 7 | 511 | 518 |
| `skills/objectui/guides/testing.md` | 4 | 341 | 345 |
| `skills/objectui/rules/composition.md` | 1 | 277 | 278 |
| `skills/objectui/rules/protocol.md` | 6 | 314 | 320 |
| `skills/objectui/rules/styling.md` | 3 | 316 | 319 |

Whole published bundle (`skills/objectui/**/*.md`): **4356 → 4412 lines, +56** — one inert comment line per marked fence, no prose added or rewritten.

⛔ **No ratchet, no count pin.** Whether the marked population becomes shrink-only, the way `check-doc-fence-languages.mjs` treats its declared-file population, is recorded as a follow-up rather than decided here. What *is* enforced is a floor: a run in which nothing is marked exits 2, because a gate that checks nothing must not report success.

## CI wiring

**Its own workflow, `.github/workflows/skill-examples.yml`, with no `paths` / `paths-ignore` — modelled on `skills-paths.yml`.**

Not the `lint.yml` route: `pnpm check` in this repo is `node packages/cli/dist/cli.js check`, the product's own command, not a gate aggregation — there is no `check:*` aggregation to join. The house route for a scripts gate here is a dedicated workflow, and the reason the trigger carries no filter is stated in `skills-paths.yml`'s own header, quoted rather than re-derived: *"both of those workflows list `'**/*.md'`, `content/**` and `docs/**` under the `paths-ignore` of their `push` trigger, with no per-job path filter available in GitHub Actions. A push that only edits a guide would therefore start neither — and editing only a guide is the single most likely way a stated path goes dead."* `check-skill-examples.test.ts` pins that, the same way `check-skills-paths.test.ts` pins it for its own gate — no `paths`, no `paths-ignore`, and exactly one home.

Not a second step *inside* `skills-paths.yml`: that file's header asks that it stay a checkout plus one `node` call, and this gate cannot be that. Its criterion is the published type surface, so the packages the marked fences import must exist as `dist/*.d.ts` first. The workflow body therefore follows `doc-snippet-types.yml`: install, derive the filter **from the gate** (`--build-filter`), refuse an empty filter rather than expanding to a whole-workspace build, build, self-test, run. Today the filter names 11 packages, and it grows only as the marked population grows — which is what keeps this inside the 2026-08-16 ruling on #4846 that rejected a per-PR full-repo build.

Because it is unfiltered and blocking, the check is classified rather than left to default into silence: `Skill Example Check` is added to `REQUIRED_CONTEXTS` in `scripts/dependabot-merge-gate.mjs` (whose test asserts its three buckets partition the produced check set exactly), the workflow subscribes `merge_group` (`merge-queue-reporting.test.ts` derives that floor from `REQUIRED_CONTEXTS`), and `content/docs/guide/ci-cd-pipeline.md` gains an inventory row and a section (`ci-cd-pipeline-doc.test.ts` requires a heading naming every workflow file).

## Reverse verification

Every leg: mutate → prove the mutation landed on disk by counting the **injected** and the **removed** text (never a bare `git diff --stat`) → run the gate → restore with `git checkout HEAD -- PATH` → prove the restore by blob hash **and** an empty `git diff HEAD`. Absolute paths throughout, with a `trap … EXIT INT TERM` restoring all three files. No build step sits between mutation and measurement — the artifact the gate reads *is* the markdown being mutated, so there is no `dist` for a stale copy to hide in.

| leg | mutation (proof) | expected | observed |
|---|---|---|---|
| baseline | — | 0 | **0** — `Every marked skill example holds up against the built types.` |
| A — marked `ts` fence | `useObjectTranslation` → `useObjectTranslationNoSuchExport` in `guides/i18n.md`; removed-text count 7 → 0, injected-text count → 7 | red, naming file and fence line | **1** — `[semantic] skills/objectui/guides/i18n.md:40:10 TS2305: Module '"@object-ui/i18n"' has no exported member 'useObjectTranslationNoSuchExport'.` · `Semantic phase: 17 of 17 ts fence(s) judged, 1 failed.` |
| B — marked `json` fence | trailing comma injected in `rules/styling.md`; removed-text 1 → 0, injected-text → 1 | red | **1** — `[json] skills/objectui/rules/styling.md:183 Expected double-quoted property name in JSON at position 86` · `JSON phase: 39 fence(s) parsed, 1 failed.` |
| C — marker adjacency | one blank line inserted between the marker and its fence in `rules/composition.md`; marker-followed-by-blank occurrences → 1 | orphan reported | **1** — `skills/objectui/rules/composition.md:203 [orphan-marker]` |
| restored | — | 0 | **0**, worktree clean, all three blob hashes match `HEAD` |

**The opt-in half is measured too, not assumed.** On the same tree, in the same runs: `--measure` reports 12 parse failures + 83 semantic failures + 17 JSON failures across all 168 candidates, while the gate itself reports `0 failed` and exits 0. An unmarked broken fence is ignored, by measurement.

**Harness controls, from the head run** — a probe that cannot fail is not a probe:

```
resolution   resolved to '…/packages/types/dist/index.d.ts'
sentinel     a planted missing export produced 1 diagnostic(s) (TS2305)
positive     a real export produced 0 diagnostic(s)
undeclared   a specifier no imported package declares … produced 1 diagnostic(s) (TS2307)
```

## Gates

All run at head `70fdb0e`, on the tree this PR pushes. Exit codes captured by redirect **before** any pipe.

| command | exit | verdict line |
|---|---|---|
| `node scripts/check-skill-examples.mjs` | 0 | `Every marked skill example holds up against the built types.` (`Semantic phase: 17 of 17 … 0 failed` · `JSON phase: 39 … 0 failed`) |
| `node scripts/check-skill-examples.mjs --self-test` | 0 | `check-skill-examples self-test: 19 cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, and the compiler legs through the real harness)` |
| `node scripts/check-skill-examples.mjs --measure` | 0 | `Starting population — ts: 17/112 pass; json: 39/56 pass.` |
| `pnpm exec vitest run` × 12 wiring/pin suites | 0 | `Test Files 12 passed (12)` · `Tests 318 passed (318)` — includes `check-skill-examples`, `check-skills-paths`, `check-doc-snippet-types`, `merge-queue-reporting`, `dependabot-merge-gate`, `ci-cd-pipeline-doc`, `workflow-cache-save-bound`, `lint-workflow`, `scripts-type-check`, `entry-guard-wiring` |
| `node scripts/check-skills-paths.mjs` | 0 | `check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined)` |
| `node scripts/check-doc-links.mjs` | 0 | ran clean |
| `node scripts/check-control-bytes.mjs` | 0 | ran clean |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `OK (5/5 root(s) resolved … skills: 16 file(s), 196 fence(s) … 1304 fenced block(s) examined)` — the marker lines do not disturb its fence walk |
| `node scripts/check-doc-fence-languages.mjs` | 0 | `every TypeScript block in 225 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) … (⛔ SHRINK-ONLY)` |
| `node scripts/check-doc-snippet-types.mjs` | 0 | `Every covered documentation snippet compiles against the built types.` (`Semantic phase: 417 of 417 block(s) judged, 0 failed`) |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` — **its own verdict decides; no changeset added** |
| `node scripts/check-lint-coverage.mjs` | 0 | ran clean |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `132 cases pass` |
| `node scripts/check-governed-queue-guard.mjs --test CHANGE-SET-PATHS` | **3** | `GOVERNED` — the correct verdict for this diff, not a red: `Do not flip it ready … Park it as a DRAFT` |

**ESLint narrowing.** `pnpm lint` is `turbo run lint`, i.e. each *workspace package* running its own `eslint .`; `scripts/` has no `package.json`, so it is in no package's lint run at all — the same structural gap `scripts-type-check.test.ts` records for type-check and closes with `tsconfig.scripts.json`. Ran ESLint directly on the lintable files this PR touches: `pnpm exec eslint --format json scripts/__tests__/check-skill-examples.test.ts scripts/__tests__/merge-queue-reporting.test.ts` → exit 0, **2 files linted, 0 errors, 0 warnings**. Invariance for untouched files: `eslint.config.js` configures **no** type-aware linting (no `project`, no `projectService` anywhere in it), so no edit in this PR can move the verdict for a file it does not touch. The new `.mjs` is also clean (0/0), though no config block in `eslint.config.js` matches `**/*.mjs` — its blocks match `**/*.{ts,tsx}` only.

## Follow-ups, recorded not taken

1. **Shrink-only?** Whether the marked population becomes a ratchet is #7359 step 3, explicitly deferred. The number is re-derivable at any time with `--measure`, so the decision does not need this PR's memory.
2. **Bare `any` in a marked block.** objectstack's runner treats it as a third assertion — a marker is the claim "this compiles", and every property access on an `any` proves nothing. Worth porting; it is a new assertion rather than the convention, so it is not in this flight.
3. **Root-devDependency resolution.** `vitest` and `@playwright/test` resolve out of the repository root's `node_modules`. Printed on every run today; a control that bounds it the way the UNDECLARED control bounds transitives would close it.
4. **`.claude/skills/**`.** `check-skills-paths.mjs` scans it (#7358 widened it there); this gate's root is the published bundle. Widening is a separate, visible edit with its own measurement.
5. **Two pre-existing suites fail on a BUILT tree**, unrelated to this change set (which touches no `packages/**` file): `check-sdui-registration-pins.test.ts` derives `packages/app-shell/dist/console/connect/ConnectAgentWidget.js` where it expects the `src/…tsx` path, and `check-readme-exports.test.ts` reports `excerptsNotJudged` 1 where it expects 3. Both suites claim to hold "in BOTH build states"; CI's `Test (shard N/4)` runs on an unbuilt tree, so neither is visible there. Reported here rather than fixed.

## Draft

**Draft, and it stays draft.** `skills/objectui/**` is a governed surface (ui#6866 批 #7) and `check-governed-queue-guard.mjs --test` returns exit 3 GOVERNED over this change set. No ready flip, no auto-merge, no reviewer requests — a human merge **is** the review record for a governed surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_