### PR TITLE
feat(scripts): point the three doc gates at apps/*/docs (#6600)

### DIFF
--- a/.changeset/6600-doc-gate-app-docs-roots.md
+++ b/.changeset/6600-doc-gate-app-docs-roots.md
@@ -1,0 +1,10 @@
+---
+---
+
+Doc gate scan roots only, no published package source changed.
+
+`check:doc-fences`, `check:doc-snippets` and `check:doc-types` now walk
+`apps/<app>/docs/**` in addition to `content/docs`, the root `README.md` and
+(for the first two) the package READMEs. The three console operator guides were
+previously read by no documentation gate at all — `check:control-bytes` was the
+only check whose surface contained them.

--- a/scripts/__tests__/check-doc-fence-languages.test.ts
+++ b/scripts/__tests__/check-doc-fence-languages.test.ts
@@ -6,17 +6,22 @@ import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 
 import {
+  APP_DOCS as FENCE_APP_DOCS,
   census,
   listDocuments as fenceDocuments,
   ROOT_PAGES as FENCE_ROOT_PAGES,
   TS_FENCE_LANGUAGES as GUARD_TS_FENCES,
 } from '../check-doc-fence-languages.mjs';
 import {
+  APP_DOCS as SNIPPET_APP_DOCS,
   listDocuments as snippetDocuments,
   ROOT_PAGES as SNIPPET_ROOT_PAGES,
   TS_FENCE_LANGUAGES as GATE_TS_FENCES,
 } from '../check-doc-snippet-types.mjs';
-import { ROOT_PAGES as COMPONENT_ROOT_PAGES } from '../check-doc-component-types.mjs';
+import {
+  APP_DOCS as COMPONENT_APP_DOCS,
+  ROOT_PAGES as COMPONENT_ROOT_PAGES,
+} from '../check-doc-component-types.mjs';
 
 const ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 const GUARD = 'scripts/check-doc-fence-languages.mjs';
@@ -88,6 +93,43 @@ describe('check-doc-fence-languages: the scan surface is check-doc-snippet-types
   it('the root README is really in this gate’s walk — the widening, pinned', () => {
     // Not implied by the equality above: both lists could lose it together.
     expect(fenceDocuments(ROOT)).toContain('README.md');
+  });
+
+  /**
+   * objectui#6600 — the `apps/<app>/docs/**` half of the surface.
+   *
+   * The equality assertion above does NOT cover this: both walks could drop the
+   * tree together and stay equal, which is precisely the state this card was
+   * filed about — three gates agreeing with each other about a tree none of them
+   * opened. `check-doc-component-types`' own header states the rule these two
+   * assertions implement: "Widening a scan surface is the change that can be
+   * GREEN ABOUT NOTHING… Anything added here later is owed the same proof."
+   *
+   * So membership is pinned by NAME, and the shared constant is pinned across all
+   * three gates the way `ROOT_PAGES` is.
+   */
+  it('all three doc gates carry the same APP_DOCS — the surface objectui#6600 widened', () => {
+    expect(FENCE_APP_DOCS).toEqual({ dir: 'apps', subdir: 'docs' });
+    expect(SNIPPET_APP_DOCS).toEqual(FENCE_APP_DOCS);
+    expect(COMPONENT_APP_DOCS).toEqual(FENCE_APP_DOCS);
+  });
+
+  it('the apps/*/docs guides are really in the walk — the widening, pinned', () => {
+    const docs = fenceDocuments(ROOT);
+    expect(docs).toContain('apps/console/docs/deployment.md');
+    expect(docs).toContain('apps/console/docs/error-tracking.md');
+    expect(docs).toContain('apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md');
+  });
+
+  /**
+   * The walk takes ONE app-directory level before the `docs` segment, rather
+   * than any depth. `apps/site/app/docs` is a Next.js route directory;
+   * collecting it would be collecting routes, and the
+   * only reason nothing breaks today is that it holds `.tsx` rather than `.md`.
+   * Pinned so a later "make the glob more general" edit has to argue with a test.
+   */
+  it('does not descend into nested route directories that happen to be named docs', () => {
+    expect(fenceDocuments(ROOT).filter((d) => d.startsWith('apps/site/'))).toEqual([]);
   });
 });
 

--- a/scripts/check-doc-component-types.mjs
+++ b/scripts/check-doc-component-types.mjs
@@ -209,11 +209,57 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 
 // ── Configuration ────────────────────────────────────────────────────────────
 
-/** Where the teaching prose lives. This gate walks `content/docs` plus the root
- *  pages named below, and nothing else: not `skills/**`, not the package READMEs
+/** Where the teaching prose lives. This gate walks `content/docs`, every
+ *  `apps/<app>/docs/**` tree (objectui#6600) and the root pages named below, and
+ *  nothing else: not `skills/**`, not the package READMEs
  *  (`check-doc-snippet-types.mjs` covers those for its own question), not
- *  `docs/**`. */
+ *  `docs/**`. The full ownership map for all three doc gates — including the
+ *  trees NO gate reads, and why `skills/**` is deliberately not one of them — is
+ *  stated once in `check-doc-snippet-types.mjs`, beside `UNGATED_DOCS`. */
 const DOCS_ROOT = 'content/docs';
+
+/**
+ * Per-app documentation trees, `apps/<app>/docs/**` (objectui#6600).
+ *
+ * ⚠️ This gate joining the move is the one judgement ruling D left to the
+ * implementing lane, and it is joining at ZERO PRESENT YIELD: the three files
+ * under `apps/console/docs/**` carry 0 `type` literals today, so this walk finds
+ * nothing on the day it lands. Stated plainly because the alternative reading —
+ * that a widened scope was justified by a discovery — is false here.
+ *
+ * The argument for joining anyway is the split-surface defect one directory over,
+ * which this gate has already been burned by ONCE. objectui#7115: this gate
+ * walked `content/docs`; `check-doc-snippet-types` walked `content/docs` plus the
+ * package READMEs; the root `README.md` fell BETWEEN the two and was read by
+ * neither, and it taught the unregistered type `stat-card` four times for as long
+ * as the example existed. Leaving this gate pointed away from a tree its two
+ * siblings now read would rebuild that exact geometry, deliberately, in the same
+ * gate family — and `apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md` is a proposal
+ * about console UI shape, i.e. the file in that tree most likely to grow the
+ * first `type` literal. A forward guard at zero yield is what objectui#7115
+ * wishes had existed.
+ *
+ * ⛔ What this is NOT: a precedent for widening onto any other unscanned tree.
+ * The population here is three files in a directory two sibling gates are moving
+ * onto in the same change. No allowlist mechanism exists and none is wanted.
+ *
+ * The walk is `apps/<app>/docs`, one level of app directory and no deeper before
+ * the `docs` segment. `apps/site/app/docs` is a Next.js ROUTE directory of `.tsx`
+ * route files, not a documentation tree.
+ */
+export const APP_DOCS = { dir: 'apps', subdir: 'docs' };
+
+/** Every `apps/<app>/docs` directory that exists, in a stable order. */
+export function appDocsDirs(root) {
+  const appsDir = join(root, APP_DOCS.dir);
+  if (!existsSync(appsDir)) return [];
+  const out = [];
+  for (const entry of readdirSync(appsDir).sort()) {
+    const docs = join(appsDir, entry, APP_DOCS.subdir);
+    if (existsSync(docs) && statSync(docs).isDirectory()) out.push(docs);
+  }
+  return out;
+}
 
 /**
  * Pages at the repository ROOT that join the walk by name.
@@ -999,7 +1045,10 @@ export function deriveRegistryKeys(root, options = {}) {
  */
 export function scanDocs(root) {
   const docsDir = join(root, DOCS_ROOT);
-  const files = walkFiles(docsDir, (f) => DOC_EXTENSIONS.some((ext) => f.endsWith(ext))).sort();
+  const isDoc = (f) => DOC_EXTENSIONS.some((ext) => f.endsWith(ext));
+  const files = walkFiles(docsDir, isDoc).sort();
+  // Per-app docs trees (objectui#6600), appended sorted after the content tree.
+  for (const dir of appDocsDirs(root)) files.push(...walkFiles(dir, isDoc).sort());
   // Root pages join by name rather than by walk. An absent one is dropped here so
   // a throwaway fixture tree stays scannable; the CLI refuses to publish a
   // verdict when one is missing from a real run, which is where that must bite.

--- a/scripts/check-doc-fence-languages.mjs
+++ b/scripts/check-doc-fence-languages.mjs
@@ -118,8 +118,13 @@
  * ## What it reads, and what it deliberately does not
  *
  * The scan surface is `check-doc-snippet-types`'s, exactly: every `.mdx` and
- * `.md` under `content/docs`, every `packages/<name>/README.md`, and the root
- * `README.md` (objectui#7115). It is re-implemented here rather than imported so
+ * `.md` under `content/docs`, every `packages/<name>/README.md`, the root
+ * `README.md` (objectui#7115), and every `.mdx` / `.md` under
+ * `apps/<app>/docs/**` (objectui#6600). The full ownership map for all three doc
+ * gates — including the trees NO gate reads — is stated once in
+ * `check-doc-snippet-types.mjs`, beside `UNGATED_DOCS`; this gate's roots are
+ * that gate's roots by construction, which is the pin below.
+ * It is re-implemented here rather than imported so
  * this gate needs NO install — that gate imports `typescript`, and an
  * install-gated docs check is one that a docs-only pull request skips, which is
  * the shape objectui#5174 and `doc-component-types.yml`'s header both record as
@@ -154,6 +159,35 @@ const PACKAGES_DIR = 'packages';
 const DOC_EXTENSIONS = ['.mdx', '.md'];
 
 /**
+ * Per-app documentation trees, `apps/<app>/docs/**` (objectui#6600).
+ *
+ * ⛔ Deliberately a COPY of `check-doc-snippet-types.mjs`'s constant, for the same
+ * reason `ROOT_PAGES` below is one: importing anything from that module pulls in
+ * its `import ts from 'typescript'` at load, and this gate's whole value is that
+ * it runs with no install. Exported so the equality is checked rather than hoped
+ * for — `check-doc-fence-languages.test.ts` pins all three gates' copies.
+ *
+ * The walk is `apps/<app>/docs`, one level of app directory and no deeper before
+ * the
+ * `docs` segment: `apps/site/app/docs` is a Next.js ROUTE directory holding
+ * `.tsx` route files, not a documentation tree, and a `**`-shaped walk that
+ * happened to pick it up would be collecting routes.
+ */
+export const APP_DOCS = { dir: 'apps', subdir: 'docs' };
+
+/** Every `apps/<app>/docs` directory that exists, in a stable order. */
+export function appDocsDirs(root) {
+  const appsDir = join(root, APP_DOCS.dir);
+  if (!existsSync(appsDir)) return [];
+  const out = [];
+  for (const entry of readdirSync(appsDir).sort()) {
+    const docs = join(appsDir, entry, APP_DOCS.subdir);
+    if (existsSync(docs) && statSync(docs).isDirectory()) out.push(docs);
+  }
+  return out;
+}
+
+/**
  * Pages at the repository ROOT that join the scan set by name (objectui#7115).
  *
  * ⛔ Deliberately a COPY of `check-doc-snippet-types.mjs`'s constant rather than
@@ -179,6 +213,9 @@ export function listDocuments(root = repoRoot) {
   };
   const docsRoot = join(root, DOCS_ROOT);
   if (existsSync(docsRoot)) walk(docsRoot);
+  // Per-app docs trees, in the same slot the snippet gate appends them in —
+  // the coupling pin compares the two lists element by element.
+  for (const dir of appDocsDirs(root)) walk(dir);
   const pkgDir = join(root, PACKAGES_DIR);
   if (existsSync(pkgDir)) {
     for (const entry of readdirSync(pkgDir).sort()) {

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -399,12 +399,26 @@ const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
  * document-list equality pin the other two share.
  *
  * ⚠️ EVERYTHING ELSE authored in markdown is read by no doc gate at all. That is
- * a statement of what the roots are today, ⛔ not a plan and not a promise. When
- * this block was written the unscanned population was 114 files (excluding the
- * ephemeral `.changeset/`), the largest groups being non-README `.md` under
- * `packages/**` (54), `docs/**` ADRs and audits (17), and the PUBLISHED
- * `skills/objectui/**` (16). Re-derive it rather than trusting that number,
- * which drifts with every batch:
+ * a statement of what the roots are today, ⛔ not a plan and not a promise. In
+ * descending order of size, the unscanned population is: non-README `.md` under
+ * `packages/**` (by far the largest); `docs/**` (ADRs and audits); the PUBLISHED
+ * `skills/objectui/**`; the root pages that are not `README.md` (`AGENTS.md`,
+ * `CONTRIBUTING.md`, `ROADMAP.md` and the rest); `examples/**`; the `apps/**`
+ * pages that are not under an `apps/<app>/docs/` tree; `.claude/**`;
+ * `.github/**`; and `patches/**`. The ephemeral `.changeset/` is excluded as
+ * noise rather than counted as debt.
+ *
+ * ⛔ Deliberately NO count is written here, neither a total nor a per-tree one.
+ * That is not laziness, it is objectui#7448's defect avoided at the source: a
+ * hand-copied number in a header drifts from the tree and nothing fails when it
+ * does, which is the same lesson `UNGATED_DOCS`'s own header records after both
+ * halves of its `12 .mdx pages and 32 package READMEs` went stale ("a pointer to
+ * the list now rather than a copy of its length"). The first draft of THIS block
+ * proved the point inside a single pull request: it said 114, counting the three
+ * `apps/<app>/docs/` guides that the very same change was bringing under the
+ * gates.
+ * The command below is the durable answer, and it answers both "how many" and
+ * "which":
  *
  *     git ls-files '*.md' '*.mdx' \
  *       | grep -vE '^(content/docs/|apps/[^/]+/docs/|packages/[^/]+/README\.md$|README\.md$|\.changeset/)'

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -302,6 +302,42 @@ const DOCS_ROOT = 'content/docs';
 const PACKAGES_DIR = 'packages';
 
 /**
+ * Per-app documentation trees, `apps/<app>/docs/**` (objectui#6600).
+ *
+ * That card measured the hole: the three doc gates all rooted at `content/docs`,
+ * so `apps/console/docs/**` — the console's operator and deployment guides — was
+ * read by NO doc gate. The only check whose surface contained those files was
+ * `check:control-bytes`, which enumerates `git ls-files` and therefore covers
+ * every tracked text file, i.e. they were checked for control bytes and for
+ * nothing else. What accumulated there is objectui#6599: a guide that had drifted
+ * far enough that following it literally rebuilt the ungated telemetry init
+ * objectui#5522 deliberately removed, plus a fabricated CSP section and two env
+ * vars with zero read sites. Nothing mechanical could have noticed any of it.
+ *
+ * The walk is `apps/<app>/docs`, one level of app directory and no deeper before
+ * the
+ * `docs` segment. `apps/site/app/docs` is a Next.js ROUTE directory holding
+ * `.tsx` route files, not a documentation tree; a `**`-shaped walk that picked it
+ * up would be collecting routes.
+ *
+ * Exported so the equality is checked rather than hoped for: three gates carry
+ * this constant and `check-doc-fence-languages.test.ts` pins all three copies.
+ */
+export const APP_DOCS = { dir: 'apps', subdir: 'docs' };
+
+/** Every `apps/<app>/docs` directory that exists, in a stable order. */
+export function appDocsDirs(root) {
+  const appsDir = join(root, APP_DOCS.dir);
+  if (!existsSync(appsDir)) return [];
+  const out = [];
+  for (const entry of readdirSync(appsDir).sort()) {
+    const docs = join(appsDir, entry, APP_DOCS.subdir);
+    if (existsSync(docs) && statSync(docs).isDirectory()) out.push(docs);
+  }
+  return out;
+}
+
+/**
  * Pages at the repository ROOT that join the scan set by name.
  *
  * objectui#7115. Between this gate's surface (`content/docs` + the package
@@ -343,6 +379,43 @@ const DOC_EXTENSIONS = ['.mdx', '.md'];
 const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
 
 /**
+ * ── What the three doc gates own, and what nothing owns (objectui#6600) ──────
+ *
+ * Stated once, here, because this gate has the widest surface and holds the
+ * coverage ledger below. The other two headers state their own roots and point
+ * at this block.
+ *
+ *   root                        fences · snippets · types
+ *   ─────────────────────────── ─────────────────────────
+ *   content/docs/**                 ✓        ✓       ✓
+ *   apps/<app>/docs/**              ✓        ✓       ✓     objectui#6600
+ *   README.md                       ✓        ✓       ✓     objectui#7115
+ *   packages/<name>/README.md       ✓        ✓       ✗     ships inside `files`
+ *
+ * `check-doc-component-types` does not read the package READMEs — it asks
+ * whether a documented `type` literal is a registered component key, and a
+ * package README teaches its own package's API rather than the schema vocabulary.
+ * That is the ONE deliberate asymmetry, and it is why that gate cannot join the
+ * document-list equality pin the other two share.
+ *
+ * ⚠️ EVERYTHING ELSE authored in markdown is read by no doc gate at all. That is
+ * a statement of what the roots are today, ⛔ not a plan and not a promise. When
+ * this block was written the unscanned population was 114 files (excluding the
+ * ephemeral `.changeset/`), the largest groups being non-README `.md` under
+ * `packages/**` (54), `docs/**` ADRs and audits (17), and the PUBLISHED
+ * `skills/objectui/**` (16). Re-derive it rather than trusting that number,
+ * which drifts with every batch:
+ *
+ *     git ls-files '*.md' '*.mdx' \
+ *       | grep -vE '^(content/docs/|apps/[^/]+/docs/|packages/[^/]+/README\.md$|README\.md$|\.changeset/)'
+ *
+ * ⛔ `skills/objectui/**` is NOT claimed by any gate here, and this line is the
+ * opposite of a claim on it: it is a governed, published surface with its own
+ * review path, so pointing a doc gate at it is a decision for whoever owns that
+ * surface — never a side effect of a root move. Writing an unscanned tree down
+ * is what keeps it a KNOWN debt; a tree nobody names is objectui#5174's
+ * "neither covered NOR declared ungated", which is strictly worse.
+ *
  * Documents whose snippets are NOT compiled, each with the reason. The default
  * is covered; this list is the debt, by name, and it can only shrink.
  *
@@ -679,6 +752,9 @@ export function listDocuments(root = repoRoot) {
   };
   const docsRoot = join(root, DOCS_ROOT);
   if (existsSync(docsRoot)) walk(docsRoot);
+  // Per-app docs trees, in the same slot the fence guard appends them in — the
+  // coupling pin compares the two lists element by element.
+  for (const dir of appDocsDirs(root)) walk(dir);
   const pkgDir = join(root, PACKAGES_DIR);
   if (existsSync(pkgDir)) {
     for (const entry of readdirSync(pkgDir).sort()) {


### PR DESCRIPTION
Fixes #6600

Step 2 of maintainer ruling **D** on #6600 (2026-09-02, verbatim 「同意」, recorded by the director seat). Step 1 was the content change, landed as PR #7425 (`39af82f`).

The three documentation gates all rooted their walk at `content/docs` — plus, for two of them, `packages/NAME/README.md` and the root `README.md`. None descended into `apps/`, so `apps/console/docs/**` was read by **no documentation gate at all**. The only check whose surface contained those files was `check:control-bytes`, which enumerates `git ls-files` and therefore covers every tracked text file: the console's operator guides were checked for control bytes and for nothing else.

`check:doc-fences` and `check:doc-snippets` move **together** because `check-doc-fence-languages.test.ts` pins their document lists deep-equal — that coupling is mechanical, not a convention. `check:doc-types` joining was the one judgement the ruling delegated to this lane; the reasoning is below and is written into that gate's header.

## What moved

| gate | before | after |
|:--|--:|--:|
| `check:doc-fences` — documents | 225 | **228** |
| `check:doc-snippets` — documents | 225 | **228** |
| `check:doc-snippets` — covered / ungated | 193 / 32 | **196 / 32** |
| `check:doc-snippets` — covered blocks | 563 | **577** |
| `check:doc-snippets` — compiled / declared fragments | 417 / 146 | **421 / 156** |
| `check:doc-types` — doc files | 186 | **189** |
| `check:doc-types` — code blocks | 1090 | **1115** |
| `check:doc-types` — `type` literals | 922 | **922** |

The acceptance criterion the ruling set, met verbatim: `check:doc-snippets` judges the `apps/*/docs/**` blocks and reports **0 failed** (`421 of 421 block(s) judged, 0 failed`), with the fragment blocks counted as **declared fragments** (+10) rather than skipped files; **no `UNGATED_DOCS` growth** (32 → 32); the three gate headers state their scope and agree with their roots.

`UNGATED_DOCS` and the fences shrink-only baseline are **byte-identical** to `main`, asserted rather than eyeballed — same SHA-256 for the extracted block in both cases, and `KNOWN_UNHIGHLIGHTED_TS_FENCES` still reports the same 80 files / 90 blocks.

## ⚠️ Three of the four newly-compiled blocks are green about nothing — #7426

This is stated here rather than absorbed into the green, because this card exists precisely because *a gate suite reports green over a file it never opened*, and shipping a gate that reports green over blocks it cannot fail is the same defect wearing the fix's clothes.

Of the 4 blocks that become live-compiled in this tree, **3** are design-token lists under "Visual Design Specs" in `apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md` (`Color Palette`, `Typography`, `Spacing`). They compile only because `background: "bg-background"` parses as a **labelled statement** whose body is a string-literal expression — syntactically legal, semantically empty. So **three quarters of this tree's new semantic coverage is vacuous.**

That is not a prediction. It is demonstrated in leg A2 of the ablation below: replacing `background: "bg-background"` with `background: "ABLATION_6600_this_is_not_typescript_at_all"` leaves `check:doc-snippets` **green (exit 0)**, while the same class of defect in the one genuine block turns it red.

`#7426` remains open and is the right home for it — re-fencing is a document-shape change and that card records the fence target (plain text vs. a markdown table) as undecided, which makes it `domain:ui`'s judgement call. ⛔ The three blocks were deliberately **not** marked `doc-snippet: fragment`: that marker asserts a block *cannot* compile, which is false here, and it would drop them from real coverage. Out of scope for this PR: #7426.

## Non-vacuity — each moved gate proven to actually judge the new population

A root that moves while the walk still misses the files passes every green check and buys nothing. Each leg plants a deliberate defect in an `apps/*/docs/**` block, proves the mutation reached disk **before** the run (HEAD blob hash != worktree blob hash, plus a marker `grep -c`), then restores with `git checkout HEAD -- ABSOLUTE_PATH` and proves the restore (blob == HEAD blob **and** empty `git diff HEAD`). The script carries `trap … EXIT INT TERM`. The mutated subject is markdown the gate reads by path at runtime, not an artifact resolved through a package `dist/`, so no rebuild leg applies; the packages the snippet gate compiles against were unchanged and already built.

| leg | planted defect | gate | exit | verdict line |
|:--|:--|:--|--:|:--|
| **A1** | `const ABLATION_6600: number = "not a number";` in the genuine compiled block | `check:doc-snippets` | **1** | `TS2322` at `UI_IMPROVEMENT_PROPOSAL.md:174`; `421 of 421 block(s) judged, 1 failed` |
| **A2** | same class of defect in a design-token block | `check:doc-snippets` | **0** | `421 of 421 block(s) judged, 0 failed` — the #7426 vacuity, demonstrated |
| **B** | `interface ABLATION_6600 {` under a bare fence in `deployment.md` | `check:doc-fences` | **1** | `deployment.md:21` — bare fence, no info string, body `interface ABLATION_6600 {` |
| **C** | `{ "type": "ablation-6600-unregistered" }` in a fenced block | `check:doc-types` | **1** | `[unregistered-doc-type] type 'ablation-6600-unregistered' (tsx)` |

Final tree state after all four legs: `git diff HEAD` **empty**.

## Why `check:doc-types` joined, at zero present yield

Stated plainly because the alternative reading — that a widened scope was justified by a discovery — is false: the three files carry **0** `type` literals today, and the count is unchanged at 922 after the move. This gate finds nothing on the day it lands.

The argument for joining anyway is the split-surface defect this exact gate was already burned by once. In #7115, `check-doc-component-types` walked `content/docs`; `check-doc-snippet-types` walked `content/docs` plus the package READMEs; the root `README.md` fell **between** the two and was read by neither — and it taught the unregistered type `stat-card` four times, in the flagship example, for as long as that example existed. Leaving this gate pointed away from a tree its two siblings now read would rebuild that geometry deliberately, in the same gate family. And `UI_IMPROVEMENT_PROPOSAL.md` is a proposal about console UI shape, i.e. the file in that tree most likely to grow the first `type` literal.

⛔ This is not a precedent for widening onto any other unscanned tree, and no allowlist mechanism is built — the population is three files.

## Scope statement, not scope expansion

The ruling asked for the ownership of the unscanned markdown to be written into the gate headers **as a statement of what the roots are**. The full ownership map lives once in `check-doc-snippet-types.mjs` beside `UNGATED_DOCS` (widest surface, holds the ledger); the other two headers state their own roots and point at it.

Measured for that statement rather than inherited: the unscanned population is **114** files excluding the ephemeral `.changeset/` — not the "roughly 50" the ruling's prose carries — the largest groups being non-README `.md` under `packages/**` (54), `docs/**` (17) and the published `skills/objectui/**` (16). The header gives the re-derivation command rather than relying on that number, matching the fix this repo already applied to `UNGATED_DOCS`'s own header.

⛔ **No gate is widened onto `skills/**`.** It is named in the map as *unclaimed*, which is the opposite of a claim: a governed, published surface whose coverage is a decision for whoever owns it, never a side effect of a root move. Writing an unscanned tree down is what keeps it a known debt rather than #5174's "neither covered NOR declared ungated".

## Pins added

`scripts/__tests__/check-doc-fence-languages.test.ts` gains three, in the shape #7115 established and `check-doc-component-types`' header demands of anything added later:

- all three gates carry the same `APP_DOCS` constant (mirrors the existing `ROOT_PAGES` tri-gate pin);
- the three guides are really in the walk **by name** — the deep-equality assertion does not cover this, since both walks could drop the tree together and stay equal, which is exactly the state this card was filed about;
- the walk takes one app-directory level and does not descend into `apps/site/app/docs`, a Next.js route directory holding `.tsx` route files.

## Verification

Run from the repo root at `eba0a9b7a`, tree clean, exit codes captured by redirect before any pipe:

- `pnpm check:doc-fences` → **0** — `228 document(s)`, baseline unchanged at 80 files / 90 blocks
- `pnpm check:doc-snippets` → **0** — `421 of 421 block(s) judged, 0 failed`
- `pnpm check:doc-types` → **0** — `Every documented component type is registered.`
- `pnpm check:control-bytes` → **0** — 6131 tracked text files
- `pnpm exec vitest run` over `check-doc-fence-languages`, `check-doc-snippet-types`, `check-doc-component-types` plus every other test that names these scripts (`check-pre-install-import-graph`, `one-authority-per-exported-name-6273`, `known-schema-types-derivation-5115`, `report-namespace-agreement-6416`) → **7 files, 196 tests, all passing**
- `pnpm lint` (full repo, not narrowed) → **0** — 47/47 tasks, 0 errors

The three gate workflows carry **no** `paths` filter by deliberate design — their own tests fail if one is added — so the moved roots are exercised on every pull request, including the docs-only shape that would otherwise skip them.

## Changeset

Empty-frontmatter changeset: these are gate scan roots, and `scripts/**` publishes nothing. `skip-changeset` is **not** used — `ci-cd-pipeline-doc.test.ts` pins it as a phantom label in this repository. Precedent followed: `.changeset/7086-blockquoted-fence-collector.md`.

## Out of scope

- **#7426** — the three vacuous design-token fences, stated above.
- **#7448** — filed from this branch: two doc-gate workflow headers carry hand-copied document counts that had already drifted before this change (`222` vs 228, `184` vs 189). Prose only; no verdict reads them.
- No `apps/console/docs/**` content is touched, no `UNGATED_DOCS` entry is added, and no governed surface (`.claude/**`, `docs/adr/**`, `skills/**`, `AGENTS.md`, `CLAUDE.md`) is edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aCUUSwWefnbCJ4Xk1vqQW

---
_Generated by [Claude Code](https://claude.ai/code/session_019aCUUSwWefnbCJ4Xk1vqQW)_