### PR TITLE
fix(plugin-calendar,i18n): a record with no date leaves the grid for an "unscheduled" area

### DIFF
--- a/.changeset/calendar-unscheduled-area.md
+++ b/.changeset/calendar-unscheduled-area.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/plugin-calendar': patch
+'@object-ui/i18n': patch
+---
+
+fix(plugin-calendar): a record with no date is no longer placed on today
+
+`ObjectCalendar` mapped a record whose declared `startDateField` carried no
+value to `new Date()` — the current moment — so it rendered on today's cell as
+an ordinary event, indistinguishable from a real one. The `isNaN` guard six
+lines below could not catch it by construction: a no-argument `new Date()` is
+always valid, so the absent-value case became a well-formed lie *before* the
+check that would have caught it.
+
+The fabricating arm is deleted. Such records now leave the grid entirely and
+appear in a collapsed "Unscheduled (N)" area below the calendar — a visible
+count and an expandable list, with no invented date and no scheduling UI. The
+`isNaN` filter keeps its original job for values that are present but
+unparseable: absent and malformed stay two distinguishable outcomes.
+`allDay: !endDate` now applies only to records that have a start, so a record
+with no dates at all is unscheduled rather than silently all-day; a record with
+a start and no end still renders all-day exactly as before.
+
+Adds `calendar.unscheduled` to all ten locale packs.

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -553,6 +553,7 @@ const ar = {
     allDay: "طوال اليوم",
     newEvent: "حدث جديد",
     moreEvents: "+{{count}} المزيد",
+    unscheduled: "غير مجدولة ({{count}})",
   },
   list: {
     firstRunTitle: "لا يوجد شيء هنا بعد",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -549,6 +549,7 @@ const de = {
     allDay: "Ganztägig",
     newEvent: "Neuer Termin",
     moreEvents: "+{{count}} weitere",
+    unscheduled: "Nicht geplant ({{count}})",
   },
   list: {
     firstRunTitle: "Hier ist noch nichts",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -661,6 +661,7 @@ const en = {
     allDay: 'All Day',
     newEvent: 'New event',
     moreEvents: '+{{count}} more',
+    unscheduled: 'Unscheduled ({{count}})',
   },
   list: {
     loading: 'Loading records…',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -553,6 +553,7 @@ const es = {
     allDay: "Todo el día",
     newEvent: "Nuevo evento",
     moreEvents: "+{{count}} más",
+    unscheduled: "Sin programar ({{count}})",
   },
   list: {
     firstRunTitle: "Aquí todavía no hay nada",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -549,6 +549,7 @@ const fr = {
     allDay: "Toute la journée",
     newEvent: "Nouvel événement",
     moreEvents: "+{{count}} de plus",
+    unscheduled: "Non planifié ({{count}})",
   },
   list: {
     firstRunTitle: "Rien pour l'instant",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -549,6 +549,7 @@ const ja = {
     allDay: "終日",
     newEvent: "新しい予定",
     moreEvents: "+{{count}} 件",
+    unscheduled: "日時未定 ({{count}})",
   },
   list: {
     firstRunTitle: "まだ何もありません",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -549,6 +549,7 @@ const ko = {
     allDay: "종일",
     newEvent: "새 일정",
     moreEvents: "+{{count}} 더보기",
+    unscheduled: "일정 없음 ({{count}})",
   },
   list: {
     firstRunTitle: "아직 아무것도 없습니다",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -548,6 +548,7 @@ const pt = {
     allDay: "Dia inteiro",
     newEvent: "Novo evento",
     moreEvents: "+{{count}} mais",
+    unscheduled: "Sem agendamento ({{count}})",
   },
   list: {
     firstRunTitle: "Ainda não há nada aqui",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -555,6 +555,7 @@ const ru = {
     allDay: "Весь день",
     newEvent: "Новое событие",
     moreEvents: "+{{count}} ещё",
+    unscheduled: "Без даты ({{count}})",
   },
   list: {
     firstRunTitle: "Здесь пока пусто",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -568,6 +568,7 @@ const zh = {
     allDay: '全天',
     newEvent: '新建事件',
     moreEvents: '+{{count}} 更多',
+    unscheduled: '未排期 ({{count}})',
   },
   list: {
     loading: '正在加载记录…',

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -24,18 +24,21 @@
 
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import type { ObjectGridSchema, DataSource, ViewData, CalendarConfig } from '@object-ui/types';
-import { CalendarView } from './CalendarView';
+import { CalendarView, type CalendarViewEvent } from './CalendarView';
 import { usePullToRefresh } from '@object-ui/mobile';
 import {
   useNavigationOverlay,
   useSafeTranslate,
+  useObjectTranslation,
   extractWriteErrorMessage,
   isPermissionError,
   declaredUserMessage,
 } from '@object-ui/react';
 import { RecordDetailDrawer, deriveRecordPageHref } from '@object-ui/plugin-detail';
 import { usePermissions } from '@object-ui/permissions';
+import { ChevronRight } from 'lucide-react';
 import {
+  cn,
   useIsMobile,
   Dialog,
   DialogContent,
@@ -157,6 +160,17 @@ function getCalendarConfig(schema: ObjectGridSchema | CalendarSchema): CalendarC
   return null;
 }
 
+/**
+ * A record the calendar cannot place: the field declared as `startDateField`
+ * carries no value on it, so there is no date to draw and none is invented
+ * (objectui#7071). Deliberately just an id and a display title — the ruled
+ * affordance is a count and a list, so nothing here feeds a scheduling gesture.
+ */
+interface UnscheduledRecord {
+  id: string | number;
+  title: string;
+}
+
 export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
   schema,
   dataSource,
@@ -172,6 +186,12 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
   locale,
 }) => {
   const tt = useSafeTranslate();
+  // `useSafeTranslate` takes a plain English fallback and passes NO options to
+  // i18next, so it cannot fill a `{{count}}` hole — the unscheduled label needs
+  // one, and reads its key through `useObjectTranslation` instead. Both spell
+  // the provider-less fallback the same way (objectui#6219), so the label is
+  // correct whether or not an `I18nProvider` is mounted.
+  const { t } = useObjectTranslation();
   // When the parent (e.g. ObjectView) pre-fetches data and passes it via the `data` prop,
   // we must not trigger a second fetch. Detect external data by checking for an array.
   const hasExternalData = Array.isArray(externalData);
@@ -186,6 +206,12 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
   const [schemaResolution, setSchemaResolution] =
     useState<{ key: string; def: any } | null>(null);
   const [currentDate, setCurrentDate] = useState(new Date());
+  // Disclosure state of the "unscheduled" area (objectui#7071). Collapsed by
+  // default, as ruled: the count is always on screen, the list is opt-in.
+  // Component state is the right home per AGENTS.md §5 #8 — nobody would share
+  // or bookmark it — and it survives a data refresh because a refetch re-renders
+  // this component rather than remounting it.
+  const [unscheduledOpen, setUnscheduledOpen] = useState(false);
   const isMobile = useIsMobile();
   const schemaDefaultView = (schema as any).defaultView as 'month' | 'week' | 'day' | undefined;
   // Lazy initializer: read window.innerWidth synchronously so SSR-friendly
@@ -459,10 +485,13 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
     return () => { isMounted = false; };
   }, [schemaKey, dataSource, hasInlineData]);
 
-  // Transform data to calendar events
-  const events = useMemo(() => {
+  // Transform data to calendar events, and separate out the records that have
+  // no date to be placed on at all (objectui#7071 — see the early return in the
+  // loop below). ONE pass, so the two lists are always answers about the same
+  // dataset and the count under the calendar can never disagree with the grid.
+  const { events, unscheduledRecords } = useMemo(() => {
     if (!calendarConfig || !data.length) {
-      return [];
+      return { events: [] as CalendarViewEvent[], unscheduledRecords: [] as UnscheduledRecord[] };
     }
 
     const { startDateField, endDateField, titleField, colorField } = calendarConfig;
@@ -489,7 +518,10 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
       return getRecordDisplayName(objectSchema, record);
     };
 
-    return data.map((record, index) => {
+    const scheduled: CalendarViewEvent[] = [];
+    const unscheduled: UnscheduledRecord[] = [];
+
+    data.forEach((record, index) => {
       const startDate = record[startDateField];
       const endDate = endDateField ? record[endDateField] : null;
       const title = resolveTitle(record);
@@ -501,17 +533,51 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
       // is well beyond this fix.
       const colorRaw = colorField ? record[colorField] : undefined;
       const color = resolveColorFieldValue(colorRaw) ?? colorRaw;
+      const id = record.id || record._id || `event-${index}`;
 
-      return {
-        id: record.id || record._id || `event-${index}`,
+      // NO VALUE in the declared start field means the record has no date —
+      // full stop (objectui#7071, ruled 2026-09-01, re-confirmed 2026-09-02).
+      // This line used to read `startDate ? new Date(startDate) : new Date()`,
+      // so a record missing its date was handed THE CURRENT MOMENT and drawn on
+      // today's cell as an ordinary event. The `isNaN` guard below could not
+      // catch that by construction: a no-argument `new Date()` is always valid,
+      // so the absent-value case was converted into a well-formed lie *before*
+      // the check that would have caught it. `end`, three lines down, has
+      // always been honest about the same absence (`undefined`); this is
+      // `start` catching up. The record leaves the grid entirely and is counted
+      // in the "unscheduled" area below the calendar instead: nothing is
+      // invented, and nothing disappears without a count.
+      if (!startDate) {
+        unscheduled.push({ id, title });
+        return;
+      }
+
+      const start = new Date(startDate);
+      // The guard keeps its ORIGINAL job, on a DIFFERENT fact from the one
+      // above: a value that is PRESENT but unparseable ('not a date') is
+      // dropped here, never bucketed as unscheduled. Absent and malformed are
+      // two distinct defects and the two paths stay distinguishable.
+      if (isNaN(start.getTime())) return; // Filter out invalid dates
+
+      scheduled.push({
+        id,
         title,
-        start: startDate ? new Date(startDate) : new Date(),
+        start,
         end: endDate ? new Date(endDate) : undefined,
         color,
+        // Only a record that HAS a start reaches this line. That is the point
+        // of the early return above, not an accident of ordering: `!endDate`
+        // used to fire for a record with no dates AT ALL, so one absent field
+        // silently set two rendered properties and a dateless record rendered
+        // as an all-day event on today. A record without a start is
+        // unscheduled, not all-day. For a record WITH a start the inference is
+        // unchanged.
         allDay: !endDate, // If no end date, treat as all-day event
         data: record,
-      };
-    }).filter(event => !isNaN(event.start.getTime())); // Filter out invalid dates
+      });
+    });
+
+    return { events: scheduled, unscheduledRecords: unscheduled };
   }, [data, calendarConfig, objectSchema]);
 
   // Get days in current month view - REMOVED (Handled by CalendarView)
@@ -783,6 +849,49 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
           onTimeRangeSelect={handleTimeRangeSelectDefault}
         />
       </div>
+
+      {/* The "unscheduled" containment area (objectui#7071, ruled 2026-09-01 and
+          re-confirmed 2026-09-02). Records with no value in the declared start
+          field are no longer given a fabricated date, so they are not on the
+          grid above — they are counted here and listed on demand, which is what
+          makes their absence from the grid honest rather than silent.
+
+          Rendered only when there is something to report: a calendar whose
+          records all carry a date looks exactly as it did before.
+
+          ⛔ Deliberately inert, and that is the ruling, not an omission: no
+          drag-to-schedule, no date picker, no way to assign a date from here.
+          The ruled affordance is a visible count and an expandable list, and
+          nothing more. Do not grow this into a scheduling surface without a
+          fresh ruling. */}
+      {unscheduledRecords.length > 0 && (
+        <div className="mt-2 border-t pt-2" data-calendar-unscheduled="">
+          <button
+            type="button"
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            aria-expanded={unscheduledOpen}
+            onClick={() => setUnscheduledOpen((open) => !open)}
+          >
+            <ChevronRight
+              aria-hidden="true"
+              className={cn('h-4 w-4 transition-transform', unscheduledOpen && 'rotate-90')}
+            />
+            {t('calendar.unscheduled', {
+              count: unscheduledRecords.length,
+              defaultValue: 'Unscheduled ({{count}})',
+            })}
+          </button>
+          {unscheduledOpen && (
+            <ul className="mt-1 space-y-1 pl-6" data-calendar-unscheduled-list="">
+              {unscheduledRecords.map((record) => (
+                <li key={record.id} className="truncate text-sm">
+                  {record.title}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       {/* Quick-create dialog: opens when the user clicks an empty day cell.
           Pre-fills start_date (and end_date) with the clicked day; only the

--- a/packages/plugin-calendar/src/ObjectCalendar.unscheduled-7071.test.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.unscheduled-7071.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7071 — a record with NO value in the declared date field is no
+ * longer given a fabricated date.
+ *
+ * Ruled by the maintainer on 2026-09-01 (option 2, minimal form) and
+ * re-confirmed on 2026-09-02 after a second seat had recommended option 1: the
+ * `start: startDate ? new Date(startDate) : new Date()` fallback is deleted,
+ * and the records it used to invent a date for are counted in a collapsed
+ * "unscheduled (N)" area instead. ⛔ Option 1 (drop the row, surface a dropped
+ * count) was considered and NOT adopted — do not "simplify" this file toward
+ * it.
+ *
+ * ## Why the grid half of every assertion is written against `CalendarView`'s
+ * ## `events` prop rather than the rendered grid
+ *
+ * "Appears in the unscheduled area" alone would pass on an implementation that
+ * ALSO still draws the record on today's cell — which is precisely the defect.
+ * The two halves must both be asserted, and the strongest available spelling of
+ * "nowhere on the grid" is that the event never reaches the grid component at
+ * all. `CalendarView` is therefore mocked to record its `events` prop (the same
+ * technique as `ObjectCalendar.colorFieldLadder-7243.test.tsx` next door), while
+ * the unscheduled area itself renders for real — `ObjectCalendar` owns that DOM.
+ *
+ * ## The four facts pinned here
+ *
+ *   1. a record with no start renders in the unscheduled area AND nowhere on
+ *      the grid;
+ *   2. a record with a start and no end still renders ALL-DAY — the ruling's
+ *      "`allDay: !endDate` applies only to records that have a start" must not
+ *      over-reach and break the legitimate all-day case;
+ *   3. the "(N)" equals the number of startless records;
+ *   4. a PRESENT but unparseable value still goes through the `isNaN` filter —
+ *      dropped, not bucketed as unscheduled. Absent and malformed are two
+ *      different defects and the two code paths stay distinguishable; a fix
+ *      that routed both into the same bucket would pass 1-3 and fail here.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import { ObjectCalendar } from './ObjectCalendar';
+
+afterEach(cleanup);
+
+// The overlay drawer is irrelevant here and drags in a per-record permission
+// probe that would leave the process for real (see the propsContract suite's
+// own note on that probe). Stub it out.
+vi.mock('@object-ui/plugin-detail', () => ({
+  RecordDetailDrawer: () => null,
+  deriveRecordPageHref: () => null,
+}));
+
+let lastEvents: any[] = [];
+
+vi.mock('./CalendarView', async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    CalendarView: ({ events }: any) => {
+      lastEvents = events;
+      return <div data-testid="calendar-view" data-event-count={String(events.length)} />;
+    },
+  };
+});
+
+const OBJECT_SCHEMA = {
+  name: 'duly_task',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    subject: { name: 'subject', type: 'text' },
+    starts_at: { name: 'starts_at', type: 'datetime' },
+    ends_at: { name: 'ends_at', type: 'datetime' },
+  },
+};
+
+/**
+ * One row per path through the mapping loop.
+ *
+ * `no-start-field` and `empty-start` are the two spellings of "no value" this
+ * component has always tested with the same truthiness check the deleted
+ * fallback used, so both must land in the same bucket.
+ */
+const ROWS = [
+  {
+    id: 'timed',
+    subject: 'Timed meeting',
+    starts_at: '2026-01-05T09:00:00Z',
+    ends_at: '2026-01-05T10:00:00Z',
+  },
+  { id: 'all-day', subject: 'Company holiday', starts_at: '2026-01-06T00:00:00Z' },
+  { id: 'no-start-field', subject: 'Someday task' },
+  { id: 'empty-start', subject: 'Blank date task', starts_at: '' },
+  { id: 'garbage-start', subject: 'Broken date task', starts_at: 'not a date' },
+];
+
+const SCHEMA: any = {
+  type: 'object-calendar',
+  objectName: 'duly_task',
+  calendar: {
+    startDateField: 'starts_at',
+    endDateField: 'ends_at',
+    titleField: 'subject',
+  },
+};
+
+const makeDataSource = (rows: any[]) =>
+  ({
+    find: vi.fn(async () => ({ data: rows, total: rows.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => OBJECT_SCHEMA),
+  }) as any;
+
+async function renderCalendar(rows: any[] = ROWS) {
+  lastEvents = [];
+  const view = render(<ObjectCalendar schema={SCHEMA} dataSource={makeDataSource(rows)} />);
+  await waitFor(() => expect(screen.getByTestId('calendar-view')).toBeTruthy());
+  return view;
+}
+
+const idsOnGrid = () => lastEvents.map((e) => String(e.id));
+const area = (container: HTMLElement) =>
+  container.querySelector('[data-calendar-unscheduled]');
+const list = (container: HTMLElement) =>
+  container.querySelector('[data-calendar-unscheduled-list]');
+
+describe('objectui#7071 — records with no date land in an unscheduled area, not on today', () => {
+  it('ARM 1: a startless record is in the unscheduled area AND nowhere on the grid', async () => {
+    const { container } = await renderCalendar();
+    await waitFor(() => expect(lastEvents.length).toBeGreaterThan(0));
+
+    // Nowhere on the grid: the event never reaches `CalendarView` at all.
+    expect(idsOnGrid()).not.toContain('no-start-field');
+    expect(idsOnGrid()).not.toContain('empty-start');
+    expect(lastEvents.some((e) => e.data?.id === 'no-start-field')).toBe(false);
+
+    // ...and in the area, once expanded.
+    const el = area(container);
+    expect(el).not.toBeNull();
+    fireEvent.click(el!.querySelector('button')!);
+    expect(list(container)!.textContent).toContain('Someday task');
+    expect(list(container)!.textContent).toContain('Blank date task');
+  });
+
+  it('ARM 1 (the deleted fabrication): no event is stamped with the current moment', async () => {
+    await renderCalendar();
+    await waitFor(() => expect(lastEvents.length).toBeGreaterThan(0));
+
+    // Before the fix, `no-start-field` and `empty-start` arrived here carrying
+    // `new Date()` — a valid Date the `isNaN` guard was guaranteed to pass, on
+    // today's cell, indistinguishable from a real event. Every start that
+    // reaches the grid now traces back to a value the RECORD carried.
+    const now = Date.now();
+    for (const event of lastEvents) {
+      expect(Math.abs(event.start.getTime() - now)).toBeGreaterThan(60_000);
+      expect(new Date(event.data.starts_at).getTime()).toBe(event.start.getTime());
+    }
+  });
+
+  it('ARM 2: a record with a start and no end still renders ALL-DAY', async () => {
+    await renderCalendar();
+    await waitFor(() => expect(lastEvents.length).toBeGreaterThan(0));
+
+    const allDay = lastEvents.find((e) => String(e.id) === 'all-day');
+    expect(allDay).toBeTruthy();
+    expect(allDay.allDay).toBe(true);
+    expect(allDay.end).toBeUndefined();
+
+    // The other direction, so "everything is all-day" cannot pass this file:
+    // a record with both dates is still a timed event.
+    const timed = lastEvents.find((e) => String(e.id) === 'timed');
+    expect(timed.allDay).toBe(false);
+
+    // And the arm the ruling settled: a record with NO start is unscheduled,
+    // not all-day. It is absent from the grid entirely, so there is no all-day
+    // event for it to have become.
+    expect(lastEvents.some((e) => String(e.id) === 'no-start-field')).toBe(false);
+  });
+
+  it('ARM 3: the count equals the number of startless records', async () => {
+    const { container } = await renderCalendar();
+    await waitFor(() => expect(lastEvents.length).toBeGreaterThan(0));
+
+    // Two of the five rows have no value in `starts_at`.
+    expect(area(container)!.textContent).toContain('Unscheduled (2)');
+
+    // The count is a count of the LIST, not a separate tally that could drift.
+    fireEvent.click(area(container)!.querySelector('button')!);
+    expect(list(container)!.querySelectorAll('li')).toHaveLength(2);
+  });
+
+  it('ARM 4: a PRESENT but unparseable value is filtered, not bucketed as unscheduled', async () => {
+    const { container } = await renderCalendar();
+    await waitFor(() => expect(lastEvents.length).toBeGreaterThan(0));
+
+    // The `isNaN` guard keeps its original job.
+    expect(idsOnGrid()).not.toContain('garbage-start');
+    // ...and this is a DIFFERENT fact from "no value": it is not in the area,
+    // and it is not in the count (which stays 2, not 3).
+    expect(area(container)!.textContent).toContain('Unscheduled (2)');
+    fireEvent.click(area(container)!.querySelector('button')!);
+    expect(list(container)!.textContent).not.toContain('Broken date task');
+  });
+
+  it('the area is collapsed by default and expands on click', async () => {
+    const { container } = await renderCalendar();
+    await waitFor(() => expect(lastEvents.length).toBeGreaterThan(0));
+
+    const toggle = area(container)!.querySelector('button')!;
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(list(container)).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(list(container)).not.toBeNull();
+
+    fireEvent.click(toggle);
+    expect(list(container)).toBeNull();
+  });
+
+  it('CONTROL: a calendar whose records all carry a date grows no area at all', async () => {
+    const { container } = await renderCalendar(ROWS.slice(0, 2));
+    await waitFor(() => expect(lastEvents.length).toBe(2));
+
+    expect(area(container)).toBeNull();
+    expect(idsOnGrid()).toEqual(['timed', 'all-day']);
+  });
+
+  it('SCOPE FENCE: the area offers no way to schedule anything', async () => {
+    // The ruling is explicit that this is a count and a list and nothing more:
+    // no drag-to-schedule, no scheduling UI. Pinned so a later "helpful"
+    // addition has to argue with a red test instead of slipping in.
+    const { container } = await renderCalendar();
+    await waitFor(() => expect(lastEvents.length).toBeGreaterThan(0));
+    fireEvent.click(area(container)!.querySelector('button')!);
+
+    const el = area(container)!;
+    // One control only: the disclosure toggle itself.
+    expect(el.querySelectorAll('button')).toHaveLength(1);
+    expect(el.querySelectorAll('input, select, textarea, [draggable="true"]')).toHaveLength(0);
+    for (const item of Array.from(el.querySelectorAll('li'))) {
+      expect(item.getAttribute('draggable')).toBeNull();
+      expect(item.getAttribute('role')).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #7071

A record whose declared `startDateField` carried **no value** was mapped to
`new Date()` — the current moment — and drawn on today's cell as an ordinary
event, indistinguishable from a real one. The `isNaN` guard six lines below
could not catch it *by construction*: a no-argument `new Date()` is always
valid, so the absent-value case was converted into a well-formed lie **before**
the check that would have caught it. `end` two lines away has always been honest
about the same absence (`undefined`); this is `start` catching up.

## The ruling this implements

Maintainer, 2026-09-01 (director decision batch D, verbatim 「同意」): **option 2,
minimal form** — the fabricating arm is deleted and such records land in a
collapsed "unscheduled (N)" area. **Re-confirmed 2026-09-02** (director seat,
summon #8, decision batch #5, verbatim 「同意」) after a second seat, not having
read the first ruling, had recommended option 1 and moved the card back to
`needs-user-decision`.

⛔ **Option 1 (drop the row, surface a dropped-rows count) was considered and is
NOT what this PR does.** The `ChartFootnote` precedent it cited is a different
shape; it was put to the maintainer and declined.

## What changed

`packages/plugin-calendar/src/ObjectCalendar.tsx` — the event-mapping `useMemo`
now makes **one** pass producing two lists, so the count under the calendar can
never disagree with the grid:

1. **`start` stops fabricating.** `startDate ? new Date(startDate) : new Date()`
   loses its second arm. A record with no start value is pushed to
   `unscheduledRecords` and returns — it never reaches `CalendarView`.
2. **`allDay: !endDate` applies only to records that HAVE a start.** The early
   return above it is the mechanism, and it is the point rather than an accident
   of ordering: `!endDate` used to fire for a record with *no dates at all*, so
   one absent field silently set two rendered properties and a dateless record
   rendered as an all-day event on today. A record with a start and no end is
   unchanged.
3. **The `isNaN` filter keeps its original job** for a value that is *present but
   unparseable*. That record is dropped, never bucketed as unscheduled — absent
   and malformed are two different defects and the two paths stay separable in
   both the code and the tests.

The area itself: collapsed by default, a visible `Unscheduled (N)` count, an
expandable list of titles. **Deliberately inert per the ruling — no
drag-to-schedule, no date picker, no way to assign a date from here.** A
dedicated `SCOPE FENCE` test pins that, so a later "helpful" addition has to
argue with a red test. Click-through to the record was also *not* added: it is
outside the ruled affordance.

i18n: one new key, `calendar.unscheduled` = `Unscheduled ({{count}})`, added to
all ten locale packs. It reads through `useObjectTranslation` rather than the
file's existing `useSafeTranslate`, because the latter passes no options to
i18next and so cannot fill the `{{count}}` hole; both spell the provider-less
fallback the same way (objectui#6219), so the label is correct with or without
an `I18nProvider`.

**Changeset: `patch`** for `@object-ui/plugin-calendar` + `@object-ui/i18n`. This
is a defect fix — a renderer that invented data — and the area is the honest
surface that fix needs, not a feature in its own right. No contract change
(Clause ② no): no spec key, no public type, no authored metadata moves.

## Tests

New `packages/plugin-calendar/src/ObjectCalendar.unscheduled-7071.test.tsx`,
8 cases. The grid half of each assertion is written against the `events` prop
handed to a mocked `CalendarView` (same technique as
`ObjectCalendar.colorFieldLadder-7243.test.tsx` next door), because "appears in
the unscheduled area" *alone* would pass on an implementation that also still
draws the record on today's cell — which is the defect. The area itself renders
for real; `ObjectCalendar` owns that DOM.

The ruling's three pins, plus a fourth:

1. **ARM 1** — a startless record is in the area **and nowhere on the grid**
   (both halves asserted), with a companion case proving no event that *does*
   reach the grid is stamped with the current moment.
2. **ARM 2** — a record with a start and no end still renders **all-day**
   (`allDay === true`, `end === undefined`), with the opposite direction pinned
   too (a record with both dates is still timed), so "everything is all-day"
   cannot pass.
3. **ARM 3** — the `(N)` equals the number of startless records (2 of 5 rows),
   and the list it expands to has exactly that many `li` elements.
4. **ARM 4 (added)** — a **present but unparseable** value (`'not a date'`) goes
   through the `isNaN` filter: absent from the grid, absent from the area, and
   *not* in the count. A fix that routed both cases into one bucket passes 1–3
   and fails here.

Plus: collapsed-by-default / expand / collapse, a CONTROL where every record
carries a date and no area is rendered at all, and the SCOPE FENCE above.

### Ablation — red-then-green, both legs proved on disk by content

The mutation restores the deleted fabricating arm
(`const start = startDate ? new Date(startDate) : new Date();`) — the pre-fix
behaviour exactly. The module is imported by the test through a **relative**
specifier, so vitest transforms the source file directly: there is no `dist/`
leg for this ablation to be blind to.

```
HEAD blob:        76da0f45fb96fa6d66fb6c0cd1434076f7590cc0
pre-mutation      removed-anchor 1 · injected-anchor 0
post-mutation     removed-anchor 0 · injected-anchor 1 · blob 953565f6… (≠ HEAD blob)
RED leg           Tests  7 failed | 1 passed (8)
restore           blob 76da0f45… == HEAD blob · `git diff HEAD` 0 bytes
                  removed-anchor back to 1 · injected-anchor back to 0
GREEN leg         Tests  8 passed (8)
```

Restore points at `HEAD` explicitly (`git checkout HEAD -- ` plus an absolute
path), is proved **by state** rather than by an exit code, and the script carries
`trap … EXIT INT TERM` with absolute paths.

**Directions were predicted before the run and all eight matched.** The two
informative ones:

- **CONTROL stays green** — a calendar whose records all carry a date cannot
  detect this defect, which is exactly why the other arms exist.
- **ARM 2 fails on its *unscheduled* assertion (line 187), not on its all-day
  assertions.** The all-day fact stays true under the mutation, which is the
  evidence that change (2) above did not over-reach: `allDay` and "has a start"
  are separate facts, and only the second one moved.

### Verification run

All at `a0a21897b`, the branch head:

```
pnpm exec vitest run packages/plugin-calendar/ packages/i18n/
  → Test Files 78 passed (78) · Tests 1054 passed (1054)
pnpm --filter @object-ui/plugin-calendar --filter @object-ui/i18n run type-check
  → both packages "Done"
pnpm --filter @object-ui/plugin-calendar --filter @object-ui/i18n run lint
  → 0 errors (149 pre-existing warnings, none on changed lines)
pnpm check:i18n-keys       → "Every in-scope call-site key resolves against the en
                              pack (2960 keys), every literal inline defaultValue
                              matches the value the pack serves, every call site
                              passes exactly the arguments that value has holes for"
pnpm check:i18n-drift      → "0 en value(s) changed (1 key(s) added, 0 removed)"
pnpm check:control-bytes   → "OK (scanned 6135 tracked text file(s))"
pnpm check:phantom-deps    → "Every in-scope import is declared by the package that publishes it"
pnpm check:self-import · check:side-effects-array · check:esm-specifiers → clean
node scripts/check-changeset-presence.mjs → "11 source file(s) of 2 released
                              package(s) changed, and this change declares 1 changeset"
node scripts/check-changeset-no-major.mjs → "No changeset declares a `major` bump"
```

The new test file was confirmed to be **inside** the typecheck program rather
than assumed to be — `tsc -p tsconfig.test.json --listFiles` lists it (1 hit).

**Not measured here:** `pnpm check:eager-closure` needs
`apps/console/dist/eager-closure.json`, which only a console `vite build` writes;
it exits 2 locally with "broken gauge, not a passing budget". That is a missing
prerequisite, not a red gate on this diff — CI owns that run. The repo-wide
`turbo run lint` farm is likewise CI's; the narrowing here is the two packages
this diff touches, declared.

## Drift note

The card and the ruling cite `:445` / `:451`. On current `main` the site is at
`ObjectCalendar.tsx:508` / `:514`. `ObjectCalendar.tsx` is also touched by the
unlanded PR #7391 (parked behind #7399); its hunks are disjoint from this one and
git merges by content, so this is line drift, not a conflict — this diff was kept
out of those regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_