### PR TITLE
fix(types): declare what the tooltip / context-menu renderers read

### DIFF
--- a/.changeset/6939-overlay-trigger-mirror.md
+++ b/.changeset/6939-overlay-trigger-mirror.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/types': patch
+---
+
+Repair the `tooltip` and `context-menu` mirrors: declare the keys their renderers
+actually read, and stop requiring the `children` neither of them reads
+(objectui#6939, maintainer ruling recorded 2026-09-02 — this is one of the eight
+groups on that card, dispatched as its own PR per the ruling).
+
+Both members demanded `children` and omitted keys the renderer reads first, so
+`safeValidateSchema` refused two catalog entries that draw correctly:
+
+- **`tooltip`** now declares `trigger`, and `content` / `body` as the two halves of
+  one read (`renderers/overlay/tooltip.tsx:28,31` — `renderChildren(schema.trigger)`
+  and `schema.content || renderChildren(schema.body)`). The registration's own
+  `inputs` list `trigger` / `content` / `body` and never `children`. `trigger`
+  follows `HoverCardSchema` two entries below, which is the settled in-repo shape
+  for this slot.
+- **`context-menu`** now declares `triggerClassName`, `contentClassName` and
+  `modal` (read at `renderers/overlay/context-menu.tsx:87,88,91`), which survived
+  only on `BaseSchema.passthrough()`.
+
+**patch, not minor: the accept set only widens toward what already renders.**
+Every key involved is optional, and `children` stays legal — it is `BaseSchema`'s
+own optional key, merely no longer demanded here. No document that validated
+before this change stops validating; documents the renderers already draw start
+validating. The TypeScript twins in `packages/types/src/overlay.ts` move in the
+same stroke, so the published declaration and the published validator keep saying
+the same thing.
+
+⛔ A tooltip's trigger is authored under `trigger`, never `children`: the catalog
+entry was already moved to `trigger` once on render evidence (objectui#4626 — it
+was a measured blank tile) and moving it back is a known regression.

--- a/content/docs/components/overlay/context-menu.mdx
+++ b/content/docs/components/overlay/context-menu.mdx
@@ -47,6 +47,9 @@ interface ContextMenuSchema {
   type: 'context-menu';
   trigger?: SchemaNode | SchemaNode[];  // Trigger element — a placeholder renders when absent
   items: ContextMenuItem[];             // Menu items
+  triggerClassName?: string;            // Classes for the right-clickable area
+  contentClassName?: string;            // Classes for the menu panel
+  modal?: boolean;                      // Forwarded to the Radix root
   className?: string;
 }
 ```

--- a/content/docs/components/overlay/tooltip.mdx
+++ b/content/docs/components/overlay/tooltip.mdx
@@ -12,8 +12,16 @@ description: "Contextual information on hover"
 ```plaintext
 interface TooltipSchema {
   type: 'tooltip';
-  content: string;
-  children: SchemaNode;
+  trigger?: SchemaNode | SchemaNode[];  // Element the tooltip attaches to
+  content?: string | SchemaNode;        // Tooltip content — read first
+  body?: SchemaNode | SchemaNode[];     // Rich content — the fallback half
   side?: 'top' | 'right' | 'bottom' | 'left';
+  align?: 'start' | 'center' | 'end';
+  delayDuration?: number;               // Delay before showing (ms)
 }
 ```
+
+The trigger is authored under `trigger`, not `children`: the renderer reads
+`schema.trigger` and `schema.content || schema.body`, and never `children`
+(objectui#6939). A tooltip that puts its trigger under `children` validates —
+`children` is a `BaseSchema` key — but paints an empty trigger.

--- a/examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx
+++ b/examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#6939, the `tooltip` + `context-menu` group — one of the eight the
+ * card measured, dispatched as its own PR per the maintainer ruling recorded
+ * 2026-09-02 (director seat, summon #8, decision batch #8).
+ *
+ * ## The defect
+ *
+ * Both mirrors in `@object-ui/types/zod` REQUIRED `children` — a key neither
+ * renderer reads — and omitted keys both renderers do read. `AnyComponentSchema`
+ * therefore refused two catalog entries that draw correctly:
+ *
+ *   - `tooltip` reads `schema.trigger` and `schema.content || schema.body`
+ *     (`renderers/overlay/tooltip.tsx:28,31`); its registration's `inputs` list
+ *     `trigger` / `content` / `body` and never `children`.
+ *   - `context-menu` reads `schema.trigger` and `schema.items` (:95, :99), plus
+ *     `triggerClassName` / `contentClassName` / `modal` (:87, :88, :91), none of
+ *     which were declared.
+ *
+ * ## Why the render half is the discriminating half
+ *
+ * From objectui#6318's triage: a "correction" that renders identically proves
+ * the SCHEMA was wrong, not the fixture. So a repair on the schema side has to
+ * clear the mirror image of that bar — the validator's verdict must change and
+ * the renderer's output must NOT. The numbers in `PRE_REPAIR` below were
+ * measured on `origin/main` at `5ad0641e0`, BEFORE the mirrors were touched,
+ * through this file's own harness. They are the "before" half of "byte-identical
+ * before and after"; a repair that moved a pixel reddens here.
+ *
+ * ⛔ Do NOT "fix" a red `authors its trigger under 'trigger'` case by moving the
+ * tooltip fixture back to `children`. It was already moved from `children` to
+ * `trigger` once, on render evidence (objectui#4626 measured it as a blank
+ * tile), and reverting it is a named regression — which is why the fixture
+ * spelling is pinned here rather than left implicit.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import '@object-ui/components';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
+import { ContextMenuSchema, TooltipSchema, safeValidateSchema } from '@object-ui/types/zod';
+import { getExample } from '../src/index.js';
+
+const TOOLTIP_ID = 'components-overlay-tooltip/basic-tooltip';
+const CONTEXT_MENU_ID = 'components-overlay-context-menu/basic-context-menu';
+
+/**
+ * The render measured on `origin/main` BEFORE the mirror repair. Element count
+ * and text are what the ruling names; the tag census is carried alongside
+ * because a count alone cannot tell a swapped element from an equal one.
+ */
+const PRE_REPAIR = {
+  [TOOLTIP_ID]: { elements: 1, text: 'Hover me', tags: ['BUTTON'] },
+  [CONTEXT_MENU_ID]: { elements: 3, text: 'Right-click here', tags: ['DIV', 'DIV', 'DIV'] },
+} as const;
+
+/** Render one entry the way the docs gallery does and measure what it drew. */
+function measure(schema: unknown) {
+  const { container } = render(
+    <SchemaRenderer schema={toRenderableSchema(schema as never) as never} />,
+  );
+  const nodes = Array.from(container.querySelectorAll('*'));
+  return {
+    elements: nodes.length,
+    text: container.textContent ?? '',
+    tags: nodes.map((el) => el.tagName),
+  };
+}
+
+/** Report the issues rather than `false`, so a red run says what broke. */
+function reasons(schema: unknown): string[] {
+  const r = safeValidateSchema(schema);
+  return r.success ? [] : r.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+}
+
+describe('objectui#6939 — the two entries the mirror refused now validate', () => {
+  it.each([TOOLTIP_ID, CONTEXT_MENU_ID])('%s validates under safeValidateSchema', (id) => {
+    // Both reported `: Invalid input` (the union's own top-level issue) before
+    // this card, for a key neither renderer reads.
+    expect(reasons(getExample(id).schema)).toEqual([]);
+  });
+});
+
+describe('objectui#6939 — and the repair moved the validator, not the renderer', () => {
+  it.each([TOOLTIP_ID, CONTEXT_MENU_ID] as const)('%s renders exactly what it rendered before', (id) => {
+    const after = measure(getExample(id).schema);
+    const before = PRE_REPAIR[id];
+    expect(after.elements).toBe(before.elements);
+    expect(after.text).toBe(before.text);
+    expect(after.tags).toEqual([...before.tags]);
+  });
+
+  it('anti-vacuity: both tiles drew something of their own', () => {
+    // An entry that renders nothing satisfies "identical" trivially.
+    for (const id of [TOOLTIP_ID, CONTEXT_MENU_ID]) {
+      const m = measure(getExample(id).schema);
+      expect(m.elements).toBeGreaterThan(0);
+      expect(m.text.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('the context menu still paints its AUTHORED trigger, not the placeholder', () => {
+    // The card's measurement for this row: "correcting" the fixture to
+    // `children` loses the authored trigger and the renderer's hardcoded
+    // fallback `Right click here` (no hyphen) takes its place.
+    const text = measure(getExample(CONTEXT_MENU_ID).schema).text;
+    expect(text).toBe('Right-click here');
+    expect(text).not.toBe('Right click here');
+  });
+});
+
+describe('objectui#6939 — `children` is no longer required on either member', () => {
+  it('a tooltip with no children validates', () => {
+    expect(reasons({ type: 'tooltip', trigger: { type: 'text', value: 'x' }, content: 'y' })).toEqual([]);
+    expect(TooltipSchema.safeParse({ type: 'tooltip' }).success).toBe(true);
+  });
+
+  it('a context menu with no children validates', () => {
+    expect(reasons({ type: 'context-menu', trigger: { type: 'text', value: 'x' }, items: [{ label: 'a' }] })).toEqual([]);
+    expect(ContextMenuSchema.safeParse({ type: 'context-menu', items: [] }).success).toBe(true);
+  });
+
+  it('the accept set only WIDENED — the `children` spelling still parses', () => {
+    // The ruling's patch reasoning. Nothing that validated before this change
+    // may stop validating; `children` survives as `BaseSchema`'s optional key.
+    expect(TooltipSchema.safeParse({
+      type: 'tooltip',
+      content: 'Helpful information',
+      children: [{ type: 'button', label: 'Hover me' }],
+    }).success).toBe(true);
+    expect(ContextMenuSchema.safeParse({
+      type: 'context-menu',
+      items: [{ label: 'Copy' }],
+      children: { type: 'text', value: 'Right-click here' },
+    }).success).toBe(true);
+  });
+});
+
+describe('objectui#6939 — the keys the renderers read are DECLARED, not passthrough holes', () => {
+  // Counter-probes. Every key probed is one the mirror now declares; an unknown
+  // key proves nothing, because `BaseSchema` is `.passthrough()`. Each of these
+  // parsed GREEN before this card for exactly that reason.
+  it('tooltip.trigger is a schema node, not anything at all', () => {
+    expect(TooltipSchema.safeParse({ type: 'tooltip', trigger: { label: 'no type' } }).success).toBe(false);
+    expect(TooltipSchema.safeParse({ type: 'tooltip', trigger: [{ label: 'no type' }] }).success).toBe(false);
+    // …and the authored shape still passes, so the two above are not failing
+    // for some unrelated reason.
+    expect(TooltipSchema.safeParse({ type: 'tooltip', trigger: [{ type: 'button', label: 'Hover me' }] }).success).toBe(true);
+  });
+
+  it('tooltip declares BOTH halves of its content read', () => {
+    const shape = (TooltipSchema as unknown as { shape: Record<string, unknown> }).shape;
+    expect(Object.keys(shape)).toEqual(expect.arrayContaining(['trigger', 'content', 'body']));
+    expect(TooltipSchema.safeParse({ type: 'tooltip', content: 'text only' }).success).toBe(true);
+    expect(TooltipSchema.safeParse({ type: 'tooltip', body: { type: 'text', value: 'rich only' } }).success).toBe(true);
+  });
+
+  it('context-menu declares triggerClassName / contentClassName / modal', () => {
+    const ok = { type: 'context-menu', items: [{ label: 'Copy' }] };
+    expect(ContextMenuSchema.safeParse({ ...ok, modal: 'yes' }).success).toBe(false);
+    expect(ContextMenuSchema.safeParse({ ...ok, triggerClassName: 5 }).success).toBe(false);
+    expect(ContextMenuSchema.safeParse({ ...ok, contentClassName: 5 }).success).toBe(false);
+    expect(ContextMenuSchema.safeParse({
+      ...ok, modal: true, triggerClassName: 'p-8', contentClassName: 'w-64',
+    }).success).toBe(true);
+  });
+});
+
+describe('objectui#6939 — the fixtures stay on the spelling their renderers read', () => {
+  it('basic-tooltip authors its trigger under `trigger` (objectui#4626)', () => {
+    const schema = getExample(TOOLTIP_ID).schema as Record<string, unknown>;
+    expect(schema.trigger).toBeDefined();
+    expect('children' in schema).toBe(false);
+  });
+
+  it('basic-context-menu authors its trigger under `trigger`', () => {
+    const schema = getExample(CONTEXT_MENU_ID).schema as Record<string, unknown>;
+    expect(schema.trigger).toBeDefined();
+    expect('children' in schema).toBe(false);
+  });
+});

--- a/packages/types/src/overlay.ts
+++ b/packages/types/src/overlay.ts
@@ -287,17 +287,46 @@ export interface PopoverSchema extends BaseSchema {
 
 /**
  * Tooltip component
+ *
+ * ⚠️ This declaration used to REQUIRE `children` and declare neither `trigger`
+ * nor `body` (objectui#6939). Nothing reads `children` here — the renderer
+ * reads `schema.trigger` and `schema.content || renderChildren(schema.body)`
+ * (`packages/components/src/renderers/overlay/tooltip.tsx:28,31`), and the
+ * registration's own `inputs` list `trigger` / `content` / `body` and never
+ * `children`. `children` stays legal through {@link BaseSchema}, where it is
+ * optional; it is no longer demanded, so nothing that type-checked before
+ * stops type-checking.
+ *
+ * ⛔ Do not move a tooltip's trigger back under `children`: `basic-tooltip`
+ * was already moved from `children` to `trigger` on render evidence
+ * (objectui#4626 — a measured blank tile) and reverting it is a named
+ * regression.
  */
 export interface TooltipSchema extends BaseSchema {
   type: 'tooltip';
   /**
-   * Tooltip content/text
+   * Element the tooltip attaches to.
+   *
+   * READ SITE: `packages/components/src/renderers/overlay/tooltip.tsx:28` —
+   * `renderChildren(schema.trigger)` inside `TooltipTrigger`. The same spelling
+   * {@link HoverCardSchema.trigger} declares, which is the settled in-repo
+   * shape for this slot.
    */
-  content: string | SchemaNode;
+  trigger?: SchemaNode | SchemaNode[];
   /**
-   * Element to attach tooltip to
+   * Tooltip content/text — the FIRST half of the content read.
+   *
+   * READ SITE: `packages/components/src/renderers/overlay/tooltip.tsx:31` —
+   * `schema.content || renderChildren(schema.body)`. Optional because
+   * {@link TooltipSchema.body} is the other half of that same read.
    */
-  children: SchemaNode;
+  content?: string | SchemaNode;
+  /**
+   * Rich tooltip content — the FALLBACK half of the same read at
+   * `packages/components/src/renderers/overlay/tooltip.tsx:31`, listed by the
+   * registration as the "Rich Content" slot.
+   */
+  body?: SchemaNode | SchemaNode[];
   /**
    * Tooltip side
    * @default 'top'
@@ -508,6 +537,13 @@ export interface DropdownMenuSchema extends BaseSchema {
 
 /**
  * Context menu component
+ *
+ * ⚠️ This declaration used to REQUIRE `children`, which no read site consumes
+ * (objectui#6939): the renderer reads `schema.trigger` and `schema.items`
+ * (`packages/components/src/renderers/overlay/context-menu.tsx:95,99`), so a
+ * document authoring its right-clickable area under `children` loses it to the
+ * hardcoded placeholder. `children` stays legal through {@link BaseSchema},
+ * where it is optional; it is simply no longer demanded.
  */
 export interface ContextMenuSchema extends BaseSchema {
   type: 'context-menu';
@@ -516,24 +552,42 @@ export interface ContextMenuSchema extends BaseSchema {
    */
   items: MenuItem[];
   /**
-   * Element to attach context menu to
-   */
-  children: SchemaNode | SchemaNode[];
-  /**
    * The right-clickable area's content.
    *
    * READ SITE: `packages/components/src/renderers/overlay/context-menu.tsx:95`
    * — `renderChildren(schema.trigger || { type: 'text', value: 'Right click here' })`
    * inside `ContextMenuTrigger`. ⚠️ Note the renderer renders `trigger`, NOT
-   * the declared {@link ContextMenuSchema.children}, which no read site
-   * consumes.
+   * `children` — which this member used to sit beside as a REQUIRED key and
+   * which no read site consumes (objectui#6939 dropped that requirement;
+   * `children` is now only {@link BaseSchema}'s optional one).
    *
-   * Declared OPTIONAL although the docs page shows it required: the renderer
-   * substitutes a placeholder when it is absent, so every document without a
-   * `trigger` is legal today and declaring it required would refuse them.
-   * Declared by objectui#6150.
+   * Declared OPTIONAL: the renderer substitutes a placeholder when it is
+   * absent, so every document without a `trigger` is legal today and declaring
+   * it required would refuse them. Declared by objectui#6150.
    */
   trigger?: SchemaNode | SchemaNode[];
+  /**
+   * Classes for the right-clickable area.
+   *
+   * READ SITE: `packages/components/src/renderers/overlay/context-menu.tsx:87`
+   * — first in `schema.triggerClassName || className || schema.className ||
+   * <a dashed-border default>`. Undeclared until objectui#6939, surviving only
+   * on `BaseSchema`'s index signature.
+   */
+  triggerClassName?: string;
+  /**
+   * Classes for the menu panel.
+   *
+   * READ SITE: `packages/components/src/renderers/overlay/context-menu.tsx:88`,
+   * applied to `ContextMenuContent` at :98. Undeclared until objectui#6939.
+   */
+  contentClassName?: string;
+  /**
+   * Forwarded to the Radix `ContextMenu` root — `modal={schema.modal}` at
+   * `packages/components/src/renderers/overlay/context-menu.tsx:91`.
+   * Undeclared until objectui#6939.
+   */
+  modal?: boolean;
 }
 
 /**

--- a/packages/types/src/zod/overlay.zod.ts
+++ b/packages/types/src/zod/overlay.zod.ts
@@ -101,11 +101,37 @@ export const PopoverSchema = BaseSchema.extend({
 
 /**
  * Tooltip Schema - Tooltip component
+ *
+ * ⚠️ This member used to REQUIRE `children` and declare neither `trigger` nor
+ * `body` (objectui#6939). No read site has ever consumed `children` here: the
+ * renderer reads `schema.trigger` (`renderers/overlay/tooltip.tsx:28`) and
+ * `schema.content || renderChildren(schema.body)` (:31), and the registration's
+ * own `inputs` list `trigger` / `content` / `body` and never `children`. So the
+ * validator refused documents the renderer draws and blessed a spelling that
+ * paints an empty trigger — `declared !== enforced`, with the corpus on the
+ * right side of it.
+ *
+ * `HoverCardSchema` two entries below is the settled in-repo shape for this
+ * pair of slots and is what `trigger` follows here.
+ *
+ * ⛔ Do not "repair" a tooltip document by moving its trigger back under
+ * `children`: `basic-tooltip` was ALREADY moved from `children` to `trigger` on
+ * render evidence (objectui#4626 — it was a measured blank tile), and reverting
+ * it is a named regression.
+ *
+ * Every slot is optional because the accept set may only WIDEN toward what
+ * already renders: `children` stays legal (inherited from `BaseSchema`, where
+ * it is optional), and nothing that validated before this change stops
+ * validating.
  */
 export const TooltipSchema = BaseSchema.extend({
   type: z.literal('tooltip'),
-  content: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).describe('Tooltip content'),
-  children: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).describe('Tooltip children'),
+  trigger: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()
+    .describe('Element the tooltip attaches to, read at renderers/overlay/tooltip.tsx:28 — `renderChildren(schema.trigger)` inside `TooltipTrigger` (objectui#6939)'),
+  content: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()
+    .describe('Tooltip content, read FIRST at renderers/overlay/tooltip.tsx:31 — `schema.content || renderChildren(schema.body)`. Optional because `body` is the other half of that read (objectui#6939)'),
+  body: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()
+    .describe('Rich tooltip content — the fallback half of the same read at renderers/overlay/tooltip.tsx:31, listed by the registration as the "Rich Content" slot (objectui#6939)'),
   side: z.enum(['top', 'right', 'bottom', 'left']).optional().describe('Tooltip side'),
   align: z.enum(['start', 'center', 'end']).optional().describe('Tooltip alignment'),
   delayDuration: z.number().optional().describe('Delay before showing (ms)'),
@@ -183,13 +209,29 @@ export const DropdownMenuSchema = BaseSchema.extend({
 
 /**
  * Context Menu Schema - Context menu component
+ *
+ * ⚠️ This member used to REQUIRE `children`, which no read site consumes
+ * (objectui#6939). The renderer reads `schema.trigger` and `schema.items`
+ * (`renderers/overlay/context-menu.tsx:95,99`), so a document authoring its
+ * right-clickable area under `children` loses it to the hardcoded placeholder
+ * — `Right-click here` renders as `Right click here`. `children` stays legal
+ * (inherited from `BaseSchema`, where it is optional); it is simply no longer
+ * demanded, so the accept set only widens toward what already renders.
+ *
+ * `triggerClassName` / `contentClassName` / `modal` are read at :87, :88 and
+ * :91 and were undeclared, surviving only on `BaseSchema.passthrough()`.
  */
 export const ContextMenuSchema = BaseSchema.extend({
   type: z.literal('context-menu'),
   items: z.array(MenuItemSchema).describe('Menu items'),
-  children: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).describe('Context menu children'),
   trigger: z.union([SchemaNodeSchema, z.array(SchemaNodeSchema)]).optional()
-    .describe("Right-clickable area, read at renderers/overlay/context-menu.tsx:95 — `renderChildren(schema.trigger || {type:'text', value:'Right click here'})`. Optional although the docs page shows it required: the renderer substitutes a placeholder, so trigger-less documents are legal today (objectui#6150)"),
+    .describe("Right-clickable area, read at renderers/overlay/context-menu.tsx:95 — `renderChildren(schema.trigger || {type:'text', value:'Right click here'})`. Optional: the renderer substitutes a placeholder, so trigger-less documents are legal today (objectui#6150)"),
+  triggerClassName: z.string().optional()
+    .describe('Classes for the right-clickable area, read FIRST at renderers/overlay/context-menu.tsx:87 — `schema.triggerClassName || className || schema.className || <a dashed-border default>` (objectui#6939)'),
+  contentClassName: z.string().optional()
+    .describe('Classes for the menu panel, read at renderers/overlay/context-menu.tsx:88 and applied to `ContextMenuContent` at :98 (objectui#6939)'),
+  modal: z.boolean().optional()
+    .describe('Forwarded to the Radix `ContextMenu` root at renderers/overlay/context-menu.tsx:91 — `modal={schema.modal}` (objectui#6939)'),
 });
 
 /**


### PR DESCRIPTION
Part of #6939 — the `tooltip` + `context-menu` group, **one of eight**. The card
stays open; the other seven groups are their own PRs per the maintainer ruling
recorded on that card 2026-09-02 (director seat, summon #8, decision batch #8).

## What was wrong

For both components the Zod mirror in `@object-ui/types/zod` **required
`children`** — which neither renderer reads — and **omitted the keys they do
read**. `safeValidateSchema` therefore refused two catalog entries that draw
correctly: `declared` and `enforced` disagreed, with the corpus on the right side.

| component | mirror demanded | renderer actually reads |
|---|---|---|
| `tooltip` | `children` (required) | `schema.trigger`, and `schema.content OR schema.body` — `renderers/overlay/tooltip.tsx:28,31`. Its registration's own `inputs` list `trigger` / `content` / `body` and never `children`. |
| `context-menu` | `children` (required) | `schema.trigger`, `schema.items` (`:95`, `:99`), plus `triggerClassName` / `contentClassName` / `modal` (`:87`, `:88`, `:91`), none of them declared |

## What changed

`packages/types/src/zod/overlay.zod.ts` and its TypeScript twin
`packages/types/src/overlay.ts`, moved in the same stroke so the published
declaration and the published validator keep saying the same thing:

- **`tooltip`** — declares `trigger`, and `content` / `body` as the two halves of
  one read. `trigger` follows `HoverCardSchema` two entries below, which the
  ruling names as the settled in-repo shape. `content` becomes optional because
  `body` is the other half of the same `OR`.
- **`context-menu`** — declares `triggerClassName`, `contentClassName` and
  `modal`, which until now survived only on `BaseSchema.passthrough()`.
- **Neither requires `children` any more.** It stays legal — it is `BaseSchema`'s
  own optional key — it is simply no longer demanded.

Docs updated to match: `content/docs/components/overlay/tooltip.mdx` still showed
`content: string; children: SchemaNode;`, which was the declaration this PR
corrects.

**Changeset: `@object-ui/types`, patch.** Per the ruling, patch "where the accept
set only widens toward what already renders", which is exactly this group: every
key involved is optional and `children` still parses, so no document that
validated before this change stops validating.

## Pin — both halves the ruling asks for

`examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx`, 14 cases.

**1. The catalog entries validate** (they did not before — both reported the
union's own `: Invalid input`).

**2. Their render is byte-identical in element count and text, before and after.**
This is the discriminating half: the repair must move what the *validator*
accepts, not what the *renderer* draws. The numbers below were measured on
`origin/main` at `5ad0641e0` through the test's own harness, BEFORE the mirrors
were touched, and are asserted as literals in the file:

| entry | elements | text | tags |
|---|---|---|---|
| `components-overlay-tooltip/basic-tooltip` | 1 → 1 | `Hover me` → `Hover me` | `BUTTON` → `BUTTON` |
| `components-overlay-context-menu/basic-context-menu` | 3 → 3 | `Right-click here` → `Right-click here` | `DIV,DIV,DIV` → `DIV,DIV,DIV` |

The context-menu case additionally asserts the text is the AUTHORED
`Right-click here` and not the renderer's hardcoded placeholder (the card's own
measurement for that row), and an anti-vacuity case rules out "identical because
nothing rendered".

**Negative arm** — `children` is no longer required on either member; the keys the
renderers read are DECLARED rather than passthrough holes (counter-probes that a
passthrough hole cannot fail: a non-boolean `modal`, a numeric
`triggerClassName` / `contentClassName`, a `trigger` object with no `type`), each
paired with the good shape so a red case cannot be red for an unrelated reason;
and the widening is pinned — the `children` spelling still parses on both.

⛔ The tooltip fixture is NOT reverted to `children`. It was already moved from
`children` to `trigger` once on render evidence (objectui#4626 measured it as a
blank tile); that spelling is now pinned in this file so the regression cannot
land quietly.

## Ledger

`packages/types/src/__tests__/zod-mirror-parity.test.ts` — **measured first: no
entry existed** for `overlay.zod.ts#TooltipSchema` or
`overlay.zod.ts#ContextMenuSchema` in `KnownDrift`, `UnmirroredDeclared` or
`RuntimeOnlyDeclared` (the file's only overlay entries are the objectui#6124
runtime-slot ones on `AlertDialog` / `Dialog` / `Drawer` / `DropdownMenu` /
`HoverCard` / `Popover` / `Sheet`). Because both faces moved together, none is
needed now either, and **the ledger file is untouched** — so the two unlanded PRs
that do touch it (#7432, #7447) have nothing to conflict with here.

That is asserted, not assumed: `tsc -p packages/types/tsconfig.test.json` compiles
that file, and `--listFiles` confirms both edited sources and the parity test are
in the program, so the compile-time `assertionDriftMatchesLedger` was genuinely
evaluated.

## Red-then-green ablation

Mutation leg: restore `packages/types/src/zod/overlay.zod.ts` to the pinned base
`5ad0641e0` (undo the repair) and re-run the pin. `@object-ui/types/zod` is
vitest-aliased to `packages/types/src/zod/index.zod.ts` — SOURCE, no `dist` — so
the mutation is what the run reads.

- Mutation proven on disk before the run: blob `8d8d7b8b` becomes `44ba6619`
  (equal to the base blob), injected anchor `1 → 0`, deleted anchor `0 → 1`.
- **Red leg: 7 failed | 7 passed.** Every failure is validator-facing (the two
  entries, the two "no children required" cases, the three declaration
  counter-probes). Both render-identity cases, anti-vacuity, the authored-trigger
  case, the widening case and the two fixture-spelling cases stayed **green** —
  which is the ablation's own confirmation of the discriminating claim: undoing
  the repair changes the verdict and not one pixel of the render.
- Restore proven BY STATE, not by exit code: blob back to `8d8d7b8b` (equal to
  HEAD), anchors back to `1` / `0`, `git diff HEAD` on the path empty, working
  tree clean. `trap` on EXIT/INT/TERM with absolute paths throughout.
- Green leg on the restored tree: 14 passed.

## Verification

Run at final HEAD `9ecd3b0af` with a clean tree:

- `pnpm exec vitest run packages/types/ examples/schema-catalog/` — 113 files,
  3499 tests passed, exit 0
- `pnpm --filter @object-ui/types --filter @object-ui/example-schema-catalog run type-check` — exit 0
- `pnpm --filter @object-ui/types --filter @object-ui/example-schema-catalog run lint` — exit 0 (273 pre-existing warnings, 0 errors)
- gates whose inputs this diff touches: `check:control-bytes`, `check:doc-fences`,
  `check:doc-types`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`,
  `check:spec-symbols`, `check:changeset-presence`, `check:changeset-no-major` — all exit 0

`check:doc-snippets` reports PRECONDITION NOT MET on an unbuilt tree and is left
to CI, with a measured narrowing rather than a guess: read from the gate's own
`analyze()`, it covers 225 documents / 193 covered / 417 compiled blocks, its
`TS_FENCE_LANGUAGES` is `ts` / `tsx` / `typescript`, and the two documents edited
here are in the covered set while contributing **0** of the 417 compiled blocks —
their only fence is `plaintext`. No other document mentions either schema name.

`check:readme-exports` also reports the unbuilt-tree failure ("run `pnpm build`
first", 406 unjudgeable self-imports across 43 READMEs); this diff edits no README
and adds or removes no export symbol.

## Landing

Stays **draft**: not enqueued, not auto-merged, not self-reviewed. It waits on the
project director seat with `needs:contract-review`. Expected, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_