### PR TITLE
docs(skills): tag the 16 comment-carrying JSON fences `jsonc`

### DIFF
--- a/.changeset/jsonc-fence-extractor-test-only.md
+++ b/.changeset/jsonc-fence-extractor-test-only.md
@@ -1,0 +1,7 @@
+---
+---
+
+Test-only change in `@object-ui/components`: the skill-guide fence extractor in
+`skill-guide-data-table-binding.test.tsx` now reads `jsonc` fences as well as
+`json`, so retagging a comment-carrying guide example no longer hides it from
+every assertion in that file. No published behaviour changes.

--- a/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
+++ b/packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx
@@ -91,10 +91,16 @@ function readGuide(rel: string): string {
   return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
 }
 
-/** Every fenced ```json block body in a markdown file, in document order. */
+/**
+ * Every fenced ```json OR ```jsonc block body in a markdown file, in document
+ * order. Both tags are read on purpose: the guides tag their comment-carrying
+ * examples ```jsonc, and `parseBlock` below already strips those `//` comments
+ * before parsing. Reading only ```json would let a retag silently hide an
+ * example from every assertion here — which is a pass, not a failure.
+ */
 function jsonBlocks(md: string): string[] {
   const out: string[] = [];
-  const fence = /```json\n([\s\S]*?)```/g;
+  const fence = /```jsonc?\n([\s\S]*?)```/g;
   let m: RegExpExecArray | null;
   while ((m = fence.exec(md)) !== null) out.push(m[1]);
   return out;

--- a/skills/objectui/guides/schema-expressions.md
+++ b/skills/objectui/guides/schema-expressions.md
@@ -29,7 +29,7 @@ full boundary tables -- the evaluated fields, the raw ones, `visible` over
 -- are in [`rules/protocol.md`](../rules/protocol.md), which is the anchor for
 this rule. The four cases that decide most schemas:
 
-```json
+```jsonc
 // Evaluated, then dropped -- renders an empty card
 { "type": "card", "props": { "title": "${data.customer.name}" } }
 
@@ -167,7 +167,7 @@ name, so calls are case-insensitive.
 
 Each condition field has two forms — a shorthand and an `On` suffix:
 
-```json
+```jsonc
 { "hidden": true }                              // static boolean
 { "hidden": "${data.role !== 'admin'}" }        // template expression
 { "hiddenOn": "data.role !== 'admin'" }         // raw expression (no ${} needed)
@@ -325,7 +325,7 @@ what reaches the screen.
 `list` is the component authors reach for first, and it is **data-as-nodes**:
 the array it renders *is* the node list. It never reads `children`.
 
-```json
+```jsonc
 // ❌ Renders two EMPTY <li>. `children` is not a template — `list` never reads it,
 //    and `${item.name}` would render literally even if it did.
 {
@@ -352,7 +352,7 @@ descriptor:
 section exists to close: binding `list` to ordinary records produces one empty
 `<li>` per record — the right number of bullets, no text in any of them.
 
-```json
+```jsonc
 // ✅ Authored items — `title` and `ordered` are read off the node
 {
   "type": "list",
@@ -362,7 +362,7 @@ section exists to close: binding `list` to ordinary records produces one empty
 }
 ```
 
-```json
+```jsonc
 // ✅ Bound data, already node-shaped: dataSource = { rows: [{ "content": "Ada" }, { "content": "Linus" }] }
 { "type": "list", "bind": "rows" }
 ```
@@ -371,7 +371,7 @@ Only `body` entries go back through `SchemaRenderer`, so they are the one place
 inside a list where expressions are evaluated at all — against the host scope,
 never against a current element:
 
-```json
+```jsonc
 // ✅ `${data.*}` works inside `body`; there is still no `${item.*}`
 {
   "type": "list",
@@ -388,7 +388,7 @@ never against a current element:
   accessors (`accessorKey`). Cell values are plain property lookups — never
   expressions — and `table` does not read `bind`.
 
-```json
+```jsonc
 // ✅ `table`: inline rows + column accessors, no per-row scope
 {
   "type": "table",
@@ -444,7 +444,7 @@ Expressions are compiled once per unique `(expression, variableNames)` pair and 
 
 **Cause:** The field isn't expression-evaluated. Use `content`.
 
-```json
+```jsonc
 // ❌ Won't evaluate — `value` is read but never templated
 { "type": "text", "value": "${data.total}" }
 
@@ -460,7 +460,7 @@ Expressions are compiled once per unique `(expression, variableNames)` pair and 
 **Cause 1:** `visible` is also set and takes priority.
 **Cause 2:** Expression returns a non-boolean truthy value — use explicit comparison.
 
-```json
+```jsonc
 // ❌ Truthy but not boolean
 { "hidden": "${data.count}" }
 
@@ -476,7 +476,7 @@ is **not** blocked — measured through the schema path, it returns a real
 `Date`. Prefer a formula function anyway: a `Date` object stringifies into
 the DOM as a locale-dependent blob.
 
-```json
+```jsonc
 // ✅ Works, but renders "Thu Jan 01 1970 …"
 { "type": "text", "content": "${new Date(data.timestamp)}" }
 
@@ -489,7 +489,7 @@ the DOM as a locale-dependent blob.
 
 ### Object literal in expression
 
-```json
+```jsonc
 // ❌ Object literals not supported
 { "type": "text", "style": "${{ color: 'red' }}" }
 

--- a/skills/objectui/rules/protocol.md
+++ b/skills/objectui/rules/protocol.md
@@ -154,7 +154,7 @@ key under `props` never reaches a `ui:*` / `page:*` renderer at all.
 **❌ FORBIDDEN:** Adding custom properties not defined in `@objectstack/spec`.
 
 **Example violation:**
-```json
+```jsonc
 {
   "type": "data-table",
   "fields": [...],  // ❌ spec uses "columns"
@@ -163,7 +163,7 @@ key under `props` never reaches a `ui:*` / `page:*` renderer at all.
 ```
 
 **✅ CORRECT:**
-```json
+```jsonc
 {
   "type": "data-table",
   "columns": [...]  // ✅ declared by DataTableSchema, read off the node
@@ -174,7 +174,7 @@ key under `props` never reaches a `ui:*` / `page:*` renderer at all.
 
 When the entire string is a single `${expression}`, the result preserves its type:
 
-```json
+```jsonc
 "${data.count}"        // → returns number 42, not string "42"
 "${data.isActive}"     // → returns boolean true, not string "true"
 "Count: ${data.count}" // → returns string "Count: 42" (mixed template)
@@ -184,7 +184,7 @@ When the entire string is a single `${expression}`, the result preserves its typ
 
 The `bind` field is NOT expression-evaluated. It's a path string resolved by `useDataScope()`, and only a component that calls that hook reads it:
 
-```json
+```jsonc
 {
   "type": "list",
   "bind": "customerNames"  // Resolved as dataSource.customerNames

--- a/skills/objectui/rules/styling.md
+++ b/skills/objectui/rules/styling.md
@@ -167,7 +167,7 @@ const buttonVariants = cva(
 
 **Every component must accept `className` on its schema node** to allow JSON-level style overrides. Like every other key, it is read off the node itself — not out of a `props` envelope, which the renderers never read:
 
-```json
+```jsonc
 {
   "type": "card",
   "className": "bg-red-500",  // ✅ User can override styles


### PR DESCRIPTION
Fixes #7462

Sixteen fenced blocks under `skills/objectui/` were tagged ```` ```json ```` while
their bodies carry `//` comments — syntax JSON forbids and JSONC allows. This
retags exactly those sixteen to ```` ```jsonc ````. Tag-only: the whole diff is
sixteen opener lines.

## What was counted, at the branch point 0246d11

`skills/objectui/**/*.md` holds 56 fences tagged `json` (and zero tagged `jsonc`).
**17 of them fail `JSON.parse`** — the card's figure, reproduced exactly:
12 in `guides/schema-expressions.md`, 4 in `rules/protocol.md`, 1 in `rules/styling.md`.

⚠️ The card's criterion and the card's number do not select the same set, and the
gap is exactly one block. Counting by "carries a `//` comment or a `...` elision"
(the claim comment's wording) gives **16**; counting by "fails `JSON.parse`" gives
**17**. The seventeenth is `guides/schema-expressions.md:206`, which uses no JSONC
feature at all — it is two top-level JSON documents listed in one fence. **It keeps
its `json` tag**, because `jsonc` would be a different false claim rather than a
truer one: the block's defect is that it is a listing, not that it is a dialect.
That is a judgement call, recorded here and on the card, and it is reversible in
one byte if the maintainer reads the card's headline number as the scope.

## Sites retagged, per file

| file | fence opener lines | fences retagged |
|---|---|---|
| `skills/objectui/guides/schema-expressions.md` | 32, 170, 328, 355, 365, 374, 391, 447, 463, 479, 492 | 11 |
| `skills/objectui/rules/protocol.md` | 157, 166, 177, 187 | 4 |
| `skills/objectui/rules/styling.md` | 170 | 1 |

Each opener was asserted to be exactly the six bytes of the `json` info string
before it was rewritten; the retag script refuses the file otherwise.

## Arithmetic

| file | bytes before | bytes after | delta | lines before | lines after |
|---|---|---|---|---|---|
| `skills/objectui/guides/schema-expressions.md` | 20653 | 20664 | +11 | 518 | 518 |
| `skills/objectui/rules/protocol.md` | 13549 | 13553 | +4 | 320 | 320 |
| `skills/objectui/rules/styling.md` | 10793 | 10794 | +1 | 319 | 319 |
| **total** | | | **+16** | | **unchanged** |

+1 byte per retagged fence, sixteen fences, sixteen bytes, zero line-count change.
`git diff -U0` filtered to changed lines yields exactly 16 removals of the `json`
opener and 16 additions of the `jsonc` opener, and nothing else.

**Token ratchet: none exists.** No script in this repository budgets tokens, bytes
or lines over `skills/**`. The two budget scripts, `check-eager-closure-budget.mjs`
and `render-budget-comment.mjs`, measure the shipped JavaScript closure, not
markdown. The five scripts that read `skills/` at all are
`check-skill-examples.mjs`, `check-skills-paths.mjs`, `check-shell-escape-residue.mjs`,
`check-governed-queue-guard.mjs` and `check-doc-snippet-types.mjs` (the last only to
NAME the tree as unscanned). So the arithmetic above is reported because the card
asked for it, not because anything gates on it.

## What the tag buys, measured with the repository's own parser

`check-skill-examples.mjs` already implements both dialects — `JSON_FENCE_LANGUAGES`
is the set `json`, `jsonc`, and `parseJsonFence` strips comments and trailing commas
for `jsonc` only. Its header records the corpus state this pull request changes:
"There are zero `jsonc` fences in the corpus today; the language is recognised so
that adding one is not a silent no-op."

Running that exact function over the corpus, before and after:

| | fences | parse under their own tag |
|---|---|---|
| before | 56 `json`, 0 `jsonc` | 39 of 56 |
| after | 40 `json`, 16 `jsonc` | 39 of 40 `json`, 7 of 16 `jsonc` = 46 of 56 |

So seven blocks become genuinely checkable — eligible for the gate's opt-in marker —
and nine do not. **That residue is honest and is not repaired here**, because
repairing it needs content edits and this flight is tag-only:

- **seven** list several top-level JSON documents in one fence
  (`schema-expressions.md` 32, 170, 447, 463, 479, 492; `protocol.md` 177);
- **two** carry `...` elisions, which no JSON dialect accepts
  (`protocol.md` 157, 166);
- plus `schema-expressions.md:206`, which stays `json`, same listing shape.

Eleven blocks in total still parse under no dialect. They are recorded on the card
as a follow-up, not smuggled in here.

## Decision: `check-doc-fence-languages.mjs` does NOT gain a `skills/` root

The card asked whether this gate should be widened the way `check-skills-paths.mjs`
was by #7358. **No** — and the answer is measured rather than argued. Both legs
below ran against a throwaway mutation that added a `skills` walk to
`listDocuments`, proven on disk before any verdict was read (marker count 1, blob
hash de67f1d to 194926b) and restored byte-identically afterwards (hash back to
de67f1d, `git diff HEAD` for that path empty).

**Leg A — the gate itself reds, in the one mode it can never absorb.** Widened, it
exits 1 on `skills/objectui/guides/project-setup.md:115`: a ```` ```javascript ````
fence whose first line is `export default`, which its quoted triage classifier calls
code. Because `javascript` is not in `UNHIGHLIGHTED_SPELLINGS`, that is UNKNOWN mode,
and the gate's header is explicit that UNKNOWN "⛔ can never be baselined and fails
on sight". So this is worse than the "would the baseline grow" test the card set:
the baseline could not take it at any size. Zero SYNONYM findings, one UNKNOWN.

**Leg B — the widening is refused by the tree's own pin.** The gate's scan surface is
pinned equal, element by element, to `check-doc-snippet-types`'s by
`scripts/__tests__/check-doc-fence-languages.test.ts` ("walks exactly the documents
the snippet gate walks"). Under the mutation the two lists are 243 and 227 documents
and the assertion is false, the difference being exactly the 16 `skills/objectui`
pages. Widening this gate alone is therefore not a small edit; it is a three-gate
surface move.

**And the surface owner has already been named.** `check-doc-snippet-types.mjs`
states, beside `UNGATED_DOCS`: "⛔ `skills/objectui/**` is NOT claimed by any gate
here, and this line is the opposite of a claim on it: it is a governed, published
surface with its own review path, so pointing a doc gate at it is a decision for
whoever owns that surface — never a side effect of a root move." Doing it inside a
tag flight would be exactly the side effect that sentence forbids. For scale: that
gate is covered-by-default and compiles every `ts`/`tsx` fence it walks, and
`skills/` holds 112 of them.

### The four axes

- **Real business need.** Measured, not assumed: the population the widening would
  find in `skills/` is ONE block, and it is a genuine JavaScript config example, not
  hidden TypeScript. There is no accumulation to catch here today. The need the card
  actually names — a tag that lies to a reader — is served in full by the retag,
  which the gate would not have caught either: it judges TypeScript bodies under
  non-TypeScript fences and says nothing whatsoever about `json` versus `jsonc`.
- **Long-term soundness (the axis carrying at least half the weight).** The durable
  shape is one surface decision made once, by the surface's owner, moving all three
  doc gates together with the `UNGATED_DOCS` accounting that decision implies. The
  patch-shaped alternative — widen one gate, then either re-fence a JavaScript block
  as TypeScript or add `javascript` to a set of spellings for unhighlighted blocks —
  buys one gate's reach by corrupting two vocabularies that other gates read. Both
  remedies are worse than the debt, and the debt is already written down by name.
- **Preventing AI-authored mistakes.** This is what decides the retag half and does
  not decide the widening half. An agent reading `skills/objectui/` copies what the
  fence claims: a block tagged `json` carrying `//` teaches that comments are legal
  in the `.json` files it is about to write, and metadata files are exactly where
  that error would land silently. The fence gate would not have caught that in any
  configuration. Making the tag honest is the enforceable half available today;
  widening a TypeScript-body gate is not related to it.
- **Startup scope discipline.** A p3 truth item stays a p3 truth item. Turning it
  into a three-gate surface move plus a compile-coverage decision over a published,
  governed tree is the scope creep the focus principle exists to refuse. The debt
  stays named and unclaimed, which is the state that header calls strictly better
  than an unnamed one.

**Consequently there is no self-test leg to add** (the card's conditional step): no
gate changed, so no gate needs a new fixture. The reverse verification that WOULD
have accompanied a widening was still run, as the two ablation legs above — they are
what makes "do not widen" a measurement instead of a preference.

## The tag is load-bearing, not cosmetic — proven both directions

A tag-only change invites the question "does anything actually read this?", so it
was answered against the live gate rather than asserted. Throwaway mutation on
`rules/styling.md`, under a trap, both legs proven on disk before any verdict was
read:

1. **Opt the retagged fence in, tag left `jsonc`.** Marker lines 3 to 4, blob
   06654f3 to 60b888c. `check-skill-examples` exits **0**:
   "JSON phase: 40 fence(s) parsed, 0 failed."
2. **Same block, same marker, tag flipped back to `json`.** jsonc openers 1 to 0,
   blob 60b888c to 057fa51. The gate exits **1** and names the site:
   "[json] skills/objectui/rules/styling.md:171 Expected double-quoted property
   name in JSON at position 50 (line 3 column 31)."
3. **Restore proven**, not assumed: `git checkout HEAD` on the path, blob back to
   06654f3 — byte-identical to the HEAD blob — `git diff HEAD` for that path empty,
   marker count back to 3, jsonc openers back to 1.

So the retag moves seven blocks from "cannot be opted in without the gate going red"
to "can". Opting them in is a content edit and is NOT done here; it is the natural
follow-up and is recorded on the card.

An earlier attempt at this probe used a `perl` substitution whose anchor matched
nothing. It exited 0 with the file untouched — the classic green no-op — and was
caught only because the mutation is proven by hash and grep count before any verdict
is read. Recording it because the guard is the reason the numbers above mean
anything.

## Gates

Every exit code was captured by redirect before any pipe, and each row quotes the
gate's own verdict line.

| gate | exit | its own verdict line |
|---|---|---|
| `node scripts/check-skill-examples.mjs` | **0** | "Every marked skill example holds up against the built types." — "Scanned 16 guide(s) under skills: 112 ts/tsx/typescript fence(s), 56 json/jsonc fence(s). Marked: 17 ts fence(s) and 39 json fence(s)." · "JSON phase: 39 fence(s) parsed, 0 failed." The 16 retagged fences stay UNMARKED, exactly as the card requires, so the marked population is unchanged at 39. Needed a build first — it exits 2, "PRECONDITION NOT MET", against an unbuilt tree, and that is not a verdict about any guide. |
| `node scripts/check-doc-fence-languages.mjs` | **0** | "✅ check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s) of objectui#5867's remaining population (⛔ SHRINK-ONLY). No unknown fence spelling hides one." Unchanged by this diff — the gate does not walk `skills/`, which is the subject of the decision above. |
| `node scripts/check-skills-paths.mjs` | **0** | "✅ check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined)." — "skills/ — 28/28 resolve across 16 file(s)". |
| `node scripts/check-shell-escape-residue.mjs` | **0** | "✅ check-shell-escape-residue: OK (5/5 root(s) resolved … skills: 16 file(s), 196 fence(s) … 0 occurrence(s) outside a fence)". This one DOES read the retagged files. |
| `node scripts/check-control-bytes.mjs` | **0** | "✅ check-control-bytes: OK (scanned 6144 tracked text file(s); skipped 85 binary)." Plus a direct scan of the three changed files for the control range: no hits. |
| `node scripts/check-doc-links.mjs` | **0** | "Links are valid across 17 scan roots." |
| `node scripts/check-changeset-presence.mjs` | **0** | "✅ No source or published contract of a released package changed in this range, so no changeset is owed." — "3 file(s) changed, 0 of them published source of a package the release covers". Its own verdict decides, and it says none is owed. |
| `node scripts/check-governed-queue-guard.mjs --test` (the three final paths) | **3** | "⛔ GOVERNED — 3 of 3 path(s) are on a governed surface: skills/** x3 — the published skills catalog … Park it as a DRAFT and leave the merge to the maintainer." Exit 3 is the CORRECT verdict for this diff, not a red. This pull request is a draft and stays one. |
| `pnpm exec vitest run` over 8 `scripts/__tests__` specs, under the shared lock | **0** | "Test Files 8 passed (8) · Tests 347 passed (347)". Specs: doc-fence-languages, skill-examples, skills-paths, shell-escape-residue, governed-queue-guard, control-bytes, doc-links, changeset-presence. Lock verdict: "command-exit 0 · held the lock 25s · waited 0s". |
| the build the skill-examples gate needs | **0** | `turbo run build` over the gate's own `--build-filter` closure: "Tasks: 29 successful, 29 total". Lock verdict: "command-exit 0 · held the lock 294s". |
| `eslint` over changed `.mjs` | — | Nothing to run: the diff is three markdown files. |
| objectstack `scripts/pm/dispatch-gates.mjs --repo objectstack-ai/objectui` | **2** | Verbatim: "dispatch-gates: REFUSING — asked for 'objectstack-ai/objectui', but this checkout is 'objectstack-ai/objectstack'." and "this script exists only in 'objectstack-ai/objectstack', so a sister repo's list is hand-derived from its own package manifest and its own workflow files." So the union above was hand-derived from this repo's own `package.json` and `.github/workflows/`, which carry no `paths` filter for these gates. |

All ten runnable rows were re-run at the final commit `ec67429` with a clean working
tree, and every exit code was captured by redirect before any pipe.

## Not measured, and why

- **Remote CI.** Reported at draft time by dispatch contract; the merge-queue leg of
  Governed Surface Queue Guard cannot run on a draft at all.
- **`eslint` over changed `.mjs` files.** Nothing to run: the diff contains three
  markdown files and no script.
- **Changeset.** Not owed, by the presence gate's own verdict, quoted in the table.
- **The nine `jsonc` fences and one `json` fence that still parse under no dialect.**
  Their content is untouched by design; they are a follow-up on the card.
- **Whether a widened trio of doc gates would pass over `skills/`.** Deliberately not
  measured. Compiling 112 fences against built `dist` to cost a surface move nobody
  has authorised is the scope this pull request declines.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_

## Queue fix (2026-09-04)

New head **`dc4811c`**. One commit on top of `ec67429`; nothing above this section
is changed, and no retag is reverted.

### Why the queue rejected this pull request twice

`packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx` reads the
real guides at run time, and its extractor was literal about the fence tag:

    const fence = /```json\n([\s\S]*?)```/g;

`rules/protocol.md`'s `"bind": "customerNames"` list example is one of the four
fences this branch retags, so a `jsonc` opener made it invisible to every assertion
in that file. Two of them read the absence as data:

- the counter-probe "still teaches `bind` in a JSON block" — "expected false to be true";
- "its `list` example renders one entry per bound item" — "the guide must carry a
  parseable list example bound with `bind`: expected undefined to be truthy".

The pull-request-level run never saw it: the "Decide whether this change needs a full
run" step trims the suite for a docs-only diff, and the full run is the `merge_group`
one. Same failure both ejections.

### The fix

Widen the extractor to read both tags — the opener becomes ```` jsonc? ```` in the
same expression — and say so in the helper's doc comment. `parseBlock` already strips `//` comments before
`JSON.parse`, so jsonc bodies parse today; only the extractor was behind. The `bind`
block keeps its `jsonc` tag: those fences carry comments, which is the falsehood this
branch exists to remove.

Files: `packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx` and
`.changeset/jsonc-fence-extractor-test-only.md` (empty frontmatter — a test-only change
declared as releasing nothing; the presence gate demanded a declaration once a
`packages/components/src` file entered the diff, and this is its explicit pass form).

### Counts, re-derived at this head

A faithful re-implementation of `jsonBlocks` + `parseBlock`, run over the three guides
the test names, narrow tag then widened — fences / data-table / list /
bind=customerNames / offenders:

| guide | narrow (`json` only) | widened (`jsonc?`) |
|---|---|---|
| `guides/schema-expressions.md` | 8 / 1 / 1 / 1 / 0 | 19 / **1** / 5 / 1 / 0 |
| `rules/protocol.md` | 6 / 0 / 0 / 0 / 0 | 10 / **0** / 1 / **1** / 0 |
| `guides/data-integration.md` | 4 / 1 / 1 / 1 / 0 | 4 / **1** / 1 / 1 / 0 |

The `data-table` count is unchanged at 1 / 0 / 1, so `expect(extra).toEqual([])` and
the `[taught]` node selection are untouched; the offenders list stays empty; the two
failing assertions get their block back. The newly visible `protocol.md` node is the
shape the other two guides already carry, character for character:
`{"type":"list","bind":"customerNames"}` — which is why widening it renders rather
than merely parses. `guides/data-integration.md` is untouched by this branch and stays
untouched; the widening only makes a future retag there safe.

### Reverse verification — one mutation, proven on disk before any verdict was read

Restore the narrow `json`-only extractor on the committed state, under an
EXIT/INT/TERM trap with an absolute path:

1. **Mutation proven, not assumed.** File back to blob `421bca4` — byte-identical to
   the parent's blob for that path — widened-regex count **0**, narrow-regex count
   **1**, all three read before the test ran.
2. **Exactly the two named assertions red, and nothing else.** "Tests 2 failed | 14
   passed (16)", "Test Files 1 failed (1)", with the two messages quoted above. Lock
   verdict: "command-exit 1".
3. **Restore proven.** Hash back to `76fdb28`, `git diff HEAD` for that path empty,
   working tree clean at the final commit.

With the fix, the same whole-file command: "Test Files 1 passed (1)" / "Tests 16
passed (16)", lock verdict "command-exit 0".

### Gates, re-run at `dc4811c` with a clean working tree

Every exit code captured by redirect before any pipe; each row quotes the gate's own
verdict line.

| gate | exit | its own verdict line |
|---|---|---|
| `pnpm exec vitest run packages/components/src/__tests__/skill-guide-data-table-binding.test.tsx` (whole file, shared lock) | **0** | "Test Files 1 passed (1)" · "Tests 16 passed (16)" · lock "VERDICT command-exit 0" |
| `node scripts/check-skill-examples.mjs` (after `turbo run build` over its own `--build-filter`) | **0** | "Every marked skill example holds up against the built types." · "JSON phase: 39 fence(s) parsed, 0 failed." |
| `node scripts/check-changeset-presence.mjs` | **0** | "✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate." |
| `node scripts/check-changeset-fixed.mjs` | **0** | "✅ All workspace packages are in the changeset fixed group." |
| `node scripts/check-changeset-no-major.mjs` | **0** | "✅ No changeset declares a `major` bump." |
| `node scripts/check-changeset-overwrite.mjs` | **0** | "✅ No pre-existing changeset was modified or deleted." |
| `node scripts/check-control-bytes.mjs` | **0** | "✅ check-control-bytes: OK (scanned 6145 tracked text file(s); skipped 85 binary)." |
| `node scripts/check-doc-fence-languages.mjs` | **0** | "✅ check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript …" |
| `node scripts/check-skills-paths.mjs` | **0** | "✅ check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined)." |
| `node scripts/check-shell-escape-residue.mjs` | **0** | "✅ check-shell-escape-residue: OK (5/5 root(s) resolved … 0 occurrence(s) outside a fence)." |
| `node scripts/check-package-self-import.mjs` | **0** | "✅ No package names itself inside its own src/." |
| `node scripts/check-vi-mock-specifiers.mjs` | **0** | "✅ check-vi-mock-specifiers: OK (4218 tracked source file(s), 2474 test-named …)" |
| `node scripts/check-vi-mock-inherit.mjs` | **0** | "✅ check-vi-mock-inherit: OK (… 121 inherit, 0 auto-mocked …)" |
| `node scripts/check-governed-queue-guard.mjs --self-test` | **0** | "OK check-governed-queue-guard self-test: 132 cases pass …" |
| `node scripts/check-governed-queue-guard.mjs --test` (the five final paths) | **3** | "⛔ GOVERNED — 3 of 5 path(s) are on a governed surface: skills/** x3 — the published skills catalog". Unchanged verdict: the two paths this section adds are not governed, and exit 3 is the correct reading for this diff, not a red. |
| `pnpm --filter @object-ui/components run type-check` | **0** | "tsc --noEmit && tsc -p tsconfig.test.json", both clean. Coverage measured rather than assumed: `tsc -p tsconfig.test.json --listFiles` names the edited file exactly once, so this is a reading about it. |
| `pnpm exec eslint .` in `packages/components` (the whole changed package) | **0** | 448 file(s) judged, 0 error(s); 934 pre-existing warnings. The changed `.tsx` alone: exit 0, no output. |

### Not measured, and why

- **Remote CI, including the `merge_group` run.** Reported at push time by dispatch
  contract. The whole-file run above is the local stand-in for the queue's full run.
- **`tsc -p tsconfig.scripts.json`.** Does not apply: the changed file belongs to
  `@object-ui/components`, whose own `type-check` chains `tsconfig.test.json`, and that
  is the project that reads it.
- **The repository-wide `pnpm lint`.** Narrowed to the one changed PACKAGE, and the
  narrowing is measured rather than asserted. Population read from eslint's own config:
  the root flat config extends `tseslint.configs.recommended`, not the type-checked
  variant, and its `languageOptions` names no `parserOptions.project` or
  `projectService` — so no file's verdict depends on a TypeScript program, and a diff
  inside `packages/components` cannot move the verdict of a file in another package.
  File count read from `--format json`: `eslint .` in `packages/components` judged
  **448 files, 0 errors** (934 pre-existing warnings), exit 0, and the edited file is in
  that judged set.
- **The nine `jsonc` fences and one `json` fence that still parse under no dialect.**
  Unchanged by this section, still the follow-up recorded on the card.

### What this needs from a human

The earlier approving review was pinned to `ec67429`. **The new head `dc4811c` needs a
fresh approval pinned to it before the merge queue will take this pull request** —
that is the approver's action. Nothing here touched the draft/ready state, reviewers,
labels, auto-merge, or queue membership; the push landed only because the failing
group had already dequeued this pull request on its own.