### PR TITLE
feat(scripts): gate every eval must_contain token against the guides its bundle ships

### DIFF
--- a/.github/workflows/skill-eval-tokens.yml
+++ b/.github/workflows/skill-eval-tokens.yml
@@ -1,0 +1,91 @@
+name: Skill Eval Tokens
+
+# Holds every `must_contain` token of every `skills/<bundle>/evals/*.json` to
+# the guides that bundle actually ships: the token must occur as a WHOLE token
+# (never a substring) somewhere in the bundle's own markdown. The oracle choice
+# — bundle-wide over per-guide, argued on four axes and measured both ways —
+# the whole-token boundary rule, the `must_not_contain` polarity and the
+# declared exit codes are documented at length in
+# `scripts/check-skill-eval-tokens.mjs`.
+#
+# ── Why this is its own workflow, with NO path filter ───────────────────────
+#
+# Same reason `skills-paths.yml`, `skill-examples.yml`, `docs-links.yml` and
+# `control-bytes.yml` are theirs. This gate's whole input is the markdown and
+# JSON under `skills/`, and both `ci.yml` and `lint.yml` list `'**/*.md'`,
+# `content/**` and `docs/**` under the `paths-ignore` of their `push` trigger.
+# GitHub has no per-job path filter, so a push that only edits a guide would
+# start neither — and editing only a guide is exactly how a token an eval grades
+# stops being taught. `control-bytes.yml`'s header names the consequence: a gate
+# that cannot see a markdown-only change "rebuilds the hole it exists to close".
+#
+# Hence: no `paths` and no `paths-ignore` here, deliberately.
+# `scripts/__tests__/check-skill-eval-tokens.test.ts` fails if either is ever
+# added, and fails too if a second workflow starts running the same script —
+# one gate, one home.
+#
+# ── Why it does NOT install, unlike its sibling `skill-examples.yml` ────────
+#
+# `skill-examples.yml` installs and builds because its criterion is the
+# PUBLISHED type surface, so the packages its marked fences import have to exist
+# as `dist/*.d.ts` first. This gate's criterion is text: it reads eval JSON and
+# guide markdown out of the checkout and nothing else. So it takes
+# `skills-paths.yml`'s shape instead — a checkout plus two `node` calls — and
+# `check-pre-install-import-graph.mjs` picks it up automatically and enforces
+# that this script's whole static import graph stays free of `node_modules`.
+#
+# That install-free shape is also why folding this check into
+# `check-skill-examples.mjs` as a second phase was rejected. That script exits 2
+# (PRECONDITION NOT MET) on an unbuilt tree BEFORE judging anything, so an
+# eval-token phase inside it would simply never run wherever the workspace is
+# not built — and its own header already lists this oracle, in "Deliberately NOT
+# answered here" item 4, as a different question over a different corpus.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  # Merge queue (objectui#3523 — see `ci.yml`'s trigger block for the full note
+  # and the measurements behind it). A required check that does not report on a
+  # queue build stalls the queue until the ruleset's 60-minute timeout fails it,
+  # so an unfiltered gate that could become required subscribes here from the
+  # start. `types:` is named although `checks_requested` is currently the only
+  # activity type GitHub defines for `merge_group`.
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: skill-eval-tokens-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  skill-eval-tokens:
+    name: Skill Eval Token Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22.x'
+
+      # The self-test runs FIRST. A probe that cannot fail is not a probe: it
+      # plants an untaught token that must go red, a substring-only match that
+      # must go red, a `must_not_contain` entry that must NOT, and a baseline row
+      # that must suppress exactly its own row — so a gate broken into permanent
+      # green is caught here rather than by nobody.
+      - name: Self-test the oracle and the whole-token rule, both directions
+        run: node scripts/check-skill-eval-tokens.mjs --self-test
+
+      # Reads the checkout and nothing else, so no install is required.
+      - name: Check every eval must_contain token against the guides
+        run: node scripts/check-skill-eval-tokens.mjs

--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -31,6 +31,7 @@ one has its own section below.
 | `docs-links.yml` | Internal Docs Link Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** |
 | `skills-paths.yml` | Skill Guide Path Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a path stated in a `skills/` guide does not exist |
 | `skill-examples.yml` | Skill Example Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a MARKED fenced example in a `skills/` guide no longer compiles against the packages' built types, no longer parses as JSON, or carries a marker that opts nothing in |
+| `skill-eval-tokens.yml` | Skill Eval Token Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when an eval assertion's `must_contain` token is not taught as a whole token anywhere in its own `skills/` bundle |
 | `doc-component-types.yml` | Doc Component Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a `content/docs/**.mdx` snippet teaches a `type` nothing registers |
 | `doc-snippet-types.yml` | Doc Snippet Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a covered documentation snippet no longer compiles against the packages' built types |
 | `doc-fence-languages.yml` | Doc Fence Language Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a TypeScript block sits under a fence the snippet gate does not read |
@@ -647,6 +648,63 @@ the JSON parser's message, or the orphan marker's line. Fix the example — or, 
 to stand alone, remove its marker rather than weakening the gate. Run it locally with
 `pnpm check:skill-examples`, `node scripts/check-skill-examples.mjs --list` to see every candidate
 fence and its verdict, and `--measure` to judge every candidate whether marked or not.
+
+## Skill Eval Tokens (`skill-eval-tokens.yml`)
+
+**Triggers:** Push and PR to `main`/`develop`, merge-queue builds, plus manual dispatch — with **no
+path filter at all**, for the same reason as the two sections above: the whole input is the markdown
+and JSON under `skills/`, which `ci.yml` and `lint.yml` structurally cannot see. It appears in the
+checks list as **Skill Eval Token Check**.
+
+Runs `scripts/check-skill-eval-tokens.mjs`. The two sections above check the *paths* a guide states
+and the *worked examples* it ships; this one checks the **evals** — the `skills/<bundle>/evals/*.json`
+files that grade an answering agent. Every `must_contain` token must occur as a **whole token** in the
+markdown of its own skill bundle. Unlike its sibling it does **not** install or build: it reads text
+out of the checkout, so it is a checkout plus two `node` calls, the shape `skills-paths.yml` uses.
+
+**Why it was needed:** nothing checked that a token an eval grades on is something the skill actually
+teaches, so an eval could require a word the guides never say and grade nothing forever. The class had
+already been cleaned by hand twice —
+[#7360](https://github.com/objectstack-ai/objectui/issues/7360) (six assertions, one of them passing
+only by accidental substring) and
+[#7405](https://github.com/objectstack-ai/objectui/issues/7405) (three more) — both rounds found by a
+human reading, which is the economics this gate family exists to end
+([#7461](https://github.com/objectstack-ai/objectui/issues/7461)).
+
+**The oracle is bundle-wide, and the losing option stays measurable.** A token counts as taught if it
+appears anywhere in its own bundle's markdown, not only in the guide whose basename matches the eval
+file. That is what the artefact supports: `SKILL.md` is a router that names every guide, and its rules
+block tells the reader to read `rules/` before writing schemas, so the corpus an eval is answered from
+is the whole bundle. Measured at the gate's branch point, per-guide would have started with 14 red rows
+against bundle-wide's 0 — and 12 of those 14 exist only because `evals/protocol.json` has no
+`guides/protocol.md` (its guide is `rules/protocol.md`), so they name no defect at all. `--measure`
+prints **both** red lists on every run, so that comparison stays re-derivable rather than a claim in a
+merged pull request.
+
+**Whole tokens, never substrings.** An identifier-shaped token is matched on word boundaries, so `view`
+does not match the tail of `// vite preview` and `FieldWidgetProps` does not match the head of
+`FieldWidgetPropsSchema` — both real rows that a substring grep had reported clean. A token that is not
+identifier-shaped at an end (a quoted JSON key, an operator) takes no boundary at that end and so
+degrades to an exact substring, which is what such a token means. Matching is case-sensitive.
+
+**`must_not_contain` is deliberately not scored against the guides** — it gets a shape check and
+nothing else. Those entries are tokens an answer must *avoid*, so "no guide says it" is the healthy
+case, and one of them is spelled as a quoted key fragment precisely so it does not fail an answer that
+names the rule while following it. A check that validated that array the way it validates `must_contain`
+would have the polarity backwards.
+
+**Three exit codes, not two.** `0` = every token is taught, and something was actually checked. `1` =
+the gate ran and found errors — an untaught token, a malformed assertion array, or a stale baseline
+row. `2` = the gate **could not run**: no eval population, no guide corpus, or an eval file that does
+not parse. Nothing printed under exit 2 is a verdict about any eval, and it is never a pass.
+
+**If it fails:** it prints `file eval N token` for every red row, and says whether the token is absent
+entirely or present only as a substring. Do **not** rewrite guide prose to teach the token and do
+**not** re-point the row mechanically — which of the two is right is a per-row skills decision. The
+declared list `KNOWN_UNTAUGHT_EVAL_TOKENS` is empty at landing and is **shrink-only**: a row parked in
+it stays visible, and a row whose red goes away fails as stale until its line is deleted. Run it
+locally with `pnpm check:skill-eval-tokens`, `--list` for every row under both oracles, and `--measure`
+for the two red lists side by side.
 
 ## Documented Component Types (`doc-component-types.yml`)
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "check:i18n-dead-keys": "node scripts/check-i18n-dead-keys.mjs",
     "check:skills-paths": "node scripts/check-skills-paths.mjs",
     "check:skill-examples": "node scripts/check-skill-examples.mjs",
+    "check:skill-eval-tokens": "node scripts/check-skill-eval-tokens.mjs",
     "check:doc-types": "node scripts/check-doc-component-types.mjs",
     "check:doc-snippets": "node scripts/check-doc-snippet-types.mjs",
     "check:doc-fences": "node scripts/check-doc-fence-languages.mjs",

--- a/scripts/__tests__/check-skill-eval-tokens.test.ts
+++ b/scripts/__tests__/check-skill-eval-tokens.test.ts
@@ -1,0 +1,451 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Plain-JS CI helper. Its types are INFERRED from the .mjs source by
+// `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
+// re-adding one is now itself an error (TS2578). See objectui#3494.
+import {
+  EXIT_CODES,
+  IDENT_CHAR,
+  KNOWN_UNTAUGHT_EVAL_TOKENS,
+  ORACLE,
+  SCAN_ROOTS,
+  analyze,
+  countSubstring,
+  countWholeToken,
+  listBundles,
+  rowKey,
+} from '../check-skill-eval-tokens.mjs';
+
+/**
+ * objectui#7461 — the test for `scripts/check-skill-eval-tokens.mjs`.
+ *
+ * ## What this file covers, and what it leaves to `--self-test`
+ *
+ * Everything here runs on an UNBUILT tree with no install, because that is what
+ * the gate itself needs: its whole input is text in the checkout. The split
+ * against `--self-test` is therefore not the one `check-skill-examples.test.ts`
+ * makes (there, the compiler half needs a built workspace). Here it is by
+ * AUDIENCE: `--self-test` is the probe the workflow runs so a gate broken into
+ * permanent green is caught in CI, and this file pins the things a future edit
+ * could quietly change — the oracle identity, the boundary rule's exact edges,
+ * the shrink-only direction of the baseline, and the wiring.
+ *
+ * Both are needed and neither substitutes: a self-test nobody runs is a probe
+ * that passes, and a wiring assertion cannot see a boundary rule regress.
+ *
+ * The fixtures are throwaway trees, never the real bundle: a committed fixture
+ * eval would have to assert a deliberately untaught token, and something else in
+ * this repository would eventually scan it — the reasoning
+ * `check-skills-paths.test.ts` states for its own trees.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** Builds a throwaway tree and hands the caller its root. */
+function withTree<T>(
+  build: (write: (rel: string, contents: string) => void) => void,
+  run: (dir: string) => T,
+): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'check-skill-eval-tokens-'));
+  const write = (rel: string, contents: string) => {
+    const full = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, contents);
+  };
+  try {
+    build(write);
+    return run(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const evalDoc = (assertions: unknown, id = 1) =>
+  JSON.stringify({ skill_name: 'fixture', evals: [{ id, prompt: 'p', expected_output: 'e', files: [], assertions }] });
+
+describe('the whole-token rule', () => {
+  /**
+   * objectui#7405 measured these three, and they are the entire argument for
+   * comparing whole tokens. Two of them the rule closes; the third it cannot,
+   * and pinning that here is what stops a future reader from mistaking this
+   * gate's green for a semantic guarantee.
+   */
+  it('does not match `view` inside `// vite preview`', () => {
+    expect(countWholeToken('// vite preview', 'view')).toBe(0);
+    expect(countSubstring('// vite preview', 'view')).toBe(1);
+  });
+
+  it('does not match `FieldWidgetProps` inside `FieldWidgetPropsSchema`', () => {
+    expect(countWholeToken('import { FieldWidgetPropsSchema } from "x";', 'FieldWidgetProps')).toBe(0);
+    expect(countSubstring('FieldWidgetPropsSchema', 'FieldWidgetProps')).toBe(1);
+  });
+
+  it('DOES match `create` in `create: vi.fn()` — the stated limit of this gate', () => {
+    // ⚠️ Not a defect and not fixable by any token rule: `create` really is a
+    // whole token there. The mismatch objectui#7405 recorded was SEMANTIC — the
+    // eval meant the form mode, the guide had a mocked dataSource method. So a
+    // green here means "the bundle says this word", never "the bundle teaches
+    // what the eval means". Pinned so the boundary stays stated.
+    expect(countWholeToken("create: vi.fn().mockResolvedValue({ id: '1' })", 'create')).toBe(1);
+  });
+
+  it('binds on a boundary only where the token itself is identifier-shaped', () => {
+    // Both ends identifier-shaped: a full word match.
+    expect(countWholeToken('the view name', 'view')).toBe(1);
+    expect(countWholeToken('overview', 'view')).toBe(0);
+    // Left end only: `t(` must not be found inside `format(`.
+    expect(countWholeToken('format( and t( here', 't(')).toBe(1);
+    // Neither end: an exact substring, which is what such a token means.
+    expect(countWholeToken('a "props": { b', '"props": {')).toBe(1);
+    expect(countWholeToken('x && y', '&&')).toBe(1);
+  });
+
+  it('treats a digit as continuing an identifier, so `xl` does not match `2xl`', () => {
+    expect(countWholeToken('the 2xl step', 'xl')).toBe(0);
+    expect(countWholeToken('up to xl only', 'xl')).toBe(1);
+  });
+
+  it('is case-sensitive — `Type` must not vouch for `type`', () => {
+    expect(countWholeToken('Type is not type', 'type')).toBe(1);
+  });
+
+  it('handles hyphenated and scoped tokens without treating the punctuation as a boundary hole', () => {
+    expect(countWholeToken('use grid-cols-1 here', 'grid-cols-1')).toBe(1);
+    expect(countWholeToken('grid-cols-12', 'grid-cols-1')).toBe(0);
+    expect(countWholeToken('from "@object-ui/mobile"', '@object-ui/mobile')).toBe(1);
+    expect(countWholeToken('from "@object-ui/mobiles"', '@object-ui/mobile')).toBe(0);
+  });
+
+  it('never matches the empty token, rather than matching everywhere', () => {
+    expect(countWholeToken('anything', '')).toBe(0);
+    expect(countSubstring('anything', '')).toBe(0);
+  });
+
+  it('escapes regex metacharacters in the token', () => {
+    // `${` and `${data.` are real tokens in this corpus; treating them as a
+    // pattern would either throw or match the wrong thing.
+    expect(countWholeToken('value is ${data.total}', '${data.')).toBe(1);
+    expect(countWholeToken('value is ${data.total}', '${')).toBe(1);
+    expect(countWholeToken('a.b', 'a.b')).toBe(1);
+    expect(countWholeToken('axb', 'a.b')).toBe(0);
+  });
+
+  it('exports the identifier class the boundary rule is stated in terms of', () => {
+    for (const ch of ['a', 'Z', '0', '_', '$']) expect(IDENT_CHAR.test(ch)).toBe(true);
+    for (const ch of ['-', '.', ':', '/', '"', ' ', '(']) expect(IDENT_CHAR.test(ch)).toBe(false);
+  });
+});
+
+describe('the oracle', () => {
+  it('is bundle-wide, declared rather than inferred from the walker', () => {
+    expect(ORACLE).toBe('bundle-wide');
+    expect(SCAN_ROOTS).toEqual(['skills']);
+  });
+
+  it('accepts a token taught in a SIBLING file of the same bundle', () => {
+    // The disagreement comment 5514262423 measured: `registerComponent` is
+    // taught in `guides/plugin-development.md` and required by an eval whose
+    // basename is `page-builder`. Honest under this oracle; a defect under the
+    // rejected one.
+    withTree(
+      (write) => {
+        write('skills/fixture/guides/page-builder.md', 'A page builder guide.\n');
+        write('skills/fixture/guides/plugin-development.md', 'Call scope.registerComponent(type, c).\n');
+        write('skills/fixture/evals/page-builder.json', evalDoc({ must_contain: ['registerComponent'], must_not_contain: [] }));
+      },
+      (root) => {
+        const r = analyze({ root, baseline: new Set<string>() });
+        expect(r.red).toEqual([]);
+        expect(r.redPerGuide.map((x: { token: string }) => x.token)).toEqual(['registerComponent']);
+      },
+    );
+  });
+
+  it('scores each bundle against its OWN markdown, never a neighbour bundle', () => {
+    // Today there is one bundle, so this can only be wrong later — which is
+    // exactly when nobody would be looking.
+    withTree(
+      (write) => {
+        write('skills/alpha/guides/a.md', 'alphaOnlyToken\n');
+        write('skills/alpha/evals/a.json', evalDoc({ must_contain: ['alphaOnlyToken'], must_not_contain: [] }));
+        write('skills/beta/guides/b.md', 'betaOnlyToken\n');
+        write('skills/beta/evals/b.json', evalDoc({ must_contain: ['alphaOnlyToken'], must_not_contain: [] }));
+      },
+      (root) => {
+        expect(listBundles(root).map((b: { rel: string }) => b.rel)).toEqual(['skills/alpha', 'skills/beta']);
+        const r = analyze({ root, baseline: new Set<string>() });
+        expect(r.red.map((x: { key: string }) => x.key)).toEqual(['skills/beta/evals/b.json eval 1 alphaOnlyToken']);
+      },
+    );
+  });
+
+  it('reds a substring-only match and says so', () => {
+    withTree(
+      (write) => {
+        write('skills/fixture/guides/a.md', 'heavy widgets (grids, charts, kanbans)\n');
+        write('skills/fixture/evals/a.json', evalDoc({ must_contain: ['chart'], must_not_contain: [] }));
+      },
+      (root) => {
+        const r = analyze({ root, baseline: new Set<string>() });
+        expect(r.red).toHaveLength(1);
+        expect(r.red[0].bundleWhole).toBe(0);
+        expect(r.red[0].bundleSubstring).toBe(1);
+      },
+    );
+  });
+});
+
+describe('must_not_contain is never scored against the guides', () => {
+  it('does not red on an entry absent from every guide', () => {
+    withTree(
+      (write) => {
+        write('skills/fixture/guides/a.md', 'taughtToken\n');
+        write(
+          'skills/fixture/evals/a.json',
+          evalDoc({
+            must_contain: ['taughtToken'],
+            // objectui#7370 spelled one deliberately as a quoted key fragment.
+            must_not_contain: ['nothingInAnyGuideSaysThis', '"props": {', 'return <div'],
+          }),
+        );
+      },
+      (root) => {
+        const r = analyze({ root, baseline: new Set<string>() });
+        expect(r.red).toEqual([]);
+        expect(r.shapeFindings).toEqual([]);
+        // And it produces no ROW at all — the array is not part of the judgement.
+        expect(r.rows.map((x: { token: string }) => x.token)).toEqual(['taughtToken']);
+      },
+    );
+  });
+
+  it('still shape-checks it — an empty entry or a non-array is a finding', () => {
+    withTree(
+      (write) => {
+        write('skills/fixture/guides/a.md', 'taughtToken\n');
+        write('skills/fixture/evals/a.json', evalDoc({ must_contain: ['taughtToken'], must_not_contain: ['', 7] }));
+      },
+      (root) => {
+        const r = analyze({ root, baseline: new Set<string>() });
+        expect(r.shapeFindings).toHaveLength(2);
+        expect(r.shapeFindings.every((f: { reason: string }) => f.reason === 'bad-token')).toBe(true);
+        expect(r.red).toEqual([]);
+      },
+    );
+  });
+});
+
+describe('the baseline is shrink-only', () => {
+  const build = (write: (rel: string, contents: string) => void) => {
+    write('skills/fixture/guides/a.md', 'taughtToken and charts\n');
+    write(
+      'skills/fixture/evals/a.json',
+      evalDoc({ must_contain: ['taughtToken', 'chart', 'neverTaught'], must_not_contain: [] }),
+    );
+  };
+  const CHART = 'skills/fixture/evals/a.json eval 1 chart';
+  const NEVER = 'skills/fixture/evals/a.json eval 1 neverTaught';
+
+  it('is EMPTY at landing, because the chosen oracle has no red rows', () => {
+    expect([...KNOWN_UNTAUGHT_EVAL_TOKENS]).toEqual([]);
+  });
+
+  it('suppresses exactly its own row and nothing else', () => {
+    withTree(build, (root) => {
+      const r = analyze({ root, baseline: new Set([CHART]) });
+      expect(r.red.map((x: { key: string }) => x.key).sort()).toEqual([CHART, NEVER].sort());
+      expect(r.fresh.map((x: { key: string }) => x.key)).toEqual([NEVER]);
+      expect(r.stale).toEqual([]);
+    });
+  });
+
+  it('reports a row whose red is gone as STALE, so the list can only shrink', () => {
+    withTree(build, (root) => {
+      const r = analyze({ root, baseline: new Set([CHART, NEVER, 'skills/fixture/evals/a.json eval 1 taughtToken']) });
+      expect(r.fresh).toEqual([]);
+      expect(r.stale).toEqual(['skills/fixture/evals/a.json eval 1 taughtToken']);
+    });
+  });
+
+  it('keys a row by file, eval and token, keeping a token with spaces whole', () => {
+    expect(rowKey('skills/x/evals/y.json', 3, 'await expect')).toBe('skills/x/evals/y.json eval 3 await expect');
+  });
+});
+
+describe('the preconditions — never exit 0 for "nothing checked"', () => {
+  it('names three distinct exit codes, with 1 and 2 kept apart', () => {
+    expect(EXIT_CODES).toEqual({ verified: 0, tokensUntaught: 1, couldNotRun: 2 });
+  });
+
+  it('refuses a tree with no bundle at all', () => {
+    withTree(
+      (write) => write('skills/fixture/guides/a.md', 'prose\n'),
+      (root) => {
+        expect(analyze({ root, baseline: new Set<string>() }).preconditions.map((p: { reason: string }) => p.reason)).toContain(
+          'no-bundles',
+        );
+      },
+    );
+  });
+
+  it('refuses a bundle whose evals assert no must_contain token', () => {
+    withTree(
+      (write) => {
+        write('skills/fixture/guides/a.md', 'prose\n');
+        write('skills/fixture/evals/a.json', evalDoc({ must_contain: [], must_not_contain: [] }));
+      },
+      (root) => {
+        expect(analyze({ root, baseline: new Set<string>() }).preconditions.map((p: { reason: string }) => p.reason)).toContain(
+          'empty-population',
+        );
+      },
+    );
+  });
+
+  it('refuses a bundle with eval files but no markdown corpus', () => {
+    withTree(
+      (write) => write('skills/fixture/evals/a.json', evalDoc({ must_contain: ['x'], must_not_contain: [] })),
+      (root) => {
+        expect(analyze({ root, baseline: new Set<string>() }).preconditions.map((p: { reason: string }) => p.reason)).toContain(
+          'no-guides',
+        );
+      },
+    );
+  });
+
+  it('refuses an eval file that does not parse, rather than greening over the rest', () => {
+    withTree(
+      (write) => {
+        write('skills/fixture/guides/a.md', 'taughtToken\n');
+        write('skills/fixture/evals/good.json', evalDoc({ must_contain: ['taughtToken'], must_not_contain: [] }));
+        write('skills/fixture/evals/bad.json', '{ "evals": [ }');
+      },
+      (root) => {
+        const r = analyze({ root, baseline: new Set<string>() });
+        expect(r.preconditions.map((p: { reason: string }) => p.reason)).toContain('unparseable');
+      },
+    );
+  });
+});
+
+describe('the real corpus', () => {
+  it('is non-empty and green under the chosen oracle', () => {
+    // The starting population objectui#7461 asked to be stated. If this ever
+    // reads zero, the gate has stopped finding the corpus rather than started
+    // agreeing with it.
+    const r = analyze({ root: repoRoot });
+    expect(r.preconditions).toEqual([]);
+    expect(r.bundles.map((b: { rel: string }) => b.rel)).toEqual(['skills/objectui']);
+    expect(r.rows.length).toBeGreaterThan(100);
+    expect(r.shapeFindings).toEqual([]);
+    expect(r.fresh).toEqual([]);
+    expect(r.stale).toEqual([]);
+  });
+
+  it('keeps the rejected oracle re-derivable rather than deleted', () => {
+    // The comparison the header's decision rests on. It is computed on every
+    // run, so `--measure` cannot drift from the gate.
+    const r = analyze({ root: repoRoot });
+    expect(r.redBundle).toEqual([]);
+    expect(r.redPerGuide.length).toBeGreaterThan(0);
+    const artefacts = r.redPerGuide.filter((x: { perGuideExists: boolean }) => !x.perGuideExists);
+    expect(
+      artefacts.length,
+      'the per-guide oracle is not total over this corpus — that is the header\'s argument, and if ' +
+        'it ever becomes total the decision deserves re-reading rather than silently holding',
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe('wiring — the gate is reachable and a markdown-only PR starts it', () => {
+  const SCRIPT = 'scripts/check-skill-eval-tokens.mjs';
+  const workflowDir = path.join(repoRoot, '.github/workflows');
+  const workflowPath = path.join(workflowDir, 'skill-eval-tokens.yml');
+  const workflowFiles = fs.readdirSync(workflowDir).filter((f) => f.endsWith('.yml'));
+
+  /**
+   * A workflow's YAML with whole-line comments removed. Every workflow in this
+   * repository discusses `paths`, `paths-ignore` and its neighbours' scripts in
+   * prose; a scan that counted comments would report filters and duplicate homes
+   * that no file has.
+   */
+  const yamlOf = (file: string) =>
+    fs
+      .readFileSync(path.join(workflowDir, file), 'utf8')
+      .split('\n')
+      .filter((line) => !/^\s*#/.test(line))
+      .join('\n');
+
+  it('is exposed as a root package script', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    expect(pkg.scripts['check:skill-eval-tokens']).toBe(`node ${SCRIPT}`);
+  });
+
+  it('has a workflow that gates pull requests, not just pushes', () => {
+    expect(fs.existsSync(workflowPath), 'a check nothing runs is not a gate').toBe(true);
+    const yaml = yamlOf('skill-eval-tokens.yml');
+    expect(yaml).toMatch(new RegExp(`run:\\s*node\\s+${SCRIPT.replace(/[.]/g, '\\.')}\\s*$`, 'm'));
+    expect(yaml).toMatch(/^\s*pull_request:/m);
+    expect(yaml).toMatch(/^\s*push:/m);
+    expect(yaml).toMatch(/^\s*merge_group:/m);
+  });
+
+  it('runs the self-test too — a probe nobody runs is a probe that passes', () => {
+    expect(yamlOf('skill-eval-tokens.yml')).toMatch(
+      new RegExp(`run:\\s*node\\s+${SCRIPT.replace(/[.]/g, '\\.')}\\s+--self-test`),
+    );
+  });
+
+  it('installs nothing — the criterion is text in the checkout', () => {
+    // The property `check-pre-install-import-graph.mjs` then enforces on the
+    // script: with no `pnpm install` step in the job, every step is a
+    // pre-install step, so the whole static import graph must stay free of
+    // `node_modules`. Folding this gate into `check-skill-examples.mjs` would
+    // have lost exactly this, since that one exits 2 on an unbuilt tree.
+    const yaml = yamlOf('skill-eval-tokens.yml');
+    expect(yaml).not.toMatch(/pnpm install/);
+    expect(yaml).not.toMatch(/turbo run build/);
+    expect(yaml).not.toMatch(/pnpm build/);
+  });
+
+  it('runs it in NO path-filtered workflow — the scan surface is entirely markdown and JSON', () => {
+    expect(workflowFiles.length, 'the workflow directory scan returned implausibly few files').toBeGreaterThan(5);
+    for (const file of workflowFiles) {
+      const yaml = yamlOf(file);
+      if (!yaml.includes(SCRIPT)) continue;
+      expect(yaml, `${file} runs ${SCRIPT} behind a paths-ignore — a guide-only change would not start it`).not.toMatch(
+        /paths-ignore:/,
+      );
+      expect(yaml, `${file} runs ${SCRIPT} behind a paths filter — see objectui#3448`).not.toMatch(/^\s+paths:/m);
+    }
+  });
+
+  it('has exactly one home', () => {
+    expect(workflowFiles.filter((f) => yamlOf(f).includes(SCRIPT))).toEqual(['skill-eval-tokens.yml']);
+  });
+
+  it('does not run a NEIGHBOUR gate from this workflow', () => {
+    // `check-skill-examples.test.ts` pins that its own script lives in exactly
+    // one workflow. Invoking it from this YAML would break that pin and give
+    // one gate two homes.
+    expect(yamlOf('skill-eval-tokens.yml')).not.toContain('scripts/check-skill-examples.mjs');
+  });
+
+  it('is classified as a blocking context rather than defaulting into silence', () => {
+    const gate = fs.readFileSync(path.join(repoRoot, 'scripts/dependabot-merge-gate.mjs'), 'utf8');
+    expect(gate).toContain("'Skill Eval Token Check'");
+  });
+
+  it('has a section on the CI page, named by heading', () => {
+    // `ci-cd-pipeline-doc.test.ts` enforces this repo-wide; restated here
+    // because objectui#3212's lesson is that the omission happens at the moment
+    // the workflow is added, not later.
+    const doc = fs.readFileSync(path.join(repoRoot, 'content/docs/guide/ci-cd-pipeline.md'), 'utf8');
+    const headings = doc.split('\n').filter((line) => /^#{1,6}\s/.test(line));
+    expect(headings.some((h) => h.includes('skill-eval-tokens.yml'))).toBe(true);
+  });
+});

--- a/scripts/__tests__/merge-queue-reporting.test.ts
+++ b/scripts/__tests__/merge-queue-reporting.test.ts
@@ -102,6 +102,15 @@ const MUST_SUBSCRIBE_MERGE_GROUP = new Map<string, string>([
       'classifies it as a required context',
   ],
   [
+    'skill-eval-tokens.yml',
+    'produces Skill Eval Token Check — added by objectui#7461. It holds every eval assertion\'s ' +
+      '`must_contain` token to the guides its own skill bundle ships, and its whole input is the ' +
+      'markdown and JSON under `skills/` — the shape `ci.yml` and `lint.yml` structurally cannot ' +
+      'see (both list `**/*.md` under the `paths-ignore` of their `push` trigger), so it carries ' +
+      'no path filter, reports on every pull request, and is therefore requirable; ' +
+      '`scripts/dependabot-merge-gate.mjs` classifies it as a required context',
+  ],
+  [
     'pre-install-import-graph.yml',
     'produces Pre-Install Import Graph Check — added by objectui#6148. What it judges is the ' +
       'arrangement of the workflows themselves, so it carries no path filter, reports on every ' +

--- a/scripts/check-skill-eval-tokens.mjs
+++ b/scripts/check-skill-eval-tokens.mjs
@@ -1,0 +1,750 @@
+#!/usr/bin/env node
+/**
+ * Every `must_contain` token of every `skills/<bundle>/evals/*.json` must be
+ * something the skill bundle actually TEACHES — present as a WHOLE token in the
+ * bundle's own markdown.
+ *
+ * Run:  node scripts/check-skill-eval-tokens.mjs        (also `pnpm check:skill-eval-tokens`)
+ *       node scripts/check-skill-eval-tokens.mjs --list        # every row + both oracles' counts
+ *       node scripts/check-skill-eval-tokens.mjs --measure     # BOTH red lists, side by side
+ *       node scripts/check-skill-eval-tokens.mjs --self-test   # fixtures, both directions
+ * Exit: 0 = every `must_contain` token is taught, and the population is non-empty.
+ *       1 = THE GATE RAN AND FOUND ERRORS. A token no guide teaches, an eval
+ *           assertion of the wrong shape, or a stale baseline row. Everything
+ *           printed above the summary is a verdict about an eval.
+ *       2 = THE GATE COULD NOT RUN, so nothing printed above is a verdict about
+ *           any eval: no eval population, no guide corpus, or an eval file that
+ *           does not parse. Fix the tree and re-run. Never read this as an eval
+ *           defect, and never as a pass.
+ *
+ * ## The gap this closes (objectui#7461)
+ *
+ * `skills/objectui/evals/*.json` grade an answering agent by `must_contain` /
+ * `must_not_contain` tokens. Nothing checked that a `must_contain` token was
+ * something the skill teaches, so an eval could require a word the guides never
+ * say and grade nothing forever. The class has been cleaned BY HAND twice:
+ *
+ *   - objectui#7360 (PR #7408): six assertions graded tokens their own guide
+ *     never taught; one passed only by accidental substring.
+ *   - objectui#7405 (PR #7422): three more — `create` matched a mocked
+ *     dataSource method, `view` matched the tail of `// vite preview`, and
+ *     `visible` was untaught and was re-pointed to the taught `hidden`.
+ *
+ * Both rounds were found by a human reading, which is exactly the economics
+ * `check-skills-paths.mjs` and `check-skill-examples.mjs` were built to end for
+ * their own surfaces. `check-skill-examples.mjs` names this check in its
+ * "Deliberately NOT answered here" list, item 4, as a different oracle over a
+ * different corpus — this file is that check.
+ *
+ * ## THE ORACLE: bundle-wide, and what the losing option would have cost
+ *
+ * The load-bearing decision is which guide set a token has to appear in. Two
+ * candidates, both measured at the branch point over all 125 `must_contain`
+ * tokens of all 33 evals in all 11 eval files:
+ *
+ *   | oracle                                  | red rows on day one |
+ *   |-----------------------------------------|---------------------|
+ *   | BUNDLE-WIDE (every `.md` in the bundle)  | 0 of 125           |
+ *   | PER-GUIDE (`guides/BASENAME.md` only)    | 14 of 125          |
+ *
+ * ⭐ CHOSEN: BUNDLE-WIDE. The reasoning, on the four axes this repository's
+ * dispatch requires, with the long-term axis weighted heaviest:
+ *
+ * **1. Real business need — measured, not assumed.** The consumer of an eval is
+ * an answering agent, and what it loads is the WHOLE bundle. `SKILL.md` is a
+ * router: its "Where to go" table names all eleven guides, and its rules block
+ * says the three files under `rules/` are "the anchor for every rule the guides
+ * only cue" and are to be read "before writing schemas". So the corpus an eval
+ * is answered from is the bundle, and an oracle narrower than the corpus asserts
+ * a fact the artifact does not support. The disagreement comment 5514262423
+ * flagged is exactly this: `evals/page-builder.json` eval 1 requires
+ * `registerComponent`, which is taught once — in `guides/plugin-development.md`,
+ * the file `SKILL.md` routes "package a custom renderer or field widget as a
+ * plugin" to. That eval is honest; per-guide would call it a defect.
+ *
+ * **2. Long-term soundness (weighted heaviest).** Per-guide is not even TOTAL
+ * over today's corpus, and that is a structural fault rather than a missing
+ * mapping row. `evals/protocol.json` has no `guides/protocol.md`: its guide is
+ * `rules/protocol.md`. Twelve of per-guide's fourteen red rows are that one
+ * file, red for the sole reason that the oracle cannot find a file. Adopting
+ * per-guide would therefore mean inventing a second, undeclared convention
+ * ("`guides/BASENAME.md`, or `rules/BASENAME.md`, or ...") whose only job is to
+ * repair the oracle — and then baselining twelve rows that name no defect. A
+ * baseline that large on a 125-row population is the shape this repository has
+ * repeatedly measured people learning to ignore. Bundle-wide needs no mapping
+ * table, no baseline, and stays correct when a twelfth guide or a second bundle
+ * lands.
+ *
+ * **3. Making AI-written code hard to get wrong.** Both oracles catch the whole
+ * class the two hand sweeps found — a token NOTHING teaches. What bundle-wide
+ * gives up is narrower than it looks: only "taught, but in a sibling file",
+ * which for a whole-bundle reader is not an error at all. What actually closed
+ * the false-negative half is the WHOLE-TOKEN rule below, and that is orthogonal
+ * to the oracle — it applies under either.
+ *
+ * **4. Startup scope discipline.** Bundle-wide lands green on day one with an
+ * EMPTY baseline and no follow-up programme. Per-guide would land a fourteen-row
+ * debt list, twelve rows of which are oracle artefacts that no per-row skills
+ * decision can ever retire, plus the mapping convention needed to make it run.
+ *
+ * ⛔ The losing option is not deleted, it is kept RE-DERIVABLE: `--measure`
+ * prints BOTH red lists on every invocation, so the fourteen rows above are a
+ * number anyone can reproduce rather than a claim in a merged pull request body.
+ *
+ * ## WHOLE TOKENS, and the one false positive this rule does NOT close
+ *
+ * A token counts only as a whole token, never as a substring. The boundary rule
+ * is stated here because half the corpus is not identifier-shaped:
+ *
+ *   IDENT_CHAR is `[A-Za-z0-9_$]`. An occurrence of the literal token counts if
+ *     - its FIRST character is an IDENT_CHAR  -> the character before it must
+ *       not be an IDENT_CHAR (or there is none), and
+ *     - its LAST character is an IDENT_CHAR   -> the character after it must not
+ *       be an IDENT_CHAR (or there is none).
+ *   A token that is not identifier-shaped at an end gets NO boundary at that
+ *   end. So an identifier token is matched on word boundaries, while a token
+ *   like a quoted key or an operator degrades to an exact substring — which is
+ *   what such a token means. Matching is CASE-SENSITIVE: these are identifiers
+ *   and JSON keys, and case-folding would let `Type` vouch for `type`.
+ *
+ * The rule is pinned in `--self-test` against the three false positives
+ * objectui#7405 measured, and the third one is the honest limit of this gate:
+ *
+ *   - `view` inside `// vite preview`      -> substring 1, WHOLE 0. Caught.
+ *   - `FieldWidgetProps` inside
+ *     `FieldWidgetPropsSchema`             -> substring 1, WHOLE 0. Caught.
+ *   - `create` inside `create: vi.fn()`    -> substring 1, WHOLE 1. NOT caught,
+ *     and cannot be: `create` really is a whole token there. The mismatch is
+ *     SEMANTIC — the eval meant the form mode, the guide had a mocked
+ *     dataSource method. ⚠️ A green from this gate therefore means "the bundle
+ *     says this word somewhere", never "the bundle teaches the thing the eval
+ *     means". That second question is a human reading and this gate does not
+ *     claim it. Saying so here is the difference between a stated boundary and
+ *     a silent one.
+ *
+ * ## `must_not_contain` is NOT validated against the guides, deliberately
+ *
+ * It gets a SHAPE check (a non-empty string) and nothing else. objectui#7370
+ * spelled one entry as a quoted JSON key fragment rather than the bare word,
+ * precisely because a bare word would fail any answer that names the rule while
+ * following it. An entry there is a token the answer must AVOID, so "no guide
+ * says it" is the healthy case; a check that validated it the way it validates
+ * `must_contain` would have the polarity backwards and would red on the entries
+ * that are most carefully chosen. `--self-test` pins that direction.
+ *
+ * ## The baseline: declared, SHRINK-ONLY, and EMPTY at landing
+ *
+ * `KNOWN_UNTAUGHT_EVAL_TOKENS` is empty today, because the chosen oracle has no
+ * red rows. It exists anyway, in the shape `check-doc-fence-languages.mjs`
+ * landed for `KNOWN_UNHIGHLIGHTED_TS_FENCES`, because the alternative landing
+ * route for the first future red is editing an eval row or guide prose — and
+ * objectui#7461 rules that out in as many words: re-pointing a row is a per-row
+ * skills decision, never a mechanical one. Without a declared list, the first
+ * red forces the mechanical edit the card forbids.
+ *
+ *   - a red row NOT in the list fails — a newly untaught token cannot land;
+ *   - a row IN the list whose red is GONE fails as STALE and names itself, the
+ *     remedy being to delete the line. No supported route adds one silently.
+ *
+ * That second direction is what stops an empty list from decaying into a
+ * permit: the list can only ever shrink, so a row parked in it is visible debt
+ * with a stated owner, not an exemption.
+ *
+ * ## What this gate deliberately does NOT answer
+ *
+ *   1. **Whether the guide teaches what the eval MEANS.** See the `create` case
+ *      above. Word presence is the mechanical half; the semantic half stays a
+ *      human reading, which is why the red list is described as a starting list
+ *      for per-row judgement rather than a work queue to be cleared.
+ *   2. **Whether an eval's `expected_output` is reachable.** A different oracle
+ *      over a different corpus.
+ *   3. **Whether `must_contain` is EMPTY.** An eval that asserts nothing is a
+ *      real question and a different one; the count is printed on every run so
+ *      it cannot hide, and no verdict is taken on it here.
+ *   4. **`.claude/skills/**`.** This gate's root is the PUBLISHED bundle, the
+ *      governed surface objectui#7461 was filed about — the same boundary
+ *      `check-skill-examples.mjs` states for itself.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isEntrypoint } from './invoked-as.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/**
+ * The prose root this gate walks. One entry today: the PUBLISHED skill bundles.
+ * Stated here as a decision rather than left to be read off the walker — see
+ * "What this gate deliberately does NOT answer" item 4 for why `.claude/skills`
+ * is not in it.
+ */
+export const SCAN_ROOTS = ['skills'];
+
+/**
+ * A skill BUNDLE is any directory under a scan root that contains an `evals/`
+ * directory. The oracle corpus is every `.md` under THAT bundle — which is what
+ * "the answering agent loads the whole skill" means when there is more than one
+ * skill. Today there is exactly one bundle, `skills/objectui`, so this is
+ * identical to "every `.md` under `skills/`"; it is written per-bundle so it
+ * stays correct rather than accidentally right.
+ */
+export const ORACLE = 'bundle-wide';
+
+/** Characters that continue an identifier, for the whole-token boundary rule. */
+export const IDENT_CHAR = /[A-Za-z0-9_$]/;
+
+/**
+ * This gate's exit codes, named so callers and tests can talk about them.
+ * `couldNotRun` is deliberately distinct from `tokensUntaught`; see the header.
+ * The numbers are this repository's convention (`check-skill-examples.mjs`,
+ * `check-doc-snippet-types.mjs`, `check-eager-closure-budget.mjs`), and each
+ * gate names them for itself so no gate's exit contract is a side effect of
+ * importing another one.
+ */
+export const EXIT_CODES = {
+  /** Every `must_contain` token is taught, and something was actually checked. */
+  verified: 0,
+  /** The gate RAN. An eval row or a baseline row is at fault. */
+  tokensUntaught: 1,
+  /** The gate COULD NOT RUN. Nothing it printed is a verdict about any eval. */
+  couldNotRun: 2,
+};
+
+// ── The debt list ───────────────────────────────────────────────────────────
+
+/**
+ * ⛔ SHRINK-ONLY. Rows spelled exactly as `rowKey()` builds them:
+ *
+ *     skills/<bundle>/evals/<file>.json eval <id> <token>
+ *
+ * EMPTY at landing, because the bundle-wide oracle has no red rows over the
+ * corpus at objectui#7461's branch point. The header says why an empty list
+ * still earns its place, and why the only supported direction is down.
+ *
+ * ⚠️ The row key is bundle-QUALIFIED (it carries the full repo-relative eval
+ * path) where objectui#7461 sketched a bare `evals/FILE.json`. Same granularity
+ * — one file, one eval, one token, so a per-row fix removes exactly one line —
+ * but it stays unambiguous if a second skill bundle ever lands beside
+ * `objectui`. The token is everything after `eval <id> ` and is never re-split,
+ * so a token containing spaces is safe here.
+ *
+ * @type {ReadonlySet<string>}
+ */
+export const KNOWN_UNTAUGHT_EVAL_TOKENS = new Set([]);
+
+// ── The whole-token rule ─────────────────────────────────────────────────────
+
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * The boundary rule from the header, as a regular expression. A boundary is
+ * asserted on an end only when the token's own character at that end is an
+ * IDENT_CHAR, so a token that is not identifier-shaped at an end degrades to an
+ * exact substring there.
+ */
+export function wholeTokenPattern(token) {
+  const left = IDENT_CHAR.test(token[0]) ? '(?<![A-Za-z0-9_$])' : '';
+  const right = IDENT_CHAR.test(token[token.length - 1]) ? '(?![A-Za-z0-9_$])' : '';
+  return new RegExp(`${left}${escapeRegExp(token)}${right}`, 'g');
+}
+
+/** How many times `token` occurs as a WHOLE token in `text`. Case-sensitive. */
+export function countWholeToken(text, token) {
+  if (token === '') return 0;
+  return (text.match(wholeTokenPattern(token)) ?? []).length;
+}
+
+/**
+ * How many times `token` occurs as a bare SUBSTRING. Kept only so the run can
+ * SHOW the difference — a row that is substring-present and whole-token-absent
+ * is precisely the class objectui#7405 found by hand, and printing the pair is
+ * what makes "the whole-token rule is doing work" auditable instead of claimed.
+ */
+export function countSubstring(text, token) {
+  if (token === '') return 0;
+  return (text.match(new RegExp(escapeRegExp(token), 'g')) ?? []).length;
+}
+
+// ── Corpus walking ───────────────────────────────────────────────────────────
+
+function walk(dir, predicate, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => (a.name < b.name ? -1 : 1))) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, predicate, out);
+    else if (predicate(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Every skill bundle under the scan roots: a directory holding an `evals/`
+ * directory. Returned sorted, with paths repo-relative and `/`-separated so the
+ * output and the row keys read the same on every platform.
+ */
+export function listBundles(root) {
+  const bundles = [];
+  for (const scanRoot of SCAN_ROOTS) {
+    const base = join(root, scanRoot);
+    if (!existsSync(base) || !statSync(base).isDirectory()) continue;
+    const seen = new Set();
+    for (const evalFile of walk(base, (name) => name.endsWith('.json'))) {
+      const evalsDir = dirname(evalFile);
+      if (evalsDir.split(sep).pop() !== 'evals') continue;
+      const bundleDir = dirname(evalsDir);
+      if (seen.has(bundleDir)) continue;
+      seen.add(bundleDir);
+      bundles.push(bundleDir);
+    }
+  }
+  return bundles.sort().map((dir) => ({ dir, rel: relative(root, dir).split(sep).join('/') }));
+}
+
+/** The row key. One file, one eval, one token — the unit a per-row fix removes. */
+export function rowKey(evalPath, evalId, token) {
+  return `${evalPath} eval ${evalId} ${token}`;
+}
+
+// ── Analysis ─────────────────────────────────────────────────────────────────
+
+/**
+ * Read the corpus and score every `must_contain` token under BOTH oracles. The
+ * losing oracle is computed on every run rather than only under `--measure`, so
+ * `--list` can show the disagreement and no separate code path can drift.
+ *
+ * Findings are split three ways, and the split IS the exit contract:
+ *   - `preconditions` -> exit 2. The gate could not read the population.
+ *   - `shapeFindings` -> exit 1. An assertion array is malformed.
+ *   - `rows`          -> the judgement, reconciled against the baseline.
+ */
+export function analyze({ root, baseline = KNOWN_UNTAUGHT_EVAL_TOKENS }) {
+  const preconditions = [];
+  const shapeFindings = [];
+  const rows = [];
+  const bundles = [];
+
+  for (const bundle of listBundles(root)) {
+    const guideFiles = walk(bundle.dir, (name) => name.endsWith('.md'));
+    const guides = guideFiles.map((full) => ({
+      rel: relative(root, full).split(sep).join('/'),
+      text: readFileSync(full, 'utf8'),
+    }));
+    if (guides.length === 0) {
+      preconditions.push({
+        site: bundle.rel,
+        reason: 'no-guides',
+        detail: 'the bundle holds eval files but no .md at all, so there is no corpus to score against',
+      });
+    }
+    const bundleText = guides.map((g) => g.text).join('\n');
+
+    const evalFiles = walk(join(bundle.dir, 'evals'), (name) => name.endsWith('.json'));
+    const record = { rel: bundle.rel, guides: guides.map((g) => g.rel), evalFiles: [], evalCount: 0, emptyMustContain: 0 };
+
+    for (const full of evalFiles) {
+      const evalPath = relative(root, full).split(sep).join('/');
+      record.evalFiles.push(evalPath);
+      let doc;
+      try {
+        doc = JSON.parse(readFileSync(full, 'utf8'));
+      } catch (error) {
+        preconditions.push({
+          site: evalPath,
+          reason: 'unparseable',
+          detail: `${error.message} — the population is incomplete, so a green over the rest would be a coverage claim this run cannot make`,
+        });
+        continue;
+      }
+
+      // The per-guide candidate the card names, measured but NOT adopted. Its
+      // absence is recorded rather than repaired: 12 of its 14 red rows exist
+      // only because this file is missing, which is the header's point.
+      const basename = evalPath.split('/').pop().replace(/\.json$/, '');
+      const perGuideRel = `${bundle.rel}/guides/${basename}.md`;
+      const perGuide = guides.find((g) => g.rel === perGuideRel) ?? null;
+
+      for (const item of doc.evals ?? []) {
+        record.evalCount += 1;
+        const assertions = item.assertions ?? {};
+        const mustContain = assertions.must_contain ?? [];
+        const mustNotContain = assertions.must_not_contain ?? [];
+
+        if (Array.isArray(mustContain) && mustContain.length === 0) record.emptyMustContain += 1;
+
+        for (const [field, list] of [
+          ['must_contain', mustContain],
+          ['must_not_contain', mustNotContain],
+        ]) {
+          if (!Array.isArray(list)) {
+            shapeFindings.push({
+              site: `${evalPath} eval ${item.id}`,
+              reason: 'not-an-array',
+              detail: `${field} is ${typeof list}, not an array`,
+            });
+            continue;
+          }
+          for (const token of list) {
+            if (typeof token !== 'string' || token === '') {
+              shapeFindings.push({
+                site: `${evalPath} eval ${item.id}`,
+                reason: 'bad-token',
+                detail: `${field} holds ${JSON.stringify(token)} — every entry must be a non-empty string`,
+              });
+            }
+          }
+        }
+
+        // ⛔ `must_not_contain` stops at the shape check above and is NEVER
+        // scored against the guides. The header states why; the self-test pins
+        // that an entry absent from every guide does not red.
+        if (!Array.isArray(mustContain)) continue;
+        for (const token of mustContain) {
+          if (typeof token !== 'string' || token === '') continue;
+          rows.push({
+            key: rowKey(evalPath, item.id, token),
+            evalPath,
+            evalId: item.id,
+            token,
+            bundleWhole: countWholeToken(bundleText, token),
+            bundleSubstring: countSubstring(bundleText, token),
+            perGuideRel,
+            perGuideExists: perGuide !== null,
+            perGuideWhole: perGuide === null ? null : countWholeToken(perGuide.text, token),
+            perGuideSubstring: perGuide === null ? null : countSubstring(perGuide.text, token),
+          });
+        }
+      }
+    }
+    bundles.push(record);
+  }
+
+  if (bundles.length === 0) {
+    preconditions.push({
+      site: SCAN_ROOTS.join(', '),
+      reason: 'no-bundles',
+      detail: 'no directory under the scan roots holds an evals/ directory',
+    });
+  } else if (rows.length === 0 && preconditions.length === 0) {
+    preconditions.push({
+      site: SCAN_ROOTS.join(', '),
+      reason: 'empty-population',
+      detail: 'the bundles hold no must_contain token at all, so this run judged nothing',
+    });
+  }
+
+  const redBundle = rows.filter((r) => r.bundleWhole === 0);
+  const redPerGuide = rows.filter((r) => !r.perGuideExists || r.perGuideWhole === 0);
+  const red = ORACLE === 'bundle-wide' ? redBundle : redPerGuide;
+
+  const fresh = red.filter((r) => !baseline.has(r.key));
+  const redKeys = new Set(red.map((r) => r.key));
+  const stale = [...baseline].filter((key) => !redKeys.has(key)).sort();
+
+  return { bundles, rows, preconditions, shapeFindings, red, redBundle, redPerGuide, fresh, stale };
+}
+
+// ── Verdict ──────────────────────────────────────────────────────────────────
+
+const REMEDY =
+  '\n    A `must_contain` token no guide in the bundle states as a WHOLE token.' +
+  '\n    ⛔ Do NOT rewrite guide prose to teach the token, and do NOT drop or' +
+  '\n    re-point the row mechanically — objectui#7461 rules both out: which of' +
+  '\n    the two is right is a per-row skills decision, funded per row.' +
+  '\n' +
+  '\n    Land the judgement in a card, and if the gate must be green first, add' +
+  '\n    the row VERBATIM to KNOWN_UNTAUGHT_EVAL_TOKENS in this script. That list' +
+  '\n    is ⛔ SHRINK-ONLY: a row whose red goes away fails as STALE, so a parked' +
+  '\n    row stays visible until someone retires it.';
+
+function report(result) {
+  for (const f of result.preconditions) console.error(`  ${f.site}  [${f.reason}]  ${f.detail}`);
+  if (result.preconditions.length > 0) {
+    console.error(
+      `\nPRECONDITION NOT MET (exit ${EXIT_CODES.couldNotRun}) — the eval population or the guide ` +
+        'corpus could not be read, so NO line above is a verdict about any eval. This is ' +
+        '"I could not run", NOT "I ran and everything is taught": a gate that checks nothing must ' +
+        'not report success (objectui#4846).',
+    );
+    return EXIT_CODES.couldNotRun;
+  }
+
+  const totalEvals = result.bundles.reduce((n, b) => n + b.evalCount, 0);
+  const totalGuides = result.bundles.reduce((n, b) => n + b.guides.length, 0);
+  const emptyMustContain = result.bundles.reduce((n, b) => n + b.emptyMustContain, 0);
+
+  for (const f of result.shapeFindings) console.error(`  ${f.site}  [${f.reason}]  ${f.detail}`);
+  for (const row of result.fresh) {
+    const hint =
+      row.bundleSubstring > 0
+        ? ` (it appears ${row.bundleSubstring} time(s) as a SUBSTRING only — see the whole-token rule)`
+        : ' (it appears nowhere in the bundle, in any form)';
+    console.error(`  ${row.evalPath} eval ${row.evalId}  [untaught]  ${JSON.stringify(row.token)}${hint}`);
+  }
+  for (const key of result.stale) {
+    console.error(`  ${key}  [stale-baseline]  this row is no longer red — delete its line, the list only shrinks`);
+  }
+
+  console.log(
+    `Scanned ${result.bundles.length} skill bundle(s) under ${SCAN_ROOTS.join(', ')}: ` +
+      `${result.bundles.reduce((n, b) => n + b.evalFiles.length, 0)} eval file(s), ${totalEvals} eval(s), ` +
+      `${result.rows.length} must_contain token(s), scored against ${totalGuides} guide file(s).`,
+  );
+  console.log(
+    `Oracle: ${ORACLE} — a token must occur as a WHOLE token (case-sensitive) somewhere in its own ` +
+      "bundle's markdown. `must_not_contain` is shape-checked only and is never scored against the guides.",
+  );
+  console.log(
+    `Baseline: ${KNOWN_UNTAUGHT_EVAL_TOKENS.size} row(s) declared in KNOWN_UNTAUGHT_EVAL_TOKENS (⛔ SHRINK-ONLY).`,
+  );
+  console.log(
+    `Evals whose must_contain is EMPTY: ${emptyMustContain}. Printed so it cannot hide; no verdict is taken on it here.`,
+  );
+  console.log(
+    `Red under the chosen oracle: ${result.red.length} (${result.fresh.length} beyond the baseline). ` +
+      `Under the rejected per-guide oracle it would be ${result.redPerGuide.length} — re-derive both with --measure.`,
+  );
+
+  if (result.shapeFindings.length > 0 || result.fresh.length > 0 || result.stale.length > 0) {
+    if (result.fresh.length > 0) console.error(REMEDY);
+    console.error(`\nThe eval assertions above do not hold up (exit ${EXIT_CODES.tokensUntaught}).`);
+    return EXIT_CODES.tokensUntaught;
+  }
+  console.log('\nEvery must_contain token is taught by its own skill bundle.');
+  return EXIT_CODES.verified;
+}
+
+function measure(result) {
+  const show = (label, rows, describe) => {
+    console.log(`\n=== RED under ${label}: ${rows.length} of ${result.rows.length} ===`);
+    for (const row of rows) console.log(`  ${row.key}${describe(row)}`);
+    if (rows.length === 0) console.log('  (none)');
+  };
+  show('BUNDLE-WIDE whole-token  [CHOSEN]', result.redBundle, (row) =>
+    row.bundleSubstring > 0 ? `   (substring-only: ${row.bundleSubstring})` : '',
+  );
+  show('PER-GUIDE whole-token  [rejected]', result.redPerGuide, (row) =>
+    !row.perGuideExists
+      ? `   (no ${row.perGuideRel} — the oracle cannot find a file, so this row names no defect)`
+      : row.perGuideSubstring > 0
+        ? `   (substring-only: ${row.perGuideSubstring})`
+        : '',
+  );
+  const artefacts = result.redPerGuide.filter((r) => !r.perGuideExists).length;
+  console.log(
+    `\nOf the per-guide reds, ${artefacts} exist only because the basename-matching guide is MISSING ` +
+      `and ${result.redPerGuide.length - artefacts} name a token taught elsewhere in the bundle. ` +
+      'That split is the header\'s argument, measured rather than asserted.',
+  );
+}
+
+function list(result) {
+  console.log('  perGuide  bundle    row');
+  for (const row of result.rows) {
+    const pg = row.perGuideExists ? `${row.perGuideWhole}/${row.perGuideSubstring}` : 'NO-GUIDE';
+    console.log(`  ${pg.padEnd(9)} ${`${row.bundleWhole}/${row.bundleSubstring}`.padEnd(9)} ${row.key}`);
+  }
+  console.log('  (counts are whole-token/substring; a pair like 0/3 is the class objectui#7405 found by hand)\n');
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const result = analyze({ root: repoRoot });
+
+  if (result.preconditions.length > 0) return report(result);
+  if (argv.includes('--list')) list(result);
+  if (argv.includes('--measure')) {
+    measure(result);
+    // `--measure` reports; it does not gate. It exists to keep the rejected
+    // oracle's cost re-derivable rather than a claim in a merged PR body.
+    console.log('');
+    report(result);
+    return EXIT_CODES.verified;
+  }
+  return report(result);
+}
+
+// ── Self-test ────────────────────────────────────────────────────────────────
+
+/**
+ * The rules pinned on FIXTURES rather than on the real bundle. A committed
+ * fixture guide would have to contain a deliberately untaught eval, and
+ * something else in this repository would eventually scan it — the reasoning
+ * `check-skills-paths.test.ts` states for its own throwaway trees.
+ *
+ * Every case here is a direction this gate could fail in silently, and the six
+ * objectui#7461 asks for are all present: a taught token passes; an untaught one
+ * reds; a substring-only match reds; a `must_not_contain` entry never reds; an
+ * empty population exits 2; and a baseline row suppresses exactly its own red
+ * and nothing else.
+ */
+export function selfTest() {
+  const cases = [];
+  const t = (name, ok, detail) => cases.push({ name, ok: Boolean(ok), detail });
+
+  const trees = [];
+  const tree = (files) => {
+    const dir = mkdtempSync(join(tmpdir(), 'check-skill-eval-tokens-'));
+    trees.push(dir);
+    for (const [rel, contents] of Object.entries(files)) {
+      const full = join(dir, rel);
+      mkdirSync(dirname(full), { recursive: true });
+      writeFileSync(full, contents);
+    }
+    return dir;
+  };
+  const evalDoc = (assertions) =>
+    JSON.stringify({ skill_name: 'fixture', evals: [{ id: 1, prompt: 'p', expected_output: 'e', files: [], assertions }] });
+
+  try {
+    // ── the whole-token rule, on the three measured false positives ─────────
+    t('a taught identifier is found as a whole token', countWholeToken('call scope.registerComponent(x)', 'registerComponent') === 1);
+    t('`view` does NOT match inside `// vite preview`', countWholeToken('// vite preview', 'view') === 0, `got ${countWholeToken('// vite preview', 'view')}`);
+    t('`view` DOES match when it stands alone', countWholeToken('the view name', 'view') === 1);
+    t(
+      '`FieldWidgetProps` does NOT match the head of `FieldWidgetPropsSchema`',
+      countWholeToken('import { FieldWidgetPropsSchema } from "x";', 'FieldWidgetProps') === 0,
+    );
+    t(
+      '⚠️ `create` DOES match `create: vi.fn()` — the stated limit, pinned so it is never mistaken for coverage',
+      countWholeToken("create: vi.fn().mockResolvedValue({ id: '1' })", 'create') === 1,
+    );
+    t('substring counting still sees all three, which is why the rule exists',
+      countSubstring('// vite preview', 'view') === 1 &&
+        countSubstring('FieldWidgetPropsSchema', 'FieldWidgetProps') === 1);
+    t('`xl` does not match inside `2xl` — a digit continues an identifier', countWholeToken('the 2xl step', 'xl') === 0);
+    t('a non-identifier-shaped token degrades to an exact substring', countWholeToken('a "props": { b', '"props": {') === 1);
+    t('a token that is identifier-shaped on ONE end binds on that end only', countWholeToken('format( and t( here', 't(') === 1);
+    t('matching is case-sensitive', countWholeToken('Type is not type', 'type') === 1);
+    t('an empty token never matches, rather than matching everywhere', countWholeToken('anything', '') === 0);
+
+    // ── the corpus judgement, end to end ────────────────────────────────────
+    const root = tree({
+      'skills/fixture/guides/alpha.md': 'The alpha guide teaches registerComponent and charts.\n',
+      'skills/fixture/rules/protocol.md': 'The protocol rule teaches hoisted nodes.\n',
+      'skills/fixture/evals/alpha.json': evalDoc({
+        must_contain: ['registerComponent', 'hoisted', 'chart', 'neverTaughtAnywhere'],
+        must_not_contain: ['absolutelyNoGuideSaysThis', '"props": {'],
+      }),
+    });
+    const r = analyze({ root, baseline: new Set() });
+    const redKeys = r.red.map((x) => x.key);
+
+    t('a token taught in the eval\'s OWN guide passes', !redKeys.some((k) => k.endsWith('registerComponent')));
+    t(
+      'a token taught in a SIBLING file of the bundle passes — this is the oracle',
+      !redKeys.some((k) => k.endsWith('hoisted')),
+      JSON.stringify(redKeys),
+    );
+    t('a token nothing teaches REDS', redKeys.some((k) => k.endsWith('neverTaughtAnywhere')));
+    t(
+      'a SUBSTRING-only match reds — `chart` inside `charts` is not taught',
+      redKeys.some((k) => k.endsWith(' chart')),
+      JSON.stringify(redKeys),
+    );
+    t('exactly those two are red, and nothing else', r.red.length === 2, JSON.stringify(redKeys));
+    t(
+      'a must_not_contain entry absent from EVERY guide does NOT red',
+      !redKeys.some((k) => k.includes('absolutelyNoGuideSaysThis')) && r.shapeFindings.length === 0,
+      JSON.stringify({ redKeys, shape: r.shapeFindings }),
+    );
+    t(
+      'the rejected per-guide oracle would additionally red the sibling-taught token',
+      r.redPerGuide.some((x) => x.token === 'hoisted') && !r.redBundle.some((x) => x.token === 'hoisted'),
+    );
+
+    // ── the baseline: exactly its own row, and only downwards ───────────────
+    const chartKey = r.red.find((x) => x.token === 'chart').key;
+    const baselined = analyze({ root, baseline: new Set([chartKey]) });
+    t(
+      'a baseline row suppresses exactly its own red',
+      baselined.fresh.length === 1 && baselined.fresh[0].token === 'neverTaughtAnywhere',
+      JSON.stringify(baselined.fresh.map((x) => x.key)),
+    );
+    t('...and nothing else — the other red survives it', baselined.red.length === 2 && baselined.stale.length === 0);
+    t(
+      'a baseline row whose red is GONE is STALE, so the list can only shrink',
+      analyze({ root, baseline: new Set([chartKey, 'skills/fixture/evals/alpha.json eval 1 registerComponent']) }).stale
+        .length === 1,
+    );
+
+    // ── shape checks on the assertion arrays ────────────────────────────────
+    const badShape = analyze({
+      root: tree({
+        'skills/fixture/guides/alpha.md': 'taught\n',
+        'skills/fixture/evals/alpha.json': evalDoc({ must_contain: ['taught', ''], must_not_contain: 'nope' }),
+      }),
+      baseline: new Set(),
+    });
+    t('an empty-string token is a SHAPE failure, not a silent always-red', badShape.shapeFindings.some((f) => f.reason === 'bad-token'));
+    t('a non-array assertion list is a SHAPE failure', badShape.shapeFindings.some((f) => f.reason === 'not-an-array'));
+    t('the shape failures do not become token reds', badShape.red.length === 0, JSON.stringify(badShape.red.map((x) => x.key)));
+
+    // ── the preconditions: never 0 for "nothing checked" ────────────────────
+    t(
+      'a tree with NO bundle at all is a PRECONDITION, never a pass',
+      analyze({ root: tree({ 'skills/fixture/guides/alpha.md': 'x\n' }), baseline: new Set() }).preconditions.some(
+        (p) => p.reason === 'no-bundles',
+      ),
+    );
+    t(
+      'a bundle whose evals assert NO must_contain token is a PRECONDITION',
+      analyze({
+        root: tree({
+          'skills/fixture/guides/alpha.md': 'x\n',
+          'skills/fixture/evals/alpha.json': evalDoc({ must_contain: [], must_not_contain: [] }),
+        }),
+        baseline: new Set(),
+      }).preconditions.some((p) => p.reason === 'empty-population'),
+    );
+    t(
+      'a bundle with eval files but NO markdown is a PRECONDITION',
+      analyze({
+        root: tree({ 'skills/fixture/evals/alpha.json': evalDoc({ must_contain: ['x'], must_not_contain: [] }) }),
+        baseline: new Set(),
+      }).preconditions.some((p) => p.reason === 'no-guides'),
+    );
+    t(
+      'an eval file that does not PARSE is a PRECONDITION, not a green over the rest',
+      analyze({
+        root: tree({
+          'skills/fixture/guides/alpha.md': 'taught\n',
+          'skills/fixture/evals/alpha.json': '{ "evals": [ }',
+        }),
+        baseline: new Set(),
+      }).preconditions.some((p) => p.reason === 'unparseable'),
+    );
+
+    // ── the row key is the unit a per-row fix removes ───────────────────────
+    t(
+      'the row key names file, eval and token, and keeps a token containing spaces whole',
+      rowKey('skills/x/evals/y.json', 3, 'await expect') === 'skills/x/evals/y.json eval 3 await expect',
+    );
+  } finally {
+    for (const dir of trees) rmSync(dir, { recursive: true, force: true });
+  }
+
+  const failed = cases.filter((c) => !c.ok);
+  for (const c of failed) console.error(`  x ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+  if (failed.length) {
+    console.error(`x check-skill-eval-tokens self-test: ${failed.length} of ${cases.length} case(s) failed.`);
+    return EXIT_CODES.tokensUntaught;
+  }
+  console.log(
+    `OK check-skill-eval-tokens self-test: ${cases.length} cases pass (the whole-token rule on all three ` +
+      'measured false positives, both oracles on the sibling-taught row, must_not_contain never scored, ' +
+      'the shrink-only baseline in both directions, and every precondition that must not read as a pass).',
+  );
+  return EXIT_CODES.verified;
+}
+
+if (isEntrypoint(import.meta.url)) {
+  process.exit(process.argv.includes('--self-test') ? selfTest() : main());
+}
+
+export { main };

--- a/scripts/dependabot-merge-gate.mjs
+++ b/scripts/dependabot-merge-gate.mjs
@@ -123,6 +123,7 @@ import { isEntrypoint } from './invoked-as.mjs';
  *   docs-links.yml    Internal Docs Link Check
  *   skills-paths.yml  Skill Guide Path Check
  *   skill-examples.yml  Skill Example Check
+ *   skill-eval-tokens.yml  Skill Eval Token Check
  *   changeset-presence.yml   Changeset Declaration
  *   doc-component-types.yml  Doc Component Type Check
  *   doc-snippet-types.yml    Doc Snippet Type Check
@@ -164,6 +165,7 @@ export const REQUIRED_CONTEXTS = Object.freeze([
   'Internal Docs Link Check',
   'Skill Guide Path Check',
   'Skill Example Check',
+  'Skill Eval Token Check',
   'Changeset Declaration',
   'Doc Component Type Check',
   'Doc Snippet Type Check',


### PR DESCRIPTION
Fixes #7461

`skills/objectui/evals/*.json` grade an answering agent by `must_contain` tokens, and nothing checked
that a token is something the skill actually teaches. The class had been cleaned by hand twice — #7360
(PR #7408) and #7405 (PR #7422) — both rounds found by a human reading, which is the economics
`check-skills-paths.mjs` and `check-skill-examples.mjs` (#7427) were built to end for their surfaces.

This adds `scripts/check-skill-eval-tokens.mjs`. **No eval row and no guide prose is edited: the diff
touches zero files under `skills/`.**

## The oracle: bundle-wide, and what the losing option would have cost

The load-bearing decision. Both candidates measured at the branch point `0246d11` over all 125
`must_contain` tokens of all 33 evals in all 11 eval files:

| oracle | red rows on day one |
|---|---|
| **BUNDLE-WIDE** — every `.md` in the eval's own skill bundle | **0 of 125** |
| PER-GUIDE — `guides/BASENAME.md` matching the eval file only | 14 of 125 |

**Chosen: bundle-wide.** On the four axes, long-term soundness weighted heaviest:

1. **Real business need, measured.** The consumer of an eval is an answering agent, and what it loads
   is the whole bundle. `SKILL.md` is a router: its "Where to go" table names all eleven guides, and
   its rules block says the three files under `rules/` are "the anchor for every rule the guides only
   cue" and are to be read "before writing schemas". So the corpus an eval is answered from is the
   bundle, and an oracle narrower than the corpus asserts a fact the artefact does not support. The
   disagreement comment 5514262423 flagged is exactly this: `evals/page-builder.json` eval 1 requires
   `registerComponent`, taught once — in `guides/plugin-development.md`, the file `SKILL.md` routes
   "package a custom renderer or field widget as a plugin" to. That eval is honest; per-guide calls it
   a defect.
2. **Long-term soundness (weighted heaviest).** Per-guide is not even *total* over today's corpus, and
   that is structural rather than a missing mapping row. `evals/protocol.json` has no
   `guides/protocol.md` — its guide is `rules/protocol.md`. **Twelve of per-guide's fourteen red rows
   are that one file**, red only because the oracle cannot find a file. Adopting per-guide would mean
   inventing a second undeclared convention whose only job is to repair the oracle, then baselining
   twelve rows that name no defect. Bundle-wide needs no mapping table, no baseline, and stays correct
   when a twelfth guide or a second bundle lands.
3. **Making AI-written code hard to get wrong.** Both oracles catch the class both hand sweeps found —
   a token *nothing* teaches. What bundle-wide gives up is only "taught, but in a sibling file", which
   for a whole-bundle reader is not an error. What actually closed the false-negative half is the
   whole-token rule, and that is orthogonal to the oracle.
4. **Startup scope discipline.** Bundle-wide lands green with an empty baseline and no follow-up
   programme. Per-guide would land a fourteen-row debt list, twelve rows of which no per-row skills
   decision can ever retire.

⛔ The losing option is kept **re-derivable**, not deleted: `--measure` prints both red lists on every
run, and a test asserts the per-guide oracle is still non-total so the decision gets re-read rather
than silently holding if that ever changes.

### The 14 per-guide reds, site by site (measured, NOT adopted)

| eval row | why per-guide reds it | bundle-wide |
|---|---|---|
| `evals/page-builder.json` eval 1 `registerComponent` | taught in `guides/plugin-development.md`, not in `guides/page-builder.md` | taught (1) |
| `evals/page-builder.json` eval 3 `chart` | `guides/page-builder.md` says `charts` / `plugin-charts` only — substring 3, whole-token 0 | taught (3, in three sibling guides) |
| `evals/protocol.json` eval 1 `node`, `title`, `description`, `card` | no `guides/protocol.md` exists | taught (61 / 44 / 23 / 31) |
| `evals/protocol.json` eval 2 `properties`, `hoisted`, `element:`, `statistic` | no `guides/protocol.md` exists | taught (24 / 3 / 7 / 11) |
| `evals/protocol.json` eval 3 `columns`, `node`, `xl`, `className` | no `guides/protocol.md` exists | taught (31 / 61 / 7 / 63) |

12 of 14 are the missing-file artefact; 2 name a token taught elsewhere in the bundle.

## Whole tokens, and the one false positive this rule does NOT close

`IDENT_CHAR` is `[A-Za-z0-9_$]`. A boundary is asserted on an end **only where the token's own
character at that end is an IDENT_CHAR** — so an identifier token matches on word boundaries, while a
token that is not identifier-shaped at an end (a quoted key, an operator) takes no boundary there and
degrades to an exact substring, which is what such a token means. Matching is case-sensitive.

The three false positives #7405 measured are pinned in the self-test, and the third is this gate's
stated limit:

| token | context | substring | whole token |
|---|---|---|---|
| `view` | `// vite preview` | 1 | **0 — caught** |
| `FieldWidgetProps` | `FieldWidgetPropsSchema` | 1 | **0 — caught** |
| `create` | `create: vi.fn()` | 1 | **1 — NOT caught, and cannot be** |

⚠️ `create` really is a whole token there; the mismatch #7405 recorded was *semantic* (the eval meant
the form mode, the guide had a mocked dataSource method). **A green from this gate means "the bundle
says this word somewhere", never "the bundle teaches the thing the eval means."** That second question
stays a human reading, which is why the red list is described as a starting list for per-row judgement
rather than a work queue.

## `must_not_contain` gets the opposite treatment

Shape check only (a non-empty string); it is **never** scored against the guides. Those entries are
tokens an answer must *avoid*, so "no guide says it" is the healthy case — and #7370 deliberately
spelled one as a quoted JSON key fragment rather than the bare word, precisely so it does not fail an
answer that names the rule while following it. A check that validated that array the way it validates
`must_contain` would have the polarity backwards. Pinned in both the self-test and the spec.

## Baseline: declared, shrink-only, EMPTY at landing

`KNOWN_UNTAUGHT_EVAL_TOKENS` is empty, because the chosen oracle has no red rows. It exists anyway, in
the shape `check-doc-fence-languages.mjs` landed for `KNOWN_UNHIGHLIGHTED_TS_FENCES`, because the
alternative landing route for the first future red is editing an eval row or guide prose — which #7461
rules out in as many words. A red row not in the list fails; a row in the list whose red is gone fails
as **stale** and names itself. That second direction is what stops an empty list from decaying into a
permit.

⚠️ **Judgement call worth flagging:** the card sketched the row spelling as `evals/FILE.json eval N
token`; the implementation uses the bundle-qualified path
(`skills/objectui/evals/page-builder.json eval 1 registerComponent`). Same granularity — one file, one
eval, one token, so a per-row fix removes exactly one line — but unambiguous if a second bundle ever
lands. The token is everything after `eval N ` and is never re-split, so a token containing spaces is
safe.

## Its own script and its own workflow, not a phase of `check-skill-examples.mjs`

Decided on the same axes, and the deciding fact is measurable: **`check-skill-examples.mjs` exits 2
(PRECONDITION NOT MET) on an unbuilt tree before judging anything**, so an eval-token phase inside it
would simply never run wherever the workspace is not built. That gate's own header already lists this
oracle, in "Deliberately NOT answered here" item 4, as a different question over a different corpus.

So this takes `skills-paths.yml`'s shape instead — a checkout plus two `node` calls, **no install and
no build**, because the criterion is text in the checkout. `check-pre-install-import-graph.mjs` picks
the new steps up automatically and now enforces that this script's whole static import graph stays
free of `node_modules` (its run reports 23 pre-install steps in 18 jobs running 21 gates, up from 21
steps / 19 gates).

Wired the way this repository requires a new blocking check to be wired: `REQUIRED_CONTEXTS` row in
`scripts/dependabot-merge-gate.mjs`, a row in `merge-queue-reporting.test.ts`, the `ci-cd-pipeline.md`
inventory row plus a section named by heading, a `package.json` script, and a pin suite.

## Exit codes

`0` every token taught and something actually checked; `1` the gate ran and found errors (untaught
token, malformed assertion array, stale baseline row); `2` **PRECONDITION NOT MET** — no eval
population, no guide corpus, or an eval file that does not parse. Never 0 for "nothing checked".

## Per-file line counts

| file | before | after |
|---|---|---|
| `scripts/check-skill-eval-tokens.mjs` | new | 750 |
| `scripts/__tests__/check-skill-eval-tokens.test.ts` | new | 451 |
| `.github/workflows/skill-eval-tokens.yml` | new | 91 |
| `content/docs/guide/ci-cd-pipeline.md` | 2021 | 2079 |
| `scripts/__tests__/merge-queue-reporting.test.ts` | 728 | 737 |
| `scripts/dependabot-merge-gate.mjs` | 535 | 537 |
| `package.json` | 174 | 175 |

7 files, +1,362 −0. **Files under `skills/`: 0** — so the published-skill surface budget does not
apply to this diff at all, and no eval row or guide prose moved.

## Reverse verification — three mutations on the committed implementation

Each leg mutated under a `trap ... EXIT INT TERM` restoring absolute paths, **proved on disk by
counting both the removed and the injected text before any verdict was read**, then restored and the
restore proved by `git hash-object` equal to the HEAD blob plus an empty `git diff HEAD`. No build step
sits between mutation and measurement — the artefacts this gate reads *are* the mutated JSON and
markdown, so no `dist` can hold a stale copy and the dist-preflight rule does not apply and is not
claimed.

| leg | mutation, proved on disk | verdict |
|---|---|---|
| **A — an eval token changed to an untaught word** | `evals/page-builder.json`: `"SchemaRenderer"` 1 to 0, `"SchemaRendererNobodyTeachesThis"` 0 to 1 | **exit 1**, `skills/objectui/evals/page-builder.json eval 1 [untaught] "SchemaRendererNobodyTeachesThis" (it appears nowhere in the bundle, in any form)`. Restored, blob `9669f174`, `git diff HEAD` empty |
| **B — a guide's only occurrence of a taught token removed** | `guides/plugin-development.md`: whole-token `registerComponent` in the bundle 1 to 0, injected `registerComponentHandler` 0 to 1, **substring still present (1)** | **exit 1**, three rows: `page-builder.json eval 1`, `plugin-development.json` evals 1 and 2, each `(it appears 1 time(s) as a SUBSTRING only)`. This leg doubles as proof that the whole-token rule is what catches it. Restored, blob `398f8f56`, `git diff HEAD` empty |
| **C — a baseline row deleted while its red persists** | leg B's mutation held; 3 real-corpus baseline rows 0 to 3 (`exit 0`, "Red under the chosen oracle: 3 (0 beyond the baseline)"); then one row deleted, 1 to 0 | **exit 1** naming exactly the deleted row, "Red under the chosen oracle: 3 (1 beyond the baseline)". Both files restored, blobs `398f8f56` / `680ce368`, `git diff HEAD` empty |

Restored-tree re-measure: gate exit 0, self-test exit 0, `git diff HEAD` empty.

⚠️ Recorded rather than smoothed over: leg C's **first** attempt aborted on its own on-disk check
(`BASELINE EDIT DID NOT LAND`, exit 91) because the expected count was miscalibrated — the string it
counted already occurred once in a self-test fixture. The edit *had* landed; the assertion was wrong.
The trap restored cleanly and the leg was re-run against a specific anchor. The guard did its job, and
silently re-running until something landed would have been the defect this discipline exists to
prevent.

## Gates

Each verdict below is the gate's own printed line; every exit code was captured by redirect **before**
any pipe.

| command | exit | its own verdict line |
|---|---|---|
| `node scripts/check-skill-eval-tokens.mjs` | 0 | `Every must_contain token is taught by its own skill bundle.` — 1 bundle, 11 eval files, 33 evals, 125 tokens, 16 guide files; red 0, baseline 0 |
| `node scripts/check-skill-eval-tokens.mjs --self-test` | 0 | `OK check-skill-eval-tokens self-test: 29 cases pass` |
| `node scripts/check-skill-eval-tokens.mjs --measure` | 0 | bundle-wide 0 of 125; per-guide 14 of 125, `12 exist only because the basename-matching guide is MISSING and 2 name a token taught elsewhere in the bundle` |
| `pnpm exec vitest run --maxWorkers=2 scripts/__tests__` (under the shared verify lock) | 0 | `Test Files 100 passed (100); Tests 2866 passed (2866)` |
| `node scripts/check-skill-examples.mjs` (after the filtered 11-package build it derives) | 0 | `Every marked skill example holds up against the built types.` — Semantic phase 17 of 17 ts fences judged, 0 failed; JSON phase 39 parsed, 0 failed; all four harness controls green |
| `node scripts/check-pre-install-import-graph.mjs` | 0 | `OK — 23 pre-install step(s) in 18 job(s) run 21 scripts/ gate(s); 23 module(s) walked, every non-relative leaf a node builtin.` |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` — its own verdict decides; **no changeset added** |
| `node scripts/check-governed-queue-guard.mjs --test PATHS` | 0 | `NOT GOVERNED — 7 path(s) checked against 5 governed surface(s); none matched.` The diff touches zero `skills/` files, so GOVERNED is correctly *not* the verdict. **The PR still stays DRAFT** per the dispatch; the flip is the seat's step |
| `node scripts/check-control-bytes.mjs` | 0 | `OK (scanned 6144 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `OK (5/5 root(s) resolved ... 206 file(s) and 1292 fenced block(s) examined in total)` |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-doc-fence-languages.mjs` | 0 | `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s) (SHRINK-ONLY)` |
| `node scripts/check-skills-paths.mjs` | 0 | `OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined)` |
| `node scripts/check-lint-coverage.mjs` | 0 | `lint coverage: 46/46 packages linted, 0 with outstanding errors (0 total).` |
| `pnpm exec tsc -p tsconfig.scripts.json --noEmit` | 0 | clean — this is what compiles the new pin suite |
| `pnpm exec eslint --format json` over the 4 changed lintable files | 0 | `4 files linted, 0 errors, 0 warnings` |

**Gate-family derivation.** `scripts/pm/dispatch-gates.mjs` is absent from this tree and says so
itself: *"this script exists only in `objectstack-ai/objectstack`, so a sister repo's list is
hand-derived from its own package manifest and its own workflow files"* (it refused with
`REFUSING — asked for 'objectstack-ai/objectui', but this checkout is 'objectstack-ai/objectstack'`).
Hand-derived here from objectui's own `package.json` and `.github/workflows/`: a new workflow file plus
an edited `dependabot-merge-gate.mjs` pull in 50 suites that read `.github/workflows` and 10 that read
`ci-cd-pipeline.md`, so rather than guess which matter the **whole `scripts/__tests__` directory** was
run — 100 files, 2866 tests, the cheap superset. That also discharges the separate obligation an edited
gate script owes: `dependabot-merge-gate.test.ts` and `merge-queue-reporting.test.ts` are its own pin
suites and both ran.

## NOT MEASURED, and why

- **`pnpm lint` (repo-wide `eslint .`) was narrowed** to the 4 changed lintable files. Declared, with
  the three pieces of evidence: (1) the population is read from eslint's own config, not a guess —
  `pnpm lint` is `turbo run lint`, i.e. each workspace package's own `eslint .`, and `scripts/` has no
  `package.json` so it is in no package's lint run at all (the structural gap
  `scripts-type-check.test.ts` records for type-check); (2) the file count is read from
  `--format json`; (3) invariance — `eslint.config.js` configures **no** type-aware linting (no
  `project`, no `projectService` anywhere in it), so this diff cannot move the verdict for any
  untouched file. `check-lint-coverage.mjs` ran clean over all 46 packages independently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1)_