### PR TITLE
feat(scripts): assert no bare `any` in a marked skill example, and scan `.claude/skills` too

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -30,7 +30,7 @@ one has its own section below.
 | `control-bytes.yml` | Control Byte Scan | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** |
 | `docs-links.yml` | Internal Docs Link Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** |
 | `skills-paths.yml` | Skill Guide Path Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a path stated in a `skills/` guide does not exist |
-| `skill-examples.yml` | Skill Example Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a MARKED fenced example in a `skills/` guide no longer compiles against the packages' built types, no longer parses as JSON, or carries a marker that opts nothing in |
+| `skill-examples.yml` | Skill Example Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a MARKED fenced example in a `skills/` or `.claude/skills/` guide no longer compiles against the packages' built types, no longer parses as JSON, uses a bare `any`, or carries a marker that opts nothing in |
 | `skill-eval-tokens.yml` | Skill Eval Token Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when an eval assertion's `must_contain` token is not taught as a whole token anywhere in its own `skills/` bundle |
 | `doc-component-types.yml` | Doc Component Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a `content/docs/**.mdx` snippet teaches a `type` nothing registers |
 | `doc-snippet-types.yml` | Doc Snippet Type Check | Push / PR to `main`, `develop` — **no path filter**; merge-queue builds; manual | **Yes** — when a covered documentation snippet no longer compiles against the packages' built types |
@@ -600,13 +600,13 @@ how it was classified.
 
 **Triggers:** Push and PR to `main`/`develop`, merge-queue builds, plus manual dispatch — with **no
 path filter at all**, for the same reason as the section above: the scan surface is markdown under
-`skills/`, and both `ci.yml` and `lint.yml` list `'**/*.md'` under the `paths-ignore` of their `push`
-trigger. It appears in the checks list as **Skill Example Check**.
+`skills/` and `.claude/skills/`, and both `ci.yml` and `lint.yml` list `'**/*.md'` under the
+`paths-ignore` of their `push` trigger. It appears in the checks list as **Skill Example Check**.
 
 Runs `scripts/check-skill-examples.mjs`. Where the section above checks the *paths* a guide states in
 prose, this one checks the *worked examples* themselves: a marked `ts` / `tsx` / `typescript` fence
-must compile `--strict` against the packages' built `dist/*.d.ts`, and a marked `json` / `jsonc`
-fence must parse.
+must compile `--strict` against the packages' built `dist/*.d.ts` **and must not use a bare `any`**,
+and a marked `json` / `jsonc` fence must parse.
 
 **Why it was needed:** at the time it landed, `skills/objectui/` carried 112 TypeScript fences and 56
 JSON fences and **not one gate in the repository read inside any of them**
@@ -623,6 +623,27 @@ not wrong, and a gate that reds on correct code gets deleted by the first person
 marker is an inert HTML comment and leaves the fence info string bare, so the three gates that key on
 the info string still see the block. The convention is ported byte-for-byte from objectstack's
 `packages/spec/scripts/check-skill-examples.ts`.
+
+**No bare `any` in a marked block** ([#7463](https://github.com/objectstack-ai/objectui/issues/7463)):
+a marker is the author's claim that the block compiles, and every property access on an `any` is
+unchecked — so a marked block full of `any` is a green badge over a `tsc` run that proved nothing.
+The rule is ported from objectstack's runner with its scope intact: the annotation must **be** `any`
+in a position that erases checking (a parameter, a variable / property / return annotation, a type
+alias, an `as any` / `satisfies any` / angle-bracket assertion). An `any` **nested** inside a larger
+type — `Record<string, any>`, `any[]`, `Promise<any>` — is deliberately allowed; that boundary is
+what keeps a red meaning broken. The corpus had four such sites when the assertion landed, and each
+is declared verbatim in `KNOWN_BARE_ANY_EXAMPLES` in the script. That list is a **shrink-only**
+ratchet, not an allowlist: a row whose red goes away fails as **stale** and must be deleted. Fixing a
+row is a judgement about the guide (one of them faithfully restates a platform type that really is
+`any`), so the rows are declared debt rather than a mechanical unmark.
+
+**It scans `.claude/skills/` too** ([#7463](https://github.com/objectstack-ai/objectui/issues/7463)):
+`SCAN_ROOTS` holds `skills` and `.claude/skills`, the same widening `check-skills-paths.mjs` took in
+[#7358](https://github.com/objectstack-ai/objectui/issues/7358). When #7251 moved the two
+contributor-only guides out of `skills/`, that gate stopped looking at them and nothing turned red.
+Widening a root is **not** arming it: opt-in is the design, so this added 9 candidate fences (18 → 20
+guides, 112 → 121 `ts` fences) and **zero** marked ones. Adding a marker under `.claude/skills/` is
+the surface owner's step.
 
 **Adjacency is strict:** a marker that is not directly above a checkable fence — separated by a blank
 line, above a `bash` fence, or left behind when its example was deleted — is an **orphan** and fails
@@ -644,7 +665,8 @@ the failure shape this gate family exists to prevent
 ([#4846](https://github.com/objectstack-ai/objectui/issues/4846)).
 
 **If it fails:** it prints `file:line` for every failing fence with the compiler's own diagnostic, or
-the JSON parser's message, or the orphan marker's line. Fix the example — or, if it was never meant
+the JSON parser's message, or the orphan marker's line, or — for a bare `any` — the position and the
+verbatim baseline row to declare if the fix belongs to a later card. Fix the example — or, if it was never meant
 to stand alone, remove its marker rather than weakening the gate. Run it locally with
 `pnpm check:skill-examples`, `node scripts/check-skill-examples.mjs --list` to see every candidate
 fence and its verdict, and `--measure` to judge every candidate whether marked or not.

--- a/scripts/__tests__/check-skill-examples.test.ts
+++ b/scripts/__tests__/check-skill-examples.test.ts
@@ -10,11 +10,14 @@ import { fileURLToPath } from 'node:url';
 import {
   EXIT_CODES,
   JSON_FENCE_LANGUAGES,
+  KNOWN_BARE_ANY_EXAMPLES,
   MARKER,
   SCAN_ROOTS,
   TS_FENCE_LANGUAGES,
+  bareAnyRowKey,
   buildFilterArgs,
   fenceSpans,
+  findBareAny,
   listGuides,
   parseJsonFence,
   scanSkillFences,
@@ -232,11 +235,14 @@ describe('JSON fences — `json` is strict, `jsonc` is exactly two things looser
 });
 
 describe('the scan surface is a decision, stated here rather than read off the walker', () => {
-  it('walks `skills` and, today, nothing else', () => {
-    // `.claude/skills/**` is deliberately outside this gate for now, the way
-    // `check-skills-paths.mjs`'s prefix allow-list was: widening it is a
-    // separate, visible edit with its own measurement, not a silent drift.
-    expect(SCAN_ROOTS).toEqual(['skills']);
+  it('walks the published bundle AND `.claude/skills`, and nothing else', () => {
+    // objectui#7463 item 3 widened this to `.claude/skills`, the same widening
+    // `check-skills-paths.mjs` took in objectui#7358 and for the same reason:
+    // when objectui#7251 moved the contributor-only guides out of `skills/`,
+    // a gate rooted only at `skills` silently stopped looking at them. It
+    // stays a stated decision with a measurement, never a silent drift — the
+    // widening added 9 candidate fences and ZERO marked ones.
+    expect(SCAN_ROOTS).toEqual(['skills', '.claude/skills']);
   });
 
   it('collects every `.md` under the roots, recursively and in a stable order', () => {
@@ -271,7 +277,11 @@ describe('the scan surface is a decision, stated here rather than read off the w
     // nothing at all.
     const guides = listGuides(repoRoot) as string[];
     expect(guides.length).toBeGreaterThan(5);
-    expect(guides.every((g) => g.startsWith('skills/'))).toBe(true);
+    expect(guides.every((g) => SCAN_ROOTS.some((r) => g.startsWith(`${r}/`)))).toBe(true);
+    // Both roots must actually be non-empty in this checkout, or the widening
+    // would be a root list nothing reads — the vacuity this leg exists to deny.
+    expect(guides.some((g) => g.startsWith('skills/'))).toBe(true);
+    expect(guides.some((g) => g.startsWith('.claude/skills/'))).toBe(true);
   });
 });
 
@@ -472,5 +482,76 @@ describe('the harness is imported, not re-rolled', () => {
     const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-skill-examples.mjs'), 'utf8');
     expect(source).not.toContain('ts.createProgram');
     expect(source).not.toContain('ts.createCompilerHost');
+  });
+});
+
+/**
+ * objectui#7463 item 1 — the bare-`any` assertion, ported from objectstack's
+ * `packages/spec/scripts/check-skill-examples.ts`.
+ *
+ * The NEGATIVE half carries the weight. A bare `any` erases checking wholesale,
+ * but an `any` nested in a larger type is a much broader question with a much
+ * larger baseline, and a guard that flagged it would red on prose that is not
+ * wrong — which is how gates get deleted. That boundary is the whole design, so
+ * it is pinned rather than left to the implementation.
+ */
+describe('the bare-`any` assertion', () => {
+  it.each([
+    ['a parameter', 'export function f(ctx: any) { return ctx; }', 'parameter `ctx`'],
+    ['a variable', 'export const x: any = 1;', 'variable `x`'],
+    ['an interface property', 'export interface I { p: any }', 'property `p`'],
+    ['a class property', 'export class C { p: any = 1; }', 'property `p`'],
+    ['a type alias', 'export type A = any;', 'type alias `A`'],
+    ['a return type', 'export function g(): any { return 1; }', 'return type'],
+    ['an arrow return type', 'export const h = (): any => 1;', 'return type'],
+    ['a method signature return', 'export interface J { m(): any }', 'return type'],
+    ['an `as any` cast', 'export const y = ({} as any);', '`as any` assertion'],
+    ['a `satisfies any`', 'export const z = ({} satisfies any);', '`satisfies any` assertion'],
+  ])('flags %s', (_label, code, want) => {
+    const hits = findBareAny(code) as { where: string }[];
+    expect(hits.map((h) => h.where)).toEqual([want]);
+  });
+
+  it.each([
+    ['Record<string, any>', 'export const a: Record<string, any> = {};'],
+    ['any[]', 'export const b: any[] = [];'],
+    ['Array<any>', 'export const c: Array<any> = [];'],
+    ['Promise<any>', 'export async function d(): Promise<any> { return 1; }'],
+    ['a union arm', 'export const e: string | any[] = [];'],
+    ['the word "any" in a string or a comment', 'export const f = "any"; // any of them'],
+  ])('does NOT flag a nested `any` in %s', (_label, code) => {
+    expect(findBareAny(code)).toEqual([]);
+  });
+
+  it('parses as TSX, so a JSX example is not mis-read as a type assertion', () => {
+    // `compileSnippets` parses every block as TSX regardless of the fence
+    // label. A guard walking a different tree would be reporting about a
+    // program `tsc` never judged.
+    expect(findBareAny('export const El = () => <div className="x">hi</div>;')).toEqual([]);
+  });
+
+  it('yields nothing rather than throwing on a block too broken to parse', () => {
+    // The `tsc` syntax leg owns that verdict; this guard must not double-report
+    // it, and must not crash the run either.
+    expect(() => findBareAny('export const three: = ;')).not.toThrow();
+  });
+
+  it('builds a baseline row key naming the guide, the fence line and the position', () => {
+    const block = { doc: 'skills/objectui/guides/x.md', fenceLine: 42 };
+    const finding = (findBareAny('export function f(ctx: any) {}') as { where: string }[])[0];
+    expect(bareAnyRowKey(block, finding)).toBe('skills/objectui/guides/x.md:42 parameter `ctx`');
+  });
+
+  it('declares its baseline as a shrink-only Set of verbatim rows', () => {
+    // Every row must be shaped like a key this gate can actually produce, or it
+    // would sit in the list forever covering nothing — a parked exemption
+    // wearing a ratchet's clothes.
+    expect(KNOWN_BARE_ANY_EXAMPLES).toBeInstanceOf(Set);
+    for (const row of KNOWN_BARE_ANY_EXAMPLES as Set<string>) {
+      expect(row, `baseline row is not \`GUIDE:LINE POSITION\`: ${row}`).toMatch(
+        /^[\w./-]+\.md:\d+ .+$/,
+      );
+      expect(SCAN_ROOTS.some((r: string) => row.startsWith(`${r}/`))).toBe(true);
+    }
   });
 });

--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -182,6 +182,54 @@
  * NOTHING is marked exits 2, because a gate that checks nothing must not report
  * success.
  *
+ * ## The third assertion: no bare `any` in a marked block (objectui#7463)
+ *
+ * A marker is the author's claim "this block compiles", and the orphan-marker
+ * and empty-population guards above exist because a gate that checks nothing
+ * must not report success. A bare `any` inside a marked block is that same
+ * failure wearing a green badge: every property access on an `any` is
+ * unchecked, so `tsc` proves exactly nothing about the lines a reader copies.
+ * objectstack's `packages/spec/scripts/check-skill-examples.ts` carries this as
+ * its third assertion and records the measured specimen — two marked hook
+ * examples annotated `ctx: any` that read a key the hook context does not have,
+ * green through the whole of that gate's life.
+ *
+ * SCOPE, ported from that file rather than re-derived: the annotation must BE
+ * `any`, in a position where it erases checking wholesale — a parameter, a
+ * variable/property/return annotation, a type alias, or an `as any` /
+ * `satisfies any` / angle-bracket assertion. `any` NESTED inside a larger type
+ * (`Record<string, any>`, `any[]`, `Promise<any>`) is deliberately NOT flagged.
+ * That boundary is the zero-false-positive line, and holding it is what keeps a
+ * red meaning broken. Casts and locals are in scope and not for symmetry: a
+ * parameter-only rule is defeated by exactly the edit an author reaches for
+ * when it goes red — move the `any` one line down (`const c: any = ctx`) or
+ * into the access (`(ctx as any).x`) — leaving the gate green over an unchanged
+ * defect.
+ *
+ * ⚠️ ONE DELIBERATE DIVERGENCE from objectstack, and it is about which tree is
+ * walked. objectstack picks `ScriptKind` off the fence label; the harness THIS
+ * gate compiles through parses EVERY block as TSX regardless of label (see
+ * `compileSnippets`, and its own header for why). So this walk uses TSX too. A
+ * guard that walked a different tree from the one `tsc` judged would be exactly
+ * the dormant checker this file's own docblocks warn about. The visible
+ * consequence: an angle-bracket `<any>value` assertion is JSX under TSX and is
+ * therefore a PARSE failure — already red through the syntax leg, one exit code
+ * earlier, never reaching this walk. Its arm is kept in the position table
+ * anyway, so the rule stays whole if the harness's ScriptKind ever changes.
+ *
+ * Parsing, never a regex: the corpus is prose, and `any` occurs in string
+ * literal unions, in JSDoc and in ordinary English. `createSourceFile` never
+ * throws on malformed input, so a block too broken to parse yields no findings
+ * here and is caught by the `tsc` pass — the right division of labour.
+ *
+ * ⛔ The baseline (`KNOWN_BARE_ANY_EXAMPLES`) is SHRINK-ONLY and is NOT an
+ * allowlist: a row whose red is gone fails as STALE. It exists because the
+ * assertion landed over a corpus that already had four sites, and unmarking or
+ * re-pointing those fences mechanically would have been the gate weakening the
+ * guides to suit itself. Each row is a declared debt with a named site, so the
+ * per-row skills judgement it needs is a visible piece of work rather than a
+ * silent exemption. See the list's own docblock for what each row is.
+ *
  * ## Deliberately NOT answered here
  *
  *   1. **Whether a marked JSON fence is VALID METADATA.** It is parsed, not
@@ -190,18 +238,20 @@
  *      fences are complete documents rather than prose fragments is the same
  *      boundary `check-doc-snippet-types.mjs` left unruled for the same reason,
  *      and guessing it is what produces a gate people learn to ignore.
- *   2. **Bare `any` inside a marked block.** objectstack's runner treats it as a
- *      third assertion — a marker is the author's claim "this compiles", and
- *      every property access on an `any` proves nothing. Worth porting; it is a
- *      new assertion rather than the convention, so it is recorded as a
- *      follow-up.
- *   3. **`.claude/skills/**`.** `check-skills-paths.mjs` scans it too
- *      (objectui#7358 widened it there). This gate's root is the PUBLISHED
- *      bundle, which is the governed surface objectui#7359 was filed about;
- *      widening is a separate, visible edit with its own measurement — the
- *      discipline that file's own "prefix allow-list is a decision, not an
- *      accident" section records.
- *   4. **Whether an eval's `must_contain` token is taught by the guides.** A
+ *   2. **Bounding ROOT-devDependency resolution.** The `Unmapped specifiers`
+ *      line below names the leak; closing it is objectui#7463 item 2 and is
+ *      still open, because the harness that would carry the bound is SHARED and
+ *      the fix is not local to this gate. Measured at objectui#7463's head, so
+ *      the next reader argues from a number rather than re-deriving it: the
+ *      marked population's unmapped set is exactly `@playwright/test` and
+ *      `vitest`, both declared by the repository ROOT and both resolving out of
+ *      `/node_modules`; and a bound placed in `compileSnippets` would newly red
+ *      exactly ONE of `check-doc-snippet-types.mjs`'s own 432 compiled snippets
+ *      (`content/docs/guide/objectos-integration.mdx:638`, importing
+ *      `@playwright/test`). One new red on a surface this gate does not own is
+ *      a decision about the docs corpus, not a refactor, so it is escalated
+ *      rather than taken.
+ *   3. **Whether an eval's `must_contain` token is taught by the guides.** A
  *      different oracle over a different corpus, discussed at length on
  *      objectui#7359 and explicitly not this check.
  */
@@ -223,14 +273,42 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 // ── Configuration ────────────────────────────────────────────────────────────
 
 /**
- * The prose roots this gate walks. One entry today: the PUBLISHED skill bundle.
+ * The prose roots this gate walks: the PUBLISHED skill bundle, and the
+ * CONTRIBUTOR-ONLY bundle under `.claude/skills`.
  *
  * Stated here as a decision rather than left to be read off the walker, which is
  * objectui#5174's finding restated — a reader had to open the collector to learn
- * that "covered by default" meant "covered if the filename ends in `.mdx`". See
- * "Deliberately NOT answered here" item 3 for why `.claude/skills` is not in it.
+ * that "covered by default" meant "covered if the filename ends in `.mdx`".
+ *
+ * `.claude/skills` was added by objectui#7463 item 3, the same widening
+ * `check-skills-paths.mjs` took in objectui#7358 and for the same reason: when
+ * objectui#7251 moved the two contributor-only guides out of `skills/`, that
+ * gate simply stopped looking at them and nothing turned red. A gate whose scan
+ * root is narrower than the surface it claims silently un-covers whatever moves
+ * out of it.
+ *
+ * ⚠️ WIDENING A ROOT IS NOT ARMING IT. Opt-in is the whole design here, so this
+ * edit adds candidates, not coverage: nothing under `.claude/skills/**` carries
+ * the marker, and adding one is the surface owner's step, not this widening's.
+ * Measured at objectui#7463's head, which is the number that makes "zero new
+ * red on day one" checkable rather than asserted:
+ *
+ *   |                          | before | after |
+ *   |--------------------------|--------|-------|
+ *   | guides scanned           | 18     | 20    |
+ *   | ts/tsx/typescript fences | 112    | 121   |
+ *   | json/jsonc fences        | 56     | 56    |
+ *   | MARKED fences            | 56     | 56    |
+ *
+ * All 9 new candidates are `typescript` fences in
+ * `.claude/skills/objectui-contributor/` (5 in `guides/console-development.md`,
+ * 4 in `rules/no-touch-zones.md`); the two `SKILL.md` files carry none. The
+ * MARKED row is the one that decides whether this widening is safe, and it does
+ * not move.
+ *
+ * Re-derive it with `--measure`; `--list` names every new candidate.
  */
-export const SCAN_ROOTS = ['skills'];
+export const SCAN_ROOTS = ['skills', '.claude/skills'];
 
 /** Fence languages compiled as TypeScript. */
 export const TS_FENCE_LANGUAGES = new Set(['ts', 'tsx', 'typescript']);
@@ -263,6 +341,125 @@ export const EXIT_CODES = {
   /** The gate COULD NOT RUN. Nothing it printed is a verdict about a guide. */
   couldNotRun: 2,
 };
+
+// ── The bare-`any` debt list ─────────────────────────────────────────────────
+
+/**
+ * ⛔ SHRINK-ONLY. Rows spelled exactly as `bareAnyRowKey()` builds them:
+ *
+ *     GUIDE:FENCELINE POSITION
+ *
+ * where POSITION is `describeAnyPosition()`'s own wording, so a row names one
+ * `any` at one site and a per-row fix removes exactly one line. Two `any`s of
+ * different kinds in one fence are two rows; the fence line disambiguates two
+ * of the SAME kind in different fences.
+ *
+ * ⚠️ Not an allowlist. A row whose red is GONE fails as STALE, so the list can
+ * only shrink — the same direction, and the same reasoning, as
+ * `KNOWN_UNTAUGHT_EVAL_TOKENS` in `check-skill-eval-tokens.mjs`. It is keyed on
+ * the fence LINE, which means moving a guide's prose above the fence forces a
+ * re-declaration. That cost is deliberate: a row that floated free of its line
+ * would keep covering a site nobody has looked at since.
+ *
+ * The four rows below are the whole corpus at objectui#7463's branch point,
+ * measured under `--measure` before the assertion was armed. Each needs a
+ * per-row SKILLS judgement that this gate-hardening change is not the place to
+ * make, and none of them is a mechanical unmark:
+ *
+ *   - `plugin-development.md:92` `defaultValue` — the guide is FAITHFUL prose,
+ *     not rot. `ComponentInput.defaultValue` really is `any` in
+ *     `packages/types/src/base.ts`, so the honest fix is to the platform type,
+ *     not to the guide restating it. Fixing the guide alone would make it lie.
+ *   - `testing.md:60` `as any` — `validateSchema({} as any)`, feeding the
+ *     validator something invalid ON PURPOSE. Which idiom the testing guide
+ *     should teach for that (`as unknown as T`, a `@ts-expect-error`) is a
+ *     question about the guide, not about this gate.
+ *   - `testing.md:208` `mockClient` and its `as any` — the test-double idiom,
+ *     including reaching a private field through `(adapter as any).client`.
+ *     Same question, same owner.
+ *
+ * @type {ReadonlySet<string>}
+ */
+export const KNOWN_BARE_ANY_EXAMPLES = new Set([
+  'skills/objectui/guides/plugin-development.md:92 property `defaultValue`',
+  'skills/objectui/guides/testing.md:60 `as any` assertion',
+  'skills/objectui/guides/testing.md:208 variable `mockClient`',
+  'skills/objectui/guides/testing.md:208 `as any` assertion',
+]);
+
+/** The baseline key for one bare-`any` finding at one site. */
+export function bareAnyRowKey(block, finding) {
+  return `${block.doc}:${block.fenceLine} ${finding.where}`;
+}
+
+// ── Bare-`any` guard (objectui#7463, ported from objectstack #5943) ──────────
+
+/**
+ * Every position in which a bare `any` erases checking wholesale, keyed by the
+ * PARENT node kind. The test is `parent.type === node` (or the assertion's own
+ * type slot), so an `any` nested in a larger type — `Record<string, any>`,
+ * `any[]`, `Promise<any>` — has a TypeReference/ArrayType parent and is not a
+ * finding. That boundary is this guard's zero-false-positive line; widening it
+ * is a different question with a different, much larger baseline.
+ *
+ * Returns the human-readable position (which is also half the baseline key), or
+ * `null` when this `any` is not in a checking-erasing position.
+ */
+export function describeAnyPosition(node) {
+  const parent = node.parent;
+  if (!parent) return null;
+
+  const named = (name) => (name && ts.isIdentifier(name) ? ` \`${name.text}\`` : '');
+
+  if (ts.isParameter(parent) && parent.type === node) return `parameter${named(parent.name)}`;
+  if (ts.isVariableDeclaration(parent) && parent.type === node) return `variable${named(parent.name)}`;
+  if ((ts.isPropertyDeclaration(parent) || ts.isPropertySignature(parent)) && parent.type === node)
+    return `property${named(parent.name)}`;
+  if (ts.isTypeAliasDeclaration(parent) && parent.type === node)
+    return `type alias \`${parent.name.text}\``;
+  if (ts.isAsExpression(parent) && parent.type === node) return '`as any` assertion';
+  if (ts.isSatisfiesExpression(parent) && parent.type === node) return '`satisfies any` assertion';
+  // Unreachable under TSX (the harness's ScriptKind) — an angle-bracket
+  // assertion is JSX there and fails the syntax leg first. Kept so the rule
+  // stays whole if that ever changes; see the header's divergence note.
+  if (ts.isTypeAssertionExpression(parent) && parent.type === node)
+    return 'angle-bracket `any` assertion';
+  // Return annotations: functions, methods, arrows, getters, signatures.
+  if (ts.isFunctionLike(parent) && parent.type === node) return 'return type';
+  return null;
+}
+
+/**
+ * Every bare `any` annotation in one block body, in source order.
+ *
+ * ⚠️ Parsed as TSX, matching `compileSnippets`, which parses EVERY block as TSX
+ * regardless of the fence label. A guard that walked a different tree from the
+ * one `tsc` judged would be reporting about a program that was never checked.
+ * `createSourceFile` never throws: a block too broken to parse yields no
+ * findings here and is caught by the syntax leg instead.
+ */
+export function findBareAny(code) {
+  const sf = ts.createSourceFile(
+    'block.tsx',
+    code,
+    ts.ScriptTarget.ES2020,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX,
+  );
+  const findings = [];
+  const visit = (node) => {
+    if (node.kind === ts.SyntaxKind.AnyKeyword) {
+      const where = describeAnyPosition(node);
+      if (where) {
+        const { line, character } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+        findings.push({ line: line + 1, col: character + 1, where });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sf, visit);
+  return findings;
+}
 
 // ── Fence scanning ───────────────────────────────────────────────────────────
 
@@ -499,8 +696,14 @@ function importedSpecifiers(body) {
  * measurement mode behind step 2 of objectui#7359, and it is the only difference
  * between the two modes — one predicate, so a fence cannot be measured under one
  * set of rules and gated under another.
+ *
+ * `baseline` is the bare-`any` debt list, taken as a parameter only so the
+ * self-test can drive it in both directions over fixtures. The STALE half is
+ * always computed against the MARKED population, never against the
+ * measure-selected one: the list describes what is gated, so its rows must not
+ * appear to be covered by a fence that is merely being measured.
  */
-export function analyze({ root = repoRoot, measure = false } = {}) {
+export function analyze({ root = repoRoot, measure = false, baseline = KNOWN_BARE_ANY_EXAMPLES } = {}) {
   const guides = listGuides(root);
   const scans = new Map();
   for (const guide of guides) {
@@ -582,8 +785,31 @@ export function analyze({ root = repoRoot, measure = false } = {}) {
     }
   }
 
+  // ── the bare-`any` assertion, over the SELECTED ts blocks ─────────────────
+  // Purely syntactic, so it runs whether or not the tree is built and whether or
+  // not a block later fails to parse — an `any` that a reader would copy is a
+  // finding about that guide either way.
+  const bareAny = [];
+  for (const block of tsBlocks) {
+    for (const finding of findBareAny(block.body)) {
+      const key = bareAnyRowKey(block, finding);
+      bareAny.push({ block, finding, key, baselined: baseline.has(key) });
+    }
+  }
+
+  // STALE rows are read off the MARKED population regardless of mode (see the
+  // docblock): a baseline row is a claim about a gated fence.
+  const markedRedKeys = new Set();
+  for (const block of candidates) {
+    if (block.kind !== 'ts' || !block.marked) continue;
+    for (const finding of findBareAny(block.body)) markedRedKeys.add(bareAnyRowKey(block, finding));
+  }
+  const bareAnyStale = [...baseline].filter((key) => !markedRedKeys.has(key)).sort();
+
   return {
     unmappedSpecifiers,
+    bareAny,
+    bareAnyStale,
     guides,
     scans,
     candidates,
@@ -795,10 +1021,15 @@ function main() {
   if (argv.includes('--list') || measure) {
     for (const block of state.candidates) {
       let verdict;
+      const anyHits = state.bareAny.filter((h) => h.block === block);
+      const anyNote = anyHits.length
+        ? ` + ${anyHits.length} bare \`any\`${anyHits.every((h) => h.baselined) ? ' (all baselined)' : ''}`
+        : '';
       if (!block.selected) verdict = 'unmarked — ignored';
       else if (block.kind === 'json')
         verdict = jsonFailures.some((f) => f.block === block) ? 'FAIL' : 'pass';
-      else verdict = failedTs.has(block) ? 'FAIL' : 'pass';
+      else if (failedTs.has(block)) verdict = `FAIL${anyNote}`;
+      else verdict = anyHits.some((h) => !h.baselined) ? `FAIL${anyNote}` : `pass${anyNote}`;
       console.log(
         `  ${block.doc}:${block.fenceLine}  [${block.language}]  ${block.marked ? 'marked' : '      '}  ${verdict}`,
       );
@@ -815,6 +1046,21 @@ function main() {
   }
   for (const { block, message } of jsonFailures) {
     console.error(`  [json]      ${block.doc}:${block.fenceLine}  ${message}`);
+  }
+  for (const hit of state.bareAny) {
+    if (hit.baselined) continue;
+    console.error(
+      `  [bare-any]  ${hit.block.doc}:${hit.block.fenceLine + hit.finding.line}:${hit.finding.col}  ` +
+        `${hit.finding.where} is annotated \`any\`, which erases checking wholesale — this fence's ` +
+        'marker claims it compiles, and every property access on that `any` is unchecked. Give it the ' +
+        'honest type, or declare the row VERBATIM in KNOWN_BARE_ANY_EXAMPLES (⛔ SHRINK-ONLY):\n' +
+        `                ${hit.key}`,
+    );
+  }
+  for (const key of state.bareAnyStale) {
+    console.error(
+      `  ${key}  [stale-baseline]  this row is no longer red — delete its line, KNOWN_BARE_ANY_EXAMPLES only shrinks`,
+    );
   }
 
   // ── the summary always states COVERAGE, never just a verdict ──────────────
@@ -841,6 +1087,12 @@ function main() {
   console.log(
     `JSON phase:     ${state.jsonBlocks.length} fence(s) parsed, ${jsonFailures.length} failed.`,
   );
+  const bareAnyNew = state.bareAny.filter((h) => !h.baselined);
+  console.log(
+    `Bare \`any\`:     ${state.bareAny.length} finding(s) across ${new Set(state.bareAny.map((h) => h.block)).size} selected fence(s); ` +
+      `${state.bareAny.length - bareAnyNew.length} declared in KNOWN_BARE_ANY_EXAMPLES (⛔ SHRINK-ONLY, ${KNOWN_BARE_ANY_EXAMPLES.size} row(s)), ` +
+      `${bareAnyNew.length} NOT declared, ${state.bareAnyStale.length} declared row(s) no longer red.`,
+  );
   if (parseFailedBlocks > 0) {
     console.log(
       `NOTE: this run's semantic result covers ${run.semanticallyJudged} fence(s) only. A syntax failure is not a semantic pass.`,
@@ -853,6 +1105,16 @@ function main() {
     console.log(
       `\nStarting population — ts: ${tsPass}/${tsCandidates.length} pass; json: ${jsonPass}/${jsonCandidates.length} pass.`,
     );
+    const markedAny = state.bareAny.filter((h) => h.block.marked);
+    console.log(
+      `Bare \`any\` would-be population — ${state.bareAny.length} finding(s) over every candidate, ` +
+        `of which ${markedAny.length} sit in a MARKED fence (the population this assertion actually gates).`,
+    );
+    for (const hit of state.bareAny) {
+      console.log(
+        `  ${hit.block.marked ? 'marked  ' : 'unmarked'}  ${hit.block.doc}:${hit.block.fenceLine + hit.finding.line}  ${hit.finding.where}${hit.baselined ? '  [declared]' : ''}`,
+      );
+    }
   }
 
   if (controlFailures.length > 0) {
@@ -875,7 +1137,9 @@ function main() {
     state.findings.length > 0 ||
     parseFailedBlocks > 0 ||
     run.semanticFailures.length > 0 ||
-    jsonFailures.length > 0;
+    jsonFailures.length > 0 ||
+    bareAnyNew.length > 0 ||
+    state.bareAnyStale.length > 0;
 
   if (failed) {
     console.error(
@@ -912,6 +1176,13 @@ function main() {
  * Plus the two the design turns on and nobody would think to write down: a
  * marker shown as EXAMPLE TEXT inside another fence claims nothing and is not an
  * orphan either, and a marker above a ```bash fence IS an orphan.
+ *
+ * The bare-`any` guard (objectui#7463) is pinned on BOTH edges here, and the
+ * negative edge is the load-bearing one: ten in-scope positions must be found
+ * and six nested `any`s must NOT be, because that boundary is the whole reason
+ * a red from this assertion means something. Its shrink-only baseline is pinned
+ * in both directions too — a declared row suppresses, and a row whose red is
+ * gone is STALE.
  */
 export function selfTest() {
   const cases = [];
@@ -989,6 +1260,77 @@ export function selfTest() {
   );
   t('a truncated object fails', parseJsonFence('{"a": 1', 'json') !== null);
 
+  // ── the bare-`any` assertion, BOTH directions ────────────────────────────
+  // Every in-scope position must be found, and every nested `any` must not be.
+  // The negative half is the half that matters: it is the zero-false-positive
+  // line, and a widening of it would red on prose that is not wrong.
+  const anyPositive = [
+    ['parameter', 'export function f(ctx: any) { return ctx; }', 'parameter `ctx`'],
+    ['variable', 'export const x: any = 1;', 'variable `x`'],
+    ['property (interface)', 'export interface I { p: any }', 'property `p`'],
+    ['property (class)', 'export class C { p: any = 1; }', 'property `p`'],
+    ['type alias', 'export type A = any;', 'type alias `A`'],
+    ['return type', 'export function g(): any { return 1; }', 'return type'],
+    ['arrow return type', 'export const h = (): any => 1;', 'return type'],
+    ['method signature return', 'export interface J { m(): any }', 'return type'],
+    ['`as any`', 'export const y = ({} as any);', '`as any` assertion'],
+    ['`satisfies any`', 'export const z = ({} satisfies any);', '`satisfies any` assertion'],
+  ];
+  for (const [label, code, want] of anyPositive) {
+    const hits = findBareAny(code);
+    t(
+      `bare \`any\` in a ${label} position is FOUND`,
+      hits.length === 1 && hits[0].where === want,
+      `got ${JSON.stringify(hits.map((f) => f.where))}, want ["${want}"]`,
+    );
+  }
+
+  const anyNegative = [
+    ['Record<string, any>', 'export const a: Record<string, any> = {};'],
+    ['any[]', 'export const b: any[] = [];'],
+    ['Array<any>', 'export const c: Array<any> = [];'],
+    ['Promise<any>', 'export async function d(): Promise<any> { return 1; }'],
+    ['a union arm', 'export const e: string | any[] = [];'],
+    ['the WORD any in prose', 'export const f2 = "any"; // any old comment about any of it'],
+  ];
+  for (const [label, code] of anyNegative) {
+    const hits = findBareAny(code);
+    t(`a nested \`any\` (${label}) is NOT a finding`, hits.length === 0, JSON.stringify(hits));
+  }
+
+  t(
+    'JSX parses rather than mis-reading as a type assertion (the harness ScriptKind)',
+    findBareAny('export const El = () => <div className="x">hi</div>;').length === 0,
+  );
+
+  // ── the baseline, both directions, over fixture blocks ───────────────────
+  const anyBlock = { doc: 'fixture/any.md', fenceLine: 10, kind: 'ts', marked: true, body: 'export function f(ctx: any) { return ctx; }\n' };
+  const anyKey = bareAnyRowKey(anyBlock, findBareAny(anyBlock.body)[0]);
+  t(
+    'the baseline row key names the guide, the fence line and the position',
+    anyKey === 'fixture/any.md:10 parameter `ctx`',
+    anyKey,
+  );
+  t('an UNDECLARED bare `any` is red', !new Set([]).has(anyKey));
+  t('a DECLARED bare `any` is suppressed', new Set([anyKey]).has(anyKey));
+
+  const realState = analyze({ root: repoRoot, measure: false });
+  t(
+    'the real run has NO undeclared bare `any` — every row is in KNOWN_BARE_ANY_EXAMPLES',
+    realState.bareAny.every((h) => h.baselined),
+    JSON.stringify(realState.bareAny.filter((h) => !h.baselined).map((h) => h.key)),
+  );
+  t(
+    'and NO declared row has gone stale — the list only shrinks',
+    realState.bareAnyStale.length === 0,
+    JSON.stringify(realState.bareAnyStale),
+  );
+  t(
+    'a baseline row whose red is GONE is reported as STALE',
+    analyze({ root: repoRoot, measure: false, baseline: new Set([...KNOWN_BARE_ANY_EXAMPLES, 'skills/objectui/guides/testing.md:1 parameter `ghost`']) }).bareAnyStale
+      .length === 1,
+  );
+
   // ── the type-check half, through the REAL harness ─────────────────────────
   // Two fixture blocks that need no package types at all, so this leg measures
   // the harness rather than the workspace. The CONTROLS still need the built
@@ -1043,7 +1385,7 @@ export function selfTest() {
     return EXIT_CODES.examplesFailed;
   }
   console.log(
-    `✓ check-skill-examples self-test: ${cases.length} cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, and the compiler legs through the real harness).`,
+    `✓ check-skill-examples self-test: ${cases.length} cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, the bare-\`any\` guard in both directions with its shrink-only baseline, and the compiler legs through the real harness).`,
   );
   return EXIT_CODES.verified;
 }


### PR DESCRIPTION
Part of #7463

Two of the card's three hardening items on `check-skill-examples.mjs` are implemented. Item 2 is **measured and escalated**, not taken: the bound's two candidate homes lead to materially different edits, and the brief for this flight says stop there rather than guess.

Every population below was measured **before** the assertion was armed, and re-measured at head `2df07b7`.

---

## Item 1 — the bare-`any` assertion (implemented)

Ported from objectstack's `packages/spec/scripts/check-skill-examples.ts` with its scope intact: the annotation must **be** `any` in a position that erases checking — a parameter, a variable / property / return annotation, a type alias, or an `as any` / `satisfies any` / angle-bracket assertion. An `any` **nested** inside a larger type is deliberately allowed: `Record` of string to `any`, `any[]`, `Promise` of `any`. That boundary is the zero-false-positive line, and holding it is what keeps a red meaning broken.

### One deliberate divergence from objectstack, and why

objectstack picks `ScriptKind` off the fence label. The harness this gate compiles through — `compileSnippets` in `check-doc-snippet-types.mjs` — parses **every** block as TSX regardless of label, for reasons its own header records. So this walk uses TSX too. A guard that walked a different tree from the one `tsc` judged would be exactly the dormant checker this file's docblocks warn about.

Visible consequence: an angle-bracket `any` assertion is JSX under TSX, so it is a **parse** failure — already red through the syntax leg, one exit code earlier, never reaching this walk. Its arm is kept in the position table so the rule stays whole if the harness's ScriptKind ever changes, and the header says so rather than leaving a reader to discover a dead branch.

### Measured population, before arming

`--measure` over every candidate fence, marked or not:

| population | findings |
|---|---|
| every candidate fence (121 ts) | 10 |
| **MARKED fences only — what this assertion gates** | **4, in 3 fences** |
| new red on day one | **0** |
| `.claude/skills` fences (item 3's new candidates) | 0 |

### The 4 would-be-red rows, each declared verbatim

None is unmarked or re-pointed. All four are carried in `KNOWN_BARE_ANY_EXAMPLES`, a **shrink-only** ratchet in the shape `KNOWN_UNTAUGHT_EVAL_TOKENS` uses in `check-skill-eval-tokens.mjs`: a row whose red goes away fails as **stale**, so the list can only shrink.

| row | position | why it is declared debt, not a mechanical unmark |
|---|---|---|
| `skills/objectui/guides/plugin-development.md:92` | property `defaultValue` | **The guide is faithful prose, not rot.** `ComponentInput.defaultValue` really is `any` at `packages/types/src/base.ts:550`. The honest fix is to the platform type; changing the guide alone would make it lie about the contract it restates. |
| `skills/objectui/guides/testing.md:60` | `as any` assertion | `validateSchema({} as any)` — feeding the validator something invalid **on purpose**. Which idiom the testing guide should teach for that (`as unknown as T`, a ts-expect-error) is a question about the guide. |
| `skills/objectui/guides/testing.md:208` | variable `mockClient` | The test-double idiom. Same question, same owner. |
| `skills/objectui/guides/testing.md:208` | `as any` assertion | Reaching a private field through an adapter cast, in the same block. |

Each needs a per-row **skills** judgement that a gate-hardening change is not the place to make. Declaring them keeps that judgement a visible piece of work instead of a silent exemption — and the stale direction means a row cannot be parked forever.

---

## Item 2 — bounding root-devDependency resolution (MEASURED, ESCALATED, no code)

### What was measured

The marked population's unmapped specifiers are exactly `@playwright/test` and `vitest`. Both are declared by the repository **root** and both resolve out of `/node_modules`, where pnpm symlinks the root's own dependency set. Neither is declared by any package a marked fence imports, so neither is covered by the workspace map or the declared-dependency map. The inherited UNDECLARED control does **not** close this: it bounds resolution against **transitive** packages, which pnpm leaves only under `.pnpm/` — a different leak.

Under `--measure` the unmapped set is 12: six root-declared and installed (`@playwright/test`, `@testing-library/react`, `msw`, `react`, `vite`, `vitest`), and six not installed at the root at all (four `@objectstack/*`, plus `@tailwindcss/vite` and `@vitejs/plugin-react`) — those already fail to resolve, which is the existing bound working.

### Why this stops here

The harness is shared by exactly two production consumers: `check-doc-snippet-types.mjs` itself and this gate. Measured blast radius of putting the bound in `compileSnippets`:

> **A harness-level bound newly reds exactly ONE of `check-doc-snippet-types.mjs`'s own 432 compiled snippets** — `content/docs/guide/objectos-integration.mdx:638`, which imports `@playwright/test`.

That is a verdict move on a gate this flight does not own, over a documentation surface with its own owner. The card's own words are that the harness "carries the same edge" and asks where the bound should live; the two readings produce materially different edits, so per the flight brief this item returns for a decision rather than being guessed.

### The options, on the four axes

**Option A — bound inside `compileSnippets`, unconditionally (both gates).**

- *Real business need*: measured pull is real but small — one leaking snippet in the docs corpus, two specifiers in the skills corpus. The need is genuine (a green that rests on this workspace's devDependencies is not a claim about what a reader installs) but the surface is narrow.
- *Long-term soundness*: **strongest.** One resolution regime, one answer to "how far does resolution reach", stated once in the harness that already owns the syntax/semantics split and the four self-controls. It is the contract-first shape: the harness's guarantee stops being "narrow, except for whatever the root happens to declare".
- *Preventing AI-authored mistakes*: strongest. Declared equals enforced — a guide cannot silently rest on a package the reader was never told to install, which is precisely the class an AI copying a fence would propagate.
- *Startup scope discipline*: cheapest in surface — no new flag, no second regime, no staged window. Costs one docs snippet, which must be fixed or declared in the same change.

**Option B — bound per gate (a parameter `compileSnippets` accepts, default off).**

- *Real business need*: same pull, and it lands the skills half today without touching the docs corpus.
- *Long-term soundness*: **weakest, and the cost should be stated plainly.** An opt-in leniency flag in a shared harness is two resolution regimes behind one function, with the docs gate permanently on the lenient one. That is the consumer-tolerance shape the decision frame names — the harness would answer "did resolution stay narrow" with "depends who is asking".
- *Preventing AI-authored mistakes*: weaker. A gate whose strictness is a caller-side argument is a gate whose guarantee has to be re-read at every call site.
- *Startup scope discipline*: it looks cheaper and is not — it adds a permanent configuration surface to avoid one docs edit, which is sunk-cost reasoning about a snippet nobody has argued for.

**Option C — do nothing; keep naming the specifiers on every run.**

- *Real business need*: the `Unmapped specifiers` line already stops the leak from being silent, which is what the landing flight chose deliberately.
- *Long-term soundness*: weakest — a known-unenforced property that a reader must remember to read.
- *Preventing AI-authored mistakes*: weakest; a printed line is not a gate.
- *Startup scope discipline*: strongest in the short run, and it is the status quo.

**Recommendation: Option A**, led by long-term soundness (weighted at least 50%): it is the only option that leaves one answer to one question, and it is the option the frame's contract-first and declared-equals-enforced axes both select. The one docs snippet it reds is a real finding, not collateral — that snippet's green rests on this workspace's devDependencies rather than on anything its reader installs. Option A does need a call this flight cannot make on its own: whether that snippet is fixed, or declared, and by whom. **Option B is not recommended at any weighting** — it buys one avoided docs edit with a permanent second resolution regime in shared code.

---

## Item 3 — `SCAN_ROOTS` widened to `.claude/skills` (implemented)

`.claude/skills` **does** exist in objectui (4 markdown files), so this is code, not a note. Widened the way `check-skills-paths.mjs` was in #7358, and for the same measured reason: when #7251 moved the two contributor-only guides out of `skills/`, that gate stopped looking at them and nothing turned red.

**Widening a root is not arming it.** Opt-in is the design, so this adds candidates, not coverage:

| | before | after |
|---|---|---|
| guides scanned | 18 | 20 |
| ts / tsx / typescript fences | 112 | 121 |
| json / jsonc fences | 56 | 56 |
| **MARKED fences** | **56** | **56** |

All 9 new candidates are `typescript` fences in `.claude/skills/objectui-contributor/` — 5 in `guides/console-development.md`, 4 in `rules/no-touch-zones.md`. The two `SKILL.md` files carry none. **No marker was added to any file under `.claude/skills`** in this PR; that is the surface owner's step. None of the 9 carries a bare `any` either, so item 1 gains nothing to declare from item 3.

---

## Reverse verification

Each leg: commit first, mutate under a `trap ... EXIT INT TERM` restoring an **absolute** path, prove the mutation on disk by grep count **before** reading any verdict, then prove the restore by `git hash-object` equal to the HEAD blob plus an empty `git diff HEAD`.

### Leg A — an undeclared bare `any` in a marked fence must red

Mutated `skills/objectui/guides/i18n.md` (marked fence at line 39), injecting a bare `any` variable.

- mutation proof: injected-text count `0 -> 1`; worktree blob `7c2f01fe…` differs from HEAD blob `fc0d4ad3…`
- **verdict: gate exit 1**, `[bare-any] skills/objectui/guides/i18n.md:44:35 variable ... is annotated any`, summary line `5 finding(s) ... 1 NOT declared`
- restore proof: blob back to `fc0d4ad3…` (equal to HEAD), injected-text count `0`, `git diff HEAD` empty

### Leg B — the ratchet's shrink-only direction

Mutated `skills/objectui/guides/testing.md` so a **declared** row's red goes away (`{} as any` becomes `{} as unknown as never`).

- mutation proof: removed-text count `1 -> 0`, injected-text count `0 -> 1`; blob `a88336f9…` differs from HEAD `601d98fd…`
- **verdict: gate exit 1**, `skills/objectui/guides/testing.md:60 as any assertion [stale-baseline] this row is no longer red — delete its line`
- restore proof: blob back to `601d98fd…`, removed-text count back to `1`, `git diff HEAD` empty

### Leg C — the widened root is real coverage, not a cosmetic list

Appended a marked fence carrying a bare `any` to `.claude/skills/verify/SKILL.md`.

- mutation proof: injected-text count `0 -> 1`; blob `38816807…` differs from HEAD `68b48b7e…`
- **verdict: gate exit 1**, `[bare-any] .claude/skills/verify/SKILL.md:50:42 parameter v`, and `Marked: 18 ts fence(s)` (up from 17) — the widened root both **scans** and **gates** the file
- **control, the load-bearing half**: the same probe run against a copy of the script with `SCAN_ROOTS` narrowed back to `skills` alone sees **0** `.claude/skills` guides and **0** findings. Without this control the leg would only show the gate working, not that the widening is what made it reach.
- restore proof: blob back to `68b48b7e…`, injected-text count `0`, `git diff HEAD` empty

### Leg D — classifying three unrelated red tests

Three failures in `scripts/__tests__` are **pre-existing and independent of this change**. Proven rather than asserted: reverted all three of my changed files to the merge-base `e307c98` (proof on disk: the narrow `SCAN_ROOTS` line present, `findBareAny` absent), re-ran both suites, and **the same 3 tests failed identically**. Neither suite references `check-skill-examples`. Restore proof: all three blobs equal their HEAD blobs, `git diff HEAD` and `git status --porcelain` both empty.

They are built-tree-sensitive: `check-sdui-registration-pins` expects `packages/app-shell/src/...tsx` and gets `dist/...js`, and the two `check-readme-exports` legs are explicitly about "BOTH build states". This gate requires a built tree, so running its suite after the build surfaces them. Reported as out-of-scope findings, not fixed here.

---

## Gate table

Every exit code captured by redirect **before** any pipe. Verdicts quoted from each gate's own printed line.

| gate | exit | its own verdict line |
|---|---|---|
| `node scripts/check-skill-examples.mjs` (after the filtered build it derives) | **0** | `Every marked skill example holds up against the built types.` — `Bare any: 4 finding(s) across 3 selected fence(s); 4 declared ... 0 NOT declared, 0 declared row(s) no longer red.` |
| `--self-test` | **0** | `✓ check-skill-examples self-test: 42 cases pass (... the bare-any guard in both directions with its shrink-only baseline ...)` (21 new legs) |
| `--measure` | **0** | `Starting population — ts: 18/121 pass; json: 39/56 pass.` — `Bare any would-be population — 10 finding(s) over every candidate, of which 4 sit in a MARKED fence.` |
| `--build-filter` | **0** | output **byte-identical** to the pre-change run (diffed) — the workflow's build step is unmoved |
| `pnpm exec vitest run --maxWorkers=2 scripts/__tests__` | **1** | `Test Files 2 failed, 98 passed (100)` / `Tests 3 failed, 2883 passed (2886)` — the only failures are the 3 pre-existing ones classified in Leg D; `check-skill-examples.test.ts` alone: **65 passed, exit 0** |
| `pnpm exec tsc -p tsconfig.scripts.json --noEmit` | **0** | clean |
| `eslint scripts/check-skill-examples.mjs --format json` | **0** | 1 file linted, **0 errors, 0 warnings** |
| `pnpm lint` (repo-wide) | **0** | `Tasks: 47 successful, 47 total` — 4220 files linted repo-wide, **0 errors** (11832 pre-existing warnings, unchanged in kind) |
| `node scripts/check-pre-install-import-graph.mjs` | **0** | `✅ check-pre-install-import-graph: OK — 23 pre-install step(s) in 18 job(s) run 21 scripts/ gate(s); 23 module(s) walked, every non-relative leaf a node builtin.` |
| `node scripts/check-changeset-presence.mjs` | **0** | `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --test` over the final path list | **0** | `✅ NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.` |

The governed-queue verdict is **NOT GOVERNED** and that is the expected answer: this change set touches only `scripts/`, its tests, and `content/docs/` — no file under `skills/` or `.claude/skills/` is modified. The PR stays **draft** either way.

Control-byte scan over the changed files (`grep -naP` for C0/C1 and DEL) returned no matches.

---

## Per-file before and after

| file | before | after | delta |
|---|---|---|---|
| `scripts/check-skill-examples.mjs` | 1055 | 1397 | +342 |
| `scripts/__tests__/check-skill-examples.test.ts` | 476 | 557 | +81 |
| `content/docs/guide/ci-cd-pipeline.md` | 2079 | 2101 | +22 |

No file under the published `skills` bundle or under `.claude/skills` is touched, so the published-skill line budget does not apply.

## Invariants held

- exit 2 `PRECONDITION NOT MET` semantics **unchanged** — unbuilt tree, failed harness control and empty marked population all still leave through `couldNotRun`. A bare `any` and a stale row are verdicts about a guide, so they leave through exit **1**, alongside the orphan marker.
- The marked-population shrink-only ratchet (#7359 step 3) is **not** taken here.
- No behaviour change for the existing 17 ts and 39 json marked fences: all still pass, and the only new findings are the 4 declared rows.
- `--build-filter` output byte-identical, so `REQUIRED_CONTEXTS` and the workflow are unchanged.

## NOT MEASURED, and why

- **The body of `check-skill-examples.mjs` is not type-checked.** `tsconfig.scripts.json` sets `allowJs: true` with **`checkJs: false`** on purpose (its own comment records the measurement behind that choice). Confirmed with `--listFiles`: the file **is** in the program, so the `.ts` tests' use of the new exports (`findBareAny`, `bareAnyRowKey`, `KNOWN_BARE_ANY_EXAMPLES`) is checked — but errors inside the `.mjs` are not reported. A clean `tsc` here is a statement about the callers, not about the module body.
- **Whether the 4 declared rows should be fixed, and how.** That is a per-row skills judgement, deliberately deferred to a card rather than made by a gate-hardening PR. The shrink-only direction is what stops the deferral from becoming permanent.
- **Item 2's bound is not implemented**, so nothing here proves a bound works in either direction. The blast radius is measured; the bound is not written.
- **CI convergence.** Reported at draft-PR time per the dispatch contract; the merge-queue and workflow results are the reviewer's read, not this body's.

## Out-of-scope findings

Recorded for the seat to dedup and file — **not** fixed here, and no cards filed by me.

1. `scripts/__tests__/check-sdui-registration-pins.test.ts:146` — the pin expects the source module `packages/app-shell/src/console/connect/ConnectAgentWidget.tsx` and gets `packages/app-shell/dist/console/connect/ConnectAgentWidget.js` on a **built** tree. The derivation prefers `dist` once it exists, so this pin passes only on an unbuilt checkout. Proven pre-existing at `e307c98` (Leg D).
2. `scripts/__tests__/check-readme-exports.test.ts:899` and `:950` — both legs of "hides ONLY omissions, and the tree says so in BOTH build states" / "finds no fabricated or wrong-path import when built" fail on a built tree (`excerptsNotJudged` is 1, expected 3). Same class as (1), same proof.
3. `packages/types/src/base.ts:550` — `defaultValue?: any` in the exported `ComponentInput` interface. Not a guide defect: it is why row 1 of the baseline exists. Tightening it to `unknown` is the contract-first fix, and it is a platform-type change with its own consumers, so it wants its own card.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1