### PR TITLE
fix(skills): teach the honest test-double idiom in testing.md, retiring its three bare-any rows

### DIFF
--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -361,30 +361,27 @@ export const EXIT_CODES = {
  * re-declaration. That cost is deliberate: a row that floated free of its line
  * would keep covering a site nobody has looked at since.
  *
- * The four rows below are the whole corpus at objectui#7463's branch point,
- * measured under `--measure` before the assertion was armed. Each needs a
- * per-row SKILLS judgement that this gate-hardening change is not the place to
- * make, and none of them is a mechanical unmark:
+ * The corpus at objectui#7463's branch point was FOUR rows, measured under
+ * `--measure` before the assertion was armed. One is left, and it is not a
+ * mechanical unmark:
  *
  *   - `plugin-development.md:92` `defaultValue` — the guide is FAITHFUL prose,
  *     not rot. `ComponentInput.defaultValue` really is `any` in
  *     `packages/types/src/base.ts`, so the honest fix is to the platform type,
  *     not to the guide restating it. Fixing the guide alone would make it lie.
- *   - `testing.md:60` `as any` — `validateSchema({} as any)`, feeding the
- *     validator something invalid ON PURPOSE. Which idiom the testing guide
- *     should teach for that (`as unknown as T`, a `@ts-expect-error`) is a
- *     question about the guide, not about this gate.
- *   - `testing.md:208` `mockClient` and its `as any` — the test-double idiom,
- *     including reaching a private field through `(adapter as any).client`.
- *     Same question, same owner.
+ *
+ * The three `testing.md` rows were retired by objectui#7494, which answered the
+ * skills judgement each of them was waiting on and taught the honest idiom in
+ * their place — the schema fence hands the validator its invalid value with no
+ * assertion at all (the parameter takes it as-is), and the adapter fence doubles
+ * through the public `getClient()` seam instead of reaching the private `client`
+ * field through a cast. Both fences stay MARKED; the rows went in the same
+ * commit as the guide edit, because a row whose red is gone fails as STALE.
  *
  * @type {ReadonlySet<string>}
  */
 export const KNOWN_BARE_ANY_EXAMPLES = new Set([
   'skills/objectui/guides/plugin-development.md:92 property `defaultValue`',
-  'skills/objectui/guides/testing.md:60 `as any` assertion',
-  'skills/objectui/guides/testing.md:208 variable `mockClient`',
-  'skills/objectui/guides/testing.md:208 `as any` assertion',
 ]);
 
 /** The baseline key for one bare-`any` finding at one site. */

--- a/skills/objectui/guides/testing.md
+++ b/skills/objectui/guides/testing.md
@@ -173,7 +173,7 @@ describe('SchemaRenderer', () => {
 ```typescript
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { AuthProvider, useAuth } from '@object-ui/auth';
+import { AuthProvider, useAuth, type AuthClient } from '@object-ui/auth';
 
 function AuthConsumer() {
   const { isAuthenticated, user, isLoading } = useAuth();
@@ -184,14 +184,21 @@ function AuthConsumer() {
 
 describe('AuthProvider', () => {
   it('shows loading then authenticated state', async () => {
-    const mockClient = {
-      getSession: vi.fn().mockResolvedValue({
-        data: { user: { id: '1', name: 'Alice' }, session: { token: 'abc' } },
+    // `AuthClient` declares ~38 methods and the provider reaches ONE of them on
+    // this path. Type the literal `Partial<AuthClient>` and the stubbed member
+    // against `AuthClient['getSession']`: the key, the signature and the
+    // resolved value are then all checked, and the widening happens ONCE, in a
+    // named place. Casting the double to `any` unchecks all three at once.
+    // This is the shape `@object-ui/auth`'s own AuthProvider.test.tsx uses.
+    const stub: Partial<AuthClient> = {
+      getSession: vi.fn<AuthClient['getSession']>().mockResolvedValue({
+        user: { id: '1', email: 'alice@example.com', name: 'Alice' },
+        session: { token: 'abc' },
       }),
     };
 
     render(
-      <AuthProvider authClient={mockClient as any}>
+      <AuthProvider authUrl="/api/v1/auth" client={stub as unknown as AuthClient}>
         <AuthConsumer />
       </AuthProvider>
     );

--- a/skills/objectui/guides/testing.md
+++ b/skills/objectui/guides/testing.md
@@ -67,7 +67,10 @@ describe('schema validation', () => {
   });
 
   it('rejects schema without type', () => {
-    const result = validateSchema({} as any);
+    // `validateSchema` takes the schema value as given, so a deliberately
+    // invalid one goes in as-is. A type assertion here would add nothing and
+    // would hide what this test feeds the validator.
+    const result = validateSchema({});
     expect(result.valid).toBe(false);
     expect(formatValidationErrors(result)).toContain('type');
   });
@@ -211,21 +214,30 @@ import { ObjectStackAdapter } from '@object-ui/data-objectstack';
 
 describe('ObjectStackAdapter', () => {
   let adapter: ObjectStackAdapter;
-  let mockClient: any;
 
   beforeEach(() => {
-    mockClient = {
-      find: vi.fn().mockResolvedValue({ records: [], total: 0 }),
-      create: vi.fn().mockResolvedValue({ id: '1', name: 'New' }),
-    };
-    adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000' });
-    (adapter as any).client = mockClient;
+    adapter = new ObjectStackAdapter({
+      baseUrl: 'http://localhost:3000',
+      // `connect()` reads discovery through THIS injected fetch, not through the
+      // client, so stub it or every call fails before it reaches the client.
+      fetch: async () => new Response('{}', { status: 200 }),
+    });
   });
 
-  it('delegates find to client', async () => {
-    await adapter.find('contacts', { filter: { active: true } });
-    expect(mockClient.find).toHaveBeenCalledWith('contacts', expect.objectContaining({
-      filter: { active: true },
+  it('delegates find to the client', async () => {
+    // `getClient()` is the public seam: it hands back the very client the
+    // adapter calls, so the double needs no reach into a private field and
+    // stays checked against the client's real signature.
+    const find = vi
+      .spyOn(adapter.getClient().data, 'find')
+      .mockResolvedValue({ records: [], total: 0 });
+
+    await adapter.find('contacts', { $filter: { active: true } });
+
+    // The adapter lowers `$filter` into the ObjectQL AST before calling the
+    // client, so assert the lowered shape rather than the input.
+    expect(find).toHaveBeenCalledWith('contacts', expect.objectContaining({
+      filters: ['active', '=', true],
     }));
   });
 });


### PR DESCRIPTION
Fixes #7494

Retires the three `KNOWN_BARE_ANY_EXAMPLES` rows over `skills/objectui/guides/testing.md`
by teaching the honest test-double idiom, deletes the rows in the same commit as the guide
edit, and — second commit — applies the same idiom to the third `any` cast in the same
guide (Pattern 6, the auth double), which was an unmarked sibling of the two gated ones.
Both gated fences stay MARKED and the Pattern 6 fence stays UNMARKED; no marker was added
or removed anywhere. Row 384, `plugin-development.md:92 property defaultValue`, is #7493's
and is left in place.

Governed surface (`skills/**`): this PR stays a DRAFT for a human merge. Not flipped ready,
not enqueued, no auto-merge, no requested reviewers.

Head `45136c1`, two commits, one file plus the gate's baseline: `testing.md` and
`scripts/check-skill-examples.mjs`.

## A note on how this body is written

GitHub's body sanitizer deletes tag-shaped fragments, and backticks and fenced blocks do
NOT protect them (AGENTS.md records six measured rewrites; the first report comment on the
card lost a JSX line to exactly this and was repaired in a follow-up). So generics and JSX
in this body are spelled in WORDS — "Partial of AuthClient", "an AuthProvider element" —
never with literal angle brackets. The committed bytes are in the diff.

## Row 1 — `testing.md:60` `as any` assertion (Pattern 3, schema validation)

Measured against the BUILT type, `packages/core/dist/validation/schema-validator.d.ts:72`:

```
export declare function validateSchema(schema: any, path?: string): SchemaNodeValidationResult;
```

The parameter takes the value as given, so nothing had to be asserted to hand the validator
something invalid. Per the flight rule (delete the cast when the parameter already accepts
the value; otherwise name the real type) the cast is DELETED, not replaced.

Before:

```typescript
    const result = validateSchema({} as any);
```

After:

```typescript
    // `validateSchema` takes the schema value as given, so a deliberately
    // invalid one goes in as-is. A type assertion here would add nothing and
    // would hide what this test feeds the validator.
    const result = validateSchema({});
```

## Rows 2 and 3 — `testing.md:208` variable `mockClient` and its `as any` (Pattern 7, DataSource adapter)

`packages/data-objectstack/src/index.ts:2149` holds a private `client` field of type
`ObjectStackClient`, assigned once in the constructor (`:2237`). A PUBLIC SEAM exists:
`getClient()` at `:4096` returns that same instance, and the adapter's own doc comment at
`:2856` says so — "every caller outside it via getClient, which hands back this same
instance". So the private-field reach is dropped entirely and the double goes through the
seam with `vi.spyOn`, checked against the client's real signature. There is no `client`
constructor option and no public setter, so the ts-expect-error fallback did not apply.

Before:

```typescript
describe('ObjectStackAdapter', () => {
  let adapter: ObjectStackAdapter;
  let mockClient: any;

  beforeEach(() => {
    mockClient = {
      find: vi.fn().mockResolvedValue({ records: [], total: 0 }),
      create: vi.fn().mockResolvedValue({ id: '1', name: 'New' }),
    };
    adapter = new ObjectStackAdapter({ baseUrl: 'http://localhost:3000' });
    (adapter as any).client = mockClient;
  });

  it('delegates find to client', async () => {
    await adapter.find('contacts', { filter: { active: true } });
    expect(mockClient.find).toHaveBeenCalledWith('contacts', expect.objectContaining({
      filter: { active: true },
    }));
  });
});
```

After:

```typescript
describe('ObjectStackAdapter', () => {
  let adapter: ObjectStackAdapter;

  beforeEach(() => {
    adapter = new ObjectStackAdapter({
      baseUrl: 'http://localhost:3000',
      // `connect()` reads discovery through THIS injected fetch, not through the
      // client, so stub it or every call fails before it reaches the client.
      fetch: async () => new Response('{}', { status: 200 }),
    });
  });

  it('delegates find to the client', async () => {
    // `getClient()` is the public seam: it hands back the very client the
    // adapter calls, so the double needs no reach into a private field and
    // stays checked against the client's real signature.
    const find = vi
      .spyOn(adapter.getClient().data, 'find')
      .mockResolvedValue({ records: [], total: 0 });

    await adapter.find('contacts', { $filter: { active: true } });

    // The adapter lowers `$filter` into the ObjectQL AST before calling the
    // client, so assert the lowered shape rather than the input.
    expect(find).toHaveBeenCalledWith('contacts', expect.objectContaining({
      filters: ['active', '=', true],
    }));
  });
});
```

Three claims the `any` had been hiding became checkable and were all false; each is
corrected, each is measured. (a) The adapter calls the client's `data.find`
(`index.ts:2454`), never a top-level `find`. (b) `filter` is not a `QueryParams` key:
`packages/types/src/data.ts:43` declares `$filter`, and the interface's
`[key: string]: any` index signature is what let the misspelling compile;
`convertQueryParams` (`index.ts:3817`) reads only the dollar-prefixed keys, so `filter` was
dropped and the old assertion could never have matched. The asserted AST value is what
`convertFiltersToAST` (`packages/core/src/utils/filter-converter.ts:107`) returns for one
simple equality. (c) `find` awaits `connect()`, which fetches discovery through the
injected `fetch` constructor option, not through the client, so with no stub the example
failed at the network before delegating.

This is the one JUDGEMENT CALL a reviewer may want reversed. The assertion line had to be
rewritten regardless (the identifier `mockClient` is gone), and writing a knowingly-false
line into a published guide is the same rot the guard exists to end. Restoring those three
lines' previous wording is a one-commit reversal that leaves the row retirement intact.

## Third fence — `testing.md:173` Pattern 6, the auth double (second commit)

Same idiom, same guide, so it lands here rather than on a new card. The fence is UNMARKED
and STAYS unmarked; its language tag is untouched; the change is content only.

The gate had already proved the old fence wrong without being asked to: at the previous
head, `--measure` (which judges EVERY candidate, marked or not) reported

```
  skills/objectui/guides/testing.md:173  [typescript]          FAIL + 1 bare `any`
  [semantic]  skills/objectui/guides/testing.md:194:21  TS2322: Type '{ children: Element; authClient: any; }' is not assignable to type 'IntrinsicAttributes & AuthProviderProps'.   Property 'authClient' does not exist on type 'IntrinsicAttributes & AuthProviderProps'.
```

Measured shapes: `AuthProviderProps` extends `AuthProviderOptions`
(`packages/auth/src/types.ts:513`), whose seam for an already-created client is `client`
(optional, of type `AuthClient`) and whose `authUrl` is REQUIRED. `AuthClient`
(`types.ts:299`) declares roughly 38 methods; its `getSession` (`types.ts:306`) resolves
the user and session directly, with no `data` envelope. `AuthUser` requires `id`, `email`
and `name` (spec `contracts`).

Changes, line by line (angle brackets in words, per the note above):

- the import from `@object-ui/auth` now also brings in the type `AuthClient`;
- `const mockClient = {` becomes `const stub:` followed by Partial of AuthClient, then `= {`;
- `getSession: vi.fn().mockResolvedValue({` becomes `getSession: vi.fn` parameterised by
  AuthClient indexed at `'getSession'`, then `().mockResolvedValue({`;
- the resolved value loses its wrong `data:` envelope and becomes
  `user: { id: '1', email: 'alice@example.com', name: 'Alice' }, session: { token: 'abc' }`
  — `email` was missing and is required;
- the AuthProvider element's attributes change from a single `authClient` set to
  `mockClient as any`, to `authUrl` set to the string `/api/v1/auth` plus `client` set to
  the expression `stub as unknown as AuthClient`;
- a six-line comment above the double states why: the interface declares ~38 methods and
  the provider reaches ONE on this path, so typing the literal and the stubbed member
  checks the key, the signature AND the resolved value, and the widening happens once, in a
  named place. Casting the double to `any` unchecks all three at once.

Why a named widening rather than a `Pick` or a `satisfies` literal passed straight in:
the prop's type is the FULL `AuthClient`, so no partial value is assignable to it without
one widening step somewhere. Putting that step in one named place, over a literal that is
itself typed against the interface, is strictly stronger than the `any` it replaces, and it
is the shape `@object-ui/auth`'s own `AuthProvider.test.tsx` already uses for this same
interface — measured in the repo, not invented here. A ts-expect-error line was not used
because nothing here is expected to fail to compile.

Result at the new head, from the same `--measure` run:

```
  skills/objectui/guides/testing.md:173  [typescript]          pass
```

and the would-be bare-any population drops from 7 findings to 6, with the `testing.md:194`
row gone. The marked population is unchanged (17 ts fences, 0 failed, 1 declared row), and
the gate's derived `--build-filter` is byte-identical to before — `@object-ui/auth` is
still not in it, which is the mechanical confirmation that the fence stayed unmarked.

## The row deletions

Three rows deleted from `KNOWN_BARE_ANY_EXAMPLES` in `scripts/check-skill-examples.mjs`,
leaving one:

```
  'skills/objectui/guides/plugin-development.md:92 property `defaultValue`',
```

The comment block above the set is updated to record that the three `testing.md` rows were
retired here and why the remaining row is not a mechanical unmark. No change to the gate's
logic, its positions, or its baseline mechanics.

## Reverse verification — both legs, at the final head

Committed first, then mutated under a `trap` restoring an absolute path. Every mutation was
proved on disk BEFORE any verdict was read.

HEAD blob of the guide: `0f68499c93fe2fed42d6220281a4afcc19127e3f`.

| leg | mutation, proved on disk | verdict | restore, proved |
|:--|:--|:--|:--|
| A — Pattern 3, re-inject the deleted cast | `grep -c` on the injected text 0 to 1; blob `9d4bccffaba7c875533cacbd0da5c2b9f0746824`, different from the HEAD blob | gate exit **1**, `[bare-any]  skills/objectui/guides/testing.md:73:41` demanding the verbatim row `skills/objectui/guides/testing.md:60 as any assertion` — the exact row this PR deletes; summary `1 NOT declared` | blob back to `0f68499c…`, equal to the HEAD blob; `git diff HEAD --stat` empty |
| B — Pattern 6, replace the named widening with a bare cast | `grep -c` on the injected text 0 to 1; blob `cb560d60de00b011b898c8749aa4c0d5bf268d04`, different from the HEAD blob | main gate stays exit **0** — the honesty of an UNMARKED fence is not gated, which is exactly why this card fixes it by hand — while `--measure` re-lists `unmarked  skills/objectui/guides/testing.md:201  as any assertion`, the finding that had disappeared at the honest head | blob back to `0f68499c…`; `git diff HEAD --stat` empty; injected count back to 0, honest count back to 1 |

Leg B's compile result stays `pass` under the mutation, because a bare cast still compiles.
That is the point of the second, independent read: the bare-any guard is what sees it.

## Gates — union re-run at the final head `45136c1`, working tree clean

Every exit code captured by redirect BEFORE any pipe.

| gate | exit | its own verdict line |
|:--|:--|:--|
| `node scripts/check-skill-examples.mjs` (built, under the lock) | 0 | `Semantic phase: 17 of 17 ts fence(s) judged, 0 failed.` / `Bare any: 1 finding(s) across 1 selected fence(s); 1 declared in KNOWN_BARE_ANY_EXAMPLES (SHRINK-ONLY, 1 row(s)), 0 NOT declared, 0 declared row(s) no longer red.` / `Every marked skill example holds up against the built types.` |
| `--self-test` | 0 | `42 cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, the bare-any guard in both directions with its shrink-only baseline, and the compiler legs through the real harness).` |
| `--measure` | 0 | `Starting population — ts: 19/121 pass; json: 39/56 pass.` (was 18/121) / `Bare any would-be population — 6 finding(s) over every candidate, of which 1 sit in a MARKED fence` (was 7) |
| `--build-filter` | 0 | byte-identical to the previous head; 11 packages, `@object-ui/auth` absent |
| `node scripts/check-skill-eval-tokens.mjs` | 0 | `Every must_contain token is taught by its own skill bundle.` |
| `node scripts/check-skills-paths.mjs` | 0 | `check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).` |
| `pnpm exec vitest run --maxWorkers=2 scripts/__tests__/check-skill-examples.test.ts scripts/__tests__/check-skill-eval-tokens.test.ts` | 0 | `Test Files  2 passed (2)` / `Tests  101 passed (101)` |
| `pnpm exec tsc -p tsconfig.scripts.json --noEmit` | 0 | no output |
| `node scripts/check-governed-queue-guard.mjs --test` over the final path list | **3** | `GOVERNED — 1 of 2 path(s) are on a governed surface: skills/** x1 — the published skills catalog` — the correct verdict here, not a red |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-control-bytes.mjs` | 0 | `check-control-bytes: OK (scanned 6157 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `check-shell-escape-residue: OK (5/5 root(s) resolved …; 0 occurrence(s) outside a fence)` |

Heavy work went through objectstack's shared verify lock (slot `issue-7494`): the filtered
build the gate derives from `--build-filter` — plus `@object-ui/auth` so the third fence
could be judged against BUILT types rather than source — 29 turbo tasks, all successful,
then each gate leg.

## Line and byte arithmetic (reported, not gated)

There is no token ratchet over `skills/**` in objectui, so these are numbers, not a budget.

| file | lines at base | lines now | bytes at base | bytes now |
|:--|--:|--:|--:|--:|
| `skills/objectui/guides/testing.md` | 345 | 364 | 9671 | 10937 |
| `scripts/check-skill-examples.mjs` | 1397 | 1394 | 67820 | 67610 |
| published `skills/` tree (27 files) | 5014 | 5033 | 175711 | 176977 |

Net over the published tree: +19 lines, +1266 bytes. Second commit alone: +7 lines,
+583 bytes. All of it is explanatory comments in the three fences, the discovery stub, and
the corrected props; no new capability, section or example was added.

## NOT MEASURED, and why

- **The fences were type-checked, never RUN.** The gate compiles fences against the built
  `dist/*.d.ts`; it does not execute them. That the rewritten Pattern 7 and Pattern 6 tests
  would now PASS rests on reading the sources cited above, not on a run. Their compile
  results ARE measured — the Pattern 6 fence is judged by `--measure` and now reads `pass`.
- **`pnpm lint` repo-wide was NOT run — the narrowing is declared with its evidence.**
  (1) Population read from eslint's own config: every `files:` selector in
  `eslint.config.js` is `**/*.{ts,tsx}` or a `.{ts,tsx}` subset of it, and `pnpm lint` is
  `turbo run lint`, i.e. per-package `eslint .`, which does not reach repo-root `scripts/`;
  neither changed file is `.ts`/`.tsx`. (2) File count read from `--format json` over
  exactly the two changed files: `scripts/check-skill-examples.mjs` 0 errors 0 warnings,
  `skills/objectui/guides/testing.md` one warning, "File ignored because no matching
  configuration was supplied." (3) Invariance for untouched files: no type-aware linting is
  configured at all (`grep -c project eslint.config.js` is 0), so no untouched file's
  verdict can move because of this diff.
- **CI convergence was not waited for** (standing dispatch contract).
- **objectstack's `scripts/pm/dispatch-gates.mjs` was NOT used**: it answers only about the
  tree it lives in, and objectui has no `scripts/pm/`. The gate list is hand-derived from
  this repo's `package.json` check scripts and the three `skills`-touching workflows.

## Out-of-scope findings (reported, not filed here — the seat dedups and files)

- `skills/objectui/guides/testing.md:173` — the Pattern 6 fence carries the language tag
  `typescript` while its body is JSX. The gate's harness compiles every candidate as TSX so
  it judges the fence correctly, but `check-doc-fence-languages.mjs` keys on info strings,
  and marking this fence later would also pull `@object-ui/auth` into the gate's derived
  build set. Both are marking-mechanics questions, deliberately untouched here.
- `packages/core/src/validation/schema-validator.ts:459` — the first parameter of
  `validateSchema` is annotated `any`. The Pattern 3 fence is honest now precisely BECAUSE
  the platform type is this wide. Same class as row 384's `ComponentInput.defaultValue`:
  the honest fix is `unknown` plus a narrowing entry point in the platform type, never in
  the guide restating it.
- `packages/types/src/data.ts:133` — `QueryParams` carries an `[key: string]: any` index
  signature. That is what let the misspelled `filter` key compile in the guide for as long
  as it did, and it does the same for every caller in the repo: any typo in a query param
  is accepted silently and then dropped by `convertQueryParams`.
- `scripts/check-skill-examples.mjs` `--measure` — its would-be-population summary prints
  the FINDING's line while a baseline row is keyed on the FENCE's line. For the surviving
  row the summary reads `plugin-development.md:103` while the declared row is `:92`. The
  per-finding diagnostic DOES print the verbatim row spelling, so the correct spelling is
  available; only the summary list can mislead someone declaring a row from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LraLgQVGq8egUwfYZpbYt1