### PR TITLE
fix(data-objectstack): createObjectStackAdapter declares the adapter it returns

### DIFF
--- a/.changeset/7323-adapter-factory-return.md
+++ b/.changeset/7323-adapter-factory-return.md
@@ -12,12 +12,32 @@ A wider value is assignable to a narrower annotation, so nothing ever failed to 
 `ReturnType<typeof createObjectStackAdapter>` failed with TS2339: `getClient`,
 `getCacheStats`, `invalidateCache`, `clearCache`, `getConnectionState`, `isConnected`,
 `onConnectionStateChange`, `onBatchProgress` and `setSystemCapabilities`. Eight of those
-are exactly the members this package's README API Reference documents, and four whole
-README sections are built on them; the ninth is the one the factory's own JSDoc links to
-(`[ADR-0066] See {@link ObjectStackAdapter.setSystemCapabilities}`). So the file's own
-doc comment pointed the reader at a method its declared return hid, and the two
-documented ways to obtain the same object — the factory and `new ObjectStackAdapter(…)`
-— handed back different type surfaces.
+nine reads are on this package's README API Reference list, and four whole README
+sections are built on them; the ninth measured read is the one the factory's own JSDoc
+links to (`[ADR-0066] See {@link ObjectStackAdapter.setSystemCapabilities}`). The README
+list is itself **nine** adapter-only members, not eight — `connect()` is adapter-only
+too and was documented all along; it simply was not one of the reads the card's
+reproduction measured. So the file's own doc comment pointed the reader at a method its
+declared return hid, and the two documented ways to obtain the same object — the factory
+and `new ObjectStackAdapter(…)` — handed back different type surfaces.
+
+**What the declared return now is: the whole class, not those nine reads.** The nine
+above are what the reproduction measured, not the size of this change. The factory's
+declared return is now `ObjectStackAdapter<T>` itself, so **every public member of the
+class** is part of what the factory promises. Against `DataSource` that is **20**
+members, not nine — `tsc`-computed as
+`Exclude<keyof ObjectStackAdapter<unknown>, keyof DataSource<unknown>>`: `clearCache`,
+`connect`, `getCacheStats`, `getCached`, `getClient`, `getConnectionState`,
+`getDiscovery`, `getItems`, `invalidateCache`, `invalidateViewKeys`, `isConnected`,
+`listImportMappings`, `onBatchProgress`, `onConnectionStateChange`, `onSaveAdvisory`,
+`onWriteWarning`, `probeAppAccess`, `queryDataset`, `setSystemCapabilities`,
+`updateDashboard`. The eleven past the documented nine were already in the shipped class
+type — none is `@internal` or `@deprecated`, `stripInternal` is not set, and all were
+already reachable through `new ObjectStackAdapter(…)` and through every
+`ObjectStackAdapter`-typed seam in `@object-ui/react` and `app-shell` — so what widens
+here is what the **factory declares**, not what the package ships. Two are escape-hatch
+shaped and worth knowing before building on them: `getCached(key)` is a raw cache read,
+and `getDiscovery()` reaches an internal property of the underlying `ObjectStackClient`.
 
 **Branch taken: A (widen the factory's declared return), and why.** The card offered
 three. B — moving caching, connection state and batch progress onto `DataSource` — was
@@ -37,18 +57,23 @@ the commit that added `autoReconnect` / `maxReconnectAttempts` / `reconnectDelay
 factory's own config bag left the members that observe those features off the factory's
 declared return in the same change.
 
-**Not a breaking change for callers.** A wider return is assignable to the narrower
-annotation, so `const ds: DataSource = createObjectStackAdapter(…)` keeps compiling and
-keeps giving the narrow surface to anyone who wants it. The one shape that changes is a
-hand-written object literal assigned to `ReturnType<typeof createObjectStackAdapter>`:
-that type is now a class with private members, so a structural stand-in no longer
-satisfies it — annotate such a fake as `DataSource` instead, which is what it was
-standing in for.
+**One caller shape breaks: a structural stand-in for the factory's return.** A
+hand-written object literal annotated `ReturnType<typeof createObjectStackAdapter>` no
+longer satisfies that type, because it is now a class with private members (TS2740) —
+annotate such a fake as `DataSource` instead, which is what it was standing in for.
+Nothing else moves: a wider return is assignable to the narrower annotation, so
+`const ds: DataSource = createObjectStackAdapter(…)` keeps compiling and keeps giving
+the narrow surface to anyone who wants it.
 
 The README's note saying the page could not yet teach the factory's shape is removed, and
 the four sections built on the adapter-only members (Metadata Caching, Connection State
 Monitoring, Batch Operation Progress, Troubleshooting → Cache Issues) now continue from
 Basic Setup's `createObjectStackAdapter(…)` call instead of declaring the class by hand.
-`src/adapterFactoryReturn.types.test.ts` pins the card's TS2339 reproduction inverted,
+The docs-site page `content/docs/utilities/data-objectstack.mdx` is corrected the same
+way: its prose, its factory signature fragment and its "hold the class type to reach
+these" section described the old narrow return, and its Mutations and Troubleshooting
+examples told the reader to construct the class by hand to reach members the factory now
+declares. `src/adapterFactoryReturn.types.test.ts` pins the card's TS2339 reproduction
+inverted,
 with two controls: the adapter-only members stay absent from `DataSource` (fires on
 option B), and the widened return stays assignable to `DataSource` (swappability kept).

--- a/.changeset/7323-adapter-factory-return.md
+++ b/.changeset/7323-adapter-factory-return.md
@@ -1,0 +1,54 @@
+---
+'@object-ui/data-objectstack': minor
+---
+
+`createObjectStackAdapter` declares the adapter it returns, not the shared `DataSource`
+interface (objectui#7323).
+
+The factory returned `new ObjectStackAdapter(config)` while declaring `DataSource<T>`.
+A wider value is assignable to a narrower annotation, so nothing ever failed to compile
+— the loss was entirely on the reading side. Measured against the shipped
+`dist/index.d.ts` with the doc-snippet gate's own compiler options, nine reads through
+`ReturnType<typeof createObjectStackAdapter>` failed with TS2339: `getClient`,
+`getCacheStats`, `invalidateCache`, `clearCache`, `getConnectionState`, `isConnected`,
+`onConnectionStateChange`, `onBatchProgress` and `setSystemCapabilities`. Eight of those
+are exactly the members this package's README API Reference documents, and four whole
+README sections are built on them; the ninth is the one the factory's own JSDoc links to
+(`[ADR-0066] See {@link ObjectStackAdapter.setSystemCapabilities}`). So the file's own
+doc comment pointed the reader at a method its declared return hid, and the two
+documented ways to obtain the same object — the factory and `new ObjectStackAdapter(…)`
+— handed back different type surfaces.
+
+**Branch taken: A (widen the factory's declared return), and why.** The card offered
+three. B — moving caching, connection state and batch progress onto `DataSource` — was
+rejected because those are this adapter's concerns, not every data source's; every other
+`DataSource` implementation would then declare members it does not have. C — documenting
+a cast — teaches a cast around a declaration that is merely narrower than the value,
+which is the opposite of `declared = enforced`. A is one line and makes declared match
+shipped for every documented member at once.
+
+Two questions decided the shape and both were answered from the code before the diff.
+`ObjectStackAdapter` was **already** exported from the package's only entry
+(`src/index.ts`, tsup's single entry; the class is in the shipped `dist/index.d.ts`
+export list, two pin tests assert the exported spelling, and `apps/console` re-exports it
+by name) — so widening the return exports nothing by implication. And the narrow return
+was **not** a deliberate swappability guarantee: no comment, ADR or test pinned it, and
+the commit that added `autoReconnect` / `maxReconnectAttempts` / `reconnectDelay` to the
+factory's own config bag left the members that observe those features off the factory's
+declared return in the same change.
+
+**Not a breaking change for callers.** A wider return is assignable to the narrower
+annotation, so `const ds: DataSource = createObjectStackAdapter(…)` keeps compiling and
+keeps giving the narrow surface to anyone who wants it. The one shape that changes is a
+hand-written object literal assigned to `ReturnType<typeof createObjectStackAdapter>`:
+that type is now a class with private members, so a structural stand-in no longer
+satisfies it — annotate such a fake as `DataSource` instead, which is what it was
+standing in for.
+
+The README's note saying the page could not yet teach the factory's shape is removed, and
+the four sections built on the adapter-only members (Metadata Caching, Connection State
+Monitoring, Batch Operation Progress, Troubleshooting → Cache Issues) now continue from
+Basic Setup's `createObjectStackAdapter(…)` call instead of declaring the class by hand.
+`src/adapterFactoryReturn.types.test.ts` pins the card's TS2339 reproduction inverted,
+with two controls: the adapter-only members stay absent from `DataSource` (fires on
+option B), and the widened return stays assignable to `DataSource` (swappability kept).

--- a/content/docs/utilities/data-objectstack.mdx
+++ b/content/docs/utilities/data-objectstack.mdx
@@ -178,7 +178,7 @@ const fromFactory = createObjectStackAdapter<User>({ baseUrl: 'https://api.examp
 const fromClass = new ObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
 ```
 
-**What changed.** Until v17.7 this section told you to hold the class type to
+**What changed.** This section used to tell you to hold the class type to
 reach the members listed under *Beyond `DataSource`* below, because the factory
 declared `DataSource<T>` while returning `new ObjectStackAdapter(config)`: the
 value always carried those members, only the declared type hid them
@@ -210,16 +210,15 @@ adapter):
 - `getObjectSchema(objectName)` - Fetch schema metadata (cached)
 - `bulk?(resource, operation, data)` - Batch create/update/delete on one object
 - `batchTransaction?(operations)` - Cross-object atomic batch (master-detail)
+- `onMutation?(listener)` - Subscribe to create/update/delete events
 
 `bulk`, `batchTransaction` and `onMutation` are **optional** members of
 `DataSource`: not every adapter implements them, so through a `DataSource`-typed
 value they must be feature-detected (`typeof dataSource.bulk === 'function'`).
 `ObjectStackAdapter` implements all three unconditionally, and the factory
-declares the class, so a value from either form calls them directly:
-
-- `bulk(resource, operation, data)` - Batch create/update/delete on one object
-- `batchTransaction(operations)` - Cross-object atomic batch (master-detail)
-- `onMutation(listener)` - Subscribe to create/update/delete events
+declares the class, so a value from either form calls them directly. (`onMutation`
+was listed under *Adapter-only* here until objectui#7323; it is optional on
+`DataSource`, not absent from it.)
 
 **Beyond `DataSource`** (declared on `ObjectStackAdapter`, so reachable from
 either form):
@@ -231,10 +230,12 @@ either form):
 - `onConnectionStateChange(listener)` - Subscribe to state changes (returns unsubscribe)
 - `onBatchProgress(listener)` - Subscribe to bulk progress (returns unsubscribe)
 
-Those nine are the documented subset. `ObjectStackAdapter` declares **20** members
-beyond `DataSource` in all; the other eleven are lower-level seams (client
-discovery, cache-key invalidation, dataset and dashboard access, advisory
-subscriptions) that this page does not document and that carry no compatibility
+Those six bullets cover nine members, and they are the documented subset.
+`ObjectStackAdapter` declares **20** members beyond `DataSource` in all
+(`Exclude<keyof ObjectStackAdapter<unknown>, keyof DataSource<unknown>>`); the
+other eleven are lower-level seams — client discovery, cache-key invalidation,
+dataset and dashboard access, advisory subscriptions and capability configuration
+among them — which this page does not document and which carry no compatibility
 promise here.
 
 ### Per-element data binding

--- a/content/docs/utilities/data-objectstack.mdx
+++ b/content/docs/utilities/data-objectstack.mdx
@@ -50,9 +50,11 @@ const dataSource = createObjectStackAdapter({
 });
 ```
 
-`createObjectStackAdapter` returns a `DataSource` — the same universal interface
-every ObjectUI renderer consumes. `new ObjectStackAdapter(config)` is the class
-form of the same thing.
+`createObjectStackAdapter` returns an `ObjectStackAdapter` — the concrete adapter
+class, which implements `DataSource`, the universal interface every ObjectUI
+renderer consumes. `new ObjectStackAdapter(config)` is the class form of the same
+thing and has the same type. Annotate the value as `DataSource` wherever you want
+only the universal surface.
 
 ### 2. Inject it at the renderer boundary
 
@@ -106,11 +108,12 @@ full table of which blocks honour which keys.
 
 ### `createObjectStackAdapter`
 
-Factory returning a `DataSource` backed by an ObjectStack backend.
+Factory returning an `ObjectStackAdapter` — the concrete adapter class, which
+implements `DataSource` — backed by an ObjectStack backend.
 
 **Config:**
 
-{/* doc-snippet: fragment — a SIGNATURE excerpt of the factory, quoted from its declaration so the config members can be annotated one by one: a `function` declaration with no body and a `DataSource` return type this reference block does not import (measured: TS2391 x1, TS2304 x1). Checked against the shipped `packages/data-objectstack/dist/index.d.ts`: every member listed here is declared there with the same type */}
+{/* doc-snippet: fragment — a SIGNATURE excerpt of the factory, quoted from its declaration so the config members can be annotated one by one: a `function` declaration with no body and an `ObjectStackAdapter` return type this reference block does not import (measured: TS2391 x1, TS2304 x1). Because the block is DECLARED, this gate never compiles it, so the agreement with the shipped `packages/data-objectstack/dist/index.d.ts` — every config member declared there with the same type, and the return type — is hand-checked at each edit, not gate-enforced; that gap is why the return type here outlived the change that widened it (objectui#7323) */}
 ```typescript
 function createObjectStackAdapter<T = unknown>(config: {
   /** ObjectStack server base URL */
@@ -132,7 +135,7 @@ function createObjectStackAdapter<T = unknown>(config: {
   autoReconnect?: boolean; // default true
   maxReconnectAttempts?: number; // default 3
   reconnectDelay?: number; // default 1000 ms
-}): DataSource<T>;
+}): ObjectStackAdapter<T>;
 ```
 
 **Example:**
@@ -161,20 +164,43 @@ const dataSource = createObjectStackAdapter<User>({ baseUrl: 'https://api.exampl
 
 ### `ObjectStackAdapter`
 
-The class behind the factory. `new ObjectStackAdapter(config)` takes the same
-config, but its declared type is the **concrete adapter** rather than the
-`DataSource` interface the factory returns — which matters, because part of the
-adapter's surface is not on that interface:
+The class behind the factory — and the type the factory declares. `new
+ObjectStackAdapter(config)` and `createObjectStackAdapter(config)` take the same
+config and produce the same type, so the two forms are interchangeable:
 
 ```typescript
-import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackAdapter, ObjectStackAdapter } from '@object-ui/data-objectstack';
 
 type User = { id: string; name: string; email: string };
 
-const adapter = new ObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
+// Same declared type, either way.
+const fromFactory = createObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
+const fromClass = new ObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
 ```
 
-**On the `DataSource` interface** (available from either form):
+**What changed.** Until v17.7 this section told you to hold the class type to
+reach the members listed under *Beyond `DataSource`* below, because the factory
+declared `DataSource<T>` while returning `new ObjectStackAdapter(config)`: the
+value always carried those members, only the declared type hid them
+(objectui#7323). That distinction is gone. If you switched to
+`new ObjectStackAdapter(...)` solely to reach a cache, connection-state or batch
+method, you can switch back to the factory — nothing about the value changes, and
+neither does its type. The class name is still worth importing when you need
+something to annotate with.
+
+Narrowing still works, and is still the right shape for a prop, a field or a test
+double that must accept **any** adapter:
+
+```typescript
+import type { DataSource } from '@object-ui/types';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
+
+// The universal surface only, by annotation.
+const dataSource: DataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com' });
+```
+
+**On the `DataSource` interface** (available from either form, and from any other
+adapter):
 
 - `find(resource, params?)` - Query multiple records
 - `findOne(resource, id, params?)` - Get a single record by ID
@@ -185,13 +211,18 @@ const adapter = new ObjectStackAdapter<User>({ baseUrl: 'https://api.example.com
 - `bulk?(resource, operation, data)` - Batch create/update/delete on one object
 - `batchTransaction?(operations)` - Cross-object atomic batch (master-detail)
 
-`bulk` and `batchTransaction` are **optional** members of `DataSource`: not every
-adapter implements them, so through a `DataSource`-typed value they must be
-feature-detected (`typeof dataSource.bulk === 'function'`). `ObjectStackAdapter`
-implements both unconditionally, so a value held at the class type calls them
-directly.
+`bulk`, `batchTransaction` and `onMutation` are **optional** members of
+`DataSource`: not every adapter implements them, so through a `DataSource`-typed
+value they must be feature-detected (`typeof dataSource.bulk === 'function'`).
+`ObjectStackAdapter` implements all three unconditionally, and the factory
+declares the class, so a value from either form calls them directly:
 
-**Adapter-only** (hold the class type to reach these):
+- `bulk(resource, operation, data)` - Batch create/update/delete on one object
+- `batchTransaction(operations)` - Cross-object atomic batch (master-detail)
+- `onMutation(listener)` - Subscribe to create/update/delete events
+
+**Beyond `DataSource`** (declared on `ObjectStackAdapter`, so reachable from
+either form):
 
 - `connect()` - Establish the connection (called lazily by every operation)
 - `getCacheStats()` / `invalidateCache(key?)` / `clearCache()` - Cache control
@@ -199,7 +230,12 @@ directly.
 - `getConnectionState()` / `isConnected()` - Connection introspection
 - `onConnectionStateChange(listener)` - Subscribe to state changes (returns unsubscribe)
 - `onBatchProgress(listener)` - Subscribe to bulk progress (returns unsubscribe)
-- `onMutation(listener)` - Subscribe to create/update/delete events
+
+Those nine are the documented subset. `ObjectStackAdapter` declares **20** members
+beyond `DataSource` in all; the other eleven are lower-level seams (client
+discovery, cache-key invalidation, dataset and dashboard access, advisory
+subscriptions) that this page does not document and that carry no compatibility
+promise here.
 
 ### Per-element data binding
 
@@ -369,15 +405,16 @@ await dataSource.delete('user', user.id);
 
 Batch writes on one object go through `bulk`, and cross-object writes that must
 commit or roll back together go through `batchTransaction`. Both are optional on
-the `DataSource` interface, so hold the adapter at its class type (or
-feature-detect) before calling them:
+the `DataSource` interface, so a value you annotated as `DataSource` still has to
+feature-detect them — but the adapter implements both unconditionally and the
+factory declares the adapter, so the value from Quick Start calls them directly:
 
 ```typescript
-import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
 type User = { id: string; name: string; email: string };
 
-const adapter = new ObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
+const adapter = createObjectStackAdapter<User>({ baseUrl: 'https://api.example.com' });
 
 await adapter.bulk('user', 'create', [
   { name: 'Alice', email: 'alice@example.com' },
@@ -463,17 +500,18 @@ An `AuthenticationError` (code `AUTHENTICATION_ERROR`, status 401) means the
 `token` passed to `createObjectStackAdapter` was missing, expired or rejected.
 Check the connection state and the values you passed in:
 
-Connection introspection lives on the adapter class, not on the `DataSource`
-interface, so hold it at the class type:
+Connection introspection lives on the adapter, not on the `DataSource` interface
+— and the factory declares the adapter, so the value from Quick Start reaches it
+without a second construction:
 
 ```typescript
-import { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
-const adapter = new ObjectStackAdapter({ baseUrl: 'https://api.example.com' });
+const dataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com' });
 
-console.log(adapter.getConnectionState()); // 'connected' | 'error' | ...
+console.log(dataSource.getConnectionState()); // 'connected' | 'error' | ...
 
-adapter.onConnectionStateChange((event) => {
+dataSource.onConnectionStateChange((event) => {
   if (event.error) console.error('Connection error:', event.error);
 });
 ```

--- a/packages/data-objectstack/README.md
+++ b/packages/data-objectstack/README.md
@@ -44,16 +44,6 @@ function App() {
 }
 ```
 
-> **Reaching the adapter-only API from TypeScript.** `createObjectStackAdapter`
-> declares `DataSource` as its return type, so the members below that belong to the
-> adapter rather than to every data source — `getClient`, the cache methods, the
-> connection-state and batch-progress subscriptions — are not on the type the factory
-> hands back, even though they are on the object it hands back. Until
-> [#7323](https://github.com/objectstack-ai/objectui/issues/7323) is settled, hold the
-> adapter as `ObjectStackAdapter` (the exported class, whose constructor is documented
-> under **API Reference** below) wherever you use those members; the examples in this
-> README do exactly that.
-
 ### Advanced Configuration
 
 ```typescript
@@ -258,9 +248,9 @@ await dataSource.find('users', {
 The adapter includes built-in metadata caching to improve performance when fetching schemas:
 
 ```typescript
-import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
-declare const dataSource: ObjectStackAdapter;
+const dataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com' });
 
 // Get cache statistics
 const stats = dataSource.getCacheStats();
@@ -288,9 +278,9 @@ dataSource.clearCache();
 The adapter provides real-time connection state monitoring with automatic reconnection:
 
 ```typescript
-import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
-declare const dataSource: ObjectStackAdapter;
+const dataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com' });
 
 // Monitor connection state changes
 const unsubscribe = dataSource.onConnectionStateChange((event) => {
@@ -336,9 +326,9 @@ The adapter automatically attempts to reconnect on connection failures:
 Track progress of bulk operations in real-time:
 
 ```typescript
-import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
-declare const dataSource: ObjectStackAdapter;
+const dataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com' });
 
 declare const largeDataset: Array<Record<string, unknown>>;
 
@@ -712,9 +702,9 @@ const dataSource = createObjectStackAdapter({
 #### Cache Issues
 
 ```typescript
-import type { ObjectStackAdapter } from '@object-ui/data-objectstack';
+import { createObjectStackAdapter } from '@object-ui/data-objectstack';
 
-declare const dataSource: ObjectStackAdapter;
+const dataSource = createObjectStackAdapter({ baseUrl: 'https://api.example.com' });
 
 // Clear cache if stale data is being returned
 dataSource.clearCache();

--- a/packages/data-objectstack/src/adapterFactoryReturn.types.test.ts
+++ b/packages/data-objectstack/src/adapterFactoryReturn.types.test.ts
@@ -1,0 +1,162 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { DataSource } from '@object-ui/types';
+import { createObjectStackAdapter, ObjectStackAdapter } from './index';
+
+/**
+ * `createObjectStackAdapter`'s declared return is the adapter, not the shared
+ * `DataSource` interface (#7323).
+ *
+ * The factory declared `DataSource<T>` while returning `new ObjectStackAdapter`.
+ * A wider value is assignable to a narrower annotation, so nothing failed to
+ * compile — the loss was entirely on the reading side: every adapter-only
+ * member was erased from the type the factory handed back, while staying on the
+ * object it handed back. Measured on the shipped `dist/index.d.ts` before the
+ * fix, nine reads through `ReturnType<typeof createObjectStackAdapter>` failed
+ * with TS2339: `getClient`, `getCacheStats`, `invalidateCache`, `clearCache`,
+ * `getConnectionState`, `isConnected`, `onConnectionStateChange`,
+ * `onBatchProgress`, `setSystemCapabilities`. Eight of those are exactly the
+ * members the package README's API Reference documents, and the ninth is the
+ * one the factory's own JSDoc links to.
+ *
+ * ## Where these pins get their colour
+ *
+ * Most of this file is COMPILE-time, which is the only place this defect is
+ * observable: the values were always there, so every runtime test passed
+ * against the narrow declaration too. `vitest` transpiles with esbuild and
+ * erases types, so the colour comes from
+ * `pnpm --filter @object-ui/data-objectstack type-check` — this package's
+ * `tsconfig.json` includes its whole `src/**` (tests included), the same
+ * property `deleteViewContract.types.test.ts` documents and relies on.
+ *
+ * ## The controls
+ *
+ * Two, and they answer different questions.
+ *
+ *   1. `_NotOnDataSource` — the adapter-only members are ABSENT from the shared
+ *      `DataSource` interface. This is what makes the reads below a statement
+ *      about the FACTORY's return rather than a statement about every data
+ *      source. It also fires on option B of the card (moving caching,
+ *      connection state and batch progress onto `DataSource` so every
+ *      implementation has to declare them) — the shape #7323 argues against.
+ *   2. `_StillADataSource` — the widened return is still assignable to
+ *      `DataSource`. The triage's open question was whether the narrow return
+ *      was a deliberate swappability guarantee; this states that widening did
+ *      not cost it, so a caller who wants the narrow surface still just writes
+ *      `const ds: DataSource = createObjectStackAdapter(…)`.
+ *
+ * Both controls are independent of the return annotation, so a revert of the
+ * source change turns the reads below red and leaves these two green.
+ */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+  ? true
+  : false;
+
+type FactoryReturn = ReturnType<typeof createObjectStackAdapter>;
+
+describe('createObjectStackAdapter declares the adapter it returns (#7323)', () => {
+  it('exposes the adapter-only members the README documents', () => {
+    const dataSource = createObjectStackAdapter({ baseUrl: 'http://test.local' });
+
+    // The card's own TS2339 reproduction, inverted into a pin. Each read is a
+    // compile error the moment the declared return narrows back. They are real
+    // calls rather than a type-only region because every one of them is inert
+    // on an adapter that has never connected, so the same nine lines carry the
+    // runtime half too.
+    expect(dataSource.getClient()).toBeDefined();
+    expect(dataSource.getCacheStats()).toBeDefined();
+    dataSource.invalidateCache('users');
+    dataSource.invalidateCache();
+    dataSource.clearCache();
+    expect(dataSource.getConnectionState()).toBe('disconnected');
+    expect(dataSource.isConnected()).toBe(false);
+    expect(typeof dataSource.onConnectionStateChange(() => {})).toBe('function');
+    expect(typeof dataSource.onBatchProgress(() => {})).toBe('function');
+    dataSource.setSystemCapabilities(['manage_view_config']);
+
+    // ...and the same nine through the named type, because a consumer who
+    // annotates a field or a hook's return writes the type, not the call.
+    type _HasHiddenMembers = Assert<
+      'getClient' extends keyof FactoryReturn
+        ? 'getCacheStats' extends keyof FactoryReturn
+          ? 'invalidateCache' extends keyof FactoryReturn
+            ? 'clearCache' extends keyof FactoryReturn
+              ? 'getConnectionState' extends keyof FactoryReturn
+                ? 'isConnected' extends keyof FactoryReturn
+                  ? 'onConnectionStateChange' extends keyof FactoryReturn
+                    ? 'onBatchProgress' extends keyof FactoryReturn
+                      ? 'setSystemCapabilities' extends keyof FactoryReturn
+                        ? true
+                        : false
+                      : false
+                    : false
+                  : false
+                : false
+              : false
+            : false
+          : false
+        : false
+    >;
+
+    // Identity, not mere assignability: two structurally similar declarations
+    // are mutually assignable, so only `Equal` can tell "the factory returns
+    // THE adapter type" from "the factory returns something adapter-shaped".
+    type _IsTheAdapter = Assert<Equal<FactoryReturn, ObjectStackAdapter<unknown>>>;
+
+    expect(true).toBe(true);
+  });
+
+  it('CONTROL — the adapter-only members are not on the shared DataSource', () => {
+    // Fires if anyone answers #7323 by widening `DataSource` itself (option B).
+    type _NotOnDataSource = Assert<
+      'getCacheStats' extends keyof DataSource
+        ? false
+        : 'onConnectionStateChange' extends keyof DataSource
+          ? false
+          : 'getClient' extends keyof DataSource
+            ? false
+            : true
+    >;
+
+    expect(true).toBe(true);
+  });
+
+  it('CONTROL — the widened return is still a DataSource', () => {
+    // Swappability, the property the narrow return was suspected of protecting.
+    type _StillADataSource = Assert<FactoryReturn extends DataSource<unknown> ? true : false>;
+
+    const dataSource: DataSource = createObjectStackAdapter({ baseUrl: 'http://test.local' });
+    expect(typeof dataSource.find).toBe('function');
+  });
+
+  it('the value really carries what the declaration now promises', () => {
+    // Declared = shipped. Compile-time reachability is worth nothing if the
+    // object does not actually have the members, so this half is runtime.
+    const dataSource = createObjectStackAdapter({ baseUrl: 'http://test.local' });
+
+    for (const member of [
+      'getClient',
+      'getCacheStats',
+      'invalidateCache',
+      'clearCache',
+      'getConnectionState',
+      'isConnected',
+      'onConnectionStateChange',
+      'onBatchProgress',
+      'setSystemCapabilities',
+    ] as const) {
+      expect(typeof dataSource[member]).toBe('function');
+    }
+
+    expect(dataSource).toBeInstanceOf(ObjectStackAdapter);
+  });
+});

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -5652,6 +5652,21 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
 
 /**
  * Factory function to create an ObjectStack data source.
+ *
+ * The declared return is `ObjectStackAdapter<T>`, not the shared
+ * `DataSource<T>` interface: the object this hands back is an
+ * `ObjectStackAdapter`, and the adapter-only members the package README
+ * documents — `getClient`, the metadata-cache controls, the connection-state
+ * and batch-progress subscriptions, and `setSystemCapabilities` — live on the
+ * class, not on `DataSource`. Declaring the interface here narrowed all of them
+ * away from the factory while leaving them on the value (objectui#7323), so
+ * `createObjectStackAdapter(...)` and `new ObjectStackAdapter(...)` — the two
+ * documented ways to obtain the same object — handed back different type
+ * surfaces. ⛔ Do not narrow this back to `DataSource<T>`: a caller who wants
+ * the narrow surface writes `const ds: DataSource = createObjectStackAdapter(…)`
+ * and gets it, because a wider return is assignable to the narrower annotation;
+ * the reverse is not recoverable at the call site without a cast.
+ * `adapterFactoryReturn.types.test.ts` pins both directions.
  * 
  * @example
  * ```typescript
@@ -5677,7 +5692,7 @@ export function createObjectStackAdapter<T = unknown>(config: {
   reconnectDelay?: number;
   /** [ADR-0066] See {@link ObjectStackAdapter.setSystemCapabilities}. */
   systemCapabilities?: string[];
-}): DataSource<T> {
+}): ObjectStackAdapter<T> {
   return new ObjectStackAdapter<T>(config);
 }
 


### PR DESCRIPTION
Fixes #7323

`createObjectStackAdapter` returned `new ObjectStackAdapter(config)` while declaring the shared `DataSource` interface as its return. A wider value is assignable to a narrower annotation, so nothing ever failed to compile — the loss was entirely on the reading side: every adapter-only member was erased from the type the factory hands back, while staying on the object it hands back.

**Measured before the change**, compiling against the shipped `packages/data-objectstack/dist/index.d.ts` with the doc-snippet gate's own compiler options (strict, bundler resolution): **9 x TS2339**, not the 4 the card lists — `getClient`, `getCacheStats`, `invalidateCache`, `clearCache`, `getConnectionState`, `isConnected`, `onConnectionStateChange`, `onBatchProgress`, `setSystemCapabilities`. Eight of those are exactly the members the README's **API Reference — Methods** list documents; the ninth is the one the factory's own JSDoc links to (`[ADR-0066] See ObjectStackAdapter.setSystemCapabilities`). The same probe after this change: **0 diagnostics**.

## The two questions that decided the shape

The triage set these as a stop-condition and both are answered from the code, on `origin/main` `e17605309`.

**Q1 — is `ObjectStackAdapter` exported from the package's public entry? Yes, already.** `packages/data-objectstack/src/index.ts:2148` reads `export class ObjectStackAdapter`, and `tsup.config.ts` has exactly one entry, `src/index.ts`. The class is in the shipped `dist/index.d.ts` export list (verified in the built artifact, not inferred). Two pin tests already assert the exported spelling in source — `cloud-surface-retired-4152.pin.test.ts:114` and `v3-deep-integration-retired-4241.pin.test.ts:135` — and `apps/console/src/dataSource.ts:14` re-exports it by name. **So this PR exports nothing by implication**: the export list in `dist/index.d.ts` is unchanged, name for name, before and after.

**Q2 — is the narrow return deliberate? No, and there are two pieces of evidence against it.**

1. Commit `a5d817061` ("Add connection state monitoring, auto-reconnect, and batch progress") added `autoReconnect` / `maxReconnectAttempts` / `reconnectDelay` to the **factory's own config bag** while leaving the members that observe those features off the factory's declared return. The same change configured a feature it made unobservable through its own entry point. That is an oversight shape, not an encapsulation decision.
2. The factory's JSDoc, added by `41b7ce3ce`, points the reader at `ObjectStackAdapter.setSystemCapabilities` — a member its declared return hides.

Nothing anywhere pins the return: no comment, no ADR, no test, no `Equal` assertion, and no swappability note. Searched the export list, `package.json` `files` / `exports`, ADR-0066, the sibling adapters, and every test that names the factory.

Had either answer come back the other way this would have been a docs-only PR. They did not, so it is option **A** — and swappability, the property the narrow return was suspected of protecting, is not lost: a wider return is assignable to the narrower annotation, so `const ds: DataSource = createObjectStackAdapter(...)` still compiles and still gives the narrow surface. There is a control test that says exactly that.

## Why A and not B or C

**B** (add the missing members to `DataSource`) would make every other `DataSource` implementation declare caching, connection state and batch progress it does not have — those are this adapter's concerns. **C** (document a cast) teaches a cast around a declaration that is merely narrower than the value, which is the opposite of `declared = enforced`. **A** is one line and makes declared match shipped for every documented member at once.

## The pin

`packages/data-objectstack/src/adapterFactoryReturn.types.test.ts` — the card's TS2339 reproduction, inverted. It reads all nine members through the factory's return, asserts the return's identity with `Equal` (not mere assignability — two adapter-shaped declarations are mutually assignable, so only identity can tell "returns THE adapter" from "returns something adapter-shaped"), and carries **two controls**:

- `_NotOnDataSource` — the adapter-only members stay ABSENT from the shared `DataSource`. This is what makes the reads a statement about the factory's return rather than about every data source, and it fires on option B.
- `_StillADataSource` — the widened return is still assignable to `DataSource`.

Both controls are independent of the return annotation, so reverting the source change turns the reads red and leaves the controls green. That split is measured below, not asserted.

**Which tree the pin exercises.** Two, deliberately. The test is compiled by `pnpm --filter @object-ui/data-objectstack type-check`, whose program includes the whole `src/**` (tests included) and resolves `./index` from **`src`** — proven with `--listFiles`: 1 hit for the new file, 55 test files, `src/index.ts` present. `@object-ui/types` in that same program resolves from **`packages/types/dist`**, so the type used for the controls is the shipped one. The README blocks are the **`dist`** half: `check:doc-snippets` compiles them against the built `dist/*.d.ts` (its own resolution control prints `'@object-ui/types' was successfully resolved to packages/types/dist/index.d.ts`).

## Documentation

The README note naming this card (added by #5174 batch 8) is removed. The four sections built on the adapter-only members — Metadata Caching, Connection State Monitoring, Batch Operation Progress, Troubleshooting → Cache Issues — now continue from Basic Setup's `createObjectStackAdapter(...)` call instead of hand-declaring the class, so the page teaches one shape and the doc-snippet gate pins the fix against `dist`. The other README blocks still declare the class where they only need `DataSource`-level members; that is truthful (the class is public and documented) and rewriting them buys nothing, so they are left alone.

`setSystemCapabilities` is still absent from the README's Methods list. It was absent before this PR too, it is a separate doc gap, and adding it here would be scope this card did not ask for.

## Verification — every number below was observed, at head `922ca54ec`

| Check | Command | Result |
| --- | --- | --- |
| Package type-check | `pnpm --filter @object-ui/data-objectstack type-check` | exit 0, `tsc --noEmit` echoed |
| Package tests | `pnpm exec vitest run --maxWorkers=2 packages/data-objectstack/` (repo root — a package-dir run is refused by objectui#3378's guard) | **55 files, 737 tests, all passed** |
| `check:doc-snippets` | `node scripts/check-doc-snippet-types.mjs` | exit 0 — *"Semantic phase: 455 of 455 block(s) judged, 0 failed."* / *"Every covered documentation snippet compiles against the built types."* |
| `check:readme-exports` | `pnpm check:readme-exports` | exit 0 — *"OK (43 tracked README(s) ...; 414 self-imports judged (414 real, 0 wrong-path, 0 fabricated); 3305 export symbol(s) read from 37 of 40 tracked package(s) (0 unbuilt ...))"* |
| changeset presence | `node scripts/check-changeset-presence.mjs` | exit 0 — *"1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"* |
| `check:doc-fences` | `node scripts/check-doc-fence-languages.mjs` | exit 0 — *"every TypeScript block in 227 document(s) is fenced ts/tsx/typescript ..."* |
| control bytes | `node scripts/check-control-bytes.mjs` | exit 0 — *"OK (scanned 6180 tracked text file(s); skipped 85 binary)"* |
| Package lint | `pnpm --filter @object-ui/data-objectstack lint` | exit 0 — **423 problems, 0 errors, 423 warnings**, all pre-existing `no-explicit-any`; the new file contributes **0 findings** (`eslint --format json` on the two changed source files: new test 0/0) |

Every gate result above is quoted from the gate's own verdict line; exit codes were captured by redirecting first and reading `$?` before any pipe.

Dependency closure built first (`pnpm --filter '@object-ui/data-objectstack...' build`, then the doc-snippet gate's own derived `--build-filter`: 26 packages, 34 turbo tasks, then `--filter='./packages/*'` for `check:readme-exports`, which had reported 2 unbuilt packages — a *"could not run"*, not a defect).

**Lint scope, declared:** the table's lint row is the changed package only, not the repo. `pnpm lint` here is `turbo run lint` (each package's own `eslint .`), and CI runs it in full regardless. One reading that needs stating: a separate probe with `eslint --no-inline-config` reports **4 errors** in `src/index.ts` at lines 1369–1389. Those are the documented `eslint-disable-next-line no-console` sites for the spec `Logger` binding (objectui#4029), they are ~4300 lines from either of my edits, and they are invisible to the lint CI actually runs because it honours inline config. Not introduced here, and not silently omitted either.

## Reverse verification — red/green split, both directions proven on disk

Method: commit first, then mutate `packages/data-objectstack/src/index.ts` back to the narrow return under `trap ... EXIT INT TERM` with an absolute restore path, prove the mutation landed by counting the injected and removed text (not by the editor's exit code) and by comparing blob hashes, then restore and prove the restore **by state**.

Mutation landed: injected-text count 0 → 1, removed-text count 1 → 0; mutated blob `447fffc8` differs from HEAD blob `bad31df4`.

**Leg 1 — the src pin, no rebuild needed** (the pin imports `./index` from `src`; the mutation cannot reach `packages/types/dist`, which is where its `DataSource` comes from):

- 13 diagnostics total, **every one of them inside the pin file**, 0 anywhere else in the package.
- 10 x TS2339 at lines 75–84: the nine member reads (`invalidateCache` twice, with and without an argument).
- TS2344 at 89 and 113: the `_HasHiddenMembers` and `_IsTheAdapter` assertions.
- TS7053 at 157: the runtime member sweep can no longer index the narrowed type.
- **The controls at lines 120 (`_NotOnDataSource`) and 135 (`_StillADataSource`) produced ZERO diagnostics** — the split the pin was designed for.
- `vitest` on the same mutated tree still passes, which is the point: esbuild erases types, so the colour comes from `tsc` and from nowhere else.

**Leg 2 — the dist pin, rebuilt in both directions.** Rebuilt from the mutated source, then a dist preflight: the widened marker count in `dist/index.d.ts` was **0** (the mutation reached `dist`). The standalone dist probe then reproduced the card's failure exactly — **9 x TS2339** — and `check:doc-snippets` went to **exit 1, "455 of 455 block(s) judged, 4 failed"**: precisely the four README sections this PR rewired, failing on `getCacheStats`, `invalidateCache` x2, `clearCache`, `onConnectionStateChange`, `getConnectionState`, `isConnected`, `onBatchProgress`, `clearCache`, `invalidateCache`.

**Restore, proven by state, both halves.** Source: restored blob `bad31df4` equals HEAD's blob and `git diff HEAD` is 0 bytes. `dist`: rebuilt again, widened marker back to **1** and narrow marker **0**, dist probe back to **0 diagnostics**, `check:doc-snippets` back to **exit 0, 0 failed**. The restore leg is rebuilt on purpose — a mutated marker left in `dist` would keep acting on every later run in this tree.

## Clause ②

**`Clause-②: yes`**, declared in the claim comment on #7323 in the fixed machine spelling, and `needs:contract-review` is on both carriers (this PR and the card). It widens the declared public surface reachable through a published entry point. Q1's answer removes the triage's specific worry — no class is exported by implication — but the declaration limb is judged from content, not from paths or from diff size.

**The one compatibility note a reviewer should weigh.** The widened return is a class with private members, so it is no longer satisfied by a hand-written structural stand-in: an object literal assigned to the factory's `ReturnType` will now be rejected where it used to be accepted. Nothing in this repo does that (searched every test and app that names the factory — `apps/console/src/dataSource.ts` only re-exports it), and the fix for a downstream consumer is to annotate such a fake as `DataSource`, which is what it was standing in for. It is the only direction in which this change is not purely additive, and it belongs in the contract review rather than in a footnote.

Draft on purpose, not flipped ready, auto-merge not enabled — the seat lands it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_