### PR TITLE
feat(plugin-form): publish the parameter types of the entry's exported functions

### DIFF
--- a/.changeset/7324-plugin-form-nameable-parameter-types.md
+++ b/.changeset/7324-plugin-form-nameable-parameter-types.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/plugin-form': minor
+---
+
+Publish the parameter types of the entry's own exported functions, so a consumer can
+name what it must pass (objectui#7324).
+
+`ChildObjectSchemaLike` and `FieldDefaultsSchemaLike` are now exported from
+`@object-ui/plugin-form`. They are **type-only** additions — no runtime name is added
+to the entry, which is pinned.
+
+**Why `minor`, not `patch`.** Nothing breaks and no behaviour changes, but two names
+join the published surface of a published package. Additions are `minor` in this repo,
+and a new public export is the kind of addition a consumer's lockfile-pinned range
+should be able to see.
+
+**What was wrong.** Five exported derive functions (`deriveDetail`, `deriveColumns`,
+`deriveFormFields`, `findRelationshipField`, `resolveInlineMode`) take a `childSchema`,
+and the exported `omitServerResolvedDefaults` takes an `objectSchema` — and neither
+parameter type reached the entry. A host with its own form renderer (the reason
+objectui#6059 published `omitServerResolvedDefaults` in the first place) has to hold
+that schema in a variable or a prop, and could not annotate it. Structural typing means
+such a host still compiled by writing the shape out by hand, so the cost was not a hard
+failure but a producer-owned shape restated in every consumer, invisible to every gate
+until the producer's shape moved. The package README carried exactly that restatement,
+and now imports the real name instead.
+
+**Renamed at the declaration site first, deliberately.** Both types were called
+`ObjectSchemaLike`, in two files, and they are **not** the same type: the defaults one
+pins the four field members its rule reads (`defaultValue`, `type`, `reference`,
+`reference_to`), while the child one leaves a field value as `any` because the derive
+functions read much more of it. Measured with `tsc`, they are mutually assignable
+**only** through that `any` — replace it with `unknown` and the child → defaults
+direction fails (TS2322) — so re-exporting either under the shared name would have put
+a name on the public surface that already meant something else two files over, with
+nothing in the name to say which. Neither old name was reachable from outside the
+package (the package `exports` map has a single `.` entry and the entry never re-exported
+them), so the rename is not a break for any consumer.
+
+**Not** `@object-ui/types`' `ObjectSchemaMetadata`: measured, it requires `name`,
+requires a `type` on every field, and has no `reference_to` member — while
+`isCurrentUserSeedField` honours both `reference` and `reference_to` on purpose. Adopting
+it would have narrowed what these functions accept and dropped one of the two honoured
+spellings, not widened anything.

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -122,6 +122,8 @@ import type {
   LineItemsPanelSchema,
   DerivedDetail,
   InlineMode,
+  ChildObjectSchemaLike,
+  FieldDefaultsSchemaLike,
 } from '@object-ui/plugin-form';
 ```
 
@@ -338,9 +340,13 @@ renderer applies the same rule rather than re-deriving it (objectui#6059):
 declare const field: { required?: unknown; defaultValue?: unknown };
 declare const isCreateForm: boolean;
 declare const values: Record<string, unknown>;
-declare const objectSchema: { fields?: Record<string, { defaultValue?: unknown }> };
+declare const objectSchema: FieldDefaultsSchemaLike;
 
-import { isRequiredInForm, omitServerResolvedDefaults } from '@object-ui/plugin-form';
+import {
+  isRequiredInForm,
+  omitServerResolvedDefaults,
+  type FieldDefaultsSchemaLike,
+} from '@object-ui/plugin-form';
 
 // Should this create form enforce `required` on the field?
 const required = isRequiredInForm(field, isCreateForm);

--- a/packages/plugin-form/src/__tests__/parameterTypesNameable-7324.test.ts
+++ b/packages/plugin-form/src/__tests__/parameterTypesNameable-7324.test.ts
@@ -1,0 +1,161 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7324 — the parameter types of this package's published functions
+ * are themselves published, so a consumer can NAME what it must pass.
+ *
+ * ## What went wrong, and why one `export` line would have made it worse
+ *
+ * Two DIFFERENT shapes carried the SAME name `ObjectSchemaLike` in two files
+ * of this package, and neither reached the entry:
+ *
+ *   - `deriveMasterDetail.ts` — `{ name?, fields?: Record<string, any> }`, the
+ *     `childSchema` of five functions the entry exports;
+ *   - `schemaDefaults.ts` — `{ fields?: Record<string, {defaultValue?, type?,
+ *     reference?, reference_to?} | undefined> }`, the `objectSchema` of
+ *     `omitServerResolvedDefaults`, which the entry also exports.
+ *
+ * Re-exporting either under the shared name would have put a name on the
+ * package's public surface that already meant something else two files over,
+ * with nothing in the name to say which. So each was renamed at its
+ * declaration site first: `ChildObjectSchemaLike` and
+ * `FieldDefaultsSchemaLike`.
+ *
+ * ## Why the type-level half is the load-bearing half
+ *
+ * These are types. `import * as entry` cannot see them at runtime, so "the
+ * name is importable" is only assertable by ANNOTATING with it and letting
+ * `tsc` judge — this file is compiled by the package's `type-check`
+ * (`tsc -p tsconfig.test.json`), which is where the pin actually bites. The
+ * runtime `describe` below carries the one fact that IS runtime-visible and is
+ * the thing a "widens the public surface" card must not get wrong: a
+ * type-only export adds no runtime name.
+ *
+ * ## The controls
+ *
+ * `ChildObjectSchemaLike` and `FieldDefaultsSchemaLike` are MUTUALLY
+ * ASSIGNABLE as written — measured, `tsc` accepts both directions — but only
+ * because the child one's field values are `any`. So assignability cannot tell
+ * them apart, and a control built on it would pass no matter which of the two
+ * were exported under either name. The controls below are built on the two
+ * facts `any` does not erase: the member SETS differ (`name` exists on one
+ * only), and one's field value is `any` where the other's is pinned to four
+ * members. Export the wrong declaration under either name and
+ * `WRONG_ONE_EXPORTED_CONTROL` stops type-checking.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  deriveColumns,
+  omitServerResolvedDefaults,
+  type ChildObjectSchemaLike,
+  type FieldDefaultsSchemaLike,
+} from '../index';
+
+/** Invariant type equality — `Equals<X, X>` is `true`, anything else `false`. */
+type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+
+/** `true` only for `any` (the one type that is both a subtype and a supertype of `1 & T`). */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type ChildFieldValue = NonNullable<ChildObjectSchemaLike['fields']>[string];
+type DefaultsFieldValue = NonNullable<NonNullable<FieldDefaultsSchemaLike['fields']>[string]>;
+
+/**
+ * PIN — each published name names the shape it is supposed to name.
+ *
+ * Every line is a compile-time assertion: the annotation is the test, and the
+ * literal on the right is what the type must evaluate to.
+ */
+const PIN = {
+  /** The child schema carries the object's `name`; the defaults one does not. */
+  childKeys: true satisfies Equals<keyof ChildObjectSchemaLike, 'name' | 'fields'>,
+  defaultsKeys: true satisfies Equals<keyof FieldDefaultsSchemaLike, 'fields'>,
+  /** The child one deliberately does not constrain a field value. */
+  childFieldValueIsAny: true satisfies IsAny<ChildFieldValue>,
+  /** The defaults one pins exactly the four members its rule reads. */
+  defaultsFieldValueIsPinned: false satisfies IsAny<DefaultsFieldValue>,
+  defaultsFieldMembers: true satisfies Equals<
+    keyof DefaultsFieldValue,
+    'defaultValue' | 'type' | 'reference' | 'reference_to'
+  >,
+} as const;
+
+/**
+ * CONTROL — would fire if the WRONG one of the two were exported.
+ *
+ * If a future edit publishes one declaration under both names (the
+ * "deduplicate them" mistake this card measured its way out of), or swaps
+ * which name points at which declaration, `Equals` here becomes `true` or the
+ * per-name pins above flip. Assignability would NOT catch either: the two are
+ * mutually assignable today, through `any`.
+ */
+const WRONG_ONE_EXPORTED_CONTROL = false satisfies Equals<
+  ChildObjectSchemaLike,
+  FieldDefaultsSchemaLike
+>;
+
+/**
+ * The consumer this card is about: a host with its own form renderer, holding
+ * the schema it will pass in an ANNOTATED variable — the thing that was
+ * impossible before. If the published name stopped naming the right shape,
+ * these annotations would stop compiling.
+ */
+const consumerHeldDefaultsSchema: FieldDefaultsSchemaLike = {
+  fields: {
+    created_at: { defaultValue: 'NOW()' },
+    owner: { defaultValue: 'current_user', type: 'lookup', reference_to: 'sys_user' },
+    stage: { defaultValue: 'draft' },
+  },
+};
+
+const consumerHeldChildSchema: ChildObjectSchemaLike = {
+  name: 'order_line',
+  fields: {
+    product: { type: 'lookup', reference: 'product', label: 'Product' },
+    qty: { type: 'number', label: 'Qty' },
+  },
+};
+
+describe('objectui#7324 — published parameter types are nameable', () => {
+  it('type-level pins and controls hold (the annotations above are the assertion)', () => {
+    expect(PIN.childKeys).toBe(true);
+    expect(PIN.defaultsKeys).toBe(true);
+    expect(PIN.childFieldValueIsAny).toBe(true);
+    expect(PIN.defaultsFieldValueIsPinned).toBe(false);
+    expect(PIN.defaultsFieldMembers).toBe(true);
+    expect(WRONG_ONE_EXPORTED_CONTROL).toBe(false);
+  });
+
+  it('a schema held under the published name flows through the published function', () => {
+    const payload = omitServerResolvedDefaults(
+      { created_at: '', stage: 'draft', note: 'kept' },
+      consumerHeldDefaultsSchema,
+    );
+    // `created_at` declares a runtime default and arrived empty -> the key is
+    // dropped so the producer resolves it. Nothing else moves.
+    expect(payload).toEqual({ stage: 'draft', note: 'kept' });
+    expect('created_at' in payload).toBe(false);
+  });
+
+  it('a child schema held under the published name flows through the published deriver', () => {
+    const columns = deriveColumns(consumerHeldChildSchema, { relationshipField: 'product' });
+    expect(columns.map((c) => c.name)).toContain('qty');
+    expect(columns.map((c) => c.name)).not.toContain('product');
+  });
+
+  it('adds no RUNTIME name to the entry — both additions are type-only', async () => {
+    const entry = await import('../index');
+    expect(Object.keys(entry)).not.toContain('ChildObjectSchemaLike');
+    expect(Object.keys(entry)).not.toContain('FieldDefaultsSchemaLike');
+    // The pair #6059 published is still there, unchanged.
+    expect(typeof entry.omitServerResolvedDefaults).toBe('function');
+    expect(typeof entry.isRequiredInForm).toBe('function');
+  });
+});

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -15,8 +15,27 @@
 
 import type { GridColumn } from '@object-ui/fields';
 
-/** Minimal shape of an object schema as returned by `DataSource.getObjectSchema`. */
-export interface ObjectSchemaLike {
+/**
+ * Minimal shape of a MASTER-DETAIL CHILD object's schema, as returned by
+ * `DataSource.getObjectSchema` — the `childSchema` parameter of every derive
+ * function below (objectui#7324).
+ *
+ * Named for the child because that is the only thing it is ever used for, and
+ * because `schemaDefaults.ts` holds a DIFFERENT shape under what used to be
+ * the same name (`FieldDefaultsSchemaLike` now). The two are not
+ * interchangeable: this one's field values are `any` — these functions read a
+ * field's `type`, `label`, `options`, `hidden`, `reference` and more — while
+ * the defaults one pins the four members that rule reads. Publishing both
+ * under one name would have put a name on the package surface that already
+ * meant something else two files over.
+ *
+ * NOT `@object-ui/types`' `ObjectSchemaMetadata`: that type requires `name`
+ * and requires a `type` on every field, so the partial schemas these
+ * functions are handed (and every fixture that exercises them) would stop
+ * compiling. This is a deliberately structural parameter type — pass the
+ * object document your data source serves.
+ */
+export interface ChildObjectSchemaLike {
   name?: string;
   fields?: Record<string, any>;
 }
@@ -118,7 +137,7 @@ function optionsFor(def: any): GridColumn['options'] | undefined {
  * `master_detail` over `lookup` when both exist.
  */
 export function findRelationshipField(
-  childSchema: ObjectSchemaLike | undefined,
+  childSchema: ChildObjectSchemaLike | undefined,
   parentObjectName: string,
 ): string | undefined {
   const fields = childSchema?.fields;
@@ -205,7 +224,7 @@ function curateColumns(cols: GridColumn[], max: number): GridColumn[] {
  * dropped). Pass `maxColumns: 0` to flag none.
  */
 export function deriveColumns(
-  childSchema: ObjectSchemaLike | undefined,
+  childSchema: ChildObjectSchemaLike | undefined,
   opts: { relationshipField?: string; exclude?: string[]; maxColumns?: number } = {},
 ): GridColumn[] {
   const fields = childSchema?.fields;
@@ -264,7 +283,7 @@ export function deriveColumns(
  */
 export function hydrateColumns(
   columns: GridColumn[] | undefined,
-  childSchema: ObjectSchemaLike | undefined,
+  childSchema: ChildObjectSchemaLike | undefined,
 ): GridColumn[] {
   const cols = columns ?? [];
   const fields = childSchema?.fields;
@@ -311,7 +330,7 @@ const NON_INPUT_TYPES = new Set(['formula', 'summary', 'rollup', 'autonumber', '
  * grid-friendly types): the form has room for textarea/richtext/file/etc.
  */
 export function deriveFormFields(
-  childSchema: ObjectSchemaLike | undefined,
+  childSchema: ChildObjectSchemaLike | undefined,
   opts: { relationshipField?: string; exclude?: string[] } = {},
 ): string[] {
   const fields = childSchema?.fields;
@@ -363,7 +382,7 @@ export const RICH_FIELD_FORM_THRESHOLD = 2;
  *     {@link SMART_FORM_FIELD_THRESHOLD} editable business fields; else a `grid`.
  */
 export function resolveInlineMode(
-  childSchema: ObjectSchemaLike | undefined,
+  childSchema: ChildObjectSchemaLike | undefined,
   inlineEdit: boolean | InlineMode | undefined,
   opts: { relationshipField?: string } = {},
 ): InlineMode {
@@ -426,7 +445,7 @@ export interface DerivedDetail {
  */
 export function deriveDetail(
   childObject: string,
-  childSchema: ObjectSchemaLike | undefined,
+  childSchema: ChildObjectSchemaLike | undefined,
   parentObjectName: string,
   override: { relationshipField?: string; columns?: GridColumn[]; amountField?: string; inlineEdit?: boolean | InlineMode } = {},
 ): DerivedDetail {

--- a/packages/plugin-form/src/index.tsx
+++ b/packages/plugin-form/src/index.tsx
@@ -66,7 +66,7 @@ export type {
 export { LineItemsPanel } from './LineItemsPanel';
 export type { LineItemsPanelSchema } from './LineItemsPanel';
 export { deriveDetail, deriveColumns, deriveFormFields, findRelationshipField, resolveInlineMode } from './deriveMasterDetail';
-export type { DerivedDetail, InlineMode } from './deriveMasterDetail';
+export type { DerivedDetail, InlineMode, ChildObjectSchemaLike } from './deriveMasterDetail';
 
 /**
  * The CREATE-payload rule this package owns, published for the OTHER form
@@ -100,6 +100,32 @@ export type { DerivedDetail, InlineMode } from './deriveMasterDetail';
  * thing #4085 collapsed.
  */
 export { omitServerResolvedDefaults, isRequiredInForm } from './schemaDefaults';
+
+/**
+ * The parameter types those published signatures require, so a consumer can
+ * NAME what it must pass (objectui#7324).
+ *
+ * Both were unnameable: `ChildObjectSchemaLike` is the `childSchema` of the
+ * five derive functions exported above, and `FieldDefaultsSchemaLike` is the
+ * `objectSchema` of `omitServerResolvedDefaults`. Neither reached this barrel,
+ * so a host held them in a variable it could not annotate and wrote the shape
+ * out by hand instead — a producer-owned shape copied into every consumer,
+ * which is what `declared = enforced` exists to prevent.
+ *
+ * Two names, not one. They arrived carrying the SAME name (`ObjectSchemaLike`)
+ * in two files, and they are not the same type: measured with `tsc`, the
+ * defaults one is a strict subtype of the child one, and the compiler calls
+ * them mutually assignable ONLY because the child one's field values are
+ * `any` — swap that single `any` for `unknown` and the child -> defaults
+ * direction fails (TS2322). Lifting either under the shared name would have
+ * put a name on this package's public surface that already meant something
+ * else two files over, with nothing in the name to say which.
+ *
+ * These are types, not values: they add no runtime surface, and each is the
+ * type a signature already published requires — not an adjacent name lifted
+ * because it was nearby.
+ */
+export type { FieldDefaultsSchemaLike } from './schemaDefaults';
 
 // Register object-form component
 const ObjectFormRenderer: React.FC<{ schema: any; dataSource?: unknown }> = elementDataSourceBlock(({

--- a/packages/plugin-form/src/schemaDefaults.ts
+++ b/packages/plugin-form/src/schemaDefaults.ts
@@ -85,8 +85,30 @@ import { isCurrentUserDefaultToken } from '@objectstack/spec/data';
 // `@object-ui/components` cannot depend on a `plugin-*` package.
 export { isRuntimeDefault };
 
-/** An object schema as the data source serves it (`{ fields: { [name]: def } }`). */
-interface ObjectSchemaLike {
+/**
+ * An object schema as the data source serves it (`{ fields: { [name]: def } }`),
+ * narrowed to the four field members THIS module's rule reads.
+ *
+ * Exported and published (objectui#7324) because `omitServerResolvedDefaults`
+ * is published and this is its second parameter: a host with its own form
+ * renderer has to hold that schema in a variable or a prop, and until now it
+ * could not name the variable's type. Structural typing meant such a host
+ * still compiled by writing the shape out by hand — which is a copy of a
+ * producer-owned shape in every consumer, invisible to every gate until the
+ * producer's shape moves.
+ *
+ * `FieldDefaults`, not `ObjectSchema`: `deriveMasterDetail.ts` holds a
+ * different shape that used to carry the same `ObjectSchemaLike` name, and the
+ * two are NOT interchangeable — see `ChildObjectSchemaLike` there. This one is
+ * the stricter of the pair (its field values are pinned, not `any`), so a
+ * value legal here is legal there but not the reverse.
+ *
+ * NOT `@object-ui/types`' `ObjectSchemaMetadata`: that type requires `name`,
+ * requires a `type` on every field, and has no `reference_to` member at all —
+ * and `isCurrentUserSeedField` below honours BOTH `reference` (the ObjectStack
+ * spelling) and `reference_to` (the objectui-types one) on purpose.
+ */
+export interface FieldDefaultsSchemaLike {
   fields?: Record<
     string,
     { defaultValue?: unknown; type?: unknown; reference?: unknown; reference_to?: unknown } | undefined
@@ -197,7 +219,7 @@ export function isRequiredInForm(
  * so callers can spread it unconditionally.
  */
 export function schemaDefaultValues(
-  objectSchema: ObjectSchemaLike | null | undefined,
+  objectSchema: FieldDefaultsSchemaLike | null | undefined,
   ctx?: SeedContext,
 ): Record<string, unknown> {
   const fields = objectSchema?.fields;
@@ -255,7 +277,7 @@ function isCurrentUserSeedField(
  * "leave this blank", not an absence.
  */
 export function seedCreateValues(
-  objectSchema: ObjectSchemaLike | null | undefined,
+  objectSchema: FieldDefaultsSchemaLike | null | undefined,
   initial?: Record<string, unknown> | null,
   ctx?: SeedContext,
 ): Record<string, unknown> {
@@ -291,7 +313,7 @@ export function seedCreateValues(
  */
 export function omitServerResolvedDefaults(
   data: Record<string, unknown>,
-  objectSchema: ObjectSchemaLike | null | undefined,
+  objectSchema: FieldDefaultsSchemaLike | null | undefined,
 ): Record<string, unknown> {
   if (!data || typeof data !== 'object') return data;
   const fields = objectSchema?.fields;


### PR DESCRIPTION
Fixes #7324

Head sha `e3ea71f03`. Every readout below was taken at that commit, on a clean tree.

⚠️ **Clause-② is yes** — this widens the published surface of `@object-ui/plugin-form` with two new type exports. `needs:contract-review` is on this PR and on #7324; it comes off only when the seat's contract review passes. Do not flip this ready.

---

## The structural comparison, which decides the fix

The triage's stop-condition was that this comparison be reported either way. Here it is, measured with `tsc`, not read off.

The two declarations that carried the name `ObjectSchemaLike`, side by side:

```ts
// packages/plugin-form/src/deriveMasterDetail.ts:19   (was `export interface`)
interface ObjectSchemaLike { name?: string; fields?: Record<string, any> }

// packages/plugin-form/src/schemaDefaults.ts:89       (was `interface`, no export)
interface ObjectSchemaLike {
  fields?: Record<string, { defaultValue?: unknown; type?: unknown; reference?: unknown; reference_to?: unknown } | undefined>;
}
```

**Assignable in each direction? Yes — both directions, as written.** `tsc --strict` accepts `const a: A = b` and `const b: B = a`, and accepts the conditional-type form `[A] extends [B]` and `[B] extends [A]` too. Exit 0, no diagnostics.

**That mutual assignability is an artifact of `any`, and nothing else.** Control: change the single token `Record<string, any>` to `Record<string, unknown>` in the child declaration, leaving everything else identical, and re-run:

```
error TS2322: Type 'A' is not assignable to type 'B'.
  Types of property 'fields' are incompatible.
    ... 'string' index signatures are incompatible.
      Type 'unknown' is not assignable to type '{ defaultValue?: unknown; type?: unknown; reference?: unknown; reference_to?: unknown; } | undefined'.
```

The `B -> A` direction keeps passing. So the true relation is **`B` is a strict structural subtype of `A`; `A` is not a subtype of `B`**, and the compiler says otherwise only because `any` suspends the check. They also differ in their member sets: `A` has `name`, `B` does not.

⇒ **Structurally different.** Per the stop-condition: do not export under this name. Renamed at the declaration site first, then exported.

## What was exported, and why two names

| declaration | renamed to | the published signatures that require it |
|:--|:--|:--|
| `deriveMasterDetail.ts` | `ChildObjectSchemaLike` | `deriveDetail`, `deriveColumns`, `deriveFormFields`, `findRelationshipField`, `resolveInlineMode` — **five** entry exports take it as `childSchema` |
| `schemaDefaults.ts` | `FieldDefaultsSchemaLike` | `omitServerResolvedDefaults` — **one** entry export takes it as `objectSchema` |

Both were unnameable from outside the package, so both are fixed. Publishing either under the shared name would have put a name on the public surface that already meant something else two files over, with nothing in the name to say which — which is exactly the hazard the triage flagged.

Neither old name was reachable by any consumer before this change: the package `exports` map has a single `.` entry, the entry never re-exported either name, and no file outside these two declarations referenced either. So the rename breaks nothing.

These are **type-only** exports. No runtime name joins the entry, and that is asserted rather than assumed.

## Option B was measured and refused — and it fails in the opposite direction from the card's guess

The card and the dispatch both expected `@object-ui/types`' object-schema type to **widen** what the functions accept. Measured against `ObjectSchemaMetadata` with the package's own `tsc`, it **narrows**, three ways:

- `error TS2322: Property 'name' is missing in type 'B' but required in type '{ name: string; ... }'` — the shipped type **requires** `name`.
- `error TS2741: Property 'type' is missing in type '{ defaultValue: number; }' but required` — it requires a `type` on **every** field, so the minimal `{ fields: { amount: { defaultValue: 1 } } }` that today's call sites and fixtures hand these functions would stop compiling.
- `error TS2551: Property 'reference_to' does not exist on type '{...}'. Did you mean 'reference'?` — it has no `reference_to` member at all, while `isCurrentUserSeedField` honours **both** `reference` (the ObjectStack spelling) and `reference_to` (the objectui-types one) deliberately, per its own docblock. Adopting the shipped type would make one of the two honoured spellings unreadable.

The one direction that does hold: `ObjectSchemaMetadata` **is** assignable to both local types, so a consumer already holding the shipped type can pass it to these functions today and could before this PR. Option B is refused on evidence, not on a hunch.

## The pin and its controls

`packages/plugin-form/src/__tests__/parameterTypesNameable-7324.test.ts`.

Because these are types, "the name is importable from the package root" is only assertable by annotating with it and letting `tsc` judge. Measured, not assumed, that the pin is actually compiled: `tsc -p tsconfig.test.json --listFiles` lists the new file (1 hit of 1630 files), and the package's other half `tsc --noEmit` does **not** (0 hits) — so the pin bites in the second leg of `type-check`.

Assignability cannot tell the two types apart — they are mutually assignable — so a control built on it would pass no matter which was exported. The controls are built on the two facts `any` does not erase: the member sets differ, and one field value is `any` where the other is pinned to four members.

## Verification — every number below was observed

Run from the repo root, heavy work serialized through the shared verify lock.

| check | verdict line quoted from the tool |
|:--|:--|
| `pnpm --filter '@object-ui/plugin-form...' build` (dependency closure) | `VERDICT command-exit 0` |
| `pnpm --filter @object-ui/plugin-form type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) | `VERDICT command-exit 0` |
| `vitest run packages/plugin-form` (repo root) | `Test Files 84 passed (84)` · `Tests 830 passed \| 8 skipped (838)` |
| `pnpm --filter @object-ui/plugin-form lint` | `✖ 762 problems (0 errors, 762 warnings)` — 0 errors; the warnings are the package's pre-existing baseline, and the diff adds no `any` token (checked on the diff itself) |
| `check:readme-exports` | `✅ check-readme-exports: OK (... 417 of them self-imports judged (417 real, 0 wrong-path, 0 fabricated); 3306 export symbol(s) read from 37 of 40 tracked package(s) ... 0 unbuilt ...)` |
| `check:doc-snippets` | `Semantic phase: 455 of 455 block(s) judged, 0 failed.` · `Every covered documentation snippet compiles against the built types.` |
| `check-changeset-presence.mjs` | `✅ 4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `check-changeset-fixed` / `-no-major` / `-overwrite` | `✅ All workspace packages are in the changeset fixed group.` · `✅ No changeset declares a 'major' bump.` · `✅ No pre-existing changeset was modified or deleted.` |
| `check:doc-fences` | `✅ check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript ...` |
| `check:entry-guard` | `✓ check:entry-guard: 62 scripts/ file(s) — no entry guard outside the baseline` |
| `check:self-import` | `✅ No package names itself inside its own src/.` |
| `check:dist-completeness --all` | `✓ dist completeness: 12 package(s) complete (1606 emitted files verified)` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 6171 tracked text file(s); skipped 85 binary).` |
| `check:side-effects-array` / `check:esm-specifiers` | exit 0 |

**Downstream consumers** (prefix direction — `--filter '...@object-ui/plugin-form'` = this package **and its dependents**): all 9 ran `type-check` and all 9 are clean, **0** `error TS` lines — `apps/console`, `apps/site`, `examples/byo-backend-console`, `examples/console-starter`, `examples/schema-catalog`, `packages/app-shell`, `packages/plugin-designer`, `packages/plugin-form`, `packages/plugin-view`. The script name is echoed once per package in the log, so this is not a zero-match run.

⚠️ One honest note on that: the first attempt reported `apps/site` failing with `TS2307: Cannot find module '@object-ui/example-schema-catalog'`. That is a missing build of an `examples/*` package (the earlier build filter was `./packages/*`), not this diff — no error named `plugin-form`. Building that example and re-running gave the clean result above. Recording it rather than quietly reporting only the green run.

## Reverse verification — three legs, each mutation proved on disk, each restore proved by state

Every leg ran with `trap '<restore>' EXIT INT TERM` and an absolute path; every restore is proved by `git status --porcelain` empty **and** `git hash-object <path>` equal to the `HEAD` blob, never by an exit code.

**RV-1 — revert the source over the new test; the pin must go red.** `index.tsx` reverted to `origin/main`; mutation proved on disk (`ChildObjectSchemaLike` occurrences 0, `FieldDefaultsSchemaLike` 0, the `origin/main` export line back at 1, blob `bd347781` ≠ HEAD `23ca478b`).

- 🔴 pin: `tsc -p tsconfig.test.json` **exit 2**, 6 errors, all naming the new file — `TS2305: Module '"../index"' has no exported member 'ChildObjectSchemaLike'`, same for `'FieldDefaultsSchemaLike'`, then four `TS1360` on the type-level assertions.
- 🟢 control: the pre-existing #6059 entry-surface suite stayed green — `Test Files 1 passed (1)` · `Tests 3 passed (3)`.
- restore: `HEAD=23ca478b… disk=23ca478b…` MATCH, `git status` empty.

**RV-2 — export the WRONG one of the two; the control must fire.** Replaced the defaults export with `export type { ChildObjectSchemaLike as FieldDefaultsSchemaLike } from './deriveMasterDetail';` — the exact mistake this card warns about, in the form a reviewer would most plausibly wave through. Mutation proved on disk (injected alias 1, original line 0, blob `8b087bd6` ≠ HEAD).

- 🔴 four `TS1360` errors fire: the defaults key set, the "field value is not `any`" pin, the four-member pin, and `WRONG_ONE_EXPORTED_CONTROL`.
- 🟢 and this is the point: the README snippet and the consumer-held literal still compile under that mutation. Assignability would have waved it through; these controls do not.
- restore: MATCH, `git status` empty.

**RV-3 — is the README block actually judged, or merely "covered"?** Fabricated the imported type name in that one snippet. `check:readme-exports` went **exit 1** and named the exact line: `packages/plugin-form/README.md:348 -- import { FieldDefaultsSchemaLikeSENTINEL } from '@object-ui/plugin-form'`, census `416 real, 1 fabricated`. So the README half is measured, not assumed. Restore: MATCH, `git status` empty.

## Also in this PR

- `packages/plugin-form/README.md` no longer hand-writes `{ fields?: Record<string, { defaultValue?: unknown }> }` for the #6059 snippet — it imports `FieldDefaultsSchemaLike`, which is the duplication this card is about. Both new names are added to the README's type inventory block. Still compiles: `check:doc-snippets` judges it against the **built** types.
- Changeset: `@object-ui/plugin-form: minor`. Nothing breaks and no behaviour changes, but two names join the published surface of a published package — additions are `minor` here, and a new public export is the kind of addition a consumer's pinned range should be able to see. Reasoning is spelled out in the changeset itself.

## Corrections to the card and to the dispatch brief — I would rather be corrected than obeyed, and so would the seat

1. **The card says three functions are published; on today's `main` it is one.** `index.tsx:102` exports exactly `omitServerResolvedDefaults` and `isRequiredInForm` from `schemaDefaults`. `schemaDefaultValues` and `seedCreateValues` are **not** on the entry, and a docblock right above that line argues at length that they are deliberately withheld.
2. **The card says `SeedContext` is exported; it is not.** It is exported from the *module* (`dist/schemaDefaults.d.ts`) but never re-exported by the root barrel — `git log -S` shows it was never on the entry in any commit. So the card's "`SeedContext` is exported, `ObjectSchemaLike` is the one that is not" asymmetry does not exist. The real asymmetry is with `SeedContext`'s neighbour `DeriveColumnsOptions` in a sibling package (see #7502).
3. **The entry file is `packages/plugin-form/src/index.tsx`, not `index.ts`.** The triage reported a `git grep` in `index.ts` returning nothing; that file does not exist, so the negative result was true for the wrong reason.
4. **Option B narrows, it does not widen.** Both the card and the brief describe it as widening what the functions accept. Measured, it requires `name`, requires a per-field `type`, and drops `reference_to`. Evidence above.
5. **The `deriveMasterDetail` line anchors in the brief were accurate** on today's `main` (`:19`, and `:121 :208 :267 :314 :366 :429`). `schemaDefaults` has **three** use sites (`:200`, `:258`, `:294`), not the two listed. Six functions take `childSchema`; five of them are on the entry (`hydrateColumns` is module-exported only).

## Out of scope, filed not fixed

- **#7502** — `@object-ui/fields` has the identical defect: `deriveLookupColumns` is on the package root, its `objectSchema` parameter is a **third**, structurally distinct unexported `ObjectSchemaLike`, while its sibling parameter type `DeriveColumnsOptions` is exported. Different package and a different shape (it pins `type`/`label` to `string`), so folding it in would have made this card's surface decision harder to review. Searched first; no existing card (the search channel was proved live with a control query that returned this very issue).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_