### PR TITLE
fix(types,fields): correct three false spec-alignment claims and pin the real boundary

### DIFF
--- a/.changeset/7014-select-option-spec-claim-correction.md
+++ b/.changeset/7014-select-option-spec-claim-correction.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/types': patch
+---
+
+Correct three false `@objectstack/spec` alignment claims on field metadata, and pin the
+real boundary (objectui#7014).
+
+**No contract change.** No type, schema, export or runtime path moves. What changes is
+published JSDoc — the text that reaches your editor tooltips through `.d.ts` — which was
+asserting the opposite of what the spec does.
+
+Three doc comments claimed the installed `@objectstack/spec` DECLARES a key that it in
+fact **refuses by name**. Measured on `@objectstack/spec@17.2.0`, each paired with a
+control that accepts the same payload minus the key:
+
+- `SelectOptionMetadata.description` said it "Aligns `@objectstack/spec`
+  `SelectOptionSchema.description`". That schema is `.strict()` over exactly
+  `{label, value, color, default, visibleWhen}`; `description` fails with
+  `unrecognized_keys`.
+- `MarkdownFieldMetadata.rows` and `HtmlFieldMetadata.rows` said `@objectstack/spec`
+  `FieldSchema.rows` declares the key "authorable on exactly the multiline editor
+  types". `FieldSchema` refuses `rows` by name on all four of
+  textarea/markdown/html/richtext.
+
+The keys themselves stay declared and stay consumed — `LookupField` searches an option's
+`description` (objectui#6153) and `RichTextField` reads `rows` (objectui#6140). Only the
+attribution was wrong, and it mattered in a specific way: `FieldSchema` routes a select
+field's `options` through the strict option schema, so authoring `description` on an
+option makes `PUT /api/v1/meta/object/:name` fail the **whole field** with a 422
+`INVALID_METADATA`. The comments were inviting exactly that write. They now say these are
+objectui-side read-model extensions that must never reach authored object metadata.
+
+A new pin (`select-option-spec-extension-7014.test.ts`) asserts the spec's option key set
+and each by-name refusal, so if the spec ever adopts one of these names the claim is
+re-opened loudly instead of silently becoming true.

--- a/packages/fields/src/widgets/LookupField.optionDescription.test.tsx
+++ b/packages/fields/src/widgets/LookupField.optionDescription.test.tsx
@@ -8,8 +8,9 @@
  * `opt.description` alongside the label, and `recordToOption` emits the same
  * key for fetched records. What the card changed is the CONTRACT:
  * `SelectOptionMetadata` (the declared type of `LookupFieldMetadata.options`)
- * now declares `description?: string`, aligned with `@objectstack/spec`'s
- * `SelectOptionSchema.description`, so the fixture below is an ANNOTATED
+ * now declares `description?: string` as an objectui-side extension - the
+ * installed `@objectstack/spec` 17.2.0 has no such key and REFUSES it BY NAME
+ * on `SelectOptionSchema` (objectui#7014) - so the fixture below is an ANNOTATED
  * literal — the excess-property check that used to refuse this exact document
  * is the compile half of the pin, and the search behaviour is the runtime
  * half. Behaviour unchanged by design; the test would have passed before the

--- a/packages/types/src/__tests__/select-option-spec-extension-7014.test.ts
+++ b/packages/types/src/__tests__/select-option-spec-extension-7014.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The objectui-side select-option / editor keys are extensions the spec
+ * REFUSES BY NAME — pinned so the comments that say so cannot rot (objectui#7014).
+ *
+ * Why this exists. `SelectOptionMetadata` (packages/types/src/field-types.ts)
+ * and the two `rows` declarations beside it each carried a doc comment
+ * asserting the installed `@objectstack/spec` DECLARES the key:
+ *
+ *   "Aligns `@objectstack/spec` `SelectOptionSchema.description`"
+ *   "`@objectstack/spec` `FieldSchema.rows` (a positive integer, authorable …)"
+ *
+ * Measured on `@objectstack/spec@17.2.0`, all three are false: the spec has no
+ * such key and rejects it BY NAME. A false canonical claim is not stale
+ * documentation — it is a planted premise for the next agent, which is the
+ * whole failure class `scripts/check-spec-symbol-derivation.mjs` exists to
+ * prevent. That gate could not see these, because it reads only the comment
+ * block attached to a DECLARATION and validates a citation only at SYMBOL
+ * granularity; both claims sit on MEMBERS and dangle at the member
+ * (`SelectOptionSchema` is a live export, `.description` is not a key of it).
+ *
+ * The keys themselves are legitimate and consumed — objectui#6153 for the
+ * option `description` (LookupField searches it), objectui#6140 for `rows`
+ * (RichTextField reads it). What was wrong was the attribution. So this pin
+ * asserts the BOUNDARY rather than removing anything: these are read-model
+ * extensions that must never reach authored object metadata.
+ *
+ * Every assertion below pairs the refusal with a CONTROL that accepts the same
+ * payload minus the key, so a red here means "the key's status changed", never
+ * "the fixture drifted".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SelectOptionSchema as SpecSelectOptionSchema, FieldSchema } from '@objectstack/spec/data';
+
+/** Keys of the spec's select option, as installed. */
+const SPEC_OPTION_KEYS = Object.keys(SpecSelectOptionSchema.shape).sort();
+
+/** A valid option — `value` is a system identifier, min length 2. */
+const validOption = { label: 'High', value: 'high' } as const;
+
+/** Pull the `unrecognized_keys` issue naming `key`, or undefined. */
+const refusedByName = (result: { success: boolean; error?: { issues: readonly any[] } }, key: string) =>
+  result.success
+    ? undefined
+    : result.error!.issues.find(
+        (i) => i.code === 'unrecognized_keys' && (i.keys ?? []).includes(key)
+      );
+
+describe('spec SelectOptionSchema is the boundary these extensions sit outside', () => {
+  it('declares exactly the five keys the corrected comments name', () => {
+    // If the spec ever ADDS `description`/`icon`/`disabled`, this fails and the
+    // comments in field-types.ts must be re-corrected rather than left stale.
+    expect(SPEC_OPTION_KEYS).toEqual(['color', 'default', 'label', 'value', 'visibleWhen']);
+  });
+
+  it('accepts the control option', () => {
+    expect(SpecSelectOptionSchema.safeParse(validOption).success).toBe(true);
+  });
+
+  for (const key of ['description', 'icon', 'disabled'] as const) {
+    it(`refuses the objectui-only key \`${key}\` BY NAME`, () => {
+      const res = SpecSelectOptionSchema.safeParse({ ...validOption, [key]: key === 'disabled' ? true : 'x' });
+      expect(res.success).toBe(false);
+      expect(refusedByName(res, key), `expected unrecognized_keys naming '${key}'`).toBeDefined();
+    });
+  }
+});
+
+describe('FieldSchema routes options through that strict schema', () => {
+  const field = (options: unknown[]) => ({ name: 'status', type: 'select', label: 'Status', options });
+
+  it('accepts a field whose options carry only spec keys', () => {
+    expect(FieldSchema.safeParse(field([validOption])).success).toBe(true);
+  });
+
+  it('fails the WHOLE field when an option carries `description`', () => {
+    const res = FieldSchema.safeParse(field([{ ...validOption, description: 'help' }]));
+    expect(res.success).toBe(false);
+    expect(refusedByName(res, 'description')).toBeDefined();
+  });
+});
+
+describe('FieldSchema refuses `rows` by name on every multiline editor type', () => {
+  const base = (type: string) => ({ name: 'body', type, label: 'Body' });
+
+  for (const type of ['textarea', 'markdown', 'html', 'richtext'] as const) {
+    it(`control: \`${type}\` without \`rows\` is accepted`, () => {
+      expect(FieldSchema.safeParse(base(type)).success).toBe(true);
+    });
+
+    it(`\`${type}\` with \`rows\` is refused BY NAME`, () => {
+      const res = FieldSchema.safeParse({ ...base(type), rows: 4 });
+      expect(res.success).toBe(false);
+      expect(refusedByName(res, 'rows'), `expected unrecognized_keys naming 'rows' on ${type}`).toBeDefined();
+    });
+  }
+});

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -205,9 +205,13 @@ export interface MarkdownFieldMetadata extends BaseFieldMetadata {
    * `RichTextField` — the one widget behind the `markdown`/`html`/`richtext`
    * registry keys — has always read `rows` off this metadata (default 8) while
    * no rich-content type declared it, so the running widget honoured a key an
-   * annotated literal rejected. Aligns the `TextareaFieldMetadata` precedent
-   * and `@objectstack/spec` `FieldSchema.rows` (a positive integer, authorable
-   * on exactly the multiline editor types textarea/markdown/html/richtext).
+   * annotated literal rejected. Follows the `TextareaFieldMetadata` precedent.
+   *
+   * WARNING - NOT a spec key. Measured on the installed `@objectstack/spec`
+   * 17.2.0: `FieldSchema` REFUSES `rows` BY NAME (`unrecognized_keys`) on all
+   * four of textarea/markdown/html/richtext, with the same payload minus
+   * `rows` accepted as the control. It is an objectui render hint and must not
+   * be written into authored object metadata (objectui#7014).
    * The four inert editor keys the same ruling measured (`toolbar`/`preview`/
    * `minHeight`/`maxHeight`) stay deliberately undeclared — nothing reads them.
    */
@@ -224,8 +228,8 @@ export interface HtmlFieldMetadata extends BaseFieldMetadata {
    * Height of the INLINE editor, in text rows. Same declaration as
    * `MarkdownFieldMetadata.rows` (objectui#6140 Option A ruling — see the
    * docblock there): `RichTextField` reads it for all three registry keys it
-   * serves, and `@objectstack/spec` `FieldSchema.rows` declares it for the
-   * multiline editor types.
+   * serves. WARNING - NOT a spec key either; see the measured refusal in the
+   * docblock there (objectui#7014).
    */
   rows?: number;
 }
@@ -320,9 +324,17 @@ export interface SelectOptionMetadata {
    * (`opt.description && opt.description.toLowerCase().includes(q)`) and its
    * `recordToOption` emits the same key for fetched records — while this type
    * never declared it, so the behaviour was real for a key no annotated
-   * literal could carry. Aligns `@objectstack/spec`
-   * `SelectOptionSchema.description`; renderers may show it as supporting
-   * text.
+   * literal could carry. Renderers may show it as supporting text.
+   *
+   * WARNING - objectui-side extension, NOT a spec key. Measured on the
+   * installed `@objectstack/spec` 17.2.0: `SelectOptionSchema` is `.strict()`
+   * over exactly `{label, value, color, default, visibleWhen}` and REFUSES
+   * `description` BY NAME (`unrecognized_keys`), with the same option minus
+   * the key accepted as the control. `FieldSchema` routes `options` through
+   * that schema, so writing this key into authored object metadata fails the
+   * whole field. It lives on the runtime READ model the renderers consume and
+   * must never reach the metadata payload. Pinned by
+   * `__tests__/select-option-spec-extension-7014.test.ts` (objectui#7014).
    */
   description?: string;
   color?: string;


### PR DESCRIPTION
Part of #7014

⚠️ This PR deliberately implements **only the determinate half** of #7014. The card's headline ask — converging the 8 hand-written select-option shapes — is left to the seat, because the card itself says it "should not be taken as one undifferentiated task" and names three open decisions. Those go back in the report. What lands here is the part with no decision in it, plus the measurement that makes the ruling cheap.

`Clause-②: no` — no type, schema, export or runtime path changes. Justification in the claim comment on #7014.

## The card's structural diagnosis is stale — corrected here

#7014 says the gate is blind because "**both rules skip any declaration without an `export` modifier** (`hasExportModifier`, applied once per scanner)". On today's `main` (`a27d153c2`) that is no longer true. Both halves of the filter were removed in objectui#6291; `hasExportModifier` survives at `scripts/check-spec-symbol-derivation.mjs:980` with **zero call sites**, and `scanFile` carries the literal comment `// No export filter (objectui#6291).`

The card's **conclusion** is correct and survives — the class really is invisible to its own gate. It is invisible for three different, still-live reasons, set out in the report and summarised at the bottom of this body.

## What this PR fixes

Three doc comments asserted the installed `@objectstack/spec` **declares** a key that it in fact **refuses by name**. Measured on `@objectstack/spec@17.2.0`, each paired with a control that accepts the same payload minus the key:

| site | claim | measured |
|---|---|---|
| `packages/types/src/field-types.ts` `SelectOptionMetadata.description` | "Aligns `@objectstack/spec` `SelectOptionSchema.description`" | `REJECT unrecognized_keys(description)`; control `ACCEPT` |
| `packages/types/src/field-types.ts` `MarkdownFieldMetadata.rows` | "`@objectstack/spec` `FieldSchema.rows` (a positive integer, authorable on exactly the multiline editor types)" | `REJECT unrecognized_keys(rows)` on **all four** of textarea/markdown/html/richtext; control `ACCEPT` |
| `packages/types/src/field-types.ts` `HtmlFieldMetadata.rows` | "`@objectstack/spec` `FieldSchema.rows` declares it for the multiline editor types" | same |
| `packages/fields/src/widgets/LookupField.optionDescription.test.tsx` | "aligned with `@objectstack/spec`'s `SelectOptionSchema.description`" | same as row 1 |

`SelectOptionSchema` is `.strict()` over exactly `{label, value, color, default, visibleWhen}` — five keys, no `description`, no `icon`, no `disabled`.

**The keys stay declared and stay consumed.** `LookupField` genuinely searches an option's `description` (objectui#6153) and `RichTextField` genuinely reads `rows` (objectui#6140). Only the attribution was wrong — and it mattered in a specific way: `FieldSchema` routes a select field's `options` through the strict option schema, so authoring `description` on an option fails the **whole field**:

```
FieldSchema w/ option.description  REJECT -> options.0:unrecognized_keys(description)
FieldSchema w/ clean option        ACCEPT
```

That is the same failure class already documented in `MetadataService.ts` for `indexed` / `referenceTo` / `formula` — a designer-authored key that makes `PUT /api/v1/meta/object/:name` fail 422 `INVALID_METADATA`. The comments were inviting exactly that write; they now name the boundary instead.

A false canonical claim is not stale documentation — it is a planted premise for the next agent, which is the whole failure class `check-spec-symbol-derivation.mjs` exists to prevent.

## New pin

`packages/types/src/__tests__/select-option-spec-extension-7014.test.ts` (15 tests) asserts the spec's option key set and each by-name refusal, every one paired with an accepting control. If the spec ever adopts `description` / `icon` / `disabled`, the claim re-opens loudly instead of silently becoming true.

## Verification — all readings at head `71e7e5db`

| check | verdict line |
|---|---|
| new pin | `Test Files 1 passed (1)` / `Tests 15 passed (15)` |
| neighbouring suites (5 files: the pin, `field-metadata-rows-option-description-6140`, `select-option-spec-parity`, `bulk-action-param-options`, `LookupField.optionDescription`) | `Test Files 5 passed (5)` / `Tests 36 passed (36)` |
| `type-check` (`@object-ui/types`, `@object-ui/fields`) | exit 0, both echo their script names |
| `lint` (both changed packages, in full) | exit 0 — `911 problems (0 errors, 911 warnings)`, all pre-existing |
| `check:spec-symbols` | `✅ spec symbol derivation: 1344 files scanned against 4959 spec export names; 18 declared dialects, 14 untriaged collisions in 7 packages.` / `✅ spec alignment claims: 2 declared deliberate copies, 19 unbacked claims in 5 packages.` |
| `check:control-bytes` | `✅ check-control-bytes: OK (scanned 6196 tracked text file(s); skipped 85 binary).` |
| `check:changeset-presence` | `✅ 3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `check:changeset-no-major` | `✅ No changeset declares a `major` bump.` |
| `check:dist-completeness` | `✓ dist completeness: 7 package(s) complete (522 emitted files verified); 5 not built yet, 2 type-check-only` |
| `check:readme-exports` | ⚠️ **could-not-run, not a pass** — exit 1 with 319 findings, every one `its type entry ./dist/index.d.ts is not on disk -- run pnpm build first`. Needs a full 40-package build; unrelated to this diff, which touches no README and no export. |

**Reverse verification.** Implementation committed first, then the pin mutated into the world the old comments asserted — key set widened to include `description`, and the refusal loop repointed at `color` (a key the spec accepts). Mutation proven on disk in both directions (injected text present ×2, removed text absent ×2, blob `11a1a4bf` → `697a2bad`). Result: `Tests 2 failed | 11 passed (13)` — exactly the two mutated assertions red, all 11 controls green including the whole `rows` block. Restored under `trap … EXIT INT TERM` with `git checkout HEAD -- <abs path>`, and proven **by state**: worktree blob back to `11a1a4bf` = HEAD blob, `git diff HEAD` empty, `git status` clean.

**Which tsc leg sees the pin** — measured with `--listFiles`: `tsc --noEmit` → **0** hits; `tsc -p tsconfig.test.json` → **1** hit. The package's `type-check` script runs `tsc --noEmit && tsc -p tsconfig.test.json`, so CI runs **both** legs and the pin is inside the checked program. (The edited source file `field-types.ts` is in both.)

**Lint narrowing, declared.** Rather than the repo-wide `pnpm lint`, both *changed packages* were linted in full — broader than the changed files, narrower than the repo. The narrowing is safe because ESLint here is **not type-aware**: no `projectService` and no `parserOptions.project` anywhere in `eslint.config.js`, so this diff cannot move the verdict on any file it does not touch. ESLint's own count over the 3 changed files: 3 linted, 0 errors, 7 warnings.

## ⚠️ The gate is no greener than before — deliberately

`check:spec-symbols` prints **byte-identical** output before and after this change (verified by `diff`). That is the finding, not a pass. This PR removes three real false claims and the gate cannot tell. Reporting it as a green gate would be the exact failure the card warns about.

It cannot see them for three independent, still-live reasons:

1. **Rule 2 reads only the comment block attached to a DECLARATION** (`attachedDoc(stmt, text)`). All three claims sit on **members**. `SelectOptionMetadata`'s own docblock is just `/** Select option */`.
2. **The claim-phrase list requires `aligns with`.** The real comment says bare "Aligns" — measured: `findClaim(...)` returns `null` on the actual text, and returns a claim on the same text with "with" inserted.
3. **A citation is validated only at SYMBOL granularity, never at MEMBER granularity.** `SelectOptionSchema` is a live spec export, so the dangling-citation precision rule (objectui#4607) does not fire, although `.description` is not a key of it.

Sizing for the ruling, since #7014's 47-vs-18 figure refers to the already-shipped export widening: a member-granularity citation check over the tree finds **3** genuinely dangling member citations — the two fixed here plus `DashboardSchema.title`, filed as #7509 — once Zod's own method surface (`.safeParse`, `.parse`, `.shape`) is excluded, which is 22 of the 27 raw hits. Three, not thirty. Whether to build that check is a decision for the seat and is **not** taken in this PR.

## Not in this PR, on purpose

- **No shape converged.** All 8 sites still stand; re-measured, counts and drift in the report.
- **`ObjectFieldInspector`'s `patchOptions` writes an option with no `label` when the label is empty** (`if (o.label) out.label = o.label`), while the spec **requires** `label`. Real defect on an authoring surface, but narrowing it is a contract decision — escalated, not guessed.
- **The gate's three holes** — left open and measured rather than patched unruled; every previous widening of this instrument was ruled on first (objectui#6291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_