### PR TITLE
refactor(plugin-gantt): delete the taskListWidth tombstone, keep the one fact it held

### DIFF
--- a/.changeset/7421-gantt-tasklistwidth-tombstone.md
+++ b/.changeset/7421-gantt-tasklistwidth-tombstone.md
@@ -1,0 +1,22 @@
+---
+---
+
+Removes the `taskListWidth_LEGACY_REMOVED` tombstone from `GanttView`, and records the fact
+it was carrying at the site that owns it.
+
+The line was one `const` bound to the literal `null` inside the component body, left behind
+by the finished task-list-width refactor. Measured on `origin/main` `a27d153c2`, the
+identifier appeared exactly once in the whole repo — its own declaration — and zero times in
+a read position; the same probe run returned 20 read sites for the live `taskListWidth` and
+360 for `rowHeight`, so the zero is a reading and not a broken grep. Nothing in the platform
+repo declared it either. It carried no state, no side effect and no contract surface.
+
+What it did carry was a false signal. A name spelling `_LEGACY_REMOVED`, sitting inside the
+component a few hundred lines below the real width derivation, reads as a seam deliberately
+retained for a reason recorded elsewhere, so the next reader goes looking for that reason.
+
+Its trailing comment held one fact worth keeping — that the width now comes from the
+container `useResizeObserver` — and that fact was stated nowhere at the observer call site.
+It moves there rather than dying with the line: the observed container width is named as the
+source the auto-sized row height, base column width and task-list pane width all derive
+from. No behaviour changes, and nothing published moves.

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -872,6 +872,8 @@ export function GanttView({
   const dateLocale = language || undefined;
   const [currentDate, setCurrentDate] = React.useState(() => tzShift.now());
   const containerRef = React.useRef<HTMLDivElement>(null);
+  // Observed container width — the source every auto-sized dimension below
+  // derives from: row height, base column width, and the task-list pane width.
   const { width: containerWidth } = useResizeObserver(containerRef);
   const effectiveWidth = containerWidth || (typeof window !== 'undefined' ? window.innerWidth : 1024);
   const isNarrow = effectiveWidth < 640;
@@ -2320,8 +2322,6 @@ export function GanttView({
       .filter((m) => m.valid);
   }, [markers, timelineRange, dateToX]);
 
-  const taskListWidth_LEGACY_REMOVED = null; // taskListWidth now derived from useResizeObserver above
-  
   const headerRef = React.useRef<HTMLDivElement>(null);
   const listRef = React.useRef<HTMLDivElement>(null);
   const timelineRef = React.useRef<HTMLDivElement>(null);


### PR DESCRIPTION
Fixes #7421

Head sha `73ef5ec7a`. Every reading below was taken on that tree.

## What changed

Two lines out, two lines in, one file:

- **Out** — `const taskListWidth_LEGACY_REMOVED = null;` from the `GanttView` body (and the whitespace-only line it left behind).
- **In** — the one fact its trailing comment was carrying, moved to the site that owns it. The `useResizeObserver` call site now names the observed container width as the source the auto-sized row height, base column width and task-list pane width all derive from. Triage asked for exactly this: *"the trailing comment records where the value went. If that fact is not already stated at the `useResizeObserver` call site, carry it there rather than deleting it with the line."* It was not stated there — checked at the call site, `GanttView.tsx:875`, which had no comment at all.

Plus an **empty-frontmatter changeset**: `packages/plugin-gantt/src` is released source, so the presence gate wants a declaration, and there is nothing to release.

## Liveness probe, with the control that fired

The premise holds. Probed the **declaration form** and the **read sites** separately, never the bare word:

| probe | shape | result |
|---|---|---|
| declaration | `git grep -E '\b(const\|let\|var\|function\|class\|interface\|type\|enum)\s+taskListWidth_LEGACY_REMOVED\b'` | **1** — `packages/plugin-gantt/src/GanttView.tsx:2323`, its own binding |
| read sites | the same grep for the identifier, minus lines matching the binder form | **0** |
| **control** `taskListWidth` | identical two shapes | 3 declaration lines, **20** read sites |
| **control** `rowHeight` | identical two shapes | 2 declaration lines, **360** read sites |

Both controls fired in the same run as the zero, so the zero is a reading. objectstack was swept too: **0 files / 0 lines** for `taskListWidth_LEGACY_REMOVED` *and* for the bare `taskListWidth`, in a run where the controls `gantt` (94 files / 359 lines) and `rowHeight` (34 / 74) fired — no spec, zod or type declaration of this key exists in the platform repo.

The word-count trap this card sits on, measured rather than trusted: in `GanttView.tsx`, `\btaskListWidth\b` goes **21 to 20** across this diff, not 21 to 0, because the tombstone's own comment said `taskListWidth` once. A word count would read that as "the key survives". The declaration-form count goes **1 to 0**.

## Reverse verification

Committed first, then mutated: the pre-fix file restored from the base commit under `trap … EXIT INT TERM` with an absolute path.

- **Mutation proved on disk** — blob `756df02d3` becomes `96033b44f`; the deleted text greps **0 to 1**, the injected comment greps **1 to 0**.
- **Restore proved by state, not by exit code** — blob back to `756df02d3`, byte-equal to HEAD's; `git diff HEAD` prints nothing; the greps read 0 and 1 again.
- No rebuild leg is owed here: both gates read source directly (ESLint lints the file, Vitest resolves `packages/plugin-gantt/src` through the root config), so no `dist/` sits between the mutation and the reading.

What moved, and what stayed:

| reading | tombstone present | tombstone deleted |
|---|---|---|
| `eslint .` on the package | 354 problems (0 errors), `GanttView.tsx` 17 | **353** problems (0 errors), `GanttView.tsx` **16** |
| the specific message | `2323:9 warning 'taskListWidth_LEGACY_REMOVED' is assigned a value but never used @typescript-eslint/no-unused-vars` | absent |
| control warning `'currentDate' is assigned a value but never used` | present | present |
| `vitest run packages/plugin-gantt/src` | 62 files, 485 passed | 62 files, 485 passed |

**⚠️ A correction to the card, from that table.** The card says this line is something "the compiler and lint have no reason to complain about". Lint did complain: ESLint flagged it as `@typescript-eslint/no-unused-vars`. It never failed CI because unused **vars** sit at warning severity in this repo, while #7332 lifted only unused **imports** to error. The card's conclusion is unaffected — but the line was not invisible to the tooling, it was one row inside a 353-warning backlog.

**No behavioural pin exists here and none was invented.** The deleted binding was `null` with zero readers, so nothing observable distinguishes the two trees — and the table shows it: the suite is 485-green on both sides. The honest red/green is the lint reading above, from a rule that already existed.

## Gates, each quoted from its own verdict line

Dependency closure built first (`pnpm --filter '@object-ui/plugin-gantt^...' build`, exit 0), so nothing below is a could-not-run.

- `pnpm --filter @object-ui/plugin-gantt type-check` — exit **0**, running `tsc --noEmit && tsc -p tsconfig.test.json` (both, the second being the test project).
- `pnpm --filter @object-ui/plugin-gantt lint` — exit **0**: `✖ 353 problems (0 errors, 353 warnings)`, all pre-existing, none in the lines this diff touches.
- `pnpm exec vitest run --maxWorkers=2 packages/plugin-gantt/src` from the **repo root** (a package-cwd run is refused, objectui#3378) — `Test Files 62 passed (62)` / `Tests 485 passed (485)`.
- `node scripts/check-changeset-presence.mjs` — `✅ 1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s) … Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.`
- `node scripts/check-changeset-no-major.mjs` — `✅ No changeset declares a 'major' bump.`
- `node scripts/check-control-bytes.mjs` — `✅ check-control-bytes: OK (scanned 6195 tracked text file(s); skipped 85 binary).`

**Declared narrowing.** The repo lint job is `turbo run lint`, i.e. per-package `eslint .`; only the one package this diff touches was linted. The three readings that make that a measurement rather than a skip: the population comes from ESLint's own config resolution, not from my guess — `eslint . --format json` reports **92 files linted** in `packages/plugin-gantt`; the counts above are that run's; and `eslint.config.js` configures **no type-aware linting** (no `parserOptions.project`, no `projectService`), so this diff cannot move the verdict of any file it does not contain. CI runs the full farm regardless.

## Not in scope

Clause-②: no. The diff removes a function-local `const` and adds a comment — no exported symbol, prop, type, zod schema or spec key moves, so nothing on the published accept surface changes. The declaration check was derived, not assumed from the `_LEGACY_REMOVED` spelling; the sweep is in the claim comment on the card.

#7228 — the same file's other dead sizing arm, `columnWidthForContainer` returning 110 from all three branches — is deliberately untouched here and remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_