### PR TITLE
docs(app-shell): DashboardView's header comment stops attributing `title` to the spec

### DIFF
--- a/.changeset/7509-dashboardview-title-comment-corrected.md
+++ b/.changeset/7509-dashboardview-title-comment-corrected.md
@@ -1,0 +1,27 @@
+---
+---
+
+Comment-only correction in `app-shell`'s `DashboardView` header block — no type,
+schema, export or runtime path is touched, so nothing releases.
+
+The block over the header's title fallback claimed "Per @objectstack/spec,
+`DashboardSchema.title` is 'the dashboard title displayed in the header'".
+Measured on the installed `@objectstack/spec@17.2.0`, `DashboardSchema` refuses
+`title` **by name** — `unrecognized_keys(title)` at the document root, against a
+spec-legal control (`{ name, label, widgets }`) that parses — and its 20 keys
+spell the display name `label`, not `title`. `header` declares `showTitle` /
+`showDescription` / `actions` only, so it toggles a title and never carries one;
+`{ header: { title } }` is refused too (`unrecognized_keys(title)@header`).
+
+The old wording made `title` read as authorable dashboard metadata, which is the
+expensive way to learn it is not: the save route refuses the whole body with
+`422 INVALID_METADATA` / `unrecognized_keys` before persistence, so an author
+who follows the comment gets no header and a rejected document. The replacement
+says what `title` actually is — the legacy objectui spelling, the same
+legacy-then-canonical pair `DashboardRenderer` reads — and states the 422, which
+is the fact the next reader needs.
+
+It also corrects a second reading the old block invited: `previewSchema` is not
+a host-supplied preview channel. `DashboardView` takes no such prop; the value
+is the view's own widget-pruned copy of `dashboard`, so both arms of `headerSrc`
+read the same stored document.

--- a/packages/app-shell/src/views/DashboardView.tsx
+++ b/packages/app-shell/src/views/DashboardView.tsx
@@ -170,10 +170,23 @@ export function DashboardView({ dataSource }: { dataSource?: any }) {
       <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-3 sm:gap-4 p-4 sm:p-6 border-b shrink-0">
         <div className="min-w-0 flex-1">
           {(() => {
-            // Per @objectstack/spec, DashboardSchema.title is "the dashboard
-            // title displayed in the header". We prefer it when present, then
-            // fall back to `label` (the metadata display name) and finally to
-            // the raw `name`.
+            // `title` is NOT a spec key — it is the LEGACY objectui spelling,
+            // read here only so a stored dashboard document that predates
+            // `label` still gets a header. Measured on @objectstack/spec
+            // 17.2.0: `DashboardSchema` refuses `title` BY NAME
+            // (`unrecognized_keys(title)` at the document root) and spells the
+            // display name `label`; `header` declares `showTitle` /
+            // `showDescription` / `actions` only, so it TOGGLES a title and
+            // never carries one. So authored dashboard metadata must use
+            // `label`: writing `title` earns a `422 INVALID_METADATA` /
+            // `unrecognized_keys` from the save route before persistence
+            // (see `MetadataService`), not a header.
+            //
+            // `previewSchema` is NOT a host-supplied preview channel — it is
+            // this view's own widget-pruned copy of `dashboard` (above), so
+            // either arm of `headerSrc` reads the same stored document.
+            // `DashboardRenderer` reads the same legacy-then-canonical pair.
+            // Order: legacy `title`, then `label`, then the raw `name`.
             const headerSrc = (previewSchema as any) || dashboard;
             const resolvedTitle = resolveKeyedI18nLabel(headerSrc.title, t);
             const resolvedLabel = resolveKeyedI18nLabel(dashboard.label, t);


### PR DESCRIPTION
Refs #7509 — deliberately not a closing reference. The card asked for two things; only the first is delivered here, because the census it asked for came back **zero in-repo suppliers**, which turns the second into a behaviour change and therefore a maintainer call.

## 1. What landed: the comment correction (zero risk)

`packages/app-shell/src/views/DashboardView.tsx` claimed:

```js
// Per @objectstack/spec, DashboardSchema.title is "the dashboard
// title displayed in the header". We prefer it when present, then
// fall back to `label` (the metadata display name) and finally to
// the raw `name`.
```

Replaced with a block that states what `title` is (the legacy objectui spelling), that the spec refuses it **by name**, and — the fact the next reader actually needs — that authoring it earns a `422 INVALID_METADATA` / `unrecognized_keys` from the save route before persistence, not a header. It also corrects a second misreading the old block invited, on which more below.

No type, schema, export or runtime path is touched. The `.changeset` has **empty frontmatter** — declared as releasing nothing, the repo's explicit exemption.

## 2. Spec readings, re-measured on this branch

`@objectstack/spec@17.2.0`, resolved from this worktree's `node_modules`, via `DashboardSchema.safeParse`:

| probe | verdict |
|---|---|
| control, spec-legal `{ name, label, widgets }` | **ACCEPT** (the lit control) |
| `{ …control, title: "T" }` | **REJECT** `unrecognized_keys(title)@root` |
| `{ …control, header: { title: "T" } }` | **REJECT** `unrecognized_keys(title)@header` |

20 keys, `label` among them, `title` not: `_lock, _lockDocsUrl, _lockReason, _lockSource, _packageId, _packageVersion, _provenance, aria, columns, dateRange, description, gap, globalFilters, header, label, name, performance, protection, refreshInterval, widgets`. `header` declares `showTitle` / `showDescription` / `actions` only — it *toggles* a title, it never carries one.

The card's readings reproduce exactly. Note the control matters: the card's "control (no title) ACCEPT" only holds when `label` is present, since `label` is required — a bare `{ name, widgets }` control fails on `label`, not on `title`, and would have read as a false positive.

## 3. The census the card asked for

Every probe below is a declaration/AST-shaped query, not a bare word count, and **every zero is reported next to a control that lit in the same run**.

### 3a. Supply — who puts a root `title` on a dashboard?

| probe | population | `title` | control |
|---|---|---|---|
| all tracked `*.json`, structural walk for a dashboard-shaped node (has a `widgets` array) | 546 files parsed, 9 such nodes | **6** | same probe reports the other 3 nodes and their key sets — the query discriminates |
| all tracked `*.ts` / `*.tsx`, TS-AST object literals with a `widgets` array initializer | 4137 files, 78 such literals | **12** | `label` 8, `name` 21, same probe |
| TS-AST assignment expressions writing a `title` member anywhere in the tree | 4137 files | 12, **none** on a dashboard document (all `document.title`, `out.title` in chart normalizers, `this.schema.title` in the builder) | control `X.label = …` lit at 20 sites |

Triaging the hits:

- The **6 JSON** hits are all `examples/schema-catalog/src/schemas/plugin-dashboard/filtered-dashboard*.json`. They are objectui **component** schemas (`type: "dashboard"`, no `name`), consumed by `SchemaRenderer` → `DashboardRenderer`. They never reach `DashboardView`, which resolves dashboards by `name` out of `useMetadata().dashboards`.
- Of the **12 TS/TSX** hits, 9 are test fixtures and 1 is a Zod declaration (`DashboardConfigSchema`, objectui's own `DashboardConfig`, not the document). The two remaining non-test hits:
  - `packages/plugin-dashboard/src/index.tsx:350` — `defaultProps` for the `dashboard-grid` **component** registration, not a document.
  - `packages/plugin-designer/src/pages/DashboardDesignPage.tsx:39` — a seed literal `{ type, name, title, columns, widgets: [] }`, reachable **only** on the `!dashboard` branch, and that branch early-returns "not found" without ever calling `handleChange` / `saveSchema`. It cannot persist.
- The authoring surface that *does* write dashboard documents, `packages/app-shell/src/views/metadata-admin/dashboard-schema.ts`, derives its whole form from spec `DashboardSchema` via `z.toJSONSchema`, and names `label` "dashboard display name rendered as a dedicated control". It structurally cannot emit `title`.

**Result: zero in-repo suppliers of a root `title` on a dashboard document.**

### 3b. Read points of a dashboard-root `title`

TS-AST census of every `expr.title` / `expr['title']` read in non-test source: 436 sites, of which 5 have a dashboard-root receiver (the rest are widget-, card-, item- and unrelated-component-level; the receiver grouping is what separates them):

| site | shape |
|---|---|
| `packages/app-shell/src/views/DashboardView.tsx:178` | `headerSrc.title` — this card |
| `packages/plugin-dashboard/src/DashboardRenderer.tsx:947` | `schema.title \|\| schema.label` — its comment is already accurate, calling `title` "the legacy objectui spelling" |
| `packages/plugin-dashboard/src/DashboardGridLayout.tsx:394` | `schema.title \|\| pickLocalized(schema.label) \|\| 'Dashboard'` |
| `packages/plugin-designer/src/DashboardEditor.tsx:467` | preview panel heading |
| `packages/plugin-designer/src/pages/DashboardDesignPage.tsx:138` | `(dashboard as any).label \|\| (dashboard as any).title` |

So the arm this card is about is one of five, and it is the only one whose comment got the attribution wrong.

### 3c. Fixtures

`DashboardView` has exactly one test file, `packages/app-shell/src/views/DashboardView.modalTarget.test.tsx`. Its dashboard fixture is `{ name: 'sales_overview', label: 'Sales Overview', widgets: [] }` — **no `title`** (control: `label` lit in that file at `:91`). **No test anywhere pins `DashboardView`'s `title` arm.**

## 4. The card's premise, corrected on one point

The card reasons that "the fallback chain still works for a host that passes a `previewSchema` carrying `title`". There is no such host channel. `DashboardView` takes one prop, `dataSource`; `previewSchema` is a `useMemo` **local to this view** (lines 129-142) producing a widget-pruned copy of `dashboard`. So `headerSrc.title` is `dashboard.title` in every case — a key on the stored `sys_dashboard` document, which is exactly the surface the spec refuses. The new comment says so, since the old one is what invited the reading.

This does not weaken the card; it sharpens it. The `title` arm is not "preview-only", it is legacy-document-only.

## 5. Why disposition 2 is not in this PR

With zero in-repo suppliers, deleting the `title` read arm and its fallback stops being a comment fix and becomes a behaviour change on documents this repo cannot see: dashboard documents are served by the platform, and `DashboardRenderer`'s comment dates the spelling to framework#1878 / #1891, so legacy stored documents carrying `title` are the population at risk. The same-class precedents the card names, #5830 and #5852, were both retirements of keys that **nothing read**; this one is read at five sites. That difference is the maintainer's call, not mine, so the card stays open and this PR does not close it.

## Verification

Union re-run on the final commit `90abd60c`:

| run | result |
|---|---|
| `pnpm --filter '@object-ui/app-shell^...' build` | exit 0 (dependency closure built before any test or typecheck) |
| `pnpm exec vitest run packages/app-shell/src/views/DashboardView.modalTarget.test.tsx` | `Test Files 1 passed (1)`, `Tests 5 passed (5)`, `VITEST_EXIT=0` |
| `pnpm --filter @object-ui/app-shell run type-check` | `TYPECHECK_EXIT=0`; script name echoed as `@object-ui/app-shell@17.6.0 type-check` (not a zero-match no-op), and `tsc --listFiles` confirms `views/DashboardView.tsx` is in the checked set |
| `pnpm exec eslint packages/app-shell --format json` | `ESLINT_EXIT=0`; **1062 files** checked, 0 errors. The edited file carries 10 warnings, all pre-existing `no-explicit-any` / `set-state-in-effect` on lines the comment merely shifted |
| `node scripts/check-control-bytes.mjs` | `check-control-bytes: OK (scanned 6195 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-spec-symbol-derivation.mjs` | exit 0 — `1344 files scanned against 4959 spec export names` |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 1 changeset, empty frontmatter, "the explicit exemption and a complete answer to this gate" |
| `node scripts/check-changeset-no-major.mjs` | exit 0 |
| `node scripts/check-changeset-overwrite.mjs` | exit 0 |

Exit codes were captured by redirecting to a file **before** reading, never through a pipe.

**Declared narrowing:** the repo-wide `pnpm lint` (`turbo run lint`, every package) was narrowed to `packages/app-shell`. Three pieces of evidence, not a guess: (i) the checked population comes from eslint's own config resolution, not my guess about which files count; (ii) the count, 1062 files, is read from `--format json` output; (iii) `eslint.config.js` enables **no** type-aware linting — its `languageOptions` carries no `parserOptions.project` and no `projectService` (control: `rules` occurs 10 times in that file, so the grep shape is live) — so every rule is evaluated per-file and a comment edit in one app-shell file cannot move the verdict on any file it does not touch. CI runs the full farm regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_