### PR TITLE
refactor(plugin-gantt): drop three unread declarations from GanttView

### DIFF
--- a/.changeset/7512-ganttview-unread-residues.md
+++ b/.changeset/7512-ganttview-unread-residues.md
@@ -1,0 +1,21 @@
+---
+---
+
+Internal cleanup in `@object-ui/plugin-gantt`: `GanttView.tsx` dropped three
+declarations (four bindings) that nothing in the tree ever read.
+
+- `const HEADER_HEIGHT = 50;` and `const COLUMN_WIDTH = 100;` — module-level
+  constants with zero readers repo-wide. Both were lazy: unread module bindings
+  cost nothing at runtime, so removing them changes no behaviour at all.
+- `const [currentDate, setCurrentDate] = React.useState(() => tzShift.now());` —
+  a different class of residue. Unlike the two constants this one was **live**:
+  every mount allocated a state slot and ran the `tzShift.now()` initializer,
+  even though neither the value nor the setter was ever referenced. Removing it
+  has a real (if tiny) runtime effect, and no observable one — nothing rendered
+  from it and nothing could set it, so no output, prop, or timing a consumer can
+  see changes.
+
+No published symbol moves: none of the four were exported, `COLUMN_WIDTH` is not
+the same binding as the local `const COLUMN_WIDTH = 110` that three sibling test
+files declare for themselves, and `tzShift` keeps 27 other readers in the file so
+its import stays live. Nothing to release — declared as a no-bump change.

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -40,9 +40,6 @@ import { computeCriticalPath, computeProjectRescheduleDetailed, wouldCreateDepen
 import { shiftDayStart, type NormShiftSegments } from "./shifts"
 import { useGanttTranslation } from "./useGanttTranslation"
 
-const HEADER_HEIGHT = 50;
-const COLUMN_WIDTH = 100; // Time column width
-
 // Width, in px, of the resize "grab zone" at each end of a task bar. The visible
 // grip is only a few px, but pointer synthesis in headless browsers quantizes the
 // click coordinate, so a click aimed at the edge routinely lands a pixel or two
@@ -870,7 +867,6 @@ export function GanttView({
   // (browser locale) when no I18nProvider supplies a language, so standalone
   // embeds and tests behave exactly as before.
   const dateLocale = language || undefined;
-  const [currentDate, setCurrentDate] = React.useState(() => tzShift.now());
   const containerRef = React.useRef<HTMLDivElement>(null);
   const { width: containerWidth } = useResizeObserver(containerRef);
   const effectiveWidth = containerWidth || (typeof window !== 'undefined' ? window.innerWidth : 1024);


### PR DESCRIPTION
Fixes #7512

Deletes three declarations (four bindings) from `packages/plugin-gantt/src/GanttView.tsx` that nothing read. Option **A** of the three the card offered, on the maintainer's ruling. 4 deletions, 0 insertions in source.

```diff
-const HEADER_HEIGHT = 50;
-const COLUMN_WIDTH = 100; // Time column width
-  const [currentDate, setCurrentDate] = React.useState(() => tzShift.now());
```

## Two different classes, not one

The card and this PR keep them apart deliberately:

- `HEADER_HEIGHT` / `COLUMN_WIDTH` are **lazy module constants**. An unread module binding costs nothing at runtime, so removing them changes no behaviour whatsoever. Their cost was purely as a false signal — `COLUMN_WIDTH = 100` sits beside code whose live column width is 110.
- `const [currentDate, setCurrentDate] = React.useState(...)` was **live**. Every mount allocated a state slot and executed the `tzShift.now()` initializer, while neither the value nor the setter was ever referenced. Removing it has a real (if tiny) runtime effect — and no *observable* one: nothing rendered from the value and nothing could call the setter, so no output, prop, or timing a consumer can see moves.

Lumping these into one sentence of "all dead code" would misstate the second.

## Readings, re-measured on this PR's base (`a27d153c2`)

Every zero below was taken with a **declaration-form** probe and a **whole-word read-site** probe run separately, each with a control that lit up in the same run.

| symbol | declaration form | whole-word hits, repo-wide | control lit in the same run |
|---|---|---|---|
| `HEADER_HEIGHT` | 1 (line 43) | **1 file, 1 line** — its own declaration | `git grep -lw RESIZE_EDGE_PX` returned 2 files |
| `COLUMN_WIDTH` | 1 (line 44) | **1 line in `GanttView.tsx`**; 8 / 5 / 4 lines in three sibling test files, each of which declares its **own** `const COLUMN_WIDTH = 110` and imports nothing (verified: 0 import lines mentioning the name in all three) | same run listed `TASK_LIST_MIN_W` at 7 lines |
| `currentDate` | 1 (line 873) | **1 line in plugin-gantt.** The 60-odd other hits are all `plugin-calendar` plus `packages/types` — that `currentDate` is the **CalendarSchema** authorable key (`packages/types/src/complex.ts:261`), a different binding entirely | `tzShift` lit at 27 lines in the same file |
| `setCurrentDate` | 1 (line 873) | **1 line in plugin-gantt**; 2 in `plugin-calendar/src/ObjectCalendar.tsx` | as above |

**Published surface: none of the four moves.** `grep -nE 'export.*(HEADER_HEIGHT|COLUMN_WIDTH|currentDate|setCurrentDate)'` over the file returns 0, with two controls lit in the same run: `export const MS_PER_DAY` matched, and the `export {` block query matched 3 lines in `src/index.tsx`. The file has no trailing re-export block at all (its last line is the component's closing brace), and `index.tsx` re-exports `GanttView` by name, so no `export *` chain could carry a non-exported binding out. Two are module-scope, two are function-scope inside `GanttView`. No published symbol, prop, type, zod schema or spec key changes.

`tzShift` keeps 27 whole-word readers in the file after the deletion, so its import stays live — the error-severity unused-**import** rule is not in play here.

## Reverse verification — ESLint, with a control that stays put

There is no honest behaviour pin to add for the removal of four bindings with zero readers, so the red/green is ESLint. Package-level `eslint .` in `packages/plugin-gantt`, before and after, `--format json`, exit code captured before any pipe (both runs exited 0 — this package is warning-only):

| | files linted | problems | errors | warnings | `GanttView.tsx` |
|---|---|---|---|---|---|
| before (`a27d153c2`) | 92 | 354 | 0 | 354 | 17 |
| after (`d4b093cd2`) | 92 | **350** | 0 | **350** | **13** |

Exactly four messages disappeared, and **none appeared**:

```
-1 @typescript-eslint/no-unused-vars :: 'HEADER_HEIGHT' is assigned a value but never used.
-1 @typescript-eslint/no-unused-vars :: 'COLUMN_WIDTH' is assigned a value but never used.
-1 @typescript-eslint/no-unused-vars :: 'currentDate' is assigned a value but never used.
-1 @typescript-eslint/no-unused-vars :: 'setCurrentDate' is assigned a value but never used.
```

**The control that stays in place** — same rule, same file, deliberately untouched:

```
before  line 2323:9  'taskListWidth_LEGACY_REMOVED' is assigned a value but never used.
after   line 2319:9  'taskListWidth_LEGACY_REMOVED' is assigned a value but never used.
```

It survives and shifts by exactly 4 lines, matching the 4 deleted lines. That tombstone belongs to objectui#7421 / PR objectui#7511 and is not touched here; objectui#7421 stays open for it.

## Baseline note

The card quotes 16 warnings for this file and 353 for the package; this PR's base `a27d153c2` measures **17** and **354**. The difference is exactly the `taskListWidth_LEGACY_REMOVED` warning above — the card's figures were taken on a tree where PR objectui#7511 had already removed the tombstone, and that PR had not landed on `main` when this branch was cut. Every other figure in the card reproduced exactly.

## Verification run, all at `d4b093cd2`

Heavy steps went through the shared verify lock.

- `pnpm exec eslint .` in `packages/plugin-gantt` — exit 0, 350 problems / 0 errors (table above)
- `pnpm --filter @object-ui/plugin-gantt run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — **exit 0**, after `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-gantt^...' build` (the first attempt failed only with `TS2307: Cannot find module '@object-ui/components'` — unbuilt dependency closure in a fresh worktree, not a finding)
- `pnpm exec vitest run packages/plugin-gantt/ --maxWorkers=2`, from the repo root — **Test Files 62 passed (62), Tests 485 passed (485)**
- `node scripts/check-changeset-presence.mjs` — exit 0, accepts the empty-frontmatter declaration
- `node scripts/check-changeset-fixed.mjs`, `node scripts/check-changeset-no-major.mjs` — exit 0
- `node scripts/check-control-bytes.mjs` — exit 0 (6195 tracked text files scanned), plus a targeted control-byte grep over the two changed files: clean

**Lint scope was narrowed to this package, and here is the proof the narrowing excludes nothing.** (1) The universe came from ESLint's own config, not a guess: `eslint .` resolved the package's file set itself. (2) The count is read from `--format json` — 92 entries, identical in both runs. (3) The config cannot carry a verdict across files: `grep -nE 'projectService|parserOptions|project:' eslint.config.js` returns **0** (control: the same grep shape returns 9 lines for `files:|ignores:` in that same file), so type-aware linting is not enabled and a deletion inside one `.tsx` cannot move any untouched file's result. The added `.changeset/*.md` is outside ESLint's `files: ['**/*.{ts,tsx}']` entirely.

**Not measured here:** `node scripts/check-readme-exports.mjs` exits 1 in this worktree, but all 312 messages read `type entry ./dist/index.d.ts is not on disk -- run pnpm build first` — the gate needs a full workspace build that this worktree does not have. That is a missing prerequisite, not a red gate; CI builds first and measures it there. None of the four deleted bindings appears in any README, since none was exported.

## Changeset

Empty frontmatter (`.changeset/7512-ganttview-unread-residues.md`), which this repo treats as the explicit "releases nothing" declaration rather than an omission. Justification: `plugin-gantt` source changed, so the presence gate demands a declaration; but no published symbol, prop, type or rendered output moves, and the one binding with a runtime cost had no observable effect. Same shape as PR objectui#7511.

## Out of scope

`columnWidthForContainer` is untouched. Its three arms all return 110, which is what made `COLUMN_WIDTH = 100` misleading — but that is objectui#7228's subject, and objectui#7228 remains open. Lifting `@typescript-eslint/no-unused-vars` to error (the card's option C) was ruled out for this unit of work; the package still carries 350 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_