### PR TITLE
test(plugin-timeline): remove the shared-lastItems race in the colorField ladder

### DIFF
--- a/.changeset/7521-timeline-colorfieldladder-race.md
+++ b/.changeset/7521-timeline-colorfieldladder-race.md
@@ -1,0 +1,24 @@
+---
+---
+
+Removes the shared-`lastItems` race in
+`packages/plugin-timeline/src/ObjectTimeline.colorFieldLadder-7243.test.tsx`. No
+runtime, type, schema or exported-symbol change — the diff is one test file, so
+this declares "not published" rather than a version bump.
+
+The test helper `colorsFor` left every render mounted and waited on
+`lastItems.length` alone. React Testing Library's auto-cleanup runs in
+`afterEach`, never between two renders inside one `it`, so the two `it`s that
+call `colorsFor` twice had two `ObjectTimeline`s alive writing one module-level
+`lastItems` — and a length-only predicate cannot say which of them wrote it.
+
+The late write was structural rather than incidental: `ObjectTimeline`'s data
+effect lists `objectDef` in its dependencies and a separate metadata fetch sets
+`objectDef`, so every mount issues two `find()` calls. The second is still in
+flight when the predicate goes green, which left each `colorsFor` returning with
+a write queued against a component nothing ever unmounted. Under load that write
+landed after the next call had reset `lastItems`, and rung 2 read the previous
+rung's colour back out.
+
+Because the failure was load-dependent it could kick any PR that happened to be
+in the merge queue, not just changes to `plugin-timeline`.

--- a/packages/plugin-timeline/src/ObjectTimeline.colorFieldLadder-7243.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.colorFieldLadder-7243.test.tsx
@@ -28,10 +28,17 @@
  * The assertions read the items `ObjectTimeline` composes for
  * `TimelineRenderer`; that `color` is what the renderer turns into the
  * marker's `borderColor` / translucent `backgroundColor`.
+ *
+ * objectui#7521 — `colorsFor` used to leave every render mounted and wait on
+ * `lastItems.length` alone. Two components then shared one module-level
+ * `lastItems`, and the predicate could not say which of them had written it, so
+ * an `it` that called `colorsFor` twice read the FIRST call's colour back out
+ * of the second under load. See the two comments in `colorsFor`: the unmount
+ * removes the second writer, the title-token predicate removes the blind spot.
  */
 
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ObjectTimeline } from './ObjectTimeline';
 
@@ -80,7 +87,25 @@ function makeDataSource(rows: any[]) {
   } as any;
 }
 
+/** Distinguishes one `colorsFor` render from the next. See `token` below. */
+let renderSeq = 0;
+
 async function colorsFor(colorField: string, rows: any[] = [ROW]) {
+  // objectui#7521 — a STRUCTURAL guard, deliberately not a timing one. RTL's
+  // auto-cleanup runs in `afterEach`, never between two renders inside one
+  // `it`, so before the `unmount()` below existed this read 1 on the second
+  // call of every multi-render `it` — a settled fact about the DOM at a
+  // synchronous point, not a race that has to be caught in the act.
+  expect(screen.queryAllByTestId('timeline-renderer')).toHaveLength(0);
+
+  // A token this call OWNS. `ObjectTimeline` composes `title` from
+  // `titleField`, so it rides through to `lastItems` untouched — and it is NOT
+  // the value under test, so the predicate below can tell "THIS render is
+  // ready" from "something else wrote again" without asserting the colour the
+  // caller is about to assert.
+  const token = `render-${++renderSeq}`;
+  const stampedRows = rows.map((row, i) => ({ ...row, subject: `${token}-${i}` }));
+
   lastItems = [];
   const schema: any = {
     type: 'timeline',
@@ -89,9 +114,26 @@ async function colorsFor(colorField: string, rows: any[] = [ROW]) {
     startDateField: 'starts_at',
     colorField,
   };
-  render(<ObjectTimeline schema={schema} dataSource={makeDataSource(rows)} />);
-  await waitFor(() => expect(lastItems.length).toBe(rows.length));
-  return lastItems.map((i) => i.color);
+  const { unmount } = render(
+    <ObjectTimeline schema={schema} dataSource={makeDataSource(stampedRows)} />,
+  );
+  try {
+    // Identify the AUTHOR, not just the arity. `lastItems.length` alone cannot
+    // separate "the component I just mounted has painted" from "an earlier one
+    // painted again", because both leave length === rows.length.
+    await waitFor(() =>
+      expect(lastItems.map((i) => i.title)).toEqual(stampedRows.map((r) => r.subject)),
+    );
+    return lastItems.map((i) => i.color);
+  } finally {
+    // Tear THIS render down before returning. `ObjectTimeline` still has a
+    // second `find()` in flight when the predicate goes green: its data effect
+    // lists `objectDef`, which the separate metadata fetch sets a beat later,
+    // so every mount fetches twice. A component left mounted here re-renders
+    // when that second fetch lands — during the NEXT call, after it has reset
+    // `lastItems`.
+    unmount();
+  }
 }
 
 describe('objectui#7243 — timeline colorField ladder (control: green before and after)', () => {


### PR DESCRIPTION
Fixes #7521

This was not a flake. It kicked whatever PR happened to be in the merge queue under load, so every queue failure had to rule it out first.

## Causal chain, re-derived here (agrees with the card, and names the engine it did not)

The card's reading is confirmed: `lastItems` is module-level, the `vi.mock` renderer writes it on every render, `colorsFor` never unmounts, and the `waitFor` predicate read `lastItems.length` only — so it could not tell which of two live components had written it.

What the card did not name is **why a late write is guaranteed rather than incidental**. `ObjectTimeline` has two async effects, and the data effect lists `objectDef` in its dependency array while a separate metadata fetch sets `objectDef`. So **every mount issues two `find()` calls**, and the second is still in flight when the predicate goes green. Measured trace of one `colorsFor`:

```
GETSCHEMA phase=A #1
FIND phase=A #1
RENDER phase=A n=1 len=1 color=["#abc"]
FIND phase=A #2                    <- second fetch issued
>>> waitFor resolved, returning ["#abc"]   <- ... and still in flight here
```

Every `colorsFor` therefore returned with a write queued against a component nothing ever unmounted. A gated repro then forced the interleaving and reproduced the CI failure exactly — the stale component re-rendering *after* the next call's reset:

```
A returned ["#abc"]
GETSCHEMA A resolved phase=B
RENDER phase=B len=1 color=["#abc"]        <- component A writes during phase B
B predicate (length-only) resolved with ["#abc"]
```

## The deterministic probe

Asserting "two renderers are alive after two `colorsFor` calls" (the card's suggested shape) is **not** reliably red: in the very run where the bug bites, the length-only predicate resolves on the stale component's write *before* the new one has painted, so only one element is in the DOM. Measured — the failing cell of the matrix below reports `alive=1`.

The probe used instead inverts it and asserts, **before each mount**, that no renderer is alive:

```js
expect(screen.queryAllByTestId('timeline-renderer')).toHaveLength(0);
```

This is timing-independent. At the top of the second `colorsFor` in any `it`, the first component's element is in the DOM as a settled fact: it rendered (the previous `waitFor` could only have been satisfied by it), and RTL's auto-cleanup runs in `afterEach`, never between two renders inside one `it`. Pre-fix reading, necessarily red on exactly the two multi-render `it`s:

```
AssertionError: expected [ ... ] to have a length of +0 but got 1
Tests  2 failed | 5 passed (7)
```

## The two fixes, and what each is actually worth

- **Unmount** — `colorsFor` tears its own render down in a `finally`, so there is never a second writer.
- **Author-identifying predicate** — each call stamps a token on `titleField` and waits for `lastItems` to carry it. The token is deliberately not the value under test, so the predicate can separate "this render is ready" from "something else wrote again" without asserting the colour the caller is about to assert.

A 2x2 ablation on a deterministic race gate measures what each buys. Reported as measured, which is **not** what the card assumed:

| unmount | predicate | 2nd call returns | renderers alive | |
|---|---|---|---|---|
| no | length-only | `["#abc"]` | 1 | **WRONG** — reproduces the CI failure |
| yes | length-only | `["#123456"]` | 1 | correct |
| no | token | `["#123456"]` | 2 | correct |
| yes | token | `["#123456"]` | 1 | correct (delivered) |

So each fix **alone** closes the correctness hole in the measured scenario — the card's "neither alone is enough" does not hold as stated, and I am not going to claim a red I did not get. They are still both worth keeping, for different reasons: the unmount removes the second writer (`alive` 2 to 1), the predicate refuses a stale write while two components coexist, and the structural probe pins the unmount mechanically. The first control I built for this matrix did **not** light up — its gap was too short and the new component overwrote the stale one before `waitFor`'s first poll — so it was repaired until the pre-fix cell failed, rather than read as "no bug".

## Per-`it` census (all seven, not just the two named)

| `colorsFor` calls | `it` |
|---|---|
| 1 | rung 1: a select field paints the AUTHORED option colour |
| 1 | rung 1: an unmatched value in an optioned field takes no option colour |
| **2** | rung 2: 3- and 6-digit hex literals pass through |
| **2** | rung 2: rgb() and hsl() literals pass through |
| 1 | a value that is neither an option nor a colour literal yields no colour |
| 1 | an empty value yields no colour |
| 1 | rung 2: an 8-digit #rrggbbaa literal now passes through too |

The fix is in the shared helper, so all seven are covered, not only the two that could fail today. No test was skipped, disabled, retried or split into separate `it`s, and no `ObjectTimeline` product code was touched.

## Verification

At final HEAD `4e69c05f5`:

- `pnpm exec vitest run packages/plugin-timeline/` — `Test Files 22 passed (22)`, `Tests 287 passed (287)`, exit 0.
- `tsc -p tsconfig.test.json --noEmit` — exit 0, after building the dependency closure (`pnpm --filter "@object-ui/plugin-timeline^..." build`). The edited file is proven in that program via `--listFiles` (1 hit), so this is a real reading and not a vacuous one.
- `node scripts/check-changeset-presence.mjs` and `check-changeset-no-major.mjs` — both exit 0.
- eslint on the changed file — 0 errors; warnings 6 before and 6 after, all pre-existing `no-explicit-any`.

Both readings were taken at `e1331a952`; the only later commit adds `.changeset/7521-timeline-colorfieldladder-race.md` and moves **0** non-`.changeset` paths, so they hold at `4e69c05f5`.

Repo-wide `pnpm lint` is left to CI. The narrowing above is a measurement rather than a skip: eslint is not type-aware in this repo (no `projectService`, no `parserOptions.project`), so this diff cannot move the verdict on any file it does not touch.

## Changeset

Empty frontmatter — the established spelling here (239 existing changesets use it). One test file plus the changeset; no package contract moves, so this declares "releasing nothing" rather than a version bump. No `skip-changeset` label: nothing in this repo reads it.

## Same-shape census (task 4 — reported, deliberately not fixed here)

Scanned all 2451 tracked test files for the shape: module-level `let` + written inside a `vi.mock` factory + an `it` rendering more than once + no `unmount()`/`cleanup()`.

```
(a)+(b) module-level `let` written inside a vi.mock factory : 47
  +(c) AND an `it` that renders more than once              : 1
  +(d) AND no unmount()/cleanup() anywhere in the file       : 0
```

The single step-(c) file is this one. The scanner was validated against the **pre-fix** version of this file as a positive control and lit up correctly, so the zero is a reading rather than a query-shape artifact. Nothing else in the repo carries this shape, so there is no follow-up issue to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_