### PR TITLE
docs(scripts): stop restating the eager-closure headroom in prose

### DIFF
--- a/scripts/check-eager-closure-budget.mjs
+++ b/scripts/check-eager-closure-budget.mjs
@@ -47,13 +47,17 @@
  * gate just read, not against a literal frozen next to them:
  *
  *   - It must PASS on today's `main`. A gate that lands red is a gate someone
- *     disables, and this one replaced a gate nobody could fail. Headroom above
- *     the current 3,254,004 bytes: 45,996 (1.41%).
+ *     disables, and this one replaced a gate nobody could fail. ⛔ No figure is
+ *     restated here: this bullet carried one and it went a whole re-baseline
+ *     stale (objectui#7518). The headroom the CONSTANTS carry is stated once,
+ *     on {@link MAX_EAGER_CLOSURE_GZIP_BYTES}; what the LIVE closure has left
+ *     is what `pnpm check:eager-closure` prints, and it is the smaller of the
+ *     two once the payload has drifted up from the baseline.
  *   - The headroom must stay SMALLER than the regression the gate exists to
- *     catch. objectui#5266 was 89 KiB = 91,136 bytes; 45,996 < 91,136, so this
- *     ceiling would have failed on that change. Widening the headroom past ~89
- *     KiB would leave the gate green through a repeat of its own motivating
- *     incident.
+ *     catch. objectui#5266 was 89 KiB = 91,136 bytes, and this ceiling is built
+ *     to carry half of that, so it would have failed on that change. Widening
+ *     the headroom past ~89 KiB would leave the gate green through a repeat of
+ *     its own motivating incident.
  *
  * Half the regression size, rather than the ~2% this line used to carry, is a
  * deliberate choice that only became necessary once the second constraint
@@ -252,7 +256,12 @@ import { isEntrypoint } from './invoked-as.mjs';
  *     0.85x the regression this gate must catch, the blind band reopening — and
  *     the 2026-08-30 ruling made moving it part of the same change.
  *
- * Headroom is 45,686 bytes — 0.50x {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES}.
+ * Headroom above {@link BASELINE} is 45,686 bytes — 0.50x
+ * {@link REGRESSION_THIS_GATE_MUST_CATCH_BYTES}. ⚠️ That is arithmetic on two
+ * constants in this file, so it stays true while they do — it is NOT what the
+ * closure has left today, which is smaller by every byte the payload has
+ * drifted up since the baseline below was taken. `pnpm check:eager-closure`
+ * prints the figure in force, and that is the one governing your build.
  */
 export const MAX_EAGER_CLOSURE_GZIP_BYTES = 3_268_000;
 
@@ -449,12 +458,15 @@ export const REGRESSION_THIS_GATE_MUST_CATCH_BYTES = 89 * 1024;
  * line per named group; inventing one for it would be a number with no
  * incident behind it.
  *
- * ⭐ Read the new `i18n-locales` headroom for what it is. 8,924 bytes is about
- * sixty translation keys at the measured ~147 gzipped bytes a short key costs
- * across ten locales — enough for the five PRs this unparked, and then the
- * AGGREGATE line (11,988 bytes of headroom) becomes the binding one. That is the
- * correct place for the constraint to live, and it is the argument for taking
- * the catalogues out of the eager closure rather than for raising anything.
+ * ⭐ Read the new `i18n-locales` headroom for what it is. 8,924 bytes above the
+ * baseline it was measured from is about sixty translation keys at the measured
+ * ~147 gzipped bytes a short key costs across ten locales — enough for the five
+ * PRs this unparked, and then the AGGREGATE line becomes the binding one. ⛔ Its
+ * headroom is not restated here: the figure that was went stale inside a
+ * fortnight (objectui#7518), and `pnpm check:eager-closure` prints both lines in
+ * force on your own build. That the aggregate is the correct place for the
+ * constraint to live is the argument for taking the catalogues out of the eager
+ * closure rather than for raising anything.
  *
  * ## Raising one
  *
@@ -545,14 +557,17 @@ export const PER_CHUNK_GZIP_CEILINGS = Object.freeze({
  * All four sit inside one regression, which is the whole of what "in range"
  * means here — {@link evaluateHeadroomSensitivity} calls 1.00x an error. So the
  * relationship these ceilings have to the aggregate is no longer "we are the
- * half that still works". It is narrower, and still worth having: they are the
- * TIGHTER half — 0.21x, 0.08x, 0.04x against the aggregate's 0.47x — so growth
- * in these three chunks reds the gate well before the aggregate would, and they
- * say WHERE, which one total never can.
+ * half that still works". It is narrower, and still worth having: WHICH line is
+ * tightest moves with every build and is not restated here — the ranking this
+ * sentence used to assert had inverted by the time anyone re-read it
+ * (objectui#7518) — and whichever it is, these say WHERE, which one total
+ * never can.
  *
  * ⛔ Do not size a re-baseline off the figures above. They are ONE dated run,
- * recorded so this paragraph rests on a measurement instead of an argument; the
- * answer in force is the table the gate prints on YOUR build. That this prose
+ * taken before objectui#7399 re-attributed `framework`, so its `framework` row
+ * weighs locale catalogues that line no longer holds. They are recorded so this
+ * paragraph rests on a measurement instead of an argument; the answer in force
+ * is the table the gate prints on YOUR build. That this prose
  * went three re-baselines stale while the numbers beside it could not
  * (objectui#6778) is the reason to distrust the prose first.
  *
@@ -1242,9 +1257,10 @@ export function extractCeilingDeclarations(source, names = VERDICT_CEILING_CONST
  * {@link MAX_EAGER_CLOSURE_GZIP_BYTES} from 4,086,000 to 3,345,000 on `main`,
  * and published `BUDGET_CLOSURE_BUDGET_KB: 3990.2` — 4,086,000 bytes, the
  * retired ceiling — with `conclusion: success`. It did not bite: the payload was
- * 3222.6 KB, under both numbers. With the aggregate headroom now 44.0 KB against
- * an 89.0 KB regression class, the next one has half a regression of room to
- * hide in.
+ * 3222.6 KB, under both numbers. What bounds how much the NEXT one could hide is
+ * the aggregate headroom in force, which `pnpm check:eager-closure` prints and
+ * this comment deliberately does not restate: the figure that stood here was two
+ * re-baselines out of date (objectui#7518).
  *
  * ## Why THREE readings and not two
  *


### PR DESCRIPTION
Fixes #7518

Comment-only. Every constant keeps its value; the gate's verdict is byte-identical
before and after.

## The disposition, and why it is not "write today's number"

The card offered three routes — (a) restate the figure, (b) restate a ratio,
(c) point at the live verdict. The dispatching seat ruled **(c)**, and the argument
is one this file has already proved on itself: a hardcoded headroom here went stale
badly enough to produce three mutually contradictory versions, two of them in the
same file. (a) only winds the clock forward to today; (b) drifts with the baseline.

So the prose now says **which line is binding and how to read the current value**
(`pnpm check:eager-closure`) and does not say what it equals.

Same shape as #7517 (`f620a26f6`), which fixed the ten locale packs' stale headroom
note by naming the ceiling's distance from *the baseline it was measured from* and
pointing at the same command.

## Whole-file census

The card required a survey of the entire file, not only the line it names. Line
numbers are on the pre-change file at `f620a26f6`.

### Aggregate surface — rewritten

| site | what was written | what it actually was | now |
|---|---|---|---|
| `:50-51` | "Headroom above the current 3,254,004 bytes: 45,996 (1.41%)" | `3,300,000 − 3,254,004` — the objectui#6683 ceiling/baseline pair, one full re-baseline stale, and "the current" is a baseline that was replaced by objectui#6776 | no figure; points at the constant that states it once, and at the live verdict |
| `:54` | "45,996 < 91,136, so this ceiling would have failed" | the same retired figure reused as the proof of the second constraint | argues from the policy (headroom is half the regression by construction) instead of a literal |
| `:455` | "the AGGREGATE line (11,988 bytes of headroom) becomes the binding one" | `3,268,000 − 3,256,012` — objectui#7399's own post-change **live reading** frozen into a sentence | no figure; the claim that the aggregate becomes binding stands, the number is read off the gate |
| `:1245-1246` | "With the aggregate headroom now 44.0 KB against an 89.0 KB regression class" | `3,345,000 − 3,299,898 = 45,102` — the objectui#5924 pair, two re-baselines back, present tense | no figure |
| `:548-550` | "they are the TIGHTER half — 0.21x, 0.08x, 0.04x against the aggregate's 0.47x" | dated `e33b44796` ratios promoted into a present-tense structural claim — and the claim has **inverted** (below) | states that which line is tightest moves with every build and is ranked by the gate's own sensitivity table |

### Aggregate surface — deliberately kept, with the reason

| site | figure | why it is not in the class above |
|---|---|---|
| `:255` | "Headroom is 45,686 bytes — 0.50x" | `3,268,000 − 3,222,314`: arithmetic on two constants **in this file**, correct at write time and correct now, and it cannot drift independently of them (the unit test asserts `MAX − BASELINE.gzipBytes < REGRESSION`). What was missing is that this is headroom above the **baseline**, not what the closure has left — the sentence now says so and points at the live figure. |
| `:530-531` | "4,086,000 over the 3,298,620 reading, 787,380 bytes, 8.64x" | explicitly a **retired** claim that the same paragraph goes on to call false. A dated record of a defect, not an assertion about today. |
| `:64-65` | "~45 KB of room in each direction rather than 66 KB one way and 25 KB the other" | arithmetic on `REGRESSION_THIS_GATE_MUST_CATCH_BYTES` and on the retired ~2% policy it replaced. A statement about the **policy**; no measurement in it. |
| `:117`, `:136`, `:156`, `:242`, `:251` | "~200 KB", "45,102", "75.9 KB = 0.85x" | each dated to the card that measured it, inside a narrative that names that card. |
| `:544-547` | the four-line `e33b44796` run table | one dated run, already carrying its own "do not size a re-baseline off these; the answer in force is the table the gate prints on YOUR build". **One clause added**: the run predates objectui#7399's re-attribution, so its `framework` row weighs locale catalogues that line no longer holds — without it a reader takes a retired subject for the current one, which is the false rule objectui#7399 was itself written about. |

### The inverted ranking, measured

`:548-550` asserted the three per-chunk lines were tighter than the aggregate. On this
branch's base the gate prints the opposite for one of them, and there are four
per-chunk ceilings now, not three:

    aggregate closure          headroom 9.5 KB = 0.11x
    chunk `vendor-objectstack` headroom 18.2 KB = 0.20x

That is why the replacement asserts no ranking at all.

### Per-chunk surface — reported separately, numbers never joined to the aggregate's

The dispatching seat's fence: the three budget surfaces are three things and their
numbers do not go in one sentence. Nothing in this PR joins them.

| site | figure | disposition |
|---|---|---|
| `:442-446` | "9,535 bytes (0.10x) for `framework`, 8,924 (0.10x) for `i18n-locales`, against the 9,137 (0.10x) the retired `framework` pair carried" | **correct, untouched.** `71,000 − 61,465 = 9,535` and `455,000 − 446,076 = 8,924`, both from constants in this file; 9,137 is dated to the retired pair. |
| `:452` | "8,924 bytes is about sixty translation keys" | **correct, number kept.** It was silent about being headroom above the *baseline*; it now says so. Its trailing clause was the `11,988` defect and is rewritten. |
| `:346-348`, `:386`, `:411`, `:431` | per-chunk narratives | dated to their cards. Kept. |

Live per-chunk drift is **not** written into the file — that is the whole ruling —
but for the record, measured on `f620a26f6`: `i18n-locales` has spent 1,882 of its
8,924 baseline headroom and `ui-components` is down to 2,716 bytes (0.03x). The gate
prints all of it.

## Verification

Full `apps/console` build (this file is in `performance-budget.yml`'s runtime
closure, so the gate cannot be judged without one). Both builds and the test run went
through the shared verify lock; wall-clock figures are shared-box seconds.

    pnpm turbo run build --filter='./packages/*' --concurrency=2    39 tasks ok
    pnpm --filter @object-ui/console build                          ok
    node scripts/check-eager-closure-budget.mjs                     exit 0

The verdict this PR's new prose points at, printed on `f620a26f6`:

    ✅ Console eager closure is 3181.9 KB gzipped across 50 of 518 chunks (budget: 3191.4 KB, headroom: 9.5 KB).
    ✅ Per-chunk eager budgets (4 chunks weighed):
      ✅ vendor-objectstack       926.1 KB / 944.3 KB ceiling (headroom 18.2 KB)
      ✅ i18n-locales             437.5 KB / 444.3 KB ceiling (headroom 6.9 KB)
      ✅ ui-components            387.0 KB / 389.6 KB ceiling (headroom 2.7 KB)
      ✅ framework                 61.0 KB / 69.3 KB ceiling (headroom 8.3 KB)
    ✅ Ceiling sensitivity (5 ceilings, each weighed against the report just read):
      ✅ aggregate closure               3181.9 KB measured / 3191.4 KB ceiling (headroom 9.5 KB = 0.11x the 89.0 KB regression)  [MAX_EAGER_CLOSURE_GZIP_BYTES]
      ✅ chunk `vendor-objectstack`       926.1 KB measured / 944.3 KB ceiling (headroom 18.2 KB = 0.20x the 89.0 KB regression)  [PER_CHUNK_GZIP_CEILINGS['vendor-objectstack']]
      ✅ chunk `i18n-locales`             437.5 KB measured / 444.3 KB ceiling (headroom 6.9 KB = 0.08x the 89.0 KB regression)  [PER_CHUNK_GZIP_CEILINGS['i18n-locales']]
      ✅ chunk `framework`                 61.0 KB measured / 69.3 KB ceiling (headroom 8.3 KB = 0.09x the 89.0 KB regression)  [PER_CHUNK_GZIP_CEILINGS['framework']]
      ✅ chunk `ui-components`            387.0 KB measured / 389.6 KB ceiling (headroom 2.7 KB = 0.03x the 89.0 KB regression)  [PER_CHUNK_GZIP_CEILINGS['ui-components']]

Exactly: `eagerGzipBytes = 3,258,288`, so the headroom in force is **9,712 bytes**.
None of 45,996 / 45,686 / 11,988 is that number — and the figure this seat was handed
in dispatch, taken from CI on a neighbouring commit, was 9,734. Twenty-two bytes
apart, in the same afternoon, is the argument for (c) in one line.

### The gate's behaviour did not move

The report is held constant (one build) and the checker is run on the pristine tree
and again on the edited one:

    cmp verdict-before.txt verdict-after.txt   -> exit 0, identical
    md5 both                                   -> 754fcf61b9a33e9e0cf1b92ce644abc3

Negative control, so "identical" is a reading and not a tautology: appending one byte
to a copy makes the same `cmp` exit 1 at byte 2186. Re-run again at the final commit
`2e001f5f2`, still byte-identical to the pristine reading.

`scripts/check-eager-closure-budget.mjs` is not a build input (turbo's console
`inputs` cover `scripts/vite-*.ts`, not `scripts/check-*.mjs` — the argument
`BASELINE` already makes about its own commit), which is why one build is enough to
hold the report fixed across the edit.

### Gates, on `2e001f5f2`

    pnpm exec vitest run scripts/__tests__/check-eager-closure-budget.test.ts \
      scripts/__tests__/render-budget-comment.test.ts \
      scripts/__tests__/check-side-effects-array.test.ts \
      scripts/__tests__/vite-declared-lazy-views.test.ts \
      scripts/__tests__/vite-ineffective-dynamic-imports.test.ts
    Test Files  5 passed (5)      Tests  207 passed (207)

Those five are every test file in the repo that reads this script's source. The set
matters here because objectui#7046 pins **prose** against live values —
`attachedDocs` locates the block attached to each baseline and asserts what it says
about commits and chunk names — so a comment-only edit to these blocks is exactly the
kind that can red them. It does not.

    node scripts/check-control-bytes.mjs        ✅ 6199 tracked text files
    node scripts/check-changeset-presence.mjs   ✅ no changeset owed

The changeset checker's own verdict line: *"1 file(s) changed, 0 of them published
source of a package the release covers ... no changeset is owed."* No
`skip-changeset` label is applied — this repo declares with an empty-frontmatter
changeset when one is owed, and here none is.

Not run locally: the rest of the gate farm, which CI runs exactly once anyway.

## Fences honoured

No ceiling is raised, lowered, or otherwise moved. `MAX_EAGER_CLOSURE_GZIP_BYTES`,
`BASELINE`, `PER_CHUNK_GZIP_CEILINGS`, `PER_CHUNK_BASELINE` and
`REGRESSION_THIS_GATE_MUST_CATCH_BYTES` are byte-identical to `origin/main`; the diff
is 38 insertions and 22 deletions, all of them inside comments. If 9.7 KB of
aggregate headroom is too tight, that is a different card and a maintainer's call.

## Filed, not fixed here

#7528 — two more frozen measurements in this gate's prose that the ruling above does
not cover: "one number over 52 chunks" asserted in the present tense in this file and
in its test (the build measures 50; `BASELINE.chunks` says 48), and
`performance-budget.yml` citing "3.15 MB", the ceiling objectui#6776 retired. Out of
scope: neither is an aggregate-headroom sentence, and one lives in another file.
#7528 is not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_