### PR TITLE
fix(core): localize built-in aggregate chart labels via builtinAggregate (#7258)

### DIFF
--- a/.changeset/7258-chart-builtin-aggregate-label.md
+++ b/.changeset/7258-chart-builtin-aggregate-label.md
@@ -1,0 +1,47 @@
+---
+'@object-ui/core': minor
+'@object-ui/i18n': minor
+'@object-ui/plugin-charts': patch
+'@object-ui/plugin-dashboard': patch
+'@object-ui/plugin-report': patch
+---
+
+Localize the server's built-in aggregate measure titles on dataset charts
+(objectui#7258 — consumer half of the objectstack#14492 contract; maintainer
+ruling B, 2026-09-02).
+
+A dataset-bound chart's aggregate axis / legend title read the analytics
+service's hard-coded English `Count` on a zh console whose category labels were
+already Chinese. The renderer was passing `fields[].label` through verbatim —
+correctly, for an author-declared measure (objectui#4106) — and had no way to
+tell the server's built-in default apart from an author's label.
+
+The wire now can: `AnalyticsResult.fields[]` gains an OPTIONAL structural
+discriminator, `builtinAggregate?: 'count' | 'sum' | 'avg' | 'min' | 'max' |
+'count_distinct'`, populated only on the server-side built-in defaults
+(objectstack#14492). This change is the consumer side of that contract:
+
+- `@object-ui/core`: `buildChartSeries` now accepts `ChartMeasureField[]` —
+  `ChartResultField` plus the optional `builtinAggregate` carrier
+  (`BuiltinAggregateCarrier`), declared beside the renderer shape rather than
+  on it because the spec this release is built against does not carry the key
+  yet; new `BUILTIN_AGGREGATES` / `BuiltinAggregate` / `isBuiltinAggregate` /
+  `resolveMeasureLabel`; `ChartSeriesOptions.builtinAggregateLabels` carries
+  the locale strings in (core stays React-free and i18n-free — the same
+  division as `nullCategoryLabel`). A field carrying a recognised
+  discriminator resolves through that map; every other field keeps its wire
+  `label` verbatim — never by matching the label's text or the field's name
+  (the rejected option A).
+- `@object-ui/i18n`: `builtinAggregateLabels(tt)` resolves the six strings
+  through the existing `report.aggregate.*` keys (zh already carried 计数 /
+  求和 / 平均 / …; all ten packs are pinned to cover the vocabulary).
+- `plugin-charts` (`ObjectChart`), `plugin-dashboard` (`DatasetWidget`),
+  `plugin-report` (`DatasetReportRenderer`): pass the resolved map to
+  `buildChartSeries`.
+
+Before: 合作中 / 已流失 / 潜在 under an axis titled `Count`. After: the same
+chart titled `计数`; an `en` session still reads `Count`; an author-labelled
+measure (`Tasks`) and a measure literally named `count` without the
+discriminator are byte-for-byte unchanged. Until the upstream field is
+populated the wire carries no discriminator and every chart renders exactly as
+before.

--- a/packages/core/src/utils/chart-series.builtinAggregate.test.ts
+++ b/packages/core/src/utils/chart-series.builtinAggregate.test.ts
@@ -1,0 +1,207 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7258 — a dataset chart's aggregate axis / legend title read the
+ * server's English `Count` on a zh console whose category labels were already
+ * Chinese (合作中 / 已流失 / 潜在).
+ *
+ * The literal is not minted here: `buildChartSeries` passes `fields[].label`
+ * through verbatim, which objectui#4106 pinned for a REAL author measure
+ * (`'Tasks'`), and the analytics service hard-codes `label: 'Count'` on the
+ * built-in default measure with no i18n hook. Maintainer ruling B (2026-09-02):
+ * the wire grows an OPTIONAL structural discriminator,
+ * `fields[].builtinAggregate` (objectstack#14492, populated only on the
+ * server-side built-in defaults), and this consumer resolves such a field's
+ * label through the locale bundle — keyed by that discriminator, never by the
+ * label's text or the field's name (option A, rejected: it would clobber a
+ * real author measure called `count`, and text-matching dies the moment the
+ * string is anything but that exact English literal).
+ *
+ * `@object-ui/core` is React-free and i18n-free, so the resolved strings arrive
+ * as `ChartSeriesOptions.builtinAggregateLabels` (the `nullCategoryLabel`
+ * division of labour); the bundle-reading half is pinned in `@object-ui/i18n`.
+ *
+ * DIRECTIONS, written before the reverse verification was run:
+ *  - every case handing a discriminator AND a labels map is RED before the
+ *    change (the series reads the wire `Count`);
+ *  - every "verbatim" and "fallback" case is GREEN on both sides — they are the
+ *    pre-#7258 behaviour restated, and the whole safety argument of the change
+ *    is that a field without the discriminator, or a host without labels, keeps
+ *    exactly the label it had;
+ *  - `isBuiltinAggregate` / `resolveMeasureLabel` do not exist before it, so
+ *    those blocks fail at import.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  BUILTIN_AGGREGATES,
+  buildChartSeries,
+  isBuiltinAggregate,
+  resolveMeasureLabel,
+  type BuiltinAggregateLabels,
+  type ChartMeasureField,
+  type ChartResultField,
+} from './chart-series';
+
+/** What `builtinAggregateLabels(tt)` resolves under the zh pack. */
+const ZH: BuiltinAggregateLabels = {
+  count: '计数',
+  count_distinct: '去重计数',
+  sum: '求和',
+  avg: '平均',
+  min: '最小值',
+  max: '最大值',
+};
+
+/** … and under the en pack. */
+const EN: BuiltinAggregateLabels = {
+  count: 'Count',
+  count_distinct: 'Distinct Count',
+  sum: 'Sum',
+  avg: 'Average',
+  min: 'Min',
+  max: 'Max',
+};
+
+/** The card's own chart: customers by status, categories already localized. */
+const ROWS = [
+  { status: '合作中', count: 3 },
+  { status: '已流失', count: 1 },
+  { status: '潜在', count: 2 },
+];
+
+/** The wire shape objectstack#14492 emits for the server's built-in count. */
+const BUILTIN_COUNT: ChartMeasureField = { name: 'count', label: 'Count', builtinAggregate: 'count' };
+
+/** objectui#4106's fixture: an author-declared measure, no discriminator. */
+const AUTHORED: ChartResultField = { name: 'task_count', label: 'Tasks' };
+
+describe('buildChartSeries — built-in aggregate labels resolve through the locale (objectui#7258)', () => {
+  it('zh: the server`s built-in count draws under 计数, not the wire`s English', () => {
+    const r = buildChartSeries(ROWS, ['status'], ['count'], [BUILTIN_COUNT], { builtinAggregateLabels: ZH });
+    expect(r.series).toEqual([{ dataKey: 'count', label: '计数' }]);
+    // Only the LABEL moved: the key, the axis and the rows are what they were.
+    expect(r.xAxisKey).toBe('status');
+    expect(r.data).toEqual(ROWS);
+  });
+
+  it('en: the same wire field draws under Count', () => {
+    const r = buildChartSeries(ROWS, ['status'], ['count'], [BUILTIN_COUNT], { builtinAggregateLabels: EN });
+    expect(r.series).toEqual([{ dataKey: 'count', label: 'Count' }]);
+  });
+
+  it('every member of the closed vocabulary resolves through the map', () => {
+    for (const aggregate of BUILTIN_AGGREGATES) {
+      const field: ChartMeasureField = { name: `m_${aggregate}`, label: 'server default', builtinAggregate: aggregate };
+      const r = buildChartSeries([], ['status'], [field.name], [field], { builtinAggregateLabels: ZH });
+      expect(r.series, aggregate).toEqual([{ dataKey: field.name, label: ZH[aggregate] }]);
+    }
+  });
+
+  it('keeps an author-declared label VERBATIM when the field carries no discriminator (objectui#4106)', () => {
+    // Control, green on both sides: a labels map in play changes nothing for a
+    // measure the author labelled — `'Tasks'` reaches the legend untouched.
+    const r = buildChartSeries([], ['status'], ['task_count'], [AUTHORED], { builtinAggregateLabels: ZH });
+    expect(r.series).toEqual([{ dataKey: 'task_count', label: 'Tasks' }]);
+  });
+
+  it('never infers from the NAME or the label TEXT — the rejected option A', () => {
+    // A real author measure that happens to be called `count` and labelled
+    // `Count`, with NO discriminator: it is the author's, and it keeps its own
+    // label under a zh map. Only the structural field can switch the lookup on.
+    const authoredCount: ChartResultField = { name: 'count', label: 'Count' };
+    const r = buildChartSeries(ROWS, ['status'], ['count'], [authoredCount], { builtinAggregateLabels: ZH });
+    expect(r.series).toEqual([{ dataKey: 'count', label: 'Count' }]);
+  });
+
+  it('resolves each measure independently in a multi-measure chart', () => {
+    const r = buildChartSeries(
+      [{ status: '合作中', count: 3, task_count: 9 }],
+      ['status'],
+      ['count', 'task_count'],
+      [BUILTIN_COUNT, AUTHORED],
+      { builtinAggregateLabels: ZH },
+    );
+    expect(r.series).toEqual([
+      { dataKey: 'count', label: '计数' },
+      { dataKey: 'task_count', label: 'Tasks' },
+    ]);
+  });
+
+  it('falls back to the wire label for a discriminator OUTSIDE the closed vocabulary', () => {
+    // An unrecognised value is not "a new aggregate", it is absent: the field
+    // renders exactly what it rendered before the discriminator existed.
+    const median: ChartMeasureField = { name: 'median_age', label: 'Median', builtinAggregate: 'median' };
+    const r = buildChartSeries([], ['status'], ['median_age'], [median], { builtinAggregateLabels: ZH });
+    expect(r.series).toEqual([{ dataKey: 'median_age', label: 'Median' }]);
+  });
+
+  it('falls back to the NAME when an unknown discriminator comes with no label at all', () => {
+    const bare: ChartMeasureField = { name: 'median_age', builtinAggregate: 'median' };
+    const r = buildChartSeries([], ['status'], ['median_age'], [bare], { builtinAggregateLabels: ZH });
+    expect(r.series).toEqual([{ dataKey: 'median_age', label: 'median_age' }]);
+  });
+
+  it('keeps the wire label when the caller resolved NO labels (a provider-less host)', () => {
+    // The floor: without a bundle the server's English is still the best
+    // string available, and it is exactly the pre-#7258 rendering.
+    expect(buildChartSeries([], ['status'], ['count'], [BUILTIN_COUNT]).series).toEqual([
+      { dataKey: 'count', label: 'Count' },
+    ]);
+    expect(buildChartSeries([], ['status'], ['count'], [BUILTIN_COUNT], {}).series).toEqual([
+      { dataKey: 'count', label: 'Count' },
+    ]);
+  });
+
+  it('keeps the wire label when the map lacks that aggregate, or resolves it to the empty string', () => {
+    expect(
+      buildChartSeries([], ['status'], ['count'], [BUILTIN_COUNT], { builtinAggregateLabels: { sum: '求和' } }).series,
+    ).toEqual([{ dataKey: 'count', label: 'Count' }]);
+    expect(
+      buildChartSeries([], ['status'], ['count'], [BUILTIN_COUNT], { builtinAggregateLabels: { count: '' } }).series,
+    ).toEqual([{ dataKey: 'count', label: 'Count' }]);
+  });
+
+  it('leaves the pivot branch alone — its series are the second dimension`s VALUES, not measures', () => {
+    const rows = [
+      { status: '合作中', tier: 'High', count: 5 },
+      { status: '合作中', tier: 'Low', count: 3 },
+    ];
+    const r = buildChartSeries(rows, ['status', 'tier'], ['count'], [BUILTIN_COUNT], { builtinAggregateLabels: ZH });
+    expect(r.series).toEqual([
+      { dataKey: 'High', label: 'High' },
+      { dataKey: 'Low', label: 'Low' },
+    ]);
+  });
+});
+
+describe('resolveMeasureLabel — the resolution order, stated on its own', () => {
+  it('locale label → wire label → name', () => {
+    expect(resolveMeasureLabel(BUILTIN_COUNT, ZH)).toBe('计数');
+    expect(resolveMeasureLabel(BUILTIN_COUNT)).toBe('Count');
+    expect(resolveMeasureLabel({ name: 'count', builtinAggregate: 'count' })).toBe('count');
+    expect(resolveMeasureLabel(AUTHORED, ZH)).toBe('Tasks');
+    expect(resolveMeasureLabel({ name: 'raw' }, ZH)).toBe('raw');
+  });
+});
+
+describe('isBuiltinAggregate — the closed vocabulary, spelled the spec`s way', () => {
+  it('accepts exactly the six wire spellings', () => {
+    expect([...BUILTIN_AGGREGATES].sort()).toEqual(['avg', 'count', 'count_distinct', 'max', 'min', 'sum']);
+    for (const aggregate of BUILTIN_AGGREGATES) expect(isBuiltinAggregate(aggregate), aggregate).toBe(true);
+  });
+
+  it('rejects other spellings, other types, and the bundle key`s camelCase', () => {
+    // `countDistinct` is the i18n KEY, not the wire value — the seam maps one
+    // to the other, so only one spelling may exist on the wire.
+    for (const value of ['COUNT', 'Count', 'countDistinct', 'median', 'first', '', undefined, null, 1, {}]) {
+      expect(isBuiltinAggregate(value), String(value)).toBe(false);
+    }
+  });
+});

--- a/packages/core/src/utils/chart-series.ts
+++ b/packages/core/src/utils/chart-series.ts
@@ -53,6 +53,39 @@ export interface ChartResultField {
 }
 
 /**
+ * The OPTIONAL wire discriminator naming which server-side BUILT-IN default
+ * measure a result column is (objectui#7258; producer half objectstack#14492).
+ * The analytics service sets it ONLY on the measures it minted itself with a
+ * hard-coded English default label (`count` → `'Count'`, …); an author-declared
+ * measure never carries it, so its `label` stays the author's verbatim text
+ * (objectui#4106). {@link resolveMeasureLabel} is the one reader.
+ *
+ * Declared BESIDE {@link ChartResultField} rather than on it, deliberately:
+ * `dataset-result-field-spec-parity` pins every key of `ChartResultField` as a
+ * key of the spec's `AnalyticsResult.fields[]`, and the `@objectstack/spec`
+ * this package is built against does not carry `builtinAggregate` yet. The
+ * intersection {@link ChartMeasureField} is what the helpers accept, so a
+ * spec-typed field flows in unchanged today and carries the key the moment
+ * the spec does — structurally, with no cast at the call sites.
+ *
+ * Typed as `string` rather than the closed {@link BuiltinAggregate} union on
+ * purpose: a JSON response is handed here as-is, so the value is validated at
+ * the lookup ({@link isBuiltinAggregate}) instead of trusted at the type.
+ *
+ * TODO(objectstack#14492): once the spec dependency is bumped past the release
+ * that adds `AnalyticsResult.fields[].builtinAggregate`, fold this key into
+ * `ChartResultField` as `DatasetResultField['builtinAggregate']` (pinning the
+ * two closed vocabularies to each other in the parity suite) and retire the
+ * carrier.
+ */
+export interface BuiltinAggregateCarrier {
+  builtinAggregate?: string;
+}
+
+/** A result field as the series helpers read it: the renderer shape plus the optional discriminator. */
+export type ChartMeasureField = ChartResultField & BuiltinAggregateCarrier;
+
+/**
  * One renderer-internal series binding produced by {@link buildChartSeries}:
  * WHICH result-set column to draw and what to call it.
  *
@@ -73,6 +106,61 @@ export interface ChartSeriesResult {
   data: Array<Record<string, unknown>>;
   xAxisKey: string | undefined;
   series: ChartSeriesBinding[];
+}
+
+/**
+ * The closed vocabulary of server-side built-in default measures a result field
+ * can declare itself as (objectui#7258 / objectstack#14492) — the spec's own
+ * measure-aggregate enum spelling (`count_distinct`, not `countDistinct`), so
+ * there is exactly ONE spelling on the wire and this list never grows on its
+ * own: a value outside it is not "a new aggregate", it is an unrecognised one,
+ * and {@link resolveMeasureLabel} treats it as absent.
+ */
+export const BUILTIN_AGGREGATES = ['count', 'sum', 'avg', 'min', 'max', 'count_distinct'] as const;
+
+/** One member of {@link BUILTIN_AGGREGATES}. */
+export type BuiltinAggregate = (typeof BUILTIN_AGGREGATES)[number];
+
+/** Runtime membership test for {@link BUILTIN_AGGREGATES}, over an untrusted wire value. */
+export function isBuiltinAggregate(value: unknown): value is BuiltinAggregate {
+  return typeof value === 'string' && (BUILTIN_AGGREGATES as readonly string[]).includes(value);
+}
+
+/**
+ * The LOCALIZED display label per built-in aggregate, as the layer that holds
+ * the i18n provider resolved them (`@object-ui/i18n`'s
+ * `builtinAggregateLabels(tt)`). Partial on purpose: an aggregate the caller
+ * did not resolve falls back to the wire `label`, exactly as if the field had
+ * carried no discriminator.
+ */
+export type BuiltinAggregateLabels = Partial<Record<BuiltinAggregate, string>>;
+
+/**
+ * The display label of ONE result field, for a legend / axis / tooltip.
+ *
+ * Resolution order (objectui#7258, maintainer ruling B of 2026-09-02):
+ *  1. the field declares itself a built-in default measure
+ *     (`builtinAggregate` ∈ {@link BUILTIN_AGGREGATES}) AND the caller resolved
+ *     a locale label for it → that label. This is the only path that can
+ *     replace a wire `label`, and it is keyed by a STRUCTURAL discriminator —
+ *     never by matching the label's text or the field's name, both of which
+ *     the ruling rejected (a real author measure literally named `count`, or
+ *     labelled `Count`, must keep its own label);
+ *  2. otherwise the wire `label` verbatim — the objectui#4106 contract for an
+ *     author-declared measure (`'Tasks'` reaches the legend untouched);
+ *  3. otherwise the field's `name`.
+ *
+ * So a discriminator the caller has no label for (a provider-less host, or a
+ * value outside the closed vocabulary) costs nothing: the field renders exactly
+ * what it rendered before the discriminator existed.
+ */
+export function resolveMeasureLabel(field: ChartMeasureField, labels?: BuiltinAggregateLabels): string {
+  const aggregate = field.builtinAggregate;
+  if (isBuiltinAggregate(aggregate)) {
+    const localized = labels?.[aggregate];
+    if (typeof localized === 'string' && localized !== '') return localized;
+  }
+  return field.label ?? field.name;
 }
 
 /**
@@ -164,6 +252,16 @@ export interface ChartSeriesOptions {
    * it, so a mismatch costs the null bucket its drill-through.
    */
   nullCategoryLabel?: string;
+  /**
+   * Locale labels for the server's BUILT-IN default measures, keyed by the
+   * wire discriminator a result field carries as `builtinAggregate`
+   * (objectui#7258). Same division of labour as `nullCategoryLabel`: this
+   * package is React-free and i18n-free, so the renderer that holds the
+   * provider resolves the strings (`builtinAggregateLabels(tt)` in
+   * `@object-ui/i18n`) and passes them in. Absent ⇒ every measure keeps its
+   * wire `label`, which for a built-in default is the server's English.
+   */
+  builtinAggregateLabels?: BuiltinAggregateLabels;
 }
 
 /** Per-CLICK knobs for {@link findChartSeriesRow}, on top of the shared ones. */
@@ -432,14 +530,19 @@ export function buildChartSeries(
   rows: Array<Record<string, unknown>> | null | undefined,
   dimensions: string[] | null | undefined,
   values: string[] | null | undefined,
-  fields?: ChartResultField[] | null,
+  fields?: ChartMeasureField[] | null,
   options?: ChartSeriesOptions,
 ): ChartSeriesResult {
   const dims = (dimensions ?? []).filter(Boolean);
   const vals = (values ?? []).filter(Boolean);
   const safeRows = Array.isArray(rows) ? rows : [];
-  const labelOf = (name: string): string =>
-    (fields ?? []).find((f) => f.name === name)?.label ?? name;
+  // A measure's series label: the locale label when the field declares itself
+  // a built-in default measure and the caller resolved one, else the wire
+  // `label` verbatim (objectui#4106), else the name — see `resolveMeasureLabel`.
+  const labelOf = (name: string): string => {
+    const field = (fields ?? []).find((f) => f.name === name);
+    return field ? resolveMeasureLabel(field, options?.builtinAggregateLabels) : name;
+  };
 
   // Multi-dimension, single-measure → pivot the second dimension into series.
   if (dims.length >= 2 && vals.length === 1) {

--- a/packages/i18n/src/__tests__/builtinAggregateLabels-locale-parity-7258.test.ts
+++ b/packages/i18n/src/__tests__/builtinAggregateLabels-locale-parity-7258.test.ts
@@ -1,0 +1,119 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7258 — the bundle-reading half of the built-in aggregate label seam.
+ *
+ * `all-locales-key-parity` already enforces en ↔ pack key parity generically,
+ * so this file is deliberately narrow (the `gantt-quickfilter-locale-parity`
+ * shape). It pins the three things that guard cannot express on its own:
+ *
+ *  1. Every pack carries a non-empty `report.aggregate.*` label for EVERY
+ *     member of core's closed `BUILTIN_AGGREGATES` vocabulary. Parity is
+ *     symmetric — deleting the block from all ten packs keeps that suite green
+ *     while every built-in measure silently reverts to the server's English.
+ *  2. `builtinAggregateLabels(tt)` maps the wire spelling to the bundle key
+ *     (`count_distinct` → `countDistinct`) for each member and for nothing
+ *     else — a member added to core without a line in the seam is a compile
+ *     error, and this is its runtime twin.
+ *  3. The English fallbacks the seam carries are byte-equal to the `en` pack,
+ *     so a provider-less host renders what an `en` session renders.
+ */
+import { describe, it, expect } from 'vitest';
+import { BUILTIN_AGGREGATES, type BuiltinAggregate } from '@object-ui/core';
+import { builtInLocales } from '../locales';
+import { builtinAggregateLabels } from '../builtinAggregateLabels';
+
+// Derived from the map rather than left as `string[]` — the same convention as
+// `gantt-quickfilter-locale-parity.test.ts` next door (TS7053 otherwise).
+type LocaleCode = keyof typeof builtInLocales;
+const LANGS = Object.keys(builtInLocales) as LocaleCode[];
+
+/** Wire spelling → `report.aggregate.*` leaf. The ONLY mapping the seam does. */
+const BUNDLE_KEY: Record<BuiltinAggregate, string> = {
+  count: 'count',
+  count_distinct: 'countDistinct',
+  sum: 'sum',
+  avg: 'avg',
+  min: 'min',
+  max: 'max',
+};
+
+/** The pack's `report.aggregate` block, reached through the one shape this file reads. */
+const aggregateOf = (lang: LocaleCode) =>
+  (builtInLocales[lang] as { report?: { aggregate?: Record<string, string> } }).report?.aggregate;
+
+/**
+ * A `useSafeTranslate()` stand-in bound to one pack: a real, non-empty pack
+ * value wins, anything else falls back — the hook's own contract.
+ */
+const ttFrom = (lang: LocaleCode) => (key: string, fallback: string): string => {
+  const value = key
+    .split('.')
+    .reduce<unknown>((node, part) => (node as Record<string, unknown> | undefined)?.[part], builtInLocales[lang]);
+  return typeof value === 'string' && value !== '' ? value : fallback;
+};
+
+describe('report.aggregate.* covers the built-in aggregate vocabulary in every pack (objectui#7258)', () => {
+  it('covers all ten built-in packs', () => {
+    expect(LANGS).toHaveLength(10);
+  });
+
+  it.each(LANGS)('%s defines a non-empty label for every built-in aggregate', (lang) => {
+    const block = aggregateOf(lang);
+    expect(block, `${lang} has no report.aggregate block`).toBeTruthy();
+    for (const aggregate of BUILTIN_AGGREGATES) {
+      const leaf = BUNDLE_KEY[aggregate];
+      expect(typeof block![leaf], `${lang}.report.aggregate.${leaf}`).toBe('string');
+      expect(block![leaf].trim().length, `${lang}.report.aggregate.${leaf} is empty`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('builtinAggregateLabels — the seam between the wire spelling and the bundle', () => {
+  it('maps every member of the closed vocabulary, and nothing else', () => {
+    const labels = builtinAggregateLabels(ttFrom('en'));
+    expect(Object.keys(labels).sort()).toEqual([...BUILTIN_AGGREGATES].sort());
+  });
+
+  it.each(LANGS)('%s: each label IS that pack`s report.aggregate value', (lang) => {
+    const labels = builtinAggregateLabels(ttFrom(lang));
+    for (const aggregate of BUILTIN_AGGREGATES) {
+      expect(labels[aggregate], `${lang}:${aggregate}`).toBe(aggregateOf(lang)![BUNDLE_KEY[aggregate]]);
+    }
+  });
+
+  it('zh: the card`s own strings — a built-in count reads 计数', () => {
+    expect(builtinAggregateLabels(ttFrom('zh'))).toEqual({
+      count: '计数',
+      count_distinct: '去重计数',
+      sum: '求和',
+      avg: '平均',
+      min: '最小值',
+      max: '最大值',
+    });
+  });
+
+  it('en: reads the en pack', () => {
+    expect(builtinAggregateLabels(ttFrom('en'))).toEqual({
+      count: 'Count',
+      count_distinct: 'Distinct Count',
+      sum: 'Sum',
+      avg: 'Average',
+      min: 'Min',
+      max: 'Max',
+    });
+  });
+
+  it('provider-less: the inline English fallbacks are byte-equal to the en pack', () => {
+    // A `tt` that misses every key is what a host with no I18nProvider gets;
+    // its output must not drift from what an `en` session renders.
+    const missEverything = (_key: string, fallback: string) => fallback;
+    expect(builtinAggregateLabels(missEverything)).toEqual(builtinAggregateLabels(ttFrom('en')));
+  });
+});

--- a/packages/i18n/src/builtinAggregateLabels.ts
+++ b/packages/i18n/src/builtinAggregateLabels.ts
@@ -1,0 +1,52 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7258 — the locale labels for the analytics service's BUILT-IN
+ * default measures, keyed by the wire discriminator a result field carries as
+ * `builtinAggregate` (producer half: objectstack#14492).
+ *
+ * `@object-ui/core`'s `buildChartSeries` cannot read the locale bundle (that
+ * package is React-free and i18n-free by design), so this is the seam: the
+ * renderer that holds the provider resolves the six strings ONCE through its
+ * `useSafeTranslate()` and hands the map to core as
+ * `ChartSeriesOptions.builtinAggregateLabels` — the same division of labour
+ * `chart.nullCategory` already makes for the null bucket's label.
+ *
+ * The keys are the `report.aggregate.*` family the matrix report and the
+ * dashboard's aggregate charts already read, not a second namespace: the
+ * vocabulary (Count / Sum / Average / …) is the same on every surface, so ten
+ * packs already carry it and a new key would only add drift surface. The only
+ * mapping done here is spelling — the wire enum says `count_distinct`, the
+ * bundle key says `countDistinct`.
+ *
+ * The English fallbacks are byte-equal to the `en` pack's values, so a
+ * provider-less host renders exactly what an `en` session renders (pinned in
+ * `__tests__/builtinAggregateLabels-locale-parity-7258.test.ts`).
+ */
+import type { BuiltinAggregate } from '@object-ui/core';
+
+/** The per-call translate shape `useSafeTranslate()` returns: first real translation, else the English fallback. */
+export type SafeTranslate = (key: string, fallback: string) => string;
+
+/**
+ * Resolve the display label of every built-in aggregate through the locale
+ * bundle. Typed as the FULL record on purpose: a member added to core's
+ * `BUILTIN_AGGREGATES` without a line here is a compile error, not a legend
+ * that silently falls back to the server's English.
+ */
+export function builtinAggregateLabels(tt: SafeTranslate): Record<BuiltinAggregate, string> {
+  return {
+    count: tt('report.aggregate.count', 'Count'),
+    count_distinct: tt('report.aggregate.countDistinct', 'Distinct Count'),
+    sum: tt('report.aggregate.sum', 'Sum'),
+    avg: tt('report.aggregate.avg', 'Average'),
+    min: tt('report.aggregate.min', 'Min'),
+    max: tt('report.aggregate.max', 'Max'),
+  };
+}

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -56,6 +56,10 @@ export {
 // Safe translation hook factory
 export { createSafeTranslation, useSafeTranslate } from './useSafeTranslation.js';
 
+// objectui#7258 — locale labels for the server's built-in default measures,
+// handed to core's `buildChartSeries` as `builtinAggregateLabels`.
+export { builtinAggregateLabels, type SafeTranslate } from './builtinAggregateLabels.js';
+
 // Convention-based object/field label i18n
 export { useObjectLabel, useSafeFieldLabel } from './useObjectLabel.js';
 

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -5,7 +5,7 @@ import { ChartRenderer } from './ChartRenderer';
 import { ComponentRegistry, humanizeLabel, extractRecords, computeDrillFilter, isDrillEnabled, resolveDrillTitle, resolveFilterPlaceholders, resolveContextTokens, shiftFilterByCompareTo, compareToTrendLabelKey, buildChartSeries, buildOptionColorMap, deriveDimensionLabelMaps, dimensionOptionTranslator, loadDimensionFieldMeta, relabelDimensions, localizeFieldOptions, elementDataSourceBlock, type DimensionFieldMeta, type CompareToConfig, type DrillEvent, type ChartResultField, type ChartSegmentClickEvent } from '@object-ui/core';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Dialog, DialogContent, DialogHeader, DialogTitle, RefreshIndicator, Button, ChartSkeleton, DataEmptyState } from '@object-ui/components';
 import { AlertCircle, ArrowUpRight, Inbox } from 'lucide-react';
-import { useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
+import { builtinAggregateLabels, useSafeFieldLabel, useSafeTranslate } from '@object-ui/i18n';
 import type { DrillDownConfig } from '@object-ui/types';
 
 /**
@@ -859,13 +859,23 @@ export const ObjectChart = (props: any) => {
   // from here because `@object-ui/core` is React-free and cannot read the locale
   // bundle (same division as `dimensionOptionTranslator` above — core takes the
   // resolver, the renderer holds the provider).
+  //
+  // `builtinAggregateLabels` is the same division for a MEASURE's label
+  // (objectui#7258): a result field the server minted as a built-in default
+  // (`builtinAggregate: 'count'`, objectstack#14492) reads its legend / axis
+  // text from the locale bundle here instead of the server's English `label`;
+  // an author-declared measure carries no discriminator and keeps its label
+  // verbatim (objectui#4106).
   const datasetChart = schema.dataset
     ? buildChartSeries(
         relabelDimensions(finalData, dimensionLabels),
         schema.dimensions,
         schema.values,
         datasetFields,
-        { nullCategoryLabel: tt('chart.nullCategory', '(None)') },
+        {
+          nullCategoryLabel: tt('chart.nullCategory', '(None)'),
+          builtinAggregateLabels: builtinAggregateLabels(tt),
+        },
       )
     : null;
 

--- a/packages/plugin-dashboard/src/DatasetWidget.tsx
+++ b/packages/plugin-dashboard/src/DatasetWidget.tsx
@@ -76,7 +76,7 @@ import {
   type DatasetDrillRange,
 } from '@object-ui/core';
 import { cn, Skeleton, ChartSkeleton, GridSkeleton } from '@object-ui/components';
-import { useSafeFieldLabel, useSafeTranslate, useDisplayLocale } from '@object-ui/i18n';
+import { builtinAggregateLabels, useSafeFieldLabel, useSafeTranslate, useDisplayLocale } from '@object-ui/i18n';
 import { AlertTriangle, Download, ArrowUpIcon, ArrowDownIcon, MinusIcon, ChevronsUpDown, ChevronUp, ChevronDown } from 'lucide-react';
 // objectui#7063 — the default empty state is stated ONCE for the dashboard
 // surface (see that component's header for why it is dashboard-local).
@@ -1387,7 +1387,17 @@ export function DatasetWidget({ widget, dataSource }: { widget: any; dataSource:
   const nullCategoryLabel = tt('chart.nullCategory', '(None)');
   // ADR-0021 (#1759): shared helper — pivots a second dimension into grouped
   // series so multi-dimension dataset widgets match the chart-view renderer.
-  const { data: chartData, xAxisKey, series } = buildChartSeries(chartRows, dimensions, values, state.fields, { nullCategoryLabel });
+  //
+  // `builtinAggregateLabels` (objectui#7258) is the same division for a
+  // MEASURE's label: a result field the server minted as a built-in default
+  // (`builtinAggregate: 'count'`, objectstack#14492) takes its series label
+  // from the locale bundle here — `计数` on a zh console, not the server's
+  // English `Count` — while an author-declared measure carries no discriminator
+  // and keeps its wire `label` verbatim (objectui#4106).
+  const { data: chartData, xAxisKey, series } = buildChartSeries(chartRows, dimensions, values, state.fields, {
+    nullCategoryLabel,
+    builtinAggregateLabels: builtinAggregateLabels(tt),
+  });
 
   // The author's PRESENTATION, merged onto those derived bindings — per-series
   // mark and axis binding, plus the axis definitions (#4229). Membership stays

--- a/packages/plugin-dashboard/src/__tests__/DatasetWidget.builtinAggregateLabel.test.tsx
+++ b/packages/plugin-dashboard/src/__tests__/DatasetWidget.builtinAggregateLabel.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7258 — the SURFACE pin for the built-in aggregate label seam, on
+ * the widget the card was measured on: an AI-built customer dashboard's
+ * "customers by status" bar, whose three category labels were already
+ * localized (合作中 / 已流失 / 潜在) while the measure title read `Count`.
+ *
+ * The pure halves are pinned in `@object-ui/core` (`chart-series.builtinAggregate`)
+ * and `@object-ui/i18n` (`builtinAggregateLabels-locale-parity-7258`). What
+ * neither can show is the WIRING — that `DatasetWidget` actually resolves the
+ * six strings through its provider and hands them to `buildChartSeries` — and
+ * a seam nothing wires is the exact "declared but dead" shape this repo hunts.
+ * So this file renders the widget under a real `I18nProvider` and reads the
+ * series it handed the chart renderer.
+ *
+ * DIRECTIONS, written before the reverse verification was run: the zh
+ * built-in case is RED before the change (the series reads `Count`); the `en`
+ * case and both "verbatim" cases are GREEN on both sides.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { I18nProvider } from '@object-ui/i18n';
+import { DatasetWidget } from '../DatasetWidget';
+
+/** The slice of the chart renderer's props this file reads. */
+interface CapturedChart {
+  schema?: { series?: Array<{ dataKey: string; label?: string }>; data?: Array<Record<string, unknown>> };
+}
+
+/** Capture what the widget hands the chart renderer (jsdom lays out no SVG). */
+let capturedChartProps: CapturedChart | null = null;
+beforeAll(() => {
+  ComponentRegistry.register('chart', (props: unknown) => {
+    capturedChartProps = props as CapturedChart;
+    return null;
+  });
+});
+
+vi.mock('../DrillDownDrawer', () => ({ DrillDownDrawer: () => null }));
+
+beforeEach(() => {
+  // No `object` on the result, so the widget has no definition to probe; the
+  // stub is here so any escape onto the network is loud rather than swallowed.
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, json: async () => ({}) })));
+});
+
+afterEach(() => {
+  cleanup();
+  capturedChartProps = null;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+/** The card's rows: categories already localized by the server. */
+const ROWS = [
+  { status: '合作中', count: 3 },
+  { status: '已流失', count: 1 },
+  { status: '潜在', count: 2 },
+];
+
+/** What objectstack#14492 puts on the wire for the server's built-in count. */
+const BUILTIN_COUNT = { name: 'count', type: 'number', label: 'Count', builtinAggregate: 'count' };
+const STATUS = { name: 'status', type: 'string', label: 'Status' };
+
+type WidgetSource = React.ComponentProps<typeof DatasetWidget>['dataSource'];
+
+const sourceOf = (fields: Array<Record<string, unknown>>, rows: Array<Record<string, unknown>> = ROWS) =>
+  ({ queryDataset: vi.fn(async () => ({ rows, fields })) }) as unknown as WidgetSource;
+
+function renderIn(language: string, dataSource: WidgetSource, values = ['count']) {
+  return render(
+    <I18nProvider config={{ defaultLanguage: language, detectBrowserLanguage: false, resources: {} }}>
+      <DatasetWidget
+        widget={{ type: 'bar', dataset: 'customers_by_status', dimensions: ['status'], values }}
+        dataSource={dataSource}
+      />
+    </I18nProvider>,
+  );
+}
+
+/** The series labels the widget handed the renderer — the legend / axis text. */
+const seriesLabels = (): Array<string | undefined> =>
+  (capturedChartProps?.schema?.series ?? []).map((s) => s.label);
+
+describe('DatasetWidget — the built-in aggregate title follows the locale (objectui#7258)', () => {
+  it('zh: the server`s built-in count draws under 计数, not the wire`s English Count', async () => {
+    renderIn('zh', sourceOf([STATUS, BUILTIN_COUNT]));
+    await waitFor(() => expect(seriesLabels()).toEqual(['计数']));
+    // The category labels are untouched by the seam — they were already right.
+    expect((capturedChartProps?.schema?.data ?? []).map((r) => r.status)).toEqual(['合作中', '已流失', '潜在']);
+  });
+
+  it('en: the same wire field draws under Count', async () => {
+    renderIn('en', sourceOf([STATUS, BUILTIN_COUNT]));
+    await waitFor(() => expect(seriesLabels()).toEqual(['Count']));
+  });
+
+  it('zh: an author-declared measure keeps its verbatim label (objectui#4106)', async () => {
+    const rows = ROWS.map(({ status, count }) => ({ status, opp_count: count }));
+    renderIn('zh', sourceOf([STATUS, { name: 'opp_count', type: 'number', label: 'Opportunities' }], rows), [
+      'opp_count',
+    ]);
+    await waitFor(() => expect(seriesLabels()).toEqual(['Opportunities']));
+  });
+
+  it('zh: a measure literally named `count` with NO discriminator keeps its own label', async () => {
+    // Option A, rejected, stated on the surface: neither the name nor the
+    // English text switches the lookup on — only the structural field does.
+    renderIn('zh', sourceOf([STATUS, { name: 'count', type: 'number', label: 'Count' }]));
+    await waitFor(() => expect(seriesLabels()).toEqual(['Count']));
+  });
+});

--- a/packages/plugin-report/src/DatasetReportRenderer.tsx
+++ b/packages/plugin-report/src/DatasetReportRenderer.tsx
@@ -93,7 +93,7 @@ import {
   type DatasetResultField,
   type DatasetDrillRange,
 } from '@object-ui/core';
-import { useSafeFieldLabel, useSafeTranslate, useDisplayLocale, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
+import { builtinAggregateLabels, useSafeFieldLabel, useSafeTranslate, useDisplayLocale, useObjectTranslation, pickLocalized } from '@object-ui/i18n';
 import { mergeFilters } from './mergeFilters';
 import { useDatasetDimensionLabels, useDatasetDimensionMeta } from './useDatasetDimensionLabels';
 
@@ -1000,12 +1000,20 @@ function DatasetReportChart({
   // helper's single-dimension branch and returns ONE series; the pivot branch
   // (2+ dimensions) is unreachable from a report chart, whose schema declares a
   // single `xAxis`/`yAxis` pair.
+  //
+  // `builtinAggregateLabels` (objectui#7258): a measure the server minted as a
+  // built-in default (`builtinAggregate: 'count'`, objectstack#14492) reads its
+  // series label from the locale bundle; an author-declared measure carries no
+  // discriminator and keeps its wire `label` verbatim (objectui#4106).
   const { data: chartData, xAxisKey, series: derivedSeries } = buildChartSeries(
     relabelDimensions(state.rows, dimensionLabels),
     [xAxis],
     [yAxis],
     state.fields,
-    { nullCategoryLabel: tt('chart.nullCategory', '(None)') },
+    {
+      nullCategoryLabel: tt('chart.nullCategory', '(None)'),
+      builtinAggregateLabels: builtinAggregateLabels(tt),
+    },
   );
 
   // ── The PRESENTATION half: authored, merged forward (#4229) ──────────────


### PR DESCRIPTION
Closes #7258
Part of objectstack-ai/cloud#1841 — the CONSUMER half of maintainer ruling B (2026-09-02); the producer half is objectstack-ai/objectstack#14492.

**Depends on objectstack#14492 landing upstream for the field to be populated.** Until then the wire carries no `builtinAggregate`, and every chart renders exactly as today — this PR is inert by construction on the current spec, and stays a draft until the producer merges.

## The defect

An AI-built customer dashboard's "customers by status" bar shows three localized category labels (合作中 / 已流失 / 潜在) under an aggregate axis title that reads `Count` on a zh console. The literal is not minted in this repo: `buildChartSeries` passes `fields[].label` through verbatim — correctly, for an author-declared measure (objectui#4106 pins `'Tasks'`) — and the analytics service hard-codes `label: 'Count'` on its built-in default measure with no i18n hook. The renderer had no way to tell the two apart, and guessing from the label's text or the field's name (option A) was rejected.

## Consumer contract — what this PR reads

- `AnalyticsResult.fields[]` gains an OPTIONAL structural discriminator, `builtinAggregate`, with the closed enum `'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'` (the spec's own measure-aggregate spelling), populated ONLY on the server-side built-in default measures. An author-declared measure never carries it.
- Read structurally and validated at the lookup: `isBuiltinAggregate` checks the wire value against the closed vocabulary; a recognised value resolves through the caller's locale map; an unrecognised value (or none) is treated as absent and the field keeps its wire `label` verbatim, then its `name`.
- Never inferred from the field's name or the label's text: a real author measure literally named `count` and labelled `Count`, without the discriminator, keeps its own label — pinned at both the pure and the surface level.

## How `@objectstack/spec` is consumed here, and whether a pin bump is needed

- By npm RANGE, not a workspace link or SHA pin: `@object-ui/core` declares `@objectstack/spec` `^17.2.0` (root `^17.0.0`), the lockfile resolves **17.2.0**. This repo has no `.objectstack-sha`-style pin.
- The 17.2.0 `AnalyticsResult.fields[]` element has no `builtinAggregate`, and `packages/core/src/utils/__tests__/dataset-result-field-spec-parity.test.ts` pins `keyof ChartResultField` as a subset of the spec element's keys at compile time. Adding the key ON `ChartResultField` turned that pin red (measured: TS2344 at line 121, `Extends` distributing to `boolean`). So the key lives BESIDE it as `BuiltinAggregateCarrier`, and `buildChartSeries` takes `ChartMeasureField[]` (`ChartResultField` intersected with the carrier): a spec-typed `DatasetResultField[]` flows in unchanged today and carries the key the moment the spec does, with no cast at any call site. The parity suite stays green on 17.2.0.
- **No pin bump in this PR.** Follow-up once the spec release carrying the field ships: raise `@objectstack/spec` to that minor, fold `builtinAggregate` into `ChartResultField` as `DatasetResultField['builtinAggregate']`, retire the carrier, and pin the two closed enums to each other in the parity suite — recorded as `TODO(objectstack#14492)` in `chart-series.ts`.

## Before / after

| wire field | session | before | after |
|---|---|---|---|
| `{ name: 'count', label: 'Count', builtinAggregate: 'count' }` | zh | `Count` | `计数` |
| same | en | `Count` | `Count` |
| `{ name: 'task_count', label: 'Tasks' }` (author, no discriminator) | zh | `Tasks` | `Tasks` |
| `{ name: 'count', label: 'Count' }` (author, no discriminator) | zh | `Count` | `Count` |
| `{ …, builtinAggregate: 'median' }` (outside the vocabulary) | zh | label | label |
| built-in field, provider-less host / map without the entry | — | `Count` | `Count` |

## What changed, and the file-surface note

- `packages/core/src/utils/chart-series.ts` — `BuiltinAggregateCarrier`, `ChartMeasureField`, `BUILTIN_AGGREGATES`, `BuiltinAggregate`, `isBuiltinAggregate`, `BuiltinAggregateLabels`, `resolveMeasureLabel`; `ChartSeriesOptions.builtinAggregateLabels`; `labelOf` resolves through `resolveMeasureLabel`.
- `packages/i18n/src/builtinAggregateLabels.ts` (+ `index.ts` export) — `builtinAggregateLabels(tt)` resolves the six strings through the existing `report.aggregate.*` keys (`count_distinct` maps to the bundle's `countDistinct`); English fallbacks byte-equal to the `en` pack.
- `ObjectChart.tsx`, `DatasetWidget.tsx`, `DatasetReportRenderer.tsx` — pass `builtinAggregateLabels(tt)` beside `nullCategoryLabel`.
- Tests (below) and `.changeset/7258-chart-builtin-aggregate-label.md`.

The claim's surface was `chart-series.ts`, the locale bundles, and tests beside it. Three things sit outside it, each necessary for the fix to reach a user rather than stay a seam nothing wires:

1. **The three call sites** — one option each. `@object-ui/core` is React-free and i18n-free (its own doctrine for `nullCategoryLabel`), so the locale strings MUST be resolved by the layer holding the provider and passed in.
2. **The i18n seam module** — the ONE place the six keys are read for this purpose, instead of six `tt()` calls copied into three renderers. The locale bundles themselves are untouched: all ten packs already carry `report.aggregate.{count, countDistinct, sum, avg, min, max}` (now pinned per pack).
3. **`DatasetWidget.builtinAggregateLabel.test.tsx`** — the surface pin under a real `I18nProvider`, on the widget the card was measured on.

## Tests

- core `chart-series.builtinAggregate.test.ts` (14): zh 计数 / en Count; every enum member; verbatim author label (objectui#4106); authored `count` keeps `Count`; unknown discriminator → label / → name; no labels, missing entry, empty string → wire label; pivot branch untouched; `resolveMeasureLabel` order; `isBuiltinAggregate` truth table.
- i18n `builtinAggregateLabels-locale-parity-7258.test.ts` (15): all ten packs carry a non-empty label for every member; the seam maps exactly the closed vocabulary; per-pack value identity; zh / en literal pins; provider-less fallbacks equal the en pack.
- dashboard `DatasetWidget.builtinAggregateLabel.test.tsx` (4): zh 计数 / en Count / verbatim `Opportunities` / authored `count` keeps `Count`, read off the series the widget hands the chart renderer.

### Reverse verification (ablation) — at `799c84a27`, after the commit

Mutation: `labelOf` back to the pre-fix `field?.label ?? name` (on-disk proof: injected marker count 1, removed call count 0). Ran the core + dashboard pins: **4 failed / 14 passed** — red exactly where predicted: zh built-in count (core), every-member, multi-measure, zh built-in count (surface). Direction note, recorded rather than fitted: the `en` pins stayed green under the mutation because the `en` locale label IS the wire `Count` — they are controls, not discriminating pins. Restore: `git checkout HEAD -- path`; `git hash-object` equals the HEAD blob (`bcae7ca08…`), `git diff HEAD` empty, marker count 0. No `dist/` is involved in either leg: the root vitest config aliases `@object-ui/*` to `src/` and the core test imports relatively.

## Verification — union at `799c84a27` (the final commit)

- `pnpm --filter` core / i18n / plugin-charts / plugin-dashboard / plugin-report `run type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`): all five **Done, exit 0**, after `pnpm --filter 'plugin-{dashboard,report,charts}^...' build`. `--listFiles` shows each new test file inside its package's test project (1 / 1 / 1), so "type-check clean" covers the new tests.
- `pnpm exec vitest run --maxWorkers=2` over 16 files (the 3 new + every chart-series / dataset-format / spec-parity / label-net sibling + `ObjectChart.datasetMeasureLabel` + two `DatasetWidget` label suites): **Test Files 16 passed, Tests 256 passed**, exit 0.
- ESLint (root config, `--format json`) over the 9 `.ts` / `.tsx` files this diff touches (the 10th changed file is the changeset, outside `files: ['**/*.{ts,tsx}']`): exit 0, **0 errors**, 74 warnings — **0 on any line this diff added** (measured against `git diff -U0` hunks; the 74 are pre-existing: ObjectChart.tsx 58, DatasetWidget.tsx 11, DatasetReportRenderer.tsx 5). Narrowing proof: the universe is eslint's own `files` glob; the count is the JSON output's 9 entries; `grep -cE 'projectService|parserOptions|project:' eslint.config.js` = 0 (control `files:|ignores:` = 9), so type-aware linting is off and no untouched file's verdict can move.
- `check-changeset-presence` (9 source files of 5 released packages, 1 changeset declared), `check-changeset-fixed`, `check-changeset-no-major`, `check-changeset-overwrite`: exit 0 each.
- `check-control-bytes`: OK (6206 tracked files); targeted perl scan over the diff files: 0 hits.
- `check-i18n-call-site-keys`: every in-scope key resolves and every positional default matches the en pack; `check-i18n-en-drift`: no en value changed; `check-phantom-dependencies`: OK.
- **NOT MEASURED locally**: `check:readme-exports` (257 "type entry not on disk" — 22 packages this worktree never built) and `check:spec-floors` (12 findings, all `no-artifact` on those same unbuilt packages; the 19 built ones, including all five touched here, judged 185 subpath/symbol pairs clean). This diff changes no manifest and imports no new spec symbol; CI builds the workspace and measures both.
- Verify lock: `os-verify-lock.sh` ran in DECLARED UNLOCKED MODE (no usable `flock` on this macOS host) — nothing was serialized.

## Changeset

`.changeset/7258-chart-builtin-aggregate-label.md` — core and i18n `minor` (new exports), plugin-charts / plugin-dashboard / plugin-report `patch`.

## Out of scope, filed

- objectui-issue 7534 — the same class one seam over: `buildDatasetFieldHelpers().headerLabel` (KPI caption, table / pivot headers, report metric caption, `DatasetPreview`) still prints the wire `Count`; the resolver from this PR makes it a mechanical follow-up across five call sites (including app-shell). It remains open; nothing here addresses it.

Session: `session_c5c0ce54-bb9c-478c-9e5b-cf44b80d4569`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
