### PR TITLE
fix(types): rename KanbanColumn.items to cards on both published halves

### DIFF
--- a/.changeset/6939-kanban-column-cards.md
+++ b/.changeset/6939-kanban-column-cards.md
@@ -1,0 +1,38 @@
+---
+'@object-ui/types': minor
+---
+
+Rename `KanbanColumn.items` to `cards`, in both halves of the published surface
+(objectui#6939, maintainer ruling 2026-09-02).
+
+**Breaking, deliberately.** `KanbanColumn` declared its card list as `items` in
+`complex.ts` and in the zod mirror `complex.zod.ts`. Every board reads `cards`.
+Measured on `origin/main` `78a3cc238`: `KanbanImpl.tsx` reads `.cards` on 12
+lines, `KanbanEnhanced.tsx` on 8, and `bucketCardsIntoColumns` twice more as
+`col.cards || []`; `.items` had **zero** read sites in either board (a
+same-shaped `.title` control on the same two files returns 8 and 3, so those
+zeros are readings and not a mis-shaped probe). Both catalog entries, the
+plugin docs and `content/docs/api/schema-reference.md` all author `cards`.
+
+The consequence was `declared !== enforced` on a published mirror: every
+authored kanban document failed `safeValidateSchema` with `: Invalid input`
+while rendering perfectly, which is how the type sat in objectui#6318's
+"carries a registered component type but did not validate" bucket.
+
+**Why the rename went this way and not the other.** Renaming the twelve read
+sites to `items` was considered and rejected: `bucketCardsIntoColumns` reads
+`col.cards || []`, so the `items` spelling buckets every column to zero cards.
+Measured through the render harness in
+`examples/schema-catalog/test/kanban-column-cards-6939.test.tsx`, the
+`basic-kanban-board` entry goes from 64 elements reading `To Do2 … Design new
+feature …` to 45 elements reading `No cards3 columnsTo Do0 …` — an empty board.
+The declaration, not the corpus, was the wrong side.
+
+**Migration.** If you author `KanbanColumn` objects against `@object-ui/types`
+or validate them through `@object-ui/types/zod`, rename `items` to `cards`.
+Documents that already author `cards` — which is every document in this
+repository, and what the boards have always rendered — need no change and now
+validate. Documents authoring `items` are refused rather than silently drawn as
+an empty board.
+
+`@object-ui/plugin-kanban` is unchanged; it already declared `cards`.

--- a/examples/schema-catalog/test/kanban-column-cards-6939.test.tsx
+++ b/examples/schema-catalog/test/kanban-column-cards-6939.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#6939, the `kanban` group — `KanbanColumn`'s card list.
+ *
+ * `packages/types` declared the member as `items`, in both halves of the
+ * published surface (`complex.ts` and its zod mirror `complex.zod.ts`), while
+ * every board reads `cards`. Re-measured on `origin/main` @ `78a3cc238`, the
+ * base of this branch:
+ *
+ *   - `KanbanImpl.tsx`      12 lines read `.cards`,  0 read `.items`
+ *   - `KanbanEnhanced.tsx`   8 lines read `.cards`,  0 read `.items`
+ *   - `index.tsx`            `bucketCardsIntoColumns` reads `col.cards` twice,
+ *                            each as `col.cards || []`
+ *
+ * (A same-shaped LIT control on the same two files — `.title` — returns 8 and
+ * 3, so the two zeros above are readings and not a mis-shaped probe.)
+ *
+ * ## Why the render half is the discriminating half, and why it is inverted here
+ *
+ * objectui#6318's triage: a "correction" that renders identically proves the
+ * SCHEMA was the wrong side. The tree-view row of this card cleared that bar by
+ * rendering identically. This row clears the STRONGER, opposite-polarity bar —
+ * "correcting" the fixtures toward the declaration does not merely change the
+ * render, it EMPTIES THE BOARD. Measured through this file's harness on
+ * `78a3cc238`, before either declaration was touched:
+ *
+ *   basic-kanban-board       `cards` 64 elements, "To Do2 … Design new feature …"
+ *                            `items` 45 elements, "No cards3 columnsTo Do0 …"
+ *   advanced-…-and-limits    `cards` 86 elements, "Backlog2 … User Authentication …"
+ *                            `items` 58 elements, "No cards4 columnsBacklog0 …"
+ *
+ * `column.cards || []` in `bucketCardsIntoColumns` is the mechanism: under the
+ * `items` spelling every column buckets to zero cards. So the accepted spelling
+ * had to move to `cards` — renaming the twelve read sites instead would have
+ * emptied every authored board.
+ *
+ * ## The accept-set move this pins (Clause-② surface)
+ *
+ * Before: the two catalog entries FAILED `safeValidateSchema` (": Invalid
+ * input") and the `items` spelling PASSED. After: exactly reversed. That is a
+ * published mirror's accept/reject behaviour moving, and a renamed member on a
+ * published type — pinned in both directions below.
+ *
+ * ## The harness, and why identity is claimed only within it
+ *
+ * `kanban` resolves to `KanbanRenderer`, which is
+ * `<Suspense><LazyKanban/></Suspense>` over `React.lazy(() =>
+ * import('./KanbanImpl'))`. A bare render measures the Suspense fallback — one
+ * `<div>` skeleton, empty `textContent`, which is the vacuous identity pin this
+ * file must not be (it was the first reading taken here, and it was discarded).
+ *
+ * `measure()` therefore settles the boundary with `waitFor`, the same way the
+ * sibling `catalog-gallery-render.test.tsx` settles it for these very entries
+ * (its comment names `kanban` as one of its three `React.lazy` categories).
+ * Side-effect-importing the lazy chunk at module scope would be faster, but the
+ * only specifier that reaches it — `@object-ui/plugin-kanban/KanbanImpl` — is
+ * not in the package's `exports` map and resolves solely through the repo's
+ * vitest source alias. objectui#4325 ruled that shape out for
+ * `@object-ui/fields`: a package's surface is its index, and one test's preload
+ * does not justify minting permanent public API. The witness used here is a
+ * column heading, which exists in BOTH the populated and the empty board, so
+ * the wait cannot pass for one spelling and time out for the other.
+ *
+ * Absolute counts are harness-relative; identity within THIS harness is the claim.
+ *
+ * Three readings per tile, because a count alone cannot tell a swapped element
+ * from an equal one: element count, a tag census, and the text — visible text
+ * as a literal, plus a SHA-256 over the full `textContent` with the Radix
+ * scroll-area `<style>` blocks included.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { createHash } from 'node:crypto';
+import '@object-ui/components';
+import '@object-ui/plugin-kanban';
+import { SchemaRenderer, SchemaRendererProvider, toRenderableSchema } from '@object-ui/react';
+import { safeValidateSchema } from '@object-ui/types/zod';
+import { getExample } from '../src/index.js';
+
+const IDS = [
+  'plugin-kanban/basic-kanban-board',
+  'plugin-kanban/advanced-kanban-with-badges-and-limits',
+] as const;
+
+type Reading = {
+  elements: number;
+  tags: Record<string, number>;
+  sha256: string;
+  visibleText: string;
+};
+
+/** Radix ScrollArea injects this per viewport; folded out of `visibleText`. */
+const SCROLL_AREA_STYLE =
+  '[data-radix-scroll-area-viewport]{scrollbar-width:none;-ms-overflow-style:none;' +
+  '-webkit-overflow-scrolling:touch;}[data-radix-scroll-area-viewport]::-webkit-scrollbar{display:none}';
+
+/**
+ * The AUTHORED (`cards`) spelling, measured on `origin/main` @ `78a3cc238`
+ * through `measure()` below with both declarations still saying `items`. The
+ * repair must not move any of these numbers.
+ */
+const PRE_REPAIR: Record<(typeof IDS)[number], Reading> = {
+  'plugin-kanban/basic-kanban-board': {
+    elements: 64,
+    tags: { DIV: 52, SPAN: 6, H3: 3, STYLE: 3 },
+    sha256: '034c51898d2e87caa57aaced4c1eff31c8b0e9f3832cd55ee2847aa580b084b4',
+    visibleText: "To Do2Design new featureCreate mockups and wireframesWrite documentationUpdate API docsIn Progress1Implement featureCode the new componentHigh PriorityDone1Setup projectInitialize repository\n    To pick up a draggable item, press the space bar.\n    While dragging, use the arrow keys to move the item.\n    Press space again to drop the item in its new position, or press escape to cancel.\n  ",
+  },
+  'plugin-kanban/advanced-kanban-with-badges-and-limits': {
+    elements: 86,
+    tags: { DIV: 68, SPAN: 10, H3: 4, STYLE: 4 },
+    sha256: 'bec0ae1f2c2a0c945ad582232730fe29a25c529f63f2e4996b40c8ef77454d66',
+    visibleText: "Backlog2User AuthenticationImplement OAuth2.0BackendHighDark ModeAdd theme switcherUIWork In Progress1 / 3API IntegrationConnect to backend servicesIn ProgressCode Review0No cardsCompleted1Project SetupRepository initialized\n    To pick up a draggable item, press the space bar.\n    While dragging, use the arrow keys to move the item.\n    Press space again to drop the item in its new position, or press escape to cancel.\n  ",
+  },
+};
+
+/**
+ * The `items` spelling, measured in the same run. This is the board the
+ * declaration was asking authors to write, and it is empty. Pinned so that the
+ * claim "the rename is toward the shape that ships" stays a measurement.
+ */
+const ITEMS_SPELLING: Record<(typeof IDS)[number], Reading> = {
+  'plugin-kanban/basic-kanban-board': {
+    elements: 45,
+    tags: { DIV: 31, SPAN: 6, H3: 4, P: 1, STYLE: 3 },
+    sha256: '2523834600c510b6673b125862cb2041d9b20d3ddc8c0f53292b17f227d73410',
+    visibleText: "No cards3 columnsTo Do0In Progress0Done0\n    To pick up a draggable item, press the space bar.\n    While dragging, use the arrow keys to move the item.\n    Press space again to drop the item in its new position, or press escape to cancel.\n  ",
+  },
+  'plugin-kanban/advanced-kanban-with-badges-and-limits': {
+    elements: 58,
+    tags: { DIV: 39, SPAN: 9, H3: 5, P: 1, STYLE: 4 },
+    sha256: 'acd99051b378a9eaf6e5096604dba293a6b8f14bd0b8af68e511bc2b1269eeb0',
+    visibleText: "No cards4 columnsBacklog0Work In Progress0 / 3Code Review0Completed0\n    To pick up a draggable item, press the space bar.\n    While dragging, use the arrow keys to move the item.\n    Press space again to drop the item in its new position, or press escape to cancel.\n  ",
+  },
+};
+
+/** Render one entry through the provider-wrapped bare renderer and measure it. */
+async function measure(schema: unknown): Promise<Reading & { text: string }> {
+  const { container, unmount } = render(
+    <SchemaRendererProvider dataSource={undefined}>
+      <SchemaRenderer schema={toRenderableSchema(schema as never) as never} />
+    </SchemaRendererProvider>,
+  );
+  // A column heading exists in BOTH the populated and the empty board, so this
+  // wait is a carrier legal in both states — it cannot pass for one spelling
+  // and time out for the other.
+  await waitFor(() => expect(container.querySelector('h3')).not.toBeNull());
+  const nodes = Array.from(container.querySelectorAll('*'));
+  const text = container.textContent ?? '';
+  const tags = nodes.reduce<Record<string, number>>((h, el) => ((h[el.tagName] = (h[el.tagName] ?? 0) + 1), h), {});
+  const out = {
+    elements: nodes.length,
+    tags,
+    sha256: createHash('sha256').update(text).digest('hex'),
+    visibleText: text.split(SCROLL_AREA_STYLE).join(''),
+    text,
+  };
+  unmount();
+  return out;
+}
+
+/** Report the issues rather than `false`, so a red run says what broke. */
+function reasons(schema: unknown): string[] {
+  const r = safeValidateSchema(schema);
+  return r.success ? [] : r.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+}
+
+/** The same document with every column's `cards` renamed back to `items`. */
+function toItemsSpelling(schema: unknown): unknown {
+  const s = JSON.parse(JSON.stringify(schema)) as { columns: Array<Record<string, unknown>> };
+  for (const col of s.columns) {
+    col.items = col.cards;
+    delete col.cards;
+  }
+  return s;
+}
+
+describe('objectui#6939 — the mirror now accepts the spelling every board reads', () => {
+  it.each(IDS)('%s validates under safeValidateSchema', (id) => {
+    // Each reported `: Invalid input` on `78a3cc238` — `columns[].items` was
+    // required and no authored entry has ever carried it.
+    expect(reasons(getExample(id).schema)).toEqual([]);
+  });
+
+  it.each(IDS)('%s: the `items` spelling is now REFUSED', (id) => {
+    // The other half of the accept-set move. This document PASSED before the
+    // rename; a mirror that merely widened would still accept it.
+    expect(reasons(toItemsSpelling(getExample(id).schema))).not.toEqual([]);
+  });
+
+  it('`cards` is a real declaration, not a passthrough hole', () => {
+    // `BaseSchema` is `.passthrough()`, so an unknown key proves nothing here.
+    // Every probe below uses the DECLARED key.
+    const col = (extra: Record<string, unknown>) => ({
+      type: 'kanban',
+      columns: [{ id: 'todo', title: 'To Do', ...extra }],
+    });
+    expect(safeValidateSchema(col({ cards: 'nope' })).success).toBe(false);
+    expect(safeValidateSchema(col({ cards: [{ id: '1' }] })).success).toBe(false); // card needs `title`
+    expect(safeValidateSchema(col({})).success).toBe(false); // `cards` is required
+    // …and the good shape passes, so the three above fail for their own reason.
+    expect(safeValidateSchema(col({ cards: [] })).success).toBe(true);
+    expect(safeValidateSchema(col({ cards: [{ id: '1', title: 'Task' }] })).success).toBe(true);
+  });
+});
+
+describe('objectui#6939 — and the repair moved the validator, not the renderer', () => {
+  it.each(IDS)('%s renders exactly what it rendered before', async (id) => {
+    const after = await measure(getExample(id).schema);
+    const before = PRE_REPAIR[id];
+    expect(after.elements).toBe(before.elements);
+    expect(after.tags).toEqual(before.tags);
+    expect(after.visibleText).toBe(before.visibleText);
+    expect(after.sha256).toBe(before.sha256);
+  });
+
+  it.each(IDS)('%s anti-vacuity: the authored columns AND cards are on screen', async (id) => {
+    // A tile that renders nothing satisfies "identical" trivially — and the
+    // empty board below is exactly such a tile, so this guard is load-bearing.
+    const schema = getExample(id).schema as {
+      columns: Array<{ title: string; cards: Array<{ title: string }> }>;
+    };
+    const m = await measure(schema);
+    expect(m.text).not.toContain('failed to render');
+    expect(m.text).not.toContain('Unknown component type');
+    for (const column of schema.columns) {
+      expect(m.visibleText).toContain(column.title);
+      for (const card of column.cards) expect(m.visibleText).toContain(card.title);
+    }
+    // At least one card actually exists, or the loop above is vacuous.
+    expect(schema.columns.reduce((n, c) => n + c.cards.length, 0)).toBeGreaterThan(0);
+  });
+
+  it.each(IDS)('%s: the `items` spelling still draws an EMPTY board', async (id) => {
+    // The discriminator. `bucketCardsIntoColumns` reads `col.cards || []`, so
+    // under `items` every column buckets to zero — unchanged by this card,
+    // which is why this reading is a carrier legal in both states.
+    const m = await measure(toItemsSpelling(getExample(id).schema));
+    const expected = ITEMS_SPELLING[id];
+    expect(m.elements).toBe(expected.elements);
+    expect(m.tags).toEqual(expected.tags);
+    expect(m.visibleText).toBe(expected.visibleText);
+    expect(m.sha256).toBe(expected.sha256);
+    // Named explicitly: no authored card title survives, and every column reads zero.
+    expect(m.visibleText).toContain('No cards');
+    const schema = getExample(id).schema as { columns: Array<{ cards: Array<{ title: string }> }> };
+    for (const column of schema.columns) {
+      for (const card of column.cards) expect(m.visibleText).not.toContain(card.title);
+    }
+  });
+});

--- a/examples/schema-catalog/test/safe-validate-corpus-6318.test.ts
+++ b/examples/schema-catalog/test/safe-validate-corpus-6318.test.ts
@@ -44,8 +44,7 @@
  * ⛔ This file deliberately does NOT pin the size of the remaining bucket. The
  * 28 entries still in it are open findings on the Zod union (`tooltip` and
  * `context-menu` demand a `children` their renderers never read; `tree-view`
- * demands `data` where the renderer reads `nodes` first; `kanban` declares
- * `columns[].items` where the board reads `columns[].cards`; and so on), and a
+ * demands `data` where the renderer reads `nodes` first; and so on), and a
  * number pinned here would turn red on the card that repairs any one of them.
  */
 import { describe, it, expect } from 'vitest';

--- a/packages/cli/src/__tests__/check-validity-recogniser.test.ts
+++ b/packages/cli/src/__tests__/check-validity-recogniser.test.ts
@@ -42,6 +42,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+import { safeValidateSchema } from '@object-ui/types/zod';
+
 import { check } from '../commands/check.js';
 
 let cwd: string;
@@ -180,19 +182,57 @@ describe('objectui check — a broken ObjectUI schema is never filed as a foreig
 
   it('reports a registered component type the bundled schemas do not model', async () => {
     // The other half of the bucket, and why its wording says "off-spec OR not
-    // modelled": `kanban` is a real registered plugin type that
-    // `AnyComponentSchema` has no member for, so a perfectly good kanban board
-    // fails the validity arm. Reporting it is right — a component type the
-    // shipped validator cannot validate is itself a finding — but calling it
-    // invalid would overclaim.
-    writeSchema('board.json', {
-      type: 'kanban',
-      columns: [{ id: 'backlog', title: 'Backlog', cards: [] }],
+    // modelled". `abbr` is a real registered type — `packages/components/src/
+    // renderers/basic/html-elements.tsx` registers the raw HTML elements in
+    // bulk — and `AnyComponentSchema` is a union of COMPONENT schemas that has
+    // no member for it. So the well-formed document below fails the validity
+    // arm. Reporting it is right (a registered type the shipped validator
+    // cannot validate is itself a finding) but calling it INVALID would
+    // overclaim: nothing about this document is wrong.
+    //
+    // ## Pick this type by measurement, not memory (objectui#6939)
+    //
+    // Measured on this tree: `KNOWN_SCHEMA_TYPES` carries 658 registered types
+    // and `AnyComponentSchema` declares 102 distinct literal `type` values, so
+    // 558 registered types have no member. The probe was controlled in both
+    // directions — `kanban`, `text` and `tree-view` all read as MODELLED (so it
+    // is not blind to real members) and a nonsense type reads as unmodelled.
+    //
+    // Not every one of those 558 is a safe fixture. The type used here must be
+    // one nothing is about to model, and the raw HTML primitives are the stable
+    // inhabitants of this bucket: they are registered as a bulk passthrough
+    // list, not as authorable component schemas. A plugin-ish type such as
+    // `dashboard-grid` also lands here today and would be the wrong choice.
+    //
+    // ## Why it is no longer `kanban`
+    //
+    // This sample used to be a kanban board authoring `cards`, and the comment
+    // here claimed `AnyComponentSchema` "has no member for" kanban. That claim
+    // was FALSE, and was false before objectui#6939 touched anything —
+    // `ComplexSchema` has carried `KanbanSchema` throughout. The real mechanism
+    // was a required-key mismatch: `KanbanColumnSchema` demanded `items` while
+    // every board, and this sample, writes `cards`. objectui#6939 repaired that
+    // fork, the board started validating, and this case measured 0 candidates.
+    // The defect this file's own subject matter exists to catch had been frozen
+    // into an assertion of expected behaviour.
+    writeSchema('abbr.json', {
+      type: 'abbr',
+      content: 'HTML',
+      title: 'HyperText Markup Language',
     });
+    // The precondition, asserted rather than assumed, so that the day someone
+    // models `abbr` this file says WHY it went red instead of reporting a bare
+    // `expected +0 to be 1`. If this fires: pick another registered type with
+    // no member in `AnyComponentSchema` (a raw HTML primitive) and update the
+    // counts above.
+    expect(
+      safeValidateSchema({ type: 'abbr', content: 'HTML', title: 'HyperText Markup Language' }).success,
+      '`abbr` is now modelled by AnyComponentSchema — this fixture needs a type that still is not; see the comment above',
+    ).toBe(false);
     await check(cwd);
     expect(candidateCount()).toBe(1);
     expect(candidateLines()).toEqual([
-      expect.stringContaining('board.json (type "kanban")'),
+      expect.stringContaining('abbr.json (type "abbr")'),
     ]);
     expect(skippedCount()).toBe(0);
   });

--- a/packages/types/examples/zod-validation-example.ts
+++ b/packages/types/examples/zod-validation-example.ts
@@ -138,7 +138,7 @@ const kanbanExample = {
     {
       id: 'todo',
       title: 'To Do',
-      items: [
+      cards: [
         {
           id: '1',
           title: 'Task 1',
@@ -150,12 +150,12 @@ const kanbanExample = {
     {
       id: 'in-progress',
       title: 'In Progress',
-      items: [],
+      cards: [],
     },
     {
       id: 'done',
       title: 'Done',
-      items: [],
+      cards: [],
     },
   ],
   draggable: true,

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -35,9 +35,17 @@ export interface KanbanColumn {
    */
   title: string;
   /**
-   * Column cards/items
+   * Cards in this column.
+   *
+   * Named `cards` because that is what every board reads and every authored
+   * document writes: `KanbanImpl` (12 lines), `KanbanEnhanced` (8) and
+   * `bucketCardsIntoColumns` all read `column.cards`, and the two catalog
+   * entries, the plugin docs and `content/docs/api/schema-reference.md` all
+   * author it. This member was spelled `items` until objectui#6939 — a
+   * spelling with zero read sites, which made every authored board fail
+   * `safeValidateSchema` while rendering correctly (objectui#6318's bucket).
    */
-  items: KanbanCard[];
+  cards: KanbanCard[];
   /**
    * Column color/variant
    */

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -52,7 +52,7 @@ export const KanbanCardSchema = z.object({
 export const KanbanColumnSchema = z.object({
   id: z.string().describe('Column ID'),
   title: z.string().describe('Column title'),
-  items: z.array(KanbanCardSchema).describe('Column cards'),
+  cards: z.array(KanbanCardSchema).describe('Column cards'),
   color: z.string().optional().describe('Column color'),
   limit: z.number().optional().describe('Card limit'),
   collapsed: z.boolean().optional().describe('Whether column is collapsed'),


### PR DESCRIPTION
Part of #6939 — the `kanban` row (group 3) only. Groups 4 (`filter-builder`) and 5 (`chart`) are **not** addressed here and remain open; group 2 (`tree-view`) is PR #7533.

**Clause-②: yes** — this moves a published mirror's accept/reject behaviour AND renames a member on a published type. Draft + `needs:contract-review`; not marked ready, no auto-merge.

## What changed

`KanbanColumn` declared its card list as `items` in both halves of the published surface — `packages/types/src/complex.ts` and the zod mirror `packages/types/src/zod/complex.zod.ts` — while every board reads `cards`. Renamed to `cards`.

## The ruling's own numbers, re-measured on this branch's base

The maintainer ruling (comment 5510084784) took its counts on `origin/main` `ec0a7b84`. This branch is based on `78a3cc238`. All three reproduce:

| Reading | Ruling | Re-measured on `78a3cc238` |
|---|---|---|
| `plugin-kanban/src/types.ts` declares `cards: KanbanCard[]` | line 75 | line 75 ✓ |
| `complex.zod.ts` declares `items` | line 54 | line 55 (one line of drift) |
| `.cards` read lines in `KanbanImpl.tsx` | 12 | 12 ✓ |
| `.cards` read lines in `KanbanEnhanced.tsx` | 8 | 8 ✓ |
| `.items` read lines in either | 0 | 0 ✓ |

**Control for the two zeros:** a same-shaped probe (`grep -c '\.title'`) on the same two files returns 8 and 3, so the zeros are readings and not a mis-shaped probe. A nonsense-member probe of the same shape returns 0 on both.

**Addendum the ruling did not count:** `packages/plugin-kanban/src/index.tsx` reads `col.cards` **three more times** — lines 64 and 89 in `bucketCardsIntoColumns`, and line 327 in the `kanban-enhanced` registration's `useMemo`, which has the same shape. Each is `col.cards || []`, and that `|| []` is the mechanism behind the discriminator below. (An earlier revision said "twice more (lines 64 and 89)", missing line 327; corrected on review.)

## Why the rename went toward `cards` — measured, not asserted

Per #6318's triage, a "correction" that renders identically proves the schema was the wrong side. This row clears the stronger, opposite-polarity bar: "correcting" the fixtures toward the declaration does not merely change the render, it **empties the board**. Measured through the harness in the new test file, on `78a3cc238`, before either declaration was touched:

| Entry | `cards` (authored) | `items` (the declared spelling) |
|---|---|---|
| `basic-kanban-board` | 64 elements — `To Do2 … Design new feature …` | 45 elements — `No cards3 columnsTo Do0In Progress0Done0` |
| `advanced-kanban-with-badges-and-limits` | 86 elements — `Backlog2 … User Authentication …` | 58 elements — `No cards4 columnsBacklog0 …` |

Validator verdicts, same run: the authored `cards` documents **failed** `safeValidateSchema` (`: Invalid input`) and the `items` documents **passed**. After this change, exactly reversed.

## What is pinned

`examples/schema-catalog/test/kanban-column-cards-6939.test.tsx` (11 tests):

- both catalog entries validate;
- the `items` spelling is now **refused** (the other half of the accept-set move — a mirror that merely widened would still accept it);
- `cards` is a real declaration, not a passthrough hole — counter-probes use only the **declared** key, since `BaseSchema` is `.passthrough()` and an unknown key would prove nothing;
- render identity against the pre-change readings: element count, tag census, visible text literal, and SHA-256 over the full `textContent`;
- **anti-vacuity** — every authored column title and card title is asserted on screen, plus a guard that at least one card exists, so the identity pin cannot pass on a blank tile;
- the `items` empty-board reading is itself pinned, so the direction of the rename stays a measurement.

**Controls are legal in both states.** The render carriers never pass through the validator, and `bucketCardsIntoColumns` is untouched, so both the populated and the empty board render the same before and after. The `waitFor` witness is a column heading, which exists in *both* boards — it cannot settle for one spelling and time out for the other.

## Ablation (predicted before measured)

Restoring `items` to both declarations, renderer untouched. Predicted red: the two `validates` cases, the two `items`-refused cases, and the passthrough counter-probe — 5 of 11, with the six render/anti-vacuity cases and all 12 `zod-mirror-parity` cases staying green.

**Measured: exactly that** — `Tests 5 failed | 18 passed (23)`, and the five names match the prediction one-for-one.

The mutation was proven on disk before the run (anchored counts in both directions, plus blob hashes differing from HEAD), and the restore was proven **by state**, not by exit code: both worktree blob hashes equal their HEAD blobs, `git diff HEAD` empty, `git status --porcelain` empty. Both files resolve through the repo's vitest source alias (`packages/types/src/...`), so no `dist` rebuild participates in this ablation.

## Notes

- `packages/types/examples/zod-validation-example.ts` authored the old spelling in three places; renamed. It is covered by `packages/types`' `type-check` (which runs `tsc -p tsconfig.examples.json`).
- The header of `examples/schema-catalog/test/safe-validate-corpus-6318.test.ts` listed this row as an open finding on the Zod union; that sentence is now stale and the kanban clause is removed. That file deliberately pins no bucket size, so nothing else there moves.
- `@object-ui/plugin-kanban` is **unchanged** — it already declared `cards`.
- An earlier revision of the test preloaded the lazy chunk via `@object-ui/plugin-kanban/KanbanImpl`. That shape was removed: it is not in the package's `exports` map and resolves only through the repo's vitest alias, which #4325 ruled out for `@object-ui/fields`. The test now settles the boundary with `waitFor`, the way `catalog-gallery-render.test.tsx` already does for these same entries.

## Changeset

`minor`, not `patch` — this is a rename on a published type, not a widening. `@object-ui/types` only. (`major` is forbidden repo-wide by `scripts/check-changeset-no-major.mjs`; the breaking semantics are spelled out in the changeset body per repo convention.)

## Verification — all at merged head `fba1bfd78`

| Check | Result |
|---|---|
| `vitest run packages/types/ packages/plugin-kanban/ examples/schema-catalog/` | `Test Files 140 passed (140)`, `Tests 3727 passed (3727)` |
| `zod-mirror-parity.test.ts` (run explicitly) | `Tests 12 passed (12)` |
| `turbo run type-check --filter=@object-ui/types --filter=@object-ui/plugin-kanban` | `Tasks: 15 successful, 15 total` |
| `turbo run type-check --filter=@object-ui/example-schema-catalog` | `Tasks: 30 successful, 30 total` |
| `eslint . --format json` | 4254 files, **0 errors** (eslint's own population, not a narrowed list) |
| `check-changeset-presence.mjs` | exit 0 — 1 changeset for 1 released package |
| `check-changeset-no-major.mjs` | exit 0 |
| `check-control-bytes.mjs` | exit 0 — 6210 tracked text files |

Branch merged with `origin/main` `47547d01a` (a merge, not a rebase, per AGENTS.md); the full suite above was re-run after the merge.

## Clause 2 of the ruling, and a PRIOR ruling on this exact pair

The 2026-09-02 ruling has two clauses. This PR implements clause 1 (the rename). **Clause 2 — "`packages/plugin-kanban/src/types.ts` stops carrying its own `KanbanColumn` declaration and re-uses the public one" — is NOT implemented here**, and two things about it belong on the record. Neither asks this PR to decide anything.

**1. The public declaration is not structurally sufficient.** Measured: the plugin's local `KanbanCard` carries four members the public `@object-ui/types` `KanbanCard` does not declare — `badges`, `cardSubtitle`, `cardFieldCells`, `coverImage` — plus an index signature; the plugin's `KanbanColumn` carries `className` where the public one has `color`. All are live reads (`card.coverImage`, `card.cardFieldCells`, `card.cardSubtitle`, `card.badges`, `column.className`, and `card[swimlaneField]` at `KanbanImpl.tsx` 449, 672 and 692). Deleting the local declaration would type `column.cards` as the *public* `KanbanCard[]` and break every one of them, so clause 2 cannot be executed without widening the published type — which the dispatch explicitly forbids doing silently.

**2. Correction to an earlier revision of this PR, and the prior ruling it missed.**

An earlier revision cited the comment at `KanbanImpl.tsx:52` as "a landed decision pointing the other way", saying objectui#6172 / #6155 made `./types` the authority *because the local card carried members the public one did not*. **That attribution was wrong.** The comment compares `KanbanImpl.tsx`'s own former copies against the plugin's `./types` — an **in-package** drift — and says so in as many words: "the local `KanbanCard` carried `cardSubtitle` / `cardFieldCells` / `coverImage` that **`./types`** did not". It says nothing about `@object-ui/types`.

That card was explicit about *not* touching the cross-package question. Its changeset (`.changeset/6172-markdown-kanban-one-authority.md`, landed in `b3d562c02`):

> The cross-package `KanbanCard` / `KanbanColumn` / `KanbanSchema` collision between `@object-ui/types` and `@object-ui/plugin-kanban` is **NOT resolved here** and is escalated on objectui#6172 — those are two different dialects (`items` vs `cards`, `labels` vs `badges`), and collapsing them renames a published name, which needs an authority ruling.

So `:52` is in-package convergence **plus an explicit escalation**, not a contrary decision.

**And that escalation was answered.** objectui#6172 comment `5474954379` (2026-08-31, maintainer verbatim 「其他同意」, director-seat batch #14) rules **option A**:

> plugin-kanban 保留裸名 `KanbanSchema` 家族;`@object-ui/types` 三重奏改名(如 `DeclarativeKanbanSchema` 族)

Under that ruling the public `KanbanColumn` is **renamed away**, so clause 2's "re-use the public one" would have nothing to re-use. It predates the 2026-09-02 ruling by two days, the two do not cite each other, and it is **not yet executed** (`packages/types/src/complex.ts:28` still declares `KanbanColumn`). It also lists retiring the `@object-ui/types` triplet outright as escalation option D — under which this PR's member rename would travel with the renamed type, or disappear with a retired one.

⛔ **I am not adjudicating which ruling governs.** Both are recorded so the reviewer and the maintainer can see the conflict; the dispatching seat has escalated it as-is. Worth noting that #6172's own census agrees with this PR's measurement independently: it found the types-dialect `items` spelling had **zero** non-demo, non-known-bad uses across the bound.

## Follow-up: CI red on `fba1bfd78`, and the fix (`a3fb15e5e`)

`Test (shard 3/4)` went red on one case — `packages/cli/src/__tests__/check-validity-recogniser.test.ts`, "reports a registered component type the bundled schemas do not model", `expected +0 to be 1`. **It is a correct consequence of this repair, and it is fixed here rather than worked around.**

That case wrote a kanban board authoring `cards` and asserted `objectui check` would report it as a registered type the bundled schemas cannot model. It only ever landed in that bucket because the mirror required `items` — the exact fork this PR repairs. Once the board validates, the count drops to 0. The defect was frozen into an assertion of expected behaviour.

Reproduced end-to-end through the real `check`, not inferred: a kanban board with `cards` now yields `candidates=[]`; the sibling `text` fixture still yields a candidate (positive control); a foreign `package.json` still yields `Skipped 1` and no candidate (negative control).

**The comment was also wrong, independently of this PR.** It claimed `AnyComponentSchema` "has no member for" kanban. `ComplexSchema` has carried `KanbanSchema` throughout (`complex.zod.ts:691-692`, reached from `AnyComponentSchema` via the `ComplexSchema` arm). Corrected to the real mechanism — a required-key mismatch, not an absent member.

**The replacement type was chosen by measurement.** Difference set, by introspecting every literal `type` the union declares: 658 registered types in `KNOWN_SCHEMA_TYPES`, 102 modelled, **558 with no member**. Probe controlled in both directions — `kanban`, `text` and `tree-view` all read as modelled (so it is not blind to real members), a nonsense type does not.

Picked `abbr`. Raw HTML primitives are the stable inhabitants of that bucket: `packages/components/src/renderers/basic/html-elements.tsx` registers them in bulk and they are not candidates for authorable component schemas — unlike a plugin-ish type such as `dashboard-grid`, which also lands there today but is a plausible future modelling target. The fixture is a *well-formed* `abbr` document, which keeps the case's original point: the file is unmodelled, not broken.

**The timer is defused rather than passed on.** The case now asserts its own precondition — that `abbr` is still refused by `safeValidateSchema` — with a message naming what to do. If anyone ever models `abbr`, this file says why it went red instead of reporting a bare `expected +0 to be 1`. A synthetic always-unmodelled type was considered and rejected: the registered-type universe is a generated, separately-pinned file (`packages/cli/src/utils/known-schema-types.ts`), so a synthetic type would have to be injected by mocking it — and that would fabricate the "registered" half, which is precisely the half this bucket is about.

⛔ The test was not skipped, disabled, isolated or deleted, and the sample was not reverted to `items`. The changeset level is unchanged (`minor`).

### Re-verified at merged head `a3fb15e5e` (merged `origin/main` `f0f774b0d`)

| Check | Result |
|---|---|
| `vitest run packages/cli/ packages/types/ packages/plugin-kanban/ examples/schema-catalog/` | `Test Files 156 passed (156)`, `Tests 3973 passed (3973)` |
| `check-validity-recogniser.test.ts` alone | `Tests 10 passed (10)` |
| `turbo run type-check --filter=@object-ui/cli` | `Tasks: 10 successful, 10 total` |
| `eslint` on the changed file | 0 errors, 0 warnings |
| `check-changeset-presence.mjs` | exit 0 — 1 changeset for 2 released packages |
| `check-changeset-no-major.mjs` | exit 0 |
| `check-control-bytes.mjs` | exit 0 — 6212 tracked text files |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code)_