### PR TITLE
feat(types): declare the predicate string `BaseSchema.hidden` already evaluates

### DIFF
--- a/.changeset/hidden-predicate-widen-7455.md
+++ b/.changeset/hidden-predicate-widen-7455.md
@@ -1,0 +1,13 @@
+---
+'@object-ui/types': minor
+---
+
+**`BaseSchema.hidden` now declares the predicate string the renderer already evaluates** (objectui#7455, maintainer ruling 2026-09-03).
+
+`hidden?: boolean` becomes `hidden?: boolean | string`, and the Zod mirror's `z.boolean()` becomes `z.union([z.boolean(), z.string()])` — matching `visible` (#4581) and `disabled` (#4580 ruling Q3-A) on both faces. `hidden` was the third key on the same evaluated path and the only one still declared boolean-only.
+
+This is a **widening**, not a replacement: every boolean `hidden` keeps parsing and keeps type-checking unchanged, and the renderer's behaviour is untouched by this change — `SchemaRenderer`'s `shouldHide` chain already routed this key through `hasDeclaredPredicate` and evaluated it, which is the evidence the widening rests on. What changes is that authors and their tooling can now write `hidden: "${data.status === 'draft'}"` without casting past the declaration, and the Zod mirror stops refusing it (before this, that value failed `safeParse` with `invalid_type` at path `hidden` while the identical string on `visible` parsed).
+
+`hiddenOn` is unchanged and remains the sibling expression spelling. The CEL envelope object form is still declared on none of `visible` / `hidden` / `disabled`; objectui#7530 rules on all three together.
+
+Per this repository's version-alignment convention, a widening of a published type surface ships as `minor` with the semantics spelled out here rather than as `major` (see AGENTS.md, "版本号策略").

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -69,7 +69,7 @@ One row per declared member, in declaration order, so the list can be checked ag
 | `visible` | `boolean \| string` | Visibility control. Accepts a boolean **or** a predicate expression string — the renderer evaluates this key rather than reading it as a boolean. |
 | `visibleWhen` | `string` | Canonical conditional-visibility predicate (ADR-0089); the element is shown when it evaluates truthy. Evaluated **before** `visible` and `visibleOn`, and outranks both. |
 | `visibleOn` | `string` | Expression for conditional visibility. **Deprecated** (ADR-0089) — use `visibleWhen`. |
-| `hidden` | `boolean` | Inverse of `visible`. Boolean only — unlike `visible`, this key takes no expression. |
+| `hidden` | `boolean \| string` | Inverse of `visible` — the node is not rendered. Accepts a boolean **or** a predicate expression string, which the renderer evaluates rather than reading as a boolean; `hiddenOn` remains the sibling spelling. |
 | `hiddenOn` | `string` | Expression for conditional hiding. |
 | `disabled` | `boolean \| string` | Disabled state. Accepts a boolean **or** a predicate expression string, on the same evaluated path as `visible`. |
 | `disabledOn` | `string` | Expression for conditional disabling. |

--- a/packages/react/src/__tests__/SchemaRenderer.hiddenDeclaredGate.test.tsx
+++ b/packages/react/src/__tests__/SchemaRenderer.hiddenDeclaredGate.test.tsx
@@ -89,6 +89,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 import { ComponentRegistry } from '@object-ui/core';
+import type { BaseSchema } from '@object-ui/types';
 import { SchemaRenderer } from '../SchemaRenderer';
 import { SchemaRendererContext } from '../context/SchemaRendererContext';
 
@@ -109,6 +110,34 @@ function renderNode(schema: Record<string, unknown>) {
   return render(
     <SchemaRendererContext.Provider value={{ dataSource: DATA }}>
       <SchemaRenderer schema={{ type: 'probe-3955', ...schema } as never} />
+    </SchemaRendererContext.Provider>,
+  );
+}
+
+/**
+ * The DECLARED path -- no cast at all.
+ *
+ * `renderNode` above spreads a `Record<string, unknown>` through `as never`
+ * because most of this file exercises shapes `BaseSchema` does not declare and
+ * should not: `null`, `0`, `[]`, `{}`, and the CEL envelope object. Those keep
+ * the cast.
+ *
+ * The STRING form is different since objectui#7455 (ruled 2026-09-03):
+ * `hidden` is declared `boolean | string`, so an expression-valued `hidden` is
+ * authorable and the compiler is the right checker for it. Narrowing `hidden`
+ * back to `boolean` makes the call sites below TS2322 -- and `tsc -p
+ * tsconfig.test.json` (chained from this package's `type-check` script) is the
+ * only thing that can see that; vitest cannot, because the annotation is erased
+ * before a single case runs.
+ *
+ * The envelope pin below deliberately stays on `renderNode`: the envelope form
+ * is declared on NONE of `visible` / `hidden` / `disabled`, and objectui#7530
+ * rules on all three together.
+ */
+function renderDeclaredNode(schema: BaseSchema) {
+  return render(
+    <SchemaRendererContext.Provider value={{ dataSource: DATA }}>
+      <SchemaRenderer schema={schema} />
     </SchemaRendererContext.Provider>,
   );
 }
@@ -177,11 +206,11 @@ describe('SchemaRenderer `hidden` — an empty predicate is not a declared gate 
     expect(rendered()).toBe(true);
   });
 
-  it('an expression-valued `hidden` keeps its verdict, both ways', () => {
-    const { unmount } = renderNode({ hidden: '${data.status === "draft"}' });
+  it('an expression-valued `hidden` keeps its verdict, both ways -- through the DECLARED path, no cast (objectui#7455)', () => {
+    const { unmount } = renderDeclaredNode({ type: 'probe-3955', hidden: '${data.status === "draft"}' });
     expect(rendered()).toBe(false);
     unmount();
-    renderNode({ hidden: '${data.published}' });
+    renderDeclaredNode({ type: 'probe-3955', hidden: '${data.published}' });
     expect(rendered()).toBe(true);
   });
 

--- a/packages/types/src/__tests__/base-schema-hidden-predicate.test.ts
+++ b/packages/types/src/__tests__/base-schema-hidden-predicate.test.ts
@@ -1,0 +1,164 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `BaseSchema.hidden` admits the predicate string the renderer evaluates
+ * (objectui#7455, maintainer ruling 2026-09-03: option A, widen).
+ *
+ * The twin of `base-schema-visible-predicate.test.ts` (#4581) and of
+ * `disabled-twin-symmetry-7087.test.ts` (#4580 Q3-A). `hidden` was the third
+ * key on the same evaluated path and the only one still declared boolean-only
+ * on both faces.
+ *
+ * ## The evidence
+ *
+ * `SchemaRenderer`'s `shouldHide` chain does not read this key as a boolean:
+ *
+ *   ```ts
+ *   if (hasDeclaredPredicate(newSchema.hidden)) {
+ *     return evaluateVisibilityPredicate(newSchema.hidden, 'hidden');
+ *   }
+ *   ```
+ *
+ * `hasDeclaredPredicate` (`packages/core/src/evaluator/declaredPredicate.ts`)
+ * is the repo's single shared definition of "declared", asked by all three
+ * keys, all three `*On` siblings, `ActionRunner` and `ActionEngine`; the
+ * evaluator underneath is declared
+ * `(condition: string | boolean | undefined, ...) => boolean`. Predicate
+ * strings on `hidden` were already SHIPPED and PINNED — see
+ * `packages/react/src/__tests__/SchemaRenderer.hiddenDeclaredGate.test.tsx`,
+ * which drove them through a `Record<string, unknown>` helper because the
+ * declaration refused them.
+ *
+ * ## Measured before the change (red-first, on `origin/main` d04e79a80)
+ *
+ *   • TS  — `base.ts:328` was `hidden?: boolean`.
+ *   • zod — `base.zod.ts:175` was `z.boolean()`, and
+ *     `BaseSchema.safeParse({ type: 'probe', hidden: '${data.status === "draft"}' })`
+ *     returned `success: false`,
+ *     `{ code: 'invalid_type', expected: 'boolean', path: ['hidden'] }`,
+ *     while the identical string on `visible` parsed. So the zod mirror was NOT
+ *     already ahead of TS — both faces refused it.
+ *
+ * ## What this file pins, and why in this shape
+ *
+ *   1. Type level — `BaseSchema['hidden']` is EXACTLY
+ *      `boolean | string | undefined`, invariantly. `Equal`, not `extends`:
+ *      the narrow `boolean` is assignable to the wide union, so a one-way check
+ *      stays green on a widening that never happened, and `BaseSchema`'s
+ *      `[key: string]: any` index signature means a DELETED member reads `any`,
+ *      which a one-way check also accepts. The overshoot is the live risk here,
+ *      not a hypothetical.
+ *   2. The three keys are asserted to carry the SAME declared type. The ruling's
+ *      words are "matching `visible` and `disabled` on both faces"; asserting
+ *      `hidden` alone would stay green if a later change narrowed one of the
+ *      other two, which is the asymmetry this card exists to remove.
+ *   3. Runtime (zod face) — the string form and the boolean form both
+ *      `safeParse` GREEN in full, and a NUMBER is still refused at path
+ *      `hidden`. The refusal is the anti-overshoot guard: `z.any()` would
+ *      satisfy every positive case on its own.
+ *
+ * ## Deliberately NOT pinned here: the CEL envelope object
+ *
+ * `hasDeclaredPredicate` accepts `{ dialect, source }` on this key, and NO key
+ * declares it — `visible` and `disabled` are `boolean | string` and under-report
+ * it too. objectui#7530 rules on all three together (declare on all three, or
+ * refuse on all three). This file therefore asserts nothing about that shape in
+ * either direction; pinning the current refusal on `hidden` alone would
+ * pre-empt that ruling and re-introduce, in the pins, exactly the three-way
+ * asymmetry the widening just removed.
+ *
+ * ADR-0089's carve-out ("the boolean `visible` ... is explicitly out of scope")
+ * governs `packages/spec`'s keys, not this surface — `BaseSchema` is objectui's
+ * own declaration. It is evidence of intent about the same concept, which is
+ * why this was ruled rather than applied mechanically.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { BaseSchema } from '../base';
+import { BaseSchema as Mirror } from '../zod/base.zod';
+
+/* ── Type-level helpers ──────────────────────────────────────────────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+type Equal< A, B > =
+  (< T >() => T extends A ? 1 : 2) extends (< T >() => T extends B ? 1 : 2) ? true : false;
+type Expect< T extends true > = T;
+
+/* ── The declared type is exactly what the evaluator accepts ─────────────── */
+
+export type assertionHidden = Expect<
+  Equal< BaseSchema['hidden'], boolean | string | undefined >
+>;
+
+/** The two siblings, asserted beside it: all three keys carry one type. */
+export type assertionHiddenMatchesVisible = Expect<
+  Equal< BaseSchema['hidden'], BaseSchema['visible'] >
+>;
+export type assertionHiddenMatchesDisabled = Expect<
+  Equal< BaseSchema['hidden'], BaseSchema['disabled'] >
+>;
+
+/* ── Authorable fixtures ─────────────────────────────────────────────────── */
+
+/** The capability the renderer implements, now declared. */
+export const hiddenPredicateStringIsAuthorable: BaseSchema = {
+  type: 'test-component',
+  hidden: 'record.status == "draft"',
+};
+
+/** The template-expression spelling the shipped react pins use. */
+export const hiddenTemplateExpressionIsAuthorable: BaseSchema = {
+  type: 'test-component',
+  hidden: '${data.status === "draft"}',
+};
+
+/** The boolean form is untouched — this is a widening, not a replacement. */
+export const hiddenBooleanIsStillAuthorable: BaseSchema = {
+  type: 'test-component',
+  hidden: true,
+};
+
+/* ── Runtime companion (the zod mirror) ──────────────────────────────────── */
+
+const PREDICATE = '${data.status === "draft"}';
+
+describe('BaseSchema.hidden (objectui#7455)', () => {
+  it('type-level: hidden is boolean | string, pinned invariantly against both siblings', () => {
+    // Erased at runtime; `tsc -p tsconfig.test.json` is the checker, chained
+    // from this package's `type-check` script. The runtime case exists so a
+    // green vitest run is not mistaken for the proof.
+    expect(hiddenPredicateStringIsAuthorable.hidden).toBe('record.status == "draft"');
+    expect(hiddenBooleanIsStillAuthorable.hidden).toBe(true);
+  });
+
+  it('zod mirror: a predicate string on `hidden` parses in full', () => {
+    const result = Mirror.safeParse({ type: 'test-component', hidden: PREDICATE });
+    // Full parse, not just "no unrecognized_keys": this is a judgement about
+    // the VALUE, so nothing short of a green `safeParse` measures it.
+    expect(result.success).toBe(true);
+  });
+
+  it('zod mirror: `visible` and `disabled` take the same string — the control', () => {
+    // If these ever go red, the failure is NOT about `hidden`, and the
+    // assertion above would have been passing for the wrong reason.
+    expect(Mirror.safeParse({ type: 'test-component', visible: PREDICATE }).success).toBe(true);
+    expect(Mirror.safeParse({ type: 'test-component', disabled: PREDICATE }).success).toBe(true);
+  });
+
+  it('zod mirror: the boolean form still parses — a widening, not a replacement', () => {
+    expect(Mirror.safeParse({ type: 'test-component', hidden: true }).success).toBe(true);
+    expect(Mirror.safeParse({ type: 'test-component', hidden: false }).success).toBe(true);
+  });
+
+  it('zod mirror: a number is still refused at path `hidden` — the anti-overshoot guard', () => {
+    // `BaseSchema` is `.passthrough()`, but `hidden` is a DECLARED key, so a
+    // wrong-typed value is an `invalid_type` error rather than a passthrough.
+    // Without this case, widening the key to `z.any()` would satisfy every
+    // positive assertion above.
+    const result = Mirror.safeParse({ type: 'test-component', hidden: 123 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.path.join('.') === 'hidden')).toBe(true);
+    }
+  });
+});

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -57,7 +57,12 @@
  *     already pins equal to `keyof Declared`. Nothing asserts it against a written
  *     number, so this line is prose and can rot; the pin that cannot is the one
  *     comparing the two halves to each other.
- *   - **39 entries** in `KnownDrift`, **55 keys** across them — 56 until objectui#6940
+ *   - **40 entries** in `KnownDrift`, **56 keys** across them — 39 / 55 until
+ *     objectui#7455 SEEDED `app.zod.ts#AppComponentSchema` with its one
+ *     spec-derived key `hidden` (a pair born ledgered, not growth on an existing
+ *     entry: both faces read `boolean` until the base was widened, and only the
+ *     DECLARED face moved — see that entry). It stood at 39 / 55 rather than
+ *     39 / 56 because objectui#6940
  *     REPAIRED `DataTableSchema.rowActions` (the entry kept its other four keys, so
  *     the entry count did not move). It was 12 / 17 until
  *     objectui#6124 added the RUNTIME-SLOT class (28 pairs touched, 35 keys) — see
@@ -85,7 +90,7 @@
  *     "no entry in either" population dropped by one to 141 — went to 142 when
  *     objectui#6576 added two pairs, one of them ledgered, and stands at **143**
  *     since objectui#7129 retired `DetailViewSectionSchema`'s only ledgered key.
- *   - 160 − 39 = **121**, the "pairs with no entry" `LedgerMismatch` speaks of.
+ *   - 160 − 40 = **120**, the "pairs with no entry" `LedgerMismatch` speaks of.
  *
  * ## Two ratchets, because the forward comparison has two halves
  *
@@ -106,7 +111,7 @@
  *
  * ## KNOWN_DRIFT is a ratchet, not a waiver
  *
- * 39 of the 160 pairs carry TYPE drift TODAY (measured, not assumed). Each is
+ * 40 of the 160 pairs carry TYPE drift TODAY (measured, not assumed). Each is
  * pinned to its EXACT drifted key set, so the entry fails when new drift appears on
  * that mirror AND when the recorded drift is fixed — a stale entry cannot rot
  * quietly. Correcting them is not one change: the pairs below split into DISJOINT
@@ -685,6 +690,34 @@ export type UnmirroredOf< K extends MirrorKey > = UnmirroredDeclaredKeys< (typeo
  * new drift on a listed mirror fails, and so does a listed key that has been fixed.
  */
 interface KnownDrift {
+  /**
+   * SPEC-DERIVED, not a mirroring debt, and NOT closable by editing this entry.
+   *
+   * Measured on `@objectstack/spec@17.2.0` by resolving `AppSchema.shape`: the
+   * spec's `AppSchema` declares `hidden` (`z.boolean().optional()` -- accepts a
+   * boolean, refuses a string) and declares NEITHER `visible` NOR `disabled`.
+   * `AppComponentSchema` is `BaseSchema.extend(SpecAppFields.shape).extend(...)`
+   * and `SpecAppFields` excludes six keys -- `name`, `label`, `description`,
+   * `navigation`, `areas`, `contextSelectors` -- with `hidden` not among them,
+   * so on the MIRROR face the spec's boolean lands after the base's and
+   * overrides it. On the DECLARED face `interface AppComponentSchema extends
+   * BaseSchema` does not restate the key at all, so it inherits the base.
+   *
+   * That is why widening `BaseSchema.hidden` to `boolean | string`
+   * (objectui#7455, ruled 2026-09-03) moved only the TS side of THIS pair and
+   * seeded this entry, while the same widening on `visible` (objectui#4581) and
+   * `disabled` (objectui#4580 ruling Q3-A) moved both sides and seeded nothing.
+   * The asymmetry is the spec's, one layer under the one #7455 removed.
+   *
+   * The two keys collide in NAME and differ in MEANING -- the spec's is an
+   * app-catalogue flag (does the app show in the switcher), the base's is the
+   * renderer's hide predicate -- so this is a contract ruling, not a repair.
+   * objectui#7542 carries it, with the directions measured and none chosen.
+   * The one direction that reads easy and is probably wrong: dropping `hidden`
+   * from `SpecAppFields` would make a spec-DERIVED schema accept, by local
+   * divergence, a value the spec refuses.
+   */
+  'app.zod.ts#AppComponentSchema': 'hidden';
   /**
    * RUNTIME SLOT (objectui#6124): `calendar-view`'s `pickHostCallbacks` reads
    * `onViewChange` off the spread props (function values only) and hands it to
@@ -1318,7 +1351,7 @@ export type assertionLedgerHalvesAreDisjoint = Expect< Equal< DoubleFiledKey, ne
 
 /**
  * Every pair's TYPE drift equals what `KnownDrift` records for it — `never` for the
- * 121 pairs with no entry (160 − 39).
+ * 120 pairs with no entry (160 − 40).
  *
  * Routed through `ReconcileAgainstLedger` rather than spelling the conditional
  * inline. That is a semantics-preserving refactor and nothing else — the type is

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -323,9 +323,40 @@ export interface BaseSchema {
    * (`SchemaRenderer.expressions.test.tsx`,
    * `SchemaRenderer.hiddenDeclaredGate.test.tsx`).
    *
+   * Accepts a PREDICATE STRING as well as a boolean (objectui#7455, ruled
+   * 2026-09-03), on exactly the evidence that widened `visible` (#4581) and
+   * `disabled` (#4580 ruling Q3-A): the renderer does not read this key as a
+   * boolean, it evaluates it. The `shouldHide` chain asks core's one definition
+   * of "declared" and then evaluates the value --
+   * `hasDeclaredPredicate(newSchema.hidden)` then
+   * `evaluateVisibilityPredicate(newSchema.hidden, 'hidden')` in
+   * `SchemaRenderer.tsx` (the `hidden` leg, :1236 as of d04e79a80 -- re-derive
+   * the line, do not trust it) -- and the evaluator underneath is declared
+   * `(condition: string | boolean | undefined, ...) => boolean`. The sibling
+   * key `hiddenOn` is `string` for the same reason, and its existence was NOT
+   * taken to mean this key should stay boolean -- exactly as it was not taken
+   * that way for `visibleWhen` / `visibleOn` beside `visible`, or `disabledOn`
+   * beside `disabled`. The declaration simply under-reported a shipped, pinned
+   * capability (`SchemaRenderer.hiddenDeclaredGate.test.tsx`), and the fixtures
+   * exercising it had to cast past it.
+   *
+   * ADR-0089 -- "The boolean `visible` (Tab on/off) is a different type and
+   * concept and is explicitly out of scope" -- governs `packages/spec`'s keys,
+   * NOT this surface: `BaseSchema` is objectui's own declaration. The ADR is
+   * evidence of intent about the same concept, which is why this widening was
+   * ruled rather than applied mechanically.
+   *
+   * The CEL ENVELOPE OBJECT form is deliberately NOT declared here.
+   * `hasDeclaredPredicate` accepts it on this key, and it is declared on NONE
+   * of the three: `visible` and `disabled` are `boolean | string` and
+   * under-report it too. objectui#7530 rules on all three together (declare on
+   * all three, or refuse on all three); do not declare it on this key alone.
+   *
    * @default false
+   * @example true
+   * @example "${data.status === 'draft'}"
    */
-  hidden?: boolean;
+  hidden?: boolean | string;
 
   /**
    * Expression for conditional hiding.

--- a/packages/types/src/zod/base.zod.ts
+++ b/packages/types/src/zod/base.zod.ts
@@ -170,9 +170,22 @@ const BaseSchemaCore = z.object({
   visibleOn: z.string().optional().describe('[DEPRECATED → visibleWhen] Expression for conditional visibility'),
 
   /**
-   * Hidden control
+   * Hidden control -- a boolean, or the predicate STRING the renderer evaluates.
+   *
+   * Mirrors `BaseSchema.hidden: boolean | string` (`../base.ts`), widened by
+   * objectui#7455 (ruled 2026-09-03) on the same evidence that widened
+   * `visible` (#4581) and `disabled` (#4580 Q3-A): `SchemaRenderer`'s
+   * `shouldHide` chain asks `hasDeclaredPredicate` and then evaluates the
+   * value, never reading this key as a boolean. Measured before the widening:
+   * `BaseSchema.safeParse({ type, hidden: '${data.status === "draft"}' })`
+   * returned `success: false` with `invalid_type` (expected boolean, received
+   * string) while the identical string on `visible` parsed -- this validator
+   * was the one surface still refusing a shipped, pinned capability.
+   *
+   * The CEL envelope object form is NOT declared here, and is declared on none
+   * of the three keys; objectui#7530 rules on all three together.
    */
-  hidden: z.boolean().optional().describe('Hidden control'),
+  hidden: z.union([z.boolean(), z.string()]).optional().describe('Hidden control (boolean or predicate expression)'),
 
   /**
    * Conditional hidden expression


### PR DESCRIPTION
Fixes #7455

Implements the maintainer ruling recorded 2026-09-03 on that card (option **A: widen**), decision batch #24.

**Clause-②: yes** — a published type surface widens. Draft + `needs:contract-review`; ⛔ not marked ready, no auto-merge.

Measurements below are at `f7b8948b1`, the head of this branch, taken after `origin/main` was merged in.

## What changed

| file | before | after |
|:--|:--|:--|
| `packages/types/src/base.ts` | `hidden?: boolean` | `hidden?: boolean \| string` |
| `packages/types/src/zod/base.zod.ts` | `z.boolean()` | `z.union([z.boolean(), z.string()])` |
| `content/docs/api/schema-reference.md:72` | "Boolean only — unlike `visible`, this key takes no expression." | states what the renderer does; `hiddenOn` named as the sibling spelling |
| `SchemaRenderer.hiddenDeclaredGate.test.tsx` | the string form went through a `Record` helper and a cast | the string form goes through a typed, cast-free helper |

Plus the JSDoc block on `hidden` (recording the reasoning the way `visible` and `disabled`'s blocks already do, and noting that ADR-0089 governs `packages/spec`'s keys and not this surface), a new types-side pin, one `KnownDrift` entry explained below, and a `minor` changeset on `@object-ui/types`.

## ⛔ This is not "consistent with objectui#4581 / objectui#4580-Q3-A", and the PR does not say that

The precedent is incomplete, and the triage on the card measured why. The **CEL envelope object form** is accepted by the shared evaluator on all three keys and is declared on **none** of them — `visible` and `disabled` are `boolean \| string` and under-report it exactly as `hidden` did. objectui#7530 carries that question for all three together.

So, per key, after this PR:

- `visible` — boolean and string declared on both faces; envelope undeclared.
- `hidden` — boolean and string declared on both faces **as of this PR**; envelope undeclared.
- `disabled` — boolean and string declared on both faces; envelope undeclared.

⛔ Nothing here declares the envelope on `hidden`. The pin that exercises it keeps the helper and the cast it already used, deliberately.

## Verification I re-derived rather than inherited

**The three keys' shapes on this branch's base (`d04e79a80`), both faces.** The triage read them at `ac8d523`; the line numbers moved, the readings reproduce:

| key | `base.ts` | `base.zod.ts` |
|:--|:--|:--|
| `visible` | `boolean \| string` :281 | union :158 |
| `hidden` | **`boolean`** :328 | **`z.boolean()`** :175 |
| `disabled` | `boolean \| string` :354 | union :190 |

**The triage's claim that the Zod mirror is NOT already ahead of TS — re-measured, and it holds.** Run against the unmodified base tree:

```
hidden: '<predicate>'  safeParse.success = false
  { code: 'invalid_type', expected: 'boolean', path: ['hidden'] }
visible: '<predicate>' safeParse.success = true    (lit control — the probe can pass)
hidden: true           safeParse.success = true    (control, legal in both states)
```

Both faces refused the string. The specific line the triage cited (`base.zod.ts:170`) is `visibleOn` on this base; `hiddenOn` sits at :180. Both are `z.string()`, so the citation had drifted by a line but the conclusion it supported is correct.

**The docs row is hand-written, not generated — so the stop-condition on that row does not fire.** Four readings, with a lit control on the one that could otherwise return a confident zero:

- 15+ tracked files in this repo carry a real generation banner (`git grep -liE 'DO NOT EDIT|@generated|automatically generated'`); `content/docs/api/schema-reference.md` carries none. The control proves the probe fires.
- `git check-ignore` does not ignore it — it is a tracked file.
- No script writes to it; every script that names it (`check-doc-component-types.mjs`, `check-doc-snippet-types.mjs`) only reads it.
- Its history is hand-authored docs PRs editing individual rows, e.g. `ab7dc31ce` "state every declared BaseSchema member at its declared type".

## Reverse verification — direction predicted before running

Mutation: restore `hidden` to boolean-only on **both** faces, keep every new pin. Mutation and restore each proved on disk by anchor counts in both directions; the rebuilt `dist` was re-read each way so nothing was measured against a stale `.d.ts`; the restore was proved by **state** (`git diff HEAD` empty **and** both worktree blob hashes byte-identical to their `HEAD` blobs), never by an exit code.

**Predicted RED, observed RED, no surprises:**

| site | predicted | observed |
|:--|:--|:--|
| `base-schema-hidden-predicate.test.ts` invariant `Equal` assertions (3) | TS2344 | TS2344 at :90, :95, :98 |
| the two authorable string fixtures | TS2322 | TS2322 at :106, :112 |
| the Zod-face runtime case | vitest fail | `× zod mirror: a predicate string on 'hidden' parses in full` |
| the two declared-path react call sites | TS2322 | TS2322 at :210, :213 — and those two were the **only** errors in the whole react test project |

**Predicted GREEN and observed GREEN in both states — the carriers are legal either way:**

- every runtime case in `SchemaRenderer.hiddenDeclaredGate.test.tsx`, including the new declared-path one. A declaration change cannot move runtime behaviour, and this is the control that says so.
- `base-schema-visible-predicate.test.ts`, and the `visible` / `disabled` control cases inside the new pin.
- `hidden: true` / `hidden: false` parse, and `hidden: 123` is refused. The refusal is the anti-overshoot guard: widening to `z.any()` would satisfy every positive case on its own.

**One prediction I got wrong, and it was a NOT-MEASURED rather than a green.** The first mutation run measured `@object-ui/types` and `@object-ui/react` in one recursive `pnpm --filter` invocation. It stopped at the first failing package (`ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`), so the react leg **did not run at all** — reading its absence from the output as "react stayed green" would have been wrong in the most ordinary way. It was re-run on its own, under the same mutation, and produced the two predicted errors and nothing else.

## ⭐ One thing the ruling could not have known: the widening seeds a ledger entry

`zod-mirror-parity.test.ts` turned red naming `app.zod.ts#AppComponentSchema` — a pair with no ledger entry, so its recorded drift was `never`. Cause, measured on `@objectstack/spec@17.2.0` by resolving `AppSchema.shape` at runtime:

- the spec's `AppSchema` declares `hidden` (`z.boolean().optional()` — accepts a boolean, refuses a string) and declares **neither** `visible` **nor** `disabled`;
- `AppComponentSchema` is `BaseSchema.extend(SpecAppFields.shape).extend(...)`, and `SpecAppFields` excludes six keys with `hidden` not among them — so on the mirror face the spec's boolean lands after the base's and overrides it;
- the TS interface `extends BaseSchema` and does not restate the key, so it inherits the widened union.

That asymmetry is the spec's, one layer under the one this card removed: `visible` and `disabled` widened without seeding anything precisely because the spec's `AppSchema` does not declare them. Attribution is measured, not assumed — under the mutation above, this error disappears.

Handled the way that file instructs a firing to be handled: **by measuring**, with a `KnownDrift` entry carrying the measurement and the reason. `ReconcileAgainstLedger` compares invariantly, so the file going green proves the entry is *exactly* the measured drift — the single key `hidden`, no more and no less. The ledger's prose counts moved with it (39/55 to 40/56, and the two "pairs with no entry" figures).

⛔ I did **not** close it by dropping `hidden` from `SpecAppFields`: that would make a spec-derived schema accept, by local divergence, a value the spec refuses — a second published surface, outside this ruling. The collision underneath (the spec's app-catalogue flag and the renderer's hide predicate sharing one name) is filed as objectui#7542, unassigned, with the directions measured and none chosen.

## What was run, at `f7b8948b1`

| run | result |
|:--|:--|
| `pnpm build` (whole repo) | 43 packages, **0 errors**. This is also the consumer sweep — direction: **dependents** of `@object-ui/types`, all of them, green. |
| `pnpm --filter @object-ui/types type-check` (`tsc` + examples + `tsconfig.test.json`) | exit 0, 0 `error TS` lines |
| `pnpm --filter @object-ui/react type-check` (`tsc` + `tsconfig.test.json`) | exit 0, 0 `error TS` lines |
| `pnpm exec vitest run packages/types/` | 97 files, 1642 tests, all passed |
| `pnpm exec vitest run` on 6 react visibility/enablement suites | 6 files, 105 tests, all passed |
| `check:control-bytes` | OK, 6212 tracked text files scanned |
| `check:doc-types` / `check:doc-fences` / `check:doc-snippets` | all OK; doc-snippets judged 456 of 456 blocks against the built types |
| `check:phantom-deps` / `check:published-tsconfig-exclude` / `check:readme-exports` | all OK (readme-exports over the full population: 0 unbuilt, 52 keys compared) |
| `check-changeset-presence` / `check-changeset-no-major` | OK — 1 changeset declared, no `major` |
| `check-governed-queue-guard --test` over all 7 changed paths | **NOT GOVERNED**; the draft hold here is Clause-② only |
| `pnpm lint` (`eslint . --no-inline-config`, full repo, not narrowed) | 4257 files linted. My 5 changed source files: **0 errors, 0 new warnings**. The repo carries 93 pre-existing errors across 77 files, none of them touched by this diff. |

The test file the cast was dropped in is genuinely compiled: `tsc -p packages/react/tsconfig.test.json --listFiles` reports it, so the type-level half of that pin is checked rather than merely written.

**Not measured, declared:** remote CI. Per the dispatch contract the report is handed over at draft-PR time and CI convergence is the reviewing seat's; nothing here waits on it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_