### PR TITLE
feat(types)!: ChartSchema declares the data model it renders — chart-level `data`, `xAxisKey`, and both series binding dialects

### DIFF
--- a/.changeset/7113-chart-data-model.md
+++ b/.changeset/7113-chart-data-model.md
@@ -1,0 +1,73 @@
+---
+'@object-ui/types': minor
+---
+
+`ChartSchema` declares the data model it renders — chart-level `data` and `xAxisKey`, with
+the bare-string `xAxis` folded onto the latter — and `ChartDataSeries` accepts both binding
+dialects (objectui#7113 option B, 项目总监席 总监批 #28 2026-09-01 「同意」; and
+objectui#6939's `chart` row, maintainer ruling 2026-09-02 「同意」 — both rulings
+independently instructed declaring these two keys, so they land as one change).
+
+⚠️ Shipped as `minor`, not `patch`, because two document classes that validated before now
+REFUSE. objectui#6939 grades this class "patch where the accept set only widens toward what
+already renders"; this change is not a pure widening, so it takes the level objectui#6896
+set for the same transition in this same file — the mirror starting to refuse — and for the
+same reason: this repository's `major` is a cross-repo pin to `@objectstack`'s major rather
+than a severity dial, so the break is announced here, which is the channel that carries it.
+
+## What now refuses (the narrowing, named)
+
+Both were previously accepted, unchecked, and drew an EMPTY CHART in silence — they
+survived only on `BaseSchema`'s `.passthrough()`:
+
+```jsonc
+{ "type": "chart", "chartType": "bar", "data": "oops" }      // now: data — expected array
+{ "type": "chart", "chartType": "bar", "xAxisKey": 123 }     // now: xAxisKey — expected string
+```
+
+Rows that are not objects (`data: [1, 2, 3]`, the shape of the inline model retired by
+objectui#6896) are likewise refused, at `data.0`.
+
+## What now validates (the widening)
+
+`series: [{ dataKey: 'revenue' }]`. `normalizeSeries` reads
+`str(raw.dataKey) ?? str(raw.name)`, so `dataKey` alone has always been a complete binding
+— but the mirror REQUIRED `name` and refused it. That is why both catalog chart fixtures
+(`advanced-line-chart.json`, `area-chart.json`) failed validation: they are the `chart: 2`
+entry in `objectui check`'s 28-file census. `name` is now optional, `dataKey` is declared,
+and a series binding to NEITHER is refused by name at `series.N.name` — the same path the
+required flag used to report, so the diagnostic did not move.
+
+## `xAxis` folds; it does not become a second name
+
+`xAxis: 'month'` is accepted at input and is ABSENT from the output, having landed on
+`xAxisKey`. When both are written the canonical key is kept and the alias dropped — not a
+precedence rule minted here, but the one already running at `normalizeChartSchema.ts:292`,
+where `xAxisKey` is the first limb of `str(schema.xAxisKey) ?? xAxisSpec?.field ??
+str(xAxisRaw)`. No chart that renders today changes what it renders.
+
+⚠️ The `xAxis` **config object** (`{ field, format, title, showGridLines }`) is NOT folded.
+Only the bare string is a sibling spelling of `xAxisKey`; the object's presentation keys
+survive separately into `out.xAxis` (`normalizeChartSchema.ts:289-291`), and folding it
+would discard them.
+
+## Not done, deliberately
+
+objectui#6939's `chart` row also says "`series[].data` stops being required". On this base
+it already is not: objectui#6896 replaced it with `retirementTombstone(...)` —
+`z.never({ error }).optional()` — which is optional AND refuses any authored value by name.
+Implementing the clause literally would re-widen a retired key and reverse a landed ruling,
+so it is not done.
+
+## FROM → TO
+
+```ts
+// ChartDataSeries
+- name: string;
++ name?: string;
++ dataKey?: string;
+
+// ChartSchema
++ data?: Array<Record<string, any>>;
++ xAxisKey?: string;
+```

--- a/.changeset/7113-chart-data-model.md
+++ b/.changeset/7113-chart-data-model.md
@@ -17,16 +17,58 @@ than a severity dial, so the break is announced here, which is the channel that 
 
 ## What now refuses (the narrowing, named)
 
-Both were previously accepted, unchecked, and drew an EMPTY CHART in silence — they
-survived only on `BaseSchema`'s `.passthrough()`:
+**Three** classes validated before and refuse now. The first two survived only on
+`BaseSchema`'s `.passthrough()`; the third was silently STRIPPED by the non-strict
+`ChartDataSeriesSchema` object.
 
 ```jsonc
-{ "type": "chart", "chartType": "bar", "data": "oops" }      // now: data — expected array
-{ "type": "chart", "chartType": "bar", "xAxisKey": 123 }     // now: xAxisKey — expected string
+// 1. chart-level `data` that is not an array of row objects
+{ "type": "chart", "chartType": "bar", "data": "oops" }   // now: [data] expected array
+{ "type": "chart", "chartType": "bar", "data": [1,2,3] }  // now: [data.0] expected object
+
+// 2. a non-string `xAxisKey`
+{ "type": "chart", "chartType": "bar", "xAxisKey": 123 }  // now: [xAxisKey] expected string
+
+// 3. a non-string `series[].dataKey`  ⚠️ THIS ONE DRAWS A REAL CHART TODAY
+{ "type": "chart", "chartType": "bar",
+  "series": [{ "name": "a", "dataKey": 123 }] }           // now: [series.0.dataKey] expected string
 ```
 
-Rows that are not objects (`data: [1, 2, 3]`, the shape of the inline model retired by
-objectui#6896) are likewise refused, at `data.0`.
+⚠️ **Class 3 is the sharp one and is called out separately.** Classes 1 and 2 are malformed
+documents whose chart was already broken. Class 3 is not: at base it parsed to
+`series: [{ name: 'a' }]` (the non-string `dataKey` stripped in silence) and
+`normalizeChartSchema` renders it — `str(123)` is `undefined`, so the read falls back to
+`name` and yields `series: [{ dataKey: 'a' }]` (`normalizeChartSchema.ts:239`). So this is a
+narrowing away from a document that **renders today**, which is precisely the distinction
+objectui#6939's grading language turns on. `dataKey: null` behaves identically. Measured on
+both states; the declaration itself is right, and this note is the disclosure it was owed.
+
+## Corrected: what class 2 actually did
+
+An earlier draft of this changeset said `xAxisKey: 123` "drew an EMPTY CHART". The read
+sites do not support that: `ChartRenderer.tsx:133` takes `schema.xAxisKey` raw and the rows
+still reach `data` at `:164`, while the normaliser drops the key (`str(123)` is `undefined`).
+Measured through `normalizeChartSchema`, the result keeps the series and loses only the
+category binding — **a drawn chart with a broken category axis**, not an empty one. Class 1
+(`data` malformed) is the one that leaves nothing to plot.
+
+## Also changed on the published surface: combinators
+
+Both consts now carry a check (`ChartSchema` the `xAxis` fold, `ChartDataSeriesSchema` the
+at-least-one-binding refinement), and on zod 4.4.3 that makes three combinators **throw**
+where they previously returned a schema:
+
+```
+ChartSchema.pick(…) / .omit(…) / .partial()        -> throws "cannot be used on object
+ChartDataSeriesSchema.pick(…) / .omit(…) / …          schemas containing refinements"
+```
+
+`.extend()` with a NEW key still works and preserves the fold and the refinement;
+`.optional()`, `z.discriminatedUnion`, `z.toJSONSchema` and `safeValidateSchema` are all
+unaffected. Nothing in this repository calls the throwing combinators on either const, and
+the published surface already ships refined mirrors (`objectql.zod.ts`, `complex.zod.ts`,
+`form.zod.ts`, `app.zod.ts`), so the class is not new — but it is a real behaviour change on
+a published export and it belongs in the release note rather than in a reviewer's file.
 
 ## What now validates (the widening)
 

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -457,35 +457,29 @@ A chart visualization supporting multiple chart types.
   "showLegend": true,
   "showGrid": true,
   "animate": true,
-  "xAxisKey": "month",
-  "data": [
-    { "month": "Jan", "revenue": 4200, "expenses": 3100 },
-    { "month": "Feb", "revenue": 5100, "expenses": 3400 },
-    { "month": "Mar", "revenue": 4800, "expenses": 3200 },
-    { "month": "Apr", "revenue": 6200, "expenses": 3800 },
-    { "month": "May", "revenue": 5800, "expenses": 3600 },
-    { "month": "Jun", "revenue": 7100, "expenses": 4000 }
-  ],
+  "categories": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
   "series": [
-    { "name": "revenue", "color": "#3b82f6" },
-    { "name": "expenses", "color": "#ef4444" }
+    {
+      "name": "Revenue",
+      "data": [4200, 5100, 4800, 6200, 5800, 7100],
+      "color": "#3b82f6"
+    },
+    {
+      "name": "Expenses",
+      "data": [3100, 3400, 3200, 3800, 3600, 4000],
+      "color": "#ef4444"
+    }
   ]
 }
 ```
-
-The rows live on the chart-level `data`; each series names the COLUMN it plots and carries
-no numbers of its own. An inline `series[].data` array was retired by objectui#6896 — it
-was never read, and it is now refused by name.
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `chartType` | `ChartType` | **Required.** `"bar"`, `"line"`, `"area"`, `"pie"`, `"donut"`, `"radar"`, `"scatter"`, `"heatmap"`. |
 | `title` | `string` | Chart title. |
 | `description` | `string` | Chart description / subtitle. |
-| `data` | `Array<Record<string, any>>` | Rows to plot — one object per row, keyed by column name. |
-| `xAxisKey` | `string` | Row key holding the category (x) axis. The bare-string spelling `xAxis: "month"` folds onto this key when the schema is parsed. |
-| `categories` | `string[]` | An **alternative series list** — column names to plot, consulted only when `series` is absent. Not axis labels. |
-| `series` | `ChartDataSeries[]` | Data series. Each names the column it plots with `name` or `dataKey` (either alone is enough), plus optional `color` and a per-series `type` for combo charts. |
+| `categories` | `string[]` | X-axis category labels. |
+| `series` | `ChartSeries[]` | Data series, each with `name`, `data` array, and optional `color`. |
 | `height` / `width` | `string \| number` | Chart dimensions. |
 | `showLegend` | `boolean` | Display the legend. |
 | `showGrid` | `boolean` | Display grid lines. |
@@ -967,15 +961,8 @@ A widget-based dashboard with configurable grid layout and auto-refresh.
       "body": {
         "type": "chart",
         "chartType": "area",
-        "xAxisKey": "day",
-        "data": [
-          { "day": "Mon", "sales": 120 },
-          { "day": "Tue", "sales": 180 },
-          { "day": "Wed", "sales": 150 },
-          { "day": "Thu", "sales": 210 },
-          { "day": "Fri", "sales": 190 }
-        ],
-        "series": [{ "dataKey": "sales" }]
+        "categories": ["Mon", "Tue", "Wed", "Thu", "Fri"],
+        "series": [{ "name": "Sales", "data": [120, 180, 150, 210, 190] }]
       }
     },
     {

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -457,29 +457,35 @@ A chart visualization supporting multiple chart types.
   "showLegend": true,
   "showGrid": true,
   "animate": true,
-  "categories": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+  "xAxisKey": "month",
+  "data": [
+    { "month": "Jan", "revenue": 4200, "expenses": 3100 },
+    { "month": "Feb", "revenue": 5100, "expenses": 3400 },
+    { "month": "Mar", "revenue": 4800, "expenses": 3200 },
+    { "month": "Apr", "revenue": 6200, "expenses": 3800 },
+    { "month": "May", "revenue": 5800, "expenses": 3600 },
+    { "month": "Jun", "revenue": 7100, "expenses": 4000 }
+  ],
   "series": [
-    {
-      "name": "Revenue",
-      "data": [4200, 5100, 4800, 6200, 5800, 7100],
-      "color": "#3b82f6"
-    },
-    {
-      "name": "Expenses",
-      "data": [3100, 3400, 3200, 3800, 3600, 4000],
-      "color": "#ef4444"
-    }
+    { "name": "revenue", "color": "#3b82f6" },
+    { "name": "expenses", "color": "#ef4444" }
   ]
 }
 ```
+
+The rows live on the chart-level `data`; each series names the COLUMN it plots and carries
+no numbers of its own. An inline `series[].data` array was retired by objectui#6896 — it
+was never read, and it is now refused by name.
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `chartType` | `ChartType` | **Required.** `"bar"`, `"line"`, `"area"`, `"pie"`, `"donut"`, `"radar"`, `"scatter"`, `"heatmap"`. |
 | `title` | `string` | Chart title. |
 | `description` | `string` | Chart description / subtitle. |
-| `categories` | `string[]` | X-axis category labels. |
-| `series` | `ChartSeries[]` | Data series, each with `name`, `data` array, and optional `color`. |
+| `data` | `Array<Record<string, any>>` | Rows to plot — one object per row, keyed by column name. |
+| `xAxisKey` | `string` | Row key holding the category (x) axis. The bare-string spelling `xAxis: "month"` folds onto this key when the schema is parsed. |
+| `categories` | `string[]` | An **alternative series list** — column names to plot, consulted only when `series` is absent. Not axis labels. |
+| `series` | `ChartDataSeries[]` | Data series. Each names the column it plots with `name` or `dataKey` (either alone is enough), plus optional `color` and a per-series `type` for combo charts. |
 | `height` / `width` | `string \| number` | Chart dimensions. |
 | `showLegend` | `boolean` | Display the legend. |
 | `showGrid` | `boolean` | Display grid lines. |
@@ -961,8 +967,15 @@ A widget-based dashboard with configurable grid layout and auto-refresh.
       "body": {
         "type": "chart",
         "chartType": "area",
-        "categories": ["Mon", "Tue", "Wed", "Thu", "Fri"],
-        "series": [{ "name": "Sales", "data": [120, 180, 150, 210, 190] }]
+        "xAxisKey": "day",
+        "data": [
+          { "day": "Mon", "sales": 120 },
+          { "day": "Tue", "sales": 180 },
+          { "day": "Wed", "sales": 150 },
+          { "day": "Thu", "sales": 210 },
+          { "day": "Fri", "sales": 190 }
+        ],
+        "series": [{ "dataKey": "sales" }]
       }
     },
     {

--- a/packages/plugin-charts/package.json
+++ b/packages/plugin-charts/package.json
@@ -27,7 +27,7 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/packages/plugin-charts/src/ChartRenderer.catalogRender-6939.test.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.catalogRender-6939.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6939, the `chart` group — the RENDER half. The validator-side
+ * contract is pinned in
+ * `packages/types/src/__tests__/chart-data-model-7113.test.ts`.
+ *
+ * Ruling 5510084784 (maintainer 2026-09-02, verbatim 「同意」) sets the bar per
+ * group, from objectui#6318's triage: "the catalog entry validates, **and its
+ * render is byte-identical in element count and text before and after**". The
+ * validator half alone cannot make the claim — a "repair" that also changes
+ * what is drawn has not proved the SCHEMA was wrong, it has changed the
+ * product. Both landed sibling groups carry this half
+ * (`plugin-map/src/ObjectMap.catalogRecordSource-6939.test.tsx`,
+ * `examples/schema-catalog/test/tree-view-nodes-mirror-6939.test.tsx`), and
+ * this file is the chart group's.
+ *
+ * ## The asymmetry this group has and the siblings do not
+ *
+ * At BASE both fixtures **FAIL** validation (`series.N.name`: they are authored
+ * in the `dataKey` dialect, which the mirror required `name` instead of) while
+ * **drawing correctly**. So the before/after identity cannot be measured through
+ * a parse-then-render path — there is no parse at base. It is measured through
+ * the renderer directly, which is also honest about how charts actually reach
+ * the screen: `ChartRenderer` consumes the AUTHORED schema and calls
+ * `normalizeChartSchema` on it; it never sees the mirror's parse output.
+ *
+ * That also bounds what this file can regress on: the objectui#7113 diff touches
+ * no file under `packages/plugin-charts`, so the renderer is byte-identical
+ * across the change. The pin's job is to keep it that way as the mirror moves.
+ *
+ * ## PRE_REPAIR — measured, not transcribed
+ *
+ * Captured on `origin/main` @ `98d4108a2` (the merge-base), both faces
+ * untouched, through THIS file's `measure()` in a worktree at that commit.
+ *
+ * ⚠️ Element counts are HARNESS-BOUND and must never be carried over from
+ * another run. The contract review of PR #7545 measured this same property on
+ * its own harness and read `advanced-line-chart` 136 / `area-chart` 132 with 11
+ * x-axis ticks; this harness reads 136 and **127** with **6** ticks. Both are
+ * correct about their own harness — `ResponsiveContainer` is mocked to a fixed
+ * 480x320 here, and tick density is a function of that width
+ * (`AdvancedChartImpl`'s categorical axis thins labels by available space). The
+ * claim that discriminates is IDENTITY WITHIN ONE HARNESS, which is why the
+ * numbers below were re-derived here rather than copied.
+ *
+ * Three readings per fixture, because a count alone cannot tell a swapped
+ * element from an equal one: element count, a tag census, and a SHA-256 of the
+ * text.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Recharts' ResponsiveContainer measures via ResizeObserver, which reports 0x0
+// under the headless DOM, so nothing paints. Fix its size — the same shim the
+// other render tests in this package use.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import { ChartRenderer } from './ChartRenderer';
+import { safeValidateSchema } from '@object-ui/types/zod';
+
+afterEach(cleanup);
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const NAMES = ['advanced-line-chart', 'area-chart'] as const;
+
+function catalogEntry(name: (typeof NAMES)[number]): Record<string, unknown> {
+  const file = path.join(REPO_ROOT, 'examples/schema-catalog/src/schemas/plugin-charts', `${name}.json`);
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+interface Reading {
+  elements: number;
+  tags: Record<string, number>;
+  lines: number;
+  areas: number;
+  xTicks: number;
+  sha256: string;
+}
+
+/** Measured at `98d4108a2` through `measure()` below. See the header. */
+const PRE_REPAIR: Record<(typeof NAMES)[number], Reading> = {
+  'advanced-line-chart': {
+    elements: 136,
+    tags: { DIV: 9, STYLE: 1, svg: 1, title: 1, desc: 1, g: 48, line: 5, defs: 2, clipPath: 1, rect: 1, linearGradient: 14, stop: 28, path: 2, text: 11, tspan: 11 },
+    lines: 2,
+    areas: 0,
+    xTicks: 6,
+    sha256: 'dd56a5f8c25242bb737db18308f2952c3f5dabbe1dcb6eb9e0b71cdb3a3bbccd',
+  },
+  'area-chart': {
+    elements: 127,
+    tags: { DIV: 7, STYLE: 1, svg: 1, title: 1, desc: 1, g: 47, line: 5, defs: 2, clipPath: 1, rect: 1, linearGradient: 12, stop: 24, path: 2, text: 11, tspan: 11 },
+    lines: 0,
+    areas: 1,
+    xTicks: 6,
+    sha256: 'c1270f6053d2dd82c9da87b57607ae04896bf3fc317c9c15357632b48fa05386',
+  },
+};
+
+async function measure(schema: unknown): Promise<Reading> {
+  const { container } = render(
+    <ChartRenderer schema={{ ...(schema as any), isAnimationActive: false }} />,
+  );
+  // `AdvancedChartImpl` is lazy — wait for the real plot, not the skeleton. A
+  // fixture that stopped drawing fails HERE, loudly, rather than reporting a
+  // tidy zero further down.
+  await waitFor(() => {
+    if (!container.querySelector('.recharts-surface')) throw new Error('nothing drew');
+  });
+  const nodes = Array.from(container.querySelectorAll('*'));
+  // React's `useId` lands in the injected <style> block (`chart-_r_0_`), so it
+  // varies with render ORDER inside the file. Normalise it, or the hash pins
+  // the test order rather than the drawing.
+  const text = (container.textContent ?? '').replace(/chart-_r_[0-9a-z]+_/g, 'chart-ID');
+  return {
+    elements: nodes.length,
+    tags: nodes.reduce<Record<string, number>>((h, el) => ((h[el.tagName] = (h[el.tagName] ?? 0) + 1), h), {}),
+    lines: container.querySelectorAll('.recharts-line').length,
+    areas: container.querySelectorAll('.recharts-area').length,
+    xTicks: container.querySelectorAll('.recharts-xAxis .recharts-cartesian-axis-tick').length,
+    sha256: createHash('sha256').update(text).digest('hex'),
+  };
+}
+
+describe('objectui#6939 `chart` — the catalog fixtures draw exactly what they drew before', () => {
+  it.each(NAMES)('%s renders identically to BASE', async (name) => {
+    expect(await measure(catalogEntry(name))).toEqual(PRE_REPAIR[name]);
+  });
+
+  /*
+   * The verdict half — the thing that DID change. At `98d4108a2` both of these
+   * reported `series.N.name: Invalid input: expected string, received undefined`
+   * from `safeValidateSchema` while drawing the readings pinned above. Together
+   * with the identity above, that is objectui#6318's bar: the validator's
+   * verdict moves, the drawing does not.
+   */
+  it.each(NAMES)('%s now VALIDATES, which is the half that changed', (name) => {
+    const r = safeValidateSchema(catalogEntry(name));
+    expect(r.success ? [] : r.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`)).toEqual([]);
+  });
+
+  /*
+   * LIT CONTROL for the identity assertions. Without it, `toEqual(PRE_REPAIR)`
+   * passing proves only that two things matched — it cannot show the instrument
+   * would have NOTICED a difference. Perturb the authored rows and the same
+   * measurement must move.
+   */
+  it('CONTROL — the measurement detects a changed drawing', async () => {
+    const doc = catalogEntry('area-chart') as { data: Record<string, unknown>[] };
+    const perturbed = { ...doc, data: [...doc.data, { month: 'Jul', users: 2600 }] };
+    const reading = await measure(perturbed);
+    expect(reading.sha256).not.toBe(PRE_REPAIR['area-chart'].sha256);
+    expect(reading.elements).not.toBe(PRE_REPAIR['area-chart'].elements);
+  });
+});

--- a/packages/plugin-charts/tsconfig.json
+++ b/packages/plugin-charts/tsconfig.json
@@ -13,5 +13,22 @@
     "composite": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Tooling is excluded by DIRECTORY, not just by file NAME — the arrangement
+  // 34 of this repo's 38 test-bearing packages already use (see
+  // `packages/plugin-map/tsconfig.json`, whose comment carries the history).
+  // Until objectui#7113 this package had no exclusion at all, so its 45 test
+  // files were inputs to THIS program — which emits (`declaration`, `composite`,
+  // `outDir: dist`). That is the defect objectui#4006 / #4836 / #6943 hit three
+  // times and `pnpm check:published-tsconfig-exclude` exists to stop. The tests
+  // are still type-checked, by `tsconfig.test.json`, which `type-check` chains.
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__benchmarks__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
 }

--- a/packages/plugin-charts/tsconfig.test.json
+++ b/packages/plugin-charts/tsconfig.test.json
@@ -1,0 +1,31 @@
+{
+  // Type-checks this package's TESTS, which `tsconfig.json` excludes.
+  // Modelled on `packages/plugin-map/tsconfig.test.json` — the sibling that
+  // already reads schema-catalog fixtures off disk from a `*-6939` render pin.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // The package build emits `dist`; this project emits nothing, so it must
+    // not inherit `composite` / `declaration` from the build config.
+    "composite": false,
+    // Naming `types` at all switches off automatic `@types/*` inclusion, so
+    // every type package these tests need is named here.
+    // - `@testing-library/jest-dom` is a global augmentation, not an import,
+    //   and does not live under `@types/`, so it is never picked up
+    //   automatically (two test files here use its matchers).
+    // - `node` is what `ChartRenderer.catalogRender-6939.test.tsx` needs: it
+    //   reads the schema-catalog chart fixtures off disk with `node:fs` /
+    //   `node:path` / `node:url` and hashes their render with `node:crypto`.
+    //   The pin has to cross a package boundary, and it cannot move to
+    //   `examples/schema-catalog/test/` — `vi.mock('recharts')` does not
+    //   intercept plugin-charts' import from there, because pnpm's strict
+    //   layout gives the two packages different resolved paths for recharts,
+    //   so the real `ResponsiveContainer` renders 0x0 and nothing paints.
+    "types": ["@testing-library/jest-dom", "node"],
+    // Drop the root tsconfig's source-tree `paths` so `@object-ui/*` resolves
+    // through the workspace dependency's built `.d.ts` instead of pulling
+    // sibling sources in as program inputs (TS6059).
+    "paths": {}
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.d.ts"]
+}

--- a/packages/types/src/__tests__/chart-data-model-7113.test.ts
+++ b/packages/types/src/__tests__/chart-data-model-7113.test.ts
@@ -1,0 +1,339 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `ChartSchema` declares the data model it actually renders: chart-level `data`
+ * and `xAxisKey`, with the bare-string `xAxis` folded onto the latter; and
+ * `ChartDataSeries` accepts both binding dialects.
+ *
+ * Two rulings land here as ONE change, because both independently instructed
+ * declaring `xAxisKey` and chart-level `data` on this schema:
+ *
+ *   - objectui#7113, option **B** (项目总监席, 总监批 #28, 2026-09-01, maintainer
+ *     verbatim 「同意」) — declare both keys, and fold `xAxis` per the
+ *     objectstack#13897 precedent: parse-time fold, no second writable name, no
+ *     precedence semantics invented here.
+ *   - objectui#6939's `chart` row (maintainer ruling 2026-09-02, verbatim
+ *     「同意」) — the mirror accepts both binding dialects (`dataKey` and
+ *     `name`), and `series[].data` stops being required.
+ *
+ * ## What was measured on `origin/main` 98d4108a2, before the change
+ *
+ * The renderer has always implemented this model; the declaration never carried
+ * it. Both keys survived only on `BaseSchema`'s `.passthrough()` (mirror) and
+ * its `[key: string]: any` index signature (TS twin) — authored, read, and
+ * UNCHECKED. Measured against the built mirror:
+ *
+ *     data: 'oops'      -> ACCEPT      xAxisKey: 123 -> ACCEPT
+ *     series: [{ dataKey: 'revenue' }] -> REFUSE  (series.0.name required)
+ *
+ * The third reading is the live defect the other two frame: `dataKey` is the
+ * spelling BOTH catalog chart fixtures are written in and the one
+ * `normalizeSeries` prefers, and the mirror refused it — so
+ * `examples/schema-catalog/src/schemas/plugin-charts/{advanced-line,area}-chart.json`
+ * are exactly the `chart: 2` files in `objectui check`'s 28-file census
+ * (objectui#6939 comment 5493518990).
+ *
+ * Meanwhile this file's own PUBLISHED `.describe()` prose was already teaching
+ * authors to write both keys — the `ChartDataSeries.data` tombstone says
+ * "put the rows on the chart-level `data` and the category axis on `xAxisKey`",
+ * and `categories` says "the category axis comes from `xAxisKey`/`xAxis`". So
+ * this is a RESTORATION of `declared = enforced`, not new capability
+ * (objectui#7113 ruling, clause 4).
+ *
+ * ## ⚠️ What declaring these keys does NOT do — measured, and contrary to the
+ * ruling's stated justification
+ *
+ * objectui#7113's ruling justifies option B by saying a misspelling like
+ * `xAxiskey` / `datas` moves "from tsc-green + zod-green + empty chart to loud
+ * at authoring time". That is FALSE on both faces, before AND after this change,
+ * and section (f) below pins it rather than letting the claim stand unmeasured:
+ *
+ *   - the mirror's `BaseSchema` is `.passthrough()` (`base.zod.ts:212`), so an
+ *     undeclared key is KEPT, never refused;
+ *   - the TS `BaseSchema` carries `[key: string]: any` (`base.ts:409`), which
+ *     suppresses excess-property checking on every chart literal.
+ *
+ * What the declaration DOES buy is the VALUE check — `data` and `xAxisKey` are
+ * now refused BY NAME when malformed, where before they drew an empty chart in
+ * silence — plus editor completion for the correct spellings, and prose that is
+ * finally true. That is the real remedy, and it is worth stating precisely so
+ * the next reader does not go looking for a typo refusal that cannot exist
+ * while `BaseSchema` passes through.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { ChartSchema, ChartDataSeries } from '../data-display';
+import { ChartSchema as ChartZodSchema, ChartDataSeriesSchema } from '../zod/data-display.zod';
+
+const CHART = { type: 'chart', chartType: 'bar' } as const;
+const chart = (extra: Record<string, unknown>) => ({ ...CHART, ...extra });
+
+/** Parse and report the OUTPUT keys — the fold is only visible in the output. */
+const parsed = (doc: unknown) => {
+  const r = ChartZodSchema.safeParse(doc);
+  if (!r.success) throw new Error(`expected ACCEPT, got: ${JSON.stringify(r.error.issues)}`);
+  return r.data as Record<string, unknown>;
+};
+
+const refusalPaths = (doc: unknown): string[] => {
+  const r = ChartZodSchema.safeParse(doc);
+  if (r.success) throw new Error('expected REFUSE, got ACCEPT');
+  return r.error.issues.map((i) => i.path.join('.'));
+};
+
+const catalog = (name: string) =>
+  JSON.parse(
+    readFileSync(
+      fileURLToPath(
+        new URL(`../../../../examples/schema-catalog/src/schemas/plugin-charts/${name}.json`, import.meta.url),
+      ),
+      'utf8',
+    ),
+  );
+
+/* ── (a) chart-level `data` — the shape comes from the READ SITES ─────────── */
+
+/**
+ * ⛔ NOT from `normalizeChartSchema`. objectui#7113's ruling says `data`'s
+ * declared shape follows "`normalizeChartSchema`'s actual read shape", and that
+ * function has **zero** reads of `schema.data` — `grep -n 'schema\.data\b'
+ * packages/plugin-charts/src/normalizeChartSchema.ts` returns nothing. The read
+ * sites are elsewhere, and the shape below is derived from them:
+ *
+ *   - `ChartRenderer.tsx:17,47`  — the prop is declared `Array<Record<string, any>>`
+ *   - `ChartRenderer.tsx:164`    — `data: Array.isArray(schema.data) ? schema.data : []`
+ *   - `AdvancedChartImpl.tsx:2229` — `Object.keys(props.data[0] ?? {})`, i.e. a row's
+ *                                    keys ARE the column names
+ *   - `AdvancedChartImpl.tsx:1968` — `d[xAxisKey]`, i.e. a row is indexed by column name
+ *   - `ObjectChart.tsx:279,703`  — `Array.isArray(schema.data)`, rows used verbatim
+ *
+ * ⇒ an ARRAY OF ROW OBJECTS keyed by column name. Identical to the sibling
+ * `BarChartSchema.data`, which objectui#6318 derived from the same renderer the
+ * same way — the two chart nodes agreeing is a check on the derivation.
+ */
+describe('objectui#7113 (a) — chart-level `data` is declared, with the shape the renderer reads', () => {
+  it('accepts an array of row objects keyed by column name', () => {
+    const out = parsed(chart({ series: [{ name: 'revenue' }], data: [{ month: 'Jan', revenue: 4000 }] }));
+    expect(out.data).toEqual([{ month: 'Jan', revenue: 4000 }]);
+  });
+
+  it('refuses a non-array `data` BY NAME — before, this parsed clean and drew an empty chart', () => {
+    expect(refusalPaths(chart({ series: [{ name: 'r' }], data: 'oops' }))).toContain('data');
+  });
+
+  it('refuses rows that are not objects — a bare number array is the retired inline model', () => {
+    expect(refusalPaths(chart({ series: [{ name: 'r' }], data: [1, 2, 3] }))).toContain('data.0');
+  });
+
+  it('stays OPTIONAL — a query-backed chart carries no inline rows', () => {
+    expect(parsed(chart({ series: [{ name: 'r' }] })).data).toBeUndefined();
+  });
+
+  it('agrees with the sibling `BarChartSchema.data`, derived from the same renderer', () => {
+    const rows = [{ name: 'Jan', value: 10 }];
+    expect(parsed(chart({ series: [{ name: 'value' }], data: rows })).data).toEqual(rows);
+  });
+});
+
+/* ── (b) `xAxisKey` declared, and the `xAxis` alias fold ──────────────────── */
+
+describe('objectui#7113 (b) — `xAxisKey` is declared and the bare-string `xAxis` folds onto it', () => {
+  it('accepts `xAxisKey` and refuses a non-string one BY NAME', () => {
+    expect(parsed(chart({ series: [{ name: 'r' }], xAxisKey: 'month' })).xAxisKey).toBe('month');
+    expect(refusalPaths(chart({ series: [{ name: 'r' }], xAxisKey: 123 }))).toContain('xAxisKey');
+  });
+
+  /* Direction 1 of the fold: the alias ARRIVES on the canonical key. */
+  it('`xAxis` authored ALONE lands on `xAxisKey`', () => {
+    expect(parsed(chart({ series: [{ name: 'r' }], xAxis: 'month' })).xAxisKey).toBe('month');
+  });
+
+  /*
+   * Direction 2, and the half a "does it parse?" pin cannot see: NO SECOND
+   * WRITABLE NAME. The alias must not survive the parse — if it did, the fold
+   * would have produced two spellings of one fact instead of folding them.
+   */
+  it('`xAxis` does NOT survive the parse — exactly one name for the category column', () => {
+    const out = parsed(chart({ series: [{ name: 'r' }], xAxis: 'month' }));
+    expect(out).not.toHaveProperty('xAxis');
+    expect(Object.keys(out).filter((k) => k === 'xAxis' || k === 'xAxisKey')).toEqual(['xAxisKey']);
+  });
+
+  /*
+   * ⛔ NO PRECEDENCE SEMANTICS. There is no output in which both survive with a
+   * rule for reading them: when both are written the canonical key is kept and
+   * the alias is dropped. That is not a rule minted here — it is the one already
+   * running at `normalizeChartSchema.ts:292`, where `xAxisKey` is the first limb
+   * of `str(schema.xAxisKey) ?? xAxisSpec?.field ?? str(xAxisRaw)`. So no chart
+   * that renders today changes what it renders.
+   */
+  it('both written: canonical kept, alias dropped — never a surviving pair', () => {
+    const out = parsed(chart({ series: [{ name: 'r' }], xAxisKey: 'canonical', xAxis: 'alias' }));
+    expect(out.xAxisKey).toBe('canonical');
+    expect(out).not.toHaveProperty('xAxis');
+  });
+
+  /*
+   * The object dialect is NOT an alias and is deliberately NOT folded. Its
+   * `field` also answers the column question, but `format` / `title` /
+   * `showGridLines` are presentation that `normalizeChartSchema:289-291` keeps
+   * separately in `out.xAxis` — folding it would discard them.
+   */
+  it('the `xAxis` CONFIG OBJECT is left intact — folding it would discard presentation', () => {
+    const axis = { field: 'month', title: 'Month', format: 'MMM' };
+    const out = parsed(chart({ series: [{ name: 'r' }], xAxis: axis }));
+    expect(out.xAxis).toEqual(axis);
+    expect(out.xAxisKey).toBeUndefined();
+  });
+
+  /*
+   * CONTROL for the fold's construction, and it must pass FOR THE REASON IT
+   * CLAIMS: `ChartSchema` was a plain `ZodObject` before this change and must
+   * still be one after it, so this assertion is legal in BOTH states and
+   * reddens only if the fold is rewritten as `.transform()`. ⚠️ It deliberately
+   * does NOT assert the new keys — an earlier draft did, and the reverse
+   * verification caught it reddening for the DECLARATION instead of for
+   * pipe-ness, which would have made it a probe wearing a control's label.
+   * `.transform()` returns a ZodPipe: no `.shape`, no `.extend()`.
+   * `zod-mirror-parity.test.ts` reads `.shape` on every mirror and would answer
+   * with an EMPTY set — a silent hole in the ratchet rather than an error — and
+   * `reports.zod.ts` consumes `ChartSchema` as an object.
+   */
+  it('CONTROL — `ChartSchema` is still a ZodObject, so the parity ratchet can read `.shape`', () => {
+    const shape = (ChartZodSchema as unknown as { shape: Record<string, unknown> }).shape;
+    expect(Object.keys(shape).length).toBeGreaterThan(0);
+    expect(Object.keys(shape)).toContain('series');
+    expect(typeof (ChartZodSchema as unknown as { extend?: unknown }).extend).toBe('function');
+  });
+
+  it('the two keys are DECLARED in the shape, not merely passed through', () => {
+    const shape = (ChartZodSchema as unknown as { shape: Record<string, unknown> }).shape;
+    expect(Object.keys(shape)).toEqual(expect.arrayContaining(['data', 'xAxisKey']));
+  });
+});
+
+/* ── (c) both binding dialects (objectui#6939's `chart` row) ──────────────── */
+
+describe('objectui#6939 `chart` — the mirror accepts both binding dialects', () => {
+  it('accepts `name`', () => {
+    expect(parsed(chart({ series: [{ name: 'revenue' }] })).series).toEqual([{ name: 'revenue' }]);
+  });
+
+  it('accepts `dataKey` — REFUSED before this change, and it is what the renderer prefers', () => {
+    expect(parsed(chart({ series: [{ dataKey: 'revenue' }] })).series).toEqual([{ dataKey: 'revenue' }]);
+  });
+
+  it('accepts both written together', () => {
+    expect(ChartDataSeriesSchema.safeParse({ name: 'Revenue', dataKey: 'revenue' }).success).toBe(true);
+  });
+
+  /*
+   * CONTROL for the two ACCEPTs above. Without it they could be reporting a
+   * passthrough that accepts anything. This series resolves to NEITHER spelling,
+   * which `normalizeSeries` drops in silence (`normalizeChartSchema.ts:240`,
+   * `if (!dataKey) return undefined`) — the mirror refuses it by name instead.
+   * ⚠️ It is legal in BOTH states of the change (`name`'s required flag refused
+   * it before, the refinement refuses it now), so it is a control, not a probe
+   * for the very thing it controls.
+   */
+  it('CONTROL — a series binding to neither spelling is still refused, at `series.0.name`', () => {
+    expect(refusalPaths(chart({ series: [{ color: '#fff' }] }))).toContain('series.0.name');
+  });
+
+  it('CONTROL — the `series[].data` tombstone still refuses, with its migration note', () => {
+    const r = ChartDataSeriesSchema.safeParse({ name: 'r', data: [1, 2, 3] });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.issues[0]?.message).toMatch(/RETIRED \(objectui#6896\)/);
+  });
+});
+
+/*
+ * ⚠️ objectui#6939's `chart` row also says "`series[].data` stops being
+ * required". On this base it ALREADY is not required, and by a STRONGER
+ * mechanism than the row anticipated: objectui#6896 (landed in b0d308da9, after
+ * the 2026-09-01 census the row cites) replaced it with
+ * `retirementTombstone(...)` = `z.never({ error }).optional()`. It is optional
+ * AND refuses any authored value by name. Implementing the clause literally
+ * would mean re-widening a retired key — reversing a landed maintainer ruling —
+ * so it is deliberately NOT done, and this pin holds that line.
+ */
+describe('objectui#6939 `chart` — `series[].data` is already not required (and must stay retired)', () => {
+  it('a series omitting `data` parses', () => {
+    expect(ChartDataSeriesSchema.safeParse({ name: 'revenue' }).success).toBe(true);
+  });
+
+  it('the tombstone is optional, not required — the clause is satisfied without re-widening', () => {
+    const shape = (ChartDataSeriesSchema as unknown as { shape: Record<string, { safeParse: (v: unknown) => { success: boolean } }> }).shape;
+    expect(shape.data.safeParse(undefined).success).toBe(true);
+    expect(shape.data.safeParse([1, 2, 3]).success).toBe(false);
+  });
+});
+
+/* ── (d) the catalog fixtures — the two `chart` files in the census ───────── */
+
+describe('objectui#6939/#7113 — both catalog chart fixtures now validate', () => {
+  it.each(['advanced-line-chart', 'area-chart'])('%s validates against the published mirror', (name) => {
+    const doc = catalog(name);
+    const out = parsed(doc);
+    // Byte-identical inputs to the renderer: every authored key survives with
+    // its authored value (nothing is folded or dropped in these two).
+    expect(out.data).toEqual(doc.data);
+    expect(out.xAxisKey).toEqual(doc.xAxisKey);
+    expect(out.series).toEqual(doc.series);
+  });
+
+  it('CONTROL — the fixtures are written in the `dataKey` dialect, which is why they were refused', () => {
+    for (const name of ['advanced-line-chart', 'area-chart']) {
+      for (const s of catalog(name).series as Array<Record<string, unknown>>) {
+        expect(s.dataKey).toBeTypeOf('string');
+        expect(s.name).toBeUndefined();
+      }
+    }
+  });
+});
+
+/* ── (e) the TS twin moves with the mirror ───────────────────────────────── */
+
+describe('objectui#7113 — the TS twin declares the same model', () => {
+  it('accepts the model at the authoring site', () => {
+    const node: ChartSchema = {
+      type: 'chart',
+      chartType: 'line',
+      data: [{ month: 'Jan', revenue: 4000 }],
+      xAxisKey: 'month',
+      series: [{ dataKey: 'revenue' }],
+    };
+    expect(node.data).toHaveLength(1);
+    expect(node.xAxisKey).toBe('month');
+  });
+
+  it('`dataKey` alone is a complete binding on the twin', () => {
+    const series: ChartDataSeries = { dataKey: 'revenue' };
+    expect(series.dataKey).toBe('revenue');
+  });
+});
+
+/* ── (f) the limit of the remedy — pinned so the claim is not inherited ──── */
+
+/**
+ * These two pins assert what this change CANNOT do, because objectui#7113's
+ * ruling claims it does. Keeping them here means the next reader measures the
+ * claim instead of quoting it: while `BaseSchema` passes through, a MISSPELLED
+ * key is kept, not refused — before and after. If someone later makes
+ * `ChartSchema` strict, these turn red and the ruling's justification becomes
+ * true for the first time; that is the correct signal, not a failure.
+ */
+describe('objectui#7113 (f) — declaring the keys does NOT make a misspelling loud', () => {
+  it.each(['datas', 'xAxiskey'])('`%s` is still ACCEPTED — `BaseSchema` is `.passthrough()`', (typo) => {
+    const out = parsed(chart({ series: [{ name: 'r' }], [typo]: 'x' }));
+    expect(out).toHaveProperty(typo);
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -1348,9 +1348,23 @@ export type ChartType = SpecChartType;
  */
 export interface ChartDataSeries {
   /**
-   * Series name
+   * Series name — also selects this series' column within each chart-level
+   * `data` row when {@link dataKey} is absent.
+   *
+   * ⚠️ OPTIONAL since objectui#6939 (maintainer ruling 2026-09-02, the `chart`
+   * row): `normalizeSeries` reads `str(raw.dataKey) ?? str(raw.name)`, so
+   * `dataKey` alone is a complete binding and the required flag refused a
+   * document the renderer draws. At least one of the two must still be present
+   * — a series that resolves to neither is dropped in silence by the
+   * normalizer, and the zod mirror refuses it by name.
    */
-  name: string;
+  name?: string;
+  /**
+   * Column this series plots within each chart-level `data` row — the internal
+   * spelling of {@link name}, and the one the renderer takes when both are
+   * written (`normalizeChartSchema.ts:239`).
+   */
+  dataKey?: string;
   /**
    * RETIRED (objectui#6896, ADR-0049 enforce-or-remove) — the inline-data model
    * this key belonged to was never implemented. `normalizeChartSchema`'s
@@ -1430,6 +1444,29 @@ export interface ChartSchema extends BaseSchema {
    * Data series
    */
   series: ChartDataSeries[];
+  /**
+   * Rows to plot — one object per row, keyed by column name. A series' `name`
+   * (or `dataKey`) picks the column to plot within each row, and
+   * {@link xAxisKey} names the category column.
+   *
+   * ⚠️ Declared by objectui#7113. This is the data model the renderer has always
+   * implemented and this interface never declared: rows reached
+   * `ChartRenderer.tsx:164` and were read back as columns at
+   * `AdvancedChartImpl.tsx:2229` while surviving here only on `BaseSchema`'s
+   * index signature. The `ChartDataSeries.data` tombstone above has been
+   * pointing authors at this key since objectui#6896.
+   */
+  data?: Array<Record<string, any>>;
+  /**
+   * Row key holding the category (x) axis.
+   *
+   * The bare-string sibling spelling `xAxis: 'month'` folds onto this key when
+   * the zod mirror parses, and does not survive the parse. The spec's `xAxis`
+   * CONFIG OBJECT is a different key and is not folded — its `field` also
+   * answers the column question, but its `format` / `title` / `showGridLines`
+   * are presentation the fold would discard.
+   */
+  xAxisKey?: string;
   /**
    * Chart height
    */

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -355,7 +355,20 @@ export const ChartTypeSchema = SpecChartTypeSchema;
  * dataset-bound one, and neither carries values.
  */
 export const ChartDataSeriesSchema = z.object({
-  name: z.string().describe('Series name'),
+  // BOTH BINDING DIALECTS (objectui#6939, maintainer ruling 2026-09-02 — the
+  // `chart` row, verbatim 「同意」). `normalizeSeries` reads
+  // `str(raw.dataKey) ?? str(raw.name)` (`plugin-charts/src/normalizeChartSchema.ts:239`),
+  // so the two spellings are interchangeable at the renderer. This mirror
+  // REQUIRED `name`, which refused `series: [{ dataKey: 'revenue' }]` — the
+  // spelling BOTH catalog chart fixtures are written in and the renderer draws.
+  // `name` is optional here and the refinement below carries the floor its
+  // required flag used to: the accept set only widens.
+  name: z.string().optional().describe(
+    'Series name — also selects this series\' column within each chart-level `data` row when `dataKey` is absent',
+  ),
+  dataKey: z.string().optional().describe(
+    'Column this series plots within each chart-level `data` row — the internal spelling of `name`, and the one the renderer takes when both are written',
+  ),
   // ADR-0049 RETIREMENT TOMBSTONE (objectui#6896). Deleting the member was the
   // option NOT taken: `ChartDataSeriesSchema` is a non-strict `z.object`, which
   // STRIPS an undeclared key in silence — the same silent no-op the retirement
@@ -372,10 +385,84 @@ export const ChartDataSeriesSchema = z.object({
   // the TS declaration for the read this narrowness is taken from.
   type: z.enum(['bar', 'line', 'area']).optional().describe('Per-series chart family override (combo charts)'),
   color: z.string().optional().describe('Series color'),
+}).superRefine((series, ctx) => {
+  // `normalizeSeries` returns `undefined` when NEITHER spelling resolves
+  // (`normalizeChartSchema.ts:240`, `if (!dataKey) return undefined`) and the
+  // series is dropped from the chart in silence. Refusing by name here is that
+  // silent drop made loud. ⚠️ This is not a new narrowing: `name`'s required
+  // flag already refused exactly this document, and the path is kept on `name`
+  // so the diagnostic lands where it always did.
+  if (series.name === undefined && series.dataKey === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['name'],
+      message:
+        'A chart series must name the column it plots, with `name` or `dataKey` — '
+        + '`normalizeChartSchema` drops a series that resolves to neither.',
+    });
+  }
 });
 
 /**
+ * Fold the bare-string `xAxis` spelling onto the canonical `xAxisKey` and drop
+ * it from the output (objectui#7113, 项目总监席 总监批 #28, 2026-09-01,
+ * maintainer verbatim 「同意」 — option B), in the shape objectstack#13897
+ * landed for `FormViewSchema`'s legacy `groups`.
+ *
+ * ## Only the BARE-STRING dialect is an alias — measured, not assumed
+ *
+ * `xAxis` carries TWO authored dialects, and only one of them is a sibling
+ * spelling of `xAxisKey`:
+ *
+ *   - `xAxis: 'month'` — a bare string. `normalizeChartSchema` resolves it
+ *     through `str(xAxisRaw)`, the third limb of
+ *     `str(schema.xAxisKey) ?? xAxisSpec?.field ?? str(xAxisRaw)`
+ *     (`normalizeChartSchema.ts:292`). It means the category COLUMN and nothing
+ *     else, so it folds here.
+ *   - `xAxis: { field, format, title, showGridLines, … }` — the spec's axis
+ *     CONFIG object. Its `field` reaches `xAxisKey` through the same line, but
+ *     its presentation keys survive separately into `out.xAxis`
+ *     (`normalizeChartSchema.ts:289-291`). It is a DIFFERENT key that happens to
+ *     also answer the column question, not a spelling of `xAxisKey` — folding it
+ *     would discard `format` / `title` / `showGridLines`. It is left untouched.
+ *
+ * ## No second writable name, and no invented precedence
+ *
+ * The alias is legal at INPUT and absent from OUTPUT, so exactly one name for
+ * the category column survives a parse. When both are written the canonical key
+ * is kept and the alias dropped — which is not a precedence semantic minted
+ * here, it is the one already running at `normalizeChartSchema.ts:292`, where
+ * `xAxisKey` is the first limb of the `??` chain. Nothing that renders today
+ * changes what it renders.
+ *
+ * ## Why `.overwrite()` and not `.transform()`
+ *
+ * Measured, and the same reason objectstack#13897 gives: `.transform()` returns
+ * a `ZodPipe`, which has no `.shape` and no `.extend()`. Both are load-bearing
+ * here — `zod-mirror-parity.test.ts` reads every mirror's OWN `.shape` (a pipe
+ * answers with nothing, i.e. a silent hole in the ratchet rather than an error),
+ * and `reports.zod.ts` consumes `ChartSchema` as an object. `.overwrite()` is
+ * zod 4's transform that does not change the type, which is exactly what this
+ * fold is.
+ */
+function foldChartXAxisAlias<T extends Record<string, unknown>>(input: T): T {
+  const alias = input.xAxis;
+  // The object dialect is not an alias — see the docblock. Leave it alone.
+  if (typeof alias !== 'string') return input;
+  const { xAxis: _alias, ...rest } = input;
+  return (rest.xAxisKey === undefined ? { ...rest, xAxisKey: alias } : rest) as T;
+}
+
+/**
  * Chart Schema - Chart/graph component
+ *
+ * ⚠️ `data` and `xAxisKey` are the DATA MODEL this node has always rendered and
+ * never declared (objectui#7113). Until this declaration both keys survived only
+ * on `BaseSchema`'s `.passthrough()` / index signature: authored, read by the
+ * renderer, and unchecked — `data: 'oops'` and `xAxisKey: 123` both parsed
+ * clean and drew an empty chart. The `.describe()` prose on `categories` below
+ * and on the `ChartDataSeries.data` tombstone was already teaching authors to
+ * write them.
  */
 export const ChartSchema = BaseSchema.extend({
   type: z.literal('chart'),
@@ -392,13 +479,34 @@ export const ChartSchema = BaseSchema.extend({
       + 'NOT axis labels: the category axis comes from `xAxisKey`/`xAxis`.',
     ),
   series: z.array(ChartDataSeriesSchema).describe('Chart data series'),
+  // THE ROWS. Shape derived from the read sites, not from what looks reasonable:
+  // `ChartRenderer.tsx:164` passes `Array.isArray(schema.data) ? schema.data : []`
+  // through to the implementation, `ChartRenderer.tsx:17,47` declare the prop as
+  // `Array<Record<string, any>>`, and `AdvancedChartImpl.tsx:2229` reads the
+  // COLUMN NAMES back with `Object.keys(props.data[0] ?? {})` while
+  // `AdvancedChartImpl.tsx:1968` indexes a row as `d[xAxisKey]`. So: an array of
+  // row objects keyed by column name. Identical to the sibling `BarChartSchema.data`
+  // below, which objectui#6318 derived from the same renderer the same way.
+  // ⛔ NOT `normalizeChartSchema`: that function has ZERO reads of `schema.data`.
+  data: z
+    .array(z.record(z.string(), z.any()))
+    .optional()
+    .describe(
+      'Rows to plot — one object per row, keyed by column name. `series[].name`/`dataKey` picks the column to plot within each row; `xAxisKey` names the category column.',
+    ),
+  xAxisKey: z
+    .string()
+    .optional()
+    .describe(
+      'Row key holding the category (x) axis. The bare-string sibling spelling `xAxis: \'month\'` folds onto this key at parse and does not survive it.',
+    ),
   height: z.union([z.string(), z.number()]).optional().describe('Chart height'),
   width: z.union([z.string(), z.number()]).optional().describe('Chart width'),
   showLegend: z.boolean().optional().describe('Show legend'),
   showGrid: z.boolean().optional().describe('Show grid lines'),
   animate: z.boolean().optional().describe('Enable animations'),
   config: z.record(z.string(), z.any()).optional().describe('Additional chart configuration'),
-});
+}).overwrite(foldChartXAxisAlias);
 
 /**
  * Timeline Event Schema

--- a/scripts/__tests__/check-published-tsconfig-tooling-exclude.test.ts
+++ b/scripts/__tests__/check-published-tsconfig-tooling-exclude.test.ts
@@ -309,12 +309,19 @@ describe('the shipped carve-outs, against the emitters they claim', () => {
     // whether they were exhaustive was to be verified here. They were not —
     // `create-plugin` is a THIRD tsup package and `runner` is a SECOND Vite
     // application, and both sat inside the ruling's "29 name-only" red set.
+    //
+    // SIX until objectui#7113, which retired `@object-ui/plugin-charts` — the
+    // list SHRANK, which is the only direction it should ever move. That entry
+    // was exempt precisely because its build tsconfig carried no `exclude` key;
+    // when the package gained the directory form, the entry's own `requires`
+    // predicate fired `carve-out-no-longer-holds` and named the remedy. The
+    // package is now ENFORCED (the gate's population reads 34 enforced / 5
+    // carve-outs, up from 33 / 6), so this is protection gained, not waived.
     expect(Object.keys(EMITTER_CARVE_OUTS).sort()).toEqual([
       '@object-ui/cli',
       '@object-ui/console',
       '@object-ui/create-plugin',
       '@object-ui/data-objectstack',
-      '@object-ui/plugin-charts',
       '@object-ui/runner',
     ]);
   });

--- a/scripts/check-published-tsconfig-tooling-exclude.mjs
+++ b/scripts/check-published-tsconfig-tooling-exclude.mjs
@@ -266,19 +266,21 @@ export const EMITTER_CARVE_OUTS = {
     reason: '`tsup` emits from its entry graph only (objectui#4846)',
     requires: (facts) => (facts.usesTsup ? null : `its build script is now \`${facts.build}\`, not tsup`),
   },
-  '@object-ui/plugin-charts': {
-    reason:
-      'named by the ruling: its build tsconfig carries no `exclude` key at all and its tooling ' +
-      'protection lives in the `exclude` passed to `dts()` in `vite.config.ts` (objectui#4846 ' +
-      'measured 31 tooling files in its program, none emitted)',
-    requires: (facts) => {
-      if (!facts.hasDtsPlugin) return 'its vite config no longer loads the `dts()` plugin';
-      if (!facts.dtsHasOwnExclude) return 'its `dts()` options no longer pass their own `exclude`';
-      if (facts.hasExcludeKey)
-        return 'its build tsconfig now HAS an `exclude` key, so the directory form belongs in it';
-      return null;
-    },
-  },
+  // `@object-ui/plugin-charts` was here until objectui#7113, exempt precisely
+  // BECAUSE its build tsconfig carried no `exclude` key — its tooling protection
+  // lived only in the `exclude` passed to `dts()` in `vite.config.ts`. That
+  // carve-out's own `requires` predicate is what retired it: the package now
+  // carries the directory form in its build tsconfig, so `hasExcludeKey` fired
+  // and the entry named its own remedy ("delete the entry and give the package
+  // the directory form"). It has the directory form; the entry is deleted. The
+  // `dts()` exclude is untouched, so the protection is now doubled, not moved.
+  //
+  // Why it grew an `exclude` at all: the package had NO test exclusion, so its
+  // 45 test files were inputs to its emitting build program, and a pin that
+  // needed `node:fs` could not be given `node` types without putting them in the
+  // published program. It now excludes tests by directory and type-checks them
+  // through `tsconfig.test.json`, the arrangement 34 of 38 test-bearing packages
+  // already use.
   '@object-ui/console': {
     reason:
       'a Vite APPLICATION: `noEmit: true` and no `dts()` plugin, so it writes no declarations and ' +


### PR DESCRIPTION
Fixes #7113

Also covers **#6939's `chart` group**. Both rulings independently instruct declaring `xAxisKey` and chart-level `data` on `ChartSchema`, so they land as **one** change rather than two PRs racing on the same keys — the reconciliation recorded on #7113 (comment 5521506615), whose single requirement was that whoever lands it says so here.

**Clause-②: yes** — this changes what a published mirror accepts. Draft, with `needs:contract-review`; not marked ready, no auto-merge.

Rulings implemented:

- **#7113 comment 5494801290** — 项目总监席, 总监批 #28, 2026-09-01, maintainer verbatim 「同意」 — option **B**.
- **#6939 comment 5510084784** — 2026-09-02, maintainer verbatim 「同意」 — the `chart` row.

Re-measured on the merge-base `98d4108a2`: `ChartSchema` at `packages/types/src/zod/data-display.zod.ts:380` declared neither key; the `xAxisKey` at `:552` belongs to `BarChartSchema`. Meanwhile this file's own published `.describe()` prose at `:368` and `:392` was already teaching authors to write both. Published prose taught keys the validator did not model — the restoration of `declared = enforced` that ruling clause 4 names.

---

# Patch round — the three contract-review findings (comment 5531522981)

The reviewed contract surface is **byte-unmoved**: `packages/types/src/zod/data-display.zod.ts` is still `1178da417a3ded8beae7ed05fe616a16aab57336` and `packages/types/src/data-display.ts` still `681dfc58be5f395fb89a81d8852d738d2b22a415`, verified after the base merge. Nothing in this round touches either file.

## F1 — the docs sweep is REMOVED from this PR (scope)

`content/docs/api/schema-reference.md` has been restored to the merge-base byte for byte and no longer appears in this diff.

Ruling #7113 clause 5 says verbatim 「#7112 的五处教材站点按其自身卡修，⛔ 不折」 — #7112's five teaching sites are repaired on their own card and are **not** folded in here. Three of those five live in that file. The earlier revision of this PR edited them and presented it as a routine "published docs sweep" **without disclosing the deviation**, which is the defect; the rewritten content itself was correct. #7112 will land them, and can now cite `data` and `xAxisKey` as declared keys rather than describing an undeclared model.

Following the ruling as written needs no new ruling, so the reviewer's alternative — asking the maintainer to bless the fold — was deliberately not taken.

## F2 — the changeset's named narrowing was incomplete, and the missing class is the sharp one

The changeset named two refusal classes. There is a **third**, and unlike the other two it **draws a real chart today**:

```jsonc
{ "type": "chart", "chartType": "bar", "series": [{ "name": "a", "dataKey": 123 }] }
```

Re-derived independently on both states rather than inherited:

| state | verdict |
|---|---|
| base `98d4108a2` | **ACCEPT**, output `series: [{ name: 'a' }]` — the non-strict object strips the key in silence |
| head | **REFUSE** `[series.0.dataKey] invalid_type: expected string, received number` |

`dataKey: null` behaves identically. And it renders: `normalizeChartSchema` gives `series: [{ dataKey: 'a' }]`, because `str(123)` is `undefined` and the read falls back to `name` (`normalizeChartSchema.ts:239`) — measured through the built normaliser. That is a narrowing away from a document that renders, which is exactly the distinction #6939's grading language turns on. Added to the changeset and to §3 below.

Two prose corrections in the same file:

- **`xAxisKey: 123` did not draw an "EMPTY CHART".** Measured through the normaliser, the result keeps the series and loses only the category binding — a drawn chart with a broken category axis. Only class 1 (`data` malformed) leaves nothing to plot. The changeset now says what the reads support.
- **Undisclosed published-surface change: combinators.** Both consts now carry a check, and on zod 4.4.3 `.pick()`, `.omit()` and `.partial()` **throw** on `ChartSchema` *and* on `ChartDataSeriesSchema` ("cannot be used on object schemas containing refinements") where they previously returned a schema. Measured at base (all OK) and head (all throw). `.extend()` with a new key still works and preserves the fold and the refinement; `.optional()`, `z.discriminatedUnion`, `z.toJSONSchema` and `safeValidateSchema` are unaffected. Nothing in-repo calls the throwing combinators on either const, and the published surface already ships refined mirrors, so the class is not new — but it belongs in the release note. Now in the changeset.

## F3 — the per-group render pin, which was missing

Ruling 5510084784 sets the bar per group: *"the catalog entry validates, **and its render is byte-identical in element count and text before and after**"*. The earlier revision pinned only the validator half. `packages/plugin-charts/src/ChartRenderer.catalogRender-6939.test.tsx` adds the render half, in the idiom the landed siblings use.

Measurements **re-derived on this harness** at the merge-base, not transcribed:

| fixture | base validates | head validates | elements | marks | x ticks | text SHA-256 |
|---|---|---|---|---|---|---|
| `advanced-line-chart` | **no** (`series.N.name`) | **yes** | 136 → 136 | 2 lines | 6 | `dd56a5f8…` → `dd56a5f8…` |
| `area-chart` | **no** (`series.N.name`) | **yes** | 127 → 127 | 1 area | 6 | `c1270f60…` → `c1270f60…` |

The validator's verdict moves; the drawing does not. Element count, a tag census and the text hash all match, because a count alone cannot tell a swapped element from an equal one.

⚠️ **These numbers deliberately differ from the review's** (which read 132 elements / 11 ticks for `area-chart`). Element counts are harness-bound — `ResponsiveContainer` is mocked to a fixed 480x320 here and tick density is a function of that width. Both readings are right about their own harness; the claim that discriminates is identity **within** one harness, which is why they were re-measured here. A pin built from another run's figures is a hand-copied constant.

Note the asymmetry the pin has to survive: at base both fixtures **fail** validation while drawing correctly, so the before/after identity cannot go through a parse-then-render path — there is no parse at base. It is measured through `ChartRenderer` directly, which is also how charts really reach the screen: the renderer consumes the authored schema and never sees the mirror's parse output. The pin carries a **lit control** (perturb the authored rows; the same measurement must move) so the identity assertions cannot pass vacuously.

---

## 1. `data`'s declared shape, and the lines it was derived from

**Declared as:** `data: z.array(z.record(z.string(), z.any())).optional()` — an array of row objects keyed by column name. TS twin: optional, an array of `Record` with string keys and `any` values, byte-identical to the sibling `BarChartSchema.data`.

**Derived from these read sites** (all in `packages/plugin-charts/src`):

| line | read |
|---|---|
| `ChartRenderer.tsx:17`, `:47` | the prop is declared as an array of `Record` string-to-any |
| `ChartRenderer.tsx:164` | `data: Array.isArray(schema.data) ? schema.data : []` |
| `AdvancedChartImpl.tsx:2229` | `Object.keys(props.data[0] ?? {})` — a row's keys **are** the column names |
| `AdvancedChartImpl.tsx:1968` | `d[xAxisKey]` — a row is indexed by column name |
| `ObjectChart.tsx:279`, `:703` | `Array.isArray(schema.data)`, rows used verbatim |

Cross-check: identical to `BarChartSchema.data`, which #6318 derived from the same renderer independently.

### ⚠️ Ruling premise that did not hold

Ruling clause 2 says `data`'s declared shape follows **`normalizeChartSchema`'s** actual read. **That function has zero reads of `schema.data`** — `grep -n 'schema\.data\b' packages/plugin-charts/src/normalizeChartSchema.ts` returns nothing. The ruling's *intent* (derive the shape from the real read) is what was followed; only the function it names is wrong. The reviewer confirmed this independently.

## 2. The `xAxis` fold — pinned in both directions

Per the objectstack#13897 precedent: parse-time fold, no second writable name, no precedence semantics minted here.

- `xAxis: 'month'` authored **alone** parses and lands on `xAxisKey`.
- `xAxis` **does not survive the parse** — the output carries `xAxisKey` and nothing else for the category column.
- Both written: canonical kept, alias dropped. **There is no output in which both survive with a rule for reading them.** That tie-break is not invented here — it is the one already running at `normalizeChartSchema.ts:292`, where `xAxisKey` is the first limb of `str(schema.xAxisKey) ?? xAxisSpec?.field ?? str(xAxisRaw)`.

**⚠️ Only the bare-string dialect is folded.** The **config object** (`field`, `format`, `title`, `showGridLines`) has its `field` reach `xAxisKey` through that same line, but its presentation keys survive separately into `out.xAxis` at `normalizeChartSchema.ts:289-291` — folding it would discard them. Left untouched, and pinned.

**`.overwrite()`, not `.transform()`** — `.transform()` returns a `ZodPipe`: no `.shape`, no `.extend()`. `zod-mirror-parity.test.ts` reads every mirror's own `.shape` and a pipe answers with an empty set — a silent hole in the ratchet — and `reports.zod.ts:105` consumes `ChartSchema` as an object.

## 3. Both binding dialects, with controls

`normalizeSeries` reads `str(raw.dataKey) ?? str(raw.name)` (`normalizeChartSchema.ts:239`), so either alone is a complete binding. The mirror **required** `name`.

| document | base | head |
|---|---|---|
| `series: [{ name: 'revenue' }]` | ACCEPT | ACCEPT |
| `series: [{ dataKey: 'revenue' }]` | **REFUSE** (`series.0.name`) | ACCEPT |
| `series: [{ name: 'a', dataKey: 123 }]` — **renders today** | **ACCEPT** (key stripped) | **REFUSE** (`series.0.dataKey`) |
| `series: [{ color: '#fff' }]` — binds to neither | REFUSE | REFUSE (control) |
| `series: [{ name: 'r', data: [1,2,3] }]` — retired key | REFUSE | REFUSE (control) |

The two controls are legal in **both** states, so neither reddens for the very thing it controls for. Row 3 is F2's third class, now disclosed here and in the changeset.

That refusal is why `advanced-line-chart.json` and `area-chart.json` failed validation — they are written in the `dataKey` dialect, and are the `chart: 2` entry in `objectui check`'s census. Both validate now; `objectui check` reports no `chart` entries.

### ⚠️ Second ruling premise that did not hold

#6939's `chart` row also says "`series[].data` stops being required". **On this base it already is not**, by a stronger mechanism: #6896 (landed in `b0d308da9`) replaced it with `retirementTombstone(...)` = `z.never({ error }).optional()` — optional **and** refusing by name. Implementing the clause literally would re-widen a retired key and reverse a landed ruling, so **it is deliberately not done**, and a pin holds that line.

## 4. Changeset level — `minor`

Three document classes validated before and refuse now (§F2 above lists all three, one of which renders today). Not a pure widening, so not the `patch` branch of #6939's grading. `minor` follows #6896's precedent in this same file for the same transition, and AGENTS.md's rule that objectui's own breaking changes ship `minor` (`major` is forbidden by `check-changeset-no-major`).

## 5. ⚠️ What this does NOT do — the ruling's typo justification is false

Ruling clause 1 claims misspellings like `xAxiskey` / `datas` become loud. **Measured false on both faces, before and after:** the mirror's `BaseSchema` is `.passthrough()` (`base.zod.ts`) and the TS `BaseSchema` carries an index signature. Both typos still ACCEPT; section (f) of the pin file asserts that rather than letting the claim stand. What the declaration buys is the **value** check, plus editor completion and prose that is finally true. The decision (option B) is unaffected; only its stated justification is. The reviewer confirmed this independently.

## Verification

All at head `e7a4b7786`, after merging `origin/main` (⛔ merge, not rebase — no history rewritten).

- `pnpm --filter '@object-ui/types...' build` — green, 120 emitted files verified.
- `pnpm --filter '@object-ui/types' type-check` — green, all three `tsc` projects echoed.
- `vitest run` on `chart-data-model-7113` + `chart-inline-data-retired` + `zod-mirror-parity` + `ChartRenderer.catalogRender-6939` — **4 files, 58 tests, all pass** (was 53; +5 from the new render pin). The parity ratchet passing is the check that the TS twin and the mirror moved together — and it re-passes after the merge, which brought in changes to `base.zod.ts` / `base.ts` / the ratchet itself.
- `vitest run packages/plugin-charts/src` — **45 files, 410 tests, all pass**, run as its own leg so no recursive first-fail could hide a later package.
- Gates, all exit 0 with real populations: `check:control-bytes` (6227 files), `check:doc-types` (188 docs), `check:doc-fences` (227 documents), `check:element-data-source-declaration`, `check:spec-symbols` (1345 files), and — newly relevant because this round adds a `vi.mock` — `check:vi-mock-specifiers` and `check:vi-mock-inherit` (4267 files, 573 carrying a mock).
- `eslint .` — `packages/types` **0 errors** / 269 warnings over 165 files; `packages/plugin-charts` **0 errors** / 334 warnings over 58 files. The new pin file contributes 0 errors and 3 `no-explicit-any` warnings, all in the recharts mock, identical to the sibling chart render tests; the rule is `warn`.

### Reverse verification (earlier revision, still valid — the contract files are unchanged)

Red set predicted before running, then measured by reverting the mirror to its pre-change state; mutation proven on disk by blob hash and anchor counts in both directions, restore proven by state (`git diff HEAD` empty and worktree blob equal to the HEAD blob). Predicted 9 red, measured **10 red / 16 green**; the extra one was a real finding — a pin labelled a control was reddening for the declaration rather than the `ZodObject`-ness it claimed to measure, and was split into a genuine control plus an honest probe.

### Not measured

- `check:doc-snippets` and `check:sdui-registration-pins` return **exit 2 = precondition not met**, which those gates document as "I could not run", not a failure. `doc-snippets` needs a full workspace build; this round removes the only docs edit, so nothing in the diff can reach it. `sdui-registration-pins` weighs `apps/console/dist` bundle assets. Both CI-owned.
- Repo-wide lint and the full gate farm are CI-owned; the narrowing is declared, not silent. eslint is **not** type-aware in this repo (no `projectService` / `project` in the flat config), so this diff cannot move the verdict on a file it does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC


---
_Generated by [Claude Code](https://claude.ai/code)_