### PR TITLE
feat(scripts): make the marked skill-example population shrink-only, per category

### DIFF
--- a/scripts/__tests__/check-skill-examples.test.ts
+++ b/scripts/__tests__/check-skill-examples.test.ts
@@ -11,6 +11,7 @@ import {
   EXIT_CODES,
   JSON_FENCE_LANGUAGES,
   KNOWN_BARE_ANY_EXAMPLES,
+  MARKED_FLOOR,
   MARKER,
   SCAN_ROOTS,
   TS_FENCE_LANGUAGES,
@@ -18,8 +19,11 @@ import {
   buildFilterArgs,
   fenceSpans,
   findBareAny,
+  floorReport,
   listGuides,
+  markedPopulation,
   parseJsonFence,
+  reconcileFloors,
   scanSkillFences,
   stripJsonComments,
 } from '../check-skill-examples.mjs';
@@ -316,10 +320,11 @@ describe('the corpus this gate governs', () => {
   });
 
   it('leaves the majority unmarked — opt-in is the design, not a migration halfway done', () => {
-    // Stated as a RATIO rather than a count on purpose. objectui#7359 explicitly
-    // did NOT decide whether the marked population becomes shrink-only, and a
-    // count pinned here would be that decision taken by accident, red on the
-    // next guide anyone edits.
+    // Stated as a RATIO rather than a count on purpose, and it stays one now
+    // that objectui#7550 has made the population shrink-only: that ratchet is a
+    // FLOOR (`MARKED_FLOOR`, pinned below), which reds only downwards. An
+    // equality pinned here would red on the next fence anyone opts IN, which is
+    // the move this gate exists to encourage.
     const all = scans.flatMap(({ scan }) => scan.fences);
     const marked = all.filter((f) => f.marked);
     expect(marked.length).toBeLessThan(all.length);
@@ -336,6 +341,133 @@ describe('the corpus this gate governs', () => {
         expect(line, `${guide}:${index + 1} carries a near-spelling of the marker`).toBe(MARKER);
       }
     }
+  });
+});
+
+/**
+ * objectui#7550 — the marked population is SHRINK-ONLY, per category.
+ *
+ * objectui#7359 landed this gate with no ratchet and said so in as many words;
+ * the ruling on objectstack #14909 item 2 took the deferred decision, as a
+ * per-category FLOOR in `check-doc-fence-languages.mjs`'s shape. These pins
+ * follow that gate's test file: both directions on fixtures, plus one reading of
+ * the REAL corpus, so the committed numbers cannot drift away from the tree they
+ * claim to describe while every fixture assertion stays green.
+ *
+ * All of it runs on an UNBUILT tree — the floor is a count over the scanner's
+ * output, no compiler involved — so it belongs here rather than in `--self-test`.
+ */
+describe('the shrink-only floor on the marked population', () => {
+  type Breach = { category: string; count: number; floor: number };
+  const corpusMarked = (listGuides(repoRoot) as string[]).flatMap(
+    (guide) =>
+      (scanSkillFences(fs.readFileSync(path.join(repoRoot, guide), 'utf8')) as Scan).fences.filter(
+        (f) => f.marked,
+      ),
+  );
+
+  it('declares one floor per marked-fence category, and no others', () => {
+    // The coupling pin, in the shape `check-doc-fence-languages.test.ts` uses
+    // for its two walks: the categories are derived from the scanner rather
+    // than restated, so a THIRD fence kind cannot be added without this line
+    // going red and forcing a floor decision for it. A new kind that quietly
+    // had no floor would be shrink-only in name over a population nothing
+    // ratchets.
+    const languages = [...TS_FENCE_LANGUAGES, ...JSON_FENCE_LANGUAGES] as string[];
+    const scan: Scan = scanSkillFences(
+      languages.flatMap((language) => [MARKER, `\`\`\`${language}`, '{}', '```']).join('\n'),
+    );
+    expect(scan.fences.every((f) => f.marked)).toBe(true);
+    expect([...MARKED_FLOOR.keys()].sort()).toEqual([...new Set(scan.fences.map((f) => f.kind))].sort());
+  });
+
+  it('counts per category, and a category with no marker left reads as 0 rather than absent', () => {
+    // "Shrank to nothing" and "was never a category here" are the two readings
+    // a bare map of observed counts cannot tell apart, and the first is exactly
+    // what this floor exists to catch.
+    const population = markedPopulation([{ kind: 'ts' }, { kind: 'ts' }]) as Map<string, number>;
+    expect(population.get('ts')).toBe(2);
+    expect(population.has('json')).toBe(true);
+    expect(population.get('json')).toBe(0);
+  });
+
+  it('is green when a category MEETS its floor, and when it is above it', () => {
+    const floors = new Map([
+      ['ts', 2],
+      ['json', 1],
+    ]);
+    expect(reconcileFloors(new Map([['ts', 2], ['json', 1]]), floors)).toEqual([]);
+    // Above the floor is deliberately NOT a failure: opting one more fence in is
+    // the direction this gate travels, and a ratchet that reds on the good move
+    // is one people route around — here, by unmarking.
+    expect(reconcileFloors(new Map([['ts', 9], ['json', 4]]), floors)).toEqual([]);
+  });
+
+  it('reds BELOW the floor, naming the category, the count and the floor', () => {
+    const floors = new Map([
+      ['ts', 2],
+      ['json', 1],
+    ]);
+    expect(reconcileFloors(new Map([['ts', 1], ['json', 1]]), floors)).toEqual([
+      { category: 'ts', count: 1, floor: 2 },
+    ]);
+    expect(reconcileFloors(new Map([['ts', 0], ['json', 0]]), floors)).toEqual([
+      { category: 'ts', count: 0, floor: 2 },
+      { category: 'json', count: 0, floor: 1 },
+    ]);
+  });
+
+  it('reports the population BESIDE its floor, which is what makes the number re-derivable', () => {
+    expect(floorReport(new Map([['ts', 5]]), new Map([['ts', 3]]))).toBe('5 ts fence(s) (floor 3)');
+    // And the real line names every governed category with both numbers on it.
+    const line = floorReport(markedPopulation(corpusMarked)) as string;
+    for (const [category, floor] of MARKED_FLOOR as Map<string, number>) {
+      expect(line).toContain(`${category} fence(s) (floor ${floor})`);
+    }
+  });
+
+  it('the committed floors are MET by the corpus in this checkout', () => {
+    const breaches = reconcileFloors(markedPopulation(corpusMarked)) as Breach[];
+    expect(
+      breaches,
+      'MARKED_FLOOR is shrink-only. If a marker was deliberately removed, lower the number ' +
+        'in scripts/check-skill-examples.mjs and write the reason beside the row:\n' +
+        breaches.map((b) => `  - ${b.category}: ${b.count} marked, floor ${b.floor}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('a floor ONE ABOVE the current count reds and names itself', () => {
+    // The direction that has to fail, driven off the REAL population so it is a
+    // statement about this corpus rather than about a fixture. Without this the
+    // pin above could pass over an empty corpus, a floor of zero, or a
+    // reconciler that never returns anything.
+    const population = markedPopulation(corpusMarked) as Map<string, number>;
+    const raised = new Map(
+      [...(MARKED_FLOOR as Map<string, number>).keys()].map((c) => [c, (population.get(c) ?? 0) + 1]),
+    );
+    expect(reconcileFloors(population, raised)).toEqual(
+      [...raised].map(([category, floor]) => ({ category, count: floor - 1, floor })),
+    );
+  });
+
+  it('is READ by the gate, after the preconditions and never under `--measure`', () => {
+    // Pinned as a source-level fact for the reason the harness-import pin
+    // states for its own: a floor that is computed and never consulted passes
+    // every assertion above. The ORDER is half the contract — an unbuilt tree
+    // and an empty population are exit 2, and this ratchet must not be able to
+    // re-label either of them as exit 1.
+    const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-skill-examples.mjs'), 'utf8');
+    const main = source.slice(source.indexOf('function main()'), source.indexOf('// ── Self-test'));
+    expect(main, 'main() no longer reconciles the marked population against MARKED_FLOOR').toContain(
+      'const breaches = reconcileFloors(population);',
+    );
+    expect(main, 'a floor breach no longer exits `examplesFailed`').toMatch(
+      /if \(breaches\.length > 0\) \{[\s\S]*?return EXIT_CODES\.examplesFailed;[\s\S]*?\n {2}\}/,
+    );
+    expect(main.indexOf('PRECONDITION NOT MET')).toBeLessThan(main.indexOf('const breaches ='));
+    expect(main.indexOf('if (measure) return EXIT_CODES.verified;')).toBeLessThan(
+      main.indexOf('const breaches ='),
+    );
   });
 });
 

--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -9,9 +9,11 @@
  *       node scripts/check-skill-examples.mjs --measure       # judge EVERY candidate, marked or not
  *       node scripts/check-skill-examples.mjs --build-filter  # filter args for turbo/pnpm
  *       node scripts/check-skill-examples.mjs --self-test     # fixtures, both directions
- * Exit: 0 = every MARKED fence holds up, and the marked population is non-empty.
+ * Exit: 0 = every MARKED fence holds up, the marked population is non-empty, and
+ *           no category of it sits below its declared floor.
  *       1 = THE GATE RAN AND FOUND ERRORS. A marked fence failed to parse, failed
- *           to type-check, or a marker is not adjacent to a fence it can opt in.
+ *           to type-check, a marker is not adjacent to a fence it can opt in, or
+ *           the marked population SHRANK below `MARKED_FLOOR` (see below).
  *           Everything printed above the summary is a verdict about a guide.
  *       2 = THE GATE COULD NOT RUN, so nothing printed above is a verdict about
  *           any guide: the packages the marked fences import are not built (or
@@ -175,12 +177,38 @@
  * fences that already held up at the branch point, and it stays in the file so
  * the number is re-derivable rather than a claim in a merged PR body.
  *
- * ⛔ There is deliberately NO ratchet and NO count pin. Whether the marked
- * population becomes shrink-only — the way `check-doc-fence-languages.mjs`
- * treats its declared-file population — is a separate decision, recorded as a
- * follow-up rather than taken here. What IS enforced is a floor: a run in which
- * NOTHING is marked exits 2, because a gate that checks nothing must not report
- * success.
+ * ## The marked population is SHRINK-ONLY (objectui#7550)
+ *
+ * objectui#7359 landed this gate with no ratchet and no count pin, and said so:
+ * whether the marked population becomes shrink-only — the way
+ * `check-doc-fence-languages.mjs` treats its declared-file population — was
+ * left as a separate decision. That decision is taken: it does, PER CATEGORY,
+ * and as a FLOOR rather than an exact pin. `MARKED_FLOOR` below carries one
+ * number per marked-fence category, seeded at the population measured at this
+ * card's branch point, and a run whose count for a category is BELOW its number
+ * exits 1 naming the category, the count, the floor and the two legal moves.
+ *
+ * A floor and not an equality, because the two directions are not symmetric.
+ * Marking one more fence is the direction this whole gate exists to travel, and
+ * an exact pin reds on it — a ratchet that goes red on the good move is one
+ * people learn to route around, and routing around this one means unmarking.
+ * The DOWNWARD move is the one that needs a witness: a marker deleted in the
+ * same edit that broke the example it claimed is a red turning green with
+ * nothing said, which is the "looks like enforcement, isn't" class this header
+ * already records five separate measurements of.
+ *
+ * ⛔ Deliberately NOT a `file:line` register of which fences carry the marker.
+ * That register already exists as `--list`'s output, re-derivable on demand;
+ * committing it would red on every guide edit that moves a fence down a line,
+ * which teaches precisely the reflex a ratchet must not teach — that going red
+ * is normal and the fix is to edit the ratchet.
+ *
+ * An EMPTY population stays a PRECONDITION rather than becoming a floor breach:
+ * a run in which nothing at all is marked exits 2, because a gate that checks
+ * nothing must not report success, and that is a statement about the harness or
+ * about SCAN_ROOTS rather than a verdict about the corpus. The floor is read
+ * only after every precondition has passed, so exit 2 can never be re-labelled
+ * as exit 1 by this ratchet.
  *
  * ## The third assertion: no bare `any` in a marked block (objectui#7463)
  *
@@ -336,11 +364,107 @@ export const MARKER = '<!-- os:check -->';
 export const EXIT_CODES = {
   /** Every marked fence held up, the controls held, something was marked. */
   verified: 0,
-  /** The gate RAN. A marked fence or a marker is at fault — a verdict was read. */
+  /**
+   * The gate RAN. A marked fence, a marker, or the shrink-only floor on the
+   * marked population is at fault — a verdict was read.
+   */
   examplesFailed: 1,
   /** The gate COULD NOT RUN. Nothing it printed is a verdict about a guide. */
   couldNotRun: 2,
 };
+
+// ── The shrink-only floor on the MARKED population (objectui#7550) ──────────
+
+/**
+ * ⛔ SHRINK-ONLY. `category -> the MARKED population that category carried when
+ * this floor landed` — the shape `check-doc-fence-languages.mjs` landed for
+ * `KNOWN_UNHIGHLIGHTED_TS_FENCES`, and a count per category for that map's
+ * reason: a single total silently accepts a category collapsing to nothing
+ * while the other one grows past it, and the two halves of this gate — `tsc`
+ * over `ts` fences, `JSON.parse` over `json` ones — are separate machinery that
+ * can die separately.
+ *
+ * Seeded from a measurement, never from a claim in a merged pull request body.
+ * At this card's branch point (`3e01cb5`) `pnpm check:skill-examples` printed:
+ *
+ *     Marked: 17 ts fence(s) and 39 json fence(s).
+ *
+ * which is exactly the population objectui#7359 reported at the gate's own
+ * landing, so nothing had moved in between. ⚠️ That is the MARKED population,
+ * not the passing one: the same tree under `--measure` prints `ts: 20/121 pass`
+ * — three more `ts` fences hold up today than are opted in, and a floor seeded
+ * off that line would have been red on the day it landed.
+ *
+ * Re-derive it with `pnpm check:skill-examples`, which prints each count beside
+ * its floor on every run.
+ *
+ * ## The two legal moves, and why only one of them has to be declared
+ *
+ *   • MORE marks than the floor is GREEN. Opting a fence in is the direction
+ *     this gate exists to travel; raise the number here in the pull request
+ *     that adds the markers, and this file stops under-stating its own
+ *     coverage. Nothing reds if you forget.
+ *   • FEWER is RED, and the remedy is to lower the number here IN THE SAME PULL
+ *     REQUEST that removes the marker, ⛔ with the reason written beside the
+ *     row — which example stopped being one, and why unmarking it was the
+ *     honest call rather than the cheap way out of a red.
+ *
+ * There is no row-with-a-reason yet, because nothing has been unmarked since
+ * the gate landed. The first one to lower a number writes it here.
+ *
+ * @type {ReadonlyMap<string, number>}
+ */
+export const MARKED_FLOOR = new Map([
+  ['ts', 17],
+  ['json', 39],
+]);
+
+/**
+ * The MARKED population, per category.
+ *
+ * Every category the floor names is present with a count, so one that has lost
+ * its last marker reads as `0` rather than as absent. That difference is the
+ * whole point: "shrank to nothing" and "was never a category here" are the two
+ * readings a bare `Map` of observed counts cannot tell apart, and the first is
+ * the failure this floor exists to catch.
+ */
+export function markedPopulation(marked, floors = MARKED_FLOOR) {
+  const population = new Map([...floors.keys()].map((category) => [category, 0]));
+  for (const block of marked) population.set(block.kind, (population.get(block.kind) ?? 0) + 1);
+  return population;
+}
+
+/** Every category whose marked population sits BELOW its floor. */
+export function reconcileFloors(population, floors = MARKED_FLOOR) {
+  const breaches = [];
+  for (const [category, floor] of floors) {
+    const count = population.get(category) ?? 0;
+    if (count < floor) breaches.push({ category, count, floor });
+  }
+  return breaches;
+}
+
+/** The population printed BESIDE its floor — the phrasing both report modes share. */
+export function floorReport(population, floors = MARKED_FLOOR) {
+  return [...floors]
+    .map(([category, floor]) => `${population.get(category) ?? 0} ${category} fence(s) (floor ${floor})`)
+    .join(', ');
+}
+
+const REMEDY_FLOOR =
+  `\n    Opt-in is the design, so this count moves only because someone edited a` +
+  `\n    marker line. MARKED_FLOOR in scripts/check-skill-examples.mjs is` +
+  `\n    ⛔ SHRINK-ONLY, and there are exactly two legal moves — both of them in` +
+  `\n    the same pull request that moves the markers:` +
+  `\n` +
+  `\n      • you ADDED marks    -> raise that category's number to the new count;` +
+  `\n      • you REMOVED a mark -> lower it to the new count, and write the REASON` +
+  `\n                              beside the row: which example stopped being one,` +
+  `\n                              and why unmarking it was the honest call.` +
+  `\n` +
+  `\n    ⛔ Deleting a marker is not a way to make a red example pass. That is the` +
+  `\n    move this floor exists to make visible; fix the example, or unmark it and` +
+  `\n    say so here where the next reader will see it.`;
 
 // ── The bare-`any` debt list ─────────────────────────────────────────────────
 
@@ -965,6 +1089,10 @@ function main() {
   }
 
   const marked = state.candidates.filter((c) => c.marked);
+  // Read off `marked`, never off `state.tsBlocks` / `state.jsonBlocks`: under
+  // `--measure` those hold EVERY candidate, so a floor read from them would be
+  // measuring one population and gating another.
+  const population = markedPopulation(marked);
 
   // ── the anti-idle floor, checked before anything expensive ────────────────
   // A gate that checks nothing must not report success. Under `--measure` the
@@ -1070,8 +1198,8 @@ function main() {
   );
   console.log(
     measure
-      ? `MEASURE MODE: every candidate judged, marked or not — ${marked.length} of them carry the marker today.`
-      : `Marked: ${state.tsBlocks.length} ts fence(s) and ${state.jsonBlocks.length} json fence(s). Unmarked fences are ignored by design (opt-in).`,
+      ? `MEASURE MODE: every candidate judged, marked or not — ${marked.length} of them carry the marker today: ${floorReport(population)}.`
+      : `Marked: ${floorReport(population)} — the floor is ⛔ SHRINK-ONLY. Unmarked fences are ignored by design (opt-in).`,
   );
   console.log(
     parseFailedBlocks === 0
@@ -1129,6 +1257,28 @@ function main() {
   // failures are the UNMARKED population by construction — a verdict about what
   // is not yet opted in, which is not a defect.
   if (measure) return EXIT_CODES.verified;
+
+  // ── the shrink-only floor on the marked population (objectui#7550) ────────
+  // Read AFTER every precondition has returned, so a tree that could not be
+  // judged exits 2 and is never re-labelled as a floor breach; and after the
+  // summary, so the count and its floor are printed whichever way this goes.
+  // Every per-example error line above has already been printed, so returning
+  // here hides nothing — only the closing sentence differs, and this one is the
+  // accurate sentence for a population that shrank.
+  const breaches = reconcileFloors(population);
+  if (breaches.length > 0) {
+    console.error(
+      `\n❌  check:skill-examples — the MARKED population fell below its floor ` +
+        `in ${breaches.length} categor${breaches.length === 1 ? 'y' : 'ies'}:\n`,
+    );
+    for (const b of breaches) {
+      console.error(
+        `  ${b.category}: ${b.count} marked fence(s), floor ${b.floor} — ${b.floor - b.count} short`,
+      );
+    }
+    console.error(REMEDY_FLOOR);
+    return EXIT_CODES.examplesFailed;
+  }
 
   const failed =
     state.findings.length > 0 ||


### PR DESCRIPTION
Fixes #7550
Part of #7359

Executes the maintainer's ruling on objectstack #14909 item 2 (option A): the marked-fence population that `scripts/check-skill-examples.mjs` type-checks becomes shrink-only, per category, as a **floor** rather than an exact pin and ⛔ not as a `file:line` register (option B, refused).

The gate landed saying so in its own header — "There is deliberately NO ratchet and NO count pin ... a separate decision, recorded as a follow-up rather than taken here". That paragraph is replaced by the decision.

## The seeded floors, and the run that measured them

`MARKED_FLOOR` carries one number per marked-fence category. Seeded from a measurement at the branch point `3e01cb5`, not from a claim in a merged pull request body — `pnpm check:skill-examples` on the unmodified tree printed:

```
Scanned 20 guide(s) under skills, .claude/skills: 121 ts/tsx/typescript fence(s), 56 json/jsonc fence(s).
Marked: 17 ts fence(s) and 39 json fence(s). Unmarked fences are ignored by design (opt-in).
```

so `ts: 17`, `json: 39` — the same numbers objectui#7359 reported at the gate's landing, meaning no marker had moved in between.

⚠️ That is the **marked** population, not the passing one, and the two are not the same number today. The same tree under `--measure` printed:

```
MEASURE MODE: every candidate judged, marked or not — 56 of them carry the marker today.
Starting population — ts: 20/121 pass; json: 39/56 pass.
```

Three more `ts` fences hold up than are opted in, so a floor seeded off the `Starting population` line would have been red on the day it landed. The docblock records the distinction beside the constant.

## What the gate now does

- **Below the floor exits 1**, naming the category, the count, the floor and the two legal moves — raise it in the pull request that adds markers; lower it in the one that removes a marker, with the reason written beside the row.
- **Above the floor stays green.** Opting one more fence in is the direction this gate exists to travel, and a ratchet that reds on the good move is one people learn to route around — here, by unmarking, which is the exact move the floor exists to catch. Only the downward move has to be declared.
- **The report line prints each count beside its floor** on every run, so the number stays re-derivable:
  `Marked: 17 ts fence(s) (floor 17), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY. Unmarked fences are ignored by design (opt-in).`
- **An empty population stays a PRECONDITION (exit 2).** The floor is read only after every precondition has returned and never under `--measure`, so this ratchet cannot re-label "could not run" as "ran and found errors". The ordering is pinned, not just written.

The self-description is in `check-doc-fence-languages.mjs`'s idiom for its `KNOWN_UNHIGHLIGHTED_TS_FENCES` baseline: a per-key count, ⛔ SHRINK-ONLY, with the remedy spelled out as a `REMEDY_FLOOR` block the way that gate spells `REMEDY_SYNONYM`.

## One reading declared, so the seat can redirect cheaply

The card says "two floor constants: `MARKED_FLOOR` for `ts` and for `json`". Landed as **one exported `Map` named `MARKED_FLOOR` carrying exactly those two rows** — two floors, one per category, each with room for its reason beside it. That reading keeps the identifier the card names verbatim, matches the sibling idiom it told me to copy (a `Map` keyed per category, injectable so the self-test can drive it), and lets the check be a loop that names the category. If the seat meant two separate identifiers, it is a rename.

## Pins (`scripts/__tests__/check-skill-examples.test.ts`)

All of it runs on an unbuilt tree — the floor is a count over the scanner's output — so it belongs in the vitest suite rather than in `--self-test`, per that file's stated boundary.

- floor **met** and floor **exceeded** are green;
- **below** the floor reds, and the breach names the category, the count and the floor;
- a floor **one above the current count** reds and names itself, driven off the REAL corpus rather than a fixture;
- the committed floors are met by the corpus in this checkout;
- the report line prints the population beside the floor;
- the **category coupling**: `MARKED_FLOOR`'s keys are derived from what `scanSkillFences` can actually produce, so a third fence kind cannot land without a floor decision for it;
- the **wiring**, as a source-level fact for the reason the harness-import pin above it states for its own: a floor computed and never consulted passes every other assertion in the file. It pins that `main()` reads it, that a breach exits `examplesFailed`, and that it is read **after** the preconditions and **not** under `--measure`.

The existing `leaves the majority unmarked` pin stays a ratio; its comment, which said objectui#7359 had not decided this, is updated rather than the assertion.

## Ablation

Two legs, each mutated on disk with the mutation proved by grepping both the removed and the injected text, each restored with `git checkout HEAD -- ...` and the restore proved **by state** (disk blob `b83b589` equals the HEAD blob, `git diff HEAD` empty), under a `trap ... EXIT INT TERM` with absolute paths. No build leg is involved: the pins are pure functions plus a source read, and the gate runs from source.

**Leg A — the floor check deleted from `main()`** (`reconcileFloors(population)` occurrences on disk: 1 → 0). The wiring pin reds and names itself:

```
× is READ by the gate, after the preconditions and never under `--measure`
AssertionError: main() no longer reconciles the marked population against MARKED_FLOOR
Tests  1 failed | 72 passed (73)
```

**Leg B — the `ts` floor raised one above the measured count** (`['ts', 17]` → `['ts', 18]`; injected 1, replaced 0). The gate itself exits 1 and names everything the ruling asked for:

```
Marked: 17 ts fence(s) (floor 18), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY. ...

❌  check:skill-examples — the MARKED population fell below its floor in 1 category:

  ts: 17 marked fence(s), floor 18 — 1 short
```

followed by the two legal moves. The corpus pin reds in the same leg and names itself (`Tests  1 failed | 72 passed`).

## Gates — verdict lines, run on head `e9508b4` after the final commit, clean tree

| gate | exit | verdict line |
|---|---|---|
| `pnpm check:skill-examples` | 0 | `Every marked skill example holds up against the built types.` |
| `node scripts/check-skill-examples.mjs --self-test` | 0 | `✓ check-skill-examples self-test: 42 cases pass (...)` |
| `pnpm check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| `pnpm check:doc-fences` | 0 | `✅  check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s) ... (⛔ SHRINK-ONLY).` |
| `pnpm check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 6224 tracked text file(s); skipped 85 binary).` |
| `pnpm vitest run scripts/__tests__/check-skill-examples.test.ts` | 0 | `Test Files  1 passed (1) · Tests  73 passed (73)` |
| `pnpm vitest run scripts/__tests__/check-skill-eval-tokens.test.ts scripts/__tests__/scripts-type-check.test.ts` | 0 | `Test Files  2 passed (2) · Tests  51 passed (51)` |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, no diagnostics |
| `pnpm lint` | 0 | `Tasks: 47 successful, 47 total` |

Every exit code was captured before any pipe (`cmd redirected to a file; EXIT=$?; tail`), never read through one.

Both edited files are proved to be **in** the `type-check:scripts` program by `tsc --listFiles` (2 hits), so "typecheck clean" is a statement about them and not a vacuous pass. The two heavier gates needed a build first: `check:skill-examples` builds the closure its own `--build-filter` names, and `check:doc-snippets` exited 2 `PRECONDITION NOT MET` on the wider closure until that was built too — an exit 2 that is "could not run", not a red, and it is 0 above.

## Changeset

None owed, and none added. `node scripts/check-changeset-presence.mjs` on this range: `2 file(s) changed, 0 of them published source of a package the release covers ... ✅ No source or published contract of a released package changed in this range, so no changeset is owed.`

⚠️ The dispatch asked for the `skip-changeset` label. It is **not applied**, and deliberately: in this repository that label is the phantom `scripts/__tests__/ci-cd-pipeline-doc.test.ts` documents at length — auto-minted by an API call, read by no workflow and no script, and one whose application was refused and the refusal upheld on PR #6260. The repo's exemption is an empty-frontmatter changeset, and here not even that is owed. Raised for the seat rather than acted on silently.

## Out of scope, filed

- #7552 — `content/docs/guide/ci-cd-pipeline.md` documents every other assertion of this gate including the `KNOWN_BARE_ANY_EXAMPLES` ratchet, and now says nothing about this second one; its "If it fails" paragraph advises removing a marker, which is now a move that reds until the floor is lowered. Not fixed here: this card's ruling pins the file surface to the two files in this diff.

Session, as prose so it survives a later body edit: `https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox`

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_