### PR TITLE
feat(scripts): bound snippet resolution at the repository root manifest

### DIFF
--- a/content/docs/guide/objectos-integration.mdx
+++ b/content/docs/guide/objectos-integration.mdx
@@ -635,6 +635,13 @@ test('renders contact grid', () => {
 
 ### Integration Tests
 
+End-to-end tests drive the running app, so they need a browser runner the app itself
+does not depend on. Install it in your project first — `npm install -D @playwright/test`
+(then `npx playwright install` once, for the browsers) — and run these specs with
+`npx playwright test`.
+
+{/* doc-snippet: fragment — an end-to-end spec for the READER's own Playwright installation: `@playwright/test` is a test runner the reader installs themselves (the sentence above says so), and no package documented here declares it, so it does not resolve in this gate's program (measured: TS2307 x1). It used to compile only because THIS repository happens to carry `@playwright/test` as a root devDependency, which is what objectui#7463 item 2 bounded */}
+
 ```typescript
 import { test, expect } from '@playwright/test';
 

--- a/scripts/__tests__/check-doc-snippet-types.test.ts
+++ b/scripts/__tests__/check-doc-snippet-types.test.ts
@@ -8,19 +8,26 @@ import { parse as parseYaml } from 'yaml';
 
 // Plain-JS CI helper; its types are inferred from the .mjs source by
 // `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here.
+import ts from 'typescript';
 import {
   EXIT_CODES,
   FRAGMENT_MARKER_EXAMPLES,
+  ROOT_DECLARED_CONTROL_PACKAGE,
   UNDECLARED_CONTROL_PACKAGE,
   UNGATED_DOCS,
   analyze,
   blockingPreconditions,
   buildFilterArgs,
+  compileSnippets,
   deriveDeclaredDependencyPaths,
   derivePackageTypePaths,
   findInstalledCopy,
   listDocuments,
+  moduleSpecifiersOf,
+  resolvesOnlyThroughRootManifest,
+  rootDeclaredSpecifiers,
   scanFences,
+  specifierRoot,
 } from '../check-doc-snippet-types.mjs';
 
 /**
@@ -482,6 +489,202 @@ describe('third-party resolution reaches exactly as far as the imported packages
           return Boolean(manifest.dependencies?.[UNDECLARED_CONTROL_PACKAGE]);
         });
       expect(declaring, 'pick a control specifier no package declares').toEqual([]);
+    });
+  });
+});
+
+describe('the ROOT BOUND — what only this repository declares does not resolve (objectui#7463 item 2)', () => {
+  /**
+   * The bound closes the last way a snippet could be green over a package its
+   * reader was never told to install: pnpm symlinks the repository ROOT's own
+   * devDependencies into `/node_modules`, one directory above where every block
+   * is compiled. Ruled into the SHARED harness, unconditionally for both gates,
+   * on 2026-09-03 (objectstack#14909 item 1, option A).
+   *
+   * Both directions are pinned here, and the negative half is the load-bearing
+   * one: a bound that refused everything would satisfy the positive half alone
+   * while turning every correct snippet red.
+   */
+  const rootDeclared = new Set(['root-dev-dep', '@scope/root-dev-dep', 'react']);
+
+  it('refuses a specifier only the repository ROOT declares', () => {
+    expect(resolvesOnlyThroughRootManifest('root-dev-dep', { paths: {}, rootDeclared })).toBe(true);
+    expect(resolvesOnlyThroughRootManifest('@scope/root-dev-dep', { paths: {}, rootDeclared })).toBe(true);
+  });
+
+  it('refuses a SUBPATH of one too — the root symlink carries the whole package', () => {
+    expect(resolvesOnlyThroughRootManifest('root-dev-dep/sub', { paths: {}, rootDeclared })).toBe(true);
+    expect(specifierRoot('@scope/root-dev-dep/sub')).toBe('@scope/root-dev-dep');
+  });
+
+  it('does NOT refuse a mapped specifier — one a documented package declares reaches the reader', () => {
+    const paths = { 'root-dev-dep': ['/somewhere/index.d.ts'] };
+    expect(resolvesOnlyThroughRootManifest('root-dev-dep', { paths, rootDeclared })).toBe(false);
+    expect(resolvesOnlyThroughRootManifest('root-dev-dep/sub', { paths, rootDeclared })).toBe(false);
+  });
+
+  it('does NOT refuse a specifier the root never declared — that is the UNDECLARED control\'s half', () => {
+    expect(resolvesOnlyThroughRootManifest('some-transitive', { paths: {}, rootDeclared })).toBe(false);
+  });
+
+  it('does NOT refuse a relative or absolute specifier', () => {
+    expect(resolvesOnlyThroughRootManifest('./sibling', { paths: {}, rootDeclared })).toBe(false);
+    expect(resolvesOnlyThroughRootManifest('/abs/path', { paths: {}, rootDeclared })).toBe(false);
+  });
+
+  it('never refuses the JSX factory module, even when `react` is root-declared and unmapped', () => {
+    // Compiler-emitted, not author-written: every block is compiled as TSX, so
+    // refusing it would red a block over a line nobody wrote.
+    expect(resolvesOnlyThroughRootManifest('react/jsx-runtime', { paths: {}, rootDeclared })).toBe(false);
+    expect(resolvesOnlyThroughRootManifest('react/jsx-dev-runtime', { paths: {}, rootDeclared })).toBe(false);
+  });
+
+  it('reads BOTH dependency fields of the root manifest, not just the populated one', () => {
+    const root = tempTree({
+      'package.json': JSON.stringify({ dependencies: { 'a-dep': '1' }, devDependencies: { 'a-dev': '1' } }),
+    });
+    const declared = rootDeclaredSpecifiers(root) as Set<string>;
+    expect([...declared].sort()).toEqual(['a-dep', 'a-dev']);
+  });
+
+  describe('the specifier set comes from the AST, never from a regex over the text', () => {
+    const parse = (code: string) =>
+      ts.createSourceFile('probe.tsx', code, ts.ScriptTarget.ES2020, true, ts.ScriptKind.TSX);
+
+    it('collects static, type-only, side-effect, re-export and dynamic imports', () => {
+      const found = moduleSpecifiersOf(
+        parse(
+          [
+            "import a from 'a';",
+            "import type { B } from 'b';",
+            "import 'c';",
+            "export { d } from 'd';",
+            "const e = await import('e');",
+            'export const used = [a, B, e, d];',
+          ].join('\n'),
+        ),
+      ) as string[];
+      expect(found.sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+
+    it('does NOT collect an import-shaped line inside a template literal', () => {
+      // Measured while deriving the bound: a README example whose fenced body
+      // held `npm install project-name` inside a template literal read as an
+      // import of `project-name` under the regex the gate uses elsewhere. A
+      // false refusal would red a document that is correct.
+      const found = moduleSpecifiersOf(
+        parse("export const readme = `\n# Project\n\nimport x from 'project-name';\n`;\n"),
+      ) as string[];
+      expect(found).toEqual([]);
+    });
+  });
+
+  describe('end to end, over a throwaway tree', () => {
+    /** A root that declares one devDependency and installs it where pnpm would. */
+    function treeWithRootDevDependency(): string {
+      const root = tempTree({
+        'package.json': JSON.stringify({ name: 'root', devDependencies: { 'root-dev-dep': '^1.0.0' } }),
+        'node_modules/root-dev-dep/package.json': JSON.stringify({ name: 'root-dev-dep', types: 'index.d.ts' }),
+        'node_modules/root-dev-dep/index.d.ts': 'export declare const fromRoot: number;\n',
+        'node_modules/mapped-dep/package.json': JSON.stringify({ name: 'mapped-dep', types: 'index.d.ts' }),
+        'node_modules/mapped-dep/index.d.ts': 'export declare const mapped: number;\n',
+      });
+      return root;
+    }
+
+    const block = (doc: string, body: string) => ({ doc, fenceLine: 1, body });
+
+    it('keeps a block importing a root-only specifier OUT of the program and names the specifier', () => {
+      const root = treeWithRootDevDependency();
+      const run = compileSnippets({
+        root,
+        compiled: [block('fixture/root-only.md', "import { fromRoot } from 'root-dev-dep';\nexport const x = fromRoot;\n")],
+        paths: {},
+        declaredSpecifiers: [],
+      }) as unknown as {
+        boundFailures: { block: { doc: string }; specifiers: string[] }[];
+        boundedSpecifiers: string[];
+        semanticallyJudged: number;
+      };
+      expect(run.boundFailures.map((f) => f.block.doc)).toEqual(['fixture/root-only.md']);
+      expect(run.boundFailures[0].specifiers).toEqual(['root-dev-dep']);
+      expect(run.boundedSpecifiers).toEqual(['root-dev-dep']);
+      // Refused, therefore NOT judged: the coverage count is what stops a
+      // refusal from reading as a pass.
+      expect(run.semanticallyJudged).toBe(0);
+    });
+
+    it('still resolves a MAPPED specifier — the bound refuses the root set, not everything', () => {
+      const root = treeWithRootDevDependency();
+      const run = compileSnippets({
+        root,
+        compiled: [block('fixture/mapped.md', "import { mapped } from 'mapped-dep';\nexport const y = mapped;\n")],
+        paths: { 'mapped-dep': [path.join(root, 'node_modules/mapped-dep/index.d.ts')] },
+        declaredSpecifiers: [],
+      }) as unknown as {
+        boundFailures: unknown[];
+        semanticFailures: unknown[];
+        semanticallyJudged: number;
+      };
+      expect(run.boundFailures).toEqual([]);
+      expect(run.semanticFailures).toEqual([]);
+      expect(run.semanticallyJudged).toBe(1);
+    });
+
+    it('refuses a root-only specifier even when the map covers a DIFFERENT one', () => {
+      const root = treeWithRootDevDependency();
+      const run = compileSnippets({
+        root,
+        compiled: [
+          block(
+            'fixture/both.md',
+            "import { mapped } from 'mapped-dep';\nimport { fromRoot } from 'root-dev-dep';\nexport const z = [mapped, fromRoot];\n",
+          ),
+        ],
+        paths: { 'mapped-dep': [path.join(root, 'node_modules/mapped-dep/index.d.ts')] },
+        declaredSpecifiers: [],
+      }) as unknown as { boundFailures: { specifiers: string[] }[] };
+      expect(run.boundFailures[0].specifiers).toEqual(['root-dev-dep']);
+    });
+  });
+
+  describe('in this repository', () => {
+    it("the ROOT-DECLARED control specifier is declared by the root and covered by no paths entry", () => {
+      // Both are preconditions for the control to mean anything, and both are
+      // re-checked at run time by the gate itself; pinned here so a change to
+      // either shows up in a test rather than only in a red gate.
+      const declared = rootDeclaredSpecifiers(repoRoot) as Set<string>;
+      expect(declared.has(ROOT_DECLARED_CONTROL_PACKAGE)).toBe(true);
+      const state = analyze({}) as unknown as { paths: Record<string, string[]> };
+      expect(Object.keys(state.paths)).not.toContain(ROOT_DECLARED_CONTROL_PACKAGE);
+      expect(findInstalledCopy(repoRoot, ROOT_DECLARED_CONTROL_PACKAGE)).toBeTruthy();
+    });
+
+    it('no COVERED snippet imports a specifier that only the root declares', () => {
+      // The gate itself proves this on a built tree; this pin is the build-free
+      // half, so a new page resting on the workspace's own devDependencies is
+      // caught by the per-PR suite too.
+      const declared = rootDeclaredSpecifiers(repoRoot) as Set<string>;
+      const state = analyze({}) as unknown as {
+        compiled: { doc: string; fenceLine: number; body: string }[];
+        paths: Record<string, string[]>;
+      };
+      const offenders: string[] = [];
+      for (const b of state.compiled) {
+        const sf = ts.createSourceFile('probe.tsx', b.body, ts.ScriptTarget.ES2020, true, ts.ScriptKind.TSX);
+        for (const specifier of moduleSpecifiersOf(sf) as string[]) {
+          if (resolvesOnlyThroughRootManifest(specifier, { paths: state.paths, rootDeclared: declared })) {
+            offenders.push(`${b.doc}:${b.fenceLine} ${specifier}`);
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('states the bound in its own header, so the rule cannot drift out of the source', () => {
+      const source = fs.readFileSync(path.join(repoRoot, SCRIPT), 'utf8');
+      expect(source).toContain('resolves ONLY through the repository root');
+      expect(source).toContain('ROOT-');
     });
   });
 });

--- a/scripts/__tests__/check-skill-examples.test.ts
+++ b/scripts/__tests__/check-skill-examples.test.ts
@@ -11,18 +11,22 @@ import {
   EXIT_CODES,
   JSON_FENCE_LANGUAGES,
   KNOWN_BARE_ANY_EXAMPLES,
+  KNOWN_ROOT_DEVDEP_EXAMPLES,
   MARKER,
   SCAN_ROOTS,
   TS_FENCE_LANGUAGES,
   bareAnyRowKey,
   buildFilterArgs,
+  classifyRootDevDep,
   fenceSpans,
   findBareAny,
   listGuides,
   parseJsonFence,
+  rootDevDepRowKey,
   scanSkillFences,
   stripJsonComments,
 } from '../check-skill-examples.mjs';
+import { rootDeclaredSpecifiers } from '../check-doc-snippet-types.mjs';
 
 /**
  * objectui#7359 — the test for `scripts/check-skill-examples.mjs`.
@@ -495,6 +499,102 @@ describe('the harness is imported, not re-rolled', () => {
  * wrong — which is how gates get deleted. That boundary is the whole design, so
  * it is pinned rather than left to the implementation.
  */
+describe('the ROOT BOUND, and its declared debt (objectui#7463 item 2)', () => {
+  /**
+   * The bound itself lives in the shared harness and is pinned in
+   * `check-doc-snippet-types.test.ts`. What is this gate's own is the DEBT LIST:
+   * a refused fence is not type-checked, and the four rows that were already
+   * refused when the bound landed are carried here rather than unmarked in the
+   * guides — those are a GOVERNED surface, and a gate that removes a marker to
+   * make itself green is the exact move the shrink-only lists exist to prevent.
+   */
+  const refusal = (doc: string, fenceLine: number, specifiers: string[]) => ({
+    block: { doc, fenceLine },
+    specifiers,
+  });
+
+  it('builds a debt row key naming the guide, the fence line and the specifier', () => {
+    expect(rootDevDepRowKey({ doc: 'skills/objectui/guides/x.md', fenceLine: 42 }, 'vitest')).toBe(
+      'skills/objectui/guides/x.md:42 vitest',
+    );
+  });
+
+  it('reports an UNDECLARED refusal as red', () => {
+    const { undeclared, stale } = classifyRootDevDep(
+      [refusal('skills/objectui/guides/x.md', 7, ['vitest'])],
+      new Set<string>(),
+    ) as { undeclared: { key: string }[]; stale: string[] };
+    expect(undeclared.map((r) => r.key)).toEqual(['skills/objectui/guides/x.md:7 vitest']);
+    expect(stale).toEqual([]);
+  });
+
+  it('does not report a DECLARED refusal as red', () => {
+    const { rows, undeclared } = classifyRootDevDep(
+      [refusal('skills/objectui/guides/x.md', 7, ['vitest'])],
+      new Set(['skills/objectui/guides/x.md:7 vitest']),
+    ) as { rows: { declared: boolean }[]; undeclared: unknown[] };
+    expect(undeclared).toEqual([]);
+    expect(rows.map((r) => r.declared)).toEqual([true]);
+  });
+
+  it('splits one fence importing two refused specifiers into two rows', () => {
+    const { rows } = classifyRootDevDep(
+      [refusal('skills/objectui/guides/x.md', 7, ['@playwright/test', 'vitest'])],
+      new Set<string>(),
+    ) as { rows: { key: string }[] };
+    expect(rows.map((r) => r.key)).toEqual([
+      'skills/objectui/guides/x.md:7 @playwright/test',
+      'skills/objectui/guides/x.md:7 vitest',
+    ]);
+  });
+
+  it('reports a declared row that is no longer refused as STALE — the list only shrinks', () => {
+    const { stale } = classifyRootDevDep([], new Set(['skills/objectui/guides/x.md:7 vitest'])) as {
+      stale: string[];
+    };
+    expect(stale).toEqual(['skills/objectui/guides/x.md:7 vitest']);
+  });
+
+  it('declares its debt list as a shrink-only Set of verbatim rows', () => {
+    expect(KNOWN_ROOT_DEVDEP_EXAMPLES).toBeInstanceOf(Set);
+    for (const row of KNOWN_ROOT_DEVDEP_EXAMPLES as Set<string>) {
+      expect(row, `debt row is not \`GUIDE:LINE SPECIFIER\`: ${row}`).toMatch(
+        /^[\w./-]+\.md:\d+ (@[\w.-]+\/)?[\w.-]+$/,
+      );
+      expect(SCAN_ROOTS.some((r: string) => row.startsWith(`${r}/`))).toBe(true);
+    }
+  });
+
+  it('names only specifiers this repository ROOT actually declares', () => {
+    // A row for something the root does not declare could never be refused, so
+    // it would sit in the list forever covering nothing.
+    const declared = rootDeclaredSpecifiers(repoRoot) as Set<string>;
+    for (const row of KNOWN_ROOT_DEVDEP_EXAMPLES as Set<string>) {
+      const specifier = row.slice(row.lastIndexOf(' ') + 1);
+      expect(declared.has(specifier), `${specifier} is not declared by the root manifest`).toBe(true);
+    }
+  });
+
+  it('names only fences that exist and carry the marker', () => {
+    // Keyed on the fence LINE, so a guide edit above the fence forces a
+    // re-declaration; this pin is what turns that into a test failure rather
+    // than a row that silently stops covering anything.
+    for (const row of KNOWN_ROOT_DEVDEP_EXAMPLES as Set<string>) {
+      const [site] = row.split(' ');
+      const lastColon = site.lastIndexOf(':');
+      const guide = site.slice(0, lastColon);
+      const line = Number(site.slice(lastColon + 1));
+      const source = fs.readFileSync(path.join(repoRoot, guide), 'utf8');
+      const { fences: all } = scanSkillFences(source) as {
+        fences: { fenceLine: number; marked: boolean }[];
+      };
+      const fences = all.filter((f) => f.fenceLine === line);
+      expect(fences.length, `no fence at ${site}`).toBe(1);
+      expect(fences[0].marked, `the fence at ${site} carries no marker`).toBe(true);
+    }
+  });
+});
+
 describe('the bare-`any` assertion', () => {
   it.each([
     ['a parameter', 'export function f(ctx: any) { return ctx; }', 'parameter `ctx`'],

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -199,6 +199,72 @@
  *               or is not installed at all (a specifier that resolves nowhere
  *               proves nothing about how far resolution reaches).
  *
+ *   ROOT-       a synthetic module importing `vitest` MUST produce TS2307.
+ *   DECLARED    `vitest` is declared by this repository's ROOT `package.json`,
+ *               which pnpm symlinks into `/node_modules`, so it USED to resolve
+ *               here and now must not — it is the control on the bound stated
+ *               in the next section. Its three failure modes are the UNDECLARED
+ *               control's, for the same reasons: the specifier becoming mapped
+ *               (pick another), the specifier no longer being declared by the
+ *               root (it then proves nothing about the root's set), and the
+ *               specifier not being installed (a specifier that resolves
+ *               nowhere anyway proves nothing about how far resolution reaches).
+ *
+ * ## The bound: what the repository ROOT declares does not resolve either
+ *
+ * The rule in the next section maps what the IMPORTED PACKAGES declare. Nothing
+ * in it says anything about the repository's own `package.json` — and under pnpm
+ * the root's own dependency set IS symlinked into `/node_modules`, one directory
+ * above where every block is compiled. So a bare specifier that neither map
+ * covers still resolved, as long as this repository happened to declare it as a
+ * devDependency: measured, `vitest` and `@playwright/test`. A snippet importing
+ * one was green because of what THIS WORKSPACE installs to test itself, which is
+ * not a claim about anything its reader installs. The UNDECLARED control does
+ * not reach this: it bounds TRANSITIVE packages (which pnpm leaves only under
+ * `.pnpm/`, unreachable from here), a different leak.
+ *
+ *     A bare specifier that resolves ONLY through the repository root's own
+ *     manifest is REFUSED, in this harness, for every consumer of it.
+ *
+ * Ruled by the maintainer on 2026-09-03 (objectstack#14909 item 1, option A;
+ * objectui#7463 item 2) after the objectui#7490 flight measured both halves. ⛔
+ * What it is deliberately NOT: a parameter defaulting to off. Two resolution
+ * regimes behind one function would answer "did resolution stay narrow?" with
+ * "depends who is asking", which is the consumer-side tolerance this whole file
+ * is built against. There is one regime, and the control above proves it is on.
+ *
+ * ONE predicate (`resolvesOnlyThroughRootManifest`), enforced at two points
+ * because a bound needs to be both TOTAL and ATTRIBUTABLE:
+ *
+ *   - **In the resolver** (`host.resolveModuleNames`, for files inside the
+ *     virtual probe directory only — the bound is about what a SNIPPET may
+ *     import, never about how a `.d.ts` deep in `node_modules` resolves its own
+ *     imports). This is the regime, and the ROOT-DECLARED control is exactly the
+ *     probe that it is live.
+ *   - **Per block** (from the parsed AST, never a regex — the corpus is prose,
+ *     and a specifier-shaped string in a template literal is not an import). A
+ *     block importing such a specifier is kept OUT of the semantic program and
+ *     reported as its own failure class, the way an unparseable block is: its
+ *     other diagnostics would be noise cascading off an import that resolves
+ *     nowhere, and the summary's coverage count then tells the truth about what
+ *     was judged instead of counting it as checked.
+ *
+ * The manifest, not the disk, decides — the same direction as "declared, never
+ * merely installed" below. A specifier the root declares AND a mapped package
+ * declares is mapped, and stays resolvable: it reaches the reader through the
+ * package they install, so the root's copy is not what backs it.
+ *
+ * ONE exemption, and it is about authorship rather than about resolution: the
+ * JSX factory module (`react/jsx-runtime`). It is the only module the compiler
+ * imports on the author's behalf — see `JSX_RUNTIME_SPECIFIERS` for the measured
+ * reason, which is that refusing it would red blocks over a line nobody wrote,
+ * unevenly between the two corpora.
+ *
+ * ⛔ What this rule exists INSTEAD of, again: adding `@playwright/test` to some
+ * package's `dependencies` so the map covers it. See the 2026-08-24 ruling
+ * quoted at the end of the next section — a manifest is a claim about what a
+ * package needs, and a doc gate's convenience is not that claim.
+ *
  * ## Third-party specifiers resolve exactly as far as the imported packages declare
  *
  * A snippet that imports `@object-ui/layout` may also import `lucide-react`,
@@ -913,6 +979,117 @@ export function findInstalledCopy(root = repoRoot, specifier = '') {
   return null;
 }
 
+/**
+ * The bare-specifier ROOT: `lucide-react/dynamic` -> `lucide-react`, and a
+ * scoped `@playwright/test/foo` -> `@playwright/test`. Package manifests and
+ * `node_modules` are both keyed on this, so every question about "what does the
+ * root declare" and "what does the map cover" is asked about it.
+ */
+export function specifierRoot(specifier) {
+  return specifier.startsWith('@')
+    ? specifier.split('/').slice(0, 2).join('/')
+    : specifier.split('/')[0];
+}
+
+/**
+ * Every specifier the repository ROOT's own manifest declares — `dependencies`
+ * and `devDependencies` together.
+ *
+ * Both, deliberately, though this repository's root declares only the second
+ * today: the bound is "what makes it into the root's `/node_modules`", and pnpm
+ * links both fields there. Reading only the field that happens to be populated
+ * would leave a rule that silently reopens the day someone adds the other one.
+ */
+export function rootDeclaredSpecifiers(root = repoRoot) {
+  const manifestPath = join(root, 'package.json');
+  if (!existsSync(manifestPath)) return new Set();
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  return new Set([
+    ...Object.keys(manifest.dependencies || {}),
+    ...Object.keys(manifest.devDependencies || {}),
+  ]);
+}
+
+/**
+ * The JSX factory modules, which the bound never refuses.
+ *
+ * They are the ONE module the compiler imports on the author's behalf: every
+ * block is compiled with `jsx: ReactJSX`, so a block containing a single JSX tag
+ * needs `react/jsx-runtime` whether or not its author wrote an import at all.
+ * Refusing it would red a block for a line nobody wrote and no reader could fix,
+ * and it would do so unevenly — measured: `react` is mapped in the docs corpus
+ * only because `@object-ui/layout` happens to declare it as a real dependency,
+ * while the skills corpus imports no package that does, so the same JSX tag is
+ * bounded in one gate and not in the other. The bound is a rule about what an
+ * AUTHOR may import; whether the compiler can find its own JSX factory is a
+ * different question, and TS2875 already answers it loudly.
+ *
+ * Exempted at BOTH enforcement points, so the block-level check and the resolver
+ * cannot disagree about one specifier.
+ */
+const JSX_RUNTIME_SPECIFIERS = new Set(['react/jsx-runtime', 'react/jsx-dev-runtime']);
+
+/**
+ * THE BOUND, as one predicate (see the header section that names it): a bare
+ * specifier that nothing in the `paths` map covers and that the repository ROOT
+ * declares reaches a snippet ONLY through this workspace's own installation, so
+ * it is refused.
+ *
+ * Relative and absolute specifiers are never bounded, and neither is one the map
+ * covers — a specifier both the root and a mapped package declare reaches the
+ * reader through the package they install, so the root's copy is not what backs
+ * it and mapping wins.
+ */
+export function resolvesOnlyThroughRootManifest(specifier, { paths = {}, rootDeclared = new Set() } = {}) {
+  if (!specifier || specifier.startsWith('.') || specifier.startsWith('/')) return false;
+  if (JSX_RUNTIME_SPECIFIERS.has(specifier)) return false;
+  if (specifier in paths) return false;
+  const bare = specifierRoot(specifier);
+  if (bare in paths) return false;
+  return rootDeclared.has(bare);
+}
+
+/**
+ * Every module specifier one parsed block imports, from the AST rather than from
+ * a regex over the text.
+ *
+ * Parsing, never a regex, for the reason the corpus keeps proving: an
+ * import-shaped line inside a template literal or a prose sample is not an
+ * import, and a regex over 456 blocks finds those too (measured while this bound
+ * was being derived: a `npm install project-name` line inside a README example's
+ * template literal read as an import of `project-name`). A false refusal would
+ * red a document that is correct, which is the failure this whole file is most
+ * careful about.
+ */
+export function moduleSpecifiersOf(sourceFile) {
+  const out = new Set();
+  const visit = (node) => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      out.add(node.moduleSpecifier.text);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      ts.isStringLiteral(node.moduleReference.expression)
+    ) {
+      out.add(node.moduleReference.expression.text);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      out.add(node.arguments[0].text);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return [...out];
+}
+
 /** Workspace package specifiers a document imports (bare specifier root only). */
 function importedSpecifiers(body) {
   const out = new Set();
@@ -950,6 +1127,18 @@ const CONTROL_REAL_EXPORT = 'BaseSchema';
  * and "we hope the rule is narrow".
  */
 const UNDECLARED_CONTROL_PACKAGE = '@floating-ui/react-dom';
+
+/**
+ * The ROOT-DECLARED control's specifier (see the header). The same three
+ * properties are asserted at run time rather than trusted: this repository's
+ * ROOT `package.json` declares it (so pnpm symlinks it into `/node_modules` and
+ * it is exactly the reach the bound closes), no `paths` entry covers it (a
+ * mapped specifier resolves through the map and would prove nothing about the
+ * root), and it is installed and ships real `.d.ts` files — so if the bound ever
+ * stopped being applied, the control module would compile CLEANLY rather than
+ * fail for some unrelated reason.
+ */
+const ROOT_DECLARED_CONTROL_PACKAGE = 'vitest';
 
 const COMPILER_OPTIONS = {
   target: ts.ScriptTarget.ES2020,
@@ -1087,6 +1276,13 @@ export function analyze({ root = repoRoot, ungated = UNGATED_DOCS } = {}) {
 /** Phase 1 (syntax) and phase 2 (semantics), kept apart on purpose. */
 export function compileSnippets({ root = repoRoot, compiled, paths, declaredSpecifiers = [] }) {
   const parseFailures = [];
+  // THE BOUND (see the header): blocks importing a specifier that reaches them
+  // only through the repository root's own manifest. Kept out of the semantic
+  // program the way an unparseable block is, so the coverage count stays honest.
+  const boundFailures = [];
+  const boundedSpecifiers = new Set();
+  const rootDeclared = rootDeclaredSpecifiers(root);
+  const bounded = (specifier) => resolvesOnlyThroughRootManifest(specifier, { paths, rootDeclared });
   const virtual = new Map();
   const owners = new Map();
   compiled.forEach((block, index) => {
@@ -1100,6 +1296,12 @@ export function compileSnippets({ root = repoRoot, compiled, paths, declaredSpec
     const probe = ts.createSourceFile('probe.tsx', block.body, ts.ScriptTarget.ES2020, true, ts.ScriptKind.TSX);
     if (probe.parseDiagnostics && probe.parseDiagnostics.length > 0) {
       parseFailures.push({ block, diagnostics: probe.parseDiagnostics });
+      return;
+    }
+    const refused = moduleSpecifiersOf(probe).filter(bounded).sort();
+    if (refused.length > 0) {
+      for (const specifier of refused) boundedSpecifiers.add(specifierRoot(specifier));
+      boundFailures.push({ block, specifiers: refused });
       return;
     }
     const name = join(root, VIRTUAL_DIR, `s${String(index).padStart(4, '0')}.tsx`);
@@ -1129,6 +1331,13 @@ export function compileSnippets({ root = repoRoot, compiled, paths, declaredSpec
     undeclaredFile,
     `import * as undeclared from '${UNDECLARED_CONTROL_PACKAGE}';\nexport type Undeclared = typeof undeclared;\n`,
   );
+  // The bound's own control, read the same way as UNDECLARED's: a namespace
+  // import, so ANY successful resolution reports zero diagnostics.
+  const rootDeclaredFile = join(root, VIRTUAL_DIR, '__control_root_declared.ts');
+  virtual.set(
+    rootDeclaredFile,
+    `import * as rootDeclared from '${ROOT_DECLARED_CONTROL_PACKAGE}';\nexport type RootDeclared = typeof rootDeclared;\n`,
+  );
 
   const options = { ...COMPILER_OPTIONS, baseUrl: root, paths, types: [] };
   const host = ts.createCompilerHost(options, true);
@@ -1141,6 +1350,33 @@ export function compileSnippets({ root = repoRoot, compiled, paths, declaredSpec
     virtual.has(f)
       ? ts.createSourceFile(f, virtual.get(f), languageVersion, true, f.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS)
       : getSourceFile(f, languageVersion, onError, shouldCreate);
+
+  // THE BOUND, at the resolver. Scoped to the virtual probe directory: the rule
+  // is about what a SNIPPET may import, and a `.d.ts` inside `node_modules`
+  // resolving its own imports is not a snippet. Without that scoping the bound
+  // would reach into unrelated type graphs and red documents for a reason that
+  // has nothing to do with them.
+  const probeDir = join(root, VIRTUAL_DIR);
+  const resolutionCache = new Map();
+  host.resolveModuleNames = (moduleNames, containingFile, _reused, _redirected, compilerOptions) =>
+    moduleNames.map((name) => {
+      const key = `${containingFile}|${name}`;
+      if (resolutionCache.has(key)) return resolutionCache.get(key);
+      const resolved = ts.resolveModuleName(
+        name,
+        containingFile,
+        compilerOptions ?? options,
+        host,
+      ).resolvedModule;
+      const inProbeDir = dirname(containingFile) === probeDir;
+      // ⚠️ Deliberately NOT added to `boundedSpecifiers`: that set reports what
+      // the bound refused THE CORPUS, and the only file that reaches this arm is
+      // the ROOT-DECLARED control, which has its own line. Counting the control
+      // there would make every run read as though a document had imported it.
+      const answer = resolved && inProbeDir && bounded(name) ? undefined : resolved;
+      resolutionCache.set(key, answer);
+      return answer;
+    });
 
   const program = ts.createProgram([...virtual.keys()], options, host);
 
@@ -1162,9 +1398,12 @@ export function compileSnippets({ root = repoRoot, compiled, paths, declaredSpec
   const sentinelDiagnostics = [...program.getSemanticDiagnostics(program.getSourceFile(sentinelFile))];
   const positiveDiagnostics = [...program.getSemanticDiagnostics(program.getSourceFile(positiveFile))];
   const undeclaredDiagnostics = [...program.getSemanticDiagnostics(program.getSourceFile(undeclaredFile))];
+  const rootDeclaredDiagnostics = [...program.getSemanticDiagnostics(program.getSourceFile(rootDeclaredFile))];
 
   return {
     parseFailures,
+    boundFailures,
+    boundedSpecifiers: [...boundedSpecifiers].sort(),
     semanticFailures,
     semanticallyJudged: owners.size,
     resolvedFileName,
@@ -1174,6 +1413,11 @@ export function compileSnippets({ root = repoRoot, compiled, paths, declaredSpec
     undeclaredDiagnostics,
     undeclaredDeclared: declaredSpecifiers.includes(UNDECLARED_CONTROL_PACKAGE),
     undeclaredInstalledAt: findInstalledCopy(root, UNDECLARED_CONTROL_PACKAGE),
+    rootDeclaredDiagnostics,
+    rootDeclaredControl: ROOT_DECLARED_CONTROL_PACKAGE,
+    rootDeclaredByRoot: rootDeclared.has(ROOT_DECLARED_CONTROL_PACKAGE),
+    rootDeclaredMapped: ROOT_DECLARED_CONTROL_PACKAGE in paths,
+    rootDeclaredInstalledAt: findInstalledCopy(root, ROOT_DECLARED_CONTROL_PACKAGE),
   };
 }
 
@@ -1368,6 +1612,27 @@ function main() {
       `a specifier NO imported package declares now resolves — third-party resolution has widened past the imported packages' own dependencies, so a snippet may import what no reader of these packages can get, and every document would stay green while it does`,
     );
   }
+  const rootDeclaredCodes = run.rootDeclaredDiagnostics.map((d) => d.code);
+  console.log(
+    `  root-declared importing '${run.rootDeclaredControl}' (declared by this repository's ROOT package.json, installed at ${run.rootDeclaredInstalledAt ?? '(NOT INSTALLED)'}, covered by no paths entry) produced ${run.rootDeclaredDiagnostics.length} diagnostic(s)${rootDeclaredCodes.length ? ` (TS${rootDeclaredCodes.join(', TS')})` : ''}`,
+  );
+  if (run.rootDeclaredMapped) {
+    controlFailures.push(
+      `'${run.rootDeclaredControl}' is now covered by the paths map, so it resolves through the map and can no longer show that the ROOT's own manifest is bounded — pick a control specifier the root declares and the map does not cover`,
+    );
+  } else if (!run.rootDeclaredByRoot) {
+    controlFailures.push(
+      `'${run.rootDeclaredControl}' is no longer declared by the repository ROOT's package.json, so its failure to resolve says nothing about the root's set — pick a specifier the root declares`,
+    );
+  } else if (!run.rootDeclaredInstalledAt) {
+    controlFailures.push(
+      `'${run.rootDeclaredControl}' is not installed in this workspace, so its failure to resolve proves nothing about how far resolution reaches — pick an installed specifier the root declares`,
+    );
+  } else if (!rootDeclaredCodes.includes(2307)) {
+    controlFailures.push(
+      `a specifier only the repository ROOT declares still resolves — the bound is not being applied, so a snippet may import what this workspace installs to test itself and no reader of the documented packages is told to install, and every document would stay green while it does`,
+    );
+  }
   console.log('');
 
   const total = state.compiled.length + state.declaredFragments.length;
@@ -1377,6 +1642,15 @@ function main() {
   }
   for (const { block, diagnostics } of run.semanticFailures) {
     for (const d of diagnostics) console.error(`  [semantic]  ${formatDiagnostic(d, block)}`);
+  }
+  for (const { block, specifiers } of run.boundFailures) {
+    console.error(
+      `  [bound]     ${block.doc}:${block.fenceLine}  imports ${specifiers.map((s) => `'${s}'`).join(', ')}, which ` +
+        "resolve only through this repository's ROOT package.json — this workspace's own devDependency " +
+        'set, not anything a reader of the documented packages installs. Import what an imported ' +
+        'package DECLARES, or declare the block a fragment with a reason naming what the reader must ' +
+        `install:\n                ${FRAGMENT_MARKER_EXAMPLES[0]}`,
+    );
   }
 
   // ── the summary always states semantic COVERAGE, never just a verdict ─────
@@ -1397,11 +1671,16 @@ function main() {
       : `Syntax phase:   ${parseFailedBlocks} block(s) failed to parse and were NOT semantically checked.`,
   );
   console.log(
+    run.boundFailures.length === 0
+      ? "Root bound:     no block imports a specifier that resolves only through this repository's ROOT manifest."
+      : `Root bound:     ${run.boundFailures.length} block(s) import a specifier that resolves only through the ROOT manifest (${run.boundedSpecifiers.join(', ')}) and were NOT semantically checked.`,
+  );
+  console.log(
     `Semantic phase: ${run.semanticallyJudged} of ${state.compiled.length} block(s) judged, ${run.semanticFailures.length} failed.`,
   );
-  if (parseFailedBlocks > 0) {
+  if (parseFailedBlocks > 0 || run.boundFailures.length > 0) {
     console.log(
-      `NOTE: this run's semantic result covers ${run.semanticallyJudged} block(s) only. A syntax failure is not a semantic pass.`,
+      `NOTE: this run's semantic result covers ${run.semanticallyJudged} block(s) only. A syntax failure, and a block the root bound refused, are neither of them a semantic pass.`,
     );
   }
 
@@ -1409,6 +1688,7 @@ function main() {
     controlFailures.length > 0 ||
     state.findings.length > 0 ||
     parseFailedBlocks > 0 ||
+    run.boundFailures.length > 0 ||
     run.semanticFailures.length > 0;
 
   if (controlFailures.length > 0) {
@@ -1433,4 +1713,11 @@ if (isEntrypoint(import.meta.url)) {
   process.exit(main());
 }
 
-export { UNGATED_DOCS, TS_FENCE_LANGUAGES, FRAGMENT_MARKER, UNDECLARED_CONTROL_PACKAGE, main };
+export {
+  UNGATED_DOCS,
+  TS_FENCE_LANGUAGES,
+  FRAGMENT_MARKER,
+  UNDECLARED_CONTROL_PACKAGE,
+  ROOT_DECLARED_CONTROL_PACKAGE,
+  main,
+};

--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -126,19 +126,27 @@
  * guide is a consumer who installs `@object-ui/react` from npm. That is the
  * surface, so that is what is compiled against.
  *
- * ⚠️ The honest edge of that resolution, measured rather than assumed, and
- * printed on every run as `Unmapped specifiers`: a bare specifier that neither
- * the workspace map nor the declared-dependency map covers still resolves if the
- * REPOSITORY ROOT declares it, because pnpm symlinks the root's own dependency
- * set into `/node_modules`. `vitest`, `react` and `@testing-library/react` are
- * root devDependencies here, so a marked fence importing them is verified
- * against THIS workspace's copy — not against anything a reader of the guide is
- * told to install. The guides do tell that reader to install vitest, so the
- * examples are not wrong; the GATE simply is not the thing that proves it. The
- * inherited UNDECLARED control does not close this: it bounds resolution against
+ * ⚠️ That edge USED to be wider, and the `Unmapped specifiers` line printed on
+ * every run is what is left of it. A bare specifier that neither the workspace
+ * map nor the declared-dependency map covers still resolved if the REPOSITORY
+ * ROOT declared it, because pnpm symlinks the root's own dependency set into
+ * `/node_modules`: `vitest` and `@playwright/test` are root devDependencies
+ * here, so a marked fence importing them was verified against THIS workspace's
+ * copy — not against anything a reader of the guide is told to install. The
+ * inherited UNDECLARED control never closed that: it bounds resolution against
  * TRANSITIVE packages (which pnpm leaves only under `.pnpm/`), a different leak.
- * Naming the specifiers in the run output is what stops that from being a silent
- * property of a green — tightening it is recorded as a follow-up, not done here.
+ *
+ * objectui#7463 item 2 closed it in the SHARED harness, unconditionally for both
+ * gates (maintainer ruling 2026-09-03, objectstack#14909 item 1, option A):
+ * `compileSnippets` refuses such a specifier and keeps the fence importing it
+ * OUT of the semantic program. The `Unmapped specifiers` line stays, now as the
+ * report of what the bound refuses, and the harness's new ROOT-DECLARED control
+ * is what proves on every run that it is still being applied.
+ *
+ * ⚠️ A refused fence is NOT type-checked. The four pre-existing ones are carried
+ * in the shrink-only `KNOWN_ROOT_DEVDEP_EXAMPLES` below so the bound landed with
+ * zero new red, and the `Root bound` and `Semantic phase` lines both say how
+ * many fences that costs — a declared row is uncovered debt, never a green.
  *
  * The cost of that decision is the PRECONDITION, and it is a declared exit code
  * rather than a silent green: if a package a marked fence imports has no `dist`,
@@ -238,19 +246,13 @@
  *      fences are complete documents rather than prose fragments is the same
  *      boundary `check-doc-snippet-types.mjs` left unruled for the same reason,
  *      and guessing it is what produces a gate people learn to ignore.
- *   2. **Bounding ROOT-devDependency resolution.** The `Unmapped specifiers`
- *      line below names the leak; closing it is objectui#7463 item 2 and is
- *      still open, because the harness that would carry the bound is SHARED and
- *      the fix is not local to this gate. Measured at objectui#7463's head, so
- *      the next reader argues from a number rather than re-deriving it: the
- *      marked population's unmapped set is exactly `@playwright/test` and
- *      `vitest`, both declared by the repository ROOT and both resolving out of
- *      `/node_modules`; and a bound placed in `compileSnippets` would newly red
- *      exactly ONE of `check-doc-snippet-types.mjs`'s own 432 compiled snippets
- *      (`content/docs/guide/objectos-integration.mdx:638`, importing
- *      `@playwright/test`). One new red on a surface this gate does not own is
- *      a decision about the docs corpus, not a refactor, so it is escalated
- *      rather than taken.
+ *   2. **Whether a REFUSED fence's example is correct.** The root bound says
+ *      only that this gate cannot reach the package the fence imports, never
+ *      that the fence is wrong — the four declared rows are good documentation
+ *      about test runners the reader installs. Retiring a row means giving the
+ *      example an import the reader provably has, or the guide's owner deciding
+ *      the fence should not be gated; both are skills judgements over a GOVERNED
+ *      surface, made in a skills PR.
  *   3. **Whether an eval's `must_contain` token is taught by the guides.** A
  *      different oracle over a different corpus, discussed at length on
  *      objectui#7359 and explicitly not this check.
@@ -387,6 +389,81 @@ export const KNOWN_BARE_ANY_EXAMPLES = new Set([
 /** The baseline key for one bare-`any` finding at one site. */
 export function bareAnyRowKey(block, finding) {
   return `${block.doc}:${block.fenceLine} ${finding.where}`;
+}
+
+// ── The root-devDependency debt list (objectui#7463 item 2) ──────────────────
+
+/**
+ * ⛔ SHRINK-ONLY. Rows spelled exactly as `rootDevDepRowKey()` builds them:
+ *
+ *     GUIDE:FENCELINE SPECIFIER
+ *
+ * so a row names ONE fence importing ONE specifier the shared harness's root
+ * bound refuses (see `resolvesOnlyThroughRootManifest` in
+ * `check-doc-snippet-types.mjs`). A fence importing two such specifiers is two
+ * rows, and a per-row fix removes exactly one import.
+ *
+ * ⚠️ Not an allowlist, and it does NOT re-open resolution: a declared row's
+ * fence is still refused by the harness and is NOT type-checked — the run's
+ * `Semantic phase` count says so out loud. What the row buys is that a
+ * PRE-EXISTING one is not a new red on the day the bound landed; what it costs
+ * is the fence's coverage, which is the honest price of an example resting on a
+ * package the gate cannot show the reader has.
+ *
+ * A row whose refusal is GONE fails as STALE, so the list can only shrink — the
+ * same direction, and the same reasoning, as `KNOWN_BARE_ANY_EXAMPLES` above.
+ *
+ * The corpus at the bound's branch point was FOUR rows, all in one guide, all
+ * measured before the bound was armed. Each one is real documentation the gate
+ * cannot verify rather than a defect:
+ *
+ *   - `testing.md:60`, `:94`, `:218` import `vitest`, and `:258` imports
+ *     `@playwright/test`. Both are TEST RUNNERS the reader installs in their own
+ *     project — the guide's first sentence names both — and no package this
+ *     repository publishes declares either, so nothing in the map covers them.
+ *     They compiled until now only because THIS repository carries both as root
+ *     devDependencies, which is the leak the bound closed.
+ *
+ * ⛔ Why they are declared here rather than unmarked in the guide: the guides
+ * under `skills/**` are a GOVERNED surface (see `AGENTS.md`), and removing a
+ * marker to make a gate green is the "gate weakens the guide to suit itself"
+ * move the shrink-only lists exist to prevent. Retiring a row means giving the
+ * example an import the reader provably has, or the guide's owner deciding the
+ * fence should not be gated — either way a skills judgement, made in a skills
+ * PR, not in this one.
+ *
+ * @type {ReadonlySet<string>}
+ */
+export const KNOWN_ROOT_DEVDEP_EXAMPLES = new Set([
+  'skills/objectui/guides/testing.md:60 vitest',
+  'skills/objectui/guides/testing.md:94 vitest',
+  'skills/objectui/guides/testing.md:218 vitest',
+  'skills/objectui/guides/testing.md:258 @playwright/test',
+]);
+
+/** The debt-list key for one refused specifier in one fence. */
+export function rootDevDepRowKey(block, specifier) {
+  return `${block.doc}:${block.fenceLine} ${specifier}`;
+}
+
+/**
+ * Split the harness's root-bound refusals into DECLARED debt and new red, and
+ * name the declared rows that are no longer refused.
+ *
+ * Kept a pure function of the run so the self-test can drive both directions
+ * over fixture blocks rather than over the real guides.
+ */
+export function classifyRootDevDep(boundFailures, declared = KNOWN_ROOT_DEVDEP_EXAMPLES) {
+  const rows = [];
+  for (const { block, specifiers } of boundFailures) {
+    for (const specifier of specifiers) {
+      const key = rootDevDepRowKey(block, specifier);
+      rows.push({ block, specifier, key, declared: declared.has(key) });
+    }
+  }
+  const live = new Set(rows.map((r) => r.key));
+  const stale = [...declared].filter((key) => !live.has(key)).sort();
+  return { rows, stale, undeclared: rows.filter((r) => !r.declared) };
 }
 
 // ── Bare-`any` guard (objectui#7463, ported from objectstack #5943) ──────────
@@ -919,6 +996,28 @@ export function evaluateControls(run) {
     );
   }
 
+  const rootDeclaredCodes = run.rootDeclaredDiagnostics.map((d) => d.code);
+  lines.push(
+    `  root-declared a specifier only the repository ROOT declares (installed at ${run.rootDeclaredInstalledAt ?? '(NOT INSTALLED)'}) produced ${run.rootDeclaredDiagnostics.length} diagnostic(s)${rootDeclaredCodes.length ? ` (TS${rootDeclaredCodes.join(', TS')})` : ''}`,
+  );
+  if (run.rootDeclaredMapped) {
+    failures.push(
+      'the root-declared control specifier is now covered by the paths map, so it resolves through the map and can no longer show that the ROOT\'s own set is bounded — pick another',
+    );
+  } else if (!run.rootDeclaredByRoot) {
+    failures.push(
+      'the root-declared control specifier is no longer declared by the repository ROOT, so its failure to resolve says nothing about the root\'s set — pick another',
+    );
+  } else if (!run.rootDeclaredInstalledAt) {
+    failures.push(
+      'the root-declared control specifier is not installed, so its failure to resolve proves nothing about how far resolution reaches — pick another',
+    );
+  } else if (!rootDeclaredCodes.includes(2307)) {
+    failures.push(
+      'a specifier only the repository ROOT declares now resolves — the root bound is not being applied, so a marked example may rest on what THIS workspace installs to test itself rather than on anything the guide tells its reader to install, and every guide would stay green while it does',
+    );
+  }
+
   return { lines, failures };
 }
 
@@ -926,7 +1025,7 @@ export function evaluateControls(run) {
  * Judge the selected fences. Returns everything the caller needs to print a
  * verdict, with the type-check and JSON halves kept apart.
  */
-export function judge(state) {
+export function judge(state, declaredRootDevDep = KNOWN_ROOT_DEVDEP_EXAMPLES) {
   const run = compileSnippets({
     root: repoRoot,
     compiled: state.tsBlocks,
@@ -934,9 +1033,15 @@ export function judge(state) {
     declaredSpecifiers: state.declaredSpecifiers,
   });
 
+  const rootDevDep = classifyRootDevDep(run.boundFailures, declaredRootDevDep);
+
   const failedTs = new Set();
   for (const { block } of run.parseFailures) failedTs.add(block);
   for (const { block } of run.semanticFailures) failedTs.add(block);
+  // A refused fence is NOT judged either way. It counts as failed only when its
+  // row is undeclared; a declared row is debt, and the coverage line — not this
+  // set — is what stops it reading as verified.
+  for (const { block } of rootDevDep.undeclared) failedTs.add(block);
 
   const jsonFailures = [];
   for (const block of state.jsonBlocks) {
@@ -944,7 +1049,7 @@ export function judge(state) {
     if (message !== null) jsonFailures.push({ block, message });
   }
 
-  return { run, failedTs, jsonFailures };
+  return { run, failedTs, jsonFailures, rootDevDep };
 }
 
 // ── The run ──────────────────────────────────────────────────────────────────
@@ -1000,7 +1105,7 @@ function main() {
     return EXIT_CODES.couldNotRun;
   }
 
-  const { run, failedTs, jsonFailures } = judge(state);
+  const { run, failedTs, jsonFailures, rootDevDep } = judge(state);
 
   const { lines: controlLines, failures: controlFailures } = evaluateControls(run);
   console.log(
@@ -1009,7 +1114,7 @@ function main() {
   console.log(
     state.unmappedSpecifiers.size === 0
       ? 'Unmapped specifiers: none — every bare import of a selected fence is covered by the map above.'
-      : `Unmapped specifiers (resolve, if at all, from the repository ROOT's own node_modules — this workspace's devDependency set, NOT what a reader of the guide installs): ${[...state.unmappedSpecifiers].sort().join(', ')}`,
+      : `Unmapped specifiers (covered by neither map, so the shared harness's ROOT BOUND refuses them — they would otherwise resolve from the repository ROOT's own node_modules, this workspace's devDependency set, NOT what a reader of the guide installs): ${[...state.unmappedSpecifiers].sort().join(', ')}`,
   );
   console.log('Controls:');
   for (const line of controlLines) console.log(line);
@@ -1022,10 +1127,16 @@ function main() {
       const anyNote = anyHits.length
         ? ` + ${anyHits.length} bare \`any\`${anyHits.every((h) => h.baselined) ? ' (all baselined)' : ''}`
         : '';
+      const boundRows = rootDevDep.rows.filter((r) => r.block === block);
+      const boundNote = boundRows.length
+        ? ` + root-bound refused (${boundRows.map((r) => r.specifier).join(', ')})${boundRows.every((r) => r.declared) ? ', declared' : ''}`
+        : '';
       if (!block.selected) verdict = 'unmarked — ignored';
       else if (block.kind === 'json')
         verdict = jsonFailures.some((f) => f.block === block) ? 'FAIL' : 'pass';
-      else if (failedTs.has(block)) verdict = `FAIL${anyNote}`;
+      else if (failedTs.has(block)) verdict = `FAIL${anyNote}${boundNote}`;
+      // A refused fence is never "pass": it was not type-checked at all.
+      else if (boundRows.length) verdict = `NOT CHECKED${anyNote}${boundNote}`;
       else verdict = anyHits.some((h) => !h.baselined) ? `FAIL${anyNote}` : `pass${anyNote}`;
       console.log(
         `  ${block.doc}:${block.fenceLine}  [${block.language}]  ${block.marked ? 'marked' : '      '}  ${verdict}`,
@@ -1059,6 +1170,22 @@ function main() {
       `  ${key}  [stale-baseline]  this row is no longer red — delete its line, KNOWN_BARE_ANY_EXAMPLES only shrinks`,
     );
   }
+  for (const row of rootDevDep.rows) {
+    if (row.declared) continue;
+    console.error(
+      `  [bound]     ${row.block.doc}:${row.block.fenceLine}  imports '${row.specifier}', which resolves ` +
+        "only through this repository's ROOT package.json — this workspace's own devDependency set, not " +
+        'anything this guide tells its reader to install. This fence is therefore NOT type-checked. ' +
+        'Import what a documented package DECLARES, drop the marker if the fence was never meant to ' +
+        'compile on its own, or declare the row VERBATIM in KNOWN_ROOT_DEVDEP_EXAMPLES ' +
+        `(⛔ SHRINK-ONLY):\n                ${row.key}`,
+    );
+  }
+  for (const key of rootDevDep.stale) {
+    console.error(
+      `  ${key}  [stale-baseline]  this row is no longer refused — delete its line, KNOWN_ROOT_DEVDEP_EXAMPLES only shrinks`,
+    );
+  }
 
   // ── the summary always states COVERAGE, never just a verdict ──────────────
   const tsCandidates = state.candidates.filter((c) => c.kind === 'ts');
@@ -1078,6 +1205,14 @@ function main() {
       ? 'Syntax phase:   every selected ts fence parsed, so every one of them reached the semantic phase.'
       : `Syntax phase:   ${parseFailedBlocks} ts fence(s) failed to parse and were NOT semantically checked.`,
   );
+  const declaredRootDevDep = rootDevDep.rows.filter((r) => r.declared);
+  console.log(
+    run.boundFailures.length === 0
+      ? "Root bound:     no selected fence imports a specifier that resolves only through the repository's ROOT manifest."
+      : `Root bound:     ${run.boundFailures.length} fence(s) refused (${run.boundedSpecifiers.join(', ')}) and therefore NOT type-checked; ` +
+          `${declaredRootDevDep.length} row(s) declared in KNOWN_ROOT_DEVDEP_EXAMPLES (⛔ SHRINK-ONLY, ${KNOWN_ROOT_DEVDEP_EXAMPLES.size} row(s)), ` +
+          `${rootDevDep.undeclared.length} NOT declared, ${rootDevDep.stale.length} declared row(s) no longer refused.`,
+  );
   console.log(
     `Semantic phase: ${run.semanticallyJudged} of ${state.tsBlocks.length} ts fence(s) judged, ${run.semanticFailures.length} failed.`,
   );
@@ -1090,14 +1225,19 @@ function main() {
       `${state.bareAny.length - bareAnyNew.length} declared in KNOWN_BARE_ANY_EXAMPLES (⛔ SHRINK-ONLY, ${KNOWN_BARE_ANY_EXAMPLES.size} row(s)), ` +
       `${bareAnyNew.length} NOT declared, ${state.bareAnyStale.length} declared row(s) no longer red.`,
   );
-  if (parseFailedBlocks > 0) {
+  if (parseFailedBlocks > 0 || run.boundFailures.length > 0) {
     console.log(
-      `NOTE: this run's semantic result covers ${run.semanticallyJudged} fence(s) only. A syntax failure is not a semantic pass.`,
+      `NOTE: this run's semantic result covers ${run.semanticallyJudged} fence(s) only. A syntax failure, and a fence the root bound refused, are neither of them a semantic pass — a DECLARED root-bound row is uncovered debt, not a green.`,
     );
   }
 
   if (measure) {
-    const tsPass = tsCandidates.length - [...failedTs].filter((b) => b.kind === 'ts').length;
+    // A fence the root bound refused is NOT a pass, whether or not its row is
+    // declared: nothing type-checked it. Declared rows are absent from
+    // `failedTs` on purpose (they are debt, not red), so they are subtracted
+    // here explicitly rather than being counted as having held up.
+    const notChecked = new Set([...failedTs, ...rootDevDep.rows.map((r) => r.block)]);
+    const tsPass = tsCandidates.length - [...notChecked].filter((b) => b.kind === 'ts').length;
     const jsonPass = jsonCandidates.length - jsonFailures.length;
     console.log(
       `\nStarting population — ts: ${tsPass}/${tsCandidates.length} pass; json: ${jsonPass}/${jsonCandidates.length} pass.`,
@@ -1110,6 +1250,16 @@ function main() {
     for (const hit of state.bareAny) {
       console.log(
         `  ${hit.block.marked ? 'marked  ' : 'unmarked'}  ${hit.block.doc}:${hit.block.fenceLine + hit.finding.line}  ${hit.finding.where}${hit.baselined ? '  [declared]' : ''}`,
+      );
+    }
+    const markedBound = rootDevDep.rows.filter((r) => r.block.marked);
+    console.log(
+      `Root-bound would-be population — ${rootDevDep.rows.length} refusal(s) over every candidate, ` +
+        `of which ${markedBound.length} sit in a MARKED fence (the population this bound actually gates).`,
+    );
+    for (const row of rootDevDep.rows) {
+      console.log(
+        `  ${row.block.marked ? 'marked  ' : 'unmarked'}  ${row.key}${row.declared ? '  [declared]' : ''}`,
       );
     }
   }
@@ -1136,7 +1286,9 @@ function main() {
     run.semanticFailures.length > 0 ||
     jsonFailures.length > 0 ||
     bareAnyNew.length > 0 ||
-    state.bareAnyStale.length > 0;
+    state.bareAnyStale.length > 0 ||
+    rootDevDep.undeclared.length > 0 ||
+    rootDevDep.stale.length > 0;
 
   if (failed) {
     console.error(
@@ -1145,7 +1297,11 @@ function main() {
     );
     return EXIT_CODES.examplesFailed;
   }
-  console.log('\nEvery marked skill example holds up against the built types.');
+  console.log(
+    declaredRootDevDep.length === 0
+      ? '\nEvery marked skill example holds up against the built types.'
+      : `\nEvery marked skill example the root bound could reach holds up against the built types — ${declaredRootDevDep.length} declared row(s) in KNOWN_ROOT_DEVDEP_EXAMPLES were NOT reached, and this line does not speak for them.`,
+  );
   return EXIT_CODES.verified;
 }
 
@@ -1364,6 +1520,78 @@ export function selfTest() {
     return EXIT_CODES.couldNotRun;
   }
 
+  // ── the ROOT BOUND, both directions, through the REAL harness ────────────
+  // The positive leg imports a specifier only the repository ROOT declares
+  // (`vitest`); the negative leg imports one a DOCUMENTED package declares, and
+  // it must still resolve — without that half, a bound that refused everything
+  // would look identical here.
+  const rootOnly = {
+    doc: 'fixture/root-only.md',
+    fenceLine: 3,
+    kind: 'ts',
+    marked: true,
+    body: "import { describe } from 'vitest';\nexport const d = describe;\n",
+  };
+  const declaredDep = {
+    doc: 'fixture/declared-dep.md',
+    fenceLine: 5,
+    kind: 'ts',
+    marked: true,
+    body: "import type { BaseSchema } from '@object-ui/types';\nexport type S = BaseSchema;\n",
+  };
+  const boundRun = compileSnippets({
+    root: repoRoot,
+    compiled: [rootOnly, declaredDep],
+    paths: state.paths,
+    declaredSpecifiers: state.declaredSpecifiers,
+  });
+  const refusedBlocks = new Set(boundRun.boundFailures.map((f) => f.block));
+  t(
+    'a fence importing a ROOT-only specifier is REFUSED and the specifier is named',
+    refusedBlocks.has(rootOnly) &&
+      boundRun.boundFailures.find((f) => f.block === rootOnly).specifiers.join() === 'vitest',
+    JSON.stringify(boundRun.boundFailures.map((f) => [f.block.doc, f.specifiers])),
+  );
+  t(
+    'a fence importing a MAPPED specifier still resolves — the bound refuses the root set, not everything',
+    !refusedBlocks.has(declaredDep) &&
+      !boundRun.semanticFailures.some((f) => f.block === declaredDep),
+    JSON.stringify(boundRun.semanticFailures.map((f) => f.block.doc)),
+  );
+  t(
+    'a refused fence is kept OUT of the semantic program rather than counted as judged',
+    boundRun.semanticallyJudged === 1,
+    `semanticallyJudged=${boundRun.semanticallyJudged}`,
+  );
+  const undeclaredBound = classifyRootDevDep(boundRun.boundFailures, new Set());
+  t('an UNDECLARED refusal is red', undeclaredBound.undeclared.length === 1, JSON.stringify(undeclaredBound.undeclared.map((r) => r.key)));
+  const declaredBound = classifyRootDevDep(boundRun.boundFailures, new Set(['fixture/root-only.md:3 vitest']));
+  t('a DECLARED refusal is not red', declaredBound.undeclared.length === 0 && declaredBound.stale.length === 0);
+  t(
+    'the debt row key names the guide, the fence line and the specifier',
+    rootDevDepRowKey(rootOnly, 'vitest') === 'fixture/root-only.md:3 vitest',
+    rootDevDepRowKey(rootOnly, 'vitest'),
+  );
+  t(
+    'a declared row that is no longer refused is reported as STALE',
+    classifyRootDevDep(boundRun.boundFailures, new Set(['fixture/ghost.md:1 vitest'])).stale.length === 1,
+  );
+  t(
+    "the root-declared CONTROL is red in the same run — the bound is applied, not just described",
+    boundRun.rootDeclaredDiagnostics.some((d) => d.code === 2307),
+    JSON.stringify(boundRun.rootDeclaredDiagnostics.map((d) => d.code)),
+  );
+  t(
+    'the real run has NO undeclared refusal — every row is in KNOWN_ROOT_DEVDEP_EXAMPLES',
+    judge(state).rootDevDep.undeclared.length === 0,
+    JSON.stringify(judge(state).rootDevDep.undeclared.map((r) => r.key)),
+  );
+  t(
+    'and NO declared root-bound row has gone stale — that list only shrinks too',
+    judge(state).rootDevDep.stale.length === 0,
+    JSON.stringify(judge(state).rootDevDep.stale),
+  );
+
   const semanticallyFailed = new Set(run.semanticFailures.map((f) => f.block));
   const parseFailed = new Set(run.parseFailures.map((f) => f.block));
   t('a marked fence that holds up is CLEAN', !semanticallyFailed.has(holds) && !parseFailed.has(holds));
@@ -1382,7 +1610,7 @@ export function selfTest() {
     return EXIT_CODES.examplesFailed;
   }
   console.log(
-    `✓ check-skill-examples self-test: ${cases.length} cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, the bare-\`any\` guard in both directions with its shrink-only baseline, and the compiler legs through the real harness).`,
+    `✓ check-skill-examples self-test: ${cases.length} cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, the bare-\`any\` guard in both directions with its shrink-only baseline, the ROOT BOUND in both directions with its own shrink-only baseline and control, and the compiler legs through the real harness).`,
   );
   return EXIT_CODES.verified;
 }


### PR DESCRIPTION
Part of #7463 — its item 2, the second flight, executing the maintainer ruling of 2026-09-03 (objectstack#14909 item 1, option **A**: the bound lives in the shared harness, unconditionally, for both consumers).

## What resolved before this change, and no longer does

The harness maps two things: every workspace package's own `exports`/`types`, and every specifier the imported packages DECLARE in their `dependencies`. Neither says anything about the repository's own `package.json` — and under pnpm the root's own set is symlinked into `/node_modules`, one directory above where every block is compiled. So a bare specifier neither map covered still resolved, as long as this repository happened to declare it. The inherited UNDECLARED control never reached that: it bounds TRANSITIVE packages, which pnpm leaves only under `.pnpm/`.

`compileSnippets` now refuses such a specifier and keeps the block importing it OUT of the semantic program, the way an unparseable block is kept out — so the coverage count states what was judged rather than counting it as checked.

**One predicate (`resolvesOnlyThroughRootManifest`), two enforcement points**, because a bound has to be both total and attributable:

- **the resolver** (`host.resolveModuleNames`, scoped to the virtual probe directory — the rule is about what a SNIPPET may import, never about how a declaration file inside `node_modules` resolves its own imports). This is the regime, and the new ROOT-DECLARED control is the probe that it is live.
- **per block, from the parsed AST** — never a regex. This is the attribution. Measured while deriving the bound: a regex over the same corpus read `npm install project-name` inside a README example's template literal as an import of `project-name`, and a false refusal reds a document that is correct.

⛔ Not a parameter defaulting to off: two resolution regimes behind one function would answer "did resolution stay narrow?" with "depends who is asking".

**One exemption, about authorship rather than resolution: the JSX factory module.** Every block is compiled as TSX, so the compiler imports `react/jsx-runtime` on the author's behalf. Measured: `react` is mapped in the docs corpus only because `@object-ui/layout` declares it as a real dependency, while the skills corpus imports no package that does — so without the exemption the same JSX tag would be bounded in one gate and not the other, over a line nobody wrote. Exempted at both enforcement points, so they cannot disagree about one specifier.

## The two known specifiers, before and after

Measured on this branch at `58737af`, on a tree built from the gate's own `--build-filter` closure; every reading re-run unchanged at the merged head `3ca73aa` (see the merge section below).

| reading | before | after |
|---|---|---|
| skills gate, `Unmapped specifiers` | `@playwright/test, vitest` | `@playwright/test, vitest` (the line stays, now as the report of what the bound refuses) |
| skills gate, marked ts fences JUDGED | 17 of 17 | 13 of 17 — 4 refused, all declared |
| docs gate, blocks compiled / judged | 456 / 456, 0 failed | 455 / 455, 0 failed |
| docs gate, blocks the bound refuses on the UNFIXED corpus | n/a | exactly **1** |
| skills `--measure`, ts candidates passing | 20 / 121 | 14 / 121 |
| docs gate `--build-filter` | | byte-identical to the pre-change run, so the workflow's build step is unmoved |

The one docs block, re-measured at this branch point and matching the ruling's premise exactly:

```
[bound]  content/docs/guide/objectos-integration.mdx:638  imports '@playwright/test'
```

Nothing else in the 456-block docs corpus and nothing outside `skills/objectui/guides/testing.md` in the skills corpus is touched.

## The one docs snippet: declared, and the guide now names the install

`content/docs/guide/objectos-integration.mdx`, the "Integration Tests" fence, is DECLARED through this gate's own mechanism (an MDX-expression fragment marker carrying a written reason and the measured diagnostic, the idiom the same file already uses ten times over) — and, taking the ruling's stated preference for the form a reader can reproduce, the section now tells the reader what to install before the fence:

> End-to-end tests drive the running app, so they need a browser runner the app itself does not depend on. Install it in your project first — `npm install -D @playwright/test` … and run these specs with `npx playwright test`.

The example is kept intact; nothing was deleted to make a gate green.

## The four marked skill fences, and why they are declared in the SCRIPT

The bound also refuses four MARKED fences in `skills/objectui/guides/testing.md` (`:60`, `:94`, `:218` on `vitest`; `:258` on `@playwright/test`). The ruling names those two specifiers as the marked population it closes but rules only on the docs snippet, so this is the judgement this flight had to make, and it is the one thing here beyond the ruling's letter:

They are carried in a new shrink-only `KNOWN_ROOT_DEVDEP_EXAMPLES`, mirroring `KNOWN_BARE_ANY_EXAMPLES` one flight earlier, because:

- **the card's own constraint is zero new red on day one**, and every prior item on it landed that way;
- **`skills/**` is a GOVERNED surface** and outside this PR's file surface, so unmarking a fence here is both out of bounds and the "gate weakens the guide to suit itself" move the shrink-only lists exist to prevent;
- **the examples are correct** — they are unit and end-to-end tests written against test runners the reader installs, which the guide's first sentence names. What is missing is not correctness but the gate's ability to prove it.

⚠️ A declared row is **uncovered debt, never a green**, and every line of the run says so: the `Root bound` line counts refusals, `Semantic phase` drops to `13 of 17`, a NOTE spells it out, and the success sentence itself now reads "…the root bound could reach … 4 declared row(s) … were NOT reached, and this line does not speak for them." Retiring a row means giving the example an import the reader provably has, or the guide's owner deciding the fence should not be gated — a skills judgement, in a skills PR.

## Self-tests, both directions

`--self-test` grew by 10 legs, to **52 cases pass**; the two vitest suites grew by 15 and 8 cases, to 67 and 73 tests respectively:

- a root-devDependency-only specifier IS refused, and the refusal names it;
- a specifier a documented package DECLARES still resolves, and its block is still judged — the load-bearing negative half, since a bound that refused everything would satisfy the positive half alone;
- a refused block is kept out of the program rather than counted as judged;
- an undeclared refusal is red · a declared one is not · a declared row that is no longer refused is STALE;
- the AST specifier walk finds static, type-only, side-effect, re-export and dynamic imports, and does NOT find an import-shaped line inside a template literal;
- the JSX factory module is never refused, even with `react` root-declared and unmapped;
- the root manifest is read from BOTH dependency fields, not only the populated one;
- every debt row names a specifier the root really declares and a fence that really exists and really carries the marker;
- no COVERED docs snippet imports a root-only specifier — the build-free half of the gate's own verdict;
- the four inherited harness self-controls stay green in every run above.

## Reverse verification

Three legs, each with the fix committed FIRST, mutated under a trap restoring ABSOLUTE paths, the mutation proven on disk by grep counts BEFORE any verdict was read, and the restore proven by `git hash-object` equal to the HEAD blob plus an empty `git diff HEAD`. No `dist/` is involved: both gates run from source, and the packages they resolve against were unchanged.

- **A — the bound is what reds the docs snippet.** Removed the new fragment declaration from the mdx (declaration count 1 → 0; blob `3115b38e` → `a6c30eab`): docs gate EXIT 1 with `[bound] content/docs/guide/objectos-integration.mdx:644 imports '@playwright/test'` and `Semantic phase: 455 of 456`. Restored to `3115b38e`, count back to 1, `git diff HEAD` empty.
- **B — the bound is applied, not merely described.** Replaced the predicate's verdict with a constant false (removed-text 1 → 0, injected-text 0 → 1; blob `99bf34d2` → `d959bc4d`): **both** gates EXIT **2** (`couldNotRun`), the ROOT-DECLARED control reporting `produced 0 diagnostic(s)` and `a specifier only the repository ROOT declares still resolves — the bound is not being applied`. That is the whole point of the control: with the bound off the gates refuse to render a verdict instead of going quietly green. Restored to `99bf34d2`, `git diff HEAD` empty.
- **C — the debt list only shrinks, both directions.** Deleted the `:258` row (row count 1 → 0; blob `8c5c5ec2` → `82e6826d`): EXIT 1, `[bound] … testing.md:258` and `1 NOT declared`. Added a ghost row (`testing.md:9999 vitest`, ghost count 0 → 1; blob → `617553e3`): EXIT 1, `[stale-baseline] this row is no longer refused`. Restored both times to `8c5c5ec2`; `git diff HEAD` and `git status --porcelain` both empty.

## Gates, at head `3ca73aa` (the merge commit)

Exit codes captured by redirect BEFORE any pipe; each verdict quoted from the gate's own printed line.

| gate | exit | its own verdict line |
|---|---|---|
| `pnpm check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| `pnpm check:skill-examples` | 0 | `Every marked skill example the root bound could reach holds up against the built types — 4 declared row(s) in KNOWN_ROOT_DEVDEP_EXAMPLES were NOT reached, and this line does not speak for them.` + `Marked: 17 ts fence(s) (floor 17), 39 json fence(s) (floor 39) — the floor is SHRINK-ONLY.` |
| `check-skill-examples.mjs --self-test` | 0 | `52 cases pass (… the ROOT BOUND in both directions with its own shrink-only baseline and control …)` |
| `check-skill-examples.mjs --measure` | 0 | `Starting population — ts: 14/121 pass; json: 39/56 pass.` + `Root-bound would-be population — 18 refusal(s) over every candidate, of which 4 sit in a MARKED fence.` |
| `pnpm check:doc-fences` | 0 | `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) … (SHRINK-ONLY)` |
| `pnpm check:skills-paths` | 0 | `check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).` |
| `pnpm check:skill-eval-tokens` | 0 | `Every must_contain token is taught by its own skill bundle.` |
| `pnpm check:doc-types` | 0 | `Every documented component type is registered.` |
| `pnpm check:control-bytes` | 0 | `check-control-bytes: OK (scanned 6224 tracked text file(s); skipped 85 binary).` |
| `pnpm check:pre-install-import-graph` | 0 | `OK — 23 pre-install step(s) in 18 job(s) run 21 scripts/ gate(s)` |
| `check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `check-governed-queue-guard.mjs --test` over all 5 changed paths | 0 | `NOT GOVERNED — 5 path(s) checked against 5 governed surface(s); none matched.` |
| `tsc -p tsconfig.scripts.json --noEmit` | 0 | (no diagnostics) |
| `vitest run` over the 11 suites that reference either script | 0 | `Test Files 11 passed (11)` · `Tests 402 passed (402)` (394 before the merge; +8 are objectui#7550's floor pins) |
| `pnpm lint` (repo-wide, no narrowing claimed) | 0 | `Tasks: 47 successful, 47 total` — 0 errors |

**NOT MEASURED, stated rather than implied:** `tsconfig.scripts.json` sets `allowJs` with `checkJs` FALSE on purpose, so errors inside the two `.mjs` BODIES are not reported — `--listFiles` confirms both modules and both edited test files are in the program, which makes the clean `tsc` a statement about the callers, not about the module bodies. CI convergence is likewise not measured here; this report is filed at draft-PR time per the dispatch contract.

## Merge with objectui#7550's floors (`3ca73aa`)

PR #7553 (objectui#7550, the per-category `MARKED_FLOOR` ratchet) landed on the same two files while this PR was in draft, and GitHub read this branch `mergeable_state: dirty`. Merged `origin/main` at `34ea56d` into the branch — a merge commit, no rebase, no force. Both behaviours are kept whole:

- **`scripts/check-skill-examples.mjs` auto-merged.** The summary carries both: `Marked: 17 ts fence(s) (floor 17), 39 json fence(s) (floor 39) — the floor is SHRINK-ONLY.` on the floors' line, and `Root bound: 4 fence(s) refused … 4 row(s) declared … 0 NOT declared, 0 declared row(s) no longer refused.` on this PR's. The exit path reads both — the floor-breach check and the undeclared/stale root-bound rows.
- **One conflict**, in `scripts/__tests__/check-skill-examples.test.ts`: the import list, where the two PRs each added symbols. Resolved by keeping both sides (`KNOWN_ROOT_DEVDEP_EXAMPLES` and `MARKED_FLOOR`, `rootDevDepRowKey` and `reconcileFloors`). No test from either side was dropped: the merged suite runs 73 + 8 cases and the union is green.
- **The two docblocks now name each other** — the interaction neither PR could state alone, and the one a reader needs. `MARKED_FLOOR` counts MARKS, not verifications: a fence the root bound refuses keeps its marker and stays inside the floor while being type-checked by nothing, so the floor's number is not coverage and the `Root bound` / `Semantic phase` lines are what say how many marked fences were reached. And unmarking a fence to silence a root-bound refusal would breach that floor — two ratchets, counting different things, neither substituting for the other.

Re-run at the merged head `3ca73aa`, all green: `pnpm check:skill-examples`, `pnpm check:doc-snippets`, `check-skill-examples.mjs --self-test` (`52 cases pass`), `pnpm check:doc-fences`, `pnpm check:skills-paths`, `pnpm check:skill-eval-tokens`, `pnpm check:control-bytes`, `check-changeset-presence.mjs` (`no changeset is owed`, now compared against `34ea56d`), `check-governed-queue-guard.mjs --test` (`NOT GOVERNED — 5 path(s)`), `tsc -p tsconfig.scripts.json --noEmit`, the 11-suite vitest union (`402 passed`), and repo-wide `pnpm lint` (`Tasks: 47 successful, 47 total`, 0 errors).

Session for this and every earlier revision: `https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox`.

## Posture

Not governed (verdict above), no changeset owed (verdict above, and no `skip-changeset` label is applied — that label is a phantom in this repository). Draft, for the seat to review and land.