### PR TITLE
fix(app-shell,plugin-view): relay a per-view `rowColor` to ListView (objectui#7218)

### DIFF
--- a/.changeset/7218-rowcolor-host-relay.md
+++ b/.changeset/7218-rowcolor-host-relay.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/app-shell': patch
+'@object-ui/plugin-view': patch
+---
+
+Relay a per-view `rowColor` through the two object-view hosts (objectui#7218).
+
+`rowColor` is a declared member of `ListViewSchema` — imported by reference from
+`@objectstack/spec`, shape `{ field, colors? }` — and `ListView` reads it to
+seed its `rowColorConfig` state, which colours whole rows from the named field's
+value. Neither object-view host relayed it: `app-shell`'s
+`ObjectView.renderListView` builds its list schema by spreading the host's and
+then relaying 47 named keys off the active view, and `plugin-view`'s
+`ObjectView` assembles 46 inside its `object-view HOST-COMPOSITION SURFACE`
+fence. `rowColor` had a rung in neither.
+
+So an authored per-view row colour was unreachable on the object route:
+authored, validated, built and served correctly, then dropped at the relay.
+Nothing errored and every authoring gate passed — the only symptom was that the
+rows were not coloured, which an author cannot notice short of diffing the DOM.
+Same "declared and inert" shape objectui#7199 fixed for `description`.
+
+**This is a relay, not a new surface.** The interface route
+(`InterfaceListPage.tsx`) has shipped `rowColor: view.rowColor` next to
+`grouping` and `pagination` since ADR-0047, into a schema typed
+`ListViewSchema`, with no fence of any kind — so the key was already
+author-reachable and already had a delivery path; two of three hosts simply did
+not use it. The legacy shorthand for the same feature (bare `color`) already had
+a rung in both literals; only the spec-canonical spelling was missing.
+
+**No published surface moves.** Both rungs are view-sourced only, and neither
+adds a cast read off the object-view node — that would have added a 28th name to
+the objectui#5097 HOST-COMPOSITION exemption whose count the 2026-08-18 ruling
+fixed at 27, which is a ruling and not a refactor. `grouping` is the in-fence
+precedent for a view-only rung.
+
+⚠️ Not `userActions.rowColor`, a boolean permission toggle sharing this name at
+a different nesting level ("may the user open the colour panel" versus "what the
+colours are"). That key is untouched, and the new pins hold the two apart.

--- a/packages/app-shell/src/views/ObjectView.rowColorRelay-7218.test.tsx
+++ b/packages/app-shell/src/views/ObjectView.rowColorRelay-7218.test.tsx
@@ -1,0 +1,297 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7218 — the object page relays a per-view `rowColor`.
+ *
+ * ## The defect this pins
+ *
+ * `renderListView` builds `fullSchema` by spreading the OBJECT's `listSchema`
+ * and then relaying 47 named keys off the active `viewDef`. `label`,
+ * `description`, `color`, `conditionalFormatting`, `fieldTextColor` and the
+ * rest each have a rung. `rowColor` had NONE, so `schema.rowColor` at the
+ * `ListView` end could only ever be whatever arrived on the host's list schema,
+ * and a per-view row colour was unreachable — authored, validated, built and
+ * served correctly, then dropped here.
+ *
+ * Same shape as objectui#7199's `description`, and this file is that file's
+ * sibling by construction: nothing errors, every authoring gate passes, and the
+ * only symptom is that rows the author asked to be coloured are not.
+ *
+ * ## Why this is a relay and not an intent question
+ *
+ * `packages/app-shell/src/views/InterfaceListPage.tsx` — the interface route,
+ * the third host — already relays `rowColor: view.rowColor` into a schema typed
+ * `ListViewSchema`, alongside `grouping` and `pagination`, with no fence of any
+ * kind. `rowColor` is a declared member of `ListViewSchema` (by-reference from
+ * `@objectstack/spec`) and `ListView` reads it to seed `rowColorConfig`. So the
+ * delivery path exists and is in use; this route simply did not take it.
+ *
+ * ⚠️ NOT `userActions.rowColor`, which is a different key at a different
+ * nesting level that shares a name: a BOOLEAN permission toggle ("may the user
+ * open the colour panel"), folded from the legacy `showColor` flag by
+ * `normalizeListViewSchema` and asserted by that fold's own tests. This card is
+ * the row-colour CONFIGURATION ("what the colours are"). The `userActions`
+ * relay above is untouched by this change, and the last case holds the two
+ * apart so a crossed wire fails instead of passing.
+ *
+ * ## The value DOES arrive here — the relay is where it dies
+ *
+ * `buildViewTabs` composes each entry through `viewEntry`, which is
+ * `Object.assign` over the authored body and stamps only `id` afterwards. No
+ * key whitelist runs between `objectDef.listViews` and `activeView`, so an
+ * authored `rowColor` is present on `viewDef` and this relay is the single
+ * point of loss.
+ *
+ * ## Direction and counts, written before the run (reverse verification)
+ *
+ * Deleting the `rowColor:` rung from `fullSchema` was PREDICTED to turn the
+ * three view-authored cases RED (`captured.rowColor` `undefined`, or the
+ * host-level value where the view's own was expected) and to leave the three
+ * fallback/absence/`userActions` controls GREEN — they resolve through the
+ * `...listSchema` spread and the untouched `userActions` fold, neither of which
+ * the rung touches. Predicted 3 red / 3 passing.
+ *
+ * ⚠️ MEASURED 4 red / 2 passing, and the prediction was the thing that was
+ * wrong. The last case is not a pure control: it asserts the config rung AND
+ * the untouched toggle in ONE render, so it carries a FIX limb and goes red
+ * with the other three. The two limbs are kept together on purpose — holding
+ * the two same-named keys apart is only meaningful when both are read off the
+ * same relayed schema — so the case stays as written.
+ *
+ * ⛔ The predicted line above is left EXACTLY as it was written before the run,
+ * annotated rather than corrected: a prediction edited to agree with its result
+ * is no longer evidence of anything. The gap is a mislabelling in THIS file,
+ * not a finding about the relay — the case was filed under "controls" while
+ * asserting the fix — and the controls that are genuinely pure (the
+ * `...listSchema` fallback and the absence case) did stay green in both states,
+ * which is the property the prediction existed to check.
+ *
+ * ## Why the schema is captured rather than rendered
+ *
+ * The claim is about what THIS file hands down, so `ListView` is stubbed and
+ * its `schema` prop recorded — the same posture as
+ * `ObjectView.viewDescriptionRelay-7199.test.tsx`. Whether the captured value
+ * then colours a row is `plugin-list`/`plugin-grid`'s half (`useRowColor`), and
+ * is not re-pinned here.
+ */
+
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+vi.mock('@object-ui/permissions', () => ({
+  usePermissions: () => ({
+    check: () => ({ allowed: true }),
+    checkField: () => true,
+    getFieldPermissions: () => [],
+    getRowFilter: () => undefined,
+    getObjectApiOperations: () => undefined,
+    roles: [],
+    isLoaded: false,
+    hasCapabilities: () => true,
+    can: () => true,
+    cannot: () => false,
+  }),
+  useFieldPermissions: () => ({ canRead: () => true, canWrite: () => true, permissions: [] }),
+}));
+
+vi.mock('@object-ui/auth', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada' }, activeOrganization: null }),
+  useWorkspaceAdminStatus: () => ({ isAdmin: false, isResolved: true }),
+  createAuthenticatedFetch: () => vi.fn(),
+}));
+
+vi.mock('@object-ui/collaboration', () => ({
+  useRealtimeSubscription: () => ({ lastMessage: null }),
+  useConflictResolution: () => ({ hasConflicts: false, resolveAllConflicts: () => {} }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    success: vi.fn(), error: vi.fn(), info: vi.fn(),
+    warning: vi.fn(), loading: vi.fn(), dismiss: vi.fn(),
+  }),
+}));
+
+/** The list schema this page hands down — captured, not rendered. */
+let captured: any = null;
+vi.mock('@object-ui/plugin-list', () => ({
+  ListView: (props: any) => {
+    captured = props.schema;
+    return null;
+  },
+}));
+
+/**
+ * What the HOST puts on the list schema before this page's relay runs — i.e.
+ * the `listSchema` the `...listSchema` spread carries in.
+ *
+ * The in-tree host (`plugin-view`'s `ObjectView`) relays the ACTIVE VIEW's
+ * `rowColor` into this slot as of this same card, so this stands in for an
+ * object-level / host-supplied row colour. It is the rung's SECOND limb, and
+ * the only way to exercise it from here.
+ */
+let hostListRowColor: unknown;
+
+vi.mock('@object-ui/plugin-view', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ObjectView: (props: any) =>
+    props.renderListView?.({
+      schema: {
+        ...(props.schema ?? {}),
+        ...(hostListRowColor === undefined ? {} : { rowColor: hostListRowColor }),
+      },
+      dataSource: props.dataSource,
+      onEdit: props.onEdit,
+      className: '',
+      refreshKey: 0,
+    }) ?? null,
+  ViewTabBar: () => null,
+  ManageViewsDialog: () => null,
+}));
+
+vi.mock('./MetadataInspector', () => ({
+  MetadataPanel: () => null,
+  useMetadataInspector: () => ({ showDebug: false, toggle: () => {} }),
+}));
+vi.mock('./RecordDetailView', () => ({ RecordDetailView: () => null }));
+
+import { ObjectView } from './ObjectView';
+import { ExpressionProvider } from '../providers/ExpressionProvider';
+
+const OBJECT_NAME = 'duly_task';
+
+/** The per-view row colour — the configuration this card is about. */
+const VIEW_ROW_COLOR = { field: 'stage', colors: { won: '#16a34a', lost: '#dc2626' } };
+/** A host/object-level one. Distinct so a crossed wire fails instead of passing. */
+const LIST_ROW_COLOR = { field: 'priority', colors: { high: '#f97316' } };
+
+function objectsWith(objectExtra: Record<string, unknown>, view: Record<string, unknown>) {
+  return [
+    {
+      name: OBJECT_NAME,
+      label: 'Task',
+      fields: {
+        id: { type: 'text', label: 'Id' },
+        name: { type: 'text', label: 'Name' },
+        stage: { type: 'text', label: 'Stage' },
+      },
+      listViews: {
+        by_stage: { label: 'By stage', type: 'grid', columns: ['name'], ...view },
+      },
+      ...objectExtra,
+    },
+  ];
+}
+
+function makeDataSource() {
+  return {
+    find: vi.fn(async () => ({ data: [], total: 0 })),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async () => ({})),
+    update: vi.fn(async () => ({})),
+    delete: vi.fn(async () => ({})),
+  } as any;
+}
+
+/** Render the object list and return the whole schema the relay handed down. */
+async function relayed(objects: any[]): Promise<any> {
+  captured = null;
+  render(
+    <ExpressionProvider user={{ id: 'u1', name: 'Ada', profile: 'admin' }}>
+      <MemoryRouter initialEntries={[`/apps/demo/${OBJECT_NAME}`]}>
+        <Routes>
+          <Route
+            path="/apps/:appName/:objectName"
+            element={<ObjectView dataSource={makeDataSource()} objects={objects} onEdit={() => {}} />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </ExpressionProvider>,
+  );
+  // `options` is built unconditionally by the same object literal as the rung
+  // under test, so its arrival is the signal that the relay actually ran —
+  // waiting on `rowColor` itself would hang rather than fail on a regression.
+  await waitFor(() => {
+    expect(captured?.options).toBeTruthy();
+  });
+  return captured;
+}
+
+/** Just the row colour the relay handed down. */
+const relayedRowColor = async (objects: any[]): Promise<unknown> => (await relayed(objects)).rowColor;
+
+beforeEach(() => {
+  cleanup();
+  captured = null;
+  hostListRowColor = undefined;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("ObjectView relays the active view's own rowColor (objectui#7218)", () => {
+  it('THE FIX: a per-view `rowColor` reaches the renderer', async () => {
+    // Before the rung existed this was `undefined` for every object, which is
+    // the whole of the reported defect.
+    expect(await relayedRowColor(objectsWith({}, { rowColor: VIEW_ROW_COLOR }))).toEqual(VIEW_ROW_COLOR);
+  });
+
+  it('THE FIX: the config is relayed VERBATIM, palette included', async () => {
+    // `ListView` seeds `rowColorConfig` from this value and reads `.field` and
+    // `.colors` off it. A relay that carried the field alone would satisfy "a
+    // rowColor arrives" while dropping the author's palette.
+    const got: any = await relayedRowColor(objectsWith({}, { rowColor: VIEW_ROW_COLOR }));
+    expect(got).toEqual(VIEW_ROW_COLOR);
+    expect(got.colors).toEqual(VIEW_ROW_COLOR.colors);
+  });
+
+  it('THE FIX: the per-view value OVERRIDES a host-supplied list row colour', async () => {
+    hostListRowColor = LIST_ROW_COLOR;
+    expect(await relayedRowColor(objectsWith({}, { rowColor: VIEW_ROW_COLOR }))).toEqual(VIEW_ROW_COLOR);
+  });
+
+  it('CONTROL: the host-supplied row colour still shows when the view authors none', async () => {
+    // The control that the rung is a FALLBACK, not a replacement. Green in
+    // either world — it resolves through the `...listSchema` spread that the
+    // rung's second limb only restates — so a fix that stomped the incoming
+    // value with `undefined` fails here.
+    hostListRowColor = LIST_ROW_COLOR;
+    expect(await relayedRowColor(objectsWith({}, {}))).toEqual(LIST_ROW_COLOR);
+  });
+
+  it('CONTROL: no row colour anywhere stays absent', async () => {
+    expect(await relayedRowColor(objectsWith({}, {}))).toBeUndefined();
+  });
+
+  it('the BOOLEAN `userActions.rowColor` toggle is never crossed with the config', async () => {
+    // Two different keys at two nesting levels sharing a name. The toggle says
+    // "may the user open the colour panel"; this card's key says "what the
+    // colours are". A relay that folded one into the other would read as fixed
+    // and render nothing — so both are asserted in one render, on a view that
+    // authors the toggle OFF while authoring a colour config.
+    const schema = await relayed(
+      objectsWith({}, { rowColor: VIEW_ROW_COLOR, userActions: { rowColor: false } }),
+    );
+    expect(schema.rowColor).toEqual(VIEW_ROW_COLOR);
+    expect(schema.userActions?.rowColor).toBe(false);
+  });
+});

--- a/packages/app-shell/src/views/ObjectView.tsx
+++ b/packages/app-shell/src/views/ObjectView.tsx
@@ -2265,6 +2265,28 @@ function ObjectViewInner({ dataSource, objects, onEdit, externalRefreshKey }: an
             allowExport: viewDef.allowExport ?? listSchema.allowExport,
             exportOptions: viewDef.allowExport === false ? undefined : (viewDef.exportOptions ?? listSchema.exportOptions),
             color: viewDef.color ?? listSchema.color,
+            /**
+             * The spec-canonical row-colour CONFIGURATION the author put on
+             * THIS view (objectui#7218) — `ListView` seeds `rowColorConfig`
+             * from it and colours whole rows from the named field's value.
+             *
+             * It was the one key of this relay's set with no rung, so
+             * `schema.rowColor` at the `ListView` end could only ever be what
+             * the host put on the list schema, and a per-view colour was
+             * unreachable — authored, validated, built and served, then
+             * silently dropped here. Same two-rung shape as `description`
+             * above, and the same shape the interface route has shipped all
+             * along (`InterfaceListPage.tsx`, `rowColor: view.rowColor`).
+             *
+             * The bare `color` above is the LEGACY shorthand for this same
+             * feature and already had a rung; this adds the canonical one.
+             *
+             * NOT `userActions.rowColor`, relayed above through the toolbar
+             * fold — that is a boolean permission toggle sharing this name at
+             * a different nesting level ('may the user open the colour panel'
+             * versus 'what the colours are').
+             */
+            rowColor: viewDef.rowColor ?? listSchema.rowColor,
             // Propagate view-config properties (Bug 4 / items 14-22)
             wrapHeaders: viewDef.wrapHeaders ?? listSchema.wrapHeaders,
             clickIntoRecordDetails: viewDef.clickIntoRecordDetails ?? listSchema.clickIntoRecordDetails,

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -1785,6 +1785,20 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
           allowExport: activeView?.allowExport ?? (schema as any).allowExport,
           // Propagate display properties
           color: activeView?.color ?? (schema as any).color,
+          // The spec-canonical row-colour CONFIGURATION (objectui#7218).
+          // `ListView` seeds its `rowColorConfig` state from this key; the
+          // bare `color` above is the legacy shorthand for the same feature
+          // and was already relayed, so only the canonical spelling was
+          // missing. Copied from the interface route, which has shipped
+          // `rowColor: view.rowColor` next to `grouping`/`pagination` since
+          // ADR-0047 (`app-shell/src/views/InterfaceListPage.tsx`).
+          //
+          // View-sourced ONLY, deliberately: no fallback to the same key on
+          // the object-view node. Such a cast read would add a 28th name to
+          // the objectui#5097 HOST-COMPOSITION exemption the 2026-08-18
+          // ruling fixed at 27, which is a ruling and not a refactor.
+          // `grouping` above is the precedent for a view-only rung here.
+          rowColor: activeView?.rowColor,
           // Propagate view-config properties (Bug 4 / items 14-22)
           inlineEdit: activeView?.inlineEdit ?? (schema as any).inlineEdit,
           wrapHeaders: activeView?.wrapHeaders ?? (schema as any).wrapHeaders,

--- a/packages/plugin-view/src/__tests__/ObjectView.rowColorRelay-7218.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.rowColorRelay-7218.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7218 — the object-view host relays the active view's `rowColor`.
+ *
+ * ## The defect this pins
+ *
+ * `rowColor` is a declared member of `ListViewSchema` (imported by reference
+ * from `@objectstack/spec`'s `ListViewSchema`, shape `{ field, colors? }`), and
+ * `ListView` READS it: `ListView.tsx` seeds `rowColorConfig` state from
+ * `schema.rowColor` and hands it to the grid, which colours whole rows from a
+ * field value. The delegation branch below relays 46 keys off the active view
+ * and `rowColor` had NO rung, so an authored per-view row colour could not
+ * reach the renderer through this host at all.
+ *
+ * It is the "declared and inert" shape — the same one objectui#7199 fixed for
+ * `description`: nothing errors, every authoring gate passes, the API serves
+ * the value, and the only symptom is that the rows are not coloured. An author
+ * has no way to notice short of diffing the DOM.
+ *
+ * ## Why this is a relay and not an intent question
+ *
+ * A sibling host already ships the key with no fence:
+ * `packages/app-shell/src/views/InterfaceListPage.tsx` relays
+ * `rowColor: view.rowColor` alongside `grouping` and `pagination` into a
+ * schema typed `ListViewSchema`. So `rowColor` is demonstrably author-reachable
+ * on the interface route already; the object-view route simply did not use the
+ * delivery path. The rung added here copies that precedent verbatim.
+ *
+ * The legacy shorthand for the same feature — bare `color`, which
+ * `list-view-spec-parity` records as "legacy row/text coloring shorthand
+ * (spec-canonical: `rowColor`)" — was ALREADY relayed by this literal. Only the
+ * spec-canonical spelling was missing.
+ *
+ * ## ⛔ The rung is view-sourced ONLY, and that is load-bearing
+ *
+ * The relay reads `activeView?.rowColor` and deliberately does NOT fall back to
+ * `(schema as any).rowColor`. A cast read off the object-view NODE would add a
+ * 28th key to the objectui#5097 HOST-COMPOSITION exemption — the maintainer
+ * ruling of 2026-08-18 that fixed that set at 27 — and that is a ruling, not a
+ * refactor. The last case in this file pins the narrowness so the shortcut
+ * cannot be taken later without a test going red and naming the ledger.
+ *
+ * `grouping: activeView?.grouping` is the in-fence precedent for a view-only
+ * rung carrying no cast read, and it is the control used below.
+ *
+ * ## Direction, written before the run (reverse verification)
+ *
+ * Deleting the `rowColor:` rung was PREDICTED to turn the two FIX cases RED
+ * (`captured.rowColor` `undefined`) and to leave the three controls GREEN — the
+ * `grouping` control rides its own untouched rung, and the two absence cases
+ * assert `undefined`, which is what a missing rung produces. Predicted 2 red /
+ * 3 passing. Measured outcome is recorded on the PR.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { ObjectView } from '../ObjectView';
+import type { ObjectViewSchema } from '@object-ui/types';
+
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const React = await import('react');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    SchemaRenderer: ({ schema }: any) => <div data-testid="schema-renderer">{schema?.type}</div>,
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+vi.mock('@object-ui/plugin-grid', () => ({ ObjectGrid: () => <div data-testid="object-grid" /> }));
+vi.mock('@object-ui/plugin-form', () => ({ ObjectForm: () => <div data-testid="object-form" /> }));
+
+const mockDataSource = () => ({
+  find: vi.fn().mockResolvedValue({ data: [], total: 0 }),
+  findOne: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  delete: vi.fn(),
+  getObjectSchema: vi.fn().mockResolvedValue({ name: 'task', fields: {} }),
+});
+
+/**
+ * The row-colour configuration an author writes on a view — the spec's
+ * `RowColorConfigSchema` shape (`field` plus an optional value/colour map).
+ */
+const ROW_COLOR = { field: 'stage', colors: { won: '#16a34a', lost: '#dc2626' } };
+/** A grouping config on the SAME view — the control's payload. */
+const GROUPING = { fields: [{ field: 'owner' }] };
+
+/**
+ * Render through the delegated `renderListView` slot and return the `list-view`
+ * schema the host handed down. `views` is the prop segment `activeView` is
+ * drawn from, which is the segment this relay reads.
+ */
+function delegatedSchema(
+  views: any[] | undefined,
+  nodeExtra: Record<string, unknown> = {},
+): any {
+  const seen: any[] = [];
+  render(
+    <ObjectView
+      schema={{ type: 'object-view', objectName: 'task', ...nodeExtra } as unknown as ObjectViewSchema}
+      views={views}
+      activeViewId={views?.[0]?.id}
+      dataSource={mockDataSource() as any}
+      renderListView={({ schema: s }: any) => {
+        seen.push(s);
+        return <div data-testid="delegated" />;
+      }}
+    />,
+  );
+  expect(seen.length).toBeGreaterThan(0);
+  return seen[0];
+}
+
+/** One view entry, carrying whatever the case authors on it. */
+const viewWith = (extra: Record<string, unknown>) => [
+  { id: 'v1', label: 'By stage', type: 'grid' as const, columns: ['name'], ...extra },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ObjectView relays the active view rowColor (objectui#7218)', () => {
+  it('THE FIX: a per-view `rowColor` reaches the host list renderer', () => {
+    // Before the rung existed this was `undefined` for every view, which is the
+    // whole of the reported defect.
+    expect(delegatedSchema(viewWith({ rowColor: ROW_COLOR })).rowColor).toEqual(ROW_COLOR);
+  });
+
+  it('THE FIX: the config is relayed VERBATIM, not rebuilt or flattened', () => {
+    // `ListView` seeds its `rowColorConfig` state from this value and reads
+    // `.field` and `.colors` off it. A relay that reached for `.field` alone
+    // would satisfy "a rowColor arrives" while dropping the author's palette.
+    const relayed = delegatedSchema(viewWith({ rowColor: ROW_COLOR })).rowColor;
+    expect(relayed).toEqual(ROW_COLOR);
+    expect(relayed.colors).toEqual(ROW_COLOR.colors);
+  });
+
+  it('CONTROL: the neighbouring `grouping` rung still relays — green in both states', () => {
+    // Legal before AND after the change: `grouping: activeView?.grouping` is an
+    // existing view-only rung this diff does not touch. It proves the harness
+    // actually exercises the relay, so a red FIX case above means "no rung",
+    // not "the delegation branch never ran".
+    const s = delegatedSchema(viewWith({ rowColor: ROW_COLOR, grouping: GROUPING }));
+    expect(s.grouping).toEqual(GROUPING);
+  });
+
+  it('CONTROL: a view that authors no `rowColor` gets none — the relay invents nothing', () => {
+    expect(delegatedSchema(viewWith({})).rowColor).toBeUndefined();
+  });
+
+  it('⛔ `rowColor` on the object-view NODE stays unreachable (the objectui#5097 ledger)', () => {
+    // The rung is view-sourced only. Reading `(schema as any).rowColor` here
+    // would promote a 28th key onto the HOST-COMPOSITION exemption whose count
+    // the 2026-08-18 maintainer ruling fixed at 27, and
+    // `objectViewHostSurface.test.tsx` would fail BY NAME. This case is the
+    // early, readable half of that: it fails here first, and says why.
+    expect(delegatedSchema(undefined, { rowColor: ROW_COLOR }).rowColor).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #7218

**Scope of record: `rowColor` only.** The card's TITLE names two keys and is out
of date; the authority is triage comment
[5528535616](https://github.com/objectstack-ai/objectui/issues/7218#issuecomment-5528535616)
(R+122, 2026-09-03), which split the card and says so in terms: *"Scope now:
`rowColor` only. `fieldOrder` moved to #7516 … This comment is the scope of
record."* `fieldOrder` is untouched here — it is #7516's, it is
`needs-user-decision`, and it got the opposite answer (no producer on any host,
and `columns` already expresses order), so it needs a ruling rather than a
relay. Nothing in this branch touches it.

Clause-②: no

## What was wrong

`rowColor` is a declared member of `ListViewSchema` — imported by reference from
`@objectstack/spec` (`RowColorConfigSchema`, shape `field` plus an optional
`colors` map) — and `ListView` READS it: it seeds `rowColorConfig` state from
`schema.rowColor` and hands it to the grid, which colours whole rows from the
named field's value.

Neither object-view host relayed it:

| host | literal | relayed keys before | `rowColor` rung |
|:--|:--|--:|:--|
| `app-shell` `ObjectView.renderListView` | `fullSchema` | 47 named + the host spread | none |
| `plugin-view` `ObjectView` | the `object-view HOST-COMPOSITION SURFACE` fence | 46 | none |
| `app-shell` `InterfaceListPage` | the interface route | — | **already shipped** |

So an authored per-view row colour was unreachable on the object route:
authored, validated, built and served correctly, then dropped at the relay.
Nothing errored, every authoring gate passed, and the only symptom was that the
rows were not coloured — an author cannot notice short of diffing the DOM. Same
"declared and inert" shape as #7199's `description`, whose PR is the shape this
one follows.

## Why this is mechanical, and not an intent question

The card concluded `rowColor` was *"authorable metadata with a live reader and
no delivery path"*. That conclusion does not hold: the triage measured a THIRD
host, and it already relays the key. `packages/app-shell/src/views/InterfaceListPage.tsx`
relays `rowColor: view.rowColor` next to `grouping` and `pagination` into a
schema typed `ListViewSchema`, and has since ADR-0047. There IS a delivery
path — two of three hosts simply did not use it.

Re-measured on the tree this branch cuts from (`origin/main` `045d20ba8`, the
triage read `0e3b3be`), and the precedent still stands at
`InterfaceListPage.tsx:465`.

One measurement of my own strengthens it: the LEGACY shorthand for this same
feature — bare `color`, which `list-view-spec-parity` records as *"legacy
row/text coloring shorthand (spec-canonical: `rowColor`)"* — was **already**
relayed by both host literals. Only the spec-canonical spelling was missing. The
hosts were not withholding row colour; they were carrying only its deprecated
name.

## Stop-condition: searched for, not found

The brief said to stop and report if the object-view route **deliberately**
excludes this key. Four independent readings, all negative:

1. **No marker, pin, ruling or comment names `rowColor` as excluded** anywhere
   in the repo — a full-tree grep of the identifier returns the type
   declarations, the `ListView`/`ObjectGrid` readers, the `InterfaceListPage`
   relay, the i18n keys, and the `userActions` toggle. No fence.
2. **`git log -S rowColor` on both host files returns ZERO commits.** The key
   was never relayed and never removed — it was simply never added. A deliberate
   exclusion would have left a deletion.
3. **The objectui#5097 ledger does not cover this.** RECORD 1 governs the CAST
   reads off the object-view NODE — the 27 undeclared keys the 2026-08-18 ruling
   exempted. A view-sourced rung adds no cast read, and `grouping` is the
   in-fence precedent for exactly that shape.
4. **`rowColor` is published authoring surface elsewhere already** — the
   `object-grid` registration declares it as an input, with the description
   "Rules that colour whole rows from a field value."

## The change

Two rungs, one per host, both inside the existing region markers where markers
exist:

- `plugin-view/src/ObjectView.tsx` — `rowColor: activeView?.rowColor,` inside the
  fence, next to the legacy `color` rung. 46 keys becomes 47.
- `app-shell/src/views/ObjectView.tsx` — `rowColor: viewDef.rowColor ?? listSchema.rowColor,`
  in `fullSchema`, the same two-rung shape as the neighbouring `description`.
  47 named keys becomes 48.

⛔ **Both rungs are view-sourced only, and that is load-bearing.** Neither adds a
cast read off the object-view node. Such a read would put a 28th name on the
objectui#5097 HOST-COMPOSITION exemption whose count the 2026-08-18 maintainer
ruling fixed at 27 — a ruling, not a refactor. A pin in the new `plugin-view`
test asserts the node-level key stays unreachable, so the shortcut cannot be
taken later without a test going red and naming the ledger.

## On the two traps carried from the triage

**Trap 1 — the key count.** ⚠️ One half of this did not survive re-measurement,
and the correction matters for anyone reading the triage later. Only
`plugin-view`'s literal is fenced by `object-view HOST-COMPOSITION SURFACE`
markers; `app-shell`'s `fullSchema` has NO region markers at all (`grep` for the
marker returns only `plugin-view` sources and its ledger test). And the two
literals do not carry the same count: `plugin-view` carries 46, matching the
triage, but `app-shell` carries 47 named keys plus the host spread, not 46.
Measured with a brace-depth scan of each literal, before and after.

**No gate hand-copies either count.** The one ledger that counts anything —
`plugin-view/src/__tests__/objectViewHostSurface.test.tsx` — derives its set from
the fence at test time and pins the CAST reads (27 exempt + 4 declared), not the
literal's key count, so a view-sourced rung leaves it untouched. It is green,
and is included in the runs below precisely because a red there would have been
the #7448 shape.

**Trap 2 — #5435.** Confirmed independently and NOT held behind it. That card
concerns `userActions.rowColor`, a boolean permission toggle that
`normalizeListViewSchema` folds from the legacy `showColor` flag. This card
concerns top-level `rowColor`, the row-colour configuration. "May the user open
the colour panel" versus "what the colours are" — same name, different nesting
level, different key. The last case in the new `app-shell` pin authors the
toggle OFF alongside a colour config and asserts both survive independently, so
a future crossed wire fails instead of passing.

**Scheduling.** The earlier reading that PR #7332 touches `ListView.tsx` was
re-checked and is moot either way: this branch does not touch `ListView.tsx`.

## Verification

All runs from the repo root, at the final commit `79e31a597`.

**Measured in both directions.** The pins were written and run BEFORE the fix
existed, so the before-state is a measurement rather than a claim:

- `plugin-view` pin, before: `2 failed | 3 passed` —
  `expected undefined to deeply equal { field: 'stage', colors: … }`
- `app-shell` pin, before: `4 failed | 2 passed`, including
  `expected { field: 'priority', … } to deeply equal { field: 'stage', … }` —
  the host-supplied value arriving where the view's own was expected, which is
  the defect stated as an assertion.

**Reverse verification**, on the committed tree, each rung deleted in turn:

| leg | mutation proven on disk | result | restore proven by state |
|:--|:--|:--|:--|
| remove `plugin-view` rung | rung occurrences 1 to 0 | `2 failed \| 17 passed` | blob equals HEAD blob, `git diff HEAD` empty |
| remove `app-shell` rung | rung occurrences 1 to 0 | `4 failed \| 2 passed` | blob equals HEAD blob, `git diff HEAD` empty |

Each leg asserted the anchor was present exactly once before mutating and absent
after, and each restore was proven by comparing the worktree blob hash against
the HEAD blob hash AND requiring an empty `git diff HEAD` — never by an exit
code. No build or `dist` is involved: this repo's vitest config aliases every
package specifier to its `src`, so there is no stale-artifact leg to preflight.

**Green at `79e31a597`:**

- `pnpm exec vitest run packages/plugin-view/` — `Test Files 34 passed`, `Tests 297 passed`
- `pnpm exec vitest run packages/app-shell/src/views/` — `Test Files 370 passed`, `Tests 3535 passed | 1 skipped`
- `pnpm --filter @object-ui/plugin-view type-check` — clean; echoed `tsc --noEmit && tsc -p tsconfig.test.json`
- `pnpm --filter @object-ui/app-shell type-check` — clean, same two-program script
- both new pins confirmed INSIDE the typecheck program via `tsc -p tsconfig.test.json --listFiles` (1 hit each), so the green covers them rather than merely excluding them
- `eslint` on the four changed source files: **0 errors** (warnings are the
  pre-existing `no-explicit-any` population every sibling test carries)
- `pnpm --filter @object-ui/plugin-view --filter @object-ui/app-shell lint` — 0 errors
- gates implicated by these paths, each printing its own verdict line:
  `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`,
  `check:phantom-deps`, `check:self-import`, `check:changeset-no-major` — all OK
- `check:governed-queue-guard --test` on the five changed paths: NOT GOVERNED

### Narrowings, declared

- **Repo-wide `pnpm lint` (`turbo run lint`) was not run locally**; the two
  affected packages were linted in full instead, which is the same unit turbo
  invokes for them. Safe to narrow here because this repo enables NO type-aware
  linting (no `projectService` and no `parserOptions.project` anywhere in
  `eslint.config.js`), so a change confined to two files cannot move the verdict
  on a file it does not touch, and no rule block is scoped to either changed
  path. What it could have caught and did not: a lint regression in a package
  this diff does not touch. CI runs the full farm regardless.
- **The remaining `check:*` farm was not enumerated locally.** The aggregate
  `pnpm check` needs the CLI built; the gates whose inputs this diff actually
  moves are listed above and are green. What this could have caught: a gate
  keyed on a path class I did not recognise as implicated.
- **`plugin-list` / `plugin-grid` tests were not re-run.** No file in either
  package changed, and vitest resolves package specifiers to `src`, so no
  rebuilt artifact can reach them. The consumer half — that a `rowColor` which
  ARRIVES then colours a row — is `useRowColor`'s, already covered there, and is
  not re-pinned here; this PR pins the relay, exactly as #7199 split the same
  two halves.
- **No browser/dogfood run.** The claim is about what each host hands down, so
  both pins capture the schema at the boundary rather than rendering it.

## Reviewer notes

⛔ Draft, per the dispatch: not marked ready, no auto-merge, no self-review.

#7516 is NOT addressed here and remains open — it is the other half of the split
card and is awaiting a ruling. #5435 also remains open and is neither a
duplicate of this nor a blocker on it, for the reason measured above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_