### PR TITLE
fix(types): the filter-builder mirror names the keys and the vocabulary its renderer reads

### DIFF
--- a/.changeset/6939-filter-builder-mirror.md
+++ b/.changeset/6939-filter-builder-mirror.md
@@ -1,0 +1,108 @@
+---
+'@object-ui/types': minor
+---
+
+Repair the `filter-builder` mirror: the field key is `value`, the type
+vocabulary is the value families the component actually folds a column into,
+and a filter group is `{ id, logic, conditions }` (objectui#6939, maintainer
+ruling recorded 2026-09-02 — one of the eight groups on that card, dispatched
+as its own PR per the ruling).
+
+Three independent mis-declarations sat in one member, and each is a key-name or
+vocabulary **move** rather than a missing optional key:
+
+1. **`FilterFieldSchema` required `name`.** Every read site matches an entry by
+   `value` — `fields.find((f) => f.value === …)` in `getOperatorsForField`,
+   `changeField`, `getInputType` and `renderValueInput`, `fields[0]?.value` in
+   `addCondition`, and `<SelectItem value={field.value}>` in the field dropdown
+   (`packages/components/src/custom/filter-builder.tsx`). `name` had zero read
+   sites, and `FilterBuilderProps.fields` in that same file already declares
+   `Array<{ value, label, type? }>`. `@object-ui/fields`' `deriveFilterFields`,
+   the real producer that builds this list from an object schema, emits `value`
+   too, and the published doc
+   (`content/docs/components/complex/filter-builder.mdx`) has declared
+   `value: string` all along.
+2. **Its `type` enum was `string | number | date | boolean | select`.** `string`
+   is a phantom, and `text`, `datetime` and `time` — three of the six
+   `FilterValueFamily` members the component folds a column into — were all
+   refused.
+3. **`FilterGroupSchema` was `{ operator, conditions }`.** The gate is
+   `isValidGroup`, which tests `Array.isArray(v.conditions)` and
+   `v.logic === "and" || v.logic === "or"` and nothing else.
+
+All five `components-complex-filter-builder/*` catalog entries author
+`{ value, label, type }` fields and a `{ id, logic, conditions }` group — the
+registration's own `inputs` / `defaultProps` spelling — so the mirror refused
+them while the renderer drew them. Re-measured on `origin/main` at `3e01cb55f`,
+both faces untouched: four refusals at the root (`search-interface` roots at
+`stack`, so `objectui check` counts four for this row, and the `filter-builder`
+it wraps is refused on its own), and five renders this change leaves
+byte-identical (11 / 76 / 65 / 11 / 57 elements, same tag census, same
+`textContent` SHA-256).
+
+**This is `minor`, not `patch`, and the reason is that the accept set MOVES.**
+The ruling grades this class "patch where the accept set only widens toward what
+already renders"; that grading does not hold here. Three refusal classes are
+created, each of which was a legal document before:
+
+- **`fields[].name` as the field key.** `{ name, label, type }` now refuses:
+  `value` is required and `name` is not declared, so a field entry spelled the
+  old way has no identity at all. A document carrying BOTH keys still validates
+  (the undeclared one is stripped), which is the migration path.
+- **`type: 'string'`.** Refused outright. It reached the text control only
+  through the unrecognised-word fallthrough in `valueFamilyForFieldType` —
+  measured indistinguishable from a nonsense spelling — so nothing that read the
+  key ever saw it; but a document that carried it did validate before and does
+  not now.
+- **`{ operator, conditions }` as the group shape.** Refused: `logic` is
+  required. This is the loudest of the three at render time — a group spelled
+  that way already failed `isValidGroup`, fell back to `EMPTY_GROUP` and drew an
+  **empty board** (76 elements and three condition rows became 11 and none), so
+  the mirror was blessing a shape that never rendered.
+
+The widening half, for completeness: `fields[].value`, `type: 'text'` /
+`'datetime'` / `'time'`, and the `{ id, logic, conditions }` group all become
+legal. On the TypeScript twin the same move applies to `FilterField.value` /
+`FilterField.type` and to `FilterGroup.logic`, so a consumer reading
+`field.name` or `group.operator` stops compiling. `major` is not available in
+this repository (`check-changeset-no-major`), so a breaking change is `minor`.
+
+**Two places this departs from a literal reading of the ruling, both measured
+and both flagged for contract review rather than made quietly:**
+
+- **`select` is RETAINED** in the type vocabulary. The ruling's six-member list
+  inherits the finding card's description of `select` as "extra"; it is not.
+  `selectLikeTypes = ["select", "status"]` gives it its own operator bucket
+  (`equals` / `in` / `notIn`) and its own value control — measured, a `select`
+  column draws the option-driven Select and no `<input>` at all, against a text
+  box for an unrecognised spelling. Dropping it would refuse a spelling this
+  mirror accepts *today* and the renderer draws distinctly, which is a fresh
+  instance of the class objectui#6939 exists to close.
+- **The group's `id` is declared OPTIONAL.** `isValidGroup` never consults it
+  and nothing reads `filterGroup.id`; deleting it from an authored group renders
+  byte-identically. Requiring it would invent a refusal the renderer does not
+  make. It stays *declared* because a plain `z.object` strips unknown keys in
+  silence, so an undeclared `id` would be admitted unvalidated — declaring it
+  buys the type check (`id: 42` now refuses) for a key the catalog authors,
+  `EMPTY_GROUP` emits and `onChange` round-trips.
+
+**What this does NOT reach, stated rather than left as an absence.** Two of the
+four census entries — `product-search` and `with-conditions`, plus the
+`filter-builder` nested in `search-interface` — still refuse afterwards, on a
+FOURTH divergence the ruling does not address: they author
+`conditions[].operator` as `eq` / `gt` / `lt`, while `FilterOperatorSchema` is
+the spec's canonical `equals` / `greater_than` / `less_than`. Swapping only
+those three spellings makes both entries parse, which is pinned, so the claim
+"the three ruled divergences are gone from all four" is measured. That
+vocabulary is a genuine fork needing its own ruling — the builder's dropdown ids
+are `notEquals` / `greaterThan`, which this mirror also refuses, while the
+canonical spellings it accepts render a **blank** operator trigger — and it is
+reported on objectui#6939 rather than decided here. Seven further live field
+types (`status`, `currency`, `percent`, `rating`, `lookup`, `master_detail`,
+`user`) each have their own bucket and control and are still refused; they were
+refused before this change as well, so that gap is pre-existing rather than a
+regression introduced here, and it is reported on the same card. The published
+doc for this component already offers all fourteen spellings and already marks
+`type` OPTIONAL, which the mirror still does not — a third declaration that
+agrees with the renderer, pinned here so the gap is measured rather than
+asserted, and left for the same review.

--- a/examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx
+++ b/examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx
@@ -1,0 +1,374 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#6939, the `filter-builder` group — the RENDER half. The
+ * validator-side contract is pinned in
+ * `packages/types/src/__tests__/filter-builder-mirror-6939.test.ts`.
+ *
+ * ## Why the render half is the discriminating half
+ *
+ * From objectui#6318's triage: a "correction" that renders identically proves
+ * the SCHEMA was wrong, not the fixture. A repair on the schema side has to
+ * clear the mirror image of that bar — the validator's verdict must change and
+ * the renderer's output must NOT. `PRE_REPAIR` was measured on `origin/main` at
+ * `3e01cb55f`, BOTH faces untouched, through THIS file's `measure()`.
+ *
+ * ⚠️ Measured directly through `SchemaRenderer`, never through a parse-then-
+ * render path: at base four of these five entries FAIL `safeValidateSchema`, so
+ * anything that validates first cannot run at base and the "before" column
+ * would not exist.
+ *
+ * ⚠️ Element counts are harness-bound — the docs-gallery harness
+ * (`catalog-gallery-render.test.tsx`: provider, `SidebarProvider`, a padded
+ * wrapper) gives different absolutes for the same tile — so identity WITHIN one
+ * harness is the claim that discriminates, and the numbers below are recorded
+ * from this harness rather than carried over from the card.
+ *
+ * Three readings per tile, because a count alone cannot tell a swapped element
+ * from an equal one: element count, a tag census, and the text (literally, plus
+ * a SHA-256 of it).
+ *
+ * ## The second thing this file measures
+ *
+ * The mirror change is a set of key-name and vocabulary MOVES, so "identical
+ * render" is necessary but not sufficient — each spelling the mirror now names
+ * has to be a spelling the renderer actually distinguishes. `the vocabulary is
+ * live` drives one condition row per member and reads the control it draws.
+ * Every assertion in this file is legal in BOTH states of the change (the
+ * renderer is untouched by it), so none of them can redden for the repair
+ * rather than for the thing it controls for.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { createHash } from 'node:crypto';
+import '@object-ui/components';
+import { SchemaRenderer, toRenderableSchema } from '@object-ui/react';
+import { getExample } from '../src/index.js';
+
+const IDS = [
+  'components-complex-filter-builder/empty-filter-builder',
+  'components-complex-filter-builder/product-search',
+  'components-complex-filter-builder/search-interface',
+  'components-complex-filter-builder/user-filters',
+  'components-complex-filter-builder/with-conditions',
+] as const;
+
+type Reading = {
+  elements: number;
+  tags: Record<string, number>;
+  text: string;
+  sha256: string;
+};
+
+/**
+ * Measured on `origin/main` @ `3e01cb55f` through `measure()` below, both faces
+ * untouched. Four of the five reported `: Invalid input` from
+ * `safeValidateSchema` at that commit — `search-interface` roots at `stack` and
+ * validated, while the `filter-builder` it wraps did not — and every one of the
+ * five drew exactly this.
+ *
+ * ⚠️ The empty operator triggers in the `…Category` / `…Price` runs below are
+ * NOT damage from this change and are not repaired by it: those entries author
+ * `eq` / `gt` / `lt`, which no `SelectItem` in the operator dropdown carries, so
+ * the trigger renders blank. It is the fourth divergence the validator half
+ * reports and the ruling does not cover, and it is captured here so a later fix
+ * to it has a "before" to move away from.
+ */
+const PRE_REPAIR: Record<(typeof IDS)[number], Reading> = {
+  'components-complex-filter-builder/empty-filter-builder': {
+    elements: 11,
+    tags: { DIV: 5, LABEL: 1, SPAN: 1, BUTTON: 1, svg: 1, path: 2 },
+    text: 'Build FilterWhereAdd filter',
+    sha256: '4f7116e49e263e517c7d54451327413dc9f8b8513c07f52d9c2686f2b2a381aa',
+  },
+  'components-complex-filter-builder/product-search': {
+    elements: 76,
+    tags: { DIV: 20, LABEL: 1, SPAN: 10, BUTTON: 12, svg: 11, path: 19, INPUT: 3 },
+    text: 'Product Search FiltersWhereANDClear allCategoryRemove conditionPriceRemove conditionStock QuantityRemove conditionAdd filter',
+    sha256: '708dab4e6b4d8bd35777d4115ae86af02d44c5f1ed5ff7be8a4c50a40b4a6b7f',
+  },
+  'components-complex-filter-builder/search-interface': {
+    elements: 65,
+    tags: { DIV: 17, SPAN: 10, BUTTON: 12, svg: 9, path: 16, INPUT: 1 },
+    text: 'Advanced SearchBuild complex queries with multiple conditionsWhereANDClear allPublishedTrueRemove conditionViewsRemove conditionAdd filterApply FiltersClear',
+    sha256: '31b9cb48754fb0de14f23e7eb1b5804fa8862767cf509baed36927dd446c0062',
+  },
+  'components-complex-filter-builder/user-filters': {
+    elements: 11,
+    tags: { DIV: 5, LABEL: 1, SPAN: 1, BUTTON: 1, svg: 1, path: 2 },
+    text: 'Find UsersWhereAdd filter',
+    sha256: 'bc346672868113c9a7ba6ff47057ccaa1b865707f5b99c24234e1a9e3e46e9bc',
+  },
+  'components-complex-filter-builder/with-conditions': {
+    elements: 57,
+    tags: { DIV: 15, LABEL: 1, SPAN: 7, BUTTON: 9, svg: 8, path: 15, INPUT: 2 },
+    text: 'User FiltersWhereANDClear allAgeRemove conditionDepartmentRemove conditionAdd filter',
+    sha256: '23cdc02620baca3e7f7e3b18615d0d02910e3cdc095e323e6f8a00acc835d24a',
+  },
+};
+
+/** Render one entry the way the docs gallery does and measure what it drew. */
+function measure(schema: unknown): Reading & { inputs: (string | null)[]; triggers: (string | null)[] } {
+  const { container, unmount } = render(
+    <SchemaRenderer schema={toRenderableSchema(schema as never) as never} />,
+  );
+  const nodes = Array.from(container.querySelectorAll('*'));
+  const text = container.textContent ?? '';
+  const out = {
+    elements: nodes.length,
+    tags: nodes.reduce<Record<string, number>>((h, el) => ((h[el.tagName] = (h[el.tagName] ?? 0) + 1), h), {}),
+    text,
+    sha256: createHash('sha256').update(text).digest('hex'),
+    inputs: Array.from(container.querySelectorAll('input')).map((i) => i.getAttribute('type')),
+    triggers: Array.from(container.querySelectorAll('[role="combobox"]')).map((e) => e.textContent),
+  };
+  unmount();
+  return out;
+}
+
+function asAuthored(id: (typeof IDS)[number]): Record<string, unknown> {
+  return getExample(id).schema as Record<string, unknown>;
+}
+
+/** The `filter-builder` node, wherever it sits in the entry. */
+function builderNode(id: (typeof IDS)[number]): Record<string, unknown> {
+  const doc = asAuthored(id);
+  if (doc.type === 'filter-builder') return doc;
+  const child = (doc.children as Record<string, unknown>[]).find((c) => c.type === 'filter-builder');
+  if (!child) throw new Error(`${id} no longer carries a filter-builder`);
+  return child;
+}
+
+/** Replace the builder node inside an entry, wrapper and all. */
+function withBuilder(id: (typeof IDS)[number], next: Record<string, unknown>): Record<string, unknown> {
+  const doc = asAuthored(id);
+  if (doc.type === 'filter-builder') return next;
+  return {
+    ...doc,
+    children: (doc.children as Record<string, unknown>[]).map((c) => (c.type === 'filter-builder' ? next : c)),
+  };
+}
+
+/* The three "corrections" objectui#6318's triage asks about — one per ruled
+ * divergence, each applied to the entry as authored. */
+function fieldsSpelledName(id: (typeof IDS)[number]) {
+  const b = builderNode(id) as { fields: Record<string, unknown>[] };
+  return withBuilder(id, {
+    ...b,
+    fields: b.fields.map(({ value, ...rest }) => ({ ...rest, name: value })),
+  });
+}
+function groupSpelledOperator(id: (typeof IDS)[number]) {
+  const b = builderNode(id) as { value: { id?: string; logic: string; conditions: unknown[] } };
+  return withBuilder(id, { ...b, value: { operator: b.value.logic, conditions: b.value.conditions } });
+}
+function typeSpelledString(id: (typeof IDS)[number]) {
+  const b = builderNode(id) as { fields: { type?: string }[] };
+  return withBuilder(id, {
+    ...b,
+    fields: b.fields.map((f) => ({ ...f, type: f.type === 'text' ? 'string' : f.type })),
+  });
+}
+function groupWithoutId(id: (typeof IDS)[number]) {
+  const b = builderNode(id) as { value: Record<string, unknown> };
+  const { id: _dropped, ...rest } = b.value;
+  return withBuilder(id, { ...b, value: rest });
+}
+
+/** Entries whose group actually carries condition rows — the discriminating ones. */
+const WITH_ROWS = [
+  'components-complex-filter-builder/product-search',
+  'components-complex-filter-builder/search-interface',
+  'components-complex-filter-builder/with-conditions',
+] as const;
+
+describe('objectui#6939 — the repair moved the validator, not the renderer', () => {
+  it.each(IDS)('%s renders exactly what it rendered before', (id) => {
+    const after = measure(asAuthored(id));
+    const before = PRE_REPAIR[id];
+    expect(after.elements).toBe(before.elements);
+    expect(after.tags).toEqual(before.tags);
+    expect(after.text).toBe(before.text);
+    expect(after.sha256).toBe(before.sha256);
+  });
+
+  it.each(IDS)('%s anti-vacuity: the tile drew its AUTHORED builder, not an empty box', (id) => {
+    // A tile that renders nothing — or the error boundary — satisfies
+    // "identical" trivially. Every authored field label on screen proves the
+    // `fields` reached the renderer through `value`, the spelling the mirror
+    // refused; the "Add filter" control proves the builder itself mounted.
+    const b = builderNode(id) as {
+      fields: { value: string; label: string }[];
+      value: { conditions: { field: string }[] };
+    };
+    const m = measure(asAuthored(id));
+    expect(m.text).not.toContain('failed to render');
+    expect(m.text).toContain('Add filter');
+    expect(m.text).toContain('Where');
+    expect(m.elements).toBeGreaterThan(10);
+    // Where the entry authors rows, the label of the column each row points at
+    // must be ON SCREEN — the lookup that produces it is the `f.value === …`
+    // match, so this is the reading that says `fields` arrived through the
+    // spelling the mirror used to refuse.
+    for (const condition of b.value.conditions) {
+      const field = b.fields.find((f) => f.value === condition.field);
+      expect(field, `${id} points a row at an undeclared field`).toBeDefined();
+      expect(m.text).toContain(field!.label);
+    }
+  });
+});
+
+describe('objectui#6939 — the fixtures were the side that was right', () => {
+  it.each(WITH_ROWS)('%s: "correcting" the field key to `name` LOSES the field', (id) => {
+    // The card's own discriminator, re-measured here rather than quoted:
+    // `…Clear allCategoryRemove condition…` becomes
+    // `…Clear allRemove condition…`. Contrast the tree-view group, where the
+    // same probe moved nothing and the schema was therefore the wrong side.
+    const authored = measure(asAuthored(id));
+    const corrected = measure(fieldsSpelledName(id));
+    expect(corrected.text).not.toBe(authored.text);
+    expect(corrected.sha256).not.toBe(authored.sha256);
+    // Every field trigger goes blank — the lookup `fields.find(f => f.value === …)`
+    // finds nothing — while the rows themselves survive, so the loss is the
+    // field cell and not the whole tile (that is the NEXT probe's failure mode,
+    // and the two must stay distinguishable).
+    expect(authored.triggers.some((t) => t !== '')).toBe(true);
+    expect(corrected.triggers.every((t) => t === '')).toBe(true);
+    const rows = (r: { text: string }) => r.text.split('Remove condition').length - 1;
+    expect(rows(corrected)).toBe(rows(authored));
+    expect(rows(authored)).toBeGreaterThan(0);
+    // ⚠️ The element count is NOT asserted equal, and the reason is a finding:
+    // losing the field def also loses its TYPE, so a column that drew a
+    // non-text control degrades to a text box. `search-interface`'s `boolean`
+    // column costs three elements that way (65 → 62); the two all-text/number
+    // entries happen to break even. The damage is therefore at least the label
+    // and sometimes more, never less.
+    expect(corrected.elements).toBeLessThanOrEqual(authored.elements);
+  });
+
+  it.each(WITH_ROWS)('%s: "correcting" the group key to `operator` EMPTIES the board', (id) => {
+    // `isValidGroup` rejects it, the component falls back to `EMPTY_GROUP`, and
+    // every condition row disappears.
+    const authored = measure(asAuthored(id));
+    const corrected = measure(groupSpelledOperator(id));
+    expect(corrected.elements).toBeLessThan(authored.elements);
+    expect(corrected.text).not.toContain('Remove condition');
+    expect(authored.text).toContain('Remove condition');
+  });
+
+  it.each(WITH_ROWS)('%s: `type: "string"` renders identically — it is a PHANTOM', (id) => {
+    // The asymmetry that justifies dropping `string` rather than keeping it as
+    // an alias: swapping `text` for it changes nothing, because both reach the
+    // text control through the unrecognised-word fallthrough in
+    // `valueFamilyForFieldType`. `text` is the spelling the component names.
+    const authored = measure(asAuthored(id));
+    const corrected = measure(typeSpelledString(id));
+    expect(corrected.elements).toBe(authored.elements);
+    expect(corrected.text).toBe(authored.text);
+    expect(corrected.sha256).toBe(authored.sha256);
+    expect(corrected.inputs).toEqual(authored.inputs);
+  });
+
+  it.each(WITH_ROWS)('%s: deleting the group `id` renders identically — it has NO read site', (id) => {
+    // The measurement behind declaring `id` OPTIONAL rather than required.
+    // `isValidGroup` gates on `conditions` and `logic` only.
+    const authored = measure(asAuthored(id));
+    const without = measure(groupWithoutId(id));
+    expect(without.elements).toBe(authored.elements);
+    expect(without.text).toBe(authored.text);
+    expect(without.sha256).toBe(authored.sha256);
+  });
+
+  it.each(IDS)('%s stays on the spellings its renderer reads', (id) => {
+    // ⛔ Do NOT "repair" a future red here by migrating the fixtures back to
+    // `name` / `operator`. They are the side that renders.
+    const b = builderNode(id) as { fields: Record<string, unknown>[]; value: Record<string, unknown> };
+    for (const f of b.fields) {
+      expect(typeof f.value).toBe('string');
+      expect('name' in f).toBe(false);
+    }
+    expect(b.value.logic).toMatch(/^(and|or)$/);
+    expect('operator' in b.value).toBe(false);
+  });
+});
+
+describe('objectui#6939 — the vocabulary the mirror now names is live', () => {
+  /**
+   * One condition row on one column of the given type, so the value control the
+   * column draws is observable. Legal in both states of this change — the
+   * renderer never consults the mirror.
+   */
+  function oneRow(type: string) {
+    return measure({
+      type: 'filter-builder',
+      name: 'f',
+      fields: [{ value: 'a', label: 'A', type, options: [{ value: 'x', label: 'X' }] }],
+      value: { id: 'r', logic: 'and', conditions: [{ id: '1', field: 'a', operator: 'equals', value: '' }] },
+    });
+  }
+
+  /**
+   * The `<input type>` each ruled member's family is edited with —
+   * `FILTER_INPUT_TYPE_BY_FAMILY` in `custom/filter-builder.tsx`, observed from
+   * the DOM rather than imported (it is module-private on purpose). `boolean`
+   * and `select` draw no input at all: a Select, which is the third combobox on
+   * the row beside the field and operator ones.
+   */
+  const DRAWN: Record<string, string | null> = {
+    text: 'text',
+    number: 'number',
+    boolean: null,
+    date: 'date',
+    datetime: 'datetime-local',
+    time: 'time',
+    select: null,
+  };
+
+  it.each(Object.entries(DRAWN))('`%s` draws its own value control (%s)', (type, expected) => {
+    const m = oneRow(type);
+    if (expected === null) {
+      expect(m.inputs).toEqual([]);
+      expect(m.triggers).toHaveLength(3);
+    } else {
+      expect(m.inputs).toEqual([expected]);
+      expect(m.triggers).toHaveLength(2);
+    }
+  });
+
+  it('the seven members are MUTUALLY distinguishable, not just individually plausible', () => {
+    // A per-member assertion would pass on a component that drew one control
+    // for everything. This is the claim that cannot: seven members, six
+    // distinct control signatures, and the only pair that shares one
+    // (`boolean` / `select`) shares it for a stated reason — both are
+    // option-driven Selects.
+    const signature = (type: string) => {
+      const m = oneRow(type);
+      return `${m.inputs.join(',')}|${m.triggers.length}`;
+    };
+    const signatures = Object.keys(DRAWN).map(signature);
+    expect(new Set(signatures).size).toBe(6);
+    expect(signature('boolean')).toBe(signature('select'));
+  });
+
+  it('`string` is indistinguishable from a nonsense spelling — the phantom, again', () => {
+    expect(oneRow('string').inputs).toEqual(oneRow('zzz-not-a-field-type').inputs);
+    expect(oneRow('string').elements).toBe(oneRow('zzz-not-a-field-type').elements);
+    // …and it is distinguishable from `number`, so the probe above is not
+    // reporting "everything looks the same to this harness".
+    expect(oneRow('string').inputs).not.toEqual(oneRow('number').inputs);
+  });
+
+  it.each(['status', 'currency', 'percent', 'rating', 'lookup', 'master_detail', 'user'])(
+    '`%s` is live too, and the mirror refuses it — a pre-existing gap, reported not repaired',
+    (type) => {
+      // These draw a REAL control (a number input, or the option-driven Select),
+      // so they are not phantoms like `string`; the mirror refused them before
+      // this change and still does. Recorded here so the gap is a decision.
+      expect(oneRow(type).inputs).not.toEqual(oneRow('zzz-not-a-field-type').inputs);
+    },
+  );
+});

--- a/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
+++ b/packages/types/src/__tests__/filter-builder-mirror-6939.test.ts
@@ -1,0 +1,360 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#6939, the `filter-builder` group — the VALIDATOR half. The render
+ * half is
+ * `examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx`.
+ *
+ * ## The defect
+ *
+ * Three independent mis-declarations in one member, each a key-name or
+ * vocabulary MOVE rather than a missing optional key:
+ *
+ *   1. `FilterFieldSchema` required `name`. Every read site matches an entry by
+ *      `value` — `fields.find((f) => f.value === …)` in `getOperatorsForField`,
+ *      `changeField`, `getInputType` and `renderValueInput`, `fields[0]?.value`
+ *      in `addCondition`, and `<SelectItem value={field.value}>` in the field
+ *      dropdown. `name` had zero.
+ *   2. Its `type` enum was `string | number | date | boolean | select`.
+ *      `string` is a phantom; `text`, `datetime` and `time` — three of the six
+ *      `FilterValueFamily` members the component actually folds a column into —
+ *      were all refused.
+ *   3. `FilterGroupSchema` was `{ operator, conditions }`. The gate is
+ *      `isValidGroup` (`custom/filter-builder.tsx:1060`), which reads
+ *      `conditions` and `logic` and nothing else.
+ *
+ * All five `components-complex-filter-builder/*` catalog entries author
+ * `{ value, label, type }` fields and a `{ id, logic, conditions }` group — the
+ * registration's own `inputs`/`defaultProps` spelling — so the mirror refused
+ * every one of them while the renderer drew them.
+ *
+ * ## Ruling
+ *
+ * Maintainer, 2026-09-02, via the director seat (summon #8), verbatim 「同意」,
+ * recorded as objectui#6939 comment 5510084784. Its `filter-builder` row:
+ * *field key is `value`; type vocabulary `text` / `number` / `boolean` /
+ * `date` / `datetime` / `time`; group shape `{ id, logic, conditions }`.*
+ *
+ * ## Two places this implementation departs from a LITERAL reading, and why
+ *
+ * Both are measured, both are declared here rather than made quietly, and both
+ * are flagged on the PR for contract review.
+ *
+ *   - **`select` is retained.** The ruling's six-member list inherits the
+ *     finding card's description of `select` as "extra". It is not: it has its
+ *     own operator bucket (`selectLikeTypes`, `custom/filter-builder.tsx:935`,
+ *     read by `operatorsForFieldType` and `isOptionDrivenValueControl`) and
+ *     draws the option-driven Select instead of a text box. Dropping it would
+ *     refuse a spelling this mirror accepts TODAY and the renderer draws
+ *     distinctly — a fresh instance of the class this card closes.
+ *   - **Group `id` is declared OPTIONAL.** `isValidGroup` never consults it and
+ *     nothing reads `filterGroup.id`; deleting it from an authored group
+ *     renders byte-identically (the render half measures that). Requiring it
+ *     would invent a refusal the renderer does not make.
+ *
+ * ## What this change does NOT reach, stated rather than left as an absence
+ *
+ * Two of the four census entries — `product-search` and `with-conditions`, plus
+ * the `filter-builder` nested inside `search-interface` — still refuse
+ * afterwards, on a FOURTH divergence the ruling does not address: they author
+ * `conditions[].operator` as `eq` / `gt` / `lt`, and `FilterOperatorSchema` is
+ * the spec's canonical `equals` / `greater_than` / `less_than`.
+ * `assertion the residual refusal is the operator alias and nothing else`
+ * pins that mechanically — swapping only those three spellings makes both
+ * entries parse — so the claim "the three ruled divergences are gone from all
+ * four" is measured rather than asserted. The operator vocabulary is a genuine
+ * fork (the builder's own dropdown ids are `notEquals` / `greaterThan`, which
+ * this mirror ALSO refuses, while the canonical spellings it accepts render a
+ * blank operator trigger) and needs its own ruling.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { FilterBuilderSchema, FilterFieldSchema, FilterGroupSchema } from '../zod/complex.zod';
+import { safeValidateSchema } from '../zod/index.zod';
+import type { FilterField as TsFilterField, FilterGroup as TsFilterGroup } from '../complex';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const CATALOG = join(REPO_ROOT, 'examples/schema-catalog/src/schemas/components-complex-filter-builder');
+const READER = 'packages/components/src/custom/filter-builder.tsx';
+
+/** The four entries `node packages/cli/dist/cli.js check` counts for this row. */
+const CENSUS = ['empty-filter-builder', 'product-search', 'user-filters', 'with-conditions'] as const;
+
+function entry(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(CATALOG, `${name}.json`), 'utf8')) as Record<string, unknown>;
+}
+
+/** The `filter-builder` node nested inside the `stack`-rooted fifth entry. */
+function nestedSearchInterface(): Record<string, unknown> {
+  const doc = entry('search-interface') as { children: Record<string, unknown>[] };
+  const node = doc.children.find((c) => c.type === 'filter-builder');
+  if (!node) throw new Error('search-interface no longer carries a filter-builder child');
+  return node;
+}
+
+/** Report the issues rather than `false`, so a red run says what broke. */
+function reasons(schema: unknown): string[] {
+  const r = safeValidateSchema(schema);
+  return r.success ? [] : r.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
+}
+
+/** The three alias spellings the fixtures use, mapped to what this mirror declares. */
+const CANONICAL: Record<string, string> = { eq: 'equals', gt: 'greater_than', lt: 'less_than' };
+
+function withCanonicalOperators(doc: Record<string, unknown>): Record<string, unknown> {
+  const group = doc.value as { conditions: { operator: string }[] };
+  return {
+    ...doc,
+    value: {
+      ...group,
+      conditions: group.conditions.map((c) => ({ ...c, operator: CANONICAL[c.operator] ?? c.operator })),
+    },
+  };
+}
+
+/* ── Type-level pins (invariant equality, house form) ─────────────────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+function expectType<T extends true>(_: T = true as T): void { /* compile-time only */ }
+
+// The TS twin moved WITH the mirror. These fail to compile if either face
+// drifts back, which is the half a runtime assertion cannot cover.
+expectType<Equal<TsFilterField['value'], string>>();
+expectType<Equal<TsFilterField['type'],
+  'text' | 'number' | 'boolean' | 'date' | 'datetime' | 'time' | 'select'>>();
+expectType<Equal<TsFilterGroup['logic'], 'and' | 'or'>>();
+expectType<Equal<TsFilterGroup['id'], string | undefined>>();
+// `id` is OPTIONAL, not merely typed `string | undefined`: an object that omits
+// the key must be assignable, which only this annotation proves.
+const groupWithoutId: TsFilterGroup = { logic: 'and', conditions: [] };
+// `name` is gone from the declaration — `@ts-expect-error` is the assertion.
+// @ts-expect-error `FilterField.name` was renamed to `value` (objectui#6939)
+const legacyNamedField: TsFilterField = { name: 'a', label: 'A', type: 'text' };
+
+describe('objectui#6939 — the field key is `value`', () => {
+  it('accepts the spelling every read site matches on', () => {
+    expect(FilterFieldSchema.safeParse({ value: 'a', label: 'A', type: 'text' }).success).toBe(true);
+  });
+
+  it('REFUSES the former `name` spelling — this half of the move is breaking', () => {
+    // The accept set MOVES here, it does not merely widen: a document authored
+    // against the old mirror stops validating. Named in the changeset.
+    expect(FilterFieldSchema.safeParse({ name: 'a', label: 'A', type: 'text' }).success).toBe(false);
+  });
+
+  it('`name` is not silently tolerated as a passthrough hole either', () => {
+    // A plain `z.object` STRIPS unknown keys, so an undeclared `name` would be
+    // accepted-and-discarded rather than refused. What makes the refusal real
+    // is that `value` is REQUIRED, so the old shape has no identity at all.
+    const parsed = FilterFieldSchema.safeParse({ value: 'a', label: 'A', type: 'text', name: 'a' });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && 'name' in parsed.data).toBe(false);
+  });
+
+  it('the reader still matches on `value`', () => {
+    // Text-anchored, so a rename in the component turns this red instead of
+    // leaving the prose above quietly false.
+    const src = readFileSync(join(REPO_ROOT, READER), 'utf8');
+    expect(src).toContain('fields.find((f) => f.value === fieldValue)');
+    expect(src).toContain('fields[0]?.value');
+    expect(src).toContain('value: string');
+  });
+});
+
+/** The ruling's six. */
+const RULED = ['text', 'number', 'boolean', 'date', 'datetime', 'time'] as const;
+
+/**
+ * Live field-type spellings this mirror refuses BEFORE this change and still
+ * refuses after — each with its own bucket in `custom/filter-builder.tsx`
+ * (`numberLikeTypes` for the first four, `selectLikeTypes`/`lookupLikeTypes`
+ * for the rest) and its own value control.
+ */
+const UNRULED_LIVE_TYPES = ['status', 'currency', 'percent', 'rating', 'lookup', 'master_detail', 'user'] as const;
+
+describe('objectui#6939 — the type vocabulary', () => {
+
+  it.each(RULED)('accepts the ruled member `%s`', (type) => {
+    expect(FilterFieldSchema.safeParse({ value: 'a', label: 'A', type }).success).toBe(true);
+  });
+
+  it('accepts `select`, which this implementation RETAINS against a literal reading', () => {
+    // ⚠️ Declared departure — see the header. `selectLikeTypes` gives `select`
+    // its own operator bucket and the option-driven value control, so dropping
+    // it would refuse a live spelling. If contract review rules the other way,
+    // this is the assertion that flips, together with the enum.
+    expect(FilterFieldSchema.safeParse({ value: 'a', label: 'A', type: 'select' }).success).toBe(true);
+    const src = readFileSync(join(REPO_ROOT, READER), 'utf8');
+    expect(src).toContain('const selectLikeTypes = ["select", "status"]');
+  });
+
+  it('REFUSES `string` — the phantom the enum used to carry', () => {
+    // Breaking half #2. `string` reached the text control only by the
+    // unrecognised-word fallthrough in `valueFamilyForFieldType`, so it was
+    // indistinguishable from a nonsense spelling; the render half measures that.
+    expect(FilterFieldSchema.safeParse({ value: 'a', label: 'A', type: 'string' }).success).toBe(false);
+  });
+
+  it.each(UNRULED_LIVE_TYPES)(
+    'still refuses the live-but-unruled spelling `%s` — a PRE-EXISTING gap, not a regression here',
+    (type) => {
+      // ⚠️ Each of these has its own bucket in the component and draws its own
+      // control, and each was refused by this mirror BEFORE this change as well
+      // as after. Widening to them is an accept-set change the ruling does not
+      // cover; reported on objectui#6939 instead of taken here. This assertion
+      // exists so the gap is a recorded decision rather than an absence.
+      expect(FilterFieldSchema.safeParse({ value: 'a', label: 'A', type }).success).toBe(false);
+    },
+  );
+
+  it('the gap is measured against the PUBLISHED doc, not against a private opinion', () => {
+    // `content/docs/components/complex/filter-builder.mdx` is a THIRD
+    // declaration of this component's authoring surface, independent of both
+    // faces repaired here, and it already agrees with the renderer: `value` as
+    // the field key, `{ id, logic, conditions }` as the group, and a FOURTEEN
+    // member `type?` union. This assertion is what makes "the mirror is the odd
+    // one out" a reading rather than a claim — and it turns red if someone
+    // narrows the DOC to match the mirror, which is the wrong direction.
+    const doc = readFileSync(join(REPO_ROOT, 'content/docs/components/complex/filter-builder.mdx'), 'utf8');
+    expect(doc).toContain("logic: 'and' | 'or';");
+    expect(doc).toMatch(/value: string;\s+\/\/ Field identifier/);
+    for (const type of [...RULED, 'select', ...UNRULED_LIVE_TYPES]) {
+      expect(doc, `the published doc no longer offers \`${type}\``).toContain(`'${type}'`);
+    }
+    // …and the doc declares `type` OPTIONAL, which this mirror still does not.
+    // A fourth pre-existing gap, recorded for the same reason as the seven.
+    expect(doc).toContain('type?:');
+    expect(FilterFieldSchema.safeParse({ value: 'a', label: 'A' }).success).toBe(false);
+  });
+});
+
+describe('objectui#6939 — the group shape is `{ id, logic, conditions }`', () => {
+  it('accepts the shape the catalog authors and `EMPTY_GROUP` emits', () => {
+    expect(FilterGroupSchema.safeParse({ id: 'root', logic: 'and', conditions: [] }).success).toBe(true);
+  });
+
+  it('`id` is OPTIONAL — the renderer never reads it', () => {
+    // ⚠️ Declared departure — see the header. `isValidGroup` gates on
+    // `conditions` and `logic` only, so a group without `id` renders
+    // identically; requiring it would invent a refusal.
+    expect(FilterGroupSchema.safeParse({ logic: 'or', conditions: [] }).success).toBe(true);
+    const src = readFileSync(join(REPO_ROOT, READER), 'utf8');
+    expect(src).toContain('Array.isArray((v as FilterGroup).conditions) &&');
+    expect(src).toContain('((v as FilterGroup).logic === "and" || (v as FilterGroup).logic === "or")');
+  });
+
+  it('`id` is DECLARED, so it is type-checked rather than admitted unvalidated', () => {
+    // The reason for declaring a key with no read site: `z.object` strips
+    // unknown keys in silence, so an undeclared `id` would accept `42`.
+    expect(FilterGroupSchema.safeParse({ id: 42, logic: 'and', conditions: [] }).success).toBe(false);
+  });
+
+  it('REFUSES the former `{ operator, conditions }` shape', () => {
+    // Breaking half #3, and the loudest of the three at render time: a group
+    // spelled this way fails `isValidGroup`, falls back to `EMPTY_GROUP`, and
+    // the board empties.
+    expect(FilterGroupSchema.safeParse({ operator: 'and', conditions: [] }).success).toBe(false);
+  });
+
+  it('`logic` is still a closed vocabulary', () => {
+    expect(FilterGroupSchema.safeParse({ id: 'r', logic: 'xor', conditions: [] }).success).toBe(false);
+  });
+});
+
+describe('objectui#6939 — the catalog entries the mirror refused', () => {
+  it.each(['empty-filter-builder', 'user-filters'])(
+    '%s now validates under safeValidateSchema',
+    (name) => {
+      expect(reasons(entry(name))).toEqual([]);
+    },
+  );
+
+  it.each(['product-search', 'with-conditions'])(
+    '%s: the residual refusal is the operator alias and NOTHING else',
+    (name) => {
+      // ⛔ Do NOT "repair" this by widening `FilterOperatorSchema` or by
+      // rewriting the fixtures. Both are outside the ruling and both need one:
+      // the builder's dropdown ids (`greaterThan`) and the spec's canonical
+      // spellings (`greater_than`) are a genuine fork, and this mirror refuses
+      // the former while the RENDERER draws a blank operator trigger for the
+      // latter. Reported on objectui#6939.
+      expect(reasons(entry(name))).not.toEqual([]);
+      expect(reasons(withCanonicalOperators(entry(name)))).toEqual([]);
+    },
+  );
+
+  it('the `stack`-rooted fifth entry: its nested filter-builder behaves the same way', () => {
+    // `search-interface.json` roots at `stack`, so `objectui check` (which runs
+    // `safeValidateSchema` on the ROOT only — `packages/cli/src/commands/check.ts:137`)
+    // counts four entries for this row, not five. The nested node is measured
+    // here so the fifth file is not silently unexamined.
+    const node = nestedSearchInterface();
+    expect(reasons(node)).not.toEqual([]);
+    expect(reasons(withCanonicalOperators(node))).toEqual([]);
+  });
+
+  it.each(CENSUS)('%s: none of the THREE ruled divergences is left in it', (name) => {
+    // The positive statement behind the split above, key by key.
+    const doc = entry(name) as {
+      fields: Record<string, unknown>[];
+      value: Record<string, unknown>;
+    };
+    for (const f of doc.fields) {
+      expect(FilterFieldSchema.safeParse(f).success).toBe(true);
+      expect('name' in f).toBe(false);
+    }
+    expect(doc.value.logic).toMatch(/^(and|or)$/);
+    expect('operator' in doc.value).toBe(false);
+  });
+});
+
+describe('objectui#6939 — the controls are legal in BOTH states of this change', () => {
+  // Every assertion above that changes verdict is paired with a carrier that
+  // does not, so a red run cannot be read as "the repair broke something
+  // unrelated". These documents parse before AND after: they carry both key
+  // spellings at once (the extra one is stripped in each state) and a `type`
+  // that is a member of both enums.
+  const bothWays = {
+    type: 'filter-builder',
+    name: 'x',
+    fields: [{ name: 'a', value: 'a', label: 'A', type: 'select' }],
+    value: { id: 'r', operator: 'and', logic: 'and', conditions: [] },
+  };
+
+  it('the both-spellings carrier validates', () => {
+    expect(reasons(bothWays)).toEqual([]);
+  });
+
+  it('and it is genuinely reaching FilterBuilderSchema, not some other union arm', () => {
+    expect(FilterBuilderSchema.safeParse(bothWays).success).toBe(true);
+  });
+
+  it('a `fields` entry that is not an object still refuses, in either state', () => {
+    expect(FilterBuilderSchema.safeParse({ ...bothWays, fields: ['a'] }).success).toBe(false);
+  });
+});
+
+describe('objectui#6939 — the keys are DECLARED, not passthrough holes', () => {
+  it('both mirrors expose the ruled keys and no stale one', () => {
+    expect(Object.keys((FilterFieldSchema as unknown as { shape: Record<string, unknown> }).shape))
+      .toEqual(['value', 'label', 'type', 'operators', 'options']);
+    // `FilterGroupSchema` is a `z.lazy`, so its shape is behind the thunk.
+    const group = (FilterGroupSchema as unknown as { _def: { getter: () => { shape: Record<string, unknown> } } })
+      ._def.getter();
+    expect(Object.keys(group.shape)).toEqual(['id', 'logic', 'conditions']);
+  });
+
+  it('the unused type-level bindings above are referenced, so lint keeps them', () => {
+    expect(groupWithoutId.conditions).toEqual([]);
+    expect(legacyNamedField).toBeDefined();
+  });
+});

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -339,14 +339,34 @@ export interface FilterBuilderCondition {
 }
 
 /**
- * Filter group
+ * Filter group — the shape `FilterBuilder` reads (objectui#6939, the
+ * `filter-builder` group; maintainer ruling 2026-09-02, director seat summon
+ * #8, verbatim 「同意」).
+ *
+ * The gate is `isValidGroup`,
+ * `packages/components/src/custom/filter-builder.tsx:1060`:
+ * `Array.isArray(v.conditions) && (v.logic === "and" || v.logic === "or")`.
+ * `logic` is the read key; the former `operator` on this face had zero read
+ * sites, and a group spelled that way fails the gate, falls back to
+ * `EMPTY_GROUP` and renders an EMPTY board.
  */
 export interface FilterGroup {
   /**
-   * Logical operator (AND/OR)
+   * Group id.
+   *
+   * OPTIONAL on purpose. `isValidGroup` never consults it and nothing reads
+   * `filterGroup.id`; measured, deleting it from an authored group renders
+   * byte-identically. It is declared because the component's own `FilterGroup`
+   * carries it, `EMPTY_GROUP` emits it and it round-trips out through
+   * `onChange` — so a document that carries it should be TYPE-CHECKED on it
+   * rather than admitted unvalidated.
+   */
+  id?: string;
+  /**
+   * How the conditions combine — the key `isValidGroup` reads.
    * @default 'and'
    */
-  operator: 'and' | 'or';
+  logic: 'and' | 'or';
   /**
    * Filter conditions or nested groups
    */
@@ -403,21 +423,46 @@ export interface FilterBuilderSchema extends BaseSchema {
 }
 
 /**
- * Filter field definition
+ * Filter field definition — one entry of `FilterBuilderSchema.fields`
+ * (objectui#6939, same ruling).
+ *
+ * Renamed from `name` to `value`: every read site matches on `value`
+ * (`fields.find((f) => f.value === …)` in `getOperatorsForField`,
+ * `changeField`, `getInputType` and `renderValueInput`; `fields[0]?.value` in
+ * `addCondition`; `<SelectItem value={field.value}>` in the field dropdown),
+ * `name` had zero, and `FilterBuilderProps.fields` in
+ * `packages/components/src/custom/filter-builder.tsx` already declares
+ * `Array<{ value, label, type? }>`.
  */
 export interface FilterField {
   /**
-   * Field name/key
+   * Field key — the identity the builder matches a condition's `field`
+   * against, and the value its field dropdown puts on each option.
    */
-  name: string;
+  value: string;
   /**
    * Field label
    */
   label: string;
   /**
-   * Field type
+   * Field type — the value FAMILY the column is edited in.
+   *
+   * The six ruled members are `FilterValueFamily`
+   * (`custom/filter-builder.tsx:406`) and each draws a distinct control:
+   * `<input type>` `text` / `number` / `date` / `datetime-local` / `time`, and
+   * for `boolean` a two-item Select and no input at all. `string` left this
+   * union as a phantom — it reached the text control by the unrecognised-word
+   * fallthrough, indistinguishable from a nonsense spelling, while `text` is
+   * what the registration's `defaultProps` and every catalog entry author.
+   *
+   * `select` is RETAINED against a literal reading of the ruling's six:
+   * `selectLikeTypes` gives it its own operator bucket and the option-driven
+   * Select, so dropping it would refuse a live spelling. `status`, `currency`,
+   * `percent`, `rating`, `lookup`, `master_detail` and `user` are live too and
+   * are still absent — a pre-existing gap reported on objectui#6939, not a
+   * regression introduced here.
    */
-  type: 'string' | 'number' | 'date' | 'boolean' | 'select';
+  type: 'text' | 'number' | 'boolean' | 'date' | 'datetime' | 'time' | 'select';
   /**
    * Available operators for this field
    */

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -181,22 +181,99 @@ export const FilterBuilderConditionSchema: z.ZodType<any> = z.lazy(() =>
 );
 
 /**
- * Filter Group Schema
+ * Filter Group Schema — the shape `FilterBuilder` actually reads
+ * (objectui#6939, the `filter-builder` group; maintainer ruling 2026-09-02,
+ * director seat summon #8, verbatim 「同意」).
+ *
+ * The gate is `isValidGroup`, `packages/components/src/custom/filter-builder.tsx:1060`:
+ *
+ *     Array.isArray(v.conditions) && (v.logic === "and" || v.logic === "or")
+ *
+ * so `logic` is the read key and the mirror's former `operator` was a spelling
+ * with ZERO read sites. Measured through the real `SchemaRenderer`: rewriting a
+ * catalog entry's group from `{ id, logic, conditions }` to
+ * `{ operator, conditions }` fails that gate, the component falls back to
+ * `EMPTY_GROUP`, and the board EMPTIES — 76 elements and three condition rows
+ * become 11 elements and none.
+ *
+ * `id` is DECLARED here but deliberately OPTIONAL, and that is a departure from
+ * a literal reading of the ruling's `{ id, logic, conditions }`. `isValidGroup`
+ * never consults it and nothing else reads `filterGroup.id`; measured, deleting
+ * `id` from an authored group renders BYTE-IDENTICALLY (76 elements, same text,
+ * same SHA-256). Requiring it would refuse a document the renderer draws
+ * perfectly — a fresh instance of the exact class objectui#6939 exists to
+ * close. Declared rather than dropped because the component's own exported
+ * `FilterGroup` carries it, `EMPTY_GROUP` emits it, every catalog entry authors
+ * it, and it round-trips out through `onChange`; declaring it buys the type
+ * check (`id: 42` now refuses) that an undeclared key would not get, since a
+ * plain `z.object` strips unknown keys in silence.
  */
 export const FilterGroupSchema: z.ZodType<any> = z.lazy(() =>
   z.object({
-    operator: z.enum(['and', 'or']).describe('Group operator'),
+    id: z.string().optional().describe('Group id — round-tripped through `onChange`; no read site'),
+    logic: z.enum(['and', 'or']).describe('How the conditions combine — read by `isValidGroup`'),
     conditions: z.array(z.union([FilterBuilderConditionSchema, FilterGroupSchema])).describe('Conditions or sub-groups'),
   })
 );
 
 /**
- * Filter Field Schema
+ * Filter Field Schema — one entry of `FilterBuilderSchema.fields`
+ * (objectui#6939, same ruling).
+ *
+ * ## `value`, not `name`
+ *
+ * Every read site looks the entry up by `value`:
+ * `fields.find((f) => f.value === fieldValue)` in `getOperatorsForField`,
+ * `changeField`, `getInputType` and `renderValueInput`, plus `fields[0]?.value`
+ * in `addCondition` and `<SelectItem value={field.value}>` in the field
+ * dropdown — `custom/filter-builder.tsx:1099,1161,1201,1234,1239` and the row
+ * render. `name` has zero read sites, and `FilterBuilderProps.fields` (line 66
+ * of that file) declares `Array<{ value, label, type? }>`. Measured: rewriting
+ * a catalog entry's `value` to `name` loses the field on every row —
+ * `…Clear allCategoryRemove condition…` becomes
+ * `…Clear allRemove condition…`, and the three value inputs degrade from
+ * `text`/`number`/`number` to three `text` boxes.
+ *
+ * ## The type vocabulary
+ *
+ * `text` / `number` / `boolean` / `date` / `datetime` / `time` are the ruled
+ * six, and all six are live and MUTUALLY DISTINGUISHABLE at the value control
+ * (measured, one condition row each): `<input type>` `text`, `number`, `date`,
+ * `datetime-local`, `time`, and for `boolean` no input at all but an extra
+ * option Select. They are `FilterValueFamily`
+ * (`custom/filter-builder.tsx:406`), which `valueFamilyForFieldType` folds a
+ * column's `type` into and `FILTER_INPUT_TYPE_BY_FAMILY` draws from.
+ *
+ * `string` LEAVES the vocabulary: it renders identically to a nonsense
+ * spelling, because both reach the text control by the unrecognised-word
+ * fallthrough rather than by being read. It is a phantom, and `text` is the
+ * spelling the registration's own `defaultProps` and all five catalog entries
+ * use.
+ *
+ * ⚠ `select` is RETAINED, which departs from a literal reading of the ruling's
+ * six. The ruling inherits the finding card's description of `select` as
+ * "extra"; measured, it is not. `selectLikeTypes = ["select", "status"]`
+ * (`custom/filter-builder.tsx:935`) is consumed by `operatorsForFieldType`
+ * (line 989, the `equals`/`in`/`notIn` bucket) and by
+ * `isOptionDrivenValueControl` (line 739), and a `select` column draws the
+ * option-driven Select rather than a text box — 39 elements and no `<input>`,
+ * against 36 and one. Dropping it would REFUSE a spelling this mirror accepts
+ * today and the renderer draws distinctly, which is a fresh instance of the
+ * class this card closes. Flagged for contract review rather than decided here.
+ *
+ * ⚠ NOT declared, and NOT a regression this change introduces: `status`,
+ * `currency`, `percent`, `rating`, `lookup`, `master_detail` and `user` are
+ * live spellings with their own buckets and controls (`number` inputs for the
+ * first four by way of `numberLikeTypes`, the option Select for the last three
+ * by way of `lookupLikeTypes`) and every one of them is refused by this mirror
+ * BEFORE this change as well as after. Reported on objectui#6939 as a
+ * pre-existing gap; widening to them is an accept-set change the ruling does
+ * not cover.
  */
 export const FilterFieldSchema = z.object({
-  name: z.string().describe('Field name'),
+  value: z.string().describe('Field key — the identity every read site matches on'),
   label: z.string().describe('Field label'),
-  type: z.enum(['string', 'number', 'date', 'boolean', 'select']).describe('Field type'),
+  type: z.enum(['text', 'number', 'boolean', 'date', 'datetime', 'time', 'select']).describe('Field type'),
   operators: z.array(FilterOperatorSchema).optional().describe('Available operators'),
   options: z.array(z.object({
     label: z.string(),


### PR DESCRIPTION
Part of #6939 — the `filter-builder` group (group 4 of eight; the card's own instruction is that the groups land as separate PRs).

**Clause-②: yes**

This changes what a published mirror ACCEPTS, in both directions. Draft, `needs:contract-review`, no auto-merge, no self-review.

## Authority

Maintainer ruling recorded 2026-09-02, director seat summon #8, verbatim 「同意」 — [#6939 comment 5510084784](https://github.com/objectstack-ai/objectui/issues/6939#issuecomment-5510084784). Its `filter-builder` row:

> `filter-builder`: field key is `value`; type vocabulary `text` / `number` / `boolean` / `date` / `datetime` / `time`; group shape `{ id, logic, conditions }`.

## What was wrong, re-measured on `origin/main` `3e01cb55f`

| ruled | mirror at base | read site |
|---|---|---|
| field key `value` | `FilterFieldSchema` requires **`name`** | `fields.find((f) =` `> f.value === …)` in `getOperatorsForField` / `changeField` / `getInputType` / `renderValueInput`; `fields[0]?.value` in `addCondition`; `SelectItem value={field.value}` in the field dropdown. `name`: **zero** read sites |
| `text`/`number`/`boolean`/`date`/`datetime`/`time` | `z.enum(['string','number','date','boolean','select'])` | `FilterValueFamily` — `custom/filter-builder.tsx:406` — folded from a column's `type` by `valueFamilyForFieldType`, drawn by `FILTER_INPUT_TYPE_BY_FAMILY` |
| group `{ id, logic, conditions }` | `FilterGroupSchema` is **`{ operator, conditions }`** | `isValidGroup`, `custom/filter-builder.tsx:1060` — `Array.isArray(v.conditions) && (v.logic === "and" \|\| v.logic === "or")` |

All five `components-complex-filter-builder/*` entries author the spellings the renderer reads. Four refuse at the root (`objectui check` runs `safeValidateSchema` on the ROOT only — `packages/cli/src/commands/check.ts:137` — so `search-interface`, which roots at `stack`, is not one of the four, while the `filter-builder` it wraps refuses on its own).

## The presupposition check — what did NOT hold

The card asked for this explicitly, and two of the row's presuppositions failed.

**1. The six-member "type switch" is the value-FAMILY switch, not the field-`type` vocabulary.** The card read the cases at `custom/filter-builder.tsx:532-573`; that switch is `convertScalarToFamily(value, family)`, over `FilterValueFamily`. The live field-`type` vocabulary is wider — `numberLikeTypes = ["number","currency","percent","rating"]`, `dateLikeTypes`, `selectLikeTypes = ["select","status"]`, `lookupLikeTypes = ["lookup","master_detail","user"]`, `boolean`, and anything unrecognised falling to the text bucket.

Measured, one condition row per spelling, through the real `SchemaRenderer`:

| `type` | value control drawn |
|---|---|
| `text` / `string` / any unrecognised word | `input type="text"` |
| `number` / `currency` / `percent` / `rating` | `input type="number"` |
| `date` / `datetime` / `time` | `input type="date"` / `"datetime-local"` / `"time"` |
| `boolean` / `select` / `status` / `lookup` / `master_detail` / `user` | no `input` at all — an option-driven Select |

⇒ **`string` is a phantom** (indistinguishable from a nonsense spelling) and is dropped. ⇒ **`select` is RETAINED against a literal reading of the ruling.** The ruling inherits the finding card's description of `select` as "extra"; it is not — it has its own operator bucket and its own control, and this mirror accepts it *today*. Dropping it would refuse a live spelling, which is a fresh instance of the class #6939 exists to close. Flagged here rather than decided.

**2. The group's `id` has ZERO read sites.** `isValidGroup` gates on `conditions` and `logic` only; nothing reads `filterGroup.id`. Measured: deleting `id` from an authored group renders **byte-identically**. So `id` is declared but **optional** — requiring it would invent a refusal the renderer does not make. It stays declared (rather than dropped) because a plain `z.object` strips unknown keys in silence, so an undeclared `id` would be admitted unvalidated; declared, `id: 42` now refuses.

**A third declaration agrees with the renderer and against the mirror.** `content/docs/components/complex/filter-builder.mdx` has all along published `value: string`, `logic: 'and' | 'or'`, and a **fourteen**-member optional `type?`. `@object-ui/fields`' `deriveFilterFields` — the real producer that builds `fields` from an object schema — emits `{ value, label, type?, options?, referenceTo? }` and passes any object field type through except thirteen non-filterable ones. Pinned, so the claim is a reading.

## What this does NOT reach — declared, not left as an absence

- **A fourth divergence the ruling does not cover.** `product-search`, `with-conditions` and `search-interface`'s nested node author `conditions[].operator` as `eq` / `gt` / `lt`, while `FilterOperatorSchema` is the spec's canonical `equals` / `greater_than` / `less_than`. **2 of the 4 census entries validate after this change; the other 2 do not.** That is pinned mechanically rather than described — swapping only those three spellings makes both parse, so "the three ruled divergences are gone from all four" is measured. It is a genuine fork needing its own ruling: the builder's dropdown ids are `notEquals` / `greaterThan`, which this mirror also refuses, while the canonical spellings it accepts render a **blank** operator trigger (visible in `PRE_REPAIR` — `…CategoryRemove condition…` with no operator text).
- **Seven live field types stay refused** — `status`, `currency`, `percent`, `rating`, `lookup`, `master_detail`, `user`. Each draws a real control; each was refused *before* this change as well, so this is a pre-existing gap, not a regression introduced here. Widening to them is an accept-set change the ruling does not cover.
- **`type` stays required**, though the renderer and the published doc both treat it as optional. Same reason.

Each of the three is pinned with an assertion, so the gap is a recorded decision rather than an absence, and each is filed rather than left in prose:

- **#7561** — the operator-vocabulary fork (the residual refusal on 2 of the 4 census entries).
- **#7562** — the seven live field types, the `type` optionality, and the condition-level `id` the mirror omits.

## The pin — both halves

**Validator** — `packages/types/src/__tests__/filter-builder-mirror-6939.test.ts` (39 assertions): the ruled spellings accept, the old ones refuse, the residual operator refusal is isolated, the unruled gaps are recorded, and the published doc is read off disk.

**Render** — `examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx` (43 assertions): all five tiles measured **through `SchemaRenderer` directly**, never through a parse-then-render path — at base four of the five fail validation, so a validating path has no "before" to measure. `PRE_REPAIR` was taken on `origin/main` `3e01cb55f` with both faces untouched: element count, tag census, `textContent`, and its SHA-256.

| entry | elements | textContent SHA-256 |
|---|---|---|
| `empty-filter-builder` | 11 | `4f7116e4…` |
| `product-search` | 76 | `708dab4e…` |
| `search-interface` | 65 | `31b9cb48…` |
| `user-filters` | 11 | `bc346672…` |
| `with-conditions` | 57 | `23cdc026…` |

All five identical after. Plus the #6318 discriminators, re-measured rather than quoted:

- `value` → `name`: **the field is lost** — `…Clear allCategoryRemove condition…` becomes `…Clear allRemove condition…`, every field trigger goes blank, and a non-text column additionally degrades to a text box (`search-interface`: 65 → 62).
- group `{id,logic,…}` → `{operator,…}`: **the board empties** — 76 elements and three rows become 11 and none.
- `text` → `string`: **identical** — the phantom.
- group `id` deleted: **identical** — the zero-read-site measurement.

## Verification

| run | result |
|---|---|
| `pnpm exec vitest run packages/types/ examples/schema-catalog/test/filter-builder-mirror-6939.test.tsx` | **101 files, 1743 tests passed**, at `3c54edb28` |
| `pnpm --filter @object-ui/types --filter @object-ui/components --filter @object-ui/react --filter @object-ui/example-schema-catalog run type-check` | 4/4 `Done`, at `3c54edb28` |
| `tsc -p packages/types/tsconfig.test.json --listFiles` | `zod-mirror-parity.test.ts` and the new pin are both IN the program — the parity ledger's compile-time `assertionDriftMatchesLedger` is a reading, not a not-run |
| `pnpm --filter @object-ui/types --filter @object-ui/example-schema-catalog run lint` | both `Done`, **0 errors** (268 pre-existing warnings in types) |
| `check:control-bytes`, `check:changeset-*`, `check:doc-types`, `check:doc-snippets`, `check:doc-fences`, `check:designer-field-key-parity`, `check:spec-symbols`, `check:vi-mock-inherit`, `check:vi-mock-specifiers`, `check:published-tsconfig-exclude`, `check:readme-exports`, `check:self-import`, `check:phantom-deps`, `check:dist-completeness` | all green (`check:doc-snippets` and `check:readme-exports` only after building what they need — both were `PRECONDITION NOT MET` on an unbuilt closure first) |

**The parity ledger did not move.** `FilterFieldSchema`'s `KnownDrift` entry stays `'operators'` and `FilterBuilderSchema`'s stays `'fields' \| 'onChange'`, because both faces moved in lockstep; `FilterGroupSchema` / `FilterBuilderConditionSchema` are `EXCLUSIONS` (recursive `z.ZodType<any>`, no `.shape`). No count in that file is touched, so #7433's header defect is not compounded here.

**Reverse verification** — prediction written before the run.

- *Leg A*, mirror only reverted to the pre-repair shape (mutation proven on disk: three injected anchors at 1, three removed at 0, blob `5c5c9aa3…` ≠ HEAD `b0503d08…`): validator pin **22 failed / 17 passed**. Predicted 23; the one that stayed green is the assertion that the former `name` spelling is REFUSED, and the reason is worth recording — under the old enum `{ name, label, type: 'text' }` refuses for the *wrong* reason (`text` is not in `['string','number','date','boolean','select']`), which is why that assertion cannot carry the claim on its own.
- *Leg A control*: the render pin is **43/43 green under the same mutation** — it is legal in both states and cannot redden for the mirror change.
- *Leg B*, TS twin only reverted (blob `41f6a22d…` ≠ HEAD `68d79a4a…`): `tsc -p packages/types/tsconfig.test.json` → 6 errors, 4 on the type pins and **2 on `zod-mirror-parity.test.ts`** — the ledger reddens the moment the faces stop moving together.
- Both restores proven by STATE, not by exit code: `git diff HEAD` empty AND the worktree blob equal to the HEAD blob, for both files.
- Every assertion that changes verdict is paired with a carrier legal in BOTH states — a document carrying `name` *and* `value`, `operator` *and* `logic`, and `type: 'select'` (a member of both enums) — so a red run cannot be misread as unrelated breakage.

**Declared narrowings.**

1. `check:sdui-registration-pins` was NOT run: `PRECONDITION NOT MET` — it needs an `apps/console` production build. What it could have caught that this diff introduces: a change in registration weight or eager closure. This diff registers nothing and edits no registration; the only `filter-builder` registration is untouched.
2. Repo-wide `pnpm lint` was replaced by the two affected packages' own `lint` (which is exactly what `turbo run lint` invokes for them). ESLint here is not type-aware, so this diff cannot move a verdict on a file it does not touch.
3. Only `@object-ui/types`, `@object-ui/components`, `@object-ui/react` and `@object-ui/example-schema-catalog` were type-checked. The renamed keys have no other in-repo consumer: every `FilterGroup` in this repo imports `@object-ui/components`' own interface, and the sole `@object-ui/types` import of `FilterBuilderSchema` is `renderers/complex/filter-builder.tsx`.

CI runs the full farm.

## Changeset

`@object-ui/types`: **`minor`**, not the `patch` the ruling grades this class. Measured, the accept set does not only widen — three refusal classes are created, each a document that validated before: `fields[].name` as the field key; `type: 'string'`; and `{ operator, conditions }` as the group shape. `major` is forbidden here (`check-changeset-no-major`), so a breaking change is `minor`. Every refusal class is named in the changeset, with its migration (a document carrying both key spellings validates in either state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC


---
_Generated by [Claude Code](https://claude.ai/code)_