### PR TITLE
docs(ci-cd-pipeline): document the MARKED_FLOOR shrink-only ratchet

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -637,6 +637,20 @@ ratchet, not an allowlist: a row whose red goes away fails as **stale** and must
 row is a judgement about the guide (one of them faithfully restates a platform type that really is
 `any`), so the rows are declared debt rather than a mechanical unmark.
 
+**`MARKED_FLOOR` is a second shrink-only ratchet, per category**
+([#7550](https://github.com/objectstack-ai/objectui/issues/7550)): the script also floors the
+*marked* population itself, one number per fence category, seeded at what `main` carried when it
+landed — `ts: 17`, `json: 39` — and printed beside its own count on every run: `Marked: 17 ts
+fence(s) (floor 17), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY.` A category whose
+marked count falls below its floor exits 1 naming the category, the count, the floor and the two
+legal moves. It is a **floor**, not an exact pin, because the two directions are not symmetric:
+marking one more fence is the direction this gate exists to travel, and an equality that reds on
+that move is one people learn to route around — by unmarking, which is exactly the move this floor
+exists to catch. Only the downward move needs a witness — raise the number in the pull request that
+adds marks; lower it, in the *same* pull request that removes one, with the reason written beside
+the constant: which example stopped being one, and why unmarking it was the honest call rather than
+the cheap way out of a red.
+
 **It scans `.claude/skills/` too** ([#7463](https://github.com/objectstack-ai/objectui/issues/7463)):
 `SCAN_ROOTS` holds `skills` and `.claude/skills`, the same widening `check-skills-paths.mjs` took in
 [#7358](https://github.com/objectstack-ai/objectui/issues/7358). When #7251 moved the two
@@ -666,8 +680,11 @@ the failure shape this gate family exists to prevent
 
 **If it fails:** it prints `file:line` for every failing fence with the compiler's own diagnostic, or
 the JSON parser's message, or the orphan marker's line, or — for a bare `any` — the position and the
-verbatim baseline row to declare if the fix belongs to a later card. Fix the example — or, if it was never meant
-to stand alone, remove its marker rather than weakening the gate. Run it locally with
+verbatim baseline row to declare if the fix belongs to a later card, or — for a floor breach — the
+category, the count, the floor and the two legal moves. Fix the example — or, if it was never meant
+to stand alone, remove its marker **and lower `MARKED_FLOOR` for that category in the same pull
+request**, with the reason written beside the constant: a marker deleted without that edit is a
+silent unmark, exactly the move this floor exists to catch. Run it locally with
 `pnpm check:skill-examples`, `node scripts/check-skill-examples.mjs --list` to see every candidate
 fence and its verdict, and `--measure` to judge every candidate whether marked or not.
 


### PR DESCRIPTION
Fixes #7552

## What changed

One file, one section: `content/docs/guide/ci-cd-pipeline.md`, the Skill Example Check
section. Two edits, exactly as scoped in the card's triage:

1. A new paragraph beside the existing `KNOWN_BARE_ANY_EXAMPLES` one, documenting the
   second shrink-only ratchet PR #7553 added (`MARKED_FLOOR`):

   > **`MARKED_FLOOR` is a second shrink-only ratchet, per category**
   > ([#7550](https://github.com/objectstack-ai/objectui/issues/7550)): the script also
   > floors the *marked* population itself, one number per fence category, seeded at
   > what `main` carried when it landed — `ts: 17`, `json: 39` — and printed beside its
   > own count on every run: `Marked: 17 ts fence(s) (floor 17), 39 json fence(s) (floor
   > 39) — the floor is ⛔ SHRINK-ONLY.` A category whose marked count falls below its
   > floor exits 1 naming the category, the count, the floor and the two legal moves. It
   > is a **floor**, not an exact pin, because the two directions are not symmetric:
   > marking one more fence is the direction this gate exists to travel, and an equality
   > that reds on that move is one people learn to route around — by unmarking, which is
   > exactly the move this floor exists to catch. Only the downward move needs a witness
   > — raise the number in the pull request that adds marks; lower it, in the *same*
   > pull request that removes one, with the reason written beside the constant: which
   > example stopped being one, and why unmarking it was the honest call rather than the
   > cheap way out of a red.

2. The "If it fails" paragraph rewritten so removing a marker is named as the
   floor-lowering move (with its reason), never a silent unmark:

   > **If it fails:** it prints `file:line` for every failing fence with the compiler's
   > own diagnostic, or the JSON parser's message, or the orphan marker's line, or —
   > for a bare `any` — the position and the verbatim baseline row to declare if the fix
   > belongs to a later card, or — for a floor breach — the category, the count, the
   > floor and the two legal moves. Fix the example — or, if it was never meant to
   > stand alone, remove its marker **and lower `MARKED_FLOOR` for that category in the
   > same pull request**, with the reason written beside the constant: a marker deleted
   > without that edit is a silent unmark, exactly the move this floor exists to catch.
   > Run it locally with `pnpm check:skill-examples`, `node
   > scripts/check-skill-examples.mjs --list` to see every candidate fence and its
   > verdict, and `--measure` to judge every candidate whether marked or not.

The seeded numbers (`ts: 17`, `json: 39`) are not typed from the card or from PR #7553's
body — they are read off `MARKED_FLOOR` in `scripts/check-skill-examples.mjs` on this
tree and confirmed by running the gate on a built tree, whose own report line matches
exactly (see the gate table below).

No script edit, no other page, no marker change — the diff is 19 insertions / 2
deletions in one file.

## Pin-suite reading

The page's own pin suite, `scripts/__tests__/ci-cd-pipeline-doc.test.ts`, does **not**
pin any sentence of the Skill Example Check section verbatim — it pins the workflow
inventory table, the console budget, the lockfile-merge-driver section, and a few other
tables/sections, none of which this diff touches. The only pins that read this section
at all are in *other* files and only check that a heading containing `skill-examples.yml`
exists (`scripts/__tests__/check-skill-examples.test.ts:587`) — unrelated to the two
paragraphs edited here, and still true (`## Skill Examples (`skill-examples.yml`)` is
untouched). So no pinned sentence needed moving; none was moved.

## Gates — verdict lines, run on head `715f5b3` after the final commit

| gate | exit | verdict line |
|---|---|---|
| `pnpm vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` | 0 | `Test Files  1 passed (1)` / `Tests  36 passed (36)` |
| `pnpm check:skill-examples` (built tree) | 0 | `Marked: 17 ts fence(s) (floor 17), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY. ...` then `Every marked skill example holds up against the built types.` |
| `pnpm check:doc-fences` | 0 | `✅  check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s) of objectui#5867's remaining population (⛔ SHRINK-ONLY). No unknown fence spelling hides one.` |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `pnpm check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 6225 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `pnpm vitest run scripts/__tests__/check-skill-eval-tokens.test.ts` | 0 | `Test Files  1 passed (1)` / `Tests  36 passed (36)` (its own heading-pin on this same page, unaffected) |

⚠️ Naming note: the dispatch listed `pnpm check:doc-links`, but `package.json` has no
such script (`docs:check-links` is the registered one, both wired to
`scripts/check-doc-links.mjs`) — ran the underlying `node scripts/check-doc-links.mjs`
directly and confirmed against `package.json` before treating this as "ran the named
gate" rather than a typo'd no-op.

Every exit code was captured before any pipe (command redirected to a file; `EXIT=$?`;
then read the file), never read through one.

Local scope, per objectstack's os-dev contract (objectui has no `scripts/pm/` gate
derivation tool, and no verify-lock script — confirmed absent): the page's own pin
suite plus the gates the dispatch named. `pnpm lint` does not cover markdown in this
repo (`eslint.config.js` has no rule targeting `.md`), so it is not part of this diff's
verification.

## Changeset

None owed, and none added — docs-only change, no package source or published contract
moved. `node scripts/check-changeset-presence.mjs`: `1 file(s) changed, 0 of them
published source of a package the release covers ... ✅ No source or published contract
of a released package changed in this range, so no changeset is owed.`

## Scope

Not governed (`content/docs`), no `skills/**` — opened as a draft for the seat to
review, flip ready and arm auto-merge, per the claim comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_