### PR TITLE
fix(types): one authority for MenuItem and ValidationFunction (objectui#6349 batch 2)

### DIFF
--- a/.changeset/6349-types-internal-name-collisions-batch-2.md
+++ b/.changeset/6349-types-internal-name-collisions-batch-2.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/types': minor
+---
+
+The last two exported type names with two authorities *inside* `@object-ui/types` now have
+one each (objectui#6349, second batch — the remaining intra-package collisions from the
+census on objectui#6273). Both took the **rename** branch, because in both cases the two
+declarations are genuinely different types; the surviving spelling is in each case the name
+`src/index.ts` has always published that declaration under, so **no importable name
+changes** and the barrel alias becomes a plain re-export.
+
+**`MenuItem` — renamed to `AppMenuItem` in `app.ts`.** `app.ts` declared a flat,
+all-optional `interface` (`type?: 'item' | 'group' | 'separator'`, `label`, `icon`, `path`,
+`href`, `children`, `badge`, `hidden`) — the `@deprecated` legacy navigation item that
+`AppComponentSchema.menu`, `AppAction.items` and `menuItemToNavigationItem` read.
+`overlay.ts` declared a discriminated **union**, `MenuCommandItem | MenuDividerItem`, whose
+command arm requires `label` and whose both arms **tombstone** `type` as `type?: never`
+(objectui#6523) — precisely the key `app.ts` declares as a three-value enum. Re-pointing
+either at the other would have made an authored `type: 'separator'` legal on one side and a
+type error on the other, so the two names had to part. `@object-ui/types` continues to
+publish overlay's union as `MenuItem` and app's interface as `AppMenuItem`, exactly as
+before.
+
+**`ValidationFunction` — renamed to `FieldValidationFunction` in `field-types.ts`.**
+`data-protocol.ts` declares `(value, context?: ValidationContext) => boolean | string`;
+`field-types.ts` declared `(value) => boolean | string | Promise<boolean | string>`. They
+disagree at both ends of the arrow — different parameter lists, and a `Promise` return that
+the data-protocol signature does not admit — so field-types' is not assignable to
+data-protocol's in the direction that matters. `data-protocol.ts` had said so in prose ("may
+differ from similarly named validation function types in other packages (e.g., in
+`field-types`)") for as long as both existed. The published names `ValidationFunction`
+(data-protocol's) and `FieldValidationFunction` (field-types') are unchanged.
+
+Both `KNOWN_COLLISIONS` lines come down in the same change; that baseline fails in **both**
+directions, so converging without deleting them is red too. 38 entries -> 36.

--- a/content/docs/core/app-schema.mdx
+++ b/content/docs/core/app-schema.mdx
@@ -89,16 +89,16 @@ topic; the declaration remains the complete list.
 
 ### Navigation Menu
 
-The `menu` property accepts an array of `MenuItem` objects:
+The `menu` property accepts an array of `AppMenuItem` objects:
 
 ```ts
-interface MenuItem {
+interface AppMenuItem {
   type?: 'item' | 'group' | 'separator';
   label?: string;
   icon?: string;          // Lucide icon name
   path?: string;          // Route path
   href?: string;          // External link
-  children?: MenuItem[];  // Submenu items
+  children?: AppMenuItem[];  // Submenu items
   badge?: string | number;
   hidden?: boolean | string; // Visibility condition
 }
@@ -143,7 +143,7 @@ The `actions` property defines global toolbar buttons:
 
 ```ts
 // `AppAction.items` uses the navigation-item shape documented under "Navigation
-// Menu" above, which the barrel exports as `AppMenuItem`. The bare `MenuItem`
+// Menu" above — declared and published as `AppMenuItem`. The bare `MenuItem`
 // export is the unrelated overlay menu type used by `ui:dropdown-menu`.
 import type { AppMenuItem } from '@object-ui/types';
 

--- a/packages/types/src/__tests__/navigation-model.test.ts
+++ b/packages/types/src/__tests__/navigation-model.test.ts
@@ -2,7 +2,7 @@
  * Tests for Unified Navigation Model
  * 
  * Validates NavigationItem, NavigationArea types, Zod schemas,
- * and the MenuItem → NavigationItem transform.
+ * and the AppMenuItem → NavigationItem transform.
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -11,7 +11,7 @@ import {
   NavigationAreaSchema,
 } from '../zod/index.zod';
 import { menuItemToNavigationItem } from '../app';
-import type { MenuItem, NavigationItem, NavigationArea } from '../app';
+import type { AppMenuItem, NavigationItem, NavigationArea } from '../app';
 
 // ============================================================================
 // NavigationItem Zod Schema
@@ -288,12 +288,12 @@ describe('AppComponentSchema with unified navigation', () => {
 });
 
 // ============================================================================
-// MenuItem → NavigationItem Transform
+// AppMenuItem → NavigationItem Transform
 // ============================================================================
 
 describe('menuItemToNavigationItem', () => {
   it('should convert a simple path-based item', () => {
-    const menuItem: MenuItem = {
+    const menuItem: AppMenuItem = {
       type: 'item',
       label: 'Dashboard',
       icon: 'LayoutDashboard',
@@ -309,7 +309,7 @@ describe('menuItemToNavigationItem', () => {
   });
 
   it('should convert an external link item', () => {
-    const menuItem: MenuItem = {
+    const menuItem: AppMenuItem = {
       type: 'item',
       label: 'Docs',
       href: 'https://docs.example.com',
@@ -322,7 +322,7 @@ describe('menuItemToNavigationItem', () => {
   });
 
   it('should convert a group with children', () => {
-    const menuItem: MenuItem = {
+    const menuItem: AppMenuItem = {
       type: 'group',
       label: 'Sales',
       children: [
@@ -341,7 +341,7 @@ describe('menuItemToNavigationItem', () => {
   });
 
   it('should convert a separator', () => {
-    const menuItem: MenuItem = { type: 'separator' };
+    const menuItem: AppMenuItem = { type: 'separator' };
 
     const result = menuItemToNavigationItem(menuItem, 3);
     expect(result.type).toBe('separator');
@@ -349,7 +349,7 @@ describe('menuItemToNavigationItem', () => {
   });
 
   it('should invert hidden to visible', () => {
-    const menuItem: MenuItem = {
+    const menuItem: AppMenuItem = {
       type: 'item',
       label: 'Admin',
       path: '/admin',
@@ -361,7 +361,7 @@ describe('menuItemToNavigationItem', () => {
   });
 
   it('should preserve badge', () => {
-    const menuItem: MenuItem = {
+    const menuItem: AppMenuItem = {
       type: 'item',
       label: 'Notifications',
       path: '/notifications',
@@ -373,7 +373,7 @@ describe('menuItemToNavigationItem', () => {
   });
 
   it('should handle item without explicit type', () => {
-    const menuItem: MenuItem = {
+    const menuItem: AppMenuItem = {
       label: 'About',
       path: '/about',
     };

--- a/packages/types/src/__tests__/navigation-spec-parity.test.ts
+++ b/packages/types/src/__tests__/navigation-spec-parity.test.ts
@@ -154,7 +154,7 @@ describe('referencing the spec NavigationItemSchema would reject metadata object
     ['defaultOpen', { id: 'grp', type: 'group', label: 'G', children: [], defaultOpen: true },
       'the legacy spelling this file keeps accepting for published metadata'],
     ['visible: boolean', { id: 'ai', type: 'url', label: 'AI', url: '/ai', visible: true },
-      'menuItemToNavigationItem MANUFACTURES one when it inverts MenuItem.hidden'],
+      'menuItemToNavigationItem MANUFACTURES one when it inverts AppMenuItem.hidden'],
     ['separator label', { type: 'separator', label: 'Section' },
       'menuItemToNavigationItem emits one; the spec separator declares only id/order'],
     ['single-character id', { id: 'a', type: 'url', label: 'A', url: '/a' },

--- a/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
+++ b/packages/types/src/__tests__/page-nav-misc-spec-parity.test.ts
@@ -240,7 +240,7 @@ describe('NavigationArea derives from the spec', () => {
     // whether an objectui area's items still carry semantics the spec's type
     // rejects. `visible: boolean` is the sharpest of the three blockers
     // (`menuItemToNavigationItem` MANUFACTURES one from legacy
-    // `MenuItem.hidden`), and it is the one that fails first if someone tries
+    // `AppMenuItem.hidden`), and it is the one that fails first if someone tries
     // to inherit `navigation`. The umbrella verdict and the other two blockers
     // are pinned per-key in `spec-derived-unions.test.ts`; when they lift,
     // that file fails and sends the reader back here.

--- a/packages/types/src/__tests__/spec-derived-unions.test.ts
+++ b/packages/types/src/__tests__/spec-derived-unions.test.ts
@@ -239,7 +239,7 @@ const _localNavIsNotYetTheSpecUnion = false satisfies [NavigationItem] extends [
 // 1. `visible: boolean`. The spec takes a CEL string (input) / Expression
 //    envelope (output); neither tier admits a boolean. `NavigationRenderer`
 //    evaluates one, and `menuItemToNavigationItem` MANUFACTURES one when it
-//    inverts legacy `MenuItem.hidden`. Measured: binding to the input tier
+//    inverts legacy `AppMenuItem.hidden`. Measured: binding to the input tier
 //    fails with 3x TS2322 on exactly those lines.
 type SpecNavVisible =
   | NonNullable<Extract<SpecNavigationItem, { type: 'url' }>['visible']>

--- a/packages/types/src/app.ts
+++ b/packages/types/src/app.ts
@@ -15,7 +15,7 @@
  * ## Navigation Model
  * 
  * ObjectUI uses a unified `NavigationItem` model aligned with @objectstack/spec.
- * The legacy `MenuItem` type is retained for backward compatibility but new
+ * The legacy `AppMenuItem` type is retained for backward compatibility but new
  * configurations should use `NavigationItem` and the `navigation` / `areas` fields.
  */
 
@@ -31,7 +31,7 @@
 //      already recorded in `__tests__/navigation-spec-parity.test.ts`.
 //   2. Three semantics the spec has at NEITHER tier: `visible: boolean` (the
 //      spec takes only a CEL string / Expression envelope, yet
-//      `menuItemToNavigationItem` below inverts legacy `MenuItem.hidden` into
+//      `menuItemToNavigationItem` below inverts legacy `AppMenuItem.hidden` into
 //      a boolean), `pinned` (backs `useNavPins` + `FavoritesProvider`), and the
 //      legacy `defaultOpen` spelling. Binding deletes all three from the type
 //      while their implementations keep running.
@@ -77,7 +77,7 @@ export type NavigationItemType = SpecNavigationItem['type'];
  * Unified Navigation Item
  * 
  * The single navigation primitive used across ObjectUI and @objectstack/spec.
- * Replaces the legacy `MenuItem` for application navigation trees.
+ * Replaces the legacy `AppMenuItem` for application navigation trees.
  * 
  * Supports typed navigation targets (object, dashboard, page, report, url),
  * nested groups, visibility expressions, RBAC permissions, and UX enhancements
@@ -229,7 +229,7 @@ export interface NavigationItem {
    * envelope `{ dialect, source }` on output — `boolean` is absent at BOTH
    * tiers. `NavigationRenderer`'s `evalVis(item.visible)` honours the boolean,
    * and `menuItemToNavigationItem` produces one when mapping legacy
-   * `MenuItem.hidden`. Pinned in `spec-derived-unions.test.ts`, which fails the
+   * `AppMenuItem.hidden`. Pinned in `spec-derived-unions.test.ts`, which fails the
    * day the spec accepts a boolean and this can come off it.
    */
   visible?: boolean | string;
@@ -423,7 +423,7 @@ export interface AppComponentSchema extends BaseSchema {
    * Global Navigation Menu
    * @deprecated Use `navigation` instead. Retained for backward compatibility.
    */
-  menu?: MenuItem[];
+  menu?: AppMenuItem[];
 
   /**
    * Unified navigation tree (aligned with @objectstack/spec NavigationItem model).
@@ -451,14 +451,14 @@ export interface AppComponentSchema extends BaseSchema {
 }
 
 // ============================================================================
-// Legacy MenuItem (backward compat — prefer NavigationItem)
+// Legacy AppMenuItem (backward compat — prefer NavigationItem)
 // ============================================================================
 
 /**
  * Navigation Menu Item
  * @deprecated Use `NavigationItem` instead.
  */
-export interface MenuItem {
+export interface AppMenuItem {
   /**
    * Item Type
    */
@@ -487,7 +487,7 @@ export interface MenuItem {
   /**
    * Child Items (Submenu)
    */
-  children?: MenuItem[];
+  children?: AppMenuItem[];
 
   /**
    * Badge / Count
@@ -501,11 +501,11 @@ export interface MenuItem {
 }
 
 // ============================================================================
-// MenuItem → NavigationItem Transform
+// AppMenuItem → NavigationItem Transform
 // ============================================================================
 
 /**
- * Convert a legacy `MenuItem` to a `NavigationItem`.
+ * Convert a legacy `AppMenuItem` to a `NavigationItem`.
  * 
  * Mapping rules:
  * - `type: 'item'` → inferred from `href` (url) or `path` (page)
@@ -516,7 +516,7 @@ export interface MenuItem {
  * - `href` → `url` with `target: '_blank'`
  */
 export function menuItemToNavigationItem(
-  item: MenuItem,
+  item: AppMenuItem,
   index: number = 0,
 ): NavigationItem {
   const id = `migrated_${index}`;
@@ -734,7 +734,7 @@ export interface AppAction {
   /**
    * Dropdown Menu Items (for type='dropdown' or 'user')
    */
-  items?: MenuItem[];
+  items?: AppMenuItem[];
   /**
    * Keyboard shortcut
    */

--- a/packages/types/src/field-types.ts
+++ b/packages/types/src/field-types.ts
@@ -119,7 +119,7 @@ export interface BaseFieldMetadata {
   /**
    * Custom validation function or rules
    */
-  validate?: ValidationFunction | FieldConstraints;
+  validate?: FieldValidationFunction | FieldConstraints;
   
   /**
    * Field dependencies (Phase 3.2.3)
@@ -155,7 +155,7 @@ export type VisibilityCondition = {
 /**
  * Validation function type
  */
-export type ValidationFunction = (value: any) => boolean | string | Promise<boolean | string>;
+export type FieldValidationFunction = (value: any) => boolean | string | Promise<boolean | string>;
 
 /**
  * Validation rule type
@@ -167,7 +167,7 @@ export type FieldConstraints = {
   min?: number;
   max?: number;
   pattern?: string | RegExp;
-  custom?: ValidationFunction;
+  custom?: FieldValidationFunction;
 };
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -56,7 +56,7 @@ export type {
   NavigationItem,
   NavigationItemType,
   NavigationArea,
-  MenuItem as AppMenuItem,
+  AppMenuItem,
   AppWizardStepId,
   AppWizardStep,
   BrandingConfig,
@@ -445,7 +445,7 @@ export type {
 export type {
   BaseFieldMetadata,
   VisibilityCondition,
-  ValidationFunction as FieldValidationFunction,
+  FieldValidationFunction,
   TextFieldMetadata,
   TextareaFieldMetadata,
   MarkdownFieldMetadata,

--- a/scripts/__tests__/one-authority-per-exported-name-6273.test.ts
+++ b/scripts/__tests__/one-authority-per-exported-name-6273.test.ts
@@ -417,7 +417,15 @@ const KNOWN_COLLISIONS: ReadonlyMap<string, readonly string[]> = new Map([
   // `z.string()`, and every authored `type: 'markdown'` NODE in the repo supplies it.
   // So plugin-markdown re-points at the one authority in `@object-ui/types`
   // (objectui#6172).
-  ['MenuItem', ['packages/types/src/app.ts', 'packages/types/src/overlay.ts']],
+  // `MenuItem` sat here, colliding between `packages/types/src/app.ts` and
+  // `packages/types/src/overlay.ts`. The two are not one type measured twice:
+  // app's is a flat, all-optional `interface` whose `type` is
+  // `'item' | 'group' | 'separator'`; overlay's is a discriminated UNION
+  // (`MenuCommandItem | MenuDividerItem`) that TOMBSTONES that same key as
+  // `type?: never` (objectui#6523), so a re-point would have made an authored
+  // `type: 'separator'` legal on one side and a refusal on the other. That is
+  // the RENAME branch: app's declaration now spells `AppMenuItem`, the name
+  // `src/index.ts` always published it under (objectui#6349).
   ['MetadataTypeStatus', ['packages/app-shell/src/providers/MetadataProvider.tsx', 'packages/react/src/context/AppShellContext.tsx']],
   ['NamedActionDef', ['packages/plugin-grid/src/resolveBulkActions.ts', 'packages/plugin-grid/src/resolveLegacyRowActions.ts']],
   ['OrgTranslate', ['packages/app-shell/src/console/organizations/orgErrorMessage.ts', 'packages/app-shell/src/console/organizations/orgRoleLabel.ts']],
@@ -428,7 +436,17 @@ const KNOWN_COLLISIONS: ReadonlyMap<string, readonly string[]> = new Map([
   ['TranslateFn', ['packages/app-shell/src/providers/saveAdvisoryToast.ts', 'packages/app-shell/src/providers/writeWarningToast.ts', 'packages/fields/src/widgets/file-size-guard.ts']],
   ['UndoRedoState', ['packages/plugin-designer/src/hooks/useUndoRedo.ts', 'packages/types/src/ui-action.ts']],
   ['UserDataAdapter', ['packages/app-shell/src/context/UserStateAdapters.tsx', 'packages/data-objectstack/src/userState.ts']],
-  ['ValidationFunction', ['packages/types/src/data-protocol.ts', 'packages/types/src/field-types.ts']],
+  // `ValidationFunction` sat here, colliding between
+  // `packages/types/src/data-protocol.ts` and `packages/types/src/field-types.ts`.
+  // The two signatures disagree at both ends of the arrow — data-protocol's takes
+  // a second `ValidationContext` parameter and returns `boolean | string`, while
+  // field-types' takes the value alone and may also return a `Promise` — so
+  // field-types' is not assignable to data-protocol's at all, and data-protocol.ts
+  // had said so in prose ("may differ from similarly named validation function
+  // types in other packages (e.g., in `field-types`)") for as long as both
+  // existed. RENAME branch again: field-types' declaration now spells
+  // `FieldValidationFunction`, the name `src/index.ts` always published it under
+  // (objectui#6349).
   ['VersionEntry', ['packages/collaboration/src/useConflictResolution.ts', 'packages/plugin-designer/src/components/VersionHistory.tsx']],
   ['ViewSwitcherProps', ['packages/plugin-list/src/ViewSwitcher.tsx', 'packages/plugin-view/src/ViewSwitcher.tsx']],
   ['ViewType', ['packages/plugin-list/src/ViewSwitcher.tsx', 'packages/types/src/views.ts']],
@@ -568,10 +586,15 @@ describe('objectui#6273 — the matcher discriminates', () => {
         { rel: 'packages/types/src/index.ts', source: "export type { KanbanCard } from './complex';" },
         { rel: 'packages/plugin-kanban/src/index.tsx', source: "export type { KanbanCard } from '@object-ui/types';" },
       ],
-      // An alias publishing a name nothing else declares — the CURE the family
-      // cards apply, e.g. `MenuItem as AppMenuItem` (types/src/index.ts:59) and
-      // `ValidationFunction as FieldValidationFunction` (:429). It must stay
-      // green or the remedy reds.
+      // An alias publishing a name nothing else declares — the shape the family
+      // cards land on, spelled below as a synthetic corpus. Today's live
+      // instances are the `Spec*` family in `packages/types/src/index.ts`
+      // (`FormField as SpecFormField`, …), which republishes @objectstack/spec
+      // names this package also declares. ⚠️ The two aliases this comment used
+      // to point at are gone: objectui#6349 renamed the DECLARATIONS to
+      // `AppMenuItem` / `FieldValidationFunction`, which is what actually
+      // removed those collisions — an alias alone cures the barrel's ambiguity,
+      // not the two authorities behind it. It must stay green or the remedy reds.
       [
         { rel: 'packages/types/src/app.ts', source: 'export interface MenuItem { id: string }' },
         { rel: 'packages/types/src/index.ts', source: "export type { MenuItem as AppMenuItem } from './app';" },
@@ -703,8 +726,9 @@ describe('objectui#6273 — every exported schema name has exactly one authority
         '  Remedy: pick the ONE authority, and re-point the others at it —\n' +
         "  `export type { X } from '<the-owner>'` is a re-export, not a second declaration,\n" +
         '  and this gate does not count it. If the two shapes are genuinely different\n' +
-        '  things, rename one (the `MenuItem as AppMenuItem` pattern in\n' +
-        '  packages/types/src/index.ts:59 is this repo’s worked example).\n' +
+        '  things, rename the loser to the name the barrel already publishes it\n' +
+        '  under — `UIActionSchema`, `AppMenuItem` and `FieldValidationFunction`\n' +
+        '  (objectui#6349) are this repo’s worked examples.\n' +
         '  ⛔ KNOWN_COLLISIONS is SHRINK-ONLY: adding a line is not a supported way\n' +
         '  to make this pass.',
     ).toEqual([]);


### PR DESCRIPTION
Refs #6349

Clause-②: no

Second batch of objectui#6349: the two remaining collisions that live entirely inside `packages/types`, where a barrel consumer cannot disambiguate them. Same class and same reason as batch 1 (PR #6936, landed as `b84dc1854`). Nothing else from the ledger is touched.

## 1. Re-derived on the merge-base first — no delta

Merge-base `d4493fdbc`. Both collisions still exist exactly as the card's table names them, established two independent ways:

- Direct read: `packages/types/src/app.ts:461 export interface MenuItem` · `packages/types/src/overlay.ts:426 export type MenuItem = MenuCommandItem | MenuDividerItem`; `packages/types/src/data-protocol.ts:798 export type ValidationFunction` · `packages/types/src/field-types.ts:158 export type ValidationFunction`.
- The gate itself: it was green on the merge-base with both lines present, and it fails in the stale direction too, so a converged name could not have stayed listed.

Baseline size, printed rather than counted from an unverified pattern (the list is in the report): **38 entries before, 36 after**. ⚠️ Not 46 (the card body's 2026-08-25 reading), not 43, not 40, not 39 — those were true on earlier trees. The two names removed are exactly `MenuItem` and `ValidationFunction`, by set difference over the printed lists.

## 2. Shapes compared before picking an authority — both genuinely differ, so both are RENAMES

**`MenuItem` — the two are opposites on the same key.** `app.ts` declares a flat, all-optional `interface` (8 members) whose `type` is `'item' | 'group' | 'separator'`; it is the `@deprecated` legacy navigation item read by `AppComponentSchema.menu`, `AppAction.items` and `menuItemToNavigationItem`. `overlay.ts` declares a discriminated **union**, `MenuCommandItem | MenuDividerItem`, whose command arm requires `label` and whose **both** arms tombstone that same key as `type?: never` (objectui#6523, so that authoring it is a refusal rather than a silent no-op). Re-pointing either at the other would have made an authored `type: 'separator'` legal on one side and a type error on the other — the silent-change failure the fence exists against. Established by reading both declarations in full and by the acceptance probe in section 5, which shows a `type: 'separator'` literal accepted as the app shape and refused as the overlay shape on the same build.

**`ValidationFunction` — the signatures disagree at both ends of the arrow.** `data-protocol.ts`: value plus an optional `ValidationContext`, returning `boolean | string`. `field-types.ts`: value alone, and it may also return a Promise. field-types' function is therefore **not** assignable to data-protocol's type at all (the Promise return is not admitted) — measured by the negative control in section 5, which reds with `TS2322: Type 'Promise of boolean' is not assignable to type 'string | boolean'` on both builds. `data-protocol.ts` had recorded the divergence in prose ("may differ from similarly named validation function types in other packages (e.g., in `field-types`)") for as long as both existed.

**Which name survives — decided by the barrel, not by preference.** `src/index.ts` has always published app's declaration as `AppMenuItem` and field-types' as `FieldValidationFunction`; the card and the triage ruling both name those two aliases as this repo's worked examples. So the remedy is the batch-1 `UIActionSchema` move: the declaration takes the name the barrel already published it under, and the barrel alias becomes a plain re-export. ⚠️ Consequence worth stating plainly: the card's own "worked example" citation now points at aliases that no longer exist — because they became declarations. The gate's two citations of them are re-pointed in this PR for the same reason.

## 3. Consumers enumerated before re-pointing

- **`AppMenuItem`**: zero importers anywhere before this change other than the barrel alias itself. `MenuItem` from `app.ts` was used only inside `app.ts` (`:426`, `:490`, `:519`, `:737`) and by exactly one direct importer of the losing file, `packages/types/src/__tests__/navigation-model.test.ts` (`import type { MenuItem } from '../app'`), updated here.
- **`FieldValidationFunction`**: zero importers other than the barrel alias. `ValidationFunction` from `field-types.ts` was used only inside `field-types.ts` (`:122`, `:170`). No file outside `packages/types/src` imports either losing file directly.
- Consumers of the two **surviving** published names are untouched: `packages/components/src/renderers/overlay/{dropdown-menu,context-menu}.tsx` keep importing `MenuItem` (overlay's union) from `@object-ui/types`, and `packages/core/src/validation/validation-engine.ts` keeps importing `ValidationFunction` (data-protocol's) from `@object-ui/types`. Neither name moved.

## 4. What changed in the emitted `.d.ts`, and for whom

Built `@object-ui/types` from the merge-base sources and from head, then diffed the emitted declarations recursively (118 emitted `.d.ts`, 120 files verified complete each time).

- **3 files differ**: `app.d.ts`, `field-types.d.ts`, `index.d.ts`.
- **Every changed line is an identifier rename.** No member added, removed, retyped or made optional: `AppComponentSchema.menu`, `AppAction.items`, `menuItemToNavigationItem(item)`, `BaseFieldMetadata.validate` and `FieldConstraints.custom` all still resolve to the same declared shapes, now spelled `AppMenuItem` / `FieldValidationFunction`. In `index.d.ts` two alias re-export specifiers become plain ones.
- **The published name set is unchanged**: 681 exported names before, 681 after, `diff` reports zero lines. (Enumerated through the type checker over `dist/index.d.ts`, not by grep.)
- **For whom**: nobody. `app.ts` and `field-types.ts` are **not published subpaths** — `packages/types/package.json` `exports` lists `.`, `./base`, `./layout`, `./form`, `./data-display`, `./feedback`, `./overlay`, `./navigation`, `./complex`, `./data`, `./zod`, `./internal/retired-field-keys`, with no wildcard. The only door to either declaration is the root barrel, and the barrel's names are identical. This is exactly the distinction batch 1's contract review drew: there, the narrow copy was the sole authority **of a published subpath**, so deleting it moved that subpath's contract. Here there is no such subpath.

## 5. Clause-② determined by measurement, not by argument

Two probes compiled against the **built** `.d.ts` of each side (base build kept aside, head build fresh), direction predicted in writing first: identical on both.

- **Acceptance probe** (11 assignments: both arms of overlay's union, app's `type: 'separator'` and a nested `group`, a `Record` of `keyof AppMenuItem` to `string`, both validation signatures, and every published member that references a renamed declaration) — base **exit 0**, head **exit 0**.
- **Negative control** (an undeclared key on the app shape; a Promise-returning function assigned to the data-protocol signature) — base **exit 2**, head **exit 2**, the **same two errors at the same positions**: `TS2353` and `TS2322`.

⭐ The only observable delta in the entire probe run is the identifier **printed inside** the `TS2353` message: `does not exist in type 'MenuItem'` on base, `'AppMenuItem'` on head. Acceptance is unchanged in both directions, `keyof` is unchanged, the name set is unchanged, and no published subpath exposes a renamed declaration ⇒ **Clause-②: no**. (The PR stays draft and is not enqueued regardless, per the dispatch order.)

## 6. The gate is the instrument, and it is shown non-vacuous

⛔ No new assertion was written. `scripts/__tests__/one-authority-per-exported-name-6273.test.ts` fails in both directions, and both were exercised from a **committed** state, mutating the ledger (the fact) rather than the assertion, with `trap ... EXIT INT TERM` restoring by absolute path via `git checkout HEAD -- ...`:

- **Leg 1 — delete a line without converging.** Removed the still-live `ComponentMeta` entry. Predicted: red in the **fresh** direction. Mutation proved on disk: anchored line count 1 to 0, blob `e9959e30` to `0519f131`. Result: `Tests 1 failed | 10 passed (11)`, diagnostic `ComponentMeta — a NEW colliding name`. Restore proved by state: `git diff HEAD` empty, worktree blob equal to the HEAD blob, 0 modified paths.
- **Leg 2 — re-add a converged line.** Put `['MenuItem', ...]` back on top of the converged tree. Predicted: red in the **stale** direction, naming the sites that no longer collide. Mutation proved: anchored count 0 to 1, blob `e9959e30` to `f146fa4f`. Result: `Tests 1 failed | 10 passed (11)`, diagnostic `MenuItem — no longer collides at: packages/types/src/app.ts` / `packages/types/src/overlay.ts`. Restore proved by state, whole-tree `git status` empty. ⭐ This leg is the direct proof that this PR's convergence is real rather than a baseline edit.

The gate resolves through source (vitest runs the test file, and its scan reads tracked working-tree files), so no `dist/` rebuild is involved in either leg.

## 7. Verification

All commands run from the repo root; exit codes captured **before** any pipe (redirect-then-read); every verdict quoted is the tool's own. Final commit **`8a39491d1`**; the union below was re-run on that commit with a clean `git status`.

| check | result |
|---|---|
| `pnpm --filter @object-ui/types type-check` | exit 0 before and after. Script name echoed, expands to `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`, so test files are covered — proved with `--listFiles`: all 6 edited TypeScript files appear (1 hit each), including the 4 edited test files. |
| root-form vitest, identical file set before and after | before `Test Files 101 passed (101)` / `Tests 1711 passed (1711)`; after 101/101 and 1711/1711; re-run on `8a39491d1`: 101/101, 1711/1711. Scope: `scripts/__tests__/one-authority-per-exported-name-6273.test.ts` plus `packages/types/`. |
| `pnpm exec eslint .` (plain form, whole repo) | exit 0 — `11922 problems (0 errors, 11922 warnings)`. |
| `node scripts/check-changeset-presence.mjs` | red before the changeset, green after: `7 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`. |
| `node scripts/check-changeset-no-major.mjs` | `No changeset declares a major bump.` |
| `pnpm type-check:scripts` | exit 0 — covers the edited gate file under `scripts/__tests__/`. |
| `pnpm check:doc-snippets` | exit 0 after building the closure it asks for: `Semantic phase: 456 of 456 block(s) judged, 0 failed.` This is the gate that judges the edited `content/docs/core/app-schema.mdx` snippet. |
| `pnpm check:readme-exports` | exit 0 — `421 self-imports judged (421 real, 0 wrong-path, 0 fabricated)`. First run was `PRECONDITION NOT MET` (unbuilt packages), resolved by building, not by narrowing. |
| `pnpm check:control-bytes`, `check:doc-types`, `check:doc-fences`, `check:spec-symbols`, `check:action-forward-parity` | all exit 0. |
| `pnpm exec turbo run build` over the doc-snippet closure | 34 tasks successful. 13 packages compiled their own sources against the rebuilt `@object-ui/types` declarations, including `@object-ui/core` and `@object-ui/components` — the two packages that consume the surviving names. |
| `node scripts/check-governed-queue-guard.mjs --test ...` | `NOT GOVERNED — 10 path(s) checked against 5 governed surface(s); none matched.` |

**Declared narrowings**, one line each, with what each could have caught:

1. **Full-repo `pnpm test` not run** (the gate test plus `packages/types/` was). It could have caught a runtime regression in another package. Bounded here: this diff is type-level only with zero emitted JavaScript delta outside identifier names, no published name moved, and the 13 packages that compile against these declarations all built green.
2. **`pnpm type-check` for every workspace package not run individually.** It could have caught a downstream type error. Bounded by the turbo build above, which runs each package's own `tsc`, and by the acceptance probe showing zero acceptance change at the barrel.
3. **`packages/types/src/zod/` mirrors deliberately not renamed** (`app.zod.ts` still declares `MenuItemSchema`, published as `AppMenuItemSchema` by `zod/index.zod.ts`). Not an omission: zod schemas are `export const`, and the gate's stated bound is "Type-level names only … the value namespace is a different population with a different remedy". Renaming them would widen this batch past the card. The zod-mirror parity test keys its entries by file and const name (`app.zod.ts#MenuItemSchema`, `overlay.zod.ts#MenuItemSchema`), never derived from the TypeScript type name, so nothing there depends on the rename.

## 8. Files, and the two edits that are consequences of the rename rather than the rename itself

`packages/types/src/app.ts`, `packages/types/src/field-types.ts`, `packages/types/src/index.ts` (two alias specifiers become plain), `packages/types/src/__tests__/navigation-model.test.ts` (the one direct importer of the losing file), `scripts/__tests__/one-authority-per-exported-name-6273.test.ts` (the two baseline lines come down, replaced by tombstone comments in the file's existing convention), and a changeset.

Two more, both stale **because of this diff** rather than found lying around:

- `content/docs/core/app-schema.mdx` — the "Navigation Menu" section documented `interface MenuItem` for `AppSchema.menu`; that declaration is now `AppMenuItem`, which is also the name the page's own "Global Actions" block already used. The page's sentence distinguishing it from the unrelated overlay `MenuItem` export is kept.
- Three prose references to `MenuItem.hidden` in `packages/types/src/__tests__/` (`navigation-spec-parity`, `page-nav-misc-spec-parity`, `spec-derived-unions`) that name the renamed type.

⛔ Nothing else from the ledger was touched. `git diff --name-only` against the merge-base does not include `packages/types/src/complex.ts`, `packages/types/src/base.ts`, or any `plugin-kanban` file — the three fenced areas (objectui#6155 / #6172, objectui#7560 / #7561, and the hot `base.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_