### PR TITLE
fix(skills): retire the four root-devdep rows by unmarking their fences

### DIFF
--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -145,10 +145,14 @@
  * report of what the bound refuses, and the harness's new ROOT-DECLARED control
  * is what proves on every run that it is still being applied.
  *
- * ⚠️ A refused fence is NOT type-checked. The four pre-existing ones are carried
- * in the shrink-only `KNOWN_ROOT_DEVDEP_EXAMPLES` below so the bound landed with
- * zero new red, and the `Root bound` and `Semantic phase` lines both say how
- * many fences that costs — a declared row is uncovered debt, never a green.
+ * ⚠️ A refused fence is NOT type-checked. The four pre-existing ones were
+ * carried in the shrink-only `KNOWN_ROOT_DEVDEP_EXAMPLES` below so the bound
+ * landed with zero new red, and the `Root bound` and `Semantic phase` lines both
+ * say how many fences that costs — a declared row is uncovered debt, never a
+ * green. Those four were retired in objectui#7557 by unmarking their fences, so
+ * that list is now EMPTY and the bound refuses nothing; see its docblock for the
+ * measurement that chose unmarking over declaring, and for when a NEW row is
+ * still the right answer.
  *
  * The cost of that decision is the PRECONDITION, and it is a declared exit code
  * rather than a silent green: if a package a marked fence imports has no `dist`,
@@ -276,11 +280,13 @@
  *      and guessing it is what produces a gate people learn to ignore.
  *   2. **Whether a REFUSED fence's example is correct.** The root bound says
  *      only that this gate cannot reach the package the fence imports, never
- *      that the fence is wrong — the four declared rows are good documentation
- *      about test runners the reader installs. Retiring a row means giving the
- *      example an import the reader provably has, or the guide's owner deciding
- *      the fence should not be gated; both are skills judgements over a GOVERNED
- *      surface, made in a skills PR.
+ *      that the fence is wrong — the four rows it once declared were good
+ *      documentation about test runners the reader installs, which is why
+ *      objectui#7557 retired them by unmarking the fences rather than by editing
+ *      the examples. Retiring a row means giving the example an import the
+ *      reader provably has, or the guide's owner deciding the fence should not
+ *      be gated; both are skills judgements over a GOVERNED surface, made in a
+ *      skills PR.
  *   3. **Whether an eval's `must_contain` token is taught by the guides.** A
  *      different oracle over a different corpus, discussed at length on
  *      objectui#7359 and explicitly not this check.
@@ -411,8 +417,11 @@ export const EXIT_CODES = {
  *     row — which example stopped being one, and why unmarking it was the
  *     honest call rather than the cheap way out of a red.
  *
- * There is no row-with-a-reason yet, because nothing has been unmarked since
- * the gate landed. The first one to lower a number writes it here.
+ * The first lowering is `ts` 17 -> 13 (objectui#7557), and its reason is on the
+ * row itself below. Read it as the worked example of what this section asks
+ * for: the four fences it names were marked over imports the harness cannot
+ * reach, so their marks were claims no run could honour — the honest move was
+ * to withdraw the claim in the guide, not to carry it as debt forever.
  *
  * ## What this floor counts, and what the OTHER ratchet counts
  *
@@ -430,7 +439,19 @@ export const EXIT_CODES = {
  * @type {ReadonlyMap<string, number>}
  */
 export const MARKED_FLOOR = new Map([
-  ['ts', 17],
+  // 17 -> 13 (objectui#7557): the four marked fences in
+  // `skills/objectui/guides/testing.md` that imported `vitest` (`:60`, `:94`,
+  // `:218`) or `@playwright/test` (`:258`) were unmarked, with the reason
+  // written beside each fence. Those two are TEST RUNNERS the reader installs
+  // in their own project and no package this repository publishes declares
+  // either, so the root bound refused all four and NOTHING type-checked them —
+  // their markers claimed a check that could not run, and the four rows in
+  // `KNOWN_ROOT_DEVDEP_EXAMPLES` below (now empty) were that claim's standing
+  // cost. Unmarking is the honest call here and not the cheap way out of a red:
+  // the marks were not hiding a broken example, they were over-stating this
+  // gate's reach, and the guide already carried five UNMARKED `vitest` fences
+  // beside them. ⛔ Not a precedent for unmarking a fence that reds.
+  ['ts', 13],
   ['json', 39],
 ]);
 
@@ -551,36 +572,46 @@ export function bareAnyRowKey(block, finding) {
  * same direction, and the same reasoning, as `KNOWN_BARE_ANY_EXAMPLES` above.
  *
  * The corpus at the bound's branch point was FOUR rows, all in one guide, all
- * measured before the bound was armed. Each one is real documentation the gate
- * cannot verify rather than a defect:
+ * measured before the bound was armed:
  *
- *   - `testing.md:60`, `:94`, `:218` import `vitest`, and `:258` imports
+ *   - `testing.md:60`, `:94`, `:218` imported `vitest`, and `:258` imported
  *     `@playwright/test`. Both are TEST RUNNERS the reader installs in their own
  *     project — the guide's first sentence names both — and no package this
- *     repository publishes declares either, so nothing in the map covers them.
- *     They compiled until now only because THIS repository carries both as root
- *     devDependencies, which is the leak the bound closed.
+ *     repository publishes declares either, so nothing in the map covered them.
+ *     They compiled until the bound only because THIS repository carries both as
+ *     root devDependencies, which is the leak the bound closed.
  *
- * ⛔ Why they are declared here rather than unmarked in the guide: the guides
- * under `skills/**` are a GOVERNED surface (see `AGENTS.md`), and removing a
- * marker to make a gate green is the "gate weakens the guide to suit itself"
- * move the shrink-only lists exist to prevent. It would also breach
- * `MARKED_FLOOR` above, which counts MARKS: a declared row here leaves the
- * marked population exactly where it was, because the fence is still marked —
- * these two ratchets count different things on purpose, and neither one
- * substitutes for the other. Retiring a row means giving the
- * example an import the reader provably has, or the guide's owner deciding the
- * fence should not be gated — either way a skills judgement, made in a skills
- * PR, not in this one.
+ * ## The list is EMPTY, and that is the terminal state (objectui#7557)
+ *
+ * All four rows are retired. The bound's own card left the choice to the guide's
+ * owner and it was made by MEASUREMENT rather than by taste: this gate reads
+ * exactly ONE declaration on a fence — `MARKER` above, an exact-string match on
+ * the whole line, with no reason field, no install field and no capture group —
+ * and `check-doc-snippet-types.mjs`'s `FRAGMENT_MARKER` is not read here at all.
+ * The bound itself (`resolvesOnlyThroughRootManifest`) is a pure function of the
+ * specifier and two repository-wide maps, with no per-block parameter to declare
+ * into. So there was no form in which a fence could keep its mark and name its
+ * install, and the four fences were unmarked in `testing.md` with the reason
+ * written beside each. `MARKED_FLOOR` above records the matching `ts` 17 -> 13.
+ *
+ * ⚠️ This is NOT the precedent it can be misread as. Unmarking to silence a red
+ * is the "gate weakens the guide to suit itself" move these shrink-only lists
+ * exist to prevent, and it stays refused. What was withdrawn here was different:
+ * a mark over a fence the harness REFUSES is a claim no run can honour — those
+ * four were type-checked by nothing at all for the whole of their life as rows,
+ * and the summary said so on every run. The two ratchets still count different
+ * things on purpose, and neither substitutes for the other.
+ *
+ * A NEW row may still be declared if the bound ever refuses a marked fence
+ * again — the machinery below is live, and `judge()` reds an undeclared refusal.
+ * But a row is uncovered debt, never a green, so the first question stays: can
+ * this example import what the reader provably has? Declare a row only when the
+ * answer is no AND the fence must keep its mark for some reason this comment
+ * does not anticipate; otherwise unmark it here, the way these four were.
  *
  * @type {ReadonlySet<string>}
  */
-export const KNOWN_ROOT_DEVDEP_EXAMPLES = new Set([
-  'skills/objectui/guides/testing.md:60 vitest',
-  'skills/objectui/guides/testing.md:94 vitest',
-  'skills/objectui/guides/testing.md:218 vitest',
-  'skills/objectui/guides/testing.md:258 @playwright/test',
-]);
+export const KNOWN_ROOT_DEVDEP_EXAMPLES = new Set([]);
 
 /** The debt-list key for one refused specifier in one fence. */
 export function rootDevDepRowKey(block, specifier) {

--- a/skills/objectui/guides/testing.md
+++ b/skills/objectui/guides/testing.md
@@ -56,7 +56,7 @@ describe('plugin-kanban registration', () => {
 
 ### Pattern 3: Schema validation testing
 
-<!-- os:check -->
+<!-- Not opted into the example gate: `vitest` is a test runner the reader installs in their own project, not a package this repository publishes, so there is nothing here to type-check this block against. -->
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { validateSchema, isValidSchema, formatValidationErrors } from '@object-ui/core';
@@ -90,7 +90,7 @@ describe('schema validation', () => {
 
 ### Pattern 4: Expression evaluation testing
 
-<!-- os:check -->
+<!-- Not opted into the example gate: `vitest` is a test runner the reader installs in their own project, not a package this repository publishes, so there is nothing here to type-check this block against. -->
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { ExpressionEvaluator } from '@object-ui/core';
@@ -214,7 +214,7 @@ describe('AuthProvider', () => {
 
 ### Pattern 7: DataSource adapter testing
 
-<!-- os:check -->
+<!-- Not opted into the example gate: `vitest` is a test runner the reader installs in their own project, not a package this repository publishes, so there is nothing here to type-check this block against. -->
 ```typescript
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ObjectStackAdapter } from '@object-ui/data-objectstack';
@@ -254,7 +254,7 @@ describe('ObjectStackAdapter', () => {
 
 ### Smoke test
 
-<!-- os:check -->
+<!-- Not opted into the example gate: `@playwright/test` is a test runner the reader installs in their own project, not a package this repository publishes, so there is nothing here to type-check this block against. -->
 ```typescript
 import { test, expect } from '@playwright/test';
 


### PR DESCRIPTION
Fixes #7557

Retires the four `KNOWN_ROOT_DEVDEP_EXAMPLES` rows the root-manifest bound (PR #7554) left behind, by unmarking the four fences in `skills/objectui/guides/testing.md` and lowering the `ts` floor to match.

> **A note on spelling in this body.** This repository has measured GitHub's body sanitizer eating tag-shaped fragments — backticks and fenced blocks do not protect them (AGENTS.md, "GitHub 会改写你写进 issue/PR 正文的字节"). The opt-in marker is an HTML comment, so quoting it literally here would delete the very thing under discussion. Throughout this body the marker is written **`os:check` wrapped in HTML-comment delimiters** rather than spelled out, and the same goes for the replacement lines. The file itself carries the real delimiters.

## The measurement that selected the option

The card offered two options and the ruling was to **measure first, then take the option the measurement selects**. The question: does `scripts/check-skill-examples.mjs` have a declaration form for a marked fence whose install the surrounding prose names — the docs gate's fragment mechanism, or any per-fence declaration the skills gate honours?

**Measured answer: no.** Three independent readings, all at this branch's base:

| what was read | finding |
|---|---|
| the fence collector, `scripts/check-skill-examples.mjs:769-782` | recognises exactly ONE declaration: `lines[markerLine].trim() === MARKER`. An exact-string equality on the whole trimmed line — no reason field, no install field, no capture group. There is no second form. |
| the string `fragment` in that file | occurs **twice**, at `:51` and `:274`, both in prose *describing the docs gate's opposite, opt-OUT design*. It never appears in code, so `check-doc-snippet-types.mjs`'s `FRAGMENT_MARKER` (`:737-738`) is not read by this gate at all. |
| the bound itself, `check-doc-snippet-types.mjs:1043-1050` | `resolvesOnlyThroughRootManifest(specifier, { paths, rootDeclared })` is a pure function of the specifier and two repository-wide maps. `compileSnippets` applies it per specifier at `:1285` with **no block-level parameter**. No marker of any spelling can widen it for one fence. |

And a fourth reading closes the remaining escape: even if the docs gate's fragment form *were* honoured here, `check-doc-snippet-types.mjs:1214` routes a block with a `fragmentReason` into `declaredFragments` — **away from** `compiled`. That is the same coverage loss as the row it would replace, under a different name; it cannot deliver option 1's "stay marked **and type-checked**".

⇒ **Option 2.**

## What changed

**1. `skills/objectui/guides/testing.md` — four fences unmarked, reason beside each.** Net zero lines: each marker line is replaced in place by a one-line HTML comment carrying its reason. The four sites are exactly the four rows:

| fence | import | section |
|---|---|---|
| `:60` | `vitest` | Pattern 3: Schema validation testing |
| `:94` | `vitest` | Pattern 4: Expression evaluation testing |
| `:218` | `vitest` | Pattern 7: DataSource adapter testing |
| `:258` | `@playwright/test` | Smoke test |

The reason text, carried as an HTML comment on the line the marker used to occupy (inner text quoted, delimiters spelled out per the note above):

> Not opted into the example gate: RUNNER is a test runner the reader installs in their own project, not a package this repository publishes, so there is nothing here to type-check this block against.

where RUNNER is `vitest` for the first three and `@playwright/test` for the fourth. After this edit `testing.md` carries **zero** markers — and it already carried five *unmarked* `vitest` fences (`:9`, `:33`, `:130`, `:173`, `:342`) beside the four marked ones, so unmarking makes the guide internally consistent rather than making it an exception.

**2. `scripts/check-skill-examples.mjs` — the four rows deleted.** `KNOWN_ROOT_DEVDEP_EXAMPLES` is now an empty `Set`. Its docblock records the measurement above, keeps the "gate weakens the guide to suit itself" rule intact as a still-live refusal, and states when a NEW row is still the right answer (the machinery is live; `judge()` still reds an undeclared refusal).

**3. `scripts/check-skill-examples.mjs` — `MARKED_FLOOR` `ts` 17 → 13, reason beside the row.** The move objectui#7550's ratchet allows only in the PR that removes the marks. The reason is written on the constant itself and says which examples stopped being ones and why this was the honest call, with an explicit ⛔ that it is not a precedent for unmarking a fence that *reds*: these four were type-checked by nothing at all for the whole of their life as rows.

No harness change: the root bound is untouched, no root-manifest exemption was added, and nothing changed about what a marked fence is checked against.

## Summary lines, before and after

Before (at base `e304a4e`):

```
Marked: 17 ts fence(s) (floor 17), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY. Unmarked fences are ignored by design (opt-in).
Root bound:     4 fence(s) refused (@playwright/test, vitest) and therefore NOT type-checked; 4 row(s) declared in KNOWN_ROOT_DEVDEP_EXAMPLES (⛔ SHRINK-ONLY, 4 row(s)), 0 NOT declared, 0 declared row(s) no longer refused.
Semantic phase: 13 of 17 ts fence(s) judged, 0 failed.

Every marked skill example the root bound could reach holds up against the built types — 4 declared row(s) in KNOWN_ROOT_DEVDEP_EXAMPLES were NOT reached, and this line does not speak for them.
```

After (at `f7de6dc`):

```
Marked: 13 ts fence(s) (floor 13), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY. Unmarked fences are ignored by design (opt-in).
Root bound:     no selected fence imports a specifier that resolves only through the repository's ROOT manifest.
Semantic phase: 13 of 13 ts fence(s) judged, 0 failed.

Every marked skill example holds up against the built types.
```

⚠️ **One deviation from the shape the card predicted, and it is in the gate's code, not in this change.** The card's clause 4 expected `Root bound: 0 fence(s) refused …; 0 row(s) declared …`. That wording is the gate's **non-zero branch** (`scripts/check-skill-examples.mjs:1354-1359`); when `run.boundFailures.length === 0` the gate takes a dedicated zero-branch sentence instead — the line quoted above. It asserts the same fact more strongly, and the `Marked:` and `Semantic phase:` lines match the prediction exactly. Editing the gate to emit the predicted string would have been changing a gate to suit a report, so it was not done.

The `Semantic phase` line is the one that measures this card: **13 of 17 → 13 of 13**. The marked population and the verified population are now the same set, and the closing line lost its caveat.

## Reverse verification: the floor lowering is load-bearing

Run from the committed state, so the restore leg has a real reference point. With the four fences left unmarked and **only** the floor put back to 17:

```
Marked: 13 ts fence(s) (floor 17), 39 json fence(s) (floor 39) …
❌  check:skill-examples — the MARKED population fell below its floor in 1 category:
  ts: 13 marked fence(s), floor 17 — 4 short
```

exit **1** (`examplesFailed`), the predicted direction. Mutation confirmed on disk before the run (`['ts', 13]` count 0, `['ts', 17]` count 1); restored under a `trap … EXIT INT TERM` using absolute paths, and the restore proven rather than assumed — `git diff HEAD` empty and `git hash-object` on the file equal to its HEAD blob `bf2d77b393230fb0ee43947512ab559df5bfa42b`.

## Gates

All run at head **`f7de6dc`**, exit code captured by redirect *before* any pipe. Verdict lines are the gates' own, not a reading of `$?`.

| gate | exit | its own verdict line |
|---|---|---|
| `pnpm check:skill-examples` | 0 | `Every marked skill example holds up against the built types.` |
| `node scripts/check-skill-examples.mjs --self-test` | 0 | `check-skill-examples self-test: 52 cases pass (marker adjacency both directions, orphans, nested illustration, json/jsonc, the bare-any guard in both directions with its shrink-only baseline, the ROOT BOUND in both directions with its own shrink-only baseline and control, and the compiler legs through the real harness).` |
| `pnpm check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| `pnpm exec vitest run scripts/__tests__/check-skill-examples.test.ts scripts/__tests__/check-skill-eval-tokens.test.ts` | 0 | `Test Files  2 passed (2)` / `Tests  117 passed (117)` |
| `pnpm check:skills-paths` | 0 | `✅  check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).` |
| `pnpm check:skill-eval-tokens` | 0 | `Every must_contain token is taught by its own skill bundle.` |
| `pnpm check:doc-fences` | 0 | `✅  check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s) of objectui#5867's remaining population (⛔ SHRINK-ONLY). No unknown fence spelling hides one.` |
| `pnpm check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 6237 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `pnpm lint` | 0 | `Tasks:    47 successful, 47 total` (0 errors; the 2878 warnings are the repository's standing `no-explicit-any` population, none in this diff) |

Notes on two of those:

- **`check:doc-snippets` first exited 2** (`PRECONDITION NOT MET` — five packages unbuilt), which is "I could not run", never a verdict about a document. Built what its own `--build-filter` named, re-ran, exit 0. The failing run is reported here rather than dropped, because a 2 that is quietly retried until green is indistinguishable from a 2 that was never noticed.
- **`check-changeset-presence` is the decider for this PR**, per the card: it says no changeset is owed, so none is added and ⛔ no `skip-changeset` label is applied.

`scripts/check-skill-examples.mjs` was also linted directly against the repository's own config (`eslint --no-inline-config --format json`), to show `pnpm lint`'s green actually covers the edited file rather than merely not excluding it: 1 file in the population, 0 errors, 0 warnings.

## Governed surface

`skills/objectui/**` is the published skills catalog and `scripts/**` carries the gate, so this PR **stays a draft for a human to merge** — not flipped ready, no auto-merge, no merge queue, no reviewers requested. The seat reviews at the contract tier and requests the approvers.

A parallel flight, objectui#7555, swaps the import reader in both gates. That is a different region of `check-skill-examples.mjs`; this change is confined to the rows, the floor and the guide. Whichever lands second merges `main` first.

Session: `https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox`


## Merge round — `main` merged at `5d27493`

PR #7569 (objectui#7555, the AST import reader) landed on `main` as `78d592b` and conflicted with this branch in exactly one place. Merged `origin/main` with a merge commit (no rebase, no force-push); merge commit **`5d27493`**.

**The one conflict, and the resolution.** Both branches add a paragraph at the same position in the header docblock of `scripts/check-skill-examples.mjs`. Both paragraphs are kept and nothing else is in the resolution. Order follows the prose above them: #7569's paragraph — the report OF the refusals must be read the same way the refusals are, both now going through the harness's `moduleSpecifiersOfBlock` — comes first, because the paragraph immediately before it ends on the `Unmapped specifiers` line that paragraph is about. This branch's paragraph, "a refused fence is NOT type-checked", follows in its updated form recording the four rows' retirement. The other side's copy of that second paragraph is the pre-edit original and is superseded by the updated one, not dropped.

**Both sides verified across the merge**, by grep at the merged head rather than by assumption: `KNOWN_ROOT_DEVDEP_EXAMPLES = new Set([])` (`:622`), `MARKED_FLOOR` `ts` `13` (`:462`), `skills/objectui/guides/testing.md` byte-identical to this branch's own commit (`git diff f7de6dc` on that path: zero lines) with 0 markers and 4 reason lines — and, from #7569, the `moduleSpecifiersOfBlock` import (`:311`) and both of its call sites (`:985`, `:1026`), plus the definition and call site in `check-doc-snippet-types.mjs`.

**Gate union re-run at the merged head `5d27493`**, exit captured by redirect before any pipe, verdict lines quoted from the gates themselves. Every one of the five values the seat's merge probe predicted came back exactly as predicted:

| gate | exit | its own verdict line |
|---|---|---|
| `pnpm check:skill-examples` | 0 | `Unmapped specifiers: none — every bare import of a selected fence is covered by the map above.` · `Marked: 13 ts fence(s) (floor 13), 39 json fence(s) (floor 39)` · `Root bound:     no selected fence imports a specifier that resolves only through the repository's ROOT manifest.` · `Semantic phase: 13 of 13 ts fence(s) judged, 0 failed.` · `Every marked skill example holds up against the built types.` |
| `node scripts/check-skill-examples.mjs --self-test` | 0 | `check-skill-examples self-test: 52 cases pass (...)` |
| `pnpm check:doc-snippets` | 0 | `Semantic phase: 455 of 455 block(s) judged, 0 failed.` · `Every covered documentation snippet compiles against the built types.` |
| `pnpm exec vitest run scripts/__tests__/check-skill-examples.test.ts scripts/__tests__/check-doc-snippet-types.test.ts` | 0 | `Test Files  2 passed (2)` · `Tests  154 passed (154)` |
| `pnpm check:skills-paths` | 0 | `✅  check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).` |
| `pnpm check:skill-eval-tokens` | 0 | `Every must_contain token is taught by its own skill bundle.` |
| `pnpm check:doc-fences` | 0 | `✅  check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript ...` |
| `pnpm check:control-bytes` | 0 | `✅  check-control-bytes: OK (scanned 6238 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` (merge-base now `78d592bb9`; still 2 files changed, still none of them published source) |
| `pnpm lint` | 0 | `Tasks:    47 successful, 47 total` |

`pnpm check:doc-snippets` needed its own `--build-filter` set built first, as before; that build ran green ahead of the measurement.

**State after the push.** Head moved to `5d27493`, `mergeable: true`, and `mergeable_state` is `behind` rather than `dirty` — the conflict is gone. `behind` is only because one unrelated commit, PR #7571 (a `packages/fields` test change), landed on `main` after this merge; it does not touch this PR's surface, and the ACCEPT on objectui#7555 records that the queue's own merge absorbs that state. Chasing it with a second merge would just race the next landing, so it was left alone. Still a **draft**: not flipped ready, no auto-merge, reviewers (already requested) untouched, no labels, no assignees.

_Generated by Claude Code — session `https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox`. This attribution is written as prose because the `PATCH` behind a PR-body update is measured to delete the footer block; the block is still appended below, and this line is what survives if it goes._

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_


---
_Generated by [Claude Code](https://claude.ai/code)_