### PR TITLE
fix(scripts): read snippet imports from the AST in both gates

### DIFF
--- a/scripts/__tests__/check-doc-snippet-types.test.ts
+++ b/scripts/__tests__/check-doc-snippet-types.test.ts
@@ -24,6 +24,7 @@ import {
   findInstalledCopy,
   listDocuments,
   moduleSpecifiersOf,
+  moduleSpecifiersOfBlock,
   resolvesOnlyThroughRootManifest,
   rootDeclaredSpecifiers,
   scanFences,
@@ -89,6 +90,34 @@ function tempTree(files: Record<string, string>): string {
 }
 
 const FENCE = '```';
+
+/**
+ * The corpus specimen behind objectui#7555 — a `tsx` block whose body assigns a
+ * template literal holding a README sample, and inside that literal the line
+ * `npm install project-name`.
+ */
+const README_SAMPLE_DOC = 'content/docs/plugins/plugin-markdown.mdx';
+const README_SAMPLE_FENCE_LINE = 195;
+
+/**
+ * The regex reader objectui#7555 removed from both gates, kept HERE and only
+ * here, as the contrast that makes the pin using it a measurement rather than a
+ * tautology. ⛔ Not a fallback and not a second answer: nothing in either gate
+ * may call anything shaped like this.
+ */
+function retiredRegexReader(body: string): string[] {
+  const out = new Set<string>();
+  const patterns = [
+    /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/g,
+    /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g,
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
+  ];
+  for (const re of patterns) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(body)) !== null) out.add(m[1]);
+  }
+  return [...out];
+}
 
 describe('fence scanning', () => {
   it('reads ts, tsx and typescript fences and nothing else', () => {
@@ -570,12 +599,38 @@ describe('the ROOT BOUND — what only this repository declares does not resolve
     it('does NOT collect an import-shaped line inside a template literal', () => {
       // Measured while deriving the bound: a README example whose fenced body
       // held `npm install project-name` inside a template literal read as an
-      // import of `project-name` under the regex the gate uses elsewhere. A
-      // false refusal would red a document that is correct.
+      // import of `project-name` under the regex reader each gate carried
+      // privately until objectui#7555. A false refusal would red a document
+      // that is correct.
       const found = moduleSpecifiersOf(
         parse("export const readme = `\n# Project\n\nimport x from 'project-name';\n`;\n"),
       ) as string[];
       expect(found).toEqual([]);
+    });
+
+    it('reports nothing for the corpus block that finding measured', () => {
+      // The synthetic pin above paraphrases the specimen; this one is the
+      // specimen. Keyed on the fence LINE, so an edit above it forces a
+      // re-declaration here rather than a row that silently covers nothing —
+      // the convention `KNOWN_ROOT_DEVDEP_EXAMPLES` already uses in the skills
+      // gate's suite.
+      const state = analyze({}) as unknown as {
+        compiled: { doc: string; fenceLine: number; body: string }[];
+      };
+      const site = `${README_SAMPLE_DOC}:${README_SAMPLE_FENCE_LINE}`;
+      const block = state.compiled.find(
+        (b) => b.doc === README_SAMPLE_DOC && b.fenceLine === README_SAMPLE_FENCE_LINE,
+      );
+      expect(block, `no compiled block at ${site}`).toBeDefined();
+      expect(block!.body, `the README sample moved out of ${site}`).toContain(
+        'npm install project-name',
+      );
+      expect(moduleSpecifiersOfBlock(block!.body)).toEqual([]);
+      // The retired reader, kept as this pin's CONTRAST: without it, the
+      // assertion above would hold just as well for a block that imports
+      // nothing and has no template literal either, and the pin would stop
+      // being about the defect it was written for.
+      expect(retiredRegexReader(block!.body)).toEqual(['project-name']);
     });
   });
 
@@ -686,6 +741,49 @@ describe('the ROOT BOUND — what only this repository declares does not resolve
       expect(source).toContain('resolves ONLY through the repository root');
       expect(source).toContain('ROOT-');
     });
+  });
+});
+
+/**
+ * objectui#7555 — the OTHER consumer of the reader, and the one with teeth.
+ *
+ * A specifier the reader invents matters here only when it happens to equal a
+ * workspace package: that package then joins the build filter AND the
+ * unbuilt-package precondition, so the gate refuses to run (exit 2) over a
+ * package no snippet imports. On this corpus the invented name was
+ * `project-name`, which is not a workspace package, so nothing moved — luck,
+ * not construction, which is why the consequence is pinned over a tree where
+ * the name DOES collide.
+ */
+describe('what the snippets make the gate build is read by the same reader (objectui#7555)', () => {
+  const treeWithBlock = (body: string): string =>
+    tempTree({
+      'content/docs/sample.mdx': [`${FENCE}tsx`, body, FENCE].join('\n'),
+      'packages/pkg-a/package.json': JSON.stringify({ name: '@fixture/pkg-a', types: 'dist/index.d.ts' }),
+    });
+
+  type State = { neededPackages: Set<string>; findings: { reason: string }[] };
+
+  it('adds a package a block really imports — the control for the pin below', () => {
+    // Without this half, the pin below would also pass over a tree where the
+    // package was never discovered at all.
+    const state = analyze({
+      root: treeWithBlock("import { a } from '@fixture/pkg-a';\nexport const x = a;"),
+    }) as unknown as State;
+    expect([...state.neededPackages]).toEqual(['@fixture/pkg-a']);
+    expect(buildFilterArgs(state.neededPackages)).toBe('--filter=@fixture/pkg-a...');
+    expect(state.findings.map((f) => f.reason)).toContain('unbuilt-package');
+  });
+
+  it('does NOT add one named only inside a template literal', () => {
+    const state = analyze({
+      root: treeWithBlock(
+        "export const readme = `\n# Project\n\nimport { a } from '@fixture/pkg-a';\n`;",
+      ),
+    }) as unknown as State;
+    expect([...state.neededPackages]).toEqual([]);
+    expect(buildFilterArgs(state.neededPackages)).toBe('');
+    expect(state.findings.map((f) => f.reason)).not.toContain('unbuilt-package');
   });
 });
 

--- a/scripts/__tests__/check-skill-examples.test.ts
+++ b/scripts/__tests__/check-skill-examples.test.ts
@@ -16,6 +16,7 @@ import {
   MARKER,
   SCAN_ROOTS,
   TS_FENCE_LANGUAGES,
+  analyze,
   bareAnyRowKey,
   buildFilterArgs,
   classifyRootDevDep,
@@ -30,7 +31,12 @@ import {
   scanSkillFences,
   stripJsonComments,
 } from '../check-skill-examples.mjs';
-import { rootDeclaredSpecifiers } from '../check-doc-snippet-types.mjs';
+import {
+  moduleSpecifiersOfBlock,
+  resolvesOnlyThroughRootManifest,
+  rootDeclaredSpecifiers,
+  specifierRoot,
+} from '../check-doc-snippet-types.mjs';
 
 /**
  * objectui#7359 — the test for `scripts/check-skill-examples.mjs`.
@@ -609,7 +615,15 @@ describe('the harness is imported, not re-rolled', () => {
     const source = fs.readFileSync(path.join(repoRoot, 'scripts/check-skill-examples.mjs'), 'utf8');
     const importBlock = source.match(/import\s*\{[^}]*\}\s*from\s*'\.\/check-doc-snippet-types\.mjs';/);
     expect(importBlock, 'the shared harness import is gone — has it been forked?').not.toBeNull();
-    for (const name of ['compileSnippets', 'derivePackageTypePaths', 'deriveDeclaredDependencyPaths']) {
+    for (const name of [
+      'compileSnippets',
+      'derivePackageTypePaths',
+      'deriveDeclaredDependencyPaths',
+      // objectui#7555: the import reader too. It was a private regex copy here,
+      // and the `Unmapped specifiers` line it feeds is the REPORT of refusals
+      // the harness derives from the AST — two readers, one claim.
+      'moduleSpecifiersOfBlock',
+    ]) {
       expect(importBlock![0]).toContain(name);
     }
   });
@@ -724,6 +738,82 @@ describe('the ROOT BOUND, and its declared debt (objectui#7463 item 2)', () => {
       expect(fences.length, `no fence at ${site}`).toBe(1);
       expect(fences[0].marked, `the fence at ${site} carries no marker`).toBe(true);
     }
+  });
+});
+
+/**
+ * objectui#7555 — the `Unmapped specifiers` line reads imports the same way the
+ * refusals it reports do.
+ *
+ * Since objectui#7463 item 2 that line is the REPORT of what the shared
+ * harness's ROOT BOUND refuses. The bound has always walked the AST; the line
+ * came from a private regex over the block text, so the two were two answers to
+ * one question and were free to name different sets over the same fences. The
+ * regex's error is one-directional and measured (`plugin-markdown.mdx:195` in
+ * the DOCS corpus: `npm install project-name` inside a template literal read as
+ * an import), so the line could name a specifier no fence imports — an
+ * invented refusal, printed on every run, in the one line a reader consults to
+ * learn what a green did NOT cover.
+ */
+describe('the `Unmapped specifiers` line and the refusals it reports (objectui#7555)', () => {
+  type State = { unmappedSpecifiers: Set<string>; neededPackages: Set<string> };
+
+  // ⚠️ `withTree` deletes the tree when its callback returns, so each case
+  // builds and reads inside one call.
+  const stateFor = (body: string): State =>
+    withTree(
+      (write) => {
+        write(
+          'skills/objectui/guides/sample.md',
+          ['# Sample', '', MARKER, '```ts', body, '```', ''].join('\n'),
+        );
+        // The workspace scan reads `packages/` directly; an absent directory is
+        // a throw, not an empty map.
+        write('packages/.keep', '');
+      },
+      (dir) => analyze({ root: dir }) as unknown as State,
+    );
+
+  it('names a specifier a marked fence really imports — the control for the pin below', () => {
+    // Without this half, the pin below would pass just as well over a tree
+    // whose guide was never scanned at all.
+    const state = stateFor("import { test } from 'some-runner';\nexport const t = test;");
+    expect([...state.unmappedSpecifiers]).toEqual(['some-runner']);
+  });
+
+  it('does NOT name one that appears only inside a template literal', () => {
+    const state = stateFor(
+      "export const readme = `\n# Project\n\nimport { test } from 'some-runner';\n`;",
+    );
+    expect([...state.unmappedSpecifiers]).toEqual([]);
+    expect([...state.neededPackages]).toEqual([]);
+  });
+
+  it('agrees with the bound over the real corpus, specifier for specifier', () => {
+    // The build-free half of the claim the gate's own run prints: the line and
+    // the refusals are now one reader, so over THIS corpus the two sets are
+    // equal. They can only diverge on a specifier that is unmapped and NOT
+    // root-declared — which the bound leaves in the program, where it fails to
+    // resolve and reds the semantic phase. So a divergence is never silent, and
+    // a red here is a real finding rather than upkeep.
+    const state = analyze({}) as unknown as {
+      unmappedSpecifiers: Set<string>;
+      tsBlocks: { body: string }[];
+      paths: Record<string, string[]>;
+    };
+    const rootDeclared = rootDeclaredSpecifiers(repoRoot) as Set<string>;
+    const refused = new Set<string>();
+    for (const block of state.tsBlocks) {
+      for (const specifier of moduleSpecifiersOfBlock(block.body) as string[]) {
+        if (resolvesOnlyThroughRootManifest(specifier, { paths: state.paths, rootDeclared })) {
+          refused.add(specifierRoot(specifier) as string);
+        }
+      }
+    }
+    expect([...state.unmappedSpecifiers].sort()).toEqual([...refused].sort());
+    // And the corpus really does exercise the comparison — an empty set on both
+    // sides would satisfy the equality above while proving nothing.
+    expect(refused.size).toBeGreaterThan(0);
   });
 });
 

--- a/scripts/__tests__/check-skill-examples.test.ts
+++ b/scripts/__tests__/check-skill-examples.test.ts
@@ -791,29 +791,48 @@ describe('the `Unmapped specifiers` line and the refusals it reports (objectui#7
 
   it('agrees with the bound over the real corpus, specifier for specifier', () => {
     // The build-free half of the claim the gate's own run prints: the line and
-    // the refusals are now one reader, so over THIS corpus the two sets are
-    // equal. They can only diverge on a specifier that is unmapped and NOT
-    // root-declared — which the bound leaves in the program, where it fails to
-    // resolve and reds the semantic phase. So a divergence is never silent, and
-    // a red here is a real finding rather than upkeep.
+    // the refusals are now one reader, so over the SELECTED population the two
+    // sets are equal. They can only diverge on a specifier that is unmapped and
+    // NOT root-declared — which the bound leaves in the program, where it fails
+    // to resolve and reds the semantic phase. So a divergence is never silent,
+    // and a red here is a real finding rather than upkeep.
+    //
+    // ⛔ Scoped to the SELECTED population on purpose; it does NOT widen to
+    // `--measure`. Measured while writing this: under `measure: true` all 121
+    // candidate fences are selected and the two sets legitimately differ, 12
+    // names on the line against 6 refused — the extra six (`@objectstack/*`,
+    // `@tailwindcss/vite`, `@vitejs/plugin-react`) are unmapped and NOT
+    // root-declared, so they belong on the line and are correctly left in the
+    // program to fail there. Widening this pin would red on the design.
     const state = analyze({}) as unknown as {
       unmappedSpecifiers: Set<string>;
       tsBlocks: { body: string }[];
       paths: Record<string, string[]>;
     };
     const rootDeclared = rootDeclaredSpecifiers(repoRoot) as Set<string>;
+    const read = new Set<string>();
     const refused = new Set<string>();
     for (const block of state.tsBlocks) {
       for (const specifier of moduleSpecifiersOfBlock(block.body) as string[]) {
+        read.add(specifier);
         if (resolvesOnlyThroughRootManifest(specifier, { paths: state.paths, rootDeclared })) {
           refused.add(specifierRoot(specifier) as string);
         }
       }
     }
     expect([...state.unmappedSpecifiers].sort()).toEqual([...refused].sort());
-    // And the corpus really does exercise the comparison — an empty set on both
-    // sides would satisfy the equality above while proving nothing.
-    expect(refused.size).toBeGreaterThan(0);
+    // And the reader really did run over this corpus — an equality between two
+    // sets nothing ever put anything into would pass while proving nothing.
+    //
+    // ⛔ NOT `refused.size > 0`. That asserts the corpus still MARKS a fence
+    // importing a root-only specifier, which is a fact about the markers, and
+    // the markers belong to whoever is editing the guides: unmarking the four
+    // fences in `skills/objectui/guides/testing.md` empties `refused`, leaves
+    // the equality true, and would red this pin over a change that is not about
+    // it (measured against objectui#7557's head while writing this). What this
+    // pin owns is that the two READERS agree, so its non-vacuity clause has to
+    // be about the reader.
+    expect(read.size).toBeGreaterThan(0);
   });
 });
 

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -1090,19 +1090,39 @@ export function moduleSpecifiersOf(sourceFile) {
   return [...out];
 }
 
-/** Workspace package specifiers a document imports (bare specifier root only). */
-function importedSpecifiers(body) {
-  const out = new Set();
-  const patterns = [
-    /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/g,
-    /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g,
-    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
-  ];
-  for (const re of patterns) {
-    let m;
-    while ((m = re.exec(body)) !== null) out.add(m[1]);
-  }
-  return out;
+/**
+ * Every module specifier ONE BLOCK BODY imports — the parse and the walk
+ * together, so that BOTH gates read imports through this one function and
+ * cannot answer the question differently.
+ *
+ * ⚠️ It replaces two copies of a regex reader, one per gate, and both were
+ * wrong the same way: prose is part of the corpus, so an import-shaped line
+ * inside a template literal or a string was read as an import. Measured on
+ * this corpus (objectui#7555): `content/docs/plugins/plugin-markdown.mdx`
+ * carries a README sample whose template literal holds `npm install
+ * project-name`, and the regex reported `project-name` as a specifier that
+ * block imports. Nothing in that block imports anything. Both consumers
+ * survived it by luck rather than by construction — a false name matters to
+ * `neededPackages` only if it happens to equal a workspace package, and it
+ * reaches the skills gate's `Unmapped specifiers` line, which since
+ * objectui#7463 item 2 is the REPORT of what the AST-derived root bound
+ * refuses, so a regex-derived line and an AST-derived refusal could disagree.
+ *
+ * ⚠️ Parsed as TSX, matching `compileSnippets` — a reader walking a different
+ * tree from the one `tsc` judges would answer about a program nobody compiled.
+ * `createSourceFile` never throws, so a block too broken to parse yields no
+ * specifiers here and is caught by the syntax leg instead.
+ */
+export function moduleSpecifiersOfBlock(body) {
+  return moduleSpecifiersOf(
+    ts.createSourceFile(
+      'block.tsx',
+      body,
+      ts.ScriptTarget.ES2020,
+      /* setParentNodes */ true,
+      ts.ScriptKind.TSX,
+    ),
+  );
 }
 
 // ── The run ──────────────────────────────────────────────────────────────────
@@ -1219,7 +1239,7 @@ export function analyze({ root = repoRoot, ungated = UNGATED_DOCS } = {}) {
   const { paths, packageDirOf, sourceTyped } = derivePackageTypePaths(root);
   const neededPackages = new Set();
   for (const block of compiled) {
-    for (const specifier of importedSpecifiers(block.body)) {
+    for (const specifier of moduleSpecifiersOfBlock(block.body)) {
       const owner = Object.keys(packageDirOf).find(
         (name) => specifier === name || specifier.startsWith(`${name}/`),
       );

--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -145,6 +145,13 @@
  * report of what the bound refuses, and the harness's new ROOT-DECLARED control
  * is what proves on every run that it is still being applied.
  *
+ * ⚠️ A report OF the refusals has to be read the same way the refusals are, and
+ * when the bound landed it was not: the line came from a private regex over the
+ * block text while the bound walked the AST, so the two could name different
+ * sets over the same fences (objectui#7555). Both now read through the
+ * harness's `moduleSpecifiersOfBlock`, so the line cannot name a specifier no
+ * fence imports, and the suite pins that the two sets agree over this corpus.
+ *
  * ⚠️ A refused fence is NOT type-checked. The four pre-existing ones are carried
  * in the shrink-only `KNOWN_ROOT_DEVDEP_EXAMPLES` below so the bound landed with
  * zero new red, and the `Root bound` and `Semantic phase` lines both say how
@@ -295,6 +302,7 @@ import {
   compileSnippets,
   deriveDeclaredDependencyPaths,
   derivePackageTypePaths,
+  moduleSpecifiersOfBlock,
 } from './check-doc-snippet-types.mjs';
 import { isEntrypoint } from './invoked-as.mjs';
 
@@ -889,20 +897,12 @@ export function parseJsonFence(body, language) {
 
 // ── Collection ───────────────────────────────────────────────────────────────
 
-/** Workspace package specifiers a block imports (bare specifier root only). */
-function importedSpecifiers(body) {
-  const out = new Set();
-  const patterns = [
-    /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/g,
-    /(?:^|\n)\s*import\s*['"]([^'"]+)['"]/g,
-    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g,
-  ];
-  for (const re of patterns) {
-    let m;
-    while ((m = re.exec(body)) !== null) out.add(m[1]);
-  }
-  return out;
-}
+// The specifiers a block imports are read by `moduleSpecifiersOfBlock`, from the
+// shared harness. This gate carried its own regex copy of that reader until
+// objectui#7555; the harness's docblock records why a regex over a corpus that
+// is mostly prose cannot answer the question, and ONE reader is what keeps the
+// `Unmapped specifiers` line below and the harness's root bound — AST-derived
+// since it landed — from being two answers free to disagree.
 
 /**
  * Everything this run knows before any compiler is started.
@@ -951,7 +951,7 @@ export function analyze({ root = repoRoot, measure = false, baseline = KNOWN_BAR
   const { paths, packageDirOf, sourceTyped } = derivePackageTypePaths(root);
   const neededPackages = new Set();
   for (const block of tsBlocks) {
-    for (const specifier of importedSpecifiers(block.body)) {
+    for (const specifier of moduleSpecifiersOfBlock(block.body)) {
       const owner = Object.keys(packageDirOf).find(
         (name) => specifier === name || specifier.startsWith(`${name}/`),
       );
@@ -992,7 +992,7 @@ export function analyze({ root = repoRoot, measure = false, baseline = KNOWN_BAR
   const mapped = new Set(Object.keys(mergedPaths));
   const unmappedSpecifiers = new Set();
   for (const block of tsBlocks) {
-    for (const specifier of importedSpecifiers(block.body)) {
+    for (const specifier of moduleSpecifiersOfBlock(block.body)) {
       if (specifier.startsWith('.') || specifier.startsWith('/')) continue;
       const root2 = specifier.startsWith('@') ? specifier.split('/').slice(0, 2).join('/') : specifier.split('/')[0];
       if (mapped.has(root2) || mapped.has(specifier)) continue;


### PR DESCRIPTION
Fixes #7555

Both snippet gates carried a private `importedSpecifiers(body)` that found module
specifiers with three regexes over the raw block text. Documentation prose is part of
that corpus, so the pattern matched text that is not an import. Both copies are gone;
the one reader is now `moduleSpecifiersOfBlock`, exported from the shared harness — the
TSX parse plus the AST walk `moduleSpecifiersOf` that PR #7554 added — so the two gates
cannot answer the question differently.

Verification head: `aa54aee` (two commits: the reader swap `9f1a2ad`, then the
corpus-agreement pin patch `aa54aee` asked for in review). Written by Claude Code in
session `session_019RfFHiRCSs3JXLK4cwcfox` — attribution kept as prose here because the
pull-request PATCH endpoint strips the footer block from this body (measured twice, see
the closing note).

## The specimen, measured

`content/docs/plugins/plugin-markdown.mdx:195` is a `tsx` block whose body assigns a
template literal holding a README sample. Inside that literal is the line
`npm install project-name`. Nothing in that block imports anything.

| reader | reports for that block |
| --- | --- |
| the private regex reader (before) | `["project-name"]` |
| `moduleSpecifiersOfBlock` (after) | `[]` |

Over the whole corpus the two readers disagree on exactly that one block, and in one
direction only:

| population | blocks | agree | regex-only specifiers | AST-only |
| --- | --- | --- | --- | --- |
| docs gate, compiled blocks | 455 | 454 | 1 (`project-name`) | 0 |
| skills gate, marked ts fences | 17 | 17 | 0 | 0 |
| skills gate, `--measure` ts fences | 121 | 121 | 0 | 0 |

## Population and behaviour: nothing moved

Both gates print **byte-identical** output before (`e304a4e`) and after (`9f1a2ad`) —
`diff` over the full stdout of each run is empty. The lines the card and the triage
name, quoted from both runs:

```
Scanned 227 document(s): 201 covered (99 of them hold a ts/tsx block), 26 ungated — declared in this script, NOT verified by it.
Covered blocks: 613 — 455 to compile, 158 declared fragment(s).
Root bound:     no block imports a specifier that resolves only through this repository's ROOT manifest.
Semantic phase: 455 of 455 block(s) judged, 0 failed.
```

```
Unmapped specifiers (covered by neither map, so the shared harness's ROOT BOUND refuses them — they would otherwise resolve from the repository ROOT's own node_modules, this workspace's devDependency set, NOT what a reader of the guide installs): @playwright/test, vitest
Marked: 17 ts fence(s) (floor 17), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY. Unmarked fences are ignored by design (opt-in).
Root bound:     4 fence(s) refused (@playwright/test, vitest) and therefore NOT type-checked; 4 row(s) declared in KNOWN_ROOT_DEVDEP_EXAMPLES (⛔ SHRINK-ONLY, 4 row(s)), 0 NOT declared, 0 declared row(s) no longer refused.
Semantic phase: 13 of 17 ts fence(s) judged, 0 failed.
```

`--build-filter` is byte-identical for both gates too (26 workspace filter words for the
docs gate, 11 for the skills gate). No false specifier was moving it: a false name joins
the filter only when it happens to equal a workspace package, and `project-name` is not
one — luck, not construction, which is why the collision case is now pinned over a
throwaway tree with the real-import control beside it.

The `Unmapped specifiers` line is unchanged for the same reason in reverse: the false
name lives in the **docs** corpus, and that line is the **skills** gate's. What changed
is that the line and the refusals it reports are now one reader. Since PR #7554 the line
is the report of what the ROOT BOUND refuses, and the bound has always walked the AST —
a regex-derived report of an AST-derived refusal is two answers to one question, free to
name different sets over the same fences. The suite pins that the two sets agree over
this corpus, and that the line cannot name a specifier no fence imports.

## What is pinned (3 new tests per suite)

`scripts/__tests__/check-doc-snippet-types.test.ts` (67 to 70 tests):

- the corpus specimen itself — the block at `plugin-markdown.mdx:195` still holds
  `npm install project-name`, `moduleSpecifiersOfBlock` reports `[]` for it, and the
  retired regex (kept in the test file, and only there, as the contrast) reports
  `["project-name"]`. Without the contrast the pin would hold for any block that imports
  nothing;
- the consumer with teeth: over a throwaway tree where the invented name **does** equal a
  workspace package, `neededPackages` and the build filter stay empty and no
  `unbuilt-package` precondition is raised — with the real-import control beside it, so
  an empty result cannot come from a tree that was never scanned.

`scripts/__tests__/check-skill-examples.test.ts` (81 to 84 tests):

- the source-level "one reader" fact, added to the existing harness-not-forked pin:
  `moduleSpecifiersOfBlock` must be in the import block from the docs gate;
- the same template-literal shape through this gate's own path: `unmappedSpecifiers` and
  `neededPackages` stay empty, with the real-import control naming `some-runner`;
- the agreement itself, build-free, over the real corpus: the `Unmapped specifiers` set
  equals the set the bound refuses, specifier for specifier.

**Patched in review (`aa54aee`).** That last pin first closed with
`expect(refused.size).toBeGreaterThan(0)`, which is not a fact about the two readers it
compares — it asserts the corpus still MARKS a fence importing a root-only specifier, and
today that set is exactly the four marked fences in `skills/objectui/guides/testing.md`.
PR #7568 (objectui#7557, governed, draft) unmarks them, so on the merge of both changes
`refused` is empty, the equality still holds, and the clause would have red over a change
that is not about it. The clause is now `expect(read.size).toBeGreaterThan(0)` — the
specifiers the reader actually produced over the selected fences, which is what this pin
owns. Nothing in that flight's region is touched (`KNOWN_ROOT_DEVDEP_EXAMPLES`,
`MARKED_FLOOR`, `testing.md`); `git diff` against `main` for those two identifiers is
empty.

The pin's comment also now records, as a measurement, why the equality is scoped to the
SELECTED population and must not widen to `--measure`: over all 121 candidate fences the
two sets legitimately differ, 12 names on the line against 6 refused, because a specifier
that is unmapped and NOT root-declared belongs on the line and is correctly left in the
program to fail there.

### The two readings the patch is proved by

Both taken in this worktree, exit captured before any pipe, restore proved by state.

**(a) `skills/objectui/guides/testing.md` taken from PR #7568's head `f7de6dc`, nothing
else changed** — applied blob `74382b9...` over HEAD blob `0f68499...`, os:check markers
4 to 0:

| | before the patch (`9f1a2ad`) | after the patch (`aa54aee`) |
| --- | --- | --- |
| `agrees with the bound over the real corpus` | **red** — `expected 0 to be greater than 0` | **green** |
| the two suites | `3 failed \| 151 passed (154)` | `2 failed \| 152 passed (154)` |

The two that stay red in both columns are pre-existing pins on `MARKED_FLOOR` and
`KNOWN_ROOT_DEVDEP_EXAMPLES` — PR #7568's own region, which its commit moves in the same
change; only its guide was applied here, so they red by construction and neither is
touched by this branch.

Restored after each reading: `git hash-object` back to `0f68499...` = the HEAD blob,
`git status --porcelain` empty, markers back to 4.

**(b) the real merge of both pull requests**, built in a throwaway compare worktree at
`f7de6dc` with this branch's diff applied on top. `git merge-tree --write-tree` reports
ONE conflict, in the `check-skill-examples.mjs` header docblock — both changes add a
paragraph at the same place; resolved for the probe by keeping both paragraphs, which is
the whole resolution. On that merged tree, everything is green:

```
check-skill-examples EXIT=0   self-test EXIT=0   check-doc-snippets EXIT=0   vitest EXIT=0
Unmapped specifiers: none — every bare import of a selected fence is covered by the map above.
Marked: 13 ts fence(s) (floor 13), 39 json fence(s) (floor 39) — the floor is ⛔ SHRINK-ONLY. Unmarked fences are ignored by design (opt-in).
Root bound:     no selected fence imports a specifier that resolves only through the repository's ROOT manifest.
Semantic phase: 13 of 13 ts fence(s) judged, 0 failed.
Every marked skill example holds up against the built types.
Test Files 2 passed (2) · Tests 154 passed (154)
```

⚠️ For whoever lands second: the conflict above is textual, not just semantic. It is one
docblock paragraph and the resolution is to keep both.

## Ablation

`moduleSpecifiersOfBlock`'s body swapped back to the three regexes, at `9f1a2ad`, under a
`trap ... EXIT INT TERM` restore with absolute paths. No rebuild leg: both suites import
their subject by relative path (`../check-doc-snippet-types.mjs`), so the mutated source
is what runs — no `dist`, no package `exports`, no vitest alias between them.

Mutation proved on disk before any reading was taken: injected marker present (3
occurrences), removed anchor absent (0), and the file's `git hash-object` moved from the
HEAD blob `f1bb41e...` to `a0b7200...`.

Three tests red, each naming itself and the false specifier; every control stayed green:

```
× reports nothing for the corpus block that finding measured
  AssertionError: expected [ 'project-name' ] to deeply equal []
× does NOT add one named only inside a template literal
  AssertionError: expected [ '@fixture/pkg-a' ] to deeply equal []
× does NOT name one that appears only inside a template literal
  AssertionError: expected [ 'some-runner' ] to deeply equal []

Tests  3 failed | 151 passed (154)
```

The agreement pin cannot red under this ablation and did not: it mutates both sides of
the comparison at once. It is the standing assertion, not the ablation's target.

Restored, proved by state rather than by exit code: on-disk `git hash-object` back to
`f1bb41e...` (equal to the HEAD blob), `git diff HEAD` empty, `git status --porcelain`
empty, injected marker 0 occurrences.

## Gates

All re-run at `aa54aee`, exit captured before any pipe.

| command | exit | verdict line |
| --- | --- | --- |
| `pnpm check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| `pnpm check:skill-examples` | 0 | `Every marked skill example the root bound could reach holds up against the built types — 4 declared row(s) in KNOWN_ROOT_DEVDEP_EXAMPLES were NOT reached, and this line does not speak for them.` |
| `node scripts/check-skill-examples.mjs --self-test` | 0 | `✓ check-skill-examples self-test: 52 cases pass (...)` |
| `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts scripts/__tests__/check-skill-examples.test.ts` | 0 | `Test Files 2 passed (2) · Tests 154 passed (154)` |
| `pnpm check:doc-fences` | 0 | `✅ check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s) ... (⛔ SHRINK-ONLY).` |
| `pnpm check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 6237 tracked text file(s); skipped 85 binary).` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json` clean |
| `pnpm lint` | 0 | `Tasks: 47 successful, 47 total` — 0 errors; none of the four files appears in the output |

Derived beyond the dispatched list, because the diff is `scripts/**`: `pnpm
type-check:scripts` (and `tsc --listFiles` confirms both edited test files **and** both
edited `.mjs` gates are in that program — 2 hits each, so "clean" really covers them),
plus `check:esm-specifiers`, `check:pre-install-import-graph`, `lint:coverage`,
`type-check:coverage`, `check:skills-paths` — all exit 0. The union of every test file
that names either gate (13 files, found by `git grep`) passes: 466 tests.

No changeset: `check-changeset-presence.mjs` decides, and it says none is owed —
`scripts/**` publishes nothing. No `skip-changeset` label applied.

Nothing under `content/docs/`, `skills/**` or `.claude/**` is touched; the bound, the
floors and the declared rows are unchanged. Not a governed surface, so this stays draft
for the seat to review, flip ready and arm auto-merge.

**Platform note, measured on this body.** `create_pull_request` stored the footer block
and normalised it to the session-URL form. The PATCH behind `update_pull_request` then
DELETED it: the body sent without a footer and the body sent with one both stored at
exactly 12317 bytes with zero footers, so this is removal, not the recorded downgrade and
not the recorded append. Attribution is therefore carried as prose at the top of this
body, which is the shape the repo's own guidance says survives an edit; it is not
re-posted as a block, to avoid a retry loop against a sanitizer.