### PR TITLE
refactor(i18n): retire the dead `dashboard.noRows` and `dashboard.noDataAvailable` keys

### DIFF
--- a/.changeset/7125-dashboard-empty-state-keys-retired.md
+++ b/.changeset/7125-dashboard-empty-state-keys-retired.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/i18n': patch
+---
+
+`dashboard.noRows` and `dashboard.noDataAvailable` are retired — two rows removed from
+each of the ten locale packs, 20 entries, zero readers (objectui#7125).
+
+objectui#7063 routed the three dashboard empty-state renders (`DatasetWidget`,
+`ObjectDataTable`, `PivotTable`) through one shared `WidgetEmptyState`, which resolves its
+own copy from the `dashboard.empty.*` family. The two keys the old per-widget placeholders
+used outlived their call sites in `packages/i18n/src/locales/{en,de,es,fr,pt,ru,ja,ko,zh,ar}.ts`.
+
+Removed under objectui#4658's evidence standard, re-measured on this branch rather than
+inherited from the card: zero `t()`/`tt()` call sites for either fully qualified key, no
+dynamic `dashboard.` head a substitution could resolve onto them, and every surviving
+textual occurrence in `packages/` is a comment recording the consolidation. `pnpm
+check:i18n-keys` stays green across the deletion with the `en` pack at 2,962 keys (2,964
+before) and every in-scope call-site key still resolving.
+
+Not touched: `table.noRows` (`'No rows to display'`) and `engine.form.noRows`
+(`packages/app-shell/src/views/metadata-admin/i18n.ts`, read at `widgets.tsx`) — two
+different, same-named keys in different namespaces. Nor the comments in
+`WidgetEmptyState.tsx`, `DatasetWidget.tsx`, `ObjectDataTable.tsx` and `PivotTable.tsx`
+that record WHY three widgets with three strings became one shared empty state; the packs'
+own comment keeps that rationale and now names the retirement instead of a row that is
+gone.
+
+`packages/i18n/src/__tests__/dashboard-emptyState-keys-retired-7125.test.ts` pins the removal
+by name, following the five prior retirements (objectui#4145, objectui#4392, objectui#4730,
+objectui#5504, objectui#6310). Every i18n gate here runs call site → key, so none of them can
+see a dead key come BACK into the packs: the reverse sweep that found these is report-only by
+design, `all-locales-key-parity` is fully satisfied by ten packs agreeing on a dead key, and
+`check:i18n-drift` reported the deletion as `2 removed — those are all-locales-key-parity's`.

--- a/packages/i18n/src/__tests__/dashboard-emptyState-keys-retired-7125.test.ts
+++ b/packages/i18n/src/__tests__/dashboard-emptyState-keys-retired-7125.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `dashboard.noRows` and `dashboard.noDataAvailable` are retired from all ten
+ * packs (objectui#7125). Sixth in the retirement-pin series (objectui#4145,
+ * objectui#4392, objectui#4730, objectui#5504, objectui#6310), same shape: the
+ * retired leaves asserted absent from every pack, plus surviving-sibling
+ * assertions so a green here cannot be bought by deleting the neighbourhood.
+ *
+ * ## What was removed and why
+ *
+ * objectui#7063 routed the three dashboard empty-state renders — `DatasetWidget`,
+ * `ObjectDataTable`, `PivotTable` — through one shared `WidgetEmptyState`, which
+ * resolves its own copy from the `dashboard.empty.*` family. That left the two
+ * keys the old per-widget placeholders used with no call site at all: two rows in
+ * each of the ten packs, 20 entries.
+ *
+ * Re-measured on the retiring branch rather than inherited from the card: zero
+ * `t()`/`tt()` call sites for either FULLY QUALIFIED key; every surviving textual
+ * occurrence under `packages/` is a COMMENT recording the consolidation
+ * (`WidgetEmptyState.tsx`, `DatasetWidget.tsx`, `ObjectDataTable.tsx`,
+ * `PivotTable.tsx`); no dynamic `dashboard.` head exists for a substitution to
+ * resolve onto them (the package's one template family is `dashboard.trend.`);
+ * and `scripts/check-i18n-call-site-keys.mjs` stays green across the deletion,
+ * with the `en` pack going 2,964 -> 2,962 keys and every in-scope call-site key
+ * still resolving.
+ *
+ * ## Why this pin is NEGATIVE, and why it is needed at all
+ *
+ * Every i18n gate in this repo runs **call site -> key**, so none of them can see
+ * a dead key come BACK into the packs:
+ *
+ *   - `scripts/check-i18n-call-site-keys.mjs` visits keys a call site asks for; a
+ *     key with no call site is never reached.
+ *   - `all-locales-key-parity.test.ts` compares the ten packs' key SETS to each
+ *     other, and ten packs agreeing on a dead key is exactly what it wants.
+ *   - `scripts/check-i18n-en-drift.mjs` fires only when an `en` VALUE changes; it
+ *     says so itself about added/removed keys, and printed `2 removed — those are
+ *     all-locales-key-parity's` on this very deletion.
+ *   - `scripts/check-i18n-dead-keys.mjs` IS the reverse direction, and it is
+ *     report-only by design and wired into no workflow (objectui#4658).
+ *
+ * So both rows can return to all ten packs with every gate green, and "the empty
+ * state has no `noRows` string" is a plausible way for a translator or a widget
+ * author to put them back — the surrounding block still describes empty states.
+ * Restoring either one goes red here.
+ *
+ * ## What this file does NOT claim
+ *
+ * - **`table.noRows` (`'No rows to display'`) is a DIFFERENT key** in a different
+ *   namespace, and this retirement did not touch it. The case that pins it below
+ *   is a claim about THIS deletion's precision, ⛔ not a claim that `table.noRows`
+ *   is live — the reverse sweep lists it as a CONFIRMED candidate in its own
+ *   right. Retiring it is a separate card with its own evidence; if that is what
+ *   you are doing, delete that case along with the rows. If you are here because a
+ *   BARE-NAME sweep took it out as collateral of the dashboard retirement, restore
+ *   it: three keys in this repo are spelled `noRows`, and only the `dashboard.` one
+ *   was retired.
+ * - **`engine.form.noRows` is a third, live key** —
+ *   `packages/app-shell/src/views/metadata-admin/i18n.ts`, read at
+ *   `widgets.tsx`. It lives in a module-local table, not in these packs, and is out
+ *   of this file's reach by dependency direction (`@object-ui/app-shell` depends on
+ *   `@object-ui/i18n`, not the reverse) — the same boundary
+ *   `appDesigner-fieldDesigner-formula-retired-6310.test.ts` states for
+ *   `designer.field.formula`.
+ * - **`dashboard` is a live namespace.** Only two leaves went; {@link SURVIVING}
+ *   exists so the neighbourhood cannot be deleted for a green.
+ */
+import { describe, it, expect } from 'vitest';
+import { builtInLocales } from '../locales/index';
+
+type LocaleCode = keyof typeof builtInLocales;
+const LANGS = Object.keys(builtInLocales) as LocaleCode[];
+
+const at = (pack: unknown, path: string): unknown =>
+  path.split('.').reduce<unknown>((n, k) => (n as Record<string, unknown> | undefined)?.[k], pack);
+
+/** The retired leaves, named rather than counted, and fully qualified. */
+const RETIRED = ['dashboard.noDataAvailable', 'dashboard.noRows'] as const;
+
+/**
+ * Rows the deletion swept around — each confirmed live by a `t()`/`tt()` call
+ * site, not merely by sitting nearby. The `dashboard.empty.*` family is the copy
+ * that REPLACED the retired rows (`WidgetEmptyState.tsx`, `ObjectChart.tsx`), so a
+ * revert that removed the replacement instead of restoring the placeholders lands
+ * here first; `noDataSourceFor` is the row that sat immediately beside the retired
+ * `noDataAvailable` in every pack and describes a DIFFERENT state — a misconfigured
+ * binding rather than an empty result (`ObjectDataTable.tsx`); `total` is read by
+ * `PivotTable.tsx` and `DatasetWidget.tsx`.
+ */
+const SURVIVING = [
+  'dashboard.empty.title',
+  'dashboard.empty.message',
+  'dashboard.empty.sourceLabel',
+  'dashboard.noDataSourceFor',
+  'dashboard.total',
+] as const;
+
+/**
+ * The same NAME, a different KEY. Deleting `dashboard.noRows` by bare name takes
+ * this row with it in all ten packs, and no other gate would notice: the packs
+ * would still be at full parity with each other, and `table.noRows` has no call
+ * site to report a missing key. See "What this file does NOT claim" above for why
+ * this is a precision assertion rather than a liveness one.
+ */
+const DIFFERENT_NAMESPACE = 'table.noRows';
+
+describe('the dashboard empty-state placeholders are retired from the ten packs (objectui#7125)', () => {
+  it('covers all ten packs and a live `dashboard` root', () => {
+    // Guards the premise the rest of the file rests on: a pin that iterates an
+    // empty pack list, or asserts absence inside a namespace that itself
+    // vanished, is green for the wrong reason.
+    expect(LANGS).toHaveLength(10);
+    for (const lang of LANGS) {
+      const root = at(builtInLocales[lang], 'dashboard');
+      expect(root, `${lang} lost the dashboard root`).toBeDefined();
+      expect(Object.keys(root as Record<string, unknown>).length, lang).toBeGreaterThanOrEqual(15);
+    }
+  });
+
+  it('no pack defines either retired placeholder', () => {
+    const revived: string[] = [];
+    for (const lang of LANGS) {
+      for (const key of RETIRED) {
+        if (at(builtInLocales[lang], key) !== undefined) revived.push(`${lang} :: ${key}`);
+      }
+    }
+    // Named, not counted: a half-reverted retirement is repaired pack by pack.
+    expect(
+      revived,
+      'A retired dashboard empty-state placeholder is back in a locale pack. ' +
+        'objectui#7063 replaced all three per-widget placeholders with the shared ' +
+        '`WidgetEmptyState`, which reads `dashboard.empty.*`, so nothing reads these ' +
+        'two — and no other i18n gate can see a dead key return, because every one ' +
+        'of them runs call site -> key (objectui#7125). If a widget needs its own ' +
+        'empty-state copy again, author it with the control that renders it rather ' +
+        'than restoring these rows.',
+    ).toEqual([]);
+  });
+
+  it('the deletion swept around its neighbours', () => {
+    const missing: string[] = [];
+    for (const lang of LANGS) {
+      for (const key of SURVIVING) {
+        const value = at(builtInLocales[lang], key);
+        if (typeof value !== 'string' || value.length === 0) missing.push(`${lang} :: ${key}`);
+      }
+    }
+    expect(
+      missing,
+      'a live `dashboard` row is gone. `dashboard.empty.*` is the copy that ' +
+        'REPLACED the retired placeholders; losing it renders the shared empty ' +
+        'state as raw keys, which no parity gate can see because all ten packs ' +
+        'would have lost it together',
+    ).toEqual([]);
+  });
+
+  it('leaves the same-named key in another namespace alone', () => {
+    const swept: string[] = [];
+    for (const lang of LANGS) {
+      if (typeof at(builtInLocales[lang], DIFFERENT_NAMESPACE) !== 'string') {
+        swept.push(`${lang} :: ${DIFFERENT_NAMESPACE}`);
+      }
+    }
+    expect(
+      swept,
+      '`table.noRows` is gone from a pack. It is NOT the key objectui#7125 ' +
+        'retired — three keys in this repo are spelled `noRows` (`table.noRows`, ' +
+        'the retired `dashboard.noRows`, and `engine.form.noRows` in ' +
+        "app-shell's module-local table), and a bare-name sweep is how the wrong " +
+        'one goes. If `table.noRows` is being retired on its own evidence, delete ' +
+        'this case with it rather than working around it.',
+    ).toEqual([]);
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1105,13 +1105,14 @@ const ar = {
     scatterOneMeasure: "المخطط المبعثر يرسم مقياسًا واحدًا فقط. أبقِ سلسلة واحدة:",
   },
   dashboard: {
-    noRows: "لا توجد صفوف",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "لا توجد بيانات بعد",
       message: "تم تحميل هذه الأداة بنجاح، لكن الاستعلام لم يُرجع أي سجلات بعد.",
@@ -1152,7 +1153,6 @@ const ar = {
     saveLayout: "حفظ التخطيط",
     resetLayout: "إعادة تعيين التخطيط",
     total: "الإجمالي",
-    noDataAvailable: "لا بيانات متاحة",
     noDataSourceFor: "لا مصدر بيانات لـ",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1098,13 +1098,14 @@ const de = {
     scatterOneMeasure: "Ein Streudiagramm zeichnet genau eine Kennzahl. Behalten Sie nur eine Datenreihe:",
   },
   dashboard: {
-    noRows: "Keine Zeilen",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "Noch keine Daten",
       message: "Dieses Widget wurde erfolgreich geladen, die Abfrage hat aber noch keine Datensätze zurückgegeben.",
@@ -1145,7 +1146,6 @@ const de = {
     saveLayout: "Layout speichern",
     resetLayout: "Layout zurücksetzen",
     total: "Gesamt",
-    noDataAvailable: "Keine Daten verfügbar",
     noDataSourceFor: "Keine Datenquelle verfügbar für",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1309,15 +1309,15 @@ const en = {
     saveLayout: 'Save layout',
     resetLayout: 'Reset layout',
     total: 'Total',
-    noDataAvailable: 'No data available',
     noDataSourceFor: 'No data source available for',
-    noRows: 'No rows',
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: 'No data yet',
       message: 'This widget loaded successfully and its query returned no records yet.',

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1102,13 +1102,14 @@ const es = {
     scatterOneMeasure: "Un gráfico de dispersión traza una sola medida. Conserve una sola serie:",
   },
   dashboard: {
-    noRows: "Sin filas",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "Aún no hay datos",
       message: "Este widget se cargó correctamente, pero la consulta todavía no ha devuelto ningún registro.",
@@ -1149,7 +1150,6 @@ const es = {
     saveLayout: "Guardar diseño",
     resetLayout: "Restablecer diseño",
     total: "Total",
-    noDataAvailable: "Sin datos disponibles",
     noDataSourceFor: "Sin fuente de datos para",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1100,13 +1100,14 @@ const fr = {
     scatterOneMeasure: "Un nuage de points trace une seule mesure. Ne conservez qu’une série :",
   },
   dashboard: {
-    noRows: "Aucune ligne",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "Pas encore de données",
       message: "Ce widget s'est chargé correctement, mais la requête n'a encore renvoyé aucun enregistrement.",
@@ -1147,7 +1148,6 @@ const fr = {
     saveLayout: "Enregistrer la mise en page",
     resetLayout: "Réinitialiser la mise en page",
     total: "Total",
-    noDataAvailable: "Aucune donnée disponible",
     noDataSourceFor: "Aucune source de données pour",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1098,13 +1098,14 @@ const ja = {
     scatterOneMeasure: "散布図は1つの指標だけを描画します。系列は1つだけ残してください：",
   },
   dashboard: {
-    noRows: "行がありません",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "まだデータがありません",
       message: "このウィジェットは正常に読み込まれましたが、クエリはまだレコードを返していません。",
@@ -1145,7 +1146,6 @@ const ja = {
     saveLayout: "レイアウトを保存",
     resetLayout: "レイアウトをリセット",
     total: "合計",
-    noDataAvailable: "データがありません",
     noDataSourceFor: "データソースが利用できません：",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1098,13 +1098,14 @@ const ko = {
     scatterOneMeasure: "산점도는 측정값 하나만 그립니다. 계열을 하나만 남기세요:",
   },
   dashboard: {
-    noRows: "행 없음",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "아직 데이터가 없습니다",
       message: "이 위젯은 정상적으로 로드되었지만 쿼리가 아직 레코드를 반환하지 않았습니다.",
@@ -1145,7 +1146,6 @@ const ko = {
     saveLayout: "레이아웃 저장",
     resetLayout: "레이아웃 초기화",
     total: "합계",
-    noDataAvailable: "사용 가능한 데이터 없음",
     noDataSourceFor: "데이터 소스 없음:",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1097,13 +1097,14 @@ const pt = {
     scatterOneMeasure: "Um gráfico de dispersão traça uma única medida. Mantenha apenas uma série:",
   },
   dashboard: {
-    noRows: "Sem linhas",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "Ainda sem dados",
       message: "Este widget foi carregado com sucesso, mas a consulta ainda não retornou nenhum registro.",
@@ -1144,7 +1145,6 @@ const pt = {
     saveLayout: "Salvar layout",
     resetLayout: "Redefinir layout",
     total: "Total",
-    noDataAvailable: "Sem dados disponíveis",
     noDataSourceFor: "Sem fonte de dados para",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1108,13 +1108,14 @@ const ru = {
     scatterOneMeasure: "Точечная диаграмма строит только одну меру. Оставьте один ряд:",
   },
   dashboard: {
-    noRows: "Нет строк",
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: "Данных пока нет",
       message: "Виджет успешно загружен, но запрос пока не вернул ни одной записи.",
@@ -1155,7 +1156,6 @@ const ru = {
     saveLayout: "Сохранить макет",
     resetLayout: "Сбросить макет",
     total: "Итого",
-    noDataAvailable: "Данные недоступны",
     noDataSourceFor: "Нет источника данных для",
     config: {
       breadcrumb: {

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1169,15 +1169,15 @@ const zh = {
     saveLayout: '保存布局',
     resetLayout: '重置布局',
     total: '总计',
-    noDataAvailable: '暂无数据',
     noDataSourceFor: '没有可用的数据源：',
-    noRows: '暂无数据行',
     // objectui#7063 — the DEFAULT empty state every dashboard widget renders
-    // when its query SUCCEEDED and returned nothing. `noRows` above is the
-    // terse fragment it replaces at the render site; the copy here has to
-    // read as a state rather than a failure, which is why it says the widget
-    // loaded. `sourceLabel` carries its own punctuation so the call site
-    // concatenates no separator (see `WidgetEmptyState`).
+    // when its query SUCCEEDED and returned nothing. It replaced the terse
+    // per-widget `noRows` / `noDataAvailable` fragments at the render site;
+    // objectui#7125 deleted those two keys from all ten packs once nothing
+    // read them. The copy here has to read as a state rather than a failure,
+    // which is why it says the widget loaded. `sourceLabel` carries its own
+    // punctuation so the call site concatenates no separator (see
+    // `WidgetEmptyState`).
     empty: {
       title: '暂时还没有数据',
       message: '该组件已成功加载，只是查询目前没有返回任何记录。',


### PR DESCRIPTION
Fixes #7125

Clause-②: no — argued from this diff below, not adopted. One measured fact cuts the other way and is stated there rather than omitted.

Two rows removed from each of the ten locale packs (20 entries), plus the retirement pin and a changeset. `packages/i18n/src/locales/*` only; no widget, no call site, no comment outside the packs was touched.

## The gate that owns "all ten packs move together"

`packages/i18n/src/__tests__/all-locales-key-parity.test.ts` — every pack defines every `en` key and no pack defines a key `en` lacks. Found before editing, named here, run after, and shown **discriminating** below. `en-zh-key-parity.test.ts` is the second, narrower one; both are green.

## Deadness re-measured on this branch, by fully-qualified key, with lit controls

Triage's zero was not adopted. Three independent instruments, each with a control so a zero reads as a measurement:

1. **Text sweep by fully-qualified key** over `packages/` + `apps/` + `scripts/`, locale packs excluded. `dashboard.noRows` → 4 hits, `dashboard.noDataAvailable` → 6 hits, and **every one is a comment** (`WidgetEmptyState.tsx:19,25,26`, `DatasetWidget.tsx:731`, `ObjectDataTable.tsx:619,969`, `PivotTable.tsx:306`, and the #7063 pin test's docblock). Lit controls in the *same query shape*: `dashboard.empty.title` → 2 live `tt()` call sites, `dashboard.total` → 3. The query finds live call sites when they exist.
2. **`pnpm check:i18n-keys`** (the repo's AST call-site gate) stays green across the deletion, with the `en` pack going **2,964 → 2,962** keys and "every in-scope call-site key resolves against the en pack". A live `t()` asking for either key would land red here.
3. **`scripts/check-i18n-dead-keys.mjs`** (the reverse sweep) listed both as candidates before and lists neither after; the `dashboard` namespace goes 4-confirmed/3-needs-review → 4-confirmed/1-needs-review. The lit controls never appear in its candidate list at all.

Also checked, because a fully-qualified sweep alone can miss them: no i18next `keyPrefix` / namespaced `useTranslation('ns')` call sites exist in this repo (so no bare-name resolution channel), and the only `dashboard.${...}` template in the tree is an assertion *message* in a test, not a key. The package's one dynamic key family is `dashboard.trend.`, whose prefix covers neither key.

## Deleted by fully-qualified key, never by bare name

Three keys in this repo are spelled `noRows`. The deletion was done positionally — inside each pack's `dashboard: {` block, asserted to be exactly one block with exactly one matching row per key — so the other two are untouched and are now pinned as untouched:

| key | what it is | this PR |
|---|---|---|
| `table.noRows` (`en.ts:396`) | different namespace | **kept**, pinned |
| `dashboard.noRows` | this card's key | removed |
| `engine.form.noRows` (`app-shell/.../metadata-admin/i18n.ts`, read at `widgets.tsx`) | module-local table, live | **untouched** |

## The rationale stayed; only the keys went

`WidgetEmptyState.tsx:19-26` and the comments in `DatasetWidget.tsx`, `ObjectDataTable.tsx` and `PivotTable.tsx` are not in this diff.

The one comment that *is* edited is the packs' own #7063 block, which said "`noRows` **above** is the terse fragment it replaces" — a sentence that points at a row this PR removes. It keeps every clause of its rationale and now names the retirement instead of a row that is gone. Byte-identical in all ten packs before and after.

## The pin, and why a green parity gate is not enough

`packages/i18n/src/__tests__/dashboard-emptyState-keys-retired-7125.test.ts` — sixth in the retirement-pin series (#4145, #4392, #4730, #5504, #6310), same shape. Every i18n gate in this repo runs call site → key, so **none of them can see a dead key come back**: the reverse sweep is report-only by design, `check:i18n-drift` fires only when a value changes, and ten packs agreeing on a dead key is exactly what the parity gate wants.

## Verification

Union re-run after the final commit, on `2b343c226`:

- `pnpm exec vitest run packages/i18n/ packages/plugin-dashboard/` → `Test Files 150 passed (150)` / `Tests 1781 passed (1781)`, exit 0
- `pnpm check:i18n-keys` → exit 0, "Every in-scope call-site key resolves against the en pack (2962 keys) …"
- `pnpm check:i18n-drift` → exit 0, "0 en value(s) changed (0 key(s) added, **2 removed — those are all-locales-key-parity's**)"
- `node scripts/check-changeset-presence.mjs` → exit 0, "11 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"
- `node scripts/check-changeset-no-major.mjs` → exit 0, "No changeset declares a `major` bump"
- `node scripts/check-control-bytes.mjs` → exit 0, "scanned 6240 tracked text file(s)"
- `pnpm --filter @object-ui/i18n run type-check` → exit 0 (both legs; `tsc -p tsconfig.test.json --listFiles` confirms the new test file is IN that project, so the green covers it)
- `pnpm --filter @object-ui/i18n run lint` → exit 0, 33 pre-existing warnings, **none in a file this PR touches**

Exit codes were captured by redirect-then-read, never through a pipe.

### The parity gate shown discriminating, and the pin shown to catch what it cannot

Run from the committed implementation, restore under `trap ... EXIT INT TERM` with absolute paths via `git checkout HEAD -- ABSOLUTE_PATH`, each mutation proven on disk before any result was read.

**Leg 1 — nine packs deleted, `de` left behind** (the failure mode the card warns about). Mutation proven by `de.ts` blob equal to the base blob `e063401cd…`. Result: exit 1,

```
AssertionError: de has 2 key(s) absent from en: expected [ 'dashboard.noDataAvailable', …(1) ] to deeply equal []
```

— red, naming the tenth pack, plus the pin red on `de :: dashboard.noRows` / `de :: dashboard.noDataAvailable`.

**Leg 2 — the deletion fully reverted in all ten packs.** Parity: `Test Files 1 passed (1)` / `Tests 32 passed (32)` — **green**, because ten packs agreeing on a dead key satisfies it. Pin: exit 1, red, naming all 20 pack::key pairs. That contrast is the whole reason the pin exists.

Both legs restored and **proven by state**: `git diff HEAD` empty *and* all ten pack blobs equal to their HEAD blobs (an empty hash would have been read as failure, not as "nothing to compare").

One honest correction: leg 1's on-disk probe printed `3` where the script's inline annotation said "expect 2" — the regex `^    (noRows|noDataAvailable): ` also matches `table.noRows` in the same file, which is the very key this PR keeps. The mutation itself is proven by the blob hash and by the parity failure naming exactly the two `dashboard.*` keys; the annotation was wrong, not the leg.

## Clause-②: no

The removal moves no accept/reject behaviour on any contract, and it is not on a governed surface: `GOVERNED_SURFACES` in `scripts/check-governed-queue-guard.mjs` is `docs/adr/`, `.claude/`, `skills/`, none of which this diff touches, and the changeset gate reports "0 of them a manifest whose published contract moved". No signature changes: `I18nConfig.resources` is `Record<string, Record<string, unknown>>` and `t`/`tt`/`useSafeTranslate` take `key: string`, so nothing accepts or rejects on the pack's member set. Five prior retirements of exactly this shape shipped as `patch` on `@object-ui/i18n` with a pin test and no contract review.

**The fact that cuts the other way, stated rather than omitted:** `TranslationKeys = typeof en` *is* exported from `@object-ui/i18n` and re-exported by `@object-ui/react`, so the removal does narrow a published structural type. Measured with `tsc`, not asserted — reading the retired member now fails, and the surviving control compiles:

```
type-probe-retired.ts(3,43): error TS2339: Property 'noRows' does not exist on type '{ readonly addWidget: …
type-probe-control.ts  → exit 0    (TranslationKeys['dashboard']['total'])
```

I still read that as `no`: the narrowed thing is a snapshot type of a data catalogue that no API consumes as a constraint — its six occurrences in this repo are import/export lines only — and a review commissioned on it would have no design question to answer. If the maintainer reads a shipped catalogue entry as contract surface regardless of whether anything constrains on it, the datum above is the one to overrule me with, and `needs:contract-review` belongs on this PR.

## Narrowings declared

- **vitest scoped to `packages/i18n/` + `packages/plugin-dashboard/`, not the whole farm.** Could have caught: a test in another package asserting a retired value, or type-depending on the removed members. Why the subset still covers it: the repo-wide AST gate (`check:i18n-keys`) is green over all of `packages/` + `apps/`; a repo-wide text sweep for the retired *values* outside the packs returns only comments plus one hardcoded `title="No rows"` prop in an app-shell preview that never reads the pack; and `plugin-dashboard` is the only runtime consumer of `dashboard.*` — its one assertion on the old copy is a *negative* one (`not.toContain('暂无数据行')`), which deletion can only strengthen. CI runs the full farm regardless.
- **eslint scoped to `packages/i18n`.** That package owns every changed file, so this is the exact per-package command turbo runs for them. It could not catch a rule violation raised in another package by this change — none is possible: no exported symbol, import or call site moved.
- **Typecheck scoped to `@object-ui/i18n` (both legs).** Downstream type-check not run locally; the probe above is the direct measurement of the only cross-package type surface involved, and `TranslationKeys` is a constraint nowhere.
- **`check:eager-closure` not run.** It needs a full `apps/console` vite build to produce `dist/eager-closure.json`. Direction argument: this diff only removes catalogue entries, so the measured `i18n-locales` bytes move DOWN, away from the ceiling; at the script's own ~147 gzipped bytes per short key across ten packs, ~294 bytes against 8,924 of recorded headroom moves the blind-gauge ratio by ~0.003x from 0.10x, nowhere near the 1.00x that errors. CI runs it.
- **Report status:** filed at draft-PR time; CI convergence is the PM's half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_