### PR TITLE
fix(plugin-calendar): align the calendar.allDay default to the pack and drop its dead ternary

### DIFF
--- a/.changeset/7454-calendar-allday-spelling.md
+++ b/.changeset/7454-calendar-allday-spelling.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/plugin-calendar': patch
+---
+
+fix(plugin-calendar): the all-day lane header reads the same string with or without an I18nProvider
+
+`CalendarView`'s `DEFAULT_TRANSLATIONS` table — the `defaults` map behind its
+`createSafeTranslation` factory — spelled `calendar.allDay` as `all-day`, while
+all ten locale packs carry the key and `en` spells it `All Day`. Since
+`createSafeTranslation` serves that table only when no `I18nProvider` is
+mounted, the same lane header rendered `all-day` in a standalone embed and
+`All Day` inside the console. The table now matches the pack, so both paths
+render one string.
+
+The table entry was the only one of the seven that disagreed with its `en`
+value, and the packs predate it by three months — the drift was an oversight,
+not a compact spelling chosen for the 56px gutter (both strings are seven
+characters wide).
+
+Also removes the dead `t('calendar.allDay') === 'calendar.allDay'` ternary that
+guarded the lane header: the factory's provider-less arm returns `defaults[key]`
+before it could ever return the bare key, and with a provider the merged
+resources always carry `calendar.allDay`, so its lowercase branch was
+unreachable from either side.

--- a/packages/plugin-calendar/src/CalendarView.allDaySpelling-7454.test.tsx
+++ b/packages/plugin-calendar/src/CalendarView.allDaySpelling-7454.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7454 — the all-day lane header must read the SAME string whether or
+ * not an `I18nProvider` is mounted.
+ *
+ * It did not. `CalendarView`'s `DEFAULT_TRANSLATIONS` table (the `defaults`
+ * argument of its `createSafeTranslation` factory) carried `'all-day'` while
+ * every one of the ten packs carries the `calendar.allDay` key and `en` spells
+ * it `All Day` — so a standalone embed rendered `all-day` and a provider-mounted
+ * host rendered `All Day` from the same lane header.
+ *
+ * The table entry is a promise — "this is what the pack says" — written one
+ * indirection away from the `t(key, { defaultValue })` form that
+ * `scripts/check-i18n-call-site-keys.mjs` DOES value-compare, which is why no
+ * gate saw the drift. Extending that gate to factory tables is objectui#7567
+ * and deliberately not this file's job; this file pins the one instance.
+ *
+ * WHAT MAKES IT DISCRIMINATE: the expected value is read from the `en` pack
+ * itself, never spelled as a literal here. Put `'all-day'` back into
+ * `CalendarView.tsx`'s table and the provider-less case goes red while the
+ * provider case stays green — which is exactly the split the card recorded.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { getI18n } from 'react-i18next'
+import { I18nProvider, en } from '@object-ui/i18n'
+import { CalendarView, type CalendarViewEvent } from './CalendarView'
+
+/**
+ * The contract, read from the pack rather than restated. `en` is the source the
+ * nine translations follow and the value a provider-mounted host renders, so a
+ * literal here would just be a fourth spelling of the same string.
+ */
+const PACK_ALL_DAY = en.calendar.allDay
+
+const EVENT_TITLE = 'Company holiday'
+const DAY = new Date(2026, 0, 15) // Thu Jan 15, 2026
+
+const ALL_DAY_EVENT: CalendarViewEvent = {
+  id: 'evt-allday-7454',
+  title: EVENT_TITLE,
+  start: new Date(2026, 0, 15, 0, 0, 0),
+  end: new Date(2026, 0, 16, 0, 0, 0), // exclusive midnight end — one whole day
+  allDay: true,
+  data: { id: 'evt-allday-7454' },
+}
+
+/**
+ * Read the all-day row's label gutter by STRUCTURE, not by its text — a query
+ * that searched for the expected string would pass by construction and could
+ * never observe the wrong spelling.
+ *
+ * The row is `[gutter, ...one cell per visible day]`, so the gutter is the
+ * first child of the event bar's grandparent. Both structural assumptions are
+ * asserted rather than trusted: if the markup is reshaped this throws instead
+ * of silently reading some other element's text.
+ */
+function allDayLaneLabel(container: HTMLElement): string {
+  const bar = container.querySelector(`[title="${EVENT_TITLE}"]`)
+  if (!bar) {
+    throw new Error('all-day row not rendered — the event bar is absent, so there is no lane to read')
+  }
+  const dayCell = bar.parentElement
+  const allDayRow = dayCell?.parentElement
+  const gutter = allDayRow?.firstElementChild
+  if (!gutter || gutter === dayCell) {
+    throw new Error('all-day row shape changed — its first child is no longer the label gutter')
+  }
+  return (gutter.textContent ?? '').trim()
+}
+
+/**
+ * Captured across the three cases below so the last one can compare the two
+ * renders directly. They are filled in declaration order, and the comparison
+ * asserts it got both rather than comparing two `undefined`s.
+ */
+let labelWithoutProvider: string | undefined
+let labelWithProvider: string | undefined
+
+describe('objectui#7454 — calendar.allDay renders one spelling on both paths', () => {
+  /**
+   * ORDER IS LOAD-BEARING, and this case guards its own precondition rather
+   * than relying on the order alone. `createI18n` calls `instance.use(
+   * initReactI18next)`, which installs a MODULE-LEVEL global instance; once the
+   * provider case below has mounted, a later provider-less render would find
+   * that global, take `useObjectTranslation`'s instance path and serve the pack
+   * value — passing without ever reading the defaults table. `getI18n()` is
+   * how that contamination is caught: undefined means no instance exists yet,
+   * so this render genuinely exercises `createSafeTranslation`'s fallback arm.
+   */
+  it('provider-less: the defaults table serves the pack spelling', () => {
+    expect(getI18n()).toBeUndefined()
+
+    const { container } = render(
+      <CalendarView events={[ALL_DAY_EVENT]} view="day" currentDate={DAY} />,
+    )
+    labelWithoutProvider = allDayLaneLabel(container)
+    expect(labelWithoutProvider).toBe(PACK_ALL_DAY)
+  })
+
+  it('with an I18nProvider: the en pack value renders', () => {
+    const { container } = render(
+      <I18nProvider config={{ defaultLanguage: 'en', detectBrowserLanguage: false, warnMissingKeys: false }}>
+        <CalendarView events={[ALL_DAY_EVENT]} view="day" currentDate={DAY} />
+      </I18nProvider>,
+    )
+    labelWithProvider = allDayLaneLabel(container)
+    expect(labelWithProvider).toBe(PACK_ALL_DAY)
+  })
+
+  it('the two paths agree — that they disagreed is the whole of this card', () => {
+    expect(labelWithoutProvider).toBeTypeOf('string')
+    expect(labelWithProvider).toBeTypeOf('string')
+    expect(labelWithoutProvider).toBe(labelWithProvider)
+  })
+})

--- a/packages/plugin-calendar/src/CalendarView.tsx
+++ b/packages/plugin-calendar/src/CalendarView.tsx
@@ -81,7 +81,7 @@ const DEFAULT_TRANSLATIONS: Record<string, string> = {
   'calendar.day': 'Day',
   'calendar.newEvent': 'New event',
   'calendar.moreEvents': '+{{count}} more',
-  'calendar.allDay': 'all-day',
+  'calendar.allDay': 'All Day',
 }
 
 /**
@@ -1268,7 +1268,7 @@ function TimeGridView({
       {allDayEvents.length > 0 && (
         <div className="flex border-b bg-muted/20 max-h-[140px] overflow-y-auto">
           <div className="w-14 shrink-0 border-r flex items-start justify-end pr-1 pt-1 text-[10px] text-muted-foreground sticky left-0 bg-muted/20">
-            {t('calendar.allDay') === 'calendar.allDay' ? 'all-day' : t('calendar.allDay')}
+            {t('calendar.allDay')}
           </div>
           {days.map((day) => {
             const key = dayKey(day)


### PR DESCRIPTION
Fixes #7454

`Clause-②: no` — determined from this diff, not adopted. The diff moves no
declaration and changes no published surface: the only changed line in shipped
code is a value inside the module-private `const DEFAULT_TRANSLATIONS`, plus one
JSX expression. No `export` line is added, removed or moved (the sole
`export`/`type` token anywhere in the diff is a `type` **import** in the new
test file, which `files: ["dist", ...]` never publishes).

Scope is the triage ruling **R+129**, not the card title: the title still
describes two halves and only the instance half is here. The class half —
value-comparing factory `defaults` tables in `scripts/check-i18n-call-site-keys.mjs`
— is objectui#7567 and is untouched, as are `packages/i18n/src/locales/*`.

## What changed

Two lines in `packages/plugin-calendar/src/CalendarView.tsx`:

- the `DEFAULT_TRANSLATIONS` entry `'calendar.allDay': 'all-day'` becomes `'All Day'`
- the lane header's ternary `t('calendar.allDay') === 'calendar.allDay' ? 'all-day' : t('calendar.allDay')` becomes `t('calendar.allDay')`

Both sites were re-derived by content on this base rather than taken from
R+129's line numbers: they are still at **84** and **1271**, so nothing drifted
from the `e304a4e` measurement.

## R+129's three grounds, re-measured

1. **The packs say `All Day`.** Confirmed, and stronger than stated: all **ten**
   packs define `calendar.allDay` (`en.ts:671` is `allDay: 'All Day'`), so no
   language depends on the local table.
2. **Sibling entries match their `en` value.** Confirmed, with one arithmetic
   correction: the table holds **seven** entries, so there are **six** siblings,
   not seven — and **6 of 6** match `en` exactly. The direction of the ground
   holds and is unanimous; only the count in the ruling's phrasing was off by
   one.
3. **The lowercase branch is unreachable.** Confirmed by reading
   `createSafeTranslation` (`packages/i18n/src/useSafeTranslation.ts`) rather
   than taking triage's word. Its provider-less arm is
   `defaults[key] || inlineDefault || key`, and `defaults` carries a non-empty
   `calendar.allDay`, so the `|| key` arm cannot be reached for this key. The
   provider path is i18next's own `t`, and `createI18n` lays the built-in packs
   under any caller resources, so it too carries the key.

## Stop-condition: swept, and it does not fire

Nothing marks the lowercase spelling as deliberate.

- **No pin.** Repo-wide, the only two occurrences of the literal `all-day` that
  can reach a user are the two lines this PR changes. Every other hit is prose
  about the concept, a spec `describe()` string, or a test fixture's `id`.
- **No width constraint.** The gutter is `w-14` (56px) with `pr-1` and no
  `truncate`, and the two candidate strings are **both seven characters**, so
  there is no width argument that distinguishes them.
- **No design note — and evidence the other way.** The spelling entered in
  `20ae38aff` (2026-05-11), whose message says only "Adds calendar.allDay
  translation key with English fallback 'all-day'", with no rationale. `en.ts`
  had said `All Day` since `bd3deb60f` (2026-02-08) — **three months earlier**,
  and an ancestor of that commit. That same message records the author verifying
  in a Chinese locale ("campaigns show as horizontal bars in 全天 row"), so the
  lowercase fallback was never seen rendering. That is the oversight shape, not
  the objectui#7443 shape.

The ternary landed in that same commit alongside the table entry, and it is the
**only** bare-key guard among the **seven** `t('calendar.` call sites in the
file — one label guarded, six not. That asymmetry is what makes it a leftover
rather than a policy.

## Tests

New: `packages/plugin-calendar/src/CalendarView.allDaySpelling-7454.test.tsx`,
three cases — provider-less, provider-mounted, and the two compared directly.

It discriminates on the **fact**, never on the assertion: the expected value is
read from the pack itself (`en.calendar.allDay`), so a literal spelling never
appears in the assertion. The lane header is located by **structure** (first
child of the event bar's grandparent, with both structural assumptions asserted)
rather than by searching for the expected text, which would have passed by
construction.

The provider-less case guards its own precondition with `expect(getI18n()).toBeUndefined()`.
`createI18n` installs a module-level i18next global via `initReactI18next`, so
without that guard a reordering that let the provider case run first would leave
the "provider-less" render quietly reading the pack and passing for the wrong
reason.

**Discrimination, measured twice.** On the pristine base before any edit, the
provider-less case rendered `all-day` and the provider case rendered `All Day`
— the card's exact split, with react-i18next's `NO_I18NEXT_INSTANCE` notice on
stderr confirming the fallback arm really was the one under test. Then, as a
formal ablation on the committed tree:

```
HEAD_BLOB=389b6e119adb4e0a88d1ccfcd8ec9519049a9730
injected-text count (want 1): 1
removed-text count  (want 0): 0
MUTATED_WORKTREE_BLOB=5d44b909620a43cedd1568e32219899946c97a21
MUTATION CONFIRMED ON DISK
MUTATED_TEST_EXIT=1        Tests  2 failed | 1 passed (3)
   AssertionError: expected 'all-day' to be 'All Day'
RESTORED_WORKTREE_BLOB=389b6e119adb4e0a88d1ccfcd8ec9519049a9730
git diff HEAD byte length (want 0): 0
RESTORE CONFIRMED BY STATE
RESTORED_TEST_EXIT=0       Tests  3 passed (3)
```

The mutation edited the table entry in `CalendarView.tsx`; the assertion was not
touched. Both legs ran under `trap ... EXIT INT TERM` with absolute paths,
restoring via `git checkout HEAD -- ABSOLUTE_PATH`; the restore is proven by
state (worktree blob equal to the HEAD blob **and** an empty `git diff HEAD`),
not by an exit code. Note the mutated run leaves the **provider** case green —
that one-of-three split is the defect itself, reproduced on demand.

### Gate results, all at `e9566e8d6`

Run from the repo root (the package-scoped vitest form is refused here as a
known false-green), exit codes captured by redirect-then-read, never through a
pipe.

| gate | result |
|---|---|
| `vitest run packages/plugin-calendar/` | `Test Files 23 passed (23)` · `Tests 134 passed (134)` |
| `turbo run type-check --filter=@object-ui/plugin-calendar` | `Tasks: 15 successful, 15 total` |
| `pnpm check:i18n-keys` | exit 0 |
| `pnpm check:i18n-drift` | "No en value changed in this range." |
| `pnpm check:control-bytes` | "OK (scanned 6240 tracked text file(s); skipped 85 binary)" |
| `pnpm check:phantom-deps` | "Every in-scope import is declared by the package that publishes it." |
| `pnpm check:vi-mock-specifiers` / `check:vi-mock-inherit` | OK |
| `pnpm changeset:check` | "All workspace packages are in the changeset fixed group." · "No changeset declares a `major` bump." |

The package's `type-check` is `tsc --noEmit && tsc -p tsconfig.test.json`, and
that second config's `include` names `src/**/*.test.tsx` — so the new test file
is genuinely type-checked, not merely adjacent to a green typecheck.

**`check:i18n-keys` is not evidence for this change, and is reported as such.**
It is green before the fix, after the fix, **and in the ablation's mutated
state** (`MUTATED_I18N_GATE_EXIT=0`, full verdict line printed). Its own census
puts this entry under "1114 module-local table", which it never value-compares —
that blindness is precisely objectui#7567.

## Narrowings, declared

- **Lint.** Run over the two changed source files instead of `turbo run lint`
  across the repo. What the full run could have caught that a subset cannot is a
  verdict moving on a file this diff did not touch — and it cannot here: the
  root `eslint.config.js` enables **no** type-aware linting (no `projectService`,
  no `project:`, no `parserOptions`, no `recommendedTypeChecked`), so each
  file's verdict is a function of its own bytes plus the shared config, and this
  diff changes no config file. File count read from eslint's own `--format json`
  output: **2 files, 0 errors**. The 24 warnings on `CalendarView.tsx` are
  pre-existing and sit on lines 123-1445, none on 84 or 1271.
- **Tests.** `packages/plugin-calendar/` rather than the whole suite. CI runs the
  full farm regardless; this narrowing covers the only package whose bytes moved.
- **Gates.** The list above rather than every `check:*` script. Derived from this
  diff's actual paths (a plugin source file, a new test file, a changeset), not
  copied from the dispatch. CI runs the rest.

## Filed, not fixed here

`#7572` — `createI18n`'s `resources` merge is one level deep, so a caller
overriding part of an existing group replaces the whole group and drops its
sibling keys. That is the single construction under which a provider-mounted
host could still see a bare `calendar.allDay`, and it is why the ternary's
deletion is safe rather than merely tidy: in that scenario the file's other six
`calendar.*` labels already render raw keys, so a guard on one of them was never
a defence. Fixing it belongs in `packages/i18n`, out of this fence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_