### PR TITLE
test(app-shell): pin the target-required degrade set equal across app-shell and plugin-grid

### DIFF
--- a/.changeset/degrade-set-twin-pin-5880.md
+++ b/.changeset/degrade-set-twin-pin-5880.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only change: pins the target-required degrade set (`{lookup, master_detail}`) equal
+across `@object-ui/app-shell`'s `paramToField` and `@object-ui/plugin-grid`'s
+`bulkParamToField`, which were two independent statements of one rule with nothing
+mechanical holding them together. No published behaviour changes, no new exported symbol,
+and neither set's membership was touched — the pin derives each package's effective set
+through its own adapter and asserts the contents equal.

--- a/packages/app-shell/src/utils/degradeSetTwin-5880.test.ts
+++ b/packages/app-shell/src/utils/degradeSetTwin-5880.test.ts
@@ -1,0 +1,241 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#5880 — the TARGET-REQUIRED DEGRADE set is stated once per package,
+ * and this file is the only thing holding the two statements together.
+ *
+ * The rule: "this picker widget cannot query without a DECLARED target, so
+ * degrade it to a plain text input." It has exactly two production statements,
+ * both spelled `new Set(['lookup', 'master_detail'])`:
+ *
+ *  - `packages/app-shell/src/utils/paramToField.ts` — read by the exported
+ *    `paramDegradesWithoutTarget(param)`, keyed on `ActionParamDef.referenceTo`;
+ *  - `packages/plugin-grid/src/components/bulkParamToField.ts` — read inline in
+ *    `bulkParamToField`, keyed on `BulkActionParam.object`.
+ *
+ * The two are documented as twins ("mirrors app-shell's `paramToField`", "same
+ * last-resort fallback as app-shell's `paramToField`"), and before this file
+ * NOTHING mechanical held them together: no shared object, no pin, no gate that
+ * could report a split. Members were identical, so there was no measured
+ * divergence — the latent kind, not a live defect.
+ *
+ * Cost if it drifts: a third picker widget that needs a declared target gets
+ * added to one set. The bulk dialog then silently stops degrading it — a picker
+ * that cannot query, rendered as a picker.
+ *
+ * ## Why a PIN and not a shared constant
+ *
+ * A shared member set was the alternative, and it is declined on measurement,
+ * not on taste:
+ *
+ *  1. It would only share the MEMBER half. The two predicates read different
+ *     fields on different types (`ActionParamDef.referenceTo` vs
+ *     `BulkActionParam.object`), so each surface keeps its own "has a target?"
+ *     half either way. The shared constant therefore buys no coverage this pin
+ *     does not already have — both catch exactly membership drift.
+ *  2. It costs a NEW EXPORTED SYMBOL on a published package (`@object-ui/core`
+ *     or `@object-ui/types`) — a permanent public surface, for a two-member
+ *     internal heuristic. This pin exports nothing and publishes nothing.
+ *  3. objectui#5312 ruled the deliberate separation for the SIBLING rule in
+ *     these same two files (`LOOKUP_WIDGET_TYPES` vs `widgetNeedsDataSource`),
+ *     because `user` is reference-bearing but must never degrade. Converging
+ *     the member set of the smaller rule would re-open the question #5312 shut.
+ *
+ * The pin lives in app-shell rather than plugin-grid because the dependency
+ * direction already runs that way: `@object-ui/app-shell` declares
+ * `@object-ui/plugin-grid` in `devDependencies` and `peerDependencies`, while
+ * plugin-grid does not depend on app-shell. The cross-package source import
+ * below is the shape already established by
+ * `packages/app-shell/src/layout/__tests__/activityItemType-6730.test.ts` and
+ * `packages/plugin-grid/src/__tests__/rowRecordCrudVerdict.test.tsx`. So this
+ * file adds no dependency edge at all.
+ *
+ * ## Why the sets are DERIVED, not read
+ *
+ * Neither `LOOKUP_WIDGET_TYPES` is exported, and neither should become exported
+ * just to be testable — that is the published-surface cost item 2 refuses. So
+ * each set is derived through its own package's real adapter, over one shared
+ * probe vocabulary. That reads the EFFECTIVE rule, which is the thing that can
+ * drift, rather than the text of a declaration.
+ *
+ * ## Why CONTENTS and not cardinality
+ *
+ * "Both sets have two members" passes against two sets that disagree — swap a
+ * member on one side and the count is untouched. The load-bearing assertion is
+ * set equality over the derived contents.
+ *
+ * ## Ablation direction, predicted before running
+ *
+ * Add a member to (or drop one from) EITHER package's set and the equality goes
+ * RED, with a message naming both packages and the side that moved. The lit
+ * control below goes red in the same run when app-shell is the side that moved,
+ * and stays green when plugin-grid is — which is what makes it a control on
+ * probe liveness rather than a second copy of the pin.
+ *
+ * The control earned its keep on first run: it caught that this file's probe
+ * vocabulary reaches `tree`, a degrading row the narrower sweep in
+ * `paramToField.test.ts` never sees. That was the instrument being wrong, not
+ * the sets — both packages degrade `tree`, and neither set was touched.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FORM_FIELD_TYPES } from '@object-ui/fields';
+import { type ActionParamDef } from '@object-ui/core';
+import { FieldType } from '@objectstack/spec/data';
+import { enumOptions } from '@object-ui/test-support';
+import type { BulkActionParam } from '@object-ui/types';
+
+import { paramDegradesWithoutTarget } from './paramToField';
+// The twin, by source path — see the dependency-direction note above.
+import { bulkParamToField } from '../../../plugin-grid/src/components/bulkParamToField';
+
+/**
+ * The spec's own `FieldType` vocabulary.
+ *
+ * The wrapper walk is `@object-ui/test-support`'s shared reader (objectui#6924);
+ * the THROW stays HERE, because the reader deliberately answers `[]` rather than
+ * raising and this read is module-scope. A bare `enumOptions` call would trade a
+ * loud failure for a silently empty vocabulary, and every assertion below would
+ * then pass over nothing.
+ */
+const readSpecFieldTypes = (): readonly string[] => {
+  const options = enumOptions(FieldType);
+  if (options.length === 0) {
+    throw new Error('could not read FieldType.options from @objectstack/spec');
+  }
+  return options;
+};
+
+/**
+ * Param-only dialect spellings BOTH modules fold onto the canonical widget
+ * vocabulary (`PARAM_TYPE_ALIASES` / `BULK_PARAM_TYPE_ALIASES`). Neither map is
+ * exported, so they are restated here as inputs to probe with — never as the
+ * answer being checked.
+ */
+const PARAM_DIALECT = ['reference', 'checkbox', 'datetime-local', 'autonumber'] as const;
+
+/**
+ * The probe domain, and why it is complete for this question.
+ *
+ * Both sets are tested against WIDGET KEYS — the output of
+ * `resolveParamWidgetType` / `resolveBulkParamWidgetType`. `FORM_FIELD_TYPES` is
+ * `Object.keys(fieldWidgetMap)`, i.e. the entire widget-key domain, so any key a
+ * future author could add to either set is probed here. The spec vocabulary and
+ * the param dialect are added because a set member could also be added in a RAW
+ * spelling by mistake; `no-such-type` is the unknown-input control.
+ */
+const PROBE_VOCABULARY: readonly string[] = [
+  ...new Set<string>([
+    ...FORM_FIELD_TYPES,
+    ...readSpecFieldTypes(),
+    ...PARAM_DIALECT,
+    'no-such-type',
+  ]),
+].sort();
+
+/** app-shell's set, read through the ONE exported answer to the question. */
+const shellDegrades = (type: string): boolean =>
+  paramDegradesWithoutTarget({ name: 'probe', label: 'Probe', type } as ActionParamDef);
+
+/**
+ * plugin-grid's set, read through `bulkParamToField`.
+ *
+ * `bulkParamToField` exposes no predicate, so degradation is observed as the
+ * difference the declared target makes: the widget collapses to `text` WITHOUT
+ * a target and does not collapse WITH one. Both halves are needed — a param
+ * that resolves to `text` anyway (`text` itself, `no-such-type`) yields `text`
+ * on both passes and is correctly not counted as degrading.
+ */
+const gridDegrades = (type: string): boolean => {
+  const base = { name: 'probe', label: 'Probe', type } as BulkActionParam;
+  const withoutTarget = bulkParamToField(base, false);
+  const withTarget = bulkParamToField({ ...base, object: 'accounts' }, false);
+  return withoutTarget.type === 'text' && withTarget.type !== 'text';
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('the target-required degrade set is the same set in both packages (objectui#5880)', () => {
+  it('app-shell `paramToField` and plugin-grid `bulkParamToField` degrade exactly the same types', () => {
+    // plugin-grid warns on every degrading probe by design (dev-only guidance
+    // for the param author); silence it so the sweep does not flood the run.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const shellSet = PROBE_VOCABULARY.filter(shellDegrades);
+      const gridSet = PROBE_VOCABULARY.filter(gridDegrades);
+
+      // LIT CONTROL, not the pin. Two EMPTY sets are equal, so the equality
+      // below would pass vacuously if the probe stopped reaching either
+      // adapter. Naming the rows that actually degrade keeps the sweep from
+      // going quietly hollow.
+      //
+      // TWO of the four rows are NOT set members — they reach the members by
+      // resolution, and both were measured here rather than assumed:
+      //   - `reference` — folded onto `lookup` by both modules' own alias map
+      //     (`PARAM_TYPE_ALIASES` / `BULK_PARAM_TYPE_ALIASES`);
+      //   - `tree` — a spec `FieldType` that is NOT a widget-map key, so
+      //     `resolveFormWidgetType` sends it through
+      //     `packages/fields/src/field-type-alias.ts` (`tree: 'field:lookup'`)
+      //     and it arrives as `lookup`. It is absent from the narrower sweep in
+      //     `paramToField.test.ts` only because that vocabulary is
+      //     `FORM_FIELD_TYPES` + the dialect, and `tree` is in neither.
+      // Both sides agree on both rows, which is the point.
+      //
+      // If a deliberate, CO-ORDINATED membership change lands, this line is
+      // updated with it — that is a behaviour change and wants the thought.
+      expect(
+        shellSet,
+        "app-shell's degrade set is not the one objectui#5880 measured. Either the probe went " +
+          'HOLLOW (it reached no adapter, and the equality below would then prove nothing by ' +
+          'comparing two empty sets), or `LOOKUP_WIDGET_TYPES` in ' +
+          'packages/app-shell/src/utils/paramToField.ts MOVED — in which case plugin-grid\'s twin ' +
+          'in packages/plugin-grid/src/components/bulkParamToField.ts needs the same move, and ' +
+          'this line is updated with it.',
+      ).toEqual(['lookup', 'master_detail', 'reference', 'tree']);
+
+      // THE PIN. Contents, not cardinality: "both have 2 members" is satisfied
+      // by two sets that disagree.
+      expect(
+        gridSet,
+        'the target-required degrade set has DRIFTED: `LOOKUP_WIDGET_TYPES` in ' +
+          'packages/plugin-grid/src/components/bulkParamToField.ts no longer degrades the same ' +
+          'types as `LOOKUP_WIDGET_TYPES` in packages/app-shell/src/utils/paramToField.ts. ' +
+          'These two are documented twins with no shared object between them — whichever side ' +
+          'moved, the other needs the same move (or objectui#5880 needs re-deciding).',
+      ).toEqual(shellSet);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('the probe reaches BOTH adapters — neither side is answering for the other', () => {
+    // Control on the derivation itself: `gridDegrades` observes plugin-grid's
+    // module, not app-shell's. A copy-paste that pointed both readers at the
+    // same adapter would make the pin above unfalsifiable, and this is what
+    // notices. plugin-grid's degrade path warns; app-shell's does not.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(gridDegrades('lookup')).toBe(true);
+      expect(
+        warn.mock.calls.some(([m]) => String(m).includes('[BulkActionDialog]')),
+        'gridDegrades did not reach plugin-grid `bulkParamToField`',
+      ).toBe(true);
+
+      warn.mockClear();
+      expect(shellDegrades('lookup')).toBe(true);
+      expect(
+        warn.mock.calls.length,
+        'shellDegrades reached plugin-grid — the two readers are not independent',
+      ).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #5880

Clause-②: no — two added files, zero new exported symbols, no source file touched, and the changeset declares the change as releasing nothing. Determined from the diff itself: `git diff BASE..HEAD | grep '^+.*\bexport\b'` returns nothing.

## Premise re-verified first (the card is from 2026-08-24)

Measured on `origin/main` at `ac8abb0f5` before writing anything. The premise **holds**:

| what the card asserts | measured |
|---|---|
| two statements, one per package | yes — `git grep LOOKUP_WIDGET_TYPES` finds exactly two declarations |
| still `{lookup, master_detail}` | yes — both still exactly two members |
| no third site | none — see the lit controls below |
| neither already repaired | neither; nothing mechanical ties them |

One drift, and it is the card's only error: the plugin-grid site is at **`bulkParamToField.ts:41`**, not `:40`. The app-shell site is at `paramToField.ts:54` as stated.

### Lit controls, because three of these answers are zeros

A zero from an unlit instrument is not a reading, so every zero-answering query was run in the same shape against a population known to be non-empty:

- **Set-literal shape** — `new Set([...])` containing `'lookup'`: 7 hits, of which only the two under test have exactly two members. *Control:* the same query with `'boolean'` returns `SELECT_TYPES`, `USER_FILTER_TYPES`, `FILTERABLE_FIELD_TYPES` — the shape matches.
- **Array-const shape** — the shape a Set-only query would miss (this is the `COMPONENTS_LEAK_GROUPS` trap: a `readonly LedgerGroup[]` reads as "not found" against an object-literal query). `const NAME = [...]` containing `'lookup'`: **zero**. *Control:* the identical query with no member filter returns `ENV_ROWS`, `ROW_ACTION_DEFS`, `EXCLUDED_META_TYPES` and more — the shape matches, so the zero is a measurement.
- **Multi-line array shape** — same query spanning lines: returns `INVENTORY`, `DESIGNER_FIELD_TYPES`, `UNRULED_LIVE_TYPES`, none of which is this rule. *Control:* the same query on `'currency'` returns `TABLE_COLUMN_TYPES`.
- **The predicate shape** — the rule can be restated with no named set at all, so the decisive query was for the degrade predicate itself (a targetless picker falling back to text). It returns exactly two production sites: `paramToField.ts:84` and `bulkParamToField.ts:134`. Every other hit is a widget-internal "do I have a datasource" check, not the param-degrade rule.

## What this adds

One test file. It derives **each package's effective degrade set through that package's own adapter**, over one shared probe vocabulary, and asserts the **contents** equal.

Contents, not cardinality — deliberately. "Both sets have two members" passes against two sets that disagree; swap a member on one side and the count is untouched.

The sets are derived rather than read because neither `LOOKUP_WIDGET_TYPES` is exported, and neither should become exported just to be testable. app-shell is read through its exported `paramDegradesWithoutTarget`; plugin-grid has no predicate to export, so degradation is observed as the difference a declared target makes — the widget collapses to `text` without one and does not collapse with one. Both halves are needed: a param that resolves to `text` anyway yields `text` on both passes and is correctly not counted.

## Why the pin, and not the shared constant

Triage recommended the pin and left explicit latitude: *"If a shared home both packages already depend on exists (e.g. `@object-ui/types`) the dev may choose the shared-constant shape instead — say which and why in the PR."*

**I took the pin.** A shared home does exist — both packages already import `EXPANDABLE_FIELD_TYPES` from `@object-ui/core`, so triage's stated cost (a new dependency edge) is actually **not** what the shared constant would cost here. That argument is weaker than triage assumed, and I am saying so rather than quietly leaning on it. The pin still wins on three measured grounds:

1. **A shared constant would share only the member half.** The two predicates read different fields on different types (`ActionParamDef.referenceTo` vs `BulkActionParam.object`), so each surface keeps its own "has a target?" half either way. Both shapes therefore catch exactly membership drift — the shared constant buys no coverage this pin does not already have.
2. **It costs a new exported symbol on a published package**, permanently, for a two-member internal heuristic. That is `Clause-②: yes` and a contract review, bought for no additional coverage per (1). This file exports nothing.
3. **#5312 ruled the deliberate separation** for the sibling rule in these same two files, because `user` is reference-bearing but must never degrade. Converging the member set of the smaller rule re-opens a question that ruling shut.

The pin lives in **app-shell**, not plugin-grid, because the dependency direction already runs that way: app-shell declares plugin-grid in `devDependencies` and `peerDependencies`, while plugin-grid does not depend on app-shell. The cross-package source import is the shape already established by `packages/app-shell/src/layout/__tests__/activityItemType-6730.test.ts` and `packages/plugin-grid/src/__tests__/rowRecordCrudVerdict.test.tsx`. **So this adds no dependency edge at all.**

For the record, the third option the card listed — "rule the duplication acceptable and say so in both files" — was not available and I did not argue for it. It is the comment #5312 measured as false for the twin rule in these very files.

## The set membership was NOT changed

Neither `LOOKUP_WIDGET_TYPES` was touched. `git diff` shows two **added** files and no modified source. Which field types degrade is a behaviour question and needs its own ruling.

## Something the instrument caught about itself

The lit control failed on first run, and it was right to. My probe vocabulary is wider than the existing sweep in `paramToField.test.ts` (it adds the spec `FieldType` vocabulary), and it turned up a **fourth** degrading row: `tree`. `tree` is a spec field type that is not a widget-map key, so `resolveFormWidgetType` sends it through `packages/fields/src/field-type-alias.ts` (`tree: 'field:lookup'`) and it arrives as `lookup`.

**Both packages degrade `tree`, identically.** This is not a divergence and not a defect — it is a row the narrower existing sweep never sees. The instrument was wrong, not the sets; I corrected the control's expected literal and documented the route. Recording it because a silently-corrected control is indistinguishable from a control that was never lit.

## Verification

**The pin discriminates — ablated in both directions**, each leg with the mutation proven on disk before any result was read, and each restore proven **by state** (not by exit code) under `trap ... EXIT INT TERM` with absolute paths, restoring via `git checkout HEAD -- ABSOLUTE_PATH`. Run against the final HEAD, with the implementation already committed so the restore leg had a real reference point.

| leg | mutation | result | which assertion fired |
|---|---|---|---|
| A | plugin-grid: add `'user'` to its set | RED | the **pin**, naming `packages/plugin-grid/.../bulkParamToField.ts` |
| B | app-shell: drop `'master_detail'` | RED | the **lit control**, naming `packages/app-shell/.../paramToField.ts` |

Each side's movement is caught by a different assertion, and each message names the package that actually moved. Baseline before both legs: 2 passed.

Restore proof, both legs — blob identity, with an empty hash read as failure rather than as "nothing to compare":

```
RESTORED-OK packages/plugin-grid/src/components/bulkParamToField.ts
  disk=c7b6e1db1d5739ef6f8e46849067f2a000d8f597 == HEAD=c7b6e1db1d5739ef6f8e46849067f2a000d8f597 ; git diff HEAD empty
RESTORED-OK packages/app-shell/src/utils/paramToField.ts
  disk=1800efd21993e5546d6d495eb39388c69a04fc71 == HEAD=1800efd21993e5546d6d495eb39388c69a04fc71 ; git diff HEAD empty
```

No rebuild leg is owed: the root vitest config aliases every package specifier to its `src`, and the plugin-grid import is a relative source path, so both legs read source directly and never a stale `dist`.

**Gate union, all run on the final HEAD `a59038538`.** Exit codes captured by redirect-then-read, never through a pipe; each verdict is the gate's own line.

```
check-changeset-presence     EXIT=0  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)
                                     Every one of them has an EMPTY frontmatter — declared as releasing nothing
check-changeset-no-major     EXIT=0  No changeset declares a `major` bump.
check-control-bytes          EXIT=0  OK (scanned 6240 tracked text file(s); skipped 85 binary)
check-package-self-import    EXIT=0  No package names itself inside its own src/.
check-phantom-dependencies   EXIT=0  Every in-scope import is declared by the package that publishes it.
check-vi-mock-specifiers     EXIT=0  OK
check-vi-mock-inherit        EXIT=0  OK
check-lint-coverage          EXIT=0  46/46 packages linted, 0 with outstanding errors
check-type-check-coverage    EXIT=0  45/46 via `type-check`, 0 known-broken
```

Tests, at `a59038538`: `pnpm exec vitest run` from the repo root over the pin and its four nearest neighbours (`paramToField.test.ts`, `bulkParamToField.test.ts`, `expandableFamily.identity-5874.test.ts`, `resolveActionParams.test.ts`) — **Test Files 5 passed (5), Tests 79 passed (79)**.

Type check: `pnpm --filter @object-ui/app-shell type-check` — exit 0, and the script name echoed (`tsc --noEmit && tsc -p tsconfig.test.json`), so this is not the zero-match false green. Dependency closure built first (`pnpm --workspace-concurrency=2 --filter '@object-ui/app-shell^...' build`), because `tsconfig.test.json` drops `paths` and resolves workspace packages through built declarations.

**And the type-check green actually covers the new file** — `tsc -p tsconfig.test.json --listFiles` confirms both of these are in the 4545-file program, rather than silently excluded:

```
/home/user/objectui-5880/packages/plugin-grid/src/components/bulkParamToField.ts
/home/user/objectui-5880/packages/app-shell/src/utils/degradeSetTwin-5880.test.ts
```

## Declared narrowings

**Lint.** Ran `eslint --no-inline-config --format json` over the one changed file rather than `turbo run lint` over the repo. What the full run could have caught that a single-file run cannot: a rule whose verdict on an *untouched* file changes because of my diff. It cannot happen here, and the reason is read from eslint's own config rather than assumed: `eslint.config.js` configures **no type-aware linting** (no `project`, no `projectService`, no `tsconfigRootDir`), so no rule can see across file boundaries, and my diff modifies zero existing files. File count read from the JSON output, not from prose: **1 file, 0 errors, 0 warnings.** `check-lint-coverage` (46/46 packages) was run in full and covers the "is every package linted at all" question separately.

**Tests.** Ran the pin plus its four nearest neighbours rather than the full suite. What the full run could catch: a module-state interaction between my new file and an unrelated suite sharing a worker. The neighbours chosen are precisely the suites that import the same two adapters and the same shared `EXPANDABLE_FIELD_TYPES` object (the one piece of cross-test shared mutable state in this area, which the neighbouring suites spy on). CI runs the full farm regardless.

**Gates.** Ran the nine derived above rather than enumerating every workflow. Derived from the diff's actual surface: one `.test.ts` under a released package's `src/`, plus one `.changeset/` file. Gates keyed on docs, i18n, skills, dist, SDUI registration, icons and spec symbols have no input in this diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_