### PR TITLE
docs(console): re-fence three design-token lists as tables, not `tsx`

### DIFF
--- a/apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md
+++ b/apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md
@@ -204,28 +204,34 @@ const [showDebug, setShowDebug] = useLocalStorage('console:metadata-panel', fals
 ## Visual Design Specs
 
 ### Color Palette
-```tsx
-// Reduce visual weight
-background: "bg-background" // Instead of "bg-muted/30"
-border: "border-border/50" // Subtle
-header: "bg-muted/5" // Barely visible
-```
+
+Reduce visual weight:
+
+| Slot | Class | Note |
+|:--|:--|:--|
+| `background` | `bg-background` | Instead of `bg-muted/30` |
+| `border` | `border-border/50` | Subtle |
+| `header` | `bg-muted/5` | Barely visible |
 
 ### Typography
-```tsx
-// Hierarchy
-title: "text-xs font-semibold uppercase tracking-wider text-muted-foreground"
-content: "text-sm font-mono"
-label: "text-xs text-muted-foreground"
-```
+
+Hierarchy:
+
+| Slot | Classes |
+|:--|:--|
+| `title` | `text-xs font-semibold uppercase tracking-wider text-muted-foreground` |
+| `content` | `text-sm font-mono` |
+| `label` | `text-xs text-muted-foreground` |
 
 ### Spacing
-```tsx
-// More breathing room
-panel: "p-0" // Let inner components control padding
-section: "p-4 space-y-4"
-compact: "p-3 space-y-3"
-```
+
+More breathing room:
+
+| Slot | Classes | Note |
+|:--|:--|:--|
+| `panel` | `p-0` | Let inner components control padding |
+| `section` | `p-4 space-y-4` | |
+| `compact` | `p-3 space-y-3` | |
 
 ## Implementation Priority
 


### PR DESCRIPTION
Fixes #7426

Clause-②: no — the diff is one markdown file under `apps/console/docs/`. It touches no `skills/**`, no published package source, and no contract surface. Determined from my own diff and confirmed mechanically: `check-changeset-presence` reports "1 file(s) changed, 0 of them published source of a package the release covers, 0 of them a manifest whose published contract moved".

## What was wrong

The "Visual Design Specs" section carried three `tsx`-fenced blocks — **Color Palette**, **Typography** and **Spacing** — that are not TypeScript. Each is a list of bare `key: "value"` lines with trailing `//` comments and no braces, which parses as **labelled statements whose bodies are string literals**: syntactically legal, semantically empty, and so compiled clean by `check-doc-snippet-types`.

The card framed this as pending on objectui#6600 step 2. It is not — re-confirmed on my own base `ccb3ad78a` by the **executed walk**, not the header prose about scope:

- `scripts/check-doc-snippet-types.mjs:822` — `for (const dir of appDocsDirs(root)) walk(dir);`
- `:399` — `readdirSync(appsDir)` enumerating `apps/`

## The gate was compiling these blocks — measured, not assumed

A green run alone proves nothing here, so I lit the blocks up. Injecting one type error into the Color Palette block on the pristine base turned the gate **red and named it**:

```
apps/console/docs/UI_IMPROVEMENT_PROPOSAL.md:212:7  TS2322: Type 'string' is not assignable to type 'number'.
```

Exit code 1, captured by redirect-then-read. Line 212 is inside that fence. The mutation was proven on disk (injected-marker count 1, disk hash differing from the HEAD blob) before the reading was taken, and the restore was proven three ways: empty `git diff HEAD`, disk hash equal to the HEAD blob, zero residual markers. No rebuild leg applies — the mutated subject is a markdown document the gate reads from disk at runtime, not a package resolved through `dist`.

## The blocks left the population — they were not silenced

| Reading | Before | After |
|:--|:--|:--|
| `Covered blocks` | 613 | 610 |
| of them **to compile** | **455** | **452** |
| declared fragment(s) | 158 | **158** |
| `Semantic phase` judged | 455 of 455, 0 failed | 452 of 452, 0 failed |
| exit code | 0 | 0 |

The judged count drops by **exactly three**, and the declared-fragment count is **unchanged**. That second number is the one that matters: it shows the blocks left the ts/tsx population outright rather than being converted into fragment markers.

A fragment marker was the tempting repair and the wrong one — it asserts a block *cannot* compile. These compile fine and mean nothing, which is the whole defect. The fence language is the honest lever, as ruled in objectui#5997.

## Why a table, and not a plain-text fence

Both were live options and this is presentation, not correctness. I picked the table:

1. **It is already this tree's convention.** Both sibling docs — `deployment.md` and `error-tracking.md` — document settings as markdown tables. The table is not a third shape; it mirrors objectui#5997's principle of expressing content in the markup that matches it (that card's content was a bullet list, so it became a real bullet list; this content is a slot/value/note triple, so it becomes a table).
2. **It needs no exemption to be green.** A `text` fence would also pass `check:doc-fences`, but only because `classifiesAsTypeScript` inspects the first line against five patterns and these bodies open with a `//` comment. Passing on a first-line heuristic is a weaker reason to be green than not being a fence at all.

Every token, value and per-row note is preserved verbatim. Nothing was invented — Typography had no per-row notes, so it stays two columns rather than gaining fabricated ones.

## Verification

Union run on final commit `2f346eff0`, clean tree, each exit code captured by redirect-then-read and each verdict line quoted from the gate itself:

- `check:doc-snippets` — exit 0 — "Every covered documentation snippet compiles against the built types."
- `check:doc-fences` — exit 0 — "every TypeScript block in 227 document(s) is fenced ts/tsx/typescript … No unknown fence spelling hides one."
- `check:doc-types` — exit 0 — "Every documented component type is registered."
- `check:control-bytes` — exit 0 — "OK (scanned 6245 tracked text file(s); skipped 85 binary)."
- `check:changeset-presence` — exit 0 — "No source or published contract of a released package changed in this range, so no changeset is owed."

The three doc gates carrying `APP_DOCS` (`check-doc-snippet-types`, `check-doc-fence-languages`, `check-doc-component-types`) are all in that list, so every gate that walks this tree ran.

**The changeset gate ruled the bump, and it ruled none owed.** I did not pre-empt it and added no changeset.

### Coverage number — measured here, method printed

I do **not** carry over the card's "three quarters" ratio; it was never verified. Measured independently by driving the gate's own exported `scanFences` collector over every file under `apps/*/docs` (three documents, `apps/console/docs` being the only such tree):

- 14 ts/tsx blocks collected tree-wide — 4 to compile, 10 declared fragments.
- All 4 of the compile population were in this one file, and **3 of those 4 were the design-token lists**.
- After: the tree's compile population is **1** — the genuine `ResizablePanel` import block.

### Narrowings, declared

- **Repo-wide `pnpm lint` not run.** Measured, not assumed: eslint's own config resolution reports this file as *"File ignored because no matching configuration was supplied"*, so it is not in eslint's linted population at all. 1 file changed, 0 of them lintable. No untouched file's verdict can move either — the diff adds and removes no JS/TS and touches no eslint config.
- **The full check farm was not enumerated locally.** CI runs it exactly once regardless. I ran the doc-gate family that walks this tree plus the changeset and control-byte gates.
- **No docs-site render check.** objectui#5997 owed one because it changed `content/docs`, which the site serves. `apps/console/docs/**` is imported, routed and bundled by nothing (verified with a lit control on the same query shape), so there is no rendered page to regress; GitHub's own view renders these tables natively.

## Scope

Only the three design-token fences. The document's other eight `tsx` fences are real JSX/TS — `Accordion`, the `ResizablePanel` import, the `useLocalStorage` call — and I confirmed that split myself before editing. They are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_