### PR TITLE
fix(plugin-detail): resolveTitleField delegates to the shared ADR-0079 ladder

### DIFF
--- a/.changeset/7287-resolve-title-field-shared-ladder.md
+++ b/.changeset/7287-resolve-title-field-shared-ladder.md
@@ -37,6 +37,21 @@ with no type check.
   name alone and is now correctly skipped, so the strip no longer hides a chip on
   account of a field the H1 never shows.
 
+**A third user-visible change, in the highlight strip's skip set.** It previously read
+`primaryField`, `nameField` and `displayNameField` separately and skipped EVERY declared
+one; it now skips the single field the shared ladder resolves. These differ on one input:
+an object declaring `nameField` and the deprecated `displayNameField` alias to DIFFERENT
+fields. The alias's field is no longer hidden from the strip — deliberately, because
+`getRecordDisplayName` reads the same ladder and renders the WINNER's value, so the loser
+is an ordinary field the H1 never shows and hiding it spent a strip slot for nothing.
+This also makes the heuristic branch agree with the declared branch, which has only ever
+filtered a single title field.
+
 `deriveHighlightFields` asks the retirement gate (objectui#4914) about the title field
 **before** skipping it: an object whose only retired-typed field is the one that titles
 it must still get its report, which skipping-first would have silenced.
+
+`ObjectDefLike.primaryField` stays DECLARED but is never read. The interface is
+re-exported from this package's index and this package is published, so removing the
+member would narrow a shipped `.d.ts` — a contract change owed its own card, not a rider
+on a behaviour fix.

--- a/.changeset/7287-resolve-title-field-shared-ladder.md
+++ b/.changeset/7287-resolve-title-field-shared-ladder.md
@@ -1,0 +1,42 @@
+---
+'@object-ui/plugin-detail': minor
+---
+
+`resolveTitleField` delegates to the shared ADR-0079 ladder (objectui#7287).
+
+ADR-0079 collapsed ~6 divergent record-title resolvers onto one — `@object-ui/core`'s
+`record-title.ts`, whose header tells the "Untitled everywhere" story that produced it.
+`plugin-detail` grew one back. `resolveTitleField` now calls core's `resolveNameField`
+and nothing else, so the detail page, the list column and the lookup chip cannot
+disagree about which field titles an object.
+
+**Two rungs are gone.**
+
+`def.primaryField` — a `DetailViewSchema` key (`@object-ui/types` `views.ts`), read off
+an OBJECT def and ranked ABOVE the canonical `nameField` ADR-0079 Phase 2 made the
+pointer (AGENTS.md Commandment #0.1). No producer can put it there: `@objectstack/spec`'s
+object schema is a `strictObject` that answers `unrecognized_keys: ['primaryField']`,
+and `ObjectSchema.create()` throws — which is why objectstack#6326 deleted the identical
+read from two lint rules. A census across both repos found **zero** object payloads
+carrying it (the only writers are three test fixtures), and `primaryField` appears in
+**zero** files of the shipped `@objectstack/spec@17.2.0` dist against 68 for `nameField`.
+Same shape as the undeclared `objectDef.titleField` read objectui#6531 measured and
+#6557 removed. `DetailViewSchema.primaryField` is untouched and still honoured by
+`DetailView`'s own header — it is a view key, and on a view it is legitimate.
+
+The literal `['name','full_name','title','subject','display_name']` walk — a NAME match
+with no type check.
+
+**User-visible, deliberately.** Two shapes retitle:
+
+- An object with no conventional name field — `{ due_at: datetime, headline: text }` —
+  resolved to `null` here while every other surface titled the record `headline`. The
+  detail page now agrees, and the highlight strip stops repeating the H1 as its first
+  chip (the objectui#2548 duplication, which until now only DECLARED titles were spared).
+- A field named `title` of a non-title-eligible type (e.g. a `select`) was chosen by
+  name alone and is now correctly skipped, so the strip no longer hides a chip on
+  account of a field the H1 never shows.
+
+`deriveHighlightFields` asks the retirement gate (objectui#4914) about the title field
+**before** skipping it: an object whose only retired-typed field is the one that titles
+it must still get its report, which skipping-first would have silenced.

--- a/packages/plugin-detail/src/__tests__/buildDefaultPageSchema.retiredFieldType.test.ts
+++ b/packages/plugin-detail/src/__tests__/buildDefaultPageSchema.retiredFieldType.test.ts
@@ -55,10 +55,23 @@ afterEach(() => {
   resetRetiredFieldTypeReports();
 });
 
+/**
+ * Both fixtures carry an explicit `name` text field so the object's TITLE
+ * resolves to `name` and nothing else. `deriveHighlightFields` skips whatever
+ * titles the record (it is already the page H1), and since objectui#7287 that
+ * answer comes from the shared ADR-0079 ladder, which DERIVES a title when the
+ * object declares none — on a def of only `{owner, amount, priority}` it lands
+ * on `owner`, and on `{reviewer, note}` on `reviewer`. That would remove these
+ * tests' own subject from the strip for a reason that has nothing to do with
+ * the retirement gate they exist to pin. Naming the title field keeps the
+ * fixture about the gate.
+ */
+
 /** An object def whose `owner` field carries `type`. */
 const defWithOwnerTyped = (type: string) => ({
   name: 'tasks',
   fields: {
+    name: { type: 'text', label: 'Name' },
     owner: { type, label: 'Owner' },
     amount: { type: 'currency', label: 'Amount' },
     priority: { type: 'select', label: 'Priority' },
@@ -69,8 +82,24 @@ const defWithOwnerTyped = (type: string) => ({
 const defWithArbitraryName = (type: string) => ({
   name: 'tasks',
   fields: {
+    name: { type: 'text', label: 'Name' },
     reviewer: { type, label: 'Reviewer' },
     note: { type: 'text', label: 'Note' },
+  },
+});
+
+/**
+ * The one shape the fixtures above deliberately exclude: an object whose ONLY
+ * retired-typed field is the one the shared ladder DERIVES as the title. It is
+ * skipped from the strip as the page H1 — and must still be reported, or
+ * objectui#7287's skip would have quietly closed the gate for exactly the
+ * objects that most need it (objectui#4914 ruling B).
+ */
+const defWhoseTitleIsRetired = (type: string) => ({
+  name: 'tasks',
+  fields: {
+    headline: { type, label: 'Headline' },
+    closed_on: { type: 'date', label: 'Closed on' },
   },
 });
 
@@ -109,6 +138,15 @@ describe('the refusal is loud, and said once', () => {
     deriveHighlightFields(defWithOwnerTyped(RETIRED), null);
     deriveHighlightFields(defWithArbitraryName(RETIRED), null);
     deriveHighlightFields(defWithOwnerTyped(RETIRED), null);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(RETIRED_FIELD_TYPES[RETIRED]);
+  });
+
+  it('still reports when the retired field is the one the ladder titles with', () => {
+    // `headline` is the only title-eligible field here, so it IS the H1 and is
+    // skipped from the strip before either selection loop can see it.
+    const out = deriveHighlightFields(defWhoseTitleIsRetired(RETIRED), null);
+    expect(out).not.toContain('headline');
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(RETIRED_FIELD_TYPES[RETIRED]);
   });

--- a/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/buildDefaultPageSchema.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { getRecordDisplayName } from '@object-ui/core';
 import {
   buildDefaultPageSchema,
   buildDefaultHeader,
@@ -138,9 +139,18 @@ describe('deriveHighlightFields', () => {
     expect(fields.length).toBeLessThanOrEqual(4);
   });
 
-  it('falls back to any field order when preferred names absent', () => {
+  it('falls back to any field order when preferred names absent, minus the H1 field', () => {
     const def: ObjectDefLike = { fields: { foo: {}, bar: {}, baz: {} } };
-    expect(deriveHighlightFields(def, null)).toEqual(['foo', 'bar', 'baz']);
+    // No conventional name field here, so the shared ADR-0079 ladder DERIVES
+    // the title: the first title-eligible field in declaration order, `foo`.
+    // The page H1 renders ITS value — so the strip sitting directly beneath
+    // must not repeat it. Before objectui#7287 this module ran its own ladder,
+    // whose literal five-name walk did not know `foo`; it returned null, and
+    // `foo` was the first chip under a heading already showing it.
+    expect(
+      getRecordDisplayName(def, { id: 'r1', foo: 'Acme', bar: 'x', baz: 'y' }),
+    ).toBe('Acme');
+    expect(deriveHighlightFields(def, null)).toEqual(['bar', 'baz']);
   });
 
   it('skips system tenancy + audit fields (organization_id, created_by, etc.)', () => {
@@ -166,9 +176,13 @@ describe('deriveHighlightFields', () => {
     expect(fields).toContain('another_useful');
   });
 
-  it('skips the record primary/title field to avoid duplicating the page H1', () => {
-    const def: ObjectDefLike = {
-      primaryField: 'subject',
+  it('skips the record title field to avoid duplicating the page H1', () => {
+    const def = {
+      // The DECLARED role, ADR-0079's canonical pointer. This fixture used to
+      // spell it `primaryField` — a `DetailViewSchema` key that no object
+      // payload can carry, and whose read this module dropped in
+      // objectui#7287.
+      nameField: 'subject',
       fields: {
         subject: {},
         name: {}, // common candidate also skipped
@@ -177,7 +191,7 @@ describe('deriveHighlightFields', () => {
         due_date: {},
         notes: {},
       },
-    };
+    } as unknown as ObjectDefLike;
     const fields = deriveHighlightFields(def, 'status');
     expect(fields).not.toContain('subject');
     expect(fields).not.toContain('name');
@@ -936,12 +950,15 @@ describe('semantic-role hints (ADR-0085 / #2065)', () => {
     });
 
     it('title resolution honours declared roles over conventional names', () => {
-      const def: ObjectDefLike = {
-        primaryField: 'subject',
+      const def = {
+        // ADR-0079's canonical pointer, which outranks the conventional
+        // `name`. (`primaryField` stood here until objectui#7287 — a
+        // `DetailViewSchema` key read off an object def.)
+        nameField: 'subject',
         fields: { subject: {}, name: {}, status: {} },
         highlightFields: ['subject', 'name', 'status'],
-      };
-      // primaryField wins → `subject` is the H1 and drops; the literal
+      } as unknown as ObjectDefLike;
+      // The declared role wins → `subject` is the H1 and drops; the literal
       // `name` field is NOT the title here and stays a chip.
       expect(deriveHighlightFields(def, null)).toEqual(['name', 'status']);
     });

--- a/packages/plugin-detail/src/synth/__tests__/resolveTitleField.sharedLadder-7287.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/resolveTitleField.sharedLadder-7287.test.ts
@@ -160,6 +160,53 @@ describe('[#7287] resolveTitleField delegates to the shared ADR-0079 ladder', ()
     });
 
     /**
+     * THE ONE INPUT where the old skip set and the new one disagree, and so
+     * the one that has to be pinned: an object declaring `nameField` AND the
+     * deprecated `displayNameField` alias to DIFFERENT fields, both present.
+     *
+     * The old `deriveHighlightFields` read all three declared roles
+     * separately and skipped EVERY one it found, so `legacy_title` never
+     * reached the strip. The shared ADR-0079 ladder PICKS one rung —
+     * `nameField` outranks its deprecated alias — so only `headline` is
+     * skipped now, deliberately: `getRecordDisplayName` reads that same
+     * ladder and renders `headline`'s value, so `legacy_title` is an ordinary
+     * field the heading never shows, and hiding it spent a strip slot for
+     * nothing. This also makes the heuristic branch agree with the DECLARED
+     * branch, which has only ever filtered a single title field.
+     *
+     * Goes red if the three raw reads come back, which is the shape this card
+     * exists to remove — so the pin is on the BEHAVIOUR, not on the spelling.
+     */
+    it('skips only the winner when nameField and displayNameField disagree', () => {
+      const def = {
+        nameField: 'headline',
+        displayNameField: 'legacy_title',
+        fields: {
+          headline: { type: 'text' },
+          legacy_title: { type: 'text' },
+          priority: { type: 'text' },
+        },
+      } as unknown as ObjectDefLike;
+      const record = {
+        id: 'r5',
+        headline: 'Q3 rollout',
+        legacy_title: 'stale',
+        priority: 'High',
+      };
+
+      // The canonical pointer wins the ladder on every surface…
+      expect(resolveTitleField(def)).toBe('headline');
+      expect(leadWithNameField(def, ['priority', 'headline'])[0]).toBe('headline');
+      expect(getRecordDisplayName(def, record)).toBe(record.headline);
+
+      // …so the strip drops the H1 field and KEEPS the losing alias, which
+      // the heading never shows.
+      const strip = deriveHighlightFields(def, null);
+      expect(strip).not.toContain('headline');
+      expect(strip).toContain('legacy_title');
+    });
+
+    /**
      * The invariant, stated once over a table: for every object, the field the
      * detail page calls "the title" is the field core calls "the name". A
      * second ladder can satisfy the cases above and still break here on the

--- a/packages/plugin-detail/src/synth/__tests__/resolveTitleField.sharedLadder-7287.test.ts
+++ b/packages/plugin-detail/src/synth/__tests__/resolveTitleField.sharedLadder-7287.test.ts
@@ -1,0 +1,190 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getRecordDisplayName,
+  leadWithNameField,
+  resolveNameField,
+} from '@object-ui/core';
+import {
+  deriveHighlightFields,
+  resolveTitleField,
+  type ObjectDefLike,
+} from '../buildDefaultPageSchema';
+
+/**
+ * objectui#7287 — `resolveTitleField` must BE the shared ADR-0079 ladder, not a
+ * second one that happens to agree.
+ *
+ * ADR-0079 collapsed ~6 divergent record-title resolvers (`record-title.ts`'s
+ * own header tells that story, and the "Untitled everywhere" bug it produced).
+ * `plugin-detail` grew one back: a private ladder topped by `def.primaryField`
+ * — a `DetailViewSchema` key (`@object-ui/types` `views.ts`) read off an
+ * OBJECT def — with a literal `['name','full_name','title','subject',
+ * 'display_name']` walk underneath that matches on NAME with no type check.
+ *
+ * These tests pin the two halves that a second ladder cannot give you:
+ *
+ *  1. the `primaryField` rung is GONE (each test here goes red the moment it
+ *     returns to the chain — that is what makes them discriminating rather
+ *     than merely descriptive);
+ *  2. the detail page, the list column and the lookup chip resolve the SAME
+ *     field for the same object — asserted against core's OTHER consumers
+ *     (`getRecordDisplayName`, `leadWithNameField`), not by re-reading
+ *     `resolveNameField` back at itself, so the assertions still mean
+ *     something if the delegation is ever unwound.
+ */
+describe('[#7287] resolveTitleField delegates to the shared ADR-0079 ladder', () => {
+  describe('the `primaryField` rung is gone', () => {
+    /**
+     * `primaryField` is not a key any producer can put on an object.
+     * `@objectstack/spec`'s object schema is a `strictObject`: `safeParse`
+     * answers `unrecognized_keys: ['primaryField']` and `ObjectSchema.create()`
+     * throws — which is why objectstack#6326 deleted the identical read from
+     * two lint rules. Reading it here ranked a view key ABOVE the canonical
+     * `nameField` that ADR-0079 Phase 2 made the pointer.
+     */
+    it('does not let `primaryField` outrank the canonical `nameField`', () => {
+      const def = {
+        primaryField: 'ref_no',
+        nameField: 'name',
+        fields: { ref_no: { type: 'text' }, name: { type: 'text' } },
+      } as unknown as ObjectDefLike;
+      expect(resolveTitleField(def)).toBe('name');
+    });
+
+    it('does not let `primaryField` outrank the type-aware derivation', () => {
+      const def = {
+        primaryField: 'ref_no',
+        fields: { ref_no: { type: 'text' }, name: { type: 'text' } },
+      } as unknown as ObjectDefLike;
+      // `name` is name-ish-exact, `ref_no` is not: the shared ladder ranks
+      // `name` first. With the rung present, `ref_no` won regardless.
+      expect(resolveTitleField(def)).toBe('name');
+    });
+
+    it('does not let `primaryField` keep the H1 field out of the highlight strip', () => {
+      const def = {
+        primaryField: 'ref_no',
+        fields: {
+          ref_no: { type: 'text' },
+          name: { type: 'text' },
+          priority: { type: 'text' },
+        },
+      } as unknown as ObjectDefLike;
+      // The strip skips the field the H1 actually shows (`name`), and no
+      // longer burns a slot hiding `ref_no`, which the H1 never shows.
+      expect(deriveHighlightFields(def, null)).toContain('ref_no');
+      expect(deriveHighlightFields(def, null)).not.toContain('name');
+    });
+  });
+
+  describe('the detail page, the list column and the lookup chip agree', () => {
+    /**
+     * The card's first divergence example, executed. `headline` is the only
+     * title-eligible field, so core derives it and the H1 renders its value —
+     * while the old literal walk knew only five names, returned `null`, and
+     * left the detail page skipping nothing.
+     */
+    it('a derived title field (`headline`) resolves the same on every surface', () => {
+      const def = {
+        fields: { due_at: { type: 'datetime' }, headline: { type: 'text' } },
+      } as unknown as ObjectDefLike;
+      const record = { id: 'r1', due_at: '2026-01-01', headline: 'Q3 rollout' };
+
+      // detail page (this module) === list/lookup (core)
+      expect(resolveTitleField(def)).toBe('headline');
+      expect(leadWithNameField(def, ['due_at', 'headline'])[0]).toBe('headline');
+      // …and the field they name is the one whose value the H1 renders.
+      expect(getRecordDisplayName(def, record)).toBe(record.headline);
+      expect(getRecordDisplayName(def, record)).toBe(
+        (record as any)[resolveTitleField(def) as string],
+      );
+    });
+
+    /**
+     * The card's second divergence example, executed. A `select` named `title`
+     * is matched by NAME alone by the old literal walk, and rejected by TYPE
+     * by the shared ladder — so the detail page used to skip a field the H1
+     * never shows, and show nothing where the title belonged.
+     */
+    it('a `select` named `title` is not mistaken for the title field', () => {
+      const def = {
+        fields: { title: { type: 'select' }, body: { type: 'text' } },
+      } as unknown as ObjectDefLike;
+      const record = { id: 'r2', title: 'open', body: 'Ship the thing' };
+
+      expect(resolveTitleField(def)).toBe('body');
+      expect(leadWithNameField(def, ['title', 'body'])[0]).toBe('body');
+      expect(getRecordDisplayName(def, record)).toBe(record.body);
+    });
+
+    /**
+     * The strip sits directly under the H1 and must not repeat it — the
+     * duplication objectui#2548 removed for DECLARED titles. A derived title
+     * used to slip through: the literal walk knew five names, `headline` is
+     * not one of them, `resolveTitleField` returned `null`, and `headline`
+     * became the first chip under a heading already showing its value.
+     */
+    it('the strip stops repeating a DERIVED title field under the H1', () => {
+      const def = {
+        fields: {
+          stage: { type: 'select' },
+          headline: { type: 'text' },
+          priority: { type: 'text' },
+        },
+      } as unknown as ObjectDefLike;
+      const record = { id: 'r4', stage: 'open', headline: 'Q3 rollout', priority: 'High' };
+
+      expect(getRecordDisplayName(def, record)).toBe(record.headline);
+      expect(deriveHighlightFields(def, null)).not.toContain('headline');
+      expect(deriveHighlightFields(def, null)).toContain('priority');
+    });
+
+    it('a deprecated `displayNameField` alias resolves the same on every surface', () => {
+      const def = {
+        displayNameField: 'activity_name',
+        fields: { activity_name: { type: 'text' }, note: { type: 'text' } },
+      } as unknown as ObjectDefLike;
+      const record = { id: 'r3', activity_name: 'Kickoff call', note: 'n/a' };
+
+      expect(resolveTitleField(def)).toBe('activity_name');
+      expect(leadWithNameField(def, ['note', 'activity_name'])[0]).toBe('activity_name');
+      expect(getRecordDisplayName(def, record)).toBe(record.activity_name);
+    });
+
+    /**
+     * The invariant, stated once over a table: for every object, the field the
+     * detail page calls "the title" is the field core calls "the name". A
+     * second ladder can satisfy the cases above and still break here on the
+     * next change; delegation cannot.
+     */
+    it('agrees with core on every shape in the table', () => {
+      const defs: Array<Record<string, any>> = [
+        { fields: { name: { type: 'text' } } },
+        { fields: { due_at: { type: 'datetime' }, headline: { type: 'text' } } },
+        { fields: { title: { type: 'select' }, body: { type: 'text' } } },
+        { nameField: 'code_label', fields: { code_label: { type: 'text' }, x: { type: 'text' } } },
+        { displayNameField: 'activity_name', fields: { activity_name: { type: 'text' } } },
+        { fields: { amount: { type: 'currency' }, closed_on: { type: 'date' } } },
+        { fields: {} },
+        {},
+      ];
+      for (const def of defs) {
+        expect(resolveTitleField(def as ObjectDefLike)).toBe(resolveNameField(def) ?? null);
+      }
+    });
+
+    it('returns null (not undefined) when nothing resolves, for the `?? \'name\'` call sites', () => {
+      const def = { fields: { amount: { type: 'currency' } } } as unknown as ObjectDefLike;
+      expect(resolveTitleField(def)).toBeNull();
+      expect(resolveTitleField(undefined)).toBeNull();
+    });
+  });
+});

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -30,7 +30,7 @@ import { detectStatusField } from '@object-ui/types';
 // re-exports the same function; this module reads it from `@object-ui/core`
 // because that is the dependency this package's synth layer already carries
 // at this depth, and both spellings resolve to one table and one dedupe set.
-import { isRetiredFieldType, reportRetiredFieldType } from '@object-ui/core';
+import { isRetiredFieldType, reportRetiredFieldType, resolveNameField } from '@object-ui/core';
 import { inferDetailColumns } from '../autoLayout';
 
 /** Minimal shape of an object definition we read here. We deliberately
@@ -48,10 +48,6 @@ export interface ObjectDefLike {
   /** Semantic role (ADR-0085): the object's most important fields —
    *  drives the highlight strip (first 4). */
   highlightFields?: string[];
-  /** Name of the field that holds the record's display title (e.g. `name`,
-   *  `subject`). When present we exclude it from the auto-derived highlight
-   *  list to avoid duplicating the page H1. */
-  primaryField?: string;
   /** Optional section grouping for the details region. The heading rides
    *  `label` — the one slot `@object-ui/types` declares (objectui#6190). */
   sections?: Array<{ label?: string; columns?: number; fields?: any[] }>;
@@ -380,28 +376,39 @@ export function deriveStages(
 }
 
 /**
- * Resolve the record's title field — the value the page renders as its H1.
- * Declared role first (`primaryField` / `nameField` / deprecated
- * `displayNameField`), else the first conventional display-field name present
- * on the object. Mirrors `record-details`' titleCandidates so "what the H1
- * shows" and "what the strip skips" can never disagree.
+ * WHICH FIELD titles this record — the field whose value the page renders as
+ * its H1, in NAME space.
+ *
+ * DELEGATES to `@object-ui/core`'s `resolveNameField`: the ONE shared ADR-0079
+ * ladder (`nameField` -> deprecated `displayNameField` / `NAME_FIELD_KEY` ->
+ * type-aware derivation), the same spelling `getRecordDisplayName` reads to
+ * produce the H1's VALUE and `leadWithNameField` reads to lead a list. It does
+ * not re-implement that ladder. ADR-0079 collapsed ~6 divergent title
+ * resolvers and this module grew one back (objectui#7287); a second ladder
+ * that agrees today diverges again on the next change, which is the whole
+ * history of this defect.
+ *
+ * Two rungs went away with the delegation:
+ *
+ *  - `def.primaryField` — a `DetailViewSchema` key (`@object-ui/types`
+ *    `views.ts`), read here off an OBJECT def and ranked ABOVE the canonical
+ *    `nameField` ADR-0079 Phase 2 made the pointer. No producer can put it
+ *    there: `@objectstack/spec`'s object schema is a `strictObject` that
+ *    answers `unrecognized_keys: ['primaryField']`, and `ObjectSchema.create()`
+ *    throws — which is why objectstack#6326 deleted the identical read from
+ *    two lint rules. A census across both repos found zero object payloads
+ *    carrying it. Same shape as the undeclared `objectDef.titleField` read
+ *    objectui#6531 measured and #6557 removed.
+ *  - the literal `['name','full_name','title','subject','display_name']` walk
+ *    — a NAME match with no type check. `deriveTitleField` ranks those same
+ *    name-ish names first AND rejects non-title types, so a `select` named
+ *    `title` stops being named as the H1 field that the H1 never shows.
+ *
+ * Returns `null` rather than `undefined` for this module's `!== titleField`
+ * filters and app-shell's `?? 'name'` call site.
  */
 export function resolveTitleField(def: ObjectDefLike | undefined): string | null {
-  if (!def) return null;
-  const fields = def.fields || {};
-  for (const candidate of [
-    def.primaryField,
-    (def as any).nameField,
-    (def as any).displayNameField,
-  ]) {
-    if (typeof candidate === 'string' && candidate.length > 0 && candidate in fields) {
-      return candidate;
-    }
-  }
-  for (const candidate of ['name', 'full_name', 'title', 'subject', 'display_name']) {
-    if (candidate in fields) return candidate;
-  }
-  return null;
+  return resolveNameField(def) ?? null;
 }
 
 /**
@@ -444,14 +451,8 @@ export function deriveHighlightFields(
     'org_id',
   ]);
   if (statusField) skip.add(statusField);
-  // The record's display/primary field is already shown as the page H1 —
-  // surfacing it again in the highlight strip duplicates content and
-  // wastes a slot (e.g. Task pages would show 主题 twice). Skip the
-  // common candidates and whatever the def declares as `primaryField`,
-  // `nameField`, or the deprecated `displayNameField` alias (ADR-0079).
-  if (def.primaryField) skip.add(def.primaryField);
-  if ((def as any).nameField) skip.add((def as any).nameField);
-  if ((def as any).displayNameField) skip.add((def as any).displayNameField);
+  // (The title field joins `skip` below, AFTER the retirement gate is defined
+  // — see the block above the selection loops for why the order matters.)
   for (const candidate of ['name', 'full_name', 'title', 'subject', 'display_name']) {
     if (candidate in (def.fields || {})) skip.add(candidate);
   }
@@ -502,6 +503,28 @@ export function deriveHighlightFields(
     reportRetiredFieldType(ftype);
     return true;
   };
+  // The record's title field is already shown as the page H1 — surfacing it
+  // again in the highlight strip duplicates content and wastes a slot (e.g.
+  // Task pages would show 主题 twice). ONE resolver decides it, the same one
+  // the DECLARED branch above uses, so "what the strip skips" and "what the
+  // H1 shows" cannot disagree (objectui#7287). This subsumes the three
+  // separate `nameField` / `displayNameField` / `primaryField` reads that
+  // stood in the skip set — the first two are rungs of that ladder, and the
+  // third was a `DetailViewSchema` key no object payload can carry (see
+  // {@link resolveTitleField}).
+  //
+  // ⚠️ Ask THE GATE first, then skip. A field skipped as the H1 never reaches
+  // the selection loops, so skipping it silently would take the objectui#4914
+  // report with it — the author of an object whose only retired-typed field
+  // happens to title the record would stop being told, while the strip looked
+  // correct. That is the same "one door left open" the gate's own docstring
+  // above is about. Hence this sits below `refusedAsRetired`, not up in the
+  // skip set.
+  const h1Field = resolveTitleField(def);
+  if (h1Field) {
+    refusedAsRetired(h1Field);
+    skip.add(h1Field);
+  }
   for (const name of preferred) {
     if (name in fields && !skip.has(name) && !refusedAsRetired(name)) out.push(name);
     if (out.length >= max) return out;

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -525,13 +525,32 @@ export function deriveHighlightFields(
   };
   // The record's title field is already shown as the page H1 — surfacing it
   // again in the highlight strip duplicates content and wastes a slot (e.g.
-  // Task pages would show 主题 twice). ONE resolver decides it, the same one
-  // the DECLARED branch above uses, so "what the strip skips" and "what the
-  // H1 shows" cannot disagree (objectui#7287). This subsumes the three
-  // separate `nameField` / `displayNameField` / `primaryField` reads that
-  // stood in the skip set — the first two are rungs of that ladder, and the
-  // third was a `DetailViewSchema` key no object payload can carry (see
-  // {@link resolveTitleField}).
+  // Task pages would show 主题 twice). ONE resolver decides WHICH field that
+  // is, the same one the DECLARED branch above uses, so "what the strip
+  // skips" and "what the H1 shows" cannot disagree (objectui#7287).
+  //
+  // ⚠️ This REPLACES three separate reads (`primaryField` / `nameField` /
+  // `displayNameField`, each adding whatever it found) and it is a deliberate
+  // BEHAVIOUR CHANGE, not a rewrite of them. `primaryField` is simply gone —
+  // a `DetailViewSchema` key no object payload can carry (see
+  // {@link resolveTitleField}). The other two are rungs of the shared ladder,
+  // but the ladder PICKS one rung where the old set added EVERY declared one,
+  // so old and new disagree on exactly one input: an object declaring
+  // `nameField` AND the deprecated `displayNameField` alias to DIFFERENT
+  // fields. The old set skipped both; this skips only the winner.
+  //
+  // Skipping only the winner is the intended behaviour. The loser is not the
+  // H1 — `getRecordDisplayName` reads this same `declaredNameField` ladder
+  // and renders the WINNER's value — so hiding the loser removed an ordinary
+  // field and spent a strip slot on a field the heading never shows, which is
+  // the class of bug this card is about. It also makes this heuristic branch
+  // agree with the DECLARED branch above, which has only ever filtered a
+  // single `titleField`: the "#2548 follow-up" note up there claims both
+  // branches agree, and until now that was true only for objects declaring
+  // one alias.
+  //
+  // Pinned by "skips only the winner when nameField and displayNameField
+  // disagree" in `resolveTitleField.sharedLadder-7287.test.ts`.
   //
   // ⚠️ Ask THE GATE first, then skip. A field skipped as the H1 never reaches
   // the selection loops, so skipping it silently would take the objectui#4914

--- a/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
+++ b/packages/plugin-detail/src/synth/buildDefaultPageSchema.ts
@@ -48,6 +48,26 @@ export interface ObjectDefLike {
   /** Semantic role (ADR-0085): the object's most important fields —
    *  drives the highlight strip (first 4). */
   highlightFields?: string[];
+  /**
+   * ACCEPTED BUT NEVER READ — do not "tidy" this away (objectui#7287).
+   *
+   * `primaryField` is a `DetailViewSchema` key (`@object-ui/types` `views.ts`),
+   * and reading it off an OBJECT def is the defect objectui#7287 removed:
+   * `resolveTitleField` now delegates to `@object-ui/core`'s `resolveNameField`
+   * and no code in this module consults this member. No producer can populate
+   * it either — `@objectstack/spec`'s object schema is a `strictObject` that
+   * answers `unrecognized_keys: ['primaryField']`.
+   *
+   * It stays declared because this interface is REACHABLE, which is a
+   * different question from what it describes: `ObjectDefLike` is re-exported
+   * from this package's index and `@object-ui/plugin-detail` is published, so
+   * the member is part of a shipped `.d.ts`. Deleting it narrows a published
+   * type — an external `const d: ObjectDefLike = { primaryField: 'x' }`
+   * compiles today and would stop compiling — and that is a contract change
+   * owed its own card, not a rider on a behaviour fix. Retiring it is a
+   * deliberate act for someone to take on purpose.
+   */
+  primaryField?: string;
   /** Optional section grouping for the details region. The heading rides
    *  `label` — the one slot `@object-ui/types` declares (objectui#6190). */
   sections?: Array<{ label?: string; columns?: number; fields?: any[] }>;


### PR DESCRIPTION
Fixes #7287

`Clause-②: no` — re-verified on this diff at `ac41b2a51`, not carried forward. Four mechanical checks against merge-base `ccb3ad78a62b`:

- `packages/types` files in the diff: **0** (lit control `packages/plugin-detail/` = 4). `views.ts` blob `be5b9d2e3e21…` identical at base and head; `DetailViewSchema.primaryField` still declared.
- deleted type-member declarations anywhere in the diff: **0**. The only two member-shaped deletions are object-literal properties in test fixtures (`primaryField: 'subject',`); lit control — the same regex matches 36 added lines.
- `ObjectDefLike` member set: **identical in order**, 10 members, none removed, none added.
- `index.tsx`: byte-identical (`diff` exit 0). `resolveTitleField`'s signature: unchanged.

`ObjectDefLike.primaryField` stays **declared but never read**. The interface is re-exported at `packages/plugin-detail/src/index.tsx:182` and `@object-ui/plugin-detail` is published (v17.6.0, `exports["."].types` → `./dist/index.d.ts`), so removing the member would narrow a shipped type — verified on the artifact, not inferred: it is emitted at line 40 of `dist/synth/buildDefaultPageSchema.d.ts` (lit control, sibling `stageField` = 3 hits in that same file; `index.d.ts` shows 0 for **both**, so a grep there proves nothing). Retiring it is a contract change owed its own card. Code reads of `def.primaryField`: **0**.

## What changed

`resolveTitleField` now calls `@object-ui/core`'s `resolveNameField` and nothing else:

```ts
export function resolveTitleField(def: ObjectDefLike | undefined): string | null {
  return resolveNameField(def) ?? null;
}
```

ADR-0079 collapsed ~6 divergent record-title resolvers onto that one ladder. This module grew one back. The repair is **delegation**, not a second ladder that agrees today — two ladders that agree now diverge on the next change, which is the entire history of this defect.

Two *reads* went with it: `def.primaryField`, and the literal `['name','full_name','title','subject','display_name']` walk that matched on NAME with no type check.

## Three user-visible changes, all deliberate and pinned

**1. A derived title now resolves.** An object with no conventional name field — `{ due_at: datetime, headline: text }` — resolved to `null` here while every other surface titled the record `headline`.

**2. A `select` named `title` is no longer mistaken for the title field.** The literal walk matched on name alone; the shared ladder rejects non-title types.

**3. The highlight strip's skip set now skips ONE field, not every declared role.** It previously read `primaryField`, `nameField` and `displayNameField` separately and skipped whatever each found; it now skips the single field the ladder resolves. These differ on exactly one input: an object declaring `nameField` **and** the deprecated `displayNameField` alias to **different** fields. The old set skipped both; this skips only the winner.

Skipping only the winner is intended. `getRecordDisplayName` reads the same `declaredNameField` ladder and renders the **winner's** value, so the losing alias is an ordinary field the H1 never shows — hiding it removed a field and spent a strip slot for nothing, which is the class of bug this card is about. It also makes the heuristic branch agree with the **declared** branch, which has only ever filtered a single `titleField`: the "#2548 follow-up" note in that branch claims both branches agree, and until now that held only for objects declaring one alias.

`deriveHighlightFields` asks the objectui#4914 retirement gate about the title field **before** skipping it. Skipping first would have silenced the report for an object whose only retired-typed field is the one that titles it — the strip would look right while the gate went quiet.

## The census — card step 1, genuinely unmeasured until now

Nothing produces `primaryField` on an object payload.

| query | answer | lit control, same shape |
|:--|--:|:--|
| `primaryField` in shipped `@objectstack/spec@17.2.0` `dist/` | **0 files** | `nameField` → 68 files |
| declaration-form `primaryField?:` in `packages/types/src/**` | **1** (`views.ts`, on `DetailViewSchema`) | `summaryFields?:` / `recordNavigation?:` / `sectionGroups?:` → 1 each |
| object payloads carrying `primaryField`, objectstack | **0** | `nameField` present in objectql fixtures/engine |
| object payloads carrying `primaryField`, objectui | **3, all test fixtures** | — |

The structural half is stronger than a census: `@objectstack/spec`'s object schema is a `strictObject`. `ObjectSchema.safeParse` answers `unrecognized_keys: ['primaryField']` and `ObjectSchema.create()` throws — which is why **objectstack#6326 removed this identical read from two lint rules**. This PR is the objectui half of a removal the sibling repo already ruled on. Same shape as the `objectDef.titleField` read objectui#6531 measured and #6557 removed.

The census is about **producers**; the surviving type member is about **consumers who type their own defs**. That is why zero producers does not license deleting it.

## The two divergence examples — executed, not reasoned

Triage was explicit that it had not run either resolver. Both were run, and the RED output below is the "before":

| object | before — `resolveTitleField` | core (list column + lookup chip) | after |
|:--|:--|:--|:--|
| `{ due_at: datetime, headline: text }` | `null` | `headline` | `headline` |
| `{ title: select, body: text }` | `title` | `body` | `body` |
| `{ primaryField: 'ref_no', nameField: 'name' }` | `ref_no` | `name` | `name` |

```
AssertionError: expected null to be 'headline'      // detail page vs list/lookup
AssertionError: expected 'title' to be 'body'       // name match with no type check
AssertionError: expected 'ref_no' to be 'name'      // view key outranking the canonical pointer
```

The `headline` case is worse than the card framed it. `resolveTitleField` is how the detail page *predicts what the H1 shows* — but the H1 is rendered by core's `getRecordDisplayName`. On that object the H1 showed `headline`'s value while `resolveTitleField` returned `null`, so `deriveHighlightFields` skipped nothing and `headline` became the first chip directly under a heading already showing it. It is now pinned as an equality across three surfaces: the field the strip skips, the field the list leads with (`leadWithNameField`), and the field whose value the H1 renders.

## Verification — on `ac41b2a51`

- **Two discriminating ablations, both mutating the FACT in source, never an assertion.**
  - *The rung.* Put `primaryField` back on top of the ladder. Mutation proven on disk first (blob `177c1d55…` → `0ea5032b…`, marker count checked, hard exit if not) → `Tests 3 failed | 6 passed`, exactly the three rung tests.
  - *The skip set.* Put the three raw reads back. Mutation proven on disk (blob `b6466f98…` → `9838c1ef…`, marker lines 2 and the injected `displayNameField) skip.add` line 1) → `Tests 1 failed | 9 passed`, failing precisely on `expected [ 'priority' ] to include 'legacy_title'`. That is the one input where old and new disagree, so the pin is on the behaviour rather than the spelling.
  - Both restored **by state** under `trap ... EXIT INT TERM` with absolute paths via `git checkout HEAD -- ABSOLUTE_PATH`: `git diff HEAD` empty **and** on-disk blob back to the HEAD blob, residual markers 0. The second ablation's first attempt aborted on its own guard (my expected marker count was wrong — `grep -c` counts lines, not occurrences); it refused to measure, the trap restored the tree, and it was re-run with the correct expectation rather than nudged until green.
- **No rebuild leg is owed for those, and it is shown rather than assumed.** `vitest.config.mts:408` aliases `@object-ui/core` to `packages/core/src` and `:427` aliases `@object-ui/plugin-detail` to `packages/plugin-detail/src`; the tests import the subject relatively. No `dist` on the resolution path.
- **Tests:** `pnpm exec vitest run packages/plugin-detail/` from the repo root — `Test Files 131 passed (131)`, `Tests 1189 passed (1189)`, lock verdict `command-exit 0`. The wider sweep (`plugin-detail` + `app-shell` + `core` + `components` + the console fixture) ran green on the previous head at `Test Files 1089 passed (1089)`, `Tests 11522 passed | 1 skipped`; this head's delta is confined to `plugin-detail`, so that package's suite is the re-run — a declared narrowing, with CI running the full farm regardless.
- **Type-check:** `plugin-detail` + `app-shell` after building their dependency closures — `Scope: 2 of 47 workspace projects`, both `tsc --noEmit && tsc -p tsconfig.test.json` echoed and `Done`.
- **Gates:** `check:control-bytes` — `OK (scanned 6247 tracked text file(s))`; `check:phantom-deps` — `Every in-scope import is declared by the package that publishes it.`; `check:self-import` — `No package names itself inside its own src/.`; `check-changeset-presence` — `4 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`; `check-changeset-no-major` — `No changeset declares a major bump.` Plus a control-byte self-scan of every changed file: clean.
- **`check:readme-exports` is NOT MEASURED, not red.** All 75 findings are the prerequisite form "type entry `./dist/index.d.ts` is not on disk -- run `pnpm build` first" (0 lines of any other form), naming app-shell / cli / plugin-ai / plugin-gantt and never `plugin-detail` (lit control: `plugin-gantt` appears 43 times in the same file). It wants a full-repo build this seat did not run, and this diff touches no README and — as measured above — no export surface.

**Declared narrowing — lint.** The gate is `turbo run lint`, i.e. each package's own `eslint .`; this diff touches exactly one package. `packages/plugin-detail` linted whole: **184 files, 0 errors** (exit 0); changed files at 0 errors each (warnings only, against 894 pre-existing there). The narrowing cannot hide anything: the single `eslint.config.js` configures **no** type-aware linting (`grep` for `projectService`/`parserOptions` exits 1), so a verdict is a per-file function. The wide shape was run once too — root `eslint . --no-inline-config` over **4274** files (count from `--format json`) shows 93 errors, all pre-existing, none in a file this PR touches.

## Not in this PR — out of the fence

Two more consumers read `primaryField` off an OBJECT def, both outside this card's fence and both user-visible on their own: `packages/components/src/renderers/layout/containers.tsx` (the record-chip / page-header `resolvedTitle` chain) and `packages/plugin-detail/src/renderers/record-details.tsx` (a fourth inline `titleCandidates` ladder). Handed up with their evidence; the coordinator is filing them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_