### PR TITLE
fix(icons): correct two retired lucide spellings on registration icon meta

### DIFF
--- a/.changeset/5936-retired-icon-spellings.md
+++ b/.changeset/5936-retired-icon-spellings.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/components': patch
+'@object-ui/plugin-detail': patch
+---
+
+Correct two retired lucide spellings on component-registration `icon` meta
+(objectui#5936, the behaviour-neutral slice).
+
+`ui:page` declared `icon: 'Layout'` and `record:alert` declared
+`icon: 'AlertTriangle'`. lucide retires a spelling by dropping it from the runtime
+`icons` record while keeping the deprecated named export, so both names still
+import and still type-check while resolving to nothing through any resolver that
+reads that record. They are now the live keys `panels-top-left` and
+`triangle-alert`.
+
+**Behaviour-neutral by identity, in every resolution world.** The retired export
+and the live record entry are the SAME OBJECT — measured against the installed
+lucide 1.31.0, not asserted: `Layout === icons['PanelsTopLeft']` and
+`AlertTriangle === icons['TriangleAlert']` are both true. So the repair cannot
+substitute one glyph for another; it can only turn a name that resolves to
+nothing into one that resolves to the glyph it always meant.
+
+- Through a record-reading resolver (`renderers/action/resolve-icon.ts`), the old
+  spellings resolve to `null` and the new ones to that shared object.
+- Through the dynamic surface (`iconNames`, 2025 names, retired aliases included),
+  both spellings already resolved, and to the same glyph.
+- The kebab spellings were chosen because they are the only ones live on BOTH
+  surfaces: `PanelsTopLeft` and `TriangleAlert` are record keys but are absent
+  from `iconNames`, which is kebab-case only.
+
+Nothing is retired and no gate is extended here. `check-lucide-icon-record-names.mjs`
+deliberately does not judge a registration's `icon` meta, and it stays that way —
+its verdict is unchanged by this diff (182 names judged, green, both before and
+after). Whether the registration `icon` meta itself should be retired is the open
+half of objectui#5936 and is a maintainer decision under ADR-0049.

--- a/packages/components/src/renderers/layout/page.tsx
+++ b/packages/components/src/renderers/layout/page.tsx
@@ -671,7 +671,7 @@ export const PageRenderer: React.FC<{
 const pageMeta: any = {
   namespace: 'ui',
   label: 'Page',
-  icon: 'Layout',
+  icon: 'panels-top-left',
   category: 'layout',
   inputs: [
     { name: 'title', type: 'string', label: 'Title' },

--- a/packages/plugin-detail/src/index.tsx
+++ b/packages/plugin-detail/src/index.tsx
@@ -758,7 +758,7 @@ ComponentRegistry.register('alert', RecordAlertRenderer, {
   skipFallback: true,
   category: 'record',
   label: 'Alert Banner',
-  icon: 'AlertTriangle',
+  icon: 'triangle-alert',
   inputs: [
     { name: 'severity', type: 'enum', label: 'Severity', enum: ['info', 'warning', 'error', 'success'], defaultValue: 'info' },
     // Two arms each (objectui#3832). Unlike the `page:*` specimens these two


### PR DESCRIPTION
Part of #5936

Clause-②: no — this diff changes two authored VALUES and reaches no declaration. No key is declared or removed, no accept set moves, no gate is extended. Determined from the diff itself: two lines, both the right-hand side of an existing `icon:` property inside an existing registration meta object.

## What changed

Two component registrations declared lucide spellings that lucide has retired:

| Site | Before | After |
|---|---|---|
| `packages/components/src/renderers/layout/page.tsx` (`ui:page`) | `icon: 'Layout'` | `icon: 'panels-top-left'` |
| `packages/plugin-detail/src/index.tsx` (`record:alert`) | `icon: 'AlertTriangle'` | `icon: 'triangle-alert'` |

Plus one changeset. Nothing else. `git diff --stat` is `2 files changed, 2 insertions(+), 2 deletions(-)` before the changeset.

## The load-bearing measurement: behaviour-neutral BY IDENTITY

lucide retires a spelling by dropping it from the runtime `icons` record while keeping the deprecated named export pointing at the very same glyph object. So the repair cannot substitute one glyph for another — that is what makes it landable without a contract review, and it is measured against the installed lucide 1.31.0 rather than asserted:

```
>> IDENTITY  lucide.Layout        === icons["PanelsTopLeft"] : true
>> IDENTITY  lucide.Layout        === lucide.PanelsTopLeft   : true
>> IDENTITY  lucide.AlertTriangle === icons["TriangleAlert"] : true
>> IDENTITY  lucide.AlertTriangle === lucide.TriangleAlert   : true
```

Membership, resolved through the seam's own tokeniser (`renderers/action/resolve-icon.ts`):

```
"Layout"          -> key "Layout"        | member of RECORD icons: false | resolveIcon: null
"panels-top-left" -> key "PanelsTopLeft" | member of RECORD icons: true  | resolveIcon: component
"AlertTriangle"   -> key "AlertTriangle" | member of RECORD icons: false | resolveIcon: null
"triangle-alert"  -> key "TriangleAlert" | member of RECORD icons: true  | resolveIcon: component

LIT  CONTROL hasOwnProperty(icons, "CircleCheck")       : true   (membership instrument live)
LIT  CONTROL resolveIcon("circle-check")                : component
LIT  CONTROL iconNames.includes("circle-check")         : true   (dynamic instrument live)
DARK CONTROL hasOwnProperty(icons, "NoSuchGlyphXyzzy")  : false  (false is reachable)
DARK CONTROL resolveIcon("no-such-glyph-xyzzy")         : null
```

Every zero-answering query above is printed beside a control in the same query shape that fires.

**Neutral in all three resolution worlds**, which is why it is correct whichever way the open half of #5936 is decided:

- through a **record-reading** resolver — old resolves to `null`, new resolves to that shared object; a repair, never a substitution;
- through the **dynamic** surface (`iconNames`, 2025 names, retired aliases included) — both spellings already resolved, to the same glyph;
- with **no consumer at all** — inert either way.

**Why the kebab spellings.** They are the only ones live on BOTH surfaces. Measured:

```
panels-top-left | RECORD: true  | DYNAMIC: true
PanelsTopLeft   | RECORD: true  | DYNAMIC: false
triangle-alert  | RECORD: true  | DYNAMIC: true
TriangleAlert   | RECORD: true  | DYNAMIC: false
Layout          | RECORD: false | DYNAMIC: false
AlertTriangle   | RECORD: false | DYNAMIC: false
```

`iconNames` is kebab-case only, so a PascalCase record key is absent from it. The card's prescribed spellings are therefore also the strictly safer ones.

## The gate reading, and an honest correction

`scripts/check-lucide-icon-record-names.mjs` is **green both before and after**, with **identical counters** (182 judged names). It does not go red on the old spellings, because it deliberately does not judge a component registration's `icon` meta — which is exactly what #5936 says, and this PR does not change it.

That green is a real reading and not a dead instrument, proven two ways in the same run shape:

**1. Lit control — the same retired spelling on a site the gate DOES judge.** Put `'Layout'` into the anchored `iconMap` in `packages/plugin-view/src/ObjectView.tsx`:

```
GATE exit=1
FAIL  lucide icon names
    - packages/plugin-view/src/ObjectView.tsx:1119  [iconMap (strings)]
      "Layout" -> `Layout` is not a key of the runtime `icons` record. lucide keeps it only as a
      DEPRECATED EXPORT of the same glyph — write `panels-top-left` (the spelling the record carries).
```

The gate derives `panels-top-left` by identity, independently corroborating the measurement above.

**2. Ablation — the retired spellings put back at the two sites in this PR.** Gate exit `0`, and every counter identical to the repaired tree: `authored icon names judged: 148`, `anchored map entries judged: 34`, `182` total.

Both ablations ran under `trap ... EXIT INT TERM` with absolute paths. Each mutation was proven on disk before any result was read (anchored fixed-string counts plus `git hash-object` differing from the HEAD blob), and each restore was proven BY STATE — `git diff HEAD` empty AND on-disk blob equal to the HEAD blob, restored via `git checkout HEAD -- ABSOLUTE_PATH`. The mutated blobs round-tripped byte-exactly to the pre-repair blobs (`0c14df03c`, `b9451e00f`), so the ablation is provably the exact inverse of the repair.

## Verification

Gate union re-run **after** the final commit, at `fadfd6e06`, tree clean:

```
check-lucide-icon-record-names  exit=0  OK  lucide icon names: 182 authored/declared names reaching 1
                                            record-reading resolver are live `icons` keys
check-control-bytes             exit=0  check-control-bytes: OK (scanned 6246 tracked text file(s))
check-changeset-presence        exit=0  2 source file(s) of 2 released package(s) changed, and this
                                            change declares 1 changeset(s)
check-changeset-fixed           exit=0  All workspace packages are in the changeset fixed group.
check-changeset-no-major        exit=0  No changeset declares a `major` bump.
```

Every exit code captured by redirect-then-read, never through a pipe, and each verdict line above is the gate's own.

- **Tests** — `pnpm exec vitest run packages/components/ packages/plugin-detail/` from the repo root (the package-scoped form is refused by `scripts/vitest-invocation-guard.mjs`): **360 test files passed, 3333 tests passed, 0 failures.** Both changed packages in full, not a subset.
- **Type-check** — `packages/components` and `packages/plugin-detail`, both `tsc --noEmit && tsc -p tsconfig.test.json`, both `Done`. `Scope: 2 of 47 workspace projects` confirms the filter matched rather than silently matching nothing.
- **Dependency closure built first**, so nothing above read a stale `dist`.
- **Changeset** — the gate ruled the bump. It demanded a declaration and offered the empty-frontmatter form; a real `patch` for the two packages was written instead, because the "no consumer anywhere" reading is #5936's ADR-0049 retirement PREMISE and not a proof of absence, so declaring "releases nothing" would lean on exactly the premise this slice is fenced away from.

### Declared narrowing (one)

**Lint.** `eslint` was run on the two changed files rather than repo-wide: 2 files linted (count from `--format json`), **0 errors, 42 warnings, all pre-existing** and none on the changed lines. The three things that make this a measurement rather than a skipped run:

1. the population is read off eslint's own config (`files: ['**/*.{ts,tsx}']` in `eslint.config.js`), not guessed — and eslint's own membership answer was exercised in both directions (`--print-config` resolves 117 rules for each changed file; a `node_modules` path comes back `File ignored by default`);
2. the file count is eslint's own, from `--format json`;
3. **type-aware linting is not enabled** — the config extends `tseslint.configs.recommended`, not `recommendedTypeChecked`, and declares no `project` / `projectService`. Every rule is therefore per-file, so a string-literal change inside these two files cannot move the verdict of any untouched file. A repo-wide run could not have caught anything this run did not.

CI runs the full farm regardless.

## What is deliberately NOT here

#5936 has a second half that this PR does not touch and must not be read as having settled:

- **Nothing is retired.** No declared key removed, no registration meta deleted.
- **The gate is not extended** to registrations' `icon` meta (scope item 3) — the relayed reading found no record-reading consumer to justify it.
- **Whether the registration `icon` meta should itself be retired** (scope item 4) is ADR-0049 territory and stays with the maintainer. The card stays open for it, which is why this is `Part of #5936` and not `Fixes`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_