### PR TITLE
fix(plugin-gantt): the timeline column width is a flat floor, not a dead breakpoint table

### DIFF
--- a/.changeset/7228-gantt-column-width-flat-floor.md
+++ b/.changeset/7228-gantt-column-width-flat-floor.md
@@ -1,0 +1,35 @@
+---
+---
+
+The gantt's timeline column width says what it does: a flat 110px floor, not a
+container-width breakpoint table (objectui#7228). **No behaviour changes** — this is
+why the changeset carries no package bump.
+
+`columnWidthForContainer(width)` branched on the container width three ways and returned
+110 from all three arms, so its parameter was read only to be compared against thresholds
+nothing acted on. That shape is not neutral: the two siblings directly beneath it,
+`taskListWidthForContainer` and `showStartEndColumns`, branch on the *same* 640/1024
+breakpoints and really do vary, so the dead table read as a live responsive policy. A
+reader — human or agent — reasonably concluded the gantt narrows its columns in small
+embeds. It does not, and has not since objectui#1870.
+
+The history settles what the arms were for. The function was born a real curve
+(`35/50/60` off `window.innerWidth`), kept it through the rename to a container-derived
+width, and was bumped to `44/64/80` inside objectui#1870 — then, in a later commit of that
+same PR titled *"floor timeline columns at 110px so day/week/month stay readable"*, the
+whole curve was deliberately replaced by a single floor. The comment added in that commit
+names the value's provenance ("user-specified minimum") and why a flat floor costs nothing
+at the wide end (the fit-stretch and manual zoom both move the width upward). The
+branching was leftover shape, not an unfinished table.
+
+So the arms are gone and the value all three returned is now a module constant,
+`BASE_COLUMN_W`, documented as the floor it is — matching how objectui#7420 hoisted the
+task-list geometry in this file: fixed px values become named module constants, helpers
+stay functions only where they genuinely vary with the container.
+
+Nine pins now hold the behaviour on both sides of each retired breakpoint (320 / 500 /
+639 / 640 / 800 / 1023 / 1024 / 1280 / 1920), plus one that requires a single distinct
+value across all of them. Nothing pinned this before: every sibling suite that reads a
+column width first forces the container to 1280 "so columnWidth=110 (deterministic)",
+pinning the widest arm alone — so neither re-curving the width nor moving the floor would
+have been caught.

--- a/packages/plugin-gantt/src/GanttView.columnWidth-7228.test.tsx
+++ b/packages/plugin-gantt/src/GanttView.columnWidth-7228.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * objectui#7228 — the timeline column width is a FLAT FLOOR, not a
+ * container-width curve.
+ *
+ * `columnWidthForContainer` was a three-arm breakpoint table whose three arms
+ * all returned 110. It read as a live responsive policy — its siblings
+ * `taskListWidthForContainer` and `showStartEndColumns` branch on the SAME
+ * breakpoints and really do vary — and it was inert. The arms are gone; the
+ * value every one of them returned is now the module constant `BASE_COLUMN_W`.
+ *
+ * Nothing pinned that before. Every sibling suite that reads a column width
+ * first forces `innerWidth` to 1280 "so columnWidth=110 (deterministic)",
+ * which pins the widest arm only — so neither direction of drift would have
+ * been caught: re-curving the width per container, or moving the floor.
+ *
+ * These pins read the rendered day-column width on BOTH SIDES of the two
+ * retired breakpoints (640 and 1024) and require a single value across all of
+ * them. Assertions are about the DOM, never about computed style.
+ *
+ * Conventions match the sibling suites: the container width is jsdom's
+ * `window.innerWidth` (`useResizeObserver` measures 0 without layout, so
+ * `effectiveWidth` falls back to it), and an explicit `endDate` keeps the
+ * fit-stretch out of the reading — `fitColumnWidth` returns null outright for
+ * a caller-pinned window, so the rendered width is exactly the base.
+ */
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { GanttView, type GanttTask } from './GanttView';
+
+/** The floor, as the source states it. */
+const BASE_COLUMN_W = 110;
+
+/**
+ * Both sides of each retired breakpoint. 639/640 and 1023/1024 are the exact
+ * pairs the old table branched on, so a restored curve cannot pass here.
+ */
+const CONTAINER_WIDTHS = [320, 500, 639, 640, 800, 1023, 1024, 1280, 1920];
+
+const TASKS: GanttTask[] = [
+  {
+    id: 'a',
+    title: 'Task a',
+    start: new Date('2024-06-03T00:00:00.000Z'),
+    end: new Date('2024-06-13T00:00:00.000Z'),
+    progress: 0,
+  },
+];
+
+function renderAt(containerWidth: number) {
+  Object.defineProperty(window, 'innerWidth', { value: containerWidth, configurable: true });
+  return render(
+    <div style={{ width: containerWidth, height: 600 }}>
+      <GanttView
+        tasks={TASKS}
+        startDate={new Date('2024-06-01T00:00:00.000Z')}
+        endDate={new Date('2024-06-30T00:00:00.000Z')}
+      />
+    </div>
+  );
+}
+
+/** Width of the first day column, read off the header's unit cells. */
+function firstUnitWidth(container: HTMLElement): number {
+  const units = Array.from(
+    container.querySelectorAll('[data-testid="gantt-header-units"] > div'),
+  ) as HTMLElement[];
+  expect(units.length).toBeGreaterThan(0);
+  return parseFloat(units[0].style.width);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('GanttView timeline column width (objectui#7228)', () => {
+  for (const width of CONTAINER_WIDTHS) {
+    it(`renders a ${BASE_COLUMN_W}px day column in a ${width}px container`, () => {
+      const { container } = renderAt(width);
+      expect(firstUnitWidth(container)).toBeCloseTo(BASE_COLUMN_W, 5);
+    });
+  }
+
+  it('does not vary with the container width — one value across every tier', () => {
+    const widths = CONTAINER_WIDTHS.map((w) => {
+      const { container } = renderAt(w);
+      const read = firstUnitWidth(container);
+      cleanup();
+      return read;
+    });
+    // A restored curve shows up here as more than one distinct value, whatever
+    // the individual numbers are.
+    expect(new Set(widths).size).toBe(1);
+    expect(widths[0]).toBeCloseTo(BASE_COLUMN_W, 5);
+  });
+});

--- a/packages/plugin-gantt/src/GanttView.tsx
+++ b/packages/plugin-gantt/src/GanttView.tsx
@@ -71,18 +71,30 @@ export function resolveBarDragMode(
 }
 
 /**
+ * Timeline column width, in px: the width of ONE unit of the active
+ * granularity (a day in Day view, a week in Week view…).
+ *
+ * A flat FLOOR, not a container-derived curve. 110 is the user-specified
+ * minimum at which a day/week/month caption stays readable, so it applies at
+ * every container width — narrow embeds included. It is a floor rather than
+ * the final width because `columnWidth` below resolves to
+ * `columnWidthOverride ?? fitColumnWidth ?? BASE_COLUMN_W`, and the fit-stretch
+ * yields a value only when that value is strictly greater: a short project
+ * still fills a roomy timeline, and manual zoom can override either way.
+ *
+ * ⚠️ This was a container-width branch table once — 35/50/60, later bumped to
+ * 44/64/80 — until objectui#1870 replaced the curve with the 110 floor "so
+ * day/week/month stay readable". The three-arm `if` survived that change with
+ * all three arms returning 110, so it went on reading as a live responsive
+ * policy next to siblings that really do vary (objectui#7228). The arms are
+ * gone; the floor every one of them returned is unchanged.
+ */
+const BASE_COLUMN_W = 110;
+
+/**
  * Container-aware sizing helpers — replace the legacy viewport (`window.innerWidth`)
  * checks so the Gantt adapts to whatever slot it sits in (cards, sidebars, popups…).
  */
-function columnWidthForContainer(width: number) {
-  // Day/week/month columns stay readable at a 110px floor — even in narrow
-  // embeds (user-specified minimum). A short project still fills a roomy
-  // timeline via the fit-stretch below; manual zoom can override either way.
-  if (width < 640) return 110;
-  if (width < 1024) return 110;
-  return 110;
-}
-
 /**
  * Task-list geometry, in px. Every term below is traced to the markup that
  * spends it, so the Start/End threshold is DERIVED rather than estimated.
@@ -908,7 +920,6 @@ export function GanttView({
   const autoSchedule = effectiveReadOnly ? false : autoScheduleProp;
   const rescheduleOnConflict = effectiveReadOnly ? false : rescheduleOnConflictProp;
   const rowHeight = rowHeightForContainer(effectiveWidth);
-  const baseColumnWidth = columnWidthForContainer(effectiveWidth);
   // Restore a persisted layout once on first render (when persistLayoutKey set).
   // It seeds the initial granularity / zoom / list-collapse below; the prop
   // still wins for viewMode if explicitly supplied.
@@ -1004,13 +1015,13 @@ export function GanttView({
     if (avail <= 0) return null;
     // Column width that makes the natural span exactly fill the area.
     const fit = (avail / spanDays) * NOMINAL_DAYS[viewMode];
-    if (fit <= baseColumnWidth) return null; // grid already overflows → scroll
+    if (fit <= BASE_COLUMN_W) return null; // grid already overflows → scroll
     // Cap so one unit can't dominate (keep ≥ ~2 columns visible) — a sub-unit
     // project then fills most of the area with a small honest gap, not 1 slab.
     const capped = Math.min(fit, avail * 0.6);
-    return capped > baseColumnWidth ? capped : null;
-  }, [columnWidthOverride, tasks, startDate, endDate, viewMode, effectiveWidth, taskListWidth, baseColumnWidth]);
-  const columnWidth = columnWidthOverride ?? fitColumnWidth ?? baseColumnWidth;
+    return capped > BASE_COLUMN_W ? capped : null;
+  }, [columnWidthOverride, tasks, startDate, endDate, viewMode, effectiveWidth, taskListWidth]);
+  const columnWidth = columnWidthOverride ?? fitColumnWidth ?? BASE_COLUMN_W;
   // One column = one unit of the active granularity; bars/markers map time
   // linearly at pxPerDay so they stay aligned with the calendar-width columns.
   const pxPerDay = columnWidth / NOMINAL_DAYS[viewMode];
@@ -3436,7 +3447,7 @@ export function GanttView({
                   const i = VIEW_MODES.indexOf(viewMode);
                   if (i < VIEW_MODES.length - 1) {
                     changeViewMode(VIEW_MODES[i + 1]);
-                    setColumnWidthOverride(baseColumnWidth);
+                    setColumnWidthOverride(BASE_COLUMN_W);
                   }
                 }
               }}
@@ -3455,7 +3466,7 @@ export function GanttView({
                   const i = VIEW_MODES.indexOf(viewMode);
                   if (i > 0) {
                     changeViewMode(VIEW_MODES[i - 1]);
-                    setColumnWidthOverride(baseColumnWidth);
+                    setColumnWidthOverride(BASE_COLUMN_W);
                   }
                 }
               }}


### PR DESCRIPTION
Fixes #7228

Clause-②: no

`columnWidthForContainer` is declared without `export` in `GanttView.tsx`; the package entry
`packages/plugin-gantt/src/index.tsx` never names it, and the package publishes exactly one
path (`.` to `dist/index.d.ts`). A repo-wide `git grep` finds two occurrences before this
change — the definition and its single call site, both inside `GanttView.tsx`. Nothing
authorable, nothing accepted or rejected, no published surface widened or narrowed. Answered
from the export graph, not from expectation.

## The measurement came first, because it decides the repair

Triage refused to queue this until someone established whether 110 is right at all three
tiers (collapse the table) or whether the narrow tiers were meant to differ and the table was
never finished (restore a curve). That is history, not taste.

**The function was born a real curve, and a later commit flattened it deliberately.**

| commit | shape | value |
| --- | --- | --- |
| `81781fb04` | born as `getResponsiveColumnWidth()`, reading `window.innerWidth` | **35 / 50 / 60** |
| `a2d7023b7` | renamed to `columnWidthForContainer(width)`, container-derived | 35 / 50 / 60 |
| `cb7e05a50` (#1870) | **flattened** | **110 / 110 / 110** |
| `bf244f400` (#7420) | untouched (context only in that diff) | 110 / 110 / 110 |

So the fork's second arm is reached — a curve existed and a later change flattened it — and
the deliberateness test the dispatch asks for comes back **deliberate**, on four independent
pieces of evidence inside the flattening commit itself:

1. `cb7e05a50` is a squashed PR, and one of its own sub-commit titles is
   *"fix(plugin-gantt): floor timeline columns at 110px so day/week/month stay readable"* —
   it names the concept (**floor**), the value, and the reason.
2. The stage immediately before it in the same PR had just re-tuned the curve *as a curve*
   (*"Default column width was too narrow (35/50/60). Bumped to 44/64/80 so day/week/month
   columns have room to breathe"*). The flattening is the next deliberate step, not a
   collision of sloppy edits.
3. The comment added by that same commit records the value's provenance —
   *"even in narrow embeds (**user-specified minimum**)"*. Raising the narrow arms from 44/64
   up to 110 **is** the content of the change: a minimum applied everywhere.
4. It states why flatness costs nothing at the wide end: *"A short project still fills a roomy
   timeline via the fit-stretch below; manual zoom can override either way."* Both mechanisms
   are real and still in the file.

A deliberately flattened helper is the dispatch's Route 1. Nobody is proposing to restore a
curve here — the design call was already made and recorded; only the code's shape lied about
it. **Route 1, mechanical.** No responsive behaviour is invented, and none is restored.

## Consistency with #7420, which just ruled on this file

That PR imposed a convention on the same breakpoint family, and this follows it rather than
inventing a third one: fixed px values become **named module constants with a doc comment
tracing the value**; helpers stay `somethingForContainer(width)` functions **only where they
genuinely vary** with the container. `showStartEndColumns` stayed a function because it varies;
`TASK_LIST_MIN_W` went the other way — #7420 deleted the function-local `const` and hoisted it
to a module constant used directly at every site.

`columnWidthForContainer` does not vary with its argument, so keeping it a function named
`...ForContainer` would restate the same lie in a smaller form. It becomes `BASE_COLUMN_W`,
hoisted exactly like `TASK_LIST_MIN_W`.

⚠️ Scope fence honoured: `showStartEndColumns`, `taskListWidthForContainer`,
`rowHeightForContainer` and the date sublabel are untouched here.

## Behaviour equivalence — by exhaustion, not by sampling

The old function was **total over `number`** and every path returned the same literal:

| input interval | before | after |
| --- | --- | --- |
| `width < 640` (incl. negatives, `-Infinity`) | `110` | `110` |
| `640 <= width < 1024` | `110` | `110` |
| `width >= 1024` (incl. `+Infinity`) | `110` | `110` |
| `NaN` — both comparisons false, falls to the third arm | `110` | `110` |

There is no input, `NaN` included, at which the two disagree, so this is equivalence by
exhaustion over the whole domain. Three further facts close the call-site side:

- The sole call was `columnWidthForContainer(effectiveWidth)`, whose argument is a plain
  number binding — deleting the call removes no side effect.
- `baseColumnWidth` was a local alias holding that same constant. Its five uses now read
  `BASE_COLUMN_W` directly; `columnWidth` still resolves as
  `columnWidthOverride ?? fitColumnWidth ?? BASE_COLUMN_W`.
- It was also a `useMemo` dependency. It never changed across renders (always 110), so
  dropping it from the array cannot change when that memo recomputes — and a module constant
  is not a valid dependency in the first place.

## Verification

Every reading below was taken at `1735f6150`, the branch head, with a clean tree.

- **Package suite: 63 files, 496 tests, all passing.** `pnpm exec vitest run
  packages/plugin-gantt/` from the repo root (the canonical invocation this repo's guard
  enforces). The suite ran 63 files and the tree contains exactly 63 test files, so nothing
  was silently globbed out; `origin/main` carries 62, this branch adds the 63rd.
- **`type-check`: exit 0** — `turbo run type-check --filter=@object-ui/plugin-gantt`, 14/14
  tasks successful, with the dependency closure built first (`dependsOn: ["^build"]`), since a
  stale `dist/*.d.ts` lies in both directions. Verified it actually covered the new code rather
  than excluding it: `tsc -p tsconfig.test.json --listFiles` contains both `GanttView.tsx` and
  the new test file.
- **Lint: exit 0, and zero verdicts moved.** `pnpm --filter @object-ui/plugin-gantt lint` →
  0 errors / 352 warnings. Measured before and after by restoring the pre-fix blob and
  re-linting: **93 files, 2 errors, 356 warnings, identical on both sides**, and `GanttView.tsx`
  is 0 errors / 12 warnings with an **identical rule multiset** —
  `react-refresh/only-export-components` 5, `@typescript-eslint/no-explicit-any` 3,
  `react-hooks/set-state-in-effect` 2, `react-hooks/exhaustive-deps` 2. (Those 2 errors are
  pre-existing and appear on both sides; `--no-inline-config` is what surfaces them.)
- **Repo-wide lint is CI's run.** The narrowing here is declared and measured, not skipped:
  the file population was read from **eslint's own** config resolution (93 files, counted from
  `--format json`, not guessed); `packages/plugin-gantt` is the only package this diff touches
  (the other path is a `.changeset/*.md`, which eslint does not lint); and `eslint.config.js`
  enables **no type-aware linting** — zero occurrences of `parserOptions`, `projectService` or
  `recommendedTypeChecked` in a 17.5 KB config — so this diff cannot move a verdict on a file it
  does not contain.
- **Gate family derived from the touched paths**, all exit 0: `check:control-bytes`,
  `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:element-data-source-declaration`,
  `check:shell-escape-residue`. Plus a manual control-byte sweep over the diff's own files.

### Reverse verification — the pair that fits a behaviour-preserving change

A red-then-green does not apply to a refactor that changes nothing. The honest pair is
*equivalence* and *bite*, and both legs were run against the **committed** fix, each with a
`trap ... EXIT INT TERM`, absolute paths, and the mutation proved on disk by blob hash plus an
anchored text control before anything was measured. The pre-fix side is pinned to this
branch's recorded base commit, never to the shared `origin/main` pointer.

**Leg A — equivalence.** The new pins were run against the **pre-fix** `GanttView.tsx`
(on-disk blob `aa4f3229b`, controls: pre-fix marker present, `BASE_COLUMN_W` absent):
**10 passed / 10**. The behaviour these pins describe is therefore identical before and after,
measured at nine container widths rather than argued.

**Leg B — bite.** Re-introducing exactly the curve a future reader might "restore"
(`effectiveWidth < 640 ? 90 : BASE_COLUMN_W`; injected marker counted on disk, blob changed):
**4 failed / 10** — the three narrow-tier pins plus the single-distinct-value pin. The pins are
not vacuous.

Both restores were proved **by state, not by an exit code**: blob equality against the `HEAD`
blob (`5fe7529a4`) and an empty `git diff HEAD`, and the restore is `git checkout HEAD -- ...`
rather than a bare `git checkout -- ...`, which reads back from the index the mutation just
polluted. No rebuild step is needed for either leg and none is claimed: the root Vitest config
aliases every `@object-ui/*` specifier to its `src`, and the suite imports `./GanttView`
relatively, so nothing here resolves through a package's `dist`.

### Test surface

`packages/plugin-gantt/src/GanttView.columnWidth-7228.test.tsx` — 10 pins, all DOM readings
(the rendered day-column width off the header's unit cells), never computed style. Nine of them
sit on **both sides of each retired breakpoint** — 320 / 500 / 639 / 640 / 800 / 1023 / 1024 /
1280 / 1920 — and the tenth requires a single distinct value across all nine, so a restored
curve fails here whatever numbers it picks.

This gap was real: every sibling suite that reads a column width opens by forcing the container
to 1280 *"so columnWidth=110 (deterministic)"*, which pins the widest arm alone. Neither
direction of drift — re-curving the width, or moving the floor — had a test that could catch it.

### Not measured locally, and why

`check:readme-exports` and `check:sdui-registration-pins` both stopped on **an unmet
prerequisite**, not on a finding, and each says so in its own verdict: the first reports
`the population COLLAPSED -- this run proves nothing` with 36 packages unbuilt, the second
prints `No console build to weigh ... This is exit 2, not a pass`. Both want builds this change
has no reason to produce, and neither is reachable by this diff: `index.tsx` is untouched, no
`ComponentRegistry.register` call changes, and no export appears or disappears. Recorded as NOT
MEASURED rather than as a pass or a failure. CI runs the full farm regardless.

## Release impact

None, so the changeset carries **empty frontmatter** and no package bump — behaviour is
identical at every input; what changes is the shape of the code and its comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_