### PR TITLE
fix(plugin-detail): record-alert success renders a check mark, not a database glyph

### DIFF
--- a/.changeset/7593-record-alert-success-icon.md
+++ b/.changeset/7593-record-alert-success-icon.md
@@ -1,0 +1,33 @@
+---
+'@object-ui/plugin-detail': patch
+---
+
+Fix `record-alert` with `severity: 'success'` rendering a database glyph instead of a
+check mark (objectui#7593).
+
+`SEVERITY_STYLES.success.icon` was the string `'CheckCircle2'`. That literal reaches
+`<LazyIcon name={…} />`, whose resolver degrades an unresolvable name to the `Database`
+icon — deliberately, because server-driven schemas reference icons from other
+libraries and it is better to degrade than to throw. The result was an emerald
+"success" banner with a database glyph in it, on every such alert, silently.
+
+The fix is the live spelling `'circle-check'`, and it is **substitution-free**: it was
+derived by identity rather than remembered. On `lucide-react@1.31.0`,
+`CheckCircle2 === icons.CircleCheck` is `true` — the same glyph object under two names
+— so the repair cannot change which glyph is drawn, only whether one is drawn at all.
+`CheckCircle2` remains a live named export, so static `import { CheckCircle2 }`
+call-sites are unaffected; it is dead only for NAME-BASED lookup, which is the route
+this constant takes.
+
+The load-bearing half is a new pin, because nothing could catch this in either
+direction. The icon gate does not judge dynamic-surface resolvers (its own verdict line
+says so), and the renderer's suite mocks `LazyIcon`, so its assertion could only echo
+the literal back — and it did, pinning the dead spelling. The pin consults the real
+resolver and asserts that every `SEVERITY_STYLES` icon RESOLVES, rather than that it is
+spelled any particular way, so it fails on the actual failure mode rather than
+restating the diff.
+
+The other three severities (`Info`, `AlertTriangle`, `AlertCircle`) are **not** changed
+and were never defective: two of them are absent from lucide's `icons` record but
+present on the dynamic surface (1767 keys vs 2025 names), which is the surface that
+decides here, so they resolve and render correctly today.

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.severityIcons.test.ts
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.severityIcons.test.ts
@@ -1,0 +1,168 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isLucideIconName, toKebabIconName } from '@object-ui/components';
+import { iconNames } from 'lucide-react/dynamic.mjs';
+
+/**
+ * objectui#7593 — every `SEVERITY_STYLES` icon must RESOLVE, judged on the
+ * surface it actually resolves through.
+ *
+ * ## The defect this exists to catch
+ *
+ * `SEVERITY_STYLES.success.icon` was `'CheckCircle2'`. That string reaches
+ * `<LazyIcon name={iconName} />`, and `lazy-icon.tsx` degrades an unresolvable
+ * name to the `Database` glyph — deliberately, because server-driven schemas
+ * reference icons from other libraries and it would rather degrade than throw.
+ * Right default for an AUTHORED slot; wrong outcome for a hardcoded platform
+ * constant. So every `record-alert` with `severity: 'success'` painted a
+ * database icon inside an emerald "success" banner, silently.
+ *
+ * ## Why nothing caught it, in EITHER direction
+ *
+ * Two blind spots lined up:
+ *
+ *  1. The icon gate (`scripts/check-lucide-icon-record-names.mjs`) does not
+ *     judge dynamic-surface resolvers — its own verdict line says so:
+ *     "dynamic surface N sites, 2025 names, not judged here".
+ *  2. The renderer's own suite (`record-alert.test.tsx`) MOCKS `LazyIcon` with
+ *     a stub that echoes `name` back as `data-name`. Resolution never happens
+ *     there, so its assertion could only restate the literal — and it did,
+ *     pinning the dead spelling as if it were correct.
+ *
+ * This file is the half that neither of those can be: it consults the REAL
+ * resolver, so it fails when a name stops resolving. It deliberately does not
+ * assert that any icon is spelled `'circle-check'`; an assertion like that
+ * would only restate the diff and would go green again the next time a dead
+ * name is copied in.
+ *
+ * ## Which surface decides — measured, not remembered
+ *
+ * `lucide-react@1.31.0`, measured 2026-09-04: the `icons` RECORD holds 1767
+ * keys, the DYNAMIC surface (`iconNames`) holds 2025. They disagree, and this
+ * file resolves through the dynamic one via `isLucideIconName`.
+ *
+ *     name            icons record   iconNames    renders?
+ *     Info            present        present      yes
+ *     AlertTriangle   ABSENT         present      yes
+ *     AlertCircle     ABSENT         present      yes
+ *     CheckCircle2    ABSENT         ABSENT       NO -> Database glyph
+ *
+ * That middle pair is why the surface choice is load-bearing rather than
+ * pedantic: a pin written against the `icons` record would fail three names
+ * that render perfectly well and look thorough while being wrong. Only
+ * `CheckCircle2` is dead on the surface that decides, and only it was a defect.
+ *
+ * ## Why the table is read from source instead of imported
+ *
+ * `SEVERITY_STYLES` is module-local and stays that way — this is a behaviour
+ * fix, not a change to what the package publishes. Re-declaring the table here
+ * would put a second copy in the test, which can drift from the one under test
+ * and go on passing while it does. Reading the shipped source keeps one copy.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RENDERER = path.resolve(HERE, '../record-alert.tsx');
+const SRC = fs.readFileSync(RENDERER, 'utf8');
+
+/**
+ * The declared severity vocabulary, read from the renderer's own union type.
+ * Throws rather than returning empty: a silent miss here would make the
+ * coverage assertion below vacuous, and a loud module-load failure is the one
+ * outcome a pin may never trade for a quiet pass.
+ */
+function severityVocabulary(): string[] {
+  const m = SRC.match(/type Severity\s*=\s*([^;]+);/);
+  if (!m) throw new Error(`could not find the \`Severity\` union in ${RENDERER}`);
+  const names = [...m[1].matchAll(/'([^']+)'/g)].map((x) => x[1]);
+  if (names.length === 0) throw new Error(`\`Severity\` union parsed to nothing in ${RENDERER}`);
+  return names;
+}
+
+/** The `severity -> icon` literals, read from the shipped `SEVERITY_STYLES`. */
+function severityIcons(): Array<{ severity: string; icon: string }> {
+  const start = SRC.indexOf('const SEVERITY_STYLES');
+  if (start < 0) throw new Error(`could not find \`SEVERITY_STYLES\` in ${RENDERER}`);
+  // Slice from the initialiser, so the `Record<Severity, { … }>` annotation's
+  // own braces cannot be mistaken for a table row.
+  const open = SRC.indexOf('= {', start);
+  const end = SRC.indexOf('\n};', open);
+  if (open < 0 || end <= open) {
+    throw new Error(`could not delimit the \`SEVERITY_STYLES\` table in ${RENDERER}`);
+  }
+  const block = SRC.slice(open, end);
+  const rows = [...block.matchAll(/(\w+):\s*\{[^}]*?icon:\s*'([^']+)'/g)].map((m) => ({
+    severity: m[1],
+    icon: m[2],
+  }));
+  if (rows.length === 0) throw new Error(`\`SEVERITY_STYLES\` parsed to no rows in ${RENDERER}`);
+  return rows;
+}
+
+const VOCABULARY = severityVocabulary();
+const ROWS = severityIcons();
+
+const DYNAMIC_SURFACE = new Set(iconNames as unknown as string[]);
+
+describe('record-alert SEVERITY_STYLES icons resolve (objectui#7593)', () => {
+  it('the table is read successfully and covers the whole severity vocabulary', () => {
+    // Anti-vacuity. Without this, a regex that silently matched nothing would
+    // leave the per-severity cases below registering ZERO tests — a green that
+    // means "we checked no icons", which is the failure mode a pin like this
+    // dies of.
+    expect(ROWS.length).toBeGreaterThan(0);
+    expect(ROWS.map((r) => r.severity).sort()).toEqual([...VOCABULARY].sort());
+  });
+
+  // One case PER SEVERITY, deliberately. A single loop would collapse to one
+  // red the moment any name died, and the useful signal here is WHICH ones did:
+  // three of these four names are absent from lucide's `icons` record and still
+  // render perfectly, so a pin that reddened all four would look thorough while
+  // being wrong about three of them.
+  it.each(ROWS)('$severity: `$icon` resolves through the LazyIcon seam', ({ severity, icon }) => {
+    // The property under test: NOT "is it spelled X", but "does it resolve".
+    expect({ severity, icon, resolves: isLucideIconName(icon) }).toEqual({
+      severity,
+      icon,
+      resolves: true,
+    });
+  });
+
+  it.each(ROWS)('$severity: `$icon` is on the DYNAMIC surface, the one that decides', ({ severity, icon }) => {
+    // `isLucideIconName` is the seam the renderer goes through; this states
+    // outright which inventory it reads, so a future change of surface shows up
+    // here instead of silently changing what the cases above mean.
+    const kebab = toKebabIconName(icon);
+    expect({ severity, kebab, onDynamicSurface: DYNAMIC_SURFACE.has(kebab) }).toEqual({
+      severity,
+      kebab,
+      onDynamicSurface: true,
+    });
+  });
+
+  it('controls — the assertions above can actually fail', () => {
+    // LIT: names that must resolve, in both spellings the seam accepts.
+    expect(isLucideIconName('circle-check')).toBe(true);
+    expect(isLucideIconName('CircleCheck')).toBe(true);
+
+    // DARK: names that must NOT resolve. The first is the exact spelling that
+    // shipped the defect — `CheckCircle2` is still a live NAMED EXPORT of
+    // `lucide-react` (it is an alias of `CircleCheck`; the two are the same
+    // object), which is why it looks correct at a glance and why static
+    // `import { CheckCircle2 }` call-sites elsewhere in the repo are fine. It
+    // is dead only for NAME-BASED lookup, which is the route this constant
+    // takes. Should lucide ever add `check-circle2` to the dynamic surface,
+    // this line goes red — deliberately, because that would be worth a look.
+    expect(isLucideIconName('CheckCircle2')).toBe(false);
+    expect(isLucideIconName('no-such-glyph-xyz')).toBe(false);
+  });
+});

--- a/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-alert.test.tsx
@@ -325,7 +325,7 @@ describe('RecordAlertRenderer', () => {
   it('flat properties (legacy shape) are read as a fallback to nested .properties', () => {
     render(<RecordAlertRenderer schema={{ severity: 'success', title: 'Saved' } as any} />);
     expect(screen.getByTestId('alert-title').textContent).toBe('Saved');
-    expect(screen.getByTestId('alert-icon').getAttribute('data-name')).toBe('CheckCircle2');
+    expect(screen.getByTestId('alert-icon').getAttribute('data-name')).toBe('circle-check');
   });
 });
 

--- a/packages/plugin-detail/src/renderers/record-alert.tsx
+++ b/packages/plugin-detail/src/renderers/record-alert.tsx
@@ -161,7 +161,7 @@ const SEVERITY_STYLES: Record<Severity, { wrap: string; icon: string }> = {
   },
   success: {
     wrap: 'border-emerald-300/60 bg-emerald-50 text-emerald-900 dark:border-emerald-700/40 dark:bg-emerald-950/30 dark:text-emerald-100 [&>svg]:text-emerald-600 dark:[&>svg]:text-emerald-300',
-    icon: 'CheckCircle2',
+    icon: 'circle-check',
   },
 };
 


### PR DESCRIPTION
Fixes #7593

Clause-②: no. `SEVERITY_STYLES` is a module-local `const` (`record-alert.tsx:149`, no `export`). Read from the export graph rather than from expectation: `record-alert.tsx` exports exactly two names, `RecordAlertRenderer` (line 173) and its default (line 326); the barrel `packages/plugin-detail/src/index.tsx` carries **no** `export *` — every export is named, and it names `RecordAlertRenderer`, never the table. Repo-wide, `SEVERITY_STYLES` is referenced only at its declaration and its one use in the same file. Nothing about accept/reject moves either: the severity vocabulary is untouched, and so is the `props.icon || styles.icon` override precedence. What changes is which glyph is painted for an input that was already accepted. No `needs:contract-review`.

## The defect

`SEVERITY_STYLES.success.icon` was the string `'CheckCircle2'`. That literal reaches `LazyIcon` in the same file, and `getLazyIcon` degrades an unresolvable name to the `Database` glyph — deliberately, because server-driven schemas reference icons from other libraries and it is better to degrade than to throw. Right default for an authored slot; wrong outcome for a hardcoded platform constant. So every `record-alert` with `severity: 'success'` painted a database icon inside an emerald success banner, silently.

## Measurements — re-derived on this ref, not taken from the card

`lucide-react@1.31.0`, resolved from `packages/plugin-detail` and independently from `packages/components` (the `LazyIcon` seam). Both anchors resolve the same single pnpm store entry, so the seam is not on a different version.

Dynamic surface (`iconNames`, the inventory `isLucideIconName` actually consults), size **2025**:

```
CheckCircle2  -> check-circle2   in iconNames : false   <-- the defect
CircleCheck   -> circle-check    in iconNames : true
Info          -> info            in iconNames : true
AlertTriangle -> alert-triangle  in iconNames : true
AlertCircle   -> alert-circle    in iconNames : true
LIT  control    circle-check                  : true
DARK control    no-such-glyph-xyz             : false
```

Record surface (`icons`), size **1767**:

```
CheckCircle2  in icons record : false
CircleCheck   in icons record : true
Info          in icons record : true
AlertTriangle in icons record : false
AlertCircle   in icons record : false
LIT  control    icons.Info                    : true
DARK control    icons.Xyzzy                   : false
```

Every zero above sits beside a control in the same query shape that fires. The repo's own icon gate corroborates the two sizes independently, in its verdict line: `record 1767 keys; dynamic surface 4 sites, 2025 names, not judged here`.

### One disagreement with the card, reported rather than smoothed over

The card's neighbour table lists `Info` as **absent** from the `icons` record. It is **present** (measured true above). The card contradicts itself on this point — it uses `icons.Info` as its own LIT control for the record surface two sections earlier, which only works if `Info` is present. The corrected table:

| name | `icons` record (1767) | `iconNames` (2025) | renders? |
|---|---|---|---|
| `Info` | **present** | present | correctly |
| `AlertTriangle` | absent | present | correctly |
| `AlertCircle` | absent | present | correctly |
| `CheckCircle2` | absent | absent | **no — Database glyph** |

The load-bearing conclusion is unchanged: only `CheckCircle2` is dead on the surface that decides, so only it is a defect, and a pin written against the record surface would still be wrong about two healthy neighbours instead of three.

### The correct spelling, derived by identity rather than remembered

```
typeof lucide.CheckCircle2                           : object
CheckCircle2 === icons.CircleCheck                   : true
LIT  control  icons.CircleCheck === icons.CircleCheck: true
DARK control  CheckCircle2 === icons.Info            : false
```

Same glyph object under two names, so the rename is substitution-free: it cannot change which glyph is drawn, only whether one is drawn at all. `CheckCircle2` also remains a live **named export**, which is why static `import { CheckCircle2 }` call-sites elsewhere in the repo are fine and untouched — it is dead only for name-based lookup, the route this constant takes.

## The pin — the load-bearing half

`packages/plugin-detail/src/renderers/__tests__/record-alert.severityIcons.test.ts`

Nothing could have caught this in either direction. The icon gate does not judge dynamic-surface resolvers (its own verdict line, quoted above), and the renderer's own suite **mocks** `LazyIcon` with a stub that echoes `name` back as `data-name` — so resolution never happens there and its assertion could only restate the literal. It did exactly that, pinning the dead spelling as if it were correct; that assertion is corrected in this PR.

The pin asserts that every `SEVERITY_STYLES` icon **resolves**, through the real `isLucideIconName` seam and on the dynamic surface, and deliberately never asserts that anything is spelled `'circle-check'` — an assertion like that would restate the diff and go green again the next time a dead name is copied in. The table is read from the shipped source rather than imported, because `SEVERITY_STYLES` stays module-local (see Clause ②) and a re-declared copy in the test could drift from the one under test while still passing. Extraction failure throws, and a separate case asserts the parsed severities equal the renderer's own `Severity` union, so the cases cannot pass vacuously over an empty list.

## Reverse verification — both legs

Run under `trap ... EXIT INT TERM` with absolute paths. Mutation proved on disk **before** any result was read: HEAD blob `2a89f786`, on-disk blob after mutation `31c811b1`, plus anchored text controls (injected count 1, removed count 0). Restore proved **by state**, not by exit code: on-disk blob back to `2a89f786` and `git diff HEAD` empty. Restored with `git checkout HEAD -- ABSOLUTE_PATH`.

**Bite** — restore `'CheckCircle2'`, the pin must go red naming it. Exit 1, and it names it:

```
× 'success': `'CheckCircle2'` resolves through the LazyIcon seam
× 'success': `'CheckCircle2'` is on the DYNAMIC surface, the one that decides

AssertionError: expected { severity: 'success', …(2) } to deeply equal { … }
    "icon": "CheckCircle2",
-   "resolves": true,
+   "resolves": false,
```

**Discrimination** — in that same red run the three healthy neighbours stayed green: `Tests 2 failed | 8 passed (10)`, and both failures are `success`.

```
✓ 'info': `'Info'` resolves through the LazyIcon seam
✓ 'warning': `'AlertTriangle'` resolves through the LazyIcon seam
✓ 'error': `'AlertCircle'` resolves through the LazyIcon seam
```

Green-for-three, red-for-one is the proof the pin discriminates: a pin written against the `icons` record would have reddened `AlertTriangle` and `AlertCircle` too and looked thorough while being wrong about both. The cases are `it.each` per severity precisely so this is readable at test granularity rather than buried in one loop's first failure.

## The three neighbours are NOT moved to their live spellings — deliberately

This is hygiene, not a fix, and I chose not to do it. They resolve today on the surface that decides, so moving them changes no rendered glyph. The motive for the hygiene pass — that a dead-for-lookup spelling sitting in a map is how the last one got copied around — is now answered **structurally** by the pin, which enforces resolvability for whatever spelling the table carries, rather than by churning three lines that a reviewer would have to re-verify. Keeping the diff to the one defective line also keeps the discrimination leg above meaningful. Happy to add it as a separate commit if preferred.

## Verification

All at `766d15e24`, the pushed head.

| check | result |
|---|---|
| new pin, `--project unit` | 10 passed |
| `packages/plugin-detail/src/renderers/__tests__/` | 28 files, 244 passed |
| `scripts/__tests__/unit-registry-absence-collision.test.ts` + `check-lucide-icon-record-names.test.ts` | 57 passed |
| `check:icon-record-names` | `OK ... 182 authored/declared names ... are live icons keys` |
| `check:control-bytes` | `OK (scanned 6216 tracked text file(s))` |
| `check:vi-mock-specifiers` / `check:vi-mock-inherit` | OK / OK |
| `check:phantom-deps` | `Every in-scope import is declared by the package that publishes it` |
| `plugin-detail` `type-check` | exit 0 |
| `plugin-detail` `lint` | exit 0, 0 errors (898 pre-existing warnings, none in the new file) |

Vitest was run from the **repo root** throughout; the package-cwd form is refused by `scripts/vitest-invocation-guard.mjs` as a known false-green.

`type-check` first came back with `Cannot find module '@object-ui/types'` and friends. That is **PRECONDITION NOT MET**, not a red gate — the dependency closure was unbuilt. Satisfied with `pnpm --workspace-concurrency=2 --filter '@object-ui/plugin-detail^...' build` and re-run, after which it is clean. I also confirmed the type-check actually **covers** the changed files rather than excluding them, via `tsc -p tsconfig.test.json --listFiles`: 1 hit each for the new pin, the corrected suite, and the renderer.

Not measured by me: whether any shipped metadata actually authors `severity: 'success'` on a `record-alert` — the defect is proven from source, its field frequency is not. Repo-wide `pnpm lint` and the full gate farm are left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMrWaQw3XS5DxTHxp4yRyC)_