### PR TITLE
docs(claude-md): collapse the two AGENTS.md excerpts to rule + hook + pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,51 +1,25 @@
 # CLAUDE.md
 
 **[AGENTS.md](./AGENTS.md) is the source of truth for working in this repo — read it.**
-Its rules are binding. Don't rely on this file alone; the one rule that must never be
-missed is inlined here because missing it corrupts other agents' work.
+Its rules are binding: each of the two rules that must never be missed is inlined below as
+one sentence, its enforcing hook, and a pointer to the AGENTS.md heading.
 
 ## ⛔ Worktree-first — before your FIRST file edit
 
-This repo — **and every sibling repo you touch (`framework`, `cloud`)** — is edited by
-**multiple agents at once**. The shared primary checkout has its HEAD switched and its
-tree reset *under you*, silently clobbering uncommitted work. **A feature branch on the
-shared checkout is NOT enough** — it still gets switched under you. You MUST be in a
-**dedicated per-task worktree**:
-
-```
-git fetch origin main && git worktree add --no-track ../<repo>-<task> -b <branch> origin/main && cd ../<repo>-<task> && pnpm install
-```
-
-Make all edits there, **one worktree per repo** a task spans. A PreToolUse hook
-(`.claude/hooks/guard-main-checkout.sh`) enforces this — it blocks `Edit`/`Write`/
-`NotebookEdit` unless the edited file is in a linked worktree, and it checks the edited
-file's own repo (so sibling repos are covered). Non-task exception: `OS_ALLOW_MAIN_EDITS=1`.
+Never edit a shared primary checkout — this repo's or any sibling repo's (`framework`,
+`cloud`); its HEAD and tree move under you, and a feature branch there is not enough. One
+dedicated worktree per task, per repo. Hooks in `.claude/hooks/`: `guard-main-checkout.sh`
+(Edit/Write/NotebookEdit) and `guard-main-checkout-bash.sh` (the same writes as Bash);
+override `OS_ALLOW_MAIN_EDITS=1`. Full rule: AGENTS.md → **9. Operational Rules**, its
+paragraph **多 agent 协作纪律**.
 
 ## ⛔ Never `git stash` — the stash stack is NOT covered by worktree isolation
 
-`git stash` keeps its stack in `refs/stash` inside the **common `.git` directory**, so
-**every worktree shares one LIFO stack**. The per-task worktree isolation above does not
-extend to it: two agents stashing in their own worktrees push and pop the *same* stack —
-your `pop` restores whatever the other agent pushed a moment earlier, and your own
-changes stay on the stack for them to take. `pop` reports **success**; the only symptom
-is someone else's files appearing in your `git status`, and a following `git add -A`
-merges their work into your PR. This is not hypothetical — it happened between two
-parallel agents (objectui#3430) and cost both of them their in-flight changes.
+`refs/stash` lives in the common `.git` dir, so all worktrees share one LIFO stack: your
+`pop` takes another agent's entry and reports **success** — use a patch or a wip commit.
+Hook `guard-shared-stash.sh` enforces it (override `OS_ALLOW_STASH=1`; re-run its
+`.selftest.sh` if you change it). Full rule: AGENTS.md → **9. Operational Rules**, its
+paragraph **多 agent 协作纪律**.
 
-Use one of these instead — no shared state, all inside your own worktree:
-
-```
-git diff > /tmp/wip.patch && git checkout -- <paths>   # then: git apply /tmp/wip.patch
-git commit -am wip                                     # then: git reset --soft HEAD~1
-git worktree add ../objectui-<task>-cmp <ref>          # a second tree to compare against
-```
-
-A PreToolUse hook (`.claude/hooks/guard-shared-stash.sh`) enforces this — it blocks
-`Bash` commands that push/pop/drop/clear the stack, and allows the forms that cannot
-take another agent's entry: `git stash list`/`show`/`create`, and `git stash apply <sha>`
-/ `store <sha>` pinned to a **literal hex object id** (never `stash@{N}` — that is a
-*position* in a stack you don't own). Deliberate exception: `OS_ALLOW_STASH=1`. Changing
-the hook? Re-run `.claude/hooks/guard-shared-stash.selftest.sh`.
-
-See **AGENTS.md** for the full playbook — both rules above are stated in full there, in
-§9 多 agent 协作纪律; this file carries them only as the excerpt.
+See **AGENTS.md** for the rest: the JSON protocol, coding standards, how to run the tests,
+the governed surface, and the merge-queue PR flow.


### PR DESCRIPTION
Fixes #7506

Executes the maintainer ruling of 2026-09-04 (decision batch #27, objectstack#14978 item 2 → **A**, verbatim 「同意」; director record comment 5535783628): ruling B on objectstack#14685 item 3 is extended to objectui's `CLAUDE.md`. The landed precedent mirrored here is PR objectstack#14855 (`5290fcbe91`).

`CLAUDE.md` carried two hand-copied excerpts of the `AGENTS.md` multi-agent discipline paragraph, plus a charter line reading "the one rule" while two rules were inlined. Each section now carries **one rule sentence + the enforcing hook(s) with the override switch + a pointer to the `AGENTS.md` heading that holds the full rule**. Both `## ⛔` heading lines are byte-identical to the previous file, so greps that name them keep working.

**Governed surface** — `CLAUDE.md` is one of the five governed items in `AGENTS.md` § ⛔ 受管面. This PR stays a **draft** for human merge: not flipped ready, not enqueued, no auto-merge armed. The guard agrees, asked directly:

```
$ node scripts/check-governed-queue-guard.mjs --test CLAUDE.md      # exit 3
⛔ GOVERNED — 1 of 1 path(s) are on a governed surface:
   CLAUDE.md x1 — the repo-root Claude instruction file
```

## Size — shrink-only

| measure | before | after | delta |
|:--|--:|--:|--:|
| `CLAUDE.md` lines | 51 | 25 | -26 |
| `CLAUDE.md` bytes | 2979 | 1424 | -1555 |
| `git diff --stat` | | | 1 file changed, 15 insertions, 41 deletions |

File surface: `CLAUDE.md` only. `AGENTS.md` is untouched — see the measurement below.

## Before deleting: the uniqueness diff against `AGENTS.md`

The ruling requires that any measured narrative, command form or incident fact existing **only** in `CLAUDE.md` move into `AGENTS.md` in this same PR before being deleted. The two excerpts were decomposed into 21 atomic facts and each was tested for a counterpart in the `AGENTS.md` § `多 agent 协作纪律` paragraph (anchored by heading text; it resolves to `AGENTS.md:243-315` at this head). **21 of 21 covered, 0 unique — so nothing moved and `AGENTS.md` is not touched.**

| id | fact deleted from `CLAUDE.md` | counterpart in `AGENTS.md` § 多 agent 协作纪律 |
|:--|:--|:--|
| W1 | sibling repos `framework` / `cloud` are in scope | covered |
| W2 | shared checkout has HEAD switched, tree reset under you | covered |
| W3 | a feature branch on the shared checkout is NOT enough | covered |
| W4 | you MUST be in a dedicated per-task worktree | covered |
| W5 | the worktree recipe command | covered |
| W6 | the guard judges the edited file's own repo | covered |
| W7 | `guard-main-checkout.sh` blocks Edit/Write/NotebookEdit | covered |
| W8 | it checks the edited file's own repo, siblings included | covered |
| W9 | override `OS_ALLOW_MAIN_EDITS=1` | covered |
| S1 | `refs/stash` lives in the common `.git` directory | covered |
| S2 | every worktree shares one LIFO stack | covered |
| S3 | your `pop` takes the other agent's entry | covered |
| S4 | `pop` reports success; symptom; `git add -A` merges their work | covered |
| S5 | incident objectui#3430 cost both agents their in-flight work | covered (and richer there: adds the reverse-verification context and the unreachable-commit recovery) |
| S6a | alternative: patch file | covered |
| S6b | alternative: wip commit | covered |
| S6c | alternative: a second worktree to compare against | covered |
| S7 | `guard-shared-stash.sh` blocks push/pop/drop/clear, allows list/show/create and sha-pinned apply/store | covered |
| S8 | never the stack-position spelling of a stash entry — a position in a stack you do not own | covered |
| S9 | override `OS_ALLOW_STASH=1` | covered |
| S10 | re-run `guard-shared-stash.selftest.sh` after changing the hook | covered |

Direction of the containment: `AGENTS.md` is a strict **superset**. It carries material the excerpts never had — that the wip-commit form is the preferred one, the unreachable-commit recovery of the objectui#3430 loss, and the objectstack#7800 lesson about overwrite-then-restore recipes. Nothing was lost by deleting the excerpts; the reverse would have been true had they been kept and drifted.

Out of scope, per the card and the ruling: `AGENTS.md`'s own omission of `guard-main-checkout-bash.sh` is a separate finding on the skills seat's ledger and is not addressed here. The hooks themselves and `.claude/` are untouched.

## The collapsed file, in full

```markdown
# CLAUDE.md

**[AGENTS.md](./AGENTS.md) is the source of truth for working in this repo — read it.**
Its rules are binding: each of the two rules that must never be missed is inlined below as
one sentence, its enforcing hook, and a pointer to the AGENTS.md heading.

## ⛔ Worktree-first — before your FIRST file edit

Never edit a shared primary checkout — this repo's or any sibling repo's (`framework`,
`cloud`); its HEAD and tree move under you, and a feature branch there is not enough. One
dedicated worktree per task, per repo. Hooks in `.claude/hooks/`: `guard-main-checkout.sh`
(Edit/Write/NotebookEdit) and `guard-main-checkout-bash.sh` (the same writes as Bash);
override `OS_ALLOW_MAIN_EDITS=1`. Full rule: AGENTS.md → **9. Operational Rules**, its
paragraph **多 agent 协作纪律**.

## ⛔ Never `git stash` — the stash stack is NOT covered by worktree isolation

`refs/stash` lives in the common `.git` dir, so all worktrees share one LIFO stack: your
`pop` takes another agent's entry and reports **success** — use a patch or a wip commit.
Hook `guard-shared-stash.sh` enforces it (override `OS_ALLOW_STASH=1`; re-run its
`.selftest.sh` if you change it). Full rule: AGENTS.md → **9. Operational Rules**, its
paragraph **多 agent 协作纪律**.

See **AGENTS.md** for the rest: the JSON protocol, coding standards, how to run the tests,
the governed surface, and the merge-queue PR flow.
```

Both hooks are named on the worktree rule because both are wired in `.claude/settings.json` — `guard-main-checkout.sh` at `:23` on the `Edit|Write|NotebookEdit` matcher, `guard-main-checkout-bash.sh` at `:36` on the `Bash` matcher. The enforcing sentences are quoted from the hooks' own docblocks, not from memory: the first "Blocks Edit / Write / NotebookEdit unless the file being edited lives in a dedicated git WORKTREE"; the second "the SAME worktree-first rule as guard-main-checkout.sh, applied to file writes that arrive through Bash".

Heading bytes, proved rather than eyeballed — the two `## ⛔` lines extracted before and after hash the same:

```
21c416589cd528f43979b4a029efe2fd  headings-before.txt
21c416589cd528f43979b4a029efe2fd  headings-after.txt
```

## Gates

All verdicts below were produced on head `eb09098`, the branch's only and final commit; the tree was clean at the time of every run.

| gate | exit | verdict line it printed |
|:--|--:|:--|
| `pnpm exec turbo run lint --concurrency=2` (= `pnpm lint`) | 0 | `Tasks: 47 successful, 47 total` — 0 errors repo-wide (warnings only; the workflow deliberately sets no `--max-warnings`) |
| `pnpm check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 6225 tracked text file(s); skipped 85 binary).` |
| `pnpm check:doc-fences` | 0 | `✅ check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 90 block(s) of objectui#5867's remaining population (⛔ SHRINK-ONLY). No unknown fence spelling hides one.` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` (it measured `1 file(s) changed` against merge-base `4bb5e1086`) |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `node scripts/check-shell-escape-residue.mjs` | 0 | `✅ check-shell-escape-residue: OK (5/5 root(s) resolved -- ... CLAUDE.md: 1 file(s), 0 fence(s); ...)` |
| `node scripts/check-governed-queue-guard.mjs --self-test` | 0 | `OK check-governed-queue-guard self-test: 132 cases pass` |
| `npx vitest run` on the 3 suites that read the real `CLAUDE.md` | 0 | `Test Files 3 passed (3)` / `Tests 151 passed (151)` |

Exit codes were captured by redirecting to a file **before** any pipe, so no pipeline could rewrite them, and each row quotes the line the gate printed itself rather than a bare status.

**No changeset is owed** and none was added — the gate decided that, quoted above, not a judgement call: a repo-root markdown file publishes nothing from any package. ⛔ No `skip-changeset` label was applied; objectui has no such mechanism.

Four gates beyond the dispatch list were derived from the actually-changed path and run: `check-doc-links` (`CLAUDE.md` is one of its scan roots and the file carries a relative link to `AGENTS.md`), `check-shell-escape-residue` (`CLAUDE.md` is a declared root — it now reports 0 fences there, down from 2), the governed-surface guard, and the three vitest suites that read the real `CLAUDE.md` rather than a fixture (`check-doc-links.test.ts`, `check-shell-escape-residue.test.ts`, `check-governed-queue-guard.test.ts`). `check-links.yml` runs `lycheeverse/lychee-action` for external URLs and is left to CI; the collapsed file contains no external URL.

Generated by the skills lane seat, session `session_019RfFHiRCSs3JXLK4cwcfox`, as a governed-surface draft: review is requested at the contract tier from `os-zhuang` and `hotlong`, and the merge is the maintainer's.

---
_Generated by [Claude Code](https://claude.ai/code/session_019RfFHiRCSs3JXLK4cwcfox)_