### PR TITLE
feat(core): fold ListView's `object` data provider onto `objectName` and read the author's view kind

### DIFF
--- a/.changeset/7477-listview-object-provider-fold.md
+++ b/.changeset/7477-listview-object-provider-fold.md
@@ -1,0 +1,44 @@
+---
+'@object-ui/core': minor
+---
+
+ListView: fold `data={{ provider: 'object', object }}` onto `objectName`, and read the
+author's view kind from `specType` / `type` (objectui#7477 — step 6 of #2890, released
+by the maintainer's ruling B on objectstack#14791, 2026-09-03).
+
+**What was broken.** A react page bound the way the published `react-blocks` contract
+recommends —
+
+```jsx
+<ListView data={{ provider: 'object', object: 'crm_task' }} type="kanban" />
+```
+
+— validated green against `@objectstack/spec` and then rendered an **empty grid** with no
+diagnostic. Both halves of that binding were inert in the renderer: `ListView` read
+`data.provider === 'object'` at zero sites (`'value'` and `'api'` are both live there, so
+the gap was real and not a dead instrument), and it read `specType` — the slot the react
+page tier parks an author's `type` in, because the SDUI envelope claims the `type` key
+(ADR-0078) — at zero sites, so an absent `viewType` forced the view to `grid`.
+
+**What changed.** `normalizeListViewSchema` (`@object-ui/core`) gains two folds. Per
+AGENTS.md #0.1 they live in the one documented normalizer — not as a seventh per-block
+copy of the six sibling `data.object` reads, and not as a renderer-side `??` dual-read.
+
+- `data: { provider: 'object', object }` → `objectName`. The `object` provider is a
+  `strictObject` carrying exactly `{ provider, object }`, so `objectName` captures all of
+  it. Two deliberate departures from the folds around it, both narrowing: an
+  already-present `objectName` **wins** (the fold only fills a gap and can never re-point
+  a binding that already resolves), and `data` is **not** deleted — it has four
+  providers, `api`/`value` are read live, and the block is forwarded to child views whose
+  own `getDataConfig` reads `data` before `objectName`.
+- the author's view kind is read from `specType`, then from a bare `type` when it names a
+  kind ListView draws (the component discriminator `'list-view'` never does) — the same
+  two legs, in the same order, as `normalizeChartSchema`'s chart-family read. An explicit
+  `viewType` still wins; this only fills the gap that used to resolve to `grid`, and a
+  kind ListView does not draw is left to that `grid` default rather than written through.
+
+**Accept behaviour widens.** Metadata that previously had no effect now binds a view: a
+list view carrying an `object` data source, or an author `type`, renders differently
+after this change than before. Nothing that renders today renders differently. No
+authored spelling is removed here — `objectName` / `viewType` remain accepted; their
+retirement is objectstack's, after this ships.

--- a/packages/core/src/utils/__tests__/normalize-list-view.test.ts
+++ b/packages/core/src/utils/__tests__/normalize-list-view.test.ts
@@ -395,6 +395,156 @@ describe('normalizeListViewSchema (#2890)', () => {
     });
   });
 
+  describe("data: { provider: 'object', object } \u2192 objectName (#7477)", () => {
+    it('folds the object provider\'s `object` onto `objectName`', () => {
+      const out = normalizeListViewSchema({
+        type: 'list-view',
+        viewType: 'grid',
+        data: { provider: 'object', object: 'crm_task' },
+      }) as Record<string, unknown>;
+      expect(out.objectName).toBe('crm_task');
+    });
+
+    it('KEEPS `data` — unlike every other fold here, and deliberately', () => {
+      // `data` is not a legacy alias with one meaning: it has four providers,
+      // `api`/`value` are read live in ListView, and the whole block is
+      // forwarded to child views whose own `getDataConfig` reads it BEFORE
+      // `objectName`. Deleting it for one provider would rewrite what a child
+      // resolves. See the note on `normalizeListViewSchema`.
+      const data = { provider: 'object', object: 'crm_task' };
+      const out = normalizeListViewSchema({ viewType: 'grid', data }) as Record<string, unknown>;
+      expect(out.data).toEqual(data);
+    });
+
+    it('lets an existing `objectName` win — the fold only ever fills a gap', () => {
+      const out = normalizeListViewSchema({
+        viewType: 'grid',
+        objectName: 'crm_task',
+        data: { provider: 'object', object: 'crm_other' },
+      }) as Record<string, unknown>;
+      expect(out.objectName).toBe('crm_task');
+    });
+
+    it('treats an EMPTY `objectName` as absent', () => {
+      const out = normalizeListViewSchema({
+        viewType: 'grid',
+        objectName: '',
+        data: { provider: 'object', object: 'crm_task' },
+      }) as Record<string, unknown>;
+      expect(out.objectName).toBe('crm_task');
+    });
+
+    it.each(['api', 'value', 'schema'])('ignores the `%s` provider', (provider) => {
+      const out = normalizeListViewSchema({
+        viewType: 'grid',
+        data: { provider, object: 'crm_task' },
+      }) as Record<string, unknown>;
+      expect(out.objectName).toBeUndefined();
+    });
+
+    it('invents no binding from an object provider that names no object', () => {
+      const out = normalizeListViewSchema({
+        viewType: 'grid',
+        data: { provider: 'object' },
+      }) as Record<string, unknown>;
+      expect(out.objectName).toBeUndefined();
+    });
+
+    it.each<[unknown, string]>([['', 'empty string'], [42, 'number'], [null, 'null']])(
+      'ignores an `object` that is not a non-empty string (%s — %s)',
+      (object) => {
+        const out = normalizeListViewSchema({
+          viewType: 'grid',
+          data: { provider: 'object', object },
+        }) as Record<string, unknown>;
+        expect(out.objectName).toBeUndefined();
+      },
+    );
+
+    it('ignores a `data` that is an ARRAY (the inline-rows shorthand)', () => {
+      const out = normalizeListViewSchema({
+        viewType: 'grid',
+        data: [{ id: '1' }],
+      }) as Record<string, unknown>;
+      expect(out.objectName).toBeUndefined();
+    });
+
+    it('is idempotent', () => {
+      const once = normalizeListViewSchema({
+        viewType: 'grid',
+        data: { provider: 'object', object: 'crm_task' },
+      });
+      const twice = normalizeListViewSchema(once);
+      expect(twice).toEqual(once);
+      expect(twice).toBe(once); // objectName now present ⇒ nothing left to fold
+    });
+  });
+
+  describe('the author\'s view kind — `specType`, then `type` (#7477)', () => {
+    it('reads `specType`, where the react-page wrapper parks an author `type`', () => {
+      // The card's criterion: `type="kanban"` with no `viewType` must not be
+      // forced to `grid`.
+      const out = normalizeListViewSchema({
+        type: 'list-view',
+        specType: 'kanban',
+      }) as Record<string, unknown>;
+      expect(out.viewType).toBe('kanban');
+    });
+
+    it("reads `specType` over the view CATEGORY `'list'` too", () => {
+      const out = normalizeListViewSchema({ viewType: 'list', specType: 'calendar' }) as Record<string, unknown>;
+      expect(out.viewType).toBe('calendar');
+    });
+
+    it('lets an explicit renderable `viewType` win', () => {
+      const out = normalizeListViewSchema({ viewType: 'gallery', specType: 'kanban' }) as Record<string, unknown>;
+      expect(out.viewType).toBe('gallery');
+    });
+
+    it('reads a bare `type` when it names a kind ListView draws', () => {
+      // The spec spells the view kind `type`; on a SchemaNode that key is the
+      // component discriminator, which is why `specType` exists at all. A
+      // stored view handed straight to the block still carries the spec word.
+      const out = normalizeListViewSchema({ type: 'timeline' }) as Record<string, unknown>;
+      expect(out.viewType).toBe('timeline');
+    });
+
+    it('prefers `specType` to a bare `type`', () => {
+      const out = normalizeListViewSchema({ type: 'gantt', specType: 'map' }) as Record<string, unknown>;
+      expect(out.viewType).toBe('map');
+    });
+
+    it("does NOT read the component discriminator as a kind", () => {
+      // The control that keeps the `type` leg above from swallowing the
+      // envelope: `list-view` is a tag, never a visualization.
+      const out = normalizeListViewSchema({ type: 'list-view' }) as Record<string, unknown>;
+      expect(out.viewType).toBe('grid');
+    });
+
+    it('falls back to `grid` for a kind ListView does not draw', () => {
+      // `detail` is a different renderer; `donut` is a chart family. Neither is
+      // written through to `viewType` — the caller\'s default is the honest
+      // answer, exactly as `normalizeChartSchema` treats a family it cannot draw.
+      expect((normalizeListViewSchema({ specType: 'detail' }) as Record<string, unknown>).viewType).toBe('grid');
+      expect((normalizeListViewSchema({ specType: 'donut' }) as Record<string, unknown>).viewType).toBe('grid');
+    });
+
+    it('does not read a prototype key as a view kind', () => {
+      // `in` walks the prototype chain — the trap `rowHeightToDensityMode`
+      // documents. `hasOwnProperty` is why these stay `grid`.
+      expect((normalizeListViewSchema({ specType: 'toString' }) as Record<string, unknown>).viewType).toBe('grid');
+      expect((normalizeListViewSchema({ specType: 'constructor' }) as Record<string, unknown>).viewType).toBe('grid');
+    });
+
+    it('KEEPS `specType` — the fold is a READ, not a rename', () => {
+      // `specType` is the react tier\'s rescue slot for an author `type`, shared
+      // with the other blocks that read it (`normalizeChartSchema`). It is not
+      // an objectui alias being retired, so nothing deletes it.
+      const out = normalizeListViewSchema({ specType: 'kanban' }) as Record<string, unknown>;
+      expect(out.specType).toBe('kanban');
+    });
+  });
+
   describe('reference stability', () => {
     it('returns the input by reference when there is nothing to fold', () => {
       // Load-bearing: ListView memoizes on this identity, so allocating a fresh

--- a/packages/core/src/utils/normalize-list-view.ts
+++ b/packages/core/src/utils/normalize-list-view.ts
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { ViewType } from '@object-ui/types';
 import type { RowHeight } from '@objectstack/spec/ui';
 
 import { normalizeColumnIdentities } from './column-identity.js';
@@ -128,6 +129,44 @@ const ARIA_KEY_ALIASES: Record<string, string> = {
 };
 
 /**
+ * The view kinds `ListView` actually draws — one key per `case` in its
+ * `viewComponentSchema` switch (`packages/plugin-list/src/ListView.tsx`).
+ *
+ * A total `Record<…, true>` over the shared {@link ViewType} union minus the
+ * two members that are not a LIST visualization, for the same reason the
+ * density maps above are `Record<RowHeight, …>`: a kind added to the union
+ * fails the build HERE instead of silently staying unreadable authored input.
+ *  - `list` is the view CATEGORY, not a kind — it already folds to `grid`.
+ *  - `detail` is a different renderer (`plugin-detail`), never a ListView case.
+ *
+ * `hasOwnProperty`, not `in` — same trap as {@link rowHeightToDensityMode}:
+ * `in` walks the prototype chain, so `'toString'` would read as a view kind.
+ */
+const LIST_VIEW_KINDS: Record<Exclude<ViewType, 'list' | 'detail'>, true> = {
+  grid: true,
+  kanban: true,
+  gallery: true,
+  calendar: true,
+  timeline: true,
+  gantt: true,
+  map: true,
+  chart: true,
+  tree: true,
+};
+
+/**
+ * The author's view kind, or `undefined` when the value names no kind ListView
+ * draws. An unrecognized kind is deliberately left unresolved rather than
+ * written through to `viewType`: the caller's own `'grid'` default is a more
+ * honest answer than a `viewType` no branch matches (the same call
+ * `normalizeChartSchema` makes for a chart family it cannot draw).
+ */
+function readListViewKind(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return Object.prototype.hasOwnProperty.call(LIST_VIEW_KINDS, value) ? value : undefined;
+}
+
+/**
  * Per-view-type config aliases → the spec key each one aliases (#2890, the
  * phase-3 carry-over).
  *
@@ -206,10 +245,34 @@ const PER_VIEW_CONFIG_ALIASES: Record<string, Readonly<Record<string, string>>> 
  *    so objectui's field is typed from the spec but used as something else.
  *    That mismatch is real and out of scope here; converting formats inside a
  *    vocabulary fold would change what reaches the data source.
+ *  - `data: { provider: 'object', object }` → `objectName` (#7477, step 6 of
+ *    #2890). This is the spelling the published `react-blocks` contract
+ *    recommends and the one `@objectstack/spec`'s `ViewDataSchema` declares;
+ *    ListView read it at ZERO sites, so a page bound that way validated green
+ *    upstream and rendered an empty list here with no diagnostic. The `object`
+ *    provider is a `strictObject` carrying exactly `{ provider, object }`, so
+ *    `objectName` captures all of it. Two deliberate departures from the folds
+ *    above, both narrowing:
+ *      · an already-present `objectName` WINS — this fold only fills a gap, it
+ *        never re-points a binding that already resolves;
+ *      · `data` is NOT deleted. Every other fold deletes because the legacy key
+ *        has one meaning and one home; `data` has four providers, `api`/`value`
+ *        are read live in `ListView`, and the whole block is FORWARDED to child
+ *        views (the gantt branch), whose own `getDataConfig` reads `data` before
+ *        `objectName`. Deleting it for one provider would rewrite what a child
+ *        resolves. Nothing in `ListView` reads `data.provider === 'object'`, so
+ *        keeping it cannot create a second de-facto contract inside the renderer.
  *  - `viewType`: a missing kind, or the view CATEGORY `'list'` that AI-authored
  *    metadata stores and hosts forward verbatim, becomes the renderable `'grid'`
  *    — otherwise it reaches the renderer's typeless default branch and shows as
- *    a red "Unknown component type" box.
+ *    a red "Unknown component type" box. Before that default applies, the
+ *    AUTHOR's kind is read (#7477): `specType` — the slot
+ *    `components/renderers/layout/react-page.tsx` parks a react-tier `type` in
+ *    when the SDUI envelope claims the `type` key (ADR-0078) — and then a bare
+ *    `type` when it names a kind ListView draws, which the component
+ *    discriminator (`'list-view'`) never does. Same two legs, same order, as
+ *    `normalizeChartSchema`'s chart-family read. An explicit `viewType` still
+ *    wins: this leg only fills the gap that used to resolve to `'grid'`.
  *  - each `columns` entry's IDENTITY — `name` / `fieldName` → the spec's `field`
  *    (#3104). This one MIRRORS instead of deleting, for the reason given on
  *    {@link normalizeColumnIdentities}: `columns` entries cross the package
@@ -244,7 +307,19 @@ export function normalizeListViewSchema<T>(schema: T): T {
   const foldAria = !!aria && Object.keys(ARIA_KEY_ALIASES).some((k) => aria[k] !== undefined);
   const sharing = isRecord(s.sharing) ? s.sharing : undefined;
   const foldSharing = !!sharing && (sharing.visibility !== undefined || sharing.enabled !== undefined);
+  // `data: { provider: 'object', object }` → `objectName` (#7477). Gap-fill
+  // only: a non-empty `objectName` already on the schema wins, so this can
+  // never re-point a binding that resolves today.
+  const dataConfig = isRecord(s.data) ? s.data : undefined;
+  const dataObjectName =
+    dataConfig?.provider === 'object' && typeof dataConfig.object === 'string' && dataConfig.object
+      ? dataConfig.object
+      : undefined;
+  const foldObjectName =
+    dataObjectName !== undefined && !(typeof s.objectName === 'string' && s.objectName);
   const viewType = s.viewType;
+  // The author's kind, read before the `'grid'` default applies (#7477).
+  const authoredViewKind = readListViewKind(s.specType) ?? readListViewKind(s.type);
   const defaultViewKind = !viewType || viewType === 'list';
   // The columns array the identity fold will see — mirroring the `foldColumns`
   // precedence below (canonical `columns` wins; otherwise the legacy `fields`
@@ -273,7 +348,7 @@ export function normalizeListViewSchema<T>(schema: T): T {
   if (
     !foldColumns && !foldRowHeight && !foldFilter && !legacyFlags.length &&
     !foldDescription && !foldAria && !foldSharing && !defaultViewKind &&
-    !foldColumnIdentity && !perViewFolds.length
+    !foldColumnIdentity && !perViewFolds.length && !foldObjectName
   ) {
     return schema;
   }
@@ -356,6 +431,7 @@ export function normalizeListViewSchema<T>(schema: T): T {
     }
     next[viewKey] = nextCfg;
   }
-  if (defaultViewKind) next.viewType = 'grid';
+  if (foldObjectName) next.objectName = dataObjectName;
+  if (defaultViewKind) next.viewType = authoredViewKind ?? 'grid';
   return next as T;
 }

--- a/packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx
+++ b/packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7477 — a react page binds ListView the way the published
+ * `react-blocks` contract recommends, and it renders.
+ *
+ * Step 6 of #2890, released by the maintainer's ruling B on objectstack#14791.
+ * The reported shape:
+ *
+ *     <ListView data={{ provider: 'object', object: 'x' }} type="kanban" />
+ *
+ * Both halves of that binding used to be INERT here, and silently so:
+ *
+ *   - `data.provider === 'object'` was read at ZERO sites in `ListView.tsx`
+ *     (`provider === 'value'` and `provider === 'api'` are both live there, so
+ *     the zero was a real gap and not a dead instrument). `schema.objectName`
+ *     stayed undefined, `fetchData` returned early on `!schema.objectName`, and
+ *     the page rendered an empty list with NO diagnostic — while the same
+ *     metadata validates green against `@objectstack/spec`'s `ViewDataSchema`.
+ *   - the author's `type` — which the react tier parks under `specType`,
+ *     because the SDUI envelope claims the `type` key (ADR-0078,
+ *     `components/renderers/layout/react-page.tsx`) — was read at ZERO sites in
+ *     this package, so an absent `viewType` forced the view to `grid`.
+ *
+ * The fix is ONE fold in `normalizeListViewSchema` (`@object-ui/core`), not a
+ * seventh per-block copy of the six sibling `data.object` reads and not a
+ * renderer-side `??` dual-read (AGENTS.md #0.1).
+ *
+ * ## Why this file mounts the REAL react page tier
+ *
+ * The card's criterion is written about a react PAGE, and the `specType` park
+ * only exists because that tier's wrapper puts it there. Asserting against a
+ * hand-built `{ specType }` bag would pin this package's half against a shape
+ * this file itself asserts — so the first test drives the real
+ * `kind:'react'` compile, the real scope injection, the real `list-view`
+ * registration and a spy under `object-kanban`, and the hand-built bag is kept
+ * only as the narrower second case.
+ *
+ * REVERSE VERIFICATION — direction predicted before running, then observed:
+ * drop either leg of the fold in `normalize-list-view.ts` and this file goes
+ * red in a leg-specific way — without the `data.object` leg the kanban is
+ * handed `objectName: undefined` and nothing is fetched; without the
+ * `specType` leg the page renders `object-grid` instead of `object-kanban`.
+ * The `provider: 'value'` case is the control that stays green either way.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer, SchemaRendererProvider, AdapterCtx } from '@object-ui/react';
+// Registers the page renderers (`type:'page'` / `'home'`), which dispatch
+// `kind:'react'` to `ReactKindPage`.
+import '@object-ui/components';
+// Registers the REAL `list-view`, which is what the react page's scope resolves.
+import '../index';
+import { ListView } from '../ListView';
+
+const OBJECT = 'crm_task';
+
+const rows = [
+  { id: 't-1', name: 'Draft the brief', stage: 'todo' },
+  { id: 't-2', name: 'Ship the fold', stage: 'doing' },
+];
+
+const objectDef = {
+  name: OBJECT,
+  label: 'Task',
+  fields: {
+    id: { name: 'id', type: 'text', label: 'Id' },
+    name: { name: 'name', type: 'text', label: 'Name' },
+    stage: { name: 'stage', type: 'text', label: 'Stage' },
+  },
+};
+
+/** Props each view spy last received. */
+let kanbanProps: Array<Record<string, any>> = [];
+let gridProps: Array<Record<string, any>> = [];
+
+ComponentRegistry.register(
+  'object-kanban',
+  (props: Record<string, any>) => {
+    kanbanProps.push(props);
+    return <div data-testid="kanban-spy" />;
+  },
+  { namespace: 'test', label: 'Kanban spy', category: 'view' },
+);
+
+ComponentRegistry.register(
+  'object-grid',
+  (props: Record<string, any>) => {
+    gridProps.push(props);
+    return <div data-testid="grid-spy" />;
+  },
+  { namespace: 'test', label: 'Grid spy', category: 'view' },
+);
+
+const makeDataSource = () =>
+  ({
+    find: vi.fn(async () => rows),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    count: vi.fn(async () => rows.length),
+    getObjectSchema: vi.fn(async () => objectDef),
+    getObjects: vi.fn(async () => []),
+    onMutation: () => () => {},
+  }) as any;
+
+/** Render a real `kind:'react'` page and return its live adapter. */
+function renderReactPage(source: string) {
+  const dataSource = makeDataSource();
+  render(
+    <AdapterCtx.Provider value={dataSource}>
+      <SchemaRendererProvider dataSource={dataSource}>
+        <SchemaRenderer
+          schema={{ type: 'page', kind: 'react', name: 'binding_page', source } as never}
+        />
+      </SchemaRendererProvider>
+    </AdapterCtx.Provider>,
+  );
+  return dataSource;
+}
+
+/** Mount ListView directly on an already-built schema bag. */
+function renderListView(schema: Record<string, any>) {
+  const dataSource = makeDataSource();
+  render(
+    <SchemaRendererProvider dataSource={dataSource}>
+      <ListView schema={{ type: 'list-view', ...schema } as never} dataSource={dataSource} />
+    </SchemaRendererProvider>,
+  );
+  return dataSource;
+}
+
+beforeEach(() => {
+  kanbanProps = [];
+  gridProps = [];
+});
+afterEach(cleanup);
+
+describe("ListView — data={{ provider: 'object', object }} binds the view (objectui#7477)", () => {
+  it("renders object `x` as a KANBAN from a react page that declares neither objectName nor viewType", async () => {
+    // THE EXECUTABLE CRITERION, verbatim in substance from the card. Before the
+    // fold this rendered `object-grid` with `objectName: undefined` and never
+    // called `find` — an empty list, no diagnostic.
+    const dataSource = renderReactPage(`
+function Page() {
+  return <ListView data={{ provider: 'object', object: '${OBJECT}' }} type="kanban" />;
+}`);
+
+    await waitFor(() => expect(kanbanProps.length).toBeGreaterThan(0));
+    // (a) the KIND came from the author's `type`, parked under `specType`.
+    expect(gridProps).toHaveLength(0);
+    // (b) the OBJECT came from the `object` provider's `object`.
+    expect(kanbanProps[kanbanProps.length - 1].schema.objectName).toBe(OBJECT);
+    // (c) and it is a live binding, not just a prop: the view queried object x.
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(dataSource.find.mock.calls[0][0]).toBe(OBJECT);
+  });
+
+  it('binds the same way when the wrapper-built bag is handed straight to the block', async () => {
+    // The narrower half of the case above: exactly the bag
+    // `buildComponentScope`'s wrapper produces (react-page.tsx — the
+    // discriminator wins `type`, the author's value is parked beside it), with
+    // the page tier taken out of the picture.
+    const dataSource = renderListView({
+      data: { provider: 'object', object: OBJECT },
+      specType: 'kanban',
+    });
+
+    await waitFor(() => expect(kanbanProps.length).toBeGreaterThan(0));
+    expect(kanbanProps[kanbanProps.length - 1].schema.objectName).toBe(OBJECT);
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(dataSource.find.mock.calls[0][0]).toBe(OBJECT);
+  });
+
+  it('binds the object even when the author states no kind at all (still a grid)', async () => {
+    // The `object` provider leg alone. `viewType` absent and no author `type`
+    // ⇒ the pre-existing `'grid'` default still applies, unchanged.
+    const dataSource = renderListView({ data: { provider: 'object', object: OBJECT } });
+
+    await waitFor(() => expect(gridProps.length).toBeGreaterThan(0));
+    expect(kanbanProps).toHaveLength(0);
+    expect(gridProps[gridProps.length - 1].schema.objectName).toBe(OBJECT);
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(dataSource.find.mock.calls[0][0]).toBe(OBJECT);
+  });
+
+  it('invents NO binding from an `object` provider that names no object', async () => {
+    // The negative control that keeps the three cases above from passing
+    // vacuously: a half-written data block must not manufacture an objectName,
+    // and must not start a query.
+    const dataSource = renderListView({ data: { provider: 'object' }, specType: 'kanban' });
+
+    await waitFor(() => expect(kanbanProps.length).toBeGreaterThan(0));
+    expect(kanbanProps[kanbanProps.length - 1].schema.objectName).toBeUndefined();
+    expect(dataSource.find).not.toHaveBeenCalled();
+  });
+
+  it("leaves the `value` provider alone — it never gains an objectName", async () => {
+    // The live sibling provider, as the control this fold must not disturb:
+    // inline rows still render with no object binding and no query.
+    const dataSource = renderListView({
+      data: { provider: 'value', items: rows },
+      specType: 'kanban',
+    });
+
+    await waitFor(() => expect(kanbanProps.length).toBeGreaterThan(0));
+    expect(kanbanProps[kanbanProps.length - 1].schema.objectName).toBeUndefined();
+    expect(dataSource.find).not.toHaveBeenCalled();
+  });
+
+  it('lets an explicit `viewType` win over the author-parked `specType`', async () => {
+    // Gap-fill only. The `specType` leg fills the kind that used to resolve to
+    // `'grid'`; it never overrides a kind the view already states.
+    renderListView({
+      data: { provider: 'object', object: OBJECT },
+      viewType: 'grid',
+      specType: 'kanban',
+    });
+
+    await waitFor(() => expect(gridProps.length).toBeGreaterThan(0));
+    expect(kanbanProps).toHaveLength(0);
+  });
+
+  it('lets an explicit `objectName` win over the data block', async () => {
+    // The other half of gap-fill: this fold can never re-point a binding that
+    // already resolves.
+    const dataSource = renderListView({
+      objectName: OBJECT,
+      data: { provider: 'object', object: 'crm_other' },
+      specType: 'kanban',
+    });
+
+    await waitFor(() => expect(kanbanProps.length).toBeGreaterThan(0));
+    expect(kanbanProps[kanbanProps.length - 1].schema.objectName).toBe(OBJECT);
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(dataSource.find.mock.calls[0][0]).toBe(OBJECT);
+  });
+});


### PR DESCRIPTION
Fixes #7477

Step 6 of objectui#2890, released by the maintainer's ruling B on objectstack#14791
(2026-09-03, verbatim 「同意」). The direction was decided there; this PR implements,
measures and declares it.

> **A note on how this body is written.** Angle-bracket, tag-shaped fragments are eaten
> by GitHub's body sanitizer — inside backticks and fenced blocks too (AGENTS.md, the
> "GitHub mutates body BYTES" clause). So the JSX in this description is spelled out in
> words: "a `ListView` element with …" rather than written literally. That is deliberate,
> not sloppiness.

## What changed, and why

A react page that binds the list block the way the published `react-blocks` contract
recommends — a `ListView` element carrying `data={{ provider: 'object', object: 'x' }}`
and `type="kanban"`, and no `objectName` and no `viewType` — validated green against
`@objectstack/spec` and then rendered nothing useful here. Both halves of that binding
were inert in the renderer, and silently so:

- `packages/plugin-list/src/ListView.tsx` read `data.provider === 'object'` at **0**
  sites. `provider === 'value'` and `provider === 'api'` are both live in that same file,
  so the zero was a real gap and not a dead instrument. `schema.objectName` stayed
  undefined and the fetch effect returns early on `!schema.objectName`.
- `specType` — the slot `packages/components/src/renderers/layout/react-page.tsx:91`
  parks a react-tier `type` in, because the SDUI envelope claims the `type` key
  (ADR-0078) — was read at **0** sites in `packages/plugin-list/`. With `viewType` absent
  the kind was forced to `grid`.

Both folds land in **one** place: `normalizeListViewSchema`
(`packages/core/src/utils/normalize-list-view.ts`), the normalizer `ListView` already
runs over its schema before it reads anything. Not a seventh per-block copy of the six
sibling `data.object` reads, and not a renderer-side `??` dual-read — AGENTS.md #0.1.
`ListView.tsx` is **not touched by this PR**.

### The `object` provider fold

`data: { provider: 'object', object }` folds onto `objectName`. The spec's `object`
provider is a `strictObject` carrying exactly `{ provider, object }`
(`@objectstack/spec/src/ui/view.zod.ts`), so `objectName` captures all of it.

Two deliberate departures from the folds around it, both **narrowing**, both documented
in the source:

1. **An already-present `objectName` wins.** The fold only ever fills a gap; it can never
   re-point a binding that already resolves. Pinned in both test files.
2. **`data` is NOT deleted**, unlike every other fold in this normalizer. Those delete
   because the legacy key has one meaning and one home. `data` has four providers,
   `api`/`value` are read live in `ListView`, and the whole block is forwarded to child
   views (the gantt branch) whose own `getDataConfig` reads `data` **before** `objectName`
   — so deleting it for one provider would rewrite what a child resolves. Keeping it
   cannot create a second de-facto contract inside the renderer, because nothing in
   `ListView` reads `data.provider === 'object'` at all.

### The view-kind read

The author's kind is read from `specType`, then from a bare `type` when that names a kind
`ListView` draws — the same two legs, in the same order, as `normalizeChartSchema`'s
chart-family read. The component discriminator (`list-view`) is never a view kind, which
is what makes the second leg unambiguous. An explicit `viewType` still wins; a kind
`ListView` does not draw is left to the pre-existing `grid` default rather than written
through.

The accepted set is a total `Record` over `@object-ui/types`' `ViewType` union minus
`list` (the view CATEGORY, which already folds to `grid`) and `detail` (a different
renderer) — so a kind added to that union fails the build here instead of silently
staying unreadable authored input. Same device as the file's existing
total-`Record`-keyed-by-`RowHeight` maps.

## The executable criterion — measured, not asserted

The card's criterion: *a react page binding the list block with
`data={{ provider: 'object', object: 'x' }}` and `type="kanban"` and no `objectName` /
`viewType` renders object `x` as a kanban.*

`packages/plugin-list/src/__tests__/ListView.objectProviderBinding-7477.test.tsx` drives
the REAL `kind:'react'` page tier — the real source compile, the real scope injection, the
real `list-view` registration — with a spy under `object-kanban` and another under
`object-grid`. "Before" below is this branch with both apply-lines neutered, which is
`origin/main`'s behaviour for these inputs.

| observation on the criterion input | before | after |
| --- | --- | --- |
| which child view mounts | **neither** — the kanban spy and the grid spy both stay at 0 mounts through a 1s `waitFor` | `object-kanban` |
| `objectName` handed to the view | n/a — no view mounts | `crm_task` |
| `dataSource.find` calls | **0** | called, first argument `crm_task` |

The card's "renders an empty list, with no diagnostic" is confirmed on the first two rows;
the "no diagnostic" half is **not separately measured** here (this file asserts what
mounts and what is queried, not what copy the unbound state shows).

## Ablation — predicted before running, then observed

Each leg was cut on a committed tree, the mutation proved on disk (anchor matched exactly
once; removed text at 0 hits, injected marker at 1), and the restore proved by
`git diff HEAD` being empty **and** the live blob hash equalling the `HEAD` blob hash.
No rebuild step: `vitest.config.mts` aliases `@object-ui/core` to `packages/core/src`, so
the run reads the mutated source directly and there is no `dist` that could serve a stale
copy.

| leg | mutation | predicted | observed |
| --- | --- | --- | --- |
| **A1** | drop `if (foldObjectName) next.objectName = dataObjectName` | 3 red in plugin-list (the three cases that assert a bound object) + the core `objectName` cases | **7 red** — 4 in plugin-list, 3 in core. One MORE than predicted, and in an informative direction: with no `objectName` the child view does not mount **at all** (both "still a grid" cases time out), rather than mounting with an undefined binding as I expected |
| **A2** | `next.viewType = 'grid'` instead of `authoredViewKind ?? 'grid'` | 5 red in plugin-list (1, 2, 4, 5, 7) + the core `specType` reads | **9 red** — exactly those 5 in plugin-list, and 4 of the 10 core kind cases. The other 6 core cases assert the `grid` default / the `hasOwnProperty` guard / that `specType` survives, and A2 restores that default, so they are green **by construction** — recorded here rather than presented as coverage |
| **A0** | both legs at once (= `origin/main` behaviour) | every case in the plugin-list file red | **7 of 7 red**; the criterion case fails at `expected 0 to be greater than 0` — the kanban never mounts |

Two of the plugin-list cases named as controls (the half-written `object` provider, and
the `value` provider) go red under **A2** as well as passing under A1, because they build
their view with `specType`. They are still controls for the `objectName` leg (their point
is that no binding is invented); they are **not** independent of the kind leg, and this
row says so rather than letting the ablation table imply otherwise.

## Verification

Run from the repo root of a dedicated worktree (a guard refuses package-cwd vitest runs).
Exit codes captured before any pipe.

| command | result |
| --- | --- |
| `pnpm exec vitest run packages/core/ packages/plugin-list/ packages/plugin-view/` | **214 files / 3405 tests passed**, exit 0 |
| `pnpm exec vitest run packages/app-shell/` | **614 files / 5908 passed, 1 skipped**, exit 0 |
| `pnpm exec turbo run type-check --concurrency=2` (repo-wide) | **81/81 tasks successful**, exit 0 |
| `pnpm exec eslint` over the three changed source files | exit 0 — 0 errors, 6 `no-explicit-any` **warnings** in the new test, the same class and count-per-file as the sibling `ListView.calendar-binding-7029.test.tsx` (5) |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 1 changeset declared |
| `check-changeset-fixed` / `-no-major` / `-overwrite` | exit 0 each |
| `node scripts/check-control-bytes.mjs` | exit 0 — 6230 tracked text files scanned |
| `node scripts/check-phantom-dependencies.mjs` | exit 0 — the new `@object-ui/types` import is a declared dependency of `@object-ui/core` |
| `node scripts/check-package-self-import.mjs` | exit 0 |
| `node scripts/check-element-data-source-declaration.mjs` | exit 0 — 13 gate-consuming files, all still take the seam from core |
| `node scripts/check-side-effects-array.mjs` | exit 0 |
| `node scripts/check-sdui-registration-pins.mjs` | **NOT MEASURED** — refuses without a console bundle (`PREREQUISITE`: build `@object-ui/console` first). Not a red gate; CI runs it with the bundle present |

`packages/app-shell/` — the third caller of this normalizer — was run separately and in
full: **614 files / 5908 passed, 1 skipped**, exit 0. Both it and
`plugin-view/src/ObjectView.tsx` call `normalizeListViewSchema` only to read
`.userActions` off the result, and neither new fold writes `userActions`, so the risk was
low to begin with; the run says so rather than the argument alone.

**Commit the runs belong to.** Every result in this section was produced on a working
tree byte-identical to this branch's tip, `d865352c` — `git status` clean and
`git diff HEAD` empty at the time of the runs and after them. The two pinning files were
re-run against that exact commit as the last action before opening this PR: **2 files /
87 tests passed**, exit 0.

## Housekeeping

### Clause-②: **yes**

Judged from this diff, not inherited from the dispatch (which expected `yes` but
explicitly declined to pre-judge it):

**Yes, this changes accept behaviour.** Two authored spellings that previously had no
effect on what renders now decide it — an `object` data source now binds the view, and an
author `type` now selects the kind. Metadata that produced an unbound empty state
yesterday produces a working kanban today. That is precisely the "a previously-inert
authored spelling becomes meaningful" shape, and the measured before/after table above is
the evidence, so the label goes on.

Three qualifications, all of which narrow the blast radius without changing the verdict:

- The change is a **widening only**. Both folds are gap-fills, and both gap-fills are
  pinned by a test that fails if they ever start overriding: "lets an explicit `viewType`
  win over the author-parked `specType`" and "lets an explicit `objectName` win over the
  data block". Nothing that renders today renders differently after this PR — that is a
  claim about the folds' own precedence, which is measured; it is **not** a claim about
  every authored corpus in the world, which is not.
- **No authored spelling is removed.** `objectName` and `viewType` stay accepted. Their
  retirement is objectstack's move, after this ships and the objectui pin moves.
- `data` is not deleted from the schema, so no child view loses a binding it reads today.

I could not read this repo's canonical text for the clause — `references/contract-review.md`
lives in the objectstack pm-dispatch skill, not here — so the judgement above is reasoned
from the diff against the definition carried in the dispatch. `needs:contract-review` has
been added to this PR; the card carrier is the PM's to hang.

### Deliberately NOT done

- **The six sibling folds are not collapsed.** The card's own ask offered "in
  `normalizeListViewSchema` **or** one shared helper the six sibling folds can collapse
  into", and the dispatch fenced the collapse out: `packages/plugin-dashboard/**` (held by
  dispatch objectui#7509) and `packages/components/src/ui/**` (held by objectui#7397) were
  in flight. Filed as **objectui#7627** so the option does not evaporate with the round —
  it carries the seven measured read-sites and the one real defect found while counting
  them (`ObjectGantt.tsx:661` and `:1374` disagree with each other about which side wins
  when a view carries both bindings).
- **The showcase and skill sites are not renamed** — objectstack#14343, which lands after
  this and the pin bump.
- **`ListView.tsx` is untouched.** No `??` dual-read was added anywhere; the diff to
  `packages/plugin-list/` is one new test file.
- **The `viewType`-wins precedence is a choice, and the alternative was weighed.** Under
  this normalizer's "the canonical key wins" rule one could argue the spec-side spelling
  (`specType` / `type`) should beat objectui's `viewType`. I did not do that: it would
  change what already-working input renders, which is a strictly larger contract change
  than the card asked for, and that rule governs pairs where the legacy key is deleted —
  `viewType` is neither deleted nor legacy here; it is the key this fold **writes**. If
  contract review prefers the inverted precedence, it is a two-line change plus its pins.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3

Session (prose, so it survives a later edit): `https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3`


---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_