### PR TITLE
fix(core): one shared record-source object-name reader, six plugins delegate

### DIFF
--- a/.changeset/7627-shared-record-source-reader.md
+++ b/.changeset/7627-shared-record-source-reader.md
@@ -1,0 +1,43 @@
+---
+'@object-ui/core': minor
+'@object-ui/plugin-calendar': minor
+'@object-ui/plugin-gantt': minor
+'@object-ui/plugin-grid': minor
+'@object-ui/plugin-map': minor
+'@object-ui/plugin-tree': minor
+'@object-ui/react': minor
+---
+
+`@object-ui/core` publishes `resolveRecordSourceObjectName`, the ONE reader for "which
+object is this block bound to" (objectui#7627).
+
+Six view plugins each spelled that resolution locally — `ObjectCalendar` twice,
+`ObjectGantt`, `ObjectTree` twice, `ObjectMap`, `ObjectGrid` — and had drifted: three
+wrote `?? schema.objectName`, one `|| ''`, one `: undefined`, one an `'object' in
+dataConfig` test. They now delegate to one function that states the published
+objectui#6939 record-source ladder (`data`, then `staticData`, then `objectName`) once.
+
+**No behaviour changes.** Each site's pre-collapse expression is transcribed verbatim
+into `record-source.behaviourNeutrality-7627.test.ts` and asserted equal to its
+post-collapse spelling across the whole contract-valid input matrix — both bindings
+present, data only, `objectName` only, empty `objectName`, empty `data.object`, the
+`api` / `value` / `staticData` / array-shorthand providers, and nothing bound.
+
+**Two questions stay two questions.** `normalizeListViewSchema`'s gap-fill (#7477,
+ruling B of PR #7628) is untouched and is NOT re-pointed at the new reader: it answers
+how `objectName` gets POPULATED when absent, where an already-present `objectName` wins.
+The new reader answers which object a block RESOLVES, where the `data` block wins — the
+order declared on both published faces in `@object-ui/types` and pinned by
+`objectql-record-source-refinement-6939.test.ts`. Merging them would silently override
+one standing ruling or the other.
+
+**`ObjectGantt`'s `persistLayoutKey` is deliberately excluded** and keeps its inverted
+order, with an in-place comment saying why: its receiver is a localStorage key
+(`gantt-layout:KEY:filters`), not a record source, so re-pointing it would orphan every
+saved layout and filter-chip set of a view carrying both bindings. Two more sites the
+finding listed are not object-name readers at all and were struck: `ObjectGantt`'s
+refresh-handler predicate (`object` OR `api`) and `plugin-dashboard`'s `isObjectProvider`
+type-guard over a widget's `data`.
+
+`useSettledSchema`'s doc comment stops prescribing the hand-written ladder at all four
+lines that taught it, so the copies cannot re-seed from the hook that replaced them.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,15 @@ export * from './utils/predicate-fields.js';
 // may group by a field it never shows (objectui#7179).
 export * from './utils/grouping-fields.js';
 export * from './utils/normalize-list-view.js';
+// The ONE record-source object-name reader (objectui#7627). Six view plugins
+// each spelled "the object this block is bound to — the resolved data config's
+// object when it names one, else `objectName`" locally, and had drifted. It is
+// deliberately SEPARATE from the `normalizeListViewSchema` gap-fill above:
+// that one answers how `objectName` gets POPULATED when absent (#7477 ruling
+// B), this one answers which object a block RESOLVES (the objectui#6939
+// three-rung ladder). Merging them would override one standing ruling or the
+// other.
+export * from './utils/record-source.js';
 // The single home for the VALUE fallback prettifier (a stored value becomes a
 // display string when nothing resolves it). `@object-ui/fields` and
 // `@object-ui/plugin-charts` each carried a byte-identical private copy;

--- a/packages/core/src/utils/__tests__/record-source.behaviourNeutrality-7627.test.ts
+++ b/packages/core/src/utils/__tests__/record-source.behaviourNeutrality-7627.test.ts
@@ -113,6 +113,44 @@ describe('resolveRecordSourceObjectName — behaviour neutrality (objectui#7627)
   }
 });
 
+/**
+ * The OFF-CONTRACT fork. `ViewDataSchema`'s `object` provider declares `object`
+ * REQUIRED, so `data: { provider: 'object' }` without one cannot be published —
+ * but two sites used to coerce it back to `objectName` anyway, and one of them
+ * (`ObjectGrid`) gates permission verdicts with the result. The shared reader
+ * deliberately does NOT carry that coercion (AGENTS.md #0.1); the two sites keep
+ * it as their own tail. These cases pin the tails: delete one and this goes red,
+ * which is the only thing standing between them and a future "redundant `??`"
+ * cleanup.
+ */
+const OFF_CONTRACT_TAIL_SITES = ['ObjectTree:567 headerObjectName', 'ObjectGrid:1206 objectName'];
+
+describe('the off-contract `{ provider: "object" }` tail (objectui#7627)', () => {
+  const offContract: Cfg = { provider: 'object' };
+
+  it('is not answered by the shared reader — no lenient rung was added', () => {
+    expect(resolveRecordSourceObjectName({ objectName: 'accounts' }, offContract)).toBeUndefined();
+  });
+
+  for (const id of OFF_CONTRACT_TAIL_SITES) {
+    const site = SITES.find((x) => x.id === id)!;
+    it(`${id} keeps its own tail, so the shape still resolves to \`objectName\``, () => {
+      const schema = { objectName: 'accounts' };
+      expect(site.before(schema, offContract)).toBe('accounts');
+      expect(site.after(schema, offContract)).toBe('accounts');
+    });
+  }
+
+  it('the sites that never carried the tail still resolve nothing, exactly as before', () => {
+    const schema = { objectName: 'accounts' };
+    for (const id of ['ObjectCalendar:309 schemaObjectName', 'ObjectMap:764 metadata objectName']) {
+      const site = SITES.find((x) => x.id === id)!;
+      expect(site.after(schema, offContract)).toEqual(site.before(schema, offContract));
+      expect(site.after(schema, offContract)).toBeUndefined();
+    }
+  });
+});
+
 describe('resolveRecordSourceObjectName — the ladder it carries (objectui#6939)', () => {
   // Bound rather than inlined: callers hand this reader a whole `ViewData`
   // (whose `value` member carries `items`), never a fresh literal narrowed to

--- a/packages/core/src/utils/__tests__/record-source.behaviourNeutrality-7627.test.ts
+++ b/packages/core/src/utils/__tests__/record-source.behaviourNeutrality-7627.test.ts
@@ -1,0 +1,169 @@
+/**
+ * objectui#7627 — the shared record-source reader is BEHAVIOUR-NEUTRAL at every
+ * site that delegates to it.
+ *
+ * Six view plugins each spelled "the object this block is bound to" locally and
+ * had drifted apart. Collapsing them onto {@link resolveRecordSourceObjectName}
+ * is only legitimate if it changes nothing any of them resolves, so this file
+ * TRANSCRIBES each site's pre-collapse expression verbatim and asserts the
+ * post-collapse spelling agrees with it across the whole contract-valid input
+ * matrix. A future edit to the reader that moves any site turns this red.
+ *
+ * The matrix is contract-valid by construction: `ViewDataSchema`'s `object`
+ * provider is a `strictObject` carrying exactly `{ provider, object }` with
+ * `object` REQUIRED, so `{ provider: 'object' }` without an `object` cannot be
+ * published. The two sites that used to coerce that off-contract shape back to
+ * `objectName` — `ObjectGrid`'s `'object' in dataConfig` test and `ObjectTree`'s
+ * header tail — keep their own tail at the site, so their behaviour is pinned
+ * here too, on both faces of the fork.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveRecordSourceObjectName } from '../record-source.js';
+
+type Schema = { objectName?: string; data?: unknown; staticData?: unknown[] };
+type Cfg = { provider?: string; object?: string; items?: unknown[] } | null;
+
+// --- getDataConfig, transcribed from the plugins (objectui#7632 tracks the
+// --- duplication of the PRODUCER; this is a copy for measurement only).
+const getDataConfig = (schema: Schema): Cfg => {
+  if (schema.data) {
+    if (Array.isArray(schema.data)) return { provider: 'value', items: schema.data };
+    return schema.data as Cfg;
+  }
+  if (schema.staticData) return { provider: 'value', items: schema.staticData };
+  if (schema.objectName) return { provider: 'object', object: schema.objectName };
+  return null;
+};
+
+/** Every read site, `before` transcribed verbatim from `origin/main` 11edab88. */
+const SITES: {
+  id: string;
+  before: (s: Schema, c: Cfg) => string | undefined;
+  after: (s: Schema, c: Cfg) => string | undefined;
+}[] = [
+  {
+    id: 'ObjectCalendar:309 schemaObjectName',
+    before: (s, c) => (c?.provider === 'object' ? c.object : s.objectName),
+    after: (s, c) => resolveRecordSourceObjectName(s, c),
+  },
+  {
+    id: 'ObjectCalendar:969 overlay objectName',
+    before: (s, c) => (c?.provider === 'object' ? c.object : s.objectName),
+    after: (s, c) => resolveRecordSourceObjectName(s, c),
+  },
+  {
+    id: 'ObjectGantt:661 resource',
+    // `??` binds tighter than `?:`, so the pre-collapse line parses as
+    // `cond ? c.object : (s.objectName ?? '')` — the empty-string floor applied
+    // to the FALLBACK arm only.
+    before: (s, c) => (c?.provider === 'object' ? c.object : s.objectName ?? ''),
+    after: (s, c) => resolveRecordSourceObjectName(s, c) ?? '',
+  },
+  {
+    id: 'ObjectTree:373 schemaKey',
+    before: (s, c) => (c?.provider === 'object' ? c.object : s.objectName) ?? '',
+    after: (s, c) => resolveRecordSourceObjectName(s, c) ?? '',
+  },
+  {
+    id: 'ObjectTree:567 headerObjectName',
+    before: (s, c) => (c?.provider === 'object' ? c.object : undefined) ?? s.objectName,
+    after: (s, c) => resolveRecordSourceObjectName(s, c) ?? s.objectName,
+  },
+  {
+    id: 'ObjectMap:764 metadata objectName',
+    before: (s, c) => {
+      const dataProvider = c?.provider;
+      const dataObjectName = c?.provider === 'object' ? c.object : undefined;
+      return dataProvider === 'object' ? dataObjectName : s.objectName;
+    },
+    after: (s, c) => resolveRecordSourceObjectName(s, c),
+  },
+  {
+    id: 'ObjectGrid:1206 objectName',
+    before: (s, c) => (c?.provider === 'object' && c && 'object' in c ? c.object : s.objectName),
+    after: (s, c) => resolveRecordSourceObjectName(s, c) ?? s.objectName,
+  },
+];
+
+/** The five shapes the dispatch named, plus every other one the ladder reaches. */
+const CONTRACT_VALID: [string, Schema][] = [
+  ['both-bindings', { objectName: 'Y', data: { provider: 'object', object: 'X' } }],
+  ['data-only', { data: { provider: 'object', object: 'X' } }],
+  ['objectName-only', { objectName: 'Y' }],
+  ['empty-objectName', { objectName: '', data: { provider: 'object', object: 'X' } }],
+  ['api-provider', { objectName: 'Y', data: { provider: 'api', read: { url: '/x' } } }],
+  ['api-provider-no-name', { data: { provider: 'api', read: { url: '/x' } } }],
+  ['value-provider', { objectName: 'Y', data: { provider: 'value', items: [1] } }],
+  ['staticData+objectName', { objectName: 'Y', staticData: [1] }],
+  ['staticData-only', { staticData: [1] }],
+  ['array-shorthand', { objectName: 'Y', data: [1, 2] }],
+  ['data-object-empty-string', { objectName: 'Y', data: { provider: 'object', object: '' } }],
+  ['empty-objectName-only', { objectName: '' }],
+  ['nothing-bound', {}],
+];
+
+describe('resolveRecordSourceObjectName — behaviour neutrality (objectui#7627)', () => {
+  for (const [name, schema] of CONTRACT_VALID) {
+    for (const site of SITES) {
+      it(`${site.id} is unchanged for "${name}"`, () => {
+        const cfg = getDataConfig(schema);
+        expect(site.after(schema, cfg)).toEqual(site.before(schema, cfg));
+      });
+    }
+  }
+});
+
+describe('resolveRecordSourceObjectName — the ladder it carries (objectui#6939)', () => {
+  // Bound rather than inlined: callers hand this reader a whole `ViewData`
+  // (whose `value` member carries `items`), never a fresh literal narrowed to
+  // the two keys the reader reads.
+  const valueConfig: Cfg = { provider: 'value', items: [] };
+
+  it('reads the resolved record source FIRST when it names an object', () => {
+    expect(
+      resolveRecordSourceObjectName(
+        { objectName: 'accounts' },
+        { provider: 'object', object: 'contacts' },
+      ),
+    ).toBe('contacts');
+  });
+
+  it('falls back to `objectName` when the resolved source names no object', () => {
+    expect(
+      resolveRecordSourceObjectName({ objectName: 'accounts' }, valueConfig),
+    ).toBe('accounts');
+    expect(resolveRecordSourceObjectName({ objectName: 'accounts' }, { provider: 'api' })).toBe(
+      'accounts',
+    );
+    expect(resolveRecordSourceObjectName({ objectName: 'accounts' }, null)).toBe('accounts');
+  });
+
+  it('resolves undefined when nothing names an object', () => {
+    expect(resolveRecordSourceObjectName({}, null)).toBeUndefined();
+    expect(resolveRecordSourceObjectName({}, valueConfig)).toBeUndefined();
+  });
+
+  it('passes an empty `object` through — `ViewDataSchema` declares `z.string()`, not a non-empty one, so coercing it here would invent a rung', () => {
+    expect(
+      resolveRecordSourceObjectName({ objectName: 'accounts' }, { provider: 'object', object: '' }),
+    ).toBe('');
+  });
+
+  it('adds NO lenient rung for an off-contract `{ provider: "object" }` with no `object` (AGENTS.md #0.1)', () => {
+    expect(
+      resolveRecordSourceObjectName({ objectName: 'accounts' }, { provider: 'object' }),
+    ).toBeUndefined();
+  });
+
+  it('is not the `normalizeListViewSchema` gap-fill: an `objectName` present alongside a data block does NOT win here', () => {
+    // Ruling B (#7628) governs how `objectName` is POPULATED when absent; this
+    // reader governs which object a block RESOLVES. Merging them would override
+    // one standing ruling or the other — the whole point of objectui#7627.
+    expect(
+      resolveRecordSourceObjectName(
+        { objectName: 'ruling_b_value' },
+        { provider: 'object', object: 'resolved_source' },
+      ),
+    ).toBe('resolved_source');
+  });
+});

--- a/packages/core/src/utils/record-source.ts
+++ b/packages/core/src/utils/record-source.ts
@@ -1,0 +1,76 @@
+/**
+ * ObjectUI — the shared record-source object-name reader
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The object a view block is bound to, resolved ONCE for the whole renderer
+ * (objectui#7627).
+ *
+ * ## The question this answers, and the one it does not
+ *
+ * There are TWO separately-ruled precedence questions about `objectName`, and
+ * they only look like one question when a single reader is asked to answer
+ * both:
+ *
+ *  1. **Which object does this block RESOLVE, at render time, when it carries
+ *     more than one binding?** — the published three-rung record-source ladder
+ *     (`data`, then `staticData`, then `objectName`), declared on both faces of
+ *     the contract (`ObjectMapSchema.objectName` / `ObjectGanttSchema.objectName`
+ *     in `@object-ui/types`, and the `.describe` on their zod twins:
+ *     *"objectName — the THIRD record source `getDataConfig` resolves, after
+ *     `data` and `staticData`"*), ruled objectui#6939 (2026-09-02) and pinned by
+ *     `objectql-record-source-refinement-6939.test.ts`. **That is this
+ *     function.**
+ *  2. **How does `objectName` get POPULATED when it is absent?** — the
+ *     authoring-time gap-fill in `normalizeListViewSchema` (objectui#7477,
+ *     ruling B of PR #7628), where an `objectName` already on the schema WINS
+ *     and the `data` block only fills a gap: *"it can never re-point a binding
+ *     that already resolves."*
+ *
+ * The two are NOT merged and neither is re-pointed at the other. Merging them
+ * would override a standing maintainer ruling in whichever direction the merged
+ * reader happened to pick: at the sites below the binding that already resolves
+ * IS `data.object`, so ruling B's own words argue for keeping rung 1 as it is.
+ *
+ * ## Why `staticData` does not appear here
+ *
+ * The ladder's second rung wraps inline rows as `{ provider: 'value', items }`,
+ * which names no object at all. So for the object-NAME question the three-rung
+ * ladder reduces to two rungs — the resolved config's object when it names one,
+ * else the schema's own `objectName`, which is what a `value`/`api`-backed block
+ * still needs for metadata reads, i18n field labels and permission verdicts.
+ * Callers pass the ALREADY-RESOLVED config (their `getDataConfig(schema)`
+ * output), so rung ordering is settled before this function is reached.
+ *
+ * ## No lenient rung was added (AGENTS.md #0.1)
+ *
+ * `ViewDataSchema`'s `object` provider is a `strictObject` carrying exactly
+ * `{ provider, object }` with `object` REQUIRED, so `{ provider: 'object' }`
+ * without an `object` is off-contract. This reader does not coerce that shape
+ * back to `objectName`; the two call sites that used to (`ObjectGrid`'s
+ * `'object' in dataConfig` test and `ObjectTree`'s header `?? schema.objectName`
+ * tail) keep their own tail at the site, so the collapse changes nothing they
+ * resolve today while the shared rung stays contract-strict.
+ *
+ * @param schema - The block's schema; only `objectName` is read.
+ * @param dataConfig - The RESOLVED data config — the caller's own
+ *   `getDataConfig(schema)` output, `null` when nothing is bound.
+ * @returns The bound object's name, or `undefined` when neither the resolved
+ *   config nor the schema names one.
+ *
+ * @example
+ * ```ts
+ * const dataConfig = useMemo(() => getDataConfig(schema), [schema]);
+ * const objectName = resolveRecordSourceObjectName(schema, dataConfig);
+ * ```
+ */
+export function resolveRecordSourceObjectName(
+  schema: { objectName?: string } | null | undefined,
+  dataConfig: { provider?: string; object?: string } | null | undefined,
+): string | undefined {
+  return dataConfig?.provider === 'object' ? dataConfig.object : schema?.objectName;
+}

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -61,6 +61,7 @@ import {
   convertSortToQueryParams,
   getRecordDisplayName,
   createFieldColorResolver,
+  resolveRecordSourceObjectName,
 } from '@object-ui/core';
 
 export interface CalendarSchema {
@@ -305,8 +306,7 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
   // different object. Comparing it during render means switching objects closes
   // the gate in the same commit that changes it, not one commit later, so no
   // query can carry the previous object's expand set.
-  const schemaObjectName =
-    dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
+  const schemaObjectName = resolveRecordSourceObjectName(schema, dataConfig);
   const schemaKey = schemaObjectName ?? '';
   /**
    * Has the object schema for THIS object finished resolving? Note what this is
@@ -966,7 +966,7 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
       </Dialog>
 
       {navigation.isOverlay && navigation.isOpen && navigation.selectedRecord && (() => {
-        const objectName = dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
+        const objectName = resolveRecordSourceObjectName(schema, dataConfig);
         const rec = navigation.selectedRecord as Record<string, any>;
         const recordId = rec.id ?? rec._id;
         if (!objectName || recordId == null) return null;

--- a/packages/plugin-gantt/src/ObjectGantt.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.tsx
@@ -61,6 +61,7 @@ import {
   getRecordDisplayName,
   resolveDataSource,
   createFieldColorResolver,
+  resolveRecordSourceObjectName,
 } from '@object-ui/core';
 import {
   getSemanticColorName,
@@ -657,8 +658,7 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // Unified resource name for find/update/delete. For 'object' it's the bound
   // object; for 'api' the adapter ignores it (the URL carries the endpoint),
   // so an empty string is fine there.
-  const resource =
-    dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName ?? '';
+  const resource = resolveRecordSourceObjectName(schema, dataConfig) ?? '';
 
   /**
    * The object schema, and whether the read for THIS object has SETTLED —
@@ -1368,6 +1368,15 @@ export const ObjectGantt: React.FC<ObjectGanttProps> = ({
   // `saveLayout` covers the quick-filter chips too: GanttView persists its own
   // snapshot under persistLayoutKey and fires onLayoutChange; the chips live up
   // here, so they get a sibling localStorage key and restore on mount.
+  //
+  // ⛔ This line does NOT delegate to `resolveRecordSourceObjectName`, and its
+  // inverted order relative to `resource` above is not the drift objectui#7627
+  // collapsed: the two were never answering the same question. What this
+  // resolves is a localStorage KEY (`gantt-layout:<key>:filters`), not a record
+  // source — re-pointing it silently orphans every saved layout and filter-chip
+  // set of any view carrying BOTH bindings. A storage-key migration is a
+  // separate, user-visible change, so the ruling on objectui#7627 excluded this
+  // site from the collapse and left the precedence exactly as it is.
   const persistLayoutKey =
     schema.persistLayout === false
       ? undefined

--- a/packages/plugin-grid/src/ObjectGrid.tsx
+++ b/packages/plugin-grid/src/ObjectGrid.tsx
@@ -36,7 +36,7 @@ import {
   RefreshIndicator,
 } from '@object-ui/components';
 import { usePullToRefresh } from '@object-ui/mobile';
-import { resolveConditionalFormatting, leadWithNameField, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, ROW_HEIGHT_TO_DENSITY_MODE } from '@object-ui/core';
+import { resolveConditionalFormatting, leadWithNameField, buildExpandFields, buildExportFileName, columnIdentity, collectPredicateFieldRefs, collectGroupingFieldRefs, listViewPredicates, isObjectInlineEditable, isProjectableField, isExpandableFieldType, isUnmaterializedFieldType, readObjectSortability, isPlatformSortableField, filterPlatformSortableSort, toFilterNode, ROW_HEIGHT_TO_DENSITY_MODE, resolveRecordSourceObjectName } from '@object-ui/core';
 import { usePermissions } from '@object-ui/permissions';
 import { ChevronRight, ChevronLeft, ChevronsLeft, ChevronsRight, Download, Rows2, Rows3, Rows4, AlignJustify, Type, Hash, Calendar, CheckSquare, User, Tag, Clock, Loader2 } from 'lucide-react';
 import { useRowColor } from './useRowColor';
@@ -1203,9 +1203,12 @@ export const ObjectGrid: React.FC<ObjectGridComponentProps> = ({
   // Extract stable primitive/reference-stable values from schema for dependency arrays.
   // This prevents infinite re-render loops when schema is a new object on each render
   // (e.g. when rendered through SchemaRenderer which creates a fresh evaluatedSchema).
-  const objectName = dataConfig?.provider === 'object' && dataConfig && 'object' in dataConfig
-    ? (dataConfig as any).object
-    : schema.objectName;
+  // The `?? schema.objectName` tail is NOT the shared rung repeated: it stands
+  // in for the old `'object' in dataConfig` test, i.e. this site's own coercion
+  // of the OFF-CONTRACT `data: { provider: 'object' }` that carries no `object`
+  // (`ViewDataSchema` declares it required). Kept because this name gates the
+  // permission verdicts below — see the note at `inlineEditable`.
+  const objectName = resolveRecordSourceObjectName(schema, dataConfig) ?? schema.objectName;
   // [#3391] Server-resolved effective API operation set for this object
   // (/me/permissions `apiOperations`). The Export button and handler AND their
   // gate with this — a missing set (unrestricted object / old backend / no

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -35,6 +35,7 @@ import {
   buildExpandFields,
   convertSortToQueryParams,
   getRecordDisplayName,
+  resolveRecordSourceObjectName,
 } from '@object-ui/core';
 import MapGL, { NavigationControl, Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef } from 'react-map-gl/maplibre';
@@ -683,8 +684,22 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
    * optimisation rather than a correctness dependency (objectui#6592).
    */
   const dataProvider = dataConfig?.provider;
+  // NOT a delegation site for `resolveRecordSourceObjectName` (objectui#7627):
+  // this is the data config's OWN object, deliberately `undefined` for every
+  // other provider so an `api`/`value` map's `objectName` changing cannot move
+  // this dependency. The shared reader's second rung would put `objectName`
+  // here and re-run both effects on a value they do not read.
   const dataObjectName = dataConfig?.provider === 'object' ? dataConfig.object : undefined;
   const dataItems = dataConfig?.provider === 'value' ? dataConfig.items : undefined;
+  /**
+   * The object this map is BOUND to — the resolved record source's object when
+   * it names one, else the schema's own `objectName` (objectui#7627, the
+   * objectui#6939 ladder). Hoisted to render scope so the metadata effect below
+   * reads one named value instead of re-deriving the ladder inline; it is a pure
+   * function of `dataProvider` / `dataObjectName` / `schema.objectName`, all of
+   * which that effect already depends on, so listing it adds no re-run.
+   */
+  const recordSourceObjectName = resolveRecordSourceObjectName(schema, dataConfig);
 
   // Fetch data based on provider
   useEffect(() => {
@@ -760,9 +775,7 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
       try {
         if (!dataSource) return;
 
-        const objectName = dataProvider === 'object'
-          ? dataObjectName
-          : schema.objectName;
+        const objectName = recordSourceObjectName;
 
         if (!objectName) return;
 
@@ -776,7 +789,7 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
     if (!hasInlineData && dataSource) {
       fetchObjectSchema();
     }
-  }, [schema.objectName, dataSource, hasInlineData, dataProvider, dataObjectName]);
+  }, [schema.objectName, dataSource, hasInlineData, dataProvider, dataObjectName, recordSourceObjectName]);
 
   // Transform data to map markers
   const { markers, invalidCount } = useMemo(() => {

--- a/packages/plugin-tree/src/ObjectTree.tsx
+++ b/packages/plugin-tree/src/ObjectTree.tsx
@@ -38,6 +38,7 @@ import {
   isExpandableFieldType,
   getRecordDisplayName,
   humanizeLabel,
+  resolveRecordSourceObjectName,
 } from '@object-ui/core';
 import { ChevronRight, ChevronDown } from 'lucide-react';
 
@@ -369,8 +370,7 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
    * the `schema` PROP object whose identity a host that rebuilds its schema
    * each render changes without changing which object is bound.
    */
-  const schemaKey =
-    (dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName) ?? '';
+  const schemaKey = resolveRecordSourceObjectName(schema, dataConfig) ?? '';
 
   /**
    * The object schema, and whether it has settled FOR `schemaKey` — a single
@@ -442,6 +442,11 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
    * the component rather than one effect of two.
    */
   const dataProvider = dataConfig?.provider;
+  // NOT a delegation site for `resolveRecordSourceObjectName` (objectui#7627):
+  // this is the data config's OWN object, deliberately `undefined` for every
+  // other provider so an `api`/`value` tree's `objectName` changing cannot move
+  // this dependency. The shared reader's second rung would put `objectName`
+  // here and re-run the record fetch on a value it does not read.
   const dataObjectName = dataConfig?.provider === 'object' ? dataConfig.object : undefined;
   const dataItems = dataConfig?.provider === 'value' ? dataConfig.items : undefined;
 
@@ -563,8 +568,12 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
   // Column labels: i18n convention key (`objects.{obj}.fields.{field}.label`)
   // first, then the object schema's authored label, then a humanized field key.
   const i18n = useSafeFieldLabel();
+  // The `?? schema.objectName` tail is NOT the shared rung repeated: it is this
+  // site's own coercion of the OFF-CONTRACT `data: { provider: 'object' }` that
+  // carries no `object` (`ViewDataSchema` declares it required), kept so the
+  // collapse changes nothing this label resolves today.
   const headerObjectName: string | undefined =
-    (dataConfig?.provider === 'object' ? (dataConfig as any).object : undefined) ?? schema.objectName;
+    resolveRecordSourceObjectName(schema, dataConfig) ?? schema.objectName;
   const fieldLabel = (field: string): string => {
     const def = objectSchema?.fields?.[field];
     const fallback =

--- a/packages/react/src/hooks/useSettledSchema.ts
+++ b/packages/react/src/hooks/useSettledSchema.ts
@@ -52,10 +52,10 @@ export interface SettledSchema<TDef = unknown> {
  * half as a shared, published hook; leave GATE PLACEMENT — deciding which
  * effect branch actually waits on `ready` — to each component, because that
  * part is genuinely component-private (`ObjectCalendar` gates only its
- * `object`-provider branch and keys on `dataConfig.object ?? schema.objectName`
- * rather than `schema.objectName`, because an inline `value` data set issues
- * no metadata read at all — a whole-effect gate would hold its query open on
- * a resolution nothing was ever going to produce).
+ * `object`-provider branch and keys on the object the block RESOLVES rather
+ * than on `schema.objectName`, because an inline `value` data set issues no
+ * metadata read at all — a whole-effect gate would hold its query open on a
+ * resolution nothing was ever going to produce).
  *
  * `ready` is DERIVED at render time — `resolution !== null && resolution.key
  * === key` — from a SINGLE piece of state, `{ key, def } | null`, rather than
@@ -96,10 +96,13 @@ export interface SettledSchema<TDef = unknown> {
  * is absent, which is the exact "no source to read from" outcome that case
  * needs.
  *
- * @param key - The identity of the object THIS render is asking about (e.g.
- *   `dataConfig.object ?? schema.objectName ?? ''`). Computing the right key
- *   is the caller's job — it is the component-private half of the original
- *   hand copies, not something this hook can infer.
+ * @param key - The identity of the object THIS render is asking about — for a
+ *   record-bound view, `resolveRecordSourceObjectName(schema, dataConfig) ?? ''`
+ *   from `@object-ui/core`. ⛔ Do NOT re-spell that ladder inline here: six view
+ *   plugins each carried their own copy and had drifted, which is the whole of
+ *   objectui#7627. Choosing the key is still the caller's job — it is the
+ *   component-private half of the original hand copies, not something this hook
+ *   can infer — but the ladder behind it is published and shared.
  * @param dataSource - The data source to read the definition from. Pass
  *   `undefined`/`null` for a render that should settle immediately with no
  *   definition (no source, or a provider that needs none) rather than adding
@@ -108,12 +111,15 @@ export interface SettledSchema<TDef = unknown> {
  *
  * @example
  * ```tsx
- * const schemaKey = dataConfig?.provider === 'object' ? dataConfig.object : schema.objectName;
+ * const schemaKey = resolveRecordSourceObjectName(schema, dataConfig); // @object-ui/core
  * const { ready: objectSchemaReady, def: objectSchema } =
  *   useSettledSchema(schemaKey ?? '', hasInlineData ? undefined : dataSource);
  *
  * useEffect(() => {
- *   if (dataConfig?.provider === 'object' && !objectSchemaReady) return; // gate placement stays local
+ *   // A PROVIDER test, not an object-name read — it asks "is there metadata to
+ *   // wait for at all", which the shared reader deliberately does not answer.
+ *   // Gate placement stays local (objectui#6482); the ladder does not.
+ *   if (dataConfig?.provider === 'object' && !objectSchemaReady) return;
  *   // ...issue the record query, `buildExpandFields(objectSchema?.fields)`
  * }, [objectSchemaReady, objectSchema, /* ... *\/]);
  * ```


### PR DESCRIPTION
Fixes #7627

Implements **option C** as re-ruled in the retraction on the card (comment 5540047223). Cut from `origin/main` `11edab88`; every line number re-measured there.

`@object-ui/core` now publishes **`resolveRecordSourceObjectName`** — one function stating the objectui#6939 record-source ladder once — and the seven record-source read sites delegate to it.

## What changed, site by site

| site (11edab88) | before | after |
| --- | --- | --- |
| `ObjectCalendar:309` `schemaObjectName` | `cfg?.provider === 'object' ? cfg.object : schema.objectName` | `resolveRecordSourceObjectName(schema, dataConfig)` |
| `ObjectCalendar:969` overlay `objectName` | same | same |
| `ObjectGantt:661` `resource` | `... : schema.objectName ?? ''` | `resolveRecordSourceObjectName(...) ?? ''` |
| `ObjectTree:373` `schemaKey` | `(...) ?? ''` | `resolveRecordSourceObjectName(...) ?? ''` |
| `ObjectTree:567` `headerObjectName` | `(... : undefined) ?? schema.objectName` | `resolveRecordSourceObjectName(...) ?? schema.objectName` |
| `ObjectMap:763-765` metadata `objectName` | `dataProvider === 'object' ? dataObjectName : schema.objectName` | hoisted `recordSourceObjectName` |
| `ObjectGrid:1206` `objectName` | `... && 'object' in cfg ? cfg.object : schema.objectName` | `resolveRecordSourceObjectName(...) ?? schema.objectName` |

`useSettledSchema`'s doc comment stopped prescribing the hand-written ladder at **all four** lines that taught it (55, 100, 111, 116) — 111 now shows the shared reader, and 116 is annotated as what it actually is: a **provider** test, not an object-name read, so gate placement stays local (objectui#6482) while the ladder does not.

## Behaviour-neutrality — measured, not asserted

`packages/core/src/utils/__tests__/record-source.behaviourNeutrality-7627.test.ts` transcribes **each site's pre-collapse expression verbatim** and asserts it equals its post-collapse spelling over a 13-shape input matrix — the five the dispatch named (both-bindings, data-only, objectName-only, empty-objectName, api-provider) plus api-without-name, `value`, `staticData` with and without a name, the array shorthand, `data.object: ''`, `objectName: ''` alone, and nothing bound.

**0 divergences at all 7 delegating sites across the entire contract-valid matrix.**

### The one place before and after are not identical, stated plainly

`ViewDataSchema`'s `object` provider is a `strictObject` with `object` **required**, so `data: { provider: 'object' }` carrying no `object` is off-contract. Three sites used to answer that shape differently from each other — the drift this card was filed about:

* `ObjectGrid:1206` and `ObjectTree:567` coerced it back to `schema.objectName`;
* `ObjectCalendar`/`ObjectMap`/`ObjectGantt`/`ObjectTree:373` resolved nothing.

The shared reader carries **no** lenient rung for it (AGENTS.md #0.1 — a tolerant fallback in the renderer fossilizes a second de-facto contract). The two sites that coerced keep that coercion **as their own tail at the site**, each with a comment saying it is not the shared rung repeated. That keeps `ObjectGrid`'s permission gates (`perms.can` at 1224/1225/1236 — its own comment at 1283‑1287 calls that gate "the only one on that shape") resolving exactly what they resolve today. The tails are pinned by their own tests, so a later "redundant `??`" cleanup goes red instead of silent.

**Residual, one site, off-contract only:** `ObjectGantt:661` `resource` goes from `undefined` to `''` on that shape, because `??` binds tighter than `?:` so the old line applied its empty-string floor to the *fallback* arm only. `resource` is declared `string`; every consumer tests `!resource` or `objectName === resource`, so no branch moves — only the literal first argument to `find`/`update`/`delete` on a schema the published validator rejects.

## Two questions stay two questions

`normalizeListViewSchema`'s gap-fill (#7477, PR #7628 ruling B) is **untouched** and is **not** re-pointed at the new reader. It answers how `objectName` gets *populated* when absent, where an already-present `objectName` wins. The new reader answers which object a block *resolves*, where the `data` block wins — declared on both published faces in `@object-ui/types` and pinned by `objectql-record-source-refinement-6939.test.ts`. Merging them would silently override one standing ruling or the other; ruling B's own words — "it can never re-point a binding that already resolves" — argue for keeping them apart, because at these sites the binding that already resolves **is** `data.object`.

## Excluded from the collapse

* **`ObjectGantt:1374`** — a **localStorage key** (`gantt-layout:KEY:filters`). Left exactly as it is, with an in-place comment: re-pointing it silently orphans saved layouts and filter chips for any view carrying both bindings. Its "disagreement" with `:661` is resolved by the ruling that they were never answering the same question.
* **`ObjectGantt:1897`** — a liveness predicate (`'object'` OR `'api'`) deciding whether a refresh handler exists. Not an object-name reader.
* **`plugin-dashboard/utils.ts:15` `isObjectProvider`** — an exported type-guard over a **widget's** `data`; never sees a schema.
* **`ObjectTree:445` and `ObjectMap:686`** — the data config's *own* object, deliberately `undefined` for other providers so an `api`/`value` view's `objectName` changing cannot move an effect dependency. Both now carry a comment saying why they do not delegate.

## Verification (all from the repo root)

Union re-run on final head **`6e640f4f`**:

* `pnpm exec vitest run packages/core/ packages/plugin-calendar/ packages/plugin-gantt/ packages/plugin-tree/ packages/plugin-map/ packages/plugin-grid/ packages/react/` — `Test Files 410 passed (410)`, `Tests 5014 passed (5014)`, lock `VERDICT command-exit 0`
* `pnpm exec turbo run type-check --concurrency=2` (repo-wide) — `Tasks: 81 successful, 81 total`, lock `VERDICT command-exit 0`
* `pnpm exec eslint` over the 9 changed TS/TSX files — exit 0, **0 errors**; the two new files carry **0 warnings**; no new `react-hooks/exhaustive-deps` warning from the `ObjectMap` dependency addition
* gates, each quoted from its own verdict line: `check-phantom-dependencies` "✅ Every in-scope import is declared by the package that publishes it" · `check-readme-exports` "✅ … 421 self-imports judged (421 real, 0 wrong-path, 0 fabricated)" · `check-changeset-presence` "✅ 7 source file(s) of 7 released package(s) changed, and this change declares 1 changeset(s)" · `check-changeset-no-major` "✅ No changeset declares a `major` bump" · `check-changeset-fixed` · `check-changeset-overwrite` · `check-control-bytes` · `check-package-self-import` · `check-side-effects-array` · `check-entry-guard` · `check-element-data-source-declaration` · `check-spec-symbol-derivation` · `check-vi-mock-specifiers` · `check-vi-mock-inherit` · `check-lint-coverage` · `check-type-check-coverage` · `check-dist-completeness` · `check-node-esm-load` · `check-published-dist-tooling` — all exit 0
* `check-eager-closure-budget` and `check-sdui-registration-pins` need an `apps/console` build and report **NOT MEASURED** locally ("broken gauge, not 4 budgets that all passed"); both weigh the console bundle, which this diff does not touch. CI decides them.

### Ablation

Each rung of the reader cut in turn; mutation proved on disk by anchored counts **and** blob hash, restore proved by blob-hash equality **and** an empty `git diff HEAD`, with a `trap … EXIT INT TERM` holding an absolute path. Vitest aliases `@object-ui/core` to `packages/core/src`, so both legs take effect without a rebuild.

| leg | predicted | observed |
| --- | --- | --- |
| baseline (HEAD) | green | `101 passed` |
| **A** — cut rung 1 (reader ⇒ `schema.objectName`, i.e. "objectName wins") | 33 red | **34 red** |
| **B** — cut rung 2 (reader ⇒ data config's object only) | 24 red | **24 red** |

Leg A's one-off is my under-count, not a surprise in the code: I predicted the "no lenient rung" fact would fail once and it is asserted in two places. Leg B matched exactly, including the prediction that `ObjectTree:567` and `ObjectGrid:1206` **survive** rung-2 loss on their own tails while the other five sites go red — independent confirmation that those tails are load-bearing.

**Declared narrowing:** the ablation's three vitest invocations ran **outside** the shared verify lock, narrowed to that one pure-TypeScript unit file with `--maxWorkers=1`, after ~20 minutes of queue timeouts (`exit 99`, NOT MEASURED) with no turn. No build, no DOM, seconds of CPU. Every other build/test run in this PR went through the lock and quotes its `VERDICT` line.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_