### PR TITLE
docs(plugin-charts, plugin-form, plugin-list, app-shell): census of the object-schema snake lookup reads — all seven legs keep, with the evidence recorded at each site

### DIFF
--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -1,0 +1,58 @@
+---
+---
+
+Census only (objectui#7642): record, at each of the six sites, which contract types
+the field-def bag it reads. No runtime behaviour changes — every snake leg is kept,
+so this declares no release.
+
+The card proposed retiring `display_field` / `description_field` / `lookup_filters` /
+`id_field` reads on the ground that `@objectstack/spec`'s `FieldSchema` is strict and
+refuses them. Measured against the installed spec, that is true — of the AUTHORING
+path. Three findings moved every site to KEEP:
+
+1. The SERVE path runs no parse. `ObjectStackAdapter.getObjectSchema` returns the
+   server document verbatim plus exactly two rewrites (`normalizeSchemaReferenceKeys`,
+   `applyFieldWidgetOverrides`); there is no `ObjectSchema.parse`/`safeParse` on that
+   path. A stored pre-strict document therefore still delivers these keys to every
+   consumer. The legs are not unreachable.
+2. Five of the six sites have NO camelCase leg. They read the refused spelling and
+   nothing else, so retiring it does not re-point the read to the declared spelling —
+   it deletes the only read of the value. The corollary is the real user-facing gap:
+   on fully spec-compliant metadata those five sites already ignore a configured
+   `displayField` / `idField` / `descriptionField` / `lookupFilters` today.
+3. The object-schema field def and the widget bag are the same object at runtime.
+   `ObjectForm` builds its fields from `getObjectSchema` and threads each def to the
+   widget, where `@object-ui/fields` `LookupField` reads `display_field` /
+   `description_field` / `id_field` / `lookup_filters` SNAKE-FIRST, and
+   `@object-ui/types`' `LookupFieldMetadata` (published, and documented as authorable
+   in `content/docs/fields/lookup.mdx`) declares all four. Retiring the legs at the
+   object-schema consumers while the form widget keeps reading snake-first off the
+   same def would make one stored document render one way in the form and another in
+   the chart, list, filters and action dialogs.
+
+Per site, which way the value would have flipped had the leg been retired:
+
+- `plugin-charts` `ObjectChart` (`id_field`, `display_field`) — bag proved to be the
+  object-schema def (`ds.getObjectSchema`). No camel leg: the value would have
+  collapsed to the constants `'id'` and `'name'` for every host, spec-compliant or not.
+- `plugin-form` `deriveMasterDetail` (`display_field`) — object-schema def in-repo,
+  but `deriveColumns` is a public export, so external callers' bags are untraceable.
+  No camel leg: `col.displayField` would have become `undefined`.
+- `plugin-list` `ListView`, columns branch — NOT the object-schema def. The bag is a
+  list-view column (`ListColumnSchema`), which refuses BOTH castings of all three keys.
+  A third contract, filed separately rather than half-retired.
+- `plugin-list` `ListView`, object-def branch — object-schema def proved. No camel leg:
+  `displayField` and `idField` would have gone `undefined`.
+- `plugin-list` `UserFilters` — `objectDef` is a public prop typed `any` on a publicly
+  exported component; the bag cannot be traced past this package. No camel leg.
+- `app-shell` `resolveActionParams` — the in-file provenance note is correct; this is
+  the object-schema def. No camel leg for any of its four reads.
+- `app-shell` `ObjectFieldInspector` (`lookup_filters`) — the only camel-first site,
+  and it writes camel back. Its snake leg reads a stored pre-strict document, so
+  retiring it would show an admin an empty filter list and let a save strand the real
+  filters.
+
+One live bug found and filed, not fixed here: the designer reads
+`lookupFilters ?? lookup_filters` (camel first) while the runtime `LookupField` reads
+`lookup_filters ?? lookupFilters` (snake first), so a document carrying both keys with
+different values is displayed one way and honoured the other.

--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -26,20 +26,37 @@ path. Three findings moved every site to KEEP:
    on fully spec-compliant metadata those five sites already ignore a configured
    `displayField` / `descriptionField` / `lookupFilters` today. `idField` is NOT in
    that list: measured on the pinned spec 17.2.0, `FieldSchema` refuses `idField` with
-   `unrecognized_keys` exactly as it refuses `id_field` — neither spelling of the id
-   key is declared, so the `id_field` reads have no camel leg to gain and their only
-   route is the ingestion choke point (objectui#7650, option A).
+   `unrecognized_keys` exactly as it refuses `id_field` — on `FieldSchema` neither
+   spelling of the id key is declared, so the `id_field` reads have no `FieldSchema`
+   spelling to gain a leg for and their only route is the ingestion choke point
+   (objectui#7650, option A). That is a `FieldSchema` statement only: the widget
+   contract `@object-ui/types` `LookupFieldMetadata` DOES declare `idField` (kept by
+   PR #7641 as a widget-contract key), and `LookupField` reads it off the same runtime
+   object finding 3 describes.
 3. The object-schema field def and the widget bag are the same object at runtime.
    `ObjectForm` builds its fields from `getObjectSchema` and threads each def to the
-   widget, where `@object-ui/fields` `LookupField` reads `display_field` /
-   `description_field` / `id_field` / `lookup_filters` SNAKE-FIRST, and
-   `@object-ui/types`' `LookupFieldMetadata` (published) declares all four —
-   `content/docs/fields/lookup.mdx` documents three of them as authorable
-   (`description_field`, `id_field`, `lookup_filters`; `display_field` has zero hits in
-   all of `content/docs`, which document `reference_field` instead). Retiring the legs at the
-   object-schema consumers while the form widget keeps reading snake-first off the
-   same def would make one stored document render one way in the form and another in
-   the chart, list, filters and action dialogs.
+   widget, `@object-ui/fields` `LookupField`. What that widget reads moved while this
+   census was under review, so this record is dated. At this branch's base (`1ec291c0`,
+   2026-09-04) `LookupField` read `display_field` / `description_field` / `id_field` /
+   `lookup_filters` SNAKE-FIRST, the published `@object-ui/types` `LookupFieldMetadata`
+   declared all four snake members, and `content/docs/fields/lookup.mdx` documented
+   three of them as authorable (`description_field`, `id_field`, `lookup_filters`;
+   `display_field` 0 hits in all of `content/docs`, which documented `reference_field`
+   instead). PR #7641 (merged 2026-09-04T15:01:32Z as `351eb318`) then converged the
+   widget contract on the spec's camelCase. Measured on `origin/main` (`a3eb5d07`):
+   `LookupField` reads `displayField` / `descriptionField` / `idField` / `lookupFilters`
+   ONLY (its `reference_field` fallback is kept), `LookupFieldMetadata` declares the
+   camel members only, and `content/docs` has 0 hits for all four snake keys (controls
+   in the same run: `reference_field` 4, `lookupFilters` 3). On the tree this census
+   lands in, the split therefore runs the OTHER way: it is KEEPING these six snake
+   legs, while the form widget reads camel-only, that lets one stored pre-strict
+   document render one way in the form and another in the chart, list, filters and
+   action dialogs. KEEP still stands — on findings 1-2 (the serve path delivers the
+   stored key, and five sites have no camel leg, so retiring the read deletes the only
+   read) and on the ruling that refused option B and made the ingestion choke point
+   (option A, objectui#7650) the prerequisite for any retirement. The way to close the
+   split is A (canonicalise once at ingestion) plus the additive camel legs tracked on
+   objectui#7435, not a consumer-side deletion.
 
 Per site, which way the value would have flipped had the leg been retired:
 
@@ -64,9 +81,14 @@ Per site, which way the value would have flipped had the leg been retired:
   retiring it would show an admin an empty filter list and let a save strand the real
   filters.
 
-One live bug found and deliberately NOT filed as a card (open PR #7641 flips the
-runtime half and retires it on its own; the PM recorded it on objectui#7642 so it
-becomes a card the moment #7641 stops being its fix), not addressed here: the designer reads
-`lookupFilters ?? lookup_filters` (camel first) while the runtime `LookupField` reads
-`lookup_filters ?? lookupFilters` (snake first), so a document carrying both keys with
-different values is displayed one way and honoured the other.
+One live bug found during the census and deliberately NOT filed as a card, not
+addressed here: at this branch's base the designer (`ObjectFieldInspector`,
+`readLookupFilters`) read `lookupFilters ?? lookup_filters` (camel first) while the
+runtime `LookupField` read `lookup_filters ?? lookupFilters` (snake first), so a
+document carrying both keys with different values was displayed one way and honoured
+the other. It is RETIRED on `main`: PR #7641 (merged 2026-09-04T15:01:32Z, `351eb318`)
+made `LookupField` read `lookupFilters` only, so both halves now honour the camel key
+and there is nothing left to file. The fallback the PM recorded on objectui#7642 (a
+card the moment #7641 stopped being its fix) is moot — #7641 landed. The designer's
+snake leg survives as a read of a STORED pre-strict document, which is the ground of
+its KEEP above, not as one side of a competing read order.

--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -13,19 +13,30 @@ path. Three findings moved every site to KEEP:
 1. The SERVE path runs no parse. `ObjectStackAdapter.getObjectSchema` returns the
    server document verbatim plus exactly two rewrites (`normalizeSchemaReferenceKeys`,
    `applyFieldWidgetOverrides`); there is no `ObjectSchema.parse`/`safeParse` on that
-   path. A stored pre-strict document therefore still delivers these keys to every
-   consumer. The legs are not unreachable.
+   path. The `resolveActionParams` site is served by a different path —
+   `useMetadata().objects`, filled by `client.meta.getItems('object')` in `app-shell`'s
+   `MetadataProvider` — and that path runs no schema parse either (the provider's only
+   `parse` is `JSON.parse` of its session cache; the pinned `@objectstack/client`'s
+   three `safeParse` calls are all event-payload schemas, none on `getItems`). A
+   stored pre-strict document therefore still delivers these keys to every consumer.
+   The legs are not unreachable.
 2. Five of the six sites have NO camelCase leg. They read the refused spelling and
    nothing else, so retiring it does not re-point the read to the declared spelling —
    it deletes the only read of the value. The corollary is the real user-facing gap:
    on fully spec-compliant metadata those five sites already ignore a configured
-   `displayField` / `idField` / `descriptionField` / `lookupFilters` today.
+   `displayField` / `descriptionField` / `lookupFilters` today. `idField` is NOT in
+   that list: measured on the pinned spec 17.2.0, `FieldSchema` refuses `idField` with
+   `unrecognized_keys` exactly as it refuses `id_field` — neither spelling of the id
+   key is declared, so the `id_field` reads have no camel leg to gain and their only
+   route is the ingestion choke point (objectui#7650, option A).
 3. The object-schema field def and the widget bag are the same object at runtime.
    `ObjectForm` builds its fields from `getObjectSchema` and threads each def to the
    widget, where `@object-ui/fields` `LookupField` reads `display_field` /
    `description_field` / `id_field` / `lookup_filters` SNAKE-FIRST, and
-   `@object-ui/types`' `LookupFieldMetadata` (published, and documented as authorable
-   in `content/docs/fields/lookup.mdx`) declares all four. Retiring the legs at the
+   `@object-ui/types`' `LookupFieldMetadata` (published) declares all four —
+   `content/docs/fields/lookup.mdx` documents three of them as authorable
+   (`description_field`, `id_field`, `lookup_filters`; `display_field` has zero hits in
+   all of `content/docs`, which document `reference_field` instead). Retiring the legs at the
    object-schema consumers while the form widget keeps reading snake-first off the
    same def would make one stored document render one way in the form and another in
    the chart, list, filters and action dialogs.
@@ -42,7 +53,8 @@ Per site, which way the value would have flipped had the leg been retired:
   list-view column (`ListColumnSchema`), which refuses BOTH castings of all three keys.
   A third contract, filed separately rather than half-retired.
 - `plugin-list` `ListView`, object-def branch — object-schema def proved. No camel leg:
-  `displayField` and `idField` would have gone `undefined`.
+  the branch's output `displayField` and `idField` (its own descriptor keys, not spec
+  spellings) would have gone `undefined`.
 - `plugin-list` `UserFilters` — `objectDef` is a public prop typed `any` on a publicly
   exported component; the bag cannot be traced past this package. No camel leg.
 - `app-shell` `resolveActionParams` — the in-file provenance note is correct; this is
@@ -52,7 +64,9 @@ Per site, which way the value would have flipped had the leg been retired:
   retiring it would show an admin an empty filter list and let a save strand the real
   filters.
 
-One live bug found and filed, not fixed here: the designer reads
+One live bug found and deliberately NOT filed as a card (open PR #7641 flips the
+runtime half and retires it on its own; the PM recorded it on objectui#7642 so it
+becomes a card the moment #7641 stops being its fix), not addressed here: the designer reads
 `lookupFilters ?? lookup_filters` (camel first) while the runtime `LookupField` reads
 `lookup_filters ?? lookupFilters` (snake first), so a document carrying both keys with
 different values is displayed one way and honoured the other.

--- a/packages/app-shell/src/utils/resolveActionParams.ts
+++ b/packages/app-shell/src/utils/resolveActionParams.ts
@@ -535,6 +535,11 @@ export function resolveActionParam(
         // contract declares, and renaming it would be a separate change.
         // Source here is `owner.fields[param.field]` — an object schema field def,
         // i.e. the protocol. Target contract: `ActionParamDef.referenceTo`.
+        // objectui#7642 CENSUS — verdict KEEP. The in-file provenance note above is
+        // CORRECT (`ctx.objects` is `useMetadata().objects`, the `/api/v1/meta/object`
+        // documents), so this really is the object-schema def. It is still kept: the
+        // serve path runs no parse, and none of the four reads below has a camel leg,
+        // so retiring them deletes the only read of four authorable keys.
         referenceTo: param.reference ?? field.reference,
         displayField: field.display_field ?? field.reference_field,
         idField: field.id_field,

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -1142,6 +1142,14 @@ const LOOKUP_OPERATORS: Array<{ value: string; label: string }> = [
 type LookupFilter = { field?: string; operator?: string; value?: unknown };
 
 function readLookupFilters(def: Record<string, unknown>): LookupFilter[] {
+  // objectui#7642 CENSUS — verdict KEEP. This is the one site of the six that
+  // reads camel FIRST and writes camel back (`patchDef({ lookupFilters })`), so
+  // its snake leg is purely a read of a STORED pre-strict document. Retiring it
+  // would show an admin an EMPTY filter list for such a document and let a save
+  // strand the real filters. NOTE the live inversion it participates in: the
+  // runtime reads `lookup_filters ?? lookupFilters` (snake first,
+  // `@object-ui/fields` LookupField) while this designer reads camel first — a
+  // document carrying both keys is displayed one way and honoured the other.
   const raw = def.lookupFilters ?? (def as Record<string, unknown>).lookup_filters;
   return Array.isArray(raw) ? (raw as LookupFilter[]) : [];
 }

--- a/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/ObjectFieldInspector.tsx
@@ -1146,10 +1146,10 @@ function readLookupFilters(def: Record<string, unknown>): LookupFilter[] {
   // reads camel FIRST and writes camel back (`patchDef({ lookupFilters })`), so
   // its snake leg is purely a read of a STORED pre-strict document. Retiring it
   // would show an admin an EMPTY filter list for such a document and let a save
-  // strand the real filters. NOTE the live inversion it participates in: the
-  // runtime reads `lookup_filters ?? lookupFilters` (snake first,
-  // `@object-ui/fields` LookupField) while this designer reads camel first — a
-  // document carrying both keys is displayed one way and honoured the other.
+  // strand the real filters. The runtime widget (`@object-ui/fields` LookupField)
+  // reads `lookupFilters` ONLY since objectui#7641 (merged 2026-09-04), so both
+  // halves honour the camel key: this snake leg is the designer's read of a stored
+  // document, not one side of a competing read order.
   const raw = def.lookupFilters ?? (def as Record<string, unknown>).lookup_filters;
   return Array.isArray(raw) ? (raw as LookupFilter[]) : [];
 }

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -201,8 +201,12 @@ export async function resolveGroupByLabels(
     // the server document plus only `normalizeSchemaReferenceKeys` and
     // `applyFieldWidgetOverrides` — so a stored pre-strict def still arrives here.
     // And there is NO camel leg below to fall back to: retiring these reads would
-    // delete the only read of the value, not re-point it. Adding the declared
-    // `idField`/`displayField` is a separate, contract-shaped change.
+    // delete the only read of the value, not re-point it. Adding a `displayField`
+    // leg (the spelling `FieldSchema` declares) is a separate, contract-shaped
+    // change. `idField` is NOT such a leg: measured on the pinned spec 17.2.0,
+    // `FieldSchema` refuses `idField` with `unrecognized_keys` exactly as it
+    // refuses `id_field` (the spec's only `idField` sits on `InlineGridColumnSchema`,
+    // a different shape), so the id read has no declared spelling to re-point to.
     const idField: string = fieldDef.id_field || 'id';
 
     try {

--- a/packages/plugin-charts/src/ObjectChart.tsx
+++ b/packages/plugin-charts/src/ObjectChart.tsx
@@ -194,6 +194,15 @@ export async function resolveGroupByLabels(
     if (ids.length === 0) return data.map(row => ({ ...row, [rawKey]: row[groupByField] }));
 
     // Derive the ID field from metadata (fallback to 'id')
+    // objectui#7642 CENSUS — verdict KEEP (bag traced: `objectSchema` is
+    // `ds.getObjectSchema(schema.objectName)`, so this IS the object-schema def).
+    // `FieldSchema` refuses `id_field`/`display_field` on the AUTHORING path, but
+    // the SERVE path runs no parse — `ObjectStackAdapter.getObjectSchema` returns
+    // the server document plus only `normalizeSchemaReferenceKeys` and
+    // `applyFieldWidgetOverrides` — so a stored pre-strict def still arrives here.
+    // And there is NO camel leg below to fall back to: retiring these reads would
+    // delete the only read of the value, not re-point it. Adding the declared
+    // `idField`/`displayField` is a separate, contract-shaped change.
     const idField: string = fieldDef.id_field || 'id';
 
     try {

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -251,6 +251,7 @@ export function deriveColumns(
       // but `deriveColumns` is a PUBLIC export of `@object-ui/plugin-form`, so an
       // external caller's `childSchema` cannot be traced from here. There is also no
       // camel `d?.displayField` leg: retiring this read deletes the only read.
+      // The same read recurs in `hydrateColumns` below; this verdict covers both.
       col.displayField = d?.display_field || d?.reference_field;
     }
     if (col.type === 'file') applyFileColumnProps(col, d);
@@ -305,6 +306,8 @@ export function hydrateColumns(
     if (type === 'select' && options && !next.options) next.options = options;
     if (type === 'lookup') {
       if (next.reference == null) next.reference = d?.reference;
+      // objectui#7642 CENSUS — verdict KEEP, same bag and same missing camel leg as
+      // `deriveColumns` above.
       if (next.displayField == null) next.displayField = d?.display_field || d?.reference_field;
     }
     if (type === 'file') applyFileColumnProps(next, d);

--- a/packages/plugin-form/src/deriveMasterDetail.ts
+++ b/packages/plugin-form/src/deriveMasterDetail.ts
@@ -246,6 +246,11 @@ export function deriveColumns(
     if (col.type === 'select' && options) col.options = options;
     if (col.type === 'lookup') {
       col.reference = d?.reference;
+      // objectui#7642 CENSUS — verdict KEEP. In-repo the bag is the object-schema
+      // def (`MasterDetailForm` passes `dataSource.getObjectSchema(d.childObject)`),
+      // but `deriveColumns` is a PUBLIC export of `@object-ui/plugin-form`, so an
+      // external caller's `childSchema` cannot be traced from here. There is also no
+      // camel `d?.displayField` leg: retiring this read deletes the only read.
       col.displayField = d?.display_field || d?.reference_field;
     }
     if (col.type === 'file') applyFileColumnProps(col, d);

--- a/packages/plugin-list/src/ListView.tsx
+++ b/packages/plugin-list/src/ListView.tsx
@@ -2710,6 +2710,14 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
               label: tFieldLabel(fieldName, f.label || fieldName),
               type: f.type || 'text',
               options: buildOptions(fieldName, f.options),
+              // objectui#7642 CENSUS — verdict KEEP, and NOTE the bag differs from
+              // the sibling branch below: `f` here is a LIST-VIEW COLUMN
+              // (`ListColumnSchema`), not an object-schema field def. Measured against
+              // the installed spec, `ListColumnSchema` refuses BOTH castings of all
+              // three keys (`display_field` AND `displayField`, `id_field` AND
+              // `idField`, `reference_to` AND `reference`), so this is not a
+              // snake-vs-camel question at all — it is a third contract. Filed
+              // separately rather than half-retired here.
               referenceTo: f.reference_to || f.reference,
               displayField: f.display_field || f.reference_field,
               idField: f.id_field,
@@ -2733,6 +2741,11 @@ export const ListView = React.forwardRef<ListViewHandle, ListViewProps>(({
             // with no rename hint. That is a different question and is filed, not
             // answered here.
             referenceTo: field.reference,
+            // objectui#7642 CENSUS — verdict KEEP. Bag traced: `objectDef` is
+            // `dataSource.getObjectSchema(schema.objectName)`, so this IS the
+            // object-schema def. But the serve path runs no parse, so a stored
+            // pre-strict def still arrives; and there is no camel leg here, so
+            // retiring these reads deletes the only read of the value.
             displayField: field.display_field || field.reference_field,
             idField: field.id_field,
         }));

--- a/packages/plugin-list/src/UserFilters.tsx
+++ b/packages/plugin-list/src/UserFilters.tsx
@@ -297,6 +297,10 @@ function resolveFields(
         // legacy-only def is canonicalised ONCE at the ingestion choke point
         // (`normalizeSchemaReferenceKeys`, which warns in dev) — never here.
         referenceTo = fieldDef.reference;
+        // objectui#7642 CENSUS — verdict KEEP. `objectDef` is a PUBLIC prop typed
+        // `any` on a publicly exported component, so the bag cannot be traced past
+        // this package: the in-repo caller (`ListView`) passes `getObjectSchema`
+        // output, but an external host's is unknown. No camel leg here either.
         displayField = fieldDef.display_field ?? fieldDef.reference_field;
         idField = fieldDef.id_field;
 


### PR DESCRIPTION
Part of #7642

**Census only. Zero sites retired, zero runtime change** (+145 / −0 at `95872adb7` against the
merge-base `1ec291c0`: `//` comments plus one empty-frontmatter changeset; 0 executable tokens
moved, measured — see Verification). Per the dispatching ruling, the census is the deliverable
and the retirements were conditional on it.

## Verdict: all seven legs KEEP

The card's argument is that `FieldSchema` is strict, the four snake spellings are
absent, therefore no producer can emit them. Measured against the spec installed in
this repo, with all controls lit, that is **true — of the authoring path**. Three
further measurements moved every site to KEEP.

### 1. The serve path runs no parse

`ObjectStackAdapter.getObjectSchema` returns the server document verbatim plus exactly
two rewrites (`normalizeSchemaReferenceKeys`, `applyFieldWidgetOverrides`). Count of
`ObjectSchema.parse`/`safeParse` on that path: **0**, against a lit control (the same
file does use `DroppedFieldsEventSchema` and `isFilterAST`). So `FieldSchema`'s
strictness gates **authoring**, not **serving**: a stored pre-strict document still
delivers these keys to every one of these consumers. The legs are not unreachable.

Corrected 2026-09-05: the `resolveActionParams` site is served by a **different** path —
`useMetadata().objects`, filled by `client.meta.getItems(type)` in `app-shell`'s
`MetadataProvider` (line 648 on this branch) — and that path runs no schema parse either:
the provider's only `parse` is `JSON.parse` of its session cache (control: the same file
imports and uses `expandViewContainer` from the spec), and the pinned
`@objectstack/client@17.2.0` dist carries exactly 3 `safeParse` calls, all event-payload
schemas (`MetadataEventSchema`, `DataEventSchema`, `BulkDataEventSchema`), none on
`getItems` (control: `unwrapResponse` 166 hits). The conclusion held; the cited path was
wrong for that one site.

### 2. Five of the six sites have no camelCase leg at all

Measured per file, control lit. Only `ObjectFieldInspector` reads a camel spelling off
the field def. For the other five, retiring the snake read does not re-point the read
to the declared spelling — it **deletes the only read of the value**.

The corollary is the more interesting half, and it inverts the card's disposition:
those five sites **already ignore** a spec-compliant `displayField` /
`descriptionField` / `lookupFilters` today. The user-serving change is to **add** those
three declared camel reads, not to remove the snake ones. **`idField` is not one of
them** (corrected 2026-09-05 after contract review): measured on the pinned spec 17.2.0,
`FieldSchema` REJECTS `idField` with `unrecognized_keys` exactly as it rejects `id_field`
— the spec's only `idField` sits on `InlineGridColumnSchema`, a different shape — so the
`id_field` reads at `ObjectChart`, `ListView` (object-def branch), `UserFilters` and
`resolveActionParams` have no `FieldSchema` spelling to gain a leg for, and adding an
`idField` read would fossilise a spelling `FieldSchema` does not declare. That is a
`FieldSchema` statement only (scoped 2026-09-05, round 2): the widget contract
`@object-ui/types` `LookupFieldMetadata.idField` (`packages/types/src/field-types.ts:525`
on `main`, read by `LookupField.tsx:262`) **is** declared — a widget-contract key that
PR #7641 deliberately kept, on the same runtime object §3 describes — but it is a
different contract, not a `FieldSchema` target. Their route is the ingestion choke point
(objectui#7650, option A), not an additive camel leg. objectui#7435 already carries that
finding for two of the five; this census adds three more (`deriveMasterDetail`,
`ListView`'s object-def branch, `UserFilters`).

### 3. The object-schema def and the widget bag are the same object at runtime — and what the widget reads moved during review

`ObjectForm` builds its fields from `getObjectSchema` and threads each def to the widget
(`ObjectForm.tsx` is byte-identical on `origin/main` and this head, so the hop itself
did not move). The widget half of this finding is **dated**, because PR #7641 landed
while this PR was in review:

- **At this branch's base (`1ec291c0`, 2026-09-04T13:55Z):** `LookupField` read
  `display_field` / `description_field` / `id_field` / `lookup_filters` **snake-first**
  (`:260-262`, `:278`); `LookupFieldMetadata` in `@object-ui/types` — published — declared
  all four snake members; `content/docs/fields/lookup.mdx` documented three of them as
  authorable (`description_field` 3, `id_field` 1, `lookup_filters` 3; `display_field` 0,
  `reference_field` 4 as the control). That was the objectui#7155 shape exactly: the
  "no producer can emit it" argument true of the object contract and false of a second
  published one.
- **On `origin/main` (`a3eb5d07`), fetched and measured 2026-09-05 with predictions
  written before each probe, 11/11 met:** PR #7641 — **merged 2026-09-04T15:01:32Z as
  `351eb318`**, 30 files, 0 of them this PR's — converged the widget contract on the
  spec's camelCase. `LookupField.tsx:260-262/:278` read `displayField || reference_field`,
  `descriptionField`, `idField`, `lookupFilters` — **camel-only** (snake spellings in the
  file: 0; `reference_field` 1 as the control); `LookupFieldMetadata`
  (`field-types.ts:516/:525/:539/:561`) declares the camel members only (0 snake keys
  inside the interface); `content/docs` has **0** hits for all four snake keys (controls
  in the same run: `reference_field` 4, `lookupFilters` 3).

So on the tree this PR lands in, the split runs the **other way**: it is *keeping*
these six snake legs, while the form widget reads camel-only, that lets one stored
pre-strict document render one way in the form and another in the chart, list,
filters and action dialogs. The second published contract no longer declares the snake
spellings, so that half of the #7155 argument is gone on `main`. **KEEP still stands**,
on §1 and §2 (the serve path delivers the stored key, and five sites have no camel leg,
so retiring the read deletes the only read) and on the dispatching ruling that refused
option B and made the ingestion choke point (option A, objectui#7650) the prerequisite
for any retirement. The way to close the split is A plus the additive camel legs on
objectui#7435 — not a consumer-side deletion.

## The census

| site | bag, traced to its producer | contract | camel leg? | verdict |
|---|---|---|---|---|
| `plugin-charts` `ObjectChart` | `ds.getObjectSchema(schema.objectName)`, sole producer; the function is not in the package's public API | object-schema def | no | KEEP |
| `plugin-form` `deriveMasterDetail` | `dataSource.getObjectSchema(d.childObject)` in-repo, but `deriveColumns` is a public export so external bags are untraceable (two reads: `deriveColumns` and `hydrateColumns`, both marked) | object-schema def in-repo, ambiguous outside | no | KEEP |
| `plugin-list` `ListView`, columns branch | the view's own `schema.columns` | **`ListColumnSchema`, a third contract** | n/a, both castings refused | KEEP |
| `plugin-list` `ListView`, object-def branch | `dataSource.getObjectSchema(...)`, sole producer | object-schema def | no | KEEP |
| `plugin-list` `UserFilters` | `objectDef`, a public prop typed loosely on a publicly exported component | untraceable past this package | no | KEEP |
| `app-shell` `resolveActionParams` | `useMetadata().objects`, the meta-API object documents | object-schema def | no | KEEP |
| `app-shell` `ObjectFieldInspector` | field def in the metadata-admin designer; writes camel back | object-schema def | yes, camel first | KEEP |

The card's table lists `ListView` as one site. It is **two**, on two different
contracts: the columns branch reads a list-view column, where `ListColumnSchema`
refuses `display_field` **and** `displayField`, `id_field` **and** `idField`,
`reference_to` **and** `reference` — measured, with a positive and a negative control.
That is objectui#7531's population, not this card's.

## Measurements

`FieldSchema.safeParse`, installed spec, every control lit:

```
CONTROL A  {type:'lookup',name,label,reference}       ACCEPTED   (instrument live)
CONTROL B  displayField / descriptionField /
           lookupFilters                              ACCEPTED   (camel declared)
CONTROL C  zzz_not_a_real_key                         REJECTED unrecognized_keys
TEST       display_field / description_field /
           id_field / lookup_filters /
           reference_field / reference_to             REJECTED unrecognized_keys
TEST       idField                                    REJECTED unrecognized_keys
```

Re-measured 2026-09-05 (remediation), predictions written before the run, all five met,
`MISSED PREDICTIONS: none`; the spec resolved through this worktree's `package.json` to the
lockfile pin `@objectstack/spec@17.2.0`. The `idField` row is the one the first version of
this body did not carry, and the one that falsified its "declared camel spelling" claim.

`ListColumnSchema.safeParse`, same controls: minimal column ACCEPTED, bogus key
REJECTED, and **all ten** keys tested (both castings) REJECTED with
`unrecognized_keys`.

`ObjectSchema.fields` is a record; an array is refused with
`invalid_type: expected record, received array` — noted because two of these sites
carry an `Array.isArray(objectDef.fields)` branch the object contract cannot produce.

## One live disagreement at the base — retired on `main`, so nothing to file

At the base the designer (`ObjectFieldInspector`, `readLookupFilters`) read
`lookupFilters ?? lookup_filters` (camel first) while the runtime `LookupField` read
`lookup_filters ?? lookupFilters` (snake first), so a document carrying both keys with
different values was displayed one way and honoured the other. PR #7641 (merged
2026-09-04T15:01:32Z, `351eb318`) made `LookupField` read `lookupFilters` only, so both
halves now honour the camel key; the PM's recorded fallback on objectui#7642 ("a card
the moment #7641 stops being its fix") is moot. The designer's snake leg survives as a
read of a stored pre-strict document — the ground of its KEEP — not as one side of a
competing read order. The in-tree comment at `ObjectFieldInspector.tsx:1149-1152` now
says exactly that. No card was filed for the inversion (a targeted search returned 0
against a lit control), and none is owed.

## Clause-2 determination

**No** — and it holds for the diff actually shipped, which is comments plus a
changeset. Worth recording, though, that the *proposed* retirement would not have been
Clause-2-no in the assumed way: because five sites carry no camel leg, removing the
snake reads would have removed the only read of four authorable keys, a user-visible
behaviour change rather than a dead-code deletion.

## Remediation 2026-09-05 (round 1) — contract review REFUSE, text only

The isolated contract review (comment 5548607662) refused this PR on two false factual
claims and recorded two non-blocking imprecisions. Commit `8c99d10d7` corrects the text;
**no code, test or behaviour changed** — proven by stripping every `//`-comment line from
`ObjectChart.tsx` at the base `09a2726a` and at `8c99d10d7` and comparing hashes
(`8b9ebbf582ea` both, and also equal to `origin/main`'s; control: injecting one code line
moves it to `82492a4b8841`). `git diff --stat 09a2726a..8c99d10d7`: `.changeset/lucky-donkeys-shave.md`
+21/-7 and `packages/plugin-charts/src/ObjectChart.tsx` +6/-2, and 0 of the `.tsx` hunk lines
are non-comment.

1. **`idField` is NOT a declared camel spelling** — four carriers named, all corrected:
   this PR body (sections 1-3 and the measurements block above); the changeset (finding 2
   now says `idField` is not in the list and routes `id_field` to objectui#7650 option A);
   the in-tree `ObjectChart.tsx` comment (now: adding a `displayField` leg is the
   contract-shaped change, and `idField` is refused exactly like `id_field`); and the
   census comment on objectui#7435 (corrected by a follow-up comment there, since comments
   cannot be edited from this seat). The PM's ruling comment on objectui#7642 carries the
   same phrase and is corrected by the remediation report comment on that card.
2. **The changeset said the inversion bug was "filed"** — round 1 changed that to
   "deliberately NOT filed" but called PR #7641 open; the second review caught that #7641
   had merged eleven hours before that sentence was written. Corrected in round 2 below.
3. Non-blocking imprecisions, both re-measured and corrected in place above: the
   `resolveActionParams` serve path, and the docs over-statement.

Follow-up C ("add the declared camel legs", blessed on objectui#7642) is narrowed to
`displayField` / `descriptionField` / `lookupFilters` on objectui#7435, where that scope
lives; `id_field` is excluded and routed to objectui#7650 option A, with a routing note
added there. Remediation session: `https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3`.

## Remediation 2026-09-05 (round 2) — the record dated against `main`, text only

The second contract review (comment 5548785535) refused the record for asserting in the
present tense that PR #7641 was open, and for describing a snake-first `LookupField` that
`main` no longer has. Commit `95872adb7` corrects the text; **no code, test or behaviour
changed**. Method fix applied: every present-tense claim in this record was re-measured
against current `origin/main` (`a3eb5d07`, fetched first — not this branch's merge-base),
and the state and merge time of every PR named was read before choosing a tense.

1. Changeset finding 3 and the inversion paragraph: dated to the base, the post-#7641
   state added, and the direction of the split corrected (on `main` it is keeping the six
   snake legs while the form reads camel-only that splits a stored document).
2. `ObjectFieldInspector.tsx:1149-1152`: the "live inversion … runtime reads snake first"
   sentence replaced with the post-#7641 fact.
3. This body: §3, the disagreement section, the opening count and Scope, aligned with 1-2.
4. "Neither spelling of the id key is declared" scoped to `FieldSchema` in §2 and in
   changeset finding 2, with `LookupFieldMetadata.idField` named as the declared
   widget-contract spelling. The objectui#7435 follow-up comment (5548681329) carries the
   same sentence and is corrected by a further comment there, which also gives the
   dispatcher of that card the per-key reading its triage predates.
5. `deriveMasterDetail.ts`: the second snake read, in `hydrateColumns` (`:311`), now carries
   its own marker (`:309-310`) and is named by the `deriveColumns` comment (`:254`).

## Verification

Gate union re-run at `09a2726a`, the first commit:

```
check:control-bytes             exit 0   OK (scanned 6247 tracked text files)
check:designer-field-key-parity exit 0   designer-field-key-parity: OK
check-changeset-presence        exit 0   6 source files, 1 changeset, empty frontmatter
check-changeset-no-major        exit 0   no changeset declares a major bump
```

- Dependency closure built, then `type-check` for `app-shell`, `plugin-list`,
  `plugin-charts`, `plugin-form` — all four echoed the script name (`Scope: 4 of 47
  workspace projects`) and passed, so this is not a zero-match false green. The script
  in this repo is spelled `type-check`, not `typecheck`.
- Targeted vitest from the repo root: 5 files, 107 tests, all passed.
- eslint over the 6 changed files: **0 errors**. The 303 warnings are pre-existing —
  **0** lint messages land on any of the 44 added lines. The narrowing is a
  measurement, not a skip: file count read from `--format json` (6), and the flat
  config declares no `project`/`projectService`, so no file's verdict can depend on
  another file's contents.
- Heavy runs went through the shared verify lock, slot `issue-7642`.

Re-run at `8c99d10d7`, the round-1 commit (exit captured by redirect before any pipe,
verdict lines quoted):

```
check:control-bytes              exit 0   check-control-bytes: OK (scanned 6247 tracked text file(s); skipped 85 binary)
check-changeset-presence         exit 0   Every one of them has an EMPTY frontmatter — declared as releasing nothing
check-changeset-no-major         exit 0   No changeset declares a `major` bump
check-changeset-fixed            exit 0   All workspace packages are in the changeset fixed group
check-changeset-overwrite        exit 0   No pre-existing changeset was modified or deleted
check:designer-field-key-parity  exit 0   designer-field-key-parity: OK
```

- Dependency closure built (`Scope: 9 of 47 workspace projects`) then `type-check` for
  `plugin-charts`, echoing `tsc --noEmit && tsc -p tsconfig.test.json`: `VERDICT
  command-exit 0 · held the lock 54s · waited 2s`.
- eslint on `ObjectChart.tsx` (`--format json`, 1 file): **0 errors**, 58 pre-existing
  warnings, **0** messages on the edited comment lines 204-210.

Re-run at `95872adb7`, the round-2 commit (exit captured by redirect before any pipe,
verdict lines quoted):

```
check:control-bytes              exit 0   check-control-bytes: OK (scanned 6247 tracked text file(s); skipped 85 binary)
check:designer-field-key-parity  exit 0   designer-field-key-parity: OK
check-changeset-presence         exit 0   EMPTY frontmatter … the explicit exemption and a complete answer to this gate
check-changeset-no-major         exit 0   No changeset declares a `major` bump
check-changeset-fixed            exit 0   privatePackages declared: version=true, tag=false
check-changeset-overwrite        exit 0   No pre-existing changeset was modified or deleted
```

- **Executable-change instrument** (TypeScript 5.9.3 from the pinned store): per file,
  R1 = sha1 of the `transpileModule` emit with `removeComments`, R2 = sha1 of the AST
  leaf-token sequence (JSDoc nodes excluded) plus the token count. All six census files
  read **identical** at `8c99d10d7`, at `origin/main` (`a3eb5d07`) and at `95872adb7`:
  `resolveActionParams.ts` 1589 tokens, `ObjectFieldInspector.tsx` 11197,
  `ObjectChart.tsx` 5997, `deriveMasterDetail.ts` 2580, `ListView.tsx` 18098,
  `UserFilters.tsx` 5607. Lit control on `ObjectFieldInspector.tsx`: injecting
  `const __ctl_code = 1;` moved R1, R2 and the count by +5 tokens; injecting a `//` line
  or a `/* */` block moved neither. `git diff -U0 8c99d10d7..95872adb7` under `packages/`:
  **0** added or removed lines that are not `//` comments; max added line width 88;
  raw control bytes in the three touched files 0.
- eslint on the two touched source files (`--format json`, 2 files): **0 errors**, 22
  pre-existing warnings, **0** messages on the edited lines (1149-1152; 254, 309-310).
- Declared narrowing: type-check and vitest not re-run for this commit — the token
  instrument above is the measurement that nothing executable moved; CI runs the farm.

## Scope

`packages/types/**`, `plugin-grid/relationalMetaKeys.ts` and the widget-metadata bag
were not touched. PR #7641 (merged 2026-09-04, `351eb318`) touched 30 files, none of this
PR's 7; `main` has moved 80 files since the base, 0 of them this PR's, so the PR merges
cleanly — the only conflict was the record versus the tree it lands in, fixed above.
`reference_field` is reported on but not retired.

Labelled `needs:contract-review` on both carriers, as the dispatching ruling directs
when the census concludes a second published contract declares these spellings. That
trigger was true at the base and is dissolved on `main` by #7641 (`LookupFieldMetadata`
is camel-only there); the labels stay for the review round to clear — not cleared here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_