### PR TITLE
fix(types): SchemaRegistry's kanban entry stops describing a component it cannot name

### DIFF
--- a/.changeset/7645-schema-registry-kanban-honesty.md
+++ b/.changeset/7645-schema-registry-kanban-honesty.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/types': minor
+---
+
+`SchemaRegistry['kanban']` stops describing a component it cannot name
+
+`SchemaRegistry` documents itself as "the Single Source of Truth for component
+type lookups". Its `'kanban'` entry named `DeclarativeKanbanSchema` — the
+authoring/validation face declared in this package — while the renderer
+registered for that key is `ObjectKanbanRenderer` in `@object-ui/plugin-kanban`
+(`ComponentRegistry.register('kanban', …)`), which consumes that package's own
+`KanbanSchema`. The two are structurally unrelated dialects: 19 members against
+the declarative face's own set, sharing only the `type` tag. For this one key
+the map's value did not describe the component the key names.
+
+Pointing the entry at the honest type is not reachable from this layer, and
+that was measured rather than assumed. Importing `@object-ui/plugin-kanban`
+here is a phantom dependency — `check:phantom-deps` rejects it by file and
+pair, type-only imports included — and declaring the dependency would close the
+cycle `@object-ui/types` → `@object-ui/plugin-kanban` → `@object-ui/types`,
+because this package is the zero-workspace-dependency bottom layer.
+objectui#6172's ruling kept the plugin's bare names rather than relocating that
+dialect down here, so the gap is permanent by decision.
+
+So the entry now asserts only what this layer can prove, and what BOTH dialects
+satisfy: `BaseSchema & { type: 'kanban' }`.
+
+**What this changes for consumers.** `keyof SchemaRegistry` — and therefore the
+published `ComponentType` union — is unchanged; `'kanban'` is still a member,
+pinned at compile time so it cannot be narrowed away silently. What changes is
+the value side of this one key: `SchemaRegistry['kanban']` no longer resolves to
+`DeclarativeKanbanSchema`. Code that read members off it gets the base node
+shape instead and should name the face it actually means —
+`DeclarativeKanbanSchema` is still exported from `@object-ui/types` unchanged
+for the authoring face, and `KanbanSchema` from `@object-ui/plugin-kanban` for
+the rendered one. Nothing in this repository performed such an indexed access,
+which is why this is a correction rather than a break.

--- a/.changeset/7645-schema-registry-kanban-honesty.md
+++ b/.changeset/7645-schema-registry-kanban-honesty.md
@@ -9,9 +9,15 @@ type lookups". Its `'kanban'` entry named `DeclarativeKanbanSchema` — the
 authoring/validation face declared in this package — while the renderer
 registered for that key is `ObjectKanbanRenderer` in `@object-ui/plugin-kanban`
 (`ComponentRegistry.register('kanban', …)`), which consumes that package's own
-`KanbanSchema`. The two are structurally unrelated dialects: 19 members against
-the declarative face's own set, sharing only the `type` tag. For this one key
-the map's value did not describe the component the key names.
+`KanbanSchema`. The two are distinct dialects, measured member by member: the
+plugin face declares 19 members in its own body, the declarative face 7, and
+they share three names — `type`, `columns` and `onCardMove`. `onCardMove` has
+the same signature on both sides; `columns` is required
+`DeclarativeKanbanColumn[]` on one and optional `KanbanColumn[]` on the other,
+the two element types sharing five of their six members; the remaining 16
+plugin members and the declarative `draggable` / `onCardClick` have no
+counterpart across the gap. For this one key the map's value did not describe
+the component the key names.
 
 Pointing the entry at the honest type is not reachable from this layer, and
 that was measured rather than assumed. Importing `@object-ui/plugin-kanban`
@@ -28,10 +34,30 @@ satisfy: `BaseSchema & { type: 'kanban' }`.
 **What this changes for consumers.** `keyof SchemaRegistry` — and therefore the
 published `ComponentType` union — is unchanged; `'kanban'` is still a member,
 pinned at compile time so it cannot be narrowed away silently. What changes is
-the value side of this one key: `SchemaRegistry['kanban']` no longer resolves to
-`DeclarativeKanbanSchema`. Code that read members off it gets the base node
-shape instead and should name the face it actually means —
-`DeclarativeKanbanSchema` is still exported from `@object-ui/types` unchanged
-for the authoring face, and `KanbanSchema` from `@object-ui/plugin-kanban` for
-the rendered one. Nothing in this repository performed such an indexed access,
-which is why this is a correction rather than a break.
+the value side of this one key, in two ways, one loud and one silent:
+
+- **Breaking, loudly, for consumers who indexed `SchemaRegistry['kanban']` and
+  flowed the value into the declarative face.** Before this change
+  `SchemaRegistry['kanban']` *was* `DeclarativeKanbanSchema`, so
+  `const s: DeclarativeKanbanSchema = registryValue` compiled. It no longer
+  does: the entry lacks the required `columns` member, and that assignment is
+  a compile error (TS2741). Nothing in this repository performed such an
+  indexed access, so no in-repo code moves — the break is for consumers
+  outside it.
+- **Silent, for member reads.** `BaseSchema` carries an index signature
+  (`[key: string]: any`), so reading the declarative face's own members —
+  `columns`, `draggable`, `onCardMove`, `onCardClick` — off the new entry is
+  not an error: the reads resolve through the index signature and type as
+  `any`. `SchemaRegistry['kanban']['columns']` was `DeclarativeKanbanColumn[]`
+  and is now `any`; nothing turns red, the read just stops being checked.
+  (Undeclared keys already read as `any` before, through the same signature;
+  what changes is those declared members.)
+
+Migration: name the face you actually mean. `DeclarativeKanbanSchema` is still
+exported from `@object-ui/types` unchanged for the authoring face, and
+`KanbanSchema` from `@object-ui/plugin-kanban` for the rendered one.
+
+This is a breaking change shipped as `minor`: this repository's
+version-alignment rule keeps objectui's major pinned to `@objectstack`'s and
+ships objectui's own breaking changes as `minor` with the break spelled out in
+the changeset body, which is what the two bullets above are.

--- a/.changeset/7645-schema-registry-kanban-honesty.md
+++ b/.changeset/7645-schema-registry-kanban-honesty.md
@@ -25,8 +25,14 @@ here is a phantom dependency — `check:phantom-deps` rejects it by file and
 pair, type-only imports included — and declaring the dependency would close the
 cycle `@object-ui/types` → `@object-ui/plugin-kanban` → `@object-ui/types`,
 because this package is the zero-workspace-dependency bottom layer.
-objectui#6172's ruling kept the plugin's bare names rather than relocating that
-dialect down here, so the gap is permanent by decision.
+objectui#6172's ruling (2026-08-31) kept the plugin's bare names rather than
+relocating that dialect down here — that is why this entry cannot name the
+plugin's type at this commit. That half of the ruling has since been reversed:
+objectui#7664's ruling (a) (2026-09-05) rewrites this package's `'kanban'`
+arm to the plugin's shape, has `@object-ui/plugin-kanban` conform to it, and
+retires the `DeclarativeKanban*` trio; `registry.ts` is on its execution list,
+so this entry is scheduled to be re-pointed at the declared type. The value
+below is the transitional state under that ruling, not the permanent one.
 
 So the entry now asserts only what this layer can prove, and what BOTH dialects
 satisfy: `BaseSchema & { type: 'kanban' }`.

--- a/packages/plugin-kanban/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
+++ b/packages/plugin-kanban/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
@@ -1,0 +1,84 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The renderer's own face satisfies what `SchemaRegistry['kanban']` asserts.
+ *
+ * ## Why this pin lives here and can live nowhere else
+ *
+ * objectui#7645: `@object-ui/types`' `SchemaRegistry` advertises itself as the
+ * Single Source of Truth for component type lookups, and its `'kanban'` entry
+ * named the DECLARATIVE authoring face while the renderer registered for that
+ * key — `ObjectKanbanRenderer`, `ComponentRegistry.register('kanban', …)` in
+ * `../index` — consumes {@link KanbanSchema} from this package. The two are
+ * unrelated dialects (objectui#6172 ruled this package KEEPS the bare names).
+ *
+ * The entry was therefore weakened to the claim that layer can prove and both
+ * dialects satisfy: a schema node tagged `'kanban'`. That claim is only worth
+ * anything if it is actually TRUE of the renderer's face — and
+ * `@object-ui/types` cannot check that, because it cannot name this package:
+ * the import is a phantom dependency and declaring it would close the cycle
+ * `@object-ui/types` → `@object-ui/plugin-kanban` → `@object-ui/types`. This
+ * package depends on `@object-ui/types`, so it is the only place in the
+ * workspace that can see both sides at once. That is the whole reason this
+ * file exists rather than one more pin next to the map.
+ *
+ * ⛔ This file does not touch {@link KanbanSchema} — it only reads it. The
+ * plugin dialect is the face objectui#6172 ruled kept, and `KanbanSchema.data`
+ * is objectui#7651, an open maintainer decision.
+ *
+ * ## The instrument
+ *
+ * Compile-time only. Vitest strips types without checking them, so a green run
+ * of this file proves nothing on its own; the assertions are read by
+ * `tsc -p packages/plugin-kanban/tsconfig.test.json`, chained off this
+ * package's `type-check` script. That project sets `"paths": {}`, so
+ * `@object-ui/types` resolves through the workspace dependency to
+ * `packages/types/dist/index.d.ts` — BUILD `@object-ui/types` before believing
+ * either colour this file reports.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { SchemaRegistry, DeclarativeKanbanSchema } from '@object-ui/types';
+import type { KanbanSchema } from '../types';
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins — compiled by tsconfig.test.json, chained off type-check. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+describe("the registered kanban renderer's schema satisfies the registry entry", () => {
+  it('is pinned at compile time', () => {
+    // Non-vacuity controls: `any` on either side would satisfy every `extends`
+    // below while checking nothing.
+    type _PluginFaceIsReal = Assert<Equal<IsAny<KanbanSchema>, false>>;
+    type _RegistryIsReal = Assert<Equal<IsAny<SchemaRegistry>, false>>;
+
+    // 1. The claim the map now makes for `'kanban'` is TRUE of the face the
+    //    registered renderer actually consumes. This is the assertion that
+    //    makes the weakened entry honest rather than merely vaguer.
+    type _PluginFaceSatisfiesTheEntry = Assert<
+      KanbanSchema extends SchemaRegistry['kanban'] ? true : false
+    >;
+
+    // 2. …and it is still two dialects, not one. If these ever converge, the
+    //    weakened entry has outlived its reason and objectui#7645 should be
+    //    re-triaged rather than left as a permanent retreat.
+    type _StillTwoDialects = Assert<
+      Equal<Equal<KanbanSchema, DeclarativeKanbanSchema>, false>
+    >;
+
+    // 3. Both faces agree on the one thing the map asserts: the tag.
+    type _PluginFaceIsTagged = Assert<Equal<KanbanSchema['type'], 'kanban'>>;
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/plugin-kanban/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
+++ b/packages/plugin-kanban/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
@@ -20,17 +20,17 @@
  *
  * The entry was therefore weakened to the claim that layer can prove and both
  * dialects satisfy: a schema node tagged `'kanban'`. That claim is only worth
- * anything if it is actually TRUE of the renderer's face — and
- * `@object-ui/types` cannot check that, because it cannot name this package:
- * the import is a phantom dependency and declaring it would close the cycle
- * `@object-ui/types` → `@object-ui/plugin-kanban` → `@object-ui/types`. This
- * package depends on `@object-ui/types`, so it is the only place in the
- * workspace that can see both sides at once. That is the whole reason this
- * file exists rather than one more pin next to the map.
+ * anything if it is actually TRUE of the renderer's face — and `@object-ui/types`
+ * cannot check that: it cannot name this package (the import is a phantom
+ * dependency; declaring it would close the cycle `@object-ui/types` →
+ * `@object-ui/plugin-kanban` → `@object-ui/types`). This package depends on
+ * `@object-ui/types`, so it is the only place in the workspace that can see both
+ * sides at once — which is why this file exists, not one more pin by the map.
  *
- * ⛔ This file does not touch {@link KanbanSchema} — it only reads it. The
- * plugin dialect is the face objectui#6172 ruled kept, and `KanbanSchema.data`
- * is objectui#7651, an open maintainer decision.
+ * ⛔ This file does not touch {@link KanbanSchema} — it only reads it. It is the
+ * face objectui#6172 kept, and the one objectui#7664's ruling (a) (2026-09-05)
+ * makes the declared shape; `KanbanSchema.data` stays a raw-row input, since
+ * objectui#7651 was ruled B and closed as not_planned (2026-09-05T02:09:54Z).
  *
  * ## The instrument
  *
@@ -69,9 +69,9 @@ describe("the registered kanban renderer's schema satisfies the registry entry",
       KanbanSchema extends SchemaRegistry['kanban'] ? true : false
     >;
 
-    // 2. …and it is still two dialects, not one. If these ever converge, the
-    //    weakened entry has outlived its reason and objectui#7645 should be
-    //    re-triaged rather than left as a permanent retreat.
+    // 2. …and, at this commit, still two dialects. objectui#7664's ruling (a)
+    //    (2026-09-05) schedules their convergence; when it lands, the weakened
+    //    entry has outlived its reason and this pin retires with the re-point.
     type _StillTwoDialects = Assert<
       Equal<Equal<KanbanSchema, DeclarativeKanbanSchema>, false>
     >;

--- a/packages/types/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
+++ b/packages/types/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
@@ -26,12 +26,12 @@
  * `@object-ui/plugin-kanban`, which consumes that package's `KanbanSchema`.
  * `@object-ui/types` cannot name it: the import is a phantom dependency
  * (`check:phantom-deps` names the pair), and declaring the dependency closes
- * the cycle `@object-ui/types` → `@object-ui/plugin-kanban` →
- * `@object-ui/types`. objectui#6172's ruling kept the plugin's bare names
- * rather than relocating that dialect into this zero-dependency layer, so the
- * gap is permanent by decision. The half of the claim that IS provable here —
- * a schema node tagged `'kanban'` — is what the entry now states, and the
- * plugin side proves its own face satisfies it in
+ * the cycle `@object-ui/types` → `@object-ui/plugin-kanban` → `@object-ui/types`.
+ * objectui#6172's ruling (2026-08-31) kept the plugin's bare names there;
+ * objectui#7664's ruling (a) (2026-09-05) reverses that half — this package's
+ * `'kanban'` arm is rewritten to the plugin's shape and the entry re-pointed at
+ * it, so the value pinned below is TRANSITIONAL. What IS provable here — a
+ * node tagged `'kanban'` — is what it states; the plugin's face satisfies it in
  * `packages/plugin-kanban/src/__tests__/schema-registry-kanban-honesty-7645.test.ts`.
  *
  * ## These assertions are compile-time only

--- a/packages/types/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
+++ b/packages/types/src/__tests__/schema-registry-kanban-honesty-7645.test.ts
@@ -1,0 +1,94 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `SchemaRegistry['kanban']` — the key survives, the value stops asserting.
+ *
+ * ## What this pins, and why the key half is the load-bearing half
+ *
+ * `ComponentType = keyof SchemaRegistry` is a PUBLISHED union. The remedy for
+ * objectui#7645 (this map's `'kanban'` value described the declarative
+ * authoring face, not the type the registered renderer honours) had to leave
+ * that union byte-identical: dropping the key would silently narrow a
+ * published type, turning a false claim into a missing one. So the value was
+ * weakened to what this layer can prove and the KEY was kept — and only a pin
+ * can tell those two edits apart afterwards, because deleting the entry
+ * outright also removes the false claim and every runtime suite stays green.
+ *
+ * ## Why the value cannot simply be corrected
+ *
+ * The renderer registered for `'kanban'` is `ObjectKanbanRenderer` in
+ * `@object-ui/plugin-kanban`, which consumes that package's `KanbanSchema`.
+ * `@object-ui/types` cannot name it: the import is a phantom dependency
+ * (`check:phantom-deps` names the pair), and declaring the dependency closes
+ * the cycle `@object-ui/types` → `@object-ui/plugin-kanban` →
+ * `@object-ui/types`. objectui#6172's ruling kept the plugin's bare names
+ * rather than relocating that dialect into this zero-dependency layer, so the
+ * gap is permanent by decision. The half of the claim that IS provable here —
+ * a schema node tagged `'kanban'` — is what the entry now states, and the
+ * plugin side proves its own face satisfies it in
+ * `packages/plugin-kanban/src/__tests__/schema-registry-kanban-honesty-7645.test.ts`.
+ *
+ * ## These assertions are compile-time only
+ *
+ * They mean something only because this package type-checks its tests:
+ * `tsconfig.json` excludes test files (they must not emit into `dist`) and
+ * `tsconfig.test.json` picks them back up, chained off the package's
+ * `type-check` script. Vitest strips types without checking them, so a green
+ * vitest run is NOT evidence about anything below. The instrument is
+ * `tsc -p packages/types/tsconfig.test.json`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type {
+  SchemaRegistry,
+  ComponentType,
+  DeclarativeKanbanSchema,
+} from '../index';
+
+/* -------------------------------------------------------------------------- */
+/* Compile-time pins — compiled by tsconfig.test.json, chained off type-check. */
+/* -------------------------------------------------------------------------- */
+
+type Assert<T extends true> = T;
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+describe("SchemaRegistry's kanban key outlives its value's retreat", () => {
+  it('is pinned at compile time', () => {
+    // Non-vacuity controls. `Equal<any, X>` is `false` and `any` satisfies
+    // every `extends`, so an `any` on either side would let the pins below
+    // pass while checking nothing at all.
+    type _RegistryIsReal = Assert<Equal<IsAny<SchemaRegistry>, false>>;
+    type _DeclarativeIsReal = Assert<Equal<IsAny<DeclarativeKanbanSchema>, false>>;
+
+    // 1. The published union still yields `'kanban'`. `Extract` collapses to
+    //    `never` if the key is ever removed, which fails this pin loudly.
+    type _KeyKept = Assert<Equal<Extract<ComponentType, 'kanban'>, 'kanban'>>;
+
+    // 2. The value no longer claims the declarative authoring face. This is
+    //    the objectui#7645 defect itself; re-pointing the entry turns it red.
+    type _ValueIsNotTheDeclarativeFace = Assert<
+      Equal<Equal<SchemaRegistry['kanban'], DeclarativeKanbanSchema>, false>
+    >;
+
+    // 3. What it DOES assert is true and non-empty: a node tagged `'kanban'`.
+    //    `never` or `unknown` in that slot fails here rather than passing as a
+    //    quieter kind of nothing.
+    type _ValueIsATaggedNode = Assert<Equal<SchemaRegistry['kanban']['type'], 'kanban'>>;
+
+    // 4. Nothing was invalidated by the retreat: the declarative face still
+    //    satisfies the weaker claim, as does the plugin's face (pinned in
+    //    `@object-ui/plugin-kanban`, the only package that can name both).
+    type _DeclarativeStillSatisfiesIt = Assert<
+      DeclarativeKanbanSchema extends SchemaRegistry['kanban'] ? true : false
+    >;
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/types/src/registry.ts
+++ b/packages/types/src/registry.ts
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type { BaseSchema } from './base.js';
+
 import type {
   DivSchema,
   BoxSchema,
@@ -92,7 +94,6 @@ import type {
 } from './navigation.js';
 
 import type {
-  DeclarativeKanbanSchema,
   CalendarViewSchema,
   FilterBuilderSchema,
   CarouselSchema,
@@ -183,14 +184,38 @@ export interface SchemaRegistry {
   'pagination': PaginationSchema;
 
   // Complex
-  // ⚠️ The renderer registered for `'kanban'` (`ObjectKanbanRenderer`, in
-  // `@object-ui/plugin-kanban`) consumes that package's own `KanbanSchema`,
-  // NOT this declarative face. The mismatch is latent — the value side of this
-  // map is reached only through `ComponentType = keyof SchemaRegistry` and
-  // nothing performs an indexed access — and objectui#6172's ruling (option A)
-  // renamed the declarative copy rather than relocating the plugin dialect
-  // into this zero-dependency layer, so the mismatch stays latent-but-named.
-  'kanban': DeclarativeKanbanSchema;
+  // ⚠️ `'kanban'` is the one key whose value this layer cannot state
+  // precisely, so it deliberately states LESS rather than stating it wrongly
+  // (objectui#7645).
+  //
+  // The renderer registered for this key is `ObjectKanbanRenderer` in
+  // `@object-ui/plugin-kanban` (`ComponentRegistry.register('kanban', …)`,
+  // `plugin-kanban/src/index.tsx`), and it consumes THAT package's
+  // `KanbanSchema`. `@object-ui/types` cannot name that type, measured two
+  // ways: importing it is a phantom dependency this package does not declare
+  // (`check:phantom-deps` rejects it by file and pair), and declaring the
+  // dependency would close the cycle `@object-ui/types` →
+  // `@object-ui/plugin-kanban` → `@object-ui/types` — this is the
+  // zero-workspace-dependency bottom layer. objectui#6172's ruling (option A)
+  // kept the plugin's bare names rather than relocating that dialect down
+  // here, so the gap is permanent by decision, not by oversight.
+  //
+  // What this entry asserts is therefore only what this layer can PROVE, and
+  // what BOTH dialects satisfy: a schema node tagged `'kanban'`. It no longer
+  // names `DeclarativeKanbanSchema` — that is the AUTHORING/validation face
+  // (the `'kanban'` arm of `ComplexSchema` → `AnyComponentSchema` →
+  // `safeValidateSchema`, still exported from `./complex.js` and unchanged),
+  // not the type the registered renderer honours. Naming it here made a map
+  // that advertises itself as the Single Source of Truth describe a different
+  // component than the key names.
+  //
+  // ⛔ Do not "restore" a precise type here without moving the renderer's
+  // dialect into a layer this package may depend on. Two compile-time pins
+  // hold the shape: `src/__tests__/schema-registry-kanban-honesty-7645.test.ts`
+  // (the key survives in `keyof`; the value no longer claims the declarative
+  // face) and the same file name under `plugin-kanban/src/__tests__/` (the
+  // renderer's own `KanbanSchema` satisfies what this entry asserts).
+  'kanban': BaseSchema & { type: 'kanban' };
   'calendar-view': CalendarViewSchema;
   'filter-builder': FilterBuilderSchema;
   'carousel': CarouselSchema;

--- a/packages/types/src/registry.ts
+++ b/packages/types/src/registry.ts
@@ -196,18 +196,18 @@ export interface SchemaRegistry {
   // (`check:phantom-deps` rejects it by file and pair), and declaring the
   // dependency would close the cycle `@object-ui/types` →
   // `@object-ui/plugin-kanban` → `@object-ui/types` — this is the
-  // zero-workspace-dependency bottom layer. objectui#6172's ruling (option A)
-  // kept the plugin's bare names rather than relocating that dialect down
-  // here, so the gap is permanent by decision, not by oversight.
+  // zero-workspace-dependency bottom layer. objectui#6172's ruling (option A,
+  // 2026-08-31) kept the plugin's bare names rather than relocating that
+  // dialect down here. objectui#7664's ruling (a) (2026-09-05) reverses that
+  // half: this package's `'kanban'` arm is rewritten to the plugin's shape and
+  // this entry is re-pointed at the declared type — this value is TRANSITIONAL.
   //
-  // What this entry asserts is therefore only what this layer can PROVE, and
-  // what BOTH dialects satisfy: a schema node tagged `'kanban'`. It no longer
-  // names `DeclarativeKanbanSchema` — that is the AUTHORING/validation face
-  // (the `'kanban'` arm of `ComplexSchema` → `AnyComponentSchema` →
-  // `safeValidateSchema`, still exported from `./complex.js` and unchanged),
+  // Until then the entry asserts only what this layer can PROVE, and what BOTH
+  // dialects satisfy: a schema node tagged `'kanban'`. It no longer names
+  // `DeclarativeKanbanSchema` — the AUTHORING/validation face (the `'kanban'`
+  // arm of `ComplexSchema` → `AnyComponentSchema` → `safeValidateSchema`),
   // not the type the registered renderer honours. Naming it here made a map
-  // that advertises itself as the Single Source of Truth describe a different
-  // component than the key names.
+  // that calls itself the Single Source of Truth describe the wrong component.
   //
   // ⛔ Do not "restore" a precise type here without moving the renderer's
   // dialect into a layer this package may depend on. Two compile-time pins


### PR DESCRIPTION
Fixes #7645

`SchemaRegistry` documents itself as *"the Single Source of Truth for component
type lookups"*. Its `'kanban'` entry named `DeclarativeKanbanSchema`, while the
renderer registered for that key is `ObjectKanbanRenderer` in
`@object-ui/plugin-kanban`, which consumes that package's own `KanbanSchema`.
For this one key the map's value did not describe the component the key names.

**Option taken: B — the value stops asserting; the key is untouched.** The
entry is now `BaseSchema & { type: 'kanban' }`: the strongest claim this layer
can prove, and one that is true of *both* dialects.

## Why A was unreachable — three routes, all measured

**A1 — import the honest type.** `check:phantom-deps`, exit 1:

```
❌  1 import(s) are not declared where a consumer would find them (1 distinct package/dependency pair(s)):
      packages/types/src/registry.ts:9:1  [undeclared-runtime]  @object-ui/types imports '@object-ui/plugin-kanban' -> @object-ui/plugin-kanban (type-only)
```

Baseline for that reading, same gate, unmutated tree: `✅  Every in-scope
import is declared by the package that publishes it.` (exit 0). Type-only
imports are not exempt — the gate names the pair explicitly.

**A2 — declare the dependency instead.** Read off the manifests: `@object-ui/types`
has **0** workspace runtime deps, and `@object-ui/plugin-kanban` declares
`@object-ui/types`. Adding the edge closes the cycle
`@object-ui/types -> @object-ui/plugin-kanban -> @object-ui/types`. (Reader
proven live by the same pass returning 7 workspace deps for plugin-kanban.)

**A3 — name a proxy this layer can already reach.** `@objectstack/spec/ui` is a
declared dependency of `@object-ui/types` and does export `ObjectKanbanProps`,
mirroring the same renderer. It is **not** the same type: of the plugin
`KanbanSchema`'s 19 members it shares 11, cannot express 8 (`allowCollapse`,
`cardTemplates`, `className`, `columnWidths`, `limit`, `onCardMove`,
`onQuickAdd`, and the `type` discriminant every other registry value carries),
and adds 2 the plugin does not have (`filter`, `titleField`). Pointing there
swaps one false claim for a differently false one, so it was rejected.

Relocating the plugin dialect into this layer is the remaining route. At the
time of the code commit it was the one objectui#6172's ruling (2026-08-31) had
declined, and the dispatch ruled out widening the published surface for a
latent defect, so it was not taken here. Since then objectui#7664's ruling (a)
(2026-09-05T02:09:40Z) has taken exactly that route — see "The record moved"
below; nothing of it is implemented in this PR.

## Latency re-verified, with a lit control

The card's claim that nothing indexes the value side was re-measured, not
inherited. Repo-wide, excluding `node_modules` and `dist`, `SchemaRegistry[`
returns exactly **1** hit — prose in `.changeset/3965-mint-box-neutral-container.md`,
not a TypeScript indexed access. Control for the query shape, same command,
same file set: `ComponentPropsMap[` returns **39**. An earlier control for this
measurement read zero; it was discarded as a dark instrument and rebuilt rather
than published. Also measured: **0** gate scripts mention `SchemaRegistry`
(control: 36 hits for `packages/types/src` in the same corpus), and the
`@object-ui/types` `ComponentType` has no in-repo consumer but its own
declaration.

## The pins, and proof they are lit

Type-level assertions are erased at runtime, so vitest says nothing about them.
The instruments are `tsc -p packages/types/tsconfig.test.json` and
`tsc -p packages/plugin-kanban/tsconfig.test.json`, both chained off their
packages' `type-check` scripts. Program membership proved with `--listFiles`:
each pin file appears once; the plugin project resolves `@object-ui/types` to
`packages/types/dist/index.d.ts` (0 hits for the source path), so
`@object-ui/types` was rebuilt before every reading on that side.

Three ablation legs, prediction written before each run:

| Leg | Mutation | Predicted | Observed |
|---|---|---|---|
| 2 | restore the defect (`'kanban': DeclarativeKanbanSchema`) | non-zero, exactly 1 error, at `_ValueIsNotTheDeclarativeFace` | exit 2, 1 error, `…test.ts(77,7): error TS2344` — that pin, only that pin |
| 3 | delete the `'kanban'` key | non-zero, several errors incl. `_KeyKept` | exit 2, 5 errors: line 72 (`_KeyKept`) plus TS2339 at 77/83/89 |
| 4 | add a member the plugin face lacks, rebuild `types` | non-zero at `_PluginFaceSatisfiesTheEntry` | exit 2, 1 error, `…test.ts(69,7): error TS2344` |

No prediction missed. Every mutation was proved on disk by anchored
before/after counts **and** `git hash-object` movement off the HEAD blob; every
restore by blob equality **and** an empty `git diff HEAD`. Leg 4's restore leg
also rebuilt and re-checked, confirming the marker left `dist` (1 -> 0) and the
plugin project returned to 0 errors — an unrebuilt restore would have left
every later reading measuring the wrong tree. One earlier attempt at leg 1
mutated only half of its target; the count-based guard caught it, the trap
restored, and it was re-run rather than quietly repeated.

Leg 3 is the one that matters most for the published surface: it is the proof
that `keyof SchemaRegistry` still yields `'kanban'`, and that deleting the key
— which also removes the false claim and leaves every runtime suite green — is
now a loud compile error.

## Verification, at commit `41ff58ff`

Union re-run after the final commit, on a clean tree. Each gate's own verdict
line:

- `check:phantom-deps` — `✅  Every in-scope import is declared by the package that publishes it.`
- `check:control-bytes` — `✅  check-control-bytes: OK (scanned 6255 tracked text file(s); skipped 85 binary).`
- `check:changeset-presence` — `✅  3 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)`
- `check:changeset-no-major` — verdict: no changeset declares a major bump
- `check:doc-types` — `✅  Every documented component type is registered.`
- `check:readme-exports` — `✅  check-readme-exports: OK (… 0 unbuilt …)`
- `check:dist-completeness` — `✓ dist completeness: 12 package(s) complete (1609 emitted files verified)`
- `check:spec-symbols` — `✅  spec symbol derivation: 1344 files scanned against 4959 spec export names`
- `check:node-esm-load`, `check:published-dist`, `check:entry-guard` — exit 0
- `pnpm --filter @object-ui/types run type-check` and the same for
  `@object-ui/plugin-kanban` — exit 0
- `pnpm exec vitest run packages/types/ packages/plugin-kanban/` — 126 files,
  1844 tests passed
- `eslint` on the three touched files — exit 0

`check:readme-exports` first reported `the population COLLAPSED -- this run
proves nothing` (24 of 40 packages unbuilt locally). That is a precondition
failure, not a red: all packages were built and it was re-run, which is the
green quoted above (`0 unbuilt`, 421 self-imports judged, up from 312
unjudgeable).

**Declared narrowing.** `check:sdui-registration-pins` is **not measured** here
— it reads the built console bundle and refuses to judge without one
(`a run with nothing to read has measured nothing`). It is not implicated: the
diff changes no registration. The full repo-wide lint and the remaining gate
farm are left to CI, which runs them unfiltered. Exit codes throughout were
captured by redirect before any pipe.

## Contract review

**Clause-②: yes.** `SchemaRegistry` is published, and this changes the type of
one of its members — a falsifiable contract-semantics claim, not a spelling. It
adds no exported symbol and no key (the diff contains **0** changed `export`
lines), so `keyof SchemaRegistry` and the published `ComponentType` union are
byte-identical; what moves is the value side of one key.
`needs:contract-review` is on both carriers and this stays a **draft** — not
ready, not enqueued.

Semver: `minor`, and this **is a breaking change** for consumers outside this
repository. It ships as `minor` because this repo's version-alignment rule
(AGENTS.md §版本号策略) pins objectui's major to `@objectstack`'s and ships
objectui's own breaking changes as `minor` with the break spelled out in the
changeset body — which, after the contract-review remediation below, it is:
the assignability break for consumers who indexed `SchemaRegistry['kanban']`,
and the silent `any` on member reads.

## Remediation after contract review — commit `3748de9a`

The isolated contract reviewer **REFUSED on the changeset alone** (code and pins
judged sound, bump level correct). Three defects in that one file, each
re-measured here before rewriting — merge-base tree `2ce2612d` and head tree
`41ff58ff`, `@object-ui/types` rebuilt on both, predictions written before each
run, instrument proved to read `packages/types/dist/index.d.ts` (1 hit, 0 for
`src/`) by `--listFiles`:

- **Shared members** (AST census through the TypeScript compiler API, identical
  on both trees since neither source moved): declarative face **7** body
  members, plugin face **19**, shared names **3** — `type`, `columns`,
  `onCardMove`. `onCardMove` is type-identical on both sides (probe
  `_A_OnCardMoveEqual` passes on both trees; only parameter names differ);
  column element types are 6 vs 6 sharing 5. Controls: `DeclarativeKanbanCard`
  read 9, self-intersection read 7, a disjoint pair read 0. The changeset's
  "sharing only the `type` tag" was false and is corrected.
- **Assignability break**: `const s: DeclarativeKanbanSchema = registryValue`
  compiles at base and fires **TS2741** at head (`Property 'columns' is
  missing`). Lit controls fired on both trees: a `GridSchema` value and a
  `number` into the same target, TS2322 each. The changeset now names this as
  a break for consumers who indexed `SchemaRegistry['kanban']`; the bump stays
  `minor` per the repo rule.
- **Silent any-read**: `SchemaRegistry['kanban']['columns']` is
  `DeclarativeKanbanColumn[]` at base and `any` at head (probe pair
  `_C_ColsIsAny` / `_C_ColsIsDecl`, each the other's cross-control — exactly
  one fires per tree); `draggable` likewise. Undeclared keys already read
  `any` at base through the same `BaseSchema` index signature (control passes
  on both trees), so the change is to the declared members. The changeset now
  states the mechanism.

Probe totals matched prediction exactly — 5 errors at head, 6 at base, no
missed prediction. The reviewer's own recorded miss (item 5) reproduced:
`const k: KanbanSchema = registryValue` compiles on **both** trees, and the
reverse (plugin face into the registry value) is TS2322 at base — `columns`
optional vs required — and compiles at head. So the plugin-side pin proves the
tag and nothing narrower; neither the changeset nor this body claims more for
it.

Remediation diff, `git diff --stat 41ff58ff7..3748de9af`:
`.changeset/7645-schema-registry-kanban-honesty.md | 46 ++++++++++++++++++-----`
— 1 file, no source or test file moved. Gates re-run on the committed head
`3748de9a`, each's own verdict line: `check-changeset-no-major` — `✅  No
changeset declares a `major` bump.`; `check-changeset-overwrite` — `✅  No
pre-existing changeset was modified or deleted.`; `check-changeset-presence` —
`✅  3 source file(s) of 2 released package(s) changed, and this change declares
1 changeset(s)`; `check:control-bytes` — `✅  check-control-bytes: OK (scanned
6255 tracked text file(s); skipped 85 binary).`; `check:shell-escape-residue`
— `✅  check-shell-escape-residue: OK`. Session for this remediation:
`https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3`.

## The record moved — round-2 contract review, commit `55a7470e9`

The second isolated review (PR comment 5548793740) reproduced all twelve of the
first review's judgments and graded the code and the `minor` bump correct, then
**REFUSED** on one factual claim that went false while it was being written: the
changeset, the comment above the entry in `registry.ts`, and both pin docblocks
said the types-vs-plugin gap was "permanent by decision". The record:

- **objectui#7664 was ruled (a)** at 2026-09-05T02:09:40Z (comment 5548643216,
  director seat, maintainer verbatim 「同意」, decision batch #41). Under (a) the
  `@object-ui/types` `'kanban'` arm is rewritten to the plugin's shape,
  `@object-ui/plugin-kanban` conforms to that declaration, the
  `DeclarativeKanban*` trio retires under ADR-0049, and `registry.ts` is on the
  execution list. The ruling itself notes that it reverses the "keep both faces"
  half of objectui#6172 (2026-08-31). So this PR's `BaseSchema & { type: 'kanban' }`
  entry is the **transitional** state under that ruling — honest at this commit,
  scheduled to be re-pointed at the declared type — not a permanent one. The
  remediation commit `3748de9af` (02:18:01Z) post-dated the ruling by 8m21s and
  carried the stale phrase. Nothing of (a) is implemented here.
- **objectui#7651 is closed** `not_planned` (ruled B, 2026-09-05T02:09:54Z), not
  "an open maintainer decision".

Commit `55a7470e9` corrects the tense in all four carriers in the tree — the
changeset paragraph, `registry.ts` (comment above the entry only), the types pin
docblock, the plugin pin docblock and its `_StillTwoDialects` comment (the latter
beyond the review's five items: "if these ever converge" is now a scheduled
event, same class) — and this body corrects the two claims above. Every tense
was written after reading the card's current state and its ruling comment.

**Wording only, proved:** the TypeScript token stream (scanner with trivia —
whitespace and comments — dropped) of each of the three `.ts` files is
identical before and after, 496 / 231 / 212 tokens, 0 differing; lit control:
the same instrument on a scratch copy with `'kanban'` spelled `'kanbam'` on the
type line reports exactly one differing token. `registry.ts:218` is
byte-identical (sha256 `7fbfa7bd…` before and after) and every code file keeps
its line count (228 / 94 / 84), so the pins' cited lines (69/72/77/83/89) are
where the prior evidence cites them. Blob ids moved for all four files, so the
comparison was of changed files. Phrase census after the edit, predictions
written first: "permanent by decision" 0 (from 3), "open maintainer decision"
0 (from 1), `7664` 5 (from 0); one prediction missed — the lit control for the
census (`TRANSITIONAL`) read 2 where 3 was predicted (the plugin pin says
"schedules their convergence" and the changeset uses lowercase).

**Both pins still read exit 0 through their declared instruments** on the
committed head `55a7470e9` (dirty-files 0), `@object-ui/types` rebuilt first:
`tsc -p packages/types/tsconfig.test.json --listFiles` — exit 0, 0 errors, pin
file 1, `registry.ts` 1; `tsc -p packages/plugin-kanban/tsconfig.test.json
--listFiles` — exit 0, 0 errors, pin file 1, `packages/types/dist/index.d.ts`
1, `packages/types/src/` 0. Lit control per instrument, prediction first: a
scratch `__lit7645__.test.ts` asserting `Equal` of 1 and 2 dropped into each
`__tests__` dir — exit 2, exactly 1 error, `error TS2344` at `(3,24)` in that
file, both projects; removed, `git status` back to the four edited files only.

Gate union on `55a7470e9`, each gate's own verdict line: `check:control-bytes`
— `✅  check-control-bytes: OK (scanned 6255 tracked text file(s); skipped 85 binary).`;
`check-changeset-presence` — `✅  3 source file(s) of 2 released package(s)
changed, and this change declares 1 changeset(s)`; `check-changeset-no-major` —
`` ✅  No changeset declares a `major` bump. ``; `check-changeset-overwrite` — `✅
No pre-existing changeset was modified or deleted.`; `check:shell-escape-residue`
— `✅  check-shell-escape-residue: OK`; vitest on the two pin files — `Test Files
2 passed (2)`; eslint on the three `.ts` files — exit 0. `check:phantom-deps` is
not re-run: the import token streams are unchanged (declared narrowing). Exit
codes captured by redirect before any pipe.

For the PM, not edited here: #7664's own sequencing note calls PR #7662
"already merged per the card"; it is open and draft.

## Scope

Untouched, as fenced: `packages/plugin-kanban`'s own `KanbanSchema` (the face
objectui#6172 kept — the new file there only *reads* it), `KanbanSchema.data`
(objectui#7651 — ruled B and closed as `not_planned` at 2026-09-05T02:09:54Z:
no record-source ladder, `data` stays a raw-row input; nothing here reads it), `scripts/check-doc-links.mjs` and
`scripts/github-slug.mjs` (#7644), and the `getDataConfig` producers (#7632).

The card also asks whether the one-authority family rule should be extended so
that *every* `SchemaRegistry` value must be the type its registered renderer
honours. That is not answered here: this PR settles the `'kanban'` key, and the
generalization lives on as objectui#7665 (open, `pm:queue` when this body was
written), which takes the cheap option C — narrow the docblock's promise to the
key set — while the sweep of the other keys stays unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3