### PR TITLE
fix(plugin-markdown): keep code-span content out of extractToc's HTML strip (objectui#7658)

### DIFF
--- a/.changeset/7658-toc-code-span-anchor-parity.md
+++ b/.changeset/7658-toc-code-span-anchor-parity.md
@@ -1,0 +1,29 @@
+---
+'@object-ui/plugin-markdown': patch
+---
+
+Fix `extractToc` deleting tag-shaped text that lives INSIDE an inline code span,
+so its `#id` links resolve to the heading they name again (objectui#7658).
+
+`stripInline()` applied its rules in sequence: the inline-code rule unwrapped
+`` `objectui add <component>` `` to `objectui add <component>`, and the raw-HTML
+rule that ran next over that same text deleted `<component>` as if it were
+markup. The slug became `objectui-add` while `rehype-slug` — which slugs the
+RENDERED heading, where a code span's content is a literal text value — put
+`objectui-add-component` on the anchor. The TOC entry rendered, was clickable,
+and silently went nowhere. The same sequencing let the emphasis rules eat the
+underscores out of `` `a_b_c` `` and the link rule rewrite `` `[x](y)` ``.
+
+Code spans are now lifted out before any other inline rule runs and restored
+verbatim at the end, so nothing reaches inside one. The raw-HTML rule is
+unchanged and still strips genuine markup — `remark-rehype` runs without
+`allowDangerousHtml`, so the renderer likewise drops raw html nodes and keeps the
+text they wrapped. Link labels that are code spans still collapse (`` [`getData`](/api) ``
+→ `getData`), because the placeholder stays ordinary text to the link rule.
+
+Seven live headings in this repo's own docs were affected
+(`content/docs/utilities/cli.mdx`, `content/docs/utilities/runner.mdx`,
+`packages/cli/README.md`). Pinned against the real render pipeline rather than a
+second derivation of the slug rules: the new test renders each heading through
+`MarkdownImpl` and compares `extractToc`'s id to the `id` attribute
+`rehype-slug` actually emitted.

--- a/packages/plugin-markdown/src/toc-anchor-parity.test.tsx
+++ b/packages/plugin-markdown/src/toc-anchor-parity.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#7658 — `extractToc`'s ids must be the ids `rehype-slug` actually
+ * puts on the RENDERED headings, because that is the only thing a `#id` link
+ * can resolve to.
+ *
+ * The truth source here is the real render pipeline (`MarkdownImpl` — the same
+ * remark/rehype chain this plugin ships), NOT a second derivation of the slug
+ * rules. Re-deriving them would only prove the two derivations agree; reading
+ * the rendered `id` attribute proves the anchor exists.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import * as React from 'react';
+import MarkdownImpl from './MarkdownImpl';
+import { extractToc } from './toc';
+
+/** The ids `rehype-slug` put on the rendered headings, in document order. */
+function renderedHeadingIds(markdown: string): string[] {
+  const html = renderToStaticMarkup(React.createElement(MarkdownImpl, { content: markdown }));
+  return [...html.matchAll(/<h[1-6]\b[^>]*\bid="([^"]*)"/g)].map((m) => m[1]);
+}
+
+/** Every heading `extractToc` sees, in document order — h1–h6, not just the default h2–h3. */
+function tocIds(markdown: string): string[] {
+  return extractToc(markdown, { minDepth: 1, maxDepth: 6 }).map((item) => item.id);
+}
+
+/**
+ * The three heading shapes this repository's own docs carry that hit the
+ * defect: tag-shaped text inside a code span. In the DOM it is literal text
+ * (a code span's content is a text value), so it is part of the anchor.
+ */
+const LIVE_SHAPES: ReadonlyArray<{ md: string; id: string; where: string }> = [
+  {
+    md: '### `objectui generate <type> <name>` (alias `g`)',
+    id: 'objectui-generate-type-name-alias-g',
+    where: 'content/docs/utilities/cli.mdx:136, packages/cli/README.md:108',
+  },
+  {
+    md: '### `objectui add <component>`',
+    id: 'objectui-add-component',
+    where: 'content/docs/utilities/cli.mdx:220, packages/cli/README.md:112',
+  },
+  {
+    md: '#### Serving metadata over HTTP (`?api=<base>`)',
+    id: 'serving-metadata-over-http-apibase',
+    where: 'content/docs/utilities/runner.mdx:106',
+  },
+];
+
+describe('extractToc ↔ rendered-anchor parity (objectui#7658)', () => {
+  for (const { md, id, where } of LIVE_SHAPES) {
+    it(`resolves the anchor for ${md} (${where})`, () => {
+      const source = `${md}\n`;
+      // Reading the truth source is itself the lit control: an empty list here
+      // means the harness rendered nothing, and every comparison below it would
+      // be a vacuous pass.
+      expect(renderedHeadingIds(source)).toEqual([id]);
+      expect(tocIds(source)).toEqual([id]);
+    });
+  }
+
+  it('control: agrees on the inline shapes that never had the defect', () => {
+    // Lit control — these ids are non-empty and already matched before the fix,
+    // so a run in which they read `[]` (or drifted) is a broken instrument
+    // rather than evidence about the defect.
+    const source = '# Title\n\n## First Section\n\n## The **overlay** `rule` and a [link](/x)\n';
+    const rendered = renderedHeadingIds(source);
+    expect(rendered).toEqual(['title', 'first-section', 'the-overlay-rule-and-a-link']);
+    expect(tocIds(source)).toEqual(rendered);
+  });
+
+  it('still drops genuine raw HTML, exactly as the renderer does', () => {
+    // The raw-HTML rule is not being removed, only kept off code spans:
+    // `remark-rehype` drops raw html nodes (no `allowDangerousHtml`), so the
+    // rendered heading keeps the wrapped text and not the tags.
+    const source = '## A <b>bold</b> tag\n';
+    expect(tocIds(source)).toEqual(renderedHeadingIds(source));
+  });
+
+  it('keeps duplicate-suffix alignment across affected headings', () => {
+    // The `-1/-2` suffixes only line up if EVERY heading slugs the same text
+    // the renderer slugs — one wrong id upstream shifts every later anchor.
+    const source =
+      '# `objectui add <component>`\n\n' +
+      '## `objectui add <component>`\n\n' +
+      '## `objectui add <component>`\n';
+    const rendered = renderedHeadingIds(source);
+    expect(rendered).toEqual(['objectui-add-component', 'objectui-add-component-1', 'objectui-add-component-2']);
+    expect(tocIds(source)).toEqual(rendered);
+  });
+
+  it('keeps a code span literal against every other inline rule', () => {
+    // Markdown inside a code span is not markdown — the renderer emits the
+    // bytes verbatim, so no inline rule may reach inside one.
+    const source = '## `a_b_c` and `**not bold**` and `[x](y)`\n';
+    expect(tocIds(source)).toEqual(renderedHeadingIds(source));
+  });
+
+  it('still collapses a link whose label is a code span', () => {
+    // The masking must stay VISIBLE to the link rule as ordinary text,
+    // otherwise `[`code`](url)` stops collapsing to its label.
+    const source = '## Read [`getData`](/api) now\n';
+    expect(tocIds(source)).toEqual(renderedHeadingIds(source));
+  });
+});

--- a/packages/plugin-markdown/src/toc.ts
+++ b/packages/plugin-markdown/src/toc.ts
@@ -17,15 +17,51 @@ export interface TocItem {
   id: string
 }
 
-/** Strip the inline-markdown wrappers so the text matches `rehype-slug`'s. */
+/**
+ * A code span's slot while the other inline rules run: private-use sentinels
+ * around its index in `codeSpans`.
+ *
+ * Inert to the emphasis and raw-HTML rules (it carries no `*`, `_` or angle
+ * bracket), but still ORDINARY TEXT to the image and link rules — which is
+ * what keeps ``[`getData`](/api)`` collapsing to its label, exactly as the
+ * renderer does.
+ */
+const SLOT_OPEN = "\uE000"
+const SLOT_CLOSE = "\uE001"
+const SLOT_RE = /\uE000(\d+)\uE001/g
+const SENTINEL_RE = /[\uE000\uE001]/g
+
+/**
+ * Strip the inline-markdown wrappers so the text matches `rehype-slug`'s.
+ *
+ * Code spans are lifted out BEFORE any other rule and put back verbatim at the
+ * end, because markdown inside a code span is not markdown: `rehype-slug` slugs
+ * the rendered heading's flattened text, and a code span contributes its content
+ * as a literal text value inside `<code>`. Rules run over already-unwrapped
+ * code-span text therefore delete characters the anchor is built from — the
+ * raw-HTML rule ate `<type>` out of `` `objectui generate <type> <name>` `` and
+ * the emphasis rules ate the underscores out of `` `a_b_c` `` — so the TOC's
+ * `#id` named a heading anchor that does not exist (objectui#7658).
+ *
+ * The raw-HTML rule itself stays: `remark-rehype` runs without
+ * `allowDangerousHtml`, so it drops raw html nodes and keeps the text they
+ * wrapped, which is what removing the tags reproduces. Sentinels present in the
+ * source are dropped first, so no input can forge a slot.
+ */
 function stripInline(s: string): string {
+  const codeSpans: string[] = []
   return s
+    .replace(SENTINEL_RE, "") // no input can forge a slot
+    .replace(/`([^`]+)`/g, (_match, content: string) => {
+      codeSpans.push(content)
+      return `${SLOT_OPEN}${codeSpans.length - 1}${SLOT_CLOSE}`
+    }) // inline code → an opaque slot
     .replace(/!\[[^\]]*\]\([^)]*\)/g, "") // images
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links → text
-    .replace(/`([^`]+)`/g, "$1") // inline code
     .replace(/(\*\*|__)(.*?)\1/g, "$2") // bold
     .replace(/(\*|_)(.*?)\1/g, "$2") // italic
     .replace(/<[^>]+>/g, "") // raw html
+    .replace(SLOT_RE, (_match, index: string) => codeSpans[Number(index)]) // code spans, verbatim
     .trim()
 }
 


### PR DESCRIPTION
Fixes #7658

> **A note on spelling in this body.** Every angle-bracket placeholder below is written as a bare uppercase word (`TYPE`, `NAME`, `COMPONENT`, `BASE`). GitHub's body sanitizer deletes tag-shaped fragments on save, and neither backticks nor fenced blocks protect them (AGENTS.md, "GitHub mutates body BYTES") — a table written to show angle brackets being eaten would itself have them eaten, and would render as if nothing were wrong.

## The defect

`stripInline()` in `packages/plugin-markdown/src/toc.ts` applied its rules in sequence: the inline-code rule unwrapped a code span, and the raw-HTML rule that ran **next, over that same text** deleted tag-shaped text the code span had contained. In the rendered DOM that text is literal — `rehype-slug` slugs the heading's flattened value and a code span's content is a text value — so the id `extractToc` produced named an anchor that does not exist. A TOC entry that renders, is clickable, and silently does nothing.

Measured against the real render pipeline, before the fix:

| heading (placeholders as words) | `extractToc` id | id `rehype-slug` puts on the heading |
| --- | --- | --- |
| `objectui generate TYPE NAME` (alias `g`) | `objectui-generate---alias-g` | `objectui-generate-type-name-alias-g` |
| `objectui add COMPONENT` | `objectui-add` | `objectui-add-component` |
| Serving metadata over HTTP (`?api=BASE`) | `serving-metadata-over-http-api` | `serving-metadata-over-http-apibase` |

Seven live headings in this repo's own docs: `content/docs/utilities/cli.mdx` (3), `content/docs/utilities/runner.mdx` (1), `packages/cli/README.md` (3).

The same sequencing had two more consequences the card did not name, both found by the same measurement and both repaired here: the emphasis rules ate the underscores out of a code span (`a_b_c` slugged as `abc`), and the link rule rewrote a code span that documents link syntax.

## The fix

Code spans are lifted into an opaque slot **before any other inline rule** and restored verbatim at the end, so nothing reaches inside one. This is the shape the card listed as "tokenising code spans before any other inline rule", and the same approach PR #7657 takes for the gate.

Two properties the slot has to hold at once, and both are pinned:

- **Inert to the emphasis and raw-HTML rules** — it carries no `*`, `_` or angle bracket, so those rules cannot see into a code span any more.
- **Still ordinary text to the image and link rules** — so a link whose label is a code span keeps collapsing to its label, exactly as the renderer does. Splitting the string on code spans instead of masking would have broken that, since the link rule has to match across the span.

**The raw-HTML rule is unchanged and still strips genuine markup.** That was verified rather than assumed: `remark-rehype` runs without `allowDangerousHtml`, so it drops raw html nodes and keeps the text they wrapped — a heading with a bold tag around a word renders as `a-bold-tag`, which removing the tags reproduces exactly. This settles the second question the card left open ("a heading containing genuine raw HTML flattens to its raw text under mdast, not to nothing"): for **this** pipeline it flattens to the wrapped text, and the existing rule already matches it.

The private-use sentinels are written as escape spellings in the source, so the file carries no raw non-ASCII byte; any sentinel present in the input is dropped first, so no input can forge a slot.

## Truth source

`scripts/github-slug.mjs` from PR #7657 is **not on this base** (checked at `8e501cb9`, the merge-base) so nothing here depends on it, and neither it nor `scripts/check-doc-links.mjs` is touched. As the brief directed, this package uses the real `github-slugger` it already depends on.

The pin does not re-derive the slug rules at all — re-deriving them would only prove two derivations agree. `packages/plugin-markdown/src/toc-anchor-parity.test.tsx` renders each heading through `MarkdownImpl` (the real remark/rehype chain this plugin ships) and compares `extractToc`'s id to the `id` attribute `rehype-slug` actually emitted. Reading the rendered id is what proves the anchor exists.

## Evidence

All runs at `d3ba962a`, through the shared verify lock (slot `issue-7658`); wall-clock figures from it are shared-box readings, not idle-box.

**Red first.** The new pin was run before the repair existed: **5 failed / 3 passed** — the three live shapes, the duplicate-suffix case, and the code-span-literal case. Predicted 5 failures before running; observed 5. The three rendered ids in the table above came out of that run, confirming the card's measurements against the real renderer.

**Green.** `vitest run packages/plugin-markdown/` — `Test Files 5 passed (5)`, `Tests 39 passed (39)`. Union at `d3ba962a` including the console docs-portal consumer: `Test Files 6 passed (6)`, `Tests 45 passed (45)`, `VITEST_EXIT=0`.

**Non-vacuity (ablation).** Predicted in writing before the leg: red with exactly 5 failures / 3 passes, then 8/8 after restore. Observed exactly that.

- Mutation proven on disk before the run: blob moved off the HEAD blob (`b0eae89f` to `1d49f884`), anchored grep counts `SLOT_OPEN` 2 to 0 and the old one-line code rule 0 to 1. The leg refuses to run if any of those checks disagrees.
- Ablated: `Tests 5 failed | 3 passed (8)`, `ABLATED_VITEST_EXIT=1`.
- Restored via `git checkout HEAD -- ABSOLUTE_PATH` (never a bare checkout) under an `EXIT INT TERM` trap holding absolute paths from `git rev-parse --show-toplevel`; verified by blob equality back to `b0eae89f`, empty `git diff HEAD`, and `SLOT_OPEN` back to 2.
- No rebuild leg is needed and none is claimed: the pin imports `./toc` and `./MarkdownImpl` by relative path from source, so no `dist` sits between the mutation and the assertion.

**Type-check / lint.** `pnpm --filter @object-ui/plugin-markdown run type-check` — `TYPECHECK_EXIT=0`. Package lint — `PKG_LINT_EXIT=0` (7 pre-existing warnings, 0 errors). Repo-wide `eslint . --no-inline-config --format json`: 4259 files linted, and both changed files report 0 errors and 0 warnings; the 93 errors in that run are pre-existing across 77 other files, none of them touched here. No narrowing to declare — the full population was linted.

**Gates**, exit codes captured by redirect before any pipe, each quoted from the gate's own verdict line: `check:control-bytes` OK (6254 tracked text files); `check:phantom-deps` OK; `check:self-import` OK; `check:esm-specifiers` OK; `check:vi-mock-specifiers` OK; `check:vi-mock-inherit` OK; `check:shell-escape-residue` OK; `check:published-tsconfig-exclude` OK; `check:side-effects-array` OK; `check:entry-guard` OK; `check:doc-fences` OK; `check:published-dist` OK; `check:dist-completeness` OK.

`check:readme-exports` first reported `PRECONDITION NOT MET` — "the population COLLAPSED, this run proves nothing", 28 packages unbuilt. Recorded as NOT MEASURED, not as a pass and not as a red; the workspace was then built (39/39 turbo tasks) and it was re-run: OK, with a lit population — 37 of 40 packages read, 52 keys compared both ways.

Changeset gates: `check-changeset-presence` OK — "2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"; `check-changeset-no-major` OK; `check-changeset-overwrite` OK. `skip-changeset` is not applied.

## Clause 2 determination: no contract review needed

`extractToc`'s signature, its `opts` shape and the `TocItem` interface are all byte-identical to before; nothing is added to or withdrawn from the package's exports, and no schema key is added, removed or re-typed. The change is entirely inside a private module-scoped helper, and what moves is the **value** of an id that was measurably wrong. Consumers that relied on the broken id would have been relying on an anchor that does not exist. So this is a consumer-side bug fix and can land through the merge queue; `needs:contract-review` is not applied to either carrier.

The visible `text` field does change for affected headings — it now keeps the code span's content, which is what the heading actually reads. Its only consumer, `apps/console/src/pages/DocPage.tsx`, renders it as React text (no `dangerouslySetInnerHTML` anywhere in that file), so the restored characters are escaped by React and cannot become markup.

## Adjacent gaps: measured and filed, not repaired here

A corpus sweep was run to check whether this change left anything behind — every file in `content/docs` plus every `packages/*/README.md` rendered through `MarkdownImpl` and compared id-by-id with `extractToc`. **223 files, 2941 rendered headings** (a lit population, not a zero reading); **5 files still diverge**, in two classes, neither of them this card's defect class. Per the scope fence they are measured and filed rather than repaired here:

- **objectui#7666** — `extractToc` lists a heading the renderer never emits, when the heading sits on the line right after a JSX/raw-HTML block with no blank line. 4 live files, all `content/docs/fields/*.mdx`.
- **objectui#7667** — the emphasis rules eat intraword underscores, so `NON_GRID_ROW_CEILING` slugs as `nongridrow_ceiling` while the anchor reads `non_grid_row_ceiling`. 1 live instance, `packages/react/README.md:224`. That card also records setext headings being invisible to `extractToc`, with zero live instances measured.

Both were dedup-searched first over all 383 open issues in this repo (repo-scoped REST list plus local grep, after a repo-scoped REST read returned HTTP 200), with a lit control: the term `extractToc` returns objectui#7658, so the instrument was demonstrably not dark. Neither card is assigned and neither carries labels; grading is the triage seat's.

Left untouched per the scope fence: `scripts/check-doc-links.mjs`, `scripts/github-slug.mjs`, `scripts/__tests__/check-doc-links.test.ts` (PR #7657's territory), the `getDataConfig` producers, and `packages/types/src/registry.ts` / `complex.ts`.

Generated by Claude Code in session `https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3` (a seat-level id, not a per-change one), dispatched by the `domain:ui` PM seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3


---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_