### PR TITLE
fix(plugin-markdown): teach extractToc's emphasis rules CommonMark's flanking rule (objectui#7667)

### DIFF
--- a/.changeset/7667-toc-emphasis-flanking.md
+++ b/.changeset/7667-toc-emphasis-flanking.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/plugin-markdown': patch
+---
+
+Fix `extractToc` eating the underscores out of a `SCREAMING_SNAKE` heading, so
+its `#id` links resolve to the heading they name again (objectui#7667).
+
+`stripInline()` ended with two hand-rolled emphasis rules that gave `*` and `_`
+one shared regex — `(\*\*|__)(.*?)\1` and `(\*|_)(.*?)\1`. Neither knew
+CommonMark's flanking rule, under which a `_` run INSIDE a word opens nothing:
+it is both left- and right-flanking with no adjacent punctuation, so it may
+neither open nor close emphasis. The renderer obeys that and keeps the
+underscores; the shared rule paired the first two underscores of
+`### NON_GRID_ROW_CEILING` and ate `GRID`, then resumed and ate `ROW`. The TOC
+said `nongridrow_ceiling` while `rehype-slug` put `non_grid_row_ceiling` on the
+anchor, so the entry rendered, was clickable, and silently went nowhere.
+
+The underscore form is now its own flanking-aware rule and the asterisk rules
+are left alone, because only `_` carries the intraword exemption — giving `*`
+the same one would break `a*b*c`, which the renderer really does emphasise.
+Underscore runs are matched whole (`(?<!_)` / `(?!_)`), which is what keeps
+`x__init__y` literal, and a matched pair is dropped at whatever length it has,
+since it contributes no characters to the rendered text however it nests.
+
+The one-underscore case is a REGRESSION pin, not a repair: `## the snake_case
+name` was already correct — a lone underscore has nothing to pair with, which
+is why this went unnoticed for so long — and it still slugs
+`the-snake_case-name`. It takes two or more underscores in one heading for the
+old italic rule to find a pair.
+
+One live heading in this repository's own docs was affected
+(`packages/react/README.md:224`). Measured, not derived: the corpus sweep over
+`content/docs/**` plus every `packages/*/README.md` — 223 files, 2941 rendered
+headings — goes from 5 divergent files to 4, and the 4 that remain are a
+different, already-filed defect (objectui#7666, a heading `extractToc` lists
+that the renderer never emits under a JSX block). Pinned against the real
+render pipeline rather than a second derivation of the flanking rule: each
+heading is rendered through `MarkdownImpl` and `extractToc`'s id compared to
+the `id` attribute `rehype-slug` actually emitted.

--- a/packages/plugin-markdown/src/toc-anchor-parity.test.tsx
+++ b/packages/plugin-markdown/src/toc-anchor-parity.test.tsx
@@ -111,3 +111,99 @@ describe('extractToc ↔ rendered-anchor parity (objectui#7658)', () => {
     expect(tocIds(source)).toEqual(renderedHeadingIds(source));
   });
 });
+
+/**
+ * objectui#7667 — the emphasis rules and CommonMark's FLANKING rule.
+ *
+ * `*` and `_` are not interchangeable. `*` opens emphasis anywhere, including
+ * inside a word; a `_` run inside a word opens nothing, because it is both
+ * left- and right-flanking with no adjacent punctuation and CommonMark lets
+ * such a run neither open nor close. The renderer obeys that and keeps the
+ * underscores, so the ids only agree if `stripInline` does too.
+ *
+ * Same truth source as above: the `id` the real chain puts on the rendered
+ * heading, never a second derivation of the flanking rule.
+ */
+describe('extractToc ↔ rendered-anchor parity, emphasis flanking (objectui#7667)', () => {
+  /** Asserts parity AND that the shared expectation is the id named here. */
+  const bothAgree = (source: string, id: string) => {
+    // Reading the renderer is the lit control: `[]` here means the harness
+    // rendered nothing and the comparison below it would be vacuous.
+    expect(renderedHeadingIds(source)).toEqual([id]);
+    expect(tocIds(source)).toEqual([id]);
+  };
+
+  it('resolves the anchor for ### NON_GRID_ROW_CEILING (packages/react/README.md:224)', () => {
+    // The live instance. Before the fix the TOC said `nongridrow_ceiling`:
+    // the italic rule paired the 1st and 2nd underscores and ate `GRID`, then
+    // resumed past them and ate `ROW` — an id no anchor on the page carries.
+    bothAgree('### NON_GRID_ROW_CEILING\n', 'non_grid_row_ceiling');
+  });
+
+  it('leaves the ONE-underscore boundary exactly where it was', () => {
+    // Why this went unnoticed: a lone underscore has nothing to pair with, so
+    // ordinary `snake_case` prose was already correct. The fix must not move
+    // it — this case is a regression pin, not a repair.
+    bothAgree('## the snake_case name\n', 'the-snake_case-name');
+  });
+
+  it('keeps every intraword underscore run literal, whatever its length', () => {
+    for (const [md, id] of [
+      ['## A_B_C_D', 'a_b_c_d'], // 3 runs, so the naive rule paired two of them
+      ['## snake_case_word', 'snake_case_word'],
+      ['## MAX_ROWS vs MIN_ROWS', 'max_rows-vs-min_rows'],
+      ['## file_name.ts and other_name.ts', 'file_namets-and-other_namets'],
+      ['## trailing_underscore_', 'trailing_underscore_'], // nothing opened, so the closer stays
+      ['## x__init__y', 'x__init__y'], // a `__` run is intraword too
+    ] as const) {
+      bothAgree(`${md}\n`, id);
+    }
+  });
+
+  it('still strips underscore emphasis that CommonMark really opens', () => {
+    // The intraword exemption is not "underscores are inert" — a run flanked
+    // by whitespace or punctuation opens and closes exactly as before.
+    for (const [md, id] of [
+      ['## _em_ leading', 'em-leading'],
+      ['## __bold__ leading', 'bold-leading'],
+      ['## a _b_ c', 'a-b-c'],
+      ['## a __b__ c', 'a-b-c'],
+      ['## __init__', 'init'], // dunder at word boundaries DOES pair
+      ['## _leading and trailing_', 'leading-and-trailing'],
+      ['## _a_b_c_', 'a_b_c'], // outer runs pair; the inner two are intraword
+    ] as const) {
+      bothAgree(`${md}\n`, id);
+    }
+  });
+
+  it('leaves the asterisk forms alone — only `_` carries the exemption', () => {
+    // The counter-direction: a fix that gave `*` the same intraword exemption
+    // would be wrong here, because `*` opens emphasis inside a word.
+    for (const [md, id] of [
+      ['## *em* asterisk', 'em-asterisk'],
+      ['## **bold** asterisk', 'bold-asterisk'],
+      ['## a*b*c intraword asterisk', 'abc-intraword-asterisk'],
+      ['## a**b**c intraword asterisk bold', 'abc-intraword-asterisk-bold'],
+      ['## *a_b_c*', 'a_b_c'], // asterisk emphasis wrapping intraword underscores
+    ] as const) {
+      bothAgree(`${md}\n`, id);
+    }
+  });
+
+  it('agrees when the two markers meet in one heading', () => {
+    for (const [md, id] of [
+      ['## SOME_CONST and *em*', 'some_const-and-em'],
+      ['## snake_case and *em* mixed', 'snake_case-and-em-mixed'],
+      ['## snake_case *and* more_words', 'snake_case-and-more_words'],
+    ] as const) {
+      bothAgree(`${md}\n`, id);
+    }
+  });
+
+  it('control: a heading with no emphasis marker at all is untouched', () => {
+    // Lit control — a non-empty id that neither the old nor the new rule can
+    // move. A run in which this reads `[]` or drifts is a broken instrument
+    // rather than evidence about the flanking rule.
+    bothAgree('## Plain heading text\n', 'plain-heading-text');
+  });
+});

--- a/packages/plugin-markdown/src/toc.ts
+++ b/packages/plugin-markdown/src/toc.ts
@@ -32,6 +32,41 @@ const SLOT_RE = /\uE000(\d+)\uE001/g
 const SENTINEL_RE = /[\uE000\uE001]/g
 
 /**
+ * A matched pair of `_` delimiter runs, under CommonMark's FLANKING rule.
+ *
+ * `*` and `_` used to share one regex, and that is the bug: `*` opens emphasis
+ * anywhere, including inside a word, but a `_` run INSIDE a word opens nothing.
+ * It is both left- and right-flanking with no adjacent punctuation, and
+ * CommonMark lets such a run neither open nor close. The renderer obeys that
+ * and keeps the underscores, so `### NON_GRID_ROW_CEILING` is slugged
+ * `non_grid_row_ceiling`; the shared rule paired the first two underscores and
+ * ate `GRID`, then resumed and ate `ROW`, yielding `nongridrow_ceiling` — a
+ * `#id` naming an anchor the page does not carry (objectui#7667).
+ *
+ * Specialised to `_`, CommonMark's can-open / can-close conditions each reduce
+ * to one boundary test on either side of the whole RUN:
+ *
+ *   open  ⟺ preceded by start-of-text, whitespace or punctuation
+ *            AND followed by a non-whitespace character
+ *   close ⟺ followed by end-of-text, whitespace or punctuation
+ *            AND preceded by a non-whitespace character
+ *
+ * so `[^\s\p{P}\p{S}]` — neither Unicode whitespace nor CommonMark's Unicode
+ * punctuation (categories P and S) — is the character class both lookarounds
+ * negate. `(?<!_)` / `(?!_)` anchor each match to a WHOLE run, which is what
+ * keeps `x__init__y` literal instead of pairing that run's inner underscores.
+ * A run is consumed at whatever length it has, because a matched pair
+ * contributes no characters to the rendered text however it nests
+ * (`___x___` → `<em><strong>x</strong></em>` → `x`).
+ *
+ * Only the underscore form is flanking-aware: the asterisk rules above it are
+ * unchanged, since giving `*` the same exemption would break `a*b*c`, which
+ * the renderer really does emphasise.
+ */
+const UNDERSCORE_EMPHASIS_RE =
+  /(?<![^\s\p{P}\p{S}])(?<!_)(_+)(?!\s)(.+?)(?<!\s)(_+)(?!_)(?![^\s\p{P}\p{S}])/gu
+
+/**
  * Strip the inline-markdown wrappers so the text matches `rehype-slug`'s.
  *
  * Code spans are lifted out BEFORE any other rule and put back verbatim at the
@@ -58,8 +93,9 @@ function stripInline(s: string): string {
     }) // inline code → an opaque slot
     .replace(/!\[[^\]]*\]\([^)]*\)/g, "") // images
     .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links → text
-    .replace(/(\*\*|__)(.*?)\1/g, "$2") // bold
-    .replace(/(\*|_)(.*?)\1/g, "$2") // italic
+    .replace(/\*\*(.*?)\*\*/g, "$1") // bold, asterisk form
+    .replace(/\*(.*?)\*/g, "$1") // italic, asterisk form
+    .replace(UNDERSCORE_EMPHASIS_RE, "$2") // emphasis, underscore form
     .replace(/<[^>]+>/g, "") // raw html
     .replace(SLOT_RE, (_match, index: string) => codeSpans[Number(index)]) // code spans, verbatim
     .trim()


### PR DESCRIPTION
Fixes #7667

`extractToc`'s ids must be the ids `rehype-slug` actually puts on the rendered
headings, because that is the only thing a `#id` link can resolve to. One
shape in this repository's own docs did not qualify.

## What was wrong

`stripInline()` ended with two hand-rolled emphasis rules that gave `*` and `_`
a single shared regex:

```
.replace(/(\*\*|__)(.*?)\1/g, "$2")   // bold
.replace(/(\*|_)(.*?)\1/g, "$2")      // italic
```

Neither knew CommonMark's flanking rule, under which a `_` run **inside a word**
opens nothing — it is both left- and right-flanking with no adjacent
punctuation, so it may neither open nor close emphasis. The renderer obeys that
and keeps the underscores. The shared rule paired the first two underscores of
`### NON_GRID_ROW_CEILING` and ate `GRID`, then resumed past them and ate `ROW`:

| heading | `extractToc` id | id `rehype-slug` emits |
|---|---|---|
| `### NON_GRID_ROW_CEILING` | `nongridrow_ceiling` | `non_grid_row_ceiling` |

The TOC entry rendered, was clickable, and silently went nowhere. Live
instance: `packages/react/README.md:224`.

## The fix

The underscore form becomes its own flanking-aware rule; the asterisk rules are
left byte-identical, because **only `_` carries the intraword exemption** —
giving `*` the same one would break `a*b*c`, which the renderer really does
emphasise. That counter-direction is pinned too.

Specialised to `_`, CommonMark's can-open / can-close conditions each reduce to
one boundary test on either side of the whole delimiter **run**, which is what
the new regex spells:

```
open  ⟺ preceded by start-of-text, whitespace or punctuation
         AND followed by a non-whitespace character
close ⟺ followed by end-of-text, whitespace or punctuation
         AND preceded by a non-whitespace character
```

A negative lookbehind and lookahead for one more underscore anchor each match
to a whole run, which keeps `x__init__y` literal instead of pairing that run's
inner underscores. A matched pair is
dropped at whatever length it has, because it contributes no characters to the
rendered text however it nests (`___x___` renders `x`).

**The one-underscore case is a regression pin, not a repair.** `## the
snake_case name` was already correct — a lone underscore has nothing to pair
with, which is exactly why this went unnoticed — and it still slugs
`the-snake_case-name`. It takes two or more underscores in one heading for the
old italic rule to find a pair.

## Evidence

Truth source throughout is the real render pipeline, never a second derivation
of the flanking rule: each heading is rendered through `MarkdownImpl` and
`extractToc`'s id compared to the `id` attribute `rehype-slug` actually
emitted. Every measurement below carries a lit control.

**Red first.** The new pins were written and run against unmodified `toc.ts`.
Predicted in writing beforehand: 4 of the 7 new tests red. Observed: exactly
those 4, at exactly the predicted cases.

```
× resolves the anchor for ### NON_GRID_ROW_CEILING (packages/react/README.md:224)
    expected [ 'nongridrow_ceiling' ] to deeply equal [ 'non_grid_row_ceiling' ]
× keeps every intraword underscore run literal, whatever its length
    expected [ 'abc_d' ] to deeply equal [ 'a_b_c_d' ]
× still strips underscore emphasis that CommonMark really opens
    expected [ 'abc' ] to deeply equal [ 'a_b_c' ]
× agrees when the two markers meet in one heading
    expected [ 'snakecase-and-morewords' ] to deeply equal [ 'snake_case-and-more_words' ]
Tests  4 failed | 11 passed (15)
```

**Corpus sweep, re-run.** Same corpus the card measured — `content/docs/**`
plus every `packages/*/README.md`, frontmatter stripped from both sides.
Predicted before the baseline run: 223 files / 2941 rendered headings / 5
divergent files. Observed: exactly that. After the fix: **223 / 2941 / 4**.

The 4 that remain are all the same, different, already-filed defect — an extra
`field-schema` entry `extractToc` lists that the renderer never emits, under a
JSX block with no blank line, which shifts every id after it:
`content/docs/fields/{date,rich-text,text,textarea}.mdx`. That is #7666, filed
as needing a decision because `apps/site` renders the same `.mdx` through
fumadocs; it is deliberately **not addressed here** and remains open.

**Non-vacuity.** The naive shared regexes were reinstated on the committed tree
and the pins re-run. Predicted: the same 4 tests red. Observed: the same 4 red,
11 passing. The mutation was proved on disk by anchored fixed-string counts
(new rule 1 to 0, naive rule 0 to 1) and `git hash-object` movement off the HEAD
blob; restore ran from a trap installed **before** the mutation, using absolute
paths from `git rev-parse --show-toplevel` and `git checkout HEAD -- ABSOLUTE_PATH`,
and was verified three ways — blob equality with the HEAD blob, an empty
`git diff HEAD`, and the anchored counts back at 1/0. The ablation subject
resolves through a relative **source** specifier (`import { extractToc } from './toc'`),
not through the package's `exports` into `dist/`, so no rebuild gates the leg.

**Gates, all at the final commit `6a44becf`**, exit codes captured by redirect
before any pipe, each quoted from the gate's own verdict line:

| gate | verdict |
|---|---|
| `pnpm --filter @object-ui/plugin-markdown test` | `Test Files  5 passed (5)` · `Tests  46 passed (46)` |
| `pnpm --filter @object-ui/plugin-markdown type-check` | exit 0, `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/plugin-markdown lint` | `✖ 7 problems (0 errors, 7 warnings)` — all pre-existing, in `Mermaid.tsx` / `index.tsx` |
| `pnpm changeset:check` | `✅ All workspace packages are in the changeset fixed group.` |
| `pnpm check:control-bytes` | `✅ check-control-bytes: OK (scanned 6256 tracked text file(s); skipped 85 binary).` |

**Declared narrowing.** The repo-wide `pnpm lint` farm is CI's run, not
duplicated here. The narrowing excludes nothing, on three readings: the
population came from eslint's own config — `eslint .` inside
`packages/plugin-markdown` covers the whole package, a superset of the two
changed source files; the count came from `--format json` (2 files, 0 errors, 0
warnings), and `.changeset/*.md` is outside eslint's configured population
entirely ("File ignored because no matching configuration was supplied"); and
`eslint.config.js` declares neither `parserOptions.project` nor
`projectService`, so linting is not type-aware and no untouched file's verdict
can depend on the contents of `toc.ts`.

## Clause-② determination: no

Own determination, same conclusion as the dispatching seat. The criterion is
whether the card changes contract accept/reject behaviour or widens the
published surface, and neither moves:

- The change is confined to `stripInline()`, a module-private helper — one
  definition, one call site, never exported and never re-exported from the
  package entry.
- The exported surface is byte-identical. `extractToc`'s signature, its `opts`
  shape and the `TocItem` interface are untouched; the diff contains no
  `export` and no `interface` line.
- There is no accept/reject boundary to move: `extractToc` accepted every
  string before and accepts every string now. It never validated or rejected.
- Nothing widens: no new export, no new option, no new accepted spelling of
  anything authorable. `@objectstack/spec` is untouched.

What moves is only the **value** of an id that was measurably wrong. That value
now equals what `rehype-slug` emits — which is the contract `TocItem.id`'s own
doc comment already published ("Slug id, identical to what `rehype-slug` puts
on the rendered heading"). The change brings the implementation to its declared
contract rather than changing the contract.

## Scope

`packages/plugin-markdown/src/toc.ts` only, plus its pins and a changeset.
Nothing under `scripts/` was touched. #7666 is not addressed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_