### PR TITLE
fix(types): ChartDataSeriesSchema declares the six series keys the renderer reads (objectui#7546)

### DIFF
--- a/.changeset/7546-chart-series-keys-declared.md
+++ b/.changeset/7546-chart-series-keys-declared.md
@@ -11,8 +11,11 @@ non-strict Zod object had been **stripping in silence** while `safeParse` report
 set widens toward what already renders — but one document class that validated before now
 **refuses**: a series carrying one of these keys with a value the renderer drops in silence
 (`variant: 'bogus'`, `yAxis: 'top'`, `opacity: '0.4'` / `Infinity`, a non-string `stack` /
-`dashArray`, a non-string non-map `label`). Such a document draws a chart today — the normalizer
-ignores the bad value — so this is a narrowing away from something that renders, which is the
+`dashArray`, a non-string non-map `label`) — and, separately, `variant: 'current'`, which the
+renderer does NOT drop: the normalizer keeps that renderer-internal spelling and draws it exactly as
+`primary`, but it is not a member of the published pair, so it now refuses at `variant` (below).
+Such a document draws a chart today — the normalizer ignores the bad value, or honours `current`
+— so this is a narrowing away from something that renders, which is the
 distinction objectui#6939's grading language turns on, and it takes the level objectui#6896 and
 objectui#7113 set for the same transition in this same file. This repository's `major` is a
 cross-repo pin to `@objectstack`'s major, not a severity dial; the change is announced here.

--- a/.changeset/7546-chart-series-keys-declared.md
+++ b/.changeset/7546-chart-series-keys-declared.md
@@ -1,0 +1,80 @@
+---
+'@object-ui/types': minor
+---
+
+`ChartDataSeriesSchema` (and its TS twin `ChartDataSeries`) declares the six series keys the
+renderer reads — `label`, `variant`, `opacity`, `dashArray`, `stack`, `yAxis` — which the
+non-strict Zod object had been **stripping in silence** while `safeParse` reported success
+(objectui#7546, `domain:ui` PM ruling: measure per key, declare what is live, report the rest).
+
+⚠️ Shipped as `minor`, not `patch`. The declared value domains are the read's own, so the accept
+set widens toward what already renders — but one document class that validated before now
+**refuses**: a series carrying one of these keys with a value the renderer drops in silence
+(`variant: 'bogus'`, `yAxis: 'top'`, `opacity: '0.4'` / `Infinity`, a non-string `stack` /
+`dashArray`, a non-string non-map `label`). Such a document draws a chart today — the normalizer
+ignores the bad value — so this is a narrowing away from something that renders, which is the
+distinction objectui#6939's grading language turns on, and it takes the level objectui#6896 and
+objectui#7113 set for the same transition in this same file. This repository's `major` is a
+cross-repo pin to `@objectstack`'s major, not a severity dial; the change is announced here.
+
+## The defect, measured
+
+`ChartDataSeriesSchema` is a non-strict `z.object` — not `.passthrough()` like `BaseSchema` — so an
+undeclared key is removed, not kept. Reproduced red on `origin/main` `a472b071` before the change:
+
+```
+input : { name, label, stack, yAxis, opacity, dashArray, variant }
+parse : success = true
+output: { name }
+```
+
+Every one of the six is read by `normalizeSeries` (`@object-ui/plugin-charts`,
+`normalizeChartSchema.ts:242-255`) and does real work in `AdvancedChartImpl.tsx` — `label` names
+the legend entry, `variant === 'comparison'` selects the muted overlay, `opacity` / `dashArray` set
+stroke and fill, `stack` becomes Recharts' `stackId`, `yAxis` binds the secondary axis. Any consumer
+of the parse output — `objectui check` / `objectui validate` via `safeValidateSchema`, a JSON
+schema derived from the mirror, or any pipeline that keeps `parse()`'s result — lost them outright.
+
+## Per-key liveness, not a blanket declare
+
+"The renderer reads it" was ruled insufficient (a read leg can sit on a value nothing produces —
+objectui#7642), so each key was measured on producers, real work in the reader, and consumer
+surprise, with a lit control on every count. The six are `@objectstack/spec`'s own
+`ChartSeriesSchema` members under the same names and value domains; this node's `series`
+accepts the spec shape by design; in-repo producers write them onto `type: 'chart'` nodes
+(`DashboardRenderer`, `ObjectChart`, `DatasetWidget`, `core/utils/chart-presentation`); and
+the `variant` / `yAxis` narrowings are design intent the reader already enforces.
+
+**`chartType` — the seventh key the review found — is deliberately NOT declared.** It is the first
+limb of `str(raw.chartType) ?? str(raw.type)`, but it is the renderer's *internal* spelling of the
+declared `type`; the spec's `ChartSeriesSchema` lists it as an alias of `type` and refuses it by
+name; and zero documents, fixtures, catalog entries or designer inputs write it on this face
+(controls lit). Declaring it would mint a second writable name for one override. It is reported
+for its own card; the mirror still strips it, and the pin test holds that gap visible.
+
+## FROM → TO
+
+```ts
+// ChartDataSeries — all optional, all additive on the TS face
++ label?: string | I18nLabel;                       // spec I18nLabel: string | inline locale map
++ variant?: 'primary' | 'comparison' | 'current';   // the three normalizeSeries honours
++ opacity?: number;                                 // finite; NaN / Infinity / strings refused
++ dashArray?: string;
++ stack?: string;
++ yAxis?: 'left' | 'right';
+```
+
+`variant` is one value wider than the spec's `'primary' | 'comparison'`: `current` is what this
+repository's own comparison producers write (`ObjectChart`, `DatasetWidget`) and what the renderer
+reads, and it draws identically to `primary`.
+
+## Unchanged, deliberately
+
+The object stays non-strict — a truly undeclared key is still stripped, exactly as
+`chart-inline-data-retired.test.ts` pins; this change declares what is read, it does not close
+the object. The `data` tombstone (objectui#6896) and the at-least-one-binding refinement
+(objectui#6939 / #7113) are untouched. No reader changed.
+
+Pinned in `packages/types/src/__tests__/chart-series-keys-7546.test.ts` — the card's fixture
+surviving byte-for-byte, each key on the mirror's own `.shape`, each value domain refusing at its
+own path, the TS face in lockstep, and the `chartType` gap.

--- a/.changeset/7546-chart-series-keys-declared.md
+++ b/.changeset/7546-chart-series-keys-declared.md
@@ -57,16 +57,19 @@ for its own card; the mirror still strips it, and the pin test holds that gap vi
 ```ts
 // ChartDataSeries — all optional, all additive on the TS face
 + label?: string | I18nLabel;                       // spec I18nLabel: string | inline locale map
-+ variant?: 'primary' | 'comparison' | 'current';   // the three normalizeSeries honours
-+ opacity?: number;                                 // finite; NaN / Infinity / strings refused
++ variant?: 'primary' | 'comparison';               // the spec's own pair
++ opacity?: number;                                 // finite; NaN / Infinity / strings refused (the spec's 0–1 bound is not enforced — the read's domain)
 + dashArray?: string;
 + stack?: string;
 + yAxis?: 'left' | 'right';
 ```
 
-`variant` is one value wider than the spec's `'primary' | 'comparison'`: `current` is what this
-repository's own comparison producers write (`ObjectChart`, `DatasetWidget`) and what the renderer
-reads, and it draws identically to `primary`.
+`variant` is the spec's own pair. The normalizer also tolerates a third spelling, `current`, but that
+is the renderer's internal default — written only by the compare-to producers (`ObjectChart`,
+`DatasetWidget`) onto internal-shape arrays that never pass this mirror, and by nothing an author
+writes (docs, fixtures, designer inputs: 0, controls lit) — so it is not a member here: declaring it
+would have fossilised a renderer-side tolerance into a second contract. The normalizer's tolerance
+is unchanged; objectui#7682 owns that decision.
 
 ## Unchanged, deliberately
 

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -479,7 +479,7 @@ A chart visualization supporting multiple chart types.
 | `title` | `string` | Chart title. |
 | `description` | `string` | Chart description / subtitle. |
 | `categories` | `string[]` | X-axis category labels. |
-| `series` | `ChartSeries[]` | Data series, each with `name`, `data` array, and optional `color`. |
+| `series` | `ChartDataSeries[]` | Data series. Each names the column it plots within the chart-level `data` rows (`name`, or `dataKey`) and may carry `label`, `type` (`bar` / `line` / `area` per-series override), `color`, `stack`, `yAxis` (`left` / `right`), `variant` (`primary` / `comparison` / `current`), `dashArray` and `opacity`. |
 | `height` / `width` | `string \| number` | Chart dimensions. |
 | `showLegend` | `boolean` | Display the legend. |
 | `showGrid` | `boolean` | Display grid lines. |

--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -491,7 +491,7 @@ numbers of its own: `ChartDataSeries.data` is a retirement tombstone
 | `title` | `string` | Chart title. |
 | `description` | `string` | Chart description / subtitle. |
 | `categories` | `string[]` | An **alternative series list** — column names to plot, read only when `series` is absent, and ignored outright when it is present. Not axis labels: the category axis comes from `xAxisKey`. |
-| `series` | `ChartDataSeries[]` | Data series. Each entry's `name` (or `dataKey`) names the column it plots within a `data` row; optional `label`, `color`, a per-series `type` (`"bar"`, `"line"`, `"area"`) for combo charts, `stack`, `yAxis` (`"left"` / `"right"`), `variant` (`"primary"` / `"comparison"` / `"current"`), `dashArray` and `opacity`. |
+| `series` | `ChartDataSeries[]` | Data series. Each entry's `name` (or `dataKey`) names the column it plots within a `data` row; optional `label`, `color`, a per-series `type` (`"bar"`, `"line"`, `"area"`) for combo charts, `stack`, `yAxis` (`"left"` / `"right"`), `variant` (`"primary"` / `"comparison"`), `dashArray` and `opacity`. |
 | `data` | `Array<Record<string, any>>` | Rows to plot — one object per row, keyed by column name. |
 | `xAxisKey` | `string` | Row key holding the category (x) axis. The bare-string `xAxis: "month"` spelling folds onto this key at parse. |
 | `height` / `width` | `string \| number` | Chart dimensions. |

--- a/content/docs/plugins/plugin-charts.mdx
+++ b/content/docs/plugins/plugin-charts.mdx
@@ -189,9 +189,9 @@ Each `series` entry names the column it plots (`dataKey`, or the spec spelling `
 | `color` | `string` | Series colour; wins over the positional palette. |
 | `stack` | `string` | Stack group id — series sharing one id stack together. |
 | `yAxis` | `'left' \| 'right'` | Which y-axis the series binds to, on a chart that declares a second y-axis. |
-| `variant` | `'primary' \| 'comparison' \| 'current'` | `comparison` draws the muted period-over-period overlay. |
-| `dashArray` | `string` | SVG `stroke-dasharray`, e.g. `"4 4"` for a dashed line. |
-| `opacity` | `number` | Stroke and fill opacity, 0–1. |
+| `variant` | `'primary' \| 'comparison'` | `comparison` draws the muted period-over-period overlay; `primary` (the default) is the normal treatment. |
+| `dashArray` | `string` | SVG `stroke-dasharray`, e.g. `"4 4"` for a dashed line. Today the renderer applies it only on a `variant: 'comparison'` series, where it overrides the overlay's default dash; on a primary series it is read and unused. |
+| `opacity` | `number` | Stroke and fill opacity override — any finite number (the spec bounds it to 0–1). Today the renderer applies it only on a `variant: 'comparison'` series, where it overrides the overlay's per-family default; on a primary series it is read and unused. |
 
 ```tsx
 const schema = {
@@ -204,8 +204,8 @@ const schema = {
   xAxisKey: 'month',
   series: [
     { name: 'revenue', label: 'Revenue', stack: 'money' },
-    { name: 'cost', label: 'Cost', stack: 'money', opacity: 0.6 },
-    { name: 'revenue_prev', label: 'Revenue (previous period)', variant: 'comparison', dashArray: '4 4' }
+    { name: 'cost', label: 'Cost', stack: 'money' },
+    { name: 'revenue_prev', label: 'Revenue (previous period)', variant: 'comparison', dashArray: '4 4', opacity: 0.6 }
   ]
 }
 ```

--- a/content/docs/plugins/plugin-charts.mdx
+++ b/content/docs/plugins/plugin-charts.mdx
@@ -190,13 +190,15 @@ Each `series` entry names the column it plots (`dataKey`, or the spec spelling `
 | `stack` | `string` | Stack group id — series sharing one id stack together. |
 | `yAxis` | `'left' \| 'right'` | Which y-axis the series binds to, on a chart that declares a second y-axis. |
 | `variant` | `'primary' \| 'comparison'` | `comparison` draws the muted period-over-period overlay; `primary` (the default) is the normal treatment. |
-| `dashArray` | `string` | SVG `stroke-dasharray`, e.g. `"4 4"` for a dashed line. Today the renderer applies it only on a `variant: 'comparison'` series, where it overrides the overlay's default dash; on a primary series it is read and unused. |
-| `opacity` | `number` | Stroke and fill opacity override — any finite number (the spec bounds it to 0–1). Today the renderer applies it only on a `variant: 'comparison'` series, where it overrides the overlay's per-family default; on a primary series it is read and unused. |
+| `dashArray` | `string` | SVG `stroke-dasharray`, e.g. `"4 4"` for a dashed line. Today the renderer applies it only on a `variant: 'comparison'` series **and** only on a mark that has a stroke to dash — a `line` or `area` mark (the chart's `chartType`, or a per-series `type` override), where it overrides the overlay's default `"4 4"`; a comparison `bar` or `scatter` mark takes `opacity` only and drops the dash, and on a primary series of any family it is read and unused. |
+| `opacity` | `number` | Stroke and fill opacity override — any finite number (the spec bounds it to 0–1). Today the renderer applies it only on a `variant: 'comparison'` series, where it overrides the overlay's per-family default on every mark family — the fill of a `bar` or `scatter` mark, the stroke of a `line` mark, both on an `area` mark; on a primary series it is read and unused. |
+
+An `area` chart keeps every key in this example live: `stack` stacks the two primary areas, and the comparison overlay takes both the dash and the opacity (on a `bar` chart the overlay would take `opacity` only).
 
 ```tsx
 const schema = {
   type: 'chart',
-  chartType: 'bar',
+  chartType: 'area',
   data: [
     { month: 'Jan', revenue: 400, cost: 250, revenue_prev: 360 },
     { month: 'Feb', revenue: 300, cost: 210, revenue_prev: 330 }
@@ -205,7 +207,8 @@ const schema = {
   series: [
     { name: 'revenue', label: 'Revenue', stack: 'money' },
     { name: 'cost', label: 'Cost', stack: 'money' },
-    { name: 'revenue_prev', label: 'Revenue (previous period)', variant: 'comparison', dashArray: '4 4', opacity: 0.6 }
+    // '8 4' overrides the overlay's default '4 4' dash; 0.6 lifts its 0.2 fill default (its stroke default is already 0.6)
+    { name: 'revenue_prev', label: 'Revenue (previous period)', variant: 'comparison', dashArray: '8 4', opacity: 0.6 }
   ]
 }
 ```

--- a/content/docs/plugins/plugin-charts.mdx
+++ b/content/docs/plugins/plugin-charts.mdx
@@ -178,6 +178,38 @@ const schema = {
 }
 ```
 
+##### Per-series options
+
+Each `series` entry names the column it plots (`dataKey`, or the spec spelling `name`) and may carry the presentation keys the renderer reads — the same keys as `@objectstack/spec`'s `ChartSeries`:
+
+| Key | Type | Effect |
+|---|---|---|
+| `label` | `string` or inline locale map | Legend / tooltip name; defaults to the column key. |
+| `type` | `'bar' \| 'line' \| 'area'` | Per-series family override — a combo chart is a series disagreeing with the chart's `chartType`. |
+| `color` | `string` | Series colour; wins over the positional palette. |
+| `stack` | `string` | Stack group id — series sharing one id stack together. |
+| `yAxis` | `'left' \| 'right'` | Which y-axis the series binds to, on a chart that declares a second y-axis. |
+| `variant` | `'primary' \| 'comparison' \| 'current'` | `comparison` draws the muted period-over-period overlay. |
+| `dashArray` | `string` | SVG `stroke-dasharray`, e.g. `"4 4"` for a dashed line. |
+| `opacity` | `number` | Stroke and fill opacity, 0–1. |
+
+```tsx
+const schema = {
+  type: 'chart',
+  chartType: 'bar',
+  data: [
+    { month: 'Jan', revenue: 400, cost: 250, revenue_prev: 360 },
+    { month: 'Feb', revenue: 300, cost: 210, revenue_prev: 330 }
+  ],
+  xAxisKey: 'month',
+  series: [
+    { name: 'revenue', label: 'Revenue', stack: 'money' },
+    { name: 'cost', label: 'Cost', stack: 'money', opacity: 0.6 },
+    { name: 'revenue_prev', label: 'Revenue (previous period)', variant: 'comparison', dashArray: '4 4' }
+  ]
+}
+```
+
 ## Examples
 
 ### Revenue Dashboard

--- a/packages/types/src/__tests__/chart-series-keys-7546.test.ts
+++ b/packages/types/src/__tests__/chart-series-keys-7546.test.ts
@@ -1,0 +1,239 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7546 — `ChartDataSeriesSchema` declares the SIX series keys its
+ * renderer reads and honours: `label`, `variant`, `opacity`, `dashArray`,
+ * `stack`, `yAxis`. The seventh key the review found, `chartType`, is measured
+ * NOT live on this authoring face and is deliberately left undeclared — see the
+ * last block, which pins that decision so it is visible rather than silent.
+ *
+ * ## The defect (measured RED on origin/main a472b071 before the declaration)
+ *
+ * `ChartDataSeriesSchema` is a NON-STRICT `z.object`, unlike `BaseSchema`'s
+ * `.passthrough()`: an undeclared key is STRIPPED in silence and `safeParse`
+ * still reports success. The card's own fixture reproduced exactly:
+ *
+ *     input : { name, label, stack, yAxis, opacity, dashArray, variant }
+ *     parse : success = true
+ *     output: { name }
+ *
+ * Every one of the six is read by `normalizeSeries`
+ * (`@object-ui/plugin-charts`, `normalizeChartSchema.ts:242-255`) and does real
+ * work downstream in `AdvancedChartImpl.tsx`: `label` names the legend entry
+ * (:1364, :1592; `ChartRenderer.tsx:157`), `variant === 'comparison'` selects
+ * the muted overlay treatment (:2010-2033), `opacity` / `dashArray` set the
+ * stroke and fill (:94-96), `stack` becomes Recharts' `stackId` (:1893, :2023)
+ * and `yAxis` binds the series to the secondary axis (:1887, :2019, :2025).
+ *
+ * ## The ruling (comment 5548523375): measure per key, declare what is live
+ *
+ * "The renderer reads it" was ruled INSUFFICIENT evidence of liveness (a read
+ * leg can sit on a value nothing produces — objectui#7642). So each key was
+ * measured on three axes, with a lit control on every count: (1) producers,
+ * (2) real work in the reader, (3) whether declaring it could surprise a
+ * consumer. The six are the spec's own canonical `ChartSeriesSchema` members
+ * (`@objectstack/spec/ui`, `chart.zod.ts:243-276`) under the same names and
+ * with the same value domains; this node's `series` accepts the spec shape by
+ * design ("both shapes" — `ChartRenderer.tsx:55-66`), in-repo producers write
+ * them onto `type: 'chart'` nodes (`DashboardRenderer.tsx:648-652` `label`;
+ * `ObjectChart.tsx:852-856` and `DatasetWidget.tsx:1444-1447` `variant`,
+ * `chartType`, `yAxis`; `core/utils/chart-presentation.ts:126-131` all six on
+ * the dataset path), and the narrowings (`variant`, `yAxis`) are design intent
+ * the reader already enforces. Declaring them widens the accept set only
+ * toward what already renders.
+ *
+ * ## The seventh — `chartType` — measured, and NOT declared
+ *
+ * The same instrument reads it differently on every axis. (1) Zero producers
+ * on this authoring face — no doc, fixture, catalog entry or designer input
+ * writes `chartType` on a series (controls `name` / `dataKey` / `color` lit in
+ * the same query); its only literal producers pass the renderer's INTERNAL
+ * shape directly. (2) The spec's `ChartSeriesSchema` does not declare it — it
+ * lists `chartType` in its `aliases` map as a spelling of `type`, refused by
+ * name (`chart.zod.ts:231`), and this package's own `ChartDataSeries.type`
+ * docblock (objectui#6121) calls `type` the AUTHOR spelling and `chartType`
+ * the internal one. (3) Declaring it would mint a second writable name for the
+ * same override, against the spec's alias posture — the N-dialects hazard
+ * AGENTS.md #0.1 names. So it is REPORTED, per the ruling, not declared and
+ * not retired: the right shape for it (a named alias refusal pointing at
+ * `type`, as the spec does; or a fold) is a contract decision for its own card.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ChartDataSeries } from '../data-display';
+import { ChartDataSeriesSchema } from '../zod/data-display.zod';
+
+/** The card's own fixture — byte-for-byte the input it measured. */
+const CARD_FIXTURE = {
+  name: 'Revenue',
+  label: 'Revenue (USD)',
+  stack: 'money',
+  yAxis: 'right',
+  opacity: 0.4,
+  dashArray: '4 4',
+  variant: 'comparison',
+} as const;
+
+const SIX = ['label', 'variant', 'opacity', 'dashArray', 'stack', 'yAxis'] as const;
+
+const shapeOf = (schema: unknown): Record<string, unknown> =>
+  (schema as { shape: Record<string, unknown> }).shape;
+
+const refusalPaths = (input: unknown): string[] => {
+  const r = ChartDataSeriesSchema.safeParse(input);
+  return r.success ? [] : r.error.issues.map((i) => i.path.join('.'));
+};
+
+type Eq<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+
+/* ── (a) the reproduction: the card's fixture, every key surviving ────────── */
+
+describe('objectui#7546 — the card fixture parses green AND every authored key survives', () => {
+  it('reproduces the card measurement, inverted: output equals input, not `{ name }`', () => {
+    // RED on the untouched base: success is true and the output is `{ name: 'Revenue' }`.
+    const r = ChartDataSeriesSchema.safeParse(CARD_FIXTURE);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toEqual(CARD_FIXTURE);
+  });
+
+  it.each(SIX)('`%s` survives the parse with its authored value', (key) => {
+    const r = ChartDataSeriesSchema.safeParse(CARD_FIXTURE);
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty(key, CARD_FIXTURE[key]);
+  });
+
+  it('CONTROL — a key declared BEFORE this change survives under the same query', () => {
+    // `name` / `type` / `color` were declared on the base; if this fails the
+    // instrument is dark, and the six readings above say nothing.
+    const r = ChartDataSeriesSchema.safeParse({ name: 'Revenue', type: 'line', color: '#3b82f6' });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data).toHaveProperty('name', 'Revenue');
+      expect(r.data).toHaveProperty('type', 'line');
+      expect(r.data).toHaveProperty('color', '#3b82f6');
+    }
+  });
+
+  it('the six are on the mirror\'s OWN shape — what `zod-mirror-parity` reads', () => {
+    for (const key of SIX) expect(shapeOf(ChartDataSeriesSchema)).toHaveProperty(key);
+  });
+});
+
+/* ── (b) the declarations narrow to what the renderer honours ─────────────── */
+
+describe('objectui#7546 — each declaration is the read\'s own value domain, not `unknown`', () => {
+  it.each(['primary', 'comparison', 'current'] as const)('`variant: %s` is accepted — the three `normalizeSeries` honours', (v) => {
+    expect(ChartDataSeriesSchema.safeParse({ name: 'r', variant: v }).success).toBe(true);
+  });
+
+  it('`variant` refuses a value the renderer would drop in silence, at its own path', () => {
+    expect(refusalPaths({ name: 'r', variant: 'bogus' })).toEqual(['variant']);
+  });
+
+  it.each(['left', 'right'] as const)('`yAxis: %s` is accepted', (v) => {
+    expect(ChartDataSeriesSchema.safeParse({ name: 'r', yAxis: v }).success).toBe(true);
+  });
+
+  it('`yAxis` refuses a side the renderer does not bind', () => {
+    expect(refusalPaths({ name: 'r', yAxis: 'top' })).toEqual(['yAxis']);
+  });
+
+  it('`opacity` is a FINITE number — exactly `num()`\'s `Number.isFinite` gate', () => {
+    expect(ChartDataSeriesSchema.safeParse({ name: 'r', opacity: 0.4 }).success).toBe(true);
+    expect(refusalPaths({ name: 'r', opacity: '0.4' })).toEqual(['opacity']);
+    expect(refusalPaths({ name: 'r', opacity: Number.POSITIVE_INFINITY })).toEqual(['opacity']);
+  });
+
+  it('`dashArray` and `stack` are strings', () => {
+    expect(ChartDataSeriesSchema.safeParse({ name: 'r', dashArray: '4 2', stack: 'g' }).success).toBe(true);
+    expect(refusalPaths({ name: 'r', dashArray: 4 })).toEqual(['dashArray']);
+    expect(refusalPaths({ name: 'r', stack: 1 })).toEqual(['stack']);
+  });
+
+  it('`label` takes the spec\'s `I18nLabel` — a string OR an inline locale map, as `label()` reads', () => {
+    expect(ChartDataSeriesSchema.safeParse({ name: 'r', label: 'Revenue' }).success).toBe(true);
+    const map = ChartDataSeriesSchema.safeParse({ name: 'r', label: { en: 'Revenue', 'zh-CN': '收入' } });
+    expect(map.success).toBe(true);
+    if (map.success) expect(map.data.label).toEqual({ en: 'Revenue', 'zh-CN': '收入' });
+    expect(refusalPaths({ name: 'r', label: 42 })).toEqual(['label']);
+  });
+});
+
+/* ── (c) the TypeScript face moves in lockstep ────────────────────────────── */
+
+describe('objectui#7546 — the `ChartDataSeries` interface declares the same six', () => {
+  it('a series authored with all six type-checks and round-trips', () => {
+    const series: ChartDataSeries = {
+      name: 'Revenue',
+      label: { en: 'Revenue' },
+      variant: 'comparison',
+      opacity: 0.4,
+      dashArray: '4 4',
+      stack: 'money',
+      yAxis: 'right',
+    };
+    expect(ChartDataSeriesSchema.parse(series)).toEqual(series);
+  });
+
+  it('the unions are the reader\'s, pinned at the type level', () => {
+    const variant: Eq<ChartDataSeries['variant'], 'primary' | 'comparison' | 'current' | undefined> = true;
+    const yAxis: Eq<ChartDataSeries['yAxis'], 'left' | 'right' | undefined> = true;
+    expect(variant && yAxis).toBe(true);
+  });
+});
+
+/* ── (d) the seventh key: measured NOT live here, reported — and pinned ────── */
+
+describe('objectui#7546 — `chartType` is NOT declared on the series (reported, not retired)', () => {
+  it('is still stripped — the split is pinned so it stays visible, not so it lasts', () => {
+    // If this goes red, someone declared `chartType` on the series. That is a
+    // contract decision this card explicitly did not take (see the file
+    // header): either its own card landed — then move this pin there — or it
+    // was added by hand, and the spec's alias posture (`chartType` -> `type`)
+    // is the thing to re-read first.
+    const r = ChartDataSeriesSchema.safeParse({ name: 'r', chartType: 'line' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).not.toHaveProperty('chartType');
+    expect(shapeOf(ChartDataSeriesSchema)).not.toHaveProperty('chartType');
+  });
+
+  it('the TS face agrees — `chartType` is an excess property on `ChartDataSeries`', () => {
+    // @ts-expect-error `chartType` is the renderer's INTERNAL spelling of `type`; not a member here (objectui#7546)
+    const s: ChartDataSeries = { name: 'r', chartType: 'line' };
+    expect(s.name).toBe('r');
+  });
+
+  it('CONTROL — `type`, the author spelling of the same override, is declared and survives', () => {
+    const r = ChartDataSeriesSchema.safeParse({ name: 'r', type: 'line' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).toHaveProperty('type', 'line');
+  });
+});
+
+/* ── (e) neighbours unchanged: the fix is declaration, not `.strict()` ────── */
+
+describe('objectui#7546 — what did NOT change', () => {
+  it('the `data` tombstone (objectui#6896) still refuses with its remedy', () => {
+    const r = ChartDataSeriesSchema.safeParse({ name: 'r', data: [1, 2, 3] });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.issues[0]?.message).toMatch(/RETIRED \(objectui#6896\)/);
+  });
+
+  it('a series binding to neither `name` nor `dataKey` is still refused at `name` (objectui#6939)', () => {
+    expect(refusalPaths({ color: '#fff' })).toContain('name');
+  });
+
+  it('a truly undeclared key is still stripped — the object is still non-strict', () => {
+    // Deliberate: this change declares the keys the renderer reads; it does not
+    // close the object. `chart-inline-data-retired.test.ts` pins the same fact.
+    const r = ChartDataSeriesSchema.safeParse({ name: 'r', notAKeyAtAll: 'x' });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data).not.toHaveProperty('notAKeyAtAll');
+  });
+});

--- a/packages/types/src/__tests__/chart-series-keys-7546.test.ts
+++ b/packages/types/src/__tests__/chart-series-keys-7546.test.ts
@@ -43,10 +43,13 @@
  * design ("both shapes" — `ChartRenderer.tsx:55-66`), in-repo producers write
  * them onto `type: 'chart'` nodes (`DashboardRenderer.tsx:648-652` `label`;
  * `ObjectChart.tsx:852-856` and `DatasetWidget.tsx:1444-1447` `variant`,
- * `chartType`, `yAxis`; `core/utils/chart-presentation.ts:126-131` all six on
- * the dataset path), and the narrowings (`variant`, `yAxis`) are design intent
- * the reader already enforces. Declaring them widens the accept set only
- * toward what already renders.
+ * `chartType`, `yAxis` — internal-shape callers, see block (b);
+ * `core/utils/chart-presentation.ts:126-131` all six on the dataset path),
+ * and the narrowings (`variant`, `yAxis`) are design intent the reader already
+ * enforces. Declaring them widens the accept set only toward what already
+ * renders. `variant` is the spec's PAIR, not the normalizer's three: the third
+ * spelling, `current`, is the renderer's internal default written only by the
+ * two internal-shape producers above, which never meet this mirror.
  *
  * ## The seventh — `chartType` — measured, and NOT declared
  *
@@ -128,8 +131,20 @@ describe('objectui#7546 — the card fixture parses green AND every authored key
 /* ── (b) the declarations narrow to what the renderer honours ─────────────── */
 
 describe('objectui#7546 — each declaration is the read\'s own value domain, not `unknown`', () => {
-  it.each(['primary', 'comparison', 'current'] as const)('`variant: %s` is accepted — the three `normalizeSeries` honours', (v) => {
+  it.each(['primary', 'comparison'] as const)('`variant: %s` is accepted — the spec\'s own pair', (v) => {
     expect(ChartDataSeriesSchema.safeParse({ name: 'r', variant: v }).success).toBe(true);
+  });
+
+  it('`variant` refuses the renderer-internal `current` spelling — not a member of the published face', () => {
+    // `normalizeSeries` tolerates `current` (`normalizeChartSchema.ts:247`), but
+    // it is written only by the compare-to producers onto `dataKey`-shaped
+    // arrays handed straight to `ChartRenderer` (`ObjectChart.tsx:852`,
+    // `DatasetWidget.tsx:1450`) — they never meet this mirror — and by nothing
+    // an author writes. The spec's `ChartSeries.variant` is the pair; declaring
+    // a third value here would fossilise a renderer-side tolerance into a
+    // second contract (AGENTS.md #0.1). The normalizer's tolerance itself is
+    // objectui#7682's decision, untouched by this card.
+    expect(refusalPaths({ name: 'r', variant: 'current' })).toEqual(['variant']);
   });
 
   it('`variant` refuses a value the renderer would drop in silence, at its own path', () => {
@@ -182,7 +197,7 @@ describe('objectui#7546 — the `ChartDataSeries` interface declares the same si
   });
 
   it('the unions are the reader\'s, pinned at the type level', () => {
-    const variant: Eq<ChartDataSeries['variant'], 'primary' | 'comparison' | 'current' | undefined> = true;
+    const variant: Eq<ChartDataSeries['variant'], 'primary' | 'comparison' | undefined> = true;
     const yAxis: Eq<ChartDataSeries['yAxis'], 'left' | 'right' | undefined> = true;
     expect(variant && yAxis).toBe(true);
   });

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -15,7 +15,7 @@
  * @packageDocumentation
  */
 
-import type { ChartType as SpecChartType } from '@objectstack/spec/ui';
+import type { ChartType as SpecChartType, I18nLabel } from '@objectstack/spec/ui';
 import type { BaseSchema, SchemaNode } from './base.js';
 import type { BreadcrumbSchema } from './navigation.js';
 
@@ -1407,6 +1407,71 @@ export interface ChartDataSeries {
    * Series color
    */
   color?: string;
+  /**
+   * Legend / tooltip name for this series — the spec's `I18nLabel`: a plain
+   * string, or an inline locale map (`{ en: 'Revenue', 'zh-CN': '收入' }`),
+   * the same spelling as {@link BaseSchema.label}.
+   *
+   * Declared by objectui#7546. `normalizeSeries` reads it through `label()`
+   * (`normalizeChartSchema.ts:242` — a string as-is, the first string value of
+   * a map), and the legend takes it at `ChartRenderer.tsx:157`
+   * (`s.label || s.dataKey`) and `AdvancedChartImpl.tsx:1364`. Until this
+   * declaration the Zod mirror STRIPPED it in silence — `ChartDataSeriesSchema`
+   * is a non-strict `z.object` — so a parsed series lost its name and the
+   * legend fell back to the column key.
+   */
+  label?: string | I18nLabel;
+  /**
+   * Visual role. `'comparison'` is the muted period-over-period overlay
+   * (`AdvancedChartImpl.tsx:2010-2033` — lower opacity, dashed stroke, and it
+   * is left out when the primary series are counted); `'primary'` and
+   * `'current'` both mean "not the overlay" and draw identically.
+   *
+   * ⚠️ The union is the THREE values `normalizeSeries` honours
+   * (`normalizeChartSchema.ts:246-247`) — one wider than the spec's own
+   * `ChartSeries.variant` (`'primary' | 'comparison'`), because `current` is
+   * the spelling this repository's own comparison producers write
+   * (`ObjectChart.tsx:852`, `DatasetWidget.tsx:1450`) and the renderer reads.
+   * Any other value is dropped in silence by the normalizer, so the mirror
+   * refuses it by name instead (objectui#7546).
+   */
+  variant?: 'primary' | 'comparison' | 'current';
+  /**
+   * Stroke and fill opacity, 0–1. Read by `num()` (`normalizeChartSchema.ts:248`
+   * — any finite number; the mirror refuses `NaN`, `Infinity` and strings the
+   * same way) and applied at `AdvancedChartImpl.tsx:94-95`, where it overrides
+   * the per-family default (objectui#7546).
+   */
+  opacity?: number;
+  /**
+   * SVG `stroke-dasharray` override, e.g. `"4 4"` for a dashed line
+   * (`normalizeChartSchema.ts:250`; applied at `AdvancedChartImpl.tsx:96`)
+   * (objectui#7546).
+   */
+  dashArray?: string;
+  /**
+   * Stack group id — series sharing one id stack together. Becomes Recharts'
+   * `stackId` (`normalizeChartSchema.ts:252`; `AdvancedChartImpl.tsx:1893`,
+   * `:2023`) (objectui#7546).
+   */
+  stack?: string;
+  /**
+   * Which y-axis this series binds to on a dual-axis chart. Narrowed to the two
+   * sides the renderer binds (`normalizeChartSchema.ts:254-255`;
+   * `AdvancedChartImpl.tsx:1887`, `:2019`) — the spec's `ChartSeries.yAxis`
+   * carries the same union (objectui#7546).
+   */
+  yAxis?: 'left' | 'right';
+  // ⛔ NOT declared: `chartType`. It is the first limb of `normalizeSeries`'
+  // `str(raw.chartType) ?? str(raw.type)` (`normalizeChartSchema.ts:244`), but
+  // it is the renderer's INTERNAL spelling of `type` above, the spec's
+  // `ChartSeriesSchema` lists it as an alias of `type` and refuses it by name
+  // (`@objectstack/spec` `ui/chart.zod.ts:231`), and no document, fixture or
+  // designer input on this face writes it (objectui#7546 — measured with lit
+  // controls). Declaring it would mint a second writable name for one override;
+  // its shape — a named alias refusal like the spec's, or a fold — is a contract
+  // decision for its own card. Until then the mirror still strips it, and
+  // `__tests__/chart-series-keys-7546.test.ts` pins that gap so it stays visible.
 }
 
 /**

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -1452,17 +1452,28 @@ export interface ChartDataSeries {
    * refuse an out-of-range value either.
    *
    * ⚠️ Today the renderer honours it ONLY on a `variant: 'comparison'` series —
-   * `comparisonStyle` returns `null` for any other variant and every mark reads
-   * `cmp?.fillOpacity` / `cmp?.strokeOpacity`, so on a primary series the value
-   * is read and unused. The spec declares it as an unconditional override, so
-   * that is a renderer gap (objectui#7698), not a reason to narrow this face.
+   * `comparisonStyle` returns `null` for any other variant, so on a primary
+   * series the value is read and unused. On a comparison series it reaches
+   * EVERY mark family: `fillOpacity` on a Bar (`:1911`, `:2037`) or Scatter
+   * (`:1832`) mark, `strokeOpacity` on a Line mark (`:1898`, `:2048`), both on
+   * an Area mark (`:1905`, `:2056`). The spec declares it as an unconditional
+   * override, so the primary-series half is a renderer gap (objectui#7698),
+   * not a reason to narrow this face.
    */
   opacity?: number;
   /**
    * SVG `stroke-dasharray` override, e.g. `"4 4"` for a dashed line
-   * (`normalizeChartSchema.ts:250`; applied at `AdvancedChartImpl.tsx:96`)
-   * (objectui#7546). Same condition as {@link ChartDataSeries.opacity}: today
-   * only a `variant: 'comparison'` series reaches that read (objectui#7698).
+   * (`normalizeChartSchema.ts:250`; read at `AdvancedChartImpl.tsx:96`)
+   * (objectui#7546).
+   *
+   * ⚠️ Narrower condition than {@link ChartDataSeries.opacity}: today it is
+   * honoured only on a `variant: 'comparison'` series AND only on a mark with
+   * a stroke to dash — a Line (`:1898`, `:2048`) or Area (`:1905`, `:2056`)
+   * mark, whether from the chart's `chartType` or a per-series `type`
+   * override. `comparisonStyle` returns the authored value for every family,
+   * but a Bar (`:1911`, `:2037`) or Scatter (`:1832`) mark passes
+   * `fillOpacity` only and drops `strokeDasharray` (and `strokeOpacity`); on
+   * a primary series of any family it is read and unused (objectui#7698).
    */
   dashArray?: string;
   /**

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -1424,29 +1424,45 @@ export interface ChartDataSeries {
   /**
    * Visual role. `'comparison'` is the muted period-over-period overlay
    * (`AdvancedChartImpl.tsx:2010-2033` — lower opacity, dashed stroke, and it
-   * is left out when the primary series are counted); `'primary'` and
-   * `'current'` both mean "not the overlay" and draw identically.
+   * is left out when the primary series are counted); `'primary'` (the
+   * default) is the normal treatment.
    *
-   * ⚠️ The union is the THREE values `normalizeSeries` honours
-   * (`normalizeChartSchema.ts:246-247`) — one wider than the spec's own
-   * `ChartSeries.variant` (`'primary' | 'comparison'`), because `current` is
-   * the spelling this repository's own comparison producers write
-   * (`ObjectChart.tsx:852`, `DatasetWidget.tsx:1450`) and the renderer reads.
-   * Any other value is dropped in silence by the normalizer, so the mirror
-   * refuses it by name instead (objectui#7546).
+   * The union is the spec's own `ChartSeries.variant` pair. The normalizer
+   * also tolerates a third spelling, `'current'` (`normalizeChartSchema.ts:247`),
+   * but that is the renderer's INTERNAL default — written only by the
+   * compare-to producers onto `dataKey`-shaped arrays handed straight to
+   * `ChartRenderer` (`ObjectChart.tsx:852`, `DatasetWidget.tsx:1450`), which
+   * never pass through this mirror — and by nothing an author writes (docs,
+   * fixtures and designer inputs: 0, controls lit). It is NOT a member here,
+   * so the published face does not fossilise a renderer-side tolerance into a
+   * second contract (AGENTS.md #0.1); the normalizer's own tolerance is
+   * objectui#7682's decision and is unchanged by this. Any other value is
+   * dropped in silence by the normalizer, so the mirror refuses it by name
+   * instead (objectui#7546).
    */
-  variant?: 'primary' | 'comparison' | 'current';
+  variant?: 'primary' | 'comparison';
   /**
-   * Stroke and fill opacity, 0–1. Read by `num()` (`normalizeChartSchema.ts:248`
+   * Stroke and fill opacity. Read by `num()` (`normalizeChartSchema.ts:248`
    * — any finite number; the mirror refuses `NaN`, `Infinity` and strings the
-   * same way) and applied at `AdvancedChartImpl.tsx:94-95`, where it overrides
-   * the per-family default (objectui#7546).
+   * same way) and applied at `AdvancedChartImpl.tsx:94-95` inside
+   * `comparisonStyle`, where it overrides the comparison overlay's per-family
+   * default (objectui#7546). Declared as the read's own domain: the spec's
+   * `ChartSeries.opacity` bounds it to 0–1, a bound the renderer does not
+   * enforce (SVG clamps at paint, nothing is dropped), so the mirror does not
+   * refuse an out-of-range value either.
+   *
+   * ⚠️ Today the renderer honours it ONLY on a `variant: 'comparison'` series —
+   * `comparisonStyle` returns `null` for any other variant and every mark reads
+   * `cmp?.fillOpacity` / `cmp?.strokeOpacity`, so on a primary series the value
+   * is read and unused. The spec declares it as an unconditional override, so
+   * that is a renderer gap (objectui#7698), not a reason to narrow this face.
    */
   opacity?: number;
   /**
    * SVG `stroke-dasharray` override, e.g. `"4 4"` for a dashed line
    * (`normalizeChartSchema.ts:250`; applied at `AdvancedChartImpl.tsx:96`)
-   * (objectui#7546).
+   * (objectui#7546). Same condition as {@link ChartDataSeries.opacity}: today
+   * only a `variant: 'comparison'` series reaches that read (objectui#7698).
    */
   dashArray?: string;
   /**

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -17,7 +17,7 @@
  */
 
 import { z } from 'zod';
-import { ChartTypeSchema as SpecChartTypeSchema } from '@objectstack/spec/ui';
+import { ChartTypeSchema as SpecChartTypeSchema, I18nLabelSchema } from '@objectstack/spec/ui';
 import { BaseSchema, SchemaNodeSchema } from './base.zod.js';
 import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 import { TABLE_COLUMN_TYPES } from '../data-display.js';
@@ -385,6 +385,34 @@ export const ChartDataSeriesSchema = z.object({
   // the TS declaration for the read this narrowness is taken from.
   type: z.enum(['bar', 'line', 'area']).optional().describe('Per-series chart family override (combo charts)'),
   color: z.string().optional().describe('Series color'),
+  // THE SIX KEYS THE RENDERER READS (objectui#7546). Each was undeclared, and
+  // because this object is NON-STRICT the mirror STRIPPED it in silence while
+  // `safeParse` reported success — the card's own measurement:
+  // `{ name, label, stack, yAxis, opacity, dashArray, variant }` parsed to
+  // `{ name }`. Every one is read by `normalizeSeries`
+  // (`normalizeChartSchema.ts:242-255`) and does real work in
+  // `AdvancedChartImpl.tsx`; each value domain below is the read's own, so the
+  // accept set widens only toward what already renders, and a value the
+  // renderer would drop in silence is refused by name instead. They are the
+  // spec's `ChartSeriesSchema` members under the same names; the TS twin's
+  // docblocks carry the read sites and the liveness measurement.
+  //
+  // ⛔ `chartType` is NOT among them — deliberately. It is the renderer's
+  // INTERNAL spelling of `type` (the first limb of
+  // `str(raw.chartType) ?? str(raw.type)`), the spec refuses it by name as an
+  // alias of `type`, and nothing on this authoring face writes it. Declaring it
+  // is a contract decision for its own card; `chart-series-keys-7546.test.ts`
+  // pins the gap so it stays visible.
+  label: I18nLabelSchema.optional().describe(
+    'Legend / tooltip name for this series — a plain string or an inline locale map; defaults to the column key',
+  ),
+  variant: z.enum(['primary', 'comparison', 'current']).optional().describe(
+    'Visual role — `comparison` draws the muted period-over-period overlay; `primary` and `current` both mean the normal treatment',
+  ),
+  opacity: z.number().optional().describe('Stroke and fill opacity override, 0–1'),
+  dashArray: z.string().optional().describe('SVG stroke-dasharray override, e.g. "4 4" for a dashed line'),
+  stack: z.string().optional().describe('Stack group id — series sharing one id stack together'),
+  yAxis: z.enum(['left', 'right']).optional().describe('Which y-axis this series binds to on a dual-axis chart'),
 }).superRefine((series, ctx) => {
   // `normalizeSeries` returns `undefined` when NEITHER spelling resolves
   // (`normalizeChartSchema.ts:240`, `if (!dataKey) return undefined`) and the

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -406,10 +406,10 @@ export const ChartDataSeriesSchema = z.object({
   label: I18nLabelSchema.optional().describe(
     'Legend / tooltip name for this series — a plain string or an inline locale map; defaults to the column key',
   ),
-  variant: z.enum(['primary', 'comparison', 'current']).optional().describe(
-    'Visual role — `comparison` draws the muted period-over-period overlay; `primary` and `current` both mean the normal treatment',
+  variant: z.enum(['primary', 'comparison']).optional().describe(
+    'Visual role — `comparison` draws the muted period-over-period overlay; `primary` (the default) is the normal treatment. The spec pair: the renderer-internal `current` spelling is not a member (objectui#7682)',
   ),
-  opacity: z.number().optional().describe('Stroke and fill opacity override, 0–1'),
+  opacity: z.number().optional().describe('Stroke and fill opacity override — any finite number, the read\'s own domain; the spec bounds it to 0–1'),
   dashArray: z.string().optional().describe('SVG stroke-dasharray override, e.g. "4 4" for a dashed line'),
   stack: z.string().optional().describe('Stack group id — series sharing one id stack together'),
   yAxis: z.enum(['left', 'right']).optional().describe('Which y-axis this series binds to on a dual-axis chart'),


### PR DESCRIPTION
Fixes #7546

## What

`ChartDataSeriesSchema` is a **non-strict `z.object`** — not `.passthrough()` like `BaseSchema` — so an undeclared key is **stripped in silence** while `safeParse` reports success. Six keys that `normalizeSeries` reads (`normalizeChartSchema.ts:242-255`) and `AdvancedChartImpl` does real work with were undeclared: `label` (legend name, `:1364`), `variant` (comparison overlay, `:2010-2033`), `opacity` / `dashArray` (stroke and fill, `:94-96`), `stack` (`stackId`, `:1893`), `yAxis` (axis binding, `:1887`). Both faces — the TS twin `ChartDataSeries` and the Zod mirror — now declare them, each with its own measured value domain. **No reader changed.** The object stays non-strict; a truly undeclared key is still stripped, as `chart-inline-data-retired.test.ts` pins.

`chartType`, the seventh key the prior review found, is measured **not live on this authoring face** and is deliberately **not declared** — reported below with its evidence, per the ruling (comment 5548523375: declare what is live, report the rest, retire nothing here). Its carrier is objectui#7694 (see "Out of scope").

## Remediation after the second contract review (comment 5550238043, REFUSE) — head `5f7e032a8`

The one blocking item: the "Per-series options" example taught `dashArray` on a `chartType: 'bar'` chart, where it reaches nothing. **Re-measured before rewriting** — neither the verdict's reading (`comparisonStyle` sets `strokeDasharray` to `undefined` for bar) nor the dispatcher's taken on trust — through the real `ChartRenderer` under happy-dom (Recharts' `ResponsiveContainer` sized as in `ChartRenderer.specSeries.test.tsx`), on this branch with `main` `bc640ec56` merged. Predictions stated first; a lit control on every probe; readings persisted to disk because vitest hides passing tests' stdout.

| probe | schema | predicted | observed |
|---|---|---|---|
| P1 | the OLD example verbatim — `bar`, comparison `{ dashArray: '4 4', opacity: 0.6 }` | `fill-opacity="0.6"` on the comparison rects (lit), zero `stroke-dasharray` | 2 `recharts-rectangle` paths at `0.6`; `stroke-dasharray` hits: **0** |
| P2 | the NEW example — `area`, comparison `{ dashArray: '8 4', opacity: 0.6 }` | `stroke-dasharray="8 4"`, `stroke-opacity="0.6"`, `fill-opacity="0.6"` on the comparison mark; primaries untouched | `8 4` on both the comparison's `area-area` and `area-curve` paths, `0.6` stroke and fill on the same two; the four primary paths keep `fill-opacity="1"`, no dash, and the default `4 4` appears nowhere |
| P2b | `area`, two series with `stack: 'money'` vs without | stacked: the `cost` area's lower edge IS the `revenue` area's upper edge; control: unstacked both sit on the baseline | stacked `cost` path `…L475,180L53,145Z` against `revenue` `M53,145L475,180…`; unstacked both end on `285` |
| P3 | `line`, comparison `{ dashArray: '2 6', opacity: 0.6 }` | dash `2 6` + `stroke-opacity 0.6` on the line curve; no `fill-opacity` from it | exactly that |
| P4 | `scatter`, one comparison series with both keys | `fill-opacity="0.6"` on every symbol, zero `stroke-dasharray` | 3 `recharts-symbols` at `0.6`; dash hits **0** |
| P5a/b | comparison line with NO `dashArray`; comparison bar with NO `opacity` | the family defaults `4 4` / `0.5` and `0.4` (instrument sees the attributes) | `4 4` + `0.5`; `0.4` |
| P5c | PRIMARY series with `opacity: 0.6, dashArray: '2 6'` on bar and on line | nothing reaches the DOM (objectui#7698) | `dash: [] fillOp: [] strokeOp: []` on both |
| P6 | `bar` chart, comparison series with per-series `type: 'line'` and `dashArray: '2 6'` | the dash lands — the condition is the MARK, not `chartType` | `2 6` + `0.6` on the line curve |

9/9 on the final run. **One control miss, reported:** P2b's first control predicted the bottom (`revenue`) area path unchanged by stacking — wrong, stacking rescales the y-domain so both paths move (`M53,5…` → `M53,145…`); the readings themselves already showed the stacking (the lower edge coincidence above), so the control was recast geometrically and the probe re-run: 9/9.

**The mechanism is one step lower than the verdict puts it** (renderer blob `63a5e34c9`, identical on `main` and here — no reader changed): `comparisonStyle` (`AdvancedChartImpl.tsx:96`) returns the AUTHORED `dashArray` for every family — the `undefined` at `:96` is only the fallback half. What drops it is the mark: Scatter `:1832`, combo Bar `:1911` and Bar `:2037` pass `fillOpacity` only; Line `:1898` / `:2048` pass `strokeOpacity` + `strokeDasharray`; Area `:1905` / `:2056` pass all three. **So the two keys split:** `opacity` is live on every family under `comparison` (fill on bar/scatter, stroke on line, both on area); `dashArray` — and `strokeOpacity` with it — only on a line/area mark.

What changed (wording plus one example's `chartType`; no contract, reader or changeset-level change):

1. **`plugin-charts.mdx`** — the example moves to **`chartType: 'area'`**, the one family where `stack`, `variant`, `dashArray` and `opacity` are ALL live (P2 + P2b); dropping `dashArray` from the bar example was the alternative, rejected because the row would then have no live demonstration at all. The dash is `'8 4'`, not `'4 4'`: on a comparison line/area `'4 4'` IS the default, so an example writing it would be inert in a second, quieter way. A one-line lead-in says why `area`. The `dashArray` row states the full condition — comparison **and** a line/area mark (chart `chartType` or per-series `type`), bar/scatter take `opacity` only; the `opacity` row now says every mark family, fill vs stroke per family (it neither over- nor understated before, it was silent on the split).
2. **`data-display.ts`** — the `dashArray` docblock carries the full condition with the mark sites; the `opacity` docblock says it reaches every family. The Zod `.describe` strings are deliberately untouched: on all six keys they state the value domain, not the renderer's current coverage, and the coverage lives in the rows and docblocks.
3. **Changeset** (non-blocking item) — the ⚠️ refusal list now names `variant: 'current'` as refused-but-honoured: the normalizer keeps it and draws it as `primary`; it is refused because it is not a member of the published pair.
4. Not taken, recorded: `.min(0).max(1)` for mirror/spec range parity on `opacity` — the maintainer's follow-up, not this card's.

`main` `bc640ec56` merged again (merge commit `51f2a9634`; #7691, #7649 and #7662 landed after the previous merge) — clean, no conflicts; the lockfile did NOT move — corrected 2026-09-05 by the `domain:ui` PM seat after the round-3 contract review measured it: `pnpm-lock.yaml` is blob `df8fbcd77` at `6eebc54b6`, `bc640ec56`, `493b52eb3` and `5f7e032a8` alike, 0 commits touched it in the merge window (lit control: `registry.ts` moved once in the same window), and its last movement on `main` was `2f61238b9` (#7670), before this PR's original base. The re-install was a no-op in the worktree; `git diff --stat origin/main..HEAD` is still exactly this PR's six files.

## Remediation after the contract review (comment 5548861339, REFUSE) — head `493b52eb3`

1. **`variant` narrowed to the spec pair on both faces** — `z.enum(['primary', 'comparison'])` and `variant?: 'primary' | 'comparison'`. Re-measured before rewriting, on `origin/main` `6eebc54b6` (neither the PM's summary nor the reviewer's numbers taken on trust): the only writers of `'current'` are the two internal-shape producers `ObjectChart.tsx:852` (`s.variant || 'current'`) and `DatasetWidget.tsx:1450` (`s.variant ?? 'current'`) plus their four `dataKey`-shaped test assertions; docs 0, fixtures 0, designer 0 — `git grep` over `content/**`, `examples/**`, `apps/**` in both the TS and the JSON spelling, controls lit (`variant: 'comparison'` 1 hit in `content/**` on this branch; the same query over `apps/**` finds the button-action `variant: 'primary'` sites). The installed `@objectstack/spec@17.2.0` declares `variant: z.enum(["primary", "comparison"])` (`dist/ui/index.js:2395`). Core's own authored-series reader `seriesPresentation` keeps the pair and drops `current` (`chart-presentation.ts:125`). So `current` is the renderer's internal default and nothing an author writes — the same reading that excluded `chartType` — and declaring it would have fossilised a renderer-side tolerance into a second contract (AGENTS.md #0.1). The narrowing refuses zero live producers. Pin test: `it.each` over the pair, a new refusal pin for `variant: 'current'` at its own path, the type-level `Eq` pin narrowed. Both doc pages, the TS docblock (the "one wider than the spec" paragraph removed) and the changeset's FROM→TO block and paragraph rewritten. **No reader changed** — the normalizer's tolerance for `current` (`normalizeChartSchema.ts:247`) is untouched; objectui#7682 owns it.
2. **`chartType` carrier** — objectui#7694 exists (filed by the PM seat; re-read 2026-09-05: open, `pm:queue`) and is named in the out-of-scope list below, so `Fixes #7546` no longer sinks a measured finding.
3. **`opacity` (the non-blocking item)** — took the wording option, not `.min(0).max(1)`: the mirror stays `z.number()`; the doc row and the `.describe` now read "any finite number (the spec bounds it to 0–1)" instead of claiming a bound the mirror does not enforce. Why: every domain in this change is the read's own (`num()` = `Number.isFinite`), and the renderer never drops an out-of-range opacity (SVG clamps at paint), so `.min(0).max(1)` would refuse a document class that renders today — a second narrowing nothing in this PR measured; its own card if triage wants it. Census: every series-level `opacity` literal in the repo is within 0–1 (`0.4`, `0.6`; the same grep is the control).
4. **`main` merged into the branch** (merge commit `71f0c1941` — no rebase, no amend, no force): one conflict, `content/docs/api/schema-reference.md`, where #7679 rewrote the chart node's property table (`categories` / `data` / `xAxisKey` rows) while this branch rewrote the `series` row. Resolution keeps #7679's table and folds the declared keys into its `series` row. No lockfile or generated file moved on `main` since the merge-base (`git diff --stat a472b0716..origin/main -- pnpm-lock.yaml` is empty; `pnpm install` not re-run). After the merge `git diff --stat origin/main..HEAD` lists exactly this PR's six files.

### Found while re-measuring — filed, left to its own card: objectui#7698

The renderer's ONLY read of series-level `opacity` / `dashArray` is inside `comparisonStyle` (`AdvancedChartImpl.tsx:92-97`), which returns `null` unless `variant === 'comparison'`; every mark reads through `cmp?.…`, so on a primary series both keys are read and unused (and, measured in the second remediation above, the marks split further: Bar `:1911` / `:2037` and Scatter `:1832` pass `fillOpacity` only, so `dashArray` is line/area-only even on a comparison series — the PM seat has already posted that correction on #7698 as comment 5550238143; not this PR's change) — while the spec declares them as unconditional overrides. The declarations stay (spec members, real work on comparison series). My own doc example had taught `opacity: 0.6` on a plain stacked series, a no-op: the example now puts it on the comparison series, both rows say so, and the TS docblocks carry the condition. The renderer gap is objectui#7698's (duplicate check: 119 open issues read via the repo-scoped list endpoint — every open issue from #7380 up plus every `finding`-labelled one — control #7694 present, no prior card).

## Red first, on the untouched base `a472b071`

The pin file `packages/types/src/__tests__/chart-series-keys-7546.test.ts` was written and run before any schema edit. Predicted 14 red / 13 green; observed `Tests 14 failed | 13 passed (27)`. The reproduction assertion is the card's measurement verbatim: `expected { name: 'Revenue' } to deeply equal { name: 'Revenue', …(6) }` on `success: true`. The lit control — declared `name` / `type` / `color` surviving the same query — was green in that run. After the change: `Tests 27 passed (27)`.

## Per-key measurement (the ruling's three axes, lit controls on every count)

Producer census = key counts INSIDE `series` array literals, by file class, with the declared keys measured by the identical query. Controls lit: docs `name` 6 / `dataKey` 10 / `color` 2; fixtures `name` 2 / `dataKey` 6 / `color` 2.

| key | docs / fixtures / designer inputs | in-repo producers of a `type: 'chart'` node | tests | reader does real work | spec `ChartSeriesSchema` | disposition |
|---|---|---|---|---|---|---|
| `label` | 0 / 0 / 0 | `DashboardRenderer.tsx:648-652`, `ObjectView.tsx`, `ListView.tsx`, `plugin-view/ObjectView.tsx` (4 sites) | 27 | `label()` string or locale map; legend name | `I18nLabelSchema` | **declared** `string \| I18nLabel` |
| `variant` | 0 / 0 / 0 | `ObjectChart.tsx:852,856`, `DatasetWidget.tsx:1444,1450` — internal-shape callers that never meet this mirror | 1 | normalizer honours 3; `comparison` selects the overlay | `primary \| comparison` | **declared `primary \| comparison`** — the spec pair; `current` is the renderer's internal default, written by nothing an author writes (objectui#7682 owns the normalizer's tolerance) |
| `opacity` | 0 / 0 / 0 | `core/utils/chart-presentation.ts:131` (dataset path) | 1 | `num()`; stroke/fill opacity — today only on a `comparison` series (objectui#7698) | `number` 0–1 | **declared** finite `number` (the spec's bound stated in docs, not enforced — remediation item 3) |
| `dashArray` | 0 / 0 / 0 | `chart-presentation.ts:130` | 1 | `str()`; `strokeDasharray` — same condition (objectui#7698) | `string` | **declared** |
| `stack` | 0 / 0 / 0 | `chart-presentation.ts:128` | 5 | `str()`; Recharts `stackId` | `string` | **declared** |
| `yAxis` | 0 / 0 / 0 | `chart-presentation.ts:124`, `DatasetWidget.tsx:1446` | 10 | narrowed to `left \| right`; axis binding | `left \| right` | **declared** |
| `chartType` | 0 / 0 / 0 | internal-shape callers only | 9 | first limb of `?? type`, narrowed to 3 | **not a member — listed in `aliases` as a spelling of `type`, refused by name** (`chart.zod.ts:231`) | **reported, not declared** — carrier objectui#7694 |

Designer: the `chart` registration's `series` input is a single `code` (JSON) field with no per-key inputs, and `defaultProps.series` authors `dataKey` only (`plugin-charts/src/index.tsx`). The six are the spec's canonical members under the same names; this node's `series` accepts the spec shape by design (`ChartRenderer.tsx:55-66`, "both shapes"). Declaring them widens the accept set only toward what already renders.

## `chartType` — the seventh, measured and reported

1. **Producers on this face: zero**, controls lit. Its only literal producers hand the renderer's INTERNAL shape straight to `ChartRenderer`, which forwards an all-`dataKey` array raw (`:126-131`), so the normalizer's read never carries their value.
2. **The contract of record refuses it by name** as an alias of `type`, and this package's own `ChartDataSeries.type` docblock (objectui#6121) calls `type` the author spelling and `chartType` the internal one.
3. **Liveness ablation of the first limb** (`normalizeChartSchema.ts:244`, restored under trap, blob `05a66dfb` moved to `bd9e640f` and back): with `str(raw.chartType) ??` deleted, `packages/plugin-charts/` plus the four dashboard/report series tests read `49 files / 470 tests passed` — predicted 0 red, observed 0 red. Control with the sibling `?? str(raw.type)` deleted instead: predicted at least 2 red in 2 files, observed `2 failed` in `normalizeChartSchema.test.ts` and `ChartRenderer.specSeries.test.tsx`. The review re-measured the same legs on 197 files / 2380 tests with the same outcome.
4. **Consumer surprise:** declaring it would mint a second writable name for one override, against the spec's alias posture (AGENTS.md #0.1).

The shape it should take — a named alias refusal pointing at `type`, graded as its own narrowing — is objectui#7694's decision. The pin test holds the gap visible and the TS face carries a `ts-expect-error` ratchet so it cannot be added by hand without re-reading this.

## Clause-② — my own determination: **yes**

The accept set moves both ways on a published mirror: six keys now survive with their values (widening toward what renders), and a series carrying one of them with a value the renderer silently drops — `variant: 'bogus'` or the renderer-internal `variant: 'current'`, `yAxis: 'top'`, `opacity: '0.4'` or `Infinity`, a non-string `stack` / `dashArray`, a non-string non-map `label` — now refuses at its own path. Hence the changeset is `minor`, the level objectui#6896 and objectui#7113 set for the same transition in this file; the grade did not move with the narrowing. Draft; not flipped ready; not enqueued; `needs:contract-review` rides on both carriers (re-read 2026-09-05: the card and this PR both carry it).

## Ablation A — the six Zod declarations deleted (measured on `593be2ee9`; restored under trap, absolute paths)

Mutation proven on disk: anchored counts `yAxis: z.enum([left,right])` 0 and `label: I18nLabelSchema` 0; blob `f6769b2c` moved to `db9ef916`. Restore proven: blob equals the HEAD blob and `git diff HEAD` on the path is empty.

- Pin file: predicted 14 red / 13 green — observed `14 failed | 13 passed`. Matched.
- `zod-mirror-parity` under vitest: predicted red — observed `12 passed (12)`. **A miss.** The instrument was wrong, not the ratchet: the declared-but-unmirrored half (`UnmirroredDeclaredKeys`) is a compile-time assertion, and vitest does not typecheck. Re-run as leg A2 with `tsc -p tsconfig.test.json` under the same mutation (blob movement re-proven): predicted red naming the pair and the six keys — observed exit 2 with `zod-mirror-parity.test.ts(1478,14): error TS2322: Type '"data-display.zod.ts#ChartDataSeriesSchema"' is not assignable to type 'never'` plus `chart-series-keys-7546.test.ts(163,38): TS2339: Property 'label' does not exist`. Matched on instrument and pair; **partial miss on wording** — the error names the pair, not the keys. The review confirmed the channel is live in CI (`@object-ui/types:type-check`, cache miss, job success).

## Reverse verification B — the narrowing reverted (on `493b52eb3`; restored under trap, absolute paths)

Mutation: `git checkout 71f0c1941 -- packages/types/src/zod/data-display.zod.ts` (the merge commit's three-value enum), proven on disk: blob `f5c89fe4` moved to `f6769b2c`; anchored counts `'comparison', 'current'` 0 to 1 and `z.enum(['primary', 'comparison'])` 1 to 0. Predicted exactly 1 red / 26 green, the red being the new `current` refusal pin — observed `Tests 1 failed | 26 passed (27)`, that test. Restore proven: `git hash-object` equals the HEAD blob `f5c89fe4`, `git diff HEAD` empty, `git status` empty. No `dist/` is involved — the pin imports `../zod/data-display.zod` from source — so there is no rebuild leg to skip.

## Gates on the pushed head `5f7e032a8` (after the final commit)

Through `os-verify-lock.sh` (slot `objectui-7546`), joined with `&&`, the head echoed inside the hold (`union-head=5f7e032a8`) — verdict line `os-verify-lock: VERDICT command-exit 0` (shared-box seconds):

- `pnpm exec vitest run packages/types/ --maxWorkers=2` — `Test Files 107 passed (107)`, `Tests 1769 passed (1769)` (was 106 / 1768 on `493b52eb3`; the one new file is `main`'s #7662 pin `schema-registry-kanban-honesty-7645.test.ts`)
- `pnpm --filter @object-ui/types type-check` (three tsc projects, the tests included) — 0 errors
- `pnpm --filter @object-ui/types lint` — 0 errors, 269 pre-existing `no-explicit-any` warnings

Outside the lock, exit codes captured before any pipe, on the same head: `check:doc-fences` ✅ (227 documents), `check:doc-types` ✅ (188 doc files, 895 `type` literals, every documented type registered), `check:control-bytes` ✅ (6271 tracked files, plus a direct control-byte grep of the three edited files = 0), `check-changeset-presence` ✅ ("3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)"), `check-changeset-no-major` ✅, `check-changeset-overwrite` ✅ ("1 changeset(s) added, 0 modified" — the edited changeset is this branch's own).

The DOM probe itself (9 tests, one untracked file under `packages/plugin-charts/src/`, removed before the commit) ran through the same lock: `Tests 9 passed (9)`, verdict `command-exit 0`; it is an instrument, not a pin — pinning "dashArray is dropped on a comparison bar" would fossilise the very gap #7698 exists to close.

**NOT MEASURED locally: `check:doc-snippets`** — the same declared narrowing as before (it needs all 26 packages built): population `content/docs` plus the package READMEs; my one edited fence compiles standalone (`tsc --noEmit --strict --ignoreConfig`, exit 0); CI's `Doc Snippet Type Check` is the authority and was green on `593be2ee9`. Dependency build: not owed — `pnpm --filter '@object-ui/types^...' build` answers `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` (the only workspace dependency, `@object-ui/test-support`, has no build script); the package's runtime dependencies are `@objectstack/spec` and `zod` from `node_modules`. Consumer sweep: no structural consumer of `ChartSchema` / `ChartDataSeries` exists outside `packages/types` (`ChartRendererProps` types its schema inline), so no downstream type-check is owed.

## Docs

`content/docs/api/schema-reference.md` — the `series` row, now inside #7679's rewritten chart table (which teaches the rows model and the `data` tombstone), lists the declared keys with `variant` as the pair. `content/docs/plugins/plugin-charts.mdx` — the "Per-series options" table and example: `variant` is the pair, `opacity` says any finite number with the spec's bound and that it reaches every mark family on a comparison series, the `dashArray` row states the full condition (comparison AND a line/area mark), and the example is an `area` chart on which every key it writes is live (second remediation).

## Out of scope — filed, not fixed here

- objectui#7681 — a declared per-series `type` override is dropped when every entry is written with `dataKey`: the fast path forwards the array raw and the renderer reads only `chartType`. Open (`pm:queue`).
- objectui#7682 — series `variant` carries three different unions across four sites; `current` is an undocumented synonym of `primary` that core's `seriesPresentation` drops. Open (`finding`, `pm:queue`); it owns the normalizer's tolerance this PR leaves untouched.
- objectui#7690 — the chart-level axis-config object dialect (`xAxis` / `yAxis` objects) rides through `ChartSchema` unvalidated; filed by the PM seat from the card's own body. Open (`pm:queue`).
- objectui#7694 — series `chartType` is undeclared and silently stripped; the carrier for the named-alias-refusal shape, graded as its own narrowing. Open (`pm:queue`).
- objectui#7698 — series-level `opacity` / `dashArray` are honoured only on a `variant: 'comparison'` series while the spec declares them unconditional; filed from the first remediation. Open (`pm:queue`, p3, triaged 07:05Z with "do not open this as narrow the mirror").

Dev seat: Claude Code session `session_01KbJQ1y1J12nZxYzFWhP8Q3`, dispatched by the `domain:ui` PM seat; contract-review remediation by the same seat.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3

---
_Generated by [Claude Code](https://claude.ai/code)_