### PR TITLE
feat(types): one named authoring-face type per chatbot registration — ChatbotEnhancedSchema and ChatbotFloatingSchema (objectui#7655)

### DIFF
--- a/.changeset/7655-chatbot-registration-authoring-faces.md
+++ b/.changeset/7655-chatbot-registration-authoring-faces.md
@@ -35,22 +35,39 @@ per key on the PR's base (one `schema.KEY` read per registration body in
   'plain'`, objectui#6687) and the `onClear` runtime slot — four keys
   `ChatbotSchema` never declared.
 - **`ChatbotFloatingSchema`** (`type: 'chatbot-floating'`): the shared twenty,
-  plus `enableMarkdown`, `enableFileUpload`, `onClear`, `floatingConfig`
-  (`FloatingChatbotConfig`) and `displayMode`. No `maxHeight`,
-  `processVisibility` or `surface` — the floating registration forwards none of
-  them.
+  plus `enableMarkdown`, `enableFileUpload`, `onClear`, and the two keys it
+  declares alongside `ChatbotSchema` — `floatingConfig` (`FloatingChatbotConfig`)
+  and `displayMode`. No `maxHeight`, `processVisibility` or `surface`: the
+  floating registration has no named read for any of them. (Its trailing raw
+  props spread does carry authored keys into the panel today — `processVisibility`,
+  `surface` and `showAvatars` are live there, measured through the real host;
+  that accidental channel is tracked as objectui#7708, and this face neither
+  declares nor promises it.)
 - Neither face declares `ChatbotSchema`'s six legacy members (`loading`,
   `showAvatars`, `userAvatar`, `assistantAvatar`, `markdown`, `height`) — no
-  registration reads them — and neither redeclares `disabled`, which stays
-  `BaseSchema`'s `boolean | string` (objectui#7087).
+  registration reads them by name — and neither redeclares `disabled`, which
+  stays `BaseSchema`'s `boolean | string` (objectui#7087).
 
-**Two keys MOVED off `ChatbotSchema`:** `displayMode` and `floatingConfig`. The
-`chatbot` registration has no read, no designer control and no `defaultProps`
-seed for either; both are `chatbot-floating`'s. `displayMode` crossed UNCHANGED
-— same `'inline' | 'floating'` type, still unmirrored, still read by nothing —
-because its fate is objectui#7654's and that card is parked on a maintainer
-decision; a tripwire test pins that any value still parses green. Nothing was
-retired, tombstoned, mirrored or made live.
+**`ChatbotSchema` is unchanged.** It keeps `displayMode` and `floatingConfig`
+(declarations verbatim), and the floating face declares the same two, so
+`ChatbotSchema['displayMode']` and `ChatbotSchema['floatingConfig']` stay the
+typed members they were — the objectui#7669 `triggerIcon` tombstone keeps its
+reach on `chatbot` nodes, now pinned on the node. `floatingConfig`'s doc comment
+is rewritten on both faces: the old text said it was "only used when
+`displayMode` is `'floating'`", which was false — it is read by `chatbot-floating`
+alone and forwarded to the panel. `displayMode` is RULED RETIRED — objectui#7654,
+maintainer ruling B (2026-09-05): `?: never` tombstone, designer control and
+`defaultProps` seed removed, in that card's own change. This change carries the
+key untouched on both faces (still unmirrored, still read by nothing) so that PR
+finds the member exactly as ruled, and a tripwire test pins that any value still
+parses green until that PR flips it.
+
+**New published symbol:** `ChatbotSharedKey`, the string-literal union of the
+twenty keys all three registrations read. It is exported from `complex.ts`
+because an exported interface may not extend a `Pick` over a private name
+(TS4022), so it is emitted into `dist/complex.d.ts` and is reachable through the
+published `@object-ui/types/complex` subpath (it is not re-exported from the
+package entry). It is a census, not an authoring face.
 
 ## Zod twins, in lockstep
 
@@ -59,7 +76,8 @@ retired, tombstoned, mirrored or made live.
 arm except: the three runtime slots (`onError`, `onSend`, `onClear`), refused by
 name per objectui#6124; and, on the floating twin only, `floatingConfig` (no
 `FloatingChatbotConfig` mirror exists — minting one is objectui#6152's axis) and
-`displayMode` (objectui#7654). The twins mirror the API body params under the
+`displayMode` (unmirrored on `ChatbotSchema`'s twin too; retired by ruling on
+objectui#7654 and executed there). The twins mirror the API body params under the
 key the renderer reads, `requestBody`, and inherit `body` as the children slot —
 they do not copy `ChatbotSchema`'s `body` naming collision.
 
@@ -84,7 +102,7 @@ objectui#4431. No render outcome moves; the pin renders through the real host
 both ways.
 
 This ships as `minor` for `@object-ui/types` because it widens the published
-surface with two new node types and two new Zod twins, and moves two declared
-keys from one face to another: objectui's major is pinned to `@objectstack`'s
+surface with two new node types, two new Zod twins and one new type alias;
+`ChatbotSchema`'s own accept set does not move: objectui's major is pinned to `@objectstack`'s
 (`scripts/check-changeset-no-major.mjs`), and objectui's own contract changes
 ship as `minor` with the semantics spelled out — as above.

--- a/.changeset/7655-chatbot-registration-authoring-faces.md
+++ b/.changeset/7655-chatbot-registration-authoring-faces.md
@@ -1,0 +1,90 @@
+---
+'@object-ui/types': minor
+'@object-ui/plugin-chatbot': patch
+---
+
+One named, importable authoring-face type per `plugin-chatbot` registration:
+`ChatbotEnhancedSchema` and `ChatbotFloatingSchema` join `ChatbotSchema`
+(objectui#7655, under the objectui#6169 / #6172 family ruling — every component
+node has exactly one named, importable authoring-face type).
+
+`packages/plugin-chatbot` registers three components — `chatbot`,
+`chatbot-enhanced`, `chatbot-floating` — and `@object-ui/types` published ONE
+face for the family with `type` pinned to `'chatbot'`. An author annotating a
+`chatbot-enhanced` or `chatbot-floating` node either dropped to untyped JSON or
+annotated with `ChatbotSchema` and lied about `type`; the docs' floating example
+had to be a `json` fence because no `tsx` fence could compile. The two
+registrations' real key sets lived in anonymous `ChatbotSchema & { ... }`
+intersections local to the renderer, referenceable by nothing outside that file.
+
+## The shape, and why not the smaller diff
+
+One interface per registration, not `ChatbotSchema['type']` widened to the union
+of the three keys. The union would give three nodes ONE type and re-open what
+#6169 closed — a single interface declaring keys only some of its own `type`
+values read — and this card exists because the family's declarations had already
+drifted from its reads. Each face declares what ITS registration reads, censused
+per key on the PR's base (one `schema.KEY` read per registration body in
+`renderer.tsx`, lit by keys that are NOT shared: `processVisibility` 0 / 1 / 0,
+`floatingConfig` 0 / 0 / 1), and the twenty keys all three read are picked off
+`ChatbotSchema` by name (`ChatbotSharedKey`) so they stay one declaration:
+
+- **`ChatbotEnhancedSchema`** (`type: 'chatbot-enhanced'`): the shared twenty,
+  plus `maxHeight` and `processVisibility` (read here, not by the floating
+  panel), plus `enableMarkdown`, `enableFileUpload`, `surface` (`'card' |
+  'plain'`, objectui#6687) and the `onClear` runtime slot — four keys
+  `ChatbotSchema` never declared.
+- **`ChatbotFloatingSchema`** (`type: 'chatbot-floating'`): the shared twenty,
+  plus `enableMarkdown`, `enableFileUpload`, `onClear`, `floatingConfig`
+  (`FloatingChatbotConfig`) and `displayMode`. No `maxHeight`,
+  `processVisibility` or `surface` — the floating registration forwards none of
+  them.
+- Neither face declares `ChatbotSchema`'s six legacy members (`loading`,
+  `showAvatars`, `userAvatar`, `assistantAvatar`, `markdown`, `height`) — no
+  registration reads them — and neither redeclares `disabled`, which stays
+  `BaseSchema`'s `boolean | string` (objectui#7087).
+
+**Two keys MOVED off `ChatbotSchema`:** `displayMode` and `floatingConfig`. The
+`chatbot` registration has no read, no designer control and no `defaultProps`
+seed for either; both are `chatbot-floating`'s. `displayMode` crossed UNCHANGED
+— same `'inline' | 'floating'` type, still unmirrored, still read by nothing —
+because its fate is objectui#7654's and that card is parked on a maintainer
+decision; a tripwire test pins that any value still parses green. Nothing was
+retired, tombstoned, mirrored or made live.
+
+## Zod twins, in lockstep
+
+`@object-ui/types/zod` gains `ChatbotEnhancedSchema` and `ChatbotFloatingSchema`
+(and `ComplexSchema` routes the two new discriminants). Every declared key is an
+arm except: the three runtime slots (`onError`, `onSend`, `onClear`), refused by
+name per objectui#6124; and, on the floating twin only, `floatingConfig` (no
+`FloatingChatbotConfig` mirror exists — minting one is objectui#6152's axis) and
+`displayMode` (objectui#7654). The twins mirror the API body params under the
+key the renderer reads, `requestBody`, and inherit `body` as the children slot —
+they do not copy `ChatbotSchema`'s `body` naming collision.
+
+**Accept-set change, stated plainly:** a `chatbot-enhanced` or `chatbot-floating`
+document parsed through the family's only twin used to fail on `type`; through
+its own twin it now parses, and the keys the twin declares are VALIDATED where
+they rode through `.passthrough()` unexamined before (`surface: 'frameless'`,
+`enableMarkdown: 'yes'` and `requestBody: 'x'` are refused). A `chatbot` node's
+parse outcome is unchanged: `ChatbotSchema`'s twin did not move.
+
+## `@object-ui/plugin-chatbot`
+
+The `chatbot-enhanced` and `chatbot-floating` registrations type `schema` as the
+published faces and drop the anonymous intersections. One consequence:
+`chatbot-floating` used to write `disabled={schema.disabled}` and then spread
+`{...props}` AFTER it — and `SchemaRenderer` always includes `disabled: verdict
+|| undefined` in those props, so the raw read was overridden on every render.
+With `disabled` honestly typed as `boolean | string` the raw union cannot be
+forwarded into the panel's `boolean` prop, so the registration now names the
+host verdict (`disabled: hostDisabled`) the way its two siblings have since
+objectui#4431. No render outcome moves; the pin renders through the real host
+both ways.
+
+This ships as `minor` for `@object-ui/types` because it widens the published
+surface with two new node types and two new Zod twins, and moves two declared
+keys from one face to another: objectui's major is pinned to `@objectstack`'s
+(`scripts/check-changeset-no-major.mjs`), and objectui's own contract changes
+ship as `minor` with the semantics spelled out — as above.

--- a/content/docs/plugins/plugin-chatbot.mdx
+++ b/content/docs/plugins/plugin-chatbot.mdx
@@ -150,8 +150,14 @@ twenty shared rows below are one declaration the two newer faces pick off
 registration reads it. A key a registration ignores is therefore not a declared
 member of its type. It still type-checks (`BaseSchema` ends in an index
 signature, so an unlisted key is `any` rather than an error) and still parses
-(the Zod twins are `.passthrough()`), and it is dropped silently at render
-time - which is why the scope is spelled out here as well as in the types.
+(the Zod twins are `.passthrough()`). On `chatbot` and `chatbot-enhanced` it is
+then dropped silently at render time. `chatbot-floating` is different today: its
+registration forwards the whole authored node to the panel through an
+unfiltered props spread, so some keys its type does not declare
+(`processVisibility`, `surface`, `showAvatars`) do reach the panel - an
+accidental channel, measured and tracked as objectui#7708, not a contract to
+author against. That is why the scope is spelled out here as well as in the
+types.
 
 The table below is that shared chat surface. `chatbot-floating` declares
 seven more keys of its own - `displayMode` and six `floatingConfig` entries -
@@ -183,8 +189,8 @@ one, under **`chatbot-floating` panel and trigger keys**.
 | `headers` | object | - | Additional headers for API requests |
 | `requestBody` | object | - | Additional body parameters sent with each API request. Authored on the node as `requestBody`; the renderer forwards it to the chat runtime under its own `body` option. Writing `body` on the node instead sets the base schema's children container and never reaches the API |
 | `maxToolRoundtrips` | number | - | **Deprecated - has no effect.** Nothing reads this value, so it never capped anything. Cap tool-calling loops on the agent instead (`planning.maxIterations`). Still accepted so existing documents keep parsing; slated for removal in a future major |
-| `surface` | `'card' \| 'plain'` | `'card'` | **`chatbot-enhanced` only** (declared on `ChatbotEnhancedSchema`). Controls whether the chat renders as a bordered panel (`'card'`) or a frameless full-page workspace (`'plain'`). The `chatbot` and `chatbot-floating` registrations render different components, which have no such chrome to switch, and do not read this key |
-| `processVisibility` | `'hidden' \| 'summary' \| 'debug'` | `'summary'` | **`chatbot-enhanced` only** (declared on `ChatbotEnhancedSchema`; `ChatbotSchema` still declares it too, though the `chatbot` registration has no read for it). Controls how much agent reasoning and tool detail is shown. `chatbot` renders the plain chat component, which has no agent-process display to configure at all - switch the node to `chatbot-enhanced` if you need one. `chatbot-floating` does not forward the key either, so its panel always renders at the `'summary'` default; there is no floating-side substitute to author |
+| `surface` | `'card' \| 'plain'` | `'card'` | **`chatbot-enhanced` only** (declared on `ChatbotEnhancedSchema`). Controls whether the chat renders as a bordered panel (`'card'`) or a frameless full-page workspace (`'plain'`). `chatbot` renders the plain chat component, which has no such chrome to switch, and does not read this key. `chatbot-floating` has no named read for it and `ChatbotFloatingSchema` does not declare it; its panel is a `ChatbotEnhanced`, and an authored value currently reaches that panel only through the registration's unfiltered props spread (objectui#7708) - not a contract to author against |
+| `processVisibility` | `'hidden' \| 'summary' \| 'debug'` | `'summary'` | **`chatbot-enhanced` only** (declared on `ChatbotEnhancedSchema`; `ChatbotSchema` still declares it too, though the `chatbot` registration has no read for it). Controls how much agent reasoning and tool detail is shown. `chatbot` renders the plain chat component, which has no agent-process display to configure at all - switch the node to `chatbot-enhanced` if you need one. `chatbot-floating` has no named read for it and `ChatbotFloatingSchema` does not declare it; an authored value currently reaches its panel only through the registration's unfiltered props spread (objectui#7708), which is not a contract - there is no floating-side substitute to author |
 | `onError` | function | - | Error callback for streaming/API errors |
 
 ### `chatbot-floating` panel and trigger keys
@@ -193,14 +199,15 @@ The seven keys below are declared in the `chatbot-floating` registration's own
 `inputs` (`packages/plugin-chatbot/src/renderer.tsx`). They configure the
 floating action button and the panel it opens; the `chatbot` and
 `chatbot-enhanced` registrations render neither and ignore them. `displayMode`
-and `floatingConfig` are declared on `ChatbotFloatingSchema` only (objectui#7655
-moved them off `ChatbotSchema`, whose `chatbot` node never read either);
-authoring them on an inline node still type-checks through the index signature
-and still parses - it is dropped at render time.
+and `floatingConfig` are declared on `ChatbotSchema` and on
+`ChatbotFloatingSchema` alike (objectui#7655 declared the floating face with the
+same two members; `ChatbotSchema` kept its own), so authoring them on an inline
+node type-checks and parses - and is dropped at render time, because the
+`chatbot` node never read either.
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `displayMode` | `'inline' \| 'floating'` | `'floating'` | **Declared and offered in the designer, but read by nothing.** The node's own `type` selects the presentation: a `chatbot-floating` node renders the trigger and panel unconditionally, and authoring `'inline'` here does not make it inline - author a `chatbot` node for that. The registration declares it with `defaultValue: 'floating'` and writes the same value into its `defaultProps`, so nodes created in the designer carry it |
+| `displayMode` | `'inline' \| 'floating'` | `'floating'` | **Declared and offered in the designer, but read by nothing.** The node's own `type` selects the presentation: a `chatbot-floating` node renders the trigger and panel unconditionally, and authoring `'inline'` here does not make it inline - author a `chatbot` node for that. The registration declares it with `defaultValue: 'floating'` and writes the same value into its `defaultProps`, so nodes created in the designer carry it. objectui#7654 ruled it retired (maintainer, 2026-09-05): the declaration becomes a `never` tombstone and the designer control and default are removed in that card's own change; until that lands the key is carried exactly as described here |
 | `floatingConfig.position` | `'bottom-right' \| 'bottom-left'` | `'bottom-right'` | Corner the trigger sits in; the panel is anchored to the same side |
 | `floatingConfig.defaultOpen` | boolean | `false` | Whether the panel is already open when the node mounts |
 | `floatingConfig.panelWidth` | number | `400` | Panel width in pixels, applied from the `sm` breakpoint up - below it the panel is full-bleed. Snapped to a step, see below |

--- a/content/docs/plugins/plugin-chatbot.mdx
+++ b/content/docs/plugins/plugin-chatbot.mdx
@@ -139,10 +139,19 @@ This page documents **three** registrations - `chatbot`, `chatbot-enhanced` and
 `chatbot-floating` - and they do not all read the same keys. **A row whose
 description carries no bolded scope note is read by all three.** The rows only
 some of them read say so in bold at the start of the description, and name what
-to author instead on the registrations that ignore the key. Every key below is
-declared on `ChatbotSchema`, so a key a registration ignores still type-checks
-and still parses - it is dropped silently at render time, which is why the scope
-is spelled out here rather than left to the type to express.
+to author instead on the registrations that ignore the key.
+
+Each registration has its own importable authoring-face type in
+`@object-ui/types` (objectui#7655): `ChatbotSchema` for `chatbot`,
+`ChatbotEnhancedSchema` for `chatbot-enhanced` and `ChatbotFloatingSchema` for
+`chatbot-floating`. Each declares exactly the keys its registration reads - the
+twenty shared rows below are one declaration the two newer faces pick off
+`ChatbotSchema` by name, and a scoped row is declared only on the face(s) whose
+registration reads it. A key a registration ignores is therefore not a declared
+member of its type. It still type-checks (`BaseSchema` ends in an index
+signature, so an unlisted key is `any` rather than an error) and still parses
+(the Zod twins are `.passthrough()`), and it is dropped silently at render
+time - which is why the scope is spelled out here as well as in the types.
 
 The table below is that shared chat surface. `chatbot-floating` declares
 seven more keys of its own - `displayMode` and six `floatingConfig` entries -
@@ -160,7 +169,7 @@ one, under **`chatbot-floating` panel and trigger keys**.
 | `userAvatarFallback` | string | `'You'` | Fallback text for user avatar |
 | `assistantAvatarUrl` | string | - | URL for assistant avatar image |
 | `assistantAvatarFallback` | string | `'AI'` | Fallback text for assistant avatar |
-| `maxHeight` | string | `'500px'` | **`chatbot` and `chatbot-enhanced` only.** Maximum height of the chat message container, as a CSS length. `chatbot-floating` does not read it: its panel is sized by `floatingConfig.panelHeight` (a **number** of pixels, default `520`), and the panel pins its inner chat to `maxHeight: '100%'` so it fills that panel - a `maxHeight` authored on a floating node would be overridden even if it were forwarded. Size a floating chatbot with `floatingConfig.panelHeight` instead |
+| `maxHeight` | string | `'500px'` | **`chatbot` and `chatbot-enhanced` only** (declared on `ChatbotSchema` and `ChatbotEnhancedSchema`; `ChatbotFloatingSchema` does not declare it). Maximum height of the chat message container, as a CSS length. `chatbot-floating` does not read it: its panel is sized by `floatingConfig.panelHeight` (a **number** of pixels, default `520`), and the panel pins its inner chat to `maxHeight: '100%'` so it fills that panel - a `maxHeight` authored on a floating node would be overridden even if it were forwarded. Size a floating chatbot with `floatingConfig.panelHeight` instead |
 | `autoResponse` | boolean | `false` | Enable auto-response (demo mode, ignored when `api` is set) |
 | `autoResponseText` | string | - | Text for auto-response |
 | `autoResponseDelay` | number | `1000` | Delay before auto-response (ms) |
@@ -174,8 +183,8 @@ one, under **`chatbot-floating` panel and trigger keys**.
 | `headers` | object | - | Additional headers for API requests |
 | `requestBody` | object | - | Additional body parameters sent with each API request. Authored on the node as `requestBody`; the renderer forwards it to the chat runtime under its own `body` option. Writing `body` on the node instead sets the base schema's children container and never reaches the API |
 | `maxToolRoundtrips` | number | - | **Deprecated - has no effect.** Nothing reads this value, so it never capped anything. Cap tool-calling loops on the agent instead (`planning.maxIterations`). Still accepted so existing documents keep parsing; slated for removal in a future major |
-| `surface` | `'card' \| 'plain'` | `'card'` | **`chatbot-enhanced` only.** Controls whether the chat renders as a bordered panel (`'card'`) or a frameless full-page workspace (`'plain'`). The `chatbot` and `chatbot-floating` registrations render different components, which have no such chrome to switch, and do not read this key |
-| `processVisibility` | `'hidden' \| 'summary' \| 'debug'` | `'summary'` | **`chatbot-enhanced` only.** Controls how much agent reasoning and tool detail is shown. `chatbot` renders the plain chat component, which has no agent-process display to configure at all - switch the node to `chatbot-enhanced` if you need one. `chatbot-floating` does not forward the key either, so its panel always renders at the `'summary'` default; there is no floating-side substitute to author |
+| `surface` | `'card' \| 'plain'` | `'card'` | **`chatbot-enhanced` only** (declared on `ChatbotEnhancedSchema`). Controls whether the chat renders as a bordered panel (`'card'`) or a frameless full-page workspace (`'plain'`). The `chatbot` and `chatbot-floating` registrations render different components, which have no such chrome to switch, and do not read this key |
+| `processVisibility` | `'hidden' \| 'summary' \| 'debug'` | `'summary'` | **`chatbot-enhanced` only** (declared on `ChatbotEnhancedSchema`; `ChatbotSchema` still declares it too, though the `chatbot` registration has no read for it). Controls how much agent reasoning and tool detail is shown. `chatbot` renders the plain chat component, which has no agent-process display to configure at all - switch the node to `chatbot-enhanced` if you need one. `chatbot-floating` does not forward the key either, so its panel always renders at the `'summary'` default; there is no floating-side substitute to author |
 | `onError` | function | - | Error callback for streaming/API errors |
 
 ### `chatbot-floating` panel and trigger keys
@@ -184,9 +193,10 @@ The seven keys below are declared in the `chatbot-floating` registration's own
 `inputs` (`packages/plugin-chatbot/src/renderer.tsx`). They configure the
 floating action button and the panel it opens; the `chatbot` and
 `chatbot-enhanced` registrations render neither and ignore them. `displayMode`
-and `floatingConfig` are declared on `ChatbotSchema` like every key above, so
-authoring them on an inline node still type-checks and still parses - it is
-dropped at render time.
+and `floatingConfig` are declared on `ChatbotFloatingSchema` only (objectui#7655
+moved them off `ChatbotSchema`, whose `chatbot` node never read either);
+authoring them on an inline node still type-checks through the index signature
+and still parses - it is dropped at render time.
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
@@ -211,25 +221,31 @@ On small screens `panelHeight` is additionally capped to the viewport
 (`min(step, 100svh - 6rem - safe-area-inset-bottom)`), and while the panel is
 fullscreen it ignores both size keys and fills the screen.
 
-Authored on the node:
+Authored on the node, with the node's own type - `ChatbotFloatingSchema` pins
+`type` to `'chatbot-floating'` and declares `floatingConfig`, so this fence
+compiles against the published types. (Until objectui#7655 no type could
+annotate a floating node - `ChatbotSchema` pins `type` to `'chatbot'` - and
+this example had to be untyped JSON.)
 
-```json
-{
-  "type": "chatbot-floating",
-  "floatingConfig": {
-    "position": "bottom-left",
-    "defaultOpen": false,
-    "panelWidth": 400,
-    "panelHeight": 520,
-    "title": "Support",
-    "triggerSize": 56
+```tsx
+import type { ChatbotFloatingSchema } from '@object-ui/types';
+
+const supportChat: ChatbotFloatingSchema = {
+  type: 'chatbot-floating',
+  messages: [], // seed with your own ChatMessage values
+  floatingConfig: {
+    position: 'bottom-left',
+    defaultOpen: false,
+    panelWidth: 400,
+    panelHeight: 520,
+    title: 'Support',
+    triggerSize: 56,
   },
-  "placeholder": "Ask us anything..."
-}
+  placeholder: 'Ask us anything...',
+};
 ```
 
-`ChatbotSchema` pins `type` to `'chatbot'`, so it cannot annotate a floating
-node, but the config object has its own exported type:
+The config object also has its own exported type:
 
 ```tsx
 import type { FloatingChatbotConfig } from '@object-ui/types';
@@ -335,6 +351,22 @@ By default, `ChatbotEnhanced` renders tool invocations as a compact agent activi
 Use `surface="plain"` for full-page chat workspaces where the surrounding app
 already provides navigation chrome. The default `surface="card"` remains a
 better fit for embedded dashboards, side panels, and floating chat windows.
+
+Both keys are authorable as metadata on a `chatbot-enhanced` node, typed with
+that node's own face (objectui#7655):
+
+```tsx
+import type { ChatbotEnhancedSchema } from '@object-ui/types';
+
+const workspace: ChatbotEnhancedSchema = {
+  type: 'chatbot-enhanced',
+  messages: [], // seed with your own ChatMessage values
+  api: '/api/v1/ai/chat',
+  surface: 'plain',
+  processVisibility: 'debug',
+  enableFileUpload: true,
+};
+```
 
 Console chat surfaces also keep a sanitized browser-side display cache for the
 current conversation. When a conversation can be reopened but the server returns
@@ -573,8 +605,13 @@ const schema: ChatbotSchema = {
 
 ## TypeScript Support
 
+Each of the three registrations has its own authoring-face type:
+`ChatbotSchema` (`chatbot`), `ChatbotEnhancedSchema` (`chatbot-enhanced`) and
+`ChatbotFloatingSchema` (`chatbot-floating`) - see the typed examples under
+**Tool Messages** and **`chatbot-floating` panel and trigger keys** above.
+
 ```plaintext
-import type { ChatbotSchema, ChatMessage, ChatToolInvocation } from '@object-ui/types'
+import type { ChatbotSchema, ChatbotEnhancedSchema, ChatbotFloatingSchema, ChatMessage, ChatToolInvocation } from '@object-ui/types'
 import { useObjectChat } from '@object-ui/plugin-chatbot'
 
 // Basic messages

--- a/packages/plugin-chatbot/src/__tests__/renderer.authoring-faces-7655.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/renderer.authoring-faces-7655.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * The `chatbot-enhanced` and `chatbot-floating` registrations type their
+ * `schema` against the PUBLISHED faces (objectui#7655) — and the one runtime
+ * consequence of doing so is pinned.
+ *
+ * ## The three things this file pins
+ *
+ *   1. **The registrations consume the published faces.** Read off the
+ *      renderer's own source: each registration's parameter annotation names
+ *      `ChatbotEnhancedSchema` / `ChatbotFloatingSchema`, and no anonymous
+ *      `ChatbotSchema & { ... }` intersection is left in the file. A source pin
+ *      rather than a type pin because `ComponentRegistry` is untyped — the
+ *      registered component's props type is not recoverable from the registry.
+ *   2. **One vocabulary, two spellings, pinned equal.** `ChatbotEnhanced.tsx`
+ *      owns `ChatbotSurface` and `ChatbotProcessVisibility` as component props;
+ *      `@object-ui/types` declares the same unions on the face. Neither can
+ *      widen without the other or this goes red at `tsc -p tsconfig.test.json`
+ *      (compile-time — erased before vitest runs).
+ *   3. **`chatbot-floating` consumes the host's evaluated `disabled` verdict.**
+ *      Before #7655 it wrote `disabled={schema.disabled}` and then spread
+ *      `{...props}` AFTER it — and `SchemaRenderer` always includes
+ *      `disabled: verdict || undefined` in those props, so the raw read was
+ *      overridden on every render. Typing the face honestly (`disabled` stays
+ *      `BaseSchema`'s `boolean | string`, objectui#7087) means the raw union
+ *      cannot be forwarded into the panel's `boolean` prop, so the registration
+ *      now names the verdict the way its two siblings do. The render cases
+ *      below measure the OUTCOME through the real SDUI host — the composer is
+ *      disabled when the node says so and enabled when it does not — which is
+ *      what must not move.
+ *
+ * The runtime cases render through `SchemaRenderer`, not the bare component,
+ * for the reason `renderer.surface.test.tsx` gives: what is measured is what
+ * an AUTHOR gets.
+ */
+
+import '@testing-library/jest-dom/vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+import type { ChatbotEnhancedSchema } from '@object-ui/types';
+import type { ChatbotProcessVisibility, ChatbotSurface } from '../ChatbotEnhanced';
+// Side-effect import: this is what registers the chat components.
+import '../renderer';
+
+/* ── 2. One vocabulary, two spellings (the `tsc` channel) ────────────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+export type assertionSurfaceIsOneContract = Expect<
+  Equal<ChatbotSurface, NonNullable<ChatbotEnhancedSchema['surface']>>
+>;
+export type assertionProcessVisibilityIsOneContract = Expect<
+  Equal<ChatbotProcessVisibility, NonNullable<ChatbotEnhancedSchema['processVisibility']>>
+>;
+
+/* ── 1. The registrations consume the published faces ────────────────────── */
+
+const RENDERER = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'renderer.tsx'), 'utf8');
+
+/** The body of one `ComponentRegistry.register('<key>', ...)` call, up to the next registration. */
+function registration(key: string): string {
+  const start = RENDERER.indexOf(`ComponentRegistry.register('${key}',`);
+  if (start < 0) throw new Error(`no registration for ${key}`);
+  const next = RENDERER.indexOf('ComponentRegistry.register(', start + 1);
+  return RENDERER.slice(start, next < 0 ? undefined : next);
+}
+
+describe('the registrations type `schema` as the published faces (objectui#7655)', () => {
+  it("`chatbot-enhanced` names `ChatbotEnhancedSchema`; `chatbot-floating` names `ChatbotFloatingSchema`", () => {
+    expect(registration('chatbot-enhanced')).toContain('schema: ChatbotEnhancedSchema;');
+    expect(registration('chatbot-floating')).toContain('schema: ChatbotFloatingSchema;');
+    // Lit control: the `chatbot` registration still names its own face.
+    expect(registration('chatbot')).toContain('schema: ChatbotSchema;');
+  });
+
+  it('no anonymous `ChatbotSchema & { ... }` intersection is left in the renderer', () => {
+    // Code only: strip line and block comments before counting, since the
+    // registrations' own comments recount the history in those exact words.
+    const code = RENDERER.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(code.match(/ChatbotSchema\s*&\s*\{/g) ?? []).toEqual([]);
+  });
+
+  it('`chatbot-floating` consumes the host verdict, not the raw `schema.disabled`', () => {
+    const floating = registration('chatbot-floating').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(floating).toContain('disabled: hostDisabled');
+    expect(floating).toContain('disabled={hostDisabled}');
+    expect(floating).not.toContain('schema.disabled');
+  });
+});
+
+/* ── 3. The `disabled` outcome, through the real host ────────────────────── */
+
+const FAKE_ADAPTER = {
+  find: async () => [],
+  findOne: async () => null,
+  aggregate: async () => [],
+  count: async () => 0,
+  getObject: async () => null,
+};
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).ResizeObserver ??= class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+    (Element.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView = () => {};
+  }
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Renders a `chatbot-floating` node with the panel open and returns its composer. */
+async function renderFloatingComposer(extra: Record<string, unknown>): Promise<HTMLTextAreaElement> {
+  render(
+    <SchemaRendererProvider dataSource={FAKE_ADAPTER as never}>
+      <SchemaRenderer
+        schema={{
+          type: 'plugin-chatbot:chatbot-floating',
+          id: 'chat-node',
+          messages: [],
+          floatingConfig: { defaultOpen: true, title: 'Chat' },
+          ...extra,
+        } as never}
+        dataSource={FAKE_ADAPTER as never}
+      />
+    </SchemaRendererProvider>,
+  );
+  // The panel mounts through a portal onto `document.body`, so query the body.
+  await waitFor(() => {
+    if (!document.body.querySelector('textarea')) {
+      throw new Error(`the floating panel never reached its composer. Body was:\n${document.body.innerHTML.slice(0, 600)}`);
+    }
+  });
+  return document.body.querySelector('textarea') as HTMLTextAreaElement;
+}
+
+describe('chatbot-floating: `disabled` is the host-evaluated verdict (objectui#7655)', () => {
+  it('an authored `disabled: true` disables the composer', async () => {
+    const composer = await renderFloatingComposer({ disabled: true });
+    expect(composer).toBeDisabled();
+  });
+
+  it('an UNAUTHORED `disabled` leaves the composer enabled — the absent case is unchanged', async () => {
+    const composer = await renderFloatingComposer({});
+    expect(composer).toBeEnabled();
+  });
+
+  it('an authored `disabled: false` leaves the composer enabled', async () => {
+    const composer = await renderFloatingComposer({ disabled: false });
+    expect(composer).toBeEnabled();
+  });
+});

--- a/packages/plugin-chatbot/src/__tests__/renderer.authoring-faces-7655.test.tsx
+++ b/packages/plugin-chatbot/src/__tests__/renderer.authoring-faces-7655.test.tsx
@@ -11,7 +11,7 @@
  * `schema` against the PUBLISHED faces (objectui#7655) — and the one runtime
  * consequence of doing so is pinned.
  *
- * ## The three things this file pins
+ * ## The four things this file pins
  *
  *   1. **The registrations consume the published faces.** Read off the
  *      renderer's own source: each registration's parameter annotation names
@@ -35,6 +35,19 @@
  *      below measure the OUTCOME through the real SDUI host — the composer is
  *      disabled when the node says so and enabled when it does not — which is
  *      what must not move.
+ *   4. **`chatbot-floating` has a second channel the named-read census cannot
+ *      see — TRIPWIRE, not contract.** The registration ends its
+ *      `FloatingChatbot` element with a raw `{...props}` spread, LAST, where
+ *      its two siblings spread `toDomProps(props)` FIRST. So three keys
+ *      `ChatbotFloatingSchema` does NOT declare — and the named-read census in
+ *      `@object-ui/types`' `chatbot-registration-authoring-faces-7655.test.ts`
+ *      correctly reads 0 for — still reach the panel's `ChatbotEnhanced`:
+ *      `showAvatars`, `surface`, `processVisibility`. The cases below pin that
+ *      MEASUREMENT (lit/dark pairs on a floating node, `chatbot-enhanced` as the
+ *      control) so the face's docblock cannot rot silently. They do not make the
+ *      channel a contract: fencing the spread like the siblings, or declaring
+ *      the keys, is objectui#7708's ruling, and whichever lands flips these
+ *      pins with it — deliberately, never silently.
  *
  * The runtime cases render through `SchemaRenderer`, not the bare component,
  * for the reason `renderer.surface.test.tsx` gives: what is measured is what
@@ -47,6 +60,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import { render, waitFor, cleanup } from '@testing-library/react';
+import { toDomProps } from '@object-ui/core';
 import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
 import type { ChatbotEnhancedSchema } from '@object-ui/types';
 import type { ChatbotProcessVisibility, ChatbotSurface } from '../ChatbotEnhanced';
@@ -165,5 +179,83 @@ describe('chatbot-floating: `disabled` is the host-evaluated verdict (objectui#7
   it('an authored `disabled: false` leaves the composer enabled', async () => {
     const composer = await renderFloatingComposer({ disabled: false });
     expect(composer).toBeEnabled();
+  });
+});
+
+/* ── 4. The raw spread is a second channel — TRIPWIRE for objectui#7708 ── */
+
+/** An assistant turn with a tool result: `processVisibility: 'debug'` shows the raw tool name; `'summary'` (the default) does not. */
+const ASSISTANT_WITH_TOOL = [
+  {
+    id: 'a1',
+    role: 'assistant',
+    content: 'seed reply',
+    toolInvocations: [{ toolCallId: 't1', toolName: 'search_records', state: 'result', args: { q: 'x' }, result: { rows: 3 } }],
+  },
+];
+
+/** Renders one node through the real host and returns the root to query — `document.body` (the floating panel portals there). */
+async function renderNode(kind: 'chatbot-floating' | 'chatbot-enhanced', extra: Record<string, unknown>): Promise<HTMLElement> {
+  render(
+    <SchemaRendererProvider dataSource={FAKE_ADAPTER as never}>
+      <SchemaRenderer
+        schema={{
+          type: `plugin-chatbot:${kind}`,
+          id: 'chat-node',
+          messages: ASSISTANT_WITH_TOOL,
+          autoResponse: false,
+          ...(kind === 'chatbot-floating' ? { floatingConfig: { defaultOpen: true, title: 'Chat' } } : {}),
+          ...extra,
+        } as never}
+        dataSource={FAKE_ADAPTER as never}
+      />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => {
+    if (!document.body.querySelector('textarea')) {
+      throw new Error(`the ${kind} node never reached its composer. Body was:\n${document.body.innerHTML.slice(0, 600)}`);
+    }
+  });
+  return document.body;
+}
+
+/** The per-message avatar `MessageAvatar` renders only when `showAvatars` is on. */
+const AVATAR = 'div.size-7.rounded-full[aria-hidden="true"]';
+
+describe('chatbot-floating: three undeclared keys are LIVE through the raw spread — tripwire for objectui#7708', () => {
+  it('the spread really is the difference: `showAvatars` survives `props` and not `toDomProps(props)`', () => {
+    // The mechanism, pinned on the whitelist itself so the render readings
+    // below have a stated cause and not just a correlation.
+    const props = { showAvatars: true, surface: 'plain', processVisibility: 'debug', className: 'x' };
+    expect(toDomProps(props)).not.toHaveProperty('showAvatars');
+    expect(toDomProps(props)).not.toHaveProperty('surface');
+    expect(toDomProps(props)).not.toHaveProperty('processVisibility');
+    expect(toDomProps(props)).toHaveProperty('className', 'x'); // lit control
+  });
+
+  it('`showAvatars: true` renders the message avatar on a floating node (lit 1 / dark 0); dark on `chatbot-enhanced` either way', async () => {
+    expect((await renderNode('chatbot-floating', { showAvatars: true })).querySelectorAll(AVATAR)).toHaveLength(1);
+    cleanup();
+    expect((await renderNode('chatbot-floating', {})).querySelectorAll(AVATAR)).toHaveLength(0);
+    cleanup();
+    expect((await renderNode('chatbot-enhanced', { showAvatars: true })).querySelectorAll(AVATAR)).toHaveLength(0);
+  });
+
+  it("`surface: 'plain'` reaches the floating panel (two `.max-w-2xl` wrappers lit / 0 dark) — `chatbot-enhanced` reads it by name, so it lights there too", async () => {
+    expect((await renderNode('chatbot-floating', { surface: 'plain' })).querySelectorAll('.max-w-2xl')).toHaveLength(2);
+    cleanup();
+    expect((await renderNode('chatbot-floating', {})).querySelectorAll('.max-w-2xl')).toHaveLength(0);
+    cleanup();
+    expect((await renderNode('chatbot-enhanced', { surface: 'plain' })).querySelectorAll('.max-w-2xl')).toHaveLength(2);
+  });
+
+  it("`processVisibility: 'debug'` reaches the floating panel (raw tool name shown / hidden at the default) — named read lights `chatbot-enhanced` the same way", async () => {
+    expect((await renderNode('chatbot-floating', { processVisibility: 'debug' })).textContent).toContain('search_records');
+    cleanup();
+    expect((await renderNode('chatbot-floating', {})).textContent).not.toContain('search_records');
+    cleanup();
+    expect((await renderNode('chatbot-enhanced', { processVisibility: 'debug' })).textContent).toContain('search_records');
+    cleanup();
+    expect((await renderNode('chatbot-enhanced', {})).textContent).not.toContain('search_records');
   });
 });

--- a/packages/plugin-chatbot/src/renderer.tsx
+++ b/packages/plugin-chatbot/src/renderer.tsx
@@ -8,13 +8,11 @@
 
 import { useMemo } from 'react';
 import { ComponentRegistry, toDomProps } from '@object-ui/core';
-import type { ChatbotSchema } from '@object-ui/types';
+import type { ChatbotSchema, ChatbotEnhancedSchema, ChatbotFloatingSchema } from '@object-ui/types';
 import { Chatbot } from './index';
 import { ChatbotEnhanced } from './ChatbotEnhanced';
-import type { ChatbotSurface } from './ChatbotEnhanced';
 import { FloatingChatbot } from './FloatingChatbot';
 import { useObjectChat } from './useObjectChat';
-import type { ObjectChatMessage } from './useObjectChat';
 import { toRuntimeMessages } from './chatMessageAdapter';
 
 /**
@@ -269,33 +267,19 @@ ComponentRegistry.register('chatbot',
 
 // Register Enhanced Chatbot
 ComponentRegistry.register('chatbot-enhanced',
-  ({ schema, className, disabled: hostDisabled, ...props }: { schema: ChatbotSchema & {
-    enableMarkdown?: boolean; 
-    enableFileUpload?: boolean;
-    /**
-     * Visual chrome for the chat surface (objectui#6687, maintainer ruling
-     * 2026-08-29). `card` keeps the embeddable bordered panel; `plain` removes
-     * the panel chrome for a full-page chat workspace. Declared here, on the
-     * registration that actually renders `<ChatbotEnhanced>`, because that is
-     * the only one with a `surface` prop to forward it to — `chatbot` and
-     * `chatbot-floating` render different components and do not gain the key.
-     * Typed by importing `ChatbotSurface` rather than re-spelling the union:
-     * one contract, not two dialects (AGENTS.md #0.1).
-     */
-    surface?: ChatbotSurface;
-    showTimestamp?: boolean;
-    disabled?: boolean;
-    userAvatarUrl?: string;
-    userAvatarFallback?: string;
-    assistantAvatarUrl?: string;
-    assistantAvatarFallback?: string;
-    maxHeight?: string;
-    autoResponse?: boolean;
-    autoResponseText?: string;
-    autoResponseDelay?: number;
-    onSend?: (content: string, messages: ObjectChatMessage[]) => void;
-    onClear?: () => void;
-  }; className?: string; disabled?: boolean; [key: string]: any }) => {
+  // `schema` is the published authoring face of THIS registration
+  // (objectui#7655, the #6169 / #6172 family ruling: every component node has
+  // exactly one named, importable authoring-face type). It used to be an
+  // anonymous `ChatbotSchema & { ... }` intersection local to this file;
+  // every key that intersection carried was read-site-censused before being
+  // declared on `ChatbotEnhancedSchema`, and the two `ChatbotSchema` keys this
+  // registration never read (`displayMode`, `floatingConfig`) are not on it.
+  // `surface` (objectui#6687, maintainer ruling 2026-08-29) is declared there
+  // too; the plugin's own `ChatbotSurface` alias is pinned equal to it in
+  // `__tests__`, so the union has one contract, not two dialects
+  // (AGENTS.md #0.1). `disabled` is the host-EVALUATED verdict, as on
+  // `chatbot` above.
+  ({ schema, className, disabled: hostDisabled, ...props }: { schema: ChatbotEnhancedSchema; className?: string; disabled?: boolean; [key: string]: any }) => {
     const {
       messages,
       isLoading,
@@ -419,21 +403,21 @@ ComponentRegistry.register('chatbot-enhanced',
 
 // Register Floating Chatbot (FAB widget)
 ComponentRegistry.register('chatbot-floating',
-  ({ schema, className, ...props }: { schema: ChatbotSchema & {
-    enableMarkdown?: boolean;
-    enableFileUpload?: boolean;
-    showTimestamp?: boolean;
-    disabled?: boolean;
-    userAvatarUrl?: string;
-    userAvatarFallback?: string;
-    assistantAvatarUrl?: string;
-    assistantAvatarFallback?: string;
-    autoResponse?: boolean;
-    autoResponseText?: string;
-    autoResponseDelay?: number;
-    onSend?: (content: string, messages: ObjectChatMessage[]) => void;
-    onClear?: () => void;
-  }; className?: string; [key: string]: any }) => {
+  // `schema` is the published authoring face of THIS registration
+  // (objectui#7655) — see the `chatbot-enhanced` note above. `disabled` is
+  // the host-EVALUATED verdict `SchemaRenderer` forwards for every node type,
+  // destructured under the name its two sibling registrations use. The raw
+  // `schema.disabled` read that used to sit on the `disabled` prop below was
+  // already dead: `SchemaRenderer` spreads `disabled: verdict || undefined`
+  // LAST into the props it hands a registration, and `{...props}` below is
+  // spread after that prop, so the verdict overrode the raw value on every
+  // render. Naming it changes no outcome; it keeps one carrier for one
+  // question (AGENTS.md #0.1) and lets the published face inherit
+  // `BaseSchema.disabled` (`boolean | string`) unnarrowed (objectui#7087) —
+  // a raw forward of that union into the panel's `boolean` prop would not
+  // type-check, and narrowing the face to make it fit is the shape #7087
+  // retired.
+  ({ schema, className, disabled: hostDisabled, ...props }: { schema: ChatbotFloatingSchema; className?: string; disabled?: boolean; [key: string]: any }) => {
     const {
       messages,
       isLoading,
@@ -482,7 +466,8 @@ ComponentRegistry.register('chatbot-floating',
         onClear={handleClear}
         onStop={isApiMode && isLoading ? stop : undefined}
         onReload={isApiMode ? reload : undefined}
-        disabled={schema.disabled}
+        // The evaluated verdict — see the head of this registration.
+        disabled={hostDisabled}
         isLoading={isLoading}
         error={error}
         showTimestamp={schema.showTimestamp}

--- a/packages/plugin-chatbot/src/renderer.tsx
+++ b/packages/plugin-chatbot/src/renderer.tsx
@@ -478,6 +478,15 @@ ComponentRegistry.register('chatbot-floating',
         enableMarkdown={schema.enableMarkdown ?? true}
         enableFileUpload={schema.enableFileUpload ?? false}
         className={className}
+        // ⚠️ Raw and LAST — the two sibling registrations spread
+        // `toDomProps(props)` FIRST. Every authored key `SchemaRenderer`
+        // forwards reaches the panel's `ChatbotEnhanced` unfiltered (so
+        // `processVisibility`, `surface` and `showAvatars` are live here
+        // although `ChatbotFloatingSchema` declares none of them), and the
+        // authored `messages` seed overrides the runtime `messages` prop
+        // written above. Measured through the real host and carded as objectui#7708
+        // — fence vs declare is that card's ruling. Deliberately NOT changed
+        // by objectui#7655, which declared faces and moved no render outcome.
         {...props}
       />
     );

--- a/packages/types/src/__tests__/chatbot-registration-authoring-faces-7655.test.ts
+++ b/packages/types/src/__tests__/chatbot-registration-authoring-faces-7655.test.ts
@@ -1,0 +1,416 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * One named, importable authoring-face type per `plugin-chatbot` registration
+ * (objectui#7655, under the objectui#6169 / #6172 family ruling: every
+ * component node has exactly one named, importable authoring-face type).
+ *
+ * ## What was wrong
+ *
+ * `packages/plugin-chatbot/src/renderer.tsx` registers three components —
+ * `chatbot`, `chatbot-enhanced`, `chatbot-floating` — and `@object-ui/types`
+ * published ONE face for the family, `ChatbotSchema`, with `type` pinned to
+ * `'chatbot'`. An author annotating a `chatbot-floating` node either dropped to
+ * untyped JSON or annotated with `ChatbotSchema` and lied about `type`; the
+ * docs' floating example had to be a `json` fence because no `tsx` fence could
+ * compile. The two registrations' real key sets lived in anonymous
+ * `ChatbotSchema & { ... }` intersections local to the renderer.
+ *
+ * ## The shape, and why not the smaller diff
+ *
+ * One interface per registration — `ChatbotEnhancedSchema`,
+ * `ChatbotFloatingSchema` — not `ChatbotSchema['type']` widened to the union
+ * of the three keys. The union would give three nodes ONE type and re-open what
+ * #6169 closed: a single interface declaring keys only some of its own `type`
+ * values read. Each new face declares what ITS registration reads, censused per
+ * key on the PR's base with lit controls, and the twenty keys all three read
+ * are picked off `ChatbotSchema` by name (`ChatbotSharedKey`) so they stay one
+ * declaration.
+ *
+ * ## Two channels, stated so nobody reads the wrong one
+ *
+ * The `export type assertion…` blocks below are COMPILE-TIME: they are checked
+ * by `tsc -p tsconfig.test.json` (this package's `type-check` script chains it)
+ * and are erased before vitest runs. A green vitest run says nothing about
+ * them — the same instrument split `zod-mirror-parity.test.ts` documents, and
+ * the same one `chatbot-authoring-face-keys.test.ts` (objectui#6169) uses for
+ * its `@ts-expect-error` pins. The `it` blocks are the RUNTIME channel: the Zod
+ * twins' accept sets.
+ *
+ * ## `displayMode` is carried, not decided (objectui#7654)
+ *
+ * The key crossed from `ChatbotSchema` onto `ChatbotFloatingSchema` UNCHANGED —
+ * same type, still unmirrored — because the designer control and the
+ * `defaultProps` seed that carry it are the `chatbot-floating` registration's.
+ * Its fate is a maintainer decision parked on objectui#7654. The runtime pin
+ * below asserts it STILL parses green with any value, as a tripwire: whoever
+ * mirrors, retires or wires it must flip that pin deliberately, with #7654's
+ * ruling in hand, rather than have it change under them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { BaseSchema } from '../base';
+import type {
+  ChatMessage,
+  ChatbotEnhancedSchema,
+  ChatbotFloatingSchema,
+  ChatbotSchema,
+  ChatbotSharedKey,
+  FloatingChatbotConfig,
+} from '../complex';
+import {
+  ChatbotEnhancedSchema as ChatbotEnhancedZod,
+  ChatbotFloatingSchema as ChatbotFloatingZod,
+  ChatbotSchema as ChatbotZod,
+  ComplexSchema as ComplexZod,
+} from '../zod/complex.zod';
+
+/* ── Type-level helpers (the `tsc` channel) ──────────────────────────────── */
+
+/** Invariant equality — `extends` both ways would accept a narrowing. */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+
+/** Declared keys, read past `BaseSchema`'s `[key: string]: any` index signature. */
+type WithoutIndexSignature<D> = {
+  [K in keyof D as string extends K ? never : number extends K ? never : K]: D[K];
+};
+type DeclaredKeys<D> = Extract<keyof WithoutIndexSignature<D>, string>;
+/**
+ * Every face's declared keys are `BaseSchema`'s plus exactly its own census, so
+ * each pin below is spelled `BaseKeys | <census>`. A union rather than a
+ * subtraction on purpose: `placeholder` is declared on the base AND redeclared
+ * on `ChatbotSchema` (hence picked onto both new faces), and a subtraction
+ * would silently drop it from the census it belongs to — measured, not
+ * assumed, with a compiler probe before this file was written.
+ */
+type BaseKeys = DeclaredKeys<BaseSchema>;
+
+/** The twenty keys every registration reads, spelled out so the alias is pinned to a list and not to itself. */
+type SharedKeys =
+  | 'messages' | 'placeholder' | 'api' | 'conversationId' | 'systemPrompt' | 'model'
+  | 'streamingEnabled' | 'headers' | 'requestBody' | 'maxToolRoundtrips' | 'onError'
+  | 'showTimestamp' | 'userAvatarUrl' | 'userAvatarFallback' | 'assistantAvatarUrl'
+  | 'assistantAvatarFallback' | 'autoResponse' | 'autoResponseText' | 'autoResponseDelay'
+  | 'onSend';
+
+/* ── The discriminants: one node, one type ───────────────────────────────── */
+
+export type assertionOneDiscriminantPerFace = [
+  Expect<Equal<ChatbotSchema['type'], 'chatbot'>>,
+  Expect<Equal<ChatbotEnhancedSchema['type'], 'chatbot-enhanced'>>,
+  Expect<Equal<ChatbotFloatingSchema['type'], 'chatbot-floating'>>,
+];
+
+/* ── The census, as EXACT key sets (both directions) ─────────────────────── */
+
+export type assertionSharedKeyAliasIsTheCensus = Expect<Equal<ChatbotSharedKey, SharedKeys>>;
+
+/** `chatbot-enhanced`: the shared twenty + `maxHeight`, `processVisibility`, and its four own keys. */
+export type assertionEnhancedDeclaresWhatItReads = Expect<
+  Equal<
+    DeclaredKeys<ChatbotEnhancedSchema>,
+    BaseKeys | SharedKeys | 'maxHeight' | 'processVisibility' | 'enableMarkdown' | 'enableFileUpload' | 'surface' | 'onClear'
+  >
+>;
+
+/** `chatbot-floating`: the shared twenty + its three own keys + the two carried keys. NO `maxHeight`, `processVisibility` or `surface`. */
+export type assertionFloatingDeclaresWhatItReads = Expect<
+  Equal<
+    DeclaredKeys<ChatbotFloatingSchema>,
+    BaseKeys | SharedKeys | 'enableMarkdown' | 'enableFileUpload' | 'onClear' | 'displayMode' | 'floatingConfig'
+  >
+>;
+
+/**
+ * `chatbot` keeps every member it had EXCEPT the two that moved. The six legacy
+ * keys (`loading` … `height`) and the `onSendMessage` tombstone stay exactly
+ * where they were — this card declared faces, it retired nothing.
+ */
+export type assertionChatbotKeepsItsOwnFaceMinusTheTwoMoved = Expect<
+  Equal<
+    DeclaredKeys<ChatbotSchema>,
+    | BaseKeys | SharedKeys | 'loading' | 'onSendMessage' | 'showAvatars' | 'userAvatar' | 'assistantAvatar'
+    | 'markdown' | 'processVisibility' | 'height' | 'maxHeight'
+  >
+>;
+
+/** The two keys are not on `ChatbotSchema` any more — a move, so declared on exactly one face. */
+export type assertionMovedKeysLeftChatbot = Expect<
+  Equal<Extract<DeclaredKeys<ChatbotSchema>, 'displayMode' | 'floatingConfig'>, never>
+>;
+
+/* ── One declaration per shared key: a pick, not a copy ──────────────────── */
+
+export type assertionSharedKeysAreOneDeclaration = [
+  Expect<Equal<ChatbotEnhancedSchema['onSend'], ChatbotSchema['onSend']>>,
+  Expect<Equal<ChatbotFloatingSchema['onSend'], ChatbotSchema['onSend']>>,
+  Expect<Equal<ChatbotEnhancedSchema['messages'], ChatMessage[]>>,
+  Expect<Equal<ChatbotFloatingSchema['requestBody'], ChatbotSchema['requestBody']>>,
+  Expect<Equal<ChatbotEnhancedSchema['maxToolRoundtrips'], ChatbotSchema['maxToolRoundtrips']>>,
+  Expect<Equal<ChatbotEnhancedSchema['processVisibility'], ChatbotSchema['processVisibility']>>,
+];
+
+/* ── `displayMode` carried UNCHANGED; `floatingConfig` keeps its shape ───── */
+
+export type assertionCarriedKeysUnchanged = [
+  Expect<Equal<ChatbotFloatingSchema['displayMode'], 'inline' | 'floating' | undefined>>,
+  Expect<Equal<ChatbotFloatingSchema['floatingConfig'], FloatingChatbotConfig | undefined>>,
+];
+
+/* ── `surface` has one vocabulary; `disabled` stays the inherited union ──── */
+
+export type assertionSurfaceVocabulary = Expect<
+  Equal<ChatbotEnhancedSchema['surface'], 'card' | 'plain' | undefined>
+>;
+
+/**
+ * Neither face redeclares `disabled` (objectui#6169, #7087): the host evaluates
+ * it for every node type, and a `boolean` redeclaration would narrow away the
+ * expression-string half. `visible` beside it is the twin control, so a face
+ * that dropped both keys cannot pass vacuously.
+ */
+export type assertionDisabledStaysTheBaseUnion = [
+  Expect<Equal<ChatbotEnhancedSchema['disabled'], boolean | string | undefined>>,
+  Expect<Equal<ChatbotFloatingSchema['disabled'], boolean | string | undefined>>,
+  Expect<Equal<ChatbotEnhancedSchema['visible'], BaseSchema['visible']>>,
+  Expect<Equal<ChatbotFloatingSchema['visible'], BaseSchema['visible']>>,
+];
+
+/* ── Runtime: the TypeScript face accepts what it declares, refuses the lie ─ */
+
+const baseMessages: ChatMessage[] = [{ id: '1', role: 'user', content: 'hi' }];
+
+describe('the two faces annotate the nodes their registrations render (objectui#7655)', () => {
+  it('a fully authored `chatbot-enhanced` node type-checks against `ChatbotEnhancedSchema`', () => {
+    const node: ChatbotEnhancedSchema = {
+      type: 'chatbot-enhanced',
+      messages: baseMessages,
+      api: '/api/v1/ai/chat',
+      requestBody: { tenant: 'acme' },
+      maxHeight: '600px',
+      processVisibility: 'debug',
+      enableMarkdown: true,
+      enableFileUpload: true,
+      surface: 'plain',
+      onClear: () => undefined,
+      onSend: (content, messages) => {
+        expect(typeof content).toBe('string');
+        expect(Array.isArray(messages)).toBe(true);
+      },
+    };
+    expect(node.type).toBe('chatbot-enhanced');
+    expect(node.surface).toBe('plain');
+    node.onSend?.('hello', baseMessages);
+  });
+
+  it('a fully authored `chatbot-floating` node type-checks against `ChatbotFloatingSchema`', () => {
+    const node: ChatbotFloatingSchema = {
+      type: 'chatbot-floating',
+      messages: baseMessages,
+      floatingConfig: { position: 'bottom-left', defaultOpen: true, panelHeight: 520, title: 'Support' },
+      displayMode: 'floating',
+      enableMarkdown: false,
+      onClear: () => undefined,
+    };
+    expect(node.floatingConfig?.title).toBe('Support');
+  });
+
+  it('the lie the card was filed on is now a `tsc` error: `ChatbotSchema` cannot annotate the other two nodes, and vice versa', () => {
+    const wrongOnChatbot: ChatbotSchema = {
+      // @ts-expect-error `ChatbotSchema` pins `type` to `'chatbot'` — annotate with `ChatbotFloatingSchema`
+      type: 'chatbot-floating',
+      messages: baseMessages,
+    };
+    const wrongOnEnhanced: ChatbotEnhancedSchema = {
+      // @ts-expect-error `ChatbotEnhancedSchema` pins `type` to `'chatbot-enhanced'`
+      type: 'chatbot',
+      messages: baseMessages,
+    };
+    const wrongOnFloating: ChatbotFloatingSchema = {
+      // @ts-expect-error `ChatbotFloatingSchema` pins `type` to `'chatbot-floating'`
+      type: 'chatbot-enhanced',
+      messages: baseMessages,
+    };
+    expect([wrongOnChatbot, wrongOnEnhanced, wrongOnFloating]).toHaveLength(3);
+  });
+
+  it('a wrong-typed value on a DECLARED key is refused — the field is no longer `any` through the index signature', () => {
+    const enhanced: ChatbotEnhancedSchema = {
+      type: 'chatbot-enhanced',
+      messages: baseMessages,
+      // @ts-expect-error `enableFileUpload` is declared `boolean`
+      enableFileUpload: 'yes',
+    };
+    const floating: ChatbotFloatingSchema = {
+      type: 'chatbot-floating',
+      messages: baseMessages,
+      // @ts-expect-error `panelHeight` is a number of pixels, not a CSS length
+      floatingConfig: { panelHeight: '520px' },
+    };
+    expect(enhanced.type).toBe('chatbot-enhanced');
+    expect(floating.type).toBe('chatbot-floating');
+  });
+});
+
+/* ── Runtime: the Zod twins, in lockstep with the declarations ───────────── */
+
+describe('`ChatbotEnhancedSchema` (zod) validates what the face declares', () => {
+  const node = {
+    type: 'chatbot-enhanced',
+    messages: [{ id: '1', role: 'user', content: 'hi' }],
+  };
+
+  it('parses a fully authored node green', () => {
+    const result = ChatbotEnhancedZod.safeParse({
+      ...node,
+      api: '/api/v1/ai/chat',
+      requestBody: { tenant: 'acme' },
+      maxHeight: '600px',
+      processVisibility: 'summary',
+      enableMarkdown: true,
+      enableFileUpload: false,
+      surface: 'plain',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('refuses the other two discriminants — the twin is for THIS node', () => {
+    for (const type of ['chatbot', 'chatbot-floating']) {
+      const result = ChatbotEnhancedZod.safeParse({ ...node, type });
+      expect(result.success, type).toBe(false);
+      expect(result.error?.issues.some((i) => i.path.join('.') === 'type'), type).toBe(true);
+    }
+  });
+
+  it("refuses a `surface` outside 'card' | 'plain', and a non-boolean `enableMarkdown` — mirrored, not passed through", () => {
+    const surface = ChatbotEnhancedZod.safeParse({ ...node, surface: 'frameless' });
+    expect(surface.success).toBe(false);
+    expect(surface.error?.issues.some((i) => i.path.join('.') === 'surface')).toBe(true);
+
+    const markdown = ChatbotEnhancedZod.safeParse({ ...node, enableMarkdown: 'yes' });
+    expect(markdown.success).toBe(false);
+    expect(
+      markdown.error?.issues.some((i) => i.path.join('.') === 'enableMarkdown' && i.code === 'invalid_type'),
+    ).toBe(true);
+  });
+
+  it('mirrors `requestBody` under the key the renderer reads, and refuses a non-object', () => {
+    // `ChatbotSchema`'s twin mirrors this under `body`, colliding with the base
+    // children slot; the two new twins do not copy that collision.
+    expect(ChatbotEnhancedZod.shape.requestBody).toBeDefined();
+    const result = ChatbotEnhancedZod.safeParse({ ...node, requestBody: 'tenant=acme' });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((i) => i.path.join('.') === 'requestBody')).toBe(true);
+  });
+
+  it('`onClear` is a RUNTIME SLOT the twin refuses by name (objectui#6124), like `onError` and `onSend`', () => {
+    for (const key of ['onClear', 'onError', 'onSend']) {
+      const result = ChatbotEnhancedZod.safeParse({ ...node, [key]: () => undefined });
+      expect(result.success, key).toBe(false);
+      const issue = result.error?.issues.find((i) => String(i.path[0]) === key);
+      expect(issue?.code, key).toBe('custom');
+      expect(issue?.message, key).toContain(`\`${key}\` is a RUNTIME SLOT`);
+    }
+  });
+});
+
+describe('`ChatbotFloatingSchema` (zod) validates what the face declares, and carries what it carries', () => {
+  const node = {
+    type: 'chatbot-floating',
+    messages: [{ id: '1', role: 'user', content: 'hi' }],
+  };
+
+  it('parses a fully authored floating node green', () => {
+    const result = ChatbotFloatingZod.safeParse({
+      ...node,
+      floatingConfig: { position: 'bottom-left', defaultOpen: true, panelWidth: 400, panelHeight: 520, title: 'Support', triggerSize: 56 },
+      displayMode: 'floating',
+      enableMarkdown: true,
+      enableFileUpload: true,
+      requestBody: { tenant: 'acme' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('refuses the other two discriminants', () => {
+    for (const type of ['chatbot', 'chatbot-enhanced']) {
+      const result = ChatbotFloatingZod.safeParse({ ...node, type });
+      expect(result.success, type).toBe(false);
+    }
+  });
+
+  it('TRIPWIRE — `displayMode` is carried UNMIRRORED: any value still parses green (objectui#7654 decides its fate, not this card)', () => {
+    // Declared on the face with its original `'inline' | 'floating'` type,
+    // deliberately NOT given a mirror arm: on `ChatbotSchema` it was
+    // declared-but-unmirrored, and it crossed in that exact state. A value the
+    // declaration would refuse rides through `.passthrough()` here, as it did
+    // before. If this goes red, someone mirrored, retired or wired the key —
+    // flip this pin with #7654's ruling in hand, never silently.
+    expect((ChatbotFloatingZod.shape as Record<string, unknown>).displayMode).toBeUndefined();
+    expect(ChatbotFloatingZod.safeParse({ ...node, displayMode: 'anything-at-all' }).success).toBe(true);
+    // Lit control on the same instrument: a key the twin DOES declare is in its
+    // shape and DOES refuse a wrong value, so "undefined" above is a reading.
+    expect(ChatbotFloatingZod.shape.enableMarkdown).toBeDefined();
+    expect(ChatbotFloatingZod.safeParse({ ...node, enableMarkdown: 'anything-at-all' }).success).toBe(false);
+  });
+
+  it('`floatingConfig` has no mirror here either — the objectui#6152 axis is not widened into', () => {
+    expect((ChatbotFloatingZod.shape as Record<string, unknown>).floatingConfig).toBeUndefined();
+    // Rides through unvalidated, wrong shape and all — byte for byte the
+    // pre-#7655 outcome on `ChatbotSchema`.
+    expect(ChatbotFloatingZod.safeParse({ ...node, floatingConfig: { panelHeight: '520px' } }).success).toBe(true);
+  });
+
+  it('`onClear` / `onError` / `onSend` are refused by name here too', () => {
+    for (const key of ['onClear', 'onError', 'onSend']) {
+      const result = ChatbotFloatingZod.safeParse({ ...node, [key]: () => undefined });
+      expect(result.success, key).toBe(false);
+      expect(result.error?.issues.find((i) => String(i.path[0]) === key)?.code, key).toBe('custom');
+    }
+  });
+});
+
+describe('the census is structural: picked off `ChatbotSchema`, never copied', () => {
+  const shared: readonly ChatbotSharedKey[] = [
+    'messages', 'placeholder', 'api', 'conversationId', 'systemPrompt', 'model', 'streamingEnabled',
+    'headers', 'maxToolRoundtrips', 'onError', 'showTimestamp', 'userAvatarUrl', 'userAvatarFallback',
+    'assistantAvatarUrl', 'assistantAvatarFallback', 'autoResponse', 'autoResponseText',
+    'autoResponseDelay', 'onSend',
+  ];
+
+  it('every shared arm on the two twins carries `ChatbotSchema`\'s own description — one spelling', () => {
+    const describe_ = (shape: Record<string, { description?: string }>, key: string) => shape[key]?.description;
+    for (const key of shared) {
+      expect(describe_(ChatbotEnhancedZod.shape, key), key).toBe(describe_(ChatbotZod.shape, key));
+      expect(describe_(ChatbotFloatingZod.shape, key), key).toBe(describe_(ChatbotZod.shape, key));
+      expect(describe_(ChatbotZod.shape, key), key).toBeDefined();
+    }
+  });
+
+  it('the keys a registration never reads are NOT on its twin — with `ChatbotSchema` as the lit control', () => {
+    const enhanced = ChatbotEnhancedZod.shape as Record<string, unknown>;
+    const floating = ChatbotFloatingZod.shape as Record<string, unknown>;
+    const chatbot = ChatbotZod.shape as Record<string, unknown>;
+    for (const legacy of ['loading', 'showAvatars', 'userAvatar', 'assistantAvatar', 'markdown', 'height', 'onSendMessage']) {
+      expect(enhanced[legacy], legacy).toBeUndefined();
+      expect(floating[legacy], legacy).toBeUndefined();
+      expect(chatbot[legacy], legacy).toBeDefined();
+    }
+    for (const enhancedOnly of ['maxHeight', 'processVisibility', 'surface']) {
+      expect(enhanced[enhancedOnly], enhancedOnly).toBeDefined();
+      expect(floating[enhancedOnly], enhancedOnly).toBeUndefined();
+    }
+  });
+
+  it('`ComplexSchema` routes each discriminant to its own arm', () => {
+    const messages = [{ id: '1', role: 'user', content: 'hi' }];
+    expect(ComplexZod.safeParse({ type: 'chatbot-floating', messages }).success).toBe(true);
+    expect(ComplexZod.safeParse({ type: 'chatbot-enhanced', messages }).success).toBe(true);
+    // Routed to the ENHANCED arm — a `surface` refusal can only come from there.
+    const routed = ComplexZod.safeParse({ type: 'chatbot-enhanced', messages, surface: 'frameless' });
+    expect(routed.success).toBe(false);
+    expect(routed.error?.issues.some((i) => i.path.join('.') === 'surface')).toBe(true);
+  });
+});

--- a/packages/types/src/__tests__/chatbot-registration-authoring-faces-7655.test.ts
+++ b/packages/types/src/__tests__/chatbot-registration-authoring-faces-7655.test.ts
@@ -37,15 +37,32 @@
  * its `@ts-expect-error` pins. The `it` blocks are the RUNTIME channel: the Zod
  * twins' accept sets.
  *
- * ## `displayMode` is carried, not decided (objectui#7654)
+ * ## `displayMode` and `floatingConfig` live on BOTH faces; neither is decided here
  *
- * The key crossed from `ChatbotSchema` onto `ChatbotFloatingSchema` UNCHANGED —
- * same type, still unmirrored — because the designer control and the
- * `defaultProps` seed that carry it are the `chatbot-floating` registration's.
- * Its fate is a maintainer decision parked on objectui#7654. The runtime pin
- * below asserts it STILL parses green with any value, as a tripwire: whoever
- * mirrors, retires or wires it must flip that pin deliberately, with #7654's
- * ruling in hand, rather than have it change under them.
+ * `ChatbotSchema` keeps both members exactly as it had them (declarations
+ * verbatim), and `ChatbotFloatingSchema` declares the same two — the designer
+ * control and the `defaultProps` seed for `displayMode` are the
+ * `chatbot-floating` registration's. `displayMode` is RULED RETIRED:
+ * objectui#7654, maintainer ruling B (2026-09-05) — `?: never` tombstone on
+ * `ChatbotSchema`, control and seed removed — and that retirement executes in
+ * #7654's own PR, which must find the member on both faces as ruled. So this
+ * card carries the key untouched, and the runtime pin below asserts it STILL
+ * parses green with any value, as a tripwire: that PR flips the pin
+ * deliberately, with the ruling in hand, rather than have it change under it.
+ *
+ * ## The census counts NAMED reads; the floating registration has a second channel
+ *
+ * `assertionFloatingDeclaresWhatItReads` pins the named-read instrument —
+ * `schema.KEY` inside the `chatbot-floating` registration body — and nothing
+ * else. That registration also ends its `FloatingChatbot` element with a raw
+ * `{...props}` spread, so every authored key `SchemaRenderer` forwards reaches
+ * the panel's `ChatbotEnhanced` unfiltered: `processVisibility`, `surface` and
+ * `showAvatars` are LIVE on a `chatbot-floating` node today (measured through
+ * the real host with lit/dark pairs, `chatbot-enhanced`'s `toDomProps`-filtered
+ * spread as the control — pinned as a tripwire in `plugin-chatbot`'s
+ * `renderer.authoring-faces-7655.test.tsx`). The face does not declare them:
+ * that channel is accidental and is carded for a declare-vs-fence ruling
+ * (objectui#7708).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -115,7 +132,12 @@ export type assertionEnhancedDeclaresWhatItReads = Expect<
   >
 >;
 
-/** `chatbot-floating`: the shared twenty + its three own keys + the two carried keys. NO `maxHeight`, `processVisibility` or `surface`. */
+/**
+ * `chatbot-floating`, NAMED reads only: the shared twenty + its three own keys +
+ * the two keys it declares alongside `ChatbotSchema`. NO `maxHeight`,
+ * `processVisibility` or `surface` — no named read; the raw-spread channel is NOT
+ * what this pin measures (see the header).
+ */
 export type assertionFloatingDeclaresWhatItReads = Expect<
   Equal<
     DeclaredKeys<ChatbotFloatingSchema>,
@@ -124,22 +146,30 @@ export type assertionFloatingDeclaresWhatItReads = Expect<
 >;
 
 /**
- * `chatbot` keeps every member it had EXCEPT the two that moved. The six legacy
- * keys (`loading` … `height`) and the `onSendMessage` tombstone stay exactly
- * where they were — this card declared faces, it retired nothing.
+ * `chatbot` keeps its WHOLE face — the six legacy keys (`loading` … `height`),
+ * the `onSendMessage` tombstone, and `displayMode` / `floatingConfig` — exactly
+ * where they were. This card declared faces; it retired and moved nothing.
  */
-export type assertionChatbotKeepsItsOwnFaceMinusTheTwoMoved = Expect<
+export type assertionChatbotKeepsItsWholeFace = Expect<
   Equal<
     DeclaredKeys<ChatbotSchema>,
     | BaseKeys | SharedKeys | 'loading' | 'onSendMessage' | 'showAvatars' | 'userAvatar' | 'assistantAvatar'
-    | 'markdown' | 'processVisibility' | 'height' | 'maxHeight'
+    | 'markdown' | 'processVisibility' | 'height' | 'maxHeight' | 'displayMode' | 'floatingConfig'
   >
 >;
 
-/** The two keys are not on `ChatbotSchema` any more — a move, so declared on exactly one face. */
-export type assertionMovedKeysLeftChatbot = Expect<
-  Equal<Extract<DeclaredKeys<ChatbotSchema>, 'displayMode' | 'floatingConfig'>, never>
->;
+/**
+ * The two floating keys stay TYPED on `ChatbotSchema`. Read off the member,
+ * not the key set: a member that fell off the declaration would not go missing
+ * here — it would read as `any` through `BaseSchema`'s index signature, wrong
+ * values would compile, and the objectui#7669 `triggerIcon` tombstone would lose
+ * its reach on `chatbot` nodes (all three measured on #7655's first cut, which
+ * moved the keys). `Equal` is what catches the `any`.
+ */
+export type assertionFloatingKeysStayTypedOnChatbot = [
+  Expect<Equal<ChatbotSchema['displayMode'], 'inline' | 'floating' | undefined>>,
+  Expect<Equal<ChatbotSchema['floatingConfig'], FloatingChatbotConfig | undefined>>,
+];
 
 /* ── One declaration per shared key: a pick, not a copy ──────────────────── */
 
@@ -152,9 +182,11 @@ export type assertionSharedKeysAreOneDeclaration = [
   Expect<Equal<ChatbotEnhancedSchema['processVisibility'], ChatbotSchema['processVisibility']>>,
 ];
 
-/* ── `displayMode` carried UNCHANGED; `floatingConfig` keeps its shape ───── */
+/* ── `displayMode` / `floatingConfig`: one type, both faces ─────────────── */
 
-export type assertionCarriedKeysUnchanged = [
+export type assertionFloatingKeysHaveOneTypeOnBothFaces = [
+  Expect<Equal<ChatbotFloatingSchema['displayMode'], ChatbotSchema['displayMode']>>,
+  Expect<Equal<ChatbotFloatingSchema['floatingConfig'], ChatbotSchema['floatingConfig']>>,
   Expect<Equal<ChatbotFloatingSchema['displayMode'], 'inline' | 'floating' | undefined>>,
   Expect<Equal<ChatbotFloatingSchema['floatingConfig'], FloatingChatbotConfig | undefined>>,
 ];
@@ -249,8 +281,17 @@ describe('the two faces annotate the nodes their registrations render (objectui#
       // @ts-expect-error `panelHeight` is a number of pixels, not a CSS length
       floatingConfig: { panelHeight: '520px' },
     };
+    // …and on `ChatbotSchema` too, which still declares both keys: a wrong
+    // `displayMode` is refused there, not swallowed as `any`.
+    const chatbot: ChatbotSchema = {
+      type: 'chatbot',
+      messages: baseMessages,
+      // @ts-expect-error `displayMode` is the typed union on `ChatbotSchema`, unchanged
+      displayMode: 'bogus',
+    };
     expect(enhanced.type).toBe('chatbot-enhanced');
     expect(floating.type).toBe('chatbot-floating');
+    expect(chatbot.type).toBe('chatbot');
   });
 });
 
@@ -316,7 +357,7 @@ describe('`ChatbotEnhancedSchema` (zod) validates what the face declares', () =>
   });
 });
 
-describe('`ChatbotFloatingSchema` (zod) validates what the face declares, and carries what it carries', () => {
+describe('`ChatbotFloatingSchema` (zod) validates what the face declares, and leaves the two shared floating keys unmirrored', () => {
   const node = {
     type: 'chatbot-floating',
     messages: [{ id: '1', role: 'user', content: 'hi' }],
@@ -341,13 +382,15 @@ describe('`ChatbotFloatingSchema` (zod) validates what the face declares, and ca
     }
   });
 
-  it('TRIPWIRE — `displayMode` is carried UNMIRRORED: any value still parses green (objectui#7654 decides its fate, not this card)', () => {
-    // Declared on the face with its original `'inline' | 'floating'` type,
-    // deliberately NOT given a mirror arm: on `ChatbotSchema` it was
-    // declared-but-unmirrored, and it crossed in that exact state. A value the
-    // declaration would refuse rides through `.passthrough()` here, as it did
-    // before. If this goes red, someone mirrored, retired or wired the key —
-    // flip this pin with #7654's ruling in hand, never silently.
+  it('TRIPWIRE — `displayMode` is unmirrored here as on `ChatbotSchema`: any value still parses green (objectui#7654 ruled it retired; its own PR flips this)', () => {
+    // Declared on the face with the same `'inline' | 'floating'` type
+    // `ChatbotSchema` carries, deliberately NOT given a mirror arm: it is
+    // declared-but-unmirrored on both faces. A value the declaration would
+    // refuse rides through `.passthrough()` here, as it does on `ChatbotSchema`'s
+    // twin. objectui#7654 RULED the key retired (maintainer ruling B,
+    // 2026-09-05); that card's own PR lands the tombstone and flips this pin
+    // with the ruling in hand — if it goes red any other way, someone mirrored,
+    // retired or wired the key silently.
     expect((ChatbotFloatingZod.shape as Record<string, unknown>).displayMode).toBeUndefined();
     expect(ChatbotFloatingZod.safeParse({ ...node, displayMode: 'anything-at-all' }).success).toBe(true);
     // Lit control on the same instrument: a key the twin DOES declare is in its
@@ -359,7 +402,7 @@ describe('`ChatbotFloatingSchema` (zod) validates what the face declares, and ca
   it('`floatingConfig` has no mirror here either — the objectui#6152 axis is not widened into', () => {
     expect((ChatbotFloatingZod.shape as Record<string, unknown>).floatingConfig).toBeUndefined();
     // Rides through unvalidated, wrong shape and all — byte for byte the
-    // pre-#7655 outcome on `ChatbotSchema`.
+    // outcome on `ChatbotSchema`'s twin, which has no arm for it either.
     expect(ChatbotFloatingZod.safeParse({ ...node, floatingConfig: { panelHeight: '520px' } }).success).toBe(true);
   });
 

--- a/packages/types/src/__tests__/floating-chatbot-trigger-icon-retired.test.ts
+++ b/packages/types/src/__tests__/floating-chatbot-trigger-icon-retired.test.ts
@@ -53,7 +53,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { FloatingChatbotConfig } from '../complex';
-import { ChatbotSchema } from '../zod/complex.zod';
+import { ChatbotFloatingSchema } from '../zod/complex.zod';
 
 /* ── type-level pins: the `tsc` channel ──────────────────────────────────── */
 
@@ -103,15 +103,19 @@ describe('the `triggerIcon` tombstone makes authoring a `tsc` error', () => {
 /* ── the runtime channel: DELIBERATELY unchanged, and a tripwire if that ends ─ */
 
 describe('there is NO zod refusal, and that is deliberate (objectui#7654)', () => {
+  // objectui#7655 moved `floatingConfig` onto `ChatbotFloatingSchema` — the face
+  // of the one registration that reads it — so this tripwire parses the node
+  // that actually carries the key, through that face's Zod twin.
   const node = {
-    type: 'chatbot' as const,
+    type: 'chatbot-floating' as const,
     messages: [{ id: 'm1', role: 'user' as const, content: 'hi' }],
   };
 
-  it('a chatbot node carrying `floatingConfig.triggerIcon` still parses GREEN', () => {
+  it('a chatbot-floating node carrying `floatingConfig.triggerIcon` still parses GREEN', () => {
     // `FloatingChatbotConfig` has NO zod mirror: `floatingConfig` sits in the
     // `UnmirroredDeclared` ledger (`zod-mirror-parity.test.ts`,
-    // `complex.zod.ts#ChatbotSchema`), and `BaseSchema` is `.passthrough()`, so
+    // `complex.zod.ts#ChatbotFloatingSchema` since objectui#7655; it was recorded
+    // under `ChatbotSchema` before), and `BaseSchema` is `.passthrough()`, so
     // the whole object rides through unvalidated. This was green before the
     // tombstone and is green after it — the retirement changed the TypeScript
     // face only, and this pins that it changed no parse outcome.
@@ -121,7 +125,7 @@ describe('there is NO zod refusal, and that is deliberate (objectui#7654)', () =
     // lands the mirror must add the `retirementTombstone()` half for
     // `triggerIcon` at the same time, and flip this control rather than delete
     // it into a vacuum.
-    const result = ChatbotSchema.safeParse({
+    const result = ChatbotFloatingSchema.safeParse({
       ...node,
       floatingConfig: { title: 'Chat', triggerIcon: 'Sparkles' },
     });
@@ -129,7 +133,7 @@ describe('there is NO zod refusal, and that is deliberate (objectui#7654)', () =
   });
 
   it('a live `floatingConfig` parses green too — the non-vacuity control', () => {
-    const result = ChatbotSchema.safeParse({
+    const result = ChatbotFloatingSchema.safeParse({
       ...node,
       floatingConfig: { title: 'Chat', triggerSize: 56 },
     });
@@ -139,7 +143,7 @@ describe('there is NO zod refusal, and that is deliberate (objectui#7654)', () =
   it('the mirror really has no `floatingConfig` key at all', () => {
     // The load-bearing fact behind everything above, asserted rather than
     // assumed: a key the mirror declares would appear in its shape.
-    const shape = (ChatbotSchema as unknown as { shape: Record<string, unknown> }).shape;
+    const shape = (ChatbotFloatingSchema as unknown as { shape: Record<string, unknown> }).shape;
     expect(shape.floatingConfig).toBeUndefined();
     // Lit control: a key the mirror DOES declare is present, so the reading
     // above is a measurement and not an empty object.

--- a/packages/types/src/__tests__/floating-chatbot-trigger-icon-retired.test.ts
+++ b/packages/types/src/__tests__/floating-chatbot-trigger-icon-retired.test.ts
@@ -52,8 +52,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { FloatingChatbotConfig } from '../complex';
-import { ChatbotFloatingSchema } from '../zod/complex.zod';
+import type {
+  ChatbotFloatingSchema as TsChatbotFloatingSchema,
+  ChatbotSchema as TsChatbotSchema,
+  FloatingChatbotConfig,
+} from '../complex';
+import { ChatbotFloatingSchema, ChatbotSchema } from '../zod/complex.zod';
 
 /* ── type-level pins: the `tsc` channel ──────────────────────────────────── */
 
@@ -89,6 +93,30 @@ describe('the `triggerIcon` tombstone makes authoring a `tsc` error', () => {
     expect(config.triggerSize).toBe(56);
   });
 
+  it('reaches a `chatbot` node AND a `chatbot-floating` node through their faces — the tombstone bites wherever `floatingConfig` is declared', () => {
+    // Both faces declare `floatingConfig` (`ChatbotSchema` always did;
+    // objectui#7655 declared it on `ChatbotFloatingSchema` too). The pins above
+    // sit on `FloatingChatbotConfig` directly, so a face that LOST the member
+    // would not turn them red — the member would read as `any` through
+    // `BaseSchema`'s index signature and this literal would compile clean. That
+    // is exactly what #7655's contract review measured on its first cut, which
+    // moved the key off `ChatbotSchema`; pinned on the nodes since.
+    const onChatbot: TsChatbotSchema = {
+      type: 'chatbot',
+      messages: [],
+      // @ts-expect-error `triggerIcon` is a retirement tombstone (objectui#7654), reached through `ChatbotSchema.floatingConfig`
+      floatingConfig: { title: 'Chat', triggerIcon: 'Sparkles' },
+    };
+    const onFloating: TsChatbotFloatingSchema = {
+      type: 'chatbot-floating',
+      messages: [],
+      // @ts-expect-error `triggerIcon` is a retirement tombstone (objectui#7654), reached through `ChatbotFloatingSchema.floatingConfig`
+      floatingConfig: { title: 'Chat', triggerIcon: 'Sparkles' },
+    };
+    expect(onChatbot.type).toBe('chatbot');
+    expect(onFloating.type).toBe('chatbot-floating');
+  });
+
   it('a key the interface never declared still rides the widened path — the DELETED row', () => {
     // This carries NO directive on purpose. It is the measured contrast that
     // justifies `?: never` over deletion: an undeclared key IS refused in a
@@ -102,30 +130,34 @@ describe('the `triggerIcon` tombstone makes authoring a `tsc` error', () => {
 
 /* ── the runtime channel: DELIBERATELY unchanged, and a tripwire if that ends ─ */
 
-describe('there is NO zod refusal, and that is deliberate (objectui#7654)', () => {
-  // objectui#7655 moved `floatingConfig` onto `ChatbotFloatingSchema` — the face
-  // of the one registration that reads it — so this tripwire parses the node
-  // that actually carries the key, through that face's Zod twin.
+// Both faces declare `floatingConfig` — `ChatbotSchema` always did, and
+// objectui#7655 declared it on `ChatbotFloatingSchema`, the face of the one
+// registration that reads it — and NEITHER twin has an arm for it, so the
+// tripwire parses both nodes, each through its own twin.
+describe.each([
+  ['chatbot', ChatbotSchema],
+  ['chatbot-floating', ChatbotFloatingSchema],
+] as const)('there is NO zod refusal on a `%s` node, and that is deliberate (objectui#7654)', (type, twin) => {
   const node = {
-    type: 'chatbot-floating' as const,
+    type,
     messages: [{ id: 'm1', role: 'user' as const, content: 'hi' }],
   };
 
-  it('a chatbot-floating node carrying `floatingConfig.triggerIcon` still parses GREEN', () => {
+  it(`a ${type} node carrying \`floatingConfig.triggerIcon\` still parses GREEN`, () => {
     // `FloatingChatbotConfig` has NO zod mirror: `floatingConfig` sits in the
-    // `UnmirroredDeclared` ledger (`zod-mirror-parity.test.ts`,
-    // `complex.zod.ts#ChatbotFloatingSchema` since objectui#7655; it was recorded
-    // under `ChatbotSchema` before), and `BaseSchema` is `.passthrough()`, so
-    // the whole object rides through unvalidated. This was green before the
-    // tombstone and is green after it — the retirement changed the TypeScript
-    // face only, and this pins that it changed no parse outcome.
+    // `UnmirroredDeclared` ledger (`zod-mirror-parity.test.ts`, under both
+    // `complex.zod.ts#ChatbotSchema` and, since objectui#7655,
+    // `complex.zod.ts#ChatbotFloatingSchema`), and `BaseSchema` is
+    // `.passthrough()`, so the whole object rides through unvalidated. This was
+    // green before the tombstone and is green after it — the retirement changed
+    // the TypeScript face only, and this pins that it changed no parse outcome.
     //
     // ⚠️ TRIPWIRE: if objectui#6152 ever mints a `FloatingChatbotConfigSchema`,
     // this goes RED. That is the intended signal, not a nuisance — whoever
     // lands the mirror must add the `retirementTombstone()` half for
     // `triggerIcon` at the same time, and flip this control rather than delete
     // it into a vacuum.
-    const result = ChatbotFloatingSchema.safeParse({
+    const result = twin.safeParse({
       ...node,
       floatingConfig: { title: 'Chat', triggerIcon: 'Sparkles' },
     });
@@ -133,7 +165,7 @@ describe('there is NO zod refusal, and that is deliberate (objectui#7654)', () =
   });
 
   it('a live `floatingConfig` parses green too — the non-vacuity control', () => {
-    const result = ChatbotFloatingSchema.safeParse({
+    const result = twin.safeParse({
       ...node,
       floatingConfig: { title: 'Chat', triggerSize: 56 },
     });
@@ -143,7 +175,7 @@ describe('there is NO zod refusal, and that is deliberate (objectui#7654)', () =
   it('the mirror really has no `floatingConfig` key at all', () => {
     // The load-bearing fact behind everything above, asserted rather than
     // assumed: a key the mirror declares would appear in its shape.
-    const shape = (ChatbotFloatingSchema as unknown as { shape: Record<string, unknown> }).shape;
+    const shape = (twin as unknown as { shape: Record<string, unknown> }).shape;
     expect(shape.floatingConfig).toBeUndefined();
     // Lit control: a key the mirror DOES declare is present, so the reading
     // above is a measurement and not an empty object.

--- a/packages/types/src/__tests__/handler-keys-json-refusal-6124.test.ts
+++ b/packages/types/src/__tests__/handler-keys-json-refusal-6124.test.ts
@@ -82,6 +82,8 @@ import {
   CalendarViewSchema as CalendarViewZod,
   CarouselSchema as CarouselZod,
   ChatbotSchema as ChatbotZod,
+  ChatbotEnhancedSchema as ChatbotEnhancedZod,
+  ChatbotFloatingSchema as ChatbotFloatingZod,
   FilterBuilderSchema as FilterBuilderZod,
   DeclarativeKanbanSchema as KanbanZod,
 } from '../zod/complex.zod';
@@ -138,6 +140,8 @@ import type {
   CalendarViewSchema,
   CarouselSchema,
   ChatbotSchema,
+  ChatbotEnhancedSchema,
+  ChatbotFloatingSchema,
   FilterBuilderSchema,
   DeclarativeKanbanSchema,
 } from '../complex';
@@ -203,7 +207,9 @@ const objectOf = (mirror: z.ZodType, key: string): z.ZodObject<z.ZodRawShape> =>
 };
 
 /**
- * 36 keys whose function value REACHES a renderer at runtime — the TypeScript
+ * 42 keys whose function value REACHES a renderer at runtime (36 until objectui#7655
+ * gave `chatbot-enhanced` and `chatbot-floating` their own faces, each carrying the
+ * three slots its registration forwards) — the TypeScript
  * interface keeps the function type. Channel measured per key on this tree:
  * `schema.onX` read/forwarded (kanban, chatbot, data-table, form, code-editor,
  * menu items), `props.onX` called after `SchemaRenderer`'s spread (input,
@@ -220,6 +226,14 @@ const RUNTIME_SLOT: readonly Site[] = [
   ['complex.zod.ts', 'FilterBuilderSchema', 'onChange', FilterBuilderZod],
   ['complex.zod.ts', 'ChatbotSchema', 'onError', ChatbotZod],
   ['complex.zod.ts', 'ChatbotSchema', 'onSend', ChatbotZod],
+  // objectui#7655 — the two sibling faces forward the same two slots off `schema.*`
+  // into `useObjectChat`, and their `handleClear` calls `schema.onClear?.()`.
+  ['complex.zod.ts', 'ChatbotEnhancedSchema', 'onError', ChatbotEnhancedZod],
+  ['complex.zod.ts', 'ChatbotEnhancedSchema', 'onSend', ChatbotEnhancedZod],
+  ['complex.zod.ts', 'ChatbotEnhancedSchema', 'onClear', ChatbotEnhancedZod],
+  ['complex.zod.ts', 'ChatbotFloatingSchema', 'onError', ChatbotFloatingZod],
+  ['complex.zod.ts', 'ChatbotFloatingSchema', 'onSend', ChatbotFloatingZod],
+  ['complex.zod.ts', 'ChatbotFloatingSchema', 'onClear', ChatbotFloatingZod],
   ['data-display.zod.ts', 'DataTableSchema', 'onRowEdit', DataTableZod],
   ['data-display.zod.ts', 'DataTableSchema', 'onRowDelete', DataTableZod],
   ['data-display.zod.ts', 'DataTableSchema', 'onSelectionChange', DataTableZod],
@@ -351,13 +365,15 @@ describe('census: no on* key in the eight mirrors is declared z.function() (obje
     ]);
   });
 
-  it('59 sites are ledgered, 37 runtime slots + 22 retired, with no key filed twice', () => {
+  it('65 sites are ledgered, 43 runtime slots + 22 retired, with no key filed twice', () => {
     // 58 from objectui#6124; the 59th is `ObjectDataTableSchema.onRowClick`,
-    // minted with its arm by objectui#6576 / #6914.
-    expect(RUNTIME_SLOT).toHaveLength(37);
+    // minted with its arm by objectui#6576 / #6914; 60–65 are the six slots the
+    // `ChatbotEnhancedSchema` / `ChatbotFloatingSchema` twins were born with
+    // (objectui#7655).
+    expect(RUNTIME_SLOT).toHaveLength(43);
     expect(RETIRED).toHaveLength(22);
     const ids = ALL_SITES.map(([file, schema, key]) => `${file}#${schema}.${key}`);
-    expect(new Set(ids).size).toBe(59);
+    expect(new Set(ids).size).toBe(65);
   });
 
   it.each(ALL_SITES)('%s %s.%s is DECLARED on the mirror shape, with the objectui#6124 guidance as its description', (_file, _schema, key, mirror) => {
@@ -511,6 +527,12 @@ export type assertionRuntimeSlotsKeepTheirFunctionType = [
   Expect<KeepsFunction<FilterBuilderSchema['onChange']>>,
   Expect<KeepsFunction<ChatbotSchema['onError']>>,
   Expect<KeepsFunction<ChatbotSchema['onSend']>>,
+  Expect<KeepsFunction<ChatbotEnhancedSchema['onError']>>,
+  Expect<KeepsFunction<ChatbotEnhancedSchema['onSend']>>,
+  Expect<KeepsFunction<ChatbotEnhancedSchema['onClear']>>,
+  Expect<KeepsFunction<ChatbotFloatingSchema['onError']>>,
+  Expect<KeepsFunction<ChatbotFloatingSchema['onSend']>>,
+  Expect<KeepsFunction<ChatbotFloatingSchema['onClear']>>,
   Expect<KeepsFunction<DataTableSchema['onRowEdit']>>,
   Expect<KeepsFunction<DataTableSchema['onRowDelete']>>,
   Expect<KeepsFunction<DataTableSchema['onSelectionChange']>>,

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -28,7 +28,7 @@
  *
  * It reads `.shape` and not `keyof z.input<typeof Mirror>` because that spelling is
  * vacuous — `.passthrough()` collapses the inferred key union to bare `string`.
- * `assertionNoVacuousEntry` below pins that for all 162 entries at once.
+ * `assertionNoVacuousEntry` below pins that for all 156 entries at once.
  *
  * ## What is registered
  *
@@ -53,11 +53,16 @@
  * framing, and objectui#6058's own dispatch, both inherited "163"). On a file whose
  * entire subject is measurement that is worth stating explicitly:
  *
- *   - **162 pairs** (160 until objectui#7655 registered the `ChatbotEnhancedSchema` and
+ *   - **156 pairs** (154 until objectui#7655 registered the `ChatbotEnhancedSchema` and
  *     `ChatbotFloatingSchema` twins) — `Object.keys(MIRRORS).length`, which `assertionRegistryHalvesAgree`
  *     already pins equal to `keyof Declared`. Nothing asserts it against a written
  *     number, so this line is prose and can rot; the pin that cannot is the one
- *     comparing the two halves to each other.
+ *     comparing the two halves to each other. ⚠️ And it HAD rotted: this line read
+ *     "160" at objectui#7655's base while three instruments — a key regex over the
+ *     `MIRRORS` block, the `Declared` entry count, `Object.keys(MIRRORS).length` at
+ *     runtime — all read 154, six too high, and every "pairs" derivative below
+ *     inherited the same six. Re-measured and rewritten under #7655's contract
+ *     review; figures below are the measured ones, not the inherited chain.
  *   - **42 entries** in `KnownDrift`, **63 keys** across them — 40 / 57 until
  *     objectui#7655 SEEDED the `ChatbotEnhancedSchema` and `ChatbotFloatingSchema` pairs
  *     with three runtime-slot refusals each (pairs born ledgered in the #6124 shape,
@@ -79,10 +84,11 @@
  *     and 37 / 53 until objectui#7344 swept the string / `z.any()` handler mirrors:
  *     `DetailSchema` and `DetailViewSchema` entered (one `onBack` each) and
  *     `CalendarViewSchema` grew by `onEventClick`.
- *   - **16 entries** in `UnmirroredDeclared`, **96 keys** across them — 15 / 96 until
- *     objectui#7655 MOVED `displayMode` and `floatingConfig` off `ChatbotSchema`'s entry
- *     (3 → 1 key) onto a new `ChatbotFloatingSchema` entry born with exactly those two,
- *     so the key count did not move. It read 17 / 98
+ *   - **16 entries** in `UnmirroredDeclared`, **98 keys** across them — 15 / 96 until
+ *     objectui#7655 SEEDED a `ChatbotFloatingSchema` entry with `displayMode` and
+ *     `floatingConfig`, the two keys that face declares alongside `ChatbotSchema`
+ *     (whose own entry keeps all three of its keys — a pair born ledgered, not a
+ *     move). It read 17 / 98
  *     between objectui#6576, which SEEDED the new `ObjectDataTableSchema` pair with its
  *     one measured key `drillDown` (a pair born ledgered, not growth on an existing
  *     one), and objectui#7129, which RETIRED `DetailViewSectionSchema.hideEmpty` —
@@ -101,15 +107,17 @@
  *     seven are a subset of the 16 pairs above; `TreeViewSchema` is NOT — it is
  *     the first pair whose ONLY ledger entry is a runtime-only one
  *     (objectui#6150 declared `onNodeClick` on an otherwise clean pair), so the
- *     "no entry in either" population dropped by one to 141 — went to 142 when
- *     objectui#6576 added two pairs, one of them ledgered, went to 143 when
- *     objectui#7129 retired `DetailViewSectionSchema`'s only ledgered key, and
- *     went to 144 when objectui#7623 retired `DashboardComponentSchema`'s
- *     only UNMIRRORED one (that pair keeps its `KnownDrift` entry — this
- *     population counts entries in the two unmirrored ledgers), and stands at
- *     **145** since objectui#7655 added two pairs, one of them ledgered
- *     (`ChatbotFloatingSchema`).
- *   - 162 − 42 = **120**, the "pairs with no entry" `LedgerMismatch` speaks of.
+ *     "no entry in either" population dropped by one — and rose again when
+ *     objectui#6576 added two pairs, one of them ledgered, when objectui#7129
+ *     retired `DetailViewSectionSchema`'s only ledgered key, and when
+ *     objectui#7623 retired `DashboardComponentSchema`'s only UNMIRRORED one
+ *     (that pair keeps its `KnownDrift` entry — this population counts entries
+ *     in the two unmirrored ledgers). The chain this header used to quote for it
+ *     (141 → 142 → 143 → 144) was derived from the rotten "160" above and was six
+ *     too high at every step; measured, it stood at **138** (154 − 16) at
+ *     objectui#7655's base and stands at **139** (156 − 17) since #7655 added two
+ *     pairs, one of them ledgered (`ChatbotFloatingSchema`).
+ *   - 156 − 42 = **114**, the "pairs with no entry" `LedgerMismatch` speaks of.
  *
  * ## Two ratchets, because the forward comparison has two halves
  *
@@ -130,7 +138,7 @@
  *
  * ## KNOWN_DRIFT is a ratchet, not a waiver
  *
- * 42 of the 162 pairs carry TYPE drift TODAY (measured, not assumed). Each is
+ * 42 of the 156 pairs carry TYPE drift TODAY (measured, not assumed). Each is
  * pinned to its EXACT drifted key set, so the entry fails when new drift appears on
  * that mirror AND when the recorded drift is fixed — a stale entry cannot rot
  * quietly. Correcting them is not one change: the pairs below split into DISJOINT
@@ -295,7 +303,10 @@ export type ReconcileAgainstLedger< K, Measured, Recorded > =
 export type assertionRatchetAcceptsAgreement =
   Expect< Equal< ReconcileAgainstLedger< 'p', 'a', 'a' >, never > >;
 
-/** …and so does a clean pair with no entry, which is the case for 145 of the 162. */
+/**
+ * …and so does a clean pair with no entry — 114 of the 156 on the `KnownDrift` half,
+ * 139 on the unmirrored half (both measured; the inherited "145 of 162" was neither).
+ */
 export type assertionRatchetAcceptsCleanPair =
   Expect< Equal< ReconcileAgainstLedger< 'p', never, never >, never > >;
 
@@ -980,7 +991,7 @@ interface KnownDrift {
  * is being let through, because there was no such thing. Seeding takes the count of
  * VISIBLE, RATCHETED facts from 0 to 121 and installs a floor: the problem cannot
  * grow while they are worked off, and a new declared-but-unmirrored key on any of
- * the 162 pairs reddens immediately (`assertionRatchetRejectsFreshDrift`) —
+ * the 156 pairs reddens immediately (`assertionRatchetRejectsFreshDrift`) —
  * including a callback-shaped one, which reddens until it is filed in
  * `RuntimeOnlyDeclared` (`assertionSplitLedgerRejectsFreshCallback`).
  *
@@ -1017,11 +1028,12 @@ interface KnownDrift {
  *     spec schema does not model, which is objectui#2231's unification question and
  *     NOT a local mirror edit. They are marked, not exempted: exempting them in the
  *     instrument would re-blind exactly the pairs objectui#5927 leaned on hardest.
- *   - **LOCAL (13 entries, 83 keys)** — plain omissions from a hand-written mirror.
+ *   - **LOCAL (13 entries, 85 keys)** — plain omissions from a hand-written mirror.
  *     It was 13 / 84 until objectui#7129 RETIRED `DetailViewSectionSchema.hideEmpty`,
  *     a shrink by removing the DECLARATION rather than by mirroring it, and 12 / 83
- *     until objectui#7655 moved two of `ChatbotSchema`'s keys onto a new
- *     `ChatbotFloatingSchema` entry — an entry gained, no key gained.
+ *     until objectui#7655 SEEDED a `ChatbotFloatingSchema` entry with the two keys
+ *     that face declares alongside `ChatbotSchema` — an entry and two keys gained;
+ *     `ChatbotSchema`'s own entry did not move.
  *
  * ⚠️ Both counts moved with the reclassification: the spec-derived side lost
  * `ObjectViewSchema.onNavigate` (14 → 13) and the local side lost the other 22
@@ -1032,8 +1044,9 @@ interface KnownDrift {
  * objectui#6576 SEEDED `ObjectDataTableSchema` (a 17th entry, in neither half
  * above), objectui#7129 RETIRED an entry from the LOCAL half, and objectui#7623
  * RETIRED one from the SPEC-DERIVED half (13 → 12 keys there). The ledger now
- * totals **16 entries / 96 keys** — 2 / 12 spec-derived, 13 / 83 local, plus the
- * seeded pair (objectui#7655 added the 13th LOCAL entry by moving keys, not adding).
+ * totals **16 entries / 98 keys** — 2 / 12 spec-derived, 13 / 85 local, plus the
+ * seeded pair (objectui#7655 added the 13th LOCAL entry, `ChatbotFloatingSchema`,
+ * born with two keys).
  *
  * ## How this was measured, and the trap that makes the number hard to get
  *
@@ -1063,23 +1076,23 @@ interface KnownDrift {
 interface UnmirroredDeclared {
   /**
    * LOCAL. `body` sits in `KnownDrift` above for an unrelated reason (a naming
-   * collision on a key both sides declare); `requestBody` the mirror has simply
-   * never heard of. It was three keys until objectui#7655 MOVED `displayMode` and
-   * `floatingConfig` off this declaration — neither was the `chatbot` node's (no
-   * read, no designer control, no `defaultProps` seed on that registration) — onto
-   * `ChatbotFloatingSchema`, where the entry below records them in the same state.
+   * collision on a key both sides declare); these three the mirror has simply never
+   * heard of.
    */
-  'complex.zod.ts#ChatbotSchema': 'requestBody';
+  'complex.zod.ts#ChatbotSchema': 'displayMode' | 'floatingConfig' | 'requestBody';
   /**
-   * LOCAL — a pair born ledgered (objectui#7655) with exactly the two keys that
-   * crossed from `ChatbotSchema`'s entry above, in exactly the state they crossed
-   * in. `floatingConfig` has no `FloatingChatbotConfig` mirror at all — minting one
-   * is objectui#6152's axis, and the `triggerIcon` tombstone's tripwire
+   * LOCAL — a pair born ledgered (objectui#7655) with the two keys the floating
+   * face declares alongside `ChatbotSchema`, in the same state the entry above
+   * records them. `floatingConfig` has no `FloatingChatbotConfig` mirror at all —
+   * minting one is objectui#6152's axis, and the `triggerIcon` tombstone's tripwire
    * (objectui#7654, `floating-chatbot-trigger-icon-retired.test.ts`) watches for
-   * it. `displayMode` is parked on a maintainer decision (objectui#7654); a mirror
-   * arm would be a parse outcome that card has not ruled on. ⛔ Not a waiver: every
-   * OTHER key this pair declares is mirrored, and a third key here reddens the
-   * pair like growth on any other entry.
+   * it. `displayMode` is RULED RETIRED (objectui#7654, maintainer ruling B,
+   * 2026-09-05) and the retirement executes in that card's own PR: the TypeScript
+   * half is the `?: never` tombstone, and the mirror half (`retirementTombstone()`)
+   * is owed when objectui#6152 mints the arm — until then the key stays unmirrored
+   * here and on `ChatbotSchema` alike, and what that PR does to these two entries
+   * is its own to record. ⛔ Not a waiver: every OTHER key this pair declares is
+   * mirrored, and a third key here reddens the pair like growth on any other entry.
    */
   'complex.zod.ts#ChatbotFloatingSchema': 'displayMode' | 'floatingConfig';
   // `complex.zod.ts#DashboardComponentSchema` recorded `title` here (SPEC-DERIVED)
@@ -1428,7 +1441,7 @@ export type assertionLedgerHalvesAreDisjoint = Expect< Equal< DoubleFiledKey, ne
 
 /**
  * Every pair's TYPE drift equals what `KnownDrift` records for it — `never` for the
- * 120 pairs with no entry (162 − 42).
+ * 114 pairs with no entry (156 − 42).
  *
  * Routed through `ReconcileAgainstLedger` rather than spelling the conditional
  * inline. That is a semantics-preserving refactor and nothing else — the type is
@@ -1476,8 +1489,8 @@ export const assertionDriftMatchesLedger: never = 0 as unknown as LedgerMismatch
 
 /**
  * The SECOND half of the forward comparison: every pair's declared-but-unmirrored
- * key set equals what the two ledgers TOGETHER record for it — `never` for the 145
- * pairs with no entry in either (162 − 17). Six of `RuntimeOnlyDeclared`'s seven
+ * key set equals what the two ledgers TOGETHER record for it — `never` for the 139
+ * pairs with no entry in either (156 − 17). Six of `RuntimeOnlyDeclared`'s seven
  * pairs are a measured subset of `UnmirroredDeclared`'s 16, so objectui#6152's
  * reclassification left the clean population unchanged; objectui#6150 then added
  * `TreeViewSchema`, whose only entry is runtime-only, which is why the union is 16
@@ -1536,7 +1549,7 @@ export const assertionUnmirroredMatchesLedger: never = 0 as unknown as {
 }[MirrorKey];
 
 /**
- * Non-vacuity for all 162 entries at once.
+ * Non-vacuity for all 156 entries at once.
  *
  * `NarrowerThanDeclared` is `never` — green — for an entry whose mirror exposes no
  * `.shape`, and also for one whose key union has degenerated to bare `string` (the

--- a/packages/types/src/__tests__/zod-mirror-parity.test.ts
+++ b/packages/types/src/__tests__/zod-mirror-parity.test.ts
@@ -28,7 +28,7 @@
  *
  * It reads `.shape` and not `keyof z.input<typeof Mirror>` because that spelling is
  * vacuous — `.passthrough()` collapses the inferred key union to bare `string`.
- * `assertionNoVacuousEntry` below pins that for all 160 entries at once.
+ * `assertionNoVacuousEntry` below pins that for all 162 entries at once.
  *
  * ## What is registered
  *
@@ -53,11 +53,15 @@
  * framing, and objectui#6058's own dispatch, both inherited "163"). On a file whose
  * entire subject is measurement that is worth stating explicitly:
  *
- *   - **160 pairs** — `Object.keys(MIRRORS).length`, which `assertionRegistryHalvesAgree`
+ *   - **162 pairs** (160 until objectui#7655 registered the `ChatbotEnhancedSchema` and
+ *     `ChatbotFloatingSchema` twins) — `Object.keys(MIRRORS).length`, which `assertionRegistryHalvesAgree`
  *     already pins equal to `keyof Declared`. Nothing asserts it against a written
  *     number, so this line is prose and can rot; the pin that cannot is the one
  *     comparing the two halves to each other.
- *   - **40 entries** in `KnownDrift`, **56 keys** across them — 39 / 55 until
+ *   - **42 entries** in `KnownDrift`, **62 keys** across them — 40 / 56 until
+ *     objectui#7655 SEEDED the `ChatbotEnhancedSchema` and `ChatbotFloatingSchema` pairs
+ *     with three runtime-slot refusals each (pairs born ledgered in the #6124 shape,
+ *     not growth on an existing entry), 39 / 55 until
  *     objectui#7455 SEEDED `app.zod.ts#AppComponentSchema` with its one
  *     spec-derived key `hidden` (a pair born ledgered, not growth on an existing
  *     entry: both faces read `boolean` until the base was widened, and only the
@@ -71,7 +75,10 @@
  *     and 37 / 53 until objectui#7344 swept the string / `z.any()` handler mirrors:
  *     `DetailSchema` and `DetailViewSchema` entered (one `onBack` each) and
  *     `CalendarViewSchema` grew by `onEventClick`.
- *   - **15 entries** in `UnmirroredDeclared`, **96 keys** across them. It read 17 / 98
+ *   - **16 entries** in `UnmirroredDeclared`, **96 keys** across them — 15 / 96 until
+ *     objectui#7655 MOVED `displayMode` and `floatingConfig` off `ChatbotSchema`'s entry
+ *     (3 → 1 key) onto a new `ChatbotFloatingSchema` entry born with exactly those two,
+ *     so the key count did not move. It read 17 / 98
  *     between objectui#6576, which SEEDED the new `ObjectDataTableSchema` pair with its
  *     one measured key `drillDown` (a pair born ledgered, not growth on an existing
  *     one), and objectui#7129, which RETIRED `DetailViewSectionSchema.hideEmpty` —
@@ -87,16 +94,18 @@
  *     meaning — the comparable figure is 95 + 1 mirrored + 2 retired + 23
  *     reclassified. The full statement is on that ledger.
  *   - **7 entries** in `RuntimeOnlyDeclared`, **24 keys** across them. Six of the
- *     seven are a subset of the 15 pairs above; `TreeViewSchema` is NOT — it is
+ *     seven are a subset of the 16 pairs above; `TreeViewSchema` is NOT — it is
  *     the first pair whose ONLY ledger entry is a runtime-only one
  *     (objectui#6150 declared `onNodeClick` on an otherwise clean pair), so the
  *     "no entry in either" population dropped by one to 141 — went to 142 when
  *     objectui#6576 added two pairs, one of them ledgered, went to 143 when
  *     objectui#7129 retired `DetailViewSectionSchema`'s only ledgered key, and
- *     stands at **144** since objectui#7623 retired `DashboardComponentSchema`'s
+ *     went to 144 when objectui#7623 retired `DashboardComponentSchema`'s
  *     only UNMIRRORED one (that pair keeps its `KnownDrift` entry — this
- *     population counts entries in the two unmirrored ledgers).
- *   - 160 − 40 = **120**, the "pairs with no entry" `LedgerMismatch` speaks of.
+ *     population counts entries in the two unmirrored ledgers), and stands at
+ *     **145** since objectui#7655 added two pairs, one of them ledgered
+ *     (`ChatbotFloatingSchema`).
+ *   - 162 − 42 = **120**, the "pairs with no entry" `LedgerMismatch` speaks of.
  *
  * ## Two ratchets, because the forward comparison has two halves
  *
@@ -117,7 +126,7 @@
  *
  * ## KNOWN_DRIFT is a ratchet, not a waiver
  *
- * 40 of the 160 pairs carry TYPE drift TODAY (measured, not assumed). Each is
+ * 42 of the 162 pairs carry TYPE drift TODAY (measured, not assumed). Each is
  * pinned to its EXACT drifted key set, so the entry fails when new drift appears on
  * that mirror AND when the recorded drift is fixed — a stale entry cannot rot
  * quietly. Correcting them is not one change: the pairs below split into DISJOINT
@@ -151,7 +160,7 @@ import type { z } from 'zod';
 
 import { AppActionSchema, AppComponentSchema, NavigationAreaSchema } from '../zod/app.zod.js';
 import { BaseSchema, ComponentConfigSchema, ComponentInputSchema, ComponentMetaSchema, KeyedI18nLabelSchema } from '../zod/base.zod.js';
-import { CalendarEventSchema, CalendarViewSchema, CarouselItemSchema, CarouselSchema, ChatbotSchema, ChatMessageSchema, ChatMessageSourceSchema, ChatToolInvocationSchema, DashboardComponentSchema, DashboardConfigSchema, DashboardWidgetConfigSchema, DashboardWidgetLayoutSchema, DashboardWidgetSchema, FilterBuilderSchema, FilterFieldSchema, DeclarativeKanbanCardSchema, DeclarativeKanbanColumnSchema, DeclarativeKanbanSchema } from '../zod/complex.zod.js';
+import { CalendarEventSchema, CalendarViewSchema, CarouselItemSchema, CarouselSchema, ChatbotSchema, ChatbotEnhancedSchema, ChatbotFloatingSchema, ChatMessageSchema, ChatMessageSourceSchema, ChatToolInvocationSchema, DashboardComponentSchema, DashboardConfigSchema, DashboardWidgetConfigSchema, DashboardWidgetLayoutSchema, DashboardWidgetSchema, FilterBuilderSchema, FilterFieldSchema, DeclarativeKanbanCardSchema, DeclarativeKanbanColumnSchema, DeclarativeKanbanSchema } from '../zod/complex.zod.js';
 import { ActionCallbackSchema, CRUDDialogSchema, DetailSchema } from '../zod/crud.zod.js';
 import { AlertSchema, AvatarSchema, BadgeSchema, BarChartSchema, ChartDataSeriesSchema, ChartSchema, DataTableSchema, HtmlSchema, KbdSchema, ListItemSchema, ListSchema, MarkdownSchema, StaticTableColumnSchema, StatisticSchema, TableColumnSchema, TableSchema, TimelineEventSchema, TimelineSchema, TreeViewSchema } from '../zod/data-display.zod.js';
 import { AccordionItemSchema, AccordionSchema, CollapsibleSchema, ToggleGroupItemSchema, ToggleGroupSchema } from '../zod/disclosure.zod.js';
@@ -166,7 +175,7 @@ import { DetailViewFieldSchema, DetailViewSchema, DetailViewSectionSchema, Detai
 
 import type { AppAction as Ts_AppAction, AppComponentSchema as Ts_AppComponentSchema, NavigationArea as Ts_NavigationArea } from '../app';
 import type { BaseSchema as Ts_BaseSchema, ComponentConfig as Ts_ComponentConfig, ComponentInput as Ts_ComponentInput, ComponentMeta as Ts_ComponentMeta, KeyedI18nLabel as Ts_KeyedI18nLabel } from '../base';
-import type { CalendarEvent as Ts_CalendarEvent, CalendarViewSchema as Ts_CalendarViewSchema, CarouselItem as Ts_CarouselItem, CarouselSchema as Ts_CarouselSchema, ChatbotSchema as Ts_ChatbotSchema, ChatMessage as Ts_ChatMessage, ChatMessageSource as Ts_ChatMessageSource, ChatToolInvocation as Ts_ChatToolInvocation, DashboardComponentSchema as Ts_DashboardComponentSchema, DashboardWidgetLayout as Ts_DashboardWidgetLayout, DashboardWidgetSchema as Ts_DashboardWidgetSchema, FilterBuilderSchema as Ts_FilterBuilderSchema, FilterField as Ts_FilterField, DeclarativeKanbanCard as Ts_KanbanCard, DeclarativeKanbanColumn as Ts_KanbanColumn, DeclarativeKanbanSchema as Ts_KanbanSchema } from '../complex';
+import type { CalendarEvent as Ts_CalendarEvent, CalendarViewSchema as Ts_CalendarViewSchema, CarouselItem as Ts_CarouselItem, CarouselSchema as Ts_CarouselSchema, ChatbotSchema as Ts_ChatbotSchema, ChatbotEnhancedSchema as Ts_ChatbotEnhancedSchema, ChatbotFloatingSchema as Ts_ChatbotFloatingSchema, ChatMessage as Ts_ChatMessage, ChatMessageSource as Ts_ChatMessageSource, ChatToolInvocation as Ts_ChatToolInvocation, DashboardComponentSchema as Ts_DashboardComponentSchema, DashboardWidgetLayout as Ts_DashboardWidgetLayout, DashboardWidgetSchema as Ts_DashboardWidgetSchema, FilterBuilderSchema as Ts_FilterBuilderSchema, FilterField as Ts_FilterField, DeclarativeKanbanCard as Ts_KanbanCard, DeclarativeKanbanColumn as Ts_KanbanColumn, DeclarativeKanbanSchema as Ts_KanbanSchema } from '../complex';
 import type { DashboardConfig as Ts_DashboardConfig, DashboardWidgetConfig as Ts_DashboardWidgetConfig } from '../designer';
 import type { ActionCallback as Ts_ActionCallback, CRUDDialogSchema as Ts_CRUDDialogSchema, DetailSchema as Ts_DetailSchema } from '../crud';
 import type { AlertSchema as Ts_AlertSchema, AvatarSchema as Ts_AvatarSchema, BadgeSchema as Ts_BadgeSchema, BarChartSchema as Ts_BarChartSchema, ChartDataSeries as Ts_ChartDataSeries, ChartSchema as Ts_ChartSchema, DataTableSchema as Ts_DataTableSchema, HtmlSchema as Ts_HtmlSchema, KbdSchema as Ts_KbdSchema, ListItem as Ts_ListItem, ListSchema as Ts_ListSchema, MarkdownSchema as Ts_MarkdownSchema, StaticTableColumn as Ts_StaticTableColumn, StatisticSchema as Ts_StatisticSchema, TableColumn as Ts_TableColumn, TableSchema as Ts_TableSchema, TimelineEvent as Ts_TimelineEvent, TimelineSchema as Ts_TimelineSchema, TreeViewSchema as Ts_TreeViewSchema, BreadcrumbItem as Ts_BreadcrumbItem, BreadcrumbSchema as Ts_BreadcrumbSchema } from '../data-display';
@@ -282,7 +291,7 @@ export type ReconcileAgainstLedger< K, Measured, Recorded > =
 export type assertionRatchetAcceptsAgreement =
   Expect< Equal< ReconcileAgainstLedger< 'p', 'a', 'a' >, never > >;
 
-/** …and so does a clean pair with no entry, which is the case for 143 of the 160. */
+/** …and so does a clean pair with no entry, which is the case for 145 of the 162. */
 export type assertionRatchetAcceptsCleanPair =
   Expect< Equal< ReconcileAgainstLedger< 'p', never, never >, never > >;
 
@@ -377,6 +386,8 @@ const MIRRORS = {
   'complex.zod.ts#CarouselItemSchema': CarouselItemSchema,
   'complex.zod.ts#CarouselSchema': CarouselSchema,
   'complex.zod.ts#ChatbotSchema': ChatbotSchema,
+  'complex.zod.ts#ChatbotEnhancedSchema': ChatbotEnhancedSchema,
+  'complex.zod.ts#ChatbotFloatingSchema': ChatbotFloatingSchema,
   'complex.zod.ts#ChatMessageSchema': ChatMessageSchema,
   'complex.zod.ts#ChatMessageSourceSchema': ChatMessageSourceSchema,
   'complex.zod.ts#ChatToolInvocationSchema': ChatToolInvocationSchema,
@@ -535,6 +546,8 @@ interface Declared {
   'complex.zod.ts#CarouselItemSchema': Ts_CarouselItem;
   'complex.zod.ts#CarouselSchema': Ts_CarouselSchema;
   'complex.zod.ts#ChatbotSchema': Ts_ChatbotSchema;
+  'complex.zod.ts#ChatbotEnhancedSchema': Ts_ChatbotEnhancedSchema;
+  'complex.zod.ts#ChatbotFloatingSchema': Ts_ChatbotFloatingSchema;
   'complex.zod.ts#ChatMessageSchema': Ts_ChatMessage;
   'complex.zod.ts#ChatMessageSourceSchema': Ts_ChatMessageSource;
   'complex.zod.ts#ChatToolInvocationSchema': Ts_ChatToolInvocation;
@@ -742,6 +755,19 @@ interface KnownDrift {
    */
   'complex.zod.ts#ChatbotSchema': 'body' | 'onError' | 'onSend';
   /**
+   * RUNTIME SLOT (objectui#6124) — pairs born ledgered by objectui#7655, which gave
+   * the `chatbot-enhanced` and `chatbot-floating` registrations their own faces.
+   * Each face keeps the callables its registration forwards off `schema.*` —
+   * `onError` and `onSend` into `useObjectChat`, `onClear` from `handleClear` —
+   * and the mirror refuses all three by name (`handlerKeyRefusal`). No `body`
+   * here: these twins mirror the key the renderer reads, `requestBody`, and
+   * inherit `body` as the children slot, so `ChatbotSchema`'s naming collision
+   * was deliberately not copied across.
+   */
+  'complex.zod.ts#ChatbotEnhancedSchema': 'onClear' | 'onError' | 'onSend';
+  /** The same three slots on the same channel — see `ChatbotEnhancedSchema` above. */
+  'complex.zod.ts#ChatbotFloatingSchema': 'onClear' | 'onError' | 'onSend';
+  /**
    * spec-derived shape (`SpecDashboardFields`) measured against a hand-written
    * local declaration. Needs the spec-unification triage of #2231 rather than a
    * local widening.
@@ -942,7 +968,7 @@ interface KnownDrift {
  * is being let through, because there was no such thing. Seeding takes the count of
  * VISIBLE, RATCHETED facts from 0 to 121 and installs a floor: the problem cannot
  * grow while they are worked off, and a new declared-but-unmirrored key on any of
- * the 160 pairs reddens immediately (`assertionRatchetRejectsFreshDrift`) —
+ * the 162 pairs reddens immediately (`assertionRatchetRejectsFreshDrift`) —
  * including a callback-shaped one, which reddens until it is filed in
  * `RuntimeOnlyDeclared` (`assertionSplitLedgerRejectsFreshCallback`).
  *
@@ -979,9 +1005,11 @@ interface KnownDrift {
  *     spec schema does not model, which is objectui#2231's unification question and
  *     NOT a local mirror edit. They are marked, not exempted: exempting them in the
  *     instrument would re-blind exactly the pairs objectui#5927 leaned on hardest.
- *   - **LOCAL (12 entries, 83 keys)** — plain omissions from a hand-written mirror.
+ *   - **LOCAL (13 entries, 83 keys)** — plain omissions from a hand-written mirror.
  *     It was 13 / 84 until objectui#7129 RETIRED `DetailViewSectionSchema.hideEmpty`,
- *     a shrink by removing the DECLARATION rather than by mirroring it.
+ *     a shrink by removing the DECLARATION rather than by mirroring it, and 12 / 83
+ *     until objectui#7655 moved two of `ChatbotSchema`'s keys onto a new
+ *     `ChatbotFloatingSchema` entry — an entry gained, no key gained.
  *
  * ⚠️ Both counts moved with the reclassification: the spec-derived side lost
  * `ObjectViewSchema.onNavigate` (14 → 13) and the local side lost the other 22
@@ -992,8 +1020,8 @@ interface KnownDrift {
  * objectui#6576 SEEDED `ObjectDataTableSchema` (a 17th entry, in neither half
  * above), objectui#7129 RETIRED an entry from the LOCAL half, and objectui#7623
  * RETIRED one from the SPEC-DERIVED half (13 → 12 keys there). The ledger now
- * totals **15 entries / 96 keys** — 2 / 12 spec-derived, 12 / 83 local, plus the
- * seeded pair.
+ * totals **16 entries / 96 keys** — 2 / 12 spec-derived, 13 / 83 local, plus the
+ * seeded pair (objectui#7655 added the 13th LOCAL entry by moving keys, not adding).
  *
  * ## How this was measured, and the trap that makes the number hard to get
  *
@@ -1023,10 +1051,25 @@ interface KnownDrift {
 interface UnmirroredDeclared {
   /**
    * LOCAL. `body` sits in `KnownDrift` above for an unrelated reason (a naming
-   * collision on a key both sides declare); these three the mirror has simply never
-   * heard of.
+   * collision on a key both sides declare); `requestBody` the mirror has simply
+   * never heard of. It was three keys until objectui#7655 MOVED `displayMode` and
+   * `floatingConfig` off this declaration — neither was the `chatbot` node's (no
+   * read, no designer control, no `defaultProps` seed on that registration) — onto
+   * `ChatbotFloatingSchema`, where the entry below records them in the same state.
    */
-  'complex.zod.ts#ChatbotSchema': 'displayMode' | 'floatingConfig' | 'requestBody';
+  'complex.zod.ts#ChatbotSchema': 'requestBody';
+  /**
+   * LOCAL — a pair born ledgered (objectui#7655) with exactly the two keys that
+   * crossed from `ChatbotSchema`'s entry above, in exactly the state they crossed
+   * in. `floatingConfig` has no `FloatingChatbotConfig` mirror at all — minting one
+   * is objectui#6152's axis, and the `triggerIcon` tombstone's tripwire
+   * (objectui#7654, `floating-chatbot-trigger-icon-retired.test.ts`) watches for
+   * it. `displayMode` is parked on a maintainer decision (objectui#7654); a mirror
+   * arm would be a parse outcome that card has not ruled on. ⛔ Not a waiver: every
+   * OTHER key this pair declares is mirrored, and a third key here reddens the
+   * pair like growth on any other entry.
+   */
+  'complex.zod.ts#ChatbotFloatingSchema': 'displayMode' | 'floatingConfig';
   // `complex.zod.ts#DashboardComponentSchema` recorded `title` here (SPEC-DERIVED)
   // until objectui#7623 RETIRED the declaration — the objectui#7129 route, not a
   // mirror edit: the spec's strict `DashboardSchema` refuses a root `title` outright,
@@ -1373,7 +1416,7 @@ export type assertionLedgerHalvesAreDisjoint = Expect< Equal< DoubleFiledKey, ne
 
 /**
  * Every pair's TYPE drift equals what `KnownDrift` records for it — `never` for the
- * 120 pairs with no entry (160 − 40).
+ * 120 pairs with no entry (162 − 42).
  *
  * Routed through `ReconcileAgainstLedger` rather than spelling the conditional
  * inline. That is a semantics-preserving refactor and nothing else — the type is
@@ -1421,16 +1464,17 @@ export const assertionDriftMatchesLedger: never = 0 as unknown as LedgerMismatch
 
 /**
  * The SECOND half of the forward comparison: every pair's declared-but-unmirrored
- * key set equals what the two ledgers TOGETHER record for it — `never` for the 144
- * pairs with no entry in either (160 − 16). Six of `RuntimeOnlyDeclared`'s seven
- * pairs are a measured subset of `UnmirroredDeclared`'s 15, so objectui#6152's
+ * key set equals what the two ledgers TOGETHER record for it — `never` for the 145
+ * pairs with no entry in either (162 − 17). Six of `RuntimeOnlyDeclared`'s seven
+ * pairs are a measured subset of `UnmirroredDeclared`'s 16, so objectui#6152's
  * reclassification left the clean population unchanged; objectui#6150 then added
  * `TreeViewSchema`, whose only entry is runtime-only, which is why the union is 16
  * pairs and not 15. (objectui#6576 took the union to 18; objectui#7129 brought it
  * back to 17 by retiring `DetailViewSectionSchema`'s only ledgered key, and
  * objectui#7623 to 16 by retiring `DashboardComponentSchema`'s — each leaving its
  * pair with no entry in either half. ⚠️ That pair still carries a `KnownDrift`
- * entry: "no entry in either" is about the two UNMIRRORED ledgers.)
+ * entry: "no entry in either" is about the two UNMIRRORED ledgers. objectui#7655
+ * then took the union to 17 by registering `ChatbotFloatingSchema` born ledgered.)
  *
  * ⚠️ **The discriminating signal is the PER-PAIR set, not this file's exit code.**
  * The exit code is a whole-file verdict, so it moves only while the rest of the
@@ -1480,7 +1524,7 @@ export const assertionUnmirroredMatchesLedger: never = 0 as unknown as {
 }[MirrorKey];
 
 /**
- * Non-vacuity for all 160 entries at once.
+ * Non-vacuity for all 162 entries at once.
  *
  * `NarrowerThanDeclared` is `never` — green — for an entry whose mirror exposes no
  * `.shape`, and also for one whose key union has degenerated to bare `string` (the

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -876,14 +876,20 @@ export interface ChatbotSchema extends BaseSchema {
    */
   onSend?: (content: string, messages: ChatMessage[]) => void;
 
-  // `displayMode` and `floatingConfig` were declared here, under a "Floating /
-  // FAB display mode" heading, until objectui#7655. Neither belongs to this
-  // node: the `chatbot` registration has no read, no designer `inputs` entry
-  // and no `defaultProps` seed for either — both are the `chatbot-floating`
-  // registration's, and they are now declared on {@link ChatbotFloatingSchema},
-  // the type that names that node. Nothing was retired by the move:
-  // `displayMode` crossed UNCHANGED (its fate is objectui#7654's, still open)
-  // and `floatingConfig` kept its {@link FloatingChatbotConfig} shape.
+  // --- Floating / FAB display mode ---
+
+  /**
+   * Display mode for the chatbot.
+   * - `'inline'` (default): Embedded in the page flow.
+   * - `'floating'`: Rendered as a floating action button (FAB) that opens a panel overlay.
+   */
+  displayMode?: 'inline' | 'floating';
+
+  /**
+   * Configuration for the floating action button and the panel it opens —
+   * read by `chatbot-floating` alone and forwarded to `<FloatingChatbot>`.
+   */
+  floatingConfig?: FloatingChatbotConfig;
 }
 
 /**
@@ -893,9 +899,11 @@ export interface ChatbotSchema extends BaseSchema {
  * three faces share ONE declaration and ONE doc comment per key.
  *
  * Every member was read-site-censused per registration on the PR's base: one
- * `schema.KEY` read in each of the three `ComponentRegistry.register(...)`
+ * NAMED `schema.KEY` read in each of the three `ComponentRegistry.register(...)`
  * bodies of `packages/plugin-chatbot/src/renderer.tsx`, forwarded into
- * `useObjectChat` or onto the rendered component. The instrument was lit by
+ * `useObjectChat` or onto the rendered component. (Named reads are the
+ * instrument; the `chatbot-floating` registration also has an unfiltered
+ * props spread — see {@link ChatbotFloatingSchema}.) The instrument was lit by
  * keys that are NOT shared — `processVisibility` read 0 / 1 / 0 across
  * `chatbot` / `chatbot-enhanced` / `chatbot-floating` and `floatingConfig`
  * 0 / 0 / 1 — so a zero in that census is a reading, not a blind grep.
@@ -944,9 +952,9 @@ export type ChatbotSharedKey =
  *
  *   - the twenty {@link ChatbotSharedKey} members every registration reads;
  *   - `maxHeight` and `processVisibility`, which `chatbot-enhanced` forwards to
- *     `<ChatbotEnhanced>` and `chatbot-floating` never reads (its panel is
- *     sized by `floatingConfig.panelHeight` and always renders the `'summary'`
- *     process view);
+ *     `<ChatbotEnhanced>` by name and `chatbot-floating` has no named read for
+ *     (its panel is sized by `floatingConfig.panelHeight`; for the second,
+ *     unnamed channel on that registration see {@link ChatbotFloatingSchema});
  *   - `enableMarkdown`, `enableFileUpload`, `surface` and the `onClear`
  *     runtime slot, which `ChatbotSchema` never declared.
  *
@@ -1010,23 +1018,34 @@ export interface ChatbotEnhancedSchema
  * {@link ChatbotEnhancedSchema}). The floating-action-button presentation: a
  * trigger in a page corner that opens a chat panel overlay.
  *
- * Declared here is what THIS registration reads, censused per key on the
- * PR's base:
+ * Declared here is what THIS registration reads by name (`schema.KEY`),
+ * censused per key on the PR's base:
  *
  *   - the twenty {@link ChatbotSharedKey} members;
  *   - `enableMarkdown`, `enableFileUpload` and the `onClear` runtime slot,
  *     forwarded into the panel's `<ChatbotEnhanced>`;
  *   - `floatingConfig`, the trigger and panel geometry
- *     ({@link FloatingChatbotConfig});
- *   - `displayMode`, carried across from `ChatbotSchema` UNCHANGED — see the
- *     member's own comment.
+ *     ({@link FloatingChatbotConfig}), and `displayMode` — both ALSO declared
+ *     on {@link ChatbotSchema}, unchanged there; see each member's comment.
  *
  * NOT declared, on purpose: `maxHeight` (the panel pins its inner chat to
- * `100%` of `floatingConfig.panelHeight`, and a `maxHeight` authored here was
- * never forwarded), `processVisibility` and `surface` (not forwarded — the
- * panel renders the component defaults), and the six `ChatbotSchema` legacy
- * members no registration reads. `disabled` / `className` are inherited from
- * {@link BaseSchema}, as on the two sibling faces.
+ * `100%` of `floatingConfig.panelHeight` AFTER any forwarded value, so an
+ * authored `maxHeight` is dead here), `processVisibility` and `surface` (no
+ * named read in this registration), and the six `ChatbotSchema` legacy
+ * members no registration reads by name. `disabled` / `className` are
+ * inherited from {@link BaseSchema}, as on the two sibling faces.
+ *
+ * ⚠️ The named-read census is not the only channel. This registration ends
+ * its `<FloatingChatbot>` element with a raw `{...props}` spread — every
+ * authored key `SchemaRenderer` forwards, unfiltered — and the panel is a
+ * `<ChatbotEnhanced>`, so an authored `processVisibility`, `surface` or
+ * `showAvatars` DOES reach it today (measured through the real host: each
+ * lights its marker on a `chatbot-floating` node and stays dark without the
+ * key, while `chatbot-enhanced`, whose spread is `toDomProps`-filtered, keeps
+ * `showAvatars` dark). That channel is accidental, not contract: declaring
+ * the three here would fossilise it (AGENTS.md #0.1), and fencing it is a
+ * behaviour change with its own review. Recorded on its own card,
+ * objectui#7708; this face neither declares nor promises it.
  */
 export interface ChatbotFloatingSchema
   extends BaseSchema,
@@ -1060,15 +1079,16 @@ export interface ChatbotFloatingSchema
    * - `'inline'` (default): Embedded in the page flow.
    * - `'floating'`: Rendered as a floating action button (FAB) that opens a panel overlay.
    *
-   * ⚠️ Carried across from `ChatbotSchema` by objectui#7655 UNCHANGED — the
-   * three lines above are the original declaration's own words. Its fate is
-   * objectui#7654's, parked on a maintainer decision: measured there and
-   * re-measured here, the key is declared, offered as a designer control
-   * (the `chatbot-floating` registration's `inputs`) and seeded into that
-   * registration's `defaultProps`, and READ BY NOTHING — the node's own `type`
-   * selects the presentation. It moved onto this interface because the control
-   * and the seed are this registration's; it was not retired, tombstoned,
-   * mirrored or made live here.
+   * ⚠️ RULED RETIRED — objectui#7654, maintainer ruling B (2026-09-05): the
+   * node's own `type` is the one selector of presentation, and this key is a
+   * second spelling of that choice that no renderer has ever read (measured
+   * there and re-measured here: declared, offered as a designer control in the
+   * `chatbot-floating` registration's `inputs`, seeded by its `defaultProps`,
+   * read by nothing). The retirement — `?: never` tombstone, control and seed
+   * removed — executes in that card's own PR. objectui#7655 declared the key
+   * here with the same three lines {@link ChatbotSchema} still carries, so
+   * that PR finds the member on both faces exactly as ruled; nothing was
+   * retired, tombstoned, mirrored or made live here.
    */
   displayMode?: 'inline' | 'floating';
   /**

--- a/packages/types/src/complex.ts
+++ b/packages/types/src/complex.ts
@@ -876,18 +876,204 @@ export interface ChatbotSchema extends BaseSchema {
    */
   onSend?: (content: string, messages: ChatMessage[]) => void;
 
-  // --- Floating / FAB display mode ---
+  // `displayMode` and `floatingConfig` were declared here, under a "Floating /
+  // FAB display mode" heading, until objectui#7655. Neither belongs to this
+  // node: the `chatbot` registration has no read, no designer `inputs` entry
+  // and no `defaultProps` seed for either — both are the `chatbot-floating`
+  // registration's, and they are now declared on {@link ChatbotFloatingSchema},
+  // the type that names that node. Nothing was retired by the move:
+  // `displayMode` crossed UNCHANGED (its fate is objectui#7654's, still open)
+  // and `floatingConfig` kept its {@link FloatingChatbotConfig} shape.
+}
 
+/**
+ * The chat-surface keys that ALL THREE `plugin-chatbot` registrations read
+ * (objectui#7655) — the members {@link ChatbotEnhancedSchema} and
+ * {@link ChatbotFloatingSchema} pick off {@link ChatbotSchema} by name, so the
+ * three faces share ONE declaration and ONE doc comment per key.
+ *
+ * Every member was read-site-censused per registration on the PR's base: one
+ * `schema.KEY` read in each of the three `ComponentRegistry.register(...)`
+ * bodies of `packages/plugin-chatbot/src/renderer.tsx`, forwarded into
+ * `useObjectChat` or onto the rendered component. The instrument was lit by
+ * keys that are NOT shared — `processVisibility` read 0 / 1 / 0 across
+ * `chatbot` / `chatbot-enhanced` / `chatbot-floating` and `floatingConfig`
+ * 0 / 0 / 1 — so a zero in that census is a reading, not a blind grep.
+ *
+ * Exported only because an exported interface may not extend a `Pick` over a
+ * private name (TS4022). It is a census, not an authoring face, and it is not
+ * re-exported from the package entry: the node types are.
+ */
+export type ChatbotSharedKey =
+  | 'messages'
+  | 'placeholder'
+  | 'api'
+  | 'conversationId'
+  | 'systemPrompt'
+  | 'model'
+  | 'streamingEnabled'
+  | 'headers'
+  | 'requestBody'
+  | 'maxToolRoundtrips'
+  | 'onError'
+  | 'showTimestamp'
+  | 'userAvatarUrl'
+  | 'userAvatarFallback'
+  | 'assistantAvatarUrl'
+  | 'assistantAvatarFallback'
+  | 'autoResponse'
+  | 'autoResponseText'
+  | 'autoResponseDelay'
+  | 'onSend';
+
+/**
+ * `chatbot-enhanced` component — the authoring face of the
+ * `ComponentRegistry.register('chatbot-enhanced', ...)` registration in
+ * `packages/plugin-chatbot/src/renderer.tsx` (objectui#7655, under the
+ * objectui#6169 / #6172 family ruling: every component node has exactly one
+ * named, importable authoring-face type).
+ *
+ * Until objectui#7655 this node had no importable type: {@link ChatbotSchema}
+ * pins `type` to `'chatbot'`, so an author either dropped to untyped JSON or
+ * annotated with `ChatbotSchema` and lied about `type`. The registration's
+ * parameter type was an anonymous `ChatbotSchema & { ... }` intersection
+ * local to the renderer, referenceable by nothing outside that file.
+ *
+ * What is declared here is what THIS registration reads — censused per key on
+ * the PR's base, not copied off `ChatbotSchema`:
+ *
+ *   - the twenty {@link ChatbotSharedKey} members every registration reads;
+ *   - `maxHeight` and `processVisibility`, which `chatbot-enhanced` forwards to
+ *     `<ChatbotEnhanced>` and `chatbot-floating` never reads (its panel is
+ *     sized by `floatingConfig.panelHeight` and always renders the `'summary'`
+ *     process view);
+ *   - `enableMarkdown`, `enableFileUpload`, `surface` and the `onClear`
+ *     runtime slot, which `ChatbotSchema` never declared.
+ *
+ * NOT declared, on purpose: `loading`, `showAvatars`, `userAvatar`,
+ * `assistantAvatar`, `markdown` and `height` — `ChatbotSchema` members this
+ * registration has no read for. `disabled` and `className` are inherited from
+ * {@link BaseSchema}: `SchemaRenderer` evaluates `disabled` / `disabledOn`
+ * for every node type and hands the verdict to the registration as a prop, so
+ * redeclaring `disabled` here as `boolean` would only narrow away the
+ * expression-string half of an inherited field (objectui#6169, #7087).
+ */
+export interface ChatbotEnhancedSchema
+  extends BaseSchema,
+    Pick<ChatbotSchema, ChatbotSharedKey | 'maxHeight' | 'processVisibility'> {
+  type: 'chatbot-enhanced';
+  /**
+   * Render assistant messages as markdown. Forwarded to `<ChatbotEnhanced>`'s
+   * `enableMarkdown` prop; an unauthored value falls back to `true` at the
+   * registration (`schema.enableMarkdown ?? true`).
+   * @default true
+   */
+  enableMarkdown?: boolean;
+  /**
+   * Show the file-attachment control in the composer. Forwarded to
+   * `<ChatbotEnhanced>`'s `enableFileUpload` prop; an unauthored value falls
+   * back to `false` at the registration.
+   * @default false
+   */
+  enableFileUpload?: boolean;
+  /**
+   * Visual chrome for the chat surface (objectui#6687, maintainer ruling
+   * 2026-08-29). `'card'` keeps the embeddable bordered panel; `'plain'`
+   * removes the panel chrome for a full-page chat workspace. Declared on this
+   * node only: `chatbot-enhanced` is the one registration that renders
+   * `<ChatbotEnhanced>` and has a `surface` prop to forward it to. Passed
+   * through `undefined` when unauthored, so the component's own `'card'`
+   * default keeps applying.
+   *
+   * The plugin's `ChatbotSurface` alias (`@object-ui/plugin-chatbot`) is the
+   * component-side spelling of this same union; the plugin's tests pin the
+   * two equal so they cannot drift into two dialects (AGENTS.md #0.1).
+   * @default 'card'
+   */
+  surface?: 'card' | 'plain';
+  /**
+   * Called after the conversation is cleared through the composer's clear
+   * control, once the chat runtime has dropped its messages.
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata: JSON has no function value, so the zod twin refuses this key by
+   * name and points at the node-type spelling. Kept callable here because
+   * `plugin-chatbot`'s `handleClear` invokes `schema.onClear?.()`.
+   */
+  onClear?: () => void;
+}
+
+/**
+ * `chatbot-floating` component — the authoring face of the
+ * `ComponentRegistry.register('chatbot-floating', ...)` registration
+ * (objectui#7655; same ruling and same census discipline as
+ * {@link ChatbotEnhancedSchema}). The floating-action-button presentation: a
+ * trigger in a page corner that opens a chat panel overlay.
+ *
+ * Declared here is what THIS registration reads, censused per key on the
+ * PR's base:
+ *
+ *   - the twenty {@link ChatbotSharedKey} members;
+ *   - `enableMarkdown`, `enableFileUpload` and the `onClear` runtime slot,
+ *     forwarded into the panel's `<ChatbotEnhanced>`;
+ *   - `floatingConfig`, the trigger and panel geometry
+ *     ({@link FloatingChatbotConfig});
+ *   - `displayMode`, carried across from `ChatbotSchema` UNCHANGED — see the
+ *     member's own comment.
+ *
+ * NOT declared, on purpose: `maxHeight` (the panel pins its inner chat to
+ * `100%` of `floatingConfig.panelHeight`, and a `maxHeight` authored here was
+ * never forwarded), `processVisibility` and `surface` (not forwarded — the
+ * panel renders the component defaults), and the six `ChatbotSchema` legacy
+ * members no registration reads. `disabled` / `className` are inherited from
+ * {@link BaseSchema}, as on the two sibling faces.
+ */
+export interface ChatbotFloatingSchema
+  extends BaseSchema,
+    Pick<ChatbotSchema, ChatbotSharedKey> {
+  type: 'chatbot-floating';
+  /**
+   * Render assistant messages as markdown inside the panel. Forwarded to the
+   * panel's `enableMarkdown` prop; an unauthored value falls back to `true` at
+   * the registration.
+   * @default true
+   */
+  enableMarkdown?: boolean;
+  /**
+   * Show the file-attachment control in the panel's composer. Forwarded to
+   * the panel's `enableFileUpload` prop; an unauthored value falls back to
+   * `false` at the registration.
+   * @default false
+   */
+  enableFileUpload?: boolean;
+  /**
+   * Called after the conversation is cleared through the panel's clear
+   * control, once the chat runtime has dropped its messages.
+   *
+   * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
+   * metadata; the zod twin refuses it by name. Kept callable here because
+   * `plugin-chatbot`'s `handleClear` invokes `schema.onClear?.()`.
+   */
+  onClear?: () => void;
   /**
    * Display mode for the chatbot.
    * - `'inline'` (default): Embedded in the page flow.
    * - `'floating'`: Rendered as a floating action button (FAB) that opens a panel overlay.
+   *
+   * ⚠️ Carried across from `ChatbotSchema` by objectui#7655 UNCHANGED — the
+   * three lines above are the original declaration's own words. Its fate is
+   * objectui#7654's, parked on a maintainer decision: measured there and
+   * re-measured here, the key is declared, offered as a designer control
+   * (the `chatbot-floating` registration's `inputs`) and seeded into that
+   * registration's `defaultProps`, and READ BY NOTHING — the node's own `type`
+   * selects the presentation. It moved onto this interface because the control
+   * and the seed are this registration's; it was not retired, tombstoned,
+   * mirrored or made live here.
    */
   displayMode?: 'inline' | 'floating';
-
   /**
-   * Configuration for floating display mode.
-   * Only used when `displayMode` is `'floating'`.
+   * Configuration for the floating action button and the panel it opens —
+   * read by `chatbot-floating` alone and forwarded to `<FloatingChatbot>`.
    */
   floatingConfig?: FloatingChatbotConfig;
 }
@@ -1275,4 +1461,6 @@ export type ComplexSchema =
   | FilterBuilderSchema
   | CarouselSchema
   | ChatbotSchema
+  | ChatbotEnhancedSchema
+  | ChatbotFloatingSchema
   | DashboardComponentSchema;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -312,6 +312,8 @@ export type {
   ChatMessageSource,
   ChatToolInvocation,
   ChatbotSchema,
+  ChatbotEnhancedSchema,
+  ChatbotFloatingSchema,
   FloatingChatbotConfig,
   ComplexSchema,
 } from './complex.js';

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -486,19 +486,24 @@ export const ChatbotEnhancedSchema = BaseSchema.extend({
  *
  * Zod twin of `../complex.ts`'s `ChatbotFloatingSchema`. Two of that
  * declaration's keys are deliberately NOT mirrored, and the parity ledger
- * records both under `UnmirroredDeclared` for this pair:
+ * records both under `UnmirroredDeclared` for this pair — exactly as it
+ * records the same two keys for `ChatbotSchema`, which declares them too:
  *
  *   - `floatingConfig` — `FloatingChatbotConfig` has no Zod mirror at all;
  *     minting one is the declared-but-unmirrored axis (objectui#6152), a
  *     different defect from the one this pair closes, and the axis the
  *     `triggerIcon` tombstone's tripwire watches (objectui#7654).
- *   - `displayMode` — its fate is objectui#7654's, parked on a maintainer
- *     decision. A mirror arm here would be a parse outcome that card has not
- *     ruled on, so the key crossed from `ChatbotSchema` in exactly the state it
- *     was in: declared, unmirrored.
+ *   - `displayMode` — RULED RETIRED by objectui#7654 (maintainer ruling B,
+ *     2026-09-05): the node `type` is the one selector of presentation. The
+ *     retirement executes in that card's own PR — `?: never` tombstone on the
+ *     TypeScript faces, designer control and seed removed — and, per the
+ *     ruling, the mirror half (`retirementTombstone()`) is owed at the moment
+ *     objectui#6152 mints an arm for it, not before. Until then a mirror arm
+ *     here would be a parse outcome that ruling did not ask for, so this twin
+ *     has none.
  *
  * Both ride through `BaseSchema`'s `.passthrough()` unvalidated, byte for byte
- * as they did on `ChatbotSchema`.
+ * as they do on `ChatbotSchema`'s twin.
  */
 export const ChatbotFloatingSchema = BaseSchema.extend({
   type: z.literal('chatbot-floating'),

--- a/packages/types/src/zod/complex.zod.ts
+++ b/packages/types/src/zod/complex.zod.ts
@@ -414,6 +414,102 @@ export const ChatbotSchema = BaseSchema.extend({
 });
 
 /**
+ * The chat-surface arms ALL THREE `plugin-chatbot` registrations read
+ * (objectui#7655) — the Zod side of `../complex.ts`'s `ChatbotSharedKey`,
+ * taken off `ChatbotSchema`'s own shape so every shared arm has ONE spelling.
+ * Not exported: it is a census, not a mirror, and the parity census in
+ * `__tests__/zod-mirror-parity.test.ts` registers `export const`s only.
+ *
+ * `requestBody` is deliberately NOT in this pick. `ChatbotSchema` above mirrors
+ * the API body params under the key `body`, which collides with `BaseSchema`'s
+ * `body` children slot — the naming collision the parity ledger records under
+ * `KnownDrift`. The two twins below mirror the key the renderer actually reads,
+ * `requestBody`, and inherit `body` as the children slot, so they are born
+ * without the collision. Ruling on `ChatbotSchema`'s own `body` arm is a
+ * separate question and is not decided here.
+ */
+const ChatbotSharedMirrorShape = ChatbotSchema.pick({
+  messages: true,
+  placeholder: true,
+  api: true,
+  conversationId: true,
+  systemPrompt: true,
+  model: true,
+  streamingEnabled: true,
+  headers: true,
+  maxToolRoundtrips: true,
+  onError: true,
+  showTimestamp: true,
+  userAvatarUrl: true,
+  userAvatarFallback: true,
+  assistantAvatarUrl: true,
+  assistantAvatarFallback: true,
+  autoResponse: true,
+  autoResponseText: true,
+  autoResponseDelay: true,
+  onSend: true,
+}).shape;
+
+/** The arms `chatbot-enhanced` and `chatbot-floating` share beyond the pick above. */
+const chatbotRequestBodyArm = () =>
+  z.record(z.string(), z.unknown()).optional()
+    .describe('Additional body parameters sent with each API request (forwarded to the chat runtime as its `body` option)');
+const chatbotEnableMarkdownArm = () =>
+  z.boolean().optional().describe('Render assistant messages as markdown (default true)');
+const chatbotEnableFileUploadArm = () =>
+  z.boolean().optional().describe('Show the file-attachment control in the composer (default false)');
+const chatbotOnClearArm = () =>
+  handlerKeyRefusal('onClear', 'runtime-slot', 'Called after the conversation is cleared');
+
+/**
+ * Chatbot Enhanced Schema - `chatbot-enhanced` component (objectui#7655).
+ *
+ * Zod twin of `../complex.ts`'s `ChatbotEnhancedSchema`, in lockstep: every
+ * key that declaration lists is an arm here, and the three runtime slots
+ * (`onError`, `onSend`, `onClear`) are named refusals (objectui#6124).
+ */
+export const ChatbotEnhancedSchema = BaseSchema.extend({
+  type: z.literal('chatbot-enhanced'),
+  ...ChatbotSharedMirrorShape,
+  requestBody: chatbotRequestBodyArm(),
+  maxHeight: ChatbotSchema.shape.maxHeight,
+  processVisibility: ChatbotSchema.shape.processVisibility,
+  enableMarkdown: chatbotEnableMarkdownArm(),
+  enableFileUpload: chatbotEnableFileUploadArm(),
+  surface: z.enum(['card', 'plain']).optional()
+    .describe("Visual chrome for the chat surface: 'card' bordered panel (default) or 'plain' frameless full-page workspace (objectui#6687)"),
+  onClear: chatbotOnClearArm(),
+});
+
+/**
+ * Chatbot Floating Schema - `chatbot-floating` component (objectui#7655).
+ *
+ * Zod twin of `../complex.ts`'s `ChatbotFloatingSchema`. Two of that
+ * declaration's keys are deliberately NOT mirrored, and the parity ledger
+ * records both under `UnmirroredDeclared` for this pair:
+ *
+ *   - `floatingConfig` — `FloatingChatbotConfig` has no Zod mirror at all;
+ *     minting one is the declared-but-unmirrored axis (objectui#6152), a
+ *     different defect from the one this pair closes, and the axis the
+ *     `triggerIcon` tombstone's tripwire watches (objectui#7654).
+ *   - `displayMode` — its fate is objectui#7654's, parked on a maintainer
+ *     decision. A mirror arm here would be a parse outcome that card has not
+ *     ruled on, so the key crossed from `ChatbotSchema` in exactly the state it
+ *     was in: declared, unmirrored.
+ *
+ * Both ride through `BaseSchema`'s `.passthrough()` unvalidated, byte for byte
+ * as they did on `ChatbotSchema`.
+ */
+export const ChatbotFloatingSchema = BaseSchema.extend({
+  type: z.literal('chatbot-floating'),
+  ...ChatbotSharedMirrorShape,
+  requestBody: chatbotRequestBodyArm(),
+  enableMarkdown: chatbotEnableMarkdownArm(),
+  enableFileUpload: chatbotEnableFileUploadArm(),
+  onClear: chatbotOnClearArm(),
+});
+
+/**
  * Dashboard Widget Layout Schema
  */
 export const DashboardWidgetLayoutSchema = z.object({
@@ -771,5 +867,7 @@ export const ComplexSchema = z.discriminatedUnion('type', [
   FilterBuilderSchema,
   CarouselSchema,
   ChatbotSchema,
+  ChatbotEnhancedSchema,
+  ChatbotFloatingSchema,
   DashboardComponentSchema,
 ]);

--- a/packages/types/src/zod/index.zod.ts
+++ b/packages/types/src/zod/index.zod.ts
@@ -234,6 +234,8 @@ export {
   ChatMessageSourceSchema,
   ChatMessageSchema,
   ChatbotSchema,
+  ChatbotEnhancedSchema,
+  ChatbotFloatingSchema,
   DashboardWidgetLayoutSchema,
   DashboardWidgetTypeSchema,
   DashboardWidgetSchema,


### PR DESCRIPTION
Fixes #7655

## What

One named, importable authoring-face type per `plugin-chatbot` registration. `ChatbotEnhancedSchema` (`type: 'chatbot-enhanced'`) and `ChatbotFloatingSchema` (`type: 'chatbot-floating'`) join `ChatbotSchema` in `@object-ui/types`, with Zod twins in `@object-ui/types/zod` and both discriminants routed by `ComplexSchema`; the two registrations in `packages/plugin-chatbot/src/renderer.tsx` type their `schema` as those faces and drop the anonymous intersections. The docs' floating example is a typed `tsx` fence again — the card's own evidence — plus a typed `chatbot-enhanced` example. **`ChatbotSchema` itself is unchanged.**

**Clause-②: yes** — two new published node types, two new Zod twins, one new published type alias (`ChatbotSharedKey`, below). Draft, `needs:contract-review`. Changeset: `@object-ui/types: minor` with the accept-set change and the new symbol spelled out; `@object-ui/plugin-chatbot: patch`.

## Contract-review remediation — what changed between `30a53bd32` and `4579bdff9`

The review (PR comment 5550439212) returned REFUSE on seven items. Each is addressed in this push, and every measurement below was re-taken here rather than copied from the review.

1. **The floating face's channel claims were false and are gone.** The first cut said `processVisibility` and `surface` were "not forwarded — the panel renders the component defaults" (in `ChatbotFloatingSchema`'s JSDoc, emitted into `dist/complex.d.ts`, and in the docs rows). Re-measured through the real `SchemaRenderer` host: the `chatbot-floating` registration ends its `FloatingChatbot` element with a raw `{...props}` spread, LAST, so every authored key reaches the panel's `ChatbotEnhanced` unfiltered — `showAvatars`, `surface` and `processVisibility` are LIVE on a floating node (table below). The JSDoc, the census pin's docblock, the docs rows and this body now say so: the census counts NAMED `schema.KEY` reads, the raw spread is a second channel, and the face neither declares nor promises it. The three readings are pinned as a TRIPWIRE in the plugin's real-host test (ablation 2 shows it bites), and the channel is carded as objectui#7708 for a fence-vs-declare ruling — not decided here.
2. **Every `displayMode` tense reads the ruled state.** objectui#7654 was ruled at 2026-09-05T02:48:39Z (comment 5548848737, maintainer verbatim 「同意」, ruling B: retire — `?: never` tombstone on `ChatbotSchema`, designer control and `defaultProps` seed removed). The eight "parked on a maintainer decision" lines (changeset, `complex.ts` twice, `complex.zod.ts`, the parity ledger, the census test) and this body now read: ruled B; execution is #7654's own PR; this PR carries the key untouched on both faces so that PR finds the member exactly as ruled.
3. **Option B taken.** `displayMode` and `floatingConfig` are restored on `ChatbotSchema` — the declaration lines and `displayMode`'s three JSDoc lines byte-identical to the base (diffed against `6eebc54b6`), the `// --- Floating / FAB display mode ---` heading included; `ChatbotFloatingSchema` declares the same two. The `UnmirroredDeclared` entry for `ChatbotSchema` is back to its three keys with its base comment verbatim. The two "moved" pins are inverted into `assertionChatbotKeepsItsWholeFace` and `assertionFloatingKeysStayTypedOnChatbot`, and a third, `assertionFloatingKeysHaveOneTypeOnBothFaces`, pins the two members equal across the faces. The MOVED narrative is gone from every carrier. The measured reasons, verified here: on the first cut `ChatbotSchema['displayMode']` and `['floatingConfig']` read as `any` and `{ type: 'chatbot', floatingConfig: { triggerIcon: 'Sparkles' } }` compiled clean — the objectui#7669 tombstone had lost its reach on `chatbot` nodes, and nothing was red for it because that card's pins sit on `FloatingChatbotConfig` directly. Both are now pinned on the node (`floating-chatbot-trigger-icon-retired.test.ts` refuses `triggerIcon` through `ChatbotSchema.floatingConfig` AND through `ChatbotFloatingSchema.floatingConfig`; the census test refuses `displayMode: 'bogus'` on a `chatbot` node), and ablation 1 shows every one of them turning red in the option-A state.
4. **Changeset completeness.** `ChatbotSharedKey` is named as a new published symbol: exported for TS4022, emitted into `dist/complex.d.ts` (5 hits), reachable through the `@object-ui/types/complex` subpath, not re-exported from the entry. The "two keys MOVED" paragraph is replaced by "`ChatbotSchema` is unchanged".
5. **Parity-ledger prose rewritten from measurement.** At this PR's original base three instruments (a key regex over the `MIRRORS` block, the `Declared` entry count, `Object.keys(MIRRORS).length` at runtime) read **154 pairs where the prose said 160** — six too high, carried into every derivative — and the first cut had added its two to the stale number (162). `main` found the same rot independently at #7352's contract review (its re-derivation: 155 after `DrillDownConfigSchema`, `UnmirroredDeclared` 13 / 94, union 14) and landed while this PR was open, so the merged file carries main's re-derived text plus this PR's two pairs, every figure re-measured on the merged tree by the same three instruments: **157 pairs**, `KnownDrift` 42 / 63, `UnmirroredDeclared` 14 / 96 (2 / 12 spec-derived, 12 / 84 local; the seeded pair is gone), union of the two unmirrored ledgers 15, **115** pairs with no `KnownDrift` entry, **142** with no entry in either unmirrored ledger.
6. **`floatingConfig`'s JSDoc was rewritten, on both faces.** The base text said "Only used when `displayMode` is `'floating'`", which was false — the key is read by `chatbot-floating` alone and forwarded to `FloatingChatbot`. The corrected sentence is what the restored `ChatbotSchema` member carries too: its declaration line is verbatim, and that comment is the only difference from the base in the restored block (the diff shows exactly that).
7. **`main` merged — twice, no rebase, no amend, no force-push.** First `8ad218d58` (merge commit `368045e28`; conflicts in the two ledger tests reconciled as the union of both sides — #7104's `AlertDialogSchema.onAction` plus this PR's six chatbot slots: 66 sites / 44 runtime slots / 22 retired). Then, because `main` moved again under the first merge (#7684, #7701), `52c8cf741` (merge commit `4579bdff9`, the head): twelve conflict hunks, all in the parity ledger's prose and figures, reconciled as main's #7352 re-derivation plus this PR's two pairs and then re-measured (item 5). The head has `origin/main` `52c8cf741` as a parent; `git merge-tree` against it is clean.

## The ruling followed: one interface per registration, not a widened `type`

The governing line is quoted in the registration file itself (`renderer.tsx`, the `chatbot` registration's head comment): *"objectui#6169, the #6172 family ruling: every component node has exactly one named, importable authoring-face type"*. Widening `ChatbotSchema['type']` to the union of the three registered keys would give three nodes ONE type and re-open what #6169 closed. Each new face declares what ITS registration reads by name; the twenty keys all three read are picked off `ChatbotSchema` by name (`ChatbotSharedKey`, a `Pick` keyed by that alias) so they stay one declaration with one doc comment.

## The census — NAMED reads per key, per registration, with lit controls

Counts are `schema.KEY` reads inside each `ComponentRegistry.register(...)` body of `renderer.tsx` (a script splits the file at the three `register(` calls and counts word-bounded `schema.KEY`), re-run on `origin/main` `8ad218d58`, as `chatbot` / `chatbot-enhanced` / `chatbot-floating`:

| keys | named reads | declared on |
| :-- | :-- | :-- |
| `messages`, `placeholder`, `api`, `conversationId`, `systemPrompt`, `model`, `streamingEnabled`, `headers`, `requestBody`, `maxToolRoundtrips`, `onError`, `userAvatarUrl`, `userAvatarFallback`, `assistantAvatarUrl`, `assistantAvatarFallback`, `autoResponse`, `autoResponseText`, `autoResponseDelay`, `onSend` | 1 / 1 / 1 | all three (`ChatbotSharedKey`) |
| `showTimestamp` | 2 / 2 / 2 | all three (`ChatbotSharedKey`) |
| `maxHeight` | 1 / 1 / 0 | `ChatbotSchema`, `ChatbotEnhancedSchema` |
| `processVisibility` | 0 / 1 / 0 | `ChatbotEnhancedSchema` (still on `ChatbotSchema` too — not retired here, #7703) — LIVE on `chatbot-floating` through the raw spread, undeclared there (#7708) |
| `surface` | 0 / 1 / 0 | `ChatbotEnhancedSchema` (`'card' or 'plain'`, objectui#6687) — LIVE on `chatbot-floating` through the raw spread, undeclared there (#7708) |
| `enableMarkdown`, `enableFileUpload`, `onClear` | 0 / 1 / 1 | both new faces — `ChatbotSchema` never declared them |
| `floatingConfig` | 0 / 0 / 1 | `ChatbotSchema` (unchanged) and `ChatbotFloatingSchema` |
| `displayMode` | 0 / 0 / 0 reads; `inputs` 0 / 0 / 1; `defaultProps` 0 / 0 / 1 | `ChatbotSchema` (unchanged) and `ChatbotFloatingSchema` — ruled retired on #7654, executed there |
| `loading`, `showAvatars`, `userAvatar`, `assistantAvatar`, `markdown`, `height` | 0 / 0 / 0 | neither new face (#7703) — `showAvatars` is nonetheless LIVE on `chatbot-floating` through the raw spread (#7708; told on #7703) |

`disabled` is not redeclared on either face — it stays `BaseSchema`'s `boolean | string` (objectui#7087). Lit controls: the instrument reads non-zero exactly on the rows where the registrations differ (`processVisibility`, `floatingConfig`, `surface`), so the zeros are readings.

### The second channel, measured through the real host

`chatbot` and `chatbot-enhanced` open their rendered element with `{...toDomProps(props)}` (whitelist-filtered, FIRST); `chatbot-floating` ends its `FloatingChatbot` element with raw `{...props}` (LAST), and `FloatingChatbot` forwards the rest onto `ChatbotEnhanced`. Rendered through `SchemaRendererProvider` + `SchemaRenderer` with a lit/dark pair per key and `chatbot-enhanced` as the control — identical readings on `origin/main` `8ad218d58` and on this branch (`renderer.tsx` is byte-identical between the first remediation commit and the head):

| authored key → marker | `chatbot-floating` lit / dark | `chatbot-enhanced` lit / dark |
| :-- | :-- | :-- |
| `showAvatars: true` → per-message avatar element | 1 / 0 | 0 / 0 (the whitelist drops it; no named forward) |
| `surface: 'plain'` → `.max-w-2xl` wrappers | 2 / 0 | 2 / 0 (named read — lit control) |
| `processVisibility: 'debug'` → raw tool name for a tool result | shown / hidden | shown / hidden (named read — lit control) |

Mechanism pinned on the whitelist itself: `toDomProps({ showAvatars, surface, processVisibility, className })` keeps `className` and drops the other three.

One prediction missed, recorded: my first `processVisibility` control on `chatbot-enhanced` used the `data-trace-id` link and read 0 where I predicted 1. Cause, read off the source: `useObjectChat`'s `normalizeMessages` rebuilds every seed message with a fixed key set and drops `traceId`, so the link cannot render on the named-read path — while on floating the raw spread overrides `messages` with the authored seed, which keeps `traceId`, so it does render there. The raw-tool-name marker rides `toolInvocations`, which normalisation keeps, and lights on both; that is the marker the tripwire uses. The same `messages` override is why a sent message never renders on a floating node — measured (`userShown: false, replyShown: false` on floating; both `true` on `chatbot-enhanced`) and carded on #7708, deliberately not pinned here (pinning a bug as expected is the wrong shape).

## `displayMode` — ruled retired on objectui#7654; carried untouched here, on both faces

Re-measured on the base: word-boundary `displayMode` over `packages/plugin-chatbot/src`, tests excluded — two hits, `renderer.tsx` (a designer `inputs` control and a `defaultProps` seed, both the `chatbot-floating` registration's), zero reads. #7654 ruled B on that measurement: the node `type` is the one selector of presentation. The retirement — tombstone on `ChatbotSchema`, control and seed removed — executes in #7654's own PR. Here the member stays on `ChatbotSchema` byte for byte and is declared on `ChatbotFloatingSchema` with the same three lines, unmirrored on both twins (`UnmirroredDeclared` records it under both pairs), and the census test pins as a TRIPWIRE that any value still parses green — #7654's PR flips that pin with the ruling in hand. Nothing was retired, tombstoned, mirrored or made live.

## Zod twins and the ledgers — counts as measured on `4579bdff9`

- Two pairs registered in `zod-mirror-parity.test.ts`: **157 pairs** (155 on `main` after #7352; 154 at this PR's original base). `KnownDrift`: each born with exactly its three runtime-slot refusals (`onClear` | `onError` | `onSend`, the objectui#6124 shape) — **42 entries / 63 keys** (40 / 57 on `main`). `UnmirroredDeclared`: `ChatbotSchema` keeps `displayMode` | `floatingConfig` | `requestBody`; `ChatbotFloatingSchema` is born with `displayMode` | `floatingConfig` — **14 / 96** (13 / 94 on `main`). `RuntimeOnlyDeclared` 7 / 24 unchanged. Derivatives: 115 pairs with no `KnownDrift` entry, 142 with no entry in either unmirrored ledger.
- `handler-keys-json-refusal-6124.test.ts`: 66 sites, 44 runtime slots, 22 retired (this PR's six plus #7104's `onAction` from the first merge); the type-level `KeepsFunction` pins carry all of them.
- `floatingConfig`: no `FloatingChatbotConfig` mirror minted on either twin — objectui#6152's axis. The objectui#7669 tripwire (`floating-chatbot-trigger-icon-retired.test.ts`) now runs on BOTH twins (`describe.each`), and the tombstone's reach is pinned on both node types.
- `requestBody` is mirrored under its own name on both twins; `ChatbotSchema`'s `body` naming collision (in `KnownDrift`) was not copied across and is not ruled on here. The twenty shared arms are taken off `ChatbotSchema`'s own `.shape` by `.pick(...)`, so each has one spelling; the test asserts description equality per key.

## Fence extension, declared: `packages/types/src/zod/index.zod.ts` (two export lines)

The fence lists `complex.zod.ts`, so Zod twins were in scope, but the Zod barrel is an explicit named-export list — a twin not exported from `@object-ui/types/zod` would be declared-but-unreachable. This PR's barrel edits are the same two lines the review read; the only other barrel change on the branch is `main`'s own `DrillDownConfigSchema` export (#7701), carried by the merge. `packages/types/src/registry.ts` was deliberately NOT touched (#7704).

## `chatbot-floating` and `disabled` — one consequence, no render outcome moves

Unchanged from the first cut: the raw `disabled={schema.disabled}` read was already overridden on every render by the host verdict the trailing spread carried; the registration now destructures `disabled: hostDisabled` and forwards it, as its two siblings do. Pinned through the real host both ways. The trailing spread itself is untouched (see #7708) — only annotated at the site.

## Evidence — every run below is on `4579bdff9`, after the final commit (tree clean, `git status` 0 lines)

- `pnpm --filter @object-ui/types build && pnpm --filter @object-ui/types type-check && pnpm --filter @object-ui/plugin-chatbot type-check`, chained, under the verify lock: `VERDICT command-exit 0`, the sha echoed after the chain; each script name echoed (`tsc && check-dist-completeness`; `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`; `tsc --noEmit && tsc -p tsconfig.test.json`), 0 `error TS` lines in all three logs. The types `type-check` is the channel the parity ratchet and every new pin live in; the plugin `type-check` read the REBUILT types dist (which emits `displayMode?:` on both faces and `ChatbotSharedKey` 5 hits) with the dependency closure built in this worktree (test-support, react-runtime, types, core, i18n, sdui-parser, data-objectstack, components, react — all exit 0).
- `pnpm exec vitest run --maxWorkers=2` over the four affected `packages/types` test files plus all of `packages/plugin-chatbot/` → `Test Files 39 passed (39)`, `Tests 747 passed (747)`, `git rev-parse --short HEAD` = `4579bdff9` echoed at its head. One red on the way, recorded: `chat-message-contract.test.ts` counts the literal runtime-messages prop in `renderer.tsx` and my first spread-site comment contained it — reworded; a comment tripping a source-scanning pin, no behaviour involved.
- Gates re-run on the merged tree, each quoting its own verdict line, exit codes captured by redirect before any pipe: `check:doc-fences` ✅ (227 documents); `check:doc-types` ✅ "Every documented component type is registered"; `check:control-bytes` ✅ (6280 files); `check:published-tsconfig-exclude` OK (34 packages); `check:shell-escape-residue` ✅; `check-doc-links` "Links are valid across 17 scan roots"; `check-changeset-no-major` ✅.
- **`check:doc-snippets` NOT MEASURED locally** — exit 2, `PRECONDITION NOT MET` (it wants the whole workspace built: app-shell, auth, cli, every plugin), which its own text says is "I could not run", not a verdict. Declared narrowing with evidence: a line-level diff of the mdx between the reviewed head and this branch changes 9 → 16 prose lines and **0 lines inside any code fence** (26 fenced blocks before and after), against a lit control — the same instrument on the first cut vs the merge-base reads 29 changed fence lines; the mdx is untouched by both merges; and the only type change since the reviewed 455 / 455 run is additive on `ChatbotSchema`. CI runs it.
- **`check:readme-exports` not re-run**: this PR's two barrel lines are byte-identical to the reviewed head `30a53bd32`, where it ran green after the closures were built; the merges add only `main`'s own export. CI runs it.
- Lint on the merged tree: `pnpm --filter @object-ui/types lint` and `pnpm --filter @object-ui/plugin-chatbot lint` (each package's own `eslint .`) → exit 0, 0 errors (269 / 90 warnings, all pre-existing). Narrowing declared with the three evidences: the population is eslint's own config (`eslint.config.js`, 0 `projectService` / `parserOptions` hits, so no untouched file's verdict can move); a `--format json` run over the diff's ten lintable files judged 10 files, 0 errors, 13 warnings; other packages are untouched by the diff.
- **Reach probes (tsc over `packages/types` source, predictions written first, scratch files never committed; `complex.ts` is byte-identical between the first remediation commit and the head):** at `origin/main` `8ad218d58` — `ChatbotSchema['displayMode']` / `['floatingConfig']` typed (green); `displayMode: 'bogus'`, a wrong-shaped `floatingConfig` and `floatingConfig.triggerIcon` on a `chatbot` node all TS2322 (3 errors). At the first cut (`368045e28`) — the two typed-read pins TS2344 (`any`), all three wrong values compile CLEAN (2 errors, the opposite set). After the restore — identical to the base (3 errors on the same three lines), plus the floating face refusing `triggerIcon` and `'bogus'` (5 in total, 0 outside the probes).
- **Ablation 1 — the option-A state turns the new pins red (re-run on `4579bdff9`).** After committing, the restored block was deleted from `ChatbotSchema` (heading count 1 → 0, `displayMode?: 'inline'` count 2 → 1, blob `06d14941` ≠ HEAD `fd59df10`); predicted red on `tsc -p tsconfig.test.json`: five TS2344 (the whole-face pin; the two typed-key pins; the two one-type-on-both-faces pins), two TS2578 unused-directive (`displayMode: 'bogus'` on a `chatbot` node; `triggerIcon` reached through `ChatbotSchema.floatingConfig`), one TS2322 naming `complex.zod.ts#ChatbotSchema` (the ledger records three keys, the declaration then had one). Observed: exactly those 8, at lines 154 / 170 / 171 / 188 / 189 / 289 of the census test, 107 of the trigger-icon test, 1571 of the parity test. Restored with `git checkout HEAD -- ABSOLUTE_PATH` under an `EXIT INT TERM` trap; blob back to `fd59df10` = HEAD, `git diff HEAD` empty. Rebuild statement: none needed and none done — `tsconfig.test.json` resolves `../complex` from source (the reach probes read the same channel), and the dist on disk was built from the final source before the leg and untouched by it.
- **Ablation 2 — the spread tripwire bites (re-run on `4579bdff9`).** The floating spread was fenced to `{...toDomProps(props)}` (count 2 → 3, blob `5acbed9b` ≠ HEAD `3dbd2634`); predicted: the three render tripwires red, the mechanism test and the other six green. Observed: `Tests 3 failed | 7 passed (10)` — exactly `showAvatars`, `surface`, `processVisibility`. Restored the same way; blob back to `3dbd2634` = HEAD, `git diff HEAD` empty. No build involved: the test imports `../renderer` from source.
- Heavy runs went through `os-verify-lock.sh` (slots `issue-7655-*`), every wait 0 s; wall-clock figures are shared-box readings.
- NOT measured locally, CI owns: `check:doc-snippets` and `check:readme-exports` (above), the full `pnpm lint` farm beyond the two packages, `check:published-dist`, `check:sdui-registration-pins`.

## Out of scope, filed — nothing addressed here

- #7708 (new this round): the `chatbot-floating` raw spread — three undeclared keys live; the authored `messages` seed overriding the runtime messages (a sent message never renders on a floating node, both render on `chatbot-enhanced`); `displayMode` / `systemPrompt` / `model` landing as DOM attributes (1 / 1 / 1 vs 0 / 0 / 0). Two options with costs stated, none picked.
- #7703: six `ChatbotSchema` keys declared and read by no registration. Its tension is settled on the card: `userAvatar` / `assistantAvatar` are 0 everywhere; the "four avatar keys" were the `*Url` / `*Fallback` four; `showAvatars` IS live on floating through the spread.
- #7704: `SchemaRegistry` / `ComponentType` omit the two keys; `registry.ts` untouched here.

## Related cards that stay open

objectui#7654 — ruled B (retire `displayMode`), open for its own PR; this PR leaves the member on both faces for it. objectui#6152 (the unmirrored ledger) and objectui#7665 (`SchemaRegistry`'s docblock) are untouched. objectui#7669's tripwire now watches both twins.

Session `session_01KbJQ1y1J12nZxYzFWhP8Q3`, `domain:ui` dev seat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3