### PR TITLE
Fixes #7101: drop the undeclared `variant` key from the dropdown-menu Delete item

### DIFF
--- a/examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/with-icons.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/with-icons.json
@@ -16,8 +16,7 @@
     },
     {
       "label": "Delete",
-      "icon": "trash",
-      "variant": "destructive"
+      "icon": "trash"
     }
   ]
 }


### PR DESCRIPTION
Fixes #7101

## Ruling executed

Option **A** (director seat comment https://github.com/objectstack-ai/objectui/issues/7101#issuecomment-5536049455, maintainer verbatim 「同意」, batch #28): the `variant` key leaves the Delete item in `examples/schema-catalog/src/schemas/components-overlay-dropdown-menu/with-icons.json`; the item keeps `label` / `icon`; `MenuCommandItem` gains NO `variant` (no change under `packages/**`); not a rider on any other PR.

## What changed

One file, one key removed (plus the preceding line's trailing comma) — exactly the expected diff shape:

```diff
     {
       "label": "Delete",
-      "icon": "trash",
-      "variant": "destructive"
+      "icon": "trash"
     }
```

## Mechanism verification (re-grep, per the ruling's execution constraints)

Grepped `variant` across all menu-item fixtures under `examples/schema-catalog/src/schemas/` — the two `components-overlay-dropdown-menu/*.json`, `components-overlay-context-menu/basic-context-menu.json`, `components-overlay-menubar/application-menubar.json`, and `components-form-command/command-menu.json`:

```
components-overlay-dropdown-menu/with-icons.json:20:      "variant": "destructive"   (the only hit — this PR removes it)
components-overlay-context-menu/*.json                                                (zero hits)
components-overlay-menubar/*.json                                                     (zero hits)
components-form-command/*.json                                                        (zero hits)
```

**Positive control** — `components-overlay-alert-dialog/*.json` (buttons, where `ButtonSchema` declares `variant`) stays non-zero, confirming the grep is discriminating menu-item spelling from button spelling, not just returning zero everywhere:

```
basic-alert-dialog.json:13:      "variant": "outline"
basic-alert-dialog.json:18:      "variant": "destructive"
confirmation-dialog.json:8:    "variant": "outline"
confirmation-dialog.json:14:      "variant": "ghost"
confirmation-dialog.json:19:      "variant": "default"
custom-actions.json:8:    "variant": "default"
custom-actions.json:14:      "variant": "outline"
custom-actions.json:19:      "variant": "default"
destructive-action.json:8:    "variant": "destructive"
destructive-action.json:18:      "variant": "destructive"
```

Zero-beyond-line-20 for menu items + non-zero control ⇒ the mechanism assumption held.

## Gates (HEAD `02bc828`, base `origin/main` `4ce14f1`)

| Gate | Command | Exit |
|---|---|---|
| Schema-catalog tests | `pnpm exec vitest run examples/schema-catalog/` | 0 — Test Files 28 passed (28), Tests 2075 passed (2075) |
| Changeset presence | `node scripts/check-changeset-presence.mjs` | 0 — "No source or published contract of a released package changed in this range, so no changeset is owed." (`examples/schema-catalog` is unpublished; no changeset added) |
| Control bytes | `node scripts/check-control-bytes.mjs` | 0 — scanned 6291 tracked text file(s) |
| JSON syntax | `node -e "JSON.parse(...)"` | 0 — valid JSON |

No `check:*` gate family targets JSON fixture content directly beyond the two run above; this is a JSON-only fixture edit (no `packages/**`, no TS/JS source), so no package `typecheck`/`test` is otherwise implicated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s)_