### PR TITLE
fix(runner): render `AppAction.items` from its declared type — delete the two retired-key `as any` reads and make the `onClick` refusal true again

### DIFF
--- a/.changeset/6854-layout-renderer-retired-onclick.md
+++ b/.changeset/6854-layout-renderer-retired-onclick.md
@@ -1,0 +1,37 @@
+---
+'@object-ui/types': patch
+'@object-ui/runner': patch
+---
+
+The standalone runner renders `AppAction.items` from its declared type only, which
+makes `AppActionSchema.onClick`'s retirement message true again (objectui#6854,
+maintainer ruling of 2026-09-05, option B2).
+
+`AppAction.items` is `AppMenuItem[]`, and the zod mirror parses it with the legacy
+eight-member `MenuItemSchema` — neither declares `onClick` or `shortcut`.
+`LayoutRenderer` reached both through `as any`, past the type it was handed, and
+that left three mutually exclusive signals about the same key: the TypeScript face
+said `?: never`, the validator's refusal said "no renderer reads this key, so
+nothing could ever run it", and a renderer read it. An agent or a reader could
+believe any one of the three and be contradicted by the other two.
+
+**No published accept set moves and no exported symbol changes.** `AppAction.items`
+is NOT re-typed (the alternative was measured and refused: it would have carried a
+breaking migration for `path` / `href` / `badge` / `type` and the divider spelling,
+for a capability with no measured consumer). The refusal message itself is unchanged
+— it is shared by 22 other retired handler keys, and deleting the cast is what makes
+its sentence true rather than restating it.
+
+- `@object-ui/runner`: `LayoutRenderer` no longer reads `onClick` or `shortcut` on a
+  `type: 'user'` action's `items`. The `onClick` branch was an empty body and could
+  never run a JSON value; the `shortcut` read rendered a `DropdownMenuShortcut` from
+  a key the mirror strips in silence, so no validated document could reach it. A
+  census of every JSON and TypeScript app document in this repository found zero
+  authors of either key (positive controls recorded on the issue).
+- `@object-ui/types`: the rationale comments on `AppAction.onClick` and
+  `AppActionSchema.onClick` said "nothing reads `AppComponentSchema.actions[]`".
+  That was false — the runner renders both the `'button'` and the `'user'` arm.
+  Corrected to what was measured: `actions[]` is read, `onClick` is not.
+
+Whether `shortcut` should become authorable on `AppAction.items` is a separate
+contract question and is filed on its own.

--- a/packages/runner/src/LayoutRenderer.tsx
+++ b/packages/runner/src/LayoutRenderer.tsx
@@ -25,7 +25,6 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  DropdownMenuShortcut,
   Avatar,
   AvatarImage,
   AvatarFallback,
@@ -298,20 +297,28 @@ export const LayoutRenderer = ({ app, children, currentPath, onNavigate }: Layou
                         </DropdownMenuLabel>
                         <DropdownMenuSeparator />
                         <DropdownMenuGroup>
+                            {/*
+                              * Renders `AppAction.items` from its DECLARED type and nothing else
+                              * (objectui#6854, maintainer ruling of 2026-09-05, option B2).
+                              *
+                              * `items` is `AppMenuItem[]` (`@object-ui/types` `app.ts`), and the zod
+                              * mirror parses it with the legacy eight-member `MenuItemSchema`.
+                              * Neither declares `onClick` or `shortcut`; this map used to reach both
+                              * through `as any`, i.e. past the type it was handed. The `onClick` read
+                              * is also what made the retirement refusal's own sentence — "no renderer
+                              * reads this key, so nothing could ever run it" — false. `type` and
+                              * `label` ARE declared on `AppMenuItem` and stay.
+                              *
+                              * Whether `shortcut` should become authorable on `AppAction.items` is a
+                              * separate contract question; do not re-add either read to answer it.
+                              */}
                             {userAction.items?.map((item, idx) => {
                                 if (item.type === 'separator') {
                                     return <DropdownMenuSeparator key={idx} />;
                                 }
                                 return (
-                                    <DropdownMenuItem key={idx} onSelect={() => {
-                                        if ((item as any).onClick) {
-                                            // Handle click logic
-                                        }
-                                    }}>
+                                    <DropdownMenuItem key={idx}>
                                         {item.label}
-                                        {(item as any).shortcut && (
-                                            <DropdownMenuShortcut>{(item as any).shortcut}</DropdownMenuShortcut>
-                                        )}
                                     </DropdownMenuItem>
                                 );
                             })}

--- a/packages/runner/src/__tests__/LayoutRenderer.appActionItems-6854.test.tsx
+++ b/packages/runner/src/__tests__/LayoutRenderer.appActionItems-6854.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `LayoutRenderer` renders `AppAction.items` from the DECLARED element type and
+ * nothing else (objectui#6854, maintainer ruling of 2026-09-05, option B2).
+ *
+ * `AppAction.items` is `AppMenuItem[]` — `type` / `label` / `icon` / `path` /
+ * `href` / `children` / `badge` / `hidden` — and the zod mirror parses it with
+ * the legacy eight-member `MenuItemSchema`, which drops anything else in
+ * silence. This map used to reach two keys that are on neither list through
+ * `as any`: `onClick` and `shortcut`.
+ *
+ * Deleting them is what makes `AppActionSchema.onClick`'s refusal message true
+ * again. It tells an author "no renderer reads this key, so nothing could ever
+ * run it", and until this ruling one did — the three-layer contradiction the
+ * card was filed for (`?: never` on the type, "nobody reads it" from the
+ * validator, a renderer reading it).
+ *
+ * These assertions author BOTH undeclared keys anyway — exactly what a host
+ * bypassing the validator would hand in, which the card's Zone-2 census found
+ * none of in this repo — and require the renderer to ignore both. Re-adding
+ * either read turns one of them red.
+ *
+ * ⛔ NOT a ruling that `shortcut` must stay unrendered for ever: whether it
+ * should become AUTHORABLE on `AppAction.items` is its own contract card. This
+ * pins the contract as it stands, not the answer to that question.
+ *
+ * The `packages/types` half of the same claim — that the refusal message still
+ * makes it — is pinned in
+ * `packages/types/src/__tests__/app-action-onclick-refusal-6854.test.ts`.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AppComponentSchema } from '@object-ui/types';
+
+// Static, module-scope import: `LayoutRenderer` pulls `@object-ui/components`
+// in for the dropdown primitives, and that cost must not land inside a test's
+// timeout budget (AGENTS.md 测试纪律).
+import { LayoutRenderer } from '../LayoutRenderer';
+
+afterEach(() => cleanup());
+
+const SHORTCUT = 'Ctrl+P';
+
+/**
+ * A user action whose items carry the two keys the declared type does not have.
+ * `label` and `type: 'separator'` ARE declared on `AppMenuItem`, so they are the
+ * control: they must keep rendering, or this file would pass by rendering
+ * nothing at all.
+ */
+function appWith(onClick: () => void): AppComponentSchema {
+  return {
+    type: 'app',
+    name: 'pin_app',
+    title: 'Pin App',
+    layout: 'header',
+    actions: [
+      {
+        type: 'user',
+        label: 'Ada Lovelace',
+        description: 'ada@example.com',
+        items: [
+          // `onClick` / `shortcut` are NOT on `AppMenuItem`; authored here on
+          // purpose, through the same cast the renderer used to read them with.
+          { label: 'Profile', onClick, shortcut: SHORTCUT } as never,
+          { type: 'separator' },
+          { label: 'Sign out' },
+        ],
+      },
+    ],
+  } as AppComponentSchema;
+}
+
+async function openUserMenu(app: AppComponentSchema) {
+  const user = userEvent.setup();
+  render(
+    <LayoutRenderer app={app}>
+      <div>page body</div>
+    </LayoutRenderer>,
+  );
+  // The trigger is the avatar button; with no `avatar` URL the Radix fallback
+  // renders the label's initials, which is the stable accessible name here.
+  await user.click(screen.getByRole('button', { name: 'AD' }));
+  return user;
+}
+
+describe('LayoutRenderer renders AppAction.items without reading onClick or shortcut (objectui#6854)', () => {
+  it('renders the declared `label` of each item — the control for the two negatives below', async () => {
+    await openUserMenu(appWith(vi.fn()));
+    expect(await screen.findByText('Profile')).toBeTruthy();
+    expect(screen.getByText('Sign out')).toBeTruthy();
+  });
+
+  it('still renders the declared `type: "separator"` item as a separator', async () => {
+    await openUserMenu(appWith(vi.fn()));
+    await screen.findByText('Profile');
+    // Two separators: the one above the group, plus the authored divider item.
+    expect(screen.getAllByRole('separator').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('never invokes an authored `onClick` — the key the refusal message says no renderer reads', async () => {
+    const onClick = vi.fn();
+    const user = await openUserMenu(appWith(onClick));
+    await user.click(await screen.findByText('Profile'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('never puts an authored `shortcut` into the DOM', async () => {
+    await openUserMenu(appWith(vi.fn()));
+    await screen.findByText('Profile');
+    expect(screen.queryByText(SHORTCUT)).toBeNull();
+    expect(document.body.textContent).not.toContain(SHORTCUT);
+  });
+});

--- a/packages/types/src/__tests__/app-action-onclick-refusal-6854.test.ts
+++ b/packages/types/src/__tests__/app-action-onclick-refusal-6854.test.ts
@@ -1,0 +1,113 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * `AppActionSchema.onClick`'s retirement message says something FALSIFIABLE
+ * about this tree, so it is pinned here (objectui#6854, maintainer ruling of
+ * 2026-09-05, option B2).
+ *
+ * The message `handlerKeyRefusal('onClick', 'retired', …)` generates ends:
+ *
+ *   > … and no renderer reads this key, so nothing could ever run it.
+ *
+ * That sentence was FALSE when this card was filed. `@object-ui/runner`'s
+ * `LayoutRenderer` mapped `AppAction.items` and reached `(item as any).onClick`
+ * — past the declared element type, which is `AppMenuItem` and has no such key
+ * — leaving three mutually exclusive signals for a reader to pick from: the
+ * TypeScript face said `?: never`, the validator said nobody reads it, and a
+ * renderer read it. The ruling closed that by deleting the cast rather than by
+ * softening the sentence, so the sentence is true again and this file is what
+ * keeps it that way from the `packages/types` side: edit the shared template in
+ * `zod/tombstone.zod.ts` and this test names what the edit costs.
+ *
+ * The renderer side is pinned where the renderer lives —
+ * `packages/runner/src/__tests__/LayoutRenderer.appActionItems-6854.test.tsx`
+ * drives a real menu and requires an authored `onClick` never to be invoked.
+ * Neither pin can see the other's package, which is the point: the claim is
+ * about both, so it takes an assertion on each side.
+ *
+ * ⛔ NOT a pin on the template's exact prose in general — 22 other retired keys
+ * share it and their own message assertions live with them. This one asserts
+ * the clause whose truth this card measured.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AppActionSchema, MenuItemSchema } from '../zod/app.zod';
+
+/** The clause this card measured. Spelled out, not built from the template. */
+const MEASURED_CLAUSE = 'no renderer reads this key, so nothing could ever run it';
+
+const onClickArm = AppActionSchema.shape.onClick;
+const describeText = (onClickArm as { description?: string }).description;
+
+describe('AppActionSchema.onClick — the retirement message states a measured fact (objectui#6854)', () => {
+  it('claims, verbatim, that no renderer reads the key', () => {
+    expect(describeText).toContain(MEASURED_CLAUSE);
+  });
+
+  it('names the key and marks it RETIRED, not a runtime slot', () => {
+    expect(describeText).toContain('`onClick`');
+    expect(describeText).toContain('RETIRED (objectui#6124');
+    expect(describeText).not.toContain('RUNTIME SLOT');
+  });
+
+  it('an authored value is refused BY NAME, carrying that same sentence to the author', () => {
+    const result = AppActionSchema.safeParse({
+      type: 'button',
+      label: 'Quick actions',
+      onClick: 'openQuickActions',
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issue = result.error.issues.find((i) => String(i.path[0]) === 'onClick');
+    expect(issue, 'no issue addressed to `onClick`').toBeDefined();
+    expect(issue!.code).toBe('custom');
+    // ONE string feeds both author-facing channels (the `handlerKeyRefusal`
+    // invariant): the parse-time message an author reads cannot drift away from
+    // the `.describe()` metadata the docs surface publishes.
+    expect(issue!.message).toBe(describeText);
+    expect(issue!.message).toContain(MEASURED_CLAUSE);
+  });
+
+  it('the action without the key parses green — the refusal is about the key, not the action', () => {
+    expect(AppActionSchema.safeParse({ type: 'button', label: 'Quick actions' }).success).toBe(true);
+  });
+});
+
+describe('why the cast could never have been fed by an author (objectui#6854 Zone 2, the premise)', () => {
+  // `AppAction.items` is parsed by the LEGACY eight-member `MenuItemSchema`, a
+  // plain `z.object` — so `onClick` and `shortcut` are not refused there, they
+  // are STRIPPED in silence. An author therefore has no declared route to send
+  // either key, which is what made deleting the two reads a cleanup rather than
+  // a behaviour removal. Whether `shortcut` SHOULD become authorable here is a
+  // separate contract question and deliberately not answered by this file.
+  const authored = { label: 'Profile', onClick: 'goProfile', shortcut: 'Ctrl+P' };
+
+  it('the items mirror accepts the document and drops both undeclared keys', () => {
+    const result = MenuItemSchema.safeParse(authored);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const parsed = result.data as Record<string, unknown>;
+    expect(parsed.label).toBe('Profile');
+    expect('onClick' in parsed).toBe(false);
+    expect('shortcut' in parsed).toBe(false);
+  });
+
+  it('a whole action carrying such an item parses green, with the item scrubbed', () => {
+    const result = AppActionSchema.safeParse({
+      type: 'user',
+      label: 'Ada Lovelace',
+      items: [authored, { type: 'separator' }],
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const [first] = (result.data as { items: Record<string, unknown>[] }).items;
+    expect('onClick' in first).toBe(false);
+    expect('shortcut' in first).toBe(false);
+  });
+});

--- a/packages/types/src/app.ts
+++ b/packages/types/src/app.ts
@@ -716,10 +716,19 @@ export interface AppAction {
   /**
    * RETIRED (objectui#7344; the objectui#6182 ruling of 2026-08-25 — the
    * handler-expression string dialect is not a supported authoring form — in
-   * the objectui#6124 shape). Nothing reads `AppComponentSchema.actions[]`, so
-   * no value here could ever run. The zod twin refuses the key by name; author
-   * behaviour as a node type (an `action:button` node with a declared action)
-   * instead.
+   * the objectui#6124 shape). No renderer reads THIS KEY, so no value here
+   * could ever run. The zod twin refuses the key by name; author behaviour as a
+   * node type (an `action:button` node with a declared action) instead.
+   *
+   * Re-measured at objectui#6854, which corrects the narrower claim this
+   * comment used to make. `AppComponentSchema.actions[]` IS read — the standalone
+   * runner's `LayoutRenderer` (`@object-ui/runner`) renders both the `'button'`
+   * and the `'user'` arm — so "nothing reads `actions[]`" was never the reason
+   * this key is inert. The reason is that no reader touches `onClick`: not on
+   * the action, and no longer on {@link AppAction.items}, where that renderer
+   * reached one through an `as any` cast until the maintainer ruling of
+   * 2026-09-05 (option B2) deleted it. Guarded from the renderer side by
+   * `packages/runner/src/__tests__/LayoutRenderer.appActionItems-6854.test.tsx`.
    * @deprecated Not part of this contract — the value was inert.
    */
   onClick?: never;

--- a/packages/types/src/zod/app.zod.ts
+++ b/packages/types/src/zod/app.zod.ts
@@ -204,8 +204,16 @@ export const AppActionSchema = z.object({
   label: z.string().optional().describe('Action label'),
   icon: z.string().optional().describe('Icon name'),
   // RETIRED (objectui#7344 — the objectui#6182 ruling: the handler-expression
-  // string dialect is not an authoring form; the objectui#6124 shape). Nothing
-  // reads `AppComponentSchema.actions[]`, so the key refuses by name.
+  // string dialect is not an authoring form; the objectui#6124 shape). The
+  // `'retired'` arm's message tells an author "no renderer reads this key, so
+  // nothing could ever run it"; objectui#6854 re-measured that sentence rather
+  // than restating it. `actions[]` itself IS read (`@object-ui/runner`'s
+  // `LayoutRenderer` renders the `'button'` and `'user'` arms) — the earlier
+  // "nothing reads `actions[]`" here was wrong — but no reader touches
+  // `onClick`, on the action or on `items[]`, since the maintainer ruling of
+  // 2026-09-05 (option B2) deleted the two `as any` reads that did. Text pinned
+  // in `__tests__/app-action-onclick-refusal-6854.test.ts`; the renderer side in
+  // `packages/runner/src/__tests__/LayoutRenderer.appActionItems-6854.test.tsx`.
   onClick: handlerKeyRefusal('onClick', 'retired', 'Click handler'),
   avatar: z.string().optional().describe('User avatar URL (for type="user")'),
   description: z.string().optional().describe('Additional description (e.g., email for user)'),


### PR DESCRIPTION
Fixes #6854

Executes the maintainer ruling recorded at #6854 comment 5548581017 (director seat, decision batch #40, maintainer verbatim 「同意」): **option B2** — the runner stops reading a retired key through `as any`, `AppAction.items` is **not** re-typed, and the `shortcut`-as-authorable question goes to its own card (filed: #7719).

Verified at HEAD `96fcb35` (`origin/main` merged in at `f96a781`).

---

## Zone 2 first — the census the ruling gated the deletion on

> **Zone 2 first:** measure whether any host feeds `onClick` on `AppAction.items` by bypassing the validator (TS / props); if one exists in-repo, stop and report before deleting (the cast would then be load-bearing).

**Result: empty. No such host exists in this repository, and none can.** Four legs, each with a positive control:

| Leg | Method | Population | Result |
|:--|:--|--:|:--|
| 1. Who reads `AppComponentSchema.actions[]` at all? | grep for `.actions` across `packages/layout`, `packages/app-shell`, `packages/runner`, `apps/console`, then classify | all in-repo readers | **exactly one**: `packages/runner/src/LayoutRenderer.tsx`. `layout`'s `AppSchemaRenderer.tsx` contains zero occurrences of `actions`; `app-shell`'s `useNavigationSync.ts` likewise; every other hit is `objectDef.actions` or an `action:bar` node — a different contract |
| 2. What can reach that reader? | trace the prop | `LayoutRenderer` has one call site, `App.tsx:204` | its `app` comes from `MetadataLoader`, whose two implementations return an `import.meta.glob`'d `.json` module or `res.json()` — **a JSON document, never a hand-built object**. `@object-ui/runner` publishes no library entry (`files: ["dist"]` from a Vite app; no `main`, `module` or `exports`), so nothing can import the component and hand it one either |
| 3. Does any JSON author the keys? | structural walk for any object with an `items` array whose members carry `onClick` or `shortcut` | **594** JSON files under `packages` / `apps` / `examples` / `content` / `docs` / `e2e` | **0 hits.** Control: the same walker on a synthetic `app.json` carrying exactly that shape → `CONTROL HIT … .actions[0].items[0]`, `INSTRUMENT LIVE` |
| 4. Does any TypeScript author them? | multiline scan for an `items:` array literal containing `onClick` or `shortcut` | `packages` / `apps` / `examples`, `.ts` + `.tsx` | **2 files, neither an `AppAction`** — `components/src/__tests__/menu-item-onclick-handler.test.tsx` and `examples/schema-catalog/test/component-fixture-declared-keys.test.ts`, both the **overlay** `MenuItem` path (`dropdown-menu` / `context-menu` / `menubar`). Control: same pattern on a synthetic host file → matched, `INSTRUMENT LIVE` |

Legs 3 and 4 are the ones that could have gone quiet, so both carry a control that fired. The `shortcut` read in particular deleted no reachable behaviour: leg 3 found nobody writing the key, and `MenuItemSchema` strips it from anything that is validated.

## The diff

**`packages/runner/src/LayoutRenderer.tsx`** — the two `as any` reads deleted, the block re-verified at the line numbers the ruling named (`:307`, `:312-313` on `4ce14f1`):

⚠️ **Notation:** this repository has measured that GitHub's body sanitizer deletes tag-shaped fragments on save — inside fenced code blocks and backticks too — which is how a before/after listing silently collapses into "nothing changed". So the JSX below is written with the angle brackets spelled out as `OPEN`/`CLOSE` markers instead of typed literally. Read the real bytes in the diff of this PR.

```text
  OPEN DropdownMenuItem key={idx}                       ← kept (was: … plus an onSelect prop)
-   REMOVED   onSelect={() => { if ((item as any).onClick) { /* Handle click logic */ } }}
    {item.label}                                        ← kept, declared on AppMenuItem
-   REMOVED   {(item as any).shortcut && ( OPEN DropdownMenuShortcut … CLOSE )}
  CLOSE DropdownMenuItem
```

The `type === 'separator'` branch and the `item.label` read are legal against `AppMenuItem` and stay. The `DropdownMenuShortcut` import goes with its only use. Casts in the file: **3 → 0** (the one `as any` `grep` still finds is the word inside the new explanatory comment).

**`packages/types`** — comment-only on published source. Machine-checkable: of the 29 changed lines in `app.ts` + `app.zod.ts`, `grep -vE '^[+-][[:space:]]*(\*|/\*|//|\*/)'` returns **nothing**. No accepted key moves, no exported symbol moves, no shape changes — clause ② stays **no**.

## The retirement message: made true, not restated

The ruling's body offers two branches — "the retirement message is made true again (**or** restated to say the renderer no longer reads it)". **This PR takes the first**, and that is a deliberate reading worth reviewing.

`handlerKeyRefusal(key, 'retired', …)` generates, from a template in `zod/tombstone.zod.ts` shared by **22 other retired handler keys**:

> `onClick` is RETIRED (objectui#6124, ADR-0049): JSON has no function value, and no renderer reads this key, so nothing could ever run it.

**Before this PR that sentence was false** — `LayoutRenderer` read the key. **After the deletion it is true**, so the text is unchanged and is instead *pinned*, on both sides. Softening it (say, to "no renderer is intended to read this key") would have bought nothing and cost the property that makes it worth having: it is falsifiable, and a gate can hold it. It would also have rewritten 22 other keys' published messages and their pins to fix one key's claim.

What **is** corrected in `packages/types` is a different sentence, one the deletion does *not* make true. Both rationale comments on this key said:

> ~~Nothing reads `AppComponentSchema.actions[]`, so no value here could ever run.~~

That is false in the other direction: `LayoutRenderer` renders both the `'button'` and the `'user'` arm of `actions[]`. They now say what was measured — `actions[]` **is** read, `onClick` is not, on the action or on `items[]`.

## Pins, and the ablation that shows they can fail

Both were run mutation-then-restore, from the committed tree; each restore is proven by blob hash **and** an empty `git diff HEAD`, not by an exit code, and both scripts carry a `trap … EXIT INT TERM`. No build is involved: the root vitest config aliases `@object-ui/*` to `src`, so `dist` is not on the resolution path for either.

**A — `packages/runner/src/__tests__/LayoutRenderer.appActionItems-6854.test.tsx`** drives a real user menu with **both** undeclared keys authored, exactly as a validator-bypassing host would, and requires neither to be read.

Re-inject the two reads → `blob 7e45da19 → 3b99c550`, and:

```
     × never invokes an authored `onClick` — the key the refusal message says no renderer reads
     × never puts an authored `shortcut` into the DOM
 Tests  2 failed | 2 passed (4)
```

Only the two negatives fail; the two positive controls in the same file (the declared `label` renders, the declared `type: 'separator'` still renders a separator) stay green — so the pin discriminates rather than just detecting a broken render. Restored: blob back to `7e45da19`, `git diff HEAD` empty, `4 passed (4)`.

**B — `packages/types/src/__tests__/app-action-onclick-refusal-6854.test.ts`** asserts the measured clause survives, that the refusal is addressed to `onClick` with `code: 'custom'`, and that the parse message and the `.describe()` metadata are still one string. It also pins the premise: the legacy mirror **strips** `onClick` and `shortcut` from an item rather than refusing them, which is why no author could ever have fed the cast.

Soften the shared clause in `tombstone.zod.ts` → `blob 8eaed046 → 4ff4ba1f`, and:

| pin | under the mutation |
|:--|:--|
| the new pin | `Tests 2 failed \| 4 passed (6)` — **red** |
| `handler-keys-json-refusal-6124.test.ts` (pre-existing) | `Tests 272 passed (272)` — **green** |

That second row is the point: **the clause this card measured had no guard at all before this PR**. Restored: blob back to `8eaed046`, `git diff HEAD` empty, both pins `278 passed (278)`.

## Gates

Exit codes captured before any pipe (`cmd > log 2>&1; EXIT=$?`), all at HEAD `96fcb35`, heavy runs through the container's shared verify lock (`VERDICT command-exit` read, never a bare `$?`).

| Command | Exit | Evidence |
|:--|--:|:--|
| `pnpm exec vitest run packages/types/` | 0 | `Test Files 112 passed (112)` · `Tests 1931 passed (1931)` |
| `pnpm exec vitest run packages/runner/` | 0 | `Test Files 4 passed (4)` · `Tests 17 passed (17)` |
| `pnpm --filter @object-ui/types type-check` | 0 | echoed `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/runner type-check` | 0 | echoed `tsc --noEmit && tsc -p tsconfig.test.json` |
| `pnpm --filter @object-ui/types build` | 0 | rebuilt before every judgement, so no stale `.d.ts` was read |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ 5 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-fixed.mjs` | 0 | `✅ All workspace packages are in the changeset fixed group.` |
| `node scripts/check-changeset-no-major.mjs` | 0 | ✅ No changeset declares a major bump. |
| `node scripts/check-control-bytes.mjs` | 0 | `✅ check-control-bytes: OK (scanned 6294 tracked text file(s); skipped 85 binary)` |
| `node scripts/check-vi-mock-specifiers.mjs` · `check-vi-mock-inherit.mjs` · `check-unreferenced-sources.mjs` | 0 | derived from the diff (two new test files) |
| `pnpm exec eslint . --format json` | 0 | **not narrowed** — the whole repo ran: 4284 files, **0 errors**. The five changed files carry 0 errors; the 7 warnings on them are pre-existing (`NavItem`'s `any` props, two `set-state-in-effect`, `MenuItemSchema` typed as ZodType-of-ANY), and the deletion removed three `no-explicit-any` warnings rather than adding any |

Both new test files were confirmed to be **inside** their package's type-check project by `tsc -p tsconfig.test.json --listFiles`, rather than assumed to be.

`@object-ui/types` is a dependency of all 43 workspace packages, so `turbo ls --affected` lists every one of them. Their suites were **not** run locally and are left to CI; the narrowing is declared, and the ground for it is the comment-only proof above — no behaviour, type shape or zod shape moved in `packages/types`, so no consumer's verdict can move.

## Deviations, declared

1. **The shared `handlerKeyRefusal` template is unedited.** The ruling's title asks for the message to be corrected "so it no longer claims *no renderer reads this key*"; its body and the dispatch both allow the other branch — make the claim true — which is what deleting the cast does. Reviewer's call if the title was meant literally; ablation B shows the sentence is now guarded either way.
2. **The message pin is a new file, not a row in `handler-keys-json-refusal-6124.test.ts`.** That census is scoped to the nine `#6124` mirror files and `app.zod.ts` is not one of them; adding `AppActionSchema.onClick` would move its asserted `22` retired / `66` total counts, which belong to that card. The pre-existing file is re-run here unchanged and stays green.
3. **Two `packages/types` doc comments were corrected** beyond the literal instruction, because they carried a claim the deletion does not make true (above). Comment-only; no shape moves.

## Out of scope, filed and reported

- **#7719** — the ruling's required follow-up: should `shortcut` become authorable on `AppAction.items`? Unassigned, unlabelled, with the consumer reading and both instrument controls attached. Dedup: MCP `search_issues` returned 0 for the question; a control query in the same session returned #6854, #6346 and #6250 (open **and** closed), so the zero is a reading.
- **#7469** (open, `pm:queue`, p3) rests on a premise this work falsifies: it records that `AppComponentSchema.actions[]` has **no reader**, and triage endorsed retiring the whole surface as the default direction on that basis. The runner renders it. Both censuses asked for the type NAME `AppAction`, which `LayoutRenderer` never spells — it types its prop `AppComponentSchema` and reads `app.actions` structurally. The measurement is attached there as comment 5551453088; no label, state or assignee touched.
- **`.changeset/7344-handler-string-any-mirrors.md:32`** still carries the same false parenthetical — "`AppAction.onClick` (nothing reads `AppComponentSchema.actions[]`)" — and will otherwise ship as published CHANGELOG copy. It belongs to another card's pending changeset, so it is reported rather than edited here.

Drafted by the `domain:spec` @ objectui dev dispatch, session `https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s` — recorded here in prose as well, because a markdown-link footer is not measured to survive an edit of this body.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s)_