### PR TITLE
fix(types): declare `CheckboxSchema.wrapperClass` on both faces

### DIFF
--- a/.changeset/6938-checkbox-wrapper-class.md
+++ b/.changeset/6938-checkbox-wrapper-class.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/types': patch
+---
+
+Declare `wrapperClass` on `CheckboxSchema`, on both faces (objectui#6938 — the
+residue of that card; its `context-menu` half landed with objectui#6939 group 1).
+
+`packages/components/src/renderers/form/checkbox.tsx:36` reads
+`cn("flex items-center space-x-2", schema.wrapperClass)` — classes on the wrapper
+`div` around the box and its label — and neither the TypeScript interface in
+`packages/types/src/form.ts` nor the zod mirror in `zod/form.zod.ts` declared the
+key. It compiled through `BaseSchema`'s index signature and parsed through
+`.passthrough()`, admitted unexamined. The same key, on the same class of read, is
+declared on `FileUploadSchema` and `FilterBuilderSchema` (objectui#6150); the
+checkbox was left out only because its doc page's schema block is a six-line
+summary.
+
+**patch, not minor: the accept set only widens toward what already renders.** The
+key is optional; no document that validated before stops validating. In the value
+dimension the mirror now REFUSES a non-string `wrapperClass` it used to admit
+unexamined — enforcement of the declared type, not a new capability.

--- a/packages/types/src/__tests__/checkbox-wrapper-class-6938.test.ts
+++ b/packages/types/src/__tests__/checkbox-wrapper-class-6938.test.ts
@@ -1,0 +1,160 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * objectui#6938 — `CheckboxSchema.wrapperClass`, the residue of that card.
+ *
+ * ## The defect
+ *
+ * `packages/components/src/renderers/form/checkbox.tsx:36` reads
+ * `cn("flex items-center space-x-2", schema.wrapperClass)` — classes on the
+ * wrapper `div` around the box and its label — and neither face of the shipped
+ * contract declared the key: not the TypeScript interface in `../form.ts`, not
+ * the zod mirror in `../zod/form.zod.ts`. The read compiled through
+ * `BaseSchema`'s index signature (objectui#5155) and the value parsed through
+ * `.passthrough()`, admitted unexamined. The same key, on the same class of
+ * read, IS declared on `FileUploadSchema` and `FilterBuilderSchema`
+ * (objectui#6150); the checkbox was left out only because its doc page's
+ * schema block is a six-line summary — the asymmetry is the docs', not the
+ * renderer's.
+ *
+ * The card's other half (`ContextMenuSchema`'s three read keys and its dead
+ * required `children`) landed with objectui#6939 group 1 and is not pinned
+ * here.
+ *
+ * ## What this file pins, and the shape it borrows
+ *
+ * The form is `undeclared-but-consumed-keys-6150.test.ts`, unchanged:
+ * membership is asserted on the mirror's OWN `.shape`, never on parse
+ * acceptance — under `.passthrough()` acceptance cannot tell "declared" from
+ * "admitted unexamined". The type-level pin uses invariant equality, so an
+ * undeclared key (which resolves to `any` through the index signature) reads
+ * as a failure rather than as a match.
+ *
+ * The CONTROL is a key the renderer does NOT read — derived from the renderer
+ * source, not asserted from memory — and it must stay undeclared on both
+ * faces. That is the half that keeps this from being a widening: the change
+ * declares the one key the renderer honours and nothing else.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { CheckboxSchema } from '../zod/form.zod';
+import { safeValidateSchema } from '../zod/index.zod';
+import type { CheckboxSchema as TsCheckboxSchema } from '../form';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const READER = 'packages/components/src/renderers/form/checkbox.tsx';
+const READ_TEXT = 'cn("flex items-center space-x-2", schema.wrapperClass)';
+
+const KEY = 'wrapperClass';
+/**
+ * A plausible-looking class key the renderer never reads: the label's classes
+ * are hard-coded at `checkbox.tsx:52`. It stays undeclared on both faces.
+ */
+const CONTROL_KEY = 'labelClass';
+/** A declared-keys-only document; every assertion below is a delta on it. */
+const CONTROL = { type: 'checkbox', label: 'Accept' };
+
+/* ── Type-level pins (invariant equality, house form) ─────────────────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+/** The canonical `any` detector: only `any` absorbs `1 &` down to something `0` extends. */
+type IsAny<T> = 0 extends (1 & T) ? true : false;
+
+// Declared as `string`. Were the member removed, the read would fall back to
+// the index signature and resolve to `any`, and `Equal<any, string>` is false.
+export type _WrapperClassIsString = Expect<Equal<NonNullable<TsCheckboxSchema['wrapperClass']>, string>>;
+export type _WrapperClassIsNotAny = Expect<Equal<IsAny<TsCheckboxSchema['wrapperClass']>, false>>;
+// The control key is NOT declared: it resolves to `any` through the index
+// signature, exactly as `wrapperClass` did before this card. Declaring it turns
+// this red — which is the point.
+export type _ControlKeyFallsThroughToIndexSignature = Expect<IsAny<TsCheckboxSchema['labelClass']>>;
+
+// The TS face accepts the key on a literal. ⚠️ This is the WEAK half: the index
+// signature would accept it undeclared too. The invariant pins above are the
+// guard; this line only shows the declared spelling in use.
+const literal: TsCheckboxSchema = { type: 'checkbox', label: 'Accept', wrapperClass: 'gap-4' };
+
+/** Every `schema.KEY` read in the renderer, off disk. */
+function rendererReads(): Set<string> {
+  const src = readFileSync(join(REPO_ROOT, READER), 'utf8');
+  return new Set([...src.matchAll(/\bschema\.([A-Za-z_$][\w$]*)/g)].map((m) => m[1]));
+}
+
+function shapeKeys(): string[] {
+  return Object.keys((CheckboxSchema as unknown as { shape: Record<string, unknown> }).shape);
+}
+
+describe('objectui#6938 — the renderer reads `wrapperClass`, which is the fact the declaration records', () => {
+  it('the read is still there, as the exact text the docblocks cite', () => {
+    const src = readFileSync(join(REPO_ROOT, READER), 'utf8');
+    expect(src, `${READER} no longer reads \`schema.${KEY}\` as \`${READ_TEXT}\``).toContain(READ_TEXT);
+  });
+
+  it('the read set, derived from the renderer, contains the key and NOT the control key', () => {
+    // Non-vacuity for the control: if the renderer ever starts reading
+    // `labelClass`, this turns red and the control must be re-chosen, not
+    // declared on the way past.
+    const reads = rendererReads();
+    expect(reads.has(KEY)).toBe(true);
+    expect(reads.has(CONTROL_KEY)).toBe(false);
+  });
+});
+
+describe('objectui#6938 — the zod mirror declares it', () => {
+  it('is a member of the mirror shape (membership cannot be read off acceptance under passthrough)', () => {
+    expect(shapeKeys()).toContain(KEY);
+  });
+
+  it('accepts the declared value and the value SURVIVES the parse', () => {
+    const r = CheckboxSchema.safeParse({ ...CONTROL, [KEY]: 'gap-4' });
+    expect(r.success, JSON.stringify(r.error?.issues)).toBe(true);
+    if (r.success) expect((r.data as Record<string, unknown>)[KEY]).toBe('gap-4');
+  });
+
+  it('…and through the published union entry point, so the `checkbox` arm is the one reached', () => {
+    const r = safeValidateSchema({ ...CONTROL, [KEY]: 'gap-4' });
+    expect(r.success, r.success ? '' : JSON.stringify(r.error.issues)).toBe(true);
+    if (r.success) expect((r.data as Record<string, unknown>)[KEY]).toBe('gap-4');
+  });
+
+  it('refuses a wrong-typed value AT the key — the enforcement mirroring adds', () => {
+    // Before this card `wrapperClass: 42` parsed green under `.passthrough()`.
+    // This is the only verdict that moves, and it moves toward refusal.
+    const r = CheckboxSchema.safeParse({ ...CONTROL, [KEY]: 42 });
+    expect(r.success).toBe(false);
+    if (!r.success) expect(r.error.issues.map((i) => i.path.join('.'))).toContain(KEY);
+  });
+
+  it('control: the declared-keys-only document parses green, before and after', () => {
+    expect(CheckboxSchema.safeParse(CONTROL).success).toBe(true);
+  });
+});
+
+describe('objectui#6938 — the control key stays undeclared, so nothing outside the one key moved', () => {
+  it('is ABSENT from the mirror shape', () => {
+    expect(shapeKeys()).not.toContain(CONTROL_KEY);
+  });
+
+  it('the SAME wrong-typed value under the control key is still admitted unexamined', () => {
+    // The before-state of `wrapperClass`, kept on purpose on a key that is not
+    // read: `.passthrough()` admits it, of any type, and it survives. This is
+    // the proof the mirror's unknown-key policy is byte-for-byte what it was.
+    const r = CheckboxSchema.safeParse({ ...CONTROL, [CONTROL_KEY]: 42 });
+    expect(r.success).toBe(true);
+    if (r.success) expect((r.data as Record<string, unknown>)[CONTROL_KEY]).toBe(42);
+  });
+
+  it('the type-level bindings above are referenced, so lint keeps them', () => {
+    expect(literal.wrapperClass).toBe('gap-4');
+  });
+});

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -342,6 +342,17 @@ export interface CheckboxSchema extends BaseSchema {
    */
   required?: boolean;
   /**
+   * Classes on the wrapper `div` around the box and its label.
+   *
+   * READ SITE: `packages/components/src/renderers/form/checkbox.tsx:36` —
+   * `cn("flex items-center space-x-2", schema.wrapperClass)`. Undeclared until
+   * objectui#6938, surviving only on `BaseSchema`'s index signature: the same
+   * key, on the same class of read, that `FileUploadSchema` and
+   * `FilterBuilderSchema` declare (objectui#6150) — left out here only because
+   * the checkbox doc page's schema block is a six-line summary.
+   */
+  wrapperClass?: string;
+  /**
    * Change handler
    *
    * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -260,6 +260,8 @@ export const CheckboxSchema = BaseSchema.extend({
   checked: z.boolean().optional().describe('Controlled checked state'),
   required: z.boolean().optional()
     .describe("Required affordance, read at renderers/form/checkbox.tsx:45 (`required=` on the Radix Checkbox) and :49 (gates the label's `*` marker) (objectui#6150)"),
+  wrapperClass: z.string().optional()
+    .describe('Classes on the wrapper div around the box and its label, read at renderers/form/checkbox.tsx:36 — `cn("flex items-center space-x-2", schema.wrapperClass)` (objectui#6938)'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),


### PR DESCRIPTION
Fixes #6938

## What

Declares `wrapperClass?: string` on `CheckboxSchema`, on both faces — the TypeScript interface in `packages/types/src/form.ts` (docblock citing the read site, in the form the objectui#6939 declarations use) and the zod mirror in `packages/types/src/zod/form.zod.ts` — plus one pin and an `@object-ui/types` `patch` changeset. Nothing else moves: no consolidation with `className`, no other schema block touched.

## Why the card shrank to one key (measured, not inherited)

The card has two halves. Its context-menu half — `ContextMenuSchema.triggerClassName` / `contentClassName` / `modal` and the retirement of the dead required `children` — is already on `main`, landed with objectui#6939 group 1 (PR objectui#7456): re-verified on this branch's base `f96a781` at `packages/types/src/overlay.ts:617/624/630` and `zod/overlay.zod.ts:237-246`. It is not touched here.

The residue is `CheckboxSchema.wrapperClass`. On `main` the `wrapperClass` at `form.ts:133` belongs to `InputSchema` and the one at `:606` to `FileUploadSchema`; the `CheckboxSchema` interface (from `:306`) declared none, and the mirror (`form.zod.ts:255`) declared none — while `packages/components/src/renderers/form/checkbox.tsx:36` reads `cn("flex items-center space-x-2", schema.wrapperClass)`. The read compiled through `BaseSchema`'s index signature and the value parsed through `.passthrough()`, admitted unexamined. This pulls the declaration back to delivered behaviour (Bug side, triage half 甲).

## Contract review (Clause-② yes — a new declared key on a published payload type)

- Accept set: only widens toward what already renders. The key is optional; no document that validated before stops validating.
- Value dimension: the mirror now REFUSES a non-string `wrapperClass` it used to admit unexamined (`wrapperClass: 42` — green before, refused at the key now). Enforcement of the declared type, not a new capability.
- Business need, measured: in-repo authors of `wrapperClass` on a `checkbox` node — zero (`examples/`, `apps/`, `content/`, `skills/` grepped). The read is the fact the declaration records; the same key on the same class of read is declared on `InputSchema`, `FileUploadSchema` and `FilterBuilderSchema`. The checkbox was left out only because its doc page's schema block is a six-line summary.
- Changeset level `patch`, following the objectui#6939 group-1 precedent (`.changeset/6939-overlay-trigger-mirror.md`, same argument).

## Pin — `packages/types/src/__tests__/checkbox-wrapper-class-6938.test.ts` (10 tests)

Form borrowed from `undeclared-but-consumed-keys-6150.test.ts`: membership on the mirror's own `.shape` (acceptance cannot tell declared from admitted-unexamined under passthrough); parse accepts the key and the value survives, through the mirror and through `safeValidateSchema`; refusal of a wrong-typed value AT the key; invariant type-level pins on the TS face (an undeclared key resolves to `any` through the index signature, so `Equal` fails); and a CONTROL key the renderer does not read — `labelClass`, checked against the read set derived from `checkbox.tsx` — that stays undeclared on both faces (absent from `.shape`, resolves to the index signature, still admitted unexamined).

## Ablation (fix committed first; restore by trap, proven by bytes)

Mutation: `git checkout BASE -- form.ts form.zod.ts` (both faces lose the declaration; anchors `objectui#6938` 1 → 0 in each file). Observed direction: RED — vitest `2 failed | 8 passed (10)` (mirror-shape membership, refusal at the key; the 8 that stay green are the passthrough before-state by design) and `tsc -p tsconfig.test.json` exit 2 with `TS2344` on the two type-level pins (`:75`, `:76`). Restore: `git checkout HEAD -- ...`, `git diff HEAD` = 0 lines, on-disk blob hashes equal to `HEAD`'s (`12dd197…`, `21ee145…`), anchors back to 1. Restored leg: `10 passed (10)`, tsc exit 0. Resolution path is `src` on both legs (relative imports in the pin; `tsconfig.test.json` reads `src`), so no dist preflight applies.

## Gates (exit captured before any pipe; at HEAD `d54e1b9` unless noted)

| command | exit |
|---|---|
| `pnpm exec vitest run --maxWorkers=2 packages/types/` | 0 — `Test Files 112 passed (112)`, `Tests 1935 passed (1935)` |
| `pnpm --filter @object-ui/types type-check` (three tsc projects incl. `tsconfig.test.json`) | 0 |
| `pnpm --filter @object-ui/types lint` | 0 — 0 errors, 269 pre-existing warnings, none in the touched hunks or the new file (identical pre-commit tree) |
| `pnpm --workspace-concurrency=2 --filter "@object-ui/components^..." build` then `pnpm --filter @object-ui/components type-check` | 0 / 0 — the consumer reads `@object-ui/types` from `dist`, rebuilt with this change (`dist/form.d.ts:346` carries the key); identical pre-commit tree |
| `node scripts/check-changeset-presence.mjs` | 0 |
| `node scripts/check-changeset-fixed.mjs` | 0 |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `node scripts/check-control-bytes.mjs` | 0 (re-run after staging — it scans tracked files only) |
| `pnpm check:spec-symbols` | 0 |
| `check:doc-types` | not run — no docs touched; measured that it checks `type` literals only, and no doc gate requires a documented row for a declared key |

`zod-mirror-parity.test.ts` stays green with the key on both faces (it is among the 112). Heavy runs went through the shared verify lock; repo-wide `pnpm lint` is CI's.

## Docs

`content/docs/components/form/checkbox.mdx` untouched: its schema block is a six-line summary (the card's own diagnosis of the asymmetry) and no doc-parity gate asks for the row; adding one row there while `checked`, `description`, `error` and `className` are also absent from that summary is a docs card, not this one — handed to the PM in the report.

## Out of scope, filed

objectui#7722 — five more renderers read `schema.wrapperClass` undeclared on either face (`switch`, `textarea`, `date-picker`, `select`, `list`); same class, same remedy; dedup done (21 search hits read, #6951 / #6952 read in full).

## Serial

Base `f96a781` = `origin/main` at PR time (re-fetched; nothing to merge). objectui#7530 edits the top region of `form.zod.ts`, a different region from the `CheckboxSchema` block; conflicts, if any, go to the merge queue. `packages/types` is not a governed surface; `needs:contract-review` attached; stays draft for the in-seat review at tier.

Dev of the `domain:spec` @ objectui dispatch, session `session_01BAZFhALsQsGqxui8sNqM8s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s)_