### PR TITLE
fix(types): lift the flex example's direction/gap out of the inert `props` envelope

### DIFF
--- a/.changeset/6751-flex-props-envelope-lift.md
+++ b/.changeset/6751-flex-props-envelope-lift.md
@@ -1,0 +1,15 @@
+---
+---
+
+Fixes the `flex` node in `packages/types/examples/data-display-examples.json`, which authored
+its layout configuration under a `props` envelope (`props: { direction: 'col', gap: 4 }`).
+`SchemaRenderer` hoists `properties.*` onto the node and spreads `props` as React props
+instead, so a renderer declared `({ schema })` — the ordinary component-renderer shape, which
+`flex.tsx` has — never reads the envelope. The example therefore rendered with the default
+`row` direction and the default gap while presenting itself as a column with `gap: 4`. The
+two keys are lifted onto the node, where `FlexSchema` declares them; `props` is not renamed,
+because renaming it to `properties` would be a second spelling for something the schema
+already declares at node level.
+
+Declared as releasing nothing: `packages/types/examples/**` is not in that package's
+published `files`, and the accompanying pin is a test. No published behaviour changes.

--- a/packages/types/examples/data-display-examples.json
+++ b/packages/types/examples/data-display-examples.json
@@ -246,10 +246,8 @@
   "compositeExample": {
     "type": "flex",
     "id": "user-profile-card",
-    "props": {
-      "direction": "col",
-      "gap": 4
-    },
+    "direction": "col",
+    "gap": 4,
     "children": [
       {
         "type": "avatar",

--- a/packages/types/src/__tests__/flex-props-envelope-lift-6751.test.ts
+++ b/packages/types/src/__tests__/flex-props-envelope-lift-6751.test.ts
@@ -52,8 +52,20 @@ import { FlexSchema, LayoutSchema } from '../zod/layout.zod';
 const ROOT = resolve(__dirname, '../../../..');
 const FIXTURE = 'packages/types/examples/data-display-examples.json';
 
-function readFixture(): any {
-  return JSON.parse(readFileSync(resolve(ROOT, FIXTURE), 'utf8'));
+/** The fixture is an arbitrary JSON document, so it is read as one. */
+type JsonObject = { [key: string]: unknown };
+
+function readFixture(): JsonObject {
+  return JSON.parse(readFileSync(resolve(ROOT, FIXTURE), 'utf8')) as JsonObject;
+}
+
+/** `doc[key]`, refused loudly rather than read as `undefined` if it is not an object. */
+function objectAt(doc: JsonObject, key: string): JsonObject {
+  const value = doc[key];
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${FIXTURE}: expected an object at \`${key}\`, got ${JSON.stringify(value)}`);
+  }
+  return value as JsonObject;
 }
 
 /**
@@ -80,7 +92,7 @@ function envelopeSites(doc: unknown, path = '$'): string[] {
 
 describe('objectui#6751 — flex layout keys sit on the node, not under `props`', () => {
   it('compositeExample parses through FlexSchema with direction/gap as authored', () => {
-    const node = readFixture().compositeExample;
+    const node = objectAt(readFixture(), 'compositeExample');
     expect(node.type).toBe('flex');
 
     const parsed = FlexSchema.parse(node);
@@ -94,7 +106,7 @@ describe('objectui#6751 — flex layout keys sit on the node, not under `props`'
   });
 
   it('compositeExample parses the same way through the published LayoutSchema union', () => {
-    const parsed = LayoutSchema.parse(readFixture().compositeExample) as Record<string, unknown>;
+    const parsed = LayoutSchema.parse(objectAt(readFixture(), 'compositeExample')) as JsonObject;
     expect(parsed.type).toBe('flex');
     expect(parsed.direction).toBe('col');
     expect(parsed.gap).toBe(4);
@@ -109,7 +121,7 @@ describe('objectui#6751 — flex layout keys sit on the node, not under `props`'
     // Without this, the zero on the previous assertion could come from a walker
     // that never reports anything.
     const doc = readFixture();
-    doc.compositeExample.props = { direction: 'col', gap: 4 };
+    objectAt(doc, 'compositeExample').props = { direction: 'col', gap: 4 };
     expect(envelopeSites(doc)).toEqual(['$.compositeExample (type=flex)']);
   });
 
@@ -121,12 +133,11 @@ describe('objectui#6751 — flex layout keys sit on the node, not under `props`'
   });
 
   it('negative control — the lift left the rest of the node untouched', () => {
-    const node = readFixture().compositeExample;
+    const node = objectAt(readFixture(), 'compositeExample');
     expect(node.id).toBe('user-profile-card');
-    expect(node.children.map((c: { type: string }) => c.type)).toEqual([
-      'avatar', 'statistic', 'badge', 'list',
-    ]);
-    expect(node.children[0]).toMatchObject({
+    const children = node.children as JsonObject[];
+    expect(children.map((c) => c.type)).toEqual(['avatar', 'statistic', 'badge', 'list']);
+    expect(children[0]).toMatchObject({
       type: 'avatar', alt: 'User Avatar', fallback: 'JD', size: 'lg',
     });
   });

--- a/packages/types/src/__tests__/flex-props-envelope-lift-6751.test.ts
+++ b/packages/types/src/__tests__/flex-props-envelope-lift-6751.test.ts
@@ -1,0 +1,133 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6751 — the `flex` node in `data-display-examples.json` declares its
+ * layout keys at NODE level, not inside a `props` envelope.
+ *
+ * ## What was wrong
+ *
+ * `compositeExample` authored
+ *
+ *     { "type": "flex", "props": { "direction": "col", "gap": 4 } }
+ *
+ * `SchemaRenderer` hoists `properties.*` onto the node and spreads `props` as
+ * React props instead, so a renderer declared `({ schema })` — the ordinary
+ * component-renderer shape, which `flex.tsx` has — never sees the envelope.
+ * The example therefore rendered with the DEFAULT `row` direction and the
+ * DEFAULT gap while presenting itself as a column with `gap: 4`. The fix is to
+ * lift the two keys onto the node, which is where `FlexSchema` declares them;
+ * it is NOT to rename `props` to `properties`.
+ *
+ * ## Why the assertions here are structural rather than acceptance-shaped
+ *
+ * `BaseSchema` is `.passthrough()`, so the broken document parsed GREEN through
+ * every schema in this package and would keep doing so. Acceptance cannot tell
+ * "lifted" from "still under `props`, admitted unexamined". What separates the
+ * two is the parsed VALUE:
+ *
+ *     fixture state          FlexSchema.parse(node).direction / .gap / 'props' in node
+ *     props envelope         'row' (default) / 2 (default) / true
+ *     lifted onto the node   'col'           / 4           / false
+ *
+ * ## The fence this file must not cross (objectui#6751 triage, twice)
+ *
+ * Three same-shaped occurrences elsewhere in the repo are DELIBERATE
+ * counter-examples — `skills/objectui/rules/protocol.md`'s `card`, and
+ * `skills/objectui/guides/schema-expressions.md`'s `card` and `text`, each
+ * marked wrong where it stands. The walk below is scoped to this one fixture
+ * for that reason: a repo-wide "no node carries `props`" assertion would make
+ * the teaching material fail.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FlexSchema, LayoutSchema } from '../zod/layout.zod';
+
+const ROOT = resolve(__dirname, '../../../..');
+const FIXTURE = 'packages/types/examples/data-display-examples.json';
+
+function readFixture(): any {
+  return JSON.parse(readFileSync(resolve(ROOT, FIXTURE), 'utf8'));
+}
+
+/**
+ * Every object in `doc` that carries a `type` AND a `props` key, reported as
+ * `type` + JSON path. The `element:*` namespace is excluded because those
+ * renderers read `props` by design (`readProps` merges both bags); every other
+ * `type` is a component-renderer type, which never sees the envelope.
+ */
+function envelopeSites(doc: unknown, path = '$'): string[] {
+  const hits: string[] = [];
+  if (Array.isArray(doc)) {
+    doc.forEach((v, i) => hits.push(...envelopeSites(v, `${path}[${i}]`)));
+    return hits;
+  }
+  if (doc === null || typeof doc !== 'object') return hits;
+  const node = doc as Record<string, unknown>;
+  if (typeof node.type === 'string' && !node.type.startsWith('element:')
+      && Object.prototype.hasOwnProperty.call(node, 'props')) {
+    hits.push(`${path} (type=${node.type})`);
+  }
+  for (const [k, v] of Object.entries(node)) hits.push(...envelopeSites(v, `${path}.${k}`));
+  return hits;
+}
+
+describe('objectui#6751 — flex layout keys sit on the node, not under `props`', () => {
+  it('compositeExample parses through FlexSchema with direction/gap as authored', () => {
+    const node = readFixture().compositeExample;
+    expect(node.type).toBe('flex');
+
+    const parsed = FlexSchema.parse(node);
+    // Under the envelope these two read the SCHEMA DEFAULTS ('row' / 2), which
+    // is precisely the bug: the document says one thing and renders another.
+    expect(parsed.direction).toBe('col');
+    expect(parsed.gap).toBe(4);
+    // `.passthrough()` carries unknown keys through, so a surviving `props` on
+    // the PARSED node is the direct reading that the envelope is still there.
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'props')).toBe(false);
+  });
+
+  it('compositeExample parses the same way through the published LayoutSchema union', () => {
+    const parsed = LayoutSchema.parse(readFixture().compositeExample) as Record<string, unknown>;
+    expect(parsed.type).toBe('flex');
+    expect(parsed.direction).toBe('col');
+    expect(parsed.gap).toBe(4);
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'props')).toBe(false);
+  });
+
+  it('no component-renderer node anywhere in the fixture carries a `props` envelope', () => {
+    expect(envelopeSites(readFixture())).toEqual([]);
+  });
+
+  it('positive control — the walk above catches an envelope when one is present', () => {
+    // Without this, the zero on the previous assertion could come from a walker
+    // that never reports anything.
+    const doc = readFixture();
+    doc.compositeExample.props = { direction: 'col', gap: 4 };
+    expect(envelopeSites(doc)).toEqual(['$.compositeExample (type=flex)']);
+  });
+
+  it('negative control — `properties` and the `element:*` carve-out are not flagged', () => {
+    // `properties` is the bag SchemaRenderer DOES hoist, and `element:*` reads
+    // `props` by design; flagging either would make the zero above meaningless.
+    expect(envelopeSites({ type: 'card', properties: { title: 'Customer Summary' } })).toEqual([]);
+    expect(envelopeSites({ type: 'element:div', props: { className: 'p-4' } })).toEqual([]);
+  });
+
+  it('negative control — the lift left the rest of the node untouched', () => {
+    const node = readFixture().compositeExample;
+    expect(node.id).toBe('user-profile-card');
+    expect(node.children.map((c: { type: string }) => c.type)).toEqual([
+      'avatar', 'statistic', 'badge', 'list',
+    ]);
+    expect(node.children[0]).toMatchObject({
+      type: 'avatar', alt: 'User Avatar', fallback: 'JD', size: 'lg',
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6751

`compositeExample` in `packages/types/examples/data-display-examples.json` authored its layout configuration inside a `props` envelope:

```json
{ "type": "flex", "id": "user-profile-card", "props": { "direction": "col", "gap": 4 } }
```

`SchemaRenderer` hoists `properties.*` onto the node and spreads `props` as React props instead, so a renderer declared `({ schema })` — the ordinary component-renderer shape, which `flex.tsx` has — never reads the envelope. The example therefore rendered with the default `row` direction and the default gap, while presenting itself as a column with `gap: 4`. Nothing complained, because `BaseSchema` is `.passthrough()` and every gate accepted the spelling.

## The fix is the lift, not a rename

Both faces of `FlexSchema` declare the two keys at NODE level, so the envelope has no legitimate reading here and `props` is **not** renamed to `properties` — that would add a second spelling for something the schema already declares:

- `packages/types/src/zod/layout.zod.ts:179` — `direction: z.enum(['row','col','row-reverse','col-reverse'])`, `gap: z.number()`
- `packages/types/src/layout.ts:309` — `FlexSchema extends BaseSchema, FlexLayoutProps`, and `FlexLayoutProps` declares `direction` and `gap`

No schema is widened by this PR.

## The pin is structural, not acceptance-shaped

`.passthrough()` is exactly why acceptance cannot close this: the broken document parsed GREEN through every schema in the package and would keep doing so. What separates the two states is the parsed VALUE, so that is what the pin asserts.

| fixture state | `FlexSchema.parse(node).direction` | `.gap` | `'props' in parsed` |
|---|---|---|---|
| under the `props` envelope | `'row'` (schema default) | `2` (schema default) | `true` |
| lifted onto the node | `'col'` | `4` | `false` |

`packages/types/src/__tests__/flex-props-envelope-lift-6751.test.ts` reads the fixture from disk (so a fixture edit is measured, not remembered) and asserts, in six cases:

1. the node parses through `FlexSchema` with the AUTHORED values, and no `props` survives on the parsed node;
2. the same through the published `LayoutSchema` union entry point, which covers `flex`;
3. a walk over every object in the fixture carrying `type` reports no `props` envelope — **zero hits**;
4. **positive control** — the same walk, over a copy with one synthetic `props` node injected, reports exactly that node. Without it the zero in (3) could come from a walker that never reports anything;
5. **negative control** — neither `properties` (the bag the renderer DOES hoist) nor the `element:*` namespace (which reads `props` by design, through `readProps`) is flagged, so the zero is about `props` on component-renderer types specifically;
6. **negative control** — the lift left the rest of the node untouched: `id`, the four children and their types, and the avatar child's own keys.

The walk is scoped to this one fixture deliberately. See the fence below.

## The fence: three counter-examples read, and left alone

The card names three same-shaped occurrences that are DELIBERATE teaching material and must not be "fixed". All three are intact on this branch point, and this PR edits none of them — a repo-wide "no node carries `props`" assertion would have made the teaching material fail, which is why (3) above is fixture-scoped:

| site | reading |
|---|---|
| `skills/objectui/rules/protocol.md:110` | the `card` carrying `props: { title }`, still immediately followed by the measurement table at 130-137 whose row for it reads "no header element at all" |
| `skills/objectui/guides/schema-expressions.md:35` | the `card`, under the comment "Evaluated, then dropped -- renders an empty card" |
| `skills/objectui/guides/schema-expressions.md:485` | the `text`, under the comment "Worse — evaluated inside the envelope, then discarded: renders nothing", with its cross mark |

The other half of the card (`skills/objectui/guides/page-builder.md`'s `statistic` node) had already landed on `main` before this branch: that file matches `"props"` on 0 lines, with the control term `"statistic"` matching on 1 line in the same file, so the zero is a reading rather than a miss.

## Changeset: declared as releasing nothing

`.changeset/6751-flex-props-envelope-lift.md` uses the empty-frontmatter form, which is the explicit exemption rather than a workaround, and `node scripts/check-changeset-presence.mjs` accepts it on that basis. The reasoning it records:

- `packages/types/package.json` `files` is `["dist","README.md","CHANGELOG.md","LICENSE"]` — `examples/` is **not** published, and the gate agrees (it counts 3 changed files and 1 of them as published source);
- the one file it does count is the new pin, and `packages/types/tsconfig.json` excludes `**/__tests__/**` by directory, so the pin never reaches `dist`. Confirmed by `check:published-tsconfig-exclude`.

⇒ no published behaviour changes.

## Ablation — the pin can fail, proven on the shipping tree

Fix committed first, then the fixture mutated, then restored — trap-guarded, absolute paths, and verified by content rather than by an exit code. Run at `8c4d206`:

```
HEAD_BLOB=613aaf3e711d9593fb77785c9bc9b291e9785ec5
git checkout f96a781 -- packages/types/examples/data-display-examples.json
MUT_BLOB=73e3e63dd1a3eb6235028d73bb3541a4cc26a337        (differs => the mutation really landed)
on-disk, indent-anchored:  node-level direction=0 (expect 0)  envelope direction=1 (expect 1)  props key=1 (expect 1)

ABLATION_VITEST_EXIT=1
  AssertionError: expected 'row' to be 'col'
  AssertionError: expected 'row' to be 'col'
  AssertionError: expected [ '$.compositeExample (type=flex)' ] to deeply equal []
  Test Files  1 failed (1)   Tests  3 failed | 3 passed (6)

git checkout HEAD -- packages/types/examples/data-display-examples.json
RES_BLOB=613aaf3e711d9593fb77785c9bc9b291e9785ec5        (== HEAD_BLOB)
git diff HEAD bytes after restore: 0
on-disk after restore:  node-level direction=1 (expect 1)  props key=0 (expect 0)
RESTORED_VITEST_EXIT=0    Test Files  1 passed (1)   Tests  6 passed (6)
```

The direction the ablation went is the ordinary one — RED — and it goes red on three legs, two of them value assertions and one the structural walk. The three cases that stay GREEN under the mutation are the two controls and the untouched-neighbours check, which is what they are for: they do not depend on the lift.

Choosing `f96a781` as the mutation source is the card's own recipe and needed no adjustment even though this branch was cut from `adb2a86`: the fixture blob is byte-identical at both refs.

## Gates

All at `8c4d206`, which is the pushed head. Exit codes captured before any pipe.

| command | exit |
|---|---|
| `pnpm exec vitest run --maxWorkers=2 packages/types/` | 0 — Test Files 114 passed (114), Tests 1956 passed (1956) |
| `pnpm --filter @object-ui/types type-check` | 0 |
| `node scripts/check-changeset-presence.mjs` | 0 |
| `node scripts/check-changeset-fixed.mjs` | 0 |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `node scripts/check-changeset-overwrite.mjs` | 0 |
| `pnpm run check:control-bytes` | 0 |
| `pnpm run check:spec-symbols` | 0 |
| `pnpm run check:unreferenced-sources` | 0 |
| `pnpm run check:published-tsconfig-exclude` | 0 |
| `pnpm run check:self-import` | 0 |

Heavy runs went through the container's shared verify lock; the verdict line read `VERDICT command-exit 0` each time.

**The type-check genuinely covers the pin, rather than merely being green beside it.** `packages/types`'s `type-check` is `tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`, and the root program excludes `**/__tests__/**` — so the coverage claim was measured rather than assumed: `tsc -p tsconfig.test.json --listFilesOnly` lists 572 program inputs, and the pin is one of them.

**Lint, as a declared narrowing.** The repo-wide `eslint . --no-inline-config` run is CI's; this branch ran the narrowed one and offers the three readings that make the narrowing a measurement rather than a skip: (a) exactly one file in the diff is lintable at all — the other two are a `.json` fixture and a `.md` changeset; (b) `eslint --format json` on it reports `files linted: 1, errors: 0, warnings: 0`; (c) `eslint.config.js` declares no `projectService`, no `parserOptions` and no `project`, so type-aware linting is not enabled and nothing in this diff can move the verdict on any file it does not touch. The first pass caught one real warning — `@typescript-eslint/no-explicit-any` on the fixture reader, also a commandment #6 violation — fixed by reading the document as JSON (`{ [key: string]: unknown }`) through an `objectAt` helper that refuses a non-object loudly, instead of `any`. No assertion changed.

`origin/main` was merged into this branch before the PR was opened, which brought in #7718 (#6972) — it edits the same fixture in a different region (`examples.markdown` losing `sanitize`) and merged clean; every number above is from after that merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s)_