### PR TITLE
docs(types): align two layout `@default` docblocks with the renderer fallbacks

### DIFF
--- a/.changeset/layout-default-jsdoc-7361.md
+++ b/.changeset/layout-default-jsdoc-7361.md
@@ -1,0 +1,5 @@
+---
+'@object-ui/types': patch
+---
+
+The published `@default` documentation on two `layout.ts` members now matches the value the renderer actually applies. `ContainerSchema.maxWidth` documented `'lg'` while `container.tsx` applies `schema.maxWidth ?? 'xl'`, and the shared `FlexLayoutProps.align` documented `'center'` while `flex.tsx` applies `schema.align || 'start'` and `stack.tsx` applies `schema.align || 'stretch'`. The renderers are unchanged — they are the authority for what runs — so only the docblocks moved; `align` now states both consumers in prose instead of carrying a single `@default`, because one member shared by two deliberately divergent component types cannot have one correct default.

--- a/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
+++ b/packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts
@@ -1,0 +1,165 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The `@default` documentation on two `layout.ts` members agrees with the value
+ * the renderer actually applies (objectui#7361).
+ *
+ * Two published docblocks described a default no renderer ever applied:
+ *
+ *   | member                     | tag said   | renderer applies                    |
+ *   |----------------------------|------------|-------------------------------------|
+ *   | `ContainerSchema.maxWidth` | `'lg'`     | `container.tsx`: `?? 'xl'`          |
+ *   | `FlexLayoutProps.align`    | `'center'` | `flex.tsx`: `|| 'start'`,           |
+ *   |                            |            | `stack.tsx`: `|| 'stretch'`         |
+ *
+ * The renderers are the authority — they are what runs — so the tags moved, not
+ * the reads. Changing the reads to match the tags would relayout every existing
+ * page that omits either key, which is a behaviour change and a separate ruling.
+ *
+ * `FlexLayoutProps.align` is the structurally interesting half. The member is
+ * declared ONCE (objectui#6151 — see the interface docblock for why `StackSchema`
+ * cannot derive it with an `Omit`), but `flex` and `stack` deliberately diverge
+ * on it: that divergence is most of what distinguishes the two component types.
+ * So no single `@default` value can be correct there, and the fix is the absence
+ * of a tag plus prose naming both consumers — not a second wrong single value.
+ *
+ * ## Why this pin reads both sides off disk
+ *
+ * Every expected value below is DERIVED: the renderer's fallback is extracted
+ * from the renderer source with a narrow regex, and compared against the
+ * docblock text extracted from `layout.ts`. Nothing is written from memory, so
+ * the pin turns red if EITHER side moves — a renderer changing its fallback
+ * without the docblock following is the same defect this card fixed, in the
+ * other direction.
+ *
+ * The regexes are guarded by explicit positive controls: a regex that quietly
+ * matches nothing would make every assertion below vacuously true, which is the
+ * failure mode this pin exists to prevent.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const read = (relative: string): string => readFileSync(join(REPO_ROOT, relative), 'utf8');
+
+const TYPES = 'packages/types/src/layout.ts';
+const CONTAINER = 'packages/components/src/renderers/layout/container.tsx';
+const FLEX = 'packages/components/src/renderers/layout/flex.tsx';
+const STACK = 'packages/components/src/renderers/layout/stack.tsx';
+
+/** The fallback each renderer applies when the authored key is absent. */
+const CONTAINER_MAXWIDTH = /schema\.maxWidth\s*\?\?\s*'([^']+)'/;
+const FLEX_ALIGN = /schema\.align\s*\|\|\s*'([^']+)'/;
+const STACK_ALIGN = /schema\.align\s*\|\|\s*'([^']+)'/;
+
+/** The body of a named `export interface`, so member lookups cannot stray. */
+function interfaceBody(src: string, name: string): string {
+  const start = src.indexOf(`export interface ${name}`);
+  expect(start, `interface ${name} not found in ${TYPES}`).toBeGreaterThan(-1);
+  const open = src.indexOf('{', start);
+  const end = src.indexOf('\n}', open);
+  expect(end, `interface ${name} is unterminated`).toBeGreaterThan(open);
+  return src.slice(start, end);
+}
+
+/** The docblock immediately preceding `member` inside an interface body. */
+function docblockFor(body: string, member: string): string {
+  const idx = body.search(new RegExp(`\\n\\s*${member}\\?:`));
+  expect(idx, `member ${member} not found`).toBeGreaterThan(-1);
+  const before = body.slice(0, idx);
+  const open = before.lastIndexOf('/**');
+  const close = before.lastIndexOf('*/');
+  expect(open, `no docblock before ${member}`).toBeGreaterThan(-1);
+  expect(close).toBeGreaterThan(open);
+  return before.slice(open, close + 2);
+}
+
+/** Every `@default` BLOCK tag in a docblock (an inline mention is not a tag). */
+function defaultTags(doc: string): string[] {
+  return [...doc.matchAll(/^\s*\*\s*@default\s+(.*)$/gm)].map((m) => m[1].trim());
+}
+
+describe('layout.ts `@default` docs agree with the renderer fallbacks (objectui#7361)', () => {
+  const types = read(TYPES);
+
+  describe('positive controls — the regexes match today', () => {
+    it('finds the fallback each of the three renderers applies', () => {
+      expect(CONTAINER_MAXWIDTH.exec(read(CONTAINER))).not.toBeNull();
+      expect(FLEX_ALIGN.exec(read(FLEX))).not.toBeNull();
+      expect(STACK_ALIGN.exec(read(STACK))).not.toBeNull();
+    });
+
+    it('each extracted fallback is a member of the union the type declares', () => {
+      const maxWidth = CONTAINER_MAXWIDTH.exec(read(CONTAINER))![1];
+      const flexAlign = FLEX_ALIGN.exec(read(FLEX))![1];
+      const stackAlign = STACK_ALIGN.exec(read(STACK))![1];
+      const container = interfaceBody(types, 'ContainerSchema');
+      const flexProps = interfaceBody(types, 'FlexLayoutProps');
+      expect(container).toContain(`'${maxWidth}'`);
+      expect(flexProps).toContain(`'${flexAlign}'`);
+      expect(flexProps).toContain(`'${stackAlign}'`);
+    });
+  });
+
+  describe('row 1 — ContainerSchema.maxWidth', () => {
+    it('carries exactly one `@default`, and it is the value container.tsx applies', () => {
+      const applied = CONTAINER_MAXWIDTH.exec(read(CONTAINER))![1];
+      const doc = docblockFor(interfaceBody(types, 'ContainerSchema'), 'maxWidth');
+      expect(defaultTags(doc)).toEqual([`'${applied}'`]);
+    });
+
+    it('names the read site so the next reader can re-derive it', () => {
+      const doc = docblockFor(interfaceBody(types, 'ContainerSchema'), 'maxWidth');
+      expect(doc).toContain('container.tsx');
+      expect(doc).toContain('??');
+    });
+  });
+
+  describe('row 2 — FlexLayoutProps.align (shared member, two divergent consumers)', () => {
+    const flexAlign = FLEX_ALIGN.exec(read(FLEX))![1];
+    const stackAlign = STACK_ALIGN.exec(read(STACK))![1];
+
+    it('the two consumers really do diverge — the reason a single tag cannot be right', () => {
+      expect(flexAlign).not.toEqual(stackAlign);
+    });
+
+    it('publishes NO single-value `@default` block tag', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'align');
+      expect(defaultTags(doc)).toEqual([]);
+    });
+
+    it('names BOTH consumers and the fallback each one applies', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'align');
+      expect(doc).toContain('flex.tsx');
+      expect(doc).toContain('stack.tsx');
+      expect(doc).toContain(`'${flexAlign}'`);
+      expect(doc).toContain(`'${stackAlign}'`);
+    });
+
+    it('no longer publishes the value neither renderer applies', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'align');
+      expect(defaultTags(doc)).not.toContain("'center'");
+    });
+  });
+
+  describe('negative controls — neighbouring `@default` tags are untouched', () => {
+    it('ContainerSchema.centered still reads `@default true`', () => {
+      const doc = docblockFor(interfaceBody(types, 'ContainerSchema'), 'centered');
+      expect(defaultTags(doc)).toEqual(['true']);
+    });
+
+    it('FlexLayoutProps.justify still reads `@default \'start\'`', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'justify');
+      expect(defaultTags(doc)).toEqual(["'start'"]);
+    });
+
+    it('FlexLayoutProps.gap still reads `@default 2`', () => {
+      const doc = docblockFor(interfaceBody(types, 'FlexLayoutProps'), 'gap');
+      expect(defaultTags(doc)).toEqual(['2']);
+    });
+  });
+});

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -213,8 +213,12 @@ export interface SeparatorSchema extends BaseSchema {
 export interface ContainerSchema extends BaseSchema {
   type: 'container';
   /**
-   * Max width constraint
-   * @default 'lg'
+   * Max width constraint.
+   *
+   * `container.tsx` applies this as `schema.maxWidth ?? 'xl'`, so a
+   * `container` that omits the key renders `max-w-xl` — the tag said
+   * `'lg'` and no renderer ever applied it (objectui#7361).
+   * @default 'xl'
    */
   maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl' | '4xl' | '5xl' | '6xl' | '7xl' | 'full' | 'screen' | false;
   /**
@@ -283,8 +287,18 @@ export interface FlexLayoutProps {
    */
   justify?: 'start' | 'end' | 'center' | 'between' | 'around' | 'evenly';
   /**
-   * Align items
-   * @default 'center'
+   * Align items.
+   *
+   * Deliberately carries NO `@default` tag. The member is declared once here
+   * (see this interface's docblock and objectui#6151), but the two component
+   * types that consume it diverge on the value they apply when it is omitted:
+   * `flex.tsx` reads `schema.align || 'start'`, `stack.tsx` reads
+   * `schema.align || 'stretch'` ("Stack items usually stretch"). One tag on a
+   * shared member cannot be right for both — it would publish a single default
+   * that only one consumer applies, which is the defect objectui#7361 records
+   * (the tag here used to read `'center'`, which NEITHER renderer applies).
+   * The per-type values are stated in prose so no parser reads a value that is
+   * only conditionally true.
    */
   align?: 'start' | 'end' | 'center' | 'baseline' | 'stretch';
   /**


### PR DESCRIPTION
Fixes #7361

Two published `@default` docblocks in `packages/types/src/layout.ts` described a default that no renderer ever applies. The renderers are the authority — they are what runs — so only the docblocks moved. Changing the reads to match the tags would relayout every existing page that omits either key, which is a behaviour change and a separate ruling (the triage said so explicitly).

## Row 1 — `ContainerSchema.maxWidth`

`@default 'lg'` became `@default 'xl'`, with the read site named in prose: `container.tsx` applies `schema.maxWidth ?? 'xl'`, so a `container` that omits the key renders `max-w-xl`.

Three other surfaces already agreed with the renderer and only the JSDoc dissented, which is why `'xl'` is not a judgement call:

| surface | says |
|---|---|
| `container.tsx` read | `?? 'xl'` |
| registration `inputs[].defaultValue` | `'xl'` |
| registration `defaultProps.maxWidth` | `'xl'` |
| JSDoc tag (before this change) | `'lg'` |

## Row 2 — `FlexLayoutProps.align`, and why shape (a) rather than (b)

The dispatch allowed two shapes and preferred (b) — moving the tag onto `FlexSchema` and `StackSchema` — **if** those types carry a docblock where a tag can live without redeclaring the member. They do carry docblocks, but the condition is about where a tag can live *as a tag for that member*, and it fails:

`@default` is a member-level tag. Placed on an interface docblock it attaches to the *interface reflection*, not to `align`. TypeDoc would render it as a default value for `FlexSchema` itself, and editor hover over `align` on a `flex` node resolves to the declaring member on `FlexLayoutProps` and never sees the consuming interface's docblock. Shape (b) would therefore have replaced a wrong-value tag with a wrongly-placed one — a fresh instance of the same family the card is about, a declaration whose tooling behaviour does not match its apparent promise.

So shape (a): the member keeps its single declaration (objectui#6151 — `StackSchema` cannot derive it through an `Omit` without erasing every named member), and the docblock now carries **no** `@default` tag at all, stating both consumers in prose instead:

- `flex.tsx` reads `schema.align || 'start'`
- `stack.tsx` reads `schema.align || 'stretch'` ("Stack items usually stretch")

Dropping the tag rather than writing a tag whose text is not a value expression is the point: one shared member serving two deliberately divergent types cannot carry a single correct machine-readable default, and publishing one that is only conditionally true is what this card exists to stop. The prose still renders in hover and in the generated API reference.

## Triage boundary 3 — does the tag reach anything downstream? Measured

The card's stated route is that `sdui-parser` serializes the tag into `sdui.manifest.json` and `sdui-intrinsics.d.ts`. That is not the actual route, and the correction matters for how much this change is worth:

- `scripts/dump-public-manifest.mjs` builds the manifest from **runtime registrations** (`config.inputs`, via `manifestFromConfigs`, read out of a real browser). Its own header says it records what each registration declares. It never opens a TypeScript source file.
- `packages/sdui-parser/src/codegen.ts` generates the intrinsics declaration from that **manifest**, not from JSDoc.
- Neither artefact is checked in (`git ls-files` returns nothing for either; the manifest is written into `packages/console/dist` at build time), so there was nothing to regenerate here.
- Repo-wide there is no JSDoc-tag parser at all: no `getJSDocTags`, no `jsDocTags`, no `@microsoft/tsdoc`. The only matches for those names are prose mentions of "TSDoc" inside comments.

What the tag *does* reach is real, just different: **TypeDoc** is wired up (`typedoc.json`, the `docs:api` script, and the devDependency), and `packages/types` is its first entry point — its output directory is gitignored, so it is regenerated on demand. And the docblock ships: the emitted `packages/types/dist/layout.d.ts` carries both corrected blocks verbatim, which is what editor hover reads for every consumer of the published package.

So: no generator consumes the tag, and the card's premise that it "reaches downstream" holds for the shipped declaration file, the API reference and IDE hover — not for the serialized SDUI artefacts.

## Triage boundary 4 — the census, with its denominator

`layout.ts` declares **24** `@default` tags. **14** are cleanly comparable against a fallback the matching renderer actually applies; the other 10 declare a default no renderer applies as a fallback at all, so they are not comparable rather than wrong. Of the 14, **3** disagreed:

| member | tag | renderer applies | disposition |
|---|---|---|---|
| `ContainerSchema.maxWidth` | `'lg'` | `container.tsx`: `xl` | fixed here |
| `FlexLayoutProps.align` | `'center'` | `flex.tsx`: `start`, `stack.tsx`: `stretch` | fixed here |
| `FlexLayoutProps.direction` | `'row'` | `flex.tsx`: `row`, `stack.tsx`: `col` | out of scope, filed |

The remaining 11 agree. The census was matched per component type rather than by member name — several names (`variant`, `size`, `orientation`, `gap`) recur across unrelated schemas, and a name-only sweep produces false pairs.

## Out-of-scope findings filed (not touched here)

- **objectui#7734** — `FlexLayoutProps.direction` carries a shared `@default 'row'` that is right for `flex` and wrong for `stack`, whose renderer reads `|| 'col'` under the comment "Default to column for Stack". Structurally identical to row 2 and on the same interface; left alone because the dispatch drew the file surface at exactly two docblocks.
- **objectui#7735** — the bigger one, and runtime rather than documentation: `packages/types/src/zod/layout.zod.ts` carries `.optional().default(VALUE)` on these same members, and `.default()` substitutes at parse time. Measured through the built `safeValidateSchema`: a bare `container` node parses to `maxWidth: "lg"` and a bare `flex` node parses to `align: "center"` — values the renderers never apply. A node that has been through the mirror therefore renders differently from the same node authored as-is. Deliberately untouched here: the dispatch ruled out moving any default VALUE, and both candidate remedies change published behaviour, so it needs a ruling rather than a patch.

Both were deduplicated against open and closed issues before filing, with a known-hit control query to prove the search channel was live in this session.

## Verification

All runs foreground; heavy runs through the container's shared verify lock; exit codes captured before any pipe. Everything below was re-run on the merged head `243236ea` unless noted.

| check | result |
|---|---|
| `pnpm exec vitest run --maxWorkers=2 packages/types/` | 116 files, 1977 tests passed |
| `pnpm --filter @object-ui/types build` | exit 0 (dist completeness: 120 emitted files) |
| `pnpm --filter @object-ui/types type-check` | exit 0 |
| `pnpm lint` (whole repo) | exit 0 — 0 errors |
| `node scripts/check-changeset-presence.mjs` | exit 0, declares `@object-ui/types: patch` |
| `check-changeset-fixed` / `-no-major` / `-overwrite` | exit 0 |
| `check-control-bytes` | exit 0 (6302 files) |
| `check-spec-symbol-derivation` | exit 0 |
| governed-surface predicate on the final file list | NOT governed (0 of 3 paths) |

The new pin is inside `tsconfig.test.json`'s program, proven with `--listFilesOnly` rather than assumed.

### The pin, and its ablation

`packages/types/src/__tests__/layout-default-jsdoc-7361.test.ts` derives every expected value by reading the renderer sources off disk with narrow regexes and comparing them against the docblock text extracted from `layout.ts`. Nothing is written from memory, so it turns red if *either* side moves — a renderer changing its fallback without the docblock following is the same defect in the other direction. The regexes are guarded by explicit positive controls, because a regex that quietly matches nothing would make every assertion vacuous.

Ablation, with the fix committed first, trap-guarded, absolute paths, and the mutation proven to have reached the disk before anything was read:

```
mutation : layout.ts reverted to b74a859
           '@default lg' 1, '@default center' 1, '@default xl' 0
           blob 266e700e differs from HEAD blob 92225fa2  (not a no-op)
result   : vitest exit 1 — 5 failed | 6 passed (11)
           red: the 2 row-1 legs and the 3 row-2 legs
           green: both positive controls, the divergence assertion,
                  and all 3 negative controls (centered / justify / gap)
restore  : blob back to 92225fa2, identical to HEAD; git diff HEAD empty
```

The pin reads source off disk rather than a built artefact, so no rebuild is needed for the mutation to take effect and the dist preflight that guards dist-resolved ablations does not apply.

## Notes

- Renderers untouched. No member, type, union or default VALUE moved — docblock text only.
- `layout.ts:113` (`align` on `TextSchema`, text alignment) is a different member and was left alone; it carries no `@default` tag at all.
- This PR is left in **draft** for the PM seat to route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s)_