### PR TITLE
test(data-objectstack): pin listImportMappings against the measured GET /meta/mapping body

### DIFF
--- a/.changeset/14026-list-import-mappings-pin.md
+++ b/.changeset/14026-list-import-mappings-pin.md
@@ -1,0 +1,6 @@
+---
+---
+
+Pin `listImportMappings(objectName)` against the framework's measured
+`GET /api/v1/meta/mapping` body (objectui#14026). Test only; no package is
+released by this change.

--- a/packages/data-objectstack/src/listImportMappings.test.ts
+++ b/packages/data-objectstack/src/listImportMappings.test.ts
@@ -1,0 +1,118 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ObjectStackAdapter, clearSharedDiscoveryCache } from './index';
+
+/**
+ * `listImportMappings(objectName)` feeds the import wizard's "saved mapping"
+ * selector (framework #2611). The selector is FEATURE-DETECTED: an empty list
+ * hides it, and the adapter deliberately degrades every failure to an empty
+ * list — so a filter reading the wrong depth of the served item would not
+ * fail anywhere; it would just make the selector never appear, on every
+ * deployment, silently (objectui#14026).
+ *
+ * This pin therefore does not stub the SDK. The `fetch` stub answers the
+ * discovery probe and `GET /api/v1/meta/mapping` with the body the framework's
+ * REST list door was MEASURED to emit — `RestServer`'s `GET /meta/:type`
+ * driven by a real `ObjectStackProtocolImplementation` over a registered
+ * `mapping` artifact (objectstack `packages/rest`, probe run 2026-09-05):
+ * raw spec documents decorated with `_packageId` / `_provenance` /
+ * `_diagnostics`, carrying `targetObject` at the TOP LEVEL, inside the spec's
+ * `{ type, items }` envelope with no `{ success, data }` wrapper. The real
+ * `@objectstack/client` `meta.getItems` then unwraps it, and the adapter's
+ * own filter runs on what the SDK hands back.
+ */
+
+/** Verbatim `GET /api/v1/meta/mapping` body from the framework probe. */
+const WIRE_BODY = {
+  type: 'mapping',
+  items: [
+    {
+      name: 'task_feed_import',
+      label: 'Task feed import (manifest path)',
+      sourceFormat: 'csv',
+      targetObject: 'task',
+      fieldMapping: [
+        { source: 'ID', target: 'id', transform: 'none' },
+        { source: 'Task Title', target: 'title', transform: 'none' },
+      ],
+      mode: 'upsert',
+      upsertKey: ['id'],
+      _packageId: 'probe_pkg',
+      _provenance: 'package',
+      _diagnostics: { valid: true },
+    },
+    {
+      name: 'user_only_mapping',
+      label: 'User feed import',
+      sourceFormat: 'json',
+      targetObject: 'user',
+      fieldMapping: [{ source: 'id', target: 'id', transform: 'none' }],
+      mode: 'insert',
+      _diagnostics: { valid: true },
+    },
+  ],
+};
+
+const BASE_URL = 'http://list-import-mappings-pin.local';
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeDS() {
+  const requested: string[] = [];
+  const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    requested.push(url);
+    if (url.endsWith('/api/v1/discovery')) {
+      return json({ success: true, data: { capabilities: {}, routes: {} } });
+    }
+    if (url.endsWith('/api/v1/meta/mapping')) {
+      return json(WIRE_BODY);
+    }
+    return json({ success: false, error: { code: 'NOT_FOUND', message: `unexpected ${url}` } }, 404);
+  });
+  const ds = new ObjectStackAdapter({ baseUrl: BASE_URL, fetch: fetchImpl, autoReconnect: false });
+  return { ds, requested };
+}
+
+describe('ObjectStackDataSource.listImportMappings (objectui#14026)', () => {
+  beforeEach(() => {
+    clearSharedDiscoveryCache();
+  });
+
+  it('returns a registered mapping artifact targeting the object, read through the real SDK', async () => {
+    const { ds, requested } = makeDS();
+
+    const mappings = await ds.listImportMappings('task');
+
+    // The SDK route the adapter reads — not a stubbed client method.
+    expect(requested).toContain(`${BASE_URL}/api/v1/meta/mapping`);
+    // The artifact targeting `task` is served; the one targeting `user` is not.
+    expect(mappings.map((m: any) => m.name)).toEqual(['task_feed_import']);
+    // …and it is the served document itself, decorations included, so the
+    // wizard's `asSavedMapping` predicate (`name` string, `targetObject`
+    // string, `fieldMapping` array) accepts it as-is.
+    const [m] = mappings;
+    expect(typeof m.name).toBe('string');
+    expect(m.targetObject).toBe('task');
+    expect(Array.isArray(m.fieldMapping)).toBe(true);
+    expect(m.mode).toBe('upsert');
+    expect(m.upsertKey).toEqual(['id']);
+  });
+
+  it('answers an empty list, not a match, for an object no artifact targets', async () => {
+    const { ds } = makeDS();
+    expect(await ds.listImportMappings('project')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Part of objectstack-ai/objectui#10102 — measurement round; no runtime code changes.

## What was measured

The card's working hypothesis was that `GET /api/v1/meta/mapping` serves publish envelopes (`{ name, packageId, state, metadata }`), so the adapter's top-level `targetObject` filter would read nothing on every item and the wizard's saved-mapping selector could never appear on any deployment.

Executed against the framework at objectstack `132742f10` (`packages/rest`, the same harness as `import-integration.test.ts`: real `ObjectQL` + sqlite `:memory:` + real `ObjectStackProtocolImplementation` + `RestServer`'s registered route table), with a `mapping` artifact registered through each of the three producer paths — manifest `mappings:` via `registerApp`, direct `registry.registerItem`, and `MetadataManager.register` installed as the `metadata` service (the file-based artifact loader's registrar). The list door answers `{ "type": "mapping", "items": [ ... ] }`, and every item is the raw document with `targetObject` at the top level, decorated with `_packageId` / `_provenance` / `_diagnostics`; no item carries a nested `metadata` member. `GET /api/v1/meta/types` lists `mapping` in the live set, so the door does not refuse the kind. The hypothesis is dead; the adapter's filter is correct against the served body, and the wizard is unchanged because it was already correct.

## What this PR adds

`packages/data-objectstack/src/listImportMappings.test.ts` feeds that verbatim body through a `fetch` stub, so the real `@objectstack/client` `meta.getItems` and the adapter's own filter both run, and asserts that the artifact targeting the object comes back as served — with the fields the wizard's `asSavedMapping` predicate needs — while an artifact targeting another object does not.

Red-then-green, stated plainly: the pin is green on the current code on its first run (2 passed, exit 0), because the code is right. Ablating the filter to the hypothesised envelope depth (`m.metadata?.targetObject`; mutation confirmed on disk by anchored grep counts, original 1 to 0 and mutant 0 to 1) turns it red — `AssertionError: expected [] to deeply equal [ 'task_feed_import' ]`, 1 failed, exit 1. Restore to HEAD is proven by an empty `git diff HEAD` and a matching HEAD blob hash; the re-run is 2 passed, exit 0.

Changeset: empty frontmatter (test only, nothing released).

## Checks run, exit codes captured before any pipe, all at `6cbaed1`

- `pnpm exec vitest run packages/data-objectstack/src/listImportMappings.test.ts` — 2 passed, exit 0
- `pnpm exec vitest run packages/data-objectstack/` — 56 files, 739 tests passed, exit 0
- `pnpm --filter @object-ui/data-objectstack type-check` — exit 0; `tsc --listFiles` shows the new test file in the population (1 hit)
- `pnpm --filter @object-ui/data-objectstack lint` — 0 errors, 424 pre-existing warnings, exit 0
- `node scripts/check-control-bytes.mjs` — OK, exit 0
- `node scripts/check-changeset-presence.mjs` — exit 0; `node scripts/check-changeset-no-major.mjs` — exit 0

Session: `https://claude.ai/code/session_01ARYe3yQTQCUFm5qPYNgKaJ`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARYe3yQTQCUFm5qPYNgKaJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARYe3yQTQCUFm5qPYNgKaJ)_