### PR TITLE
fix(core): DataScopeManager denies a row on an operator it does not implement

### DIFF
--- a/.changeset/core-datascope-unknown-operator-denies-7378.md
+++ b/.changeset/core-datascope-unknown-operator-denies-7378.md
@@ -1,0 +1,11 @@
+---
+'@object-ui/core': minor
+---
+
+`DataScopeManager` now **denies** a row when a row-level scope rule carries an operator its evaluator does not implement. It used to **admit** the row.
+
+Behaviour change on a permission boundary, stated plainly. `evaluateFilter` implements nine operator spellings — `eq`, `ne`, `gt`, `lt`, `gte`, `lte`, `in`, `nin`, `contains` — and its `default` arm returned `true`, so a stored `RowLevelFilter` carrying any other spelling passed every record the rule existed to hide, silently: no error, no console line, only a result set that was too large, which looks exactly like a correctly configured permissive scope. The arm now returns `false`, the answer `evaluateCondition` in `@object-ui/permissions` already gives from its own `default` arm. Because `applyFilters` ANDs a scope's rules, one unrecognised rule now denies every row in that scope.
+
+Who this reaches, measured on this release's base rather than assumed. The `RowLevelFilter['operator']` union is closed, so no TypeScript caller can write an unimplemented spelling, and no code in this repository constructs a `RowLevelFilter` outside the evaluator's own test. The path that changes is scope configuration read back from stored or hand-written JSON and handed to `setFilters` / `registerScopeWithConfig`, where the operator arrives as a plain string the type never checked. A deployment holding such a rule with a spelling outside the nine — including the spec's canonical `equals` / `not_equals` / `greater_than` / `starts_with` and the null-ness family `is_null` / `is_not_null`, none of which have an arm — sees fewer rows from that scope after upgrading, never more. Those spellings are not implemented here; they are refused instead of admitted. Whether to canonicalise them through the spec's `canonicalAstOperator` is left open on objectui#7378.
+
+Graded `minor` because a release reader can observe the narrowing on stored data; the declared type is unchanged and the set of spellings the evaluator accepts has not widened.

--- a/packages/core/src/data-scope/DataScopeManager.ts
+++ b/packages/core/src/data-scope/DataScopeManager.ts
@@ -25,7 +25,11 @@ import type { DataScope, DataContext, DataSource } from '@object-ui/types';
 export interface RowLevelFilter {
   /** Field to filter on */
   field: string;
-  /** Filter operator */
+  /**
+   * Filter operator. The set is closed: a rule whose operator is outside it
+   * (possible for a rule read back from stored JSON, which the type does not
+   * guard) evaluates to `false` and denies the row.
+   */
   operator: 'eq' | 'ne' | 'gt' | 'lt' | 'gte' | 'lte' | 'in' | 'nin' | 'contains';
   /** Filter value */
   value: any;
@@ -236,7 +240,10 @@ export class DataScopeManager implements DataContext {
 }
 
 /**
- * Evaluate a single filter condition against a field value
+ * Evaluate a single filter condition against a field value.
+ *
+ * An operator the switch does not implement evaluates to `false` (fail
+ * closed); see the `default` arm.
  */
 function evaluateFilter(fieldValue: any, operator: RowLevelFilter['operator'], filterValue: any): boolean {
   switch (operator) {
@@ -259,7 +266,15 @@ function evaluateFilter(fieldValue: any, operator: RowLevelFilter['operator'], f
     case 'contains':
       return typeof fieldValue === 'string' && fieldValue.includes(String(filterValue));
     default:
-      return true;
+      // Fail closed. A row-level rule this evaluator cannot answer must not
+      // admit the row it exists to hide: the same answer `evaluateCondition`
+      // in @object-ui/permissions gives from its own `default` arm, and the
+      // opposite of the admit-all this arm used to return. The declared union
+      // above keeps TypeScript callers off this arm; a rule read back from
+      // stored JSON arrives as a plain string and is not protected by it.
+      // Silent, like the sibling: the caller sees a narrower result set, not
+      // a thrown error (objectui#7378).
+      return false;
   }
 }
 

--- a/packages/core/src/data-scope/__tests__/DataScopeManager.test.ts
+++ b/packages/core/src/data-scope/__tests__/DataScopeManager.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { DataScopeManager } from '../DataScopeManager';
+import { DataScopeManager, type RowLevelFilter } from '../DataScopeManager';
 
 describe('DataScopeManager', () => {
   describe('Scope Registration', () => {
@@ -206,6 +206,90 @@ describe('DataScopeManager', () => {
       unsub();
       manager.updateScopeData('test', [2]);
       expect(count).toBe(1);
+    });
+  });
+
+  describe('Unknown operator fails closed (objectui#7378)', () => {
+    // Why the cast is here, and why it must stay: `RowLevelFilter['operator']`
+    // is a closed nine-member union, so TypeScript refuses `'equals'` or
+    // `'is_null'` at a call site. That protects TypeScript callers and nothing
+    // else. A scope rule read back from stored JSON reaches `applyFilters` as a
+    // plain string, and the switch keys on that string at runtime, exactly the
+    // way it is spelled below. The cast reproduces the path stored data takes;
+    // it is the point of these tests, not a shortcut to be "cleaned up". A
+    // test that only spells the nine declared operators cannot reach the
+    // `default` arm at all.
+    const storedRule = (field: string, operator: string, value: unknown): RowLevelFilter =>
+      ({ field, operator, value }) as unknown as RowLevelFilter;
+
+    it('does not admit a record it cannot evaluate (operator outside every published vocabulary)', () => {
+      const manager = new DataScopeManager();
+      manager.registerScope('test', { data: [] });
+      manager.setFilters('test', [storedRule('status', 'not_an_operator', 'active')]);
+
+      const result = manager.applyFilters('test', [
+        { id: 1, status: 'active' },
+        { id: 2, status: 'inactive' },
+      ]);
+
+      // Fail closed: a rule the evaluator cannot answer denies every row in
+      // the scope, the same answer `evaluateCondition` in @object-ui/permissions
+      // gives from its own `default` arm. Before the fix this returned both
+      // rows, `{ id: 2 }` included, with no error and no console line.
+      expect(result).toEqual([]);
+    });
+
+    it('does not let an unrecognised rule widen a scope another rule narrows (AND semantics)', () => {
+      const manager = new DataScopeManager();
+      manager.registerScope('test', { data: [] });
+      manager.setFilters('test', [
+        { field: 'status', operator: 'eq', value: 'active' },
+        storedRule('tenant', 'not_an_operator', 'acme'),
+      ]);
+
+      const result = manager.applyFilters('test', [
+        { id: 1, status: 'active', tenant: 'acme' },
+        { id: 2, status: 'active', tenant: 'other' },
+        { id: 3, status: 'inactive', tenant: 'acme' },
+      ]);
+
+      // Before the fix the unknown `tenant` rule evaluated to `true`, so the
+      // `status` rule alone decided and `{ id: 2, tenant: 'other' }` passed —
+      // the row the second rule existed to hide. Now nothing passes.
+      expect(result).toEqual([]);
+    });
+
+    // The spec's published vocabularies (`VIEW_FILTER_OPERATORS` from
+    // `@objectstack/spec/ui`, `VALID_AST_OPERATORS` from `@objectstack/spec/data`)
+    // carry spellings this switch has no arm for: the canonical forms of the
+    // implemented abbreviations, and the whole null-ness family. Measured on
+    // @objectstack/spec 17.2.0: 18 of the 20 view operators and 44 of the 53
+    // AST operators have no arm. Until they are either implemented or refused
+    // by name, they MUST take the fail-closed arm rather than the admit-all one.
+    // A change that implements these spellings rewrites the expectations below
+    // to the evaluated result; it never deletes the cases. Every case is
+    // chosen so that a CORRECT evaluation of the spelling admits at least one
+    // of the two rows: an implementation that lands without rewriting the
+    // expectation turns red here instead of passing by coincidence.
+    it.each([
+      ['equals', 'status', 'active'],
+      ['not_equals', 'status', 'active'],
+      ['greater_than', 'age', 20],
+      ['not_in', 'status', ['inactive']],
+      ['starts_with', 'status', 'act'],
+      ['is_null', 'status', null],
+      ['is_not_null', 'status', null],
+    ])('denies rather than admits for the published-but-unimplemented spelling %s', (operator, field, value) => {
+      const manager = new DataScopeManager();
+      manager.registerScope('test', { data: [] });
+      manager.setFilters('test', [storedRule(field, operator, value)]);
+
+      const result = manager.applyFilters('test', [
+        { id: 1, status: 'active', age: 30 },
+        { id: 2, status: null, age: 10 },
+      ]);
+
+      expect(result).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Fixes #7378

`DataScopeManager.evaluateFilter` implements nine operator spellings and its `default` arm returned `true`, so a stored `RowLevelFilter` carrying any other operator admitted every record the rule existed to hide, with no error and no console line. The arm now returns `false`, the answer the sibling `evaluateCondition` in `@object-ui/permissions` already gives from its own `default` arm. A red-first test reaches the arm the way stored data does, past the closed union, and pins the fail-closed answer.

## Clause-② — accept-set and behaviour changes in this diff

- `packages/core/src/data-scope/DataScopeManager.ts` `evaluateFilter`, `default` arm: **admit (`return true`) → deny (`return false`)** for any operator outside `eq` / `ne` / `gt` / `lt` / `gte` / `lte` / `in` / `nin` / `contains`.
- Consequence in `applyFilters` (unchanged code, changed outcome): a scope holding one unrecognised rule now returns **zero rows** for that scope, because rules are ANDed; it used to let the remaining rules alone decide.
- No other accept-set change: the nine implemented spellings behave as before, the declared `RowLevelFilter['operator']` union is unchanged, no export was added or removed, nothing is logged or thrown.

## Measurements (all taken in this run on `origin/main` at `565f2b6aa`, the branch base)

### 1. Liveness census — reproduces the execution seat's reading, with one count corrected

| probe | execution seat (2026-09-02) | this run | note |
|---|---:|---:|---|
| files referencing `RowLevelFilter` (`git grep -ln`) | 2 | **2** | declaration + `data-scope/index.ts` barrel — reproduced |
| files referencing `DataScopeManager` | 4 | **5** | the fifth is `content/docs/guide/architecture-overview.md:311`, a directory-tree comment; present at the card's filing commit `d53e472` (checked via REST at that ref), so it was an undercount then, not a new reference — and it is not a producer |
| in-repo call sites constructing a `RowLevelFilter` | 0 | **0** | `git grep -n 'registerScopeWithConfig\|setFilters(\|applyFilters('` hits only the class itself and its own test |
| declared union closed, nine members, switch implements all nine | yes | **yes** | `DataScopeManager.ts:29` and the switch at the same nine `case` labels |
| lit control: `git grep -ln evaluateFilter` | — | **1 file** | the query mechanism fires on a known-present symbol |

⇒ Nothing in this repository can reach the `default` arm through a TypeScript caller. The path that can is scope configuration read from stored or hand-written JSON, where the operator arrives as a plain string — the path the test exercises.

### 2. Spec-vocabulary gap census — measured on `@objectstack/spec` 17.2.0 as resolved from `packages/core`

- `VIEW_FILTER_OPERATORS` (`@objectstack/spec/ui`): **20** members. With an arm: **2** (`contains`, `in`). Without an arm: **18** — `equals`, `not_equals`, `not_contains`, `icontains`, `starts_with`, `ends_with`, `greater_than`, `less_than`, `greater_than_or_equal`, `less_than_or_equal`, `not_in`, `is_empty`, `is_not_empty`, `is_null`, `is_not_null`, `before`, `after`, `between`.
- `VALID_AST_OPERATORS` (`@objectstack/spec/data`): **53** members. With an arm: **9** — exactly the nine implemented spellings. Without an arm: **44** (the canonical words; the seven symbolic forms — equals-sign, bang-equals, the angle-bracket not-equals, greater-than, greater-or-equal, less-than, less-or-equal — spelled in words here because GitHub's sanitizer eats angle-bracket shapes even inside backticks; `like` / `ilike`; and the whole null-ness / emptiness family).
- `VIEW_FILTER_OPERATOR_ALIASES` maps every implemented abbreviation onto a canonical word the switch has no arm for: `eq → equals`, `ne → not_equals`, `gt → greater_than`, `lt → less_than`, `gte → greater_than_or_equal`, `lte → less_than_or_equal`, `nin → not_in`.
- Lit controls for the census query: positive — `contains` is a member of both published sets (`true` / `true`); negative — `totally_unknown_op` is a member of neither (`false` / `false`).

### 3. The sibling's `default` arm, quoted, and whether this matches it

`packages/permissions/src/evaluator.ts:158-159` reads, verbatim:

```ts
    default:
      return false;
```

It is silent — no `console` line, no throw, no diagnostic collector. This PR's arm is the same: `return false`, silent, with a comment. Its own test pins the behaviour as `operator: 'unknown' as any` → `toBe(false)` (`evaluator.test.ts:229-231`); the new test here uses the same shape (`as unknown as RowLevelFilter`) and explains in its header why the cast is the point. `evaluator.ts` itself is untouched; it is the control group.

### 4. Red-first test — measured, not asserted

Base source (`565f2b6aa`) with the final test text, run via `pnpm exec vitest run packages/core/src/data-scope/__tests__/DataScopeManager.test.ts` from the repo root:

```
 Test Files  1 failed (1)
      Tests  9 failed | 19 passed (28)
AssertionError: expected [ { id: 1, status: 'active' }, …(1) ] to deeply equal []
+ Received
+ [ { "id": 1, "status": "active" }, { "id": 2, "status": "inactive" } ]
```

`{ id: 2, status: 'inactive' }` — the row the rule existed to exclude — is admitted. All nine new cases fail this way: the two structural cases and the seven published-but-unimplemented spellings (`equals`, `not_equals`, `greater_than`, `not_in`, `starts_with`, `is_null`, `is_not_null`).

Head (`a12751d78`), same command: `Test Files 1 passed (1) · Tests 28 passed (28)`.

The red run above was a reverse verification from the **committed** state: source blob checked out from the base sha, on-disk mutation proven by anchored counts (`return true;` = 1, `Fail closed` = 0), restore by `git checkout HEAD -- ABSOLUTE_PATH` under a `trap`, proven by `git hash-object` equal to the HEAD blob `90af27c88…` and an empty `git diff HEAD`, then re-run green.

Every `it.each` case is chosen so that a **correct** evaluation of the spelling admits at least one row (numeric `age` for `greater_than`): a later change that implements these spellings turns them red rather than passing by coincidence, and the header says the expectation is to be rewritten, never deleted.

## Boundary flag — a question this PR does NOT resolve, with the measurements a ruler needs

**Should `evaluateFilter` canonicalise its operator through `canonicalAstOperator` (`@objectstack/spec/data`), the way PR #7377 repaired the sibling card objectui#7349, so that the accepted vocabulary is the published one rather than this hand-written nine?** The card offers that as a worked precedent, explicitly not a ruling. This PR ships the minimal repair (fail closed) and leaves the question open for `needs:contract-review`. What a ruler would need, measured:

- `canonicalAstOperator` maps the nine implemented spellings to the **symbolic forms** — `eq` to the equals-sign, `ne` to bang-equals, `gt` / `lt` / `gte` / `lte` to the greater-than, less-than, greater-or-equal and less-or-equal signs (spelled in words because of the sanitizer), and `in` / `nin` / `contains` to themselves — so canonicalising is not a prefix step, it **re-keys the switch** onto those symbols (that is what `ValueDataSource.matchesComparisonNode` keys on today).
- It passes an unknown string through **unchanged** (`totally_unknown_op → totally_unknown_op`), so a fail-closed `default` arm stays load-bearing under either route.
- It would move **18 view / 44 AST** spellings from refused to evaluated, which needs arms for the null-ness family, `between`, `starts_with` / `ends_with`, `not_contains` / `icontains`, and a decision on `like` / `ilike` (the precedent refuses those by name).
- **Semantics would not survive a copy-paste**: the precedent's `contains` is ASCII case-insensitive (`toLowerCase` on both sides); this evaluator's `contains` is case-sensitive. Canonicalising by copying #7377 would silently change `contains` for existing rules.
- The declared `RowLevelFilter['operator']` union would need widening — a public type change on a published package — or the type would keep lying about what the runtime accepts.
- The execution seat's larger question stands beside this one: with zero in-repo producers, "canonicalise" and "retire under ADR-0049" are competing repairs, and the second is a cross-repo read this seat did not take.

Options a ruler might weigh: **A** keep the minimal fail-closed arm (this PR) and file canonicalisation as its own card; **B** canonicalise here (rejected for this PR: widens scope on a p1 security card, and the measurements above show it is a design, not a transplant); **C** retire the surface (needs the cross-repo consumer read). No recommendation beyond "not in this PR" — that is the contract reviewer's call.

## Serial constraints — re-measured at implementation time

11 open PRs; every file list paged to completion (PR #5400 = 633 files across 7 pages, sum verified). Zero touch `packages/core/src/data-scope/`. The only hits under `packages/permissions/` are PR #5400's `packages/permissions/CHANGELOG.md` and `package.json` — release bookkeeping, not source, and not in this PR's file surface. Lit control: PR #7621 shows `packages/core/src/utils/date-display.ts`, as the claim said.

## Verification on head `a12751d78` (exit codes captured before any pipe; verdict lines quoted)

- `pnpm exec vitest run packages/core/src/data-scope/` (repo root, via the verify lock): `Test Files 3 passed (3) · Tests 63 passed (63)` — `VERDICT command-exit 0`.
- `pnpm --filter @object-ui/core type-check` (after `pnpm --filter '@object-ui/core^...' build`): echoed `tsc --noEmit && tsc -p tsconfig.test.json` — `VERDICT command-exit 0`. `--listFiles` proof: `tsconfig.test.json` reads the edited test file (1 hit) and the build project reads the edited source (1 hit); this is not a typecheck that excluded the test.
- `pnpm --filter @object-ui/core lint` — exit 0, `✖ 515 problems (0 errors, 515 warnings)`. Not a narrowing: this is the full `eslint .` run CI performs for this package, 214 files by `--format json`. The 7 + 1 `no-explicit-any` warnings on the two edited files are **identical in count to the BASE blobs linted at the same paths** (7 + 1), and 0 `any` tokens occur on added lines.
- `node scripts/check-changeset-fixed.mjs` · `check-changeset-no-major.mjs` · `check-changeset-overwrite.mjs` · `check-changeset-presence.mjs` — all exit 0; presence gate: `2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)`.
- `node scripts/check-control-bytes.mjs` — exit 0, `OK (scanned 6311 tracked text file(s))`.
- Not run locally, left to CI: the repo-wide `pnpm lint` / `pnpm test` shards and the rest of the `check:*` farm.

## Changeset

`.changeset/core-datascope-unknown-operator-denies-7378.md`, `@object-ui/core: minor`. Argued from the accept-set change: the narrowing is observable on stored data — a deployment holding a rule with an unimplemented spelling sees fewer rows after upgrading — so `patch` would tell a release reader nothing they can observe changed, which is false on exactly the boundary where being wrong matters. `major` is CI-refused; per AGENTS.md §版本号策略 objectui's own breaking semantics ship as `minor` with the break stated in the body, which the body does. The body also carries the liveness reading so a reader can judge whether it bites them today.

## Not done here, on purpose

- `packages/core/README.md` is unchanged: it documents `DataScopeManager` without describing operators or the fall-through, so there is no sentence to correct.
- `packages/permissions/src/evaluator.ts` is unchanged: it is the control group.
- No canonicalisation, no new operator arms, no union widening — see the boundary flag.

Session: `https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_