### PR TITLE
fix(data-objectstack): lower an array analytics filter through parseFilterAST before the wire (#7752)

### DIFF
--- a/.changeset/7752-analytics-where-lowering.md
+++ b/.changeset/7752-analytics-where-lowering.md
@@ -1,0 +1,9 @@
+---
+'@object-ui/data-objectstack': patch
+---
+
+Array filters on analytics aggregates were posted un-lowered and refused by the runtime with 400; they are now lowered to the canonical `FilterCondition` before the wire.
+
+An `element:number` or an `object-metric` whose filter is authored as an array (`[{ field, operator, value }, ...]`, a comparison tuple, or an `and`/`or` group) reached `POST /analytics/query` as an array. That route parses the body with `AnalyticsQueryRequestSchema` first, and its `where` is a `FilterCondition`, so the widget answered `400 Invalid AnalyticsQuery body: where: ...` instead of its number — leaving the MongoDB-style record as the only authoring form that still worked.
+
+`aggregate()` now lowers the array through `parseFilterAST`, the single sink `@objectstack/spec` names for turning a `FilterArray` into a `FilterCondition`, so the posted `where` is the shape the wire declares. An empty array posts no `where` at all, a record-shaped filter is unchanged, and an array the sink cannot lower — an infix join such as `[condA, 'or', condB]` — is refused with this adapter's `INVALID_FILTER` / 400 error rather than posted or silently dropped into an unfiltered aggregate.

--- a/.changeset/7752-analytics-where-lowering.md
+++ b/.changeset/7752-analytics-where-lowering.md
@@ -1,5 +1,5 @@
 ---
-'@object-ui/data-objectstack': patch
+'@object-ui/data-objectstack': minor
 ---
 
 Array filters on analytics aggregates were posted un-lowered and refused by the runtime with 400; they are now lowered to the canonical `FilterCondition` before the wire.

--- a/packages/data-objectstack/src/aggregate-filter-lowering.test.ts
+++ b/packages/data-objectstack/src/aggregate-filter-lowering.test.ts
@@ -7,45 +7,63 @@
  */
 
 /**
- * `aggregate()` lowers rule-shaped filter arrays before the analytics wire.
+ * `aggregate()` lowers an array filter through `parseFilterAST` before the
+ * analytics wire, so the posted `where` is the `FilterCondition` the protocol
+ * declares.
  *
- * WHY THIS FILE EXISTS (objectui#6302). `find()` has translated
- * `[{ field, operator, value }, ...]` into the server's filter AST since the
- * day `convertQueryParams` learned to — see `filter-entry-translation.test.ts`,
- * which runs every shape down both `find()` routes. The analytics path did not:
- * `aggregate()` assigned `payload.where = params.filter` verbatim and posted it
- * to `/analytics/query`.
+ * WHY THIS FILE EXISTS, AND WHY IT MOVED (objectui#6302, then objectui#7752 /
+ * objectstack#15828). `find()` has translated `[{ field, operator, value }, ...]`
+ * into the server's filter AST since the day `convertQueryParams` learned to —
+ * see `filter-entry-translation.test.ts`. The analytics path did not: it posted
+ * `params.filter` verbatim. #6302 fixed half of that by running the same
+ * `translateFilterArray`, and this file pinned the AST it produced as the value
+ * on the wire.
  *
- * The two doors are not equally forgiving, which is why the gap had a
- * user-visible end. `lowerAnalyticsWhere` in `@objectstack/service-analytics`
- * — shared by BOTH aggregation strategies, so there is no deployment where the
- * lenient reading applies — accepts AST tuples and THROWS on an array of rule
- * objects ("[analytics] received a 'where' array that is not a filter"). The
- * spec's own `isFilterAST` gate says the same thing about the same value, and
- * the tests below assert on it directly so the refusal is pinned by the
- * contract rather than by a message string:
+ * That pin named the wrong door. `translateFilterArray` normalises rule objects
+ * into AST tuples; the result is still a `FilterArray`, and a `FilterArray` is
+ * input-only sugar (objectstack#5158 ruling C, `data/filter.zod.ts`): it is
+ * lowered to a `FilterCondition` at the single sink `parseFilterAST` the moment
+ * it arrives, and only the lowered condition travels further. `where` on a query
+ * is a `FilterCondition` and stays one. The door #6302 measured —
+ * `lowerAnalyticsWhere` in `@objectstack/service-analytics` (objectstack#5334) —
+ * is the IN-PROCESS door and sits one hop too late: `POST /analytics/query`
+ * parses the body with `AnalyticsQueryRequestSchema` first, whose `where` is
+ * `FilterConditionSchema`, so every array shape answered `400 Invalid
+ * AnalyticsQuery body: where: ...`. An `element:number` (array-only since
+ * objectstack#12039) therefore rendered into its error state on any deployment
+ * served through the runtime route, and the only surviving authoring form was
+ * the MongoDB-style record — the exact form objectui#6206 ruling B retired.
  *
- *   isFilterAST([{ field: 'stage', operator: 'equals', value: 'won' }])  // false
- *   isFilterAST(['stage', '=', 'won'])                                   // true
+ * So the assertions below are re-pointed one hop, and TWO properties are pinned
+ * rather than one:
  *
- * Net effect before the fix: a stored `ViewFilterRule[]` that a LIST renders
- * correctly rendered `element:number` into its error state on every
- * analytics-capable deployment — and analytics is the default one, because the
- * CLI always loads it.
+ * 1. The posted `where` is `parseFilterAST`'s own output for the same filter —
+ *    read from the spec's function, never hand-written here, so this file cannot
+ *    drift away from the contract it exists to pin.
+ * 2. The whole posted payload passes `AnalyticsQueryRequestSchema.safeParse` —
+ *    the runtime route's own gate, run on the real body. That is the hop nobody
+ *    had a test for on either side of the repo boundary, which is how the two
+ *    declarations diverged unnoticed in the first place.
  *
- * The fix reuses `translateFilterArray` rather than adding a second lowering.
- * That is load-bearing and is asserted as such below: the cross-path parity
- * block requires `aggregate()`'s `where` and `find()`'s `filter=` to be the
- * SAME value for the same input, so the two paths cannot drift the way the two
- * `find()` routes once did. Non-array filters are deliberately untouched — the
- * MongoDB-style object this branch was written for is already what the
- * analytics endpoint accepts, and translating it would be a semantic change
- * this fix does not make.
+ * One lowering, not two, is still load-bearing and still asserted: the
+ * cross-path block requires `aggregate()`'s `where` to be exactly
+ * `parseFilterAST` applied to the AST `find()` puts on its `filter=` query
+ * string. The two doors differ by that lowering and by nothing else — `$filter`
+ * is a declared door where an array may arrive, a POST body is transport.
+ *
+ * Non-array filters are deliberately untouched: the MongoDB-style object this
+ * branch was written for is already a `FilterCondition`.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { isFilterAST } from '@objectstack/spec/data';
-import { ObjectStackAdapter, clearSharedDiscoveryCache, isMalformedFilterError } from './index';
+import { isFilterAST, parseFilterAST } from '@objectstack/spec/data';
+import { AnalyticsQueryRequestSchema } from '@objectstack/spec/api';
+import {
+  ObjectStackAdapter,
+  clearSharedDiscoveryCache,
+  isMalformedFilterError,
+  UnlowerableAnalyticsFilterError,
+} from './index';
 
 /** Rows that carry the requested measure, so nothing degrades to the fallback. */
 const ANALYTICS_ROWS = { rows: [{ amount_sum: 150 }] };
@@ -88,11 +106,17 @@ const SUM_BY_STAGE = { function: 'sum', field: 'amount', groupBy: '_all' };
  */
 const HAS_NO_WHERE = Symbol('no where key');
 
-async function whereOnWire(filter: unknown): Promise<unknown> {
+/** The whole body posted to `/analytics/query` — what the route's gate parses. */
+async function payloadOnWire(filter?: unknown): Promise<any> {
   const { adapter, analyticsBodies } = makeAdapter();
-  await adapter.aggregate('opportunity', { ...SUM_BY_STAGE, filter });
+  const params = filter === undefined ? SUM_BY_STAGE : { ...SUM_BY_STAGE, filter };
+  await adapter.aggregate('opportunity', params);
   expect(analyticsBodies).toHaveLength(1);
-  const body = analyticsBodies[0];
+  return analyticsBodies[0];
+}
+
+async function whereOnWire(filter: unknown): Promise<unknown> {
+  const body = await payloadOnWire(filter);
   return 'where' in body ? body.where : HAS_NO_WHERE;
 }
 
@@ -105,33 +129,40 @@ async function filterOnFindWire(filter: unknown): Promise<unknown> {
   return raw === null ? HAS_NO_WHERE : JSON.parse(raw);
 }
 
-describe('aggregate() lowers a rule-shaped filter array before `client.analytics.query`', () => {
+describe('aggregate() posts the LOWERED FilterCondition, not the filter array', () => {
   beforeEach(() => clearSharedDiscoveryCache());
 
-  it('translates a single rule into an AST tuple', async () => {
-    const where = await whereOnWire([{ field: 'stage', operator: 'equals', value: 'won' }]);
-    expect(where).toEqual(['stage', '=', 'won']);
+  it('lowers a single rule the way the spec lowers its AST equivalent', async () => {
+    // Expected value read from the spec's own sink, on the AST this rule
+    // translates to. A hand-written `{ stage: 'won' }` would pin this file to
+    // today's `parseFilterAST` output instead of to `parseFilterAST`.
+    expect(await whereOnWire([{ field: 'stage', operator: 'equals', value: 'won' }]))
+      .toEqual(parseFilterAST(['stage', '=', 'won']));
   });
 
-  it('the lowered value passes the AST gate the raw one fails', async () => {
+  it('posts a condition, never the FilterArray the wire refuses', async () => {
     const rules = [{ field: 'stage', operator: 'equals', value: 'won' }];
-    // Negative control: this is what used to reach the wire, and it is exactly
-    // the value `lowerAnalyticsWhere` refuses. Without this line the test above
-    // could pass against a lowering that produced some OTHER non-AST shape.
+    // What used to reach the wire, at both stages of the old pipeline: the raw
+    // rules, and the AST `translateFilterArray` normalises them into. Neither is
+    // a `FilterCondition`, and `AnalyticsQueryRequestSchema` refuses both.
     expect(isFilterAST(rules)).toBe(false);
-    expect(isFilterAST(await whereOnWire(rules) as any)).toBe(true);
+    expect(isFilterAST(['stage', '=', 'won'])).toBe(true);
+
+    const where = await whereOnWire(rules);
+    expect(Array.isArray(where)).toBe(false);
+    expect(where).toEqual({ stage: 'won' });
   });
 
-  it('maps operator aliases the way the find() path does', async () => {
+  it('maps operator aliases the way the find() path does, then lowers', async () => {
     expect(await whereOnWire([{ field: 'amount', operator: 'greater_than_or_equal', value: 3 }]))
-      .toEqual(['amount', '>=', 3]);
+      .toEqual(parseFilterAST(['amount', '>=', 3]));
   });
 
-  it('joins several rules with `and`', async () => {
+  it('joins several rules with `and`, lowered', async () => {
     expect(await whereOnWire([
       { field: 'stage', operator: 'eq', value: 'won' },
       { field: 'amount', operator: 'gt', value: 100 },
-    ])).toEqual(['and', ['stage', '=', 'won'], ['amount', '>', 100]]);
+    ])).toEqual(parseFilterAST(['and', ['stage', '=', 'won'], ['amount', '>', 100]]));
   });
 
   it('lowers rules SPREAD into a logical node, not just top-level ones', async () => {
@@ -140,9 +171,8 @@ describe('aggregate() lowers a rule-shaped filter array before `client.analytics
     // check would call the whole thing "already AST" and ship the rule raw.
     const composite = ['and', { field: 'stage', operator: 'eq', value: 'won' }, ['amount', '>', 100]];
     expect(isFilterAST(composite as any)).toBe(false);
-    const where = await whereOnWire(composite);
-    expect(where).toEqual(['and', ['stage', '=', 'won'], ['amount', '>', 100]]);
-    expect(isFilterAST(where as any)).toBe(true);
+    expect(await whereOnWire(composite))
+      .toEqual(parseFilterAST(['and', ['stage', '=', 'won'], ['amount', '>', 100]]));
   });
 
   it('produces the SAME `where` as the AST-tuple equivalent (the acceptance criterion)', async () => {
@@ -152,26 +182,49 @@ describe('aggregate() lowers a rule-shaped filter array before `client.analytics
   });
 });
 
-describe('aggregate() leaves every already-correct filter shape byte-unchanged', () => {
+describe('the posted payload passes the route\'s own gate, AnalyticsQueryRequestSchema', () => {
   beforeEach(() => clearSharedDiscoveryCache());
 
-  it('an AST tuple passes through untouched', async () => {
-    expect(await whereOnWire(['stage', '=', 'won'])).toEqual(['stage', '=', 'won']);
+  // The hop objectui#6302 never measured. `POST /analytics/query` runs exactly
+  // this parse on the body BEFORE any normalisation, so a payload this schema
+  // refuses is a 400 in production, whatever the in-process door would accept.
+  const GATED_CASES: Array<[string, unknown]> = [
+    ['a comparison tuple', ['stage', '=', 'won']],
+    ['a rule array', [{ field: 'stage', operator: 'equals', value: 'won' }]],
+    ['a logical group', ['and', ['stage', '=', 'won'], ['amount', '>', 100]]],
+    ['a bare list of nodes', [['stage', '=', 'won'], ['amount', '>', 100]]],
+    ['a record-shaped filter', { stage: 'won' }],
+    ['a record-shaped filter with an operator object', { amount: { $gt: 100 } }],
+    ['an empty array', []],
+  ];
+
+  for (const [name, filter] of GATED_CASES) {
+    it(`accepts the body built from ${name}`, async () => {
+      const body = await payloadOnWire(filter);
+      const parsed = AnalyticsQueryRequestSchema.safeParse(body);
+      expect(parsed.success).toBe(true);
+    });
+  }
+
+  it('accepts the body built with no filter at all', async () => {
+    expect(AnalyticsQueryRequestSchema.safeParse(await payloadOnWire()).success).toBe(true);
   });
 
-  it('a logical AST node passes through untouched', async () => {
-    expect(await whereOnWire(['or', ['stage', '=', 'won'], ['stage', '=', 'lost']]))
-      .toEqual(['or', ['stage', '=', 'won'], ['stage', '=', 'lost']]);
+  it('refuses the un-lowered array this branch used to post (the negative control)', async () => {
+    // Without this row the rows above could pass against a gate that accepts
+    // anything. This is the exact body objectstack#15828 measured a 400 for.
+    const body = await payloadOnWire(['stage', '=', 'won']);
+    const unlowered = { ...body, where: ['stage', '=', 'won'] };
+    expect(AnalyticsQueryRequestSchema.safeParse(unlowered).success).toBe(false);
   });
+});
 
-  it('a legacy nested array of nodes passes through untouched', async () => {
-    expect(await whereOnWire([['stage', '=', 'won'], ['amount', '>', 100]]))
-      .toEqual([['stage', '=', 'won'], ['amount', '>', 100]]);
-  });
+describe('aggregate() leaves every already-lowered filter shape byte-unchanged', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
 
   it('a record-shaped (MongoDB-style) filter is NOT translated', async () => {
-    // The shape this branch was written for. `/analytics/query` accepts it, so
-    // lowering it here would be a semantic change, not a fix.
+    // The shape this branch was written for, and what `AnalyticsQuerySchema.where`
+    // declares. Lowering it would be a semantic change, not a fix.
     expect(await whereOnWire({ stage: 'won' })).toEqual({ stage: 'won' });
   });
 
@@ -179,24 +232,27 @@ describe('aggregate() leaves every already-correct filter shape byte-unchanged',
     expect(await whereOnWire({ amount: { $gt: 100 } })).toEqual({ amount: { $gt: 100 } });
   });
 
-  it('an empty array still reaches the wire as an empty array', async () => {
-    // Unchanged on purpose: `if (params.filter)` is truthy for `[]`, and this
-    // fix moves no boundary it did not have to move.
-    expect(await whereOnWire([])).toEqual([]);
+  it('an empty array posts no `where` at all', async () => {
+    // Pinned by objectui#7752: `parseFilterAST([])` is `undefined`, and the
+    // in-process door reads `[]` the same way ("`[]` is no filter",
+    // objectstack#5334). Before the lowering this posted a literal `[]`.
+    expect(await whereOnWire([])).toBe(HAS_NO_WHERE);
   });
 
   it('no filter means no `where` key at all', async () => {
-    const { adapter, analyticsBodies } = makeAdapter();
-    await adapter.aggregate('opportunity', SUM_BY_STAGE);
-    expect(analyticsBodies[0]).not.toHaveProperty('where');
+    const body = await payloadOnWire();
+    expect(body).not.toHaveProperty('where');
   });
 });
 
 describe('the find() path is unchanged, and the two paths share one lowering', () => {
   beforeEach(() => clearSharedDiscoveryCache());
 
-  // Each row is one input. Both sides are measured on the wire, so a change to
-  // either path that the other does not make turns this red.
+  // Each row is one input. `find()` puts the AST on its `$filter` query string —
+  // a declared door where a `FilterArray` may arrive — and the analytics body
+  // carries that same AST lowered by the sink. So the two paths differ by
+  // `parseFilterAST` and by nothing else; a change to either that the other does
+  // not make turns this red.
   const SHARED_CASES: Array<[string, unknown]> = [
     ['a single rule', [{ field: 'stage', operator: 'equals', value: 'won' }]],
     ['an aliased operator', [{ field: 'amount', operator: 'greater_than_or_equal', value: 3 }]],
@@ -207,29 +263,84 @@ describe('the find() path is unchanged, and the two paths share one lowering', (
     ['rules spread into a logical node', ['and', { field: 'stage', operator: 'eq', value: 'won' }, ['amount', '>', 100]]],
     ['an AST tuple', ['stage', '=', 'won']],
     ['a logical AST node', ['or', ['stage', '=', 'won'], ['stage', '=', 'lost']]],
+    ['a bare list of nodes', [['stage', '=', 'won'], ['amount', '>', 100]]],
   ];
 
   for (const [name, filter] of SHARED_CASES) {
-    it(`aggregate() and find() agree on ${name}`, async () => {
+    it(`aggregate() posts find()'s AST, lowered, for ${name}`, async () => {
       const viaFind = await filterOnFindWire(filter);
       expect(viaFind).not.toBe(HAS_NO_WHERE);
-      expect(await whereOnWire(filter)).toEqual(viaFind);
+      expect(await whereOnWire(filter)).toEqual(parseFilterAST(viaFind));
     });
   }
 
   it('find() still lowers a single rule exactly as it did before', async () => {
     // The `find()` half of the card's acceptance, stated independently of
     // `aggregate()` so a regression there cannot hide behind the parity rows.
+    // `$filter` is a declared door: the AST arrives there and is lowered by the
+    // metadata protocol on the far side, so this side stays an array.
     expect(await filterOnFindWire([{ field: 'stage', operator: 'equals', value: 'won' }]))
       .toEqual(['stage', '=', 'won']);
   });
 
-  it('find() still sends no filter for an empty array', async () => {
-    // The one place the two paths legitimately differ: `convertQueryParams`
-    // drops an empty filter, the analytics payload keeps `[]`. Recorded, not
-    // reconciled — reconciling it is a behaviour change this card does not make.
+  it('neither path sends a filter for an empty array', async () => {
+    // The two paths used to disagree here — `convertQueryParams` dropped an
+    // empty filter while the analytics payload kept `[]`. The lowering settles
+    // it: `parseFilterAST([])` is `undefined`, so both now send nothing.
     expect(await filterOnFindWire([])).toBe(HAS_NO_WHERE);
-    expect(await whereOnWire([])).toEqual([]);
+    expect(await whereOnWire([])).toBe(HAS_NO_WHERE);
+  });
+});
+
+describe('an array the sink cannot lower is refused before the wire, never dropped', () => {
+  beforeEach(() => clearSharedDiscoveryCache());
+
+  it('refuses an infix join instead of posting an unfiltered aggregate', async () => {
+    // `['stage','=','won'] or ['stage','=','lost']` written infix. The spec's
+    // gate rejects it and `parseFilterAST` answers `undefined` for it — and
+    // `undefined` on this path would mean "no `where`", i.e. an aggregate over
+    // EVERY row returned as a confident number under a filtered question.
+    const infix = [['stage', '=', 'won'], 'or', ['stage', '=', 'lost']];
+    expect(isFilterAST(infix as any)).toBe(false);
+    expect(parseFilterAST(infix as any)).toBeUndefined();
+
+    const { adapter, analyticsBodies, urls } = makeAdapter();
+    const err = await adapter
+      .aggregate('opportunity', { ...SUM_BY_STAGE, filter: infix })
+      .then(() => null, (e) => e);
+
+    expect(err).toBeInstanceOf(UnlowerableAnalyticsFilterError);
+    // Same `INVALID_FILTER` / 400 envelope its two siblings carry, so a widget
+    // renders "this filter is malformed" rather than "check your connection".
+    expect((err as UnlowerableAnalyticsFilterError).code).toBe('INVALID_FILTER');
+    expect((err as UnlowerableAnalyticsFilterError).httpStatus).toBe(400);
+    expect(isMalformedFilterError(err)).toBe(true);
+    expect((err as UnlowerableAnalyticsFilterError).filter).toBe(infix);
+    expect((err as UnlowerableAnalyticsFilterError).resource).toBe('opportunity');
+
+    // Nothing was posted, and the client-side fallback did not answer it either.
+    expect(analyticsBodies).toHaveLength(0);
+    expect(urls.some((u) => u.includes('/analytics/query'))).toBe(false);
+    expect(urls.some((u) => u.includes('/data/opportunity'))).toBe(false);
+  });
+
+  it('refuses a tuple the sink itself throws on, keeping the sink\'s words', async () => {
+    // `isFilterAST` accepts this two-element tuple; `parseFilterAST` refuses it
+    // ("comparand is undefined"). Re-dressed in this adapter's envelope rather
+    // than escaping as a bare `Error` that reads like a transport failure.
+    const truncated = ['stage', '='];
+    expect(isFilterAST(truncated as any)).toBe(true);
+    expect(() => parseFilterAST(truncated as any)).toThrow();
+
+    const { adapter, analyticsBodies, urls } = makeAdapter();
+    const err = await adapter
+      .aggregate('opportunity', { ...SUM_BY_STAGE, filter: truncated })
+      .then(() => null, (e) => e);
+
+    expect(err).toBeInstanceOf(UnlowerableAnalyticsFilterError);
+    expect(isMalformedFilterError(err)).toBe(true);
+    expect(analyticsBodies).toHaveLength(0);
+    expect(urls.some((u) => u.includes('/data/opportunity'))).toBe(false);
   });
 });
 

--- a/packages/data-objectstack/src/aggregate-spec-shape-where.test.ts
+++ b/packages/data-objectstack/src/aggregate-spec-shape-where.test.ts
@@ -56,7 +56,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { isFilterAST } from '@objectstack/spec/data';
+import { isFilterAST, parseFilterAST } from '@objectstack/spec/data';
 import {
   ObjectStackAdapter,
   clearSharedDiscoveryCache,
@@ -167,14 +167,22 @@ describe('the spec-shape branch is the branch under test — asserted on the wir
     expect(r.urls.some((u) => u === 'http://localhost:3000/api/v1/data/opportunity/query')).toBe(true);
   });
 
-  it('legacy analytics params go to POST /analytics/query — the OTHER branch, still lowering (#6302)', async () => {
+  it('legacy analytics params go to POST /analytics/query — the OTHER branch, still lowering (#6302, #7752)', async () => {
     // The control that keeps "we now refuse" from meaning "we now refuse
-    // everything": the analytics branch is untouched by this change and still
-    // LOWERS the very rule array the spec-shape branch refuses.
+    // everything": the analytics branch is untouched by THIS file's ruling and
+    // still LOWERS the very rule array the spec-shape branch refuses.
+    //
+    // What that branch lowers TO moved one hop in objectui#7752: it used to post
+    // the AST tuple, and now posts the `FilterCondition` `parseFilterAST` makes
+    // of it, because a POST body's `where` is transport and a `FilterArray` is
+    // input-only sugar (objectstack#5158 ruling C). The refusal this file pins
+    // is unaffected — the two branches still take their filter by different
+    // names and answer it differently — so only the expected value moves, read
+    // from the spec's own sink rather than written out here.
     const r = await run({ function: 'sum', field: 'amount', groupBy: '_all', filter: RULE_WHERE });
     expect(r.error).toBeNull();
     expect(r.door).toBe('analytics');
-    expect(r.analyticsBodies[0].where).toEqual(['stage', '=', 'won']);
+    expect(r.analyticsBodies[0].where).toEqual(parseFilterAST(['stage', '=', 'won']));
     expect(r.specShapeBodies).toHaveLength(0);
   });
 

--- a/packages/data-objectstack/src/index.ts
+++ b/packages/data-objectstack/src/index.ts
@@ -13,12 +13,14 @@ import type { DroppedFieldsEvent } from '@objectstack/spec/data';
 // is read off the pin instead of hand-copied here (a hand copy is the drift
 // this seam already paid for once — see `DroppedFieldsEvent`'s comment below).
 import { DroppedFieldsEventSchema } from '@objectstack/spec/data';
-// #6825 — the spec's OWN filter-AST gate, imported as a VALUE for the same
-// reason: `aggregate()`'s spec-shape branch decides whether a `where` is a
-// filter by asking the contract, not by a hand-rolled shape sniff that could
-// disagree with the door it is protecting. Same predicate the server ingress
-// runs, so the producer-side refusal and the wire-side one cannot drift.
-import { isFilterAST } from '@objectstack/spec/data';
+// #6825 / #7752 — the spec's OWN filter-AST gate and its OWN lowering sink,
+// imported as VALUES for the same reason: `aggregate()` decides whether a
+// `where` is a filter, and turns a `FilterArray` into the `FilterCondition` the
+// wire declares, by asking the contract — not by a hand-rolled shape sniff or a
+// second lowering that could disagree with the door it is feeding. Same
+// predicate and same sink the server ingress runs, so the producer-side refusal
+// and the wire-side one cannot drift.
+import { isFilterAST, parseFilterAST } from '@objectstack/spec/data';
 import type { ApiError } from '@objectstack/spec/api';
 // #4237 — the metadata save door's advisory reader, shared with `MetadataClient`
 // rather than forked. ONE reader, two call sites: the other client class calls it
@@ -267,6 +269,59 @@ function assertSpecShapeWhereIsFilterAst(where: unknown, resource: string): void
   throw new UnloweredAggregateWhereError(where, resource);
 }
 
+/**
+ * An ARRAY `filter` that reached `aggregate()`'s ANALYTICS branch and that the
+ * protocol's lowering sink cannot turn into a `FilterCondition` — an infix join
+ * (`[condA, 'or', condB]`) above all.
+ *
+ * WHY A REFUSAL AND NOT A DROP (objectui#7752; maintainer ruling of 2026-09-05
+ * on objectstack#15828, which reads that card as a frontend defect: the
+ * protocol is right and the adapter was wrong). `parseFilterAST` answers
+ * `undefined` for an array it cannot read, and `undefined` here would post a
+ * body with NO `where` at all: the aggregate would then be computed over every
+ * row and returned as a confident number, with the author's predicate gone and
+ * nothing on the wire to say it went. That is the same silent over-fetch
+ * {@link MalformedFilterError} exists to stop, one door further along.
+ *
+ * Deliberately NOT {@link UnloweredAggregateWhereError}, whose meaning is not
+ * widened to cover this: that one guards the SPEC-SHAPE branch, whose `where`
+ * is posted verbatim and must therefore have been lowered by its PRODUCER
+ * (objectui#6825, ruling 2026-08-30 option A — refuse, never lower). This
+ * branch's `filter` is authoring input and IS lowered here, at the door the
+ * protocol names; this error covers only the input that sink cannot lower.
+ *
+ * Carries the `INVALID_FILTER` / 400 pair both siblings carry, so
+ * `isMalformedFilterError()` recognises it and a failed widget renders "this
+ * filter is malformed" rather than "check your connection" (objectui#3066).
+ */
+export class UnlowerableAnalyticsFilterError extends Error {
+  readonly code = 'INVALID_FILTER';
+  readonly httpStatus = 400;
+  /** The filter as received, so a caller can log what its producer actually built. */
+  readonly filter: unknown;
+  /** The object `aggregate()` was called for. */
+  readonly resource: string;
+  constructor(filter: unknown, resource: string, detail?: string) {
+    const shown = JSON.stringify(filter) ?? String(filter);
+    super(
+      `aggregate('${resource}'): the analytics branch received a \`filter\` array `
+      + `that \`parseFilterAST\` cannot lower into a FilterCondition — ${shown}.`
+      + (detail ? ` (${detail})` : '')
+      + ' `where` on the analytics wire is a FilterCondition (`AnalyticsQuerySchema`, '
+      + '@objectstack/spec data/analytics.zod.ts), and a FilterArray is input-only '
+      + 'sugar lowered into one at the single sink `parseFilterAST` '
+      + '(data/filter.zod.ts, objectstack#5158 ruling C). Lowerable shapes are a '
+      + "comparison tuple (['stage','=','won']), a logical node (['and',[..],[..]]), "
+      + 'an array of such nodes, and a ViewFilterRule[] this adapter translates '
+      + "first. An infix join ([condA, 'or', condB]) is none of them. Nothing was "
+      + 'sent to the server, so no unfiltered numbers came back.',
+    );
+    this.name = 'UnlowerableAnalyticsFilterError';
+    this.filter = filter;
+    this.resource = resource;
+  }
+}
+
 function objectFilterEntryToAST(entry: any): [string, string, any] | null {
   if (!entry || typeof entry !== 'object') return null;
   // `field` only. A `?? entry.name` fallback lived here from the day the
@@ -418,6 +473,74 @@ function translateFilterToAST(filter: unknown): unknown | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Lower an analytics `filter` into the `where` the analytics wire declares.
+ *
+ * THE CONTRACT (objectstack#5158 ruling C, `data/filter.zod.ts`'s `FilterArray`
+ * docblock, verbatim): "A `FilterArray` is not a storage shape and not a
+ * protocol shape. It is lowered to a `FilterCondition` at the single sink
+ * `parseFilterAST` (`@objectstack/spec/data`) the moment it arrives, and only
+ * the lowered `FilterCondition` travels any further. `where` on a query is a
+ * `FilterCondition` and stays one." A POST body is transport, not one of the
+ * declared doors where an array may arrive (React block props, `FilterBuilder`,
+ * the REST `$filter` query string) — so the lowering happens HERE, before the
+ * body is built, and only a `FilterCondition` goes out.
+ *
+ * Three shapes, three answers:
+ *
+ * - A NON-array filter is already a `FilterCondition` — the MongoDB-style
+ *   object this branch was written for, and what `AnalyticsQuerySchema.where`
+ *   declares. Passed through untouched; translating it here would be a semantic
+ *   change, not a fix.
+ * - An EMPTY array is no filter, so no `where` key is posted at all. Decided
+ *   here rather than inferred: `parseFilterAST([])` is `undefined`, and the
+ *   in-process analytics door reads `[]` the same way ("`[]` is no filter",
+ *   objectstack#5334). The two readings agree, and this pins that they do.
+ * - Every other array is first normalised by `translateFilterArray` — the SAME
+ *   function `find()` runs in `convertQueryParams`, so one stored filter cannot
+ *   mean two things on two paths — and then lowered by the sink.
+ *
+ * Anything the sink cannot lower is refused, never posted and never dropped:
+ * see {@link UnlowerableAnalyticsFilterError} for why `undefined` on the wire
+ * would be the worst of the three possible answers.
+ */
+function lowerAnalyticsFilterForWire(filter: unknown, resource: string): unknown | undefined {
+  if (!Array.isArray(filter)) return filter;
+  if (filter.length === 0) return undefined;
+
+  // Throws `MalformedFilterError` on an untranslatable rule entry, exactly as it
+  // does on the `find()` path. Raised from here — outside `aggregate()`'s
+  // analytics `try` — so the refusal reaches the caller as itself instead of
+  // being classified as an unknown analytics failure and answered by the
+  // client-side fallback.
+  const ast = translateFilterArray(filter);
+
+  // The spec's own predicate, not a shape sniff: an array it rejects is an array
+  // the sink cannot read, and `parseFilterAST` would answer `undefined` for it.
+  if (!isFilterAST(ast)) throw new UnlowerableAnalyticsFilterError(filter, resource);
+
+  let lowered: unknown;
+  try {
+    lowered = parseFilterAST(ast);
+  } catch (e) {
+    // The sink's own refusal (a comparison tuple missing its comparand, say).
+    // Re-dressed in this adapter's `INVALID_FILTER` / 400 envelope, its message
+    // kept, so a widget can tell a malformed filter from a dead connection.
+    throw new UnlowerableAnalyticsFilterError(
+      filter, resource, e instanceof Error ? e.message : String(e),
+    );
+  }
+  // Belt to the gate's braces: the gate said this array is a filter, so the sink
+  // owes a condition. `undefined` here would post an unfiltered aggregate under
+  // a filtered question, so it is a refusal rather than a value.
+  if (lowered === undefined) {
+    throw new UnlowerableAnalyticsFilterError(
+      filter, resource, '`parseFilterAST` answered `undefined` for a non-empty filter',
+    );
+  }
+  return lowered;
 }
 
 /**
@@ -4951,6 +5074,17 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
       return [];
     }
 
+    // Lowered BEFORE the `try` below, deliberately. A filter this adapter
+    // refuses is a defect in the request we were asked to build, not an
+    // analytics failure: raised inside the `try`, it would be handed to
+    // `classifyAnalyticsFailure`, come back `unknown`, and be answered by the
+    // client-side fallback — which would re-read the same rows through `find()`
+    // and hand the caller plausible numbers for a question the adapter had
+    // already decided it could not ask.
+    const analyticsWhere = params.filter
+      ? lowerAnalyticsFilterForWire(params.filter, resource)
+      : undefined;
+
     try {
       // Build measure name in the format expected by the backend analytics
       // service (memory-analytics / cube).  For 'count' the measure key is
@@ -4972,36 +5106,29 @@ export class ObjectStackAdapter<T = unknown> implements DataSource<T> {
         // When groupBy is '_all' no dimensions are needed (single-bucket).
         dimensions: params.groupBy && params.groupBy !== '_all' ? [params.groupBy] : [],
       };
-      if (params.filter) {
-        // Dashboard widgets emit MongoDB-style FilterCondition (per
-        // spec/ui/dashboard.zod.ts). Send via the canonical `where`
-        // field of the analytics endpoint, matching the unified Query
-        // DSL (spec/data/query.zod.ts).
-        //
-        // An ARRAY filter goes through the same `translateFilterArray` the
-        // `find()` path runs in `convertQueryParams`, because an authored
-        // `ViewFilterRule[]` reaches this method exactly as it reaches that
-        // one. It used to ship RAW from here, and the analytics door is
-        // stricter than the data door: `lowerAnalyticsWhere`
-        // (`@objectstack/service-analytics`, shared by both aggregation
-        // strategies) THROWS "[analytics] received a 'where' array that is
-        // not a filter" on an array of rule objects, while accepting AST
-        // tuples. So a stored filter that a list renders correctly rendered
-        // `element:number` into its error state on every analytics-capable
-        // deployment — and analytics is the default one, since the CLI always
-        // loads it (objectui#6302).
-        //
-        // One lowering, not two: the same function, so the analytics path and
-        // the `find()` path cannot disagree about one stored filter — which is
-        // the whole reason `translateFilterArray` was made a single definition
-        // (see its header). Non-array filters keep passing through untouched:
-        // the MongoDB-style object this branch was written for is what
-        // `/analytics/query` already accepts, and translating it here would be
-        // a semantic change this fix is expressly not making.
-        payload.where = Array.isArray(params.filter)
-          ? translateFilterArray(params.filter)
-          : params.filter;
-      }
+      // `where` is a `FilterCondition` here, always — see
+      // `lowerAnalyticsFilterForWire`, which did the lowering above. Dashboard
+      // widgets already emit one (spec/ui/dashboard.zod.ts) and it passes
+      // through; an authored array is lowered through `parseFilterAST`, the
+      // single sink the protocol names, so what leaves this method is what
+      // `AnalyticsQuerySchema.where` declares.
+      //
+      // This branch used to post the array itself, normalised into filter AST
+      // but not lowered, and named `lowerAnalyticsWhere` as its door. That was
+      // the wrong hop: `lowerAnalyticsWhere` (`@objectstack/service-analytics`,
+      // objectstack#5334) is the door for IN-PROCESS callers, and objectui#6302's
+      // gate measured that function. The wire's door is one hop earlier —
+      // `POST /analytics/query` parses the body with `AnalyticsQueryRequestSchema`
+      // before any normalisation runs — and it answered `400 Invalid
+      // AnalyticsQuery body: where: ...` to every array shape, so an
+      // `element:number` (array-only since objectstack#12039) rendered into its
+      // error state on any deployment served through the runtime route
+      // (objectui#7752, objectstack#15828).
+      //
+      // `undefined` means "no filter to send", not "send nothing meaningful":
+      // only a filter that was absent or empty reaches here as `undefined`, and
+      // an array the sink cannot lower was refused above rather than dropped.
+      if (analyticsWhere !== undefined) payload.where = analyticsWhere;
 
       const data = await this.client.analytics.query(payload);
 


### PR DESCRIPTION
Fixes #7752

Executes the maintainer ruling recorded on objectstack-ai/objectstack#15828 (2026-09-05, verbatim 「15828 按前端缺陷处理」): the protocol is right and this adapter was wrong. No `@objectstack/spec` change, and no widening of `AnalyticsQuerySchema.where` — that direction is objectstack#5158's rejected option A.

## What was broken

`aggregate()`'s analytics branch built `payload.where = translateFilterArray(params.filter)` for an array filter. `translateFilterArray` only normalises rule objects into AST tuples; the result is still a `FilterArray`. Per `@objectstack/spec` `data/filter.zod.ts`, the `FilterArray` docblock (objectstack#5158 ruling C, verbatim):

> A `FilterArray` is not a storage shape and not a protocol shape. It is lowered to a `FilterCondition` at the single sink `parseFilterAST` (`@objectstack/spec/data`) the moment it arrives, and only the lowered `FilterCondition` travels any further. `where` on a query is a `FilterCondition` and stays one … no driver, no transport, no stored row — ever has to understand two filter dialects.

The declared doors where an array may arrive are React block props, `FilterBuilder`, and the REST `$filter` query string. A POST body is transport, so `POST /analytics/query` parses the body with `AnalyticsQueryRequestSchema` (`where: FilterConditionSchema`) before any normalisation and answered `400 Invalid AnalyticsQuery body: where: …` to every array shape. An `element:number` (array-only since objectstack#12039) or an `object-metric` with an array `filter` therefore rendered into its error state on any deployment served through the runtime route, and the only surviving authoring form was the MongoDB-style record — the exact form #6206 ruling B retired.

The branch's own comment showed the misreading: it named `lowerAnalyticsWhere` (`@objectstack/service-analytics`, objectstack#5334) as the wire's door. That is the in-process door, one hop later, and it is the function #6302's gate measured. The comment is rewritten to name the route hop.

## The change

`packages/data-objectstack/src/index.ts`, analytics branch only:

- `parseFilterAST` is imported beside the `isFilterAST` this file already imported from `@objectstack/spec/data`, and a new `lowerAnalyticsFilterForWire` does the lowering: a non-array filter passes through (it is already a `FilterCondition`), and any other array is normalised by the same `translateFilterArray` the `find()` path runs, then lowered by the sink.
- **Empty case pinned:** `parseFilterAST([])` is `undefined`, so an empty authored filter posts no `where` key at all — the same reading the in-process door gives `[]` ("`[]` is no filter", objectstack#5334). It used to post a literal `[]`.
- **Refusal, never a drop:** an array the sink cannot lower — an infix join `[condA, 'or', condB]` above all — throws a new `UnlowerableAnalyticsFilterError` carrying the same `INVALID_FILTER` / 400 envelope `MalformedFilterError` and `UnloweredAggregateWhereError` carry, so `isMalformedFilterError()` recognises it. Neither of those two classes' meaning is widened: this one covers only the analytics branch's authoring input. The alternative was worse than a 400 — `parseFilterAST` answers `undefined` for such an array, and `undefined` here would post a body with no `where`, i.e. an aggregate over every row returned as a confident number under a filtered question. The sink's own throw (a truncated tuple such as `['stage','=']`, which `isFilterAST` accepts) is re-dressed in the same envelope with its message kept.
- The lowering runs **before** the analytics `try`. Raised inside it, a refusal would be handed to `classifyAnalyticsFailure`, come back `unknown`, and be answered by the client-side fallback — which re-reads the same rows through `find()` and hands the caller plausible numbers. `MalformedFilterError` reaches the caller directly now too; before, it only survived because `aggregateViaFind` happened to re-throw it.

Untouched, deliberately: `translateFilterArray`'s body, `find()`'s `$filter` query string (a declared door), the spec-shape branch and `UnloweredAggregateWhereError` (#6825, ruling 2026-08-30 option A), the record producer path, and every governed surface.

## Tests

`aggregate-filter-lowering.test.ts` re-pointed, and the route-hop pin both triage comments on objectstack#15828 asked for is added. Two properties, not one:

1. The posted `where` is **`parseFilterAST`'s own output** for the same filter, never a hand-written literal — so this file cannot drift away from the contract it pins. The cross-path block now asserts `aggregate()`'s `where` equals `parseFilterAST` applied to the AST `find()` puts on `filter=`: the two doors differ by that lowering and by nothing else.
2. The **whole posted payload passes `AnalyticsQueryRequestSchema.safeParse`** — the route's own gate, run on the real body — for a comparison tuple, a rule array, an `and` group, a bare list, both record forms, the empty array, and no filter at all. A negative control in the same block asserts the array this branch used to post is refused by that schema, so the accept rows cannot pass against a gate that accepts anything.

Plus: the infix join is refused **before** any request (the analytics body list is empty and no `/data/…` fallback call happens either), and `aggregate-spec-shape-where.test.ts`'s one row that pinned the old analytics value is re-pointed the same way — that file's own refusal is unaffected.

### Gates (exit codes captured by redirect, verdict lines quoted)

| Command | Exit | Verdict line |
|---|---|---|
| `pnpm exec vitest run packages/data-objectstack/` | 0 | `Test Files  56 passed (56)` · `Tests  748 passed (748)` |
| `pnpm exec vitest run packages/data-objectstack/ packages/plugin-charts/ packages/plugin-dashboard/ packages/components/ packages/core/` | 0 | `Test Files  544 passed (544)` · `Tests  6649 passed (6649)` |
| `pnpm --filter @object-ui/data-objectstack type-check` | 0 | `tsc --noEmit`, no diagnostics |
| `pnpm --filter @object-ui/data-objectstack lint` | 0 | `✖ 427 problems (0 errors, 427 warnings)` — warnings all pre-existing `no-explicit-any` |
| `node scripts/check-changeset-presence.mjs` | 0 | `✅ 3 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-no-major.mjs` | 0 | `✅ No changeset declares a major bump.` |
| `pnpm check:control-bytes` | 0 | `✅ check-control-bytes: OK (scanned 6315 tracked text file(s))` |
| `pnpm check:spec-symbols` | 0 | `✅ spec member citations: no comment cites a key its spec symbol does not declare.` |
| `pnpm check:phantom-deps` | 0 | `✅ Every in-scope import is declared by the package that publishes it.` |
| `pnpm check:vi-mock-specifiers` | 0 | `✅ check-vi-mock-specifiers: OK` |
| `pnpm check:self-import` / `check:unreferenced-sources` | 0 | OK |

The second row covers every in-repo `aggregate()` caller's package (`plugin-charts` `ObjectChart`, `plugin-dashboard` `ObjectMetricWidget`, `components` `elements.tsx`, `core` `ValueDataSource`). The two heavy runs went through this container's shared verify lock.

`pnpm check:readme-exports` exits 1 in this worktree with `the population COLLAPSED — packagesRead: found 4, floor is 25`: it needs every package built, and its own workflow builds first. Declared, not silently skipped — with `@object-ui/data-objectstack` built it reports zero findings for this package, and the change only **adds** an export (`UnlowerableAnalyticsFilterError`, confirmed present in `dist/index.d.ts`), which cannot make a README name stop resolving. The repo-wide run belongs to CI.

### Reverse verification

Run on the committed tree (`00acc4a9`), mutation proven on disk before the run and the restore proven after:

```
HEAD blob:        78acecd0406c629f65102b714c3386e3c7f5bef6
before mutation:  78acecd0406c629f65102b714c3386e3c7f5bef6
anchors BEFORE:   parseFilterAST(ast) call: 1 · ABLATED marker: 0
anchors AFTER:    parseFilterAST(ast) call: 0 · ABLATED marker: 1
after mutation:   c8d20a3bb258d5c823a99acfb691d7964a982121
ABLATED_TEST_EXIT=1        Tests  17 failed | 14 passed (31)
after restore:    78acecd0406c629f65102b714c3386e3c7f5bef6
diff-vs-HEAD:     []
```

With `lowered = ast` in place of `lowered = parseFilterAST(ast)`, the four `AnalyticsQueryRequestSchema` accept rows go red (`expected false to be true`) alongside the value assertions, and the truncated-tuple refusal stops firing — the new pin can fail, and it fails at the hop it exists to measure. The mutation was a source-level edit read directly by vitest (the tests import `./index`, not the package's `dist/`), so no rebuild leg applies. The script carried a `trap … EXIT INT TERM` restoring from `HEAD` by absolute path; restoration is proven by blob equality plus an empty `git diff HEAD`, not by an exit code.

### Changeset

`.changeset/7752-analytics-where-lowering.md`, `@object-ui/data-objectstack` patch, written for a user.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TezFG8ZMrNH6n5VTNpPpdH)_