### PR TITLE
feat(types)!: retire TextSchema.value as an ADR-0049 tombstone — `content` is the one spelling (objectui#6951 A1 / objectui#7016)

### DIFF
--- a/.changeset/6951-text-value-retired.md
+++ b/.changeset/6951-text-value-retired.md
@@ -1,0 +1,78 @@
+---
+'@object-ui/types': minor
+'@object-ui/components': minor
+'@object-ui/plugin-dashboard': patch
+---
+
+**Breaking for authored metadata:** `TextSchema.value` is RETIRED (objectui#6951,
+maintainer ruling A1 of 2026-09-04; objectui#7016; ADR-0049 enforce-or-remove).
+A `text` node that authors `value` no longer validates: the parse fails loudly on
+the `value` path with the explanation in the message, the TS member is a
+`?: never` tombstone so the same document is refused at compile time, and the
+renderer no longer reads the key. Write `content`.
+
+**What was measured, on this branch's base.** `TextSchema` declared two spellings
+for its one content slot — `content` (read first) and `value` (the fallback limb
+of `{schema.content || schema.value}` at `renderers/basic/text.tsx:162` and
+`:167`) — both declared by objectui#6150, whose docblock called the pair "a
+dialect, not a design" and deferred the choice. The ruling's premise, that
+`value` is the minority spelling, was measured before any edit over the four
+roots it named: **776 `content`-only `text` nodes, 25 `value`-only, 0 authoring
+both** across `examples/` (674 / 13), `apps/` (59 / 0), the `examples/`
+directories under `packages/` (0 / 1) and `content/docs/**` (43 / 11) — a
+thirty-to-one majority for `content`, so the retirement went ahead as ruled.
+(A further 14 `{ value, label, type: "text" }` objects in the filter-builder
+catalog entries are field descriptors whose `type` is a field type, not `text`
+nodes, and were excluded by kind.)
+
+**Who is affected — a `value` authored on a `text` node:**
+
+```json
+{ "type": "text",
+  "value": "Hello" }   // ← was tolerated (rendered as the fallback)
+```
+
+now fails validation with:
+
+> RETIRED (objectui#6951) — `value` is no longer part of TextSchema; write
+> `content`. It was a second spelling of the one content slot, read only as the
+> fallback limb of `schema.content || schema.value`, and was retired under
+> ADR-0049 enforce-or-remove with no deprecation window (maintainer ruling A1,
+> 2026-09-04). The renderer reads `content` alone now, so an authored `value`
+> would render nothing. Rename the key; the string is unchanged.
+
+**Two published faces, one retirement.** The TypeScript interface `TextSchema`
+(`@object-ui/types`, `layout.ts`) declares `value?: never`; the Zod mirror
+`TextSchema` (`@object-ui/types/zod`, `layout.zod.ts`) declares `value` as a
+`retirementTombstone()`, so the key stays DECLARED and is refused BY NAME —
+a plain deletion would have let an authored `value` ride `BaseSchema`'s
+`.passthrough()` into a silent blank, which is worse than the tolerated
+fallback it replaces. The `value?: string` members of `TextSpanSchema` and
+`TabsSchema` in the same file are other schemas' contracts and are unchanged.
+
+**`@object-ui/components`** — the `text` renderer renders `{schema.content}` at
+both arms (the `|| schema.value` limb is gone from each), and the `context-menu`
+renderer's built-in fallback trigger node now spells `content`. Nothing else in
+the package moves. **`@object-ui/plugin-dashboard`** — its three placeholder
+`text` nodes ("chart type is not supported yet", "Custom widget — set
+`component`…", the retired-widget notice) spell `content` so they keep rendering;
+their wording is unchanged and still pinned.
+
+**Who is NOT affected.** A document that already wrote `content` is untouched;
+`content`, `variant`, `align` and `className` are unchanged; `absent` stays
+valid (`{ "type": "text" }` still parses). Every in-repo document that authored
+`value` on a `text` node was rewritten to `content` in the same change: nine
+`examples/schema-catalog` entries, `packages/types/examples/zod-validation-example.ts`,
+eleven doc fences under `content/docs/`, and the `@object-ui/components`,
+`@object-ui/react` and `@object-ui/types/zod` README samples; the catalog is now
+pinned tree-wide against the retired spelling.
+
+**Migration:** rename `value` to `content` on every `text` node; the string is
+unchanged. If a document authored both, `content` was already the value that
+rendered — delete `value`.
+
+Graded `minor`, not `patch`: this narrows the accepted input set, which is
+breaking for any author who wrote the tolerated spelling. It is not `major` per
+this repo's fixed-group convention (objectui's own breaking changes ship as
+`minor`; the group's major tracks `@objectstack` — AGENTS.md 版本号策略,
+mechanically enforced by `scripts/check-changeset-no-major.mjs`).

--- a/content/docs/components/basic/span.mdx
+++ b/content/docs/components/basic/span.mdx
@@ -64,7 +64,7 @@ interface SpanSchema {
   value?: string;                        // Text content
   children?: SchemaNode | SchemaNode[];  // Child components (the child key this component reads)
   // Both keys are read. When both are authored, child content wins and `value`
-  // is ignored — the same precedence `text` uses for `content` over `value`.
+  // is ignored (the richer key renders, the scalar does not).
   
   // Styling
   className?: string;                    // Tailwind CSS classes

--- a/content/docs/components/basic/text.mdx
+++ b/content/docs/components/basic/text.mdx
@@ -33,14 +33,25 @@ rather than ignored.
 ```plaintext
 interface TextSchema {
   type: 'text';
-  content: string;           // Text content to display
-  value?: string;            // Alias for content
+  content: string;           // Text content to display — the one spelling
   variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'body' | 'caption' | 'overline';
   align?: 'left' | 'center' | 'right' | 'justify';
   color?: string;            // Tailwind color class
   className?: string;        // Additional CSS classes
 }
 ```
+
+> **Retired: `value`** (objectui#6951, ADR-0049 enforce-or-remove). `value` was a
+> second spelling of the one content slot — the renderer read it only as the
+> fallback of `content || value` — and it is no longer part of `TextSchema` on
+> either face. A `text` node that authors `value` now fails validation with:
+>
+> > RETIRED (objectui#6951) — `value` is no longer part of TextSchema; write
+> > `content`. …
+>
+> Rename the key to `content`; the string is unchanged. Measured before the
+> retirement: 776 `content`-only `text` nodes against 25 `value`-only across
+> `examples/`, `apps/`, `packages/*/examples` and `content/docs/**`.
 
 ## Examples
 

--- a/content/docs/core/enhanced-actions.mdx
+++ b/content/docs/core/enhanced-actions.mdx
@@ -328,7 +328,7 @@ const actionWithCallbacks: ActionSchema = {
       title: 'Submission Failed',
       content: {
         type: 'text',
-        value: 'Please try again or contact support.'
+        content: 'Please try again or contact support.'
       }
     }
   }
@@ -458,7 +458,7 @@ const complexAction: ActionSchema = {
       title: 'Order Processing Failed',
       content: {
         type: 'text',
-        value: 'Unable to process order. Please try again.'
+        content: 'Unable to process order. Please try again.'
       }
     }
   },

--- a/content/docs/guide/architecture.md
+++ b/content/docs/guide/architecture.md
@@ -397,10 +397,10 @@ Use expressions for dynamic content:
 <!-- doc-snippet: fragment — a good/bad contrast pair of two bare schema object literals -->
 ```tsx
 // ❌ Bad - hardcoded
-{ type: 'text', value: 'Hello, John!' }
+{ type: 'text', content: 'Hello, John!' }
 
 // ✅ Good - dynamic
-{ type: 'text', value: 'Hello, ${user.name}!' }
+{ type: 'text', content: 'Hello, ${user.name}!' }
 ```
 
 ## Plugin Development

--- a/content/docs/guide/layout.md
+++ b/content/docs/guide/layout.md
@@ -137,7 +137,7 @@ The `Page` component provides a consistent wrapper for individual pages with opt
   "body": {
     "type": "container",
     "children": [
-      { "type": "text", "value": "User list goes here" }
+      { "type": "text", "content": "User list goes here" }
     ]
   }
 }
@@ -533,7 +533,7 @@ Omit `sidebar` and the content fills the width under the top bar.
   "body": {
     "type": "card",
     "children": [
-      { "type": "text", "value": "Record details..." }
+      { "type": "text", "content": "Record details..." }
     ]
   }
 }

--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -31,7 +31,7 @@ function App() {
   const schema = {
     type: "page",
     title: "My Dashboard",
-    body: { type: "text", value: "Hello" }
+    body: { type: "text", content: "Hello" }
   }
   
   return <SchemaRenderer schema={schema} />
@@ -133,7 +133,7 @@ Schemas can be nested to create complex UIs:
         "title": "Card 1",
         "body": {
           "type": "text",
-          "value": "Nested content"
+          "content": "Nested content"
         }
       },
       {
@@ -158,9 +158,9 @@ Use arrays for multiple items:
 {
   "type": "container",
   "body": [
-    { "type": "text", "value": "First item" },
-    { "type": "text", "value": "Second item" },
-    { "type": "text", "value": "Third item" }
+    { "type": "text", "content": "First item" },
+    { "type": "text", "content": "Second item" },
+    { "type": "text", "content": "Third item" }
   ]
 }
 ```

--- a/examples/schema-catalog/src/schemas/components-data-display-kbd/inline-usage.json
+++ b/examples/schema-catalog/src/schemas/components-data-display-kbd/inline-usage.json
@@ -5,7 +5,7 @@
   "children": [
     {
       "type": "text",
-      "value": "Press"
+      "content": "Press"
     },
     {
       "type": "kbd",
@@ -16,7 +16,7 @@
     },
     {
       "type": "text",
-      "value": "to save"
+      "content": "to save"
     }
   ]
 }

--- a/examples/schema-catalog/src/schemas/components-feedback-spinner/loading-button.json
+++ b/examples/schema-catalog/src/schemas/components-feedback-spinner/loading-button.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "text",
-      "value": "Please wait"
+      "content": "Please wait"
     }
   ]
 }

--- a/examples/schema-catalog/src/schemas/components-form-date-picker/date-range-selector.json
+++ b/examples/schema-catalog/src/schemas/components-form-date-picker/date-range-selector.json
@@ -9,7 +9,7 @@
     },
     {
       "type": "text",
-      "value": "to"
+      "content": "to"
     },
     {
       "type": "date-picker",

--- a/examples/schema-catalog/src/schemas/components-form-input-otp/verification-form.json
+++ b/examples/schema-catalog/src/schemas/components-form-input-otp/verification-form.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "text",
-      "value": "We sent a code to your email",
+      "content": "We sent a code to your email",
       "className": "text-sm text-muted-foreground"
     }
   ]

--- a/examples/schema-catalog/src/schemas/components-overlay-hover-card/basic-hover-card.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-hover-card/basic-hover-card.json
@@ -7,6 +7,6 @@
   },
   "content": {
     "type": "text",
-    "value": "This is the hover card content"
+    "content": "This is the hover card content"
   }
 }

--- a/examples/schema-catalog/src/schemas/components-overlay-sheet/basic-sheet.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-sheet/basic-sheet.json
@@ -8,6 +8,6 @@
   "description": "Sheet description goes here.",
   "content": {
     "type": "text",
-    "value": "Sheet content"
+    "content": "Sheet content"
   }
 }

--- a/examples/schema-catalog/src/schemas/components-overlay-sheet/left-side.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-sheet/left-side.json
@@ -8,6 +8,6 @@
   "title": "Left Sheet",
   "content": {
     "type": "text",
-    "value": "Content"
+    "content": "Content"
   }
 }

--- a/examples/schema-catalog/src/schemas/components-overlay-sheet/right-side.json
+++ b/examples/schema-catalog/src/schemas/components-overlay-sheet/right-side.json
@@ -8,6 +8,6 @@
   "title": "Right Sheet",
   "content": {
     "type": "text",
-    "value": "Content"
+    "content": "Content"
   }
 }

--- a/examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx
+++ b/examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx
@@ -115,12 +115,12 @@ describe('objectui#6939 — and the repair moved the validator, not the renderer
 
 describe('objectui#6939 — `children` is no longer required on either member', () => {
   it('a tooltip with no children validates', () => {
-    expect(reasons({ type: 'tooltip', trigger: { type: 'text', value: 'x' }, content: 'y' })).toEqual([]);
+    expect(reasons({ type: 'tooltip', trigger: { type: 'text', content: 'x' }, content: 'y' })).toEqual([]);
     expect(TooltipSchema.safeParse({ type: 'tooltip' }).success).toBe(true);
   });
 
   it('a context menu with no children validates', () => {
-    expect(reasons({ type: 'context-menu', trigger: { type: 'text', value: 'x' }, items: [{ label: 'a' }] })).toEqual([]);
+    expect(reasons({ type: 'context-menu', trigger: { type: 'text', content: 'x' }, items: [{ label: 'a' }] })).toEqual([]);
     expect(ContextMenuSchema.safeParse({ type: 'context-menu', items: [] }).success).toBe(true);
   });
 
@@ -135,7 +135,7 @@ describe('objectui#6939 — `children` is no longer required on either member', 
     expect(ContextMenuSchema.safeParse({
       type: 'context-menu',
       items: [{ label: 'Copy' }],
-      children: { type: 'text', value: 'Right-click here' },
+      children: { type: 'text', content: 'Right-click here' },
     }).success).toBe(true);
   });
 });
@@ -156,7 +156,7 @@ describe('objectui#6939 — the keys the renderers read are DECLARED, not passth
     const shape = (TooltipSchema as unknown as { shape: Record<string, unknown> }).shape;
     expect(Object.keys(shape)).toEqual(expect.arrayContaining(['trigger', 'content', 'body']));
     expect(TooltipSchema.safeParse({ type: 'tooltip', content: 'text only' }).success).toBe(true);
-    expect(TooltipSchema.safeParse({ type: 'tooltip', body: { type: 'text', value: 'rich only' } }).success).toBe(true);
+    expect(TooltipSchema.safeParse({ type: 'tooltip', body: { type: 'text', content: 'rich only' } }).success).toBe(true);
   });
 
   it('context-menu declares triggerClassName / contentClassName / modal', () => {

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -94,7 +94,7 @@ const schema = {
   title: 'Welcome',
   body: {
     type: 'text',
-    value: 'Hello from Object UI!'
+    content: 'Hello from Object UI!'
   }
 }
 

--- a/packages/components/src/__tests__/basic-renderers.test.tsx
+++ b/packages/components/src/__tests__/basic-renderers.test.tsx
@@ -53,13 +53,19 @@ describe('Basic Renderers - Display Issue Detection', () => {
       expect(domCheck).toBeDefined();
     });
 
-    it('should support value property as alias', () => {
+    it('no longer reads `value` — RETIRED (objectui#6951, ADR-0049), `content` is the one spelling', () => {
+      // Before objectui#6951 this case pinned `value` as an alias for `content`
+      // (`{schema.content || schema.value}`). The alias is retired on both
+      // published faces and the renderer reads `content` alone, so an authored
+      // `value` reaches the DOM as NOTHING — the enforce-or-remove half this
+      // pin now guards. The refusal itself is pinned in `@object-ui/types`
+      // (`text-value-retired-6951.test.ts`); this leg is the read side.
       const { container } = renderComponent({
         type: 'text',
         value: 'Test Value',
-      });
+      } as never);
 
-      expect(container.textContent).toContain('Test Value');
+      expect(container.textContent).not.toContain('Test Value');
     });
 
     it('should render with designer props correctly', () => {

--- a/packages/components/src/__tests__/bindable-text-keys-4795.test.tsx
+++ b/packages/components/src/__tests__/bindable-text-keys-4795.test.tsx
@@ -81,18 +81,19 @@ describe('objectui#4795 — declared text keys are evaluated AND read back, thro
 
 describe('objectui#4795 — the undeclared half stays inert, through real renderers', () => {
   /**
-   * `basic/text.tsx` renders `schema.content || schema.value`, so `text.value`
-   * IS a top-level read-back site — and `text` has no row in the spec's
-   * carriage map, so the memo must not evaluate it. This assertion therefore
-   * pins a KNOWN, reported gap rather than a desired behaviour: the literal on
-   * screen is what an author writing the form the expressions guide teaches
-   * gets today, and closing it is a spec-side row (objectstack), not a
-   * renderer-side inference here. If a row is ever added upstream, this is the
-   * test that will go red and say so.
+   * `text.value` is RETIRED (objectui#6951, ADR-0049 enforce-or-remove):
+   * `basic/text.tsx` renders `{schema.content}` alone, so `value` is no longer
+   * a read-back site at all — neither evaluated (the spec's carriage map never
+   * had a `text` row for it, objectstack#13670 ruled `content` the sole
+   * channel) nor rendered as a literal. Before the retirement this case pinned
+   * the literal `${data.total}` on screen as a known gap; now the pin is that
+   * NOTHING from the retired key reaches the DOM. The refusal at the authoring
+   * boundary is pinned in `@object-ui/types` (`text-value-retired-6951.test.ts`).
    */
-  it('`text.value` is still not evaluated — no spec row (reported upstream)', () => {
-    renderNode({ type: 'text', value: '${data.total}' });
-    expect(screen.getByText('${data.total}')).toBeTruthy();
+  it('`text.value` is retired — neither evaluated nor read back', () => {
+    const { container } = renderNode({ type: 'text', value: '${data.total}' });
+    expect(container.textContent).not.toContain('${data.total}');
+    expect(container.textContent).not.toContain('99');
   });
 
   it('a key outside the component\'s declared row stays inert (`card.value`)', () => {

--- a/packages/components/src/__tests__/span-children-rendering.test.tsx
+++ b/packages/components/src/__tests__/span-children-rendering.test.tsx
@@ -69,7 +69,7 @@ describe('span renders its canonical child key (#5027)', () => {
     const schema: TextSpanSchema = {
       type: 'span',
       className: 'json-authored',
-      children: [{ type: 'text', value: 'inline from children' }],
+      children: [{ type: 'text', content: 'inline from children' }],
     };
 
     const { container } = render(<SchemaRenderer schema={schema} />);
@@ -83,7 +83,7 @@ describe('span renders its canonical child key (#5027)', () => {
     const schema: TextSpanSchema = {
       type: 'span',
       className: 'single-child',
-      children: { type: 'text', value: 'lone child' },
+      children: { type: 'text', content: 'lone child' },
     };
 
     const { container } = render(<SchemaRenderer schema={schema} />);
@@ -101,7 +101,7 @@ describe('span renders its canonical child key (#5027)', () => {
         schema={{
           type: 'span',
           className: 'alias-probe',
-          body: [{ type: 'text', value: 'must not render' }],
+          body: [{ type: 'text', content: 'must not render' }],
         } as never}
       />,
     );

--- a/packages/components/src/__tests__/span-value-fallback.test.tsx
+++ b/packages/components/src/__tests__/span-value-fallback.test.tsx
@@ -26,9 +26,10 @@
  * Ruled 2026-08-17: wire it. Both declared faces stay as written, and the
  * renderer makes them true, rather than the declarations being retracted.
  *
- * PRECEDENCE, and why it is not a bespoke rule: `basic/text.tsx` renders
- * `schema.content || schema.value`, so on the sibling type in the same family
- * the richer key already wins and the scalar is already the fallback. `span`
+ * PRECEDENCE, and why it is not a bespoke rule: at the time `basic/text.tsx`
+ * rendered `schema.content || schema.value` (that fallback limb was retired by
+ * objectui#6951; `content` is now `text`'s one spelling), so on the sibling type
+ * in the same family the richer key already won and the scalar was the fallback. `span`
  * follows that, with `children` (its canonical child key, #5027) in the winning
  * position. `body` stays refused — see `span-children-rendering.test.tsx`; it is
  * declared nowhere for this type, whereas `value` is declared twice.
@@ -66,8 +67,9 @@ describe('span reads its declared `value` key (#5050)', () => {
   });
 
   it('lets child content win when both `children` and `value` are authored', () => {
-    // The precedence half of the ruling. `text`'s `content || value` is the
-    // family precedent: the richer key renders, the scalar does not — and the
+    // The precedence half of the ruling. `text`'s `content || value` was the
+    // family precedent (its `value` limb is retired since objectui#6951): the
+    // richer key renders, the scalar does not — and the
     // scalar must not be appended either, which is what the second assertion
     // rules out (a `+` instead of a `||` would keep the first one green).
     const schema: TextSpanSchema = {

--- a/packages/components/src/__tests__/span-value-fallback.test.tsx
+++ b/packages/components/src/__tests__/span-value-fallback.test.tsx
@@ -74,7 +74,7 @@ describe('span reads its declared `value` key (#5050)', () => {
       type: 'span',
       className: 'both-keys',
       value: 'value must not render',
-      children: [{ type: 'text', value: 'children win' }],
+      children: [{ type: 'text', content: 'children win' }],
     };
 
     const { container } = render(<SchemaRenderer schema={schema} />);
@@ -93,7 +93,7 @@ describe('span reads its declared `value` key (#5050)', () => {
       type: 'span',
       className: 'single-child-wins',
       value: 'value must not render',
-      children: { type: 'text', value: 'lone child wins' },
+      children: { type: 'text', content: 'lone child wins' },
     };
 
     const { container } = render(<SchemaRenderer schema={schema} />);

--- a/packages/components/src/renderers/basic/text.tsx
+++ b/packages/components/src/renderers/basic/text.tsx
@@ -159,12 +159,12 @@ ComponentRegistry.register('text',
                 style={style}
                 className={className}
             >
-                {schema.content || schema.value}
+                {schema.content}
             </Tag>
         );
     }
 
-    return <>{schema.content || schema.value}</>;
+    return <>{schema.content}</>;
   },
   {
     namespace: 'ui',

--- a/packages/components/src/renderers/overlay/context-menu.tsx
+++ b/packages/components/src/renderers/overlay/context-menu.tsx
@@ -92,7 +92,7 @@ ComponentRegistry.register('context-menu',
       <ContextMenuTrigger asChild>
           {/* Usually a Right Click area */}
           <div className={triggerClass}>
-             {renderChildren(schema.trigger || { type: 'text', value: "Right click here" })}
+             {renderChildren(schema.trigger || { type: 'text', content: "Right click here" })}
           </div>
       </ContextMenuTrigger>
       <ContextMenuContent className={contentClass}>

--- a/packages/plugin-dashboard/src/DashboardGridLayout.tsx
+++ b/packages/plugin-dashboard/src/DashboardGridLayout.tsx
@@ -359,7 +359,7 @@ export const DashboardGridLayout: React.FC<DashboardGridLayoutProps> = ({
     if (dispatch.family === 'unsupported') {
       return {
         type: 'text',
-        value: `「${widgetType}」chart type is not supported yet`,
+        content: `「${widgetType}」chart type is not supported yet`,
         variant: 'caption',
         align: 'center',
         className: 'flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-muted-foreground',

--- a/packages/plugin-dashboard/src/DashboardRenderer.tsx
+++ b/packages/plugin-dashboard/src/DashboardRenderer.tsx
@@ -789,7 +789,7 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
             if (dispatch.family === 'custom') {
                 return {
                     type: 'text',
-                    value: 'Custom widget — set `component` to a UIComponent schema.',
+                    content: 'Custom widget — set `component` to a UIComponent schema.',
                     variant: 'caption',
                     align: 'center',
                     className: 'flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-muted-foreground',
@@ -802,7 +802,7 @@ const DashboardRendererInner = forwardRef<HTMLDivElement, DashboardRendererProps
             if (dispatch.family === 'unsupported') {
                 return {
                     type: 'text',
-                    value: `「${widgetType}」chart type is not supported yet`,
+                    content: `「${widgetType}」chart type is not supported yet`,
                     variant: 'caption',
                     align: 'center',
                     className: 'flex h-full w-full items-center justify-center rounded border border-dashed bg-muted/20 p-4 text-muted-foreground',

--- a/packages/plugin-dashboard/src/legacyRetiredWidget.ts
+++ b/packages/plugin-dashboard/src/legacyRetiredWidget.ts
@@ -55,7 +55,7 @@ import type { DashboardWidgetSchema } from '@object-ui/types';
  */
 export const LEGACY_RETIRED_WIDGET_SCHEMA = {
   type: 'text',
-  value: 'This widget uses a retired data format. Edit it to bind a dataset.',
+  content: 'This widget uses a retired data format. Edit it to bind a dataset.',
   variant: 'caption',
   align: 'center',
   className: 'flex h-full w-full items-center justify-center rounded border border-dashed border-destructive/40 bg-destructive/5 p-4 text-center text-destructive',

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -28,7 +28,7 @@ import { SchemaRenderer } from '@object-ui/react'
 
 const schema = {
   type: 'text',
-  value: 'Hello, Object UI!'
+  content: 'Hello, Object UI!'
 }
 
 function App() {

--- a/packages/types/examples/zod-validation-example.ts
+++ b/packages/types/examples/zod-validation-example.ts
@@ -93,7 +93,7 @@ const cardExample = {
   children: [
     {
       type: 'text',
-      value: 'Card content goes here',
+      content: 'Card content goes here',
     },
   ],
 };

--- a/packages/types/src/__tests__/text-value-retired-6951.test.ts
+++ b/packages/types/src/__tests__/text-value-retired-6951.test.ts
@@ -197,7 +197,18 @@ describe('the retirement narrows exactly `value` and nothing else (objectui#6951
 
 /* ── the corpus: no shipped fixture authors the retired spelling ─────────── */
 
-/** Every `text` node (an object whose OWN `type` is `"text"`) in a parsed JSON document. */
+/**
+ * Keys whose arrays hold DESCRIPTORS, not component nodes: a filter-builder's
+ * `fields[]` entry is `{ value, label, type: "text" }`, where `type` is a FIELD
+ * type and `value` is the field key — the same three keys as a retired `text`
+ * node and a different vocabulary. The census that sized this retirement
+ * excluded them by kind (14 in the catalog); the walk below excludes them by
+ * position, so the pin measures `text` NODES and not every object that spells
+ * `type: "text"`.
+ */
+const DESCRIPTOR_SLOTS = new Set(['fields', 'columns', 'filters', 'options']);
+
+/** Every `text` node (an object whose OWN `type` is `"text"`, reached through a node slot) in a parsed JSON document. */
 function* textNodes(node: unknown, path: string): Generator<[string, Record<string, unknown>]> {
   if (Array.isArray(node)) {
     for (let i = 0; i < node.length; i++) yield* textNodes(node[i], `${path}[${i}]`);
@@ -206,7 +217,10 @@ function* textNodes(node: unknown, path: string): Generator<[string, Record<stri
   if (!node || typeof node !== 'object') return;
   const obj = node as Record<string, unknown>;
   if (obj.type === 'text') yield [path, obj];
-  for (const [k, v] of Object.entries(obj)) yield* textNodes(v, `${path}.${k}`);
+  for (const [k, v] of Object.entries(obj)) {
+    if (DESCRIPTOR_SLOTS.has(k)) continue;
+    yield* textNodes(v, `${path}.${k}`);
+  }
 }
 
 function* jsonFiles(dir: string): Generator<string> {

--- a/packages/types/src/__tests__/text-value-retired-6951.test.ts
+++ b/packages/types/src/__tests__/text-value-retired-6951.test.ts
@@ -1,0 +1,332 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Retirement pin — `TextSchema.value` is REFUSED on both published faces and
+ * no longer READ by the renderer (objectui#6951 A1 / objectui#7016, ADR-0049
+ * enforce-or-remove). Maintainer ruling A1 of 2026-09-04: retire `value`, keep
+ * `content`, immediately, no deprecation window.
+ *
+ * ## What was measured before the retirement
+ *
+ * `TextSchema` declared two spellings for its one content slot — `content`
+ * (read first) and `value` (the fallback limb of
+ * `{schema.content || schema.value}` at `renderers/basic/text.tsx`). Both were
+ * declared by objectui#6150, whose own docblock called the pair "a dialect, not
+ * a design" and left the choice to an ADR-0049 ruling. The ruling's premise —
+ * that `value` is the MINORITY spelling — was measured on the four roots it
+ * named (`examples/`, `apps/`, the `examples/` directories under `packages/`,
+ * `content/docs/**`) before any edit: 776 `content`-only `text` nodes, 25
+ * `value`-only, 0 authoring both. Every `value`-only node in the repository
+ * was rewritten to `content` in the retiring PR; the absence leg below is
+ * tree-scoped over the catalog so a new one cannot creep back in.
+ *
+ * ## Why a tombstone and not a deletion
+ *
+ * `BaseSchema` is `.passthrough()` on the Zod side and carries a
+ * `[key: string]: any` index signature on the TS side, and the renderer no
+ * longer reads `value` at all. Deleting the member would therefore hand an
+ * authored `value` the WORST outcome available: accepted, unvalidated, and
+ * rendered as a blank. `?: never` / `retirementTombstone()` is this package's
+ * convention (`MarkdownSchema.sanitize`, objectui#6972; `DataTableSchema.toolbar`,
+ * objectui#6881) and is lockstep: both faces or neither. The "deleted" row is
+ * pinned live below as a control.
+ *
+ * The `@ts-expect-error` directives are REAL enforcement: this package
+ * type-checks its tests through `tsconfig.test.json`, so re-widening the
+ * declaration fails the build on the unused directive. A green `vitest` run is
+ * NOT evidence about them — type assertions are erased before it runs.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { TextSchema, TextSpanSchema } from '../zod/layout.zod.js';
+import { safeValidateSchema } from '../zod/index.zod.js';
+import type { TextSchema as TextSchemaTS, TextSpanSchema as TextSpanSchemaTS } from '../layout.js';
+
+const ROOT = resolve(__dirname, '../../../..');
+
+/**
+ * The FULL guidance string, pinned as a literal so the derived assertions below
+ * cannot all drift together. The first sentence is the contract an author acts
+ * on: the retired key, and the spelling to write instead.
+ */
+const GUIDANCE =
+  'RETIRED (objectui#6951) — `value` is no longer part of TextSchema; write `content`. It was a second '
+  + 'spelling of the one content slot, read only as the fallback limb of `schema.content || schema.value`, '
+  + 'and was retired under ADR-0049 enforce-or-remove with no deprecation window (maintainer ruling A1, '
+  + '2026-09-04). The renderer reads `content` alone now, so an authored `value` would render nothing. '
+  + 'Rename the key; the string is unchanged.';
+const PRESCRIPTIVE = '`value` is no longer part of TextSchema; write `content`.';
+
+/** The values an author would plausibly have written on the retired key. */
+const RETIRED_VALUES = ['Hello', '', '${data.total}'] as const;
+
+/** A minimal document that is valid TODAY and stays valid — the inside of the boundary. */
+const VALID_TEXT = { type: 'text', content: 'Hello' } as const;
+
+const describeOf = (schema: unknown, key: string): string | undefined =>
+  ((schema as { shape: Record<string, { description?: string }> }).shape[key])?.description;
+
+/** Flatten a union refusal so the arm-level issues are addressable by path. */
+type Issue = { code: string; path: PropertyKey[]; message: string; expected?: string; errors?: Issue[][] };
+const flatIssues = (issues: Issue[]): Issue[] =>
+  issues.flatMap((i) => (i.code === 'invalid_union' && i.errors ? i.errors.flat().flatMap((e) => flatIssues([e])) : [i]));
+
+/* ── the Zod half: refused BY NAME, with the guidance in the message ─────── */
+
+describe('TextSchema.value is RETIRED — the Zod half of the tombstone (objectui#6951)', () => {
+  it.each(RETIRED_VALUES.map((v) => [JSON.stringify(v), v] as const))(
+    'REFUSES `value: %s`, naming the retired key in the path — every value, not one spelling',
+    (_label, value) => {
+      // The pin. Before the retirement this document parsed GREEN (`value` was
+      // `z.string().optional()`, measured ACCEPTED on the retiring PR's base).
+      // Asserting the ENVELOPE — not merely `success:false` — so the pin cannot
+      // be satisfied by an unrelated rejection.
+      const result = TextSchema.safeParse({ type: 'text', value });
+      expect(result.success, `an authored \`value: ${JSON.stringify(value)}\` was ACCEPTED`).toBe(false);
+      if (result.success) return;
+
+      const issue = result.error.issues.find((i) => i.path[0] === 'value');
+      expect(issue, 'parse failed, but not on the `value` path').toBeTruthy();
+      // The accept-set contract: same address, same code a bare `z.never()`
+      // reports — `retirementTombstone()` customises the MESSAGE only.
+      expect(issue?.code).toBe('invalid_type');
+      expect((issue as { expected?: string } | undefined)?.expected).toBe('never');
+      expect(issue?.path).toEqual(['value']);
+    },
+  );
+
+  it('the refusal CARRIES the guidance — it names `content`, not zod\'s generic message', () => {
+    const result = TextSchema.safeParse({ type: 'text', value: 'Hello' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const issue = result.error.issues.find((i) => i.path[0] === 'value');
+    expect(issue?.message).not.toContain('Invalid input: expected never, received ');
+    expect(issue?.message).toContain(PRESCRIPTIVE);
+    expect(issue?.message).toContain('write `content`');
+    expect(issue?.message).toBe(GUIDANCE);
+    // ONE string, BOTH channels — asserted derived, so the parse message and
+    // the generated-docs metadata cannot drift apart (objectui#6931).
+    expect(issue?.message).toBe(describeOf(TextSchema, 'value'));
+  });
+
+  it('is refused through `safeValidateSchema` too — the `AnyComponentSchema` union arm carries the tombstone', () => {
+    // The entry point a validating host actually calls. `AnyComponentSchema`
+    // is a plain `z.union`, so a document every arm refuses surfaces as
+    // `invalid_union`; the `TextSchema` arm's own issue — path `value`, the
+    // guidance — must be inside it, otherwise the refusal an author reads
+    // through this door would not say what to write.
+    const result = safeValidateSchema({ type: 'text', value: 'Hello' });
+    expect(result.success, 'a `text` node authoring `value` validated GREEN through the union').toBe(false);
+    if (result.success) return;
+
+    const named = flatIssues(result.error.issues as Issue[]).find((i) => i.path[0] === 'value');
+    expect(named, 'the union refusal does not name the `value` path').toBeTruthy();
+    expect(named?.message).toBe(GUIDANCE);
+
+    // Positive control on the same door: the migrated document validates.
+    expect(safeValidateSchema({ ...VALID_TEXT }).success).toBe(true);
+  });
+
+  it('keeps the key DECLARED — a tombstone, not a deletion', () => {
+    // The route guard. `BaseSchema` is `.passthrough()`, so removing the key
+    // from the mirror would make the authored spelling parse green again — and
+    // with the renderer no longer reading it, render as a BLANK.
+    expect(
+      Object.keys(TextSchema.shape),
+      'value left the mirror — under .passthrough() the retired key becomes a silent blank',
+    ).toContain('value');
+    expect(describeOf(TextSchema, 'value')).toContain('RETIRED (objectui#6951)');
+  });
+});
+
+/* ── the inside of the boundary: everything else is untouched ────────────── */
+
+describe('the retirement narrows exactly `value` and nothing else (objectui#6951)', () => {
+  it('`content` still parses and its value SURVIVES the parse', () => {
+    const result = TextSchema.safeParse(VALID_TEXT);
+    expect(result.success ? null : result.error.issues).toBe(null);
+    if (result.success) expect(result.data.content).toBe('Hello');
+  });
+
+  it('a document that never wrote `value` parses GREEN — `absent` stays valid', () => {
+    // `.optional()` on the tombstone. A bare `{ type: "text" }` was legal
+    // before (#6150's own control document) and stays legal.
+    const result = TextSchema.safeParse({ type: 'text' });
+    expect(result.success ? null : result.error.issues).toBe(null);
+  });
+
+  it('still REFUSES a wrong-typed `content` — the mirror did not stop validating', () => {
+    // Counter-probe in the other direction: the schema is not `z.any()` in
+    // disguise, so the green results above are readings.
+    const result = TextSchema.safeParse({ type: 'text', content: 42 });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.find((i) => i.path[0] === 'content')).toBeTruthy();
+  });
+
+  it('control: `TextSpanSchema.value` — the sibling member at `layout.ts:66` — is still ACCEPTED and survives', () => {
+    // `value?: string` appears on three interfaces in `layout.ts`; only
+    // `TextSchema`'s is retired. The `span` renderer still reads its own
+    // `value` (`basic/span.tsx`), so this member must keep parsing — the pin
+    // that the retirement was located by SYMBOL, not by grep hit.
+    const result = TextSpanSchema.safeParse({ type: 'span', value: 'inline' });
+    expect(result.success ? null : result.error.issues).toBe(null);
+    if (result.success) expect(result.data.value).toBe('inline');
+  });
+
+  it('an UNDECLARED key still rides `.passthrough()` — the DELETED row, measured live', () => {
+    // This is the contrast that justifies `?: never` over deletion, pinned
+    // rather than argued: a key the mirror does not declare is neither refused
+    // nor stripped, it is KEPT. Had `value` been deleted instead of tombstoned,
+    // an authored value would sit exactly where this one sits — green, kept,
+    // and read by nothing.
+    const result = TextSchema.safeParse({ ...VALID_TEXT, notAKeyAtAll: 'anything' });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toHaveProperty('notAKeyAtAll', 'anything');
+  });
+});
+
+/* ── the corpus: no shipped fixture authors the retired spelling ─────────── */
+
+/** Every `text` node (an object whose OWN `type` is `"text"`) in a parsed JSON document. */
+function* textNodes(node: unknown, path: string): Generator<[string, Record<string, unknown>]> {
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) yield* textNodes(node[i], `${path}[${i}]`);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+  const obj = node as Record<string, unknown>;
+  if (obj.type === 'text') yield [path, obj];
+  for (const [k, v] of Object.entries(obj)) yield* textNodes(v, `${path}.${k}`);
+}
+
+function* jsonFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* jsonFiles(full);
+    else if (entry.endsWith('.json')) yield full;
+  }
+}
+
+describe('no shipped JSON fixture authors `text.value` any more (objectui#6951) — tree-scoped', () => {
+  // Tree-scoped on purpose: a file-scoped pin sees only the files its author
+  // knew about, and the nine catalog entries rewritten by the retiring PR
+  // (`components-data-display-kbd/inline-usage` ×2, `components-feedback-spinner/
+  // loading-button`, `components-form-date-picker/date-range-selector`,
+  // `components-form-input-otp/verification-form`, `components-overlay-hover-card/
+  // basic-hover-card`, `components-overlay-sheet/{basic-sheet,left-side,right-side}`)
+  // were found by census, not by memory. Nested nodes are validated per node
+  // because `SchemaNodeSchema` does not descend into `AnyComponentSchema`.
+  const CATALOG = resolve(ROOT, 'examples/schema-catalog/src/schemas');
+  const TYPES_EXAMPLES = resolve(ROOT, 'packages/types/examples');
+
+  it('every `text` node in the catalog and the types examples spells `content`, and parses green', () => {
+    const offenders: string[] = [];
+    let seen = 0;
+    for (const dir of [CATALOG, TYPES_EXAMPLES]) {
+      for (const file of jsonFiles(dir)) {
+        const doc = JSON.parse(readFileSync(file, 'utf8')) as unknown;
+        for (const [path, node] of textNodes(doc, '$')) {
+          seen++;
+          if ('value' in node) offenders.push(`${file.slice(ROOT.length + 1)} ${path}`);
+          const result = TextSchema.safeParse(node);
+          if (!result.success) offenders.push(`${file.slice(ROOT.length + 1)} ${path}: ${JSON.stringify(result.error.issues)}`);
+        }
+      }
+    }
+    // Non-vacuity: the catalog carried 688 `text` nodes at the retirement; a
+    // walk that finds none is a broken walk, not a clean corpus.
+    expect(seen).toBeGreaterThan(500);
+    expect(offenders).toEqual([]);
+  });
+});
+
+/* ── the renderer half: the retired key is no longer READ ────────────────── */
+
+describe('the `text` renderer no longer reads `schema.value` (objectui#6951, enforce-or-remove)', () => {
+  it('both read sites render `{schema.content}` alone — the read set, off disk', () => {
+    // Enforce-or-remove: a retired key must stop being READ, not only stop
+    // being declared. Both arms of `text.tsx` — the wrapped element and the
+    // bare fragment — rendered `{schema.content || schema.value}`; the
+    // fallback limb is gone from both. Read off disk so a renderer-side
+    // re-widening cannot pass while the schema faces still refuse.
+    const src = readFileSync(resolve(ROOT, 'packages/components/src/renderers/basic/text.tsx'), 'utf8');
+    expect(src.match(/schema\.value\b/g)).toBeNull();
+    expect(src.match(/\{schema\.content\}/g)).toHaveLength(2);
+  });
+
+  it('the one in-package producer of the dialect spells `content` too (`context-menu` fallback trigger)', () => {
+    // `renderers/overlay/context-menu.tsx` authors a `text` node itself as the
+    // default trigger; under the retirement a `value` there would render a
+    // blank click area. Pinned so the producer cannot drift back.
+    const src = readFileSync(resolve(ROOT, 'packages/components/src/renderers/overlay/context-menu.tsx'), 'utf8');
+    expect(src).toContain("{ type: 'text', content: \"Right click here\" }");
+    expect(src).not.toMatch(/type: 'text', value:/);
+  });
+});
+
+/* ── the TS half: the `tsc` channel ──────────────────────────────────────── */
+
+describe('TextSchema.value is RETIRED — the TS half of the tombstone (objectui#6951)', () => {
+  it('refuses the retired key at compile time', () => {
+    // On the pre-fix tree `value` is `string | undefined`, so the assignment
+    // is LEGAL, the directive below is unused, and `tsc` fails the build with
+    // TS2578 naming the key — this leg is red before the fix in `type-check`,
+    // not in vitest, which strips types.
+
+    // @ts-expect-error — `value` is RETIRED (objectui#6951): declared `?: never`, so no value is authorable.
+    const retired: TextSchemaTS['value'] = 'Hello';
+
+    // Counter-probe on the same surface: the live sibling still accepts its
+    // value, so the directive above pins the KEY's retirement and not a
+    // blanket narrowing of the interface.
+    const sibling: TextSchemaTS['content'] = 'Hello';
+
+    expect([retired, sibling]).toHaveLength(2);
+  });
+
+  it('refuses the retired key in the form authors actually write', () => {
+    // The leg that proves the tombstone survives `BaseSchema`'s
+    // `[key: string]: any`: if the index signature won, `value` would widen
+    // back to `any` here and the directive would go unused (TS2578).
+    const retiredDocument: TextSchemaTS = {
+      type: 'text',
+      // @ts-expect-error — `value` is RETIRED (objectui#6951); write `content`.
+      value: 'Hello',
+    };
+
+    // The migrated document — the key renamed — still type-checks.
+    const migratedDocument: TextSchemaTS = {
+      type: 'text',
+      content: 'Hello',
+      variant: 'body',
+    };
+
+    expect([retiredDocument, migratedDocument]).toHaveLength(2);
+  });
+
+  it('refuses it through a WIDENED value too — the half a deletion would have missed', () => {
+    // Excess-property checking only reaches a FRESH literal (objectui#7654
+    // measured the contrast): a deleted key would ride a widened value
+    // silently. The declared `never` makes the assignment itself ill-typed,
+    // so freshness stops mattering.
+    const raw = { type: 'text' as const, value: 'Hello' };
+    // @ts-expect-error — `value` is RETIRED (objectui#6951), reached through a non-fresh value.
+    const document: TextSchemaTS = raw;
+    expect(document.type).toBe('text');
+  });
+
+  it('control: `TextSpanSchema.value` (`layout.ts:66`) still type-checks — retired by symbol, not by grep', () => {
+    const span: TextSpanSchemaTS = { type: 'span', value: 'inline' };
+    expect(span.value).toBe('inline');
+  });
+});

--- a/packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts
+++ b/packages/types/src/__tests__/undeclared-but-consumed-keys-6150.test.ts
@@ -147,7 +147,7 @@ interface Case {
   readText: string;
 }
 
-const NODE: SchemaNode = { type: 'text', value: 'x' } as SchemaNode;
+const NODE: SchemaNode = { type: 'text', content: 'x' } as SchemaNode;
 const TEXT_CONTROL = { type: 'text' };
 const CAROUSEL_CONTROL = { type: 'carousel', items: [] };
 const FILTER_CONTROL = { type: 'filter-builder', fields: [] };
@@ -162,7 +162,7 @@ const R = 'packages/components/src/renderers/';
 const CASES: Case[] = [
   { type: 'TextSchema', key: 'content', mirror: TextSchema as never, control: TEXT_CONTROL,
     legal: 'hello', illegal: 42,
-    reader: R + 'basic/text.tsx', readText: '{schema.content || schema.value}' },
+    reader: R + 'basic/text.tsx', readText: '{schema.content}' },
 
   { type: 'CarouselSchema', key: 'opts', mirror: CarouselSchema as never, control: CAROUSEL_CONTROL,
     legal: { loop: true, align: 'start' }, illegal: 'not-an-option-bag',

--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -474,7 +474,7 @@ export interface BaseSchema {
  * @example
  * ```typescript
  * const nodes: SchemaNode[] = [
- *   { type: 'text', value: 'Hello' },
+ *   { type: 'text', content: 'Hello' },
  *   'Plain string',
  *   { type: 'button', label: 'Click' }
  * ]

--- a/packages/types/src/layout.ts
+++ b/packages/types/src/layout.ts
@@ -76,32 +76,41 @@ export interface TextSpanSchema extends BaseSchema {
 export interface TextSchema extends BaseSchema {
   type: 'text';
   /**
-   * Text content to display — the spelling the renderer reads FIRST.
+   * Text content to display — the ONE content spelling `text` reads.
    *
-   * READ SITE: `packages/components/src/renderers/basic/text.tsx:51` (the
-   * wrapped `span` arm, taken when the node carries a designer id or a
-   * className) and `:56` (the bare fragment arm), both as
-   * `{schema.content || schema.value}`. `content` therefore WINS over
-   * {@link TextSchema.value} whenever both are authored.
+   * READ SITE: `packages/components/src/renderers/basic/text.tsx:162` (the
+   * wrapped element arm, taken when the node carries a designer id, a
+   * typography class or a className) and `:167` (the bare fragment arm), both
+   * as `{schema.content}`.
    *
    * Declared by objectui#6150 (undeclared-but-consumed census). Before that
    * card the renderer read this key through `BaseSchema`'s
    * `[key: string]: any` (objectui#5155) and no shipped type mentioned it —
-   * the docs page was the only record of a capability that works.
-   *
-   * ⚠️ Two spellings for one slot is a dialect, not a design. Retiring one of
-   * them is an ADR-0049 enforce-or-remove question and is deliberately NOT
-   * decided here; this declaration records what the renderer does today.
+   * the docs page was the only record of a capability that works. #6150
+   * declared it next to a `value` fallback spelling and recorded that choosing
+   * between the two was an ADR-0049 question it did not decide; objectui#6951
+   * (maintainer ruling A1, 2026-09-04) decided it: `content` is the one
+   * spelling, and {@link TextSchema.value} is the tombstone below.
    */
   content?: string;
   /**
-   * Text content — the fallback spelling, read only when
-   * {@link TextSchema.content} is absent or falsy.
+   * RETIRED (objectui#6951 / objectui#7016, ADR-0049 enforce-or-remove) — the
+   * second spelling of the one content slot, read only as the fallback limb of
+   * `schema.content || schema.value`. Maintainer ruling A1 (2026-09-04): retire
+   * `value`, keep `content`, immediately and with no deprecation window
+   * (「项目在创业阶段,用户也很少,短期不考虑渐进。」). Measured before the
+   * retirement, on the four roots the ruling named (`examples/`, `apps/`, the
+   * `examples/` directories under `packages/`, `content/docs/**`): 776 `content`-only `text`
+   * nodes, 25 `value`-only, none authoring both — so the retired limb was the
+   * minority spelling by thirty to one.
    *
-   * READ SITE: `renderers/basic/text.tsx:51,56`, the right-hand side of
-   * `{schema.content || schema.value}`.
+   * The renderer no longer reads it (`text.tsx` renders `{schema.content}` at
+   * both arms), so an authored `value` would be a silent blank; the tombstone
+   * turns it into a `tsc` error here and a named refusal on the Zod mirror
+   * (`../zod/layout.zod.ts`) instead. Write `content`; the string is unchanged.
+   * @deprecated Not part of this contract — write `content`.
    */
-  value?: string;
+  value?: never;
   /**
    * Text variant/style
    * @default 'body'

--- a/packages/types/src/overlay.ts
+++ b/packages/types/src/overlay.ts
@@ -595,7 +595,7 @@ export interface ContextMenuSchema extends BaseSchema {
    * The right-clickable area's content.
    *
    * READ SITE: `packages/components/src/renderers/overlay/context-menu.tsx:95`
-   * — `renderChildren(schema.trigger || { type: 'text', value: 'Right click here' })`
+   * — `renderChildren(schema.trigger || { type: 'text', content: 'Right click here' })`
    * inside `ContextMenuTrigger`. ⚠️ Note the renderer renders `trigger`, NOT
    * `children` — which this member used to sit beside as a REQUIRED key and
    * which no read site consumes (objectui#6939 dropped that requirement;

--- a/packages/types/src/zod/README.md
+++ b/packages/types/src/zod/README.md
@@ -269,7 +269,7 @@ const cardWithChildren = CardSchema.parse({
   type: 'card',
   title: 'My Card',
   children: [
-    { type: 'text', value: 'Hello' },
+    { type: 'text', content: 'Hello' },
     { type: 'button', label: 'Click' }
   ]
 });

--- a/packages/types/src/zod/layout.zod.ts
+++ b/packages/types/src/zod/layout.zod.ts
@@ -17,7 +17,7 @@
  */
 
 import { z } from 'zod';
-import { handlerKeyRefusal } from './tombstone.zod.js';
+import { handlerKeyRefusal, retirementTombstone } from './tombstone.zod.js';
 import {
   PageSchema as SpecPageSchema,
   PageTypeSchema as SpecPageTypeSchema,
@@ -61,9 +61,20 @@ export const TextSpanSchema = BaseSchema.extend({
 export const TextSchema = BaseSchema.extend({
   type: z.literal('text'),
   content: z.string().optional()
-    .describe("Text content, read FIRST at renderers/basic/text.tsx:51,56 — `schema.content || schema.value`, so it wins over `value` (objectui#6150)"),
-  value: z.string().optional()
-    .describe('Text content, read as the fallback limb of `schema.content || schema.value` at renderers/basic/text.tsx:51,56'),
+    .describe('Text content — the one content spelling `text` reads, at renderers/basic/text.tsx:162,167 as `{schema.content}` (declared by objectui#6150; its `value` fallback spelling was retired by objectui#6951)'),
+  // ADR-0049 RETIREMENT TOMBSTONE (objectui#6951 / objectui#7016, maintainer
+  // ruling A1 of 2026-09-04). `value` was the second spelling of the one
+  // content slot; the renderer now reads `content` alone, so a plain deletion
+  // here would let an authored `value` ride `BaseSchema.passthrough()` into a
+  // silent blank. The tombstone refuses it BY NAME instead — one string, both
+  // channels (parse-time message and `.describe()`), see `./tombstone.zod.ts`.
+  value: retirementTombstone(
+    'RETIRED (objectui#6951) — `value` is no longer part of TextSchema; write `content`. It was a second '
+    + 'spelling of the one content slot, read only as the fallback limb of `schema.content || schema.value`, '
+    + 'and was retired under ADR-0049 enforce-or-remove with no deprecation window (maintainer ruling A1, '
+    + '2026-09-04). The renderer reads `content` alone now, so an authored `value` would render nothing. '
+    + 'Rename the key; the string is unchanged.',
+  ),
   variant: z.enum(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body', 'caption', 'overline'])
     .optional()
     .default('body')


### PR DESCRIPTION
Fixes #7016
Refs #6951 (A half — `TextSchema`; the B half, `TreeViewSchema.data`, is its own PR and the card stays open until both are on `main`)

⚠️ **Draft + `needs:contract-review` on purpose.** This narrows a published validator's accept set (Clause-② yes); the dispatching seat reviews at tier before it lands. Please do not mark ready or enable auto-merge.

## The ruling

Maintainer ruling A1 (2026-09-04, director record on #6951, batch #25), verbatim: "**A1: retire `value`, keep `content`** … Retirement is immediate, no deprecation window (maintainer 2026-08-27: 「项目在创业阶段,用户也很少,短期不考虑渐进。」). Existing `value`-only documents are not a reason to stage it." — premise-bound: the dev measures the `content`-only / `value`-only / both distribution first and STOPS if `value` is the majority. It is not (below), so the retirement is carried out as ruled.

## Measurement — the ruling's premise, taken before any edit

A `text` node is an object literal whose OWN `type` key is the string `text` (not `element:text`, not other schemas carrying a `value` member). Walker: a tokenizer over JSON files, TS/TSX object literals and the fenced code blocks of md/mdx, recording each such object's depth-1 keys and its parent key; declaration contexts (`interface` / `type` bodies) excluded; objects classified by KIND from their keys and position — `sdui-text` (the population the ruling is about), `field-descriptor` (`{ value, label, type: "text" }` under `fields[]`, where `type` is a FIELD type and `value` the field key — the filter-builder catalog entries), `ai-sdk-part` (`output: { type: 'text', value }` tool-result envelopes). Tree read at `origin/main` = `9587fc95` (dispatch base, before the merge); re-verified unchanged on the merge-base `83c77dc3` by grep (below).

**The four ruling-named roots, `sdui-text` kind** (`examples/`, `apps/`, the `examples/` directories under `packages/` = `packages/types/examples` + `packages/plugin-charts/examples`, `content/docs/**`; 939 files scanned):

| root | text nodes | `content`-only | `value`-only | both | neither |
|---|---:|---:|---:|---:|---:|
| `examples/` | 688 | 674 | 13 | 0 | 1 |
| `apps/` | 79 | 59 | 0 | 0 | 20 |
| `packages/*/examples` | 1 | 0 | 1 | 0 | 0 |
| `content/docs/**` | 59 | 43 | 11 | 0 | 5 |
| **total** | **827** | **776** | **25** | **0** | **26** |

Raw, all kinds, same roots: 947 objects — 776 / 39 / 0 / 132; the 14 extra `value`-only are the filter-builder field descriptors (all under `fields[]`, keys `value,label,type`), the 106 extra `neither` are form/field descriptors. Verdict on the premise: `content` by 30 : 1 — **no stop**.

**In-repo tests and fixtures, separately** (`packages/**/__tests__`, `packages/**/*.test.ts*`, `**/test/`; 2314 files): `sdui-text` 634 — 45 / 25 / 0 / 564; `ai-sdk-part` 6 (all `value`); `field-descriptor` 885 (16 `value`). Of the 25 `sdui-text` `value`-only hits: 13 are AI-SDK / MCP tool-result envelopes in `plugin-chatbot` and `app-shell` (`unwrapToolResult`, `isProposalResult`, `detectReplayOutcome` — a different vocabulary, untouched); 7 are real `text` nodes and were rewritten (`span-children-rendering` ×3, `span-value-fallback` ×2, `undeclared-but-consumed-keys-6150`'s NODE fixture) or flipped (`basic-renderers` "value as alias"); 1 keeps authoring `value` deliberately as the retired-key probe (`bindable-text-keys-4795`, now asserting nothing reaches the DOM); 4 are left as they are with a reason — a LOCAL `interface TextSchema` fixture in `packages/react` (`ComponentRendererProps.reconciliation`, its own declaration), a generic `CoreSchemaNode` literal (`SchemaNode.reconciliation`), the `packages/react` carriage-map probe pin (`SchemaRenderer.bindableTextKeys:155`, about the memo, passes unchanged), and a negative fixture for the retired `block` type (`phase2-schemas:329`, refused either way).

**Non-test package sources** (`packages/*/src`, outside the ruling roots, scanned because a producer of the dialect inside the renderer package would ship a blank): 7 real producers — `components/.../overlay/context-menu.tsx:95` (the built-in fallback trigger node), `plugin-dashboard` `DashboardGridLayout.tsx:360`, `DashboardRenderer.tsx:790` and `:803`, `legacyRetiredWidget.ts:56` (placeholder text nodes whose wording is pinned through the rendered DOM), and three published README samples (`components`, `react`, `types/src/zod`); plus 3 hast / AI-SDK objects that are not SDUI nodes (`plugin-markdown/MarkdownImpl.tsx:105`, `plugin-chatbot/elements/code-block.tsx:53`, `app-shell/hooks/useChatConversation.ts:590`, untouched).

Grep cross-checks (single-line forms, `git grep -c` summed): `content/docs/**` fences spelling `text` + `value`: **8 on `83c77dc3`, 0 on this head**; `"type": "text"` objects in the catalog on base: 701 (the walker's 688 `sdui-text` + the descriptors); `packages/*/src` non-test `type: 'text', value` on this head: 8 hits, all of them the hast / AI-SDK objects above or comments describing that envelope.

## The retirement — both faces, and the read

- **TS face** (`packages/types/src/layout.ts`, `TextSchema` block only): `value?: never` with the house-form `@deprecated` RETIRED docblock; `content`'s docblock no longer says it "wins over `value`" and names the two read sites as `{schema.content}`. The `value?: string` members of `TextSpanSchema` (`:66`) and `TabsSchema` (`:414`) are other schemas' contracts — untouched, and pinned as the control.
- **Zod face** (`packages/types/src/zod/layout.zod.ts`, `TextSchema` const only): `value: retirementTombstone('RETIRED (objectui#6951) — `value` is no longer part of TextSchema; write `content`. …')` — one string feeding both the parse-time message and `.describe()`; `content`'s describe no longer references the retired limb.
- **Renderer** (`packages/components/src/renderers/basic/text.tsx:162` and `:167`): `{schema.content || schema.value}` → `{schema.content}` at BOTH arms.
- **Why a tombstone, not a deletion:** `BaseSchema` is `.passthrough()` / carries `[key: string]: any`, and the renderer no longer reads `value`, so a deleted member would make an authored `value` accepted, unvalidated and rendered as a blank. Pinned live as the "deleted row" control.
- **Boundary, unchanged by this PR:** `SchemaNodeSchema` validates nested nodes against `BaseSchemaCore`, not `AnyComponentSchema`, so the refusal bites at the node's own validator (`TextSchema.safeParse`) and at the union entry (`safeValidateSchema` on a top-level `text` node), and on the TS face wherever a literal is typed. A `text` node nested under a `content` / `children` slot is not deep-validated today — the same reach every tombstone in this package has.

## Corpus rewrite — every `value`-authoring `text` node found above

No document authored both keys, so no "content wins" tie-break was needed anywhere; every rewrite is a rename with the string unchanged.

- `examples/schema-catalog/src/schemas/` (9, JSON-aware rename, byte-identical formatting round-trip): `components-data-display-kbd/inline-usage.json` ×2 · `components-feedback-spinner/loading-button.json` · `components-form-date-picker/date-range-selector.json` · `components-form-input-otp/verification-form.json` · `components-overlay-hover-card/basic-hover-card.json` · `components-overlay-sheet/basic-sheet.json` · `left-side.json` · `right-side.json`
- `examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx` ×4 · `packages/types/examples/zod-validation-example.ts` ×1
- `content/docs/` (11): `core/enhanced-actions.mdx` ×2 · `guide/architecture.md` ×2 (the `doc-snippet: fragment` contrast pair — `Hello, John!` and `Hello, ${user.name}!`; the second was an expression site PR #7114 / #7015 left) · `guide/layout.md` ×2 · `guide/schema-rendering.md` ×5; `components/basic/text.mdx` row `value?: string; // Alias for content` replaced by a retirement note quoting the refusal; `components/basic/span.mdx` comment no longer cites `text`'s `content` over `value` precedence
- READMEs (3): `packages/components/README.md:95` · `packages/react/README.md:29` · `packages/types/src/zod/README.md:272`
- Producers (5 sites, 4 files): `context-menu.tsx:95`; `plugin-dashboard` ×4 (wording unchanged, still pinned by the `legacyRetired` suites through the DOM)
- Docblocks (comment-only, 3 files): `packages/types/src/base.ts:477` example, `packages/types/src/overlay.ts:598` read-site quote, `span-value-fallback.test.tsx` precedence rationale dated to before this card

#7015 status checked: landed as PR #7114 (29 expression occurrences); the 11 doc sites above are plain-string `value` and were outside its scope.

## Pins

- **#6150 pins** (`undeclared-but-consumed-keys-6150.test.ts`): the `TextSchema.content` case follows the read site (`readText: '{schema.content}'`) and the shared NODE fixture spells `content`; the file had no case asserting `value` accepted — the acceptance lived in the renderer pins below.
- **Component pins flipped** (`basic-renderers` "should support value property as alias" → nothing from the retired key reaches the DOM; `bindable-text-keys-4795` "`text.value` is still not evaluated" → neither evaluated nor read back).
- **New pin** `packages/types/src/__tests__/text-value-retired-6951.test.ts` (18 tests): zod half — three authored values refused at path `value` with `invalid_type` / `expected: never`, the message names `content` and equals the `.describe()`, the same node refused through `safeValidateSchema` with the guidance inside the `invalid_union` envelope, key still DECLARED; inside the boundary — `content` parses and survives, `{ type: "text" }` parses, `content: 42` still refused, `TextSpanSchema.value` (the `layout.ts:66` sibling) still accepted and survives, an undeclared key still rides passthrough; corpus — tree-scoped walk of every JSON under `examples/schema-catalog/src/schemas` and `packages/types/examples` (descriptor arrays skipped by position; non-vacuity floor 500 nodes) asserting no `text` node spells `value` and each parses; renderer — `text.tsx` read set off disk (`schema.value` absent, `{schema.content}` ×2) and the `context-menu` producer spelling; TS half — `@ts-expect-error` legs on the member type, the fresh literal and a widened value, `TextSpanSchema` control compiles.
- **Parity ledger**: no row. The `?: never` / `retirementTombstone()` pair does not drift (`undefined` meets `undefined`); ablation leg B shows the existing ledger reddening `layout.zod.ts#TextSchema` (TS2322) the moment only one face moves, so the lockstep is already enforced without a row. ⛔ `MIRRORS` / `EXCLUSIONS` untouched.

## Verification (exit codes captured before any pipe; heavy runs through the shared verify lock; every reading on the head named)

| command | exit | head | verdict line |
|---|---:|---|---|
| `pnpm --filter '@object-ui/plugin-dashboard^...' --filter '@object-ui/components^...' --filter @object-ui/types build` (lock) | 0 | `9587fc95`+diff | `VERDICT command-exit 0 · held the lock 98s` |
| `pnpm exec vitest run --maxWorkers=2 packages/types/ packages/components/ packages/plugin-dashboard/ packages/react/src/__tests__/SchemaRenderer.bindableTextKeys.test.tsx examples/schema-catalog/test/` (lock) | 1 | `588c0c8f` (pre-merge) | `Test Files 1 failed, 471 passed (472) · Tests 1 failed, 7103 passed (7104)` — the one failure was the new pin's own walker counting the 14 filter-builder descriptors; fixed in `2c188f09` |
| `pnpm --filter @object-ui/types build && pnpm exec vitest run --maxWorkers=2 packages/types/ packages/components/ packages/plugin-dashboard/ packages/react/src/__tests__/SchemaRenderer.bindableTextKeys.test.tsx examples/schema-catalog/test/overlay-trigger-mirror-6939.test.tsx scripts/__tests__/check-doc-component-types.test.ts scripts/__tests__/doc-version-claims.test.ts` (lock) | 0 | `2c188f09` (post-merge) | `Test Files 449 passed (449) · Tests 5160 passed (5160) · VERDICT command-exit 0 · held the lock 542s` |
| `pnpm exec vitest run --maxWorkers=2 scripts/__tests__/check-doc-snippet-types.test.ts scripts/__tests__/check-readme-exports.test.ts scripts/__tests__/check-doc-links.test.ts` (lock) | 0 | `2c188f09` | `Test Files 3 passed (3) · Tests 278 passed (278)` |
| `pnpm --filter @object-ui/types type-check` (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`) | 0 | `2c188f09`, re-run on `a80deb15` and on the final head `d4de1ca4` | clean |
| `pnpm --filter @object-ui/components type-check` · `pnpm --filter @object-ui/plugin-dashboard type-check` | 0 · 0 | `2c188f09` (components re-run on `d4de1ca4`) | clean |
| `pnpm --filter @object-ui/types build && pnpm exec vitest run --maxWorkers=2 packages/types/ packages/components/src/__tests__/basic-renderers.test.tsx …bindable-text-keys-4795… …span-value-fallback… …span-children-rendering…` (lock; after merging `origin/main` = `3e377c93`, so #7736's `layout-default-jsdoc-7361` pin runs on the merged `layout.ts`) | 0 | **`d4de1ca4` (final head)** | `Test Files 126 passed (126) · Tests 2132 passed (2132) · VERDICT command-exit 0 · held the lock 33s` |
| `pnpm --filter @object-ui/types lint` · `@object-ui/components lint` · `@object-ui/plugin-dashboard lint` · `@object-ui/example-schema-catalog lint` (each `eslint .`, the population CI's Lint job runs) | 0 ×4 | `588c0c8f`+diff | `0 errors` each (268 / 924 / 426 pre-existing warnings, none on a touched line) |
| `node scripts/check-changeset-presence.mjs` | 0 | `d4de1ca4` | `✅ 16 source file(s) of 3 released package(s) changed, and this change declares 1 changeset(s)` |
| `node scripts/check-changeset-fixed.mjs` · `check-changeset-no-major.mjs` · `check-changeset-overwrite.mjs` | 0 · 0 · 0 | `2c188f09` | `✅ All workspace packages are in the changeset fixed group` · `✅ No changeset declares a major bump` · `✅ No pre-existing changeset was modified or deleted` |
| `node scripts/check-control-bytes.mjs` | 0 | `a80deb15` | `✅ check-control-bytes: OK (scanned 6318 tracked text file(s))` |
| `pnpm check:spec-symbols` | 0 | `a80deb15` | `✅ spec member citations: no comment cites a key its spec symbol does not declare` |
| `pnpm check:doc-types` · `pnpm check:doc-fences` · `node scripts/check-doc-links.mjs` | 0 · 0 · 0 | `2c188f09` | `✅ Every documented component type is registered` · `✅ check:doc-fences — every TypeScript block in 227 document(s) is fenced ts/tsx/typescript …` · `Links are valid across 17 scan roots` |
| `pnpm check:unreferenced-sources` · `check:i18n-keys` · `check:i18n-drift` · `check:element-data-source-declaration` · `check:action-forward-parity` · `check:designer-field-key-parity` · `check:phantom-deps` · `check:self-import` · `check:side-effects-array` · `check:entry-guard` · `check:icon-record-names` · `check:skills-paths` · `check:shell-escape-residue` · `check:docs-route-closure` | 0 ×14 | `2c188f09` | green (the families `lint.yml` / `ci.yml` run that read a path in this diff; derived by hand from `.github/workflows/*` — the objectstack `dispatch-gates.mjs` derivation is objectstack-only and does not answer for this tree) |
| governed-surface predicate: `node scripts/pm/check-governed-merges.mjs --test …` (objectstack, on the final 35-path list at `d4de1ca4`) | 0 | — | `0 of 35 path(s) hit the register … NOT governed` |

**NOT MEASURED (precondition exits, not verdicts):** `pnpm check:doc-snippets` → exit 2 `PRECONDITION NOT MET` (its `--build-filter` closure is 26 packages with `...`, effectively the whole workspace; not built on this shared box); `pnpm check:skill-examples` → exit 2 (same closure; this diff touches no `skills/**` file, and the only `skills/` fences spelling `text.value` are `jsonc` counter-examples, which that gate parses and does not schema-validate); `pnpm check:readme-exports` → exit 1 `population COLLAPSED — run pnpm build first`; `pnpm check:sdui-registration-pins` → exit 2 `No console build to weigh`. CI runs all four on the farm.

**Narrowed measurement standing in for `check:doc-snippets`:** the six touched non-fragment `ts` / `tsx` fences (`content/docs/core/enhanced-actions.mdx:309`, `:399`; `content/docs/guide/schema-rendering.md:21`; `packages/components/README.md:86`; `packages/react/README.md:26`; `packages/types/src/zod/README.md:266`; `architecture.md:398` is a declared `doc-snippet: fragment` and is not compiled by the gate either) were extracted from the merge-base `83c77dc3` and from this branch and compiled with `tsc --strict --noEmit` (`jsx: react-jsx`, `paths` derived from each workspace package's `exports[*].types`, against the dist built above). Diagnostic sets are IDENTICAL before and after: five fences clean; the zod README fence reports the same pre-existing `TS2304 Cannot find name 'CardSchema'` on both sides (no import in that fence on base either). This diff moves no fence verdict.

## Ablation (red-first evidence; each leg mutate → prove on disk by blob hash and anchor counts → run → `git checkout HEAD -- ABSOLUTE PATH` → prove restored by blob hash == HEAD blob; `trap` on EXIT INT TERM; final `git diff HEAD` empty)

- **Leg A — zod face** (`value` back to `z.string().optional()`; anchors `value: retirementTombstone(` 1→0, marker 0→1): the pin file → **exit 1, 6 failed / 12 passed** — the three refusal cases, the guidance case, the `safeValidateSchema` case and the DECLARED case; every inside-the-boundary, corpus, renderer and TS-erased leg stays green (that asymmetry is the point).
- **Leg B — TS face** (`value?: never` → `value?: string`; anchors 1→0 / 0→1): `tsc -p tsconfig.test.json` → **exit 2** — `TS2578 Unused '@ts-expect-error'` on exactly the three directives (`:300`, `:317`, `:337`) plus `zod-mirror-parity.test.ts(1522): TS2322 '"layout.zod.ts#TextSchema"' is not assignable to type 'never'` — the existing ledger catching the one-face drift.
- **Leg C — renderer** (`{schema.content}` → `{schema.content || schema.value}` at both arms; anchors 2→0 / 0→2): pin + `basic-renderers` + `bindable-text-keys-4795` + `undeclared-but-consumed-keys-6150` → **exit 1, 4 failed / 119 passed** — the two flipped component pins, #6150's read-site pin, and the off-disk read-set pin.
- All three restored: blob hashes equal HEAD's, `git diff HEAD` empty, `git status` clean.

## ADR-0087 disposition marker — the gate's own reading

Grep of `scripts/check-changeset-*.mjs` (4 scripts: `fixed`, `no-major`, `overwrite`, `presence`), `scripts/__tests__/*`, `.github/workflows/*` and `.changeset/README.md` for `adr-0087` / `disposition`: no gate in this repository reads a changeset or PR-body marker — the only hits are a prose entry in `scripts/__tests__/doc-version-claims.test.ts` (quoting a spec tombstone) and a comment in `changelog.yml`. objectstack's `check:adr-0087-registration` has no objectui counterpart. The four changeset gates ran (table above), all green. **No marker was added** — copying one from a sibling PR would be the deviation the ruling forbids; if the reviewing seat wants a marker, say which gate should read it.

## Deviations from the dispatch's file surface (declared, not silent)

1. The run was interrupted at ~13:36Z (account usage limit, HTTP 429) after the first full vitest pass and resumed at 15:26Z; nothing was reverted; `origin/main` merged twice before opening (`83c77dc3`, then `3e377c93` after the PM's notice that #7736 touched `layout.ts` in another region).
2. Surface expanded by the census: `context-menu.tsx` (a producer inside `@object-ui/components` — "nothing else in the package moves" was read as the renderer read site, and a fallback trigger that would render blank is the retirement's own consequence); three `plugin-dashboard` source files carrying four producer sites (none of their tests — the wording pins pass through the DOM unchanged); three READMEs; four component test files whose fixtures authored the retired key; two comment-only docblocks in `packages/types/src/base.ts` / `overlay.ts`. The changeset therefore also names `@object-ui/plugin-dashboard: patch` (the presence gate requires the declaration; behaviour is unchanged).
3. 14 filter-builder field descriptors excluded from the measured population by kind (and by position in the pin's walker) — they spell `type: "text"` but are not `text` nodes.
4. `check:doc-snippets` / `check:skill-examples` / `check:readme-exports` / `check:sdui-registration-pins` NOT MEASURED locally (above), differential fence measurement supplied.

## Out of scope — observed, not touched

- `skills/objectui/guides/schema-expressions.md:47`, `:479`, `:485` teach `{ "type": "text", "value": … }` as counter-examples with prose "`value` is read but never templated"; after this retirement the key is refused outright, so that prose is stale. `skills/**` is a governed surface (human merge) — handed back on the report, not edited here.
- Comments still describing the old `schema.content || schema.value` read, in files this PR does not otherwise touch: `packages/components/src/renderers/basic/span.tsx:131`, `examples/schema-catalog/test/catalog-authored-key-6805-6806.test.tsx:64`, `catalog-gallery-render.test.tsx:68`, `packages/react/src/__tests__/SchemaRenderer.bindableTextKeys.test.tsx:147` (its pin is about the carriage map and passes unchanged).
- The B half (`TreeViewSchema.data`) — its own PR, as the ruling requires.

Session: `https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAZFhALsQsGqxui8sNqM8s)_