### PR TITLE
fix(ui): the maker's edit-mode starter offers sample data, not an automation v1 cannot build (#7709)

### DIFF
--- a/.changeset/7709-edit-mode-chip-sample-data.md
+++ b/.changeset/7709-edit-mode-chip-sample-data.md
@@ -1,0 +1,24 @@
+---
+'@object-ui/i18n': minor
+'@object-ui/app-shell': minor
+---
+
+**The maker's edit-mode starter offers sample data, not an automation v1 cannot
+build (objectui#7709).** Bound to an existing app (`?package=`), the maker's
+empty state offered four starters: add a field, add an object, add a dashboard,
+and 「加一个自动化 —— 审批、状态流转或通知」. Approval, status flow and
+notification are all refused by ADR-0112 v1 (cloud#1956 / PR #1970), and the
+measured behaviour on the sibling chips was not a refusal but a silent degrade
+into a view — so the product recommended an automation and would have handed
+back a page.
+
+Rewording it was not available: asking for a field, a view or a dashboard
+duplicates one of the three chips beside it. The fourth chip is now
+`addSampleData` —「给现有对象补一批贴近真实的示例数据，好拿去演示。」 — in all
+ten packs and in the call-site `defaultValue` fallback, which is a second copy
+of the same string. The three surviving chips all add STRUCTURE; what an app
+that already has objects most often lacks is DATA, and `seed` is on v1's
+authoring whitelist. A note beside the keys in every pack and at the call site
+says this chip's automation wording comes back when ADR-0112 v2 re-adds flows
+and actions, and the retired sentence for each pack is kept in the guard suite
+so v2 has it verbatim.

--- a/packages/app-shell/src/console/ai/AiChatPage.tsx
+++ b/packages/app-shell/src/console/ai/AiChatPage.tsx
@@ -2611,12 +2611,24 @@ function genericSuggestions(t: TranslationFn): string[] {
 // ADR-0057 A1.b — edit-mode starters: when the build surface is bound to an
 // existing app (`?package=`), nudge toward INCREMENTAL changes to that app
 // rather than describing a new system from scratch.
+//
+// objectui#7709 — same rule as `metadataAssistantSuggestions()` above: these
+// are the PRODUCT's own recommendations, so they may only ask for what
+// ADR-0112 v1 BUILDS. The fourth chip used to be `addAutomation` ("an
+// approval, a status flow, or a notification") and every capability it named
+// is refused by v1 (cloud#1956 / PR #1970), so it now asks for sample data —
+// `seed` IS on v1's whitelist, and having no data is what an existing app most
+// often lacks. REVERT: when ADR-0112 v2 re-adds flows and actions, THIS chip's
+// automation wording comes back as `addAutomation`. The `defaultValue`s below
+// are byte-equal to the `en` pack.
 function editAppSuggestions(t: TranslationFn): string[] {
   return [
     t('console.ai.suggestions.editApp.addField', { defaultValue: 'Add a field to one of the objects.' }),
     t('console.ai.suggestions.editApp.addObject', { defaultValue: 'Add a new object and relate it to an existing one.' }),
     t('console.ai.suggestions.editApp.addDashboard', { defaultValue: 'Add a dashboard for the key metrics.' }),
-    t('console.ai.suggestions.editApp.addAutomation', { defaultValue: 'Add an automation — an approval, a status flow, or a notification.' }),
+    t('console.ai.suggestions.editApp.addSampleData', {
+      defaultValue: 'Fill the existing objects with realistic sample records so I can demo the app.',
+    }),
   ];
 }
 

--- a/packages/app-shell/src/console/ai/__tests__/AiChatPage.editChips-7709.test.ts
+++ b/packages/app-shell/src/console/ai/__tests__/AiChatPage.editChips-7709.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7709 — the CALL-SITE half of the maker's EDIT-mode chips.
+ *
+ * `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts` guards the
+ * ten packs. This guards the other copy of the same four strings: the
+ * `defaultValue` fallbacks in `editAppSuggestions()`, which are what a host
+ * with no I18nProvider (and any locale that ever loses the key) actually
+ * renders. cloud#1984 measured that shape on the sibling family — the packs
+ * were reworded and the fallbacks kept promising a status workflow, invisibly,
+ * on precisely the surface with the least i18n — so the two copies are pinned
+ * to each other here rather than trusted to stay in step.
+ *
+ * So: the edit-mode branch is reached at all, byte-equality with the `en` pack,
+ * and the same automation/approval-vocabulary ban.
+ */
+import { describe, it, expect } from 'vitest';
+import { builtInLocales } from '@object-ui/i18n';
+import { buildAgentSuggestions } from '../AiChatPage.js';
+
+/** A `t` that misses every key — i.e. what a provider-less host resolves. */
+const missEverything = (_key: string, options?: Record<string, unknown>): string =>
+  String(options?.defaultValue ?? _key);
+
+/** The `en` pack's edit-mode chip block. */
+const enChips = (
+  builtInLocales.en as {
+    console: { ai: { suggestions: { editApp: Record<string, string> } } };
+  }
+).console.ai.suggestions.editApp;
+
+const CHIP_KEYS = ['addField', 'addObject', 'addDashboard', 'addSampleData'] as const;
+
+/** The English half of the i18n suite's banned vocabulary. @see makerEditChips-v1-scope-7709 */
+const BANNED_EN = ['alert', 'remind', 'notif', 'automat', 'workflow', 'trigger', 'schedule', 'approv'];
+
+const editChips = () => buildAgentSuggestions('build', 'Build', missEverything, true);
+
+describe('editAppSuggestions — the build agent`s four edit-mode chips (objectui#7709)', () => {
+  it('renders the edit-mode starters when the surface is bound to an app', () => {
+    const chips = editChips();
+    expect(chips).toHaveLength(4);
+    // The `editing` flag is what selects this family; without it the from-
+    // scratch five are rendered and this suite would be guarding nothing.
+    expect(buildAgentSuggestions('build', 'Build', missEverything)).toHaveLength(5);
+  });
+
+  it('every `defaultValue` is byte-equal to the en pack', () => {
+    expect(editChips()).toEqual(CHIP_KEYS.map((k) => enChips[k]));
+  });
+
+  it('no fallback promises autonomous behaviour', () => {
+    for (const chip of editChips()) {
+      const hits = BANNED_EN.filter((term) => chip.toLowerCase().includes(term));
+      expect(hits, chip).toEqual([]);
+    }
+  });
+
+  it('the control: the retired wording WOULD have been flagged', () => {
+    // Non-vacuity, same reasoning as the pack-side suite: a banned list that
+    // has stopped matching anything passes the assertion above in silence.
+    const retired = 'Add an automation — an approval, a status flow, or a notification.';
+    const hits = BANNED_EN.filter((term) => retired.toLowerCase().includes(term));
+    expect(hits).toContain('automat');
+    expect(hits).toContain('approv');
+    expect(hits).toContain('notif');
+  });
+});

--- a/packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts
+++ b/packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts
@@ -1,0 +1,157 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7709 — the maker's EDIT-mode start chips, the sibling family of the
+ * five guarded by `makerStartChips-v1-scope-1984.test.ts`.
+ *
+ * `editAppSuggestions()` renders four starters when the build surface is bound
+ * to an EXISTING app (`?package=`). Three of them ask for structure — a field,
+ * an object, a dashboard — and all three are inside ADR-0112 v1's whitelist.
+ * The fourth was `addAutomation`: 「加一个自动化 —— 审批、状态流转或通知」,
+ * and approval / status flow / notification are ALL refused by v1 (cloud#1956 /
+ * PR #1970). Worse than a refusal, measured on the sibling chips: the model
+ * silently DEGRADES such a request into a view, so the chip promised an
+ * automation and delivered a page.
+ *
+ * The product ruling (epic cloud#1955, 2026-09-05) replaced it rather than
+ * dropping it: the three surviving chips all add STRUCTURE, and what an
+ * existing app most often lacks is DATA — `seed` is on v1's whitelist
+ * (`V1_METADATA_TYPES` in cloud `service-ai-studio/src/authoring-whitelist.ts`,
+ * commented "sample data"), so the fourth chip now asks for sample records.
+ *
+ * Same three-part shape as the 1984 suite, and the third part is what keeps the
+ * other two honest:
+ *
+ *  1. Every shipped pack carries all four chips, non-empty, and no fifth.
+ *  2. No chip in any pack uses vocabulary that promises autonomous behaviour or
+ *     an approval, scanned with that pack's OWN banned list — an English-only
+ *     scan would have declared the five non-Latin packs clean without reading a
+ *     character of them (AGENTS.md i18n forensics rule).
+ *  3. A NON-VACUITY control: each pack's banned list is re-run against the
+ *     `addAutomation` wording that pack actually shipped before this card, and
+ *     must flag it.
+ *
+ * REVERT the wording (and relax this suite) when ADR-0112 v2 re-adds flows and
+ * actions — the note beside the keys in every pack says so, and RETIRED below
+ * is where that pack's automation sentence is kept.
+ */
+import { describe, it, expect } from 'vitest';
+import { builtInLocales } from '../locales';
+
+type LocaleCode = keyof typeof builtInLocales;
+const LANGS = Object.keys(builtInLocales) as LocaleCode[];
+
+/** The four chips `editAppSuggestions()` renders, in order. */
+const CHIP_KEYS = ['addField', 'addObject', 'addDashboard', 'addSampleData'] as const;
+
+/** The pack's edit-mode chip block, reached through the shape the call site reads. */
+const chipsOf = (lang: LocaleCode) =>
+  (
+    builtInLocales[lang] as {
+      console?: { ai?: { suggestions?: { editApp?: Record<string, string> } } };
+    }
+  ).console?.ai?.suggestions?.editApp;
+
+/**
+ * Vocabulary that promises the product will ACT on its own — an automation, an
+ * approval, a status workflow, an alert, a reminder, a notification, a trigger,
+ * a schedule. Per locale, because the whole point is that the check reads each
+ * pack in its own script; substring matching with no ASCII word classes, since
+ * five of the ten packs are non-Latin and CJK has no word boundaries.
+ *
+ * The automation half is the `makerStartChips-v1-scope-1984` list verbatim (one
+ * v1 boundary, two families reading it). The approval half is added here: this
+ * chip's retired wording led with 审批 / approval, which that list did not name.
+ *
+ * Stems, not whole words: `automat` covers automate/automatic/automation and
+ * their Romance cognates, `notifi` covers notify/notification/notificación,
+ * `aprob` covers aprobación/aprobar.
+ */
+const BANNED: Record<LocaleCode, readonly string[]> = {
+  en: ['alert', 'remind', 'notif', 'automat', 'workflow', 'trigger', 'schedule', 'approv'],
+  zh: ['提醒', '预警', '警报', '自动', '流转', '通知', '触发', '定时', '审批'],
+  de: ['automat', 'erinner', 'warnung', 'alarm', 'benachrichtig', 'workflow', 'auslös', 'ablauf', 'freigabe', 'genehmig'],
+  fr: ['automat', 'alerte', 'rappel', 'notifi', 'workflow', 'flux', 'déclench', 'approbation', 'approuv'],
+  es: ['automat', 'alerta', 'recordar', 'recordatorio', 'notifi', 'flujo', 'disparador', 'aprob'],
+  pt: ['automa', 'alerta', 'lembr', 'notifi', 'fluxo', 'gatilho', 'aprova'],
+  ru: ['автомат', 'оповещ', 'уведомл', 'напомин', 'триггер', 'процесс', 'поток', 'согласован', 'утвержд'],
+  ja: ['自動', '通知', 'アラート', 'リマイン', 'ワークフロー', 'フロー', 'トリガー', '承認'],
+  ko: ['자동', '알림', '알람', '워크플로', '흐름', '트리거', '승인'],
+  ar: ['أتمتة', 'مؤتمت', 'تنبيه', 'إشعار', 'تذكير', 'سير عمل', 'موافقة', 'اعتماد'],
+};
+
+/** Every banned term this text hits, lower-cased for the case-insensitive scripts. */
+function bannedHits(lang: LocaleCode, text: string): string[] {
+  const haystack = text.toLocaleLowerCase(lang === 'zh' ? 'zh' : undefined);
+  return BANNED[lang].filter((term) => haystack.includes(term.toLocaleLowerCase()));
+}
+
+/**
+ * The `addAutomation` sentence each pack shipped BEFORE this card. Kept as the
+ * control sample AND as the record of what ADR-0112 v2 restores — not as a
+ * fixture to revert to today.
+ */
+const RETIRED: Record<LocaleCode, string> = {
+  en: 'Add an automation — an approval, a status flow, or a notification.',
+  zh: '加一个自动化 —— 审批、状态流转或通知。',
+  de: 'Füge eine Automatisierung hinzu — eine Freigabe, einen Statusablauf oder eine Benachrichtigung.',
+  fr: 'Ajoute une automatisation — une approbation, un flux de statuts ou une notification.',
+  es: 'Añade una automatización — una aprobación, un flujo de estados o una notificación.',
+  pt: 'Adicione uma automação — uma aprovação, um fluxo de status ou uma notificação.',
+  ru: 'Добавь автоматизацию — согласование, процесс статусов или уведомление.',
+  ja: '自動化を追加してください — 承認、ステータスフロー、または通知。',
+  ko: '자동화를 추가해 주세요 — 승인, 상태 흐름 또는 알림.',
+  ar: 'أضف أتمتة — موافقة أو سير حالات أو إشعارًا.',
+};
+
+describe('maker edit-mode chips — every shipped pack carries all four (objectui#7709)', () => {
+  it('covers all ten built-in packs', () => {
+    expect(LANGS).toHaveLength(10);
+  });
+
+  it.each(LANGS)('%s defines a non-empty string for every chip', (lang) => {
+    const block = chipsOf(lang);
+    expect(block, `${lang} has no console.ai.suggestions.editApp block`).toBeTruthy();
+    for (const key of CHIP_KEYS) {
+      expect(typeof block![key], `${lang}.${key}`).toBe('string');
+      expect(block![key].trim().length, `${lang}.${key} is empty`).toBeGreaterThan(0);
+    }
+    // No chip beyond the four the call site renders, and — the half that
+    // matters here — no `addAutomation` left behind in any pack.
+    expect(Object.keys(block!).sort()).toEqual([...CHIP_KEYS].sort());
+  });
+
+  it.each(LANGS)('%s: the four chips are four DIFFERENT asks', (lang) => {
+    // The replacement had to avoid duplicating the three chips beside it —
+    // that is precisely why "reword it like the other five" was not available
+    // and this became its own product call.
+    const block = chipsOf(lang)!;
+    const values = CHIP_KEYS.map((k) => block[k].trim());
+    expect(new Set(values).size, `${lang}: ${values.join(' | ')}`).toBe(CHIP_KEYS.length);
+  });
+});
+
+describe('maker edit-mode chips — none promises autonomous behaviour (objectui#7709)', () => {
+  it.each(LANGS)('%s: no chip uses that pack`s automation/approval vocabulary', (lang) => {
+    const block = chipsOf(lang)!;
+    for (const key of CHIP_KEYS) {
+      expect(bannedHits(lang, block[key]), `${lang}.${key}: "${block[key]}"`).toEqual([]);
+    }
+  });
+
+  it.each(LANGS)('%s: the banned list still flags the wording this pack retired', (lang) => {
+    // Non-vacuity. A green run above means nothing unless this is green too.
+    expect(bannedHits(lang, RETIRED[lang]).length, `${lang} control: "${RETIRED[lang]}"`).toBeGreaterThan(0);
+  });
+
+  it('the replaced chip asks for DATA, in the two languages the card quoted', () => {
+    expect(chipsOf('en')!.addSampleData).toContain('sample records');
+    expect(chipsOf('zh')!.addSampleData).toContain('示例数据');
+  });
+});

--- a/packages/i18n/src/locales/ar.ts
+++ b/packages/i18n/src/locales/ar.ts
@@ -1643,11 +1643,21 @@ const ar = {
           availableObjects: "اذكر كائنات البيانات المتاحة.",
           recentActivity: "لخّص نشاطي الأخير.",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "أضف حقلًا إلى أحد الكائنات.",
           addObject: "أضف كائنًا جديدًا واربطه بكائن موجود.",
           addDashboard: "أضف لوحة معلومات للمؤشرات الرئيسية.",
-          addAutomation: "أضف أتمتة — موافقة أو سير حالات أو إشعارًا.",
+          addSampleData: "املأ الكائنات الحالية ببيانات نموذجية واقعية تصلح للعرض التوضيحي.",
         },
       },
       changesTitle: "تأكيد التغييرات",

--- a/packages/i18n/src/locales/de.ts
+++ b/packages/i18n/src/locales/de.ts
@@ -1636,11 +1636,21 @@ const de = {
           availableObjects: "Liste die verfügbaren Datenobjekte auf.",
           recentActivity: "Fasse meine letzten Aktivitäten zusammen.",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "Füge einem der Objekte ein Feld hinzu.",
           addObject: "Füge ein neues Objekt hinzu und verknüpfe es mit einem bestehenden.",
           addDashboard: "Füge ein Dashboard für die wichtigsten Kennzahlen hinzu.",
-          addAutomation: "Füge eine Automatisierung hinzu — eine Freigabe, einen Statusablauf oder eine Benachrichtigung.",
+          addSampleData: "Fülle die vorhandenen Objekte mit realistischen Beispieldatensätzen, damit ich die App vorführen kann.",
         },
       },
       changesTitle: "Änderungen bestätigen",

--- a/packages/i18n/src/locales/en.ts
+++ b/packages/i18n/src/locales/en.ts
@@ -1996,11 +1996,21 @@ const en = {
           availableObjects: 'List the available data objects.',
           recentActivity: 'Summarize my recent activity.',
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: 'Add a field to one of the objects.',
           addObject: 'Add a new object and relate it to an existing one.',
           addDashboard: 'Add a dashboard for the key metrics.',
-          addAutomation: 'Add an automation — an approval, a status flow, or a notification.',
+          addSampleData: 'Fill the existing objects with realistic sample records so I can demo the app.',
         },
       },
       // objectui#3546 slice four — the AI console surfaces: the /ai chat page's app switcher,

--- a/packages/i18n/src/locales/es.ts
+++ b/packages/i18n/src/locales/es.ts
@@ -1640,11 +1640,21 @@ const es = {
           availableObjects: "Enumera los objetos de datos disponibles.",
           recentActivity: "Resume mi actividad reciente.",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "Añade un campo a uno de los objetos.",
           addObject: "Añade un objeto nuevo y relaciónalo con uno existente.",
           addDashboard: "Añade un panel para las métricas clave.",
-          addAutomation: "Añade una automatización — una aprobación, un flujo de estados o una notificación.",
+          addSampleData: "Rellena los objetos existentes con registros de ejemplo realistas para poder mostrar la aplicación.",
         },
       },
       changesTitle: "Confirmar cambios",

--- a/packages/i18n/src/locales/fr.ts
+++ b/packages/i18n/src/locales/fr.ts
@@ -1638,11 +1638,21 @@ const fr = {
           availableObjects: "Liste les objets de données disponibles.",
           recentActivity: "Résume mon activité récente.",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "Ajoute un champ à l'un des objets.",
           addObject: "Ajoute un nouvel objet et relie-le à un objet existant.",
           addDashboard: "Ajoute un tableau de bord pour les indicateurs clés.",
-          addAutomation: "Ajoute une automatisation — une approbation, un flux de statuts ou une notification.",
+          addSampleData: "Remplis les objets existants avec des données d'exemple réalistes pour que je puisse présenter l'application.",
         },
       },
       changesTitle: "Confirmer les modifications",

--- a/packages/i18n/src/locales/ja.ts
+++ b/packages/i18n/src/locales/ja.ts
@@ -1638,11 +1638,21 @@ const ja = {
           availableObjects: "利用できるデータオブジェクトを一覧にしてください。",
           recentActivity: "最近の自分の活動を要約してください。",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "いずれかのオブジェクトに項目を追加してください。",
           addObject: "新しいオブジェクトを追加し、既存のものと関連づけてください。",
           addDashboard: "主要指標のダッシュボードを追加してください。",
-          addAutomation: "自動化を追加してください — 承認、ステータスフロー、または通知。",
+          addSampleData: "既存のオブジェクトに、デモで使えるリアルなサンプルデータを入れてください。",
         },
       },
       changesTitle: "変更の確認",

--- a/packages/i18n/src/locales/ko.ts
+++ b/packages/i18n/src/locales/ko.ts
@@ -1636,11 +1636,21 @@ const ko = {
           availableObjects: "사용 가능한 데이터 객체를 나열해 주세요.",
           recentActivity: "내 최근 활동을 요약해 주세요.",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "객체 중 하나에 필드를 추가해 주세요.",
           addObject: "새 객체를 추가하고 기존 객체와 연결해 주세요.",
           addDashboard: "핵심 지표를 위한 대시보드를 추가해 주세요.",
-          addAutomation: "자동화를 추가해 주세요 — 승인, 상태 흐름 또는 알림.",
+          addSampleData: "기존 객체에 데모에서 보여 줄 만한 현실적인 샘플 데이터를 채워 주세요.",
         },
       },
       changesTitle: "변경 확인",

--- a/packages/i18n/src/locales/pt.ts
+++ b/packages/i18n/src/locales/pt.ts
@@ -1635,11 +1635,21 @@ const pt = {
           availableObjects: "Liste os objetos de dados disponíveis.",
           recentActivity: "Resuma minha atividade recente.",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "Adicione um campo a um dos objetos.",
           addObject: "Adicione um novo objeto e relacione-o a um existente.",
           addDashboard: "Adicione um painel para as métricas principais.",
-          addAutomation: "Adicione uma automação — uma aprovação, um fluxo de status ou uma notificação.",
+          addSampleData: "Preencha os objetos existentes com registros de exemplo realistas para eu poder demonstrar o aplicativo.",
         },
       },
       changesTitle: "Confirmar alterações",

--- a/packages/i18n/src/locales/ru.ts
+++ b/packages/i18n/src/locales/ru.ts
@@ -1648,11 +1648,21 @@ const ru = {
           availableObjects: "Перечисли доступные объекты данных.",
           recentActivity: "Сделай сводку моей недавней активности.",
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: "Добавь поле в один из объектов.",
           addObject: "Добавь новый объект и свяжи его с существующим.",
           addDashboard: "Добавь дашборд с ключевыми показателями.",
-          addAutomation: "Добавь автоматизацию — согласование, процесс статусов или уведомление.",
+          addSampleData: "Заполни существующие объекты правдоподобными демонстрационными записями, чтобы приложение можно было показать.",
         },
       },
       changesTitle: "Подтвердите изменения",

--- a/packages/i18n/src/locales/zh.ts
+++ b/packages/i18n/src/locales/zh.ts
@@ -1827,11 +1827,21 @@ const zh = {
           availableObjects: '列出可用的数据对象。',
           recentActivity: '总结我的最近动态。',
         },
+        // objectui#7709 — the edit-mode starters, shown when the maker is bound
+        // to an EXISTING app (`?package=`). Same rule as the five above: they
+        // may only ask for what ADR-0112 v1 BUILDS. The fourth chip used to be
+        // `addAutomation` ("an approval, a status flow, or a notification") and
+        // every capability it named is refused by v1 (cloud#1956 / PR #1970), so
+        // it now asks for sample data — `seed` IS on v1's whitelist, and having
+        // no data is what an existing app most often lacks. REVERT: when
+        // ADR-0112 v2 re-adds flows and actions, THIS chip's automation wording
+        // comes back as `addAutomation`; the retired string is pinned for every
+        // pack in `packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts`.
         editApp: {
           addField: '给某个对象加一个字段。',
           addObject: '新增一个对象，并关联到已有对象。',
           addDashboard: '加一个展示关键指标的仪表盘。',
-          addAutomation: '加一个自动化 —— 审批、状态流转或通知。',
+          addSampleData: '给现有对象补一批贴近真实的示例数据，好拿去演示。',
         },
       },
       // objectui#3546 slice four — the AI console surfaces: the /ai chat page's app switcher,


### PR DESCRIPTION
Closes #7709. Verified on `4d1e0be1b`.

⚠️ **cloud needs a `.objectui-sha` bump before this reaches the product** — the chip a tenant sees does not change until that pin moves. cloud#2008 / PR #2009 is already queued and carries objectui#7710; this one needs the next bump after it.

---

## The ruling

The card laid out two honest options and said which one was right is a product call, not a translation fix. The ruling on the epic cloud#1955 lane, 2026-09-05, is **option 2 — replace the fourth chip with sample data**, and the reasoning is the shape of the family:

> 另外三个编辑态 chip（加字段 / 加对象 / 加仪表盘）都在**加结构**，而一个已有应用最常见的缺失是**没有数据** …… 换成页面或日历视图都更小众；砍成三个则白丢一个位置且与 v2 回滚不对称。

So: the three surviving chips all add STRUCTURE, and what an app that already HAS objects most often lacks is DATA. A page or a calendar view is the more niche ask; dropping to three starters throws a slot away and is asymmetric with the v2 restore.

**Checked on contact rather than assumed, because a second broken promise would have been worse than the first:** `seed` is on v1's authoring whitelist — cloud `packages/service-ai-studio/src/authoring-whitelist.ts`, `V1_METADATA_TYPES`, listed with the comment *"`seed` (sample data)"*. The whitelist is version-scoped, not mode-scoped, and its own header states that every authoring path reads it and nothing else, `apply_edit` — the edit-mode path — named among them. So the maker bound to an existing app can author this, and the new chip is not a second refusal.

## What was wrong

`editAppSuggestions()` renders four starters for the maker bound to an existing app (`?package=`). The fourth was `console.ai.suggestions.editApp.addAutomation`:

- en: `Add an automation — an approval, a status flow, or a notification.`
- zh: 「加一个自动化 —— 审批、状态流转或通知。」

Approval, status flow and notification are all refused by ADR-0112 v1 (cloud#1956 / PR #1970). The measured failure mode on the sibling chip family (cloud#1984) was not a refusal but a **silent degrade into a view** — so the product recommended an automation and would have handed back a page, with nothing telling the user that is what happened.

Rewording it the way the five from-scratch chips were reworded was not available: a field, a view or a dashboard duplicates one of the three chips beside it. That is exactly why the card was filed separately instead of folded into #7710.

## What changed

The key is now `console.ai.suggestions.editApp.addSampleData`, in **all ten packs** and in the **call-site `defaultValue` fallback** — the second copy of the same string, which #7710 measured is where a scope fix gets applied to only one of the two and keeps the old promise alive on precisely the surface with the least i18n. All ten packs carried a full translation of the old key (none was fallback-only), so ten real sentences went in, each written as a business ask in its own language rather than a literal rendering of "add sample data":

| pack | new fourth chip |
|---|---|
| en | Fill the existing objects with realistic sample records so I can demo the app. |
| zh | 给现有对象补一批贴近真实的示例数据，好拿去演示。 |
| ja | 既存のオブジェクトに、デモで使えるリアルなサンプルデータを入れてください。 |
| ko | 기존 객체에 데모에서 보여 줄 만한 현실적인 샘플 데이터를 채워 주세요. |
| de / fr / es / pt / ru / ar | same ask, each in its own idiom — see the diff |

**Key renamed, not just revalued.** A key literally named `addAutomation` serving a sample-data sentence is the declared-vs-actual drift this repo keeps paying for, and it would send a future editor grepping for "automation" to the wrong conclusion. Renaming also makes the v2 restore additive: `addAutomation` comes back under its own name instead of overwriting the chip that replaced it. `check:i18n-drift` reads the rename as a key-set change and correctly defers to `all-locales-key-parity`, which is green.

**The REVERT note is beside the keys in every pack and at the call site**, following #7710's precedent, and it is specific to THIS chip: when ADR-0112 v2 re-adds flows and actions, this chip's automation wording comes back as `addAutomation`. Each pack's retired sentence is kept verbatim in the new guard suite, so v2 does not have to reconstruct ten translations from git history.

## Verification

Host is macOS on Node v26.7.0; CI runs Node 22.x. **`scripts/pm/os-verify-lock.sh` reported `UNLOCKED (declared)` on every run** — no usable `flock` on this host, so the shared verify lock was never taken and nothing was serialized. Declared, not claimed.

| what | command | result |
|---|---|---|
| build (dep closures) | `pnpm --filter '@object-ui/i18n^...' --filter '@object-ui/app-shell^...' run build` | exit **0** |
| type-check | `pnpm --filter @object-ui/i18n --filter @object-ui/app-shell run type-check` | exit **0**, both `Done` |
| tests | `pnpm exec vitest run packages/i18n/ packages/app-shell/src/console/ai/` | exit **0** — `Test Files 84 passed (84)`, `Tests 1162 passed (1162)` |
| the two new suites + the two #7710 suites + key parity | `pnpm exec vitest run` on the five files | exit **0** — `Test Files 5 passed (5)`, `Tests 114 passed (114)` |
| lint (whole farm) | `pnpm lint` | exit **0** — `Tasks: 47 successful, 47 total`, `0 errors` (2883 warnings, the same count `main` carries) |
| lint (this diff) | `eslint --no-inline-config --format json` on the 13 changed files | exit **0** — 13 files, **0 errors**, 31 warnings, every one pre-existing in `AiChatPage.tsx` and none in the edited region |
| i18n gates | `check:i18n-keys`, `check:i18n-drift`, `check:control-bytes` | exit **0**, **0**, **0** — drift: *"0 en value(s) changed (1 key(s) added, 1 removed — those are all-locales-key-parity's)"* |
| changeset gates | `check-changeset-presence.mjs`, `check-changeset-no-major.mjs` | exit **0**, **0** — *"13 source file(s) of 2 released package(s) changed, and this change declares 1 changeset(s)"* |

The whole table was re-run on the final commit `4d1e0be1b`; exit codes were captured before any pipe.

### The two new suites

`packages/i18n/src/__tests__/makerEditChips-v1-scope-7709.test.ts` (42 cases) — all four keys present, non-empty and exactly four in each of the ten packs (which is also what proves no pack kept an `addAutomation` behind); the four chips are four DIFFERENT asks in every pack, which is the constraint that made "reword it like the others" unavailable in the first place; and no chip matches that pack's OWN automation/approval vocabulary. Scanning in each pack's own script matters: an English-only scan would have declared the five non-Latin packs clean without reading a character of them. The banned lists are #7710's automation vocabulary verbatim (one v1 boundary, two families reading it) plus an approval stem per locale, which this chip's wording needed and that list did not name.

`packages/app-shell/src/console/ai/__tests__/AiChatPage.editChips-7709.test.ts` (4 cases) — the call-site copy: the `editing` branch is reached at all (and the from-scratch branch still returns five, so the suite cannot silently be guarding the wrong family), byte-equality with the `en` pack, and the same ban on the fallbacks.

### Non-vacuity

Both suites carry their control **in the file** rather than as a one-off run: each pack's banned list is re-run against the `addAutomation` sentence that pack actually shipped, and must flag it. A list that silently stops matching therefore fails the suite instead of passing it. The call-site control additionally pins which three terms the retired English sentence must hit (`automat`, `approv`, `notif`), so deleting any one of them from the list turns the suite red rather than quietly narrowing it.

### Not done

No browser run. The card's re-check is "open the maker bound to an existing app on an empty thread and read the fourth starter", and that needs a tenant environment with a published package; the change is ten strings plus one `defaultValue`, and both copies are pinned to each other and to the packs by the suites above. Stated rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
