### PR TITLE
fix(test-infra): the SDUI registration pins attribute a key to its source spelling, not to whichever spelling was built

### DIFF
--- a/scripts/__tests__/check-sdui-registration-pins.test.ts
+++ b/scripts/__tests__/check-sdui-registration-pins.test.ts
@@ -13,6 +13,7 @@ import {
   countChunksCarrying,
   derivePinnedKeys,
   main,
+  sourceFirstEntries,
 } from '../check-sdui-registration-pins.mjs';
 
 /**
@@ -28,8 +29,18 @@ import {
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
-/** A fixture root: one array package with one registrar, plus a fake console dist. */
-function fixture(chunks: Record<string, string>): string {
+/** The registrar body both spellings of the fixture package carry. */
+const REGISTRAR = "import { ComponentRegistry } from 'somewhere';\nComponentRegistry.register('fixture:widget', 1);\n";
+
+/**
+ * A fixture root: one array package with one registrar, plus a fake console dist.
+ *
+ * `built` writes the package's PUBLISHED spelling too. The array always names
+ * both (that is the `check-side-effects-array` rule), but only a built tree has
+ * both on disk — so this flag is how a case states which build state it means
+ * instead of inheriting the runner's, which is objectui#6893's whole subject.
+ */
+function fixture(chunks: Record<string, string>, { built = false }: { built?: boolean } = {}): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'objectui-6683-pins-'));
   fs.writeFileSync(path.join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
   const pkg = path.join(dir, 'packages/pkg');
@@ -42,10 +53,11 @@ function fixture(chunks: Record<string, string>): string {
       sideEffects: ['./dist/index.js', './src/index.ts'],
     }),
   );
-  fs.writeFileSync(
-    path.join(pkg, 'src/index.ts'),
-    "import { ComponentRegistry } from 'somewhere';\nComponentRegistry.register('fixture:widget', 1);\n",
-  );
+  fs.writeFileSync(path.join(pkg, 'src/index.ts'), REGISTRAR);
+  if (built) {
+    fs.mkdirSync(path.join(pkg, 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(pkg, 'dist/index.js'), REGISTRAR);
+  }
   const assets = path.join(dir, 'apps/console/dist/assets');
   fs.mkdirSync(assets, { recursive: true });
   for (const [name, code] of Object.entries(chunks)) fs.writeFileSync(path.join(assets, name), code);
@@ -132,6 +144,91 @@ describe('the fixture console', () => {
   });
 });
 
+describe('the source spelling wins, whatever the tree has been built to', () => {
+  // objectui#6893. A `sideEffects` array names every registrar TWICE — once as
+  // `src/x.tsx`, once as `dist/x.js` — and `derivePinnedKeys` attributes a key
+  // to the FIRST module it read it from. With no order of its own, the winner
+  // was decided by the array's literal order in `package.json` AND by whether
+  // `dist/` happened to be on disk. `packages/app-shell/dist` is gitignored, so
+  // the SAME COMMIT answered the source spelling on an unbuilt checkout and the
+  // published one on a built checkout — a verdict that is a function of hidden
+  // local state, which is the family this repo keeps paying for.
+  //
+  // The two cases below are ONE assertion run over the two build states, which
+  // is the property itself. They use a fixture rather than the workspace on
+  // purpose: a fixture owns its own build state, so these cases keep asserting
+  // the preference on a machine where nothing has been built — exactly the
+  // machines a conditional skip would have stopped running on.
+  const chunk = { 'index-abc.js': "R.register('fixture:widget',1)" };
+
+  it('attributes the key to the SOURCE spelling when BOTH spellings are on disk', () => {
+    const dir = fixture(chunk, { built: true });
+    try {
+      const { keys, sources, modulesRead } = derivePinnedKeys(dir);
+      // Both spellings were still READ: this is a reordering, not a filter, so
+      // the derived population — the only input to the gate's verdict — cannot
+      // move. If this drops to 1 the fix has started hiding modules instead.
+      expect(modulesRead).toBe(2);
+      expect(keys).toEqual(['fixture:widget']);
+      expect(sources.get('fixture:widget')).toBe('packages/pkg/src/index.ts');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('gives that same answer when only the source spelling is on disk', () => {
+    const dir = fixture(chunk);
+    try {
+      const { keys, sources, modulesRead } = derivePinnedKeys(dir);
+      expect(modulesRead).toBe(1);
+      expect(keys).toEqual(['fixture:widget']);
+      expect(sources.get('fixture:widget')).toBe('packages/pkg/src/index.ts');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('THROWS rather than falling back to array order when the two spellings cannot be told apart', () => {
+    // The ordering is derived from the package's own spelling map. When that map
+    // cannot be derived there is no source-first answer, and quietly reverting
+    // to array order would restore the build-state-dependent attribution above
+    // — silently, which is the failure this gate exists to refuse. Loud instead;
+    // `scripts/check-side-effects-array.mjs` owns this condition and already
+    // reports it as exit 2, so such a workspace is red there too.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'objectui-6893-nomap-'));
+    try {
+      fs.writeFileSync(path.join(dir, 'pnpm-workspace.yaml'), "packages:\n  - 'packages/*'\n");
+      const pkg = path.join(dir, 'packages/pkg');
+      fs.mkdirSync(path.join(pkg, 'src'), { recursive: true });
+      // `main` names the SOURCE barrel, so the manifest publishes no
+      // `index.js`-shaped entry and the map has nothing to anchor on.
+      fs.writeFileSync(
+        path.join(pkg, 'package.json'),
+        JSON.stringify({ name: '@fixture/pkg', main: './src/index.ts', sideEffects: ['./src/index.ts'] }),
+      );
+      fs.writeFileSync(path.join(pkg, 'src/index.ts'), REGISTRAR);
+      expect(() => derivePinnedKeys(dir)).toThrow(/source spelling from its published one/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps every declared entry — it reorders the read, it does not filter it', () => {
+    // The population guard for the reordering itself: a partition that dropped
+    // an entry would shrink the derived key set without any assertion noticing.
+    const declared = ['dist/index.js', 'src/index.ts', 'src/styles.css', 'dist/a/b.js', 'src/a/b.tsx'];
+    const dir = fixture(chunk, { built: true });
+    try {
+      const pkg = { name: '@fixture/pkg', dir: 'packages/pkg', declared, manifest: { main: './dist/index.js' } };
+      const ordered = sourceFirstEntries(pkg, dir);
+      expect([...ordered].sort()).toEqual([...declared].sort());
+      expect(ordered.slice(0, 3).every((e) => e.startsWith('src/'))).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('the real workspace', () => {
   it('derives the keys from the arrays, and the ruled controls are among them', () => {
     const { keys, sources, unreadable, modulesRead } = derivePinnedKeys(repoRoot);
@@ -142,7 +239,13 @@ describe('the real workspace', () => {
       expect(keys, `${control} is one of the three registrations the 2026-08-29 ruling pins`).toContain(control);
     }
     // The derivation must point at the module it read the key from, or a drop
-    // would be reported without saying which array entry promised it.
+    // would be reported without saying which array entry promised it — and it
+    // must point at the SOURCE module, the one an author can go and fix, not at
+    // the gitignored build artifact beside it. Before objectui#6893 this line
+    // was the workspace's build state in disguise: green on an unbuilt checkout,
+    // red on a built one, same commit. The preference itself is pinned above on
+    // a fixture that owns its build state; this line is the real workspace's
+    // half, and it now holds in every build state.
     expect(sources.get('mcp:connect-agent')).toBe(
       'packages/app-shell/src/console/connect/ConnectAgentWidget.tsx',
     );

--- a/scripts/check-sdui-registration-pins.mjs
+++ b/scripts/check-sdui-registration-pins.mjs
@@ -59,7 +59,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { findComponentRegistrations } from './component-registrations.mjs';
-import { readArrayPackages } from './check-side-effects-array.mjs';
+import { deriveSpellingMap, readArrayPackages } from './check-side-effects-array.mjs';
 import { isEntrypoint } from './invoked-as.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -92,8 +92,61 @@ export const RULED_CONTROLS = Object.freeze([
 export const NEGATIVE_CONTROL_KEY = 'objectui:6683-registration-pin-negative-control';
 
 /**
+ * `pkg.declared`, ordered so a module's SOURCE spelling is read before its
+ * PUBLISHED spelling.
+ *
+ * ## Why the order is fixed here rather than left to the array (objectui#6893)
+ *
+ * A `sideEffects` array names every registering module TWICE -- once as
+ * `src/x.tsx`, once as `dist/x.js` (see `check-side-effects-array.mjs`: both
+ * spellings are required, because consumers resolve the published one and
+ * in-repo bundler aliases resolve the source one). {@link derivePinnedKeys}
+ * attributes each key to the FIRST module it read the key from, so without an
+ * order of its own the attribution was decided by two things that have nothing
+ * to say about it: the literal order of the entries in `package.json`, and
+ * whether `dist/` happens to be on disk. `packages/app-shell/dist` is
+ * gitignored, so the SAME COMMIT attributed `mcp:connect-agent` to
+ * `.../src/console/connect/ConnectAgentWidget.tsx` on an unbuilt checkout and to
+ * `.../dist/console/connect/ConnectAgentWidget.js` on a built one.
+ *
+ * The published spelling is still READ -- `keys` is a union deduplicated by key,
+ * so reordering cannot change the derived population, only which spelling is
+ * reported for it. Source-first is the right end of that choice because the
+ * attribution is a diagnostic pointing an author at the module to go fix, and
+ * `dist/` is a build artifact nobody edits.
+ *
+ * `srcRoot` comes from the package's own derived spelling map rather than from a
+ * hardcoded `dist` test, so there is no second answer here to "which prefix is
+ * the source one" that could rot away from the one `check-side-effects-array`
+ * derives and round-trip-checks.
+ *
+ * @param {{name: string, dir: string, manifest: object, declared: string[]}} pkg
+ * @param {string} [root]
+ * @returns {string[]}
+ */
+export function sourceFirstEntries(pkg, root = REPO_ROOT) {
+  const map = deriveSpellingMap(pkg, root);
+  if (map.error) {
+    // Falling back to the array's own order would restore exactly the
+    // build-state-dependent attribution above, and it would do it silently.
+    // `scripts/check-side-effects-array.mjs` owns this condition and already
+    // reports it as exit 2, so a workspace that reaches here is red there too.
+    throw new Error(
+      `${pkg.name}: this gate cannot tell the package's source spelling from its published one — ` +
+        `${map.error}. Without that, the key attribution below falls back to array order, which is what ` +
+        `made this derivation answer differently on a built and an unbuilt checkout (objectui#6893).`,
+    );
+  }
+  const isSource = (entry) => entry === map.srcRoot || entry.startsWith(`${map.srcRoot}/`);
+  return [...pkg.declared.filter(isSource), ...pkg.declared.filter((entry) => !isSource(entry))];
+}
+
+/**
  * Every component key registered by a module some package's `sideEffects` array
  * names. Derived; see the header.
+ *
+ * The per-package read order is {@link sourceFirstEntries}, so `sources`
+ * answers the same spelling whether or not the tree has been built.
  *
  * @param {string} [root]
  * @returns {{keys: string[], sources: Map<string, string>, unreadable: string[], modulesRead: number}}
@@ -105,7 +158,7 @@ export function derivePinnedKeys(root = REPO_ROOT) {
   let modulesRead = 0;
 
   for (const pkg of readArrayPackages(root)) {
-    for (const entry of pkg.declared) {
+    for (const entry of sourceFirstEntries(pkg, root)) {
       if (!/\.(ts|tsx|mts|js|jsx|mjs)$/.test(entry)) continue;
       const abs = path.join(root, pkg.dir, entry);
       if (!fs.existsSync(abs)) continue; // a `dist/*` spelling in an unbuilt tree


### PR DESCRIPTION
Fixes #6893

`scripts/__tests__/check-sdui-registration-pins.test.ts` had a verdict that was a function of untracked local state: `packages/app-shell/dist` is gitignored (`git ls-files` returns 0 entries) and `derivePinnedKeys` walks the filesystem with `fs.existsSync`, so the **same commit** passed on an unbuilt checkout and failed on a built one — a permanent red sitting in the same file as the pins that actually matter.

## 1. The load-bearing measurement — is the `dist` preference deliberate?

**It is not, and it is not expressed anywhere in the gate.** The measurement, not taste, selects the repair.

**Static half.** `derivePinnedKeys` attributes a key to the first module it read the key from (`if (!sources.has(key))`, `check-sdui-registration-pins.mjs:119`). Nothing in the gate says "prefer dist". The preference was a by-product of two facts with nothing to say about it:

1. `packages/app-shell/package.json` lists all fifteen `./dist/*.js` entries **before** all fifteen `./src/*` entries — the array names every registrar in **both** spellings, which is `check-side-effects-array.mjs`'s own rule ("the array names EXACTLY: entry forms + every module ... in BOTH its source and its published spelling");
2. whether `dist/` is on disk.

The `sources` map is read at exactly four sites, and only one of them can reach a verdict:

| site | use | spelling-sensitive? |
|:--|:--|:--|
| `:187` the `RULED_CONTROLS` floor | `sources.has(key)` — membership only | no |
| `:201` `--list` output | diagnostic | column only |
| `:233` per-key report row | diagnostic | column only |
| `:234` dropped-key error message | diagnostic | column only |

The verdict itself is a function of `keys` (a **union deduplicated by key**), `unreadable`, `modulesRead`, the chunk list and the sentinel. Reordering the read cannot move a union.

**Empirical half — the real gate, run end to end on a fully built tree** (39 package `dist/` dirs plus `apps/console/dist/assets`, 518 chunks), pre-fix binary recovered with `git show HEAD:...` so both arms are real runs of real code:

```
PRE-FIX  gate exit=0   16 key(s) derived from 32 module(s)
POST-FIX gate exit=0   16 key(s) derived from 32 module(s)
diff of the per-key chunk-count column: IDENTICAL
✅ All 16 registration(s) a `sideEffects` array promises are present in the built console
   (518 chunks weighed; the 3 ruled control(s) are in the derived set).      <- both arms, verbatim
```

Only the source column moved, e.g. `mcp:connect-agent` from `packages/app-shell/dist/console/connect/ConnectAgentWidget.js` to `packages/app-shell/src/console/connect/ConnectAgentWidget.tsx`. `modulesRead` stayed at **32**, so the published spelling is still read — this is a reordering, not a filter.

⇒ **Option 1 (source-first)**, per the triage ruling of 2026-09-04. Option 2 was never in play (a conditional skip stops the case running on exactly the machines where it fires); option 3 is the branch the ruling reserved for a load-bearing `dist` preference, and the measurement says there is none.

`srcRoot` comes from the package's own `deriveSpellingMap` — derived from the manifest and round-trip-checked — rather than a hardcoded `dist` test, so this file does not grow a second answer to "which prefix is the source one". A package whose spelling map cannot be derived **throws** rather than quietly reverting to array order; `check-side-effects-array.mjs` owns that condition and already reports it as exit 2 (`ci.yml:341`), so such a workspace is red there too.

## 2. Does CI hit this? **No — and the reason is step order, measured, not assumed.**

The card left this unmeasured and one seat had read it one way. Read out of `.github/workflows/ci.yml` (read-only; PR #7789 is editing that file):

**`test` job — "Test (shard N/4)", `ci.yml:611`.** This is the job that owns `scripts/__tests__/`. Its steps, in order:

| line | step |
|--:|:--|
| 639 | Checkout code |
| 651 | Decide whether this change needs a full run |
| 679 | Enable Corepack |
| 683 | Verify pnpm version |
| 687 | Setup Node.js |
| 694-696 | Install dependencies — `pnpm install --frozen-lockfile` |
| **702-704** | **Run tests — `pnpm test --shard=N/4`** |
| 720-722 | Run built-artifact pins — `pnpm test:dist` (shard 1 only, **after** the tests) |

**There is no build step before `pnpm test`.** The push lane `test-coverage` (`ci.yml:789`) has the same shape: install at 821-822, tests at 830-831, no build.

The only two build invocations anywhere in `ci.yml` are `ci.yml:1182` (`pnpm --filter @object-ui/console exec vite build`, inside the `e2e` job at 1104) and `ci.yml:1503` (`pnpm turbo run build --filter='@object-ui/site'`, inside the `docs` job at 1371). Both are **different jobs**, i.e. different runners with different filesystems, so neither can put `packages/app-shell/dist` on the `test` job's disk.

`pnpm test:dist` at 720-722 is `turbo run test:dist --filter=@object-ui/components` and runs **after** the shard's `pnpm test`, so it cannot affect it either.

Confirming the install leg empirically rather than by reading: `pnpm install` in a fresh worktree of this branch left **0 of 42** package directories with a `dist/`.

⇒ **CI never reproduced this.** The failure was invisible to CI and visible only on developer and agent machines — which is exactly why it survived, and why it was cheap in the way the card describes. The real gate, `pnpm check:sdui-registration-pins`, runs in the **other** direction: `performance-budget.yml:393-394`, after "Build packages" (`:177-179`) and "Build Console" (`:181-182`), so it has always seen the `dist` spelling. That is the run the measurement above reproduces, and its verdict is unchanged.

## 3. Verification — every reading names its build state

Command, once per state, from the repo root: `pnpm exec vitest run --maxWorkers=2 scripts/__tests__/`. Post-fix readings are at `04754509a` on a clean tree.

| build state | how it was made | before fix | after fix |
|:--|:--|:--|:--|
| **completely unbuilt** | fresh worktree + `pnpm install`; **0 of 42** package dirs with `dist/` | 102 files / 3009 tests, **all green** — the control: this card's red really is caused by `dist` | 102 files / **3013** tests, **all green** |
| **fully built** | `turbo run build --filter='./packages/*'` (39 tasks) + `--filter @object-ui/console build`; `packages/app-shell/dist` present | 102 files / 3009 tests, **1 file / 1 test RED** — this card, on a real tree, no mutation | 102 files / 3013 tests, **all green** |
| **half built** | fully built, then `packages/plugin-gantt/dist` moved aside (a non-`app-shell` package) | 102 files / 3009, 2 files / 3 tests red: this card ×1 **+ `check-readme-exports.test.ts` ×2** | 102 files / 3013, 2 files / 3 tests red — **this card: 0** (the string `check-sdui-registration-pins` appears 0 times in the failure log) |

The pre-fix red, on a real tree, byte-identical to the card:

```
FAIL  |unit| scripts/__tests__/check-sdui-registration-pins.test.ts > the real workspace >
      derives the keys from the arrays, and the ruled controls are among them
AssertionError: expected 'packages/app-shell/dist/console/conne…' to be 'packages/app-shell/src/console/connec…'
Expected: "packages/app-shell/src/console/connect/ConnectAgentWidget.tsx"
Received: "packages/app-shell/dist/console/connect/ConnectAgentWidget.js"
```

**The two reds still in the half-built row are not this diff's**, and neither was touched:

- `check-readme-exports.test.ts` ×2 — that is **#7460**'s file and #7460's documented half-built behaviour. It is red in that state before **and** after this diff, identically. Nothing here touches it, and making that row green is not this card's job.
- `check-doc-links.test.ts` ×1 — `Error: Test timed out in 15000ms`, not an assertion failure. Re-run alone it passes **121/121**. It is the shared-box flake AGENTS.md describes (an unbounded module load inside a bounded window); this diff changes two files it does not read.

## 4. Lit control

Deliberately inverting the source-first partition to published-first, on the **fully built** tree, at `04754509a`:

- HEAD blob `1fa07fdeacedf8e9359f4c64d1842c92282adaae` == on-disk before, both non-empty (an empty hash is read as failure, not as "nothing to compare").
- After the edit, on-disk `ba8756d0eba35bc1275b3825528117774e28d1d6` — different, and the removed text greps to **0** while the injected text greps to **1**. **Mutation confirmed on disk before anything was read.**
- No rebuild leg is owed and none was faked: the test imports `'../check-sdui-registration-pins.mjs'` by relative path, so the module under test *is* that source file and never resolves through a package `exports` map or a `dist/`.

It lit, and each case named itself:

```
### vitest exit while mutated: 1
 Test Files  1 failed (1)
      Tests  3 failed | 12 passed (15)

FAIL … > the source spelling wins, whatever the tree has been built to >
       attributes the key to the SOURCE spelling when BOTH spellings are on disk
  Expected: "packages/pkg/src/index.ts"   Received: "packages/pkg/dist/index.js"
FAIL … > the source spelling wins … > keeps every declared entry — it reorders the read, it does not filter it
FAIL … > the real workspace > derives the keys from the arrays, and the ruled controls are among them
  Expected: "packages/app-shell/src/console/connect/ConnectAgentWidget.tsx"
  Received: "packages/app-shell/dist/console/connect/ConnectAgentWidget.js"
```

Restored under `trap '...' EXIT INT TERM` with `git checkout HEAD -- ABSOLUTE_PATH` (absolute, resolved from `git rev-parse --show-toplevel`), and the restoration is proven by state, not by an exit code:

```
HEAD blob        : 1fa07fdeacedf8e9359f4c64d1842c92282adaae
on-disk restored : 1fa07fdeacedf8e9359f4c64d1842c92282adaae
git diff HEAD    : 0 bytes
git status --short: empty
```

## 5. Why the new cases use a fixture

The real-workspace assertion is the card's own symptom, and it is kept. But on an unbuilt checkout it passes for the wrong reason — `dist/` simply is not there — so on its own it would still be a case whose meaning depends on the runner. The two new cases run against a fixture that **owns its build state** (`fixture(chunks, { built: true })` writes the published spelling too), so they are the same assertion over both build states and they keep asserting the preference on machines where nothing has been built. A third case pins the throw, and a fourth pins that the reordering is a permutation of `pkg.declared`, so a partition that dropped an entry could not shrink the derived key set unnoticed.

## 6. Gates

Run at `04754509a` on a clean tree, exit code captured before any pipe:

| gate | verdict |
|:--|:--|
| `node scripts/check-changeset-presence.mjs` | exit 0 — `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` (`2 file(s) changed, 0 of them published source of a package the release covers, 0 changeset(s) added`) ⇒ **no changeset in this PR** |
| `pnpm check:side-effects-array` | exit 0 — app-shell 14 modules / 31 entries / 442 walked; layout 1 / 3 / 8 |
| `pnpm check:sdui-registration-pins` | exit 0 — see the measurement in §1 (run on the byte-identical content: the file's on-disk hash equalled `HEAD:scripts/check-sdui-registration-pins.mjs` = `1fa07fdea`; the console `dist/` was removed afterwards to make the unbuilt row, so it was not re-run at that point) |
| `pnpm check:control-bytes` | exit 0 — 6348 tracked text files scanned; plus a direct control-byte grep over both changed files: no hits |
| `pnpm check:esm-specifiers` / `check:entry-guard` / `check:self-import` | exit 0 |
| `node scripts/check-governed-queue-guard.mjs --test` on both paths | exit 0 — `✅ NOT GOVERNED` ⇒ ordinary PR route |
| `pnpm type-check:scripts` | exit 0 — and `tsc --listFiles` names **both** changed files, so this is a measurement rather than a green over an empty program |
| `eslint` on both changed files, `--no-inline-config --format json` | exit 0, **2 files linted**, 0 errors, 0 warnings |

The repo-wide lint scan was **not** run here; it is CI's, and this is a declared narrowing with its three legs: the two files are in eslint's own scope (they were linted, not reported as ignored); the count of 2 is read from `--format json`, not guessed; and `eslint.config.js` configures no `projectService` and no `parserOptions.project`, so type-aware linting is off and this diff cannot move a verdict on a file it did not touch.

## Scope

Two files, both under `scripts/`. No `packages/*/src` file was touched, so the Clause-② void condition did not fire. `.github/workflows/ci.yml` was **read only**, never written. `scripts/__tests__/check-readme-exports.test.ts` (#7460) was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_