### PR TITLE
test(plugin-detail): take the render out of RelatedList's lookup-label waitFor predicate

### DIFF
--- a/.changeset/wild-tables-shout.md
+++ b/.changeset/wild-tables-shout.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: `RelatedList.lookupLabelResolution` waits for the batch lookup-label map with a side-effect-free predicate and renders the cell once afterwards, instead of rendering inside the `waitFor` callback. No published behaviour changes.

--- a/packages/plugin-detail/src/__tests__/RelatedList.lookupLabelResolution.test.tsx
+++ b/packages/plugin-detail/src/__tests__/RelatedList.lookupLabelResolution.test.tsx
@@ -77,9 +77,40 @@ const makeDataSource = () => ({
   }),
 });
 
-/** Render the permission_set_id column's cell for `value`, return its text. */
+const lookupColumn = () =>
+  h.schema?.columns?.find((c: any) => c.accessorKey === 'permission_set_id');
+
+/**
+ * Has the batch id -> label map landed? Answered WITHOUT touching the DOM.
+ *
+ * This is the readiness signal the two cases below wait on, and it is
+ * side-effect free on purpose (objectui#7756). `waitFor` re-runs its callback
+ * on DOM MUTATIONS as well as on its interval, so a callback that renders
+ * schedules its own next run — self-feeding. Measured here with the interval
+ * pinned at the timeout, so the interval timer can never re-run the callback:
+ * a rendering callback still reached 200 runs in 144ms, an inert one and one
+ * rendering into a DETACHED container reached 1. Every run of the rendering
+ * callback also leaked one node into `document.body` (growth == run count):
+ * RTL's `unmount()` tears down the React root but leaves behind the container
+ * div `render` appended. So the loop is unbounded ALLOCATION, and when the
+ * lookup batch resolves slowly it exhausts the V8 heap and kills the whole
+ * vitest worker — `Tests (2) / Errors 1 / tests 0ms`, nothing reported — which
+ * fails the entire shard rather than one test.
+ *
+ * `col.cell(value)` only ALLOCATES a React element; nothing is mounted. The
+ * junction field declares no `options` of its own, so `field.options` on that
+ * element exists only once the batch map is folded in — that IS the readiness
+ * fact, and it is a pure read.
+ */
+const batchLabelsLanded = (value: string): boolean =>
+  Boolean((lookupColumn()?.cell?.(value) as any)?.props?.field?.options);
+
+/**
+ * Render the permission_set_id column's cell for `value`, return its text.
+ * Called ONCE per case, after the wait above — never from inside a `waitFor`.
+ */
 const renderCellText = (value: string): string | undefined => {
-  const col = h.schema?.columns?.find((c: any) => c.accessorKey === 'permission_set_id');
+  const col = lookupColumn();
   if (!col?.cell) return undefined;
   const { container, unmount } = render(<>{col.cell(value)}</>);
   const text = container.textContent ?? undefined;
@@ -112,9 +143,13 @@ describe('RelatedList batch lookup-label resolution (objectui#3330)', () => {
       expect(dataSource.find).toHaveBeenCalledWith('sys_permission_set', expect.anything()),
     );
 
-    // Once the map lands, the cell must show the declared display name —
-    // never flip to the API name the legacy chain would have picked.
-    await waitFor(() => expect(renderCellText('ps_1')).toBe('排班员权限'));
+    // Wait for the map to land — side-effect free, so the predicate cannot
+    // feed its own re-runs — then render the cell ONCE and read what it shows.
+    await waitFor(() => expect(batchLabelsLanded('ps_1')).toBe(true));
+
+    // The cell must show the declared display name — never flip to the API
+    // name the legacy chain would have picked.
+    expect(renderCellText('ps_1')).toBe('排班员权限');
   });
 
   it('falls back to the legacy chain when the target schema is unavailable', async () => {
@@ -139,7 +174,9 @@ describe('RelatedList batch lookup-label resolution (objectui#3330)', () => {
     await waitFor(() =>
       expect(dataSource.find).toHaveBeenCalledWith('sys_permission_set', expect.anything()),
     );
+    await waitFor(() => expect(batchLabelsLanded('ps_1')).toBe(true));
+
     // Non-regressive: without a schema the old `name`-first chain still applies.
-    await waitFor(() => expect(renderCellText('ps_1')).toBe('ehr_production_planner'));
+    expect(renderCellText('ps_1')).toBe('ehr_production_planner');
   });
 });


### PR DESCRIPTION
Fixes #7756

`RelatedList.lookupLabelResolution.test.tsx` killed its whole vitest worker — not one
test, the shard — when the batch lookup-label chain resolved 50 ms later than it does
today. This takes the render out of the `waitFor` predicate. Only that test file and its
changeset change; `RelatedList.tsx` is untouched.

## The causal chain: CONFIRMED, and separately instrumented

The card stated its mechanism as a reading, not a measurement, and asked for it to be
confirmed or falsified before anything was built on it. It is **confirmed**, by a probe
that pins `interval` at `timeout` so the interval timer can **never** re-run the
predicate — every run past the first is therefore MutationObserver-driven and nothing
else. Three arms, same file, same run (cap: settle at 200 runs; `timeout: 2000`,
`interval: 2000`):

| predicate | runs | ms | timed out | `document.body` growth |
|:--|--:|--:|:--|--:|
| renders into the document, then unmounts | **200** | **144** | no | **200** |
| renders into a **detached** container | 1 | 2006 | yes | 0 |
| inert (no DOM mutation) | 1 | 2003 | yes | 0 |

Two facts fall out, and the second was not in the card:

1. **Self-feeding is real, and it is the document mutation that feeds it.** The rendering
   predicate re-ran 200 times where the interval permitted exactly one. Rendering into a
   container that is never in the document drops it straight back to one — so the feedback
   runs through `waitFor`'s own `MutationObserver`, which
   `@testing-library/dom@10.4.1`'s `wait-for.js` attaches to `getDocument()` with
   `{subtree, childList, attributes, characterData}`.
2. **Each run leaks, which is why it is an OOM and not merely a spin.** Body growth equals
   the run count exactly: RTL's `unmount()` tears down the React root but leaves behind
   the container div `render` appended to `document.body`. The loop is unbounded
   *allocation*, which is why a raised `--testTimeout` never stopped it.

A fourth arm measured the sibling shape at default interval (`timeout: 2000`,
`interval: 50`): a rendering predicate reached 200 runs in 168 ms, an inert one 40 runs in
2005 ms — the 50 ms cadence exactly. Ratio ~60x.

## Before: the worker kill, reproduced

Mutation, exactly the card's: the batch resolution deferred at the outer `.then` that
calls `setLookupLabels`, in `packages/plugin-detail/src/RelatedList.tsx`. Proved on disk
before each run — bare-anchor count 1 to 0, marker count 0 to 1, blob hash
`a025a86cd...` to `fd25c10b4...`, and `git diff --numstat` naming the file.

Reproduced **3 times out of 3** (default pool at a raised ceiling, default pool at the
default ceiling, `--pool=forks`). The forks run carries the full evidence:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(...)
v8::internal::Runtime_AllocateInYoungGeneration(...)
Test Files   (1)
     Tests   (2)
    Errors  1 error
  Duration  38.73s (transform 5.24s, setup 379ms, import 9.50s, tests 0ms, ...)
```

`tests 0ms` — nothing was ever reported.

Reported honestly: the two default-pool runs printed `Error: Worker exited unexpectedly`
and exited 1, but their logs carried **neither** the V8 frames **nor** the `tests 0ms`
line — the reporter died with the worker. Only the forks run captured those.

## The repair

Both cases now wait on a side-effect-free readiness predicate, then render **once** and
assert the text — which is the assertion each case always made. Neither case is deleted,
skipped, or weakened.

The readiness fact is available without mounting anything. `makeCell` folds the batch map
into the cell's `field.options`, and the junction field declares no `options` of its own,
so `options` being defined *is* "the map has landed". Calling `col.cell(value)` only
allocates a React element — nothing is mounted, nothing is observed:

```js
const batchLabelsLanded = (value) =>
  Boolean((lookupColumn()?.cell?.(value)).props?.field?.options);

await waitFor(() => expect(batchLabelsLanded('ps_1')).toBe(true));
expect(renderCellText('ps_1')).toBe('排班员权限');
```

Acceptance property met: the predicate no longer mutates the DOM. A repo-wide scan
(2410 test files, brace-balanced, following helpers transitively — a plain text search
misses this file, whose predicate renders via `renderCellText`) now reports this file
clear.

## After: alive under the same mutation, and past it

The acceptance reading is the repaired file under the **same 50 ms mutation** — green
unmutated proves nothing, it was green before.

| deferral | file | result | `tests` time |
|:--|:--|:--|--:|
| **50 ms** (the card's) | before | **worker killed, exit 1** | `0ms` |
| **50 ms** | after | **2 passed, exit 0** | 280 ms |
| 200 ms | after | 2 passed, exit 0 | 578 ms |
| 500 ms | after | 2 passed, exit 0 | 1.19 s |
| unmutated | after | 2 passed, exit 0 | 179 ms |

The threshold was not merely pushed out by 50 ms: the `tests` time is **linear in the
deferral** — 179 ms baseline plus roughly one deferral per case (two cases: 179 + 2x50 =
279 vs 280 measured; 179 + 2x200 = 579 vs 578; 179 + 2x500 = 1179 vs 1190). The repair
*waits*; it does not spin. Its honest bound is RTL's own 1000 ms `asyncUtilTimeout`,
which a deferral near that would hit as an ordinary timeout — bounded, one red test, not
a dead worker.

Every mutation was restored with `git checkout HEAD -- ABSOLUTE_PATH` under
`trap ... EXIT INT TERM`, and each restoration proved **by state**, not by whether the
trap fired: blob hash back to `a025a86cd...` **and** `git diff HEAD` for that path empty
(0 bytes). 6 of 6.

## Unmutated readings, at this commit

At `fc7b672fc`, exit codes captured before any pipe:

- `vitest run packages/plugin-detail/src/__tests__/RelatedList.lookupLabelResolution.test.tsx`
  — `Test Files 1 passed (1)`, `Tests 2 passed (2)`, exit 0
- `vitest run packages/plugin-detail/` — `Test Files 132 passed (132)`,
  `Tests 1199 passed (1199)`, exit 0
- `turbo run type-check --filter @object-ui/plugin-detail` — `13 successful, 13 total`,
  exit 0. Run through turbo, not a bare `tsc`. **Measured, not assumed**: `--listFiles`
  confirms the edited file is a program input of `tsconfig.test.json` (1 hit).
- `turbo run lint --filter @object-ui/plugin-detail` — `2 successful, 2 total`, exit 0;
  183 files, **0 errors**, 895 warnings, of which the edited file contributes 8, all
  `@typescript-eslint/no-explicit-any` in the style the file already used.

**Declared narrowing**: lint ran 2 of the 47 workspace lint tasks. `eslint.config.js`
declares no type-aware parser options (no `projectService`, no `project`, no
`parserOptions`) and each package lints its own directory, so a change confined to one
test file in `plugin-detail` cannot move an untouched package's verdict. CI runs the full
farm regardless.

## Changeset gate

`node scripts/check-changeset-presence.mjs`, verbatim, after adding
`.changeset/wild-tables-shout.md`:

```
✅  1 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s): .changeset/wild-tables-shout.md.
    Every one of them has an EMPTY frontmatter — declared as releasing nothing, which
    is the explicit exemption and a complete answer to this gate.
```

Empty frontmatter, as the gate's own exemption prescribes: this is test-only, nothing
published moves. Before the changeset the same gate said `❌`, so it is a live reading.

## Out of scope, named rather than fixed

The same scan found the construct in two `plugin-view` files —
`ObjectView.contractEnvelope-6726.test.tsx:103` and
`ObjectView.contractEnvelope-6840.test.tsx:132`, both
`waitFor(async () => expect(await deliveredThrough(asData))...)` where the helper renders.

**They are not this defect, and the probe says so rather than my judgement.** The fourth
probe arm measured the async shape at 40 runs in 2003 ms — the plain interval cadence,
not self-feeding — because `wait-for.js`'s `checkCallback` early-returns while
`promiseStatus === 'pending'`, so a mutation cannot re-enter an async predicate still in
flight. A style smell, not a heap bomb. Left untouched: different package, so fixing them
would add verification surface this card cleared nothing for.

No defect was found in `RelatedList.tsx`. It is untouched, as the card required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_