### PR TITLE
fix(i18n-gate): read a key family off its BUILDER, so a helper-built head is not swept as dead (objectui#7592)

### DIFF
--- a/scripts/__tests__/check-i18n-call-site-keys.test.ts
+++ b/scripts/__tests__/check-i18n-call-site-keys.test.ts
@@ -1379,6 +1379,115 @@ export const A = (x: string) => { const { t } = useObjectTranslation(); return t
   });
 });
 
+describe('the key-builder leg: a family whose head is never at a call site (objectui#7592)', () => {
+  // The measured shape, reduced: a module that BUILDS the key and hands it to a
+  // translator it was passed as a value. It holds no `t(`/`tt(` spelling at all,
+  // so before this leg the pre-filter dropped it before the parser ever ran.
+  const EN_TOOL = `const en = { chatbot: { tool: { apply_edit: 'Apply edit' } }, common: { save: 'Save' } } as const;\nexport default en;\n`;
+  const BUILDER = `export function toolTitleKey(name: string): string {
+  return \`chatbot.tool.\${String(name).trim()}\`;
+}
+export function humanize(name: string, translate?: (k: string, f: string) => string): string {
+  return translate ? translate(toolTitleKey(name), name) : name;
+}
+`;
+  const declared: Family[] = [
+    { head: 'chatbot.tool.', enumerable: false, why: 'external-vocabulary', reason: 'fixture' },
+  ];
+  const builderRoot = () =>
+    repoWith({ 'packages/i18n/src/locales/en.ts': EN_TOOL, 'packages/x/src/tool-display.ts': BUILDER });
+
+  it('records the head and the family with no t()/tt() call anywhere in the module', () => {
+    const { dynamicHeads, dynamicFamilies, counters, findings } = analyze(builderRoot(), { families: declared });
+    expect(counters.callSites, 'the fixture must contain no t()/tt() call at all').toBe(0);
+    expect([...dynamicHeads]).toEqual(['chatbot.tool.']);
+    expect([...dynamicFamilies.keys()]).toEqual(['chatbot.tool.']);
+    expect(counters.keyBuilderSites).toBe(1);
+    expect(findings).toEqual([]);
+  });
+
+  it('a builder family is subject to the SAME ratchet: undeclared is a red', () => {
+    expect(findingsOf(builderRoot(), 'undeclared-dynamic-family')).toEqual([
+      'chatbot.tool.@packages/x/src/tool-display.ts:1',
+    ]);
+  });
+
+  it('ANTI-VACUOUS: the leg going quiet is a RED, not a silent green', () => {
+    // The one failure mode this whole card family is about — a detection leg
+    // that degrades to a no-op while the gate stays green. Here the helper is
+    // rewritten so it is no longer a single returned template (a local, then a
+    // return): the head leaves the census, and the declaration the fix added
+    // goes STALE, which fails. Nothing about this depends on the corpus, which
+    // is clean the moment the fix lands.
+    const degraded = BUILDER.replace(
+      'return `chatbot.tool.${String(name).trim()}`;',
+      'const trimmed = String(name).trim();\n  return `chatbot.tool.${trimmed}`;',
+    );
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_TOOL,
+      'packages/x/src/tool-display.ts': degraded,
+    });
+    const { counters, findings } = analyze(root, { families: declared });
+    expect(counters.keyBuilderSites, 'the leg must have stopped detecting for this control to mean anything').toBe(0);
+    expect(findings.map((f: { reason: string }) => f.reason)).toEqual(['stale-dynamic-family']);
+  });
+
+  it('boundary 1: only ONE returned template — a helper that does anything else is not a builder', () => {
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_TOOL,
+      'packages/x/src/a.ts': `export function k(n: string): string {
+  if (!n) return 'chatbot.tool.unknown';
+  return \`chatbot.tool.\${n}\`;
+}
+`,
+    });
+    expect(analyze(root, { families: [] }).counters.keyBuilderSites).toBe(0);
+  });
+
+  it('boundary 2: the head must RESOLVE against en, or every dotted template becomes a family', () => {
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_TOOL,
+      'packages/x/src/a.ts': `export const url = (v: string) => \`api.v1.\${v}\`;
+export const css = (v: string) => \`--oui.color.\${v}\`;
+`,
+    });
+    const { counters, findings } = analyze(root, { families: [] });
+    expect(counters.keyBuilderSites).toBe(0);
+    // And specifically NOT a missing-prefix red: an unresolvable head means
+    // "not a key builder", never "a key family whose every expansion misses".
+    expect(findings).toEqual([]);
+  });
+
+  it('boundary 3: a builder inside a registered local table is skipped, like its call sites are', () => {
+    const localModule = EXCLUDED_TRANSLATORS[0].module;
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_TOOL,
+      [localModule]: `export const k = (n: string) => \`chatbot.tool.\${n}\`;\n`,
+    });
+    expect(analyze(root, { families: [] }).counters.keyBuilderSites).toBe(0);
+  });
+
+  it('a concise arrow body is the same builder, so the spelling does not decide', () => {
+    const root = repoWith({
+      'packages/i18n/src/locales/en.ts': EN_TOOL,
+      'packages/x/src/a.ts': `export const k = (n: string): string => \`chatbot.tool.\${n}\`;\n`,
+    });
+    expect(analyze(root, { families: declared }).counters.keyBuilderSites).toBe(1);
+  });
+
+  it('ANTI-VACUOUS on THIS checkout: the leg is live, and the family it feeds is real', () => {
+    // The synthetic controls above prove the shape. This one proves the leg is
+    // still pointed at the repo: if `toolTitleKey` is inlined, renamed into a
+    // shape this leg cannot read, or moved behind a concatenation, the head
+    // disappears here and `stale-dynamic-family` fails the gate.
+    const { dynamicHeads, counters, findings } = analyze(repoRoot);
+    expect(counters.keyBuilderSites, 'the key-builder leg detects nothing on this tree').toBeGreaterThanOrEqual(1);
+    expect(dynamicHeads.has('chatbot.tool.'), 'chatbot.tool. is no longer reached by any leg').toBe(true);
+    expect(DYNAMIC_KEY_FAMILIES.some((f) => f.head === 'chatbot.tool.')).toBe(true);
+    expect(findings).toEqual([]);
+  });
+});
+
 describe('readVocabulary reads each declared shape, and refuses what it cannot read', () => {
   const shapes: Array<[string, string, Omit<Spec, 'module'>, string[]]> = [
     ['union', "export type X = 'a' | 'b';", { kind: 'union', name: 'X' }, ['a', 'b']],

--- a/scripts/__tests__/check-i18n-dead-keys.test.ts
+++ b/scripts/__tests__/check-i18n-dead-keys.test.ts
@@ -402,6 +402,48 @@ describe('both control groups from the card, measured on THIS repository (object
   });
 });
 
+describe('the key-builder leg reaches the sweep end to end (objectui#7592)', () => {
+  // The class the property-chain leg does NOT cover: the consumer never spells
+  // the key AND never calls t() — it builds the key in a helper and hands it to
+  // a translator it was given as a value. Before the key-builder leg all three
+  // legs were blind at once and every member of the family landed in CONFIRMED,
+  // the tier this file's header discusses deleting from.
+  const EN_TOOLS = `const en = {
+  chatbot: { tool: { apply_edit: 'Apply edit', list_objects: 'List objects' } },
+  orphan: { group: { leaf: 'Nobody reads this' } },
+} as const;
+export default en;
+`;
+  const BUILDER_CONSUMER = `
+export function toolTitleKey(name: string): string {
+  return \`chatbot.tool.\${String(name).trim()}\`;
+}
+export function humanize(name: string, translate?: (k: string, f: string) => string): string {
+  const english = name.replace(/_/g, ' ');
+  return translate ? translate(toolTitleKey(name), english) : english;
+}
+`;
+  const builderRoot = () =>
+    repoWith({
+      'packages/i18n/src/locales/en.ts': EN_TOOLS,
+      'packages/x/src/tool-display.ts': BUILDER_CONSUMER,
+    });
+
+  it('POSITIVE: a helper-built family is no longer a candidate at all', () => {
+    const { confirmed, needsReview } = sweep(builderRoot());
+    const asCandidate = [...confirmed, ...needsReview.map((e: { key: string }) => e.key)].filter((k: string) =>
+      k.startsWith('chatbot.tool.'),
+    );
+    expect(asCandidate, 'a live helper-built key is still being offered for deletion').toEqual([]);
+  });
+
+  it('NEGATIVE: the leg does not hollow out the tier — a key nothing reads is STILL CONFIRMED', () => {
+    // Without this, "no chatbot.tool key is confirmed" would also pass on a
+    // sweep that confirmed nothing at all.
+    expect(sweep(builderRoot()).confirmed).toEqual(['orphan.group.leaf']);
+  });
+});
+
 describe('the collapse guard lives in the CLI block, not in sweep() itself', () => {
   it('sweep() runs against a small synthetic fixture without throwing', () => {
     // Unlike the CLI entry point (which exits 1 below ~2000 keys on the REAL

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -358,6 +358,54 @@
  * checker could resolve. Same treatment, same reason, for the deliberate
  * `I18N_PROBE_FLAG` misses (see below) and for the skipped binding classes.
  *
+ * ## Key-building helpers: the leg that needs no call site (objectui#7592)
+ *
+ * Everything above starts at a `t()`/`tt()` call and reads its arguments. A
+ * module that BUILDS a key and hands it to a translator it received as a plain
+ * function VALUE has no such call for the walk to start from:
+ *
+ *   export function toolTitleKey(name) { return `ns.family.${name}`; }
+ *   // …
+ *   return translate ? translate(toolTitleKey(trimmed), english) : english;
+ *
+ * `translate` is a parameter, not `t`/`tt`, so the callee never matches; and the
+ * file holds no `t(` spelling at all, so the pre-filter below drops it before
+ * anything is even parsed. Both reverse-sweep legs and both family ratchets are
+ * therefore blind at once — measured on `chatbot.tool.*`, whose 35 live,
+ * rendering keys put 33 entries into `check-i18n-dead-keys.mjs`'s CONFIRMED
+ * tier, 22% of it, one deletion away from reverting every AI tool card to
+ * English in nine locales (objectui#7592, the regression cloud#1658 filed and
+ * objectui#7254 fixed).
+ *
+ * So the head is read WHERE IT IS WRITTEN instead. A KEY BUILDER is a function
+ * whose whole body is one returned template literal whose head is a dotted key
+ * prefix that resolves against `en`; its head and tail feed `dynamicHeads` and
+ * `dynamicFamilies` exactly as a template ARGUMENT would, which means the
+ * family lands under the same two ratchets: undeclared is a red, and a builder
+ * that stops being one turns its declaration stale, also a red. That is the
+ * anti-vacuous half — a detection leg that silently degrades to a no-op is the
+ * failure mode this whole class of card is about.
+ *
+ * Three boundaries, each load-bearing and each measured on this tree:
+ *
+ *   1. ONE returned template, nothing else. A multi-statement helper composes
+ *      its head from things this parser cannot follow, and reading its first
+ *      template anyway would invent families out of unrelated strings.
+ *   2. The head must RESOLVE against `en` (`headMatches`), which is what makes
+ *      this a key probe rather than a template-literal census: 97 files hold a
+ *      dotted template, and requiring the head to prefix a real pack path is
+ *      what leaves the builder shapes that are about i18n. The consequence is
+ *      deliberate and is the one place this leg differs from the argument
+ *      position: a builder whose head matches NOTHING is not recognised at all,
+ *      so it never raises `missing-prefix`. Judging it would make every
+ *      `` `${a}.${b}` `` in the repo a candidate defect.
+ *   3. The registered local tables are skipped, same scope rule the call-site
+ *      classifier uses — a builder inside `metadata-admin/` builds `engine.*`
+ *      keys that are not in any pack by design.
+ *
+ * Blast radius on this checkout: 1 builder, 1 head, 47 extra files parsed out of
+ * 1572 walked. The leg is narrow BY MEASUREMENT, not by hope.
+ *
  * ## The probe exclusion
  *
  * `useObjectLabel` probes convention keys (`{ns}.objects.{name}.label`) that are
@@ -729,6 +777,22 @@ export const DYNAMIC_KEY_FAMILIES = [
   {
     head: 'capability.label.',
     vocabulary: { module: 'packages/fields/src/widgets/CapabilityMultiSelectField.tsx', name: 'CURATED_CAPABILITY_LABELS', kind: 'set' },
+  },
+  {
+    head: 'chatbot.tool.',
+    // Reached through the KEY-BUILDER leg, not a call site: `toolTitleKey()` in
+    // packages/plugin-chatbot/src/tool-display.ts builds the key and the module
+    // spells no `t(` at all (objectui#7592).
+    enumerable: false,
+    why: 'external-vocabulary',
+    reason:
+      'The member set is the platform tool registry — `PLATFORM_TOOLS_BY_PACKAGE` in ' +
+      '`@objectstack/spec/system` — and this reader opens repo source only (see readVocabulary). ' +
+      'No repo-local exhaustive Record mirrors it, and writing one here would be a SECOND ' +
+      'registry to keep in sync with a pinned spec that already lags the cloud runtime. The set ' +
+      'identity is pinned one layer out instead, where the registry can be imported: ' +
+      'packages/plugin-chatbot/src/__tests__/toolLabels-locale-parity-7481.test.ts requires every ' +
+      'registered tool to carry a non-empty label in all ten packs (objectui#7481).',
   },
   {
     head: 'common.',
@@ -1527,6 +1591,51 @@ function templateShape(argument) {
   return { head, tail: inner.templateSpans[0].literal.text };
 }
 
+/**
+ * The key family a KEY BUILDER declares (objectui#7592).
+ *
+ * A key builder is a function whose ENTIRE body is one returned template
+ * literal — `function toolTitleKey(n) { return `ns.family.${n}`; }`, or the
+ * concise-arrow spelling of the same thing. The head/tail it yields is the same
+ * shape `templateShape()` reads off a key ARGUMENT, so the caller can record it
+ * through the identical bookkeeping; see the header section "Key-building
+ * helpers" for why the argument position never sees this shape at all.
+ *
+ * Shape only. Whether the head is an i18n key at all is the CALLER's test
+ * (`headMatches`), because that answer needs the `en` pack and this does not.
+ *
+ * @returns {{ head: string, tail: string | null } | null}
+ */
+function keyBuilderShape(node) {
+  if (
+    !ts.isFunctionDeclaration(node) &&
+    !ts.isFunctionExpression(node) &&
+    !ts.isArrowFunction(node) &&
+    !ts.isMethodDeclaration(node)
+  ) {
+    return null;
+  }
+  const body = node.body;
+  if (!body) return null;
+  // A block body must be exactly `return <expr>` — boundary 1 in the header.
+  let returned = body;
+  if (ts.isBlock(body)) {
+    if (body.statements.length !== 1 || !ts.isReturnStatement(body.statements[0])) return null;
+    returned = body.statements[0].expression;
+  }
+  const shape = templateShape(returned);
+  if (!shape || !KEY_PREFIX_HEAD.test(shape.head)) return null;
+  return shape;
+}
+
+/**
+ * A template head that is a dotted key prefix ending at a segment boundary
+ * (`chatbot.tool.`). The trailing dot is required: it is what separates a key
+ * family from a template that merely contains a dot (a URL, a version, a CSS
+ * custom property), and it is the shape every entry in DYNAMIC_KEY_FAMILIES has.
+ */
+const KEY_PREFIX_HEAD = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*\.$/;
+
 // ── the analysis ─────────────────────────────────────────────────────────────
 
 /**
@@ -1565,6 +1674,11 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
   // key have a call site" can never drift apart from each other. Unused by
   // this gate's own findings/counters; `scripts/check-i18n-dead-keys.mjs` is
   // the consumer.
+  //
+  // objectui#7592 — a head also reaches both Sets from a KEY BUILDER, a helper
+  // whose body is one returned template literal, with no `t()` call anywhere in
+  // its module. Same bookkeeping, same ratchets; see the header section
+  // "Key-building helpers".
   const referencedKeys = new Set();
   const referencedBranches = new Set();
   const dynamicHeads = new Set();
@@ -1587,6 +1701,7 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
     resolvedKeys: 0,
     dynamicKeySites: 0,
     headlessDynamicKeySites: 0,
+    keyBuilderSites: 0,
     declaredFamilies: 0,
     enumerableFamilies: 0,
     notEnumerableFamilies: 0,
@@ -1611,6 +1726,29 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
     computedSiblingFallbacks: 0,
     optionalCallFallbacks: 0,
     unjudgedSiblingFallbacks: 0,
+  };
+
+  // objectui#7592 — the key-builder leg. `keyBuilderShape()` answers the SHAPE
+  // question; `headMatches` is the one that makes it a key probe rather than a
+  // census of every dotted template. Findings are deliberately never raised
+  // here: `missing-prefix` is an argument-position rule and a builder whose head
+  // resolves to nothing is simply not a key builder (header, boundary 2).
+  const recordKeyBuilders = (source, relPath) => {
+    const visit = (node) => {
+      const shape = keyBuilderShape(node);
+      if (shape && headMatches(shape.head)) {
+        const { line, character } = source.getLineAndCharacterOfPosition(node.getStart(source));
+        counters.keyBuilderSites += 1;
+        dynamicHeads.add(shape.head);
+        const family = dynamicFamilies.get(shape.head) ?? { tails: new Set(), sites: [], multiSubstitution: 0 };
+        if (shape.tail === null) family.multiSubstitution += 1;
+        else family.tails.add(shape.tail);
+        family.sites.push({ file: relPath, line: line + 1, column: character + 1 });
+        dynamicFamilies.set(shape.head, family);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
   };
 
   for (const file of collectSourceFiles(root)) {
@@ -1640,13 +1778,29 @@ export function analyze(root, /** @type {{ families?: DynamicKeyFamily[] }} */ {
     // spells EVERY call `t?.(…)` because its `t` is an optional prop, so it holds
     // no `t(` at all and this pre-filter used to drop the whole file — silently,
     // out of all five classes at once (objectui#4117).
-    if (!/\btt?\s*(?:\?\.)?\s*\(/.test(text)) continue;
+    const hasTranslatorCall = /\btt?\s*(?:\?\.)?\s*\(/.test(text);
+    // objectui#7592 — the key-builder leg's own pre-filter, because a builder's
+    // module need hold no `t(` spelling at all (the measured one does not, and
+    // the line above used to drop it unparsed). `.${` is the adjacency a dotted
+    // key template always has and that essentially nothing else in TS source
+    // does: 97 files match it, 47 of which the line above rejects — that 47 is
+    // the whole added parse cost, against 1572 files walked.
+    const hasKeyTemplate = text.includes('.${');
+    if (!hasTranslatorCall && !hasKeyTemplate) continue;
     const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
-    const bindings = collectBindings(root, file, source);
 
     // A file's provenance: which table its own `t` reaches. A forwarded `t`
     // inherits it, because the parser cannot follow the value across modules.
-    let provenance = localScopes.some((dir) => relPath.startsWith(dir)) || isLocalTableFile ? 'local' : null;
+    const inLocalScope = localScopes.some((dir) => relPath.startsWith(dir)) || isLocalTableFile;
+
+    // Boundary 3: a builder inside a registered local table builds keys no pack
+    // defines by design, so it must not mark pack leaves live.
+    if (hasKeyTemplate && !inLocalScope) recordKeyBuilders(source, relPath);
+
+    if (!hasTranslatorCall) continue;
+    const bindings = collectBindings(root, file, source);
+
+    let provenance = inLocalScope ? 'local' : null;
     for (const binding of bindings) {
       if (binding.kind === 'packHook' && provenance === null) provenance = 'pack';
       if (binding.kind === 'import' && registeredModules.has(binding.detail)) provenance = 'local';
@@ -2209,7 +2363,8 @@ if (invokedDirectly) {
       `static vocabulary (${counters.checkedMembers} member key(s) checked exactly), ` +
       `${counters.notEnumerableFamilies} with no enumerable member set (prefix-checked only), ` +
       `${counters.unexpandableFamilySites} multi-substitution site(s) not expandable, ` +
-      `${counters.headlessDynamicKeySites} dynamic call site(s) with no static head at all.`,
+      `${counters.headlessDynamicKeySites} dynamic call site(s) with no static head at all, ` +
+      `${counters.keyBuilderSites} head(s) read off a key-building helper rather than a call site.`,
   );
   console.log(
     `Sibling fallbacks: ${counters.siblingFallbacks} call site(s) sit left of a ||/?? — ` +

--- a/scripts/check-i18n-call-site-keys.mjs
+++ b/scripts/check-i18n-call-site-keys.mjs
@@ -2210,7 +2210,8 @@ const HINTS = {
     ' registry — narrowing a declared vocabulary to make a red go away is how an exact' +
     ' check silently becomes a smaller one.',
   'undeclared-dynamic-family':
-    'A pack-backed template key whose static head is not in DYNAMIC_KEY_FAMILIES' +
+    'A pack-backed template key — at a call site, or built by a helper (objectui#7592) —' +
+    ' whose static head is not in DYNAMIC_KEY_FAMILIES' +
     ' (objectui#4964). Prefix-checking alone cannot see a member missing from all ten' +
     ' packs, so every family must say how its member set is known: add an entry with a' +
     ' `vocabulary` naming the declaration the call site iterates (a union, a const array,' +
@@ -2219,7 +2220,10 @@ const HINTS = {
     ' preferred over a guessed vocabulary; what is not allowed is silence.',
   'stale-dynamic-family':
     'A DYNAMIC_KEY_FAMILIES entry whose head no longer appears at any pack-backed call' +
-    ' site. Delete the entry — the registry describes the repo, and an entry nothing' +
+    ' site — nor, since objectui#7592, at any key-building helper. Delete the entry, OR' +
+    ' find out why the head stopped being seen: for a family that reaches the scan through' +
+    ' a builder, this finding is also how a detection leg that quietly stopped detecting' +
+    ' announces itself. Either way the registry describes the repo, and an entry nothing' +
     ' exercises is an exact check running against nothing.',
   'duplicate-family':
     'Two DYNAMIC_KEY_FAMILIES entries declare the same head. Only the first would be' +

--- a/scripts/check-i18n-dead-keys.mjs
+++ b/scripts/check-i18n-dead-keys.mjs
@@ -46,7 +46,12 @@
  *     this key" is exactly why the key must NOT be called dead. Deliberately
  *     recall-over-precision — a namespace nothing dynamically reaches costs
  *     nothing extra to keep live, and marking it dead when it is not would be
- *     the wrong direction to be wrong in for a deletion sweep.
+ *     the wrong direction to be wrong in for a deletion sweep. Since
+ *     objectui#7592 a head also arrives from a KEY BUILDER — a helper whose
+ *     whole body returns one template literal — so a module that builds the key
+ *     and hands it to a translator it received as a VALUE (no `t()` call in it
+ *     at all, therefore invisible to every leg here at once) now marks its
+ *     family live. See that gate's header, "Key-building helpers".
  *
  * A key not covered by any of the three is a CANDIDATE. Two things this
  * mechanism does NOT see, both false-positive sources by construction, both
@@ -84,10 +89,11 @@
  * an argument of `t()`).
  *
  *   - CONFIRMED — no call site (AST) and no textual occurrence anywhere else in
- *     the repo. The strongest tier; still sample-verify before deleting
- *     (objectui#4658's own dispatch ruling), because a key can still be built by
- *     concatenation this grep cannot fold (`'console.' + 'objectView.' + 'new'`)
- *     or documented only in a form this script does not scan.
+ *     the repo. The tier with the MOST EVIDENCE, which is not the same claim as
+ *     the safest to delete: what it does and does not guarantee is written out
+ *     under "What CONFIRMED does NOT guarantee" below rather than left to the
+ *     word "strongest". Sample-verifying before deleting (objectui#4658's own
+ *     dispatch ruling) is a standing requirement, not a transitional one.
  *   - NEEDS-REVIEW — no call site, but the literal string appears somewhere
  *     (a comment, a doc, a fixture, an indirect `i18nKey:`-style property). The
  *     candidate might still be genuinely dead; the hit just means a human has to
@@ -102,8 +108,7 @@
  * so the source says `myPack.someGroup.someLeaf` where the pack key is
  * `topNamespace.someGroup.someLeaf`. The AST pass sees nothing either — there
  * is no `t()`/`tt()` call to classify. Both legs are blind at once, and the
- * key lands in CONFIRMED, the tier documented as the safest thing to delete,
- * while a shipping screen renders it. (That example is synthetic on purpose;
+ * key lands in CONFIRMED — the top tier — while a shipping screen renders it. (That example is synthetic on purpose;
  * naming a real key here would make this file a textual hit for it — same
  * trap `textFootprint()`'s own note below records.)
  *
@@ -172,6 +177,35 @@
  * importer never establishes liveness — it only ever adds a textual footprint,
  * which the full-key probe already catches. The re-derivation returns both
  * sets; the split is the point, not the count.
+ *
+ * ## What CONFIRMED does NOT guarantee (objectui#7592)
+ *
+ * Every leg here is a syntactic probe, so CONFIRMED means "no leg saw a
+ * reference", never "no consumer exists". Three classes are KNOWN to be able to
+ * put a live key in this tier. They are enumerated so the claim this header
+ * makes about the tier can be CHECKED against them instead of trusted:
+ *
+ *   1. A pack-object reader that indexes DYNAMICALLY — the `outboundAgentText`
+ *      shape above. No dotted key, no property chain, no call site. Measured on
+ *      this checkout, and it corrects the note above: its four keys are demoted
+ *      to NEEDS-REVIEW by CHANGELOG entries and test files that spell them, NOT
+ *      by the neighbouring type union, whose members are bare property names
+ *      (`'planApproveMessage'`) and therefore match neither probe. The luck is
+ *      real, it is not where objectui#6666 recorded it, and nothing holds it in
+ *      place — a CHANGELOG is not a liveness argument.
+ *   2. A key built by CONCATENATION (`'console.' + 'objectView.' + 'new'`), or
+ *      by a builder shape the key-builder leg does not read: anything but one
+ *      returned template literal, and anything that composes the head across
+ *      modules.
+ *   3. A consumer outside the AST walk's `packages/`+`apps/` scope that also
+ *      never spells the key as text (gap 1 above).
+ *
+ * The tier is therefore the one to READ FIRST, and each entry still needs a
+ * human before deletion. The cost of reading it as bulk-deletable is measured:
+ * on the day objectui#7592 was filed, 33 of 147 CONFIRMED entries — 22% of the
+ * tier — were one live subtree (`chatbot.tool.*`, rendering in ten packs), and
+ * following the tier would have reverted every AI tool card to English in nine
+ * locales. That class is closed; these three are not.
  *
  * ## Usage
  *


### PR DESCRIPTION
Fixes #7592

## What was wrong, and it was not the application code

`packages/plugin-chatbot/src/tool-display.ts`'s `toolTitleKey()` is idiomatic, correct code and is untouched. The detector is what mis-tiered it.

Every leg `check-i18n-dead-keys.mjs` owns begins at a `t()`/`tt()` call. This family has none — and the card's own account of *why* is one level off, which I re-derived rather than transcribed:

- `tool-display.ts:88` is `translate(toolTitleKey(trimmed), english)`. The callee is a **parameter named `translate`**, so `analyze()`'s classifier (`name === 't' || name === 'tt'`) never matches it.
- The module holds **no `t(` spelling at all**, so the pre-filter `/\btt?\s*(?:\?\.)?\s*\(/` drops the file *before the parser runs*. `filesScanned` counts it; nothing else ever opens it.

So the card's statement — "`dynamicHeads` (1879) and `dynamicFamilies` (1887) are populated only from a template-literal argument, and a helper call yields neither" — is **literally true at those exact lines** but is not the operative cause: it is vacuously true, because no argument position is ever reached. The consequence matters: a fix that resolved a helper call *in the key-argument position* would have changed nothing here.

## The fix: read the head where it is written

`analyze()` now recognises a **KEY BUILDER** — a function whose whole body is one returned template literal whose head is a dotted key prefix that resolves against `en` — and feeds its head/tail into `dynamicHeads`/`dynamicFamilies` through the *identical* bookkeeping a template argument uses.

Three boundaries, each measured on this tree, each pinned:

1. **One returned template, nothing else.** A multi-statement helper composes its head from things this parser cannot follow.
2. **The head must resolve against `en`.** 97 files hold a dotted template; requiring the head to prefix a real pack path is what makes this a key probe instead of a template census. Deliberate consequence: an unresolvable head means *not a key builder*, never `missing-prefix` — judging it would make every `` `${a}.${b}` `` a candidate defect.
3. **Registered local tables are skipped**, same scope rule the call-site classifier uses.

**Blast radius: 1 builder, 1 head, 47 extra files parsed of 1572 walked.** Narrow by measurement, not by hope.

### One script, not two

`check-i18n-dead-keys.mjs` needed **no consumption change**. The card's remedy §2 (it destructures only `referencedKeys, referencedBranches, dynamicHeads` at `:373` — still literally true) is about a *declared* family. Because the builder leg makes the head **observed**, the existing `dynamicHeads` read already protects the subtree. The whole detection fix lives in `check-i18n-call-site-keys.mjs`; `scripts/i18n-call-site-key-baseline.json` did **not** move.

## Tier counts — the number that says whether this worked

Measured with `node scripts/check-i18n-dead-keys.mjs --json` at `52cac38` (branch point) and at this branch's head `7e60e31`:

| | before | after |
|---|---|---|
| candidates | 396 | 361 |
| **CONFIRMED** | **147** | **114** |
| NEEDS-REVIEW | 249 | 247 |
| namespaces in CONFIRMED | 105 | 104 |

All **33** CONFIRMED removals are `chatbot.tool.*` keys. **Zero** keys added to either tier, zero other namespace moved, and the two that were in NEEDS-REVIEW "by luck" (`describe_object`, `visualize_data`, spelled as literals in one test) are now excluded as live rather than as lucky.

⚠️ The card measured 142/28 on `24135aba1`. Today's tree carries **35** `chatbot.tool` keys, **33** of them CONFIRMED out of **147** — the block grew, the share grew from 19.7% to 22.4%. The shape of the claim survived re-measurement; the digits did not.

## Anti-vacuous, in three places

The corpus is clean the moment the fix lands, so the leg is held up by things that fail when it stops detecting:

1. **The existing ratchet, for free.** The family is declared in `DYNAMIC_KEY_FAMILIES`, so if the builder leg stops seeing the head, the entry goes **stale** and `check:i18n-keys` exits 1. No new ratchet was invented.
2. **A real-repo pin** — `counters.keyBuilderSites >= 1` and `dynamicHeads.has('chatbot.tool.')` on this checkout.
3. **An end-to-end sweep pin** with a negative control (`orphan.group.leaf` must still be CONFIRMED), so "no `chatbot.tool` key is confirmed" cannot pass on a sweep that confirmed nothing.

**Ablation** (mutation and restore both proved on disk; restored blob `be120888` byte-identical to its `HEAD` blob, `git diff HEAD` empty). Deleting the one line that drives the leg:

```
VERDICT ablated check:i18n-keys exit=1
  scripts/check-i18n-call-site-keys.mjs:0  [stale-dynamic-family]  chatbot.tool.
VERDICT ablated pins exit=1   →   6 failed | 111 passed
ablated CONFIRMED 147 | chatbot.tool in CONFIRMED: 33
```

## The header's self-description is now true

`check-i18n-dead-keys.mjs` called CONFIRMED the tier "documented as the safest thing to delete". That sentence was false and is corrected rather than softened: CONFIRMED is the tier with the **most evidence**, which is not the same claim, and a new section enumerates the three classes that can **still** land a live key there — so the claim can be checked against them instead of trusted.

One of those entries corrects #6666's own note, from measurement: `outboundAgentText.ts`'s four keys are demoted to NEEDS-REVIEW by **CHANGELOG entries and test files**, *not* by the neighbouring `OutboundAgentTextKey` union — whose members are bare property names (`'planApproveMessage'`) and therefore match neither the full-key probe nor the property chain (`.ai.planApproveMessage`). The luck is real, it is not where it was recorded, and a CHANGELOG is not a liveness argument. Pinning that luck would mean pinning a changelog, so it is documented as a residual class instead.

## Explicitly not done

- ⛔ **Zero translation keys deleted.**
- ⛔ **No suppression entry, no allowlist** keyed to `chatbot.tool.*`. The registry entry is the repo's existing declaration mechanism, under both of its ratchets — and the leg that finds the head is shape-based, so the next helper-built family is detected without anyone remembering to list it.
- ⛔ **No change under `packages/plugin-chatbot/src/`**, and root `package.json` untouched (held by #7010).
- The "cheaper interim guard" the triage asked for first — the `PLATFORM_TOOLS_BY_PACKAGE` ↔ `chatbot.tool.*` set-identity pin — **already exists**: it landed as #7481 in `packages/plugin-chatbot/src/__tests__/toolLabels-locale-parity-7481.test.ts`. The registry entry cites it rather than duplicating it.

## Gates

Derived from objectui's own root `package.json` and `.github/workflows/` for the four files changed (objectstack's `dispatch-gates.mjs` refuses cross-repo derivation and was not used).

| gate | verdict |
|---|---|
| `pnpm check:i18n-keys` (`ci.yml:487`) | exit 0 |
| `pnpm check:i18n-drift` (`ci.yml:500`) | exit 0 |
| `pnpm type-check:scripts` (`ci.yml:519`) | exit 0 |
| `pnpm exec vitest run scripts/__tests__` (`changeset-release.yml:1080`) | exit 0 — 104 files / 3071 tests |
| `node scripts/check-control-bytes.mjs` (`control-bytes.yml`) | exit 0 — 6365 files |
| `node scripts/check-shell-escape-residue.mjs` | exit 0 |
| `node scripts/check-entry-guard.mjs` | exit 0 |
| `node scripts/check-lint-coverage.mjs` | exit 0 — 46/46 |
| `node scripts/check-changeset-presence.mjs` | exit 0 — **no changeset owed** |
| `node scripts/check-i18n-dead-keys.mjs` (report-only, not in CI) | exit 0 — the table above |

**Changeset:** the gate's own verdict is *"4 file(s) changed, 0 of them published source of a package the release covers … no changeset is owed"*. Root `scripts/` is not a published package, so no `.changeset/*.md` is added and the (dead, pin-forbidden) `skip-changeset` label is **not** applied.

**Lint narrowing, declared:** `pnpm lint` is `turbo run lint` — 46 *packages*; root `scripts/` is in no package, so CI lints these four files with nothing. I ran `eslint --no-inline-config` over all four anyway: 4 files by `--format json` count, 0 errors, 0 warnings, at head `7e60e31`. `eslint.config.js` enables no type-aware linting (no `parserOptions.project` / `projectService`), so this diff cannot move the verdict of any file it did not touch.

## 维护者速读（草稿）

**改了什么** — i18n 死键清扫器的探测腿。`analyze()` 现在会认一种「键构造器」：整个函数体就是一条返回的模板字面量，且其静态头能在 `en` 里解析。它的头/尾走和模板实参完全相同的记账路径。应用侧代码一行未动。

**为什么改** — 35 个正在渲染的 `chatbot.tool.*` 键里有 33 个躺在 CONFIRMED 档（该档 147 条中的 22%）。按这个档删下去，会删掉 350 条译文，让九种语言下每张 AI 工具卡回退成英文 —— 就是 cloud#1658 报过、#7254 修过的那次回归。⛔ 一个键都没删；⛔ 没加豁免名单：修的是探测器，不是被它冤枉的代码。

**风险与代价（含回滚）** — 探测面只增不减：多解析 47 个文件（共 1572 个），新增 1 个族声明。假阳性风险由「头必须能在 `en` 里解析」挡住 —— 全仓 97 个带点模板里只有 1 个符合构造器形状。回滚 = revert 本 PR 两个 commit；门禁会立刻退回旧读数（消融实验已经跑过这条路：CONFIRMED 回到 147）。⚠️ 这个改动**不影响任何用户可见行为**，它只影响一份 report-only 的清单和一条 CI 门禁。

**席位意见** —

**你要做的** — 确认一件事：`chatbot.tool.` 这个族声明成 `enumerable: false / external-vocabulary`（成员集在 `@objectstack/spec` 里，本仓读不到），成员完整性靠 #7481 那条 pin 在另一层保证。如果你更希望它在本仓再做一份可读的 `Record`，那是另一张卡。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDq78vMMSzCGWGmhUYBabh)_