### PR TITLE
fix(docs): replace the `ObjectRenderer` phantom in `docs/` with the measured `ObjectView` spelling (objectui#7838)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,9 @@ This document describes the refactored architecture that enables third-party sys
 
 **Exports**:
 - `AppShell` - Basic layout container
-- `ObjectRenderer` - Renders object views
+- `ObjectView` - Renders object views; it reads `objectName` from the router
+  (`useParams()`) and takes an `objects` metadata array. For a router-free embed,
+  use `ObjectView` from `@object-ui/plugin-view` instead - see the examples below.
 - `DashboardRenderer` - Renders dashboard layouts
 - `PageRenderer` - Renders custom pages
 - `FormRenderer` - Renders forms
@@ -49,7 +51,7 @@ This document describes the refactored architecture that enables third-party sys
 ┌────────────────┴────────────────────────┐
 │  @object-ui/app-shell                   │
 │  - AppShell                             │
-│  - ObjectRenderer                       │
+│  - ObjectView                           │
 │  - DashboardRenderer                    │
 │  - PageRenderer                         │
 │  - FormRenderer                         │
@@ -151,16 +153,24 @@ Third-Party App
 ### Example 1: Minimal Custom Console
 
 ```tsx
-import { AppShell, ObjectRenderer } from '@object-ui/app-shell';
-import { DataSourceProvider } from '@object-ui/providers';
+import { AppShell } from '@object-ui/app-shell';
+import { ObjectView } from '@object-ui/plugin-view';
+import { DataSourceProvider, useDataSource } from '@object-ui/providers';
 
 function MyConsole() {
   return (
     <DataSourceProvider dataSource={myAPI}>
       <AppShell sidebar={<MySidebar />}>
-        <ObjectRenderer objectName="contact" />
+        <ContactList />
       </AppShell>
     </DataSourceProvider>
+  );
+}
+
+function ContactList() {
+  const dataSource = useDataSource();
+  return (
+    <ObjectView schema={{ type: 'object-view', objectName: 'contact' }} dataSource={dataSource} />
   );
 }
 ```
@@ -181,18 +191,20 @@ export default function RootLayout({ children }) {
 }
 
 // app/[object]/page.tsx
-import { ObjectRenderer } from '@object-ui/app-shell';
+import { ObjectView } from '@object-ui/plugin-view';
+import { useDataSource } from '@object-ui/providers';
 
 export default function Page({ params }) {
-  return <ObjectRenderer objectName={params.object} />;
+  const dataSource = useDataSource();
+  return <ObjectView schema={{ type: 'object-view', objectName: params.object }} dataSource={dataSource} />;
 }
 ```
 
 ### Example 3: Embedded Widget
 
 ```tsx
-import { ObjectRenderer } from '@object-ui/app-shell';
-import { DataSourceProvider } from '@object-ui/providers';
+import { ObjectView } from '@object-ui/plugin-view';
+import { DataSourceProvider, useDataSource } from '@object-ui/providers';
 
 function MyExistingApp() {
   return (
@@ -201,12 +213,17 @@ function MyExistingApp() {
 
       {/* Embed ObjectUI widget */}
       <DataSourceProvider dataSource={myAPI}>
-        <ObjectRenderer objectName="contact" />
+        <ContactWidget />
       </DataSourceProvider>
 
       <footer>My App Footer</footer>
     </div>
   );
+}
+
+function ContactWidget() {
+  const dataSource = useDataSource();
+  return <ObjectView schema={{ type: 'object-view', objectName: 'contact' }} dataSource={dataSource} />;
 }
 ```
 

--- a/docs/CONSOLE-STREAMLINING-SUMMARY.md
+++ b/docs/CONSOLE-STREAMLINING-SUMMARY.md
@@ -14,7 +14,9 @@ This implementation completed **Phase 1** of the console streamlining project, e
 
 **Components**:
 - `AppShell` - Basic layout container with sidebar/header/footer support
-- `ObjectRenderer` - Renders object views (Grid, Kanban, List, etc.)
+- `ObjectView` - Renders object views (Grid, Kanban, List, etc.); it reads
+  `objectName` from the router (`useParams()`) and takes an `objects` metadata
+  array. For a router-free embed, use `ObjectView` from `@object-ui/plugin-view`.
 - `DashboardRenderer` - Renders dashboard layouts from schema
 - `PageRenderer` - Renders custom page schemas
 - `FormRenderer` - Renders forms (modal or inline)


### PR DESCRIPTION
Fixes #7838

`docs/ARCHITECTURE.md` taught `ObjectRenderer` from `@object-ui/app-shell` in three code blocks and two prose lines, and `docs/CONSOLE-STREAMLINING-SUMMARY.md` repeated the claim once. This is the third site of the same phantom; PR objectui#7836 fixed the root `README.md` and objectui#7095 records the remaining one in `examples/byo-backend-console/README.md`.

## The trap this card walked into, and why the fix is not a rename

objectui#7095's card text proposes *"The real export is `ObjectView` ... It takes `objectName`, so the fix is a rename in place."* **Re-measured here on today's tree, that sentence is false in all three of its parts:**

| claim | measured at `8507a2283` |
|---|---|
| app-shell's `ObjectView` takes `objectName` | it does **not** — `packages/app-shell/src/views/ObjectView.tsx:865` is `export function ObjectView({ dataSource, objects, onEdit, externalRefreshKey }: any)`, and line 866 is `const { objectName } = useParams()`, i.e. it comes from a router route |
| it is a drop-in for the doc's snippets | it also needs an `objects` metadata array — line 877 is `objects.find(...)`, and a missing object renders the "object not found" empty state |
| a wrong prop would be caught | its whole props surface is typed `any` (objectui#7483), so **nothing** is raised at build time |

⇒ a bare rename would have gone green and still been broken at runtime. The spelling used here is the one PR objectui#7836 measured and landed for the root README: **`ObjectView` from `@object-ui/plugin-view`**, which has a real typed props surface (`schema: ObjectViewSchema`, `dataSource: DataSource`, `packages/plugin-view/src/ObjectView.tsx:225`) and is what `examples/byo-backend-console/src/App.tsx:141` actually runs. Each block reads its data source out of the `DataSourceProvider` it already installs, via `useDataSource()` from `@object-ui/providers` (a real export, `packages/providers/src/index.ts:7`), so no block gains a new undefined ambient name.

**Clause-2 stays `no`**: no export added, no signature changed, no gate predicate or population touched.

## The prose lines say what is actually true

The two **Exports** bullets could not simply be renamed: `ObjectView` from `plugin-view` is not an export of `app-shell`. app-shell does export an `ObjectView` of its own (barrel line 194), so each bullet now names that one and says what it costs — router-coupled, needs `objects` — and points at `plugin-view` for a router-free embed.

## ⛔ "The gates are still green" proves nothing here

No gate reads either file. That is the card's own second half, re-verified at `8507a2283`: `check-doc-snippet-types`'s `listDocuments()` walks `content/docs`, the per-app docs trees, `packages/NAME/README.md` and `ROOT_PAGES = ['README.md']`; `check-readme-exports` prints `43 tracked README(s) under packages/ (0 outside any package)`; `lint:root` is literally `--ignore-pattern 'docs/**'`.

**The reading that matters** is the before/after diagnostic list from a harness that runs the gate's own `analyze()` / `derivePackageTypePaths()` / `deriveDeclaredDependencyPaths()` / `compileSnippets()` over the `docs/` tree, on the gate's own build closure (`pnpm exec turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2`, **34/34 tasks successful**, all 27 imported workspace packages built — so this is a result, not an unmet prerequisite). The harness lives in scratchpad and **imports** the gate; it changes no gate.

**Before — 43 diagnostics tree-wide, 14 in `docs/ARCHITECTURE.md`:**

```
[semantic]  docs/ARCHITECTURE.md:154:20  TS2305: Module '"@object-ui/app-shell"' has no exported member 'ObjectRenderer'.
[semantic]  docs/ARCHITECTURE.md:159:37  TS2552: Cannot find name 'myAPI'. Did you mean 'Map'?
[semantic]  docs/ARCHITECTURE.md:160:27  TS2304: Cannot find name 'MySidebar'.
[semantic]  docs/ARCHITECTURE.md:175:25  TS2323: Cannot redeclare exported variable 'default'.
[semantic]  docs/ARCHITECTURE.md:175:25  TS2393: Duplicate function implementation.
[semantic]  docs/ARCHITECTURE.md:175:38  TS7031: Binding element 'children' implicitly has an 'any' type.
[semantic]  docs/ARCHITECTURE.md:184:10  TS2305: Module '"@object-ui/app-shell"' has no exported member 'ObjectRenderer'.
[semantic]  docs/ARCHITECTURE.md:186:25  TS2323: Cannot redeclare exported variable 'default'.
[semantic]  docs/ARCHITECTURE.md:186:25  TS2393: Duplicate function implementation.
[semantic]  docs/ARCHITECTURE.md:186:32  TS7031: Binding element 'params' implicitly has an 'any' type.
[semantic]  docs/ARCHITECTURE.md:194:10  TS2305: Module '"@object-ui/app-shell"' has no exported member 'ObjectRenderer'.
[semantic]  docs/ARCHITECTURE.md:203:39  TS2552: Cannot find name 'myAPI'. Did you mean 'Map'?
[semantic]  docs/ARCHITECTURE.md:232:14  TS7006: Parameter 'objectName' implicitly has an 'any' type.
[semantic]  docs/ARCHITECTURE.md:232:26  TS7006: Parameter 'params' implicitly has an 'any' type.
```

**After, at `8507a2283` — 40 tree-wide, 11 in `docs/ARCHITECTURE.md`.** Diffed as sets with the line/column normalised away, so a pure line-shift is not misread as a change:

```
--- REMOVED (before minus after) ---
  x3  [semantic]  docs/ARCHITECTURE.md  TS2305: Module '"@object-ui/app-shell"' has no exported member 'ObjectRenderer'.

--- NEW (after minus before) ---
  (none)
```

Exactly the three TS2305s, and **no new diagnostic**. The survivors (`myAPI`, `MySidebar`, the two `export default` in one Next.js fence) are pre-existing and out of this card's surface.

## Is `docs/` a governed surface? — turned into a reading, not recalled

```
$ node scripts/check-governed-queue-guard.mjs --test docs/ARCHITECTURE.md               # exit 0
✅ NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched.
   An ordinary pull request: the normal review and merge-queue route applies.

$ node scripts/check-governed-queue-guard.mjs --test docs/CONSOLE-STREAMLINING-SUMMARY.md   # exit 0
✅ NOT GOVERNED — 1 path(s) checked against 5 governed surface(s); none matched.
   An ordinary pull request: the normal review and merge-queue route applies.
```

(`docs/adr/**` **is** governed; these two files are not.)

## Changeset

```
$ node scripts/check-changeset-presence.mjs    # exit 0
Compared the working tree with 3faaa7d0f (merge-base with origin/main): 2 file(s) changed, 0 of them
published source of a package the release covers, 0 of them a manifest whose published contract moved,
0 under a package changesets ignores, 0 changeset(s) added.
✅  No source or published contract of a released package changed in this range, so no changeset is owed.
```

Acted on: no changeset added.

## Gates, all re-run at the final commit `8507a2283`, exit code captured by redirecting first

| gate | exit | its own verdict line |
|---|---|---|
| `check:doc-snippets` | 0 | `Semantic phase: 456 of 456 block(s) judged, 0 failed.` |
| `check:doc-types` | 0 | `Every documented component type is registered.` |
| `check:doc-fences` | 0 | `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript` |
| `check:readme-exports` | 0 | `421 self-imports judged (421 real, 0 wrong-path, 0 fabricated)` |
| `check:control-bytes` | 0 | `scanned 6367 tracked text file(s); skipped 85 binary` |
| `lint:root` | 0 | `0 errors, 33 warnings` — all pre-existing, none in either changed file |

Plus a direct control-byte scan of both changed files (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`): no hits.

`check:readme-exports` first exited 1 with three `@object-ui/plugin-ai` lines reading `its type entry ./dist/index.d.ts is not on disk — run pnpm build first`. That is an **unmet prerequisite, not a result** — `plugin-ai` is outside the doc gate's scoped build closure by design (objectui#7795 / objectui#7812). Building `--filter=@object-ui/plugin-ai...` turned it into the green above. The #7417 seat hit exactly this one.

## Not run, stated plainly

- **No package test suite and no `turbo run lint` fan-out.** This diff is two Markdown files under `docs/`, and `lint:root` — defined as everything outside `packages/*`, `examples/*`, `apps/*` and `docs/*` — does not even include them. `eslint.config.js` declares no `project`/`projectService`, so no rule reads across files and this diff cannot move an untouched file's verdict.
- CI runs the whole farm regardless.

## Deliberately not touched, so no reader infers the list was audited clean

The same two export lists carry `DashboardRenderer`, `PageRenderer` and `FormRenderer`, and **all three are also wrong** — measured here, `grep -c Renderer packages/app-shell/dist/index.d.ts` is `0`, so none of them is an app-shell export either. They are not in this card's enumerated line surface and, unlike `ObjectRenderer`, they have three *different* correct answers (`DashboardRenderer` is real but ships from `@object-ui/plugin-dashboard`; `PageRenderer` and `FormRenderer` are on no package's built `dist/index.d.ts` at all). Picking each is a judgement call, not a rename, so they are filed rather than edited: objectui#7854.

## Out-of-scope findings filed

- objectui#7854 — the three sibling renderer names in these same two files.
- objectui#7856 — the `docs/` tree is in no gate's scan surface: **40 diagnostics** measured if it were added (21 syntax, 19 semantic), **26 of them in the governed `docs/adr/**`**. That size is itself the answer to "why was it never added", and the finding proposes splitting the next card in two along the governed boundary. ⛔ No gate population was changed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_