### PR TITLE
docs(plugin-detail): record:activity states the unmapped-row fallback, not the pre-fallback drop

### DIFF
--- a/content/docs/plugins/plugin-detail.mdx
+++ b/content/docs/plugins/plugin-detail.mdx
@@ -230,16 +230,23 @@ meeting is `completed` → `task`, hidden unless `showCompleted`; a not-yet-held
 meeting is `scheduled` → `event`, shown, because an upcoming meeting is the part
 of a timeline you still act on.
 
-A row whose `type` is in neither list is dropped and logs one `console.warn`
-naming the type — `sys_activity.type` is not validated on write, so a producer
-can store a value the platform never declared, and a silently missing row is
-indistinguishable from no activity at all.
+A row whose `type` is in neither list is **not dropped**: it renders through the
+generic `system` presentation and logs one `console.warn` naming the type.
+`sys_activity.type` is author-extensible and is not validated on write, so a
+value this map has never seen is real record activity a producer stored, not a
+mistake to discard. The warning therefore reports a **missing decision**, not
+lost data — the row is on the timeline; what it lacks is the icon and colour a
+mapped type gets. Give it one by adding the type to `ACTIVITY_TYPE_TO_FEED_TYPE`
+in `@object-ui/plugin-detail`.
 
-<Callout type="warn">
-  The console's own record page maps these rows with a second, hand-written copy
-  of the table, so the two surfaces agree on everything except `scheduled`,
-  which that page still drops. Tracked in `objectui#5878`.
-</Callout>
+The rows that really are dropped are the four the map lists as non-activity —
+`commented` / `mentioned` / `login` / `logout` — and they go silently on
+purpose: each is a decision already taken, and a warning about a decision
+teaches authors to ignore the channel.
+
+Both surfaces map rows through the same `activityRowToFeedItem`: the console's
+own record page imports it from this package rather than mapping the rows
+itself, so everything above describes that page too.
 
 ### Which inputs do what
 


### PR DESCRIPTION
Fixes #6932

Docs-only. Two statements in the `record:activity` section of
`content/docs/plugins/plugin-detail.mdx` were true when written and are false on
today's `main`. Both re-verified against `origin/main` at `cf7f2af` before editing
(`git show origin/main:PATH`, not the shared working tree) — both were still stale,
so the card's premise holds.

## 1. "A row whose `type` is in neither list is dropped"

It is not dropped. `activityRowToFeedItem` gives a `sys_activity.type` outside
`ACTIVITY_TYPE_TO_FEED_TYPE` the fallback `UNMAPPED_ACTIVITY_FEED_TYPE = 'system'`
(`packages/plugin-detail/src/renderers/recordActivityFeed.ts:162`, re-derived — the
line is unchanged), so the row renders through the generic presentation and the
`console.warn` reports a **missing decision**, not lost data.

This is a meaning change, not a word swap: "dropped" and "rendered generically" send
an author to two different fixes, and the fallback exists precisely so the value does
not vanish. The rewritten paragraph therefore names the fallback, says what the
warning now means, and names `ACTIVITY_TYPE_TO_FEED_TYPE` as the fix — so a reader
reaches for a mapping rather than hunting for a vanished row.

A second short paragraph keeps the contrast that makes the section diagnostic: the
four types the map lists as non-activity (`commented` / `mentioned` / `login` /
`logout`) are the rows that really are dropped, and silently on purpose. Without it,
"nothing was dropped" and "my row disappeared with no warning" have no distinguishing
text on the page.

Note the page already contradicted itself — the "Feed kinds with no producer" table
below states the generic-fallback behaviour correctly. The two now agree.

## 2. The callout about a second, hand-written copy of the table

Deleted. `packages/app-shell/src/views/RecordDetailView.tsx:13` imports
`activityRowToFeedItem` from `@object-ui/plugin-detail` and calls it at `:1670`; the
comment at `:1632` says in the source that it is not a copy. Both surfaces reach
`FeedItemType` through one constructor and neither drops `scheduled`, so the callout
warned readers away from a hazard that no longer exists and pointed at objectui#5878,
a card that is no longer open (named here without any keyword, deliberately). One
sentence replaces it, stating the arrangement that holds now.

## No dated clause

Neither passage says "as of PR #6112" or similar. The page teaches current behaviour;
a dated clause is the next thing to rot, and this card is an instance of that rot
class. The card numbers stay in this PR body and in the commit message, where they
belong.

## Deliberately not done

The card's "suggested shape" floats a **pin** so the pair cannot drift again. Not
done here: a pin needs a test file, and the dispatched file surface for this card is
`content/docs/plugins/plugin-detail.mdx` only. Reported back to the PM rather than
absorbed — the pin's shape (transcription comparison vs. rewriting the prose to carry
no driftable assertion) is an open design choice that triage explicitly declined to
rule on.

## Gates

Derived from objectui's own root `package.json` and `.github/workflows/` for a
`content/docs/**/*.mdx` change (the doc gates are all unfiltered — no `paths:`
filter — so every one of them reports on this PR). All run locally on the final tree,
exit codes captured before any pipe:

| gate | workflow | verdict |
|---|---|---|
| `check:doc-types` | `doc-component-types.yml` | exit 0 — "Every documented component type is registered." |
| `check:doc-fences` | `doc-fence-languages.yml` | exit 0 — 227 documents |
| `check:doc-snippets` | `doc-snippet-types.yml` | exit 0 — "455 of 455 block(s) judged, 0 failed" |
| `docs:check-links` | `docs-links.yml` | exit 0 — "Links are valid across 17 scan roots." |
| `check:docs-route-closure` | `docs-route-eager-closure.yml` | exit 0 |
| `check-control-bytes` | `control-bytes.yml` | exit 0 — 6378 tracked text files |
| `check-changeset-presence` | `changeset-presence.yml` | exit 0 |

`check:doc-snippets` first exited **2** — its own "I could not run, NOT I ran and
found errors" prerequisite state, read as NOT MEASURED. Its scoped build
(26 packages plus closures, 34 turbo tasks) ran through the container's shared
heavy-verify lock (`VERDICT command-exit 0 · held the lock 164s · waited 0s`), and
the gate then exited 0.

Repo-wide scans (`pnpm lint`) are CI's: `eslint.config.js` targets no `.mdx`, so this
diff is outside its file set entirely.

## Changeset

None, and none is owed. Derived from the repo's gate rather than assumed:

```
check-changeset-presence: 1 file(s) changed, 0 of them published source of a package
the release covers, 0 of them a manifest whose published contract moved, 0 changeset(s) added.
No source or published contract of a released package changed in this range.
```

The `skip-changeset` label is **not** applied — it is dead in this repo (objectui#4912)
and pin-forbidden.

## Scope

- Files changed: 1 — `content/docs/plugins/plugin-detail.mdx` (+17 / -10), the
  `record:activity` section only.
- Zero changes under `packages/plugin-detail/src/**`. The code is correct; the docs
  were stale.
- Not governed surface: `node scripts/check-governed-queue-guard.mjs --test` returns
  "NOT GOVERNED — none matched".
- One grep across `content/docs/**` for the stale phrasing found **no second page**
  carrying either statement. The one neighbouring "dropped" in the same section (the
  `types` allow-list row) was checked against `normalizeFeedTypes` and is accurate —
  unrecognised `types` entries genuinely are ignored and named in one warning.

Session: `session_01KDq78vMMSzCGWGmhUYBabh`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDq78vMMSzCGWGmhUYBabh)_