### PR TITLE
fix(docs): alert-dialog and sheet publish trigger/content as optional

### DIFF
--- a/.changeset/overlay-slot-requiredness-7106.md
+++ b/.changeset/overlay-slot-requiredness-7106.md
@@ -1,0 +1,8 @@
+---
+---
+
+Docs-only fix: `alert-dialog.mdx` and `sheet.mdx` published `trigger`/`content`
+node slots as required; the shipped `AlertDialogSchema`/`SheetSchema`
+declarations (and their Zod mirrors) already declare them optional. No
+declaration changes; test-only update to the fixture pin that records this
+class of divergence.

--- a/content/docs/components/overlay/alert-dialog.mdx
+++ b/content/docs/components/overlay/alert-dialog.mdx
@@ -27,7 +27,7 @@ interface AlertDialogSchema {
   description?: string;                 // Dialog description
 
   // Trigger
-  trigger: SchemaNode | SchemaNode[];   // Component that triggers the dialog
+  trigger?: SchemaNode | SchemaNode[];  // Component that triggers the dialog
 
   // Body and footer
   content?: SchemaNode | SchemaNode[];  // Rendered between the header and the footer

--- a/content/docs/components/overlay/sheet.mdx
+++ b/content/docs/components/overlay/sheet.mdx
@@ -23,10 +23,10 @@ The Sheet component displays content in a panel that slides in from the edge of 
 ```plaintext
 interface SheetSchema {
   type: 'sheet';
-  trigger: SchemaNode | SchemaNode[];   // Trigger component
+  trigger?: SchemaNode | SchemaNode[];  // Trigger component
   title?: string;                       // Sheet title
   description?: string;                 // Sheet description
-  content: SchemaNode | SchemaNode[];   // Sheet content
+  content?: SchemaNode | SchemaNode[];  // Sheet content
   side?: 'left' | 'right' | 'top' | 'bottom';
   className?: string;
 }

--- a/packages/types/src/__tests__/overlay-node-slot-doc-types-7082.test.ts
+++ b/packages/types/src/__tests__/overlay-node-slot-doc-types-7082.test.ts
@@ -71,11 +71,14 @@
  * pins those rows). `EmptySchema.action` keeps its row and its pin. The day it
  * is declared, this file goes red and the page is owed a row.
  *
- * Likewise the requiredness of `AlertDialogSchema.trigger`, `SheetSchema.trigger`
- * and `SheetSchema.content`: all three are declared OPTIONAL and published
- * REQUIRED. That is objectui#7073's defect class, not this card's, and it is
- * fenced out of the diff -- but pinned here so it cannot be lost, and so a fix
- * on either side turns this file red rather than passing unnoticed.
+ * The requiredness of `AlertDialogSchema.trigger`, `SheetSchema.trigger` and
+ * `SheetSchema.content` was the exception left after that: all three were
+ * declared OPTIONAL and published REQUIRED, objectui#7073's defect class
+ * rather than this card's, so it was fenced out of the diff and pinned
+ * instead so a fix on either side would turn this file red rather than
+ * passing unnoticed. objectui#7106 closed it: all three pages now spell `?`,
+ * joining `ContextMenuSchema.trigger` -- the row #7073 had already corrected
+ * -- as agreement rather than divergence.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -326,19 +329,15 @@ describe('rows a docs-only edit cannot honestly resolve, recorded rather than re
   });
 });
 
-describe('requiredness divergences left to the objectui#7073 class, pinned so they cannot be lost', () => {
+describe('requiredness: the objectui#7073 class, closed -- all four rows agree on both faces (objectui#7106)', () => {
   it.each([
+    ['ContextMenuSchema', 'trigger'],
     ['AlertDialogSchema', 'trigger'],
     ['SheetSchema', 'trigger'],
     ['SheetSchema', 'content'],
-  ])('%s.%s is declared optional and still published required', (owner, key) => {
+  ])('%s.%s is declared optional and published optional', (owner, key) => {
     expect(declRow(owner, key)?.optional).toBe(true);
-    expect(docRow(owner, key)?.optional).toBe(false);
-  });
-
-  it('`ContextMenuSchema.trigger` is the one already corrected, by #7073 -- the control', () => {
-    expect(declRow('ContextMenuSchema', 'trigger')?.optional).toBe(true);
-    expect(docRow('ContextMenuSchema', 'trigger')?.optional).toBe(true);
+    expect(docRow(owner, key)?.optional).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes #7106

## What

`alert-dialog.mdx:30` (`trigger`) and `sheet.mdx:26` / `:29` (`trigger` /
`content`) published these node slots as **required**. `AlertDialogSchema`
and `SheetSchema` (`packages/types/src/overlay.ts`) and their Zod mirrors
(`zod/overlay.zod.ts`) already declare all three **optional** — objectui#7073's
defect class (the pages refuse what the platform accepts), left on these two
pages after #7073 fenced itself to `context-menu.mdx` / `dropdown-menu.mdx`.

Fix is the mechanical one the card names: flip the three `?`, no declaration
changes.

## Pin file

The divergence was already machine-recorded in
`packages/types/src/__tests__/overlay-node-slot-doc-types-7082.test.ts`
(`describe('requiredness divergences left to the objectui#7073 class …')`).
Moved the three rows to the corrected/agreeing side, merged into the same
`it.each` as the `ContextMenuSchema` control #7073 already fixed, and updated
the file's top-of-file JSDoc note. Proved the coupling both ways:

- **Red** (pages flipped, pin not yet updated): 3 failures, exactly the 3
  target rows —
  `AlertDialogSchema.trigger` / `SheetSchema.trigger` / `SheetSchema.content`
  each failed `expect(docRow(...).optional).toBe(false)` (received `true`).
- **Green** (pin updated to match): 33/33 passed.

## Gates run locally

| Gate | Result |
| --- | --- |
| `overlay-node-slot-doc-types-7082.test.ts` (vitest) | 33/33 passed |
| `pnpm --filter @object-ui/types type-check` | exit 0 (`tsc --noEmit && tsc -p tsconfig.examples.json && tsc -p tsconfig.test.json`) |
| `node scripts/check-doc-fence-languages.mjs` | ✅ every TS block fenced correctly |
| `node scripts/check-doc-component-types.mjs` | ✅ every documented component type registered |
| `node scripts/check-doc-links.mjs` | ✅ links valid across 17 scan roots |
| `node scripts/check-control-bytes.mjs` | ✅ OK, 6408 tracked text files scanned |
| `node scripts/check-changeset-presence.mjs` | ✅ empty-frontmatter changeset declared, `.changeset/overlay-slot-requiredness-7106.md` |
| `node scripts/check-governed-queue-guard.mjs --test <4 changed paths>` | ✅ NOT GOVERNED — ordinary PR route |

## Scope

Only the three `?` on the two pages, plus the pin-file move and an
empty-frontmatter changeset (docs-only, releases nothing). No declaration
changes (`overlay.ts` / `zod/overlay.zod.ts` untouched — they were already
correct). `alert-dialog.mdx`'s deeper Schema-fence divergence (#7104) is
CLOSED and, measured on this branch's base, left these three rows untouched —
no entanglement remained, so both pages land in this one PR per PM ruling.

---
_Generated by [Claude Code](https://claude.ai/code/session_013uAaxiwgYDybsTNV9xwa1M)_