### PR TITLE
test(gates): give both document-count pins the third copy's non-vacuous floor, and census `content/docs/**` (non-zero, so no expansion)

### DIFF
--- a/scripts/__tests__/check-doc-component-types.test.ts
+++ b/scripts/__tests__/check-doc-component-types.test.ts
@@ -68,6 +68,38 @@ function documentCounts(text: string): string[] {
   return [...text.matchAll(new RegExp(POPULATION_COUNT.source, 'gi'))].map((m) => m[0].replace(/\s+/g, ' ').trim());
 }
 
+/**
+ * The workflow header's comment prose, as the count pin reads it.
+ *
+ * Lifted to module scope by objectui#7901 for the same reason objectui#7914
+ * lifted the pattern: the pin below and the emptiness control beside it must
+ * read ONE extraction, or the control demonstrates a surface the pin does not
+ * have. The extraction itself is unchanged, character for character, from what
+ * the pin carried inline.
+ */
+function headerComments(yaml: string): string {
+  return yaml
+    .split('\n')
+    .filter((line) => /^\s*#/.test(line))
+    .join('\n');
+}
+
+/**
+ * The floor the extracted header must clear before an empty count list means
+ * anything — carried from the third copy of this pin
+ * (`check-links-workflow.test.ts`, objectui#7825), which has asserted it since
+ * that copy was written and which both twins were missing (objectui#7901).
+ *
+ * Why a floor at all: `documentCounts('')` is `[]`. A header this extraction has
+ * stopped reading — the workflow renamed or deleted, its comment markers
+ * changed, the path moved — therefore satisfies the pin perfectly, and the pin
+ * reports a clean surface it never read. The floor is what makes "no counts
+ * here" a reading rather than the absence of one. It is the same claim the
+ * scan-collapse pins in this file already make about the document walk, applied
+ * to the one surface that had none.
+ */
+const MIN_HEADER_PROSE = 400;
+
 interface Finding {
   reason: string;
   site: string;
@@ -949,11 +981,18 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
    * across, so this closes a proven hole rather than a live violation.
    */
   it('its header states the population and never counts it — no count can rot here', () => {
-    const header = fs
-      .readFileSync(workflowPath, 'utf8')
-      .split('\n')
-      .filter((line) => /^\s*#/.test(line))
-      .join('\n');
+    const header = headerComments(fs.readFileSync(workflowPath, 'utf8'));
+
+    // objectui#7901 — the floor first, or the assertion below is vacuous. The
+    // count half cannot distinguish a header that carries no counts from a
+    // header this pin has stopped reading; both score `[]`. Measured when this
+    // was added, so it is latent rather than live: the extraction returned 4514
+    // characters from this header, 11.3 times the floor.
+    expect(
+      header.length,
+      'doc-component-types.yml: the header prose this pin reads came back empty or near-empty, so it asserted over nothing',
+    ).toBeGreaterThan(MIN_HEADER_PROSE);
+
     const counts = documentCounts(header);
     expect(
       counts,
@@ -1025,6 +1064,38 @@ describe('wiring — the gate is reachable and a docs-only PR starts it', () => 
     for (const line of legitimate) {
       expect(documentCounts(line), `doc-component-types.yml's count pin must NOT fire on: ${line}`).toEqual([]);
     }
+  });
+  /**
+   * The positive control for the emptiness floor — objectui#7901.
+   *
+   * The pin above has two halves and they fail differently. The control right
+   * above this one exercises the PATTERN half; this one exercises the other,
+   * and the shape it demonstrates is what makes a pin vacuous rather than
+   * merely wrong — a surface that came back empty scores clean under any
+   * pattern, however good. That is not hypothetical for this family:
+   * objectui#7466 is the pin in this repository that scored the same on the
+   * broken tree and the fixed one.
+   *
+   * Demonstrated on synthetic YAML rather than by emptying the real workflow,
+   * so the claim stays reproducible in a checkout whose header is intact —
+   * which is every checkout.
+   */
+  it('the emptiness floor fires on a header this pin has stopped reading', () => {
+    const unread = 'name: Doc Component Types\non:\n  workflow_dispatch:\n';
+    expect(headerComments(unread), 'the extraction returns nothing on a comment-less workflow').toBe('');
+    expect(
+      documentCounts(headerComments(unread)),
+      'and the count half alone scores that identically to a header carrying no counts',
+    ).toEqual([]);
+    expect(headerComments(unread).length, 'so the floor is the half that has to reject it').not.toBeGreaterThan(
+      MIN_HEADER_PROSE,
+    );
+
+    // Short, not empty: a header truncated to a line or two is the same defect
+    // arriving gradually, and `toBe('')` would wave it through.
+    const nearEmpty = '# Doc component types.\n# The gate prints its own verdict line.\nname: x\n';
+    expect(headerComments(nearEmpty).length, 'this fixture must be short, not empty').toBeGreaterThan(0);
+    expect(headerComments(nearEmpty).length).not.toBeGreaterThan(MIN_HEADER_PROSE);
   });
 });
 

--- a/scripts/__tests__/check-doc-fence-languages.test.ts
+++ b/scripts/__tests__/check-doc-fence-languages.test.ts
@@ -51,6 +51,38 @@ function documentCounts(text: string): string[] {
 }
 
 /**
+ * The workflow header's comment prose, as the count pin reads it.
+ *
+ * Lifted to module scope by objectui#7901 for the same reason objectui#7914
+ * lifted the pattern: the pin below and the emptiness control beside it must
+ * read ONE extraction, or the control demonstrates a surface the pin does not
+ * have. The extraction itself is unchanged, character for character, from what
+ * the pin carried inline.
+ */
+function headerComments(yaml: string): string {
+  return yaml
+    .split('\n')
+    .filter((line) => /^\s*#/.test(line))
+    .join('\n');
+}
+
+/**
+ * The floor the extracted header must clear before an empty count list means
+ * anything — carried from the third copy of this pin
+ * (`check-links-workflow.test.ts`, objectui#7825), which has asserted it since
+ * that copy was written and which both twins were missing (objectui#7901).
+ *
+ * Why a floor at all: `documentCounts('')` is `[]`. A header this extraction has
+ * stopped reading — the workflow renamed or deleted, its comment markers
+ * changed, the path moved — therefore satisfies the pin perfectly, and the pin
+ * reports a clean surface it never read. The floor is what makes "no counts
+ * here" a reading rather than the absence of one. It is the same claim the
+ * scan-collapse pins in this file already make about the document walk, applied
+ * to the one surface that had none.
+ */
+const MIN_HEADER_PROSE = 400;
+
+/**
  * objectui#6135. `check-doc-snippet-types` reads `ts` / `tsx` / `typescript`
  * fences, so a TypeScript block fenced any other way is invisible to it, and
  * objectui#5867's remediation lane collected its population from `plaintext`
@@ -292,11 +324,18 @@ describe('check-doc-fence-languages is wired, not merely present', () => {
    * number is written here that a document being added would falsify.
    */
   it('its header states the population and never counts it — no count can rot here', () => {
-    const header = fs
-      .readFileSync(path.join(ROOT, '.github/workflows', WORKFLOW), 'utf8')
-      .split('\n')
-      .filter((line) => /^\s*#/.test(line))
-      .join('\n');
+    const header = headerComments(fs.readFileSync(path.join(ROOT, '.github/workflows', WORKFLOW), 'utf8'));
+
+    // objectui#7901 — the floor first, or the assertion below is vacuous. The
+    // count half cannot distinguish a header that carries no counts from a
+    // header this pin has stopped reading; both score `[]`. Measured when this
+    // was added, so it is latent rather than live: the extraction returned 4696
+    // characters from this header, 11.7 times the floor.
+    expect(
+      header.length,
+      `${WORKFLOW}: the header prose this pin reads came back empty or near-empty, so it asserted over nothing`,
+    ).toBeGreaterThan(MIN_HEADER_PROSE);
+
     const counts = documentCounts(header);
     expect(
       counts,
@@ -368,5 +407,37 @@ describe('check-doc-fence-languages is wired, not merely present', () => {
     for (const line of legitimate) {
       expect(documentCounts(line), `${WORKFLOW}'s count pin must NOT fire on: ${line}`).toEqual([]);
     }
+  });
+  /**
+   * The positive control for the emptiness floor — objectui#7901.
+   *
+   * The pin above has two halves and they fail differently. The control right
+   * above this one exercises the PATTERN half; this one exercises the other,
+   * and the shape it demonstrates is what makes a pin vacuous rather than
+   * merely wrong — a surface that came back empty scores clean under any
+   * pattern, however good. That is not hypothetical for this family:
+   * objectui#7466 is the pin in this repository that scored the same on the
+   * broken tree and the fixed one.
+   *
+   * Demonstrated on synthetic YAML rather than by emptying the real workflow,
+   * so the claim stays reproducible in a checkout whose header is intact —
+   * which is every checkout.
+   */
+  it('the emptiness floor fires on a header this pin has stopped reading', () => {
+    const unread = 'name: Doc Fence Languages\non:\n  workflow_dispatch:\n';
+    expect(headerComments(unread), 'the extraction returns nothing on a comment-less workflow').toBe('');
+    expect(
+      documentCounts(headerComments(unread)),
+      'and the count half alone scores that identically to a header carrying no counts',
+    ).toEqual([]);
+    expect(headerComments(unread).length, 'so the floor is the half that has to reject it').not.toBeGreaterThan(
+      MIN_HEADER_PROSE,
+    );
+
+    // Short, not empty: a header truncated to a line or two is the same defect
+    // arriving gradually, and `toBe('')` would wave it through.
+    const nearEmpty = '# Doc fence languages.\n# The gate prints its own verdict line.\nname: x\n';
+    expect(headerComments(nearEmpty).length, 'this fixture must be short, not empty').toBeGreaterThan(0);
+    expect(headerComments(nearEmpty).length).not.toBeGreaterThan(MIN_HEADER_PROSE);
   });
 });


### PR DESCRIPTION
Fixes #7901

> ⓘ PM 席改动：本行原为 `Part of objectui#7901.`。按本车道对本卡的裁定，**普查非零时的交付物就是「下限 + 普查 + 提案」**，
> 覆盖扩张另立一张卡（objectui#7966）。所以本 PR 关闭 objectui#7901，剩余的覆盖问题由 objectui#7966 承载 ——
> 让两张卡同时开着描述同一件剩余工作是重复。另：`objectui#7901` 这种写法**不是** GitHub 认的 closing reference 形式，
> 必须是 `#7901`；PM 的 clause-② carrier gate 也靠这个关键词把 PR 与卡配对。


`Clause-②: no`

Two things, in the order the card fixed: **the floor lands, the coverage expansion does not.** The census came back **non-zero on both axes**, so per this lane's standing rule the expansion is deferred to its own card and this PR carries the census plus a proposal.

---

## 1. The non-vacuous floor (landed)

`check-links-workflow.test.ts` — the third copy of objectui#7448's document-count pin — asserts the extracted prose is longer than 400 characters *before* asserting it carries no document count. The two twins did not.

Without the floor the count assertion is vacuous by construction: `documentCounts('')` is `[]`, so a header the extraction has stopped reading — workflow renamed or deleted, comment markers changed, path moved — passes the pin while nothing at all was scanned. It is the same claim the scan-collapse assertions in both files already make about the document walk, applied to the one surface that had none.

**Measured in characters before writing, not inferred from line counts:**

| workflow header | comment lines | characters the pin extracts | ratio to the 400 floor |
|:--|--:|--:|--:|
| `doc-fence-languages.yml` | 71 | 4696 | 11.7x |
| `doc-component-types.yml` | 68 | 4514 | 11.3x |
| `check-links.yml` (third copy, for reference) | 61 | 3673 | 9.2x |

Both twins clear the floor by an order of magnitude, so this is **latent, not live**. Nothing in the tree changes verdict today.

The extraction is lifted to module scope beside `POPULATION_COUNT`, **unchanged character for character**, so the pin and its new control read one definition — the same reason objectui#7914 lifted the pattern a few hours earlier.

### Positive control A — in file

Each twin gains `the emptiness floor fires on a header this pin has stopped reading`. It demonstrates on synthetic YAML that a comment-less workflow extracts to the empty string, that the count half scores that **identically** to a header carrying no counts, and that the floor is the half which rejects it. A near-empty (two-line) fixture is asserted too, so a header truncated gradually is not waved through by an emptiness-only check.

### Positive control B — the real headers mutated, restored by state

Each real workflow header was emptied on disk, the pin file re-run, and the header restored. The mutation was proven on disk by blob hash before the reading was taken, and the restore proven by state — never by an exit code.

**`doc-fence-languages.yml`, header emptied (71 comment lines to 0, 5559 bytes to 838):**

```
HEAD blob     : 179f1c9eb62c9855aaed84900b22c2f115d67647
mutated blob  : e7e0c9e33d3277950b85b794949c5a1913b60a24   -- differs from the HEAD blob, so the mutation landed
vitest exit   : 1
 FAIL  scripts/__tests__/check-doc-fence-languages.test.ts > its header states the population and never counts it
AssertionError: doc-fence-languages.yml: the header prose this pin reads came back empty or near-empty,
                so it asserted over nothing: expected 0 to be greater than 400
 Tests  1 failed | 27 passed (28)
restored blob : 179f1c9eb62c9855aaed84900b22c2f115d67647   == HEAD blob, and `git diff HEAD` empty
```

**`doc-component-types.yml`, header cut to two comment lines (68 to 2, 5304 bytes to 824):**

```
HEAD blob     : 18e8bbdbb004b0275a139fcb2dbde0c157a59bcf
mutated blob  : 8710adabc5b7d47be8c874e92a7e4211ca9ed63e   -- differs from the HEAD blob, so the mutation landed
vitest exit   : 1
 FAIL  scripts/__tests__/check-doc-component-types.test.ts > its header states the population and never counts it
AssertionError: doc-component-types.yml: the header prose this pin reads came back empty or near-empty,
                so it asserted over nothing: expected 62 to be greater than 400
 Tests  1 failed | 55 passed (56)
restored blob : 18e8bbdbb004b0275a139fcb2dbde0c157a59bcf   == HEAD blob, and `git diff HEAD` empty
```

Exactly one test failed in each run, and it named itself and its surface. The near-empty leg is the one that matters: `62 to be greater than 400` is the floor firing, not an emptiness check.

Restore used `git checkout HEAD -- ABSOLUTE_PATH` and was proven by **state** — blob back to the HEAD blob **and** `git diff HEAD` empty for that path — never by the exit code of the restore itself. A restore step's failure mode is exit 0 having done nothing.

### The three copies still hold one pattern

objectui#7943 proved this a few hours ago and the card requires it re-run after this change:

```
$ grep -h -A1 '^const POPULATION_COUNT' THE_THREE_PIN_FILES | grep -v '^const' | grep -v '^--' | sed 's/^ *//' | sort | uniq -c
      3 (the single regex literal, one distinct line)

$ grep -h 'text.matchAll(new RegExp(POPULATION_COUNT.source' THE_THREE_PIN_FILES | sed 's/^ *//' | sort | uniq -c
      3 (the single documentCounts body, one distinct line)
```

One distinct line, count 3, for the pattern **and** for the function that applies it. No divergence introduced.

---

## 2. The census of `content/docs/**` — NON-ZERO, so no expansion here

The half that could not be inherited from PR objectui#7915. That census covered 34 `.github/workflows/*.yml` headers; this card's whole subject is that **no copy of the pin reads the published docs tree at all**, so that half had to be measured fresh.

**Corpus, derived rather than hard-coded** — the same derivation the third copy already uses for scope:

```
apps/site/source.config.ts   dir: '../../content/docs'   ->   content/docs
membership : git ls-files (tracked only), filtered to .md / .mdx
size       : 184 file(s) · 35194 line(s) · 1270087 byte(s)
unit       : one LINE, matching how all three pins read a header (line-filtered, then joined)
pattern    : the family pattern, verbatim from all three copies — a numeral with optional
             thousands separators, then ZERO TO TWO intervening words, then one of
             `.mdx` / `.md` / documents / pages / docs / files, with a negative lookbehind
             ruling out a preceding hash, word character or dot
```

### Hits — the family pattern fires: **6**

| # | site | matched text | verdict |
|:--|:--|:--|:--|
| 1 | `content/docs/guide/ci-cd-pipeline.md:576` | `18 guide files` | **historical, measurement point declared.** The sentence opens "Measured on `main@6422aa891`". The gate prints `20 guide file(s)` today, so the figure has moved — but the sentence stays **true**, because it says which tree it measured. |
| 2 | `content/docs/guide/ci-cd-pipeline.md:781` | `143 files` | **live claim, no measurement point.** "measured across 143 files and 558 literals". The gate's own verdict line prints `889 type literal(s)` today: the companion figure has drifted 558 to 889. |
| 3 | `content/docs/guide/ci-cd-pipeline.md:1083` | `207 files` | **live, drifted, and asserts currency** — "the other four still return 203 of today's 207 files". `check:shell-escape-residue` prints `206 file(s) ... examined in total` today. The strongest member: the word "today's" is the claim rotting out loud. |
| 4 | `content/docs/guide/ci-cd-pipeline.md:1440` | `73 files` | **drifted 73 to 107** (`scripts/__tests__/*.test.ts`), but a **test**-file population, not a document population. See the proposal below. |
| 5 | `content/docs/guide/ci-cd-pipeline.md:1659` | `19 files` | **historical, window declared** — "Across all 5281 first-parent commits on `main`, 12 commits modified a pre-existing changeset (19 files)". Same class as #1. |
| 6 | `content/docs/fields/file.mdx:89` | `3 files` | **quoted rendered output, inside a fence**: `// Renders: "3 files" or "document.pdf"`. The PM ruling of 2026-09-06 applies verbatim — this family governs prose assertions about a document population, not quoted program output. |

By segment: **prose 5 · fenced code 1 · frontmatter 0**.

### Blind-spot reading: **18**

Required by the card, and the reason a zero would have been believable. The definition mirrors the family's own pattern shape rather than a loose window — each category is a way a real count can be present and still be unreadable to this pattern:

| id | blind spot | count |
|:--|:--|--:|
| B1 | file unreadable / undecodable (any read throw, or U+FFFD after a UTF-8 decode) | **0** |
| B2 | numeral, then **three to six** intervening words, then the noun — the family allows at most two | **2** |
| B3 | the noun **before** the numeral — the family reads one direction only | **12** |
| B4 | the count spelled as a word rather than a numeral | **4** |
| | **blind spot total** | **18** |

B1 being zero is the load-bearing one: every file in the corpus was read and decoded, so the 6 above is a reading over the whole tree and not over the part that happened to parse.

B3 is dominated by fenced configuration (`max_files: 5`, `pageSize?: number; // Items per page (default: 10)`) which the prose/fence split already separates. B4 contains one genuine word-spelled count — `content/docs/guide/ci-cd-pipeline.md:304`, "by which time five files had accumulated the defect".

An earlier, deliberately over-inclusive pass (any numeral with a population noun within 60 characters) returned **112**. The excess over 18 was ordered-list markers (`1. Reads ...`), issue references, TS error codes, version numbers and the English quantifiers one / every / all / both. Both readings are recorded here so the tightening is visible rather than assumed.

### Ruling: report-only

Census 6, blind spot 18. Neither is zero, so the coverage expansion does **not** land here. Nothing was added to any exemption table — an exemption table records adjudicated exceptions, it is not a switch for turning a first run green.

---

## 3. Proposal for the expansion card

The expansion needs three criteria that the workflow-header version never needed, because docs prose is a different register. Each is measured above rather than anticipated:

1. **Prose versus fence.** A workflow header has no code fences, so no copy of the pin has ever needed this distinction. On a docs page, quoted program output lives in fences — member #6 is the instance. The prose/fence/frontmatter split used in this census is the minimum shape.
2. **A declared measurement point makes a count non-rotting.** Members #1 and #5 name the tree they measured (a commit sha; an explicit commit window). Both are stale against today and both are still true. A pattern that cannot see the difference would red two correct sentences, which is how gates get deleted.
3. **The noun set is wider than the family's stated subject.** `files?` catches test-file and source-file populations, not only document populations — member #4 is the instance. Either narrow the noun set on the docs surface, or accept that the docs census governs all file populations and say so in the header.

Members #2, #3 and #4 are live drifted counts on `content/docs/guide/ci-cd-pipeline.md` and must be cleared before the expansion can land, or the expansion reds on its first run. They are filed separately rather than ridden along here: the card's file surface is these two test files, and `content/docs/` is read-only for it.

**Filed out of this run, all three unassigned for PM triage:**

- objectui#7965 — the three live drifted counts on `content/docs/guide/ci-cd-pipeline.md`, each measured against its own gate's verdict line. Also records the two neighbouring sentences that are stale-looking and **correct**, so nobody rewrites them.
- objectui#7966 — the coverage expansion itself, `Blocked-by:` objectui#7965, carrying the three criteria above and the blind-spot note.
- objectui#7967 — a fourth divergence inside this family, found while writing the floor and **not** repaired here. Both twins keep the `#` markers the third copy strips, so a count wrapping across a comment line is invisible to both and visible to the third. Measured: markers kept scores `[]` on a wrapped `184 / pages`, markers stripped scores `["184 pages"]`. Latent — all three headers are clean under both extractions today.

---

## Verification

All from `f949c4381`, the final commit on this branch, in the worktree `/home/user/objectui-issue-7901`. Every heavy run went through the shared verify lock; every exit code was captured after redirecting to a file, never through a pipe.

| command | exit | evidence |
|:--|--:|:--|
| `pnpm exec vitest run scripts/__tests__` | 0 | `RUN v4.1.10 /home/user/objectui-issue-7901` · `Test Files 107 passed (107)` · `Tests 3224 passed (3224)` |
| the two pin files alone, before this change | 0 | `Test Files 2 passed (2)` · `Tests 82 passed (82)` |
| the two pin files alone, after | 0 | `Test Files 2 passed (2)` · `Tests 84 passed (84)` — the two new controls |
| `pnpm type-check:scripts` | 0 | `tsc -p tsconfig.scripts.json`, no output |
| `pnpm lint:root` | 0 | `32 problems (0 errors, 32 warnings)`, all pre-existing; neither edited file appears |
| `pnpm check:control-bytes` | 0 | `OK (scanned 6414 tracked text file(s); skipped 85 binary)` |
| `pnpm check:vi-mock-specifiers` | 0 | `OK (4339 tracked source file(s), 2616 test-named ...)` |
| `pnpm check:vi-mock-inherit` | 0 | `OK (... 225 call site(s) judged ...)` |
| `pnpm type-check:coverage` | 0 | `45/46 via type-check` · `42/42 packages compile their tests` |
| `pnpm lint:coverage` | 0 | `46/46 packages linted, 0 with outstanding errors` |
| `pnpm check:unreferenced-sources` | 0 | `Every shipped source file in every covered package is reachable.` |

The vitest banner reads `RUN v4.1.10 /home/user/objectui-issue-7901` — the repository root, not a package directory (objectui#3378), and no argument was passed after a bare double dash (objectui#3288).

**Changeset.** `node scripts/check-changeset-presence.mjs`, verbatim: `✅  No source or published contract of a released package changed in this range, so no changeset is owed.` Two test files, nothing published. None added, not even an empty declaration.

Session: `https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbJQ1y1J12nZxYzFWhP8Q3)_

---
_Generated by [Claude Code](https://claude.ai/code)_