### PR TITLE
fix(ci): align the live-e2e backend pin with the lockfile, and pin the rule that says it must

### DIFF
--- a/e2e/live/ci/backend.env
+++ b/e2e/live/ci/backend.env
@@ -7,11 +7,18 @@
 #   "this console x that published backend" as a matched pair. Testing a
 #   mismatched pair (backend rc.N vs console pinned rc.M) proves nothing —
 #   bump this in the same PR that bumps the console's @objectstack pins.
+#   Pinned by scripts/__tests__/ci-cd-pipeline-doc.test.ts, which reads this
+#   value and the version pnpm-lock.yaml resolves and requires them equal. It
+#   had drifted two minor versions (17.0.0-rc.2 against a 17.2.0 lockfile)
+#   before anything compared the two numbers — objectui#7689.
 #
 # OBJECTSTACK_REF — the objectstack-ai/objectstack commit the showcase app
 #   metadata is checked out from. Always the commit the release tag
 #   `@objectstack/cli@${OBJECTSTACK_VERSION}` points at, so the app source and
 #   the published packages it runs on come from the same tree. (Mirror image
 #   of the framework repo's `.objectui-sha` console pin.)
-OBJECTSTACK_VERSION=17.0.0-rc.2
-OBJECTSTACK_REF=89d2a4eb3f3b6b8f8c0fbc4cb3953cbe8218dc66
+#   NOT machine-checked, and deliberately so: resolving that tag needs the
+#   objectstack repository, which the unit lane cannot reach. Move this by
+#   hand whenever the version above moves, from the tag's own commit.
+OBJECTSTACK_VERSION=17.2.0
+OBJECTSTACK_REF=e7d2cc67fdef7fee9d2c6d65d7363fe1c78ce6a4

--- a/e2e/live/saved-view-filter.spec.ts
+++ b/e2e/live/saved-view-filter.spec.ts
@@ -6,8 +6,15 @@ import { test, expect } from '@playwright/test';
  *
  * This is the empirical pin for the defect, run against the REAL stack because
  * only the server can answer the question the issue asked: does it accept a
- * rule array in `$filter`? It does not. Measured on
- * `@objectstack/*@17.0.0-rc.2` with the showcase app:
+ * rule array in `$filter`? It does not. Measured against the published backend
+ * pair this lane pins — `OBJECTSTACK_VERSION` and `OBJECTSTACK_REF` in
+ * `e2e/live/ci/backend.env`, which move together and are now held to the
+ * lockfile by `scripts/__tests__/ci-cd-pipeline-doc.test.ts` (objectui#7689).
+ * That pair has moved since this measurement was first taken, which is why it
+ * is named by FILE and not by value: a version literal written here goes stale
+ * behind the pin silently, and the whole point of objectui#7689 is that it did
+ * — for two minor versions, in the pin itself. The showcase app is the one that
+ * ref checks out:
  *
  *   GET /api/v1/data/showcase_task
  *     ?$filter=[{"field":"status","operator":"equals","value":"in_progress"}]

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -1263,3 +1263,174 @@ describe('ci-cd-pipeline.md — contexts that can never be required (#4170)', ()
     ).toEqual([]);
   });
 });
+
+/**
+ * objectui#7689 — the page's live-e2e section states a pin rule that nothing read.
+ *
+ * `content/docs/guide/ci-cd-pipeline.md` says the backend pins "must match the
+ * `@objectstack/spec` version in `pnpm-lock.yaml` — bump both in the same PR, or the
+ * run proves nothing", and `e2e/live/ci/backend.env` repeats the same MUST in its own
+ * header. Both were true statements about what a reader should do and false statements
+ * about what CI checked: `git grep -l backend.env scripts/ .github/ e2e/` reached only
+ * the workflow that caches on its hash and the script that sources it. Nothing compared
+ * the two numbers, so the pin sat at `17.0.0-rc.2` against a lockfile resolving `17.2.0`
+ * for two minor versions while `Live E2E (informational)` reported green.
+ *
+ * That is the shape this file exists for, and the worst instance of it yet. The size
+ * regime in #3197 advertised a guardrail CI did not have; here the lane's OWN contract
+ * says a mismatched pair "proves nothing", so every green run it produced over those two
+ * minors was a check whose documentation declared it meaningless. A stale constant is a
+ * chore; a green light its own spec disclaims is worse than a red one.
+ *
+ * ## What this asserts, and the one half it deliberately does not
+ *
+ * ASSERTED: `OBJECTSTACK_VERSION` equals the `@objectstack/spec` version the lockfile
+ * resolves, read two independent ways (the resolution keys under `packages:`/`snapshots:`
+ * and the `version:` line of every workspace importer) whose union must hold exactly one
+ * value. Two readings rather than one because "the resolved version" is only a
+ * well-formed question while the tree agrees with itself: a lockfile carrying two
+ * `@objectstack/spec` versions has no single number for the pin to match, and naming that
+ * is more useful than picking one of them and comparing to it.
+ *
+ * NOT asserted: the file's other pin, `OBJECTSTACK_REF`, whose stated rule is that it is
+ * the commit the `@objectstack/cli@${OBJECTSTACK_VERSION}` release tag points at. Reading
+ * that tag needs the objectstack repository over the network, which this lane has not got,
+ * so the pairing moves by hand and this file says so rather than implying coverage it has
+ * not got. What IS checked is the shape a hand move can still get wrong in a way the lane
+ * only discovers 300 seconds later: `start-backend.sh` fetches the ref with
+ * `git fetch --depth 1 origin "$OBJECTSTACK_REF"`, which needs a full object name.
+ *
+ * ## Anti-vacuity
+ *
+ * Each half is floored. The doc sentence is required to still be on the page, because
+ * this whole block is the enforcement of that sentence and a page that stopped making the
+ * claim should retire the pin deliberately rather than leave it running on prose nobody
+ * reads. The lockfile scan is required to have matched something, so a lockfile format
+ * change turns this red instead of green-with-an-empty-set — the failure mode #3451 keeps
+ * teaching this page.
+ */
+const backendEnvPath = path.join(repoRoot, 'e2e/live/ci/backend.env');
+const lockfilePath = path.join(repoRoot, 'pnpm-lock.yaml');
+const backendEnv = fs.readFileSync(backendEnvPath, 'utf8');
+
+/** The page's statement of the rule, whitespace-normalised because the source wraps it. */
+const PIN_RULE_SENTENCE =
+  /Backend pins live in `e2e\/live\/ci\/backend\.env` and must match the `@objectstack\/spec` version in `pnpm-lock\.yaml`/;
+
+const readEnvKey = (key: string): string | null =>
+  backendEnv.match(new RegExp('^' + key + '=(.+)$', 'm'))?.[1].trim() ?? null;
+
+/**
+ * Every `@objectstack/spec` version the lockfile resolves, from both spellings.
+ *
+ * The resolution keys carry the peer-suffixed identity (`17.2.0(ai@…)`) under
+ * `snapshots:` and the bare one under `packages:`; the importer entries carry the same
+ * value on their `version:` line. Each is truncated at the first `(` so the three
+ * spellings collapse to one comparable number.
+ */
+function resolvedSpecVersions(): string[] {
+  const lock = fs.readFileSync(lockfilePath, 'utf8');
+  const found = new Set<string>();
+
+  for (const m of lock.matchAll(/^\s{0,4}'?@objectstack\/spec@([0-9][^'(\s:]*)/gm)) {
+    found.add(m[1]);
+  }
+  for (const m of lock.matchAll(
+    /^\s*'@objectstack\/spec':\s*\n\s*specifier:.*\n\s*version:\s*([0-9][^\s(]*)/gm,
+  )) {
+    found.add(m[1]);
+  }
+  return [...found].sort();
+}
+
+describe('ci-cd-pipeline.md — live-e2e backend pin (#7689)', () => {
+  it('still carries the sentence this block enforces', () => {
+    expect(
+      PIN_RULE_SENTENCE.test(doc.replace(/\s+/g, ' ')),
+      'content/docs/guide/ci-cd-pipeline.md no longer states that the backend pins in ' +
+        '`e2e/live/ci/backend.env` must match the `@objectstack/spec` version in ' +
+        '`pnpm-lock.yaml`. Everything below is the enforcement of that sentence, so losing it ' +
+        'would leave these assertions running on a rule the page stopped teaching. If the rule ' +
+        'was retired, retire this describe with it; if the sentence merely moved or was ' +
+        'reworded, update PIN_RULE_SENTENCE.',
+    ).toBe(true);
+  });
+
+  it('resolves exactly one @objectstack/spec version to compare against', () => {
+    const versions = resolvedSpecVersions();
+
+    expect(
+      versions.length,
+      `Nothing in ${path.relative(repoRoot, lockfilePath)} matched either reading of an ` +
+        '`@objectstack/spec` resolution. That is a green this test must never report: the ' +
+        'comparison below would run against an empty set and pass no matter what ' +
+        '`e2e/live/ci/backend.env` says. Either the dependency is genuinely gone — in which ' +
+        'case the live lane has nothing to pin and this block should go — or the lockfile ' +
+        'format moved and the two regexes above need updating.',
+    ).toBeGreaterThan(0);
+
+    expect(
+      versions,
+      'The lockfile resolves more than one `@objectstack/spec` version:\n' +
+        versions.map((v) => `  - ${v}`).join('\n') +
+        '\n\nThere is then no single "the resolved version" for `OBJECTSTACK_VERSION` to ' +
+        'match, so the live lane cannot be a matched pair against any of them. Resolve the ' +
+        'workspace onto one version first; this test deliberately names the split rather than ' +
+        'picking a winner.',
+    ).toHaveLength(1);
+  });
+
+  it('pins OBJECTSTACK_VERSION to the version the lockfile resolves', () => {
+    const versions = resolvedSpecVersions();
+    if (versions.length !== 1) return; // reported by the test above
+
+    const pinned = readEnvKey('OBJECTSTACK_VERSION');
+    expect(
+      pinned,
+      `${path.relative(repoRoot, backendEnvPath)} declares no OBJECTSTACK_VERSION. ` +
+        '`start-backend.sh` sources this file and installs published `@objectstack/*` at that ' +
+        'value, so an absent key is not a lighter failure than a wrong one.',
+    ).not.toBeNull();
+
+    expect(
+      pinned,
+      `The live-e2e lane is pinned to an unmatched pair:\n` +
+        `  ${path.relative(repoRoot, backendEnvPath)}  OBJECTSTACK_VERSION=${pinned}\n` +
+        `  ${path.relative(repoRoot, lockfilePath)}          @objectstack/spec  ${versions[0]}\n\n` +
+        'content/docs/guide/ci-cd-pipeline.md states the rule: "Backend pins live in ' +
+        '`e2e/live/ci/backend.env` and must match the `@objectstack/spec` version in ' +
+        '`pnpm-lock.yaml` — bump both in the same PR, or the run proves nothing." The header ' +
+        'of backend.env says the same thing in its own words. A run of `Live E2E ' +
+        '(informational)` against this pair therefore carries no information, green or red — ' +
+        'it exercises one published backend against a console built for another.\n\n' +
+        'Fix it in whichever direction the change came from: a lockfile bump must move ' +
+        'OBJECTSTACK_VERSION (and, by hand, OBJECTSTACK_REF to the commit the matching ' +
+        '`@objectstack/cli` release tag points at), and a pin bump must be a lockfile bump. ' +
+        '⛔ Do not resolve this by reverting the pin to whatever was green last: a failing ' +
+        'matched pair carries strictly more information than a green mismatched one ' +
+        '(objectui#7689).',
+    ).toBe(versions[0]);
+  });
+
+  it('keeps OBJECTSTACK_REF in the one shape start-backend.sh can fetch', () => {
+    const ref = readEnvKey('OBJECTSTACK_REF');
+    expect(
+      ref,
+      `${path.relative(repoRoot, backendEnvPath)} declares no OBJECTSTACK_REF, which ` +
+        '`start-backend.sh` needs to sparse-checkout the showcase app.',
+    ).not.toBeNull();
+
+    // Which COMMIT it should be is the half this file cannot read (see the header): that
+    // needs the objectstack release tag. The shape it must have is readable here, and it
+    // is the one a hand move gets wrong — `git fetch --depth 1 origin <ref>` wants a full
+    // object name, and an abbreviated one fails 300 seconds into the lane, in a log nobody
+    // reads until the job goes red.
+    expect(
+      ref,
+      `OBJECTSTACK_REF is ${JSON.stringify(ref)}. start-backend.sh fetches it with ` +
+        '`git fetch --depth 1 origin "$OBJECTSTACK_REF"`, which needs a full 40-character ' +
+        'commit sha — an abbreviated one, a branch name or a tag is refused by the remote and ' +
+        'the lane only says so once the backend fails to boot.',
+    ).toMatch(/^[0-9a-f]{40}$/);
+  });
+});


### PR DESCRIPTION
Fixes #7689

`e2e/live/ci/backend.env` pinned `OBJECTSTACK_VERSION=17.0.0-rc.2` while `pnpm-lock.yaml` resolved `@objectstack/spec` **17.2.0**. Three separate places state that the two MUST match and that a mismatched pair “proves nothing”: the file's own header, `content/docs/guide/ci-cd-pipeline.md:420`, and `.github/workflows/live-e2e.yml`'s header at `:27`. For two minor versions `Live E2E (informational)` therefore published a green signal its own contract declares meaningless — because nothing compared the two numbers.

## The pair pinned, and why these values

| key | was | now | why |
|---|---|---|---|
| `OBJECTSTACK_VERSION` | `17.0.0-rc.2` | `17.2.0` | the version the lockfile **resolves**, not the `^17.0.0` range it declares. Verified on this branch's base: `@objectstack/spec@` appears in `pnpm-lock.yaml` at exactly one version, in both spellings (the bare `packages:` key and the peer-suffixed `snapshots:` key), and all 10 workspace importers resolve `17.2.0`. |
| `OBJECTSTACK_REF` | `89d2a4eb3f3b…` | `e7d2cc67fdef…` | the file header's own pairing rule: the commit the `@objectstack/cli@` + that version release tag points at. Measured, not guessed — `@objectstack/cli@17.2.0` dereferences to `e7d2cc67fdef7fee9d2c6d65d7363fe1c78ce6a4`. The rule was being honoured before: the outgoing ref is byte-for-byte the commit `@objectstack/cli@17.0.0-rc.2` points at. |

Registry probe before pinning: every `@objectstack/*` package `start-backend.sh` installs — the nine runtime deps the showcase app declares at that ref, plus `@objectstack/cli` — publishes `17.2.0`. None had to be substituted, so this is not a `needs_decision`.

Deliberately **not** `17.3.0`: that is PR #7685's lockfile, not this branch's.

## The check

`scripts/__tests__/ci-cd-pipeline-doc.test.ts`, in a new `describe`. That file's charter is pinning this exact page's claims to CI reality, and the sentence at `ci-cd-pipeline.md:420` is a claim of exactly the shape it was written for — its header already says a doc advertising a guardrail CI does not have is worse than no doc.

The version-claim ledger `doc-version-claims.test.ts` was the dispatch's first candidate and was ruled out on measurement, not taste: its `SCAN_ROOTS` are `content/docs`, `packages/*/README.md` and `skills`, `.md`/`.mdx` only, so `backend.env` is not on a scanned surface and no `KNOWN_CLAIMS` row holds the `17.0.0-rc.2` literal. Its own rule — one rule judges one kind of fact — argues against bolting a two-non-doc-file comparison onto it.

Four assertions: the doc sentence is still on the page (this whole block is its enforcement); the lockfile resolves **exactly one** `@objectstack/spec` version, read two independent ways whose union must be a singleton; `OBJECTSTACK_VERSION` equals it; and `OBJECTSTACK_REF` is a full 40-character object name, because `git fetch --depth 1` refuses an abbreviated one and the lane only says so 300 seconds later.

Both anti-vacuity floors this file's culture asks for are in: an empty lockfile match set is a **failure**, not a silent pass, and a missing doc sentence is a failure rather than a quiet retirement.

`content/docs/guide/ci-cd-pipeline.md` is **unchanged**: the sentence names no version number, so it did not misstate anything after the pin moved.

**Second commit, after review.** The reader sweep for the outgoing literal (`git grep -n '17\.0\.0-rc\.2' -- scripts/ content/ e2e/ .github/`) returns exactly two hits, and the first is the pin itself; the second was `e2e/live/saved-view-filter.spec.ts:10`, whose header restated the pair as a value and went stale the moment the pin moved. It now names `OBJECTSTACK_VERSION` / `OBJECTSTACK_REF` in `e2e/live/ci/backend.env` instead, and says the pair has moved since that measurement rather than implying it has not — comment only, with no assertion, import or code line touched (`git diff -U0` on that file yields no changed line that is not a comment line).

The half deliberately not asserted, stated in both the env file and the test rather than implied as covered: whether `OBJECTSTACK_REF` really is the tag's commit. Reading that tag needs the objectstack repository over the network, which the unit lane has not got. Filed separately as #7964.

## Ablation, on the committed tree

Three legs, each proving on disk that the mutation landed (injected/removed line counts and `git hash-object`) before reading the run, with a `trap` restoring from `HEAD` by absolute path:

| leg | mutation | vitest | what it proves |
|---|---|---|---|
| 1 | pin back to `17.0.0-rc.2` | **exit 1**, 1 failed / 39 passed | the check names both files, both values and the doc sentence — the assertion message reads `e2e/live/ci/backend.env  OBJECTSTACK_VERSION=17.0.0-rc.2` against `pnpm-lock.yaml  @objectstack/spec  17.2.0` |
| 2 | abbreviate the ref to `e7d2cc6` | **exit 1**, 1 failed / 39 passed | the shape assertion is not vacuous |
| 3 | restored | **exit 0**, 40 passed | restoration verified by blob equality (`db35d5ef…` back to the `HEAD` blob) and an empty `git diff HEAD`, not by an exit code |

No dist leg: the test reads `backend.env` and `pnpm-lock.yaml` straight off the working tree, so there is no build output for a mutation to fail to reach.

## The live lane will go red here, and that is the point

Per the triage ruling on the card — 「一条失败的匹配对携带的信息,严格多于一条绿色的不匹配对」 — a red `Live E2E (informational)` after alignment is the expected result, not a regression, and ⛔ the repair is never to put the pin back.

Measured in this container before opening the PR, so it is no longer a prediction. The matched pair prepares cleanly — sparse checkout at the new ref, `npm install` of the ten published `@objectstack/*@17.2.0` packages, 521 packages — and the server starts, but never seeds: the system tables are never created (`no such table: sys_user`, `sys_organization`, `sys_permission_set`, `sys_position`), so the seeded sign-in `start-backend.sh` polls never answers and the script exits 1 at its 300-second deadline.

The cause is upstream of this repository and was traced to a single declaration, from the registry rather than by inference:

| published `@objectstack/plugin-auth` | declares `@better-auth/core` | resolves to | boots |
|---|---|---|---|
| `17.0.0-rc.2` (the outgoing pin) | `1.7.0-rc.2` — **exact** | `1.7.0-rc.2` | yes |
| `17.1.0` | `^1.7.1` | `1.7.3` | no |
| `17.2.0` (the incoming pin) | `^1.7.1` | `1.7.3` | no |
| `17.3.0` (PR #7685's target) | `^1.7.2` | `1.7.3` | expected no |

`@objectstack/plugin-auth@17.2.0` imports `createLocalAccountIssuer` from `@better-auth/core/db`; `@better-auth/core@1.7.3` does not export it (verified by grep over the installed package: zero hits), and the CLI logs exactly that as a load failure before the schema step. So the outgoing pin booted only because rc.2 happened to pin its auth dependency exactly, and every published version since has floated into a range that is now broken.

A control leg run minutes later in the same container, through the same `start-backend.sh`, boots the **outgoing** pair (`@objectstack/*@17.0.0-rc.2` at ref `89d2a4eb…`) to a seeded sign-in in 30 seconds, with zero `createLocalAccountIssuer` lines and zero `no such table` lines. That is the load-bearing half of the measurement: it rules out "this container cannot boot the lane at all" and attributes the failure to the published version rather than to the harness or the alignment.

That is precisely the class of breakage this lane exists to catch, and precisely what an unmatched pair could not tell anyone. It is not a regression introduced here and ⛔ must not be repaired by reverting the pin. Filed upstream, where the change belongs, as objectstack-ai/objectstack#16186.

⛔ Out of scope on purpose, per the triage: the lane's tier. `informational` stays; promoting it is the manual floor and its own decision card. No change to `.github/workflows/live-e2e.yml`, `pnpm-lock.yaml` or any `package.json`.

## For the `domain:spec` seat merging main

PR #7685 (the 17.3.0 lockfile bump) does not move `backend.env`; this check will red there until it does.

## Verification

- `pnpm exec vitest run --maxWorkers=2 scripts/__tests__/ci-cd-pipeline-doc.test.ts` — 40 passed (36 before, 4 added)
- `pnpm exec vitest run --maxWorkers=2 scripts/__tests__/{doc-version-claims,check-control-bytes,e2e-type-check,scripts-type-check}.test.ts` — 94 passed
- `pnpm type-check:scripts` — exit 0; `tsc --listFiles` confirms `scripts/__tests__/ci-cd-pipeline-doc.test.ts` is in the program, so this is a measurement and not an exclusion
- `pnpm lint:root` — exit 0, 0 errors (32 pre-existing warnings, none in a changed file). Full repo-root scan, not narrowed
- `pnpm check:control-bytes` — OK, 6415 files; `pnpm check:shell-escape-residue` — OK
- `node scripts/check-governed-queue-guard.mjs --test` on both changed paths — `NOT GOVERNED`
- `node scripts/check-changeset-presence.mjs` — no changeset owed (0 published sources, 0 published contracts changed)
- `pnpm type-check:e2e` (`tsconfig.e2e.json`, the program that owns that spec) — exit 0; `--listFiles` puts `e2e/live/saved-view-filter.spec.ts` in the program (1 hit), so it is measured and not excluded
- `pnpm exec eslint --format json` on the changed spec — exit 0, 0 errors, 0 warnings, **1 file reported** (a count of 0 would have meant out-of-scope, which is not a pass); the whole `e2e/**/*.ts` glob lints at 0 errors across 31 files
- The report's claim that the version-claim ledger cannot see `e2e/` is now **measured, not asserted**: with the literal injected into that spec, `doc-version-claims.test.ts` stays green (exit 0), and with the same literal on a throwaway page under `content/docs/` it goes red (exit 1). The negative reading is a blind spot, not a dead instrument. Both probes restored; tree verified clean afterwards.

Heavy runs went through the shared verify lock; every verdict above was read from the gate's own printed line with the exit code captured before any pipe.

Authored by a Claude Code developer seat, session `session_013uAaxiwgYDybsTNV9xwa1M` (repeated here as prose because a footer link does not reliably survive an edit to this body).

## Judgement, on the four axes

- **Real business need** — measured, not assumed: `start-backend.sh` sources this file at `:25`, builds its cache stamp from both keys at `:32` and installs from `OBJECTSTACK_VERSION` at `:41` and `:65`; `live-e2e.yml` keys the backend cache on the file's hash at `:133` and `:302`. Two live readers, and the lane they serve is the only one that can see cross-version breakage at all.
- **Long-term soundness** — contract-first. The rule was already declared in prose in three places; this adds the enforcement the declarations always implied, in a file that already exists for it. No new convention, no lenient fallback, nothing to unwind later.
- **Making it structurally harder to get wrong** — the check refuses rather than tolerates. A lockfile resolving two `@objectstack/spec` versions is named as a split, not silently reduced to one to compare against; an empty match set fails instead of passing; and the failure text forbids by name the repair that would restore green while restoring meaninglessness.
- **Startup-stage focus** — one `describe` in an existing file. No new script, no new workflow, no new declaration surface, and the two expansions available here were both declined: the tier change (the card's own out-of-scope half) and a network check for the ref (a real fork between checking the pin and deriving it, filed as #7964 for the maintainer rather than picked here).


---
_Generated by [Claude Code](https://claude.ai/code)_