### PR TITLE
docs(mobile): shrink UNGATED_DOCS by one — the mobile README's 10 blocks compile (#5174 batch 14)

### DIFF
--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -25,18 +25,22 @@ npm install @object-ui/mobile
 ## Quick Start
 
 ```tsx
-import { MobileProvider, useBreakpoint, useGesture } from '@object-ui/mobile';
+import { MobileProvider, useBreakpoint } from '@object-ui/mobile';
 
-function App() {
-  return (
-    <MobileProvider>
-      <ResponsiveApp />
-    </MobileProvider>
-  );
+function MobileNav() {
+  return <nav>Mobile navigation</nav>;
+}
+
+function DesktopSidebar() {
+  return <aside>Desktop sidebar</aside>;
+}
+
+function MainContent() {
+  return <main>Main content</main>;
 }
 
 function ResponsiveApp() {
-  const { isMobile, isTablet, isDesktop } = useBreakpoint();
+  const { isMobile, isDesktop } = useBreakpoint();
 
   return (
     <div>
@@ -46,84 +50,219 @@ function ResponsiveApp() {
     </div>
   );
 }
+
+export function App() {
+  return (
+    <MobileProvider>
+      <ResponsiveApp />
+    </MobileProvider>
+  );
+}
 ```
 
 ## API
 
 ### MobileProvider
 
-Wraps your application with mobile context:
+Wraps your application with mobile context. Both props are optional: `pwa` takes a
+`PWAConfig`, `offline` takes a `PWAOfflineConfig`.
 
 ```tsx
-<MobileProvider>
-  <App />
-</MobileProvider>
+import { MobileProvider } from '@object-ui/mobile';
+
+function App() {
+  return <p>Your application</p>;
+}
+
+export function Root() {
+  return (
+    <MobileProvider>
+      <App />
+    </MobileProvider>
+  );
+}
 ```
 
 ### useBreakpoint
 
-Hook for detecting the current breakpoint:
+Hook for detecting the current breakpoint. The current breakpoint name is
+`breakpoint` — one of `xs`, `sm`, `md`, `lg`, `xl`, `2xl`:
 
 ```tsx
-const { isMobile, isTablet, isDesktop, current } = useBreakpoint();
+import { useBreakpoint } from '@object-ui/mobile';
+
+export function BreakpointBadge() {
+  const { isMobile, isTablet, isDesktop, breakpoint, width } = useBreakpoint();
+
+  return (
+    <span>
+      {breakpoint} at {width}px — mobile {String(isMobile)}, tablet {String(isTablet)}, desktop{' '}
+      {String(isDesktop)}
+    </span>
+  );
+}
 ```
+
+`isAbove(bp)` and `isBelow(bp)` are also returned, for comparisons against a named
+breakpoint.
 
 ### useResponsive
 
-Hook for responsive values based on screen size:
+Hook for responsive values based on screen size. The keys are breakpoint names; a
+breakpoint with no entry falls back to the next smaller one that has one:
 
 ```tsx
-const columns = useResponsive({ mobile: 1, tablet: 2, desktop: 4 });
+import { useResponsive } from '@object-ui/mobile';
+
+export function ResponsiveGrid() {
+  const columns = useResponsive({ xs: 1, md: 2, lg: 4 });
+
+  return <div data-columns={columns}>{columns} column(s)</div>;
+}
 ```
 
 ### useGesture / useSpecGesture
 
-Hooks for gesture detection on touch devices:
+`useGesture` detects one gesture from Object UI's direction-fused vocabulary
+(`tap`, `double-tap`, `long-press`, `swipe-left`, `swipe-right`, `swipe-up`,
+`swipe-down`, `pinch`, `rotate`, `pan`) per call, and returns a ref to attach:
 
 ```tsx
-const gestureRef = useGesture({
-  onSwipeLeft: () => navigateNext(),
-  onSwipeRight: () => navigateBack(),
-  onPinch: (scale) => handleZoom(scale),
-});
+import { useGesture } from '@object-ui/mobile';
 
-return <div ref={gestureRef}>Swipeable content</div>;
+function navigateNext() {}
+function navigateBack() {}
+
+export function SwipeArea() {
+  const nextRef = useGesture<HTMLDivElement>({
+    type: 'swipe-left',
+    onGesture: () => navigateNext(),
+  });
+  const backRef = useGesture<HTMLDivElement>({
+    type: 'swipe-right',
+    onGesture: () => navigateBack(),
+  });
+
+  return (
+    <div>
+      <div ref={nextRef}>Swipe left for the next record</div>
+      <div ref={backRef}>Swipe right to go back</div>
+    </div>
+  );
+}
+```
+
+`useSpecGesture` takes the declarative `SpecGestureConfig` tuning shape instead, and
+dispatches to per-gesture callbacks:
+
+```tsx
+import { useSpecGesture } from '@object-ui/mobile';
+
+function handleZoom(scale: number) {
+  return scale;
+}
+
+export function PinchArea() {
+  const ref = useSpecGesture<HTMLDivElement>({
+    config: { type: 'pinch', enabled: true, pinch: { minScale: 0.5, maxScale: 3 } },
+    onPinch: (scale) => handleZoom(scale),
+  });
+
+  return <div ref={ref}>Pinchable content</div>;
+}
 ```
 
 ### usePullToRefresh
 
-Hook for pull-to-refresh behavior:
+Hook for pull-to-refresh behavior. Attach the returned `ref` to the scrollable
+container:
 
 ```tsx
-const { isRefreshing } = usePullToRefresh({
-  onRefresh: async () => await fetchData(),
-});
+import { usePullToRefresh } from '@object-ui/mobile';
+
+async function fetchData(): Promise<void> {}
+
+export function Feed() {
+  const { ref, isRefreshing, pullDistance } = usePullToRefresh<HTMLDivElement>({
+    onRefresh: async () => await fetchData(),
+  });
+
+  return (
+    <div ref={ref} data-pull-distance={pullDistance}>
+      {isRefreshing ? 'Refreshing…' : 'Pull to refresh'}
+    </div>
+  );
+}
 ```
 
 ### useTouchTarget
 
-Hook for ensuring minimum touch target sizes:
+Hook for ensuring minimum touch target sizes. It returns the `style` and `className`
+to spread onto the element; the defaults follow WCAG 2.5.5 (44×44 CSS pixels):
 
 ```tsx
-const { targetProps } = useTouchTarget({ minSize: 44 });
-return <button {...targetProps}>Tap me</button>;
+import { useTouchTarget } from '@object-ui/mobile';
+
+export function TapButton() {
+  const { style, className } = useTouchTarget({
+    config: { minWidth: 44, minHeight: 44 },
+  });
+
+  return (
+    <button style={style} className={className}>
+      Tap me
+    </button>
+  );
+}
 ```
 
 ### ResponsiveContainer
 
-Renders children based on breakpoint:
+Renders children based on breakpoint. Pick the range with `minBreakpoint` /
+`maxBreakpoint`, or name the breakpoints outright with `showOn` / `hideOn`:
 
 ```tsx
-<ResponsiveContainer mobile={<MobileView />} desktop={<DesktopView />} />
+import { ResponsiveContainer } from '@object-ui/mobile';
+
+function MobileView() {
+  return <p>Compact layout</p>;
+}
+
+function DesktopView() {
+  return <p>Full layout</p>;
+}
+
+export function BreakpointSwitch() {
+  return (
+    <div>
+      <ResponsiveContainer maxBreakpoint="md">
+        <MobileView />
+      </ResponsiveContainer>
+      <ResponsiveContainer minBreakpoint="lg">
+        <DesktopView />
+      </ResponsiveContainer>
+    </div>
+  );
+}
 ```
 
 ### PWA Utilities
 
+`PWAConfig` requires `enabled`, `name` and `shortName`. `registerServiceWorker` takes
+the script `url` and `scope` plus lifecycle callbacks — the caching strategies live in
+the generated worker (`getServiceWorkerSource`), not in this call:
+
 ```tsx
 import { generatePWAManifest, registerServiceWorker } from '@object-ui/mobile';
 
-const manifest = generatePWAManifest({ name: 'My App', themeColor: '#000' });
-registerServiceWorker({ cacheStrategy: 'network-first' });
+export const manifest = generatePWAManifest({
+  enabled: true,
+  name: 'My App',
+  shortName: 'My App',
+  themeColor: '#000',
+});
+
+void registerServiceWorker({ url: '/service-worker.js' });
 ```
 
 ## Links

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -723,8 +723,6 @@ const UNGATED_DOCS = {
     '7 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2554x2 TS2559x2 — candidate real defects, un-triaged',
   'packages/layout/README.md':
     '3 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 3 unresolved-module diagnostic(s)',
-  'packages/mobile/README.md':
-    '19 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS1108x2 TS2345x1 TS2353x1 — candidate real defects, un-triaged',
   'packages/permissions/README.md':
     '12 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2322x4 TS2345x1 TS2353x1 — candidate real defects, un-triaged',
   'packages/plugin-ai/README.md':


### PR DESCRIPTION
Part of #5174 — batch 14 of the `check-doc-snippet-types` ungated-docs ledger burn-down.

`packages/mobile/README.md` leaves `UNGATED_DOCS`. All **10** of its ts/tsx blocks now compile `--strict` against the built `dist/*.d.ts`. **Zero fragment markers written, zero entries added** — the ledger hunk is `0` additions / `2` deletions and the whole diff is exactly two files.

| reading | before | after |
|:--|--:|--:|
| ledger entries | 24 | **23** |
| covered documents | 203 | **204** |
| of those, holding a ts/tsx block | 101 | **102** |
| covered blocks | 635 | **645** |
| of those, to compile | 477 | **487** |
| declared fragments | 158 | **158** |
| scan-set size | 227 | 227 |

Fragments unmoved ⇒ every one of the 10 newly covered blocks earned it **by compiling**. The block count went 9 → 10 because the `useGesture / useSpecGesture` section now carries one block per hook.

Base for every figure: `859de84a0`. Nothing here is inherited from batch 13.

## Census, re-taken on this base

Taken with the gate's own exports (`UNGATED_DOCS`, `listDocuments`, `scanFences`), not by eye. Verdict line at the branch point, exit 0:

```
Scanned 227 document(s): 203 covered (101 of them hold a ts/tsx block), 24 ungated — declared in this script, NOT verified by it.
Covered blocks: 635 — 477 to compile, 158 declared fragment(s).
Semantic phase: 477 of 477 block(s) judged, 0 failed.
```

24 entries, by ts/tsx block count:

| blocks | entry | takeable? |
|--:|:--|:--|
| 18 | `packages/plugin-gantt/README.md` | no — #7302 |
| 11 | `packages/plugin-chatbot/README.md` | no — deferred |
| 10 | `packages/auth/README.md` | no — held by draft PR #7685 |
| **9** | **`packages/mobile/README.md`** | **taken this batch** |
| 8 | `packages/i18n/README.md` | yes |
| 8 | `packages/plugin-designer/README.md` | yes |
| 7 | `collaboration`, `layout`, `permissions`, `plugin-detail`, `types` | yes |
| 5 | `core`, `plugin-list`, `react-runtime`, root `README.md` | yes |
| 5 | `packages/plugin-kanban/README.md` | no — #7302 |
| 4 | `plugin-ai`, `plugin-charts`, `plugin-editor`, `plugin-map`, `plugin-markdown`, `providers` | yes |
| 2 | `packages/fields/README.md` | yes |
| 1 | `packages/plugin-tree/README.md` | yes |

**Exclusions re-verified on this base, not inherited:**

- `packages/auth/README.md` — `GET /repos/objectstack-ai/objectui/pulls/7685/files` re-read today: PR #7685 is `state: open`, `draft: true`, 67 files, and `packages/auth/README.md` is still among them. The hold stands.
- `packages/plugin-gantt/README.md` / `packages/plugin-kanban/README.md` — #7302 re-read: `state: open`, `assignee: null`, labels `documentation` / `pm:queue` / `finding` / `priority:p3` / `domain:devx`. The hold stands.
- `packages/plugin-chatbot/README.md` — deferred by dispatch; untouched.

## Decomposition, before any edit

The ledger's reason string was a clue, and it was wrong in two places. Measured at the base by removing the entry in memory (never on disk) and running the gate's own `analyze` + `compileSnippets` over the same tree:

| ledger reason said | measured |
|:--|:--|
| `19 undefined-name diagnostic(s)` | **18** TS2304 |
| `plus TS1108x2 TS2345x1 TS2353x1` | matches |
| (not mentioned) | **TS7006 x1** — implicit `any` on a callback parameter |

Total **23** diagnostics across **9** of 9 blocks.

⚠️ **The bigger finding is what those 23 numbers HID.** Eight of the nine blocks never imported the symbols they called, so every call sat on an `any` and no argument was ever checked. Once the imports are written, six documented call shapes turn out never to have existed on `@object-ui/mobile`:

| the page taught | the package ships |
|:--|:--|
| `useGesture({ onSwipeLeft, onSwipeRight, onPinch })` | `UseGestureOptions` is `{ type, onGesture, threshold?, longPressDuration?, enabled? }`; the callback-shaped hook is `useSpecGesture` |
| `useBreakpoint()` returning `current` | the field is `breakpoint` (`isAbove` / `isBelow` / `width` are also returned) |
| `useTouchTarget({ minSize: 44 })` returning `targetProps` | `{ config?: TouchTargetConfig }` returning `{ style, className }` |
| `ResponsiveContainer` with `mobile` / `desktop` props | `minBreakpoint` / `maxBreakpoint` / `showOn` / `hideOn` / `fallback`, children required |
| `registerServiceWorker({ cacheStrategy })` | `ServiceWorkerConfig` is `{ url?, scope?, onSuccess?, onUpdate?, onError? }`; caching strategy lives in the generated worker (`getServiceWorkerSource`) |
| `useResponsive({ mobile, tablet, desktop })` | keys are breakpoint names; `resolveResponsiveValue` walks `BREAKPOINT_ORDER` only, so the documented call returned `undefined` at **every** breakpoint |

None of these is a which-side-is-wrong question, so none is refused. For each one the correct spelling already ships and is already exercised elsewhere: `useSpecGesture` exists precisely to carry per-gesture callbacks, `useTouchTarget`'s own `@example` in its `.d.ts` spells `style` and `className`, and `BREAKPOINTS` / `BREAKPOINT_ORDER` are the only keys the resolver reads. Repairing the page teaches the shipped surface; widening the types to match the prose would have been an unpulled capability expansion, which the startup-stage focus axis rejects by default, and a lenient consumer-side alias, which commandment #0.1 rejects outright.

## Coverage limit, measured rather than asserted

`ResponsiveValue` is `T` OR a partial record keyed by breakpoint name. The bare-`T` branch means **any object literal type-checks as a responsive value**, so wrong breakpoint keys are invisible to this gate on their own. Probe P2b below plants `{ mobile, tablet, desktop }` back into the repaired block with the result no longer rendered, and the gate stays **GREEN**. What makes P2 red is the repaired block *consuming* `columns` at a narrower type — a property of the block this PR writes, not a property of the gate. Stated so the next reader does not credit the gate with catching key validity.

## Scope guard

- The gate file is touched **only inside the `UNGATED_DOCS` object literal**, by removal; `git diff --numstat` reads `0 2`. Asserted programmatically, not by eye, by parsing both sides' literal and diffing: `base entries: 24 | branch entries: 23`, `ADDED entries: []`, `REMOVED entries: ["packages/mobile/README.md"]`, `SURVIVING entries whose reason text changed: []`, `key order preserved for survivors: true`.
- **Strictness proven byte for byte**: everything from the `Fence scanning` banner to end of file is identical on both sides of this diff — sha256 `f46b5662ba336f026bca3a0003e0b7979789d48d0291fa5760be7d23c8ed0160` on `859de84a0` **and** on this branch. ⚠️ Asserted as *identity across this diff*, never as a constant carried from an earlier batch; it differs from batch 13's value because #7099's blockquote walk landed in between, which is expected.
- The gate's `--build-filter` closure grew by exactly one entry, `--filter=@object-ui/mobile...`, and lost none.
- **Every reader of the edited document was enumerated before choosing the rewrite's shape.** `git grep -l 'packages/mobile/README.md' -- scripts/ packages/ examples/ apps/` returns the gate itself and `scripts/__tests__/doc-version-claims.test.ts`, which pins the peer-dependency line. That line is byte-identical in this diff, and probe P5 proves the pin is live rather than assumed.
- Untouched: `packages/auth/README.md`, `packages/plugin-gantt`, `packages/plugin-kanban`, `packages/plugin-chatbot`.

## Probes — predicted in writing, then observed

Every mutation proven on disk (occurrence count of the removed text and of the injected text, plus a blob hash differing from the `HEAD` blob); every restore proven (blob equal to the `HEAD` blob **and** an empty `git diff HEAD`); each run under an `EXIT INT TERM` trap restoring by absolute path from `HEAD`. No rebuild leg applies: none of these mutations touches a package source, and the built `dist` the gate resolves against is unchanged throughout.

| # | mutation | predicted | observed |
|--:|:--|:--|:--|
| P1 | `minWidth: 44` becomes `minWidth: '44'` in the repaired `useTouchTarget` block | RED | **RED** — `[semantic] packages/mobile/README.md:208:15 TS2322: Type 'string' is not assignable to type 'number'.`, `487 of 487 block(s) judged, 1 failed`, exit 1 |
| P2 | non-breakpoint keys restored to `useResponsive`, result still rendered | GREEN (the union's bare-`T` branch swallows it) | **RED, and for a different reason than predicted** — `TS2322: Type '{ mobile: number; tablet: number; desktop: number; } OPT' is not assignable to type 'ReactNode'`. The keys are caught only through the *downstream* use of the inferred type |
| P2b | same keys, result no longer rendered | GREEN | **GREEN** — `487 of 487 block(s) judged, 0 failed`, exit 0. This is the coverage limit above, isolated |
| P3 | README reverted to its base content, ledger removal kept | RED with the original diagnostics | **RED** — `486 of 486 block(s) judged, 9 failed`, every base-measured code present (TS2304, TS7006, TS1108, TS2345, TS2353), exit 1 |
| P4 | ledger entry restored, repaired README kept (ablation of the removal alone) | GREEN, coverage falling back to the base figures | **GREEN** — `203 covered … 24 ungated`, `635 — 477 to compile, 158 declared fragment(s)`, exit 0. The mutated blob equals the base blob `5024e6bf9`, so the ablation reproduced the base gate file byte for byte |
| P5 | peer-dependency line changed to add a caret-17 range | RED on the pin that reads the same bytes | **RED** — `doc-version-claims.test.ts`: `packages/mobile/README.md:23  react: README says "^17.0.0 || ^18.0.0 || ^19.0.0", manifest says "^18.0.0 || ^19.0.0"`, `Tests 3 failed | 26 passed (29)` |
| P6 | a fabricated name added to a self-import | RED | **RED** — `check-readme-exports: 1 README import name(s) NO package exports`, naming `packages/mobile/README.md:204 -- import { useTouchTargetSize } from '@object-ui/mobile'` |

P2 is reported as observed rather than as predicted; the prediction was wrong about the mechanism and P2b was added to isolate what it was actually measuring.

Working tree verified clean after the last probe (`git status --porcelain` empty).

## Gates

All at `50ab43b1b`, exit codes captured by redirect **before** any pipe, each quoted from the gate's own verdict line:

| gate | exit | verdict line |
|:--|--:|:--|
| `check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| `check:doc-fences` | 0 | `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript …` |
| `check:doc-types` | 0 | `Every documented component type is registered.` |
| `check:readme-exports` | 0 | `OK (43 tracked README(s) … 433 of them self-imports judged (433 real, 0 wrong-path, 0 fabricated) …)` |
| `check:control-bytes` | 0 | `OK (scanned 6417 tracked text file(s); skipped 85 binary)` |
| `check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `check:doc-example-readers` | 0 | `OK  80 documented symbol(s), 3947 call site(s) …` |
| `type-check:scripts` | 0 | (silent success) |
| `check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `check-governed-queue-guard.mjs --test` | 0 | `NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.` |

A manual `grep -naP` over the C0 control-byte set on both changed files returns no hits (exit 1).

⚠️ `check:readme-exports` first exited 1 with 3 findings, all *"its type entry `./dist/index.d.ts` is not on disk -- run `pnpm build` first"* for `plugin-ai`, none naming a file in this diff. That is the gate's own by-design **precondition** refusal, not a verdict about any document. Building `plugin-ai` and `plugin-tree` turned it into a real, green measurement — and `check:doc-snippets` was re-taken afterwards and read **identically** (`204 covered … 645 — 487 to compile, 158 declared fragment(s)`, `487 of 487 … 0 failed`), so the top-up build moved no figure here.

Vitest from the repository root, `--maxWorkers=2`, through the shared verify lock: **`Test Files 15 passed (15)` / `Tests 591 passed (591)`**, exit 0. The suite union is `git grep -l` for the gate's file name and for the edited document, unioned — it includes `scripts/__tests__/check-doc-snippet-types.test.ts`, `scripts/__tests__/check-readme-exports.test.ts` and `scripts/__tests__/doc-version-claims.test.ts`, the peer-line pin discussed above.

No changeset is added: the presence gate's verdict is that none is owed, and no `skip-changeset` label is applied — that label is inert in this repository.

## No changeset, no queue actions

This pull request stays **draft**. It is not flipped ready, auto-merge is not enabled, no label and no assignee is written, and the card stays open — the ledger burn-down continues in later batches.

## Follow-up filed, not ridden along

#7974 — `useSpecGesture`'s own `@example` passes a scalar `swipe.direction` where the declared type is an array, and the implementation carries the lenient cast that hides it. Seen while reading `@object-ui/mobile`'s built types for this repair; out of this pull request's two-file surface, so it is filed unassigned and unlabelled for triage. Deduplicated against the round-R44 open-issue snapshot plus one targeted search, with a known-hit control query run in the same session so the empty result is a reading rather than a silent zero.

## Next takeable, measured on this branch

After this batch the ledger's largest takeable entries tie at **8** blocks:

| entry | blocks | measured diagnostics |
|:--|--:|--:|
| `packages/plugin-designer/README.md` | 8 | **22** (TS2304x11, TS2339x6, TS1003x1, TS1382x1, TS2741x1, TS2552x1, TS2554x1) |
| `packages/i18n/README.md` | 8 | **11** (TS2304x7, TS2559x2, TS2554x2) |

Under batch 12's tie-break — larger measured debt wins — that is `plugin-designer`. Flagged rather than assumed: the tie-break rule reads "ties broken by measured debt" without a direction, and both numbers are given so the next dispatch can price it either way.


---
_Generated by [Claude Code](https://claude.ai/code/session_013uAaxiwgYDybsTNV9xwa1M)_