### PR TITLE
test(gates): share attachedDocs and pin the lazy-views ledger to its own prose

### DIFF
--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -4,6 +4,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+// The structural locator for the prose attached to an exported constant, shared
+// with `vite-declared-lazy-views.test.ts` (objectui#7289). It was written here
+// for objectui#7046 and moved out unchanged; see the helper's own header for
+// why one implementation rather than two.
+import { attachedDocs } from './helpers/attached-docs';
+
 // Plain-JS CI helper. Its types are INFERRED from the .mjs source by
 // `tsconfig.scripts.json` (`allowJs`), so no `@ts-expect-error` here —
 // re-adding one is now itself an error (TS2578). See objectui#3494.
@@ -1396,84 +1402,6 @@ describe('performance-budget.yml + vite.config.ts contract', () => {
  */
 describe('the prose attached to the baselines (objectui#7046)', () => {
   const checkerSource = fs.readFileSync(checkerPath, 'utf8');
-
-  /**
-   * The documentation ATTACHED to one exported constant, located structurally —
-   * never by a line number, which objectui#6778 demonstrated three times over
-   * rots within days.
-   *
-   * "Attached" is the JSDoc block ending immediately before the
-   * `export const NAME` declaration PLUS every comment lexically inside that
-   * declaration, with the code itself stripped out. Both halves are load-bearing
-   * and neither is a convenience:
-   *
-   *   - the leading block alone is not enough. Measured on `main` when this was
-   *     written, `BASELINE`'s leading block carries no commit hash at all — the
-   *     sentence naming the commit the measurement was taken on is the JSDoc on
-   *     the `gzipBytes` FIELD, inside the object literal. Scoping there would
-   *     make the positive pin below red on an honest file.
-   *   - the declaration TEXT is too much. `commit: '...'` would satisfy the pin
-   *     by restating the constant — the prose about the value passing because it
-   *     contains the value, which is this card's own defect one layer up.
-   */
-  function attachedDocs(source: string, exportName: string): { prose: string; code: string } {
-    const declaration = new RegExp(String.raw`^export const ${exportName}\b`, 'm').exec(source);
-    if (!declaration) throw new Error(`no \`export const ${exportName}\` in the checker`);
-    const declStart = declaration.index;
-
-    const before = source.slice(0, declStart).replace(/\s+$/, '');
-    if (!before.endsWith('*/')) {
-      throw new Error(`\`export const ${exportName}\` is not preceded by a block comment`);
-    }
-    const open = before.lastIndexOf('/**');
-    if (open === -1) throw new Error(`unterminated JSDoc above \`export const ${exportName}\``);
-
-    // Walk the initializer, skipping comments and string literals, until the
-    // brackets it opened close again. Comments met on the way are the per-field
-    // prose; everything else is code.
-    const inner: string[] = [];
-    let i = source.indexOf('=', declStart) + 1;
-    let depth = 0;
-    let opened = false;
-    while (i < source.length) {
-      const two = source.slice(i, i + 2);
-      if (two === '/*') {
-        const end = source.indexOf('*/', i + 2);
-        if (end === -1) throw new Error(`unterminated comment inside ${exportName}`);
-        inner.push(source.slice(i, end + 2));
-        i = end + 2;
-        continue;
-      }
-      if (two === '//') {
-        const end = source.indexOf('\n', i);
-        inner.push(source.slice(i, end));
-        i = end;
-        continue;
-      }
-      const c = source[i];
-      if (c === "'" || c === '"' || c === '`') {
-        i += 1;
-        while (i < source.length && source[i] !== c) i += source[i] === '\\' ? 2 : 1;
-        i += 1;
-        continue;
-      }
-      if (c === '(' || c === '{' || c === '[') {
-        depth += 1;
-        opened = true;
-      } else if (c === ')' || c === '}' || c === ']') {
-        depth -= 1;
-        if (opened && depth === 0) {
-          i += 1;
-          break;
-        }
-      } else if (!opened && c === ';') {
-        break;
-      }
-      i += 1;
-    }
-
-    return { prose: [before.slice(open), ...inner].join('\n'), code: source.slice(declStart, i) };
-  }
 
   /** Commit strings a constant carries AS DATA, found by walking its values. */
   function commitsCarriedBy(value: unknown): string[] {

--- a/scripts/__tests__/helpers/attached-docs.ts
+++ b/scripts/__tests__/helpers/attached-docs.ts
@@ -1,0 +1,106 @@
+/**
+ * The documentation ATTACHED to one exported constant, located structurally —
+ * never by a line number, which objectui#6778 demonstrated three times over
+ * rots within days.
+ *
+ * "Attached" is the JSDoc block ending immediately before the
+ * `export const NAME` declaration PLUS every comment lexically inside that
+ * declaration, with the code itself stripped out. Both halves are load-bearing
+ * and neither is a convenience:
+ *
+ *   - the leading block alone is not enough. Measured on `main` when this was
+ *     written for `scripts/check-eager-closure-budget.mjs`, `BASELINE`'s
+ *     leading block carries no commit hash at all — the sentence naming the
+ *     commit the measurement was taken on is the JSDoc on the `gzipBytes`
+ *     FIELD, inside the object literal. Scoping there would make that file's
+ *     positive pin red on an honest file.
+ *   - the declaration TEXT is too much. `commit: '...'` would satisfy such a
+ *     pin by restating the constant — the prose about the value passing
+ *     because it contains the value, which is the defect one layer up.
+ *
+ * ## Why this lives here rather than in one test file
+ *
+ * It is a structural parser with no knowledge of any particular file: it takes
+ * a source string and an export name and uses no line numbers, no offsets and
+ * no per-file table. Nothing in it is specific to the checker it was written
+ * for, and it now has two customers (objectui#7289):
+ *
+ *   - `scripts/__tests__/check-eager-closure-budget.test.ts` — pins the commits
+ *     `BASELINE` carries, the `` BASELINE's `HASH` `` claims, and the per-key
+ *     provenance list, into their own attached prose;
+ *   - `scripts/__tests__/vite-declared-lazy-views.test.ts` — pins the ledger
+ *     paths and the two control paths into theirs.
+ *
+ * A second hand-written copy is exactly the drift this class of pin exists to
+ * stop, and it would fail in the quiet direction: a copy that walks the
+ * initializer slightly differently returns a slightly larger `prose`, and a
+ * larger `prose` makes every `prose.includes(value)` pin above it MORE likely
+ * to pass. One implementation, used by both.
+ *
+ * Not collected as a test: the `unit` project in `vitest.config.mts` includes
+ * only files whose name ends in `.test.ts` under `scripts/`, so a module named
+ * like this one is importable from a test but is never collected as an empty
+ * suite — which is why the repo's existing shared test plumbing already sits in
+ * this directory (`./turbo-inputs.ts`, `./tsc-program.ts`, and the rest).
+ */
+export function attachedDocs(
+  source: string,
+  exportName: string,
+): { prose: string; code: string } {
+  const declaration = new RegExp(String.raw`^export const ${exportName}\b`, 'm').exec(source);
+  if (!declaration) throw new Error(`no \`export const ${exportName}\` in the source`);
+  const declStart = declaration.index;
+
+  const before = source.slice(0, declStart).replace(/\s+$/, '');
+  if (!before.endsWith('*/')) {
+    throw new Error(`\`export const ${exportName}\` is not preceded by a block comment`);
+  }
+  const open = before.lastIndexOf('/**');
+  if (open === -1) throw new Error(`unterminated JSDoc above \`export const ${exportName}\``);
+
+  // Walk the initializer, skipping comments and string literals, until the
+  // brackets it opened close again. Comments met on the way are the per-field
+  // prose; everything else is code.
+  const inner: string[] = [];
+  let i = source.indexOf('=', declStart) + 1;
+  let depth = 0;
+  let opened = false;
+  while (i < source.length) {
+    const two = source.slice(i, i + 2);
+    if (two === '/*') {
+      const end = source.indexOf('*/', i + 2);
+      if (end === -1) throw new Error(`unterminated comment inside ${exportName}`);
+      inner.push(source.slice(i, end + 2));
+      i = end + 2;
+      continue;
+    }
+    if (two === '//') {
+      const end = source.indexOf('\n', i);
+      inner.push(source.slice(i, end));
+      i = end;
+      continue;
+    }
+    const c = source[i];
+    if (c === "'" || c === '"' || c === '`') {
+      i += 1;
+      while (i < source.length && source[i] !== c) i += source[i] === '\\' ? 2 : 1;
+      i += 1;
+      continue;
+    }
+    if (c === '(' || c === '{' || c === '[') {
+      depth += 1;
+      opened = true;
+    } else if (c === ')' || c === '}' || c === ']') {
+      depth -= 1;
+      if (opened && depth === 0) {
+        i += 1;
+        break;
+      }
+    } else if (!opened && c === ';') {
+      break;
+    }
+    i += 1;
+  }
+
+  return { prose: [before.slice(open), ...inner].join('\n'), code: source.slice(declStart, i) };
+}

--- a/scripts/__tests__/vite-declared-lazy-views.test.ts
+++ b/scripts/__tests__/vite-declared-lazy-views.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
+import { attachedDocs } from './helpers/attached-docs';
 import {
   APP_CONTENT_PATH,
   DECLARED_LAZY_VIEWS_STILL_EAGER,
@@ -314,5 +315,115 @@ describe('formatDeclaredLazyViewFailure', () => {
     });
     expect(message).toContain('views/PageView.tsx');
     expect(message).toContain('views/RecordDetailView.tsx');
+  });
+});
+
+/**
+ * objectui#7289 — the VALUE half of the attached-prose pin objectui#7046 built
+ * for `scripts/check-eager-closure-budget.mjs`, applied here.
+ *
+ * Same defect, one file over: a constant carries a value, a paragraph beside it
+ * explains that value, and nothing makes the two agree. objectui#6785 was the
+ * same rot in this very file's prose and was repaired BY HAND, so nothing
+ * stopped the next paragraph from going stale. {@link attachedDocs} locates the
+ * block attached to an export structurally — the JSDoc ending immediately
+ * before the declaration plus every comment lexically inside it, code stripped
+ * — so these pins carry no line numbers to rot.
+ *
+ * ⚠️ Only the value half transfers, and that was MEASURED before it was
+ * written. This file carries five 9-hex commit citations in prose, and it
+ * exports no constant carrying a commit string as data — so the commit half of
+ * objectui#7046's pin has nothing live to check those five against, and
+ * copying it here would ship a vacuously green test: the defect one layer up,
+ * which is the wall objectui#7046 itself hit on `PER_CHUNK_BASELINE`. The five
+ * hashes are deliberately left unguarded; see the PR body for the reading.
+ *
+ * ⚠️ Non-vacuous, also measured: all three constants FAILED this pin when it
+ * was written. Not one of the three paragraphs named the path its constant
+ * carries — the ledger's bullet said `RecordDetailView`, the two control
+ * constants' blocks named no path at all — and the three sentences that now do
+ * are the only edit this card made to `scripts/vite-declared-lazy-views.ts`.
+ */
+describe('the prose attached to the exported constants (objectui#7289)', () => {
+  const source = read('scripts/vite-declared-lazy-views.ts');
+
+  /** The paths a constant carries AS DATA, found by walking its value. */
+  function pathsCarriedBy(value: unknown): string[] {
+    const found: string[] = [];
+    const walk = (v: unknown): void => {
+      if (typeof v === 'string') {
+        found.push(v);
+        return;
+      }
+      if (Array.isArray(v)) v.forEach(walk);
+      else if (v && typeof v === 'object') Object.values(v).forEach(walk);
+    };
+    walk(value);
+    return [...new Set(found)];
+  }
+
+  const PINNED = {
+    APP_CONTENT_PATH,
+    EAGER_WALK_CONTROL,
+    DECLARED_LAZY_VIEWS_STILL_EAGER,
+  } as const;
+
+  it('locates the block attached to each constant, and only that block', () => {
+    const appContent = attachedDocs(source, 'APP_CONTENT_PATH');
+    const control = attachedDocs(source, 'EAGER_WALK_CONTROL');
+    const ledger = attachedDocs(source, 'DECLARED_LAZY_VIEWS_STILL_EAGER');
+
+    // Controls that MUST hit: a phrase verified to be inside each attached
+    // block. A locator that quietly found the wrong span would pass every pin
+    // below by scanning prose that says nothing about these constants.
+    expect(appContent.prose).toContain('declarations are the subject');
+    expect(control.prose).toContain('The positive control for the eager walk');
+    expect(ledger.prose).toContain('Deleting a line is a MEASUREMENT');
+
+    // ...and the neighbours are not swept in. These three declarations sit
+    // consecutively with nothing but their own blocks between them, so an
+    // over-wide span shows up as one constant's block reaching into another's.
+    expect(appContent.prose).not.toContain('Repo root');
+    expect(appContent.prose).not.toContain('The positive control for the eager walk');
+    expect(control.prose).not.toContain('declarations are the subject');
+    expect(ledger.prose).not.toContain('The positive control for the eager walk');
+    expect(ledger.prose).not.toContain('Pull the modules out of');
+
+    // The code is not prose. Without this the positive pin below would be
+    // satisfiable by the ledger's own entry line.
+    expect(ledger.code).toContain("'packages/app-shell/src/views/RecordDetailView.tsx'");
+    expect(ledger.prose).not.toContain("'packages/app-shell/src/views/RecordDetailView.tsx'");
+  });
+
+  /**
+   * The positive pin: every path a constant carries must appear in the prose
+   * attached to that same constant. An entry added, removed or re-pathed
+   * without touching the paragraph that explains it reds here instead of
+   * drifting — which is the whole of what objectui#6785 had to be fixed by
+   * hand.
+   */
+  it.each(Object.keys(PINNED))('pins every path %s carries into its own attached prose', (name) => {
+    const { prose } = attachedDocs(source, name);
+    const carried = pathsCarriedBy(PINNED[name as keyof typeof PINNED]);
+    expect(carried.filter((entry) => !prose.includes(entry))).toEqual([]);
+  });
+
+  /**
+   * What each constant carries AS DATA, recorded so the pin above cannot go
+   * vacuous in silence. The two controls carry exactly themselves; the ledger
+   * carries one entry.
+   *
+   * ⚠️ The ledger EMPTYING is a win, not a failure — the block above this
+   * declaration says it in as many words ("Deleting a line is a MEASUREMENT,
+   * never a repair"), and the `missing` half of the diff is what licenses the
+   * deletion. So this number going down is not a regression; it is the line
+   * where that win gets recorded, alongside the paragraph the deleted entry
+   * took with it. A pin over an empty set passes without checking anything,
+   * and that silence is what this case exists to break.
+   */
+  it('records what each constant carries as data, so the pin cannot go vacuous', () => {
+    expect(pathsCarriedBy(APP_CONTENT_PATH)).toEqual([APP_CONTENT_PATH]);
+    expect(pathsCarriedBy(EAGER_WALK_CONTROL)).toEqual([EAGER_WALK_CONTROL]);
+    expect(pathsCarriedBy(DECLARED_LAZY_VIEWS_STILL_EAGER)).toHaveLength(1);
   });
 });

--- a/scripts/vite-declared-lazy-views.ts
+++ b/scripts/vite-declared-lazy-views.ts
@@ -161,12 +161,14 @@ import type { Plugin, Rollup } from 'vite';
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
 
 /**
- * The module whose `lazy()` declarations are the subject. Repo-relative POSIX.
+ * The module whose `lazy()` declarations are the subject:
+ * `packages/app-shell/src/console/AppContent.tsx`, repo-relative POSIX.
  */
 export const APP_CONTENT_PATH = 'packages/app-shell/src/console/AppContent.tsx';
 
 /**
- * The positive control for the eager walk: statically imported by
+ * The positive control for the eager walk:
+ * `packages/app-shell/src/views/ObjectView.tsx`, statically imported by
  * {@link APP_CONTENT_PATH}'s "eagerly loaded — always needed" block, so it is
  * eager by construction. See counter-probe 2 in the header.
  */
@@ -181,7 +183,7 @@ export const EAGER_WALK_CONTROL = 'packages/app-shell/src/views/ObjectView.tsx';
  * ONE entry stands, and it does not stand for the barrel re-export
  * objectui#6535 removed:
  *
- *  - `RecordDetailView` — a real static edge.
+ *  - `packages/app-shell/src/views/RecordDetailView.tsx` — a real static edge.
  *    `packages/app-shell/src/views/ObjectView.tsx` imports it by name, and
  *    `ObjectView` sits in AppContent's own "eagerly loaded — always needed"
  *    block. Splitting it would mean giving `ObjectView` a lazy boundary.


### PR DESCRIPTION
Fixes #7289

Lifts `attachedDocs` — the structural locator for the documentation attached to
an exported constant, written for objectui#7046 — into a shared test helper, and
applies its **value half** to `scripts/vite-declared-lazy-views.ts`.

## Where the helper went, and why there

`scripts/__tests__/helpers/attached-docs.ts`.

That directory is the repo's existing shared test-plumbing location, not a new
convention: `helpers/turbo-inputs.ts`, `helpers/tsc-program.ts`,
`helpers/build-program.ts`, `helpers/config-program.ts`,
`helpers/eslint-config-program.ts` and `helpers/vitest-config-program.ts`
already live there and are imported as `./helpers/NAME` by six sibling suites.

Measured, because a helper collected as a suite would be an empty test file: the
`unit` project in `vitest.config.mts` includes only names ending in `.test.ts`
under `scripts/`, so this module is importable and never collected. The whole
`scripts/` surface runs 107 files after the change, the same 107 as before.

The body is **token-identical** to the one it replaces (verified by comparing
the whitespace-normalised token streams of the HEAD block and the new file). Two
things differ and nothing else: the signature is reflowed onto three lines by
the added `export`, and the not-found throw said `in the checker` and now says
`in the source`, because it has two customers. No test asserts that string.

## The commit half does not transfer — re-measured on this branch

- `scripts/vite-declared-lazy-views.ts` carries **five** 9-hex citations in
  prose, at lines 100, 227, 282, 340 and 547. They are **two distinct commits**
  (`b98352a15` four times, `fab4802e3` once) — the card said "five commits",
  and the precise reading is five citations of two.
- Its three exported constants are `APP_CONTENT_PATH`, `EAGER_WALK_CONTROL` and
  `DECLARED_LAZY_VIEWS_STILL_EAGER`. All three carry path strings. **No exported
  constant carries a commit string as data.**

So there is nothing live for a commit pin to check those citations against, and
copying objectui#7046's commit pin here would ship a vacuously green test — the
same wall objectui#7046 hit on `PER_CHUNK_BASELINE`. It is deliberately not
shipped, and the reasoning is written beside the pin rather than left in a card.
The blanket negative pin ("no OTHER hash in this block") is not shipped either,
for the reason objectui#7046 already measured: it is red on honest history.

## The value pin, and the finding it produced

Every path a constant carries must appear in the prose attached to that same
constant. `attachedDocs` strips the code, so the declaration cannot satisfy the
pin by restating itself.

**All three constants FAILED the pin as written.** Not one of the three
paragraphs named the path its constant carries: the ledger's bullet said
`RecordDetailView`, and the two control constants' blocks named no path at all.
Three sentences now do — one per constant — and that is the **only** edit this
PR makes to `scripts/vite-declared-lazy-views.ts`. `scripts/check-eager-closure-budget.mjs`
is untouched.

A companion case records what each constant carries as data, so the pin cannot
go vacuous in silence if the ledger empties. Emptying the ledger is a **win**
here, not a regression — the file's own header calls deleting a line a
MEASUREMENT — so that number moving down is where the win gets recorded.

## Probes

Every mutation was proven on disk before its run was read, and every restore is
proven by blob hash equal to the HEAD blob plus an empty `git diff HEAD`. Each
script carries an `EXIT INT TERM` trap restoring through absolute paths.

| # | Mutation, proven on disk | Result |
|---|---|---|
| A0 | budget test restored to its pre-lift blob `5a772eaa` (local function present, import absent) | `101 passed` — identical to the `101 passed` the lifted version produces |
| A | one commit hash inside the checker's `gzipBytes` prose retyped (injected count 0 to 1; the carried hash still 4 elsewhere), run **twice** — once against the pre-lift test file, once against the lifted one | identical both ways: `pins every commit BASELINE carries into its own attached prose`, `expected [ '3d257c85a' ] to deeply equal []`, `1 failed` / `100 passed` |
| B1 | `APP_CONTENT_PATH`'s value taken out of its paragraph (anchor 1 to 0, replacement 0 to 1) | `pins every path APP_CONTENT_PATH carries into its own attached prose` — `1 failed` / `30 passed` |
| B2 | `EAGER_WALK_CONTROL`'s value taken out of its paragraph | `pins every path EAGER_WALK_CONTROL carries into its own attached prose` — `1 failed` / `30 passed` |
| B3 | the ledger bullet reverted to its pre-fix wording | `pins every path DECLARED_LAZY_VIEWS_STILL_EAGER carries into its own attached prose` — `1 failed` / `30 passed` |
| C | a second ledger entry with no prose — `ObjectDataPage.tsx`, a real file `AppContent` really declares lazy, so the sorted / exists / declared-lazy cases stay green and only the new pin speaks | `2 failed` / `29 passed`: the prose pin, and the vacuity record |

⚠️ Probe C's **first attempt was a no-op** and is reported as one rather than
quietly re-run: a `\Q...\E`-quoted `\n` in the perl expression matched nothing,
the file's blob hash did not move and the injected-text count went 0 to 0. The
on-disk check caught it; the reading above is from the re-run with a working
anchor.

## Gates

Run at `5ae65749b`, exit code captured before any pipe, each gate's own verdict
line quoted:

- `pnpm exec vitest run scripts/` — `Test Files 107 passed (107)`, `Tests 3239 passed (3239)`
- `scripts/__tests__/check-eager-closure-budget.test.ts` — `Tests 101 passed (101)` (unchanged count)
- `scripts/__tests__/vite-declared-lazy-views.test.ts` — `Tests 31 passed (31)` (26 before, plus the five new cases)
- `pnpm type-check:scripts` — exit 0, no diagnostics
- `pnpm lint:root` — `32 problems (0 errors, 32 warnings)`, none of them on the four changed files
- `pnpm check:control-bytes` — `check-control-bytes: OK (scanned 6422 tracked text file(s); skipped 85 binary).`
- `pnpm check:unreferenced-sources` — `OK  Every shipped source file in every covered package is reachable.`
- `node scripts/check-changeset-presence.mjs` — `No source or published contract of a released package changed in this range, so no changeset is owed.` (`scripts/` is not released source; no changeset, and no label)
- `node scripts/check-governed-queue-guard.mjs --test` on all four paths — `NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched.`
- `pnpm exec turbo ls --affected` against the branch point — `0 no packages`; the diff is entirely under `scripts/`, which no workspace package owns, and the one code reader of `scripts/vite-declared-lazy-views.ts` outside `scripts/` (`apps/console/vite.config.ts`) sees a comment-only change.

## Overlap with draft PR #7685

Draft PR #7685 (objectui#7122, spec seat) also touches
`scripts/__tests__/check-eager-closure-budget.test.ts` — two hunks, whose headers
read `@@ -611,10 +611,11 @@` and `@@ -795,7 +796,7 @@` — and rewrites
`scripts/check-eager-closure-budget.mjs`. This PR's edits to that test file are
an import near the top and a deletion at old lines 1400 to 1477; the regions are
disjoint. Whichever of the two lands second should merge `main` first. This PR
does not touch `scripts/check-eager-closure-budget.mjs` at all, so PR #7685's
rewrite of it lands against the pins rather than through them — which is what
the pins are for.

Out of scope and untouched here: objectui#6785 and objectui#6631. Whether the
file's five prose citations should get any guard at all is the separate question
objectui#7289 recorded, and this PR does not answer it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013uAaxiwgYDybsTNV9xwa1M)_