### PR TITLE
docs(plugin-designer): shrink UNGATED_DOCS by one — 24 entries to 23, the designer README's 8 blocks compile (#5174 batch 15)

### DIFF
--- a/packages/plugin-designer/README.md
+++ b/packages/plugin-designer/README.md
@@ -30,15 +30,28 @@ npm install @object-ui/plugin-designer
 ## Quick Start
 
 ```tsx
-import {
-  PageDesigner,
-  DataModelDesigner,
-  CollaborationProvider,
-} from '@object-ui/plugin-designer';
+import { CollaborationProvider, PageDesigner } from '@object-ui/plugin-designer';
+import type { CollaborationConfig, DesignerComponent } from '@object-ui/types';
+
+const collaboration: CollaborationConfig = {
+  enabled: true,
+  roomId: 'landing-page',
+  showCursors: true,
+};
+
+const componentList: DesignerComponent[] = [
+  {
+    id: 'headline',
+    type: 'text',
+    label: 'Headline',
+    position: { x: 0, y: 0, width: 480, height: 48 },
+    props: { value: 'Welcome' },
+  },
+];
 
 function DesignerApp() {
   return (
-    <CollaborationProvider>
+    <CollaborationProvider config={collaboration}>
       <PageDesigner
         components={componentList}
         showComponentTree
@@ -56,13 +69,19 @@ function DesignerApp() {
 Drag-and-drop page layout builder:
 
 ```tsx
+import { PageDesigner } from '@object-ui/plugin-designer';
+import type { DesignerCanvasConfig, DesignerComponent } from '@object-ui/types';
+
+declare const canvasConfig: DesignerCanvasConfig;
+declare const componentList: DesignerComponent[];
+
 <PageDesigner
   canvas={canvasConfig}
   components={componentList}
   showComponentTree
   undoRedo
   readOnly={false}
-/>
+/>;
 ```
 
 ### DataModelDesigner
@@ -70,7 +89,13 @@ Drag-and-drop page layout builder:
 Entity-relationship diagram editor:
 
 ```tsx
-<DataModelDesigner entities={entities} relationships={relationships} autoLayout />
+import { DataModelDesigner } from '@object-ui/plugin-designer';
+import type { DataModelEntity, DataModelRelationship } from '@object-ui/types';
+
+declare const entities: DataModelEntity[];
+declare const relationships: DataModelRelationship[];
+
+<DataModelDesigner entities={entities} relationships={relationships} autoLayout />;
 ```
 
 ### ProcessDesigner
@@ -78,13 +103,19 @@ Entity-relationship diagram editor:
 BPMN-style process flow editor:
 
 ```tsx
+import { ProcessDesigner } from '@object-ui/plugin-designer';
+import type { BPMNEdge, BPMNNode } from '@object-ui/types';
+
+declare const nodes: BPMNNode[];
+declare const edges: BPMNEdge[];
+
 <ProcessDesigner
   processName="Order Approval"
   nodes={nodes}
   edges={edges}
   showMinimap
   showToolbar
-/>
+/>;
 ```
 
 ### ReportDesigner
@@ -92,7 +123,12 @@ BPMN-style process flow editor:
 Visual report layout builder:
 
 ```tsx
-<ReportDesigner reportName="Sales Report" objectName="Order" sections={sections} />
+import { ReportDesigner } from '@object-ui/plugin-designer';
+import type { ReportDesignerSection } from '@object-ui/types';
+
+declare const sections: ReportDesignerSection[];
+
+<ReportDesigner reportName="Sales Report" objectName="Order" sections={sections} />;
 ```
 
 ### CollaborationProvider / ConnectionStatusIndicator
@@ -100,10 +136,19 @@ Visual report layout builder:
 Multi-user real-time editing support:
 
 ```tsx
-<CollaborationProvider>
+import {
+  CollaborationProvider,
+  ConnectionStatusIndicator,
+  PageDesigner,
+} from '@object-ui/plugin-designer';
+import type { CollaborationConfig } from '@object-ui/types';
+
+declare const collaboration: CollaborationConfig;
+
+<CollaborationProvider config={collaboration}>
   <ConnectionStatusIndicator />
-  <PageDesigner ... />
-</CollaborationProvider>
+  <PageDesigner showComponentTree undoRedo />
+</CollaborationProvider>;
 ```
 
 ### Shared Hooks
@@ -117,10 +162,13 @@ import {
   useConfirmDialog,
 } from '@object-ui/plugin-designer';
 
-const { undo, redo, canUndo, canRedo } = useUndoRedo();
-const { copy, paste, cut } = useClipboard();
-const { selected, select, selectAll, clearSelection } = useMultiSelect();
-const { zoom, pan, resetView } = useCanvasPanZoom();
+import type { DesignerComponent } from '@object-ui/types';
+
+const { undo, redo, canUndo, canRedo } = useUndoRedo<DesignerComponent[]>([]);
+const { clipboard, copy, paste, hasContent } = useClipboard<DesignerComponent>();
+const { selectedIds, selectOne, selectMany, clearSelection } = useMultiSelect();
+const { zoom, panOffset, zoomIn, zoomOut, resetZoom } = useCanvasPanZoom();
+const { confirm, isOpen } = useConfirmDialog();
 ```
 
 ### Shared Components

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -733,8 +733,6 @@ const UNGATED_DOCS = {
     '6 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
   'packages/plugin-chatbot/README.md':
     '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s); plus TS17000x1 TS2322x1 — candidate real defects, un-triaged',
-  'packages/plugin-designer/README.md':
-    '2 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 12 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2339x6 TS2554x1 TS2741x1 — candidate real defects, un-triaged',
   'packages/plugin-detail/README.md':
     '5 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies; 15 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines',
   'packages/plugin-editor/README.md':


### PR DESCRIPTION
Part of #5174

Batch 15 of the `UNGATED_DOCS` burn-down in `scripts/check-doc-snippet-types.mjs`.
One document leaves the ledger: `packages/plugin-designer/README.md`. All 8 of its
ts/tsx blocks now compile against the built `dist/*.d.ts`, so the entry comes out.
The card stays open — 23 entries remain.

File surface: exactly two files. `scripts/check-doc-snippet-types.mjs` is `0 2` on
`git diff --numstat` — the two-line entry removal and nothing else.

## Census, re-taken at this branch point

Base `b31370093`, recorded before the first edit and never inherited from batch 14
or from the dispatch. Taken with the gate's own exports (`UNGATED_DOCS`,
`listDocuments`, `scanFences`).

Ledger entry count at base: **24** — batch 14 has not merged, so
`packages/mobile/README.md` is still listed. Gate verdict at base, exit **0**:

```
Scanned 227 document(s): 203 covered (101 of them hold a ts/tsx block), 24 ungated — declared in this script, NOT verified by it.
Covered blocks: 635 — 477 to compile, 158 declared fragment(s).
Semantic phase: 477 of 477 block(s) judged, 0 failed.
```

| blocks | document | takeable? |
|---:|---|---|
| 18 | `packages/plugin-gantt/README.md` | no — objectui#7302's, being dispatched to another dev this round |
| 11 | `packages/plugin-chatbot/README.md` | no — deferred, needs a which-side-is-wrong ruling against the third-party `ai` SDK |
| 10 | `packages/auth/README.md` | no — held by draft PR #7685 (re-read its file list: `packages/auth/README.md` is still in it) |
| 9 | `packages/mobile/README.md` | no — batch 14, in flight as PR #7975 |
| 8 | `packages/i18n/README.md` | yes — tie at 8, **11** measured diagnostics |
| 8 | `packages/plugin-designer/README.md` | **yes — tie at 8, 22 measured diagnostics ⇒ PICKED** |
| 7 | `packages/collaboration` · `layout` · `permissions` · `plugin-detail` · `types` | yes |
| 5 | `packages/core` · `plugin-kanban` (no — objectui#7302's) · `plugin-list` · `react-runtime` · root `README.md` | |
| 4 | `packages/plugin-ai` · `plugin-charts` · `plugin-editor` · `plugin-map` · `plugin-markdown` · `providers` | |
| 2 | `packages/fields/README.md` | |
| 1 | `packages/plugin-tree/README.md` | |

The tie at 8 blocks was broken by measured debt, per the batch-14 ruling: the entry
hiding more diagnostics is the one whose green means more. Both sides were measured
on this base by removing that one entry and running the gate — 22 for
`plugin-designer`, 11 for `i18n`.

## Decomposition, measured at the base before any edit

The ledger reason is archaeology; the measurement is the fact. This time the two
agree, which is worth recording after three batches where they did not:

| the entry claims | measured on `b31370093` |
|---|---|
| 2 parse | 2 — TS1003, TS1382, both at `README.md:105` |
| 12 undefined-name | 12 — TS2304 x11 + TS2552 x1 |
| TS2339 x6, TS2554 x1, TS2741 x1 | identical |
| **22 total** | **22 total** |

What each one was:

- **TS1382/TS1003 at line 105** — the `CollaborationProvider` example wrote a literal
  three-dot elision inside a JSX tag. Not a fragment marker, just a token TypeScript
  cannot parse.
- **TS2741 at line 41** — `CollaborationProvider` was used with no `config`, which its
  shipped `CollaborationProviderProps` declares as required.
- **TS2304/TS2552 x12** — five prop-reference blocks used ambient names (`componentList`,
  `canvasConfig`, `entities`, `relationships`, `nodes`, `edges`, `sections`) and, in four
  of them, the component itself was never imported.
- **TS2554 at line 120** — `useUndoRedo()` called with zero arguments; it ships as
  `useUndoRedo(initialState, options)`.
- **TS2339 x6 at lines 121-123** — six phantom member names on three hooks. Every one of
  them has a shipped equivalent, so each is a repair and not a refusal, except `cut`,
  which has no shipped counterpart and is simply no longer documented:

  | the page taught | the shipped surface | treatment |
  |---|---|---|
  | `useClipboard().cut` | nothing — `ClipboardState` is `clipboard` / `copy` / `paste` / `hasContent` | phantom removed |
  | `useMultiSelect().selected` | `selectedIds` | shipped spelling taught |
  | `useMultiSelect().select` | `selectOne` | shipped spelling taught |
  | `useMultiSelect().selectAll` | `selectMany(ids)` | shipped spelling taught |
  | `useCanvasPanZoom().pan` | `panOffset` (state) and `startPan` (action) | shipped spelling taught |
  | `useCanvasPanZoom().resetView` | `resetZoom` | shipped spelling taught |

No public type was widened to accept anything the page said, and no lenient alias was
added anywhere. The direction is the one AGENTS.md commandment #0.1 requires: the
document moved to the contract, never the contract to the document.

## Shape of the rewrite, and the readers it had to keep green

`git grep -l 'plugin-designer/README' -- scripts/ packages/ examples/ apps/` returns two
readers: this gate, and `scripts/__tests__/doc-version-claims.test.ts`, whose
`KNOWN_CLAIMS` pins the peer line at `README.md:26` and asserts it verbatim against the
package manifest. Lines 25-28 are byte-identical on this branch, and probe P4 below shows
that pin is still live rather than vacuous.

The five prop-reference blocks keep their original element shape and gain a compact
preamble of the real import plus `declare const` placeholders carrying the shipped type.
That form documents strictly more than the old ambient names did — a reader now sees what
type each prop wants — and probe P5 shows those annotations are load-bearing rather than
silently widened.

## Coverage arithmetic

| | base `b31370093` | branch `7116b5e1d` | delta |
|---|---:|---:|---:|
| documents scanned | 227 | 227 | 0 |
| covered | 203 | 204 | +1 |
| covered holding a ts/tsx block | 101 | 102 | +1 |
| ungated | 24 | 23 | **-1** |
| covered blocks | 635 | 643 | +8 |
| blocks to compile | 477 | 485 | +8 |
| declared fragments | 158 | 158 | **0** |
| semantic failures | 0 | 0 | 0 |

All 8 blocks were bought by compiling them. None was bought with a fragment declaration.

## Strictness invariant

sha256 of `scripts/check-doc-snippet-types.mjs` from the `Fence scanning` banner to EOF,
1178 lines on both sides:

- base `b31370093` — `f46b5662ba336f026bca3a0003e0b7979789d48d0291fa5760be7d23c8ed0160`
- branch `7116b5e1d` — `f46b5662ba336f026bca3a0003e0b7979789d48d0291fa5760be7d23c8ed0160`

Identical. Nothing in the gate's scanning, marker, control or verdict logic moved.

## Ledger invariants

Both sides' `UNGATED_DOCS` literals were imported and diffed programmatically:

```
base entries = 24 | head entries = 23
added          = []
removed        = ["packages/plugin-designer/README.md"]
reason-changed = []
key order preserved for survivors = true
survivors count = 23
```

## Probes — predicted in writing, then observed

Every mutation proved on disk (occurrence counts plus blob hash), every restore proved
(blob equals HEAD, empty `git diff HEAD`), each leg wrapped in an EXIT/INT/TERM trap with
absolute paths.

| # | mutation | predicted | observed |
|---|---|---|---|
| P1 | ledger entry restored, README repair kept | exit 0, coverage silently shrinks back to 24 ungated / 477 to compile | exact match: exit 0, `24 ungated`, `Covered blocks: 635 — 477 to compile`, `477 of 477 judged, 0 failed` |
| P2 | `zoomIn` becomes `zoomInTypo` in the hooks block | exit 1, one TS2339 on that line | exact match: `README.md:170:26 TS2339: Property 'zoomInTypo' does not exist on type 'PanZoomState'`, `485 of 485 judged, 1 failed` |
| P3 | README reverted to base bytes, removal kept | exit 1 with the same 22 diagnostics as the decomposition | exact match, all 22, same codes, same lines |
| P4 | peer line `react` caret-18 becomes caret-17 | `doc-version-claims.test.ts` goes red | exact match: 3 assertions red — the ratchet, the inventory, and the peer-line assertion (`README says caret-17 or caret-19, manifest says caret-18 or caret-19`) |
| P5 | the `entities` placeholder retyped from `DataModelEntity[]` to `BPMNNode[]` | exit 1, assignability error on `entities=` | exact match: `TS2322: Type 'BPMNNode[]' is not assignable to type 'DataModelEntity[]'` |
| P6 | `ReportDesigner` import renamed to `ReportDesignerNope` | `check:readme-exports` red, 1 fabricated | exact match: `1 README import name(s) NO package exports`, census `431 real, 0 wrong-path, 1 fabricated` |

Six of six landed in the predicted direction; nothing reversed, so no isolating follow-up
probe was needed.

## Gates

Every exit code captured by redirecting first, never through a pipe. Union re-run at the
final commit `7116b5e1d`.

| gate | exit | its own verdict line |
|---|---:|---|
| `pnpm check:doc-snippets` | 0 | `Every covered documentation snippet compiles against the built types.` |
| `pnpm check:doc-fences` | 0 | `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript, except 80 declared file(s) carrying 89 block(s)` |
| `pnpm check:readme-exports` | 0 | `OK (43 tracked README(s) ... 432 of them self-imports judged (432 real, 0 wrong-path, 0 fabricated)` |
| `pnpm check:doc-types` | 0 | `Every documented component type is registered.` |
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `pnpm check:doc-example-readers` | 0 | `OK 80 documented symbol(s), 3947 call site(s) ... no @example hand-spells one.` |
| `pnpm check:control-bytes` | 0 | `OK (scanned 6421 tracked text file(s); skipped 85 binary).` |
| `pnpm type-check:scripts` | 0 | clean `tsc -p tsconfig.scripts.json` |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --test` (both paths) | 0 | `NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.` |

Tests: `pnpm exec vitest run scripts/__tests__/check-doc-snippet-types.test.ts
scripts/__tests__/doc-version-claims.test.ts scripts/__tests__/check-doc-fence-languages.test.ts
scripts/__tests__/check-readme-exports.test.ts` — `Test Files 4 passed (4) / Tests 231 passed (231)`.
`pnpm exec vitest run packages/plugin-designer/` — `Test Files 17 passed (17) / Tests 124 passed (124)`.
`pnpm --filter @object-ui/plugin-designer type-check` — exit 0.

`check:readme-exports` first came back exit 1 with three `@object-ui/plugin-ai` entries
reading `its type entry ./dist/index.d.ts is not on disk -- run pnpm build first`. That is
the unbuilt-tree PRECONDITION, not a verdict: `@object-ui/plugin-ai` sits outside
`check:doc-snippets --build-filter`'s closure, so building only what the snippet gate asks
for leaves it unbuilt. After `turbo run build --filter=@object-ui/plugin-ai...` the gate
ran and returned the green quoted above. Read the earlier exit as NOT MEASURED.

`TURBO_SCM_BASE=b31370093 turbo ls --affected` names five packages: `plugin-designer`,
`app-shell`, `console`, `example-byo-backend-console`, `example-console-starter`. Only the
first owns anything that reads the changed bytes; the other four are affected through
turbo's package input hash alone. `git grep README` across those four returns nothing but
prose in comments and their own READMEs, none of it naming this document. Their suites are
declared to CI — a stated narrowing, not a skipped run. Repository-wide `pnpm lint` is
likewise CI's run.

## Concurrency with batch 14

Batch 14 is PR #7975, removing `packages/mobile/README.md`. The two removals are disjoint
lines of the same object literal in the same file, and the two READMEs do not overlap. Both
are `Part of #5174`; whichever lands second is rebuilt by the merge queue on the other's
result. No coordination beyond that is owed.

## Refusals

None. Every block on this page had a shipped spelling for what it meant, so all 8 compile
and none was declared a fragment. No coverage limit to record.

## Next takeable

`packages/i18n/README.md` — 8 blocks, 11 measured diagnostics on this base (TS2304 x7,
TS2559 x2, TS2554 x2), no open PR holding it.

---
_Generated by [Claude Code](https://claude.ai/code/session_013uAaxiwgYDybsTNV9xwa1M)_