### PR TITLE
docs(plugins): bring three documented interface blocks up to their shipped types

### DIFF
--- a/packages/plugin-gantt/README.md
+++ b/packages/plugin-gantt/README.md
@@ -389,6 +389,7 @@ pulses it — useful in deep or long trees.
 what `ObjectGantt` produces from each record. Dates are real `Date` objects and
 the label field is `title` (`src/GanttView.tsx`):
 
+<!-- readme-exports: partial GanttTask — deliberate excerpt: `fields` and `hasOwnDates` are populated by ObjectGantt itself, as the paragraph below the block says -->
 ```typescript
 interface GanttTask {
   id: string | number;

--- a/packages/plugin-kanban/README.md
+++ b/packages/plugin-kanban/README.md
@@ -115,8 +115,10 @@ interface KanbanColumn {
   id: string;
   title: string;
   cards: KanbanCard[];
-  limit?: number;                     // Maximum cards allowed
+  limit?: number;                     // WIP limit — the count at which the lane warns
   className?: string;
+  collapsed?: boolean;                // Lane renders collapsed (honoured by KanbanEnhanced)
+  color?: never;                      // RETIRED — refused by name; style a lane through className
 }
 
 // Card structure
@@ -128,6 +130,13 @@ interface KanbanCard {
     label: string;
     variant?: 'default' | 'secondary' | 'destructive' | 'outline';
   }>;
+  cardSubtitle?: string;              // Synthesized subtitle, rendered in preference to description
+  cardFieldCells?: Array<{            // Structured per-field cells; wins over cardSubtitle/description
+    field: string;
+    label?: string;
+    node: React.ReactNode;
+  }>;
+  coverImage?: string;                // Resolved cover-image URL, from the board's coverImageField
 }
 ```
 

--- a/scripts/__tests__/check-readme-exports.test.ts
+++ b/scripts/__tests__/check-readme-exports.test.ts
@@ -925,6 +925,66 @@ function buildState(result: ReturnType<typeof scan>) {
   };
 }
 
+/**
+ * Every DECLARED excerpt in this repository whose own package is UNBUILT — the
+ * exact population whose shrink-only rule the gate suspends, and therefore the
+ * exact number `census.excerptsNotJudged` has to come back as.
+ *
+ * objectui#7302. This used to be spelled `Object.keys(PARTIAL_EXCERPTS)`
+ * filtered by build state — the LEDGER half, alone. That was complete only
+ * while every excerpt in the tree was a ledger entry. The moment a content fix
+ * moved one to the in-README `PARTIAL_MARKER` — which is the disposition a
+ * GENUINE excerpt is meant to end at, and the ledger's own reason said so —
+ * the two assertions below expected 0 where the gate counted 1, and they went
+ * red on CI: on the UNBUILT tree the shards run, which is the only state this
+ * can fire in. The gate counts BOTH mechanisms in that one counter, on purpose
+ * and in one sentence of its header ("BOTH suppress `stale-omission` ... both
+ * are counted as `not judged` in the census"), so both belong in the
+ * expectation, under the same per-PACKAGE rule the rest of these cases use.
+ *
+ * DERIVED FROM THE READMEs, never from the counter under test: the ledger half
+ * from the exported literal, the marker half by re-reading each README of an
+ * unbuilt package through the gate's own exported grammar. So these assertions
+ * still cross-check the gate against something that is not the gate's count.
+ *
+ * The marker half is the population of the gate's `excerptFor` map — a marker
+ * that BINDS a fence and carries a long enough reason — restricted to unbuilt
+ * packages, and it deliberately does not re-parse the block to confirm the type
+ * is declared there: a bound marker whose fence declares no type of that name
+ * is reported `stale-partial-marker` in EVERY build state, and the case below
+ * asserts there are none of those. Keyed the way the gate keys it
+ * (`<fence>::<Name>`, per README), so a repeated marker collapses here exactly
+ * as it collapses there.
+ */
+function suspendedExcerpts(
+  result: ReturnType<typeof scan>,
+  excerpts: Readonly<Record<string, string>> = PARTIAL_EXCERPTS,
+) {
+  const { isUnbuilt } = buildState(result);
+  const ledger = Object.keys(excerpts).filter((key) =>
+    isUnbuilt(packageDirOf(repoRoot, key.split('::')[0])),
+  );
+  /** `<readme>::<fence>::<Name>` -> `<readme>::<Name>`, the form a finding is at. */
+  const markers = new Map<string, string>();
+  for (const record of result.packages) {
+    if (record.state !== 'unbuilt') continue;
+    for (const readme of record.readmes as string[]) {
+      const markdown = fs.readFileSync(path.join(repoRoot, readme), 'utf8');
+      for (const marker of findPartialMarkers(markdown, extractCodeBlocks(markdown))) {
+        if (marker.fence === null || marker.reason.length < MIN_PARTIAL_REASON) continue;
+        markers.set(`${readme}::${marker.fence}::${marker.name}`, `${readme}::${marker.name}`);
+      }
+    }
+  }
+  return {
+    ledger,
+    markers: [...markers.keys()],
+    /** Where each suspended marker must be REPORTED, in a finding's `<file>::<Name>` form. */
+    markerSites: [...new Set(markers.values())],
+    all: [...ledger, ...markers.keys()],
+  };
+}
+
 describe('the PARTIAL_EXCERPTS ledger, as it stands in this repository', () => {
   it('is keyed `<readme>::<InterfaceName>` and every entry carries a card number', () => {
     for (const [key, reason] of Object.entries(PARTIAL_EXCERPTS)) {
@@ -1017,13 +1077,34 @@ describe('the PARTIAL_EXCERPTS ledger, as it stands in this repository', () => {
     // case cannot see the objectui#6214 regression on its own — the one in the
     // `repo state` block below, with the ledger ON, is the leg that does.
     // Stated so the pair is not mistaken for one assertion twice.
-    expect(off.census.excerptsNotJudged).toBe(0);
+    //
+    // NOT zero, and that is objectui#7302's correction. `excerpts: {}` turns
+    // the LEDGER off, and the ledger is the only half it can turn off: a
+    // README's `PARTIAL_MARKER` lives in the README, so it still declares an
+    // excerpt in this scan, and on an unbuilt package it is still suspended and
+    // still counted. The hard-coded 0 was quietly asserting "this repository
+    // declares no excerpt by marker" under a title about the ledger, and it
+    // went red the first time one did — on CI's unbuilt tree, the only build
+    // state in which the marker half of this counter can be non-zero.
+    const suspendedOff = suspendedExcerpts(off, {});
+    expect(
+      off.census.excerptsNotJudged,
+      `with the LEDGER OFF the suspension count is not the number of MARKER-declared excerpts whose own package is unbuilt (${suspendedOff.markers.join(', ') || 'none'}). ${note}`,
+    ).toBe(suspendedOff.markers.length);
+
+    // ...and every one of those is REPORTED `unjudgeable-type`, exactly as a
+    // ledger entry is three blocks up. A suspended rule must still FAIL, and
+    // which mechanism declared the excerpt does not change that.
+    expect(
+      suspendedOff.markerSites.filter((key) => !suspended.some((f) => at(f) === key)),
+      `a marker-declared excerpt whose package is unbuilt was not reported \`unjudgeable-type\` -- a suspended rule must still FAIL. ${note}`,
+    ).toEqual([]);
   });
 });
 
 describe('repo state — assertions that hold in EVERY build state: built, unbuilt, or a mix', () => {
   const result = scan(repoRoot);
-  const { unbuiltDirs, unbuiltNames, isUnbuilt, note } = buildState(result);
+  const { unbuiltDirs, unbuiltNames, note } = buildState(result);
 
   it('walked the tree: READMEs, fenced blocks and import bindings were all found', () => {
     // These three need no `dist/`, so they assert in the test shards too.
@@ -1069,19 +1150,27 @@ describe('repo state — assertions that hold in EVERY build state: built, unbui
       `a README marker was called stale. ${note}`,
     ).toEqual([]);
 
-    // ...and the number of entries whose shrink-only rule is SUSPENDED is the
-    // number whose own package is unbuilt: the whole ledger on CI, none of it on
-    // a built tree, and in between in between. The old form hard-coded
-    // `Object.keys(PARTIAL_EXCERPTS).length`, which is only the CI answer — it is
-    // the line that failed `expected +0 to be 3` on a half-built tree, where all
-    // three ledgered packages happen to be among the ones the doc gate builds.
-    const suspendable = Object.keys(PARTIAL_EXCERPTS).filter((key) =>
-      isUnbuilt(packageDirOf(repoRoot, key.split('::')[0])),
-    );
+    // ...and the number of DECLARED excerpts whose shrink-only rule is
+    // SUSPENDED is the number whose own package is unbuilt: all of them on CI,
+    // none of them on a built tree, and in between in between. Two different
+    // cards have corrected this one line, and the second is why it reads as it
+    // does now rather than as a literal:
+    //
+    //   objectui#7460  it hard-coded `Object.keys(PARTIAL_EXCERPTS).length`,
+    //                  which is only the CI answer — the line that failed
+    //                  `expected +0 to be 3` on a half-built tree.
+    //   objectui#7302  it then counted only the LEDGER half of the population
+    //                  the gate counts. The first in-README `PARTIAL_MARKER` to
+    //                  land made it expect 0 against a gate reporting 1, red on
+    //                  `Test (shard 2/4)` and green on every built tree.
+    //
+    // See `suspendedExcerpts` for why the marker half is derived from the
+    // README bytes rather than read back off the counter it checks.
+    const suspended = suspendedExcerpts(result);
     expect(
       result.census.excerptsNotJudged,
-      `the ledger's suspension count is not the number of entries whose own package is unbuilt (${suspendable.join(', ') || 'none'}). ${note}`,
-    ).toBe(suspendable.length);
+      `the suspension count is not the number of DECLARED excerpts whose own package is unbuilt (ledger: ${suspended.ledger.join(', ') || 'none'}; marker: ${suspended.markers.join(', ') || 'none'}). ${note}`,
+    ).toBe(suspended.all.length);
 
     // An unbuilt package must be REPORTED, never silently skipped. That is the
     // rule that makes this gate's never-built CI run FAIL instead of passing

--- a/scripts/__tests__/check-readme-exports.test.ts
+++ b/scripts/__tests__/check-readme-exports.test.ts
@@ -953,7 +953,29 @@ describe('the PARTIAL_EXCERPTS ledger, as it stands in this repository', () => {
     const judgeable = new Set(ledgered.filter((key) => !isUnbuilt(packageOfEntry(key))));
     const suspendable = ledgered.filter((key) => isUnbuilt(packageOfEntry(key)));
 
-    expect(ledgered.length, 'the ledger is empty, so this case asserts nothing').toBeGreaterThan(0);
+    // THE LEDGER IS EMPTY TODAY, and this line is what says so out loud.
+    // objectui#7302 paid off the three entries objectui#6214 opened with, and
+    // the guard that stood here (`expect(ledgered.length).toBeGreaterThan(0)`,
+    // "the ledger is empty, so this case asserts nothing") went red on that
+    // content fix. It was right to: the per-ENTRY leg below does stop asserting
+    // when there is no entry. But this case does NOT go vacuous with it --
+    // `judgeable` becomes the empty set, so the equality two blocks down reads
+    // "NO declaration in this tree reds as a stale omission with the ledger
+    // off", which is the strongest state this repository can be in and reds on
+    // the next README that drifts.
+    //
+    // So the guard is replaced by the FACT, asserted rather than assumed: an
+    // entry arriving flips this line, in the same file that explains what the
+    // entry then has to satisfy. The per-entry property itself never depended
+    // on the repository carrying an entry -- it is pinned on the fixture tree
+    // above ('the LEDGER suppresses the omission it records', 'the LEDGER does
+    // NOT suppress a fabricated key either', and the two stale-entry cases),
+    // which carry an entry by construction and cannot be emptied by a content
+    // card.
+    expect(
+      ledgered,
+      'the ledger is no longer empty -- flip this assertion to the entries and re-read the case above it',
+    ).toEqual([]);
 
     const omissions = off.findings.filter((f) => f.verdict === 'stale-omission');
     const suspended = off.findings.filter((f) => f.verdict === 'unjudgeable-type');

--- a/scripts/check-readme-exports.mjs
+++ b/scripts/check-readme-exports.mjs
@@ -340,8 +340,16 @@ export const MIN_PARTIAL_REASON = 12;
  * lives in the README and says "deliberate"; this ledger lives here and says
  * "drift, owed to a content card". objectui#6214 wired this pin and was
  * explicitly not allowed to edit README CONTENT, so the drift its first run
- * found is written down here with the card number instead of being inherited
+ * found was written down here with the card number instead of being inherited
  * silently or fixed in the gate's own PR.
+ *
+ * EMPTY TODAY, and that is a state and not a retirement. objectui#7302 paid off
+ * the three entries #6214 opened with: `plugin-gantt`'s `GanttTask` was a
+ * genuine excerpt and moved to the in-README `PARTIAL_MARKER` above, and
+ * `plugin-kanban`'s `KanbanColumn` and `KanbanCard` were staleness and were
+ * brought up to the shipped declarations. ⛔ Do not delete this ledger because
+ * it holds nothing: the next pin that finds drift it may not fix in its own PR
+ * writes the entry here, exactly as #6214 did.
  *
  * SHRINK-ONLY, enforced rather than asked for: an entry whose declaration is no
  * longer in the README, or that no longer omits anything, FAILS as a stale
@@ -350,15 +358,16 @@ export const MIN_PARTIAL_REASON = 12;
  *
  * It suppresses `stale-omission` for that declaration and NOTHING else. A
  * `fabricated-key` is never excludable here -- see the header.
+ *
+ * The annotation is load-bearing while the ledger is empty: without it
+ * `Object.freeze({})` infers `Readonly<{}>`, `Object.entries` hands the test
+ * suite `unknown` values, and `pnpm type-check:scripts` fails TS18046 at the
+ * case that reads each reason. Same spelling, and the same reason, as
+ * `check-doc-snippet-types.mjs`'s `UNGATED_DOCS`.
+ *
+ * @type {Readonly<Record<string, string>>}
  */
-export const PARTIAL_EXCERPTS = Object.freeze({
-  'packages/plugin-gantt/README.md::GanttTask':
-    'objectui#6214, content fix objectui#7302 -- omits `fields` and `hasOwnDates`, which the prose immediately BELOW the block already names as populated by ObjectGantt itself. Genuinely an excerpt, so it wants the in-README PARTIAL_MARKER rather than this ledger; that one-line README edit was deliberately not made in the gate\'s own PR.',
-  'packages/plugin-kanban/README.md::KanbanColumn':
-    'objectui#6214, content fix objectui#7302 -- omits `collapsed`. Nothing in the page says the block is partial, so this is staleness, not an excerpt.',
-  'packages/plugin-kanban/README.md::KanbanCard':
-    'objectui#6214, content fix objectui#7302 -- omits `cardSubtitle`, `cardFieldCells` and `coverImage`. Same page, same class as `KanbanColumn` above: the block reads as the whole card shape and is three keys behind it. objectui#6155 may move this set: these are read from what `@object-ui/plugin-kanban` exports, and that card records four disagreeing declarations of the pair.',
-});
+export const PARTIAL_EXCERPTS = Object.freeze({});
 
 /** The NUL that `git ls-files -z` delimits with, built from its code point. */
 const NUL = String.fromCharCode(0);


### PR DESCRIPTION
Fixes #7302

`PARTIAL_EXCERPTS` in `scripts/check-readme-exports.mjs` opened with exactly three entries: objectui#6214 wired the interface pin and was deliberately not allowed to edit README CONTENT, so the drift its first run found was written down there instead of being inherited silently. All three are paid off here.

**Ledger before: 3 entries. Ledger after: 0** — `Object.freeze({})`, with the docblock kept and extended, because the list must be able to fill again.

## Three entries, three dispositions — deliberately not one template

| Declaration | Disposition | Why |
|---|---|---|
| `packages/plugin-gantt/README.md::GanttTask` | in-README `PARTIAL_MARKER` above the fence | Genuine excerpt. The paragraph **directly below** the block already says `fields` and `hasOwnDates` are populated by `ObjectGantt` itself — verified still present on this base. Adding the two keys to the block would contradict that prose. |
| `packages/plugin-kanban/README.md::KanbanColumn` | block brought up to the shipped declaration | Staleness. Nothing on the page says the block is partial. |
| `packages/plugin-kanban/README.md::KanbanCard` | block brought up to the shipped declaration | Same page, same class. |

### The marker grammar used

One marker silences one TYPE, and it binds to the next fenced block whose opening fence is the first following line that is neither blank nor another marker. Placed at `packages/plugin-gantt/README.md:392`, immediately above the fence at :393:

```
readme-exports: partial GanttTask — deliberate excerpt: `fields` and `hasOwnDates` are populated by ObjectGantt itself, as the paragraph below the block says
```

(spelled without its HTML-comment delimiters here, because a comment-shaped fragment does not survive being written into a GitHub body — see the read-back rule in `AGENTS.md`. The delimiters are present in the file, and the gate parses it: the run below reports `1 excerpt(s) declared by marker`.)

## The #6155 impact check (Zone 2 A3) — asked for, and the answer moved a key set

The key sets were **re-derived from the gate's own reading of the built tree**, not copied from the ledger reasons, exactly as objectui#6155's warning in the ledger asked.

**Which declaration `@object-ui/plugin-kanban` actually exports today:** `packages/plugin-kanban/src/index.tsx:111` re-exports `KanbanCard` / `KanbanColumn` from `src/types.ts`, and `src/types.ts:35` is itself a plain re-export from `@object-ui/types`. So the shipped declaration is the ONE in `packages/types/src/complex.ts` — `KanbanCard` at :63, `KanbanColumn` at :120 — which objectui#7664 made authoritative and which that file's own header pins against re-declaration (`one-authority-per-exported-name-6273.test.ts`). Of objectui#6155's four disagreeing declarations, this is the one that spells the lane's array `cards` (objectui#6939 retired `items`, a spelling with zero read sites) and the card's array `badges`. Both spellings the README already used are therefore correct against the export; neither was touched. **objectui#6155 is not addressed here and remains open.**

**Where the derived answer disagreed with the ledger's prose:** the ledger reason for `KanbanColumn` recorded ONE omitted key, `collapsed`. The gate on a built tree reports **two** — `collapsed` **and** `color`:

```
partial-ledger  packages/plugin-kanban/README.md:114  interface KanbanColumn  doc 5 key(s) vs own 7 of 7  omitted: collapsed, color
```

`color` arrived after that reason was written: objectui#7664 retired it as `color?: never`, a deliberate tombstone whose own JSDoc gives prong 2 as "keep loud a key the docs taught as working". The README now documents it as such rather than dropping it — which is what the tombstone exists for. The reason string was a derived value, and it was stale; the export won.

## Diff, in full

- `packages/plugin-gantt/README.md` — one marker line. The block is unchanged.
- `packages/plugin-kanban/README.md` — `collapsed?: boolean` and `color?: never` onto `KanbanColumn`; `cardSubtitle?`, `cardFieldCells?`, `coverImage?` onto `KanbanCard`, with a one-line comment each in the block's existing trailing-comment style. `limit`'s comment corrected from "Maximum cards allowed" to the WIP-limit wording the shipped JSDoc uses.
- `scripts/check-readme-exports.mjs` — **the only non-comment change in this file is the ledger literal** (three entries becoming `{}`); verified by filtering the diff. Everything else is docblock: a paragraph recording that empty is a state and not a retirement, and a `@type` annotation (see below).
- `scripts/__tests__/check-readme-exports.test.ts` — see the declared deviation below.

## Two things the dispatch did not predict — both declared

**1. The gate's own suite has a non-vacuity guard on the ledger, and it fired.** `expect(ledgered.length, 'the ledger is empty, so this case asserts nothing').toBeGreaterThan(0)` went red the moment the ledger emptied. It was right to: the per-ENTRY leg of that case does stop asserting. But the case does not go vacuous with it — `judgeable` becomes the empty set, so the equality below it then reads "NO declaration in this tree reds as a stale omission with the ledger off", which reds on the next README that drifts. So the guard is replaced by the empty state **asserted as a fact**, with a comment saying that an entry arriving flips that line, and that the per-entry property never depended on the repository carrying an entry — it is pinned on the fixture tree in the same file (`the LEDGER suppresses the omission it records`, `the LEDGER does NOT suppress a fabricated key either`, and the two stale-entry cases), which carries an entry by construction.

⚠️ **This file is outside the file surface the claim comment declared** (which named only the two READMEs and the gate script). It is not a gate LOGIC change — the judgement code is byte-identical — but it is a fourth file, and the card's own done criterion requires the self-test to pass, so it could not be avoided. Flagged rather than absorbed.

**2. `pnpm type-check:scripts` failed TS18046 on the empty ledger.** `Object.freeze({})` infers `Readonly` of the empty object type, so `Object.entries` hands the test suite `unknown` values and the case that reads each reason stops compiling. Fixed with a `@type {Readonly<Record<string, string>>}` JSDoc annotation on the export — the same spelling, and the same reason, as `check-doc-snippet-types.mjs`'s `UNGATED_DOCS`. It is a comment, so it changes no runtime byte.

## Probes — every mutation proven on disk, every restore proven

Run on the COMMITTED tree, one script with `trap ... EXIT INT TERM` and absolute paths. Each mutation is proven by comparing `git hash-object` against the path's HEAD blob (an empty or equal hash aborts loudly), and each restore by `git checkout HEAD -- path` followed by an empty `git diff HEAD`.

| Probe | Mutation | On-disk proof | Gate result | Restore |
|---|---|---|---|---|
| **A** — ablation: is it the CONTENT fix that greens the gate, or the ledger deletion? | kanban README reverted to the base blob, ledger left empty | `5d17050c` vs HEAD `97296226`; anchor counts `collapsed=0`, `coverImage=0` | **exit 1** — `2 documented type(s) are behind the shipped declaration`: `KanbanColumn omits collapsed, color`; `KanbanCard omits cardSubtitle, cardFieldCells, coverImage` | `git diff HEAD` EMPTY |
| **B** — the marker's stale direction | the two keys added to the Gantt block, marker kept | `8e2a2736` vs HEAD `17b504eb`; injected anchor `hasOwnDates=1`, marker still `1` | **exit 1** — `1 partial-excerpt marker(s) declare nothing`: `GanttTask declares an excerpt that omits nothing any more -- delete the marker` | `git diff HEAD` EMPTY |
| **C** — `fabricated-key` positive control | a made-up key planted in the `KanbanCard` block | `9e149d23` vs HEAD `97296226`; anchor count `1` | **exit 1** — `1 documented type(s) declare a key the shipped type does NOT have`: `documents totallyMadeUpKey, not on the shipped type` | `git diff HEAD` EMPTY |

B is the one that earns the marker route: the marker is checked, so it cannot outlive the fact it declares.

## Verification — at `09f1d4856`, on a BUILT tree

An unbuilt tree reports every declaration `unjudgeable-type` and SUSPENDS the shrink-only rule, so it is a precondition and not a red. Measured both ways here: before building, `426 self-import(s) could not be judged` and `3 not judged`; the build (`turbo run build --filter=./packages/*`, through the shared verify lock) reported `VERDICT command-exit 0`, `Tasks: 39 successful, 39 total`.

- `pnpm check:readme-exports` — **exit 0**, `✅ check-readme-exports: OK (... 58 key(s) compared both ways (0 fabricated, 0 stale omission(s); 1 excerpt(s) declared by marker, 0 by ledger, 0 not judged ...))`. Baseline before the change on the same built tree: `53 key(s) ... 0 by marker, 3 by ledger`.
- Done criterion, the gate's own API: `scan(repoRoot, { excerpts: {} })` returns `findings: 0 vacuous: 0` with `PARTIAL_EXCERPTS keys: []`.
- `--list` now reports `partial-marker` on `GanttTask` and **`matches  doc 7 key(s) vs own 7 of 7`** on both kanban declarations.
- Gate suite + README readers + both plugin packages: `pnpm exec vitest run packages/plugin-gantt/ packages/plugin-kanban/ scripts/__tests__/check-readme-exports.test.ts scripts/__tests__/check-unreferenced-sources.test.ts` → `Test Files 88 passed (88)`, `Tests 728 passed (728)`, lock `VERDICT command-exit 0`. The reader sweep (`git grep -l` for both README paths over `scripts/ packages/ examples/ apps/`) names `packages/plugin-gantt/src/readme-navigation-example.test.ts`, `scripts/__tests__/check-readme-exports.test.ts` and `scripts/check-doc-snippet-types.mjs`; all three are covered above.
- `pnpm check:doc-snippets` — exit 0, `Semantic phase: 477 of 477 block(s) judged, 0 failed.` **Both READMEs are on that gate's `UNGATED_DOCS` ledger** (gantt: 9 parse + 12 undefined-name; kanban: 6 parse), so their fences are NOT compiled; the ledger's counts are prose and are not re-derived, so these edits cannot move that verdict.
- `pnpm check:doc-fences` exit 0 · `check-doc-links` exit 0 · `pnpm check:control-bytes` exit 0 (`6421 tracked text file(s)`) · `pnpm check:doc-types` exit 0 · `pnpm check:doc-example-readers` exit 0 · `check-unreferenced-sources` exit 0 · `pnpm lint:coverage` exit 0 (`46/46 packages`) · `pnpm check:governed-queue-guard` exit 0 (`132 cases pass`).
- `pnpm type-check:scripts` — exit 0.
- `node scripts/check-changeset-presence.mjs` — exit 0, verdict quoted literally: `✅ No source or published contract of a released package changed in this range, so no changeset is owed.` (`0 of them published source of a package the release covers`).
- `node scripts/check-governed-queue-guard.mjs --test` over all four changed paths — `✅ NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched.`
- Control-byte self-scan beyond the gate: `grep -naP` for the control range over all four files → no hits.
- **Lint, as a declared narrowing** (three readings, so this is a measurement and not a skipped run): ① the population comes from eslint's own config — `eslint.config.js`'s `files` globs are `**/*.{ts,tsx}` and narrower, with no markdown processor, so the two READMEs and the `.mjs` are outside eslint's population entirely and the linted half of this diff is one file; ② `--format json` counted `files linted: 2, errors: 0, warnings: 0`; ③ invariance — the config declares no `project` / `projectService`, so type-aware linting is off and this diff cannot move the verdict on any untouched file. The repo-wide `eslint . --no-inline-config` run belongs to CI.

## Out of scope, filed

#7984 — the same README's `badges` element documents 2 of the shipped 4 members (`colorClass` / `colorStyle` are missing). It sits inside a nested object literal, which this gate compares in neither direction by design, and the page's fences are not compiled either. Not touched here.

## Patch round (R45) — `Test (shard 2/4)` was red at `09f1d485`, and the fix is test-side

`Test (shard 2/4)` (run `34014605149`, job `101436113831`) failed at the previous head with two assertions in `scripts/__tests__/check-readme-exports.test.ts`, the file this PR already edits:

```
FAIL  the PARTIAL_EXCERPTS ledger ... > hides ONLY omissions, at every declaration the tree can judge — in ANY build state
      expect(off.census.excerptsNotJudged).toBe(0)     // :1020 — received 1

FAIL  repo state — assertions that hold in EVERY build state > finds no fabricated or wrong-path import where it can judge, and never passes silently where it cannot
      expect(result.census.excerptsNotJudged, "the ledger's suspension count is not the number of entries whose own package is unbuilt (none)").toBe(suspendable.length)   // :1084 — received 1
      build state: census.packagesUnbuilt = 36 of 40 packages
```

### Why it was green here and red there

The test shards run `pnpm install` then `pnpm test` and never build, so CI judges an **unbuilt** tree — `packages/plugin-gantt` among the 36 unbuilt packages. On an unbuilt package every declaration comes back `unjudgeable-type`, and the gate then **suspends** the shrink-only rule for whatever declared that declaration an excerpt, counting it in `census.excerptsNotJudged`. It counts **both** mechanisms there, deliberately and in one sentence of its own header: *"BOTH suppress `stale-omission` ... both are counted as `not judged` in the census"*.

The two assertions derived their expected value from the **ledger only** — `Object.keys(PARTIAL_EXCERPTS)` filtered by build state. That was complete while every excerpt in the tree was a ledger entry. This PR moved `GanttTask` to the in-README `PARTIAL_MARKER` (the disposition the ledger's own reason prescribed), which produced a marker-declared excerpt on an unbuilt package — a count neither assertion modelled: expected 0, gate reported 1. Verification for R44 ran on a BUILT tree, which is exactly the state in which this cannot fire.

### Which side owns the count

**The test.** The gate's behaviour is the one its header specifies, and the census already attributes the suspension correctly — so nothing in `scripts/check-readme-exports.mjs` changed in this round. **No judgement byte and no census byte moves.** The whole patch is one file.

`suspendedExcerpts(result, excerpts?)` returns the declared excerpts whose OWN package is unbuilt, under the same per-package rule the rest of these cases use since objectui#7460:

- ledger half — from the exported `PARTIAL_EXCERPTS` literal, as before;
- marker half — by re-reading each README of an unbuilt package through the gate's own exported grammar (`extractCodeBlocks` + `findPartialMarkers`), keyed `fence::Name` per README exactly as the gate keys its `excerptFor` map.

Derived from the README bytes, **never read back off the counter under test**, so both assertions still cross-check the gate against something that is not the gate's own count. The marker half deliberately does not re-parse the block to confirm the named type is declared inside it: a bound marker whose fence declares no such type is reported `stale-partial-marker` in every build state, and the same case asserts there are none of those.

The property both assertions exist for is **kept and extended, not relaxed**: an unbuilt package must be REPORTED and never silently skipped, and a new line now asserts that for the marker route too — every marker-declared excerpt on an unbuilt package must carry its own `unjudgeable-type` finding, the requirement the ledger half has always had. The `:1020` line is likewise no longer a hard-coded 0: `excerpts: {}` turns the ledger off and the ledger is the only half it can turn off, so that line was quietly asserting "this repository declares no excerpt by marker" under a title about the ledger.

### Verdict lines — both build states

| state | command | verdict |
|---|---|---|
| **UNBUILT**, before the fix (reproduction; 0 of 40 `dist/` present) | `pnpm exec vitest run scripts/__tests__/check-readme-exports.test.ts` | exit **1** — `Tests  2 failed \| 85 passed (87)`, byte-identical to the CI signature at `:1020` and `:1084` |
| **UNBUILT**, after the fix | same command | exit **0** — `Test Files  1 passed (1)`, `Tests  87 passed (87)` |
| **BUILT** (`turbo run build --filter=./packages/* --concurrency=2` → `Tasks: 39 successful, 39 total`), after the fix | same command | exit **0** — `Tests  87 passed (87)` |
| **BUILT**, the gate itself | `pnpm check:readme-exports` | exit **0** — `check-readme-exports: OK (... 58 key(s) compared both ways (0 fabricated, 0 stale omission(s); 1 excerpt(s) declared by marker, 0 by ledger, 0 not judged ...))` |

### Ablation

On the committed tree, unbuilt, one script with `trap ... EXIT INT TERM` and absolute paths: the test-side change alone reverted to the pre-fix blob (`git checkout 09f1d485 -- scripts/__tests__/check-readme-exports.test.ts`).

- mutation proven on disk: blob `ddae340e` vs HEAD `e64cd41b`; anchor `suspendedExcerpts` count `0` after the revert, the old `expect(off.census.excerptsNotJudged).toBe(0);` line back at count `1`;
- result: **exit 1**, `Tests  2 failed | 85 passed (87)` — the same two assertions, the predicted direction (turns red);
- restore: `git checkout HEAD -- path`, blob back to `e64cd41b`, `git diff HEAD` on that path **empty** and `git status --porcelain` empty.

### Gates, at `b520274`

`pnpm type-check:scripts` exit 0 · `node scripts/check-governed-queue-guard.mjs --test` over all four changed paths — `NOT GOVERNED — 4 path(s) checked against 5 governed surface(s); none matched` · `node scripts/check-changeset-presence.mjs` exit 0, `No source or published contract of a released package changed in this range, so no changeset is owed` · `pnpm check:control-bytes` exit 0 (`scanned 6421 tracked text file(s)`) plus a `grep -naP` self-scan of the changed file, no hits · `pnpm check:unreferenced-sources` exit 0.

Readers of the changed file (`git grep -l` over `scripts/ packages/ .github/`, unpiped, exit 0): `.github/workflows/readme-exports.yml`, which names it in prose as the pin that fails if a `paths` filter is ever added to that workflow — no code reads it. Readers of the module it imports: `scripts/__tests__/check-unreferenced-sources.test.ts` (run: `Tests 25 passed (25)`), plus prose references in `scripts/check-unreferenced-sources.mjs`, `scripts/check-doc-snippet-types.mjs` and `.github/workflows/ci.yml`.

Lint, as a declared narrowing with its three readings: ① the changed file is a `.ts` and therefore inside eslint's own population (`files` globs `**/*.{ts,tsx}`); ② `--format json` counted `files linted: 1, errors: 0, warnings: 0`; ③ invariance — the config declares no `project` / `projectService`, so type-aware linting is off and this diff cannot move the verdict on any untouched file. The repo-wide run belongs to CI.

One deviation from the dispatch's wording: it asked for the build to go through "the repo's shared verify lock". There is no such entry point in this repository (no `scripts/pm/os-verify-lock.sh`, nothing in `AGENTS.md`); the build was run in the foreground at `--concurrency=2` as written.


---
_Generated by [Claude Code](https://claude.ai/code/session_013uAaxiwgYDybsTNV9xwa1M)_

---
_Generated by [Claude Code](https://claude.ai/code)_