### PR TITLE
fix(build): let turbo own build order, delete the hand-listed prebuild hooks

### DIFF
--- a/.changeset/7292-turbo-owns-build-order.md
+++ b/.changeset/7292-turbo-owns-build-order.md
@@ -1,0 +1,26 @@
+---
+---
+
+Build orchestration only; no published behaviour changes.
+
+`@object-ui/components` and `@object-ui/site` each carried a hand-written
+`prebuild` (and, for components, a `pretest` pointing at it) that listed the
+workspace packages their build needed. That list is a second, unchecked copy of
+the package's own `dependencies`, and the components one had drifted: it named
+three packages while the closure turbo derives is seven, so
+`pnpm --filter @object-ui/components build` failed inside `@object-ui/react` on
+any tree where `@object-ui/i18n` and `@object-ui/data-objectstack` were not
+already built. Both hooks are deleted; turbo's `build.dependsOn: ["^build"]` is
+now the single source of build order, as it already was for every path CI takes.
+
+Trade-off, recorded here rather than left implicit: the bare per-package forms
+`pnpm --filter @object-ui/components build` and `pnpm --filter @object-ui/components test`
+no longer build their upstream packages first. They were never a supported entry
+point on a clean tree — that is the defect this removes, not a capability it
+takes away — but on a warm tree they used to be self-sufficient and now are not.
+The supported forms are `turbo run build --filter=@object-ui/components` and
+`turbo run test --filter=@object-ui/components` (turbo's `test` task also
+declares `dependsOn: ["^build"]`), plus the repo-root `pnpm test`. Every
+in-repo document and hint string that taught the direct form now teaches the
+turbo form, and the root `site:build` script goes through turbo, matching what
+CI already ran.

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -3,7 +3,6 @@
   "version": "3.1.0",
   "private": true,
   "scripts": {
-    "prebuild": "pnpm --filter @object-ui/example-schema-catalog build",
     "build": "next build",
     "lint": "eslint .",
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:integration": "vitest run --project dom --project dom-heavy",
   "test:dist": "turbo run test:dist --filter=@object-ui/components",
     "site:dev": "pnpm --filter @object-ui/site dev",
-    "site:build": "pnpm --filter @object-ui/site build",
+    "site:build": "turbo run build --filter=@object-ui/site",
     "site:start": "pnpm --filter @object-ui/site start",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/packages/components/README_SHADCN_SYNC.md
+++ b/packages/components/README_SHADCN_SYNC.md
@@ -134,9 +134,13 @@ If you don't have network access or prefer manual control:
 
 7. **Test the Component**
    ```bash
-   pnpm --filter @object-ui/components build
-   pnpm --filter @object-ui/components test
+   turbo run build --filter=@object-ui/components
+   turbo run test --filter=@object-ui/components
    ```
+
+   Go through turbo, not `pnpm --filter @object-ui/components build`: turbo
+   derives this package's build closure from its `dependencies`, and on a tree
+   where those are not built yet the bare per-package build fails.
 
 ## Using Official Shadcn CLI
 
@@ -241,13 +245,14 @@ className="... dark:bg-background/95 dark:backdrop-blur-sm"
 
 ```bash
 # Type check
-pnpm --filter @object-ui/components type-check
+turbo run type-check --filter=@object-ui/components
 
-# Build
-pnpm --filter @object-ui/components build
+# Build (turbo builds the upstream packages this one needs; a bare
+# `pnpm --filter @object-ui/components build` does not)
+turbo run build --filter=@object-ui/components
 
 # Run tests
-pnpm --filter @object-ui/components test
+turbo run test --filter=@object-ui/components
 
 # Integration test
 pnpm test

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -27,8 +27,6 @@
   },
   "scripts": {
     "build": "vite build && node scripts/build-css.mjs",
-    "prebuild": "pnpm --filter @object-ui/types build && pnpm --filter @object-ui/core build && pnpm --filter @object-ui/react build",
-    "pretest": "pnpm run prebuild",
     "test": "vitest run --root ../.. packages/components/",
     "test:dist": "OBJECTUI_DIST_PINS=1 vitest run --root ../.. --config vitest.config.mts --project dist",
     "type-check": "tsc --noEmit && tsc -p tsconfig.test.json",

--- a/packages/components/src/__tests__/page-header-action-ids.dist.spec.tsx
+++ b/packages/components/src/__tests__/page-header-action-ids.dist.spec.tsx
@@ -184,7 +184,8 @@ describe('page:header — BUILT artifact (objectui#7183, re-derived from PR obje
         'meant to be reached through `pnpm test:dist`, whose turbo task carries ' +
         '`dependsOn: ["build"]` for the package under test and therefore builds it first. ' +
         'Running the project directly builds nothing — build it yourself with ' +
-        '`pnpm --filter @object-ui/components build`.',
+        '`turbo run build --filter=@object-ui/components`, which orders the packages ' +
+        'this one is built from.',
     ).toBe(true);
   });
 

--- a/scripts/__tests__/helpers/build-program.ts
+++ b/scripts/__tests__/helpers/build-program.ts
@@ -90,13 +90,17 @@ import { rel, repoRoot, type WorkspacePackage } from './turbo-inputs';
  *    plugins). Declared explicitly, and empty, so the shared walker's
  *    key-directed designation rule is visibly a decision here.
  *  - A `pnpm --filter <pkg> build` SEGMENT IS A TASK-GRAPH FACT, NOT AN INPUTS
- *    FACT. Two packages have a `prebuild` that builds another workspace package
- *    (pnpm runs `prebuild` as part of `pnpm run build`, so turbo runs it too).
- *    The right answer to "this package's build needs that package's dist" is
- *    turbo's `dependsOn: ["^build"]`, not a `$TURBO_ROOT$` glob over another
+ *    FACT. The right answer to "this package's build needs that package's dist"
+ *    is turbo's `dependsOn: ["^build"]`, not a `$TURBO_ROOT$` glob over another
  *    package's source. So delegations are collected and returned rather than
- *    walked, and `../turbo-build-inputs.test.ts` asserts each delegated package
- *    is a DECLARED dependency — which is what makes `^build` order it.
+ *    walked. NO PACKAGE DELEGATES TODAY (objectui#7292 deleted the last two:
+ *    `packages/components` hand-listed types/core/react in a `prebuild` while
+ *    its real closure was seven packages, and `apps/site` named the schema
+ *    catalog it already declares as a dependency), and
+ *    `../turbo-build-inputs.test.ts` now RATCHETS that to zero rather than
+ *    policing the survivors: a hand-written list of a package's own build
+ *    closure is a second, unchecked copy of its `dependencies`, and the
+ *    collected `delegations` are what makes re-introducing one fail loudly.
  */
 
 /** Vite's config candidates, in its own precedence order. */

--- a/scripts/__tests__/turbo-build-inputs.test.ts
+++ b/scripts/__tests__/turbo-build-inputs.test.ts
@@ -172,38 +172,34 @@ describe('turbo `build` inputs cover every out-of-package file (objectui#4185)',
   /**
    * A `pnpm --filter <pkg> build` segment inside a `prebuild` is a task-GRAPH
    * fact, not an inputs fact: the right answer to "this build needs that
-   * package's dist" is `dependsOn: ["^build"]`, which turbo already declares —
-   * but `^build` only orders DECLARED dependencies. Two packages delegate this
-   * way (`apps/site` to `@object-ui/example-schema-catalog`, `packages/components`
-   * to types/core/react), and the derivation deliberately does not walk into
-   * them. That narrowing is sound only while each delegated package is a real
-   * dependency, so assert it rather than assume it.
+   * package's dist" is `dependsOn: ["^build"]`, which turbo already declares
+   * and derives from the dependency graph. A hand-written chain is a SECOND,
+   * unchecked copy of the package's own `dependencies` — and it drifts:
+   * objectui#7292 measured `packages/components`' three-package `prebuild`
+   * against the seven-package closure turbo computes, and a clean worktree's
+   * `pnpm --filter @object-ui/components build` died inside `@object-ui/react`
+   * on the two packages the list had never gained.
+   *
+   * The predecessor of this assertion policed the survivors (each delegated
+   * package must be a declared dependency). That is the weaker guard: a
+   * delegation whose target IS declared still duplicates the graph, still
+   * drifts, and still fails only on the trees nobody looks at. So this ratchets
+   * the class to zero instead. The derivation still COLLECTS delegations —
+   * that is what makes re-introducing one fail here rather than silently widen
+   * an unswept build program.
    */
-  it('every delegated build target is a declared dependency', () => {
+  it('no build lifecycle script delegates to another package with `pnpm --filter`', () => {
     const delegating = DERIVED.filter((pkg) => pkg.program.delegations.length > 0);
     expect(
-      delegating.map((pkg) => pkg.name),
-      'no package delegates a build any more — drop this assertion with the narrowing it ' +
-        'defends, in helpers/build-program.ts',
-    ).not.toHaveLength(0);
-
-    for (const pkg of delegating) {
-      const manifest = JSON.parse(
-        fs.readFileSync(path.join(pkg.dir, 'package.json'), 'utf8'),
-      ) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> };
-      const declared = new Set([
-        ...Object.keys(manifest.dependencies ?? {}),
-        ...Object.keys(manifest.devDependencies ?? {}),
-      ]);
-      const undeclared = pkg.program.delegations.filter((name) => !declared.has(name));
-      expect(
-        undeclared,
-        `${pkg.name} builds ${undeclared.join(', ')} through a \`pnpm --filter\` lifecycle ` +
-          `script without declaring ${undeclared.length === 1 ? 'it' : 'them'} as a dependency, ` +
-          `so turbo's \`dependsOn: ["^build"]\` does not order the two. Declare the dependency, ` +
-          `or teach build-program.ts to walk into the delegated package's program.`,
-      ).toEqual([]);
-    }
+      delegating.map((pkg) => `${pkg.name} -> ${pkg.program.delegations.join(', ')}`),
+      'a build lifecycle script builds another workspace package through `pnpm --filter`. ' +
+        "That hand-writes a copy of this package's build closure next to the `dependencies` " +
+        'turbo already derives it from, and the two drift silently — the copy is only ever ' +
+        'exercised on a tree where the missing packages happen to be built already. Declare ' +
+        "the dependency in package.json and let turbo's `dependsOn: [\"^build\"]` order it; " +
+        'build the package with `turbo run build --filter=<pkg>`, not `pnpm --filter <pkg> ' +
+        'build`.',
+    ).toEqual([]);
   });
 
   /**

--- a/scripts/build-plugin-stylesheet.mjs
+++ b/scripts/build-plugin-stylesheet.mjs
@@ -284,7 +284,7 @@ export function createPluginStylesheetBuilder({ postcss, tailwind }) {
           "correctly via the `build` task's `dependsOn: [\"^build\"]`; a bare single-package",
           'build does not.',
           '',
-          '  pnpm --filter @object-ui/components build',
+          '  turbo run build --filter=@object-ui/components',
         ].join('\n'),
       );
     }

--- a/scripts/shadcn-sync.js
+++ b/scripts/shadcn-sync.js
@@ -912,7 +912,7 @@ async function updateAllComponents(options = {}) {
     log('2. Fix or roll back — the type-check above failed.', 'dim');
   } else {
     log('2. Test the components: pnpm test', 'dim');
-    log('3. Build the package: pnpm --filter @object-ui/components build', 'dim');
+    log('3. Build the package: turbo run build --filter=@object-ui/components', 'dim');
   }
 }
 


### PR DESCRIPTION
Fixes #7292

Triage picked option 1. The two hand-written `pre*` hooks are deleted and turbo's dependency graph is now the single source of build order.

## What changed

| File | Change |
|---|---|
| `packages/components/package.json` | deleted `prebuild` (types, core, react) and `pretest` (which pointed at it) |
| `apps/site/package.json` | deleted `prebuild` (the schema catalog) |
| `package.json` | `site:build` now `turbo run build --filter=@object-ui/site`, matching what `ci.yml` already ran |
| `packages/components/README_SHADCN_SYNC.md` | the two blocks teaching the direct form now teach the turbo form |
| `scripts/build-plugin-stylesheet.mjs`, `scripts/shadcn-sync.js`, `packages/components/src/__tests__/page-header-action-ids.dist.spec.tsx` | remedy strings pointed at the direct build; now point at the turbo build |
| `scripts/__tests__/turbo-build-inputs.test.ts`, `scripts/__tests__/helpers/build-program.ts` | the delegation assertion is ratcheted to zero instead of deleted -- see below |
| `.changeset/7292-turbo-owns-build-order.md` | empty frontmatter; the trade-off is recorded there |

## The defect, and the reading behind the fix

The card's reproduction was run by its author on one tree, before and after, with a live control. **I did not re-run it** -- see "What is NOT verified" -- so it is quoted, not re-measured:

```
$ pnpm --filter @object-ui/components build      # fresh worktree, nothing built yet
src/hooks/useActionTextLocalizer.ts(58,69): error TS2307: Cannot find module '@object-ui/i18n' ...
src/context/AppShellContext.tsx(2,41): error TS2307: Cannot find module '@object-ui/data-objectstack' ...
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @object-ui/react@17.6.0 build

$ turbo run build --filter=@object-ui/components
Tasks:    9 successful, 9 total
```

The hand-written chain names three packages; the closure turbo derives is seven (`core`, `data-objectstack`, `i18n`, `react`, `react-runtime`, `sdui-parser`, `types`). A hand-written chain is a second, unchecked copy of the package's own `dependencies`, and this one had drifted.

**`turbo.json` reading (measured on this branch's base, `3702f92a9`):**

```jsonc
"build": { "dependsOn": ["^build"], ... }
"test":  { "dependsOn": ["^build"], ... }
"test:dist": { "dependsOn": ["build"], ... }
```

Both `build` and `test` depend on `^build`, so turbo orders the upstream builds for both tasks from the declared dependency graph. That is what makes the hooks redundant rather than load-bearing -- and it is also why deleting `pretest` does not break `turbo run test`.

## Usage change (the one thing reviewers should read twice)

`pretest` is what let `pnpm --filter @object-ui/components test` build its upstream packages first. After this PR the bare per-package forms no longer do that:

- supported: `turbo run build --filter=@object-ui/components`, `turbo run test --filter=@object-ui/components`, and the repo-root `pnpm test`
- no longer self-sufficient on a cold tree: `pnpm --filter @object-ui/components build`, `pnpm --filter @object-ui/components test`

**Honest statement of the residual state (the card's A4):** after this deletion `pnpm --filter @object-ui/components build` on a clean tree still fails -- now on this package's own upstream `dist` rather than inside `@object-ui/react`. That is not a regression this PR introduces; the direct form was never a supported entry point on a cold tree, and the deleted hook was a partial, drifting imitation of the ordering turbo already does correctly. The remedy strings and docs now say so.

Every in-repo site that taught the direct form was found with a wider grep than the one on the card (the card's narrower sweep over `AGENTS.md` / `README.md` / `content/docs/` / `.github/` legitimately returned zero -- none of the hits live there):

```
package.json:28                        site:build   -> rewritten to the turbo form
packages/components/README_SHADCN_SYNC.md:137,138,247,250 -> rewritten
scripts/build-plugin-stylesheet.mjs:287                   -> rewritten
scripts/shadcn-sync.js:915                                -> rewritten
packages/components/src/__tests__/page-header-action-ids.dist.spec.tsx:187 -> rewritten
.claude/hooks/guard-tree-enum.selftest.sh:96              -> NOT touched (governed surface, and it is
                                                             an allow-list fixture, not a teaching site)
.changeset/7799-cwd-rooted-package-tests.md               -> NOT touched (historical record)
packages/components/src/__tests__/browser-process-shim-scope.test.ts:81,
packages/components/src/renderers/__tests__/container-declaration-ratchet.test.tsx:110
                                                          -> NOT touched: both are comments about which
                                                             ENTRY POINTS run the file, and both stay true --
                                                             `pnpm --filter @object-ui/components test` still
                                                             runs, it just no longer pre-builds
```

## `apps/site`: the dependency edge exists, so the hook goes

Judged by the same rule the card sets for it. The measurement is the manifest itself:

```
apps/site/package.json:18   "@object-ui/example-schema-catalog": "workspace:*",   <- declared dependency
```

The edge is **present**, so turbo's `build.dependsOn: ["^build"]` already orders `@object-ui/example-schema-catalog` before `@object-ui/site`. This is the "delete it" case, not the "the edge is missing, fix the manifest" case -- no dependency was added, and `turbo.json` is untouched.

One consequence had to be handled rather than assumed: `ci.yml:1545` builds the site as `pnpm turbo run build --filter='@object-ui/site'` (turbo form, unaffected), but the root `site:build` script used the direct form and would have silently stopped building the catalog. It is rewritten to the turbo form.

## Why the delegation guard is ratcheted, not deleted

`scripts/__tests__/turbo-build-inputs.test.ts` carried a liveness pin -- "no package delegates a build any more" -- whose failure message instructs deleting the assertion along with the narrowing it defends. Deleting both hooks trips exactly that pin.

I did not delete it. The predecessor policed the *survivors* (each delegated package must be a declared dependency), which is the weaker guard: a delegation whose target IS declared still duplicates the graph, still drifts, and still fails only on the trees nobody looks at -- `apps/site` was precisely that shape, declared target and all. The assertion is inverted into a ratchet on the whole class ("no build lifecycle script delegates to another package with `pnpm --filter`"), and `helpers/build-program.ts` keeps collecting delegations unchanged, so re-introducing one fails loudly here instead of silently widening an unswept build program. Under the decision frame this is the "contract tightening beats consumer leniency / declared = enforced" axis, and it adds no new gate, no new file and no new verification surface -- it replaces one assertion in a test that already ran.

## Verified (R45) -- every leg the R44 report left NOT RUN has now been run

Verification round on this exact head (`16aed838e`), no code change needed: the branch is byte-identical to what R44 pushed, and `git diff HEAD` is empty after every probe. Dedicated worktree, `pnpm install --frozen-lockfile` EXIT=0. "Cold tree" below means measured: 0 `packages/*/dist` + `apps/*/dist`, 0 `tsconfig.tsbuildinfo`, no turbo cache directory. Heavy runs went through this container's shared verify lock (its `VERDICT command-exit` line is the exit code, not a bare status variable); every exit code was captured by redirecting to a file first, never through a pipe.

| Leg | Command | Verdict line |
|---|---|---|
| 1 · the ratchet, first | `pnpm exec vitest run scripts/__tests__/turbo-build-inputs.test.ts` | EXIT=0 -- `Test Files  1 passed (1)` / `Tests  46 passed (46)`; the verbose reporter names the rewritten assertion as passing: `no build lifecycle script delegates to another package with pnpm --filter` |
| 2 · probe, restore the hook | re-add the deleted `prebuild` to `packages/components/package.json`, re-run leg 1 | RED as predicted, EXIT=1 -- `Tests` reads 1 failed, 45 passed, 46 total, received `["@object-ui/components -> @object-ui/core, @object-ui/react, @object-ui/types"]` against expected `[]`. Mutation proven on disk (`git hash-object` moved 12055578 to e6a070ba, HEAD blob 12055578); restore proven (`git checkout HEAD -- path`, hash back to 12055578, `git diff HEAD` 0 lines) |
| 3a · cold build, components | `turbo run build --filter=@object-ui/components --concurrency=2` | EXIT=0 -- `Tasks:    8 successful, 8 total` / `Cached:    0 cached, 8 total`. Zero cache hits, so this is an executed ordering, not a replay: the seven upstream packages plus this one |
| 3b · cold build, site | `turbo run build --filter=@object-ui/site --concurrency=2` | EXIT=0 -- `Tasks:   30 successful, 30 total` / `Cached:    8 cached, 30 total`. turbo reports `Remote caching disabled, using shared worktree cache`, and the 8 hits are leg 3a's own outputs in this same tree, so leg 3c re-ran it forced |
| 3c · cold build, site, forced | same plus `--force`, on a re-wiped cold tree | EXIT=0 -- `Tasks:   30 successful, 30 total` / `Cached:    0 cached, 30 total`, with `@object-ui/example-schema-catalog:build: cache bypass, force executing` at line 1032 and `@object-ui/site:build` at line 1037. This is the ordering claim with no cache in it |
| 3d · the rewritten root script, verbatim | `pnpm site:build` | EXIT=0 -- `Tasks:   30 successful, 30 total` / `Cached:   30 cached, 30 total` (warm tree). A3 holds: the turbo form still puts the catalog ahead of the site |
| 4 · probe, the edge orders the catalog | `turbo run build --filter=@object-ui/site --dry=json`, before and after deleting the `workspace:*` edge from `apps/site/package.json` | Before: 31 tasks, `@object-ui/example-schema-catalog#build` present at index 3 against site at index 28, and listed verbatim in `@object-ui/site#build`'s own `dependencies`. After deleting the edge: 30 tasks, catalog **absent** from both the task list and site's dependencies. So the manifest edge is what orders it, never the deleted hook. Restore proven (hash back to 161ab80b, `git diff HEAD` 0 lines) |
| 5 · the card's A1 reproduction, on this branch | `pnpm --filter @object-ui/components build`, cold tree | STILL FAILS, EXIT=1 -- `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @object-ui/components@17.6.0 build`. The PR body's residual-state claim is confirmed and sharpened: the failure has MOVED. Before the change it died inside `@object-ui/react`'s `tsc`; now it dies in this package's own `vite build`, on its own upstream dist -- 253 TS2307 lines naming `@object-ui/core` (100), `@object-ui/types` (83), `@object-ui/react` (36), `@object-ui/i18n` (25), `@object-ui/types/form` (4), `@object-ui/sdui-parser` (3), `@object-ui/react-runtime` (2). Not a regression this PR introduces; the direct form was never self-sufficient on a cold tree |
| 6 · the dist pin, through its real runner | `pnpm test:dist` | EXIT=0 -- `Tasks:    9 successful, 9 total`; `Test Files  1 passed (1)` / `Tests  3 passed (3)` for `page-header-action-ids.dist.spec.tsx`. Run through `test:dist` and not as a bare vitest path: the `.dist.spec.tsx` suffix is collected ONLY by the `dist` project, so a bare path run would have matched zero tests and read as green |
| 6 · the whole `scripts` suite | `pnpm exec vitest run scripts/__tests__/` | EXIT=0 -- `Test Files  107 passed (107)` / `Tests  3240 passed (3240)`. Owed because the diff edits two files in it; `helpers/build-program.ts` has exactly one reader, `turbo-build-inputs.test.ts` |
| 7 · readers | `git grep -n` for the two hook names, `prebuild` and `pretest`, excluding `CHANGELOG.md` and `pnpm-lock.yaml` | 6 hits, none of them a manifest: the changeset prose, three comment lines citing this card, and the two lines in `helpers/build-program.ts` that still COLLECT `prebuild` -- which is precisely what makes leg 2 go red |

Gates, each quoting its own verdict line:

```
pnpm lint:root                                   EXIT=0   32 problems (0 errors, 32 warnings)
turbo run lint --filter=components --filter=site EXIT=0   Tasks: 3 successful, 3 total
                                                          (site 7 warnings, components 925 warnings, 0 errors,
                                                           none in any file this PR touches)
pnpm type-check:scripts                          EXIT=0   tsc -p tsconfig.scripts.json
  MEASURED, not merely run: `--listFiles` shows 829 files, including
  scripts/__tests__/helpers/build-program.ts and scripts/__tests__/turbo-build-inputs.test.ts
node scripts/check-changeset-presence.mjs        EXIT=0   1 source file(s) of 1 released package(s) changed,
                                                          and this change declares 1 changeset(s)
node scripts/check-changeset-no-major.mjs        EXIT=0   No changeset declares a `major` bump.
node scripts/check-changeset-fixed.mjs           EXIT=0   All workspace packages are in the changeset fixed group.
node scripts/check-control-bytes.mjs             EXIT=0   OK (scanned 6428 tracked text file(s); skipped 85 binary)
node scripts/check-doc-links.mjs                 EXIT=0   Links are valid across 17 scan roots.
node scripts/check-governed-queue-guard.mjs --test (all 10 changed paths)   EXIT=0
                                                          NOT GOVERNED -- 10 path(s) checked against
                                                          5 governed surface(s); none matched.
```

Two counts moved since the card was written, both benign and both explained rather than waved through:

- The card quoted `Tasks: 9 successful, 9 total` for the components build; on this base it is **8**. The closure is unchanged at seven upstream packages plus the package itself; the card's run was on an older base.
- The site dry run lists **31** tasks where the real run executes **30**. The extra one is `@object-ui/test-support#build`, whose `command` in the dry JSON is the literal string NONEXISTENT -- the package declares no `build` script, so turbo lists it in the graph and executes nothing.

Open questions from the R44 report, decided on the measurement: **question 1 -- A stands.** The ratchet is green on this branch (leg 1) and red, naming the offending package, the moment a hook comes back (leg 2). It is neither weakened nor deleted. **Question 2 -- A stands**, the extra files are kept; leg 3d is the measurement that says the root `site:build` rewrite was forced rather than opportunistic.

Session attribution as prose, because the footer block does not survive an edit: created by `https://claude.ai/code/session_013uAaxiwgYDybsTNV9xwa1M`, verified by `https://claude.ai/code/session_01MM7kaS4dPpYHV5BsMyu4tQ`.


## Census re-count on this base

Re-counted on `3702f92a9`: 42 `packages/*/package.json` + `apps/*/package.json`. Hand-written `pre*` build/test hooks: exactly the two this PR deletes. (`packages/runner`, `apps/console` and the two console examples declare `preview` / `prepublishOnly`, and `apps/site` declares `postinstall: fumadocs-mdx` -- none of those is a build-order copy, and none is touched.)

## Out-of-scope finding, not fixed here

`scripts/setup.sh:55-70` is the same defect class outside the manifest census: it hand-lists `types -> core -> react -> components -> fields -> layout` and, under `set -e`, its `pnpm --filter @object-ui/react build` step fails on a clean checkout for the identical TS2307 reason, before this PR and after it. This PR does not change that file's behaviour (it already built types/core/react itself, so the deleted `prebuild` was redundant there). Separately, its last step calls `pnpm test:root`, which the root `package.json` does not declare. Both left untouched and reported for triage; #7292 is the only card this PR closes.


R45 update: both findings are now filed, unassigned, as objectui#7987 -- the hand-listed six-package chain and the undeclared `pnpm test:root` call. Re-measured on this branch and unchanged by it: under `set -e` the script dies at its `pnpm --filter @object-ui/react build` step, three lines before it ever reaches `pnpm --filter @object-ui/components build`, so the deleted hook was never what carried it.


---
_Generated by [Claude Code](https://claude.ai/code)_