### PR TITLE
test(network-escape): serve batch 1's five probes from doubles (ledger 21 → 16)

### DIFF
--- a/.changeset/network-escape-batch1.md
+++ b/.changeset/network-escape-batch1.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: the five network-escape files in batch 1 of objectui#7307 now serve their `/api/v1/security/explain` and `/api/v1/meta/object/<name>` probes from a recording double instead of a real socket, and their lines leave `KNOWN_ESCAPES` and `PINNED_LEDGER` together. No published behaviour changes — no product source is touched.

--- a/examples/schema-catalog/test/catalog-gallery-render.test.tsx
+++ b/examples/schema-catalog/test/catalog-gallery-render.test.tsx
@@ -125,8 +125,8 @@
  * entries render `role="alert"` because that is what an Alert IS — the
  * assertion is correct for a dashboard tile and wrong for the corpus.
  */
-import { describe, it, expect, afterAll } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
 import '@object-ui/components';
 // Mirrors apps/site/app/components/registerCatalogBlocks.ts, in its order.
 import '@object-ui/plugin-dashboard';
@@ -516,6 +516,95 @@ function authoredTitles(node: unknown, acc: string[] = []): string[] {
 
 const entries = allExamples();
 const occurrences = (haystack: string, needle: string) => haystack.split(needle).length - 1;
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point:
+ *
+ *   the grid-bearing tiles (`object-grid`, and `object-view` around it)
+ *     -> ObjectGrid             packages/plugin-grid/src/ObjectGrid.tsx:1407
+ *       -> useRecordCrudVerdicts  packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts:199
+ *         -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *           POST /api/v1/security/explain  (batched, `recordIds` per page)
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The gallery harness below supplies a `dataSource` on `SchemaRendererContext` but no `apiFetch`, so the fallback is taken. The read is best-effort (a network or parse failure leaves the verdict map empty — fail open), which is why the sweep stayed green while 18 requests per run always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on and
+ * `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx`
+ * carries. Deliberately NOT a blanket network stub: it records every URL it is
+ * handed and `afterEach` fails on any URL that is not the explain route, so an
+ * escape to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two hooks read (ADR-0090 D6 /
+ * ADR-0095 C2) — `{ record: { visible } }` for a single `recordId`,
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, and the ONLY consumer of the batched lookup is
+ * `resolveRowRecordCrudAffordance`, whose rule is `recordVerdict !== false` —
+ * so `true` and the absent verdict the failing request produced are the same
+ * value at every read site. This file asserts that each tile drew something other than a diagnostic panel; no tile's DOM is derived from the verdict.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(() => {
+  installExplainDouble();
+});
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('objectui#4616 — every catalog entry renders in the docs gallery', () => {
   /**

--- a/packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx
@@ -114,12 +114,95 @@ function readPanelWidth(): string {
   return panel!.style.maxWidth;
 }
 
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point:
+ *
+ *   RecordDetailDrawer (the drawer this file opens)
+ *     -> useRecordEditable   packages/plugin-detail/src/useRecordEditable.ts:75
+ *       -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *         POST /api/v1/security/explain
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the record editable — fail open), which is why the three cases below stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on and
+ * `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx`
+ * carries. Deliberately NOT a blanket network stub: it records every URL it is
+ * handed and `afterEach` fails on any URL that is not the explain route, so an
+ * escape to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two hooks read (ADR-0090 D6 /
+ * ADR-0095 C2) — `{ record: { visible } }` for a single `recordId`,
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, and the ONLY consumer of the batched lookup is
+ * `resolveRowRecordCrudAffordance`, whose rule is `recordVerdict !== false` —
+ * so `true` and the absent verdict the failing request produced are the same
+ * value at every read site. The drawer's width — everything this file asserts — is not derived from the verdict at all.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
 describe('calendar drawer width with no declared `navigation` (objectui#6303)', () => {
   beforeEach(() => {
     drawerProps = null;
     try { window.localStorage.clear(); } catch { /* ignore */ }
+    installExplainDouble();
   });
-  afterEach(() => cleanup());
+  afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+  });
 
   it('half 1: the calendar injects no width of its own (so the drawer default applies)', async () => {
     await openDrawer();

--- a/packages/plugin-charts/src/ObjectChart.heightChain.test.tsx
+++ b/packages/plugin-charts/src/ObjectChart.heightChain.test.tsx
@@ -22,7 +22,7 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/react';
 
 vi.mock('./ChartRenderer', () => ({
@@ -31,8 +31,80 @@ vi.mock('./ChartRenderer', () => ({
 
 import { ObjectChart } from './ObjectChart';
 
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/meta/object/task` escape, served here.
+ *
+ * Nothing below asks for metadata, yet every run opened a REAL TCP connection
+ * to `http://localhost:3000`. Traced with a stack probe on the network-escape
+ * guard's attribution point:
+ *
+ *   ObjectChart (option-colour effect)   packages/plugin-charts/src/ObjectChart.tsx:390
+ *     -> `const doFetch = apiFetch ?? fetch`        <- the escape
+ *       -> loadObjectSchema              ObjectChart.tsx:411
+ *         -> loadDimensionFieldMeta      packages/core/src/utils/chart-series.ts
+ *           GET /api/v1/meta/object/task
+ *
+ * That effect reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no `SchemaRendererProvider` in this tree,
+ * degrades to the GLOBAL `fetch` by design — a standalone embed must keep
+ * rendering rather than crash. Under happy-dom that global is a real HTTP
+ * client and the document URL defaults to `http://localhost:3000`, so the
+ * relative path resolved to a live request. The read is best-effort (every
+ * failure leaves `optionMeta` null and the chart on the theme palette), which
+ * is why the assertion below stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on and
+ * `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx`
+ * carries. Deliberately NOT a blanket network stub: it records every URL it is
+ * handed and `afterEach` fails on any URL that is not the metadata route, so an
+ * escape to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * The served document declares no fields, so nothing resolves and `optionMeta`
+ * settles null — the state the failing request already produced. The height
+ * assertion cannot see it either way: `ChartRenderer` is mocked to null.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const META_OBJECT_ROUTE = /^\/api\/v1\/meta\/object\/(.+)$/;
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let metaCalls: string[] = [];
+
+/** Serve `/api/v1/meta/object/<name>` with a field-less doc; record everything. */
+function installMetaObjectDouble() {
+  metaCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      metaCalls.push(url);
+      const m = META_OBJECT_ROUTE.exec(url);
+      if (!m) return { ok: false, status: 404, json: async () => ({}) };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ item: { name: decodeURIComponent(m[1]), fields: {} } }),
+      };
+    }),
+  );
+}
+
+beforeEach(() => {
+  installMetaObjectDouble();
+});
+
 afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the effect's best-effort `catch`.
+  expect(metaCalls.filter((url) => !META_OBJECT_ROUTE.test(url))).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a metadata effect settling in that window
+  // escapes again (objectui#7439).
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe('ObjectChart wrapper height chain (objectui#5451)', () => {

--- a/packages/plugin-grid/src/__tests__/bulkDeleteVisibleWhen.test.tsx
+++ b/packages/plugin-grid/src/__tests__/bulkDeleteVisibleWhen.test.tsx
@@ -155,12 +155,93 @@ async function renderAndSelect(
   return harness;
 }
 
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point:
+ *
+ *   ObjectGrid                packages/plugin-grid/src/ObjectGrid.tsx:1407
+ *     -> useRecordCrudVerdicts  packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts:199
+ *       -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *         POST /api/v1/security/explain  (batched, `recordIds` per page)
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the verdict map empty — fail open), which is why the four cases below stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on and
+ * `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx`
+ * carries. Deliberately NOT a blanket network stub: it records every URL it is
+ * handed and `afterEach` fails on any URL that is not the explain route, so an
+ * escape to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two hooks read (ADR-0090 D6 /
+ * ADR-0095 C2) — `{ record: { visible } }` for a single `recordId`,
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, and the ONLY consumer of the batched lookup is
+ * `resolveRowRecordCrudAffordance`, whose rule is `recordVerdict !== false` —
+ * so `true` and the absent verdict the failing request produced are the same
+ * value at every read site. The subject of this file is the OBJECT's declared `userActions.delete.visibleWhen` predicate, a layer above the record verdict and evaluated without it.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  installExplainDouble();
 });
 
 afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe('selection-bar Delete vs `userActions.delete.visibleWhen` (objectui#4420)', () => {

--- a/packages/plugin-view/src/__tests__/ObjectView.namedViewSortArity.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.namedViewSortArity.test.tsx
@@ -45,8 +45,8 @@
  * read green.
  */
 
-import { describe, it, expect, vi, beforeAll } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
 
@@ -119,6 +119,94 @@ const headerCell = (container: HTMLElement, label: string) =>
   Array.from(container.querySelectorAll('thead th')).find((th) =>
     th.textContent?.includes(label),
   ) as HTMLElement;
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point:
+ *
+ *   ObjectView -> ObjectGrid  packages/plugin-grid/src/ObjectGrid.tsx:1407
+ *     -> useRecordCrudVerdicts  packages/plugin-grid/src/hooks/useRecordCrudVerdicts.ts:199
+ *       -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *         POST /api/v1/security/explain  (batched, `recordIds` per page)
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the verdict map empty — fail open), which is why the four cases below stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on and
+ * `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx`
+ * carries. Deliberately NOT a blanket network stub: it records every URL it is
+ * handed and `afterEach` fails on any URL that is not the explain route, so an
+ * escape to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two hooks read (ADR-0090 D6 /
+ * ADR-0095 C2) — `{ record: { visible } }` for a single `recordId`,
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, and the ONLY consumer of the batched lookup is
+ * `resolveRowRecordCrudAffordance`, whose rule is `recordVerdict !== false` —
+ * so `true` and the absent verdict the failing request produced are the same
+ * value at every read site. The sort this file measures reaches the grid through the view's `listViews` entry and leaves as `$orderby`; no verdict touches that path.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(() => {
+  installExplainDouble();
+});
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe("objectui#5270 — a named view's sort reaches the grid", () => {
   it('draws the declared sort indicator before anyone clicks', async () => {

--- a/scripts/__tests__/network-escape-ledger.test.ts
+++ b/scripts/__tests__/network-escape-ledger.test.ts
@@ -31,7 +31,7 @@ import { KNOWN_ESCAPES } from '../../vitest.setup.network-escape-guard';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
 /**
- * The 21 files measured escaping on `67dadd6`, pinned verbatim.
+ * What remains of the 21 files measured escaping on `67dadd6`, pinned verbatim.
  *
  * Provenance: a full sweep of every Vitest project (`dom` all 8 shards,
  * `dom-heavy`, `unit`, `apps/console`) with an attribution ledger wrapping
@@ -39,7 +39,6 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * and must be done in lockstep with `KNOWN_ESCAPES`.
  */
 const PINNED_LEDGER: readonly string[] = [
-  'examples/schema-catalog/test/catalog-gallery-render.test.tsx',
   'packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx',
   'packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx',
   'packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx',
@@ -48,18 +47,14 @@ const PINNED_LEDGER: readonly string[] = [
   'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.specKeys.test.tsx',
   'packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx',
   'packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx',
-  'packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx',
-  'packages/plugin-charts/src/ObjectChart.heightChain.test.tsx',
   'packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx',
   'packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx',
   'packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx',
   'packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx',
   'packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx',
-  'packages/plugin-grid/src/__tests__/bulkDeleteVisibleWhen.test.tsx',
   'packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx',
   'packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx',
   'packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx',
-  'packages/plugin-view/src/__tests__/ObjectView.namedViewSortArity.test.tsx',
 ];
 
 describe('network-escape ledger (objectui#6640) is shrink-only', () => {

--- a/vitest.setup.network-escape-guard.ts
+++ b/vitest.setup.network-escape-guard.ts
@@ -47,7 +47,8 @@
  *
  * ## The burn-down list
  *
- * `KNOWN_ESCAPES` is the 21 files measured on `67dadd6`. They are not excused:
+ * `KNOWN_ESCAPES` is what REMAINS of the 21 files measured on `67dadd6`
+ * (objectui#7307 is burning them down batch by batch). They are not excused:
  * each still emits, and now prints an ATTRIBUTED line naming itself, so a
  * reader who meets a bare stack in a truncated run can tell whose it is. The
  * list may only SHRINK — enforced mechanically by the reconcile pin in
@@ -108,12 +109,10 @@ function writeStderr(message: string): void {
 const ESCAPE_ORIGIN = /^https?:\/\/(?:127\.0\.0\.1|localhost):3000(?:\/|$)/;
 
 /**
- * Files measured escaping on 67dadd6 (objectui#6640). ONLY SHRINKS.
- * The comment on each line is the endpoint it reached.
+ * What remains of the files measured escaping on 67dadd6 (objectui#6640).
+ * ONLY SHRINKS. The comment on each line is the endpoint it reached.
  */
 export const KNOWN_ESCAPES: ReadonlySet<string> = new Set([
-  // /api/v1/security/explain
-  'examples/schema-catalog/test/catalog-gallery-render.test.tsx',
   // /api/v1/meta/_drafts
   'packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx',
   // /api/v1/meta/_drafts
@@ -131,10 +130,6 @@ export const KNOWN_ESCAPES: ReadonlySet<string> = new Set([
   // /api/v1/ai/conversations
   'packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx',
   // /api/v1/security/explain
-  'packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx',
-  // /api/v1/meta/object/task
-  'packages/plugin-charts/src/ObjectChart.heightChain.test.tsx',
-  // /api/v1/security/explain
   'packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx',
   // /api/task/42, /api/v1/security/explain
   'packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx',
@@ -145,15 +140,11 @@ export const KNOWN_ESCAPES: ReadonlySet<string> = new Set([
   // /api/v1/security/explain
   'packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx',
   // /api/v1/security/explain
-  'packages/plugin-grid/src/__tests__/bulkDeleteVisibleWhen.test.tsx',
-  // /api/v1/security/explain
   'packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx',
   // /api/v1/security/explain
   'packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx',
   // /api/v1/security/explain
   'packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-view/src/__tests__/ObjectView.namedViewSortArity.test.tsx',
 ]);
 
 type Escape = { file: string; test: string; url: string };


### PR DESCRIPTION
Part of #7307 — batch 1 of the burn-down. The card stays open until both ledgers are empty; 16 rows remain.

Five files stop opening a real socket, and their lines leave `KNOWN_ESCAPES` (in `vitest.setup.network-escape-guard.ts`) and `PINNED_LEDGER` (in `scripts/__tests__/network-escape-ledger.test.ts`) **in the same commit**, as the guard's own header requires.

**Ledger arithmetic: 21 → 16 in BOTH lists.** Verified in lockstep, not by counting twice: `diff` of the quoted paths in the two literals is empty, and the pin's two reconciles (grew / went stale) plus its non-vacuity floor are green.

## Per file — endpoint, mechanism, double

Every mechanism below was **traced**, not inferred: a stack probe injected at the guard's attribution point, run once per file, then reverted (mutation and restore both proven on disk; the guard's blob is byte-identical to HEAD).

| file | endpoint | mechanism (traced) | double |
|---|---|---|---|
| `examples/schema-catalog/test/catalog-gallery-render.test.tsx` | POST `/api/v1/security/explain` (18 per run) | grid-bearing tiles → `ObjectGrid.tsx:1407` → `useRecordCrudVerdicts.ts:199` `apiFetch ?? fetch` | explain router, per-test |
| `packages/plugin-view/src/__tests__/ObjectView.namedViewSortArity.test.tsx` | POST `/api/v1/security/explain` (8) | `ObjectView` → `ObjectGrid` → `useRecordCrudVerdicts.ts:199` | explain router, per-test |
| `packages/plugin-grid/src/__tests__/bulkDeleteVisibleWhen.test.tsx` | POST `/api/v1/security/explain` (4) | `ObjectGrid` → `useRecordCrudVerdicts.ts:199` | explain router, per-test |
| `packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx` | POST `/api/v1/security/explain` (6) | `RecordDetailDrawer` → `useRecordEditable.ts:75` `apiFetch ?? fetch` | explain router, per-test |
| `packages/plugin-charts/src/ObjectChart.heightChain.test.tsx` | GET `/api/v1/meta/object/task` (1) | `ObjectChart.tsx:390` → `loadObjectSchema` (:411) → `loadDimensionFieldMeta` | meta-object router, per-test |

All five take an `apiFetch ?? fetch` fallback with no host `apiFetch` in the tree, exactly as #7307 measured. **Zone 2 A2 holds, with one refinement worth recording:** the dispatch expected the explain rows to share ONE hook. They do not — three of the four go through plugin-grid's `useRecordCrudVerdicts`, the calendar one through plugin-detail's `useRecordEditable`. One router *shape* still serves them, because both hooks POST the same route; the two differ only in the response they read, and the double answers both (see below).

### The double, and why it changes no assertion

The landed #5225 shape (`vi.stubGlobal('fetch', router)`, and `cleanup()` **before** `vi.unstubAllGlobals()` — #7439's ordering, so the tree is unmounted while the double is still installed). Not a blanket network stub: it is a **recording router**, and `afterEach` fails on any URL that is not the route it serves, so a new escape reds here instead of vanishing into the hook's best-effort `catch`. That assertion is also what stops the double degrading into a silencer: a route regex that stopped matching would 404 into the same fail-open path and look green, and this fails instead.

The explain router answers the **permissive** verdict in the two shapes the two hooks read (ADR-0090 D6 / ADR-0095 C2), keyed off the request body: `{ record: { visible: true } }` for a single `recordId`, `{ records: [{ recordId, visible: true }] }` for a batched `recordIds`. That is the same downstream state the failing request produced, at every read site:

- `useRecordEditable` initialises `allowed` to `true` and its failure path leaves it there;
- the only consumer of the batched lookup is `resolveRowRecordCrudAffordance` (`rowCrudAffordances.ts:224`), whose rule is `!!objectVerdict && recordVerdict !== false` — so `true` and the `undefined` the failing request produced are the same value there.

The charts router serves a field-less document, so `loadDimensionFieldMeta` resolves no option colours and `optionMeta` settles null — the state the failing request already produced; `ChartRenderer` is mocked to null in that file anyway.

## Zone 2 A3 — the ablation (the guard IS the acceptance criterion)

On the committed tree, one script with `trap ... EXIT INT TERM` and absolute paths: one converted file's double reverted to the base blob while its line stays deleted from both ledgers.

- mutation proven on disk: `packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx` blob `6146d87e` (HEAD) → `f03ca1ff` (equal to the `36fc746` base blob, checked); anchors `installExplainDouble` 2 → 0, `vi.stubGlobal` 1 → 0; ledger state during the run confirmed: that path appears **0** times in `KNOWN_ESCAPES` and **0** times in `PINNED_LEDGER`;
- **predicted direction: turns red. Observed: red** — exit **1**, `Tests 3 failed (3)`, every one of them `Network escape: this test reached a REAL socket at http://localhost:3000/api/v1/security/explain`, `file: packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx`;
- restore: `git checkout HEAD -- path` → blob back to `6146d87e`, `git diff HEAD` on that path **EMPTY**, `git status --porcelain` empty.

No `dist/` preflight leg: these are the vitest projects' own test files, read from disk by the runner, and the root config aliases every package specifier to `src` — measured, in that all five suites ran green on a completely unbuilt tree before any build happened here.

## Before / after, per file

| file | before | after |
|---|---|---|
| catalog-gallery-render | 18 attribution lines, 90 `ECONNREFUSED` lines | **0 / 0**, `Tests 586 passed` |
| ObjectView.namedViewSortArity | 8 / 40 | **0 / 0**, `Tests 4 passed` |
| bulkDeleteVisibleWhen | 4 / 20 | **0 / 0**, `Tests 4 passed` |
| ObjectCalendar.navWidthDefault | 6 / 30 | **0 / 0**, `Tests 3 passed` |
| ObjectChart.heightChain | 1 / 3 | **0 / 0**, `Tests 1 passed` |

Final run at `0e92bee` over the five files plus the pin: exit **0**, `Test Files 6 passed (6)`, `Tests 601 passed (601)`, zero lines matching `network-escape` or `ECONNREFUSED`.

## Suites and gates — at `0e92bee`, exit codes captured by redirect-then-capture

- **Whole affected packages**, plus the pin and the one other reader: `pnpm exec vitest run packages/plugin-calendar/ packages/plugin-grid/ packages/plugin-view/ packages/plugin-charts/ examples/schema-catalog/ scripts/__tests__/network-escape-ledger.test.ts packages/plugin-detail/src/renderers/__tests__/record-details.hideEmptyRetired-7129.test.tsx` → exit **0**, `Test Files 247 passed (247)`, `Tests 3960 passed (3960)`, **0** `network-escape` lines anywhere in the run.
- `node scripts/check-changeset-presence.mjs` → exit **0**: `4 source file(s) of 4 released package(s) changed, and this change declares 1 changeset(s)` / `Every one of them has an EMPTY frontmatter — declared as releasing nothing, which is the explicit exemption and a complete answer to this gate.` (Test files under a released package's `src/` do owe one; answered the repo's way, not with a label.)
- `pnpm check:control-bytes` → exit **0**, `scanned 6435 tracked text file(s); skipped 85 binary`. Plus a self-scan beyond the gate: `grep -naP` for the control range over all 8 changed paths — no hits.
- `node scripts/check-governed-queue-guard.mjs --test` over all 8 changed paths → exit **0**, `NOT GOVERNED — 8 path(s) checked against 5 governed surface(s); none matched.`
- `pnpm type-check:scripts` → exit **0**.
- Per package `type-check` and `lint` (plugin-calendar, plugin-charts, plugin-grid, plugin-view, examples/schema-catalog): all exit **0**, **0 errors**. Proven non-vacuous rather than assumed: `tsc -p tsconfig.test.json --listFiles` names each edited test file (1 hit each), and `eslint --format json` reports each edited file among the linted set. Warning counts are unchanged — every `no-explicit-any` warning in the touched files sits on a pre-existing line, outside this diff's hunks; the added code uses `unknown`.
- Adjacent gates that read test files: `pnpm check:vi-mock-specifiers` **0**, `pnpm check:vi-mock-inherit` **0**, `pnpm changeset:check` **0**, `pnpm check:unreferenced-sources` **0**, `pnpm lint:coverage` **0** (`46/46 packages linted, 0 with outstanding errors`).
- Build: `turbo run build --filter=./packages/* --concurrency=2` → exit **0**, `Tasks: 39 successful, 39 total`. Needed only because each package's `type-check` depends on `^build`; the suites themselves need no `dist/`.

**Readers of the two symbols** (`git grep -l` over `scripts/ packages/ .github/ vitest.*`, unpiped): `KNOWN_ESCAPES` → `vitest.setup.network-escape-guard.ts`, `scripts/__tests__/network-escape-ledger.test.ts`, and `packages/plugin-detail/src/renderers/__tests__/record-details.hideEmptyRetired-7129.test.tsx` (a prose reference in a comment — it names the list to say it deliberately does NOT join it; no code reads it). `PINNED_LEDGER` → the first two only. Nothing in `.github/` names either. All three files were run above.

## Docstring prose

Two sentences in the guard and one in the pin said "the 21 files"; the sets now hold 16. Reworded to "what REMAINS of the 21 files measured on `67dadd6`" so the provenance survives without a count that every batch would have to re-edit. No judgement byte moves in either file.

## Not in this batch, and why

- **kanban (3 rows) and gantt (1 row) were NOT taken.** The claim gated them on PR #7985 being merged; read on GitHub immediately before they would have been edited, #7985 is `state: open`, `merged: false`, `mergeable_state: unstable`. They stay for batch 2.
- app-shell's 8 rows and plugin-detail's 4 rows are batch 2 by the claim, and were not touched.

## Out of scope, filed

#7996 (`finding`) — the one other landed `security/explain` double, in `record-details.hideEmptyRetired-7129.test.tsx`, answers `{ allowed: true }`, a key neither explain hook reads. It passes only because both hooks then take the same fail-open path they take on `ECONNREFUSED`, so it pins a wire contract that does not exist. Not touched here: that file is not on the ledger and is outside this batch's file surface.

## CI note

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990 / objectstack#16186) and is not this diff's.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM7kaS4dPpYHV5BsMyu4tQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01MM7kaS4dPpYHV5BsMyu4tQ)_