### PR TITLE
docs(guide): redraw agent-skills.md's tree from disk

### DIFF
--- a/content/docs/guide/agent-skills.md
+++ b/content/docs/guide/agent-skills.md
@@ -43,10 +43,10 @@ skills/objectui/
 ├── rules/           # Non-negotiable global constraints
 │   ├── protocol.md
 │   ├── styling.md
-│   ├── composition.md
-│   └── no-touch-zones.md
+│   └── composition.md
 ├── guides/          # Domain-specific deep dives, loaded on demand
 │   ├── architecture.md
+│   ├── app-composition.md
 │   ├── page-builder.md
 │   ├── plugin-development.md
 │   ├── schema-expressions.md
@@ -55,10 +55,17 @@ skills/objectui/
 │   ├── testing.md
 │   ├── i18n.md
 │   ├── mobile.md
-│   ├── auth-permissions.md
-│   └── console-development.md
+│   └── auth-permissions.md
 └── evals/           # Machine-checkable prompts (one per guide)
 ```
+
+Two files that once shipped in this bundle — `rules/no-touch-zones.md` and
+`guides/console-development.md` — moved into the repo-internal
+[`.claude/skills/objectui-contributor/`](https://github.com/objectstack-ai/objectui/tree/main/.claude/skills/objectui-contributor)
+skill instead. Both talk about paths that only exist inside this monorepo — `apps/console/`
+and `packages/components/src/ui/` — which a customer install of the published skill never
+has, so they stayed behind as contributor-only guidance rather than shipping to every
+consumer.
 
 When the agent picks up a task it:
 


### PR DESCRIPTION
Fixes #7362

## What was stale

`content/docs/guide/agent-skills.md` drew the skill's layout as an ASCII tree that no longer matched `skills/objectui/**` on disk:

- `rules/no-touch-zones.md` and `guides/console-development.md` were still drawn — both moved to `.claude/skills/objectui-contributor/` in #7251.
- `guides/app-composition.md` (a real, current guide) was never drawn at all — it landed without the tree being updated.

## Disk listing (`find skills/objectui -type f | sort`)

```
skills/objectui/README.md
skills/objectui/SKILL.md
skills/objectui/evals/app-composition.json
skills/objectui/evals/auth-permissions.json
skills/objectui/evals/data-integration.json
skills/objectui/evals/i18n.json
skills/objectui/evals/mobile.json
skills/objectui/evals/page-builder.json
skills/objectui/evals/plugin-development.json
skills/objectui/evals/project-setup.json
skills/objectui/evals/protocol.json
skills/objectui/evals/schema-expressions.json
skills/objectui/evals/testing.json
skills/objectui/guides/app-composition.md
skills/objectui/guides/architecture.md
skills/objectui/guides/auth-permissions.md
skills/objectui/guides/data-integration.md
skills/objectui/guides/i18n.md
skills/objectui/guides/mobile.md
skills/objectui/guides/page-builder.md
skills/objectui/guides/plugin-development.md
skills/objectui/guides/project-setup.md
skills/objectui/guides/schema-expressions.md
skills/objectui/guides/testing.md
skills/objectui/rules/composition.md
skills/objectui/rules/protocol.md
skills/objectui/rules/styling.md
```

(`.claude/skills/objectui-contributor/` holds `SKILL.md`, `guides/console-development.md`, `rules/no-touch-zones.md` — the two files' actual current home, matching `skills/objectui/README.md`'s own already-current tree, which this PR's redraw mirrors.)

## Redrawn tree (`agent-skills.md`)

```
skills/objectui/
├── SKILL.md         # Entry point — core principles, tech stack, scope
├── rules/           # Non-negotiable global constraints
│   ├── protocol.md
│   ├── styling.md
│   └── composition.md
├── guides/          # Domain-specific deep dives, loaded on demand
│   ├── architecture.md
│   ├── app-composition.md
│   ├── page-builder.md
│   ├── plugin-development.md
│   ├── schema-expressions.md
│   ├── data-integration.md
│   ├── project-setup.md
│   ├── testing.md
│   ├── i18n.md
│   ├── mobile.md
│   └── auth-permissions.md
└── evals/           # Machine-checkable prompts (one per guide)
```

Added a short paragraph after it saying where `no-touch-zones.md` and `console-development.md` went and why: a customer install of the published skill never has `apps/console/` or `packages/components/src/ui/`, which is what those two files are about, so they stayed behind as contributor-only guidance in `.claude/skills/objectui-contributor/` rather than shipping to every consumer.

**Tree-resolution loop** (every row → a path that exists under `skills/objectui/`), before and after — a one-off shell check, not a new gate (the ASCII-tree gate gap is already #7358's other side / #7362's own "why no gate caught it" section):

- Before (`origin/main:content/docs/guide/agent-skills.md`): **14/16 resolve, 2 missing** — `skills/objectui/rules/no-touch-zones.md`, `skills/objectui/guides/console-development.md`.
- After (this branch): **15/15 resolve, 0 missing**.

`evals/console-development.json`: confirmed gone from disk. The tree never listed individual eval filenames to begin with (only the `evals/ # Machine-checkable prompts (one per guide)` comment line), so there was no row to delete.

## `ci-cd-pipeline.md:581` — left unchanged, on purpose

The triage comment's boundary was right: the card's own claim that the baseline is "now empty" is false. Re-running the gate today:

```
$ node scripts/check-skills-paths.mjs
✅  check-skills-paths: OK (88/89 stated path(s) resolve across 20 guide file(s); 1 baselined).
    skills/ — 28/28 resolve across 16 file(s)
    .claude/skills/ — 60/61 resolve across 4 file(s)
```

`scripts/skills-path-baseline.json` carries exactly one `allowedMissing` entry, keyed to the guide's current, post-move path (`.claude/skills/objectui-contributor/guides/console-development.md` → token `apps/console/src/context/`), with its own note confirming it was **re-stated** under that key after #7358 widened `SCAN_ROOTS`, never deleted.

The sentence at `ci-cd-pipeline.md:579-582` reads:

> Today there is exactly one: the Key contexts section of `console-development.md` exists to correct a recurring wrong guess and says there is no `apps/console/src/context/` directory at all.

Checked both claims it makes against today's truth:
- "exactly one" baseline entry — still true (confirmed above).
- the file is named only as bare `console-development.md`, with no directory prefix — it never claimed a location, so the #7251 move left nothing in this sentence to correct.
- the stated-absent path, `apps/console/src/context/`, is the directory the guide argues does *not* exist — unrelated to the guide's own location, and it hasn't moved.

Conclusion: no edit was needed here. This is the "if any" case the triage comment flagged as possible — verified rather than assumed, and left alone rather than force-editing a correct sentence.

## Gates

| Gate | Result |
|---|---|
| `node scripts/check-skills-paths.mjs` | ✅ exit 0 — `88/89 stated path(s) resolve across 20 guide file(s); 1 baselined` |
| `node scripts/check-doc-links.mjs` | ✅ exit 0 — `Links are valid across 17 scan roots.` |
| `pnpm check:doc-fences` | ✅ exit 0 |
| `pnpm check:doc-snippets` | ⚠️ NOT MEASURED — precondition not met (exit 2, `PRECONDITION NOT MET`): 28 packages + closure unbuilt in this worktree. In scope (neither file is in `UNGATED_DOCS`, both are walked), but neither touched file contains an actual `ts`/`tsx` code fence (`ci-cd-pipeline.md` has one *prose mention* of the marker at an untouched line, not a fence), so this change carries no snippet-compile risk; deferred to CI's full build rather than a 28-package scoped build for a docs-only, no-fence diff. |
| `pnpm check:control-bytes` | ✅ exit 0 |
| `node scripts/check-changeset-presence.mjs` | ✅ exit 0 — `0 changeset(s) added` / `No source or published contract of a released package changed`, none owed (docs-only) |
| `node scripts/check-governed-queue-guard.mjs --test` (both paths) | ✅ exit 0 — `NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched` |
| `pnpm exec vitest run scripts/__tests__/doc-version-claims.test.ts scripts/__tests__/check-skills-paths.test.ts` | ✅ exit 0 — `2 passed (2)`, `66 passed (66)` |
| `pnpm exec vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` (reader, since it pins this same page) | ✅ exit 0 — `1 passed (1)`, `40 passed (40)` |

**Readers** (`git grep -l 'agent-skills.md\|ci-cd-pipeline.md' -- scripts/ .github/ packages/`): `.github/workflows/changeset-release.yml`, `.github/workflows/dependabot-auto-merge.yml`, `.github/workflows/lint.yml`, and ten `scripts/__tests__/*.test.ts` files including `ci-cd-pipeline-doc.test.ts` (run above, unaffected — I did not edit that file).

**CI note:** `Live E2E (informational)` is expected red on every branch today for an upstream reason unrelated to this change (objectui#7990 / objectstack#16186).

## Out of scope

Filed objectui#8006: `ci-cd-pipeline.md:551` ("reads every markdown file under `skills/`") still undercounts the scan surface after #7358 added `.claude/skills/`. Different line/sentence from this card's boundary, `finding` label, unassigned.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM7kaS4dPpYHV5BsMyu4tQ