### PR TITLE
test(plugins): serve batch 2's four network-escape probes from doubles

### DIFF
--- a/.changeset/network-escape-batch2.md
+++ b/.changeset/network-escape-batch2.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: the four network-escape files in batch 2 of objectui#7307 (three in `plugin-kanban`, one in `plugin-gantt`) now serve their `/api/v1/security/explain` probe from a recording double instead of a real socket, and their lines leave `KNOWN_ESCAPES` and `PINNED_LEDGER` together. No published behaviour changes — no product source is touched.

--- a/packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx
+++ b/packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx
@@ -24,8 +24,8 @@
  * renders", either of which passes in both worlds.
  */
 import React from 'react';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ObjectGantt } from './ObjectGantt';
 
 /** The width the gantt's drawer has always resolved to. Must not drift. */
@@ -79,12 +79,103 @@ async function openDrawer() {
   await waitFor(() => expect(drawerProps).not.toBeNull());
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point (measured, not inferred):
+ *
+ *   RecordDetailDrawer (the drawer this file opens)
+ *     -> DetailView            packages/plugin-detail/src/DetailView.tsx:290,296
+ *       -> useRecordEditable   packages/plugin-detail/src/useRecordEditable.ts:76
+ *         -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *           POST /api/v1/security/explain  (twice per open: edit, then delete)
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the
+ * record editable — fail open), which is why the cases below stayed green while
+ * the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and
+ * by this batch's sibling
+ * `packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx`.
+ * Deliberately NOT a blanket network stub: it records every URL it is handed
+ * and `afterEach` fails on any URL that is not the explain route, so an escape
+ * to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two explain hooks read —
+ * `{ record: { visible } }` for a single `recordId`, and
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the
+ * FIRST is reached from this file (every call measured above comes from
+ * `useRecordEditable`); the batched branch is kept so this router stays
+ * byte-identical to its siblings rather than forking per file.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, so `true` and the absent verdict the failing request
+ * produced are the same value at every read site. The drawer's width —
+ * everything this file asserts — is not derived from the verdict at all.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
 describe('gantt drawer width with no declared `navigation`', () => {
   beforeEach(() => {
     drawerProps = null;
     // Cross-test leakage guard: the drawer prefers a drag-resized width
     // persisted in localStorage over its prop, which would mask half 2.
     try { window.localStorage.clear(); } catch { /* ignore */ }
+    installExplainDouble();
+  });
+  afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
   });
 
   it('half 1: the gantt injects no width of its own (so the drawer default applies)', async () => {

--- a/packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx
@@ -109,12 +109,102 @@ function readPanelWidth(): string {
   return panel!.style.maxWidth;
 }
 
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point (measured, not inferred):
+ *
+ *   RecordDetailDrawer (the drawer this file opens)
+ *     -> DetailView            packages/plugin-detail/src/DetailView.tsx:290,296
+ *       -> useRecordEditable   packages/plugin-detail/src/useRecordEditable.ts:76
+ *         -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *           POST /api/v1/security/explain  (twice per open: edit, then delete)
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the
+ * record editable — fail open), which is why the cases below stayed green while
+ * the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and
+ * by this batch's sibling
+ * `packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx`.
+ * Deliberately NOT a blanket network stub: it records every URL it is handed
+ * and `afterEach` fails on any URL that is not the explain route, so an escape
+ * to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two explain hooks read —
+ * `{ record: { visible } }` for a single `recordId`, and
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the
+ * FIRST is reached from this file (every call measured above comes from
+ * `useRecordEditable`); the batched branch is kept so this router stays
+ * byte-identical to its siblings rather than forking per file.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, so `true` and the absent verdict the failing request
+ * produced are the same value at every read site. The drawer's width —
+ * everything this file asserts — is not derived from the verdict at all.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
 describe('kanban drawer width with no declared `navigation` (objectui#6303)', () => {
   beforeEach(() => {
     drawerProps = null;
     try { window.localStorage.clear(); } catch { /* ignore */ }
+    installExplainDouble();
   });
-  afterEach(() => cleanup());
+  afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+  });
 
   it('half 1: the kanban injects no width of its own (so the drawer default applies)', async () => {
     await openDrawer();

--- a/packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx
@@ -61,7 +61,7 @@
  */
 
 import React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { I18nProvider } from '@object-ui/i18n';
@@ -109,7 +109,98 @@ async function openDrawer() {
   await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
 }
 
-afterEach(() => cleanup());
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point (measured, not inferred):
+ *
+ *   RecordDetailDrawer (the drawer this file opens)
+ *     -> DetailView            packages/plugin-detail/src/DetailView.tsx:290,296
+ *       -> useRecordEditable   packages/plugin-detail/src/useRecordEditable.ts:76
+ *         -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *           POST /api/v1/security/explain  (twice per open: edit, then delete)
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the
+ * record editable — fail open), which is why the cases below stayed green while
+ * the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and
+ * by this batch's sibling
+ * `packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx`.
+ * Deliberately NOT a blanket network stub: it records every URL it is handed
+ * and `afterEach` fails on any URL that is not the explain route, so an escape
+ * to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two explain hooks read —
+ * `{ record: { visible } }` for a single `recordId`, and
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the
+ * FIRST is reached from this file (every call measured above comes from
+ * `useRecordEditable`); the batched branch is kept so this router stays
+ * byte-identical to its siblings rather than forking per file.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, so `true` and the absent verdict the failing request
+ * produced are the same value at every read site. The drawer's accessible
+ * name — everything this file asserts — is not derived from the verdict at all.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(() => installExplainDouble());
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('ObjectKanban record-detail drawer heading (objectui#3459)', () => {
   it('names the drawer in English under an en session', async () => {

--- a/packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx
@@ -40,7 +40,7 @@
  */
 
 import React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { registerAllFields } from '@object-ui/fields';
@@ -79,7 +79,98 @@ async function openDrawer() {
   await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
 }
 
-afterEach(() => cleanup());
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point (measured, not inferred):
+ *
+ *   RecordDetailDrawer (the drawer this file opens)
+ *     -> DetailView            packages/plugin-detail/src/DetailView.tsx:290,296
+ *       -> useRecordEditable   packages/plugin-detail/src/useRecordEditable.ts:76
+ *         -> `const doFetch = apiFetch ?? fetch`      <- the escape
+ *           POST /api/v1/security/explain  (twice per open: edit, then delete)
+ *
+ * The hook reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the
+ * record editable — fail open), which is why the cases below stayed green while
+ * the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and
+ * by this batch's sibling
+ * `packages/plugin-calendar/src/ObjectCalendar.navWidthDefault.test.tsx`.
+ * Deliberately NOT a blanket network stub: it records every URL it is handed
+ * and `afterEach` fails on any URL that is not the explain route, so an escape
+ * to somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two explain hooks read —
+ * `{ record: { visible } }` for a single `recordId`, and
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the
+ * FIRST is reached from this file (every call measured above comes from
+ * `useRecordEditable`); the batched branch is kept so this router stays
+ * byte-identical to its siblings rather than forking per file.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, so `true` and the absent verdict the failing request
+ * produced are the same value at every read site. The drawer's accessible
+ * name — everything this file asserts — is not derived from the verdict at all.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this render handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(() => installExplainDouble());
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('ObjectKanban drawer heading — English fallback with no provider (objectui#3459)', () => {
   it('interpolates the capitalized object name in English, never the raw key', async () => {

--- a/scripts/__tests__/network-escape-ledger.test.ts
+++ b/scripts/__tests__/network-escape-ledger.test.ts
@@ -1,10 +1,10 @@
 /**
  * The shrink-only pin for the network-escape ledger (objectui#6640).
  *
- * `KNOWN_ESCAPES` in `vitest.setup.network-escape-guard.ts` records the 21 test
- * files measured reaching a real socket on `67dadd6`. The guard's own docstring
- * says that list "may only shrink" — and until this file existed, nothing made
- * that true. An author who hit the guard's red could make it green by adding a
+ * `KNOWN_ESCAPES` in `vitest.setup.network-escape-guard.ts` records what remains
+ * of the 21 test files measured reaching a real socket on `67dadd6`. The guard's
+ * own docstring says that list "may only shrink" — and until this file existed,
+ * nothing made that true. An author who hit the guard's red could make it green by adding a
  * line, which is exactly how a burn-down ledger decays into the permanent
  * quarantine it is not supposed to be. THAT is the failure this pin prevents;
  * it does not re-measure escapes (that needs a real DOM run) and does not try.
@@ -51,10 +51,6 @@ const PINNED_LEDGER: readonly string[] = [
   'packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx',
   'packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx',
   'packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx',
-  'packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx',
-  'packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx',
-  'packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx',
-  'packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx',
 ];
 
 describe('network-escape ledger (objectui#6640) is shrink-only', () => {

--- a/vitest.setup.network-escape-guard.ts
+++ b/vitest.setup.network-escape-guard.ts
@@ -137,14 +137,6 @@ export const KNOWN_ESCAPES: ReadonlySet<string> = new Set([
   'packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx',
   // /api/v1/security/explain
   'packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx',
 ]);
 
 type Escape = { file: string; test: string; url: string };


### PR DESCRIPTION
Part of #7307 — batch 2 of the network-escape burn-down (batch 1 was #7999).

The four `/api/v1/security/explain` rows left in the ledger for `plugin-kanban` and
`plugin-gantt` now serve that probe from the recording double batch 1 landed, and
their lines leave `KNOWN_ESCAPES` and `PINNED_LEDGER` in the same commit.

## Per file

| file | endpoint | hook it escaped through | double |
|:--|:--|:--|:--|
| `packages/plugin-kanban/src/ObjectKanban.navWidthDefault.test.tsx` | `POST /api/v1/security/explain` | `useRecordEditable.ts:76` (`apiFetch ?? fetch`) | per-test `installExplainDouble()` in `beforeEach` |
| `packages/plugin-kanban/src/ObjectKanban.overlayTitleI18n.test.tsx` | `POST /api/v1/security/explain` | `useRecordEditable.ts:76` | per-test `installExplainDouble()` in `beforeEach` |
| `packages/plugin-kanban/src/ObjectKanban.overlayTitleNoProviderFallback.test.tsx` | `POST /api/v1/security/explain` | `useRecordEditable.ts:76` | per-test `installExplainDouble()` in `beforeEach` |
| `packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx` | `POST /api/v1/security/explain` | `useRecordEditable.ts:76` | per-test `installExplainDouble()` in `beforeEach` |

**Mechanism, measured rather than assumed.** A trap-guarded stack probe on the
guard's own attribution point says all four take ONE route, not the two batch 1
found: `RecordDetailDrawer` renders `DetailView`, which calls `useRecordEditable`
twice per open (`DetailView.tsx:290` for edit, `:296` for delete). At
`useRecordEditable.ts:76` the hook degrades from the host's authenticated
`apiFetch` to the global `fetch` — by design, so a standalone embed keeps
rendering — and under happy-dom that global is a real HTTP client whose document
URL is `http://localhost:3000`, so the relative path resolved to a live socket.
The read is best-effort (`catch` leaves the record editable), which is why every
one of these files stayed green while its request always failed. The probe was
reverted by `git checkout HEAD --` and the guard is byte-identical to `HEAD`
afterwards.

**The double** is batch 1's shape verbatim: `vi.stubGlobal('fetch', router)` in
`beforeEach`, `cleanup()` before `vi.unstubAllGlobals()` in `afterEach` (#7439
ordering). It is a router, not a sink — it records every URL it is handed and
`afterEach` fails on any URL that is not the explain route, so an escape
elsewhere reds here instead of vanishing into the hook's `catch`. It answers the
permissive verdict, which is the same downstream state the failing request
produced (`useRecordEditable` initialises `allowed` to `true` and its failure
path leaves it there), so no existing assertion changes meaning. Only the
single-`recordId` response shape is reached from these four files; the batched
branch is kept so the router stays byte-identical to its siblings rather than
forking per file. Nothing is skipped, quarantined or silenced.

## Ledger arithmetic

**16 to 12, in both lists.** The four names are deleted from `KNOWN_ESCAPES` in
`vitest.setup.network-escape-guard.ts` and from `PINNED_LEDGER` in
`scripts/__tests__/network-escape-ledger.test.ts` in this one commit. Checked in
lockstep by diffing the quoted paths of the two literals against each other on
the branch: empty diff, both at 12. Remaining 12: app-shell 8, plugin-detail 4.

## Evidence

Per file, before then after (attribution lines / `ECONNREFUSED` lines, then the
post-fix run):

| file | before | after |
|:--|:--|:--|
| `ObjectKanban.navWidthDefault` | 6 / 30 | 0 / 0, `Tests 3 passed` |
| `ObjectKanban.overlayTitleI18n` | 12 / 60 | 0 / 0, `Tests 7 passed` |
| `ObjectKanban.overlayTitleNoProviderFallback` | 4 / 20 | 0 / 0, `Tests 2 passed` |
| `ObjectGantt.navWidthDefault` | 4 / 20 | 0 / 0, `Tests 2 passed` |

`pnpm exec vitest run packages/plugin-kanban/ packages/plugin-gantt/ scripts/__tests__/network-escape-ledger.test.ts`
on this head: exit 0, `Test Files 87 passed (87)`, `Tests 619 passed (619)`, and
zero lines matching `network-escape` or `ECONNREFUSED` in the whole run.

**Ablation** (on the committed tree, one script with `trap ... EXIT INT TERM` and
absolute paths). One converted file's double reverted to its pre-batch-2 blob
while its line stayed deleted from BOTH ledgers. Mutation proven on disk:
`ObjectGantt.navWidthDefault.test.tsx` blob `e9ba5b8e` to `28f37a60` (equal to
the `e1545cf` base blob), anchors `installExplainDouble` 2 to 0 and
`vi.stubGlobal` 1 to 0, that path present 0 times in each ledger during the run.
Predicted direction red; OBSERVED red — exit 1, `Tests 2 failed (2)`,
`Network escape: this test reached a REAL socket at http://localhost:3000/api/v1/security/explain`
naming `file: packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx`.
Restore proven: `git checkout HEAD -- path`, blob back to `e9ba5b8e`,
`git diff HEAD` on that path empty, `git status --porcelain` empty.

**Gates**, exit codes captured by redirect-then-capture, never through a pipe:

- `node scripts/check-changeset-presence.mjs` exit 0 — "4 source file(s) of 2
  released package(s) changed, and this change declares 1 changeset(s)"; the
  changeset has an EMPTY frontmatter, the explicit exemption for a test-only
  change under a released package.
- `pnpm check:control-bytes` exit 0 (6443 tracked text files), plus a
  `grep -naP` self-scan of the control range over all 7 changed paths, no hits.
- `node scripts/check-governed-queue-guard.mjs --test` over all 7 changed paths:
  exit 0, "NOT GOVERNED — 7 path(s) checked against 5 governed surface(s)".
- `pnpm type-check:scripts` exit 0 · `pnpm check:vi-mock-inherit` exit 0 ·
  `pnpm check:vi-mock-specifiers` exit 0.
- Per-package `type-check` and `lint` for `plugin-kanban` and `plugin-gantt`:
  exit 0, 0 errors, proven non-vacuous rather than assumed —
  `tsc -p tsconfig.test.json --listFiles` names each edited test file exactly
  once, and `eslint --format json` lists each edited file among the linted set
  (37 and 91 files). Warning counts unchanged: every `no-explicit-any` warning in
  the touched files sits on a pre-existing line above this diff's hunks. The
  `type-check` task `dependsOn ^build`, so turbo built the dependency closure.

## Concurrency note (A3)

**Yes — a #5174 batch-18 PR on one of these packages exists: #8009,
`docs(plugin-gantt): compile the gantt README's 18 blocks and drop its ledger
entry`**, opened after this branch was cut. Its file list read over git is
`packages/plugin-gantt/README.md` and `scripts/check-doc-snippet-types.mjs` —
zero overlap with the 7 files here. `main` moved by two commits while this batch
was in flight (#8003, #8002) and has been merged into this branch; the suites,
the ablation and every gate above were re-run on the merged head after that.

`Live E2E (informational)` is red on every branch today for an upstream reason
(#7990 / objectstack#16186), not for anything in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MM7kaS4dPpYHV5BsMyu4tQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM7kaS4dPpYHV5BsMyu4tQ)_