### PR TITLE
test(plugin-detail): serve batch 3's four probes from doubles (objectui#7307)

### DIFF
--- a/.changeset/network-escape-batch3.md
+++ b/.changeset/network-escape-batch3.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change: the four `plugin-detail` network-escape files in batch 3 of objectui#7307 now serve their probes from a recording double instead of a real socket, and their lines leave `KNOWN_ESCAPES` and `PINNED_LEDGER` together. One of the four also reached `/api/task/42` through `DetailView`'s `api` branch, so its router serves that route too. No published behaviour changes — no product source is touched.

--- a/packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx
+++ b/packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx
@@ -52,7 +52,7 @@
  */
 
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup, within } from '@testing-library/react';
 import { RecordContextProvider, SchemaRenderer } from '@object-ui/react';
 // Module-scope side-effect imports: the registry must hold the page/record
@@ -152,7 +152,99 @@ function renderDefaultPage(): HTMLElement {
   return block as HTMLElement;
 }
 
-afterEach(cleanup);
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point (measured, not inferred):
+ *
+ *   SchemaRenderer -> the synthesized `record:details` node
+ *     -> RecordDetailsRenderer  packages/plugin-detail/src/renderers/record-details.tsx:302
+ *       -> DetailView           packages/plugin-detail/src/DetailView.tsx:290, :296
+ *         -> useRecordEditable  packages/plugin-detail/src/useRecordEditable.ts:76
+ *           -> `const doFetch = apiFetch ?? fetch`      [the escape]
+ *             POST /api/v1/security/explain  (twice per render: edit, then delete)
+ *
+ * `useRecordEditable` reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the
+ * record editable — fail open), which is why the cases below stayed green while
+ * the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches (see
+ * `packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx`).
+ * Deliberately NOT a blanket network stub: it records every URL it is handed and
+ * `afterEach` fails on any URL outside the set it serves, so an escape to
+ * somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two explain hooks read —
+ * `{ record: { visible } }` for a single `recordId`, and
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the
+ * FIRST is reached from this file (every call measured above comes from
+ * `useRecordEditable`); the batched branch is kept so this router stays
+ * byte-identical to its siblings rather than forking per file.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, so `true` and the absent verdict the failing request
+ * produced are the same value at every read site — nothing below reads the
+ * verdict at all.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(installExplainDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('default `fieldGroups` detail page — synthesized section headings reach the DOM (#6241)', () => {
   it('renders the declared heading text of every group inside the details block', () => {

--- a/packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx
+++ b/packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx
@@ -34,7 +34,7 @@
  * the more specific signal.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor, cleanup } from '@testing-library/react';
 import React from 'react';
 import fs from 'node:fs';
@@ -96,7 +96,121 @@ function makeAdapter() {
 const DETAIL_SNIPPETS = guideSchemas('detail-view');
 const SNIPPET = DETAIL_SNIPPETS[0];
 
-beforeEach(() => cleanup());
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's TWO network escapes, both served here.
+ *
+ * Nothing below asks for a security verdict or for a REST record, yet every run
+ * opened real TCP connections to `http://localhost:3000`. Traced with a stack
+ * probe on the network-escape guard's attribution point (measured, not
+ * inferred) — this file is the only one in its batch that reaches two routes:
+ *
+ *   SchemaRenderer -> the guide's `detail-view` snippet
+ *     -> DetailView           packages/plugin-detail/src/DetailView.tsx:290, :296
+ *       -> useRecordEditable  packages/plugin-detail/src/useRecordEditable.ts:76
+ *         -> `const doFetch = apiFetch ?? fetch`      [escape 1, 12 calls]
+ *           POST /api/v1/security/explain  (twice per render: edit, then delete)
+ *
+ *   the `api`-sourced case at the bottom of this file
+ *     -> DetailView           packages/plugin-detail/src/DetailView.tsx:616
+ *       -> `fetch(`${schema.api}/${schema.resourceId}`)`   [escape 2, 1 call]
+ *         GET /api/task/42
+ *
+ * `useRecordEditable` reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. `DetailView`'s `api` branch has no such seam at all: it calls the
+ * global directly. Under happy-dom that global is a real HTTP client and the
+ * document URL defaults to `http://localhost:3000`, so both relative paths
+ * resolved to live requests. Both reads are best-effort (each failure is
+ * caught), which is why the cases below stayed green while the requests always
+ * failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches (see
+ * `packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx`).
+ * Deliberately NOT a blanket network stub: it records every URL it is handed and
+ * `afterEach` fails on any URL outside the set it serves, so an escape to
+ * somewhere else reds here instead of vanishing into one of those `catch`es.
+ *
+ * What it answers, and why that changes no assertion here:
+ *
+ *   - `/api/v1/security/explain` — the permissive verdict, in the two response
+ *     shapes the two explain hooks read: `{ record: { visible } }` for a single
+ *     `recordId` and `{ records: [{ recordId, visible }] }` for a batched
+ *     `recordIds`. Only the first is reached from this file; the batched branch
+ *     is kept so this router stays byte-identical to its siblings in this batch.
+ *     `useRecordEditable` initialises `allowed` to `true` and its failure path
+ *     leaves it there, so `true` and the absent verdict the failing request
+ *     produced are the same value at every read site.
+ *   - `/api/task/42` — the RECORD, which is the shape its reader consumes:
+ *     `DetailView` does `res.json()` then `setData(result?.data || result)`.
+ *     The one case that reaches it asserts only that the "No data source
+ *     resolved" panel stays absent, and that panel is a WIRING gate
+ *     (`ElementDataSourceGate`) decided before any response arrives — it is
+ *     absent here because the block declares `api`, not because the request
+ *     failed. Serving the record therefore exercises the success path this
+ *     route always had, without moving any assertion.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** `DetailView`'s `api`-sourced read — `${schema.api}/${schema.resourceId}`. */
+const RECORD_ROUTE = '/api/task/42';
+
+const SERVED_ROUTES: readonly string[] = [EXPLAIN_ROUTE, RECORD_ROUTE];
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let servedCalls: string[] = [];
+
+/** Serve both routes; record everything; 404 anything else. */
+function installFetchDouble() {
+  servedCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      servedCalls.push(url);
+      if (url === RECORD_ROUTE) return { ok: true, status: 200, json: async () => RECORD };
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  installFetchDouble();
+});
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into one of the readers' best-effort `catch`es.
+  expect(servedCalls.filter((url) => !SERVED_ROUTES.includes(url))).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('guide/building-crud-app.md — the `detail-view` snippet actually renders', () => {
   it('publishes exactly one detail snippet', () => {

--- a/packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx
+++ b/packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx
@@ -35,8 +35,8 @@
  * published-surface assertions in `recordDetailsInputs.spec-parity.test.ts`.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import * as React from 'react';
 import { RecordContextProvider } from '@object-ui/react';
 import { RecordDetailsRenderer } from '../renderers/record-details';
@@ -72,6 +72,99 @@ const renderDetails = (schema: Record<string, unknown>) =>
       <RecordDetailsRenderer schema={schema as any} />
     </RecordContextProvider>,
   );
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point (measured, not inferred):
+ *
+ *   RecordDetailsRenderer  packages/plugin-detail/src/renderers/record-details.tsx:302
+ *     -> DetailView        packages/plugin-detail/src/DetailView.tsx:290, :296
+ *       -> useRecordEditable  packages/plugin-detail/src/useRecordEditable.ts:76
+ *         -> `const doFetch = apiFetch ?? fetch`      [the escape]
+ *           POST /api/v1/security/explain  (twice per render: edit, then delete)
+ *
+ * `useRecordEditable` reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the
+ * record editable — fail open), which is why the cases below stayed green while
+ * the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches (see
+ * `packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx`).
+ * Deliberately NOT a blanket network stub: it records every URL it is handed and
+ * `afterEach` fails on any URL outside the set it serves, so an escape to
+ * somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two explain hooks read —
+ * `{ record: { visible } }` for a single `recordId`, and
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the
+ * FIRST is reached from this file (every call measured above comes from
+ * `useRecordEditable`); the batched branch is kept so this router stays
+ * byte-identical to its siblings rather than forking per file.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, so `true` and the absent verdict the failing request
+ * produced are the same value at every read site — nothing below reads the
+ * verdict at all.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(installExplainDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('record:details — `sections` presence decides the body (#3818)', () => {
   it('renders the authored groups when `sections` is present (the old `custom`)', () => {

--- a/packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx
+++ b/packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx
@@ -46,8 +46,8 @@
  * same DOM nodes a translated app fills with translated labels.
  */
 
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
 import * as React from 'react';
 import { RecordContextProvider } from '@object-ui/react';
 import { RecordDetailsRenderer } from '../record-details';
@@ -84,6 +84,99 @@ const renderDetails = (schema: Record<string, unknown>, data: Record<string, unk
 
 /** The empty-value placeholder `DetailSection` draws for a field with no value. */
 const emptyPlaceholders = () => screen.queryAllByTitle('No value');
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * objectui#7307 — this file's `/api/v1/security/explain` escape, served here.
+ *
+ * Nothing below asks for a security verdict, yet every run opened a REAL TCP
+ * connection to `http://localhost:3000`. Traced with a stack probe on the
+ * network-escape guard's attribution point (measured, not inferred):
+ *
+ *   RecordDetailsRenderer  packages/plugin-detail/src/renderers/record-details.tsx:302
+ *     -> DetailView        packages/plugin-detail/src/DetailView.tsx:290, :296
+ *       -> useRecordEditable  packages/plugin-detail/src/useRecordEditable.ts:76
+ *         -> `const doFetch = apiFetch ?? fetch`      [the escape]
+ *           POST /api/v1/security/explain  (twice per render: edit, then delete)
+ *
+ * `useRecordEditable` reads the host's AUTHENTICATED `apiFetch` off
+ * `SchemaRendererContext` and, with no host supplying one, degrades to the
+ * GLOBAL `fetch` by design — a standalone embed must keep rendering rather than
+ * crash. Under happy-dom that global is a real HTTP client and the document URL
+ * defaults to `http://localhost:3000`, so the relative path resolved to a live
+ * request. The read is best-effort (a network or parse failure leaves the
+ * record editable — fail open), which is why the cases below stayed green while
+ * the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches (see
+ * `packages/plugin-gantt/src/ObjectGantt.navWidthDefault.test.tsx`).
+ * Deliberately NOT a blanket network stub: it records every URL it is handed and
+ * `afterEach` fails on any URL outside the set it serves, so an escape to
+ * somewhere else reds here instead of vanishing into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: the permissive
+ * verdict, in the two response shapes the two explain hooks read —
+ * `{ record: { visible } }` for a single `recordId`, and
+ * `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the
+ * FIRST is reached from this file (every call measured above comes from
+ * `useRecordEditable`); the batched branch is kept so this router stays
+ * byte-identical to its siblings rather than forking per file.
+ * `useRecordEditable` initialises `allowed` to `true` and its failure path
+ * leaves it there, so `true` and the absent verdict the failing request
+ * produced are the same value at every read site — nothing below reads the
+ * verdict at all.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const EXPLAIN_ROUTE = '/api/v1/security/explain';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let explainCalls: string[] = [];
+
+/** Serve `POST /api/v1/security/explain` permissively; record everything. */
+function installExplainDouble() {
+  explainCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      explainCalls.push(url);
+      if (url !== EXPLAIN_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      let body: { recordId?: unknown; recordIds?: unknown } = {};
+      try {
+        body = JSON.parse(String((init as { body?: unknown } | undefined)?.body ?? '{}'));
+      } catch {
+        /* a non-JSON body is not a request this route can answer */
+      }
+      const recordIds = Array.isArray(body.recordIds) ? body.recordIds : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () =>
+          recordIds
+            ? { records: recordIds.map((recordId) => ({ recordId, visible: true })) }
+            : { record: { visible: true } },
+      };
+    }),
+  );
+}
+
+beforeEach(installExplainDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(explainCalls.filter((url) => url !== EXPLAIN_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a verdict effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 describe('record:details — the UNAUTHORED empty-section default is DetailSection\'s heuristic (#7064)', () => {
   it('an ALL-empty section renders its skeleton: heading, every field label, an empty placeholder each', () => {

--- a/scripts/__tests__/network-escape-ledger.test.ts
+++ b/scripts/__tests__/network-escape-ledger.test.ts
@@ -47,10 +47,6 @@ const PINNED_LEDGER: readonly string[] = [
   'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.specKeys.test.tsx',
   'packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx',
   'packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx',
-  'packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx',
-  'packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx',
-  'packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx',
-  'packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx',
 ];
 
 describe('network-escape ledger (objectui#6640) is shrink-only', () => {

--- a/vitest.setup.network-escape-guard.ts
+++ b/vitest.setup.network-escape-guard.ts
@@ -129,14 +129,6 @@ export const KNOWN_ESCAPES: ReadonlySet<string> = new Set([
   'packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx',
   // /api/v1/ai/conversations
   'packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-detail/src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx',
-  // /api/task/42, /api/v1/security/explain
-  'packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-detail/src/__tests__/recordDetailsBodySource.test.tsx',
-  // /api/v1/security/explain
-  'packages/plugin-detail/src/renderers/__tests__/record-details.emptySectionDefault.test.tsx',
 ]);
 
 type Escape = { file: string; test: string; url: string };


### PR DESCRIPTION
Part of #7307 — batch 3 of the network-escape burn-down (batch 1 was #7999, batch 2 was #8013).

The four `plugin-detail` rows left in the ledger now serve their probes from the
recording double batches 1 and 2 landed, and their lines leave `KNOWN_ESCAPES`
and `PINNED_LEDGER` in the same commit.

## Per file

| file | endpoint | reader it escaped through | double |
|:--|:--|:--|:--|
| `src/__tests__/defaultFieldGroupsPage.sectionHeadings.test.tsx` | `POST /api/v1/security/explain` | `useRecordEditable.ts:76` (`apiFetch ?? fetch`) | `installExplainDouble()` in `beforeEach` |
| `src/__tests__/guideCrudAppRenders.test.tsx` | `POST /api/v1/security/explain` **and** `GET /api/task/42` | `useRecordEditable.ts:76` · plus `DetailView.tsx:616`, which calls the global `fetch` with no seam at all | `installFetchDouble()` in `beforeEach` — the one two-route router in this batch |
| `src/__tests__/recordDetailsBodySource.test.tsx` | `POST /api/v1/security/explain` | `useRecordEditable.ts:76` | `installExplainDouble()` in `beforeEach` |
| `src/renderers/__tests__/record-details.emptySectionDefault.test.tsx` | `POST /api/v1/security/explain` | `useRecordEditable.ts:76` | `installExplainDouble()` in `beforeEach` |

**Mechanism, measured rather than assumed.** A trap-guarded stack probe on the
guard's own attribution point, restored by blob hash afterwards, attributes every
escape in all four files. Three of them render `RecordDetailsRenderer`, which
renders `DetailView` (`record-details.tsx:302`); the fourth renders the guide's
`detail-view` snippet directly. Either way `DetailView` calls `useRecordEditable`
twice per render — `DetailView.tsx:290` for edit, `:296` for delete — and at
`useRecordEditable.ts:76` the hook degrades from the host's authenticated
`apiFetch` to the global `fetch` by design, so a standalone embed keeps rendering.
Under happy-dom that global is a real HTTP client whose document URL is
`http://localhost:3000`, so the relative path resolved to a live socket. The read
is best-effort, which is why these files stayed green while the request always
failed.

`guideCrudAppRenders` is the exception the dispatch flagged, now measured: one
extra call from `DetailView.tsx:616`, the `api` branch that does
`fetch(SCHEMA_API + '/' + SCHEMA_RESOURCEID)` with no `apiFetch` seam. Its counts
were 12 explain calls and exactly 1 record call. The probe was reverted with
`git checkout HEAD --`; the guard is byte-identical to `HEAD` afterwards
(`git diff HEAD` empty, `git status --porcelain` empty).

**The doubles** are batch 1/2's shape verbatim: `vi.stubGlobal('fetch', router)`
in `beforeEach`, `cleanup()` before `vi.unstubAllGlobals()` in `afterEach` (the
#7439 ordering). Each is a router, not a sink — it records every URL it is handed
and `afterEach` fails on any URL outside the set it serves, so an escape elsewhere
reds here instead of vanishing into a best-effort `catch`.

What they answer, and why no assertion moves:

- `/api/v1/security/explain` — the permissive verdict, in the two shapes the two
  explain hooks read: `{ record: { visible } }` for a single `recordId`,
  `{ records: [{ recordId, visible }] }` for a batched `recordIds`. Only the first
  is reached here; the batched branch is kept so the router stays byte-identical
  to its siblings rather than forking per file. `useRecordEditable` initialises
  `allowed` to `true` and its failure path leaves it there, so the permissive
  verdict and the absent verdict are the same value at every read site.
- `/api/task/42` — the record, which is the shape its reader consumes:
  `DetailView` does `res.json()` then `setData(result?.data || result)`. The one
  case that reaches it asserts only that the "No data source resolved" panel stays
  absent, and that panel is a wiring gate in `ElementDataSourceGate` decided
  before any response arrives — absent because the block declares `api`, not
  because the request failed. Serving the record exercises the success path this
  route always had without moving that assertion.

Nothing is skipped, quarantined or silenced.

## Ledger arithmetic

**12 to 8, in both lists.** The four names are deleted from `KNOWN_ESCAPES` in
`vitest.setup.network-escape-guard.ts` (each with its endpoint comment) and from
`PINNED_LEDGER` in `scripts/__tests__/network-escape-ledger.test.ts`, in this one
commit. Checked in lockstep by diffing the quoted paths of the two literals
against each other on the branch: **empty diff**, both at 8, zero `plugin-detail`
rows left in either. The pin's non-vacuity floor is `length > 0`, so 8 clears it.
Remaining 8: all app-shell, across four endpoint families.

No prose count moved. All three "21" references in the guard are provenance
claims about the original sweep on `67dadd6`, not live counts of the current list
— batch 1 and batch 2 had already normalised the two sentences that were live.

## Evidence

Per file, before then after (attribution lines / `ECONNREFUSED` lines, then the
post-fix run):

| file | before | after |
|:--|:--|:--|
| `defaultFieldGroupsPage.sectionHeadings` | 6 / 30 | 0 / 0, `Tests 3 passed` |
| `guideCrudAppRenders` | 13 / 63 | 0 / 0, `Tests 10 passed` |
| `recordDetailsBodySource` | 6 / 30 | 0 / 0, `Tests 3 passed` |
| `record-details.emptySectionDefault` | 22 / 110 | 0 / 0, `Tests 6 passed` |

Test counts are unchanged in every file — the doubles add no cases and remove none.

`pnpm exec vitest run packages/plugin-detail/ scripts/__tests__/network-escape-ledger.test.ts`
on this head: exit 0, `Test Files 133 passed (133)`, `Tests 1202 passed (1202)`,
and **zero** lines matching `network-escape` or `ECONNREFUSED` in the whole run.
That run also covers the third reader of `KNOWN_ESCAPES`,
`record-details.hideEmptyRetired-7129.test.tsx`, whose mention is prose in a
comment rather than a read.

**Ablation** (on the committed tree, one script with `trap ... EXIT INT TERM` and
absolute paths throughout). `guideCrudAppRenders.test.tsx` — the two-route file —
had its double reverted to its pre-batch-3 blob while its line stayed deleted from
BOTH ledgers. Mutation proven on disk, not by exit code: blob `54f75c12` to
`7f7951dd`, asserted equal to the `eeda78a7` base blob and unequal to `HEAD`'s;
anchors `installFetchDouble` 2 to 0 and `vi.stubGlobal` 1 to 0; that path present
0 times in `KNOWN_ESCAPES` and 0 times in `PINNED_LEDGER` during the run.
Predicted direction stated before running: red naming the file. **OBSERVED red** —
exit 1, `Test Files 1 failed (1)`, `Tests 6 failed | 4 passed (10)`, with
`Network escape: this test reached a REAL socket at http://localhost:3000/api/v1/security/explain, http://localhost:3000/api/task/42`
and `file: packages/plugin-detail/src/__tests__/guideCrudAppRenders.test.tsx`.
That the failure names **both** routes is the load-bearing half: it shows the
second route is genuinely served by this PR rather than incidentally quiet.
Restore proven by observation: blob back to `54f75c12`, `git diff HEAD` on that
path empty, `git status --porcelain` empty.

No dist preflight leg: these are the vitest projects' own test files and the root
config aliases every package specifier to `src` — measured, in that all four
suites ran green on a fully unbuilt tree before any build happened.

**Gates**, exit codes captured by redirect-then-capture, never through a pipe:

- `node scripts/check-changeset-presence.mjs` exit 0 — "4 source file(s) of 1
  released package(s) changed, and this change declares 1 changeset(s)"; the
  changeset has an EMPTY frontmatter, the explicit exemption for a test-only
  change under a released package's `src/`, and not a label.
- `pnpm check:control-bytes` exit 0 (6444 tracked text files), plus a `grep -naP`
  self-scan of the control range over all 7 changed paths, no hits.
- `node scripts/check-governed-queue-guard.mjs --test` over all 7 changed paths:
  exit 0, "NOT GOVERNED — 7 path(s) checked against 5 governed surface(s)".
- `pnpm type-check:scripts` exit 0 · `pnpm check:vi-mock-inherit` exit 0 (226 call
  sites judged, 226 inherit) · `pnpm check:vi-mock-specifiers` exit 0.
- Per-package `type-check` and `lint` for `plugin-detail` via
  `turbo --concurrency=2 --force`: exit 0, `Tasks: 15 successful, 15 total`,
  **0 eslint errors**. Proven non-vacuous rather than assumed:
  `tsc -p tsconfig.test.json --listFiles` names each of the four edited files
  exactly once, and `eslint --format json` lists each among the 183 linted files.
  Every warning in the touched files sits on a pre-existing line **outside** this
  diff's hunks (checked hunk range by hunk range), and the warning totals are
  unchanged. `type-check` `dependsOn ^build`, so turbo built the dependency
  closure first — the build was needed for the gate, not for the suites.

The repo-wide `eslint . --no-inline-config` run belongs to CI, and CI is not
awaited here: the report is delivered at draft-PR time per the dispatch contract.

## Concurrency

`origin/main` was `eeda78a7` when this branch was cut and was still `eeda78a7`
when this PR was opened (re-fetched into a private ref rather than reading a
shared remote-tracking name), so no merge was needed and every number above was
taken on the head that ships. Draft PR #7685 touches `plugin-detail`'s
`index.tsx` and `record-details.hideEmptyRetired-7129.test.tsx` — neither is in
this diff. #5174's in-flight batch cannot land in this package (its README left
the ledger with batch 17), and PR #8016 is disjoint.

#7996 is untouched and stays open: the `{ allowed: true }` stub it reports lives
in `record-details.hideEmptyRetired-7129.test.tsx`, which this PR deliberately
does not edit. Its shape was **not** copied — these four routers answer the keys
the hooks actually read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_