### PR TITLE
docs(guide): give schema-rendering.md's nested chart rows it can actually plot

### DIFF
--- a/content/docs/guide/schema-rendering.md
+++ b/content/docs/guide/schema-rendering.md
@@ -142,13 +142,27 @@ Schemas can be nested to create complex UIs:
         "body": {
           "type": "chart",
           "chartType": "bar",
-          "data": "${chartData}"
+          "xAxisKey": "month",
+          "series": [{ "name": "revenue" }],
+          "data": [
+            { "month": "Jan", "revenue": 120 },
+            { "month": "Feb", "revenue": 80 }
+          ]
         }
       }
     ]
   }
 }
 ```
+
+The chart's rows are written out on the node, and that is the spelling that plots. A
+`${…}` on node-level `data` is **not** one of the rows `SchemaRenderer` evaluates: the raw
+string reaches `ChartRenderer`, whose `Array.isArray(schema.data) ? schema.data : []` drops
+it, and the chart frame draws with nothing in it — no error, no warning. Since objectui#7113
+that node is also refused by name, `ChartSchema.data` being `z.array(z.record(…))`. `series`
+is required alongside it: `series[].name` picks the column to plot within each row, and
+`xAxisKey` names the category column. `chart` reads no `bind` either, so resolve the array in
+your own code and hand `SchemaRenderer` a schema whose rows are already on the node.
 
 ## Array Rendering
 


### PR DESCRIPTION
Fixes #7680

The **Nested Schemas** example taught a `chart` node binding node-level `data` to
`${chartData}`. One file, one node, 15 insertions, 1 deletion. Both directions are measured
below, on the bytes the page actually carries — every node in this PR body was lifted out of
the markdown by a script, not retyped.

⚠️ Tag-shaped fragments are spelled out in words where they occur: they do not survive this
field.

## Direction (a) — the parser

Built `@object-ui/types` zod mirror, `ChartSchema.safeParse`, controls in the same run so the
instrument is demonstrably not blind:

```
FAIL  AUTHORED TODAY (schema-rendering.md:145)
        path=["data"] :: Invalid input: expected array, received string
        path=["series"] :: Invalid input: expected array, received undefined
FAIL  CONTROL literal rows, no series
        path=["series"] :: Invalid input: expected array, received undefined
PASS  CONTROL literal rows + series
PASS  CANDIDATE properties-bound rows
FAIL  CONTROL expression still at node level
        path=["data"] :: Invalid input: expected array, received string
```

The card measured one refusal; there are **two**. `ChartSchema.series` is required and the
authored node carries none, so the second control isolates that half: literal rows alone still
fail, at `series` only. The corrected node passes.

Re-run against the node parsed out of the edited page rather than retyped:

```
chart node lifted from the page (occurrence 1): {"type":"chart","chartType":"bar","xAxisKey":"month","series":[{"name":"revenue"}],"data":[{"month":"Jan","revenue":120},{"month":"Feb","revenue":80}]}
  PASS ChartSchema.safeParse
json fences: 13, parsed: 11, chart nodes found: 1
```

## Direction (b) — the renderer

The chart sibling of objectui#6665's four-leg table, which had never been run on `chart`. Real
`SchemaRenderer` inside a `SchemaRendererProvider` holding `{ chartData: 2 rows }`, identical
`series` / `xAxisKey` in every leg, counting `.recharts-bar` after the lazy implementation
resolves:

| leg | `.recharts-bar` |
|---|---|
| node-level `data` = `${data.chartData}` | 0 |
| the same expression under `props` | 0 |
| the same expression under `properties` | 1 |
| literal rows on the node | 1 |

Same shape as the `data-table` table objectui#6665 measured — so this is the same mechanism,
not a chart-specific quirk.

Then the two nodes the page itself carries, each parsed out of its own markdown file and
rendered through the same harness:

```
BEFORE (origin/main 4922b83) node = {"type":"chart","chartType":"bar","data":"${chartData}"}
BEFORE (origin/main 4922b83) bars = 0  xAxisTicks = 0
AFTER  (this branch) node = {"type":"chart","chartType":"bar","xAxisKey":"month","series":[{"name":"revenue"}],"data":[{"month":"Jan","revenue":120},{"month":"Feb","revenue":80}]}
AFTER  (this branch) bars = 1  xAxisTicks = 2
```

The provider genuinely holds `chartData` in the BEFORE leg, so 0 bars over a drawn frame is
the defect and not a missing fixture.

## Why literal rows, and not the `properties` spelling

`properties` does carry the expression — leg 3 above plots. It is not what the guide should
teach, for three measured reasons:

1. `skills/objectui/rules/protocol.md`, objectui#6665's own remediation, already rules on this
   exact question: the `properties` row "works today, but its channel is objectui#4795's open
   contract question, not a taught surface", and the route the skill teaches is the host
   resolving the array onto the node. A guide teaching the opposite would contradict the
   published skill.
2. `BaseSchema` is `.passthrough()`, so rows written under `properties` are **not validated at
   all** — that is why the CANDIDATE leg passes in (a). Teaching it would move the rows off
   the one key `ChartSchema` can refuse, which is the wrong direction for metadata an AI
   writes.
3. `chart` reads no `bind` either — `ChartRenderer` calls no `useDataScope` — so there is no
   third declarative route to point at. Host-resolved rows on the node is the whole set.

## What the page says now

The example gains `series` / `xAxisKey` and literal rows, and one paragraph states the
mechanism: the raw string reaching `ChartRenderer`'s
`Array.isArray(schema.data) ? schema.data : []`, the refusal since objectui#7113, what the
`series[].name` / `xAxisKey` pair selects, and where to resolve the array instead.

## Gates — all on final HEAD `2e3b92680`, exit codes captured by redirect-then-capture

| gate | verdict line |
|---|---|
| `pnpm check:doc-types` | `Every documented component type is registered.` (188 files, 889 `type` literals) |
| `pnpm exec vitest run` on 6 doc pin suites | `Test Files 6 passed (6)` / `Tests 344 passed (344)` |
| `pnpm check:doc-fences` | `every TypeScript block in 227 document(s) is fenced ts/tsx/typescript` |
| `node scripts/check-doc-links.mjs` | `Links are valid across 17 scan roots.` |
| `pnpm check:doc-snippets` | `528 of 528 block(s) judged, 0 failed` — recorded, not evidence: JSON fences are outside its filter (objectui#5250) |
| `pnpm check:doc-example-readers` | `OK 80 documented symbol(s) … no @example hand-spells one` |
| `pnpm check:control-bytes` | `OK (scanned 6446 tracked text file(s))`; plus a `grep -naP` self-scan of the page, no hits |
| `node scripts/check-changeset-presence.mjs` | `No source or published contract of a released package changed in this range` |
| `node scripts/check-governed-queue-guard.mjs --test` | `NOT GOVERNED — 1 path(s) checked against 5 governed surface(s)` |

The six pin suites are `check-doc-component-types`, `check-doc-expression-carriage`,
`check-doc-links`, `check-doc-snippet-types`, `check-doc-example-shared-reader`,
`doc-version-claims` — derived by `git grep -l` for the page path plus every
`scripts/__tests__` file that walks `content/docs`. Docs-only PRs skip CI's test shards by
design, so these first run in the merge group unless run here.

`scripts/check-doc-component-types.mjs`'s per-page entry for this guide needed no change: the
edit adds no unregistered `type` literal and removes none of the three exempted ones, so
neither the gate nor its `stale-exemption` leg moves.

### The repo's own census agrees, in both directions

`scripts/check-doc-expression-carriage.mjs` is a report-only gate that names exactly this class
of defect. Reverse-verified after committing, by restoring the base file, re-running, and
restoring the branch file (`git diff HEAD` empty afterwards):

```
BEFORE:  361 node(s) with a string `type`; 65 ${…} site(s) on those nodes, 61 of them carried.
         4 site(s) in 3 page(s) author ${…} on a key nothing evaluates:
           content/docs/guide/schema-rendering.md
             :145  chart.data  (carriage rows for `chart`: none)
                      ${chartData}

AFTER:   361 node(s) with a string `type`; 64 ${…} site(s) on those nodes, 61 of them carried.
         3 site(s) in 2 page(s) author ${…} on a key nothing evaluates:
```

The page leaves the census. The three sites that remain belong to the three open cards the
gate's own footer names, and are untouched here.

### Repo-wide lint

`eslint . --no-inline-config` is CI's run, not this branch's. The narrowing is a measurement,
not an omission: `npx eslint --format json content/docs/guide/schema-rendering.md` reports the
one changed file with `"message": "File ignored because no matching configuration was supplied."`
— eslint's own config supplies no matching configuration for `.md`, and type-aware linting is
not in play, so this diff cannot move any judgement, on this file or on any untouched one.

## Out of scope, filed not fixed

objectui#8021 — the same page's **Data Context** section teaches a `data` prop the evaluator
never reads, plus a bare `${user.name}` spelling no scope holds. Different key family, three
separate passages, measured with a four-leg control table on that card. Not touched here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_