### PR TITLE
docs(plugin-form): fix bare-field visibleWhen spelling in fieldTabs example

### DIFF
--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -170,7 +170,7 @@ inactive tab unmount along with its values).
   fieldTabs: [
     { key: 'basics', label: 'Basics', fields: ['subject', 'status'] },
     { key: 'detail', label: 'Detail', description: 'Anything else', fields: ['description'] },
-    { key: 'billing', label: 'Billing', fields: ['vat_id'], visibleWhen: 'status == "won"' },
+    { key: 'billing', label: 'Billing', fields: ['vat_id'], visibleWhen: 'record.status == "won"' },
   ],
   defaultFieldTab?: 'basics',       // defaults to the first tab
   fieldTabsPosition?: 'top',        // 'top' | 'bottom' | 'left' | 'right'

--- a/packages/plugin-form/README.md
+++ b/packages/plugin-form/README.md
@@ -443,7 +443,7 @@ the renderer distribute the fields:
   fieldTabs: [
     { key: 'basics', label: 'Basics', fields: ['subject', 'status'] },
     { key: 'detail', label: 'Detail', description: 'Anything else', fields: ['description'] },
-    { key: 'billing', label: 'Billing', fields: ['vat_id'], visibleWhen: 'status == "won"' },
+    { key: 'billing', label: 'Billing', fields: ['vat_id'], visibleWhen: 'record.status == "won"' },
   ],
   defaultFieldTab?: 'basics',                    // defaults to the first tab
   fieldTabsPosition?: 'top',                     // 'top' | 'bottom' | 'left' | 'right'


### PR DESCRIPTION
Fixes #7834

## What changed

The `fieldTabs[].visibleWhen` example in plugin-form's docs used the bare
identifier `status == "won"` on the `billing` tab. plugin-form's
`evalFieldPredicate` binds the row scope as `record` only
(`buildScope({ record })` in `packages/core/src/evaluator/fieldRules.ts`),
so this spelling faults with an undeclared-reference error and, per
`TabbedForm.tsx`, a broken predicate fails OPEN — the tab it was meant to
hide stays visible. Rewrote both copies of the example to the canonical
`record.status == "won"`:

- `content/docs/plugins/plugin-form.mdx:173`
- `packages/plugin-form/README.md:446`

This is the same one-token rewrite PR #5758 made to this README's
`requiredWhen` example one block earlier.

## Why

Docs should not teach a spelling the engine never bound. No behavior
changed; this is a two-token text fix in two doc files.

## Scope

Two-token rewrite at exactly the two cited sites, per this repo's triage
ruling on #7834. Not widened into a prose-corpus pin (that is tracked
separately, per the triage boundary citing
`rowPredicateCanon.schemaCatalog.test.ts:16-23`); no `packages/**` source
changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_