### PR TITLE
fix(plugin-calendar): read the calendar config from `calendar`, never from `filter`

### DIFF
--- a/.changeset/7711-calendar-filter-is-not-a-config-slot.md
+++ b/.changeset/7711-calendar-filter-is-not-a-config-slot.md
@@ -1,0 +1,49 @@
+---
+'@object-ui/plugin-calendar': minor
+---
+
+Retire the `filter.calendar` configuration spelling on `object-calendar` (objectui#7711).
+
+**Breaking, deliberately.** `getCalendarConfig` no longer probes `schema.filter` for a
+`calendar` key. A calendar whose configuration was written as
+`filter: { calendar: { startDateField: … } }` no longer resolves a configuration at all
+and now renders the component's existing "Calendar configuration required. Please
+specify startDateField and titleField." refusal screen. Write the configuration under
+the declared `calendar` container instead — the read for it already existed, directly
+below the retired arm.
+
+`filter` is the query filter and nothing else. `@objectstack/spec`'s
+`ComponentPropsMap['object-calendar']` declares `calendar` as the configuration
+container and `filter` as the base query filter, and admits no `filter.calendar`
+spelling; the renderer nevertheless read the config out of the filter FIRST, and the
+comment on the canonical read below called *that* one the "backward compatibility"
+branch — the contract inverted in a source comment. The arm and the comment are both
+gone. No compatibility rung and no deprecation window, per AGENTS.md #0.1: a tolerant
+fallback fossilizes the wrong convention into a second de-facto contract.
+
+**The bug this closes is not only the retired spelling.** One authored key was being
+read twice with two incompatible meanings. `filter: { calendar: 'team' }` — a
+legitimate condition on a field literally named `calendar` — was returned as the
+`CalendarConfig` while the same object still went to `$filter` on the wire. `'team'` is
+truthy, so the refusal screen did not fire either: `startDateField` destructured off a
+string is `undefined`, every record fell into "unscheduled", and the grid rendered empty
+while the author's declared `calendar` block sat unread. Such a filter now reaches
+`$filter` untouched and the declared container is what configures the calendar.
+
+The calendar twin of the `filter.map` retirement in objectui#4034, with one measured
+difference: there is no `Array.prototype.calendar`, so `'calendar' in schema.filter` was
+never true for an array-shaped filter the way `'map' in schema.filter` was true for
+every one of them. Only an object-shaped filter with an own `calendar` key ever reached
+the retired arm, and the calendar answers the loss of a configuration with a named
+refusal on screen rather than the map's silent fallback to default field names — so this
+retirement carries no dev-time diagnostic rider.
+
+**Migration.** A census of this repo found **zero** authored `filter: { calendar: … }`
+sites (both the object-literal and JSON spellings, with positive controls and a planted
+fixture proving the search fires).
+
+Also in this change: the `calendarConfig` memo's dependency list drops `schema.filter`,
+which the function no longer reads, and gains the three flat keys it does read but the
+list never named — `startDateField`, `endDateField` and `allDayField`. Dropping `filter`
+removed an accidental co-trigger that used to pick those up whenever a filter changed
+alongside them.

--- a/packages/plugin-calendar/src/ObjectCalendar.tsx
+++ b/packages/plugin-calendar/src/ObjectCalendar.tsx
@@ -114,15 +114,46 @@ export interface ObjectCalendarComponentProps {
 }
 
 /**
- * Helper to get calendar configuration from schema
+ * Helper to get calendar configuration from schema.
+ *
+ * `filter` is the query filter and nothing else (objectui#7711) — the calendar
+ * twin of the `filter.map` retirement `ObjectMap` took in objectui#4034.
+ *
+ * This function used to read the calendar's configuration out of
+ * `schema.filter.calendar`, in an arm ABOVE the canonical read below, and the
+ * comment on that canonical read called IT the "backward compatibility" one.
+ * The contract was inverted there: `@objectstack/spec`'s
+ * `ComponentPropsMap['object-calendar']` declares `calendar` as the
+ * configuration container and `filter` as the base query filter, and admits no
+ * `filter.calendar` spelling at all. Both the arm and that comment are gone —
+ * this block consumes only what the spec declares.
+ *
+ * What the retired arm did: it made ONE authored key mean two incompatible
+ * things at once. `filter: { calendar: 'team' }` — a legitimate condition on a
+ * field literally named `calendar` — was read here as a `CalendarConfig`,
+ * while the very same object still went to `$filter` on the wire below.
+ *
+ * ⚠️ Measured difference from the map twin, and the reason this retirement
+ * needs no dev-time diagnostic rider like plugin-map's
+ * `warnOnLegacyFilterMapConfig`:
+ * - There is no `Array.prototype.calendar`, so `'calendar' in schema.filter`
+ *   never fired on an array-shaped filter — where `'map' in schema.filter`
+ *   fired on every single one of them, inherited method and merged `and` node
+ *   included. Only an object-shaped filter carrying an own `calendar` key ever
+ *   reached the retired arm.
+ * - A schema whose only configuration lived under the retired spelling now
+ *   returns null from here, and the early return answers null with the
+ *   existing "Calendar configuration required. Please specify startDateField
+ *   and titleField." refusal screen. The map fell back to DEFAULT field names,
+ *   which looks like bad data and is why it had to warn; the calendar names
+ *   what is missing on screen. Nothing is dropped without a trace.
+ *
+ * ⛔ No compatibility rung and no deprecation window, per AGENTS.md #0.1: a
+ * tolerant fallback fossilizes the wrong convention into a second de-facto
+ * contract. Pinned in `__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx`.
  */
 function getCalendarConfig(schema: ObjectGridSchema | CalendarSchema): CalendarConfig | null {
-  // Check if schema has calendar configuration
-  if ('filter' in schema && schema.filter && typeof schema.filter === 'object' && 'calendar' in schema.filter) {
-    return (schema.filter as any).calendar as CalendarConfig;
-  }
-  
-  // For backward compatibility, check if schema has calendar config at root
+  // The declared configuration container.
   if ((schema as any).calendar) {
     return (schema as any).calendar as CalendarConfig;
   }
@@ -244,13 +275,30 @@ export const ObjectCalendar: React.FC<ObjectCalendarComponentProps> = ({
     (schema as any).staticData,
     schema.objectName,
   ]);
+  // Every key `getCalendarConfig` reads, and nothing it does not.
+  //
+  // `schema.filter` used to head this list, because the function used to read
+  // `schema.filter.calendar` (objectui#7711). With that arm retired, keeping
+  // `filter` here would say the calendar's CONFIGURATION depends on the query
+  // filter — the very claim this card removes — and would recompute on every
+  // filter change for nothing.
+  //
+  // Dropping it also removes an accidental co-trigger, so the three flat keys
+  // the function reads but this list never named are added in the same edit:
+  // `startDateField` and `endDateField` (the canonical half of the
+  // `dateField` / `endField` pairs below, which WERE named) and `allDayField`.
+  // Before this change a simultaneous `filter` change could recompute the memo
+  // and pick those up by luck; that luck is now gone, so the list has to be
+  // honest. Pinned in `__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx`.
   const calendarConfig = useMemo(() => getCalendarConfig(schema), [
-    schema.filter,
     (schema as any).calendar,
+    (schema as any).startDateField,
     (schema as any).dateField,
+    (schema as any).endDateField,
     (schema as any).endField,
     (schema as any).titleField,
-    (schema as any).colorField
+    (schema as any).colorField,
+    (schema as any).allDayField
   ]);
   const hasInlineData = dataConfig?.provider === 'value';
   /**

--- a/packages/plugin-calendar/src/__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx
+++ b/packages/plugin-calendar/src/__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7711 — `filter` is the query filter and NOTHING else.
+ *
+ * `getCalendarConfig` used to probe `schema.filter` for a `calendar` key and,
+ * on a hit, return that value as the `CalendarConfig`. The same object went to
+ * `$filter` on the wire regardless, so ONE authored key was read twice with two
+ * incompatible meanings. `calendar` is the canonical container
+ * (`@objectstack/spec`'s `ComponentPropsMap['object-calendar']`); the
+ * `filter.calendar` spelling is retired outright, with no compatibility rung
+ * and no deprecation window (AGENTS.md #0.1, and the standing maintainer ruling
+ * of 2026-08-27 on staged migrations).
+ *
+ * The calendar twin of objectui#4034, which retired the identical `filter.map`
+ * shape on `ObjectMap`. Two things differ HERE, both measured on this branch,
+ * and together they are why this retirement carries no dev-time diagnostic
+ * rider like plugin-map's `warnOnLegacyFilterMapConfig`:
+ *
+ *   1. There is no `Array.prototype.calendar`. `'map' in schema.filter` was
+ *      TRUE for every array-shaped filter — the inherited method, the empty
+ *      array, and the `and` node a dataSource binding merges — which is what
+ *      upgraded #4034 from an observation to a live defect that broke authors
+ *      writing the CORRECT shape. `'calendar' in schema.filter` is false for
+ *      all three. Only an object-shaped filter with an OWN `calendar` key ever
+ *      reached the retired arm. Pinned as a mechanism below, because it is the
+ *      ground on which the rider was omitted.
+ *   2. When the retired spelling is the only place a config was written, this
+ *      component returns null and the early return renders the existing
+ *      "Calendar configuration required. Please specify startDateField and
+ *      titleField." screen. The map fell back to DEFAULT field names — an empty
+ *      map that looks like bad data — which is exactly why it had to warn. The
+ *      calendar already says what is missing, by name, on screen.
+ *
+ * BOTH DIRECTIONS ARE PINNED, because a fix that simply stopped reading the
+ * filter would also pass a retirement-only file: the second group asserts that
+ * a legitimate `FilterCondition` on a field literally NAMED `calendar` reaches
+ * `$filter` untouched and is never mistaken for configuration. That case is the
+ * whole point of the card.
+ *
+ * The last group covers the `calendarConfig` memo's dependency list, which this
+ * card edits: `schema.filter` left it (the function no longer reads it) and the
+ * three flat keys the function reads but the list never named were added.
+ * Removing `filter` removes an accidental co-trigger, so `startDateField` had
+ * to become a real dependency rather than one that happened to be picked up
+ * whenever the filter changed alongside it.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+
+// The month grid is orthogonal to everything this file observes (which config
+// won, and what reached `$filter`), and rendering it costs a month of DOM per
+// case. Same stub idiom as `ObjectCalendar.rowCeiling-7210`.
+vi.mock('../CalendarView', () => ({
+  CalendarView: ({ events }: any) => (
+    <div
+      data-testid="calendar-view"
+      data-event-count={String(events.length)}
+      data-event-titles={events.map((e: any) => e.title).join('|')}
+    />
+  ),
+}));
+
+import { ObjectCalendar } from '../ObjectCalendar';
+
+afterEach(cleanup);
+
+const REFUSAL = /Calendar configuration required/i;
+const OBJECT = 'visit';
+
+const today = new Date();
+const inThisMonth = (d: number) =>
+  new Date(today.getFullYear(), today.getMonth(), Math.min(d, 28), 9, 0, 0, 0).toISOString();
+
+/**
+ * Two rows carrying their date under DIFFERENT field names, so which field the
+ * resolved config names is legible from the rendered event titles alone.
+ */
+const ROWS = [
+  { id: 'r1', name: 'Placed by starts_at', starts_at: inThisMonth(10) },
+  { id: 'r2', name: 'Placed by other_at', other_at: inThisMonth(12) },
+];
+
+const CANONICAL = { startDateField: 'starts_at', titleField: 'name' };
+
+function makeDataSource() {
+  return {
+    find: vi.fn().mockResolvedValue({ data: ROWS }),
+    getObjectSchema: vi.fn().mockResolvedValue({
+      name: OBJECT,
+      fields: {
+        id: { type: 'text' },
+        name: { type: 'text' },
+        starts_at: { type: 'datetime' },
+        other_at: { type: 'datetime' },
+        calendar: { type: 'text' },
+      },
+    }),
+  } as any;
+}
+
+const view = () => screen.getByTestId('calendar-view');
+const titles = () => (view().getAttribute('data-event-titles') ?? '').split('|').filter(Boolean);
+
+/** The parameters of the most recent `find` call. */
+const lastFindParams = (ds: any) => ds.find.mock.calls[ds.find.mock.calls.length - 1][1];
+
+describe('objectui#7711 — the retired `filter.calendar` spelling yields NO configuration', () => {
+  it('refuses a schema whose only calendar config is stashed under `filter.calendar`', async () => {
+    const dataSource = makeDataSource();
+    const schema: any = {
+      type: 'object-calendar',
+      objectName: OBJECT,
+      filter: { calendar: CANONICAL },
+    };
+
+    render(<ObjectCalendar schema={schema} dataSource={dataSource} />);
+
+    // RED before the fix: the retired arm returned `CANONICAL` here, so the
+    // calendar rendered its events and no refusal ever appeared.
+    await waitFor(() => expect(screen.getByText(REFUSAL)).toBeTruthy());
+    expect(screen.queryByTestId('calendar-view')).toBeNull();
+  });
+
+  it('does not let `filter.calendar` shadow the canonical `calendar` container', async () => {
+    const dataSource = makeDataSource();
+    const schema: any = {
+      type: 'object-calendar',
+      objectName: OBJECT,
+      calendar: CANONICAL,
+      // A DIFFERENT config under the retired spelling. Before the fix this arm
+      // sat ABOVE the canonical read and won, so the events were placed by
+      // `other_at`; the declared container was unreachable whenever a filter
+      // happened to carry a `calendar` key.
+      filter: { calendar: { startDateField: 'other_at', titleField: 'name' } },
+    };
+
+    render(<ObjectCalendar schema={schema} dataSource={dataSource} />);
+
+    await waitFor(() => expect(screen.getByTestId('calendar-view')).toBeTruthy());
+    expect(titles()).toEqual(['Placed by starts_at']);
+  });
+});
+
+describe('objectui#7711 — a legitimate filter on a field NAMED `calendar` stays a filter', () => {
+  it('passes `filter: { calendar: ... }` to `$filter` untouched and reads config from `calendar`', async () => {
+    const dataSource = makeDataSource();
+    const authoredFilter = { calendar: 'team' };
+    const schema: any = {
+      type: 'object-calendar',
+      objectName: OBJECT,
+      calendar: CANONICAL,
+      filter: authoredFilter,
+    };
+
+    render(<ObjectCalendar schema={schema} dataSource={dataSource} />);
+
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    const params = lastFindParams(dataSource);
+
+    // The filter half: byte-for-byte what the author wrote, and the SAME
+    // object — nothing on this path may rewrite or re-key it.
+    expect(params.$filter).toEqual({ calendar: 'team' });
+    expect(params.$filter).toBe(authoredFilter);
+
+    // The configuration half: RED before the fix, where the retired arm
+    // returned the STRING `'team'` as the `CalendarConfig`. `'team'` is truthy,
+    // so the refusal screen never fired either; `startDateField` destructured
+    // off a string is `undefined`, every record fell into "unscheduled", and
+    // the grid rendered empty while the author's declared `calendar` block sat
+    // unread. A silent wrong answer, which is why this is the card's core case.
+    await waitFor(() => expect(screen.getByTestId('calendar-view')).toBeTruthy());
+    expect(titles()).toEqual(['Placed by starts_at']);
+  });
+
+  it('leaves an array-shaped filter untouched — the shape #4034 measured on the map', async () => {
+    const dataSource = makeDataSource();
+    const authoredFilter = [['calendar', '=', 'team']];
+    const schema: any = {
+      type: 'object-calendar',
+      objectName: OBJECT,
+      calendar: CANONICAL,
+      filter: authoredFilter,
+    };
+
+    render(<ObjectCalendar schema={schema} dataSource={dataSource} />);
+
+    await waitFor(() => expect(dataSource.find).toHaveBeenCalled());
+    expect(lastFindParams(dataSource).$filter).toBe(authoredFilter);
+    await waitFor(() => expect(screen.getByTestId('calendar-view')).toBeTruthy());
+    expect(titles()).toEqual(['Placed by starts_at']);
+  });
+
+  it('MECHANISM: `calendar` is not on `Array.prototype`, unlike `map`', () => {
+    // The ground on which this retirement omits plugin-map's dev warning. If a
+    // future `Array.prototype.calendar` ever existed, the retired probe would
+    // have had #4034's much wider blast radius and this file's reasoning about
+    // the rider would need re-opening — so the asymmetry is asserted, not
+    // assumed. The `map` half is the control that proves the probe can fire.
+    const arrayShapes: unknown[][] = [[], [['a', '=', 1]], [['a', '=', 1], 'and', ['b', '=', 2]]];
+    for (const f of arrayShapes) {
+      expect('calendar' in (f as object)).toBe(false);
+      expect('map' in (f as object)).toBe(true);
+    }
+    expect('calendar' in ({ calendar: 'team' } as object)).toBe(true);
+  });
+});
+
+describe('objectui#7711 — the `calendarConfig` memo depends on every key the config can come from', () => {
+  it('recomputes when only `startDateField` changes', async () => {
+    const dataSource = makeDataSource();
+    const base = { type: 'object-calendar', objectName: OBJECT, titleField: 'name' };
+    const schemaA: any = { ...base, startDateField: 'starts_at' };
+    const schemaB: any = { ...base, startDateField: 'other_at' };
+
+    const { rerender } = render(<ObjectCalendar schema={schemaA} dataSource={dataSource} />);
+    await waitFor(() => expect(screen.getByTestId('calendar-view')).toBeTruthy());
+    expect(titles()).toEqual(['Placed by starts_at']);
+
+    rerender(<ObjectCalendar schema={schemaB} dataSource={dataSource} />);
+
+    // RED before the dependency-list edit: `startDateField` was never a
+    // dependency, so this memo kept its cached config and the grid went on
+    // placing records by the OLD field.
+    await waitFor(() => expect(titles()).toEqual(['Placed by other_at']));
+  });
+
+  it('no longer recomputes on a filter change alone — `filter` is not a config key', async () => {
+    const dataSource = makeDataSource();
+    const base = { type: 'object-calendar', objectName: OBJECT, calendar: CANONICAL };
+
+    const { rerender } = render(
+      <ObjectCalendar schema={{ ...base, filter: [['a', '=', 1]] } as any} dataSource={dataSource} />,
+    );
+    await waitFor(() => expect(screen.getByTestId('calendar-view')).toBeTruthy());
+    expect(titles()).toEqual(['Placed by starts_at']);
+
+    // A new filter still reaches the wire — the fetch effect keeps its own
+    // `schema.filter` dependency, which this card does NOT touch.
+    const nextFilter = [['a', '=', 2]];
+    rerender(<ObjectCalendar schema={{ ...base, filter: nextFilter } as any} dataSource={dataSource} />);
+
+    await waitFor(() => expect(lastFindParams(dataSource).$filter).toBe(nextFilter));
+    expect(titles()).toEqual(['Placed by starts_at']);
+  });
+});


### PR DESCRIPTION
Fixes #7711

`filter` is the query filter and nothing else. `calendar` is the configuration container. One key, one meaning — which is also the shape objectui#7712 inherits, per the dispatch decision on the card.

## What changed

`getCalendarConfig` probed `schema.filter` for a `calendar` key and, on a hit, returned that value as the `CalendarConfig` — while the very same object still went to `$filter` on the wire at `:430`. One authored key was read twice with two incompatible meanings.

That arm is deleted. `@objectstack/spec`'s `ComponentPropsMap['object-calendar']` declares `calendar` as the configuration container and `filter` as the base query filter, and admits no `filter.calendar` spelling. The canonical read already existed **directly below** the retired arm, merely shadowed by it — so this is a deletion, not a new reading. The comment sitting on that canonical read called *it* the "backward compatibility" branch; the contract was inverted in a source comment, and that comment is gone too.

⛔ No compatibility rung, no deprecation warning, no staged window — objectui `AGENTS.md` #0.1 (a tolerant fallback fossilizes the wrong convention into a second de-facto contract), plus the standing maintainer ruling of 2026-08-27: 「项目在创业阶段，用户也很少，短期不考虑渐进。」

Also here: the `calendarConfig` memo's dependency list drops `schema.filter`, which the function no longer reads, and gains the three flat keys it *does* read but the list never named — `startDateField`, `endDateField`, `allDayField`. Dropping `filter` removes an accidental co-trigger that used to pick those up whenever a filter happened to change alongside them, so leaving the list as it was would have turned a latent staleness into a reachable one.

## The defect is not only the retired spelling

`filter: { calendar: 'team' }` — triage's example, a legitimate condition on a field literally named `calendar` — was returned as the `CalendarConfig`. `'team'` is truthy, so the refusal screen did not fire either: `startDateField` destructured off a string is `undefined`, every record fell into "unscheduled", and the grid rendered **empty** while the author's declared `calendar` block sat unread. Measured, not predicted — it is ablation A's third failure below.

## Two measured differences from the `filter.map` twin (objectui#4034)

Read first, as instructed. #4034 paired the same deletion with a narrow dev-time diagnostic (`warnOnLegacyFilterMapConfig`). This change carries **no rider**, and the grounds are measurements on this branch rather than a preference:

1. **No prototype hazard here.** `'map' in schema.filter` is `true` for *every* array-shaped filter — the empty array, a JSON-Rules array, and the `and` node a dataSource binding merges — via `Array.prototype.map`. That is what upgraded #4034 from an observation to a live defect breaking authors who wrote the **correct** shape. There is no `Array.prototype.calendar`: all three answer `false`. Only an object-shaped filter with an **own** `calendar` key ever reached the retired arm. Asserted as a mechanism case, with the `map` half as the control that proves the probe can fire.
2. **The calendar already fails loudly.** A schema whose only configuration lived under the retired spelling now returns `null`, and the existing early return renders "Calendar configuration required. Please specify startDateField and titleField." The map fell back to **default field names** — an empty map that looks like bad data — which is precisely why it had to warn. The calendar names what is missing, on screen. That is the outcome #4034's rider was invented to provide, already present structurally.

⚠️ Flagged for the reviewer: the dispatch order said both "copy #4034's retirement shape" and "no deprecation warning". Those two point opposite ways on the rider. It is resolved above **by measurement** rather than by picking a side, and the explicit prohibition is what shipped. If the reviewer reads point 2 differently, the rider is a small additive follow-up, not a rework.

## Census — zero, with controls that fire

Authored `filter: { calendar: ... }` sites in this repo: **0**. Both the object-literal and the JSON spellings, over all 6,532 tracked files.

A zero is only a reading if the search could have found a positive, so three controls:

| control | result |
|---|---|
| identical object-literal regex, `calendar` → `status` | 23 hits across `apps/`, `content/`, `eslint-rules/` |
| identical JSON regex, `calendar` → `project` | 1 hit (`content/docs/utilities/data-objectstack.mdx:331`) |
| planted fixtures carrying the exact retired spelling, in `packages/plugin-calendar/src/__tests__/` and `examples/` | both found by both regexes; removal verified by an empty `git status --porcelain` |

The first JSON control I wrote (`status`) returned zero **for the control too**, so it was discarded as NOT MEASURED and replaced with `project`, which the corpus actually contains.

## Tests

New pin: `packages/plugin-calendar/src/__tests__/ObjectCalendar.filterIsNotAConfigSlot-7711.test.tsx`, 7 cases. Both directions, because a change that merely stopped reading the filter would pass a retirement-only file: the second group asserts a legitimate filter on a field named `calendar` reaches `$filter` **untouched** (same object identity) and is never mistaken for configuration.

Green, all under the shared verify lock, at `7aa2ef5`:

- `pnpm exec vitest run packages/plugin-calendar/` — **25 files, 145 tests passed**
- `pnpm --filter @object-ui/plugin-calendar type-check` (`tsc --noEmit && tsc -p tsconfig.test.json`) — pass
- consumers (`app-shell` / `plugin-view` / `plugin-list` / `types` calendar + filter-source cases) — **6 files, 56 tests passed**
- `check:control-bytes`, `check:vi-mock-specifiers`, `check:vi-mock-inherit`, `check:unreferenced-sources`, `node scripts/check-changeset-presence.mjs` — all exit 0
- `eslint` on both changed files — 0 errors (86 pre-existing `no-explicit-any` warnings; `as any` count on the edited file moved 25 → 27, the memo's three added keys less the deleted read)

⚠️ Gate family derived **by hand** from the changed paths: `scripts/pm/dispatch-gates.mjs` does not exist in this repo. Repo-wide scans (`pnpm lint`, full `pnpm test`) are left to CI.

## Reverse verification

Two ablations, each committed-first, each proving the mutation reached disk before the result was read, each restored via `git checkout HEAD -- path` with an empty `git diff HEAD` as the restore proof. Directions predicted before running; both matched.

**A — reinstate the retired arm.** Marker count 0 → 1, blob hash moved off HEAD, `+3` lines. ⇒ **3 failed / 4 passed.** Red at the refusal case, the shadowing case, and the `filter: { calendar: 'team' }` case (received `[]` — the empty grid described above). Green, correctly, at the array-filter case and the mechanism case: reinstating the arm cannot break them, because the probe never fired on an array. That asymmetry is the point of point 1.

**B — revert only the memo dependency list.** Added-key count 1 → 0, removed-dep count 1 → 2, `+2/-4`. ⇒ **1 failed / 6 passed**, red at the `startDateField` rerender case and nowhere else.

## Scope

- ⛔ The registration manifest / `inputs` declaration is **not** touched — that is objectui#7712's landing point, held behind this card, and its shape is bound by the decision above. #7712 is not addressed here and remains open.
- ⛔ No `packages/spec` surface; objectstack read-only.
- Changeset: `.changeset/7711-calendar-filter-is-not-a-config-slot.md` (`minor`, deliberately breaking). The `skip-changeset` label is inert in this repo and was not applied.
- One out-of-scope finding filed unassigned as #8026: `ObjectCalendar` resolves `allDayField` into its config and never reads it, inferring `allDay` from the absence of an end date, while the `calendar-view` sibling honours the key. Not touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnpvbdoRisQdRAczkLwnf5)_