### PR TITLE
test(app-shell): serve batch 4's four `_drafts` probes from doubles (objectui#7307)

### DIFF
--- a/.changeset/network-escape-batch4.md
+++ b/.changeset/network-escape-batch4.md
@@ -1,0 +1,9 @@
+---
+---
+
+Test-only change: the four `app-shell` `console/home` network-escape files in batch 4 of
+objectui#7307 now serve their `/api/v1/meta/_drafts` probe from a recording double instead
+of a real socket, and their lines leave `KNOWN_ESCAPES` and `PINNED_LEDGER` together. The
+double answers an empty draft ledger, which is what `PendingDraftsBanner` already rendered
+from the failed read, so no assertion moves. No published behaviour changes — no product
+source is touched.

--- a/packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx
@@ -40,9 +40,9 @@
  */
 
 import '@testing-library/jest-dom/vitest';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const navigateMock = vi.fn();
@@ -118,6 +118,77 @@ vi.mock('../../../runtime-config', () => ({
 }));
 
 import { HomePage } from '../HomePage';
+
+/* ── The `_drafts` double (objectui#7307) ─────────────────────────────────────
+ * Every render of `HomePage` below mounts `PendingDraftsBanner`, which reads the
+ * env-wide pending-draft count through `usePendingDrafts({})`. That hook fetches
+ * `GET /api/v1/meta/_drafts` with the GLOBAL `fetch` — `usePendingDrafts.ts:48`,
+ * no `apiFetch` seam anywhere on the path — from its mount effect
+ * (`usePendingDrafts.ts:116` via `refresh` at `:94`). Under happy-dom that global
+ * is a real HTTP client and the document URL defaults to `http://localhost:3000`,
+ * so the relative path resolved to a live socket, once per case. The hook's read
+ * is best-effort (its `catch` leaves `count` at `null`), which is why these cases
+ * stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches. Deliberately NOT a blanket network stub: it
+ * records every URL it is handed and `afterEach` fails on any URL outside the set
+ * it serves, so an escape to somewhere else reds here instead of vanishing into
+ * that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: a known-EMPTY draft
+ * ledger, in the `{ drafts: [...] }` envelope `fetchPendingDrafts` reads (the one
+ * `MetadataClient.listDrafts` pins for this endpoint; the bare-array and
+ * `{ data: { drafts } }` shapes parse to the same rows). Empty rather than seeded
+ * is load-bearing: `PendingDraftsBanner` renders `null` when `(count ?? 0) <= 0`,
+ * and the failing request produced `count === null` — so an empty ledger yields
+ * byte-identical output to what these cases have always rendered, while a seeded
+ * one would add a banner and a `pending-drafts-publish` button to every case's
+ * tree. Routes are matched on the PATHNAME because the hook appends a
+ * `?packageId=` scope for package-bound callers; the full URL is what gets
+ * recorded.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const DRAFTS_ROUTE = '/api/v1/meta/_drafts';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let draftsCalls: string[] = [];
+
+/** The route key of a recorded URL: its pathname, without the scope query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/** Serve `GET /api/v1/meta/_drafts` as an empty ledger; record everything. */
+function installDraftsDouble() {
+  draftsCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      draftsCalls.push(url);
+      if (routeOf(url) !== DRAFTS_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, status: 200, json: async () => ({ drafts: [] }) };
+    }),
+  );
+}
+
+beforeEach(installDraftsDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(draftsCalls.filter((url) => routeOf(url) !== DRAFTS_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a mount effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
 
 const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
 

--- a/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx
@@ -42,9 +42,9 @@
  */
 
 import '@testing-library/jest-dom/vitest';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MePermissionsProvider, type MePermissionsResponse } from '@object-ui/permissions';
 
@@ -126,6 +126,77 @@ vi.mock('../../../runtime-config', () => ({
 }));
 
 import { HomePage } from '../HomePage';
+
+/* ── The `_drafts` double (objectui#7307) ─────────────────────────────────────
+ * Every render of `HomePage` below mounts `PendingDraftsBanner`, which reads the
+ * env-wide pending-draft count through `usePendingDrafts({})`. That hook fetches
+ * `GET /api/v1/meta/_drafts` with the GLOBAL `fetch` — `usePendingDrafts.ts:48`,
+ * no `apiFetch` seam anywhere on the path — from its mount effect
+ * (`usePendingDrafts.ts:116` via `refresh` at `:94`). Under happy-dom that global
+ * is a real HTTP client and the document URL defaults to `http://localhost:3000`,
+ * so the relative path resolved to a live socket, once per case. The hook's read
+ * is best-effort (its `catch` leaves `count` at `null`), which is why these cases
+ * stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches. Deliberately NOT a blanket network stub: it
+ * records every URL it is handed and `afterEach` fails on any URL outside the set
+ * it serves, so an escape to somewhere else reds here instead of vanishing into
+ * that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: a known-EMPTY draft
+ * ledger, in the `{ drafts: [...] }` envelope `fetchPendingDrafts` reads (the one
+ * `MetadataClient.listDrafts` pins for this endpoint; the bare-array and
+ * `{ data: { drafts } }` shapes parse to the same rows). Empty rather than seeded
+ * is load-bearing: `PendingDraftsBanner` renders `null` when `(count ?? 0) <= 0`,
+ * and the failing request produced `count === null` — so an empty ledger yields
+ * byte-identical output to what these cases have always rendered, while a seeded
+ * one would add a banner and a `pending-drafts-publish` button to every case's
+ * tree. Routes are matched on the PATHNAME because the hook appends a
+ * `?packageId=` scope for package-bound callers; the full URL is what gets
+ * recorded.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const DRAFTS_ROUTE = '/api/v1/meta/_drafts';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let draftsCalls: string[] = [];
+
+/** The route key of a recorded URL: its pathname, without the scope query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/** Serve `GET /api/v1/meta/_drafts` as an empty ledger; record everything. */
+function installDraftsDouble() {
+  draftsCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      draftsCalls.push(url);
+      if (routeOf(url) !== DRAFTS_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, status: 200, json: async () => ({ drafts: [] }) };
+    }),
+  );
+}
+
+beforeEach(installDraftsDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(draftsCalls.filter((url) => routeOf(url) !== DRAFTS_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a mount effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
 
 /**
  * The `/me/permissions` answer recorded on objectstack#8270 for the EE

--- a/packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx
@@ -38,9 +38,9 @@
  */
 
 import '@testing-library/jest-dom/vitest';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const navigateMock = vi.fn();
@@ -120,6 +120,77 @@ vi.mock('../../../runtime-config', () => ({
 }));
 
 import { HomePage } from '../HomePage';
+
+/* ── The `_drafts` double (objectui#7307) ─────────────────────────────────────
+ * Every render of `HomePage` below mounts `PendingDraftsBanner`, which reads the
+ * env-wide pending-draft count through `usePendingDrafts({})`. That hook fetches
+ * `GET /api/v1/meta/_drafts` with the GLOBAL `fetch` — `usePendingDrafts.ts:48`,
+ * no `apiFetch` seam anywhere on the path — from its mount effect
+ * (`usePendingDrafts.ts:116` via `refresh` at `:94`). Under happy-dom that global
+ * is a real HTTP client and the document URL defaults to `http://localhost:3000`,
+ * so the relative path resolved to a live socket, once per case. The hook's read
+ * is best-effort (its `catch` leaves `count` at `null`), which is why these cases
+ * stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches. Deliberately NOT a blanket network stub: it
+ * records every URL it is handed and `afterEach` fails on any URL outside the set
+ * it serves, so an escape to somewhere else reds here instead of vanishing into
+ * that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: a known-EMPTY draft
+ * ledger, in the `{ drafts: [...] }` envelope `fetchPendingDrafts` reads (the one
+ * `MetadataClient.listDrafts` pins for this endpoint; the bare-array and
+ * `{ data: { drafts } }` shapes parse to the same rows). Empty rather than seeded
+ * is load-bearing: `PendingDraftsBanner` renders `null` when `(count ?? 0) <= 0`,
+ * and the failing request produced `count === null` — so an empty ledger yields
+ * byte-identical output to what these cases have always rendered, while a seeded
+ * one would add a banner and a `pending-drafts-publish` button to every case's
+ * tree. Routes are matched on the PATHNAME because the hook appends a
+ * `?packageId=` scope for package-bound callers; the full URL is what gets
+ * recorded.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const DRAFTS_ROUTE = '/api/v1/meta/_drafts';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let draftsCalls: string[] = [];
+
+/** The route key of a recorded URL: its pathname, without the scope query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/** Serve `GET /api/v1/meta/_drafts` as an empty ledger; record everything. */
+function installDraftsDouble() {
+  draftsCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      draftsCalls.push(url);
+      if (routeOf(url) !== DRAFTS_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, status: 200, json: async () => ({ drafts: [] }) };
+    }),
+  );
+}
+
+beforeEach(installDraftsDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(draftsCalls.filter((url) => routeOf(url) !== DRAFTS_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a mount effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
 
 const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
 

--- a/packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx
+++ b/packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx
@@ -38,9 +38,9 @@
  */
 
 import '@testing-library/jest-dom/vitest';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const navigateMock = vi.fn();
@@ -116,6 +116,77 @@ vi.mock('../../../runtime-config', () => ({
 }));
 
 import { HomePage } from '../HomePage';
+
+/* ── The `_drafts` double (objectui#7307) ─────────────────────────────────────
+ * Every render of `HomePage` below mounts `PendingDraftsBanner`, which reads the
+ * env-wide pending-draft count through `usePendingDrafts({})`. That hook fetches
+ * `GET /api/v1/meta/_drafts` with the GLOBAL `fetch` — `usePendingDrafts.ts:48`,
+ * no `apiFetch` seam anywhere on the path — from its mount effect
+ * (`usePendingDrafts.ts:116` via `refresh` at `:94`). Under happy-dom that global
+ * is a real HTTP client and the document URL defaults to `http://localhost:3000`,
+ * so the relative path resolved to a live socket, once per case. The hook's read
+ * is best-effort (its `catch` leaves `count` at `null`), which is why these cases
+ * stayed green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches. Deliberately NOT a blanket network stub: it
+ * records every URL it is handed and `afterEach` fails on any URL outside the set
+ * it serves, so an escape to somewhere else reds here instead of vanishing into
+ * that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: a known-EMPTY draft
+ * ledger, in the `{ drafts: [...] }` envelope `fetchPendingDrafts` reads (the one
+ * `MetadataClient.listDrafts` pins for this endpoint; the bare-array and
+ * `{ data: { drafts } }` shapes parse to the same rows). Empty rather than seeded
+ * is load-bearing: `PendingDraftsBanner` renders `null` when `(count ?? 0) <= 0`,
+ * and the failing request produced `count === null` — so an empty ledger yields
+ * byte-identical output to what these cases have always rendered, while a seeded
+ * one would add a banner and a `pending-drafts-publish` button to every case's
+ * tree. Routes are matched on the PATHNAME because the hook appends a
+ * `?packageId=` scope for package-bound callers; the full URL is what gets
+ * recorded.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+const DRAFTS_ROUTE = '/api/v1/meta/_drafts';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let draftsCalls: string[] = [];
+
+/** The route key of a recorded URL: its pathname, without the scope query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/** Serve `GET /api/v1/meta/_drafts` as an empty ledger; record everything. */
+function installDraftsDouble() {
+  draftsCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      draftsCalls.push(url);
+      if (routeOf(url) !== DRAFTS_ROUTE) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, status: 200, json: async () => ({ drafts: [] }) };
+    }),
+  );
+}
+
+beforeEach(installDraftsDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the hook's best-effort `catch`.
+  expect(draftsCalls.filter((url) => routeOf(url) !== DRAFTS_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a mount effect settling in that window
+  // escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
 
 const app = (name: string, extra: Record<string, unknown> = {}) => ({ name, label: name, ...extra });
 

--- a/scripts/__tests__/network-escape-ledger.test.ts
+++ b/scripts/__tests__/network-escape-ledger.test.ts
@@ -39,10 +39,6 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * and must be done in lockstep with `KNOWN_ESCAPES`.
  */
 const PINNED_LEDGER: readonly string[] = [
-  'packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx',
-  'packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx',
-  'packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx',
-  'packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx',
   'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx',
   'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.specKeys.test.tsx',
   'packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx',

--- a/vitest.setup.network-escape-guard.ts
+++ b/vitest.setup.network-escape-guard.ts
@@ -113,14 +113,6 @@ const ESCAPE_ORIGIN = /^https?:\/\/(?:127\.0\.0\.1|localhost):3000(?:\/|$)/;
  * ONLY SHRINKS. The comment on each line is the endpoint it reached.
  */
 export const KNOWN_ESCAPES: ReadonlySet<string> = new Set([
-  // /api/v1/meta/_drafts
-  'packages/app-shell/src/console/home/__tests__/HomePage.approvalsTarget.test.tsx',
-  // /api/v1/meta/_drafts
-  'packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx',
-  // /api/v1/meta/_drafts
-  'packages/app-shell/src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx',
-  // /api/v1/meta/_drafts
-  'packages/app-shell/src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx',
   // /api/v1/meta/object
   'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx',
   // /api/v1/meta/object


### PR DESCRIPTION
Part of #7307 — batch 4 of the network-escape burn-down (batch 1 was #7999, batch 2 #8013, batch 3 #8019).

The four `app-shell` `console/home` rows now serve their `/api/v1/meta/_drafts`
probe from a recording double, and their lines leave `KNOWN_ESCAPES` and
`PINNED_LEDGER` in the same commit.

## Per file

Every one of the four takes the same single route through the same single call
site — measured, not assumed (see below). No file in this batch needs a second
route, so all four routers are byte-identical.

| file | endpoint | reader it escaped through | double |
|:--|:--|:--|:--|
| `src/console/home/__tests__/HomePage.approvalsTarget.test.tsx` | `GET /api/v1/meta/_drafts` | `usePendingDrafts.ts:48`, a bare global `fetch` with no `apiFetch` seam | `installDraftsDouble()` in a module-scope `beforeEach` |
| `src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx` | `GET /api/v1/meta/_drafts` | `usePendingDrafts.ts:48` | `installDraftsDouble()` in a module-scope `beforeEach` |
| `src/console/home/__tests__/HomePage.inboxLinksTarget.test.tsx` | `GET /api/v1/meta/_drafts` | `usePendingDrafts.ts:48` | `installDraftsDouble()` in a module-scope `beforeEach` |
| `src/console/home/__tests__/HomePage.notificationDeepLink.test.tsx` | `GET /api/v1/meta/_drafts` | `usePendingDrafts.ts:48` | `installDraftsDouble()` in a module-scope `beforeEach` |

**Mechanism, measured rather than assumed.** A trap-guarded stack probe injected
at the guard's own attribution point, restored by blob hash afterwards, attributed
every escape in all four files. Each render of `HomePage` mounts
`PendingDraftsBanner`, which reads the env-wide count through
`usePendingDrafts({})`; the hook's mount effect (`usePendingDrafts.ts:116` via
`refresh` at `:94`) calls `fetchPendingDrafts`, which reaches the global `fetch` at
`usePendingDrafts.ts:48`. There is no `apiFetch` seam anywhere on that path — unlike
the `apiFetch ?? fetch` fallbacks batches 1 to 3 met, this hook only ever had the
global. Under happy-dom that global is a real HTTP client whose document URL is
`http://localhost:3000`, so the relative path resolved to a live socket, exactly
once per case (5 / 9 / 9 / 6 escapes against 5 / 9 / 9 / 6 tests). The read is
best-effort — its `catch` leaves `count` at `null` — which is why these files stayed
green while the request always failed.

Every escaped URL in all four files was `http://localhost:3000/api/v1/meta/_drafts`,
with no second endpoint anywhere. The probe was reverted with
`git checkout HEAD -- path`; the guard is byte-identical to `HEAD` afterwards
(blob back to `347ed78b`, `git diff HEAD` empty, `git status --porcelain` empty).

**The doubles** are batch 1/2/3's shape verbatim: `vi.stubGlobal('fetch', router)`
in `beforeEach`, `cleanup()` before `vi.unstubAllGlobals()` in `afterEach` (the
#7439 ordering). Each is a router, not a sink — it records every URL it is handed
and `afterEach` fails on any URL outside the set it serves, so an escape elsewhere
reds here instead of vanishing into the hook's best-effort `catch`. Routes are
matched on the PATHNAME, because `fetchPendingDrafts` appends a `?packageId=` scope
for package-bound callers; the full URL is what gets recorded.

What it answers, and why no assertion moves:

- `/api/v1/meta/_drafts` — a known-EMPTY draft ledger, in the `{ drafts: [...] }`
  envelope `fetchPendingDrafts` reads (the shape `MetadataClient.listDrafts` pins
  for this endpoint; the bare-array and `{ data: { drafts } }` shapes parse to the
  same rows).
- **Empty rather than seeded is load-bearing here**, and this is where the dispatch's
  warning about batches 1 to 3 was right not to transfer: the explain verdict those
  batches served was fail-open and unread, but a `_drafts` answer feeds visible UI
  state. `PendingDraftsBanner` renders `null` when `(count ?? 0) is at most 0`, and
  the failing request produced `count === null`, so an empty ledger yields
  byte-identical output to what these cases have always rendered. A seeded ledger
  would have added a banner paragraph and a `pending-drafts-publish` button to every
  case's tree — that would move what the files prove, not just what they fetch.
- No case in any of the four asserts anything about pending drafts, and none of them
  depends on the request FAILING: each stubs `useMetadataClient` and
  `usePublishAllDrafts` at the module boundary already, and asserts only navigation
  targets, CTA enablement, or gate copy.

Nothing is skipped, quarantined or silenced.

**Hook placement.** All four install at MODULE scope rather than inside the existing
`describe`-level `beforeEach`. Two of the four (`authoringCapabilityGate`,
`inboxLinksTarget`) carry nested `describe` blocks with their own `beforeEach`, and
a module-scope pair is the one placement that provably covers every block in every
file; the ablation below runs against the file with the most nesting for exactly
that reason. The router's shape and the #7439 teardown ordering are unchanged either
way.

## Ledger arithmetic

**8 to 4, in both lists.** The four names are deleted from `KNOWN_ESCAPES` in
`vitest.setup.network-escape-guard.ts` (each with its endpoint comment) and from
`PINNED_LEDGER` in `scripts/__tests__/network-escape-ledger.test.ts`, in one commit.
Checked in lockstep by diffing the quoted paths of the two literals against each
other on the final head: **empty diff**, both at 4, zero `console/home` rows left in
either. The pin's non-vacuity floor is `length` greater than 0, so 4 clears it.

Remaining 4, all app-shell, in three endpoint families: `/api/v1/meta/object`
(`FlowNodeInspector.inactiveRetained`, `FlowNodeInspector.specKeys`),
`/api/v1/automation/_status` (`StudioDesignSurface.designerRegistryMissing`),
`/api/v1/ai/conversations` (`studioSurfaceContext`).

No prose count moved. All five "21" references across the two ledger files are
provenance claims about the original sweep on `67dadd6`, not live counts of the
current list — re-checked line by line, the same reading batch 3 recorded.

## Evidence

Per file, before then after (attribution lines / `ECONNREFUSED` lines, then the
post-fix run on the final head):

| file | before | after |
|:--|:--|:--|
| `HomePage.approvalsTarget` | 5 / 15 | 0 / 0, `Tests 5 passed` |
| `HomePage.authoringCapabilityGate` | 9 / 19 | 0 / 0, `Tests 9 passed` |
| `HomePage.inboxLinksTarget` | 9 / 27 | 0 / 0, `Tests 9 passed` |
| `HomePage.notificationDeepLink` | 6 / 18 | 0 / 0, `Tests 6 passed` |

Test counts are unchanged in every file — the doubles add no cases and remove none.

`pnpm exec vitest run packages/app-shell/src/console/home/ scripts/__tests__/network-escape-ledger.test.ts`
on the final head `6a0c8d8dd`: exit 0, `Test Files 13 passed (13)`,
`Tests 72 passed (72)`, and **zero** lines matching `network-escape` or
`ECONNREFUSED` in the whole run.

The **whole `app-shell` package** plus the pin also ran green (`Test Files 633 passed
(633)`, `Tests 6080 passed | 1 skipped (6081)`, exit 0, 918s). That run is a superset,
not a zero-escape claim: its 18 remaining attribution lines all name the four rows
still on the ledger (`FlowNodeInspector.specKeys` 3, `studioSurfaceContext` 4,
`FlowNodeInspector.inactiveRetained` 1, `StudioDesignSurface.designerRegistryMissing`
1) and **zero** of them name a `console/home` file. It was taken on the pre-merge
commit `d4558f65f`; the merge that followed touched none of `app-shell`'s sources,
and the 13-file scope above was re-run on the merged head.

**Ablation** (on the committed tree, one script with `trap ... EXIT INT TERM` and
absolute paths throughout). `HomePage.authoringCapabilityGate.test.tsx` — the file
with the most `describe` nesting, so the one that most needs the module-scope
placement to be real — had its double reverted to its pre-batch-4 blob while its
line stayed deleted from BOTH ledgers. Mutation proven on disk, not by exit code:
blob `8c6b9dc7` to `ddee802f`, asserted equal to the `83a9d22a` base blob and
unequal to `HEAD`'s; anchors `installDraftsDouble` 2 to 0 and `vi.stubGlobal` 1 to 0;
that path counted 0 times in `KNOWN_ESCAPES` and 0 times in `PINNED_LEDGER` during
the run. Predicted direction stated before running: red naming the file.
**OBSERVED red** — exit 1, `Test Files 1 failed (1)`, `Tests 9 failed (9)`, with
`Network escape: this test reached a REAL socket at http://localhost:3000/api/v1/meta/_drafts`
and `file: packages/app-shell/src/console/home/__tests__/HomePage.authoringCapabilityGate.test.tsx`.
All nine cases failed, across all five `describe` blocks — which is the half that
shows the module-scope hooks really are what covers every block. Restore proven by
observation: blob back to `8c6b9dc7`, `git diff HEAD` on that path empty,
`git status --porcelain` empty.

No dist preflight leg: these are the vitest projects' own test files and the root
config aliases every package specifier to `src` — measured, in that all four suites
ran, before and after, on a fully unbuilt tree (fresh install, no build had happened
yet).

**Gates**, exit codes captured by redirect-then-capture, never through a pipe, all
re-taken on the final head `6a0c8d8dd`:

- `node scripts/check-changeset-presence.mjs` exit 0 — "4 source file(s) of 1
  released package(s) changed, and this change declares 1 changeset(s)"; the
  changeset has an EMPTY frontmatter, the explicit exemption for a test-only change
  under a released package's `src/`, and not a label.
- `pnpm check:control-bytes` exit 0 (6449 tracked text files), plus a `grep -naP`
  self-scan of the control range over every changed path, no hits.
- `node scripts/check-governed-queue-guard.mjs --test` over all changed paths: exit
  0, "NOT GOVERNED — 15 path(s) checked against 5 governed surface(s)".
- `pnpm type-check:scripts` exit 0 · `pnpm check:vi-mock-inherit` exit 0 (229 call
  sites judged on the widened specifier set #8020 landed, 229 inherit, 0
  auto-mocked) · `pnpm check:vi-mock-specifiers` exit 0.
- `pnpm type-check:vitest-setup` exit 0 — owed because this diff edits
  `vitest.setup.network-escape-guard.ts`, which lives in that program and no other.
  It is build-dependent by construction (`vitest.setup.dom.tsx` side-effect-imports
  four packages through their `exports.types`), so its first reading on the unbuilt
  tree was TS2882 on those four imports — a missing prerequisite, not a red gate, and
  it is green on the built tree. CI documents the same ordering at
  `.github/workflows/ci.yml:623`.
- Per-package `type-check` and `lint` for `app-shell` via
  `turbo --concurrency=2 --force`: exit 0, `Tasks: 32 successful, 32 total`,
  **0 eslint errors**. Proven non-vacuous rather than assumed:
  `tsc -p tsconfig.test.json --listFiles` names each of the four edited files exactly
  once (in a 4421-file program), and `eslint --format json` lists each among the 1087
  linted files. Warning totals are unchanged (2894) and no warning is mine: each
  touched file's warnings sit on pre-existing lines strictly BEFORE this diff's
  insertion point, checked hunk range by hunk range (approvalsTarget warning at line
  74 vs hunks at 43, 45 and 122+; authoringCapabilityGate 63/83 vs 45, 47, 130+;
  inboxLinksTarget 73/85/86 vs 41, 43, 124+; notificationDeepLink 71/82 vs 41, 43,
  120+), and the inserted block contributes none.

The repo-wide `eslint . --no-inline-config` run belongs to CI, and CI is not awaited
here: the report is delivered at draft-PR time per the dispatch contract.
`Live E2E (informational)` is red on every branch today for the upstream reason
tracked in #7990 — not this PR's.

## Concurrency

`origin/main` moved from `83a9d22a` to `68912772` while this branch was being
verified (#8022, #8020, #8023 landed). It was merged in before this PR was opened —
read with `git ls-remote` and fetched into a private ref rather than moving the
shared remote-tracking name — and **every reading above was re-taken on the merged
head `6a0c8d8dd`**, including the one gate whose script the merge changed
(`scripts/check-vi-mock-inherit.mjs`, widened by #8020 from 226 to 229 judged call
sites; the four edited files pass under the widened rule). None of the three merged
commits touches `console/home` or either ledger.

Draft PR #7685 touches 17 `app-shell` paths, none under `console/home/`, and
`FlowNodeInspector.specKeys` — a batch 5 row deliberately left on the ledger here.
The `domain:ui` seat is active in `packages/app-shell`; this diff touches TEST files
under `console/home/__tests__/` only, and no product source at all.

#7996 and #8014 are untouched and stay open: neither concerns this endpoint, and
neither double's shape was copied — this router answers the key the reader actually
reads.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_