### PR TITLE
fix(plugin-charts): pie / donut / radar / scatter render as the family they name

### DIFF
--- a/.changeset/7401-chart-family-from-type.md
+++ b/.changeset/7401-chart-family-from-type.md
@@ -1,0 +1,13 @@
+---
+"@object-ui/plugin-charts": patch
+---
+
+fix(plugin-charts): `pie-chart`, `donut-chart`, `radar-chart` and `scatter-chart` render as the family they name
+
+A schema written as `type: 'pie-chart'` (or `plugin-charts:pie-chart`, and likewise donut / radar / scatter) drew a **bar chart**. The four registrations declared their family as `defaultProps: { chartType: … }`, and nothing on the SDUI path has ever read a registration's `defaultProps` — so `ChartRenderer` resolved no family and `AdvancedChartImpl` fell to its `'bar'` default. Valid data, a confidently wrong picture, and no `data-chart-error` that could fire.
+
+`ChartRenderer` now derives the family from the schema's own `type`, through `normalizeChartSchema` — the package's single translation point, so the exported `normalizeChartSchema` answers what the runtime actually draws. An explicit `chartType` still wins, so `plugin-charts:chart` with `chartType: 'scatter'` is unchanged.
+
+The five inert `defaultProps: { chartType: … }` are removed with it rather than left beside a mechanism that works. Registration `defaultProps` remains unread on the SDUI path repo-wide; activating it generally is a separate, wider change and is not this one.
+
+⚠️ `scatter-chart` now genuinely reaches the scatter arm, so a two-series `scatter-chart` now renders the `scatter-multi-series` refusal it was always supposed to.

--- a/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
+++ b/packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx
@@ -486,6 +486,40 @@ const CHART_DATA = [
 ];
 const CHART_SERIES = [{ dataKey: 'sales' }, { dataKey: 'revenue' }];
 /**
+ * The scatter target's own rows and series, because scatter is the one family
+ * here that {@link CHART_DATA} / {@link CHART_SERIES} cannot reach (objectui#7401).
+ *
+ * ⭐ Until objectui#7401 this target was NOT SWEPT AT ALL. Its registration
+ * declared its family as `defaultProps: { chartType: 'scatter' }`, nothing on
+ * the SDUI path read that, and so `plugin-charts:scatter-chart` rendered — and
+ * passed this gate — as a BAR chart. `plugin-charts:pie-chart`,
+ * `donut-chart` and `radar-chart` were blind in exactly the same way: four of
+ * this package's nine targets were one target, measured four times.
+ *
+ * That is how the defect surfaced, and this file is where the evidence was:
+ * PR #7400's `scatter-multi-series` refusal (objectui#7194) SHOULD have
+ * reddened this two-series entry the day it landed, and did not. Now that the
+ * type resolves to its own family the two meet, so the entry has to be a
+ * schema scatter can actually draw, on both counts:
+ *
+ *   - ONE series. Scatter binds one measure — `series[0].dataKey` is the
+ *     `YAxis` key — and a second series is refused by name, not projected.
+ *     ⛔ Two series here would sweep the REFUSAL's markup, leaving the scatter
+ *     renderer exactly as unswept as it has been.
+ *   - A NUMERIC x. Scatter's category axis is a measure, so `name: 'Jan'` has
+ *     no position and every row is unplaceable (`no-plottable-points`) — the
+ *     other refusal, and the same blindness one step over.
+ *
+ * ⛔ Do not "simplify" this back onto the shared constants: both of those
+ * refusals render attribute-clean markup, which is precisely the phantom-clean
+ * pass this gate's objectui#5630 section warns about.
+ */
+const SCATTER_DATA = [
+  { x: 10, y: 400, value: 400 },
+  { x: 20, y: 300, value: 300 },
+];
+const SCATTER_SERIES = [{ dataKey: 'y' }];
+/**
  * The two OBJECT-BOUND chart targets (`plugin-charts:object-chart`,
  * `view:chart`). They stay object-bound — `objectName` is what makes them a
  * different registry path from the six inline chart targets above, which reach
@@ -800,7 +834,7 @@ const TARGETS: Readonly<Record<string, readonly Target[]>> = {
     { type: 'plugin-charts:pie-chart', schemaExtras: { data: CHART_DATA, series: CHART_SERIES }, ready: '[data-slot="chart"]' },
     { type: 'plugin-charts:donut-chart', schemaExtras: { data: CHART_DATA, series: CHART_SERIES }, ready: '[data-slot="chart"]' },
     { type: 'plugin-charts:radar-chart', schemaExtras: { data: CHART_DATA, series: CHART_SERIES }, ready: '[data-slot="chart"]' },
-    { type: 'plugin-charts:scatter-chart', schemaExtras: { data: CHART_DATA, series: CHART_SERIES }, ready: '[data-slot="chart"]' },
+    { type: 'plugin-charts:scatter-chart', schemaExtras: { data: SCATTER_DATA, xAxisKey: 'x', series: SCATTER_SERIES }, ready: '[data-slot="chart"]' },
     { type: 'plugin-charts:object-chart', schemaExtras: OBJECT_CHART_EXTRAS, ready: '[data-slot="chart"]' },
     { type: 'view:chart', schemaExtras: OBJECT_CHART_EXTRAS, ready: '[data-slot="chart"]' },
   ],

--- a/packages/plugin-charts/src/__tests__/chart-family-from-type-7401.test.tsx
+++ b/packages/plugin-charts/src/__tests__/chart-family-from-type-7401.test.tsx
@@ -98,9 +98,23 @@ const NUMERIC_ROWS = [
 const TWO_SERIES = [{ dataKey: 'ym' }, { dataKey: 'zm' }];
 const ONE_SERIES = [{ dataKey: 'ym' }];
 
+/**
+ * `SchemaRendererProvider` requires a data source, and every schema below
+ * carries its rows INLINE — so this one answers with nothing, exactly as the
+ * app-shell sweep's does. A chart that started querying instead of plotting
+ * its own `data` would show up here as an empty plot, not as a pass.
+ */
+const NO_ROWS_SOURCE = {
+  find: async () => [],
+  findOne: async () => null,
+  aggregate: async () => [],
+  count: async () => 0,
+  getObject: async () => null,
+};
+
 async function renderSchema(schema: Record<string, unknown>): Promise<HTMLElement> {
   const { container } = render(
-    <SchemaRendererProvider>
+    <SchemaRendererProvider dataSource={NO_ROWS_SOURCE as never}>
       <SchemaRenderer schema={schema as never} />
     </SchemaRendererProvider>,
   );

--- a/packages/plugin-charts/src/__tests__/chart-family-from-type-7401.test.tsx
+++ b/packages/plugin-charts/src/__tests__/chart-family-from-type-7401.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7401 — a chart-type registration draws the family it names.
+ *
+ * ## What was broken
+ *
+ * `pie-chart`, `donut-chart`, `radar-chart` and `scatter-chart` declared their
+ * family as `defaultProps: { chartType: … }` on the registration, and
+ * **nothing on the SDUI path has ever read a registration's `defaultProps`**.
+ * `ChartRenderer` computed `schema.chartType ?? spec.chartType` — both
+ * `undefined` — and `AdvancedChartImpl` fell to its `'bar'` default. Four
+ * documented component types were one family, on valid data, with no
+ * `data-chart-error` that could fire. The card's measurement, which the
+ * `renders as itself` block below reproduces as a REGRESSION table:
+ *
+ *   | schema `type`                    | scatter | bar | pie | refusal |
+ *   |----------------------------------|--------:|----:|----:|---------|
+ *   | `scatter-chart`                  |       0 |   2 |   0 | none    |
+ *   | `plugin-charts:scatter-chart`    |       0 |   2 |   0 | none    |
+ *   | `pie-chart`                      |       0 |   2 |   0 | none    |
+ *
+ * ## Why these render through the REAL SDUI path
+ *
+ * The defect lived between the registry and the renderer, so a unit test on
+ * either side of that seam could not see it — `normalizeChartSchema` was
+ * asked the right question and `AdvancedChartImpl` gave the right answer for
+ * the family it was handed. Only a schema going in through `SchemaRenderer`
+ * with the package's own registrations live reproduces it, which is also the
+ * form the card measured in.
+ *
+ * ## Ruled route C (director seat, 2026-09-06, on maintainer authorisation)
+ *
+ * The family is derived from the schema's own `type`, and the five inert
+ * `defaultProps: { chartType: … }` are removed rather than left beside a
+ * mechanism that works (`AGENTS.md` #0.1). ⛔ A/B are closed: A (activating
+ * registration `defaultProps` on the SDUI path generally) is a feature with a
+ * measured 32-site / 12-package blast radius and is its own card.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+
+// Recharts' ResponsiveContainer measures its parent via ResizeObserver, which
+// reports 0x0 under the headless DOM, so nothing paints. Fix its size — the
+// 480x320 the card measured at, and the size every other render pin in this
+// package uses.
+vi.mock('recharts', async () => {
+  const actual = await vi.importActual<any>('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: any) =>
+      React.cloneElement(children, { width: 480, height: 320 }),
+  };
+});
+
+import { ComponentRegistry } from '@object-ui/core';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+// The package entry, for its REGISTRATION side effects — this is the half of
+// the seam a unit test cannot reach. Relative, not `@object-ui/plugin-charts`:
+// a package must not import itself (`pnpm check:self-import`).
+import '../index';
+import { ChartRenderer } from '../ChartRenderer';
+import {
+  CHART_TYPE_KEYWORD_FAMILIES,
+  familyFromComponentType,
+  normalizeChartSchema,
+} from '../normalizeChartSchema';
+// Ruling item 3: the in-repo example that drew a bar has to draw a pie now.
+import { pieChartExample, donutChartExample, radarChartExample } from '../../examples/chart-examples';
+
+afterEach(cleanup);
+
+/** The card's fixture: two rows, one category column, two measures. */
+const ROWS = [
+  { xm: 'a', ym: 1, zm: 5 },
+  { xm: 'b', ym: 2, zm: 90 },
+];
+/**
+ * The same two rows with a NUMERIC category column, for scatter only.
+ *
+ * Scatter is the one family whose x-axis is a measure, not a category: a row
+ * whose `xm` is `'a'` has no position and `countPlottablePoints` refuses the
+ * whole chart (`no-plottable-points`). Handing scatter categorical rows would
+ * assert the wrong refusal and never reach the marks.
+ */
+const NUMERIC_ROWS = [
+  { xm: 1, ym: 1, zm: 5 },
+  { xm: 2, ym: 2, zm: 90 },
+];
+const TWO_SERIES = [{ dataKey: 'ym' }, { dataKey: 'zm' }];
+const ONE_SERIES = [{ dataKey: 'ym' }];
+
+async function renderSchema(schema: Record<string, unknown>): Promise<HTMLElement> {
+  const { container } = render(
+    <SchemaRendererProvider>
+      <SchemaRenderer schema={schema as never} />
+    </SchemaRendererProvider>,
+  );
+  // `ChartRenderer` is behind a `React.lazy` boundary; the chart shell is what
+  // says the implementation module actually landed.
+  await waitFor(
+    () => {
+      const painted =
+        container.querySelector('[data-slot="chart"]') ??
+        container.querySelector('[data-chart-error]');
+      expect(painted, 'the chart never rendered past its Suspense skeleton').not.toBeNull();
+    },
+    { timeout: 10_000 },
+  );
+  return container;
+}
+
+const marks = (c: HTMLElement, family: string) => c.querySelectorAll(`.recharts-${family}`).length;
+const refusal = (c: HTMLElement) =>
+  c.querySelector('[data-chart-error]')?.getAttribute('data-chart-error') ?? null;
+
+describe('objectui#7401 — a chart-type registration renders as itself', () => {
+  /**
+   * Both spellings, because the SDUI path reaches one registration by either
+   * and the card measured BOTH drawing a bar. A fix that handled only the
+   * namespaced key would leave `type: 'pie-chart'` — the spelling the docs and
+   * `examples/chart-examples.ts` actually use — still broken.
+   */
+  it.each([
+    ['pie-chart', 'pie'],
+    ['plugin-charts:pie-chart', 'pie'],
+    ['donut-chart', 'pie'],
+    ['plugin-charts:donut-chart', 'pie'],
+    ['radar-chart', 'radar'],
+    ['plugin-charts:radar-chart', 'radar'],
+  ])('%s draws %s marks and no bars', async (type, family) => {
+    const container = await renderSchema({ type, data: ROWS, xAxisKey: 'xm', series: ONE_SERIES });
+    expect(marks(container, family), `${type} drew no ${family}`).toBeGreaterThan(0);
+    expect(marks(container, 'bar'), `${type} still drew bars`).toBe(0);
+    expect(refusal(container)).toBeNull();
+  });
+
+  /**
+   * Donut is a pie with a HOLE, and the hole is a prop rather than a class:
+   * `AdvancedChartImpl` draws both families with Recharts' `Pie` and separates
+   * them only by `innerRadius` (`'52%'` for donut, `0` for pie). Under the
+   * headless DOM the sector's shape layer renders empty — there is no `path`
+   * whose geometry could be compared — so the DOM cannot tell the two apart at
+   * all, and asserting the mark class alone would let a donut that had
+   * silently become a pie pass.
+   *
+   * The family VALUE is therefore what is pinned for this pair, at the seam
+   * that carries it. Both halves are needed: the row above proves the marks
+   * reach the DOM, this proves which of the two families they were drawn as.
+   */
+  it('donut-chart and pie-chart resolve to DIFFERENT families', () => {
+    expect(normalizeChartSchema({ type: 'donut-chart' }).chartType).toBe('donut');
+    expect(normalizeChartSchema({ type: 'plugin-charts:donut-chart' }).chartType).toBe('donut');
+    expect(normalizeChartSchema({ type: 'pie-chart' }).chartType).toBe('pie');
+    expect(normalizeChartSchema({ type: 'plugin-charts:pie-chart' }).chartType).toBe('pie');
+  });
+
+  /**
+   * ⭐ The interaction the ruling asked to be CONFIRMED, not folded in.
+   *
+   * `scatter-chart` reaching the scatter arm for the first time means it also
+   * reaches PR #7400's `scatter-multi-series` refusal (objectui#7194). That
+   * refusal was unreachable through this type until now — which is how the
+   * whole defect surfaced: it *should* have reddened the two-series
+   * `scatter-chart` entry in `app-shell`'s DOM-leak sweep, and did not.
+   * ⛔ Not folded in: #7194 is ruled and landed, this only pins that the two
+   * now meet.
+   */
+  it('scatter-chart with one series draws scatter marks', async () => {
+    const container = await renderSchema({
+      type: 'scatter-chart', data: NUMERIC_ROWS, xAxisKey: 'xm', series: ONE_SERIES,
+    });
+    expect(marks(container, 'scatter')).toBeGreaterThan(0);
+    expect(marks(container, 'bar')).toBe(0);
+  });
+
+  it('scatter-chart with two series now REACHES PR #7400\'s refusal', async () => {
+    const container = await renderSchema({
+      type: 'scatter-chart', data: NUMERIC_ROWS, xAxisKey: 'xm', series: TWO_SERIES,
+    });
+    // Before this card the same schema drew 2 bars and no refusal at all.
+    expect(refusal(container)).toBe('scatter-multi-series');
+    expect(marks(container, 'bar')).toBe(0);
+  });
+
+  /**
+   * The card's CONTROL row, unchanged: the generic `chart` type with an
+   * explicit `chartType` already reached the family it named, and an explicit
+   * `chartType` still wins over the derivation.
+   */
+  it('plugin-charts:chart with an explicit chartType is unchanged', async () => {
+    const container = await renderSchema({
+      type: 'plugin-charts:chart', chartType: 'scatter', data: NUMERIC_ROWS, xAxisKey: 'xm', series: TWO_SERIES,
+    });
+    expect(refusal(container)).toBe('scatter-multi-series');
+  });
+
+  it('an explicit chartType wins over the type-derived family', async () => {
+    const container = await renderSchema({
+      type: 'pie-chart', chartType: 'line', data: ROWS, xAxisKey: 'xm', series: ONE_SERIES,
+    });
+    expect(marks(container, 'line')).toBeGreaterThan(0);
+    expect(marks(container, 'pie')).toBe(0);
+  });
+});
+
+/**
+ * Ruling item 3 — `packages/plugin-charts/examples/chart-examples.ts` is the
+ * in-repo victim the card named (`type: 'pie-chart'`, drawing a bar). It is
+ * confirmed here rather than argued: the example object itself is rendered.
+ */
+describe('objectui#7401 — the in-repo examples draw what they say', () => {
+  it.each([
+    ['pieChartExample', pieChartExample, 'pie'],
+    ['donutChartExample', donutChartExample, 'pie'],
+    ['radarChartExample', radarChartExample, 'radar'],
+  ])('%s draws %s', async (_name, example, family) => {
+    const container = await renderSchema(example as Record<string, unknown>);
+    expect(marks(container, family)).toBeGreaterThan(0);
+    expect(marks(container, 'bar')).toBe(0);
+  });
+});
+
+/**
+ * The two halves of the ONE mechanism, pinned against each other.
+ *
+ * The family table and the `register()` calls are in different files, so
+ * either can be edited alone. These make that a red test rather than a chart
+ * that silently draws a bar again — which is the exact failure the removed
+ * `defaultProps` produced for two years.
+ */
+describe('objectui#7401 — the family table and the registry agree', () => {
+  const NAMESPACE = 'plugin-charts';
+  /** The generic type: it carries no family of its own by design. */
+  const GENERIC = 'chart';
+
+  it('every keyword in the table is registered to ChartRenderer, both spellings', () => {
+    for (const keyword of CHART_TYPE_KEYWORD_FAMILIES.keys()) {
+      expect(ComponentRegistry.get(keyword), `${keyword} is not registered`).toBe(ChartRenderer);
+      expect(
+        ComponentRegistry.get(`${NAMESPACE}:${keyword}`),
+        `${NAMESPACE}:${keyword} is not registered`,
+      ).toBe(ChartRenderer);
+      expect(familyFromComponentType(keyword)).toBe(CHART_TYPE_KEYWORD_FAMILIES.get(keyword));
+      expect(familyFromComponentType(`${NAMESPACE}:${keyword}`)).toBe(
+        CHART_TYPE_KEYWORD_FAMILIES.get(keyword),
+      );
+    }
+  });
+
+  it('every ChartRenderer registration except the generic `chart` names a family', () => {
+    const bareTypes = new Set(
+      ComponentRegistry.getNamespaceComponents(NAMESPACE)
+        .filter((config) => config.component === ChartRenderer)
+        .map((config) => config.type.replace(`${NAMESPACE}:`, '')),
+    );
+    const unnamed = [...bareTypes].filter(
+      (type) => type !== GENERIC && !CHART_TYPE_KEYWORD_FAMILIES.has(type),
+    );
+    expect(
+      unnamed,
+      'these render through ChartRenderer with no family — they will draw a BAR ' +
+        '(objectui#7401). Add each to CHART_TYPE_KEYWORD_FAMILIES.',
+    ).toEqual([]);
+  });
+
+  it('a type that names no registered keyword derives nothing', () => {
+    // The honest answer; the caller's own default is better than a guess.
+    expect(familyFromComponentType('object-chart')).toBeUndefined();
+    expect(familyFromComponentType('chart')).toBeUndefined();
+    expect(familyFromComponentType(undefined)).toBeUndefined();
+    // ⛔ Not a `-chart` SUFFIX rule: `funnel-chart` is not a registered
+    // keyword, so it resolves to nothing rather than to a family no
+    // registration draws.
+    expect(familyFromComponentType('funnel-chart')).toBeUndefined();
+  });
+});

--- a/packages/plugin-charts/src/index.tsx
+++ b/packages/plugin-charts/src/index.tsx
@@ -133,6 +133,34 @@ ComponentRegistry.register(
   }
 );
 
+/**
+ * ⭐ The chart-family registrations below (`chart:bar`, `pie-chart`,
+ * `donut-chart`, `radar-chart`, `scatter-chart`) declare their family in ONE
+ * place, and it is not here: `CHART_TYPE_KEYWORD_FAMILIES` in
+ * `normalizeChartSchema.ts`, which `ChartRenderer` resolves through on every
+ * render.
+ *
+ * Until objectui#7401 each of them carried a second declaration —
+ * `defaultProps: { chartType: … }` — that **nothing on the SDUI path has ever
+ * read**. `SchemaRenderer` does not read a registration's `defaultProps`; the
+ * tree's one consumer (`core/src/registry/WidgetRegistry.ts`) WRITES manifest
+ * defaults into the registry and never reads these back. So all four of the
+ * families below rendered as BAR charts — `AdvancedChartImpl`'s default — on
+ * valid data, with no refusal that could fire. Ruled route C: derive the
+ * family from the schema's own `type`, and the inert declaration goes with it
+ * rather than sitting beside a mechanism that works (`AGENTS.md` #0.1).
+ *
+ * ⛔ Do not re-add `defaultProps: { chartType: … }` to a registration here. It
+ * would read as the family's declaration while changing nothing, which is the
+ * exact state this card removed. A NEW chart-family keyword is added to
+ * `CHART_TYPE_KEYWORD_FAMILIES` in the same edit as its `register()` call —
+ * `__tests__/chart-family-from-type-7401.test.tsx` fails on either half alone.
+ *
+ * ⚠️ `bar-chart` above is NOT one of these: it is registered to
+ * `ChartBarRenderer`, a wrapper that sets the family itself and never reaches
+ * `normalizeChartSchema`. Its own `defaultProps` is a sample-data seed, not a
+ * family declaration, and stays.
+ */
 // Alias for CRM App compatibility
 ComponentRegistry.register(
   'chart:bar',
@@ -140,8 +168,7 @@ ComponentRegistry.register(
   {
     namespace: 'plugin-charts',
     label: 'Bar Chart (Alias)',
-    category: 'plugin',
-    defaultProps: { chartType: 'bar' }
+    category: 'plugin'
   }
 );
 
@@ -151,8 +178,7 @@ ComponentRegistry.register(
   {
     namespace: 'plugin-charts',
     label: 'Pie Chart',
-    category: 'plugin',
-    defaultProps: { chartType: 'pie' }
+    category: 'plugin'
   }
 );
 
@@ -162,8 +188,7 @@ ComponentRegistry.register(
   {
     namespace: 'plugin-charts',
     label: 'Donut Chart',
-    category: 'plugin',
-    defaultProps: { chartType: 'donut' }
+    category: 'plugin'
   }
 );
 
@@ -173,8 +198,7 @@ ComponentRegistry.register(
   {
     namespace: 'plugin-charts',
     label: 'Radar Chart',
-    category: 'plugin',
-    defaultProps: { chartType: 'radar' }
+    category: 'plugin'
   }
 );
 
@@ -184,7 +208,6 @@ ComponentRegistry.register(
   {
     namespace: 'plugin-charts',
     label: 'Scatter Chart',
-    category: 'plugin',
-    defaultProps: { chartType: 'scatter' }
+    category: 'plugin'
   }
 );

--- a/packages/plugin-charts/src/normalizeChartSchema.ts
+++ b/packages/plugin-charts/src/normalizeChartSchema.ts
@@ -116,6 +116,81 @@ const CHART_TYPES = new Set<string>([
   ...TABULAR_CHART_TYPES,
 ]);
 
+/**
+ * The component keywords this package registers for ONE named chart family,
+ * mapped to the family each keyword names (objectui#7401).
+ *
+ * ## Why these are not just more members of {@link CHART_TYPES}
+ *
+ * `CHART_TYPES` answers "is this bare `type` a chart FAMILY" — `'pie'`,
+ * `'scatter'`, the spec's own vocabulary. These are something else: they are
+ * SDUI component discriminators, the keys `index.tsx` hands
+ * `ComponentRegistry.register`. `type: 'pie-chart'` does not name a family in
+ * any spec; it names a registration whose whole purpose is to draw one.
+ *
+ * ## Why the derivation exists at all (objectui#7401)
+ *
+ * Each of these registrations declared its family as
+ * `defaultProps: { chartType: … }` — and **nothing on the SDUI path has ever
+ * read a registration's `defaultProps`**. `SchemaRenderer` does not; the one
+ * consumer in the tree, `WidgetRegistry.ts`, WRITES manifest defaults INTO the
+ * registry rather than reading them back out. So `pie-chart`, `donut-chart`,
+ * `radar-chart` and `scatter-chart` all arrived here with no family at all and
+ * fell to `AdvancedChartImpl`'s `'bar'` default: valid data, a confidently
+ * wrong picture, and no refusal that could fire. Ruled route C (director seat,
+ * 2026-09-06, on maintainer authorisation): derive the family from the
+ * schema's own `type`, and the inert `defaultProps` go with it — a second
+ * declaration nothing reads is the `AGENTS.md` #0.1 hazard, and leaving it
+ * beside a derivation that works would fossilize exactly the wrong convention.
+ *
+ * ## Why a table and not a `-chart` suffix rule
+ *
+ * A suffix rule accepts the whole cross product of {@link RENDERABLE} — it
+ * would answer `'funnel'` for `type: 'funnel-chart'`, a keyword this package
+ * does not register and the SDUI path therefore never resolves. That answer is
+ * unreachable today and would silently become load-bearing the day someone
+ * registers the keyword with a different family in mind. The table names
+ * exactly the keywords that exist, and
+ * `__tests__/chart-family-from-type-7401.test.tsx` pins it against the live
+ * registry in both directions, so adding a registration without a family entry
+ * (or an entry without a registration) is what goes red.
+ *
+ * ⛔ `bar-chart` is deliberately ABSENT: it is registered to
+ * `ChartBarRenderer`, a different component that never calls this function.
+ * An entry for it would be inert in precisely the way this card removed.
+ */
+export const CHART_TYPE_KEYWORD_FAMILIES: ReadonlyMap<string, ChartFamily> = new Map<string, ChartFamily>([
+  ['chart:bar', 'bar'],
+  ['pie-chart', 'pie'],
+  ['donut-chart', 'donut'],
+  ['radar-chart', 'radar'],
+  ['scatter-chart', 'scatter'],
+]);
+
+/**
+ * The namespace `index.tsx` registers every keyword above under. The SDUI path
+ * reaches a registration by either spelling — bare (`pie-chart`) or namespaced
+ * (`plugin-charts:pie-chart`) — and objectui#7401 measured BOTH drawing a bar,
+ * so both are resolved here.
+ */
+const PLUGIN_CHARTS_NAMESPACE = 'plugin-charts:';
+
+/**
+ * The family a registered chart-type keyword names, or `undefined` for a
+ * `type` that is not one of them.
+ *
+ * `undefined` is the honest answer for every other discriminator that reaches
+ * a chart — `object-chart`, `chart`, a dashboard widget's own type — and the
+ * caller's own default is a better answer than a guess.
+ */
+export function familyFromComponentType(rawType: string | undefined): ChartFamily | undefined {
+  if (!rawType) return undefined;
+  const bare = rawType.startsWith(PLUGIN_CHARTS_NAMESPACE)
+    ? rawType.slice(PLUGIN_CHARTS_NAMESPACE.length)
+    : rawType;
+  return CHART_TYPE_KEYWORD_FAMILIES.get(bare);
+}
+
 export type AnyRec = Record<string, any>;
 
 /** A y-axis (or the x-axis) after normalization — spec `ChartAxis`, resolved. */
@@ -313,11 +388,17 @@ export function normalizeChartSchema(schema: unknown): NormalizedChartSchema {
   // `chartType` (internal) → `specType` (an author `type` rescued from the
   // envelope collision) → `type` (only when it is unambiguously a chart family
   // and not a component discriminator).
+  // A registered chart-type keyword (`pie-chart`) is read LAST, after both
+  // explicit spellings: an author who writes `chartType: 'line'` on a
+  // `pie-chart` node still gets a line, exactly as objectui#7401's ruling
+  // requires, and `plugin-charts:chart` with an explicit `chartType` — the
+  // card's control row — is untouched.
   const rawType = str(schema.type);
   const chartType =
     str(schema.chartType) ??
     str(schema.specType) ??
-    (rawType && CHART_TYPES.has(rawType) ? rawType : undefined);
+    (rawType && CHART_TYPES.has(rawType) ? rawType : undefined) ??
+    familyFromComponentType(rawType);
   // A family this renderer does not draw (`metric`, `table`, …) is left unset
   // rather than mapped onto a bar chart — the caller's own default is a more
   // honest answer than silently drawing the wrong picture.


### PR DESCRIPTION
Fixes #7401

Implements the ruling recorded on the card ([5557016463](https://github.com/objectstack-ai/objectui/issues/7401#issuecomment-5557016463), director seat, on maintainer authorisation): **route C** — `ChartRenderer` derives the chart family from the schema's own `type`, and the inert `defaultProps` go with it. ⛔ A/B are not re-opened and the A radius is not re-measured.

## What was wrong

`pie-chart`, `donut-chart`, `radar-chart` and `scatter-chart` each declared their family as `defaultProps: { chartType: … }` on the registration, and **nothing on the SDUI path has ever read a registration's `defaultProps`**. So `ChartRenderer` resolved no family and `AdvancedChartImpl` fell to its `'bar'` default: four documented component types were one family, on valid data, with no `data-chart-error` that could fire.

## The five ruled items

**1. The family is derived from the schema's own `type`.** ✅ At the resolution point the ruling names — `ChartRenderer.tsx:163`, `chartType: schema.chartType ?? spec.chartType` — which is **unchanged**. The derivation lands in the `spec.chartType` half, inside `normalizeChartSchema`, which already carries a `type` limb (`chartType` → `specType` → a bare spec family name) and is documented as the package's ONE translation point. Two reasons it belongs there rather than inline in `ChartRenderer`:

- `normalizeChartSchema` is **exported from the package entry** precisely so a consumer can ask what `AdvancedChartImpl` is actually handed. A derivation that lived only in `ChartRenderer` would make that exported function answer `undefined` for a schema the runtime draws as a pie — a published function lying about the runtime.
- Precedence falls out instead of being re-implemented: `schema.chartType` still wins at both layers, so `plugin-charts:chart` with `chartType: 'scatter'` (the card's control row) is byte-unchanged, and `type: 'pie-chart'` + `chartType: 'line'` draws a line.

Both spellings resolve — bare (`pie-chart`) and namespaced (`plugin-charts:pie-chart`); the card measured both drawing a bar.

⚠️ Not a `-chart` **suffix rule**. A suffix rule accepts the whole cross product of `RENDERABLE` and would answer `funnel` for `funnel-chart`, a keyword nothing registers — an unreachable answer today that becomes load-bearing the day someone registers it meaning something else. `CHART_TYPE_KEYWORD_FAMILIES` names exactly the keywords that exist and is pinned against the live registry **in both directions**, so adding a registration without a family entry (or an entry without a registration) is what goes red.

**2. The five inert `defaultProps: { chartType: … }` are removed.** ✅ `index.tsx` lines 144 / 155 / 166 / 177 / 188 (`chart:bar`, `pie-chart`, `donut-chart`, `radar-chart`, `scatter-chart`), re-measured on `f5c8b8e` and unchanged from the dispatch's reading.

**One mechanism, stated:** `bar-chart` **keeps its wrapper**. It is registered to `ChartBarRenderer`, a different component that renders through `ChartImpl` and never calls `normalizeChartSchema` at all — so a family entry for it would be inert in exactly the way this card removed. It is deliberately absent from the table, and the docblock at both ends says so. `chart:bar` is the one that moved onto the derivation: it renders through `ChartRenderer`, so it is a table entry and now declares `bar` rather than inheriting it from a default.

The two surviving `defaultProps` objects in this file (`bar-chart`, `plugin-charts:chart`) are **sample-data seeds**, not family declarations, and are not among the ruled five. They remain unread on the SDUI path — part of ruling item 5's 32-site census, not this card.

**3. `examples/chart-examples.ts` draws a pie.** ✅ Confirmed by rendering the example object itself, not by argument — `pieChartExample`, `donutChartExample` and `radarChartExample` are imported into the new pin and rendered through `SchemaRenderer`. No edit to the examples file was needed; it was correct all along and the renderer was not.

**4. The `app-shell` DOM-leak sweep went red, and the red was correct.** ✅ See its own section below.

**5. Not A.** ✅ No change to how the SDUI path treats registration `defaultProps` generally. That mechanism is still unread repo-wide.

## Ruling item 4 — the expected red, and what it actually was

`packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx` went **red on exactly one target**, first run after the fix:

```
× plugin-charts:scatter-chart  (10026ms)
  plugin-charts:scatter-chart: readiness selector `[data-slot="chart"]` never matched.
  Body was: data-chart-error="scatter-multi-series"
  "A scatter plots one measure. Keep exactly one series: sales, revenue"
```

That is **not a DOM leak**. It is PR #7400's refusal firing for the first time on a target that had been passing as a bar chart — the very evidence the card was opened on ("PR #7400's refusal *should* have reddened this two-series entry and did not"). The sweep's four chart targets were never sweeping pie / donut / radar / scatter; they were sweeping one bar chart four times.

**Leaks exposed: zero.** With the four renderers rendering as themselves for the first time, `pie-chart`, `donut-chart` and `radar-chart` pass the attribute scan unchanged, and `scatter-chart` passes once it is handed a schema scatter can draw. `plugin-charts` stays at **9 targets / 0 leaking / 0 attributes** — the reading in that file's table is still true, and is now true about four more renderers than it was. **No leak cards to file, and none folded in.**

⛔ Nothing was reverted, skipped, quarantined or `.skip`ped. What changed is the scatter target's **fixture**, on two counts, and both of them *add* coverage rather than remove it:

- **one series** — scatter binds one measure (`series[0].dataKey` is the `YAxis` key) and refuses a second by name. Two series here would have swept the **refusal's** markup, leaving the scatter renderer exactly as unswept as it has been.
- **a numeric x** — scatter's category axis is a measure, so `name: 'Jan'` has no position and every row is unplaceable (`no-plottable-points`) — the other refusal, and the same blindness one step over.

Both refusals render attribute-clean markup, which is precisely the phantom-clean pass that file's own objectui#5630 section warns about. The comment on `SCATTER_DATA` records all of this so the next editor does not "simplify" it back onto the shared constants.

## The #7396 / #7400 interaction — confirmed, not folded in

`scatter-chart` now genuinely reaches the scatter arm, so it meets both siblings. ⛔ Neither is folded in.

- **PR #7400 / objectui#7194 (`scatter-multi-series`).** Reachable through this type for the first time, and now pinned as such: a two-series `scatter-chart` renders `data-chart-error="scatter-multi-series"` where it previously drew two silent bars. This is the ruled behaviour (#7194 ruling B: refuse loudly, do not project), not a regression.
- **objectui#7396 (extreme points half-clipped).** Confirmed reachable and **left alone**. It is a clipping defect inside the scatter arm's rendering, not a DOM or contract question; it changes no assertion here and no test in this PR asserts around it. It stays queued as its own card.

## Mechanism assumptions the dispatch asked to be measured

1. **Is `ChartRenderer.tsx:163` still the right resolution point?** Yes, and `schema.type` **is** in scope there. The derivation is nonetheless placed one layer down for the two reasons in item 1 above; line 163 is untouched and still the point where the family is resolved.
2. **Do both spellings need handling?** Yes, confirmed — both are pinned, bare and namespaced.
3. **Does removing the five `defaultProps` break a reader?** No, and `WidgetRegistry.ts:189` specifically does **not** reach them. Traced: it is a **write**, not a read — it copies a widget *manifest's* `defaultProps` INTO `ComponentRegistry.register(...)`. Nothing flows the other way. The tree's only other `defaultProps` reader is `PageDesigner.tsx:173`, `paletteItem?.defaultProps`, which reads `DEFAULT_PALETTE` — a designer-local literal in the same file that has no `defaultProps` on any entry and no chart-type entries at all. No gate script or doc reads them either.

## Tests

Ablation (reverse verification), run from the committed implementation:

- **mutation** — delete the `?? familyFromComponentType(rawType)` limb. Proven on disk before running: deleted-text count 1 → 0, injected-text count 1, and `git hash-object` differing from the HEAD blob. The mutation reaches the code under test through vitest's source alias (`vitest.config.mts:421` maps `@object-ui/plugin-charts` to `src`), so there is no `dist` staleness leg.
- **direction: RED** — 12 of 17 cases fail. The pin can fail.
- **restore** — `git checkout HEAD -- ...`, proven by an empty `git diff HEAD` and a blob hash byte-identical to HEAD, not by an exit code.

| run | result |
|---|---|
| the new pin, `packages/plugin-charts/src/__tests__/chart-family-from-type-7401.test.tsx` | **17 passed** |
| `packages/plugin-charts/` (the whole package) | **47 files, 433 passed** |
| the sweep, before the fixture correction | **1 failed / 201 passed** — the expected red, quoted above |
| the sweep, after | **202 passed** |
| `packages/app-shell/` + `packages/plugin-report/` + `packages/plugin-dashboard/` + `examples/schema-catalog/` | **770 files, 9188 passed, 1 skipped** |
| `pnpm --filter @object-ui/plugin-charts type-check` / `@object-ui/app-shell type-check` | **0 / 0** |
| `pnpm --filter @object-ui/plugin-charts lint` / `@object-ui/app-shell lint` | **0 / 0** |

`plugin-report` is in that list because `ReportRenderer.test.tsx:44` authors `chart: { type: 'pie-chart' }` — the other in-repo consumer of these keywords besides the examples file. `examples/schema-catalog` carries no `FAMILY-chart` fixture (checked); its two chart fixtures are `type: "chart"` with an explicit `chartType`, which the derivation cannot reach.

Gates, derived by hand from the changed paths — ⚠️ `scripts/pm/dispatch-gates.mjs` does not exist in this repo, it is objectstack-only. Exit codes read before any pipe:

```
check:control-bytes 0   check:changeset-presence 0   check:changeset-fixed 0
check:changeset-no-major 0   check:changeset-overwrite 0   check:self-import 0
check:phantom-deps 0   check:unreferenced-sources 0   check:side-effects-array 0
check:element-data-source-declaration 0   check:vi-mock-specifiers 0
check:vi-mock-inherit 0   check:spec-symbols 0   check:handler-key-reads 0
check:entry-guard 0   check:doc-types 0   check:i18n-keys 0
check:published-tsconfig-exclude 0   check:lint-coverage 0
check:type-check-coverage 0   check:doc-example-readers 0
```

`check:sdui-registration-pins` is left to CI: it weighs `apps/console/dist/assets` and needs a console build. It reads the registration KEY set, which this PR does not move — all five `ComponentRegistry.register` calls keep their literal keys and only their `defaultProps` member is removed.

`node scripts/check-governed-queue-guard.mjs --test` on the five changed paths: **NOT GOVERNED**. This PR nonetheless stays a **draft** — it is dispatched work and the maintainer merges it.

## One observation, reported rather than swallowed

On the first full `packages/plugin-charts/` run, `ChartRenderer.catalogRender-6939.test.tsx > advanced-line-chart renders identically to BASE` failed with `nothing drew` — stuck on the Suspense skeleton at the default 1s `waitFor`, in a run whose own summary reports 279s of import time across 47 files. The same file passes **5/5** in isolation, the whole package re-ran **47/47 files, 433/433 tests** green, and both of that file's fixtures are `type: "chart"` with an explicit `chartType`, which the derivation provably cannot reach. Recorded as a load-induced timeout in that pin, not as a result of this change; ⛔ not fixed here and not folded in.

## Scope

`Clause-②: no` — no `packages/types` or `@objectstack/spec` file is touched; this is registration mechanics inside `plugin-charts`. Siblings #7681 #7682 #7690 #7698 #7396 are **not** folded in. Changeset: `@object-ui/plugin-charts` `patch`, naming the four types. ⚠️ The `skip-changeset` label is inert in this repo and is not applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnpvbdoRisQdRAczkLwnf5)_