### PR TITLE
docs(checkbox): schema block declares checked/description/error/className/wrapperClass

### DIFF
--- a/content/docs/components/form/checkbox.mdx
+++ b/content/docs/components/form/checkbox.mdx
@@ -17,7 +17,12 @@ interface CheckboxSchema {
   name?: string;
   label?: string;
   defaultChecked?: boolean;
+  checked?: boolean;
   required?: boolean;
   disabled?: boolean | string | { dialect?: string; source: string };   // boolean, predicate expression, or CEL envelope
+  description?: string;
+  error?: string;
+  className?: string;
+  wrapperClass?: string;
 }
 ```


### PR DESCRIPTION
Fixes #7724

## What changed

Replaced the six-line `## Schema` summary block in `content/docs/components/form/checkbox.mdx` with the full set of `CheckboxSchema` members declared on `main` at fix time (`packages/types/src/form.ts:306`, re-read fresh — not copied from the triage comment's `0558e0f` reading).

## Before / after

| Member | Before | After | Source |
|---|---|---|---|
| `type` | listed | listed | own |
| `name` | listed | listed | own |
| `label` | listed | listed | own |
| `defaultChecked` | listed | listed | own |
| `checked` | **missing** | added | own (`form.ts:323`) |
| `required` | listed | listed | own |
| `disabled` | listed (verbatim, #7530-current shape) | listed (verbatim, unchanged) | inherited (`BaseSchema`, `base.ts:343`) |
| `description` | **missing** | added | own (`form.ts:327`) |
| `error` | **missing** | added | own (`form.ts:331`) |
| `className` | **missing** | added | inherited (`BaseSchema`, `base.ts:171`) |
| `wrapperClass` | **missing** | added | own (`form.ts:354`, landed by #7723) |
| `onChange` | not listed | **not listed** (deliberate — see below) | own (`form.ts:364`) |

## The one judgment: `onChange`

`CheckboxSchema.onChange` carries the same docblock as `InputSchema`/`TextareaSchema`/`SelectSchema`/`FileUploadSchema`'s `onChange`: "RUNTIME SLOT ... a host-supplied function, NOT authorable metadata: JSON has no function value, so the zod twin refuses this key by name." Checked precedent across every sibling `content/docs/components/form/*.mdx` page whose schema declares a real (non-`never`) `onChange`:

- **Omit** `onChange` from the doc block: `input.mdx`, `textarea.mdx`, `select.mdx`, `file-upload.mdx` (4)
- **Include** `onChange`: `date-picker.mdx`, `input-otp.mdx` (2)

Majority (4 of 6) omits it, and it's the same majority whose schemas carry the identical "not authorable metadata" docblock as checkbox's own — so `onChange` stays out of this block.

For the inherited `className`, precedent runs the other way: 9 of 14 comparable sibling pages (`file-upload`, `radio-group`, `date-picker`, `combobox`, `input-otp`, `calendar`, `button`, `command`, `label`) document it; only the minimal-summary pages (`input`, `select`, `switch`, `textarea`, `slider`) omit it — the same genre `checkbox.mdx` is leaving behind. `className` is added.

## Scope

`content/docs/components/form/checkbox.mdx`, the `## Schema` block only — no other page, no `packages/**` change, no doc-parity gate (per triage §3/§4, filed separately if opened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_