### PR TITLE
docs(create-plugin): record that in-repo scaffolding is already refused by named pins

### DIFF
--- a/.changeset/create-plugin-in-repo-scaffold-note-7524.md
+++ b/.changeset/create-plugin-in-repo-scaffold-note-7524.md
@@ -1,0 +1,7 @@
+---
+---
+
+Comment-only change to `@object-ui/create-plugin`: `src/templates.ts` gains a docblock
+note recording that scaffolding into this monorepo is already refused by named pins
+(objectui#7524), and that the emitted per-package `test` block stays correct for the
+generator's actual audience. No generated file changes, so nothing is published.

--- a/packages/create-plugin/src/templates.ts
+++ b/packages/create-plugin/src/templates.ts
@@ -198,6 +198,35 @@ export function buildTsconfig(): Record<string, unknown> {
  * ships already-correct rather than warning on an author's first `pnpm build`.
  * Safe unconditionally here: the repo requires Node >= 22 and vite defines
  * `import.meta.dirname` under the bundle loader too.
+ *
+ * Scaffolding INTO this monorepo is a case this output deliberately does NOT
+ * serve, and it needs no change here because THIS repo already refuses it
+ * loudly (objectui#7524, measured on a9e6f04b4). Running the generator into
+ * `packages/` and re-running `pnpm exec vitest run scripts/__tests__/` turns
+ * 11 assertions red across 7 files, every one naming the generated package;
+ * four are about this shape specifically:
+ *
+ * - `scripts/__tests__/vitest-invocation-guard.test.ts` — "calls the guard
+ *   from every one of them", "declares no `test` block - a build config must
+ *   not carry test semantics", and "derives the repo root instead of counting
+ *   `..`" (objectui#3240 / objectui#5406);
+ * - `scripts/__tests__/runner-package-test-entry-3746.test.ts` — "admits no
+ *   package beyond the recorded baseline" (objectui#3746), which reads the
+ *   generated `"test": "vitest run"` from {@link buildPackageJson}.
+ *
+ * Those pins exist because inside this repo a package-cwd `vitest run` picks
+ * up a package-local `test` block instead of `vitest.config.mts` and goes
+ * green under a config CI never uses. Measured for the scaffold too: the
+ * generated `pnpm test` passes with `RUN v4.1.10 .../packages/plugin-NAME` as
+ * its root and no guard output at all - which is exactly why the pins, not
+ * the reviewer, are what catches it. In this repo a package needing different
+ * test semantics declares a PROJECT in `vitest.config.mts`.
+ *
+ * None of that is true of the audience this generator serves - a plugin in
+ * its OWN repo, where the emitted config is the only config and the block
+ * below is the only thing giving the example test a DOM. Do not teach these
+ * templates to detect an in-repo target: the two answers differ because the
+ * questions differ, and the in-repo answer is already enforced above.
  */
 export function buildViteConfig(vars: PluginTemplateVars): string {
   return `import { defineConfig } from 'vite';


### PR DESCRIPTION
Fixes #7524

This was a measurement-first card. The measurement came back **LOUD**, so the route is 2(b): no gate change, a docblock note in `packages/create-plugin/src/templates.ts` naming the pins that already refuse an in-repo scaffold, plus an empty-frontmatter changeset. The scaffolder's published output is byte-identical to `main`.

All readings below are pinned to `121147911` (the branch head) except the Step-1 planted/removed legs, which were taken on the same tree with the scratch package added and then removed; the scratch package was never committed.

## Step 1 — the measurement (mandatory, and it chose the route)

Ran the **real** scaffolder, not a hand-written imitation: `pnpm --filter @object-ui/create-plugin build`, then `node packages/create-plugin/dist/index.js scaffold-probe-7524 -d ... -a ...` from the worktree root, which writes `packages/plugin-scaffold-probe-7524/`. `pnpm-workspace.yaml` already globs `packages/*`, so it became a workspace package with no edit; `pnpm install` linked it.

Emitted shape, verified on disk before running anything: `"test": "vitest run"` in the manifest; a `test` block in `vite.config.ts` carrying `globals: true`, `environment: 'jsdom'`, `setupFiles: ['./vitest.setup.ts']`; **no** `vitest.config.*`; and **zero** occurrences of `assertCanonicalVitestInvocation` in the generated config. Exactly the hazardous shape the card describes.

| gate | exit | verdict | caused by the scaffold? |
| --- | --- | --- | --- |
| the five named pins, **clean tree (control)** | 0 | `Test Files 5 passed (5)`, `Tests 112 passed (112)` | n/a — this is the control |
| the five named pins, **scaffold planted** | 1 | 4 failed of 112 | **YES** — every one names the generated package |
| `vitest-invocation-guard.test.ts` &gt; `calls the guard from every one of them` | 1 | offender list is `packages/plugin-scaffold-probe-7524/vite.config.ts` | **YES** |
| `vitest-invocation-guard.test.ts` &gt; ``declares no `test` block — a build config must not carry test semantics`` | 1 | same file | **YES** |
| `vitest-invocation-guard.test.ts` &gt; ``derives the repo root instead of counting `..` `` | 1 | `packages/plugin-scaffold-probe-7524/vite.config.ts calls the guard with a hand-counted repo root` | **YES** |
| `runner-package-test-entry-3746.test.ts` &gt; `admits no package beyond the recorded baseline` | 1 | received `["packages/plugin-scaffold-probe-7524"]`, expected `[]` | **YES** |
| `package-scripts-vitest-projects.test.ts` | 0 | passed with the scaffold planted | **NO** — see A2 below |
| `turbo-test-inputs.test.ts` | 0 | passed with the scaffold planted | NO |
| `unit-registry-absence-collision.test.ts` | 0 | passed with the scaffold planted | NO |
| `pnpm exec vitest run scripts/__tests__/`, **clean tree (control)** | 0 | `Test Files 110 passed (110)`, `Tests 3323 passed (3323)` | n/a — this is the control |
| `pnpm exec vitest run scripts/__tests__/`, **scaffold planted** | 1 | 11 failed of 3323, across 7 files | **YES** — 10 of the 11 print the package name verbatim; the 11th is `quick-reference-commands-4149` going from `38 published` to `39 published` |
| `pnpm --filter @object-ui/plugin-scaffold-probe-7524 test` (before `pnpm install`) | 1 | startup error: `Could not resolve 'vite-plugin-dts'` / `Cannot find package '@vitejs/plugin-react'` | an install artifact, not a verdict — recorded so nobody mistakes it for a refusal |
| `pnpm --filter @object-ui/plugin-scaffold-probe-7524 test` (after `pnpm install`) | **0** | `RUN v4.1.10 /…/packages/plugin-scaffold-probe-7524`, `Test Files 1 passed (1)`, **no guard output at all** | **YES — and this is the one that is SILENT** |
| `node scripts/vitest-invocation-guard.mjs` | 0 | zero bytes of output | not a reading: the file has a shebang but no main-module block, so it has no CLI. It is a module `vitest.config.mts` and the package vite configs import |
| `check:unreferenced-sources`, `check:phantom-deps`, `check:self-import`, `check:side-effects-array`, `check:published-dist`, `check:readme-exports` | 0 each | — | NO — none of them looks at test shape |

**Reading.** The two halves point opposite ways, and that is the whole answer:

- the *invocation itself* is silently green — `pnpm test` inside a scaffolded in-repo package runs with the **package** as vitest's root, under the generated `vite.config.ts` as its test config, and the guard never fires because that config never calls it;
- but the *repo* is loud about the shape existing at all. Four named assertions in two pins refuse it, plus seven more incidental ones. Nothing can be committed in that state.

So the card's premise splits. "The scaffolder emits the shape #3240 removed" is **true**. "…with nothing to refuse it" is **false** — objectui#3240 / objectui#5406 / objectui#3746 already built the refusal, on the repo side rather than in the scaffolder, and it fires on the first CI run. The one thing that was genuinely missing is the record of that, which is what this PR adds.

**Removal proof.** The scratch package is a measurement, never a commit: after `rm -rf packages/plugin-scaffold-probe-7524` and restoring `pnpm-lock.yaml` from the base commit, `git status --porcelain` is empty and the lockfile md5 is back to its base value (`85895a3d7f8051c61b1f4803ea1b3cf7`). The control run of the whole `scripts/__tests__/` directory above was taken *after* that removal, which is what makes the 11 failures attributable.

## Step 2(b) — what changed

One docblock paragraph on `buildViteConfig` in `packages/create-plugin/src/templates.ts`. It records the measurement, names the two pins and their assertion texts, explains why the emitted shape is nevertheless right for the generator's actual audience (a plugin in its own repo, where the emitted config is the only config and the `test` block is the only thing giving the example test a DOM), and says explicitly not to teach the templates in-repo target detection.

No generated file changes — `buildPackageJson`, `buildViteConfig`'s returned string, `buildVitestSetup` and the rest are byte-identical. The changeset therefore has **empty frontmatter**: `node scripts/check-changeset-presence.mjs` requires a declaration because `src/` of a released package moved, and "this releases nothing" is the explicit exemption it names.

## Zone-2 assumptions: one falsified

- **A1 — confirmed.** `templates.ts:150` emits `test: 'vitest run'`; the `test` block and `VITEST_SETUP_FILE` are where the dispatch said.
- **A2 — FALSIFIED, and it mattered.** `scripts/__tests__/package-scripts-vitest-projects.test.ts` does **not** walk workspace packages' `test` scripts. It reads the **root** `package.json` for `--project` values and checks each is declared in `vitest.config.mts` (objectui#7096). It stayed green with the scaffold planted. The loudness comes from `vitest-invocation-guard.test.ts` and `runner-package-test-entry-3746.test.ts` instead — the answer is still (b), by a different route than the dispatch predicted.
- **A3 — confirmed.** The scaffolded `vite.config.ts` contains zero occurrences of `assertCanonicalVitestInvocation`, so the guard cannot fire from it. Every red is repo-side.
- **A4 / A5** — nothing observed contradicting them; worked from the merged tree at `a9e6f04b4`.

## Gates on `121147911`

Exit codes captured by redirect-then-capture, never through a pipe.

| gate | exit |
| --- | --- |
| `pnpm exec vitest run scripts/__tests__/` (whole directory) | 1 on the first run, **0** on re-run — see the flake note below |
| `pnpm type-check:scripts` | 0 |
| `pnpm lint:root` | 0 (32 warnings, 0 errors) |
| `pnpm check:entry-guard` | 0 |
| `pnpm check:control-bytes` | 0 — `OK (scanned 6449 tracked text file(s); skipped 85 binary)` |
| `grep -naP` control-byte self-scan of both changed files | no matches |
| `node scripts/check-changeset-presence.mjs` | 0 — "Every one of them has an EMPTY frontmatter — declared as releasing nothing" |
| `node scripts/check-changeset-no-major.mjs` | 0 |
| `node scripts/check-governed-queue-guard.mjs --test packages/create-plugin/src/templates.ts` | 0 — `NOT GOVERNED` |
| `pnpm --filter @object-ui/create-plugin test` | 0 — `Test Files 1 passed (1)`, `Tests 19 passed (19)` |
| `pnpm --filter @object-ui/create-plugin type-check` | 0 |
| `pnpm --filter @object-ui/create-plugin lint` | 0 |
| `check:unreferenced-sources`, `check:phantom-deps`, `check:self-import`, `check:published-dist` | 0 each |

**Flake, not a regression.** The first whole-directory run exited 1 on two cases in `check-doc-links.test.ts` (`agrees with the real renderers on every heading in the scan surface`, `has no setext headings…`), both with `Error: Test timed out in 15000ms` — timeouts, not assertion failures, in a run whose total duration was 145s under container contention. Re-run alone on the same HEAD: exit 0, `Test Files 1 passed (1)`, `Tests 121 passed (121)`, 10.36s. This diff touches no markdown that gate scans; the AGENTS.md flaky-test section describes this signature exactly.

`pnpm check:skill-examples` was **not** run and is not owed: the diff touches nothing under `skills/`, and the only skill mentions of this generator are a prose line and a `bash` fence (`pnpm create-plugin my-widget`) — that gate judges marked `ts`/`tsx`/`json` fences.

`Live E2E (informational)` is red on every branch today for an upstream reason (objectui#7990); not from this change.

## Out of scope, filed separately

objectui#8041 — the scaffolded `package.json` declares `license: "MIT"` while `buildPluginFiles` writes no LICENSE file, so a published scaffolded plugin ships a tarball claiming a licence whose text is absent. Surfaced by the same measurement (`package-files-exist.test.ts` reds on it), deliberately **not** touched here because this card's ruling holds the scaffolder's published output constant. Filed unassigned, no labels, for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_