### PR TITLE
test(app-shell): serve batch 5's three app-shell probes from doubles (objectui#7307)

### DIFF
--- a/.changeset/network-escapes-batch5.md
+++ b/.changeset/network-escapes-batch5.md
@@ -1,0 +1,8 @@
+---
+---
+
+Test-only (objectui#7307 batch 5): three app-shell suites now serve their
+`GET /api/v1/meta/object`, `GET /api/v1/automation/_status` and
+`/api/v1/ai/conversations` probes from recording doubles instead of a real
+socket, and their three rows leave the network-escape ledger. No published
+runtime code changes, so nothing to release.

--- a/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx
@@ -10,7 +10,7 @@
  * inert is this notice beside it.
  */
 
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, fireEvent, within } from '@testing-library/react';
 
 vi.mock('../previews/useFlowNodePalette', () => ({
@@ -24,7 +24,80 @@ vi.mock('../previews/useObjectFields', () => ({
 import { FlowNodeInspector } from './FlowNodeInspector';
 import type { MetadataSelection } from '../preview-registry';
 
-afterEach(cleanup);
+/* ── The `meta/object` double (objectui#7307) ─────────────────────────
+ * `FlowNodeInspector` renders `FlowReferenceField` for every reference-kind key
+ * on the selected node, and that field resolves its combobox options through
+ * `useMetadataListOptions` — `MetadataClient.list(type)`, i.e.
+ * `GET /api/v1/meta/object` over the authenticated wrapper, which resolves the
+ * GLOBAL `fetch` at call time (`packages/auth/src/createAuthenticatedFetch.ts`,
+ * the bare `await fetch(input, ...)`). Under happy-dom that global is a real HTTP
+ * client and the document URL defaults to `http://localhost:3000`, so the
+ * relative path resolved to a live socket. Traced from the guard's attribution
+ * point: `FlowReferenceField.tsx:389` → `metadata-client.ts:764` → that wrapper.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches. Deliberately NOT a blanket network stub: it
+ * records every URL it is handed and `afterEach` fails on any URL outside the
+ * route it serves, so an escape to somewhere else reds here instead of vanishing
+ * into the hook's `.catch`.
+ *
+ * What it answers, and why that changes no assertion here: an EMPTY registry, in
+ * the `{ type, items: [] }` envelope the server sends and `MetadataClient.list`
+ * parses (it also accepts a bare array; both parse to the same rows). Empty is
+ * load-bearing — the failing request landed in the hook's `.catch`, which sets
+ * `{ options: [], loading: false }`, so an empty registry yields byte-identical
+ * output to what these cases have always rendered, while a seeded one would put
+ * options into every reference combobox in the tree. The route is matched on the
+ * PATHNAME because `MetadataClient.list` appends `?package=` / `?preview=draft`
+ * for scoped callers; the full URL is what gets recorded.
+ *
+ * `headers` is part of the answer, not decoration: the authenticated wrapper
+ * reads `response.headers.get('set-auth-token')` on every API call before the
+ * caller ever sees the body.
+ * ──────────────────────────────────────────────────────────── */
+
+const META_OBJECT_ROUTE = '/api/v1/meta/object';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let metaCalls: string[] = [];
+
+/** The route key of a recorded URL: its pathname, without the scope query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/** Serve `GET /api/v1/meta/object` as an empty registry; record everything. */
+function installMetaObjectDouble() {
+  metaCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      metaCalls.push(url);
+      if (routeOf(url) !== META_OBJECT_ROUTE) {
+        return { ok: false, status: 404, headers: new Headers(), json: async () => ({}) };
+      }
+      return { ok: true, status: 200, headers: new Headers(), json: async () => ({ type: 'object', items: [] }) };
+    }),
+  );
+}
+
+beforeEach(installMetaObjectDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into `useMetadataListOptions`'s `.catch`.
+  expect(metaCalls.filter((url) => routeOf(url) !== META_OBJECT_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch` — this replaces the bare
+  // `afterEach(cleanup)` that used to stand here, it does not drop it. Vitest
+  // runs `afterEach` hooks in reverse registration order, so this file's
+  // teardown runs before the root setup's RTL cleanup: unstubbing first would
+  // leave the tree mounted with the real global back in place, and a mount
+  // effect settling in that window escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 function draftWith(config: Record<string, unknown>, type = 'approval') {
   return { nodes: [{ id: 'gate', type, label: 'Gate', config }], edges: [] };

--- a/packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx
+++ b/packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx
@@ -44,7 +44,7 @@
 
 import '@testing-library/jest-dom/vitest';
 import * as React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
@@ -97,7 +97,74 @@ import { listMetadataInspectorTypes, getMetadataInspector } from '../metadata-ad
 import { getMetadataDefaultInspector } from '../metadata-admin/default-inspector-registry';
 import { getStudioCanvasPreview } from './studio-canvas-preview';
 
-afterEach(cleanup);
+/* ── The `automation/_status` double (objectui#7307) ──────────────────
+ * `AutomationsPillar` reads the engine's live per-flow runtime state from a
+ * mount effect — `StudioDesignSurface.tsx:3797`, a bare global `fetch` of
+ * `GET /api/v1/automation/_status` with no `apiFetch` seam on the path. Under
+ * happy-dom that global is a real HTTP client and the document URL defaults to
+ * `http://localhost:3000`, so the relative path resolved to a live socket. The
+ * effect's read is best-effort by construction (its `catch` comment: "offline /
+ * older backend → no dots"), which is why the Automations case below stayed
+ * green while the request always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches. Deliberately NOT a blanket network stub: it
+ * records every URL it is handed and `afterEach` fails on any URL outside the
+ * route it serves, so an escape to somewhere else reds here instead of vanishing
+ * into that `catch`.
+ *
+ * What it answers, and why that changes no assertion here: a known-EMPTY runtime
+ * roster, in the `{ data: { flows: [...] } }` envelope the effect reads first
+ * (it also accepts a bare `{ flows }`; both parse to the same rows). Empty is
+ * load-bearing — the effect turns each row into a status DOT on the flow rail,
+ * and the failing request left `flowStatus` at `{}` with no dots at all, so an
+ * empty roster renders exactly what these cases have always rendered, while a
+ * seeded one would add a dot for `nightly` to the Automations tableau this file
+ * pins. Routes are matched on the PATHNAME; the full URL is what gets recorded.
+ * ──────────────────────────────────────────────────────────── */
+
+const AUTOMATION_STATUS_ROUTE = '/api/v1/automation/_status';
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let statusCalls: string[] = [];
+
+/** The route key of a recorded URL: its pathname, without any query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/** Serve `GET /api/v1/automation/_status` as an empty roster; record everything. */
+function installStatusDouble() {
+  statusCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      statusCalls.push(url);
+      if (routeOf(url) !== AUTOMATION_STATUS_ROUTE) {
+        return { ok: false, status: 404, headers: new Headers(), json: async () => ({}) };
+      }
+      return { ok: true, status: 200, headers: new Headers(), json: async () => ({ data: { flows: [] } }) };
+    }),
+  );
+}
+
+beforeEach(installStatusDouble);
+
+afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the effect's best-effort `catch`.
+  expect(statusCalls.filter((url) => routeOf(url) !== AUTOMATION_STATUS_ROUTE)).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch` — this replaces the bare
+  // `afterEach(cleanup)` that used to stand here, it does not drop it. Vitest
+  // runs `afterEach` hooks in reverse registration order, so this file's
+  // teardown runs before the root setup's RTL cleanup: unstubbing first would
+  // leave the tree mounted with the real global back in place, and a mount
+  // effect settling in that window escapes again (objectui#7439).
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 /**
  * Assert the registries really are empty — **with a control that MUST hit**.

--- a/packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx
+++ b/packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx
@@ -11,7 +11,7 @@
  */
 import '@testing-library/jest-dom/vitest';
 import * as React from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -47,8 +47,88 @@ vi.mock('@object-ui/plugin-chatbot', async (importOriginal) => {
 
 import { StudioCopilotConversation } from '../StudioAiCopilot';
 
+/* ── The `ai/conversations` double (objectui#7307) ────────────────────
+ * Every `renderAt` below mounts the real `StudioCopilotConversation`, whose
+ * `useChatConversation` resolve effect mints a thread for the signed-in user on
+ * mount: `POST /api/v1/ai/conversations` through the GLOBAL `fetch`
+ * (`hooks/useChatConversation.ts:609`, no `apiFetch` seam on the path). Under
+ * happy-dom that global is a real HTTP client and the document URL defaults to
+ * `http://localhost:3000`, so the relative path resolved to a live socket — once
+ * per case, four in the file. The resolve's `catch` is deliberately conservative
+ * (it keeps the surface as it was), which is why these cases stayed green while
+ * the mint always failed.
+ *
+ * Answered from a RECORDING double — the shape objectui#5225 settled on, carried
+ * by `packages/plugin-report/src/__tests__/DatasetReportRenderer.test.tsx` and by
+ * this burn-down's earlier batches. Deliberately NOT a blanket network stub: it
+ * records every URL it is handed and `afterEach` fails on any URL outside the
+ * routes it serves.
+ *
+ * TWO routes, because a mint that SUCCEEDS is resumable and the hook resumes it.
+ * `useChatConversation` caches the minted id in `localStorage`
+ * (`writeCache` → `readCache`), and happy-dom keeps that store for the whole
+ * file — so case 1 mints and cases 2-4 resume, reading
+ * `GET /api/v1/ai/conversations/{THE_MINTED_ID}` instead. That second route was
+ * MEASURED, not assumed: serving only the mint made this file's own
+ * router assertion red naming that exact URL. Both answer the same empty
+ * `ServerConversation` (`{ id, messages: [] }` — the shape `createConversation`
+ * and `fetchConversation` both cast their body to), so the fake server is
+ * self-consistent: one thread, minted once, resumed thereafter.
+ *
+ * Why an empty thread changes no assertion here: this file asserts ONE thing per
+ * case — the `surfaceContext` prop the pane receives, derived from the URL alone.
+ * `ChatPane` is a capture stub, the conversation never reaches an assertion, and
+ * the resolve settles in a microtask AFTER each synchronous case body has already
+ * read `capturedProps`. A SEEDED thread would hydrate `initialMessages` into that
+ * same stub for no assertion's benefit. Routes are matched on the PATHNAME; the
+ * full URL is what gets recorded.
+ * ─────────────────────────────────────────────────── */
+
+/** The one thread this fake server owns: minted by case 1, resumed by 2-4. */
+const CONVERSATION = { id: 'conv_studio_copilot', messages: [] as unknown[] };
+
+/** `POST` here mints; `GET .../{id}` resumes. Nothing else is served. */
+const MINT_ROUTE = '/api/v1/ai/conversations';
+const RESUME_ROUTE = `${MINT_ROUTE}/${CONVERSATION.id}`;
+const SERVED_ROUTES = new Set([MINT_ROUTE, RESUME_ROUTE]);
+
+/** Every URL this file's renders handed the global `fetch`, in request order. */
+let aiCalls: string[] = [];
+
+/** The route key of a recorded URL: its pathname, without any query. */
+const routeOf = (url: string) => url.split('?')[0];
+
+/** Serve the two conversation routes as one empty thread; record everything. */
+function installConversationsDouble() {
+  aiCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown) => {
+      const url = String(
+        input && typeof input === 'object' && 'url' in input ? (input as { url: unknown }).url : input,
+      );
+      aiCalls.push(url);
+      if (!SERVED_ROUTES.has(routeOf(url))) {
+        return { ok: false, status: 404, headers: new Headers(), json: async () => ({}) };
+      }
+      return { ok: true, status: 200, headers: new Headers(), json: async () => CONVERSATION };
+    }),
+  );
+}
+
+beforeEach(installConversationsDouble);
+
 afterEach(() => {
+  // The double is a router, not a sink: an escape to any OTHER endpoint fails
+  // here instead of vanishing into the resolve effect's `catch`.
+  expect(aiCalls.filter((url) => !SERVED_ROUTES.has(routeOf(url)))).toEqual([]);
+  // Unmount BEFORE restoring the real `fetch`. Vitest runs `afterEach` hooks in
+  // reverse registration order, so this file's teardown runs before the root
+  // setup's RTL cleanup: unstubbing first would leave the tree mounted with the
+  // real global back in place, and a mount effect settling in that window
+  // escapes again (objectui#7439).
   cleanup();
+  vi.unstubAllGlobals();
   capturedProps = {};
 });
 

--- a/scripts/__tests__/network-escape-ledger.test.ts
+++ b/scripts/__tests__/network-escape-ledger.test.ts
@@ -39,10 +39,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../
  * and must be done in lockstep with `KNOWN_ESCAPES`.
  */
 const PINNED_LEDGER: readonly string[] = [
-  'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx',
   'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.specKeys.test.tsx',
-  'packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx',
-  'packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx',
 ];
 
 describe('network-escape ledger (objectui#6640) is shrink-only', () => {

--- a/vitest.setup.network-escape-guard.ts
+++ b/vitest.setup.network-escape-guard.ts
@@ -114,13 +114,7 @@ const ESCAPE_ORIGIN = /^https?:\/\/(?:127\.0\.0\.1|localhost):3000(?:\/|$)/;
  */
 export const KNOWN_ESCAPES: ReadonlySet<string> = new Set([
   // /api/v1/meta/object
-  'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx',
-  // /api/v1/meta/object
   'packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.specKeys.test.tsx',
-  // /api/v1/automation/_status
-  'packages/app-shell/src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx',
-  // /api/v1/ai/conversations
-  'packages/app-shell/src/views/studio-design/__tests__/studioSurfaceContext.test.tsx',
 ]);
 
 type Escape = { file: string; test: string; url: string };


### PR DESCRIPTION
Part of #7307 — batch 5 of the network-escape burn-down (batch 1 was #7999, batch 2 #8013, batch 3 #8019, batch 4 #8032).

The three takeable `app-shell` rows now serve their probes from recording
doubles, and their lines leave `KNOWN_ESCAPES` and `PINNED_LEDGER` in the same
commit. Unlike batch 4, these three are **three different endpoint families with
three different readers**, so each gets its own route table and its own reasoning
about what answer keeps its assertions' meaning.

Session for this run, as a code span so it survives a body edit:
`https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`.

## Per file

| file | endpoint | reader it escaped through | double | answer chosen |
|:--|:--|:--|:--|:--|
| `src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx` | `GET /api/v1/meta/object` | `FlowReferenceField.tsx:389` → `MetadataClient.list` (`metadata-client.ts:764`) → the authenticated wrapper's bare `await fetch(...)` (`packages/auth/src/createAuthenticatedFetch.ts:144`) | `installMetaObjectDouble()` in a module-scope `beforeEach` | empty registry, `{ type, items: [] }` |
| `src/views/studio-design/StudioDesignSurface.designerRegistryMissing.test.tsx` | `GET /api/v1/automation/_status` | `StudioDesignSurface.tsx:3797`, a bare global `fetch` in a mount effect, no `apiFetch` seam | `installStatusDouble()` in a module-scope `beforeEach` | empty runtime roster, `{ data: { flows: [] } }` |
| `src/views/studio-design/__tests__/studioSurfaceContext.test.tsx` | `POST /api/v1/ai/conversations` **and** `GET /api/v1/ai/conversations/THE_MINTED_ID` | `useChatConversation.ts:609` (`createConversation`) from the resolve effect at `:828` / `:864`; the resume leg is `fetchConversation` at `:599` | `installConversationsDouble()` in a module-scope `beforeEach` | one empty `ServerConversation` (`{ id, messages: [] }`), minted once and resumed thereafter |

**Mechanism, measured rather than assumed.** A trap-guarded stack probe injected
at the guard's own attribution point (a `new Error('probe').stack` beside
`pending.push(escape)`), restored by blob hash afterwards, attributed every escape
in all three files. Its readings, against the dispatch's un-traced guesses:

- `/api/v1/meta/object` — the dispatch offered `AiChatPage.tsx:1528`,
  `ExcelImportBar.tsx:79`, `AppSidebar.tsx:253` or `MetadataService.ts` as
  candidates. **None of them.** The inspector renders `FlowReferenceField` for
  every reference-kind key on the selected node, and that field resolves combobox
  options through `useMetadataListOptions` → `MetadataClient.list(type)`. The
  file's own `vi.mock` of `useObjectFields` does not cover it.
- `/api/v1/automation/_status` — the dispatch had located no reader at all and
  suggested it might live in another package. It is in `app-shell` after all,
  inside `StudioDesignSurface.tsx` itself: the effect that turns per-flow runtime
  state into the rail's status dots.
- `/api/v1/ai/conversations` — the dispatch named
  `hooks/useConversationList.ts`. **Falsified.** The reader here is
  `hooks/useChatConversation.ts`, and it is not a list read at all: it is the
  resolve effect MINTING a thread with a `POST`. That difference is what produced
  the second route below.

Escaped URLs were exactly one per family, with no second endpoint before the
doubles went in. The probe was reverted with `git checkout HEAD -- path`; the
guard is byte-identical to `HEAD` afterwards (blob back to `4205b9ff`,
`git diff HEAD` empty).

**The doubles** are batch 1/2/3/4's shape verbatim: `vi.stubGlobal('fetch',
router)` in a module-scope `beforeEach`, `cleanup()` before
`vi.unstubAllGlobals()` in `afterEach` (the #7439 ordering). Each is a router,
not a sink — it records every URL it is handed and its `afterEach` fails on any
URL outside the routes it serves. All three carry a `headers: new Headers()` on
the answer, which is part of the answer rather than decoration for file 1: the
authenticated wrapper reads `response.headers.get('set-auth-token')` on every API
call before the caller ever sees the body.

In files 1 and 2 the new `afterEach` **replaces** the bare `afterEach(cleanup)`
that used to stand there — `cleanup()` is still called, from inside it, ahead of
the unstub. That is stated in the comment at each site so no reader reads it as a
dropped teardown.

Why each answer keeps every assertion's meaning:

- **`meta/object` — empty.** The failing request landed in
  `useMetadataListOptions`'s `.catch`, which sets `{ options: [], loading: false }`.
  An empty registry produces the identical state through `.then`. A seeded one
  would put options into every reference combobox in the tree. Nothing in the file
  asserts anything about reference options: the 11 cases assert the
  `inactive-retained` notice, its wording, its `data-inactive-retained` attribute,
  the clear button, and that `onPatch` is not called on render.
- **`automation/_status` — empty.** The effect turns each returned row into a
  status DOT on the flow rail; the failing request left `flowStatus` at `{}` with
  no dots. A seeded roster would have added a dot for `nightly` to the very
  Automations tableau the file pins. The four cases assert registry emptiness with
  a must-hit control, plus the "no designers are registered" copy and the absence
  of the retired "click a node" instructions.
- **`ai/conversations` — one empty thread, and TWO routes.** This is the batch's
  one real surprise, and it was measured, not reasoned: serving only the mint made
  this file's OWN router assertion go red naming
  `/api/v1/ai/conversations/conv_studio_copilot`. A mint that SUCCEEDS is
  resumable, `useChatConversation` caches the minted id in `localStorage`, and
  happy-dom keeps that store for the whole file — so case 1 mints and cases 2 to 4
  resume. Both routes answer the same empty `ServerConversation`, so the fake
  server is self-consistent: one thread, minted once, resumed thereafter. Empty
  rather than seeded because a seeded thread would hydrate `initialMessages` into
  the capture stub for no assertion's benefit. The file asserts exactly one thing
  per case — the `surfaceContext` prop the pane receives, derived from the URL
  alone — `ChatPane` is a capture stub, and the resolve settles in a microtask
  AFTER each synchronous case body has already read `capturedProps`.

No file's assertions depend on the request FAILING, so there is no fork to report.
Nothing is skipped, quarantined or silenced; the real request stayed the evidence
until the double replaced it.

## Ledger arithmetic

**4 to 1, in both lists.** The three names are deleted from `KNOWN_ESCAPES` in
`vitest.setup.network-escape-guard.ts` (each with its endpoint comment) and from
`PINNED_LEDGER` in `scripts/__tests__/network-escape-ledger.test.ts`, in one
commit. Checked in lockstep by diffing the quoted paths of the two literals
against each other on the final head: **empty diff**, both at 1. The pin's
non-vacuity floor is `length` greater than 0 and `KNOWN_ESCAPES.size` greater than
0, so 1 clears both.

The one remaining row is
`packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.specKeys.test.tsx`
(`/api/v1/meta/object`). It is deliberately untouched: draft PR #7685 holds that
file and is still open (re-checked on this run — `open`, `draft: true`, untouched
since 05:26Z). It is a one-file batch 6.

No prose count moved. Every "21" in the two ledger files is a provenance claim
about the original sweep on `67dadd6`, not a live count — re-checked line by line,
the same reading batches 3 and 4 recorded.

## Evidence

Per file, before then after. "Before" for files 2 and 3 is read off the
stack-probe run, which only ADDS stderr lines and cannot change the escape or
socket counts; file 1 also has a clean pre-probe baseline that agrees (1 / 3).

| file | before (attribution / `ECONNREFUSED` lines) | after, on the final head |
|:--|:--|:--|
| `FlowNodeInspector.inactiveRetained` | 1 / 3 | 0 / 0, exit 0, `Tests 11 passed (11)` |
| `StudioDesignSurface.designerRegistryMissing` | 1 / 3 | 0 / 0, exit 0, `Tests 4 passed (4)` |
| `studioSurfaceContext` | 4 / 20 | 0 / 0, exit 0, `Tests 4 passed (4)` |

Test counts are unchanged in every file — the doubles add no cases and remove
none.

The dispatch-named scope on the final head `e56f739d3`:

`pnpm exec vitest run packages/app-shell/src/views/metadata-admin/inspectors/ packages/app-shell/src/views/studio-design/ scripts/__tests__/network-escape-ledger.test.ts`
— exit 0, `Test Files 120 passed (120)`, `Tests 1083 passed | 1 skipped (1084)`,
316s. It is **not** zero-escape, and that is expected and stated in the dispatch:
its 1 remaining attribution line names `FlowNodeInspector.specKeys.test.tsx`, the
row still on the ledger, and its 1 `ECONNREFUSED` line is that same escape. **Zero**
lines in the run name any of this batch's three files.

The whole-package `app-shell` suite is declared as CI's rather than run here: it
took 918s for batch 4 and would exceed this container's foreground cap under
concurrent load. The scope above is the dispatch-named one and covers every file
this diff touches plus the pin.

## Ablation

Run on the final head against `FlowNodeInspector.inactiveRetained` (3 `describe`
blocks, 11 cases — the most of the three), with its `KNOWN_ESCAPES` and
`PINNED_LEDGER` lines still deleted:

- mutation proven ON DISK before the run: `installMetaObjectDouble` occurrences
  2 to 0, bare `afterEach(cleanup);` 0 to 1, blob `86b5c8f8` to `ad794f14`
  (a hash comparison, not an editor exit code);
- result: **exit 1**, `Tests 1 failed | 10 passed (11)`, and the guard's red names
  the file, the socket and the case:
  `Network escape: this test reached a REAL socket at http://localhost:3000/api/v1/meta/object`,
  `file: packages/app-shell/src/views/metadata-admin/inspectors/FlowNodeInspector.inactiveRetained.test.tsx`,
  `test: the affordance appears exactly when a value is hidden-but-stored > does NOT appear on a node with no gated fields at all`;
- restored by `git checkout HEAD -- path` from inside the script's
  `trap ... EXIT INT TERM`: blob back to `86b5c8f8`, `git diff HEAD` empty,
  `git status --porcelain` empty.

The direction is the plain one — red — and it is the direction that matters here:
it proves the three deletions are backed by real doubles rather than by luck.

**No dist preflight leg was needed**, re-confirmed on the first run as the
dispatch asked: the ablation edits the test file itself, which Vite transforms
directly, so there is no `dist/` between the mutation and the assertion.

## Gates

All on the final head `e56f739d3`, exit codes captured by redirect-then-capture.

| gate | result |
|:--|:--|
| dispatch-named `vitest` scope | exit 0 — 120 files, 1083 passed, 1 skipped |
| per-file runs, all three | exit 0, 0 attribution / 0 socket lines each |
| `node scripts/check-changeset-presence.mjs` | exit 0 — 3 source files of 1 released package, 1 changeset, EMPTY frontmatter accepted as the explicit exemption |
| `pnpm check:control-bytes` | exit 0 — 6460 tracked text files scanned |
| `grep -naP` control-byte self-scan over all 6 changed paths | no hits (grep exit 1) |
| `node scripts/check-governed-queue-guard.mjs --test` (all 6 paths) | exit 0 — **NOT GOVERNED**, 6 paths against 5 governed surfaces, none matched |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm type-check:vitest-setup` | exit 0 after the build. On the unbuilt tree it was PREREQUISITE NOT MET exactly as the dispatch predicted — 4 TS2882 side-effect-import errors in `vitest.setup.dom.tsx`, none about this diff |
| `pnpm check:vi-mock-inherit` | exit 0 |
| `pnpm check:vi-mock-specifiers` | exit 0 |
| `turbo run type-check lint --concurrency=2 --force --filter @object-ui/app-shell` | exit 0 — 32 tasks, 0 cached, 5m02s |

Non-vacuity, both proven rather than asserted:

- `tsc -p packages/app-shell/tsconfig.test.json --listFiles` — 4421 files in the
  program, and each of the three edited test files appears exactly once.
- `eslint . --format json` in `packages/app-shell` — 1087 files reported, each of
  the three edited files present, **0 errors** repo-package-wide. The two warnings
  on `FlowNodeInspector.inactiveRetained` are pre-existing
  `@typescript-eslint/no-explicit-any` hits on the file's own
  `as any` casts, at lines 104 and 144 before this change and 177 and 217 after —
  the same two, shifted by the 73 lines added above them.

`Live E2E (informational)` is red on every branch today for an upstream reason
(#7990 / objectstack#16186) — not this PR's.

## Concurrency

Branched from `8d40c18a7`. `main` moved to `58cd01a38` mid-run (#8034, #8036,
#8038, #8040), so `origin/main` was merged in and **every gate above was re-run on
the merged head** `e56f739d3` — the numbers quoted are all post-merge. The
incoming diff is disjoint from this one: it touches `plugin-charts`,
`packages/types/README.md`, two `content/docs` pages, `scripts/check-doc-snippet-types.mjs`
and `packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx`, none of
which this batch reads or writes. Draft PR #7685 still holds
`FlowNodeInspector.specKeys.test.tsx`, which is why that row is excluded here.

No labels, assignee or PR state were written by this run; the identity is the
branch named in the batch-5 claim comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_