### PR TITLE
fix(fields): GeolocationField emits null for a cleared coordinate

### DIFF
--- a/.changeset/6848-geolocation-clear-emits-null.md
+++ b/.changeset/6848-geolocation-clear-emits-null.md
@@ -1,0 +1,35 @@
+---
+'@object-ui/fields': minor
+---
+
+`GeolocationField` emits `null` for a cleared coordinate, not `undefined` (objectui#6848).
+
+Emptying a latitude or longitude box now emits `{ …, latitude: null }` where it previously
+emitted `{ …, latitude: undefined }`. `CurrencyField`, `PercentField` and `NumberField` all
+already emitted `null` for the identical user action, and `LocationField` emits `null` too —
+this composite was the only widget of the class that did not.
+
+**Why `undefined` was the wrong sentinel.** It cannot survive serialization: `JSON.stringify`
+drops an `undefined`-valued key outright, so the moment the emission left memory it stopped
+saying "the user cleared this" and started saying nothing at all. `null` says it explicitly and
+keeps saying it on the wire.
+
+**Scope — what this is NOT.** The card was filed on the reasoning that the dropped key reaches
+a PATCH-shaped update as an ABSENT key, which conventionally means "leave this field alone",
+so a cleared coordinate would silently fail to persist. That was measured before this fix was
+chosen, and the second half does not hold for this widget: the dropped key is nested one level
+below the key the write path merges on. The request body still carries the composite's own key
+(`{ <field>: { longitude: … } }`), a `location` value is stored as a single JSON column, and
+nothing on the path deep-merges — so the whole value is replaced and the cleared coordinate
+does not come back. No silent data loss was found, and none is fixed here. What is fixed is
+the emission: a widget that could not express "cleared" in a form that survives serialization,
+in a class whose other members could.
+
+**`GeolocationValue` widened** — `latitude`, `longitude` and `accuracy` are now
+`number | null | undefined`. `undefined` stays admissible, because an untouched coordinate is
+genuinely absent; `null` is now admissible because a cleared one is explicitly empty. Code that
+reads these coordinates with a falsy or `== null` test is unaffected. Code that distinguishes
+`=== undefined` specifically will now see `null` after a user clears a box.
+
+A legitimate `0` coordinate (the equator, the prime meridian) is unaffected and is now pinned:
+the emptiness test reads the raw input string, and `'0'` is not an empty string.

--- a/packages/fields/src/__tests__/GeolocationClearEmission.test.tsx
+++ b/packages/fields/src/__tests__/GeolocationClearEmission.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6848 — an emptied coordinate box emits `null`, and that emission
+ * SURVIVES serialization.
+ *
+ * ## What this file pins, and why the second half is the point
+ *
+ * `GeolocationField` used to emit `{ [coordinate]: undefined }` where
+ * `CurrencyField`, `PercentField` and `NumberField` all emit `null` for the
+ * identical user action. Asserting `=== null` alone would under-pin the fix:
+ * the defect was never about which sentinel sat in memory, it was that
+ * `undefined` STOPS EXISTING the moment the value is serialized. So every
+ * emission here is also driven through `JSON.stringify` and the key is asserted
+ * to still be there — the assertion the old code actually failed.
+ *
+ * ## The write-path measurement (objectui#6848 step 1) — recorded, NOT re-pinned
+ *
+ * The card carried a reasoned escalation: `undefined` keys vanish from
+ * `JSON.stringify`, so a cleared coordinate reaches the server as an ABSENT
+ * key, which on a PATCH conventionally means "leave it alone" ⇒ the old
+ * coordinate silently survives the save. That was measured before this fix was
+ * chosen. Both halves of the answer:
+ *
+ *  1. **Absent really is not null on the write path.** `@objectstack/client`
+ *     17.2.0 `data.update` sends `method: 'PATCH'`, `body: JSON.stringify(data)`;
+ *     `driver-memory`'s `update()` merges `{ ...stored, ...data }` and
+ *     `driver-sql`'s issues `SET` for the keys present — so an absent key keeps
+ *     the stored value and an explicit `null` overwrites it. The platform states
+ *     the same contract in prose: *"To clear the stored X, write null; to leave
+ *     it unchanged, omit the field."*
+ *
+ *  2. **But that hazard does not reach THIS widget**, which is why the card is
+ *     not the silent-data-loss defect it was filed as. The dropped key is
+ *     nested one level below the key the write path merges on: the payload is
+ *     `{ <field>: { longitude: … } }`, the composite's OWN key is present,
+ *     `location` is a single JSON column, and nothing on the path deep-merges.
+ *     The whole value is replaced, so the cleared coordinate does not come
+ *     back. Measured end to end: emission → `sanitizeFormData` → the client's
+ *     `JSON.stringify` → the drivers' shallow merge.
+ *
+ * That second half is deliberately NOT asserted here. It is a fact about
+ * `@objectstack/client` and the platform's drivers, and a hand-rolled model of
+ * them living in this package would pin this file's own guess rather than their
+ * behaviour — green forever, including on the day they change. What this
+ * package owns is the emission, and that is what is pinned below.
+ *
+ * ⛔ Does not re-measure the browser table — Chromium 141 via Playwright,
+ * provenance in the PR for objectui#6793. `''` is taken from that table as a
+ * value a real browser delivers when a box is emptied.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import type { FieldMetadata } from '@object-ui/types';
+import { CurrencyField } from '../widgets/CurrencyField';
+import { PercentField } from '../widgets/PercentField';
+import { NumberField } from '../widgets/NumberField';
+import { GeolocationField, type GeolocationValue } from '../widgets/GeolocationField';
+
+const field = (name: string, type: string): FieldMetadata =>
+  ({ name, label: name, type } as unknown as FieldMetadata);
+
+/** The composite as a form would hold it, put through what the write path does to it. */
+const roundTrip = (emitted: unknown) =>
+  JSON.parse(JSON.stringify({ geo: emitted })) as { geo: Record<string, unknown> };
+
+/** Drive the FIRST `type="number"` box of a rendered widget to `next`. */
+function driveFirstNumberBox(next: string): void {
+  const box = document.querySelectorAll('input[type="number"]')[0] as HTMLInputElement;
+  fireEvent.change(box, { target: { value: next } });
+}
+
+describe('objectui#6848 — clearing a GeolocationField coordinate', () => {
+  const seeded = { latitude: 30.2741, longitude: 120.1551 } as GeolocationValue;
+
+  it('emits null for the cleared coordinate and keeps the other one', () => {
+    const onChange = vi.fn();
+    render(<GeolocationField value={seeded} onChange={onChange} field={field('geo', 'location')} />);
+
+    driveFirstNumberBox('');
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const emitted = onChange.mock.calls[0][0] as GeolocationValue;
+    expect(emitted.latitude).toBeNull();
+    expect(emitted.longitude).toBe(120.1551);
+    cleanup();
+  });
+
+  it('⭐ the cleared coordinate SURVIVES JSON.stringify as an explicit null', () => {
+    const onChange = vi.fn();
+    render(<GeolocationField value={seeded} onChange={onChange} field={field('geo', 'location')} />);
+
+    driveFirstNumberBox('');
+    const wire = roundTrip(onChange.mock.calls[0][0]);
+
+    // The whole point of the card: `undefined` did not get this far. The key
+    // was gone from the serialized body, so the emission no longer said
+    // "cleared" by the time anything downstream could read it.
+    expect(Object.keys(wire.geo)).toContain('latitude');
+    expect(wire.geo.latitude).toBeNull();
+    expect(JSON.stringify(wire.geo)).toContain('"latitude":null');
+    cleanup();
+  });
+
+  it('clearing the LONGITUDE box behaves identically (both coordinates, one rule)', () => {
+    const onChange = vi.fn();
+    render(<GeolocationField value={seeded} onChange={onChange} field={field('geo', 'location')} />);
+
+    const lng = document.querySelectorAll('input[type="number"]')[1] as HTMLInputElement;
+    fireEvent.change(lng, { target: { value: '' } });
+
+    const wire = roundTrip(onChange.mock.calls[0][0]);
+    expect(wire.geo.longitude).toBeNull();
+    expect(wire.geo.latitude).toBe(30.2741);
+    cleanup();
+  });
+
+  /**
+   * The falsy-guard question the dispatch asked to MEASURE rather than assume:
+   * `fieldValue ? … : null` tests the raw `.value` STRING, not the parsed
+   * number. `'0'` is a non-empty string, so a legitimate zero coordinate — the
+   * equator, the prime meridian — takes the value branch, not the clear branch.
+   * The trap is not live at this emission site, and this pin is what keeps a
+   * future "simplify" from moving the guard onto the parsed number, where it
+   * WOULD be live.
+   */
+  it('a legitimate 0 coordinate emits 0, not null', () => {
+    const onChange = vi.fn();
+    render(<GeolocationField value={seeded} onChange={onChange} field={field('geo', 'location')} />);
+
+    driveFirstNumberBox('0');
+
+    const emitted = onChange.mock.calls[0][0] as GeolocationValue;
+    expect(emitted.latitude).toBe(0);
+    expect(typeof emitted.latitude).toBe('number');
+    expect(roundTrip(emitted).geo.latitude).toBe(0);
+    cleanup();
+  });
+});
+
+describe('objectui#6848 — the four `type="number"` widgets now agree on "cleared"', () => {
+  /**
+   * One rule for the class: emptying the box emits `null`, and that `null`
+   * reaches the wire. The three scalar widgets already did this; the composite
+   * was the outlier the card names.
+   */
+  it.each([
+    ['currency', (onChange: (v: unknown) => void) =>
+      <CurrencyField value={42} onChange={onChange} field={field('amount', 'currency')} />],
+    ['percent', (onChange: (v: unknown) => void) =>
+      <PercentField value={42} onChange={onChange} field={field('rate', 'percent')} />],
+    ['number', (onChange: (v: unknown) => void) =>
+      <NumberField value={42} onChange={onChange} field={field('count', 'number')} />],
+  ])('%s emits null when the box goes empty', (_name, renderWidget) => {
+    const onChange = vi.fn();
+    render(renderWidget(onChange) as React.ReactElement);
+
+    driveFirstNumberBox('');
+
+    expect(onChange.mock.calls[0][0]).toBeNull();
+    cleanup();
+  });
+
+  it('geolocation now joins them — its cleared coordinate is null too', () => {
+    const onChange = vi.fn();
+    render(
+      <GeolocationField
+        value={{ latitude: 42, longitude: 7 } as GeolocationValue}
+        onChange={onChange}
+        field={field('geo', 'location')}
+      />,
+    );
+
+    driveFirstNumberBox('');
+
+    expect((onChange.mock.calls[0][0] as GeolocationValue).latitude).toBeNull();
+    cleanup();
+  });
+});

--- a/packages/fields/src/__tests__/NumberInputWidgets.browserDeliverable.test.tsx
+++ b/packages/fields/src/__tests__/NumberInputWidgets.browserDeliverable.test.tsx
@@ -206,15 +206,18 @@ const PRODUCT: ReadonlyArray<{
   { widget: 'number', typed: '0x10', emits: 10 },
   { widget: 'number', typed: '1e', emits: null },
   { widget: 'number', typed: '', emits: NO_CALL },
-  // ⚠️ Not a transcription slip: `GeolocationField` clears a coordinate to
-  // `undefined` where the other three clear to `null`, because it builds an
-  // object (`fieldValue ? Number(fieldValue) : undefined`) instead of emitting
-  // a scalar. Reachable by any user who empties the box. Pinned as the product
-  // behaviour it is, and reported rather than "fixed" under this card.
+  // This row USED to be the odd one out, and the history is kept because the
+  // reading is what the divergence was reported from: `GeolocationField`
+  // cleared a coordinate to `undefined` where the other three cleared to
+  // `null`, because it builds an object rather than emitting a scalar. That
+  // was pinned here as product behaviour and reported rather than fixed under
+  // objectui#6793 — then fixed under objectui#6848, which is why the `1e` row
+  // now reads `null` like its three siblings. The class has ONE rule again;
+  // `GeolocationClearEmission.test.tsx` holds the fix's own pins.
   { widget: 'geolocation', typed: '12abc', emits: 12 },
   { widget: 'geolocation', typed: '1.2.3', emits: 1.23 },
   { widget: 'geolocation', typed: '0x10', emits: 10 },
-  { widget: 'geolocation', typed: '1e', emits: undefined },
+  { widget: 'geolocation', typed: '1e', emits: null },
   { widget: 'geolocation', typed: '', emits: NO_CALL },
 ];
 

--- a/packages/fields/src/widgets/GeolocationField.tsx
+++ b/packages/fields/src/widgets/GeolocationField.tsx
@@ -10,9 +10,15 @@ import { useBadInputRefusal, BadInputMessage, BAD_INPUT_BORDER } from './numberB
  * Geolocation data structure
  */
 export interface GeolocationValue {
-  latitude?: number;
-  longitude?: number;
-  accuracy?: number;
+  /**
+   * `number | null` since objectui#6848. `null` is what an emptied box emits —
+   * the spelling `CurrencyField` / `PercentField` / `NumberField` already used
+   * for the same user action — so the type has to admit it. `undefined` stays
+   * admissible because an untouched coordinate is genuinely absent.
+   */
+  latitude?: number | null;
+  longitude?: number | null;
+  accuracy?: number | null;
 }
 
 /**
@@ -79,7 +85,24 @@ export function GeolocationField({ value, onChange, field, readonly, error, ...p
   const handleFieldChange = (fieldName: keyof GeolocationValue, fieldValue: string) => {
     onChange({
       ...location,
-      [fieldName]: fieldValue ? Number(fieldValue) : undefined,
+      // `null`, not `undefined` (objectui#6848). An emptied box is a CLEAR, and
+      // `undefined` cannot say so past a serializer: `JSON.stringify` drops the
+      // key outright, so the emission stopped describing the user's action the
+      // moment it left memory. The other three `type="number"` widgets of this
+      // class already emit `null` for the identical action; this was the only
+      // one that did not.
+      //
+      // ⚠️ What this is NOT, measured on this card so the reasoning cannot rot
+      // into a bigger claim: it is not silent data loss against the ObjectStack
+      // adapter today. That hazard needs the dropped key to be the one the
+      // write path merges on, and here it is nested one level DOWN — the
+      // payload still carries the composite's own key, `location` is a single
+      // JSON column, and nothing on the path deep-merges, so the whole value is
+      // replaced and the cleared coordinate does not come back. The defect
+      // fixed here is the emission itself: a widget that cannot express "clear"
+      // in a form that survives serialization, in a class where its three
+      // siblings can.
+      [fieldName]: fieldValue ? Number(fieldValue) : null,
     });
   };
 


### PR DESCRIPTION
Fixes #6848

## Step 1 was a MEASUREMENT, and it re-prices the card

Triage wrote the escalation condition into the card so it would not be re-argued: if an absent key and an explicit `null` are treated **differently** on the write path, this is immediately a `priority:p1` silent data-loss defect (the user clears a coordinate, sees an empty box, saves, and the old coordinate survives, with no diagnostic); if they are treated identically, it drops to a `p3` consistency tidy.

**The answer has two halves, and they point in opposite directions. My verdict: NOT p1 — recommend `priority:p3`.**

### Half 1 — absent really is NOT null on the write path (the condition's literal antecedent is TRUE)

Read on the tree, entrance re-taken (triage cited `:2958`; `main` has moved, it is now `packages/data-objectstack/src/index.ts:3081`):

- `ObjectStackAdapter.update()` passes `data` straight through to `this.client.data.update(...)` — no normalization of any kind.
- `@objectstack/client` 17.2.0 `data.update` sends `method: "PATCH"`, `body: JSON.stringify(data)`.
- `driver-memory`'s `update()` merges `{ ...table[index], ...data, ... }` — a **shallow** spread.
- `driver-sql`'s `update()` issues `builder.update(payload)` — `SET` for the keys **present** in the payload.
- The platform states the same contract in prose, in `packages/objectql/src/secret-fields.ts`: *"To clear the stored X, write null; to leave it unchanged, omit the field."*

Executed end to end through that model: an absent key leaves `{"id":"r1","amount":42}` unchanged, an explicit `null` writes `{"id":"r1","amount":null}`. **Different.**

### Half 2 — but the harm the `p1` grade is DEFINED by is not reachable for this widget

The escalation condition defines its own harm in the parenthetical: *the old coordinate survives the save*. It does not.

The dropped key is nested **one level below** the key the write path merges on. `GeolocationField` emits a composite, so the payload is `{ FIELD: { longitude: 120.1551 } }` — the composite's **own** key is present. A `location` value is stored as a **single JSON column** (`JSON_COLUMN_TYPES` in `driver-sql`, which lists `composite`/`address`/`location`/`record` as objects), and **nothing on the path deep-merges** (the only `deepMerge` in `objectql` is the metadata registry's, not the data write path). So the whole value is replaced.

Measured through the real widget, then through the real chain (`sanitizeFormData` → the client's `JSON.stringify` → the drivers' shallow merge):

```
GEO emitted keys      : ["latitude","longitude"]
GEO emitted latitude  : undefined       ('latitude' in obj -> true)
GEO wire body         : {"geo":{"longitude":120.1551}}
GEO stored after save : {"longitude":120.1551}
GEO latitude survives?: false            <-- the clear DOES persist
```

`sanitizeFormData` was confirmed to be a pass-through (`out[key] = value`) that only walks **top-level** keys, and `ObjectForm` sends the whole sanitized `formData` on edit with no dirty-diff and no merge.

⇒ **No silent data loss exists here, and none is fixed by this PR.** The antecedent is true in general; the consequent is not reachable for this widget. I am reporting both rather than collapsing them, because the two halves disagree and picking a side quietly is what the card was written to prevent.

### The falsy-guard question, measured as asked

`fieldValue ? … : undefined` tests the raw input **string**, not the parsed number. `'0'` is a non-empty string, so a legitimate `0` coordinate takes the value branch:

```
GEO zero emitted lat  : 0 | typeof number
GEO zero wire         : {"geo":{"latitude":0,"longitude":120.1551}}
```

**The trap is NOT live at this emission site.** It is now pinned, so a future "simplify" cannot move the guard onto the parsed number, where it would be live.

## What changed

`packages/fields/src/widgets/GeolocationField.tsx` (emission site re-taken at `:82`, verbatim as cited):

```
-      [fieldName]: fieldValue ? Number(fieldValue) : undefined,
+      [fieldName]: fieldValue ? Number(fieldValue) : null,
```

`CurrencyField`, `PercentField` and `NumberField` already emit `null` for the identical action, and `LocationField` emits `null` too (`onChange(null)`) — this composite was the **only** widget of the class that did not. `undefined` cannot survive serialization: `JSON.stringify` drops the key outright, so the emission stopped saying "the user cleared this" the moment it left memory.

`GeolocationValue` widens `latitude` / `longitude` / `accuracy` to `number | null`. `undefined` stays admissible — an untouched coordinate is genuinely absent.

## Tests

- **New pin** `packages/fields/src/__tests__/GeolocationClearEmission.test.tsx` (8 tests). It asserts the emission is `null` **and that it survives `JSON.stringify`** — the second half is the point, since the defect was never about which sentinel sat in memory. Also pins the `0` coordinate and the class-wide agreement across all four widgets.
- **Retuned pin** `NumberInputWidgets.browserDeliverable.test.tsx` — its `geolocation` / `1e` row pinned the defect as current product behaviour. It now reads `null`, with the history kept in the comment rather than deleted, because that reading is what the divergence was reported from.
- `pnpm --filter @object-ui/fields test` → **135 files passed, 2194 tests passed**.
- `pnpm --filter @object-ui/fields type-check` → exit 0.
- Gates run locally, all exit 0: `check:control-bytes`, `check:unreferenced-sources`, `check:published-dist`, `check:published-tsconfig-exclude`, and the three changeset gates (`check-changeset-presence` confirms 1 changeset for 3 changed published-source files, compared against merge-base `06761b351`).

### Reverse verification (ablation)

Predicted direction before running: **turns red**. Fix committed first, mutation proven to land on disk by blob hash (`33979f4` → `6826a7f`) and by anchor counts (`: null` 1→0, `: undefined` 0→1), with an `EXIT INT TERM` trap holding the restore:

```
VERDICT ablation-exit=1
Test Files  2 failed (2)
Tests  5 failed | 28 passed (33)
```

Five red across **both** pin files. Restore proven by byte identity — on-disk blob back to `33979f42…`, matching `HEAD`, with `git diff HEAD` empty. The tests import the widget by relative **source** path, so no `dist` is involved and the mutation reaches them directly.

### Cross-package type check

`fields` rebuilt first, and the emitted `packages/fields/dist/widgets/GeolocationField.d.ts` confirmed to carry `latitude?: number | null` — so the reading below is of a fresh build, not a cache. Then a two-leg probe through a real consumer (`@object-ui/plugin-form`):

- `latitude: null` assigned to `GeolocationValue` → **exit 0** (rejected before this change, so the widening is live in the consumer's view).
- `latitude: 'not-a-number'` → **exit 1**, `error TS2322` — the control leg, proving the check has teeth.

`GeolocationValue` is referenced by name nowhere outside `packages/fields`, and the coordinate keys have no other consumer (the `latitudeField` / `longitudeField` hits in `@object-ui/types` are map field **names**, a different thing).

## Declared narrowing

I ran the owning package's full suite, the targeted gate families, and the consumer-direction type sweep. I did **not** run every one of the 20 affected packages' test suites locally — that is CI's run, and this is a declared narrowing rather than a silent one. Gate status at report time is therefore `in_progress`; CI convergence is the PM's read, not mine.

Note for whoever derives gates here: `scripts/pm/dispatch-gates.mjs` does not exist in this repo, so the families above were derived by hand from `.github/workflows/` and `package.json`.

## Scope fences honoured

- **The two-parser divergence is not touched.** `parseFloat` in Currency/Percent vs `Number` in Number/Geolocation was measured to agree on every string a real browser can deliver — latent, not live. Not widened.
- **The browser table was not re-measured.** Chromium 141 via Playwright, provenance in the PR for #6793. `''` is taken from that table as a value a real browser delivers.
- `packages/data-objectstack` was **read-only** for the measurement; no `packages/spec`; objectstack read-only.
- **Clause-②: no**, and the measurement agrees. Emitting `null` instead of `undefined` moves no schema's accept set — the objectstack `LocationValueSchema` is a `strictObject` over `lat`/`lng`, so `{longitude: …}` and `{latitude: null, longitude: …}` are refused identically by it. (That `lat`/`lng` vs `latitude`/`longitude` spelling gap is already known and ruled — see #6660 / the #6272 A1 ruling — so it is not filed as new.)

## Out-of-scope finding, filed not fixed

**#8055** — `GeolocationField` renders a valid `0` coordinate as EMPTY, and leaks a literal `0` into the DOM. Measured while working here: readonly at `{ latitude: 0, longitude: 120.1551 }` (a real point on the equator) renders `"—0"` against a control of `"30.274100, 120.155100View on map"`. Two distinct defects — the falsy-on-number guards in `formatLocation` / `openInMaps` / the map-button gates, and `0 && x` rendering a literal `0` through JSX. That is the widget's **display** path, a different code path and a different defect class from this card's **emission** path, so per the dispatch's instruction it is named rather than silently folded in.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnpvbdoRisQdRAczkLwnf5)_