### PR TITLE
docs(ci-cd-pipeline): correct the Half-State Patrol wiring and pin it against the workflow

### DIFF
--- a/content/docs/guide/ci-cd-pipeline.md
+++ b/content/docs/guide/ci-cd-pipeline.md
@@ -1882,13 +1882,28 @@ guess an issue number and rewrite an unrelated card.
 
 **Ported from objectstack, with the divergences listed in the workflow header.** The pair
 (`scripts/pm/check-half-states.mjs` + this workflow) is adopted from `objectstack-ai/objectstack`
-and is meant to stay re-syncable, so this install keeps its differences in one place. The
-behavioural one: the sweeper's closed-card reader (`pm:*` labels left on cards that already closed)
-is switched **off** here via `PM_SWEEP_CLOSED_WINDOW_PAGES: '0'`. Stripping `pm:*` on close was
-never this repo's practice — 815 closed cards carry `pm:dispatched`, ~87% of the reader's window —
-so that predicate would report the convention rather than a defect and bury every other finding.
-The rendered summary says that surface is **UNREAD**, never that it is clean
-([#5791](https://github.com/objectstack-ai/objectui/issues/5791)).
+and is meant to stay re-syncable, so this install keeps its differences in one place
+([#5791](https://github.com/objectstack-ai/objectui/issues/5791)). The behavioural one is how the
+sweeper's closed-card reader (`pm:*` labels left on cards that already closed) is *called* here: the
+reader is **on**, with a dated floor. The sweep step sets `PM_SWEEP_CLOSED_FLOOR: '2026-08-28'`, so
+only cards closed on or after that cutover are judged, and the page window is deliberately left
+unset — back to the sweeper's own upstream default of 4 pages. The floor, not a zeroed window, is
+what holds the historical carriers out.
+
+**Why a floor rather than a plain "on".** Stripping `pm:*` on close only became this repo's practice
+on the cutover date, and the measurement taken just before it says what an unfloored reader would do
+here: 815 closed cards carry `pm:dispatched`, and ~87% of the issues in the default window carried
+some `pm:*` residue — against the 26% upstream measured. That predicate would report the
+*convention* rather than a defect, and its rows would consume the whole body budget and trim every
+other predicate out of the anchor. Cards closed before the cutover are inert history — the dispatch
+loop reads state on open cards only — so judging from the cutover forward buys the row's whole value
+with no backfill: no bulk relabelling of closed cards was run, none is owed, and the sweeper writes
+no label under any code path ([#5985](https://github.com/objectstack-ai/objectui/issues/5985)). A
+malformed floor is refused outright rather than degraded to "no floor", because a silent degrade
+would restore the flood four times a day and a flooded anchor reads exactly like a working patrol.
+The sweeper still carries an objectui-only escape hatch that switches the closed reader fully off —
+that is what this install ran until the cutover; it is unset now, and while it is set the rendered
+summary says that surface is **UNREAD**, never that it is clean.
 
 ### Merge Queue Head Patrol (`merge-queue-head-patrol.yml`)
 

--- a/scripts/__tests__/ci-cd-pipeline-doc.test.ts
+++ b/scripts/__tests__/ci-cd-pipeline-doc.test.ts
@@ -1434,3 +1434,164 @@ describe('ci-cd-pipeline.md — live-e2e backend pin (#7689)', () => {
     ).toMatch(/^[0-9a-f]{40}$/);
   });
 });
+
+/**
+ * objectui#8043 — the Half-State Patrol section told readers the sweeper's closed-card reader was
+ * "switched **off** here via `PM_SWEEP_CLOSED_WINDOW_PAGES: '0'`". The workflow stopped setting
+ * that variable on 2026-08-28: the reader is ON with a dated floor (`PM_SWEEP_CLOSED_FLOOR`), the
+ * page window is deliberately absent, and the retired knob survives only in the workflow's header
+ * comments as history. So the page sent anyone looking for the switch to a variable nothing sets,
+ * and — worse in the direction this page is read — it described a predicate as disabled while it
+ * runs four times a day.
+ *
+ * The `workflow inventory` block above cannot see this: it matches filenames in headings, so a
+ * false sentence *inside* a documented section is exactly the drift it is blind to (objectui#7852
+ * says so in as many words). This block closes that gap for the one thing on this page that names
+ * the sweeper's wiring by identifier.
+ *
+ * ⛔ The comparison reads the workflow's `env:` KEYS, never the file as text. A whole-file grep
+ * would find `PM_SWEEP_CLOSED_WINDOW_PAGES` in the header at `:39` / `:80` and accept the very
+ * sentence this block exists to reject — the retired knob is *discussed* there precisely because
+ * it is retired. `envKeysOf` below is unit-controlled against that shape.
+ */
+const HALF_STATE_WORKFLOW = 'half-state-patrol.yml';
+
+/**
+ * Every key of every `env:` mapping in a workflow — i.e. the variables the workflow actually SETS.
+ *
+ * Whole-line comments go first (`withoutComments`), and only children at exactly `env:`'s
+ * indentation + 2 are read, so the continuation lines of a folded scalar (`PROVENANCE: >-` runs to
+ * three of them here) cannot be mistaken for further keys.
+ */
+function envKeysOf(yaml: string): Set<string> {
+  const keys = new Set<string>();
+  const lines = withoutComments(yaml).split('\n');
+
+  lines.forEach((line, index) => {
+    const opener = line.match(/^(\s*)env:\s*$/);
+    if (!opener) return;
+    const openIndent = opener[1].length;
+
+    for (const child of lines.slice(index + 1)) {
+      if (child.trim() === '') continue;
+      const indent = child.match(/^\s*/)![0].length;
+      if (indent <= openIndent) break;
+      if (indent !== openIndent + 2) continue;
+      const key = child.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:/);
+      if (key) keys.add(key[1]);
+    }
+  });
+
+  return keys;
+}
+
+/** The page section headed by `<heading> (`<file>`)`, up to the next heading at that level or above. */
+function sectionForWorkflow(file: string): string {
+  const lines = doc.split('\n');
+  const start = lines.findIndex((line) => /^#{1,6}\s/.test(line) && line.includes(file));
+  if (start === -1) return '';
+  const level = lines[start].match(/^#+/)![0].length;
+  const after = lines.slice(start + 1);
+  const next = after.findIndex((line) => new RegExp(`^#{1,${level}}\\s`).test(line));
+  return (next === -1 ? after : after.slice(0, next)).join('\n');
+}
+
+const SWEEP_NAME = /PM_SWEEP_[A-Z0-9_]+/g;
+
+describe('ci-cd-pipeline.md — Half-State Patrol sweeper wiring (#8043)', () => {
+  const section = sectionForWorkflow(HALF_STATE_WORKFLOW);
+  const set = [...envKeysOf(readWorkflow(HALF_STATE_WORKFLOW))].filter((k) => k.startsWith('PM_SWEEP_')).sort();
+  const named = [...new Set([...section.matchAll(SWEEP_NAME)].map((m) => m[0]))].sort();
+
+  it('has both sides to compare — neither may be empty', () => {
+    // The vacuity legs. Each of the three below has a failure mode that renders the comparison
+    // green while checking nothing, and each fails silently: a renamed heading empties the
+    // section, a restructured `env:` empties the workflow side, and a rewrite that drops every
+    // identifier leaves the page describing the wiring without naming any of it.
+    expect(
+      section,
+      `No heading on the page names \`${HALF_STATE_WORKFLOW}\`, so this block has no section to ` +
+        'read and its comparison below would pass vacuously. The `workflow inventory` block ' +
+        'requires that heading to exist; if it moved, teach `sectionForWorkflow` where it went.',
+    ).not.toBe('');
+
+    expect(
+      set,
+      `${HALF_STATE_WORKFLOW} sets no \`PM_SWEEP_*\` variable in any \`env:\` block. Either the ` +
+        'wiring moved out of `env:` — in which case `envKeysOf` is reading the wrong thing and ' +
+        'every name on the page would now be reported as a phantom — or the sweeper is no longer ' +
+        'called with any of it, and this section is describing a configuration that is gone.',
+    ).not.toEqual([]);
+
+    expect(
+      named,
+      'The Half-State Patrol section names no `PM_SWEEP_*` variable at all. The reader needs at ' +
+        'least the closure floor: it is the one thing about this install that is not the ' +
+        "sweeper's own default, and a section that omits it sends the next reader to the upstream " +
+        'script for behaviour that is decided in the workflow (objectui#8043).',
+    ).not.toEqual([]);
+  });
+
+  it('reads the workflow\'s env keys, not the file as text', () => {
+    // The control for the paragraph above: a commented-out key is HISTORY, and a whole-file grep
+    // cannot tell it from a setting. That is not hypothetical here — it is the exact shape of
+    // `half-state-patrol.yml`'s header, and it is why the wrong sentence survived.
+    const specimen = [
+      'jobs:',
+      '  patrol:',
+      '    steps:',
+      '      - name: sweep',
+      '        env:',
+      "          # PM_SWEEP_RETIRED: '0'  — read this until the cutover; history, not a setting",
+      "          PM_SWEEP_LIVE: 'x'",
+      '          FOLDED: >-',
+      '            PM_SWEEP_NOT_A_KEY: still just prose',
+      '',
+    ].join('\n');
+
+    expect([...envKeysOf(specimen)].sort()).toEqual(['FOLDED', 'PM_SWEEP_LIVE']);
+  });
+
+  it('names only variables the workflow actually sets', () => {
+    const phantom = named.filter((name) => !set.includes(name));
+
+    expect(
+      phantom,
+      'The Half-State Patrol section names these `PM_SWEEP_*` variables:\n' +
+        phantom.map((n) => `  - ${n}`).join('\n') +
+        `\n\n…and \`${HALF_STATE_WORKFLOW}\` sets none of them. What it does set is:\n` +
+        set.map((n) => `  - ${n}`).join('\n') +
+        '\n\nA reader who goes looking for the knob the page names finds a variable nothing ' +
+        'assigns, and — the expensive direction — believes whatever the page says that knob is ' +
+        'doing. That is objectui#8043 verbatim: the page claimed the closed-card reader was ' +
+        "switched off by `PM_SWEEP_CLOSED_WINDOW_PAGES: '0'` for the eight days after the " +
+        'workflow stopped setting it, while the reader ran four times a day. Fix the page ' +
+        'against the workflow, not the other way round: the `env:` block and the header ' +
+        'divergence list are where this install records its wiring.',
+    ).toEqual([]);
+  });
+
+  it('quotes the closure floor the sweep step is actually given', () => {
+    const floor = withoutComments(readWorkflow(HALF_STATE_WORKFLOW)).match(
+      /^\s*PM_SWEEP_CLOSED_FLOOR:\s*'([^']+)'\s*$/m,
+    )?.[1];
+
+    expect(
+      floor,
+      '`PM_SWEEP_CLOSED_FLOOR` is no longer set to a quoted literal in ' +
+        `${HALF_STATE_WORKFLOW}. If the floor was removed, the closed-card reader now judges the ` +
+        'whole window and the section above is wrong in the other direction; if it merely moved ' +
+        'to an expression, this assertion needs to read it from wherever the value now lives.',
+    ).toBeDefined();
+
+    expect(named, 'the section must keep naming the floor variable').toContain('PM_SWEEP_CLOSED_FLOOR');
+
+    expect(
+      section,
+      `The workflow floors H22 at ${floor}, and the Half-State Patrol section does not say so. ` +
+        'The date is the whole of the divergence — it is what separates "the reader is off" from ' +
+        '"the reader judges everything closed since the convention started" — so a page that ' +
+        'names the variable without its value tells a reader nothing they can check.',
+    ).toContain(floor!);
+  });
+});


### PR DESCRIPTION
Fixes #8043

The Half-State Patrol section told readers the sweeper's closed-card reader was "switched **off** here via `PM_SWEEP_CLOSED_WINDOW_PAGES: '0'`". `.github/workflows/half-state-patrol.yml` stopped setting that variable on 2026-08-28. It survives only in the file's header comments, as history — so the page sent anyone looking for the switch to a variable nothing assigns, and, in the direction this page is actually read, described a predicate as disabled while it ran four times a day.

Head this was measured on: `8d17db858`.

## What the workflow actually sets

Re-derived on the merged head, comments excluded on the workflow side:

```
PM_SWEEP_REPO           .github/workflows/half-state-patrol.yml:272
PM_SWEEP_CLOSED_FLOOR   .github/workflows/half-state-patrol.yml:280   '2026-08-28'
```

`PM_SWEEP_CLOSED_WINDOW_PAGES` appears at `:39` and `:80` only, both whole-line comments. So: the closed-card reader is **on** with a dated floor, the page window is deliberately absent (back to `CLOSED_ISSUE_WINDOW_PAGES = 4`, the sweeper's own upstream default), and the floor — not a zeroed window — is what keeps the ~815 historical `pm:dispatched` carriers out.

## The rewrite

Sourced from the workflow's env-block comment (`:270-280`) and its header divergence (1) (`:37-39`), which are the two places this install records the wiring. Two paragraphs where there was one: what is set, and why a floor rather than a plain "on" (the 2026-08-24 measurement, the body-budget consequence, the no-backfill reasoning, the loud refusal of a malformed value).

Two neighbouring claims were re-checked against the code rather than carried over:

- **"Stripping `pm:*` on close was never this repo's practice"** — no longer true as written. It became the practice on the cutover date; that is what the floor is dated to. Rewritten to say so.
- **"The rendered summary says that surface is UNREAD, never that it is clean"** — true only while the escape hatch is set. `summaryLine` in `scripts/pm/check-half-states.mjs` branches on `closedWindowDisabled`; with the window unset it renders `H22 read N recently-closed issue(s) … only cards closed on/after 2026-08-28 are judged`. Kept, but re-conditioned onto the hatch, which is dormant live code rather than removed.

The retired identifier is deliberately **not** named in the section any more — a page that names a variable nothing sets is the defect, and the pin below enforces its absence.

`#7852` is the parent; it stays open for its half ①, the repository variable `HALF_STATE_ANCHOR_ISSUE`, which only a maintainer can set. Nothing here touches that half. The workflow itself is read, not written.

## The pin

`scripts/__tests__/ci-cd-pipeline-doc.test.ts`, a new `describe` block; no existing assertion changed. Every `PM_SWEEP_*` identifier the Half-State Patrol section names must be a key the workflow sets in an `env:` mapping.

The comparison reads **env keys**, never the file as text. That is the load-bearing part: a whole-file grep finds `PM_SWEEP_CLOSED_WINDOW_PAGES` in the header at `:39` / `:80` and accepts the exact sentence this pin exists to reject. `envKeysOf` strips whole-line comments and reads only children at `env:`'s indent + 2, so the continuation lines of a folded scalar (`PROVENANCE: >-` has three) cannot be mistaken for keys; it is unit-controlled against a specimen carrying both shapes.

Four legs: the two non-vacuity checks (the workflow-side set non-empty, the doc-side set non-empty — a rewrite that names nothing leaves the comparison green over an empty list); the extractor control; the set comparison; and a value leg requiring the section to quote the floor date the sweep step is given.

The `workflow inventory` block above it matches filenames in headings, so a false sentence *inside* a documented section is precisely what it cannot see — `#7852` says that in as many words. This closes that gap for the one thing on this page that names the sweeper's wiring by identifier.

## Ablation

Doc mutated on disk back to the wrong sentence, run, restored under a `trap`, blob compared both ways.

```
HEAD blob   = e2db116a866c53033c1f9d34de5ba81e060c8618
before blob = e2db116a866c53033c1f9d34de5ba81e060c8618   (tree at HEAD before mutating)
after blob  = cd01541b3ab4631ca101f9c83b8e9313a4dc1008   (changed -> not a no-op)

anchors  PM_SWEEP_CLOSED_FLOOR         1 -> 0
         PM_SWEEP_CLOSED_WINDOW_PAGES  0 -> 1

ABLATION-VITEST-EXIT=1     Tests  2 failed | 42 passed (44)
RESTORE-DIFF: 0 path(s) still differing        blob back to e2db116a8
```

Red exactly as predicted, naming the knob:

```
AssertionError: The Half-State Patrol section names these `PM_SWEEP_*` variables:
  - PM_SWEEP_CLOSED_WINDOW_PAGES

…and `half-state-patrol.yml` sets none of them. What it does set is:
  - PM_SWEEP_CLOSED_FLOOR
  - PM_SWEEP_REPO
```

The second failure is the value leg (`the section must keep naming the floor variable`). The mutation was committed-state-relative: the implementation was committed first, so the restore leg had a real restore point, and it is verified by blob equality rather than by an exit code.

## Gates

All on `8d17db858` unless noted.

| Gate | Verdict |
|---|---|
| `pnpm exec vitest run scripts/__tests__/ci-cd-pipeline-doc.test.ts` | `Tests 44 passed (44)` |
| `pnpm exec vitest run scripts/__tests__/` | `111 passed (111)` / `3331 passed (3331)` — see note |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm lint:root` | exit 0 |
| `pnpm check:doc-fences` | exit 0 |
| `pnpm check:doc-snippets` | `Scanned 227 document(s): 211 covered … Semantic phase: 549 of 549 block(s) judged, 0 failed.` |
| `node scripts/check-doc-links.mjs` | `Links are valid across 17 scan roots.` |
| `pnpm check:doc-example-readers` | exit 0 |
| `pnpm check:control-bytes` + manual `grep -naP` over both paths | exit 0; grep exit 1 (no matches) |
| `node scripts/check-changeset-presence.mjs` | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --test <both paths>` | `NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.` |
| `node scripts/check-doc-component-types.mjs` | `Every documented component type is registered.` |
| `node scripts/check-doc-expression-carriage.mjs` | exit 0 (report-only census) |
| `node scripts/check-shell-escape-residue.mjs` | exit 0 |
| `node scripts/check-upstream-port-parity.mjs` | `3 ported file(s) match … modulo their declared divergences.` |
| `pnpm exec vitest run packages/auth/src/__tests__/reserved-auth-features.test.ts` | `17 passed (17)` — the one reader of this page outside `scripts/__tests__` |

`check:doc-snippets` first answered `PRECONDITION NOT MET (exit 2)` — not a red, and not a reading about any document. Ran its own scoped build (`--build-filter`, 34 tasks) and re-ran; the green above is the measured one.

**One flake, recorded rather than papered over.** On the first `scripts/__tests__/` run after merging `origin/main`, two corpus tests in `check-doc-links.test.ts` timed out at 15000ms (`1 failed | 110 passed`). Same tree content for those files had passed the same command minutes earlier (`111 passed`), and the file alone re-runs green in 12.5s for all 121 tests. The variable is container load, not this diff — the run that failed took 188s against 118s for the green one. `node scripts/check-doc-links.mjs`, the gate itself, is green on the merged head.

No changeset: docs plus a `scripts/__tests__` file, and the presence script agrees. `skip-changeset` is a phantom label in this repository (this same test file pins that at `:235` / `:277`); no label was applied.

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990) and is not this branch's.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_