### PR TITLE
docs(layout): compile every README snippet and leave the UNGATED_DOCS ledger

### DIFF
--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -199,9 +199,21 @@ composed in JSX rather than authored as a JSON node. Full guide:
 The layout components are designed to work seamlessly with React Router:
 
 ```typescript
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import type { ComponentType, ReactNode } from 'react';
 import { AppShell, SidebarNav } from '@object-ui/layout';
 import { Home, Users } from 'lucide-react';
+
+// `react-router-dom` is a PEER dependency (see Installation above): your app
+// installs it, this package does not. These three stand in for what you would
+// import from it, so the composition below is still checked against the shipped
+// `@object-ui/layout` types.
+declare const BrowserRouter: ComponentType<{ children?: ReactNode }>;
+declare const Routes: ComponentType<{ children?: ReactNode }>;
+declare const Route: ComponentType<{ path: string; element: ReactNode }>;
+
+// Your own page components, one per route.
+declare const Dashboard: ComponentType;
+declare const UsersPage: ComponentType;
 
 function App() {
   return (
@@ -219,13 +231,19 @@ function App() {
       >
         <Routes>
           <Route path="/" element={<Dashboard />} />
-          <Route path="/users" element={<Users />} />
+          <Route path="/users" element={<UsersPage />} />
         </Routes>
       </AppShell>
     </BrowserRouter>
   );
 }
 ```
+
+A route's `element` takes **your page component**, never the `lucide-react` icon
+of the same name. This example used to route `/users` to `Users` — the icon it
+imports for the sidebar — so the page rendered a 24-pixel glyph where its content
+belonged. Nothing catches that for you: an icon is a valid component, so the
+route type-checks either way, which is why the two are named apart here.
 
 ## Customization
 
@@ -235,6 +253,8 @@ per-slot `headerClassName` / `sidebarClassName` — the navbar and the sidebar a
 nodes **you** build, so style them where you build them:
 
 ```typescript
+import { AppShell } from '@object-ui/layout';
+
 <AppShell
   className="bg-gray-50"
   navbar={<div className="border-b px-4">My App</div>}

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -717,8 +717,6 @@ const UNGATED_DOCS = {
     'self-contained or declared, plus a way to declare a block whose rejection IS the point.',
   'packages/fields/README.md':
     '2 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 1 unresolved-module diagnostic(s)',
-  'packages/layout/README.md':
-    '3 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; 3 unresolved-module diagnostic(s)',
   'packages/plugin-ai/README.md':
     '5 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2322x3 — candidate real defects, un-triaged',
   'packages/plugin-charts/README.md':


### PR DESCRIPTION
Part of #5174 — batch 22 of the `UNGATED_DOCS` burn-down.

`packages/layout/README.md` leaves the ledger and all 7 of its ts/tsx blocks now
compile against the built types. The gate file's only change is the two lines of
that one entry.

## Notation, read this first

This repository has measured that GitHub's body sanitizer deletes tag-shaped
fragments even inside backticks and fenced blocks. So JSX elements and generic
parameters are spelled out in words below — "an AppShell element", "a
ComponentType of props with an optional className" — rather than in their real
angle-bracket form. The README itself carries the real spellings; this page does
not.

## Concurrency

`main` moved under this batch **twice**, and both moves were absorbed the way the
brief requires.

1. **PR #8038 (batch 21, `packages/types/README.md`) merged at 12:50:27Z**,
   taking `origin/main` from `ed4a2f17c` to `58cd01a38`. This branch had no
   commits of its own at that moment, so it was **fast-forwarded** rather than
   carrying a merge commit. The census was taken on both bases and is
   byte-identical across them, as is the pick.
2. **#8046, #8042 and #8039 merged**, taking `origin/main` to `a8f4bd75f`. By
   then this branch had its implementation commit, so `origin/main` was
   **merged** (never rebased, never force-pushed). That range touches neither of
   this branch's two paths, but it does move `packages/plugin-view/src/ObjectView.tsx`
   — package source, so the built types the corpus is judged against move with it.
   The forced build, every gate, every test and the lint readings were therefore
   all re-run on the merged head `85ebbcbe9`.

All 11 open pull requests' file lists were read over the REST files endpoint and
each count reconciled against that PR's own `changed_files`: 8049/3, 8048/3,
8046/2, 8042/2, 8039/3, 7749/4, 7685/67, 7058/24, 7054/2, 7053/2, 5400/1058.
#5400's 1058-file list was paged to exhaustion (11 pages) because the endpoint
pages at 100 and a truncated list renders as a confident absence. **No open PR
touches `packages/layout/README.md` or the gate file.** The only README any open
PR touches at all is `packages/auth/README.md` (PR #7685), which is excluded
anyway.

Two neighbours worth naming, neither an exclusion:

- **PR #7058** (Dependabot, lucide-react 1.31.0 to 1.40.0) edits
  `packages/layout/package.json`. This README imports `Home`, `Users`,
  `Settings` and `FolderOpen` from `lucide-react` and is now compiled against
  it, so that bump is the one open change that could move the types these
  snippets are checked against.
- **PR #7685** edits `packages/types/src/field-types.ts`, upstream of everything.

`Live E2E (informational)` is red on every branch today for an upstream reason
(objectui#7990 / objectstack#16186), not because of this diff.

## Ledger arithmetic

| reading | base `a8f4bd75f` | branch `85ebbcbe9` |
|:--|--:|--:|
| `UNGATED_DOCS` entries | 16 | **15** |
| covered documents | 211 | 212 |
| …of them holding a ts/tsx block | 109 | 110 |
| covered blocks | 707 | 714 |
| blocks to compile | 549 | 556 |
| declared fragments | 158 | **158** (zero new) |
| semantic failures | 0 | 0 |
| self-imports judged (`check:readme-exports`) | 489 | 490 |

Both rows were MEASURED, not computed. The base row is a real
`pnpm check:doc-snippets` run (probe M0) with both changed files checked out at
base bytes — on-disk hashes proven equal to the base blobs `f497d997…` and
`9beae7db…` — and restored afterwards under a trap. The base
`check:readme-exports` row is its own run against base README bytes (probe M0b).

Programmatic diff of the two `UNGATED_DOCS` objects — both imported as OBJECTS,
never diffed as text: removed = `['packages/layout/README.md']`, added = `[]`,
reason-changed = `[]`, key order preserved for survivors = true.
`git diff --numstat` on the gate file is exactly `0 2`. On the branch: layout
entries **0**, `packages/NAME/README.md` entries **14** (from 15), control
`'packages/auth/README.md'` **1**.

The strictness region — the `Fence scanning` banner line to EOF, 1178 lines on
both sides — hashes to
`f46b5662ba336f026bca3a0003e0b7979789d48d0291fa5760be7d23c8ed0160` on
`origin/main` and on the branch. Re-measured here on both bases, not inherited;
it is the value batches 15 through 21 recorded.

## Census and the rung that decided

Re-taken through the gate's exported `analyze()` / `compileSnippets()` over every
non-excluded ledger candidate — once on `ed4a2f17c` (17 entries, 13 candidates
after exclusions) and again on `58cd01a38` after batch 21 landed (16 entries, 13
candidates). **Both runs give the same table and the same pick.**

**Rung 1 (larger measured debt: blocks, then diagnostics) DECIDES OUTRIGHT:
layout is alone at 7 blocks; every other candidate holds 5 or fewer. Rungs 2 and
3 were never reached.**

| document | blocks | diagnostics | distinct codes | codes |
|:--|--:|--:|--:|:--|
| **packages/layout/README.md** | **7** | **2** | **1** | TS2304x2 (+1 bound refusal) |
| packages/react-runtime/README.md | 5 | 27 | 7 | TS2304x13 TS18004x6 TS2300x4 TS2552x1 TS2686x1 TS2813x1 TS2814x1 |
| packages/plugin-list/README.md | 5 | 8 | 3 | TS7006x4 TS2304x3 TS2657x1 |
| packages/core/README.md | 5 | 6 | 2 | TS2304x5 TS2339x1 |
| packages/plugin-kanban/README.md | 5 | 6 | 2 | TS1109x5 TS1011x1 |
| packages/plugin-ai/README.md | 4 | 8 | 3 | TS2304x4 TS2322x3 TS2552x1 |
| packages/providers/README.md | 4 | 8 | 2 | TS2304x7 TS2741x1 |
| packages/plugin-charts/README.md | 4 | 6 | 1 | TS1109x6 |
| packages/plugin-editor/README.md | 4 | 6 | 1 | TS1109x6 |
| packages/plugin-map/README.md | 4 | 2 | 2 | TS1005x1 TS2304x1 |
| packages/plugin-markdown/README.md | 4 | 2 | 2 | TS1005x1 TS1109x1 |
| packages/fields/README.md | 2 | 3 | 2 | TS7031x2 TS2307x1 |
| packages/plugin-tree/README.md | 1 | 3 | 2 | TS1005x2 TS1109x1 |

Assumption **A1 is CONFIRMED** — every block and diagnostic total matches batch
21's census exactly, including the two per-code figures batch 21 reported as
moving with the compiler program's shape (react-runtime 7 distinct codes,
plugin-ai 3). Neither column is read by rung 1, which decided outright.

Exclusions re-verified against GitHub on this base, not inherited: the root
`README.md` is not a `packages/NAME/README.md`; `packages/types/README.md` was
batch 21's and has now MERGED, so it is out of the ledger entirely rather than
merely reserved; `packages/auth/README.md` is held by open draft PR #7685;
`packages/plugin-chatbot/README.md` is deferred by the earlier ruling.

**The ledger's reason string for this page was STALE, as the dispatch warned.**
It claimed "3 undefined-name diagnostic(s) … 3 unresolved-module diagnostic(s)".
The measurement reads 2 undefined-name diagnostics and **one** refused specifier,
not three. That continues the streak batch 21 briefly broke.

## The debt, and what each repair did

Seven blocks: three were already clean, two more needed nothing, and the debt sat
in two.

**1. The "Usage with React Router" block was REFUSED, not judged.** It imports
`react-router-dom`, and the gate's root bound turned it away:

```
[bound]  packages/layout/README.md:201  imports 'react-router-dom', which resolve only
through this repository's ROOT package.json — this workspace's own devDependency set,
not anything a reader of the documented packages installs.
```

Ruling 4 asks whether that is a real dependency gap or a peer the reader
supplies. **It is a peer, and the manifest says so outright:**
`packages/layout/package.json` declares `react-router-dom` under
`peerDependencies` at `^6.0.0 || ^7.0.0`, matching the README's own Installation
section, and does not list it under `dependencies`. The gate maps third-party
specifiers from `dependencies` only — its header says so deliberately — so a peer
is unmapped, the repository root declares it as a devDependency, and the bound
refuses it. **No dependency gap, so no two-shipped-surfaces finding under ruling
5, and no manifest was touched.**

The repair takes the gate's own first-listed remedy — import only what the
package declares — by standing the three router components in with `declare
const` bindings typed to what the block uses them as. The block now imports
`react`, `@object-ui/layout` and `lucide-react`, all of which layout really
declares, so **the AppShell and SidebarNav composition is genuinely
type-checked** instead of being surrendered to a fragment marker. That mattered:
probe P7 shows a wrong `NavItem` key in that block now reds the gate, and a wrong
`NavItem` key is exactly the defect objectui#3999 recorded on this page.

**That refusal was masking a real diagnostic.** A refused block never reaches the
semantic phase, and behind it `Dashboard` was never defined anywhere in the
snippet — a TS2304 that appears the moment the bound is lifted (probe P3).

**2. The same block routed to the icon, and no gate could ever have caught it.**
It imported `Users` from `lucide-react` for the sidebar and then used that same
name as the `element` of the `/users` route, so a reader copying the block
rendered a 24-pixel glyph where the page content belonged. A Lucide icon is a
valid component, so the route type-checks either way — **probe P4 puts the icon
back and the gate stays GREEN**. The route element is now a separately named page
component, and a short prose paragraph says why the two are named apart, because
nothing mechanical will say it for the next author.

**3. The "Customization" block used AppShell with no import**, TS2304 twice. It
now self-imports it, which is also why this diff hands `check:readme-exports` one
more self-import to judge (489 to 490) rather than fewer.

No `packages/**` source touched, no public type widened, no lenient alias added,
no gate loosened, and **no new fragment marker: declared fragments stay at 158.**

## Probes — one base measurement and eight probes, each predicted in writing first

Predictions were written to the scratchpad as `5174-b22-PREDICTIONS.md`
(md5 `7a6dbf1800914b511f9f848fc52d46dd`) at implementation commit `82b1c989d`
with a clean tree, **before any probe ran**, and were not amended. Every mutation
is proven on disk by occurrence counts of both the injected and the deleted text
plus `git hash-object` against the HEAD blob; every restore is proven by an empty
`git diff HEAD`; every leg runs under a `trap ... EXIT INT TERM` with absolute
paths, restoring with `git checkout HEAD --` against an absolute path rather than
a bare checkout from the index. Nothing here is read through a package `dist/`:
both mutated paths are read from disk by the gate itself, so no rebuild sits
between a mutation and its reading.

| probe | mutation | predicted | observed |
|:--|:--|:--|:--|
| **M0** | both files at base bytes | exit 0, 211 covered / 16 ungated / 549 to compile, bound empty | exactly that |
| **P1** | ledger entry restored ALONE | exit 0, coverage falls back to 211 / 16 / 549; gate file byte-identical to base | exactly that (`9beae7db…` both sides) |
| **P2** | README restored ALONE | exit 1; bound refuses react-router-dom at :201 plus TS2304 twice for AppShell | exactly that; 555 of 556 judged |
| **P3** | delete the Dashboard declaration | exit 1, TS2304 Cannot find name 'Dashboard' | exactly that, at :232 |
| **P4** | put the lucide icon back in the route | **GREEN, no diagnostic** | exactly that — 556 of 556, 0 failed, 0 lines naming this page |
| **P5** | delete the Customization self-import | exit 1, TS2304 twice for AppShell | exactly that, at :256 and :262 |
| **P6** | fabricate a self-import name | readme-exports 0 to 1 fabricated | 490 real / 0 fabricated to 489 real / **1 fabricated** naming :256 |
| **P7** | wrong NavItem key inside the ROUTER block | exit 1, TS2739 / TS2322 / TS2353 family | **TS2322**, "Property 'title' is missing … but required in type 'NavItem'" |
| **P8** | restore the react-router-dom import | exit 1 and the Root bound line names it again | exactly that; 555 of 556 judged |

**All nine legs ran in the predicted direction.** P4 is the one whose prediction
was that the probe would NOT go red, and that is the point of it: it is what
makes the icon-in-route repair a documentation fix rather than a type fix, and
what justifies spending prose on it.

## Gates — all at `85ebbcbe9`, clean tree, nothing pushed after

Exit codes captured by redirect-then-capture, before any pipe; each row quotes
the gate's own verdict line. The build was forced first
(`turbo run build --filter=./packages/* --concurrency=2 --force`, 39 successful /
0 cached) and again inside the provenance gate (43 successful / 0 cached); every
dist-sensitive gate was then re-run on the force-built dist, as the gate
prescribes. Note the invocation: bare `turbo` is not on PATH in this container,
so `pnpm exec turbo` is what ran.

- `pnpm check:doc-snippets` exit 0 — "Scanned 227 document(s): 212 covered (110 of them hold a ts/tsx block), 15 ungated" / "Covered blocks: 714 — 556 to compile, 158 declared fragment(s)" / "Root bound: no block imports a specifier that resolves only through this repository's ROOT manifest" / "Semantic phase: 556 of 556 block(s) judged, 0 failed" / "Every covered documentation snippet compiles against the built types."
- `pnpm check:doc-fences` exit 0 — "every TypeScript block in 227 document(s) is fenced ts/tsx/typescript"
- `pnpm check:readme-exports` exit 0 — "490 of them self-imports judged (490 real, 0 wrong-path, 0 fabricated)"
- `pnpm check:doc-types` exit 0 — "Every documented component type is registered."
- `node scripts/check-doc-links.mjs` exit 0 — "Links are valid across 17 scan roots."
- `pnpm check:doc-example-readers` exit 0 — "OK 80 documented symbol(s), 3947 call site(s)"
- `pnpm check:control-bytes` exit 0 — "OK (scanned 6463 tracked text file(s); skipped 85 binary)"
- `node scripts/check-node-esm-load.mjs --force-build` exit 0 — "Provenance leg: 37 of 37 gradable entries were built by this tree." **Green on its first run**, so no gate had to be re-run over a replayed sibling cache. Its three ERR_UNKNOWN_FILE_EXTENSION lines are the gate's own by-design entries.
- `pnpm type-check:scripts` exit 0
- `node scripts/check-changeset-presence.mjs` exit 0 — "2 file(s) changed, 0 of them published source of a package the release covers … no changeset is owed." No `skip-changeset` label applied: this repository declares with an empty-frontmatter changeset rather than that label, and the presence gate says none is owed, so nothing was labelled at all by this seat.
- `node scripts/check-governed-queue-guard.mjs --test` on both paths exit 0 — "NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched"
- Owning package: `pnpm exec vitest run packages/layout/` — "Test Files 19 passed (19) / Tests 202 passed (202)"; `pnpm --filter @object-ui/layout type-check` exit 0, its output echoing `tsc --noEmit && tsc -p tsconfig.test.json`, so the test tsconfig is genuinely included.
- Beyond the gate, a manual control-byte scan of both changed paths with `grep -naP` over the C0/DEL ranges found nothing (exit 1, zero output bytes).

**Lint, with the narrowing declared and its three evidence items.** `pnpm lint`
here is `turbo run lint` per package, so the repository-wide sweep is CI's run;
the narrowed run over exactly this diff is
`pnpm exec eslint --no-inline-config --format json` on both paths — 2 entries, **0
errors**. eslint's own answer for the README is "File ignored because no matching
configuration was supplied", so the real lint surface of this diff is the one
`.mjs` at 0 errors and 0 warnings. (1) The population eslint would otherwise judge
is **4361 files** by its own count. (2) That run exits 1 with **93 errors and
12170 warnings**, all of them in files this diff does not touch — measured, and
reported rather than smoothed, because a reader must not mistake the narrowing
for a green repository. (3) `eslint.config.js` declares no `project`,
`projectService` or `parserOptions.project` (grep count 0), so type-aware linting
is off and this diff cannot move the verdict on any untouched file.

## Readers of the changed paths

Derived with `git grep -l` on both paths, not guessed — **22 test files, 642
tests, all green** in one run. This page is far more heavily pinned than batch
21's was:

- `scripts/check-doc-snippet-types.mjs` — the gate itself, which now COMPILES this page instead of excusing it (P1 proves the entry was what suppressed it).
- **Six live pins under `packages/layout/src/__tests__/`** read this README directly: `readme-app-shell-example`, `readme-sidebar-nav-example`, `readme-registration-keys`, `app-shell-docs-nav-example`, `guide-layout-app-shell-doc`, `guide-layout-sidebar-nav-doc`. Two of them assert doc parity — that an example appears in the README as a contiguous run of lines — and one re-reads every fence mentioning SidebarNav and rejects the string-icon spelling. **A3 is CONFIRMED and then some:** batch 21's page had exactly one reader; this one has seven.
- `scripts/__tests__/doc-version-claims.test.ts` — names this README path; green.
- `scripts/check-readme-exports.mjs` — reads this README's self-imports; proven live by P6. This diff ADDS one, so it hands that gate more to check than it had.
- Readers of the GATE file additionally exercised: `check-doc-snippet-types.test.ts` and six sibling gate suites, plus the six package and example suites that name it.

## Out of scope, filed rather than repaired here

**objectui#8059**, unassigned, labelled `finding` only (domain triage is not this
seat's to assign). The gate's root bound refuses a package's own declared **peer**
— measured: four packages (`app-shell`, `layout`, `plugin-designer`,
`plugin-detail`) declare `react-router-dom` as a peer and none as a dependency —
and the refusal message names two remedies, neither of which fits a package whose
headline feature IS that peer integration. This batch used a third shape that the
message and the header do not name. **That rule is deliberate and documented, so
the card asks only for the remedy text**, and changing it would mean editing the
gate's strictness region, which this batch's licence pins byte-identical. The
other three READMEs are covered and green today, so the wall is latent, not
active — but the burn-down will walk into it again.

This PR is a DRAFT and stays a draft: this seat does not flip ready, does not
enable auto-merge, and touches no labels or assignee.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_