### PR TITLE
docs(types,api): name the component node `BaseSchema` and pin the vocabulary

### DIFF
--- a/content/docs/api/schema-reference.md
+++ b/content/docs/api/schema-reference.md
@@ -17,6 +17,20 @@ This reference documents every ObjectUI schema type with annotated JSON examples
 
 ## Base Schema
 
+**"A component node" is named `BaseSchema`.** That is the object half a renderer
+receives: it carries the required `type` — the registry key that selects the renderer —
+plus the shared keys tabled below, and every schema type in this reference extends it.
+Use `BaseSchema` for any position that holds a node object: a slot's declared type, a
+prop, a type annotation in an example.
+
+Reach for `SchemaNode` only where the wider union is genuinely correct. `SchemaNode` is
+`BaseSchema` **plus** the primitive members that render as text, so it is the right word
+for a slot that also accepts a bare string (`body`, `children`) and the wrong word for a
+position that must be an object: a renderer that narrows a slot with
+`typeof node === 'object'` before reading its keys drops those primitive members on the
+floor. Naming the union where only the object half is accepted is the mismatch
+objectui#7082 had to correct nine times.
+
 ### SchemaNode
 
 The foundational building block of ObjectUI. Every component in the system is described by a `SchemaNode`. It can be a full schema object, or a primitive value rendered as text.

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -31,9 +31,9 @@ Object UI follows a strict **"Protocol First"** approach with a clear inheritanc
 ```
 @objectstack/spec (v15.x)           ← The "Highest Law" - Universal protocol
     ↓
-UIComponent                         ← Base interface for all UI components
-    ↓
-BaseSchema (@object-ui/types)       ← ObjectUI extensions (visibleOn, hiddenOn, etc.)
+BaseSchema (@object-ui/types)       ← A component node: the base interface every
+                                      UI component schema extends, carrying `type`
+                                      plus the shared keys (visibleOn, hiddenOn, etc.)
     ↓
 Specific Schemas                    ← Component implementations (ChartSchema, etc.)
     ↓

--- a/scripts/__tests__/component-node-vocabulary-7434.test.ts
+++ b/scripts/__tests__/component-node-vocabulary-7434.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The documented name for "a component node" is `BaseSchema` (objectui#7434,
+ * maintainer ruling 2026-09-06, option 1).
+ *
+ * ## What this pin is for
+ *
+ * objectui#7082 corrected nine rows where authored docs called the generic
+ * protocol node `ComponentSchema` -- a name that never meant the generic
+ * concept. It was the block family's narrow `type: 'component'` kind, and
+ * objectui#4895 retired that family outright. The rows regrew, because
+ * #7082 fixed SITES while the vocabulary gap stayed open: an author naming
+ * "a component node" had three candidates and no ruling.
+ *
+ * That recurrence is the whole argument for a pin rather than another sweep.
+ * The sharpest instance: the reference in `scripts/check-doc-snippet-types.mjs`
+ * was that gate's own POSITIVE CONTROL, so retiring the family made the gate
+ * exit 2 with "HARNESS CONTROL FAILED -- no verdict about the documents can be
+ * read from this run". A vocabulary gap took out a gate's control group; the
+ * run reported nothing about any document at all.
+ *
+ * The two banned spellings, and why each is banned:
+ *
+ * - `UIComponent` -- what AGENTS.md's topology table calls the shape, but it
+ *   is NOT EXPORTED by `@object-ui/types` (0 files under `packages/types/src`,
+ *   against 101 for `BaseSchema`, so that zero is a real zero and not a dead
+ *   grep). A doc teaching it teaches an identifier no reader can import or
+ *   type-check. Option 2 of the ruling -- minting the export -- was declined:
+ *   a public-surface widening for a word.
+ * - `ComponentSchema` in the GENERIC sense -- retired with the block family.
+ *
+ * ## The distinction this pin must not flatten
+ *
+ * `SchemaNode` is NOT interchangeable with `BaseSchema` and this pin does not
+ * push anyone toward it. `SchemaNode` is
+ * `BaseSchema | string | number | boolean | null | undefined`
+ * (`packages/types/src/base.ts:483`); `BaseSchema` is exactly the OBJECT half.
+ * Renderers that narrow a slot before reading keys -- e.g.
+ * `packages/components/src/renderers/feedback/empty.tsx:37`,
+ * `actionSchema && typeof actionSchema === 'object'` -- drop the primitive
+ * members on the floor, so the union is wrong for a node-slot position.
+ * Where the union IS genuinely correct (`content/docs/guide/layout.md`),
+ * `SchemaNode` stays. Neither name is asserted absent here: only the two
+ * spellings that name nothing real are.
+ *
+ * ## Why the boundary is `\b` and not a substring test
+ *
+ * Seven legitimate compound symbols live on this surface --
+ * `AppComponentSchema`, `DashboardComponentSchema`, `MyComponentSchema`,
+ * `PageComponentSchema`, `ReportComponentSchema`, `ThemeComponentSchema`,
+ * `AnyComponentSchema`. Each is a real, distinct type; a substring scan would
+ * flag all seven and the natural repair would be to weaken the scan until it
+ * missed the thing it exists to catch. A leading `\b` excludes them
+ * structurally: in `AppComponentSchema` there is no word boundary before `C`.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * The scan surface: the authored teaching surfaces where an author looks up
+ * the name of a concept.
+ *
+ * ⛔ Deliberately EXCLUDED, and the exclusions are load-bearing:
+ * - `docs/audits/**` and the repo-root `docs/**` -- historical audit records,
+ *   not teaching surfaces, and out of every doc gate's scan surface today
+ *   (objectui#7856). `docs/audits/2026-08-zod-to-json-schema-fidelity.md`
+ *   carries a verbatim historical symbol list that legitimately contains
+ *   `ComponentSchema`; that list is a record of what the repo once exported,
+ *   and rewriting history to satisfy a vocabulary pin would be a lie.
+ * - `AGENTS.md` -- governed surface, repaired in this card's PR B by the
+ *   `domain:skills` seat. Adding it here would red this pin on `main` until
+ *   that separate, human-merged PR lands.
+ */
+const DOCS_ROOT = 'content/docs';
+const DOC_EXTENSIONS = ['.md', '.mdx'];
+
+/**
+ * Reasoned exemptions, by repo-relative path, each with the sentence that
+ * earns it. EMPTY TODAY and that is the honest state: the surface has no
+ * legitimate use of either banned spelling.
+ *
+ * ⛔ If a real one appears -- a tombstone sentence naming the retired symbol,
+ * say -- add it HERE with its reason. ⛔ Never widen the regex: the regex is
+ * the thing that works, and an entry with a reason stays reviewable while a
+ * loosened pattern silently stops catching the class.
+ */
+const ALLOWED: Record<string, string> = {};
+
+/** Every `.md` / `.mdx` under `content/docs`, plus each `packages/<name>/README.md`. */
+function scanSurface(): string[] {
+  const out: string[] = [];
+
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(path.join(repoRoot, dir), { withFileTypes: true })) {
+      const rel = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) walk(rel);
+      else if (DOC_EXTENSIONS.some((ext) => entry.name.endsWith(ext))) out.push(rel);
+    }
+  };
+  walk(DOCS_ROOT);
+
+  for (const entry of fs.readdirSync(path.join(repoRoot, 'packages'), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const rel = `packages/${entry.name}/README.md`;
+    if (fs.existsSync(path.join(repoRoot, rel))) out.push(rel);
+  }
+
+  return out.filter((rel) => !(rel in ALLOWED)).sort();
+}
+
+const BANNED: Array<{ name: string; pattern: RegExp; why: string }> = [
+  {
+    name: 'UIComponent',
+    pattern: /\bUIComponent\b/g,
+    why: 'not exported by @object-ui/types -- a reader cannot import or type-check it',
+  },
+  {
+    name: 'ComponentSchema (generic sense)',
+    pattern: /\bComponentSchema\b/g,
+    why: 'the retired block-family kind (objectui#4895), never the generic node',
+  },
+];
+
+describe('the documented name for "a component node" is `BaseSchema` (objectui#7434)', () => {
+  const surface = scanSurface();
+  const read = (rel: string) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+  /**
+   * ⭐ The live control, and it runs FIRST. Every assertion below is an
+   * ABSENCE, and an absence is unreadable from a scan that reached nothing:
+   * a walk that silently returned [] -- a moved directory, a renamed
+   * extension -- renders as a clean green sweep, indistinguishable from a
+   * surface that is genuinely clean. So the surface must be populated AND a
+   * word that must hit has to actually hit.
+   */
+  it('control: the surface is populated and a must-hit word fires on it', () => {
+    expect(surface.length).toBeGreaterThan(50);
+    expect(surface).toContain('packages/types/README.md');
+    expect(surface).toContain('content/docs/api/schema-reference.md');
+
+    const withBaseSchema = surface.filter((rel) => /\bBaseSchema\b/.test(read(rel)));
+    expect(withBaseSchema.length).toBeGreaterThan(0);
+
+    // The page that carries the definitional statement must be one of them.
+    expect(withBaseSchema).toContain('content/docs/api/schema-reference.md');
+  });
+
+  it.each(BANNED)('no `$name` survives on the authored surface', ({ pattern, why }) => {
+    const hits: string[] = [];
+
+    for (const rel of surface) {
+      const lines = read(rel).split('\n');
+      lines.forEach((line, i) => {
+        if (new RegExp(pattern.source).test(line)) hits.push(`${rel}:${i + 1}: ${line.trim()}`);
+      });
+    }
+
+    expect(hits, `${why}. Use \`BaseSchema\`. Offending lines:\n${hits.join('\n')}`).toEqual([]);
+  });
+
+  /**
+   * Counter-probe: the matcher above can still fail. Without this, a regex
+   * broken into never matching (or a `\b` that swallowed the class) would
+   * report the same green as a clean surface.
+   */
+  it('counter-probe: the matcher fires on the residue it was built to catch, and spares the compounds', () => {
+    const residue = 'UIComponent                         <- Base interface for all UI components';
+    expect(/\bUIComponent\b/.test(residue)).toBe(true);
+    expect(/\bComponentSchema\b/.test('type: ComponentSchema')).toBe(true);
+
+    // The seven real compound symbols must NOT be caught.
+    for (const compound of [
+      'AppComponentSchema',
+      'DashboardComponentSchema',
+      'MyComponentSchema',
+      'PageComponentSchema',
+      'ReportComponentSchema',
+      'ThemeComponentSchema',
+      'AnyComponentSchema',
+    ]) {
+      expect(/\bComponentSchema\b/.test(compound)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Part of #7434 — PR A only, the `domain:devx` half.

Maintainer ruling (comment 5556352576, option 1): the concept "a component node — the object half a renderer receives" is named `BaseSchema`. This PR writes that name where docs authors look, repairs the one surviving residue, and pins the vocabulary so the gap cannot regrow.

## Three changes

**1. `packages/types/README.md` — the residue.** The inheritance chain carried a `UIComponent` rung above `BaseSchema`. Two things are wrong with it, and only the first was on the card: `UIComponent` is not exported by `@object-ui/types` (0 files under `packages/types/src`, against 101 for `BaseSchema`, so that zero is a real zero and not a dead grep), and `BaseSchema` extends nothing — it is the standalone base. The rung was therefore a phantom sitting directly above a row that already described the same interface. The repair collapses the two rows into one true row, rather than renaming the phantom, which would have produced two `BaseSchema` rungs.

That line sits inside an untagged ASCII-diagram fence, so it is not compiled. The page's `typescript` blocks are untouched, and the page is in `check:doc-snippets`' **covered** set (not among the 16 ungated — verified against the gate's own exported `UNGATED_DOCS`, 16 keys matching its printed count).

**2. `content/docs/api/schema-reference.md` — the definitional statement.** One page, no sweep, no new page. This page already owns the concept: its `## Base Schema` section defines `SchemaNode` and `BaseSchema` in adjacent subsections. The statement goes at the top of that section, so the "which word when" answer sits directly above both definitions. It adds no fenced block, so it adds no compile surface.

**3. `scripts/__tests__/component-node-vocabulary-7434.test.ts` — the pin.** Zero `UIComponent` and zero generic-sense `ComponentSchema` across `content/docs/**` (`.md` + `.mdx`) and `packages/*/README.md`, with a live control and a counter-probe. Relative imports only.

## The distinction is kept, not flattened

`BaseSchema` for node-slot positions; `SchemaNode` only where the wider union is genuinely correct. `content/docs/guide/layout.md` is untouched. The pin asserts the absence of the two spellings that name nothing real — it says nothing about `SchemaNode`, so it cannot push a future author toward flattening the two.

Verified rather than copied from the card: `SchemaNode` is `BaseSchema | string | number | boolean | null | undefined` at `packages/types/src/base.ts:483`, and the narrowing guard the card cites is real at `packages/components/src/renderers/feedback/empty.tsx:37` (`actionSchema && typeof actionSchema === 'object'`). The statement describes that mechanism without over-claiming it as a universal renderer guard, which it is not — the only other `typeof ... === 'object'` in `SchemaRenderer.tsx` guards `boundRecord`, a different thing.

## Why the pin uses a word boundary rather than a substring test

Seven legitimate compound symbols live on the scan surface: `AppComponentSchema`, `DashboardComponentSchema`, `MyComponentSchema`, `PageComponentSchema`, `ReportComponentSchema`, `ThemeComponentSchema`, `AnyComponentSchema`. A substring scan would flag all seven, and the natural repair would be to weaken the scan until it no longer caught the class it exists for. A leading word boundary excludes them structurally. The allow-list exists and is **empty**, with the rule written into it: add an entry with its reason, never widen the regex.

## Ablation — the must-fail leg

The implementation was committed first, so the restore leg had a real commit to return to.

- before: `UIComponent` count 0, blob `d1ba9bc39`
- mutation re-inserted the `:34` residue: `UIComponent` count 1, blob `d2745532c` — a different hash, so the mutation provably reached disk
- pin under mutation: **exit 1**, naming `packages/types/README.md:34` and quoting the residue line back
- `1 failed | 3 passed` — the control and the counter-probe stayed green, so the red is the banned-spelling assertion specifically, not a broken harness
- restored under a `trap` using absolute paths: blob back to `d1ba9bc39`, `git diff HEAD` empty

## What this PR deliberately leaves alone

`AGENTS.md` lines 73, 82 and 124 still teach `UIComponent`. They are left for **PR B**, the `domain:skills` half, per triage 5556499148's two-PR prescription. The reason is mechanical rather than preference: `AGENTS.md` is a governed surface, and a single governed path turns an entire PR governed (draft plus human merge). Carrying those three lines here would send an ordinary documentation change to the manual-merge queue. That half stays open and is out of scope here.

The pin's scan surface excludes `AGENTS.md` for the same reason — including it would red this pin on `main` until that separate PR lands. `docs/audits/**` and repo-root `docs/**` are excluded too: historical audit records rather than teaching surfaces, and one of them legitimately carries `ComponentSchema` inside a verbatim symbol list of what the repo once exported.

## Gates — all on merged head `5032f3cd6`

`main` moved 3 commits under this branch (`a8f4bd75f` to `bfa4fe728`, disjoint files); merged, rebuilt forced, and every reading below is from the merged head.

| gate | exit |
|---|---|
| `turbo run build --filter=./packages/* --force` | 0 — 39/39 |
| `check:doc-snippets` | 0 |
| `check:doc-fences` | 0 |
| `check:readme-exports` | 0 |
| `check:doc-types` | 0 |
| `check:doc-example-readers` | 0 |
| `check:control-bytes` | 0 |
| `check-doc-links.mjs` | 0 |
| `type-check:scripts` | 0 |
| `lint:root` | 0 errors (32 pre-existing warnings, none in changed files) |
| `vitest run scripts/__tests__/` | 0 — 112 files, 3331 tests |
| `check-changeset-presence.mjs` | 0 — none owed |
| `check-governed-queue-guard.mjs --test` | 0 — NOT GOVERNED |

`check:doc-snippets` judgment line, quoted:

```
Scanned 227 document(s): 211 covered (109 of them hold a ts/tsx block), 16 ungated — declared in this script, NOT verified by it.
Semantic phase: 549 of 549 block(s) judged, 0 failed.
```

The new pin was confirmed collected by name (JSON reporter), not inferred from a green total: 4 assertions, all passing.

No changeset is owed — `check-changeset-presence.mjs` decided it against merge-base `bfa4fe728`: 3 files changed, 0 published source, 0 moved manifest contracts.

Manual control-byte scan of all three changed paths: clean.

`Live E2E (informational)` is red on every branch today for an upstream reason (#7990, objectstack#16186) and is not from this change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Session: `https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr`


---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_