### PR TITLE
fix(devx): say the skill-examples build is scoped at both precondition sites

### DIFF
--- a/scripts/__tests__/check-skill-examples.test.ts
+++ b/scripts/__tests__/check-skill-examples.test.ts
@@ -29,6 +29,7 @@ import {
   reconcileFloors,
   rootDevDepRowKey,
   scanSkillFences,
+  scopedBuildNotice,
   stripJsonComments,
 } from '../check-skill-examples.mjs';
 import {
@@ -500,6 +501,139 @@ describe('the build filter carries the dependency closure', () => {
     // A bare `turbo run build` over the whole workspace is the one thing the
     // workflow's header forbids, so the empty case must be visibly empty here.
     expect(buildFilterArgs([])).toBe('');
+  });
+});
+
+/**
+ * The scoping notice under the printed build command — objectui#7811, porting
+ * the shape objectui#7795 landed for `check-doc-snippet-types.mjs`.
+ *
+ * Two precondition paths tell the reader to build and print a command that
+ * builds a CLOSURE rather than the tree, and neither said so. Measured on
+ * `origin/main` `65ce8c576`: `--build-filter` names 10 of the workspace's 40
+ * packages and turbo expands those to 30 in scope, so the reader who ran the
+ * printed command is left looking at 10 packages with no `dist/` and nothing to
+ * tell that apart from a build that half-failed.
+ *
+ * Pinned here is the half that rots unwatched — the notice must keep DERIVING
+ * its numbers and must never grow a package list of its own — plus the half that
+ * would make it worthless: both paths have to actually print it. That it reaches
+ * a real terminal is shown on an unbuilt tree in the pull request; this suite
+ * cannot get there, because those paths only open when this repository's own
+ * packages are unbuilt, and CI has built them by the time it runs.
+ */
+describe('the printed build command says what it does NOT build (objectui#7811)', () => {
+  const SCRIPT = 'scripts/check-skill-examples.mjs';
+  /** A workspace package name, as the notice would spell one if it grew a list. */
+  const PACKAGE_NAME = /@object-ui\//;
+  const sourceOfScript = () => fs.readFileSync(path.join(repoRoot, SCRIPT), 'utf8');
+
+  /**
+   * Every place the gate prints the build command, paired with the slice that
+   * runs from it to the `couldNotRun` exit that site leaves through.
+   *
+   * Anchored on the printed COMMAND rather than on `PRECONDITION NOT MET`: the
+   * empty-marked-population path prints that headline too and correctly prints
+   * no build command, so a scan anchored on the headline would demand a notice
+   * where there is nothing to scope.
+   */
+  const buildCommandSites = (source: string): string[] => {
+    const marker = 'check-skill-examples.mjs --build-filter) --concurrency=2';
+    const slices: string[] = [];
+    for (let at = source.indexOf(marker); at !== -1; at = source.indexOf(marker, at + 1)) {
+      const end = source.indexOf('EXIT_CODES.couldNotRun;', at);
+      expect(end, 'a site that prints the build command must still leave through exit 2').toBeGreaterThan(at);
+      slices.push(source.slice(at, end));
+    }
+    return slices;
+  };
+
+  it('interpolates the counts it is handed — without this, a fixed sentence passes every pin below', () => {
+    expect(scopedBuildNotice(10, 40)).toContain('10 package(s)');
+    expect(scopedBuildNotice(10, 40)).toContain('packages/ holds 40');
+    // The control: different inputs, different text. A hard-coded "10 of 40" —
+    // exactly the rotting summary this notice exists not to be — passes both
+    // assertions above and fails these.
+    const other = scopedBuildNotice(1, 2);
+    expect(other).toContain('1 package(s)');
+    expect(other).toContain('packages/ holds 2');
+    expect(other).not.toContain('10');
+    expect(other).not.toContain('40');
+  });
+
+  it('names no package of its own — the reader is sent to the filter, never to a copy of it', () => {
+    const notice = scopedBuildNotice(10, 40);
+    // The control, and it has to be taken from THIS tree: a matcher that catches
+    // no package name anywhere would satisfy the refusal below while proving
+    // nothing. The names come from the gate's own reading of the workspace,
+    // which is the very set a second copy would be copied from.
+    const named = [...(analyze({}) as unknown as { neededPackages: Set<string> }).neededPackages];
+    expect(
+      named.filter((n) => PACKAGE_NAME.test(n)),
+      'nothing in this tree matches the matcher, so the refusal below is vacuous',
+    ).not.toHaveLength(0);
+    expect(
+      notice,
+      'a package name written here is a second list of what gets built, and it rots the first time the marked population moves',
+    ).not.toMatch(PACKAGE_NAME);
+    expect(notice).toContain('--build-filter');
+    expect(notice, 'without a way to ask, the notice is one more thing the reader has to trust').toContain(
+      '--dry=text',
+    );
+  });
+
+  it('says the build is scoped and that what it leaves behind is the designed end state', () => {
+    const notice = scopedBuildNotice(10, 40);
+    expect(notice).toContain('not a whole-tree build');
+    expect(notice).toContain('left exactly as it was');
+    expect(notice).toContain('designed end state');
+  });
+
+  it('is printed on BOTH precondition paths that print the command, not merely defined', () => {
+    const slices = buildCommandSites(sourceOfScript());
+    expect(
+      slices,
+      'objectui#7811 named two sites — the regular path and the --self-test type-check leg',
+    ).toHaveLength(2);
+    for (const slice of slices) {
+      expect(
+        slice,
+        'a notice nothing calls is a string in a file, and objectui#7811 was filed about a reader who was never told',
+      ).toContain('scopedBuildNotice(');
+    }
+  });
+
+  it('is handed numbers the gate read, never a literal at the call site', () => {
+    for (const slice of buildCommandSites(sourceOfScript())) {
+      const call = slice.slice(slice.indexOf('scopedBuildNotice('));
+      expect(call).toContain('state.neededPackages.size');
+      expect(call).toContain('state.packageDirOf');
+      expect(
+        call,
+        'a number written at the call site is the rotting summary this notice exists not to be',
+      ).not.toMatch(/scopedBuildNotice\(\s*\d/);
+    }
+  });
+
+  it('counts the workspace from what the gate itself read, not from a number written down', () => {
+    const names = withTree(
+      (write) => {
+        write('skills/objectui/guides/sample.md', '# Sample\n');
+        write(
+          'packages/pkg-a/package.json',
+          JSON.stringify({ name: '@fixture/pkg-a', types: './dist/index.d.ts' }),
+        );
+        write(
+          'packages/pkg-b/package.json',
+          JSON.stringify({ name: '@fixture/pkg-b', types: './dist/index.d.ts' }),
+        );
+      },
+      (dir) =>
+        Object.keys(
+          (analyze({ root: dir }) as unknown as { packageDirOf: Record<string, string> }).packageDirOf,
+        ).sort(),
+    );
+    expect(names).toEqual(['@fixture/pkg-a', '@fixture/pkg-b']);
   });
 });
 

--- a/scripts/check-skill-examples.mjs
+++ b/scripts/check-skill-examples.mjs
@@ -1074,6 +1074,12 @@ export function analyze({ root = repoRoot, measure = false, baseline = KNOWN_BAR
     untypedDependencies,
     declaredSpecifiers,
     neededPackages,
+    // Carried out so the precondition paths can say how much of the workspace
+    // their build filter leaves alone (objectui#7811). It is the map this
+    // function already walked to resolve `neededPackages`, not a second reading
+    // of the tree — the whole point of `scopedBuildNotice` is that its numbers
+    // are DERIVED, so the number it is handed has to come from here.
+    packageDirOf,
   };
 }
 
@@ -1100,6 +1106,50 @@ export function buildFilterArgs(packages) {
     .sort()
     .map((n) => `--filter=${n}...`)
     .join(' ');
+}
+
+/**
+ * What that printed build command does NOT do, printed under it — objectui#7811,
+ * porting the shape objectui#7795 landed as `check-doc-snippet-types.mjs`'s
+ * `scopedBuildNotice`.
+ *
+ * Both precondition paths tell the reader to build, and both print a command
+ * that builds a CLOSURE rather than the tree, having said so nowhere. Measured
+ * on `origin/main` `65ce8c576`: `--build-filter` names 10 of the workspace's 40
+ * packages, and expanding each one's dependency closure puts 30 in scope — so
+ * running the printed command exactly as given leaves 10 packages with no
+ * `dist/`, and nothing distinguishes that from a build that half-failed. The
+ * trimming is deliberate (`skill-examples.yml`'s header forbids the unfiltered
+ * build in as many words, under the 2026-08-16 ruling on objectui#4846), so what
+ * was missing is the sentence, never a wider filter.
+ *
+ * Both counts are ARGUMENTS and the text names no package on purpose. A list of
+ * "what gets built" written out here would be a second copy of a set this file
+ * already computes, and it would rot the first time the marked population moved;
+ * the reader who wants the exact set is sent to the same filter, expanded by the
+ * same tool that is about to run it — `--dry=text` makes turbo print a
+ * `Packages in scope` line (and, below it, a table of the same set) instead of
+ * building. `packages/` is the directory `derivePackageTypePaths` walks, which
+ * is where `total` is counted from; it is a location, not a package list.
+ *
+ * `check-skill-examples.test.ts` pins the half that rots unwatched — the numbers
+ * stay derived, no package name grows here — plus the half that would make it
+ * worthless: both precondition paths have to actually print it.
+ *
+ * @param {number} named packages `--build-filter` names (the marked examples' imports)
+ * @param {number} total packages under `packages/` this gate resolves against
+ * @returns {string} one paragraph for a precondition path's stderr
+ */
+export function scopedBuildNotice(named, total) {
+  return (
+    `That build is SCOPED, and it is not a whole-tree build: --build-filter names the ${named} package(s) the ` +
+    `marked examples import (packages/ holds ${total}) plus each one's dependency closure, and every package ` +
+    'outside that closure is left exactly as it was. An unbuilt package still sitting there when the build ' +
+    "finishes is this gate's designed end state, not a build that half-failed — a whole-workspace build for a " +
+    'guide check is what this gate\'s workflow refuses outright. For the exact set, ask that same filter rather ' +
+    'than a list written down somewhere else: append --dry=text to the command above and read its "Packages in ' +
+    'scope" line.'
+  );
 }
 
 // ── Reporting ────────────────────────────────────────────────────────────────
@@ -1284,6 +1334,9 @@ function main() {
     console.error(
       '  pnpm exec turbo run build $(node scripts/check-skill-examples.mjs --build-filter) --concurrency=2\n' +
         '  pnpm check:skill-examples',
+    );
+    console.error(
+      `\n${scopedBuildNotice(state.neededPackages.size, Object.keys(state.packageDirOf).length)}`,
     );
     return EXIT_CODES.couldNotRun;
   }
@@ -1720,6 +1773,9 @@ export function selfTest() {
     console.error(
       '  pnpm exec turbo run build $(node scripts/check-skill-examples.mjs --build-filter) --concurrency=2\n' +
         '  node scripts/check-skill-examples.mjs --self-test',
+    );
+    console.error(
+      `\n${scopedBuildNotice(state.neededPackages.size, Object.keys(state.packageDirOf).length)}`,
     );
     for (const c of cases.filter((c2) => !c2.ok)) console.error(`  ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
     return EXIT_CODES.couldNotRun;


### PR DESCRIPTION
Fixes #7811

`scripts/check-skill-examples.mjs` prints the same `--build-filter` build command on two
precondition paths, and neither said the build is **trimmed**. This ports the shape objectui#7795
landed for `check-doc-snippet-types.mjs` (`scopedBuildNotice`), adapted to what *this* gate scopes:
the marked examples' import surface.

## The gap, measured on this branch (`3b26507ba`)

- `node scripts/check-skill-examples.mjs --build-filter` names **10** packages; `packages/` holds **40**.
- Running the printed command expands those to **30 packages in scope** (turbo `--dry=text`), and
  finishes with **29 of 40** packages carrying a `dist/`.
- So a reader who ran the command exactly as printed is looking at 11 package directories with no
  `dist/`, and nothing on screen told them that leftover was the intended end state rather than a
  build that half-failed. (Ten of those are simply outside the closure; `@object-ui/test-support` is
  *in* scope but is source-typed and emits no `dist/` by design.)

Trimming is this gate's design — `.github/workflows/skill-examples.yml`'s header forbids the
unfiltered build outright, under the 2026-08-16 ruling on objectui#4846 — so what was missing is the
sentence, never a wider filter.

## What changed

One exported `scopedBuildNotice(named, total)` in `scripts/check-skill-examples.mjs`, called from
both sites and from nowhere else:

- `:1285` — the regular precondition path (followed by `pnpm check:skill-examples`)
- `:1721` — the `--self-test` type-check leg (followed by `node scripts/check-skill-examples.mjs --self-test`)

Both counts are **arguments**, derived from what the gate already read: `state.neededPackages.size`,
and `Object.keys(state.packageDirOf).length`. `analyze()` now carries `packageDirOf` out in its
return — it is the same map it already walked to resolve `neededPackages`, not a second reading of
the tree. The notice names **no package**; the reader who wants the exact set is sent back to the
same filter (`--dry=text`, turbo's `Packages in scope` line), never to a second list that would rot.

⛔ Untouched: `--build-filter`'s package selection, the scanner, the judge, every exit code, and
every existing assertion in the pin test. Nothing under `skills/**` or `.claude/**` is in the diff.

## It reaches a real terminal

This worktree was genuinely unbuilt, so both paths were exercised for real (exit **2** both times,
unchanged):

Regular path — `node scripts/check-skill-examples.mjs`:

```
PRECONDITION NOT MET (exit 2) — the example program was NOT run: the packages it resolves against are not built, or are typed from source.
This is "I could not run", NOT "I ran and found errors" (exit 1). No line above is a verdict about any guide. Build what the gate needs, then re-run:
  pnpm exec turbo run build $(node scripts/check-skill-examples.mjs --build-filter) --concurrency=2
  pnpm check:skill-examples

That build is SCOPED, and it is not a whole-tree build: --build-filter names the 10 package(s) the marked examples import (packages/ holds 40) plus each one's dependency closure, and every package outside that closure is left exactly as it was. An unbuilt package still sitting there when the build finishes is this gate's designed end state, not a build that half-failed — a whole-workspace build for a guide check is what this gate's workflow refuses outright. For the exact set, ask that same filter rather than a list written down somewhere else: append --dry=text to the command above and read its "Packages in scope" line.
```

The `--self-test` leg prints the identical paragraph under its own two-line remedy. After the scoped
build, both run green and the notice is correctly absent from the happy path.

## The pin, and its must-fail leg

New `describe` in `scripts/__tests__/check-skill-examples.test.ts` (relative imports only; existing
assertions untouched). Six cases: the counts are interpolated (with the control — different inputs,
different text, so a hard-coded "10 of 40" fails); the notice names no package (with the control —
the same matcher is first shown to catch package names in *this* tree, so the refusal is not
vacuous); it says the build is scoped and its leftovers are the designed end state; **both** sites
call it; neither call site passes a numeric literal; and `analyze()` derives `packageDirOf` from the
tree it walked.

Ablation, on the committed implementation (`dcf79b983`), restoring under a `trap`:

| step | evidence |
|---|---|
| before | blob `2b105219f` = `HEAD:scripts/check-skill-examples.mjs`; 2 call sites |
| mutate (drop the `--self-test` leg's call) | blob `a6b6eb01b` — different, so it reached disk; 1 call site |
| run | `vitest run scripts/__tests__/check-skill-examples.test.ts` → exit 1, **2 failed / 88 passed** — "is printed on BOTH precondition paths" and "is handed numbers the gate read" both red |
| restore | blob back to `2b105219f`, `git diff HEAD` empty, 2 call sites |

## Gates (all at `3b26507ba`, exit codes captured by redirect-then-capture)

| command | exit |
|---|---|
| `node scripts/check-skill-examples.mjs --self-test` | 0 (52 cases pass) |
| `pnpm check:skill-examples` (after its scoped build) | 0 — 13/13 ts, 70/70 json, same verdict as `main` |
| `pnpm exec vitest run scripts/__tests__/check-skill-examples.test.ts` | 0 — 90 passed |
| `pnpm exec vitest run scripts/__tests__/` | 0 — 111 files, 3333 tests |
| `pnpm type-check:scripts` | 0 — `--listFiles` confirms both changed files are in the program, so this is measured, not vacuous |
| `pnpm lint:root` | 0 (32 pre-existing warnings, 0 errors; full scan, not narrowed) |
| `pnpm check:control-bytes` | 0 (6472 files) + manual `grep -naP` over both paths: no hits |
| `node scripts/check-changeset-presence.mjs` | 0 — none owed (root `scripts/` publishes nothing) |
| `node scripts/check-governed-queue-guard.mjs --test` both paths | 0 — **NOT GOVERNED** (control: `AGENTS.md` → exit 3, GOVERNED) |

Readers checked: `.github/workflows/skill-examples.yml` invokes the gate as
`node scripts/check-skill-examples.mjs --build-filter`, `--self-test` and bare — the command line the
notice points at still matches exactly. `scripts/__tests__/check-skill-eval-tokens.test.ts` names the
gate only in prose and ran green in the directory sweep above.

`origin/main` moved while this was in flight (#8054), so `origin/main` was merged in and every gate
above was re-run on the merged head. `Live E2E (informational)` is red on every branch today for an
upstream reason (objectui#7990) and is not this branch's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_