### PR TITLE
test(perf-budget): extend the chunk-count prose pin to performance-budget.yml

### DIFF
--- a/.github/workflows/performance-budget.yml
+++ b/.github/workflows/performance-budget.yml
@@ -435,7 +435,8 @@ jobs:
       # it cannot prove that a real bundler reading that array still EMITS the
       # registrations, and that is the question the hazard turns on —
       # `"sideEffects": false` is statically coherent and drops three live SDUI
-      # widget registrations to 0 chunks on a green build (objectui#6535).
+      # widget registrations out of the build entirely — they reach no chunk at
+      # all — on a green build (objectui#6535).
       #
       # The key set is derived from the array itself, so this step needs no
       # list of its own. It runs after the budget step and never instead of it:

--- a/scripts/__tests__/check-eager-closure-budget.test.ts
+++ b/scripts/__tests__/check-eager-closure-budget.test.ts
@@ -1562,30 +1562,72 @@ describe('the prose attached to the baselines (objectui#7046)', () => {
  * side for a check on prose — the intolerable side is a standing claim nobody
  * refuses. The two legs of the reader's own self-test above hold each direction.
  *
- * ⚠️ `.github/workflows/performance-budget.yml` is edited by the same card and is
- * NOT in this population (objectui#7850). Its comments count chunks once as the
- * OUTCOME of a hazard — a `"sideEffects": false` that emits none at all on a
- * green build, objectui#6535 — which is structural, has no build that can move
- * it, and would need either a rewrite or an exemption here; exemption lists are
- * how a pin decays. Its own frozen-SIZE defect is a different class, repaired
- * there in prose: a pin for it would have to tell a retired ceiling from the
- * several sizes that paragraph legitimately carries, which is not this test.
+ * `.github/workflows/performance-budget.yml` joined this population in
+ * objectui#7850 — the same rule, the same reader, no second matcher. Its prose
+ * is `#` comments rather than `/**` blocks, so it reaches the reader through
+ * `yamlProse` below, which translates the marker and nothing else.
+ *
+ * Its one obstacle was settled by REWORDING, not by an exemption. The workflow
+ * counted chunks once as the OUTCOME of a hazard — a `"sideEffects": false`
+ * that is statically coherent while the registrations it governs reach no chunk
+ * at all, objectui#6535 — which is structural, has no build that can move it,
+ * and which this reader cannot tell from a population count. That sentence now
+ * states the outcome without a numeral, so the reader needs no exception to be
+ * right about it; the alternative was an exemption entry, and exemption lists
+ * are how a pin decays.
+ *
+ * ⚠️ The workflow's frozen-SIZE prose is a DIFFERENT class and is deliberately
+ * OUT of this pin — named here so nobody widens a count pin into a size pin by
+ * accident. The 350 KB entry line, the 89 KiB regression and the byte figures
+ * measured on `77f846a8b` are sizes, and a pin for them would have to tell a
+ * ceiling's value from the several sizes that paragraph legitimately carries,
+ * which this test does not do.
  *
  * Only the negative half is asserted. A positive "the prose names the verdict
  * line" pin would fix a wording, and what has to stay true is narrower: that no
  * number is written here which the next build could falsify.
  */
 describe("chunk counts in this gate's prose (objectui#7528)", () => {
-  const PROSE_FILES: Record<string, string> = {
-    'check-eager-closure-budget.mjs': checkerPath,
-    'check-eager-closure-budget.test.ts': fileURLToPath(import.meta.url),
+  /**
+   * The population. Two script files whose prose is JS comments, and the
+   * workflow whose prose is `#` comments (objectui#7850) — the same rule and the
+   * same reader, with only the comment marker translated for the third.
+   */
+  const PROSE_FILES: Record<string, { path: string; toProse: (source: string) => string }> = {
+    'check-eager-closure-budget.mjs': { path: checkerPath, toProse: (source) => source },
+    'check-eager-closure-budget.test.ts': {
+      path: fileURLToPath(import.meta.url),
+      toProse: (source) => source,
+    },
+    'performance-budget.yml': { path: workflowPath, toProse: yamlProse },
   };
 
   /** A chunk population written as a numeral: "N chunks", or "N of M chunks". */
   const CHUNK_COUNT = /\b\d[\d,_]*\s+(?:of\s+\d[\d,_]*\s+)?chunks?\b/gi;
 
-  /** A commit named the way both files name one: a backticked short hash. */
+  /** A commit named the way all three files name one: a backticked short hash. */
   const NAMES_A_COMMIT = /`[0-9a-f]{7,40}`/;
+
+  /**
+   * The workflow's prose is YAML and shell `#` comments, which `proseLines`
+   * classifies as CODE — every count in it would be invisible, and the pin green
+   * because it read nothing rather than because nothing was loose. Translating
+   * the marker to the one `proseLines` already knows is the whole adaptation:
+   * one reader, one rule, no second matcher. The paragraph structure a human
+   * sees survives the translation because the two kinds of separator survive it
+   * — a bare `#` becomes a bare `//`, a blank COMMENT line that carries an
+   * anchor into the paragraph after it, while a line of YAML stays a line of
+   * code, which does not. Both directions are held by the self-test below.
+   */
+  function yamlProse(source: string): string {
+    return source
+      .split('\n')
+      .map((raw) => {
+        const line = raw.trim();
+        return line.startsWith('#') ? `//${line.slice(1)}` : raw;
+      })
+      .join('\n');
+  }
 
   /**
    * One entry per source line: the comment's text, `''` for a blank comment
@@ -1688,6 +1730,49 @@ describe("chunk counts in this gate's prose (objectui#7528)", () => {
   });
 
   /**
+   * The marker translation, held in both directions — it is what makes the
+   * reader see the paragraphs a human sees in the workflow, and a translation
+   * that quietly saw nothing would make the workflow entry green forever.
+   */
+  it('reads a `#` comment block the way it reads a `//` one — once translated', () => {
+    const block = [
+      '          # Measured on `77f846a8b`:',
+      '          #',
+      '          #   the closure — 58 of 507 chunks',
+    ].join('\n');
+
+    // Untranslated, the reader classifies every one of those lines as code: no
+    // paragraph, no count, and a pin that is green because it read nothing.
+    expect(chunkCounts(block)).toEqual([]);
+    expect(chunkCounts(yamlProse(block))).toEqual([{ text: '58 of 507 chunks', anchored: true }]);
+
+    // A blank COMMENT line joins two paragraphs of one argument, so the anchor
+    // reaches the paragraph after it — and no further. Two paragraphs away is
+    // unanchored, exactly as it is in a `/**` block.
+    const twoParagraphsAway = [
+      '          # Measured on `77f846a8b`:',
+      '          #',
+      '          # An intervening paragraph of argument, carrying no measurement.',
+      '          #',
+      '          #   the closure — 58 of 507 chunks',
+    ].join('\n');
+    expect(chunkCounts(yamlProse(twoParagraphsAway))).toEqual([
+      { text: '58 of 507 chunks', anchored: false },
+    ]);
+
+    // ...and a line of YAML breaks the paragraph the way a line of code does,
+    // so a hash in one comment block never anchors a count in another.
+    const acrossYaml = [
+      '          # Measured on `77f846a8b`.',
+      '      - name: Some step',
+      '          # the closure — 58 of 507 chunks',
+    ].join('\n');
+    expect(chunkCounts(yamlProse(acrossYaml))).toEqual([
+      { text: '58 of 507 chunks', anchored: false },
+    ]);
+  });
+
+  /**
    * The allowed branch is live: the checker really does carry an anchored count,
    * so the pin below is passing because nothing is unanchored rather than because
    * nothing was read. A deliberate must-hit control, in the manner of the
@@ -1700,16 +1785,32 @@ describe("chunk counts in this gate's prose (objectui#7528)", () => {
     expect(anchored).toContain('58 of 507 chunks');
   });
 
-  it.each(Object.entries(PROSE_FILES))('%s writes no chunk count that no commit anchors', (name, file) => {
-    const loose = chunkCounts(fs.readFileSync(file, 'utf8'))
-      .filter((count) => !count.anchored)
+  /**
+   * The same must-hit control for the workflow entry (objectui#7850). Its prose
+   * reaches the reader through a translation, and a translation that stopped
+   * working would show up as a population that passes because it is empty. This
+   * fails instead.
+   */
+  it('sees the anchored measurement the workflow must not be refused for', () => {
+    const anchored = chunkCounts(yamlProse(fs.readFileSync(workflowPath, 'utf8')))
+      .filter((count) => count.anchored)
       .map((count) => count.text);
-    expect(
-      loose,
-      `${name} states a chunk count (${loose.join(', ')}) that names no commit, so it reads as a claim ` +
-        'about the live closure — which moves on most builds, while nothing goes red when a number in a ' +
-        'comment goes stale. Pin it to the commit it was measured on, or name the population and let the ' +
-        'gate’s own verdict line print the figure on every run (objectui#7528).',
-    ).toEqual([]);
+    expect(anchored).toContain('58 of 507 chunks');
   });
+
+  it.each(Object.entries(PROSE_FILES))(
+    '%s writes no chunk count that no commit anchors',
+    (name, { path: file, toProse }) => {
+      const loose = chunkCounts(toProse(fs.readFileSync(file, 'utf8')))
+        .filter((count) => !count.anchored)
+        .map((count) => count.text);
+      expect(
+        loose,
+        `${name} states a chunk count (${loose.join(', ')}) that names no commit, so it reads as a claim ` +
+          'about the live closure — which moves on most builds, while nothing goes red when a number in a ' +
+          'comment goes stale. Pin it to the commit it was measured on, or name the population and let the ' +
+          'gate’s own verdict line print the figure on every run (objectui#7528).',
+      ).toEqual([]);
+    },
+  );
 });


### PR DESCRIPTION
Fixes #7850

objectui#7528 pinned one rule — a chunk count stays pinned to the commit it was measured on, or it is not written — over two files (`scripts/check-eager-closure-budget.mjs` and its own test) and deliberately left `.github/workflows/performance-budget.yml` beside them to a follow-up. This is that follow-up. The workflow joins the same population, under the same rule, read by the same reader, with no exemption list and no second matcher.

## What changed

**`scripts/__tests__/check-eager-closure-budget.test.ts`** — the population of `chunk counts in this gate's prose (objectui#7528)` grows by one entry. The reader is untouched: `proseLines`, `paragraphs`, `chunkCounts`, `CHUNK_COUNT` and `NAMES_A_COMMIT` are byte-identical.

What the workflow needed is a marker translation, not a reader. Its prose is hash-marker comments (both real YAML comments and shell comments inside `run:` blocks), and `proseLines` classifies those lines as CODE — every count in the workflow would have been invisible, and the new entry green because it read nothing rather than because nothing was loose. A small `yamlProse` rewrites a leading hash marker to the `//` that `proseLines` already knows, and does nothing else. The paragraph structure a human sees survives the translation because both kinds of separator survive it:

- a bare hash line becomes a bare `//` — a blank COMMENT line, which carries an anchor into the paragraph after it;
- a line of YAML stays a line of code, which does not.

Two controls guard that, because a translation that quietly stopped working would be indistinguishable from a clean population:

- the reader self-test gains a hash-block leg holding the anchor window in **both** directions — untranslated the block yields no counts at all; translated, a lead-in anchor reaches one paragraph forward, an anchor **two** paragraphs away does not, and an anchor separated by a line of YAML does not;
- the workflow gets the must-hit control the checker already had: its live anchored measurement (`58 of 507 chunks`, sitting with "On `77f846a8b`" in the same paragraph) must be seen.

**`.github/workflows/performance-budget.yml`** — comment prose only, one sentence. The objectui#6535 sentence stated a structural outcome using a count-shaped token (the SDUI widget registrations that a statically coherent `"sideEffects": false` drops on a green build). That outcome has no build that can move it, but the pin's rule cannot tell it from a population count. It is **reworded** to state the same outcome and keep the objectui#6535 reference, without a numeral — the alternative was an exemption entry, and exemption lists are how a pin decays.

`git diff` on the workflow moves only hash-marker lines. No job, step, `env`, ceiling value, trigger or `timeout-minutes` change. `scripts/check-eager-closure-budget.mjs` is untouched, and so is `scripts/vite-declared-lazy-views.ts` — that is objectui#7289's baseline-prose pin, a different pin on a different file, and it is not addressed here.

## The size half stays out, by name

The workflow's frozen-SIZE prose is a different class and is deliberately **not** in this pin: the 350 KB entry line, the 89 KiB regression and the byte figures measured on `77f846a8b` are sizes, not populations, and a pin for them would have to tell a ceiling's value from the several sizes that paragraph legitimately carries. The pin's docblock now says so in as many words, so nobody widens a count pin into a size pin by reading the workflow's presence here as a licence.

## Evidence

All readings taken on final head `dcb5f4736` (which merges `main` `295804a63`; the branch was cut from `a81336390`).

| Gate | Verdict |
| --- | --- |
| `pnpm exec vitest run scripts/__tests__/check-eager-closure-budget.test.ts` | exit 0 — 104 passed |
| `pnpm exec vitest run scripts/__tests__/` (112 files) | exit 0 — 3344 passed |
| `pnpm type-check:scripts` | exit 0 |
| `pnpm lint:root` | exit 0 — 32 problems, 0 errors (warnings all pre-existing, none in the two paths) |
| `pnpm check:control-bytes` | exit 0 — scanned 6473 tracked text files |
| manual control-byte scan of both paths (`grep -naP`) | no hits |
| `node scripts/check-changeset-presence.mjs` | exit 0 — "no changeset is owed" (2 files changed, 0 published source) |
| `node scripts/check-governed-queue-guard.mjs --test` on both paths | exit 0 — NOT GOVERNED, 2 paths against 5 governed surfaces |
| YAML parse identity vs `main` | PASS — parsed document digest `1658da92c443c216` on both sides |

Every reader of the two paths (`ci-cd-pipeline-doc`, `render-budget-comment`, `turbo-build-inputs`, `workflow-cache-save-bound`, plus this pin's own file): exit 0, 240 passed.

The YAML parse identity is the sharper half of the "prose only" claim: the edited sentence is a real YAML comment, so it is not part of the parsed document at all, and the parsed document is deep-equal to `main`'s. (Note the prose in `run:` blocks *is* part of the parse — this change does not touch any of it.)

## Ablation

Both legs run from the committed tree, blob-hash checked before and after, restored under a `trap` with absolute paths and verified by `git diff HEAD` being empty plus the blob hash returning to `aaf25a3fb`.

- **(a) revert the rewording on disk** — the pin reds, naming the workflow and the count-shaped token it restores: `performance-budget.yml states a chunk count (0 chunks) that names no commit`. 1 failed, 6 passed.
- **(b) strip the `77f846a8b` anchor from the paragraph holding the live measurement** — the pin reds twice, on the count itself (`performance-budget.yml states a chunk count (58 of 507 chunks) that names no commit`) and on the must-hit control (`expected [] to include '58 of 507 chunks'`). 2 failed, 5 passed.

Leg (b) is the one that matters for the translation: it can only red if `yamlProse` really delivered the workflow's paragraphs to the reader.

Note: `Live E2E (informational)` is red on every branch today for an upstream reason (objectui#7990 / objectstack#16186), unrelated to this change.

Drafted by an agent seat, session `session_01FhBNJcLRZLe8M87VcUgpKr`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_