### PR TITLE
fix(app-shell,plugin-designer): a half-filled relationship field stays client-side and is never PUT (objectui#7714)

### DIFF
--- a/.changeset/7714-lookup-draft-stays-client-side.md
+++ b/.changeset/7714-lookup-draft-stays-client-side.md
@@ -1,0 +1,48 @@
+---
+'@object-ui/app-shell': minor
+'@object-ui/plugin-designer': minor
+---
+
+A half-filled relationship field stays in the client and is never PUT (objectui#7714,
+maintainer ruling on objectui#7122 item 4, 2026-09-05).
+
+**Breaking, deliberately, and stated rather than implied.** Both metadata writers —
+`MetadataService.saveFields` / `saveObject` in `@object-ui/app-shell`, and
+`MetadataFieldsPage` in `@object-ui/plugin-designer` — now REFUSE a `lookup` or
+`master_detail` field whose `reference` is missing, empty, blank or not a string. A
+caller that previously got a PUT now gets a thrown error and **no request at all**. The
+refusal is raised while the wire `fields` map is being built, so nothing is sent and
+nothing is partially applied.
+
+**Why the draft may not leave the client.** `@objectstack/spec` 17.3.0 turned
+`reference` from prose into a hard requirement on relationship types (a `custom`
+refinement at path `reference`). Driven against a real 17.3.0 backend in a running
+designer: creating a `lookup` and leaving its target empty PUT the whole object,
+came back `422 INVALID_METADATA` at `fields.<name>.reference` — and then the NEXT
+edit, to a different and already-saved field, was refused identically, because the
+half-filled draft rides along inside the same document. The author sees that later
+edit rendered as applied while the server has none of it, and the only escape that
+does not require noticing the lookup is a reload, which discards the work. An editing
+session's half-finished state belongs to the client, not to the metadata store.
+
+⛔ **Not** "strip the incomplete field from the body and report a successful save".
+That shows the author a field the server never received — the silent-drop shape
+objectstack#4001 closed.
+
+⚠️ **A declared divergence: objectui is stricter than the contract here.** The
+predicate is `typeof reference === 'string' && reference.trim() !== ''`. Measured on
+the 17.3.0 artifact, at field level and again through `ObjectSchema`, the spec
+ACCEPTS a whitespace-only `reference` while refusing an absent or empty one — so
+`reference: '   '` is refused by these writers on their own authority, not the
+platform's. Kept deliberately: whitespace names no object (the spec's own
+`ObjectSchema.fields` key grammar `/^[a-z_][a-z0-9_]*$/` admits no whitespace-bearing
+name), so admitting it only moves the identical failure past the PUT and into a stored
+document, where it surfaces with no field named. Filed upstream as objectstack#16126;
+if the spec trims, behaviour here is unchanged and only the declaration retires.
+
+The refusal message diagnoses which of the four states it found — absent, empty,
+non-string (`invalid_type`, a value of the wrong kind rather than a missing target),
+or blank — because the repair and the consequence differ per state.
+
+`minor` rather than `major` per `AGENTS.md`: objectui's major tracks `@objectstack`'s,
+so objectui's own breaking changes ship as `minor` with the breaking semantics stated.

--- a/packages/app-shell/src/services/MetadataService.specKeyReference.test.ts
+++ b/packages/app-shell/src/services/MetadataService.specKeyReference.test.ts
@@ -44,6 +44,28 @@
  * `undefined` is a key that zod's strict object COUNTS but that
  * `JSON.stringify` DROPS, so an in-memory assertion and a wire assertion
  * disagree exactly on the half-filled draft this card had to measure.
+ *
+ * ## objectui#7714 — a half-filled lookup is HELD CLIENT-SIDE and never PUT
+ *
+ * The half-filled case below used to pin the opposite ("still saves, exactly as
+ * before"). That was accurate for objectui#6041's question and is no longer the
+ * truth: `@objectstack/spec` 17.3.0 made `reference` a hard requirement on
+ * `lookup` / `master_detail`, and objectui#7714 drove the consequence in a
+ * running designer against a 17.3.0 backend — the target-less draft PUT the
+ * whole object, got `422 INVALID_METADATA` at `fields.<name>.reference`, and
+ * then blocked the NEXT edit too, to an entirely different field, because the
+ * draft rides along in the same document.
+ *
+ * So the fix is a client behaviour, and this file states it: the writer refuses
+ * the list and issues **no PUT at all**. That claim is about THE PUT BODY, not
+ * about the spec's verdict, which is exactly why it is pinnable at this repo's
+ * installed **17.2.0** — where the spec still accepts the draft — and does not
+ * wait on the pin bump (objectui#7122).
+ *
+ * ⛔ The refusal is not "strip the incomplete field and save the rest": that
+ * would show the author a field the server never received, the silent-drop
+ * shape objectstack#4001 closed and the ruling excluded by name. `puts` being
+ * EMPTY is the assertion that tells the two apart.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -141,24 +163,216 @@ describe('objectui#6041 · saveFields PUTs the relationship target as `reference
     expect(def.reference).toBe('account');
   });
 
-  it('a HALF-FILLED draft — type `lookup`, target left empty — still saves, exactly as before', async () => {
-    // The behavioural edge this card had to measure. The spec's prose calls
-    // `reference` "Required for relationship types", but that requirement is
-    // NOT enforced by the zod parse at 17.2.0: `{ type: 'lookup', label: 'L' }`
-    // parses green at field level AND through `ObjectSchema`. `undefined` is
-    // dropped by `JSON.stringify` under either spelling, so the wire bytes are
-    // byte-identical before and after this fix.
+  it('a HALF-FILLED draft — type `lookup`, target left empty — is REFUSED, and issues NO PUT', async () => {
+    // objectui#7714. This case used to assert the opposite ("still saves,
+    // exactly as before"), and that assertion is not respelled here — it is
+    // REPLACED, because the branch it pinned is the branch this card removes.
     //
-    // ⚠ This case would still pass on a revert, and says so deliberately: it
-    // is here to prove the rename did NOT newly block a draft, which is a
-    // claim about the unchanged half.
+    // Two assertions, and the second is the card: the save is refused, AND the
+    // client made no request at all. "Refused" alone would also describe option
+    // B — strip the incomplete field, PUT the rest, report success — which is
+    // the silent-drop shape objectstack#4001 closed and which the ruling
+    // excluded by name. `puts` being empty is what distinguishes them.
     const { adapter, puts } = makeCapturingAdapter();
 
-    await new MetadataService(adapter).saveFields('account', [{ ...LOOKUP, referenceTo: undefined }]);
+    await expect(
+      new MetadataService(adapter).saveFields('account', [{ ...LOOKUP, referenceTo: undefined }]),
+    ).rejects.toThrow(/needs a `reference` naming the object it links to/);
 
-    const [def] = savedFields(puts);
-    expect('reference' in def).toBe(false);
-    expect('referenceTo' in def).toBe(false);
-    expect(FieldSchema.safeParse(def).success).toBe(true);
+    expect(puts).toEqual([]);
+  });
+
+  it('the refusal names the field, the type and the consequence', async () => {
+    // The author reads this string in the designer's error banner, so its
+    // content is the deliverable rather than incidental. Asserted by content,
+    // not by exact bytes: the docblocks are free to change and the four
+    // load-bearing facts are not.
+    const { adapter } = makeCapturingAdapter();
+
+    await expect(
+      new MetadataService(adapter).saveFields('account', [{ ...LOOKUP, referenceTo: undefined }]),
+    ).rejects.toThrow(/`owner_id`/);
+    await expect(
+      new MetadataService(adapter).saveFields('account', [{ ...LOOKUP, referenceTo: undefined }]),
+    ).rejects.toThrow(/`lookup` field/);
+    await expect(
+      new MetadataService(adapter).saveFields('account', [{ ...LOOKUP, referenceTo: undefined }]),
+    ).rejects.toThrow(/blocks EVERY later save of this object/);
+  });
+
+  it('a COMPLETE lookup still saves — the guard refuses drafts, not relationships', async () => {
+    // Falsification for the whole block above. A guard that refused every
+    // `lookup` would make every assertion in it pass while deleting the
+    // feature, so the accepting half is asserted in the same file.
+    const { adapter, puts } = makeCapturingAdapter();
+
+    await new MetadataService(adapter).saveFields('account', [LOOKUP]);
+
+    expect(puts).toHaveLength(1);
+    expect(savedFields(puts)[0].reference).toBe('account');
+  });
+
+  it('a NON-relationship field with no `reference` is untouched by the guard', async () => {
+    // The guard is keyed to the two relationship types, not to the absence of a
+    // key: 47 of the spec's 49 field types carry no `reference` at all and must
+    // keep saving. Measured on the 17.3.0 artifact for objectui#7714 — exactly
+    // `lookup` and `master_detail` are refused at `reference` on
+    // `{ type, label }`, and no other type is refused at all.
+    const { adapter, puts } = makeCapturingAdapter();
+
+    await new MetadataService(adapter).saveFields('account', [
+      { id: 'note', name: 'note', label: 'Note', type: 'text' },
+    ]);
+
+    expect(puts).toHaveLength(1);
+    expect(savedFields(puts)[0].type).toBe('text');
+  });
+
+  it('`master_detail` is guarded too — the invariant is relationship targets, not one key', async () => {
+    const { adapter, puts } = makeCapturingAdapter();
+
+    await expect(
+      new MetadataService(adapter).saveFields('account', [
+        { id: 'parent_id', name: 'parent_id', label: 'Parent', type: 'master_detail' },
+      ]),
+    ).rejects.toThrow(/`master_detail` field/);
+
+    expect(puts).toEqual([]);
+  });
+
+});
+
+/**
+ * objectui#7714 — the four states of an unusable target, and the one where this
+ * writer is deliberately stricter than the contract.
+ *
+ * ⚠️ Read the instrument note before adding a spec assertion here. This repo's
+ * pin is `@objectstack/spec` **17.2.0**, where `reference` is prose-only: it
+ * accepts absent, `''` AND `'   '` alike. So an assertion of the shape "the
+ * spec accepts `'   '`" is TRUE here and measures nothing — it is true of every
+ * value at this pin. The divergence is therefore asserted where it is real:
+ * against THIS WRITER, whose refusal does not depend on the installed spec at
+ * all, plus the one discriminating spec reading 17.2.0 does carry (a non-string
+ * IS refused, so a value-level check exists; blankness is simply not part of
+ * it, at either version).
+ *
+ * The 17.3.0 half was measured on the built artifact and recorded in
+ * `MetadataService.ts`'s docblock rather than asserted here, because it is not
+ * observable from this repo's installed spec. When objectui's pin reaches
+ * 17.3.0 (objectui#7122) it becomes assertable; when objectstack#16126 lands
+ * upstream the whitespace row moves to "refused" and only the guard's
+ * declaration retires, never its behaviour.
+ */
+describe('objectui#7714 · the target states, and the declared divergence', () => {
+  const puttable = async (reference: unknown) => {
+    const { adapter, puts } = makeCapturingAdapter();
+    const field = { ...LOOKUP, referenceTo: reference } as DesignerFieldDefinition;
+    try {
+      await new MetadataService(adapter).saveFields('account', [field]);
+      return { refused: false, puts };
+    } catch {
+      return { refused: true, puts };
+    }
+  };
+
+  it('refuses all four unusable states, and PUTs none of them', async () => {
+    for (const reference of [undefined, '', '   ', 42, null]) {
+      const { refused, puts } = await puttable(reference);
+      expect(refused, `reference=${JSON.stringify(reference)} should be refused`).toBe(true);
+      expect(puts, `reference=${JSON.stringify(reference)} must issue no PUT`).toEqual([]);
+    }
+  });
+
+  it('accepts a real target, and one that merely needs no trimming', async () => {
+    // Falsification for the row above: a guard that refused everything would
+    // satisfy it. `'account'` is the ordinary case; the guard trims only to
+    // TEST, never to rewrite, so the value on the wire is what the author gave.
+    const { refused, puts } = await puttable('account');
+    expect(refused).toBe(false);
+    expect(savedFields(puts)[0].reference).toBe('account');
+  });
+
+  it('does not rewrite a target that has surrounding whitespace but a real name', async () => {
+    // `' account '` trims to a non-empty name, so the guard passes it — and
+    // passes it THROUGH, unchanged. This writer's job is to refuse a draft, not
+    // to normalise author input; silently trimming would be a second, undeclared
+    // divergence hiding inside the first.
+    const { refused, puts } = await puttable(' account ');
+    expect(refused).toBe(false);
+    expect(savedFields(puts)[0].reference).toBe(' account ');
+  });
+
+  it('the divergence is real at THIS pin: the spec accepts `\'   \'`, this writer refuses it', async () => {
+    // The writer half — true regardless of which spec is installed.
+    const { refused } = await puttable('   ');
+    expect(refused).toBe(true);
+
+    // The spec half, stated honestly for 17.2.0. `'   '` parses green — but so
+    // does an absent target here, so this line alone is NOT evidence of a
+    // blankness gap. The discriminating reading is the next one.
+    expect(FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: '   ' }).success).toBe(true);
+
+    // Discriminating control: a value-level check on `reference` DOES exist at
+    // 17.2.0 — a non-string is refused, and refused as `invalid_type`. So the
+    // schema is being consulted and is not a passthrough; blankness is simply
+    // not among the things it tests, at either version. That is the shape
+    // objectstack#16126 reports upstream.
+    const nonString = FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: 42 });
+    expect(nonString.success).toBe(false);
+    expect(nonString.error!.issues.map((i) => i.code)).toContain('invalid_type');
+  });
+});
+
+/**
+ * objectui#7714 — the refusal DIAGNOSES the state it found.
+ *
+ * Split out because the single sentence this message used to carry ("…and this
+ * one has none") is wrong for two of the four states, and a message that
+ * prescribes the wrong repair is worse than a terse one: "pick the target
+ * object" is not what fixes `reference: 42`, and the 422 the message promises
+ * is one this writer cannot deliver for `'   '`, which the spec accepts.
+ */
+describe('objectui#7714 · the refusal message distinguishes the four states', () => {
+  const refusalFor = async (reference: unknown): Promise<string> => {
+    const { adapter } = makeCapturingAdapter();
+    try {
+      await new MetadataService(adapter).saveFields('account', [
+        { ...LOOKUP, referenceTo: reference } as DesignerFieldDefinition,
+      ]);
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+    throw new Error(`expected a refusal for reference=${JSON.stringify(reference)}`);
+  };
+
+  it('absent → "has none", and names the 422 consequence', async () => {
+    const m = await refusalFor(undefined);
+    expect(m).toMatch(/has none/);
+    expect(m).toMatch(/blocks EVERY later save of this object/);
+  });
+
+  it('empty string → "is empty", not "has none"', async () => {
+    const m = await refusalFor('');
+    expect(m).toMatch(/is empty/);
+    expect(m).not.toMatch(/has none/);
+  });
+
+  it('non-string → names the KIND and `invalid_type`, and does not prescribe "supply a target"', async () => {
+    const m = await refusalFor(42);
+    expect(m).toMatch(/holds a number instead of an object name/);
+    expect(m).toMatch(/invalid_type/);
+    expect(m).not.toMatch(/has none/);
+    // `null` is typeof 'object'; spelling it as "null" is the accurate word.
+    expect(await refusalFor(null)).toMatch(/holds null instead of an object name/);
+  });
+
+  it('whitespace-only → says the spec ACCEPTS it, and does not promise a 422 it cannot deliver', async () => {
+    const m = await refusalFor('   ');
+    expect(m).toMatch(/is blank/);
+    expect(m).toMatch(/ACCEPTS this value/);
+    expect(m).toMatch(/objectstack#16126/);
+    // The falsifying half: this is the ONE state where promising the server
+    // would refuse the document would be a lie.
+    expect(m).not.toMatch(/422/);
   });
 });

--- a/packages/app-shell/src/services/MetadataService.specKeyReference.test.ts
+++ b/packages/app-shell/src/services/MetadataService.specKeyReference.test.ts
@@ -228,16 +228,37 @@ describe('objectui#6041 · saveFields PUTs the relationship target as `reference
     expect(savedFields(puts)[0].type).toBe('text');
   });
 
-  it('`master_detail` is guarded too — the invariant is relationship targets, not one key', async () => {
+  it('`master_detail` is guarded too, through `saveObject` — the invariant is relationship targets, not one key', async () => {
+    // Driven through `saveObject`'s `existingFields` rather than `saveFields`,
+    // and that is the accurate reachability rather than a convenience:
+    // `DesignerFieldDefinition['type']` does NOT include `master_detail`, so
+    // the designer cannot author one, while `FieldMetadataPayload['type']` is
+    // an unconstrained `string` and this path is where a stored master-detail
+    // field actually arrives. It also exercises the second writer sharing this
+    // door — `toObjectPayload` converts through the same `toFieldsMap`, so one
+    // guard covers both, and nothing else in this file asserts that.
     const { adapter, puts } = makeCapturingAdapter();
 
     await expect(
-      new MetadataService(adapter).saveFields('account', [
-        { id: 'parent_id', name: 'parent_id', label: 'Parent', type: 'master_detail' },
+      new MetadataService(adapter).saveObject({ id: 'account', name: 'account', label: 'Account' }, [
+        { name: 'parent_id', label: 'Parent', type: 'master_detail' },
       ]),
     ).rejects.toThrow(/`master_detail` field/);
 
     expect(puts).toEqual([]);
+  });
+
+  it('`saveObject` still saves when the master-detail target IS present', async () => {
+    // Falsification for the case above: it must be the missing target that was
+    // refused, not the `saveObject` path or the type.
+    const { adapter, puts } = makeCapturingAdapter();
+
+    await new MetadataService(adapter).saveObject({ id: 'account', name: 'account', label: 'Account' }, [
+      { name: 'parent_id', label: 'Parent', type: 'master_detail', reference: 'invoice' },
+    ]);
+
+    expect(puts).toHaveLength(1);
+    expect(savedFields(puts)[0].reference).toBe('invoice');
   });
 
 });

--- a/packages/app-shell/src/services/MetadataService.ts
+++ b/packages/app-shell/src/services/MetadataService.ts
@@ -188,6 +188,167 @@ function toObjectPayload(obj: ObjectDefinition, fields?: FieldMetadataPayload[])
 }
 
 /**
+ * Field types whose `reference` — the target object a relationship links to —
+ * `@objectstack/spec` requires to be present and non-empty.
+ *
+ * Re-measured for objectui#7714 against the 17.3.0 artifact by parsing
+ * `{ type, label: 'L' }` for every one of `FieldType`'s 49 declared members:
+ * exactly two are refused at path `reference`, both with code `custom`, and
+ * the other 47 are not refused at all on that minimal document.
+ *
+ * ⛔ Deliberately NOT "parse every field through `FieldSchema` before the PUT".
+ * That would refuse plugin-registered keys the SERVER accepts — measured on the
+ * installed 17.2.0, `x_plugin_thing` is `unrecognized_keys` to the schema while
+ * the server that sent it takes it back — which is the same reason
+ * {@link RETIRED_FIELD_KEYS} is a named list rather than a schema filter. This
+ * guard states one invariant; it is not a client-side revalidation of the
+ * document.
+ */
+const RELATIONSHIP_TYPES_REQUIRING_REFERENCE = ['lookup', 'master_detail'];
+
+/**
+ * Why THIS value cannot be a target, and what the contract does about it —
+ * both halves, because the four states differ on both.
+ *
+ * Measured for objectui#7714 on `@objectstack/spec` 17.3.0, at field level and
+ * again through `ObjectSchema`, which agree on every row:
+ *
+ * | `reference`     | the spec's verdict                                 |
+ * |-----------------|----------------------------------------------------|
+ * | absent          | refused — `custom` at `reference`                  |
+ * | `''`            | refused — `custom` at `reference`                  |
+ * | non-string      | refused — **`invalid_type`**, not a missing target |
+ * | whitespace-only | ⚠️ **accepted** — refused only by this writer      |
+ *
+ * A single "…and this one has none" would be wrong for two of the four. A
+ * non-string is not a field that HAS no target; it is a field whose value is
+ * the wrong KIND, and "pick the target object" is not the repair for
+ * `reference: 42`. And the 422 the other three branches promise is one this
+ * writer cannot deliver for the whitespace case — the spec would let that
+ * through — so that branch says what actually happens instead.
+ */
+function describeUnusableTarget(reference: unknown): string {
+  if (reference === undefined) {
+    return (
+      'and this one has none. `@objectstack/spec` requires it (17.3.0), so the server refuses ' +
+      'the whole object document with 422 `INVALID_METADATA` — which then blocks EVERY later ' +
+      'save of this object, not just this field.'
+    );
+  }
+  if (typeof reference !== 'string') {
+    return (
+      `and this one holds ${reference === null ? 'null' : `a ${typeof reference}`} instead of ` +
+      'an object name. `@objectstack/spec` refuses that (17.3.0) as `invalid_type` at path ' +
+      '`reference` — not as a missing target — so the server refuses the whole object document ' +
+      'with 422 `INVALID_METADATA`, which then blocks EVERY later save of this object.'
+    );
+  }
+  if (reference === '') {
+    return (
+      'and this one is empty. `@objectstack/spec` requires a non-empty value (17.3.0), so the ' +
+      'server refuses the whole object document with 422 `INVALID_METADATA` — which then blocks ' +
+      'EVERY later save of this object, not just this field.'
+    );
+  }
+  return (
+    'and this one is blank — whitespace names no object, so nothing could ever resolve it. ' +
+    '`@objectstack/spec` 17.3.0 ACCEPTS this value (measured, at field level and through ' +
+    '`ObjectSchema`), so the PUT would succeed and the failure would surface later and further ' +
+    'away — the record picker with no object to query, `$expand` with nothing to resolve. This ' +
+    'writer refuses it deliberately and says so (objectui#7714; upstream objectstack#16126).'
+  );
+}
+
+/**
+ * Refuse a relationship field whose target is unusable — BEFORE the PUT.
+ *
+ * ## The failure this closes, measured in a running designer
+ *
+ * `@objectstack/spec` 17.3.0 made `reference` a hard requirement on `lookup`
+ * and `master_detail` (a `custom` refinement at path `reference`, not an
+ * `unrecognized_keys` name refusal). At 17.2.0 the requirement was prose only —
+ * `{ type: 'lookup', label: 'L' }` parsed green at field level AND through
+ * `ObjectSchema` — so the designer was free to persist a target-less draft and
+ * did.
+ *
+ * objectui#7714 drove that against a real 17.3.0 backend rather than inferring
+ * it. Creating a `lookup` and leaving its target empty PUT the whole object and
+ * got `422 INVALID_METADATA` at `fields.<name>.reference`; the next edit — to a
+ * DIFFERENT, already-saved field — was refused identically, because the
+ * half-filled draft rides along in the same document. The author sees the later
+ * edit rendered as applied while the server has none of it, and the only escape
+ * that does not require noticing the lookup is a reload, which discards it.
+ * That is the cost of letting the draft leave the client: not one failed save,
+ * but every subsequent save of that object for the rest of the session.
+ *
+ * ## Why this raises instead of letting the server answer
+ *
+ * The maintainer's reconciliation (objectui#7122 ruled item 4, 2026-09-05) is
+ * that the incomplete draft stays in the client and is never PUT: an editing
+ * session's half-finished work belongs to the client, not to the metadata
+ * store. ⛔ Not the alternative of stripping the incomplete field out of the
+ * body while still reporting a successful save — that shows the author a field
+ * the server never received, the silent-drop shape objectstack#4001 closed.
+ *
+ * ## Why an exception, and why HERE
+ *
+ * Same mechanism, same reason and the same call site as the nameless-field and
+ * duplicate-name refusals below: it raises before the request, so a refused
+ * list issues NO PUT AT ALL, and the designer page runs its save inside a `try`
+ * whose `catch` already renders the message in the page's existing error
+ * surface. No new UI affordance is introduced — the author sees the same banner
+ * a nameless or duplicated field already produces.
+ *
+ * `MetadataFieldsPage` carries the sibling copy for the same reason it carries
+ * the sibling `toFieldsMap` and `carryOver`: the two writers convert different
+ * input types on different paths and neither owns the other's. Both are pinned,
+ * and each pin asserts the same four states so the copies cannot drift.
+ *
+ * ## The `.trim()` is a DECLARED DIVERGENCE, not an accident
+ *
+ * The predicate is `typeof reference === 'string' && reference.trim() !== ''`,
+ * which is STRICTER than the contract. Measured on 17.3.0, at field level and
+ * again through the whole document:
+ *
+ *   FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: '   ' })
+ *     => success = true
+ *   ObjectSchema.safeParse({ …, fields: { rel: { …, reference: '   ' } } })
+ *     => success = true
+ *
+ * — the spec ACCEPTS a whitespace-only target and this writer refuses it.
+ * objectui being stricter than the platform is a divergence, not a neutral
+ * choice, so it is STATED here rather than left to be inferred from a
+ * predicate: undeclared, it is indistinguishable from a bug and the next reader
+ * "fixes" it.
+ *
+ * ⭐ Kept, deliberately. A whitespace-only `reference` names no object — the
+ * spec's own `ObjectSchema.fields` key grammar (`/^[a-z_][a-z0-9_]*$/`) admits
+ * no whitespace-bearing name for it to resolve to — so admitting it buys the
+ * author nothing and only moves the identical failure past the guard, past the
+ * PUT and into a STORED document, where it surfaces with no field named and no
+ * save to attach the message to.
+ *
+ * ⚠️ Filed upstream as objectstack#16126 (open, `domain:spec`). If the spec
+ * trims, this writer's behaviour is unchanged and only the declaration retires
+ * — which is why the pins assert the writer's refusal separately from the
+ * spec's verdict.
+ */
+function assertRelationshipTargetPresent(
+  field: { type?: string; reference?: unknown },
+  fieldName: string,
+  writer: string,
+): void {
+  if (!RELATIONSHIP_TYPES_REQUIRING_REFERENCE.includes(String(field?.type))) return;
+  const reference = field?.reference;
+  if (typeof reference === 'string' && reference.trim() !== '') return;
+  throw new Error(
+    `${writer} cannot save the field \`${fieldName}\`: a \`${field?.type}\` field needs a ` +
+      `\`reference\` naming the object it links to, ${describeUnusableTarget(reference)} ` +
+      'Pick the target object, or change the field to a non-relationship type.',
+  );
+}
+
+/**
  * Key a list of field payloads by field NAME — the shape `ObjectSchema.fields`
  * requires (objectui#6240).
  *
@@ -251,6 +412,13 @@ function toFieldsMap(fields: FieldMetadataPayload[]): Record<string, FieldMetada
       );
     }
     seen.add(name);
+    // Third refusal at this door, and the reason it lives here rather than in
+    // `saveFields`: this is the ONE conversion every PUT of an object's fields
+    // passes through — `saveFields` for a field save, `toObjectPayload` for an
+    // object save that carries `existingFields` — so one guard covers both
+    // writers on this path. It raises before the request, so a refused list
+    // issues no PUT and the half-filled draft stays in the client.
+    assertRelationshipTargetPresent(field, name, '[MetadataService]');
     entries.push([name, field]);
   });
 

--- a/packages/plugin-designer/src/MetadataFieldsPage.retiredIndexed.test.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.retiredIndexed.test.tsx
@@ -45,13 +45,20 @@ import type { DesignerFieldDefinition } from '@object-ui/types';
  * The object document as it lives in the database — `owner_id` carries the
  * key an older console wrote, `indexes` carries the object-level surface that
  * actually builds indexes. A save must drop the first and keep the second.
+ *
+ * `owner_id` also carries a `reference`, which this file makes no claim about:
+ * it is a `lookup`, and objectui#7714 refuses a relationship field with no
+ * target BEFORE the PUT, so without one every save here would be refused by a
+ * guard that is not this file's subject. Supplying it is a declaration the
+ * fixture always owed — `{ type: 'lookup' }` with no target has never been a
+ * document `@objectstack/spec` 17.3.0 would accept.
  */
 const OBJECT_BODY = {
   name: 'probe_widget',
   label: 'Widget',
   fields: {
     name: { type: 'text', label: 'Name', required: true },
-    owner_id: { type: 'lookup', label: 'Owner', indexed: true, helpText: 'Record owner.' },
+    owner_id: { type: 'lookup', label: 'Owner', reference: 'account', indexed: true, helpText: 'Record owner.' },
     code: { type: 'text', label: 'Code', indexed: false },
   },
   indexes: [{ name: 'by_owner', fields: ['owner_id'] }],

--- a/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
@@ -47,10 +47,28 @@
  * `MetadataFieldsPage.specKeySystem.test.tsx` names no reference key: the two
  * cards of this fold are independently verifiable, and reverting one fix must
  * red only its own file.
+ *
+ * ## objectui#7714 — a half-filled lookup is HELD CLIENT-SIDE and never PUT
+ *
+ * The half-filled case below used to pin the opposite ("still saves, exactly as
+ * before"). `@objectstack/spec` 17.3.0 made `reference` a hard requirement on
+ * `lookup` / `master_detail`, and objectui#7714 drove the consequence in a
+ * running designer against a 17.3.0 backend: the target-less draft PUT the
+ * whole object, got `422 INVALID_METADATA` at `fields.<name>.reference`, and
+ * then blocked the NEXT edit too — to an entirely different, already-saved
+ * field — because the draft rides along in the same document.
+ *
+ * This page now refuses the list and issues **no PUT at all**. The claim is
+ * about THE PUT BODY, not the spec's verdict, which is why it pins at this
+ * repo's installed **17.2.0** (where the spec still accepts the draft) and does
+ * not wait on the pin bump (objectui#7122). ⛔ Not "strip the incomplete field
+ * and save the rest" — that shows the author a field the server never received,
+ * the silent-drop shape objectstack#4001 closed. `puts` staying EMPTY is the
+ * assertion that tells the two apart.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { FieldSchema } from '@objectstack/spec/data';
 import { MetadataClient } from '@object-ui/data-objectstack';
 import type { DesignerFieldDefinition } from '@object-ui/types';
@@ -62,9 +80,18 @@ import type { DesignerFieldDefinition } from '@object-ui/types';
  *   the read case: before this fix the designer looked for `referenceTo` and
  *   found nothing.
  *   `legacy_id` carries the misspelling a pre-fix designer build could have
- *   left behind. `carryOver` spreads the previous server def verbatim, so
- *   without a tombstone the key rides straight back out to the route that
- *   rejects it — and the object stays blocked forever.
+ *   left behind, ALONGSIDE the spec spelling. `carryOver` spreads the previous
+ *   server def verbatim, so without a tombstone the stale key rides straight
+ *   back out to the route that rejects it — and the object stays blocked
+ *   forever.
+ *
+ *   ⚠️ It carries BOTH keys deliberately (objectui#7714). Holding the target
+ *   ONLY under the retired spelling is a different and much narrower state:
+ *   the read door reads `raw.reference` alone, so such a field reaches the wire
+ *   with NO target at all, and objectui#7714's guard now refuses it. That state
+ *   has its own case at the bottom of this file rather than riding invisibly
+ *   inside the fixture every other test here shares — where it would have made
+ *   all of them assert the guard instead of what they are named for.
  */
 const OBJECT_BODY = {
   name: 'probe_widget',
@@ -72,7 +99,7 @@ const OBJECT_BODY = {
   fields: {
     name: { type: 'text', label: 'Name', required: true },
     owner_id: { type: 'lookup', label: 'Owner', reference: 'account', inlineHelpText: 'Record owner.' },
-    legacy_id: { type: 'lookup', label: 'Legacy', referenceTo: 'contact' },
+    legacy_id: { type: 'lookup', label: 'Legacy', reference: 'contact', referenceTo: 'contact' },
   },
 };
 
@@ -250,22 +277,23 @@ describe('objectui#6041 · WRITE — the save carries `reference`, never `refere
 
     const fields = savedFields();
     expect('referenceTo' in fields.legacy_id).toBe(false);
-    // Falsification: the field is still there and still a lookup — the strip
-    // removed a key, not the field.
+    // Falsification: the field is still there, still a lookup, and still
+    // pointing at its target — the strip removed a KEY, not the field and not
+    // the relationship.
     expect(fields.legacy_id.type).toBe('lookup');
+    expect(fields.legacy_id.reference).toBe('contact');
     expect(FieldSchema.safeParse(fields.legacy_id).success).toBe(true);
   });
 
-  it('a HALF-FILLED draft — type `lookup`, target left empty — still saves, exactly as before', async () => {
-    // The behavioural edge this card had to measure. The spec's prose calls
-    // `reference` "Required for relationship types", but that requirement is
-    // NOT enforced by the zod parse at 17.2.0: `{ type: 'lookup', label: 'L' }`
-    // parses green at field level AND through `ObjectSchema`. `undefined` is
-    // dropped by `JSON.stringify` under either spelling, so the wire bytes are
-    // byte-identical before and after this fix.
+  it('a HALF-FILLED draft — type `lookup`, target left empty — is REFUSED, and issues NO PUT', async () => {
+    // objectui#7714. Replaces the assertion that used to live here, rather
+    // than respelling it: the branch it pinned is the branch this card removes.
     //
-    // ⚠ This case would still pass on a revert, and says so deliberately: it
-    // exists to prove the rename did NOT newly block a draft.
+    // This page's caller is fire-and-forget (`void handleFieldsChange(next)`),
+    // so the refusal is observed the way the AUTHOR observes it — the page's
+    // error surface — and not as a rejected promise. The second assertion is
+    // the card: no request was made at all, which is what distinguishes the
+    // ruled fix from option B (strip the field, PUT the rest, report success).
     await renderPage();
     const next: DesignerFieldDefinition[] = [
       ...designerProps!.fields,
@@ -274,11 +302,160 @@ describe('objectui#6041 · WRITE — the save carries `reference`, never `refere
     await act(async () => {
       designerProps!.onFieldsChange!(next);
     });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('metadata-fields-page-error').textContent).toMatch(
+        /needs a `reference` naming the object it links to/,
+      ),
+    );
+    expect(puts).toEqual([]);
+  });
+
+  it('a COMPLETE lookup still saves — the guard refuses drafts, not relationships', async () => {
+    // Falsification: a guard that refused every `lookup` would satisfy the case
+    // above while deleting the feature, so the accepting half is asserted here.
+    await renderPage();
+    const next: DesignerFieldDefinition[] = [
+      ...designerProps!.fields,
+      { id: 'fld_ok', name: 'billing_id', label: 'Billing', type: 'lookup', referenceTo: 'invoice' },
+    ];
+    await act(async () => {
+      designerProps!.onFieldsChange!(next);
+    });
     await waitFor(() => expect(puts).toHaveLength(1));
 
-    const fields = savedFields();
-    expect('reference' in fields.half_id).toBe(false);
-    expect('referenceTo' in fields.half_id).toBe(false);
-    expect(FieldSchema.safeParse(fields.half_id).success).toBe(true);
+    expect(savedFields().billing_id.reference).toBe('invoice');
+  });
+
+  it('an UNTOUCHED stored lookup saves on an unrelated edit — the target comes from `prev`', async () => {
+    // The reason the guard reads the EMITTED entry rather than the designer's
+    // input. `owner_id`'s target lives in the stored document and reaches the
+    // wire through `carryOver`; a guard reading `designed.referenceTo` would
+    // refuse this save — a document the server accepts, blocked by the client —
+    // on every object that has ever had a lookup.
+    await renderPage();
+    await relabel('name', 'Full name');
+
+    expect(puts).toHaveLength(1);
+    expect(savedFields().owner_id.reference).toBe('account');
+  });
+
+  it('refuses every unusable target state, and PUTs none of them', async () => {
+    // objectui#7714, all four states plus `null`. The whitespace row is this
+    // page being deliberately STRICTER than the contract: measured on 17.3.0,
+    // `reference: '   '` parses green at field level and through `ObjectSchema`
+    // (upstream objectstack#16126). The refusal is this writer's own, declared
+    // in `MetadataFieldsPage.tsx`, and it does not depend on which spec is
+    // installed — which is why it is asserted here and the spec's verdict is
+    // not (at this repo's 17.2.0 pin the spec accepts every one of these).
+    //
+    // One render, re-driven per state: `renderPage` per iteration would leave
+    // several mounted pages in the document and `getByTestId` would then find
+    // more than one error surface.
+    await renderPage();
+    const base = designerProps!.fields;
+
+    for (const referenceTo of [undefined, '', '   ', 42, null]) {
+      const next = [
+        ...base,
+        { id: 'fld_x', name: 'x_id', label: 'X', type: 'lookup', referenceTo },
+      ] as DesignerFieldDefinition[];
+      await act(async () => {
+        designerProps!.onFieldsChange!(next);
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('metadata-fields-page-error').textContent,
+          `referenceTo=${JSON.stringify(referenceTo)} should be refused`,
+        ).toMatch(/needs a `reference` naming the object it links to/),
+      );
+      expect(puts, `referenceTo=${JSON.stringify(referenceTo)} must issue no PUT`).toEqual([]);
+    }
+  });
+
+  it('`master_detail` is guarded too — the invariant is relationship targets, not one key', async () => {
+    await renderPage();
+    const next: DesignerFieldDefinition[] = [
+      ...designerProps!.fields,
+      { id: 'fld_md', name: 'parent_id', label: 'Parent', type: 'master_detail' },
+    ];
+    await act(async () => {
+      designerProps!.onFieldsChange!(next);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('metadata-fields-page-error').textContent).toMatch(
+        /`master_detail` field/,
+      ),
+    );
+    expect(puts).toEqual([]);
+  });
+
+});
+
+/**
+ * objectui#7714 — a target stored ONLY under the retired spelling.
+ *
+ * Surfaced by this card's guard rather than sought: it is what made every save
+ * in this file refuse when the shared fixture held `legacy_id` that way.
+ *
+ * The state is real. `toDesignerField` reads `raw.reference` and nothing else,
+ * and `carryOver` strips `referenceTo` — so a field whose target lives only
+ * under the pre-objectui#6041 spelling reaches the wire with NO target. Before
+ * this card that saved at the installed 17.2.0, silently dropping the
+ * relationship, and answered `422 INVALID_METADATA` at `fields.<n>.reference`
+ * against a 17.3.0 backend, with no field named. It is now refused here, by
+ * name, before the request.
+ *
+ * ⚠️ This is a behaviour change BEYOND "a half-filled lookup is not PUT", and
+ * it is stated rather than absorbed: a save that used to go through (losing the
+ * target) is now refused. The refusal is the better half of a bad pair — a
+ * named field the author can repair, instead of a silently emptied
+ * relationship — but the underlying read-side gap is not this card's to fix and
+ * is filed separately. The `carryOver` docblock's claim that stripping
+ * `referenceTo` "costs nothing" because the target is re-emitted as `reference`
+ * holds only when the READ found one, which for this shape it does not.
+ */
+describe('objectui#7714 · a lookup whose target survives only as `referenceTo`', () => {
+  it('is refused by name, and issues no PUT', async () => {
+    const client = new MetadataClient({
+      baseUrl: 'http://localhost:3000',
+      fetch: (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        const method = (init?.method ?? 'GET').toUpperCase();
+        if (method === 'PUT') {
+          puts.push(JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>);
+          return json({ success: true, name: 'probe_widget' });
+        }
+        if (/\/meta\/object\/probe_widget(\?|$)/.test(url)) {
+          return json({
+            ...OBJECT_ENVELOPE,
+            item: {
+              ...OBJECT_BODY,
+              fields: {
+                name: { type: 'text', label: 'Name', required: true },
+                stale_id: { type: 'lookup', label: 'Stale', referenceTo: 'contact' },
+              },
+            },
+          });
+        }
+        return json({ items: [] });
+      }) as unknown as typeof fetch,
+    });
+    render(<MetadataFieldsPage objectName="probe_widget" client={client} />);
+    await waitFor(() => expect(designerProps).not.toBeNull());
+
+    // A plain relabel of an UNRELATED field — the author never touched the
+    // lookup, which is what makes the refusal worth stating.
+    await act(async () => {
+      designerProps!.onFieldsChange!(
+        designerProps!.fields.map((f) => (f.name === 'name' ? { ...f, label: 'Full name' } : f)),
+      );
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('metadata-fields-page-error').textContent).toMatch(/`stale_id`/),
+    );
+    expect(puts).toEqual([]);
   });
 });

--- a/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.specKeyReference.test.tsx
@@ -373,22 +373,27 @@ describe('objectui#6041 · WRITE — the save carries `reference`, never `refere
     }
   });
 
-  it('`master_detail` is guarded too — the invariant is relationship targets, not one key', async () => {
-    await renderPage();
-    const next: DesignerFieldDefinition[] = [
-      ...designerProps!.fields,
-      { id: 'fld_md', name: 'parent_id', label: 'Parent', type: 'master_detail' },
-    ];
-    await act(async () => {
-      designerProps!.onFieldsChange!(next);
-    });
-
-    await waitFor(() =>
-      expect(screen.getByTestId('metadata-fields-page-error').textContent).toMatch(
-        /`master_detail` field/,
-      ),
-    );
-    expect(puts).toEqual([]);
+  it('does NOT pin a `master_detail` refusal — this page cannot reach one (measured)', () => {
+    // objectui#7714. The guard's list carries `master_detail` for parity with
+    // the sibling writer, where it IS reachable (`FieldMetadataPayload['type']`
+    // is an unconstrained `string`, and `MetadataService.saveObject` refuses a
+    // target-less master-detail today — pinned in
+    // `MetadataService.specKeyReference.test.ts`).
+    //
+    // Through THIS page it is unreachable, and the reason is worth stating
+    // rather than leaving as an empty spot: `toDesignerType` maps every type
+    // outside `DESIGNER_FIELD_TYPES` to `'text'`, so a stored `master_detail`
+    // arrives at the guard already flattened. Measured on this page:
+    //
+    //   stored { type: 'master_detail', reference: 'invoice' }
+    //     => designer field type "text"
+    //     => WIRE { "type": "text", "label": "Parent", "reference": "invoice" }
+    //
+    // So a refusal assertion here would be a PHANTOM — green because the guard
+    // never sees a `master_detail`, not because it handled one. The flattening
+    // is a separate defect (objectui#8060) and this case is a marker, so
+    // that when it is fixed the missing coverage is visible rather than assumed.
+    expect(true).toBe(true);
   });
 
 });

--- a/packages/plugin-designer/src/MetadataFieldsPage.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.tsx
@@ -212,6 +212,17 @@ function fromDesignerField(
  * `{ type, label: 'L' }` for every one of `FieldType`'s 49 declared members:
  * exactly these two are refused at path `reference`, both with code `custom`,
  * and the other 47 are not refused at all on that minimal document.
+ *
+ * ⚠️ `master_detail` is RECORDED-DEFENSIVE on this page rather than reachable,
+ * and says so instead of reading as coverage: `toDesignerType` maps every type
+ * outside `DESIGNER_FIELD_TYPES` to `'text'`, and `master_detail` is not in
+ * that set — so a stored master-detail field arrives here already flattened and
+ * this branch never fires. Measured for objectui#7714: a stored
+ * `{ type: 'master_detail', reference: 'invoice' }` reaches the wire as
+ * `{ type: 'text', reference: 'invoice' }`. That flattening is its own defect,
+ * filed from this card as objectui#8060; the entry stays so the two writers state ONE invariant
+ * and so this page is already correct when the flattening is fixed. The sibling
+ * in `MetadataService.ts` has it reachable today, through `saveObject`.
  */
 const RELATIONSHIP_TYPES_REQUIRING_REFERENCE = ['lookup', 'master_detail'];
 

--- a/packages/plugin-designer/src/MetadataFieldsPage.tsx
+++ b/packages/plugin-designer/src/MetadataFieldsPage.tsx
@@ -202,6 +202,145 @@ function fromDesignerField(
 }
 
 /**
+ * Field types whose `reference` — the target object a relationship links to —
+ * `@objectstack/spec` requires to be present and non-empty. The sibling of
+ * `MetadataService`'s list, kept here for the same reason this file keeps its
+ * own `toFieldsMap` and `carryOver`: the two writers convert different input
+ * types on different paths and neither owns the other's.
+ *
+ * Re-measured for objectui#7714 against the 17.3.0 artifact by parsing
+ * `{ type, label: 'L' }` for every one of `FieldType`'s 49 declared members:
+ * exactly these two are refused at path `reference`, both with code `custom`,
+ * and the other 47 are not refused at all on that minimal document.
+ */
+const RELATIONSHIP_TYPES_REQUIRING_REFERENCE = ['lookup', 'master_detail'];
+
+/**
+ * Why THIS value cannot be a target, and what the contract does about it —
+ * both halves, because the four states differ on both. The sibling copy in
+ * `MetadataService.ts` is word-for-word the same, and both pins assert all four
+ * states so the copies cannot drift silently.
+ *
+ * Measured for objectui#7714 on `@objectstack/spec` 17.3.0, at field level and
+ * again through `ObjectSchema`, which agree on every row:
+ *
+ * | `reference`     | the spec's verdict                                 |
+ * |-----------------|----------------------------------------------------|
+ * | absent          | refused — `custom` at `reference`                  |
+ * | `''`            | refused — `custom` at `reference`                  |
+ * | non-string      | refused — **`invalid_type`**, not a missing target |
+ * | whitespace-only | ⚠️ **accepted** — refused only by this writer      |
+ *
+ * A single "…and this one has none" would be wrong for two of the four: a
+ * non-string is a value of the wrong KIND rather than an absent target, so
+ * "pick the target object" is not the repair for `reference: 42`; and the 422
+ * the other branches promise is one this page cannot deliver for the
+ * whitespace case, because the spec would let that through.
+ */
+function describeUnusableTarget(reference: unknown): string {
+  if (reference === undefined) {
+    return (
+      'and this one has none. `@objectstack/spec` requires it (17.3.0), so the server refuses '
+        + 'the whole object document with 422 `INVALID_METADATA` — which then blocks EVERY later '
+        + 'save of this object, not just this field.'
+    );
+  }
+  if (typeof reference !== 'string') {
+    return (
+      `and this one holds ${reference === null ? 'null' : `a ${typeof reference}`} instead of `
+        + 'an object name. `@objectstack/spec` refuses that (17.3.0) as `invalid_type` at path '
+        + '`reference` — not as a missing target — so the server refuses the whole object document '
+        + 'with 422 `INVALID_METADATA`, which then blocks EVERY later save of this object.'
+    );
+  }
+  if (reference === '') {
+    return (
+      'and this one is empty. `@objectstack/spec` requires a non-empty value (17.3.0), so the '
+        + 'server refuses the whole object document with 422 `INVALID_METADATA` — which then blocks '
+        + 'EVERY later save of this object, not just this field.'
+    );
+  }
+  return (
+    'and this one is blank — whitespace names no object, so nothing could ever resolve it. '
+      + '`@objectstack/spec` 17.3.0 ACCEPTS this value (measured, at field level and through '
+      + '`ObjectSchema`), so the PUT would succeed and the failure would surface later and further '
+      + 'away — the record picker with no object to query, `$expand` with nothing to resolve. This '
+      + 'writer refuses it deliberately and says so (objectui#7714; upstream objectstack#16126).'
+  );
+}
+
+/**
+ * Refuse a relationship field whose target is unusable — BEFORE the PUT.
+ *
+ * ## The failure this closes, measured in a running designer
+ *
+ * `@objectstack/spec` 17.3.0 made `reference` a hard requirement on `lookup`
+ * and `master_detail` (a `custom` refinement at path `reference`). At 17.2.0
+ * the requirement was prose only — `{ type: 'lookup', label: 'L' }` parsed
+ * green at field level AND through `ObjectSchema` — so this page persisted
+ * target-less drafts freely.
+ *
+ * objectui#7714 drove that against a real 17.3.0 backend rather than inferring
+ * it: creating a `lookup` and leaving its target empty PUT the whole object and
+ * got `422 INVALID_METADATA` at `fields.<name>.reference`, and the next edit —
+ * to a DIFFERENT, already-saved field — was refused identically, because the
+ * half-filled draft rides along in the same document. The author sees that
+ * later edit rendered as applied while the server has none of it. The cost of
+ * letting the draft leave the client is not one failed save; it is every
+ * subsequent save of that object for the rest of the session.
+ *
+ * The maintainer's reconciliation (objectui#7122 ruled item 4, 2026-09-05) is
+ * that the incomplete draft stays in the client and is never PUT. ⛔ Not the
+ * alternative of stripping the incomplete field from the body while still
+ * reporting a save — that shows the author a field the server never received,
+ * the silent-drop shape objectstack#4001 closed.
+ *
+ * This raises inside the caller's save `try`, so the message lands in the
+ * page's existing error surface — the same banner a nameless or duplicated
+ * field already produces, and no new UI affordance.
+ *
+ * ## The `.trim()` is a DECLARED DIVERGENCE, not an accident
+ *
+ * The predicate is `typeof reference === 'string' && reference.trim() !== ''`,
+ * which is STRICTER than the contract. Measured on 17.3.0, at field level and
+ * again through the whole document:
+ *
+ *   FieldSchema.safeParse({ type: 'lookup', label: 'L', reference: '   ' })
+ *     => success = true
+ *   ObjectSchema.safeParse({ …, fields: { rel: { …, reference: '   ' } } })
+ *     => success = true
+ *
+ * — the spec ACCEPTS a whitespace-only target and this page refuses it.
+ * objectui being stricter than the platform is a divergence, not a neutral
+ * choice, so it is STATED rather than left to be inferred from a predicate;
+ * undeclared, it is indistinguishable from a bug and the next reader "fixes" it.
+ *
+ * ⭐ Kept, deliberately. A whitespace-only `reference` names no object — the
+ * spec's own `ObjectSchema.fields` key grammar (`/^[a-z_][a-z0-9_]*$/`) admits
+ * no whitespace-bearing name for it to resolve to — so admitting it buys the
+ * author nothing and only moves the identical failure past the PUT and into a
+ * stored document, where it surfaces with no field named.
+ *
+ * ⚠️ Filed upstream as objectstack#16126 (open). If the spec trims, this page's
+ * behaviour is unchanged and only the declaration retires — which is why the
+ * pins assert this writer's refusal separately from the spec's verdict.
+ */
+function assertRelationshipTargetPresent(
+  field: { type?: string; reference?: unknown },
+  fieldName: string,
+  writer: string,
+): void {
+  if (!RELATIONSHIP_TYPES_REQUIRING_REFERENCE.includes(String(field?.type))) return;
+  const reference = field?.reference;
+  if (typeof reference === 'string' && reference.trim() !== '') return;
+  throw new Error(
+    `${writer} cannot save the field \`${fieldName}\`: a \`${field?.type}\` field needs a `
+      + `\`reference\` naming the object it links to, ${describeUnusableTarget(reference)} `
+      + 'Pick the target object, or change the field to a non-relationship type.',
+  );
+}
+
+/**
  * Key the designer's field list by field NAME — the shape `ObjectSchema.fields`
  * requires — and refuse the three lists that shape cannot carry
  * (objectui#6489).
@@ -288,7 +427,14 @@ function toFieldsMap(
     const prev = Object.prototype.hasOwnProperty.call(prevFields, name)
       ? prevFields[name]
       : undefined;
-    entries.push([name, fromDesignerField(designed, prev)]);
+    const emitted = fromDesignerField(designed, prev);
+    // Checked on the EMITTED entry, not on `designed`: `fromDesignerField`
+    // merges the carried-over server definition underneath the designer's
+    // values, so a field the author never touched can legitimately take its
+    // target from `prev`. Reading `designed.referenceTo` alone would refuse
+    // every one of those — a save the server accepts, blocked by the client.
+    assertRelationshipTargetPresent(emitted, name, '[MetadataFieldsPage]');
+    entries.push([name, emitted]);
   });
 
   return Object.fromEntries(entries);


### PR DESCRIPTION
Fixes #7714

A half-filled relationship field now stays in the client and is never PUT. Both metadata writers refuse a `lookup` / `master_detail` whose `reference` is missing, empty, blank or not a string, and they refuse it **while the wire `fields` map is being built** — so a refused list issues no request at all.

## Step 1 — the dogfood, which the ruling made the first step

The ruling carried a confidence gap verbatim: nobody had driven "half-filled lookup → save → later saves blocked" *in a running designer*. Driven now, and it **reproduces**.

Environment: objectstack `main` (`2756e07d`) serving `@objectstack/spec` **17.3.0**, showcase app on its own port; client is this repo's `main` (`8d40c18a7`, spec pin **17.2.0**), `apps/console` vite dev with `/api` proxied to that backend. Surface: metadata-admin's object designer, `/apps/setup/metadata/object/OBJECT_NAME`. Auto-save is on by default. All interactions ref-targeted; the oracle is captured wire traffic, not DOM.

**Add field → Lookup, target left empty:**

```
PUT /api/v1/meta/object/OBJECT_NAME?mode=draft
  fields=[ ..., title:text, lookup:lookup(NO reference key) ]
RESP 422
  {"error":"[invalid_metadata] object/OBJECT_NAME failed spec validation: 1 issue
    — fields.lookup.reference [custom]","code":"INVALID_METADATA", ...}
```

**Then an unrelated later save — rename the pre-existing `title` field:**

```
PUT /api/v1/meta/object/OBJECT_NAME?mode=draft   (the half-filled lookup rides along)
RESP 422   — same issue, fields.lookup.reference
```

Server truth afterwards: `title`'s label is unchanged. The designer renders the rename as applied while the server has none of it. Reproduced twice on fresh loads.

**Scope of the wedge, measured rather than assumed:** the refused PUT stores nothing, so this is not permanent corruption of stored metadata — it is per editing session. A page reload clears it, and discards every unsaved edit made since. That reload is the only escape that does not require the author to notice the lookup.

⭐ Per triage's promote condition, this reproduction promotes the card to `p1`.

## Step 2 — the fix

The guard sits at each writer's `toFieldsMap`, the same call site as the existing nameless-field and duplicate-name refusals. In `MetadataService` that one door covers both writers on the path — `saveFields` and `toObjectPayload` (so `saveObject` too). It raises before the request, and the designer page already runs its save inside a `try` whose `catch` renders the message in the existing error surface, so no new UI affordance is introduced.

⛔ Not option B. "Strip the incomplete field and report a save" would show the author a field the server never received — the objectstack#4001 silent-drop shape. The pins assert `puts` is **empty**, which is what tells the two apart.

⛔ Not option C. Nothing is contested upstream; 17.3.0 closed a declared-not-enforced gap deliberately.

## Step 3 — what was re-derived vs. taken from `9c1a1ac5f`

`9c1a1ac5f` was read as a starting point. Everything factual in it was re-measured here against the built 17.3.0 artifact before being carried:

| claim | re-derived how | verdict |
|---|---|---|
| exactly `lookup` + `master_detail` require a target | parsed `{ type, label: 'L' }` for all 49 members of `FieldType` | holds — both `custom` at `reference`; the other 47 not refused at all |
| the spec accepts a whitespace-only `reference` | field level and through `ObjectSchema`, on 17.3.0 | holds — ACCEPT at both levels |
| non-string is `invalid_type`, not a missing target | same | holds (`42` and `null`) |
| absent and `''` are `custom` at `reference` | same | holds |
| objectstack#16126 exists and describes this | read the issue | open, `domain:spec`, matches |

Carried forward deliberately, as the card asked: the `.trim()` predicate and its **declared divergence** (objectui is stricter than the contract; stated in both docblocks, the changeset and the pins, pointing at objectstack#16126), and the four-state accuracy of the refusal message.

Re-derived differently from `9c1a1ac5f`:

- **Only this card's hunks.** `9c1a1ac5f` also carries `block-types`, `field-types`, `placeholders`, `cli/known-schema-types` and more — those are #7122's parity reconciliation, not this card's, and are not here.
- **The `master_detail` cases were wrong about reachability, in both files.** See below — this is the one place the inherited shape did not survive measurement.
- **Cross-writer drift** is now closed by both pins asserting the same four states, rather than by a prose claim that the copies are word-for-word.
- **The docblocks cite the dogfood** rather than the gate's *documentation* of the failure class. "Blocks every subsequent save" is measured here, not quoted.

Extracting a shared helper into `@object-ui/types/internal/...` was considered and **not** done: it is a new package export (entry guards, eager-closure ceiling, unreferenced-source gate) and both files already carry deliberate sibling copies of `toFieldsMap` and `carryOver` for the stated reason that neither writer owns the other's input. Flagged here rather than decided silently.

## ⚠️ Behaviour changes BEYOND "a half-filled lookup is not PUT" — stated, not absorbed

The card asked for these explicitly. There is one, and it is real:

**A lookup whose target is stored only under the retired `referenceTo` spelling is now refused.** The read door reads `raw.reference` alone and `carryOver` strips `referenceTo`, so such a field reaches the wire with no target. Before this change that save went through at 17.2.0, **silently dropping the relationship**; against 17.3.0 it was a 422 with no field named. It is now refused by name, before the request. That is the better half of a bad pair, and it is still a behaviour change: a save that used to succeed now does not. Pinned with its own case, and the underlying read-side gap is filed as **#8058** rather than fixed here.

No other accept/refuse behaviour moves. Specifically: a complete lookup still saves; a lookup whose target merely has surrounding whitespace still saves and is **passed through unchanged** (the guard trims to test, never to rewrite — silently normalising would be a second undeclared divergence hiding inside the first); non-relationship fields are untouched.

## Two fixtures were never spec-legal, and are now declared

`MetadataFieldsPage.specKeyReference.test.tsx`'s `legacy_id` and `MetadataFieldsPage.retiredIndexed.test.tsx`'s `owner_id` were both `lookup` with no target. They are declared rather than worked around, and objectui#6041's strip assertion is unchanged and still falsifiable (`legacy_id` now carries both keys, so a regressed strip still turns it red, and the target's survival is asserted too).

## The pin is not flipped green

`MetadataService.specKeyReference.test.ts`'s half-filled case used to assert "still saves, exactly as before". It is **replaced**, not respelled — the branch it pinned is the branch this card removes — and it now states the new truth: refusal **and** an empty `puts`. Same in the designer's sibling pin. Both file headers say so.

The claim is about **the PUT body**, not the spec's verdict, which is why it pins at this repo's installed 17.2.0 (where the spec still accepts the draft) and does not wait on #7122.

⚠️ One honesty note in the pin: at 17.2.0 the spec accepts absent, `''` **and** `'   '` alike, so "the spec accepts `'   '`" is true here for a trivial reason and measures nothing. The divergence is therefore asserted against **this writer** (whose refusal does not depend on the installed spec), plus the one discriminating spec reading 17.2.0 does carry — a non-string IS refused, as `invalid_type`, so the schema is being consulted and blankness simply is not among the things it tests.

## Ablation — the guards are load-bearing

Run from the committed state; both call sites commented out; mutation confirmed on disk by anchored counts (injected marker 1, removed call 0, both blob hashes changed) before any test ran.

```
guards ablated : Tests  12 failed | 19 passed (31)
guards restored: Tests  31 passed (31)
```

Restore proven by state — `git diff HEAD` empty, both files' disk hashes equal to their HEAD blobs, no marker left in the tree — not by an exit code.

## Gates

All at `3ef27b32f` — the final commit, with no commit after them — exit codes captured before any pipe (redirect first, then read `$?`), and verdicts quoted from each gate's own output line rather than from a bare exit status.

| gate | result |
|---|---|
| `pnpm build` | exit 0 — `Tasks: 43 successful, 43 total` |
| `turbo run type-check --continue` | exit 0 — `Tasks: 81 successful, 81 total` |
| `pnpm test --shard=1/4` | exit 0 — 648 files, 8492 passed, 1 skipped |
| `pnpm test --shard=2/4` | exit 0 — 648 files, 8550 passed |
| `pnpm test --shard=3/4` | exit 0 — 647 files, 8512 passed, 8 skipped |
| `pnpm test --shard=4/4` | exit 0 — 647 files, 7730 passed |
| **all four shards** | **2590 files, 33284 passed, 9 skipped, 0 failed** |
| `packages/app-shell` (full, separately) | exit 0 — 632 files, 6089 passed, 1 skipped |
| `packages/plugin-designer` (full, separately) | exit 0 — 18 files, 147 passed |
| eslint, both packages' own scripts, on every changed file | exit 0 — 0 errors (1 pre-existing `no-explicit-any` warning at `MetadataService.ts:810`, byte-identical on `main`) |
| `check:designer-field-key-parity` | exit 0 — `designer-field-key-parity: OK` |
| `check:control-bytes` | exit 0 — 6458 files scanned |
| `check:spec-symbols` / `check:spec-floors` | exit 0 |
| `check-changeset-no-major` | exit 0 — "No changeset declares a `major` bump" |
| `check-changeset-presence` | exit 0 — 1 changeset for 2 released packages |

Changeset is **`minor`** with the breaking semantics stated, per `AGENTS.md`: objectui's major tracks `@objectstack`'s, so objectui's own breaking changes ship as minor.

## ⚠️ What this PR does NOT fix — read before assuming the card closes the failure

The dogfood reproduced through **metadata-admin's `ResourceEditPage`**, and that is a **third** writer, which neither guard here covers: it serialises the draft and calls `client.save` directly, never routing through either `toFieldsMap`. Neither writer this PR guards is mounted anywhere in this repo — both are published API for consumers of `@object-ui/*` — which is exactly why the reproduction had to go through the third one.

Re-running the same reproduction against this branch confirms it: the console's PUT and its 422 are byte-identical to `main`. This PR changes nothing on that surface, in either direction.

Porting the guard there is not mechanical: that page's live Zod issues are **deliberately advisory** (ruled and pinned, objectui#4306 / objectui#6980), and its only save-gate term, `inspectorBlocking`, is stamped with the current selection so it expires when the author selects another field — which is precisely the measured step 2. Filed as **#8057** with the measurements and the conflict, for a decision rather than a guess.

## Findings filed (not fixed here)

- **#8057** — metadata-admin's designer still PUTs a half-filled lookup; the surface the dogfood actually wedged.
- **#8058** — a lookup's target is lost when stored under the retired `referenceTo` spelling; the carry-over docblock claims the strip "costs nothing".
- **#8060** — `MetadataFieldsPage` silently rewrites any field type outside `DESIGNER_FIELD_TYPES` to `text` on save. Measured: a stored `{type:'master_detail', reference:'invoice'}` reaches the wire as `{type:'text', reference:'invoice'}`; `vector` flattens the same way. This is why the designer's `master_detail` branch is unreachable and is declared as recorded-defensive with a marker case, instead of pinned green as a phantom check.

⛔ Draft on purpose, per the dispatch: not flipped ready, not enqueued, no auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E)_