### PR TITLE
fix(plugin-charts): honour series[].type override on a dataKey-shaped series too

### DIFF
--- a/.changeset/7681-chart-series-type-override-dataKey.md
+++ b/.changeset/7681-chart-series-type-override-dataKey.md
@@ -1,0 +1,21 @@
+---
+'@object-ui/plugin-charts': patch
+---
+
+Fix: a chart series' `type` override (`ChartDataSeries.type`, objectui#6121) is now
+honoured when the series array is written in the internal `dataKey` binding, not only
+the `name` binding (objectui#7681).
+
+`ChartRenderer`'s `isInternalShaped` fast path (introduced by #2945 to fix a different
+bug — a `name`-shaped `series` shadowing the normalized `dataKey`-shaped one) took the
+raw authored array untouched whenever every entry already carried `dataKey`, bypassing
+`normalizeSeries` — the only place `type` is translated to the renderer-internal
+`chartType`. So an author who wrote `series: [{ dataKey: 'revenue' }, { dataKey:
+'margin', type: 'line' }]` — both keys independently valid on `ChartDataSeriesSchema` —
+got neither the override nor a combo chart, silently.
+
+`ChartRenderer` now always takes the series array through the one normalization layer
+(objectui#2880 S1) instead of special-casing the `dataKey` shape around it.
+`normalizeSeries` is a no-op on a well-formed internal-shaped entry (it round-trips
+every key the internal series shape declares), so no existing internal caller
+(`DashboardRenderer`, `ObjectView`, the dataset path) changes behaviour.

--- a/.changeset/7681-chart-series-type-override-dataKey.md
+++ b/.changeset/7681-chart-series-type-override-dataKey.md
@@ -1,10 +1,11 @@
 ---
-'@object-ui/plugin-charts': patch
+'@object-ui/plugin-charts': minor
 ---
 
 Fix: a chart series' `type` override (`ChartDataSeries.type`, objectui#6121) is now
 honoured when the series array is written in the internal `dataKey` binding, not only
-the `name` binding (objectui#7681).
+the `name` binding (objectui#7681) — the same sentence #2945 shipped for the other
+dialect.
 
 `ChartRenderer`'s `isInternalShaped` fast path (introduced by #2945 to fix a different
 bug — a `name`-shaped `series` shadowing the normalized `dataKey`-shaped one) took the
@@ -16,6 +17,25 @@ got neither the override nor a combo chart, silently.
 
 `ChartRenderer` now always takes the series array through the one normalization layer
 (objectui#2880 S1) instead of special-casing the `dataKey` shape around it.
-`normalizeSeries` is a no-op on a well-formed internal-shaped entry (it round-trips
-every key the internal series shape declares), so no existing internal caller
-(`DashboardRenderer`, `ObjectView`, the dataset path) changes behaviour.
+
+**Breaking on unmodified documents, deliberately — this changes rendered output.** A
+chart authored with a `dataKey`-shaped series carrying a `type` override used to render
+one family for every series; it now renders the mix the author actually described (the
+card's own regression case: two bars become one bar and one line).
+
+**Two more effects on the delivered key set for a `dataKey`-shaped series array**,
+undisclosed until now — `normalizeSeries` is a no-op on a well-formed entry, but these
+two cases were never well-formed under the old fast path either:
+
+- An i18n `label` written as a `{ en, zh-CN, … }` record on a `dataKey`-shaped entry was
+  previously forwarded as that raw object; it is now resolved to a plain string (the
+  first string-valued limb), matching what a `name`-shaped series already got from
+  `normalizeChartSchema`.
+- A `dataKey`-shaped entry whose `dataKey` does not resolve to a non-empty string (and
+  has no `name` to fall back to) was previously forwarded as-is; it is now dropped from
+  the delivered series array, matching what a `name`-shaped series with no usable key
+  already got.
+
+No existing well-formed internal caller (`DashboardRenderer`, `ObjectView`, the dataset
+path) changes behaviour — every series entry those callers construct already carries a
+non-empty string `dataKey` and a string `label`.

--- a/packages/core/src/utils/chart-presentation.ts
+++ b/packages/core/src/utils/chart-presentation.ts
@@ -105,13 +105,19 @@ function labelText(v: unknown): string | undefined {
  * One authored `ChartSeries`, minus its `name` — i.e. everything about it that
  * is presentation rather than membership.
  *
- * `type` is narrowed to the three families that COMPOSE on one cartesian plot,
- * because this array reaches the renderer already speaking the internal shape
- * (`ChartRenderer` forwards a `dataKey`-shaped array untouched, so
- * `normalizeChartSchema`'s own identical narrowing never sees it). Without the
- * narrowing a `type: 'pie'` would not merely be inert — it would count as a
- * family disagreement in `effectiveChartFamily`, flip the whole chart into a
- * combo, and then draw that series as a bar anyway.
+ * `type` is narrowed to the three families that COMPOSE on one cartesian plot.
+ * Without the narrowing a `type: 'pie'` would not merely be inert — it would
+ * count as a family disagreement in `effectiveChartFamily`, flip the whole
+ * chart into a combo, and then draw that series as a bar anyway.
+ *
+ * `ChartRenderer` now narrows the same way for every series it receives,
+ * `dataKey`-shaped or not (objectui#7681 fixed the fast path that used to
+ * forward a `dataKey`-shaped array straight through, so `normalizeChartSchema`'s
+ * own identical narrowing never saw it) — so this module is no longer that
+ * narrowing's only line of defense. It stays anyway:
+ * `AuthoredSeriesPresentation.chartType` is a typed, narrower field
+ * (`'bar' | 'line' | 'area'`) this module's own callers read directly, and the
+ * double narrowing downstream is idempotent.
  */
 export function seriesPresentation(raw: Record<string, unknown>): AuthoredSeriesPresentation {
   const out: AuthoredSeriesPresentation = {};

--- a/packages/plugin-charts/src/ChartRenderer.specSeries.test.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.specSeries.test.tsx
@@ -32,6 +32,15 @@ vi.mock('recharts', async () => {
 });
 
 import { ChartRenderer } from './ChartRenderer';
+// `ChartRenderer` lazy-loads its implementation
+// (`React.lazy(() => import('./AdvancedChartImpl'))`); every assertion in
+// this file waits for the real plot to appear PAST that boundary. Import it
+// eagerly, with the SAME specifier, so its cost lands in the import phase
+// rather than inside `waitFor`'s 1000ms budget — under full-suite parallel
+// load the dynamic import alone can exceed that budget, which read as this
+// file's OWN tests flaking rather than a race with the module loader
+// (AGENTS.md "测试纪律(flaky 测试:先找竞态,别调超时)").
+import './AdvancedChartImpl';
 
 afterEach(cleanup);
 
@@ -97,6 +106,31 @@ describe('ChartRenderer — the spec `series` shape', () => {
           series: [{ dataKey: 'revenue' }, { dataKey: 'margin', chartType: 'line' }],
           isAnimationActive: false,
         }}
+      />,
+    );
+    expect(await plotted(container)).toEqual({ bars: 1, lines: 1 });
+  });
+
+  it('honours `series[].type` on an internal-shape (`dataKey`) entry too (objectui#7681)', async () => {
+    // #7681: the `isInternalShaped` fast path took the raw array whenever
+    // every entry already carried `dataKey`, bypassing `normalizeSeries` —
+    // the only place `type` is translated to the renderer-internal
+    // `chartType`. An author who wrote the documented `dataKey` binding AND
+    // the documented `type` override together (both valid independently on
+    // `ChartDataSeriesSchema`) got neither: predicted/observed 2 bars / 0
+    // lines before the fix. `type` on a `dataKey` entry is off the
+    // `ChartRendererProps` TS union (`as any` matches the schema's own
+    // acceptance, not this internal prop type — see the docblock).
+    const { container } = render(
+      <ChartRenderer
+        schema={{
+          type: 'chart',
+          chartType: 'bar',
+          data: DATA,
+          xAxisKey: 'month',
+          series: [{ dataKey: 'revenue' }, { dataKey: 'margin', type: 'line' }],
+          isAnimationActive: false,
+        } as any}
       />,
     );
     expect(await plotted(container)).toEqual({ bars: 1, lines: 1 });

--- a/packages/plugin-charts/src/ChartRenderer.tsx
+++ b/packages/plugin-charts/src/ChartRenderer.tsx
@@ -58,8 +58,15 @@ export interface ChartRendererProps {
      * the same key, so declaring only the internal shape here made
      * `series: [{ name: 'total' }]` a type error on an author who was writing
      * the protocol correctly — and, until #2945, one whose chart also rendered
-     * blank. `normalizeChartSchema` translates; an array that already speaks the
-     * internal shape passes through untouched.
+     * blank. `normalizeChartSchema` translates every entry, of either shape,
+     * uniformly — see the normalization comment in the component body.
+     *
+     * This TS union stays as declared (the `dataKey` arm has no `type`, the
+     * `name` arm has no `chartType`): at RUNTIME `type` is honoured on a
+     * `dataKey`-shaped entry too (objectui#7681, both keys are independently
+     * optional on `ChartDataSeriesSchema`), because JSON metadata never goes
+     * through this TS type. Widening the arm to match is a separate,
+     * public-face decision this fix does not make.
      */
     series?: Array<
       | { dataKey: string; label?: string; variant?: 'current' | 'comparison'; opacity?: number; dashArray?: string; chartType?: 'bar' | 'line' | 'area'; stack?: string; yAxis?: 'left' | 'right'; color?: string }
@@ -121,15 +128,30 @@ export const ChartRenderer: React.FC<ChartRendererProps> = ({ schema, onChartCli
     // the per-series family override went with it (#2945). Every other spec
     // binding has a distinct name (`xAxis` vs `xAxisKey`) and so was unaffected.
     //
-    // Prefer the raw array only when it ALREADY speaks the internal shape, which
-    // keeps every internal caller byte-for-byte. Otherwise take the normalized
-    // one — `normalizeSeries` reads `dataKey ?? name` per entry, so it is also
-    // the right answer for an array that mixes the two.
+    // #2945's fix took the raw array whenever it ALREADY spoke the internal
+    // shape (every entry has `dataKey`), on the theory that an internal
+    // producer's array should pass through untouched — but that same fast path
+    // skips `normalizeSeries` entirely, and `normalizeSeries`'s
+    // `str(raw.chartType) ?? str(raw.type)` is the ONLY place the declared
+    // per-series override (`ChartDataSeries.type`, objectui#6121) is translated
+    // to the renderer-internal `chartType`. So an author who writes the
+    // documented `dataKey` binding *and* the documented `type` override
+    // together — both valid on `ChartDataSeriesSchema` independently — got
+    // NEITHER honoured (objectui#7681).
+    //
+    // `normalizeSeries` is a no-op on a well-formed internal-shaped entry: it
+    // round-trips every key the internal arm of `ChartRendererProps.series`
+    // declares (`dataKey`/`label`/`chartType`/`variant`/`opacity`/`dashArray`/
+    // `stack`/`yAxis`/`color`) unchanged. So always taking the normalized array
+    // is not a second read site for `type` (AGENTS.md #0.1) — it is routing
+    // EVERY entry, of either shape, through the ONE normalization layer
+    // (objectui#2880 S1) instead of special-casing one shape around it, which
+    // is what made the fast path a second, un-normalized path in the first
+    // place. `authored` remains only as the fallback for a series
+    // `normalizeSeries` could not translate at all (no `dataKey` and no `name`
+    // on any entry).
     const authored = Array.isArray(schema.series) ? schema.series : undefined;
-    const isInternalShaped = authored?.length
-      ? authored.every((s) => !!s && typeof s === 'object' && 'dataKey' in s)
-      : false;
-    let series: any[] | undefined = (isInternalShaped ? authored : spec.series) ?? authored;
+    let series: any[] | undefined = spec.series ?? authored;
     let xAxisKey = schema.xAxisKey ?? spec.xAxisKey;
     let config = schema.config;
 


### PR DESCRIPTION
Fixes #7681

## What changed

`ChartRenderer`'s `isInternalShaped` fast path (added by #2945 to fix a different bug —
a `name`-shaped author `series` shadowing the normalized `dataKey`-shaped one) took the
raw authored series array untouched whenever every entry already carried `dataKey`. That
bypassed `normalizeSeries` entirely — the ONE place `str(raw.chartType) ?? str(raw.type)`
translates the declared per-series override (`ChartDataSeries.type`, objectui#6121) to
the renderer-internal `chartType`. So an author who wrote the documented `dataKey`
binding *and* the documented `type` override together — both independently valid on
`ChartDataSeriesSchema` — got neither the override nor a derived combo chart, silently.

`ChartRenderer` now always takes the series array through the one normalization layer
(objectui#2880 S1) instead of special-casing the `dataKey` shape around it:

```ts
const authored = Array.isArray(schema.series) ? schema.series : undefined;
let series: any[] | undefined = spec.series ?? authored;
```

`normalizeSeries` is a no-op on a well-formed internal-shaped entry — it round-trips
every key the internal arm of `ChartRendererProps.series` declares (`dataKey`/`label`/
`chartType`/`variant`/`opacity`/`dashArray`/`stack`/`yAxis`/`color`) unchanged — so this
is not a second read site for `type` (AGENTS.md #0.1); it routes every entry, of either
shape, through the same translation `normalizeChartSchema` already applies to a
`name`-shaped series.

The `ChartRendererProps.series` TS union is left as declared (no `type` on the `dataKey`
arm) — widening it is a separate, public-face decision this fix does not make (see the
updated docblock in the diff).

**This is a `minor`, user-visible change** (see Changeset below): it changes rendered
output on unmodified documents (two bars become a bar and a line — the card's own
regression case), and it changes the delivered key set for a `dataKey`-shaped series
array in two more ways — an i18n `label` record is now resolved to a string, and an
entry with no resolvable `dataKey` is now dropped rather than forwarded as-is. Precedent:
#2945 shipped `minor` (`f1c04b6`) for the identical sentence on the `name` dialect.

## Why

- The declared `ChartDataSeries.type` (objectui#6121 ruling: "declared because the
  renderer already READS it") was enforced on one binding dialect and silently dropped
  on the other — `declared !== enforced` on a published member.
- Triage (issue comment 5548858850) ruled Option A: route the fast path through the one
  normalization layer, rather than Option B (a second `type` read site in
  `AdvancedChartImpl` — the AGENTS.md #0.1 fallback pattern) or Option C (narrowing the
  declaration, which contradicts the declared "both shapes" series contract).

## Verification

- Re-verified every line number and the probe table against current `main` at the time
  (`0caacca373f`). PR #8034 (`ed4a2f1`, merged 12:36Z that day) moved chart-family
  resolution for the CHART-LEVEL `chartType`/`type` (objectui#7401's surface) — a
  different key on a different surface from this card's per-SERIES `type`. It does not
  change this bug's premise: `normalizeChartSchema.ts`'s `str(raw.chartType) ??
  str(raw.type)` (now at line 361, was line 244 in triage's reading) remains the only
  read of `raw.type` in the package, and `AdvancedChartImpl.tsx` still has zero reads of
  `s.type` (only `s.chartType`).
- Reused the card's probe table verbatim as the regression pin in
  `ChartRenderer.specSeries.test.tsx`, plus the `name`-dialect control (already present
  in that file). All 3 probe-table rows, plus the pre-existing mixed-shape and
  Tremor-adapter cases, pass.
- Reverse-verified: reinstated the old `isInternalShaped` fast path in place, re-ran —
  exactly the new probe test went red at `{bars: 2, lines: 0}` (matching the card's
  pre-registered prediction), the other 5 cases in the file stayed green. Restored the
  fix (confirmed byte-identical to the pre-mutation version) and re-confirmed green.
- Checked #2945's shadowing defect cannot reintroduce: the fix routes name-shaped and
  mixed-shape series through `spec.series` exactly as #2945 already did (unchanged
  behaviour for those two cases, still pinned by the existing tests in the same file);
  only the `dataKey`-only case changes, and only in that it now honours `type` too.
- `pnpm --filter @object-ui/plugin-charts test`: 47 files / 434 tests green. Two
  container-load flakes were hit along the way in files this PR does not touch
  (`ObjectChart.elementDataSource.test.tsx`, `ChartRenderer.catalogRender-6939.test.tsx`,
  `ObjectChart.datasetMeasureLabel.test.tsx` — a different subset each run) — all three
  reproduce the documented pattern in AGENTS.md "测试纪律" (Suspense-fallback-stuck under
  parallel transform load) and pass cleanly in isolation. The new test's own file
  (`ChartRenderer.specSeries.test.tsx`) hit the same pattern once before this PR added an
  eager `import './AdvancedChartImpl'` to it (matching the file's own lazy-load
  specifier), after which it was green across every full-suite rerun.
- `pnpm --filter @object-ui/plugin-charts type-check`: clean, after building the
  package's dependency closure (`pnpm --filter '@object-ui/plugin-charts^...' build`).
- `check:control-bytes`, `check:published-tsconfig-exclude`, `changeset:check`: all
  green. `check:sdui-registration-pins` and `check:published-dist` need a full
  console / near-full-monorepo build respectively (unrelated packages this diff does not
  touch) — not run locally given the cost; this diff adds no export, no registration
  entry, and no package.json field change, so the regression risk on either is null.
  Left for CI.

## Review round

Contract review flagged two issues, both fixed, mechanism unchanged:

1. **Changeset bump `patch` → `minor`**, with the two undisclosed delivered-key-set
   effects (i18n `label` resolution, dropped-unresolvable-`dataKey` filtering) added to
   the changeset body — see "Why" above.
2. **Stale docblock** — `packages/core/src/utils/chart-presentation.ts:108-115` gave, as
   the reason for `seriesPresentation`'s own `type` narrowing, "`ChartRenderer` forwards
   a `dataKey`-shaped array untouched, so `normalizeChartSchema`'s own identical
   narrowing never sees it" — false after this PR. Corrected the docblock; `
   seriesPresentation`'s logic is untouched (comment-only change), the double narrowing
   stays and is idempotent (verified: rebuilt `@object-ui/core` clean, reran the full
   `plugin-charts` suite green).

Confirmed still correct and unchanged: #2945 cannot regress (the new form prefers the
normalized array strictly more often); `normalizeSeries` is a no-op on every
well-formed internal entry; declining to widen the `dataKey` TS arm (Clause-② stays
`no`) — routing through `normalizeSeries` only filters/narrows, never accepts more.

## Changeset

`.changeset/7681-chart-series-type-override-dataKey.md` — `@object-ui/plugin-charts: minor`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_