### PR TITLE
docs(react-runtime): compile every README snippet and leave the UNGATED_DOCS ledger

### DIFF
--- a/packages/react-runtime/README.md
+++ b/packages/react-runtime/README.md
@@ -29,7 +29,15 @@ npm install @object-ui/react-runtime
 ## Usage
 
 ```tsx
+import type { ComponentType } from 'react';
 import { ReactRunner } from '@object-ui/react-runtime';
+
+// Whatever your app already has to hand: the values it injects into the runtime
+// scope, and the sink it reports errors to.
+declare const ObjectGrid: ComponentType;
+declare const useAdapter: () => unknown;
+declare const data: unknown;
+declare const report: (error: Error) => void;
 
 <ReactRunner
   code={`
@@ -60,15 +68,22 @@ import { ReactRunner } from '@object-ui/react-runtime';
 declaration, `()`, or `class`:
 
 ```tsx
-<p>hi</p>                              // ✅ bare JSX
-function Page() { return <p/>; }       // ✅ function declaration
-() => <p>hi</p>                        // ✅ arrow expression
-class Page extends React.Component {}  // ✅ class
+// `React` is always in the runtime scope, so a source never imports it.
+declare const React: typeof import('react');
 
-const Page = () => <p/>;               // ❌ exports nothing — see below
-const Page = () => <p/>;
-export default Page;                   // ✅ export it explicitly
+<p>hi</p>                                   // ✅ bare JSX
+function PageFunction() { return <p/>; }    // ✅ function declaration
+() => <p>hi</p>                             // ✅ arrow expression
+class PageClass extends React.Component {}  // ✅ class
+
+const PageNotExported = () => <p/>;         // ❌ exports nothing — see below
+const PageExported = () => <p/>;
+export default PageExported;                // ✅ export it explicitly
 ```
+
+Each line above is a **separate source** — they are alternatives, not one file.
+They carry different names only so the block compiles as a single program; the
+rule is about the shape the source *starts with*, never about the name.
 
 The `const Page = …` form is the one authors reach for most, and it does **not**
 get the implicit export. It used to render a blank page with no error anywhere;
@@ -81,6 +96,11 @@ There is no module resolver. `import x from 'y'` compiles to a `require('y')`
 that reads `scope.import`:
 
 ```tsx
+import { ReactRunner } from '@object-ui/react-runtime';
+
+declare const code: string;
+declare const dateFns: Record<string, unknown>;
+
 <ReactRunner code={code} scope={{ import: { 'date-fns': dateFns } }} />
 ```
 
@@ -116,6 +136,13 @@ Build the scope with `useMemo` (or hoist it to module scope) and keep its
 dependencies stable.
 
 ```tsx
+import { useMemo, type ComponentType } from 'react';
+import { ReactRunner } from '@object-ui/react-runtime';
+
+declare const src: string;
+declare const ObjectGrid: ComponentType;
+declare const data: unknown;
+
 // ❌ new object every render — the page remounts and loses its useState
 <ReactRunner code={src} scope={{ ObjectGrid, data }} />
 
@@ -134,6 +161,9 @@ just transpile/eval failures. New inputs clear it and recompile.
 
 ```ts
 import { generateElement, transform, type Scope } from '@object-ui/react-runtime';
+
+declare const code: string;
+declare const scope: Scope;
 
 transform(code)                  // JSX/TS → JS (classic runtime, imports → require)
 generateElement(code, scope)     // transpile + eval → ReactElement | null (throws, see above)

--- a/scripts/check-doc-snippet-types.mjs
+++ b/scripts/check-doc-snippet-types.mjs
@@ -739,8 +739,6 @@ const UNGATED_DOCS = {
     '3 parse diagnostic(s) — blocks fenced `ts` that are bare object literals or elided bodies',
   'packages/providers/README.md':
     '7 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2741x1 — candidate real defects, un-triaged',
-  'packages/react-runtime/README.md':
-    '25 undefined-name diagnostic(s) — blocks continue an earlier block, or use ambient names the page never defines; plus TS2813x1 TS2814x1 — candidate real defects, un-triaged',
 };
 
 // ── Fence scanning ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of #5174 — batch 23 of the `UNGATED_DOCS` burn-down.

`packages/react-runtime/README.md` leaves the ledger and all 5 of its ts/tsx blocks
now compile against the built types. The gate file's only change is the two lines
of that one entry.

## Notation, read this first

This repository has measured that GitHub's body sanitizer deletes tag-shaped
fragments even inside backticks and fenced blocks. So JSX elements and generic
parameters are spelled out in words below — "a ReactRunner element", "a
ComponentType" — rather than in their real angle-bracket form. The README itself
carries the real spellings; this page does not.

## Concurrency

`main` moved under this batch **twice**, and both moves were absorbed by merging
(never rebasing, never force-pushing).

1. **Batch 22's PR #8063 merged**, along with #8064, #8061, #8056 and #8054,
   taking `origin/main` from `65ce8c576` to `a81336390`. #8056 moves
   `packages/fields` source — package source, so the built types this corpus is
   judged against move with it — so the forced build, every gate, every probe
   reading and every test were re-run on the merged head.
2. **#8066 merged**, taking `origin/main` to `295804a63`. It touches only
   `scripts/check-skill-examples.mjs` and its test: **no package source, so no
   rebuild was owed** — that is a measurement, not an omission. Its test *is* a
   reader of the gate file, so the reader suite was re-run on this head.

All 9 open pull requests' file lists were read over the REST files endpoint and
each count reconciled against that PR's own `changed_files`: 8064/3, 8063/2,
8061/2, 7749/4, 7685/67, 7058/24, 7054/2, 7053/2, 5400/1058. #5400's 1058-file
list was paged to exhaustion (11 pages) because the endpoint pages at 100 and a
truncated list renders as a confident absence. **No open PR touches
`packages/react-runtime/README.md`.**

One neighbour worth naming, not an exclusion: **PR #5400** (the release PR) edits
`packages/react-runtime/package.json` and its CHANGELOG. That manifest is what
`scripts/__tests__/doc-version-claims.test.ts` compares this README's peer line
against, so a version bump there is the one open change that could move a pin on
this page. This diff does not touch that line.

`Live E2E (informational)` is red on every branch today for an upstream reason
(objectui#7990 / objectstack#16186), not because of this diff.

## Ledger arithmetic

Base row measured at `origin/main` `295804a63` bytes (probe M0'), branch row at
`8cefaa894`. Both rows MEASURED by a real gate run, never computed.

| reading | base `295804a63` | branch `8cefaa894` |
|:--|--:|--:|
| `UNGATED_DOCS` entries | 15 | **14** |
| covered documents | 212 | 213 |
| …of them holding a ts/tsx block | 110 | 111 |
| covered blocks | 714 | 719 |
| blocks to compile | 556 | 561 |
| declared fragments | 158 | **158** (zero new) |
| semantic failures | 0 | 0 |
| self-imports judged (`check:readme-exports`) | 490 | 492 |

Programmatic diff of the two `UNGATED_DOCS` objects — both imported as OBJECTS,
never diffed as text: removed = `['packages/react-runtime/README.md']`,
added = `[]`, reason-changed = `[]`, key order preserved for survivors = true.
`git diff --numstat` on the gate file against `origin/main` is exactly `0 2`.
On the branch: react-runtime entries **0**, `packages/NAME/README.md` entries
**13** (from 14), control `'packages/auth/README.md'` **1**.

The strictness region — the `Fence scanning` banner line to EOF, 1178 lines on
both sides — hashes to
`f46b5662ba336f026bca3a0003e0b7979789d48d0291fa5760be7d23c8ed0160` on
`origin/main` and on the branch. Re-measured here on the dispatched base and on
the current merge base, not inherited; it is the value batches 15 through 22
recorded.

**The ledger's reason string for this page was STALE, continuing the streak.**
It claimed "25 undefined-name diagnostic(s) … plus TS2813x1 TS2814x1". The
measurement reads **20** in the undefined-name family (TS2304x13, TS18004x6,
TS2552x1) and 27 in total, and the string names neither the TS2300x4 nor the
TS2686x1 population at all.

## Census and the rung that decided

Re-taken on this batch's own base through the gate's exported `analyze()` /
`compileSnippets()`, one document un-gated at a time, over every non-excluded
ledger candidate.

**Rung 1 does NOT decide on blocks alone: react-runtime TIES on 5 blocks with
plugin-list, core and plugin-kanban. Rung 1's second term (diagnostics) settles
it — 27 against the next-best 8. Rungs 2 and 3 were never reached.**

| document | blocks | diagnostics | distinct codes | codes |
|:--|--:|--:|--:|:--|
| **packages/react-runtime/README.md** | **5** | **27** | **7** | TS2304x13 TS18004x6 TS2300x4 TS2552x1 TS2686x1 TS2813x1 TS2814x1 |
| packages/plugin-list/README.md | 5 | 8 | 3 | TS7006x4 TS2304x3 TS2657x1 |
| packages/core/README.md | 5 | 6 | 2 | TS2304x5 TS2339x1 |
| packages/plugin-kanban/README.md | 5 | 6 | 2 | TS1109x5 TS1011x1 |
| packages/plugin-ai/README.md | 4 | 8 | 3 | TS2304x4 TS2322x3 TS2552x1 |
| packages/providers/README.md | 4 | 8 | 2 | TS2304x7 TS2741x1 |
| packages/plugin-charts/README.md | 4 | 6 | 1 | TS1109x6 |
| packages/plugin-editor/README.md | 4 | 6 | 1 | TS1109x6 |
| packages/plugin-map/README.md | 4 | 2 | 2 | TS1005x1 TS2304x1 |
| packages/plugin-markdown/README.md | 4 | 2 | 2 | TS1005x1 TS1109x1 |
| packages/fields/README.md | 2 | 3 | 2 | TS7031x2 TS2307x1 |
| packages/plugin-tree/README.md | 1 | 3 | 2 | TS1005x2 TS1109x1 |

Assumption **A1 is CONFIRMED** — every block total, diagnostic total and
per-code figure matches batch 22's census exactly, including react-runtime's 7
distinct codes, the figure batch 21 reported as moving with the compiler
program's shape.

Exclusions re-verified against GitHub on this base, not inherited: the root
`README.md` is not a `packages/NAME/README.md`; `packages/layout/README.md` was
batch 22's and has now merged, so it is out of the ledger entirely rather than
merely reserved; `packages/auth/README.md` is held by open draft PR #7685;
`packages/plugin-chatbot/README.md` is deferred by the earlier ruling.

## The debt, and what each repair did

**The 7 codes are 3 families, not 7.** The triage matters more than the count.

**1. Ambient demo names the page never defines (TS2304x13, TS18004x6, TS2552x1 —
20 of the 27).** These are the values a reader injects into the runtime scope
(`ObjectGrid`, `data`, `useAdapter`), the source strings (`code`, `src`), the
error sink (`report`) and the module object (`dateFns`). TS18004 is **not** JSX,
as the dispatch wondered — the harness parses every block as TSX regardless of
the fence label, so a JSX-bearing `ts` fence is never a parse error. TS18004 is
the *object shorthand* diagnostic, raised by the `scope` object literals whose
shorthand keys named nothing. They are now `declare const` bindings typed to
what each is used as. TS2552 is the same family with a near-miss attached:
`useAdapter` was being matched against the DOM lib's `GPUAdapter`.

**2. Three blocks used a ReactRunner element without importing it.** The Imports
block and both halves of the scope block now self-import it, which is why this
diff hands `check:readme-exports` two more self-imports to judge (490 to 492)
rather than fewer.

**3. The Accepted-source-shapes block declared `Page` four ways — and this is
where the ledger's "candidate real defects" claim is retired.** That block is a
**catalogue of alternative source strings**: bare JSX, a function declaration, an
arrow expression, a class, then the `const` form that does not get the implicit
export and the same form exported explicitly. They are alternatives, never one
program — but the harness gives each block its own virtual module, so all four
`Page` declarations landed in one scope. TS2300x4 is that collision, and
**TS2813 and TS2814 — the two the ledger called "candidate real defects,
un-triaged" — are strictly downstream of it.** Probe P4b proves this: recreate
the function-versus-class name collision alone and both codes come straight
back. **Neither is a defect in the documented API.** TS2686 was the same block's
`React` reference resolving to the UMD global once the block became a module.

The four shapes now carry distinct names, and a new prose paragraph says why —
that each line is a separate source, that they are named apart only so the block
compiles as one program, and that the rule is about the shape the source *starts
with*, never about the name. `React` is bound with a `declare const` typed as the
react module, matching what the runtime actually injects, so the page does not
tell a reader to import React into a source string when the README already says
`React` is always present.

**No README-versus-shipped-type contradiction was found.** The props table
(`code`, `scope`, `fallback`, `onError`) and the Lower-level API comments were
checked against the built `dist/index.d.ts` and all match, so ruling 5 was not
reached and nothing was filed under it.

No `packages/**` source touched, no public type widened, no lenient alias added,
no gate loosened, and **no new fragment marker: declared fragments stay at 158.**

## Probes — two base measurements and nine probes, each predicted in writing first

Predictions were written to the scratchpad before any probe ran and were not
amended: `5174-b23-PREDICTIONS.md` (md5 `89e912d0714e2a2b8ee91d541e388338`) at
implementation commit `2a7fb4884` with a clean tree, plus two pinned addenda for
a re-aim and a re-measurement (`…-P4b.md`, md5
`07cc94d60e06f0e21cb5a8436b0281c7`; `…-M0prime.md`, md5
`e3187919f47ce2c04360e5c4da7be7a8`). Every mutation is proven on disk by
occurrence counts of both the injected and the deleted text plus `git
hash-object` against the HEAD blob; every restore is proven by an empty `git diff
HEAD`; every leg runs under a `trap … EXIT INT TERM` with absolute paths,
restoring with `git checkout HEAD --` against an absolute path rather than a bare
checkout from the index. **No dist preflight is owed, and that is a measurement
rather than an omission:** both mutated paths are read from disk by the gate
itself, so no rebuild sits between a mutation and its reading.

| probe | mutation | predicted | observed |
|:--|:--|:--|:--|
| **M0** | both files at dispatched base `65ce8c576` | exit 0, 211 covered / 16 ungated / 549 to compile, bound empty | exactly that |
| **M0b** | base `check:readme-exports` | 489 real, 0 fabricated | exactly that |
| **M0'** | both files at current merge base `295804a63` | exit 0, 212 / 15 / 556; readme-exports 490 | exactly that |
| **P1** | ledger entry restored ALONE | exit 0, coverage falls back to 211 / 16 / 549; gate byte-identical to base | exactly that (`9beae7db…` both sides) |
| **P2** | README restored ALONE | exit 1, 27 diagnostics over 7 codes | exactly that; **but "549 of 554 judged" was WRONG** — see below |
| **P3** | delete the React binding in the catalogue block | exit 1, TS2686 UMD global | exactly that |
| **P4** | rename one const back to collide | TS2300 + TS2813 + TS2814 | **FALSIFIED — TS2451x2** (redeclare block-scoped); see below |
| **P4b** | recreate the function-versus-class collision | exit 1, TS2300 + TS2813 + TS2814 | **TS2814 + TS2813 returned; TS2300 did NOT** — see below |
| **P5** | delete the Imports block's self-import | exit 1, TS2304 for the runner name | exactly that |
| **P6** | fabricate a self-import name | readme-exports 490 real / 1 fabricated | exactly that, naming `packages/react-runtime/README.md:99` |
| **P7** | wrong prop key on a ReactRunner element | exit 1, props mismatch naming ReactRunnerProps | **TS2769**, not the predicted TS2322 family; see below |
| **P8** | delete the Scope-typed binding | exit 1, TS2304 for that name | exactly that |

**Three predictions were wrong, and all three are reported rather than smoothed.**

- **P2's judged count.** I predicted "549 of 554 judged", assuming the restored
  page's blocks would drop out of the judged set. They do not: nothing refuses
  them, so the gate judges all 554 and **5 fail**. The load-bearing half — exit
  1, exactly 27 diagnostics over exactly 7 codes on this page — held.
- **P4 was falsified outright.** Renaming one `const` to collide with another
  `const` gives TS2451 "Cannot redeclare block-scoped variable" — correct
  TypeScript, and evidence my aim was wrong rather than the triage claim. P4b
  re-aimed at the function-versus-class collision, which is what the base page
  actually had, and was predicted in writing before it ran.
- **P4b was half wrong too, and the half that failed is informative.** TS2813 and
  TS2814 came straight back, which is the claim that mattered. TS2300 did **not**
  — a two-way function/class collision does not raise it; the base page's
  TS2300x4 needed all four `Page` declarations. So the ledger's two "candidate
  real defects" are proven downstream of the collision, and TS2300 is proven to
  be the *four-way* catalogue shape specifically.
- **P7 returned TS2769**, not the predicted TS2322/TS2353/TS2739 family, because
  ReactRunner is a class component so a bad prop fails overload resolution. Same
  meaning, different code: the message names `ReactRunnerProps` and says
  "Property 'scopes' does not exist … Did you mean 'scope'?", which is what makes
  the point — **the composition is genuinely CHECKED against the shipped props,
  not merely parsed.**

## Gates — all at `8cefaa894`, clean tree, nothing pushed after

Exit codes captured by redirect-then-capture, before any pipe; each row quotes
the gate's own verdict line. The build was forced first
(`pnpm exec turbo run build --filter=./packages/* --concurrency=2 --force`, 39
successful / 0 cached) and again inside the provenance gate (43 successful / 0
cached); every dist-sensitive gate was then re-run on that force-built dist. Note
the invocation: bare `turbo` is not on PATH in this container, so `pnpm exec
turbo` is what ran.

- `pnpm check:doc-snippets` exit 0 — "Scanned 227 document(s): 213 covered (111 of them hold a ts/tsx block), 14 ungated" / "Covered blocks: 719 — 561 to compile, 158 declared fragment(s)" / "Root bound: no block imports a specifier that resolves only through this repository's ROOT manifest" / "Semantic phase: 561 of 561 block(s) judged, 0 failed" / "Every covered documentation snippet compiles against the built types."
- `pnpm check:doc-fences` exit 0 — "every TypeScript block in 227 document(s) is fenced ts/tsx/typescript"
- `pnpm check:readme-exports` exit 0 — "492 of them self-imports judged (492 real, 0 wrong-path, 0 fabricated)"
- `pnpm check:doc-types` exit 0 — "Every documented component type is registered."
- `node scripts/check-doc-links.mjs` exit 0 — "Links are valid across 17 scan roots."
- `pnpm check:doc-example-readers` exit 0 — "OK 80 documented symbol(s), 3947 call site(s)"
- `pnpm check:control-bytes` exit 0 — "OK (scanned 6473 tracked text file(s); skipped 85 binary)"
- `node scripts/check-node-esm-load.mjs --force-build` exit 0 — "Provenance leg: 37 of 37 gradable entries were built by this tree." **Green on its first run**, so no gate had to be re-run over a replayed sibling cache. Its three ERR_UNKNOWN_FILE_EXTENSION lines are the gate's own by-design entries.
- `pnpm type-check:scripts` exit 0
- `node scripts/check-changeset-presence.mjs` exit 0 — "2 file(s) changed, 0 of them published source of a package the release covers … no changeset is owed." No `skip-changeset` label applied: this repository declares with an empty-frontmatter changeset rather than that label, and the presence gate says none is owed, so nothing was labelled at all by this seat.
- `node scripts/check-governed-queue-guard.mjs --test` on both paths exit 0 — "NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched"
- Owning package: `pnpm exec vitest run packages/react-runtime/` — "Test Files 1 passed (1) / Tests 19 passed (19)"; `pnpm --filter @object-ui/react-runtime type-check` exit 0, its output echoing `tsc --noEmit && tsc -p tsconfig.test.json`, so the test tsconfig is genuinely included and the script really ran.
- Beyond the gate, a manual control-byte scan of both changed paths with `grep -naP` over the C0/DEL ranges found nothing (exit 1, zero output bytes).

**Lint, with the narrowing declared and its three evidence items.** `pnpm lint`
here is `turbo run lint` per package, so the repository-wide sweep is CI's run;
the narrowed run over exactly this diff is
`pnpm exec eslint --no-inline-config --format json` on both paths — 2 entries,
**0 errors**. eslint's own answer for the README is "File ignored because no
matching configuration was supplied", so the real lint surface of this diff is
the one `.mjs` at 0 errors and 0 warnings. (1) The population eslint would
otherwise judge is **4364 files** by its own count. (2) That run exits 1 with
**93 errors and 12171 warnings**, and the touched files carry **0 of them** —
measured, and reported rather than smoothed, because a reader must not mistake
the narrowing for a green repository. (3) `eslint.config.js` declares no
`project`, `projectService` or `parserOptions.project` (grep count 0), so
type-aware linting is off and this diff cannot move the verdict on any untouched
file.

## Readers of the changed paths

Derived with `git grep -l` on both paths on this head, not guessed — **17 test
files, 607 tests, all green** in one run.

- `scripts/__tests__/doc-version-claims.test.ts` — the one live pin that names this README. It asserts the page's `react ^18.0.0 || ^19.0.0` prose line restates `peerDependencies.react` verbatim. **This diff does not touch that line**, and A3 is confirmed: exactly one live reader, as predicted.
- `scripts/check-doc-snippet-types.mjs` — the gate itself, which now COMPILES this page instead of excusing it; P1 proves the entry was what suppressed it.
- `scripts/check-readme-exports.mjs` — reads this README's self-imports, proven live by P6. This diff ADDS two, so it hands that gate more to check than it had.
- Readers of the GATE file additionally exercised: `check-doc-snippet-types`, `check-doc-component-types`, `check-doc-expression-carriage`, `check-doc-fence-languages`, `check-links-workflow`, `check-readme-exports`, `check-skill-examples`, `component-node-vocabulary-7434` and `ci-cd-pipeline-doc` under `scripts/__tests__/`, the five `packages/types/src/__tests__/` doc-surface suites, `packages/plugin-gantt/src/readme-navigation-example.test.ts`, `packages/react/src/__tests__/LazyPluginLoader.jsdocExample.test.ts` and `examples/schema-catalog/test/component-fixture-declared-keys.test.ts`.

## Out of scope

Nothing was filed this batch. The one wall this burn-down keeps meeting — the
root bound refusing a package's own declared peer — did **not** bite here:
`react` is a declared peer of `@object-ui/react-runtime`, but it is mapped
anyway because other workspace packages declare it under `dependencies`, so the
bound never refused it and this page needed no stand-in for it. objectui#8059
already records that trade-off and was not refiled.

This PR is a DRAFT and stays a draft: this seat does not flip ready, does not
enable auto-merge, and touches no labels or assignee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_