### PR TITLE
fix(types): declare `wrapperClass` on Switch, Textarea, DatePicker, Select and List schemas, on both faces (objectui#7722)

### DIFF
--- a/.changeset/7722-wrapper-class-five-more.md
+++ b/.changeset/7722-wrapper-class-five-more.md
@@ -1,0 +1,45 @@
+---
+'@object-ui/types': minor
+---
+
+Declare `wrapperClass` on `SwitchSchema`, `TextareaSchema`, `DatePickerSchema`,
+`SelectSchema` and `ListSchema`, on both faces (objectui#7722 — the read-driven
+residue outside objectui#6938's batch, one key over five more types).
+
+Each of `renderers/form/switch.tsx`, `textarea.tsx`, `date-picker.tsx`,
+`select.tsx` and `renderers/data-display/list.tsx` reads `schema.wrapperClass`
+onto its wrapper element, and neither the TypeScript interface (`form.ts`,
+`data-display.ts`) nor the zod mirror (`zod/form.zod.ts`,
+`zod/data-display.zod.ts`) declared the key. The reads compiled through
+`BaseSchema`'s index signature (objectui#5155) and the values parsed through
+`.passthrough()`, admitted unexamined. The same key, on the same class of read,
+is declared on `CheckboxSchema` (objectui#6938), `FileUploadSchema` and
+`FilterBuilderSchema` (objectui#6150); these five were left out only because
+their doc pages never listed it.
+
+**minor, not patch — the published face gains five members.** objectui#6938 and
+objectui#7295 graded a one- or two-key residue `patch` because "the accept set
+only widens toward what already renders"; that reasoning still describes the
+VALUE dimension here, but this change is the batch shape of objectui#6150
+(`minor`), and it is dispatched under the contract-review tier precisely because
+it widens the PUBLISHED surface: five schemas each gain a member of the shipped
+`.d.ts` and of the mirror's `.shape` that an editor completes, an annotation
+checks and a validator enforces. Two verdicts move, in opposite directions:
+
+- **Nothing well-typed stops validating or compiling.** Key membership was never
+  narrow: `[key: string]: any` admitted the key on the TS face and
+  `.passthrough()` admitted it on the zod face, so every document that carried a
+  string `wrapperClass` parsed green before and parses green now, with the value
+  surviving the parse exactly as before.
+- **A non-string `wrapperClass` is now REFUSED at the key** on these five mirrors
+  (`{ type: 'switch', wrapperClass: 42 }` parsed green before; it is refused now,
+  at `wrapperClass`). That is enforcement of the declared type, not a new
+  capability, but it is a behaviour change for a document that carried a
+  wrong-typed value under one of these five names — a value the renderer would
+  have interpolated into the class string as text.
+
+Keys outside the five are untouched: an undeclared key of any type is still
+admitted unexamined on all five mirrors, pinned per mirror with a control key
+the renderer does not read. `InputSchema.wrapperClass`, declared on the TS face
+only, is a recorded row of the parity ledger (`UnmirroredDeclared`) and stays
+there; the new sweep pin carries it as a self-expiring exemption.

--- a/packages/types/src/__tests__/wrapper-class-declared-7722.test.ts
+++ b/packages/types/src/__tests__/wrapper-class-declared-7722.test.ts
@@ -1,0 +1,360 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Five more renderers read `schema.wrapperClass` that their shipped types never
+ * declared (objectui#7722), plus a SWEEP that turns red on the next one.
+ *
+ * ## The defect
+ *
+ * `switch.tsx`, `textarea.tsx`, `date-picker.tsx`, `select.tsx` and
+ * `data-display/list.tsx` each read `schema.wrapperClass` onto a wrapper element,
+ * and neither face of the shipped contract declared the key on `SwitchSchema`,
+ * `TextareaSchema`, `DatePickerSchema`, `SelectSchema` or `ListSchema`: not the
+ * TypeScript interface, not the zod mirror. Each read compiled through
+ * `BaseSchema`'s index signature (objectui#5155) and each value parsed through
+ * `.passthrough()`, admitted unexamined. The same key, on the same class of read,
+ * IS declared on `CheckboxSchema` (objectui#6938), `FileUploadSchema` and
+ * `FilterBuilderSchema` (objectui#6150).
+ *
+ * Re-derived on `951fa8e0d` before anything was edited: `git grep
+ * schema\.wrapperClass -- packages/components/src` finds NINE readers; four of
+ * them (`checkbox`, `file-upload`, `filter-builder`, `input`) sit on types that
+ * declare the key on the TS face, and five do not, on either face. That is the
+ * batch below — the card's five, measured, not inherited.
+ *
+ * ## The sixth asymmetry, deliberately NOT in the batch
+ *
+ * `InputSchema` declares `wrapperClass` on the TS face (`../form.ts`) and NOT on
+ * its zod mirror. That is a recorded, reconciled row of the parity ledger —
+ * `UnmirroredDeclared['form.zod.ts#InputSchema']` in `zod-mirror-parity.test.ts`
+ * — whose entry and key counts are pinned by that file's own census. Mirroring
+ * it moves those counts; it is that ledger's remedy, not this card's. The sweep
+ * carries it as a SELF-EXPIRING exemption: valid only while the mirror still
+ * lacks the key AND the ledger row is still on disk. Mirror it and the exemption
+ * turns red until it is deleted, so the carve-out cannot outlive the debt.
+ *
+ * ## What this file pins, and the two shapes it borrows
+ *
+ * The batch is the table form of `undeclared-but-consumed-keys-6150.test.ts`,
+ * unchanged: membership asserted on the mirror's OWN `.shape`, never on parse
+ * acceptance (under `.passthrough()` acceptance cannot tell "declared" from
+ * "admitted unexamined"); a CONTROL key the renderer does NOT read, derived from
+ * the renderer source, that must stay undeclared on both faces — the half that
+ * keeps this from being a widening beyond the one key; and the exact read text,
+ * checked off disk, because a declaration is worth its docblock only while the
+ * read exists.
+ *
+ * The sweep is new. It walks `packages/components/src/renderers/`, finds every
+ * file reading `schema.wrapperClass`, resolves the renderer's schema type from
+ * its own props annotation (`schema: XxxSchema`), and asserts BOTH faces declare
+ * the key — the TS interface by its source text, the mirror by `.shape`. No key
+ * list to maintain: the next renderer that grows a `wrapperClass` read on an
+ * undeclared type fails here, on the day it is written, instead of waiting for
+ * the next single-key grep (objectui#6938 → objectui#7722 was that wait).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+import * as Mirrors from '../zod/index.zod';
+import { safeValidateSchema } from '../zod/index.zod';
+import { DatePickerSchema, SelectSchema, SwitchSchema, TextareaSchema } from '../zod/form.zod';
+import { ListSchema } from '../zod/data-display.zod';
+
+import type {
+  DatePickerSchema as TsDatePickerSchema,
+  SelectSchema as TsSelectSchema,
+  SwitchSchema as TsSwitchSchema,
+  TextareaSchema as TsTextareaSchema,
+} from '../form';
+import type { ListSchema as TsListSchema } from '../data-display';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, '..', '..', '..', '..');
+const TYPES_SRC = join(REPO_ROOT, 'packages', 'types', 'src');
+const RENDERERS = join(REPO_ROOT, 'packages', 'components', 'src', 'renderers');
+const PARITY_LEDGER = join(HERE, 'zod-mirror-parity.test.ts');
+
+const KEY = 'wrapperClass';
+/**
+ * A plausible-looking class key none of the five renderers reads (each hands
+ * the label its own hard-coded classes, or has no label). It stays undeclared
+ * on both faces; `rendererReads` below proves the non-read per renderer.
+ */
+const CONTROL_KEY = 'labelClass';
+/** An undeclared key, carried by the control so the before-state stays visible. */
+const SENTINEL = 'undeclaredControlKey7722';
+
+/* ── Type-level pins (invariant equality, house form) ─────────────────────── */
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+/** The canonical `any` detector: only `any` absorbs `1 &` down to something `0` extends. */
+type IsAny<T> = 0 extends (1 & T) ? true : false;
+
+// Declared as `string` on each of the five. Were a member removed, the read
+// would fall back to the index signature and resolve to `any`, and
+// `Equal<any, string>` is false — so these are guards, not restatements.
+export type _SwitchWrapperClassIsString = Expect<Equal<NonNullable<TsSwitchSchema['wrapperClass']>, string>>;
+export type _SwitchWrapperClassIsNotAny = Expect<Equal<IsAny<TsSwitchSchema['wrapperClass']>, false>>;
+export type _TextareaWrapperClassIsString = Expect<Equal<NonNullable<TsTextareaSchema['wrapperClass']>, string>>;
+export type _TextareaWrapperClassIsNotAny = Expect<Equal<IsAny<TsTextareaSchema['wrapperClass']>, false>>;
+export type _DatePickerWrapperClassIsString = Expect<Equal<NonNullable<TsDatePickerSchema['wrapperClass']>, string>>;
+export type _DatePickerWrapperClassIsNotAny = Expect<Equal<IsAny<TsDatePickerSchema['wrapperClass']>, false>>;
+export type _SelectWrapperClassIsString = Expect<Equal<NonNullable<TsSelectSchema['wrapperClass']>, string>>;
+export type _SelectWrapperClassIsNotAny = Expect<Equal<IsAny<TsSelectSchema['wrapperClass']>, false>>;
+export type _ListWrapperClassIsString = Expect<Equal<NonNullable<TsListSchema['wrapperClass']>, string>>;
+export type _ListWrapperClassIsNotAny = Expect<Equal<IsAny<TsListSchema['wrapperClass']>, false>>;
+
+// The control key is NOT declared on any of the five: it resolves to `any`
+// through the index signature, exactly as `wrapperClass` did before this card.
+// Declaring it anywhere turns the matching line red — which is the point.
+export type _SwitchControlFallsThrough = Expect<IsAny<TsSwitchSchema['labelClass']>>;
+export type _TextareaControlFallsThrough = Expect<IsAny<TsTextareaSchema['labelClass']>>;
+export type _DatePickerControlFallsThrough = Expect<IsAny<TsDatePickerSchema['labelClass']>>;
+export type _SelectControlFallsThrough = Expect<IsAny<TsSelectSchema['labelClass']>>;
+export type _ListControlFallsThrough = Expect<IsAny<TsListSchema['labelClass']>>;
+
+// The TS face accepts the key on a literal. ⚠️ This is the WEAK half: the index
+// signature would accept it undeclared too. The invariant pins above are the
+// guard; these lines only show the declared spelling in use, once per type.
+const literals = {
+  switch: { type: 'switch', label: 'Enabled', wrapperClass: 'gap-4' } satisfies TsSwitchSchema,
+  textarea: { type: 'textarea', label: 'Notes', wrapperClass: 'gap-4' } satisfies TsTextareaSchema,
+  datePicker: { type: 'date-picker', label: 'Due', wrapperClass: 'gap-4' } satisfies TsDatePickerSchema,
+  select: { type: 'select', label: 'Pick', options: [], wrapperClass: 'gap-4' } satisfies TsSelectSchema,
+  list: { type: 'list', items: [], wrapperClass: 'gap-4' } satisfies TsListSchema,
+};
+
+/* ── The five, as data ───────────────────────────────────────────────────── */
+
+interface Mirror {
+  shape: Record<string, unknown>;
+  safeParse: (v: unknown) => {
+    success: boolean;
+    data?: Record<string, unknown>;
+    error?: { issues: { path: (string | number)[] }[] };
+  };
+}
+
+interface Case {
+  /** Mirror + TS type name — also the name the sweep resolves from the renderer. */
+  type: string;
+  mirror: Mirror;
+  /** A minimal LEGAL document for this type, carrying neither the key nor the control. */
+  control: Record<string, unknown>;
+  /** Renderer file, relative to the repo root. */
+  reader: string;
+  /** Exact source text of the read, as it stands today. */
+  readText: string;
+}
+
+const R = 'packages/components/src/renderers/';
+
+const CASES: Case[] = [
+  { type: 'SwitchSchema', mirror: SwitchSchema as unknown as Mirror,
+    control: { type: 'switch', label: 'Enabled' },
+    reader: R + 'form/switch.tsx', readText: "`flex items-center space-x-2 ${schema.wrapperClass || ''}`" },
+  { type: 'TextareaSchema', mirror: TextareaSchema as unknown as Mirror,
+    control: { type: 'textarea', label: 'Notes' },
+    reader: R + 'form/textarea.tsx', readText: 'cn("grid w-full gap-1.5", schema.wrapperClass)' },
+  { type: 'DatePickerSchema', mirror: DatePickerSchema as unknown as Mirror,
+    control: { type: 'date-picker', label: 'Due' },
+    reader: R + 'form/date-picker.tsx', readText: "`grid w-full max-w-sm items-center gap-1.5 ${schema.wrapperClass || ''}`" },
+  { type: 'SelectSchema', mirror: SelectSchema as unknown as Mirror,
+    control: { type: 'select', label: 'Pick', options: [] },
+    reader: R + 'form/select.tsx', readText: 'cn("grid w-full items-center gap-1.5", schema.wrapperClass)' },
+  { type: 'ListSchema', mirror: ListSchema as unknown as Mirror,
+    control: { type: 'list', items: [] },
+    reader: R + 'data-display/list.tsx', readText: 'cn("space-y-2", schema.wrapperClass)' },
+];
+
+/** Every `schema.KEY` read in one renderer, off disk. */
+function rendererReads(reader: string): Set<string> {
+  const src = readFileSync(join(REPO_ROOT, reader), 'utf8');
+  return new Set([...src.matchAll(/\bschema\.([A-Za-z_$][\w$]*)/g)].map((m) => m[1]));
+}
+
+describe('objectui#7722 — the five renderers read `wrapperClass`, which is the fact the declarations record', () => {
+  it('the batch is exactly five keys over five shipped types', () => {
+    // Non-vacuity for every per-case assertion below, and the card's own bound:
+    // nine readers were measured, four already declared, five not. A sixth
+    // undeclared reader belongs to the sweep below and to its own card, not here.
+    expect(CASES).toHaveLength(5);
+    expect(new Set(CASES.map((c) => c.type)).size).toBe(5);
+  });
+
+  describe.each(CASES.map((c) => [c.type, c] as const))('%s', (_title, c) => {
+    const { mirror, control, reader, readText } = c;
+
+    it('the read is still there, as the exact text the docblocks cite', () => {
+      const src = readFileSync(join(REPO_ROOT, reader), 'utf8');
+      expect(src, `${reader} no longer reads \`schema.${KEY}\` as \`${readText}\``).toContain(readText);
+    });
+
+    it('the read set, derived from the renderer, contains the key and NOT the control key', () => {
+      // Non-vacuity for the control: if the renderer ever starts reading
+      // `labelClass`, this turns red and the control must be re-chosen, not
+      // declared on the way past.
+      const reads = rendererReads(reader);
+      expect(reads.has(KEY)).toBe(true);
+      expect(reads.has(CONTROL_KEY)).toBe(false);
+    });
+
+    it('is a member of the mirror shape (membership cannot be read off acceptance under passthrough)', () => {
+      expect(Object.keys(mirror.shape)).toContain(KEY);
+    });
+
+    it('accepts the declared value and the value SURVIVES the parse', () => {
+      const r = mirror.safeParse({ ...control, [KEY]: 'gap-4' });
+      expect(r.success, JSON.stringify(r.error?.issues)).toBe(true);
+      if (r.success) expect(r.data![KEY]).toBe('gap-4');
+    });
+
+    it('…and through the published union entry point, so this type\'s arm is the one reached', () => {
+      const r = safeValidateSchema({ ...control, [KEY]: 'gap-4' });
+      expect(r.success, r.success ? '' : JSON.stringify(r.error.issues)).toBe(true);
+      if (r.success) expect((r.data as Record<string, unknown>)[KEY]).toBe('gap-4');
+    });
+
+    it('refuses a wrong-typed value AT the key — the enforcement mirroring adds', () => {
+      // Before this card `wrapperClass: 42` parsed green under `.passthrough()`.
+      // This is the only verdict that moves, and it moves toward refusal.
+      const r = mirror.safeParse({ ...control, [KEY]: 42 });
+      expect(r.success).toBe(false);
+      if (!r.success) expect(r.error!.issues.map((i) => i.path.join('.'))).toContain(KEY);
+    });
+
+    it('control: the declared-keys-only document parses green, before and after', () => {
+      expect(mirror.safeParse(control).success).toBe(true);
+    });
+
+    it('control: the control key is ABSENT from the mirror shape', () => {
+      expect(Object.keys(mirror.shape)).not.toContain(CONTROL_KEY);
+    });
+
+    it('control: the SAME wrong-typed value under an UNDECLARED key is still admitted unexamined', () => {
+      // The before-state of `wrapperClass`, kept on purpose on keys that are not
+      // read: `.passthrough()` admits them, of any type, and they survive. This is
+      // the proof the mirror's unknown-key policy is byte-for-byte what it was.
+      for (const undeclared of [CONTROL_KEY, SENTINEL]) {
+        const r = mirror.safeParse({ ...control, [undeclared]: 42 });
+        expect(r.success).toBe(true);
+        if (r.success) expect(r.data![undeclared]).toBe(42);
+      }
+    });
+  });
+
+  it('the type-level bindings above are referenced, so lint keeps them', () => {
+    for (const literal of Object.values(literals)) expect(literal.wrapperClass).toBe('gap-4');
+  });
+});
+
+/* ── The sweep: every `schema.wrapperClass` reader, both faces, no key list ── */
+
+/**
+ * Readers whose mirror is a recorded, reconciled row of the parity ledger
+ * (`UnmirroredDeclared` in `zod-mirror-parity.test.ts`). Each entry names the
+ * exact ledger row text; the exemption holds only while that text is on disk
+ * AND the mirror still lacks the key. Mirror the key and BOTH conditions flip —
+ * the exemption must then be deleted, never left to cover nothing.
+ */
+const LEDGERED_UNMIRRORED: Record<string, string> = {
+  InputSchema: "'form.zod.ts#InputSchema': 'wrapperClass'",
+};
+
+interface Reader {
+  /** Renderer file, relative to the repo root. */
+  file: string;
+  /** The schema type the renderer annotates its `schema` prop with. */
+  type: string;
+}
+
+function walkTsx(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkTsx(full));
+    else if (entry.isFile() && entry.name.endsWith('.tsx')) out.push(full);
+  }
+  return out.sort();
+}
+
+/** Every renderer reading `schema.wrapperClass`, with its annotated schema type — derived, not listed. */
+function wrapperClassReaders(): Reader[] {
+  const readers: Reader[] = [];
+  for (const full of walkTsx(RENDERERS)) {
+    const src = readFileSync(full, 'utf8');
+    if (!/\bschema\.wrapperClass\b/.test(src)) continue;
+    const file = relative(REPO_ROOT, full);
+    const m = /\bschema:\s*([A-Z][A-Za-z0-9]*Schema)\b/.exec(src);
+    if (!m) throw new Error(`${file} reads schema.wrapperClass but annotates no \`schema: XxxSchema\` prop — extend the resolver, do not exempt the reader`);
+    readers.push({ file, type: m[1] });
+  }
+  return readers;
+}
+
+/** The TS interface block for one schema type, off the package source — exactly one hit required. */
+function tsInterfaceBlock(type: string): { file: string; block: string } {
+  const hits: { file: string; block: string }[] = [];
+  for (const name of readdirSync(TYPES_SRC)) {
+    if (!name.endsWith('.ts') || name.endsWith('.test.ts')) continue;
+    const src = readFileSync(join(TYPES_SRC, name), 'utf8');
+    const re = new RegExp(`^export interface ${type} extends BaseSchema \\{\\n([\\s\\S]*?)^\\}`, 'm');
+    const m = re.exec(src);
+    if (m) hits.push({ file: `packages/types/src/${name}`, block: m[1] });
+  }
+  expect(hits, `expected exactly one \`export interface ${type} extends BaseSchema\` under packages/types/src`).toHaveLength(1);
+  return hits[0];
+}
+
+function mirrorOf(type: string): Mirror | undefined {
+  const candidate = (Mirrors as Record<string, unknown>)[type];
+  return candidate && typeof candidate === 'object' && 'shape' in candidate ? (candidate as Mirror) : undefined;
+}
+
+describe('objectui#7722 — sweep: every renderer reading `schema.wrapperClass` sits on a type that declares it, on both faces', () => {
+  const readers = wrapperClassReaders();
+
+  it('finds the readers (non-vacuity: nine were measured on 951fa8e0d; a resolver that finds fewer is broken, not clean)', () => {
+    expect(readers.length).toBeGreaterThanOrEqual(9);
+    expect(new Set(readers.map((r) => r.type)).size).toBe(readers.length);
+  });
+
+  it('the batch above is a subset of the sweep — the five were found by the resolver, not only by hand', () => {
+    const swept = new Set(readers.map((r) => r.type));
+    for (const c of CASES) expect(swept, `${c.type} not found by the sweep`).toContain(c.type);
+  });
+
+  it('every ledgered exemption names a reader the sweep found, and its ledger row is on disk', () => {
+    const ledger = readFileSync(PARITY_LEDGER, 'utf8');
+    const swept = new Set(readers.map((r) => r.type));
+    for (const [type, row] of Object.entries(LEDGERED_UNMIRRORED)) {
+      expect(swept, `exemption for ${type} covers no reader — delete it`).toContain(type);
+      expect(ledger, `ledger row ${row} is gone — the debt was paid, delete the exemption`).toContain(row);
+    }
+  });
+
+  describe.each(readers.map((r) => [`${r.type} (${r.file})`, r] as const))('%s', (_title, r) => {
+    it('declares `wrapperClass` on the TS face — a `wrapperClass?: string` member of the interface block', () => {
+      const { file, block } = tsInterfaceBlock(r.type);
+      expect(block, `${file}: ${r.type} does not declare \`${KEY}?: string\``).toMatch(/^\s*wrapperClass\?: string;/m);
+    });
+
+    it('declares `wrapperClass` on the zod face — a member of the mirror\'s own `.shape` — unless ledgered', () => {
+      const mirror = mirrorOf(r.type);
+      expect(mirror, `@object-ui/types/zod exports no mirror named ${r.type}`).toBeDefined();
+      const declared = Object.keys(mirror!.shape).includes(KEY);
+      if (r.type in LEDGERED_UNMIRRORED) {
+        // Self-expiring: the day the mirror gains the key, this turns red and the
+        // exemption (and the ledger row it cites) must go together.
+        expect(declared, `${r.type} now mirrors \`${KEY}\` — delete its LEDGERED_UNMIRRORED entry`).toBe(false);
+      } else {
+        expect(declared, `${r.file} reads schema.${KEY} but the ${r.type} mirror does not declare it`).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/types/src/data-display.ts
+++ b/packages/types/src/data-display.ts
@@ -164,6 +164,17 @@ export interface ListSchema extends BaseSchema {
    * @default false
    */
   dense?: boolean;
+  /**
+   * Classes on the wrapper `div` around the title and the list.
+   *
+   * READ SITE: `packages/components/src/renderers/data-display/list.tsx:27` —
+   * `cn("space-y-2", schema.wrapperClass)`. Undeclared until
+   * objectui#7722, surviving only on `BaseSchema`'s index signature: the same
+   * key, on the same class of read, that `CheckboxSchema` (objectui#6938),
+   * `FileUploadSchema` and `FilterBuilderSchema` (objectui#6150) declare.
+   * Distinct from `className`, which the renderer hands to the `ul` / `ol`.
+   */
+  wrapperClass?: string;
 }
 
 /**

--- a/packages/types/src/form.ts
+++ b/packages/types/src/form.ts
@@ -199,6 +199,17 @@ export interface TextareaSchema extends BaseSchema {
    */
   error?: string;
   /**
+   * Classes on the wrapper `div` around the textarea and its label.
+   *
+   * READ SITE: `packages/components/src/renderers/form/textarea.tsx:37` —
+   * `cn("grid w-full gap-1.5", schema.wrapperClass)`. Undeclared until
+   * objectui#7722, surviving only on `BaseSchema`'s index signature: the same
+   * key, on the same class of read, that `CheckboxSchema` (objectui#6938),
+   * `FileUploadSchema` and `FilterBuilderSchema` (objectui#6150) declare.
+   * Distinct from `className`, which the renderer hands to the inner control.
+   */
+  wrapperClass?: string;
+  /**
    * Change handler
    *
    * RUNTIME SLOT (objectui#6124) — a host-supplied function, NOT authorable
@@ -255,6 +266,17 @@ export interface SelectSchema extends BaseSchema {
    * Error message
    */
   error?: string;
+  /**
+   * Classes on the wrapper `div` around the trigger and its label.
+   *
+   * READ SITE: `packages/components/src/renderers/form/select.tsx:45` —
+   * `cn("grid w-full items-center gap-1.5", schema.wrapperClass)`. Undeclared until
+   * objectui#7722, surviving only on `BaseSchema`'s index signature: the same
+   * key, on the same class of read, that `CheckboxSchema` (objectui#6938),
+   * `FileUploadSchema` and `FilterBuilderSchema` (objectui#6150) declare.
+   * Distinct from `className`, which the renderer hands to the inner control.
+   */
+  wrapperClass?: string;
   /**
    * Change handler. Receives the AUTHORED option value — a numeric/boolean
    * option arrives with its type intact (#3090), not stringified by the
@@ -460,6 +482,17 @@ export interface SwitchSchema extends BaseSchema {
    * Help text or description
    */
   description?: string;
+  /**
+   * Classes on the wrapper `div` around the switch and its label.
+   *
+   * READ SITE: `packages/components/src/renderers/form/switch.tsx:26` —
+   * `` `flex items-center space-x-2 ${schema.wrapperClass || ''}` ``. Undeclared until
+   * objectui#7722, surviving only on `BaseSchema`'s index signature: the same
+   * key, on the same class of read, that `CheckboxSchema` (objectui#6938),
+   * `FileUploadSchema` and `FilterBuilderSchema` (objectui#6150) declare.
+   * Distinct from `className`, which the renderer hands to the inner control.
+   */
+  wrapperClass?: string;
   /**
    * RETIRED (objectui#6124, ADR-0049) — JSON has no function value, and the
    * `switch` renderer forwards only `toFormControlDomProps`'s whitelist, which
@@ -673,6 +706,17 @@ export interface DatePickerSchema extends BaseSchema {
    * Error message
    */
   error?: string;
+  /**
+   * Classes on the wrapper `div` around the popover trigger and its label.
+   *
+   * READ SITE: `packages/components/src/renderers/form/date-picker.tsx:35` —
+   * `` `grid w-full max-w-sm items-center gap-1.5 ${schema.wrapperClass || ''}` ``. Undeclared until
+   * objectui#7722, surviving only on `BaseSchema`'s index signature: the same
+   * key, on the same class of read, that `CheckboxSchema` (objectui#6938),
+   * `FileUploadSchema` and `FilterBuilderSchema` (objectui#6150) declare.
+   * Distinct from `className`, which the renderer hands to the inner control.
+   */
+  wrapperClass?: string;
   /**
    * Change handler
    *

--- a/packages/types/src/zod/data-display.zod.ts
+++ b/packages/types/src/zod/data-display.zod.ts
@@ -94,6 +94,8 @@ export const ListSchema = BaseSchema.extend({
   ordered: z.boolean().optional().describe('Whether list is ordered'),
   dividers: z.boolean().optional().describe('Show dividers between items'),
   dense: z.boolean().optional().describe('Dense spacing'),
+  wrapperClass: z.string().optional()
+    .describe('Classes on the wrapper div around the title and the list, read at renderers/data-display/list.tsx:27 — `cn("space-y-2", schema.wrapperClass)` (objectui#7722)'),
 });
 
 /**

--- a/packages/types/src/zod/form.zod.ts
+++ b/packages/types/src/zod/form.zod.ts
@@ -223,6 +223,8 @@ export const TextareaSchema = BaseSchema.extend({
   readOnly: z.boolean().optional().describe('Whether field is read-only'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
+  wrapperClass: z.string().optional()
+    .describe('Classes on the wrapper div around the textarea and its label, read at renderers/form/textarea.tsx:37 — `cn("grid w-full gap-1.5", schema.wrapperClass)` (objectui#7722)'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
   maxLength: z.number().optional().describe('Maximum length'),
 });
@@ -241,6 +243,8 @@ export const SelectSchema = BaseSchema.extend({
   required: z.boolean().optional().describe('Whether field is required'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
+  wrapperClass: z.string().optional()
+    .describe('Classes on the wrapper div around the trigger and its label, read at renderers/form/select.tsx:45 — `cn("grid w-full items-center gap-1.5", schema.wrapperClass)` (objectui#7722)'),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 
@@ -288,6 +292,8 @@ export const SwitchSchema = BaseSchema.extend({
   defaultChecked: z.boolean().optional().describe('Default checked state'),
   checked: z.boolean().optional().describe('Controlled checked state'),
   description: z.string().optional().describe('Help text'),
+  wrapperClass: z.string().optional()
+    .describe("Classes on the wrapper div around the switch and its label, read at renderers/form/switch.tsx:26 — `flex items-center space-x-2 ${schema.wrapperClass || ''}` (objectui#7722)"),
   onChange: handlerKeyRefusal('onChange', 'retired', 'Change handler'),
 });
 
@@ -356,6 +362,8 @@ export const DatePickerSchema = BaseSchema.extend({
   format: z.string().optional().describe('Date format string'),
   description: z.string().optional().describe('Help text'),
   error: z.string().optional().describe('Error message'),
+  wrapperClass: z.string().optional()
+    .describe("Classes on the wrapper div around the popover trigger and its label, read at renderers/form/date-picker.tsx:35 — `grid w-full max-w-sm items-center gap-1.5 ${schema.wrapperClass || ''}` (objectui#7722)"),
   onChange: handlerKeyRefusal('onChange', 'runtime-slot', 'Change handler'),
 });
 


### PR DESCRIPTION
Fixes #7722

**Clause-②: yes** — this PR widens the authorable surface (five published schemas gain a declared member). Dispatched at `CONTRACT_REVIEW_TIER`; label `needs:contract-review`; stays in draft for the PM's review. ⛔ Not flipped ready, not enqueued, no auto-merge.

## What becomes authorable that was not, per schema

Five schemas gain `wrapperClass?: string` on the TS face and `wrapperClass: z.string().optional()` on the zod mirror, with the read site cited in the docblock and in `.describe(...)` (the `CheckboxSchema` shape from objectui#6938):

| schema | TS face | zod mirror | read site the declaration records |
|---|---|---|---|
| `SwitchSchema` | `packages/types/src/form.ts` | `zod/form.zod.ts` | `renderers/form/switch.tsx:26` — wrapper `div` class, template-interpolated |
| `TextareaSchema` | `form.ts` | `zod/form.zod.ts` | `renderers/form/textarea.tsx:37` — `cn("grid w-full gap-1.5", schema.wrapperClass)` |
| `DatePickerSchema` | `form.ts` | `zod/form.zod.ts` | `renderers/form/date-picker.tsx:35` — wrapper `div` class, template-interpolated |
| `SelectSchema` | `form.ts` | `zod/form.zod.ts` | `renderers/form/select.tsx:45` — `cn("grid w-full items-center gap-1.5", schema.wrapperClass)` |
| `ListSchema` | `packages/types/src/data-display.ts` | `zod/data-display.zod.ts` | `renderers/data-display/list.tsx:27` — `cn("space-y-2", schema.wrapperClass)` |

Each read lands on a wrapper element's `className` (checked in all five; none goes nowhere), distinct from `className`, which the renderer hands to the inner control. Before this PR an author could WRITE the key (it compiled through `BaseSchema`'s index signature, objectui#5155, and parsed through `.passthrough()`), but no editor completed it, no annotation checked it and no validator enforced it — the runtime honoured a key the published contract did not acknowledge. That is the direction the ruling names: declared ≠ enforced, resolved by declaring, not by removing the reads. ⛔ The nine renderer files are unchanged; they are evidence only.

## What is refused now that was accepted before — stated exactly

- **Nothing well-typed.** Key membership was never narrow on either face, so every document carrying a string `wrapperClass` on these five types parsed green before and parses green now, the value surviving the parse; every TypeScript literal that compiled still compiles.
- **One thing, and it is the point:** a non-string `wrapperClass` on these five types — `{ type: 'switch', wrapperClass: 42 }` parsed green before and is refused now, at `wrapperClass`. That is enforcement of the declared type (the renderer would have interpolated `42` into the class string), the same verdict objectui#6150 and objectui#6938 documented for their keys. Keys outside the five are untouched: an undeclared key of any type is still admitted unexamined on all five mirrors, pinned per mirror with a control key (`labelClass`) that none of the renderers reads.

## The undeclared set, re-derived (PM mechanism assumption)

`git grep -n "schema\.wrapperClass" -- packages/components/src` on `951fa8e0d`: **9** readers. Against both faces: **5 undeclared on both faces** — `SwitchSchema`, `TextareaSchema`, `DatePickerSchema`, `SelectSchema`, `ListSchema` — the card's five, confirmed. **Plus one asymmetry the card lists as "declared":** `InputSchema` declares the key on the TS face only; its zod mirror lacks it, and that gap is a recorded row of the parity ledger (`UnmirroredDeclared['form.zod.ts#InputSchema']`, counts pinned by that file's census). It is deliberately not moved here — mirroring it moves pinned ledger figures outside this card's surface — and is filed as #8072 (unlabeled, for triage). So: five declared here, six measured, the sixth already ledgered.

## The pin (`packages/types/src/__tests__/wrapper-class-declared-7722.test.ts`)

Two halves. (1) The five in the table form of the objectui#6150 pin: exact read text off disk, read set derived from the renderer (contains the key, not the control), membership on the mirror's own `.shape`, value survives the parse (mirror and `safeValidateSchema`), wrong type refused AT the key, control document green, undeclared keys still admitted. Type-level pins with invariant equality plus an `IsAny` control per type. (2) A **sweep**: walks `packages/components/src/renderers/`, resolves each `schema.wrapperClass` reader's schema type from its own `schema: XxxSchema` annotation, and asserts BOTH faces declare the key (TS interface by source text, mirror by `.shape`) — no key list to maintain; the next reader on an undeclared type turns red the day it is written. The `InputSchema` gap is a self-expiring exemption (red as soon as the mirror gains the key or the ledger row disappears). Reverse verification, measured: on the untouched faces the pin is **20 failed / 48 passed** (5 types × mirror-membership, wrong-type refusal, sweep TS face, sweep zod face); after the edits **68 / 68**.

## Changeset — `minor`, justified in the body

objectui#6938 and objectui#7295 graded a one/two-key residue `patch`; this is the batch shape of objectui#6150 (`minor`) and is under contract review precisely because the PUBLISHED face gains five members — the boundary test's "widen the accepted set or public face" limb. The value-dimension refusal above is a behaviour change for a wrong-typed document. No `major` (fixed-group rule).

## Gates (exit codes captured before any pipe; all on `840520857`, working tree equal to HEAD)

| gate | result |
|---|---|
| `vitest run` 7722 + 6938 + 6150 + `zod-mirror-parity` pins (under the verify lock) | exit 0 — `4 passed (4)`, `175 passed (175)`; lock VERDICT `command-exit 0` |
| `vitest run --maxWorkers=2 packages/types/` (whole changed package) | exit 0 — `Test Files 132 passed (132)`, `Tests 2486 passed (2486)` |
| `pnpm --filter @object-ui/types type-check` (3 tsc projects; `--listFiles` shows the new test compiled) | exit 0 |
| `pnpm --filter @object-ui/types build` (tsc + dist-completeness; dist `.d.ts` carries the keys) | exit 0 |
| `turbo run type-check --continue --filter=@object-ui/components` (under the lock; builds core/i18n/react/react-runtime/sdui-parser/types first) | `TURBO_EXIT=0`, `Tasks: 9 successful, 9 total` |
| `pnpm --filter @object-ui/types lint` (eslint, every changed file) | exit 0 — `0 errors` (273 pre-existing `no-explicit-any` warnings, none on touched lines) |
| `check-changeset-presence` / `-no-major` / `-fixed`, `check:control-bytes`, `check:published-tsconfig-exclude`, `check:unreferenced-sources`, `check:handler-key-reads` | exit 0 each |

**Declared narrowings (CI owns the farm):** `pnpm build` and `turbo run type-check --continue` were run for `@object-ui/types` and `@object-ui/components` plus components' upstream closure; `pnpm test --shard=N/4` ×4 was narrowed to the whole `packages/types/` suite. Proof the narrowing excludes nothing: the only files outside `packages/types` that mention `wrapperClass` are the nine renderer files in `packages/components` (unchanged), and no fixture, catalog entry or doc page carries the key; adding an optional member cannot break another package's literal. The verify lock was queue-timed-out three times (9 min each; holders were sibling seats' full test shards) before the consumer type-check acquired it. `check:zod-mirror-parity` is not a package script in this repo; the parity gate is the vitest file, run green twice above.

## Deviations from the dispatch

- The PM's claimed file surface named `form.ts` / `form.zod.ts` only; the card's own fifth type, `ListSchema`, lives in `data-display.ts` / `zod/data-display.zod.ts`. Both were declared in my claim comment before any edit.
- REST `search` answered 403 in this container; the one dedup search for #8072 went through MCP (19 hits read, none naming that row).

Session `session_0114Ytxr5sM1vdW19Y9WAx6E`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E

---
_Generated by [Claude Code](https://claude.ai/code/session_0114Ytxr5sM1vdW19Y9WAx6E)_