### PR TITLE
docs(app-shell): give each of the three renderer names its measured answer

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,9 +15,15 @@ This document describes the refactored architecture that enables third-party sys
 - `ObjectView` - Renders object views; it reads `objectName` from the router
   (`useParams()`) and takes an `objects` metadata array. For a router-free embed,
   use `ObjectView` from `@object-ui/plugin-view` instead - see the examples below.
-- `DashboardRenderer` - Renders dashboard layouts
-- `PageRenderer` - Renders custom pages
-- `FormRenderer` - Renders forms
+- `DashboardView` - Renders a dashboard by name. The dashboard renderer itself,
+  `DashboardRenderer`, is not an app-shell export - it ships from
+  `@object-ui/plugin-dashboard`, and `DashboardView` renders through it.
+- `PageView` - Renders a custom page by name. No package exports a
+  `PageRenderer`: a page body is dispatched through the component registry on
+  the schema node's `type` (`page`, `app`, `utility`, `home`, `record`).
+- `RecordFormPage` - Renders a full-screen create/edit page. No package exports
+  a `FormRenderer`; the exported form renderer is `ObjectForm` from
+  `@object-ui/plugin-form`, which this page delegates to.
 
 **Dependencies**: `@object-ui/react`, `@object-ui/components`, `@object-ui/fields`, `@object-ui/layout`
 
@@ -52,9 +58,9 @@ This document describes the refactored architecture that enables third-party sys
 │  @object-ui/app-shell                   │
 │  - AppShell                             │
 │  - ObjectView                           │
-│  - DashboardRenderer                    │
-│  - PageRenderer                         │
-│  - FormRenderer                         │
+│  - DashboardView                        │
+│  - PageView                             │
+│  - RecordFormPage                       │
 └────────────────┬────────────────────────┘
                  │
 ┌────────────────┴────────────────────────┐

--- a/docs/CONSOLE-STREAMLINING-SUMMARY.md
+++ b/docs/CONSOLE-STREAMLINING-SUMMARY.md
@@ -17,9 +17,15 @@ This implementation completed **Phase 1** of the console streamlining project, e
 - `ObjectView` - Renders object views (Grid, Kanban, List, etc.); it reads
   `objectName` from the router (`useParams()`) and takes an `objects` metadata
   array. For a router-free embed, use `ObjectView` from `@object-ui/plugin-view`.
-- `DashboardRenderer` - Renders dashboard layouts from schema
-- `PageRenderer` - Renders custom page schemas
-- `FormRenderer` - Renders forms (modal or inline)
+- `DashboardView` - Renders a dashboard by name from schema. The dashboard
+  renderer itself, `DashboardRenderer`, is not an app-shell export - it ships
+  from `@object-ui/plugin-dashboard`, and `DashboardView` renders through it.
+- `PageView` - Renders a custom page by name. No package exports a
+  `PageRenderer`: a page body is dispatched through the component registry on
+  the schema node's `type` (`page`, `app`, `utility`, `home`, `record`).
+- `RecordFormPage` - Renders a full-screen create/edit page. No package exports
+  a `FormRenderer`; the exported form renderers are `ObjectForm` (inline) and
+  `ModalForm` (modal), both from `@object-ui/plugin-form`.
 
 **Key Features**:
 - Framework-agnostic (works with React Router, Next.js, Remix, etc.)


### PR DESCRIPTION
Fixes #7854

`docs/ARCHITECTURE.md` and `docs/CONSOLE-STREAMLINING-SUMMARY.md` list `DashboardRenderer`, `PageRenderer` and `FormRenderer` as exports of `@object-ui/app-shell`. Each is wrong in a **different** way, so each gets a different answer rather than one uniform rename.

## Measured, not guessed

Readings taken on a forced full build of all 37 packages (`pnpm exec turbo run build --filter=./packages/* --concurrency=2 --force`, 39/39 tasks successful, 0 cached) at branch head `41b74369b`; base `origin/main` `295804a63`, which had not moved when the PR was opened.

| name | `grep -l NAME packages/*/dist/index.d.ts` | answer applied |
|---|---|---|
| `DashboardRenderer` | `packages/plugin-dashboard/dist/index.d.ts` — real, wrong package | bullet now names app-shell's own `DashboardView`; `DashboardRenderer` re-attributed to `@object-ui/plugin-dashboard` |
| `PageRenderer` | no hit on any of the 37 built surfaces | bullet deleted as not-an-export; replaced by `PageView` plus one clause naming the registry mechanism |
| `FormRenderer` | one file, `packages/plugin-detail/dist/index.d.ts` — and that hit is a **substring** of `ObjectFormRenderer` inside a doc comment; no built surface declares the identifier | bullet deleted as not-an-export; replaced by `RecordFormPage` plus the real exported form renderers |

**Control, same run:** `grep -c Renderer packages/app-shell/dist/index.d.ts` returns **0**. No name containing "Renderer" is on app-shell's built type surface in any spelling — which is why none of the three could be re-spelled in place.

### Per name, what the measurement gave

- **`DashboardRenderer` — real, wrong package.** Declared and exported at `packages/plugin-dashboard/dist/index.d.ts:14`. app-shell's real export for that role is `DashboardView`, and `packages/app-shell/src/views/DashboardView.tsx:14` imports `DashboardRenderer` from `@object-ui/plugin-dashboard` — so "renders through it" is measured, not inferred. The bullet takes the shape objectui#7838 landed for `ObjectView`: name app-shell's export, then say where the other name really ships from.
- **`PageRenderer` — not an export anywhere.** It is `export const PageRenderer` in `packages/components/src/renderers/layout/page.tsx:475`, but `@object-ui/components`'s `exports` map has exactly two entries (`.` and `./style.css`) and its `dist/index.d.ts` does not carry the name, so it is unreachable to any importer. It reaches a page only through `ComponentRegistry.register` at that file's lines 692-696, under the five schema `type` keys `page`, `app`, `utility`, `home`, `record`. The replacement bullet names `PageView` (a real app-shell export) and describes the registry as a **mechanism**, explicitly not as an export.
- **`FormRenderer` — not an export anywhere.** The only tracked source hit is one app-shell test string (`packages/app-shell/src/__tests__/widget-dom-leak-sweep.test.tsx:1129`). The real exported form renderers are `ObjectForm` and `ModalForm`, both from `@object-ui/plugin-form`; app-shell's own entry point is `RecordFormPage`, whose docblock and line 33 show it delegating to `ObjectForm`.

## Every name written on the two pages is on the built surface it is attributed to

That is the rule this card exists to restore, so it was checked rather than assumed:

| name written | attributed to | on that package's built `dist/index.d.ts` |
|---|---|---|
| `AppShell`, `ObjectView`, `DashboardView`, `PageView`, `RecordFormPage` | `@object-ui/app-shell` | yes (1, 1, 1, 1, 2 hits) |
| `DashboardRenderer` | `@object-ui/plugin-dashboard` | yes (3 hits) |
| `ObjectForm`, `ModalForm` | `@object-ui/plugin-form` | yes (4, 2 hits) |
| `ObjectView` (router-free form, pre-existing) | `@object-ui/plugin-view` | yes (3 hits) |
| the component registry, the schema `type` keys | — | described as a mechanism, not as an export |

## Read-back — every remaining hit accounted for

`grep -n -w -e DashboardRenderer -e PageRenderer -e FormRenderer` over both files, after the edit, returns six hits and no others:

```
docs/ARCHITECTURE.md:19:  `DashboardRenderer`, is not an app-shell export - it ships from
docs/ARCHITECTURE.md:22:  `PageRenderer`: a page body is dispatched through the component registry on
docs/ARCHITECTURE.md:25:  a `FormRenderer`; the exported form renderer is `ObjectForm` from
docs/CONSOLE-STREAMLINING-SUMMARY.md:21:  renderer itself, `DashboardRenderer`, is not an app-shell export - it ships
docs/CONSOLE-STREAMLINING-SUMMARY.md:24:  `PageRenderer`: a page body is dispatched through the component registry on
docs/CONSOLE-STREAMLINING-SUMMARY.md:27:  a `FormRenderer`; the exported form renderers are `ObjectForm` (inline) and
```

Each surviving mention is either a re-attribution to the package that really ships the name, or an explicit statement that no package exports it. Zero remaining hits attribute any of the three to `@object-ui/app-shell`.

## Six sites, one answer each

`docs/ARCHITECTURE.md` `:18-20` (the **Exports** bullets) and `:55-57` (the ASCII diagram), `docs/CONSOLE-STREAMLINING-SUMMARY.md` `:20-22` (the **Components** bullets). The diagram's box alignment is preserved: every interior line is still 41 display columns wide (47 bytes, measured line by line).

## Gates — all pinned to head `41b74369b`

| gate | exit | its own verdict line |
|---|---|---|
| `node scripts/check-doc-links.mjs` | 0 | `Links are valid across 17 scan roots.` |
| `pnpm exec vitest run scripts/__tests__/check-doc-links.test.ts` | 0 | `Test Files 1 passed (1)` / `Tests 121 passed (121)` |
| `pnpm check:control-bytes` | 0 | `check-control-bytes: OK (scanned 6473 tracked text file(s); skipped 85 binary)` |
| manual control-byte scan of both paths | 1 (no match) | `grep -naP` over the two paths returns nothing |
| `node scripts/check-changeset-presence.mjs` | 0 | `No source or published contract of a released package changed in this range, so no changeset is owed.` |
| `node scripts/check-governed-queue-guard.mjs --test` (both paths) | 0 | `NOT GOVERNED — 2 path(s) checked against 5 governed surface(s); none matched.` |
| `pnpm check:doc-fences` | 0 | `every TypeScript block in 227 document(s)…` — neither path named in the run |
| `pnpm check:doc-snippets` | 0 | `Scanned 227 document(s): 212 covered … 15 ungated` — neither path named in the run |

The last two were run **only** to confirm these paths sit outside their scan surface, which they do. ⛔ No gate population was changed — objectui#7856 owns that question and is untouched here.

Exit codes were captured by redirect-then-capture, never through a pipe.

## Readers

`git grep -l` for both filenames over `scripts/`, `.github/`, `packages/`, `apps/`, `eslint-rules/` returns exactly two files:

- `scripts/__tests__/check-doc-links.test.ts` — a real reader; run above, 121/121 green.
- `scripts/check-doc-expression-carriage.mjs` — **not** a reader. Its single hit is a comment at line 125 stating that `docs/ARCHITECTURE.md` is outside `content/docs` and therefore outside that census. Nothing to run.

## Premise check

The card's per-name table holds, with one refinement worth recording: it reported `grep -l FormRenderer packages/*/dist/index.d.ts` as returning nothing, and at `295804a63` it returns one file. The substantive claim is unchanged — the hit is a substring of `ObjectFormRenderer` inside a doc comment, and `FormRenderer` is declared by no built surface — but the raw command no longer returns empty, so the finer word-boundary reading is the one recorded above.

`ObjectFormRenderer` itself was checked and is **not** a phantom: it is a module-private registry wrapper at `packages/plugin-form/src/index.tsx:131`, registered under `object-form` and `form`, and every doc comment naming it describes it as exactly that. No out-of-scope finding was filed.

## Related cards — bare references only

objectui#7838 (the `ObjectRenderer` half of these same two files — the landed spelling this PR follows), objectui#7095 (the `examples/byo-backend-console/README.md` twin), objectui#7856 (whether the repo-root `docs/` tree should enter a gate's scan surface — deliberately untouched), objectui#7483 (app-shell's `ObjectView` props typed loosely). None of those is addressed by this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhBNJcLRZLe8M87VcUgpKr)_