### PR TITLE
fix(components): a field its own `visibleWhen` hides is cleared, not carried to the server

### DIFF
--- a/.changeset/6958-visiblewhen-clears-the-field-it-hides.md
+++ b/.changeset/6958-visiblewhen-clears-the-field-it-hides.md
@@ -1,0 +1,39 @@
+---
+'@object-ui/components': minor
+---
+
+A field its own `visibleWhen` hides is now cleared, so it stops carrying a stale value
+to the server (objectui#6958).
+
+**Breaking, deliberately.** Until now a field the form renderer hid because the field's
+own `visibleWhen` (or its deprecated view-level sibling `visibleOn`) resolved FALSE kept
+its value in form state and submitted it anyway. Measured against a real running app: an
+object with four mutually-exclusive party columns and a type column naming which one
+applies could not be saved once a party column had been filled and then hidden — the
+server refused the row, correctly, by naming a column that was no longer on screen to
+clear. On the edit path the stored value was re-sent on **every** attempt, so such a
+record could never be retyped through the UI at all. The perverse consequence: *not*
+declaring `visibleWhen` produced an uglier but strictly **more usable** form, because the
+offending column stayed visible and therefore clearable.
+
+**What changes.** When a field's own visibility verdict goes VISIBLE → HIDDEN and the
+field holds a value, the renderer clears it: `null` for a scalar, `[]` for a multi-value.
+The key is deliberately PRESENT and `null` rather than withheld — objectui#6848 measured
+the write contract (`driver-memory` merges `{ ...stored, ...data }`, `driver-sql` issues
+`SET` for the keys present), so an absent key means "leave it unchanged" and only an
+explicit `null` overwrites the stored value. Omitting the key would have left the edit
+path exactly as dead as before.
+
+**What deliberately does NOT change.** Only the field's own conditional-visibility
+predicate clears. A field claimed by a hidden section (objectui#6236), a field on a hidden
+tab (objectui#6237) and a statically `hidden: true` field all keep the ruled semantics —
+visibility decides what is DRAWN and nothing else, and their values still submit. A broken
+predicate still fails OPEN, so a typo cannot silently null a stored column. The clear is
+transition-only and never writes over an empty value, so merely opening a record cannot
+strip the stored values of columns the user never saw, and a create form still omits the
+key for a field it never populated (objectui#4069).
+
+**Migration.** If you relied on `visibleWhen` to hide a field while still submitting its
+value, that value is now cleared on the transition. Carry such a value on a statically
+`hidden` field, or on a field claimed by a conditionally-hidden section, both of which are
+unaffected.

--- a/content/docs/plugins/plugin-form.mdx
+++ b/content/docs/plugins/plugin-form.mdx
@@ -220,9 +220,12 @@ drawing, and nothing else:**
   errors, the same hygiene a field's own `visibleWhen` applies.
 
 These are not tab-specific rules: they are the ruled hidden-group semantics
-every section `visibleWhen` follows, inherited through the same mechanism a
-field's own FALSE predicate uses (the fields simply stop being drawn; the form
-keeps their values and skips unmounted controls at validation).
+every section `visibleWhen` follows, inherited through the same *drawing*
+mechanism a field's own FALSE predicate uses (the fields simply stop being
+drawn, and unmounted controls skip validation). The value half does **not**
+carry across: a field hidden by its **own** `visibleWhen` / `visibleOn` has its
+value cleared (objectui#6958), while a field hidden by its **section's** or its
+**tab's** predicate keeps it, exactly as stated above.
 
 Two mechanics worth knowing:
 

--- a/packages/components/src/renderers/form/__tests__/visiblewhen-clear-on-hide-6958.test.tsx
+++ b/packages/components/src/renderers/form/__tests__/visiblewhen-clear-on-hide-6958.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#6958 — a field its OWN `visibleWhen` has just hidden must not carry
+ * its old value to the server.
+ *
+ * ## The measured dead end (card body, driven in Chromium on 17.1.0)
+ *
+ * `crm_event_attendee` has four mutually-exclusive party columns and an
+ * `attendee_type` naming which one applies. `visibleWhen` on each column does
+ * hide the three the type does not name — and the hidden column's value stayed
+ * in form state and was submitted anyway:
+ *
+ *   POST … {"attendee_type":"lead","crm_contact":"AEwPffbkMvx-OlC4", …}
+ *   400 VALIDATION_FAILED
+ *   "An attendee names exactly one party — clear every party column its
+ *    Attendee Type does not name"
+ *
+ * The refusal is CORRECT and names a column that is no longer on screen to
+ * clear. On the EDIT path the stored `crm_contact` was re-sent on every
+ * attempt, so such a record could never be retyped through the Console at all
+ * (twelve seeded rows were in that state). Central triage graded the card p1
+ * and fixed the consumer-side requirement at exactly one sentence:
+ * *`visibleWhen` on a populated field must stop producing an unsubmittable
+ * form* (objectui#6958 comment 5547207212).
+ *
+ * ## Why the value is cleared to `null` and not merely withheld
+ *
+ * The card offered two shapes: clear the value, or stop submitting invisible
+ * fields. **Withholding cannot fix the edit path**, and this repo has already
+ * measured why (objectui#6848, `GeolocationClearEmission.test.tsx`):
+ *
+ *   > `driver-memory`'s `update()` merges `{ ...stored, ...data }` and
+ *   > `driver-sql`'s issues `SET` for the keys present — so an absent key keeps
+ *   > the stored value and an explicit `null` overwrites it. The platform
+ *   > states the same contract in prose: *"To clear the stored X, write null;
+ *   > to leave it unchanged, omit the field."*
+ *
+ * An omitted `crm_contact` therefore leaves the stored contact in place: the
+ * merged row still names two parties and the same refusal comes back — or, if a
+ * validator ever read the delta alone, the row would silently persist a party
+ * column its type does not name, which is worse than the loud refusal. So the
+ * key must be PRESENT and `null`. That is what the edit-path rows below assert,
+ * `JSON.stringify` included — `undefined` would satisfy a `== null` assertion
+ * and then stop existing on the wire, which is the exact trap #6848 documents.
+ *
+ * ## The boundary — what this does NOT clear
+ *
+ * Only the field's OWN authored conditional-visibility predicate clears:
+ * `visibleWhen` (canonical, ADR-0089) and its deprecated view-level sibling
+ * `visibleOn` (#2212) — the same pair the stale-error effect in `form.tsx`
+ * already treats as one verdict. Deliberately untouched, each pinned below:
+ *
+ *   - a field claimed by a hidden SECTION (#6236) and a field on a hidden TAB
+ *     (#6237) keep the ruled semantics of the 2026-08-27 maintainer ruling —
+ *     visibility decides what is DRAWN and nothing else, their values still
+ *     submit;
+ *   - a statically `hidden: true` field is not conditionally hidden at all and
+ *     keeps its value (that is how a fixed value is carried into a payload);
+ *   - a BROKEN predicate fails OPEN, so the field is visible and nothing is
+ *     cleared — a typo must never silently null a stored column;
+ *   - a field that is already empty is never written to, so a create form
+ *     cannot turn an absent key into an explicit `null` and suppress a
+ *     server-side default (#4069).
+ *
+ * ## Reverse verification (direction predicted BEFORE running)
+ *
+ * Remove the `clearedOnHide` effect in `form.tsx` and the three CLEAR rows go
+ * red in the STALE direction (the payload carries the old value again), while
+ * every boundary row above stays green — they pin semantics the effect must not
+ * disturb, not the effect itself. Measured in that direction; see the PR.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { ComponentRegistry } from '@object-ui/core';
+// Module-scope import (not `beforeAll`) — objectui#3010/#3021.
+import '../../../renderers';
+
+/** The canonical wire shape `@objectstack/spec` normalizes to (ADR-0089 D2). */
+const cel = (source: string) => ({ dialect: 'cel', source });
+
+function renderForm(schema: Record<string, unknown>) {
+  const Form = ComponentRegistry.get('form')!;
+  return render(
+    <Form schema={{ type: 'form', showSubmit: true, submitLabel: 'Save', ...schema }} />,
+  );
+}
+
+/** The card's object, reduced to the two party columns the report drives. */
+const PARTY_FIELDS = [
+  { name: 'attendee_type', label: 'Attendee Type', type: 'input' },
+  {
+    name: 'crm_contact',
+    label: 'Contact',
+    type: 'input',
+    visibleWhen: cel("record.attendee_type == 'contact'"),
+  },
+  {
+    name: 'sys_user',
+    label: 'User',
+    type: 'input',
+    visibleWhen: cel("record.attendee_type == 'user'"),
+  },
+];
+
+const save = () => fireEvent.click(screen.getByRole('button', { name: /save/i }));
+const retype = (next: string) =>
+  fireEvent.change(screen.getByLabelText(/attendee type/i), { target: { value: next } });
+
+async function payloadOf(onSubmit: ReturnType<typeof vi.fn>) {
+  await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  return onSubmit.mock.calls[0][0] as Record<string, unknown>;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('#6958 — a field its own `visibleWhen` hides is cleared, not carried', () => {
+  it('CREATE: the value typed while the field was visible does not reach the payload', async () => {
+    const onSubmit = vi.fn();
+    renderForm({ fields: PARTY_FIELDS, defaultValues: { attendee_type: 'contact' }, onSubmit });
+
+    fireEvent.change(screen.getByLabelText(/^contact$/i), {
+      target: { value: 'AEwPffbkMvx-OlC4' },
+    });
+    retype('lead');
+    // The control the refusal names is genuinely off screen now.
+    expect(screen.queryByLabelText(/^contact$/i)).toBeNull();
+
+    save();
+    const payload = await payloadOf(onSubmit);
+    expect(payload.crm_contact).toBeNull();
+    expect(payload.attendee_type).toBe('lead');
+  });
+
+  it('EDIT: the STORED value is overwritten with an explicit null that survives serialization', async () => {
+    const onSubmit = vi.fn();
+    const stored = { attendee_type: 'contact', crm_contact: 'dzjN7iIOQeQCPQjo' };
+    renderForm({
+      fields: PARTY_FIELDS,
+      defaultValues: stored,
+      previousValues: stored,
+      onSubmit,
+    });
+
+    retype('user');
+    fireEvent.change(screen.getByLabelText(/^user$/i), { target: { value: 'brZgpOK4zIBLFPza' } });
+
+    save();
+    const payload = await payloadOf(onSubmit);
+    expect(payload.crm_contact).toBeNull();
+    expect(payload.sys_user).toBe('brZgpOK4zIBLFPza');
+    // The half #6848 says an `== null` assertion alone would miss: an absent
+    // key means "leave it unchanged" on a PATCH, so the stored contact would
+    // survive and the row would stay un-retypeable.
+    expect(Object.keys(JSON.parse(JSON.stringify(payload)))).toContain('crm_contact');
+  });
+
+  it('the deprecated view-level `visibleOn` clears the same way — one verdict, one behaviour', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: [
+        { name: 'attendee_type', label: 'Attendee Type', type: 'input' },
+        {
+          name: 'crm_contact',
+          label: 'Contact',
+          type: 'input',
+          visibleOn: cel("record.attendee_type == 'contact'"),
+        },
+      ],
+      defaultValues: { attendee_type: 'contact', crm_contact: 'AEwPffbkMvx-OlC4' },
+      onSubmit,
+    });
+
+    retype('lead');
+    save();
+    expect((await payloadOf(onSubmit)).crm_contact).toBeNull();
+  });
+
+  it('a field that comes back into view stays empty — the clear is a clear, not a stash', async () => {
+    const onSubmit = vi.fn();
+    renderForm({ fields: PARTY_FIELDS, defaultValues: { attendee_type: 'contact' }, onSubmit });
+
+    fireEvent.change(screen.getByLabelText(/^contact$/i), { target: { value: 'AEwPffbk' } });
+    retype('lead');
+    retype('contact');
+
+    await waitFor(() => expect(screen.getByLabelText(/^contact$/i)).toBeInTheDocument());
+    expect((screen.getByLabelText(/^contact$/i) as HTMLInputElement).value).toBe('');
+  });
+
+  it('BOUNDARY — a hidden SECTION\'s claimed field still submits its value (#6236 ruling intact)', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: [
+        { name: 'plan', label: 'Plan', type: 'input' },
+        {
+          name: 'pay',
+          label: 'Compensation',
+          type: 'section-divider',
+          visibleWhen: cel("record.plan == 'standard'"),
+          fields: ['salary'],
+        },
+        { name: 'salary', label: 'Salary', type: 'input' },
+      ],
+      defaultValues: { plan: 'standard', salary: '120000' },
+      onSubmit,
+    });
+
+    fireEvent.change(screen.getByLabelText(/plan/i), { target: { value: 'basic' } });
+    await waitFor(() => expect(screen.queryByLabelText(/salary/i)).toBeNull());
+
+    save();
+    expect((await payloadOf(onSubmit)).salary).toBe('120000');
+  });
+
+  it('BOUNDARY — a hidden TAB\'s field still submits its value (#6237 ruling intact)', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: [
+        { name: 'plan', label: 'Plan', type: 'input' },
+        { name: 'salary', label: 'Salary', type: 'input' },
+      ],
+      fieldTabs: [
+        { key: 'main', label: 'Main', fields: ['plan'] },
+        {
+          key: 'pay',
+          label: 'Compensation',
+          fields: ['salary'],
+          visibleWhen: cel("record.plan == 'standard'"),
+        },
+      ],
+      defaultValues: { plan: 'standard', salary: '120000' },
+      onSubmit,
+    });
+
+    fireEvent.change(screen.getByLabelText(/plan/i), { target: { value: 'basic' } });
+    await waitFor(() => expect(screen.queryByRole('tab', { name: /compensation/i })).toBeNull());
+
+    save();
+    expect((await payloadOf(onSubmit)).salary).toBe('120000');
+  });
+
+  it('BOUNDARY — a statically `hidden` field keeps its value', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: [
+        { name: 'plan', label: 'Plan', type: 'input' },
+        { name: 'source', label: 'Source', type: 'input', hidden: true },
+      ],
+      defaultValues: { plan: 'standard', source: 'import' },
+      onSubmit,
+    });
+
+    save();
+    expect((await payloadOf(onSubmit)).source).toBe('import');
+  });
+
+  it('BOUNDARY — a BROKEN predicate fails open, so nothing is cleared', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: [
+        { name: 'plan', label: 'Plan', type: 'input' },
+        {
+          name: 'crm_contact',
+          label: 'Contact',
+          type: 'input',
+          visibleWhen: cel("'x' in no_such_root.positions"),
+        },
+      ],
+      defaultValues: { plan: 'standard', crm_contact: 'AEwPffbk' },
+      onSubmit,
+    });
+
+    fireEvent.change(screen.getByLabelText(/plan/i), { target: { value: 'basic' } });
+    save();
+    expect((await payloadOf(onSubmit)).crm_contact).toBe('AEwPffbk');
+  });
+
+  it('BOUNDARY — an already-empty hidden field is never written to (no invented null)', async () => {
+    const onSubmit = vi.fn();
+    renderForm({
+      fields: [
+        { name: 'attendee_type', label: 'Attendee Type', type: 'input' },
+        {
+          name: 'crm_contact',
+          label: 'Contact',
+          type: 'input',
+          visibleWhen: cel("record.attendee_type == 'contact'"),
+        },
+      ],
+      // `crm_contact` is absent from the defaults and never typed into: a
+      // create form must keep omitting the key so the server resolves the
+      // declared runtime default (#4069).
+      defaultValues: { attendee_type: 'lead' },
+      onSubmit,
+    });
+
+    save();
+    expect(await payloadOf(onSubmit)).not.toHaveProperty('crm_contact');
+  });
+});

--- a/packages/components/src/renderers/form/form.tsx
+++ b/packages/components/src/renderers/form/form.tsx
@@ -1282,6 +1282,67 @@ ComponentRegistry.register('form',
       return locked;
     }, [fields, ruleRecord, previousRecord, isCreateForm, predicateScope]);
 
+    // Fields hidden RIGHT NOW by their OWN authored conditional-visibility
+    // predicate — `visibleWhen` (canonical, ADR-0089) or its deprecated
+    // view-level sibling `visibleOn` (#2212). The pair is one verdict here for
+    // the same reason the stale-error effect below already folds them into one:
+    // they are two spellings of "this field does not apply to the record as it
+    // now stands", and splitting them would give one authored intent two
+    // behaviours.
+    //
+    // Feeds the clear-on-hide effect (objectui#6958). Fields declaring NEITHER
+    // key are skipped outright, so a form that does not use conditional
+    // visibility recomputes nothing and behaves exactly as before.
+    //
+    // ⛔ Deliberately NOT the union of every reason a field is not drawn. A
+    // field claimed by a hidden section (#6236), a field on a hidden tab
+    // (#6237) and a statically `hidden` field are all absent from this set:
+    // the first two carry the 2026-08-27 maintainer ruling (visibility decides
+    // what is DRAWN and nothing else — their values still submit) and the
+    // third is not conditional at all, it is how a fixed value is carried into
+    // a payload. Re-evaluating the predicates the render path also evaluates
+    // cannot double-warn: `warnPredicateFailure` dedupes by predicate source,
+    // which `readonlyFieldNames` above already leans on.
+    const conditionallyHiddenFieldNames = React.useMemo(() => {
+      const hidden = new Set<string>();
+      for (const f of fields as FormFieldConfig[]) {
+        const name = f?.name;
+        if (!name) continue;
+        const visibleWhen = (f as any).visibleWhen;
+        const visibleOn = (f as any).visibleOn;
+        if (visibleWhen == null && visibleOn == null) continue;
+        if (visibleWhen != null) {
+          const st = resolveFieldRuleState(
+            { visibleWhen, readonlyWhen: (f as any).readonlyWhen, requiredWhen: (f as any).requiredWhen },
+            ruleRecord,
+            {
+              required: !!f.required,
+              readonly: (f as any).readonly === true,
+              serverOwnedValue: isServerOwnedValue(f, isCreateForm),
+            },
+            previousRecord,
+            predicateScope,
+            // Same locator the render path uses (#5149), so a faulted
+            // predicate is reported once, against the field.
+            `field '${name}'`,
+          );
+          if (!st.visible) {
+            hidden.add(name);
+            continue;
+          }
+        }
+        if (
+          visibleOn != null &&
+          !evalFieldPredicate(visibleOn, ruleRecord, true, previousRecord, predicateScope, {
+            context: `visibleOn of field '${name}'`,
+          })
+        ) {
+          hidden.add(name);
+        }
+      }
+      return hidden;
+    }, [fields, ruleRecord, previousRecord, isCreateForm, predicateScope]);
+
     // ── The section grouping contract (objectui#6236, maintainer ruling
     // 2026-08-27) ─────────────────────────────────────────────────────────────
     // A `section-divider` that CLAIMS its member fields (`fields: string[]` —
@@ -1705,6 +1766,67 @@ ComponentRegistry.register('form',
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [ruleRecord, predicateScope]);
+
+    // Clear-on-hide (objectui#6958) — the field's own `visibleWhen` turning it
+    // invisible clears its value.
+    //
+    // ## The dead end this closes
+    //
+    // Hiding a populated field without clearing it made a declared exclusivity
+    // impossible to satisfy: the Console kept the value in form state and
+    // submitted it anyway, so the server refused the row — correctly — by
+    // naming a column that was no longer on screen to clear. On the EDIT path
+    // the stored value was re-sent on EVERY attempt, so such a record could
+    // never be retyped through the Console at all. Measured against a real app
+    // (twelve rows in that state) and graded p1: `visibleWhen` on a populated
+    // field must stop producing an unsubmittable form.
+    //
+    // ## Why `null` and not `undefined`, and why not "just withhold the key"
+    //
+    // The card offered a second shape — omit invisible fields from the payload
+    // — and it cannot fix the edit path. objectui#6848 measured the write
+    // contract: `driver-memory`'s `update()` merges `{ ...stored, ...data }`
+    // and `driver-sql` issues `SET` for the keys PRESENT, so an absent key
+    // keeps the stored value and an explicit `null` overwrites it ("to clear
+    // the stored value write null; to leave it unchanged omit the field"). A
+    // withheld `crm_contact` therefore leaves the stored contact in the row and
+    // the same refusal comes back. `undefined` is the same trap one level down:
+    // it satisfies a `== null` check and then vanishes from `JSON.stringify`.
+    // So a cleared scalar is `null` — the sentinel every other clearing widget
+    // in this workspace already emits — and a cleared multi-value is `[]`,
+    // matching the cascade clear above.
+    //
+    // ## Transition-only, and only over a value that exists
+    //
+    // A field is cleared when its verdict goes VISIBLE → HIDDEN, which is the
+    // card's own wording ("clear a field's value when its `visibleWhen` TURNS
+    // it invisible"). The first pass only records the baseline, so opening a
+    // record never nulls a column the user has not seen: a save that changed
+    // one unrelated field cannot silently strip the stored values of every
+    // conditionally-hidden column. Values that are already empty are never
+    // written to either, so a create form cannot turn an absent key into an
+    // explicit `null` and suppress the server-side default the author declared
+    // (#4069).
+    //
+    // A cleared field that comes back into view comes back EMPTY: this is a
+    // clear, not a stash. Re-hiding it then writes nothing (the value is
+    // already empty), so the pair cannot oscillate.
+    const previouslyHiddenFieldNames = React.useRef<Set<string> | undefined>(undefined);
+    React.useEffect(() => {
+      const before = previouslyHiddenFieldNames.current;
+      previouslyHiddenFieldNames.current = conditionallyHiddenFieldNames;
+      if (!before) return;
+      for (const name of conditionallyHiddenFieldNames) {
+        if (before.has(name)) continue;
+        const current = form.getValues(name);
+        if (current === undefined || current === null || current === '') continue;
+        form.setValue(name, Array.isArray(current) ? [] : null, {
+          shouldValidate: false,
+          shouldDirty: true,
+        });
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [conditionallyHiddenFieldNames]);
 
     // React to defaultValues changes — but ONLY when the values actually
     // change, not on every new object identity. Callers often pass a freshly


### PR DESCRIPTION
Fixes #6958

A field its own `visibleWhen` hides is now cleared, so it stops carrying a stale value to the server — on the create path and, decisively, on the edit path.

## The dead end, re-measured on `main` rather than taken from the card

The card measured `@objectstack/spec` / `@objectstack/console` **17.1.0** in Chromium. objectui pins objectstack by npm semver with no SHA pin, and this worktree resolves **`@objectstack/spec` 17.2.0**, so the behaviour was re-established here before anything was written:

- `clearOnHide`-shaped key: **zero occurrences** in `node_modules/@objectstack/spec` at 17.2.0 and zero in this repo. The card's "the app cannot compensate" premise holds at the version we actually build against.
- The submit-time defect reproduces as a unit test on unmodified `main` — 4 of the 9 rows in the new pin file are red before the fix, including the edit-path row:

```
FAIL |dom| …/visiblewhen-clear-on-hide-6958.test.tsx > EDIT: the STORED value is
overwritten with an explicit null that survives serialization
AssertionError: expected 'dzjN7iIOQeQCPQjo' to be null
```

`premise_still_valid: true`.

## Where the mechanism actually lives (the dispatch's line numbers, re-taken)

The dispatch located `sanitizeFormData` at `ObjectForm.tsx:902`, `DrawerForm.tsx:408`, `ModalForm.tsx:461` and `masterDetailTx.ts` — all four confirmed — but flagged that the **field-level** visibility evaluation was unverified. Measured: it is **not** in `packages/plugin-form` at all. Every host delegates field rendering to the one form renderer, and the field's own verdict is taken there:

- `packages/components/src/renderers/form/form.tsx` → `renderFormField` → `resolveFieldRuleState({ visibleWhen, … })` → `if (!ruleState.visible) return null;`
- the field unmounts, react-hook-form keeps its value (`shouldUnregister` stays default-false), and `getValues()` hands it to the host, which sanitizes and sends it.

So the change is one file in `packages/components/src/renderers/form/**`, which the dispatch put in surface conditional on exactly this measurement. `packages/plugin-form` needed no edit; `packages/app-shell` (held by #7429) was not touched.

## Why the value is CLEARED and not merely withheld — the route the PM suggested is falsified

The card offered two shapes and the dispatch preferred (b), "omit invisible fields from the payload", for its smaller blast radius. **(b) cannot fix the edit path**, and this repo has already measured why — `packages/fields/src/__tests__/GeolocationClearEmission.test.tsx` (objectui#6848):

> `driver-memory`'s `update()` merges `{ ...stored, ...data }` and `driver-sql`'s issues `SET` for the keys present — so an absent key keeps the stored value and an explicit `null` overwrites it. The platform states the same contract in prose: *"To clear the stored X, write null; to leave it unchanged, omit the field."*

⇒ Withholding `crm_contact` leaves the stored contact in the row. Either the server evaluates the merged record — and the identical refusal comes straight back, so the twelve rows stay un-retypeable — or it ever evaluated the delta alone, in which case the save succeeds and **persists a party column the row's own type does not name**, which is worse than the loud refusal. Both arms of that disjunction fail the card, so (b) is out on measurement, not on taste.

`undefined` is the same trap one level down: it satisfies an `== null` assertion and then stops existing in `JSON.stringify`. The pin therefore asserts the key survives serialization, which is the assertion `undefined` would fail.

⇒ Route (a): scalar → `null`, multi-value → `[]`, matching the cascade clear that already sits immediately above the new effect.

## What is deliberately NOT cleared

The dispatch asked what this does to fields hidden for reasons other than `visibleWhen`. Answer, and each half is pinned:

| hidden because | cleared? | why |
|---|---|---|
| the field's own `visibleWhen` (ADR-0089) | **yes** | the card's subject |
| the field's own `visibleOn` (deprecated view-level sibling, #2212) | **yes** | two spellings of one authored intent; the stale-error effect in this same file already folds them into one verdict, and splitting them would give one intent two behaviours |
| claimed by a hidden section (#6236) | no | the 2026-08-27 maintainer ruling — visibility decides what is DRAWN and nothing else; its values still submit |
| on a hidden tab (#6237) | no | same ruling, tabbed arm |
| static `hidden: true` | no | not conditional at all; this is how a fixed value is carried into a payload |
| a BROKEN predicate | no | `visibleWhen` fails OPEN, so the field is visible and untouched — a typo must never silently null a stored column |
| permission-filtered fields | no | they never reach this renderer; the field list is filtered upstream, so there is no registered value to clear |

Two further guards keep the blast radius where it belongs:

- **Transition-only.** A field is cleared when its verdict goes VISIBLE → HIDDEN — the card's own wording, "clear a field's value when its `visibleWhen` *turns* it invisible". The first pass records the baseline only, so merely opening a record and saving one unrelated field cannot strip the stored values of every conditionally-hidden column. This still covers the card in full: the twelve rows are `contact`-typed with `crm_contact` set, and retyping one *is* the transition.
- **Never writes over an empty value.** A create form therefore still omits the key for a field it never populated, so an authored server-side default is not suppressed (#4069). It also makes oscillation impossible: a cleared field that comes back into view and hides again is already empty, so nothing is written.

Fields declaring neither key are skipped outright, so a form that does not use conditional visibility recomputes nothing.

## Reverse verification

Direction predicted before running, then measured on the **committed** tree (`5ebad8291`), so the restore had a real point to come back to.

The mutation: a bare `return;` inserted at the head of the clear effect. Proved to have reached disk before anything was read — the marker went `0 -> 1` and the blob hash moved off HEAD's:

```
pre  anchor_hits=1 ablation_marker_hits=0
post ablation_marker_hits=1
hash_head=2210d34bccc4c48896d02431377826ef1cd2d198
hash_disk=c0081c5159b2c2b1eff1146ef9c62c989ab558b7
```

Result — `Tests 4 failed | 5 passed (9)`, red in the predicted STALE direction and nowhere else:

```
CREATE: the value typed while the field was visible does not reach the payload
EDIT: the STORED value is overwritten with an explicit null that survives serialization
the deprecated view-level `visibleOn` clears the same way - one verdict, one behaviour
a field that comes back into view stays empty - the clear is a clear, not a stash
AssertionError: expected 'dzjN7iIOQeQCPQjo' to be null
```

Those are exactly the four rows that are red on unmodified `main`; the five boundary rows stayed green in both directions, which is what makes them semantics pins rather than differentiators.

Restore verified by state, not by an exit code — `git checkout HEAD -- PATH` (never a bare checkout, whose index copy would hand the mutation straight back at exit 0):

```
diff_head_names=[]
hash_head=2210d34bccc4c48896d02431377826ef1cd2d198
hash_disk=2210d34bccc4c48896d02431377826ef1cd2d198
ablation_marker_hits=0
RESTORED_EXIT=0   Tests  9 passed (9)
```

⚠️ Recorded rather than quietly re-run: the **first** ablation attempt was a no-op. Its `perl` substitution wrapped text containing escaped parens in `\Q…\E`, so it matched zero times — and `perl -0pi` exits **0** on zero matches. The on-disk marker check caught it and the pipeline aborted (exit 93) instead of reporting a passing ablation over an unmutated tree. The numbers above are from the corrected pattern.

## Gates run locally (exit codes captured before any pipe)

| gate | result |
|---|---|
| pin file, committed tree | `Test Files 1 passed`, `Tests 9 passed (9)` |
| `packages/components/src/renderers/form/` + `packages/plugin-form/` | `Test Files 142 passed (142)`, `Tests 1225 passed, 8 skipped (1233)` |
| `type-check` (`@object-ui/components`, `@object-ui/plugin-form`) | exit 0 — `tsc --noEmit && tsc -p tsconfig.test.json` for both |
| `check:control-bytes` | exit 0 — 6474 tracked text files |
| `changeset-presence` | exit 0 — "2 source file(s) of 1 released package(s) changed, and this change declares 1 changeset(s)" |
| `changeset-no-major` | exit 0 |
| `changeset-fixed` | exit 0 |
| `check:published-dist` | exit 0 |
| `check:published-tsconfig-exclude` | exit 0 |
| `check:handler-key-reads` | exit 0 |
| `check:phantom-deps` | exit 0 |
| `check-governed-queue-guard --test` (4 paths, post-amend) | `NOT GOVERNED` — ordinary review and merge-queue route |
| control-byte self-scan of the touched paths | grep exit 1 (clean) |
| `check:doc-fences` | exit 0 — 227 documents |
| `check:doc-snippets` | exit 0 — 549 of 549 blocks judged, 0 failed (see note) |
| `check:doc-types` | exit 0 — 188 doc files, 1105 code blocks |
| `check:doc-links` (Internal Docs Link Check) | exit 0 — valid across 17 scan roots |
| `check:docs-route-closure` | exit 0 |
| `check-doc-expression-carriage` | exit 0 |
| `check:doc-example-readers` | exit 0 |

⚠️ `check:doc-snippets` first returned **exit 2 — PRECONDITION NOT MET**, which the gate itself distinguishes in as many words: *"This is 'I could not run', NOT 'I ran and found errors' (exit 1)."* That is NOT MEASURED, not green. It was re-run after the scoped build the gate prints (`turbo run build $(node scripts/check-doc-snippet-types.mjs --build-filter) --concurrency=2`, 34 tasks), and only the second run — 549 of 549 blocks judged, 0 failed — is the exit 0 recorded above.

**Declared narrowing.** The affected-suite run is the form renderer directory plus the whole `plugin-form` package, not `packages/components` in full: the container is shared with four other dev seats and load hit 112 during this round. `pnpm lint` (repo-wide `turbo run lint`) and the remaining `check:*` farm are left to CI, which runs them all.

## The one thing a reviewer should overrule me on

The clear is **silent**. objectui#6499 (maintainer ruling 2026-08-27, Option C) adjudicated the same *shape* on the metadata-admin inspector's `showWhen` and went the other way on the mutation: it KEEPS the value, rejects pruning outright, and NAMES the state instead.

**Ruled on the card** (objectui#6958 comment 5560114937): #6499 does not govern this surface, and this fix stands. The reviewer read the ruling box rather than my paraphrase, and it decides itself twice over — it scopes its coverage to "all `showWhen` groups **in the metadata-admin inspectors**", and it names the precondition that makes "keep" safe: *"the retained residue is **inert data rather than live behaviour** — and that is the premise that makes C's 'keep' safe."* That premise is measurably false here: the retained value is live (the platform refuses the row), the field is genuinely off screen, and there is no `isFieldVisible` re-show guard keeping it visible.

⚠️ The part of #6499 that *does* generalise is its warning that *"the option that is easiest to write and most looks like 'fixed' is the one that deletes data."* This PR does clear data, so that warning is live here. What carries it, all pinned rather than asserted: shape (b) was falsified on measurement rather than preference; the clear is transition-only; a broken predicate fails OPEN; an already-empty field is never written. ⛔ Those four boundaries are load-bearing — none of them should erode in a later change.

The half of that ruling this repo *can* honour on both surfaces — naming the state — is filed as **#8070** rather than folded in, because the copy needs a new i18n key in `packages/i18n`.

## Out-of-scope findings filed

- **#8069** — every field-rule predicate falls back to the permissive verdict (`visibleWhen`→visible, `readonlyWhen`→editable, `requiredWhen`→not-required), so one typo widens the form in all three directions at once. This is the asymmetry central triage explicitly asked the ui seat to file while working this card. ⛔ Not fixed here — different mechanism, and this change deliberately leans on the fail-open half.
- **#8070** — the clear is silent; the sibling surface names the same state (#6499 Option C) and the form renderer does not.

Both deduped against this repo's open and closed issues first, with a control query that returned #6958 itself, so the search channel was answering rather than silently empty.

## The doc sentence, now amended (ruled on the card)

`content/docs/plugins/plugin-form.mdx` carried a passage deriving the tab/section submit semantics from the field-level mechanism and adding *"the form keeps their values"*. This change makes that clause false for the field-level case, so it is corrected here, in the commit that falsifies it.

The dispatching seat ruled to extend this card's file surface by that one file (objectui#6958 comment 5560114937). ⛔ Not a red-line breach: the red line is `content/docs/releases/`, which is untouched; this is `content/docs/plugins/`.

Scope held to the one misleading sentence — 6 insertions, 3 deletions, one paragraph. The three bullets above it are **not** rewritten and remain accurate: a hidden tab's and a hidden section's values still submit, which is the 2026-08-27 ruling this change deliberately leaves alone. The correction keeps the shared *drawing* mechanism (both still unmount and skip validation) and separates out the value half:

> The value half does **not** carry across: a field hidden by its **own** `visibleWhen` / `visibleOn` has its value cleared (objectui#6958), while a field hidden by its **section's** or its **tab's** predicate keeps it, exactly as stated above.

Checked and NOT stale, so deliberately not touched: `FormFieldConfig.visibleWhen` / `visibleOn` JSDoc in `packages/types/src/form.ts` says only "hidden" and "fails open" — it never claimed value retention — and every "values still submit" sentence in `packages/types` is scoped to a section or a tab.

## Notes for the queue

- `minor`, not `major`: this repo forbids `major` in a changeset (Changeset Bump Policy / `check-changeset-no-major.mjs`), and a deliberately breaking change ships `minor` with the breaking semantics written out in the changeset body. It is written out there.
- Not a governed-surface diff — re-checked on the four-path diff after the amend: `NOT GOVERNED, 4 path(s) checked against 5 governed surface(s); none matched`. The paths are `packages/components/src/renderers/form/form.tsx`, one new test file, one changeset, and `content/docs/plugins/plugin-form.mdx`.
- ⚠️ Two CI reds on this PR are known-not-mine and were not re-diagnosed here: `Build & E2E` dies at `pnpm --version` before install on a corepack/undici download assertion, and `Live E2E (informational)` is advisory and verified red on `main` itself (carded as #8084).
- Left as **draft**. ⛔ Not readied, not enqueued, no auto-merge, no approving review — CI convergence and the ready-flip belong to the dispatching seat.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S