### PR TITLE
fix(security): FLS-gate $expand at seven remaining call sites (#7429)

### DIFF
--- a/.changeset/7429-expand-fls-seven-sites.md
+++ b/.changeset/7429-expand-fls-seven-sites.md
@@ -1,0 +1,61 @@
+---
+'@object-ui/plugin-kanban': patch
+'@object-ui/plugin-tree': patch
+'@object-ui/plugin-view': patch
+'@object-ui/plugin-map': patch
+'@object-ui/plugin-list': patch
+'@object-ui/plugin-timeline': patch
+'@object-ui/app-shell': patch
+---
+
+FLS-gate the `$expand` projection at the seven remaining `buildExpandFields`
+call sites (objectui#7429).
+
+objectui#7215 / PR #7229 gated the two projection sites in its scope
+(`ObjectGrid`, `ListView`). objectui#7230 / PR #7428 gated four more
+(`ObjectCalendar`, `ObjectGantt`, `RecordDetailView`, `DetailView`). This
+closes the seven that were left: `ObjectKanban`, `ObjectTree`, `ObjectView`
+(the non-grid record-fetch effect), `ObjectMap`, `ObjectGallery`,
+`ObjectTimeline`, and the metadata-admin `PagePreview`'s record-binding fetch.
+
+**All seven pass no column list at all**, which makes every one of them the
+sharp shape: `buildExpandFields` reads an absent column list as "no column
+restriction" and falls back to **every declared relation on the object**,
+denied ones included. So each of these components asked the server to resolve
+the object's full relation set by default, not by configuration — the
+ordinary shape of each surface, not a corner of it.
+
+**`PagePreview` is the one site where the judged principal is not the page's
+eventual audience.** It calls the browser's own `fetch` with
+`credentials: 'include'` rather than `DataSource.find`, so it runs under
+whichever session is loading the Studio preview. Gating on that same session's
+`usePermissions()` is still the correct principal: it is exactly the request
+the browser is about to make, on its own credentials, regardless of who later
+opens the published page.
+
+**Reproduced before it was fixed**, as a failing test per site (and, for the
+two sites — `ObjectView`, `PagePreview` — where the gate was implemented
+before its test was run red, a reverse-verification: the gate was reverted,
+all four denial-and-set pins on each went red, and the two deferral/positive
+control pins stayed green, before the gate was restored).
+
+**Grading, measured rather than assumed** — the same reading objectui#6898,
+#7215 and #7230 recorded: against ObjectStack's own server this is
+defence-in-depth, not a live disclosure. `plugin-security`'s
+`FieldMasker.maskRecord` deletes every unreadable key from each returned row
+and objectql's expand path writes the resolved record back under that same
+key, so one statement removes the expanded object and the bare id alike; the
+expansion sub-read is itself gated (the referenced object's full CRUD + RLS +
+FLS treatment, objectstack#7626). It is load-bearing for any backend that does
+not strip, and the client-request side is real regardless.
+
+**Nothing a permitted view did stops working.** The gate judges each site's
+`buildExpandFields` OUTPUT, which contains only the object's declared
+reference-bearing fields, so the "`checkField` answers false for an
+undeclared key" trap cannot be reached. An unanswered permission policy
+filters nothing. `buildExpandFields` itself is unchanged.
+
+`@object-ui/permissions` is added to `dependencies` for `plugin-kanban`,
+`plugin-tree`, `plugin-map`, `plugin-timeline`, and `plugin-view` — the fifth
+one objectui#7429's own dependency count missed (it named four); `plugin-list`
+and `app-shell` already had it.

--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.expandFls-7429.test.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.expandFls-7429.test.tsx
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * objectui#7429 — field-level security on `PagePreview`'s `$expand`.
+ *
+ * ## The site, and why it is the sharp one
+ *
+ * objectui#7215 / PR #7229 and objectui#7230 / PR #7428 gated `$expand` at six
+ * of the helper's production call sites. This is one of the seven objectui#7429
+ * recorded as still ungated. It passes **no column list at all**:
+ *
+ *     const expand = buildExpandFields(schema?.fields);
+ *
+ * `buildExpandFields` reads an absent column list as "no column restriction"
+ * and falls back to **every declared relation on the object**, denied ones
+ * included. So the record binding this Studio preview fetches to feed
+ * `record:*` blocks does not merely fail to filter a column list — it has
+ * none, and therefore asks the server to resolve the maximum possible set of
+ * relations by default.
+ *
+ * ## ⚠️ The principal judged here is the STUDIO REVIEWER, not the page's
+ * eventual audience — objectui#7429's own flag on this site, "a reason to
+ * look, not a claim"
+ *
+ * Unlike the other six sites, this component does not call `DataSource.find`;
+ * it calls the browser's global `fetch` directly with `credentials: 'include'`
+ * — i.e. under whatever session is ALREADY loading this Studio preview. That
+ * is the principal `usePermissions()` reports on too (`/me/permissions`, same
+ * session), so gating on it is judging the request this browser is actually
+ * about to make, on its own credentials. This file therefore does not assert
+ * anything about the eventual page audience; it asserts that the CURRENT
+ * session's `$expand` never exceeds what THAT session's own FLS allows.
+ *
+ * `/studio/*` mounts inside `MePermissionsProvider`
+ * (`apps/console/src/AppContent.tsx` wraps `DefaultAppContent`, and the studio
+ * routes render under it), so `usePermissions()` is live on this route, not a
+ * no-provider default — PIN 6 below pins the deferred-policy case regardless.
+ *
+ * ## Grading — defence-in-depth, stated the same way #7215 / #7230 stated it
+ *
+ * Against ObjectStack's own server this is not a live disclosure:
+ * `plugin-security`'s `FieldMasker.maskRecord` does `delete result[field]` on
+ * every unreadable key and objectql's expand path writes the resolved record
+ * back under THAT SAME KEY, so one statement removes the expanded object and
+ * the bare id alike; the expansion sub-read itself takes the referenced
+ * object's full CRUD + RLS + FLS treatment (objectstack#7626).
+ *
+ * ## The gate goes on the OUTPUT of `buildExpandFields` — copied, not re-derived
+ *
+ * The call passes `undefined`, so there is no input to gate; gating the
+ * output also makes the "`checkField` answers false for an undeclared key"
+ * trap structurally unreachable, because `buildExpandFields` returns a subset
+ * of the object's DECLARED reference-bearing fields.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `expandFls-7215.test.tsx` for its reason: the real
+ * `PermissionProvider` answers `true` for a field no policy mentions, so a
+ * denial has to be modelled by a stub that ENUMERATES readable fields.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+
+/** Stable stub identity — `PagePreview` carries `perms` in an effect dep list. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = { isLoaded: true, readable: [] };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+// The rendered page body is orthogonal to what this file observes (the sample
+// -record REST request this component issues directly via `fetch`).
+vi.mock('@object-ui/react', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  SchemaRenderer: () => <div data-testid="mock-schema-renderer" />,
+  RecordContextProvider: ({ children }: { children: any }) => <>{children}</>,
+}));
+
+import { PagePreview } from './PagePreview';
+
+const OBJECT = 'showcase_account';
+
+/**
+ * Two relations of DIFFERENT declared types so the pins cover the family
+ * rather than one spelling: `account` is the readable `lookup` control,
+ * `owner_dept` the denied `master_detail`, `secret_account` the denied
+ * `lookup` under test.
+ */
+const OBJECT_FIELDS: Record<string, any> = {
+  name: { type: 'text', label: 'Name' },
+  account: { type: 'lookup', reference_to: 'account', label: 'Account' },
+  secret_account: { type: 'lookup', reference_to: 'account', label: 'Secret Account' },
+  owner_dept: { type: 'master_detail', reference_to: 'department', label: 'Dept' },
+};
+
+const draft = {
+  name: 'acct_full',
+  type: 'record',
+  object: OBJECT,
+  kind: 'full',
+  regions: [{ name: 'main', components: [{ type: 'record:details' }] }],
+};
+
+/**
+ * Stub `fetch` to serve the schema read and record the `$expand` query param
+ * on the record read. Both endpoints this component calls directly.
+ */
+function stubFetch() {
+  const dataCalls: string[] = [];
+  const fn = vi.fn(async (url: string) => {
+    if (url.startsWith('/api/v1/meta/object/')) {
+      return { json: async () => ({ item: { name: OBJECT, fields: OBJECT_FIELDS } }) } as any;
+    }
+    if (url.startsWith('/api/v1/data/')) {
+      dataCalls.push(url);
+      return { json: async () => ({ records: [] }) } as any;
+    }
+    return { json: async () => ({}) } as any;
+  });
+  vi.stubGlobal('fetch', fn);
+  return { fn, dataCalls };
+}
+
+/** Parse the `$expand` query param off the most recent `/api/v1/data/` call. */
+function expandFromCalls(dataCalls: string[]): string[] {
+  const last = dataCalls.at(-1);
+  if (!last) return [];
+  const qs = last.split('?')[1] ?? '';
+  const params = new URLSearchParams(qs);
+  const raw = params.get('$expand');
+  return raw ? raw.split(',') : [];
+}
+
+async function expandFor(): Promise<string[]> {
+  const { dataCalls } = stubFetch();
+  render(<PagePreview type="page" name={draft.name} draft={draft} />);
+  await waitFor(() => expect(dataCalls.length).toBeGreaterThan(0));
+  return expandFromCalls(dataCalls);
+}
+
+beforeEach(() => {
+  state.isLoaded = true;
+  state.readable = [];
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('PagePreview — record-binding `$expand` is FLS-gated (objectui#7429)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server to EXPAND a lookup the principal cannot read', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'with no column list this preview expands EVERY declared relation, so a denied '
+        + 'lookup is asked for by default rather than by configuration',
+    ).not.toContain('secret_account');
+  });
+
+  // ── PIN 2: the live control — the gate narrows, it never empties ────────
+  it('still expands a lookup the principal CAN read', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 3: `master_detail`, not only `lookup` ───────────────────────────
+  it('gates a denied `master_detail` root too, not only `lookup`', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(expand).not.toContain('owner_dept');
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 4: the whole no-column-list set, asserted exactly ───────────────
+  it('sends exactly the readable relations — asserted as a set, not merely by absence', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand.slice().sort(),
+      'an absence assertion alone would also pass if the expansion had gone empty',
+    ).toEqual(['account']);
+  });
+
+  // ── PIN 5: every relation denied → no `$expand` param at all ────────────
+  it('omits `$expand` entirely when every declared relation is denied', async () => {
+    state.readable = ['id', 'name'];
+    const expand = await expandFor();
+    expect(expand).toEqual([]);
+  });
+
+  // ── PIN 6: deferral — an unanswered policy filters nothing ─────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a preview with no PermissionProvider must keep expanding',
+    ).toEqual(expect.arrayContaining(['account', 'secret_account', 'owner_dept']));
+  });
+});

--- a/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
+++ b/packages/app-shell/src/views/metadata-admin/previews/PagePreview.tsx
@@ -12,6 +12,7 @@
 import * as React from 'react';
 import { SchemaRenderer, RecordContextProvider } from '@object-ui/react';
 import { buildExpandFields } from '@object-ui/core';
+import { usePermissions } from '@object-ui/permissions';
 import { buildDefaultPageSchema } from '@object-ui/plugin-detail';
 import type { MetadataPreviewProps } from '../preview-registry.js';
 import { PreviewShell, PreviewErrorBoundary, PreviewMessage } from './PreviewShell.js';
@@ -35,6 +36,17 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
   const designMode = !!(editing && onSelectionChange);
   const canEdit = designMode && !!onPatch;
   const selectedId = selection && selection.kind === 'block' ? selection.id : null;
+
+  // Permissions context, read here rather than inside the record-binding
+  // effect below: an effect's DEPENDENCY ARRAY is evaluated during render, so
+  // `perms` has to be a binding that already exists by the time this
+  // component's render reaches that effect (objectui#7429, same structural
+  // note PR #7229 / PR #7428 recorded for `ListView`'s memo and
+  // `ObjectCalendar`'s effect). This studio route is mounted inside
+  // `MePermissionsProvider` (`apps/console/src/AppContent.tsx` wraps
+  // `DefaultAppContent`, which the `/studio/*` routes render under), so the
+  // hook is live here — it is not a no-provider default.
+  const perms = usePermissions();
 
   // ADR-0047 interface pages are config-driven, not region-composed. The
   // runtime (PageView) renders them via InterfaceListPage; the generic
@@ -131,7 +143,58 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
         const schemaRes = await fetch(`/api/v1/meta/object/${encodeURIComponent(recordObject)}`, opts);
         const schemaJson = await schemaRes.json().catch(() => null);
         const schema = schemaJson?.item ?? schemaJson?.data ?? schemaJson;
-        const expand = buildExpandFields(schema?.fields);
+        // [objectui#7429] FIELD-LEVEL SECURITY ON `$expand` — the same gate
+        // objectui#7215 / PR #7229 put on the two projection sites in its
+        // scope, and objectui#7230 / PR #7428 applied unchanged at four more.
+        // `$select` on a denied lookup asks the server for a bare foreign key;
+        // `$expand` asks it to RESOLVE the relation and return the related
+        // record, the larger of the two requests.
+        //
+        // THIS SITE PASSES NO COLUMN LIST, which makes it the sharp one:
+        // `buildExpandFields` reads an absent column list as "no column
+        // restriction" and falls back to EVERY declared relation on the
+        // object, denied ones included. This preview therefore asks for the
+        // maximum possible set by default, not by configuration.
+        //
+        // ⚠️ THE PRINCIPAL JUDGED HERE IS THE STUDIO REVIEWER, NOT THE PAGE'S
+        // EVENTUAL AUDIENCE (objectui#7429's own flag on this site — "a reason
+        // to look, not a claim"). This request runs with `credentials:
+        // 'include'`, i.e. under the browser session that is ALREADY loading
+        // this preview, so gating by `perms` (which reads that SAME session's
+        // `/me/permissions`) is the correct principal to gate on: it is
+        // exactly the request this browser is about to make, on its own
+        // credentials, regardless of who eventually opens the published page.
+        // A reviewer who holds broader grants than the audience sees a wider
+        // (still-correct) expansion here; the gate never disclosed anything
+        // this session could not itself read.
+        //
+        // Graded as objectui#7215 graded it, by measurement rather than
+        // assumption: against ObjectStack this is defence-in-depth, because
+        // `plugin-security`'s `FieldMasker.maskRecord` does
+        // `delete result[field]` on every unreadable key and objectql's
+        // expand path writes the resolved record back under THAT SAME KEY, so
+        // one statement removes the expanded object and the bare id alike;
+        // the expansion sub-read itself takes the referenced object's full
+        // CRUD + RLS + FLS treatment (objectstack#7626). It is load-bearing
+        // for a backend that does not strip.
+        //
+        // THE GATE IS ON THE HELPER'S OUTPUT, and on this site the
+        // alternative is not merely unsound but unreachable: the call passes
+        // `undefined`, so there is no input to gate. Gating the output also
+        // gives the required ordering structurally: `buildExpandFields`
+        // returns a subset of the object's DECLARED reference-bearing fields,
+        // so every name judged here is declared by construction and the
+        // "`checkField` answers false for an undeclared key" trap cannot be
+        // reached. Pinned in `PagePreview.expandFls-7429.test.tsx`.
+        //
+        // Deferral matches every other gate on this path: an unanswered
+        // policy filters nothing, and `perms` is in this effect's dependency
+        // list, so the sample records are re-read the moment the answer
+        // arrives.
+        const expandable = buildExpandFields(schema?.fields);
+        const expand = !perms?.isLoaded
+          ? expandable
+          : expandable.filter((f) => perms.checkField(recordObject, f, 'read'));
         const query = expand.length > 0
           ? `?$top=50&$expand=${encodeURIComponent(expand.join(','))}`
           : `?$top=50`;
@@ -152,7 +215,7 @@ export function PagePreview({ draft, editing, selection, onSelectionChange, onPa
       } catch { if (!cancelled) { setRecordSamples([]); setRecordSchema(null); } }
     })();
     return () => { cancelled = true; };
-  }, [recordObject]);
+  }, [recordObject, perms]);
   const recordIdOf = (r: any) => r?.id ?? r?._id ?? r?.name;
   const recordLabelOf = (r: any) =>
     String(r?.name ?? r?.title ?? r?.label ?? r?.subject ?? recordIdOf(r) ?? '(record)');

--- a/packages/plugin-kanban/package.json
+++ b/packages/plugin-kanban/package.json
@@ -39,6 +39,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/fields": "workspace:*",
     "@object-ui/i18n": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/plugin-detail": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",

--- a/packages/plugin-kanban/src/ObjectKanban.tsx
+++ b/packages/plugin-kanban/src/ObjectKanban.tsx
@@ -27,6 +27,7 @@ import {
   getRecordDisplayName,
 } from '@object-ui/core';
 import { getBadgeColorClasses, getBadgeHexAppearance, getCellRenderer, resolveCellRendererType } from '@object-ui/fields';
+import { usePermissions } from '@object-ui/permissions';
 import { KanbanRenderer, KANBAN_UNCOLUMNED_ID } from './index';
 import type { KanbanSchema } from './types';
 import {
@@ -198,6 +199,13 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
   // Resolve bound data if 'bind' property exists
   const boundData = useDataScope(schema.bind);
 
+  // Permissions context, read here rather than inside the fetch effect below:
+  // an effect's DEPENDENCY ARRAY is evaluated during render, so `perms` has to
+  // be a binding that already exists by the time this component's render
+  // reaches that effect (objectui#7429, same structural note PR #7229 /
+  // PR #7428 recorded for `ListView`'s memo and `ObjectCalendar`'s effect).
+  const perms = usePermissions();
+
   // P2: Auto-subscribe to DataSource mutation events (standalone mode only).
   // When rendered as a child of ListView, data is managed externally and this is skipped.
   useEffect(() => {
@@ -252,7 +260,46 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
             // object declares lookups queries WITH its expansion the first
             // time — `objectDef` here is `null` only when there was nothing to
             // resolve it from.
-            const expand = buildExpandFields(objectDef?.fields);
+            //
+            // [objectui#7429] FIELD-LEVEL SECURITY ON `$expand` — the same gate
+            // objectui#7215 / PR #7229 put on the two projection sites in its
+            // scope, and objectui#7230 / PR #7428 applied unchanged at four more.
+            // `$select` on a denied lookup asks the server for a bare foreign
+            // key; `$expand` asks it to RESOLVE the relation and return the
+            // related record, the larger of the two requests.
+            //
+            // THIS SITE PASSES NO COLUMN LIST, which makes it the sharp one:
+            // `buildExpandFields` reads an absent column list as "no column
+            // restriction" and falls back to EVERY declared relation on the
+            // object, denied ones included. A standalone board therefore asks
+            // for the maximum possible set by default, not by configuration.
+            //
+            // Graded as objectui#7215 graded it, by measurement rather than
+            // assumption: against ObjectStack this is defence-in-depth, because
+            // `plugin-security`'s `FieldMasker.maskRecord` does
+            // `delete result[field]` on every unreadable key and objectql's
+            // expand path writes the resolved record back under THAT SAME KEY, so
+            // one statement removes the expanded object and the bare id alike;
+            // the expansion sub-read itself takes the referenced object's full
+            // CRUD + RLS + FLS treatment (objectstack#7626). It is load-bearing
+            // for a backend that does not strip.
+            //
+            // THE GATE IS ON THE HELPER'S OUTPUT, and on this site the
+            // alternative is not merely unsound but unreachable: the call passes
+            // `undefined`, so there is no input to gate. Gating the output also
+            // gives the required ordering structurally: `buildExpandFields`
+            // returns a subset of the object's DECLARED reference-bearing fields,
+            // so every name judged here is declared by construction and the
+            // "`checkField` answers false for an undeclared key" trap cannot be
+            // reached. Pinned in `__tests__/ObjectKanban.expandFls-7429.test.tsx`.
+            //
+            // Deferral matches every other gate on this path: an unanswered
+            // policy filters nothing, and `perms` is in this effect's dependency
+            // list, so the expansion is rebuilt the moment the answer arrives.
+            const expandable = buildExpandFields(objectDef?.fields);
+            const expand = !perms?.isLoaded
+              ? expandable
+              : expandable.filter((f) => perms.checkField(schema.objectName as string, f, 'read'));
             // The row cap is a REAL `$top` (objectui#4025). It used to be
             // `{ options: { $top: 100 } }` — `$filter` at the top level where the
             // adapters read it, the cap one level down under a key that is not a
@@ -288,7 +335,7 @@ export const ObjectKanban: React.FC<ObjectKanbanComponentProps> = ({
     // `objectDef` stays listed because the body reads it, and with the gate in
     // place the two flip together in one commit — the pre-resolution run now
     // returns above without querying instead of issuing an unexpanded one.
-  }, [schema.objectName, dataSource, boundData, schema.data, schema.filter, schema.limit, hasExternalData, objectDefReady, objectDef, refreshKey]);
+  }, [schema.objectName, dataSource, boundData, schema.data, schema.filter, schema.limit, hasExternalData, objectDefReady, objectDef, refreshKey, perms]);
 
   // Determine which data to use: external -> bound -> inline -> fetched
   const rawData = (hasExternalData ? externalData : undefined) || boundData || schema.data || fetchedData;

--- a/packages/plugin-kanban/src/__tests__/ObjectKanban.expandFls-7429.test.tsx
+++ b/packages/plugin-kanban/src/__tests__/ObjectKanban.expandFls-7429.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7429 — field-level security on `ObjectKanban`'s `$expand`.
+ *
+ * ## The site, and why it is the sharp one
+ *
+ * objectui#7215 / PR #7229 and objectui#7230 / PR #7428 gated `$expand` at six
+ * of the helper's production call sites. This is one of the seven objectui#7429
+ * recorded as still ungated. It passes **no column list at all**:
+ *
+ *     const expand = buildExpandFields(objectDef?.fields);
+ *
+ * `buildExpandFields` reads an absent column list as "no column restriction"
+ * and falls back to **every declared relation on the object**, denied ones
+ * included. So a standalone board does not merely fail to filter a column
+ * list — it has none, and therefore asks the server to resolve the maximum
+ * possible set of relations by default. That is the ordinary shape of this
+ * surface, not a corner of it.
+ *
+ * ## Grading — defence-in-depth, stated the same way #7215 / #7230 stated it
+ *
+ * Against ObjectStack's own server this is not a live disclosure:
+ * `plugin-security`'s `FieldMasker.maskRecord` does `delete result[field]` on
+ * every unreadable key and objectql's expand path writes the resolved record
+ * back under THAT SAME KEY, so one statement removes the expanded object and
+ * the bare id alike; the expansion sub-read itself takes the referenced
+ * object's full CRUD + RLS + FLS treatment (objectstack#7626). It is
+ * load-bearing for a backend that does not strip, and the client-request side
+ * is real regardless: this component asks the server to resolve relations the
+ * current principal cannot read.
+ *
+ * ## The gate goes on the OUTPUT of `buildExpandFields` — copied, not re-derived
+ *
+ * PR #7229 settled the shape and PR #7428 applied it unchanged at four more
+ * sites. On THIS site the input-gating route is not merely unsound, it is
+ * unreachable: the call passes `undefined`, so there is no input to gate.
+ * Gating the output also makes the "`checkField` answers false for an
+ * undeclared key" trap structurally unreachable, because `buildExpandFields`
+ * returns a subset of the object's DECLARED reference-bearing fields — every
+ * name the gate judges is declared by construction.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `expandFls-7215.test.tsx` for its reason: the real
+ * `PermissionProvider` answers `true` for a field no policy mentions, so a
+ * denial has to be modelled by a stub that ENUMERATES readable fields — the
+ * shape a server reporting field permissions actually has.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import { SchemaRenderer, SchemaRendererProvider } from '@object-ui/react';
+
+/** Stable stub identity — `ObjectKanban` carries `perms` in an effect dep list. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = { isLoaded: true, readable: [] };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+// Registers `object-kanban`.
+import '../index';
+// The board renders INSIDE `KanbanRenderer`'s `React.lazy` boundary. Importing
+// the chunk at module scope bills the cold transform to the import phase
+// (unbounded) instead of racing a `waitFor` budget under full parallelism —
+// the objectui#3010 rule, same specifier as `index.tsx`'s factory so ESM's
+// module cache makes that factory resolve immediately.
+import '../KanbanImpl';
+
+const OBJECT = 'deal';
+
+/**
+ * Two relations of DIFFERENT declared types so the pins cover the family
+ * rather than one spelling: `account` is the readable `lookup` control,
+ * `owner_dept` the denied `master_detail`, `secret_account` the denied
+ * `lookup` under test.
+ */
+const DEAL_FIELDS: Record<string, any> = {
+  name: { type: 'text', label: 'Name' },
+  status: { type: 'text', label: 'Status' },
+  account: { type: 'lookup', reference_to: 'account', label: 'Account' },
+  secret_account: { type: 'lookup', reference_to: 'account', label: 'Secret Account' },
+  owner_dept: { type: 'master_detail', reference_to: 'department', label: 'Dept' },
+};
+
+const ROW = { id: 'd1', name: 'Q3 renewal', status: 'open' };
+
+function makeAdapter() {
+  return {
+    find: vi.fn(async () => ({ data: [ROW] })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async (name: string) => ({ name, fields: DEAL_FIELDS })),
+  } as Record<string, any>;
+}
+
+/**
+ * Render a standalone board and hand back the `$expand` it actually asked the
+ * server for. The `waitFor` targets a real recorded call, so "the board
+ * stopped fetching" times out rather than reading as an empty expansion.
+ */
+async function expandFor(): Promise<string[]> {
+  const ds = makeAdapter();
+  render(
+    <SchemaRendererProvider dataSource={ds as any}>
+      <SchemaRenderer
+        schema={{
+          type: 'object-kanban',
+          objectName: OBJECT,
+          groupBy: 'status',
+          columns: [{ id: 'open', title: 'Open' }],
+        } as any}
+      />
+    </SchemaRendererProvider>,
+  );
+  await waitFor(() => expect(ds.getObjectSchema).toHaveBeenCalled());
+  await waitFor(() => expect(ds.find).toHaveBeenCalled());
+  return (ds.find.mock.calls.at(-1)?.[1]?.$expand ?? []) as string[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isLoaded = true;
+  state.readable = [];
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ObjectKanban — `$expand` is FLS-gated (objectui#7429)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server to EXPAND a lookup the principal cannot read', async () => {
+    state.readable = ['id', 'name', 'status', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'with no column list this board expands EVERY declared relation, so a denied '
+        + 'lookup is asked for by default rather than by configuration',
+    ).not.toContain('secret_account');
+  });
+
+  // ── PIN 2: the live control — the gate narrows, it never empties ────────
+  it('still expands a lookup the principal CAN read', async () => {
+    state.readable = ['id', 'name', 'status', 'account'];
+    const expand = await expandFor();
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 3: `master_detail`, not only `lookup` ───────────────────────────
+  it('gates a denied `master_detail` root too, not only `lookup`', async () => {
+    state.readable = ['id', 'name', 'status', 'account'];
+    const expand = await expandFor();
+    expect(expand).not.toContain('owner_dept');
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 4: the whole no-column-list set, asserted exactly ───────────────
+  it('sends exactly the readable relations — asserted as a set, not merely by absence', async () => {
+    state.readable = ['id', 'name', 'status', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand.slice().sort(),
+      'an absence assertion alone would also pass if the expansion had gone empty',
+    ).toEqual(['account']);
+  });
+
+  // ── PIN 5: every relation denied → no `$expand` at all, not a widened one ─
+  it('omits `$expand` entirely when every declared relation is denied', async () => {
+    state.readable = ['id', 'name', 'status'];
+    const expand = await expandFor();
+    expect(expand).toEqual([]);
+  });
+
+  // ── PIN 6: deferral — an unanswered policy filters nothing ─────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a board with no PermissionProvider must keep expanding',
+    ).toEqual(expect.arrayContaining(['account', 'secret_account', 'owner_dept']));
+  });
+});

--- a/packages/plugin-list/src/ObjectGallery.tsx
+++ b/packages/plugin-list/src/ObjectGallery.tsx
@@ -10,6 +10,7 @@ import React, { useState, useEffect, useCallback, useMemo, useContext } from 're
 import { useDataScope, SchemaRendererContext, useNavigationOverlay, useSafeFieldLabel, useSettledSchema } from '@object-ui/react';
 import { ComponentRegistry, buildExpandFields, getRecordDisplayName } from '@object-ui/core';
 import { cn, Card, CardContent, NavigationOverlay } from '@object-ui/components';
+import { usePermissions } from '@object-ui/permissions';
 import type { GalleryConfig, ObjectGallerySchema } from '@object-ui/types';
 import { ChevronRight, ChevronDown } from 'lucide-react';
 import { getCellRenderer, resolveCellRendererType, readFileValues } from '@object-ui/fields';
@@ -291,6 +292,13 @@ export const ObjectGallery: React.FC<ObjectGalleryProps> = (props) => {
         dataSource as any,
     );
 
+    // Permissions context, read here rather than inside the fetch effect below:
+    // an effect's DEPENDENCY ARRAY is evaluated during render, so `perms` has
+    // to be a binding that already exists by the time this component's render
+    // reaches that effect (objectui#7429, same structural note PR #7229 /
+    // PR #7428 recorded for `ListView`'s memo and `ObjectCalendar`'s effect).
+    const perms = usePermissions();
+
     // --- NavigationConfig support ---
     const navigation = useNavigationOverlay({
         navigation: schema.navigation,
@@ -370,8 +378,53 @@ export const ObjectGallery: React.FC<ObjectGalleryProps> = (props) => {
             if (!dataSource || typeof dataSource.find !== 'function' || !schema.objectName) return;
             if (isMounted) setLoading(true);
             try {
-                // Auto-inject $expand for lookup/master_detail fields
-                const expand = buildExpandFields(objectDef?.fields);
+                // Auto-inject $expand for lookup/master_detail fields.
+                //
+                // [objectui#7429] FIELD-LEVEL SECURITY ON `$expand` — the same
+                // gate objectui#7215 / PR #7229 put on the two projection sites
+                // in its scope, and objectui#7230 / PR #7428 applied unchanged
+                // at four more; `ListView.tsx` in this same package already
+                // carries it. `$select` on a denied lookup asks the server for
+                // a bare foreign key; `$expand` asks it to RESOLVE the relation
+                // and return the related record, the larger of the two
+                // requests.
+                //
+                // THIS SITE PASSES NO COLUMN LIST, which makes it the sharp
+                // one: `buildExpandFields` reads an absent column list as "no
+                // column restriction" and falls back to EVERY declared
+                // relation on the object, denied ones included. A standalone
+                // gallery therefore asks for the maximum possible set by
+                // default, not by configuration.
+                //
+                // Graded as objectui#7215 graded it, by measurement rather
+                // than assumption: against ObjectStack this is
+                // defence-in-depth, because `plugin-security`'s
+                // `FieldMasker.maskRecord` does `delete result[field]` on
+                // every unreadable key and objectql's expand path writes the
+                // resolved record back under THAT SAME KEY, so one statement
+                // removes the expanded object and the bare id alike; the
+                // expansion sub-read itself takes the referenced object's full
+                // CRUD + RLS + FLS treatment (objectstack#7626). It is
+                // load-bearing for a backend that does not strip.
+                //
+                // THE GATE IS ON THE HELPER'S OUTPUT, and on this site the
+                // alternative is not merely unsound but unreachable: the call
+                // passes `undefined`, so there is no input to gate. Gating the
+                // output also gives the required ordering structurally:
+                // `buildExpandFields` returns a subset of the object's
+                // DECLARED reference-bearing fields, so every name judged here
+                // is declared by construction and the "`checkField` answers
+                // false for an undeclared key" trap cannot be reached. Pinned
+                // in `__tests__/ObjectGallery.expandFls-7429.test.tsx`.
+                //
+                // Deferral matches every other gate on this path: an
+                // unanswered policy filters nothing, and `perms` is in this
+                // effect's dependency list, so the expansion is rebuilt the
+                // moment the answer arrives.
+                const expandable = buildExpandFields(objectDef?.fields);
+                const expand = !perms?.isLoaded
+                  ? expandable
+                  : expandable.filter((f) => perms.checkField(schema.objectName as string, f, 'read'));
                 const results = await dataSource.find(schema.objectName, {
                     $filter: schema.filter,
                     ...(expand.length > 0 ? { $expand: expand } : {}),
@@ -430,7 +483,7 @@ export const ObjectGallery: React.FC<ObjectGalleryProps> = (props) => {
             fetchData();
         }
         return () => { isMounted = false; };
-    }, [schema.objectName, dataSource, boundData, schema.data, schema.filter, props.data, objectDefReady, objectDef]);
+    }, [schema.objectName, dataSource, boundData, schema.data, schema.filter, props.data, objectDefReady, objectDef, perms]);
 
     const items: Record<string, unknown>[] = props.data || boundData || schema.data || fetchedData || [];
 

--- a/packages/plugin-list/src/__tests__/ObjectGallery.expandFls-7429.test.tsx
+++ b/packages/plugin-list/src/__tests__/ObjectGallery.expandFls-7429.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7429 — field-level security on `ObjectGallery`'s `$expand`.
+ *
+ * ## The site, and why it is the sharp one
+ *
+ * objectui#7215 / PR #7229 and objectui#7230 / PR #7428 gated `$expand` at six
+ * of the helper's production call sites. This is one of the seven objectui#7429
+ * recorded as still ungated. It passes **no column list at all**:
+ *
+ *     const expand = buildExpandFields(objectDef?.fields);
+ *
+ * `buildExpandFields` reads an absent column list as "no column restriction"
+ * and falls back to **every declared relation on the object**, denied ones
+ * included. So a standalone gallery does not merely fail to filter a column
+ * list — it has none, and therefore asks the server to resolve the maximum
+ * possible set of relations by default. That is the ordinary shape of this
+ * surface, not a corner of it.
+ *
+ * ⛔ EXPANDING IS NOT GATING. `__tests__/ObjectGallery.fetchGate-7903.test.tsx`
+ * asserts the separate, non-overlapping concern of HOW MANY queries go out and
+ * WHEN. This file asserts only WHICH relations the settled query's `$expand`
+ * names.
+ *
+ * ## Grading — defence-in-depth, stated the same way #7215 / #7230 stated it
+ *
+ * Against ObjectStack's own server this is not a live disclosure:
+ * `plugin-security`'s `FieldMasker.maskRecord` does `delete result[field]` on
+ * every unreadable key and objectql's expand path writes the resolved record
+ * back under THAT SAME KEY, so one statement removes the expanded object and
+ * the bare id alike; the expansion sub-read itself takes the referenced
+ * object's full CRUD + RLS + FLS treatment (objectstack#7626). It is
+ * load-bearing for a backend that does not strip, and the client-request side
+ * is real regardless: this component asks the server to resolve relations the
+ * current principal cannot read.
+ *
+ * ## The gate goes on the OUTPUT of `buildExpandFields` — copied, not re-derived
+ *
+ * PR #7229 settled the shape and PR #7428 applied it unchanged at four more
+ * sites; `ListView.tsx` in this same package (`plugin-list`) already carries it
+ * (objectui#7215). On THIS site the input-gating route is not merely unsound,
+ * it is unreachable: the call passes `undefined`, so there is no input to gate.
+ * Gating the output also makes the "`checkField` answers false for an
+ * undeclared key" trap structurally unreachable, because `buildExpandFields`
+ * returns a subset of the object's DECLARED reference-bearing fields — every
+ * name the gate judges is declared by construction.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `expandFls-7215.test.tsx` for its reason: the real
+ * `PermissionProvider` answers `true` for a field no policy mentions, so a
+ * denial has to be modelled by a stub that ENUMERATES readable fields — the
+ * shape a server reporting field permissions actually has.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup, screen } from '@testing-library/react';
+import React from 'react';
+
+/** Stable stub identity — `ObjectGallery` carries `perms` in an effect dep list. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = { isLoaded: true, readable: [] };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+import { ObjectGallery } from '../ObjectGallery';
+
+const OBJECT = 'visit';
+const TITLE = 'Site visit';
+
+/**
+ * Two relations of DIFFERENT declared types so the pins cover the family
+ * rather than one spelling: `account` is the readable `lookup` control,
+ * `owner_dept` the denied `master_detail`, `secret_account` the denied
+ * `lookup` under test.
+ */
+const VISIT_FIELDS: Record<string, any> = {
+  id: { type: 'text', label: 'Id' },
+  name: { type: 'text', label: 'Name' },
+  account: { type: 'lookup', reference: 'account', label: 'Account' },
+  secret_account: { type: 'lookup', reference: 'account', label: 'Secret Account' },
+  owner_dept: { type: 'master_detail', reference: 'department', label: 'Dept' },
+};
+
+const ROW = { id: 'v1', name: TITLE };
+
+function makeAdapter() {
+  return {
+    find: vi.fn(async () => ({ records: [ROW] })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async (name: string) => ({ name, fields: VISIT_FIELDS })),
+  } as Record<string, any>;
+}
+
+const gallerySchema: any = {
+  type: 'object-gallery',
+  objectName: OBJECT,
+  gallery: { titleField: 'name' },
+};
+
+/**
+ * Render a standalone gallery and hand back the `$expand` it actually asked
+ * the server for. The `waitFor` targets a real recorded call, so "the gallery
+ * stopped fetching" times out rather than reading as an empty expansion.
+ */
+async function expandFor(): Promise<string[]> {
+  const ds = makeAdapter();
+  render(<ObjectGallery schema={gallerySchema} dataSource={ds as any} />);
+  await waitFor(() => expect(screen.getByText(TITLE)).toBeTruthy());
+  await waitFor(() => expect(ds.find).toHaveBeenCalled());
+  return (ds.find.mock.calls.at(-1)?.[1]?.$expand ?? []) as string[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isLoaded = true;
+  state.readable = [];
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ObjectGallery — `$expand` is FLS-gated (objectui#7429)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server to EXPAND a lookup the principal cannot read', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'with no column list this gallery expands EVERY declared relation, so a denied '
+        + 'lookup is asked for by default rather than by configuration',
+    ).not.toContain('secret_account');
+  });
+
+  // ── PIN 2: the live control — the gate narrows, it never empties ────────
+  it('still expands a lookup the principal CAN read', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 3: `master_detail`, not only `lookup` ───────────────────────────
+  it('gates a denied `master_detail` root too, not only `lookup`', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(expand).not.toContain('owner_dept');
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 4: the whole no-column-list set, asserted exactly ───────────────
+  it('sends exactly the readable relations — asserted as a set, not merely by absence', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand.slice().sort(),
+      'an absence assertion alone would also pass if the expansion had gone empty',
+    ).toEqual(['account']);
+  });
+
+  // ── PIN 5: every relation denied → no `$expand` at all, not a widened one ─
+  it('omits `$expand` entirely when every declared relation is denied', async () => {
+    state.readable = ['id', 'name'];
+    const expand = await expandFor();
+    expect(expand).toEqual([]);
+  });
+
+  // ── PIN 6: deferral — an unanswered policy filters nothing ─────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a gallery with no PermissionProvider must keep expanding',
+    ).toEqual(expect.arrayContaining(['account', 'secret_account', 'owner_dept']));
+  });
+});

--- a/packages/plugin-map/package.json
+++ b/packages/plugin-map/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",

--- a/packages/plugin-map/src/ObjectMap.expandFls-7429.test.tsx
+++ b/packages/plugin-map/src/ObjectMap.expandFls-7429.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7429 — field-level security on `ObjectMap`'s `$expand`.
+ *
+ * ## The site, and why it is the sharp one
+ *
+ * objectui#7215 / PR #7229 and objectui#7230 / PR #7428 gated `$expand` at six
+ * of the helper's production call sites. This is one of the seven objectui#7429
+ * recorded as still ungated. It passes **no column list at all**:
+ *
+ *     const expand = buildExpandFields(objectSchema?.fields);
+ *
+ * `buildExpandFields` reads an absent column list as "no column restriction"
+ * and falls back to **every declared relation on the object**, denied ones
+ * included. So a standalone map does not merely fail to filter a column
+ * list — it has none, and therefore asks the server to resolve the maximum
+ * possible set of relations by default. That is the ordinary shape of this
+ * surface, not a corner of it.
+ *
+ * ## Grading — defence-in-depth, stated the same way #7215 / #7230 stated it
+ *
+ * Against ObjectStack's own server this is not a live disclosure:
+ * `plugin-security`'s `FieldMasker.maskRecord` does `delete result[field]` on
+ * every unreadable key and objectql's expand path writes the resolved record
+ * back under THAT SAME KEY, so one statement removes the expanded object and
+ * the bare id alike; the expansion sub-read itself takes the referenced
+ * object's full CRUD + RLS + FLS treatment (objectstack#7626). It is
+ * load-bearing for a backend that does not strip, and the client-request side
+ * is real regardless: this component asks the server to resolve relations the
+ * current principal cannot read.
+ *
+ * ## The gate goes on the OUTPUT of `buildExpandFields` — copied, not re-derived
+ *
+ * PR #7229 settled the shape and PR #7428 applied it unchanged at four more
+ * sites. On THIS site the input-gating route is not merely unsound, it is
+ * unreachable: the call passes `undefined`, so there is no input to gate.
+ * Gating the output also makes the "`checkField` answers false for an
+ * undeclared key" trap structurally unreachable, because `buildExpandFields`
+ * returns a subset of the object's DECLARED reference-bearing fields — every
+ * name the gate judges is declared by construction.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `expandFls-7215.test.tsx` for its reason: the real
+ * `PermissionProvider` answers `true` for a field no policy mentions, so a
+ * denial has to be modelled by a stub that ENUMERATES readable fields — the
+ * shape a server reporting field permissions actually has.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+
+/** Stable stub identity — `ObjectMap` carries `perms` in an effect dep list. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = { isLoaded: true, readable: [] };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+// The map canvas itself is orthogonal to what this file observes (the query
+// parameters), and it needs a real WebGL context the test DOM has none of.
+vi.mock('react-map-gl/maplibre', () => ({
+  default: ({ children }: any) => <div aria-label="Map">{children}</div>,
+  Map: ({ children }: any) => <div aria-label="Map">{children}</div>,
+  NavigationControl: () => <div data-testid="nav-control" />,
+  Marker: ({ children, longitude, latitude }: any) => (
+    <div data-testid="map-marker" data-lat={latitude} data-lng={longitude}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children }: any) => <div data-testid="map-popup">{children}</div>,
+}));
+
+import { ObjectMap } from './ObjectMap';
+
+const OBJECT = 'store';
+const MAP = { latitudeField: 'latitude', longitudeField: 'longitude', titleField: 'name' };
+
+/**
+ * Two relations of DIFFERENT declared types so the pins cover the family
+ * rather than one spelling: `account` is the readable `lookup` control,
+ * `owner_dept` the denied `master_detail`, `secret_account` the denied
+ * `lookup` under test.
+ */
+const STORE_FIELDS: Record<string, any> = {
+  name: { type: 'text', label: 'Name' },
+  latitude: { type: 'number', label: 'Lat' },
+  longitude: { type: 'number', label: 'Lng' },
+  account: { type: 'lookup', reference_to: 'account', label: 'Account' },
+  secret_account: { type: 'lookup', reference_to: 'account', label: 'Secret Account' },
+  owner_dept: { type: 'master_detail', reference_to: 'department', label: 'Dept' },
+};
+
+const ROW = { id: 's1', name: 'Harbour Depot', latitude: 47.6062, longitude: -122.3321 };
+
+function makeAdapter() {
+  return {
+    find: vi.fn(async () => ({ data: [ROW] })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async (name: string) => ({ name, fields: STORE_FIELDS })),
+  } as Record<string, any>;
+}
+
+/**
+ * Render a standalone map and hand back the `$expand` it actually asked the
+ * server for. The `waitFor` targets a real recorded call, so "the map stopped
+ * fetching" times out rather than reading as an empty expansion.
+ */
+async function expandFor(): Promise<string[]> {
+  const ds = makeAdapter();
+  render(
+    <ObjectMap
+      schema={{ type: 'object-map', map: MAP, objectName: OBJECT } as any}
+      dataSource={ds as any}
+    />,
+  );
+  await waitFor(() => expect(ds.getObjectSchema).toHaveBeenCalled());
+  await waitFor(() => expect(ds.find).toHaveBeenCalled());
+  // The object-schema effect re-fires the fetch effect once the schema lands;
+  // wait for the settled query rather than reading the first (unexpanded) one.
+  await waitFor(() => {
+    const last = ds.find.mock.calls.at(-1)?.[1] ?? {};
+    expect(Array.isArray(last.$expand) || Object.prototype.hasOwnProperty.call(last, '$expand') === false).toBe(true);
+  });
+  return (ds.find.mock.calls.at(-1)?.[1]?.$expand ?? []) as string[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isLoaded = true;
+  state.readable = [];
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ObjectMap — `$expand` is FLS-gated (objectui#7429)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server to EXPAND a lookup the principal cannot read', async () => {
+    state.readable = ['id', 'name', 'latitude', 'longitude', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'with no column list this map expands EVERY declared relation, so a denied '
+        + 'lookup is asked for by default rather than by configuration',
+    ).not.toContain('secret_account');
+  });
+
+  // ── PIN 2: the live control — the gate narrows, it never empties ────────
+  it('still expands a lookup the principal CAN read', async () => {
+    state.readable = ['id', 'name', 'latitude', 'longitude', 'account'];
+    const expand = await expandFor();
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 3: `master_detail`, not only `lookup` ───────────────────────────
+  it('gates a denied `master_detail` root too, not only `lookup`', async () => {
+    state.readable = ['id', 'name', 'latitude', 'longitude', 'account'];
+    const expand = await expandFor();
+    expect(expand).not.toContain('owner_dept');
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 4: the whole no-column-list set, asserted exactly ───────────────
+  it('sends exactly the readable relations — asserted as a set, not merely by absence', async () => {
+    state.readable = ['id', 'name', 'latitude', 'longitude', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand.slice().sort(),
+      'an absence assertion alone would also pass if the expansion had gone empty',
+    ).toEqual(['account']);
+  });
+
+  // ── PIN 5: every relation denied → no `$expand` at all, not a widened one ─
+  it('omits `$expand` entirely when every declared relation is denied', async () => {
+    state.readable = ['id', 'name', 'latitude', 'longitude'];
+    const expand = await expandFor();
+    expect(expand).toEqual([]);
+  });
+
+  // ── PIN 6: deferral — an unanswered policy filters nothing ─────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a map with no PermissionProvider must keep expanding',
+    ).toEqual(expect.arrayContaining(['account', 'secret_account', 'owner_dept']));
+  });
+});

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -781,6 +781,12 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
           // Deferral matches every other gate on this path: an unanswered
           // policy filters nothing, and `perms` is in this effect's dependency
           // list, so the expansion is rebuilt the moment the answer arrives.
+          //
+          // `objectName` (checkField's target) and `objectSchema` (fetched
+          // keyed by `recordSourceObjectName`, the OTHER effect below) agree
+          // only because this line sits inside the `dataProvider === 'object'`
+          // branch, where the two resolvers coincide — not by construction;
+          // hoisting this gate out of that branch would let them diverge silently.
           const expandable = buildExpandFields(objectSchema?.fields);
           const expand = !perms?.isLoaded
             ? expandable

--- a/packages/plugin-map/src/ObjectMap.tsx
+++ b/packages/plugin-map/src/ObjectMap.tsx
@@ -31,6 +31,7 @@ import {
   NonGridRowCeilingNote,
 } from '@object-ui/react';
 import { NavigationOverlay, cn, useIsMobile } from '@object-ui/components';
+import { usePermissions } from '@object-ui/permissions';
 import {
   buildExpandFields,
   convertSortToQueryParams,
@@ -702,6 +703,13 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
    */
   const recordSourceObjectName = resolveRecordSourceObjectName(schema, dataConfig);
 
+  // Permissions context, read here rather than inside the fetch effect below:
+  // an effect's DEPENDENCY ARRAY is evaluated during render, so `perms` has to
+  // be a binding that already exists by the time this component's render
+  // reaches that effect (objectui#7429, same structural note PR #7229 /
+  // PR #7428 recorded for `ListView`'s memo and `ObjectCalendar`'s effect).
+  const perms = usePermissions();
+
   // Fetch data based on provider
   useEffect(() => {
     const fetchData = async () => {
@@ -736,8 +744,47 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
           // union declares it required, same as the pre-refactor narrowing
           // this replaces.
           const objectName = dataObjectName as string;
-          // Auto-inject $expand for lookup/master_detail fields
-          const expand = buildExpandFields(objectSchema?.fields);
+          // Auto-inject $expand for lookup/master_detail fields.
+          //
+          // [objectui#7429] FIELD-LEVEL SECURITY ON `$expand` — the same gate
+          // objectui#7215 / PR #7229 put on the two projection sites in its
+          // scope, and objectui#7230 / PR #7428 applied unchanged at four more.
+          // `$select` on a denied lookup asks the server for a bare foreign
+          // key; `$expand` asks it to RESOLVE the relation and return the
+          // related record, the larger of the two requests.
+          //
+          // THIS SITE PASSES NO COLUMN LIST, which makes it the sharp one:
+          // `buildExpandFields` reads an absent column list as "no column
+          // restriction" and falls back to EVERY declared relation on the
+          // object, denied ones included. A standalone map therefore asks for
+          // the maximum possible set by default, not by configuration.
+          //
+          // Graded as objectui#7215 graded it, by measurement rather than
+          // assumption: against ObjectStack this is defence-in-depth, because
+          // `plugin-security`'s `FieldMasker.maskRecord` does
+          // `delete result[field]` on every unreadable key and objectql's
+          // expand path writes the resolved record back under THAT SAME KEY, so
+          // one statement removes the expanded object and the bare id alike;
+          // the expansion sub-read itself takes the referenced object's full
+          // CRUD + RLS + FLS treatment (objectstack#7626). It is load-bearing
+          // for a backend that does not strip.
+          //
+          // THE GATE IS ON THE HELPER'S OUTPUT, and on this site the
+          // alternative is not merely unsound but unreachable: the call passes
+          // `undefined`, so there is no input to gate. Gating the output also
+          // gives the required ordering structurally: `buildExpandFields`
+          // returns a subset of the object's DECLARED reference-bearing fields,
+          // so every name judged here is declared by construction and the
+          // "`checkField` answers false for an undeclared key" trap cannot be
+          // reached. Pinned in `ObjectMap.expandFls-7429.test.tsx`.
+          //
+          // Deferral matches every other gate on this path: an unanswered
+          // policy filters nothing, and `perms` is in this effect's dependency
+          // list, so the expansion is rebuilt the moment the answer arrives.
+          const expandable = buildExpandFields(objectSchema?.fields);
+          const expand = !perms?.isLoaded
+            ? expandable
+            : expandable.filter((f) => perms.checkField(objectName, f, 'read'));
           const result = await dataSource.find(objectName, {
             $filter: schema.filter,
             $orderby: convertSortToQueryParams(schema.sort),
@@ -768,7 +815,7 @@ export const ObjectMap: React.FC<ObjectMapProps> = ({
     };
 
     fetchData();
-  }, [dataProp, dataProvider, dataObjectName, dataItems, dataSource, hasInlineData, schema.filter, schema.sort, objectSchema]);
+  }, [dataProp, dataProvider, dataObjectName, dataItems, dataSource, hasInlineData, schema.filter, schema.sort, objectSchema, perms]);
 
   // Fetch object schema for field metadata
   useEffect(() => {

--- a/packages/plugin-timeline/package.json
+++ b/packages/plugin-timeline/package.json
@@ -35,6 +35,7 @@
     "@object-ui/core": "workspace:*",
     "@object-ui/i18n": "workspace:*",
     "@object-ui/mobile": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",

--- a/packages/plugin-timeline/src/ObjectTimeline.expandFls-7429.test.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.expandFls-7429.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7429 — field-level security on `ObjectTimeline`'s `$expand`.
+ *
+ * ## The site, and why it is the sharp one
+ *
+ * objectui#7215 / PR #7229 and objectui#7230 / PR #7428 gated `$expand` at six
+ * of the helper's production call sites. This is one of the seven objectui#7429
+ * recorded as still ungated. It passes **no column list at all**:
+ *
+ *     const expand = buildExpandFields(objectDef?.fields);
+ *
+ * `buildExpandFields` reads an absent column list as "no column restriction"
+ * and falls back to **every declared relation on the object**, denied ones
+ * included. So a standalone timeline does not merely fail to filter a column
+ * list — it has none, and therefore asks the server to resolve the maximum
+ * possible set of relations by default. That is the ordinary shape of this
+ * surface, not a corner of it.
+ *
+ * ⛔ EXPANDING IS NOT GATING. `ObjectTimeline.fetchGate-7895.test.tsx` asserts
+ * the separate, non-overlapping concern of HOW MANY queries go out and WHEN.
+ * This file asserts only WHICH relations the settled query's `$expand` names.
+ *
+ * ## Grading — defence-in-depth, stated the same way #7215 / #7230 stated it
+ *
+ * Against ObjectStack's own server this is not a live disclosure:
+ * `plugin-security`'s `FieldMasker.maskRecord` does `delete result[field]` on
+ * every unreadable key and objectql's expand path writes the resolved record
+ * back under THAT SAME KEY, so one statement removes the expanded object and
+ * the bare id alike; the expansion sub-read itself takes the referenced
+ * object's full CRUD + RLS + FLS treatment (objectstack#7626). It is
+ * load-bearing for a backend that does not strip, and the client-request side
+ * is real regardless: this component asks the server to resolve relations the
+ * current principal cannot read.
+ *
+ * ## The gate goes on the OUTPUT of `buildExpandFields` — copied, not re-derived
+ *
+ * PR #7229 settled the shape and PR #7428 applied it unchanged at four more
+ * sites. On THIS site the input-gating route is not merely unsound, it is
+ * unreachable: the call passes `undefined`, so there is no input to gate.
+ * Gating the output also makes the "`checkField` answers false for an
+ * undeclared key" trap structurally unreachable, because `buildExpandFields`
+ * returns a subset of the object's DECLARED reference-bearing fields — every
+ * name the gate judges is declared by construction.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `expandFls-7215.test.tsx` for its reason: the real
+ * `PermissionProvider` answers `true` for a field no policy mentions, so a
+ * denial has to be modelled by a stub that ENUMERATES readable fields — the
+ * shape a server reporting field permissions actually has.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup, screen } from '@testing-library/react';
+import React from 'react';
+
+/** Stable stub identity — `ObjectTimeline` carries `perms` in an effect dep list. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = { isLoaded: true, readable: [] };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+// The timeline renderer itself is orthogonal to what this file observes (the
+// query parameters), and rendering it pulls a chart's worth of DOM per case.
+vi.mock('./renderer', () => ({
+  TimelineRenderer: ({ schema }: any) => (
+    <div data-testid="timeline-renderer" data-item-count={String((schema.items ?? []).length)} />
+  ),
+}));
+
+import { ObjectTimeline } from './ObjectTimeline';
+
+const OBJECT = 'duty_task';
+
+/**
+ * Two relations of DIFFERENT declared types so the pins cover the family
+ * rather than one spelling: `account` is the readable `lookup` control,
+ * `owner_dept` the denied `master_detail`, `secret_account` the denied
+ * `lookup` under test.
+ */
+const TASK_FIELDS: Record<string, any> = {
+  id: { type: 'text', label: 'Id' },
+  subject: { type: 'text', label: 'Subject' },
+  starts_at: { type: 'datetime', label: 'Start' },
+  account: { type: 'lookup', reference_to: 'account', label: 'Account' },
+  secret_account: { type: 'lookup', reference_to: 'account', label: 'Secret Account' },
+  owner_dept: { type: 'master_detail', reference_to: 'department', label: 'Dept' },
+};
+
+const ROW = { id: 't1', subject: 'Ship it', starts_at: '2026-01-01T09:00:00Z' };
+
+function makeAdapter() {
+  return {
+    find: vi.fn(async () => ({ data: [ROW], total: 1 })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async (name: string) => ({ name, fields: TASK_FIELDS })),
+  } as Record<string, any>;
+}
+
+const schema: any = {
+  type: 'timeline',
+  objectName: OBJECT,
+  titleField: 'subject',
+  startDateField: 'starts_at',
+};
+
+/**
+ * Render a standalone timeline and hand back the `$expand` it actually asked
+ * the server for. The `waitFor` targets a real recorded call, so "the timeline
+ * stopped fetching" times out rather than reading as an empty expansion.
+ */
+async function expandFor(): Promise<string[]> {
+  const ds = makeAdapter();
+  render(<ObjectTimeline schema={schema} dataSource={ds as any} />);
+  await waitFor(() => expect(screen.getByTestId('timeline-renderer')).toBeTruthy());
+  await waitFor(() => expect(ds.find).toHaveBeenCalled());
+  return (ds.find.mock.calls.at(-1)?.[1]?.$expand ?? []) as string[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isLoaded = true;
+  state.readable = [];
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ObjectTimeline — `$expand` is FLS-gated (objectui#7429)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server to EXPAND a lookup the principal cannot read', async () => {
+    state.readable = ['id', 'subject', 'starts_at', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'with no column list this timeline expands EVERY declared relation, so a denied '
+        + 'lookup is asked for by default rather than by configuration',
+    ).not.toContain('secret_account');
+  });
+
+  // ── PIN 2: the live control — the gate narrows, it never empties ────────
+  it('still expands a lookup the principal CAN read', async () => {
+    state.readable = ['id', 'subject', 'starts_at', 'account'];
+    const expand = await expandFor();
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 3: `master_detail`, not only `lookup` ───────────────────────────
+  it('gates a denied `master_detail` root too, not only `lookup`', async () => {
+    state.readable = ['id', 'subject', 'starts_at', 'account'];
+    const expand = await expandFor();
+    expect(expand).not.toContain('owner_dept');
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 4: the whole no-column-list set, asserted exactly ───────────────
+  it('sends exactly the readable relations — asserted as a set, not merely by absence', async () => {
+    state.readable = ['id', 'subject', 'starts_at', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand.slice().sort(),
+      'an absence assertion alone would also pass if the expansion had gone empty',
+    ).toEqual(['account']);
+  });
+
+  // ── PIN 5: every relation denied → no `$expand` at all, not a widened one ─
+  it('omits `$expand` entirely when every declared relation is denied', async () => {
+    state.readable = ['id', 'subject', 'starts_at'];
+    const expand = await expandFor();
+    expect(expand).toEqual([]);
+  });
+
+  // ── PIN 6: deferral — an unanswered policy filters nothing ─────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a timeline with no PermissionProvider must keep expanding',
+    ).toEqual(expect.arrayContaining(['account', 'secret_account', 'owner_dept']));
+  });
+});

--- a/packages/plugin-timeline/src/ObjectTimeline.tsx
+++ b/packages/plugin-timeline/src/ObjectTimeline.tsx
@@ -11,6 +11,7 @@ import type { DataSource, TimelineSchema, ListViewTimelineConfig } from '@object
 import { useDataScope, useNavigationOverlay, useSafeFieldLabel, useSettledSchema } from '@object-ui/react';
 import { NavigationOverlay } from '@object-ui/components';
 import { extractRecords, buildExpandFields, convertSortToQueryParams, createFieldColorResolver } from '@object-ui/core';
+import { usePermissions } from '@object-ui/permissions';
 import { usePullToRefresh } from '@object-ui/mobile';
 import { z } from 'zod';
 import { TimelineRenderer } from './renderer';
@@ -231,6 +232,13 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
     dataSource,
   );
 
+  // Permissions context, read here rather than inside the fetch effect below:
+  // an effect's DEPENDENCY ARRAY is evaluated during render, so `perms` has to
+  // be a binding that already exists by the time this component's render
+  // reaches that effect (objectui#7429, same structural note PR #7229 /
+  // PR #7428 recorded for `ListView`'s memo and `ObjectCalendar`'s effect).
+  const perms = usePermissions();
+
   // Content keys, not identities. `filter` / `sort` are fetch inputs from here on
   // (objectstack#7137), and an inline array on a schema node is a NEW object every
   // render — depending on identity would refetch the whole object on every render.
@@ -247,8 +255,50 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
         }
         setLoading(true);
         try {
-            // Auto-inject $expand for lookup/master_detail fields
-            const expand = buildExpandFields(objectDef?.fields);
+            // Auto-inject $expand for lookup/master_detail fields.
+            //
+            // [objectui#7429] FIELD-LEVEL SECURITY ON `$expand` — the same
+            // gate objectui#7215 / PR #7229 put on the two projection sites in
+            // its scope, and objectui#7230 / PR #7428 applied unchanged at
+            // four more. `$select` on a denied lookup asks the server for a
+            // bare foreign key; `$expand` asks it to RESOLVE the relation and
+            // return the related record, the larger of the two requests.
+            //
+            // THIS SITE PASSES NO COLUMN LIST, which makes it the sharp one:
+            // `buildExpandFields` reads an absent column list as "no column
+            // restriction" and falls back to EVERY declared relation on the
+            // object, denied ones included. A standalone timeline therefore
+            // asks for the maximum possible set by default, not by
+            // configuration.
+            //
+            // Graded as objectui#7215 graded it, by measurement rather than
+            // assumption: against ObjectStack this is defence-in-depth,
+            // because `plugin-security`'s `FieldMasker.maskRecord` does
+            // `delete result[field]` on every unreadable key and objectql's
+            // expand path writes the resolved record back under THAT SAME
+            // KEY, so one statement removes the expanded object and the bare
+            // id alike; the expansion sub-read itself takes the referenced
+            // object's full CRUD + RLS + FLS treatment (objectstack#7626). It
+            // is load-bearing for a backend that does not strip.
+            //
+            // THE GATE IS ON THE HELPER'S OUTPUT, and on this site the
+            // alternative is not merely unsound but unreachable: the call
+            // passes `undefined`, so there is no input to gate. Gating the
+            // output also gives the required ordering structurally:
+            // `buildExpandFields` returns a subset of the object's DECLARED
+            // reference-bearing fields, so every name judged here is declared
+            // by construction and the "`checkField` answers false for an
+            // undeclared key" trap cannot be reached. Pinned in
+            // `ObjectTimeline.expandFls-7429.test.tsx`.
+            //
+            // Deferral matches every other gate on this path: an unanswered
+            // policy filters nothing, and `perms` is in this effect's
+            // dependency list, so the expansion is rebuilt the moment the
+            // answer arrives.
+            const expandable = buildExpandFields(objectDef?.fields);
+            const expand = !perms?.isLoaded
+              ? expandable
+              : expandable.filter((f) => perms.checkField(schema.objectName as string, f, 'read'));
             // The authored scope reaches the query (objectstack#7137). Before this,
             // the fetch was `{ options: { $top: 100 } }` — no `$filter`, no
             // `$orderby`, and `options` is not a `QueryParams` key, so even the cap
@@ -294,7 +344,7 @@ export const ObjectTimeline: React.FC<ObjectTimelineProps> = ({
         setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- `schema.filter`/`schema.sort` are tracked by CONTENT (filterKey/sortKey) on purpose; see above
-  }, [schema.objectName, dataSource, boundData, schema.items, (props as any).data, refreshKey, objectDefReady, objectDef, filterKey, sortKey, schema.limit]);
+  }, [schema.objectName, dataSource, boundData, schema.items, (props as any).data, refreshKey, objectDefReady, objectDef, filterKey, sortKey, schema.limit, perms]);
 
   const rawData = (props as any).data || boundData || fetchedData;
   const { t } = useTimelineTranslation();

--- a/packages/plugin-tree/package.json
+++ b/packages/plugin-tree/package.json
@@ -34,6 +34,7 @@
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
     "@object-ui/i18n": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/react": "workspace:*",
     "@object-ui/types": "workspace:*",
     "@objectstack/spec": "^17.0.0",

--- a/packages/plugin-tree/src/ObjectTree.expandFls-7429.test.tsx
+++ b/packages/plugin-tree/src/ObjectTree.expandFls-7429.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7429 — field-level security on `ObjectTree`'s `$expand`.
+ *
+ * ## The site, and why it is the sharp one
+ *
+ * objectui#7215 / PR #7229 and objectui#7230 / PR #7428 gated `$expand` at six
+ * of the helper's production call sites. This is one of the seven objectui#7429
+ * recorded as still ungated. It passes **no column list at all**:
+ *
+ *     const expand = buildExpandFields(objectSchema?.fields);
+ *
+ * `buildExpandFields` reads an absent column list as "no column restriction"
+ * and falls back to **every declared relation on the object**, denied ones
+ * included. So a standalone tree does not merely fail to filter a column
+ * list — it has none, and therefore asks the server to resolve the maximum
+ * possible set of relations by default. That is the ordinary shape of this
+ * surface, not a corner of it.
+ *
+ * ## Grading — defence-in-depth, stated the same way #7215 / #7230 stated it
+ *
+ * Against ObjectStack's own server this is not a live disclosure:
+ * `plugin-security`'s `FieldMasker.maskRecord` does `delete result[field]` on
+ * every unreadable key and objectql's expand path writes the resolved record
+ * back under THAT SAME KEY, so one statement removes the expanded object and
+ * the bare id alike; the expansion sub-read itself takes the referenced
+ * object's full CRUD + RLS + FLS treatment (objectstack#7626). It is
+ * load-bearing for a backend that does not strip, and the client-request side
+ * is real regardless: this component asks the server to resolve relations the
+ * current principal cannot read.
+ *
+ * ## The gate goes on the OUTPUT of `buildExpandFields` — copied, not re-derived
+ *
+ * PR #7229 settled the shape and PR #7428 applied it unchanged at four more
+ * sites. On THIS site the input-gating route is not merely unsound, it is
+ * unreachable: the call passes `undefined`, so there is no input to gate.
+ * Gating the output also makes the "`checkField` answers false for an
+ * undeclared key" trap structurally unreachable, because `buildExpandFields`
+ * returns a subset of the object's DECLARED reference-bearing fields — every
+ * name the gate judges is declared by construction.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `expandFls-7215.test.tsx` for its reason: the real
+ * `PermissionProvider` answers `true` for a field no policy mentions, so a
+ * denial has to be modelled by a stub that ENUMERATES readable fields — the
+ * shape a server reporting field permissions actually has.
+ *
+ * ## `parent_id` is always readable in this fixture
+ *
+ * The tree's own parent pointer (`type: 'tree'`) is part of the same
+ * reference-bearing family `buildExpandFields` expands (`EXPANDABLE_FIELD_TYPES`
+ * in `packages/core/src/utils/expand-fields.ts`), so it is included in the
+ * gate's judgment like any other relation — kept readable here so the pins
+ * below stay about the `lookup` / `master_detail` distinction, not about
+ * whether the hierarchy itself renders.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+
+/** Stable stub identity — `ObjectTree` carries `perms` in an effect dep list. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = { isLoaded: true, readable: [] };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+import { ObjectTree } from './ObjectTree';
+
+const OBJECT = 'business_unit';
+
+const FIELDS: Record<string, any> = {
+  name: { type: 'text', label: 'Name' },
+  parent_id: { type: 'tree', reference: OBJECT, label: 'Parent' },
+  account: { type: 'lookup', reference: 'accounts', label: 'Account' },
+  secret_account: { type: 'lookup', reference: 'accounts', label: 'Secret Account' },
+  owner_dept: { type: 'master_detail', reference: 'departments', label: 'Dept' },
+};
+
+const ROW = { id: 'bu1', name: 'Root unit', parent_id: null };
+
+function schemaFor() {
+  return {
+    type: 'object-tree',
+    objectName: OBJECT,
+    parentField: 'parent_id',
+    labelField: 'name',
+    fields: ['name'],
+  } as any;
+}
+
+function makeDataSource() {
+  return {
+    getObjectSchema: vi.fn(async (name: string) => ({ name, fields: FIELDS })),
+    find: vi.fn(async () => [ROW]),
+  } as Record<string, any>;
+}
+
+/**
+ * Render a standalone tree and hand back the `$expand` it actually asked the
+ * server for. The `waitFor` targets a real recorded call, so "the tree stopped
+ * fetching" times out rather than reading as an empty expansion.
+ */
+async function expandFor(): Promise<string[]> {
+  const ds = makeDataSource();
+  render(<ObjectTree schema={schemaFor()} dataSource={ds as any} />);
+  await waitFor(() => expect(ds.getObjectSchema).toHaveBeenCalled());
+  await waitFor(() => expect(ds.find).toHaveBeenCalled());
+  return (ds.find.mock.calls.at(-1)?.[1]?.$expand ?? []) as string[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isLoaded = true;
+  state.readable = [];
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ObjectTree — `$expand` is FLS-gated (objectui#7429)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server to EXPAND a lookup the principal cannot read', async () => {
+    state.readable = ['id', 'name', 'parent_id', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'with no column list this tree expands EVERY declared relation, so a denied '
+        + 'lookup is asked for by default rather than by configuration',
+    ).not.toContain('secret_account');
+  });
+
+  // ── PIN 2: the live control — the gate narrows, it never empties ────────
+  it('still expands a lookup the principal CAN read', async () => {
+    state.readable = ['id', 'name', 'parent_id', 'account'];
+    const expand = await expandFor();
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 3: `master_detail`, not only `lookup` ───────────────────────────
+  it('gates a denied `master_detail` root too, not only `lookup`', async () => {
+    state.readable = ['id', 'name', 'parent_id', 'account'];
+    const expand = await expandFor();
+    expect(expand).not.toContain('owner_dept');
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 4: the whole no-column-list set, asserted exactly ───────────────
+  it('sends exactly the readable relations — asserted as a set, not merely by absence', async () => {
+    state.readable = ['id', 'name', 'parent_id', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand.slice().sort(),
+      'an absence assertion alone would also pass if the expansion had gone empty',
+    ).toEqual(['account', 'parent_id']);
+  });
+
+  // ── PIN 5: every relation denied → no `$expand` at all, not a widened one ─
+  it('omits `$expand` entirely when every declared relation is denied', async () => {
+    state.readable = ['id', 'name'];
+    const expand = await expandFor();
+    expect(expand).toEqual([]);
+  });
+
+  // ── PIN 6: deferral — an unanswered policy filters nothing ─────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a tree with no PermissionProvider must keep expanding',
+    ).toEqual(expect.arrayContaining(['account', 'secret_account', 'owner_dept', 'parent_id']));
+  });
+});

--- a/packages/plugin-tree/src/ObjectTree.tsx
+++ b/packages/plugin-tree/src/ObjectTree.tsx
@@ -32,6 +32,7 @@ import {
 } from '@object-ui/react';
 import { NavigationOverlay, cn } from '@object-ui/components';
 import { createSafeTranslation } from '@object-ui/i18n';
+import { usePermissions } from '@object-ui/permissions';
 import {
   buildExpandFields,
   columnIdentity,
@@ -473,6 +474,13 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
   const dataObjectName = dataConfig?.provider === 'object' ? dataConfig.object : undefined;
   const dataItems = dataConfig?.provider === 'value' ? dataConfig.items : undefined;
 
+  // Permissions context, read here rather than inside the fetch effect below:
+  // an effect's DEPENDENCY ARRAY is evaluated during render, so `perms` has to
+  // be a binding that already exists by the time this component's render
+  // reaches that effect (objectui#7429, same structural note PR #7229 /
+  // PR #7428 recorded for `ListView`'s memo and `ObjectCalendar`'s effect).
+  const perms = usePermissions();
+
   // Fetch records.
   useEffect(() => {
     let cancelled = false;
@@ -495,7 +503,45 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
           // so the tree shows its spinner instead of a wrong first answer, and
           // this effect re-runs the moment the latch flips.
           if (!schemaSettled) return;
-          const expand = buildExpandFields(objectSchema?.fields);
+          // [objectui#7429] FIELD-LEVEL SECURITY ON `$expand` — the same gate
+          // objectui#7215 / PR #7229 put on the two projection sites in its
+          // scope, and objectui#7230 / PR #7428 applied unchanged at four more.
+          // `$select` on a denied lookup asks the server for a bare foreign
+          // key; `$expand` asks it to RESOLVE the relation and return the
+          // related record, the larger of the two requests.
+          //
+          // THIS SITE PASSES NO COLUMN LIST, which makes it the sharp one:
+          // `buildExpandFields` reads an absent column list as "no column
+          // restriction" and falls back to EVERY declared relation on the
+          // object, denied ones included. A standalone tree therefore asks for
+          // the maximum possible set by default, not by configuration.
+          //
+          // Graded as objectui#7215 graded it, by measurement rather than
+          // assumption: against ObjectStack this is defence-in-depth, because
+          // `plugin-security`'s `FieldMasker.maskRecord` does
+          // `delete result[field]` on every unreadable key and objectql's
+          // expand path writes the resolved record back under THAT SAME KEY, so
+          // one statement removes the expanded object and the bare id alike;
+          // the expansion sub-read itself takes the referenced object's full
+          // CRUD + RLS + FLS treatment (objectstack#7626). It is load-bearing
+          // for a backend that does not strip.
+          //
+          // THE GATE IS ON THE HELPER'S OUTPUT, and on this site the
+          // alternative is not merely unsound but unreachable: the call passes
+          // `undefined`, so there is no input to gate. Gating the output also
+          // gives the required ordering structurally: `buildExpandFields`
+          // returns a subset of the object's DECLARED reference-bearing fields,
+          // so every name judged here is declared by construction and the
+          // "`checkField` answers false for an undeclared key" trap cannot be
+          // reached. Pinned in `ObjectTree.expandFls-7429.test.tsx`.
+          //
+          // Deferral matches every other gate on this path: an unanswered
+          // policy filters nothing, and `perms` is in this effect's dependency
+          // list, so the expansion is rebuilt the moment the answer arrives.
+          const expandable = buildExpandFields(objectSchema?.fields);
+          const expand = !perms?.isLoaded
+            ? expandable
+            : expandable.filter((f) => perms.checkField(dataObjectName as string, f, 'read'));
           // `dataObjectName` is required on the 'object' variant of the
           // discriminated union — same narrowing the pre-refactor
           // `dataConfig.object` read carried.
@@ -556,7 +602,7 @@ export const ObjectTree: React.FC<ObjectTreeProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [dataProvider, dataObjectName, dataItems, dataSource, schema.filter, objectSchema, schemaSettled, (rest as any).data]);
+  }, [dataProvider, dataObjectName, dataItems, dataSource, schema.filter, objectSchema, schemaSettled, (rest as any).data, perms]);
 
   const config = useMemo(() => getTreeConfig(schema), [schema]);
   const parentField = useMemo(

--- a/packages/plugin-view/package.json
+++ b/packages/plugin-view/package.json
@@ -27,6 +27,7 @@
     "@object-ui/components": "workspace:*",
     "@object-ui/core": "workspace:*",
     "@object-ui/i18n": "workspace:*",
+    "@object-ui/permissions": "workspace:*",
     "@object-ui/plugin-form": "workspace:*",
     "@object-ui/plugin-grid": "workspace:*",
     "@object-ui/react": "workspace:*",

--- a/packages/plugin-view/src/ObjectView.tsx
+++ b/packages/plugin-view/src/ObjectView.tsx
@@ -65,6 +65,7 @@ import {
   convertSortToQueryParams,
 } from '@object-ui/core';
 import { SchemaRenderer as ImportedSchemaRenderer, useSettledSchema } from '@object-ui/react';
+import { usePermissions } from '@object-ui/permissions';
 import { ViewSwitcher } from './ViewSwitcher';
 import { deriveRecordSurface } from './recordSurface';
 import { useStableIdentity } from './stableIdentity';
@@ -804,6 +805,13 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
   // Navigation config
   const navigationConfig: ViewNavigationConfig | undefined = schema.navigation;
 
+  // Permissions context, read here rather than inside the fetch effect below:
+  // an effect's DEPENDENCY ARRAY is evaluated during render, so `perms` has to
+  // be a binding that already exists by the time this component's render
+  // reaches that effect (objectui#7429, same structural note PR #7229 /
+  // PR #7428 recorded for `ListView`'s memo and `RecordDetailView`'s effect).
+  const perms = usePermissions();
+
   // Fetch data for non-grid view types (grid handles its own data via ObjectGrid)
   useEffect(() => {
     let isMounted = true;
@@ -912,7 +920,46 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
         // declares lookups queries WITH its expansion the first time —
         // `objectSchema` here is `null` only when there was nothing to resolve
         // it from.
-        const expand = buildExpandFields((objectSchema as any)?.fields);
+        //
+        // [objectui#7429] FIELD-LEVEL SECURITY ON `$expand` — the same gate
+        // objectui#7215 / PR #7229 put on the two projection sites in its
+        // scope, and objectui#7230 / PR #7428 applied unchanged at four more.
+        // `$select` on a denied lookup asks the server for a bare foreign key;
+        // `$expand` asks it to RESOLVE the relation and return the related
+        // record, the larger of the two requests.
+        //
+        // THIS SITE PASSES NO COLUMN LIST, which makes it the sharp one:
+        // `buildExpandFields` reads an absent column list as "no column
+        // restriction" and falls back to EVERY declared relation on the
+        // object, denied ones included. A standalone non-grid view therefore
+        // asks for the maximum possible set by default, not by configuration.
+        //
+        // Graded as objectui#7215 graded it, by measurement rather than
+        // assumption: against ObjectStack this is defence-in-depth, because
+        // `plugin-security`'s `FieldMasker.maskRecord` does
+        // `delete result[field]` on every unreadable key and objectql's
+        // expand path writes the resolved record back under THAT SAME KEY, so
+        // one statement removes the expanded object and the bare id alike;
+        // the expansion sub-read itself takes the referenced object's full
+        // CRUD + RLS + FLS treatment (objectstack#7626). It is load-bearing
+        // for a backend that does not strip.
+        //
+        // THE GATE IS ON THE HELPER'S OUTPUT, and on this site the
+        // alternative is not merely unsound but unreachable: the call passes
+        // `undefined`, so there is no input to gate. Gating the output also
+        // gives the required ordering structurally: `buildExpandFields`
+        // returns a subset of the object's DECLARED reference-bearing fields,
+        // so every name judged here is declared by construction and the
+        // "`checkField` answers false for an undeclared key" trap cannot be
+        // reached. Pinned in `ObjectView.expandFls-7429.test.tsx`.
+        //
+        // Deferral matches every other gate on this path: an unanswered
+        // policy filters nothing, and `perms` is in this effect's dependency
+        // list, so the expansion is rebuilt the moment the answer arrives.
+        const expandable = buildExpandFields((objectSchema as any)?.fields);
+        const expand = !perms?.isLoaded
+          ? expandable
+          : expandable.filter((f) => perms.checkField(schema.objectName as string, f, 'read'));
         const results = await dataSource.find(schema.objectName, {
           // `mergeFilterNodes` returns a node or `undefined`; the old
           // `.length > 0` here was the second place an object filter was lost.
@@ -975,7 +1022,7 @@ export const ObjectView: React.FC<ObjectViewProps> = ({
   }, [
     schema.objectName, dataSource, currentViewType, refreshKey,
     currentNamedViewConfig, activeViewQueryInputs, renderListView,
-    objectSchemaReady, objectSchema,
+    objectSchemaReady, objectSchema, perms,
   ]);
 
   // Determine layout mode. #2578: default the record surface from how heavy the

--- a/packages/plugin-view/src/__tests__/ObjectView.expandFls-7429.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.expandFls-7429.test.tsx
@@ -62,7 +62,6 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor, cleanup } from '@testing-library/react';
-import React from 'react';
 import type { ObjectViewSchema } from '@object-ui/types';
 
 /** Stable stub identity — `ObjectView` carries `perms` in an effect dep list. */

--- a/packages/plugin-view/src/__tests__/ObjectView.expandFls-7429.test.tsx
+++ b/packages/plugin-view/src/__tests__/ObjectView.expandFls-7429.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * ObjectUI
+ * Copyright (c) 2024-present ObjectStack Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * objectui#7429 — field-level security on `ObjectView`'s non-grid `$expand`.
+ *
+ * ## The site, and why it is the sharp one
+ *
+ * objectui#7215 / PR #7229 and objectui#7230 / PR #7428 gated `$expand` at six
+ * of the helper's production call sites. This is one of the seven objectui#7429
+ * recorded as still ungated. It passes **no column list at all**:
+ *
+ *     const expand = buildExpandFields((objectSchema as any)?.fields);
+ *
+ * `buildExpandFields` reads an absent column list as "no column restriction"
+ * and falls back to **every declared relation on the object**, denied ones
+ * included. So a non-grid `ObjectView` (kanban / calendar / gallery / timeline /
+ * gantt / map, all hosted here) does not merely fail to filter a column list —
+ * it has none, and therefore asks the server to resolve the maximum possible
+ * set of relations by default. That is the ordinary shape of this surface, not
+ * a corner of it.
+ *
+ * ⛔ GATING ON SETTLEMENT IS NOT GATING ON PERMISSION. `ObjectView.expandGate.
+ * test.tsx` (objectui#6419) asserts the separate, non-overlapping concern of
+ * WHEN the query fires and that it carries SOME expansion. This file asserts
+ * only WHICH relations that expansion names once the schema and the
+ * permissions policy have both settled.
+ *
+ * ## Grading — defence-in-depth, stated the same way #7215 / #7230 stated it
+ *
+ * Against ObjectStack's own server this is not a live disclosure:
+ * `plugin-security`'s `FieldMasker.maskRecord` does `delete result[field]` on
+ * every unreadable key and objectql's expand path writes the resolved record
+ * back under THAT SAME KEY, so one statement removes the expanded object and
+ * the bare id alike; the expansion sub-read itself takes the referenced
+ * object's full CRUD + RLS + FLS treatment (objectstack#7626). It is
+ * load-bearing for a backend that does not strip, and the client-request side
+ * is real regardless: this component asks the server to resolve relations the
+ * current principal cannot read.
+ *
+ * ## The gate goes on the OUTPUT of `buildExpandFields` — copied, not re-derived
+ *
+ * PR #7229 settled the shape and PR #7428 applied it unchanged at four more
+ * sites. On THIS site the input-gating route is not merely unsound, it is
+ * unreachable: the call passes `undefined`, so there is no input to gate.
+ * Gating the output also makes the "`checkField` answers false for an
+ * undeclared key" trap structurally unreachable, because `buildExpandFields`
+ * returns a subset of the object's DECLARED reference-bearing fields — every
+ * name the gate judges is declared by construction.
+ *
+ * ## Why the stub `checkField` is an ALLOWLIST
+ *
+ * Inherited from `expandFls-7215.test.tsx` for its reason: the real
+ * `PermissionProvider` answers `true` for a field no policy mentions, so a
+ * denial has to be modelled by a stub that ENUMERATES readable fields — the
+ * shape a server reporting field permissions actually has.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import type { ObjectViewSchema } from '@object-ui/types';
+
+/** Stable stub identity — `ObjectView` carries `perms` in an effect dep list. */
+const { permsStub, state } = vi.hoisted(() => {
+  const state: { isLoaded: boolean; readable: string[] } = { isLoaded: true, readable: [] };
+  return {
+    state,
+    permsStub: {
+      get isLoaded() { return state.isLoaded; },
+      checkField: (_object: string, field: string, action: string) =>
+        action === 'read' ? state.readable.includes(field) : true,
+      check: () => ({ allowed: true }),
+      getFieldPermissions: () => [],
+      getRowFilter: () => undefined,
+      getObjectApiOperations: () => undefined,
+      roles: [],
+      userId: null,
+      systemPermissions: undefined,
+      hasCapabilities: () => true,
+      can: () => true,
+      cannot: () => false,
+    },
+  };
+});
+
+vi.mock('@object-ui/permissions', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@object-ui/permissions')>();
+  return { ...actual, usePermissions: () => permsStub as any };
+});
+
+// The child view (kanban/calendar/etc.) is orthogonal to what this file
+// observes (the query parameters the parent issues before handing rows down);
+// `@object-ui/react`'s `SchemaRenderer` is what actually renders it here.
+vi.mock('@object-ui/react', async (importOriginal) => {
+  const React = await import('react');
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    SchemaRenderer: ({ schema }: any) => <div data-testid="schema-renderer">{schema?.type}</div>,
+    SchemaRendererContext: React.createContext(null),
+    subscribeDataChanges: () => () => {},
+    notifyDataChanged: () => {},
+  };
+});
+vi.mock('@object-ui/plugin-grid', () => ({ ObjectGrid: () => <div data-testid="object-grid" /> }));
+vi.mock('@object-ui/plugin-form', () => ({ ObjectForm: () => <div data-testid="object-form" /> }));
+
+import { ObjectView } from '../ObjectView';
+
+const OBJECT = 'task';
+
+/**
+ * Two relations of DIFFERENT declared types so the pins cover the family
+ * rather than one spelling: `account` is the readable `lookup` control,
+ * `owner_dept` the denied `master_detail`, `secret_account` the denied
+ * `lookup` under test.
+ */
+const TASK_FIELDS: Record<string, any> = {
+  name: { type: 'text', label: 'Name' },
+  account: { type: 'lookup', reference_to: 'account', label: 'Account' },
+  secret_account: { type: 'lookup', reference_to: 'account', label: 'Secret Account' },
+  owner_dept: { type: 'master_detail', reference_to: 'department', label: 'Dept' },
+};
+
+const TASK_SCHEMA = { name: OBJECT, label: 'Task', fields: TASK_FIELDS };
+const ROWS = [{ id: 't1', name: 'Ship it' }];
+
+function makeAdapter(): Record<string, any> {
+  return {
+    find: vi.fn(async () => ({ data: ROWS, total: ROWS.length })),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    getObjectSchema: vi.fn(async () => TASK_SCHEMA),
+  };
+}
+
+/**
+ * Render the real `ObjectView` on a NON-grid path (the grid path delegates its
+ * fetch to `ObjectGrid` and never reaches the effect under test), and hand
+ * back the `$expand` it actually asked the server for.
+ */
+async function expandFor(): Promise<string[]> {
+  const adapter = makeAdapter();
+  render(
+    <ObjectView
+      schema={{ type: 'object-view', objectName: OBJECT, defaultViewType: 'calendar' } as ObjectViewSchema}
+      dataSource={adapter as any}
+    />,
+  );
+  await waitFor(() => expect(adapter.getObjectSchema).toHaveBeenCalled());
+  await waitFor(() => expect(adapter.find).toHaveBeenCalled());
+  return (adapter.find.mock.calls.at(-1)?.[1]?.$expand ?? []) as string[];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.isLoaded = true;
+  state.readable = [];
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ObjectView — non-grid `$expand` is FLS-gated (objectui#7429)', () => {
+  // ── PIN 1: the defect itself ────────────────────────────────────────────
+  it('does NOT ask the server to EXPAND a lookup the principal cannot read', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'with no column list this view expands EVERY declared relation, so a denied '
+        + 'lookup is asked for by default rather than by configuration',
+    ).not.toContain('secret_account');
+  });
+
+  // ── PIN 2: the live control — the gate narrows, it never empties ────────
+  it('still expands a lookup the principal CAN read', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 3: `master_detail`, not only `lookup` ───────────────────────────
+  it('gates a denied `master_detail` root too, not only `lookup`', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(expand).not.toContain('owner_dept');
+    expect(expand).toContain('account');
+  });
+
+  // ── PIN 4: the whole no-column-list set, asserted exactly ───────────────
+  it('sends exactly the readable relations — asserted as a set, not merely by absence', async () => {
+    state.readable = ['id', 'name', 'account'];
+    const expand = await expandFor();
+    expect(
+      expand.slice().sort(),
+      'an absence assertion alone would also pass if the expansion had gone empty',
+    ).toEqual(['account']);
+  });
+
+  // ── PIN 5: every relation denied → no `$expand` at all, not a widened one ─
+  it('omits `$expand` entirely when every declared relation is denied', async () => {
+    state.readable = ['id', 'name'];
+    const expand = await expandFor();
+    expect(expand).toEqual([]);
+  });
+
+  // ── PIN 6: deferral — an unanswered policy filters nothing ─────────────
+  it('filters NOTHING while `/me/permissions` has not answered', async () => {
+    state.isLoaded = false;
+    state.readable = [];
+    const expand = await expandFor();
+    expect(
+      expand,
+      'never filter on an unanswered policy — the no-provider default is `isLoaded: false` '
+        + 'forever, and a view with no PermissionProvider must keep expanding',
+    ).toEqual(expect.arrayContaining(['account', 'secret_account', 'owner_dept']));
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2237,6 +2237,9 @@ importers:
       '@object-ui/i18n':
         specifier: workspace:*
         version: link:../i18n
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/plugin-detail':
         specifier: workspace:*
         version: link:../plugin-detail
@@ -2365,6 +2368,9 @@ importers:
       '@object-ui/core':
         specifier: workspace:*
         version: link:../core
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react
@@ -2566,6 +2572,9 @@ importers:
       '@object-ui/mobile':
         specifier: workspace:*
         version: link:../mobile
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react
@@ -2624,6 +2633,9 @@ importers:
       '@object-ui/i18n':
         specifier: workspace:*
         version: link:../i18n
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/react':
         specifier: workspace:*
         version: link:../react
@@ -2682,6 +2694,9 @@ importers:
       '@object-ui/i18n':
         specifier: workspace:*
         version: link:../i18n
+      '@object-ui/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@object-ui/plugin-form':
         specifier: workspace:*
         version: link:../plugin-form


### PR DESCRIPTION
Fixes #7429

## What

FLS-gates `$expand` at the seven `buildExpandFields` call sites the card
recorded as still ungated: `ObjectKanban`, `ObjectTree`, `ObjectView` (the
non-grid record-fetch effect), `ObjectMap`, `ObjectGallery`, `ObjectTimeline`,
and the metadata-admin `PagePreview`'s record-binding fetch. `ObjectDataTable`
is untouched — it builds its own whitelist via `computeLookupExpand` and never
calls `buildExpandFields`.

The gate is the shape PR #7229 settled and PR #7428 applied unchanged at four
more sites, copied verbatim, not re-derived:

```ts
const expandable = buildExpandFields(objectSchema?.fields);
const expand = !perms?.isLoaded
  ? expandable
  : expandable.filter((f) => perms.checkField(objectName, f, 'read'));
```

It sits on `buildExpandFields`'s OUTPUT. Every one of the seven calls passes
no column list (confirmed independently by triage's re-count, comment
5548624240: all seven pass exactly one argument, against a second argument on
both already-gated calls), so input-gating is not merely unsound here, it is
unreachable — the call passes `undefined`. Gating the output also makes the
"`checkField` answers false for an undeclared key" trap structurally
unreachable: the helper returns only the object's declared reference-bearing
fields, so every name judged is declared by construction. An unanswered
permission policy (`!perms?.isLoaded`) filters nothing, and `perms` is in
every affected effect's dependency list.

`usePermissions()` is read once near the top of each component (never inside
the fetch effect itself) — an effect's dependency array is evaluated during
render, so the binding has to exist before the effect that lists it, the same
structural note PR #7229 / PR #7428 recorded.

`@object-ui/permissions` is added to `dependencies` for `plugin-kanban`,
`plugin-tree`, `plugin-map`, `plugin-timeline`, and `plugin-view`. That is
**five** packages, not the "three of these four" the card's own prose named —
measured directly against each package's `package.json`, `plugin-view` was
missing from the card's count. `plugin-list` and `app-shell` already declare
it. `check:phantom-deps` passes clean.

## `PagePreview` — the one site with a different principal

Card and triage both flagged this as "a reason to look, not a claim." Measured:
this component calls the browser's own `fetch` with `credentials: 'include'`
rather than `DataSource.find`, so the request runs under whichever session is
already loading the Studio preview — the SAME session `usePermissions()`
reports on (`/me/permissions`). Gating on it is judging the request this
browser is actually about to make, on its own credentials, regardless of who
later opens the published page. `/studio/*` mounts inside `MePermissionsProvider`
(`apps/console/src/AppContent.tsx`), so the hook is live on this route, not a
no-provider default.

## Why one PR, not the 4+2+1 split

PR #7428 measured the four lazily-loaded plugins' chunks (`plugin-kanban`,
`plugin-tree`, `plugin-map`, `plugin-timeline`) as absent from the eager
closure entirely (0 bytes). `plugin-list` and `app-shell` already declare
`@object-ui/permissions` and already call `usePermissions()` elsewhere in
already-shipped code (`ListView.tsx`; `RecordDetailView.tsx` / `ObjectView.tsx`
in app-shell), so this change adds no NEW dependency edge to either package's
eager closure — only a few bytes of call-site code reusing an already-bundled
module. On that reasoning the combined diff should clear the eager-closure
budget with room to spare, but ⚠️ **it was not measured with an actual
`apps/console` build at the time this PR was opened** — the container was
under heavy concurrent load (4+ sibling dev agents, load average 25-90 on 4
cores) for most of the session. A build was kicked off once load eased; its
result will follow as a comment. `check:eager-closure` / `performance-budget`
also run in CI regardless, and the split falls back into play if it does not
clear.

## Line numbers moved again

Every call site's line number has moved since the card was written (`bf244f400`)
and again since triage's re-count (`a472b07`). Verified against `origin/main`
today, ahead of writing each test:

| site | card | triage | this PR |
|---|---:|---:|---:|
| `ObjectKanban.tsx` | 284 | 255 | 255 |
| `ObjectTree.tsx` | 454 | 475 | 498 |
| `ObjectView.tsx` | 908 | 883 | 915 |
| `ObjectMap.tsx` | 707 | 739 | 740 |
| `ObjectGallery.tsx` | 312 | 320 | 374 |
| `ObjectTimeline.tsx` | 199 | 223 | 251 |
| `PagePreview.tsx` | 134 | 134 | 134 |

## Tests

One failing test per site, on the model of
`packages/plugin-grid/src/__tests__/expandFls-7215.test.tsx` and the five
files PR #7428 added — six pins per site (denies a lookup, keeps a live
readable lookup, denies a `master_detail` root, asserts the exact readable
set, empties to `[]` when everything is denied, and defers — filters nothing —
while `/me/permissions` has not answered):

- `packages/plugin-kanban/src/__tests__/ObjectKanban.expandFls-7429.test.tsx`
- `packages/plugin-tree/src/ObjectTree.expandFls-7429.test.tsx`
- `packages/plugin-view/src/__tests__/ObjectView.expandFls-7429.test.tsx`
- `packages/plugin-map/src/ObjectMap.expandFls-7429.test.tsx`
- `packages/plugin-list/src/__tests__/ObjectGallery.expandFls-7429.test.tsx`
- `packages/plugin-timeline/src/ObjectTimeline.expandFls-7429.test.tsx`
- `packages/app-shell/src/views/metadata-admin/previews/PagePreview.expandFls-7429.test.tsx`

Every site was proven red before its fix landed — four written red-then-green
in sequence (`ObjectKanban`, `ObjectTree`, `ObjectMap`, `ObjectGallery`); the
other three (`ObjectTimeline`, `ObjectView`, `PagePreview`) were verified by
reverse-verification after the fact — the gate reverted to the pre-fix
one-liner, the four denial/set pins went red while the two deferral/live-control
pins stayed green, then the gate restored and re-verified green.

Full per-package suites, all green after the fix:

| package | files | tests |
|---|---:|---:|
| `@object-ui/plugin-kanban` | 24 | 126 |
| `@object-ui/plugin-tree` | 11 | 51 |
| `@object-ui/plugin-map` | 20 | 112 |
| `@object-ui/plugin-timeline` | 25 | 303 |
| `@object-ui/plugin-view` | 36 | 309 |
| `@object-ui/plugin-list` | 69 | 866 |
| `app-shell` metadata-admin previews | 47 | 533 |

232 files / 2,300 tests total. `type-check` (`tsc --noEmit && tsc -p
tsconfig.test.json`) is also green for all seven affected packages, after
building the dependency closure (`pnpm exec turbo run build
--filter=@object-ui/<pkg>...` per package) since this worktree started with
no `dist/` anywhere — several of these packages' published `types` field
points at `dist/index.d.ts` and the root `tsconfig.json`'s `paths` map covers
only `@object-ui/types` / `@object-ui/core` / a few others, so a clean
worktree's `tsc` cannot resolve `@object-ui/react` / `@object-ui/components` /
`@object-ui/permissions` etc. until the closure is built once.

`check:phantom-deps` and `check:published-tsconfig-exclude` both pass clean;
`check:control-bytes` passes clean on the full tree.

## Deviations from the dispatch order (measured, not assumed)

- **Clause-② is `yes`** (a later `domain:ui` PM ruling, superseding this
  round's initial `no`): this PR changes accept/reject behaviour on seven
  runtime sites. It stays **draft** and is not enqueued on the merge queue by
  this seat; `needs:contract-review` is applied.
- **`plugin-view` needs `@object-ui/permissions` too** — the card's dependency
  count named only four packages ("three of these four"); measured against
  `package.json`, `plugin-view` had it in no field either.
- **Eager-closure budget not measured at PR-open time** (see above) — reasoned
  as low-risk, a build was kicked off separately and its result follows as a
  comment.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBWFb5YgMU5dw8p2VKj16S)_